### PR TITLE
feat: maestro import — seed state from existing worktrees (#9)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -35,6 +35,7 @@ Commands:
   watch         Open tmux dashboard with all worker logs
   spawn         Spawn a worker for a specific issue number
   stop          Stop a worker session
+  import        Seed state from existing worktrees
   version-bump  Bump project version based on merged PR labels
   version       Print version
 
@@ -91,6 +92,8 @@ func main() {
 		spawnCmd(args)
 	case "stop":
 		stopCmd(args)
+	case "import":
+		importCmd(args)
 	case "version-bump":
 		versionBumpCmd(args)
 	case "version":
@@ -485,6 +488,50 @@ func stopCmd(args []string) {
 	}
 
 	fmt.Printf("Stopped and removed session %s\n", *sessionName)
+}
+
+func importCmd(args []string) {
+	fs := flag.NewFlagSet("import", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to config file")
+	fs.Parse(args)
+
+	cfg := loadConfig(*configPath)
+
+	s, err := state.Load(cfg.StateDir)
+	if err != nil {
+		log.Fatalf("load state: %v", err)
+	}
+
+	results, err := worker.Import(cfg, s)
+	if err != nil {
+		log.Fatalf("import: %v", err)
+	}
+
+	if len(results) == 0 {
+		fmt.Println("No worktrees found to import.")
+		return
+	}
+
+	imported := 0
+	skipped := 0
+	for _, r := range results {
+		if r.Skipped {
+			fmt.Printf("  skip: %s (%s) — %s\n", r.SlotName, r.Branch, r.SkipReason)
+			skipped++
+		} else {
+			fmt.Printf("  imported: %s → issue #%d [%s]\n", r.SlotName, r.IssueNumber, r.Status)
+			imported++
+		}
+	}
+
+	fmt.Printf("\nImported %d, skipped %d.\n", imported, skipped)
+
+	if imported > 0 {
+		if err := state.Save(cfg.StateDir, s); err != nil {
+			log.Fatalf("save state: %v", err)
+		}
+		fmt.Printf("State saved to %s\n", state.StatePath(cfg.StateDir))
+	}
 }
 
 func versionBumpCmd(args []string) {

--- a/internal/worker/import.go
+++ b/internal/worker/import.go
@@ -1,0 +1,188 @@
+package worker
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// ImportResult describes the outcome of importing a single worktree.
+type ImportResult struct {
+	SlotName    string
+	IssueNumber int
+	Branch      string
+	Status      state.SessionStatus
+	Skipped     bool
+	SkipReason  string
+}
+
+// Import scans for existing worktrees under cfg.WorktreeBase, detects issue
+// numbers from branch names, checks tmux session liveness, and seeds state
+// entries. Useful for migrating from other tools or recovering from state loss.
+func Import(cfg *config.Config, s *state.State) ([]ImportResult, error) {
+	if cfg.WorktreeBase == "" {
+		return nil, fmt.Errorf("worktree_base not set in config")
+	}
+	if cfg.LocalPath == "" {
+		return nil, fmt.Errorf("local_path not set in config")
+	}
+
+	out, err := exec.Command("git", "-C", cfg.LocalPath, "worktree", "list").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("git worktree list: %w\n%s", err, out)
+	}
+
+	var results []ImportResult
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+
+		wtPath, branch, ok := parseWorktreeLine(line)
+		if !ok {
+			continue
+		}
+
+		// Only consider worktrees under WorktreeBase
+		absBase, _ := filepath.Abs(cfg.WorktreeBase)
+		absWT, _ := filepath.Abs(wtPath)
+		if !strings.HasPrefix(absWT, absBase+"/") {
+			continue
+		}
+
+		// Derive slot name from directory name
+		slotName := filepath.Base(wtPath)
+
+		// Parse issue number from branch
+		issueNum, err := ParseIssueFromBranch(branch)
+		if err != nil {
+			results = append(results, ImportResult{
+				SlotName:   slotName,
+				Branch:     branch,
+				Skipped:    true,
+				SkipReason: fmt.Sprintf("could not parse issue number: %v", err),
+			})
+			continue
+		}
+
+		// Check if already in state
+		if _, exists := s.Sessions[slotName]; exists {
+			results = append(results, ImportResult{
+				SlotName:    slotName,
+				IssueNumber: issueNum,
+				Branch:      branch,
+				Skipped:     true,
+				SkipReason:  "already in state",
+			})
+			continue
+		}
+
+		// Check if tmux session is alive
+		tmuxName := TmuxSessionName(slotName)
+		tmuxAlive := exec.Command("tmux", "has-session", "-t", tmuxName).Run() == nil
+
+		status := state.StatusDead
+		pid := 0
+		if tmuxAlive {
+			status = state.StatusRunning
+			// Try to get PID from tmux pane
+			if pidOut, err := exec.Command("tmux", "list-panes", "-t", tmuxName, "-F", "#{pane_pid}").Output(); err == nil {
+				if p, err := strconv.Atoi(strings.TrimSpace(string(pidOut))); err == nil {
+					pid = p
+				}
+			}
+		}
+
+		// Check for existing log file
+		logFile := filepath.Join(state.LogDir(cfg.StateDir), slotName+".log")
+
+		s.Sessions[slotName] = &state.Session{
+			IssueNumber: issueNum,
+			Worktree:    wtPath,
+			Branch:      branch,
+			PID:         pid,
+			LogFile:     logFile,
+			StartedAt:   time.Now().UTC(),
+			Status:      status,
+		}
+
+		// Advance NextSlot past any imported slot numbers to avoid collisions
+		if num := parseSlotNumber(slotName); num >= s.NextSlot {
+			s.NextSlot = num + 1
+		}
+
+		log.Printf("[import] %s → issue #%d [%s]", slotName, issueNum, status)
+
+		results = append(results, ImportResult{
+			SlotName:    slotName,
+			IssueNumber: issueNum,
+			Branch:      branch,
+			Status:      status,
+		})
+	}
+
+	return results, nil
+}
+
+// parseWorktreeLine parses a line from `git worktree list` output.
+// Format: /path/to/worktree  abc1234 [branch-name]
+func parseWorktreeLine(line string) (path, branch string, ok bool) {
+	bracketStart := strings.Index(line, "[")
+	bracketEnd := strings.Index(line, "]")
+	if bracketStart < 0 || bracketEnd < 0 || bracketEnd <= bracketStart {
+		return "", "", false
+	}
+
+	branch = line[bracketStart+1 : bracketEnd]
+
+	fields := strings.Fields(line[:bracketStart])
+	if len(fields) < 1 {
+		return "", "", false
+	}
+	path = fields[0]
+
+	return path, branch, true
+}
+
+// ParseIssueFromBranch extracts an issue number from a branch name.
+// Supports formats:
+//   - feat/{prefix}-{N}-{issue}-{title} (maestro: feat/pan-1-42-title)
+//   - feat/issue-{N}-{title}
+//   - {anything}/issue-{N}-{anything}
+func ParseIssueFromBranch(branch string) (int, error) {
+	// Maestro-style: feat/{letters}-{digits}-{issueNum}-...
+	reMaestro := regexp.MustCompile(`^feat/[a-zA-Z]+-\d+-(\d+)`)
+	if m := reMaestro.FindStringSubmatch(branch); len(m) >= 2 {
+		return strconv.Atoi(m[1])
+	}
+
+	// issue-N or issue/N pattern
+	reIssue := regexp.MustCompile(`issue[/-](\d+)`)
+	if m := reIssue.FindStringSubmatch(branch); len(m) >= 2 {
+		return strconv.Atoi(m[1])
+	}
+
+	return 0, fmt.Errorf("no issue number found in branch %q", branch)
+}
+
+// parseSlotNumber extracts the numeric suffix from a slot name (e.g. "pan-1" → 1).
+func parseSlotNumber(slotName string) int {
+	parts := strings.Split(slotName, "-")
+	if len(parts) < 2 {
+		return 0
+	}
+	num, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		return 0
+	}
+	return num
+}

--- a/internal/worker/import_test.go
+++ b/internal/worker/import_test.go
@@ -1,0 +1,133 @@
+package worker
+
+import (
+	"testing"
+)
+
+func TestParseIssueFromBranch_MaestroStyle(t *testing.T) {
+	tests := []struct {
+		branch string
+		want   int
+	}{
+		{"feat/pan-1-42-my-feature-title", 42},
+		{"feat/mae-33-9-feat-maestro-import", 9},
+		{"feat/abc-100-123-some-title", 123},
+		{"feat/ab-1-7-short", 7},
+	}
+	for _, tt := range tests {
+		got, err := ParseIssueFromBranch(tt.branch)
+		if err != nil {
+			t.Errorf("ParseIssueFromBranch(%q) error: %v", tt.branch, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseIssueFromBranch(%q) = %d, want %d", tt.branch, got, tt.want)
+		}
+	}
+}
+
+func TestParseIssueFromBranch_IssueStyle(t *testing.T) {
+	tests := []struct {
+		branch string
+		want   int
+	}{
+		{"feat/issue-42-add-login", 42},
+		{"fix/issue-7-bug", 7},
+		{"issue-123-something", 123},
+		{"feature/issue/99", 99},
+	}
+	for _, tt := range tests {
+		got, err := ParseIssueFromBranch(tt.branch)
+		if err != nil {
+			t.Errorf("ParseIssueFromBranch(%q) error: %v", tt.branch, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseIssueFromBranch(%q) = %d, want %d", tt.branch, got, tt.want)
+		}
+	}
+}
+
+func TestParseIssueFromBranch_NoMatch(t *testing.T) {
+	branches := []string{
+		"main",
+		"develop",
+		"feat/add-login-page",
+		"fix/typo-in-readme",
+	}
+	for _, branch := range branches {
+		_, err := ParseIssueFromBranch(branch)
+		if err == nil {
+			t.Errorf("ParseIssueFromBranch(%q) expected error, got nil", branch)
+		}
+	}
+}
+
+func TestParseWorktreeLine(t *testing.T) {
+	tests := []struct {
+		line       string
+		wantPath   string
+		wantBranch string
+		wantOK     bool
+	}{
+		{
+			"/home/user/.worktrees/maestro/pan-1  abc1234 [feat/pan-1-42-title]",
+			"/home/user/.worktrees/maestro/pan-1",
+			"feat/pan-1-42-title",
+			true,
+		},
+		{
+			"/home/user/repo  def5678 [main]",
+			"/home/user/repo",
+			"main",
+			true,
+		},
+		{
+			"/home/user/repo  abc1234 (detached HEAD)",
+			"", "", false,
+		},
+		{
+			"/home/user/repo  abc1234 (bare)",
+			"", "", false,
+		},
+		{
+			"", "", "", false,
+		},
+	}
+	for _, tt := range tests {
+		path, branch, ok := parseWorktreeLine(tt.line)
+		if ok != tt.wantOK {
+			t.Errorf("parseWorktreeLine(%q) ok=%v, want %v", tt.line, ok, tt.wantOK)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if path != tt.wantPath {
+			t.Errorf("parseWorktreeLine(%q) path=%q, want %q", tt.line, path, tt.wantPath)
+		}
+		if branch != tt.wantBranch {
+			t.Errorf("parseWorktreeLine(%q) branch=%q, want %q", tt.line, branch, tt.wantBranch)
+		}
+	}
+}
+
+func TestParseSlotNumber(t *testing.T) {
+	tests := []struct {
+		slotName string
+		want     int
+	}{
+		{"pan-1", 1},
+		{"mae-33", 33},
+		{"abc-100", 100},
+		{"noslot", 0},
+		{"", 0},
+		{"pan-abc", 0},
+	}
+	for _, tt := range tests {
+		got := parseSlotNumber(tt.slotName)
+		if got != tt.want {
+			t.Errorf("parseSlotNumber(%q) = %d, want %d", tt.slotName, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Implements #9

## Changes

Adds a `maestro import` command that scans for existing git worktrees under `worktree_base`, detects issue numbers from branch names, checks tmux session liveness, and seeds state entries. This is useful for migrating from other tools (like ao) or recovering from state file loss.

**New files:**
- `internal/worker/import.go` — Core import logic: parses `git worktree list` output, extracts issue numbers from branch names (supports maestro-style `feat/prefix-N-issueNum-title` and `issue-N` patterns), checks tmux session status, creates state entries
- `internal/worker/import_test.go` — Unit tests for branch parsing, worktree line parsing, and slot number extraction

**Modified files:**
- `cmd/maestro/main.go` — Adds `import` subcommand with `--config` flag support

**Behavior:**
- Worktrees with live tmux sessions get `running` status
- Worktrees without tmux sessions get `dead` status
- Worktrees already in state are skipped
- `NextSlot` is advanced past any imported slot numbers to avoid collisions
- Reports what was imported/skipped

## Testing

- Unit tests for `ParseIssueFromBranch` (maestro-style, issue-style, no-match cases)
- Unit tests for `parseWorktreeLine` (valid lines, detached HEAD, bare repo)
- Unit tests for `parseSlotNumber`
- `go fmt`, `go vet`, `go test ./...` all pass
- `go build ./cmd/maestro/` succeeds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `maestro import` command to scan existing git worktrees and seed state from them. This enables migration from other tools or recovery after state file loss. The implementation parses git worktree output, extracts issue numbers from branch names using regex patterns (maestro-style and issue-style), checks tmux session liveness, and creates state entries with appropriate status. The code includes comprehensive unit tests and properly advances NextSlot to prevent collisions.

**Key changes:**
- New `worker.Import()` function that scans worktrees under WorktreeBase and creates state entries
- Supports maestro-style branches (`feat/prefix-N-issueNum-title`) and generic issue branches (`issue-N`)
- Detects tmux session status and sets running/dead accordingly
- CLI integration via `importCmd()` with result reporting
- Comprehensive test coverage for parsing logic

**Issues found:**
- Error handling: `filepath.Abs` errors are silently ignored, which could cause incorrect path matching
- Missing field: `IssueTitle` is not populated in imported sessions
- Timestamp: `StartedAt` is set to import time rather than actual worktree creation time

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor improvements recommended
- The implementation is solid with good test coverage and follows existing patterns in the codebase. However, there's one critical logic issue where `filepath.Abs` errors are silently ignored, which could lead to incorrect path filtering. The missing `IssueTitle` field and incorrect `StartedAt` timestamp are non-critical but affect user experience in status displays.
- Pay attention to `internal/worker/import.go` for the error handling issue on lines 56-60

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | added `importCmd` function and wired up import subcommand with proper flag parsing and result reporting |
| internal/worker/import.go | implemented core import logic for scanning worktrees, parsing branch names, checking tmux sessions, and seeding state - missing IssueTitle field population |
| internal/worker/import_test.go | comprehensive unit tests for branch parsing, worktree parsing, and slot number extraction with good edge case coverage |

</details>



<sub>Last reviewed commit: 8790a21</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->