### PR TITLE
fix: init — validate model backend and generate richer config (#104)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/befeast/maestro/internal/worker"
 	"gopkg.in/yaml.v3"
 )
 
@@ -65,7 +67,13 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	localPath := promptInit(scanner, w, "Local clone path", "~/src/"+repoName)
 	worktreeBase := promptInit(scanner, w, "Worktree base dir", "~/.worktrees/"+repoName)
 	maxParallelStr := promptInit(scanner, w, "Max parallel workers", "3")
-	modelBackend := promptInit(scanner, w, "Default model backend (claude/codex/gemini)", "claude")
+	validBackends := worker.KnownBackends()
+	sort.Strings(validBackends)
+	backendList := strings.Join(validBackends, "/")
+	modelBackend := promptInit(scanner, w, fmt.Sprintf("Default model backend (%s)", backendList), "claude")
+	if !isValidBackend(modelBackend, validBackends) {
+		return fmt.Errorf("unknown model backend %q — valid options: %s", modelBackend, strings.Join(validBackends, ", "))
+	}
 	issueLabel := promptInit(scanner, w, "Issue label filter", "enhancement")
 
 	maxParallel, err := strconv.Atoi(maxParallelStr)
@@ -88,7 +96,8 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 
 	fmt.Fprintln(w)
 
-	// Build config
+	// Build config — marshal active settings via YAML, then append
+	// commented-out examples so new users can discover features.
 	cfg := initYAMLConfig{
 		Repo:         repo,
 		LocalPath:    localPath,
@@ -104,7 +113,18 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 
-	if err := os.WriteFile(yamlPath, yamlData, 0644); err != nil {
+	var buf strings.Builder
+	buf.Write(yamlData)
+	buf.WriteString("\n# --- Optional settings (uncomment to enable) ---\n")
+	buf.WriteString("# max_runtime_minutes: 120\n")
+	buf.WriteString("# auto_rebase: true\n")
+	buf.WriteString("# merge_strategy: sequential\n")
+	buf.WriteString("# worker_prompt: worker-prompt.md\n")
+	buf.WriteString("# exclude_labels:\n")
+	buf.WriteString("#   - wontfix\n")
+	buf.WriteString("#   - duplicate\n")
+
+	if err := os.WriteFile(yamlPath, []byte(buf.String()), 0644); err != nil {
 		return fmt.Errorf("write maestro.yaml: %w", err)
 	}
 	fmt.Fprintln(w, "\u2705 Created maestro.yaml")
@@ -211,6 +231,15 @@ func launchdPlist(binPath, configPath string) string {
 </dict>
 </plist>
 `, binPath, configPath)
+}
+
+func isValidBackend(name string, valid []string) bool {
+	for _, v := range valid {
+		if name == v {
+			return true
+		}
+	}
+	return false
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -260,6 +260,59 @@ func TestRunInitWizardStateDirConfirmation(t *testing.T) {
 	}
 }
 
+func TestRunInitWizardInvalidBackend(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// repo, local_path(default), worktree(default), max_parallel(default),
+	// model=invalid_backend
+	input := "org/repo\n\n\n\ninvalid_backend\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err == nil {
+		t.Fatal("expected error for invalid model backend")
+	}
+	if !strings.Contains(err.Error(), "unknown model backend") {
+		t.Errorf("error should mention 'unknown model backend', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error should list valid backends, got: %v", err)
+	}
+}
+
+func TestRunInitWizardRicherConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	input := "BeFeast/myrepo\n\n\n\n\n\n\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err != nil {
+		t.Fatalf("runInitWizard error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "maestro.yaml"))
+	if err != nil {
+		t.Fatal("maestro.yaml not created")
+	}
+
+	yamlStr := string(data)
+	commentedSettings := []string{
+		"# max_runtime_minutes: 120",
+		"# auto_rebase: true",
+		"# merge_strategy: sequential",
+		"# worker_prompt: worker-prompt.md",
+		"# exclude_labels:",
+	}
+	for _, setting := range commentedSettings {
+		if !strings.Contains(yamlStr, setting) {
+			t.Errorf("yaml missing commented-out setting %q, got:\n%s", setting, yamlStr)
+		}
+	}
+}
+
 func TestRunInitWizardInvalidMaxParallel(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -306,7 +306,7 @@ func TestBuildWorkerCmd_GenericInvalidPromptMode(t *testing.T) {
 
 func TestKnownBackends(t *testing.T) {
 	backends := KnownBackends()
-	expected := map[string]bool{"claude": false, "codex": false, "gemini": false}
+	expected := map[string]bool{"claude": false, "codex": false, "gemini": false, "cline": false}
 	for _, name := range backends {
 		if _, ok := expected[name]; ok {
 			expected[name] = true


### PR DESCRIPTION
Implements #104

## Changes
- **Validate model backend**: `maestro init` now rejects unknown backends with a clear error listing valid options (`claude`, `cline`, `codex`, `gemini`). The prompt dynamically lists backends from `worker.KnownBackends()` so newly added backends are automatically included.
- **Richer default config**: The generated `maestro.yaml` now includes commented-out examples for commonly used settings (`max_runtime_minutes`, `auto_rebase`, `merge_strategy`, `worker_prompt`, `exclude_labels`) to help new users discover features without reading the full README.
- **Fixed backend prompt**: Previously listed only `claude/codex/gemini` — now includes `cline` as well.
- **Fixed `TestKnownBackends`**: Was missing `cline` from expected backends.

## Testing
- Added `TestRunInitWizardInvalidBackend` — verifies unknown backends are rejected with a descriptive error
- Added `TestRunInitWizardRicherConfig` — verifies commented-out examples appear in generated YAML
- Updated `TestKnownBackends` to include all 4 backends
- All existing tests pass (`go test ./...`)
- Binary builds and runs (`go build ./cmd/maestro/ && ./maestro version`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully implements input validation for model backends during `maestro init` and enhances the generated config with helpful commented examples. The implementation is clean and well-tested.

**Key Changes:**
- Dynamically lists valid backends (`claude`, `cline`, `codex`, `gemini`) in the init prompt using `worker.KnownBackends()`
- Validates backend input and rejects unknown backends with a clear error message listing valid options
- Generates richer `maestro.yaml` with commented-out examples for `max_runtime_minutes`, `auto_rebase`, `merge_strategy`, `worker_prompt`, and `exclude_labels` to help users discover features
- Fixed test that was missing `cline` from expected backends

**Testing:**
All changes are well-covered by tests, including validation of invalid backends and verification of commented examples in generated config.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are well-tested with comprehensive test coverage, the implementation is straightforward with no complex logic, and the changes improve user experience without modifying any critical runtime behavior
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Added backend validation and richer config generation with commented examples — clean implementation |
| cmd/maestro/init_test.go | Added comprehensive tests for backend validation and richer config generation — good coverage |
| internal/config/config.go | Only cosmetic comment alignment changes — no functional modifications |
| internal/worker/backend_test.go | Updated test to include `cline` backend in expected backends — fixes test completeness |

</details>



<sub>Last reviewed commit: 639221b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->