### PR TITLE
feat: deploy hooks — run command after PR merge (#1)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	StateDir          string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model             ModelConfig      `yaml:"model"`
 	Routing           RoutingConfig    `yaml:"routing"`
+	DeployCmd         string           `yaml:"deploy_cmd"` // shell command to run after successful PR merge
 	Telegram          TelegramConfig   `yaml:"telegram"`
 	Versioning        VersioningConfig `yaml:"versioning"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -524,3 +524,29 @@ func TestLoadDir_SkipsSubdirectories(t *testing.T) {
 		t.Fatalf("expected 1 config, got %d", len(cfgs))
 	}
 }
+
+func TestParse_DeployCmdEmpty(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.DeployCmd != "" {
+		t.Errorf("DeployCmd = %q, want empty", cfg.DeployCmd)
+	}
+}
+
+func TestParse_DeployCmdExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+deploy_cmd: "go build ./cmd/app/ && systemctl --user restart app"
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := "go build ./cmd/app/ && systemctl --user restart app"
+	if cfg.DeployCmd != want {
+		t.Errorf("DeployCmd = %q, want %q", cfg.DeployCmd, want)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -363,6 +364,16 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 						o.notifier.Sendf("🏷️ maestro: version bumped after PR #%d merge", pr.Number)
 					}
 				}
+
+				// Deploy hook
+				if o.cfg.DeployCmd != "" {
+					if err := o.runDeployCmd(pr.Number); err != nil {
+						log.Printf("[orch] deploy command failed for PR #%d: %v", pr.Number, err)
+						o.notifier.Sendf("⚠️ maestro: deploy failed after PR #%d merge: %v", pr.Number, err)
+					} else {
+						o.notifier.Sendf("🚀 maestro: deploy succeeded after PR #%d merge", pr.Number)
+					}
+				}
 			}
 		case "failure":
 			// Only notify CI failure once — dedup via LastNotifiedStatus
@@ -373,6 +384,28 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			}
 		}
 	}
+}
+
+// runDeployCmd executes the configured deploy command with a 5-minute timeout.
+func (o *Orchestrator) runDeployCmd(prNumber int) error {
+	log.Printf("[orch] running deploy command after PR #%d merge: %s", prNumber, o.cfg.DeployCmd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", "-c", o.cfg.DeployCmd)
+	cmd.Dir = o.cfg.LocalPath
+	out, err := cmd.CombinedOutput()
+	if len(out) > 0 {
+		log.Printf("[orch] deploy output:\n%s", out)
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("deploy command timed out after 5 minutes")
+	}
+	if err != nil {
+		return fmt.Errorf("deploy command failed: %w\n%s", err, out)
+	}
+	return nil
 }
 
 // rebaseConflicts finds PRs with conflicts and rebases them

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,10 +1,12 @@
 package orchestrator
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
 )
 
 func makeIssue(number int, title string, labels ...string) github.Issue {
@@ -118,5 +120,55 @@ func TestSelectPrompt_CaseInsensitiveLabel(t *testing.T) {
 	got := o.selectPrompt(makeIssue(8, "Fix crash", "Bug"))
 	if got != "bug prompt" {
 		t.Errorf("selectPrompt() = %q, want %q (label matching should be case-insensitive)", got, "bug prompt")
+	}
+}
+
+func TestRunDeployCmd_Success(t *testing.T) {
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:      "owner/repo",
+			LocalPath: "/tmp",
+			DeployCmd: "echo deploy-ok",
+		},
+		notifier: &notify.Notifier{},
+	}
+	if err := o.runDeployCmd(42); err != nil {
+		t.Errorf("runDeployCmd() unexpected error: %v", err)
+	}
+}
+
+func TestRunDeployCmd_Failure(t *testing.T) {
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:      "owner/repo",
+			LocalPath: "/tmp",
+			DeployCmd: "exit 1",
+		},
+		notifier: &notify.Notifier{},
+	}
+	err := o.runDeployCmd(42)
+	if err == nil {
+		t.Fatal("runDeployCmd() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "deploy command failed") {
+		t.Errorf("error = %q, want it to contain 'deploy command failed'", err.Error())
+	}
+}
+
+func TestRunDeployCmd_CapturesOutput(t *testing.T) {
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:      "owner/repo",
+			LocalPath: "/tmp",
+			DeployCmd: "echo hello-deploy && exit 1",
+		},
+		notifier: &notify.Notifier{},
+	}
+	err := o.runDeployCmd(42)
+	if err == nil {
+		t.Fatal("runDeployCmd() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "hello-deploy") {
+		t.Errorf("error = %q, want it to contain command output 'hello-deploy'", err.Error())
 	}
 }


### PR DESCRIPTION
Implements #1

## Changes
- Added `deploy_cmd` string field to `Config` struct (`internal/config/config.go`)
- After successful PR merge in `autoMergePRs`, if `deploy_cmd` is configured, run it via `exec.Command("bash", "-c", deployCcmd)` with a 5-minute timeout
- The deploy command runs with `LocalPath` as working directory
- Logs stdout/stderr output, sends Telegram notification on success/failure
- Deploy failure does not affect merge status (merge is already complete)

## Testing
- Added `TestParse_DeployCmdEmpty` — verifies deploy_cmd defaults to empty string
- Added `TestParse_DeployCmdExplicit` — verifies deploy_cmd is parsed from YAML
- Added `TestRunDeployCmd_Success` — verifies successful command execution
- Added `TestRunDeployCmd_Failure` — verifies error handling on command failure
- Added `TestRunDeployCmd_CapturesOutput` — verifies stdout/stderr is included in error
- All existing tests pass (`go test ./...`)
- Binary builds successfully (`go build ./cmd/maestro/`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds post-merge deploy hook functionality, allowing automatic command execution after successful PR merges. The implementation is well-structured with proper testing coverage.

**Key Changes:**
- Added `deploy_cmd` configuration field to enable custom post-merge commands
- Commands execute in the repo's `LocalPath` with a 5-minute timeout
- Telegram notifications sent for deploy success/failure
- Deploy failures don't affect merge status (merge is already complete)
- Tests verify parsing, execution, failure handling, and output capture

**Issues Found:**
- Timeout detection logic may not work as intended (line 402-404) — the context error should be checked before returning other errors

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing the timeout detection logic
- The implementation is solid with good test coverage, proper error handling, and sensible design choices. The timeout check has a logic issue that should be corrected, but it's a minor bug that doesn't affect core functionality. Deploy failures are appropriately handled as non-blocking.
- Fix the timeout detection logic in `internal/orchestrator/orchestrator.go:402-404`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Implements deploy hook execution after PR merge with timeout and error handling; has minor timeout check logic issue |

</details>



<sub>Last reviewed commit: fc9c696</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->