### PR TITLE
feat: maestro history — show recently completed sessions (#6)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -38,6 +38,7 @@ Commands:
   stop          Stop a worker session
   kill          Kill a worker session by slot name
   import        Seed state from existing worktrees
+  history       Show recently completed sessions
   version-bump  Bump project version based on merged PR labels
   version       Print version
 
@@ -65,6 +66,12 @@ Version-bump flags:
 Logs:
   maestro logs              List active worker logs + tmux attach hints
   maestro logs <slot>       tail -f specific worker log (e.g. maestro logs pan-20)
+
+History:
+  maestro history              Show last 20 completed sessions
+  maestro history --limit 50   Show last 50 completed sessions
+  maestro history --json       Machine-readable JSON output
+  maestro history --prune      Remove sessions older than retention period
 
 Watch:
   maestro watch             Open tmux dashboard with all active worker logs
@@ -101,6 +108,8 @@ func main() {
 		killCmd(args)
 	case "import":
 		importCmd(args)
+	case "history":
+		historyCmd(args)
 	case "version-bump":
 		versionBumpCmd(args)
 	case "version":
@@ -588,6 +597,96 @@ func importCmd(args []string) {
 	}
 }
 
+func historyCmd(args []string) {
+	fs := flag.NewFlagSet("history", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to config file")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	limit := fs.Int("limit", 20, "Number of recent sessions to show")
+	prune := fs.Bool("prune", false, "Remove sessions older than retention period")
+	retentionDays := fs.Int("retention-days", 30, "Retention period in days for pruning")
+	fs.Parse(args)
+
+	cfg := loadConfig(*configPath)
+
+	s, err := state.Load(cfg.StateDir)
+	if err != nil {
+		log.Fatalf("load state: %v", err)
+	}
+
+	if *prune {
+		maxAge := time.Duration(*retentionDays) * 24 * time.Hour
+		pruned := s.PruneOldSessions(maxAge)
+		if pruned > 0 {
+			if err := state.Save(cfg.StateDir, s); err != nil {
+				log.Fatalf("save state: %v", err)
+			}
+		}
+		fmt.Printf("Pruned %d sessions older than %d days.\n", pruned, *retentionDays)
+		return
+	}
+
+	completed := s.CompletedSessions()
+	if *limit > 0 && len(completed) > *limit {
+		completed = completed[:*limit]
+	}
+
+	if *jsonOutput {
+		type jsonEntry struct {
+			Session    string `json:"session"`
+			Issue      int    `json:"issue"`
+			Title      string `json:"title"`
+			Status     string `json:"status"`
+			PRNumber   int    `json:"pr_number,omitempty"`
+			Duration   string `json:"duration"`
+			FinishedAt string `json:"finished_at,omitempty"`
+			Backend    string `json:"backend,omitempty"`
+		}
+		entries := make([]jsonEntry, 0, len(completed))
+		for _, c := range completed {
+			entry := jsonEntry{
+				Session:  c.SlotName,
+				Issue:    c.IssueNumber,
+				Title:    c.IssueTitle,
+				Status:   string(c.Status),
+				PRNumber: c.PRNumber,
+				Duration: sessionDuration(c.Session),
+				Backend:  c.Backend,
+			}
+			if c.FinishedAt != nil {
+				entry.FinishedAt = c.FinishedAt.Format(time.RFC3339)
+			}
+			entries = append(entries, entry)
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(entries)
+		return
+	}
+
+	if len(completed) == 0 {
+		fmt.Println("No completed sessions.")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "SESSION\tISSUE\tOUTCOME\tPR\tDURATION\tFINISHED\tTITLE")
+	fmt.Fprintln(w, "-------\t-----\t-------\t--\t--------\t--------\t-----")
+	for _, c := range completed {
+		pr := "-"
+		if c.PRNumber > 0 {
+			pr = fmt.Sprintf("#%d", c.PRNumber)
+		}
+		finished := "-"
+		if c.FinishedAt != nil {
+			finished = formatRelativeTime(*c.FinishedAt)
+		}
+		fmt.Fprintf(w, "%s\t#%d\t%s\t%s\t%s\t%s\t%s\n",
+			c.SlotName, c.IssueNumber, outcomeLabel(c.Status),
+			pr, sessionDuration(c.Session), finished, truncate(c.IssueTitle, 40))
+	}
+	w.Flush()
+}
+
 func versionBumpCmd(args []string) {
 	fs := flag.NewFlagSet("version-bump", flag.ExitOnError)
 	configPath := fs.String("config", "", "Path to config file")
@@ -607,6 +706,59 @@ func versionBumpCmd(args []string) {
 	}
 
 	fmt.Println("Version bump complete.")
+}
+
+func sessionDuration(sess *state.Session) string {
+	end := time.Now()
+	if sess.FinishedAt != nil {
+		end = *sess.FinishedAt
+	}
+	d := end.Sub(sess.StartedAt).Round(time.Second)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	if m == 0 {
+		return fmt.Sprintf("%dh", h)
+	}
+	return fmt.Sprintf("%dh%dm", h, m)
+}
+
+func outcomeLabel(status state.SessionStatus) string {
+	switch status {
+	case state.StatusDone:
+		return "merged"
+	case state.StatusDead:
+		return "died"
+	case state.StatusConflictFailed:
+		return "conflict"
+	case state.StatusFailed:
+		return "failed"
+	default:
+		return string(status)
+	}
+}
+
+func formatRelativeTime(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		days := int(d.Hours()) / 24
+		if days == 1 {
+			return "1d ago"
+		}
+		return fmt.Sprintf("%dd ago", days)
+	}
 }
 
 func truncate(s string, max int) string {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 )
 
@@ -121,4 +122,64 @@ func (s *State) IssueInProgress(issueNum int) bool {
 		}
 	}
 	return false
+}
+
+// IsTerminal returns true if the status represents a completed/dead session.
+func IsTerminal(status SessionStatus) bool {
+	switch status {
+	case StatusDone, StatusFailed, StatusConflictFailed, StatusDead:
+		return true
+	}
+	return false
+}
+
+// CompletedSession is a Session paired with its slot name.
+type CompletedSession struct {
+	SlotName string
+	*Session
+}
+
+// CompletedSessions returns sessions in a terminal state, sorted by FinishedAt descending.
+func (s *State) CompletedSessions() []CompletedSession {
+	var result []CompletedSession
+	for name, sess := range s.Sessions {
+		if IsTerminal(sess.Status) {
+			result = append(result, CompletedSession{SlotName: name, Session: sess})
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		fi, fj := result[i].FinishedAt, result[j].FinishedAt
+		if fi == nil && fj == nil {
+			return result[i].StartedAt.After(result[j].StartedAt)
+		}
+		if fi == nil {
+			return false
+		}
+		if fj == nil {
+			return true
+		}
+		return fi.After(*fj)
+	})
+	return result
+}
+
+// PruneOldSessions removes completed sessions older than maxAge.
+// Returns the number of pruned sessions.
+func (s *State) PruneOldSessions(maxAge time.Duration) int {
+	pruned := 0
+	for name, sess := range s.Sessions {
+		if !IsTerminal(sess.Status) {
+			continue
+		}
+		finished := sess.FinishedAt
+		if finished == nil {
+			// Fallback: use StartedAt if FinishedAt is not set
+			finished = &sess.StartedAt
+		}
+		if time.Since(*finished) > maxAge {
+			delete(s.Sessions, name)
+			pruned++
+		}
+	}
+	return pruned
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -244,3 +244,136 @@ func searchString(s, substr string) bool {
 	}
 	return false
 }
+
+func TestIsTerminal(t *testing.T) {
+	tests := []struct {
+		status SessionStatus
+		want   bool
+	}{
+		{StatusRunning, false},
+		{StatusPROpen, false},
+		{StatusDone, true},
+		{StatusFailed, true},
+		{StatusConflictFailed, true},
+		{StatusDead, true},
+	}
+	for _, tt := range tests {
+		if got := IsTerminal(tt.status); got != tt.want {
+			t.Errorf("IsTerminal(%q) = %v, want %v", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestCompletedSessions_Empty(t *testing.T) {
+	s := NewState()
+	if got := s.CompletedSessions(); len(got) != 0 {
+		t.Errorf("expected 0 completed sessions, got %d", len(got))
+	}
+}
+
+func TestCompletedSessions_FiltersAndSorts(t *testing.T) {
+	now := time.Now().UTC()
+	t1 := now.Add(-3 * time.Hour)
+	t2 := now.Add(-1 * time.Hour)
+	t3 := now.Add(-2 * time.Hour)
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber: 1,
+		Status:      StatusDone,
+		StartedAt:   now.Add(-4 * time.Hour),
+		FinishedAt:  &t1,
+	}
+	s.Sessions["slot-2"] = &Session{
+		IssueNumber: 2,
+		Status:      StatusRunning, // should be excluded
+		StartedAt:   now.Add(-2 * time.Hour),
+	}
+	s.Sessions["slot-3"] = &Session{
+		IssueNumber: 3,
+		Status:      StatusDead,
+		StartedAt:   now.Add(-3 * time.Hour),
+		FinishedAt:  &t2,
+	}
+	s.Sessions["slot-4"] = &Session{
+		IssueNumber: 4,
+		Status:      StatusConflictFailed,
+		StartedAt:   now.Add(-5 * time.Hour),
+		FinishedAt:  &t3,
+	}
+
+	completed := s.CompletedSessions()
+	if len(completed) != 3 {
+		t.Fatalf("expected 3 completed, got %d", len(completed))
+	}
+
+	// Should be sorted by FinishedAt descending: slot-3 (1h), slot-4 (2h), slot-1 (3h)
+	if completed[0].IssueNumber != 3 {
+		t.Errorf("first should be issue 3 (most recent), got %d", completed[0].IssueNumber)
+	}
+	if completed[1].IssueNumber != 4 {
+		t.Errorf("second should be issue 4, got %d", completed[1].IssueNumber)
+	}
+	if completed[2].IssueNumber != 1 {
+		t.Errorf("third should be issue 1 (oldest), got %d", completed[2].IssueNumber)
+	}
+}
+
+func TestPruneOldSessions(t *testing.T) {
+	now := time.Now().UTC()
+	old := now.Add(-40 * 24 * time.Hour)
+	recent := now.Add(-5 * 24 * time.Hour)
+
+	s := NewState()
+	s.Sessions["old-done"] = &Session{
+		IssueNumber: 1,
+		Status:      StatusDone,
+		StartedAt:   old.Add(-time.Hour),
+		FinishedAt:  &old,
+	}
+	s.Sessions["recent-done"] = &Session{
+		IssueNumber: 2,
+		Status:      StatusDone,
+		StartedAt:   recent.Add(-time.Hour),
+		FinishedAt:  &recent,
+	}
+	s.Sessions["running"] = &Session{
+		IssueNumber: 3,
+		Status:      StatusRunning,
+		StartedAt:   old, // old but running — should NOT be pruned
+	}
+
+	maxAge := 30 * 24 * time.Hour
+	pruned := s.PruneOldSessions(maxAge)
+
+	if pruned != 1 {
+		t.Errorf("expected 1 pruned, got %d", pruned)
+	}
+	if _, ok := s.Sessions["old-done"]; ok {
+		t.Error("old-done should have been pruned")
+	}
+	if _, ok := s.Sessions["recent-done"]; !ok {
+		t.Error("recent-done should still exist")
+	}
+	if _, ok := s.Sessions["running"]; !ok {
+		t.Error("running should still exist (not terminal)")
+	}
+}
+
+func TestPruneOldSessions_NoFinishedAt(t *testing.T) {
+	// Edge case: terminal session without FinishedAt falls back to StartedAt
+	old := time.Now().UTC().Add(-40 * 24 * time.Hour)
+
+	s := NewState()
+	s.Sessions["dead-no-finish"] = &Session{
+		IssueNumber: 1,
+		Status:      StatusDead,
+		StartedAt:   old,
+		FinishedAt:  nil, // no FinishedAt
+	}
+
+	pruned := s.PruneOldSessions(30 * 24 * time.Hour)
+	if pruned != 1 {
+		t.Errorf("expected 1 pruned, got %d", pruned)
+	}
+}


### PR DESCRIPTION
Implements #6

## Changes
- Add `maestro history` command that displays a table of recently completed/dead sessions
  - Columns: SESSION, ISSUE, OUTCOME (merged/died/conflict/failed), PR #, DURATION, FINISHED (relative time), TITLE
  - Sessions sorted by finish time (most recent first)
- Add `--json` flag for machine-readable JSON output
- Add `--limit N` flag to control how many sessions to show (default 20)
- Add `--prune` flag to remove sessions older than N days (default 30, configurable via `--retention-days`)
- Add `IsTerminal()`, `CompletedSessions()`, `PruneOldSessions()` helpers to state package
- Add unit tests for all state history helpers

## Implementation Details
- Leverages existing state: completed sessions already persist in `state.json` with `finished_at` timestamps
- No schema changes needed — sessions in terminal states (`done`, `dead`, `failed`, `conflict_failed`) are filtered and displayed
- Follows existing CLI patterns (flag-based subcommands, tabwriter tables, `--json` support)

## Testing
- Unit tests for `IsTerminal`, `CompletedSessions` (filtering + sort order), `PruneOldSessions` (age-based removal, running session protection, nil FinishedAt fallback)
- `go fmt`, `go vet`, `go test ./...` all pass
- Binary builds and runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `maestro history` command that displays recently completed/dead sessions with flexible output options. Implementation leverages existing state persistence without schema changes.

- Added `history` subcommand with `--json`, `--limit`, and `--prune` flags following existing CLI patterns
- Implemented state helpers (`IsTerminal`, `CompletedSessions`, `PruneOldSessions`) with proper nil handling and sorting
- Comprehensive test coverage for all new functionality including edge cases
- Clean implementation that reuses existing patterns (e.g., unchecked `enc.Encode` at cmd/maestro/main.go:662 matches pattern at line 178)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured implementation following existing patterns, comprehensive test coverage (including edge cases), no schema changes, and all functionality properly isolated to new command
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Added `history` command with comprehensive flags (`--json`, `--limit`, `--prune`); consistent with existing patterns; previous thread notes unchecked `enc.Encode` error (matches existing codebase style) |
| internal/state/state.go | Added `IsTerminal()`, `CompletedSessions()` with proper nil handling and sorting, and `PruneOldSessions()` with fallback logic; implementation is clean and correct |
| internal/state/state_test.go | Added comprehensive unit tests covering `IsTerminal()`, `CompletedSessions()` filtering/sorting, and `PruneOldSessions()` including edge cases like nil `FinishedAt` |

</details>



<sub>Last reviewed commit: c3243cc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->