### PR TITLE
fix: init — set PATH in generated systemd unit for AI CLI discovery (#105)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -145,6 +145,7 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 }
 
 func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
+	envPath := os.Getenv("PATH")
 	switch runtime.GOOS {
 	case "linux":
 		dir := filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user")
@@ -152,7 +153,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "maestro.service")
-		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath, envPath)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -162,7 +163,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "com.maestro.agent.plist")
-		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath, envPath)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -170,29 +171,35 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 	return nil
 }
 
-func systemdUnit(binPath, configPath string) string {
+func systemdUnit(binPath, configPath, envPath string) string {
 	return fmt.Sprintf(`[Unit]
 Description=Maestro - AI coding agent orchestrator
 After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=%s
 ExecStart=%s run --config %s
 Restart=on-failure
 RestartSec=30
 
 [Install]
 WantedBy=default.target
-`, binPath, configPath)
+`, envPath, binPath, configPath)
 }
 
-func launchdPlist(binPath, configPath string) string {
+func launchdPlist(binPath, configPath, envPath string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
     <string>com.maestro.agent</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>%s</string>
+    </dict>
     <key>ProgramArguments</key>
     <array>
         <string>%s</string>
@@ -210,7 +217,7 @@ func launchdPlist(binPath, configPath string) string {
     <string>/tmp/maestro.stderr.log</string>
 </dict>
 </plist>
-`, binPath, configPath)
+`, envPath, binPath, configPath)
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -53,9 +53,12 @@ func TestPromptInitOutput(t *testing.T) {
 }
 
 func TestSystemdUnit(t *testing.T) {
-	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin")
 	if !strings.Contains(content, "ExecStart=/usr/bin/maestro run --config /etc/maestro.yaml") {
 		t.Error("should contain correct ExecStart line")
+	}
+	if !strings.Contains(content, "Environment=PATH=/usr/local/bin:/usr/bin:/bin") {
+		t.Error("should contain Environment=PATH line")
 	}
 	for _, section := range []string{"[Unit]", "[Service]", "[Install]"} {
 		if !strings.Contains(content, section) {
@@ -65,7 +68,7 @@ func TestSystemdUnit(t *testing.T) {
 }
 
 func TestLaunchdPlist(t *testing.T) {
-	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin")
 	if !strings.Contains(content, "<string>/usr/bin/maestro</string>") {
 		t.Error("should contain binary path")
 	}
@@ -74,6 +77,15 @@ func TestLaunchdPlist(t *testing.T) {
 	}
 	if !strings.Contains(content, "com.maestro.agent") {
 		t.Error("should contain label")
+	}
+	if !strings.Contains(content, "<key>EnvironmentVariables</key>") {
+		t.Error("should contain EnvironmentVariables key")
+	}
+	if !strings.Contains(content, "<key>PATH</key>") {
+		t.Error("should contain PATH key")
+	}
+	if !strings.Contains(content, "<string>/usr/local/bin:/usr/bin:/bin</string>") {
+		t.Error("should contain PATH value")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.

--- a/maestro@.service
+++ b/maestro@.service
@@ -4,6 +4,9 @@ After=network.target
 
 [Service]
 Type=simple
+# Set PATH so AI CLIs installed via npm/bun (e.g. in ~/.local/bin) are found.
+# Replace with the output of: echo $PATH
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
 ExecStart=/usr/local/bin/maestro run --config %h/.maestro/maestro-%i.yaml
 Restart=on-failure
 RestartSec=30


### PR DESCRIPTION
Implements #105

## Changes

The systemd service file and launchd plist generated by `maestro init` did not set `PATH`, causing AI CLIs installed via npm/bun (typically in `~/.local/bin`, `~/.bun/bin`, etc.) to not be found when the service starts.

This fix captures the user's current `$PATH` at `maestro init` time and embeds it in the generated service files:

- **systemd**: adds `Environment=PATH=...` to the `[Service]` section
- **launchd**: adds an `EnvironmentVariables` dict with `PATH` to the plist
- **maestro@.service template**: adds a default `PATH` with a guidance comment for manual setup

## Testing

- Updated `TestSystemdUnit` to verify `Environment=PATH=` line is present
- Updated `TestLaunchdPlist` to verify `EnvironmentVariables` dict with `PATH` key/value
- All existing tests continue to pass: `go test ./...`
- `go fmt`, `go vet` clean
- Binary builds and runs: `go build ./cmd/maestro/ && ./maestro version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully fixes the issue where AI CLIs installed via npm/bun were not discoverable when maestro runs as a systemd or launchd service. The implementation captures the user's `PATH` at `maestro init` time and embeds it in the generated service files.

- Systemd: adds `Environment=PATH=...` directive in the `[Service]` section
- Launchd: adds `EnvironmentVariables` dict with `PATH` key/value in the plist
- Template file: includes default `PATH` with guidance comment for manual setup
- Tests: comprehensive coverage verifying `PATH` is correctly included in generated output
- Formatting: minor comment alignment in `config.go` for improved readability

The solution is clean, well-tested, and directly addresses the stated problem without introducing complexity or security concerns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and well-tested. The implementation correctly solves the stated problem by capturing and embedding PATH in service files. All tests pass, and the code follows Go conventions. No security concerns or breaking changes introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Captures user's PATH at init time and embeds it in generated systemd/launchd service files to ensure AI CLIs are discoverable |
| cmd/maestro/init_test.go | Added test coverage for PATH environment variable in both systemd and launchd service file generation |
| internal/config/config.go | Minor formatting change - aligned inline comments for better readability |
| maestro@.service | Added default PATH with helpful comment explaining how to customize for manual service setup |

</details>



<sub>Last reviewed commit: 1448a09</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->