### PR TITLE
fix: use HookEnv.IssueID directly in RunHook (#196)

### DIFF
--- a/internal/worker/hooks.go
+++ b/internal/worker/hooks.go
@@ -32,7 +32,7 @@ func RunHook(cfg *config.Config, hookName, script string, env HookEnv) error {
 	cmd := exec.CommandContext(ctx, "bash", "-c", script)
 	cmd.Dir = env.WorkspacePath
 	cmd.Env = append(cmd.Environ(),
-		fmt.Sprintf("ISSUE_ID=%s#%d", cfg.Repo, env.IssueNumber),
+		fmt.Sprintf("ISSUE_ID=%s", env.IssueID),
 		fmt.Sprintf("ISSUE_NUMBER=%d", env.IssueNumber),
 		fmt.Sprintf("WORKSPACE_PATH=%s", env.WorkspacePath),
 	)

--- a/internal/worker/hooks_test.go
+++ b/internal/worker/hooks_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/befeast/maestro/internal/config"
@@ -30,7 +31,7 @@ func TestRunHook_Success(t *testing.T) {
 		Repo:  "owner/repo",
 		Hooks: config.HooksConfig{TimeoutMs: 5000},
 	}
-	env := HookEnv{IssueNumber: 42, WorkspacePath: dir}
+	env := HookEnv{IssueID: "owner/repo#42", IssueNumber: 42, WorkspacePath: dir}
 
 	script := "echo hello > " + marker
 	if err := RunHook(cfg, "after_create", script, env); err != nil {
@@ -66,7 +67,7 @@ func TestRunHook_Timeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
-	if got := err.Error(); !contains(got, "timed out") {
+	if got := err.Error(); !strings.Contains(got, "timed out") {
 		t.Fatalf("expected timeout error, got: %v", err)
 	}
 }
@@ -95,13 +96,13 @@ func TestRunHook_EnvVars(t *testing.T) {
 		t.Fatalf("read output: %v", err)
 	}
 	got := string(data)
-	if !contains(got, "ID=owner/repo#42") {
+	if !strings.Contains(got, "ID=owner/repo#42") {
 		t.Errorf("ISSUE_ID not set correctly, got: %s", got)
 	}
-	if !contains(got, "NUM=42") {
+	if !strings.Contains(got, "NUM=42") {
 		t.Errorf("ISSUE_NUMBER not set correctly, got: %s", got)
 	}
-	if !contains(got, "WS="+dir) {
+	if !strings.Contains(got, "WS="+dir) {
 		t.Errorf("WORKSPACE_PATH not set correctly, got: %s", got)
 	}
 }
@@ -126,20 +127,7 @@ func TestRunHook_WorkingDirectory(t *testing.T) {
 		t.Fatalf("read output: %v", err)
 	}
 	got := string(data)
-	if !contains(got, dir) {
+	if !strings.Contains(got, dir) {
 		t.Errorf("expected working dir %s, got: %s", dir, got)
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
-}
-
-func containsStr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Implements #196

## Changes
The workspace lifecycle hooks feature (after_create, before_run, after_run, before_remove) was implemented in PR #209 but didn't close issue #196.

This PR fixes a bug in the hook implementation: `RunHook` was ignoring the `HookEnv.IssueID` field and reconstructing the ISSUE_ID env var from `cfg.Repo` + `env.IssueNumber`. This meant the `IssueID` field was set by all callers but silently unused. Now `RunHook` uses `env.IssueID` directly, making the API consistent.

Also replaces custom `contains`/`containsStr` test helpers with `strings.Contains` from the standard library.

## Testing
- All existing hook tests pass (`go test ./internal/worker/`)
- `go vet ./...` clean
- `go build ./cmd/maestro/` succeeds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent bug in `RunHook` where the `ISSUE_ID` environment variable was reconstructed from `cfg.Repo` + `env.IssueNumber` instead of using the `HookEnv.IssueID` field that callers were already populating. The fix is a one-line change that makes the API consistent end-to-end. All existing call-sites (`worker.go`, `phase.go`, `orchestrator.go`) already construct `IssueID` correctly, so behaviour is unchanged while the dead code path is eliminated. The test cleanup (removing the hand-rolled `contains`/`containsStr` helpers in favour of `strings.Contains`) is a welcome simplification.

- **`hooks.go`**: `fmt.Sprintf("ISSUE_ID=%s#%d", cfg.Repo, env.IssueNumber)` → `fmt.Sprintf("ISSUE_ID=%s", env.IssueID)` — the direct fix.
- **`hooks_test.go`**: `IssueID` added to `TestRunHook_Success` and `TestRunHook_EnvVars` fixtures; `contains`/`containsStr` helpers removed.
- Minor: four other test fixtures still omit `IssueID`, leaving it empty for those hook invocations — harmless because those tests don't check `$ISSUE_ID`, but worth aligning for consistency.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a focused, correct bug fix with no regressions.
- The change is a one-line correction to use a pre-populated field rather than reconstructing it; all callers already set `IssueID` correctly so runtime behaviour is identical to what the API promised. The custom test helpers are cleanly replaced by stdlib. The only observation is cosmetic (some test fixtures omit `IssueID`), which doesn't affect test correctness or production safety.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/worker/hooks.go | Core fix: `RunHook` now uses `env.IssueID` directly instead of reconstructing it from `cfg.Repo + env.IssueNumber`. All call-sites in `worker.go`, `phase.go`, and `orchestrator.go` already populate `IssueID` correctly, so the change is consistent end-to-end. |
| internal/worker/hooks_test.go | Custom `contains`/`containsStr` helpers removed in favour of `strings.Contains`. Tests that don't exercise ISSUE_ID (Failure, Timeout, WorkingDirectory, EmptyScript) still omit `IssueID` from `HookEnv`, leaving it as an empty string in the hook environment — harmless for those tests but slightly inconsistent. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/worker/hooks_test.go`, line 17 ([link](https://github.com/befeast/maestro/blob/82c118fe41df145b9c39144c04fb46482ab720b5/internal/worker/hooks_test.go#L17)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`IssueID` left empty in several tests**

   `TestRunHook_EmptyScript`, `TestRunHook_Failure` (line 51), `TestRunHook_Timeout` (line 64), and `TestRunHook_WorkingDirectory` (line 118) all leave `IssueID` unset in their `HookEnv`. Those tests don't assert on `ISSUE_ID` so this is harmless, but after this PR's change, any hook script that uses `$ISSUE_ID` would silently receive an empty string in those scenarios.

   It may be worth populating `IssueID` consistently across all test fixtures (e.g. `IssueID: "owner/repo#42"`) so the test environment accurately reflects what a real caller would provide, and so any future script-content assertions won't hit a surprising empty value.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/worker/hooks_test.go
   Line: 17

   Comment:
   **`IssueID` left empty in several tests**

   `TestRunHook_EmptyScript`, `TestRunHook_Failure` (line 51), `TestRunHook_Timeout` (line 64), and `TestRunHook_WorkingDirectory` (line 118) all leave `IssueID` unset in their `HookEnv`. Those tests don't assert on `ISSUE_ID` so this is harmless, but after this PR's change, any hook script that uses `$ISSUE_ID` would silently receive an empty string in those scenarios.

   It may be worth populating `IssueID` consistently across all test fixtures (e.g. `IssueID: "owner/repo#42"`) so the test environment accurately reflects what a real caller would provide, and so any future script-content assertions won't hit a surprising empty value.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/worker/hooks_test.go
Line: 17

Comment:
**`IssueID` left empty in several tests**

`TestRunHook_EmptyScript`, `TestRunHook_Failure` (line 51), `TestRunHook_Timeout` (line 64), and `TestRunHook_WorkingDirectory` (line 118) all leave `IssueID` unset in their `HookEnv`. Those tests don't assert on `ISSUE_ID` so this is harmless, but after this PR's change, any hook script that uses `$ISSUE_ID` would silently receive an empty string in those scenarios.

It may be worth populating `IssueID` consistently across all test fixtures (e.g. `IssueID: "owner/repo#42"`) so the test environment accurately reflects what a real caller would provide, and so any future script-content assertions won't hit a surprising empty value.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: use HookEnv.Iss..."](https://github.com/befeast/maestro/commit/82c118fe41df145b9c39144c04fb46482ab720b5)</sub>

<!-- /greptile_comment -->