### PR TITLE
feat: session_prefix and state_dir in config for multi-project support (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ repo: BeFeast/panoptikon
 local_path: /home/shtrudel/src/panoptikon
 worktree_base: /home/shtrudel/.worktrees/panoptikon
 max_parallel: 5
+session_prefix: pan         # worker session name prefix (default: first 3 chars of repo name)
+state_dir: ~/.maestro/pan   # state/log directory (default: ~/.maestro/<repo-hash>)
 claude_cmd: claude          # the claude CLI binary
 issue_label: enhancement    # label to filter issues
 exclude_labels:
@@ -147,9 +149,10 @@ maestro status --json   # JSON output
 
 Example output:
 ```
-Repo:         BeFeast/panoptikon
-State file:   /home/shtrudel/.maestro/d581c91d05cc/state.json
-Max parallel: 5
+Repo:           BeFeast/panoptikon
+Session prefix: pan
+State file:     /home/shtrudel/.maestro/d581c91d05cc/state.json
+Max parallel:   5
 
 SESSION  ISSUE  STATUS   PID    ALIVE  AGE    TITLE
 -------  -----  ------   ---    -----  ---    -----
@@ -244,6 +247,49 @@ For automatic operation, run on a cron schedule:
 Or run as a daemon:
 ```bash
 maestro run --interval 10m
+```
+
+## Multi-Project Setup
+
+To run maestro for multiple projects simultaneously, use `session_prefix` and `state_dir` to keep workers and state isolated:
+
+```yaml
+# ~/.maestro/maestro-panoptikon.yaml
+repo: BeFeast/panoptikon
+session_prefix: pan           # workers: pan-1, pan-2, ...
+state_dir: ~/.maestro/pan
+worktree_base: ~/.worktrees/panoptikon
+max_parallel: 5
+```
+
+```yaml
+# ~/.maestro/maestro-myapp.yaml
+repo: BeFeast/myapp
+session_prefix: app           # workers: app-1, app-2, ...
+state_dir: ~/.maestro/app
+worktree_base: ~/.worktrees/myapp
+max_parallel: 3
+```
+
+### systemd Template Unit
+
+A `maestro@.service` template is included for running multiple instances as user services:
+
+```bash
+# Install the template
+cp maestro@.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+
+# Start per-project instances (uses ~/.maestro/maestro-<name>.yaml)
+systemctl --user start maestro@panoptikon
+systemctl --user start maestro@myapp
+
+# Enable on boot
+systemctl --user enable maestro@panoptikon
+
+# Check status
+systemctl --user status maestro@panoptikon
+journalctl --user -u maestro@panoptikon -f
 ```
 
 ## Dependencies

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -125,7 +125,7 @@ func runCmd(args []string) {
 		log.Printf("warn: load prompt: %v", err)
 	}
 
-	log.Printf("starting maestro — repo=%s interval=%s once=%v", cfg.Repo, *interval, *once)
+	log.Printf("starting maestro — repo=%s prefix=%s interval=%s once=%v", cfg.Repo, cfg.SessionPrefix, *interval, *once)
 
 	if err := orch.Run(*interval, *once); err != nil {
 		log.Fatalf("run: %v", err)
@@ -140,7 +140,7 @@ func statusCmd(args []string) {
 
 	cfg := loadConfig(*configPath)
 
-	s, err := state.Load(cfg.Repo)
+	s, err := state.Load(cfg.StateDir)
 	if err != nil {
 		log.Fatalf("load state: %v", err)
 	}
@@ -153,9 +153,10 @@ func statusCmd(args []string) {
 	}
 
 	// Pretty table
-	fmt.Printf("Repo:       %s\n", cfg.Repo)
-	fmt.Printf("State file: %s\n", state.StatePath(cfg.Repo))
-	fmt.Printf("Max parallel: %d\n\n", cfg.MaxParallel)
+	fmt.Printf("Repo:           %s\n", cfg.Repo)
+	fmt.Printf("Session prefix: %s\n", cfg.SessionPrefix)
+	fmt.Printf("State file:     %s\n", state.StatePath(cfg.StateDir))
+	fmt.Printf("Max parallel:   %d\n\n", cfg.MaxParallel)
 
 	if len(s.Sessions) == 0 {
 		fmt.Println("No sessions.")
@@ -209,7 +210,7 @@ func logsCmd(args []string) {
 
 	cfg := loadConfig(*configPath)
 
-	s, err := state.Load(cfg.Repo)
+	s, err := state.Load(cfg.StateDir)
 	if err != nil {
 		log.Fatalf("load state: %v", err)
 	}
@@ -260,7 +261,7 @@ func logsCmd(args []string) {
 			alive = " (dead)"
 		}
 		fmt.Printf("  %s (#%d): %s%s\n", name, sess.IssueNumber, sess.LogFile, alive)
-		logDir = state.LogDir(cfg.Repo)
+		logDir = state.LogDir(cfg.StateDir)
 	}
 
 	fmt.Println()
@@ -270,7 +271,7 @@ func logsCmd(args []string) {
 	}
 
 	fmt.Println()
-	fmt.Printf("To watch all logs:\n  tail -f %s/pan-*.log\n", logDir)
+	fmt.Printf("To watch all logs:\n  tail -f %s/%s-*.log\n", logDir, cfg.SessionPrefix)
 }
 
 func watchCmd(args []string) {
@@ -280,7 +281,7 @@ func watchCmd(args []string) {
 
 	cfg := loadConfig(*configPath)
 
-	s, err := state.Load(cfg.Repo)
+	s, err := state.Load(cfg.StateDir)
 	if err != nil {
 		log.Fatalf("load state: %v", err)
 	}
@@ -364,7 +365,7 @@ func spawnCmd(args []string) {
 
 	cfg := loadConfig(*configPath)
 
-	s, err := state.Load(cfg.Repo)
+	s, err := state.Load(cfg.StateDir)
 	if err != nil {
 		log.Fatalf("load state: %v", err)
 	}
@@ -417,7 +418,7 @@ func spawnCmd(args []string) {
 		log.Fatalf("start worker: %v", err)
 	}
 
-	if err := state.Save(cfg.Repo, s); err != nil {
+	if err := state.Save(cfg.StateDir, s); err != nil {
 		log.Fatalf("save state: %v", err)
 	}
 
@@ -437,7 +438,7 @@ func stopCmd(args []string) {
 
 	cfg := loadConfig(*configPath)
 
-	s, err := state.Load(cfg.Repo)
+	s, err := state.Load(cfg.StateDir)
 	if err != nil {
 		log.Fatalf("load state: %v", err)
 	}
@@ -453,7 +454,7 @@ func stopCmd(args []string) {
 
 	delete(s.Sessions, *sessionName)
 
-	if err := state.Save(cfg.Repo, s); err != nil {
+	if err := state.Save(cfg.StateDir, s); err != nil {
 		log.Fatalf("save state: %v", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"crypto/md5"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -35,6 +37,8 @@ type Config struct {
 	IssueLabels   []string       `yaml:"issue_labels"`
 	ExcludeLabels []string       `yaml:"exclude_labels"`
 	WorkerPrompt  string         `yaml:"worker_prompt"`
+	SessionPrefix string         `yaml:"session_prefix"` // worker session name prefix (default: first 3 chars of repo name)
+	StateDir      string         `yaml:"state_dir"`      // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model         ModelConfig    `yaml:"model"`
 	Telegram      TelegramConfig `yaml:"telegram"`
 }
@@ -106,6 +110,24 @@ func parse(data []byte) (*Config, error) {
 	cfg.LocalPath = expandHome(cfg.LocalPath)
 	cfg.WorktreeBase = expandHome(cfg.WorktreeBase)
 	cfg.WorkerPrompt = expandHome(cfg.WorkerPrompt)
+	cfg.StateDir = expandHome(cfg.StateDir)
+
+	// Default session_prefix: first 3 chars of repo name
+	if cfg.SessionPrefix == "" {
+		parts := strings.Split(cfg.Repo, "/")
+		name := parts[len(parts)-1]
+		if len(name) >= 3 {
+			cfg.SessionPrefix = name[:3]
+		} else {
+			cfg.SessionPrefix = name
+		}
+	}
+
+	// Default state_dir: ~/.maestro/<md5-hash-of-repo>
+	if cfg.StateDir == "" {
+		hash := fmt.Sprintf("%x", md5.Sum([]byte(cfg.Repo)))[:12]
+		cfg.StateDir = filepath.Join(os.Getenv("HOME"), ".maestro", hash)
+	}
 
 	if cfg.Telegram.OpenclawURL == "" {
 		cfg.Telegram.OpenclawURL = "http://localhost:18789"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -99,5 +101,105 @@ issue_labels:
 		if l != want[i] {
 			t.Errorf("IssueLabels[%d] = %q, want %q", i, l, want[i])
 		}
+	}
+}
+
+func TestParse_SessionPrefixDefault(t *testing.T) {
+	yaml := `repo: BeFeast/panoptikon`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SessionPrefix != "pan" {
+		t.Errorf("expected session_prefix=pan, got %q", cfg.SessionPrefix)
+	}
+}
+
+func TestParse_SessionPrefixExplicit(t *testing.T) {
+	yaml := `
+repo: BeFeast/panoptikon
+session_prefix: myapp
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SessionPrefix != "myapp" {
+		t.Errorf("expected session_prefix=myapp, got %q", cfg.SessionPrefix)
+	}
+}
+
+func TestParse_SessionPrefixShortRepoName(t *testing.T) {
+	yaml := `repo: user/ab`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SessionPrefix != "ab" {
+		t.Errorf("expected session_prefix=ab, got %q", cfg.SessionPrefix)
+	}
+}
+
+func TestParse_StateDirDefault(t *testing.T) {
+	yaml := `repo: BeFeast/panoptikon`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	home := os.Getenv("HOME")
+	// Default should be ~/.maestro/<md5-hash>
+	if !filepath.HasPrefix(cfg.StateDir, filepath.Join(home, ".maestro")) {
+		t.Errorf("expected state_dir under ~/.maestro, got %q", cfg.StateDir)
+	}
+	if cfg.StateDir == "" {
+		t.Error("state_dir should not be empty")
+	}
+}
+
+func TestParse_StateDirExplicit(t *testing.T) {
+	yaml := `
+repo: BeFeast/panoptikon
+state_dir: /tmp/maestro-test
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.StateDir != "/tmp/maestro-test" {
+		t.Errorf("expected state_dir=/tmp/maestro-test, got %q", cfg.StateDir)
+	}
+}
+
+func TestParse_StateDirExpandsHome(t *testing.T) {
+	yaml := `
+repo: BeFeast/panoptikon
+state_dir: ~/.maestro/panoptikon
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	home := os.Getenv("HOME")
+	expected := filepath.Join(home, ".maestro/panoptikon")
+	if cfg.StateDir != expected {
+		t.Errorf("expected state_dir=%s, got %q", expected, cfg.StateDir)
+	}
+}
+
+func TestParse_DifferentReposDifferentStateDirs(t *testing.T) {
+	yaml1 := `repo: BeFeast/panoptikon`
+	yaml2 := `repo: BeFeast/myapp`
+
+	cfg1, err := parse([]byte(yaml1))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg2, err := parse([]byte(yaml2))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg1.StateDir == cfg2.StateDir {
+		t.Errorf("different repos should have different default state_dirs, both got %q", cfg1.StateDir)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -57,7 +57,7 @@ func (o *Orchestrator) LoadPromptBase(promptPath string) error {
 
 // RunOnce executes one orchestration cycle
 func (o *Orchestrator) RunOnce() error {
-	s, err := state.Load(o.repo)
+	s, err := state.Load(o.cfg.StateDir)
 	if err != nil {
 		return fmt.Errorf("load state: %w", err)
 	}
@@ -74,7 +74,7 @@ func (o *Orchestrator) RunOnce() error {
 	o.rebaseConflicts(s)
 
 	// Save after all checks
-	if err := state.Save(o.repo, s); err != nil {
+	if err := state.Save(o.cfg.StateDir, s); err != nil {
 		return fmt.Errorf("save state: %w", err)
 	}
 
@@ -85,7 +85,7 @@ func (o *Orchestrator) RunOnce() error {
 
 	if slots > 0 {
 		o.startNewWorkers(s, slots)
-		if err := state.Save(o.repo, s); err != nil {
+		if err := state.Save(o.cfg.StateDir, s); err != nil {
 			return fmt.Errorf("save state after workers: %w", err)
 		}
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"crypto/md5"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -46,21 +45,16 @@ func NewState() *State {
 	}
 }
 
-func StateDir(repo string) string {
-	hash := fmt.Sprintf("%x", md5.Sum([]byte(repo)))[:12]
-	return filepath.Join(os.Getenv("HOME"), ".maestro", hash)
+func StatePath(stateDir string) string {
+	return filepath.Join(stateDir, "state.json")
 }
 
-func StatePath(repo string) string {
-	return filepath.Join(StateDir(repo), "state.json")
+func LogDir(stateDir string) string {
+	return filepath.Join(stateDir, "logs")
 }
 
-func LogDir(repo string) string {
-	return filepath.Join(StateDir(repo), "logs")
-}
-
-func Load(repo string) (*State, error) {
-	path := StatePath(repo)
+func Load(stateDir string) (*State, error) {
+	path := StatePath(stateDir)
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return NewState(), nil
@@ -76,9 +70,8 @@ func Load(repo string) (*State, error) {
 	return s, nil
 }
 
-func Save(repo string, s *State) error {
-	dir := StateDir(repo)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+func Save(stateDir string, s *State) error {
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
 		return fmt.Errorf("create state dir: %w", err)
 	}
 
@@ -87,7 +80,7 @@ func Save(repo string, s *State) error {
 		return fmt.Errorf("marshal state: %w", err)
 	}
 
-	path := StatePath(repo)
+	path := StatePath(stateDir)
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0644); err != nil {
 		return fmt.Errorf("write temp state: %w", err)
@@ -98,7 +91,7 @@ func Save(repo string, s *State) error {
 	return nil
 }
 
-// NextSlotName returns "pan-N" for the next available slot
+// NextSlotName returns "{prefix}-N" for the next available slot
 func (s *State) NextSlotName(prefix string) string {
 	name := fmt.Sprintf("%s-%d", prefix, s.NextSlot)
 	s.NextSlot++

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -47,8 +47,7 @@ func TmuxSessionName(slotName string) string {
 // Start spawns a new worker for the given issue inside a tmux session.
 // backendName selects the model backend ("claude", "codex", etc.); empty defaults to config.
 func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, promptBase string, backendName string) (string, error) {
-	prefix := SlotPrefix(cfg.Repo)
-	slotName := s.NextSlotName(prefix)
+	slotName := s.NextSlotName(cfg.SessionPrefix)
 
 	worktreePath := filepath.Join(cfg.WorktreeBase, slotName)
 	branchName := fmt.Sprintf("feat/%s-%d-%s", slotName, issue.Number, slugify(issue.Title))
@@ -65,8 +64,7 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
 
 	// Write prompt to file
-	stateDir := state.StateDir(repo)
-	promptFile := filepath.Join(stateDir, fmt.Sprintf("%s-prompt.md", slotName))
+	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
 	if err := os.WriteFile(promptFile, []byte(prompt), 0644); err != nil {
 		return "", fmt.Errorf("write prompt file: %w", err)
 	}
@@ -90,7 +88,7 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 	}
 
 	// Prepare log file
-	logDir := state.LogDir(repo)
+	logDir := state.LogDir(cfg.StateDir)
 	if err := os.MkdirAll(logDir, 0755); err != nil {
 		return "", fmt.Errorf("create log dir: %w", err)
 	}
@@ -103,7 +101,7 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 	}
 
 	// Write runner script
-	runnerPath := filepath.Join(stateDir, slotName+"-run.sh")
+	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
 	var runnerContent string
 	if stdinFile != "" {
 		// Stdin-based backends (e.g. codex): redirect prompt file to stdin via shell

--- a/maestro@.service
+++ b/maestro@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Maestro agent orchestrator (%i)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/maestro run --config %h/.maestro/maestro-%i.yaml
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Implements #15

## Changes

- **`session_prefix` config field** — Controls the worker session name prefix (e.g. `app-1`, `app-2`). Defaults to first 3 chars of repo name (preserving current behavior like `pan-1`).
- **`state_dir` config field** — Explicit state/log directory path. Defaults to `~/.maestro/<md5-hash>` (backward compatible). Supports `~` expansion.
- **Refactored state package** — `Load()`, `Save()`, `StatePath()`, `LogDir()` now accept a resolved `stateDir` string directly instead of computing from repo name. The config layer handles default resolution.
- **`maestro@.service` systemd template** — Allows running per-project instances with `systemctl --user start maestro@panoptikon`. Reads config from `~/.maestro/maestro-%i.yaml`.
- **README updated** — Documents new config fields, multi-project setup with example configs, and systemd template installation.
- **Config tests added** — Covers default derivation, explicit overrides, `~` expansion, and isolation between different repos.

### Example multi-project config

```yaml
# ~/.maestro/maestro-myapp.yaml
repo: BeFeast/myapp
session_prefix: app    # workers: app-1, app-2, ...
state_dir: ~/.maestro/app
worktree_base: ~/.worktrees/myapp
max_parallel: 3
```

## Testing

- `go test ./...` — all tests pass (new config tests + existing worker tests)
- `go vet ./...` — clean
- `go build ./cmd/maestro/` — binary builds successfully
- Verified backward compatibility: configs without `session_prefix`/`state_dir` produce identical behavior (same MD5-hashed state dir, same 3-char prefix)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements multi-project support by adding two new config fields: `session_prefix` (controls worker session name prefix) and `state_dir` (explicit state/log directory path). The implementation is backward compatible, with sensible defaults that preserve existing behavior.

**Key Changes:**
- Config layer now computes defaults for `session_prefix` (first 3 chars of repo name) and `state_dir` (~/.maestro/<md5-hash>) if not explicitly set
- State package refactored to accept resolved `stateDir` string parameter instead of deriving from repo name
- All state load/save calls updated across main, orchestrator, and worker packages
- Added systemd template unit (`maestro@.service`) for running per-project instances
- Comprehensive test coverage for new config fields including defaults, overrides, and tilde expansion
- Documentation updated with multi-project setup examples

**Review Notes:**
- The refactoring is clean and well-structured, moving the default derivation logic to the config layer where it belongs
- Backward compatibility is maintained through intelligent defaults
- Test coverage is thorough, including isolation tests for different repos
- The systemd template follows standard conventions with `%h` (home dir) and `%i` (instance name) specifiers

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- Clean refactoring with comprehensive test coverage, backward compatibility maintained, and well-documented changes. All state management logic properly updated throughout the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Added `session_prefix` and `state_dir` config fields with proper defaults and `~` expansion |
| internal/state/state.go | Refactored to accept `stateDir` parameter instead of deriving from repo name |
| internal/worker/worker.go | Updated to use `cfg.SessionPrefix` and `cfg.StateDir` instead of deriving from repo |
| cmd/maestro/main.go | Updated all commands to use `cfg.StateDir` and display `cfg.SessionPrefix` in status |
| internal/orchestrator/orchestrator.go | Updated state load/save calls to use `cfg.StateDir` from config |
| internal/config/config_test.go | Added comprehensive tests for `session_prefix` and `state_dir` defaults and overrides |
| README.md | Documented new config fields, multi-project setup, and systemd template usage |
| maestro@.service | New systemd template unit for running multiple project instances |

</details>



<sub>Last reviewed commit: 99afadf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->