### PR TITLE
feat: Backend interface, Gemini support, generic extensible backends (#5)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,8 +18,9 @@ type TelegramConfig struct {
 
 // BackendDef defines a model backend CLI.
 type BackendDef struct {
-	Cmd       string   `yaml:"cmd"`
-	ExtraArgs []string `yaml:"extra_args"`
+	Cmd        string   `yaml:"cmd"`
+	ExtraArgs  []string `yaml:"extra_args"`
+	PromptMode string   `yaml:"prompt_mode"` // how to deliver prompt: "arg" (last argument), "stdin" (via stdin), "file" (file path as argument)
 }
 
 // ModelConfig holds multi-backend configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -329,3 +329,113 @@ max_runtime_minutes: 60
 		t.Errorf("MaxRuntimeMinutes = %d, want 60", cfg.MaxRuntimeMinutes)
 	}
 }
+
+func TestParse_ModelConfigDefaults(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Model.Default != "claude" {
+		t.Errorf("expected default backend=claude, got %q", cfg.Model.Default)
+	}
+	if _, ok := cfg.Model.Backends["claude"]; !ok {
+		t.Error("expected claude backend to be present in map")
+	}
+}
+
+func TestParse_ModelConfigExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: codex
+  backends:
+    claude:
+      cmd: claude
+    codex:
+      cmd: /usr/local/bin/codex
+      extra_args: ["--approval-mode", "full-auto"]
+    gemini:
+      cmd: gemini-cli
+      extra_args: ["--yolo"]
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Model.Default != "codex" {
+		t.Errorf("expected default=codex, got %q", cfg.Model.Default)
+	}
+	if len(cfg.Model.Backends) < 3 {
+		t.Errorf("expected at least 3 backends, got %d", len(cfg.Model.Backends))
+	}
+	codex := cfg.Model.Backends["codex"]
+	if codex.Cmd != "/usr/local/bin/codex" {
+		t.Errorf("expected codex cmd=/usr/local/bin/codex, got %q", codex.Cmd)
+	}
+	if len(codex.ExtraArgs) != 2 || codex.ExtraArgs[0] != "--approval-mode" {
+		t.Errorf("expected codex extra_args=[--approval-mode full-auto], got %v", codex.ExtraArgs)
+	}
+	gemini := cfg.Model.Backends["gemini"]
+	if gemini.Cmd != "gemini-cli" {
+		t.Errorf("expected gemini cmd=gemini-cli, got %q", gemini.Cmd)
+	}
+}
+
+func TestParse_ModelConfigPromptMode(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: custom
+  backends:
+    custom:
+      cmd: my-cli
+      prompt_mode: stdin
+      extra_args: ["--auto"]
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	custom := cfg.Model.Backends["custom"]
+	if custom.PromptMode != "stdin" {
+		t.Errorf("expected prompt_mode=stdin, got %q", custom.PromptMode)
+	}
+	if custom.Cmd != "my-cli" {
+		t.Errorf("expected cmd=my-cli, got %q", custom.Cmd)
+	}
+}
+
+func TestParse_ClaudeCmdBackwardCompat(t *testing.T) {
+	yaml := `
+repo: owner/repo
+claude_cmd: /custom/path/claude
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	claude := cfg.Model.Backends["claude"]
+	if claude.Cmd != "/custom/path/claude" {
+		t.Errorf("expected claude_cmd to populate backends[claude].cmd, got %q", claude.Cmd)
+	}
+}
+
+func TestParse_ClaudeCmdDoesNotOverrideExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+claude_cmd: /old/claude
+model:
+  backends:
+    claude:
+      cmd: /new/claude
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	claude := cfg.Model.Backends["claude"]
+	if claude.Cmd != "/new/claude" {
+		t.Errorf("explicit model.backends.claude.cmd should take precedence, got %q", claude.Cmd)
+	}
+}

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -8,16 +8,34 @@ import (
 
 // BackendConfig holds the CLI command and any extra args from config.
 type BackendConfig struct {
-	Cmd       string   // binary name (e.g. "claude", "codex")
-	ExtraArgs []string // additional args from config
+	Cmd        string   // binary name (e.g. "claude", "codex", "gemini")
+	ExtraArgs  []string // additional args from config
+	PromptMode string   // how to deliver prompt: "arg", "stdin", "file"
 }
 
-// NewClaudeCmd builds a claude --dangerously-skip-permissions -p "$(cat promptFile)" command.
-// Prompt is read from file to avoid shell quoting issues.
-func NewClaudeCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, error) {
+// Backend builds the exec.Cmd for a specific model CLI.
+type Backend interface {
+	// BuildCmd creates the command to run the model CLI.
+	// Returns the command, an optional stdinFile path (for backends that read
+	// the prompt via stdin), and any error.
+	BuildCmd(cfg BackendConfig, promptFile, worktree string) (cmd *exec.Cmd, stdinFile string, err error)
+}
+
+// knownBackends maps backend names to their implementations.
+var knownBackends = map[string]Backend{
+	"claude": claudeBackend{},
+	"codex":  codexBackend{},
+	"gemini": geminiBackend{},
+}
+
+// --- Claude Backend ---
+
+type claudeBackend struct{}
+
+func (claudeBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
 	promptData, err := os.ReadFile(promptFile)
 	if err != nil {
-		return nil, fmt.Errorf("read prompt file: %w", err)
+		return nil, "", fmt.Errorf("read prompt file: %w", err)
 	}
 	claudeCmd := cfg.Cmd
 	if claudeCmd == "" {
@@ -27,13 +45,14 @@ func NewClaudeCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, er
 	args = append(args, cfg.ExtraArgs...)
 	cmd := exec.Command(claudeCmd, args...)
 	cmd.Dir = worktree
-	return cmd, nil
+	return cmd, "", nil
 }
 
-// NewCodexCmd builds: codex exec --dangerously-bypass-approvals-and-sandbox -C <worktree> - < promptFile
-// Note: the prompt file is NOT opened here. The runner script in worker.go handles
-// stdin redirection via shell `< promptFile`, so no file descriptor is held open.
-func NewCodexCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, error) {
+// --- Codex Backend ---
+
+type codexBackend struct{}
+
+func (codexBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
 	codexCmd := cfg.Cmd
 	if codexCmd == "" {
 		codexCmd = "codex"
@@ -43,21 +62,97 @@ func NewCodexCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, err
 	cmd := exec.Command(codexCmd, args...)
 	cmd.Dir = worktree
 	// Stdin redirection is handled by the runner script — no file opened here
-	return cmd, nil
+	return cmd, promptFile, nil
+}
+
+// --- Gemini Backend ---
+
+type geminiBackend struct{}
+
+func (geminiBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
+	geminiCmd := cfg.Cmd
+	if geminiCmd == "" {
+		geminiCmd = "gemini"
+	}
+	promptData, err := os.ReadFile(promptFile)
+	if err != nil {
+		return nil, "", fmt.Errorf("read prompt file: %w", err)
+	}
+	args := []string{"-p", string(promptData)}
+	args = append(args, cfg.ExtraArgs...)
+	cmd := exec.Command(geminiCmd, args...)
+	cmd.Dir = worktree
+	return cmd, "", nil
+}
+
+// --- Generic Backend ---
+
+// genericBackend handles arbitrary CLIs using the prompt_mode config field.
+// Supported prompt modes:
+//   - "arg" (default): pass prompt content as the last CLI argument
+//   - "stdin": redirect prompt file to stdin via the runner script
+//   - "file": pass prompt file path as the last CLI argument
+type genericBackend struct{}
+
+func (genericBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
+	binary := cfg.Cmd
+	if binary == "" {
+		return nil, "", fmt.Errorf("generic backend requires cmd to be set")
+	}
+
+	mode := cfg.PromptMode
+	if mode == "" {
+		mode = "arg"
+	}
+
+	var args []string
+	var stdinFile string
+
+	args = append(args, cfg.ExtraArgs...)
+
+	switch mode {
+	case "arg":
+		promptData, err := os.ReadFile(promptFile)
+		if err != nil {
+			return nil, "", fmt.Errorf("read prompt file: %w", err)
+		}
+		args = append(args, string(promptData))
+	case "stdin":
+		stdinFile = promptFile
+	case "file":
+		args = append(args, promptFile)
+	default:
+		return nil, "", fmt.Errorf("unknown prompt_mode %q (supported: arg, stdin, file)", mode)
+	}
+
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = worktree
+	return cmd, stdinFile, nil
 }
 
 // BuildWorkerCmd creates the right exec.Cmd based on backend name.
+// Known backends (claude, codex, gemini) use their specific command builders.
+// Unknown backends use the generic builder with prompt_mode from config.
 // Returns the command, an optional stdinFile path (for backends that read
 // the prompt via stdin, e.g. codex), and any error.
 func BuildWorkerCmd(backendName string, cfg BackendConfig, promptFile, worktree string) (cmd *exec.Cmd, stdinFile string, err error) {
-	switch backendName {
-	case "claude", "":
-		cmd, err = NewClaudeCmd(cfg, promptFile, worktree)
-		return cmd, "", err
-	case "codex":
-		cmd, err = NewCodexCmd(cfg, promptFile, worktree)
-		return cmd, promptFile, err
-	default:
-		return nil, "", fmt.Errorf("unknown backend: %s", backendName)
+	if backendName == "" {
+		backendName = "claude"
 	}
+
+	if b, ok := knownBackends[backendName]; ok {
+		return b.BuildCmd(cfg, promptFile, worktree)
+	}
+
+	// Fallback: use generic backend for unknown backends
+	return (genericBackend{}).BuildCmd(cfg, promptFile, worktree)
+}
+
+// KnownBackends returns a list of built-in backend names.
+func KnownBackends() []string {
+	names := make([]string, 0, len(knownBackends))
+	for name := range knownBackends {
+		names = append(names, name)
+	}
+	return names
 }

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -103,12 +103,218 @@ func TestBuildWorkerCmd_Codex(t *testing.T) {
 	}
 }
 
-func TestBuildWorkerCmd_Unknown(t *testing.T) {
-	_, _, err := BuildWorkerCmd("gemini", BackendConfig{}, "/tmp/prompt.md", "/tmp/wt")
-	if err == nil {
-		t.Fatal("expected error for unknown backend")
+func TestBuildWorkerCmd_Gemini(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("analyze this codebase"), 0644); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "unknown backend") {
-		t.Errorf("expected 'unknown backend' error, got: %v", err)
+	worktree := "/tmp/gemini-worktree"
+
+	cfg := BackendConfig{Cmd: "gemini-cli", ExtraArgs: []string{"--yolo"}}
+	cmd, stdinFile, err := BuildWorkerCmd("gemini", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stdinFile != "" {
+		t.Errorf("expected empty stdinFile for gemini, got: %s", stdinFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "-p") {
+		t.Errorf("expected -p flag in args, got: %s", args)
+	}
+	if !strings.Contains(args, "analyze this codebase") {
+		t.Errorf("expected prompt content in args, got: %s", args)
+	}
+	if !strings.Contains(args, "--yolo") {
+		t.Errorf("expected extra args in command, got: %s", args)
+	}
+	if cmd.Dir != worktree {
+		t.Errorf("expected Dir=%s, got %s", worktree, cmd.Dir)
+	}
+}
+
+func TestBuildWorkerCmd_GeminiDefaultCmd(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BackendConfig{}
+	cmd, _, err := BuildWorkerCmd("gemini", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should use "gemini" as default cmd when none specified
+	if !strings.HasSuffix(cmd.Path, "gemini") && !strings.Contains(cmd.Args[0], "gemini") {
+		t.Errorf("expected gemini command, got: %v", cmd.Args)
+	}
+}
+
+func TestBuildWorkerCmd_GenericArgMode(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("do custom task"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	worktree := "/tmp/custom-worktree"
+
+	cfg := BackendConfig{
+		Cmd:        "my-custom-cli",
+		ExtraArgs:  []string{"--flag1", "val1"},
+		PromptMode: "arg",
+	}
+	cmd, stdinFile, err := BuildWorkerCmd("my-custom-backend", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stdinFile != "" {
+		t.Errorf("expected empty stdinFile for arg mode, got: %s", stdinFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--flag1") {
+		t.Errorf("expected extra args in command, got: %s", args)
+	}
+	if !strings.Contains(args, "do custom task") {
+		t.Errorf("expected prompt content as last arg, got: %s", args)
+	}
+	if cmd.Dir != worktree {
+		t.Errorf("expected Dir=%s, got %s", worktree, cmd.Dir)
+	}
+}
+
+func TestBuildWorkerCmd_GenericStdinMode(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("stdin prompt"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	worktree := "/tmp/stdin-worktree"
+
+	cfg := BackendConfig{
+		Cmd:        "stdin-cli",
+		ExtraArgs:  []string{"--auto"},
+		PromptMode: "stdin",
+	}
+	cmd, stdinFile, err := BuildWorkerCmd("stdin-backend", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stdinFile != promptFile {
+		t.Errorf("expected stdinFile=%s, got %s", promptFile, stdinFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--auto") {
+		t.Errorf("expected extra args in command, got: %s", args)
+	}
+	// Prompt content should NOT be in args for stdin mode
+	if strings.Contains(args, "stdin prompt") {
+		t.Errorf("prompt content should not be in args for stdin mode, got: %s", args)
+	}
+	if cmd.Dir != worktree {
+		t.Errorf("expected Dir=%s, got %s", worktree, cmd.Dir)
+	}
+}
+
+func TestBuildWorkerCmd_GenericFileMode(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("file prompt"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	worktree := "/tmp/file-worktree"
+
+	cfg := BackendConfig{
+		Cmd:        "file-cli",
+		PromptMode: "file",
+	}
+	cmd, stdinFile, err := BuildWorkerCmd("file-backend", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stdinFile != "" {
+		t.Errorf("expected empty stdinFile for file mode, got: %s", stdinFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, promptFile) {
+		t.Errorf("expected prompt file path in args, got: %s", args)
+	}
+	// Prompt content should NOT be in args
+	if strings.Contains(args, "file prompt") {
+		t.Errorf("prompt content should not be in args for file mode, got: %s", args)
+	}
+	if cmd.Dir != worktree {
+		t.Errorf("expected Dir=%s, got %s", worktree, cmd.Dir)
+	}
+}
+
+func TestBuildWorkerCmd_GenericDefaultArgMode(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("default mode"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No PromptMode set — should default to "arg"
+	cfg := BackendConfig{Cmd: "some-cli"}
+	cmd, stdinFile, err := BuildWorkerCmd("unknown-backend", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stdinFile != "" {
+		t.Errorf("expected empty stdinFile for default arg mode, got: %s", stdinFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "default mode") {
+		t.Errorf("expected prompt content in args, got: %s", args)
+	}
+}
+
+func TestBuildWorkerCmd_GenericNoCmdError(t *testing.T) {
+	cfg := BackendConfig{} // no Cmd set
+	_, _, err := BuildWorkerCmd("no-cmd-backend", cfg, "/tmp/prompt.md", "/tmp/wt")
+	if err == nil {
+		t.Fatal("expected error for generic backend with no cmd")
+	}
+	if !strings.Contains(err.Error(), "requires cmd") {
+		t.Errorf("expected 'requires cmd' error, got: %v", err)
+	}
+}
+
+func TestBuildWorkerCmd_GenericInvalidPromptMode(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BackendConfig{Cmd: "some-cli", PromptMode: "invalid"}
+	_, _, err := BuildWorkerCmd("bad-mode-backend", cfg, promptFile, "/tmp/wt")
+	if err == nil {
+		t.Fatal("expected error for invalid prompt_mode")
+	}
+	if !strings.Contains(err.Error(), "unknown prompt_mode") {
+		t.Errorf("expected 'unknown prompt_mode' error, got: %v", err)
+	}
+}
+
+func TestKnownBackends(t *testing.T) {
+	backends := KnownBackends()
+	expected := map[string]bool{"claude": false, "codex": false, "gemini": false}
+	for _, name := range backends {
+		if _, ok := expected[name]; ok {
+			expected[name] = true
+		}
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("expected %q in KnownBackends(), got: %v", name, backends)
+		}
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -83,8 +83,9 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		}
 	}
 	backendCfg := BackendConfig{
-		Cmd:       backendDef.Cmd,
-		ExtraArgs: backendDef.ExtraArgs,
+		Cmd:        backendDef.Cmd,
+		ExtraArgs:  backendDef.ExtraArgs,
+		PromptMode: backendDef.PromptMode,
 	}
 
 	// Prepare log file


### PR DESCRIPTION
Implements #5

## Changes

- **Backend interface**: Introduced a `Backend` interface in `internal/worker/backend.go` that abstracts model CLI invocation. Each backend implements `BuildCmd(cfg, promptFile, worktree) → (cmd, stdinFile, err)`.

- **Refactored existing backends**: Claude and Codex backends now implement the `Backend` interface instead of being standalone functions with a hardcoded switch.

- **Gemini CLI backend**: Added native Gemini backend support. Passes prompt via `-p` flag, supports `extra_args` for flags like `--yolo`. Default binary: `gemini`.

- **Generic backend for arbitrary CLIs**: Unknown backend names now fall back to a generic backend instead of returning an error. The generic backend uses the `prompt_mode` config field to control how prompts are delivered:
  - `arg` (default): prompt content as the last CLI argument
  - `stdin`: redirect prompt file to stdin via runner script
  - `file`: prompt file path as the last CLI argument

- **Config enhancement**: Added `prompt_mode` field to `BackendDef` in config, enabling users to configure arbitrary CLIs without code changes:
  ```yaml
  model:
    default: my-custom-agent
    backends:
      my-custom-agent:
        cmd: /path/to/agent
        prompt_mode: stdin
        extra_args: ["--auto"]
  ```

- **PromptMode passthrough**: Updated `worker.go` to pass `PromptMode` from config through to the backend builder.

## Testing

- All existing Claude and Codex backend tests pass unchanged
- Added Gemini backend tests (with and without custom cmd)
- Added generic backend tests for all prompt modes (arg, stdin, file)
- Added error tests: missing cmd, invalid prompt_mode
- Added config parsing tests: model config defaults, explicit multi-backend config, prompt_mode field, claude_cmd backward compatibility
- `go fmt`, `go vet`, `go test ./...`, `go build` all pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a clean architecture refactoring that introduces a `Backend` interface for model CLI invocation, adds native Gemini support, and enables arbitrary CLI backends through a generic fallback mechanism with configurable prompt delivery modes.

**Key changes:**
- Introduced `Backend` interface with `BuildCmd` method to abstract CLI command construction
- Refactored Claude and Codex backends to implement the new interface
- Added Gemini backend with `-p` flag prompt delivery
- Implemented generic backend fallback that supports three prompt modes: `arg` (prompt as CLI argument), `stdin` (prompt via stdin redirection), and `file` (prompt file path as argument)
- Added `prompt_mode` config field to `BackendDef` enabling users to configure arbitrary CLIs without code changes
- Maintained backward compatibility with existing `claude_cmd` config field

**Testing:**
- All existing tests pass unchanged
- Comprehensive new test coverage for Gemini backend and all generic backend prompt modes
- Tests include error cases (missing cmd, invalid prompt_mode)
- Config parsing tests verify defaults and explicit configuration

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The implementation is well-architected with clean interface design, comprehensive test coverage including edge cases and error scenarios, proper shell argument escaping via `shellJoin`, backward compatibility preservation, and no security vulnerabilities detected
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Added `PromptMode` field to `BackendDef` struct to support configurable prompt delivery modes for generic backends |
| internal/worker/backend.go | Introduced `Backend` interface, refactored existing backends (Claude, Codex) to implement it, added Gemini backend and generic backend with configurable prompt modes |
| internal/worker/worker.go | Updated worker initialization to pass `PromptMode` from config to `BackendConfig`, enabling prompt mode support for backends |

</details>



<sub>Last reviewed commit: 5e5a97d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->