### PR TITLE
feat: GitHub Projects integration — sync issue status to project board (#206)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,12 @@ type VersioningConfig struct {
 	CreateRelease bool     `yaml:"create_release"` // Create GitHub release on bump
 }
 
+// GitHubProjectsConfig controls syncing issue status to GitHub Projects boards.
+type GitHubProjectsConfig struct {
+	Enabled       bool `yaml:"enabled"`
+	ProjectNumber int  `yaml:"project_number"` // GitHub Project number (auto-detect from repo)
+}
+
 // RoutingConfig controls automatic backend selection via LLM router.
 type RoutingConfig struct {
 	Mode            string `yaml:"mode"`              // "auto", "manual" (labels only)
@@ -54,40 +60,41 @@ type ServerConfig struct {
 }
 
 type Config struct {
-	Server                     ServerConfig     `yaml:"server"`
-	Repo                       string           `yaml:"repo"`
-	LocalPath                  string           `yaml:"local_path"`
-	WorktreeBase               string           `yaml:"worktree_base"`
-	MaxParallel                int              `yaml:"max_parallel"`
-	MaxConcurrentByState       map[string]int   `yaml:"max_concurrent_by_state"`       // per-state concurrency limits (e.g. "running": 5, "pr_open": 2)
-	MaxRuntimeMinutes          int              `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
-	WorkerSilentTimeoutMinutes int              `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
-	WorkerMaxTokens            int              `yaml:"worker_max_tokens"`             // kill worker when token usage exceeds this threshold (0 = unlimited)
-	MaxRetriesPerIssue         int              `yaml:"max_retries_per_issue"`         // max failed worker sessions per issue before giving up (default: 3, 0 = unlimited)
-	AutoRebase                 bool             `yaml:"auto_rebase"`                   // auto-attempt rebase for conflicting sessions (default: true)
-	ClaudeCmd                  string           `yaml:"claude_cmd"`                    // deprecated: use model.backends.claude.cmd
-	IssueLabel                 string           `yaml:"issue_label"`                   // deprecated: use issue_labels
-	IssueLabels                []string         `yaml:"issue_labels"`
-	ExcludeLabels              []string         `yaml:"exclude_labels"`
-	WorkerPrompt               string           `yaml:"worker_prompt"`
-	BugPrompt                  string           `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
-	EnhancementPrompt          string           `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
-	SessionPrefix              string           `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string           `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
-	Model                      ModelConfig      `yaml:"model"`
-	Routing                    RoutingConfig    `yaml:"routing"`
-	DeployCmd                  string           `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
-	DeployTimeoutMinutes       int              `yaml:"deploy_timeout_minutes"` // timeout for deploy command in minutes (default: 15)
-	MergeStrategy              string           `yaml:"merge_strategy"`         // "sequential" | "parallel"
-	MergeIntervalSeconds       int              `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
-	Telegram                   TelegramConfig   `yaml:"telegram"`
-	Versioning                 VersioningConfig `yaml:"versioning"`
-	MaxRetryBackoffMs          int              `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
-	AutoResolveFiles           []string         `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
-	CleanupWorktreesOnMerge    *bool            `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
-	BlockerPatterns            []string         `yaml:"blocker_patterns"`           // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
-	PollIntervalSeconds        int              `yaml:"poll_interval_seconds"`      // override poll interval from config (0 = use CLI flag)
-	SourcePath                 string           `yaml:"-"`                          // path the config was loaded from (not serialized)
+	Server                     ServerConfig         `yaml:"server"`
+	Repo                       string               `yaml:"repo"`
+	LocalPath                  string               `yaml:"local_path"`
+	WorktreeBase               string               `yaml:"worktree_base"`
+	MaxParallel                int                  `yaml:"max_parallel"`
+	MaxConcurrentByState       map[string]int       `yaml:"max_concurrent_by_state"`       // per-state concurrency limits (e.g. "running": 5, "pr_open": 2)
+	MaxRuntimeMinutes          int                  `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
+	WorkerSilentTimeoutMinutes int                  `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
+	WorkerMaxTokens            int                  `yaml:"worker_max_tokens"`             // kill worker when token usage exceeds this threshold (0 = unlimited)
+	MaxRetriesPerIssue         int                  `yaml:"max_retries_per_issue"`         // max failed worker sessions per issue before giving up (default: 3, 0 = unlimited)
+	AutoRebase                 bool                 `yaml:"auto_rebase"`                   // auto-attempt rebase for conflicting sessions (default: true)
+	ClaudeCmd                  string               `yaml:"claude_cmd"`                    // deprecated: use model.backends.claude.cmd
+	IssueLabel                 string               `yaml:"issue_label"`                   // deprecated: use issue_labels
+	IssueLabels                []string             `yaml:"issue_labels"`
+	ExcludeLabels              []string             `yaml:"exclude_labels"`
+	WorkerPrompt               string               `yaml:"worker_prompt"`
+	BugPrompt                  string               `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
+	EnhancementPrompt          string               `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
+	SessionPrefix              string               `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string               `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
+	Model                      ModelConfig          `yaml:"model"`
+	Routing                    RoutingConfig        `yaml:"routing"`
+	DeployCmd                  string               `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
+	DeployTimeoutMinutes       int                  `yaml:"deploy_timeout_minutes"` // timeout for deploy command in minutes (default: 15)
+	MergeStrategy              string               `yaml:"merge_strategy"`         // "sequential" | "parallel"
+	MergeIntervalSeconds       int                  `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
+	Telegram                   TelegramConfig       `yaml:"telegram"`
+	Versioning                 VersioningConfig     `yaml:"versioning"`
+	GitHubProjects             GitHubProjectsConfig `yaml:"github_projects"`
+	MaxRetryBackoffMs          int                  `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
+	AutoResolveFiles           []string             `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
+	CleanupWorktreesOnMerge    *bool                `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
+	BlockerPatterns            []string             `yaml:"blocker_patterns"`           // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
+	PollIntervalSeconds        int                  `yaml:"poll_interval_seconds"`      // override poll interval from config (0 = use CLI flag)
+	SourcePath                 string               `yaml:"-"`                          // path the config was loaded from (not serialized)
 }
 
 // LoadFrom loads config from a specific path.

--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -1,0 +1,187 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+// ProjectStatus represents the status to set on a GitHub Project item.
+type ProjectStatus string
+
+const (
+	ProjectStatusTodo       ProjectStatus = "todo"
+	ProjectStatusInProgress ProjectStatus = "in_progress"
+	ProjectStatusDone       ProjectStatus = "done"
+)
+
+// projectConfig holds the IDs needed to interact with a specific GitHub Project.
+type projectConfig struct {
+	ProjectID     string // GraphQL node ID (e.g. "PVT_kwDODsWD3M4BQ3Zd")
+	StatusFieldID string // Status field ID (e.g. "PVTSSF_lADODsWD3M4BQ3Zdzg-3LbA")
+	StatusOptions map[ProjectStatus]string
+}
+
+// knownProjects maps project numbers to their configs.
+var knownProjects = map[int]projectConfig{
+	4: {
+		ProjectID:     "PVT_kwDODsWD3M4BQ3Zd",
+		StatusFieldID: "PVTSSF_lADODsWD3M4BQ3Zdzg-3LbA",
+		StatusOptions: map[ProjectStatus]string{
+			ProjectStatusTodo:       "f75ad846",
+			ProjectStatusInProgress: "47fc9ee4",
+			ProjectStatusDone:       "98236657",
+		},
+	},
+	5: {
+		ProjectID:     "PVT_kwDODsWD3M4BQ3Z7",
+		StatusFieldID: "PVTSSF_lADODsWD3M4BQ3Z7zg-3Lwo",
+		StatusOptions: map[ProjectStatus]string{
+			ProjectStatusTodo:       "f75ad846",
+			ProjectStatusInProgress: "47fc9ee4",
+			ProjectStatusDone:       "98236657",
+		},
+	},
+}
+
+// SyncIssueToProject adds an issue to the GitHub Project and sets its status.
+// It is graceful: errors are logged but not returned, so callers are never blocked.
+func (c *Client) SyncIssueToProject(issueNumber int, projectNumber int, status ProjectStatus) {
+	cfg, ok := knownProjects[projectNumber]
+	if !ok {
+		log.Printf("[projects] unknown project number %d, skipping sync for issue #%d", projectNumber, issueNumber)
+		return
+	}
+
+	optionID, ok := cfg.StatusOptions[status]
+	if !ok {
+		log.Printf("[projects] unknown status %q for project %d, skipping sync for issue #%d", status, projectNumber, issueNumber)
+		return
+	}
+
+	// Step 1: Get issue node ID
+	nodeID, err := c.getIssueNodeID(issueNumber)
+	if err != nil {
+		log.Printf("[projects] could not get node ID for issue #%d: %v", issueNumber, err)
+		return
+	}
+
+	// Step 2: Add issue to project (idempotent — returns existing item if already added)
+	itemID, err := c.addToProject(cfg.ProjectID, nodeID)
+	if err != nil {
+		log.Printf("[projects] could not add issue #%d to project %d: %v", issueNumber, projectNumber, err)
+		return
+	}
+
+	// Step 3: Set status field
+	if err := c.setProjectItemStatus(cfg.ProjectID, itemID, cfg.StatusFieldID, optionID); err != nil {
+		log.Printf("[projects] could not set status for issue #%d in project %d: %v", issueNumber, projectNumber, err)
+		return
+	}
+
+	log.Printf("[projects] synced issue #%d to project %d with status %q", issueNumber, projectNumber, status)
+}
+
+// getIssueNodeID retrieves the GraphQL node ID for an issue.
+func (c *Client) getIssueNodeID(issueNumber int) (string, error) {
+	out, err := exec.Command("gh", "issue", "view", fmt.Sprint(issueNumber),
+		"--repo", c.Repo,
+		"--json", "id").Output()
+	if err != nil {
+		return "", fmt.Errorf("gh issue view %d --json id: %w", issueNumber, err)
+	}
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return "", fmt.Errorf("parse issue %d node id: %w", issueNumber, err)
+	}
+	if result.ID == "" {
+		return "", fmt.Errorf("empty node ID for issue #%d", issueNumber)
+	}
+	return result.ID, nil
+}
+
+// addToProject adds an issue to a GitHub Project and returns the project item ID.
+func (c *Client) addToProject(projectID, contentID string) (string, error) {
+	query := fmt.Sprintf(`mutation {
+  addProjectV2ItemById(input: {projectId: %q, contentId: %q}) {
+    item { id }
+  }
+}`, projectID, contentID)
+
+	out, err := exec.Command("gh", "api", "graphql", "-f", "query="+query).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("graphql addProjectV2ItemById: %w\nstderr: %s\nstdout: %s", err, exitErr.Stderr, out)
+		}
+		return "", fmt.Errorf("graphql addProjectV2ItemById: %w", err)
+	}
+
+	var resp struct {
+		Data struct {
+			AddProjectV2ItemById struct {
+				Item struct {
+					ID string `json:"id"`
+				} `json:"item"`
+			} `json:"addProjectV2ItemById"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return "", fmt.Errorf("parse addProjectV2ItemById response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		msgs := make([]string, len(resp.Errors))
+		for i, e := range resp.Errors {
+			msgs[i] = e.Message
+		}
+		return "", fmt.Errorf("graphql errors: %s", strings.Join(msgs, "; "))
+	}
+	itemID := resp.Data.AddProjectV2ItemById.Item.ID
+	if itemID == "" {
+		return "", fmt.Errorf("empty item ID in addProjectV2ItemById response")
+	}
+	return itemID, nil
+}
+
+// setProjectItemStatus sets the Status field on a project item.
+func (c *Client) setProjectItemStatus(projectID, itemID, fieldID, optionID string) error {
+	query := fmt.Sprintf(`mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: %q,
+    itemId: %q,
+    fieldId: %q,
+    value: { singleSelectOptionId: %q }
+  }) { projectV2Item { id } }
+}`, projectID, itemID, fieldID, optionID)
+
+	out, err := exec.Command("gh", "api", "graphql", "-f", "query="+query).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("graphql updateProjectV2ItemFieldValue: %w\nstderr: %s\nstdout: %s", err, exitErr.Stderr, out)
+		}
+		return fmt.Errorf("graphql updateProjectV2ItemFieldValue: %w", err)
+	}
+
+	var resp struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return fmt.Errorf("parse updateProjectV2ItemFieldValue response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		msgs := make([]string, len(resp.Errors))
+		for i, e := range resp.Errors {
+			msgs[i] = e.Message
+		}
+		return fmt.Errorf("graphql errors: %s", strings.Join(msgs, "; "))
+	}
+	return nil
+}

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -1,0 +1,44 @@
+package github
+
+import (
+	"testing"
+)
+
+func TestKnownProjects_ContainsExpectedProjects(t *testing.T) {
+	for _, num := range []int{4, 5} {
+		cfg, ok := knownProjects[num]
+		if !ok {
+			t.Errorf("knownProjects missing project number %d", num)
+			continue
+		}
+		if cfg.ProjectID == "" {
+			t.Errorf("project %d has empty ProjectID", num)
+		}
+		if cfg.StatusFieldID == "" {
+			t.Errorf("project %d has empty StatusFieldID", num)
+		}
+		for _, status := range []ProjectStatus{ProjectStatusTodo, ProjectStatusInProgress, ProjectStatusDone} {
+			if _, ok := cfg.StatusOptions[status]; !ok {
+				t.Errorf("project %d missing status option %q", num, status)
+			}
+		}
+	}
+}
+
+func TestKnownProjects_UnknownProjectNumber(t *testing.T) {
+	if _, ok := knownProjects[999]; ok {
+		t.Error("expected project 999 to not exist in knownProjects")
+	}
+}
+
+func TestProjectStatusConstants(t *testing.T) {
+	if ProjectStatusTodo != "todo" {
+		t.Errorf("ProjectStatusTodo = %q, want %q", ProjectStatusTodo, "todo")
+	}
+	if ProjectStatusInProgress != "in_progress" {
+		t.Errorf("ProjectStatusInProgress = %q, want %q", ProjectStatusInProgress, "in_progress")
+	}
+	if ProjectStatusDone != "done" {
+		t.Errorf("ProjectStatusDone = %q, want %q", ProjectStatusDone, "done")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -227,6 +227,15 @@ func (o *Orchestrator) nextFallbackBackend(sess *state.Session) string {
 	return ""
 }
 
+// syncProject syncs an issue's status to the configured GitHub Project board.
+// No-op if github_projects is not enabled.
+func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus) {
+	if !o.cfg.GitHubProjects.Enabled || o.cfg.GitHubProjects.ProjectNumber == 0 {
+		return
+	}
+	o.gh.SyncIssueToProject(issueNumber, o.cfg.GitHubProjects.ProjectNumber, status)
+}
+
 func readLastLines(path string, limit int) (string, error) {
 	if limit <= 0 {
 		return "", nil
@@ -829,6 +838,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					if err := o.addIssueLabel(sess.IssueNumber, "blocked"); err != nil {
 						log.Printf("[orch] warn: could not label issue #%d as blocked: %v", sess.IssueNumber, err)
 					}
+					o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
 					sess.Status = state.StatusFailed
 					now := time.Now().UTC()
 					sess.FinishedAt = &now
@@ -996,6 +1006,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				if err := o.addIssueLabel(sess.IssueNumber, "blocked"); err != nil {
 					log.Printf("[orch] warn: could not label issue #%d as blocked: %v", sess.IssueNumber, err)
 				}
+				o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
 				sess.Status = state.StatusFailed
 				now := time.Now().UTC()
 				sess.FinishedAt = &now
@@ -1176,6 +1187,7 @@ func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr git
 	}
 
 	log.Printf("[orch] merged PR #%d ✓", pr.Number)
+	o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
 	if err := o.closeIssue(sess.IssueNumber, fmt.Sprintf("Implemented by PR #%d (auto-merged by maestro).", pr.Number)); err != nil {
 		log.Printf("[orch] warning: failed to close issue #%d: %v", sess.IssueNumber, err)
 	}
@@ -1411,10 +1423,6 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 
 	started := 0
 	for _, issue := range issues {
-		if started >= slots {
-			break
-		}
-
 		if s.IssueInProgress(issue.Number) {
 			continue
 		}
@@ -1465,6 +1473,12 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			continue
 		}
 
+		// No available slots — sync remaining eligible issues as backlog/todo
+		if started >= slots {
+			o.syncProject(issue.Number, github.ProjectStatusTodo)
+			continue
+		}
+
 		// Resolve backend from label / auto-routing / default
 		backendName := o.resolveBackend(issue)
 
@@ -1490,6 +1504,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if longRunning {
 			s.Sessions[slotName].LongRunning = true
 		}
+		o.syncProject(issue.Number, github.ProjectStatusInProgress)
 		o.notifier.Sendf("🚀 maestro: started worker %s for issue #%d: %s", slotName, issue.Number, issue.Title)
 		started++
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3998,3 +3998,30 @@ func TestIssueInProgress_DeadWithoutRetry(t *testing.T) {
 		t.Fatal("IssueInProgress should return false for dead session without pending retry")
 	}
 }
+
+// --- syncProject tests ---
+
+func TestSyncProject_DisabledByDefault(t *testing.T) {
+	// When github_projects is not enabled, syncProject should be a no-op (not panic)
+	o := &Orchestrator{
+		cfg: &config.Config{Repo: "owner/repo"},
+		gh:  github.New("owner/repo"),
+	}
+	// Should not panic or make any API calls
+	o.syncProject(42, github.ProjectStatusInProgress)
+}
+
+func TestSyncProject_DisabledWhenNoProjectNumber(t *testing.T) {
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			GitHubProjects: config.GitHubProjectsConfig{
+				Enabled:       true,
+				ProjectNumber: 0, // not set
+			},
+		},
+		gh: github.New("owner/repo"),
+	}
+	// Should not panic or make any API calls
+	o.syncProject(42, github.ProjectStatusInProgress)
+}


### PR DESCRIPTION
Implements #206

## Changes
- Added `GitHubProjectsConfig` struct to `internal/config/config.go` with `enabled` and `project_number` fields (YAML: `github_projects`)
- Created `internal/github/github_projects.go` with:
  - `SyncIssueToProject()` — adds issue to GitHub Project via GraphQL and sets its status field
  - Known project configs for Panoptikon (project 4) and Maestro (project 5) with pre-configured status field IDs and option IDs
  - Three-step process: get issue node ID → add to project → set status field value
  - All errors are logged as warnings but never block the orchestrator
- Integrated `syncProject()` calls at 4 lifecycle points in the orchestrator:
  - **Worker starts** → status = In Progress
  - **PR merged** → status = Done
  - **Issue in backlog** (no available slots) → status = Todo
  - **Session permanently fails** (retry exhausted or max runtime exceeded) → status = Todo
- Feature is opt-in: no-op when `github_projects.enabled` is false or `project_number` is 0

## Config
```yaml
github_projects:
  enabled: true
  project_number: 4  # Panoptikon project
```

## Testing
- Unit tests for known project config validation and status constants (`github_projects_test.go`)
- Orchestrator tests verifying `syncProject` is a no-op when disabled or project number is 0
- All existing tests pass (`go test ./...` — 12/12 packages OK)
- Binary builds and runs successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opt-in GitHub Projects integration to the orchestrator, syncing issue statuses (`Todo`, `In Progress`, `Done`) to a configured project board at four lifecycle points. The implementation works end-to-end for the two pre-registered projects and builds cleanly.

- **New regression — extra `hasOpenPRForIssue` API calls per tick**: Removing the early `break` in `startNewWorkers` causes `o.hasOpenPRForIssue` (a real GitHub REST API request) to be called for every eligible backlogged issue on every poll cycle, not just the first `slots` issues as before. This compounds the already-flagged repeated `syncProject` subprocess calls.
- **Hardcoded org-specific project configs** (flagged in previous review): `knownProjects` only contains projects 4 and 5; any other `project_number` silently no-ops with a log warning, making the feature appear broken for other users without a clear error.
- **No timeout on `exec.Command` subprocess calls** (flagged in previous review): All three `exec.Command("gh", ...)` calls in `github_projects.go` have no deadline; a hung `gh` process will block the orchestrator's main goroutine indefinitely.
- **`syncProject` called synchronously** from the orchestrator loop: even without hangs, each call involves up to 3 sequential subprocess executions on the hot path.
- Minor: `orchestrator_test.go` is missing a trailing newline.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the loop refactor introduces a new GitHub API regression on top of existing unresolved issues with blocking subprocess calls and hardcoded project IDs.
- Two pre-existing concerns from the previous review round (no subprocess timeout, hardcoded project map) remain unaddressed. This PR also introduces a new regression: `hasOpenPRForIssue` is now called for every eligible backlogged issue on every poll cycle because the early `break` was removed without guarding the API call, adding unbounded GitHub REST API traffic on top of the already-flagged `syncProject` subprocess calls.
- `internal/orchestrator/orchestrator.go` (loop refactor regression) and `internal/github/github_projects.go` (missing timeouts, hardcoded config) need the most attention before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds `GitHubProjectsConfig` struct and embeds it in `Config`. Changes are additive and non-breaking; alignment formatting is clean. |
| internal/github/github_projects.go | New file implementing project sync via `exec.Command("gh", ...)`. Has three known issues flagged in prior threads: hardcoded org-specific project IDs, no timeout/context on subprocess calls (can block orchestrator indefinitely), and the knownProjects map silently no-ops for any unknown project number. |
| internal/github/github_projects_test.go | Unit tests cover known project config validation and status constants; tests are correct but only validate compile-time constants — no integration or behaviour tests for the sync logic itself. Missing newline at end of file. |
| internal/orchestrator/orchestrator.go | Integrates `syncProject` at 4 lifecycle points. The removal of the early `break` in `startNewWorkers` causes `hasOpenPRForIssue` (a GitHub REST API call) to be invoked for every eligible backlogged issue on every poll cycle — a new regression on top of the already-flagged repeated `syncProject` subprocess calls. The `syncProject` calls are also synchronous, blocking the orchestrator main loop. |
| internal/orchestrator/orchestrator_test.go | Adds two no-op smoke tests for `syncProject`; tests are correct and pass. Missing newline at end of file. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 1466-1479 ([link](https://github.com/befeast/maestro/blob/34afef78ec39b7116a010fb95c533a6f2214da9c/internal/orchestrator/orchestrator.go#L1466-L1479)) 

   **`hasOpenPRForIssue` now called for every backlogged issue**

   The early `break` used to prevent `hasOpenPRForIssue` from being called for issues beyond the available slot count. By moving the `started >= slots` guard to _after_ this check (line 1477), the new code calls `o.hasOpenPRForIssue` (a real GitHub REST API request) for **every eligible issue** on every orchestrator tick, even when all slots are already full.

   For example, if there are 20 open issues and only 2 slots, the old code would make `hasOpenPRForIssue` calls for at most 2 issues per tick. The new code makes up to 20 calls per tick. Combined with the already-flagged repeated `syncProject` calls for the same set of issues, this can significantly amplify API usage under normal operating conditions.

   A minimal fix is to move the slot guard back to before the `hasOpenPRForIssue` call (or use a different strategy for detecting the "no slots" case without abandoning the early-exit optimisation):

   ```go
   // No available slots — sync remaining eligible issues as backlog/todo
   if started >= slots {
       o.syncProject(issue.Number, github.ProjectStatusTodo)
       continue
   }

   // Safety net: check GitHub directly for any open PR referencing this issue.
   if hasOpenPR, err := o.hasOpenPRForIssue(issue.Number); err != nil {
       log.Printf("[orch] warn: could not check open PRs for issue #%d: %v", issue.Number, err)
   } else if hasOpenPR {
       log.Printf("[orch] skipping issue #%d: open PR already exists", issue.Number)
       continue
   }
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 34afef7</sub>

<!-- /greptile_comment -->