### PR TITLE
fix: clarify TokensUsed semantics on respawn (#214)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -895,9 +895,11 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					log.Printf("[orch] warn: tmux capture-pane failed for %s (%s): %v", slotName, tmuxName, err)
 				} else {
 					// --- Token tracking ---
-					if tokens := worker.ParseTokensFromOutput(output); tokens > sess.TokensUsed {
-						sess.TokensUsed = tokens
-						log.Printf("[orch] %s tokens_used updated to %d", slotName, tokens)
+					if tokens := worker.ParseTokensFromOutput(output); tokens > sess.TokensUsedAttempt {
+						delta := tokens - sess.TokensUsedAttempt
+						sess.TokensUsedAttempt = tokens
+						sess.TokensUsed += delta
+						log.Printf("[orch] %s tokens: attempt=%d lifecycle=%d", slotName, sess.TokensUsedAttempt, sess.TokensUsed)
 					}
 
 					// --- Rate-limit detection ---
@@ -954,10 +956,10 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						}
 					}
 
-					// --- Token limit enforcement ---
-					if o.cfg.WorkerMaxTokens > 0 && sess.TokensUsed > o.cfg.WorkerMaxTokens && sess.LastNotifiedStatus != "token_limit" {
+					// --- Token limit enforcement (per-attempt budget) ---
+					if o.cfg.WorkerMaxTokens > 0 && sess.TokensUsedAttempt > o.cfg.WorkerMaxTokens && sess.LastNotifiedStatus != "token_limit" {
 						log.Printf("[orch] worker %s exceeded token limit (%d > %d), killing",
-							slotName, sess.TokensUsed, o.cfg.WorkerMaxTokens)
+							slotName, sess.TokensUsedAttempt, o.cfg.WorkerMaxTokens)
 						o.runAfterRunHook(sess)
 						if err := o.stopWorker(slotName, sess); err != nil {
 							log.Printf("[orch] warn: could not stop token-limit worker %s: %v", slotName, err)
@@ -966,8 +968,8 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						sess.Status = state.StatusDead
 						sess.LastNotifiedStatus = "token_limit"
 						sess.FinishedAt = &now
-						o.notifier.Sendf("⚠️ Worker %s (issue #%d) exceeded token limit: %s tokens used",
-							slotName, sess.IssueNumber, worker.FormatTokens(sess.TokensUsed))
+						o.notifier.Sendf("⚠️ Worker %s (issue #%d) exceeded token limit: %s tokens used (attempt), %s total",
+							slotName, sess.IssueNumber, worker.FormatTokens(sess.TokensUsedAttempt), worker.FormatTokens(sess.TokensUsed))
 						continue
 					}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,36 +99,38 @@ type tokenTotalsInfo struct {
 }
 
 type sessionInfo struct {
-	Slot        string `json:"slot"`
-	IssueNumber int    `json:"issue_number"`
-	IssueTitle  string `json:"issue_title"`
-	Status      string `json:"status"`
-	Backend     string `json:"backend,omitempty"`
-	PRNumber    int    `json:"pr_number,omitempty"`
-	TokensUsed  int    `json:"tokens_used"`
-	Runtime     string `json:"runtime"`
-	StartedAt   string `json:"started_at"`
-	FinishedAt  string `json:"finished_at,omitempty"`
-	PID         int    `json:"pid,omitempty"`
-	Alive       *bool  `json:"alive,omitempty"`
-	Worktree    string `json:"worktree,omitempty"`
-	Branch      string `json:"branch,omitempty"`
-	RetryCount  int    `json:"retry_count,omitempty"`
+	Slot              string `json:"slot"`
+	IssueNumber       int    `json:"issue_number"`
+	IssueTitle        string `json:"issue_title"`
+	Status            string `json:"status"`
+	Backend           string `json:"backend,omitempty"`
+	PRNumber          int    `json:"pr_number,omitempty"`
+	TokensUsed        int    `json:"tokens_used"`         // lifecycle total across all attempts
+	TokensUsedAttempt int    `json:"tokens_used_attempt"` // current attempt only
+	Runtime           string `json:"runtime"`
+	StartedAt         string `json:"started_at"`
+	FinishedAt        string `json:"finished_at,omitempty"`
+	PID               int    `json:"pid,omitempty"`
+	Alive             *bool  `json:"alive,omitempty"`
+	Worktree          string `json:"worktree,omitempty"`
+	Branch            string `json:"branch,omitempty"`
+	RetryCount        int    `json:"retry_count,omitempty"`
 }
 
 func makeSessionInfo(slot string, sess *state.Session) sessionInfo {
 	info := sessionInfo{
-		Slot:        slot,
-		IssueNumber: sess.IssueNumber,
-		IssueTitle:  sess.IssueTitle,
-		Status:      string(sess.Status),
-		Backend:     sess.Backend,
-		PRNumber:    sess.PRNumber,
-		TokensUsed:  sess.TokensUsed,
-		StartedAt:   sess.StartedAt.Format(time.RFC3339),
-		Worktree:    sess.Worktree,
-		Branch:      sess.Branch,
-		RetryCount:  sess.RetryCount,
+		Slot:              slot,
+		IssueNumber:       sess.IssueNumber,
+		IssueTitle:        sess.IssueTitle,
+		Status:            string(sess.Status),
+		Backend:           sess.Backend,
+		PRNumber:          sess.PRNumber,
+		TokensUsed:        sess.TokensUsed,
+		TokensUsedAttempt: sess.TokensUsedAttempt,
+		StartedAt:         sess.StartedAt.Format(time.RFC3339),
+		Worktree:          sess.Worktree,
+		Branch:            sess.Branch,
+		RetryCount:        sess.RetryCount,
 	}
 
 	// Calculate runtime
@@ -319,7 +321,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 <h1>maestro — %s</h1>
 <p>Sessions: %d | Max parallel: %d</p>
 <table>
-<tr><th>Slot</th><th>Issue</th><th>Status</th><th>Backend</th><th>PR</th><th>Tokens</th><th>Runtime</th></tr>
+<tr><th>Slot</th><th>Issue</th><th>Status</th><th>Backend</th><th>PR</th><th>Tokens (attempt)</th><th>Tokens (total)</th><th>Runtime</th></tr>
 `, s.cfg.Repo, s.cfg.Repo, len(st.Sessions), s.cfg.MaxParallel)
 
 	for slot, sess := range st.Sessions {
@@ -332,11 +334,12 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		if sess.PRNumber > 0 {
 			pr = fmt.Sprintf("#%d", sess.PRNumber)
 		}
-		tokens := worker.FormatTokens(sess.TokensUsed)
-		fmt.Fprintf(w, `<tr class="%s"><td>%s</td><td>#%d %s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>
+		tokensAttempt := worker.FormatTokens(sess.TokensUsedAttempt)
+		tokensTotal := worker.FormatTokens(sess.TokensUsed)
+		fmt.Fprintf(w, `<tr class="%s"><td>%s</td><td>#%d %s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>
 `,
 			sess.Status, slot, sess.IssueNumber, escapeHTML(sess.IssueTitle),
-			sess.Status, sess.Backend, pr, tokens, runtime)
+			sess.Status, sess.Backend, pr, tokensAttempt, tokensTotal, runtime)
 	}
 
 	fmt.Fprintf(w, `</table>

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -43,7 +43,8 @@ type Session struct {
 	NextRetryAt         *time.Time    `json:"next_retry_at,omitempty"`
 	LastOutputHash      string        `json:"last_output_hash,omitempty"`
 	LastOutputChangedAt time.Time     `json:"last_output_changed_at,omitempty"`
-	TokensUsed          int           `json:"tokens_used,omitempty"`    // cumulative tokens consumed by the worker
+	TokensUsed          int           `json:"tokens_used,omitempty"`          // cumulative tokens consumed across all attempts (lifecycle total)
+	TokensUsedAttempt   int           `json:"tokens_used_attempt,omitempty"` // tokens consumed in the current attempt (reset on respawn)
 	RateLimitHit        bool          `json:"rate_limit_hit,omitempty"` // true if worker was rate-limited (tmux detection, running worker)
 	TriedBackends       []string      `json:"tried_backends,omitempty"` // backends already attempted (for rate-limit fallback)
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -291,6 +291,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	sess.LastNotifiedStatus = ""
 	sess.LastOutputHash = ""
 	sess.LastOutputChangedAt = time.Time{}
+	sess.TokensUsedAttempt = 0 // reset per-attempt counter; TokensUsed keeps the lifecycle total
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Adds `TokensUsedAttempt` field to `Session` -- tracks tokens for the current attempt only, reset to 0 on `Respawn()`
- `TokensUsed` remains the cumulative lifecycle total across all attempts
- Token tracking uses delta-based accounting: each new reading increments both counters by the delta
- `worker_max_tokens` enforcement now checks `TokensUsedAttempt` (per-attempt budget) instead of the cumulative total
- Server API (`/api/v1/state`, `/api/v1/workers`) and HTML dashboard expose both counters

## Motivation
`Respawn()` updates a session in place but never reset `TokensUsed`, creating ambiguity about whether the value represented per-attempt or per-lifecycle usage. The token limit enforcement (`worker_max_tokens`) compared the cumulative total against what should be a per-attempt budget, causing respawned workers to be killed prematurely.

Closes #214

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests, including token-limit enforcement tests)
- [ ] Verify JSON API returns both `tokens_used` and `tokens_used_attempt`
- [ ] Verify dashboard shows both "Tokens (attempt)" and "Tokens (total)" columns
- [ ] Manual: respawn a worker and confirm `tokens_used_attempt` resets while `tokens_used` accumulates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a semantic ambiguity in token tracking by splitting `TokensUsed` (lifetime total) from a new `TokensUsedAttempt` (per-attempt counter, reset on `Respawn()`), and corrects `worker_max_tokens` enforcement to use the per-attempt budget. The approach — delta-based accumulation from `ParseTokensFromOutput` — is sound for fresh sessions, but there is a meaningful data-integrity risk on upgrade.

**Key changes:**
- `state.Session` gains `TokensUsedAttempt int` (persisted, omitempty).
- `Respawn()` resets `TokensUsedAttempt = 0` while preserving `TokensUsed`.
- Orchestrator `checkSessions` computes a delta from the latest tmux reading against `TokensUsedAttempt`, accumulating it onto both fields.
- Token-limit enforcement now compares `TokensUsedAttempt` against `worker_max_tokens`.
- Server API and HTML dashboard expose both counters.

**Primary concern — double-count on upgrade:** Any session already persisted in `state.json` with `TokensUsed > 0` will have `TokensUsedAttempt = 0` (zero-value, since the field didn't exist). On the very first orchestrator poll after deployment, `delta = current_reading - 0 = current_reading`, so `TokensUsed` grows by roughly its current value — doubling it. A one-time migration guard (seed `TokensUsedAttempt` from `TokensUsed` when upgrading) would prevent this corruption.

**Secondary concern — test coverage:** The token-tracking tests only cover fresh sessions and do not assert on `TokensUsedAttempt`. The existing `TokenLimitAlreadyNotified` test happens to use the exact inconsistent state (non-zero `TokensUsed`, zero `TokensUsedAttempt`) that triggers the bug but does not assert on `TokensUsed` after the tick, so the corruption is invisible to CI.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for greenfield deployments; carries a silent data-corruption risk for any operator upgrading with in-flight workers.
- The per-attempt semantics and token-limit enforcement fix are logically correct. However, the absence of a migration guard means existing sessions will have their `TokensUsed` lifetime total inflated (approximately doubled) on the first orchestrator tick after upgrade. This does not affect correctness of the token-limit kill (which now uses `TokensUsedAttempt`), but it permanently corrupts the observable lifetime metric for those sessions. The test suite does not cover this migration path.
- `internal/orchestrator/orchestrator.go` (migration guard) and `internal/orchestrator/orchestrator_test.go` (missing `TokensUsedAttempt` assertions and multi-cycle / respawn test coverage).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Delta-based token tracking is correct for fresh sessions, but poses a double-count risk when upgrading with in-flight sessions that have `TokensUsed > 0` and `TokensUsedAttempt` defaulting to 0. Token-limit enforcement is correctly migrated to `TokensUsedAttempt`. |
| internal/state/state.go | New `TokensUsedAttempt` field added with appropriate `omitempty` JSON tag. Field semantics are clearly documented in comments. No issues. |
| internal/worker/worker.go | `Respawn()` correctly resets `TokensUsedAttempt = 0` while leaving `TokensUsed` intact. Comment is clear. No issues. |
| internal/server/server.go | Both `tokens_used` and `tokens_used_attempt` are correctly wired into `sessionInfo`, the JSON API, and the HTML dashboard. Dashboard column count matches the new header row. No issues. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator_test.go`, line 1244-1274 ([link](https://github.com/befeast/maestro/blob/0a67d7bb3c9e68be3ef1fd4b6184e90dd42fe773/internal/orchestrator/orchestrator_test.go#L1244-L1274)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Test uses inconsistent state that masks the double-count bug**

   `TestCheckSessions_TokenLimitAlreadyNotified_NoDuplicateKill` sets `TokensUsed: 75000` but leaves `TokensUsedAttempt` at `0`. This is exactly the migration scenario where the double-count manifests. After `checkSessions`, `TokensUsed` becomes `75000 + 75000 = 150000`, but the test doesn't assert on `TokensUsed` (or `TokensUsedAttempt`), so the corruption goes undetected.

   Additionally, the existing tests for `TokensUsed` (e.g., `TestCheckSessions_TokenLimitExceeded_KillsWorker`, `TestCheckSessions_TokensBelowLimit_WorkerSurvives`) only cover fresh sessions starting at zero, so there is no test coverage for the delta-accumulation behaviour across multiple poll cycles or for the respawn-then-accumulate path.

   Consider adding:
   1. Assertions on `TokensUsedAttempt` in every token-related test.
   2. A multi-cycle test that confirms `TokensUsed` accumulates correctly after `TokensUsedAttempt` is already non-zero.
   3. A respawn test that confirms `TokensUsedAttempt` resets to `0` while `TokensUsed` preserves the pre-respawn total.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator_test.go
   Line: 1244-1274

   Comment:
   **Test uses inconsistent state that masks the double-count bug**

   `TestCheckSessions_TokenLimitAlreadyNotified_NoDuplicateKill` sets `TokensUsed: 75000` but leaves `TokensUsedAttempt` at `0`. This is exactly the migration scenario where the double-count manifests. After `checkSessions`, `TokensUsed` becomes `75000 + 75000 = 150000`, but the test doesn't assert on `TokensUsed` (or `TokensUsedAttempt`), so the corruption goes undetected.

   Additionally, the existing tests for `TokensUsed` (e.g., `TestCheckSessions_TokenLimitExceeded_KillsWorker`, `TestCheckSessions_TokensBelowLimit_WorkerSurvives`) only cover fresh sessions starting at zero, so there is no test coverage for the delta-accumulation behaviour across multiple poll cycles or for the respawn-then-accumulate path.

   Consider adding:
   1. Assertions on `TokensUsedAttempt` in every token-related test.
   2. A multi-cycle test that confirms `TokensUsed` accumulates correctly after `TokensUsedAttempt` is already non-zero.
   3. A respawn test that confirms `TokensUsedAttempt` resets to `0` while `TokensUsed` preserves the pre-respawn total.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/orchestrator/orchestrator.go
Line: 897-903

Comment:
**`TokensUsed` double-counted on first poll after upgrade**

When this change is deployed with sessions already persisted in `state.json` (i.e., sessions with `TokensUsed > 0` but the new `TokensUsedAttempt` defaulting to `0`), the very first orchestrator poll will treat the entire current token reading as a fresh delta and add it on top of the already-correct `TokensUsed` value.

**Example**: A session with `TokensUsed = 50000` and `TokensUsedAttempt = 0` (the zero-value for the new field) gets polled and `ParseTokensFromOutput` returns `52000`. The code computes `delta = 52000 - 0 = 52000` and sets `TokensUsed = 50000 + 52000 = 102000`, which is roughly double the correct value.

A safe migration would initialize `TokensUsedAttempt` from `TokensUsed` when the field is absent (zero) on an in-flight session, for example in the `Load` function or in `checkSessions` before the comparison:

```go
// One-time migration: seed TokensUsedAttempt for sessions upgraded from the old schema
if sess.TokensUsed > 0 && sess.TokensUsedAttempt == 0 {
    sess.TokensUsedAttempt = sess.TokensUsed
}
if tokens := worker.ParseTokensFromOutput(output); tokens > sess.TokensUsedAttempt {
    delta := tokens - sess.TokensUsedAttempt
    sess.TokensUsedAttempt = tokens
    sess.TokensUsed += delta
    log.Printf("[orch] %s tokens: attempt=%d lifecycle=%d", slotName, sess.TokensUsedAttempt, sess.TokensUsed)
}
```

Note: this one-time guard assumes `TokensUsed > 0` implies the old single-counter semantics and seeds `TokensUsedAttempt` accordingly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/orchestrator/orchestrator_test.go
Line: 1244-1274

Comment:
**Test uses inconsistent state that masks the double-count bug**

`TestCheckSessions_TokenLimitAlreadyNotified_NoDuplicateKill` sets `TokensUsed: 75000` but leaves `TokensUsedAttempt` at `0`. This is exactly the migration scenario where the double-count manifests. After `checkSessions`, `TokensUsed` becomes `75000 + 75000 = 150000`, but the test doesn't assert on `TokensUsed` (or `TokensUsedAttempt`), so the corruption goes undetected.

Additionally, the existing tests for `TokensUsed` (e.g., `TestCheckSessions_TokenLimitExceeded_KillsWorker`, `TestCheckSessions_TokensBelowLimit_WorkerSurvives`) only cover fresh sessions starting at zero, so there is no test coverage for the delta-accumulation behaviour across multiple poll cycles or for the respawn-then-accumulate path.

Consider adding:
1. Assertions on `TokensUsedAttempt` in every token-related test.
2. A multi-cycle test that confirms `TokensUsed` accumulates correctly after `TokensUsedAttempt` is already non-zero.
3. A respawn test that confirms `TokensUsedAttempt` resets to `0` while `TokensUsed` preserves the pre-respawn total.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: clarify TokensU..."](https://github.com/befeast/maestro/commit/0a67d7bb3c9e68be3ef1fd4b6184e90dd42fe773)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->