### PR TITLE
feat: validate repo format and confirm state dir in maestro init (#18)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -56,8 +56,11 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 		return fmt.Errorf("repo is required")
 	}
 
-	parts := strings.Split(repo, "/")
-	repoName := parts[len(parts)-1]
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("repo must be in owner/repo format (e.g. BeFeast/panoptikon)")
+	}
+	repoName := parts[1]
 
 	localPath := promptInit(scanner, w, "Local clone path", "~/src/"+repoName)
 	worktreeBase := promptInit(scanner, w, "Worktree base dir", "~/.worktrees/"+repoName)
@@ -108,7 +111,11 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 
 	// Create ~/.maestro/ state directory
 	maestroDir := filepath.Join(os.Getenv("HOME"), ".maestro")
-	os.MkdirAll(maestroDir, 0755) //nolint: state dir is best-effort
+	if err := os.MkdirAll(maestroDir, 0755); err != nil {
+		fmt.Fprintf(w, "Note: could not create state directory: %v\n", err)
+	} else {
+		fmt.Fprintf(w, "\u2705 Created %s\n", maestroDir)
+	}
 
 	// Create service file (non-fatal)
 	binPath, _ := os.Executable()

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -216,6 +216,50 @@ func TestRunInitWizardEmptyRepo(t *testing.T) {
 	}
 }
 
+func TestRunInitWizardInvalidRepoFormat(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"no slash", "justrepo\n"},
+		{"empty owner", "/repo\n"},
+		{"empty repo name", "owner/\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			var output bytes.Buffer
+			err := runInitWizard(strings.NewReader(tt.input), &output, tmpDir)
+			if err == nil {
+				t.Fatal("expected error for invalid repo format")
+			}
+			if !strings.Contains(err.Error(), "owner/repo") {
+				t.Errorf("error should mention 'owner/repo', got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunInitWizardStateDirConfirmation(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	input := "org/repo\n\n\n\n\n\n\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err != nil {
+		t.Fatalf("runInitWizard error: %v", err)
+	}
+
+	out := output.String()
+	maestroDir := filepath.Join(tmpDir, ".maestro")
+	if !strings.Contains(out, maestroDir) {
+		t.Errorf("output should mention state directory %s, got:\n%s", maestroDir, out)
+	}
+}
+
 func TestRunInitWizardInvalidMaxParallel(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)


### PR DESCRIPTION
Implements #18

## Changes
- **Repo format validation**: `maestro init` now validates that the repo input is in `owner/repo` format (e.g. `BeFeast/panoptikon`). Previously bare names like `justrepo` or malformed inputs like `/repo` or `owner/` were silently accepted, which would break at runtime.
- **State directory confirmation**: Prints a `✅ Created ~/.maestro/` confirmation message when the state directory is successfully created, matching the issue spec output. Previously this was done silently.
- **Tests**: Added table-driven tests for invalid repo formats (`no slash`, `empty owner`, `empty repo name`) and a test verifying the state directory creation confirmation appears in output.

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass (including 3 new tests)
- `go build ./cmd/maestro/` — builds successfully
- `./maestro version` — prints `maestro v0.1.0`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements repo format validation and state directory confirmation for `maestro init`.

Changes:
- Validates repo input is in `owner/repo` format, rejecting invalid inputs like `justrepo`, `/repo`, or `owner/`
- Prints confirmation message when `~/.maestro/` directory is created
- Handles state directory creation errors gracefully with a note message
- Adds comprehensive table-driven tests covering invalid formats and confirmation output

The implementation correctly prevents malformed repo names from being silently accepted. The validation logic is straightforward and well-tested.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor edge case to consider
- The validation logic is sound and well-tested. The only minor issue is that the current regex allows inputs with multiple slashes (e.g., `owner/repo/extra`), though this is unlikely to occur in practice. The error handling for state directory creation is appropriate.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Added repo format validation (owner/repo) and state directory creation confirmation message |
| cmd/maestro/init_test.go | Added comprehensive table-driven tests for invalid repo formats and state dir confirmation |

</details>



<sub>Last reviewed commit: 46cd243</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->