### PR TITLE
feat: retry logic — respawn dead workers once before giving up (#4)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -189,8 +189,8 @@ func statusCmd(args []string) {
 	sort.Strings(names)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "SESSION\tISSUE\tSTATUS\tPID\tALIVE\tAGE\tTITLE")
-	fmt.Fprintln(w, "-------\t-----\t------\t---\t-----\t---\t-----")
+	fmt.Fprintln(w, "SESSION\tISSUE\tSTATUS\tPID\tALIVE\tAGE\tRETRIES\tTITLE")
+	fmt.Fprintln(w, "-------\t-----\t------\t---\t-----\t---\t-------\t-----")
 	for _, name := range names {
 		sess := s.Sessions[name]
 		alive := "-"
@@ -202,8 +202,12 @@ func statusCmd(args []string) {
 			}
 		}
 		age := time.Since(sess.StartedAt).Round(time.Minute)
-		fmt.Fprintf(w, "%s\t#%d\t%s\t%d\t%s\t%s\t%s\n",
-			name, sess.IssueNumber, sess.Status, sess.PID, alive, age, truncate(sess.IssueTitle, 50))
+		retries := "-"
+		if sess.RetryCount > 0 {
+			retries = fmt.Sprintf("%d", sess.RetryCount)
+		}
+		fmt.Fprintf(w, "%s\t#%d\t%s\t%d\t%s\t%s\t%s\t%s\n",
+			name, sess.IssueNumber, sess.Status, sess.PID, alive, age, retries, truncate(sess.IssueTitle, 50))
 	}
 	w.Flush()
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -86,6 +86,21 @@ func (c *Client) listOpenIssuesByLabel(label string) ([]Issue, error) {
 	return issues, nil
 }
 
+// GetIssue fetches a single issue by number
+func (c *Client) GetIssue(number int) (Issue, error) {
+	out, err := exec.Command("gh", "issue", "view", fmt.Sprint(number),
+		"--repo", c.Repo,
+		"--json", "number,title,body,labels").Output()
+	if err != nil {
+		return Issue{}, fmt.Errorf("gh issue view %d: %w", number, err)
+	}
+	var issue Issue
+	if err := json.Unmarshal(out, &issue); err != nil {
+		return Issue{}, fmt.Errorf("parse issue %d: %w", number, err)
+	}
+	return issue, nil
+}
+
 // IsIssueClosed returns true if the issue is closed
 func (c *Client) IsIssueClosed(number int) (bool, error) {
 	out, err := exec.Command("gh", "issue", "view", fmt.Sprint(number),

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -200,13 +200,43 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					sess.PRNumber = pr.Number
 					o.notifier.Sendf("🔀 maestro: worker %s completed, PR #%d open for issue #%d (%s)",
 						slotName, pr.Number, sess.IssueNumber, sess.IssueTitle)
+				} else if sess.RetryCount < 1 {
+					// First failure — retry with fresh worktree
+					log.Printf("[orch] worker %s (pid=%d) died, retrying (attempt %d)", slotName, sess.PID, sess.RetryCount+1)
+					sess.RetryCount++
+
+					issue, err := o.gh.GetIssue(sess.IssueNumber)
+					if err != nil {
+						log.Printf("[orch] fetch issue #%d for retry: %v — marking as failed", sess.IssueNumber, err)
+						sess.Status = state.StatusFailed
+						now := time.Now().UTC()
+						sess.FinishedAt = &now
+						o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) died and retry failed (could not fetch issue)",
+							slotName, sess.IssueNumber, sess.IssueTitle)
+						continue
+					}
+
+					promptBase := o.selectPrompt(issue)
+					if err := worker.Respawn(o.cfg, slotName, sess, o.repo, issue, promptBase, sess.Backend); err != nil {
+						log.Printf("[orch] respawn worker %s: %v — marking as failed", slotName, err)
+						sess.Status = state.StatusFailed
+						now := time.Now().UTC()
+						sess.FinishedAt = &now
+						o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) died and respawn failed: %v",
+							slotName, sess.IssueNumber, sess.IssueTitle, err)
+						continue
+					}
+
+					o.notifier.Sendf("🔄 maestro: retrying worker %s for issue #%d: %s (attempt %d)",
+						slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount)
 				} else {
-					log.Printf("[orch] worker %s (pid=%d) is dead", slotName, sess.PID)
-					sess.Status = state.StatusDead
+					// Already retried — mark as permanently failed
+					log.Printf("[orch] worker %s (pid=%d) permanently failed after %d retries", slotName, sess.PID, sess.RetryCount)
+					sess.Status = state.StatusFailed
 					now := time.Now().UTC()
 					sess.FinishedAt = &now
-					o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) process died.\nCheck log: %s",
-						slotName, sess.IssueNumber, sess.IssueTitle, sess.LogFile)
+					o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) permanently failed after %d retry.\nCheck log: %s",
+						slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, sess.LogFile)
 				}
 				continue
 			}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -33,6 +33,7 @@ type Session struct {
 	Backend        string        `json:"backend,omitempty"` // "claude", "codex", etc.
 	LongRunning    bool          `json:"long_running,omitempty"`
 	NotifiedCIFail bool          `json:"notified_ci_fail,omitempty"`
+	RetryCount     int           `json:"retry_count,omitempty"`
 }
 
 type State struct {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -124,6 +124,114 @@ func TestNotifiedCIFail_BackwardCompatibility(t *testing.T) {
 	}
 }
 
+func TestRetryCount_Persistence(t *testing.T) {
+	dir := t.TempDir()
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber: 42,
+		Branch:      "feat/test",
+		Status:      StatusRunning,
+		StartedAt:   time.Now().UTC(),
+		RetryCount:  1,
+	}
+	s.Sessions["slot-2"] = &Session{
+		IssueNumber: 43,
+		Branch:      "feat/other",
+		Status:      StatusRunning,
+		StartedAt:   time.Now().UTC(),
+		RetryCount:  0,
+	}
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	sess1 := loaded.Sessions["slot-1"]
+	if sess1 == nil {
+		t.Fatal("slot-1 not found after load")
+	}
+	if sess1.RetryCount != 1 {
+		t.Errorf("slot-1: RetryCount = %d, want 1", sess1.RetryCount)
+	}
+
+	sess2 := loaded.Sessions["slot-2"]
+	if sess2 == nil {
+		t.Fatal("slot-2 not found after load")
+	}
+	if sess2.RetryCount != 0 {
+		t.Errorf("slot-2: RetryCount = %d, want 0", sess2.RetryCount)
+	}
+}
+
+func TestRetryCount_OmittedWhenZero(t *testing.T) {
+	dir := t.TempDir()
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber: 42,
+		Branch:      "feat/test",
+		Status:      StatusRunning,
+		StartedAt:   time.Now().UTC(),
+		RetryCount:  0,
+	}
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	json := string(data)
+	if containsString(json, "retry_count") {
+		t.Error("retry_count should be omitted from JSON when zero")
+	}
+}
+
+func TestRetryCount_BackwardCompatibility(t *testing.T) {
+	dir := t.TempDir()
+
+	// State file without retry_count (simulating old state)
+	oldJSON := `{
+  "sessions": {
+    "slot-1": {
+      "issue_number": 42,
+      "branch": "feat/test",
+      "status": "running",
+      "started_at": "2025-01-01T00:00:00Z"
+    }
+  },
+  "next_slot": 2
+}`
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(oldJSON), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	sess := loaded.Sessions["slot-1"]
+	if sess == nil {
+		t.Fatal("slot-1 not found")
+	}
+	if sess.RetryCount != 0 {
+		t.Errorf("RetryCount should default to 0 for old state files, got %d", sess.RetryCount)
+	}
+}
+
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -152,6 +152,114 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 	return slotName, nil
 }
 
+// Respawn cleans up a dead worker and restarts it in the same slot with a fresh worktree.
+// The session is updated in place with new PID, worktree, branch, and timestamps.
+func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+	// Clean up old worker (tmux session, process, worktree)
+	Stop(cfg, slotName, sess)
+
+	// Delete old local branch (ignore errors — branch may not exist locally)
+	exec.Command("git", "-C", cfg.LocalPath, "branch", "-D", sess.Branch).CombinedOutput()
+
+	// Create fresh worktree with new branch
+	worktreePath := filepath.Join(cfg.WorktreeBase, slotName)
+	branchName := fmt.Sprintf("feat/%s-%d-%s", slotName, issue.Number, slugify(issue.Title))
+
+	log.Printf("[worker] respawn: creating worktree %s on branch %s", worktreePath, branchName)
+	out, err := exec.Command("git", "-C", cfg.LocalPath,
+		"worktree", "add", worktreePath, "-b", branchName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree add: %w\n%s", err, out)
+	}
+
+	// Assemble worker prompt
+	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
+
+	// Write prompt to file
+	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
+	if err := os.WriteFile(promptFile, []byte(prompt), 0644); err != nil {
+		return fmt.Errorf("write prompt file: %w", err)
+	}
+
+	// Determine backend
+	if backendName == "" {
+		backendName = cfg.Model.Default
+	}
+	backendDef, ok := cfg.Model.Backends[backendName]
+	if !ok {
+		backendName = cfg.Model.Default
+		backendDef, ok = cfg.Model.Backends[backendName]
+		if !ok {
+			return fmt.Errorf("backend %q (default) not found in config", backendName)
+		}
+	}
+	backendCfg := BackendConfig{
+		Cmd:        backendDef.Cmd,
+		ExtraArgs:  backendDef.ExtraArgs,
+		PromptMode: backendDef.PromptMode,
+	}
+
+	// Prepare log file
+	logDir := state.LogDir(cfg.StateDir)
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	logFile := filepath.Join(logDir, slotName+".log")
+
+	// Build the worker command
+	workerCmd, stdinFile, err := BuildWorkerCmd(backendName, backendCfg, promptFile, worktreePath)
+	if err != nil {
+		return fmt.Errorf("build worker cmd: %w", err)
+	}
+
+	// Write runner script
+	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
+	var runnerContent string
+	if stdinFile != "" {
+		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s < %q 2>&1 | tee -a %q\n",
+			shellJoin(workerCmd.Args), stdinFile, logFile)
+	} else {
+		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s 2>&1 | tee -a %q\n",
+			shellJoin(workerCmd.Args), logFile)
+	}
+	if err := os.WriteFile(runnerPath, []byte(runnerContent), 0755); err != nil {
+		return fmt.Errorf("write runner script: %w", err)
+	}
+
+	// Start tmux session
+	tmuxName := TmuxSessionName(slotName)
+	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", worktreePath, "bash", runnerPath)
+	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
+	}
+
+	// Get PID
+	pidOut, err := exec.Command("tmux", "list-panes", "-t", tmuxName, "-F", "#{pane_pid}").Output()
+	if err != nil {
+		return fmt.Errorf("tmux list-panes: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidOut)))
+	if err != nil {
+		return fmt.Errorf("parse pane pid: %w", err)
+	}
+
+	log.Printf("[worker] respawned %s in tmux session %s (pane_pid=%d, log=%s)", slotName, tmuxName, pid, logFile)
+
+	// Update session in place
+	sess.Worktree = worktreePath
+	sess.Branch = branchName
+	sess.PID = pid
+	sess.LogFile = logFile
+	sess.StartedAt = time.Now().UTC()
+	sess.FinishedAt = nil
+	sess.Status = state.StatusRunning
+	sess.PRNumber = 0
+	sess.Backend = backendName
+	sess.NotifiedCIFail = false
+
+	return nil
+}
+
 // Stop kills a worker and removes its worktree
 func Stop(cfg *config.Config, slotName string, sess *state.Session) error {
 	// Try to kill the tmux session first (covers tmux-spawned workers)


### PR DESCRIPTION
Implements #4

## Changes

When a worker dies without opening a PR, maestro now retries once with a fresh worktree before marking it as permanently failed:

- **State**: Added `RetryCount int` field to `Session` (JSON-persisted with `omitempty`, backward compatible with existing state files)
- **GitHub client**: Added `GetIssue()` method to fetch issue details needed for retry prompt assembly
- **Worker**: Added `Respawn()` function that cleans up the dead worker (tmux, worktree, branch) and starts a fresh one in the same slot
- **Orchestrator**: Modified `checkSessions()` dead-worker detection:
  - `RetryCount < 1`: clean up, increment retry count, respawn with fresh worktree, notify with 🔄
  - `RetryCount >= 1`: mark as `StatusFailed` (not `StatusDead`), send permanent failure notification with 💀
  - If retry fails (can't fetch issue or respawn errors): mark as `StatusFailed` immediately
- **Status display**: Added `RETRIES` column to `maestro status` output (shows `-` when 0, count when > 0)

## Testing

- Added `TestRetryCount_Persistence` — verifies RetryCount survives save/load cycle
- Added `TestRetryCount_OmittedWhenZero` — verifies `retry_count` omitted from JSON when 0
- Added `TestRetryCount_BackwardCompatibility` — verifies old state files without `retry_count` load correctly
- All existing tests pass (`go test ./...`)
- Build verified (`go build ./cmd/maestro/ && ./maestro version`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements automatic retry logic for dead workers by respawning them once with a fresh worktree before marking as permanently failed.

**Key changes:**
- Added `RetryCount` field to session state with backward-compatible JSON serialization (`omitempty`)
- New `GetIssue()` method in GitHub client to fetch issue details for retry
- New `Respawn()` function cleans up dead worker (tmux, worktree, branch) and starts fresh in same slot
- Orchestrator detects dead workers: retries once (RetryCount < 1), then marks as failed (RetryCount >= 1)
- Status display includes new RETRIES column showing retry count
- Comprehensive test coverage for state persistence and backward compatibility

**Notes:**
- Log files append on retry (using `tee -a`), so original failure and retry logs are in same file
- Notification message has minor grammar issue: "1 retry" should be "1 retries" for consistency

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - well-tested feature addition with good error handling
- Score reflects solid implementation with comprehensive tests, backward compatibility, and proper error handling. Minor deduction for the log file append behavior (which could make logs harder to parse) and a small grammar inconsistency in notification messages
- No files require special attention - implementation is clean across all changes

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/state/state.go | Added `RetryCount int` field with `omitempty` for backward compatibility - clean implementation |
| internal/worker/worker.go | Added `Respawn()` function that cleans up dead worker and creates fresh worktree - log files append on retry which could cause confusion |
| internal/orchestrator/orchestrator.go | Implemented retry logic in `checkSessions()` - retries once before permanent failure, handles edge cases well but notification message has minor grammar issue |

</details>



<sub>Last reviewed commit: 31b0fd4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->