### PR TITLE
feat: GitHub Releases — cross-platform binaries via CI (#17)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-        run: go build -o maestro-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/maestro/
+          CGO_ENABLED: '0'
+        run: go build -trimpath -o maestro-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/maestro/
 
       - name: Create release if needed
         env:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maestro works with private repos — all GitHub operations go through `gh` CLI. 
 curl -fsSL https://raw.githubusercontent.com/BeFeast/maestro/main/scripts/install.sh | bash
 ```
 
-Or download a binary manually from [Releases](https://github.com/BeFeast/maestro/releases/latest).
+Or download a binary manually from the [latest release](https://github.com/BeFeast/maestro/releases/latest).
 
 ### Build from source
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,21 +1,24 @@
-#!/bin/bash
-# Install the latest maestro binary for your platform.
+#!/usr/bin/env bash
+# Install the latest maestro release binary.
 # Usage: curl -fsSL https://raw.githubusercontent.com/BeFeast/maestro/main/scripts/install.sh | bash
 set -euo pipefail
 
+REPO="BeFeast/maestro"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-BINARY="maestro-${OS}-${ARCH}"
 
-LATEST=$(curl -fsSL https://api.github.com/repos/BeFeast/maestro/releases/latest | grep tag_name | cut -d'"' -f4)
+LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
 if [ -z "$LATEST" ]; then
-  echo "Error: could not determine latest release" >&2
+  echo "error: could not determine latest release" >&2
   exit 1
 fi
 
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+BINARY="maestro-${OS}-${ARCH}"
+URL="https://github.com/${REPO}/releases/download/${LATEST}/${BINARY}"
 
 echo "Downloading ${BINARY} ${LATEST}..."
-curl -fsSL "https://github.com/BeFeast/maestro/releases/download/${LATEST}/${BINARY}" -o "${INSTALL_DIR}/maestro"
+curl -fsSL "${URL}" -o "${INSTALL_DIR}/maestro"
 chmod +x "${INSTALL_DIR}/maestro"
 echo "Maestro ${LATEST} installed to ${INSTALL_DIR}/maestro"


### PR DESCRIPTION
Implements #17

## Changes
- **release.yml**: Improved the release workflow with `CGO_ENABLED=0` for static binaries and `-trimpath` for reproducible builds across all 4 target platforms (linux/darwin × amd64/arm64)
- **scripts/install.sh**: Improved portability (`#!/usr/bin/env bash`), extracted repo into a variable, and tightened the `grep` pattern for tag parsing
- **README.md**: Minor wording fix in the download link text

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean  
- `go test ./...` — all tests pass
- `go build ./cmd/maestro/` — binary builds successfully
- `./maestro version` — prints `maestro v0.1.0`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the release workflow to produce static, reproducible binaries and enhances the install script's portability.

**Key improvements:**
- Added `CGO_ENABLED=0` to produce fully static binaries without CGO dependencies
- Added `-trimpath` flag for reproducible builds across different build environments
- Changed install script shebang to `#!/usr/bin/env bash` for better portability across systems
- Extracted repository name into a `REPO` variable for easier maintenance
- Tightened grep pattern from `tag_name` to `"tag_name"` to avoid false matches
- Minor README wording improvement for clarity

All changes are production-ready and follow Go best practices for cross-platform binary distribution.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues
- All changes follow best practices for Go binary distribution and shell script portability. The additions of `CGO_ENABLED=0` and `-trimpath` are standard flags for producing static, reproducible binaries. The install script improvements enhance portability without changing functionality. Testing confirms all commands pass successfully.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Added `CGO_ENABLED=0` and `-trimpath` flags for static, reproducible builds across all platforms |
| scripts/install.sh | Improved portability with `#!/usr/bin/env bash`, extracted repo variable, and tightened grep pattern for tag parsing |
| README.md | Minor wording improvement: changed "download a binary manually from Releases" to "from the latest release" |

</details>



<sub>Last reviewed commit: 29b19bc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->