### PR TITLE
feat: mission mode — decompose epics into orchestrated child issues (#217)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,13 @@ type PipelineConfig struct {
 	// Implementer uses the existing worker_prompt / bug_prompt / enhancement_prompt settings.
 }
 
+// MissionsConfig controls mission mode for decomposing epics into child issues.
+type MissionsConfig struct {
+	Enabled     bool     `yaml:"enabled"`
+	MaxChildren int      `yaml:"max_children"` // max child issues per mission (default: 10)
+	Labels      []string `yaml:"labels"`       // labels that identify mission issues (default: ["mission", "epic"])
+}
+
 // HooksConfig holds lifecycle hook scripts that run at key points.
 type HooksConfig struct {
 	AfterCreate  string `yaml:"after_create"`  // runs once when a new issue workspace is first created
@@ -121,6 +128,7 @@ type Config struct {
 	CleanupWorktreesOnMerge    *bool                `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
 	Pipeline                   PipelineConfig       `yaml:"pipeline"`
 	Hooks                      HooksConfig          `yaml:"hooks"`
+	Missions                   MissionsConfig       `yaml:"missions"`
 	BlockerPatterns            []string             `yaml:"blocker_patterns"`      // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
 	PollIntervalSeconds        int                  `yaml:"poll_interval_seconds"` // override poll interval from config (0 = use CLI flag)
 	SourcePath                 string               `yaml:"-"`                     // path the config was loaded from (not serialized)
@@ -322,6 +330,14 @@ func parse(data []byte) (*Config, error) {
 	// Default hooks timeout
 	if cfg.Hooks.TimeoutMs <= 0 {
 		cfg.Hooks.TimeoutMs = 60000
+	}
+
+	// Missions defaults
+	if cfg.Missions.MaxChildren <= 0 {
+		cfg.Missions.MaxChildren = 10
+	}
+	if len(cfg.Missions.Labels) == 0 {
+		cfg.Missions.Labels = []string{"mission", "epic"}
 	}
 
 	return cfg, nil

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -551,6 +551,49 @@ func FindBlockers(body string, patterns []string) []int {
 	return blockers
 }
 
+// CreateIssue creates a new GitHub issue and returns its number.
+func (c *Client) CreateIssue(title, body string, labels []string) (int, error) {
+	args := []string{
+		"issue", "create",
+		"--repo", c.Repo,
+		"--title", title,
+		"--body", body,
+	}
+	for _, l := range labels {
+		args = append(args, "--label", l)
+	}
+
+	out, err := exec.Command("gh", args...).CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("gh issue create: %w\n%s", err, out)
+	}
+
+	// gh issue create prints the URL; extract issue number from last path segment
+	url := strings.TrimSpace(string(out))
+	parts := strings.Split(url, "/")
+	if len(parts) == 0 {
+		return 0, fmt.Errorf("unexpected gh issue create output: %s", url)
+	}
+	n, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		return 0, fmt.Errorf("parse issue number from %q: %w", url, err)
+	}
+	return n, nil
+}
+
+// EditIssueBody updates the body of a GitHub issue.
+func (c *Client) EditIssueBody(number int, body string) error {
+	out, err := exec.Command("gh", "issue", "edit",
+		strconv.Itoa(number),
+		"--repo", c.Repo,
+		"--body", body,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh issue edit %d --body: %w\n%s", number, err, out)
+	}
+	return nil
+}
+
 // HasLabel returns true if any of the issue's labels match
 func HasLabel(issue Issue, labels []string) bool {
 	for _, l := range issue.Labels {

--- a/internal/mission/mission.go
+++ b/internal/mission/mission.go
@@ -1,0 +1,375 @@
+package mission
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// ChildTask represents a parsed subtask from a mission issue body.
+type ChildTask struct {
+	Title string
+	Body  string
+}
+
+// ChildStatus tracks a child issue's progress for parent checklist updates.
+type ChildStatus struct {
+	Number int
+	Title  string
+	Closed bool
+}
+
+// Processor handles mission decomposition and progress tracking.
+type Processor struct {
+	cfg *config.Config
+	gh  *github.Client
+
+	// Testing hooks
+	CreateIssueFn   func(title, body string, labels []string) (int, error)
+	EditIssueBodyFn func(number int, body string) error
+	IsIssueClosedFn func(number int) (bool, error)
+	GetIssueFn      func(number int) (github.Issue, error)
+}
+
+// NewProcessor creates a new mission processor.
+func NewProcessor(cfg *config.Config, gh *github.Client) *Processor {
+	return &Processor{cfg: cfg, gh: gh}
+}
+
+func (p *Processor) createIssue(title, body string, labels []string) (int, error) {
+	if p.CreateIssueFn != nil {
+		return p.CreateIssueFn(title, body, labels)
+	}
+	return p.gh.CreateIssue(title, body, labels)
+}
+
+func (p *Processor) editIssueBody(number int, body string) error {
+	if p.EditIssueBodyFn != nil {
+		return p.EditIssueBodyFn(number, body)
+	}
+	return p.gh.EditIssueBody(number, body)
+}
+
+func (p *Processor) isIssueClosed(number int) (bool, error) {
+	if p.IsIssueClosedFn != nil {
+		return p.IsIssueClosedFn(number)
+	}
+	return p.gh.IsIssueClosed(number)
+}
+
+func (p *Processor) getIssue(number int) (github.Issue, error) {
+	if p.GetIssueFn != nil {
+		return p.GetIssueFn(number)
+	}
+	return p.gh.GetIssue(number)
+}
+
+// IsMissionIssue returns true if the issue has a mission/epic label.
+func IsMissionIssue(issue github.Issue, missionLabels []string) bool {
+	return github.HasLabel(issue, missionLabels)
+}
+
+// DecomposeTasks parses the issue body for a task list.
+// It looks for markdown list items (- [ ] or - or * or numbered) under
+// headings containing "tasks", "subtasks", "plan", "milestones", or "steps".
+// Falls back to any top-level list items if no matching section is found.
+func DecomposeTasks(body string) []ChildTask {
+	lines := strings.Split(body, "\n")
+
+	var tasks []ChildTask
+	inTaskSection := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Detect headings that indicate a task section
+		if isHeading(trimmed) {
+			lower := strings.ToLower(trimmed)
+			inTaskSection = containsTaskKeyword(lower)
+			continue
+		}
+
+		if !inTaskSection {
+			continue
+		}
+
+		// Parse list items
+		title := parseListItem(trimmed)
+		if title == "" {
+			continue
+		}
+
+		tasks = append(tasks, ChildTask{Title: title})
+	}
+
+	// Fallback: if no task section found, scan entire body for checkbox items
+	if len(tasks) == 0 {
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if title := parseCheckboxItem(trimmed); title != "" {
+				tasks = append(tasks, ChildTask{Title: title})
+			}
+		}
+	}
+
+	return tasks
+}
+
+// ProcessMissions scans open issues for missions, decomposes new ones,
+// and updates progress on active missions.
+func (p *Processor) ProcessMissions(s *state.State, issues []github.Issue) {
+	if !p.cfg.Missions.Enabled {
+		return
+	}
+
+	// Ensure missions map is initialized
+	if s.Missions == nil {
+		s.Missions = make(map[int]*state.Mission)
+	}
+
+	// Phase 1: Detect and decompose new mission issues
+	for _, issue := range issues {
+		if !IsMissionIssue(issue, p.cfg.Missions.Labels) {
+			continue
+		}
+
+		// Skip if already tracked
+		if _, ok := s.Missions[issue.Number]; ok {
+			continue
+		}
+
+		log.Printf("[mission] detected new mission issue #%d: %s", issue.Number, issue.Title)
+		p.decomposeMission(s, issue)
+	}
+
+	// Phase 2: Update progress on active missions
+	for parentNum, m := range s.Missions {
+		if m.Status == "done" {
+			continue
+		}
+		p.updateMissionProgress(s, parentNum, m)
+	}
+}
+
+// decomposeMission parses the issue body, creates child issues, and records the mission.
+func (p *Processor) decomposeMission(s *state.State, issue github.Issue) {
+	tasks := DecomposeTasks(issue.Body)
+	if len(tasks) == 0 {
+		log.Printf("[mission] no tasks found in issue #%d body, skipping decomposition", issue.Number)
+		return
+	}
+
+	// Enforce max_children
+	if len(tasks) > p.cfg.Missions.MaxChildren {
+		log.Printf("[mission] issue #%d has %d tasks, capping at %d", issue.Number, len(tasks), p.cfg.Missions.MaxChildren)
+		tasks = tasks[:p.cfg.Missions.MaxChildren]
+	}
+
+	// Determine labels for child issues: use the configured issue_labels
+	// so maestro picks them up for dispatch
+	childLabels := make([]string, len(p.cfg.IssueLabels))
+	copy(childLabels, p.cfg.IssueLabels)
+
+	var childNumbers []int
+	var prevChildNum int
+
+	for i, task := range tasks {
+		// Build child issue body with parent reference and blocker
+		body := formatChildBody(issue.Number, task, prevChildNum)
+
+		title := fmt.Sprintf("%s (#%d/%d)", task.Title, i+1, len(tasks))
+		childNum, err := p.createIssue(title, body, childLabels)
+		if err != nil {
+			log.Printf("[mission] failed to create child issue %d/%d for #%d: %v",
+				i+1, len(tasks), issue.Number, err)
+			continue
+		}
+
+		log.Printf("[mission] created child issue #%d: %s", childNum, title)
+		childNumbers = append(childNumbers, childNum)
+
+		// Sync to GitHub Projects if enabled
+		if p.cfg.GitHubProjects.Enabled && p.cfg.GitHubProjects.ProjectNumber > 0 {
+			p.gh.SyncIssueToProject(childNum, p.cfg.GitHubProjects.ProjectNumber, github.ProjectStatusTodo)
+		}
+
+		prevChildNum = childNum
+	}
+
+	if len(childNumbers) == 0 {
+		log.Printf("[mission] no child issues created for #%d", issue.Number)
+		return
+	}
+
+	// Record mission in state
+	s.Missions[issue.Number] = &state.Mission{
+		ParentIssue: issue.Number,
+		ChildIssues: childNumbers,
+		Status:      "active",
+	}
+
+	// Update parent issue with checklist
+	checklist := formatParentChecklist(childNumbers, issue.Body)
+	if err := p.editIssueBody(issue.Number, checklist); err != nil {
+		log.Printf("[mission] failed to update parent issue #%d body: %v", issue.Number, err)
+	}
+
+	log.Printf("[mission] decomposed issue #%d into %d child issues: %v", issue.Number, len(childNumbers), childNumbers)
+}
+
+// updateMissionProgress checks child issue status and updates the parent.
+func (p *Processor) updateMissionProgress(s *state.State, parentNum int, m *state.Mission) {
+	var statuses []ChildStatus
+	allClosed := true
+
+	for _, childNum := range m.ChildIssues {
+		closed, err := p.isIssueClosed(childNum)
+		if err != nil {
+			log.Printf("[mission] could not check status of child issue #%d: %v", childNum, err)
+			allClosed = false
+			continue
+		}
+
+		childIssue, err := p.getIssue(childNum)
+		title := fmt.Sprintf("#%d", childNum)
+		if err == nil {
+			title = childIssue.Title
+		}
+
+		statuses = append(statuses, ChildStatus{
+			Number: childNum,
+			Title:  title,
+			Closed: closed,
+		})
+
+		if !closed {
+			allClosed = false
+		}
+	}
+
+	// Update parent issue body with current progress
+	progressBody := formatProgressUpdate(parentNum, statuses)
+	if err := p.editIssueBody(parentNum, progressBody); err != nil {
+		log.Printf("[mission] failed to update parent #%d progress: %v", parentNum, err)
+	}
+
+	// If all children are done, mark mission as done
+	if allClosed && len(m.ChildIssues) > 0 {
+		m.Status = "done"
+		log.Printf("[mission] all child issues closed for mission #%d — marking done", parentNum)
+
+		// Sync parent to done in GitHub Projects
+		if p.cfg.GitHubProjects.Enabled && p.cfg.GitHubProjects.ProjectNumber > 0 {
+			p.gh.SyncIssueToProject(parentNum, p.cfg.GitHubProjects.ProjectNumber, github.ProjectStatusDone)
+		}
+	}
+}
+
+// formatChildBody builds the body for a child issue.
+func formatChildBody(parentNumber int, task ChildTask, blockerNumber int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Part of mission #%d\n\n", parentNumber))
+
+	if task.Body != "" {
+		sb.WriteString(task.Body)
+		sb.WriteString("\n\n")
+	}
+
+	if blockerNumber > 0 {
+		sb.WriteString(fmt.Sprintf("Blocked by #%d\n", blockerNumber))
+	}
+
+	return sb.String()
+}
+
+// formatParentChecklist appends a progress checklist to the original issue body.
+func formatParentChecklist(childNumbers []int, originalBody string) string {
+	var sb strings.Builder
+	sb.WriteString(originalBody)
+	sb.WriteString("\n\n---\n\n## Mission Progress\n\n")
+
+	for i, num := range childNumbers {
+		sb.WriteString(fmt.Sprintf("- [ ] #%d (step %d/%d)\n", num, i+1, len(childNumbers)))
+	}
+
+	return sb.String()
+}
+
+// formatProgressUpdate generates a full progress checklist for the parent issue.
+func formatProgressUpdate(parentNum int, statuses []ChildStatus) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("## Mission #%d Progress\n\n", parentNum))
+
+	doneCount := 0
+	for i, cs := range statuses {
+		check := " "
+		if cs.Closed {
+			check = "x"
+			doneCount++
+		}
+		sb.WriteString(fmt.Sprintf("- [%s] #%d — %s (step %d/%d)\n", check, cs.Number, cs.Title, i+1, len(statuses)))
+	}
+
+	sb.WriteString(fmt.Sprintf("\n**Progress: %d/%d complete**\n", doneCount, len(statuses)))
+
+	return sb.String()
+}
+
+// isHeading returns true if the line is a markdown heading.
+func isHeading(line string) bool {
+	return strings.HasPrefix(line, "#")
+}
+
+// containsTaskKeyword returns true if the heading text suggests a task section.
+func containsTaskKeyword(lower string) bool {
+	keywords := []string{"task", "subtask", "plan", "milestone", "step", "breakdown", "work item", "child issue"}
+	for _, kw := range keywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseListItem extracts the text from a markdown list item.
+// Supports: "- text", "* text", "1. text", "- [ ] text", "- [x] text"
+func parseListItem(line string) string {
+	// Checkbox items
+	if title := parseCheckboxItem(line); title != "" {
+		return title
+	}
+
+	// Unordered list: - or *
+	for _, prefix := range []string{"- ", "* "} {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(line[len(prefix):])
+		}
+	}
+
+	// Numbered list: "1. text"
+	for i, ch := range line {
+		if ch >= '0' && ch <= '9' {
+			continue
+		}
+		if ch == '.' && i > 0 && i < len(line)-1 && line[i+1] == ' ' {
+			return strings.TrimSpace(line[i+2:])
+		}
+		break
+	}
+
+	return ""
+}
+
+// parseCheckboxItem extracts text from "- [ ] text" or "- [x] text" patterns.
+func parseCheckboxItem(line string) string {
+	for _, prefix := range []string{"- [ ] ", "- [x] ", "- [X] ", "* [ ] ", "* [x] ", "* [X] "} {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(line[len(prefix):])
+		}
+	}
+	return ""
+}

--- a/internal/mission/mission_test.go
+++ b/internal/mission/mission_test.go
@@ -1,0 +1,473 @@
+package mission
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// makeIssue creates a github.Issue with the given labels (works around json struct tags).
+func makeIssue(number int, title, body string, labelNames ...string) github.Issue {
+	issue := github.Issue{Number: number, Title: title, Body: body}
+	for _, name := range labelNames {
+		issue.Labels = append(issue.Labels, struct {
+			Name string `json:"name"`
+		}{Name: name})
+	}
+	return issue
+}
+
+func TestDecomposeTasks_TaskSection(t *testing.T) {
+	body := `## Summary
+Some epic description.
+
+## Tasks
+
+- Build the auth module
+- Implement the API endpoints
+- Write integration tests
+
+## Notes
+Some extra info.
+`
+	tasks := DecomposeTasks(body)
+	if len(tasks) != 3 {
+		t.Fatalf("expected 3 tasks, got %d: %v", len(tasks), tasks)
+	}
+	want := []string{"Build the auth module", "Implement the API endpoints", "Write integration tests"}
+	for i, task := range tasks {
+		if task.Title != want[i] {
+			t.Errorf("task %d: got %q, want %q", i, task.Title, want[i])
+		}
+	}
+}
+
+func TestDecomposeTasks_CheckboxFallback(t *testing.T) {
+	body := `## Epic: Build feature X
+
+- [ ] Design the schema
+- [x] Create the migration
+- [ ] Implement the handler
+`
+	tasks := DecomposeTasks(body)
+	if len(tasks) != 3 {
+		t.Fatalf("expected 3 tasks, got %d: %v", len(tasks), tasks)
+	}
+	if tasks[0].Title != "Design the schema" {
+		t.Errorf("task 0: got %q, want %q", tasks[0].Title, "Design the schema")
+	}
+}
+
+func TestDecomposeTasks_NumberedList(t *testing.T) {
+	body := `## Plan
+
+1. First step
+2. Second step
+3. Third step
+`
+	tasks := DecomposeTasks(body)
+	if len(tasks) != 3 {
+		t.Fatalf("expected 3 tasks, got %d: %v", len(tasks), tasks)
+	}
+	if tasks[0].Title != "First step" {
+		t.Errorf("task 0: got %q, want %q", tasks[0].Title, "First step")
+	}
+}
+
+func TestDecomposeTasks_MilestoneHeading(t *testing.T) {
+	body := `## Milestones
+
+- Phase 1: Foundation
+- Phase 2: Features
+`
+	tasks := DecomposeTasks(body)
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+}
+
+func TestDecomposeTasks_StepsHeading(t *testing.T) {
+	body := `### Steps
+
+* Step A
+* Step B
+`
+	tasks := DecomposeTasks(body)
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+	if tasks[0].Title != "Step A" {
+		t.Errorf("task 0: got %q, want %q", tasks[0].Title, "Step A")
+	}
+}
+
+func TestDecomposeTasks_EmptyBody(t *testing.T) {
+	tasks := DecomposeTasks("")
+	if len(tasks) != 0 {
+		t.Fatalf("expected 0 tasks, got %d", len(tasks))
+	}
+}
+
+func TestDecomposeTasks_NoTaskSection(t *testing.T) {
+	body := `## Summary
+Just a plain description with no task items.
+`
+	tasks := DecomposeTasks(body)
+	if len(tasks) != 0 {
+		t.Fatalf("expected 0 tasks from body without lists, got %d", len(tasks))
+	}
+}
+
+func TestIsMissionIssue(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue github.Issue
+		want  bool
+	}{
+		{
+			name:  "mission label",
+			issue: makeIssue(1, "test", "", "mission"),
+			want:  true,
+		},
+		{
+			name:  "epic label",
+			issue: makeIssue(2, "test", "", "Epic"),
+			want:  true,
+		},
+		{
+			name:  "no mission label",
+			issue: makeIssue(3, "test", "", "bug"),
+			want:  false,
+		},
+		{
+			name:  "empty labels",
+			issue: makeIssue(4, "test", ""),
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsMissionIssue(tt.issue, []string{"mission", "epic"})
+			if got != tt.want {
+				t.Errorf("IsMissionIssue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatChildBody(t *testing.T) {
+	task := ChildTask{Title: "Build auth", Body: "Implement OAuth2 flow"}
+	body := formatChildBody(42, task, 10)
+
+	if !strings.Contains(body, "Part of mission #42") {
+		t.Errorf("body missing parent ref: %s", body)
+	}
+	if !strings.Contains(body, "Blocked by #10") {
+		t.Errorf("body missing blocker ref: %s", body)
+	}
+	if !strings.Contains(body, "Implement OAuth2 flow") {
+		t.Errorf("body missing task body: %s", body)
+	}
+}
+
+func TestFormatChildBody_NoBlocker(t *testing.T) {
+	task := ChildTask{Title: "First task"}
+	body := formatChildBody(1, task, 0)
+	if strings.Contains(body, "Blocked by") {
+		t.Errorf("body should not have blocker for first task: %s", body)
+	}
+}
+
+func TestProcessMissions_DecomposeAndTrack(t *testing.T) {
+	cfg := &config.Config{
+		Repo:        "owner/repo",
+		IssueLabels: []string{"maestro"},
+		Missions: config.MissionsConfig{
+			Enabled:     true,
+			MaxChildren: 10,
+			Labels:      []string{"mission", "epic"},
+		},
+	}
+
+	gh := github.New("owner/repo")
+	proc := NewProcessor(cfg, gh)
+
+	childCounter := 100
+	proc.CreateIssueFn = func(title, body string, labels []string) (int, error) {
+		childCounter++
+		return childCounter, nil
+	}
+	proc.EditIssueBodyFn = func(number int, body string) error {
+		return nil
+	}
+	proc.IsIssueClosedFn = func(number int) (bool, error) {
+		return false, nil
+	}
+	proc.GetIssueFn = func(number int) (github.Issue, error) {
+		return github.Issue{Number: number, Title: fmt.Sprintf("Child #%d", number)}, nil
+	}
+
+	s := state.NewState()
+
+	issues := []github.Issue{
+		makeIssue(1, "Epic: Build the platform", `## Summary
+Build everything.
+
+## Tasks
+
+- Design the schema
+- Build the API
+- Build the frontend
+`, "mission"),
+	}
+
+	proc.ProcessMissions(s, issues)
+
+	if len(s.Missions) != 1 {
+		t.Fatalf("expected 1 mission, got %d", len(s.Missions))
+	}
+
+	m, ok := s.Missions[1]
+	if !ok {
+		t.Fatal("expected mission for issue #1")
+	}
+	if len(m.ChildIssues) != 3 {
+		t.Fatalf("expected 3 child issues, got %d", len(m.ChildIssues))
+	}
+	if m.Status != "active" {
+		t.Errorf("expected status 'active', got %q", m.Status)
+	}
+	for i, num := range m.ChildIssues {
+		if num != 101+i {
+			t.Errorf("child %d: expected #%d, got #%d", i, 101+i, num)
+		}
+	}
+}
+
+func TestProcessMissions_SkipAlreadyTracked(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Missions: config.MissionsConfig{
+			Enabled:     true,
+			MaxChildren: 10,
+			Labels:      []string{"mission"},
+		},
+	}
+
+	gh := github.New("owner/repo")
+	proc := NewProcessor(cfg, gh)
+
+	createCalled := false
+	proc.CreateIssueFn = func(title, body string, labels []string) (int, error) {
+		createCalled = true
+		return 0, fmt.Errorf("should not be called")
+	}
+	proc.IsIssueClosedFn = func(number int) (bool, error) {
+		return false, nil
+	}
+	proc.GetIssueFn = func(number int) (github.Issue, error) {
+		return github.Issue{Number: number, Title: "child"}, nil
+	}
+	proc.EditIssueBodyFn = func(number int, body string) error {
+		return nil
+	}
+
+	s := state.NewState()
+	s.Missions[1] = &state.Mission{
+		ParentIssue: 1,
+		ChildIssues: []int{10, 11},
+		Status:      "active",
+	}
+
+	issues := []github.Issue{makeIssue(1, "Already tracked mission", "", "mission")}
+
+	proc.ProcessMissions(s, issues)
+
+	if createCalled {
+		t.Error("CreateIssue should not be called for already-tracked mission")
+	}
+}
+
+func TestProcessMissions_MaxChildrenCap(t *testing.T) {
+	cfg := &config.Config{
+		Repo:        "owner/repo",
+		IssueLabels: []string{"maestro"},
+		Missions: config.MissionsConfig{
+			Enabled:     true,
+			MaxChildren: 2,
+			Labels:      []string{"mission"},
+		},
+	}
+
+	gh := github.New("owner/repo")
+	proc := NewProcessor(cfg, gh)
+
+	childCounter := 200
+	proc.CreateIssueFn = func(title, body string, labels []string) (int, error) {
+		childCounter++
+		return childCounter, nil
+	}
+	proc.EditIssueBodyFn = func(number int, body string) error {
+		return nil
+	}
+	proc.IsIssueClosedFn = func(number int) (bool, error) {
+		return false, nil
+	}
+	proc.GetIssueFn = func(number int) (github.Issue, error) {
+		return github.Issue{Number: number, Title: "child"}, nil
+	}
+
+	s := state.NewState()
+
+	issues := []github.Issue{
+		makeIssue(5, "Big epic", `## Tasks
+- Task 1
+- Task 2
+- Task 3
+- Task 4
+`, "mission"),
+	}
+
+	proc.ProcessMissions(s, issues)
+
+	m := s.Missions[5]
+	if m == nil {
+		t.Fatal("expected mission for issue #5")
+	}
+	if len(m.ChildIssues) != 2 {
+		t.Fatalf("expected 2 child issues (capped), got %d", len(m.ChildIssues))
+	}
+}
+
+func TestProcessMissions_AllChildrenClosed(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Missions: config.MissionsConfig{
+			Enabled:     true,
+			MaxChildren: 10,
+			Labels:      []string{"mission"},
+		},
+	}
+
+	gh := github.New("owner/repo")
+	proc := NewProcessor(cfg, gh)
+
+	proc.IsIssueClosedFn = func(number int) (bool, error) {
+		return true, nil
+	}
+	proc.GetIssueFn = func(number int) (github.Issue, error) {
+		return github.Issue{Number: number, Title: "done child"}, nil
+	}
+	proc.EditIssueBodyFn = func(number int, body string) error {
+		return nil
+	}
+
+	s := state.NewState()
+	s.Missions[1] = &state.Mission{
+		ParentIssue: 1,
+		ChildIssues: []int{10, 11, 12},
+		Status:      "active",
+	}
+
+	proc.ProcessMissions(s, nil)
+
+	if s.Missions[1].Status != "done" {
+		t.Errorf("expected mission status 'done', got %q", s.Missions[1].Status)
+	}
+}
+
+func TestProcessMissions_Disabled(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Missions: config.MissionsConfig{
+			Enabled: false,
+		},
+	}
+
+	gh := github.New("owner/repo")
+	proc := NewProcessor(cfg, gh)
+
+	s := state.NewState()
+	issues := []github.Issue{makeIssue(1, "test", "", "mission")}
+
+	proc.ProcessMissions(s, issues)
+
+	if len(s.Missions) != 0 {
+		t.Error("missions should not be processed when disabled")
+	}
+}
+
+func TestParseListItem(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"- Simple item", "Simple item"},
+		{"* Star item", "Star item"},
+		{"- [ ] Unchecked", "Unchecked"},
+		{"- [x] Checked", "Checked"},
+		{"1. Numbered", "Numbered"},
+		{"12. Multi-digit", "Multi-digit"},
+		{"Not a list item", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseListItem(tt.input)
+			if got != tt.want {
+				t.Errorf("parseListItem(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsTaskKeyword(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"## tasks", true},
+		{"## subtasks", true},
+		{"## implementation plan", true},
+		{"## milestones", true},
+		{"## steps", true},
+		{"## breakdown", true},
+		{"## summary", false},
+		{"## notes", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := containsTaskKeyword(tt.input)
+			if got != tt.want {
+				t.Errorf("containsTaskKeyword(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatProgressUpdate(t *testing.T) {
+	statuses := []ChildStatus{
+		{Number: 10, Title: "Design schema", Closed: true},
+		{Number: 11, Title: "Build API", Closed: false},
+		{Number: 12, Title: "Build frontend", Closed: false},
+	}
+
+	body := formatProgressUpdate(1, statuses)
+
+	if !strings.Contains(body, "[x] #10") {
+		t.Error("expected closed child to have [x]")
+	}
+	if !strings.Contains(body, "[ ] #11") {
+		t.Error("expected open child to have [ ]")
+	}
+	if !strings.Contains(body, "1/3 complete") {
+		t.Errorf("expected progress count, got: %s", body)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/mission"
 	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/pipeline"
 	"github.com/befeast/maestro/internal/router"
@@ -55,6 +56,9 @@ type Orchestrator struct {
 	listOpenIssuesFn func(labels []string) ([]github.Issue, error)
 	workerStartFn    func(cfg *config.Config, s *state.State, repo string, issue github.Issue, promptBase, backend string) (string, error)
 
+	// Mission processor (nil when missions disabled)
+	missionProc *mission.Processor
+
 	// Config hot-reload channel (nil = disabled, safe in select)
 	configReloadCh <-chan *config.Config
 
@@ -76,13 +80,19 @@ func New(cfg *config.Config) *Orchestrator {
 		n.SetDigestMode(true)
 		log.Printf("[orch] digest mode enabled — notifications will be batched per cycle")
 	}
-	return &Orchestrator{
+	gh := github.New(cfg.Repo)
+	o := &Orchestrator{
 		cfg:      cfg,
 		notifier: n,
-		gh:       github.New(cfg.Repo),
+		gh:       gh,
 		router:   router.New(cfg),
 		repo:     cfg.Repo,
 	}
+	if cfg.Missions.Enabled {
+		o.missionProc = mission.NewProcessor(cfg, gh)
+		log.Printf("[orch] mission mode enabled (max_children=%d, labels=%v)", cfg.Missions.MaxChildren, cfg.Missions.Labels)
+	}
+	return o
 }
 
 func (o *Orchestrator) pidAlive(pid int) bool {
@@ -496,6 +506,16 @@ func (o *Orchestrator) RunOnce() error {
 
 	// Step 4: Rebase conflicting PRs
 	o.rebaseConflicts(s)
+
+	// Step 4b: Process missions (decompose new epics, update progress)
+	if o.missionProc != nil {
+		issues, err := o.listOpenIssues(o.cfg.IssueLabels)
+		if err != nil {
+			log.Printf("[orch] list issues for missions: %v", err)
+		} else {
+			o.missionProc.ProcessMissions(s, issues)
+		}
+	}
 
 	// Save after all checks/reconciliation
 	if err := state.Save(o.cfg.StateDir, s); err != nil {
@@ -1545,6 +1565,16 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 	started := 0
 	for _, issue := range issues {
 		if s.IssueInProgress(issue.Number) {
+			continue
+		}
+
+		// Skip mission parent issues — they are decomposed, not dispatched directly
+		if s.IsMissionParent(issue.Number) {
+			continue
+		}
+
+		// Skip issues that carry a mission/epic label (they should be decomposed first)
+		if o.cfg.Missions.Enabled && mission.IsMissionIssue(issue, o.cfg.Missions.Labels) && !s.IsMissionChild(issue.Number) {
 			continue
 		}
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -87,8 +87,16 @@ func (s *Session) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Mission tracks a decomposed epic and its child issues.
+type Mission struct {
+	ParentIssue int    `json:"parent_issue"`
+	ChildIssues []int  `json:"child_issues"`
+	Status      string `json:"status"` // "active", "done"
+}
+
 type State struct {
 	Sessions    map[string]*Session `json:"sessions"`
+	Missions    map[int]*Mission    `json:"missions,omitempty"` // parent issue number → mission
 	NextSlot    int                 `json:"next_slot"`
 	LastMergeAt time.Time           `json:"last_merge_at,omitempty"`
 }
@@ -96,6 +104,7 @@ type State struct {
 func NewState() *State {
 	return &State{
 		Sessions: make(map[string]*Session),
+		Missions: make(map[int]*Mission),
 		NextSlot: 1,
 	}
 }
@@ -280,6 +289,30 @@ func (s *State) CompletedSessions() []CompletedSession {
 		return fi.After(*fj)
 	})
 	return result
+}
+
+// IsMissionParent returns true if the given issue number is a mission parent.
+func (s *State) IsMissionParent(issueNum int) bool {
+	if s.Missions == nil {
+		return false
+	}
+	_, ok := s.Missions[issueNum]
+	return ok
+}
+
+// IsMissionChild returns true if the given issue number is a child of any mission.
+func (s *State) IsMissionChild(issueNum int) bool {
+	if s.Missions == nil {
+		return false
+	}
+	for _, m := range s.Missions {
+		for _, child := range m.ChildIssues {
+			if child == issueNum {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // PruneOldSessions removes completed sessions older than maxAge.


### PR DESCRIPTION
Implements #217

## Changes

Adds mission mode that automates decomposing large epics into child issues and orchestrating their execution:

- **Config**: New `missions` config block with `enabled`, `max_children` (default: 10), and `labels` (default: `["mission", "epic"]`)
- **Mission package** (`internal/mission/`): Core decomposition logic that parses issue body task lists (markdown lists under headings like `## Tasks`, `## Steps`, `## Milestones`, etc.) and creates child issues with sequential blocker references
- **GitHub client**: Added `CreateIssue` and `EditIssueBody` methods for child issue management
- **State tracking**: `Mission` struct tracks parent→child mappings with `active`/`done` status, persisted in `state.json`
- **Orchestrator integration**: 
  - Processes missions each cycle (decomposes new epics, updates progress on active ones)
  - Excludes mission parent issues from direct worker dispatch
  - Child issues get blocker references (`Blocked by #N`) so existing blocker-aware dispatch handles dependency ordering
- **Progress sync**: Parent issue body updated with a checklist showing child issue completion status; mission marked done when all children close; integrates with GitHub Projects sync

### How it works

1. Issue labeled `mission` or `epic` is detected in the orchestration loop
2. Body is parsed for task lists → child issues created with sequential blockers
3. Existing blocker-aware dispatch ensures children execute in dependency order
4. Parent issue updated with progress checklist each cycle
5. When all children close, mission status transitions to `done`

### Config example
```yaml
missions:
  enabled: true
  max_children: 10
  labels: ["mission", "epic"]
```

## Testing

- 17 unit tests covering decomposition, progress tracking, label detection, max children cap, skip-already-tracked, all-children-closed transition, and disabled mode
- All existing tests pass (14 packages, 0 failures)
- `go vet`, `go fmt`, `go build` all clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements mission mode — a new orchestration layer that decomposes epic/mission-labeled issues into sequentially-blocked child issues and tracks their progress. The architecture is well-designed, the test hooks pattern is clean, and the 17 unit tests provide solid coverage. Two logic issues need attention before merge.

- **Data loss in progress updates**: `updateMissionProgress` calls `formatProgressUpdate`, which generates a body containing *only* the progress checklist. Every poll cycle after the initial decomposition, `editIssueBody` replaces the parent issue's entire body with just that block — permanently discarding the original epic description. `decomposeMission` correctly preserves the original body via `formatParentChecklist`; `updateMissionProgress` needs to do the same (e.g., by storing the original body in `state.Mission` or fetching it via `getIssue` before composing the update).
- **Mission detection gated on `IssueLabels`**: In `RunOnce`, missions are discovered via `o.listOpenIssues(o.cfg.IssueLabels)`, so a parent issue must carry both the maestro `IssueLabels` tag *and* a mission label to be detected. The PR description implies detection by mission label alone; the actual constraint should be documented or the fetch should use `Missions.Labels` directly.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is due to a data-loss bug that destroys the parent issue body on every progress poll cycle.
- The body-overwrite bug in `updateMissionProgress` will silently and permanently destroy parent issue descriptions in production on the very first progress update cycle. This directly impacts the primary user path for the feature. The fix is straightforward but needs to land before merge.
- `internal/mission/mission.go` — `updateMissionProgress`/`formatProgressUpdate` body-overwrite bug; `internal/orchestrator/orchestrator.go` — mission detection label scope.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/mission/mission.go | Core mission logic is well-structured with good test hooks; however, `updateMissionProgress` overwrites the parent issue body entirely with only the progress section each cycle, destroying the original description — a data-loss bug on every progress poll. |
| internal/orchestrator/orchestrator.go | Integration is clean; mission detection is gated on `IssueLabels` rather than `Missions.Labels`, which may prevent detection of epics that aren't also tagged with the maestro label. |
| internal/state/state.go | Clean additions: `Mission` struct, `IsMissionParent`/`IsMissionChild` helpers, and `Missions` map in `State` — all well-integrated. |
| internal/github/github.go | `CreateIssue` and `EditIssueBody` follow existing patterns; URL parsing for issue number extraction is straightforward and correctly handles the `gh` CLI output format. |
| internal/config/config.go | Clean additions of `MissionsConfig` with sensible defaults for `MaxChildren` (10) and `Labels` (`["mission", "epic"]`). |
| internal/mission/mission_test.go | Good coverage of decomposition, label detection, cap enforcement, skip-already-tracked, all-children-closed, and disabled mode; test hooks pattern is clean. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 1005-1012 ([link](https://github.com/befeast/maestro/blob/299dcbf5cd2a36822765abd3cb60ddc61260dcbb/internal/orchestrator/orchestrator.go#L1005-L1012)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Mission issues may never be detected if not also tagged with `IssueLabels`**

   `ProcessMissions` is fed the result of `o.listOpenIssues(o.cfg.IssueLabels)`, which filters by the maestro-managed labels (e.g. `["maestro"]`). If a user creates an issue labeled only `epic` or `mission` (the mission labels) but *not* the maestro `IssueLabels`, it will never appear in this list and will never be decomposed.

   The PR description says "Issue labeled `mission` or `epic` is detected in the orchestration loop", implying detection by mission label alone. The implementation requires both `IssueLabels` AND a mission label to be present on the parent issue.

   If the intent is to detect missions by their labels independent of `IssueLabels`, a separate `listOpenIssues(p.cfg.Missions.Labels)` call should be made here. If missions are expected to always carry `IssueLabels`, this constraint should be documented in the config comments and README.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 1005-1012

   Comment:
   **Mission issues may never be detected if not also tagged with `IssueLabels`**

   `ProcessMissions` is fed the result of `o.listOpenIssues(o.cfg.IssueLabels)`, which filters by the maestro-managed labels (e.g. `["maestro"]`). If a user creates an issue labeled only `epic` or `mission` (the mission labels) but *not* the maestro `IssueLabels`, it will never appear in this list and will never be decomposed.

   The PR description says "Issue labeled `mission` or `epic` is detected in the orchestration loop", implying detection by mission label alone. The implementation requires both `IssueLabels` AND a mission label to be present on the parent issue.

   If the intent is to detect missions by their labels independent of `IssueLabels`, a separate `listOpenIssues(p.cfg.Missions.Labels)` call should be made here. If missions are expected to always carry `IssueLabels`, this constraint should be documented in the config comments and README.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/mission/mission.go
Line: 155-158

Comment:
**Progress update silently destroys parent issue body**

`updateMissionProgress` calls `formatProgressUpdate`, which generates a string containing *only* the progress section (starting with `## Mission #N Progress`). When this is passed to `editIssueBody`, it completely overwrites the parent issue's original description.

In contrast, `decomposeMission` correctly uses `formatParentChecklist(childNumbers, issue.Body)`, which appends to the original body. Every subsequent poll cycle thereafter replaces the body with only the progress block — the original epic description, acceptance criteria, and any other context are permanently lost from the GitHub issue.

`formatProgressUpdate` needs to receive (and prepend) the original body, similar to how `formatParentChecklist` does it. One approach: store the original body in `state.Mission` at decomposition time and pass it here, or fetch it via `getIssue(parentNum)` before composing the updated body.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/orchestrator/orchestrator.go
Line: 1005-1012

Comment:
**Mission issues may never be detected if not also tagged with `IssueLabels`**

`ProcessMissions` is fed the result of `o.listOpenIssues(o.cfg.IssueLabels)`, which filters by the maestro-managed labels (e.g. `["maestro"]`). If a user creates an issue labeled only `epic` or `mission` (the mission labels) but *not* the maestro `IssueLabels`, it will never appear in this list and will never be decomposed.

The PR description says "Issue labeled `mission` or `epic` is detected in the orchestration loop", implying detection by mission label alone. The implementation requires both `IssueLabels` AND a mission label to be present on the parent issue.

If the intent is to detect missions by their labels independent of `IssueLabels`, a separate `listOpenIssues(p.cfg.Missions.Labels)` call should be made here. If missions are expected to always carry `IssueLabels`, this constraint should be documented in the config comments and README.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add mission mode for decomposing e..."](https://github.com/befeast/maestro/commit/299dcbf5cd2a36822765abd3cb60ddc61260dcbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25959437)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->