### PR TITLE
fix: kill stale _watch-updater processes before starting new one (#68)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -597,6 +597,9 @@ func watchCmd(args []string) {
 	exec.Command("tmux", "set-option", "-t", tmuxSession, "pane-border-format",
 		"#[fg=white,bold] #{pane_title}").Run()
 
+	// Kill stale updater processes before starting new one
+	exec.Command("pkill", "-f", "maestro _watch-updater").Run()
+
 	// Write pane mapping and start background updater to keep titles fresh
 	if err := watch.WritePaneMap(watch.PaneMapFile, paneMappings); err != nil {
 		log.Printf("[watch] warn: write pane map: %v (titles won't auto-refresh)", err)


### PR DESCRIPTION
Fixes #68

## Changes

When `maestro watch` is run repeatedly, old `_watch-updater` background processes survive because the new tmux session reuses the same `maestro-watch` name — so the updater's `sessionExists` check never triggers an exit. Multiple updaters then fight over the shared `/tmp/maestro-watch-panes.json` pane map file, causing the watch view to rapidly jump between projects.

Added a `pkill -f "maestro _watch-updater"` call in `watchCmd` right before starting a new updater process. This ensures at most one updater is active at any time.

## Testing

- `go fmt`, `go vet`, `go test ./...` all pass
- `go build ./cmd/maestro/` succeeds
- Manual verification: after the fix, running `maestro watch` multiple times results in only one `_watch-updater` process (previous ones are killed before the new one starts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `pkill -f "maestro _watch-updater"` before starting new updater process to kill stale background processes from previous watch sessions.

- Fixes race condition where reusing the `maestro-watch` tmux session name caused old updater processes to survive
- Old updaters' `sessionExists` checks would pass with the new session, causing multiple updaters to fight over `/tmp/maestro-watch-panes.json`
- Solution ensures only one updater process runs at any time

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, targeted, and follows existing patterns in the codebase. The pkill command is called the same way as the tmux kill-session command (ignoring errors), which is appropriate for cleanup operations. The pattern `maestro _watch-updater` is specific enough to avoid false positives while being flexible enough to match regardless of the binary path.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Added pkill command to terminate stale updater processes before starting new one, fixing race condition where multiple updaters fight over shared state file |

</details>



<sub>Last reviewed commit: 68874f9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->