### PR TITLE
feat: maestro watch — rich status display per worker pane (#59)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/versioning"
+	"github.com/befeast/maestro/internal/watch"
 	"github.com/befeast/maestro/internal/worker"
 )
 
@@ -130,6 +131,8 @@ func main() {
 		historyCmd(args)
 	case "version-bump":
 		versionBumpCmd(args)
+	case "_watch-updater":
+		watchUpdaterCmd(args)
 	case "version":
 		fmt.Printf("maestro %s\n", version)
 	case "help", "--help", "-h":
@@ -458,11 +461,8 @@ func logsCmd(args []string) {
 // watchPaneCmd builds a shell command for a watch pane.
 // If the worker's tmux session is alive, attach read-only for live output.
 // When the session ends (or is already gone), show the log file.
-func watchPaneCmd(w struct {
-	name string
-	sess *state.Session
-}) string {
-	tmuxName := worker.TmuxSessionName(w.name)
+func watchPaneCmd(name string, sess *state.Session) string {
+	tmuxName := worker.TmuxSessionName(name)
 	// Shell script that:
 	// 1. If worker tmux session exists → attach read-only (env -u TMUX to allow nesting)
 	// 2. After attach exits (worker done) or if session gone → show log tail
@@ -478,7 +478,7 @@ func watchPaneCmd(w struct {
 			`echo 'No log file found.'; `+
 			`fi; `+
 			`echo; echo 'Press any key to exit...'; read -n1`,
-		tmuxName, tmuxName, w.sess.LogFile, w.name, w.sess.LogFile)
+		tmuxName, tmuxName, sess.LogFile, name, sess.LogFile)
 }
 
 func watchCmd(args []string) {
@@ -491,8 +491,9 @@ func watchCmd(args []string) {
 
 	// Collect active running sessions across all projects
 	type activeWorker struct {
-		name string
-		sess *state.Session
+		name     string
+		sess     *state.Session
+		stateDir string
 	}
 	var workers []activeWorker
 	for _, cfg := range cfgs {
@@ -503,7 +504,7 @@ func watchCmd(args []string) {
 		}
 		for name, sess := range s.Sessions {
 			if sess.Status == state.StatusRunning && worker.IsAlive(sess.PID) {
-				workers = append(workers, activeWorker{name, sess})
+				workers = append(workers, activeWorker{name, sess, cfg.StateDir})
 			}
 		}
 	}
@@ -523,34 +524,70 @@ func watchCmd(args []string) {
 	// Kill stale session if exists
 	exec.Command("tmux", "kill-session", "-t", tmuxSession).Run()
 
+	// Build pane mappings for the background status updater
+	var paneMappings []watch.PaneMapping
+
 	// Create new session with first worker — attach to its tmux session
-	firstCmd := watchPaneCmd(workers[0])
+	firstCmd := watchPaneCmd(workers[0].name, workers[0].sess)
 	if out, err := exec.Command("tmux", "new-session", "-d", "-s", tmuxSession, "bash", "-c", firstCmd).CombinedOutput(); err != nil {
 		log.Fatalf("tmux new-session: %v\n%s", err, out)
 	}
 
-	// Set pane title for first pane
-	paneTitle := fmt.Sprintf("%s #%d", workers[0].name, workers[0].sess.IssueNumber)
+	// Set rich pane title for first pane
+	paneTitle := watch.FormatPaneTitle(workers[0].name, workers[0].sess)
 	exec.Command("tmux", "select-pane", "-t", tmuxSession+":0.0", "-T", paneTitle).Run()
+	paneMappings = append(paneMappings, watch.PaneMapping{
+		PaneIndex: 0,
+		SlotName:  workers[0].name,
+		StateDir:  workers[0].stateDir,
+	})
 
 	// Split for each additional worker
 	for i := 1; i < len(workers); i++ {
-		paneCmd := watchPaneCmd(workers[i])
+		paneCmd := watchPaneCmd(workers[i].name, workers[i].sess)
 		if out, err := exec.Command("tmux", "split-window", "-t", tmuxSession, "bash", "-c", paneCmd).CombinedOutput(); err != nil {
 			log.Printf("tmux split-window for %s: %v\n%s", workers[i].name, err, out)
 			continue
 		}
-		// Set pane title
-		paneTitle := fmt.Sprintf("%s #%d", workers[i].name, workers[i].sess.IssueNumber)
+		// Set rich pane title
+		paneTitle := watch.FormatPaneTitle(workers[i].name, workers[i].sess)
 		exec.Command("tmux", "select-pane", "-t", tmuxSession, "-T", paneTitle).Run()
+
+		paneMappings = append(paneMappings, watch.PaneMapping{
+			PaneIndex: i,
+			SlotName:  workers[i].name,
+			StateDir:  workers[i].stateDir,
+		})
 
 		// Re-tile after each split to keep things balanced
 		exec.Command("tmux", "select-layout", "-t", tmuxSession, "tiled").Run()
 	}
 
-	// Enable pane titles display
+	// Enable pane titles display with rich border format
 	exec.Command("tmux", "set-option", "-t", tmuxSession, "pane-border-status", "top").Run()
-	exec.Command("tmux", "set-option", "-t", tmuxSession, "pane-border-format", " #{pane_title} ").Run()
+	exec.Command("tmux", "set-option", "-t", tmuxSession, "pane-border-format",
+		"#[fg=white,bold] #{pane_title}").Run()
+
+	// Write pane mapping and start background updater to keep titles fresh
+	if err := watch.WritePaneMap(watch.PaneMapFile, paneMappings); err != nil {
+		log.Printf("[watch] warn: write pane map: %v (titles won't auto-refresh)", err)
+	} else {
+		selfBin, _ := os.Executable()
+		if selfBin == "" {
+			selfBin = os.Args[0]
+		}
+		updaterArgs := []string{selfBin, "_watch-updater"}
+		for _, c := range configs {
+			updaterArgs = append(updaterArgs, "--config", c)
+		}
+		updater := exec.Command(updaterArgs[0], updaterArgs[1:]...)
+		updater.Stdout = nil
+		updater.Stderr = nil
+		if err := updater.Start(); err != nil {
+			log.Printf("[watch] warn: start updater: %v (titles won't auto-refresh)", err)
+		}
+		// Detach — the updater will exit when the watch session dies
+	}
 
 	// Attach — replaces current process
 	tmuxPath, err := exec.LookPath("tmux")
@@ -559,6 +596,16 @@ func watchCmd(args []string) {
 	}
 	syscall.Exec(tmuxPath, []string{"tmux", "attach", "-t", tmuxSession}, os.Environ())
 	log.Fatalf("exec tmux attach: should not reach here")
+}
+
+func watchUpdaterCmd(args []string) {
+	fs := flag.NewFlagSet("_watch-updater", flag.ExitOnError)
+	var configs multiFlag
+	fs.Var(&configs, "config", "Path to config file (can be repeated)")
+	fs.Parse(args)
+
+	// The updater runs as a background daemon, refreshing pane titles every 3 seconds
+	watch.RunUpdater(watch.PaneMapFile, 3*time.Second)
 }
 
 func spawnCmd(args []string) {

--- a/internal/watch/status.go
+++ b/internal/watch/status.go
@@ -1,0 +1,76 @@
+package watch
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b\(B`)
+
+// FormatPaneTitle creates a rich status line for a watch pane border.
+// Format: " slot │ #num title │ backend │ elapsed │ status "
+func FormatPaneTitle(slotName string, sess *state.Session) string {
+	elapsed := FormatElapsed(time.Since(sess.StartedAt))
+	title := TruncateTitle(sess.IssueTitle, 40)
+	backend := sess.Backend
+	if backend == "" {
+		backend = "?"
+	}
+	return fmt.Sprintf(" %s │ #%d %s │ %s │ %s │ %s ",
+		slotName, sess.IssueNumber, title, backend, elapsed, sess.Status)
+}
+
+// FormatElapsed formats a duration as a compact human-readable string.
+func FormatElapsed(d time.Duration) string {
+	d = d.Truncate(time.Second)
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh%02dm%02ds", h, m, s)
+	}
+	return fmt.Sprintf("%dm%02ds", m, s)
+}
+
+// TruncateTitle truncates a string to maxLen runes, appending "…" if truncated.
+func TruncateTitle(s string, maxLen int) string {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}
+
+// StripANSI removes ANSI escape sequences from a string.
+func StripANSI(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
+
+// CleanOutputLine strips ANSI codes, trims whitespace, and filters spinner frames.
+// Returns empty string for lines that are just spinners or whitespace.
+func CleanOutputLine(s string) string {
+	s = StripANSI(s)
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+
+	// Filter common spinner characters and progress dots
+	spinnerPatterns := []string{
+		"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
+		"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷",
+		"◐", "◓", "◑", "◒",
+		".", "..", "...",
+	}
+	for _, sp := range spinnerPatterns {
+		if s == sp {
+			return ""
+		}
+	}
+
+	return s
+}

--- a/internal/watch/status_test.go
+++ b/internal/watch/status_test.go
@@ -1,0 +1,156 @@
+package watch
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestFormatPaneTitle(t *testing.T) {
+	sess := &state.Session{
+		IssueNumber: 59,
+		IssueTitle:  "feat: rich status display",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-15*time.Minute - 23*time.Second),
+		Status:      state.StatusRunning,
+	}
+
+	title := FormatPaneTitle("pan-1", sess)
+
+	checks := []string{"pan-1", "#59", "feat: rich status display", "claude", "running"}
+	for _, want := range checks {
+		if !strings.Contains(title, want) {
+			t.Errorf("title %q should contain %q", title, want)
+		}
+	}
+
+	if !strings.Contains(title, "15m") {
+		t.Errorf("title %q should contain elapsed time ~15m", title)
+	}
+}
+
+func TestFormatPaneTitle_EmptyBackend(t *testing.T) {
+	sess := &state.Session{
+		IssueNumber: 10,
+		IssueTitle:  "test",
+		Backend:     "",
+		StartedAt:   time.Now(),
+		Status:      state.StatusRunning,
+	}
+
+	title := FormatPaneTitle("pan-1", sess)
+	if !strings.Contains(title, "?") {
+		t.Errorf("title %q should show '?' for empty backend", title)
+	}
+}
+
+func TestFormatElapsed(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "0m00s"},
+		{30 * time.Second, "0m30s"},
+		{5*time.Minute + 10*time.Second, "5m10s"},
+		{1*time.Hour + 2*time.Minute + 3*time.Second, "1h02m03s"},
+		{10*time.Hour + 0*time.Minute + 5*time.Second, "10h00m05s"},
+	}
+	for _, tt := range tests {
+		got := FormatElapsed(tt.d)
+		if got != tt.want {
+			t.Errorf("FormatElapsed(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestTruncateTitle(t *testing.T) {
+	tests := []struct {
+		s      string
+		maxLen int
+		want   string
+	}{
+		{"short", 10, "short"},
+		{"exactly ten", 11, "exactly ten"},
+		{"this is a long title", 10, "this is a…"},
+	}
+	for _, tt := range tests {
+		got := TruncateTitle(tt.s, tt.maxLen)
+		if got != tt.want {
+			t.Errorf("TruncateTitle(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+func TestStripANSI(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello", "hello"},
+		{"\x1b[31mred\x1b[0m", "red"},
+		{"\x1b[1;32mbold green\x1b[0m", "bold green"},
+		{"\x1b]0;title\x07content", "content"},
+		{"no\x1b(Bansi", "noansi"},
+	}
+	for _, tt := range tests {
+		got := StripANSI(tt.input)
+		if got != tt.want {
+			t.Errorf("StripANSI(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestCleanOutputLine(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"hello world", "hello world"},
+		{"\x1b[31mcolored text\x1b[0m", "colored text"},
+		{"⠋", ""},
+		{"⣾", ""},
+		{"...", ""},
+		{".", ""},
+		{"Building project...", "Building project..."},
+	}
+	for _, tt := range tests {
+		got := CleanOutputLine(tt.input)
+		if got != tt.want {
+			t.Errorf("CleanOutputLine(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestPaneMappingRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "panes.json")
+
+	mappings := []PaneMapping{
+		{PaneIndex: 0, SlotName: "pan-1", StateDir: "/tmp/state1"},
+		{PaneIndex: 1, SlotName: "pan-2", StateDir: "/tmp/state2"},
+	}
+
+	if err := WritePaneMap(path, mappings); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	loaded, err := ReadPaneMap(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if len(loaded) != 2 {
+		t.Fatalf("expected 2 mappings, got %d", len(loaded))
+	}
+	if loaded[0].SlotName != "pan-1" || loaded[0].PaneIndex != 0 {
+		t.Errorf("first mapping: got %+v", loaded[0])
+	}
+	if loaded[1].SlotName != "pan-2" || loaded[1].PaneIndex != 1 {
+		t.Errorf("second mapping: got %+v", loaded[1])
+	}
+}

--- a/internal/watch/updater.go
+++ b/internal/watch/updater.go
@@ -1,0 +1,128 @@
+package watch
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+const WatchSession = "maestro-watch"
+
+// PaneMapFile is the default path for the pane mapping file.
+// Only one watch session exists at a time, so a fixed path is safe.
+const PaneMapFile = "/tmp/maestro-watch-panes.json"
+
+// PaneMapping maps a tmux pane index to a worker slot and its state directory.
+type PaneMapping struct {
+	PaneIndex int    `json:"pane_index"`
+	SlotName  string `json:"slot_name"`
+	StateDir  string `json:"state_dir"`
+}
+
+// WritePaneMap writes pane mappings to a JSON file.
+func WritePaneMap(path string, mappings []PaneMapping) error {
+	data, err := json.Marshal(mappings)
+	if err != nil {
+		return fmt.Errorf("marshal pane map: %w", err)
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// ReadPaneMap reads pane mappings from a JSON file.
+func ReadPaneMap(path string) ([]PaneMapping, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read pane map: %w", err)
+	}
+	var mappings []PaneMapping
+	if err := json.Unmarshal(data, &mappings); err != nil {
+		return nil, fmt.Errorf("parse pane map: %w", err)
+	}
+	return mappings, nil
+}
+
+// RunUpdater periodically updates pane titles in the watch session.
+// It exits when the watch session no longer exists.
+func RunUpdater(mapFile string, interval time.Duration) {
+	mappings, err := ReadPaneMap(mapFile)
+	if err != nil {
+		log.Fatalf("[watch-updater] %v", err)
+	}
+
+	log.Printf("[watch-updater] started with %d panes, interval=%s", len(mappings), interval)
+
+	for {
+		if !sessionExists(WatchSession) {
+			log.Printf("[watch-updater] watch session gone, exiting")
+			os.Remove(mapFile)
+			return
+		}
+
+		// Load state files (deduplicate by state dir)
+		stateCache := make(map[string]map[string]*state.Session)
+		for _, m := range mappings {
+			if _, ok := stateCache[m.StateDir]; ok {
+				continue
+			}
+			s, err := state.Load(m.StateDir)
+			if err != nil {
+				log.Printf("[watch-updater] load state %s: %v", m.StateDir, err)
+				continue
+			}
+			stateCache[m.StateDir] = s.Sessions
+		}
+
+		for _, m := range mappings {
+			sessions, ok := stateCache[m.StateDir]
+			if !ok {
+				continue
+			}
+			sess, ok := sessions[m.SlotName]
+			if !ok {
+				continue
+			}
+
+			title := FormatPaneTitle(m.SlotName, sess)
+
+			// Best-effort: capture last meaningful output line from the pane
+			if lastLine := captureLastLine(m.PaneIndex); lastLine != "" {
+				if len(lastLine) > 60 {
+					lastLine = lastLine[:57] + "..."
+				}
+				title += "│ " + lastLine + " "
+			}
+
+			paneTarget := fmt.Sprintf("%s:0.%d", WatchSession, m.PaneIndex)
+			exec.Command("tmux", "select-pane", "-t", paneTarget, "-T", title).Run()
+		}
+
+		time.Sleep(interval)
+	}
+}
+
+// sessionExists checks whether a tmux session exists.
+func sessionExists(name string) bool {
+	return exec.Command("tmux", "has-session", "-t", name).Run() == nil
+}
+
+// captureLastLine gets the last non-empty, non-spinner line from a watch pane.
+func captureLastLine(paneIndex int) string {
+	paneTarget := fmt.Sprintf("%s:0.%d", WatchSession, paneIndex)
+	out, err := exec.Command("tmux", "capture-pane", "-t", paneTarget, "-p", "-l", "5").Output()
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(string(out), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if cleaned := CleanOutputLine(lines[i]); cleaned != "" {
+			return cleaned
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Implements #59

## Changes

Replace minimal pane titles (`pan-1 #59`) with rich, auto-refreshing status bars showing:

- **Worker slot + issue number + title** — e.g. `pan-1 │ #59 feat: rich status display`
- **Backend model** — `claude`, `codex`, `cline`, `gemini`, etc.
- **Elapsed time** — auto-updating every 3 seconds (`15m23s`, `1h02m03s`)
- **Session status** — `running`, `pr_open`, `done`, `failed`, etc.
- **Last meaningful output line** — captured from tmux pane with ANSI stripping and spinner filtering

### Architecture

- **New `internal/watch/` package** with:
  - `status.go` — pane title formatting, ANSI escape stripping, spinner detection, duration formatting
  - `updater.go` — background updater loop that reads state files and refreshes tmux pane titles via `select-pane -T`
  - `status_test.go` — unit tests for formatting, ANSI stripping, line cleaning, pane map round-trip

- **Background status updater** — `maestro _watch-updater` hidden subcommand launched as a background process when `maestro watch` starts. It:
  - Reads pane-to-slot mappings from `/tmp/maestro-watch-panes.json`
  - Loads state files every 3 seconds
  - Updates each pane's title with live elapsed time and current status
  - Captures the last meaningful output line from each pane (best-effort)
  - Exits automatically when the `maestro-watch` tmux session dies

- **Enhanced `watchCmd`** — tracks state directory per worker, writes pane mapping file, sets rich initial titles, launches updater before `exec tmux attach`

### Pane border format

```
 pan-1 │ #59 feat: rich status display │ claude │ 15m23s │ running │ Building project...
```

## Testing

- All existing tests pass (`go test ./...`)
- New tests cover: `FormatPaneTitle`, `FormatElapsed`, `TruncateTitle`, `StripANSI`, `CleanOutputLine`, `PaneMapping` round-trip
- `go vet ./...` clean
- Binary builds and runs: `./maestro version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements rich, auto-refreshing status displays for the `maestro watch` command's tmux pane borders. The changes introduce a new `internal/watch/` package with formatting utilities and a background updater daemon.

**Key changes:**
- Created `internal/watch/status.go` with utilities for formatting pane titles, stripping ANSI codes, and cleaning output lines
- Created `internal/watch/updater.go` with a background daemon (`RunUpdater`) that refreshes tmux pane titles every 3 seconds by reading state files and capturing live output
- Added `_watch-updater` hidden subcommand to `cmd/maestro/main.go` that launches the background updater
- Refactored `watchPaneCmd` to accept separate parameters instead of a struct
- Enhanced `watchCmd` to build pane mappings, write them to `/tmp/maestro-watch-panes.json`, and launch the updater as a detached background process
- Added comprehensive unit tests in `internal/watch/status_test.go`

**Implementation:**
- Pane titles show: slot name, issue number/title, backend model, elapsed time, status, and last meaningful output line
- The updater auto-exits when the watch session dies and cleans up the mapping file
- Error handling is graceful with warnings logged when updater fails to start

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor consideration about orphaned background processes
- The implementation is well-structured with good error handling and comprehensive tests. The background updater has proper cleanup logic that exits when the watch session dies. However, there's a small edge case where the updater process could become orphaned if the parent process crashes before exec-ing tmux. This is mitigated by the updater's self-termination logic but worth noting.
- No files require special attention - all changes are straightforward and well-tested

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Added watch updater integration, refactored watchPaneCmd signature, launches background updater process with proper cleanup |
| internal/watch/status.go | New file with formatting utilities for pane titles, ANSI stripping, and output line cleaning |
| internal/watch/updater.go | Background updater daemon that refreshes tmux pane titles every 3s, exits when watch session dies |
| internal/watch/status_test.go | Comprehensive test coverage for all formatting functions and pane mapping serialization |

</details>



<sub>Last reviewed commit: a5a4cef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->