### PR TITLE
security: harden maestro merge and PR guardrails

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -9,6 +9,20 @@ import (
 	"strings"
 )
 
+type greptileCheckRun struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+type greptileReviewComment struct {
+	Body     string `json:"body"`
+	CommitID string `json:"commit_id"`
+	User     struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
 type Issue struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`
@@ -190,7 +204,8 @@ func (c *Client) PRMergeable(prNumber int) (string, error) {
 //
 // Primary path: reads GitHub Check Runs for the PR's head SHA.
 //   - Looks for a check whose name contains "greptile" (case-insensitive).
-//   - conclusion == "success" or "neutral" → approved=true
+//   - conclusion == "success" or "neutral" only approves when there are no
+//     Greptile inline review comments on the current head SHA.
 //   - check found, other conclusion → approved=false, pending=false
 //   - check not found → falls through to comment-based fallback
 //
@@ -226,31 +241,29 @@ func (c *Client) PRGreptileApproved(prNumber int) (approved bool, pending bool, 
 
 	{
 		var checksData struct {
-			CheckRuns []struct {
-				Name       string `json:"name"`
-				Status     string `json:"status"`
-				Conclusion string `json:"conclusion"`
-			} `json:"check_runs"`
+			CheckRuns []greptileCheckRun `json:"check_runs"`
 		}
 		if err := json.Unmarshal(checksOut, &checksData); err != nil {
 			goto commentFallback
 		}
 
-		for _, cr := range checksData.CheckRuns {
-			if !strings.Contains(strings.ToLower(cr.Name), "greptile") {
-				continue
-			}
-			// Found a Greptile check run
-			// neutral = Greptile reviewed but no blocking issues; treat as passing
-			if cr.Conclusion == "success" || cr.Conclusion == "neutral" {
-				return true, false, nil
-			}
-			// Check is still running
-			if cr.Status == "in_progress" || cr.Status == "queued" || cr.Status == "waiting" || cr.Conclusion == "" {
+		found, approved, pending := greptileCheckDecision(checksData.CheckRuns)
+		if found {
+			if pending {
 				return false, true, nil
 			}
-			// Only failure and action_required should block merge
-			return false, false, nil
+			if !approved {
+				return false, false, nil
+			}
+
+			reviewComments, err := c.greptileReviewComments(prNumber)
+			if err != nil {
+				return false, false, fmt.Errorf("gh api pulls/%d/comments: %w", prNumber, err)
+			}
+			if hasGreptileInlineCommentOnHead(reviewComments, sha) {
+				return false, false, nil
+			}
+			return true, false, nil
 		}
 		// No greptile check run found → fall through to comment fallback
 	}
@@ -298,6 +311,53 @@ commentFallback:
 	}
 
 	return false, false, nil
+}
+
+func greptileCheckDecision(checkRuns []greptileCheckRun) (found bool, approved bool, pending bool) {
+	for _, cr := range checkRuns {
+		if !strings.Contains(strings.ToLower(cr.Name), "greptile") {
+			continue
+		}
+		found = true
+		if cr.Conclusion == "success" || cr.Conclusion == "neutral" {
+			return true, true, false
+		}
+		if cr.Status == "in_progress" || cr.Status == "queued" || cr.Status == "waiting" || cr.Conclusion == "" {
+			return true, false, true
+		}
+		return true, false, false
+	}
+	return false, false, false
+}
+
+func isGreptileLogin(login string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(login)), "greptile")
+}
+
+func hasGreptileInlineCommentOnHead(comments []greptileReviewComment, sha string) bool {
+	for _, comment := range comments {
+		if !isGreptileLogin(comment.User.Login) {
+			continue
+		}
+		if strings.TrimSpace(sha) == "" || strings.TrimSpace(comment.CommitID) == strings.TrimSpace(sha) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Client) greptileReviewComments(prNumber int) ([]greptileReviewComment, error) {
+	out, err := exec.Command("gh", "api",
+		fmt.Sprintf("repos/%s/pulls/%d/comments", c.Repo, prNumber),
+		"--paginate").Output()
+	if err != nil {
+		return nil, err
+	}
+	var comments []greptileReviewComment
+	if err := json.Unmarshal(out, &comments); err != nil {
+		return nil, err
+	}
+	return comments, nil
 }
 
 // MergePR squash-merges a PR

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -6,6 +6,82 @@ import (
 	"testing"
 )
 
+func TestGreptileCheckDecision(t *testing.T) {
+	tests := []struct {
+		name        string
+		checks      []greptileCheckRun
+		wantFound   bool
+		wantApprove bool
+		wantPending bool
+	}{
+		{
+			name:        "success approves",
+			checks:      []greptileCheckRun{{Name: "Greptile Review", Conclusion: "success"}},
+			wantFound:   true,
+			wantApprove: true,
+		},
+		{
+			name:        "neutral approves",
+			checks:      []greptileCheckRun{{Name: "greptile", Conclusion: "neutral"}},
+			wantFound:   true,
+			wantApprove: true,
+		},
+		{
+			name:        "in progress is pending",
+			checks:      []greptileCheckRun{{Name: "Greptile Review", Status: "in_progress"}},
+			wantFound:   true,
+			wantPending: true,
+		},
+		{
+			name:      "failure blocks",
+			checks:    []greptileCheckRun{{Name: "Greptile Review", Conclusion: "failure"}},
+			wantFound: true,
+		},
+		{
+			name:   "non-greptile is ignored",
+			checks: []greptileCheckRun{{Name: "CI", Conclusion: "success"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFound, gotApprove, gotPending := greptileCheckDecision(tt.checks)
+			if gotFound != tt.wantFound || gotApprove != tt.wantApprove || gotPending != tt.wantPending {
+				t.Fatalf("greptileCheckDecision() = (found=%v, approve=%v, pending=%v), want (%v, %v, %v)",
+					gotFound, gotApprove, gotPending, tt.wantFound, tt.wantApprove, tt.wantPending)
+			}
+		})
+	}
+}
+
+func TestHasGreptileInlineCommentOnHead(t *testing.T) {
+	makeComment := func(login, sha string) greptileReviewComment {
+		var c greptileReviewComment
+		c.CommitID = sha
+		c.User.Login = login
+		return c
+	}
+
+	comments := []greptileReviewComment{
+		makeComment("greptile-apps[bot]", "head-sha"),
+		makeComment("chatgpt-codex-connector[bot]", "head-sha"),
+		makeComment("greptile-apps[bot]", "old-sha"),
+	}
+
+	if !hasGreptileInlineCommentOnHead(comments, "head-sha") {
+		t.Fatal("expected greptile inline comment on current head to block")
+	}
+	if hasGreptileInlineCommentOnHead(comments, "different-sha") {
+		t.Fatal("did not expect greptile comment from another head to block")
+	}
+	if !isGreptileLogin("greptile-apps[bot]") {
+		t.Fatal("expected greptile login to be recognized")
+	}
+	if isGreptileLogin("chatgpt-codex-connector[bot]") {
+		t.Fatal("did not expect non-greptile login to be recognized")
+	}
+}
+
 func TestFindBlockers_BasicPattern(t *testing.T) {
 	body := "This issue is blocked by #42 and depends on #99."
 	patterns := []string{`blocked by #(\d+)`, `depends on #(\d+)`}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -668,8 +668,9 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 2. Implement the required changes in the worktree at: %s
 3. Write tests if applicable.
 4. Commit your changes with a clear message.
-5. Push the branch and create a PR using: gh pr create --repo %s --title "%s" --body "Closes #%d"
-6. After creating the PR, you are done. Do NOT merge it yourself.
+5. Before committing or opening a PR, check for accidental secrets and generated artifacts. Do NOT commit or mention API keys, bearer tokens, oauth tokens, bot tokens, env values, raw config dumps, or diagnostic logs. Do NOT commit temp/debug artifacts such as tmp/, _tmp/, *.log, *.logs, *.test, or *.test.json unless the issue explicitly requires them.
+6. Keep the PR body minimal and safe. Use: gh pr create --repo %s --title "%s" --body "Closes #%d". Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.
+7. After creating the PR, you are done. Do NOT merge it yourself.
 
 Important: Always run cargo fmt --all before committing if this is a Rust project.
 Always rebase on origin/main immediately before creating the PR.

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -1,0 +1,32 @@
+package worker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+func TestAssemblePromptIncludesSecretSafetyGuardrails(t *testing.T) {
+	cfg := &config.Config{Repo: "BeFeast/ok-gobot"}
+	issue := github.Issue{
+		Number: 157,
+		Title:  "security hardening",
+		Body:   "Fix secret handling.",
+	}
+
+	prompt := assemblePrompt("base prompt", issue, "/tmp/worktree", "codex/security", cfg)
+
+	required := []string{
+		"Do NOT commit or mention API keys",
+		"Do NOT commit temp/debug artifacts such as tmp/, _tmp/, *.log, *.logs, *.test, or *.test.json",
+		"Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.",
+		`gh pr create --repo BeFeast/ok-gobot --title "security hardening" --body "Closes #157"`,
+	}
+	for _, want := range required {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("assemblePrompt() missing %q\nprompt:\n%s", want, prompt)
+		}
+	}
+}


### PR DESCRIPTION
## What changed
- block auto-merge when Greptile left inline review comments on the current PR head, even if the Greptile check-run is green
- add unit coverage for Greptile decision logic and current-head inline comment detection
- harden the worker prompt so Codex workers do not commit temp/log artifacts or paste logs and secrets into PR bodies or comments

## Verification
- go test ./internal/github ./internal/worker -count=1

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens maestro's merge guardrails and worker prompts in two ways: (1) blocks auto-merge when Greptile has left inline review comments on the current PR head SHA, even if the Greptile check-run itself passed, and (2) adds explicit instructions to the worker prompt preventing Codex workers from committing secrets, temp files, or pasting sensitive data into PR bodies.

- Extracted `greptileCheckDecision` as a pure function for testability, with comprehensive unit tests covering success/neutral/pending/failure/non-greptile cases
- Added `greptileReviewComments` + `hasGreptileInlineCommentOnHead` to detect inline comments from Greptile on the current HEAD, blocking merge when found
- The new `greptileReviewComments` function uses `gh api --paginate` with `json.Unmarshal`, which will fail on PRs with >100 review comments since `--paginate` concatenates JSON arrays rather than merging them
- Worker prompt now includes steps 5-6 with explicit guardrails against committing secrets, log files, and temp artifacts

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge but has a latent pagination bug that will surface for PRs with many review comments
- The core logic changes (check decision extraction, inline comment blocking, worker prompt hardening) are well-structured and well-tested. However, the `greptileReviewComments` function has a `--paginate` + `json.Unmarshal` bug that will fail for PRs with >100 review comments. In practice this may rarely trigger, but when it does, it will block merges with an error rather than correctly checking for inline comments.
- Pay close attention to `internal/github/github.go` — the `greptileReviewComments` function's JSON parsing will break on paginated responses

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Refactors Greptile check logic into testable `greptileCheckDecision` helper and adds inline comment detection via `hasGreptileInlineCommentOnHead`. The new `greptileReviewComments` function has a latent `--paginate` + `json.Unmarshal` bug that will surface when PRs have >100 review comments. |
| internal/github/github_test.go | Adds well-structured unit tests for `greptileCheckDecision` and `hasGreptileInlineCommentOnHead`. Good coverage of edge cases including login matching and SHA comparison. |
| internal/worker/worker.go | Adds secret-safety and artifact-prevention guardrails to the worker prompt template. Clean, minimal change to instructions 5-7. |
| internal/worker/worker_prompt_test.go | New test file verifying the secret-safety guardrails are present in assembled prompts. Simple and effective assertion-based test. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/github/github.go
Line: 349-361

Comment:
**`--paginate` breaks `json.Unmarshal` for multi-page results**

`gh api --paginate` outputs each page as a separate JSON array concatenated back-to-back (e.g. `[...][...]`), which is not valid JSON. When a PR has more than 100 review comments, `json.Unmarshal` will fail here because it expects a single valid JSON value.

This will cause `greptileReviewComments` to return an error, which in turn makes `PRGreptileApproved` return `(false, false, err)` — blocking the merge with an opaque error instead of the intended inline-comment check.

Consider using a `json.NewDecoder` loop to handle concatenated arrays:

```
func (c *Client) greptileReviewComments(prNumber int) ([]greptileReviewComment, error) {
	out, err := exec.Command("gh", "api",
		fmt.Sprintf("repos/%s/pulls/%d/comments", c.Repo, prNumber),
		"--paginate").Output()
	if err != nil {
		return nil, err
	}
	var comments []greptileReviewComment
	dec := json.NewDecoder(bytes.NewReader(out))
	for dec.More() {
		var page []greptileReviewComment
		if err := dec.Decode(&page); err != nil {
			return nil, err
		}
		comments = append(comments, page...)
	}
	return comments, nil
}
```

Note: the same `--paginate` + `json.Unmarshal` pattern at line 236 for check-runs doesn't have this issue because that endpoint returns a JSON object envelope (`{"check_runs": [...]}`) rather than a top-level array, so `--paginate` merges pages into that envelope.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 3e4476b</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->