### PR TITLE
feat: test-first guidance and validation contract in worker prompt (#219)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,10 +101,12 @@ type Config struct {
 	IssueLabels                []string             `yaml:"issue_labels"`
 	ExcludeLabels              []string             `yaml:"exclude_labels"`
 	WorkerPrompt               string               `yaml:"worker_prompt"`
-	BugPrompt                  string               `yaml:"bug_prompt"`         // prompt template for issues with "bug" label
-	EnhancementPrompt          string               `yaml:"enhancement_prompt"` // prompt template for issues with "enhancement" label
-	SessionPrefix              string               `yaml:"session_prefix"`     // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string               `yaml:"state_dir"`          // state/log directory (default: ~/.maestro/<repo-hash>)
+	BugPrompt                  string               `yaml:"bug_prompt"`          // prompt template for issues with "bug" label
+	EnhancementPrompt          string               `yaml:"enhancement_prompt"`  // prompt template for issues with "enhancement" label
+	PromptSections             []string             `yaml:"prompt_sections"`     // additional prompt section files appended to the base prompt
+	ValidationContract         bool                 `yaml:"validation_contract"` // generate VALIDATION.md in worktree with test-first guidance
+	SessionPrefix              string               `yaml:"session_prefix"`      // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string               `yaml:"state_dir"`           // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig          `yaml:"model"`
 	Routing                    RoutingConfig        `yaml:"routing"`
 	DeployCmd                  string               `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
@@ -229,6 +231,9 @@ func parse(data []byte) (*Config, error) {
 	cfg.EnhancementPrompt = expandHome(cfg.EnhancementPrompt)
 	cfg.Pipeline.Planner.Prompt = expandHome(cfg.Pipeline.Planner.Prompt)
 	cfg.Pipeline.Validator.Prompt = expandHome(cfg.Pipeline.Validator.Prompt)
+	for i, s := range cfg.PromptSections {
+		cfg.PromptSections[i] = expandHome(s)
+	}
 	cfg.StateDir = expandHome(cfg.StateDir)
 
 	// Default session_prefix: first 3 chars of repo name

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1089,3 +1089,43 @@ hooks:
 		t.Errorf("Hooks.TimeoutMs = %d, want 60000 (default)", cfg.Hooks.TimeoutMs)
 	}
 }
+
+func TestParse_PromptSectionsDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(cfg.PromptSections) != 0 {
+		t.Errorf("PromptSections = %v, want empty", cfg.PromptSections)
+	}
+	if cfg.ValidationContract {
+		t.Error("ValidationContract should default to false")
+	}
+}
+
+func TestParse_PromptSectionsExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+prompt_sections:
+  - ./tdd-section.md
+  - ./style-section.md
+validation_contract: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(cfg.PromptSections) != 2 {
+		t.Fatalf("PromptSections length = %d, want 2", len(cfg.PromptSections))
+	}
+	if cfg.PromptSections[0] != "./tdd-section.md" {
+		t.Errorf("PromptSections[0] = %q, want ./tdd-section.md", cfg.PromptSections[0])
+	}
+	if cfg.PromptSections[1] != "./style-section.md" {
+		t.Errorf("PromptSections[1] = %q, want ./style-section.md", cfg.PromptSections[1])
+	}
+	if !cfg.ValidationContract {
+		t.Error("ValidationContract should be true")
+	}
+}

--- a/internal/worker/validation.go
+++ b/internal/worker/validation.go
@@ -1,0 +1,72 @@
+package worker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+// GenerateValidationContract produces a structured validation contract for the
+// given issue and writes it as VALIDATION.md in the worktree directory.
+// Returns the contract text and any error.
+//
+// The contract encodes:
+//   - Test-first workflow instructions
+//   - Required assertions derived from the issue description
+//   - Quality gates (build, test, lint, smoke test)
+//   - Done vs partial criteria
+func GenerateValidationContract(issue github.Issue, worktreePath string) (string, error) {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("# Validation Contract — Issue #%d: %s\n\n", issue.Number, issue.Title))
+
+	// Test-first workflow
+	b.WriteString("## Test-First Workflow\n\n")
+	b.WriteString("Before writing implementation code, follow this sequence:\n\n")
+	b.WriteString("1. **Identify assertions** — extract testable requirements from the issue description\n")
+	b.WriteString("2. **Write failing tests** — encode each assertion as a test that fails before implementation\n")
+	b.WriteString("3. **Implement until tests pass** — write the minimum code to make each test green\n")
+	b.WriteString("4. **Refactor** — clean up only after all tests pass\n\n")
+	b.WriteString("This prevents implementation-led tests that merely confirm what was written.\n\n")
+
+	// Issue requirements
+	b.WriteString("## Issue Requirements\n\n")
+	if strings.TrimSpace(issue.Body) != "" {
+		b.WriteString(issue.Body)
+		b.WriteString("\n\n")
+	} else {
+		b.WriteString("(No description provided — derive assertions from the issue title.)\n\n")
+	}
+
+	// Quality gates
+	b.WriteString("## Quality Gates\n\n")
+	b.WriteString("All of the following must pass before the PR is opened:\n\n")
+	b.WriteString("- [ ] **Build passes** — project compiles without errors\n")
+	b.WriteString("- [ ] **Tests pass** — all existing and new tests are green\n")
+	b.WriteString("- [ ] **Lint clean** — no formatter or linter warnings\n")
+	b.WriteString("- [ ] **Smoke test** — manual verification that the feature works as described\n\n")
+
+	// Done criteria
+	b.WriteString("## Done Criteria\n\n")
+	b.WriteString("**Done** means:\n")
+	b.WriteString("- All quality gates pass\n")
+	b.WriteString("- Tests cover the assertions derived from the issue\n")
+	b.WriteString("- PR description includes validation evidence (which assertions passed)\n\n")
+	b.WriteString("**Partial** means:\n")
+	b.WriteString("- Some quality gates pass but not all\n")
+	b.WriteString("- Implementation works but tests are missing or incomplete\n")
+	b.WriteString("- PR opened without validation evidence\n")
+
+	contract := b.String()
+
+	// Write to worktree
+	outPath := filepath.Join(worktreePath, "VALIDATION.md")
+	if err := os.WriteFile(outPath, []byte(contract), 0644); err != nil {
+		return "", fmt.Errorf("write VALIDATION.md: %w", err)
+	}
+
+	return contract, nil
+}

--- a/internal/worker/validation_test.go
+++ b/internal/worker/validation_test.go
@@ -1,0 +1,136 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+func TestGenerateValidationContract_WritesFile(t *testing.T) {
+	dir := t.TempDir()
+	issue := github.Issue{
+		Number: 42,
+		Title:  "Add user authentication",
+		Body:   "Implement OAuth2 login flow with Google provider.\n\n- Users can sign in with Google\n- Session persists across page reloads\n- Logout clears session",
+	}
+
+	contract, err := GenerateValidationContract(issue, dir)
+	if err != nil {
+		t.Fatalf("GenerateValidationContract() error: %v", err)
+	}
+
+	// Contract text should be returned
+	if contract == "" {
+		t.Fatal("expected non-empty contract string")
+	}
+
+	// VALIDATION.md should be written to the worktree
+	data, err := os.ReadFile(filepath.Join(dir, "VALIDATION.md"))
+	if err != nil {
+		t.Fatalf("expected VALIDATION.md to exist: %v", err)
+	}
+	if string(data) != contract {
+		t.Error("file content should match returned contract")
+	}
+}
+
+func TestGenerateValidationContract_ContainsIssueInfo(t *testing.T) {
+	dir := t.TempDir()
+	issue := github.Issue{
+		Number: 99,
+		Title:  "Fix broken pagination",
+		Body:   "The pagination component breaks when there are more than 100 items.",
+	}
+
+	contract, err := GenerateValidationContract(issue, dir)
+	if err != nil {
+		t.Fatalf("GenerateValidationContract() error: %v", err)
+	}
+
+	required := []string{
+		"#99",
+		"Fix broken pagination",
+		"Quality Gates",
+		"Build passes",
+		"Tests pass",
+	}
+	for _, want := range required {
+		if !strings.Contains(contract, want) {
+			t.Errorf("contract missing %q", want)
+		}
+	}
+}
+
+func TestGenerateValidationContract_ContainsTestFirstSection(t *testing.T) {
+	dir := t.TempDir()
+	issue := github.Issue{
+		Number: 10,
+		Title:  "Add search feature",
+		Body:   "Add full-text search to the API.",
+	}
+
+	contract, err := GenerateValidationContract(issue, dir)
+	if err != nil {
+		t.Fatalf("GenerateValidationContract() error: %v", err)
+	}
+
+	required := []string{
+		"Test-First",
+		"Write failing tests",
+		"Implement until tests pass",
+	}
+	for _, want := range required {
+		if !strings.Contains(contract, want) {
+			t.Errorf("contract missing %q", want)
+		}
+	}
+}
+
+func TestGenerateValidationContract_ContainsDoneCriteria(t *testing.T) {
+	dir := t.TempDir()
+	issue := github.Issue{
+		Number: 5,
+		Title:  "Refactor config loader",
+		Body:   "Simplify the config loading logic.",
+	}
+
+	contract, err := GenerateValidationContract(issue, dir)
+	if err != nil {
+		t.Fatalf("GenerateValidationContract() error: %v", err)
+	}
+
+	required := []string{
+		"Done Criteria",
+		"Partial",
+	}
+	for _, want := range required {
+		if !strings.Contains(contract, want) {
+			t.Errorf("contract missing %q", want)
+		}
+	}
+}
+
+func TestGenerateValidationContract_EmptyBody(t *testing.T) {
+	dir := t.TempDir()
+	issue := github.Issue{
+		Number: 1,
+		Title:  "Minimal issue",
+		Body:   "",
+	}
+
+	contract, err := GenerateValidationContract(issue, dir)
+	if err != nil {
+		t.Fatalf("GenerateValidationContract() error: %v", err)
+	}
+
+	// Should still produce a valid contract even with empty body
+	if !strings.Contains(contract, "#1") {
+		t.Error("contract should reference issue number even with empty body")
+	}
+	if !strings.Contains(contract, "Quality Gates") {
+		t.Error("contract should include quality gates even with empty body")
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -70,6 +70,19 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		log.Printf("[worker] after_create hook failed: %v", err)
 	}
 
+	// Generate validation contract in worktree (if enabled and not already present from hook)
+	if cfg.ValidationContract {
+		if _, err := os.Stat(filepath.Join(worktreePath, "VALIDATION.md")); os.IsNotExist(err) {
+			if _, err := GenerateValidationContract(issue, worktreePath); err != nil {
+				log.Printf("[worker] validation contract generation failed: %v", err)
+			} else {
+				log.Printf("[worker] generated VALIDATION.md in %s", worktreePath)
+			}
+		} else {
+			log.Printf("[worker] VALIDATION.md already present (from hook), skipping generation")
+		}
+	}
+
 	// Assemble worker prompt
 	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
 
@@ -196,6 +209,19 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	}
 	if err := RunHook(cfg, "after_create", cfg.Hooks.AfterCreate, hookEnv); err != nil {
 		log.Printf("[worker] after_create hook failed: %v", err)
+	}
+
+	// Generate validation contract in worktree (if enabled and not already present from hook)
+	if cfg.ValidationContract {
+		if _, err := os.Stat(filepath.Join(worktreePath, "VALIDATION.md")); os.IsNotExist(err) {
+			if _, err := GenerateValidationContract(issue, worktreePath); err != nil {
+				log.Printf("[worker] validation contract generation failed: %v", err)
+			} else {
+				log.Printf("[worker] generated VALIDATION.md in %s", worktreePath)
+			}
+		} else {
+			log.Printf("[worker] VALIDATION.md already present (from hook), skipping generation")
+		}
 	}
 
 	// Assemble worker prompt
@@ -645,9 +671,16 @@ func readValidationContract(worktreePath string) string {
 // assemblePrompt builds the final worker prompt.
 // If the base template contains {{ISSUE_NUMBER}} placeholders, it performs
 // template substitution. Otherwise it falls back to appending a task block.
-// If the template contains {{VALIDATION_CONTRACT}}, it replaces it with
-// the content of VALIDATION.md from the worktree (or a fallback message).
+//
+// Additional behavior:
+//   - If {{VALIDATION_CONTRACT}} is in the template, replaces it with VALIDATION.md
+//     content (or a fallback message if the file is missing)
+//   - If VALIDATION.md exists but no placeholder is present, appends the contract
+//   - Loads and appends any prompt section files from cfg.PromptSections
 func assemblePrompt(base string, issue github.Issue, worktreePath, branchName string, cfg *config.Config) string {
+	// Load validation contract from worktree (if present)
+	validationContract := readValidationContract(worktreePath)
+
 	if strings.Contains(base, "{{ISSUE_NUMBER}}") {
 		// Template-style substitution
 		replacements := []string{
@@ -660,8 +693,10 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 		}
 
 		// Handle {{VALIDATION_CONTRACT}} placeholder
+		contractInlined := false
 		if strings.Contains(base, "{{VALIDATION_CONTRACT}}") {
-			contract := readValidationContract(worktreePath)
+			contractInlined = true
+			contract := validationContract
 			if contract == "" {
 				contract = "_No VALIDATION.md found in worktree. Define your own acceptance criteria from the issue requirements before implementing._"
 			}
@@ -669,11 +704,12 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 		}
 
 		r := strings.NewReplacer(replacements...)
-		return r.Replace(base)
+		result := r.Replace(base)
+		return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, contractInlined)
 	}
 
 	// Legacy: append task block after base prompt
-	return fmt.Sprintf(`%s
+	result := fmt.Sprintf(`%s
 
 ---
 
@@ -712,6 +748,33 @@ Always rebase on origin/main immediately before creating the PR.
 		issue.Title,
 		issue.Number,
 	)
+	return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, false)
+}
+
+// appendSectionsAndValidation appends prompt section files and the validation
+// contract (if not already inlined via placeholder) to the prompt.
+func appendSectionsAndValidation(prompt string, sectionPaths []string, validationContract string, contractAlreadyInlined bool) string {
+	var b strings.Builder
+	b.WriteString(prompt)
+
+	// Append prompt sections
+	for _, path := range sectionPaths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			log.Printf("[worker] warn: could not read prompt section %s: %v", path, err)
+			continue
+		}
+		b.WriteString("\n\n---\n\n")
+		b.WriteString(string(data))
+	}
+
+	// Append validation contract if present and not already inlined
+	if validationContract != "" && !contractAlreadyInlined {
+		b.WriteString("\n\n---\n\n")
+		b.WriteString(validationContract)
+	}
+
+	return b.String()
 }
 
 // SlotNameFromPID finds a slot name by PID string (for display)

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -33,6 +33,8 @@ func TestAssemblePromptIncludesSecretSafetyGuardrails(t *testing.T) {
 	}
 }
 
+// --- Tests from main: validation contract placeholder ---
+
 func TestAssemblePrompt_ValidationContractFromFile(t *testing.T) {
 	worktree := t.TempDir()
 	validationContent := `## Validation Contract
@@ -76,7 +78,7 @@ func TestAssemblePrompt_ValidationContractMissingFile(t *testing.T) {
 }
 
 func TestAssemblePrompt_NoValidationPlaceholder(t *testing.T) {
-	// Templates without {{VALIDATION_CONTRACT}} should work unchanged
+	// Templates without {{VALIDATION_CONTRACT}} and no VALIDATION.md should work unchanged
 	cfg := &config.Config{Repo: "BeFeast/maestro"}
 	issue := github.Issue{Number: 10, Title: "basic", Body: "Simple issue."}
 	base := "Template with {{ISSUE_NUMBER}} only."
@@ -87,7 +89,7 @@ func TestAssemblePrompt_NoValidationPlaceholder(t *testing.T) {
 		t.Fatal("expected issue number in prompt")
 	}
 	if strings.Contains(prompt, "VALIDATION") {
-		t.Fatal("should not inject validation content when placeholder is absent")
+		t.Fatal("should not inject validation content when placeholder is absent and no file exists")
 	}
 }
 
@@ -110,4 +112,85 @@ func TestReadValidationContract(t *testing.T) {
 			t.Fatalf("expected empty string for missing file, got %q", got)
 		}
 	})
+}
+
+// --- Tests for prompt sections ---
+
+func TestAssemblePrompt_IncludesPromptSections(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write two section files
+	section1 := filepath.Join(dir, "tdd.md")
+	section2 := filepath.Join(dir, "style.md")
+	os.WriteFile(section1, []byte("## TDD Section\nWrite tests first."), 0644)
+	os.WriteFile(section2, []byte("## Style Section\nFollow coding standards."), 0644)
+
+	cfg := &config.Config{
+		Repo:           "owner/repo",
+		PromptSections: []string{section1, section2},
+	}
+	issue := github.Issue{Number: 1, Title: "test", Body: "body"}
+
+	base := "Base prompt with {{ISSUE_NUMBER}}"
+	prompt := assemblePrompt(base, issue, "/tmp/wt", "feat/branch", cfg)
+
+	if !strings.Contains(prompt, "## TDD Section") {
+		t.Error("prompt should include TDD section content")
+	}
+	if !strings.Contains(prompt, "## Style Section") {
+		t.Error("prompt should include style section content")
+	}
+}
+
+func TestAssemblePrompt_SkipsMissingSections(t *testing.T) {
+	cfg := &config.Config{
+		Repo:           "owner/repo",
+		PromptSections: []string{"/nonexistent/path.md"},
+	}
+	issue := github.Issue{Number: 1, Title: "test", Body: "body"}
+
+	base := "Base prompt with {{ISSUE_NUMBER}}"
+	prompt := assemblePrompt(base, issue, "/tmp/wt", "feat/branch", cfg)
+
+	// Should still produce a valid prompt without crashing
+	if !strings.Contains(prompt, "Base prompt with 1") {
+		t.Error("prompt should still contain base content when sections are missing")
+	}
+}
+
+func TestAssemblePrompt_IncludesValidationContractAutoAppend(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a VALIDATION.md in the worktree
+	validationContent := "## Validation Contract\n- [ ] Build passes\n- [ ] Tests pass"
+	os.WriteFile(filepath.Join(dir, "VALIDATION.md"), []byte(validationContent), 0644)
+
+	cfg := &config.Config{Repo: "owner/repo"}
+	issue := github.Issue{Number: 5, Title: "test", Body: "body"}
+
+	// Template WITHOUT {{VALIDATION_CONTRACT}} — contract should be auto-appended
+	base := "Base prompt with {{ISSUE_NUMBER}}"
+	prompt := assemblePrompt(base, issue, dir, "feat/branch", cfg)
+
+	if !strings.Contains(prompt, "Validation Contract") {
+		t.Error("prompt should auto-append VALIDATION.md content when placeholder is absent")
+	}
+	if !strings.Contains(prompt, "Build passes") {
+		t.Error("prompt should include quality gates from VALIDATION.md")
+	}
+}
+
+func TestAssemblePrompt_NoValidationFileIsOK(t *testing.T) {
+	dir := t.TempDir() // empty dir, no VALIDATION.md
+
+	cfg := &config.Config{Repo: "owner/repo"}
+	issue := github.Issue{Number: 1, Title: "test", Body: "body"}
+
+	base := "Base prompt with {{ISSUE_NUMBER}}"
+	prompt := assemblePrompt(base, issue, dir, "feat/branch", cfg)
+
+	// Should still produce a valid prompt
+	if !strings.Contains(prompt, "Base prompt with 1") {
+		t.Error("prompt should work without VALIDATION.md")
+	}
 }

--- a/worker-prompt-tdd-section.md
+++ b/worker-prompt-tdd-section.md
@@ -1,0 +1,43 @@
+## Test-First Development Workflow
+
+Before writing any implementation code, follow this test-first sequence:
+
+### Step 1: Identify assertions
+Read the issue description and extract concrete, testable requirements. Each requirement
+becomes an assertion that your tests will verify.
+
+### Step 2: Write failing tests
+For each assertion, write a test that:
+- Describes the expected behavior clearly in the test name
+- Fails before implementation (proving it actually tests something)
+- Is deterministic and machine-checkable (no manual verification needed)
+
+### Step 3: Implement until tests pass
+Write the minimum code necessary to make each test pass. Do not write implementation
+code that is not exercised by a test.
+
+### Step 4: Refactor
+Only after all tests pass, clean up the implementation. Re-run tests after refactoring.
+
+### Why test-first?
+- Prevents implementation-led tests that just confirm what was written
+- Catches regressions — tests encode the contract, not the implementation
+- Forces clear thinking about requirements before coding
+
+---
+
+## Validation Evidence in PR
+
+When creating the PR, include validation evidence in the description:
+
+```
+## Validation
+- [ ] Tests written before implementation
+- [ ] All new tests pass
+- [ ] All existing tests still pass
+- [ ] Build compiles without errors
+- [ ] Lint/format clean
+```
+
+If a VALIDATION.md file exists in the worktree, read it first and use it as your
+validation checklist. Report which assertions passed in the PR body.


### PR DESCRIPTION
Implements #219

## Changes

Adds test-first guidance and structured validation contract support to the worker prompt system, without modifying protected production templates.

### New config options
- **`prompt_sections`** (list of file paths) — additional markdown files appended to the worker prompt, enabling test-first guidance sections
- **`validation_contract`** (bool) — when enabled, auto-generates `VALIDATION.md` in each worktree with test-first workflow, quality gates, and done/partial criteria

### Prompt assembly enhancements
- **`{{VALIDATION_CONTRACT}}` placeholder** — merges with existing support from main; replaces with VALIDATION.md content or a fallback message
- **Auto-append** — when VALIDATION.md exists in the worktree but no placeholder is used, the contract is appended to the prompt automatically
- **Prompt sections** — loads and appends all files listed in `prompt_sections` config, with graceful skip on missing files

### Validation contract generation
- `GenerateValidationContract()` writes a structured `VALIDATION.md` to the worktree containing:
  - Test-first workflow instructions (identify assertions → write failing tests → implement → refactor)
  - Issue requirements extracted from the issue body
  - Quality gates checklist (build, tests, lint, smoke test)
  - Done vs partial criteria
- Integrated into `Start()` and `Respawn()` flows, runs after `after_create` hook
- Respects hook-generated VALIDATION.md (won't overwrite if hook already created one)

### Sample TDD prompt section
- `worker-prompt-tdd-section.md` — ready-to-use prompt section with test-first guidance and PR validation evidence template

## Testing

- 5 tests for `GenerateValidationContract` (file creation, issue info, test-first content, done criteria, empty body)
- 6 tests for prompt assembly (sections, missing sections, validation auto-append, no file, placeholder replacement)
- 4 tests from main for validation placeholder (contract from file, missing file fallback, no placeholder, readValidationContract)
- 2 tests for config parsing (default values, explicit prompt_sections + validation_contract)
- All existing tests pass (`go test ./...` — 13 packages)
- Build verified (`go build ./cmd/maestro/ && ./maestro version`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds test-first guidance and a structured validation contract system to the worker prompt pipeline, introducing two new config options (`prompt_sections` and `validation_contract`), a `GenerateValidationContract` function that writes `VALIDATION.md` into each worktree, and auto-append logic so the contract reaches the AI worker regardless of whether a template placeholder is present.

- `internal/worker/validation.go`: new file generating structured `VALIDATION.md` with TDD workflow, issue requirements, quality gates, and done/partial criteria
- `internal/worker/worker.go`: integrates contract generation into `Start()` and `Respawn()` after the `after_create` hook, and extends `assemblePrompt` / new `appendSectionsAndValidation` to handle auto-append and `PromptSections` loading
- `internal/config/config.go`: adds `PromptSections []string` and `ValidationContract bool` fields with `expandHome` applied to section paths
- One logic issue: the `os.Stat` `else` branch in both `Start()` and `Respawn()` fires not only when `VALIDATION.md` exists but also when `os.Stat` returns any non-`IsNotExist` error (e.g. permission denied), silently skipping contract generation while logging a misleading "already present" message
- Test coverage is solid across all new code paths (17 new tests)

<h3>Confidence Score: 4/5</h3>

- PR is safe to merge after addressing the os.Stat error-handling edge case in Start() and Respawn().
- The implementation is well-structured, thoroughly tested, and additive (no breaking changes to existing behaviour). The one concrete logic bug — the os.Stat else branch silently swallowing non-IsNotExist errors and emitting a misleading log — is a targeted, easy fix. Everything else (config, contract generation, prompt assembly, tests) is clean.
- internal/worker/worker.go — os.Stat error handling in both Start() and Respawn()

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/worker.go | Integrates validation contract generation into Start() and Respawn(), and refactors assemblePrompt to support auto-appending VALIDATION.md and loading PromptSections. The os.Stat else-branch incorrectly handles non-IsNotExist errors in both Start() and Respawn(), logging a misleading message instead of surfacing the real error. |
| internal/worker/validation.go | New file implementing GenerateValidationContract; cleanly builds a structured VALIDATION.md and writes it to the worktree. No issues found. |
| internal/worker/validation_test.go | Five tests covering file creation, content assertions, test-first section, done criteria, and empty body. Coverage is thorough. |
| internal/worker/worker_prompt_test.go | Extends existing prompt tests with six new cases for prompt sections, auto-append, and missing-file handling. All scenarios are well covered. |
| internal/config/config.go | Adds PromptSections and ValidationContract config fields; correctly applies expandHome to each path in PromptSections during parsing. |
| internal/config/config_test.go | Two tests for default and explicit values of the new config fields. Clean and correct. |
| worker-prompt-tdd-section.md | Sample TDD prompt section file, ready to use as a PromptSections entry. No code issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/worker/worker.go
Line: 75-83

Comment:
**`else` branch swallows unexpected `os.Stat` errors**

When `os.Stat` returns an error that is **not** `os.IsNotExist` (e.g., a permission-denied error on a freshly created worktree), the `else` branch runs and logs `"VALIDATION.md already present (from hook), skipping generation"` — which is incorrect. The contract silently goes ungenerated while the log message claims the file is already there.

The same pattern is duplicated in `Respawn()` at approximately line 216.

Suggested fix:

```go
_, statErr := os.Stat(filepath.Join(worktreePath, "VALIDATION.md"))
if os.IsNotExist(statErr) {
    if _, err := GenerateValidationContract(issue, worktreePath); err != nil {
        log.Printf("[worker] validation contract generation failed: %v", err)
    } else {
        log.Printf("[worker] generated VALIDATION.md in %s", worktreePath)
    }
} else if statErr != nil {
    log.Printf("[worker] warn: could not stat VALIDATION.md: %v", statErr)
} else {
    log.Printf("[worker] VALIDATION.md already present (from hook), skipping generation")
}
```

Apply the same change in `Respawn()` (approx. line 216).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add test-first guidance and valida..."](https://github.com/befeast/maestro/commit/4626909bf3e3e5e558d8cbe621db15abbd375400) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25959150)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->