### PR TITLE
feat: sync project board on every cycle — reconcile closed issues to Done (#249)

### DIFF
--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -51,6 +51,105 @@ var knownProjects = map[int]projectConfig{
 	},
 }
 
+// ProjectItem represents an item on a GitHub Project board with its linked issue info.
+type ProjectItem struct {
+	IssueNumber int
+	IssueClosed bool
+}
+
+// ListNonDoneProjectItems fetches all project items not in Done status
+// and returns their linked issue numbers along with whether they are closed.
+// This allows the orchestrator to reconcile stale board statuses.
+func (c *Client) ListNonDoneProjectItems(projectNumber int) ([]ProjectItem, error) {
+	cfg, ok := knownProjects[projectNumber]
+	if !ok {
+		return nil, fmt.Errorf("unknown project number %d", projectNumber)
+	}
+
+	doneOptionID := cfg.StatusOptions[ProjectStatusDone]
+
+	query := fmt.Sprintf(`{
+  node(id: %q) {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              optionId
+            }
+          }
+          content {
+            ... on Issue {
+              number
+              state
+            }
+          }
+        }
+      }
+    }
+  }
+}`, cfg.ProjectID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("graphql project items: %w\nstderr: %s", err, exitErr.Stderr)
+		}
+		return nil, fmt.Errorf("graphql project items: %w", err)
+	}
+
+	var resp struct {
+		Data struct {
+			Node struct {
+				Items struct {
+					Nodes []struct {
+						FieldValueByName *struct {
+							OptionID string `json:"optionId"`
+						} `json:"fieldValueByName"`
+						Content *struct {
+							Number int    `json:"number"`
+							State  string `json:"state"`
+						} `json:"content"`
+					} `json:"nodes"`
+				} `json:"items"`
+			} `json:"node"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("parse project items response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		msgs := make([]string, len(resp.Errors))
+		for i, e := range resp.Errors {
+			msgs[i] = e.Message
+		}
+		return nil, fmt.Errorf("graphql errors: %s", strings.Join(msgs, "; "))
+	}
+
+	var items []ProjectItem
+	for _, node := range resp.Data.Node.Items.Nodes {
+		// Skip items with no linked issue (drafts, PRs, etc.)
+		if node.Content == nil || node.Content.Number == 0 {
+			continue
+		}
+		// Skip items already in Done status
+		if node.FieldValueByName != nil && node.FieldValueByName.OptionID == doneOptionID {
+			continue
+		}
+		items = append(items, ProjectItem{
+			IssueNumber: node.Content.Number,
+			IssueClosed: node.Content.State == "CLOSED",
+		})
+	}
+
+	return items, nil
+}
+
 // SyncIssueToProject adds an issue to the GitHub Project and sets its status.
 // It is graceful: errors are logged but not returned, so callers are never blocked.
 func (c *Client) SyncIssueToProject(issueNumber int, projectNumber int, status ProjectStatus) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -298,6 +298,27 @@ func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus)
 	o.gh.SyncIssueToProject(issueNumber, o.cfg.GitHubProjects.ProjectNumber, status)
 }
 
+// reconcileProjectBoard moves closed issues to Done on the project board.
+// This catches issues closed externally (manual merge, GitHub auto-close, manual close).
+func (o *Orchestrator) reconcileProjectBoard() {
+	if !o.cfg.GitHubProjects.Enabled || o.cfg.GitHubProjects.ProjectNumber == 0 {
+		return
+	}
+
+	items, err := o.gh.ListNonDoneProjectItems(o.cfg.GitHubProjects.ProjectNumber)
+	if err != nil {
+		log.Printf("[orch] reconcile project board: %v", err)
+		return
+	}
+
+	for _, item := range items {
+		if item.IssueClosed {
+			log.Printf("[orch] reconcile: issue #%d is closed, moving to Done", item.IssueNumber)
+			o.syncProject(item.IssueNumber, github.ProjectStatusDone)
+		}
+	}
+}
+
 func readLastLines(path string, limit int) (string, error) {
 	if limit <= 0 {
 		return "", nil
@@ -584,6 +605,9 @@ func (o *Orchestrator) RunOnce() error {
 			return fmt.Errorf("save state after workers: %w", err)
 		}
 	}
+
+	// Step 6: Reconcile project board — move externally-closed issues to Done
+	o.reconcileProjectBoard()
 
 	// Flush digest buffer (no-op if digest mode is off or buffer is empty)
 	if err := o.notifier.Flush(); err != nil {


### PR DESCRIPTION
Implements #249

## Changes
- Added `ListNonDoneProjectItems()` to the GitHub client — uses a single GraphQL query to fetch all project board items not in Done status, returning each item's linked issue number and closed state
- Added `reconcileProjectBoard()` method to the orchestrator — runs at the end of each cycle (Step 6), iterates non-Done items, and moves any with closed issues to Done via `syncProject()`
- Uses `exec.CommandContext` with `ghTimeout` consistent with the rest of the codebase

This is a lightweight reconciliation loop that catches issues closed externally (manual merge, GitHub auto-close via "Closes #N", or manual close) that would otherwise show stale status on the board.

## Testing
- All existing tests pass (`go test ./...`)
- `go vet ./...` clean
- Binary builds successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a lightweight project board reconciliation loop that runs at the end of every orchestrator cycle, moving any project items whose linked issues are externally closed (manual merge, GitHub auto-close, etc.) to the Done column. The implementation follows existing codebase patterns cleanly — guard conditions, timeout usage, error handling, and placement in `RunOnce` are all consistent.

**Key changes:**
- `ListNonDoneProjectItems()` in `github_projects.go` — single GraphQL query fetching board items and their linked issue state, filtering out already-Done items client-side
- `reconcileProjectBoard()` in `orchestrator.go` — iterates the returned items and calls the existing `syncProject()` helper for any closed issues
- Placed as Step 6 at the end of `RunOnce()`, after state saves and worker starts

**Issues found:**
- The GraphQL query uses `items(first: 100)` with no cursor-based pagination. Boards with more than 100 items will have reconciliation silently truncated — closed issues beyond the first page will never be moved to Done.

<h3>Confidence Score: 4/5</h3>

- Safe to merge for most project sizes; one concrete fix needed before the board outgrows 100 items.
- The orchestrator integration is clean and non-breaking. The only concrete issue is the missing pagination in the GraphQL query, which causes silent incomplete reconciliation on large boards. Since the project board is unlikely to hit 100 non-Done items in normal use today, this is a forward-looking reliability concern rather than an immediate production break — warranting a 4 rather than lower.
- `internal/github/github_projects.go` — add pagination to `ListNonDoneProjectItems` before the board exceeds 100 items.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github_projects.go | Adds `ListNonDoneProjectItems` using a single GraphQL query; hard-coded `items(first: 100)` with no pagination means reconciliation silently misses items on boards with >100 entries. |
| internal/orchestrator/orchestrator.go | Adds `reconcileProjectBoard()` called at end of each cycle; guard conditions, error handling, and placement are all consistent with the existing codebase patterns. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/github/github_projects.go
Line: 74

Comment:
**No pagination — silently drops items beyond 100**

`items(first: 100)` fetches at most 100 project items with no cursor-based pagination. If the board has more than 100 non-Done items (or 100 total items where many are Done), any issues beyond that page are never examined and will never be reconciled to Done, with no error or warning surfaced to the caller.

The GraphQL response includes `pageInfo { hasNextPage endCursor }` which can be used to loop until `hasNextPage` is false. Without it, reconciliation silently becomes incomplete once the board grows past 100 items.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: reconcile project board on every c..."](https://github.com/befeast/maestro/commit/d97b3775e92f84279cc0a0db10097859d3536ae0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26111621)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->