### PR TITLE
test: complete cline backend test coverage (#158)

### DIFF
--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -153,6 +153,55 @@ func TestBuildWorkerCmd_GeminiDefaultCmd(t *testing.T) {
 	}
 }
 
+func TestBuildWorkerCmd_Cline(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("fix the login flow"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	worktree := "/tmp/cline-worktree"
+
+	cfg := BackendConfig{Cmd: "cline", ExtraArgs: []string{"--verbose"}}
+	cmd, stdinFile, err := BuildWorkerCmd("cline", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stdinFile != "" {
+		t.Errorf("expected empty stdinFile for cline, got: %s", stdinFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "-y") {
+		t.Errorf("expected -y flag in args, got: %s", args)
+	}
+	if !strings.Contains(args, "fix the login flow") {
+		t.Errorf("expected prompt content in args, got: %s", args)
+	}
+	if !strings.Contains(args, "--verbose") {
+		t.Errorf("expected extra args in command, got: %s", args)
+	}
+	if cmd.Dir != worktree {
+		t.Errorf("expected Dir=%s, got %s", worktree, cmd.Dir)
+	}
+}
+
+func TestBuildWorkerCmd_ClineDefaultCmd(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BackendConfig{}
+	cmd, _, err := BuildWorkerCmd("cline", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasSuffix(cmd.Path, "cline") && !strings.Contains(cmd.Args[0], "cline") {
+		t.Errorf("expected cline command, got: %v", cmd.Args)
+	}
+}
+
 func TestBuildWorkerCmd_GenericArgMode(t *testing.T) {
 	dir := t.TempDir()
 	promptFile := filepath.Join(dir, "prompt.md")
@@ -306,7 +355,7 @@ func TestBuildWorkerCmd_GenericInvalidPromptMode(t *testing.T) {
 
 func TestKnownBackends(t *testing.T) {
 	backends := KnownBackends()
-	expected := map[string]bool{"claude": false, "codex": false, "gemini": false}
+	expected := map[string]bool{"claude": false, "codex": false, "gemini": false, "cline": false}
 	for _, name := range backends {
 		if _, ok := expected[name]; ok {
 			expected[name] = true


### PR DESCRIPTION
Closes #158

## Summary
- Added `TestBuildWorkerCmd_Cline` and `TestBuildWorkerCmd_ClineDefaultCmd` to verify the cline backend command building (was the only backend without tests)
- Fixed `TestKnownBackends` to include "cline" in the expected set (was missing despite cline being registered in `knownBackends`)

## Verification of #158

Per-issue model routing via GitHub labels is fully implemented end-to-end:

1. **Label extraction**: `router.BackendFromLabels()` extracts `model:<backend>` from issue labels
2. **Validation**: `router.ValidateBackend()` checks the backend exists in config, falls back to default if unknown
3. **3-tier resolution**: `router.ResolveBackend()` applies priority: label override > auto-routing > default
4. **Orchestrator integration**: `orchestrator.resolveBackend()` delegates to the router before spawning workers
5. **Worker spawning**: `worker.Start()` uses the resolved backend to build the correct CLI command
6. **Respawn preservation**: `sess.Backend` is persisted so retries use the same backend

All four backends (claude, codex, gemini, cline) now have complete test coverage.

## Testing
- `go test ./...` — all pass
- `go vet ./...` — clean
- `go build ./cmd/maestro/` — builds successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added missing test coverage for the cline backend and fixed `TestKnownBackends` to include "cline" in the expected backends list.

- Added `TestBuildWorkerCmd_Cline` verifying cline backend command building with custom config
- Added `TestBuildWorkerCmd_ClineDefaultCmd` verifying default command behavior when config is empty
- Fixed `TestKnownBackends` to include "cline" alongside claude, codex, and gemini

The new tests follow the same pattern as existing backend tests and correctly validate the cline backend implementation (checking the `-y` flag, prompt content in args, extra args, and working directory setup).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes add comprehensive test coverage for the cline backend and fix a test bug. All new tests follow existing patterns, correctly validate the implementation, and include proper assertions. No production code changes, only test additions.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/worker/backend_test.go | Added comprehensive cline backend tests and fixed TestKnownBackends to include cline |

</details>



<sub>Last reviewed commit: 3f3b1f3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->