### PR TITLE
fix: sync project board status to Done when issue is closed externally (#247)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -850,6 +850,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					log.Printf("[orch] check issue #%d: %v", sess.IssueNumber, err)
 				} else if closed {
 					log.Printf("[orch] issue #%d closed, transitioning zombie session %s from %s to done", sess.IssueNumber, slotName, sess.Status)
+					o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
 					sess.Status = state.StatusDone
 					if sess.FinishedAt == nil {
 						now := time.Now().UTC()
@@ -884,6 +885,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				log.Printf("[orch] check issue #%d: %v", sess.IssueNumber, err)
 			} else if closed {
 				log.Printf("[orch] issue #%d closed, transitioning %s from %s to done", sess.IssueNumber, slotName, sess.Status)
+				o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
 				o.stopWorker(slotName, sess)
 				sess.Status = state.StatusDone
 				now := time.Now().UTC()
@@ -899,6 +901,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				log.Printf("[orch] check issue #%d: %v", sess.IssueNumber, err)
 			} else if closed {
 				log.Printf("[orch] issue #%d closed, stopping worker %s", sess.IssueNumber, slotName)
+				o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
 				o.stopWorker(slotName, sess)
 				sess.Status = state.StatusDone
 				now := time.Now().UTC()


### PR DESCRIPTION
Implements #247

## Changes
When an issue is closed externally (via PR merge with GitHub auto-close `Closes #N`, or manually), maestro now syncs the GitHub Project board status to **Done**. Previously, the board was only updated to Done when maestro itself merged a PR via `mergeReadyPR()`.

Added `o.syncProject(sess.IssueNumber, github.ProjectStatusDone)` at the three places in `checkSessions()` where external issue closure is already detected:

1. **Zombie sessions** (dead/failed/conflict_failed) — when their underlying issue is found closed
2. **PR open/queued sessions** — when the linked issue is closed externally
3. **Running sessions** — when the issue is closed while a worker is still active

The `syncProject` helper is a no-op when the GitHub Projects feature is disabled, so this change has zero impact on deployments without project board integration.

## Testing
- All existing tests pass (`go test ./...`)
- `go vet ./...` clean
- Binary builds and runs successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ensures the GitHub Project board status is synced to **Done** whenever an issue is closed externally, covering three cases in `checkSessions()` that previously lacked this call: zombie sessions (dead/failed/conflict_failed), PR-open/queued sessions, and running sessions. The fix mirrors the existing `syncProject` call already present in `mergeReadyPR()` and uses the same graceful, fire-and-forget helper that is a no-op when GitHub Projects integration is disabled.

- Three `o.syncProject(sess.IssueNumber, github.ProjectStatusDone)` lines added, one per affected branch in `checkSessions()`.
- The placement (before `stopWorker` / before `sess.Status = state.StatusDone`) is consistent with the existing pattern at line 1427.
- `SyncIssueToProject` is already designed to log-and-swallow errors, so the new calls carry no additional failure modes.
- No new tests were added, but the change is fully covered by the "no-op when disabled" guarantee and the existing test suite.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the change is minimal, consistent, and has no new failure modes.
- Three identical one-liner additions that exactly replicate an already-proven pattern. The helper is a no-op when the feature is disabled, `SyncIssueToProject` handles its own errors gracefully, and all existing tests pass.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds three `o.syncProject(sess.IssueNumber, github.ProjectStatusDone)` calls in `checkSessions()` to mirror the existing call in `mergeReadyPR()`. Placement, ordering, and behavior are all consistent with the established pattern. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: sync project board status to Done w..."](https://github.com/befeast/maestro/commit/01e19592db73e6bae7ab1fecf61ff3edae5ce219) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25985614)</sub>

<!-- /greptile_comment -->