### PR TITLE
feat: include Greptile review comments in respawn prompt after CI failure (#253)

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -763,6 +763,46 @@ func (c *Client) CIFailureSummary(prNumber int) (string, error) {
 	return s, nil
 }
 
+// CollectPRReviewFeedback collects all Greptile review feedback from a PR,
+// including both inline review comments and issue-level summary comments.
+// Returns a formatted string ready to inject into a worker prompt, or empty
+// string if no Greptile feedback exists.
+func (c *Client) CollectPRReviewFeedback(prNumber int) (string, error) {
+	var sections []string
+
+	// 1. Fetch issue-level comments (Greptile summary with confidence score)
+	issueCommentsOut, err := exec.Command("gh", "api",
+		fmt.Sprintf("repos/%s/issues/%d/comments", c.Repo, prNumber),
+		"--paginate").Output()
+	if err == nil {
+		var comments []struct {
+			Body string `json:"body"`
+			User struct {
+				Login string `json:"login"`
+			} `json:"user"`
+		}
+		if json.Unmarshal(issueCommentsOut, &comments) == nil {
+			for _, cm := range comments {
+				if isGreptileLogin(cm.User.Login) && strings.TrimSpace(cm.Body) != "" {
+					sections = append(sections, cm.Body)
+				}
+			}
+		}
+	}
+
+	// 2. Fetch inline review comments
+	inlineComments, err := c.CollectReviewFeedback(prNumber)
+	if err == nil && len(inlineComments) > 0 {
+		sections = append(sections, FormatReviewFeedback(inlineComments))
+	}
+
+	if len(sections) == 0 {
+		return "", nil
+	}
+
+	return strings.Join(sections, "\n\n"), nil
+}
+
 // HasLabel returns true if any of the issue's labels match
 func HasLabel(issue Issue, labels []string) bool {
 	for _, l := range issue.Labels {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -215,6 +216,55 @@ func TestFindBlockers_DefaultPatternsMarkdown(t *testing.T) {
 				t.Errorf("FindBlockers(%q) = %v, want %v", tt.body, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFormatReviewFeedback_NonEmpty(t *testing.T) {
+	comments := []ReviewComment{
+		{Path: "bridge.rs", Line: 42, Body: "P2: enabled flag logic inverted", User: "greptile-apps[bot]"},
+		{Path: "pool.go", Line: 10, Body: "P2: null-dereference on pool.interface", User: "greptile-apps[bot]"},
+	}
+	result := FormatReviewFeedback(comments)
+
+	if !strings.Contains(result, "Review Feedback") {
+		t.Error("should contain header")
+	}
+	if !strings.Contains(result, "bridge.rs") {
+		t.Error("should contain file path")
+	}
+	if !strings.Contains(result, "Line: 42") {
+		t.Error("should contain line number")
+	}
+	if !strings.Contains(result, "enabled flag logic inverted") {
+		t.Error("should contain comment body")
+	}
+	if !strings.Contains(result, "null-dereference") {
+		t.Error("should contain second comment body")
+	}
+}
+
+func TestFormatReviewFeedback_Empty(t *testing.T) {
+	result := FormatReviewFeedback(nil)
+	if result != "" {
+		t.Errorf("FormatReviewFeedback(nil) = %q, want empty", result)
+	}
+}
+
+func TestIsGreptileLogin(t *testing.T) {
+	tests := []struct {
+		login string
+		want  bool
+	}{
+		{"greptile-apps[bot]", true},
+		{"greptile", true},
+		{"Greptile", true},
+		{"chatgpt-codex-connector[bot]", false},
+		{"user123", false},
+	}
+	for _, tt := range tests {
+		if got := isGreptileLogin(tt.login); got != tt.want {
+			t.Errorf("isGreptileLogin(%q) = %v, want %v", tt.login, got, tt.want)
+		}
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -69,14 +69,15 @@ type Orchestrator struct {
 	configReloadCh <-chan *config.Config
 
 	// Testing hooks for autoMergePRs / mergeReadyPR
-	ghPRCIStatusFn         func(prNumber int) (string, error)
-	ghPRGreptileApprovedFn func(prNumber int) (approved bool, pending bool, err error)
-	ghMergePRFn            func(prNumber int) error
-	ghClosePRFn            func(prNumber int, comment string) error
-	ghPRChecksOutputFn     func(prNumber int) (string, error)
-	ghCloseIssueFn         func(number int, comment string) error
-	workerStopFn           func(cfg *config.Config, slotName string, sess *state.Session) error
-	rebaseWorktreeFn       func(worktreePath, branch string, autoResolveFiles []string) error
+	ghPRCIStatusFn              func(prNumber int) (string, error)
+	ghPRGreptileApprovedFn      func(prNumber int) (approved bool, pending bool, err error)
+	ghMergePRFn                 func(prNumber int) error
+	ghClosePRFn                 func(prNumber int, comment string) error
+	ghPRChecksOutputFn          func(prNumber int) (string, error)
+	ghCollectPRReviewFeedbackFn func(prNumber int) (string, error)
+	ghCloseIssueFn              func(number int, comment string) error
+	workerStopFn                func(cfg *config.Config, slotName string, sess *state.Session) error
+	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles []string) error
 }
 
 // New creates a new Orchestrator
@@ -165,6 +166,13 @@ func (o *Orchestrator) prChecksOutput(prNumber int) (string, error) {
 		return o.ghPRChecksOutputFn(prNumber)
 	}
 	return o.gh.PRChecksOutput(prNumber)
+}
+
+func (o *Orchestrator) collectPRReviewFeedback(prNumber int) (string, error) {
+	if o.ghCollectPRReviewFeedbackFn != nil {
+		return o.ghCollectPRReviewFeedbackFn(prNumber)
+	}
+	return o.gh.CollectPRReviewFeedback(prNumber)
 }
 
 func (o *Orchestrator) closeIssue(number int, comment string) error {
@@ -462,6 +470,22 @@ Focus on fixing the CI failures while still implementing the issue requirements.
 `, promptBase, attempt, ciOutput)
 }
 
+// appendReviewFeedbackContext appends a section to the worker prompt with
+// Greptile code review findings from the previous failed attempt.
+func appendReviewFeedbackContext(promptBase, feedback string) string {
+	return fmt.Sprintf(`%s
+
+### Code Review Findings (from Greptile)
+
+The following code review comments were left on the previous PR. Address ALL of these issues:
+
+%s
+
+IMPORTANT: Address ALL code review findings above before creating a new PR.
+Do NOT repeat the same mistakes.
+`, promptBase, feedback)
+}
+
 // canRetryIssue returns true if the session can be retried, considering
 // both the session's retry count and the global max_retries_per_issue config.
 // When max_retries_per_issue is 0 (unlimited), retries are always allowed.
@@ -507,11 +531,15 @@ func (o *Orchestrator) respawnDueRetries(s *state.State) {
 
 		promptBase := o.selectPrompt(issue)
 
-		// If this is a CI failure retry, include CI output in the prompt so the
-		// new worker knows what went wrong in the previous attempt.
+		// If this is a CI failure retry, include CI output and review feedback
+		// in the prompt so the new worker knows what went wrong.
 		if sess.CIFailureOutput != "" {
 			promptBase = appendCIFailureContext(promptBase, sess.CIFailureOutput, sess.RetryCount)
 			sess.CIFailureOutput = "" // consumed — don't persist stale output
+		}
+		if sess.PreviousAttemptFeedback != "" {
+			promptBase = appendReviewFeedbackContext(promptBase, sess.PreviousAttemptFeedback)
+			sess.PreviousAttemptFeedback = "" // consumed — don't persist stale feedback
 		}
 
 		if err := o.respawnWorker(slotName, sess, issue, promptBase, sess.Backend); err != nil {
@@ -1400,6 +1428,12 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 		ciOutput = "(CI output unavailable)"
 	}
 
+	// Collect Greptile review feedback before closing the PR
+	reviewFeedback, err := o.collectPRReviewFeedback(pr.Number)
+	if err != nil {
+		log.Printf("[orch] warn: could not collect review feedback for PR #%d: %v", pr.Number, err)
+	}
+
 	// Close the failed PR with an explanation
 	closeComment := fmt.Sprintf("CI failed — maestro is closing this PR and respawning a new worker to retry (attempt %d).\n\nCI output:\n```\n%s\n```",
 		sess.RetryCount+1, ciOutput)
@@ -1413,8 +1447,9 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 	o.stopWorker(slotName, sess)
 	sess.Worktree = ""
 
-	// Store CI failure output for the next worker
+	// Store CI failure output and review feedback for the next worker
 	sess.CIFailureOutput = ciOutput
+	sess.PreviousAttemptFeedback = reviewFeedback
 
 	// Schedule retry with exponential backoff
 	sess.RetryCount++

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1037,6 +1037,9 @@ func TestAutoMergePRs_CIFailureBlocksMerge(t *testing.T) {
 		ghPRChecksOutputFn: func(prNumber int) (string, error) {
 			return "Build failed: exit code 1", nil
 		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "", nil
+		},
 		ghCloseIssueFn: func(number int, comment string) error {
 			return nil
 		},
@@ -4107,6 +4110,9 @@ func newCIFailureRetryOrchestrator(cfg *config.Config, prs []github.PR, ciStatus
 		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
 			return nil
 		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "", nil
+		},
 	}, &merged, &closedPRs
 }
 
@@ -4243,6 +4249,9 @@ func TestAutoMergePRs_CIFailure_ClosePRFails_NoRetry(t *testing.T) {
 		ghPRChecksOutputFn: func(prNumber int) (string, error) {
 			return "some CI output", nil
 		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "", nil
+		},
 		ghCloseIssueFn: func(number int, comment string) error {
 			return nil
 		},
@@ -4291,6 +4300,9 @@ func TestAutoMergePRs_CIFailure_AlreadyNotified_NoDoubleRetry(t *testing.T) {
 		},
 		ghPRChecksOutputFn: func(prNumber int) (string, error) {
 			return "CI output", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "", nil
 		},
 		ghCloseIssueFn: func(number int, comment string) error {
 			return nil
@@ -4735,5 +4747,195 @@ func TestCheckSessions_BelowSoftThreshold_NoCheckpoint(t *testing.T) {
 	}
 	if sess.TokensUsedAttempt != 50000 {
 		t.Fatalf("tokens_used_attempt = %d, want 50000", sess.TokensUsedAttempt)
+	}
+}
+
+func TestAppendReviewFeedbackContext_AddsSection(t *testing.T) {
+	base := "You are a coding agent."
+	feedback := "Confidence Score: 3/5\nP2: enabled flag logic inverted in bridge.rs"
+	result := appendReviewFeedbackContext(base, feedback)
+
+	if !strings.Contains(result, "You are a coding agent.") {
+		t.Error("result should contain original prompt base")
+	}
+	if !strings.Contains(result, "Code Review Findings (from Greptile)") {
+		t.Error("result should contain review feedback header")
+	}
+	if !strings.Contains(result, "enabled flag logic inverted") {
+		t.Error("result should contain actual review feedback")
+	}
+	if !strings.Contains(result, "IMPORTANT: Address ALL code review findings") {
+		t.Error("result should contain instruction to address findings")
+	}
+}
+
+func TestAppendReviewFeedbackContext_EmptyFeedbackNotCalled(t *testing.T) {
+	// This tests that empty feedback doesn't produce output (caller should guard)
+	base := "You are a coding agent."
+	result := appendReviewFeedbackContext(base, "")
+
+	// Even with empty string, the section header would be added —
+	// the caller (respawnDueRetries) guards against empty string
+	if !strings.Contains(result, "Code Review Findings") {
+		t.Error("function always adds header — caller must guard against empty feedback")
+	}
+}
+
+func TestRespawnDueRetries_ReviewFeedback_IncludedInPrompt(t *testing.T) {
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRetriesPerIssue: 3,
+		MaxRetryBackoffMs:  300000,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	respawnedPrompt := ""
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "base prompt {{ISSUE_NUMBER}}",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: 42, Title: "test issue", Body: "fix this"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedPrompt = promptBase
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:             42,
+		IssueTitle:              "test issue",
+		Status:                  state.StatusDead,
+		RetryCount:              1,
+		NextRetryAt:             &retryAt,
+		Backend:                 "claude",
+		CIFailureOutput:         "tests failed: FAIL main_test.go:15",
+		PreviousAttemptFeedback: "Confidence 3/5\nP2: enabled flag inverted in bridge.rs",
+	}
+
+	o.respawnDueRetries(s)
+
+	if respawnedPrompt == "" {
+		t.Fatal("respawnWorkerFn should have been called")
+	}
+	if !strings.Contains(respawnedPrompt, "Previous CI Failure") {
+		t.Error("prompt should contain CI failure context")
+	}
+	if !strings.Contains(respawnedPrompt, "Code Review Findings (from Greptile)") {
+		t.Error("prompt should contain review feedback section")
+	}
+	if !strings.Contains(respawnedPrompt, "enabled flag inverted") {
+		t.Error("prompt should contain actual Greptile feedback")
+	}
+	if !strings.Contains(respawnedPrompt, "IMPORTANT: Address ALL code review findings") {
+		t.Error("prompt should contain instruction to fix review findings")
+	}
+
+	// Both fields should be consumed (cleared)
+	sess := s.Sessions["slot-1"]
+	if sess.CIFailureOutput != "" {
+		t.Errorf("CIFailureOutput should be cleared, got %q", sess.CIFailureOutput)
+	}
+	if sess.PreviousAttemptFeedback != "" {
+		t.Errorf("PreviousAttemptFeedback should be cleared, got %q", sess.PreviousAttemptFeedback)
+	}
+}
+
+func TestRespawnDueRetries_NoReviewFeedback_OmitsSection(t *testing.T) {
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRetriesPerIssue: 3,
+		MaxRetryBackoffMs:  300000,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	respawnedPrompt := ""
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "base prompt {{ISSUE_NUMBER}}",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: 42, Title: "test issue", Body: "fix this"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedPrompt = promptBase
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:             42,
+		IssueTitle:              "test issue",
+		Status:                  state.StatusDead,
+		RetryCount:              1,
+		NextRetryAt:             &retryAt,
+		Backend:                 "claude",
+		CIFailureOutput:         "tests failed",
+		PreviousAttemptFeedback: "", // no Greptile feedback
+	}
+
+	o.respawnDueRetries(s)
+
+	if respawnedPrompt == "" {
+		t.Fatal("respawnWorkerFn should have been called")
+	}
+	if strings.Contains(respawnedPrompt, "Code Review Findings") {
+		t.Error("prompt should NOT contain review feedback section when no feedback exists")
+	}
+}
+
+func TestAutoMergePRs_CIFailure_CollectsReviewFeedback(t *testing.T) {
+	prs := []github.PR{
+		{Number: 10, HeadRefName: "feat/a"},
+	}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000}
+	o, _, _ := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{10: "failure"})
+
+	// Override with Greptile feedback
+	o.ghCollectPRReviewFeedbackFn = func(prNumber int) (string, error) {
+		return "Confidence 3/5 — Not safe to merge\nP2: null dereference on pool.interface", nil
+	}
+
+	s := makeTestState(prs)
+	o.autoMergePRs(s)
+
+	sess := s.Sessions["slot-0"]
+	if sess.PreviousAttemptFeedback == "" {
+		t.Fatal("PreviousAttemptFeedback should be set after CI failure with Greptile feedback")
+	}
+	if !strings.Contains(sess.PreviousAttemptFeedback, "null dereference") {
+		t.Errorf("PreviousAttemptFeedback should contain Greptile feedback, got %q", sess.PreviousAttemptFeedback)
+	}
+}
+
+func TestAutoMergePRs_CIFailure_NoGreptileFeedback_FeedbackEmpty(t *testing.T) {
+	prs := []github.PR{
+		{Number: 10, HeadRefName: "feat/a"},
+	}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000}
+	o, _, _ := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{10: "failure"})
+
+	// No Greptile feedback (returns empty)
+	o.ghCollectPRReviewFeedbackFn = func(prNumber int) (string, error) {
+		return "", nil
+	}
+
+	s := makeTestState(prs)
+	o.autoMergePRs(s)
+
+	sess := s.Sessions["slot-0"]
+	if sess.PreviousAttemptFeedback != "" {
+		t.Errorf("PreviousAttemptFeedback should be empty when no Greptile feedback, got %q", sess.PreviousAttemptFeedback)
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -33,35 +33,36 @@ const (
 )
 
 type Session struct {
-	IssueNumber         int           `json:"issue_number"`
-	IssueTitle          string        `json:"issue_title"`
-	Worktree            string        `json:"worktree"`
-	Branch              string        `json:"branch"`
-	PID                 int           `json:"pid"`
-	TmuxSession         string        `json:"tmux_session,omitempty"`
-	LogFile             string        `json:"log_file"`
-	StartedAt           time.Time     `json:"started_at"`
-	FinishedAt          *time.Time    `json:"finished_at,omitempty"`
-	Status              SessionStatus `json:"status"`
-	PRNumber            int           `json:"pr_number,omitempty"`
-	Backend             string        `json:"backend,omitempty"` // "claude", "codex", etc.
-	LongRunning         bool          `json:"long_running,omitempty"`
-	RebaseAttempted     bool          `json:"rebase_attempted,omitempty"`
-	NotifiedCIFail      bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
-	LastNotifiedStatus  string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
-	RetryCount          int           `json:"retry_count,omitempty"`          // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
-	NextRetryAt         *time.Time    `json:"next_retry_at,omitempty"`
-	LastOutputHash      string        `json:"last_output_hash,omitempty"`
-	LastOutputChangedAt time.Time     `json:"last_output_changed_at,omitempty"`
-	TokensUsedAttempt   int           `json:"tokens_used_attempt,omitempty"` // tokens consumed in current attempt (reset on respawn)
-	TokensUsedTotal     int           `json:"tokens_used_total,omitempty"`   // cumulative tokens across the issue lifecycle
-	RateLimitHit        bool          `json:"rate_limit_hit,omitempty"`      // true if worker was rate-limited (tmux detection, running worker)
-	TriedBackends       []string      `json:"tried_backends,omitempty"`      // backends already attempted (for rate-limit fallback)
-	Phase               Phase         `json:"phase,omitempty"`               // current pipeline phase (empty = legacy single-phase)
-	ValidationFails     int           `json:"validation_fails,omitempty"`    // number of failed validation attempts
-	ValidationFeedback  string        `json:"validation_feedback,omitempty"` // feedback from last failed validation
-	CIFailureOutput     string        `json:"ci_failure_output,omitempty"`   // CI failure output captured before retry (passed to next worker as context)
-	CheckpointFile      string        `json:"checkpoint_file,omitempty"`     // path to CHECKPOINT.md saved at soft token threshold
+	IssueNumber             int           `json:"issue_number"`
+	IssueTitle              string        `json:"issue_title"`
+	Worktree                string        `json:"worktree"`
+	Branch                  string        `json:"branch"`
+	PID                     int           `json:"pid"`
+	TmuxSession             string        `json:"tmux_session,omitempty"`
+	LogFile                 string        `json:"log_file"`
+	StartedAt               time.Time     `json:"started_at"`
+	FinishedAt              *time.Time    `json:"finished_at,omitempty"`
+	Status                  SessionStatus `json:"status"`
+	PRNumber                int           `json:"pr_number,omitempty"`
+	Backend                 string        `json:"backend,omitempty"` // "claude", "codex", etc.
+	LongRunning             bool          `json:"long_running,omitempty"`
+	RebaseAttempted         bool          `json:"rebase_attempted,omitempty"`
+	NotifiedCIFail          bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
+	LastNotifiedStatus      string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
+	RetryCount              int           `json:"retry_count,omitempty"`          // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
+	NextRetryAt             *time.Time    `json:"next_retry_at,omitempty"`
+	LastOutputHash          string        `json:"last_output_hash,omitempty"`
+	LastOutputChangedAt     time.Time     `json:"last_output_changed_at,omitempty"`
+	TokensUsedAttempt       int           `json:"tokens_used_attempt,omitempty"`       // tokens consumed in current attempt (reset on respawn)
+	TokensUsedTotal         int           `json:"tokens_used_total,omitempty"`         // cumulative tokens across the issue lifecycle
+	RateLimitHit            bool          `json:"rate_limit_hit,omitempty"`            // true if worker was rate-limited (tmux detection, running worker)
+	TriedBackends           []string      `json:"tried_backends,omitempty"`            // backends already attempted (for rate-limit fallback)
+	Phase                   Phase         `json:"phase,omitempty"`                     // current pipeline phase (empty = legacy single-phase)
+	ValidationFails         int           `json:"validation_fails,omitempty"`          // number of failed validation attempts
+	ValidationFeedback      string        `json:"validation_feedback,omitempty"`       // feedback from last failed validation
+	CIFailureOutput         string        `json:"ci_failure_output,omitempty"`         // CI failure output captured before retry (passed to next worker as context)
+	PreviousAttemptFeedback string        `json:"previous_attempt_feedback,omitempty"` // Greptile review feedback from previous failed PR attempt
+	CheckpointFile          string        `json:"checkpoint_file,omitempty"`           // path to CHECKPOINT.md saved at soft token threshold
 }
 
 // UnmarshalJSON implements custom unmarshalling to preserve the legacy

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -438,6 +438,76 @@ func TestRebaseAttempted_BackwardCompatibility(t *testing.T) {
 	}
 }
 
+func TestPreviousAttemptFeedback_Persistence(t *testing.T) {
+	dir := t.TempDir()
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber:             42,
+		Branch:                  "feat/test",
+		Status:                  StatusDead,
+		StartedAt:               time.Now().UTC(),
+		PreviousAttemptFeedback: "Confidence 3/5\nP2: null dereference",
+	}
+	s.Sessions["slot-2"] = &Session{
+		IssueNumber: 43,
+		Branch:      "feat/other",
+		Status:      StatusRunning,
+		StartedAt:   time.Now().UTC(),
+	}
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	sess1 := loaded.Sessions["slot-1"]
+	if sess1 == nil {
+		t.Fatal("slot-1 not found after load")
+	}
+	if sess1.PreviousAttemptFeedback != "Confidence 3/5\nP2: null dereference" {
+		t.Errorf("PreviousAttemptFeedback = %q, want Greptile feedback", sess1.PreviousAttemptFeedback)
+	}
+
+	sess2 := loaded.Sessions["slot-2"]
+	if sess2 == nil {
+		t.Fatal("slot-2 not found after load")
+	}
+	if sess2.PreviousAttemptFeedback != "" {
+		t.Errorf("PreviousAttemptFeedback should be empty, got %q", sess2.PreviousAttemptFeedback)
+	}
+}
+
+func TestPreviousAttemptFeedback_OmittedWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber: 42,
+		Branch:      "feat/test",
+		Status:      StatusRunning,
+		StartedAt:   time.Now().UTC(),
+	}
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	json := string(data)
+	if containsString(json, "previous_attempt_feedback") {
+		t.Error("previous_attempt_feedback should be omitted from JSON when empty")
+	}
+}
+
 func TestIssueInProgress_QueuedCountsAsInProgress(t *testing.T) {
 	s := NewState()
 	s.Sessions["slot-1"] = &Session{IssueNumber: 100, Status: StatusQueued}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -331,9 +331,11 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	sess.LastOutputHash = ""
 	sess.LastOutputChangedAt = time.Time{}
 	sess.TokensUsedAttempt = 0
-	// CIFailureOutput is normally cleared by respawnDueRetries before this call,
-	// but cleared here defensively in case Respawn is called from other paths.
+	// CIFailureOutput and PreviousAttemptFeedback are normally cleared by
+	// respawnDueRetries before this call, but cleared here defensively in
+	// case Respawn is called from other paths.
 	sess.CIFailureOutput = ""
+	sess.PreviousAttemptFeedback = ""
 	sess.CheckpointFile = ""
 
 	return nil


### PR DESCRIPTION
Implements #253

## Changes

When maestro closes a PR due to CI failure and respawns a worker for retry, the new worker now receives Greptile's code review comments in addition to CI failure output. Previously, retry workers had zero context about what bugs Greptile identified (inverted logic, null-dereferences, etc.) and would likely reproduce the same mistakes.

### What changed

- **`internal/state/state.go`**: Added `PreviousAttemptFeedback` field to `Session` struct for persisting Greptile review feedback across maestro restarts
- **`internal/github/github.go`**: Added `CollectPRReviewFeedback()` method that fetches both issue-level summary comments (confidence score) and inline review comments from Greptile
- **`internal/orchestrator/orchestrator.go`**:
  - `handleCIFailureRetry()` now collects Greptile feedback before closing the failed PR and stores it in `sess.PreviousAttemptFeedback`
  - `respawnDueRetries()` injects the feedback into the worker prompt via `appendReviewFeedbackContext()`
  - Added testable hook `ghCollectPRReviewFeedbackFn` following existing patterns
- **`internal/worker/worker.go`**: Defensive clear of `PreviousAttemptFeedback` in `Respawn()`

### Behavior

- On CI failure retry: prompt includes both "Previous CI Failure" section (existing) and "Code Review Findings (from Greptile)" section (new)
- If no Greptile comments exist, the review findings section is omitted (no empty blocks)
- Feedback is consumed after injection (cleared from state to prevent stale data)

## Testing

- `go fmt ./...` — passes
- `go vet ./...` — passes  
- `go test ./...` — all 14 packages pass
- `go build ./cmd/maestro/` — binary builds successfully

New tests added:
- `TestAppendReviewFeedbackContext_AddsSection` — verifies prompt formatting
- `TestRespawnDueRetries_ReviewFeedback_IncludedInPrompt` — end-to-end: feedback + CI output both appear in respawned prompt, both consumed after use
- `TestRespawnDueRetries_NoReviewFeedback_OmitsSection` — empty feedback → no review section
- `TestAutoMergePRs_CIFailure_CollectsReviewFeedback` — handleCIFailureRetry stores feedback
- `TestAutoMergePRs_CIFailure_NoGreptileFeedback_FeedbackEmpty` — no Greptile → empty field
- `TestPreviousAttemptFeedback_Persistence` — JSON round-trip
- `TestPreviousAttemptFeedback_OmittedWhenEmpty` — omitempty works
- `TestFormatReviewFeedback_NonEmpty` / `_Empty` — formatting unit tests
- `TestIsGreptileLogin` — login detection

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enriches the CI-failure retry prompt by injecting Greptile's inline and summary review comments from the failed PR into the respawned worker's context, so retry workers don't blindly reproduce the same bugs. The implementation follows established patterns (`CIFailureOutput` handling) and is well-tested across all new code paths.

- `Session.PreviousAttemptFeedback` persists feedback across maestro restarts with correct `omitempty` JSON serialization
- `CollectPRReviewFeedback` fetches both issue-level (confidence summary) and inline review comments, correctly gathering them before the PR is closed
- `appendReviewFeedbackContext` appends a clearly-labelled section to the respawn prompt, guarded by a non-empty check so no empty blocks appear
- Feedback is consumed (cleared) after injection, preventing stale data on subsequent retries
- `Respawn()` defensively clears the field as a belt-and-suspenders safeguard
- **One logic concern in `CollectPRReviewFeedback`**: both internal API call errors are silently swallowed; the function always returns `nil` for its error, making the caller's warning log in `handleCIFailureRetry` dead code and making transient API failures indistinguishable from "no feedback"

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the error-propagation issue in `CollectPRReviewFeedback`; all other changes are clean and well-tested.
- The overall design is sound, test coverage is thorough (10 new tests), and the change is a non-critical enhancement to the retry prompt. The one concrete issue — errors being silently swallowed in `CollectPRReviewFeedback` — means the caller's warning log will never fire and transient failures are invisible, but the failure mode is benign (retry worker simply proceeds without the review context). Fixing the error propagation is a one-targeted-change away from merge-ready.
- internal/github/github.go — `CollectPRReviewFeedback` error handling

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Added `CollectPRReviewFeedback` which fetches Greptile issue-level and inline comments. Logic issue: errors from both API calls are silently swallowed; the function always returns `nil` for its error, making the caller's error check dead code. |
| internal/orchestrator/orchestrator.go | Added `ghCollectPRReviewFeedbackFn` test hook and wiring into `handleCIFailureRetry`/`respawnDueRetries`. Feedback is collected before PR closure, stored in session state, injected into the respawn prompt, and cleared after use — all following established patterns. |
| internal/state/state.go | Added `PreviousAttemptFeedback string` field with `omitempty` JSON tag, consistent with existing similar fields like `CIFailureOutput`. No issues. |
| internal/worker/worker.go | Defensive clear of `PreviousAttemptFeedback` in `Respawn()`, matching the existing pattern for `CIFailureOutput`. No issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/github/github.go
Line: 770-803

Comment:
**Errors are silently swallowed — `(string, error)` return is always `nil`**

`CollectPRReviewFeedback` declares an `(string, error)` return type, and the caller in `handleCIFailureRetry` explicitly checks `if err != nil` to log a warning. However, this check will never trigger: both the `exec.Command` error and the `CollectReviewFeedback` error are only used as local guards (`if err == nil { ... }`) and are never propagated — the function always returns `nil` as its error regardless of what fails.

If the GitHub API is unavailable, rate-limited, or returns malformed JSON, `CollectPRReviewFeedback` silently returns `("", nil)`. This is indistinguishable from "no Greptile comments exist", so the worker will silently miss feedback without any log warning — defeating the purpose of the error-return contract and the warning log in the caller.

At minimum, the function should return the error from `CollectReviewFeedback` when it fails (step 2), since that's the same pattern used by `greptileReviewComments`:

```go
// 2. Fetch inline review comments
inlineComments, err := c.CollectReviewFeedback(prNumber)
if err != nil {
    return "", err
}
if len(inlineComments) > 0 {
    sections = append(sections, FormatReviewFeedback(inlineComments))
}
```

Or, if the intent is to be best-effort (i.e. partial results are acceptable), change the signature to `(string, error)` and return the last non-nil error encountered, or simply change the return to `(string, bool)` to make the best-effort intent explicit.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: include Greptile review comments i..."](https://github.com/befeast/maestro/commit/ac8d133a4d8bd3546d8ffe10b9d969bfc27cd959) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26140317)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->