### PR TITLE
feat: cleanup git worktrees after PR merge (#181)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -44,6 +44,7 @@ Commands:
   kill          Kill a worker session by slot name
   import        Seed state from existing worktrees
   history       Show recently completed sessions
+  cleanup       Remove worktrees for all completed/dead sessions
   version-bump  Bump project version based on merged PR labels
   version       Print version
 
@@ -164,6 +165,8 @@ func main() {
 		importCmd(args)
 	case "history":
 		historyCmd(args)
+	case "cleanup":
+		cleanupCmd(args)
 	case "version-bump":
 		versionBumpCmd(args)
 	case "_watch-updater":
@@ -1003,6 +1006,54 @@ func historyCmd(args []string) {
 			pr, sessionDuration(c.Session), finished, truncate(c.IssueTitle, 40))
 	}
 	w.Flush()
+}
+
+func cleanupCmd(args []string) {
+	fs := flag.NewFlagSet("cleanup", flag.ExitOnError)
+	var configs multiFlag
+	fs.Var(&configs, "config", "Path to config file (can be repeated)")
+	fs.Parse(args)
+
+	cfgs := loadConfigs(configs)
+
+	totalRemoved := 0
+	totalErrors := 0
+
+	for _, cfg := range cfgs {
+		s, err := state.Load(cfg.StateDir)
+		if err != nil {
+			log.Printf("load state for %s: %v", cfg.Repo, err)
+			continue
+		}
+
+		results := worker.CleanupWorktrees(cfg, s)
+		if len(results) == 0 {
+			if len(cfgs) > 1 {
+				fmt.Printf("[%s] No worktrees to clean up.\n", cfg.Repo)
+			}
+			continue
+		}
+
+		for _, r := range results {
+			if r.Removed {
+				fmt.Printf("  removed: %s (issue #%d) — %s\n", r.SlotName, r.IssueNumber, r.Worktree)
+				totalRemoved++
+			} else {
+				fmt.Printf("  error:   %s (issue #%d) — %v\n", r.SlotName, r.IssueNumber, r.Error)
+				totalErrors++
+			}
+		}
+
+		if err := state.Save(cfg.StateDir, s); err != nil {
+			log.Printf("save state for %s: %v", cfg.Repo, err)
+		}
+	}
+
+	fmt.Printf("\nCleaned up %d worktree(s)", totalRemoved)
+	if totalErrors > 0 {
+		fmt.Printf(", %d error(s)", totalErrors)
+	}
+	fmt.Println(".")
 }
 
 func versionBumpCmd(args []string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,7 +74,8 @@ type Config struct {
 	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"` // files to auto-resolve conflicts by keeping both sides
+	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
+	CleanupWorktreesOnMerge    *bool            `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
 }
 
 // LoadFrom loads config from a specific path.
@@ -216,6 +217,12 @@ func parse(data []byte) (*Config, error) {
 		cfg.Versioning.TagPrefix = "v"
 	}
 
+	// Default cleanup_worktrees_on_merge to true if not set
+	if cfg.CleanupWorktreesOnMerge == nil {
+		t := true
+		cfg.CleanupWorktreesOnMerge = &t
+	}
+
 	// Merge defaults
 	switch strings.ToLower(strings.TrimSpace(cfg.MergeStrategy)) {
 	case "", "sequential":
@@ -257,6 +264,14 @@ func LoadDir(dir string) ([]*Config, error) {
 		return nil, fmt.Errorf("no config files found in %s", dir)
 	}
 	return cfgs, nil
+}
+
+// ShouldCleanupWorktrees returns whether worktrees should be removed after PR merge.
+func (c *Config) ShouldCleanupWorktrees() bool {
+	if c.CleanupWorktreesOnMerge == nil {
+		return true
+	}
+	return *c.CleanupWorktreesOnMerge
 }
 
 func expandHome(path string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -728,3 +728,42 @@ max_retries_per_issue: 0
 		t.Errorf("MaxRetriesPerIssue = %d, want 0 (unlimited)", cfg.MaxRetriesPerIssue)
 	}
 }
+
+func TestParse_CleanupWorktreesOnMergeDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.ShouldCleanupWorktrees() {
+		t.Error("ShouldCleanupWorktrees() should default to true")
+	}
+}
+
+func TestParse_CleanupWorktreesOnMergeExplicitFalse(t *testing.T) {
+	yaml := `
+repo: owner/repo
+cleanup_worktrees_on_merge: false
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.ShouldCleanupWorktrees() {
+		t.Error("ShouldCleanupWorktrees() should be false when explicitly set to false")
+	}
+}
+
+func TestParse_CleanupWorktreesOnMergeExplicitTrue(t *testing.T) {
+	yaml := `
+repo: owner/repo
+cleanup_worktrees_on_merge: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.ShouldCleanupWorktrees() {
+		t.Error("ShouldCleanupWorktrees() should be true when explicitly set to true")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -842,7 +842,15 @@ func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr git
 	sess.Status = state.StatusDone
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
-	o.stopWorker(slotName, sess)
+
+	if o.cfg.ShouldCleanupWorktrees() {
+		log.Printf("[orch] cleaning up worktree for %s after merge", slotName)
+		o.stopWorker(slotName, sess)
+		sess.Worktree = "" // Mark as cleaned
+	} else {
+		log.Printf("[orch] skipping worktree cleanup for %s (cleanup_worktrees_on_merge=false)", slotName)
+	}
+
 	o.notifier.Sendf("✅ maestro: merged PR #%d for issue #%d (%s)", pr.Number, sess.IssueNumber, sess.IssueTitle)
 
 	// Auto version bump

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1831,6 +1831,145 @@ func TestCheckSessions_SilentTimeoutSecondKill_LabelsBlocked(t *testing.T) {
 	}
 }
 
+// --- cleanup_worktrees_on_merge tests ---
+
+func TestMergeReadyPR_CleansUpWorktreeOnMerge(t *testing.T) {
+	cleanupTrue := true
+	stopped := false
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:                    "owner/repo",
+			CleanupWorktreesOnMerge: &cleanupTrue,
+		},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			stopped = true
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR("slot-0", sess, pr)
+
+	if !result {
+		t.Fatal("mergeReadyPR should return true on successful merge")
+	}
+	if !stopped {
+		t.Fatal("worker should be stopped when cleanup_worktrees_on_merge is true")
+	}
+	if sess.Worktree != "" {
+		t.Errorf("Worktree = %q, want empty (should be cleared after cleanup)", sess.Worktree)
+	}
+	if sess.Status != state.StatusDone {
+		t.Errorf("Status = %q, want %q", sess.Status, state.StatusDone)
+	}
+}
+
+func TestMergeReadyPR_SkipsCleanupWhenDisabled(t *testing.T) {
+	cleanupFalse := false
+	stopped := false
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:                    "owner/repo",
+			CleanupWorktreesOnMerge: &cleanupFalse,
+		},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			stopped = true
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR("slot-0", sess, pr)
+
+	if !result {
+		t.Fatal("mergeReadyPR should return true on successful merge")
+	}
+	if stopped {
+		t.Fatal("worker should NOT be stopped when cleanup_worktrees_on_merge is false")
+	}
+	if sess.Worktree != "/tmp/wt" {
+		t.Errorf("Worktree = %q, want %q (should be preserved)", sess.Worktree, "/tmp/wt")
+	}
+	if sess.Status != state.StatusDone {
+		t.Errorf("Status = %q, want %q", sess.Status, state.StatusDone)
+	}
+}
+
+func TestMergeReadyPR_DefaultConfigCleansUp(t *testing.T) {
+	// Config with nil CleanupWorktreesOnMerge should default to true
+	stopped := false
+	cfg := &config.Config{Repo: "owner/repo"}
+	// Simulate default: ShouldCleanupWorktrees returns true for nil pointer
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			stopped = true
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR("slot-0", sess, pr)
+
+	if !result {
+		t.Fatal("mergeReadyPR should return true on successful merge")
+	}
+	if !stopped {
+		t.Fatal("worker should be stopped with default config (nil = true)")
+	}
+	if sess.Worktree != "" {
+		t.Errorf("Worktree = %q, want empty", sess.Worktree)
+	}
+}
+
 func TestCheckSessions_SilentTimeoutFirstObservation_SetsHash(t *testing.T) {
 	output := "initial output\nline 2"
 	o, stopped, _ := newSilentTimeoutOrchestrator(10, output)

--- a/internal/worker/cleanup_test.go
+++ b/internal/worker/cleanup_test.go
@@ -1,0 +1,135 @@
+package worker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestCleanupWorktrees_RemovesTerminalSessionWorktrees(t *testing.T) {
+	// Create fake worktree directories
+	tmpDir := t.TempDir()
+	wt1 := filepath.Join(tmpDir, "wt1")
+	wt2 := filepath.Join(tmpDir, "wt2")
+	os.MkdirAll(wt1, 0755)
+	os.MkdirAll(wt2, 0755)
+
+	cfg := &config.Config{
+		Repo:      "owner/repo",
+		LocalPath: tmpDir,
+	}
+
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 100,
+		Status:      state.StatusDone,
+		Worktree:    wt1,
+	}
+	s.Sessions["slot-2"] = &state.Session{
+		IssueNumber: 101,
+		Status:      state.StatusDead,
+		Worktree:    wt2,
+	}
+	// Running session should be skipped
+	s.Sessions["slot-3"] = &state.Session{
+		IssueNumber: 102,
+		Status:      state.StatusRunning,
+		Worktree:    filepath.Join(tmpDir, "wt3"),
+	}
+
+	results := CleanupWorktrees(cfg, s)
+
+	// Note: actual git worktree remove will fail since these aren't real worktrees,
+	// but we verify that the function attempts cleanup on the right sessions.
+	if len(results) != 2 {
+		t.Fatalf("expected 2 cleanup results, got %d", len(results))
+	}
+
+	// Running session should not be touched
+	runSess := s.Sessions["slot-3"]
+	if runSess.Worktree == "" {
+		t.Error("running session worktree should not be cleared")
+	}
+}
+
+func TestCleanupWorktrees_SkipsAlreadyCleanedSessions(t *testing.T) {
+	cfg := &config.Config{
+		Repo:      "owner/repo",
+		LocalPath: "/tmp",
+	}
+
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 100,
+		Status:      state.StatusDone,
+		Worktree:    "", // Already cleaned
+	}
+
+	results := CleanupWorktrees(cfg, s)
+
+	if len(results) != 0 {
+		t.Fatalf("expected 0 cleanup results for already-cleaned sessions, got %d", len(results))
+	}
+}
+
+func TestCleanupWorktrees_ClearsWorktreeFieldForMissingDirs(t *testing.T) {
+	cfg := &config.Config{
+		Repo:      "owner/repo",
+		LocalPath: "/tmp",
+	}
+
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 100,
+		Status:      state.StatusDone,
+		Worktree:    "/nonexistent/path/that/does/not/exist",
+	}
+
+	results := CleanupWorktrees(cfg, s)
+
+	// Directory doesn't exist, so it should silently clear the field
+	if len(results) != 0 {
+		t.Fatalf("expected 0 cleanup results for missing dirs, got %d", len(results))
+	}
+	if s.Sessions["slot-1"].Worktree != "" {
+		t.Errorf("Worktree should be cleared for nonexistent directory, got %q", s.Sessions["slot-1"].Worktree)
+	}
+}
+
+func TestCleanupWorktrees_HandlesAllTerminalStatuses(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	terminalStatuses := []state.SessionStatus{
+		state.StatusDone,
+		state.StatusFailed,
+		state.StatusConflictFailed,
+		state.StatusDead,
+	}
+
+	cfg := &config.Config{
+		Repo:      "owner/repo",
+		LocalPath: tmpDir,
+	}
+
+	s := state.NewState()
+	for i, status := range terminalStatuses {
+		wt := filepath.Join(tmpDir, fmt.Sprintf("wt-%d", i))
+		os.MkdirAll(wt, 0755)
+		s.Sessions[fmt.Sprintf("slot-%d", i)] = &state.Session{
+			IssueNumber: 100 + i,
+			Status:      status,
+			Worktree:    wt,
+		}
+	}
+
+	results := CleanupWorktrees(cfg, s)
+
+	// All 4 terminal sessions should be attempted
+	if len(results) != 4 {
+		t.Fatalf("expected 4 cleanup results, got %d", len(results))
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -293,6 +293,67 @@ func Stop(cfg *config.Config, slotName string, sess *state.Session) error {
 	return nil
 }
 
+// CleanupResult describes the outcome of cleaning up a single session's worktree.
+type CleanupResult struct {
+	SlotName    string
+	IssueNumber int
+	Worktree    string
+	Removed     bool
+	Error       error
+}
+
+// CleanupWorktrees removes worktrees for all terminal sessions that still have
+// a worktree directory on disk. Returns results for each session processed.
+func CleanupWorktrees(cfg *config.Config, s *state.State) []CleanupResult {
+	var results []CleanupResult
+	for slotName, sess := range s.Sessions {
+		if !state.IsTerminal(sess.Status) {
+			continue
+		}
+		if sess.Worktree == "" {
+			continue
+		}
+		if _, err := os.Stat(sess.Worktree); os.IsNotExist(err) {
+			// Worktree dir already gone — just clear the field
+			sess.Worktree = ""
+			continue
+		}
+		err := RemoveWorktree(cfg.LocalPath, sess.Worktree)
+		r := CleanupResult{
+			SlotName:    slotName,
+			IssueNumber: sess.IssueNumber,
+			Worktree:    sess.Worktree,
+		}
+		if err != nil {
+			r.Error = err
+			log.Printf("[worker] cleanup worktree %s for %s: %v", sess.Worktree, slotName, err)
+		} else {
+			r.Removed = true
+			sess.Worktree = ""
+			log.Printf("[worker] cleaned up worktree %s for %s", r.Worktree, slotName)
+		}
+		results = append(results, r)
+	}
+	return results
+}
+
+// RemoveWorktree removes a git worktree directory.
+// Returns nil if the worktree was removed or doesn't exist.
+func RemoveWorktree(localPath, worktreePath string) error {
+	if worktreePath == "" {
+		return nil
+	}
+	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+		return nil
+	}
+	out, err := exec.Command("git", "-C", localPath,
+		"worktree", "remove", "--force", worktreePath).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree remove %s: %w\n%s", worktreePath, err, out)
+	}
+	return nil
+}
+
 // RebaseWorktree runs git fetch + rebase in the worktree.
 // If rebase hits conflicts in known shared files, it auto-resolves by keeping
 // both sides, continues the rebase, then force-pushes the branch.


### PR DESCRIPTION
Implements #181

## Changes
- **Config option**: Added `cleanup_worktrees_on_merge` (default: `true`) to control whether worktrees are removed immediately after PR merge
- **Merge cleanup**: `mergeReadyPR()` now respects the config option — when enabled, it calls `stopWorker` and clears `sess.Worktree` to prevent re-cleanup attempts; when disabled, worktrees are preserved
- **Worker functions**: Added `RemoveWorktree()` for standalone worktree removal and `CleanupWorktrees()` to batch-remove worktrees for all terminal sessions
- **CLI command**: Added `maestro cleanup` command that removes worktrees for all completed/dead/failed sessions across all configured projects
- **Tests**: Added config parsing tests (default, explicit true/false), orchestrator tests (cleanup enabled/disabled/default), and worker cleanup tests (terminal states, already-cleaned, missing dirs)

## Config example
```yaml
cleanup_worktrees_on_merge: true  # default: true
```

## Usage
```bash
maestro cleanup  # removes worktrees for all merged/done sessions
```

## Testing
- All existing tests pass (`go test ./...`)
- Added 6 new tests covering config parsing, merge cleanup behavior, and worker cleanup logic
- Binary builds successfully (`go build ./cmd/maestro/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements configurable worktree cleanup after PR merge, with a new CLI command for batch cleanup of completed sessions. The implementation correctly handles edge cases like missing directories, already-cleaned sessions, and terminal states.

- Added `cleanup_worktrees_on_merge` config option (defaults to true) to control automatic cleanup behavior
- Modified merge flow to conditionally clean up worktrees and properly mark sessions as cleaned
- Introduced `CleanupWorktrees()` and `RemoveWorktree()` functions with appropriate error handling
- Added comprehensive test coverage for config parsing, merge behavior, and cleanup logic
- The cleanup command processes all terminal sessions across configured projects

**Issue Found:**
- Test coverage missing `StatusRetryExhausted` in terminal statuses test (see inline comments)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor test fix needed
- Well-structured implementation with comprehensive testing, but test coverage is incomplete (missing `StatusRetryExhausted`). The core logic is sound and handles edge cases properly.
- internal/worker/cleanup_test.go needs to include `StatusRetryExhausted` in terminal status test

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Added `CleanupWorktreesOnMerge` config field (defaults to true) and helper method to control worktree cleanup behavior |
| internal/orchestrator/orchestrator.go | Modified merge flow to conditionally cleanup worktrees based on config, clearing worktree field to prevent re-cleanup |
| internal/worker/cleanup_test.go | New test file for cleanup functions; missing `StatusRetryExhausted` in terminal status test |
| internal/worker/worker.go | Added `RemoveWorktree` for standalone removal and `CleanupWorktrees` for batch cleanup with proper error handling |

</details>



<sub>Last reviewed commit: 51bdf28</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->