### PR TITLE
fix: resolve version from build info when ldflags not set (#155)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -85,7 +86,41 @@ Watch:
 `
 
 // version is set at build time via -ldflags "-X main.version=X.Y.Z".
+// When not set (local builds), resolveVersion falls back to Go module/VCS info.
 var version = "dev"
+
+func resolveVersion() string {
+	if version != "dev" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return version
+	}
+	// go install github.com/befeast/maestro/cmd/maestro@v1.2.3 sets info.Main.Version
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		return strings.TrimPrefix(v, "v")
+	}
+	// Local build from git checkout — use VCS revision
+	var rev, dirty string
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			rev = s.Value
+		case "vcs.modified":
+			if s.Value == "true" {
+				dirty = "-dirty"
+			}
+		}
+	}
+	if rev != "" {
+		if len(rev) > 12 {
+			rev = rev[:12]
+		}
+		return "dev-" + rev + dirty
+	}
+	return version
+}
 
 // multiFlag accumulates repeated --config flag values.
 type multiFlag []string
@@ -136,7 +171,7 @@ func main() {
 	case "_watch-tail":
 		watchTailCmd(args)
 	case "version":
-		fmt.Printf("maestro v%s\n", version)
+		fmt.Printf("maestro v%s\n", resolveVersion())
 	case "help", "--help", "-h":
 		fmt.Print(usage)
 	default:

--- a/cmd/maestro/version_test.go
+++ b/cmd/maestro/version_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+func TestResolveVersion_LdflagsSet(t *testing.T) {
+	original := version
+	defer func() { version = original }()
+
+	version = "1.2.3"
+	got := resolveVersion()
+	if got != "1.2.3" {
+		t.Errorf("resolveVersion() = %q, want %q", got, "1.2.3")
+	}
+}
+
+func TestResolveVersion_Dev(t *testing.T) {
+	original := version
+	defer func() { version = original }()
+
+	version = "dev"
+	got := resolveVersion()
+	// In test binary, debug.ReadBuildInfo returns test module info.
+	// The result should not be empty and should not be plain "dev"
+	// in a VCS-aware build, but we accept any non-empty string.
+	if got == "" {
+		t.Error("resolveVersion() returned empty string")
+	}
+}


### PR DESCRIPTION
Implements #155

## Changes
`maestro version` showed `maestro vdev` instead of a real version because the
`version` variable defaults to `"dev"` and was only overridden via `-ldflags`
during release builds.

Added `resolveVersion()` in `cmd/maestro/main.go` that falls back to
`runtime/debug.ReadBuildInfo()` when `version` is still `"dev"`:

1. **Release builds** (via `-ldflags`): version is injected at compile time — unchanged
2. **`go install ...@v1.2.3`**: Go embeds the module version → `resolveVersion()` reads it
3. **Local `go build` in a git checkout**: Go embeds VCS revision → shows `dev-<commit>[-dirty]`
4. **No VCS info available**: gracefully falls back to `dev`

Also added `cmd/maestro/version_test.go` with tests for the ldflags and fallback paths.

## Testing
- `go test ./...` — all pass
- `go build -ldflags "-X main.version=1.2.3" ./cmd/maestro/ && ./maestro version` → `maestro v1.2.3`
- `go build ./cmd/maestro/ && ./maestro version` → falls back correctly
- `go vet ./...` and `go fmt ./...` clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the version command to display meaningful version information instead of just `"dev"` when ldflags are not set. The implementation adds a `resolveVersion()` helper that intelligently falls back through multiple sources: ldflags injection → Go module version → VCS revision → dev.

**Key changes:**
- Added `resolveVersion()` function that checks `debug.ReadBuildInfo()` for version metadata
- Handles `go install ...@v1.2.3` by reading `info.Main.Version` and trimming the `"v"` prefix
- Shows `dev-<commit>[-dirty]` for local git builds by reading VCS settings
- Version command now calls `resolveVersion()` instead of using the raw `version` variable
- Added tests covering both ldflags and dev fallback scenarios

The implementation is clean, well-structured, and handles all edge cases appropriately (missing build info, empty values, VCS availability).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The changes are isolated to version display logic, well-tested, and follow established Go patterns for reading build metadata. No bugs, security issues, or breaking changes identified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Added `resolveVersion()` function to intelligently detect version from build info when ldflags not set, with proper fallbacks for module versions and VCS revisions |
| cmd/maestro/version_test.go | Added comprehensive tests for both ldflags and dev fallback scenarios |

</details>



<sub>Last reviewed commit: 81474a3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->