### PR TITLE
fix: auto-rebase pr_open PRs behind main (#171)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -42,6 +42,7 @@ type Orchestrator struct {
 	ghMergePRFn            func(prNumber int) error
 	ghCloseIssueFn         func(number int, comment string) error
 	workerStopFn           func(cfg *config.Config, slotName string, sess *state.Session) error
+	rebaseWorktreeFn       func(worktreePath, branch string, autoResolveFiles []string) error
 }
 
 // New creates a new Orchestrator
@@ -124,6 +125,13 @@ func (o *Orchestrator) stopWorker(slotName string, sess *state.Session) error {
 		return o.workerStopFn(o.cfg, slotName, sess)
 	}
 	return worker.Stop(o.cfg, slotName, sess)
+}
+
+func (o *Orchestrator) rebaseWorktree(worktreePath, branch string) error {
+	if o.rebaseWorktreeFn != nil {
+		return o.rebaseWorktreeFn(worktreePath, branch, o.cfg.AutoResolveFiles)
+	}
+	return worker.RebaseWorktree(worktreePath, branch, o.cfg.AutoResolveFiles)
 }
 
 func readLastLines(path string, limit int) (string, error) {
@@ -772,6 +780,19 @@ func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr git
 	log.Printf("[orch] merging PR #%d (branch %s)", pr.Number, sess.Branch)
 	if err := o.mergePR(pr.Number); err != nil {
 		log.Printf("[orch] merge PR #%d: %v", pr.Number, err)
+
+		// If the branch is behind main (not conflicting, just outdated), auto-rebase
+		if strings.Contains(err.Error(), "not up to date") && o.cfg.AutoRebase {
+			log.Printf("[orch] PR #%d branch is behind main, auto-rebasing %s", pr.Number, slotName)
+			if rebaseErr := o.rebaseWorktree(sess.Worktree, sess.Branch); rebaseErr != nil {
+				log.Printf("[orch] auto-rebase failed for %s: %v", slotName, rebaseErr)
+				o.markUnresolvableConflict(slotName, sess, pr.Number, rebaseErr)
+			} else {
+				o.markRebaseQueued(slotName, sess, pr.Number)
+			}
+			return false
+		}
+
 		// Only notify merge failure once per PR
 		if sess.LastNotifiedStatus != "merge_failed" {
 			o.notifier.Sendf("❌ maestro: failed to merge PR #%d (%s): %v", pr.Number, sess.Branch, err)
@@ -874,7 +895,7 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 			}
 
 			log.Printf("[orch] PR #%d has conflicts, auto-rebasing %s", pr.Number, slotName)
-			if err := worker.RebaseWorktree(sess.Worktree, sess.Branch, o.cfg.AutoResolveFiles); err != nil {
+			if err := o.rebaseWorktree(sess.Worktree, sess.Branch); err != nil {
 				log.Printf("[orch] rebase failed for %s: %v", slotName, err)
 				o.markUnresolvableConflict(slotName, sess, pr.Number, err)
 				continue
@@ -891,7 +912,7 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 			}
 
 			log.Printf("[orch] retrying auto-rebase for conflict_failed session %s (PR #%d)", slotName, pr.Number)
-			if err := worker.RebaseWorktree(sess.Worktree, sess.Branch, o.cfg.AutoResolveFiles); err != nil {
+			if err := o.rebaseWorktree(sess.Worktree, sess.Branch); err != nil {
 				log.Printf("[orch] rebase retry failed for %s: %v", slotName, err)
 				o.markUnresolvableConflict(slotName, sess, pr.Number, err)
 				continue

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1151,3 +1151,159 @@ func TestAutoMergePRs_ParallelStatePersistence(t *testing.T) {
 		t.Errorf("LastMergeAt drift after round-trip: original=%v loaded=%v", s.LastMergeAt, loaded.LastMergeAt)
 	}
 }
+
+func TestMergeReadyPR_BehindMainTriggersRebase(t *testing.T) {
+	rebased := false
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return fmt.Errorf("gh pr merge 10: the head branch is not up to date with the base branch")
+		},
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+			rebased = true
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR("slot-0", sess, pr)
+
+	if result {
+		t.Fatal("mergeReadyPR should return false when merge fails")
+	}
+	if !rebased {
+		t.Fatal("expected rebase to be triggered for 'not up to date' error")
+	}
+	if sess.Status != state.StatusQueued {
+		t.Errorf("session status = %q, want %q", sess.Status, state.StatusQueued)
+	}
+	if !sess.RebaseAttempted {
+		t.Error("RebaseAttempted should be true after successful rebase")
+	}
+}
+
+func TestMergeReadyPR_BehindMainRebaseFailsMarksConflict(t *testing.T) {
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		gh:       github.New("owner/repo"),
+		ghMergePRFn: func(prNumber int) error {
+			return fmt.Errorf("gh pr merge 10: the head branch is not up to date with the base branch")
+		},
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+			return fmt.Errorf("rebase failed: conflict in main.go")
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR("slot-0", sess, pr)
+
+	if result {
+		t.Fatal("mergeReadyPR should return false when rebase fails")
+	}
+	if sess.Status != state.StatusConflictFailed {
+		t.Errorf("session status = %q, want %q", sess.Status, state.StatusConflictFailed)
+	}
+	if !sess.RebaseAttempted {
+		t.Error("RebaseAttempted should be true after failed rebase")
+	}
+	if sess.FinishedAt == nil {
+		t.Error("FinishedAt should be set for conflict_failed session")
+	}
+}
+
+func TestMergeReadyPR_BehindMainNoAutoRebase(t *testing.T) {
+	rebased := false
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: false},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return fmt.Errorf("gh pr merge 10: the head branch is not up to date with the base branch")
+		},
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+			rebased = true
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR("slot-0", sess, pr)
+
+	if result {
+		t.Fatal("mergeReadyPR should return false")
+	}
+	if rebased {
+		t.Fatal("rebase should not be triggered when AutoRebase is disabled")
+	}
+	if sess.Status != state.StatusPROpen {
+		t.Errorf("session status = %q, want %q (should stay pr_open)", sess.Status, state.StatusPROpen)
+	}
+}
+
+func TestMergeReadyPR_OtherMergeErrorNoRebase(t *testing.T) {
+	rebased := false
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return fmt.Errorf("gh pr merge 10: some other error")
+		},
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+			rebased = true
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR("slot-0", sess, pr)
+
+	if result {
+		t.Fatal("mergeReadyPR should return false")
+	}
+	if rebased {
+		t.Fatal("rebase should not be triggered for non-'not up to date' errors")
+	}
+	if sess.Status != state.StatusPROpen {
+		t.Errorf("session status = %q, want %q", sess.Status, state.StatusPROpen)
+	}
+	if sess.LastNotifiedStatus != "merge_failed" {
+		t.Errorf("LastNotifiedStatus = %q, want %q", sess.LastNotifiedStatus, "merge_failed")
+	}
+}


### PR DESCRIPTION
Implements #171

## Changes
When `gh pr merge` fails with "not up to date" (branch is behind main but not conflicting), maestro now immediately triggers an auto-rebase instead of notifying and deferring to the next cycle — which caused an infinite retry loop.

**In `mergeReadyPR()`:**
- Detect "not up to date" in the merge error message
- If `AutoRebase` is enabled, trigger `rebaseWorktree()` immediately
- On rebase success: transition session to `queued` (waits for CI, then retries merge)
- On rebase failure: mark session as `conflict_failed` (needs manual intervention)

**Refactored `rebaseWorktree` into a testable method** on the Orchestrator with a `rebaseWorktreeFn` testing hook, consistent with the existing pattern for `mergePR`, `closeIssue`, and `stopWorker`. Updated `rebaseConflicts()` to use the same wrapper.

## Testing
- `TestMergeReadyPR_BehindMainTriggersRebase` — merge fails with "not up to date", rebase succeeds → session moves to `queued`
- `TestMergeReadyPR_BehindMainRebaseFailsMarksConflict` — rebase fails → session marked `conflict_failed`
- `TestMergeReadyPR_BehindMainNoAutoRebase` — `AutoRebase` disabled → no rebase triggered, stays `pr_open`
- `TestMergeReadyPR_OtherMergeErrorNoRebase` — different merge error → no rebase, normal failure notification

All existing tests continue to pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully fixes the infinite retry loop when PRs are behind the main branch but not conflicting. The solution immediately triggers auto-rebase upon detecting "not up to date" merge errors, rather than deferring to the next cycle.

**Key changes:**
- Added `rebaseWorktreeFn` testing hook and `rebaseWorktree()` wrapper method following the existing pattern for `mergePR`, `closeIssue`, and `stopWorker`
- Enhanced `mergeReadyPR()` to detect "not up to date" errors and trigger immediate auto-rebase when `AutoRebase` is enabled
- On rebase success: transitions session to `queued` status (waits for CI, then retries merge with up-to-date branch)
- On rebase failure: marks session as `conflict_failed` (terminal state requiring manual intervention)
- Updated `rebaseConflicts()` to use the new wrapper for consistency and testability

**Test coverage:** All four critical scenarios are covered with dedicated tests - successful rebase, failed rebase, disabled AutoRebase, and non-matching merge errors. The implementation correctly prevents the infinite loop while maintaining proper state transitions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase, has comprehensive test coverage for all code paths, and correctly solves the infinite retry loop issue. The logic is straightforward with proper state transitions, and the refactoring maintains consistency with existing testing hooks.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Added auto-rebase logic when PRs are behind main, with new rebaseWorktreeFn hook for testing. Implementation follows existing patterns and correctly handles success/failure states. |
| internal/orchestrator/orchestrator_test.go | Added 4 comprehensive test cases covering all auto-rebase scenarios: successful rebase, failed rebase, disabled AutoRebase, and non-matching errors. |

</details>



<sub>Last reviewed commit: 75d285a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->