### PR TITLE
feat: notification dedup and digest mode (#45)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type TelegramConfig struct {
 	Target      string `yaml:"target"`
 	BotToken    string `yaml:"bot_token"`
 	OpenclawURL string `yaml:"openclaw_url"`
+	DigestMode  bool   `yaml:"digest_mode"` // batch notifications per cycle instead of sending immediately
 }
 
 // BackendDef defines a model backend CLI.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -439,3 +439,30 @@ model:
 		t.Errorf("explicit model.backends.claude.cmd should take precedence, got %q", claude.Cmd)
 	}
 }
+
+func TestParse_DigestModeDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Telegram.DigestMode {
+		t.Error("DigestMode should default to false")
+	}
+}
+
+func TestParse_DigestModeExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+telegram:
+  target: "12345"
+  digest_mode: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.Telegram.DigestMode {
+		t.Error("DigestMode should be true when explicitly set")
+	}
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -13,6 +15,10 @@ type Notifier struct {
 	BotToken    string
 	Target      string
 	OpenclawURL string
+
+	mu         sync.Mutex
+	digestMode bool
+	buffer     []string
 }
 
 func New(openclawURL, target string) *Notifier {
@@ -23,10 +29,63 @@ func NewWithToken(botToken, target, openclawURL string) *Notifier {
 	return &Notifier{BotToken: botToken, Target: target, OpenclawURL: openclawURL}
 }
 
+// SetDigestMode enables or disables digest mode.
+// In digest mode, messages are buffered and sent as a single combined
+// message when Flush() is called.
+func (n *Notifier) SetDigestMode(enabled bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.digestMode = enabled
+}
+
+// Flush sends all buffered messages as a single combined message.
+// No-op if buffer is empty or digest mode is off.
+func (n *Notifier) Flush() error {
+	n.mu.Lock()
+	msgs := n.buffer
+	n.buffer = nil
+	n.mu.Unlock()
+
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	combined := "📋 *maestro digest:*\n\n" + strings.Join(msgs, "\n\n")
+	if err := n.send(combined); err != nil {
+		log.Printf("[notify] digest flush failed: %v", err)
+		return err
+	}
+	return nil
+}
+
+// Buffered returns the number of buffered messages (for testing).
+func (n *Notifier) Buffered() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.buffer)
+}
+
 func (n *Notifier) Send(msg string) error {
 	if n.Target == "" {
 		return nil
 	}
+
+	n.mu.Lock()
+	digest := n.digestMode
+	n.mu.Unlock()
+
+	if digest {
+		n.mu.Lock()
+		n.buffer = append(n.buffer, msg)
+		n.mu.Unlock()
+		log.Printf("[notify] buffered (digest mode): %s", msg)
+		return nil
+	}
+
+	return n.send(msg)
+}
+
+func (n *Notifier) send(msg string) error {
 	if n.BotToken != "" {
 		return n.sendTelegram(msg)
 	}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,90 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDigestMode_BuffersMessages(t *testing.T) {
+	n := &Notifier{Target: "test-chat", OpenclawURL: "http://fake:1234"}
+	n.SetDigestMode(true)
+
+	// Send should buffer, not send
+	if err := n.Send("msg1"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if err := n.Send("msg2"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if n.Buffered() != 2 {
+		t.Errorf("Buffered() = %d, want 2", n.Buffered())
+	}
+}
+
+func TestDigestMode_Off_SendsImmediately(t *testing.T) {
+	n := &Notifier{Target: "test-chat"}
+	// No digest mode, no transport — should just log and return nil
+	if err := n.Send("msg1"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if n.Buffered() != 0 {
+		t.Errorf("Buffered() = %d, want 0 (not buffered when digest off)", n.Buffered())
+	}
+}
+
+func TestDigestMode_FlushClearsBuffer(t *testing.T) {
+	n := &Notifier{Target: "test-chat"} // no transport — send will log-skip
+	n.SetDigestMode(true)
+
+	n.Send("msg1")
+	n.Send("msg2")
+
+	if n.Buffered() != 2 {
+		t.Fatalf("Buffered() = %d, want 2", n.Buffered())
+	}
+
+	// Flush — will fail to send (no transport) but should clear buffer
+	n.Flush()
+
+	if n.Buffered() != 0 {
+		t.Errorf("Buffered() = %d after Flush, want 0", n.Buffered())
+	}
+}
+
+func TestDigestMode_FlushEmptyBuffer(t *testing.T) {
+	n := &Notifier{Target: "test-chat"}
+	n.SetDigestMode(true)
+
+	// Flush with no messages should be a no-op
+	if err := n.Flush(); err != nil {
+		t.Errorf("Flush with empty buffer should not error, got: %v", err)
+	}
+}
+
+func TestSendf_FormatsMessage(t *testing.T) {
+	n := &Notifier{Target: "test-chat"} // no transport, will log-skip
+	n.SetDigestMode(true)
+
+	n.Sendf("hello %s #%d", "world", 42)
+
+	if n.Buffered() != 1 {
+		t.Fatalf("Buffered() = %d, want 1", n.Buffered())
+	}
+
+	// Verify the formatted message is in the buffer
+	n.mu.Lock()
+	msg := n.buffer[0]
+	n.mu.Unlock()
+
+	if !strings.Contains(msg, "hello world #42") {
+		t.Errorf("buffer[0] = %q, want it to contain 'hello world #42'", msg)
+	}
+}
+
+func TestSend_EmptyTarget_Skips(t *testing.T) {
+	n := &Notifier{} // no target
+	if err := n.Send("msg"); err != nil {
+		t.Errorf("Send with empty target should return nil, got: %v", err)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -30,9 +30,14 @@ type Orchestrator struct {
 
 // New creates a new Orchestrator
 func New(cfg *config.Config) *Orchestrator {
+	n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.OpenclawURL)
+	if cfg.Telegram.DigestMode {
+		n.SetDigestMode(true)
+		log.Printf("[orch] digest mode enabled — notifications will be batched per cycle")
+	}
 	return &Orchestrator{
 		cfg:      cfg,
-		notifier: notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.OpenclawURL),
+		notifier: n,
 		gh:       github.New(cfg.Repo),
 		router:   router.New(cfg),
 		repo:     cfg.Repo,
@@ -126,6 +131,11 @@ func (o *Orchestrator) RunOnce() error {
 		if err := state.Save(o.cfg.StateDir, s); err != nil {
 			return fmt.Errorf("save state after workers: %w", err)
 		}
+	}
+
+	// Flush digest buffer (no-op if digest mode is off or buffer is empty)
+	if err := o.notifier.Flush(); err != nil {
+		log.Printf("[orch] digest flush: %v", err)
 	}
 
 	log.Printf("[orch] === cycle done ===")
@@ -314,13 +324,18 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 
 		switch ciStatus {
 		case "success":
-			// Reset CI failure notification flag when CI goes green
-			sess.NotifiedCIFail = false
+			// Reset notification status when CI goes green
+			sess.LastNotifiedStatus = ""
+			sess.NotifiedCIFail = false // backward compat
 
 			log.Printf("[orch] merging PR #%d (branch %s)", pr.Number, sess.Branch)
 			if err := o.gh.MergePR(pr.Number); err != nil {
 				log.Printf("[orch] merge PR #%d: %v", pr.Number, err)
-				o.notifier.Sendf("❌ maestro: failed to merge PR #%d (%s): %v", pr.Number, sess.Branch, err)
+				// Only notify merge failure once per PR
+				if sess.LastNotifiedStatus != "merge_failed" {
+					o.notifier.Sendf("❌ maestro: failed to merge PR #%d (%s): %v", pr.Number, sess.Branch, err)
+					sess.LastNotifiedStatus = "merge_failed"
+				}
 			} else {
 				log.Printf("[orch] merged PR #%d ✓", pr.Number)
 				if err := o.gh.CloseIssue(sess.IssueNumber, fmt.Sprintf("Implemented by PR #%d (auto-merged by maestro).", pr.Number)); err != nil {
@@ -343,9 +358,11 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				}
 			}
 		case "failure":
-			if !sess.NotifiedCIFail {
+			// Only notify CI failure once — dedup via LastNotifiedStatus
+			if sess.LastNotifiedStatus != "ci_failure" {
 				o.notifier.Sendf("❌ maestro: CI failing for PR #%d (%s, issue #%d)", pr.Number, sess.Branch, sess.IssueNumber)
-				sess.NotifiedCIFail = true
+				sess.LastNotifiedStatus = "ci_failure"
+				sess.NotifiedCIFail = true // backward compat
 			}
 		}
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -20,20 +20,21 @@ const (
 )
 
 type Session struct {
-	IssueNumber    int           `json:"issue_number"`
-	IssueTitle     string        `json:"issue_title"`
-	Worktree       string        `json:"worktree"`
-	Branch         string        `json:"branch"`
-	PID            int           `json:"pid"`
-	LogFile        string        `json:"log_file"`
-	StartedAt      time.Time     `json:"started_at"`
-	FinishedAt     *time.Time    `json:"finished_at,omitempty"`
-	Status         SessionStatus `json:"status"`
-	PRNumber       int           `json:"pr_number,omitempty"`
-	Backend        string        `json:"backend,omitempty"` // "claude", "codex", etc.
-	LongRunning    bool          `json:"long_running,omitempty"`
-	NotifiedCIFail bool          `json:"notified_ci_fail,omitempty"`
-	RetryCount     int           `json:"retry_count,omitempty"`
+	IssueNumber        int           `json:"issue_number"`
+	IssueTitle         string        `json:"issue_title"`
+	Worktree           string        `json:"worktree"`
+	Branch             string        `json:"branch"`
+	PID                int           `json:"pid"`
+	LogFile            string        `json:"log_file"`
+	StartedAt          time.Time     `json:"started_at"`
+	FinishedAt         *time.Time    `json:"finished_at,omitempty"`
+	Status             SessionStatus `json:"status"`
+	PRNumber           int           `json:"pr_number,omitempty"`
+	Backend            string        `json:"backend,omitempty"` // "claude", "codex", etc.
+	LongRunning        bool          `json:"long_running,omitempty"`
+	NotifiedCIFail     bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
+	LastNotifiedStatus string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
+	RetryCount         int           `json:"retry_count,omitempty"`
 }
 
 type State struct {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -232,6 +232,121 @@ func TestRetryCount_BackwardCompatibility(t *testing.T) {
 	}
 }
 
+func TestLastNotifiedStatus_Persistence(t *testing.T) {
+	dir := t.TempDir()
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber:        42,
+		Branch:             "feat/test",
+		Status:             StatusPROpen,
+		PRNumber:           10,
+		StartedAt:          time.Now().UTC(),
+		LastNotifiedStatus: "ci_failure",
+	}
+	s.Sessions["slot-2"] = &Session{
+		IssueNumber: 43,
+		Branch:      "feat/other",
+		Status:      StatusPROpen,
+		PRNumber:    11,
+		StartedAt:   time.Now().UTC(),
+	}
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	sess1 := loaded.Sessions["slot-1"]
+	if sess1 == nil {
+		t.Fatal("slot-1 not found after load")
+	}
+	if sess1.LastNotifiedStatus != "ci_failure" {
+		t.Errorf("slot-1: LastNotifiedStatus = %q, want %q", sess1.LastNotifiedStatus, "ci_failure")
+	}
+
+	sess2 := loaded.Sessions["slot-2"]
+	if sess2 == nil {
+		t.Fatal("slot-2 not found after load")
+	}
+	if sess2.LastNotifiedStatus != "" {
+		t.Errorf("slot-2: LastNotifiedStatus = %q, want empty", sess2.LastNotifiedStatus)
+	}
+}
+
+func TestLastNotifiedStatus_OmittedWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber: 42,
+		Branch:      "feat/test",
+		Status:      StatusPROpen,
+		PRNumber:    10,
+		StartedAt:   time.Now().UTC(),
+	}
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	json := string(data)
+	if containsString(json, "last_notified_status") {
+		t.Error("last_notified_status should be omitted from JSON when empty")
+	}
+}
+
+func TestLastNotifiedStatus_BackwardCompatibility(t *testing.T) {
+	dir := t.TempDir()
+
+	// State file without last_notified_status (simulating old state)
+	oldJSON := `{
+  "sessions": {
+    "slot-1": {
+      "issue_number": 42,
+      "branch": "feat/test",
+      "status": "pr_open",
+      "pr_number": 10,
+      "started_at": "2025-01-01T00:00:00Z",
+      "notified_ci_fail": true
+    }
+  },
+  "next_slot": 2
+}`
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(oldJSON), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	sess := loaded.Sessions["slot-1"]
+	if sess == nil {
+		t.Fatal("slot-1 not found")
+	}
+	if sess.LastNotifiedStatus != "" {
+		t.Errorf("LastNotifiedStatus should default to empty for old state files, got %q", sess.LastNotifiedStatus)
+	}
+	// Old NotifiedCIFail should still load correctly
+	if !sess.NotifiedCIFail {
+		t.Error("NotifiedCIFail should still load from old state files")
+	}
+}
+
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -256,6 +256,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	sess.PRNumber = 0
 	sess.Backend = backendName
 	sess.NotifiedCIFail = false
+	sess.LastNotifiedStatus = ""
 
 	return nil
 }


### PR DESCRIPTION
Implements #45

## Changes

**Notification dedup via `LastNotifiedStatus`:**
- Added `last_notified_status` string field to Session state (replaces simple `NotifiedCIFail` boolean for general-purpose dedup)
- CI failure notifications: only sent once per PR (deduped when `LastNotifiedStatus == "ci_failure"`)
- Merge failure notifications: only sent once per PR (deduped when `LastNotifiedStatus == "merge_failed"`)
- Status resets to empty when CI goes green, allowing future failure notifications
- Old `NotifiedCIFail` field kept for backward compatibility with existing state.json files

**Digest mode:**
- New `digest_mode: true` config option under `telegram:` section
- When enabled, notifications are buffered during each orchestration cycle and sent as a single combined message via `Flush()` at the end of `RunOnce()`
- Thread-safe buffering with mutex protection
- No-op when digest mode is off or buffer is empty

**Files changed:**
- `internal/state/state.go` — Added `LastNotifiedStatus` field to Session
- `internal/notify/notify.go` — Added digest mode (buffer, `SetDigestMode()`, `Flush()`, `Buffered()`)
- `internal/config/config.go` — Added `DigestMode` to `TelegramConfig`
- `internal/orchestrator/orchestrator.go` — Updated dedup logic, added digest flush at end of cycle
- `internal/worker/worker.go` — Clear `LastNotifiedStatus` on respawn

## Testing
- Added `TestLastNotifiedStatus_Persistence` — verifies save/load roundtrip
- Added `TestLastNotifiedStatus_OmittedWhenEmpty` — verifies omitempty behavior
- Added `TestLastNotifiedStatus_BackwardCompatibility` — verifies old state.json loads correctly
- Added `TestDigestMode_BuffersMessages` — verifies messages are buffered
- Added `TestDigestMode_Off_SendsImmediately` — verifies no buffering when off
- Added `TestDigestMode_FlushClearsBuffer` — verifies flush empties buffer
- Added `TestDigestMode_FlushEmptyBuffer` — verifies no-op on empty
- Added `TestParse_DigestModeDefault` / `TestParse_DigestModeExplicit` — config tests
- All existing tests pass (`go test ./...`)
- `go vet ./...` clean, `go fmt ./...` clean, binary builds successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements notification deduplication and digest mode for the maestro orchestrator.

**Key changes:**
- Replaced boolean `NotifiedCIFail` with general-purpose `LastNotifiedStatus` string field for tracking notification state
- CI failure and merge failure notifications now deduplicated per PR using status tracking
- Added digest mode to batch notifications per orchestration cycle
- All changes maintain backward compatibility with existing state files

**Implementation quality:**
- Comprehensive test coverage for all new features
- Proper thread-safety with mutex protection in digest mode
- Clean separation of concerns between notification buffering and sending

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor race condition fix recommended
- Implementation is well-designed with excellent test coverage and backward compatibility. One race condition exists in `notify.go` `Send()` method that should be addressed, though unlikely to cause issues in practice given single-threaded orchestrator usage
- internal/notify/notify.go - fix race condition in `Send()` method

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/notify/notify.go | Added digest mode with thread-safe buffering and flush functionality - implementation looks solid with minor race condition in `Send` method |
| internal/state/state.go | Added `LastNotifiedStatus` field to replace boolean `NotifiedCIFail` - clean backward-compatible change with proper `omitempty` tag |
| internal/orchestrator/orchestrator.go | Updated dedup logic to use `LastNotifiedStatus`, added digest flush at cycle end - proper notification dedup for both CI failures and merge failures |

</details>



<sub>Last reviewed commit: bb49c50</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->