### PR TITLE
fix: inject version via ldflags in CI and add Makefile (#155)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
           cache: true
 
       - name: Build
-        run: go build ./cmd/maestro/
+        run: |
+          VERSION=$(git describe --tags --always)
+          go build -ldflags "-X main.version=${VERSION#v}" ./cmd/maestro/
 
       - name: Vet
         run: go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+VERSION ?= $(shell git describe --tags --always)
+
+.PHONY: build
+build:
+	go build -ldflags "-X main.version=$(VERSION:v%=%)" -o maestro ./cmd/maestro/


### PR DESCRIPTION
Implements #155

## Changes

`maestro version` showed "vdev" because the CI workflow built without `-ldflags`, and Go does not embed VCS metadata in git worktrees (where `.git` is a file, not a directory), so the `resolveVersion()` runtime fallback was insufficient.

- **CI workflow**: inject version at build time using `git describe --tags --always` with `-ldflags "-X main.version=..."`
- **Makefile**: add `build` target with ldflags so local developers get a proper version (e.g. `make build` or `make build VERSION=v1.2.3`)
- Release workflow already injects version correctly — no change needed

## Testing

- `make build && ./maestro version` → `maestro v6a9885e` (git hash when no tags)
- `make build VERSION=v1.2.3 && ./maestro version` → `maestro v1.2.3`
- `go fmt ./...`, `go vet ./...`, `go test ./...` all pass
- `go build ./cmd/maestro/` still works (shows "vdev" without ldflags, as expected)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes version display issue by injecting version at build time via ldflags. The CI workflow now runs `git describe --tags --always` and passes the result to the Go compiler, while a new Makefile provides the same functionality for local development with an optional VERSION override.

Both implementations correctly strip the 'v' prefix from git tags (using bash `${VERSION#v}` in CI and Make's `$(VERSION:v%=%)` pattern substitution in the Makefile) to match the expected format, since `cmd/maestro/main.go:174` already prefixes the output with "v" when displaying.

The approach is consistent with the existing release workflow and handles all cases correctly: tagged releases, untagged commits, and manual version overrides.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are straightforward build configuration updates that correctly implement version injection via ldflags. Both the CI workflow and Makefile properly handle version string formatting, are consistent with the existing release workflow pattern, and the author has thoroughly tested all scenarios including tagged releases, commit hashes, and manual overrides.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | adds version injection via ldflags using `git describe --tags --always`, correctly strips 'v' prefix with bash parameter expansion |
| Makefile | adds build target with version injection, uses Make pattern substitution to strip 'v' prefix, allows VERSION override |

</details>



<sub>Last reviewed commit: 40dab20</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->