### PR TITLE
feat: improve install and init onboarding flow (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,17 @@ cd ~/src/myrepo
 maestro init
 ```
 
-The `maestro init` wizard will ask you for:
-- **GitHub repo** (owner/repo format)
-- **Local clone path** (where the repo lives on disk)
-- **Worktree base dir** (where worker worktrees are created)
-- **Max parallel workers** (how many agents run simultaneously)
-- **Default model backend** (claude, codex, gemini, or cline)
-- **Issue label filter** (which issues to pick up, e.g. `enhancement`)
-- **Telegram notifications** (optional)
-
-It generates a `maestro.yaml` config file and a systemd/launchd service file.
+The `maestro init` wizard will:
+1. **Check prerequisites** (git, gh, tmux, AI CLI) and warn about anything missing
+2. Ask you for:
+   - **GitHub repo** (owner/repo format)
+   - **Local clone path** (where the repo lives on disk)
+   - **Worktree base dir** (where worker worktrees are created)
+   - **Max parallel workers** (how many agents run simultaneously)
+   - **Default model backend** (claude, codex, gemini, or cline)
+   - **Issue label filter** (which issues to pick up, e.g. `enhancement`)
+   - **Telegram notifications** (optional)
+3. Generate a `maestro.yaml` config file and a systemd/launchd service file
 
 ```bash
 # 4. Do a test run (picks one issue, runs once, then exits)

--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -51,6 +52,9 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	fmt.Fprintln(w, "Welcome to Maestro! Let's set up your first project.")
 	fmt.Fprintln(w)
 
+	// Check prerequisites
+	checkPrerequisites(w)
+
 	repo := promptInit(scanner, w, "GitHub repo (owner/repo)", "")
 	if repo == "" {
 		return fmt.Errorf("repo is required")
@@ -65,12 +69,17 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	localPath := promptInit(scanner, w, "Local clone path", "~/src/"+repoName)
 	worktreeBase := promptInit(scanner, w, "Worktree base dir", "~/.worktrees/"+repoName)
 	maxParallelStr := promptInit(scanner, w, "Max parallel workers", "3")
-	modelBackend := promptInit(scanner, w, "Default model backend (claude/codex/gemini)", "claude")
+	modelBackend := promptInit(scanner, w, "Default model backend (claude/codex/gemini/cline)", "claude")
 	issueLabel := promptInit(scanner, w, "Issue label filter", "enhancement")
 
 	maxParallel, err := strconv.Atoi(maxParallelStr)
 	if err != nil || maxParallel < 1 {
 		maxParallel = 3
+	}
+
+	validBackends := map[string]bool{"claude": true, "codex": true, "gemini": true, "cline": true}
+	if !validBackends[modelBackend] {
+		fmt.Fprintf(w, "  Note: %q is not a known backend; using anyway.\n", modelBackend)
 	}
 
 	telegramAnswer := promptInit(scanner, w, "Telegram notifications? (y/N)", "")
@@ -211,6 +220,49 @@ func launchdPlist(binPath, configPath string) string {
 </dict>
 </plist>
 `, binPath, configPath)
+}
+
+// checkPrerequisites prints a summary of required tools and their availability.
+func checkPrerequisites(w io.Writer) {
+	fmt.Fprintln(w, "Checking prerequisites...")
+
+	required := []struct {
+		name string
+		hint string
+	}{
+		{"git", "install from https://git-scm.com"},
+		{"gh", "install from https://cli.github.com"},
+		{"tmux", "install: apt install tmux / brew install tmux"},
+	}
+
+	aiCLIs := []string{"claude", "codex", "gemini", "cline"}
+
+	allOK := true
+	for _, dep := range required {
+		if _, err := exec.LookPath(dep.name); err != nil {
+			fmt.Fprintf(w, "  \u2717 %s — %s\n", dep.name, dep.hint)
+			allOK = false
+		} else {
+			fmt.Fprintf(w, "  \u2713 %s\n", dep.name)
+		}
+	}
+
+	foundAI := false
+	for _, cli := range aiCLIs {
+		if _, err := exec.LookPath(cli); err == nil {
+			fmt.Fprintf(w, "  \u2713 %s\n", cli)
+			foundAI = true
+		}
+	}
+	if !foundAI {
+		fmt.Fprintln(w, "  \u2717 no AI CLI found (install one of: claude, codex, gemini, cline)")
+		allOK = false
+	}
+
+	if !allOK {
+		fmt.Fprintln(w, "  Warning: some prerequisites are missing. Install them before running maestro.")
+	}
+	fmt.Fprintln(w)
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -120,6 +120,9 @@ func TestRunInitWizard(t *testing.T) {
 	if !strings.Contains(out, "Welcome to Maestro") {
 		t.Error("should show welcome message")
 	}
+	if !strings.Contains(out, "Checking prerequisites") {
+		t.Error("should show prerequisite check")
+	}
 	if !strings.Contains(out, "\u2705 Created maestro.yaml") {
 		t.Error("should show config created message")
 	}
@@ -257,6 +260,45 @@ func TestRunInitWizardStateDirConfirmation(t *testing.T) {
 	maestroDir := filepath.Join(tmpDir, ".maestro")
 	if !strings.Contains(out, maestroDir) {
 		t.Errorf("output should mention state directory %s, got:\n%s", maestroDir, out)
+	}
+}
+
+func TestCheckPrerequisites(t *testing.T) {
+	var buf bytes.Buffer
+	checkPrerequisites(&buf)
+	out := buf.String()
+	if !strings.Contains(out, "Checking prerequisites") {
+		t.Error("should print header")
+	}
+	// git should always be present in test environment
+	if !strings.Contains(out, "git") {
+		t.Error("should check for git")
+	}
+}
+
+func TestRunInitWizardUnknownBackend(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	input := "org/repo\n\n\n\ncustomai\n\n\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err != nil {
+		t.Fatalf("runInitWizard error: %v", err)
+	}
+
+	out := output.String()
+	if !strings.Contains(out, "not a known backend") {
+		t.Errorf("should warn about unknown backend, got:\n%s", out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "maestro.yaml"))
+	if err != nil {
+		t.Fatal("maestro.yaml not created")
+	}
+	if !strings.Contains(string(data), "default: customai") {
+		t.Errorf("should still use the custom backend, got:\n%s", string(data))
 	}
 }
 

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,25 @@ main() {
     fi
 
     echo "maestro ${LATEST} installed to ${INSTALL_DIR}/maestro"
+
+    # Verify the install worked
+    if command -v maestro >/dev/null 2>&1; then
+        maestro version
+    fi
+
+    # Remind about prerequisites
+    echo
+    echo "Prerequisites (install if missing):"
+    for dep in git gh tmux; do
+        if command -v "$dep" >/dev/null 2>&1; then
+            printf "  ✓ %s\n" "$dep"
+        else
+            printf "  ✗ %s  ← install before running maestro\n" "$dep"
+        fi
+    done
+
+    echo
+    echo "Next: cd <your-repo> && maestro init"
 }
 
 main

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.


### PR DESCRIPTION
Implements #85

## Changes

Reviewed the install.sh script and `maestro init` wizard for friction points a new user would encounter on a fresh machine. Found and fixed:

### install.sh
- **Post-install verification**: runs `maestro version` after install to confirm the binary works
- **Prerequisite summary**: checks for `git`, `gh`, `tmux` and prints ✓/✗ status with install hints
- **Next-step guidance**: tells the user to run `cd <repo> && maestro init`

### maestro init
- **Prerequisite checker**: scans for required tools (git, gh, tmux) and at least one AI CLI (claude/codex/gemini/cline) before starting the wizard, with clear warnings for anything missing
- **Missing backend**: "cline" was not listed in the model backend prompt — fixed to show all four options
- **Backend validation**: warns (but allows) unknown backend names so users aren't silently misconfigured

### README
- Updated the `maestro init` wizard description to reflect the new prerequisite check step

## Friction points documented
1. `install.sh` gave no feedback about prerequisites after install — fixed
2. `maestro init` didn't check if required tools were available — fixed
3. `cline` was missing from the init wizard's backend choices — fixed
4. No validation on backend name input could lead to silent misconfiguration — fixed

## Testing
- All existing tests pass (`go test ./...`)
- Added new tests: `TestCheckPrerequisites`, `TestRunInitWizardUnknownBackend`
- Updated `TestRunInitWizard` to verify prerequisite check output
- `go vet ./...` clean
- Binary builds and runs: `./maestro version`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR significantly improves the onboarding experience for new Maestro users by adding prerequisite validation and clearer guidance throughout the installation and initialization process.

**Key improvements:**
- Post-install verification confirms the binary works correctly
- Prerequisite scanner checks for required tools (git, gh, tmux) and AI CLIs before starting the wizard
- Missing "cline" backend option added to the init wizard prompt
- Backend name validation warns users about unknown backends while still allowing custom configurations
- Clear next-step guidance helps users proceed after installation

**Code quality:**
- Well-structured implementation with proper error handling
- Comprehensive test coverage for new functionality
- Non-blocking warnings preserve flexibility while guiding users
- Documentation updated to reflect new behavior

All changes are backward-compatible, well-tested, and directly address the friction points documented in the PR description.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The implementation is clean, well-tested, and addresses clear UX friction points. All changes are additive improvements to user guidance without modifying core logic. Tests pass and cover new functionality comprehensively.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| install.sh | Added post-install verification, prerequisite checking for git/gh/tmux with helpful install hints, and clear next-step guidance |
| cmd/maestro/init.go | Added `checkPrerequisites()` function to scan for required tools and AI CLIs before wizard starts, updated backend prompt to include cline, added backend validation with warnings for unknown backends |
| cmd/maestro/init_test.go | Added comprehensive tests for prerequisite checking and unknown backend validation; updated existing test to verify prerequisite check output |
| internal/config/config.go | Formatting-only changes to align inline comments; no functional changes |
| README.md | Updated wizard documentation to reflect new prerequisite checking step and restructured the init wizard description for clarity |

</details>



<sub>Last reviewed commit: c9dfca7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->