### PR TITLE
feat: init — validate model backend and generate richer config (#104)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -9,9 +9,19 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 )
+
+// validBackends lists the accepted model backend names for init.
+var validBackends = []string{"claude", "codex", "gemini", "cline"}
+
+func isValidBackend(name string) bool {
+	for _, b := range validBackends {
+		if b == name {
+			return true
+		}
+	}
+	return false
+}
 
 // initYAMLConfig is the config structure written to maestro.yaml by init.
 type initYAMLConfig struct {
@@ -65,7 +75,10 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	localPath := promptInit(scanner, w, "Local clone path", "~/src/"+repoName)
 	worktreeBase := promptInit(scanner, w, "Worktree base dir", "~/.worktrees/"+repoName)
 	maxParallelStr := promptInit(scanner, w, "Max parallel workers", "3")
-	modelBackend := promptInit(scanner, w, "Default model backend (claude/codex/gemini)", "claude")
+	modelBackend := promptInit(scanner, w, "Default model backend (claude/codex/gemini/cline)", "claude")
+	if !isValidBackend(modelBackend) {
+		return fmt.Errorf("invalid model backend %q — valid options: %s", modelBackend, strings.Join(validBackends, ", "))
+	}
 	issueLabel := promptInit(scanner, w, "Issue label filter", "enhancement")
 
 	maxParallel, err := strconv.Atoi(maxParallelStr)
@@ -99,12 +112,9 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 		Telegram:     telegram,
 	}
 
-	yamlData, err := yaml.Marshal(&cfg)
-	if err != nil {
-		return fmt.Errorf("marshal config: %w", err)
-	}
+	yamlData := buildInitYAML(cfg)
 
-	if err := os.WriteFile(yamlPath, yamlData, 0644); err != nil {
+	if err := os.WriteFile(yamlPath, []byte(yamlData), 0644); err != nil {
 		return fmt.Errorf("write maestro.yaml: %w", err)
 	}
 	fmt.Fprintln(w, "\u2705 Created maestro.yaml")
@@ -218,6 +228,33 @@ func launchdPlist(binPath, configPath, pathEnv string) string {
 </dict>
 </plist>
 `, pathEnv, binPath, configPath)
+}
+
+func buildInitYAML(cfg initYAMLConfig) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("repo: %s\n", cfg.Repo))
+	sb.WriteString(fmt.Sprintf("local_path: %s\n", cfg.LocalPath))
+	sb.WriteString(fmt.Sprintf("worktree_base: %s\n", cfg.WorktreeBase))
+	sb.WriteString(fmt.Sprintf("max_parallel: %d\n", cfg.MaxParallel))
+	sb.WriteString("issue_labels:\n")
+	for _, l := range cfg.IssueLabels {
+		sb.WriteString(fmt.Sprintf("  - %s\n", l))
+	}
+	sb.WriteString("model:\n")
+	sb.WriteString(fmt.Sprintf("  default: %s\n", cfg.Model.Default))
+	if cfg.Telegram != nil {
+		sb.WriteString("telegram:\n")
+		sb.WriteString(fmt.Sprintf("  target: \"%s\"\n", cfg.Telegram.Target))
+	}
+	sb.WriteString("\n# --- Optional settings (uncomment to enable) ---\n")
+	sb.WriteString("# max_runtime_minutes: 120\n")
+	sb.WriteString("# auto_rebase: true\n")
+	sb.WriteString("# merge_strategy: sequential\n")
+	sb.WriteString("# worker_prompt: ./worker-prompt.md\n")
+	sb.WriteString("# exclude_labels:\n")
+	sb.WriteString("#   - wontfix\n")
+	sb.WriteString("#   - duplicate\n")
+	return sb.String()
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -288,5 +289,123 @@ func TestRunInitWizardInvalidMaxParallel(t *testing.T) {
 
 	if !strings.Contains(string(data), "max_parallel: 3") {
 		t.Errorf("invalid max_parallel should default to 3, got:\n%s", string(data))
+	}
+}
+
+func TestRunInitWizardInvalidBackend(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// repo, local_path(default), worktree(default), max_parallel(default),
+	// model(invalid), ...
+	input := "org/repo\n\n\n\ngpt4\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err == nil {
+		t.Fatal("expected error for invalid backend")
+	}
+	if !strings.Contains(err.Error(), "invalid model backend") {
+		t.Errorf("error should mention 'invalid model backend', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error should list valid backends, got: %v", err)
+	}
+}
+
+func TestRunInitWizardAllValidBackends(t *testing.T) {
+	for _, backend := range validBackends {
+		t.Run(backend, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+
+			input := fmt.Sprintf("org/repo\n\n\n\n%s\n\n\n", backend)
+			var output bytes.Buffer
+
+			err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+			if err != nil {
+				t.Fatalf("valid backend %q should not error: %v", backend, err)
+			}
+
+			data, err := os.ReadFile(filepath.Join(tmpDir, "maestro.yaml"))
+			if err != nil {
+				t.Fatal("maestro.yaml not created")
+			}
+			if !strings.Contains(string(data), "default: "+backend) {
+				t.Errorf("yaml should contain 'default: %s', got:\n%s", backend, string(data))
+			}
+		})
+	}
+}
+
+func TestRunInitWizardRicherConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	input := "org/repo\n\n\n\n\n\n\n"
+	var output bytes.Buffer
+
+	err := runInitWizard(strings.NewReader(input), &output, tmpDir)
+	if err != nil {
+		t.Fatalf("runInitWizard error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "maestro.yaml"))
+	if err != nil {
+		t.Fatal("maestro.yaml not created")
+	}
+
+	yamlStr := string(data)
+	commentedKeys := []string{
+		"# max_runtime_minutes: 120",
+		"# auto_rebase: true",
+		"# merge_strategy: sequential",
+		"# worker_prompt:",
+		"# exclude_labels:",
+	}
+	for _, key := range commentedKeys {
+		if !strings.Contains(yamlStr, key) {
+			t.Errorf("yaml should contain commented-out %q, got:\n%s", key, yamlStr)
+		}
+	}
+}
+
+func TestBuildInitYAML(t *testing.T) {
+	cfg := initYAMLConfig{
+		Repo:         "org/repo",
+		LocalPath:    "~/src/repo",
+		WorktreeBase: "~/.worktrees/repo",
+		MaxParallel:  3,
+		IssueLabels:  []string{"enhancement"},
+		Model:        initYAMLModel{Default: "claude"},
+	}
+
+	yaml := buildInitYAML(cfg)
+
+	// Active config present
+	if !strings.Contains(yaml, "repo: org/repo") {
+		t.Error("should contain repo")
+	}
+	if !strings.Contains(yaml, "max_parallel: 3") {
+		t.Error("should contain max_parallel")
+	}
+
+	// Commented examples present
+	if !strings.Contains(yaml, "# max_runtime_minutes: 120") {
+		t.Error("should contain commented max_runtime_minutes")
+	}
+
+	// No telegram when nil
+	if strings.Contains(yaml, "telegram") {
+		t.Error("should not contain telegram when nil")
+	}
+
+	// With telegram
+	cfg.Telegram = &initYAMLTelegram{Target: "12345"}
+	yaml = buildInitYAML(cfg)
+	if !strings.Contains(yaml, "telegram:") {
+		t.Error("should contain telegram section")
+	}
+	if !strings.Contains(yaml, `target: "12345"`) {
+		t.Error("should contain telegram target")
 	}
 }


### PR DESCRIPTION
Implements #104

## Changes
- **Validate model backend**: `maestro init` now rejects backend values not in `[claude, codex, gemini, cline]` with a clear error listing valid options. Previously any string was accepted.
- **Richer default config**: Generated `maestro.yaml` now includes commented-out examples for commonly used settings (`max_runtime_minutes`, `auto_rebase`, `merge_strategy`, `worker_prompt`, `exclude_labels`) so new users can discover features without reading the full README.
- Replaced `yaml.Marshal` with a manual YAML builder (`buildInitYAML`) to support inline comments.
- Updated the backend prompt to include `cline` as a fourth option.

## Testing
- Added `TestRunInitWizardInvalidBackend` — verifies invalid backends are rejected with descriptive error
- Added `TestRunInitWizardAllValidBackends` — verifies all four valid backends are accepted
- Added `TestRunInitWizardRicherConfig` — verifies commented-out examples appear in generated config
- Added `TestBuildInitYAML` — unit tests for the YAML builder (with and without telegram)
- All existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the `maestro init` wizard by adding backend validation and generating more helpful default configs.

**Key Changes:**
- **Backend validation**: Added `validBackends` list and `isValidBackend()` function to ensure only `claude`, `codex`, `gemini`, or `cline` are accepted, with clear error messages listing valid options
- **Cline support**: Updated prompt text from `(claude/codex/gemini)` to `(claude/codex/gemini/cline)` to reflect the new fourth backend option
- **Richer configs**: Replaced `yaml.Marshal` with manual `buildInitYAML()` function to support inline comments in generated `maestro.yaml`, including commented examples for `max_runtime_minutes`, `auto_rebase`, `merge_strategy`, `worker_prompt`, and `exclude_labels`
- **Test coverage**: Added four new test functions covering invalid backend rejection, all valid backends, commented config examples, and the YAML builder itself

The implementation is clean and well-tested. The manual YAML builder is a reasonable tradeoff to support inline comments (standard YAML libraries don't preserve comments during marshaling). The validation aligns with the documented backends in the README.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- Simple, focused changes with comprehensive test coverage. Adds validation that prevents invalid input, generates more helpful configs for new users, and includes thorough testing for all scenarios including edge cases. No logical errors, security issues, or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Added backend validation with `validBackends` list and `isValidBackend()` helper, updated prompt to include cline, replaced yaml.Marshal with manual `buildInitYAML()` to support inline comments for common config options |
| cmd/maestro/init_test.go | Added comprehensive tests: `TestRunInitWizardInvalidBackend` verifies rejection of invalid backends, `TestRunInitWizardAllValidBackends` tests all four backends, `TestRunInitWizardRicherConfig` checks commented examples, `TestBuildInitYAML` unit-tests YAML builder |

</details>



<sub>Last reviewed commit: cf3bfa6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->