### PR TITLE
feat: improve install + init onboarding flow (#85)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -51,6 +52,9 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	fmt.Fprintln(w, "Welcome to Maestro! Let's set up your first project.")
 	fmt.Fprintln(w)
 
+	// Check prerequisites
+	checkPrerequisites(w)
+
 	repo := promptInit(scanner, w, "GitHub repo (owner/repo)", "")
 	if repo == "" {
 		return fmt.Errorf("repo is required")
@@ -65,7 +69,7 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	localPath := promptInit(scanner, w, "Local clone path", "~/src/"+repoName)
 	worktreeBase := promptInit(scanner, w, "Worktree base dir", "~/.worktrees/"+repoName)
 	maxParallelStr := promptInit(scanner, w, "Max parallel workers", "3")
-	modelBackend := promptInit(scanner, w, "Default model backend (claude/codex/gemini)", "claude")
+	modelBackend := promptInit(scanner, w, "Default model backend (claude/codex/gemini/cline)", "claude")
 	issueLabel := promptInit(scanner, w, "Issue label filter", "enhancement")
 
 	maxParallel, err := strconv.Atoi(maxParallelStr)
@@ -211,6 +215,43 @@ func launchdPlist(binPath, configPath string) string {
 </dict>
 </plist>
 `, binPath, configPath)
+}
+
+// checkPrerequisites verifies that required tools are installed and prints warnings.
+// It does not abort — missing tools are shown as warnings so the user can fix them.
+func checkPrerequisites(w io.Writer) {
+	type prereq struct {
+		cmd  string
+		hint string
+	}
+	required := []prereq{
+		{"git", "install git: https://git-scm.com"},
+		{"gh", "install gh: https://cli.github.com"},
+		{"tmux", "install tmux: apt install tmux / brew install tmux"},
+	}
+
+	var missing []prereq
+	for _, p := range required {
+		if _, err := exec.LookPath(p.cmd); err != nil {
+			missing = append(missing, p)
+		}
+	}
+
+	if len(missing) > 0 {
+		fmt.Fprintln(w, "Prerequisites check:")
+		for _, p := range missing {
+			fmt.Fprintf(w, "  WARNING: %s not found — %s\n", p.cmd, p.hint)
+		}
+		fmt.Fprintln(w)
+	}
+
+	// Check gh auth status
+	if _, err := exec.LookPath("gh"); err == nil {
+		if err := exec.Command("gh", "auth", "status").Run(); err != nil {
+			fmt.Fprintln(w, "  WARNING: gh is not authenticated — run: gh auth login")
+			fmt.Fprintln(w)
+		}
+	}
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -260,6 +260,43 @@ func TestRunInitWizardStateDirConfirmation(t *testing.T) {
 	}
 }
 
+func TestCheckPrerequisites(t *testing.T) {
+	var buf bytes.Buffer
+	checkPrerequisites(&buf)
+
+	// git and tmux should be found on the test system;
+	// we just verify the function runs without panic.
+	// If a tool is missing, it prints a WARNING line.
+	out := buf.String()
+	_ = out // output depends on the host environment
+}
+
+func TestInitWizardShowsCline(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	input := "org/repo\n\n\n\ncline\n\n\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err != nil {
+		t.Fatalf("runInitWizard error: %v", err)
+	}
+
+	out := output.String()
+	if !strings.Contains(out, "cline") {
+		t.Errorf("prompt should mention cline as a backend option, got:\n%s", out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "maestro.yaml"))
+	if err != nil {
+		t.Fatal("maestro.yaml not created")
+	}
+	if !strings.Contains(string(data), "default: cline") {
+		t.Errorf("yaml should contain 'default: cline', got:\n%s", string(data))
+	}
+}
+
 func TestRunInitWizardInvalidMaxParallel(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,19 @@ main() {
     fi
 
     echo "maestro ${LATEST} installed to ${INSTALL_DIR}/maestro"
+
+    # Verify the installed binary works
+    if "${INSTALL_DIR}/maestro" version >/dev/null 2>&1; then
+        echo "Verified: $("${INSTALL_DIR}/maestro" version)"
+    else
+        echo "warning: installed binary failed verification — try running: ${INSTALL_DIR}/maestro version" >&2
+    fi
+
+    echo
+    echo "Next steps:"
+    echo "  1. cd into your repo directory"
+    echo "  2. maestro init    (interactive setup wizard)"
+    echo "  3. maestro run --once  (test run)"
 }
 
 main

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.


### PR DESCRIPTION
Implements #85

## Changes

Reviewed the install.sh and `maestro init` flow for friction points a new user would encounter on a fresh machine. Fixed the issues found:

### install.sh
- Added post-install verification — runs `maestro version` to confirm the binary works
- Added "Next steps" guidance pointing users to `maestro init` and `maestro run --once`

### maestro init
- Added prerequisite checks at wizard start: warns if `git`, `gh`, or `tmux` are missing (with install hints)
- Added `gh auth status` validation — warns if GitHub CLI is not authenticated
- Added `cline` to the model backend prompt (was missing — only showed claude/codex/gemini)

### Friction points documented
- install.sh: previously gave no feedback after install and no guidance on next steps
- init wizard: previously didn't validate prerequisites, so users would complete setup then get confusing errors on `maestro run`
- init wizard: cline backend was missing from the prompt despite being a supported backend

## Testing
- All existing tests pass (`go test ./...`)
- Added `TestCheckPrerequisites` — verifies the function runs without panic
- Added `TestInitWizardShowsCline` — verifies cline appears in prompt and config
- `go vet ./...` clean
- `go build ./cmd/maestro/` + `./maestro version` verified

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully addresses onboarding friction by adding prerequisite validation, post-install verification, and clearer user guidance. The implementation adds helpful warnings for missing tools (`git`, `gh`, `tmux`) and unauthenticated GitHub CLI, includes the missing `cline` backend option, and provides next-step instructions after installation.

**Key improvements:**
- `install.sh` now verifies the binary works and guides users to `maestro init` and `maestro run --once`
- `maestro init` validates prerequisites upfront with actionable install hints
- `cline` backend now properly appears in the prompt (was previously missing despite being supported)
- New tests ensure prerequisite checking works and `cline` appears correctly

**Minor observation:**
The `gh` auth warning (init.go:251) uses 2-space indentation but may appear standalone without a "Prerequisites check:" header if all tools are installed - minor cosmetic inconsistency but doesn't affect functionality.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are additive improvements to the onboarding flow with no breaking changes or risky logic. The code is well-tested, follows existing patterns, and the only observation is a minor formatting inconsistency that doesn't affect functionality. Tests pass and the implementation correctly addresses the stated friction points.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Added prerequisite checks and cline backend option - clean implementation |
| cmd/maestro/init_test.go | Added tests for prerequisite checks and cline backend - good coverage |
| install.sh | Added post-install verification and next steps guidance - improves UX |
| internal/config/config.go | Formatting changes only - aligned inline comments for readability |

</details>



<sub>Last reviewed commit: 83f4f22</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->