### PR TITLE
feat: sort status output by session status with running first (#210)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -414,12 +414,19 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 		return
 	}
 
-	// Sort session names for stable output
+	// Sort sessions by status priority (running first), then by name
 	names := make([]string, 0, len(s.Sessions))
 	for name := range s.Sessions {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	sort.Slice(names, func(i, j int) bool {
+		pi := state.StatusPriority(s.Sessions[names[i]].Status)
+		pj := state.StatusPriority(s.Sessions[names[j]].Status)
+		if pi != pj {
+			return pi < pj
+		}
+		return names[i] < names[j]
+	})
 
 	// Fetch CI status for pr_open sessions
 	gh := github.New(cfg.Repo)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -253,6 +253,32 @@ func (s *State) MarkIssueRetryExhausted(issueNum int) {
 }
 
 // IsTerminal returns true if the status represents a completed/dead session.
+// StatusPriority returns a sort key for session statuses.
+// Lower values sort first. Running sessions appear at the top,
+// followed by actionable states, then terminal states.
+func StatusPriority(status SessionStatus) int {
+	switch status {
+	case StatusRunning:
+		return 0
+	case StatusPROpen:
+		return 1
+	case StatusQueued:
+		return 2
+	case StatusDead:
+		return 3
+	case StatusFailed:
+		return 4
+	case StatusConflictFailed:
+		return 5
+	case StatusRetryExhausted:
+		return 6
+	case StatusDone:
+		return 7
+	default:
+		return 8
+	}
+}
+
 func IsTerminal(status SessionStatus) bool {
 	switch status {
 	case StatusDone, StatusFailed, StatusConflictFailed, StatusDead, StatusRetryExhausted:

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -689,6 +689,26 @@ func TestCountByStatus(t *testing.T) {
 	}
 }
 
+func TestStatusPriority(t *testing.T) {
+	// running should come first
+	if StatusPriority(StatusRunning) >= StatusPriority(StatusPROpen) {
+		t.Error("running should have lower priority value than pr_open")
+	}
+	// pr_open before queued
+	if StatusPriority(StatusPROpen) >= StatusPriority(StatusQueued) {
+		t.Error("pr_open should have lower priority value than queued")
+	}
+	// queued before terminal states
+	for _, terminal := range []SessionStatus{
+		StatusDead, StatusFailed, StatusConflictFailed,
+		StatusRetryExhausted, StatusDone,
+	} {
+		if StatusPriority(StatusQueued) >= StatusPriority(terminal) {
+			t.Errorf("queued should have lower priority value than %q", terminal)
+		}
+	}
+}
+
 func TestCountByStatus_Empty(t *testing.T) {
 	s := NewState()
 	counts := s.CountByStatus()


### PR DESCRIPTION
Implements #210

## Changes
- Added `StatusPriority()` function to `internal/state/state.go` that assigns a sort key to each session status: running (0) > pr_open (1) > queued (2) > terminal states (3-7)
- Updated `showProjectStatus()` in `cmd/maestro/main.go` to sort sessions by status priority first, then alphabetically by name within the same status bucket
- Added `TestStatusPriority` test verifying the ordering invariants

## Testing
- All existing tests pass (`go test ./...`)
- New `TestStatusPriority` test validates that running < pr_open < queued < all terminal states
- `go vet ./...` clean
- Binary builds successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements session status-based sorting for the `status` command output, satisfying issue #210. Sessions are now displayed with running first, followed by `pr_open`, `queued`, and terminal states — with alphabetical name ordering as a tiebreaker within each bucket.

- `StatusPriority()` in `state.go` cleanly maps all 8 defined `SessionStatus` values to integer sort keys with a safe `default` fallback for any future additions.
- The comparator in `showProjectStatus()` correctly replaces the previous `sort.Strings` call with a two-key `sort.Slice`, producing deterministic output.
- `TestStatusPriority` validates the three main ordering invariants.
- The doc comment placement issue flagged in the prior review thread (the `IsTerminal` description bleeding into `StatusPriority`'s doc block) remains unresolved.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge pending a minor doc comment fix already identified in a prior review thread.
- The logic is correct, all statuses are handled, the tiebreaker sort is deterministic, and the new test validates the key invariants. The only outstanding item is the misplaced doc comment on `IsTerminal` (the prior thread comment), which is a style concern and does not affect runtime behaviour.
- internal/state/state.go — doc comment for `IsTerminal` still needs to be restored above the function.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds `StatusPriority()` function mapping each `SessionStatus` to an integer sort key. All 8 defined statuses are explicitly handled with a safe `default` fallback. The only issue is the misplaced doc comment (already flagged in a prior review thread) — the `IsTerminal` doc line bleeds into `StatusPriority`'s doc block, leaving `IsTerminal` undocumented. |
| cmd/maestro/main.go | Replaces `sort.Strings` with `sort.Slice` using a two-key comparator (priority first, then name). Logic is correct: the comparator is consistent and the alphabetical tiebreaker ensures deterministic output within each status bucket. |
| internal/state/state_test.go | Adds `TestStatusPriority` that validates the three primary ordering invariants: running < pr_open < queued < all terminal states. Coverage is sufficient for the stated goals of the feature. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat: sort status output by session stat..."](https://github.com/befeast/maestro/commit/782d65a1c57261f8a2c7c09690979f2001c644c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25960895)</sub>

<!-- /greptile_comment -->