### PR TITLE
feat: worker prompt templates per issue type (#10)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,21 +46,23 @@ type RoutingConfig struct {
 }
 
 type Config struct {
-	Repo          string           `yaml:"repo"`
-	LocalPath     string           `yaml:"local_path"`
-	WorktreeBase  string           `yaml:"worktree_base"`
-	MaxParallel   int              `yaml:"max_parallel"`
-	ClaudeCmd     string           `yaml:"claude_cmd"`  // deprecated: use model.backends.claude.cmd
-	IssueLabel    string           `yaml:"issue_label"` // deprecated: use issue_labels
-	IssueLabels   []string         `yaml:"issue_labels"`
-	ExcludeLabels []string         `yaml:"exclude_labels"`
-	WorkerPrompt  string           `yaml:"worker_prompt"`
-	SessionPrefix string           `yaml:"session_prefix"` // worker session name prefix (default: first 3 chars of repo name)
-	StateDir      string           `yaml:"state_dir"`      // state/log directory (default: ~/.maestro/<repo-hash>)
-	Model         ModelConfig      `yaml:"model"`
-	Routing       RoutingConfig    `yaml:"routing"`
-	Telegram      TelegramConfig   `yaml:"telegram"`
-	Versioning    VersioningConfig `yaml:"versioning"`
+	Repo              string           `yaml:"repo"`
+	LocalPath         string           `yaml:"local_path"`
+	WorktreeBase      string           `yaml:"worktree_base"`
+	MaxParallel       int              `yaml:"max_parallel"`
+	ClaudeCmd         string           `yaml:"claude_cmd"`  // deprecated: use model.backends.claude.cmd
+	IssueLabel        string           `yaml:"issue_label"` // deprecated: use issue_labels
+	IssueLabels       []string         `yaml:"issue_labels"`
+	ExcludeLabels     []string         `yaml:"exclude_labels"`
+	WorkerPrompt      string           `yaml:"worker_prompt"`
+	BugPrompt         string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix     string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir          string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
+	Model             ModelConfig      `yaml:"model"`
+	Routing           RoutingConfig    `yaml:"routing"`
+	Telegram          TelegramConfig   `yaml:"telegram"`
+	Versioning        VersioningConfig `yaml:"versioning"`
 }
 
 // LoadFrom loads config from a specific path.
@@ -130,6 +132,8 @@ func parse(data []byte) (*Config, error) {
 	cfg.LocalPath = expandHome(cfg.LocalPath)
 	cfg.WorktreeBase = expandHome(cfg.WorktreeBase)
 	cfg.WorkerPrompt = expandHome(cfg.WorkerPrompt)
+	cfg.BugPrompt = expandHome(cfg.BugPrompt)
+	cfg.EnhancementPrompt = expandHome(cfg.EnhancementPrompt)
 	cfg.StateDir = expandHome(cfg.StateDir)
 
 	// Default session_prefix: first 3 chars of repo name

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -186,6 +186,66 @@ state_dir: ~/.maestro/panoptikon
 	}
 }
 
+func TestParse_PromptTemplateFields(t *testing.T) {
+	yaml := `
+repo: owner/repo
+worker_prompt: /path/to/default.md
+bug_prompt: /path/to/bug.md
+enhancement_prompt: /path/to/enhancement.md
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.WorkerPrompt != "/path/to/default.md" {
+		t.Errorf("WorkerPrompt = %q, want /path/to/default.md", cfg.WorkerPrompt)
+	}
+	if cfg.BugPrompt != "/path/to/bug.md" {
+		t.Errorf("BugPrompt = %q, want /path/to/bug.md", cfg.BugPrompt)
+	}
+	if cfg.EnhancementPrompt != "/path/to/enhancement.md" {
+		t.Errorf("EnhancementPrompt = %q, want /path/to/enhancement.md", cfg.EnhancementPrompt)
+	}
+}
+
+func TestParse_PromptTemplateExpandsHome(t *testing.T) {
+	yaml := `
+repo: owner/repo
+bug_prompt: ~/prompts/bug.md
+enhancement_prompt: ~/prompts/enhancement.md
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	home := os.Getenv("HOME")
+	expectedBug := filepath.Join(home, "prompts/bug.md")
+	expectedEnh := filepath.Join(home, "prompts/enhancement.md")
+	if cfg.BugPrompt != expectedBug {
+		t.Errorf("BugPrompt = %q, want %q", cfg.BugPrompt, expectedBug)
+	}
+	if cfg.EnhancementPrompt != expectedEnh {
+		t.Errorf("EnhancementPrompt = %q, want %q", cfg.EnhancementPrompt, expectedEnh)
+	}
+}
+
+func TestParse_PromptTemplateFieldsOptional(t *testing.T) {
+	yaml := `
+repo: owner/repo
+worker_prompt: /path/to/default.md
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.BugPrompt != "" {
+		t.Errorf("BugPrompt = %q, want empty", cfg.BugPrompt)
+	}
+	if cfg.EnhancementPrompt != "" {
+		t.Errorf("EnhancementPrompt = %q, want empty", cfg.EnhancementPrompt)
+	}
+}
+
 func TestParse_DifferentReposDifferentStateDirs(t *testing.T) {
 	yaml1 := `repo: BeFeast/panoptikon`
 	yaml2 := `repo: BeFeast/myapp`

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -18,12 +18,14 @@ import (
 
 // Orchestrator coordinates all agent sessions
 type Orchestrator struct {
-	cfg        *config.Config
-	notifier   *notify.Notifier
-	gh         *github.Client
-	router     *router.Router
-	repo       string
-	promptBase string
+	cfg                   *config.Config
+	notifier              *notify.Notifier
+	gh                    *github.Client
+	router                *router.Router
+	repo                  string
+	promptBase            string
+	bugPromptBase         string
+	enhancementPromptBase string
 }
 
 // New creates a new Orchestrator
@@ -39,6 +41,7 @@ func New(cfg *config.Config) *Orchestrator {
 
 // LoadPromptBase reads the worker prompt template from config or a provided path.
 // Priority: 1) explicit promptPath arg, 2) cfg.WorkerPrompt, 3) built-in fallback.
+// Also loads optional bug_prompt and enhancement_prompt from config.
 func (o *Orchestrator) LoadPromptBase(promptPath string) error {
 	if promptPath == "" {
 		promptPath = o.cfg.WorkerPrompt
@@ -56,7 +59,38 @@ func (o *Orchestrator) LoadPromptBase(promptPath string) error {
 	}
 	o.promptBase = string(data)
 	log.Printf("[orch] loaded prompt base from %s (%d bytes)", promptPath, len(data))
+
+	// Load optional per-issue-type prompts
+	if o.cfg.BugPrompt != "" {
+		if data, err := os.ReadFile(o.cfg.BugPrompt); err != nil {
+			log.Printf("[orch] warn: could not read bug_prompt from %s: %v", o.cfg.BugPrompt, err)
+		} else {
+			o.bugPromptBase = string(data)
+			log.Printf("[orch] loaded bug_prompt from %s (%d bytes)", o.cfg.BugPrompt, len(data))
+		}
+	}
+	if o.cfg.EnhancementPrompt != "" {
+		if data, err := os.ReadFile(o.cfg.EnhancementPrompt); err != nil {
+			log.Printf("[orch] warn: could not read enhancement_prompt from %s: %v", o.cfg.EnhancementPrompt, err)
+		} else {
+			o.enhancementPromptBase = string(data)
+			log.Printf("[orch] loaded enhancement_prompt from %s (%d bytes)", o.cfg.EnhancementPrompt, len(data))
+		}
+	}
+
 	return nil
+}
+
+// selectPrompt returns the appropriate prompt template for an issue based on its labels.
+// Priority: bug label → bug_prompt, enhancement label → enhancement_prompt, fallback → worker_prompt.
+func (o *Orchestrator) selectPrompt(issue github.Issue) string {
+	if o.bugPromptBase != "" && github.HasLabel(issue, []string{"bug"}) {
+		return o.bugPromptBase
+	}
+	if o.enhancementPromptBase != "" && github.HasLabel(issue, []string{"enhancement"}) {
+		return o.enhancementPromptBase
+	}
+	return o.promptBase
 }
 
 // RunOnce executes one orchestration cycle
@@ -366,8 +400,9 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			backendName = o.cfg.Model.Default
 		}
 
+		promptBase := o.selectPrompt(issue)
 		log.Printf("[orch] starting worker for issue #%d: %s (backend=%s)", issue.Number, issue.Title, backendName)
-		slotName, err := worker.Start(o.cfg, s, o.repo, issue, o.promptBase, backendName)
+		slotName, err := worker.Start(o.cfg, s, o.repo, issue, promptBase, backendName)
 		if err != nil {
 			log.Printf("[orch] start worker for issue #%d: %v", issue.Number, err)
 			o.notifier.Sendf("❌ maestro: failed to start worker for issue #%d (%s): %v",

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,0 +1,122 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+func makeIssue(number int, title string, labels ...string) github.Issue {
+	issue := github.Issue{Number: number, Title: title}
+	for _, l := range labels {
+		issue.Labels = append(issue.Labels, struct {
+			Name string `json:"name"`
+		}{Name: l})
+	}
+	return issue
+}
+
+func TestSelectPrompt_BugLabel(t *testing.T) {
+	o := &Orchestrator{
+		cfg:                   &config.Config{Repo: "owner/repo"},
+		promptBase:            "default prompt",
+		bugPromptBase:         "bug prompt",
+		enhancementPromptBase: "enhancement prompt",
+	}
+	got := o.selectPrompt(makeIssue(1, "Fix crash", "bug"))
+	if got != "bug prompt" {
+		t.Errorf("selectPrompt() = %q, want %q", got, "bug prompt")
+	}
+}
+
+func TestSelectPrompt_EnhancementLabel(t *testing.T) {
+	o := &Orchestrator{
+		cfg:                   &config.Config{Repo: "owner/repo"},
+		promptBase:            "default prompt",
+		bugPromptBase:         "bug prompt",
+		enhancementPromptBase: "enhancement prompt",
+	}
+	got := o.selectPrompt(makeIssue(2, "Add feature", "enhancement"))
+	if got != "enhancement prompt" {
+		t.Errorf("selectPrompt() = %q, want %q", got, "enhancement prompt")
+	}
+}
+
+func TestSelectPrompt_FallbackToDefault(t *testing.T) {
+	o := &Orchestrator{
+		cfg:                   &config.Config{Repo: "owner/repo"},
+		promptBase:            "default prompt",
+		bugPromptBase:         "bug prompt",
+		enhancementPromptBase: "enhancement prompt",
+	}
+	got := o.selectPrompt(makeIssue(3, "Update docs", "documentation"))
+	if got != "default prompt" {
+		t.Errorf("selectPrompt() = %q, want %q", got, "default prompt")
+	}
+}
+
+func TestSelectPrompt_BugTakesPrecedenceOverEnhancement(t *testing.T) {
+	o := &Orchestrator{
+		cfg:                   &config.Config{Repo: "owner/repo"},
+		promptBase:            "default prompt",
+		bugPromptBase:         "bug prompt",
+		enhancementPromptBase: "enhancement prompt",
+	}
+	got := o.selectPrompt(makeIssue(4, "Bug and enhancement", "bug", "enhancement"))
+	if got != "bug prompt" {
+		t.Errorf("selectPrompt() = %q, want %q (bug should take precedence)", got, "bug prompt")
+	}
+}
+
+func TestSelectPrompt_NoBugPromptConfigured(t *testing.T) {
+	o := &Orchestrator{
+		cfg:                   &config.Config{Repo: "owner/repo"},
+		promptBase:            "default prompt",
+		bugPromptBase:         "",
+		enhancementPromptBase: "enhancement prompt",
+	}
+	got := o.selectPrompt(makeIssue(5, "Fix crash", "bug"))
+	if got != "default prompt" {
+		t.Errorf("selectPrompt() = %q, want %q (should fall back when bug_prompt not set)", got, "default prompt")
+	}
+}
+
+func TestSelectPrompt_NoEnhancementPromptConfigured(t *testing.T) {
+	o := &Orchestrator{
+		cfg:                   &config.Config{Repo: "owner/repo"},
+		promptBase:            "default prompt",
+		bugPromptBase:         "bug prompt",
+		enhancementPromptBase: "",
+	}
+	got := o.selectPrompt(makeIssue(6, "Add feature", "enhancement"))
+	if got != "default prompt" {
+		t.Errorf("selectPrompt() = %q, want %q (should fall back when enhancement_prompt not set)", got, "default prompt")
+	}
+}
+
+func TestSelectPrompt_NoLabels(t *testing.T) {
+	o := &Orchestrator{
+		cfg:                   &config.Config{Repo: "owner/repo"},
+		promptBase:            "default prompt",
+		bugPromptBase:         "bug prompt",
+		enhancementPromptBase: "enhancement prompt",
+	}
+	got := o.selectPrompt(makeIssue(7, "Something"))
+	if got != "default prompt" {
+		t.Errorf("selectPrompt() = %q, want %q", got, "default prompt")
+	}
+}
+
+func TestSelectPrompt_CaseInsensitiveLabel(t *testing.T) {
+	o := &Orchestrator{
+		cfg:                   &config.Config{Repo: "owner/repo"},
+		promptBase:            "default prompt",
+		bugPromptBase:         "bug prompt",
+		enhancementPromptBase: "enhancement prompt",
+	}
+	got := o.selectPrompt(makeIssue(8, "Fix crash", "Bug"))
+	if got != "bug prompt" {
+		t.Errorf("selectPrompt() = %q, want %q (label matching should be case-insensitive)", got, "bug prompt")
+	}
+}


### PR DESCRIPTION
Implements #10

## Changes
- Added `bug_prompt` and `enhancement_prompt` optional fields to config (`internal/config/config.go`)
- Both fields support `~` path expansion like other path fields
- Added `selectPrompt()` method to orchestrator that checks issue labels to select the right prompt template:
  - Issue has `bug` label → uses `bug_prompt` (if configured)
  - Issue has `enhancement` label → uses `enhancement_prompt` (if configured)
  - Fallback → `worker_prompt` (existing behavior)
  - Bug label takes precedence when both labels are present
  - Label matching is case-insensitive (via existing `HasLabel` function)
- `LoadPromptBase()` now also loads bug and enhancement prompts from config paths
- All prompt templates support the same `{{REPO}}`, `{{ISSUE_NUMBER}}`, etc. template variables

## Testing
- Added 3 config parsing tests: field parsing, `~` expansion, and optionality
- Added 8 orchestrator tests covering all `selectPrompt` scenarios:
  - Bug label selection
  - Enhancement label selection
  - Fallback to default prompt
  - Bug precedence over enhancement
  - Graceful fallback when bug/enhancement prompts not configured
  - No labels case
  - Case-insensitive label matching
- All existing tests continue to pass
- Binary builds successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements per-issue-type prompt templates for worker agents. Workers can now use different prompt templates based on issue labels (`bug` or `enhancement`), with fallback to the default `worker_prompt`.

**Implementation:**
- Added optional `bug_prompt` and `enhancement_prompt` config fields to `Config` struct
- Both fields support `~` path expansion like other path fields in the config
- `LoadPromptBase()` now loads all three prompt templates (default, bug, enhancement)
- New `selectPrompt()` method handles prompt selection with proper precedence: bug label → bug_prompt, enhancement label → enhancement_prompt, otherwise → worker_prompt
- Label matching leverages the existing case-insensitive `HasLabel()` function
- Graceful degradation: if a specialized prompt isn't configured, falls back to default

**Test coverage:**
- Config tests validate field parsing, `~` expansion, and optionality
- Orchestrator tests cover all selection scenarios including precedence, fallback, case-insensitivity, and edge cases
- All existing tests continue to pass

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- Clean implementation with comprehensive test coverage. The changes follow existing patterns (config field addition, path expansion), include proper error handling with graceful fallback, and maintain backward compatibility. All edge cases are tested including precedence rules, missing config, and case-insensitive matching.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Added `bug_prompt` and `enhancement_prompt` fields with proper ~ path expansion |
| internal/config/config_test.go | Comprehensive tests for new prompt fields: parsing, ~ expansion, and optionality |
| internal/orchestrator/orchestrator.go | Added `selectPrompt()` with bug/enhancement label-based routing and graceful fallback |
| internal/orchestrator/orchestrator_test.go | 8 tests covering all `selectPrompt` scenarios including precedence and fallback |

</details>



<sub>Last reviewed commit: 2bdcc2a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->