### PR TITLE
feat: auto-close GitHub issue when PR is merged (#27)

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -182,6 +182,26 @@ func (c *Client) MergePR(prNumber int) error {
 	return nil
 }
 
+// CloseIssue closes a GitHub issue and leaves a comment explaining why
+func (c *Client) CloseIssue(number int, comment string) error {
+	if comment != "" {
+		out, err := exec.Command("gh", "issue", "comment",
+			fmt.Sprint(number),
+			"--repo", c.Repo,
+			"--body", comment).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("gh issue comment %d: %w\n%s", number, err, out)
+		}
+	}
+	out, err := exec.Command("gh", "issue", "close",
+		fmt.Sprint(number),
+		"--repo", c.Repo).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh issue close %d: %w\n%s", number, err, out)
+	}
+	return nil
+}
+
 // HasLabel returns true if any of the issue's labels match
 func HasLabel(issue Issue, labels []string) bool {
 	for _, l := range issue.Labels {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -242,6 +242,9 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				o.notifier.Sendf("❌ maestro: failed to merge PR #%d (%s): %v", pr.Number, sess.Branch, err)
 			} else {
 				log.Printf("[orch] merged PR #%d ✓", pr.Number)
+				if err := o.gh.CloseIssue(sess.IssueNumber, fmt.Sprintf("Implemented by PR #%d (auto-merged by maestro).", pr.Number)); err != nil {
+					log.Printf("[orch] warning: failed to close issue #%d: %v", sess.IssueNumber, err)
+				}
 				sess.Status = state.StatusDone
 				now := time.Now().UTC()
 				sess.FinishedAt = &now


### PR DESCRIPTION
Implements #27

## Changes
- Added `CloseIssue(number int, comment string) error` method to the GitHub client (`internal/github/github.go`). It first posts a comment on the issue explaining which PR implemented it, then closes the issue via `gh issue close`.
- In the orchestrator's `autoMergePRs` method (`internal/orchestrator/orchestrator.go`), added a `CloseIssue` call right after a successful merge. If closing fails, it logs a warning but does not block the merge flow.

This prevents workers from repeatedly picking up already-implemented issues that were left open after auto-merge.

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all tests pass
- `go build ./cmd/maestro/` — binary builds and runs (`./maestro version`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds automatic issue closure when PRs are auto-merged. The implementation adds a `CloseIssue` method to the GitHub client that first posts a comment explaining which PR implemented the issue, then closes it. This prevents workers from repeatedly picking up already-implemented issues left open after merge.

- Added `CloseIssue(number int, comment string) error` method to GitHub client
- Integrated into orchestrator's `autoMergePRs` flow after successful merge
- Includes proper error handling with warning logs that don't block the merge flow

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues found
- Clean implementation with proper error handling, follows existing patterns in the codebase, and includes appropriate logging
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/github/github.go | Added `CloseIssue` method that comments on and closes GitHub issues via gh CLI |
| internal/orchestrator/orchestrator.go | Integrated auto-close of issues after successful PR merge; includes error handling |

</details>



<sub>Last reviewed commit: eee530e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->