### PR TITLE
feat: GitHub Releases — cross-platform binaries via CI (#17)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build & Upload
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+          - os: ubuntu-latest
+            goos: linux
+            goarch: arm64
+          - os: macos-latest
+            goos: darwin
+            goarch: amd64
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go build -o maestro-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/maestro/
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.ref_name }} maestro-${{ matrix.goos }}-${{ matrix.goarch }} --clobber

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ Maestro works with private repos — all GitHub operations go through `gh` CLI. 
 
 ## Installation
 
+### Quick install
+
+```bash
+# One-liner install
+curl -fsSL https://raw.githubusercontent.com/BeFeast/maestro/main/scripts/install.sh | bash
+
+# Or download manually from:
+# https://github.com/BeFeast/maestro/releases/latest
+```
+
 ### Release binaries
 
 Download the latest binary from [Releases](https://github.com/BeFeast/maestro/releases) and add it to your PATH.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Install the latest maestro binary for your platform.
+# Usage: curl -fsSL https://raw.githubusercontent.com/BeFeast/maestro/main/scripts/install.sh | bash
+set -euo pipefail
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+LATEST=$(curl -fsSL https://api.github.com/repos/BeFeast/maestro/releases/latest | grep tag_name | cut -d'"' -f4)
+
+if [ -z "$LATEST" ]; then
+  echo "Error: could not determine latest release" >&2
+  exit 1
+fi
+
+BINARY="maestro-${OS}-${ARCH}"
+URL="https://github.com/BeFeast/maestro/releases/download/${LATEST}/${BINARY}"
+
+echo "Downloading ${BINARY} ${LATEST}..."
+curl -fsSL "$URL" -o /usr/local/bin/maestro
+chmod +x /usr/local/bin/maestro
+echo "Maestro ${LATEST} installed to /usr/local/bin/maestro"


### PR DESCRIPTION
Implements #17

## Changes
- **`.github/workflows/release.yml`** — GitHub Actions workflow triggered on `v*` tag push. Builds cross-platform binaries (linux/darwin × amd64/arm64) using a build matrix and uploads them to the GitHub release via `gh release upload`.
- **`scripts/install.sh`** — One-liner install script that detects OS/arch, fetches the latest release, and installs the binary to `/usr/local/bin/maestro`.
- **`README.md`** — Added "Quick install" subsection under Installation with the curl one-liner and a link to the releases page.

## Targets
| OS | Arch | Binary |
|----|------|--------|
| Linux | amd64 | `maestro-linux-amd64` |
| Linux | arm64 | `maestro-linux-arm64` |
| macOS | amd64 (Intel) | `maestro-darwin-amd64` |
| macOS | arm64 (Apple Silicon) | `maestro-darwin-arm64` |

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass
- `go build ./cmd/maestro/` — builds successfully
- `./maestro version` — prints `maestro v0.1.0`
- Workflow YAML validated against GitHub Actions schema (uses `actions/checkout@v4`, `actions/setup-go@v5`, matrix strategy)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds GitHub Actions-based release automation with cross-platform binary builds and a one-liner install script.

- Added GitHub Actions workflow that builds binaries for linux/darwin × amd64/arm64 using build matrix
- Created install script that detects OS/arch and downloads latest release from GitHub
- Updated README with Quick install section featuring the curl one-liner

**Issues found:**
- The workflow uploads binaries but doesn't create the GitHub release first - `gh release upload` will fail if the release doesn't exist yet
- Install script writes to `/usr/local/bin/` without sudo, causing permission errors for users
- No validation for unsupported architectures (i386, armv7l, etc.) - users will get confusing 404 errors

<h3>Confidence Score: 2/5</h3>

- This PR has critical bugs that will prevent the release workflow and install script from working on first use
- The workflow is missing the release creation step which will cause immediate failure, and the install script has permission issues that will break for all users. These are blocking issues that need to be fixed before merge.
- `.github/workflows/release.yml` and `scripts/install.sh` both need fixes before this can work

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | New GitHub Actions workflow for building cross-platform binaries and uploading to releases. Missing release creation step - will fail on first run. |
| scripts/install.sh | New install script for one-liner installation. Has permission issues (needs sudo) and doesn't validate unsupported architectures. |
| README.md | Added Quick install section with curl one-liner and link to releases page. Documentation changes only. |

</details>



<sub>Last reviewed commit: 2c3b09b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->