### PR TITLE
feat: sort status sessions by status with running first

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -414,12 +414,21 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 		return
 	}
 
-	// Sort session names for stable output
+	// Sort sessions by status priority (running first, then queued/pending,
+	// then completed), with most recently started first within each group.
 	names := make([]string, 0, len(s.Sessions))
 	for name := range s.Sessions {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	sort.Slice(names, func(i, j int) bool {
+		si, sj := s.Sessions[names[i]], s.Sessions[names[j]]
+		pi, pj := state.StatusPriority(si.Status), state.StatusPriority(sj.Status)
+		if pi != pj {
+			return pi < pj
+		}
+		// Within the same status group, most recently started first
+		return si.StartedAt.After(sj.StartedAt)
+	})
 
 	// Fetch CI status for pr_open sessions
 	gh := github.New(cfg.Repo)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -213,6 +213,28 @@ func IsTerminal(status SessionStatus) bool {
 	return false
 }
 
+// StatusPriority returns a numeric priority for sorting sessions by status.
+// Lower values sort first: running (0), then queued/pending (1-2),
+// then terminal states (3+).
+func StatusPriority(status SessionStatus) int {
+	switch status {
+	case StatusRunning:
+		return 0
+	case StatusQueued:
+		return 1
+	case StatusPROpen:
+		return 2
+	case StatusDone:
+		return 3
+	case StatusFailed, StatusConflictFailed:
+		return 4
+	case StatusDead, StatusRetryExhausted:
+		return 5
+	default:
+		return 6
+	}
+}
+
 // CompletedSession is a Session paired with its slot name.
 type CompletedSession struct {
 	SlotName string

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -696,3 +696,36 @@ func TestCountByStatus_Empty(t *testing.T) {
 		t.Errorf("expected empty map for empty state, got %v", counts)
 	}
 }
+
+func TestStatusPriority_Order(t *testing.T) {
+	// Verify running < queued < pr_open < done < failed < dead
+	if StatusPriority(StatusRunning) >= StatusPriority(StatusQueued) {
+		t.Error("running should sort before queued")
+	}
+	if StatusPriority(StatusQueued) >= StatusPriority(StatusPROpen) {
+		t.Error("queued should sort before pr_open")
+	}
+	if StatusPriority(StatusPROpen) >= StatusPriority(StatusDone) {
+		t.Error("pr_open should sort before done")
+	}
+	if StatusPriority(StatusDone) >= StatusPriority(StatusFailed) {
+		t.Error("done should sort before failed")
+	}
+	if StatusPriority(StatusFailed) >= StatusPriority(StatusDead) {
+		t.Error("failed should sort before dead")
+	}
+	if StatusPriority(StatusConflictFailed) != StatusPriority(StatusFailed) {
+		t.Error("conflict_failed should have same priority as failed")
+	}
+	if StatusPriority(StatusRetryExhausted) != StatusPriority(StatusDead) {
+		t.Error("retry_exhausted should have same priority as dead")
+	}
+}
+
+func TestStatusPriority_UnknownStatus(t *testing.T) {
+	// Unknown statuses should sort last
+	p := StatusPriority(SessionStatus("unknown"))
+	if p <= StatusPriority(StatusDead) {
+		t.Error("unknown status should sort after all known statuses")
+	}
+}


### PR DESCRIPTION
## Summary
- Sort `maestro status` output by session status priority: running first, then queued, pr_open, done, failed, and dead last
- Within the same status group, sessions are sorted by most recently started first
- Add `StatusPriority()` function to `internal/state` for centralized priority mapping

Closes #210

## Test plan
- [x] New `TestStatusPriority_Order` verifies the correct ordering of all status values
- [x] New `TestStatusPriority_UnknownStatus` verifies unknown statuses sort last
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes all existing and new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the `maestro status` display by sorting sessions by operational relevance — running first, then queued, pr_open, done, failed, and dead last — with a secondary sort by most-recently-started within each group. The implementation is clean: a new `StatusPriority()` helper is added to `internal/state` (keeping sorting logic centralized and testable), and `main.go` replaces the old alphabetical `sort.Strings` with a two-key `sort.Slice`.

**Changes:**
- `internal/state/state.go`: New `StatusPriority()` function covers all 8 known status constants and provides a safe default (`6`) for any future/unknown values.
- `cmd/maestro/main.go`: Sort updated to use `StatusPriority` as the primary key and `StartedAt` (newest first) as the secondary key.
- `internal/state/state_test.go`: Two new tests verify the full priority ordering and the unknown-status fallback.

**Issue found:**
- The sort currently lacks a final name tiebreaker. When two sessions share the same status and the same `StartedAt` (e.g., multiple `queued` sessions that have never been started, all with a zero-value timestamp), `sort.Slice`'s non-stability means the output order is undefined and may change between runs. Adding `names[i] < names[j]` as a final tiebreaker would restore the deterministic output the old `sort.Strings` provided.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the only issue is a minor non-determinism in output ordering for edge-case equal-timestamp sessions.
- The feature works correctly for the vast majority of cases. The `StatusPriority` function is complete and well-tested. The one gap — no name tiebreaker when both status priority and `StartedAt` are equal — can cause the output to flicker between runs for sessions with identical timestamps (most likely queued sessions at zero-value start time), but does not affect correctness of the application logic.
- cmd/maestro/main.go — the sort comparator should include a name tiebreaker for fully deterministic output.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Replaced alphabetical sort with a two-key sort (status priority, then most-recent-start-first). Logic is correct but lacks a name tiebreaker, making output non-deterministic when sessions share both priority and `StartedAt`. |
| internal/state/state.go | New `StatusPriority()` function cleanly maps all 8 known status constants to numeric priorities with a safe default case for unknown values. No issues found. |
| internal/state/state_test.go | Two new tests cover the full ordering of all status values, alias equality (conflict_failed == failed, retry_exhausted == dead), and the unknown-status fallback. Coverage is thorough. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: cmd/maestro/main.go
Line: 423-431

Comment:
**Non-deterministic order for equal timestamps**

`sort.Slice` is unstable: when two sessions share the same status priority **and** the same `StartedAt` timestamp (common for `queued` sessions that have never been started, whose `StartedAt` is the zero value), the comparison function returns `false` for both directions, making them "equal" — and `sort.Slice` may reorder them arbitrarily between runs.

The previous `sort.Strings` gave a deterministic alphabetical tiebreak. Adding an explicit name tiebreaker restores that guarantee:

```suggestion
	sort.Slice(names, func(i, j int) bool {
		si, sj := s.Sessions[names[i]], s.Sessions[names[j]]
		pi, pj := state.StatusPriority(si.Status), state.StatusPriority(sj.Status)
		if pi != pj {
			return pi < pj
		}
		// Within the same status group, most recently started first
		if !si.StartedAt.Equal(sj.StartedAt) {
			return si.StartedAt.After(sj.StartedAt)
		}
		// Final tiebreaker for stable output
		return names[i] < names[j]
	})
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat: sort status se..."](https://github.com/befeast/maestro/commit/1fb1390dd71d228e4c6382d4f5ed6a958ba77c51)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->