### PR TITLE
feat: split release workflow into create + build jobs (#17)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,20 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create ${{ github.ref_name }} --generate-notes
+
+  build:
     name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
     runs-on: ${{ matrix.os }}
+    needs: create-release
     strategy:
       matrix:
         include:
@@ -42,12 +53,7 @@ jobs:
           CGO_ENABLED: '0'
         run: go build -trimpath -o maestro-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/maestro/
 
-      - name: Create release if needed
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${{ github.ref_name }}" --generate-notes || true
-
       - name: Upload binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" maestro-${{ matrix.goos }}-${{ matrix.goarch }} --clobber
+        run: gh release upload ${{ github.ref_name }} maestro-${{ matrix.goos }}-${{ matrix.goarch }} --clobber


### PR DESCRIPTION
Implements #17

## Changes
- Split the release workflow into two jobs: `create-release` (runs first) and `build` (depends on it)
- Eliminates the race condition where multiple matrix build jobs competed to create the GitHub release simultaneously (previously worked around with `|| true`)
- The `create-release` job creates the release once, then all four matrix build jobs (linux/darwin × amd64/arm64) run in parallel and upload their binaries

## Testing
- `go fmt`, `go vet`, `go test`, `go build` all pass
- Workflow YAML validated for correct structure and job dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors the release workflow to eliminate race conditions by splitting into two sequential jobs: `create-release` runs first to create the GitHub release once, then `build` jobs run in parallel to upload binaries.

- removed `|| true` workaround from release creation (previously needed when all matrix jobs competed to create the release)
- added `needs: create-release` dependency to ensure proper job ordering
- consolidated release creation into a single dedicated job

The refactoring achieves the stated goal of eliminating race conditions, but workflow re-runs will now fail since `gh release create` errors when a release already exists (the previous `|| true` pattern handled this gracefully).

<h3>Confidence Score: 3/5</h3>

- This PR successfully eliminates the race condition but introduces a workflow re-run failure scenario
- The refactoring correctly implements job dependencies and eliminates the original race condition, but removes idempotency - workflow re-runs will fail when trying to create an already-existing release
- The `create-release` job in `.github/workflows/release.yml` needs error handling for re-runs

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Splits release workflow into separate create and build jobs to eliminate race conditions, but lacks idempotency for workflow re-runs |

</details>



<sub>Last reviewed commit: 5d758cd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->