### PR TITLE
feat: dynamic config reload without restart (#198)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/configwatch"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/orchestrator"
@@ -256,8 +257,22 @@ func runCmd(args []string) {
 			}()
 		}
 
-		log.Printf("starting maestro — repo=%s prefix=%s interval=%s once=%v", cfg.Repo, cfg.SessionPrefix, *interval, *once)
-		if err := orch.Run(context.Background(), *interval, *once, refreshCh); err != nil {
+		// Start config file watcher for hot-reload
+		ctx := context.Background()
+		cfgPath := cfg.ResolvePath()
+		if cfgPath != "" {
+			reloadCh := configwatch.Watch(ctx, cfgPath, 2*time.Second)
+			orch.SetConfigReloadCh(reloadCh)
+		}
+
+		// Use config-driven poll interval if set
+		runInterval := *interval
+		if cfg.PollIntervalSeconds > 0 {
+			runInterval = time.Duration(cfg.PollIntervalSeconds) * time.Second
+		}
+
+		log.Printf("starting maestro — repo=%s prefix=%s interval=%s once=%v", cfg.Repo, cfg.SessionPrefix, runInterval, *once)
+		if err := orch.Run(ctx, runInterval, *once, refreshCh); err != nil {
 			log.Fatalf("run: %v", err)
 		}
 		return
@@ -299,8 +314,21 @@ func runCmd(args []string) {
 				}()
 			}
 
-			log.Printf("[%s] starting — repo=%s interval=%s once=%v", c.SessionPrefix, c.Repo, *interval, *once)
-			if err := orch.Run(ctx, *interval, *once, refreshCh); err != nil {
+			// Start config file watcher for hot-reload
+			cfgPath := c.ResolvePath()
+			if cfgPath != "" {
+				reloadCh := configwatch.Watch(ctx, cfgPath, 2*time.Second)
+				orch.SetConfigReloadCh(reloadCh)
+			}
+
+			// Use config-driven poll interval if set
+			runInterval := *interval
+			if c.PollIntervalSeconds > 0 {
+				runInterval = time.Duration(c.PollIntervalSeconds) * time.Second
+			}
+
+			log.Printf("[%s] starting — repo=%s interval=%s once=%v", c.SessionPrefix, c.Repo, runInterval, *once)
+			if err := orch.Run(ctx, runInterval, *once, refreshCh); err != nil {
 				log.Printf("[%s] run error: %v", c.SessionPrefix, err)
 			}
 		}(cfg)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,8 @@ type Config struct {
 	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
 	CleanupWorktreesOnMerge    *bool            `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
 	BlockerPatterns            []string         `yaml:"blocker_patterns"`           // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
+	PollIntervalSeconds        int              `yaml:"poll_interval_seconds"`      // override poll interval from config (0 = use CLI flag)
+	SourcePath                 string           `yaml:"-"`                          // path the config was loaded from (not serialized)
 }
 
 // LoadFrom loads config from a specific path.
@@ -93,7 +95,12 @@ func LoadFrom(path string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read config %s: %w", path, err)
 	}
-	return parse(data)
+	cfg, err := parse(data)
+	if err != nil {
+		return nil, err
+	}
+	cfg.SourcePath = path
+	return cfg, nil
 }
 
 func Load() (*Config, error) {
@@ -115,7 +122,18 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("no config file found (tried maestro.yaml, ~/.maestro/config.yaml): %w", err)
 	}
-	return parse(data)
+	cfg, parseErr := parse(data)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	// Set SourcePath to the candidate that succeeded
+	for _, p := range candidates {
+		if _, e := os.Stat(p); e == nil {
+			cfg.SourcePath = p
+			break
+		}
+	}
+	return cfg, nil
 }
 
 func parse(data []byte) (*Config, error) {
@@ -290,6 +308,25 @@ func (c *Config) ShouldCleanupWorktrees() bool {
 		return true
 	}
 	return *c.CleanupWorktreesOnMerge
+}
+
+// ResolvePath returns the config file path, using SourcePath if set, otherwise the default candidate.
+func (c *Config) ResolvePath() string {
+	if c.SourcePath != "" {
+		return c.SourcePath
+	}
+	candidates := []string{
+		"maestro.yaml",
+		"maestro.yml",
+		filepath.Join(os.Getenv("HOME"), ".maestro", "config.yaml"),
+		filepath.Join(os.Getenv("HOME"), ".maestro", "config.yml"),
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return "maestro.yaml"
 }
 
 func expandHome(path string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -864,6 +864,46 @@ func TestParse_FallbackBackendsDefault(t *testing.T) {
 	}
 }
 
+func TestParse_PollIntervalSecondsDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.PollIntervalSeconds != 0 {
+		t.Errorf("PollIntervalSeconds = %d, want 0", cfg.PollIntervalSeconds)
+	}
+}
+
+func TestParse_PollIntervalSecondsExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+poll_interval_seconds: 300
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.PollIntervalSeconds != 300 {
+		t.Errorf("PollIntervalSeconds = %d, want 300", cfg.PollIntervalSeconds)
+	}
+}
+
+func TestLoadFrom_SetsSourcePath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.yaml")
+	if err := os.WriteFile(path, []byte("repo: owner/repo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if cfg.SourcePath != path {
+		t.Errorf("SourcePath = %q, want %q", cfg.SourcePath, path)
+	}
+}
+
 func TestParse_FallbackBackendsExplicit(t *testing.T) {
 	yaml := `
 repo: owner/repo

--- a/internal/configwatch/watcher.go
+++ b/internal/configwatch/watcher.go
@@ -1,0 +1,65 @@
+package configwatch
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// Watch polls the config file at path for modifications and sends a newly
+// parsed *config.Config on the returned channel whenever the file changes.
+// Invalid YAML is logged and skipped (last good config is retained by caller).
+func Watch(ctx context.Context, path string, pollInterval time.Duration) <-chan *config.Config {
+	ch := make(chan *config.Config, 1)
+	go func() {
+		defer close(ch)
+
+		var lastModTime time.Time
+		if info, err := os.Stat(path); err == nil {
+			lastModTime = info.ModTime()
+		}
+
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+
+		log.Printf("[configwatch] watching %s (poll every %s)", path, pollInterval)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				info, err := os.Stat(path)
+				if err != nil {
+					continue
+				}
+				if !info.ModTime().After(lastModTime) {
+					continue
+				}
+				// Debounce: wait briefly for writes to settle
+				time.Sleep(500 * time.Millisecond)
+				if info2, err := os.Stat(path); err == nil {
+					lastModTime = info2.ModTime()
+				} else {
+					lastModTime = info.ModTime()
+				}
+
+				cfg, err := config.LoadFrom(path)
+				if err != nil {
+					log.Printf("[configwatch] reload failed (keeping previous config): %v", err)
+					continue
+				}
+
+				select {
+				case ch <- cfg:
+				default:
+					// Drop if consumer hasn't drained yet
+				}
+			}
+		}
+	}()
+	return ch
+}

--- a/internal/configwatch/watcher_test.go
+++ b/internal/configwatch/watcher_test.go
@@ -1,0 +1,145 @@
+package configwatch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWatch_DetectsFileChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "maestro.yaml")
+	if err := os.WriteFile(path, []byte("repo: owner/repo\nmax_parallel: 3\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := Watch(ctx, path, 100*time.Millisecond)
+
+	// Wait for initial stat
+	time.Sleep(200 * time.Millisecond)
+
+	// Modify file
+	if err := os.WriteFile(path, []byte("repo: owner/repo\nmax_parallel: 10\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case cfg := <-ch:
+		if cfg.MaxParallel != 10 {
+			t.Errorf("MaxParallel = %d, want 10", cfg.MaxParallel)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for config reload")
+	}
+}
+
+func TestWatch_InvalidYAMLKeepsPrevious(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "maestro.yaml")
+	if err := os.WriteFile(path, []byte("repo: owner/repo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := Watch(ctx, path, 100*time.Millisecond)
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Write invalid YAML
+	if err := os.WriteFile(path, []byte("invalid: [yaml: {broken\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should not receive anything (invalid config is skipped)
+	select {
+	case cfg := <-ch:
+		t.Fatalf("should not receive config for invalid YAML, got %+v", cfg)
+	case <-time.After(1 * time.Second):
+		// Expected — no event for invalid YAML
+	}
+}
+
+func TestWatch_NoChangeNoEvent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "maestro.yaml")
+	if err := os.WriteFile(path, []byte("repo: owner/repo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := Watch(ctx, path, 100*time.Millisecond)
+
+	// No modification — should not receive anything
+	select {
+	case cfg := <-ch:
+		t.Fatalf("should not receive config when file is unchanged, got %+v", cfg)
+	case <-time.After(500 * time.Millisecond):
+		// Expected
+	}
+}
+
+func TestWatch_ContextCancelStops(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "maestro.yaml")
+	if err := os.WriteFile(path, []byte("repo: owner/repo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := Watch(ctx, path, 100*time.Millisecond)
+
+	cancel()
+
+	// Channel should be closed soon after context cancel
+	select {
+	case _, ok := <-ch:
+		if ok {
+			// Got a value before close, that's fine, drain it
+			select {
+			case _, ok := <-ch:
+				if ok {
+					t.Fatal("channel should be closed after context cancel")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("channel not closed after context cancel")
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("channel not closed after context cancel")
+	}
+}
+
+func TestWatch_MissingConfigOnReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "maestro.yaml")
+	if err := os.WriteFile(path, []byte("repo: owner/repo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := Watch(ctx, path, 100*time.Millisecond)
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Remove the file
+	os.Remove(path)
+
+	// Should not receive anything (missing file is skipped)
+	select {
+	case cfg := <-ch:
+		t.Fatalf("should not receive config for missing file, got %+v", cfg)
+	case <-time.After(500 * time.Millisecond):
+		// Expected
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -51,6 +51,9 @@ type Orchestrator struct {
 	listOpenIssuesFn func(labels []string) ([]github.Issue, error)
 	workerStartFn    func(cfg *config.Config, s *state.State, repo string, issue github.Issue, promptBase, backend string) (string, error)
 
+	// Config hot-reload channel (nil = disabled, safe in select)
+	configReloadCh <-chan *config.Config
+
 	// Testing hooks for autoMergePRs / mergeReadyPR
 	ghPRCIStatusFn         func(prNumber int) (string, error)
 	ghPRGreptileApprovedFn func(prNumber int) (approved bool, pending bool, err error)
@@ -399,6 +402,12 @@ func (o *Orchestrator) RunOnce() error {
 	return nil
 }
 
+// SetConfigReloadCh sets the channel used to receive hot-reloaded configs.
+// A nil channel is safe (select case is never chosen).
+func (o *Orchestrator) SetConfigReloadCh(ch <-chan *config.Config) {
+	o.configReloadCh = ch
+}
+
 // Run loops with the given interval; if once=true, runs once and returns.
 // The context can be used to stop the loop (e.g. for multi-project shutdown).
 // An optional refreshCh triggers an immediate poll cycle when a value is received.
@@ -425,8 +434,118 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 			if err := o.RunOnce(); err != nil {
 				log.Printf("[orch] run error: %v", err)
 			}
+		case newCfg := <-o.configReloadCh:
+			o.reloadConfig(newCfg, &ticker)
 		}
 	}
+}
+
+// reloadConfig applies non-destructive config changes at runtime.
+// Fields that require a restart (repo, model.default) are logged as warnings.
+func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker) {
+	old := o.cfg
+	var changed []string
+
+	// Restart-required fields — warn only, do not apply
+	if newCfg.Repo != old.Repo {
+		log.Printf("[orch] config reload: repo changed (%s → %s) — requires restart", old.Repo, newCfg.Repo)
+	}
+	if newCfg.Model.Default != old.Model.Default {
+		log.Printf("[orch] config reload: model.default changed (%s → %s) — requires restart", old.Model.Default, newCfg.Model.Default)
+	}
+
+	// Hot-reloadable fields
+	if newCfg.MaxParallel != old.MaxParallel {
+		changed = append(changed, fmt.Sprintf("max_parallel: %d→%d", old.MaxParallel, newCfg.MaxParallel))
+		o.cfg.MaxParallel = newCfg.MaxParallel
+	}
+	if newCfg.MaxRuntimeMinutes != old.MaxRuntimeMinutes {
+		changed = append(changed, fmt.Sprintf("max_runtime_minutes: %d→%d", old.MaxRuntimeMinutes, newCfg.MaxRuntimeMinutes))
+		o.cfg.MaxRuntimeMinutes = newCfg.MaxRuntimeMinutes
+	}
+	if newCfg.MaxRetriesPerIssue != old.MaxRetriesPerIssue {
+		changed = append(changed, fmt.Sprintf("max_retries_per_issue: %d→%d", old.MaxRetriesPerIssue, newCfg.MaxRetriesPerIssue))
+		o.cfg.MaxRetriesPerIssue = newCfg.MaxRetriesPerIssue
+	}
+	if newCfg.WorkerSilentTimeoutMinutes != old.WorkerSilentTimeoutMinutes {
+		changed = append(changed, fmt.Sprintf("worker_silent_timeout_minutes: %d→%d", old.WorkerSilentTimeoutMinutes, newCfg.WorkerSilentTimeoutMinutes))
+		o.cfg.WorkerSilentTimeoutMinutes = newCfg.WorkerSilentTimeoutMinutes
+	}
+	if newCfg.WorkerMaxTokens != old.WorkerMaxTokens {
+		changed = append(changed, fmt.Sprintf("worker_max_tokens: %d→%d", old.WorkerMaxTokens, newCfg.WorkerMaxTokens))
+		o.cfg.WorkerMaxTokens = newCfg.WorkerMaxTokens
+	}
+	if !strSliceEqual(newCfg.IssueLabels, old.IssueLabels) {
+		changed = append(changed, fmt.Sprintf("issue_labels: %v→%v", old.IssueLabels, newCfg.IssueLabels))
+		o.cfg.IssueLabels = newCfg.IssueLabels
+	}
+	if !strSliceEqual(newCfg.ExcludeLabels, old.ExcludeLabels) {
+		changed = append(changed, fmt.Sprintf("exclude_labels: %v→%v", old.ExcludeLabels, newCfg.ExcludeLabels))
+		o.cfg.ExcludeLabels = newCfg.ExcludeLabels
+	}
+	if newCfg.MergeStrategy != old.MergeStrategy {
+		changed = append(changed, fmt.Sprintf("merge_strategy: %s→%s", old.MergeStrategy, newCfg.MergeStrategy))
+		o.cfg.MergeStrategy = newCfg.MergeStrategy
+	}
+	if newCfg.MergeIntervalSeconds != old.MergeIntervalSeconds {
+		changed = append(changed, fmt.Sprintf("merge_interval_seconds: %d→%d", old.MergeIntervalSeconds, newCfg.MergeIntervalSeconds))
+		o.cfg.MergeIntervalSeconds = newCfg.MergeIntervalSeconds
+	}
+	if newCfg.DeployCmd != old.DeployCmd {
+		changed = append(changed, fmt.Sprintf("deploy_cmd: %q→%q", old.DeployCmd, newCfg.DeployCmd))
+		o.cfg.DeployCmd = newCfg.DeployCmd
+	}
+	if newCfg.DeployTimeoutMinutes != old.DeployTimeoutMinutes {
+		changed = append(changed, fmt.Sprintf("deploy_timeout_minutes: %d→%d", old.DeployTimeoutMinutes, newCfg.DeployTimeoutMinutes))
+		o.cfg.DeployTimeoutMinutes = newCfg.DeployTimeoutMinutes
+	}
+	if newCfg.AutoRebase != old.AutoRebase {
+		changed = append(changed, fmt.Sprintf("auto_rebase: %v→%v", old.AutoRebase, newCfg.AutoRebase))
+		o.cfg.AutoRebase = newCfg.AutoRebase
+	}
+
+	// Reload prompt files if paths changed
+	if newCfg.WorkerPrompt != old.WorkerPrompt {
+		changed = append(changed, fmt.Sprintf("worker_prompt: %q→%q", old.WorkerPrompt, newCfg.WorkerPrompt))
+		o.cfg.WorkerPrompt = newCfg.WorkerPrompt
+		o.LoadPromptBase("")
+	}
+	if newCfg.BugPrompt != old.BugPrompt {
+		changed = append(changed, fmt.Sprintf("bug_prompt: %q→%q", old.BugPrompt, newCfg.BugPrompt))
+		o.cfg.BugPrompt = newCfg.BugPrompt
+		o.LoadPromptBase("")
+	}
+	if newCfg.EnhancementPrompt != old.EnhancementPrompt {
+		changed = append(changed, fmt.Sprintf("enhancement_prompt: %q→%q", old.EnhancementPrompt, newCfg.EnhancementPrompt))
+		o.cfg.EnhancementPrompt = newCfg.EnhancementPrompt
+		o.LoadPromptBase("")
+	}
+
+	// Poll interval change — reset the ticker
+	if newCfg.PollIntervalSeconds != old.PollIntervalSeconds && newCfg.PollIntervalSeconds > 0 {
+		newInterval := time.Duration(newCfg.PollIntervalSeconds) * time.Second
+		changed = append(changed, fmt.Sprintf("poll_interval_seconds: %d→%d", old.PollIntervalSeconds, newCfg.PollIntervalSeconds))
+		o.cfg.PollIntervalSeconds = newCfg.PollIntervalSeconds
+		(*ticker).Reset(newInterval)
+	}
+
+	if len(changed) == 0 {
+		log.Printf("[orch] config reloaded — no effective changes")
+		return
+	}
+	log.Printf("[orch] config reloaded — changed: %s", strings.Join(changed, ", "))
+}
+
+func strSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // reconcileRunningSessions self-heals stale "running" sessions.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -3255,14 +3256,11 @@ func TestAvailableSlots_RunningLimitCapsSlots(t *testing.T) {
 		MaxConcurrentByState: map[string]int{"running": 3},
 	}
 	s := state.NewState()
-	// 2 running, 2 pr_open = 4 active
 	s.Sessions["slot-1"] = &state.Session{Status: state.StatusRunning}
 	s.Sessions["slot-2"] = &state.Session{Status: state.StatusRunning}
 	s.Sessions["slot-3"] = &state.Session{Status: state.StatusPROpen}
 	s.Sessions["slot-4"] = &state.Session{Status: state.StatusPROpen}
 
-	// Global: 10 - 4 = 6 slots
-	// Per-state running: 3 - 2 = 1 slot (more restrictive)
 	got := availableSlots(cfg, s, 4)
 	if got != 1 {
 		t.Errorf("availableSlots() = %d, want 1 (running limit should cap)", got)
@@ -3275,7 +3273,6 @@ func TestAvailableSlots_RunningLimitExceeded(t *testing.T) {
 		MaxConcurrentByState: map[string]int{"running": 2},
 	}
 	s := state.NewState()
-	// 3 running, exceeds limit of 2
 	s.Sessions["slot-1"] = &state.Session{Status: state.StatusRunning}
 	s.Sessions["slot-2"] = &state.Session{Status: state.StatusRunning}
 	s.Sessions["slot-3"] = &state.Session{Status: state.StatusRunning}
@@ -3292,14 +3289,11 @@ func TestAvailableSlots_GlobalLimitMoreRestrictive(t *testing.T) {
 		MaxConcurrentByState: map[string]int{"running": 10},
 	}
 	s := state.NewState()
-	// 3 running, 1 pr_open = 4 active
 	s.Sessions["slot-1"] = &state.Session{Status: state.StatusRunning}
 	s.Sessions["slot-2"] = &state.Session{Status: state.StatusRunning}
 	s.Sessions["slot-3"] = &state.Session{Status: state.StatusRunning}
 	s.Sessions["slot-4"] = &state.Session{Status: state.StatusPROpen}
 
-	// Global: 5 - 4 = 1 slot
-	// Per-state running: 10 - 3 = 7 (less restrictive)
 	got := availableSlots(cfg, s, 4)
 	if got != 1 {
 		t.Errorf("availableSlots() = %d, want 1 (global limit should cap)", got)
@@ -3329,19 +3323,16 @@ func TestAvailableSlots_TerminalSessionsIgnored(t *testing.T) {
 	}
 	s := state.NewState()
 	s.Sessions["slot-1"] = &state.Session{Status: state.StatusRunning}
-	s.Sessions["slot-2"] = &state.Session{Status: state.StatusDone}   // terminal
-	s.Sessions["slot-3"] = &state.Session{Status: state.StatusFailed} // terminal
+	s.Sessions["slot-2"] = &state.Session{Status: state.StatusDone}
+	s.Sessions["slot-3"] = &state.Session{Status: state.StatusFailed}
 
-	// Only 1 active (running), terminal sessions don't count
 	got := availableSlots(cfg, s, 1)
-	// Global: 10 - 1 = 9, per-state running: 3 - 1 = 2
 	if got != 2 {
 		t.Errorf("availableSlots() = %d, want 2", got)
 	}
 }
 
 func TestAvailableSlots_NonRunningLimitIgnoredForDispatch(t *testing.T) {
-	// pr_open limit shouldn't affect how many new workers can start
 	cfg := &config.Config{
 		MaxParallel:          10,
 		MaxConcurrentByState: map[string]int{"pr_open": 1},
@@ -3351,8 +3342,6 @@ func TestAvailableSlots_NonRunningLimitIgnoredForDispatch(t *testing.T) {
 	s.Sessions["slot-2"] = &state.Session{Status: state.StatusPROpen}
 	s.Sessions["slot-3"] = &state.Session{Status: state.StatusPROpen}
 
-	// Global: 10 - 3 = 7
-	// No running limit configured, so all 7 available
 	got := availableSlots(cfg, s, 3)
 	if got != 7 {
 		t.Errorf("availableSlots() = %d, want 7 (pr_open limit shouldn't affect dispatch)", got)
@@ -3473,5 +3462,215 @@ func TestStartNewWorkers_NoPatternsNoBlockerCheck(t *testing.T) {
 	// Should dispatch because blocker_patterns is empty (feature disabled)
 	if len(*started) != 1 {
 		t.Fatalf("started %d workers, want 1 (no patterns = no check)", len(*started))
+	}
+}
+
+func TestReloadConfig_AppliesReloadableFields(t *testing.T) {
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxParallel:        5,
+		MaxRuntimeMinutes:  120,
+		MaxRetriesPerIssue: 3,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: notify.NewWithToken("", "", ""),
+		router:   router.New(cfg),
+	}
+
+	newCfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxParallel:        10,
+		MaxRuntimeMinutes:  60,
+		MaxRetriesPerIssue: 5,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	o.reloadConfig(newCfg, &ticker)
+
+	if o.cfg.MaxParallel != 10 {
+		t.Errorf("MaxParallel = %d, want 10", o.cfg.MaxParallel)
+	}
+	if o.cfg.MaxRuntimeMinutes != 60 {
+		t.Errorf("MaxRuntimeMinutes = %d, want 60", o.cfg.MaxRuntimeMinutes)
+	}
+	if o.cfg.MaxRetriesPerIssue != 5 {
+		t.Errorf("MaxRetriesPerIssue = %d, want 5", o.cfg.MaxRetriesPerIssue)
+	}
+}
+
+func TestReloadConfig_PollIntervalChange(t *testing.T) {
+	cfg := &config.Config{
+		Repo:                "owner/repo",
+		PollIntervalSeconds: 600,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: notify.NewWithToken("", "", ""),
+		router:   router.New(cfg),
+	}
+
+	newCfg := &config.Config{
+		Repo:                "owner/repo",
+		PollIntervalSeconds: 300,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	o.reloadConfig(newCfg, &ticker)
+
+	if o.cfg.PollIntervalSeconds != 300 {
+		t.Errorf("PollIntervalSeconds = %d, want 300", o.cfg.PollIntervalSeconds)
+	}
+}
+
+func TestReloadConfig_NoChanges(t *testing.T) {
+	cfg := &config.Config{
+		Repo:        "owner/repo",
+		MaxParallel: 5,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: notify.NewWithToken("", "", ""),
+		router:   router.New(cfg),
+	}
+
+	newCfg := &config.Config{
+		Repo:        "owner/repo",
+		MaxParallel: 5,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	// Should not panic or change anything
+	o.reloadConfig(newCfg, &ticker)
+
+	if o.cfg.MaxParallel != 5 {
+		t.Errorf("MaxParallel = %d, want 5 (unchanged)", o.cfg.MaxParallel)
+	}
+}
+
+func TestReloadConfig_IssueLabelsUpdated(t *testing.T) {
+	cfg := &config.Config{
+		Repo:        "owner/repo",
+		IssueLabels: []string{"bug"},
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: notify.NewWithToken("", "", ""),
+		router:   router.New(cfg),
+	}
+
+	newCfg := &config.Config{
+		Repo:        "owner/repo",
+		IssueLabels: []string{"bug", "enhancement"},
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	o.reloadConfig(newCfg, &ticker)
+
+	if len(o.cfg.IssueLabels) != 2 || o.cfg.IssueLabels[1] != "enhancement" {
+		t.Errorf("IssueLabels = %v, want [bug enhancement]", o.cfg.IssueLabels)
+	}
+}
+
+func TestReloadConfig_PromptPathReload(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := dir + "/prompt.md"
+	os.WriteFile(promptFile, []byte("new prompt content"), 0644)
+
+	cfg := &config.Config{
+		Repo:         "owner/repo",
+		WorkerPrompt: "/old/path.md",
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+	o := &Orchestrator{
+		cfg:        cfg,
+		repo:       cfg.Repo,
+		promptBase: "old prompt",
+		notifier:   notify.NewWithToken("", "", ""),
+		router:     router.New(cfg),
+	}
+
+	newCfg := &config.Config{
+		Repo:         "owner/repo",
+		WorkerPrompt: promptFile,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	o.reloadConfig(newCfg, &ticker)
+
+	if o.cfg.WorkerPrompt != promptFile {
+		t.Errorf("WorkerPrompt = %q, want %q", o.cfg.WorkerPrompt, promptFile)
+	}
+	if o.promptBase != "new prompt content" {
+		t.Errorf("promptBase = %q, want %q", o.promptBase, "new prompt content")
+	}
+}
+
+func TestStrSliceEqual(t *testing.T) {
+	tests := []struct {
+		a, b []string
+		want bool
+	}{
+		{nil, nil, true},
+		{[]string{}, []string{}, true},
+		{[]string{"a"}, []string{"a"}, true},
+		{[]string{"a", "b"}, []string{"a", "b"}, true},
+		{[]string{"a"}, []string{"b"}, false},
+		{[]string{"a"}, []string{"a", "b"}, false},
+		{nil, []string{"a"}, false},
+	}
+	for _, tt := range tests {
+		got := strSliceEqual(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("strSliceEqual(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add polling-based config file watcher (`configwatch` package) that monitors `maestro.yaml` for changes every 2 seconds
- Hot-reload non-destructive config fields at runtime: `max_parallel`, `max_runtime_minutes`, `max_retries_per_issue`, `worker_silent_timeout_minutes`, `worker_max_tokens`, `issue_labels`, `exclude_labels`, `merge_strategy`, `merge_interval_seconds`, `deploy_cmd`, `deploy_timeout_minutes`, `auto_rebase`, prompt paths, and `poll_interval_seconds`
- Restart-required fields (`repo`, `model.default`) log warnings but are not applied
- Invalid YAML on reload keeps last known good config and logs an error
- Add `poll_interval_seconds` config field to override poll interval from config
- Wire up watcher in both single-project and multi-project run modes

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — all tests pass
- [x] Config watcher tests: file change detection, invalid YAML skipping, no-change no-event, context cancel cleanup, missing file handling
- [x] Orchestrator reload tests: reloadable fields applied, poll interval change resets ticker, no-change is no-op, issue labels updated, prompt path reload reads new file
- [x] Config tests: PollIntervalSeconds default/explicit, LoadFrom sets SourcePath
- [x] strSliceEqual helper tests

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a polling-based config hot-reload system: a new `configwatch` package watches `maestro.yaml` for modifications every 2 seconds, and the orchestrator's `Run` loop applies non-destructive field changes at runtime while logging warnings for restart-required fields (`repo`, `model.default`). The overall design is sound and well-tested, but there are a few correctness and efficiency issues to address:

- **Logic bug** – `poll_interval_seconds` reverting to `0` in the config does not reset the orchestrator ticker back to the CLI-specified interval. The initial CLI interval is never stored, leaving the orchestrator permanently stuck at the last non-zero custom value with no way to recover without restarting.
- **Redundant disk reads** – When `worker_prompt`, `bug_prompt`, and `enhancement_prompt` all change in a single reload, `LoadPromptBase("")` is called three times, reading all prompt files from disk on each call instead of once.
- **Order-sensitive label comparison** – `strSliceEqual` compares `IssueLabels` / `ExcludeLabels` positionally, so reordering entries in the YAML without changing semantics triggers an unnecessary reload event.
- **Unconditional watcher start in --once mode** – The `cfgPath != ""` guard is always true since `ResolvePath()` returns `"maestro.yaml"` as a fallback, so a watcher goroutine is started even when not needed in `--once` mode.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with caution; one logic bug and three efficiency/design issues should be addressed before relying on the hot-reload feature in production.
- The feature is well-structured and thoroughly tested. The watcher goroutine is context-aware and the reload path is serialized within the orchestrator event loop, avoiding data races. However, there are four specific issues: (1) a logic bug where `poll_interval_seconds` reverting to 0 leaves no way to restore the CLI interval, (2) redundant disk reads when all three prompt paths change, (3) order-sensitive label comparison triggering unnecessary reloads, and (4) wasteful watcher startup in `--once` mode. The logic bug (#1) should be prioritized for fixing before using dynamic poll interval changes in production.
- internal/orchestrator/orchestrator.go (three issues: poll_interval revert, redundant LoadPromptBase calls, order-sensitive label comparison) and cmd/maestro/main.go (unconditional watcher startup).

<sub>Last reviewed commit: b44e956</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->