### PR TITLE
fix: set PATH in generated systemd/launchd service files (#105)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -145,6 +145,7 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 }
 
 func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
+	pathEnv := os.Getenv("PATH")
 	switch runtime.GOOS {
 	case "linux":
 		dir := filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user")
@@ -152,7 +153,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "maestro.service")
-		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath, pathEnv)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -162,7 +163,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "com.maestro.agent.plist")
-		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath, pathEnv)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -170,29 +171,35 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 	return nil
 }
 
-func systemdUnit(binPath, configPath string) string {
+func systemdUnit(binPath, configPath, pathEnv string) string {
 	return fmt.Sprintf(`[Unit]
 Description=Maestro - AI coding agent orchestrator
 After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=%s
 ExecStart=%s run --config %s
 Restart=on-failure
 RestartSec=30
 
 [Install]
 WantedBy=default.target
-`, binPath, configPath)
+`, pathEnv, binPath, configPath)
 }
 
-func launchdPlist(binPath, configPath string) string {
+func launchdPlist(binPath, configPath, pathEnv string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
     <string>com.maestro.agent</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>%s</string>
+    </dict>
     <key>ProgramArguments</key>
     <array>
         <string>%s</string>
@@ -210,7 +217,7 @@ func launchdPlist(binPath, configPath string) string {
     <string>/tmp/maestro.stderr.log</string>
 </dict>
 </plist>
-`, binPath, configPath)
+`, pathEnv, binPath, configPath)
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -53,9 +53,12 @@ func TestPromptInitOutput(t *testing.T) {
 }
 
 func TestSystemdUnit(t *testing.T) {
-	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin")
 	if !strings.Contains(content, "ExecStart=/usr/bin/maestro run --config /etc/maestro.yaml") {
 		t.Error("should contain correct ExecStart line")
+	}
+	if !strings.Contains(content, "Environment=PATH=/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin") {
+		t.Error("should contain Environment=PATH line")
 	}
 	for _, section := range []string{"[Unit]", "[Service]", "[Install]"} {
 		if !strings.Contains(content, section) {
@@ -65,7 +68,7 @@ func TestSystemdUnit(t *testing.T) {
 }
 
 func TestLaunchdPlist(t *testing.T) {
-	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin")
 	if !strings.Contains(content, "<string>/usr/bin/maestro</string>") {
 		t.Error("should contain binary path")
 	}
@@ -74,6 +77,12 @@ func TestLaunchdPlist(t *testing.T) {
 	}
 	if !strings.Contains(content, "com.maestro.agent") {
 		t.Error("should contain label")
+	}
+	if !strings.Contains(content, "<key>EnvironmentVariables</key>") {
+		t.Error("should contain EnvironmentVariables key")
+	}
+	if !strings.Contains(content, "<string>/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin</string>") {
+		t.Error("should contain PATH value in EnvironmentVariables")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.

--- a/maestro@.service
+++ b/maestro@.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.local/bin:%h/.bun/bin:%h/.npm-global/bin
 ExecStart=/usr/local/bin/maestro run --config %h/.maestro/maestro-%i.yaml
 Restart=on-failure
 RestartSec=30


### PR DESCRIPTION
Implements #105

## Changes
- **systemd unit** (`maestro init` on Linux): Captures the user's current `$PATH` at init time and embeds it as `Environment=PATH=...` in the generated `~/.config/systemd/user/maestro.service` file. This ensures AI CLIs installed via npm/bun (typically in `~/.local/bin`, `~/.bun/bin`, etc.) are discoverable when the systemd service starts.
- **launchd plist** (`maestro init` on macOS): Captures the user's current `$PATH` and sets it in an `EnvironmentVariables` dict in the generated `~/Library/LaunchAgents/com.maestro.agent.plist`.
- **`maestro@.service` template**: Adds a sensible default `Environment=PATH=` line with common system and user bin directories (`%h/.local/bin`, `%h/.bun/bin`, `%h/.npm-global/bin`).

## Testing
- Updated `TestSystemdUnit` to verify `Environment=PATH=` line is present with the provided path value
- Updated `TestLaunchdPlist` to verify `EnvironmentVariables` dict with PATH is present
- All existing tests continue to pass (`go test ./...`)
- Binary builds successfully (`go build ./cmd/maestro/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Solves a real usability issue where AI CLIs installed in user-local directories (via npm/bun) were not discoverable by systemd/launchd services. The implementation captures the user's PATH at init time and embeds it in the generated service files.

- Captures `PATH` environment variable during `maestro init`
- Adds `Environment=PATH=...` to systemd unit files
- Adds `EnvironmentVariables` dict with PATH to launchd plist files
- Updates template file with sensible default PATH including common user bin directories
- Includes comprehensive test coverage for the new functionality
- Minor comment formatting cleanup in `config.go`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are focused, well-tested, and address a specific usability issue. The implementation follows established patterns in the codebase, includes comprehensive test coverage, and has no security concerns since PATH is captured from the user's own environment. All changes are additive and don't modify existing behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Captures user's PATH environment variable and embeds it in generated systemd/launchd service files |
| cmd/maestro/init_test.go | Updated tests to verify PATH environment variable is correctly included in generated service files |
| internal/config/config.go | Minor formatting changes to align inline comments, no functional changes |
| maestro@.service | Added default PATH with common system and user bin directories using systemd specifiers |

</details>



<sub>Last reviewed commit: 347ba02</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->