### PR TITLE
feat: maestro init — interactive setup wizard (#18)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// initYAMLConfig is the config structure written to maestro.yaml by init.
+type initYAMLConfig struct {
+	Repo         string            `yaml:"repo"`
+	LocalPath    string            `yaml:"local_path"`
+	WorktreeBase string            `yaml:"worktree_base"`
+	MaxParallel  int               `yaml:"max_parallel"`
+	IssueLabels  []string          `yaml:"issue_labels"`
+	Model        initYAMLModel     `yaml:"model"`
+	Telegram     *initYAMLTelegram `yaml:"telegram,omitempty"`
+}
+
+type initYAMLModel struct {
+	Default string `yaml:"default"`
+}
+
+type initYAMLTelegram struct {
+	Target string `yaml:"target"`
+}
+
+func initCmd(args []string) {
+	if err := runInitWizard(os.Stdin, os.Stdout, "."); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
+	yamlPath := filepath.Join(outDir, "maestro.yaml")
+	if _, err := os.Stat(yamlPath); err == nil {
+		return fmt.Errorf("maestro.yaml already exists in %s (remove it first to re-initialize)", outDir)
+	}
+
+	scanner := bufio.NewScanner(r)
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Welcome to Maestro! Let's set up your first project.")
+	fmt.Fprintln(w)
+
+	repo := promptInit(scanner, w, "GitHub repo (owner/repo)", "")
+	if repo == "" {
+		return fmt.Errorf("repo is required")
+	}
+
+	parts := strings.Split(repo, "/")
+	repoName := parts[len(parts)-1]
+
+	localPath := promptInit(scanner, w, "Local clone path", "~/src/"+repoName)
+	worktreeBase := promptInit(scanner, w, "Worktree base dir", "~/.worktrees/"+repoName)
+	maxParallelStr := promptInit(scanner, w, "Max parallel workers", "3")
+	modelBackend := promptInit(scanner, w, "Default model backend (claude/codex/gemini)", "claude")
+	issueLabel := promptInit(scanner, w, "Issue label filter", "enhancement")
+
+	maxParallel, err := strconv.Atoi(maxParallelStr)
+	if err != nil || maxParallel < 1 {
+		maxParallel = 3
+	}
+
+	telegramAnswer := promptInit(scanner, w, "Telegram notifications? (y/N)", "")
+	wantsTelegram := strings.EqualFold(telegramAnswer, "y") || strings.EqualFold(telegramAnswer, "yes")
+
+	var telegram *initYAMLTelegram
+	if wantsTelegram {
+		fmt.Fprintf(w, "  \u2192 Telegram target ID: ")
+		if scanner.Scan() {
+			if id := strings.TrimSpace(scanner.Text()); id != "" {
+				telegram = &initYAMLTelegram{Target: id}
+			}
+		}
+	}
+
+	fmt.Fprintln(w)
+
+	// Build config
+	cfg := initYAMLConfig{
+		Repo:         repo,
+		LocalPath:    localPath,
+		WorktreeBase: worktreeBase,
+		MaxParallel:  maxParallel,
+		IssueLabels:  []string{issueLabel},
+		Model:        initYAMLModel{Default: modelBackend},
+		Telegram:     telegram,
+	}
+
+	yamlData, err := yaml.Marshal(&cfg)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(yamlPath, yamlData, 0644); err != nil {
+		return fmt.Errorf("write maestro.yaml: %w", err)
+	}
+	fmt.Fprintln(w, "\u2705 Created maestro.yaml")
+
+	// Create ~/.maestro/ state directory
+	maestroDir := filepath.Join(os.Getenv("HOME"), ".maestro")
+	os.MkdirAll(maestroDir, 0755) //nolint: state dir is best-effort
+
+	// Create service file (non-fatal)
+	binPath, _ := os.Executable()
+	if binPath == "" {
+		binPath = "maestro"
+	}
+	absConfigPath, _ := filepath.Abs(yamlPath)
+	if absConfigPath == "" {
+		absConfigPath = yamlPath
+	}
+
+	if err := writeInitServiceFile(w, binPath, absConfigPath); err != nil {
+		fmt.Fprintf(w, "Note: could not create service file: %v\n", err)
+	}
+
+	// Next steps
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Run: maestro run --once    (test run)")
+	switch runtime.GOOS {
+	case "linux":
+		fmt.Fprintln(w, "     systemctl --user enable --now maestro.service")
+	case "darwin":
+		fmt.Fprintln(w, "     launchctl load ~/Library/LaunchAgents/com.maestro.agent.plist")
+	}
+
+	return nil
+}
+
+func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
+	switch runtime.GOOS {
+	case "linux":
+		dir := filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+		path := filepath.Join(dir, "maestro.service")
+		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath)), 0644); err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "\u2705 Created %s\n", path)
+	case "darwin":
+		dir := filepath.Join(os.Getenv("HOME"), "Library", "LaunchAgents")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+		path := filepath.Join(dir, "com.maestro.agent.plist")
+		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath)), 0644); err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "\u2705 Created %s\n", path)
+	}
+	return nil
+}
+
+func systemdUnit(binPath, configPath string) string {
+	return fmt.Sprintf(`[Unit]
+Description=Maestro - AI coding agent orchestrator
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=%s run --config %s
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+`, binPath, configPath)
+}
+
+func launchdPlist(binPath, configPath string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.maestro.agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>%s</string>
+        <string>run</string>
+        <string>--config</string>
+        <string>%s</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/maestro.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/maestro.stderr.log</string>
+</dict>
+</plist>
+`, binPath, configPath)
+}
+
+func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {
+	if defaultVal != "" {
+		fmt.Fprintf(w, "? %s (%s): ", question, defaultVal)
+	} else {
+		fmt.Fprintf(w, "? %s: ", question)
+	}
+	if !scanner.Scan() {
+		return defaultVal
+	}
+	answer := strings.TrimSpace(scanner.Text())
+	if answer == "" {
+		return defaultVal
+	}
+	return answer
+}

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPromptInit(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		question   string
+		defaultVal string
+		want       string
+	}{
+		{"user input", "my-answer\n", "Question", "default", "my-answer"},
+		{"empty uses default", "\n", "Question", "default", "default"},
+		{"no default empty", "\n", "Question", "", ""},
+		{"trims whitespace", "  spaced  \n", "Question", "", "spaced"},
+		{"eof uses default", "", "Question", "fallback", "fallback"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := bufio.NewScanner(strings.NewReader(tt.input))
+			var buf bytes.Buffer
+			got := promptInit(scanner, &buf, tt.question, tt.defaultVal)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPromptInitOutput(t *testing.T) {
+	scanner := bufio.NewScanner(strings.NewReader("answer\n"))
+	var buf bytes.Buffer
+	promptInit(scanner, &buf, "Name", "default")
+	if !strings.Contains(buf.String(), "? Name (default): ") {
+		t.Errorf("prompt output = %q, want to contain '? Name (default): '", buf.String())
+	}
+
+	scanner = bufio.NewScanner(strings.NewReader("answer\n"))
+	buf.Reset()
+	promptInit(scanner, &buf, "Name", "")
+	if !strings.Contains(buf.String(), "? Name: ") {
+		t.Errorf("prompt output = %q, want to contain '? Name: '", buf.String())
+	}
+}
+
+func TestSystemdUnit(t *testing.T) {
+	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml")
+	if !strings.Contains(content, "ExecStart=/usr/bin/maestro run --config /etc/maestro.yaml") {
+		t.Error("should contain correct ExecStart line")
+	}
+	for _, section := range []string{"[Unit]", "[Service]", "[Install]"} {
+		if !strings.Contains(content, section) {
+			t.Errorf("should contain %s section", section)
+		}
+	}
+}
+
+func TestLaunchdPlist(t *testing.T) {
+	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml")
+	if !strings.Contains(content, "<string>/usr/bin/maestro</string>") {
+		t.Error("should contain binary path")
+	}
+	if !strings.Contains(content, "<string>/etc/maestro.yaml</string>") {
+		t.Error("should contain config path")
+	}
+	if !strings.Contains(content, "com.maestro.agent") {
+		t.Error("should contain label")
+	}
+}
+
+func TestRunInitWizard(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// repo, local_path(default), worktree(default), max_parallel(default),
+	// model(default), label(default), telegram(no)
+	input := "BeFeast/myrepo\n\n\n\n\n\n\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err != nil {
+		t.Fatalf("runInitWizard error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "maestro.yaml"))
+	if err != nil {
+		t.Fatal("maestro.yaml not created")
+	}
+
+	yamlStr := string(data)
+	checks := map[string]string{
+		"repo":          "repo: BeFeast/myrepo",
+		"local_path":    "local_path: ~/src/myrepo",
+		"worktree_base": "worktree_base: ~/.worktrees/myrepo",
+		"max_parallel":  "max_parallel: 3",
+		"issue_labels":  "enhancement",
+		"model":         "default: claude",
+	}
+	for field, want := range checks {
+		if !strings.Contains(yamlStr, want) {
+			t.Errorf("yaml missing %s (%q), got:\n%s", field, want, yamlStr)
+		}
+	}
+
+	// No telegram section when declined
+	if strings.Contains(yamlStr, "telegram") {
+		t.Errorf("yaml should not contain telegram when declined, got:\n%s", yamlStr)
+	}
+
+	out := output.String()
+	if !strings.Contains(out, "Welcome to Maestro") {
+		t.Error("should show welcome message")
+	}
+	if !strings.Contains(out, "\u2705 Created maestro.yaml") {
+		t.Error("should show config created message")
+	}
+
+	// Verify ~/.maestro/ was created
+	if _, err := os.Stat(filepath.Join(tmpDir, ".maestro")); os.IsNotExist(err) {
+		t.Error("~/.maestro/ directory not created")
+	}
+}
+
+func TestRunInitWizardWithTelegram(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	input := "BeFeast/myrepo\n\n\n\n\n\ny\n79510949\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err != nil {
+		t.Fatalf("runInitWizard error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "maestro.yaml"))
+	if err != nil {
+		t.Fatal("maestro.yaml not created")
+	}
+
+	yamlStr := string(data)
+	if !strings.Contains(yamlStr, "telegram") {
+		t.Errorf("yaml should contain telegram section, got:\n%s", yamlStr)
+	}
+	if !strings.Contains(yamlStr, "79510949") {
+		t.Errorf("yaml should contain telegram target, got:\n%s", yamlStr)
+	}
+}
+
+func TestRunInitWizardCustomValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	input := "myorg/myapp\n~/code/myapp\n~/.wt/myapp\n5\ncodex\nbug\nN\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err != nil {
+		t.Fatalf("runInitWizard error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "maestro.yaml"))
+	if err != nil {
+		t.Fatal("maestro.yaml not created")
+	}
+
+	yamlStr := string(data)
+	checks := map[string]string{
+		"repo":          "repo: myorg/myapp",
+		"local_path":    "local_path: ~/code/myapp",
+		"worktree_base": "worktree_base: ~/.wt/myapp",
+		"max_parallel":  "max_parallel: 5",
+		"issue_labels":  "bug",
+		"model":         "default: codex",
+	}
+	for field, want := range checks {
+		if !strings.Contains(yamlStr, want) {
+			t.Errorf("yaml missing %s (%q), got:\n%s", field, want, yamlStr)
+		}
+	}
+}
+
+func TestRunInitWizardExistingConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "maestro.yaml"), []byte("existing"), 0644)
+
+	var output bytes.Buffer
+	err := runInitWizard(strings.NewReader("BeFeast/test\n"), &output, tmpDir)
+	if err == nil {
+		t.Fatal("expected error when maestro.yaml exists")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention 'already exists', got: %v", err)
+	}
+}
+
+func TestRunInitWizardEmptyRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	var output bytes.Buffer
+	err := runInitWizard(strings.NewReader("\n"), &output, tmpDir)
+	if err == nil {
+		t.Fatal("expected error for empty repo")
+	}
+	if !strings.Contains(err.Error(), "repo is required") {
+		t.Errorf("error should mention 'repo is required', got: %v", err)
+	}
+}
+
+func TestRunInitWizardInvalidMaxParallel(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	input := "org/repo\n\n\nabc\n\n\n\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err != nil {
+		t.Fatalf("runInitWizard error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "maestro.yaml"))
+	if err != nil {
+		t.Fatal("maestro.yaml not created")
+	}
+
+	if !strings.Contains(string(data), "max_parallel: 3") {
+		t.Errorf("invalid max_parallel should default to 3, got:\n%s", string(data))
+	}
+}

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -26,6 +26,7 @@ Usage:
   maestro <command> [flags]
 
 Commands:
+  init      Interactive setup wizard for new projects
   run       Run the orchestration loop
   status    Show current state
   logs      Show worker logs (tail -f)
@@ -70,6 +71,8 @@ func main() {
 	args := os.Args[2:]
 
 	switch cmd {
+	case "init":
+		initCmd(args)
 	case "run":
 		runCmd(args)
 	case "status":


### PR DESCRIPTION
Implements #18

## Changes
- Add `maestro init` subcommand with interactive wizard that prompts for:
  - GitHub repo, local clone path, worktree base dir
  - Max parallel workers, model backend, issue label filter
  - Telegram notification settings (optional)
- Generates `maestro.yaml` in the current directory
- Creates `~/.maestro/` state directory
- Generates systemd service file (Linux) or launchd plist (macOS)
- Shows next-step instructions after setup

## New files
- `cmd/maestro/init.go` — Init command implementation with interactive wizard
- `cmd/maestro/init_test.go` — Tests covering prompts, YAML generation, service files, full wizard flow, and error cases

## Testing
- 9 unit/integration tests covering:
  - Prompt input with defaults, whitespace trimming, EOF handling
  - Full wizard with default values and custom values
  - Telegram enabled/disabled paths
  - Invalid max_parallel fallback to default
  - Existing config file detection (prevents overwrite)
  - Empty repo validation
  - Systemd and launchd content generation
- `go fmt`, `go vet`, `go test`, `go build` all pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements an interactive setup wizard for `maestro init` that guides users through initial configuration. The implementation is well-tested with comprehensive test coverage, but has several logic issues that need to be addressed:

**Key Changes:**
- Added `maestro init` command with interactive prompts for repo, paths, workers, model backend, issue labels, and Telegram notifications
- Generates `maestro.yaml` config file and systemd/launchd service files
- Creates `~/.maestro/` state directory
- 9 comprehensive tests covering wizard flow, defaults, validation, and error cases

**Issues Found:**
- Config structure is incomplete - missing `openclaw_url`, `exclude_labels`, `worker_prompt`, and `model.backends` fields that exist in actual config
- Repo name parsing will fail if user enters full GitHub URLs (e.g., `https://github.com/owner/repo`)
- Telegram target prompt doesn't use the `promptInit` helper, causing inconsistent behavior and potential EOF handling issues
- Uses `os.Getenv("HOME")` instead of `os.UserHomeDir()`, which may fail on some systems
- Generated configs won't show users all available configuration options

<h3>Confidence Score: 2/5</h3>

- Multiple logic issues present that will cause functionality problems in production use
- The PR has solid test coverage and the core wizard flow works, but contains multiple logic bugs that will cause real issues: incomplete config generation missing several important fields (especially model.backends which is critical for multi-backend support), fragile repo name parsing that fails with URLs, inconsistent prompt handling for Telegram, and HOME directory issues. These aren't just style issues - they're functional bugs that will affect users.
- `cmd/maestro/init.go` needs attention to fix config structure completeness, repo parsing logic, Telegram prompt consistency, and HOME directory handling

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Implements interactive setup wizard but has several logic issues: missing config fields (openclaw_url, exclude_labels, worker_prompt, model.backends), fragile repo name parsing, inconsistent Telegram prompt, and HOME env var reliability issues |
| cmd/maestro/init_test.go | Comprehensive test coverage with 9 tests covering prompts, YAML generation, service files, and error cases - tests are well-structured and thorough |
| cmd/maestro/main.go | Simple integration changes adding init command to switch statement and usage text - no issues |

</details>



<sub>Last reviewed commit: 999b013</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->