### PR TITLE
fix: prevent infinite worker spawn when open PR exists for issue

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -341,6 +341,29 @@ func (c *Client) CreateRelease(tag, title string) error {
 	return nil
 }
 
+// HasOpenPRForIssue returns true if there is at least one open PR that
+// references the given issue number (e.g. "closes #N") in its body or title.
+// Uses GitHub search so it works regardless of branch naming.
+func (c *Client) HasOpenPRForIssue(issueNumber int) (bool, error) {
+	query := fmt.Sprintf("#%d", issueNumber)
+	out, err := exec.Command("gh", "pr", "list",
+		"--repo", c.Repo,
+		"--state", "open",
+		"--search", query,
+		"--json", "number",
+		"--limit", "1").Output()
+	if err != nil {
+		return false, fmt.Errorf("gh pr list --search: %w", err)
+	}
+	var prs []struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return false, fmt.Errorf("parse pr search results: %w", err)
+	}
+	return len(prs) > 0, nil
+}
+
 // HasLabel returns true if any of the issue's labels match
 func HasLabel(issue Issue, labels []string) bool {
 	for _, l := range issue.Labels {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -33,6 +33,8 @@ type Orchestrator struct {
 	enhancementPromptBase string
 	pidAliveFn            func(pid int) bool
 	tmuxSessionExistsFn   func(name string) bool
+	listOpenPRsFn         func() ([]github.PR, error)
+	hasOpenPRForIssueFn   func(issueNumber int) (bool, error)
 }
 
 // New creates a new Orchestrator
@@ -66,6 +68,20 @@ func (o *Orchestrator) tmuxSessionExists(name string) bool {
 		return false
 	}
 	return exec.Command("tmux", "has-session", "-t", name).Run() == nil
+}
+
+func (o *Orchestrator) listOpenPRs() ([]github.PR, error) {
+	if o.listOpenPRsFn != nil {
+		return o.listOpenPRsFn()
+	}
+	return o.gh.ListOpenPRs()
+}
+
+func (o *Orchestrator) hasOpenPRForIssue(issueNumber int) (bool, error) {
+	if o.hasOpenPRForIssueFn != nil {
+		return o.hasOpenPRForIssueFn(issueNumber)
+	}
+	return o.gh.HasOpenPRForIssue(issueNumber)
 }
 
 func readLastLines(path string, limit int) (string, error) {
@@ -269,8 +285,25 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 
 // reconcileRunningSessions self-heals stale "running" sessions.
 // If a session is marked running but either its PID is dead/missing OR its tmux session
-// is missing, the session is marked dead and its PID/tmux fields are cleared.
+// is missing, the session is transitioned to a terminal state.
+//
+// Before marking a session dead, it checks whether the worker already opened a PR
+// for its branch. If a PR exists, the session transitions to pr_open instead of dead.
+// This prevents the infinite-spawn loop where reconcile kills a session whose worker
+// had successfully created a PR before the tmux session was cleaned up.
 func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
+	// Fetch open PRs once — used to rescue sessions where the worker exited
+	// after creating a PR (process/tmux gone, but PR is already open on GitHub).
+	prs, prErr := o.listOpenPRs()
+	branchToPR := make(map[string]github.PR)
+	if prErr != nil {
+		log.Printf("[orch] reconcile: warn — could not list PRs: %v (will mark stale sessions dead)", prErr)
+	} else {
+		for _, pr := range prs {
+			branchToPR[pr.HeadRefName] = pr
+		}
+	}
+
 	reconciled := false
 	for slotName, sess := range s.Sessions {
 		if sess.Status != state.StatusRunning {
@@ -294,6 +327,23 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		}
 
 		if len(reasons) == 0 {
+			continue
+		}
+
+		// Worker process/session is gone. Before marking dead, check whether it
+		// already opened a PR. If so, transition to pr_open — the worker succeeded.
+		// Without this check, reconcile would mark the session dead, causing
+		// IssueInProgress to return false and startNewWorkers to spawn a duplicate.
+		if pr, found := branchToPR[sess.Branch]; found {
+			log.Printf("[orch] reconcile: %s running->pr_open (PR #%d already open for branch %q; %s)",
+				slotName, pr.Number, sess.Branch, strings.Join(reasons, ", "))
+			sess.Status = state.StatusPROpen
+			sess.PRNumber = pr.Number
+			sess.PID = 0
+			sess.TmuxSession = ""
+			now := time.Now().UTC()
+			sess.FinishedAt = &now
+			reconciled = true
 			continue
 		}
 
@@ -856,6 +906,16 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 
 		if github.HasLabel(issue, o.cfg.ExcludeLabels) {
 			log.Printf("[orch] skipping issue #%d (excluded label)", issue.Number)
+			continue
+		}
+
+		// Safety net: check GitHub directly for any open PR referencing this issue.
+		// This guards against the race where reconcileRunningSessions marked a session
+		// dead before checkSessions could detect its PR and transition it to pr_open.
+		if hasOpenPR, err := o.hasOpenPRForIssue(issue.Number); err != nil {
+			log.Printf("[orch] warn: could not check open PRs for issue #%d: %v", issue.Number, err)
+		} else if hasOpenPR {
+			log.Printf("[orch] skipping issue #%d: open PR already exists", issue.Number)
 			continue
 		}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -153,6 +153,122 @@ func TestSelectPrompt_CaseInsensitiveLabel(t *testing.T) {
 	}
 }
 
+// TestReconcileRunningSessions_DeadWorkerWithOpenPR_TransitionsToPROpen verifies
+// the fix for the infinite-spawn bug (issue #152): when a worker exits after
+// creating a PR, reconcile must NOT mark the session dead — it must transition
+// to pr_open so that IssueInProgress returns true and no duplicate worker is spawned.
+func TestReconcileRunningSessions_DeadWorkerWithOpenPR_TransitionsToPROpen(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["mae-5"] = &state.Session{
+		IssueNumber: 105,
+		IssueTitle:  "fix crash",
+		Status:      state.StatusRunning,
+		PID:         9999,
+		TmuxSession: "maestro-mae-5",
+		Branch:      "feat/mae-5-105-fix-crash",
+	}
+
+	openPRs := []github.PR{
+		{Number: 137, HeadRefName: "feat/mae-5-105-fix-crash", Title: "fix crash"},
+	}
+
+	o := &Orchestrator{
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return openPRs, nil },
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["mae-5"]
+	if sess.Status != state.StatusPROpen {
+		t.Fatalf("status = %q, want %q (worker created PR before exiting — should not be dead)", sess.Status, state.StatusPROpen)
+	}
+	if sess.PRNumber != 137 {
+		t.Fatalf("pr_number = %d, want 137", sess.PRNumber)
+	}
+	if sess.PID != 0 {
+		t.Fatalf("pid = %d, want 0", sess.PID)
+	}
+	if sess.TmuxSession != "" {
+		t.Fatalf("tmux_session = %q, want empty", sess.TmuxSession)
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("finished_at should be set")
+	}
+	// Crucially: IssueInProgress must return true so no duplicate worker is spawned
+	if !s.IssueInProgress(105) {
+		t.Fatal("IssueInProgress(105) must return true after transition to pr_open")
+	}
+}
+
+// TestReconcileRunningSessions_DeadWorkerNoPR_TransitionsToDead verifies that
+// the existing behaviour is preserved when no PR exists for the dead worker.
+func TestReconcileRunningSessions_DeadWorkerNoPR_TransitionsToDead(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["mae-6"] = &state.Session{
+		IssueNumber: 106,
+		IssueTitle:  "add feature",
+		Status:      state.StatusRunning,
+		PID:         8888,
+		TmuxSession: "maestro-mae-6",
+		Branch:      "feat/mae-6-106-add-feature",
+	}
+
+	// No open PRs for this branch
+	o := &Orchestrator{
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["mae-6"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.PRNumber != 0 {
+		t.Fatalf("pr_number = %d, want 0", sess.PRNumber)
+	}
+}
+
+// TestReconcileRunningSessions_PRListError_FallsBackToDead ensures that when
+// the GitHub PR listing fails, reconcile still marks the session dead (degraded
+// mode) rather than panicking or blocking indefinitely.
+func TestReconcileRunningSessions_PRListError_FallsBackToDead(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["mae-7"] = &state.Session{
+		IssueNumber: 107,
+		Status:      state.StatusRunning,
+		PID:         7777,
+		TmuxSession: "maestro-mae-7",
+		Branch:      "feat/mae-7-107-something",
+	}
+
+	o := &Orchestrator{
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return nil, fmt.Errorf("network error") },
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
+	sess := s.Sessions["mae-7"]
+	// Falls back to dead when PR list unavailable — better to mark dead than to loop forever
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (should fall back to dead when PR list fails)", sess.Status, state.StatusDead)
+	}
+}
+
 func TestReconcileRunningSessions_DeadPIDGetsMarkedDead(t *testing.T) {
 	s := state.NewState()
 	s.Sessions["pan-1"] = &state.Session{
@@ -163,11 +279,13 @@ func TestReconcileRunningSessions_DeadPIDGetsMarkedDead(t *testing.T) {
 		RetryCount:         2,
 		IssueTitle:         "stale worker",
 		LastNotifiedStatus: "",
+		Branch:             "feat/pan-1-71-stale-worker",
 	}
 
 	o := &Orchestrator{
 		pidAliveFn:          func(pid int) bool { return false },
 		tmuxSessionExistsFn: func(name string) bool { return true },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
 	}
 
 	changed := o.reconcileRunningSessions(s)
@@ -200,11 +318,13 @@ func TestReconcileRunningSessions_MissingTmuxGetsMarkedDead(t *testing.T) {
 		Status:      state.StatusRunning,
 		PID:         5151,
 		TmuxSession: "maestro-pan-2",
+		Branch:      "feat/pan-2-71-stale",
 	}
 
 	o := &Orchestrator{
 		pidAliveFn:          func(pid int) bool { return true },
 		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
 	}
 
 	changed := o.reconcileRunningSessions(s)
@@ -236,6 +356,7 @@ func TestReconcileRunningSessions_UsesDefaultTmuxNameWhenMissingInState(t *testi
 		IssueNumber: 73,
 		Status:      state.StatusRunning,
 		PID:         6262,
+		Branch:      "feat/pan-3-73-something",
 		// TmuxSession intentionally empty; should fall back to worker.TmuxSessionName(slot)
 	}
 
@@ -246,6 +367,7 @@ func TestReconcileRunningSessions_UsesDefaultTmuxNameWhenMissingInState(t *testi
 			calledWith = name
 			return true
 		},
+		listOpenPRsFn: func() ([]github.PR, error) { return []github.PR{}, nil },
 	}
 
 	changed := o.reconcileRunningSessions(s)


### PR DESCRIPTION
## Problem

Fixes #152

maestro was spawning 120+ workers for a single issue. Each worker successfully created a PR, but maestro kept treating the issue as "unresolved" and spawning a fresh worker every 5 minutes.

## Root Cause

Race condition between `reconcileRunningSessions` and `checkSessions`:

1. Worker exits after creating a PR → tmux session closes
2. `reconcileRunningSessions` runs **first**: detects tmux session missing → marks session as `dead` (terminal) → **saves state immediately**
3. `checkSessions` runs: **skips dead sessions** (they're in the terminal case)  
4. `IssueInProgress` returns `false` (because `dead` is terminal)
5. `startNewWorkers` spawns another worker → loop forever

## Fix

**Fix 1 (root cause) — `reconcileRunningSessions`:**  
Before marking a stale running session as `dead`, the function now checks GitHub for any open PR matching the session's branch. If found → transition to `pr_open` instead of `dead`. This keeps `IssueInProgress` returning `true` so no duplicate is spawned.

**Fix 2 (safety net) — `startNewWorkers`:**  
Before spawning a worker for issue `N`, call `HasOpenPRForIssue(N)` to check GitHub directly. If an open PR already references the issue, the issue is skipped regardless of what `state.json` says.

## Tests

Three new test cases in `orchestrator_test.go`:
- Dead worker with open PR → transitions to `pr_open` (not dead)
- Dead worker with no PR → transitions to `dead` (existing behavior preserved)
- GitHub API error during reconcile → falls back to `dead` (graceful degradation)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR effectively resolves the infinite worker spawn bug by implementing a two-layer defense strategy.

**Root Cause Fix**: Modified `reconcileRunningSessions` to check for open PRs before marking dead sessions. When a stale running session is detected (dead PID/tmux), the function now fetches all open PRs and checks if the session's branch has an open PR. If found, the session transitions to `pr_open` instead of `dead`, keeping `IssueInProgress` returning true.

**Safety Net**: Added a GitHub search-based check in `startNewWorkers` that queries for any open PR referencing the issue number before spawning a worker. This catches race conditions where reconciliation marked a session dead before PR detection occurred.

**Key Changes**:
- New `HasOpenPRForIssue` function uses GitHub search to find PRs mentioning an issue
- `reconcileRunningSessions` now fetches open PRs and matches by branch name before marking sessions dead
- `startNewWorkers` verifies no open PR exists before spawning workers
- Graceful error handling: API failures fall back to previous behavior rather than blocking progress
- Comprehensive test coverage including error scenarios

The implementation is well-designed with appropriate error handling and test coverage. The fix preserves backward compatibility while closing the race condition window.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly addresses the root cause with a well-tested two-layer fix. The code includes comprehensive test coverage, proper error handling with graceful degradation, and maintains backward compatibility. The logic is sound and the changes are isolated to the specific problem area without introducing side effects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/github/github.go | Added `HasOpenPRForIssue` function to search for open PRs referencing a given issue number using GitHub's search API - implementation is clean and handles errors appropriately |
| internal/orchestrator/orchestrator.go | Core fix for infinite worker spawn issue - reconciliation now checks for open PRs before marking sessions dead, and worker spawning includes safety net check - logic is sound and preserves backward compatibility |
| internal/orchestrator/orchestrator_test.go | Comprehensive test coverage for the fix including happy path, edge cases, and error handling - all existing tests properly updated with mock functions |

</details>



<sub>Last reviewed commit: bacf544</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->