### PR TITLE
feat: soft token threshold with checkpoint and proactive refresh (#218)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,7 @@ type Config struct {
 	MaxRuntimeMinutes          int                  `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
 	WorkerSilentTimeoutMinutes int                  `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
 	WorkerMaxTokens            int                  `yaml:"worker_max_tokens"`             // kill worker when token usage exceeds this threshold (0 = unlimited)
+	WorkerSoftTokenThreshold   float64              `yaml:"worker_soft_token_threshold"`   // fraction of max_tokens to trigger checkpoint+respawn (default: 0.8, 0 = disabled)
 	MaxRetriesPerIssue         int                  `yaml:"max_retries_per_issue"`         // max failed worker sessions per issue before giving up (default: 3, 0 = unlimited)
 	AutoRebase                 bool                 `yaml:"auto_rebase"`                   // auto-attempt rebase for conflicting sessions (default: true)
 	ClaudeCmd                  string               `yaml:"claude_cmd"`                    // deprecated: use model.backends.claude.cmd
@@ -102,9 +103,9 @@ type Config struct {
 	AutoResolveFiles           []string             `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
 	CleanupWorktreesOnMerge    *bool                `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
 	Hooks                      HooksConfig          `yaml:"hooks"`
-	BlockerPatterns            []string             `yaml:"blocker_patterns"`           // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
-	PollIntervalSeconds        int                  `yaml:"poll_interval_seconds"`      // override poll interval from config (0 = use CLI flag)
-	SourcePath                 string               `yaml:"-"`                          // path the config was loaded from (not serialized)
+	BlockerPatterns            []string             `yaml:"blocker_patterns"`      // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
+	PollIntervalSeconds        int                  `yaml:"poll_interval_seconds"` // override poll interval from config (0 = use CLI flag)
+	SourcePath                 string               `yaml:"-"`                     // path the config was loaded from (not serialized)
 }
 
 // LoadFrom loads config from a specific path.
@@ -234,6 +235,18 @@ func parse(data []byte) (*Config, error) {
 		cfg.MaxRetryBackoffMs = 300000
 	}
 
+	// Default soft token threshold: 80% of max_tokens
+	if cfg.WorkerSoftTokenThreshold == 0 && cfg.WorkerMaxTokens > 0 {
+		cfg.WorkerSoftTokenThreshold = 0.8
+	}
+	// Clamp to valid range
+	if cfg.WorkerSoftTokenThreshold < 0 {
+		cfg.WorkerSoftTokenThreshold = 0
+	}
+	if cfg.WorkerSoftTokenThreshold > 1 {
+		cfg.WorkerSoftTokenThreshold = 1
+	}
+
 	if cfg.Telegram.OpenclawURL == "" {
 		cfg.Telegram.OpenclawURL = "http://localhost:18789"
 	}
@@ -336,6 +349,15 @@ func (c *Config) ShouldCleanupWorktrees() bool {
 		return true
 	}
 	return *c.CleanupWorktreesOnMerge
+}
+
+// SoftTokenThreshold returns the absolute token count at which a soft checkpoint
+// should be triggered. Returns 0 if soft threshold is disabled.
+func (c *Config) SoftTokenThreshold() int {
+	if c.WorkerMaxTokens <= 0 || c.WorkerSoftTokenThreshold <= 0 {
+		return 0
+	}
+	return int(float64(c.WorkerMaxTokens) * c.WorkerSoftTokenThreshold)
 }
 
 // ResolvePath returns the config file path, using SourcePath if set, otherwise the default candidate.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -991,7 +991,6 @@ max_concurrent_by_state:
 	}
 }
 
-
 func TestParse_MaxRetryBackoffMsDefault(t *testing.T) {
 	yaml := `repo: owner/repo`
 	cfg, err := parse([]byte(yaml))
@@ -1088,5 +1087,70 @@ hooks:
 	}
 	if cfg.Hooks.TimeoutMs != 60000 {
 		t.Errorf("Hooks.TimeoutMs = %d, want 60000 (default)", cfg.Hooks.TimeoutMs)
+	}
+}
+
+func TestParse_SoftTokenThresholdDefault(t *testing.T) {
+	yaml := `
+repo: owner/repo
+worker_max_tokens: 100000
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.WorkerSoftTokenThreshold != 0.8 {
+		t.Errorf("WorkerSoftTokenThreshold = %f, want 0.8", cfg.WorkerSoftTokenThreshold)
+	}
+	if cfg.SoftTokenThreshold() != 80000 {
+		t.Errorf("SoftTokenThreshold() = %d, want 80000", cfg.SoftTokenThreshold())
+	}
+}
+
+func TestParse_SoftTokenThresholdExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+worker_max_tokens: 100000
+worker_soft_token_threshold: 0.5
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.WorkerSoftTokenThreshold != 0.5 {
+		t.Errorf("WorkerSoftTokenThreshold = %f, want 0.5", cfg.WorkerSoftTokenThreshold)
+	}
+	if cfg.SoftTokenThreshold() != 50000 {
+		t.Errorf("SoftTokenThreshold() = %d, want 50000", cfg.SoftTokenThreshold())
+	}
+}
+
+func TestParse_SoftTokenThresholdDisabledWhenNoMaxTokens(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// No max_tokens means soft threshold should be 0 (disabled)
+	if cfg.WorkerSoftTokenThreshold != 0 {
+		t.Errorf("WorkerSoftTokenThreshold = %f, want 0 (disabled)", cfg.WorkerSoftTokenThreshold)
+	}
+	if cfg.SoftTokenThreshold() != 0 {
+		t.Errorf("SoftTokenThreshold() = %d, want 0", cfg.SoftTokenThreshold())
+	}
+}
+
+func TestSoftTokenThreshold_ClampedAbove1(t *testing.T) {
+	yaml := `
+repo: owner/repo
+worker_max_tokens: 100000
+worker_soft_token_threshold: 1.5
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.WorkerSoftTokenThreshold != 1.0 {
+		t.Errorf("WorkerSoftTokenThreshold = %f, want 1.0 (clamped)", cfg.WorkerSoftTokenThreshold)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -46,6 +46,8 @@ type Orchestrator struct {
 	workerRespawnFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 	respawnWorkerFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 	getIssueFn      func(number int) (github.Issue, error)
+	// checkpointRespawnFn: used by soft token threshold for checkpoint+respawn (tests override)
+	checkpointRespawnFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 
 	// Testing hooks for startNewWorkers
 	listOpenIssuesFn func(labels []string) ([]github.Issue, error)
@@ -161,6 +163,13 @@ func (o *Orchestrator) respawnWorker(slotName string, sess *state.Session, issue
 		return o.workerRespawnFn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
 	}
 	return worker.Respawn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
+}
+
+func (o *Orchestrator) checkpointRespawn(slotName string, sess *state.Session, issue github.Issue, promptBase string, backendName string) error {
+	if o.checkpointRespawnFn != nil {
+		return o.checkpointRespawnFn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
+	}
+	return worker.RespawnWithCheckpoint(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
 }
 
 func (o *Orchestrator) rebaseWorktree(worktreePath, branch string) error {
@@ -962,7 +971,34 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						}
 					}
 
-					// --- Token limit enforcement ---
+					// --- Soft token threshold: checkpoint + respawn ---
+					if softThreshold := o.cfg.SoftTokenThreshold(); softThreshold > 0 &&
+						sess.TokensUsed >= softThreshold &&
+						!sess.SoftThresholdNotified &&
+						sess.LastNotifiedStatus != "token_limit" {
+
+						log.Printf("[orch] worker %s reached soft token threshold (%d >= %d), triggering checkpoint respawn",
+							slotName, sess.TokensUsed, softThreshold)
+						sess.SoftThresholdNotified = true
+
+						issue, fetchErr := o.getIssue(sess.IssueNumber)
+						if fetchErr != nil {
+							log.Printf("[orch] fetch issue #%d for checkpoint respawn: %v — skipping checkpoint", sess.IssueNumber, fetchErr)
+						} else {
+							o.runAfterRunHook(sess)
+							promptBase := o.selectPrompt(issue)
+							if respawnErr := o.checkpointRespawn(slotName, sess, issue, promptBase, sess.Backend); respawnErr != nil {
+								log.Printf("[orch] checkpoint respawn %s failed: %v — worker continues with hard limit as safety net", slotName, respawnErr)
+							} else {
+								log.Printf("[orch] checkpoint respawn %s successful, fresh token budget", slotName)
+								o.notifier.Sendf("🔄 Worker %s (issue #%d) checkpointed at %s tokens — respawned with fresh budget",
+									slotName, sess.IssueNumber, worker.FormatTokens(softThreshold))
+								continue
+							}
+						}
+					}
+
+					// --- Token limit enforcement (hard limit / safety net) ---
 					if o.cfg.WorkerMaxTokens > 0 && sess.TokensUsed > o.cfg.WorkerMaxTokens && sess.LastNotifiedStatus != "token_limit" {
 						log.Printf("[orch] worker %s exceeded token limit (%d > %d), killing",
 							slotName, sess.TokensUsed, o.cfg.WorkerMaxTokens)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1384,6 +1384,210 @@ func TestCheckSessions_TokenLimitOnlyExceedingSessionKilled(t *testing.T) {
 	}
 }
 
+func TestCheckSessions_SoftThreshold_TriggersCheckpointRespawn(t *testing.T) {
+	cfg := &config.Config{
+		Repo:                     "owner/repo",
+		WorkerMaxTokens:          100000,
+		WorkerSoftTokenThreshold: 0.8, // soft at 80k
+		MaxRuntimeMinutes:        999,
+	}
+	// Worker reports 85,000 tokens — above soft threshold (80k), below hard limit (100k)
+	o, stopped := newCheckSessionsOrchestrator(cfg, "tokens 85000 (in 30000 / out 55000)")
+
+	checkpointCalled := false
+	o.checkpointRespawnFn = func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+		checkpointCalled = true
+		// Simulate successful checkpoint respawn: reset tokens
+		sess.TokensUsed = 0
+		sess.SoftThresholdNotified = false
+		sess.Status = state.StatusRunning
+		return nil
+	}
+	o.getIssueFn = func(number int) (github.Issue, error) {
+		return github.Issue{Number: number, Title: "test issue"}, nil
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber: 101,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-1",
+		Branch:      "feat/mae-1-101-test",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+		Backend:     "claude",
+	}
+
+	o.checkSessions(s)
+
+	if !checkpointCalled {
+		t.Fatal("checkpoint respawn should have been triggered")
+	}
+
+	sess := s.Sessions["mae-1"]
+	// Worker should still be running (respawned, not killed)
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (should be respawned, not dead)", sess.Status, state.StatusRunning)
+	}
+	// Stop should NOT have been called (checkpoint respawn handles its own cleanup)
+	if len(*stopped) != 0 {
+		t.Fatalf("stopped = %v, want empty (checkpoint respawn does its own cleanup)", *stopped)
+	}
+}
+
+func TestCheckSessions_SoftThreshold_NotTriggeredBelowThreshold(t *testing.T) {
+	cfg := &config.Config{
+		Repo:                     "owner/repo",
+		WorkerMaxTokens:          100000,
+		WorkerSoftTokenThreshold: 0.8,
+		MaxRuntimeMinutes:        999,
+	}
+	// 50k tokens — below soft threshold of 80k
+	o, _ := newCheckSessionsOrchestrator(cfg, "tokens 50000")
+
+	checkpointCalled := false
+	o.checkpointRespawnFn = func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+		checkpointCalled = true
+		return nil
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-2"] = &state.Session{
+		IssueNumber: 102,
+		Status:      state.StatusRunning,
+		PID:         2345,
+		TmuxSession: "maestro-mae-2",
+		Branch:      "feat/mae-2-102-test",
+		StartedAt:   time.Now().Add(-5 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	if checkpointCalled {
+		t.Fatal("checkpoint respawn should NOT have been triggered below threshold")
+	}
+	if s.Sessions["mae-2"].SoftThresholdNotified {
+		t.Fatal("SoftThresholdNotified should be false")
+	}
+}
+
+func TestCheckSessions_SoftThreshold_NotTriggeredWhenAlreadyNotified(t *testing.T) {
+	cfg := &config.Config{
+		Repo:                     "owner/repo",
+		WorkerMaxTokens:          100000,
+		WorkerSoftTokenThreshold: 0.8,
+		MaxRuntimeMinutes:        999,
+	}
+	// Above soft threshold
+	o, _ := newCheckSessionsOrchestrator(cfg, "tokens 85000")
+
+	checkpointCalled := false
+	o.checkpointRespawnFn = func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+		checkpointCalled = true
+		return nil
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-3"] = &state.Session{
+		IssueNumber:           103,
+		Status:                state.StatusRunning,
+		PID:                   3456,
+		TmuxSession:           "maestro-mae-3",
+		Branch:                "feat/mae-3-103-test",
+		StartedAt:             time.Now().Add(-5 * time.Minute),
+		SoftThresholdNotified: true, // already triggered
+	}
+
+	o.checkSessions(s)
+
+	if checkpointCalled {
+		t.Fatal("checkpoint respawn should NOT be triggered again when already notified")
+	}
+}
+
+func TestCheckSessions_SoftThreshold_FallsToHardLimit(t *testing.T) {
+	cfg := &config.Config{
+		Repo:                     "owner/repo",
+		WorkerMaxTokens:          100000,
+		WorkerSoftTokenThreshold: 0.8,
+		MaxRuntimeMinutes:        999,
+	}
+	// 110k tokens — above hard limit
+	o, stopped := newCheckSessionsOrchestrator(cfg, "tokens 110000")
+
+	checkpointCalled := false
+	o.checkpointRespawnFn = func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+		checkpointCalled = true
+		return fmt.Errorf("simulated checkpoint failure")
+	}
+	o.getIssueFn = func(number int) (github.Issue, error) {
+		return github.Issue{Number: number, Title: "test issue"}, nil
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-4"] = &state.Session{
+		IssueNumber: 104,
+		Status:      state.StatusRunning,
+		PID:         4567,
+		TmuxSession: "maestro-mae-4",
+		Branch:      "feat/mae-4-104-test",
+		StartedAt:   time.Now().Add(-5 * time.Minute),
+		Backend:     "claude",
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-4"]
+	// Checkpoint should have been attempted (above soft threshold)
+	if !checkpointCalled {
+		t.Fatal("checkpoint respawn should have been attempted")
+	}
+	// But since checkpoint failed AND tokens exceed hard limit, worker should be dead
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (hard limit should kick in after failed checkpoint)", sess.Status, state.StatusDead)
+	}
+	if sess.LastNotifiedStatus != "token_limit" {
+		t.Fatalf("last_notified_status = %q, want %q", sess.LastNotifiedStatus, "token_limit")
+	}
+	if len(*stopped) != 1 {
+		t.Fatalf("stopped = %v, want 1 stop (from hard limit)", *stopped)
+	}
+}
+
+func TestCheckSessions_SoftThreshold_DisabledWhenZero(t *testing.T) {
+	cfg := &config.Config{
+		Repo:                     "owner/repo",
+		WorkerMaxTokens:          100000,
+		WorkerSoftTokenThreshold: 0, // disabled
+		MaxRuntimeMinutes:        999,
+	}
+	// Above where soft threshold would be
+	o, _ := newCheckSessionsOrchestrator(cfg, "tokens 85000")
+
+	checkpointCalled := false
+	o.checkpointRespawnFn = func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+		checkpointCalled = true
+		return nil
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-5"] = &state.Session{
+		IssueNumber: 105,
+		Status:      state.StatusRunning,
+		PID:         5678,
+		TmuxSession: "maestro-mae-5",
+		Branch:      "feat/mae-5-105-test",
+		StartedAt:   time.Now().Add(-5 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	if checkpointCalled {
+		t.Fatal("checkpoint respawn should NOT be triggered when soft threshold is disabled")
+	}
+}
+
 func TestAutoMergePRs_ParallelStatePersistence(t *testing.T) {
 	// Verify that state survives a save/load cycle after parallel merges.
 	// This addresses the "race conditions on the state file" concern from issue #159.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -23,29 +23,30 @@ const (
 )
 
 type Session struct {
-	IssueNumber         int           `json:"issue_number"`
-	IssueTitle          string        `json:"issue_title"`
-	Worktree            string        `json:"worktree"`
-	Branch              string        `json:"branch"`
-	PID                 int           `json:"pid"`
-	TmuxSession         string        `json:"tmux_session,omitempty"`
-	LogFile             string        `json:"log_file"`
-	StartedAt           time.Time     `json:"started_at"`
-	FinishedAt          *time.Time    `json:"finished_at,omitempty"`
-	Status              SessionStatus `json:"status"`
-	PRNumber            int           `json:"pr_number,omitempty"`
-	Backend             string        `json:"backend,omitempty"` // "claude", "codex", etc.
-	LongRunning         bool          `json:"long_running,omitempty"`
-	RebaseAttempted     bool          `json:"rebase_attempted,omitempty"`
-	NotifiedCIFail      bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
-	LastNotifiedStatus  string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
-	RetryCount          int           `json:"retry_count,omitempty"`
-	NextRetryAt         *time.Time    `json:"next_retry_at,omitempty"`
-	LastOutputHash      string        `json:"last_output_hash,omitempty"`
-	LastOutputChangedAt time.Time     `json:"last_output_changed_at,omitempty"`
-	TokensUsed          int           `json:"tokens_used,omitempty"`    // cumulative tokens consumed by the worker
-	RateLimitHit        bool          `json:"rate_limit_hit,omitempty"` // true if worker was rate-limited (tmux detection, running worker)
-	TriedBackends       []string      `json:"tried_backends,omitempty"` // backends already attempted (for rate-limit fallback)
+	IssueNumber           int           `json:"issue_number"`
+	IssueTitle            string        `json:"issue_title"`
+	Worktree              string        `json:"worktree"`
+	Branch                string        `json:"branch"`
+	PID                   int           `json:"pid"`
+	TmuxSession           string        `json:"tmux_session,omitempty"`
+	LogFile               string        `json:"log_file"`
+	StartedAt             time.Time     `json:"started_at"`
+	FinishedAt            *time.Time    `json:"finished_at,omitempty"`
+	Status                SessionStatus `json:"status"`
+	PRNumber              int           `json:"pr_number,omitempty"`
+	Backend               string        `json:"backend,omitempty"` // "claude", "codex", etc.
+	LongRunning           bool          `json:"long_running,omitempty"`
+	RebaseAttempted       bool          `json:"rebase_attempted,omitempty"`
+	NotifiedCIFail        bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
+	LastNotifiedStatus    string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
+	RetryCount            int           `json:"retry_count,omitempty"`
+	NextRetryAt           *time.Time    `json:"next_retry_at,omitempty"`
+	LastOutputHash        string        `json:"last_output_hash,omitempty"`
+	LastOutputChangedAt   time.Time     `json:"last_output_changed_at,omitempty"`
+	TokensUsed            int           `json:"tokens_used,omitempty"`             // cumulative tokens consumed by the worker
+	SoftThresholdNotified bool          `json:"soft_threshold_notified,omitempty"` // true if soft token threshold was reached and checkpoint triggered
+	RateLimitHit          bool          `json:"rate_limit_hit,omitempty"`          // true if worker was rate-limited (tmux detection, running worker)
+	TriedBackends         []string      `json:"tried_backends,omitempty"`          // backends already attempted (for rate-limit fallback)
 }
 
 type State struct {

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -1,0 +1,248 @@
+package worker
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+const checkpointFile = "CHECKPOINT.md"
+
+// SaveCheckpoint commits any pending work in the worktree and writes a
+// CHECKPOINT.md file summarizing the progress. Returns the checkpoint
+// content that was written.
+func SaveCheckpoint(worktreePath string, tokensUsed int) (string, error) {
+	// Stage all changes
+	if out, err := exec.Command("git", "-C", worktreePath, "add", "-A").CombinedOutput(); err != nil {
+		log.Printf("[checkpoint] git add failed: %v\n%s", err, out)
+		// Non-fatal: there may be nothing to stage
+	}
+
+	// Get a summary of what's been done (staged diff stat)
+	diffStat, _ := exec.Command("git", "-C", worktreePath, "diff", "--cached", "--stat").CombinedOutput()
+
+	// Get list of commits on this branch that aren't on main
+	commitLog, _ := exec.Command("git", "-C", worktreePath, "log", "--oneline", "origin/main..HEAD").CombinedOutput()
+
+	// Build checkpoint content
+	checkpoint := fmt.Sprintf(`# Checkpoint
+
+This checkpoint was automatically created when the worker reached the soft token threshold.
+The previous session used approximately %d tokens.
+
+## Commits so far
+%s
+
+## Staged changes (diff stat)
+%s
+
+## Instructions for continuation
+
+You are continuing work on this issue. The previous worker session made the progress
+described above before being checkpointed. Review the existing code changes, read the
+issue description, and continue where the previous session left off.
+
+Do NOT redo work that has already been completed. Focus on what remains.
+`, tokensUsed, strings.TrimSpace(string(commitLog)), strings.TrimSpace(string(diffStat)))
+
+	// Write CHECKPOINT.md
+	cpPath := filepath.Join(worktreePath, checkpointFile)
+	if err := os.WriteFile(cpPath, []byte(checkpoint), 0644); err != nil {
+		return "", fmt.Errorf("write %s: %w", checkpointFile, err)
+	}
+
+	// Commit everything including CHECKPOINT.md
+	exec.Command("git", "-C", worktreePath, "add", "-A").CombinedOutput()
+	if out, err := exec.Command("git", "-C", worktreePath,
+		"commit", "-m", "checkpoint: save progress before token refresh").CombinedOutput(); err != nil {
+		log.Printf("[checkpoint] git commit: %v\n%s", err, out)
+		// Non-fatal: maybe nothing to commit
+	}
+
+	return checkpoint, nil
+}
+
+// RespawnWithCheckpoint saves a checkpoint in the current worktree, stops the
+// worker, and restarts it on the same branch with the checkpoint context
+// included in the prompt.
+func RespawnWithCheckpoint(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+	// Save checkpoint in current worktree before tearing it down
+	checkpoint, err := SaveCheckpoint(sess.Worktree, sess.TokensUsed)
+	if err != nil {
+		log.Printf("[checkpoint] save failed for %s: %v — proceeding with respawn anyway", slotName, err)
+	}
+
+	oldBranch := sess.Branch
+
+	// Kill the old worker's tmux session (but don't remove worktree yet)
+	tmuxName := TmuxSessionName(slotName)
+	if out, err := exec.Command("tmux", "kill-session", "-t", tmuxName).CombinedOutput(); err != nil {
+		log.Printf("[checkpoint] tmux kill-session %s: %v (%s)", tmuxName, err, strings.TrimSpace(string(out)))
+	}
+	if sess.PID > 0 && IsAlive(sess.PID) {
+		if proc, err := os.FindProcess(sess.PID); err == nil {
+			proc.Kill()
+		}
+	}
+
+	// Run before_remove hook
+	if sess.Worktree != "" {
+		hookEnv := HookEnv{
+			IssueID:       fmt.Sprintf("%s#%d", cfg.Repo, sess.IssueNumber),
+			IssueNumber:   sess.IssueNumber,
+			WorkspacePath: sess.Worktree,
+		}
+		if err := RunHook(cfg, "before_remove", cfg.Hooks.BeforeRemove, hookEnv); err != nil {
+			log.Printf("[checkpoint] before_remove hook failed: %v", err)
+		}
+	}
+
+	// Remove old worktree (branch and commits are preserved in repo)
+	if sess.Worktree != "" {
+		out, err := exec.Command("git", "-C", cfg.LocalPath,
+			"worktree", "remove", "--force", sess.Worktree).CombinedOutput()
+		if err != nil {
+			log.Printf("[checkpoint] remove worktree %s: %v\n%s", sess.Worktree, err, out)
+		}
+	}
+
+	// Create new worktree from the EXISTING branch (no -b flag)
+	worktreePath := filepath.Join(cfg.WorktreeBase, slotName)
+	log.Printf("[checkpoint] creating worktree %s from existing branch %s", worktreePath, oldBranch)
+	out, err := exec.Command("git", "-C", cfg.LocalPath,
+		"worktree", "add", worktreePath, oldBranch).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree add (checkpoint): %w\n%s", err, out)
+	}
+
+	// Run after_create hook
+	hookEnv := HookEnv{
+		IssueID:       fmt.Sprintf("%s#%d", cfg.Repo, issue.Number),
+		IssueNumber:   issue.Number,
+		WorkspacePath: worktreePath,
+	}
+	if err := RunHook(cfg, "after_create", cfg.Hooks.AfterCreate, hookEnv); err != nil {
+		log.Printf("[checkpoint] after_create hook failed: %v", err)
+	}
+
+	// Build prompt with checkpoint context
+	prompt := assemblePrompt(promptBase, issue, worktreePath, oldBranch, cfg)
+	if checkpoint != "" {
+		prompt = prompt + "\n\n---\n\n## Checkpoint from previous session\n\n" + checkpoint +
+			"\n\nIMPORTANT: Read CHECKPOINT.md in your worktree for full context. " +
+			"Continue where the previous session left off. Do NOT redo completed work.\n"
+	}
+
+	// Write prompt to file
+	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
+	if err := os.WriteFile(promptFile, []byte(prompt), 0644); err != nil {
+		return fmt.Errorf("write prompt file: %w", err)
+	}
+
+	// Determine backend
+	if backendName == "" {
+		backendName = cfg.Model.Default
+	}
+	backendDef, ok := cfg.Model.Backends[backendName]
+	if !ok {
+		backendName = cfg.Model.Default
+		backendDef, ok = cfg.Model.Backends[backendName]
+		if !ok {
+			return fmt.Errorf("backend %q (default) not found in config", backendName)
+		}
+	}
+	backendCfg := BackendConfig{
+		Cmd:        backendDef.Cmd,
+		ExtraArgs:  backendDef.ExtraArgs,
+		PromptMode: backendDef.PromptMode,
+	}
+
+	// Prepare log file
+	logDir := state.LogDir(cfg.StateDir)
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	logFile := filepath.Join(logDir, slotName+".log")
+
+	// Build the worker command
+	workerCmd, stdinFile, err := BuildWorkerCmd(backendName, backendCfg, promptFile, worktreePath)
+	if err != nil {
+		return fmt.Errorf("build worker cmd: %w", err)
+	}
+
+	// Write runner script
+	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
+	var runnerContent string
+	if stdinFile != "" {
+		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s < %q 2>&1 | tee -a %q\n",
+			shellJoin(workerCmd.Args), stdinFile, logFile)
+	} else {
+		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s 2>&1 | tee -a %q\n",
+			shellJoin(workerCmd.Args), logFile)
+	}
+	if err := os.WriteFile(runnerPath, []byte(runnerContent), 0755); err != nil {
+		return fmt.Errorf("write runner script: %w", err)
+	}
+
+	// Run before_run hook
+	if err := RunHook(cfg, "before_run", cfg.Hooks.BeforeRun, hookEnv); err != nil {
+		return fmt.Errorf("before_run hook: %w", err)
+	}
+
+	// Start tmux session
+	tmuxName = TmuxSessionName(slotName)
+	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", worktreePath, "bash", runnerPath)
+	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
+	}
+
+	// Get PID
+	pidOut, err := exec.Command("tmux", "list-panes", "-t", tmuxName, "-F", "#{pane_pid}").Output()
+	if err != nil {
+		return fmt.Errorf("tmux list-panes: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidOut)))
+	if err != nil {
+		return fmt.Errorf("parse pane pid: %w", err)
+	}
+
+	log.Printf("[checkpoint] respawned %s with checkpoint (pane_pid=%d, branch=%s)", slotName, pid, oldBranch)
+
+	// Update session in place — reset token counters for fresh budget
+	sess.Worktree = worktreePath
+	sess.Branch = oldBranch
+	sess.PID = pid
+	sess.TmuxSession = tmuxName
+	sess.LogFile = logFile
+	sess.StartedAt = time.Now().UTC()
+	sess.FinishedAt = nil
+	sess.Status = state.StatusRunning
+	sess.Backend = backendName
+	sess.NotifiedCIFail = false
+	sess.LastNotifiedStatus = ""
+	sess.LastOutputHash = ""
+	sess.LastOutputChangedAt = time.Time{}
+	sess.TokensUsed = 0
+	sess.SoftThresholdNotified = false
+
+	return nil
+}
+
+// ReadCheckpoint reads the CHECKPOINT.md file from a worktree, if it exists.
+// Returns empty string if no checkpoint file is found.
+func ReadCheckpoint(worktreePath string) string {
+	data, err := os.ReadFile(filepath.Join(worktreePath, checkpointFile))
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}

--- a/internal/worker/checkpoint_test.go
+++ b/internal/worker/checkpoint_test.go
@@ -1,0 +1,89 @@
+package worker
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSaveCheckpoint_WritesCheckpointFile(t *testing.T) {
+	// Create a temporary directory simulating a git worktree
+	dir := t.TempDir()
+
+	// Initialize a git repo so git commands work
+	if err := runCmd(dir, "git", "init"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := runCmd(dir, "git", "commit", "--allow-empty", "-m", "init"); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+
+	// Create a file to simulate work
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	content, err := SaveCheckpoint(dir, 75000)
+	if err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	// Verify CHECKPOINT.md was created
+	cpPath := filepath.Join(dir, checkpointFile)
+	data, err := os.ReadFile(cpPath)
+	if err != nil {
+		t.Fatalf("read checkpoint: %v", err)
+	}
+	if string(data) != content {
+		t.Errorf("file content doesn't match returned content")
+	}
+
+	// Verify checkpoint mentions tokens
+	if !strings.Contains(content, "75000") {
+		t.Errorf("checkpoint should mention token count, got: %s", content)
+	}
+
+	// Verify the file was committed
+	if err := runCmd(dir, "git", "diff", "--cached", "--quiet"); err != nil {
+		t.Errorf("expected clean staging area after checkpoint commit")
+	}
+}
+
+func TestReadCheckpoint_ExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	cpContent := "# Checkpoint\nTest checkpoint content\n"
+	if err := os.WriteFile(filepath.Join(dir, checkpointFile), []byte(cpContent), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := ReadCheckpoint(dir)
+	if got != cpContent {
+		t.Errorf("ReadCheckpoint = %q, want %q", got, cpContent)
+	}
+}
+
+func TestReadCheckpoint_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	got := ReadCheckpoint(dir)
+	if got != "" {
+		t.Errorf("ReadCheckpoint = %q, want empty", got)
+	}
+}
+
+func runCmd(dir string, name string, args ...string) error {
+	cmd := newCmd(dir, name, args...)
+	return cmd.Run()
+}
+
+func newCmd(dir string, name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	return cmd
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -291,6 +291,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	sess.LastNotifiedStatus = ""
 	sess.LastOutputHash = ""
 	sess.LastOutputChangedAt = time.Time{}
+	sess.SoftThresholdNotified = false
 
 	return nil
 }


### PR DESCRIPTION
Implements #218

## Changes

- **Config**: Added `worker_soft_token_threshold` (float64, default 0.8) — fraction of `worker_max_tokens` at which checkpoint is triggered. Set to 0 to disable.
- **State**: Added `SoftThresholdNotified` field to Session to prevent duplicate checkpoint triggers.
- **Worker**: New `checkpoint.go` with `SaveCheckpoint()` (commits pending work, writes CHECKPOINT.md) and `RespawnWithCheckpoint()` (preserves branch, includes checkpoint context in prompt).
- **Orchestrator**: `checkSessions()` now checks soft threshold before hard limit. On soft threshold: saves checkpoint, respawns worker with fresh token budget. On failure, falls through to hard limit as safety net.

### Token lifecycle flow

```
tokens < soft_threshold  → normal operation
soft_threshold reached   → checkpoint saved, clean respawn with carry-forward context
hard_threshold reached   → kill (safety net, same as before)
```

### Checkpoint artifacts

- `CHECKPOINT.md` — progress summary with commits, diff stat, and continuation instructions
- All staged/unstaged changes committed before respawn
- New worker starts on the same branch, with checkpoint context appended to prompt

## Testing

- Config: 4 tests for threshold parsing, defaults, clamping, and disabled state
- Worker: 3 tests for SaveCheckpoint file creation, ReadCheckpoint, and missing checkpoint
- Orchestrator: 5 tests covering soft threshold trigger, below-threshold no-op, already-notified dedup, fallback to hard limit on failure, and disabled threshold

All existing tests continue to pass. `go vet`, `go fmt`, `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a soft token threshold mechanism that checkpoints a worker's progress and respawns it with a fresh token budget before the hard kill limit is reached, providing a cleaner alternative to abrupt termination. The architecture is well-thought-out: a new `checkpoint.go` handles git commits and worktree recycling, the orchestrator handles the lifecycle transitions, and the `SoftThresholdNotified` flag correctly deduplicates triggers across polling ticks.

**Key findings:**
- **Logic bug — "0 = disabled" doesn't work when `worker_max_tokens` is set**: The config parse function applies the default `0.8` whenever `WorkerSoftTokenThreshold == 0 && WorkerMaxTokens > 0`, making it impossible for users to explicitly disable the soft threshold (as documented) while still using the hard token limit. This needs a fix — either a pointer type, a `-1` sentinel, or a dedicated boolean `worker_soft_token_threshold_enabled` field.
- **`after_run` hook called twice on checkpoint-failure + hard-limit path**: When a checkpoint attempt fails and the session then crosses the hard limit in the same tick, `runAfterRunHook` fires on the same session twice.
- **`origin/main` hardcoded in checkpoint commit log**: The `git log origin/main..HEAD` range will silently produce empty output for repos using `master` or another default branch name; this matches an existing pattern in the codebase but is worth noting.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the "0 = disabled" config bug; all other issues are non-blocking.
- The happy path works correctly and is well-tested with 12 new tests. One targeted fix is needed: the config defaulting logic silently overrides an explicit `worker_soft_token_threshold: 0` with `0.8` when `worker_max_tokens` is also set, breaking the documented "0 = disabled" contract. The other two findings (double hook call, hardcoded `origin/main`) are non-blocking style issues.
- `internal/config/config.go` — the defaulting logic at lines 239–241 needs to handle the explicit-zero case.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds `WorkerSoftTokenThreshold` field and `SoftTokenThreshold()` helper; contains a logic bug where setting the field to `0` (documented as "disabled") is silently overwritten to `0.8` when `worker_max_tokens > 0`, making the disable path non-functional. |
| internal/worker/checkpoint.go | New file implementing `SaveCheckpoint`, `RespawnWithCheckpoint`, and `ReadCheckpoint`; logic is sound overall. Minor issue: `origin/main` is hardcoded in the commit-log range, producing an empty section for non-`main` default branches (silently ignored). The session-reset block mirrors `Respawn` closely and correctly preserves `PRNumber` for the continuing branch. |
| internal/orchestrator/orchestrator.go | Soft threshold check is well-placed before the hard limit and the `SoftThresholdNotified` guard correctly prevents re-triggering. When checkpoint fails and the hard limit subsequently fires, `runAfterRunHook` is called twice on the same session, which may cause duplicate side-effects for non-idempotent hooks. |
| internal/state/state.go | Adds `SoftThresholdNotified` field to `Session` with appropriate JSON tag; straightforward and correct. |
| internal/config/config_test.go | Four new tests cover the default, explicit, disabled (no max_tokens), and clamping cases — but there is no test for the failing case: `worker_max_tokens > 0` with an explicit `worker_soft_token_threshold: 0`, which would expose the disable bug. |
| internal/orchestrator/orchestrator_test.go | Five comprehensive orchestrator tests covering trigger, below-threshold no-op, dedup, hard-limit fallback on checkpoint failure, and disabled-threshold; all use the injectable `checkpointRespawnFn` correctly. |
| internal/worker/checkpoint_test.go | New file with three tests for checkpoint file creation, reading, and missing-file; tests initialize a real git repo in a temp dir which is the right approach for these git-heavy helpers. |
| internal/worker/worker.go | Minimal change: adds `sess.SoftThresholdNotified = false` to the regular `Respawn` reset block, keeping the field consistent across both respawn paths. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 988-1005 ([link](https://github.com/befeast/maestro/blob/8e8716dff8f81aaee0250b41c840aea819968adf/internal/orchestrator/orchestrator.go#L988-L1005)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`after_run` hook invoked twice when checkpoint fails and hard limit fires**

   When the checkpoint respawn attempt fails (line 991) and `sess.TokensUsed` is already above `WorkerMaxTokens`, execution falls through to the hard-limit block (line 1005), which calls `o.runAfterRunHook(sess)` a second time on the same session. For users with an `after_run` hook that isn't idempotent (e.g. it sends a notification or writes to an external system), this produces a duplicate event.

   Consider guarding the hard-limit hook call so it's skipped if the soft-threshold block already ran it:

   ```go
   afterRunHookDone := false

   // inside soft threshold block (after issue fetch succeeds):
   o.runAfterRunHook(sess)
   afterRunHookDone = true

   // inside hard limit block:
   if !afterRunHookDone {
       o.runAfterRunHook(sess)
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 988-1005

   Comment:
   **`after_run` hook invoked twice when checkpoint fails and hard limit fires**

   When the checkpoint respawn attempt fails (line 991) and `sess.TokensUsed` is already above `WorkerMaxTokens`, execution falls through to the hard-limit block (line 1005), which calls `o.runAfterRunHook(sess)` a second time on the same session. For users with an `after_run` hook that isn't idempotent (e.g. it sends a notification or writes to an external system), this produces a duplicate event.

   Consider guarding the hard-limit hook call so it's skipped if the soft-threshold block already ran it:

   ```go
   afterRunHookDone := false

   // inside soft threshold block (after issue fetch succeeds):
   o.runAfterRunHook(sess)
   afterRunHookDone = true

   // inside hard limit block:
   if !afterRunHookDone {
       o.runAfterRunHook(sess)
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/config/config.go
Line: 239-241

Comment:
**"Set to 0 to disable" doesn't work when `worker_max_tokens` is set**

The config field comment (and PR description) documents that `worker_soft_token_threshold: 0` disables the feature. However, this defaulting code cannot distinguish between "user explicitly set 0" and "user did not specify the field" — both arrive here as `0` after YAML parsing. As a result, any user who sets `worker_soft_token_threshold: 0` alongside `worker_max_tokens > 0` will silently have the soft threshold enabled at 0.8, contrary to what they configured.

The fix is to use a sentinel value (e.g. `-1`) to signal "disabled", or a separate boolean flag. One common Go pattern for YAML defaults is to use a pointer:

```go
// In Config struct:
WorkerSoftTokenThreshold *float64 `yaml:"worker_soft_token_threshold"`

// In parse():
if cfg.WorkerSoftTokenThreshold == nil && cfg.WorkerMaxTokens > 0 {
    v := 0.8
    cfg.WorkerSoftTokenThreshold = &v
}
```

Alternatively, document that the disable sentinel is `-1` rather than `0`, and adjust clamping accordingly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/orchestrator/orchestrator.go
Line: 988-1005

Comment:
**`after_run` hook invoked twice when checkpoint fails and hard limit fires**

When the checkpoint respawn attempt fails (line 991) and `sess.TokensUsed` is already above `WorkerMaxTokens`, execution falls through to the hard-limit block (line 1005), which calls `o.runAfterRunHook(sess)` a second time on the same session. For users with an `after_run` hook that isn't idempotent (e.g. it sends a notification or writes to an external system), this produces a duplicate event.

Consider guarding the hard-limit hook call so it's skipped if the soft-threshold block already ran it:

```go
afterRunHookDone := false

// inside soft threshold block (after issue fetch succeeds):
o.runAfterRunHook(sess)
afterRunHookDone = true

// inside hard limit block:
if !afterRunHookDone {
    o.runAfterRunHook(sess)
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/worker/checkpoint.go
Line: 34

Comment:
**`origin/main` hardcoded for commit log range**

`origin/main..HEAD` will silently produce an empty commit list for repos whose default branch is `master` or any other name. Since the error is discarded (`_`), the checkpoint's "Commits so far" section will just be blank rather than failing loudly.

This matches an existing pattern in `worker.go:417`, so it may be an accepted limitation of the codebase — but it's worth noting that repos not using `main` will get an uninformative checkpoint. If `cfg.DefaultBranch` (or a similar config field) exists, using it here would be more robust.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat: soft token thr..."](https://github.com/befeast/maestro/commit/8e8716dff8f81aaee0250b41c840aea819968adf)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->