### PR TITLE
feat: HTTP API and web dashboard for runtime observability (#201)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/orchestrator"
 	"github.com/befeast/maestro/internal/router"
+	"github.com/befeast/maestro/internal/server"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/versioning"
 	"github.com/befeast/maestro/internal/watch"
@@ -242,8 +243,21 @@ func runCmd(args []string) {
 		if err := orch.LoadPromptBase(*promptPath); err != nil {
 			log.Printf("warn: load prompt: %v", err)
 		}
+
+		refreshCh := make(chan struct{}, 1)
+
+		// Start HTTP server if configured
+		if cfg.Server.Port > 0 {
+			srv := server.New(cfg, refreshCh)
+			go func() {
+				if err := srv.Start(context.Background()); err != nil {
+					log.Printf("[server] error: %v", err)
+				}
+			}()
+		}
+
 		log.Printf("starting maestro — repo=%s prefix=%s interval=%s once=%v", cfg.Repo, cfg.SessionPrefix, *interval, *once)
-		if err := orch.Run(context.Background(), *interval, *once); err != nil {
+		if err := orch.Run(context.Background(), *interval, *once, refreshCh); err != nil {
 			log.Fatalf("run: %v", err)
 		}
 		return
@@ -272,8 +286,21 @@ func runCmd(args []string) {
 			if err := orch.LoadPromptBase(*promptPath); err != nil {
 				log.Printf("[%s] warn: load prompt: %v", c.SessionPrefix, err)
 			}
+
+			refreshCh := make(chan struct{}, 1)
+
+			// Start HTTP server if configured
+			if c.Server.Port > 0 {
+				srv := server.New(c, refreshCh)
+				go func() {
+					if err := srv.Start(ctx); err != nil {
+						log.Printf("[%s][server] error: %v", c.SessionPrefix, err)
+					}
+				}()
+			}
+
 			log.Printf("[%s] starting — repo=%s interval=%s once=%v", c.SessionPrefix, c.Repo, *interval, *once)
-			if err := orch.Run(ctx, *interval, *once); err != nil {
+			if err := orch.Run(ctx, *interval, *once, refreshCh); err != nil {
 				log.Printf("[%s] run error: %v", c.SessionPrefix, err)
 			}
 		}(cfg)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type BackendDef struct {
 
 // ModelConfig holds multi-backend configuration.
 type ModelConfig struct {
-	Default          string                `yaml:"default"`           // "claude", "codex", etc.
+	Default          string                `yaml:"default"` // "claude", "codex", etc.
 	Backends         map[string]BackendDef `yaml:"backends"`
 	FallbackBackends []string              `yaml:"fallback_backends"` // ordered list of backends to try when rate-limited
 }
@@ -48,7 +48,13 @@ type RoutingConfig struct {
 	RouterPrompt    string `yaml:"router_prompt"`     // prompt template with {{BACKENDS}}, {{NUMBER}}, {{TITLE}}, {{BODY}}
 }
 
+// ServerConfig controls the optional HTTP API server.
+type ServerConfig struct {
+	Port int `yaml:"port"` // 0 = disabled (default)
+}
+
 type Config struct {
+	Server                     ServerConfig     `yaml:"server"`
 	Repo                       string           `yaml:"repo"`
 	LocalPath                  string           `yaml:"local_path"`
 	WorktreeBase               string           `yaml:"worktree_base"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -698,6 +698,32 @@ merge_interval_seconds: 45
 	}
 }
 
+func TestParse_ServerPortDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Server.Port != 0 {
+		t.Errorf("Server.Port = %d, want 0 (disabled)", cfg.Server.Port)
+	}
+}
+
+func TestParse_ServerPortExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+server:
+  port: 8765
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Server.Port != 8765 {
+		t.Errorf("Server.Port = %d, want 8765", cfg.Server.Port)
+	}
+}
+
 func TestParse_MergeConfigInvalidFallsBack(t *testing.T) {
 	yaml := `
 repo: owner/repo

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -401,7 +401,8 @@ func (o *Orchestrator) RunOnce() error {
 
 // Run loops with the given interval; if once=true, runs once and returns.
 // The context can be used to stop the loop (e.g. for multi-project shutdown).
-func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once bool) error {
+// An optional refreshCh triggers an immediate poll cycle when a value is received.
+func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once bool, refreshCh <-chan struct{}) error {
 	if err := o.RunOnce(); err != nil {
 		log.Printf("[orch] run error: %v", err)
 	}
@@ -416,6 +417,11 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 			log.Printf("[orch] shutting down (%s)", o.repo)
 			return nil
 		case <-ticker.C:
+			if err := o.RunOnce(); err != nil {
+				log.Printf("[orch] run error: %v", err)
+			}
+		case <-refreshCh:
+			log.Printf("[orch] refresh triggered via API")
 			if err := o.RunOnce(); err != nil {
 				log.Printf("[orch] run error: %v", err)
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,354 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/worker"
+)
+
+// Server provides an HTTP API for runtime observability.
+type Server struct {
+	cfg       *config.Config
+	refreshCh chan<- struct{}
+	srv       *http.Server
+}
+
+// New creates a new Server. refreshCh is used to trigger immediate poll cycles.
+func New(cfg *config.Config, refreshCh chan<- struct{}) *Server {
+	return &Server{
+		cfg:       cfg,
+		refreshCh: refreshCh,
+	}
+}
+
+// Start begins serving HTTP on the configured port. It blocks until the server
+// is shut down. Returns nil if port is 0 (disabled).
+func (s *Server) Start(ctx context.Context) error {
+	if s.cfg.Server.Port == 0 {
+		return nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/state", s.handleState)
+	mux.HandleFunc("/api/v1/workers", s.handleWorkers)
+	mux.HandleFunc("/api/v1/refresh", s.handleRefresh)
+	mux.HandleFunc("/api/v1/", s.handleIssue)
+	mux.HandleFunc("/", s.handleDashboard)
+
+	addr := fmt.Sprintf(":%d", s.cfg.Server.Port)
+	s.srv = &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s.srv.Shutdown(shutdownCtx)
+	}()
+
+	log.Printf("[server] listening on %s", addr)
+	if err := s.srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("http server: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) loadState() (*state.State, error) {
+	return state.Load(s.cfg.StateDir)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// stateResponse is the JSON shape for GET /api/v1/state.
+type stateResponse struct {
+	Repo        string          `json:"repo"`
+	MaxParallel int             `json:"max_parallel"`
+	Running     []sessionInfo   `json:"running"`
+	PROpen      []sessionInfo   `json:"pr_open"`
+	Queued      []sessionInfo   `json:"queued"`
+	TokenTotals tokenTotalsInfo `json:"token_totals"`
+	Summary     map[string]int  `json:"summary"`
+}
+
+type tokenTotalsInfo struct {
+	Active int `json:"active"`
+	Total  int `json:"total"`
+}
+
+type sessionInfo struct {
+	Slot        string `json:"slot"`
+	IssueNumber int    `json:"issue_number"`
+	IssueTitle  string `json:"issue_title"`
+	Status      string `json:"status"`
+	Backend     string `json:"backend,omitempty"`
+	PRNumber    int    `json:"pr_number,omitempty"`
+	TokensUsed  int    `json:"tokens_used"`
+	Runtime     string `json:"runtime"`
+	StartedAt   string `json:"started_at"`
+	FinishedAt  string `json:"finished_at,omitempty"`
+	PID         int    `json:"pid,omitempty"`
+	Alive       *bool  `json:"alive,omitempty"`
+	Worktree    string `json:"worktree,omitempty"`
+	Branch      string `json:"branch,omitempty"`
+	RetryCount  int    `json:"retry_count,omitempty"`
+}
+
+func makeSessionInfo(slot string, sess *state.Session) sessionInfo {
+	info := sessionInfo{
+		Slot:        slot,
+		IssueNumber: sess.IssueNumber,
+		IssueTitle:  sess.IssueTitle,
+		Status:      string(sess.Status),
+		Backend:     sess.Backend,
+		PRNumber:    sess.PRNumber,
+		TokensUsed:  sess.TokensUsed,
+		StartedAt:   sess.StartedAt.Format(time.RFC3339),
+		Worktree:    sess.Worktree,
+		Branch:      sess.Branch,
+		RetryCount:  sess.RetryCount,
+	}
+
+	// Calculate runtime
+	end := time.Now()
+	if sess.FinishedAt != nil {
+		end = *sess.FinishedAt
+		info.FinishedAt = sess.FinishedAt.Format(time.RFC3339)
+	}
+	info.Runtime = end.Sub(sess.StartedAt).Round(time.Second).String()
+
+	if sess.Status == state.StatusRunning {
+		info.PID = sess.PID
+		alive := worker.IsAlive(sess.PID)
+		info.Alive = &alive
+	}
+
+	return info
+}
+
+func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	st, err := s.loadState()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load state: %v", err))
+		return
+	}
+
+	resp := stateResponse{
+		Repo:        s.cfg.Repo,
+		MaxParallel: s.cfg.MaxParallel,
+		Running:     make([]sessionInfo, 0),
+		PROpen:      make([]sessionInfo, 0),
+		Queued:      make([]sessionInfo, 0),
+		Summary:     make(map[string]int),
+	}
+
+	var activeTokens, totalTokens int
+	for slot, sess := range st.Sessions {
+		info := makeSessionInfo(slot, sess)
+		resp.Summary[string(sess.Status)]++
+		totalTokens += sess.TokensUsed
+
+		switch sess.Status {
+		case state.StatusRunning:
+			resp.Running = append(resp.Running, info)
+			activeTokens += sess.TokensUsed
+		case state.StatusPROpen:
+			resp.PROpen = append(resp.PROpen, info)
+			activeTokens += sess.TokensUsed
+		case state.StatusQueued:
+			resp.Queued = append(resp.Queued, info)
+		}
+	}
+
+	resp.TokenTotals = tokenTotalsInfo{
+		Active: activeTokens,
+		Total:  totalTokens,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleWorkers(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	st, err := s.loadState()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load state: %v", err))
+		return
+	}
+
+	workers := make([]sessionInfo, 0, len(st.Sessions))
+	for slot, sess := range st.Sessions {
+		workers = append(workers, makeSessionInfo(slot, sess))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"workers": workers,
+		"total":   len(workers),
+	})
+}
+
+// issueResponse is the JSON shape for GET /api/v1/<issue_number>.
+type issueResponse struct {
+	IssueNumber int           `json:"issue_number"`
+	Sessions    []sessionInfo `json:"sessions"`
+}
+
+func (s *Server) handleIssue(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Parse issue number from path: /api/v1/<number>
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/")
+	path = strings.TrimSuffix(path, "/")
+	if path == "" {
+		writeError(w, http.StatusBadRequest, "issue number required")
+		return
+	}
+
+	issueNum, err := strconv.Atoi(path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid issue number: %s", path))
+		return
+	}
+
+	st, err := s.loadState()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load state: %v", err))
+		return
+	}
+
+	resp := issueResponse{
+		IssueNumber: issueNum,
+		Sessions:    make([]sessionInfo, 0),
+	}
+
+	for slot, sess := range st.Sessions {
+		if sess.IssueNumber == issueNum {
+			resp.Sessions = append(resp.Sessions, makeSessionInfo(slot, sess))
+		}
+	}
+
+	if len(resp.Sessions) == 0 {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no sessions found for issue #%d", issueNum))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	select {
+	case s.refreshCh <- struct{}{}:
+		writeJSON(w, http.StatusOK, map[string]string{"status": "refresh triggered"})
+	default:
+		writeJSON(w, http.StatusOK, map[string]string{"status": "refresh already pending"})
+	}
+}
+
+func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	st, err := s.loadState()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("load state: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!DOCTYPE html>
+<html>
+<head>
+<title>maestro — %s</title>
+<meta http-equiv="refresh" content="10">
+<style>
+  body { font-family: monospace; background: #1a1a2e; color: #e0e0e0; margin: 2em; }
+  h1 { color: #00d4ff; }
+  table { border-collapse: collapse; width: 100%%; margin-top: 1em; }
+  th, td { padding: 6px 12px; text-align: left; border-bottom: 1px solid #333; }
+  th { color: #00d4ff; }
+  .running { color: #00ff88; }
+  .pr_open { color: #ffaa00; }
+  .done { color: #888; }
+  .dead, .failed { color: #ff4444; }
+  .queued { color: #aaaaff; }
+  a { color: #00d4ff; }
+</style>
+</head>
+<body>
+<h1>maestro — %s</h1>
+<p>Sessions: %d | Max parallel: %d</p>
+<table>
+<tr><th>Slot</th><th>Issue</th><th>Status</th><th>Backend</th><th>PR</th><th>Tokens</th><th>Runtime</th></tr>
+`, s.cfg.Repo, s.cfg.Repo, len(st.Sessions), s.cfg.MaxParallel)
+
+	for slot, sess := range st.Sessions {
+		end := time.Now()
+		if sess.FinishedAt != nil {
+			end = *sess.FinishedAt
+		}
+		runtime := end.Sub(sess.StartedAt).Round(time.Second)
+		pr := "-"
+		if sess.PRNumber > 0 {
+			pr = fmt.Sprintf("#%d", sess.PRNumber)
+		}
+		tokens := worker.FormatTokens(sess.TokensUsed)
+		fmt.Fprintf(w, `<tr class="%s"><td>%s</td><td>#%d %s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>
+`,
+			sess.Status, slot, sess.IssueNumber, escapeHTML(sess.IssueTitle),
+			sess.Status, sess.Backend, pr, tokens, runtime)
+	}
+
+	fmt.Fprintf(w, `</table>
+<p style="margin-top:2em; color:#666">Auto-refreshes every 10s | <a href="/api/v1/state">JSON API</a></p>
+</body>
+</html>`)
+}
+
+func escapeHTML(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	return s
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,412 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func setupTestServer(t *testing.T) (*Server, *config.Config) {
+	t.Helper()
+	dir := t.TempDir()
+
+	cfg := &config.Config{
+		Repo:        "test/repo",
+		MaxParallel: 3,
+		StateDir:    dir,
+		Server:      config.ServerConfig{Port: 8765},
+	}
+
+	// Write test state
+	st := state.NewState()
+	now := time.Now().UTC()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "Fix bug",
+		Status:      state.StatusRunning,
+		Backend:     "claude",
+		Branch:      "feat/slot-1-42-fix-bug",
+		Worktree:    "/tmp/worktrees/slot-1",
+		StartedAt:   now.Add(-10 * time.Minute),
+		TokensUsed:  5000,
+		PID:         1, // non-zero but won't be alive in tests
+	}
+	finished := now.Add(-5 * time.Minute)
+	st.Sessions["slot-2"] = &state.Session{
+		IssueNumber: 43,
+		IssueTitle:  "Add feature",
+		Status:      state.StatusPROpen,
+		Backend:     "codex",
+		Branch:      "feat/slot-2-43-add-feature",
+		Worktree:    "/tmp/worktrees/slot-2",
+		StartedAt:   now.Add(-30 * time.Minute),
+		FinishedAt:  &finished,
+		PRNumber:    10,
+		TokensUsed:  8000,
+	}
+	st.Sessions["slot-3"] = &state.Session{
+		IssueNumber: 44,
+		IssueTitle:  "Refactor code",
+		Status:      state.StatusDone,
+		Backend:     "claude",
+		Branch:      "feat/slot-3-44-refactor-code",
+		StartedAt:   now.Add(-1 * time.Hour),
+		FinishedAt:  &finished,
+		PRNumber:    11,
+		TokensUsed:  3000,
+	}
+
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save test state: %v", err)
+	}
+
+	refreshCh := make(chan struct{}, 1)
+	srv := New(cfg, refreshCh)
+	return srv, cfg
+}
+
+func TestHandleState(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.handleState(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp stateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if resp.Repo != "test/repo" {
+		t.Errorf("repo = %q, want %q", resp.Repo, "test/repo")
+	}
+	if resp.MaxParallel != 3 {
+		t.Errorf("max_parallel = %d, want 3", resp.MaxParallel)
+	}
+	if len(resp.Running) != 1 {
+		t.Errorf("running sessions = %d, want 1", len(resp.Running))
+	}
+	if len(resp.PROpen) != 1 {
+		t.Errorf("pr_open sessions = %d, want 1", len(resp.PROpen))
+	}
+	if resp.TokenTotals.Total != 16000 {
+		t.Errorf("total tokens = %d, want 16000", resp.TokenTotals.Total)
+	}
+	if resp.TokenTotals.Active != 13000 {
+		t.Errorf("active tokens = %d, want 13000", resp.TokenTotals.Active)
+	}
+}
+
+func TestHandleState_MethodNotAllowed(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.handleState(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandleWorkers(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workers", nil)
+	w := httptest.NewRecorder()
+	srv.handleWorkers(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	total := int(resp["total"].(float64))
+	if total != 3 {
+		t.Errorf("total workers = %d, want 3", total)
+	}
+
+	workers := resp["workers"].([]interface{})
+	if len(workers) != 3 {
+		t.Errorf("workers array len = %d, want 3", len(workers))
+	}
+}
+
+func TestHandleIssue_Found(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/42", nil)
+	w := httptest.NewRecorder()
+	srv.handleIssue(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp issueResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if resp.IssueNumber != 42 {
+		t.Errorf("issue_number = %d, want 42", resp.IssueNumber)
+	}
+	if len(resp.Sessions) != 1 {
+		t.Errorf("sessions = %d, want 1", len(resp.Sessions))
+	}
+	if resp.Sessions[0].IssueTitle != "Fix bug" {
+		t.Errorf("issue_title = %q, want %q", resp.Sessions[0].IssueTitle, "Fix bug")
+	}
+}
+
+func TestHandleIssue_NotFound(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/999", nil)
+	w := httptest.NewRecorder()
+	srv.handleIssue(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleIssue_InvalidNumber(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/abc", nil)
+	w := httptest.NewRecorder()
+	srv.handleIssue(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleRefresh(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: dir,
+		Server:   config.ServerConfig{Port: 8765},
+	}
+
+	refreshCh := make(chan struct{}, 1)
+	srv := New(cfg, refreshCh)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/refresh", nil)
+	w := httptest.NewRecorder()
+	srv.handleRefresh(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// Check channel received signal
+	select {
+	case <-refreshCh:
+		// ok
+	default:
+		t.Error("refresh channel did not receive signal")
+	}
+}
+
+func TestHandleRefresh_AlreadyPending(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: dir,
+		Server:   config.ServerConfig{Port: 8765},
+	}
+
+	refreshCh := make(chan struct{}, 1)
+	refreshCh <- struct{}{} // pre-fill the channel
+	srv := New(cfg, refreshCh)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/refresh", nil)
+	w := httptest.NewRecorder()
+	srv.handleRefresh(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "refresh already pending" {
+		t.Errorf("status = %q, want %q", resp["status"], "refresh already pending")
+	}
+}
+
+func TestHandleRefresh_MethodNotAllowed(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: dir,
+		Server:   config.ServerConfig{Port: 8765},
+	}
+
+	refreshCh := make(chan struct{}, 1)
+	srv := New(cfg, refreshCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/refresh", nil)
+	w := httptest.NewRecorder()
+	srv.handleRefresh(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandleDashboard(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.handleDashboard(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	body := w.Body.String()
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("content-type = %q, want text/html", ct)
+	}
+	if !contains(body, "test/repo") {
+		t.Error("dashboard should contain repo name")
+	}
+	if !contains(body, "Fix bug") {
+		t.Error("dashboard should contain issue titles")
+	}
+}
+
+func TestHandleDashboard_NotFoundForOtherPaths(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
+	w := httptest.NewRecorder()
+	srv.handleDashboard(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleState_EmptyState(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:        "test/repo",
+		MaxParallel: 5,
+		StateDir:    dir,
+		Server:      config.ServerConfig{Port: 8765},
+	}
+
+	refreshCh := make(chan struct{}, 1)
+	srv := New(cfg, refreshCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.handleState(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp stateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(resp.Running) != 0 {
+		t.Errorf("running = %d, want 0", len(resp.Running))
+	}
+	if resp.TokenTotals.Total != 0 {
+		t.Errorf("total tokens = %d, want 0", resp.TokenTotals.Total)
+	}
+}
+
+func TestStartDisabledPort(t *testing.T) {
+	cfg := &config.Config{
+		Repo:   "test/repo",
+		Server: config.ServerConfig{Port: 0},
+	}
+	refreshCh := make(chan struct{}, 1)
+	srv := New(cfg, refreshCh)
+
+	// Start should return nil immediately when port is 0
+	err := srv.Start(nil)
+	if err != nil {
+		t.Errorf("expected nil error for disabled port, got %v", err)
+	}
+}
+
+func TestEscapeHTML(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"hello", "hello"},
+		{"<script>", "&lt;script&gt;"},
+		{"a & b", "a &amp; b"},
+		{`"quoted"`, "&quot;quoted&quot;"},
+	}
+	for _, tt := range tests {
+		got := escapeHTML(tt.in)
+		if got != tt.want {
+			t.Errorf("escapeHTML(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestHandleState_InvalidStateDir(t *testing.T) {
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: filepath.Join(os.TempDir(), "nonexistent-dir-12345", "nested"),
+	}
+
+	// Write a corrupt state file
+	os.MkdirAll(cfg.StateDir, 0755)
+	os.WriteFile(filepath.Join(cfg.StateDir, "state.json"), []byte("{invalid"), 0644)
+
+	refreshCh := make(chan struct{}, 1)
+	srv := New(cfg, refreshCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.handleState(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+
+	// cleanup
+	os.RemoveAll(cfg.StateDir)
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Implements #201

## Changes
- Added optional HTTP server with JSON REST API for runtime observability
- New `internal/server/` package with all endpoint handlers
- Added `server.port` config option (default: 0 = disabled)

### Endpoints
| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/v1/state` | GET | Running sessions, token totals, status summary |
| `/api/v1/<issue_number>` | GET | Per-issue debug info (sessions, worktree, branch) |
| `/api/v1/workers` | GET | List all workers with full status |
| `/api/v1/refresh` | POST | Trigger immediate reconciliation cycle |
| `/` | GET | Human-readable HTML dashboard (auto-refreshes every 10s) |

### Config
```yaml
server:
  port: 8765  # 0 = disabled (default)
```

### Safety
- Server failure does not crash orchestrator (runs in separate goroutine)
- Server is disabled by default (port 0)
- Refresh endpoint uses buffered channel to prevent blocking

## Testing
- Comprehensive unit tests for all endpoints (state, workers, issue lookup, refresh, dashboard)
- Tests cover error cases (invalid state, method not allowed, not found, corrupt state)
- Config parsing tests for server.port
- All existing tests pass
- `go vet`, `go fmt`, `go build` all clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional HTTP observability server (`internal/server`) that exposes a JSON REST API and an HTML dashboard for inspecting maestro runtime state. The feature is cleanly integrated — disabled by default (port 0), non-fatal on startup failure, and wired into the existing orchestrator loop via a buffered `refreshCh` channel.

Key observations:
- The dashboard template interpolates `slot` (derived from `SessionPrefix` config) and `sess.Backend` directly into HTML without escaping — `escapeHTML` is already defined in the file and should be applied to these values consistently.
- The server binds to `0.0.0.0` by default with no authentication, making the `/api/v1/refresh` endpoint reachable by anyone who can connect to the host. Defaulting the bind address to `127.0.0.1` (with an opt-in config field for remote access) would be the safer default for an internal tool.
- The test suite is comprehensive and covers all endpoints including error cases, but `TestStartDisabledPort` passes a `nil` context (fragile) and helper functions `contains`/`containsSubstr` re-implement `strings.Contains` from the standard library.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with the noted caveats understood — no runtime crashes, but the server's default all-interfaces binding is worth addressing before wider deployment.
- The core logic is sound and well-tested. The two concerns (unescaped HTML in the dashboard and binding on all interfaces without auth) are real but neither is a showstopper for an opt-in, internally-facing feature. The HTML issue is straightforward to fix; the binding issue is a deployment/security posture decision.
- `internal/server/server.go` — HTML escaping in the dashboard template and the default bind address deserve attention before this is deployed in any network-exposed environment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/server.go | New HTTP observability server. Two issues: (1) dashboard template interpolates `slot` and `sess.Backend` without HTML-escaping, and (2) server binds to 0.0.0.0 with no authentication, making the refresh endpoint publicly reachable. |
| internal/server/server_test.go | Comprehensive endpoint tests. Two style issues: `Start(nil)` is a fragile nil-context call, and `contains`/`containsSubstr` re-implement `strings.Contains` unnecessarily. |
| cmd/maestro/main.go | Wires the new server and refreshCh into both single-project and multi-project start paths. Multi-project mode correctly propagates the cancellable context; single-project mode is consistent with the existing orchestrator context usage. |
| internal/orchestrator/orchestrator.go | Adds a `refreshCh` `<-chan struct{}` parameter to `Run` and handles it in the select loop — clean, minimal change. |
| internal/config/config.go | Adds `ServerConfig` struct with a single `port` field (default 0 = disabled). Straightforward and correctly integrated into `Config`. |
| internal/config/config_test.go | Adds two tests covering default (0) and explicit (8765) port parsing — concise and correct. |

</details>

<sub>Last reviewed commit: b80d9c1</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->