### PR TITLE
fix: harden GitHub Projects integration with timeouts and reduce API traffic (#206)

### DIFF
--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -1,12 +1,17 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+// ghTimeout is the maximum time allowed for a single gh subprocess call.
+const ghTimeout = 30 * time.Second
 
 // ProjectStatus represents the status to set on a GitHub Project item.
 type ProjectStatus string
@@ -86,7 +91,9 @@ func (c *Client) SyncIssueToProject(issueNumber int, projectNumber int, status P
 
 // getIssueNodeID retrieves the GraphQL node ID for an issue.
 func (c *Client) getIssueNodeID(issueNumber int) (string, error) {
-	out, err := exec.Command("gh", "issue", "view", fmt.Sprint(issueNumber),
+	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gh", "issue", "view", fmt.Sprint(issueNumber),
 		"--repo", c.Repo,
 		"--json", "id").Output()
 	if err != nil {
@@ -112,7 +119,9 @@ func (c *Client) addToProject(projectID, contentID string) (string, error) {
   }
 }`, projectID, contentID)
 
-	out, err := exec.Command("gh", "api", "graphql", "-f", "query="+query).Output()
+	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query).Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return "", fmt.Errorf("graphql addProjectV2ItemById: %w\nstderr: %s\nstdout: %s", err, exitErr.Stderr, out)
@@ -160,7 +169,9 @@ func (c *Client) setProjectItemStatus(projectID, itemID, fieldID, optionID strin
   }) { projectV2Item { id } }
 }`, projectID, itemID, fieldID, optionID)
 
-	out, err := exec.Command("gh", "api", "graphql", "-f", "query="+query).Output()
+	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query).Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return fmt.Errorf("graphql updateProjectV2ItemFieldValue: %w\nstderr: %s\nstdout: %s", err, exitErr.Stderr, out)

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"testing"
+	"time"
 )
 
 func TestKnownProjects_ContainsExpectedProjects(t *testing.T) {
@@ -28,6 +29,15 @@ func TestKnownProjects_ContainsExpectedProjects(t *testing.T) {
 func TestKnownProjects_UnknownProjectNumber(t *testing.T) {
 	if _, ok := knownProjects[999]; ok {
 		t.Error("expected project 999 to not exist in knownProjects")
+	}
+}
+
+func TestGhTimeout_IsReasonable(t *testing.T) {
+	if ghTimeout < 5*time.Second {
+		t.Errorf("ghTimeout = %v, want >= 5s", ghTimeout)
+	}
+	if ghTimeout > 2*time.Minute {
+		t.Errorf("ghTimeout = %v, want <= 2m", ghTimeout)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1657,6 +1657,14 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			}
 		}
 
+		// No available slots — sync remaining eligible issues as backlog/todo.
+		// This check is intentionally before hasOpenPRForIssue to avoid making
+		// a GitHub API call per backlogged issue when all slots are full.
+		if started >= slots {
+			o.syncProject(issue.Number, github.ProjectStatusTodo)
+			continue
+		}
+
 		// Safety net: check GitHub directly for any open PR referencing this issue.
 		// This guards against the race where reconcileRunningSessions marked a session
 		// dead before checkSessions could detect its PR and transition it to pr_open.
@@ -1664,12 +1672,6 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			log.Printf("[orch] warn: could not check open PRs for issue #%d: %v", issue.Number, err)
 		} else if hasOpenPR {
 			log.Printf("[orch] skipping issue #%d: open PR already exists", issue.Number)
-			continue
-		}
-
-		// No available slots — sync remaining eligible issues as backlog/todo
-		if started >= slots {
-			o.syncProject(issue.Number, github.ProjectStatusTodo)
 			continue
 		}
 


### PR DESCRIPTION
Closes #206

## Summary
Addresses the review feedback from PR #208 (Greptile confidence 2/5) to harden the GitHub Projects integration.

## Changes
- **Add 30s context timeouts** to all three `gh` subprocess calls in `github_projects.go` (`getIssueNodeID`, `addToProject`, `setProjectItemStatus`). Previously, a hung `gh` process could block the orchestrator's main goroutine indefinitely.
- **Fix API call regression in `startNewWorkers`**: move the `started >= slots` check *before* the `hasOpenPRForIssue` call. Previously, `hasOpenPRForIssue` (a GitHub REST API request) was called for every eligible backlogged issue on every poll cycle, even when all slots were full. Now backlogged issues skip the API call and go directly to project sync.
- **Add test** for the timeout constant bounds.

## Testing
- All 14 test packages pass (`go test ./...`)
- `go vet ./...` clean
- Binary builds and runs (`./maestro version`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the GitHub Projects integration by bounding all three `gh` subprocess calls with a 30-second context timeout, and reduces unnecessary GitHub REST API traffic by short-circuiting the `hasOpenPRForIssue` check when all worker slots are already full. Both changes address feedback from the previous review.

- **Timeouts** (`github_projects.go`): Each of `getIssueNodeID`, `addToProject`, and `setProjectItemStatus` now creates a `context.WithTimeout(context.Background(), ghTimeout)` (30 s) and passes it to `exec.CommandContext`. The implementation is correct; a hung `gh` process can no longer block the orchestrator indefinitely.
- **API-call reduction** (`orchestrator.go`): The `started >= slots` guard is moved before `hasOpenPRForIssue`, eliminating a REST API call for every eligible backlogged issue on every poll cycle when capacity is already exhausted. This is a net improvement for the common case, with a minor trade-off in the rare race-condition window where an issue with an open PR could briefly show "todo" on the project board (see inline comment).
- **Test** (`github_projects_test.go`): `TestGhTimeout_IsReasonable` validates the constant stays in a sane range.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — changes are bounded improvements over the previous unbounded behaviour, with only a minor and self-correcting project-board side-effect in an already-rare race window.
- Both targeted concerns from the prior review (unbounded subprocess hangs, excessive API calls) are cleanly addressed. The one behavioural change (race-condition issues synced to "todo" when slots are full) is temporary, UI-only, and self-corrects on the next poll cycle. All 14 test packages pass and `go vet` is clean.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github_projects.go | Adds a 30-second context timeout (via `ghTimeout` constant) to all three `gh` subprocess calls (`getIssueNodeID`, `addToProject`, `setProjectItemStatus`). Implementation is correct — each function creates a fresh `context.WithTimeout`, defers cancel, and passes the context to `exec.CommandContext`. |
| internal/github/github_projects_test.go | Adds `TestGhTimeout_IsReasonable` which validates the constant stays between 5s and 2m. Simple sanity check that is correct. |
| internal/orchestrator/orchestrator.go | Moves the `started >= slots` guard before `hasOpenPRForIssue` to avoid a REST API call per backlogged issue when all slots are full. Correct optimization for the normal path, with a minor behavioral change in the race-condition window described below. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/orchestrator/orchestrator.go
Line: 1660-1666

Comment:
**Race-condition window: open-PR issues incorrectly synced to "todo"**

Moving the `started >= slots` guard before `hasOpenPRForIssue` changes the behaviour for the very race condition that `hasOpenPRForIssue` was added to guard against.

In the old ordering, when `started >= slots`:
1. `hasOpenPRForIssue` is called first.
2. If it finds an open PR (the race window where `reconcileRunningSessions` has marked the session dead but `checkSessions` hasn't yet flipped the issue to `pr_open`), the loop hits `continue` and **no project sync** happens.
3. Only if no open PR is found does the issue get synced to `todo`.

In the new ordering, when `started >= slots`, `syncProject(…, ProjectStatusTodo)` fires unconditionally — including for issues that, due to the race, actually have an open PR in flight. Their project-board status will be temporarily reset to "todo" until the next poll corrects it.

This is self-correcting and only affects the project board UI, so it isn't a critical regression. Still worth noting because it's a semantic change from the stated intent of the safety net. One mitigation would be to keep `hasOpenPRForIssue` callable from the `started >= slots` branch as well, but that re-introduces the API call cost for the race-condition subset. Alternatively, a code comment acknowledging the trade-off would make the intent explicit.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add timeouts to GitHub Projects sub..."](https://github.com/befeast/maestro/commit/63b7704512b721ad1201792924df07e19d585cbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25961168)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->