### PR TITLE
feat: make deploy_cmd timeout configurable (#179)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ type Config struct {
 	Model                      ModelConfig      `yaml:"model"`
 	Routing                    RoutingConfig    `yaml:"routing"`
 	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	DeployTimeoutMinutes       int              `yaml:"deploy_timeout_minutes"` // timeout for deploy command in minutes (default: 15)
 	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
 	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
@@ -113,6 +114,7 @@ func parse(data []byte) (*Config, error) {
 		MaxParallel:          5,
 		MaxRuntimeMinutes:    120,
 		MaxRetriesPerIssue:   3,
+		DeployTimeoutMinutes: 15,
 		AutoRebase:           true,
 		ClaudeCmd:            "claude",
 		MergeStrategy:        "sequential",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -615,6 +615,31 @@ deploy_cmd: "go build ./cmd/app/ && systemctl --user restart app"
 	}
 }
 
+func TestParse_DeployTimeoutMinutesDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.DeployTimeoutMinutes != 15 {
+		t.Errorf("DeployTimeoutMinutes = %d, want 15", cfg.DeployTimeoutMinutes)
+	}
+}
+
+func TestParse_DeployTimeoutMinutesExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+deploy_timeout_minutes: 30
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.DeployTimeoutMinutes != 30 {
+		t.Errorf("DeployTimeoutMinutes = %d, want 30", cfg.DeployTimeoutMinutes)
+	}
+}
+
 func TestParse_MergeDefaults(t *testing.T) {
 	yaml := `repo: owner/repo`
 	cfg, err := parse([]byte(yaml))

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -868,11 +868,12 @@ func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr git
 	return true
 }
 
-// runDeployCmd executes the configured deploy command with a 5-minute timeout.
+// runDeployCmd executes the configured deploy command with a configurable timeout.
 func (o *Orchestrator) runDeployCmd(prNumber int) error {
-	log.Printf("[orch] running deploy command after PR #%d merge: %s", prNumber, o.cfg.DeployCmd)
+	timeout := time.Duration(o.cfg.DeployTimeoutMinutes) * time.Minute
+	log.Printf("[orch] running deploy command after PR #%d merge (timeout %dm): %s", prNumber, o.cfg.DeployTimeoutMinutes, o.cfg.DeployCmd)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "bash", "-c", o.cfg.DeployCmd)
@@ -882,7 +883,7 @@ func (o *Orchestrator) runDeployCmd(prNumber int) error {
 		log.Printf("[orch] deploy output:\n%s", out)
 	}
 	if ctx.Err() == context.DeadlineExceeded {
-		return fmt.Errorf("deploy command timed out after 5 minutes")
+		return fmt.Errorf("deploy command timed out after %d minutes", o.cfg.DeployTimeoutMinutes)
 	}
 	if err != nil {
 		return fmt.Errorf("deploy command failed: %w\n%s", err, out)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -383,9 +383,10 @@ func TestReconcileRunningSessions_UsesDefaultTmuxNameWhenMissingInState(t *testi
 func TestRunDeployCmd_Success(t *testing.T) {
 	o := &Orchestrator{
 		cfg: &config.Config{
-			Repo:      "owner/repo",
-			LocalPath: "/tmp",
-			DeployCmd: "echo deploy-ok",
+			Repo:                 "owner/repo",
+			LocalPath:            "/tmp",
+			DeployCmd:            "echo deploy-ok",
+			DeployTimeoutMinutes: 15,
 		},
 		notifier: &notify.Notifier{},
 	}
@@ -397,9 +398,10 @@ func TestRunDeployCmd_Success(t *testing.T) {
 func TestRunDeployCmd_Failure(t *testing.T) {
 	o := &Orchestrator{
 		cfg: &config.Config{
-			Repo:      "owner/repo",
-			LocalPath: "/tmp",
-			DeployCmd: "exit 1",
+			Repo:                 "owner/repo",
+			LocalPath:            "/tmp",
+			DeployCmd:            "exit 1",
+			DeployTimeoutMinutes: 15,
 		},
 		notifier: &notify.Notifier{},
 	}
@@ -415,9 +417,10 @@ func TestRunDeployCmd_Failure(t *testing.T) {
 func TestRunDeployCmd_CapturesOutput(t *testing.T) {
 	o := &Orchestrator{
 		cfg: &config.Config{
-			Repo:      "owner/repo",
-			LocalPath: "/tmp",
-			DeployCmd: "echo hello-deploy && exit 1",
+			Repo:                 "owner/repo",
+			LocalPath:            "/tmp",
+			DeployCmd:            "echo hello-deploy && exit 1",
+			DeployTimeoutMinutes: 15,
 		},
 		notifier: &notify.Notifier{},
 	}
@@ -427,6 +430,21 @@ func TestRunDeployCmd_CapturesOutput(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "hello-deploy") {
 		t.Errorf("error = %q, want it to contain command output 'hello-deploy'", err.Error())
+	}
+}
+
+func TestRunDeployCmd_UsesConfiguredTimeout(t *testing.T) {
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:                 "owner/repo",
+			LocalPath:            "/tmp",
+			DeployCmd:            "sleep 5",
+			DeployTimeoutMinutes: 1, // 1 minute — command should succeed well within this
+		},
+		notifier: &notify.Notifier{},
+	}
+	if err := o.runDeployCmd(42); err != nil {
+		t.Errorf("runDeployCmd() unexpected error: %v", err)
 	}
 }
 

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -47,6 +47,7 @@ worker_prompt: /path/to/worker-prompt-template.md
 
 # Optional: command to run after successful merge (build + deploy)
 # deploy_cmd: "cd /path/to/repo && go build ./cmd/app/ && systemctl --user restart app"
+# deploy_timeout_minutes: 15         # timeout for deploy command in minutes (default: 15)
 
 # Telegram notifications
 telegram:


### PR DESCRIPTION
Implements #179

## Changes
- Added `deploy_timeout_minutes` config option (default: 15) to replace the hardcoded 5-minute timeout in `runDeployCmd`
- Updated `runDeployCmd` to use `time.Duration(cfg.DeployTimeoutMinutes) * time.Minute` instead of `5*time.Minute`
- Timeout value is now included in log messages and error messages for better observability
- Updated `maestro.yaml.example` with the new option

## Testing
- Added `TestParse_DeployTimeoutMinutesDefault` — verifies default is 15
- Added `TestParse_DeployTimeoutMinutesExplicit` — verifies explicit config value is respected
- Added `TestRunDeployCmd_UsesConfiguredTimeout` — verifies orchestrator uses the configured timeout
- Updated existing deploy cmd tests to set `DeployTimeoutMinutes: 15` (avoids zero-value causing immediate timeout)
- All tests pass: `go test ./...`, `go vet ./...`, `go build ./cmd/maestro/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces hardcoded 5-minute deploy command timeout with a configurable `deploy_timeout_minutes` option (default: 15 minutes).

**Key Changes:**
- Config field `DeployTimeoutMinutes` added with default of 15 minutes
- `runDeployCmd` now uses configured timeout instead of hardcoded value
- Timeout value included in log messages and error output for better observability
- Comprehensive test coverage for default values, explicit values, and timeout enforcement
- Example config file updated with new option

**Note:** Default timeout increased from 5 to 15 minutes - existing deployments will have more time to complete.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- Clean implementation with comprehensive test coverage, proper defaults, and backward compatibility. All changes are localized and well-tested.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds `DeployTimeoutMinutes` field with default value of 15 minutes |
| internal/config/config_test.go | Comprehensive tests for default (15) and explicit timeout values |
| internal/orchestrator/orchestrator.go | Uses configured timeout instead of hardcoded 5 minutes, includes timeout in logs and error messages |
| internal/orchestrator/orchestrator_test.go | Updates existing tests with timeout value and adds new test to verify configured timeout is used |
| maestro.yaml.example | Documents new `deploy_timeout_minutes` option with default value |

</details>



<sub>Last reviewed commit: 1e7f402</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->