### PR TITLE
feat: per-issue model routing via GitHub labels (#158)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -35,6 +35,7 @@ type Orchestrator struct {
 	tmuxSessionExistsFn   func(name string) bool
 	listOpenPRsFn         func() ([]github.PR, error)
 	hasOpenPRForIssueFn   func(issueNumber int) (bool, error)
+	routeFn               func(issue github.Issue) (string, string, error)
 }
 
 // New creates a new Orchestrator
@@ -886,6 +887,41 @@ func (o *Orchestrator) markUnresolvableConflict(slotName string, sess *state.Ses
 	o.notifier.Sendf("⚠️ Worker %s (issue #%d) has unresolvable conflicts — manual intervention needed", slotName, sess.IssueNumber)
 }
 
+// resolveBackend determines which backend to use for the given issue.
+// Priority: 1) model:<name> label override, 2) auto-routing via LLM, 3) default.
+func (o *Orchestrator) resolveBackend(issue github.Issue) string {
+	// Check for model: label (highest priority)
+	for _, label := range issue.Labels {
+		if strings.HasPrefix(label.Name, "model:") {
+			if name := strings.TrimPrefix(label.Name, "model:"); name != "" {
+				if _, ok := o.cfg.Model.Backends[name]; !ok {
+					log.Printf("[router] issue #%d: label model:%s references unknown backend — falling back to default %q", issue.Number, name, o.cfg.Model.Default)
+					return o.cfg.Model.Default
+				}
+				log.Printf("[router] issue #%d → %s (label override)", issue.Number, name)
+				return name
+			}
+		}
+	}
+
+	// Try auto-routing via LLM
+	if o.cfg.Routing.Mode == "auto" {
+		routeFn := o.router.Route
+		if o.routeFn != nil {
+			routeFn = o.routeFn
+		}
+		routedBackend, reason, err := routeFn(issue)
+		if err != nil {
+			log.Printf("[router] issue #%d: error %v — using default", issue.Number, err)
+		} else if routedBackend != "" {
+			log.Printf("[router] issue #%d → %s (%s)", issue.Number, routedBackend, reason)
+			return routedBackend
+		}
+	}
+
+	return o.cfg.Model.Default
+}
+
 // startNewWorkers picks eligible issues and starts workers for them
 func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 	issues, err := o.gh.ListOpenIssues(o.cfg.IssueLabels)
@@ -919,35 +955,16 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			continue
 		}
 
-		// Detect model: label for backend selection (label takes precedence) and long-running label
-		backendName := ""
+		// Resolve backend from label / auto-routing / default
+		backendName := o.resolveBackend(issue)
+
+		// Detect long-running label
 		longRunning := false
 		for _, label := range issue.Labels {
-			if strings.HasPrefix(label.Name, "model:") {
-				if name := strings.TrimPrefix(label.Name, "model:"); name != "" {
-					backendName = name
-					log.Printf("[router] issue #%d → %s (label override)", issue.Number, backendName)
-				}
-			}
 			if strings.EqualFold(label.Name, "long-running") {
 				longRunning = true
+				break
 			}
-		}
-
-		// If no label, try auto-routing via LLM
-		if backendName == "" && o.cfg.Routing.Mode == "auto" {
-			routedBackend, reason, err := o.router.Route(issue)
-			if err != nil {
-				log.Printf("[router] issue #%d: error %v — using default", issue.Number, err)
-			} else {
-				log.Printf("[router] issue #%d → %s (%s)", issue.Number, routedBackend, reason)
-			}
-			backendName = routedBackend
-		}
-
-		// Fall back to default
-		if backendName == "" {
-			backendName = o.cfg.Model.Default
 		}
 
 		promptBase := o.selectPrompt(issue)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -456,3 +456,138 @@ func TestMergeInterval_Explicit(t *testing.T) {
 		t.Fatalf("mergeInterval() = %s, want %s", got, 45*time.Second)
 	}
 }
+
+// --- resolveBackend tests ---
+
+func cfgWithBackends(defaultBackend string, backends ...string) *config.Config {
+	m := make(map[string]config.BackendDef, len(backends))
+	for _, b := range backends {
+		m[b] = config.BackendDef{Cmd: b}
+	}
+	return &config.Config{
+		Repo: "owner/repo",
+		Model: config.ModelConfig{
+			Default:  defaultBackend,
+			Backends: m,
+		},
+	}
+}
+
+func TestResolveBackend_ModelLabelOverride(t *testing.T) {
+	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex", "gemini")}
+	got := o.resolveBackend(makeIssue(1, "Fix bug", "model:codex"))
+	if got != "codex" {
+		t.Errorf("resolveBackend() = %q, want %q", got, "codex")
+	}
+}
+
+func TestResolveBackend_ModelLabelGemini(t *testing.T) {
+	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex", "gemini")}
+	got := o.resolveBackend(makeIssue(2, "Add feature", "enhancement", "model:gemini"))
+	if got != "gemini" {
+		t.Errorf("resolveBackend() = %q, want %q", got, "gemini")
+	}
+}
+
+func TestResolveBackend_UnknownBackendFallsToDefault(t *testing.T) {
+	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex")}
+	got := o.resolveBackend(makeIssue(3, "Fix bug", "model:nonexistent"))
+	if got != "claude" {
+		t.Errorf("resolveBackend() = %q, want %q (unknown backend should fall back to default)", got, "claude")
+	}
+}
+
+func TestResolveBackend_NoLabelReturnsDefault(t *testing.T) {
+	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex")}
+	got := o.resolveBackend(makeIssue(4, "Fix bug"))
+	if got != "claude" {
+		t.Errorf("resolveBackend() = %q, want %q", got, "claude")
+	}
+}
+
+func TestResolveBackend_NoLabelWithAutoRouting(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	cfg.Routing.Mode = "auto"
+	o := &Orchestrator{
+		cfg: cfg,
+		routeFn: func(issue github.Issue) (string, string, error) {
+			return "codex", "simple fix", nil
+		},
+	}
+	got := o.resolveBackend(makeIssue(5, "Simple fix"))
+	if got != "codex" {
+		t.Errorf("resolveBackend() = %q, want %q", got, "codex")
+	}
+}
+
+func TestResolveBackend_LabelOverridesAutoRouting(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	cfg.Routing.Mode = "auto"
+	routerCalled := false
+	o := &Orchestrator{
+		cfg: cfg,
+		routeFn: func(issue github.Issue) (string, string, error) {
+			routerCalled = true
+			return "codex", "router pick", nil
+		},
+	}
+	got := o.resolveBackend(makeIssue(6, "Fix bug", "model:gemini"))
+	if got != "gemini" {
+		t.Errorf("resolveBackend() = %q, want %q (label should override auto-routing)", got, "gemini")
+	}
+	if routerCalled {
+		t.Error("router should not be called when model: label is present")
+	}
+}
+
+func TestResolveBackend_AutoRoutingErrorFallsToDefault(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	cfg.Routing.Mode = "auto"
+	o := &Orchestrator{
+		cfg: cfg,
+		routeFn: func(issue github.Issue) (string, string, error) {
+			return "", "", fmt.Errorf("network error")
+		},
+	}
+	got := o.resolveBackend(makeIssue(7, "Fix bug"))
+	if got != "claude" {
+		t.Errorf("resolveBackend() = %q, want %q (should fall back on router error)", got, "claude")
+	}
+}
+
+func TestResolveBackend_AutoRoutingDisabled(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	cfg.Routing.Mode = "manual"
+	routerCalled := false
+	o := &Orchestrator{
+		cfg: cfg,
+		routeFn: func(issue github.Issue) (string, string, error) {
+			routerCalled = true
+			return "codex", "router pick", nil
+		},
+	}
+	got := o.resolveBackend(makeIssue(8, "Fix bug"))
+	if got != "claude" {
+		t.Errorf("resolveBackend() = %q, want %q", got, "claude")
+	}
+	if routerCalled {
+		t.Error("router should not be called when routing mode is not auto")
+	}
+}
+
+func TestResolveBackend_EmptyModelLabelIgnored(t *testing.T) {
+	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex")}
+	// "model:" with no value after the colon should be ignored
+	got := o.resolveBackend(makeIssue(9, "Fix bug", "model:"))
+	if got != "claude" {
+		t.Errorf("resolveBackend() = %q, want %q (empty model: label should be ignored)", got, "claude")
+	}
+}
+
+func TestResolveBackend_MultipleLabelsFirstModelWins(t *testing.T) {
+	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex", "gemini")}
+	got := o.resolveBackend(makeIssue(10, "Fix bug", "bug", "model:codex", "model:gemini"))
+	if got != "codex" {
+		t.Errorf("resolveBackend() = %q, want %q (first model: label should win)", got, "codex")
+	}
+}


### PR DESCRIPTION
Implements #158

## Changes

The `model:<backend>` label routing was already implemented inline in `startNewWorkers()`, but had no tests and no validation that the label-specified backend actually exists in config.

This PR:
- **Extracts** the backend selection logic into a testable `resolveBackend()` method with clear priority: `model:` label > auto-routing > default
- **Adds validation** that a `model:<name>` label references a configured backend — if unknown, logs a warning and falls back to the default backend (previously it would pass the unknown name downstream where `worker.Start` would catch it)
- **Adds `routeFn` injection** on the Orchestrator struct (matching existing `pidAliveFn`/`listOpenPRsFn` pattern) to allow testing auto-routing without a real LLM call
- **Adds 10 unit tests** covering: label override, multiple backends (codex/gemini), unknown backend fallback, no-label default, auto-routing integration, label-overrides-auto-routing, auto-routing error fallback, routing disabled, empty `model:` label, and multiple `model:` labels

## Testing

- `go test ./...` — all tests pass (10 new tests in `orchestrator_test.go`)
- `go vet ./...` — clean
- `go build ./cmd/maestro/` — binary builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts backend selection logic into a testable `resolveBackend()` method with proper validation of `model:` labels. The implementation correctly prioritizes label override > auto-routing > default, and adds validation to prevent unknown backend names from being passed downstream.

**Key improvements:**
- Backend validation warns and falls back to default when `model:<unknown>` label is used
- Added `routeFn` injection field following existing test pattern (`pidAliveFn`, etc.)
- 10 comprehensive unit tests covering edge cases
- Added `break` after finding long-running label (minor optimization)

**Critical issue:**
- `resolveBackend()` line 909 accesses `o.router.Route` before checking if `o.routeFn` is set, causing nil pointer panic in test scenarios where `o.router` is nil

<h3>Confidence Score: 2/5</h3>

- Cannot safely merge due to nil pointer dereference bug that will cause tests to panic
- The logic refactoring and test coverage are excellent, but the nil pointer bug at line 909 in `resolveBackend()` will cause panics in test scenarios where `o.router` is nil. This is a critical correctness issue that must be fixed before merging
- internal/orchestrator/orchestrator.go requires immediate attention to fix the nil pointer dereference

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Extracted `resolveBackend()` with label validation and auto-routing support; has nil pointer issue in test scenarios |
| internal/orchestrator/orchestrator_test.go | Added 10 comprehensive unit tests covering backend routing scenarios |

</details>



<sub>Last reviewed commit: b235acf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->