### PR TITLE
feat: add BACKEND column to `maestro status` table (#186)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -375,8 +375,8 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "SESSION\tISSUE\tSTATUS\tPR\tCI\tPID\tALIVE\tAGE\tRETRIES\tTOKENS\tTITLE")
-	fmt.Fprintln(w, "-------\t-----\t------\t--\t--\t---\t-----\t---\t-------\t------\t-----")
+	fmt.Fprintln(w, "SESSION\tISSUE\tSTATUS\tBACKEND\tPR\tCI\tPID\tALIVE\tAGE\tRETRIES\tTOKENS\tTITLE")
+	fmt.Fprintln(w, "-------\t-----\t------\t-------\t--\t--\t---\t-----\t---\t-------\t------\t-----")
 	for _, name := range names {
 		sess := s.Sessions[name]
 		alive := "-"
@@ -401,8 +401,12 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 			ci = cs
 		}
 		tokens := worker.FormatTokens(sess.TokensUsed)
-		fmt.Fprintf(w, "%s\t#%d\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\n",
-			name, sess.IssueNumber, sess.Status, pr, ci, sess.PID, alive, age, retries, tokens, truncate(sess.IssueTitle, 50))
+		backend := sess.Backend
+		if backend == "" {
+			backend = "-"
+		}
+		fmt.Fprintf(w, "%s\t#%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\n",
+			name, sess.IssueNumber, sess.Status, backend, pr, ci, sess.PID, alive, age, retries, tokens, truncate(sess.IssueTitle, 50))
 	}
 	w.Flush()
 


### PR DESCRIPTION
Implements #186

## Changes
- Added a BACKEND column to the `maestro status` table output, showing which model backend (claude, codex, cline, etc.) each worker session is using
- The backend value comes from the existing `Session.Backend` field which is already populated when workers are started
- Displays "-" when no backend is recorded (e.g. legacy sessions)

## Testing
- All existing tests pass (`go test ./...`)
- `go vet ./...` clean
- `go build ./cmd/maestro/` succeeds
- Verified output format includes the new BACKEND column between STATUS and PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a BACKEND column to the `maestro status` table output, displaying which model backend (claude, codex, cline, etc.) each worker session is using. The implementation is clean and follows existing patterns:

- Column is correctly positioned between STATUS and PR in the table header
- Separator line properly aligned with 7 dashes matching "BACKEND" length
- Uses existing `Session.Backend` field which is already populated during worker initialization
- Handles empty backend values by displaying "-" (consistent with other optional fields like PR, CI, and RETRIES)
- Format specifiers and arguments are correctly aligned

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- Simple table formatting change that adds a new column using an existing field. No logic changes, no error-prone operations, and follows established code patterns perfectly.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Added BACKEND column to status table output, correctly positioned between STATUS and PR with proper formatting and null handling |

</details>



<sub>Last reviewed commit: e426f70</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->