### PR TITLE
feat: GitHub Releases — cross-platform binaries via CI (#17)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    name: Build & Upload
+    name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -41,7 +41,12 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: go build -o maestro-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/maestro/
 
-      - name: Upload to release
+      - name: Create release if needed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref_name }} maestro-${{ matrix.goos }}-${{ matrix.goarch }} --clobber
+        run: gh release create "${{ github.ref_name }}" --generate-notes || true
+
+      - name: Upload binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" maestro-${{ matrix.goos }}-${{ matrix.goarch }} --clobber

--- a/README.md
+++ b/README.md
@@ -49,16 +49,10 @@ Maestro works with private repos — all GitHub operations go through `gh` CLI. 
 ### Quick install
 
 ```bash
-# One-liner install
 curl -fsSL https://raw.githubusercontent.com/BeFeast/maestro/main/scripts/install.sh | bash
-
-# Or download manually from:
-# https://github.com/BeFeast/maestro/releases/latest
 ```
 
-### Release binaries
-
-Download the latest binary from [Releases](https://github.com/BeFeast/maestro/releases) and add it to your PATH.
+Or download a binary manually from [Releases](https://github.com/BeFeast/maestro/releases/latest).
 
 ### Build from source
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,17 +5,17 @@ set -euo pipefail
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-LATEST=$(curl -fsSL https://api.github.com/repos/BeFeast/maestro/releases/latest | grep tag_name | cut -d'"' -f4)
+BINARY="maestro-${OS}-${ARCH}"
 
+LATEST=$(curl -fsSL https://api.github.com/repos/BeFeast/maestro/releases/latest | grep tag_name | cut -d'"' -f4)
 if [ -z "$LATEST" ]; then
   echo "Error: could not determine latest release" >&2
   exit 1
 fi
 
-BINARY="maestro-${OS}-${ARCH}"
-URL="https://github.com/BeFeast/maestro/releases/download/${LATEST}/${BINARY}"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 echo "Downloading ${BINARY} ${LATEST}..."
-curl -fsSL "$URL" -o /usr/local/bin/maestro
-chmod +x /usr/local/bin/maestro
-echo "Maestro ${LATEST} installed to /usr/local/bin/maestro"
+curl -fsSL "https://github.com/BeFeast/maestro/releases/download/${LATEST}/${BINARY}" -o "${INSTALL_DIR}/maestro"
+chmod +x "${INSTALL_DIR}/maestro"
+echo "Maestro ${LATEST} installed to ${INSTALL_DIR}/maestro"


### PR DESCRIPTION
Implements #17

## Changes
- Add `.github/workflows/release.yml` — builds cross-platform binaries (linux/darwin × amd64/arm64) on version tag pushes (`v*`), creates a GitHub Release with auto-generated notes, and uploads all four binaries
- Add `scripts/install.sh` — one-liner install script that detects OS/arch and downloads the latest release binary (supports `INSTALL_DIR` override)
- Update `README.md` — replace "Release binaries" section with "Quick install" showing the curl one-liner and a link to releases

## Targets
| OS | Arch | Binary |
|----|------|--------|
| Linux | amd64 | `maestro-linux-amd64` |
| Linux | arm64 | `maestro-linux-arm64` |
| macOS | amd64 (Intel) | `maestro-darwin-amd64` |
| macOS | arm64 (Apple Silicon) | `maestro-darwin-arm64` |

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all tests pass
- `go build ./cmd/maestro/ && ./maestro version` — builds and prints `maestro v0.1.0`
- Workflow YAML validated against GitHub Actions schema (correct matrix, permissions, env vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements cross-platform binary releases via GitHub Actions workflow that builds for Linux/macOS on amd64/arm64, plus an install script for one-liner installation.

- Added workflow to build 4 platform binaries and create GitHub releases on version tags
- Install script supports `INSTALL_DIR` override and auto-detects platform
- Simplified README installation instructions

**Issues found:**
- Workflow has race condition where all 4 matrix jobs try to create the release simultaneously
- Install script lacks download validation and uses fragile JSON parsing

<h3>Confidence Score: 3/5</h3>

- Safe to merge with fixes recommended for production reliability
- The workflow race condition won't prevent releases from working due to `|| true` but creates unpredictable behavior. Install script's lack of download validation could silently install corrupt binaries. Both issues should be fixed before widespread use.
- `.github/workflows/release.yml` needs the race condition resolved; `scripts/install.sh` needs download validation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Added release creation step with race condition: all 4 matrix jobs try to create the same release simultaneously |
| scripts/install.sh | Added INSTALL_DIR support and cleaned up structure; uses fragile JSON parsing but functional for basic use cases |
| README.md | Simplified installation instructions by removing redundant comments and consolidating sections |

</details>



<sub>Last reviewed commit: 7e8c07e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->