### PR TITLE
feat: blocker-aware dispatch — skip issues with open blockers (#200)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -464,6 +464,40 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 			fmt.Printf("    log:    tail -f %s\n", sess.LogFile)
 		}
 	}
+
+	// Show blocked issues (issues with open blockers)
+	if len(cfg.BlockerPatterns) > 0 {
+		issues, err := gh.ListOpenIssues(cfg.IssueLabels)
+		if err == nil {
+			var blockedLines []string
+			for _, issue := range issues {
+				blockers := github.FindBlockers(issue.Body, cfg.BlockerPatterns)
+				if len(blockers) == 0 {
+					continue
+				}
+				var openBlockers []int
+				for _, b := range blockers {
+					closed, err := gh.IsIssueClosed(b)
+					if err != nil || !closed {
+						openBlockers = append(openBlockers, b)
+					}
+				}
+				if len(openBlockers) > 0 {
+					refs := make([]string, len(openBlockers))
+					for i, b := range openBlockers {
+						refs[i] = fmt.Sprintf("#%d", b)
+					}
+					blockedLines = append(blockedLines, fmt.Sprintf("  #%-6d blocked by %s  (%s)", issue.Number, strings.Join(refs, ", "), truncate(issue.Title, 50)))
+				}
+			}
+			if len(blockedLines) > 0 {
+				fmt.Println("\nBlocked issues:")
+				for _, line := range blockedLines {
+					fmt.Println(line)
+				}
+			}
+		}
+	}
 }
 
 func logsCmd(args []string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ type Config struct {
 	Versioning                 VersioningConfig `yaml:"versioning"`
 	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
 	CleanupWorktreesOnMerge    *bool            `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
+	BlockerPatterns            []string         `yaml:"blocker_patterns"`           // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
 }
 
 // LoadFrom loads config from a specific path.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -724,6 +724,39 @@ server:
 	}
 }
 
+func TestParse_BlockerPatternsDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(cfg.BlockerPatterns) != 0 {
+		t.Errorf("BlockerPatterns = %v, want empty (disabled by default)", cfg.BlockerPatterns)
+	}
+}
+
+func TestParse_BlockerPatternsExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+blocker_patterns:
+  - "blocked by #(\\d+)"
+  - "depends on #(\\d+)"
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(cfg.BlockerPatterns) != 2 {
+		t.Fatalf("BlockerPatterns length = %d, want 2", len(cfg.BlockerPatterns))
+	}
+	if cfg.BlockerPatterns[0] != `blocked by #(\d+)` {
+		t.Errorf("BlockerPatterns[0] = %q, want %q", cfg.BlockerPatterns[0], `blocked by #(\d+)`)
+	}
+	if cfg.BlockerPatterns[1] != `depends on #(\d+)` {
+		t.Errorf("BlockerPatterns[1] = %q, want %q", cfg.BlockerPatterns[1], `depends on #(\d+)`)
+	}
+}
+
 func TestParse_MergeConfigInvalidFallsBack(t *testing.T) {
 	yaml := `
 repo: owner/repo

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -427,6 +428,34 @@ func (c *Client) HasOpenPRForIssue(issueNumber int) (bool, error) {
 		return false, fmt.Errorf("parse pr search results: %w", err)
 	}
 	return len(prs) > 0, nil
+}
+
+// FindBlockers scans an issue body for blocker references matching the given
+// regex patterns. Each pattern must contain a capture group for the issue number.
+// Returns deduplicated issue numbers referenced as blockers.
+func FindBlockers(body string, patterns []string) []int {
+	seen := make(map[int]struct{})
+	var blockers []int
+	for _, pat := range patterns {
+		re, err := regexp.Compile("(?i)" + pat)
+		if err != nil {
+			continue
+		}
+		for _, match := range re.FindAllStringSubmatch(body, -1) {
+			if len(match) < 2 {
+				continue
+			}
+			n, err := strconv.Atoi(match[1])
+			if err != nil || n <= 0 {
+				continue
+			}
+			if _, ok := seen[n]; !ok {
+				seen[n] = struct{}{}
+				blockers = append(blockers, n)
+			}
+		}
+	}
+	return blockers
 }
 
 // HasLabel returns true if any of the issue's labels match

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,0 +1,125 @@
+package github
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestFindBlockers_BasicPattern(t *testing.T) {
+	body := "This issue is blocked by #42 and depends on #99."
+	patterns := []string{`blocked by #(\d+)`, `depends on #(\d+)`}
+	got := FindBlockers(body, patterns)
+	sort.Ints(got)
+	want := []int{42, 99}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindBlockers() = %v, want %v", got, want)
+	}
+}
+
+func TestFindBlockers_CaseInsensitive(t *testing.T) {
+	body := "BLOCKED BY #10\nBlocked By #20\nblocked by #30"
+	patterns := []string{`blocked by #(\d+)`}
+	got := FindBlockers(body, patterns)
+	sort.Ints(got)
+	want := []int{10, 20, 30}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindBlockers() = %v, want %v", got, want)
+	}
+}
+
+func TestFindBlockers_Deduplicates(t *testing.T) {
+	body := "blocked by #42 and also blocked by #42"
+	patterns := []string{`blocked by #(\d+)`}
+	got := FindBlockers(body, patterns)
+	if len(got) != 1 || got[0] != 42 {
+		t.Errorf("FindBlockers() = %v, want [42]", got)
+	}
+}
+
+func TestFindBlockers_NoMatch(t *testing.T) {
+	body := "This issue has no blockers."
+	patterns := []string{`blocked by #(\d+)`}
+	got := FindBlockers(body, patterns)
+	if len(got) != 0 {
+		t.Errorf("FindBlockers() = %v, want empty", got)
+	}
+}
+
+func TestFindBlockers_EmptyPatterns(t *testing.T) {
+	body := "blocked by #42"
+	got := FindBlockers(body, nil)
+	if len(got) != 0 {
+		t.Errorf("FindBlockers() = %v, want empty", got)
+	}
+}
+
+func TestFindBlockers_EmptyBody(t *testing.T) {
+	patterns := []string{`blocked by #(\d+)`}
+	got := FindBlockers("", patterns)
+	if len(got) != 0 {
+		t.Errorf("FindBlockers() = %v, want empty", got)
+	}
+}
+
+func TestFindBlockers_InvalidRegex(t *testing.T) {
+	body := "blocked by #42"
+	patterns := []string{`[invalid`, `blocked by #(\d+)`}
+	got := FindBlockers(body, patterns)
+	// Should still find the match from the valid pattern
+	if len(got) != 1 || got[0] != 42 {
+		t.Errorf("FindBlockers() = %v, want [42]", got)
+	}
+}
+
+func TestFindBlockers_MultipleMatches(t *testing.T) {
+	body := "blocked by #10, blocked by #20, blocked by #30"
+	patterns := []string{`blocked by #(\d+)`}
+	got := FindBlockers(body, patterns)
+	sort.Ints(got)
+	want := []int{10, 20, 30}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindBlockers() = %v, want %v", got, want)
+	}
+}
+
+func TestFindBlockers_MultilineBody(t *testing.T) {
+	body := `## Description
+This feature needs some work.
+
+## Dependencies
+- blocked by #100
+- depends on #200
+
+## Notes
+Nothing else.`
+	patterns := []string{`blocked by #(\d+)`, `depends on #(\d+)`}
+	got := FindBlockers(body, patterns)
+	sort.Ints(got)
+	want := []int{100, 200}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindBlockers() = %v, want %v", got, want)
+	}
+}
+
+func TestHasLabel_CaseInsensitive(t *testing.T) {
+	issue := Issue{
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "Bug"}},
+	}
+	if !HasLabel(issue, []string{"bug"}) {
+		t.Error("HasLabel should be case-insensitive")
+	}
+}
+
+func TestHasLabel_NoMatch(t *testing.T) {
+	issue := Issue{
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "enhancement"}},
+	}
+	if HasLabel(issue, []string{"bug"}) {
+		t.Error("HasLabel should return false when no labels match")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1159,6 +1159,24 @@ func (o *Orchestrator) markUnresolvableConflict(slotName string, sess *state.Ses
 	o.notifier.Sendf("⚠️ Worker %s (issue #%d) has unresolvable conflicts — manual intervention needed", slotName, sess.IssueNumber)
 }
 
+// findOpenBlockers returns the subset of blocker issue numbers that are still open.
+func (o *Orchestrator) findOpenBlockers(blockers []int) []int {
+	var open []int
+	for _, num := range blockers {
+		closed, err := o.isIssueClosed(num)
+		if err != nil {
+			// If we can't determine the state, assume it's open (safe default)
+			log.Printf("[orch] warn: could not check blocker #%d: %v (assuming open)", num, err)
+			open = append(open, num)
+			continue
+		}
+		if !closed {
+			open = append(open, num)
+		}
+	}
+	return open
+}
+
 // resolveBackend determines which backend to use for the given issue.
 // Delegates to router.ResolveBackend which applies 3-tier priority:
 //  1. model:<backend> label on the issue (highest priority)
@@ -1249,6 +1267,18 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 				log.Printf("[orch] skipping issue #%d: retry limit exhausted (%d/%d attempts)",
 					issue.Number, failed, o.cfg.MaxRetriesPerIssue)
 				continue
+			}
+		}
+
+		// Check for open blockers: skip if any referenced blocking issues are still open
+		if len(o.cfg.BlockerPatterns) > 0 {
+			blockers := github.FindBlockers(issue.Body, o.cfg.BlockerPatterns)
+			if len(blockers) > 0 {
+				openBlockers := o.findOpenBlockers(blockers)
+				if len(openBlockers) > 0 {
+					log.Printf("[orch] skipping issue #%d: blocked by open issues %v", issue.Number, openBlockers)
+					continue
+				}
 			}
 		}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3358,3 +3358,120 @@ func TestAvailableSlots_NonRunningLimitIgnoredForDispatch(t *testing.T) {
 		t.Errorf("availableSlots() = %d, want 7 (pr_open limit shouldn't affect dispatch)", got)
 	}
 }
+
+// --- blocker-aware dispatch tests ---
+
+func TestFindOpenBlockers_AllClosed(t *testing.T) {
+	o := &Orchestrator{
+		isIssueClosedFn: func(number int) (bool, error) {
+			return true, nil // all blockers closed
+		},
+	}
+	got := o.findOpenBlockers([]int{10, 20, 30})
+	if len(got) != 0 {
+		t.Errorf("findOpenBlockers() = %v, want empty (all closed)", got)
+	}
+}
+
+func TestFindOpenBlockers_SomeOpen(t *testing.T) {
+	closedIssues := map[int]bool{10: true, 20: false, 30: true}
+	o := &Orchestrator{
+		isIssueClosedFn: func(number int) (bool, error) {
+			return closedIssues[number], nil
+		},
+	}
+	got := o.findOpenBlockers([]int{10, 20, 30})
+	if len(got) != 1 || got[0] != 20 {
+		t.Errorf("findOpenBlockers() = %v, want [20]", got)
+	}
+}
+
+func TestFindOpenBlockers_ErrorAssumesOpen(t *testing.T) {
+	o := &Orchestrator{
+		isIssueClosedFn: func(number int) (bool, error) {
+			return false, fmt.Errorf("network error")
+		},
+	}
+	got := o.findOpenBlockers([]int{42})
+	if len(got) != 1 || got[0] != 42 {
+		t.Errorf("findOpenBlockers() = %v, want [42] (error should assume open)", got)
+	}
+}
+
+func TestFindOpenBlockers_Empty(t *testing.T) {
+	o := &Orchestrator{}
+	got := o.findOpenBlockers(nil)
+	if len(got) != 0 {
+		t.Errorf("findOpenBlockers() = %v, want empty", got)
+	}
+}
+
+func TestStartNewWorkers_SkipsBlockedIssue(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.BlockerPatterns = []string{`blocked by #(\d+)`}
+
+	issues := []github.Issue{
+		{Number: 42, Title: "blocked issue", Body: "This is blocked by #10"},
+		{Number: 43, Title: "free issue", Body: "No blockers here"},
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	// Issue #10 is still open (not closed)
+	o.isIssueClosedFn = func(number int) (bool, error) {
+		return false, nil
+	}
+
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 {
+		t.Fatalf("started %d workers, want 1", len(*started))
+	}
+	if (*started)[0] != 43 {
+		t.Errorf("started issue #%d, want #43", (*started)[0])
+	}
+}
+
+func TestStartNewWorkers_DispatchesWhenBlockersClosed(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.BlockerPatterns = []string{`blocked by #(\d+)`}
+
+	issues := []github.Issue{
+		{Number: 42, Title: "was blocked", Body: "This is blocked by #10"},
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	// Blocker #10 is closed
+	o.isIssueClosedFn = func(number int) (bool, error) {
+		return true, nil
+	}
+
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 {
+		t.Fatalf("started %d workers, want 1 (blocker closed)", len(*started))
+	}
+	if (*started)[0] != 42 {
+		t.Errorf("started issue #%d, want #42", (*started)[0])
+	}
+}
+
+func TestStartNewWorkers_NoPatternsNoBlockerCheck(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	// No blocker_patterns configured
+
+	issues := []github.Issue{
+		{Number: 42, Title: "has blocker text", Body: "blocked by #10"},
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	// Should dispatch because blocker_patterns is empty (feature disabled)
+	if len(*started) != 1 {
+		t.Fatalf("started %d workers, want 1 (no patterns = no check)", len(*started))
+	}
+}


### PR DESCRIPTION
Implements #200

## Changes
- **Config**: Added `blocker_patterns` field (list of regex patterns) to detect blocker references in issue bodies. Empty by default (feature disabled unless configured).
- **GitHub**: Added `FindBlockers()` function that scans issue body text for patterns like "blocked by #N" or "depends on #N" using configurable regex with capture groups. Case-insensitive matching, deduplication of referenced issue numbers.
- **Orchestrator**: Added `findOpenBlockers()` method that checks each referenced blocker issue via `IsIssueClosed()`. Integrated blocker check into `startNewWorkers()` dispatch loop — issues with open blockers are skipped with a log message.
- **Status**: `maestro status` now shows a "Blocked issues" section listing issues that have open blockers, with their blocker references.

## Config example
```yaml
blocker_patterns:
  - "blocked by #(\\d+)"
  - "depends on #(\\d+)"
```

## Testing
- Unit tests for `FindBlockers()`: basic patterns, case insensitivity, deduplication, multiline bodies, empty inputs, invalid regex
- Unit tests for `findOpenBlockers()`: all closed, some open, error handling (assumes open), empty input
- Integration tests for `startNewWorkers`: skips blocked issues, dispatches when blockers closed, no-op when patterns not configured
- Config parsing tests for `blocker_patterns` field
- All existing tests pass (`go test ./...`)
- Binary builds successfully (`go build ./cmd/maestro/`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements blocker-aware dispatch for maestro: issues whose bodies reference open blocking issues (via configurable regex patterns) are now skipped by the orchestrator until those blockers are resolved, and `maestro status` gains a "Blocked issues" section. The overall design is sound — deduplication, case-insensitive matching, safe-default error handling (assume open on failure), and a feature-disabled-by-default approach are all well considered, and test coverage is comprehensive.

Key observations:
- **Silent error swallowing in `maestro status`**: If `ListOpenIssues` fails inside `showProjectStatus`, the entire "Blocked issues" section is silently omitted with no user-visible feedback, making a transient API failure indistinguishable from "no blocked issues."
- **No config-time validation of `blocker_patterns`**: Invalid or misconfigured regex patterns (wrong syntax, missing capture group) are silently skipped at runtime inside `FindBlockers`. Adding validation in `parse()` would surface these errors immediately at startup, consistent with how other config fields are validated.
- **Uncached `IsIssueClosed` API calls per dispatch cycle**: `findOpenBlockers` makes one `gh issue view` subprocess call per blocker reference found across all open issues, on every dispatch tick. Pre-existing feedback about regex recompilation has been noted; the underlying API call overhead is potentially more significant and could be addressed by resolving all unique blocker numbers once per cycle rather than once per issue.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — no functional regressions; the noted issues are improvements to observability, startup validation, and performance rather than correctness bugs.
- The core dispatch logic is correct and well-tested (skip on open blockers, dispatch when closed, no-op when patterns unconfigured, safe error handling). Issues found are style/observability gaps (silent error in status output, no config-time regex validation) and a performance concern (uncached API calls per cycle), none of which affect the correctness of the feature.
- `internal/config/config.go` (missing pattern validation) and `cmd/maestro/main.go` (silent error swallowing in status output) deserve a second look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Adds "Blocked issues" section to `maestro status`; silently swallows the `ListOpenIssues` error, making failures invisible to the user. |
| internal/config/config.go | Adds `BlockerPatterns []string` field; no validation of the regex patterns at parse time, so typos or missing capture groups are only silently dropped at runtime. |
| internal/config/config_test.go | Tests default (empty) and explicit `blocker_patterns` config parsing — correct and thorough. |
| internal/github/github.go | Adds `FindBlockers` with deduplication and case-insensitive matching; recompiles regexes on every call (pre-existing concern already flagged). Logic and deduplication are correct. |
| internal/github/github_test.go | New test file with comprehensive coverage of `FindBlockers` (basic, case-insensitive, dedup, empty, invalid regex, multiline) plus pre-existing `HasLabel` tests. |
| internal/orchestrator/orchestrator.go | Adds `findOpenBlockers` and integrates blocker check into `startNewWorkers`; makes one `gh issue view` API call per blocker per issue per dispatch cycle without intra-cycle caching. |
| internal/orchestrator/orchestrator_test.go | Good integration tests covering skip-when-blocked, dispatch-when-closed, no-patterns-no-check, error-assumes-open, and empty inputs. |

</details>

<sub>Last reviewed commit: 7d2529b</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->