### PR TITLE
feat: workspace lifecycle hooks (before_run, after_run, after_create, before_remove) (#196)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,15 @@ type ServerConfig struct {
 	Port int `yaml:"port"` // 0 = disabled (default)
 }
 
+// HooksConfig holds lifecycle hook scripts that run at key points.
+type HooksConfig struct {
+	AfterCreate  string `yaml:"after_create"`  // runs once when a new issue workspace is first created
+	BeforeRun    string `yaml:"before_run"`    // runs before each agent attempt (fatal on failure)
+	AfterRun     string `yaml:"after_run"`     // runs after each agent attempt (logged, not fatal)
+	BeforeRemove string `yaml:"before_remove"` // runs before workspace cleanup (logged, not fatal)
+	TimeoutMs    int    `yaml:"timeout_ms"`    // timeout for hook execution in milliseconds (default: 60000)
+}
+
 type Config struct {
 	Server                     ServerConfig         `yaml:"server"`
 	Repo                       string               `yaml:"repo"`
@@ -92,6 +101,7 @@ type Config struct {
 	MaxRetryBackoffMs          int                  `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
 	AutoResolveFiles           []string             `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
 	CleanupWorktreesOnMerge    *bool                `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
+	Hooks                      HooksConfig          `yaml:"hooks"`
 	BlockerPatterns            []string             `yaml:"blocker_patterns"`           // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
 	PollIntervalSeconds        int                  `yaml:"poll_interval_seconds"`      // override poll interval from config (0 = use CLI flag)
 	SourcePath                 string               `yaml:"-"`                          // path the config was loaded from (not serialized)
@@ -283,6 +293,11 @@ func parse(data []byte) (*Config, error) {
 	}
 	if cfg.MergeIntervalSeconds <= 0 {
 		cfg.MergeIntervalSeconds = 30
+	}
+
+	// Default hooks timeout
+	if cfg.Hooks.TimeoutMs <= 0 {
+		cfg.Hooks.TimeoutMs = 60000
 	}
 
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -991,6 +991,7 @@ max_concurrent_by_state:
 	}
 }
 
+
 func TestParse_MaxRetryBackoffMsDefault(t *testing.T) {
 	yaml := `repo: owner/repo`
 	cfg, err := parse([]byte(yaml))
@@ -1013,5 +1014,79 @@ max_retry_backoff_ms: 60000
 	}
 	if cfg.MaxRetryBackoffMs != 60000 {
 		t.Errorf("MaxRetryBackoffMs = %d, want 60000", cfg.MaxRetryBackoffMs)
+	}
+}
+
+func TestParse_HooksDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Hooks.AfterCreate != "" {
+		t.Errorf("Hooks.AfterCreate = %q, want empty", cfg.Hooks.AfterCreate)
+	}
+	if cfg.Hooks.BeforeRun != "" {
+		t.Errorf("Hooks.BeforeRun = %q, want empty", cfg.Hooks.BeforeRun)
+	}
+	if cfg.Hooks.AfterRun != "" {
+		t.Errorf("Hooks.AfterRun = %q, want empty", cfg.Hooks.AfterRun)
+	}
+	if cfg.Hooks.BeforeRemove != "" {
+		t.Errorf("Hooks.BeforeRemove = %q, want empty", cfg.Hooks.BeforeRemove)
+	}
+	if cfg.Hooks.TimeoutMs != 60000 {
+		t.Errorf("Hooks.TimeoutMs = %d, want 60000", cfg.Hooks.TimeoutMs)
+	}
+}
+
+func TestParse_HooksExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+hooks:
+  after_create: |
+    git clone https://github.com/example/repo .
+    bun install
+  before_run: |
+    git fetch origin && git merge origin/main --ff-only || true
+  after_run: |
+    echo "Agent finished for $ISSUE_ID"
+  before_remove: |
+    echo "Cleaning up"
+  timeout_ms: 30000
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Hooks.AfterCreate == "" {
+		t.Error("Hooks.AfterCreate should not be empty")
+	}
+	if cfg.Hooks.BeforeRun == "" {
+		t.Error("Hooks.BeforeRun should not be empty")
+	}
+	if cfg.Hooks.AfterRun == "" {
+		t.Error("Hooks.AfterRun should not be empty")
+	}
+	if cfg.Hooks.BeforeRemove == "" {
+		t.Error("Hooks.BeforeRemove should not be empty")
+	}
+	if cfg.Hooks.TimeoutMs != 30000 {
+		t.Errorf("Hooks.TimeoutMs = %d, want 30000", cfg.Hooks.TimeoutMs)
+	}
+}
+
+func TestParse_HooksTimeoutDefault(t *testing.T) {
+	yaml := `
+repo: owner/repo
+hooks:
+  after_create: "echo hello"
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Hooks.TimeoutMs != 60000 {
+		t.Errorf("Hooks.TimeoutMs = %d, want 60000 (default)", cfg.Hooks.TimeoutMs)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -201,6 +201,21 @@ func (o *Orchestrator) isRateLimited(logFile string) bool {
 	return worker.IsRateLimited(logFile)
 }
 
+// runAfterRunHook executes the after_run hook for a session (best-effort, never fatal).
+func (o *Orchestrator) runAfterRunHook(sess *state.Session) {
+	if o.cfg.Hooks.AfterRun == "" {
+		return
+	}
+	env := worker.HookEnv{
+		IssueID:       fmt.Sprintf("%s#%d", o.cfg.Repo, sess.IssueNumber),
+		IssueNumber:   sess.IssueNumber,
+		WorkspacePath: sess.Worktree,
+	}
+	if err := worker.RunHook(o.cfg, "after_run", o.cfg.Hooks.AfterRun, env); err != nil {
+		log.Printf("[orch] after_run hook failed for issue #%d: %v", sess.IssueNumber, err)
+	}
+}
+
 // nextFallbackBackend returns the next untried backend from the fallback list.
 // It skips backends that are already in sess.TriedBackends or match the current backend.
 // Returns "" if no fallback is available.
@@ -608,6 +623,12 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 		(*ticker).Reset(newInterval)
 	}
 
+	// Hot-reload hooks config
+	if newCfg.Hooks != old.Hooks {
+		changed = append(changed, "hooks")
+		o.cfg.Hooks = newCfg.Hooks
+	}
+
 	if len(changed) == 0 {
 		log.Printf("[orch] config reloaded — no effective changes")
 		return
@@ -781,6 +802,9 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 			// Check if process is still alive
 			if sess.PID > 0 && !o.pidAlive(sess.PID) {
+				// Worker process died — run after_run hook
+				o.runAfterRunHook(sess)
+
 				// Check if there's an open PR for this branch BEFORE marking dead
 				if pr, found := branchToPR[sess.Branch]; found {
 					log.Printf("[orch] worker %s exited but PR #%d is open — transitioning to pr_open", slotName, pr.Number)
@@ -880,6 +904,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					if !sess.RateLimitHit && sess.LastNotifiedStatus != "rate_limit" {
 						if hit, pattern := worker.DetectRateLimit(output); hit {
 							log.Printf("[orch] worker %s hit rate limit (pattern=%s), stopping", slotName, pattern)
+							o.runAfterRunHook(sess)
 							if err := o.stopWorker(slotName, sess); err != nil {
 								log.Printf("[orch] warn: could not stop rate-limited worker %s: %v", slotName, err)
 							}
@@ -933,6 +958,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					if o.cfg.WorkerMaxTokens > 0 && sess.TokensUsed > o.cfg.WorkerMaxTokens && sess.LastNotifiedStatus != "token_limit" {
 						log.Printf("[orch] worker %s exceeded token limit (%d > %d), killing",
 							slotName, sess.TokensUsed, o.cfg.WorkerMaxTokens)
+						o.runAfterRunHook(sess)
 						if err := o.stopWorker(slotName, sess); err != nil {
 							log.Printf("[orch] warn: could not stop token-limit worker %s: %v", slotName, err)
 						}
@@ -957,6 +983,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 							timeout := time.Duration(o.cfg.WorkerSilentTimeoutMinutes) * time.Minute
 							if time.Since(sess.LastOutputChangedAt) > timeout {
 								log.Printf("[orch] worker %s silent for >%dm, killing", slotName, o.cfg.WorkerSilentTimeoutMinutes)
+								o.runAfterRunHook(sess)
 								if err := o.stopWorker(slotName, sess); err != nil {
 									log.Printf("[orch] warn: could not stop silent worker %s: %v", slotName, err)
 								}
@@ -1000,6 +1027,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					logTail = fmt.Sprintf("(could not read log file %s: %v)", sess.LogFile, err)
 				}
 
+				o.runAfterRunHook(sess)
 				if err := o.stopWorker(slotName, sess); err != nil {
 					log.Printf("[orch] warn: could not stop timed-out worker %s: %v", slotName, err)
 				}

--- a/internal/worker/hooks.go
+++ b/internal/worker/hooks.go
@@ -1,0 +1,54 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// HookEnv holds environment variables passed to lifecycle hooks.
+type HookEnv struct {
+	IssueID       string // "owner/repo#number"
+	IssueNumber   int
+	WorkspacePath string
+}
+
+// RunHook executes a lifecycle hook script with the given environment.
+// Returns an error if the hook fails. The caller decides whether to treat it as fatal.
+func RunHook(cfg *config.Config, hookName, script string, env HookEnv) error {
+	if strings.TrimSpace(script) == "" {
+		return nil
+	}
+
+	timeout := time.Duration(cfg.Hooks.TimeoutMs) * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", "-c", script)
+	cmd.Dir = env.WorkspacePath
+	cmd.Env = append(cmd.Environ(),
+		fmt.Sprintf("ISSUE_ID=%s#%d", cfg.Repo, env.IssueNumber),
+		fmt.Sprintf("ISSUE_NUMBER=%d", env.IssueNumber),
+		fmt.Sprintf("WORKSPACE_PATH=%s", env.WorkspacePath),
+	)
+
+	out, err := cmd.CombinedOutput()
+	if len(out) > 0 {
+		log.Printf("[hooks] %s output:\n%s", hookName, strings.TrimRight(string(out), "\n"))
+	}
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("hook %s timed out after %dms", hookName, cfg.Hooks.TimeoutMs)
+	}
+	if err != nil {
+		return fmt.Errorf("hook %s failed: %w", hookName, err)
+	}
+
+	log.Printf("[hooks] %s completed successfully", hookName)
+	return nil
+}

--- a/internal/worker/hooks_test.go
+++ b/internal/worker/hooks_test.go
@@ -1,0 +1,145 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+func TestRunHook_EmptyScript(t *testing.T) {
+	cfg := &config.Config{
+		Repo:  "owner/repo",
+		Hooks: config.HooksConfig{TimeoutMs: 5000},
+	}
+	env := HookEnv{IssueNumber: 42, WorkspacePath: t.TempDir()}
+	if err := RunHook(cfg, "test", "", env); err != nil {
+		t.Fatalf("expected nil error for empty script, got: %v", err)
+	}
+	if err := RunHook(cfg, "test", "   ", env); err != nil {
+		t.Fatalf("expected nil error for whitespace script, got: %v", err)
+	}
+}
+
+func TestRunHook_Success(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker.txt")
+
+	cfg := &config.Config{
+		Repo:  "owner/repo",
+		Hooks: config.HooksConfig{TimeoutMs: 5000},
+	}
+	env := HookEnv{IssueNumber: 42, WorkspacePath: dir}
+
+	script := "echo hello > " + marker
+	if err := RunHook(cfg, "after_create", script, env); err != nil {
+		t.Fatalf("RunHook failed: %v", err)
+	}
+
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("expected marker file to exist: %v", err)
+	}
+}
+
+func TestRunHook_Failure(t *testing.T) {
+	cfg := &config.Config{
+		Repo:  "owner/repo",
+		Hooks: config.HooksConfig{TimeoutMs: 5000},
+	}
+	env := HookEnv{IssueNumber: 42, WorkspacePath: t.TempDir()}
+
+	err := RunHook(cfg, "before_run", "exit 1", env)
+	if err == nil {
+		t.Fatal("expected error for failing script")
+	}
+}
+
+func TestRunHook_Timeout(t *testing.T) {
+	cfg := &config.Config{
+		Repo:  "owner/repo",
+		Hooks: config.HooksConfig{TimeoutMs: 100}, // 100ms timeout
+	}
+	env := HookEnv{IssueNumber: 42, WorkspacePath: t.TempDir()}
+
+	err := RunHook(cfg, "test", "sleep 10", env)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if got := err.Error(); !contains(got, "timed out") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+}
+
+func TestRunHook_EnvVars(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "env.txt")
+
+	cfg := &config.Config{
+		Repo:  "owner/repo",
+		Hooks: config.HooksConfig{TimeoutMs: 5000},
+	}
+	env := HookEnv{
+		IssueID:       "owner/repo#42",
+		IssueNumber:   42,
+		WorkspacePath: dir,
+	}
+
+	script := `echo "ID=$ISSUE_ID NUM=$ISSUE_NUMBER WS=$WORKSPACE_PATH" > ` + outFile
+	if err := RunHook(cfg, "test", script, env); err != nil {
+		t.Fatalf("RunHook failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	got := string(data)
+	if !contains(got, "ID=owner/repo#42") {
+		t.Errorf("ISSUE_ID not set correctly, got: %s", got)
+	}
+	if !contains(got, "NUM=42") {
+		t.Errorf("ISSUE_NUMBER not set correctly, got: %s", got)
+	}
+	if !contains(got, "WS="+dir) {
+		t.Errorf("WORKSPACE_PATH not set correctly, got: %s", got)
+	}
+}
+
+func TestRunHook_WorkingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "pwd.txt")
+
+	cfg := &config.Config{
+		Repo:  "owner/repo",
+		Hooks: config.HooksConfig{TimeoutMs: 5000},
+	}
+	env := HookEnv{IssueNumber: 1, WorkspacePath: dir}
+
+	script := "pwd > " + outFile
+	if err := RunHook(cfg, "test", script, env); err != nil {
+		t.Fatalf("RunHook failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	got := string(data)
+	if !contains(got, dir) {
+		t.Errorf("expected working dir %s, got: %s", dir, got)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -60,6 +60,16 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		return "", fmt.Errorf("git worktree add: %w\n%s", err, out)
 	}
 
+	// Run after_create hook
+	hookEnv := HookEnv{
+		IssueID:       fmt.Sprintf("%s#%d", cfg.Repo, issue.Number),
+		IssueNumber:   issue.Number,
+		WorkspacePath: worktreePath,
+	}
+	if err := RunHook(cfg, "after_create", cfg.Hooks.AfterCreate, hookEnv); err != nil {
+		log.Printf("[worker] after_create hook failed: %v", err)
+	}
+
 	// Assemble worker prompt
 	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
 
@@ -115,6 +125,11 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 	}
 	if err := os.WriteFile(runnerPath, []byte(runnerContent), 0755); err != nil {
 		return "", fmt.Errorf("write runner script: %w", err)
+	}
+
+	// Run before_run hook (fatal on failure)
+	if err := RunHook(cfg, "before_run", cfg.Hooks.BeforeRun, hookEnv); err != nil {
+		return "", fmt.Errorf("before_run hook: %w", err)
 	}
 
 	// Start tmux session
@@ -173,6 +188,16 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 		return fmt.Errorf("git worktree add: %w\n%s", err, out)
 	}
 
+	// Run after_create hook
+	hookEnv := HookEnv{
+		IssueID:       fmt.Sprintf("%s#%d", cfg.Repo, issue.Number),
+		IssueNumber:   issue.Number,
+		WorkspacePath: worktreePath,
+	}
+	if err := RunHook(cfg, "after_create", cfg.Hooks.AfterCreate, hookEnv); err != nil {
+		log.Printf("[worker] after_create hook failed: %v", err)
+	}
+
 	// Assemble worker prompt
 	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
 
@@ -227,6 +252,11 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 		return fmt.Errorf("write runner script: %w", err)
 	}
 
+	// Run before_run hook (fatal on failure)
+	if err := RunHook(cfg, "before_run", cfg.Hooks.BeforeRun, hookEnv); err != nil {
+		return fmt.Errorf("before_run hook: %w", err)
+	}
+
 	// Start tmux session
 	tmuxName := TmuxSessionName(slotName)
 	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", worktreePath, "bash", runnerPath)
@@ -278,6 +308,18 @@ func Stop(cfg *config.Config, slotName string, sess *state.Session) error {
 		proc, _ := os.FindProcess(sess.PID)
 		if err := proc.Kill(); err != nil {
 			log.Printf("[worker] kill pid %d: %v", sess.PID, err)
+		}
+	}
+
+	// Run before_remove hook
+	if sess.Worktree != "" {
+		hookEnv := HookEnv{
+			IssueID:       fmt.Sprintf("%s#%d", cfg.Repo, sess.IssueNumber),
+			IssueNumber:   sess.IssueNumber,
+			WorkspacePath: sess.Worktree,
+		}
+		if err := RunHook(cfg, "before_remove", cfg.Hooks.BeforeRemove, hookEnv); err != nil {
+			log.Printf("[worker] before_remove hook failed: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Implements #196

## Changes

Adds configurable shell script hooks in `maestro.yaml` that run at key points in the issue workspace lifecycle:

- **`hooks.after_create`** — runs once after a new worktree is created (best-effort, logged on failure)
- **`hooks.before_run`** — runs before each agent attempt (fatal on failure — prevents worker start)
- **`hooks.after_run`** — runs after each agent attempt ends (best-effort, logged on failure)
- **`hooks.before_remove`** — runs before workspace/worktree cleanup (best-effort, logged on failure)
- **`hooks.timeout_ms`** — configurable timeout for hook execution (default: 60000ms)

### Hook environment variables
All hooks receive these env vars:
- `ISSUE_ID` — `owner/repo#number` format
- `ISSUE_NUMBER` — numeric issue number
- `WORKSPACE_PATH` — absolute path to the worktree

### Config example
```yaml
hooks:
  after_create: |
    git clone https://github.com/org/repo .
    bun install
  before_run: |
    git fetch origin && git merge origin/main --ff-only || true
  after_run: |
    echo "Agent finished for $ISSUE_ID"
  before_remove: |
    echo "Archiving logs for $ISSUE_NUMBER"
  timeout_ms: 60000
```

### Files changed
- `internal/config/config.go` — added `HooksConfig` struct and `Hooks` field on `Config`, default timeout
- `internal/worker/hooks.go` — new file: `RunHook()` executes a hook script with timeout, env vars, and working dir
- `internal/worker/worker.go` — integrated `after_create` + `before_run` into `Start()` and `Respawn()`, `before_remove` into `Stop()`
- `internal/orchestrator/orchestrator.go` — added `runAfterRunHook()` helper, called at all worker termination points (PR opened, died, rate-limited, token limit, silent timeout, max runtime); hooks are hot-reloadable

### Integration points
| Hook | Location | Fatal? |
|------|----------|--------|
| `after_create` | `worker.Start()`, `worker.Respawn()` — after worktree creation | No |
| `before_run` | `worker.Start()`, `worker.Respawn()` — before tmux session start | **Yes** |
| `after_run` | `orchestrator.checkSessions()` — all worker termination paths | No |
| `before_remove` | `worker.Stop()` — before `git worktree remove` | No |

## Testing

- Added config parsing tests for hooks (default values, explicit config, timeout default)
- Added unit tests for `RunHook()`: empty script, success, failure, timeout, env vars, working directory
- All existing tests pass (`go test ./...`)
- Build verified (`go build ./cmd/maestro/ && ./maestro version`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds configurable lifecycle hooks (`after_create`, `before_run`, `after_run`, `before_remove`) to `maestro.yaml`, allowing users to run shell scripts at key points in the issue workspace lifecycle. The core implementation in `hooks.go` is clean and well-tested, and the integration across `worker.go` and `orchestrator.go` covers most termination paths.

**Key findings:**
- `after_run` is not fired when a running worker's issue is externally closed (orchestrator.go line 796) — the only termination path that doesn't call `runAfterRunHook`, making hook behavior inconsistent.
- `before_remove` is silently skipped when `maestro cleanup` is run, because `CleanupWorktrees()` calls `RemoveWorktree()` directly instead of going through `Stop()`.
- The `contains` helper in `hooks_test.go` reimplements `strings.Contains` unnecessarily.
- Pre-existing (already-threaded) issues remain open: orphaned worktree on `before_run` failure, unused `HookEnv.IssueID` field, and `after_run` not firing for workers that die after transitioning to `pr_open` status.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with awareness that hooks will silently not fire in two documented edge cases (external issue close and maestro cleanup).
- The feature is well-structured and tested, but there are two newly identified gaps where hooks are expected to fire but don't, plus three pre-existing issues from earlier threads that are still unresolved. None are blockers for the happy path, but they affect reliability of hook execution in edge cases.
- internal/orchestrator/orchestrator.go (missing after_run on issue-close path) and internal/worker/worker.go (CleanupWorktrees bypasses before_remove)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/worker/hooks.go | New file implementing RunHook(); well-structured with timeout, env injection, and combined output logging. The IssueID field on HookEnv is unused (reconstructed from cfg.Repo instead), flagged in a previous thread. |
| internal/worker/hooks_test.go | Good coverage of RunHook() (empty, success, failure, timeout, env vars, working directory). Uses a hand-rolled contains helper that should be replaced with strings.Contains. |
| internal/worker/worker.go | after_create + before_run integrated into Start() and Respawn(); before_remove integrated into Stop(). Known issue: before_run failure orphans the worktree (previous thread). CleanupWorktrees() bypasses Stop(), so before_remove never fires during maestro cleanup. |
| internal/orchestrator/orchestrator.go | after_run hook integrated at all major worker termination points, plus hot-reload support. Missing: after_run is not called when a running worker's issue is externally closed (line 796), and the pr_open dead-process path (flagged in previous thread). |
| internal/config/config.go | HooksConfig struct added cleanly with yaml tags; default timeout of 60000ms applied correctly in parse(). |
| internal/config/config_test.go | Three new tests cover default hooks, explicit hooks config, and timeout default — good coverage of the new config fields. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. General comment 

   **`after_run` not fired when issue is closed while the worker is running**

   When an issue is detected as closed for a `StatusRunning` worker (~line 715-722), `o.stopWorker` is called and the session transitions to `StatusDone` — but `runAfterRunHook` is never invoked. This is a termination path that the PR description says should trigger `after_run` ("called at all worker termination points"), but it is omitted.

   The same gap exists for the `StatusPROpen` → issue-closed path (~lines 700-707): `stopWorker` is called without a preceding `runAfterRunHook`.

   Both `if closed` branches that call `stopWorker` should call `runAfterRunHook(sess)` first, consistent with the rate-limit, token-limit, silent-timeout, and max-runtime paths.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 840-847

   Comment:
   **`after_run` not fired when issue is closed while the worker is running**

   When an issue is detected as closed for a `StatusRunning` worker (~line 715-722), `o.stopWorker` is called and the session transitions to `StatusDone` — but `runAfterRunHook` is never invoked. This is a termination path that the PR description says should trigger `after_run` ("called at all worker termination points"), but it is omitted.

   The same gap exists for the `StatusPROpen` → issue-closed path (~lines 700-707): `stopWorker` is called without a preceding `runAfterRunHook`.

   Both `if closed` branches that call `stopWorker` should call `runAfterRunHook(sess)` first, consistent with the rate-limit, token-limit, silent-timeout, and max-runtime paths.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. General comment 

   **Custom `contains` helper re-implements `strings.Contains`**

   The `contains` / `containsStr` pair at the bottom of the test file replicate `strings.Contains` from the standard library. Using `strings.Contains` directly is clearer and removes ~15 lines of unnecessary code:

   

   Or simply replace every `contains(x, y)` call with `strings.Contains(x, y)` and delete the helpers entirely (don't forget to add `"strings"` to the import if not already present).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/worker/hooks_test.go
   Line: 137-148

   Comment:
   **Custom `contains` helper re-implements `strings.Contains`**

   The `contains` / `containsStr` pair at the bottom of the test file replicate `strings.Contains` from the standard library. Using `strings.Contains` directly is clearer and removes ~15 lines of unnecessary code:

   

   Or simply replace every `contains(x, y)` call with `strings.Contains(x, y)` and delete the helpers entirely (don't forget to add `"strings"` to the import if not already present).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. General comment 

   **`after_run` not fired when issue is closed externally**

   When an issue is externally closed while its worker is in `StatusRunning`, `stopWorker` is called at line 796 but `runAfterRunHook` is never invoked. Every other worker termination path (rate limit, token limit, silent timeout, max runtime, natural death) calls `runAfterRunHook` first. The PR documentation says `after_run` fires "after each agent attempt ends" — an external issue closure terminates the attempt just as definitively as any other path.

   ```go
   } else if closed {
       log.Printf("[orch] issue #%d closed, stopping worker %s", sess.IssueNumber, slotName)
       o.runAfterRunHook(sess)
       o.stopWorker(slotName, sess)
       sess.Status = state.StatusDone
       now := time.Now().UTC()
       sess.FinishedAt = &now
       continue
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 790-800

   Comment:
   **`after_run` not fired when issue is closed externally**

   When an issue is externally closed while its worker is in `StatusRunning`, `stopWorker` is called at line 796 but `runAfterRunHook` is never invoked. Every other worker termination path (rate limit, token limit, silent timeout, max runtime, natural death) calls `runAfterRunHook` first. The PR documentation says `after_run` fires "after each agent attempt ends" — an external issue closure terminates the attempt just as definitively as any other path.

   ```go
   } else if closed {
       log.Printf("[orch] issue #%d closed, stopping worker %s", sess.IssueNumber, slotName)
       o.runAfterRunHook(sess)
       o.stopWorker(slotName, sess)
       sess.Status = state.StatusDone
       now := time.Now().UTC()
       sess.FinishedAt = &now
       continue
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


4. General comment 

   **`before_remove` skipped during `maestro cleanup`**

   `CleanupWorktrees` calls `RemoveWorktree()` directly, bypassing `Stop()` and therefore never running the `before_remove` hook. This is the path taken by the `maestro cleanup` CLI command (`cmd/maestro/main.go:1143`). Users who configure `before_remove` for tasks like archiving logs or recording metrics would silently miss those side-effects during manual cleanup.

   Consider calling `Stop()` (or at minimum `RunHook` + `RemoveWorktree`) inside `CleanupWorktrees` instead of calling `RemoveWorktree` directly, so `before_remove` fires consistently regardless of how a worktree is removed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/worker/worker.go
   Line: 349-380

   Comment:
   **`before_remove` skipped during `maestro cleanup`**

   `CleanupWorktrees` calls `RemoveWorktree()` directly, bypassing `Stop()` and therefore never running the `before_remove` hook. This is the path taken by the `maestro cleanup` CLI command (`cmd/maestro/main.go:1143`). Users who configure `before_remove` for tasks like archiving logs or recording metrics would silently miss those side-effects during manual cleanup.

   Consider calling `Stop()` (or at minimum `RunHook` + `RemoveWorktree`) inside `CleanupWorktrees` instead of calling `RemoveWorktree` directly, so `before_remove` fires consistently regardless of how a worktree is removed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 302b2b3</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->