### PR TITLE
feat: set PATH in generated systemd/launchd service files (#105)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -78,7 +78,7 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 
 	var telegram *initYAMLTelegram
 	if wantsTelegram {
-		fmt.Fprintf(w, "  \u2192 Telegram target ID: ")
+		fmt.Fprintf(w, "  → Telegram target ID: ")
 		if scanner.Scan() {
 			if id := strings.TrimSpace(scanner.Text()); id != "" {
 				telegram = &initYAMLTelegram{Target: id}
@@ -107,14 +107,14 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 	if err := os.WriteFile(yamlPath, yamlData, 0644); err != nil {
 		return fmt.Errorf("write maestro.yaml: %w", err)
 	}
-	fmt.Fprintln(w, "\u2705 Created maestro.yaml")
+	fmt.Fprintln(w, "✅ Created maestro.yaml")
 
 	// Create ~/.maestro/ state directory
 	maestroDir := filepath.Join(os.Getenv("HOME"), ".maestro")
 	if err := os.MkdirAll(maestroDir, 0755); err != nil {
 		fmt.Fprintf(w, "Note: could not create state directory: %v\n", err)
 	} else {
-		fmt.Fprintf(w, "\u2705 Created %s\n", maestroDir)
+		fmt.Fprintf(w, "✅ Created %s\n", maestroDir)
 	}
 
 	// Create service file (non-fatal)
@@ -145,6 +145,7 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 }
 
 func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
+	pathEnv := os.Getenv("PATH")
 	switch runtime.GOOS {
 	case "linux":
 		dir := filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user")
@@ -152,47 +153,53 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "maestro.service")
-		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath, pathEnv)), 0644); err != nil {
 			return err
 		}
-		fmt.Fprintf(w, "\u2705 Created %s\n", path)
+		fmt.Fprintf(w, "✅ Created %s\n", path)
 	case "darwin":
 		dir := filepath.Join(os.Getenv("HOME"), "Library", "LaunchAgents")
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
 		path := filepath.Join(dir, "com.maestro.agent.plist")
-		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath, pathEnv)), 0644); err != nil {
 			return err
 		}
-		fmt.Fprintf(w, "\u2705 Created %s\n", path)
+		fmt.Fprintf(w, "✅ Created %s\n", path)
 	}
 	return nil
 }
 
-func systemdUnit(binPath, configPath string) string {
+func systemdUnit(binPath, configPath, pathEnv string) string {
 	return fmt.Sprintf(`[Unit]
 Description=Maestro - AI coding agent orchestrator
 After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=%s
 ExecStart=%s run --config %s
 Restart=on-failure
 RestartSec=30
 
 [Install]
 WantedBy=default.target
-`, binPath, configPath)
+`, pathEnv, binPath, configPath)
 }
 
-func launchdPlist(binPath, configPath string) string {
+func launchdPlist(binPath, configPath, pathEnv string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
     <string>com.maestro.agent</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>%s</string>
+    </dict>
     <key>ProgramArguments</key>
     <array>
         <string>%s</string>
@@ -210,7 +217,7 @@ func launchdPlist(binPath, configPath string) string {
     <string>/tmp/maestro.stderr.log</string>
 </dict>
 </plist>
-`, binPath, configPath)
+`, pathEnv, binPath, configPath)
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -53,9 +53,12 @@ func TestPromptInitOutput(t *testing.T) {
 }
 
 func TestSystemdUnit(t *testing.T) {
-	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin")
 	if !strings.Contains(content, "ExecStart=/usr/bin/maestro run --config /etc/maestro.yaml") {
 		t.Error("should contain correct ExecStart line")
+	}
+	if !strings.Contains(content, "Environment=PATH=/usr/local/bin:/usr/bin:/bin:/home/user/.local/bin") {
+		t.Error("should contain Environment=PATH line with user's PATH")
 	}
 	for _, section := range []string{"[Unit]", "[Service]", "[Install]"} {
 		if !strings.Contains(content, section) {
@@ -64,8 +67,15 @@ func TestSystemdUnit(t *testing.T) {
 	}
 }
 
+func TestSystemdUnitEmptyPath(t *testing.T) {
+	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml", "")
+	if !strings.Contains(content, "Environment=PATH=") {
+		t.Error("should contain Environment=PATH line even when empty")
+	}
+}
+
 func TestLaunchdPlist(t *testing.T) {
-	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin:/Users/user/.bun/bin")
 	if !strings.Contains(content, "<string>/usr/bin/maestro</string>") {
 		t.Error("should contain binary path")
 	}
@@ -74,6 +84,15 @@ func TestLaunchdPlist(t *testing.T) {
 	}
 	if !strings.Contains(content, "com.maestro.agent") {
 		t.Error("should contain label")
+	}
+	if !strings.Contains(content, "<key>EnvironmentVariables</key>") {
+		t.Error("should contain EnvironmentVariables dict")
+	}
+	if !strings.Contains(content, "<key>PATH</key>") {
+		t.Error("should contain PATH key in EnvironmentVariables")
+	}
+	if !strings.Contains(content, "<string>/usr/local/bin:/usr/bin:/bin:/Users/user/.bun/bin</string>") {
+		t.Error("should contain user's PATH value")
 	}
 }
 
@@ -120,7 +139,7 @@ func TestRunInitWizard(t *testing.T) {
 	if !strings.Contains(out, "Welcome to Maestro") {
 		t.Error("should show welcome message")
 	}
-	if !strings.Contains(out, "\u2705 Created maestro.yaml") {
+	if !strings.Contains(out, "Created maestro.yaml") {
 		t.Error("should show config created message")
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.

--- a/maestro@.service
+++ b/maestro@.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.local/bin:%h/.bun/bin:%h/.npm-global/bin
 ExecStart=/usr/local/bin/maestro run --config %h/.maestro/maestro-%i.yaml
 Restart=on-failure
 RestartSec=30


### PR DESCRIPTION
Implements #105

## Changes

The systemd service file generated by `maestro init` did not set `PATH`, causing AI CLIs installed via npm/bun (in `~/.local/bin`, `~/.bun/bin`, etc.) to not be found when the service starts.

### Fix
- **`systemdUnit()`**: Added `pathEnv` parameter; embeds `Environment=PATH=...` in the `[Service]` section, capturing the user's current `$PATH` at init time
- **`launchdPlist()`**: Added `pathEnv` parameter; embeds an `EnvironmentVariables` dict with `PATH` in the plist for macOS
- **`writeInitServiceFile()`**: Captures `os.Getenv("PATH")` and passes it to both generators
- **`maestro@.service`** (static template): Added `Environment=PATH=...` with common default paths (`/usr/local/bin`, `/usr/bin`, `/bin`, `%h/.local/bin`, `%h/.bun/bin`, `%h/.npm-global/bin`)

### Tests
- Updated `TestSystemdUnit` to verify `Environment=PATH=` line is present
- Added `TestSystemdUnitEmptyPath` edge case
- Updated `TestLaunchdPlist` to verify `EnvironmentVariables` dict with `PATH` key

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean  
- `go test ./...` — all pass
- `go build ./cmd/maestro/` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements PATH environment variable configuration in generated systemd/launchd service files to ensure AI CLIs installed via npm/bun are discoverable when services start.

**Key Changes:**
- Captures user's current `$PATH` during `maestro init` and embeds it in generated service files
- Adds `Environment=PATH=...` to systemd unit files
- Adds `EnvironmentVariables` dict with `PATH` key to launchd plists  
- Updates static `maestro@.service` template with sensible default paths using systemd specifiers
- Includes comprehensive test coverage for both systemd and launchd, including empty PATH edge case

The implementation is straightforward and correctly solves the stated problem. All tests pass and the changes are backward compatible.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested, straightforward, and directly address the stated issue. All tests pass, the implementation follows Go best practices, and the feature is backward compatible. The code correctly captures and embeds the PATH environment variable in both systemd and launchd service files.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Adds PATH environment variable support to systemd and launchd service generators |
| cmd/maestro/init_test.go | Comprehensive test coverage for PATH environment variable in generated service files |
| internal/config/config.go | Formatting-only changes to comment alignment, no functional changes |
| maestro@.service | Adds PATH with common default paths and user directories using systemd specifiers |

</details>



<sub>Last reviewed commit: 31044ea</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->