### PR TITLE
feat: LLM router — auto-select backend model based on issue content (#13)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/orchestrator"
+	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/versioning"
 	"github.com/befeast/maestro/internal/worker"
@@ -411,14 +412,32 @@ func spawnCmd(args []string) {
 		log.Fatalf("issue #%d not found in open issues", *issueNum)
 	}
 
-	// Use default backend for manual starts (can be overridden via model: label)
-	backendName := cfg.Model.Default
+	// Detect model: label for backend selection (label takes precedence)
+	backendName := ""
 	for _, label := range targetIssue.Labels {
 		if strings.HasPrefix(label.Name, "model:") {
 			if name := strings.TrimPrefix(label.Name, "model:"); name != "" {
 				backendName = name
+				log.Printf("[router] issue #%d → %s (label override)", targetIssue.Number, backendName)
 			}
 		}
+	}
+
+	// If no label, try auto-routing via LLM
+	if backendName == "" && cfg.Routing.Mode == "auto" {
+		r := router.New(cfg)
+		routedBackend, reason, err := r.Route(*targetIssue)
+		if err != nil {
+			log.Printf("[router] issue #%d: error %v — using default", targetIssue.Number, err)
+		} else {
+			log.Printf("[router] issue #%d → %s (%s)", targetIssue.Number, routedBackend, reason)
+		}
+		backendName = routedBackend
+	}
+
+	// Fall back to default
+	if backendName == "" {
+		backendName = cfg.Model.Default
 	}
 	slotName, err := worker.Start(cfg, s, cfg.Repo, *targetIssue, promptBase, backendName)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,14 @@ type VersioningConfig struct {
 	CreateRelease bool     `yaml:"create_release"` // Create GitHub release on bump
 }
 
+// RoutingConfig controls automatic backend selection via LLM router.
+type RoutingConfig struct {
+	Mode            string `yaml:"mode"`              // "auto", "manual" (labels only)
+	RouterModel     string `yaml:"router_model"`      // backend name from model.backends (default: "claude")
+	RouterModelName string `yaml:"router_model_name"` // specific model to use (default: "claude-sonnet-4-6")
+	RouterPrompt    string `yaml:"router_prompt"`     // prompt template with {{BACKENDS}}, {{NUMBER}}, {{TITLE}}, {{BODY}}
+}
+
 type Config struct {
 	Repo          string           `yaml:"repo"`
 	LocalPath     string           `yaml:"local_path"`
@@ -50,6 +58,7 @@ type Config struct {
 	SessionPrefix string           `yaml:"session_prefix"` // worker session name prefix (default: first 3 chars of repo name)
 	StateDir      string           `yaml:"state_dir"`      // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model         ModelConfig      `yaml:"model"`
+	Routing       RoutingConfig    `yaml:"routing"`
 	Telegram      TelegramConfig   `yaml:"telegram"`
 	Versioning    VersioningConfig `yaml:"versioning"`
 }
@@ -161,6 +170,17 @@ func parse(data []byte) (*Config, error) {
 	// Ensure the default backend is always present in the map
 	if _, ok := cfg.Model.Backends[cfg.Model.Default]; !ok {
 		cfg.Model.Backends[cfg.Model.Default] = BackendDef{Cmd: cfg.Model.Default}
+	}
+
+	// Routing defaults
+	if cfg.Routing.Mode == "" {
+		cfg.Routing.Mode = "manual"
+	}
+	if cfg.Routing.RouterModel == "" {
+		cfg.Routing.RouterModel = "claude"
+	}
+	if cfg.Routing.RouterModelName == "" {
+		cfg.Routing.RouterModelName = "claude-sonnet-4-6"
 	}
 
 	// Versioning defaults

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -203,3 +203,44 @@ func TestParse_DifferentReposDifferentStateDirs(t *testing.T) {
 		t.Errorf("different repos should have different default state_dirs, both got %q", cfg1.StateDir)
 	}
 }
+
+func TestParse_RoutingDefaults(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Routing.Mode != "manual" {
+		t.Errorf("Routing.Mode = %q, want %q", cfg.Routing.Mode, "manual")
+	}
+	if cfg.Routing.RouterModel != "claude" {
+		t.Errorf("Routing.RouterModel = %q, want %q", cfg.Routing.RouterModel, "claude")
+	}
+	if cfg.Routing.RouterModelName != "claude-sonnet-4-6" {
+		t.Errorf("Routing.RouterModelName = %q, want %q", cfg.Routing.RouterModelName, "claude-sonnet-4-6")
+	}
+}
+
+func TestParse_RoutingExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+routing:
+  mode: auto
+  router_model: claude
+  router_model_name: claude-haiku-4-5-20251001
+  router_prompt: "Pick: {{BACKENDS}} for #{{NUMBER}}"
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Routing.Mode != "auto" {
+		t.Errorf("Routing.Mode = %q, want %q", cfg.Routing.Mode, "auto")
+	}
+	if cfg.Routing.RouterModelName != "claude-haiku-4-5-20251001" {
+		t.Errorf("Routing.RouterModelName = %q, want %q", cfg.Routing.RouterModelName, "claude-haiku-4-5-20251001")
+	}
+	if cfg.Routing.RouterPrompt != "Pick: {{BACKENDS}} for #{{NUMBER}}" {
+		t.Errorf("Routing.RouterPrompt = %q", cfg.Routing.RouterPrompt)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/versioning"
 	"github.com/befeast/maestro/internal/worker"
@@ -20,6 +21,7 @@ type Orchestrator struct {
 	cfg        *config.Config
 	notifier   *notify.Notifier
 	gh         *github.Client
+	router     *router.Router
 	repo       string
 	promptBase string
 }
@@ -30,6 +32,7 @@ func New(cfg *config.Config) *Orchestrator {
 		cfg:      cfg,
 		notifier: notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.OpenclawURL),
 		gh:       github.New(cfg.Repo),
+		router:   router.New(cfg),
 		repo:     cfg.Repo,
 	}
 }
@@ -336,14 +339,31 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			continue
 		}
 
-		// Detect model: label for backend selection
-		backendName := o.cfg.Model.Default
+		// Detect model: label for backend selection (label takes precedence)
+		backendName := ""
 		for _, label := range issue.Labels {
 			if strings.HasPrefix(label.Name, "model:") {
 				if name := strings.TrimPrefix(label.Name, "model:"); name != "" {
 					backendName = name
+					log.Printf("[router] issue #%d → %s (label override)", issue.Number, backendName)
 				}
 			}
+		}
+
+		// If no label, try auto-routing via LLM
+		if backendName == "" && o.cfg.Routing.Mode == "auto" {
+			routedBackend, reason, err := o.router.Route(issue)
+			if err != nil {
+				log.Printf("[router] issue #%d: error %v — using default", issue.Number, err)
+			} else {
+				log.Printf("[router] issue #%d → %s (%s)", issue.Number, routedBackend, reason)
+			}
+			backendName = routedBackend
+		}
+
+		// Fall back to default
+		if backendName == "" {
+			backendName = o.cfg.Model.Default
 		}
 
 		log.Printf("[orch] starting worker for issue #%d: %s (backend=%s)", issue.Number, issue.Title, backendName)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,0 +1,142 @@
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+const defaultRouterPrompt = `Given this GitHub issue, choose the best AI coding backend.
+Available backends: {{BACKENDS}}
+
+Issue: #{{NUMBER}} — {{TITLE}}
+{{BODY}}
+
+Return JSON only: {"backend": "<name>", "reason": "<one sentence>"}`
+
+// routerResponse is the expected JSON response from the router model.
+type routerResponse struct {
+	Backend string `json:"backend"`
+	Reason  string `json:"reason"`
+}
+
+// Router selects the best backend for a given issue using an LLM call.
+type Router struct {
+	cfg *config.Config
+}
+
+// New creates a new Router.
+func New(cfg *config.Config) *Router {
+	return &Router{cfg: cfg}
+}
+
+// Route calls the router model to decide which backend to use for the issue.
+// Returns the backend name and a short reason for the decision.
+// On any error or unknown backend, falls back to config's default backend.
+func (r *Router) Route(issue github.Issue) (backendName string, reason string, err error) {
+	prompt := r.buildPrompt(issue)
+
+	output, err := r.callModel(prompt)
+	if err != nil {
+		log.Printf("[router] model call failed: %v — falling back to default", err)
+		return r.cfg.Model.Default, "router error", err
+	}
+
+	resp, err := parseResponse(output)
+	if err != nil {
+		log.Printf("[router] parse response failed: %v — falling back to default", err)
+		return r.cfg.Model.Default, "parse error", err
+	}
+
+	// Validate that the chosen backend exists in config
+	if _, ok := r.cfg.Model.Backends[resp.Backend]; !ok {
+		log.Printf("[router] unknown backend %q — falling back to default", resp.Backend)
+		return r.cfg.Model.Default, fmt.Sprintf("unknown backend %q", resp.Backend), nil
+	}
+
+	return resp.Backend, resp.Reason, nil
+}
+
+// buildPrompt constructs the router prompt from the template and issue data.
+func (r *Router) buildPrompt(issue github.Issue) string {
+	tmpl := r.cfg.Routing.RouterPrompt
+	if tmpl == "" {
+		tmpl = defaultRouterPrompt
+	}
+
+	// Build backends list
+	backends := make([]string, 0, len(r.cfg.Model.Backends))
+	for name := range r.cfg.Model.Backends {
+		backends = append(backends, name)
+	}
+
+	prompt := tmpl
+	prompt = strings.ReplaceAll(prompt, "{{BACKENDS}}", strings.Join(backends, ", "))
+	prompt = strings.ReplaceAll(prompt, "{{NUMBER}}", fmt.Sprint(issue.Number))
+	prompt = strings.ReplaceAll(prompt, "{{TITLE}}", issue.Title)
+	prompt = strings.ReplaceAll(prompt, "{{BODY}}", issue.Body)
+
+	return prompt
+}
+
+// callModel executes the router model CLI and returns the raw output.
+func (r *Router) callModel(prompt string) (string, error) {
+	backendName := r.cfg.Routing.RouterModel
+	backend, ok := r.cfg.Model.Backends[backendName]
+	if !ok {
+		return "", fmt.Errorf("router backend %q not found in model.backends", backendName)
+	}
+
+	cmdPath := backend.Cmd
+	if cmdPath == "" {
+		cmdPath = backendName
+	}
+
+	args := []string{"-p", prompt}
+	if r.cfg.Routing.RouterModelName != "" {
+		args = append(args, "--model", r.cfg.Routing.RouterModelName)
+	}
+
+	log.Printf("[router] calling %s --model %s", cmdPath, r.cfg.Routing.RouterModelName)
+	out, err := exec.Command(cmdPath, args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("exec %s: %w", cmdPath, err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+// parseResponse extracts a JSON object from the model output.
+// The model may include extra text around the JSON, so we find and extract it.
+func parseResponse(output string) (routerResponse, error) {
+	var resp routerResponse
+
+	// Try direct unmarshal first
+	if err := json.Unmarshal([]byte(output), &resp); err == nil && resp.Backend != "" {
+		return resp, nil
+	}
+
+	// Try to extract JSON from the output (model may include surrounding text)
+	start := strings.Index(output, "{")
+	end := strings.LastIndex(output, "}")
+	if start >= 0 && end > start {
+		jsonStr := output[start : end+1]
+		if err := json.Unmarshal([]byte(jsonStr), &resp); err == nil && resp.Backend != "" {
+			return resp, nil
+		}
+	}
+
+	return resp, fmt.Errorf("no valid JSON with backend field in output: %s", truncate(output, 200))
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-3] + "..."
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,167 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+func TestParseResponse_ValidJSON(t *testing.T) {
+	resp, err := parseResponse(`{"backend": "codex", "reason": "simple bug fix"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Backend != "codex" {
+		t.Errorf("backend = %q, want %q", resp.Backend, "codex")
+	}
+	if resp.Reason != "simple bug fix" {
+		t.Errorf("reason = %q, want %q", resp.Reason, "simple bug fix")
+	}
+}
+
+func TestParseResponse_JSONWithSurroundingText(t *testing.T) {
+	input := `Here is my analysis:
+{"backend": "claude", "reason": "multi-file refactor"}
+That's my recommendation.`
+	resp, err := parseResponse(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Backend != "claude" {
+		t.Errorf("backend = %q, want %q", resp.Backend, "claude")
+	}
+}
+
+func TestParseResponse_InvalidJSON(t *testing.T) {
+	_, err := parseResponse("I think codex would be best")
+	if err == nil {
+		t.Error("expected error for non-JSON output")
+	}
+}
+
+func TestParseResponse_EmptyBackend(t *testing.T) {
+	_, err := parseResponse(`{"backend": "", "reason": "no idea"}`)
+	if err == nil {
+		t.Error("expected error for empty backend field")
+	}
+}
+
+func TestBuildPrompt_DefaultTemplate(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+		Routing: config.RoutingConfig{
+			Mode:        "auto",
+			RouterModel: "claude",
+		},
+	}
+	r := New(cfg)
+	issue := github.Issue{
+		Number: 42,
+		Title:  "Fix SQL injection",
+		Body:   "The login form is vulnerable.",
+	}
+
+	prompt := r.buildPrompt(issue)
+
+	if !contains(prompt, "#42") {
+		t.Error("prompt should contain issue number")
+	}
+	if !contains(prompt, "Fix SQL injection") {
+		t.Error("prompt should contain issue title")
+	}
+	if !contains(prompt, "The login form is vulnerable.") {
+		t.Error("prompt should contain issue body")
+	}
+	// Should contain both backend names (order may vary)
+	if !contains(prompt, "claude") || !contains(prompt, "codex") {
+		t.Error("prompt should contain backend names")
+	}
+}
+
+func TestBuildPrompt_CustomTemplate(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+			},
+		},
+		Routing: config.RoutingConfig{
+			Mode:         "auto",
+			RouterModel:  "claude",
+			RouterPrompt: "Pick backend for #{{NUMBER}}: {{TITLE}}. Options: {{BACKENDS}}",
+		},
+	}
+	r := New(cfg)
+	issue := github.Issue{Number: 10, Title: "Add tests"}
+
+	prompt := r.buildPrompt(issue)
+
+	expected := "Pick backend for #10: Add tests. Options: claude"
+	if prompt != expected {
+		t.Errorf("prompt = %q, want %q", prompt, expected)
+	}
+}
+
+func TestRoute_UnknownBackendFallsBack(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+			},
+		},
+		Routing: config.RoutingConfig{
+			Mode:        "auto",
+			RouterModel: "claude",
+		},
+	}
+	r := New(cfg)
+
+	// Simulate: parseResponse returns a valid response but with unknown backend
+	// We test the validation logic by calling the internal parseResponse + validation
+	resp, err := parseResponse(`{"backend": "gemini", "reason": "test"}`)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	// Check that the backend doesn't exist in config
+	if _, ok := cfg.Model.Backends[resp.Backend]; ok {
+		t.Fatal("test setup error: backend should not exist")
+	}
+
+	// The Route method would fall back to default — verify that logic
+	_ = r // Router exists but we can't call Route without a real CLI
+	if resp.Backend != "gemini" {
+		t.Errorf("parsed backend = %q, want %q", resp.Backend, "gemini")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("short", 10); got != "short" {
+		t.Errorf("truncate short = %q", got)
+	}
+	if got := truncate("this is a long string", 10); got != "this is..." {
+		t.Errorf("truncate long = %q, want %q", got, "this is...")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && containsStr(s, substr)
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Implements #13

## Changes

Adds an LLM router that calls a fast model (default: `claude-sonnet-4-6`) to analyze each issue's title and body and decide which backend (claude, codex, etc.) is best suited for the task.

### New config section

```yaml
routing:
  mode: auto          # or: manual (labels only, default)
  router_model: claude
  router_model_name: claude-sonnet-4-6
  router_prompt: |
    Given this GitHub issue, choose the best AI coding backend.
    Available backends: {{BACKENDS}}
    Issue: #{{NUMBER}} — {{TITLE}}
    {{BODY}}
    Return JSON only: {"backend": "<name>", "reason": "<one sentence>"}
```

### New package: `internal/router/`

- `Router` struct with `Route(issue) → (backendName, reason, err)`
- Calls configured backend CLI with `-p` flag and `--model` override
- Parses JSON response, extracts `{"backend": "...", "reason": "..."}`
- Handles surrounding text in model output (extracts JSON from prose)

### Priority and fallback

1. **Label override**: `model:codex` label on issue → use codex directly (skip router)
2. **Auto-routing**: If `routing.mode: auto` and no label → call router model
3. **Default fallback**: If router fails or returns unknown backend → use `model.default`

### Integration

- Orchestrator's `startNewWorkers()` uses router before `worker.Start()`
- CLI `spawn` command also uses router when no label override
- Logging: `[router] issue #175 → codex (focused SQL fix)`

## Testing

- Unit tests for JSON response parsing (valid, surrounding text, invalid, empty backend)
- Unit tests for prompt building (default template, custom template, variable substitution)
- Config tests for routing defaults and explicit config
- `go fmt`, `go vet`, `go test ./...` all pass
- Binary builds and runs successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements automatic backend selection via LLM routing. The router calls a fast model (default: `claude-sonnet-4-6`) to analyze issue content and choose the most suitable backend.

**Key changes:**
- New `internal/router/` package with LLM-based routing logic
- Added `RoutingConfig` to config with `mode`, `router_model`, `router_model_name`, and `router_prompt` fields
- Backend selection follows: label override → auto-routing (if enabled) → default fallback
- Integrated into both orchestrator loop and manual `spawn` command
- Comprehensive tests for JSON parsing, prompt building, and config defaults

**Architecture:**
- Router calls configured backend CLI with `-p` flag to get routing decision
- Handles JSON extraction from model output, tolerating surrounding text
- All errors fall back gracefully to default backend
- Proper logging for routing decisions and errors

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor suggestions for improvement
- Well-structured implementation with comprehensive tests and proper error handling. Two style suggestions for JSON parsing robustness and error diagnostics, but neither is critical. The fallback-to-default pattern ensures the system remains functional even if routing fails.
- No files require special attention - all changes follow consistent patterns and include proper tests

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/router/router.go | New router package that calls LLM to select backend; handles JSON extraction from model output with fallback to default backend |
| internal/config/config.go | Added RoutingConfig struct with sensible defaults; properly integrated into config parsing |
| internal/orchestrator/orchestrator.go | Integrated router into orchestrator; uses label override → auto-routing → default fallback pattern consistently |
| cmd/maestro/main.go | Integrated router into spawn command; follows same backend selection pattern as orchestrator |

</details>



<sub>Last reviewed commit: 8bcba4e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->