### PR TITLE
feat: show PR number and CI status in maestro status (#11)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -310,9 +310,33 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 	}
 	sort.Strings(names)
 
+	// Fetch CI status for pr_open sessions
+	gh := github.New(cfg.Repo)
+	ciStatuses := make(map[string]string) // session name → CI display string
+	for _, name := range names {
+		sess := s.Sessions[name]
+		if sess.Status == state.StatusPROpen && sess.PRNumber > 0 {
+			ciStatus, err := gh.PRCIStatus(sess.PRNumber)
+			if err != nil {
+				ciStatuses[name] = "?"
+			} else {
+				switch ciStatus {
+				case "success":
+					ciStatuses[name] = "✅ pass"
+				case "failure":
+					ciStatuses[name] = "❌ fail"
+				case "pending":
+					ciStatuses[name] = "⏳ pending"
+				default:
+					ciStatuses[name] = "?"
+				}
+			}
+		}
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "SESSION\tISSUE\tSTATUS\tPID\tALIVE\tAGE\tRETRIES\tTITLE")
-	fmt.Fprintln(w, "-------\t-----\t------\t---\t-----\t---\t-------\t-----")
+	fmt.Fprintln(w, "SESSION\tISSUE\tSTATUS\tPR\tCI\tPID\tALIVE\tAGE\tRETRIES\tTITLE")
+	fmt.Fprintln(w, "-------\t-----\t------\t--\t--\t---\t-----\t---\t-------\t-----")
 	for _, name := range names {
 		sess := s.Sessions[name]
 		alive := "-"
@@ -328,8 +352,16 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 		if sess.RetryCount > 0 {
 			retries = fmt.Sprintf("%d", sess.RetryCount)
 		}
-		fmt.Fprintf(w, "%s\t#%d\t%s\t%d\t%s\t%s\t%s\t%s\n",
-			name, sess.IssueNumber, sess.Status, sess.PID, alive, age, retries, truncate(sess.IssueTitle, 50))
+		pr := "-"
+		if sess.PRNumber > 0 {
+			pr = fmt.Sprintf("#%d", sess.PRNumber)
+		}
+		ci := "-"
+		if cs, ok := ciStatuses[name]; ok {
+			ci = cs
+		}
+		fmt.Fprintf(w, "%s\t#%d\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
+			name, sess.IssueNumber, sess.Status, pr, ci, sess.PID, alive, age, retries, truncate(sess.IssueTitle, 50))
 	}
 	w.Flush()
 


### PR DESCRIPTION
Implements #11

## Changes
- Added **PR** and **CI** columns to `maestro status` table output
- For sessions with `pr_open` status and a stored PR number, fetches CI check results via `gh pr checks`
- Maps CI status to visual indicators: ✅ pass, ❌ fail, ⏳ pending
- Non-PR sessions show `-` for both columns

### Example output
```
SESSION  ISSUE  STATUS   PR    CI         PID  ALIVE  AGE  RETRIES  TITLE
mae-1    #5     pr_open  #12   ✅ pass    0    -      45m  -        fix: some issue
mae-2    #3     running  -     -          1234 yes    12m  -        feat: new feature
```

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all tests pass
- `go build ./cmd/maestro/` — binary builds successfully
- `./maestro version` — runs correctly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added **PR** and **CI** columns to `maestro status` table to improve visibility of pull request status and CI check results.

Key changes:
- Fetches CI status via `gh pr checks` for sessions in `pr_open` status with valid PR numbers
- Maps CI results to visual indicators: ✅ pass, ❌ fail, ⏳ pending, ? for unknown/errors
- Non-PR sessions display `-` for both columns
- CI status only fetched for `pr_open` sessions to avoid unnecessary API calls for completed or running sessions

The implementation is clean and follows existing patterns in the codebase. Testing confirms the build and tests pass successfully.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are localized to the status display functionality with no modifications to core logic or data structures. The implementation properly handles errors by displaying `?` for unknown/failed CI checks, follows existing code patterns, and includes proper null checks (`sess.PRNumber > 0`). All tests pass and the code is well-structured.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Added PR and CI columns to status table output with CI status fetching via gh pr checks for pr_open sessions |

</details>



<sub>Last reviewed commit: 9379f3a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->