### PR TITLE
feat: ship default blocker_patterns that handle markdown formatting (#251)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -376,6 +376,15 @@ func parse(data []byte) (*Config, error) {
 		cfg.Missions.Labels = []string{"mission", "epic"}
 	}
 
+	// Default blocker patterns: nil means "not set" → use defaults.
+	// An explicit empty slice (blocker_patterns: []) means "disabled".
+	if cfg.BlockerPatterns == nil {
+		cfg.BlockerPatterns = []string{
+			`blocked by.*?#(\d+)`,
+			`depends on.*?#(\d+)`,
+		}
+	}
+
 	return cfg, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -730,8 +730,28 @@ func TestParse_BlockerPatternsDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
+	want := []string{
+		`blocked by.*?#(\d+)`,
+		`depends on.*?#(\d+)`,
+	}
+	if len(cfg.BlockerPatterns) != len(want) {
+		t.Fatalf("BlockerPatterns length = %d, want %d", len(cfg.BlockerPatterns), len(want))
+	}
+	for i, w := range want {
+		if cfg.BlockerPatterns[i] != w {
+			t.Errorf("BlockerPatterns[%d] = %q, want %q", i, cfg.BlockerPatterns[i], w)
+		}
+	}
+}
+
+func TestParse_BlockerPatternsExplicitEmpty(t *testing.T) {
+	yaml := "repo: owner/repo\nblocker_patterns: []\n"
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
 	if len(cfg.BlockerPatterns) != 0 {
-		t.Errorf("BlockerPatterns = %v, want empty (disabled by default)", cfg.BlockerPatterns)
+		t.Errorf("BlockerPatterns = %v, want empty (explicit opt-out)", cfg.BlockerPatterns)
 	}
 }
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -188,6 +188,36 @@ Nothing else.`
 	}
 }
 
+func TestFindBlockers_DefaultPatternsMarkdown(t *testing.T) {
+	// Default patterns from config should handle markdown formatting
+	defaultPatterns := []string{
+		`blocked by.*?#(\d+)`,
+		`depends on.*?#(\d+)`,
+	}
+	tests := []struct {
+		name string
+		body string
+		want []int
+	}{
+		{"plain", "blocked by #123", []int{123}},
+		{"with colon", "Blocked by: #123", []int{123}},
+		{"markdown bold colon", "**Blocked by:** #123", []int{123}},
+		{"depends on markdown", "**Depends on:** #456", []int{456}},
+		{"multiple refs", "Blocked by #123, #456", []int{123}},
+		{"multiple lines", "**Blocked by:** #673 (palette port must merge first)\n**Depends on:** #100", []int{100, 673}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindBlockers(tt.body, defaultPatterns)
+			sort.Ints(got)
+			sort.Ints(tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindBlockers(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHasLabel_CaseInsensitive(t *testing.T) {
 	issue := Issue{
 		Labels: []struct {


### PR DESCRIPTION
Implements #251

## Changes

When `blocker_patterns` is not set in config, maestro now ships sensible defaults:
- `blocked by.*?#(\d+)` — matches plain, colon, and markdown bold variants
- `depends on.*?#(\d+)` — same for dependency references

The `.*?` non-greedy match handles all common formats:
- `blocked by #123` (plain)
- `Blocked by: #123` (with colon)
- `**Blocked by:** #123` (markdown bold + colon)

Users can explicitly opt out by setting `blocker_patterns: []` in their config. This works because YAML `[]` unmarshals to a non-nil empty slice, while an absent key stays `nil` — so the code distinguishes "not set" (apply defaults) from "explicitly empty" (disabled).

### Files modified
- `internal/config/config.go` — populate default patterns when `BlockerPatterns` is nil
- `internal/config/config_test.go` — updated default test to expect new defaults; added explicit empty opt-out test
- `internal/github/github_test.go` — added test verifying default patterns match markdown-formatted bodies

## Testing

- `go test ./...` — all 14 packages pass
- `go vet ./...` — clean
- `go build ./cmd/maestro/` — builds successfully
- New tests cover: default patterns applied, explicit empty opt-out, and markdown body matching (plain, colon, bold, multiple refs)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships two sensible default `blocker_patterns` (`blocked by.*?#(\d+)` and `depends on.*?#(\d+)`) so maestro works out-of-the-box for common GitHub issue-body formats — including plain, colon-suffixed, and markdown-bold variants — without requiring any user configuration. Users who want to disable the feature entirely can set `blocker_patterns: []` in their config, which unmarshals to a non-nil empty slice and is correctly distinguished from the absent-key nil case.

- **`internal/config/config.go`**: nil-guard in `parse()` populates the two default regexes; correctly follows the nil-vs-empty-slice contract already established by YAML unmarshaling.
- **`internal/config/config_test.go`**: Existing default test updated to assert the new patterns; new `TestParse_BlockerPatternsExplicitEmpty` verifies the opt-out path.
- **`internal/github/github_test.go`**: New table-driven test covers all documented markdown formats as well as the intentional single-capture behavior when multiple issue numbers appear comma-separated on the same line (`"Blocked by #123, #456"` → `[123]` only).

<h3>Confidence Score: 5/5</h3>

- Safe to merge — minimal, well-tested change with no behavioral regressions.
- The implementation is a single nil-guard in `parse()`, the nil-vs-empty-slice distinction is already enforced by the YAML library, all three files have thorough test coverage for every documented code path, and `go test ./...` / `go vet ./...` pass cleanly. No existing behaviour is changed for users who already have `blocker_patterns` set.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds default blocker patterns when `BlockerPatterns` is nil; correctly leverages nil vs. empty-slice semantics to distinguish "not configured" from "explicitly disabled". |
| internal/config/config_test.go | Updates the default patterns test to verify the two new regexes and adds a new explicit-empty opt-out test; both cases are correctly asserted. |
| internal/github/github_test.go | Adds `TestFindBlockers_DefaultPatternsMarkdown` covering plain, colon, bold-colon, multi-line, and known single-capture behavior for comma-separated refs on the same line. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: ship default blocker\_patterns that..."](https://github.com/befeast/maestro/commit/7060776a85e1dd6842d387e7fc74d1e12bef58f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26117619)</sub>

<!-- /greptile_comment -->