### PR TITLE
fix: deduplicate CI failure notifications (#38)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -284,6 +284,9 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 
 		switch ciStatus {
 		case "success":
+			// Reset CI failure notification flag when CI goes green
+			sess.NotifiedCIFail = false
+
 			log.Printf("[orch] merging PR #%d (branch %s)", pr.Number, sess.Branch)
 			if err := o.gh.MergePR(pr.Number); err != nil {
 				log.Printf("[orch] merge PR #%d: %v", pr.Number, err)
@@ -310,7 +313,10 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				}
 			}
 		case "failure":
-			o.notifier.Sendf("❌ maestro: CI failing for PR #%d (%s, issue #%d)", pr.Number, sess.Branch, sess.IssueNumber)
+			if !sess.NotifiedCIFail {
+				o.notifier.Sendf("❌ maestro: CI failing for PR #%d (%s, issue #%d)", pr.Number, sess.Branch, sess.IssueNumber)
+				sess.NotifiedCIFail = true
+			}
 		}
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -20,18 +20,19 @@ const (
 )
 
 type Session struct {
-	IssueNumber int           `json:"issue_number"`
-	IssueTitle  string        `json:"issue_title"`
-	Worktree    string        `json:"worktree"`
-	Branch      string        `json:"branch"`
-	PID         int           `json:"pid"`
-	LogFile     string        `json:"log_file"`
-	StartedAt   time.Time     `json:"started_at"`
-	FinishedAt  *time.Time    `json:"finished_at,omitempty"`
-	Status      SessionStatus `json:"status"`
-	PRNumber    int           `json:"pr_number,omitempty"`
-	Backend     string        `json:"backend,omitempty"` // "claude", "codex", etc.
-	LongRunning bool          `json:"long_running,omitempty"`
+	IssueNumber    int           `json:"issue_number"`
+	IssueTitle     string        `json:"issue_title"`
+	Worktree       string        `json:"worktree"`
+	Branch         string        `json:"branch"`
+	PID            int           `json:"pid"`
+	LogFile        string        `json:"log_file"`
+	StartedAt      time.Time     `json:"started_at"`
+	FinishedAt     *time.Time    `json:"finished_at,omitempty"`
+	Status         SessionStatus `json:"status"`
+	PRNumber       int           `json:"pr_number,omitempty"`
+	Backend        string        `json:"backend,omitempty"` // "claude", "codex", etc.
+	LongRunning    bool          `json:"long_running,omitempty"`
+	NotifiedCIFail bool          `json:"notified_ci_fail,omitempty"`
 }
 
 type State struct {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,138 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNotifiedCIFail_Persistence(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create state with NotifiedCIFail set
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber:    42,
+		Branch:         "feat/test",
+		Status:         StatusPROpen,
+		PRNumber:       10,
+		StartedAt:      time.Now().UTC(),
+		NotifiedCIFail: true,
+	}
+	s.Sessions["slot-2"] = &Session{
+		IssueNumber:    43,
+		Branch:         "feat/other",
+		Status:         StatusPROpen,
+		PRNumber:       11,
+		StartedAt:      time.Now().UTC(),
+		NotifiedCIFail: false,
+	}
+
+	// Save
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Load and verify
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	sess1 := loaded.Sessions["slot-1"]
+	if sess1 == nil {
+		t.Fatal("slot-1 not found after load")
+	}
+	if !sess1.NotifiedCIFail {
+		t.Error("slot-1: NotifiedCIFail should be true after load")
+	}
+
+	sess2 := loaded.Sessions["slot-2"]
+	if sess2 == nil {
+		t.Fatal("slot-2 not found after load")
+	}
+	if sess2.NotifiedCIFail {
+		t.Error("slot-2: NotifiedCIFail should be false after load")
+	}
+}
+
+func TestNotifiedCIFail_OmittedWhenFalse(t *testing.T) {
+	dir := t.TempDir()
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber:    42,
+		Branch:         "feat/test",
+		Status:         StatusPROpen,
+		PRNumber:       10,
+		StartedAt:      time.Now().UTC(),
+		NotifiedCIFail: false,
+	}
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Read raw JSON and verify the field is omitted
+	data, err := os.ReadFile(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	json := string(data)
+	if containsString(json, "notified_ci_fail") {
+		t.Error("notified_ci_fail should be omitted from JSON when false")
+	}
+}
+
+func TestNotifiedCIFail_BackwardCompatibility(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a state file without the NotifiedCIFail field (simulating old state)
+	oldJSON := `{
+  "sessions": {
+    "slot-1": {
+      "issue_number": 42,
+      "branch": "feat/test",
+      "status": "pr_open",
+      "pr_number": 10,
+      "started_at": "2025-01-01T00:00:00Z"
+    }
+  },
+  "next_slot": 2
+}`
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(oldJSON), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Load should succeed and default NotifiedCIFail to false
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	sess := loaded.Sessions["slot-1"]
+	if sess == nil {
+		t.Fatal("slot-1 not found")
+	}
+	if sess.NotifiedCIFail {
+		t.Error("NotifiedCIFail should default to false for old state files")
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Implements #38

## Changes
- Added `NotifiedCIFail` bool field to `Session` struct to track whether a CI failure notification has already been sent for a given PR
- In `autoMergePRs()`, only send CI failure notification on first detection (`!sess.NotifiedCIFail`), then set the flag
- Reset `NotifiedCIFail` when CI status transitions to `"success"`, so a re-failure after recovery triggers a fresh notification
- Field uses `omitempty` JSON tag for backward compatibility with existing state files

## Testing
- Added `state_test.go` with tests for:
  - `NotifiedCIFail` persistence through save/load round-trip
  - JSON omission when false (clean state files)
  - Backward compatibility with old state files missing the field
- All existing tests pass (`go test ./...`)
- Binary builds successfully (`go build ./cmd/maestro/`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements CI failure notification deduplication by tracking notification state per PR session. When CI first fails, a notification is sent and `NotifiedCIFail` is set to `true`. The flag resets when CI recovers to "success", allowing re-notification on subsequent failures.

- Added `NotifiedCIFail` field to `Session` struct with `omitempty` for clean state files
- Updated `autoMergePRs()` to check flag before sending CI failure notifications
- Flag resets on CI success, enabling fresh notifications after recovery
- Comprehensive test coverage for persistence, JSON omission, and backward compatibility
- No breaking changes - existing state files load correctly with field defaulting to `false`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - clean implementation with excellent test coverage
- The implementation is straightforward and well-tested. The flag correctly prevents duplicate notifications while allowing re-notification after recovery. Backward compatibility is maintained with `omitempty`, and comprehensive tests verify all edge cases including persistence, JSON serialization, and old state file loading
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Added deduplication logic for CI failure notifications using `NotifiedCIFail` flag - resets on success, sets on first failure |
| internal/state/state.go | Added `NotifiedCIFail` bool field to `Session` struct with `omitempty` tag for backward compatibility |
| internal/state/state_test.go | New test file with comprehensive coverage: persistence, JSON omission, and backward compatibility tests |

</details>



<sub>Last reviewed commit: 10b93ab</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->