### PR TITLE
fix: add checksum verification to install.sh (#103)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,22 @@ main() {
         echo "Check available binaries at https://github.com/${REPO}/releases/latest" >&2
         exit 1
     fi
+
+    CHECKSUM_URL="https://github.com/${REPO}/releases/download/${LATEST}/checksums.txt"
+    if ! curl -fsSL "$CHECKSUM_URL" -o "$TMPDIR/checksums.txt"; then
+        echo "error: failed to download checksums from ${CHECKSUM_URL}" >&2
+        exit 1
+    fi
+
+    echo "Verifying checksum..."
+    if command -v sha256sum >/dev/null 2>&1; then
+        (cd "$TMPDIR" && sha256sum -c checksums.txt --ignore-missing)
+    elif command -v shasum >/dev/null 2>&1; then
+        (cd "$TMPDIR" && shasum -a 256 -c checksums.txt --ignore-missing)
+    else
+        echo "warning: sha256sum/shasum not found, skipping checksum verification" >&2
+    fi
+
     tar xzf "$TMPFILE" -C "$TMPDIR"
     BINARY_PATH="${TMPDIR}/maestro-${OS}-${ARCH}"
     chmod +x "$BINARY_PATH"


### PR DESCRIPTION
Implements #103

## Changes
After downloading the tarball, `install.sh` now also downloads `checksums.txt` from the release and verifies the SHA256 hash before extracting. This ensures binary integrity and catches corrupted or tampered downloads.

- Downloads `checksums.txt` from the same release tag
- Verifies using `sha256sum` (Linux) or `shasum -a 256` (macOS)
- Fails the install if the checksum file cannot be downloaded
- Prints a warning if neither tool is available (unlikely on supported platforms)

## Testing
- Reviewed against the release workflow to confirm `checksums.txt` format matches (`sha256sum *.tar.gz > checksums.txt`)
- Verified `--ignore-missing` flag works correctly with multi-binary checksum files
- All existing Go tests pass (`go test ./...`)
- Binary builds successfully (`go build ./cmd/maestro/`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added checksum verification to the install script by downloading `checksums.txt` from the GitHub release and verifying the binary's SHA256 hash before extraction. The implementation correctly integrates with the release workflow (which generates checksums using `sha256sum *.tar.gz > checksums.txt`) and handles platform differences between Linux (`sha256sum`) and macOS (`shasum -a 256`).

**Key changes:**
- Downloads `checksums.txt` from the same release tag as the binary
- Verifies checksum using `--ignore-missing` flag to handle multi-platform checksum files
- Fails installation if checksums file cannot be downloaded

**Issues already raised in previous threads:**
- Checksum verification lacks explicit error messaging when verification fails (relies on `set -e` behavior)
- Script proceeds with installation if neither `sha256sum` nor `shasum` is available, which bypasses the security feature this PR introduces

<h3>Confidence Score: 3/5</h3>

- This PR adds important security verification but has error handling concerns that have been previously identified
- The implementation correctly adds checksum verification and integrates well with the release workflow. However, the score reflects two significant concerns already raised in previous review threads: (1) implicit error handling that may not provide clear feedback to users when verification fails, and (2) the fallback behavior that continues installation without verification when checksum tools are unavailable, which undermines the security purpose of this change
- The `install.sh` file needs attention to address the error handling concerns on lines 57-60 and the security fallback on lines 61-62

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| install.sh | Added SHA256 checksum verification after download, correctly integrates with release workflow format and uses platform-appropriate tools (`sha256sum` or `shasum`) |

</details>



<sub>Last reviewed commit: 3981eba</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->