### PR TITLE
fix: set PATH in generated systemd unit and launchd plist (#105)

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -145,6 +145,7 @@ func runInitWizard(r io.Reader, w io.Writer, outDir string) error {
 }
 
 func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
+	pathEnv := os.Getenv("PATH")
 	switch runtime.GOOS {
 	case "linux":
 		dir := filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user")
@@ -152,7 +153,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "maestro.service")
-		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(systemdUnit(binPath, configPath, pathEnv)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -162,7 +163,7 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 			return err
 		}
 		path := filepath.Join(dir, "com.maestro.agent.plist")
-		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath)), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(launchdPlist(binPath, configPath, pathEnv)), 0644); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\u2705 Created %s\n", path)
@@ -170,29 +171,35 @@ func writeInitServiceFile(w io.Writer, binPath, configPath string) error {
 	return nil
 }
 
-func systemdUnit(binPath, configPath string) string {
+func systemdUnit(binPath, configPath, pathEnv string) string {
 	return fmt.Sprintf(`[Unit]
 Description=Maestro - AI coding agent orchestrator
 After=network.target
 
 [Service]
 Type=simple
+Environment=PATH=%s
 ExecStart=%s run --config %s
 Restart=on-failure
 RestartSec=30
 
 [Install]
 WantedBy=default.target
-`, binPath, configPath)
+`, pathEnv, binPath, configPath)
 }
 
-func launchdPlist(binPath, configPath string) string {
+func launchdPlist(binPath, configPath, pathEnv string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
     <string>com.maestro.agent</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>%s</string>
+    </dict>
     <key>ProgramArguments</key>
     <array>
         <string>%s</string>
@@ -210,7 +217,7 @@ func launchdPlist(binPath, configPath string) string {
     <string>/tmp/maestro.stderr.log</string>
 </dict>
 </plist>
-`, binPath, configPath)
+`, pathEnv, binPath, configPath)
 }
 
 func promptInit(scanner *bufio.Scanner, w io.Writer, question, defaultVal string) string {

--- a/cmd/maestro/init_test.go
+++ b/cmd/maestro/init_test.go
@@ -53,7 +53,7 @@ func TestPromptInitOutput(t *testing.T) {
 }
 
 func TestSystemdUnit(t *testing.T) {
-	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := systemdUnit("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin")
 	if !strings.Contains(content, "ExecStart=/usr/bin/maestro run --config /etc/maestro.yaml") {
 		t.Error("should contain correct ExecStart line")
 	}
@@ -62,10 +62,13 @@ func TestSystemdUnit(t *testing.T) {
 			t.Errorf("should contain %s section", section)
 		}
 	}
+	if !strings.Contains(content, "Environment=PATH=/usr/local/bin:/usr/bin:/bin") {
+		t.Error("should contain Environment=PATH line")
+	}
 }
 
 func TestLaunchdPlist(t *testing.T) {
-	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml")
+	content := launchdPlist("/usr/bin/maestro", "/etc/maestro.yaml", "/usr/local/bin:/usr/bin:/bin")
 	if !strings.Contains(content, "<string>/usr/bin/maestro</string>") {
 		t.Error("should contain binary path")
 	}
@@ -74,6 +77,12 @@ func TestLaunchdPlist(t *testing.T) {
 	}
 	if !strings.Contains(content, "com.maestro.agent") {
 		t.Error("should contain label")
+	}
+	if !strings.Contains(content, "EnvironmentVariables") {
+		t.Error("should contain EnvironmentVariables dict")
+	}
+	if !strings.Contains(content, "<string>/usr/local/bin:/usr/bin:/bin</string>") {
+		t.Error("should contain PATH value in EnvironmentVariables")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,18 +61,18 @@ type Config struct {
 	IssueLabels                []string         `yaml:"issue_labels"`
 	ExcludeLabels              []string         `yaml:"exclude_labels"`
 	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`                    // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"`            // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`                // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`                     // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`                    // shell command to run after successful PR merge
-	MergeStrategy              string           `yaml:"merge_strategy"`                // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"`        // minimum seconds between merges in sequential mode
+	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`            // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
 }
 
 // LoadFrom loads config from a specific path.


### PR DESCRIPTION
Implements #105

## Changes
- Capture the user's current `PATH` at `maestro init` time via `os.Getenv("PATH")`
- Embed `Environment=PATH=...` in the generated systemd unit file (`[Service]` section)
- Add `EnvironmentVariables` dict with `PATH` in the generated launchd plist for macOS
- This ensures AI CLIs installed in `~/.local/bin`, `~/.bun/bin`, `~/.npm-global/bin`, etc. are discoverable when the service starts

## Testing
- Updated `TestSystemdUnit` to verify `Environment=PATH=` line is present
- Updated `TestLaunchdPlist` to verify `EnvironmentVariables` dict with PATH is present
- All existing tests pass (`go test ./...`)
- Build verified (`go build ./cmd/maestro/ && ./maestro version`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Captures the user's current `PATH` environment variable during `maestro init` and embeds it in generated systemd unit files and launchd plists, ensuring AI CLIs installed in non-standard locations like `~/.local/bin`, `~/.bun/bin`, or `~/.npm-global/bin` are discoverable when the service starts.

- Added `os.Getenv("PATH")` capture in `writeInitServiceFile()`
- Updated `systemdUnit()` to include `Environment=PATH=...` in the `[Service]` section
- Updated `launchdPlist()` to include `EnvironmentVariables` dict with PATH key
- Tests verify PATH is present in both generated service files
- Code formatting cleanup in `config.go` (comment alignment only)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean implementation with focused changes, comprehensive test coverage, and no logic errors or security issues detected
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/init.go | Captures user's PATH environment variable at init time and embeds it in generated systemd/launchd service files to ensure AI CLIs in custom paths are discoverable |
| cmd/maestro/init_test.go | Updated tests to verify PATH is correctly embedded in generated service files, all assertions pass |

</details>



<sub>Last reviewed commit: fa9cb93</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->