### PR TITLE
feat: consolidate per-issue model routing into router.ResolveBackend (#158)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -35,7 +35,6 @@ type Orchestrator struct {
 	tmuxSessionExistsFn   func(name string) bool
 	listOpenPRsFn         func() ([]github.PR, error)
 	hasOpenPRForIssueFn   func(issueNumber int) (bool, error)
-	routeFn               func(issue github.Issue) (string, string, error)
 
 	// Testing hooks for autoMergePRs / mergeReadyPR
 	ghPRCIStatusFn         func(prNumber int) (string, error)
@@ -930,35 +929,13 @@ func (o *Orchestrator) markUnresolvableConflict(slotName string, sess *state.Ses
 }
 
 // resolveBackend determines which backend to use for the given issue.
-// Priority: 1) model:<name> label override, 2) auto-routing via LLM, 3) default.
+// Delegates to router.ResolveBackend which applies 3-tier priority:
+//  1. model:<backend> label on the issue (highest priority)
+//  2. Auto-routing via LLM (if routing.mode == "auto")
+//  3. Default backend from config
 func (o *Orchestrator) resolveBackend(issue github.Issue) string {
-	// Check for model: label (highest priority)
-	if name := router.BackendFromLabels(issue); name != "" {
-		validated, ok := router.ValidateBackend(name, o.cfg)
-		if !ok {
-			log.Printf("[router] issue #%d: label model:%s references unknown backend — falling back to default %q", issue.Number, name, o.cfg.Model.Default)
-		} else {
-			log.Printf("[router] issue #%d → %s (label override)", issue.Number, validated)
-		}
-		return validated
-	}
-
-	// Try auto-routing via LLM
-	if o.cfg.Routing.Mode == "auto" {
-		routeFn := o.router.Route
-		if o.routeFn != nil {
-			routeFn = o.routeFn
-		}
-		routedBackend, reason, err := routeFn(issue)
-		if err != nil {
-			log.Printf("[router] issue #%d: error %v — using default", issue.Number, err)
-		} else if routedBackend != "" {
-			log.Printf("[router] issue #%d → %s (%s)", issue.Number, routedBackend, reason)
-			return routedBackend
-		}
-	}
-
-	return o.cfg.Model.Default
+	name, _ := o.router.ResolveBackend(issue)
+	return name
 }
 
 // startNewWorkers picks eligible issues and starts workers for them

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -474,7 +475,8 @@ func cfgWithBackends(defaultBackend string, backends ...string) *config.Config {
 }
 
 func TestResolveBackend_ModelLabelOverride(t *testing.T) {
-	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex", "gemini")}
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
 	got := o.resolveBackend(makeIssue(1, "Fix bug", "model:codex"))
 	if got != "codex" {
 		t.Errorf("resolveBackend() = %q, want %q", got, "codex")
@@ -482,7 +484,8 @@ func TestResolveBackend_ModelLabelOverride(t *testing.T) {
 }
 
 func TestResolveBackend_ModelLabelGemini(t *testing.T) {
-	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex", "gemini")}
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
 	got := o.resolveBackend(makeIssue(2, "Add feature", "enhancement", "model:gemini"))
 	if got != "gemini" {
 		t.Errorf("resolveBackend() = %q, want %q", got, "gemini")
@@ -490,7 +493,8 @@ func TestResolveBackend_ModelLabelGemini(t *testing.T) {
 }
 
 func TestResolveBackend_UnknownBackendFallsToDefault(t *testing.T) {
-	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex")}
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
 	got := o.resolveBackend(makeIssue(3, "Fix bug", "model:nonexistent"))
 	if got != "claude" {
 		t.Errorf("resolveBackend() = %q, want %q (unknown backend should fall back to default)", got, "claude")
@@ -498,7 +502,8 @@ func TestResolveBackend_UnknownBackendFallsToDefault(t *testing.T) {
 }
 
 func TestResolveBackend_NoLabelReturnsDefault(t *testing.T) {
-	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex")}
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
 	got := o.resolveBackend(makeIssue(4, "Fix bug"))
 	if got != "claude" {
 		t.Errorf("resolveBackend() = %q, want %q", got, "claude")
@@ -508,12 +513,11 @@ func TestResolveBackend_NoLabelReturnsDefault(t *testing.T) {
 func TestResolveBackend_NoLabelWithAutoRouting(t *testing.T) {
 	cfg := cfgWithBackends("claude", "claude", "codex")
 	cfg.Routing.Mode = "auto"
-	o := &Orchestrator{
-		cfg: cfg,
-		routeFn: func(issue github.Issue) (string, string, error) {
-			return "codex", "simple fix", nil
-		},
+	r := router.New(cfg)
+	r.RouteFn = func(issue github.Issue) (string, string, error) {
+		return "codex", "simple fix", nil
 	}
+	o := &Orchestrator{cfg: cfg, router: r}
 	got := o.resolveBackend(makeIssue(5, "Simple fix"))
 	if got != "codex" {
 		t.Errorf("resolveBackend() = %q, want %q", got, "codex")
@@ -524,13 +528,12 @@ func TestResolveBackend_LabelOverridesAutoRouting(t *testing.T) {
 	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
 	cfg.Routing.Mode = "auto"
 	routerCalled := false
-	o := &Orchestrator{
-		cfg: cfg,
-		routeFn: func(issue github.Issue) (string, string, error) {
-			routerCalled = true
-			return "codex", "router pick", nil
-		},
+	r := router.New(cfg)
+	r.RouteFn = func(issue github.Issue) (string, string, error) {
+		routerCalled = true
+		return "codex", "router pick", nil
 	}
+	o := &Orchestrator{cfg: cfg, router: r}
 	got := o.resolveBackend(makeIssue(6, "Fix bug", "model:gemini"))
 	if got != "gemini" {
 		t.Errorf("resolveBackend() = %q, want %q (label should override auto-routing)", got, "gemini")
@@ -543,12 +546,11 @@ func TestResolveBackend_LabelOverridesAutoRouting(t *testing.T) {
 func TestResolveBackend_AutoRoutingErrorFallsToDefault(t *testing.T) {
 	cfg := cfgWithBackends("claude", "claude", "codex")
 	cfg.Routing.Mode = "auto"
-	o := &Orchestrator{
-		cfg: cfg,
-		routeFn: func(issue github.Issue) (string, string, error) {
-			return "", "", fmt.Errorf("network error")
-		},
+	r := router.New(cfg)
+	r.RouteFn = func(issue github.Issue) (string, string, error) {
+		return "", "", fmt.Errorf("network error")
 	}
+	o := &Orchestrator{cfg: cfg, router: r}
 	got := o.resolveBackend(makeIssue(7, "Fix bug"))
 	if got != "claude" {
 		t.Errorf("resolveBackend() = %q, want %q (should fall back on router error)", got, "claude")
@@ -559,13 +561,12 @@ func TestResolveBackend_AutoRoutingDisabled(t *testing.T) {
 	cfg := cfgWithBackends("claude", "claude", "codex")
 	cfg.Routing.Mode = "manual"
 	routerCalled := false
-	o := &Orchestrator{
-		cfg: cfg,
-		routeFn: func(issue github.Issue) (string, string, error) {
-			routerCalled = true
-			return "codex", "router pick", nil
-		},
+	r := router.New(cfg)
+	r.RouteFn = func(issue github.Issue) (string, string, error) {
+		routerCalled = true
+		return "codex", "router pick", nil
 	}
+	o := &Orchestrator{cfg: cfg, router: r}
 	got := o.resolveBackend(makeIssue(8, "Fix bug"))
 	if got != "claude" {
 		t.Errorf("resolveBackend() = %q, want %q", got, "claude")
@@ -576,7 +577,8 @@ func TestResolveBackend_AutoRoutingDisabled(t *testing.T) {
 }
 
 func TestResolveBackend_EmptyModelLabelIgnored(t *testing.T) {
-	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex")}
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
 	// "model:" with no value after the colon should be ignored
 	got := o.resolveBackend(makeIssue(9, "Fix bug", "model:"))
 	if got != "claude" {
@@ -585,7 +587,8 @@ func TestResolveBackend_EmptyModelLabelIgnored(t *testing.T) {
 }
 
 func TestResolveBackend_MultipleLabelsFirstModelWins(t *testing.T) {
-	o := &Orchestrator{cfg: cfgWithBackends("claude", "claude", "codex", "gemini")}
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
 	got := o.resolveBackend(makeIssue(10, "Fix bug", "bug", "model:codex", "model:gemini"))
 	if got != "codex" {
 		t.Errorf("resolveBackend() = %q, want %q (first model: label should win)", got, "codex")

--- a/internal/router/resolve.go
+++ b/internal/router/resolve.go
@@ -51,14 +51,18 @@ func (r *Router) ResolveBackend(issue github.Issue) (backendName, reason string)
 
 	// 2. Auto-routing via LLM (if enabled)
 	if r.cfg.Routing.Mode == "auto" {
-		routedBackend, routeReason, err := r.Route(issue)
+		routeFn := r.Route
+		if r.RouteFn != nil {
+			routeFn = r.RouteFn
+		}
+		routedBackend, routeReason, err := routeFn(issue)
 		if err != nil {
 			log.Printf("[router] issue #%d: error %v — using default", issue.Number, err)
-		} else {
+		} else if routedBackend != "" {
 			log.Printf("[router] issue #%d → %s (%s)", issue.Number, routedBackend, routeReason)
+			return routedBackend, routeReason
 		}
-		// Route already falls back to default on error
-		return routedBackend, routeReason
+		// Fall through to default on error or empty backend
 	}
 
 	// 3. Default backend

--- a/internal/router/resolve_test.go
+++ b/internal/router/resolve_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/befeast/maestro/internal/config"
@@ -211,6 +212,58 @@ func TestResolveBackend_NoLabelsManualMode(t *testing.T) {
 	name, reason := r.ResolveBackend(issue)
 	if name != "codex" {
 		t.Errorf("ResolveBackend() name = %q, want %q (default)", name, "codex")
+	}
+	if reason != "default" {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "default")
+	}
+}
+
+func TestResolveBackend_AutoRoutingViaRouteFn(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+		Routing: config.RoutingConfig{Mode: "auto"},
+	}
+	r := New(cfg)
+	r.RouteFn = func(issue github.Issue) (string, string, error) {
+		return "codex", "simple fix", nil
+	}
+
+	issue := makeIssue(47, "Simple fix")
+	name, reason := r.ResolveBackend(issue)
+	if name != "codex" {
+		t.Errorf("ResolveBackend() name = %q, want %q", name, "codex")
+	}
+	if reason != "simple fix" {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "simple fix")
+	}
+}
+
+func TestResolveBackend_AutoRoutingErrorFallsToDefault(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+		Routing: config.RoutingConfig{Mode: "auto"},
+	}
+	r := New(cfg)
+	r.RouteFn = func(issue github.Issue) (string, string, error) {
+		return "", "", fmt.Errorf("network error")
+	}
+
+	issue := makeIssue(48, "Fix bug")
+	name, reason := r.ResolveBackend(issue)
+	if name != "claude" {
+		t.Errorf("ResolveBackend() name = %q, want %q (should fall back to default)", name, "claude")
 	}
 	if reason != "default" {
 		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "default")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -28,6 +28,9 @@ type routerResponse struct {
 // Router selects the best backend for a given issue using an LLM call.
 type Router struct {
 	cfg *config.Config
+
+	// RouteFn overrides the default Route method (used in tests).
+	RouteFn func(issue github.Issue) (string, string, error)
 }
 
 // New creates a new Router.


### PR DESCRIPTION
Implements #158

## Changes

The per-issue model routing via `model:<backend>` GitHub labels was already implemented across two locations: `router.ResolveBackend` and a duplicate `orchestrator.resolveBackend`. This PR consolidates them:

- **Orchestrator's `resolveBackend`** now delegates to `router.ResolveBackend` instead of reimplementing the 3-tier resolution logic (label → auto-routing → default)
- **Router gains a `RouteFn` test hook** so orchestrator tests can inject auto-routing behavior without requiring a real LLM call
- **`ResolveBackend` handles errors more robustly** — on routing error or empty backend, it falls through to the default instead of returning whatever `Route()` returned
- All existing orchestrator tests updated to use `router.RouteFn` instead of the removed `routeFn` field
- Added two new router-level tests for the `RouteFn` path: success case and error-fallback case

The end-to-end flow works: when an issue has a `model:codex` label, `BackendFromLabels` extracts "codex", `ValidateBackend` confirms it exists in config, and the worker starts with that backend. Unknown backends fall back to the configured default.

## Testing

- `go test ./...` — all 9 packages pass
- `go vet ./...` — clean
- `go build ./cmd/maestro/` — binary builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Successfully consolidates duplicate model routing logic by moving it from `orchestrator.resolveBackend` to `router.ResolveBackend`.

**Key Changes:**
- Removed `orchestrator.routeFn` field and duplicate 3-tier resolution logic (label → auto-routing → default)
- `orchestrator.resolveBackend` now simply delegates to `router.ResolveBackend`
- Added `Router.RouteFn` test hook to support test injection without requiring real LLM calls
- Improved error handling in `ResolveBackend` to check for empty backends before returning
- All 9 existing orchestrator tests updated to use `router.RouteFn` instead of `orchestrator.routeFn`
- Added 2 new router tests covering the `RouteFn` code path

The refactoring maintains identical behavior while eliminating code duplication. Router is properly initialized via `orchestrator.New()` at line 58. Tests are comprehensive and cover all edge cases including label override, auto-routing, error fallback, and empty backend handling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring that consolidates duplicate code without changing behavior. All tests pass, comprehensive test coverage for both old and new code paths, proper initialization of dependencies, and correct error handling throughout
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Removed duplicate routing logic, now delegates to `router.ResolveBackend` |
| internal/orchestrator/orchestrator_test.go | Updated all tests to use `router.RouteFn` instead of orchestrator's `routeFn` field |
| internal/router/resolve.go | Added `RouteFn` test hook support with improved error handling for empty backends |
| internal/router/resolve_test.go | Added tests for `RouteFn` hook: success case and error fallback to default |
| internal/router/router.go | Added `RouteFn` test hook field to Router struct for test injection |

</details>



<sub>Last reviewed commit: d2abe7e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->