### PR TITLE
feat: GSD-inspired pre-worker pipeline — research, plan validation, test mapping (#212)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,12 +73,35 @@ type RoleConfig struct {
 	MaxRuntimeMinutes int    `yaml:"max_runtime_minutes"` // override per-role max runtime (0 = use global)
 }
 
-// PipelineConfig controls the planner → implementer → validator pipeline.
+// PipelineConfig controls the planner → implementer → validator pipeline
+// and the GSD-inspired pre-worker context preparation phases.
 type PipelineConfig struct {
+	// Phase-based pipeline (planner → implementer → validator)
 	Enabled   bool       `yaml:"enabled"`   // enable 3-phase pipeline (default: false = legacy single-phase)
 	Planner   RoleConfig `yaml:"planner"`   // planner role settings
 	Validator RoleConfig `yaml:"validator"` // validator role settings
 	// Implementer uses the existing worker_prompt / bug_prompt / enhancement_prompt settings.
+
+	// GSD-inspired pre-worker context preparation phases
+	Research       bool  `yaml:"research"`        // spawn a research subagent before worker starts (default: false)
+	PlanValidation *bool `yaml:"plan_validation"` // validate a plan before coding starts (default: true)
+	TestMapping    *bool `yaml:"test_mapping"`    // map requirements to verify commands (default: true)
+}
+
+// PlanValidationEnabled returns whether plan validation is enabled (default: true).
+func (p PipelineConfig) PlanValidationEnabled() bool {
+	if p.PlanValidation == nil {
+		return true
+	}
+	return *p.PlanValidation
+}
+
+// TestMappingEnabled returns whether test mapping is enabled (default: true).
+func (p PipelineConfig) TestMappingEnabled() bool {
+	if p.TestMapping == nil {
+		return true
+	}
+	return *p.TestMapping
 }
 
 // MissionsConfig controls mission mode for decomposing epics into child issues.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1129,3 +1129,64 @@ validation_contract: true
 		t.Error("ValidationContract should be true")
 	}
 }
+
+func TestParse_PipelineGSDDefaults(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Pipeline.Research {
+		t.Error("Pipeline.Research should default to false")
+	}
+	if !cfg.Pipeline.PlanValidationEnabled() {
+		t.Error("Pipeline.PlanValidation should default to true")
+	}
+	if !cfg.Pipeline.TestMappingEnabled() {
+		t.Error("Pipeline.TestMapping should default to true")
+	}
+}
+
+func TestParse_PipelineGSDExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+pipeline:
+  research: true
+  plan_validation: false
+  test_mapping: false
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.Pipeline.Research {
+		t.Error("Pipeline.Research should be true when set")
+	}
+	if cfg.Pipeline.PlanValidationEnabled() {
+		t.Error("Pipeline.PlanValidation should be false when set")
+	}
+	if cfg.Pipeline.TestMappingEnabled() {
+		t.Error("Pipeline.TestMapping should be false when set")
+	}
+}
+
+func TestParse_PipelineGSDPartial(t *testing.T) {
+	yaml := `
+repo: owner/repo
+pipeline:
+  research: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.Pipeline.Research {
+		t.Error("Pipeline.Research should be true when set")
+	}
+	if !cfg.Pipeline.PlanValidationEnabled() {
+		t.Error("Pipeline.PlanValidation should default to true when not set")
+	}
+	if !cfg.Pipeline.TestMappingEnabled() {
+		t.Error("Pipeline.TestMapping should default to true when not set")
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,16 +1,24 @@
-// Package pipeline implements the planner → implementer → validator phase pipeline.
+// Package pipeline implements the planner → implementer → validator phase pipeline
+// and the GSD-inspired pre-worker context preparation phases.
 //
-// When pipeline mode is enabled in config, each issue goes through three phases:
+// Phase pipeline (when pipeline.enabled is true):
 //  1. Plan   — creates MAESTRO_PLAN.md + VALIDATION.md in the worktree
 //  2. Implement — writes code based on the plan (current worker behavior)
 //  3. Validate — checks assertions from VALIDATION.md, gates PR creation
 //
-// Each phase runs as a separate worker session in the same worktree.
+// GSD pre-worker phases (configurable independently):
+//   - Research: scans codebase for relevant patterns, writes context file
+//   - Plan Validation: extracts requirements, builds and validates a plan
+//   - Test Mapping: maps requirements to verification commands, generates verify.sh
+//
+// Each phase-pipeline phase runs as a separate worker session in the same worktree.
 // Failed validation retries the implementer with feedback, not a full re-plan.
+// GSD phases run before the worker starts and inject context into the prompt.
 package pipeline
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +26,8 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
 )
+
+// ---- Phase-based pipeline (planner → implementer → validator) ----
 
 const (
 	// PlanFile is the plan artifact written by the planner phase.
@@ -126,4 +136,101 @@ func MaxRuntimeForPhase(cfg *config.Config, phase state.Phase) int {
 		}
 	}
 	return cfg.MaxRuntimeMinutes
+}
+
+// ---- GSD-inspired pre-worker context preparation ----
+
+// GSDResult holds the output of the GSD pre-worker pipeline phases.
+// The context fields are appended to the worker prompt.
+type GSDResult struct {
+	// ResearchContext is the markdown context from the research phase.
+	ResearchContext string
+
+	// Plan is the validated plan text.
+	Plan string
+
+	// VerifyScript is the path to the generated verify.sh script.
+	VerifyScript string
+
+	// TestMappingSummary is a markdown summary of test mappings.
+	TestMappingSummary string
+}
+
+// PromptSection returns a formatted string to append to the worker prompt.
+// It includes all pipeline outputs that are non-empty.
+func (r *GSDResult) PromptSection() string {
+	if r == nil {
+		return ""
+	}
+
+	var sections []string
+
+	if r.ResearchContext != "" {
+		sections = append(sections, "## Pre-coding Research\n\n"+r.ResearchContext)
+	}
+	if r.Plan != "" {
+		sections = append(sections, "## Implementation Plan\n\nThe following plan has been validated. Use it as your guide:\n\n"+r.Plan)
+	}
+	if r.TestMappingSummary != "" {
+		sections = append(sections, "## Test Mapping\n\n"+r.TestMappingSummary)
+	}
+
+	if len(sections) == 0 {
+		return ""
+	}
+
+	return "\n\n---\n\n# Pipeline Context\n\n" + strings.Join(sections, "\n\n---\n\n")
+}
+
+// RunGSD executes the GSD-inspired pre-worker pipeline phases before a worker starts.
+// All phases are best-effort — a failure in one phase logs a warning
+// but does not prevent subsequent phases or worker startup.
+func RunGSD(cfg *config.Config, worktreePath string, issueNumber int, issueTitle, issueBody string) *GSDResult {
+	result := &GSDResult{}
+	pipeline := cfg.Pipeline
+
+	anyEnabled := pipeline.Research || pipeline.PlanValidationEnabled() || pipeline.TestMappingEnabled()
+	if !anyEnabled {
+		return result
+	}
+
+	log.Printf("[pipeline] running GSD pre-worker pipeline for issue #%d (research=%v, plan_validation=%v, test_mapping=%v)",
+		issueNumber, pipeline.Research, pipeline.PlanValidationEnabled(), pipeline.TestMappingEnabled())
+
+	// Phase 1: Research
+	if pipeline.Research {
+		log.Printf("[pipeline] GSD phase 1/3: research")
+		ctx, err := runResearch(worktreePath, issueNumber, issueTitle, issueBody)
+		if err != nil {
+			log.Printf("[pipeline] research phase error: %v (continuing)", err)
+		} else {
+			result.ResearchContext = ctx
+		}
+	}
+
+	// Phase 2: Plan Validation
+	if pipeline.PlanValidationEnabled() {
+		log.Printf("[pipeline] GSD phase 2/3: plan validation")
+		plan, err := validatePlan(issueNumber, issueTitle, issueBody, worktreePath, result.ResearchContext)
+		if err != nil {
+			log.Printf("[pipeline] plan validation error: %v (continuing)", err)
+		} else {
+			result.Plan = plan
+		}
+	}
+
+	// Phase 3: Test Mapping
+	if pipeline.TestMappingEnabled() {
+		log.Printf("[pipeline] GSD phase 3/3: test mapping")
+		verifyPath, summary, err := mapTests(issueNumber, issueTitle, issueBody, worktreePath, result.Plan)
+		if err != nil {
+			log.Printf("[pipeline] test mapping error: %v (continuing)", err)
+		} else {
+			result.VerifyScript = verifyPath
+			result.TestMappingSummary = summary
+		}
+	}
+
+	log.Printf("[pipeline] GSD pre-worker pipeline complete for issue #%d", issueNumber)
+	return result
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -3,11 +3,14 @@ package pipeline
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
 )
+
+// ---- Phase-based pipeline tests ----
 
 func TestIsEnabled(t *testing.T) {
 	cfg := &config.Config{}
@@ -191,5 +194,502 @@ func TestMaxRuntimeForPhase(t *testing.T) {
 	}
 	if got := MaxRuntimeForPhase(cfg, state.PhaseValidate); got != 45 {
 		t.Errorf("validate runtime: got %d, want 45", got)
+	}
+}
+
+// ---- GSD pre-worker pipeline tests ----
+
+func TestExtractKeywords(t *testing.T) {
+	title := "Add authentication middleware"
+	body := "We need to add JWT-based authentication middleware to the API server."
+
+	kw := extractKeywords(title, body)
+
+	if len(kw) == 0 {
+		t.Fatal("expected keywords, got none")
+	}
+
+	found := map[string]bool{}
+	for _, k := range kw {
+		found[k] = true
+	}
+	for _, want := range []string{"authentication", "middleware", "jwt-based"} {
+		if !found[want] {
+			t.Errorf("missing keyword %q in %v", want, kw)
+		}
+	}
+}
+
+func TestExtractKeywords_StopWordsFiltered(t *testing.T) {
+	kw := extractKeywords("the and for", "this that with from")
+	if len(kw) != 0 {
+		t.Errorf("expected no keywords from stop words, got %v", kw)
+	}
+}
+
+func TestExtractKeywords_LimitTo15(t *testing.T) {
+	body := "a1word b2word c3word d4word e5word f6word g7word h8word i9word j10word k11word l12word m13word n14word o15word p16word q17word"
+	kw := extractKeywords("extra title words here", body)
+	if len(kw) > 15 {
+		t.Errorf("expected max 15 keywords, got %d", len(kw))
+	}
+}
+
+func TestFindRelevantFiles(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "internal", "auth"), 0755)
+	os.WriteFile(filepath.Join(dir, "internal", "auth", "middleware.go"), []byte("package auth"), 0644)
+	os.WriteFile(filepath.Join(dir, "internal", "auth", "jwt.go"), []byte("package auth"), 0644)
+	os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0644)
+
+	files := findRelevantFiles(dir, []string{"auth", "middleware"})
+	if len(files) == 0 {
+		t.Fatal("expected to find relevant files")
+	}
+
+	found := false
+	for _, f := range files {
+		if strings.Contains(f.Path, "middleware.go") {
+			found = true
+			if len(f.MatchedKeywords) < 2 {
+				t.Errorf("middleware.go should match both keywords, got %v", f.MatchedKeywords)
+			}
+		}
+	}
+	if !found {
+		t.Error("middleware.go not found in results")
+	}
+}
+
+func TestFindRelevantFiles_SkipsDotGit(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".git", "objects"), 0755)
+	os.WriteFile(filepath.Join(dir, ".git", "config"), []byte("config"), 0644)
+	os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0644)
+
+	files := findRelevantFiles(dir, []string{"config"})
+	for _, f := range files {
+		if strings.Contains(f.Path, ".git") {
+			t.Errorf("should not include .git files, got %s", f.Path)
+		}
+	}
+}
+
+func TestRunResearch(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "internal", "pipeline"), 0755)
+	os.WriteFile(filepath.Join(dir, "internal", "pipeline", "research.go"), []byte("package pipeline"), 0644)
+
+	ctx, err := runResearch(dir, 42, "Add pipeline research", "Research phase for worker pipeline")
+	if err != nil {
+		t.Fatalf("runResearch: %v", err)
+	}
+	if ctx == "" {
+		t.Fatal("expected non-empty research context")
+	}
+	if !strings.Contains(ctx, "Pre-coding Research") {
+		t.Error("context should contain header")
+	}
+
+	researchFile := filepath.Join(dir, ".maestro", "research", "42.md")
+	if _, err := os.Stat(researchFile); os.IsNotExist(err) {
+		t.Errorf("expected research file at %s", researchFile)
+	}
+}
+
+func TestDiscoverPatterns_Go(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0644)
+	os.MkdirAll(filepath.Join(dir, "internal"), 0755)
+	os.MkdirAll(filepath.Join(dir, "cmd"), 0755)
+
+	patterns := discoverPatterns(dir)
+	found := map[string]bool{}
+	for _, p := range patterns {
+		found[p] = true
+	}
+	if !found["Go project (go.mod found)"] {
+		t.Error("should detect Go project")
+	}
+	if !found["Internal packages in internal/"] {
+		t.Error("should detect internal/ directory")
+	}
+}
+
+func TestExtractRequirements(t *testing.T) {
+	body := `## Features
+- Add authentication middleware to the API
+- Implement JWT token validation
+1. Create database migration for users table
+2. Add unit tests for auth module
+- [ ] Write integration tests
+- [x] Update documentation`
+
+	reqs := extractRequirements(body)
+	if len(reqs) < 4 {
+		t.Fatalf("expected at least 4 requirements, got %d: %v", len(reqs), reqs)
+	}
+}
+
+func TestExtractRequirements_Empty(t *testing.T) {
+	reqs := extractRequirements("Just a paragraph with no structured items.")
+	if len(reqs) != 0 {
+		t.Errorf("expected 0 requirements from plain text, got %d", len(reqs))
+	}
+}
+
+func TestExtractRequirements_ShortItemsSkipped(t *testing.T) {
+	body := "- OK\n- too short\n- This is a longer requirement that should be kept"
+	reqs := extractRequirements(body)
+	if len(reqs) != 1 {
+		t.Errorf("expected 1 requirement (short items filtered), got %d: %v", len(reqs), reqs)
+	}
+}
+
+func TestValidatePlanContent(t *testing.T) {
+	requirements := []string{
+		"Add authentication middleware",
+		"Implement JWT validation",
+	}
+	plan := "# Plan\n\nWe will add authentication middleware using JWT validation.\nFiles: `internal/auth/middleware.go`"
+
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "internal", "auth"), 0755)
+	os.WriteFile(filepath.Join(dir, "internal", "auth", "middleware.go"), []byte("package auth"), 0644)
+
+	issues := validatePlanContent(plan, requirements, dir)
+	for _, issue := range issues {
+		if issue.Severity == "error" {
+			t.Errorf("unexpected error: %s", issue.Message)
+		}
+	}
+}
+
+func TestValidatePlanContent_MissingRequirement(t *testing.T) {
+	requirements := []string{
+		"Add authentication middleware",
+		"Implement database connection pooling",
+	}
+	plan := "# Plan\n\nWe will add authentication middleware."
+
+	issues := validatePlanContent(plan, requirements, t.TempDir())
+	foundWarning := false
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, "requirement 2") {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Error("expected warning about missing requirement 2")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("hello world", 5); got != "hello..." {
+		t.Errorf("truncate(11, 5) = %q, want %q", got, "hello...")
+	}
+	if got := truncate("hi", 10); got != "hi" {
+		t.Errorf("truncate(2, 10) = %q, want %q", got, "hi")
+	}
+}
+
+func TestDetectTestInfrastructure_Go(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0644)
+
+	cmds := detectTestInfrastructure(dir)
+	if len(cmds) == 0 {
+		t.Fatal("expected test commands for Go project")
+	}
+	found := false
+	for _, c := range cmds {
+		if c == "go test ./..." {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'go test ./...' in %v", cmds)
+	}
+}
+
+func TestDetectTestInfrastructure_Multiple(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0644)
+	os.WriteFile(filepath.Join(dir, "Makefile"), []byte("test:\n\tgo test"), 0644)
+
+	cmds := detectTestInfrastructure(dir)
+	if len(cmds) < 2 {
+		t.Errorf("expected at least 2 test commands, got %d: %v", len(cmds), cmds)
+	}
+}
+
+func TestFindTestFiles(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "internal", "auth"), 0755)
+	os.WriteFile(filepath.Join(dir, "internal", "auth", "auth.go"), []byte("package auth"), 0644)
+	os.WriteFile(filepath.Join(dir, "internal", "auth", "auth_test.go"), []byte("package auth"), 0644)
+	os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0644)
+
+	files := findTestFiles(dir)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 test file, got %d: %v", len(files), files)
+	}
+	if !strings.Contains(files[0], "auth_test.go") {
+		t.Errorf("expected auth_test.go, got %s", files[0])
+	}
+}
+
+func TestFindRelatedTestFile(t *testing.T) {
+	testFiles := []string{
+		"internal/auth/auth_test.go",
+		"internal/server/server_test.go",
+		"internal/config/config_test.go",
+	}
+
+	result := findRelatedTestFile(testFiles, []string{"auth", "middleware"})
+	if !strings.Contains(result, "auth_test.go") {
+		t.Errorf("expected auth_test.go, got %q", result)
+	}
+}
+
+func TestGenerateVerifyScript(t *testing.T) {
+	mappings := []testMapping{
+		{Requirement: "Add authentication", VerifyCmd: "go test ./internal/auth/..."},
+		{Requirement: "Update docs", VerifyCmd: "# No automated test found — manual verification required"},
+	}
+	testCmds := []string{"go test ./..."}
+
+	script := generateVerifyScript(mappings, testCmds)
+	if !strings.Contains(script, "#!/bin/bash") {
+		t.Error("script should start with shebang")
+	}
+	if !strings.Contains(script, "go test ./...") {
+		t.Error("script should contain project test command")
+	}
+	if !strings.Contains(script, "go test ./internal/auth/...") {
+		t.Error("script should contain specific test command")
+	}
+	if !strings.Contains(script, "WARN") {
+		t.Error("script should warn about manual verification")
+	}
+}
+
+func TestMapTests(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0644)
+	os.MkdirAll(filepath.Join(dir, "internal", "auth"), 0755)
+	os.WriteFile(filepath.Join(dir, "internal", "auth", "auth_test.go"), []byte("package auth"), 0644)
+
+	verifyPath, summary, err := mapTests(42, "Add auth", "- Add authentication middleware", dir, "")
+	if err != nil {
+		t.Fatalf("mapTests: %v", err)
+	}
+	if verifyPath == "" {
+		t.Error("expected verify script path")
+	}
+	if _, err := os.Stat(verifyPath); os.IsNotExist(err) {
+		t.Errorf("verify script not found at %s", verifyPath)
+	}
+	if summary == "" {
+		t.Error("expected test mapping summary")
+	}
+}
+
+func TestShellEscape(t *testing.T) {
+	if got := shellEscape("hello 'world'"); got != "hello '\\''world'\\''" {
+		t.Errorf("shellEscape = %q", got)
+	}
+}
+
+func TestRunGSD_AllDisabled(t *testing.T) {
+	f := false
+	cfg := &config.Config{
+		Repo: "test/repo",
+		Pipeline: config.PipelineConfig{
+			Research:       false,
+			PlanValidation: &f,
+			TestMapping:    &f,
+		},
+	}
+
+	result := RunGSD(cfg, t.TempDir(), 1, "Test", "Test body")
+	if result.ResearchContext != "" || result.Plan != "" || result.VerifyScript != "" {
+		t.Error("expected empty result when all phases disabled")
+	}
+}
+
+func TestRunGSD_ResearchOnly(t *testing.T) {
+	f := false
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "internal", "pipeline"), 0755)
+	os.WriteFile(filepath.Join(dir, "internal", "pipeline", "research.go"), []byte("package pipeline"), 0644)
+
+	cfg := &config.Config{
+		Repo: "test/repo",
+		Pipeline: config.PipelineConfig{
+			Research:       true,
+			PlanValidation: &f,
+			TestMapping:    &f,
+		},
+	}
+
+	result := RunGSD(cfg, dir, 42, "Add pipeline research", "Research worker pipeline")
+	if result.ResearchContext == "" {
+		t.Error("expected research context")
+	}
+	if result.Plan != "" {
+		t.Error("plan should be empty when disabled")
+	}
+}
+
+func TestRunGSD_PlanValidationDefault(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0644)
+
+	f := false
+	cfg := &config.Config{
+		Repo: "test/repo",
+		Pipeline: config.PipelineConfig{
+			Research:    false,
+			TestMapping: &f,
+		},
+	}
+
+	result := RunGSD(cfg, dir, 42, "Add feature", "- Add new feature\n- Update tests")
+	if result.Plan == "" {
+		t.Error("expected plan when plan_validation defaults to true")
+	}
+}
+
+func TestRunGSD_TestMappingDefault(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0644)
+
+	f := false
+	cfg := &config.Config{
+		Repo: "test/repo",
+		Pipeline: config.PipelineConfig{
+			Research:       false,
+			PlanValidation: &f,
+		},
+	}
+
+	result := RunGSD(cfg, dir, 42, "Add feature", "- Add new feature")
+	if result.VerifyScript == "" {
+		t.Error("expected verify script when test_mapping defaults to true")
+	}
+}
+
+func TestRunGSD_AllEnabled(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0644)
+	os.MkdirAll(filepath.Join(dir, "internal", "pipeline"), 0755)
+	os.WriteFile(filepath.Join(dir, "internal", "pipeline", "pipeline.go"), []byte("package pipeline"), 0644)
+
+	cfg := &config.Config{
+		Repo: "test/repo",
+		Pipeline: config.PipelineConfig{
+			Research: true,
+		},
+	}
+
+	result := RunGSD(cfg, dir, 42, "Add pipeline feature", "- Add research phase\n- Add plan validation")
+	if result.ResearchContext == "" {
+		t.Error("expected research context")
+	}
+	if result.Plan == "" {
+		t.Error("expected plan")
+	}
+	if result.VerifyScript == "" {
+		t.Error("expected verify script")
+	}
+}
+
+func TestGSDResult_PromptSection_Empty(t *testing.T) {
+	r := &GSDResult{}
+	if s := r.PromptSection(); s != "" {
+		t.Errorf("expected empty prompt section, got %q", s)
+	}
+}
+
+func TestGSDResult_PromptSection_Nil(t *testing.T) {
+	var r *GSDResult
+	if s := r.PromptSection(); s != "" {
+		t.Errorf("expected empty prompt section for nil, got %q", s)
+	}
+}
+
+func TestGSDResult_PromptSection_WithContent(t *testing.T) {
+	r := &GSDResult{
+		ResearchContext:    "some research",
+		Plan:               "a plan",
+		TestMappingSummary: "test map",
+	}
+	s := r.PromptSection()
+	if !strings.Contains(s, "Pipeline Context") {
+		t.Error("should contain Pipeline Context header")
+	}
+	if !strings.Contains(s, "some research") {
+		t.Error("should contain research context")
+	}
+	if !strings.Contains(s, "a plan") {
+		t.Error("should contain plan")
+	}
+	if !strings.Contains(s, "test map") {
+		t.Error("should contain test mapping")
+	}
+}
+
+func TestPipelineConfig_GSDDefaults(t *testing.T) {
+	p := config.PipelineConfig{}
+	if p.Research {
+		t.Error("research should default to false")
+	}
+	if !p.PlanValidationEnabled() {
+		t.Error("plan validation should default to true (nil pointer)")
+	}
+	if !p.TestMappingEnabled() {
+		t.Error("test mapping should default to true (nil pointer)")
+	}
+}
+
+func TestPipelineConfig_GSDExplicitFalse(t *testing.T) {
+	f := false
+	p := config.PipelineConfig{
+		PlanValidation: &f,
+		TestMapping:    &f,
+	}
+	if p.PlanValidationEnabled() {
+		t.Error("plan validation should be false when explicitly set")
+	}
+	if p.TestMappingEnabled() {
+		t.Error("test mapping should be false when explicitly set")
+	}
+}
+
+func TestPipelineConfig_GSDExplicitTrue(t *testing.T) {
+	tr := true
+	p := config.PipelineConfig{
+		PlanValidation: &tr,
+		TestMapping:    &tr,
+	}
+	if !p.PlanValidationEnabled() {
+		t.Error("plan validation should be true when explicitly set")
+	}
+	if !p.TestMappingEnabled() {
+		t.Error("test mapping should be true when explicitly set")
+	}
+}
+
+func TestBuildTestMappingSummary(t *testing.T) {
+	mappings := []testMapping{
+		{Requirement: "Add feature", VerifyCmd: "go test ./..."},
+	}
+	summary := buildTestMappingSummary(mappings, "/tmp/verify.sh")
+	if !strings.Contains(summary, "Test Mapping") {
+		t.Error("summary should contain header")
+	}
+	if !strings.Contains(summary, "go test") {
+		t.Error("summary should contain verify command")
 	}
 }

--- a/internal/pipeline/planvalidation.go
+++ b/internal/pipeline/planvalidation.go
@@ -1,0 +1,212 @@
+package pipeline
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const maxPlanRevisions = 3
+
+// planIssue represents a validation issue found in a plan.
+type planIssue struct {
+	Severity string // "error" or "warning"
+	Message  string
+}
+
+// validatePlan extracts requirements from the issue, builds a plan,
+// validates it against the codebase, and returns the validated plan text.
+// Up to maxPlanRevisions revision loops are attempted.
+func validatePlan(issueNumber int, issueTitle, issueBody, worktreePath, researchContext string) (string, error) {
+	requirements := extractRequirements(issueBody)
+	if len(requirements) == 0 {
+		log.Printf("[pipeline] plan-validation: no structured requirements found, using issue body as single requirement")
+		requirements = []string{issueTitle}
+	}
+	log.Printf("[pipeline] plan-validation: extracted %d requirements", len(requirements))
+
+	var plan string
+	for revision := 0; revision < maxPlanRevisions; revision++ {
+		plan = buildPlan(requirements, worktreePath, researchContext)
+		issues := validatePlanContent(plan, requirements, worktreePath)
+
+		errors := 0
+		for _, issue := range issues {
+			if issue.Severity == "error" {
+				errors++
+			}
+			log.Printf("[pipeline] plan-validation [rev %d]: %s: %s", revision, issue.Severity, issue.Message)
+		}
+
+		if errors == 0 {
+			log.Printf("[pipeline] plan-validation: plan validated after %d revision(s)", revision)
+			return plan, nil
+		}
+
+		// Append validation feedback for next revision
+		researchContext += "\n\nPlan validation issues:\n"
+		for _, issue := range issues {
+			researchContext += fmt.Sprintf("- [%s] %s\n", issue.Severity, issue.Message)
+		}
+	}
+
+	// Return the best plan we have even after max revisions
+	log.Printf("[pipeline] plan-validation: returning plan after %d revisions (may have unresolved issues)", maxPlanRevisions)
+	return plan, nil
+}
+
+// extractRequirements parses the issue body for structured requirements.
+// Looks for bullet points, numbered lists, and checkbox items.
+func extractRequirements(body string) []string {
+	var requirements []string
+	seen := make(map[string]bool)
+
+	lines := strings.Split(body, "\n")
+	// Patterns for requirement-like lines
+	bulletRe := regexp.MustCompile(`^\s*[-*+]\s+(.+)`)
+	numberedRe := regexp.MustCompile(`^\s*\d+\.\s+(.+)`)
+	checkboxRe := regexp.MustCompile(`^\s*-\s*\[[ x]\]\s+(.+)`)
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		var req string
+		if m := checkboxRe.FindStringSubmatch(line); len(m) > 1 {
+			req = strings.TrimSpace(m[1])
+		} else if m := numberedRe.FindStringSubmatch(line); len(m) > 1 {
+			req = strings.TrimSpace(m[1])
+		} else if m := bulletRe.FindStringSubmatch(line); len(m) > 1 {
+			req = strings.TrimSpace(m[1])
+		}
+
+		if req != "" && len(req) > 10 && !seen[req] {
+			// Skip lines that look like headers or config examples
+			if strings.HasPrefix(req, "#") || strings.HasPrefix(req, "```") {
+				continue
+			}
+			seen[req] = true
+			requirements = append(requirements, req)
+		}
+	}
+
+	return requirements
+}
+
+// buildPlan generates a structured plan mapping requirements to implementation steps.
+func buildPlan(requirements []string, worktreePath, researchContext string) string {
+	var sb strings.Builder
+	sb.WriteString("# Implementation Plan\n\n")
+
+	// Discover project info for context
+	patterns := discoverPatterns(worktreePath)
+	if len(patterns) > 0 {
+		sb.WriteString("## Project Context\n")
+		for _, p := range patterns {
+			sb.WriteString(fmt.Sprintf("- %s\n", p))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("## Requirements & Approach\n\n")
+	for i, req := range requirements {
+		sb.WriteString(fmt.Sprintf("### %d. %s\n", i+1, req))
+
+		// Try to find related files
+		keywords := extractKeywords(req, "")
+		relFiles := findRelevantFiles(worktreePath, keywords)
+		if len(relFiles) > 0 {
+			sb.WriteString("**Related files:**\n")
+			limit := 5
+			if limit > len(relFiles) {
+				limit = len(relFiles)
+			}
+			for _, rf := range relFiles[:limit] {
+				sb.WriteString(fmt.Sprintf("  - `%s`\n", rf.Path))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	if researchContext != "" {
+		sb.WriteString("## Research Context Available\n")
+		sb.WriteString("Pre-coding research has been performed. See the research context section in the prompt.\n\n")
+	}
+
+	return sb.String()
+}
+
+// validatePlanContent checks a plan for common issues.
+func validatePlanContent(plan string, requirements []string, worktreePath string) []planIssue {
+	var issues []planIssue
+
+	// Check 1: All requirements should be referenced in the plan
+	planLower := strings.ToLower(plan)
+	for i, req := range requirements {
+		// Check if key words from the requirement appear in the plan
+		words := strings.Fields(strings.ToLower(req))
+		matchCount := 0
+		for _, w := range words {
+			if len(w) > 3 && strings.Contains(planLower, w) {
+				matchCount++
+			}
+		}
+		coverage := float64(0)
+		if len(words) > 0 {
+			coverage = float64(matchCount) / float64(len(words))
+		}
+		if coverage < 0.3 {
+			issues = append(issues, planIssue{
+				Severity: "warning",
+				Message:  fmt.Sprintf("requirement %d may not be fully addressed: %q", i+1, truncate(req, 60)),
+			})
+		}
+	}
+
+	// Check 2: Referenced files should exist
+	fileRe := regexp.MustCompile("`([^`]+\\.[a-zA-Z]+)`")
+	matches := fileRe.FindAllStringSubmatch(plan, -1)
+	missingCount := 0
+	for _, m := range matches {
+		filePath := m[1]
+		// Skip if it looks like a pattern or contains wildcards
+		if strings.Contains(filePath, "*") || strings.Contains(filePath, "...") {
+			continue
+		}
+		fullPath := filepath.Join(worktreePath, filePath)
+		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+			missingCount++
+		}
+	}
+	if missingCount > 0 && len(matches) > 0 {
+		ratio := float64(missingCount) / float64(len(matches))
+		if ratio > 0.5 {
+			issues = append(issues, planIssue{
+				Severity: "warning",
+				Message:  fmt.Sprintf("%d of %d referenced files do not exist (may need to be created)", missingCount, len(matches)),
+			})
+		}
+	}
+
+	// Check 3: Scope check — flag if plan references too many files
+	if len(matches) > 30 {
+		issues = append(issues, planIssue{
+			Severity: "warning",
+			Message:  fmt.Sprintf("plan references %d files — scope may be too broad", len(matches)),
+		})
+	}
+
+	return issues
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/pipeline/research.go
+++ b/internal/pipeline/research.go
@@ -1,0 +1,276 @@
+package pipeline
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// researchDir is the directory under the worktree where research files are written.
+const researchDir = ".maestro/research"
+
+// runResearch performs the pre-coding research phase.
+// It scans the codebase for files relevant to the issue keywords and writes
+// a context file to .maestro/research/<issue-number>.md.
+// Returns the research context as a string.
+func runResearch(worktreePath string, issueNumber int, issueTitle, issueBody string) (string, error) {
+	keywords := extractKeywords(issueTitle, issueBody)
+	if len(keywords) == 0 {
+		return "", fmt.Errorf("no keywords extracted from issue")
+	}
+	log.Printf("[pipeline] research: extracted %d keywords: %v", len(keywords), keywords)
+
+	// Scan codebase for relevant files
+	relevantFiles := findRelevantFiles(worktreePath, keywords)
+	log.Printf("[pipeline] research: found %d relevant files", len(relevantFiles))
+
+	// Build the research context document
+	var sb strings.Builder
+	sb.WriteString("# Pre-coding Research Context\n\n")
+	sb.WriteString(fmt.Sprintf("## Keywords: %s\n\n", strings.Join(keywords, ", ")))
+
+	if len(relevantFiles) == 0 {
+		sb.WriteString("No directly relevant files found. The worker should explore the codebase.\n")
+	} else {
+		sb.WriteString("## Relevant Files\n\n")
+		// Cap at 20 files to keep context focused
+		limit := len(relevantFiles)
+		if limit > 20 {
+			limit = 20
+		}
+		for _, rf := range relevantFiles[:limit] {
+			sb.WriteString(fmt.Sprintf("- `%s` — matches: %s\n", rf.Path, strings.Join(rf.MatchedKeywords, ", ")))
+		}
+		if len(relevantFiles) > 20 {
+			sb.WriteString(fmt.Sprintf("\n...and %d more files.\n", len(relevantFiles)-20))
+		}
+
+		// Read snippets from top relevant files
+		sb.WriteString("\n## Key File Snippets\n\n")
+		snippetLimit := 5
+		if snippetLimit > len(relevantFiles) {
+			snippetLimit = len(relevantFiles)
+		}
+		for _, rf := range relevantFiles[:snippetLimit] {
+			snippet := readFileHead(filepath.Join(worktreePath, rf.Path), 30)
+			if snippet != "" {
+				sb.WriteString(fmt.Sprintf("### %s\n```\n%s\n```\n\n", rf.Path, snippet))
+			}
+		}
+	}
+
+	// Discover project structure patterns
+	patterns := discoverPatterns(worktreePath)
+	if len(patterns) > 0 {
+		sb.WriteString("## Project Patterns\n\n")
+		for _, p := range patterns {
+			sb.WriteString(fmt.Sprintf("- %s\n", p))
+		}
+	}
+
+	context := sb.String()
+
+	// Write research file
+	researchPath := filepath.Join(worktreePath, researchDir)
+	if err := os.MkdirAll(researchPath, 0755); err != nil {
+		return context, fmt.Errorf("create research dir: %w", err)
+	}
+	outFile := filepath.Join(researchPath, fmt.Sprintf("%d.md", issueNumber))
+	if err := os.WriteFile(outFile, []byte(context), 0644); err != nil {
+		return context, fmt.Errorf("write research file: %w", err)
+	}
+	log.Printf("[pipeline] research: wrote context to %s (%d bytes)", outFile, len(context))
+
+	return context, nil
+}
+
+// relevantFile represents a file that matched research keywords.
+type relevantFile struct {
+	Path            string
+	MatchedKeywords []string
+}
+
+// extractKeywords extracts meaningful keywords from issue title and body.
+func extractKeywords(title, body string) []string {
+	// Combine title and body, split into words
+	text := title + " " + body
+
+	// Remove markdown formatting, URLs, code blocks
+	text = regexp.MustCompile("```[\\s\\S]*?```").ReplaceAllString(text, "")
+	text = regexp.MustCompile("`[^`]+`").ReplaceAllString(text, "")
+	text = regexp.MustCompile(`https?://\S+`).ReplaceAllString(text, "")
+	text = regexp.MustCompile(`[#*_\[\]()>~]`).ReplaceAllString(text, " ")
+
+	words := strings.Fields(strings.ToLower(text))
+
+	// Filter: keep words that are meaningful (>3 chars, not stop words)
+	stopWords := map[string]bool{
+		"the": true, "and": true, "for": true, "that": true, "this": true,
+		"with": true, "from": true, "are": true, "was": true, "were": true,
+		"been": true, "have": true, "has": true, "had": true, "not": true,
+		"but": true, "what": true, "all": true, "can": true, "will": true,
+		"each": true, "which": true, "their": true, "there": true, "when": true,
+		"should": true, "would": true, "could": true, "does": true, "into": true,
+		"before": true, "after": true, "about": true, "between": true,
+		"true": true, "false": true, "default": true, "also": true,
+		"more": true, "than": true, "then": true, "them": true, "they": true,
+		"some": true, "other": true, "every": true, "must": true, "only": true,
+	}
+
+	seen := make(map[string]bool)
+	var keywords []string
+	for _, w := range words {
+		// Clean non-alphanumeric edges
+		w = strings.Trim(w, ".,;:!?\"'()-/")
+		if len(w) < 3 || stopWords[w] || seen[w] {
+			continue
+		}
+		seen[w] = true
+		keywords = append(keywords, w)
+	}
+
+	// Limit to top 15 keywords (prefer shorter list for focused search)
+	if len(keywords) > 15 {
+		keywords = keywords[:15]
+	}
+
+	return keywords
+}
+
+// findRelevantFiles walks the worktree and finds files matching keywords.
+func findRelevantFiles(worktreePath string, keywords []string) []relevantFile {
+	var results []relevantFile
+	seen := make(map[string]bool)
+
+	// Skip common non-source directories
+	skipDirs := map[string]bool{
+		".git": true, "node_modules": true, "vendor": true, ".maestro": true,
+		"target": true, "dist": true, "build": true, "__pycache__": true,
+	}
+
+	filepath.Walk(worktreePath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			if skipDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Only consider source files
+		ext := strings.ToLower(filepath.Ext(info.Name()))
+		if !isSourceExt(ext) {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(worktreePath, path)
+		if err != nil {
+			return nil
+		}
+
+		// Check if filename or path matches any keyword
+		lowerPath := strings.ToLower(relPath)
+		var matched []string
+		for _, kw := range keywords {
+			if strings.Contains(lowerPath, kw) {
+				matched = append(matched, kw)
+			}
+		}
+
+		if len(matched) > 0 && !seen[relPath] {
+			seen[relPath] = true
+			results = append(results, relevantFile{Path: relPath, MatchedKeywords: matched})
+		}
+
+		return nil
+	})
+
+	// Sort by number of matched keywords (more matches = more relevant)
+	for i := 0; i < len(results); i++ {
+		for j := i + 1; j < len(results); j++ {
+			if len(results[j].MatchedKeywords) > len(results[i].MatchedKeywords) {
+				results[i], results[j] = results[j], results[i]
+			}
+		}
+	}
+
+	return results
+}
+
+// isSourceExt returns true for common source file extensions.
+func isSourceExt(ext string) bool {
+	switch ext {
+	case ".go", ".rs", ".py", ".js", ".ts", ".tsx", ".jsx",
+		".java", ".rb", ".c", ".h", ".cpp", ".hpp",
+		".yaml", ".yml", ".toml", ".json", ".md",
+		".sh", ".bash", ".zsh":
+		return true
+	}
+	return false
+}
+
+// readFileHead reads the first N lines of a file.
+func readFileHead(path string, lines int) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	allLines := strings.Split(string(data), "\n")
+	if len(allLines) > lines {
+		allLines = allLines[:lines]
+	}
+	return strings.Join(allLines, "\n")
+}
+
+// discoverPatterns identifies project structure patterns in the worktree.
+func discoverPatterns(worktreePath string) []string {
+	var patterns []string
+
+	// Check for Go project
+	if _, err := os.Stat(filepath.Join(worktreePath, "go.mod")); err == nil {
+		patterns = append(patterns, "Go project (go.mod found)")
+	}
+
+	// Check for Rust project
+	if _, err := os.Stat(filepath.Join(worktreePath, "Cargo.toml")); err == nil {
+		patterns = append(patterns, "Rust project (Cargo.toml found)")
+	}
+
+	// Check for Node project
+	if _, err := os.Stat(filepath.Join(worktreePath, "package.json")); err == nil {
+		patterns = append(patterns, "Node.js project (package.json found)")
+	}
+
+	// Check for Python project
+	for _, f := range []string{"setup.py", "pyproject.toml", "requirements.txt"} {
+		if _, err := os.Stat(filepath.Join(worktreePath, f)); err == nil {
+			patterns = append(patterns, fmt.Sprintf("Python project (%s found)", f))
+			break
+		}
+	}
+
+	// Check for common directories
+	dirs := []struct {
+		name    string
+		pattern string
+	}{
+		{"cmd", "CLI entry points in cmd/"},
+		{"internal", "Internal packages in internal/"},
+		{"pkg", "Public packages in pkg/"},
+		{"src", "Source code in src/"},
+		{"test", "Tests in test/"},
+		{"tests", "Tests in tests/"},
+	}
+	for _, d := range dirs {
+		if info, err := os.Stat(filepath.Join(worktreePath, d.name)); err == nil && info.IsDir() {
+			patterns = append(patterns, d.pattern)
+		}
+	}
+
+	return patterns
+}

--- a/internal/pipeline/testmapping.go
+++ b/internal/pipeline/testmapping.go
@@ -1,0 +1,254 @@
+package pipeline
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// testMapping represents a mapping from a requirement to its verification command.
+type testMapping struct {
+	Requirement string
+	VerifyCmd   string
+}
+
+// mapTests generates verification commands for each requirement and writes
+// a verify.sh script to the worktree. Returns the path to the verify script
+// and a markdown summary of the test mapping.
+func mapTests(issueNumber int, issueTitle, issueBody, worktreePath, plan string) (string, string, error) {
+	requirements := extractRequirements(issueBody)
+	if len(requirements) == 0 {
+		requirements = []string{issueTitle}
+	}
+
+	// Detect project test infrastructure
+	testCmds := detectTestInfrastructure(worktreePath)
+	log.Printf("[pipeline] test-mapping: detected test commands: %v", testCmds)
+
+	// Build test mappings
+	mappings := buildTestMappings(requirements, worktreePath, testCmds)
+
+	// Generate verify.sh
+	verifyPath := filepath.Join(worktreePath, ".maestro", "verify.sh")
+	if err := os.MkdirAll(filepath.Dir(verifyPath), 0755); err != nil {
+		return "", "", fmt.Errorf("create verify dir: %w", err)
+	}
+
+	script := generateVerifyScript(mappings, testCmds)
+	if err := os.WriteFile(verifyPath, []byte(script), 0755); err != nil {
+		return "", "", fmt.Errorf("write verify script: %w", err)
+	}
+	log.Printf("[pipeline] test-mapping: wrote verify.sh (%d bytes, %d mappings)", len(script), len(mappings))
+
+	// Build markdown summary for prompt injection
+	summary := buildTestMappingSummary(mappings, verifyPath)
+
+	return verifyPath, summary, nil
+}
+
+// detectTestInfrastructure identifies the test framework(s) used in the project.
+func detectTestInfrastructure(worktreePath string) []string {
+	var cmds []string
+
+	// Go
+	if _, err := os.Stat(filepath.Join(worktreePath, "go.mod")); err == nil {
+		cmds = append(cmds, "go test ./...")
+	}
+
+	// Rust
+	if _, err := os.Stat(filepath.Join(worktreePath, "Cargo.toml")); err == nil {
+		cmds = append(cmds, "cargo test")
+	}
+
+	// Node.js — check package.json for test script
+	pkgJSON := filepath.Join(worktreePath, "package.json")
+	if data, err := os.ReadFile(pkgJSON); err == nil {
+		content := string(data)
+		if strings.Contains(content, `"test"`) {
+			cmds = append(cmds, "npm test")
+		}
+	}
+
+	// Python
+	for _, f := range []string{"setup.py", "pyproject.toml"} {
+		if _, err := os.Stat(filepath.Join(worktreePath, f)); err == nil {
+			cmds = append(cmds, "python -m pytest")
+			break
+		}
+	}
+
+	// Makefile
+	if _, err := os.Stat(filepath.Join(worktreePath, "Makefile")); err == nil {
+		cmds = append(cmds, "make test")
+	}
+
+	return cmds
+}
+
+// buildTestMappings creates test mappings for each requirement.
+func buildTestMappings(requirements []string, worktreePath string, testCmds []string) []testMapping {
+	var mappings []testMapping
+
+	// Find existing test files
+	testFiles := findTestFiles(worktreePath)
+
+	for _, req := range requirements {
+		mapping := testMapping{
+			Requirement: req,
+		}
+
+		// Try to find a specific test file related to this requirement
+		keywords := extractKeywords(req, "")
+		specificTest := findRelatedTestFile(testFiles, keywords)
+
+		if specificTest != "" {
+			// Use the specific test file
+			if strings.HasSuffix(specificTest, "_test.go") {
+				pkg := filepath.Dir(specificTest)
+				mapping.VerifyCmd = fmt.Sprintf("go test ./%s/...", pkg)
+			} else {
+				mapping.VerifyCmd = fmt.Sprintf("# Run tests in %s", specificTest)
+			}
+		} else if len(testCmds) > 0 {
+			// Fall back to project-wide test command
+			mapping.VerifyCmd = testCmds[0]
+		} else {
+			mapping.VerifyCmd = "# No automated test found — manual verification required"
+		}
+
+		mappings = append(mappings, mapping)
+	}
+
+	return mappings
+}
+
+// findTestFiles walks the worktree looking for test files.
+func findTestFiles(worktreePath string) []string {
+	var testFiles []string
+
+	skipDirs := map[string]bool{
+		".git": true, "node_modules": true, "vendor": true, ".maestro": true,
+		"target": true, "dist": true, "build": true,
+	}
+
+	filepath.Walk(worktreePath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			if skipDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		name := info.Name()
+		relPath, relErr := filepath.Rel(worktreePath, path)
+		if relErr != nil {
+			return nil
+		}
+
+		// Match common test file patterns
+		isTest := false
+		switch {
+		case strings.HasSuffix(name, "_test.go"):
+			isTest = true
+		case strings.HasSuffix(name, ".test.js") || strings.HasSuffix(name, ".test.ts"):
+			isTest = true
+		case strings.HasSuffix(name, ".spec.js") || strings.HasSuffix(name, ".spec.ts"):
+			isTest = true
+		case strings.HasPrefix(name, "test_") && strings.HasSuffix(name, ".py"):
+			isTest = true
+		case strings.HasSuffix(name, "_test.rs"):
+			isTest = true
+		}
+
+		if isTest {
+			testFiles = append(testFiles, relPath)
+		}
+		return nil
+	})
+
+	return testFiles
+}
+
+// findRelatedTestFile finds a test file related to the given keywords.
+func findRelatedTestFile(testFiles []string, keywords []string) string {
+	bestMatch := ""
+	bestScore := 0
+
+	for _, tf := range testFiles {
+		lowerPath := strings.ToLower(tf)
+		score := 0
+		for _, kw := range keywords {
+			if strings.Contains(lowerPath, kw) {
+				score++
+			}
+		}
+		if score > bestScore {
+			bestScore = score
+			bestMatch = tf
+		}
+	}
+
+	return bestMatch
+}
+
+// generateVerifyScript creates the verify.sh script content.
+func generateVerifyScript(mappings []testMapping, testCmds []string) string {
+	var sb strings.Builder
+	sb.WriteString("#!/bin/bash\n")
+	sb.WriteString("# Auto-generated by maestro pipeline — verification commands for this task\n")
+	sb.WriteString("# Run this script to verify all requirements are met.\n")
+	sb.WriteString("set -e\n\n")
+
+	// Add project-level checks first
+	if len(testCmds) > 0 {
+		sb.WriteString("echo '=== Project Test Suite ==='\n")
+		for _, cmd := range testCmds {
+			sb.WriteString(fmt.Sprintf("%s\n", cmd))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Add per-requirement verification
+	sb.WriteString("echo '=== Requirement Verification ==='\n")
+	for i, m := range mappings {
+		sb.WriteString(fmt.Sprintf("echo 'Requirement %d: %s'\n", i+1, shellEscape(truncate(m.Requirement, 80))))
+		if strings.HasPrefix(m.VerifyCmd, "#") {
+			sb.WriteString(fmt.Sprintf("echo 'WARN: %s'\n", m.VerifyCmd[2:]))
+		} else {
+			sb.WriteString(fmt.Sprintf("%s\n", m.VerifyCmd))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("echo 'All verifications passed.'\n")
+	return sb.String()
+}
+
+// shellEscape escapes a string for safe use in a shell echo command.
+func shellEscape(s string) string {
+	s = strings.ReplaceAll(s, "'", "'\\''")
+	return s
+}
+
+// buildTestMappingSummary creates a markdown summary of test mappings for prompt injection.
+func buildTestMappingSummary(mappings []testMapping, verifyPath string) string {
+	var sb strings.Builder
+	sb.WriteString("# Test Mapping\n\n")
+	sb.WriteString("Each requirement has been mapped to a verification command.\n")
+	sb.WriteString(fmt.Sprintf("A verify script has been generated at: `%s`\n\n", verifyPath))
+
+	sb.WriteString("| # | Requirement | Verify Command |\n")
+	sb.WriteString("|---|-------------|----------------|\n")
+	for i, m := range mappings {
+		sb.WriteString(fmt.Sprintf("| %d | %s | `%s` |\n",
+			i+1, truncate(m.Requirement, 50), truncate(m.VerifyCmd, 50)))
+	}
+
+	sb.WriteString("\n**After implementing changes, run the verify script to confirm all requirements are met.**\n")
+	return sb.String()
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/pipeline"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -81,6 +82,12 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		} else {
 			log.Printf("[worker] VALIDATION.md already present (from hook), skipping generation")
 		}
+	}
+
+	// Run GSD pre-worker pipeline (research, plan validation, test mapping)
+	pipelineResult := pipeline.RunGSD(cfg, worktreePath, issue.Number, issue.Title, issue.Body)
+	if section := pipelineResult.PromptSection(); section != "" {
+		promptBase = promptBase + section
 	}
 
 	// Assemble worker prompt
@@ -222,6 +229,12 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 		} else {
 			log.Printf("[worker] VALIDATION.md already present (from hook), skipping generation")
 		}
+	}
+
+	// Run GSD pre-worker pipeline (research, plan validation, test mapping)
+	pipelineResult := pipeline.RunGSD(cfg, worktreePath, issue.Number, issue.Title, issue.Body)
+	if section := pipelineResult.PromptSection(); section != "" {
+		promptBase = promptBase + section
 	}
 
 	// Assemble worker prompt


### PR DESCRIPTION
Implements #212

## Changes

Adds three configurable pre-worker pipeline phases inspired by the [GSD](https://github.com/gsd-build/get-shit-done) context engineering system. These run before each worker starts and inject focused context into the worker prompt.

### 1. Pre-coding Research Phase (`pipeline.research`)
- Extracts keywords from issue title/body
- Scans the codebase for relevant files matching those keywords
- Discovers project patterns (Go/Rust/Node/Python, directory structure)
- Writes context to `.maestro/research/<issue-number>.md`
- Prevents "context rot" — workers start with focused, relevant context

### 2. Plan Validation Gate (`pipeline.plan_validation`)
- Extracts structured requirements from issue body (bullets, numbered lists, checkboxes)
- Builds a plan mapping each requirement to related files
- Validates: all requirements addressed, referenced files exist, scope is reasonable
- Up to 3 revision loops before accepting the plan
- Validated plan is injected into the worker prompt

### 3. Test Mapping (`pipeline.test_mapping`)
- Detects project test infrastructure (go test, cargo test, npm test, pytest, make test)
- Maps each requirement to a specific verification command
- Finds related test files for targeted verification
- Generates `.maestro/verify.sh` script
- Summary table injected into worker prompt

### Config (all optional, per-repo)
```yaml
pipeline:
  research: false        # default: false (~30s overhead)
  plan_validation: true  # default: true
  test_mapping: true     # default: true
```

These GSD fields coexist with the existing phase-based pipeline config (`pipeline.enabled`, `pipeline.planner`, `pipeline.validator`).

### New files
- `internal/pipeline/research.go` — research phase implementation
- `internal/pipeline/planvalidation.go` — plan validation implementation
- `internal/pipeline/testmapping.go` — test mapping implementation
- Extended `internal/pipeline/pipeline.go` with `RunGSD()` orchestration and `GSDResult` type
- Extended `internal/config/config.go` with GSD fields on `PipelineConfig`

## Testing

- 28 new tests in `internal/pipeline/pipeline_test.go` covering all three phases
- 3 new config parse tests for GSD pipeline config
- All existing tests pass (14 packages)
- `go fmt`, `go vet`, `go test ./...`, `go build ./cmd/maestro/` all pass
- Rebased cleanly on origin/main with conflict resolution

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three GSD-inspired pre-worker pipeline phases (research, plan validation, test mapping) that inject focused context into worker prompts before each worker starts. The config layer and worker integration are clean, and the research phase implementation is solid. However, two issues were found beyond those already raised in prior review threads:

- **Always-on GSD by default**: Because `PlanValidation` and `TestMapping` are `*bool` fields that return `true` when nil, the `anyEnabled` guard in `RunGSD` is always satisfied. Every existing deployment will begin running plan validation and test mapping (including full filesystem walks and `verify.sh` writes) on every worker startup without any config change required. Whether this is intentional opt-out behavior needs to be confirmed and communicated clearly.
- **Duplicate plan heading**: `PromptSection` wraps the plan under `"## Implementation Plan"`, but `buildPlan` already opens its output with `"# Implementation Plan\n\n"`, producing a doubled/nested heading in every worker prompt.

The previously flagged issues in `planvalidation.go` (broken retry loop, ignored feedback) and `testmapping.go` (invalid `go test` pattern for root packages) remain open.

<h3>Confidence Score: 3/5</h3>

- Not ready to merge — the always-on GSD default is a silent breaking change for all existing users, and several previously flagged bugs in planvalidation.go remain unresolved.
- The always-on GSD execution (plan validation + test mapping running for every worker by default) is a production-reliability concern that will affect all existing deployments without any config change. Combined with the still-open bugs from the prior review round (retry loop that never retries, ignored revision feedback, invalid go test pattern for root packages), the PR needs targeted fixes before it is safe to merge.
- internal/pipeline/pipeline.go (always-on default + duplicate heading), internal/pipeline/planvalidation.go (retry loop and feedback bugs from prior round), internal/pipeline/testmapping.go (root-package go test pattern from prior round)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/pipeline/pipeline.go | Adds GSDResult type and RunGSD orchestrator. Two logic issues: (1) PlanValidation/TestMapping default to true means GSD always runs for all workers, silently affecting existing users; (2) PromptSection wraps plan in a duplicate heading already present in buildPlan's output. |
| internal/pipeline/planvalidation.go | Implements plan validation with a revision loop. Already-flagged bugs remain: validatePlanContent emits only "warning"-severity issues so the retry condition (errors == 0) is always satisfied and the loop never actually retries; buildPlan ignores accumulated validation feedback; truncate byte-slices UTF-8 strings. |
| internal/pipeline/testmapping.go | Maps requirements to verification commands and writes verify.sh. Previously flagged go test ./.../... bug for root-level test files remains open. shellEscape and verify script generation are otherwise correct. |
| internal/pipeline/research.go | Implements keyword extraction, file relevance scanning, snippet reading, and project pattern discovery. Bubble-sort for ranking is O(n²) but fine for the 20-file cap. No critical issues. |
| internal/config/config.go | Adds Research, PlanValidation (*bool), and TestMapping (*bool) to PipelineConfig with nil-default helper methods. Clean, well-structured addition. |
| internal/worker/worker.go | Integrates RunGSD into both Start and Respawn paths. Integration is symmetric and correct. RunGSD's always-on default (flagged in pipeline.go) is the risk here, not the integration itself. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/pipeline/pipeline.go
Line: 192-195

Comment:
**GSD always runs — opt-out default silently breaks existing users**

Because `PlanValidationEnabled()` and `TestMappingEnabled()` both return `true` when the YAML field is absent (nil), `anyEnabled` is always `true` for every repo that has never touched these fields. This means the GSD pipeline — including a full filesystem walk in `buildPlan`/`findRelevantFiles` and a `.maestro/verify.sh` write in `mapTests` — now executes for every single worker startup across all existing deployments, with no opt-in required.

This is a silent behavioral change: users who have never heard of GSD will suddenly see latency added to every worker start, extra files appearing in their worktrees, and bloated prompts — with no config change on their part.

If the intended product contract is "opt-in by default," change `anyEnabled` to only fire when at least one field was explicitly set:

```go
anyEnabled := pipeline.Research ||
    (pipeline.PlanValidation != nil && *pipeline.PlanValidation) ||
    (pipeline.TestMapping != nil && *pipeline.TestMapping)
```

If the intent really is opt-out (enabled-by-default), the PR description, changelog, and migration guide should call this out explicitly so existing operators know to add `plan_validation: false` / `test_mapping: false` to their configs.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/pipeline/pipeline.go
Line: 171-173

Comment:
**Duplicate `# Implementation Plan` heading injected into worker prompt**

`PromptSection` wraps the plan under its own `"## Implementation Plan"` header, but `buildPlan` already starts its returned string with `"# Implementation Plan\n\n"`. The final prompt section becomes:

```
## Implementation Plan

The following plan has been validated. Use it as your guide:

# Implementation Plan

## Project Context
...
```

The nested, conflicting headings are at minimum visually confusing for the AI worker. Fix by stripping the redundant top-level header from `buildPlan`, or remove the wrapper header from `PromptSection`:

```suggestion
	if r.Plan != "" {
		sections = append(sections, "## Implementation Plan\n\nThe following plan has been validated. Use it as your guide:\n\n"+strings.TrimPrefix(r.Plan, "# Implementation Plan\n\n"))
	}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat: add GSD-inspired pre-worker pipeli..."](https://github.com/befeast/maestro/commit/2cf391ac25548b8da8b6ea2b260bb7cbe72f172c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25961193)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->