### PR TITLE
feat: token usage visibility — track and report per-worker spend (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ worktree_base: /home/shtrudel/.worktrees/panoptikon
 max_parallel: 5
 max_runtime_minutes: 120           # hard timeout per worker (default: 120)
 worker_silent_timeout_minutes: 0   # kill worker if tmux output is unchanged for N minutes (0 = disabled)
+worker_max_tokens: 0               # kill worker when cumulative token usage exceeds this (0 = unlimited)
 auto_rebase: true                  # auto-rebase conflicting PR branches (default: true)
 merge_strategy: sequential         # "sequential" (default) or "parallel"
 merge_interval_seconds: 30         # minimum seconds between merges in sequential mode

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -337,8 +337,8 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "SESSION\tISSUE\tSTATUS\tPR\tCI\tPID\tALIVE\tAGE\tRETRIES\tTITLE")
-	fmt.Fprintln(w, "-------\t-----\t------\t--\t--\t---\t-----\t---\t-------\t-----")
+	fmt.Fprintln(w, "SESSION\tISSUE\tSTATUS\tPR\tCI\tPID\tALIVE\tAGE\tRETRIES\tTOKENS\tTITLE")
+	fmt.Fprintln(w, "-------\t-----\t------\t--\t--\t---\t-----\t---\t-------\t------\t-----")
 	for _, name := range names {
 		sess := s.Sessions[name]
 		alive := "-"
@@ -362,8 +362,9 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 		if cs, ok := ciStatuses[name]; ok {
 			ci = cs
 		}
-		fmt.Fprintf(w, "%s\t#%d\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
-			name, sess.IssueNumber, sess.Status, pr, ci, sess.PID, alive, age, retries, truncate(sess.IssueTitle, 50))
+		tokens := worker.FormatTokens(sess.TokensUsed)
+		fmt.Fprintf(w, "%s\t#%d\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\n",
+			name, sess.IssueNumber, sess.Status, pr, ci, sess.PID, alive, age, retries, tokens, truncate(sess.IssueTitle, 50))
 	}
 	w.Flush()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	MaxParallel                int              `yaml:"max_parallel"`
 	MaxRuntimeMinutes          int              `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
 	WorkerSilentTimeoutMinutes int              `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
+	WorkerMaxTokens            int              `yaml:"worker_max_tokens"`             // kill worker when token usage exceeds this threshold (0 = unlimited)
 	AutoRebase                 bool             `yaml:"auto_rebase"`                   // auto-attempt rebase for conflicting sessions (default: true)
 	ClaudeCmd                  string           `yaml:"claude_cmd"`                    // deprecated: use model.backends.claude.cmd
 	IssueLabel                 string           `yaml:"issue_label"`                   // deprecated: use issue_labels

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -416,8 +416,8 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				continue
 			}
 
-			// Silent worker detection: compare tmux pane output hash over time.
-			if o.cfg.WorkerSilentTimeoutMinutes > 0 {
+			// Capture tmux pane output for silent-timeout detection and token tracking.
+			if o.cfg.WorkerSilentTimeoutMinutes > 0 || o.cfg.WorkerMaxTokens > 0 {
 				tmuxName := sess.TmuxSession
 				if tmuxName == "" {
 					tmuxName = worker.TmuxSessionName(slotName)
@@ -427,38 +427,75 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				if err != nil {
 					log.Printf("[orch] warn: tmux capture-pane failed for %s (%s): %v", slotName, tmuxName, err)
 				} else {
-					hash := hashOutput(output)
-					now := time.Now().UTC()
+					// --- Token tracking ---
+					if tokens := worker.ParseTokensFromOutput(output); tokens > sess.TokensUsed {
+						sess.TokensUsed = tokens
+						log.Printf("[orch] %s tokens_used updated to %d", slotName, tokens)
+					}
 
-					if sess.LastOutputHash == "" || sess.LastOutputChangedAt.IsZero() || hash != sess.LastOutputHash {
-						sess.LastOutputHash = hash
-						sess.LastOutputChangedAt = now
-					} else {
-						timeout := time.Duration(o.cfg.WorkerSilentTimeoutMinutes) * time.Minute
-						if time.Since(sess.LastOutputChangedAt) > timeout {
-							log.Printf("[orch] worker %s silent for >%dm, killing", slotName, o.cfg.WorkerSilentTimeoutMinutes)
-							if err := worker.Stop(o.cfg, slotName, sess); err != nil {
-								log.Printf("[orch] warn: could not stop silent worker %s: %v", slotName, err)
-							}
-
-							// Count previous silent-timeout kills before updating this session,
-							// so the current kill is not included in the count.
-							prevSilentKills := countSilentTimeoutKillsForIssue(s, sess.IssueNumber)
-
-							sess.Status = state.StatusDead
-							sess.LastNotifiedStatus = "silent_timeout"
-							sess.FinishedAt = &now
-
-							if prevSilentKills > 0 {
-								if err := o.gh.AddIssueLabel(sess.IssueNumber, "blocked"); err != nil {
-									log.Printf("[orch] warn: could not label issue #%d as blocked: %v", sess.IssueNumber, err)
-								}
-							}
-
-							o.notifier.Sendf("⏱️ maestro: worker %s (issue #%d) killed — no output for %d minutes",
-								slotName, sess.IssueNumber, o.cfg.WorkerSilentTimeoutMinutes)
-							continue
+					// --- Token limit enforcement ---
+					if o.cfg.WorkerMaxTokens > 0 && sess.TokensUsed > o.cfg.WorkerMaxTokens && sess.LastNotifiedStatus != "token_limit" {
+						log.Printf("[orch] worker %s exceeded token limit (%d > %d), killing",
+							slotName, sess.TokensUsed, o.cfg.WorkerMaxTokens)
+						if err := worker.Stop(o.cfg, slotName, sess); err != nil {
+							log.Printf("[orch] warn: could not stop token-limit worker %s: %v", slotName, err)
 						}
+						now := time.Now().UTC()
+						sess.Status = state.StatusDead
+						sess.LastNotifiedStatus = "token_limit"
+						sess.FinishedAt = &now
+						o.notifier.Sendf("⚠️ Worker %s (issue #%d) exceeded token limit: %s tokens used",
+							slotName, sess.IssueNumber, worker.FormatTokens(sess.TokensUsed))
+						continue
+					}
+
+					// --- Silent worker detection ---
+					if o.cfg.WorkerSilentTimeoutMinutes > 0 {
+						hash := hashOutput(output)
+						now := time.Now().UTC()
+
+						if sess.LastOutputHash == "" || sess.LastOutputChangedAt.IsZero() || hash != sess.LastOutputHash {
+							sess.LastOutputHash = hash
+							sess.LastOutputChangedAt = now
+						} else {
+							timeout := time.Duration(o.cfg.WorkerSilentTimeoutMinutes) * time.Minute
+							if time.Since(sess.LastOutputChangedAt) > timeout {
+								log.Printf("[orch] worker %s silent for >%dm, killing", slotName, o.cfg.WorkerSilentTimeoutMinutes)
+								if err := worker.Stop(o.cfg, slotName, sess); err != nil {
+									log.Printf("[orch] warn: could not stop silent worker %s: %v", slotName, err)
+								}
+
+								// Count previous silent-timeout kills before updating this session,
+								// so the current kill is not included in the count.
+								prevSilentKills := countSilentTimeoutKillsForIssue(s, sess.IssueNumber)
+
+								sess.Status = state.StatusDead
+								sess.LastNotifiedStatus = "silent_timeout"
+								sess.FinishedAt = &now
+
+								if prevSilentKills > 0 {
+									if err := o.gh.AddIssueLabel(sess.IssueNumber, "blocked"); err != nil {
+										log.Printf("[orch] warn: could not label issue #%d as blocked: %v", sess.IssueNumber, err)
+									}
+								}
+
+								o.notifier.Sendf("⏱️ maestro: worker %s (issue #%d) killed — no output for %d minutes",
+									slotName, sess.IssueNumber, o.cfg.WorkerSilentTimeoutMinutes)
+								continue
+							}
+						}
+					}
+				}
+			} else {
+				// Neither silent-timeout nor token-limit is configured, but we still
+				// want to track tokens when possible. Capture pane output cheaply.
+				tmuxName := sess.TmuxSession
+				if tmuxName == "" {
+					tmuxName = worker.TmuxSessionName(slotName)
+				}
+				if output, err := tmuxCapture(tmuxName); err == nil {
+					if tokens := worker.ParseTokensFromOutput(output); tokens > sess.TokensUsed {
+						sess.TokensUsed = tokens
 					}
 				}
 			}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -41,6 +41,7 @@ type Session struct {
 	RetryCount          int           `json:"retry_count,omitempty"`
 	LastOutputHash      string        `json:"last_output_hash,omitempty"`
 	LastOutputChangedAt time.Time     `json:"last_output_changed_at,omitempty"`
+	TokensUsed          int           `json:"tokens_used,omitempty"` // cumulative tokens consumed by the worker
 }
 
 type State struct {

--- a/internal/worker/tokens.go
+++ b/internal/worker/tokens.go
@@ -1,0 +1,97 @@
+package worker
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// tokenPatterns holds compiled regexes for extracting total token counts
+// from various AI CLI output formats.
+//
+// Supported formats (case-insensitive):
+//   - openclaw/claude: "tokens 12345 (in 1000 / out 11345)"
+//   - codex-style:     "Tokens: 1234 input, 5678 output"
+//   - generic total:   "total tokens: 12345"  |  "total_tokens: 12345"
+var tokenPatterns = []*regexp.Regexp{
+	// openclaw format: "tokens 12345 (in 1000 / out 11345)"
+	regexp.MustCompile(`(?i)\btokens\s+(\d[\d,]*)(?:\s+\(in\s+[\d,]+\s*/\s*out\s+[\d,]+\))?`),
+	// codex-style: "Tokens: 1234 input, 5678 output" — sum input+output
+	regexp.MustCompile(`(?i)\bTokens:\s*(\d[\d,]*)\s+input,\s*(\d[\d,]*)\s+output`),
+	// generic "total tokens: N" or "total_tokens: N"
+	regexp.MustCompile(`(?i)\btotal[_ ]tokens[:\s]+(\d[\d,]*)`),
+}
+
+// ParseTokensFromOutput scans multi-line text for token-usage lines and
+// returns the maximum total count found (0 if none matched).
+// Commas in numbers are stripped before parsing.
+func ParseTokensFromOutput(text string) int {
+	max := 0
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if n := parseTokensFromLine(line); n > max {
+			max = n
+		}
+	}
+	return max
+}
+
+func parseTokensFromLine(line string) int {
+	// Try codex-style first: captures two groups (input + output)
+	codexRe := tokenPatterns[1]
+	if m := codexRe.FindStringSubmatch(line); m != nil {
+		in := parseNum(m[1])
+		out := parseNum(m[2])
+		return in + out
+	}
+
+	// Try the remaining patterns — each yields a single total
+	for i, re := range tokenPatterns {
+		if i == 1 {
+			continue // already handled
+		}
+		if m := re.FindStringSubmatch(line); m != nil {
+			return parseNum(m[1])
+		}
+	}
+	return 0
+}
+
+// parseNum converts a numeric string (with optional commas) to int.
+func parseNum(s string) int {
+	s = strings.ReplaceAll(s, ",", "")
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
+// FormatTokens formats a token count as a compact human-readable string.
+//
+//	0       → "-"
+//	999     → "999"
+//	1500    → "1.5k"
+//	1200000 → "1.2M"
+func FormatTokens(n int) string {
+	switch {
+	case n <= 0:
+		return "-"
+	case n < 1000:
+		return strconv.Itoa(n)
+	case n < 1_000_000:
+		k := float64(n) / 1000.0
+		return formatFloat(k) + "k"
+	default:
+		m := float64(n) / 1_000_000.0
+		return formatFloat(m) + "M"
+	}
+}
+
+// formatFloat renders a float with one decimal place, stripping trailing ".0".
+func formatFloat(f float64) string {
+	s := strconv.FormatFloat(f, 'f', 1, 64)
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimRight(s, ".")
+	return s
+}

--- a/internal/worker/tokens_test.go
+++ b/internal/worker/tokens_test.go
@@ -1,0 +1,110 @@
+package worker
+
+import (
+	"testing"
+)
+
+func TestParseTokensFromOutput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{
+			name:  "openclaw format",
+			input: "tokens 12345 (in 1000 / out 11345)",
+			want:  12345,
+		},
+		{
+			name:  "openclaw format no parens",
+			input: "tokens 999",
+			want:  999,
+		},
+		{
+			name:  "codex-style input+output",
+			input: "Tokens: 1234 input, 5678 output",
+			want:  6912,
+		},
+		{
+			name:  "codex-style with commas",
+			input: "Tokens: 1,234 input, 5,678 output",
+			want:  6912,
+		},
+		{
+			name:  "generic total tokens colon",
+			input: "total tokens: 42000",
+			want:  42000,
+		},
+		{
+			name:  "generic total_tokens underscore",
+			input: "total_tokens: 99",
+			want:  99,
+		},
+		{
+			name:  "no match",
+			input: "nothing to see here",
+			want:  0,
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  0,
+		},
+		{
+			name: "multiline — picks max",
+			input: `
+tokens 100 (in 10 / out 90)
+some other line
+tokens 5000 (in 1000 / out 4000)
+tokens 3000 (in 500 / out 2500)
+`,
+			want: 5000,
+		},
+		{
+			name:  "tokens with commas",
+			input: "tokens 1,234,567 (in 100,000 / out 1,134,567)",
+			want:  1234567,
+		},
+		{
+			name:  "case insensitive",
+			input: "TOKENS 777 (IN 300 / OUT 477)",
+			want:  777,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseTokensFromOutput(tc.input)
+			if got != tc.want {
+				t.Errorf("ParseTokensFromOutput(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatTokens(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, "-"},
+		{-1, "-"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1k"},
+		{1500, "1.5k"},
+		{12300, "12.3k"},
+		{999999, "1000k"},
+		{1000000, "1M"},
+		{1200000, "1.2M"},
+		{10000000, "10M"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			got := FormatTokens(tc.n)
+			if got != tc.want {
+				t.Errorf("FormatTokens(%d) = %q, want %q", tc.n, got, tc.want)
+			}
+		})
+	}
+}

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -10,6 +10,7 @@ worktree_base: /path/to/worktrees/repo
 max_parallel: 5
 max_runtime_minutes: 120           # hard timeout per worker (default: 120)
 worker_silent_timeout_minutes: 0   # kill worker if tmux output is unchanged for N min (0 = disabled)
+worker_max_tokens: 0               # kill worker when cumulative token usage exceeds this (0 = unlimited)
 auto_rebase: true                  # auto-rebase conflicting PR branches (default: true)
 merge_strategy: sequential         # "sequential" (default) or "parallel"
 merge_interval_seconds: 30         # minimum seconds between sequential merges (default: 30)


### PR DESCRIPTION
Closes #86

Parses token counts from tmux pane output, shows TOKENS column in maestro status, alerts+kills workers exceeding worker_max_tokens threshold.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented comprehensive token usage tracking and enforcement across the maestro worker orchestration system. The changes parse token counts from tmux output using flexible regex patterns supporting multiple CLI formats (openclaw, codex-style, generic), display token usage in the status command with human-readable formatting (k/M suffixes), and enforce configurable token limits by killing workers that exceed thresholds with appropriate notifications.

**Key changes:**
- Added `worker_max_tokens` config option (0 = unlimited) to limit per-worker token consumption
- New `TokensUsed` field in session state tracks cumulative token usage
- Token parsing supports multiple formats with comprehensive test coverage
- Status display includes new TOKENS column showing formatted usage (e.g., "1.5k", "1.2M")
- Workers exceeding limits are killed with notification, status set to `dead`, and `LastNotifiedStatus` set to "token_limit"
- Optimized tmux capture logic to track tokens even when silent-timeout is disabled

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- Well-structured implementation with proper error handling, comprehensive test coverage, consistent code style, and thoughtful optimizations. Token tracking uses monotonic increases (only updates when new value exceeds current), preventing spurious updates. The enforcement logic properly sets session state and notifications. No security concerns or edge cases identified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/worker/tokens.go | New token parsing and formatting logic with comprehensive regex patterns for multiple CLI formats |
| internal/orchestrator/orchestrator.go | Added token tracking and limit enforcement, reorganized tmux capture logic for efficiency |
| internal/state/state.go | Added `TokensUsed` field to track cumulative token consumption per session |
| cmd/maestro/main.go | Added TOKENS column to status display showing formatted token usage per worker |

</details>



<sub>Last reviewed commit: d0b0b1b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->