### PR TITLE
fix: filter spinner dots from watch pane via log tailing (#66)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -133,6 +133,8 @@ func main() {
 		versionBumpCmd(args)
 	case "_watch-updater":
 		watchUpdaterCmd(args)
+	case "_watch-tail":
+		watchTailCmd(args)
 	case "version":
 		fmt.Printf("maestro %s\n", version)
 	case "help", "--help", "-h":
@@ -491,26 +493,15 @@ func logsCmd(args []string) {
 }
 
 // watchPaneCmd builds a shell command for a watch pane.
-// If the worker's tmux session is alive, attach read-only for live output.
-// When the session ends (or is already gone), show the log file.
-func watchPaneCmd(name string, sess *state.Session) string {
+// It tails the worker's log file with spinner/dot filtering via _watch-tail,
+// then shows an exit prompt when the worker finishes.
+func watchPaneCmd(selfBin string, name string, sess *state.Session) string {
 	tmuxName := worker.TmuxSessionName(name)
-	// Shell script that:
-	// 1. If worker tmux session exists → attach read-only (env -u TMUX to allow nesting)
-	// 2. After attach exits (worker done) or if session gone → show log tail
 	return fmt.Sprintf(
-		`if tmux has-session -t %q 2>/dev/null; then `+
-			`env -u TMUX tmux attach-session -t %q -r; `+
-			`echo; echo '=== Worker session ended ==='; echo; `+
-			`fi; `+
-			`if [ -f %q ]; then `+
-			`echo '--- Log output (%s) ---'; `+
-			`tail -100 %q; `+
-			`else `+
-			`echo 'No log file found.'; `+
-			`fi; `+
+		`%s _watch-tail %q %q; `+
+			`echo; echo '=== Worker session ended ==='; `+
 			`echo; echo 'Press any key to exit...'; read -n1`,
-		tmuxName, tmuxName, sess.LogFile, name, sess.LogFile)
+		selfBin, sess.LogFile, tmuxName)
 }
 
 func watchCmd(args []string) {
@@ -556,11 +547,17 @@ func watchCmd(args []string) {
 	// Kill stale session if exists
 	exec.Command("tmux", "kill-session", "-t", tmuxSession).Run()
 
+	// Resolve path to self for _watch-tail subcommand
+	selfBin, _ := os.Executable()
+	if selfBin == "" {
+		selfBin = os.Args[0]
+	}
+
 	// Build pane mappings for the background status updater
 	var paneMappings []watch.PaneMapping
 
-	// Create new session with first worker — attach to its tmux session
-	firstCmd := watchPaneCmd(workers[0].name, workers[0].sess)
+	// Create new session with first worker — tail filtered log
+	firstCmd := watchPaneCmd(selfBin, workers[0].name, workers[0].sess)
 	if out, err := exec.Command("tmux", "new-session", "-d", "-s", tmuxSession, "bash", "-c", firstCmd).CombinedOutput(); err != nil {
 		log.Fatalf("tmux new-session: %v\n%s", err, out)
 	}
@@ -576,7 +573,7 @@ func watchCmd(args []string) {
 
 	// Split for each additional worker
 	for i := 1; i < len(workers); i++ {
-		paneCmd := watchPaneCmd(workers[i].name, workers[i].sess)
+		paneCmd := watchPaneCmd(selfBin, workers[i].name, workers[i].sess)
 		if out, err := exec.Command("tmux", "split-window", "-t", tmuxSession, "bash", "-c", paneCmd).CombinedOutput(); err != nil {
 			log.Printf("tmux split-window for %s: %v\n%s", workers[i].name, err, out)
 			continue
@@ -604,10 +601,6 @@ func watchCmd(args []string) {
 	if err := watch.WritePaneMap(watch.PaneMapFile, paneMappings); err != nil {
 		log.Printf("[watch] warn: write pane map: %v (titles won't auto-refresh)", err)
 	} else {
-		selfBin, _ := os.Executable()
-		if selfBin == "" {
-			selfBin = os.Args[0]
-		}
 		updaterArgs := []string{selfBin, "_watch-updater"}
 		for _, c := range configs {
 			updaterArgs = append(updaterArgs, "--config", c)
@@ -638,6 +631,13 @@ func watchUpdaterCmd(args []string) {
 
 	// The updater runs as a background daemon, refreshing pane titles every 3 seconds
 	watch.RunUpdater(watch.PaneMapFile, 3*time.Second)
+}
+
+func watchTailCmd(args []string) {
+	if len(args) < 2 {
+		log.Fatal("usage: maestro _watch-tail <logfile> <tmux-session>")
+	}
+	watch.TailFiltered(args[0], args[1])
 }
 
 func spawnCmd(args []string) {

--- a/internal/watch/tail.go
+++ b/internal/watch/tail.go
@@ -1,0 +1,73 @@
+package watch
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// TailFiltered tails a log file, applying CleanOutputLine to each line.
+// It exits when the specified tmux session no longer exists (worker finished).
+func TailFiltered(logFile string, tmuxSession string) {
+	// Wait for log file to appear (only while session is alive)
+	for {
+		if _, err := os.Stat(logFile); err == nil {
+			break
+		}
+		if !sessionExists(tmuxSession) {
+			fmt.Println("No log file found.")
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	f, err := os.Open(logFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open log: %v\n", err)
+		return
+	}
+	defer f.Close()
+
+	var partial string
+	buf := make([]byte, 4096)
+
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			data := partial + string(buf[:n])
+			partial = ""
+
+			lines := strings.Split(data, "\n")
+			// Last element is a partial line if data doesn't end with newline
+			if !strings.HasSuffix(data, "\n") {
+				partial = lines[len(lines)-1]
+				lines = lines[:len(lines)-1]
+			}
+
+			for _, line := range lines {
+				if cleaned := CleanOutputLine(line); cleaned != "" {
+					fmt.Println(cleaned)
+				}
+			}
+		}
+		if err == io.EOF {
+			if !sessionExists(tmuxSession) {
+				// Drain any remaining partial line
+				if partial != "" {
+					if cleaned := CleanOutputLine(partial); cleaned != "" {
+						fmt.Println(cleaned)
+					}
+				}
+				return
+			}
+			time.Sleep(300 * time.Millisecond)
+			continue
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "read log: %v\n", err)
+			return
+		}
+	}
+}

--- a/internal/watch/tail_test.go
+++ b/internal/watch/tail_test.go
@@ -1,0 +1,105 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTailFiltered_FiltersDotsAndSpinners(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "test.log")
+
+	// Write a log file with mixed content: dots, spinners, and real output
+	content := strings.Join([]string{
+		".",
+		"..",
+		"...",
+		"⠋",
+		"⣾",
+		"◐",
+		"Running tool: Read file.go",
+		"...",
+		"\x1b[31mcolored output\x1b[0m",
+		"Created PR #42",
+		".",
+		"",
+		"   ",
+		"Building project...",
+	}, "\n") + "\n"
+
+	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture stdout by redirecting to a pipe
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	// Use a nonexistent tmux session so TailFiltered reads the whole file and exits
+	TailFiltered(logFile, "nonexistent-session-that-does-not-exist")
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf [4096]byte
+	n, _ := r.Read(buf[:])
+	output := string(buf[:n])
+	r.Close()
+
+	// Should contain meaningful lines
+	if !strings.Contains(output, "Running tool: Read file.go") {
+		t.Errorf("output should contain tool call line, got:\n%s", output)
+	}
+	if !strings.Contains(output, "colored output") {
+		t.Errorf("output should contain ANSI-stripped line, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Created PR #42") {
+		t.Errorf("output should contain PR creation line, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Building project...") {
+		t.Errorf("output should contain 'Building project...' (not just dots), got:\n%s", output)
+	}
+
+	// Should NOT contain spinner/dot-only lines
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "." || trimmed == ".." || trimmed == "..." {
+			t.Errorf("output should not contain dot-only line %q", trimmed)
+		}
+		if trimmed == "⠋" || trimmed == "⣾" || trimmed == "◐" {
+			t.Errorf("output should not contain spinner character %q", trimmed)
+		}
+	}
+}
+
+func TestTailFiltered_NoLogFile(t *testing.T) {
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	// Nonexistent log file + nonexistent session → should print message and exit
+	TailFiltered("/tmp/nonexistent-maestro-test-log-file", "nonexistent-session")
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf [4096]byte
+	n, _ := r.Read(buf[:])
+	output := string(buf[:n])
+	r.Close()
+
+	if !strings.Contains(output, "No log file found") {
+		t.Errorf("expected 'No log file found' message, got: %q", output)
+	}
+}


### PR DESCRIPTION
Implements #66

## Changes

Instead of attaching directly to the worker's tmux session (which shows raw Claude CLI progress dots and spinner characters), watch panes now tail the log file through `CleanOutputLine` filtering.

- **New `TailFiltered` function** (`internal/watch/tail.go`): Reads the log file live, applies ANSI stripping and spinner/dot filtering via `CleanOutputLine`, and exits when the worker's tmux session ends
- **New `_watch-tail` hidden subcommand**: Invokes `TailFiltered` — each watch pane runs `maestro _watch-tail <logfile> <tmux-session>` instead of `tmux attach-session`
- **Updated `watchPaneCmd`**: Replaced direct tmux session attachment with the filtered log tail approach
- **Hoisted `selfBin` resolution** in `watchCmd` so it's available for both pane commands and the updater

## Testing

- Added unit tests for `TailFiltered` covering:
  - Filtering of dots (`.`, `..`, `...`), spinner characters, ANSI codes, and empty lines
  - Passthrough of meaningful content (tool calls, PR creation, build messages)
  - Graceful handling of missing log files
- All existing tests pass (`go test ./...`)
- `go vet ./...` clean
- Binary builds successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces direct tmux session attachment with filtered log file tailing to prevent spinner dots and progress characters from cluttering the watch panes. The new `TailFiltered` function reads log files live and applies `CleanOutputLine` filtering to strip out unwanted progress indicators while preserving meaningful output.

**Key changes:**
- New `_watch-tail` hidden subcommand invokes `TailFiltered` for each watch pane
- `watchPaneCmd` now runs `maestro _watch-tail` instead of `tmux attach-session`
- `TailFiltered` function handles live log tailing with graceful exit when worker session ends
- Comprehensive test coverage for filtering behavior and edge cases
- `selfBin` resolution hoisted in `watchCmd` for reuse

The implementation is clean, well-tested, and correctly addresses the issue of raw Claude CLI progress indicators appearing in watch panes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured implementation with comprehensive test coverage, clean refactoring, and proper error handling. The changes are isolated to watch functionality, don't introduce breaking changes, and solve a specific UX issue.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Adds `_watch-tail` subcommand, refactors `watchPaneCmd` to use filtered log tailing instead of direct tmux attachment, and hoists `selfBin` resolution for reuse |
| internal/watch/tail.go | New `TailFiltered` function that live-tails log files with spinner/dot filtering and exits when worker tmux session ends |
| internal/watch/tail_test.go | Comprehensive unit tests covering filtering of dots/spinners/ANSI codes and missing log file handling |

</details>



<sub>Last reviewed commit: 2c16c9c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->