### PR TITLE
feat: auto version bump on PR merge based on labels (#14)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/orchestrator"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/versioning"
 	"github.com/befeast/maestro/internal/worker"
 )
 
@@ -26,14 +27,15 @@ Usage:
   maestro <command> [flags]
 
 Commands:
-  init      Interactive setup wizard for new projects
-  run       Run the orchestration loop
-  status    Show current state
-  logs      Show worker logs (tail -f)
-  watch     Open tmux dashboard with all worker logs
-  spawn     Spawn a worker for a specific issue number
-  stop      Stop a worker session
-  version   Print version
+  init          Interactive setup wizard for new projects
+  run           Run the orchestration loop
+  status        Show current state
+  logs          Show worker logs (tail -f)
+  watch         Open tmux dashboard with all worker logs
+  spawn         Spawn a worker for a specific issue number
+  stop          Stop a worker session
+  version-bump  Bump project version based on merged PR labels
+  version       Print version
 
 Global flags:
   --config string       Path to config file (default: maestro.yaml)
@@ -49,6 +51,9 @@ Spawn flags:
 
 Stop flags:
   --session string      Session name to stop (e.g. pan-1)
+
+Version-bump flags:
+  --pr int              PR number to read labels/commits from
 
 Logs:
   maestro logs              List active worker logs + tmux attach hints
@@ -85,6 +90,8 @@ func main() {
 		spawnCmd(args)
 	case "stop":
 		stopCmd(args)
+	case "version-bump":
+		versionBumpCmd(args)
 	case "version":
 		fmt.Println("maestro v0.1.0")
 	case "help", "--help", "-h":
@@ -459,6 +466,27 @@ func stopCmd(args []string) {
 	}
 
 	fmt.Printf("Stopped and removed session %s\n", *sessionName)
+}
+
+func versionBumpCmd(args []string) {
+	fs := flag.NewFlagSet("version-bump", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to config file")
+	prNumber := fs.Int("pr", 0, "PR number to read labels/commits from")
+	fs.Parse(args)
+
+	if *prNumber == 0 {
+		fmt.Fprintln(os.Stderr, "error: --pr is required")
+		os.Exit(1)
+	}
+
+	cfg := loadConfig(*configPath)
+	gh := github.New(cfg.Repo)
+
+	if err := versioning.Run(cfg, gh, *prNumber); err != nil {
+		log.Fatalf("version bump: %v", err)
+	}
+
+	fmt.Println("Version bump complete.")
 }
 
 func truncate(s string, max int) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,20 +28,30 @@ type ModelConfig struct {
 	Backends map[string]BackendDef `yaml:"backends"`
 }
 
+// VersioningConfig controls automatic version bumping on PR merge.
+type VersioningConfig struct {
+	Enabled       bool     `yaml:"enabled"`
+	Files         []string `yaml:"files"`          // Files containing version strings to update
+	DefaultBump   string   `yaml:"default_bump"`   // "patch", "minor", or "major"
+	TagPrefix     string   `yaml:"tag_prefix"`     // e.g. "v"
+	CreateRelease bool     `yaml:"create_release"` // Create GitHub release on bump
+}
+
 type Config struct {
-	Repo          string         `yaml:"repo"`
-	LocalPath     string         `yaml:"local_path"`
-	WorktreeBase  string         `yaml:"worktree_base"`
-	MaxParallel   int            `yaml:"max_parallel"`
-	ClaudeCmd     string         `yaml:"claude_cmd"`  // deprecated: use model.backends.claude.cmd
-	IssueLabel    string         `yaml:"issue_label"` // deprecated: use issue_labels
-	IssueLabels   []string       `yaml:"issue_labels"`
-	ExcludeLabels []string       `yaml:"exclude_labels"`
-	WorkerPrompt  string         `yaml:"worker_prompt"`
-	SessionPrefix string         `yaml:"session_prefix"` // worker session name prefix (default: first 3 chars of repo name)
-	StateDir      string         `yaml:"state_dir"`      // state/log directory (default: ~/.maestro/<repo-hash>)
-	Model         ModelConfig    `yaml:"model"`
-	Telegram      TelegramConfig `yaml:"telegram"`
+	Repo          string           `yaml:"repo"`
+	LocalPath     string           `yaml:"local_path"`
+	WorktreeBase  string           `yaml:"worktree_base"`
+	MaxParallel   int              `yaml:"max_parallel"`
+	ClaudeCmd     string           `yaml:"claude_cmd"`  // deprecated: use model.backends.claude.cmd
+	IssueLabel    string           `yaml:"issue_label"` // deprecated: use issue_labels
+	IssueLabels   []string         `yaml:"issue_labels"`
+	ExcludeLabels []string         `yaml:"exclude_labels"`
+	WorkerPrompt  string           `yaml:"worker_prompt"`
+	SessionPrefix string           `yaml:"session_prefix"` // worker session name prefix (default: first 3 chars of repo name)
+	StateDir      string           `yaml:"state_dir"`      // state/log directory (default: ~/.maestro/<repo-hash>)
+	Model         ModelConfig      `yaml:"model"`
+	Telegram      TelegramConfig   `yaml:"telegram"`
+	Versioning    VersioningConfig `yaml:"versioning"`
 }
 
 // LoadFrom loads config from a specific path.
@@ -151,6 +161,14 @@ func parse(data []byte) (*Config, error) {
 	// Ensure the default backend is always present in the map
 	if _, ok := cfg.Model.Backends[cfg.Model.Default]; !ok {
 		cfg.Model.Backends[cfg.Model.Default] = BackendDef{Cmd: cfg.Model.Default}
+	}
+
+	// Versioning defaults
+	if cfg.Versioning.DefaultBump == "" {
+		cfg.Versioning.DefaultBump = "patch"
+	}
+	if cfg.Versioning.TagPrefix == "" {
+		cfg.Versioning.TagPrefix = "v"
 	}
 
 	return cfg, nil

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -202,6 +202,67 @@ func (c *Client) CloseIssue(number int, comment string) error {
 	return nil
 }
 
+// PRLabels returns the labels on a PR.
+func (c *Client) PRLabels(prNumber int) ([]string, error) {
+	out, err := exec.Command("gh", "pr", "view",
+		fmt.Sprint(prNumber),
+		"--repo", c.Repo,
+		"--json", "labels").Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh pr view %d labels: %w", prNumber, err)
+	}
+	var result struct {
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, err
+	}
+	names := make([]string, len(result.Labels))
+	for i, l := range result.Labels {
+		names[i] = l.Name
+	}
+	return names, nil
+}
+
+// PRCommits returns commit messages for a PR.
+func (c *Client) PRCommits(prNumber int) ([]string, error) {
+	out, err := exec.Command("gh", "pr", "view",
+		fmt.Sprint(prNumber),
+		"--repo", c.Repo,
+		"--json", "commits").Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh pr view %d commits: %w", prNumber, err)
+	}
+	var result struct {
+		Commits []struct {
+			MessageHeadline string `json:"messageHeadline"`
+		} `json:"commits"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, err
+	}
+	msgs := make([]string, len(result.Commits))
+	for i, c := range result.Commits {
+		msgs[i] = c.MessageHeadline
+	}
+	return msgs, nil
+}
+
+// CreateRelease creates a GitHub release for the given tag.
+func (c *Client) CreateRelease(tag, title string) error {
+	out, err := exec.Command("gh", "release", "create",
+		tag,
+		"--repo", c.Repo,
+		"--title", title,
+		"--generate-notes").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh release create %s: %w\n%s", tag, err, out)
+	}
+	return nil
+}
+
 // HasLabel returns true if any of the issue's labels match
 func HasLabel(issue Issue, labels []string) bool {
 	for _, l := range issue.Labels {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/versioning"
 	"github.com/befeast/maestro/internal/worker"
 )
 
@@ -250,6 +251,16 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				sess.FinishedAt = &now
 				worker.Stop(o.cfg, slotName, sess)
 				o.notifier.Sendf("✅ maestro: merged PR #%d for issue #%d (%s)", pr.Number, sess.IssueNumber, sess.IssueTitle)
+
+				// Auto version bump
+				if o.cfg.Versioning.Enabled {
+					if err := versioning.Run(o.cfg, o.gh, pr.Number); err != nil {
+						log.Printf("[orch] version bump for PR #%d: %v", pr.Number, err)
+						o.notifier.Sendf("⚠️ maestro: version bump failed for PR #%d: %v", pr.Number, err)
+					} else {
+						o.notifier.Sendf("🏷️ maestro: version bumped after PR #%d merge", pr.Number)
+					}
+				}
 			}
 		case "failure":
 			o.notifier.Sendf("❌ maestro: CI failing for PR #%d (%s, issue #%d)", pr.Number, sess.Branch, sess.IssueNumber)

--- a/internal/versioning/versioning.go
+++ b/internal/versioning/versioning.go
@@ -1,0 +1,322 @@
+package versioning
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+// BumpType represents a semver bump level.
+type BumpType int
+
+const (
+	BumpPatch BumpType = iota
+	BumpMinor
+	BumpMajor
+)
+
+func (b BumpType) String() string {
+	switch b {
+	case BumpMajor:
+		return "major"
+	case BumpMinor:
+		return "minor"
+	default:
+		return "patch"
+	}
+}
+
+// ParseBumpType converts a string to a BumpType.
+func ParseBumpType(s string) BumpType {
+	switch strings.ToLower(s) {
+	case "major":
+		return BumpMajor
+	case "minor":
+		return BumpMinor
+	default:
+		return BumpPatch
+	}
+}
+
+// Version represents a semver version.
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// ParseVersion parses a "X.Y.Z" version string.
+func ParseVersion(s string) (Version, error) {
+	s = strings.TrimPrefix(s, "v")
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return Version{}, fmt.Errorf("invalid version %q: expected X.Y.Z", s)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid major version %q: %w", parts[0], err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid minor version %q: %w", parts[1], err)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid patch version %q: %w", parts[2], err)
+	}
+	return Version{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+// Bump returns a new version bumped by the given type.
+func Bump(v Version, bt BumpType) Version {
+	switch bt {
+	case BumpMajor:
+		return Version{Major: v.Major + 1}
+	case BumpMinor:
+		return Version{Major: v.Major, Minor: v.Minor + 1}
+	default:
+		return Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch + 1}
+	}
+}
+
+// DetectBumpFromLabels reads version labels from a label list.
+// Labels: version:patch, version:minor, version:major.
+// Returns the highest bump found, or the default.
+func DetectBumpFromLabels(labels []string, defaultBump string) (BumpType, bool) {
+	highest := BumpType(-1)
+	for _, label := range labels {
+		switch strings.ToLower(label) {
+		case "version:major":
+			if BumpMajor > highest {
+				highest = BumpMajor
+			}
+		case "version:minor":
+			if BumpMinor > highest {
+				highest = BumpMinor
+			}
+		case "version:patch":
+			if BumpPatch > highest {
+				highest = BumpPatch
+			}
+		}
+	}
+	if highest >= 0 {
+		return highest, true
+	}
+	return ParseBumpType(defaultBump), false
+}
+
+// DetectBumpFromCommits parses conventional commit prefixes.
+// feat!: or BREAKING CHANGE → major, feat: → minor, fix: → patch.
+func DetectBumpFromCommits(messages []string, defaultBump string) BumpType {
+	highest := BumpType(-1)
+	for _, msg := range messages {
+		lower := strings.ToLower(msg)
+		switch {
+		case strings.Contains(lower, "!:") || strings.Contains(lower, "breaking change"):
+			if BumpMajor > highest {
+				highest = BumpMajor
+			}
+		case strings.HasPrefix(lower, "feat"):
+			if BumpMinor > highest {
+				highest = BumpMinor
+			}
+		case strings.HasPrefix(lower, "fix"):
+			if BumpPatch > highest {
+				highest = BumpPatch
+			}
+		}
+	}
+	if highest >= 0 {
+		return highest
+	}
+	return ParseBumpType(defaultBump)
+}
+
+// versionPatterns are regex patterns to find version strings in different file types.
+var versionPatterns = []*regexp.Regexp{
+	// Cargo.toml: version = "X.Y.Z"
+	regexp.MustCompile(`(?m)^(\s*version\s*=\s*")(\d+\.\d+\.\d+)(")`),
+	// package.json: "version": "X.Y.Z"
+	regexp.MustCompile(`(?m)("version"\s*:\s*")(\d+\.\d+\.\d+)(")`),
+}
+
+// ReadVersionFromFile reads the first semver version found in a file.
+func ReadVersionFromFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	for _, pat := range versionPatterns {
+		if m := pat.FindSubmatch(data); m != nil {
+			return string(m[2]), nil
+		}
+	}
+	return "", fmt.Errorf("no version found in %s", path)
+}
+
+// ReadCurrentVersion reads the version from the first configured file that has one.
+func ReadCurrentVersion(files []string) (string, error) {
+	for _, f := range files {
+		v, err := ReadVersionFromFile(f)
+		if err == nil {
+			return v, nil
+		}
+	}
+	return "", fmt.Errorf("no version found in any configured file")
+}
+
+// UpdateVersionInFile replaces oldVer with newVer in the file.
+func UpdateVersionInFile(path, oldVer, newVer string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	content := string(data)
+	updated := strings.ReplaceAll(content, oldVer, newVer)
+	if updated == content {
+		return fmt.Errorf("version %s not found in %s", oldVer, path)
+	}
+	if err := os.WriteFile(path, []byte(updated), 0644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// CommitAndTag creates a version bump commit and tag in the given repo.
+func CommitAndTag(repoPath, version, tagPrefix string) error {
+	tag := tagPrefix + version
+	commitMsg := fmt.Sprintf("chore: bump version to %s", version)
+
+	// Stage all changes
+	if out, err := runGit(repoPath, "add", "-A"); err != nil {
+		return fmt.Errorf("git add: %w\n%s", err, out)
+	}
+
+	// Commit
+	if out, err := runGit(repoPath, "commit", "-m", commitMsg); err != nil {
+		return fmt.Errorf("git commit: %w\n%s", err, out)
+	}
+
+	// Tag
+	if out, err := runGit(repoPath, "tag", "-a", tag, "-m", tag); err != nil {
+		return fmt.Errorf("git tag: %w\n%s", err, out)
+	}
+
+	// Push commit and tag
+	if out, err := runGit(repoPath, "push", "origin", "main", "--follow-tags"); err != nil {
+		return fmt.Errorf("git push: %w\n%s", err, out)
+	}
+
+	return nil
+}
+
+func runGit(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// Run executes the full version bump flow for a merged PR.
+func Run(cfg *config.Config, gh *github.Client, prNumber int) error {
+	if !cfg.Versioning.Enabled {
+		log.Printf("[versioning] disabled, skipping")
+		return nil
+	}
+
+	if len(cfg.Versioning.Files) == 0 {
+		return fmt.Errorf("versioning enabled but no files configured")
+	}
+
+	// Resolve file paths relative to repo local path
+	files := make([]string, len(cfg.Versioning.Files))
+	for i, f := range cfg.Versioning.Files {
+		if strings.HasPrefix(f, "/") {
+			files[i] = f
+		} else {
+			files[i] = cfg.LocalPath + "/" + f
+		}
+	}
+
+	// Read current version
+	currentStr, err := ReadCurrentVersion(files)
+	if err != nil {
+		return fmt.Errorf("read current version: %w", err)
+	}
+	current, err := ParseVersion(currentStr)
+	if err != nil {
+		return fmt.Errorf("parse current version: %w", err)
+	}
+	log.Printf("[versioning] current version: %s", current)
+
+	// Detect bump type from PR labels
+	labels, err := gh.PRLabels(prNumber)
+	if err != nil {
+		return fmt.Errorf("get PR labels: %w", err)
+	}
+
+	bumpType, fromLabel := DetectBumpFromLabels(labels, cfg.Versioning.DefaultBump)
+
+	// Fallback to conventional commits if no version label found
+	if !fromLabel {
+		commits, err := gh.PRCommits(prNumber)
+		if err != nil {
+			log.Printf("[versioning] warn: could not read PR commits: %v, using default bump", err)
+		} else {
+			bumpType = DetectBumpFromCommits(commits, cfg.Versioning.DefaultBump)
+			log.Printf("[versioning] no version label, detected %s from commits", bumpType)
+		}
+	} else {
+		log.Printf("[versioning] detected %s from PR labels", bumpType)
+	}
+
+	// Bump version
+	newVer := Bump(current, bumpType)
+	log.Printf("[versioning] bumping %s → %s (%s)", current, newVer, bumpType)
+
+	// Pull latest main before modifying
+	if out, err := runGit(cfg.LocalPath, "checkout", "main"); err != nil {
+		return fmt.Errorf("git checkout main: %w\n%s", err, out)
+	}
+	if out, err := runGit(cfg.LocalPath, "pull", "origin", "main"); err != nil {
+		return fmt.Errorf("git pull: %w\n%s", err, out)
+	}
+
+	// Update version in all configured files
+	for _, f := range files {
+		if err := UpdateVersionInFile(f, currentStr, newVer.String()); err != nil {
+			log.Printf("[versioning] warn: %v", err)
+			continue
+		}
+		log.Printf("[versioning] updated %s", f)
+	}
+
+	// Commit, tag, push
+	if err := CommitAndTag(cfg.LocalPath, newVer.String(), cfg.Versioning.TagPrefix); err != nil {
+		return fmt.Errorf("commit and tag: %w", err)
+	}
+	log.Printf("[versioning] committed and tagged %s%s", cfg.Versioning.TagPrefix, newVer)
+
+	// Optionally create GitHub release
+	if cfg.Versioning.CreateRelease {
+		tag := cfg.Versioning.TagPrefix + newVer.String()
+		if err := gh.CreateRelease(tag, tag); err != nil {
+			return fmt.Errorf("create release: %w", err)
+		}
+		log.Printf("[versioning] created release %s", tag)
+	}
+
+	return nil
+}

--- a/internal/versioning/versioning_test.go
+++ b/internal/versioning/versioning_test.go
@@ -1,0 +1,224 @@
+package versioning
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    Version
+		wantErr bool
+	}{
+		{"0.5.0", Version{0, 5, 0}, false},
+		{"1.2.3", Version{1, 2, 3}, false},
+		{"v1.0.0", Version{1, 0, 0}, false},
+		{"10.20.30", Version{10, 20, 30}, false},
+		{"", Version{}, true},
+		{"1.2", Version{}, true},
+		{"abc", Version{}, true},
+		{"1.2.x", Version{}, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseVersion(tt.input)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("ParseVersion(%q) expected error", tt.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseVersion(%q) unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseVersion(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	v := Version{1, 2, 3}
+	if s := v.String(); s != "1.2.3" {
+		t.Errorf("Version.String() = %q, want %q", s, "1.2.3")
+	}
+}
+
+func TestBump(t *testing.T) {
+	tests := []struct {
+		input Version
+		bump  BumpType
+		want  Version
+	}{
+		{Version{0, 5, 0}, BumpPatch, Version{0, 5, 1}},
+		{Version{0, 5, 0}, BumpMinor, Version{0, 6, 0}},
+		{Version{0, 5, 0}, BumpMajor, Version{1, 0, 0}},
+		{Version{1, 2, 3}, BumpPatch, Version{1, 2, 4}},
+		{Version{1, 2, 3}, BumpMinor, Version{1, 3, 0}},
+		{Version{1, 2, 3}, BumpMajor, Version{2, 0, 0}},
+	}
+	for _, tt := range tests {
+		got := Bump(tt.input, tt.bump)
+		if got != tt.want {
+			t.Errorf("Bump(%v, %v) = %v, want %v", tt.input, tt.bump, got, tt.want)
+		}
+	}
+}
+
+func TestDetectBumpFromLabels(t *testing.T) {
+	tests := []struct {
+		labels      []string
+		defaultBump string
+		wantBump    BumpType
+		wantFound   bool
+	}{
+		{[]string{"version:patch"}, "patch", BumpPatch, true},
+		{[]string{"version:minor"}, "patch", BumpMinor, true},
+		{[]string{"version:major"}, "patch", BumpMajor, true},
+		{[]string{"version:patch", "version:major"}, "patch", BumpMajor, true},
+		{[]string{"bug", "enhancement"}, "patch", BumpPatch, false},
+		{[]string{}, "minor", BumpMinor, false},
+		{[]string{"Version:Minor"}, "patch", BumpMinor, true}, // case insensitive
+	}
+	for _, tt := range tests {
+		bump, found := DetectBumpFromLabels(tt.labels, tt.defaultBump)
+		if bump != tt.wantBump || found != tt.wantFound {
+			t.Errorf("DetectBumpFromLabels(%v, %q) = (%v, %v), want (%v, %v)",
+				tt.labels, tt.defaultBump, bump, found, tt.wantBump, tt.wantFound)
+		}
+	}
+}
+
+func TestDetectBumpFromCommits(t *testing.T) {
+	tests := []struct {
+		messages    []string
+		defaultBump string
+		want        BumpType
+	}{
+		{[]string{"fix: typo"}, "patch", BumpPatch},
+		{[]string{"feat: new api"}, "patch", BumpMinor},
+		{[]string{"feat!: breaking change"}, "patch", BumpMajor},
+		{[]string{"fix: a", "feat: b"}, "patch", BumpMinor},
+		{[]string{"fix: a", "feat!: b"}, "patch", BumpMajor},
+		{[]string{"chore: update deps"}, "patch", BumpPatch},
+		{[]string{"chore: update deps"}, "minor", BumpMinor},
+		{[]string{}, "patch", BumpPatch},
+	}
+	for _, tt := range tests {
+		got := DetectBumpFromCommits(tt.messages, tt.defaultBump)
+		if got != tt.want {
+			t.Errorf("DetectBumpFromCommits(%v, %q) = %v, want %v",
+				tt.messages, tt.defaultBump, got, tt.want)
+		}
+	}
+}
+
+func TestParseBumpType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  BumpType
+	}{
+		{"patch", BumpPatch},
+		{"minor", BumpMinor},
+		{"major", BumpMajor},
+		{"MAJOR", BumpMajor},
+		{"Minor", BumpMinor},
+		{"unknown", BumpPatch},
+		{"", BumpPatch},
+	}
+	for _, tt := range tests {
+		if got := ParseBumpType(tt.input); got != tt.want {
+			t.Errorf("ParseBumpType(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestReadVersionFromFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Cargo.toml style
+	cargoPath := filepath.Join(dir, "Cargo.toml")
+	os.WriteFile(cargoPath, []byte(`[package]
+name = "myapp"
+version = "1.2.3"
+`), 0644)
+	v, err := ReadVersionFromFile(cargoPath)
+	if err != nil {
+		t.Fatalf("ReadVersionFromFile(Cargo.toml): %v", err)
+	}
+	if v != "1.2.3" {
+		t.Errorf("got %q, want %q", v, "1.2.3")
+	}
+
+	// package.json style
+	pkgPath := filepath.Join(dir, "package.json")
+	os.WriteFile(pkgPath, []byte(`{
+  "name": "myapp",
+  "version": "2.0.1"
+}
+`), 0644)
+	v, err = ReadVersionFromFile(pkgPath)
+	if err != nil {
+		t.Fatalf("ReadVersionFromFile(package.json): %v", err)
+	}
+	if v != "2.0.1" {
+		t.Errorf("got %q, want %q", v, "2.0.1")
+	}
+
+	// No version
+	noVerPath := filepath.Join(dir, "empty.txt")
+	os.WriteFile(noVerPath, []byte("no version here\n"), 0644)
+	_, err = ReadVersionFromFile(noVerPath)
+	if err == nil {
+		t.Error("expected error for file with no version")
+	}
+}
+
+func TestUpdateVersionInFile(t *testing.T) {
+	dir := t.TempDir()
+
+	content := `[package]
+name = "myapp"
+version = "0.5.0"
+edition = "2021"
+`
+	path := filepath.Join(dir, "Cargo.toml")
+	os.WriteFile(path, []byte(content), 0644)
+
+	if err := UpdateVersionInFile(path, "0.5.0", "0.6.0"); err != nil {
+		t.Fatalf("UpdateVersionInFile: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	got := string(data)
+	if expected := `[package]
+name = "myapp"
+version = "0.6.0"
+edition = "2021"
+`; got != expected {
+		t.Errorf("file content mismatch:\ngot:  %q\nwant: %q", got, expected)
+	}
+
+	// Trying to update a version that doesn't exist
+	if err := UpdateVersionInFile(path, "9.9.9", "10.0.0"); err == nil {
+		t.Error("expected error for non-existent version")
+	}
+}
+
+func TestBumpTypeString(t *testing.T) {
+	tests := []struct {
+		bt   BumpType
+		want string
+	}{
+		{BumpPatch, "patch"},
+		{BumpMinor, "minor"},
+		{BumpMajor, "major"},
+	}
+	for _, tt := range tests {
+		if got := tt.bt.String(); got != tt.want {
+			t.Errorf("BumpType(%d).String() = %q, want %q", tt.bt, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Implements #14

## Changes
- **New `internal/versioning/` package** — core version bump logic:
  - Parses semver from configured files (Cargo.toml, package.json, etc.)
  - Detects bump type from PR labels (`version:patch`, `version:minor`, `version:major`)
  - Falls back to conventional commit parsing (`fix:` → patch, `feat:` → minor, `feat!:` → major)
  - Updates version strings in all configured files
  - Commits `chore: bump version to X.Y.Z`, tags `vX.Y.Z`, pushes
  - Optionally creates GitHub Release via `gh release create`
- **`VersioningConfig` in config** — new `versioning:` YAML section with `enabled`, `files`, `default_bump`, `tag_prefix`, `create_release`
- **GitHub client extensions** — `PRLabels()`, `PRCommits()`, `CreateRelease()` methods
- **`version-bump` CLI subcommand** — manual trigger: `maestro version-bump --pr 42`
- **Orchestrator integration** — auto-bumps version after each successful PR merge when `versioning.enabled: true`

## Config example
```yaml
versioning:
  enabled: true
  files:
    - Cargo.toml
    - web/package.json
  default_bump: patch
  tag_prefix: "v"
  create_release: true
```

## Testing
- 9 unit tests covering version parsing, bumping, label detection, conventional commit parsing, file read/update
- All existing tests pass (`go test ./...`)
- `go vet ./...` clean
- Binary builds and runs successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements automatic version bumping on PR merge based on labels (`version:patch/minor/major`) with conventional commit fallback. Adds new `internal/versioning/` package with semver parsing, bump logic, and git operations.

**Key changes:**
- New versioning package with PR label detection and conventional commit parsing
- Config support via `versioning:` YAML section with file paths, default bump type, and release creation
- GitHub client methods for reading PR labels/commits and creating releases
- Orchestrator auto-triggers version bump after successful PR merge
- CLI `version-bump` subcommand for manual triggering

**Critical issues found:**
- `Bump()` function violates semver spec — major/minor bumps don't reset lower version segments (e.g., `1.2.3` → major bump → `2.2.3` instead of `2.0.0`)
- Hardcoded `main` branch name in git operations won't work for repos using `master` or other default branches
- `UpdateVersionInFile()` uses `strings.ReplaceAll` which could replace version numbers in comments/strings unintentionally
- Missing validation to prevent empty commits when all file updates fail

**Non-critical concerns:**
- Test coverage doesn't verify semver reset behavior

<h3>Confidence Score: 2/5</h3>

- This PR has critical semver compliance bugs that will produce incorrect version numbers
- The `Bump()` function doesn't follow semver specification (major/minor bumps should reset lower segments to 0). Combined with hardcoded branch names and potential for unintended string replacements, this needs fixes before merge.
- Pay close attention to `internal/versioning/versioning.go` — contains the core semver bug and hardcoded branch assumptions

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/versioning/versioning.go | New versioning package with semver bump logic and git operations. Critical bug in `Bump()` function that doesn't reset minor/patch on major/minor bumps. Hardcoded `main` branch and `strings.ReplaceAll` issues. |
| internal/versioning/versioning_test.go | Comprehensive test coverage for versioning logic. Tests miss the semver reset bug in `Bump()` function. |
| internal/config/config.go | Added `VersioningConfig` struct with sensible defaults. Clean integration into existing config structure. |
| internal/github/github.go | Added `PRLabels()`, `PRCommits()`, and `CreateRelease()` methods using `gh` CLI. Proper error handling and JSON parsing. |
| internal/orchestrator/orchestrator.go | Integrated version bumping after PR merge with proper error handling and notifications. Non-blocking on failure. |
| cmd/maestro/main.go | Added `version-bump` CLI subcommand with proper flag parsing and error handling. |

</details>



<sub>Last reviewed commit: 2a749be</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->