### PR TITLE
feat: model fallback — auto-switch to next backend when rate-limited (#183)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,9 +26,9 @@ type BackendDef struct {
 
 // ModelConfig holds multi-backend configuration.
 type ModelConfig struct {
-	Default  string                `yaml:"default"`  // "claude", "codex", etc.
-	Fallback string                `yaml:"fallback"` // backend to use when the primary hits a rate limit
-	Backends map[string]BackendDef `yaml:"backends"`
+	Default          string                `yaml:"default"`           // "claude", "codex", etc.
+	Backends         map[string]BackendDef `yaml:"backends"`
+	FallbackBackends []string              `yaml:"fallback_backends"` // ordered list of backends to try when rate-limited
 }
 
 // VersioningConfig controls automatic version bumping on PR merge.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -793,3 +793,45 @@ cleanup_worktrees_on_merge: true
 		t.Error("ShouldCleanupWorktrees() should be true when explicitly set to true")
 	}
 }
+
+func TestParse_FallbackBackendsDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(cfg.Model.FallbackBackends) != 0 {
+		t.Errorf("FallbackBackends = %v, want empty", cfg.Model.FallbackBackends)
+	}
+}
+
+func TestParse_FallbackBackendsExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: claude
+  fallback_backends:
+    - codex
+    - gemini
+  backends:
+    claude:
+      cmd: claude
+    codex:
+      cmd: codex
+    gemini:
+      cmd: gemini
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"codex", "gemini"}
+	if len(cfg.Model.FallbackBackends) != len(want) {
+		t.Fatalf("FallbackBackends = %v, want %v", cfg.Model.FallbackBackends, want)
+	}
+	for i, fb := range cfg.Model.FallbackBackends {
+		if fb != want[i] {
+			t.Errorf("FallbackBackends[%d] = %q, want %q", i, fb, want[i])
+		}
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -41,14 +41,15 @@ type Orchestrator struct {
 	tmuxCaptureFn   func(session string) (string, error)
 	isIssueClosedFn func(issueNumber int) (bool, error)
 	addIssueLabelFn func(number int, label string) error
+	isRateLimitedFn func(logFile string) bool
+	// workerRespawnFn / respawnWorkerFn: used by respawnWorker() for dead-worker fallback (tests set one or the other)
+	workerRespawnFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
+	respawnWorkerFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
+	getIssueFn      func(number int) (github.Issue, error)
 
 	// Testing hooks for startNewWorkers
 	listOpenIssuesFn func(labels []string) ([]github.Issue, error)
 	workerStartFn    func(cfg *config.Config, s *state.State, repo string, issue github.Issue, promptBase, backend string) (string, error)
-
-	// Testing hooks for rate-limit fallback
-	getIssueFn      func(number int) (github.Issue, error)
-	workerRespawnFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 
 	// Testing hooks for autoMergePRs / mergeReadyPR
 	ghPRCIStatusFn         func(prNumber int) (string, error)
@@ -149,6 +150,10 @@ func (o *Orchestrator) getIssue(number int) (github.Issue, error) {
 }
 
 func (o *Orchestrator) respawnWorker(slotName string, sess *state.Session, issue github.Issue, promptBase string, backendName string) error {
+	// Support both hook names for test compatibility (respawnWorkerFn = branch, workerRespawnFn = HEAD)
+	if o.respawnWorkerFn != nil {
+		return o.respawnWorkerFn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
+	}
 	if o.workerRespawnFn != nil {
 		return o.workerRespawnFn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
 	}
@@ -184,6 +189,39 @@ func (o *Orchestrator) addIssueLabel(number int, label string) error {
 		return o.addIssueLabelFn(number, label)
 	}
 	return o.gh.AddIssueLabel(number, label)
+}
+
+func (o *Orchestrator) isRateLimited(logFile string) bool {
+	if o.isRateLimitedFn != nil {
+		return o.isRateLimitedFn(logFile)
+	}
+	return worker.IsRateLimited(logFile)
+}
+
+// nextFallbackBackend returns the next untried backend from the fallback list.
+// It skips backends that are already in sess.TriedBackends or match the current backend.
+// Returns "" if no fallback is available.
+func (o *Orchestrator) nextFallbackBackend(sess *state.Session) string {
+	fallbacks := o.cfg.Model.FallbackBackends
+	if len(fallbacks) == 0 {
+		return ""
+	}
+
+	tried := make(map[string]bool, len(sess.TriedBackends)+1)
+	tried[sess.Backend] = true
+	for _, b := range sess.TriedBackends {
+		tried[b] = true
+	}
+
+	for _, fb := range fallbacks {
+		if !tried[fb] {
+			// Verify the backend exists in config
+			if _, ok := o.cfg.Model.Backends[fb]; ok {
+				return fb
+			}
+		}
+	}
+	return ""
 }
 
 func readLastLines(path string, limit int) (string, error) {
@@ -546,6 +584,37 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					sess.PRNumber = pr.Number
 					o.notifier.Sendf("🔀 maestro: worker %s completed, PR #%d open for issue #%d (%s)",
 						slotName, pr.Number, sess.IssueNumber, sess.IssueTitle)
+				} else if o.isRateLimited(sess.LogFile) && o.nextFallbackBackend(sess) != "" {
+					// Rate-limit detected — try next fallback backend
+					nextBackend := o.nextFallbackBackend(sess)
+					log.Printf("[orch] worker %s (backend=%s) hit rate limit, falling back to %s",
+						slotName, sess.Backend, nextBackend)
+
+					issue, err := o.getIssue(sess.IssueNumber)
+					if err != nil {
+						log.Printf("[orch] fetch issue #%d for fallback: %v — marking as failed", sess.IssueNumber, err)
+						sess.Status = state.StatusFailed
+						now := time.Now().UTC()
+						sess.FinishedAt = &now
+						o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) rate-limited and fallback failed (could not fetch issue)",
+							slotName, sess.IssueNumber, sess.IssueTitle)
+						continue
+					}
+
+					sess.TriedBackends = append(sess.TriedBackends, sess.Backend)
+					promptBase := o.selectPrompt(issue)
+					if err := o.respawnWorker(slotName, sess, issue, promptBase, nextBackend); err != nil {
+						log.Printf("[orch] fallback respawn worker %s with %s: %v — marking as failed", slotName, nextBackend, err)
+						sess.Status = state.StatusFailed
+						now := time.Now().UTC()
+						sess.FinishedAt = &now
+						o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) rate-limited and fallback to %s failed: %v",
+							slotName, sess.IssueNumber, sess.IssueTitle, nextBackend, err)
+						continue
+					}
+
+					o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) rate-limited on %s, switched to %s",
+						slotName, sess.IssueNumber, sess.TriedBackends[len(sess.TriedBackends)-1], nextBackend)
 				} else if sess.RetryCount < 1 {
 					// First failure — retry with fresh worktree
 					log.Printf("[orch] worker %s (pid=%d) died, retrying (attempt %d)", slotName, sess.PID, sess.RetryCount+1)
@@ -563,7 +632,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					}
 
 					promptBase := o.selectPrompt(issue)
-					if err := worker.Respawn(o.cfg, slotName, sess, o.repo, issue, promptBase, sess.Backend); err != nil {
+					if err := o.respawnWorker(slotName, sess, issue, promptBase, sess.Backend); err != nil {
 						log.Printf("[orch] respawn worker %s: %v — marking as failed", slotName, err)
 						sess.Status = state.StatusFailed
 						now := time.Now().UTC()
@@ -627,40 +696,37 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 							}
 							sess.RateLimitHit = true
 
-							// Attempt fallback: respawn with fallback backend if configured
-							fallback := o.cfg.Model.Fallback
-							if fallback != "" && fallback != sess.Backend {
-								if _, ok := o.cfg.Model.Backends[fallback]; ok {
-									issue, fetchErr := o.getIssue(sess.IssueNumber)
-									if fetchErr != nil {
-										log.Printf("[orch] fetch issue #%d for rate-limit fallback: %v — marking dead", sess.IssueNumber, fetchErr)
-										sess.Status = state.StatusDead
-										sess.LastNotifiedStatus = "rate_limit"
-										now := time.Now().UTC()
-										sess.FinishedAt = &now
-										o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); fallback failed (could not fetch issue)",
-											slotName, sess.IssueNumber, pattern)
-										continue
-									}
-
-									promptBase := o.selectPrompt(issue)
-									if respawnErr := o.respawnWorker(slotName, sess, issue, promptBase, fallback); respawnErr != nil {
-										log.Printf("[orch] rate-limit fallback respawn %s: %v — marking dead", slotName, respawnErr)
-										sess.Status = state.StatusDead
-										sess.LastNotifiedStatus = "rate_limit"
-										now := time.Now().UTC()
-										sess.FinishedAt = &now
-										o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); fallback to %s failed: %v",
-											slotName, sess.IssueNumber, pattern, fallback, respawnErr)
-										continue
-									}
-
-									log.Printf("[orch] rate-limit fallback: respawned %s with backend %s", slotName, fallback)
-									o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) hit rate limit — falling back to %s",
-										slotName, sess.IssueNumber, fallback)
+							// Attempt fallback: respawn with next fallback backend if configured
+							if fallback := o.nextFallbackBackend(sess); fallback != "" {
+								issue, fetchErr := o.getIssue(sess.IssueNumber)
+								if fetchErr != nil {
+									log.Printf("[orch] fetch issue #%d for rate-limit fallback: %v — marking dead", sess.IssueNumber, fetchErr)
+									sess.Status = state.StatusDead
+									sess.LastNotifiedStatus = "rate_limit"
+									now := time.Now().UTC()
+									sess.FinishedAt = &now
+									o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); fallback failed (could not fetch issue)",
+										slotName, sess.IssueNumber, pattern)
 									continue
 								}
-								log.Printf("[orch] warn: fallback backend %q not found in config, marking dead", fallback)
+
+								sess.TriedBackends = append(sess.TriedBackends, sess.Backend)
+								promptBase := o.selectPrompt(issue)
+								if respawnErr := o.respawnWorker(slotName, sess, issue, promptBase, fallback); respawnErr != nil {
+									log.Printf("[orch] rate-limit fallback respawn %s: %v — marking dead", slotName, respawnErr)
+									sess.Status = state.StatusDead
+									sess.LastNotifiedStatus = "rate_limit"
+									now := time.Now().UTC()
+									sess.FinishedAt = &now
+									o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); fallback to %s failed: %v",
+										slotName, sess.IssueNumber, pattern, fallback, respawnErr)
+									continue
+								}
+
+								log.Printf("[orch] rate-limit fallback: respawned %s with backend %s", slotName, fallback)
+								o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) hit rate limit — falling back to %s",
+									slotName, sess.IssueNumber, fallback)
+								continue
 							}
 
 							// No fallback available — mark dead

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2625,7 +2625,7 @@ func TestCheckSessions_DeadClosedIssue_SetsFinishedAtIfNil(t *testing.T) {
 	}
 }
 
-// --- rate-limit detection tests ---
+// --- rate-limit detection tests (running worker, tmux output) ---
 
 // newRateLimitOrchestrator creates an Orchestrator wired for checkSessions
 // rate-limit testing. tmuxOutput is returned by the capture hook.
@@ -2664,6 +2664,46 @@ func newRateLimitOrchestrator(cfg *config.Config, tmuxOutput string) (*Orchestra
 		},
 	}, &stopped, &respawned
 }
+
+// --- model fallback tests (dead worker, log file) ---
+
+// newFallbackTestOrchestrator creates an Orchestrator wired for testing
+// rate-limit fallback in checkSessions. It records respawned backends.
+func newFallbackTestOrchestrator(cfg *config.Config, rateLimited bool) (*Orchestrator, *[]string) {
+	respawnedBackends := make([]string, 0)
+	return &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		router:     router.New(cfg),
+		promptBase: "test prompt",
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return false // worker is dead
+		},
+		isRateLimitedFn: func(logFile string) bool {
+			return rateLimited
+		},
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "test issue"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedBackends = append(respawnedBackends, backendName)
+			sess.Status = state.StatusRunning
+			sess.PID = 9999
+			sess.Backend = backendName
+			sess.StartedAt = time.Now().UTC()
+			sess.FinishedAt = nil
+			return nil
+		},
+	}, &respawnedBackends
+}
+
+// ---- Running-worker rate-limit tests (tmux detection, worker alive) ----
 
 func TestCheckSessions_RateLimitDetected_NoFallback_MarksDead(t *testing.T) {
 	cfg := &config.Config{
@@ -2713,15 +2753,15 @@ func TestCheckSessions_RateLimitDetected_WithFallback_Respawns(t *testing.T) {
 		Repo:              "owner/repo",
 		MaxRuntimeMinutes: 999,
 		Model: config.ModelConfig{
-			Default:  "claude",
-			Fallback: "gemini",
+			Default:          "claude",
+			FallbackBackends: []string{"gemini"},
 			Backends: map[string]config.BackendDef{
 				"claude": {Cmd: "claude"},
 				"gemini": {Cmd: "gemini"},
 			},
 		},
 	}
-	o, stopped, respawned := newRateLimitOrchestrator(cfg, "rate limit exceeded — try again later")
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "rate limit exceeded â try again later")
 
 	s := state.NewState()
 	s.Sessions["mae-2"] = &state.Session{
@@ -2765,8 +2805,8 @@ func TestCheckSessions_RateLimitDetected_AlreadyOnFallback_MarksDead(t *testing.
 		Repo:              "owner/repo",
 		MaxRuntimeMinutes: 999,
 		Model: config.ModelConfig{
-			Default:  "claude",
-			Fallback: "gemini",
+			Default:          "claude",
+			FallbackBackends: []string{"gemini"},
 			Backends: map[string]config.BackendDef{
 				"claude": {Cmd: "claude"},
 				"gemini": {Cmd: "gemini"},
@@ -2790,7 +2830,7 @@ func TestCheckSessions_RateLimitDetected_AlreadyOnFallback_MarksDead(t *testing.
 	o.checkSessions(s)
 
 	sess := s.Sessions["mae-3"]
-	// Should NOT respawn — already on fallback backend
+	// Should NOT respawn â already on fallback backend
 	if sess.Status != state.StatusDead {
 		t.Fatalf("status = %q, want %q (already on fallback, should be dead)", sess.Status, state.StatusDead)
 	}
@@ -2834,7 +2874,7 @@ func TestCheckSessions_RateLimitAlreadyNotified_NoDuplicateKill(t *testing.T) {
 	o.checkSessions(s)
 
 	sess := s.Sessions["mae-4"]
-	// Should remain running — rate limit was already handled
+	// Should remain running â rate limit was already handled
 	if sess.Status != state.StatusRunning {
 		t.Fatalf("status = %q, want %q (already notified, should not re-kill)", sess.Status, state.StatusRunning)
 	}
@@ -2848,8 +2888,8 @@ func TestCheckSessions_NoRateLimit_WorkerSurvives(t *testing.T) {
 		Repo:              "owner/repo",
 		MaxRuntimeMinutes: 999,
 		Model: config.ModelConfig{
-			Default:  "claude",
-			Fallback: "gemini",
+			Default:          "claude",
+			FallbackBackends: []string{"gemini"},
 			Backends: map[string]config.BackendDef{
 				"claude": {Cmd: "claude"},
 				"gemini": {Cmd: "gemini"},
@@ -2922,5 +2962,275 @@ func TestCheckSessions_RateLimit429Pattern_Detected(t *testing.T) {
 	}
 	if len(*stopped) != 1 {
 		t.Fatalf("stopped = %v, want 1 entry", *stopped)
+	}
+}
+
+// ---- Dead-worker fallback tests (log file detection, worker dead) ----
+
+func TestCheckSessions_RateLimitFallbackToCodex(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	cfg.Model.FallbackBackends = []string{"codex", "gemini"}
+	cfg.MaxRuntimeMinutes = 999
+
+	o, respawned := newFallbackTestOrchestrator(cfg, true)
+
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber: 101,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-1",
+		Branch:      "feat/mae-1-101-test",
+		LogFile:     "/tmp/test.log",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess2 := s.Sessions["mae-1"]
+	if sess2.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (should be respawned with fallback)", sess2.Status, state.StatusRunning)
+	}
+	if len(*respawned) != 1 || (*respawned)[0] != "codex" {
+		t.Fatalf("respawned = %v, want [codex]", *respawned)
+	}
+	if len(sess2.TriedBackends) != 1 || sess2.TriedBackends[0] != "claude" {
+		t.Fatalf("tried_backends = %v, want [claude]", sess2.TriedBackends)
+	}
+}
+
+func TestCheckSessions_RateLimitFallbackSkipsAlreadyTried(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	cfg.Model.FallbackBackends = []string{"codex", "gemini"}
+	cfg.MaxRuntimeMinutes = 999
+
+	o, respawned := newFallbackTestOrchestrator(cfg, true)
+
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber:   101,
+		IssueTitle:    "test issue",
+		Status:        state.StatusRunning,
+		PID:           1234,
+		TmuxSession:   "maestro-mae-1",
+		Branch:        "feat/mae-1-101-test",
+		LogFile:       "/tmp/test.log",
+		Backend:       "codex",
+		StartedAt:     time.Now().Add(-10 * time.Minute),
+		TriedBackends: []string{"claude"}, // claude already tried
+	}
+
+	o.checkSessions(s)
+
+	sess2 := s.Sessions["mae-1"]
+	if sess2.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q", sess2.Status, state.StatusRunning)
+	}
+	if len(*respawned) != 1 || (*respawned)[0] != "gemini" {
+		t.Fatalf("respawned = %v, want [gemini] (should skip codex since claudeâcodex already tried)", *respawned)
+	}
+	if len(sess2.TriedBackends) != 2 {
+		t.Fatalf("tried_backends = %v, want [claude, codex]", sess2.TriedBackends)
+	}
+}
+
+func TestCheckSessions_RateLimitNoFallbackAvailable_NormalRetry(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	cfg.Model.FallbackBackends = []string{"codex", "gemini"}
+	cfg.MaxRuntimeMinutes = 999
+
+	o, respawned := newFallbackTestOrchestrator(cfg, true)
+
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber:   101,
+		IssueTitle:    "test issue",
+		Status:        state.StatusRunning,
+		PID:           1234,
+		TmuxSession:   "maestro-mae-1",
+		Branch:        "feat/mae-1-101-test",
+		LogFile:       "/tmp/test.log",
+		Backend:       "gemini",
+		StartedAt:     time.Now().Add(-10 * time.Minute),
+		TriedBackends: []string{"claude", "codex"}, // all fallbacks exhausted
+	}
+
+	o.checkSessions(s)
+
+	sess2 := s.Sessions["mae-1"]
+	// Should fall through to normal retry (RetryCount < 1)
+	if sess2.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (should fall through to normal retry)", sess2.Status, state.StatusRunning)
+	}
+	if len(*respawned) != 1 || (*respawned)[0] != "gemini" {
+		t.Fatalf("respawned = %v, want [gemini] (normal retry with same backend)", *respawned)
+	}
+	if sess2.RetryCount != 1 {
+		t.Fatalf("retry_count = %d, want 1", sess2.RetryCount)
+	}
+}
+
+func TestCheckSessions_NoRateLimit_NormalRetry(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	cfg.Model.FallbackBackends = []string{"codex", "gemini"}
+	cfg.MaxRuntimeMinutes = 999
+
+	o, respawned := newFallbackTestOrchestrator(cfg, false) // NOT rate limited
+
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber: 101,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-1",
+		Branch:      "feat/mae-1-101-test",
+		LogFile:     "/tmp/test.log",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess2 := s.Sessions["mae-1"]
+	if sess2.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q", sess2.Status, state.StatusRunning)
+	}
+	// Should retry with same backend (normal retry), not fallback
+	if len(*respawned) != 1 || (*respawned)[0] != "claude" {
+		t.Fatalf("respawned = %v, want [claude] (normal retry, not fallback)", *respawned)
+	}
+	if sess2.RetryCount != 1 {
+		t.Fatalf("retry_count = %d, want 1", sess2.RetryCount)
+	}
+}
+
+func TestCheckSessions_RateLimitNoFallbackConfigured_NormalRetry(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	// No fallback_backends configured
+	cfg.MaxRuntimeMinutes = 999
+
+	o, respawned := newFallbackTestOrchestrator(cfg, true)
+
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber: 101,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-1",
+		Branch:      "feat/mae-1-101-test",
+		LogFile:     "/tmp/test.log",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess2 := s.Sessions["mae-1"]
+	// No fallback backends configured, so should fall through to normal retry
+	if sess2.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q", sess2.Status, state.StatusRunning)
+	}
+	if len(*respawned) != 1 || (*respawned)[0] != "claude" {
+		t.Fatalf("respawned = %v, want [claude]", *respawned)
+	}
+	if sess2.RetryCount != 1 {
+		t.Fatalf("retry_count = %d, want 1", sess2.RetryCount)
+	}
+}
+
+func TestCheckSessions_RateLimitFallbackDoesNotIncrementRetryCount(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	cfg.Model.FallbackBackends = []string{"codex", "gemini"}
+	cfg.MaxRuntimeMinutes = 999
+
+	o, _ := newFallbackTestOrchestrator(cfg, true)
+
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber: 101,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-1",
+		Branch:      "feat/mae-1-101-test",
+		LogFile:     "/tmp/test.log",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess2 := s.Sessions["mae-1"]
+	// Fallback should NOT increment retry count â fallback is separate from normal retry
+	if sess2.RetryCount != 0 {
+		t.Fatalf("retry_count = %d, want 0 (fallback should not increment retry count)", sess2.RetryCount)
+	}
+}
+
+func TestNextFallbackBackend_Basic(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	cfg.Model.FallbackBackends = []string{"codex", "gemini"}
+
+	o := &Orchestrator{cfg: cfg}
+	sess2 := &state.Session{Backend: "claude"}
+
+	got := o.nextFallbackBackend(sess2)
+	if got != "codex" {
+		t.Errorf("nextFallbackBackend() = %q, want %q", got, "codex")
+	}
+}
+
+func TestNextFallbackBackend_SkipsTried(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	cfg.Model.FallbackBackends = []string{"codex", "gemini"}
+
+	o := &Orchestrator{cfg: cfg}
+	sess2 := &state.Session{Backend: "codex", TriedBackends: []string{"claude"}}
+
+	got := o.nextFallbackBackend(sess2)
+	if got != "gemini" {
+		t.Errorf("nextFallbackBackend() = %q, want %q", got, "gemini")
+	}
+}
+
+func TestNextFallbackBackend_AllExhausted(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex", "gemini")
+	cfg.Model.FallbackBackends = []string{"codex", "gemini"}
+
+	o := &Orchestrator{cfg: cfg}
+	sess2 := &state.Session{Backend: "gemini", TriedBackends: []string{"claude", "codex"}}
+
+	got := o.nextFallbackBackend(sess2)
+	if got != "" {
+		t.Errorf("nextFallbackBackend() = %q, want empty (all exhausted)", got)
+	}
+}
+
+func TestNextFallbackBackend_NoFallbacksConfigured(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+
+	o := &Orchestrator{cfg: cfg}
+	sess2 := &state.Session{Backend: "claude"}
+
+	got := o.nextFallbackBackend(sess2)
+	if got != "" {
+		t.Errorf("nextFallbackBackend() = %q, want empty (no fallbacks configured)", got)
+	}
+}
+
+func TestNextFallbackBackend_SkipsUnknownBackend(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	cfg.Model.FallbackBackends = []string{"unknown_backend", "codex"}
+
+	o := &Orchestrator{cfg: cfg}
+	sess2 := &state.Session{Backend: "claude"}
+
+	got := o.nextFallbackBackend(sess2)
+	if got != "codex" {
+		t.Errorf("nextFallbackBackend() = %q, want %q (should skip unknown backend)", got, "codex")
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -43,7 +43,8 @@ type Session struct {
 	LastOutputHash      string        `json:"last_output_hash,omitempty"`
 	LastOutputChangedAt time.Time     `json:"last_output_changed_at,omitempty"`
 	TokensUsed          int           `json:"tokens_used,omitempty"`    // cumulative tokens consumed by the worker
-	RateLimitHit        bool          `json:"rate_limit_hit,omitempty"` // true if worker was killed due to rate limiting
+	RateLimitHit        bool          `json:"rate_limit_hit,omitempty"` // true if worker was rate-limited (tmux detection, running worker)
+	TriedBackends       []string      `json:"tried_backends,omitempty"` // backends already attempted (for rate-limit fallback)
 }
 
 type State struct {

--- a/internal/worker/ratelimit.go
+++ b/internal/worker/ratelimit.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"os"
 	"regexp"
 	"strings"
 )
@@ -28,9 +29,23 @@ var rateLimitPatterns = []struct {
 	{"resource_exhausted", regexp.MustCompile(`(?i)resource[_.\s]?exhausted`)},
 }
 
+// rateLimitSubstrings is a flat list of case-insensitive substrings used for
+// quick log-file scanning (OutputContainsRateLimit / IsRateLimited).
+var rateLimitSubstrings = []string{
+	"you've hit your limit",
+	"you have hit your limit",
+	"rate limit",
+	"rate_limit",
+	"too many requests",
+	"quota exceeded",
+	"resource_exhausted",
+	"429",
+}
+
 // DetectRateLimit scans multi-line output for known rate-limit / quota error
 // patterns. Returns true and the matching pattern label on the first match,
 // or false and "" if no rate-limit pattern is found.
+// Used for real-time detection from live tmux output (running workers).
 func DetectRateLimit(output string) (bool, string) {
 	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
@@ -44,4 +59,31 @@ func DetectRateLimit(output string) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
+// OutputContainsRateLimit checks if the given output text contains
+// any known rate-limit error patterns (case-insensitive).
+// Used for post-mortem detection from log files (dead workers).
+func OutputContainsRateLimit(output string) bool {
+	lower := strings.ToLower(output)
+	for _, pattern := range rateLimitSubstrings {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsRateLimited checks if a log file contains rate-limit error messages.
+// It reads the entire file and looks for known rate-limit patterns.
+// Used to detect rate-limiting in dead workers for fallback logic.
+func IsRateLimited(logFile string) bool {
+	if logFile == "" {
+		return false
+	}
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		return false
+	}
+	return OutputContainsRateLimit(string(data))
 }

--- a/internal/worker/ratelimit_test.go
+++ b/internal/worker/ratelimit_test.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -107,5 +109,103 @@ func TestDetectRateLimit(t *testing.T) {
 				t.Errorf("DetectRateLimit() label = %q, want empty when no hit", gotLabel)
 			}
 		})
+	}
+}
+
+func TestOutputContainsRateLimit_ClaudeMessage(t *testing.T) {
+	output := "Error: You've hit your limit for Claude. Please wait before trying again."
+	if !OutputContainsRateLimit(output) {
+		t.Error("should detect Claude rate limit message")
+	}
+}
+
+func TestOutputContainsRateLimit_CaseInsensitive(t *testing.T) {
+	output := "ERROR: YOU'VE HIT YOUR LIMIT"
+	if !OutputContainsRateLimit(output) {
+		t.Error("should detect rate limit case-insensitively")
+	}
+}
+
+func TestOutputContainsRateLimit_TooManyRequests(t *testing.T) {
+	output := "HTTP 429 Too Many Requests"
+	if !OutputContainsRateLimit(output) {
+		t.Error("should detect 'too many requests'")
+	}
+}
+
+func TestOutputContainsRateLimit_QuotaExceeded(t *testing.T) {
+	output := "API error: quota exceeded for this billing period"
+	if !OutputContainsRateLimit(output) {
+		t.Error("should detect 'quota exceeded'")
+	}
+}
+
+func TestOutputContainsRateLimit_RateLimitUnderscore(t *testing.T) {
+	output := `{"error": {"type": "rate_limit_error", "message": "rate limited"}}`
+	if !OutputContainsRateLimit(output) {
+		t.Error("should detect 'rate_limit'")
+	}
+}
+
+func TestOutputContainsRateLimit_NoMatch(t *testing.T) {
+	output := "Worker completed successfully. All tests passing."
+	if OutputContainsRateLimit(output) {
+		t.Error("should not detect rate limit in normal output")
+	}
+}
+
+func TestOutputContainsRateLimit_EmptyString(t *testing.T) {
+	if OutputContainsRateLimit("") {
+		t.Error("should not detect rate limit in empty string")
+	}
+}
+
+func TestIsRateLimited_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "worker.log")
+	content := "Starting worker...\nProcessing issue #42\nError: You've hit your limit for Claude.\n"
+	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write log file: %v", err)
+	}
+	if !IsRateLimited(logFile) {
+		t.Error("should detect rate limit from log file")
+	}
+}
+
+func TestIsRateLimited_NoRateLimit(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "worker.log")
+	content := "Starting worker...\nDone.\n"
+	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write log file: %v", err)
+	}
+	if IsRateLimited(logFile) {
+		t.Error("should not detect rate limit in normal log file")
+	}
+}
+
+func TestIsRateLimited_EmptyPath(t *testing.T) {
+	if IsRateLimited("") {
+		t.Error("should return false for empty path")
+	}
+}
+
+func TestIsRateLimited_NonexistentFile(t *testing.T) {
+	if IsRateLimited("/nonexistent/path/worker.log") {
+		t.Error("should return false for nonexistent file")
+	}
+}
+
+func TestOutputContainsRateLimit_HTTP429(t *testing.T) {
+	output := "Request failed with status 429"
+	if !OutputContainsRateLimit(output) {
+		t.Error("should detect HTTP 429 status code")
+	}
+}
+
+func TestOutputContainsRateLimit_ResourceExhausted(t *testing.T) {
+	output := "gRPC error: RESOURCE_EXHAUSTED: quota exceeded"
+	if !OutputContainsRateLimit(output) {
+		t.Error("should detect 'resource_exhausted'")
 	}
 }


### PR DESCRIPTION
Implements #183

## Changes

When a worker fails with a rate-limit error (e.g. "You've hit your limit"), maestro now automatically retries with the next configured fallback backend instead of using a normal retry. This enables seamless backend switching when Claude hits rate limits, falling back to codex or gemini.

### Config
- Added `fallback_backends` field to `model` config section — an ordered list of backends to try when the current one is rate-limited

```yaml
model:
  default: claude
  fallback_backends: [codex, gemini]
  backends:
    claude:
      cmd: claude
    codex:
      cmd: codex
    gemini:
      cmd: gemini
```

### Implementation
- **Rate-limit detection** (`internal/worker/ratelimit.go`): Scans worker log files for known rate-limit patterns ("You've hit your limit", "rate limit", "too many requests", "quota exceeded", "429", etc.)
- **Fallback logic** (`internal/orchestrator/orchestrator.go`): When a dead worker's log shows rate-limit errors, picks the next untried backend from `fallback_backends` and respawns
- **State tracking** (`internal/state/state.go`): Added `TriedBackends` field to session to track which backends have been attempted
- Fallback retries are **separate from normal retries** — they don't consume `RetryCount`, so a worker can still get a normal retry after exhausting all fallbacks

### Key behaviors
- If rate-limited and fallback available → respawn with next fallback backend
- If rate-limited but all fallbacks exhausted → fall through to normal retry logic
- If not rate-limited → normal retry logic (unchanged)
- If no `fallback_backends` configured → behavior unchanged

## Testing

- 13 new unit tests covering:
  - Rate-limit pattern detection (various patterns, case-insensitive, file-based)
  - Fallback backend selection (basic, skip-tried, all-exhausted, unknown backend)
  - Orchestrator fallback flow (rate-limit→fallback, skip-already-tried, no-fallback-available, no-rate-limit, no-fallback-configured)
  - Fallback doesn't increment RetryCount
- Config parsing tests for `fallback_backends` (default empty, explicit list)
- All existing tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements automatic backend fallback when workers hit rate limits. When a worker fails with rate-limit errors, maestro automatically retries with the next configured backend from `fallback_backends` config array, separate from normal retry logic.

- Rate-limit detection works in two modes: real-time tmux output scanning for running workers, and post-mortem log file scanning for dead workers
- `TriedBackends` session field tracks attempted backends to prevent retry loops
- Fallback retries don't consume `RetryCount`, allowing normal retries after exhausting all fallbacks
- 13 new tests provide comprehensive coverage of fallback flows, edge cases, and retry behavior
- Breaking change: replaces single `Fallback` config field with `FallbackBackends` array

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor efficiency issue already noted
- Well-designed feature with comprehensive test coverage (13 new tests). Logic is sound and correctly handles edge cases (exhausted fallbacks, no config, etc.). Only issue is an inefficient duplicate function call already noted in previous review.
- Pay attention to `internal/orchestrator/orchestrator.go` for the duplicate function call optimization (already noted in previous review)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Replaced single `Fallback` field with `FallbackBackends` array for ordered fallback list |
| internal/state/state.go | Added `TriedBackends` field to track attempted backends during rate-limit fallback |
| internal/worker/ratelimit.go | Added `OutputContainsRateLimit` and `IsRateLimited` for log file scanning (post-mortem detection) |
| internal/orchestrator/orchestrator.go | Implemented fallback logic with rate-limit detection; has inefficient duplicate function call |

</details>



<sub>Last reviewed commit: a3b6332</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->