### PR TITLE
feat: maestro kill — terminate a specific worker (#8)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/orchestrator"
 	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
@@ -35,6 +36,7 @@ Commands:
   watch         Open tmux dashboard with all worker logs
   spawn         Spawn a worker for a specific issue number
   stop          Stop a worker session
+  kill          Kill a worker session by slot name
   import        Seed state from existing worktrees
   version-bump  Bump project version based on merged PR labels
   version       Print version
@@ -53,6 +55,9 @@ Spawn flags:
 
 Stop flags:
   --session string      Session name to stop (e.g. pan-1)
+
+Kill:
+  maestro kill <slot>   Kill a specific worker (e.g. maestro kill pan-1)
 
 Version-bump flags:
   --pr int              PR number to read labels/commits from
@@ -92,6 +97,8 @@ func main() {
 		spawnCmd(args)
 	case "stop":
 		stopCmd(args)
+	case "kill":
+		killCmd(args)
 	case "import":
 		importCmd(args)
 	case "version-bump":
@@ -488,6 +495,49 @@ func stopCmd(args []string) {
 	}
 
 	fmt.Printf("Stopped and removed session %s\n", *sessionName)
+}
+
+func killCmd(args []string) {
+	fs := flag.NewFlagSet("kill", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to config file")
+	fs.Parse(args)
+	args = fs.Args()
+
+	if len(args) == 0 || args[0] == "" {
+		fmt.Fprintln(os.Stderr, "error: slot name is required\nUsage: maestro kill <slot>")
+		os.Exit(1)
+	}
+
+	slotName := args[0]
+	cfg := loadConfig(*configPath)
+
+	s, err := state.Load(cfg.StateDir)
+	if err != nil {
+		log.Fatalf("load state: %v", err)
+	}
+
+	sess, ok := s.Sessions[slotName]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "error: session %q not found\n", slotName)
+		os.Exit(1)
+	}
+
+	if err := worker.Stop(cfg, slotName, sess); err != nil {
+		log.Fatalf("kill worker: %v", err)
+	}
+
+	now := time.Now().UTC()
+	sess.Status = state.StatusDead
+	sess.FinishedAt = &now
+
+	if err := state.Save(cfg.StateDir, s); err != nil {
+		log.Fatalf("save state: %v", err)
+	}
+
+	n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.OpenclawURL)
+	n.Sendf("maestro: manually killed worker %s (issue #%d: %s)", slotName, sess.IssueNumber, sess.IssueTitle)
+
+	fmt.Printf("Killed session %s (issue #%d: %s)\n", slotName, sess.IssueNumber, sess.IssueTitle)
 }
 
 func importCmd(args []string) {


### PR DESCRIPTION
Implements #8

## Changes
Adds `maestro kill <slot>` CLI command to terminate a stuck worker session. The command:

- Accepts a positional slot argument (e.g. `maestro kill pan-1`)
- Kills the tmux session via `worker.Stop()` (tmux kill + process kill + worktree removal)
- Marks the session as `StatusDead` with a `FinishedAt` timestamp in state
- Sends a Telegram notification about the manual kill
- Prints confirmation to stdout

This reuses the existing `worker.Stop()` infrastructure and follows the same patterns as the `stop` command, but with a simpler positional-arg UX and state preservation (marks dead instead of deleting).

## Testing
- `go fmt`, `go vet`, `go test`, `go build` all pass
- `maestro version` prints correctly
- `maestro kill` (no args) shows usage error
- `maestro help` shows the kill command in the command list

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

added `maestro kill <slot>` CLI command to terminate stuck workers. The command kills the tmux session/process, removes the worktree via `worker.Stop()`, marks the session as `StatusDead` with a `FinishedAt` timestamp (instead of deleting it like `stop` does), and sends a Telegram notification.

- follows existing patterns from `stopCmd` with simpler positional-arg UX
- reuses `worker.Stop()` infrastructure for cleanup
- preserves state history by marking dead rather than deleting
- includes help text and usage documentation

<h3>Confidence Score: 5/5</h3>

- safe to merge with no issues found
- implementation follows established patterns, reuses existing `worker.Stop()` infrastructure, adds proper error handling and user feedback, includes documentation, and preserves state history appropriately
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | added `maestro kill` command for terminating workers with positional arg UX, marks sessions as dead instead of deleting |

</details>



<sub>Last reviewed commit: 85cd853</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->