### PR TITLE
feat: improve install and init onboarding flow (#85)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -51,6 +52,9 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	fmt.Fprintln(w, "Welcome to Maestro! Let's set up your first project.")
 	fmt.Fprintln(w)
 
+	// Check prerequisites and warn about missing tools
+	checkPrerequisites(w)
+
 	repo := promptInit(scanner, w, "GitHub repo (owner/repo)", "")
 	if repo == "" {
 		return fmt.Errorf("repo is required")
@@ -65,7 +69,7 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	localPath := promptInit(scanner, w, "Local clone path", "~/src/"+repoName)
 	worktreeBase := promptInit(scanner, w, "Worktree base dir", "~/.worktrees/"+repoName)
 	maxParallelStr := promptInit(scanner, w, "Max parallel workers", "3")
-	modelBackend := promptInit(scanner, w, "Default model backend (claude/codex/gemini)", "claude")
+	modelBackend := promptInit(scanner, w, "Default model backend (claude/codex/gemini/cline)", "claude")
 	issueLabel := promptInit(scanner, w, "Issue label filter", "enhancement")
 
 	maxParallel, err := strconv.Atoi(maxParallelStr)
@@ -78,11 +82,9 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 
 	var telegram *initYAMLTelegram
 	if wantsTelegram {
-		fmt.Fprintf(w, "  \u2192 Telegram target ID: ")
-		if scanner.Scan() {
-			if id := strings.TrimSpace(scanner.Text()); id != "" {
-				telegram = &initYAMLTelegram{Target: id}
-			}
+		telegramTarget := promptInit(scanner, w, "Telegram target ID", "")
+		if telegramTarget != "" {
+			telegram = &initYAMLTelegram{Target: telegramTarget}
 		}
 	}
 
@@ -227,4 +229,60 @@ func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string
 		return defaultVal
 	}
 	return answer
+}
+
+// checkPrerequisites checks for required and optional tools and prints
+// warnings for anything missing. It does not block the wizard — just warns.
+// The lookPath parameter allows tests to inject a stub.
+func checkPrerequisites(w io.Writer) {
+	checkPrerequisitesWithLookPath(w, exec.LookPath)
+}
+
+func checkPrerequisitesWithLookPath(w io.Writer, lookPath func(string) (string, error)) {
+	type tool struct {
+		name     string
+		required bool
+		hint     string
+	}
+
+	required := []tool{
+		{"git", true, "pre-installed on most systems"},
+		{"gh", true, "install from https://cli.github.com"},
+		{"tmux", true, "install: apt install tmux / brew install tmux"},
+	}
+
+	backends := []tool{
+		{"claude", false, ""},
+		{"codex", false, ""},
+		{"gemini", false, ""},
+		{"cline", false, ""},
+	}
+
+	fmt.Fprintln(w, "Checking prerequisites...")
+
+	allOk := true
+	for _, t := range required {
+		if _, err := lookPath(t.name); err != nil {
+			fmt.Fprintf(w, "  [!] %s not found — %s\n", t.name, t.hint)
+			allOk = false
+		}
+	}
+
+	hasBackend := false
+	for _, t := range backends {
+		if _, err := lookPath(t.name); err == nil {
+			hasBackend = true
+			break
+		}
+	}
+	if !hasBackend {
+		fmt.Fprintln(w, "  [!] No AI backend CLI found (claude, codex, gemini, or cline)")
+		fmt.Fprintln(w, "      Install at least one before running maestro")
+		allOk = false
+	}
+
+	if allOk {
+		fmt.Fprintln(w, "  All prerequisites found.")
+	}
+	fmt.Fprintln(w)
 }

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -257,6 +258,69 @@ func TestRunInitWizardStateDirConfirmation(t *testing.T) {
 	maestroDir := filepath.Join(tmpDir, ".maestro")
 	if !strings.Contains(out, maestroDir) {
 		t.Errorf("output should mention state directory %s, got:\n%s", maestroDir, out)
+	}
+}
+
+func TestCheckPrerequisitesAllPresent(t *testing.T) {
+	var buf bytes.Buffer
+	found := func(name string) (string, error) { return "/usr/bin/" + name, nil }
+	checkPrerequisitesWithLookPath(&buf, found)
+
+	out := buf.String()
+	if !strings.Contains(out, "Checking prerequisites") {
+		t.Error("should show checking message")
+	}
+	if !strings.Contains(out, "All prerequisites found") {
+		t.Errorf("should show all-ok message, got:\n%s", out)
+	}
+	if strings.Contains(out, "[!]") {
+		t.Errorf("should not show warnings, got:\n%s", out)
+	}
+}
+
+func TestCheckPrerequisitesMissing(t *testing.T) {
+	var buf bytes.Buffer
+	// Only git is present
+	found := func(name string) (string, error) {
+		if name == "git" {
+			return "/usr/bin/git", nil
+		}
+		return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+	}
+	checkPrerequisitesWithLookPath(&buf, found)
+
+	out := buf.String()
+	if !strings.Contains(out, "[!] gh not found") {
+		t.Errorf("should warn about missing gh, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[!] tmux not found") {
+		t.Errorf("should warn about missing tmux, got:\n%s", out)
+	}
+	if !strings.Contains(out, "No AI backend CLI found") {
+		t.Errorf("should warn about missing backends, got:\n%s", out)
+	}
+	if strings.Contains(out, "All prerequisites found") {
+		t.Errorf("should not show all-ok message when tools missing, got:\n%s", out)
+	}
+}
+
+func TestCheckPrerequisitesOneBackend(t *testing.T) {
+	var buf bytes.Buffer
+	found := func(name string) (string, error) {
+		switch name {
+		case "git", "gh", "tmux", "codex":
+			return "/usr/bin/" + name, nil
+		}
+		return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+	}
+	checkPrerequisitesWithLookPath(&buf, found)
+
+	out := buf.String()
+	if strings.Contains(out, "No AI backend CLI found") {
+		t.Errorf("should not warn about backends when codex is present, got:\n%s", out)
+	}
+	if !strings.Contains(out, "All prerequisites found") {
+		t.Errorf("should show all-ok when all required + one backend found, got:\n%s", out)
 	}
 }
 

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,11 @@ main() {
     fi
 
     echo "maestro ${LATEST} installed to ${INSTALL_DIR}/maestro"
+
+    # Verify the installed binary works
+    if "${INSTALL_DIR}/maestro" version >/dev/null 2>&1; then
+        echo "Verified: $("${INSTALL_DIR}/maestro" version)"
+    fi
 }
 
 main

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.


### PR DESCRIPTION
Implements #85

## Changes

Reviewed `install.sh` and `maestro init` for friction points a new user on a fresh machine would encounter. Found and fixed several issues:

**`maestro init` improvements:**
- **Prerequisite checks**: The wizard now checks for `git`, `gh`, `tmux`, and at least one AI backend CLI (claude/codex/gemini/cline) before starting. Missing tools are reported with install hints. This is non-blocking — the wizard continues but the user knows what to fix.
- **Backend prompt includes cline**: The model backend prompt now lists all four supported backends (`claude/codex/gemini/cline`) instead of just three.
- **Consistent Telegram prompt**: The Telegram target ID prompt now uses the standard `promptInit()` function instead of a one-off `fmt.Fprintf` + `scanner.Scan()`, giving a consistent UX with the other prompts.

**`install.sh` improvements:**
- **Post-install verification**: After installing the binary, the script runs `maestro version` and prints the output to confirm the binary works correctly on the target system.

**Cosmetic:**
- `go fmt` alignment fix in `internal/config/config.go` (whitespace only).

## Friction points documented

1. No prerequisite checks before init — user could complete setup then fail on `maestro run` (fixed)
2. `cline` backend missing from init prompt despite being fully supported (fixed)
3. Telegram target ID prompt used different UX pattern than all other prompts (fixed)
4. No verification that installed binary actually works on target architecture (fixed)

## Testing

- All existing tests pass (`go test ./...` — 10 packages)
- Added 3 new tests for prerequisite checking: `TestCheckPrerequisitesAllPresent`, `TestCheckPrerequisitesMissing`, `TestCheckPrerequisitesOneBackend`
- Binary builds and runs successfully (`go build ./cmd/maestro/ && ./maestro version`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved the onboarding experience by adding prerequisite checks during `maestro init` and post-install verification in `install.sh`.

**Key improvements:**
- Added upfront checks for required tools (`git`, `gh`, `tmux`) and at least one AI backend CLI before the init wizard starts
- Updated model backend prompt to include `cline` alongside `claude/codex/gemini` (was missing despite being fully supported)
- Standardized Telegram target ID prompt to use `promptInit()` for consistent UX
- Added post-install verification that runs `maestro version` to confirm the binary works on the target system
- Included comprehensive test coverage for the new prerequisite checking logic

The changes directly address friction points that would confuse new users — failing to mention supported backends, discovering missing prerequisites only after completing setup, and not knowing if the installed binary works correctly.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — well-tested improvements to onboarding UX with no breaking changes
- All changes improve user experience without affecting core functionality. New prerequisite checks are non-blocking (warn-only), tests provide good coverage, and the only minor issue is a style optimization in install.sh that doesn't affect correctness
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Added prerequisite checks for git/gh/tmux/backends with helpful warnings, updated backend prompt to include cline, and standardized Telegram prompt UX - all changes improve onboarding experience |
| cmd/maestro/init_test.go | Added comprehensive test coverage for new prerequisite checking logic with proper dependency injection - tests cover all scenarios (all present, missing tools, partial backend availability) |
| install.sh | Added post-install verification by running `maestro version`, but runs command twice when successful and provides no feedback when verification fails |
| internal/config/config.go | Cosmetic formatting change only - realigned inline comments for better readability |

</details>



<sub>Last reviewed commit: a51c515</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->