### PR TITLE
feat: GitHub Releases — automated release workflow with binaries (#53)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,23 +8,31 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${{ github.ref_name }}" --generate-notes --draft
+
+  build:
     name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
-    runs-on: ${{ matrix.os }}
+    needs: create-release
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            goos: linux
+          - goos: linux
             goarch: amd64
-          - os: ubuntu-latest
-            goos: linux
+          - goos: linux
             goarch: arm64
-          - os: macos-latest
-            goos: darwin
+          - goos: darwin
             goarch: amd64
-          - os: macos-latest
-            goos: darwin
+          - goos: darwin
             goarch: arm64
     steps:
       - uses: actions/checkout@v4
@@ -40,14 +48,40 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '0'
-        run: go build -trimpath -o maestro-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/maestro/
-
-      - name: Create release if needed
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${{ github.ref_name }}" --generate-notes || true
+        run: |
+          go build -trimpath \
+            -ldflags "-s -w -X main.version=${{ github.ref_name }}" \
+            -o maestro-${{ matrix.goos }}-${{ matrix.goarch }} \
+            ./cmd/maestro/
 
       - name: Upload binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" maestro-${{ matrix.goos }}-${{ matrix.goarch }} --clobber
+        run: gh release upload "${{ github.ref_name }}" maestro-${{ matrix.goos }}-${{ matrix.goarch }}
+
+  publish:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist
+          cd dist
+          gh release download "${{ github.ref_name }}" --pattern 'maestro-*'
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum maestro-* > checksums.txt
+
+      - name: Upload checksums and publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" dist/checksums.txt
+          gh release edit "${{ github.ref_name }}" --draft=false

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -83,6 +83,9 @@ Watch:
   maestro watch             Open tmux dashboard attached to live worker sessions
 `
 
+// version is set at build time via -ldflags "-X main.version=vX.Y.Z".
+var version = "dev"
+
 // multiFlag accumulates repeated --config flag values.
 type multiFlag []string
 
@@ -128,7 +131,7 @@ func main() {
 	case "version-bump":
 		versionBumpCmd(args)
 	case "version":
-		fmt.Println("maestro v0.1.0")
+		fmt.Printf("maestro %s\n", version)
 	case "help", "--help", "-h":
 		fmt.Print(usage)
 	default:


### PR DESCRIPTION
Implements #53

## Changes
- **Build-time version injection**: Added `version` variable to `main.go` set via `-ldflags "-X main.version=..."` so release binaries report the correct git tag (e.g. `maestro v1.2.0`) instead of hardcoded `v0.1.0`. Local builds show `maestro dev`.
- **Three-job release workflow**: Split the release workflow into sequential jobs to eliminate the race condition where all 4 matrix builds tried to create the release simultaneously:
  1. `create-release` — creates a **draft** GitHub Release with auto-generated changelog
  2. `build` — cross-compiles 4 binaries (linux/darwin × amd64/arm64) with `CGO_ENABLED=0` and uploads them
  3. `publish` — generates `checksums.txt` (SHA256) and publishes the release
- **SHA256 checksums**: Every release now includes a `checksums.txt` file for binary verification
- **Smaller binaries**: Added `-s -w` ldflags to strip debug symbols
- **All builds on ubuntu-latest**: Removed macOS runners since cross-compilation with `CGO_ENABLED=0` works from Linux

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all tests pass
- `go build ./cmd/maestro/ && ./maestro version` — prints `maestro dev` (expected for local build)
- Verified ldflags injection: `go build -ldflags "-X main.version=v1.2.3" ./cmd/maestro/ && ./maestro version` prints `maestro v1.2.3`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements automated GitHub Releases with proper version management. The workflow was refactored into three sequential jobs to eliminate race conditions where multiple build matrix jobs tried to create releases simultaneously. The `create-release` job now creates a draft release first, the `build` job compiles binaries for all platforms and uploads them, and the `publish` job generates SHA256 checksums and publishes the release.

Key improvements:
- Build-time version injection using `-ldflags "-X main.version=..."` so binaries report the correct version
- Sequential job execution (`needs` dependencies) prevents race conditions
- Draft release workflow ensures all artifacts are uploaded before publishing
- SHA256 checksums file for binary verification
- Smaller binaries via `-s -w` ldflags to strip debug symbols
- Cross-compilation from Linux eliminates need for macOS runners

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The changes are well-structured and address a specific issue (race condition in release creation). The workflow refactoring uses proper GitHub Actions patterns with job dependencies, the ldflags version injection is standard Go practice, and the changes have been thoroughly tested according to the PR description. All modifications are isolated to release infrastructure without affecting runtime logic.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Improved release workflow with sequential jobs (create-release, build, publish) to prevent race conditions, added version injection via ldflags, SHA256 checksums, and draft-to-publish flow |
| cmd/maestro/main.go | Added version variable for build-time injection via ldflags, replaced hardcoded version string with dynamic version variable |

</details>



<sub>Last reviewed commit: 091a2f1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->