### PR TITLE
fix: empty issue_labels should mean all issues, not default to enhancement (#61)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,10 +128,8 @@ func parse(data []byte) (*Config, error) {
 			cfg.IssueLabels = append(cfg.IssueLabels, cfg.IssueLabel)
 		}
 	}
-	// Default to "enhancement" if neither field is set
-	if len(cfg.IssueLabels) == 0 {
-		cfg.IssueLabels = []string{"enhancement"}
-	}
+	// If no labels configured, IssueLabels stays nil — meaning no label filter
+	// (all open issues will be fetched).
 
 	// Expand ~ in paths
 	cfg.LocalPath = expandHome(cfg.LocalPath)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,7 +43,7 @@ issue_label: bug
 	}
 }
 
-func TestParse_IssueLabelsDefault(t *testing.T) {
+func TestParse_IssueLabelsDefault_Empty(t *testing.T) {
 	yaml := `
 repo: owner/repo
 `
@@ -51,8 +51,22 @@ repo: owner/repo
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if len(cfg.IssueLabels) != 1 || cfg.IssueLabels[0] != "enhancement" {
-		t.Errorf("IssueLabels = %v, want [enhancement]", cfg.IssueLabels)
+	if len(cfg.IssueLabels) != 0 {
+		t.Errorf("IssueLabels = %v, want empty (no label filter)", cfg.IssueLabels)
+	}
+}
+
+func TestParse_IssueLabelsExplicitEmpty(t *testing.T) {
+	yaml := `
+repo: owner/repo
+issue_labels: []
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(cfg.IssueLabels) != 0 {
+		t.Errorf("IssueLabels = %v, want empty (no label filter)", cfg.IssueLabels)
 	}
 }
 


### PR DESCRIPTION
Implements #61

## Changes
- Removed the default to `["enhancement"]` in `config.go` when both `issue_label` and `issue_labels` are empty
- When no labels are configured, `IssueLabels` stays nil/empty, causing `ListOpenIssues` to call `gh issue list` without any `--label` flag — returning all open issues
- Updated existing test `TestParse_IssueLabelsDefault` to expect empty slice instead of `["enhancement"]`
- Added `TestParse_IssueLabelsExplicitEmpty` to verify `issue_labels: []` also means no filter

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass
- `go build ./cmd/maestro/` — binary builds successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the hardcoded default to `["enhancement"]` when no issue labels are configured. When `issue_labels` and `issue_label` are both unset (or explicitly set to an empty array), the system now fetches all open issues instead of filtering by "enhancement".

- Removed 4 lines from `parse()` function that set default `IssueLabels = ["enhancement"]`
- Updated comment to clarify that empty/nil `IssueLabels` means no label filter
- Renamed test `TestParse_IssueLabelsDefault` to `TestParse_IssueLabelsDefault_Empty` and updated expectation from `["enhancement"]` to empty slice
- Added new test `TestParse_IssueLabelsExplicitEmpty` to verify `issue_labels: []` also results in no filter

The change correctly integrates with `internal/github/github.go:ListOpenIssues()` which already handles empty label slices by omitting the `--label` flag from `gh issue list`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues identified
- The change is straightforward, well-tested, and fixes the intended behavior. Removed code that defaulted to `["enhancement"]` and updated corresponding tests. The downstream code in `github.go:ListOpenIssues()` already handles empty label arrays correctly by omitting the `--label` flag. All tests pass according to PR description.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Removed default `["enhancement"]` fallback; empty `IssueLabels` now means no filter (all issues) |
| internal/config/config_test.go | Updated test expectations and added test for explicit empty array case |

</details>



<sub>Last reviewed commit: e13fc21</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->