### PR TITLE
feat: limit retries per issue — don't spawn infinite workers (#177)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	MaxRuntimeMinutes          int              `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
 	WorkerSilentTimeoutMinutes int              `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
 	WorkerMaxTokens            int              `yaml:"worker_max_tokens"`             // kill worker when token usage exceeds this threshold (0 = unlimited)
+	MaxRetriesPerIssue         int              `yaml:"max_retries_per_issue"`         // max failed worker sessions per issue before giving up (default: 3, 0 = unlimited)
 	AutoRebase                 bool             `yaml:"auto_rebase"`                   // auto-attempt rebase for conflicting sessions (default: true)
 	ClaudeCmd                  string           `yaml:"claude_cmd"`                    // deprecated: use model.backends.claude.cmd
 	IssueLabel                 string           `yaml:"issue_label"`                   // deprecated: use issue_labels
@@ -111,6 +112,7 @@ func parse(data []byte) (*Config, error) {
 	cfg := &Config{
 		MaxParallel:          5,
 		MaxRuntimeMinutes:    120,
+		MaxRetriesPerIssue:   3,
 		AutoRebase:           true,
 		ClaudeCmd:            "claude",
 		MergeStrategy:        "sequential",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -664,3 +664,42 @@ merge_interval_seconds: 0
 		t.Errorf("MergeIntervalSeconds = %d, want 30", cfg.MergeIntervalSeconds)
 	}
 }
+
+func TestParse_MaxRetriesPerIssueDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.MaxRetriesPerIssue != 3 {
+		t.Errorf("MaxRetriesPerIssue = %d, want 3", cfg.MaxRetriesPerIssue)
+	}
+}
+
+func TestParse_MaxRetriesPerIssueExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+max_retries_per_issue: 5
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.MaxRetriesPerIssue != 5 {
+		t.Errorf("MaxRetriesPerIssue = %d, want 5", cfg.MaxRetriesPerIssue)
+	}
+}
+
+func TestParse_MaxRetriesPerIssueZero(t *testing.T) {
+	yaml := `
+repo: owner/repo
+max_retries_per_issue: 0
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.MaxRetriesPerIssue != 0 {
+		t.Errorf("MaxRetriesPerIssue = %d, want 0 (unlimited)", cfg.MaxRetriesPerIssue)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -42,6 +42,10 @@ type Orchestrator struct {
 	isIssueClosedFn func(issueNumber int) (bool, error)
 	addIssueLabelFn func(number int, label string) error
 
+	// Testing hooks for startNewWorkers
+	listOpenIssuesFn func(labels []string) ([]github.Issue, error)
+	workerStartFn    func(cfg *config.Config, s *state.State, repo string, issue github.Issue, promptBase, backend string) (string, error)
+
 	// Testing hooks for autoMergePRs / mergeReadyPR
 	ghPRCIStatusFn         func(prNumber int) (string, error)
 	ghPRGreptileApprovedFn func(prNumber int) (approved bool, pending bool, err error)
@@ -990,8 +994,22 @@ func (o *Orchestrator) resolveBackend(issue github.Issue) string {
 }
 
 // startNewWorkers picks eligible issues and starts workers for them
+func (o *Orchestrator) listOpenIssues(labels []string) ([]github.Issue, error) {
+	if o.listOpenIssuesFn != nil {
+		return o.listOpenIssuesFn(labels)
+	}
+	return o.gh.ListOpenIssues(labels)
+}
+
+func (o *Orchestrator) startWorker(s *state.State, issue github.Issue, promptBase, backend string) (string, error) {
+	if o.workerStartFn != nil {
+		return o.workerStartFn(o.cfg, s, o.repo, issue, promptBase, backend)
+	}
+	return worker.Start(o.cfg, s, o.repo, issue, promptBase, backend)
+}
+
 func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
-	issues, err := o.gh.ListOpenIssues(o.cfg.IssueLabels)
+	issues, err := o.listOpenIssues(o.cfg.IssueLabels)
 	if err != nil {
 		log.Printf("[orch] list issues: %v", err)
 		return
@@ -1010,6 +1028,25 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if github.HasLabel(issue, o.cfg.ExcludeLabels) {
 			log.Printf("[orch] skipping issue #%d (excluded label)", issue.Number)
 			continue
+		}
+
+		// Check retry limit: skip issues that have exhausted their retry budget
+		if o.cfg.MaxRetriesPerIssue > 0 {
+			failed := s.FailedAttemptsForIssue(issue.Number)
+			if failed >= o.cfg.MaxRetriesPerIssue {
+				if !s.IssueRetryExhausted(issue.Number) {
+					// First time hitting the limit — mark, label, and notify
+					s.MarkIssueRetryExhausted(issue.Number)
+					if err := o.addIssueLabel(issue.Number, "blocked"); err != nil {
+						log.Printf("[orch] warn: could not label issue #%d as blocked: %v", issue.Number, err)
+					}
+					o.notifier.Sendf("⚠️ Issue #%d hit max retries (%d) — needs manual review",
+						issue.Number, o.cfg.MaxRetriesPerIssue)
+				}
+				log.Printf("[orch] skipping issue #%d: retry limit exhausted (%d/%d attempts)",
+					issue.Number, failed, o.cfg.MaxRetriesPerIssue)
+				continue
+			}
 		}
 
 		// Safety net: check GitHub directly for any open PR referencing this issue.
@@ -1036,7 +1073,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 
 		promptBase := o.selectPrompt(issue)
 		log.Printf("[orch] starting worker for issue #%d: %s (backend=%s, long_running=%v)", issue.Number, issue.Title, backendName, longRunning)
-		slotName, err := worker.Start(o.cfg, s, o.repo, issue, promptBase, backendName)
+		slotName, err := o.startWorker(s, issue, promptBase, backendName)
 		if err != nil {
 			log.Printf("[orch] start worker for issue #%d: %v", issue.Number, err)
 			o.notifier.Sendf("❌ maestro: failed to start worker for issue #%d (%s): %v",

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1968,3 +1968,238 @@ func TestCountSilentTimeoutKillsForIssue_NoMatches(t *testing.T) {
 		t.Fatalf("countSilentTimeoutKillsForIssue(99) = %d, want 0 (no sessions for issue)", got)
 	}
 }
+
+// --- retry limit tests ---
+
+// newStartWorkersOrchestrator creates an Orchestrator wired with test fakes for
+// startNewWorkers. It returns the orchestrator, a slice of started issue numbers,
+// and a slice of labels added.
+func newStartWorkersOrchestrator(cfg *config.Config, issues []github.Issue) (*Orchestrator, *[]int, *[]string) {
+	started := make([]int, 0)
+	labels := make([]string, 0)
+	slotCounter := 0
+	return &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		router:   router.New(cfg),
+		listOpenIssuesFn: func(labelFilter []string) ([]github.Issue, error) {
+			return issues, nil
+		},
+		hasOpenPRForIssueFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labels = append(labels, fmt.Sprintf("#%d:%s", number, label))
+			return nil
+		},
+		workerStartFn: func(cfg *config.Config, s *state.State, repo string, issue github.Issue, promptBase, backend string) (string, error) {
+			slotCounter++
+			slotName := fmt.Sprintf("slot-%d", slotCounter)
+			s.Sessions[slotName] = &state.Session{
+				IssueNumber: issue.Number,
+				IssueTitle:  issue.Title,
+				Status:      state.StatusRunning,
+				PID:         1000 + slotCounter,
+				Branch:      fmt.Sprintf("feat/%s", slotName),
+				StartedAt:   time.Now().UTC(),
+			}
+			started = append(started, issue.Number)
+			return slotName, nil
+		},
+	}, &started, &labels
+}
+
+func TestStartNewWorkers_SkipsRetryExhaustedIssue(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.MaxRetriesPerIssue = 3
+
+	issues := []github.Issue{
+		makeIssue(42, "failing issue"),
+		makeIssue(43, "fresh issue"),
+	}
+
+	o, started, labels := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+
+	// Simulate 3 prior failed attempts for issue #42 (dead without PR)
+	now := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		slotName := fmt.Sprintf("old-%d", i)
+		finished := now.Add(-time.Duration(3-i) * time.Hour)
+		s.Sessions[slotName] = &state.Session{
+			IssueNumber: 42,
+			Status:      state.StatusDead,
+			PRNumber:    0,
+			StartedAt:   finished.Add(-30 * time.Minute),
+			FinishedAt:  &finished,
+		}
+	}
+
+	o.startNewWorkers(s, 5)
+
+	// Only issue #43 should be started
+	if len(*started) != 1 {
+		t.Fatalf("started %d workers, want 1", len(*started))
+	}
+	if (*started)[0] != 43 {
+		t.Errorf("started issue #%d, want #43", (*started)[0])
+	}
+
+	// Issue #42 should be labeled blocked
+	foundBlocked := false
+	for _, label := range *labels {
+		if label == "#42:blocked" {
+			foundBlocked = true
+		}
+	}
+	if !foundBlocked {
+		t.Errorf("expected issue #42 to be labeled blocked, labels = %v", *labels)
+	}
+
+	// The most recent dead session for issue #42 should be marked retry_exhausted
+	if !s.IssueRetryExhausted(42) {
+		t.Error("issue #42 should have a retry_exhausted session")
+	}
+}
+
+func TestStartNewWorkers_RetryLimitDisabledWhenZero(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.MaxRetriesPerIssue = 0 // unlimited
+
+	issues := []github.Issue{
+		makeIssue(42, "failing issue"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+
+	// 10 prior failures — should still spawn because limit is disabled
+	now := time.Now().UTC()
+	for i := 0; i < 10; i++ {
+		slotName := fmt.Sprintf("old-%d", i)
+		finished := now.Add(-time.Duration(10-i) * time.Hour)
+		s.Sessions[slotName] = &state.Session{
+			IssueNumber: 42,
+			Status:      state.StatusDead,
+			PRNumber:    0,
+			StartedAt:   finished.Add(-30 * time.Minute),
+			FinishedAt:  &finished,
+		}
+	}
+
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 {
+		t.Fatalf("started %d workers, want 1 (limit disabled)", len(*started))
+	}
+}
+
+func TestStartNewWorkers_RetryExhaustedNotifiesOnce(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.MaxRetriesPerIssue = 2
+
+	issues := []github.Issue{
+		makeIssue(42, "failing issue"),
+	}
+
+	o, _, labels := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+
+	// 2 prior failures
+	now := time.Now().UTC()
+	for i := 0; i < 2; i++ {
+		slotName := fmt.Sprintf("old-%d", i)
+		finished := now.Add(-time.Duration(2-i) * time.Hour)
+		s.Sessions[slotName] = &state.Session{
+			IssueNumber: 42,
+			Status:      state.StatusDead,
+			PRNumber:    0,
+			StartedAt:   finished.Add(-30 * time.Minute),
+			FinishedAt:  &finished,
+		}
+	}
+
+	// First cycle: should mark retry_exhausted and label blocked
+	o.startNewWorkers(s, 5)
+	if !s.IssueRetryExhausted(42) {
+		t.Fatal("issue #42 should be retry_exhausted after first detection")
+	}
+	firstLabelCount := len(*labels)
+	if firstLabelCount == 0 {
+		t.Fatal("expected blocked label on first detection")
+	}
+
+	// Second cycle: should skip but NOT re-label or re-notify
+	o.startNewWorkers(s, 5)
+	if len(*labels) != firstLabelCount {
+		t.Errorf("labels added on second cycle: %v (should not duplicate)", *labels)
+	}
+}
+
+func TestStartNewWorkers_BelowLimitStillSpawns(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.MaxRetriesPerIssue = 3
+
+	issues := []github.Issue{
+		makeIssue(42, "failing issue"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+
+	// Only 2 prior failures — below limit of 3
+	now := time.Now().UTC()
+	for i := 0; i < 2; i++ {
+		slotName := fmt.Sprintf("old-%d", i)
+		finished := now.Add(-time.Duration(2-i) * time.Hour)
+		s.Sessions[slotName] = &state.Session{
+			IssueNumber: 42,
+			Status:      state.StatusDead,
+			PRNumber:    0,
+			StartedAt:   finished.Add(-30 * time.Minute),
+			FinishedAt:  &finished,
+		}
+	}
+
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 {
+		t.Fatalf("started %d workers, want 1 (below retry limit)", len(*started))
+	}
+	if (*started)[0] != 42 {
+		t.Errorf("started issue #%d, want #42", (*started)[0])
+	}
+}
+
+func TestStartNewWorkers_FailedWithPRNotCounted(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.MaxRetriesPerIssue = 2
+
+	issues := []github.Issue{
+		makeIssue(42, "issue with PR failures"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+
+	// 3 "failed" sessions, but all have PRs — should NOT count toward retry limit
+	now := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		slotName := fmt.Sprintf("old-%d", i)
+		finished := now.Add(-time.Duration(3-i) * time.Hour)
+		s.Sessions[slotName] = &state.Session{
+			IssueNumber: 42,
+			Status:      state.StatusFailed,
+			PRNumber:    100 + i, // has PR
+			StartedAt:   finished.Add(-30 * time.Minute),
+			FinishedAt:  &finished,
+		}
+	}
+
+	o.startNewWorkers(s, 5)
+
+	// Should still spawn because failed-with-PR doesn't count
+	if len(*started) != 1 {
+		t.Fatalf("started %d workers, want 1 (PR failures don't count)", len(*started))
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -19,6 +19,7 @@ const (
 	StatusFailed         SessionStatus = "failed"
 	StatusConflictFailed SessionStatus = "conflict_failed"
 	StatusDead           SessionStatus = "dead"
+	StatusRetryExhausted SessionStatus = "retry_exhausted" // max retries reached, needs manual review
 )
 
 type Session struct {
@@ -132,10 +133,59 @@ func (s *State) IssueInProgress(issueNum int) bool {
 	return false
 }
 
+// FailedAttemptsForIssue counts sessions for the given issue that ended
+// without producing a PR (dead, failed, or retry_exhausted).
+func (s *State) FailedAttemptsForIssue(issueNum int) int {
+	count := 0
+	for _, sess := range s.Sessions {
+		if sess.IssueNumber == issueNum && sess.PRNumber == 0 &&
+			(sess.Status == StatusDead || sess.Status == StatusFailed || sess.Status == StatusRetryExhausted) {
+			count++
+		}
+	}
+	return count
+}
+
+// IssueRetryExhausted returns true if any session for the given issue
+// has been marked as retry_exhausted.
+func (s *State) IssueRetryExhausted(issueNum int) bool {
+	for _, sess := range s.Sessions {
+		if sess.IssueNumber == issueNum && sess.Status == StatusRetryExhausted {
+			return true
+		}
+	}
+	return false
+}
+
+// MarkIssueRetryExhausted transitions the most recent dead/failed session
+// for the given issue to StatusRetryExhausted.
+func (s *State) MarkIssueRetryExhausted(issueNum int) {
+	var latest *Session
+	var latestTime time.Time
+	for _, sess := range s.Sessions {
+		if sess.IssueNumber == issueNum &&
+			(sess.Status == StatusDead || sess.Status == StatusFailed) {
+			var t time.Time
+			if sess.FinishedAt != nil {
+				t = *sess.FinishedAt
+			} else {
+				t = sess.StartedAt
+			}
+			if latest == nil || t.After(latestTime) {
+				latest = sess
+				latestTime = t
+			}
+		}
+	}
+	if latest != nil {
+		latest.Status = StatusRetryExhausted
+	}
+}
+
 // IsTerminal returns true if the status represents a completed/dead session.
 func IsTerminal(status SessionStatus) bool {
 	switch status {
-	case StatusDone, StatusFailed, StatusConflictFailed, StatusDead:
+	case StatusDone, StatusFailed, StatusConflictFailed, StatusDead, StatusRetryExhausted:
 		return true
 	}
 	return false

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -472,6 +472,7 @@ func TestIsTerminal(t *testing.T) {
 		{StatusFailed, true},
 		{StatusConflictFailed, true},
 		{StatusDead, true},
+		{StatusRetryExhausted, true},
 	}
 	for _, tt := range tests {
 		if got := IsTerminal(tt.status); got != tt.want {
@@ -592,4 +593,70 @@ func TestPruneOldSessions_NoFinishedAt(t *testing.T) {
 	if pruned != 1 {
 		t.Errorf("expected 1 pruned, got %d", pruned)
 	}
+}
+
+// --- retry exhaustion tests ---
+
+func TestFailedAttemptsForIssue(t *testing.T) {
+	now := time.Now().UTC()
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{IssueNumber: 42, Status: StatusDead, PRNumber: 0}
+	s.Sessions["slot-2"] = &Session{IssueNumber: 42, Status: StatusFailed, PRNumber: 0}
+	s.Sessions["slot-3"] = &Session{IssueNumber: 42, Status: StatusDone, PRNumber: 10}                   // success — not counted
+	s.Sessions["slot-4"] = &Session{IssueNumber: 42, Status: StatusDead, PRNumber: 5}                    // has PR — not counted
+	s.Sessions["slot-5"] = &Session{IssueNumber: 42, Status: StatusRetryExhausted, PRNumber: 0}          // counted
+	s.Sessions["slot-6"] = &Session{IssueNumber: 99, Status: StatusDead, PRNumber: 0}                    // different issue
+	s.Sessions["slot-7"] = &Session{IssueNumber: 42, Status: StatusRunning, PRNumber: 0, StartedAt: now} // running — not counted
+	s.Sessions["slot-8"] = &Session{IssueNumber: 42, Status: StatusConflictFailed, PRNumber: 0}          // conflict — not counted
+
+	if got := s.FailedAttemptsForIssue(42); got != 3 {
+		t.Errorf("FailedAttemptsForIssue(42) = %d, want 3", got)
+	}
+	if got := s.FailedAttemptsForIssue(99); got != 1 {
+		t.Errorf("FailedAttemptsForIssue(99) = %d, want 1", got)
+	}
+	if got := s.FailedAttemptsForIssue(100); got != 0 {
+		t.Errorf("FailedAttemptsForIssue(100) = %d, want 0", got)
+	}
+}
+
+func TestIssueRetryExhausted(t *testing.T) {
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{IssueNumber: 42, Status: StatusDead}
+	s.Sessions["slot-2"] = &Session{IssueNumber: 42, Status: StatusRetryExhausted}
+	s.Sessions["slot-3"] = &Session{IssueNumber: 99, Status: StatusFailed}
+
+	if !s.IssueRetryExhausted(42) {
+		t.Error("IssueRetryExhausted(42) should be true")
+	}
+	if s.IssueRetryExhausted(99) {
+		t.Error("IssueRetryExhausted(99) should be false")
+	}
+}
+
+func TestMarkIssueRetryExhausted(t *testing.T) {
+	now := time.Now().UTC()
+	old := now.Add(-1 * time.Hour)
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{IssueNumber: 42, Status: StatusDead, FinishedAt: &old}
+	s.Sessions["slot-2"] = &Session{IssueNumber: 42, Status: StatusFailed, FinishedAt: &now} // most recent
+	s.Sessions["slot-3"] = &Session{IssueNumber: 42, Status: StatusDone, PRNumber: 10}       // not eligible
+
+	s.MarkIssueRetryExhausted(42)
+
+	// The most recent dead/failed session (slot-2) should be marked
+	if s.Sessions["slot-2"].Status != StatusRetryExhausted {
+		t.Errorf("slot-2 status = %q, want %q", s.Sessions["slot-2"].Status, StatusRetryExhausted)
+	}
+	// slot-1 should remain dead
+	if s.Sessions["slot-1"].Status != StatusDead {
+		t.Errorf("slot-1 status = %q, want %q", s.Sessions["slot-1"].Status, StatusDead)
+	}
+}
+
+func TestMarkIssueRetryExhausted_NoSessions(t *testing.T) {
+	s := NewState()
+	// Should not panic when no matching sessions exist
+	s.MarkIssueRetryExhausted(42)
 }


### PR DESCRIPTION
Implements #177

## Changes
- Add `max_retries_per_issue` config option (default: 3, 0 = unlimited) to prevent infinite retry loops when workers keep failing for the same issue
- Add `retry_exhausted` session status — the most recent dead/failed session is transitioned to this status when the limit is reached
- Add `FailedAttemptsForIssue()`, `IssueRetryExhausted()`, and `MarkIssueRetryExhausted()` state helpers to track per-issue failed attempts (counts dead/failed sessions without PRs)
- In `startNewWorkers`, check retry budget before spawning — skip exhausted issues, label as "blocked", and send Telegram notification on first detection (deduplicated across cycles)
- Add testing hooks (`listOpenIssuesFn`, `workerStartFn`) to enable unit testing of `startNewWorkers`

## Testing
- Config: default (3), explicit, and zero (unlimited) parsing tests
- State: `FailedAttemptsForIssue` counts correctly (excludes PRs, running, done, conflict_failed), `IssueRetryExhausted` detection, `MarkIssueRetryExhausted` picks most recent session, `IsTerminal` includes new status
- Orchestrator: skips retry-exhausted issues, labels blocked, notifies only once, spawns below limit, disabled when zero, PR failures not counted
- All existing tests pass (`go test ./...`, `go vet ./...`, `go build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a retry limit mechanism to prevent infinite worker spawning for repeatedly failing issues. The implementation adds a configurable `max_retries_per_issue` option (default: 3, 0 = unlimited) with comprehensive tracking through a new `retry_exhausted` session status.

**Key changes:**
- New config option with proper defaults and validation
- State helpers (`FailedAttemptsForIssue`, `IssueRetryExhausted`, `MarkIssueRetryExhausted`) correctly count failures excluding PR-producing sessions and conflict failures
- Orchestrator logic properly checks retry budget before spawning, labels blocked issues, and sends deduplicated notifications
- Testing hooks enable thorough unit testing without external dependencies
- Comprehensive test coverage for all edge cases (default/explicit/zero config, below/at limit, PR failures not counted, notification deduplication)

**Issue found:**
- Line 464 in `orchestrator.go` is missing `StatusRetryExhausted` in the terminal states cleanup logic, which will prevent worktree cleanup for retry-exhausted sessions

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the worktree cleanup issue
- The implementation is solid with excellent test coverage and well-designed logic. One bug prevents retry-exhausted sessions from being cleaned up, but this won't cause functional issues—just accumulation of old worktrees. The core retry limiting feature works correctly.
- Fix the terminal status check in `internal/orchestrator/orchestrator.go:464` to include `StatusRetryExhausted`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Added max_retries_per_issue config field with default value of 3 |
| internal/state/state.go | Added retry_exhausted status and helper methods for tracking per-issue failed attempts |
| internal/orchestrator/orchestrator.go | Implements retry limit checking with testing hooks; missing retry_exhausted in cleanup logic |

</details>



<sub>Last reviewed commit: 75b7d8f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->