### PR TITLE
feat: install testing — fix friction points and document findings (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Get maestro running in under 5 minutes:
 ```bash
 # 1. Install maestro
 curl -fsSL https://raw.githubusercontent.com/BeFeast/maestro/main/install.sh | sh
+maestro version   # verify installation
 
 # 2. Clone your target repo (if not already)
 gh repo clone owner/myrepo ~/src/myrepo
@@ -99,6 +100,9 @@ gh repo clone owner/myrepo ~/src/myrepo
 # 3. Run the interactive setup wizard
 cd ~/src/myrepo
 maestro init
+
+# 4. Add maestro.yaml to .gitignore (it contains local paths)
+echo "maestro.yaml" >> .gitignore
 ```
 
 The `maestro init` wizard will ask you for:

--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -60,6 +61,9 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Welcome to Maestro! Let's set up your first project.")
 	fmt.Fprintln(w)
+
+	// Check prerequisites
+	checkInitPrerequisites(w)
 
 	repo := promptInit(scanner, w, "GitHub repo (owner/repo)", "")
 	if repo == "" {
@@ -255,6 +259,43 @@ func buildInitYAML(cfg initYAMLConfig) string {
 	sb.WriteString("#   - wontfix\n")
 	sb.WriteString("#   - duplicate\n")
 	return sb.String()
+}
+
+func checkInitPrerequisites(w io.Writer) {
+	required := []struct {
+		cmd  string
+		hint string
+	}{
+		{"git", "install git: https://git-scm.com"},
+		{"gh", "install GitHub CLI: https://cli.github.com"},
+		{"tmux", "install tmux: apt install tmux / brew install tmux"},
+	}
+
+	allOK := true
+	for _, req := range required {
+		if _, err := exec.LookPath(req.cmd); err != nil {
+			fmt.Fprintf(w, "  WARNING: %s not found — %s\n", req.cmd, req.hint)
+			allOK = false
+		}
+	}
+
+	// Check for at least one AI backend
+	backends := []string{"claude", "codex", "gemini", "cline"}
+	hasBackend := false
+	for _, b := range backends {
+		if _, err := exec.LookPath(b); err == nil {
+			hasBackend = true
+			break
+		}
+	}
+	if !hasBackend {
+		fmt.Fprintf(w, "  WARNING: no AI CLI found (claude/codex/gemini/cline) — install at least one\n")
+		allOK = false
+	}
+
+	if !allOK {
+		fmt.Fprintln(w)
+	}
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -337,6 +337,15 @@ func TestRunInitWizardAllValidBackends(t *testing.T) {
 	}
 }
 
+func TestCheckInitPrerequisites(t *testing.T) {
+	var buf bytes.Buffer
+	checkInitPrerequisites(&buf)
+	// git should always be available in test environments
+	if strings.Contains(buf.String(), "git not found") {
+		t.Error("git should be found in test environment")
+	}
+}
+
 func TestRunInitWizardRicherConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
@@ -407,5 +416,23 @@ func TestBuildInitYAML(t *testing.T) {
 	}
 	if !strings.Contains(yaml, `target: "12345"`) {
 		t.Error("should contain telegram target")
+	}
+}
+
+func TestRunInitWizardShowsBackendOptions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	input := "org/repo\n\n\n\n\n\n\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err != nil {
+		t.Fatalf("runInitWizard error: %v", err)
+	}
+
+	out := output.String()
+	if !strings.Contains(out, "cline") {
+		t.Errorf("model backend prompt should mention cline, got:\n%s", out)
 	}
 }

--- a/docs/install-testing.md
+++ b/docs/install-testing.md
@@ -1,0 +1,62 @@
+# Install Testing Report
+
+Testing the maestro installation and onboarding flow (Issue #85).
+
+## Test Environment
+
+Fresh machine (not .14 or .22), testing the full install -> init -> run flow.
+
+## install.sh
+
+### What works
+- OS/arch detection (linux/darwin, amd64/arm64) works correctly
+- Downloads correct tarball from GitHub Releases
+- Binary naming matches release workflow (`maestro-{os}-{arch}.tar.gz` containing `maestro-{os}-{arch}`)
+- `sudo` is only used when `INSTALL_DIR` is not writable
+- Custom `INSTALL_DIR` works via environment variable
+- Cleanup via `trap` on exit
+
+### Friction points found
+1. **No checksum verification** — `checksums.txt` is generated in the release workflow but `install.sh` never downloads or verifies it. A compromised release asset would be installed without detection.
+2. **No post-install verification** — Fixed: now runs `maestro version` after install.
+3. **No next-steps guidance** — Fixed: now prints next steps (init, run).
+4. **Silent failure on missing `curl`/`tar`** — These are assumed present. Rare issue in practice.
+
+## maestro init
+
+### What works
+- Interactive prompts with sensible defaults
+- Repo format validation (owner/repo)
+- Generates valid `maestro.yaml`
+- Creates `~/.maestro/` state directory
+- Generates platform-appropriate service file (systemd on Linux, launchd on macOS)
+- Invalid `max_parallel` falls back to default (3)
+
+### Friction points found
+1. **Missing "cline" in backend prompt** — Fixed: prompt now shows `(claude/codex/gemini/cline)`.
+2. **No prerequisite checks** — Fixed: init now warns if `git`, `gh`, `tmux`, or AI CLIs are missing.
+3. **No model backend validation** — Accepts any string (e.g., "foo"). Should validate against known backends.
+4. **Generated config is minimal** — Missing useful keys like `max_runtime_minutes`, `worker_prompt`, `merge_strategy`, `auto_rebase`. New users don't discover these until they read the full README.
+5. **No `.gitignore` warning** — `maestro.yaml` is created in the repo dir but contains local paths. Easy to accidentally commit.
+6. **systemd unit doesn't set PATH** — AI CLIs installed via npm/bun (in `~/.local/bin` or `~/.bun/bin`) won't be found when the service runs. Needs `Environment=PATH=...` in the unit file.
+7. **No worker prompt setup** — Init doesn't ask about or create a worker prompt template. Without one, workers use a bare-bones built-in prompt.
+
+## README
+
+### What works
+- Clear structure: prerequisites, installation, quickstart, configuration, troubleshooting
+- Good troubleshooting section covering common issues
+- Multi-project setup is well documented
+- Service file instructions for both Linux and macOS
+
+### Friction points found
+1. **No `maestro version` in quickstart** — Fixed: added verification step after install.
+2. **No `.gitignore` warning in quickstart** — Fixed: added step to add `maestro.yaml` to `.gitignore`.
+3. **`loginctl enable-linger` buried in troubleshooting** — This is required for systemd services to persist across logouts but isn't mentioned in the quickstart or service setup section.
+4. **No end-to-end walkthrough** — A new user has to piece together prerequisites, install, init, and service setup from different sections.
+
+## Sub-issues opened
+
+- #103: install.sh — add checksum verification
+- #104: init — validate model backend and generate richer config
+- #105: init — set PATH in generated systemd unit for AI CLI discovery

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,19 @@ main() {
     fi
 
     echo "maestro ${LATEST} installed to ${INSTALL_DIR}/maestro"
+
+    # Verify installation
+    if command -v maestro >/dev/null 2>&1; then
+        echo "Verify: $(maestro version)"
+    elif [ -x "${INSTALL_DIR}/maestro" ]; then
+        echo "Verify: $("${INSTALL_DIR}/maestro" version)"
+    fi
+
+    echo
+    echo "Next steps:"
+    echo "  1. cd <your-repo>"
+    echo "  2. maestro init"
+    echo "  3. maestro run --once"
 }
 
 main


### PR DESCRIPTION
Implements #85

## Changes

Tested the full maestro install → init → run onboarding flow and fixed friction points found:

### Direct fixes
- **init: add "cline" to model backend prompt** — the prompt listed `(claude/codex/gemini)` but `cline` is a supported backend
- **init: add prerequisite checks** — warns if `git`, `gh`, `tmux`, or AI CLIs are missing before proceeding with setup
- **install.sh: add post-install verification** — runs `maestro version` after install and prints next-steps guidance
- **README: improve quickstart** — added `maestro version` verification step and `.gitignore` guidance for `maestro.yaml`
- **go fmt config.go** — fixed struct tag alignment

### Documentation
- Added `docs/install-testing.md` with full testing report documenting all friction points found

### Sub-issues opened for bigger items
- #103: install.sh — add checksum verification
- #104: init — validate model backend and generate richer config
- #105: init — set PATH in generated systemd unit for AI CLI discovery

## Testing
- All existing tests pass (`go test ./...`)
- Added `TestCheckInitPrerequisites` and `TestRunInitWizardShowsBackendOptions` tests
- `go vet ./...` clean
- Binary builds and runs (`./maestro version`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully addresses friction points in the maestro installation flow by adding prerequisite checks, post-install verification, and improved documentation.

**Key improvements:**
- Added prerequisite checks during `maestro init` to warn about missing `git`, `gh`, `tmux`, or AI CLIs
- Updated model backend prompt to include "cline" as a supported option
- Enhanced `install.sh` with post-install verification (`maestro version`) and next-steps guidance
- Fixed PATH environment variable in generated systemd/launchd service files for AI CLI discovery
- Added verification step and `.gitignore` guidance to README quickstart
- Comprehensive testing documentation in `docs/install-testing.md`

**Issues found:**
- Step numbering in README quickstart is off (two step 4s)
- Minor code duplication in backends list that could cause maintenance issues

All tests pass and the changes align well with the documented friction points from the testing report.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing the README step numbering
- Score reflects well-tested, focused changes with comprehensive documentation. The step numbering issue in README is a minor documentation bug that should be fixed before merge. The code changes are sound and add valuable UX improvements to the installation flow.
- README.md needs step numbering fix, otherwise all changes look good

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Added verification step and `.gitignore` guidance to quickstart, but step numbering is off |
| cmd/maestro/init.go | Added prerequisite checks, updated model backend prompt to include cline, and set PATH in service files - minor code duplication in backends list |
| cmd/maestro/init_test.go | Added tests for prerequisite checks and backend options display |
| install.sh | Added post-install verification and helpful next-steps guidance |
| docs/install-testing.md | Comprehensive testing documentation covering installation flow and friction points |

</details>



<sub>Last reviewed commit: 86d8604</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->