### PR TITLE
fix: document RetryCount semantics and clarify retry config (#213)

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3781,9 +3781,10 @@ func TestRetryBackoffMs_SmallCap(t *testing.T) {
 
 func TestCheckSessions_DeadWorkerSchedulesRetryWithBackoff(t *testing.T) {
 	cfg := &config.Config{
-		Repo:              "owner/repo",
-		MaxRetryBackoffMs: 300000,
-		MaxRuntimeMinutes: 999,
+		Repo:               "owner/repo",
+		MaxRetryBackoffMs:  300000,
+		MaxRuntimeMinutes:  999,
+		MaxRetriesPerIssue: 3, // explicit: allow retries (0 would mean unlimited)
 	}
 	o := &Orchestrator{
 		cfg:      cfg,

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -49,7 +49,7 @@ type Session struct {
 	RebaseAttempted     bool          `json:"rebase_attempted,omitempty"`
 	NotifiedCIFail      bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
 	LastNotifiedStatus  string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
-	RetryCount          int           `json:"retry_count,omitempty"`
+	RetryCount          int           `json:"retry_count,omitempty"`          // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
 	NextRetryAt         *time.Time    `json:"next_retry_at,omitempty"`
 	LastOutputHash      string        `json:"last_output_hash,omitempty"`
 	LastOutputChangedAt time.Time     `json:"last_output_changed_at,omitempty"`


### PR DESCRIPTION
Closes #213

## Summary

The core fix for #213 (replacing hardcoded `RetryCount < 1` with the configurable `canRetryIssue` method using `MaxRetriesPerIssue`) already landed on main via PR #226. This PR addresses the remaining ask from the issue:

- **Document `RetryCount` semantics**: Added inline doc clarifying that `RetryCount` is per-session, while the global per-issue limit (`max_retries_per_issue`) combines it with `FailedAttemptsForIssue`
- **Explicit test config**: Set `MaxRetriesPerIssue` explicitly in `TestCheckSessions_DeadWorkerSchedulesRetryWithBackoff` instead of relying on implicit zero-value (unlimited)

## Changes
- `internal/state/state.go`: Add doc comment to `RetryCount` field explaining per-session vs per-issue semantics
- `internal/orchestrator/orchestrator_test.go`: Make `MaxRetriesPerIssue` explicit in retry backoff test

## Testing
- `go test ./...` — all 14 packages pass
- `go vet ./...` — clean
- `go build ./cmd/maestro/` — binary builds successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a follow-up documentation and test-clarity improvement for the retry-count semantics fix that landed in PR #226. It adds an inline comment on `Session.RetryCount` explaining that it is a per-session counter and that the global per-issue limit (`max_retries_per_issue`) combines it with `FailedAttemptsForIssue` — which directly matches the `canRetryIssue` implementation. The only code change is making `MaxRetriesPerIssue: 3` explicit in one test to avoid misleading zero-value (unlimited) semantics.

- `internal/state/state.go`: Doc comment on `RetryCount` is accurate — `canRetryIssue` computes `s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount` and compares it to `MaxRetriesPerIssue`, exactly matching the description.
- `internal/orchestrator/orchestrator_test.go`: `MaxRetriesPerIssue: 3` in `TestCheckSessions_DeadWorkerSchedulesRetryWithBackoff` ensures the test still exercises the intended retry path (0 would silently make retries unlimited and mask future regressions).

<h3>Confidence Score: 5/5</h3>

- Safe to merge — changes are purely additive (a doc comment and an explicit test config value) with no behavioral impact.
- Both changes are strictly non-functional: the doc comment on `RetryCount` is accurate relative to the `canRetryIssue` implementation, and setting `MaxRetriesPerIssue: 3` explicitly in the test preserves existing test semantics while removing a subtle zero-value pitfall. No logic, control flow, or state transitions are altered.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds an inline doc comment to `RetryCount` clarifying per-session vs. per-issue semantics; comment accurately reflects the `canRetryIssue` implementation. |
| internal/orchestrator/orchestrator_test.go | Makes `MaxRetriesPerIssue: 3` explicit in `TestCheckSessions_DeadWorkerSchedulesRetryWithBackoff`, removing reliance on the zero-value unlimited semantics; test logic is unchanged and correct. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: document RetryCount semantics and c..."](https://github.com/befeast/maestro/commit/8982644d3c2a25f3d08b4cd65aab23656fb80357) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25960747)</sub>

<!-- /greptile_comment -->