### PR TITLE
fix: state reconciler + watch shows sleeping workers (#71, #73)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -496,12 +496,26 @@ func logsCmd(args []string) {
 // It tails the worker's log file with spinner/dot filtering via _watch-tail,
 // then shows an exit prompt when the worker finishes.
 func watchPaneCmd(selfBin string, name string, sess *state.Session) string {
-	tmuxName := worker.TmuxSessionName(name)
+	tmuxName := watchSessionName(name, sess)
 	return fmt.Sprintf(
 		`%s _watch-tail %q %q; `+
 			`echo; echo '=== Worker session ended ==='; `+
 			`echo; echo 'Press any key to exit...'; read -n1`,
 		selfBin, sess.LogFile, tmuxName)
+}
+
+func watchSessionName(slotName string, sess *state.Session) string {
+	if sess != nil && strings.TrimSpace(sess.TmuxSession) != "" {
+		return sess.TmuxSession
+	}
+	return worker.TmuxSessionName(slotName)
+}
+
+func tmuxSessionAlive(name string) bool {
+	if strings.TrimSpace(name) == "" {
+		return false
+	}
+	return exec.Command("tmux", "has-session", "-t", name).Run() == nil
 }
 
 func watchCmd(args []string) {
@@ -512,7 +526,7 @@ func watchCmd(args []string) {
 
 	cfgs := loadConfigs(configs)
 
-	// Collect active running sessions across all projects
+	// Collect workers that still have an active tmux session across all projects.
 	type activeWorker struct {
 		name     string
 		sess     *state.Session
@@ -526,7 +540,8 @@ func watchCmd(args []string) {
 			continue
 		}
 		for name, sess := range s.Sessions {
-			if sess.Status == state.StatusRunning && worker.IsAlive(sess.PID) {
+			tmuxName := watchSessionName(name, sess)
+			if tmuxSessionAlive(tmuxName) {
 				workers = append(workers, activeWorker{name, sess, cfg.StateDir})
 			}
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -163,7 +163,15 @@ func (o *Orchestrator) RunOnce() error {
 	log.Printf("[orch] === cycle start — %d sessions in state ===", len(s.Sessions))
 
 	// Step 1: Reconcile stale running sessions before scheduling/slot calculation.
-	o.reconcileRunningSessions(s)
+	reconciled := o.reconcileRunningSessions(s)
+
+	// Persist immediately when reconciliation changes state, so slot calculation
+	// always sees healed state on disk.
+	if reconciled {
+		if err := state.Save(o.cfg.StateDir, s); err != nil {
+			return fmt.Errorf("save state after reconcile: %w", err)
+		}
+	}
 
 	// Step 2: Check running sessions for dead processes / stale / closed issues
 	o.checkSessions(s)
@@ -225,12 +233,18 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 }
 
 // reconcileRunningSessions self-heals stale "running" sessions.
-// If a session is marked running but its PID is dead (or missing), or its tmux session
-// is missing (when tracked in state), the session is re-queued so scheduler can restart work.
-func (o *Orchestrator) reconcileRunningSessions(s *state.State) {
+// If a session is marked running but either its PID is dead/missing OR its tmux session
+// is missing, the session is marked dead and its PID/tmux fields are cleared.
+func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
+	reconciled := false
 	for slotName, sess := range s.Sessions {
 		if sess.Status != state.StatusRunning {
 			continue
+		}
+
+		tmuxName := sess.TmuxSession
+		if tmuxName == "" {
+			tmuxName = worker.TmuxSessionName(slotName)
 		}
 
 		var reasons []string
@@ -240,8 +254,8 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) {
 			reasons = append(reasons, fmt.Sprintf("pid %d dead", sess.PID))
 		}
 
-		if sess.TmuxSession != "" && !o.tmuxSessionExists(sess.TmuxSession) {
-			reasons = append(reasons, fmt.Sprintf("tmux session %q missing", sess.TmuxSession))
+		if !o.tmuxSessionExists(tmuxName) {
+			reasons = append(reasons, fmt.Sprintf("tmux session %q missing", tmuxName))
 		}
 
 		if len(reasons) == 0 {
@@ -249,15 +263,18 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) {
 		}
 
 		oldPID := sess.PID
-		oldTmux := sess.TmuxSession
-		sess.Status = state.StatusQueued
+		oldTmux := tmuxName
+		sess.Status = state.StatusDead
 		sess.PID = 0
 		sess.TmuxSession = ""
-		sess.RetryCount++
+		now := time.Now().UTC()
+		sess.FinishedAt = &now
+		reconciled = true
 
-		log.Printf("[orch] reconcile: %s running->queued (%s); pid=%d tmux=%q retries=%d",
-			slotName, strings.Join(reasons, ", "), oldPID, oldTmux, sess.RetryCount)
+		log.Printf("[orch] reconcile: %s running->dead (%s); pid=%d tmux=%q",
+			slotName, strings.Join(reasons, ", "), oldPID, oldTmux)
 	}
+	return reconciled
 }
 
 // checkSessions inspects all sessions and updates their status

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -124,7 +124,7 @@ func TestSelectPrompt_CaseInsensitiveLabel(t *testing.T) {
 	}
 }
 
-func TestReconcileRunningSessions_DeadPIDGetsQueued(t *testing.T) {
+func TestReconcileRunningSessions_DeadPIDGetsMarkedDead(t *testing.T) {
 	s := state.NewState()
 	s.Sessions["pan-1"] = &state.Session{
 		IssueNumber:        71,
@@ -141,11 +141,14 @@ func TestReconcileRunningSessions_DeadPIDGetsQueued(t *testing.T) {
 		tmuxSessionExistsFn: func(name string) bool { return true },
 	}
 
-	o.reconcileRunningSessions(s)
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
 
 	sess := s.Sessions["pan-1"]
-	if sess.Status != state.StatusQueued {
-		t.Fatalf("status = %q, want %q", sess.Status, state.StatusQueued)
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
 	}
 	if sess.PID != 0 {
 		t.Fatalf("pid = %d, want 0", sess.PID)
@@ -153,12 +156,15 @@ func TestReconcileRunningSessions_DeadPIDGetsQueued(t *testing.T) {
 	if sess.TmuxSession != "" {
 		t.Fatalf("tmux_session = %q, want empty", sess.TmuxSession)
 	}
-	if sess.RetryCount != 3 {
-		t.Fatalf("retry_count = %d, want 3", sess.RetryCount)
+	if sess.RetryCount != 2 {
+		t.Fatalf("retry_count = %d, want 2", sess.RetryCount)
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("finished_at should be set when session is marked dead")
 	}
 }
 
-func TestReconcileRunningSessions_MissingTmuxGetsQueued(t *testing.T) {
+func TestReconcileRunningSessions_MissingTmuxGetsMarkedDead(t *testing.T) {
 	s := state.NewState()
 	s.Sessions["pan-2"] = &state.Session{
 		IssueNumber: 71,
@@ -172,11 +178,14 @@ func TestReconcileRunningSessions_MissingTmuxGetsQueued(t *testing.T) {
 		tmuxSessionExistsFn: func(name string) bool { return false },
 	}
 
-	o.reconcileRunningSessions(s)
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
 
 	sess := s.Sessions["pan-2"]
-	if sess.Status != state.StatusQueued {
-		t.Fatalf("status = %q, want %q", sess.Status, state.StatusQueued)
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
 	}
 	if sess.PID != 0 {
 		t.Fatalf("pid = %d, want 0", sess.PID)
@@ -184,8 +193,38 @@ func TestReconcileRunningSessions_MissingTmuxGetsQueued(t *testing.T) {
 	if sess.TmuxSession != "" {
 		t.Fatalf("tmux_session = %q, want empty", sess.TmuxSession)
 	}
-	if sess.RetryCount != 1 {
-		t.Fatalf("retry_count = %d, want 1", sess.RetryCount)
+	if sess.RetryCount != 0 {
+		t.Fatalf("retry_count = %d, want 0", sess.RetryCount)
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("finished_at should be set when session is marked dead")
+	}
+}
+
+func TestReconcileRunningSessions_UsesDefaultTmuxNameWhenMissingInState(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["pan-3"] = &state.Session{
+		IssueNumber: 73,
+		Status:      state.StatusRunning,
+		PID:         6262,
+		// TmuxSession intentionally empty; should fall back to worker.TmuxSessionName(slot)
+	}
+
+	calledWith := ""
+	o := &Orchestrator{
+		pidAliveFn: func(pid int) bool { return true },
+		tmuxSessionExistsFn: func(name string) bool {
+			calledWith = name
+			return true
+		},
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if changed {
+		t.Fatal("expected no reconciliation changes when pid and tmux are healthy")
+	}
+	if calledWith != "maestro-pan-3" {
+		t.Fatalf("tmux session checked = %q, want %q", calledWith, "maestro-pan-3")
 	}
 }
 


### PR DESCRIPTION
Fixes #71 and #73

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issues with stale session reconciliation and improves the watch command to show sleeping workers. Key changes:
- Changed reconciliation behavior: instead of re-queuing dead sessions, they are now marked as `StatusDead` with `FinishedAt` timestamp
- Added immediate state persistence after reconciliation to ensure slot calculations see the healed state
- Improved tmux session name resolution with fallback to default naming when `TmuxSession` field is empty
- Updated `watch` command to check for tmux session existence instead of PID+status, showing workers with active tmux sessions even if sleeping

The changes properly address the root causes of issues #71 and #73 by ensuring dead sessions don't occupy slots and watch command shows all relevant workers.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with comprehensive unit tests covering all new behaviors, the logic is straightforward and properly handles edge cases (empty tmux session names, dead PIDs, missing sessions), and the immediate state persistence prevents race conditions in slot calculation
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Added helper functions `watchSessionName` and `tmuxSessionAlive` to properly check tmux session existence and show sleeping workers with active tmux sessions |
| internal/orchestrator/orchestrator.go | Changed reconciliation logic to mark dead sessions instead of re-queuing them, added immediate state persistence after reconciliation, and improved tmux session name fallback |
| internal/orchestrator/orchestrator_test.go | Updated tests to reflect new behavior where reconciliation marks sessions as dead instead of queued, added test for fallback tmux name logic |

</details>



<sub>Last reviewed commit: b813498</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->