### PR TITLE
feat: soft token threshold with checkpoint and proactive refresh (#218)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,7 @@ type Config struct {
 	MaxRuntimeMinutes          int                  `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
 	WorkerSilentTimeoutMinutes int                  `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
 	WorkerMaxTokens            int                  `yaml:"worker_max_tokens"`             // kill worker when token usage exceeds this threshold (0 = unlimited)
+	WorkerSoftTokenThreshold   *float64             `yaml:"worker_soft_token_threshold"`   // fraction of worker_max_tokens to trigger checkpoint+respawn (default: 0.8, 0 = disabled)
 	MaxRetriesPerIssue         int                  `yaml:"max_retries_per_issue"`         // max failed worker sessions per issue before giving up (default: 3, 0 = unlimited)
 	AutoRebase                 bool                 `yaml:"auto_rebase"`                   // auto-attempt rebase for conflicting sessions (default: true)
 	ClaudeCmd                  string               `yaml:"claude_cmd"`                    // deprecated: use model.backends.claude.cmd
@@ -361,6 +362,12 @@ func parse(data []byte) (*Config, error) {
 		cfg.Hooks.TimeoutMs = 60000
 	}
 
+	// Default soft token threshold: 0.8 (80% of worker_max_tokens)
+	if cfg.WorkerSoftTokenThreshold == nil {
+		d := 0.8
+		cfg.WorkerSoftTokenThreshold = &d
+	}
+
 	// Missions defaults
 	if cfg.Missions.MaxChildren <= 0 {
 		cfg.Missions.MaxChildren = 10
@@ -400,6 +407,15 @@ func LoadDir(dir string) ([]*Config, error) {
 }
 
 // ShouldCleanupWorktrees returns whether worktrees should be removed after PR merge.
+// SoftTokenThreshold returns the soft token threshold fraction (0–1).
+// Returns 0 if disabled (pointer is nil or value is 0).
+func (c *Config) SoftTokenThreshold() float64 {
+	if c.WorkerSoftTokenThreshold == nil {
+		return 0
+	}
+	return *c.WorkerSoftTokenThreshold
+}
+
 func (c *Config) ShouldCleanupWorktrees() bool {
 	if c.CleanupWorktreesOnMerge == nil {
 		return true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1190,3 +1190,42 @@ pipeline:
 		t.Error("Pipeline.TestMapping should default to true when not set")
 	}
 }
+
+func TestParse_SoftTokenThresholdDefault(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.SoftTokenThreshold() != 0.8 {
+		t.Errorf("SoftTokenThreshold() = %f, want 0.8 (default)", cfg.SoftTokenThreshold())
+	}
+}
+
+func TestParse_SoftTokenThresholdExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+worker_soft_token_threshold: 0.7
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.SoftTokenThreshold() != 0.7 {
+		t.Errorf("SoftTokenThreshold() = %f, want 0.7", cfg.SoftTokenThreshold())
+	}
+}
+
+func TestParse_SoftTokenThresholdZeroDisabled(t *testing.T) {
+	yaml := `
+repo: owner/repo
+worker_soft_token_threshold: 0
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.SoftTokenThreshold() != 0 {
+		t.Errorf("SoftTokenThreshold() = %f, want 0 (disabled)", cfg.SoftTokenThreshold())
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -48,6 +48,9 @@ type Orchestrator struct {
 	workerRespawnFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 	respawnWorkerFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 	getIssueFn      func(number int) (github.Issue, error)
+	// saveCheckpointFn / respawnInPlaceFn: used for soft token threshold checkpoint+respawn
+	saveCheckpointFn func(sess *state.Session) (string, error)
+	respawnInPlaceFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 
 	// Testing hooks for pipeline phase transitions
 	workerStartPhaseFn func(cfg *config.Config, sess *state.Session, slotName, prompt, backendName string) error
@@ -191,6 +194,20 @@ func (o *Orchestrator) respawnWorker(slotName string, sess *state.Session, issue
 		return o.workerRespawnFn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
 	}
 	return worker.Respawn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
+}
+
+func (o *Orchestrator) saveCheckpoint(sess *state.Session) (string, error) {
+	if o.saveCheckpointFn != nil {
+		return o.saveCheckpointFn(sess)
+	}
+	return worker.SaveCheckpoint(sess)
+}
+
+func (o *Orchestrator) respawnInPlace(slotName string, sess *state.Session, issue github.Issue, promptBase string, backendName string) error {
+	if o.respawnInPlaceFn != nil {
+		return o.respawnInPlaceFn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
+	}
+	return worker.RespawnInPlace(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
 }
 
 func (o *Orchestrator) rebaseWorktree(worktreePath, branch string) error {
@@ -1049,6 +1066,39 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 							o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); no fallback configured",
 								slotName, sess.IssueNumber, pattern)
 							continue
+						}
+					}
+
+					// --- Soft token threshold: checkpoint + respawn ---
+					if o.cfg.WorkerMaxTokens > 0 && o.cfg.SoftTokenThreshold() > 0 && sess.CheckpointFile == "" {
+						softLimit := int(float64(o.cfg.WorkerMaxTokens) * o.cfg.SoftTokenThreshold())
+						if sess.TokensUsedAttempt >= softLimit {
+							log.Printf("[orch] worker %s hit soft token threshold (%d >= %d), checkpointing",
+								slotName, sess.TokensUsedAttempt, softLimit)
+
+							// Save checkpoint
+							cpFile, cpErr := o.saveCheckpoint(sess)
+							if cpErr != nil {
+								log.Printf("[orch] warn: checkpoint save failed for %s: %v — will hit hard limit", slotName, cpErr)
+							} else {
+								sess.CheckpointFile = cpFile
+
+								// Fetch issue for prompt assembly
+								issue, fetchErr := o.getIssue(sess.IssueNumber)
+								if fetchErr != nil {
+									log.Printf("[orch] fetch issue #%d for checkpoint respawn: %v — will hit hard limit", sess.IssueNumber, fetchErr)
+								} else {
+									promptBase := o.selectPrompt(issue)
+									if respawnErr := o.respawnInPlace(slotName, sess, issue, promptBase, sess.Backend); respawnErr != nil {
+										log.Printf("[orch] checkpoint respawn %s failed: %v — will hit hard limit", slotName, respawnErr)
+									} else {
+										log.Printf("[orch] checkpoint respawn complete for %s", slotName)
+										o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) hit soft token threshold (%s tokens) — checkpointed and respawned",
+											slotName, sess.IssueNumber, worker.FormatTokens(softLimit))
+										continue
+									}
+								}
+							}
 						}
 					}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -4501,3 +4501,247 @@ func TestRespawnDueRetries_NoCIContext_NormalPrompt(t *testing.T) {
 		t.Error("prompt should NOT contain CI failure context for non-CI retries")
 	}
 }
+
+func TestCheckSessions_SoftThreshold_CheckpointAndRespawn(t *testing.T) {
+	softThreshold := 0.8
+	cfg := &config.Config{
+		Repo:                     "owner/repo",
+		WorkerMaxTokens:          100000,
+		WorkerSoftTokenThreshold: &softThreshold,
+		MaxRuntimeMinutes:        999,
+	}
+	// Worker output: 85,000 tokens — above 80% soft threshold (80,000) but below hard limit (100,000)
+	stopped := make([]string, 0)
+	checkpointed := make([]string, 0)
+	respawnedInPlace := make([]string, 0)
+
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return true
+		},
+		captureTmuxFn: func(session string) (string, error) {
+			return "tokens 85000 (in 25000 / out 60000)", nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			stopped = append(stopped, slotName)
+			return nil
+		},
+		saveCheckpointFn: func(sess *state.Session) (string, error) {
+			checkpointed = append(checkpointed, fmt.Sprintf("issue-%d", sess.IssueNumber))
+			return "/tmp/CHECKPOINT.md", nil
+		},
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "test issue"}, nil
+		},
+		respawnInPlaceFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedInPlace = append(respawnedInPlace, slotName)
+			sess.Status = state.StatusRunning
+			sess.TokensUsedAttempt = 0
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber: 42,
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-1",
+		Branch:      "feat/mae-1-42-test",
+		StartedAt:   time.Now().Add(-30 * time.Minute),
+		Backend:     "claude",
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-1"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (should still be running after checkpoint respawn)", sess.Status, state.StatusRunning)
+	}
+	if sess.CheckpointFile != "/tmp/CHECKPOINT.md" {
+		t.Fatalf("checkpoint_file = %q, want /tmp/CHECKPOINT.md", sess.CheckpointFile)
+	}
+	if len(checkpointed) != 1 {
+		t.Fatalf("checkpointed = %v, want 1 call", checkpointed)
+	}
+	if len(respawnedInPlace) != 1 || respawnedInPlace[0] != "mae-1" {
+		t.Fatalf("respawnedInPlace = %v, want [mae-1]", respawnedInPlace)
+	}
+	// Worker should NOT be stopped (respawnInPlace handles the stop internally)
+	if len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want empty (respawnInPlace handles stop)", stopped)
+	}
+}
+
+func TestCheckSessions_SoftThreshold_AlreadyCheckpointed_NoRepeat(t *testing.T) {
+	softThreshold := 0.8
+	cfg := &config.Config{
+		Repo:                     "owner/repo",
+		WorkerMaxTokens:          100000,
+		WorkerSoftTokenThreshold: &softThreshold,
+		MaxRuntimeMinutes:        999,
+	}
+	checkpointed := make([]string, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return true
+		},
+		captureTmuxFn: func(session string) (string, error) {
+			return "tokens 90000 (in 30000 / out 60000)", nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+		saveCheckpointFn: func(sess *state.Session) (string, error) {
+			checkpointed = append(checkpointed, "saved")
+			return "/tmp/CHECKPOINT.md", nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-2"] = &state.Session{
+		IssueNumber:    42,
+		Status:         state.StatusRunning,
+		PID:            1234,
+		TmuxSession:    "maestro-mae-2",
+		Branch:         "feat/mae-2-42-test",
+		StartedAt:      time.Now().Add(-30 * time.Minute),
+		Backend:        "claude",
+		CheckpointFile: "/tmp/old-CHECKPOINT.md", // already checkpointed
+	}
+
+	o.checkSessions(s)
+
+	if len(checkpointed) != 0 {
+		t.Fatalf("checkpointed = %v, want empty (already has checkpoint, should not re-checkpoint)", checkpointed)
+	}
+	sess := s.Sessions["mae-2"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+}
+
+func TestCheckSessions_SoftThresholdDisabled_NoCheckpoint(t *testing.T) {
+	zero := 0.0
+	cfg := &config.Config{
+		Repo:                     "owner/repo",
+		WorkerMaxTokens:          100000,
+		WorkerSoftTokenThreshold: &zero, // disabled
+		MaxRuntimeMinutes:        999,
+	}
+	checkpointed := make([]string, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return true
+		},
+		captureTmuxFn: func(session string) (string, error) {
+			return "tokens 85000 (in 25000 / out 60000)", nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+		saveCheckpointFn: func(sess *state.Session) (string, error) {
+			checkpointed = append(checkpointed, "saved")
+			return "/tmp/CHECKPOINT.md", nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-3"] = &state.Session{
+		IssueNumber: 42,
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-3",
+		Branch:      "feat/mae-3-42-test",
+		StartedAt:   time.Now().Add(-30 * time.Minute),
+		Backend:     "claude",
+	}
+
+	o.checkSessions(s)
+
+	if len(checkpointed) != 0 {
+		t.Fatalf("checkpointed = %v, want empty (soft threshold disabled)", checkpointed)
+	}
+}
+
+func TestCheckSessions_BelowSoftThreshold_NoCheckpoint(t *testing.T) {
+	softThreshold := 0.8
+	cfg := &config.Config{
+		Repo:                     "owner/repo",
+		WorkerMaxTokens:          100000,
+		WorkerSoftTokenThreshold: &softThreshold,
+		MaxRuntimeMinutes:        999,
+	}
+	checkpointed := make([]string, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return true
+		},
+		captureTmuxFn: func(session string) (string, error) {
+			return "tokens 50000 (in 10000 / out 40000)", nil // below 80k soft limit
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+		saveCheckpointFn: func(sess *state.Session) (string, error) {
+			checkpointed = append(checkpointed, "saved")
+			return "/tmp/CHECKPOINT.md", nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-4"] = &state.Session{
+		IssueNumber: 42,
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-4",
+		Branch:      "feat/mae-4-42-test",
+		StartedAt:   time.Now().Add(-30 * time.Minute),
+		Backend:     "claude",
+	}
+
+	o.checkSessions(s)
+
+	if len(checkpointed) != 0 {
+		t.Fatalf("checkpointed = %v, want empty (below soft threshold)", checkpointed)
+	}
+	sess := s.Sessions["mae-4"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+	if sess.TokensUsedAttempt != 50000 {
+		t.Fatalf("tokens_used_attempt = %d, want 50000", sess.TokensUsedAttempt)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -61,6 +61,7 @@ type Session struct {
 	ValidationFails     int           `json:"validation_fails,omitempty"`    // number of failed validation attempts
 	ValidationFeedback  string        `json:"validation_feedback,omitempty"` // feedback from last failed validation
 	CIFailureOutput     string        `json:"ci_failure_output,omitempty"`   // CI failure output captured before retry (passed to next worker as context)
+	CheckpointFile      string        `json:"checkpoint_file,omitempty"`     // path to CHECKPOINT.md saved at soft token threshold
 }
 
 // UnmarshalJSON implements custom unmarshalling to preserve the legacy

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -1,0 +1,244 @@
+package worker
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// SaveCheckpoint captures the worker's progress and writes a CHECKPOINT.md
+// file to the worktree. Returns the path to the checkpoint file.
+func SaveCheckpoint(sess *state.Session) (string, error) {
+	if sess.Worktree == "" {
+		return "", fmt.Errorf("session has no worktree")
+	}
+
+	var sections []string
+	sections = append(sections, "# Checkpoint")
+	sections = append(sections, fmt.Sprintf("\nSaved at: %s", time.Now().UTC().Format(time.RFC3339)))
+	sections = append(sections, fmt.Sprintf("Tokens used (attempt): %d", sess.TokensUsedAttempt))
+	sections = append(sections, fmt.Sprintf("Tokens used (total): %d", sess.TokensUsedTotal))
+
+	// Capture branch commits (relative to origin/main)
+	if out, err := exec.Command("git", "-C", sess.Worktree,
+		"log", "--oneline", "origin/main..HEAD").CombinedOutput(); err == nil {
+		commits := strings.TrimSpace(string(out))
+		if commits != "" {
+			sections = append(sections, "\n## Commits made\n```\n"+commits+"\n```")
+		}
+	}
+
+	// Capture diff stat for uncommitted changes
+	if out, err := exec.Command("git", "-C", sess.Worktree,
+		"diff", "--stat").CombinedOutput(); err == nil {
+		diff := strings.TrimSpace(string(out))
+		if diff != "" {
+			sections = append(sections, "\n## Uncommitted changes\n```\n"+diff+"\n```")
+		}
+	}
+
+	// Capture staged changes stat
+	if out, err := exec.Command("git", "-C", sess.Worktree,
+		"diff", "--cached", "--stat").CombinedOutput(); err == nil {
+		staged := strings.TrimSpace(string(out))
+		if staged != "" {
+			sections = append(sections, "\n## Staged changes\n```\n"+staged+"\n```")
+		}
+	}
+
+	// Read last 30 lines of log for context
+	if sess.LogFile != "" {
+		if tail, err := readTailLines(sess.LogFile, 30); err == nil && tail != "" {
+			sections = append(sections, "\n## Last worker output\n```\n"+tail+"\n```")
+		}
+	}
+
+	content := strings.Join(sections, "\n")
+	checkpointPath := filepath.Join(sess.Worktree, "CHECKPOINT.md")
+	if err := os.WriteFile(checkpointPath, []byte(content+"\n"), 0644); err != nil {
+		return "", fmt.Errorf("write checkpoint: %w", err)
+	}
+
+	log.Printf("[worker] checkpoint saved to %s (%d bytes)", checkpointPath, len(content))
+	return checkpointPath, nil
+}
+
+// RespawnInPlace stops the current worker and restarts it in the same worktree
+// with checkpoint context included in the prompt. Unlike Respawn, this preserves
+// the existing worktree with all committed and staged code.
+func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+	// Kill tmux session + PID (but do NOT remove worktree)
+	tmuxName := TmuxSessionName(slotName)
+	if out, err := exec.Command("tmux", "kill-session", "-t", tmuxName).CombinedOutput(); err != nil {
+		log.Printf("[worker] tmux kill-session %s: %v (%s)", tmuxName, err, strings.TrimSpace(string(out)))
+	}
+	if sess.PID > 0 && IsAlive(sess.PID) {
+		proc, _ := os.FindProcess(sess.PID)
+		if err := proc.Kill(); err != nil {
+			log.Printf("[worker] kill pid %d: %v", sess.PID, err)
+		}
+	}
+
+	// Run after_run hook (non-fatal)
+	if cfg.Hooks.AfterRun != "" {
+		hookEnv := HookEnv{
+			IssueID:       fmt.Sprintf("%s#%d", repo, issue.Number),
+			IssueNumber:   issue.Number,
+			WorkspacePath: sess.Worktree,
+		}
+		if err := RunHook(cfg, "after_run", cfg.Hooks.AfterRun, hookEnv); err != nil {
+			log.Printf("[worker] after_run hook failed: %v", err)
+		}
+	}
+
+	// Read checkpoint content if it exists
+	checkpointContext := ""
+	if sess.CheckpointFile != "" {
+		if data, err := os.ReadFile(sess.CheckpointFile); err == nil {
+			checkpointContext = string(data)
+		}
+	}
+
+	// Assemble prompt with checkpoint
+	prompt := assemblePromptWithCheckpoint(promptBase, issue, sess.Worktree, sess.Branch, cfg, checkpointContext)
+
+	// Write prompt to file
+	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
+	if err := os.WriteFile(promptFile, []byte(prompt), 0644); err != nil {
+		return fmt.Errorf("write prompt file: %w", err)
+	}
+
+	// Determine backend
+	if backendName == "" {
+		backendName = cfg.Model.Default
+	}
+	backendDef, ok := cfg.Model.Backends[backendName]
+	if !ok {
+		backendName = cfg.Model.Default
+		backendDef, ok = cfg.Model.Backends[backendName]
+		if !ok {
+			return fmt.Errorf("backend %q (default) not found in config", backendName)
+		}
+	}
+	backendCfg := BackendConfig{
+		Cmd:        backendDef.Cmd,
+		ExtraArgs:  backendDef.ExtraArgs,
+		PromptMode: backendDef.PromptMode,
+	}
+
+	// Prepare log file
+	logDir := state.LogDir(cfg.StateDir)
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	logFile := filepath.Join(logDir, slotName+".log")
+
+	// Build the worker command
+	workerCmd, stdinFile, err := BuildWorkerCmd(backendName, backendCfg, promptFile, sess.Worktree)
+	if err != nil {
+		return fmt.Errorf("build worker cmd: %w", err)
+	}
+
+	// Write runner script
+	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
+	var runnerContent string
+	if stdinFile != "" {
+		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s < %q 2>&1 | tee -a %q\n",
+			shellJoin(workerCmd.Args), stdinFile, logFile)
+	} else {
+		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s 2>&1 | tee -a %q\n",
+			shellJoin(workerCmd.Args), logFile)
+	}
+	if err := os.WriteFile(runnerPath, []byte(runnerContent), 0755); err != nil {
+		return fmt.Errorf("write runner script: %w", err)
+	}
+
+	// Run before_run hook (fatal on failure)
+	hookEnv := HookEnv{
+		IssueID:       fmt.Sprintf("%s#%d", repo, issue.Number),
+		IssueNumber:   issue.Number,
+		WorkspacePath: sess.Worktree,
+	}
+	if err := RunHook(cfg, "before_run", cfg.Hooks.BeforeRun, hookEnv); err != nil {
+		return fmt.Errorf("before_run hook: %w", err)
+	}
+
+	// Start tmux session in existing worktree
+	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", sess.Worktree, "bash", runnerPath)
+	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
+	}
+
+	// Get PID
+	pidOut, err := exec.Command("tmux", "list-panes", "-t", tmuxName, "-F", "#{pane_pid}").Output()
+	if err != nil {
+		return fmt.Errorf("tmux list-panes: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidOut)))
+	if err != nil {
+		return fmt.Errorf("parse pane pid: %w", err)
+	}
+
+	log.Printf("[worker] respawned in-place %s in tmux session %s (pane_pid=%d, log=%s)", slotName, tmuxName, pid, logFile)
+
+	// Update session — keep worktree and branch, reset runtime fields
+	sess.PID = pid
+	sess.TmuxSession = tmuxName
+	sess.LogFile = logFile
+	sess.StartedAt = time.Now().UTC()
+	sess.FinishedAt = nil
+	sess.Status = state.StatusRunning
+	sess.Backend = backendName
+	sess.TokensUsedAttempt = 0
+	sess.NotifiedCIFail = false
+	sess.LastNotifiedStatus = ""
+	sess.LastOutputHash = ""
+	sess.LastOutputChangedAt = time.Time{}
+
+	return nil
+}
+
+// assemblePromptWithCheckpoint builds a prompt that includes checkpoint context
+// from a previous worker session that hit the soft token threshold.
+func assemblePromptWithCheckpoint(base string, issue github.Issue, worktreePath, branchName string, cfg *config.Config, checkpoint string) string {
+	prompt := assemblePrompt(base, issue, worktreePath, branchName, cfg)
+	if checkpoint == "" {
+		return prompt
+	}
+
+	return prompt + fmt.Sprintf(`
+
+---
+
+## Previous Session Checkpoint
+
+This task was previously worked on by another agent session that ran out of token budget.
+The worktree already contains code changes from the previous session. Review the checkpoint
+below, examine the existing code changes, and continue where the previous session left off.
+Do NOT redo work that is already done — focus on what remains.
+
+%s
+`, checkpoint)
+}
+
+// readTailLines reads the last n lines from a file.
+func readTailLines(path string, n int) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n"), nil
+}

--- a/internal/worker/checkpoint_test.go
+++ b/internal/worker/checkpoint_test.go
@@ -1,0 +1,144 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestSaveCheckpoint_WritesFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	sess := &state.Session{
+		IssueNumber:       42,
+		Worktree:          tmpDir,
+		TokensUsedAttempt: 85000,
+		TokensUsedTotal:   120000,
+		LogFile:           "",
+	}
+
+	cpPath, err := SaveCheckpoint(sess)
+	if err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	if cpPath != filepath.Join(tmpDir, "CHECKPOINT.md") {
+		t.Fatalf("checkpoint path = %q, want %q", cpPath, filepath.Join(tmpDir, "CHECKPOINT.md"))
+	}
+
+	data, err := os.ReadFile(cpPath)
+	if err != nil {
+		t.Fatalf("read checkpoint: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "# Checkpoint") {
+		t.Error("checkpoint missing header")
+	}
+	if !strings.Contains(content, "Tokens used (attempt): 85000") {
+		t.Errorf("checkpoint missing attempt token count, got:\n%s", content)
+	}
+	if !strings.Contains(content, "Tokens used (total): 120000") {
+		t.Errorf("checkpoint missing total token count, got:\n%s", content)
+	}
+}
+
+func TestSaveCheckpoint_NoWorktree(t *testing.T) {
+	sess := &state.Session{
+		IssueNumber: 42,
+	}
+
+	_, err := SaveCheckpoint(sess)
+	if err == nil {
+		t.Fatal("expected error for session with no worktree")
+	}
+}
+
+func TestSaveCheckpoint_WithLogFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	logFile := filepath.Join(tmpDir, "test.log")
+	logContent := "line1\nline2\nline3\nlast line of output\n"
+	if err := os.WriteFile(logFile, []byte(logContent), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	sess := &state.Session{
+		IssueNumber:       10,
+		Worktree:          tmpDir,
+		TokensUsedAttempt: 50000,
+		LogFile:           logFile,
+	}
+
+	cpPath, err := SaveCheckpoint(sess)
+	if err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	data, err := os.ReadFile(cpPath)
+	if err != nil {
+		t.Fatalf("read checkpoint: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "Last worker output") {
+		t.Error("checkpoint missing worker output section")
+	}
+	if !strings.Contains(content, "last line of output") {
+		t.Errorf("checkpoint missing log tail, got:\n%s", content)
+	}
+}
+
+func TestAssemblePromptWithCheckpoint_NoCheckpoint(t *testing.T) {
+	iss := github.Issue{Number: 1, Title: "test", Body: "body"}
+	cfg := &config.Config{Repo: "owner/repo"}
+
+	result := assemblePromptWithCheckpoint("base prompt", iss, "/tmp/wt", "feat/branch", cfg, "")
+	if strings.Contains(result, "Previous Session Checkpoint") {
+		t.Error("should not contain checkpoint section when checkpoint is empty")
+	}
+}
+
+func TestAssemblePromptWithCheckpoint_WithCheckpoint(t *testing.T) {
+	iss := github.Issue{Number: 1, Title: "test", Body: "body"}
+	cfg := &config.Config{Repo: "owner/repo"}
+
+	checkpoint := "# Checkpoint\nTokens used: 80000\n## Commits made\nabc123 feat: stuff"
+	result := assemblePromptWithCheckpoint("base prompt", iss, "/tmp/wt", "feat/branch", cfg, checkpoint)
+	if !strings.Contains(result, "Previous Session Checkpoint") {
+		t.Error("should contain checkpoint section header")
+	}
+	if !strings.Contains(result, "abc123 feat: stuff") {
+		t.Error("should contain checkpoint content")
+	}
+	if !strings.Contains(result, "continue where the previous session left off") {
+		t.Error("should contain continuation instructions")
+	}
+}
+
+func TestReadTailLines(t *testing.T) {
+	tmpDir := t.TempDir()
+	f := filepath.Join(tmpDir, "test.txt")
+
+	content := "line1\nline2\nline3\nline4\nline5\n"
+	if err := os.WriteFile(f, []byte(content), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	result, err := readTailLines(f, 3)
+	if err != nil {
+		t.Fatalf("readTailLines: %v", err)
+	}
+
+	lines := strings.Split(result, "\n")
+	// "line1\nline2\nline3\nline4\nline5\n" splits into ["line1","line2","line3","line4","line5",""]
+	// last 3: ["line4", "line5", ""]
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3: %v", len(lines), lines)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -334,6 +334,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	// CIFailureOutput is normally cleared by respawnDueRetries before this call,
 	// but cleared here defensively in case Respawn is called from other paths.
 	sess.CIFailureOutput = ""
+	sess.CheckpointFile = ""
 
 	return nil
 }


### PR DESCRIPTION
Implements #218

## Changes

Replace the hard `worker_max_tokens` kill with a smarter token budget system that checkpoints and respawns workers before they hit the hard limit:

- **Config**: Add `worker_soft_token_threshold` (default: 0.8) — fraction of `worker_max_tokens` at which checkpoint+respawn triggers
- **State**: Add `CheckpointFile` field to Session for tracking checkpoint state
- **Worker**: New `SaveCheckpoint()` captures progress (commits, diffs, log tail) into `CHECKPOINT.md`; new `RespawnInPlace()` restarts worker in the same worktree with checkpoint context in the prompt
- **Orchestrator**: Soft threshold check in `checkSessions()` — when `TokensUsedAttempt >= softLimit`, save checkpoint and respawn; hard limit remains as safety net

### Flow
```
tokens < soft_threshold  → normal operation
soft_threshold reached   → save CHECKPOINT.md, respawn with carry-forward context
hard_threshold reached   → kill (safety net, same as today)
```

### Config
```yaml
worker_max_tokens: 100000        # hard limit (existing)
worker_soft_token_threshold: 0.8 # fraction of max_tokens for soft warning (new, default 0.8)
```

## Testing

- Config tests: default (0.8), explicit override, zero-to-disable
- Orchestrator tests: checkpoint+respawn triggered, already-checkpointed skipped, disabled threshold, below threshold
- Worker tests: checkpoint file creation, log tail inclusion, prompt assembly with/without checkpoint, readTailLines
- All existing tests pass (`go test ./...`)
- Build verified (`go build ./cmd/maestro/ && ./maestro version`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the hard token-limit kill with a smarter checkpoint-and-respawn system: when a worker reaches a configurable fraction of its token budget (`worker_soft_token_threshold`, default 0.8), the orchestrator saves a `CHECKPOINT.md` snapshot of the worktree's progress into the worktree root, then restarts the worker in-place with the checkpoint context embedded in its prompt. The hard limit is preserved as a safety net. The implementation is well-structured, thoroughly tested, and integrates cleanly with existing orchestrator patterns.

- **`CHECKPOINT.md` written to worktree root** may be inadvertently committed to the feature branch by the respawned worker — the file contains internal metadata (token counts, log tail) that should not appear in PRs; consider placing it under `cfg.StateDir` or adding a `.gitignore` entry.
- **`after_run` hook may execute twice** when `RespawnInPlace` kills the old process but then fails to start a new tmux session — the orchestrator's dead-worker path will call `runAfterRunHook` again on the next tick, potentially causing duplicate side effects.
- The `CheckpointFile` field is correctly cleared in `Respawn()` so full respawns start clean; the `*float64` config pattern correctly distinguishes "unset → default 0.8" from "explicitly 0 → disabled".

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the CHECKPOINT.md worktree-commit risk; the after_run hook double-execution is a minor edge case.
- The core logic is sound and well-tested. Two concrete issues remain: the checkpoint file being placed in the worktree where the AI worker can commit it to the PR (a real, likely-to-occur problem), and a double-execution of the after_run hook in a specific failure path. Neither breaks the primary happy path, but the first one affects PR cleanliness in production use and should be addressed before merge.
- internal/worker/checkpoint.go — checkpoint file placement and after_run hook ordering

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/checkpoint.go | New file implementing SaveCheckpoint and RespawnInPlace; solid overall but CHECKPOINT.md is written to the worktree root with no mechanism to prevent the new worker from committing it to the PR branch. |
| internal/orchestrator/orchestrator.go | Soft-threshold check integrated cleanly into checkSessions; error-fallthrough paths are appropriately handled, though a partial RespawnInPlace failure (process killed, new session fails to start) leaves the session with Status=Running but a dead PID, causing after_run hook to fire twice on the next tick. |
| internal/config/config.go | WorkerSoftTokenThreshold added correctly using a *float64 to distinguish zero (disabled) from unset (default 0.8); the ShouldCleanupWorktrees doc comment is now misplaced above SoftTokenThreshold() but this is cosmetic only. |
| internal/state/state.go | Minimal addition of CheckpointFile field with omitempty; backward-compatible with existing state serialisation. |
| internal/worker/worker.go | Respawn() now defensively clears CheckpointFile so a future full-respawn starts clean; one-liner change, correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/worker/checkpoint.go
Line: 66-67

Comment:
**CHECKPOINT.md will be visible to git and may be committed to the PR**

`CHECKPOINT.md` is written directly into the worktree root (`sess.Worktree`). When the respawned worker runs, it operates in that same directory. Because there is no `.gitignore` entry for the file and no instruction in the assembled prompt telling the worker to leave it uncommitted, the worker is likely to include it in a `git add -A` or similar sweep and push it to the feature branch.

The file contains internal metadata (token counts, raw log tail, diff stats) that has no place in a PR. A couple of ways to address this:

1. Add `CHECKPOINT.md` to the repo's `.gitignore` (or write the file outside the worktree, e.g. under `cfg.StateDir`).
2. Append an explicit instruction to the prompt:

```go
return prompt + fmt.Sprintf(`
...
Do NOT redo work that is already done — focus on what remains.
The file CHECKPOINT.md in the repository root is an internal artifact; do NOT commit or push it.

%s
`, checkpoint)
```

Option 1 is safer because it does not rely on AI instruction-following.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/worker/checkpoint.go
Line: 81-88

Comment:
**`after_run` hook may execute twice when RespawnInPlace fails mid-way**

`RespawnInPlace` runs the `after_run` hook (lines 92–101) early in its execution, before the tmux work. If any step after that point fails (e.g. `tmux new-session` on line 176 returns an error), the function returns an error to the orchestrator.

Back in `checkSessions`, the failure falls through without a `continue`. On the very next orchestrator tick, `pidAlive(sess.PID)` returns `false` (the old PID was killed here at lines 84–88 but a new one was never started), triggering the dead-worker path in the orchestrator which calls `o.runAfterRunHook(sess)` a second time.

Depending on what `after_run` does (e.g. webhook calls, external cleanup scripts), double-execution can cause unintended side effects. Consider skipping the hook call in `RespawnInPlace` and relying solely on the orchestrator's dead-worker path, or track whether the hook was already run on the session.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: soft token threshold with checkpoi..."](https://github.com/befeast/maestro/commit/f322137671dad120f404badb86cc1813daa150ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25979333)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->