### PR TITLE
fix: align retry logic with max_retries_per_issue config

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -843,8 +843,8 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 					o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) rate-limited on %s, switched to %s",
 						slotName, sess.IssueNumber, sess.TriedBackends[len(sess.TriedBackends)-1], nextBackend)
-				} else if sess.RetryCount < 1 {
-					// First failure — schedule retry with exponential backoff
+				} else if o.cfg.MaxRetriesPerIssue == 0 || sess.RetryCount < o.cfg.MaxRetriesPerIssue {
+					// Retries remaining — schedule retry with exponential backoff
 					sess.RetryCount++
 					backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
 					retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
@@ -857,8 +857,8 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					o.notifier.Sendf("🔄 maestro: worker %s (issue #%d: %s) died, retry %d scheduled in %ds",
 						slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
 				} else {
-					// Already retried — mark as permanently failed
-					log.Printf("[orch] worker %s (pid=%d) permanently failed after %d retries", slotName, sess.PID, sess.RetryCount)
+					// Retry budget exhausted — mark as permanently failed
+					log.Printf("[orch] worker %s (pid=%d) permanently failed after %d retries (max_retries_per_issue=%d)", slotName, sess.PID, sess.RetryCount, o.cfg.MaxRetriesPerIssue)
 					if err := o.addIssueLabel(sess.IssueNumber, "blocked"); err != nil {
 						log.Printf("[orch] warn: could not label issue #%d as blocked: %v", sess.IssueNumber, err)
 					}
@@ -866,7 +866,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					sess.Status = state.StatusFailed
 					now := time.Now().UTC()
 					sess.FinishedAt = &now
-					o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) permanently failed after %d retry.\nCheck log: %s",
+					o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) permanently failed after %d retries.\nCheck log: %s",
 						slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, sess.LogFile)
 				}
 				continue

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3790,9 +3790,10 @@ func TestCheckSessions_DeadWorkerSchedulesRetryWithBackoff(t *testing.T) {
 
 func TestCheckSessions_AlreadyRetriedWorkerFails(t *testing.T) {
 	cfg := &config.Config{
-		Repo:              "owner/repo",
-		MaxRetryBackoffMs: 300000,
-		MaxRuntimeMinutes: 999,
+		Repo:               "owner/repo",
+		MaxRetryBackoffMs:  300000,
+		MaxRuntimeMinutes:  999,
+		MaxRetriesPerIssue: 1, // allow only 1 retry
 	}
 	labeled := make([]string, 0)
 	o := &Orchestrator{
@@ -3828,6 +3829,115 @@ func TestCheckSessions_AlreadyRetriedWorkerFails(t *testing.T) {
 	o.checkSessions(s)
 
 	sess := s.Sessions["mae-11"]
+	if sess.Status != state.StatusFailed {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusFailed)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt should be nil for permanently failed session")
+	}
+	found := false
+	for _, label := range labeled {
+		if label == "blocked" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'blocked' label to be added on permanent failure")
+	}
+}
+
+func TestCheckSessions_RetryCountRespectsMaxRetriesPerIssue(t *testing.T) {
+	// With max_retries_per_issue=3, a worker that has retried once should
+	// schedule another retry (not permanently fail).
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRetryBackoffMs:  300000,
+		MaxRuntimeMinutes:  999,
+		MaxRetriesPerIssue: 3,
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return false // worker is dead
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-retry"] = &state.Session{
+		IssueNumber: 200,
+		IssueTitle:  "multi-retry test",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-retry",
+		Branch:      "feat/mae-retry-200-test",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+		RetryCount:  1, // retried once, 2 more attempts allowed
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-retry"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (should schedule retry, not permanently fail)", sess.Status, state.StatusDead)
+	}
+	if sess.RetryCount != 2 {
+		t.Fatalf("retry_count = %d, want 2", sess.RetryCount)
+	}
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set for scheduled retry")
+	}
+}
+
+func TestCheckSessions_RetryExhaustedAtMaxRetries(t *testing.T) {
+	// With max_retries_per_issue=3, a worker that has retried 3 times
+	// should permanently fail.
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRetryBackoffMs:  300000,
+		MaxRuntimeMinutes:  999,
+		MaxRetriesPerIssue: 3,
+	}
+	labeled := make([]string, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return false // worker is dead
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labeled = append(labeled, label)
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-exhausted"] = &state.Session{
+		IssueNumber: 201,
+		IssueTitle:  "exhausted retries",
+		Status:      state.StatusRunning,
+		PID:         5678,
+		TmuxSession: "maestro-mae-exhausted",
+		Branch:      "feat/mae-exhausted-201-test",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+		RetryCount:  3, // already retried max times
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-exhausted"]
 	if sess.Status != state.StatusFailed {
 		t.Fatalf("status = %q, want %q", sess.Status, state.StatusFailed)
 	}


### PR DESCRIPTION
## Summary
- Fixes #213
- Replaced hardcoded `sess.RetryCount < 1` with `o.cfg.MaxRetriesPerIssue` in `checkSessions`, so retry behavior actually respects the configured `max_retries_per_issue` value (default: 3)
- `MaxRetriesPerIssue == 0` is treated as unlimited retries, consistent with the existing guard in `startNewWorkers`
- Updated existing test to explicitly set `MaxRetriesPerIssue: 1` and added two new tests: one verifying mid-budget retries are scheduled, one verifying exhaustion triggers permanent failure

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 12 packages)
- [x] `TestCheckSessions_RetryCountRespectsMaxRetriesPerIssue` — worker with RetryCount=1, max=3 gets another retry
- [x] `TestCheckSessions_RetryExhaustedAtMaxRetries` — worker with RetryCount=3, max=3 permanently fails
- [x] `TestCheckSessions_AlreadyRetriedWorkerFails` — worker with RetryCount=1, max=1 permanently fails (updated existing test)
- [x] `TestCheckSessions_DeadWorkerSchedulesRetryWithBackoff` — first failure still schedules retry (unchanged, max=0 means unlimited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a genuine bug where retry behaviour in `checkSessions` was controlled by a hardcoded `sess.RetryCount < 1` guard rather than the user-configurable `max_retries_per_issue` value. The one-line logic change (`o.cfg.MaxRetriesPerIssue == 0 || sess.RetryCount < o.cfg.MaxRetriesPerIssue`) correctly propagates the configured limit and treats `0` as unlimited — matching the existing semantics in `startNewWorkers`. The change is well-scoped, easy to verify, and comes with three targeted tests covering mid-budget retries, exhaustion at the limit, and the updated single-retry boundary case.

- **Core fix** (`orchestrator.go:846`): replaces the hardcoded `< 1` sentinel with the configurable limit; semantics are correct and off-by-one analysis confirms exactly `MaxRetriesPerIssue` retries are allowed before permanent failure.
- **Unlimited-retry (`== 0`) handling** is consistent with `startNewWorkers` (which skips the check entirely when `MaxRetriesPerIssue == 0`).
- **Log message improvement** (`orchestrator.go:861`): now includes `max_retries_per_issue` in the permanent-failure log line, aiding debugging.
- **Minor grammar issue** (`orchestrator.go:869`): the notification message unconditionally uses "retries", so it will read *"permanently failed after 1 retries"* when `RetryCount == 1`.
- **Tests** are thorough and correctly mock only the code paths exercised by each scenario.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the fix is logically correct and well-covered by tests, with only a trivial grammatical issue in a notification string.
- The logic change is minimal, mathematically correct, and consistent with the adjacent `startNewWorkers` guard. Three new/updated tests validate all relevant boundaries. The only finding is a cosmetic grammar issue ("1 retries") in a notification message that does not affect runtime behaviour.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Core fix: replaces hardcoded `sess.RetryCount < 1` with `o.cfg.MaxRetriesPerIssue == 0 || sess.RetryCount < o.cfg.MaxRetriesPerIssue`, correctly honouring the configured retry limit and treating 0 as unlimited — consistent with `startNewWorkers`. Logic is sound with no off-by-one errors. Minor: notification message now reads "after 1 retries" when RetryCount == 1. |
| internal/orchestrator/orchestrator_test.go | Three new/updated tests cover the repaired boundary conditions well: mid-budget retry (RetryCount=1, max=3), exhaustion at the limit (RetryCount=3, max=3), and the existing test updated to explicitly set MaxRetriesPerIssue=1. All mocks are correctly wired for each code path. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/orchestrator/orchestrator.go
Line: 869

Comment:
**Grammatically incorrect plural for `RetryCount == 1`**

The message now unconditionally uses "retries", so when `RetryCount` is `1` it will read *"permanently failed after 1 retries"*. The old message had the mirror problem ("after 2 retry"), so consider using a ternary or `fmt.Sprintf` helper to pick the right noun:

```suggestion
					o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) permanently failed after %d %s.\nCheck log: %s",
						slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, func() string {
							if sess.RetryCount == 1 {
								return "retry"
							}
							return "retries"
						}(), sess.LogFile)
```

Alternatively, a small helper like `pluralise(n, "retry", "retries")` keeps it clean.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: align retry log..."](https://github.com/befeast/maestro/commit/cdfee0654a522757fe6627e83fdc77c3b016e110)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->