### PR TITLE
test: verify worker_silent_timeout_minutes kills stuck workers (#156)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -43,6 +43,11 @@ type Orchestrator struct {
 	ghCloseIssueFn         func(number int, comment string) error
 	workerStopFn           func(cfg *config.Config, slotName string, sess *state.Session) error
 	rebaseWorktreeFn       func(worktreePath, branch string, autoResolveFiles []string) error
+
+	// Testing hooks for checkSessions
+	tmuxCaptureFn   func(session string) (string, error)
+	isIssueClosedFn func(number int) (bool, error)
+	addIssueLabelFn func(number int, label string) error
 }
 
 // New creates a new Orchestrator
@@ -132,6 +137,27 @@ func (o *Orchestrator) rebaseWorktree(worktreePath, branch string) error {
 		return o.rebaseWorktreeFn(worktreePath, branch, o.cfg.AutoResolveFiles)
 	}
 	return worker.RebaseWorktree(worktreePath, branch, o.cfg.AutoResolveFiles)
+}
+
+func (o *Orchestrator) captureTmux(session string) (string, error) {
+	if o.tmuxCaptureFn != nil {
+		return o.tmuxCaptureFn(session)
+	}
+	return tmuxCapture(session)
+}
+
+func (o *Orchestrator) isIssueClosed(number int) (bool, error) {
+	if o.isIssueClosedFn != nil {
+		return o.isIssueClosedFn(number)
+	}
+	return o.gh.IsIssueClosed(number)
+}
+
+func (o *Orchestrator) addIssueLabel(number int, label string) error {
+	if o.addIssueLabelFn != nil {
+		return o.addIssueLabelFn(number, label)
+	}
+	return o.gh.AddIssueLabel(number, label)
 }
 
 func readLastLines(path string, limit int) (string, error) {
@@ -415,7 +441,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 // checkSessions inspects all sessions and updates their status
 func (o *Orchestrator) checkSessions(s *state.State) {
 	// Fetch open PRs once for the whole check cycle
-	prs, prErr := o.gh.ListOpenPRs()
+	prs, prErr := o.listOpenPRs()
 	branchToPR := make(map[string]github.PR)
 	if prErr != nil {
 		log.Printf("[orch] list PRs (check): %v", prErr)
@@ -441,12 +467,12 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 		// Check if issue is now closed (only for running sessions)
 		if sess.Status == state.StatusRunning {
-			closed, err := o.gh.IsIssueClosed(sess.IssueNumber)
+			closed, err := o.isIssueClosed(sess.IssueNumber)
 			if err != nil {
 				log.Printf("[orch] check issue #%d: %v", sess.IssueNumber, err)
 			} else if closed {
 				log.Printf("[orch] issue #%d closed, stopping worker %s", sess.IssueNumber, slotName)
-				worker.Stop(o.cfg, slotName, sess)
+				o.stopWorker(slotName, sess)
 				sess.Status = state.StatusDone
 				now := time.Now().UTC()
 				sess.FinishedAt = &now
@@ -454,7 +480,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 			}
 
 			// Check if process is still alive
-			if sess.PID > 0 && !worker.IsAlive(sess.PID) {
+			if sess.PID > 0 && !o.pidAlive(sess.PID) {
 				// Check if there's an open PR for this branch BEFORE marking dead
 				if pr, found := branchToPR[sess.Branch]; found {
 					log.Printf("[orch] worker %s exited but PR #%d is open — transitioning to pr_open", slotName, pr.Number)
@@ -494,7 +520,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				} else {
 					// Already retried — mark as permanently failed
 					log.Printf("[orch] worker %s (pid=%d) permanently failed after %d retries", slotName, sess.PID, sess.RetryCount)
-					if err := o.gh.AddIssueLabel(sess.IssueNumber, "blocked"); err != nil {
+					if err := o.addIssueLabel(sess.IssueNumber, "blocked"); err != nil {
 						log.Printf("[orch] warn: could not label issue #%d as blocked: %v", sess.IssueNumber, err)
 					}
 					sess.Status = state.StatusFailed
@@ -523,7 +549,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					tmuxName = worker.TmuxSessionName(slotName)
 				}
 
-				output, err := tmuxCapture(tmuxName)
+				output, err := o.captureTmux(tmuxName)
 				if err != nil {
 					log.Printf("[orch] warn: tmux capture-pane failed for %s (%s): %v", slotName, tmuxName, err)
 				} else {
@@ -537,7 +563,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					if o.cfg.WorkerMaxTokens > 0 && sess.TokensUsed > o.cfg.WorkerMaxTokens && sess.LastNotifiedStatus != "token_limit" {
 						log.Printf("[orch] worker %s exceeded token limit (%d > %d), killing",
 							slotName, sess.TokensUsed, o.cfg.WorkerMaxTokens)
-						if err := worker.Stop(o.cfg, slotName, sess); err != nil {
+						if err := o.stopWorker(slotName, sess); err != nil {
 							log.Printf("[orch] warn: could not stop token-limit worker %s: %v", slotName, err)
 						}
 						now := time.Now().UTC()
@@ -561,7 +587,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 							timeout := time.Duration(o.cfg.WorkerSilentTimeoutMinutes) * time.Minute
 							if time.Since(sess.LastOutputChangedAt) > timeout {
 								log.Printf("[orch] worker %s silent for >%dm, killing", slotName, o.cfg.WorkerSilentTimeoutMinutes)
-								if err := worker.Stop(o.cfg, slotName, sess); err != nil {
+								if err := o.stopWorker(slotName, sess); err != nil {
 									log.Printf("[orch] warn: could not stop silent worker %s: %v", slotName, err)
 								}
 
@@ -574,7 +600,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 								sess.FinishedAt = &now
 
 								if prevSilentKills > 0 {
-									if err := o.gh.AddIssueLabel(sess.IssueNumber, "blocked"); err != nil {
+									if err := o.addIssueLabel(sess.IssueNumber, "blocked"); err != nil {
 										log.Printf("[orch] warn: could not label issue #%d as blocked: %v", sess.IssueNumber, err)
 									}
 								}
@@ -593,7 +619,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				if tmuxName == "" {
 					tmuxName = worker.TmuxSessionName(slotName)
 				}
-				if output, err := tmuxCapture(tmuxName); err == nil {
+				if output, err := o.captureTmux(tmuxName); err == nil {
 					if tokens := worker.ParseTokensFromOutput(output); tokens > sess.TokensUsed {
 						sess.TokensUsed = tokens
 					}
@@ -616,10 +642,10 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					logTail = fmt.Sprintf("(could not read log file %s: %v)", sess.LogFile, err)
 				}
 
-				if err := worker.Stop(o.cfg, slotName, sess); err != nil {
+				if err := o.stopWorker(slotName, sess); err != nil {
 					log.Printf("[orch] warn: could not stop timed-out worker %s: %v", slotName, err)
 				}
-				if err := o.gh.AddIssueLabel(sess.IssueNumber, "blocked"); err != nil {
+				if err := o.addIssueLabel(sess.IssueNumber, "blocked"); err != nil {
 					log.Printf("[orch] warn: could not label issue #%d as blocked: %v", sess.IssueNumber, err)
 				}
 				sess.Status = state.StatusFailed

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1307,3 +1307,265 @@ func TestMergeReadyPR_OtherMergeErrorNoRebase(t *testing.T) {
 		t.Errorf("LastNotifiedStatus = %q, want %q", sess.LastNotifiedStatus, "merge_failed")
 	}
 }
+
+// --- silent timeout tests ---
+
+// newSilentTimeoutOrchestrator creates an Orchestrator wired for checkSessions
+// testing. The tmux capture function returns the provided output string.
+// It records whether stopWorker was called and which labels were added.
+func newSilentTimeoutOrchestrator(timeoutMinutes int, tmuxOutput string) (*Orchestrator, *bool, *[]string) {
+	stopped := false
+	labels := make([]string, 0)
+	return &Orchestrator{
+		cfg: &config.Config{
+			Repo:                       "owner/repo",
+			WorkerSilentTimeoutMinutes: timeoutMinutes,
+			MaxRuntimeMinutes:          120,
+		},
+		notifier:        &notify.Notifier{},
+		pidAliveFn:      func(pid int) bool { return true },
+		listOpenPRsFn:   func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn: func(number int) (bool, error) { return false, nil },
+		tmuxCaptureFn:   func(session string) (string, error) { return tmuxOutput, nil },
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			stopped = true
+			return nil
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labels = append(labels, label)
+			return nil
+		},
+	}, &stopped, &labels
+}
+
+func TestCheckSessions_SilentTimeoutKillsStuckWorker(t *testing.T) {
+	output := "some static output\nline 2\nline 3"
+	o, stopped, _ := newSilentTimeoutOrchestrator(10, output)
+
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:         42,
+		IssueTitle:          "stuck worker",
+		Status:              state.StatusRunning,
+		PID:                 1234,
+		TmuxSession:         "maestro-slot-1",
+		Branch:              "feat/slot-1-42-stuck",
+		StartedAt:           time.Now().Add(-30 * time.Minute),
+		LastOutputHash:      hashOutput(output),                // same hash as current output
+		LastOutputChangedAt: time.Now().Add(-15 * time.Minute), // 15 min ago > 10 min timeout
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["slot-1"]
+	if !*stopped {
+		t.Fatal("expected worker to be stopped")
+	}
+	if sess.Status != state.StatusDead {
+		t.Errorf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.LastNotifiedStatus != "silent_timeout" {
+		t.Errorf("LastNotifiedStatus = %q, want %q", sess.LastNotifiedStatus, "silent_timeout")
+	}
+	if sess.FinishedAt == nil {
+		t.Error("FinishedAt should be set")
+	}
+}
+
+func TestCheckSessions_SilentTimeoutWithinTimeout_NoKill(t *testing.T) {
+	output := "some static output\nline 2\nline 3"
+	o, stopped, _ := newSilentTimeoutOrchestrator(10, output)
+
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:         42,
+		IssueTitle:          "not yet stuck",
+		Status:              state.StatusRunning,
+		PID:                 1234,
+		TmuxSession:         "maestro-slot-1",
+		Branch:              "feat/slot-1-42-not-stuck",
+		StartedAt:           time.Now().Add(-30 * time.Minute),
+		LastOutputHash:      hashOutput(output),
+		LastOutputChangedAt: time.Now().Add(-5 * time.Minute), // 5 min ago < 10 min timeout
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["slot-1"]
+	if *stopped {
+		t.Fatal("worker should NOT be stopped within timeout")
+	}
+	if sess.Status != state.StatusRunning {
+		t.Errorf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+}
+
+func TestCheckSessions_SilentTimeoutOutputChanges_NoKill(t *testing.T) {
+	// Tmux returns different output than last recorded hash
+	o, stopped, _ := newSilentTimeoutOrchestrator(10, "new output line\nline 2")
+
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:         42,
+		IssueTitle:          "active worker",
+		Status:              state.StatusRunning,
+		PID:                 1234,
+		TmuxSession:         "maestro-slot-1",
+		Branch:              "feat/slot-1-42-active",
+		StartedAt:           time.Now().Add(-30 * time.Minute),
+		LastOutputHash:      hashOutput("old output"), // different from current
+		LastOutputChangedAt: time.Now().Add(-15 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["slot-1"]
+	if *stopped {
+		t.Fatal("worker should NOT be stopped when output changes")
+	}
+	if sess.Status != state.StatusRunning {
+		t.Errorf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+	// Hash should be updated to new output
+	if sess.LastOutputHash != hashOutput("new output line\nline 2") {
+		t.Error("LastOutputHash should be updated to new output hash")
+	}
+}
+
+func TestCheckSessions_SilentTimeoutDisabled_NoKill(t *testing.T) {
+	output := "static output"
+	o, stopped, _ := newSilentTimeoutOrchestrator(0, output) // timeout=0 means disabled
+
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:         42,
+		IssueTitle:          "no timeout",
+		Status:              state.StatusRunning,
+		PID:                 1234,
+		TmuxSession:         "maestro-slot-1",
+		Branch:              "feat/slot-1-42-no-timeout",
+		StartedAt:           time.Now().Add(-30 * time.Minute),
+		LastOutputHash:      hashOutput(output),
+		LastOutputChangedAt: time.Now().Add(-60 * time.Minute), // way past any timeout
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["slot-1"]
+	if *stopped {
+		t.Fatal("worker should NOT be stopped when timeout is disabled (0)")
+	}
+	if sess.Status != state.StatusRunning {
+		t.Errorf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+}
+
+func TestCheckSessions_SilentTimeoutFirstKill_NoBlockedLabel(t *testing.T) {
+	output := "static output"
+	o, _, labels := newSilentTimeoutOrchestrator(10, output)
+
+	s := state.NewState()
+	// Only one session for this issue — first silent timeout
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:         42,
+		IssueTitle:          "first timeout",
+		Status:              state.StatusRunning,
+		PID:                 1234,
+		TmuxSession:         "maestro-slot-1",
+		Branch:              "feat/slot-1-42-first",
+		StartedAt:           time.Now().Add(-30 * time.Minute),
+		LastOutputHash:      hashOutput(output),
+		LastOutputChangedAt: time.Now().Add(-15 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["slot-1"]
+	if sess.Status != state.StatusDead {
+		t.Errorf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	// First silent timeout should NOT add "blocked" label
+	for _, label := range *labels {
+		if label == "blocked" {
+			t.Error("first silent timeout should NOT add 'blocked' label")
+		}
+	}
+}
+
+func TestCheckSessions_SilentTimeoutSecondKill_LabelsBlocked(t *testing.T) {
+	output := "static output"
+	o, _, labels := newSilentTimeoutOrchestrator(10, output)
+
+	s := state.NewState()
+	// Previous silent timeout for same issue
+	s.Sessions["slot-old"] = &state.Session{
+		IssueNumber:        42,
+		LastNotifiedStatus: "silent_timeout",
+		Status:             state.StatusDead,
+	}
+	// Current running session — will be killed
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:         42,
+		IssueTitle:          "second timeout",
+		Status:              state.StatusRunning,
+		PID:                 1234,
+		TmuxSession:         "maestro-slot-1",
+		Branch:              "feat/slot-1-42-second",
+		StartedAt:           time.Now().Add(-30 * time.Minute),
+		LastOutputHash:      hashOutput(output),
+		LastOutputChangedAt: time.Now().Add(-15 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["slot-1"]
+	if sess.Status != state.StatusDead {
+		t.Errorf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	// Second silent timeout SHOULD add "blocked" label
+	found := false
+	for _, label := range *labels {
+		if label == "blocked" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("second silent timeout should add 'blocked' label")
+	}
+}
+
+func TestCheckSessions_SilentTimeoutFirstObservation_SetsHash(t *testing.T) {
+	output := "initial output\nline 2"
+	o, stopped, _ := newSilentTimeoutOrchestrator(10, output)
+
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "new worker",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-slot-1",
+		Branch:      "feat/slot-1-42-new",
+		StartedAt:   time.Now().Add(-5 * time.Minute),
+		// LastOutputHash and LastOutputChangedAt are zero values (first observation)
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["slot-1"]
+	if *stopped {
+		t.Fatal("worker should NOT be stopped on first observation")
+	}
+	if sess.Status != state.StatusRunning {
+		t.Errorf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+	if sess.LastOutputHash == "" {
+		t.Error("LastOutputHash should be set on first observation")
+	}
+	if sess.LastOutputHash != hashOutput(output) {
+		t.Errorf("LastOutputHash = %q, want hash of output", sess.LastOutputHash)
+	}
+	if sess.LastOutputChangedAt.IsZero() {
+		t.Error("LastOutputChangedAt should be set on first observation")
+	}
+}


### PR DESCRIPTION
Implements #156

## Changes

Added testing hooks and comprehensive unit tests to verify that `worker_silent_timeout_minutes` correctly kills workers when tmux output is unchanged for N minutes.

**Production code (`orchestrator.go`):**
- Added 3 testing hooks to Orchestrator: `tmuxCaptureFn`, `isIssueClosedFn`, `addIssueLabelFn` (following the existing pattern used by `pidAliveFn`, `workerStopFn`, etc.)
- Updated `checkSessions()` to use hookable wrapper methods consistently instead of calling `worker.Stop()`, `worker.IsAlive()`, `tmuxCapture()`, `o.gh.IsIssueClosed()`, `o.gh.AddIssueLabel()`, and `o.gh.ListOpenPRs()` directly. This makes checkSessions testable and consistent with `reconcileRunningSessions` and `autoMergePRs`.

**Tests (`orchestrator_test.go`):**
- `TestCheckSessions_SilentTimeoutKillsStuckWorker` — verifies worker is stopped and marked dead when output hash unchanged past timeout
- `TestCheckSessions_SilentTimeoutWithinTimeout_NoKill` — output unchanged but within timeout window, worker stays running
- `TestCheckSessions_SilentTimeoutOutputChanges_NoKill` — output changes reset the timer, worker stays running
- `TestCheckSessions_SilentTimeoutDisabled_NoKill` — timeout=0 (disabled) never kills, even with very stale output
- `TestCheckSessions_SilentTimeoutFirstKill_NoBlockedLabel` — first silent timeout does not label issue as blocked
- `TestCheckSessions_SilentTimeoutSecondKill_LabelsBlocked` — second silent timeout for same issue adds "blocked" label
- `TestCheckSessions_SilentTimeoutFirstObservation_SetsHash` — first observation stores hash and timestamp without killing

## Testing

All tests pass:
```
go fmt ./...   ✓
go vet ./...   ✓
go test ./...  ✓ (all packages)
go build       ✓
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds comprehensive test coverage for the `worker_silent_timeout_minutes` feature that kills workers when tmux output remains unchanged. The implementation follows existing testing patterns by adding hookable wrappers (`tmuxCaptureFn`, `isIssueClosedFn`, `addIssueLabelFn`) and updating `checkSessions()` to use them.

**Key changes:**
- Added 7 test cases covering timeout enforcement, timer resets, disabled timeouts, and blocked label logic
- Updated most `checkSessions()` calls to use hookable wrapper methods for testability
- Tests verify correct behavior: workers are killed after timeout, timers reset on output changes, and "blocked" labels are only added on second silent timeout

**Test coverage includes:**
- Timeout exceeded kills worker
- Within timeout window preserves worker
- Output changes reset timer
- Disabled timeout (0) never kills
- First timeout doesn't label issue
- Second timeout labels issue as blocked
- First observation sets hash and timestamp

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor consistency improvement recommended
- The implementation is solid with comprehensive test coverage. Testing hooks follow established patterns, and the silent timeout logic is correct. One minor inconsistency exists where line 461 still uses direct `worker.Stop()` instead of the wrapper method, but this doesn't affect the tested functionality.
- internal/orchestrator/orchestrator.go line 461 could use the wrapper method for consistency

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Added three testing hooks (`tmuxCaptureFn`, `isIssueClosedFn`, `addIssueLabelFn`) and wrapper methods for `checkSessions` testability. Updated most calls to use wrappers, but line 461 still uses direct `worker.Stop()` call. |
| internal/orchestrator/orchestrator_test.go | Added comprehensive silent timeout test coverage with 7 test cases covering timeout enforcement, timer resets, disabled timeouts, and blocked label logic. Tests are well-structured and thorough. |

</details>



<sub>Last reviewed commit: ca13c8a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->