### PR TITLE
fix: split backend cmd into binary + args (#188)

### DIFF
--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -4,7 +4,18 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
+
+// splitCmd splits a command string into binary and extra arguments.
+// e.g. "claude --model opus" → ("claude", ["--model", "opus"])
+func splitCmd(cmd string) (binary string, prefixArgs []string) {
+	parts := strings.Fields(cmd)
+	if len(parts) == 0 {
+		return cmd, nil
+	}
+	return parts[0], parts[1:]
+}
 
 // BackendConfig holds the CLI command and any extra args from config.
 type BackendConfig struct {
@@ -42,9 +53,10 @@ func (claudeBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*
 	if claudeCmd == "" {
 		claudeCmd = "claude"
 	}
-	args := []string{"--dangerously-skip-permissions", "-p", string(promptData)}
+	binary, cmdArgs := splitCmd(claudeCmd)
+	args := append(cmdArgs, "--dangerously-skip-permissions", "-p", string(promptData))
 	args = append(args, cfg.ExtraArgs...)
-	cmd := exec.Command(claudeCmd, args...)
+	cmd := exec.Command(binary, args...)
 	cmd.Dir = worktree
 	return cmd, "", nil
 }
@@ -58,9 +70,10 @@ func (codexBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*e
 	if codexCmd == "" {
 		codexCmd = "codex"
 	}
-	args := []string{"exec", "--dangerously-bypass-approvals-and-sandbox", "-C", worktree, "-"}
+	binary, cmdArgs := splitCmd(codexCmd)
+	args := append(cmdArgs, "exec", "--dangerously-bypass-approvals-and-sandbox", "-C", worktree, "-")
 	args = append(args, cfg.ExtraArgs...)
-	cmd := exec.Command(codexCmd, args...)
+	cmd := exec.Command(binary, args...)
 	cmd.Dir = worktree
 	// Stdin redirection is handled by the runner script — no file opened here
 	return cmd, promptFile, nil
@@ -79,9 +92,10 @@ func (geminiBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*
 	if err != nil {
 		return nil, "", fmt.Errorf("read prompt file: %w", err)
 	}
-	args := []string{"-p", string(promptData)}
+	binary, cmdArgs := splitCmd(geminiCmd)
+	args := append(cmdArgs, "-p", string(promptData))
 	args = append(args, cfg.ExtraArgs...)
-	cmd := exec.Command(geminiCmd, args...)
+	cmd := exec.Command(binary, args...)
 	cmd.Dir = worktree
 	return cmd, "", nil
 }
@@ -99,9 +113,10 @@ func (clineBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*e
 	if clineCmd == "" {
 		clineCmd = "cline"
 	}
-	args := []string{"-y", string(promptData)}
+	binary, cmdArgs := splitCmd(clineCmd)
+	args := append(cmdArgs, "-y", string(promptData))
 	args = append(args, cfg.ExtraArgs...)
-	cmd := exec.Command(clineCmd, args...)
+	cmd := exec.Command(binary, args...)
 	cmd.Dir = worktree
 	return cmd, "", nil
 }
@@ -116,10 +131,10 @@ func (clineBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*e
 type genericBackend struct{}
 
 func (genericBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
-	binary := cfg.Cmd
-	if binary == "" {
+	if cfg.Cmd == "" {
 		return nil, "", fmt.Errorf("generic backend requires cmd to be set")
 	}
+	binary, cmdArgs := splitCmd(cfg.Cmd)
 
 	mode := cfg.PromptMode
 	if mode == "" {
@@ -129,6 +144,7 @@ func (genericBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (
 	var args []string
 	var stdinFile string
 
+	args = append(args, cmdArgs...)
 	args = append(args, cfg.ExtraArgs...)
 
 	switch mode {

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -353,6 +353,95 @@ func TestBuildWorkerCmd_GenericInvalidPromptMode(t *testing.T) {
 	}
 }
 
+func TestSplitCmd(t *testing.T) {
+	tests := []struct {
+		input      string
+		wantBinary string
+		wantArgs   []string
+	}{
+		{"claude", "claude", nil},
+		{"claude --model claude-opus-4-6", "claude", []string{"--model", "claude-opus-4-6"}},
+		{"/usr/local/bin/codex --flag", "/usr/local/bin/codex", []string{"--flag"}},
+		{"  gemini  --fast  ", "gemini", []string{"--fast"}},
+		{"", "", nil},
+	}
+	for _, tt := range tests {
+		binary, args := splitCmd(tt.input)
+		if binary != tt.wantBinary {
+			t.Errorf("splitCmd(%q) binary = %q, want %q", tt.input, binary, tt.wantBinary)
+		}
+		if len(args) != len(tt.wantArgs) {
+			t.Errorf("splitCmd(%q) args = %v, want %v", tt.input, args, tt.wantArgs)
+			continue
+		}
+		for i := range args {
+			if args[i] != tt.wantArgs[i] {
+				t.Errorf("splitCmd(%q) args[%d] = %q, want %q", tt.input, i, args[i], tt.wantArgs[i])
+			}
+		}
+	}
+}
+
+func TestBuildWorkerCmd_CmdWithArgs(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("do work"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Claude backend: cmd contains arguments
+	cfg := BackendConfig{Cmd: "claude --model claude-opus-4-6"}
+	cmd, _, err := BuildWorkerCmd("claude", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Binary should be just "claude", not the full string
+	if cmd.Args[0] != "claude" {
+		t.Errorf("expected Args[0]=%q, got %q", "claude", cmd.Args[0])
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--model") {
+		t.Errorf("expected --model in args, got: %s", args)
+	}
+	if !strings.Contains(args, "claude-opus-4-6") {
+		t.Errorf("expected claude-opus-4-6 in args, got: %s", args)
+	}
+	if !strings.Contains(args, "--dangerously-skip-permissions") {
+		t.Errorf("expected --dangerously-skip-permissions in args, got: %s", args)
+	}
+
+	// Codex backend: cmd contains arguments
+	cfg = BackendConfig{Cmd: "codex --some-flag"}
+	cmd, _, err = BuildWorkerCmd("codex", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.Args[0] != "codex" {
+		t.Errorf("expected Args[0]=%q, got %q", "codex", cmd.Args[0])
+	}
+	args = strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--some-flag") {
+		t.Errorf("expected --some-flag in args, got: %s", args)
+	}
+
+	// Generic backend: cmd contains arguments
+	cfg = BackendConfig{Cmd: "my-cli --verbose --debug", PromptMode: "arg"}
+	cmd, _, err = BuildWorkerCmd("custom", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.Args[0] != "my-cli" {
+		t.Errorf("expected Args[0]=%q, got %q", "my-cli", cmd.Args[0])
+	}
+	args = strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--verbose") {
+		t.Errorf("expected --verbose in args, got: %s", args)
+	}
+	if !strings.Contains(args, "--debug") {
+		t.Errorf("expected --debug in args, got: %s", args)
+	}
+}
+
 func TestKnownBackends(t *testing.T) {
 	backends := KnownBackends()
 	expected := map[string]bool{"claude": false, "codex": false, "gemini": false, "cline": false}


### PR DESCRIPTION
Implements #188

## Changes
When `claude_cmd` or other backend `cmd` contains arguments (e.g. `claude --model claude-opus-4-6`), `exec.Command()` treated the full string as a single binary name, causing the runner script to fail with `exec: claude --model claude-opus-4-6: not found`.

Added a `splitCmd` helper that splits the command string on whitespace, using the first token as the binary and remaining tokens as prefix arguments. Updated all five backends (claude, codex, gemini, cline, generic) to use `splitCmd`.

## Testing
- Added `TestSplitCmd` — table-driven tests covering single command, command with args, paths, whitespace trimming, and empty string
- Added `TestBuildWorkerCmd_CmdWithArgs` — verifies claude, codex, and generic backends correctly split `cmd` strings containing arguments
- All existing tests continue to pass (`go test ./...`)
- `go vet ./...` clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where backend commands containing arguments (like `claude --model claude-opus-4-6`) were treated as a single binary name, causing execution failures. The solution adds a `splitCmd` helper that uses `strings.Fields` to split commands on whitespace, separating the binary from its arguments.

- Added `splitCmd` function to parse command strings into binary + prefix arguments
- Updated all 5 backends (claude, codex, gemini, cline, generic) to use the new splitting logic
- Arguments from the command string are prepended before backend-specific flags and extra args
- Test coverage includes unit tests for `splitCmd` and integration tests verifying command parsing works correctly

The implementation is straightforward and uses simple whitespace splitting, which handles the common use case of adding flags to commands. Note that this approach doesn't support quoted arguments with spaces (e.g., `--flag "value with spaces"`), but this is a reasonable trade-off for the stated use case.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean fix for a well-defined bug with comprehensive test coverage, consistent implementation across all backends, and no breaking changes or security concerns
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/worker/backend.go | Added `splitCmd` helper and updated all 5 backends to correctly split command strings into binary + arguments |
| internal/worker/backend_test.go | Added comprehensive tests for `splitCmd` function and integration tests for backends with arguments in command strings |

</details>



<sub>Last reviewed commit: 2ddea6b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->