### PR TITLE
feat: exponential retry backoff for failed agent sessions (#197)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -461,7 +461,12 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 		age := time.Since(sess.StartedAt).Round(time.Minute)
 		retries := "-"
 		if sess.RetryCount > 0 {
-			retries = fmt.Sprintf("%d", sess.RetryCount)
+			if sess.NextRetryAt != nil && time.Now().Before(*sess.NextRetryAt) {
+				remaining := time.Until(*sess.NextRetryAt).Round(time.Second)
+				retries = fmt.Sprintf("%d (in %s)", sess.RetryCount, remaining)
+			} else {
+				retries = fmt.Sprintf("%d", sess.RetryCount)
+			}
 		}
 		pr := "-"
 		if sess.PRNumber > 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,7 @@ type Config struct {
 	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
 	Telegram                   TelegramConfig   `yaml:"telegram"`
 	Versioning                 VersioningConfig `yaml:"versioning"`
+	MaxRetryBackoffMs          int              `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
 	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
 	CleanupWorktreesOnMerge    *bool            `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
 	BlockerPatterns            []string         `yaml:"blocker_patterns"`           // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
@@ -209,6 +210,11 @@ func parse(data []byte) (*Config, error) {
 	if cfg.StateDir == "" {
 		hash := fmt.Sprintf("%x", md5.Sum([]byte(cfg.Repo)))[:12]
 		cfg.StateDir = filepath.Join(os.Getenv("HOME"), ".maestro", hash)
+	}
+
+	// Default max_retry_backoff_ms: 300000 (5 minutes)
+	if cfg.MaxRetryBackoffMs <= 0 {
+		cfg.MaxRetryBackoffMs = 300000
 	}
 
 	if cfg.Telegram.OpenclawURL == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -990,3 +990,28 @@ max_concurrent_by_state:
 		t.Errorf("pr_open = %d, want 2 (key should be normalized to lowercase)", cfg.MaxConcurrentByState["pr_open"])
 	}
 }
+
+func TestParse_MaxRetryBackoffMsDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.MaxRetryBackoffMs != 300000 {
+		t.Errorf("MaxRetryBackoffMs = %d, want 300000", cfg.MaxRetryBackoffMs)
+	}
+}
+
+func TestParse_MaxRetryBackoffMsExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+max_retry_backoff_ms: 60000
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.MaxRetryBackoffMs != 60000 {
+		t.Errorf("MaxRetryBackoffMs = %d, want 60000", cfg.MaxRetryBackoffMs)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -293,6 +293,73 @@ func countSilentTimeoutKillsForIssue(s *state.State, issueNumber int) int {
 	return count
 }
 
+// retryBackoffMs computes the exponential backoff delay for a retry attempt.
+// Formula: min(10000 * 2^(attempt-1), maxRetryBackoffMs).
+// attempt is 1-based (the first retry is attempt 1).
+func retryBackoffMs(attempt, maxRetryBackoffMs int) int {
+	if attempt <= 0 {
+		attempt = 1
+	}
+	delay := 10000 // 10 seconds base
+	for i := 1; i < attempt; i++ {
+		delay *= 2
+		if delay > maxRetryBackoffMs {
+			return maxRetryBackoffMs
+		}
+	}
+	if delay > maxRetryBackoffMs {
+		return maxRetryBackoffMs
+	}
+	return delay
+}
+
+// respawnDueRetries checks dead sessions with a scheduled retry time and
+// respawns them when the backoff period has elapsed.
+func (o *Orchestrator) respawnDueRetries(s *state.State) {
+	for slotName, sess := range s.Sessions {
+		if sess.Status != state.StatusDead {
+			continue
+		}
+		if sess.NextRetryAt == nil {
+			continue
+		}
+		if time.Now().UTC().Before(*sess.NextRetryAt) {
+			log.Printf("[orch] worker %s retry %d waiting until %s",
+				slotName, sess.RetryCount, sess.NextRetryAt.Format(time.RFC3339))
+			continue
+		}
+
+		// Backoff elapsed — respawn the worker
+		log.Printf("[orch] worker %s backoff elapsed, respawning (retry %d)", slotName, sess.RetryCount)
+		sess.NextRetryAt = nil
+
+		issue, err := o.getIssue(sess.IssueNumber)
+		if err != nil {
+			log.Printf("[orch] fetch issue #%d for retry: %v — marking as failed", sess.IssueNumber, err)
+			sess.Status = state.StatusFailed
+			now := time.Now().UTC()
+			sess.FinishedAt = &now
+			o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) retry failed (could not fetch issue)",
+				slotName, sess.IssueNumber, sess.IssueTitle)
+			continue
+		}
+
+		promptBase := o.selectPrompt(issue)
+		if err := o.respawnWorker(slotName, sess, issue, promptBase, sess.Backend); err != nil {
+			log.Printf("[orch] respawn worker %s: %v — marking as failed", slotName, err)
+			sess.Status = state.StatusFailed
+			now := time.Now().UTC()
+			sess.FinishedAt = &now
+			o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) respawn failed: %v",
+				slotName, sess.IssueNumber, sess.IssueTitle, err)
+			continue
+		}
+
+		o.notifier.Sendf("🔄 maestro: retrying worker %s for issue #%d: %s (attempt %d)",
+			slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount)
+	}
+}
+
 // LoadPromptBase reads the worker prompt template from config or a provided path.
 // Priority: 1) explicit promptPath arg, 2) cfg.WorkerPrompt, 3) built-in fallback.
 // Also loads optional bug_prompt and enhancement_prompt from config.
@@ -369,6 +436,9 @@ func (o *Orchestrator) RunOnce() error {
 
 	// Step 2: Check running sessions for dead processes / stale / closed issues
 	o.checkSessions(s)
+
+	// Step 2b: Respawn dead sessions whose backoff has elapsed
+	o.respawnDueRetries(s)
 
 	// Step 3: Auto-merge green PRs
 	o.autoMergePRs(s)
@@ -741,34 +811,18 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) rate-limited on %s, switched to %s",
 						slotName, sess.IssueNumber, sess.TriedBackends[len(sess.TriedBackends)-1], nextBackend)
 				} else if sess.RetryCount < 1 {
-					// First failure — retry with fresh worktree
-					log.Printf("[orch] worker %s (pid=%d) died, retrying (attempt %d)", slotName, sess.PID, sess.RetryCount+1)
+					// First failure — schedule retry with exponential backoff
 					sess.RetryCount++
-
-					issue, err := o.getIssue(sess.IssueNumber)
-					if err != nil {
-						log.Printf("[orch] fetch issue #%d for retry: %v — marking as failed", sess.IssueNumber, err)
-						sess.Status = state.StatusFailed
-						now := time.Now().UTC()
-						sess.FinishedAt = &now
-						o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) died and retry failed (could not fetch issue)",
-							slotName, sess.IssueNumber, sess.IssueTitle)
-						continue
-					}
-
-					promptBase := o.selectPrompt(issue)
-					if err := o.respawnWorker(slotName, sess, issue, promptBase, sess.Backend); err != nil {
-						log.Printf("[orch] respawn worker %s: %v — marking as failed", slotName, err)
-						sess.Status = state.StatusFailed
-						now := time.Now().UTC()
-						sess.FinishedAt = &now
-						o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) died and respawn failed: %v",
-							slotName, sess.IssueNumber, sess.IssueTitle, err)
-						continue
-					}
-
-					o.notifier.Sendf("🔄 maestro: retrying worker %s for issue #%d: %s (attempt %d)",
-						slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount)
+					backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
+					retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
+					sess.NextRetryAt = &retryAt
+					sess.Status = state.StatusDead
+					now := time.Now().UTC()
+					sess.FinishedAt = &now
+					log.Printf("[orch] worker %s (pid=%d) died, scheduling retry %d in %dms",
+						slotName, sess.PID, sess.RetryCount, backoffMs)
+					o.notifier.Sendf("🔄 maestro: worker %s (issue #%d: %s) died, retry %d scheduled in %ds",
+						slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
 				} else {
 					// Already retried — mark as permanently failed
 					log.Printf("[orch] worker %s (pid=%d) permanently failed after %d retries", slotName, sess.PID, sess.RetryCount)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3061,12 +3061,15 @@ func TestCheckSessions_RateLimitNoFallbackAvailable_NormalRetry(t *testing.T) {
 	o.checkSessions(s)
 
 	sess2 := s.Sessions["mae-1"]
-	// Should fall through to normal retry (RetryCount < 1)
-	if sess2.Status != state.StatusRunning {
-		t.Fatalf("status = %q, want %q (should fall through to normal retry)", sess2.Status, state.StatusRunning)
+	// Should schedule retry with backoff (not immediate respawn)
+	if sess2.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (should schedule backoff)", sess2.Status, state.StatusDead)
 	}
-	if len(*respawned) != 1 || (*respawned)[0] != "gemini" {
-		t.Fatalf("respawned = %v, want [gemini] (normal retry with same backend)", *respawned)
+	if sess2.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set for scheduled retry")
+	}
+	if len(*respawned) != 0 {
+		t.Fatalf("respawned = %v, want [] (retry is scheduled, not immediate)", *respawned)
 	}
 	if sess2.RetryCount != 1 {
 		t.Fatalf("retry_count = %d, want 1", sess2.RetryCount)
@@ -3096,12 +3099,15 @@ func TestCheckSessions_NoRateLimit_NormalRetry(t *testing.T) {
 	o.checkSessions(s)
 
 	sess2 := s.Sessions["mae-1"]
-	if sess2.Status != state.StatusRunning {
-		t.Fatalf("status = %q, want %q", sess2.Status, state.StatusRunning)
+	// Should schedule retry with backoff (not immediate respawn)
+	if sess2.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (should schedule backoff)", sess2.Status, state.StatusDead)
 	}
-	// Should retry with same backend (normal retry), not fallback
-	if len(*respawned) != 1 || (*respawned)[0] != "claude" {
-		t.Fatalf("respawned = %v, want [claude] (normal retry, not fallback)", *respawned)
+	if sess2.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set for scheduled retry")
+	}
+	if len(*respawned) != 0 {
+		t.Fatalf("respawned = %v, want [] (retry is scheduled, not immediate)", *respawned)
 	}
 	if sess2.RetryCount != 1 {
 		t.Fatalf("retry_count = %d, want 1", sess2.RetryCount)
@@ -3131,12 +3137,15 @@ func TestCheckSessions_RateLimitNoFallbackConfigured_NormalRetry(t *testing.T) {
 	o.checkSessions(s)
 
 	sess2 := s.Sessions["mae-1"]
-	// No fallback backends configured, so should fall through to normal retry
-	if sess2.Status != state.StatusRunning {
-		t.Fatalf("status = %q, want %q", sess2.Status, state.StatusRunning)
+	// No fallback backends configured, so should schedule retry with backoff
+	if sess2.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (should schedule backoff)", sess2.Status, state.StatusDead)
 	}
-	if len(*respawned) != 1 || (*respawned)[0] != "claude" {
-		t.Fatalf("respawned = %v, want [claude]", *respawned)
+	if sess2.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set for scheduled retry")
+	}
+	if len(*respawned) != 0 {
+		t.Fatalf("respawned = %v, want [] (retry is scheduled, not immediate)", *respawned)
 	}
 	if sess2.RetryCount != 1 {
 		t.Fatalf("retry_count = %d, want 1", sess2.RetryCount)
@@ -3672,5 +3681,320 @@ func TestStrSliceEqual(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("strSliceEqual(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
 		}
+	}
+}
+
+// --- exponential retry backoff tests ---
+
+func TestRetryBackoffMs_FirstAttempt(t *testing.T) {
+	// attempt=1: 10000 * 2^0 = 10000ms
+	got := retryBackoffMs(1, 300000)
+	if got != 10000 {
+		t.Errorf("retryBackoffMs(1, 300000) = %d, want 10000", got)
+	}
+}
+
+func TestRetryBackoffMs_SecondAttempt(t *testing.T) {
+	// attempt=2: 10000 * 2^1 = 20000ms
+	got := retryBackoffMs(2, 300000)
+	if got != 20000 {
+		t.Errorf("retryBackoffMs(2, 300000) = %d, want 20000", got)
+	}
+}
+
+func TestRetryBackoffMs_ThirdAttempt(t *testing.T) {
+	// attempt=3: 10000 * 2^2 = 40000ms
+	got := retryBackoffMs(3, 300000)
+	if got != 40000 {
+		t.Errorf("retryBackoffMs(3, 300000) = %d, want 40000", got)
+	}
+}
+
+func TestRetryBackoffMs_CappedAtMax(t *testing.T) {
+	// attempt=10: 10000 * 2^9 = 5120000 > 300000, should be capped
+	got := retryBackoffMs(10, 300000)
+	if got != 300000 {
+		t.Errorf("retryBackoffMs(10, 300000) = %d, want 300000 (capped)", got)
+	}
+}
+
+func TestRetryBackoffMs_ZeroAttempt(t *testing.T) {
+	// attempt=0 should be treated as 1
+	got := retryBackoffMs(0, 300000)
+	if got != 10000 {
+		t.Errorf("retryBackoffMs(0, 300000) = %d, want 10000", got)
+	}
+}
+
+func TestRetryBackoffMs_SmallCap(t *testing.T) {
+	// cap of 5000ms should limit even the first attempt
+	got := retryBackoffMs(1, 5000)
+	if got != 5000 {
+		t.Errorf("retryBackoffMs(1, 5000) = %d, want 5000 (capped)", got)
+	}
+}
+
+func TestCheckSessions_DeadWorkerSchedulesRetryWithBackoff(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRetryBackoffMs: 300000,
+		MaxRuntimeMinutes: 999,
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return false // worker is dead
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-10"] = &state.Session{
+		IssueNumber: 110,
+		IssueTitle:  "test backoff",
+		Status:      state.StatusRunning,
+		PID:         9876,
+		TmuxSession: "maestro-mae-10",
+		Branch:      "feat/mae-10-110-test",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+		RetryCount:  0,
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-10"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.RetryCount != 1 {
+		t.Fatalf("retry_count = %d, want 1", sess.RetryCount)
+	}
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set for scheduled retry")
+	}
+	// NextRetryAt should be ~10s in the future (10000ms for attempt 1)
+	until := time.Until(*sess.NextRetryAt)
+	if until < 5*time.Second || until > 15*time.Second {
+		t.Errorf("NextRetryAt should be ~10s from now, got %s", until)
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("FinishedAt should be set")
+	}
+}
+
+func TestCheckSessions_AlreadyRetriedWorkerFails(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRetryBackoffMs: 300000,
+		MaxRuntimeMinutes: 999,
+	}
+	labeled := make([]string, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return false // worker is dead
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labeled = append(labeled, label)
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-11"] = &state.Session{
+		IssueNumber: 111,
+		IssueTitle:  "already retried",
+		Status:      state.StatusRunning,
+		PID:         8765,
+		TmuxSession: "maestro-mae-11",
+		Branch:      "feat/mae-11-111-test",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+		RetryCount:  1, // already retried once
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-11"]
+	if sess.Status != state.StatusFailed {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusFailed)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt should be nil for permanently failed session")
+	}
+	found := false
+	for _, label := range labeled {
+		if label == "blocked" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'blocked' label to be added on permanent failure")
+	}
+}
+
+func TestRespawnDueRetries_BackoffElapsed_Respawns(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRetryBackoffMs: 300000,
+		MaxRuntimeMinutes: 999,
+	}
+	respawned := false
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "test prompt",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return makeIssue(number, "test issue"), nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawned = true
+			sess.Status = state.StatusRunning
+			sess.PID = 5555
+			return nil
+		},
+	}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second) // backoff already elapsed
+	s := state.NewState()
+	s.Sessions["mae-12"] = &state.Session{
+		IssueNumber: 112,
+		IssueTitle:  "test issue",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/mae-12-112-test",
+	}
+
+	o.respawnDueRetries(s)
+
+	if !respawned {
+		t.Fatal("expected worker to be respawned after backoff elapsed")
+	}
+	sess := s.Sessions["mae-12"]
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt should be nil after respawn")
+	}
+	if sess.Status != state.StatusRunning {
+		t.Errorf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+}
+
+func TestRespawnDueRetries_BackoffNotElapsed_Waits(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRetryBackoffMs: 300000,
+	}
+	respawned := false
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawned = true
+			return nil
+		},
+	}
+
+	futureTime := time.Now().UTC().Add(1 * time.Hour) // backoff not yet elapsed
+	s := state.NewState()
+	s.Sessions["mae-13"] = &state.Session{
+		IssueNumber: 113,
+		IssueTitle:  "waiting",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &futureTime,
+		Branch:      "feat/mae-13-113-test",
+	}
+
+	o.respawnDueRetries(s)
+
+	if respawned {
+		t.Fatal("worker should NOT be respawned while backoff is still pending")
+	}
+	sess := s.Sessions["mae-13"]
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should still be set while waiting")
+	}
+	if sess.Status != state.StatusDead {
+		t.Errorf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+}
+
+func TestRespawnDueRetries_RespawnFails_MarksAsFailed(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRetryBackoffMs: 300000,
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		getIssueFn: func(number int) (github.Issue, error) {
+			return makeIssue(number, "test"), nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			return fmt.Errorf("respawn error")
+		},
+	}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	s := state.NewState()
+	s.Sessions["mae-14"] = &state.Session{
+		IssueNumber: 114,
+		IssueTitle:  "will fail",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/mae-14-114-test",
+	}
+
+	o.respawnDueRetries(s)
+
+	sess := s.Sessions["mae-14"]
+	if sess.Status != state.StatusFailed {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusFailed)
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("FinishedAt should be set on failure")
+	}
+}
+
+func TestIssueInProgress_DeadWithPendingRetry(t *testing.T) {
+	s := state.NewState()
+	futureTime := time.Now().UTC().Add(1 * time.Hour)
+	s.Sessions["mae-15"] = &state.Session{
+		IssueNumber: 115,
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &futureTime,
+	}
+
+	if !s.IssueInProgress(115) {
+		t.Fatal("IssueInProgress should return true for dead session with pending retry")
+	}
+}
+
+func TestIssueInProgress_DeadWithoutRetry(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["mae-16"] = &state.Session{
+		IssueNumber: 116,
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: nil, // no pending retry
+	}
+
+	if s.IssueInProgress(116) {
+		t.Fatal("IssueInProgress should return false for dead session without pending retry")
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -40,6 +40,7 @@ type Session struct {
 	NotifiedCIFail      bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
 	LastNotifiedStatus  string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
 	RetryCount          int           `json:"retry_count,omitempty"`
+	NextRetryAt         *time.Time    `json:"next_retry_at,omitempty"`
 	LastOutputHash      string        `json:"last_output_hash,omitempty"`
 	LastOutputChangedAt time.Time     `json:"last_output_changed_at,omitempty"`
 	TokensUsed          int           `json:"tokens_used,omitempty"`    // cumulative tokens consumed by the worker
@@ -135,11 +136,19 @@ func (s *State) CountByStatus() map[SessionStatus]int {
 	return counts
 }
 
-// IssueInProgress returns true if the given issue is already being handled
+// IssueInProgress returns true if the given issue is already being handled.
+// This includes dead sessions with a pending retry (NextRetryAt set) to prevent
+// duplicate worker spawns during backoff periods.
 func (s *State) IssueInProgress(issueNum int) bool {
 	for _, sess := range s.Sessions {
-		if sess.IssueNumber == issueNum &&
-			(sess.Status == StatusRunning || sess.Status == StatusPROpen || sess.Status == StatusQueued) {
+		if sess.IssueNumber != issueNum {
+			continue
+		}
+		if sess.Status == StatusRunning || sess.Status == StatusPROpen || sess.Status == StatusQueued {
+			return true
+		}
+		// Dead session with pending retry — still in progress
+		if sess.Status == StatusDead && sess.NextRetryAt != nil {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- Replace immediate retry with exponential backoff: `delay = min(10000 * 2^(attempt-1), max_retry_backoff_ms)`
- Default backoff cap: 300,000ms (5 minutes), configurable via `max_retry_backoff_ms` in maestro.yaml
- Dead sessions with a pending retry (`NextRetryAt`) are treated as in-progress to prevent duplicate spawns
- Status output shows retry countdown (e.g., `1 (in 8s)`)

## Changes
- **`internal/config/config.go`**: Add `max_retry_backoff_ms` config field (default 300000)
- **`internal/state/state.go`**: Add `NextRetryAt` field to Session; update `IssueInProgress` for pending retries
- **`internal/orchestrator/orchestrator.go`**: Add `retryBackoffMs` helper, `respawnDueRetries` method, schedule backoff in `checkSessions`, call `respawnDueRetries` in `RunOnce`
- **`cmd/maestro/main.go`**: Show retry countdown in status output
- **Tests**: Backoff formula, scheduling, respawn (elapsed/not-elapsed/failure), IssueInProgress with pending retries, config defaults

## Test plan
- [x] `go fmt ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go build ./cmd/maestro/` succeeds
- [x] Existing tests updated for new backoff behavior

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the immediate single-retry logic with an exponential backoff scheme: failed workers are parked as `StatusDead` with a `NextRetryAt` timestamp, then respawned by the new `respawnDueRetries` step once the delay elapses. The approach is well-structured and the state model is correct, but there are two issues to address before merge:

- **`MaxParallel` can be transiently exceeded** (`orchestrator.go:455–457`): `ActiveSessions()` counts only `StatusRunning`/`StatusPROpen` sessions, so dead+pending-retry sessions are invisible to the slot calculator. When enough time passes and a retry fires in the same cycle that a newly-spawned worker was already started to fill the "vacant" slot, the total concurrency can exceed `MaxParallel` by the number of pending retries. The fix is to add pending-retry session count to `active` before computing available slots.
- **Per-cycle log noise** (`orchestrator.go:327–328`): every waiting session emits a log line on every `RunOnce` call, which can become noisy over a long backoff window.

The `IssueInProgress` extension correctly gates duplicate spawns for the *same* issue during backoff, the config default and parsing are clean, and the test coverage is thorough.

<h3>Confidence Score: 3/5</h3>

- The PR introduces a logic bug that can cause the orchestrator to temporarily run more concurrent workers than `MaxParallel` allows; should be fixed before merging.
- The overall design is sound and the test coverage is good, but the slot-counting regression means dead+pending-retry sessions are not deducted from the available-worker budget. In production this can cause transient `MaxParallel` overshoot by up to the number of in-flight retries, which may trigger API rate limits or resource pressure depending on the deployment.
- internal/orchestrator/orchestrator.go — the slot calculation at lines 455–457 needs to account for pending-retry sessions.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   **Dead+pending-retry sessions not counted toward `MaxParallel`**

   `ActiveSessions()` only counts sessions with `StatusRunning` or `StatusPROpen` (see `state.go:121`). Dead sessions with a pending `NextRetryAt` are invisible to the slot calculator.

   Concretely, if `MaxParallel = 2` and both slots are occupied but one worker dies and gets a scheduled backoff:
   1. **Cycle N**: `active = 1` (only the still-running session), `slots = 1` → a new worker is spawned for a different issue → now 2 running + 1 dead+pending.
   2. **Cycle N+K** (when the backoff elapses): `respawnDueRetries` fires first, making the dead session `StatusRunning` → **3 workers running** against a `MaxParallel` of 2.

   The fix is to include pending-retry sessions in the capacity count before calculating slots:

   ```go
   // Count dead sessions with pending retries — they will respawn and count against capacity
   pendingRetries := 0
   for _, sess := range s.Sessions {
       if sess.Status == state.StatusDead && sess.NextRetryAt != nil {
           pendingRetries++
       }
   }
   active := len(s.ActiveSessions()) + pendingRetries
   slots := availableSlots(o.cfg, s, active)
   ```

   Alternatively, `ActiveSessions()` (or a new `occupiedSlots()` helper) could be updated to include dead+pending sessions. Without this fix the `MaxParallel` limit can be transiently exceeded by however many retries are pending.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 455-457

   Comment:
   **Dead+pending-retry sessions not counted toward `MaxParallel`**

   `ActiveSessions()` only counts sessions with `StatusRunning` or `StatusPROpen` (see `state.go:121`). Dead sessions with a pending `NextRetryAt` are invisible to the slot calculator.

   Concretely, if `MaxParallel = 2` and both slots are occupied but one worker dies and gets a scheduled backoff:
   1. **Cycle N**: `active = 1` (only the still-running session), `slots = 1` → a new worker is spawned for a different issue → now 2 running + 1 dead+pending.
   2. **Cycle N+K** (when the backoff elapses): `respawnDueRetries` fires first, making the dead session `StatusRunning` → **3 workers running** against a `MaxParallel` of 2.

   The fix is to include pending-retry sessions in the capacity count before calculating slots:

   ```go
   // Count dead sessions with pending retries — they will respawn and count against capacity
   pendingRetries := 0
   for _, sess := range s.Sessions {
       if sess.Status == state.StatusDead && sess.NextRetryAt != nil {
           pendingRetries++
       }
   }
   active := len(s.ActiveSessions()) + pendingRetries
   slots := availableSlots(o.cfg, s, active)
   ```

   Alternatively, `ActiveSessions()` (or a new `occupiedSlots()` helper) could be updated to include dead+pending sessions. Without this fix the `MaxParallel` limit can be transiently exceeded by however many retries are pending.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 6a1d0dd</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->