### PR TITLE
feat: rate limit detection — parse worker output and retry with fallback (#185)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,8 @@ type BackendDef struct {
 
 // ModelConfig holds multi-backend configuration.
 type ModelConfig struct {
-	Default  string                `yaml:"default"` // "claude", "codex", etc.
+	Default  string                `yaml:"default"`  // "claude", "codex", etc.
+	Fallback string                `yaml:"fallback"` // backend to use when the primary hits a rate limit
 	Backends map[string]BackendDef `yaml:"backends"`
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -46,6 +46,10 @@ type Orchestrator struct {
 	listOpenIssuesFn func(labels []string) ([]github.Issue, error)
 	workerStartFn    func(cfg *config.Config, s *state.State, repo string, issue github.Issue, promptBase, backend string) (string, error)
 
+	// Testing hooks for rate-limit fallback
+	getIssueFn      func(number int) (github.Issue, error)
+	workerRespawnFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
+
 	// Testing hooks for autoMergePRs / mergeReadyPR
 	ghPRCIStatusFn         func(prNumber int) (string, error)
 	ghPRGreptileApprovedFn func(prNumber int) (approved bool, pending bool, err error)
@@ -135,6 +139,20 @@ func (o *Orchestrator) stopWorker(slotName string, sess *state.Session) error {
 		return o.workerStopFn(o.cfg, slotName, sess)
 	}
 	return worker.Stop(o.cfg, slotName, sess)
+}
+
+func (o *Orchestrator) getIssue(number int) (github.Issue, error) {
+	if o.getIssueFn != nil {
+		return o.getIssueFn(number)
+	}
+	return o.gh.GetIssue(number)
+}
+
+func (o *Orchestrator) respawnWorker(slotName string, sess *state.Session, issue github.Issue, promptBase string, backendName string) error {
+	if o.workerRespawnFn != nil {
+		return o.workerRespawnFn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
+	}
+	return worker.Respawn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
 }
 
 func (o *Orchestrator) rebaseWorktree(worktreePath, branch string) error {
@@ -533,7 +551,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					log.Printf("[orch] worker %s (pid=%d) died, retrying (attempt %d)", slotName, sess.PID, sess.RetryCount+1)
 					sess.RetryCount++
 
-					issue, err := o.gh.GetIssue(sess.IssueNumber)
+					issue, err := o.getIssue(sess.IssueNumber)
 					if err != nil {
 						log.Printf("[orch] fetch issue #%d for retry: %v — marking as failed", sess.IssueNumber, err)
 						sess.Status = state.StatusFailed
@@ -582,8 +600,9 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				continue
 			}
 
-			// Capture tmux pane output for silent-timeout detection and token tracking.
-			if o.cfg.WorkerSilentTimeoutMinutes > 0 || o.cfg.WorkerMaxTokens > 0 {
+			// Capture tmux pane output for token tracking, rate-limit detection,
+			// silent-timeout detection, and token-limit enforcement.
+			{
 				tmuxName := sess.TmuxSession
 				if tmuxName == "" {
 					tmuxName = worker.TmuxSessionName(slotName)
@@ -597,6 +616,62 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					if tokens := worker.ParseTokensFromOutput(output); tokens > sess.TokensUsed {
 						sess.TokensUsed = tokens
 						log.Printf("[orch] %s tokens_used updated to %d", slotName, tokens)
+					}
+
+					// --- Rate-limit detection ---
+					if !sess.RateLimitHit && sess.LastNotifiedStatus != "rate_limit" {
+						if hit, pattern := worker.DetectRateLimit(output); hit {
+							log.Printf("[orch] worker %s hit rate limit (pattern=%s), stopping", slotName, pattern)
+							if err := o.stopWorker(slotName, sess); err != nil {
+								log.Printf("[orch] warn: could not stop rate-limited worker %s: %v", slotName, err)
+							}
+							sess.RateLimitHit = true
+
+							// Attempt fallback: respawn with fallback backend if configured
+							fallback := o.cfg.Model.Fallback
+							if fallback != "" && fallback != sess.Backend {
+								if _, ok := o.cfg.Model.Backends[fallback]; ok {
+									issue, fetchErr := o.getIssue(sess.IssueNumber)
+									if fetchErr != nil {
+										log.Printf("[orch] fetch issue #%d for rate-limit fallback: %v — marking dead", sess.IssueNumber, fetchErr)
+										sess.Status = state.StatusDead
+										sess.LastNotifiedStatus = "rate_limit"
+										now := time.Now().UTC()
+										sess.FinishedAt = &now
+										o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); fallback failed (could not fetch issue)",
+											slotName, sess.IssueNumber, pattern)
+										continue
+									}
+
+									promptBase := o.selectPrompt(issue)
+									if respawnErr := o.respawnWorker(slotName, sess, issue, promptBase, fallback); respawnErr != nil {
+										log.Printf("[orch] rate-limit fallback respawn %s: %v — marking dead", slotName, respawnErr)
+										sess.Status = state.StatusDead
+										sess.LastNotifiedStatus = "rate_limit"
+										now := time.Now().UTC()
+										sess.FinishedAt = &now
+										o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); fallback to %s failed: %v",
+											slotName, sess.IssueNumber, pattern, fallback, respawnErr)
+										continue
+									}
+
+									log.Printf("[orch] rate-limit fallback: respawned %s with backend %s", slotName, fallback)
+									o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) hit rate limit — falling back to %s",
+										slotName, sess.IssueNumber, fallback)
+									continue
+								}
+								log.Printf("[orch] warn: fallback backend %q not found in config, marking dead", fallback)
+							}
+
+							// No fallback available — mark dead
+							sess.Status = state.StatusDead
+							sess.LastNotifiedStatus = "rate_limit"
+							now := time.Now().UTC()
+							sess.FinishedAt = &now
+							o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); no fallback configured",
+								slotName, sess.IssueNumber, pattern)
+							continue
+						}
 					}
 
 					// --- Token limit enforcement ---
@@ -650,18 +725,6 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 								continue
 							}
 						}
-					}
-				}
-			} else {
-				// Neither silent-timeout nor token-limit is configured, but we still
-				// want to track tokens when possible. Capture pane output cheaply.
-				tmuxName := sess.TmuxSession
-				if tmuxName == "" {
-					tmuxName = worker.TmuxSessionName(slotName)
-				}
-				if output, err := o.captureTmux(tmuxName); err == nil {
-					if tokens := worker.ParseTokensFromOutput(output); tokens > sess.TokensUsed {
-						sess.TokensUsed = tokens
 					}
 				}
 			}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2624,3 +2624,303 @@ func TestCheckSessions_DeadClosedIssue_SetsFinishedAtIfNil(t *testing.T) {
 		t.Fatal("FinishedAt should be set when transitioning from dead with nil FinishedAt")
 	}
 }
+
+// --- rate-limit detection tests ---
+
+// newRateLimitOrchestrator creates an Orchestrator wired for checkSessions
+// rate-limit testing. tmuxOutput is returned by the capture hook.
+// Returns the orchestrator, a slice of stopped slot names, and a slice of
+// (slotName, backendName) pairs for respawned workers.
+func newRateLimitOrchestrator(cfg *config.Config, tmuxOutput string) (*Orchestrator, *[]string, *[][2]string) {
+	stopped := make([]string, 0)
+	respawned := make([][2]string, 0) // [slotName, backendName]
+	return &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return true
+		},
+		captureTmuxFn: func(session string) (string, error) {
+			return tmuxOutput, nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			stopped = append(stopped, slotName)
+			return nil
+		},
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "test issue"}, nil
+		},
+		workerRespawnFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawned = append(respawned, [2]string{slotName, backendName})
+			sess.Backend = backendName
+			sess.Status = state.StatusRunning
+			return nil
+		},
+	}, &stopped, &respawned
+}
+
+func TestCheckSessions_RateLimitDetected_NoFallback_MarksDead(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+	o, stopped, _ := newRateLimitOrchestrator(cfg, "Error: You've hit your limit for today.")
+
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber: 101,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-1",
+		Branch:      "feat/mae-1-101-test",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-1"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.LastNotifiedStatus != "rate_limit" {
+		t.Fatalf("last_notified_status = %q, want %q", sess.LastNotifiedStatus, "rate_limit")
+	}
+	if !sess.RateLimitHit {
+		t.Fatal("rate_limit_hit should be true")
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("finished_at should be set")
+	}
+	if len(*stopped) != 1 || (*stopped)[0] != "mae-1" {
+		t.Fatalf("stopped = %v, want [mae-1]", *stopped)
+	}
+}
+
+func TestCheckSessions_RateLimitDetected_WithFallback_Respawns(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Fallback: "gemini",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"gemini": {Cmd: "gemini"},
+			},
+		},
+	}
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "rate limit exceeded — try again later")
+
+	s := state.NewState()
+	s.Sessions["mae-2"] = &state.Session{
+		IssueNumber: 102,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         2345,
+		TmuxSession: "maestro-mae-2",
+		Branch:      "feat/mae-2-102-test",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-2"]
+	// Worker should be stopped (old one killed) then respawned with fallback
+	if len(*stopped) != 1 || (*stopped)[0] != "mae-2" {
+		t.Fatalf("stopped = %v, want [mae-2]", *stopped)
+	}
+	if len(*respawned) != 1 {
+		t.Fatalf("respawned = %v, want 1 entry", *respawned)
+	}
+	if (*respawned)[0][0] != "mae-2" || (*respawned)[0][1] != "gemini" {
+		t.Fatalf("respawned = %v, want [mae-2, gemini]", (*respawned)[0])
+	}
+	// Session should be running with new backend
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (should be running after fallback respawn)", sess.Status, state.StatusRunning)
+	}
+	if sess.Backend != "gemini" {
+		t.Fatalf("backend = %q, want %q", sess.Backend, "gemini")
+	}
+	if !sess.RateLimitHit {
+		t.Fatal("rate_limit_hit should be true")
+	}
+}
+
+func TestCheckSessions_RateLimitDetected_AlreadyOnFallback_MarksDead(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Fallback: "gemini",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"gemini": {Cmd: "gemini"},
+			},
+		},
+	}
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "Error 429: too many requests")
+
+	s := state.NewState()
+	s.Sessions["mae-3"] = &state.Session{
+		IssueNumber: 103,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         3456,
+		TmuxSession: "maestro-mae-3",
+		Branch:      "feat/mae-3-103-test",
+		Backend:     "gemini", // already on fallback
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-3"]
+	// Should NOT respawn — already on fallback backend
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (already on fallback, should be dead)", sess.Status, state.StatusDead)
+	}
+	if len(*stopped) != 1 {
+		t.Fatalf("stopped = %v, want 1 entry", *stopped)
+	}
+	if len(*respawned) != 0 {
+		t.Fatalf("respawned = %v, want empty (should not respawn when already on fallback)", *respawned)
+	}
+	if sess.LastNotifiedStatus != "rate_limit" {
+		t.Fatalf("last_notified_status = %q, want %q", sess.LastNotifiedStatus, "rate_limit")
+	}
+}
+
+func TestCheckSessions_RateLimitAlreadyNotified_NoDuplicateKill(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+	// Output still contains rate limit text from previous cycle
+	o, stopped, _ := newRateLimitOrchestrator(cfg, "Error: rate limit exceeded")
+
+	s := state.NewState()
+	s.Sessions["mae-4"] = &state.Session{
+		IssueNumber:        104,
+		IssueTitle:         "test issue",
+		Status:             state.StatusRunning,
+		PID:                4567,
+		TmuxSession:        "maestro-mae-4",
+		Branch:             "feat/mae-4-104-test",
+		Backend:            "claude",
+		StartedAt:          time.Now().Add(-10 * time.Minute),
+		RateLimitHit:       true,         // already detected
+		LastNotifiedStatus: "rate_limit", // already notified
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-4"]
+	// Should remain running — rate limit was already handled
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (already notified, should not re-kill)", sess.Status, state.StatusRunning)
+	}
+	if len(*stopped) != 0 {
+		t.Fatalf("stopped = %v, want empty (should not duplicate kill)", *stopped)
+	}
+}
+
+func TestCheckSessions_NoRateLimit_WorkerSurvives(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Fallback: "gemini",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"gemini": {Cmd: "gemini"},
+			},
+		},
+	}
+	// Normal output, no rate limit patterns
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "tokens 50000 (in 10000 / out 40000)\nTask completed successfully.")
+
+	s := state.NewState()
+	s.Sessions["mae-5"] = &state.Session{
+		IssueNumber: 105,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         5678,
+		TmuxSession: "maestro-mae-5",
+		Branch:      "feat/mae-5-105-test",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-5 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-5"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+	if sess.RateLimitHit {
+		t.Fatal("rate_limit_hit should be false")
+	}
+	if len(*stopped) != 0 {
+		t.Fatalf("stopped = %v, want empty", *stopped)
+	}
+	if len(*respawned) != 0 {
+		t.Fatalf("respawned = %v, want empty", *respawned)
+	}
+}
+
+func TestCheckSessions_RateLimit429Pattern_Detected(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+	o, stopped, _ := newRateLimitOrchestrator(cfg, "API returned status 429")
+
+	s := state.NewState()
+	s.Sessions["mae-6"] = &state.Session{
+		IssueNumber: 106,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         6789,
+		TmuxSession: "maestro-mae-6",
+		Branch:      "feat/mae-6-106-test",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-6"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if !sess.RateLimitHit {
+		t.Fatal("rate_limit_hit should be true for 429 pattern")
+	}
+	if len(*stopped) != 1 {
+		t.Fatalf("stopped = %v, want 1 entry", *stopped)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -42,7 +42,8 @@ type Session struct {
 	RetryCount          int           `json:"retry_count,omitempty"`
 	LastOutputHash      string        `json:"last_output_hash,omitempty"`
 	LastOutputChangedAt time.Time     `json:"last_output_changed_at,omitempty"`
-	TokensUsed          int           `json:"tokens_used,omitempty"` // cumulative tokens consumed by the worker
+	TokensUsed          int           `json:"tokens_used,omitempty"`    // cumulative tokens consumed by the worker
+	RateLimitHit        bool          `json:"rate_limit_hit,omitempty"` // true if worker was killed due to rate limiting
 }
 
 type State struct {

--- a/internal/worker/ratelimit.go
+++ b/internal/worker/ratelimit.go
@@ -1,0 +1,47 @@
+package worker
+
+import (
+	"regexp"
+	"strings"
+)
+
+// rateLimitPatterns holds compiled regexes for detecting rate-limit / quota
+// errors in AI CLI output. Each entry pairs a human-readable label with
+// its regex.
+//
+// Supported patterns (case-insensitive):
+//   - "You've hit your limit" (Claude web / API)
+//   - HTTP 429 status codes
+//   - "rate limit exceeded" (generic)
+//   - "quota exceeded" (Google / generic)
+//   - "too many requests" (HTTP 429 reason)
+//   - "resource_exhausted" (gRPC status)
+var rateLimitPatterns = []struct {
+	label string
+	re    *regexp.Regexp
+}{
+	{"hit_limit", regexp.MustCompile(`(?i)you'?ve hit your limit`)},
+	{"http_429", regexp.MustCompile(`\b429\b`)},
+	{"rate_limit_exceeded", regexp.MustCompile(`(?i)rate.limit.exceeded`)},
+	{"quota_exceeded", regexp.MustCompile(`(?i)quota.exceeded`)},
+	{"too_many_requests", regexp.MustCompile(`(?i)too many requests`)},
+	{"resource_exhausted", regexp.MustCompile(`(?i)resource[_.\s]?exhausted`)},
+}
+
+// DetectRateLimit scans multi-line output for known rate-limit / quota error
+// patterns. Returns true and the matching pattern label on the first match,
+// or false and "" if no rate-limit pattern is found.
+func DetectRateLimit(output string) (bool, string) {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		for _, p := range rateLimitPatterns {
+			if p.re.MatchString(line) {
+				return true, p.label
+			}
+		}
+	}
+	return false, ""
+}

--- a/internal/worker/ratelimit_test.go
+++ b/internal/worker/ratelimit_test.go
@@ -1,0 +1,111 @@
+package worker
+
+import (
+	"testing"
+)
+
+func TestDetectRateLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantHit   bool
+		wantLabel string
+	}{
+		{
+			name:      "hit your limit",
+			input:     "Error: You've hit your limit for the day.",
+			wantHit:   true,
+			wantLabel: "hit_limit",
+		},
+		{
+			name:      "hit your limit without apostrophe",
+			input:     "Youve hit your limit",
+			wantHit:   true,
+			wantLabel: "hit_limit",
+		},
+		{
+			name:      "HTTP 429 status code",
+			input:     "HTTP error 429: Too Many Requests",
+			wantHit:   true,
+			wantLabel: "http_429",
+		},
+		{
+			name:      "429 in error message",
+			input:     "Error: received status 429 from API",
+			wantHit:   true,
+			wantLabel: "http_429",
+		},
+		{
+			name:      "rate limit exceeded",
+			input:     "Rate limit exceeded. Please retry after 60 seconds.",
+			wantHit:   true,
+			wantLabel: "rate_limit_exceeded",
+		},
+		{
+			name:      "rate limit exceeded case insensitive",
+			input:     "RATE LIMIT EXCEEDED",
+			wantHit:   true,
+			wantLabel: "rate_limit_exceeded",
+		},
+		{
+			name:      "quota exceeded",
+			input:     "Error: Quota exceeded for project xyz",
+			wantHit:   true,
+			wantLabel: "quota_exceeded",
+		},
+		{
+			name:      "too many requests",
+			input:     "Too many requests, please slow down",
+			wantHit:   true,
+			wantLabel: "too_many_requests",
+		},
+		{
+			name:      "resource exhausted gRPC",
+			input:     "rpc error: code = ResourceExhausted desc = request limit",
+			wantHit:   true,
+			wantLabel: "resource_exhausted",
+		},
+		{
+			name:      "multiline with rate limit on later line",
+			input:     "Starting task...\nProcessing...\nError: rate limit exceeded\nRetrying...",
+			wantHit:   true,
+			wantLabel: "rate_limit_exceeded",
+		},
+		{
+			name:    "normal output no rate limit",
+			input:   "tokens 50000 (in 10000 / out 40000)\nTask completed successfully.",
+			wantHit: false,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantHit: false,
+		},
+		{
+			name:    "429 as part of larger number — no match",
+			input:   "processed 14290 records",
+			wantHit: false,
+		},
+		{
+			name:      "429 standalone in error context",
+			input:     "status: 429",
+			wantHit:   true,
+			wantLabel: "http_429",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHit, gotLabel := DetectRateLimit(tc.input)
+			if gotHit != tc.wantHit {
+				t.Errorf("DetectRateLimit() hit = %v, want %v", gotHit, tc.wantHit)
+			}
+			if tc.wantHit && gotLabel != tc.wantLabel {
+				t.Errorf("DetectRateLimit() label = %q, want %q", gotLabel, tc.wantLabel)
+			}
+			if !tc.wantHit && gotLabel != "" {
+				t.Errorf("DetectRateLimit() label = %q, want empty when no hit", gotLabel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements #185

## Changes

- **`internal/worker/ratelimit.go`**: New module with `DetectRateLimit()` function that scans worker output for known rate-limit/quota error patterns:
  - `You've hit your limit` (Claude API)
  - HTTP `429` status codes
  - `rate limit exceeded` (generic)
  - `quota exceeded` (Google/generic)
  - `too many requests` (HTTP 429 reason)
  - `resource_exhausted` (gRPC status)

- **`internal/config/config.go`**: Added `Fallback` field to `ModelConfig` — specifies the backend to use when the primary hits a rate limit (configured via `model.fallback` in YAML).

- **`internal/state/state.go`**: Added `RateLimitHit` field to `Session` — tracks whether a worker was killed due to rate limiting (prevents duplicate detection).

- **`internal/orchestrator/orchestrator.go`**: 
  - Restructured tmux output capture to always run (was previously conditional on silent-timeout/token-limit being configured)
  - Added rate-limit detection check after token tracking — when detected:
    1. Stops the current worker
    2. If `model.fallback` is configured and differs from current backend, respawns worker with fallback
    3. Otherwise marks session as dead with `rate_limit` notification status
  - Added `getIssue()` and `respawnWorker()` testable wrapper methods

## Testing

- **`internal/worker/ratelimit_test.go`**: 14 test cases covering all patterns, edge cases (empty input, no match, multiline), and false positive avoidance (429 in larger numbers)
- **`internal/orchestrator/orchestrator_test.go`**: 6 integration tests:
  - Rate limit detected with no fallback → marks dead
  - Rate limit detected with fallback → respawns with fallback backend
  - Rate limit on fallback backend → marks dead (no infinite loop)
  - Already notified → no duplicate kill
  - Normal output → worker survives
  - 429 pattern detection
- All existing tests pass (`go test ./...`)
- Binary builds and runs (`go build ./cmd/maestro/ && ./maestro version`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements rate limit detection by parsing worker output for known error patterns and automatically falling back to a configured alternative backend when rate limits are encountered.

## Key Changes
- **Rate Limit Detection**: New `worker.DetectRateLimit()` function scans output for 6 common rate limit patterns (Claude API limits, HTTP 429, quota exceeded, etc.)
- **Fallback Configuration**: Added `model.fallback` config field to specify backup backend
- **Automatic Respawn**: When rate limit detected, orchestrator stops current worker and respawns with fallback backend
- **State Tracking**: `RateLimitHit` flag prevents duplicate notifications

## Issue Found
The `RateLimitHit` flag is not reset after successful fallback respawn (line 658). This prevents the orchestrator from detecting if the fallback backend also hits a rate limit, as the guard condition on line 621 checks `!sess.RateLimitHit`. The worker would continue running on a rate-limited fallback backend without detection or notification.

<h3>Confidence Score: 3/5</h3>

- This PR has a logical bug that prevents rate limit detection on fallback backends
- The implementation is well-structured with comprehensive tests, but the `RateLimitHit` flag not being reset after successful respawn creates a blind spot where rate limits on the fallback backend won't be detected. This could lead to workers continuing to run against rate-limited APIs without proper handling.
- Pay close attention to `internal/orchestrator/orchestrator.go` - the flag reset is needed after successful fallback respawn

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/worker/ratelimit.go | New rate limit detection module with comprehensive pattern matching - implementation is clean and well-tested |
| internal/config/config.go | Added `Fallback` field to ModelConfig for fallback backend configuration - straightforward addition |
| internal/orchestrator/orchestrator.go | Implements rate limit detection and fallback respawn logic, but `RateLimitHit` flag not reset after successful respawn prevents detecting subsequent rate limits on fallback backend |

</details>



<sub>Last reviewed commit: 1f255e8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->