### PR TITLE
feat: per-issue model routing via GitHub labels (#158)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -753,33 +753,9 @@ func spawnCmd(args []string) {
 		log.Fatalf("issue #%d not found in open issues", *issueNum)
 	}
 
-	// Detect model: label for backend selection (label takes precedence)
-	backendName := ""
-	for _, label := range targetIssue.Labels {
-		if strings.HasPrefix(label.Name, "model:") {
-			if name := strings.TrimPrefix(label.Name, "model:"); name != "" {
-				backendName = name
-				log.Printf("[router] issue #%d → %s (label override)", targetIssue.Number, backendName)
-			}
-		}
-	}
-
-	// If no label, try auto-routing via LLM
-	if backendName == "" && cfg.Routing.Mode == "auto" {
-		r := router.New(cfg)
-		routedBackend, reason, err := r.Route(*targetIssue)
-		if err != nil {
-			log.Printf("[router] issue #%d: error %v — using default", targetIssue.Number, err)
-		} else {
-			log.Printf("[router] issue #%d → %s (%s)", targetIssue.Number, routedBackend, reason)
-		}
-		backendName = routedBackend
-	}
-
-	// Fall back to default
-	if backendName == "" {
-		backendName = cfg.Model.Default
-	}
+	// Resolve backend via 3-tier priority: label → auto-routing → default
+	r := router.New(cfg)
+	backendName, _ := r.ResolveBackend(*targetIssue)
 	slotName, err := worker.Start(cfg, s, cfg.Repo, *targetIssue, promptBase, backendName)
 	if err != nil {
 		log.Fatalf("start worker: %v", err)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -933,17 +933,14 @@ func (o *Orchestrator) markUnresolvableConflict(slotName string, sess *state.Ses
 // Priority: 1) model:<name> label override, 2) auto-routing via LLM, 3) default.
 func (o *Orchestrator) resolveBackend(issue github.Issue) string {
 	// Check for model: label (highest priority)
-	for _, label := range issue.Labels {
-		if strings.HasPrefix(label.Name, "model:") {
-			if name := strings.TrimPrefix(label.Name, "model:"); name != "" {
-				if _, ok := o.cfg.Model.Backends[name]; !ok {
-					log.Printf("[router] issue #%d: label model:%s references unknown backend — falling back to default %q", issue.Number, name, o.cfg.Model.Default)
-					return o.cfg.Model.Default
-				}
-				log.Printf("[router] issue #%d → %s (label override)", issue.Number, name)
-				return name
-			}
+	if name := router.BackendFromLabels(issue); name != "" {
+		validated, ok := router.ValidateBackend(name, o.cfg)
+		if !ok {
+			log.Printf("[router] issue #%d: label model:%s references unknown backend — falling back to default %q", issue.Number, name, o.cfg.Model.Default)
+		} else {
+			log.Printf("[router] issue #%d → %s (label override)", issue.Number, validated)
 		}
+		return validated
 	}
 
 	// Try auto-routing via LLM

--- a/internal/router/resolve.go
+++ b/internal/router/resolve.go
@@ -1,0 +1,66 @@
+package router
+
+import (
+	"log"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+// BackendFromLabels extracts a backend name from issue labels with the "model:" prefix.
+// Returns the backend name if found, empty string otherwise.
+// If multiple model: labels exist, the first one wins.
+func BackendFromLabels(issue github.Issue) string {
+	for _, label := range issue.Labels {
+		if strings.HasPrefix(label.Name, "model:") {
+			if name := strings.TrimPrefix(label.Name, "model:"); name != "" {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+// ValidateBackend checks that a backend name exists in the config's backend map.
+// Returns the validated name and true if valid, or the default backend name and
+// false if the requested backend is unknown.
+func ValidateBackend(name string, cfg *config.Config) (string, bool) {
+	if _, ok := cfg.Model.Backends[name]; ok {
+		return name, true
+	}
+	return cfg.Model.Default, false
+}
+
+// ResolveBackend determines the backend for an issue using 3-tier priority:
+//  1. model:<backend> label on the issue (highest priority)
+//  2. Auto-routing via LLM (if routing.mode == "auto")
+//  3. Default backend from config
+func (r *Router) ResolveBackend(issue github.Issue) (backendName, reason string) {
+	// 1. Check for model: label (highest priority)
+	if name := BackendFromLabels(issue); name != "" {
+		validated, ok := ValidateBackend(name, r.cfg)
+		if !ok {
+			log.Printf("[router] issue #%d: label specifies unknown backend %q, falling back to default %q",
+				issue.Number, name, r.cfg.Model.Default)
+			return validated, "unknown label backend"
+		}
+		log.Printf("[router] issue #%d → %s (label override)", issue.Number, validated)
+		return validated, "label"
+	}
+
+	// 2. Auto-routing via LLM (if enabled)
+	if r.cfg.Routing.Mode == "auto" {
+		routedBackend, routeReason, err := r.Route(issue)
+		if err != nil {
+			log.Printf("[router] issue #%d: error %v — using default", issue.Number, err)
+		} else {
+			log.Printf("[router] issue #%d → %s (%s)", issue.Number, routedBackend, routeReason)
+		}
+		// Route already falls back to default on error
+		return routedBackend, routeReason
+	}
+
+	// 3. Default backend
+	return r.cfg.Model.Default, "default"
+}

--- a/internal/router/resolve_test.go
+++ b/internal/router/resolve_test.go
@@ -1,0 +1,218 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+func makeIssue(number int, title string, labels ...string) github.Issue {
+	issue := github.Issue{Number: number, Title: title}
+	for _, l := range labels {
+		issue.Labels = append(issue.Labels, struct {
+			Name string `json:"name"`
+		}{Name: l})
+	}
+	return issue
+}
+
+func TestBackendFromLabels_ModelLabel(t *testing.T) {
+	issue := makeIssue(1, "Fix bug", "enhancement", "model:codex")
+	got := BackendFromLabels(issue)
+	if got != "codex" {
+		t.Errorf("BackendFromLabels() = %q, want %q", got, "codex")
+	}
+}
+
+func TestBackendFromLabels_NoModelLabel(t *testing.T) {
+	issue := makeIssue(2, "Add feature", "enhancement", "bug")
+	got := BackendFromLabels(issue)
+	if got != "" {
+		t.Errorf("BackendFromLabels() = %q, want empty", got)
+	}
+}
+
+func TestBackendFromLabels_NoLabels(t *testing.T) {
+	issue := makeIssue(3, "Update docs")
+	got := BackendFromLabels(issue)
+	if got != "" {
+		t.Errorf("BackendFromLabels() = %q, want empty", got)
+	}
+}
+
+func TestBackendFromLabels_MultipleModelLabels_FirstWins(t *testing.T) {
+	issue := makeIssue(4, "Complex", "model:gemini", "model:codex")
+	got := BackendFromLabels(issue)
+	if got != "gemini" {
+		t.Errorf("BackendFromLabels() = %q, want %q (first model: label wins)", got, "gemini")
+	}
+}
+
+func TestBackendFromLabels_EmptyModelValue(t *testing.T) {
+	issue := makeIssue(5, "Edge case", "model:", "model:cline")
+	got := BackendFromLabels(issue)
+	if got != "cline" {
+		t.Errorf("BackendFromLabels() = %q, want %q (empty model: should be skipped)", got, "cline")
+	}
+}
+
+func TestBackendFromLabels_AllKnownBackends(t *testing.T) {
+	backends := []string{"claude", "codex", "gemini", "cline"}
+	for _, b := range backends {
+		issue := makeIssue(10, "Test", "model:"+b)
+		got := BackendFromLabels(issue)
+		if got != b {
+			t.Errorf("BackendFromLabels(model:%s) = %q, want %q", b, got, b)
+		}
+	}
+}
+
+func TestValidateBackend_Known(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+	}
+	name, ok := ValidateBackend("codex", cfg)
+	if !ok || name != "codex" {
+		t.Errorf("ValidateBackend(codex) = (%q, %v), want (%q, true)", name, ok, "codex")
+	}
+}
+
+func TestValidateBackend_Unknown(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+			},
+		},
+	}
+	name, ok := ValidateBackend("nonexistent", cfg)
+	if ok || name != "claude" {
+		t.Errorf("ValidateBackend(nonexistent) = (%q, %v), want (%q, false)", name, ok, "claude")
+	}
+}
+
+func TestResolveBackend_LabelOverride(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+		Routing: config.RoutingConfig{Mode: "manual"},
+	}
+	r := New(cfg)
+
+	issue := makeIssue(42, "Fix SQL injection", "enhancement", "model:codex")
+	name, reason := r.ResolveBackend(issue)
+	if name != "codex" {
+		t.Errorf("ResolveBackend() name = %q, want %q", name, "codex")
+	}
+	if reason != "label" {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "label")
+	}
+}
+
+func TestResolveBackend_LabelOverride_UnknownBackend(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+			},
+		},
+		Routing: config.RoutingConfig{Mode: "manual"},
+	}
+	r := New(cfg)
+
+	issue := makeIssue(43, "Test unknown", "model:nonexistent")
+	name, reason := r.ResolveBackend(issue)
+	if name != "claude" {
+		t.Errorf("ResolveBackend() name = %q, want %q (should fall back to default)", name, "claude")
+	}
+	if reason != "unknown label backend" {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "unknown label backend")
+	}
+}
+
+func TestResolveBackend_DefaultFallback(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+		Routing: config.RoutingConfig{Mode: "manual"},
+	}
+	r := New(cfg)
+
+	issue := makeIssue(44, "Add feature", "enhancement")
+	name, reason := r.ResolveBackend(issue)
+	if name != "claude" {
+		t.Errorf("ResolveBackend() name = %q, want %q", name, "claude")
+	}
+	if reason != "default" {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "default")
+	}
+}
+
+func TestResolveBackend_LabelTakesPrecedenceOverAutoRouting(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+				"gemini": {Cmd: "gemini"},
+			},
+		},
+		Routing: config.RoutingConfig{
+			Mode:        "auto",
+			RouterModel: "claude",
+		},
+	}
+	r := New(cfg)
+
+	// Even with auto-routing enabled, the label should win
+	issue := makeIssue(45, "Refactor auth", "model:gemini")
+	name, reason := r.ResolveBackend(issue)
+	if name != "gemini" {
+		t.Errorf("ResolveBackend() name = %q, want %q (label should override auto-routing)", name, "gemini")
+	}
+	if reason != "label" {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "label")
+	}
+}
+
+func TestResolveBackend_NoLabelsManualMode(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "codex",
+			Backends: map[string]config.BackendDef{
+				"codex": {Cmd: "codex"},
+			},
+		},
+		Routing: config.RoutingConfig{Mode: "manual"},
+	}
+	r := New(cfg)
+
+	issue := makeIssue(46, "Something")
+	name, reason := r.ResolveBackend(issue)
+	if name != "codex" {
+		t.Errorf("ResolveBackend() name = %q, want %q (default)", name, "codex")
+	}
+	if reason != "default" {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "default")
+	}
+}


### PR DESCRIPTION
Implements #158

## Changes

Extracts per-issue model routing logic into reusable helpers in the `router` package:

- **`router.BackendFromLabels(issue)`** — extracts backend name from `model:<backend>` labels
- **`router.ValidateBackend(name, cfg)`** — validates a backend exists in config, returns default if unknown
- **`router.ResolveBackend(issue)`** — full 3-tier resolution: label → auto-routing → default

The orchestrator's `resolveBackend` method now delegates label parsing and validation to these shared helpers, while retaining its injectable `routeFn` for testability. The `spawnCmd` (manual spawn) uses `router.ResolveBackend` directly, eliminating the duplicated inline routing logic.

Key improvement: label-specified backends (`model:nonexistent`) are now validated against config at routing time with a clear log warning, rather than being caught later during worker startup.

## Testing

- 13 new tests in `internal/router/resolve_test.go` covering:
  - Label extraction (model:codex, model:gemini, model:cline, empty labels, multiple model labels, empty model: value)
  - Backend validation (known/unknown backends)
  - Full ResolveBackend (label override, unknown backend fallback, default fallback, label precedence over auto-routing)
- All 10 existing orchestrator-level `TestResolveBackend_*` tests pass with the refactored code
- `go fmt`, `go vet`, `go test ./...`, `go build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully extracts per-issue model routing logic into reusable helpers in the `router` package. The refactoring eliminates code duplication between `spawnCmd` and the orchestrator while maintaining backward compatibility and testability.

**Key improvements:**
- **Code organization**: Three new helper functions (`BackendFromLabels`, `ValidateBackend`, `ResolveBackend`) centralize routing logic with clear separation of concerns
- **Earlier validation**: Label-specified backends (`model:nonexistent`) are now validated at routing time with clear log warnings
- **Maintained testability**: The orchestrator retains its `routeFn` injection pattern for mocking in tests
- **Comprehensive testing**: 13 new tests cover edge cases (empty labels, multiple labels, unknown backends, priority order)

**Implementation notes:**
- The orchestrator's `resolveBackend` uses `router.BackendFromLabels()` and `router.ValidateBackend()` while keeping `routeFn` injectable
- The `spawnCmd` uses `router.ResolveBackend()` directly for simplicity
- All 10 existing orchestrator tests continue to pass with the refactored code

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- Clean refactoring that extracts common logic without changing behavior. Comprehensive test coverage (13 new tests), maintains backward compatibility, and all existing tests pass. No bugs, security issues, or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/router/resolve.go | New file extracting backend resolution logic into reusable helpers with clear 3-tier priority (label → auto-routing → default). Well documented and tested. |
| internal/router/resolve_test.go | Comprehensive test coverage with 13 tests covering label extraction, validation, and full resolution including edge cases (empty labels, multiple labels, unknown backends). |
| internal/orchestrator/orchestrator.go | Refactored to use shared router helpers while maintaining `routeFn` injection for testability. Clean delegation to `router.BackendFromLabels` and `router.ValidateBackend`. |
| cmd/maestro/main.go | Simplified `spawnCmd` by replacing inline routing logic with direct call to `router.ResolveBackend`. Reduces code duplication significantly. |

</details>



<sub>Last reviewed commit: fda9317</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->