### PR TITLE
fix: init — set PATH in generated systemd unit for AI CLI discovery (#105)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -145,6 +145,7 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 }
 
 func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
+	pathEnv := os.Getenv("PATH")
 	switch runtime.GOOS {
 	case "linux":
 		dir := filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user")
@@ -152,7 +153,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "maestro.service")
-		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath, pathEnv)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -162,7 +163,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "com.maestro.agent.plist")
-		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath, pathEnv)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -170,29 +171,35 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 	return nil
 }
 
-func systemdUnit(binPath, configPath string) string {
+func systemdUnit(binPath, configPath, pathEnv string) string {
 	return fmt.Sprintf(`[Unit]
 Description=Maestro - AI coding agent orchestrator
 After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=%s
 ExecStart=%s run --config %s
 Restart=on-failure
 RestartSec=30
 
 [Install]
 WantedBy=default.target
-`, binPath, configPath)
+`, pathEnv, binPath, configPath)
 }
 
-func launchdPlist(binPath, configPath string) string {
+func launchdPlist(binPath, configPath, pathEnv string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
     <string>com.maestro.agent</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>%s</string>
+    </dict>
     <key>ProgramArguments</key>
     <array>
         <string>%s</string>
@@ -210,7 +217,7 @@ func launchdPlist(binPath, configPath string) string {
     <string>/tmp/maestro.stderr.log</string>
 </dict>
 </plist>
-`, binPath, configPath)
+`, pathEnv, binPath, configPath)
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -53,9 +53,12 @@ func TestPromptInitOutput(t *testing.T) {
 }
 
 func TestSystemdUnit(t *testing.T) {
-	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin")
 	if !strings.Contains(content, "ExecStart=/usr/bin/maestro run --config /etc/maestro.yaml") {
 		t.Error("should contain correct ExecStart line")
+	}
+	if !strings.Contains(content, "Environment=PATH=/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin") {
+		t.Error("should contain Environment=PATH line")
 	}
 	for _, section := range []string{"[Unit]", "[Service]", "[Install]"} {
 		if !strings.Contains(content, section) {
@@ -65,7 +68,7 @@ func TestSystemdUnit(t *testing.T) {
 }
 
 func TestLaunchdPlist(t *testing.T) {
-	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin")
 	if !strings.Contains(content, "<string>/usr/bin/maestro</string>") {
 		t.Error("should contain binary path")
 	}
@@ -74,6 +77,12 @@ func TestLaunchdPlist(t *testing.T) {
 	}
 	if !strings.Contains(content, "com.maestro.agent") {
 		t.Error("should contain label")
+	}
+	if !strings.Contains(content, "<key>EnvironmentVariables</key>") {
+		t.Error("should contain EnvironmentVariables key")
+	}
+	if !strings.Contains(content, "<string>/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin</string>") {
+		t.Error("should contain PATH value in EnvironmentVariables")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.


### PR DESCRIPTION
Implements #105

## Changes
- `systemdUnit()` now accepts a `pathEnv` parameter and emits `Environment=PATH=...` in the `[Service]` section
- `launchdPlist()` now accepts a `pathEnv` parameter and emits an `EnvironmentVariables` dict with the PATH
- `writeInitServiceFile()` captures `$PATH` from the current environment at init time and passes it to both generators
- Updated tests to verify PATH is embedded in both systemd and launchd output

This ensures AI CLIs installed via npm/bun (typically in `~/.local/bin`, `~/.bun/bin`, etc.) are discoverable when the service starts.

## Testing
- `go test ./...` — all tests pass
- `go vet ./...` — clean
- `go build ./cmd/maestro/` — binary builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully implements PATH environment variable propagation to generated service files (systemd and launchd), ensuring AI CLIs installed via npm/bun are discoverable when the service starts.

**Key Changes:**
- Captures `$PATH` from the current environment during `maestro init`
- Injects PATH into systemd unit files via `Environment=PATH=...` directive
- Injects PATH into launchd plist files via `EnvironmentVariables` dictionary
- Comprehensive test coverage verifies PATH embedding in both service types

**Implementation:**
- Clean function signature updates with new `pathEnv` parameter
- Single point of capture (`os.Getenv("PATH")`) passed to both generators
- Non-breaking changes - all existing tests pass
- Formatting improvements in `config.go` (trailing space cleanup)

The implementation is straightforward, well-tested, and directly addresses the stated issue of AI CLI discovery in service environments.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects clean implementation with comprehensive test coverage. The changes are narrowly scoped, well-tested (all tests pass), and directly address the stated issue. No logic errors, security concerns, or breaking changes identified. The PATH capture and injection mechanism is straightforward and follows established patterns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Added PATH environment variable capture and injection into systemd unit and launchd plist files to ensure AI CLI discoverability |
| cmd/maestro/init_test.go | Updated tests to verify PATH embedding in both systemd and launchd service configurations |
| internal/config/config.go | Minor formatting changes to inline comments (removed trailing spaces) |

</details>



<sub>Last reviewed commit: d97ad8a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->