### PR TITLE
feat: configurable per-worker max runtime with auto-kill (#7)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,8 +50,9 @@ type Config struct {
 	LocalPath         string           `yaml:"local_path"`
 	WorktreeBase      string           `yaml:"worktree_base"`
 	MaxParallel       int              `yaml:"max_parallel"`
-	ClaudeCmd         string           `yaml:"claude_cmd"`  // deprecated: use model.backends.claude.cmd
-	IssueLabel        string           `yaml:"issue_label"` // deprecated: use issue_labels
+	MaxRuntimeMinutes int              `yaml:"max_runtime_minutes"` // max worker runtime in minutes (default: 120)
+	ClaudeCmd         string           `yaml:"claude_cmd"`          // deprecated: use model.backends.claude.cmd
+	IssueLabel        string           `yaml:"issue_label"`         // deprecated: use issue_labels
 	IssueLabels       []string         `yaml:"issue_labels"`
 	ExcludeLabels     []string         `yaml:"exclude_labels"`
 	WorkerPrompt      string           `yaml:"worker_prompt"`
@@ -99,8 +100,9 @@ func Load() (*Config, error) {
 func parse(data []byte) (*Config, error) {
 
 	cfg := &Config{
-		MaxParallel: 5,
-		ClaudeCmd:   "claude",
+		MaxParallel:       5,
+		MaxRuntimeMinutes: 120,
+		ClaudeCmd:         "claude",
 	}
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -304,3 +304,28 @@ routing:
 		t.Errorf("Routing.RouterPrompt = %q", cfg.Routing.RouterPrompt)
 	}
 }
+
+func TestParse_MaxRuntimeMinutesDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.MaxRuntimeMinutes != 120 {
+		t.Errorf("MaxRuntimeMinutes = %d, want 120", cfg.MaxRuntimeMinutes)
+	}
+}
+
+func TestParse_MaxRuntimeMinutesExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+max_runtime_minutes: 60
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.MaxRuntimeMinutes != 60 {
+		t.Errorf("MaxRuntimeMinutes = %d, want 60", cfg.MaxRuntimeMinutes)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -221,11 +221,21 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				continue
 			}
 
-			// Check for stale sessions (> 2h)
+			// Check if worker exceeded max runtime — kill if so
+			maxMinutes := o.cfg.MaxRuntimeMinutes
+			if sess.LongRunning {
+				maxMinutes *= 2
+			}
+			maxRuntime := time.Duration(maxMinutes) * time.Minute
 			age := time.Since(sess.StartedAt)
-			if age > 2*time.Hour {
-				o.notifier.Sendf("⏰ maestro: worker %s has been running for %s (issue #%d: %s) — might be stuck",
-					slotName, age.Round(time.Minute), sess.IssueNumber, sess.IssueTitle)
+			if age > maxRuntime {
+				log.Printf("[orch] worker %s exceeded max runtime (%dm), killing", slotName, maxMinutes)
+				worker.Stop(o.cfg, slotName, sess)
+				sess.Status = state.StatusDead
+				now := time.Now().UTC()
+				sess.FinishedAt = &now
+				o.notifier.Sendf("💀 maestro: worker for #%d killed after %dm (max runtime exceeded)",
+					sess.IssueNumber, int(age.Minutes()))
 			}
 		}
 	}
@@ -373,14 +383,18 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			continue
 		}
 
-		// Detect model: label for backend selection (label takes precedence)
+		// Detect model: label for backend selection (label takes precedence) and long-running label
 		backendName := ""
+		longRunning := false
 		for _, label := range issue.Labels {
 			if strings.HasPrefix(label.Name, "model:") {
 				if name := strings.TrimPrefix(label.Name, "model:"); name != "" {
 					backendName = name
 					log.Printf("[router] issue #%d → %s (label override)", issue.Number, backendName)
 				}
+			}
+			if strings.EqualFold(label.Name, "long-running") {
+				longRunning = true
 			}
 		}
 
@@ -401,7 +415,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		}
 
 		promptBase := o.selectPrompt(issue)
-		log.Printf("[orch] starting worker for issue #%d: %s (backend=%s)", issue.Number, issue.Title, backendName)
+		log.Printf("[orch] starting worker for issue #%d: %s (backend=%s, long_running=%v)", issue.Number, issue.Title, backendName, longRunning)
 		slotName, err := worker.Start(o.cfg, s, o.repo, issue, promptBase, backendName)
 		if err != nil {
 			log.Printf("[orch] start worker for issue #%d: %v", issue.Number, err)
@@ -410,6 +424,9 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			continue
 		}
 
+		if longRunning {
+			s.Sessions[slotName].LongRunning = true
+		}
 		o.notifier.Sendf("🚀 maestro: started worker %s for issue #%d: %s", slotName, issue.Number, issue.Title)
 		started++
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -31,6 +31,7 @@ type Session struct {
 	Status      SessionStatus `json:"status"`
 	PRNumber    int           `json:"pr_number,omitempty"`
 	Backend     string        `json:"backend,omitempty"` // "claude", "codex", etc.
+	LongRunning bool          `json:"long_running,omitempty"`
 }
 
 type State struct {


### PR DESCRIPTION
Implements #7

## Changes
- Added `max_runtime_minutes` config field (default: 120) to control maximum worker runtime
- When a worker exceeds the configured max runtime: kills the tmux session, removes the worktree, and marks the session as `StatusDead`
- Added `long-running` issue label support: doubles the max runtime for labeled issues
- Added `LongRunning` field to session state to persist the label flag
- Sends Telegram notification when a worker is killed for exceeding max runtime
- Replaced the previous hardcoded 2-hour warning (which only notified) with actual enforcement (kill + cleanup)

## Testing
- Added `TestParse_MaxRuntimeMinutesDefault` — verifies default of 120 minutes
- Added `TestParse_MaxRuntimeMinutesExplicit` — verifies custom value from config
- All existing tests pass (`go test ./...`)
- Build verified (`go build ./cmd/maestro/ && ./maestro version`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements configurable per-worker max runtime with automatic worker termination. The implementation adds a `max_runtime_minutes` config field (default 120 minutes) and enforces it by killing workers that exceed the limit. Issues labeled with `long-running` receive 2x the configured timeout.

**Key Changes:**
- Replaced previous passive 2-hour warning with active enforcement (kill + cleanup)
- Added config field with sensible default and test coverage
- Properly persisted `LongRunning` state to survive orchestrator restarts
- Sends Telegram notification when workers are killed

**Issues Found:**
- Missing validation for `MaxRuntimeMinutes <= 0` could cause immediate worker kills if misconfigured
- Notification message could be clearer by showing the actual max runtime limit

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one configuration validation fix
- The implementation is sound with proper state persistence and test coverage. However, missing validation for non-positive `MaxRuntimeMinutes` values could cause unexpected behavior if misconfigured. The core logic correctly handles runtime enforcement and long-running label detection. Once the validation is added, this would be a 5/5.
- Fix validation in `internal/config/config.go` before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Added `MaxRuntimeMinutes` config field with default value of 120 minutes and corresponding YAML parsing |
| internal/config/config_test.go | Added tests for default and explicit `max_runtime_minutes` configuration parsing |
| internal/state/state.go | Added `LongRunning` boolean field to Session struct to persist long-running label state |
| internal/orchestrator/orchestrator.go | Implemented max runtime enforcement with auto-kill, long-running label detection (2x timeout), and Telegram notifications for killed workers |

</details>



<sub>Last reviewed commit: 62b919e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->