### PR TITLE
fix: set PATH in generated systemd unit and launchd plist (#105)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -127,7 +127,8 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 		absConfigPath = yamlPath
 	}
 
-	if err := writeInitServiceFile(w, binPath, absConfigPath); err != nil {
+	currentPATH := os.Getenv("PATH")
+	if err := writeInitServiceFile(w, binPath, absConfigPath, currentPATH); err != nil {
 		fmt.Fprintf(w, "Note: could not create service file: %v\n", err)
 	}
 
@@ -144,7 +145,7 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	return nil
 }
 
-func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
+func writeInitServiceFile(w io.Writer, binPath, configPath, pathEnv string) error {
 	switch runtime.GOOS {
 	case "linux":
 		dir := filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user")
@@ -152,7 +153,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "maestro.service")
-		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath, pathEnv)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -162,7 +163,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "com.maestro.agent.plist")
-		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath, pathEnv)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -170,23 +171,24 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 	return nil
 }
 
-func systemdUnit(binPath, configPath string) string {
+func systemdUnit(binPath, configPath, pathEnv string) string {
 	return fmt.Sprintf(`[Unit]
 Description=Maestro - AI coding agent orchestrator
 After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=%s
 ExecStart=%s run --config %s
 Restart=on-failure
 RestartSec=30
 
 [Install]
 WantedBy=default.target
-`, binPath, configPath)
+`, pathEnv, binPath, configPath)
 }
 
-func launchdPlist(binPath, configPath string) string {
+func launchdPlist(binPath, configPath, pathEnv string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -200,6 +202,11 @@ func launchdPlist(binPath, configPath string) string {
         <string>--config</string>
         <string>%s</string>
     </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>%s</string>
+    </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -210,7 +217,7 @@ func launchdPlist(binPath, configPath string) string {
     <string>/tmp/maestro.stderr.log</string>
 </dict>
 </plist>
-`, binPath, configPath)
+`, binPath, configPath, pathEnv)
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -53,9 +53,12 @@ func TestPromptInitOutput(t *testing.T) {
 }
 
 func TestSystemdUnit(t *testing.T) {
-	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin")
 	if !strings.Contains(content, "ExecStart=/usr/bin/maestro run --config /etc/maestro.yaml") {
 		t.Error("should contain correct ExecStart line")
+	}
+	if !strings.Contains(content, "Environment=PATH=/usr/local/bin:/usr/bin:/bin") {
+		t.Errorf("should contain Environment=PATH line, got:\n%s", content)
 	}
 	for _, section := range []string{"[Unit]", "[Service]", "[Install]"} {
 		if !strings.Contains(content, section) {
@@ -65,7 +68,7 @@ func TestSystemdUnit(t *testing.T) {
 }
 
 func TestLaunchdPlist(t *testing.T) {
-	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin")
 	if !strings.Contains(content, "<string>/usr/bin/maestro</string>") {
 		t.Error("should contain binary path")
 	}
@@ -74,6 +77,12 @@ func TestLaunchdPlist(t *testing.T) {
 	}
 	if !strings.Contains(content, "com.maestro.agent") {
 		t.Error("should contain label")
+	}
+	if !strings.Contains(content, "<key>EnvironmentVariables</key>") {
+		t.Error("should contain EnvironmentVariables key")
+	}
+	if !strings.Contains(content, "<string>/usr/local/bin:/usr/bin:/bin</string>") {
+		t.Errorf("should contain PATH value in EnvironmentVariables, got:\n%s", content)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.


### PR DESCRIPTION
Implements #105

## Changes
- Capture the user's current `PATH` during `maestro init` and embed it in the generated service files
- **systemd** (Linux): Add `Environment=PATH=...` to the `[Service]` section so AI CLIs in user directories (`~/.local/bin`, `~/.bun/bin`, etc.) are found at runtime
- **launchd** (macOS): Add `EnvironmentVariables` dict with `PATH` key to the plist for the same reason
- Updated `systemdUnit()`, `launchdPlist()`, and `writeInitServiceFile()` signatures to accept the PATH string
- Updated existing tests to verify PATH is present in generated output

## Testing
- All existing tests pass with updated signatures
- `TestSystemdUnit` verifies `Environment=PATH=...` line is present
- `TestLaunchdPlist` verifies `EnvironmentVariables` dict with PATH is present
- `go vet`, `go fmt`, `go build` all pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully implements #105 by capturing the user's PATH environment variable during `maestro init` and embedding it in generated systemd unit and launchd plist files. This ensures that AI CLIs installed in user-specific directories (like `~/.local/bin`, `~/.bun/bin`, etc.) are available when the service runs.

**Key Changes:**
- Captures `PATH` using `os.Getenv("PATH")` during initialization
- Added `Environment=PATH=...` to systemd service unit `[Service]` section
- Added `EnvironmentVariables` dict with `PATH` key to launchd plist
- Updated function signatures for `systemdUnit()`, `launchdPlist()`, and `writeInitServiceFile()` to accept PATH parameter
- Tests updated to verify PATH presence in generated output

**Minor Concern:**
- The PATH value inserted into the launchd plist XML template should be XML-escaped to handle edge cases where PATH might contain XML special characters (`&`, `<`, etc.)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and solves a real problem (AI CLIs not being found at runtime). Tests have been updated to verify the new functionality. The only minor concern is the lack of XML escaping for the PATH value in the launchd plist, which could theoretically cause issues if PATH contains XML special characters, though this is unlikely in practice.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Added PATH environment variable capture and injection into systemd/launchd service files; minor XML escaping concern in plist generation |
| cmd/maestro/init_test.go | Updated tests to include PATH parameter and verify it appears in generated service files |
| internal/config/config.go | Comment alignment formatting only, no functional changes |

</details>



<sub>Last reviewed commit: 4c7441f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->