### PR TITLE
fix: init — set PATH in generated systemd/launchd service files (#105)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -145,6 +145,8 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 }
 
 func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
+	envPath := os.Getenv("PATH")
+
 	switch runtime.GOOS {
 	case "linux":
 		dir := filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user")
@@ -152,7 +154,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "maestro.service")
-		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath, envPath)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -162,7 +164,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "com.maestro.agent.plist")
-		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath, envPath)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -170,29 +172,35 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 	return nil
 }
 
-func systemdUnit(binPath, configPath string) string {
+func systemdUnit(binPath, configPath, envPath string) string {
 	return fmt.Sprintf(`[Unit]
 Description=Maestro - AI coding agent orchestrator
 After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=%s
 ExecStart=%s run --config %s
 Restart=on-failure
 RestartSec=30
 
 [Install]
 WantedBy=default.target
-`, binPath, configPath)
+`, envPath, binPath, configPath)
 }
 
-func launchdPlist(binPath, configPath string) string {
+func launchdPlist(binPath, configPath, envPath string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
     <string>com.maestro.agent</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>%s</string>
+    </dict>
     <key>ProgramArguments</key>
     <array>
         <string>%s</string>
@@ -210,7 +218,7 @@ func launchdPlist(binPath, configPath string) string {
     <string>/tmp/maestro.stderr.log</string>
 </dict>
 </plist>
-`, binPath, configPath)
+`, envPath, binPath, configPath)
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -53,7 +53,7 @@ func TestPromptInitOutput(t *testing.T) {
 }
 
 func TestSystemdUnit(t *testing.T) {
-	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin")
 	if !strings.Contains(content, "ExecStart=/usr/bin/maestro run --config /etc/maestro.yaml") {
 		t.Error("should contain correct ExecStart line")
 	}
@@ -62,10 +62,13 @@ func TestSystemdUnit(t *testing.T) {
 			t.Errorf("should contain %s section", section)
 		}
 	}
+	if !strings.Contains(content, "Environment=PATH=/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin") {
+		t.Error("should contain Environment=PATH line")
+	}
 }
 
 func TestLaunchdPlist(t *testing.T) {
-	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin")
 	if !strings.Contains(content, "<string>/usr/bin/maestro</string>") {
 		t.Error("should contain binary path")
 	}
@@ -74,6 +77,12 @@ func TestLaunchdPlist(t *testing.T) {
 	}
 	if !strings.Contains(content, "com.maestro.agent") {
 		t.Error("should contain label")
+	}
+	if !strings.Contains(content, "<key>EnvironmentVariables</key>") {
+		t.Error("should contain EnvironmentVariables key")
+	}
+	if !strings.Contains(content, "<string>/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin</string>") {
+		t.Error("should contain PATH value in EnvironmentVariables")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.

--- a/maestro@.service
+++ b/maestro@.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=%h/.local/bin:%h/.bun/bin:%h/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=/usr/local/bin/maestro run --config %h/.maestro/maestro-%i.yaml
 Restart=on-failure
 RestartSec=30


### PR DESCRIPTION
Implements #105

## Changes
The systemd service file generated by `maestro init` did not set `PATH`, causing AI CLIs installed via npm/bun (in `~/.local/bin`, `~/.bun/bin`, etc.) to not be found when the service starts.

- **`systemdUnit()`**: Added `Environment=PATH=...` directive, capturing the user's current `$PATH` at init time
- **`launchdPlist()`**: Added `<key>EnvironmentVariables</key>` dict with `PATH` for macOS launchd
- **`writeInitServiceFile()`**: Captures `os.Getenv("PATH")` and passes it to both generators
- **`maestro@.service`** template: Added default `PATH` with common AI CLI directories (`%h/.local/bin`, `%h/.bun/bin`, `%h/.npm-global/bin`)
- Updated tests to validate PATH presence in both systemd and launchd output

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass (including updated `TestSystemdUnit` and `TestLaunchdPlist`)
- `go build ./cmd/maestro/` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Captures the user's `PATH` environment variable during `maestro init` and injects it into generated systemd and launchd service files, ensuring AI CLIs installed via npm/bun are discoverable when the service starts.

## Changes
- `systemdUnit()` and `launchdPlist()` now accept `envPath` parameter and generate service files with `PATH` environment variable
- `maestro@.service` template includes default `PATH` with common AI CLI directories (`%h/.local/bin`, `%h/.bun/bin`, `%h/.npm-global/bin`)
- Tests updated to verify `PATH` presence in generated service files
- Minor comment formatting cleanup in `config.go`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Straightforward implementation that solves a real problem (AI CLIs not found by service). Tests are comprehensive and validate the new behavior. No critical issues found.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Captures user's PATH during init and passes it to service file generators for systemd and launchd |
| cmd/maestro/init_test.go | Updated test signatures and added assertions to verify PATH is present in generated service files |
| internal/config/config.go | Minor formatting changes to inline comments for consistency (no functional changes) |
| maestro@.service | Added hardcoded PATH environment variable with common AI CLI directories for systemd template |

</details>



<sub>Last reviewed commit: f4ded39</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->