### PR TITLE
feat: pluggable model backends — Claude and Codex (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binary
-maestro
+/maestro
 
 # macOS
 .DS_Store


### PR DESCRIPTION
Implements #5. Adds ModelBackend abstraction with Claude and Codex support.

## Changes

- **`internal/worker/backend.go`** — New file: `BuildWorkerCmd()` dispatches to `NewClaudeCmd` or `NewCodexCmd` based on backend name
- **`internal/config/config.go`** — Added `ModelConfig` with `default` backend and `backends` map; backward-compat: `claude_cmd` auto-populates `model.backends.claude`
- **`internal/state/state.go`** — Added `Backend` field to Session (omitempty for backward compat)
- **`internal/worker/worker.go`** — `Start()` now accepts `backendName` param, generates backend-specific runner scripts (stdin-based for codex, arg-based for claude)
- **`internal/orchestrator/orchestrator.go`** — Detects `model:` issue labels to route workers to specific backends
- **`cmd/maestro/main.go`** — Manual `start-issue` also respects `model:` labels
- **`maestro.yaml` / `maestro-self.yaml`** — Added model config with claude and codex backends
- **`internal/worker/backend_test.go`** — Unit tests for all backend builders

## Usage

Add `model:codex` label to a GitHub issue → worker spawns with Codex CLI instead of Claude.

```yaml
model:
  default: claude
  backends:
    claude:
      cmd: claude
    codex:
      cmd: /path/to/codex
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `.gitignore` pattern to prevent accidentally ignoring the `cmd/maestro` source directory. Changed from `maestro` (which matches any file or directory named maestro anywhere in the tree) to `/maestro` (which only matches the binary at the root).

**Note**: The PR title and description reference pluggable model backends and multiple file changes, but those changes were actually merged in a previous commit (01d8743). This PR only contains the `.gitignore` fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a simple, correct `.gitignore` pattern fix that prevents the source directory from being accidentally ignored. The leading slash properly restricts the pattern to only match the root-level binary.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .gitignore | Fixed pattern from `maestro` to `/maestro` to only ignore root binary, not `cmd/maestro` directory |

</details>



<sub>Last reviewed commit: 110dc88</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->