### PR TITLE
Improve review-gated auto retry orchestration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,15 +147,18 @@ type Config struct {
 	StateDir                   string               `yaml:"state_dir"`           // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig          `yaml:"model"`
 	Routing                    RoutingConfig        `yaml:"routing"`
-	DeployCmd                  string               `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
-	DeployTimeoutMinutes       int                  `yaml:"deploy_timeout_minutes"` // timeout for deploy command in minutes (default: 15)
-	MergeStrategy              string               `yaml:"merge_strategy"`         // "sequential" | "parallel"
-	MergeIntervalSeconds       int                  `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
+	DeployCmd                  string               `yaml:"deploy_cmd"`                 // shell command to run after successful PR merge
+	DeployTimeoutMinutes       int                  `yaml:"deploy_timeout_minutes"`     // timeout for deploy command in minutes (default: 15)
+	MergeStrategy              string               `yaml:"merge_strategy"`             // "sequential" | "parallel"
+	MergeIntervalSeconds       int                  `yaml:"merge_interval_seconds"`     // minimum seconds between merges in sequential mode
+	ReviewGate                 string               `yaml:"review_gate"`                // "greptile" (default) | "none"
+	AutoRetryReviewFeedback    bool                 `yaml:"auto_retry_review_feedback"` // close PRs with review comments and respawn a fixer
 	Telegram                   TelegramConfig       `yaml:"telegram"`
 	Versioning                 VersioningConfig     `yaml:"versioning"`
 	GitHubProjects             GitHubProjectsConfig `yaml:"github_projects"`
 	MaxRetryBackoffMs          int                  `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
 	AutoResolveFiles           []string             `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
+	AutoRestoreFiles           []string             `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase
 	CleanupWorktreesOnMerge    *bool                `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
 	Pipeline                   PipelineConfig       `yaml:"pipeline"`
 	Hooks                      HooksConfig          `yaml:"hooks"`
@@ -223,6 +226,7 @@ func parse(data []byte) (*Config, error) {
 		ClaudeCmd:            "claude",
 		MergeStrategy:        "sequential",
 		MergeIntervalSeconds: 30,
+		ReviewGate:           "greptile",
 		AutoResolveFiles: []string{
 			"server/src/api/mod.rs",
 			"web/src/lib/api.ts",
@@ -356,6 +360,16 @@ func parse(data []byte) (*Config, error) {
 	}
 	if cfg.MergeIntervalSeconds <= 0 {
 		cfg.MergeIntervalSeconds = 30
+	}
+
+	// Review gate defaults
+	switch strings.ToLower(strings.TrimSpace(cfg.ReviewGate)) {
+	case "", "greptile":
+		cfg.ReviewGate = "greptile"
+	case "none", "off", "disabled":
+		cfg.ReviewGate = "none"
+	default:
+		cfg.ReviewGate = "greptile"
 	}
 
 	// Default hooks timeout

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -70,6 +70,28 @@ issue_labels: []
 	}
 }
 
+func TestParse_AutoRestoreFiles(t *testing.T) {
+	yaml := `
+repo: owner/repo
+auto_restore_files:
+  - ok-gobot
+  - build/output.bin
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"ok-gobot", "build/output.bin"}
+	if len(cfg.AutoRestoreFiles) != len(want) {
+		t.Fatalf("AutoRestoreFiles = %v, want %v", cfg.AutoRestoreFiles, want)
+	}
+	for i, file := range cfg.AutoRestoreFiles {
+		if file != want[i] {
+			t.Errorf("AutoRestoreFiles[%d] = %q, want %q", i, file, want[i])
+		}
+	}
+}
+
 func TestParse_IssueLabelsLegacyMerged(t *testing.T) {
 	yaml := `
 repo: owner/repo
@@ -734,6 +756,38 @@ merge_interval_seconds: 45
 	}
 	if cfg.MergeIntervalSeconds != 45 {
 		t.Errorf("MergeIntervalSeconds = %d, want 45", cfg.MergeIntervalSeconds)
+	}
+}
+
+func TestParse_ReviewGateDefaults(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.ReviewGate != "greptile" {
+		t.Errorf("ReviewGate = %q, want %q", cfg.ReviewGate, "greptile")
+	}
+	if cfg.AutoRetryReviewFeedback {
+		t.Error("AutoRetryReviewFeedback should default to false")
+	}
+}
+
+func TestParse_ReviewGateExplicitNone(t *testing.T) {
+	yaml := `
+repo: owner/repo
+review_gate: none
+auto_retry_review_feedback: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.ReviewGate != "none" {
+		t.Errorf("ReviewGate = %q, want %q", cfg.ReviewGate, "none")
+	}
+	if !cfg.AutoRetryReviewFeedback {
+		t.Error("AutoRetryReviewFeedback should be true when configured")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -77,7 +77,7 @@ type Orchestrator struct {
 	ghCollectPRReviewFeedbackFn func(prNumber int) (string, error)
 	ghCloseIssueFn              func(number int, comment string) error
 	workerStopFn                func(cfg *config.Config, slotName string, sess *state.Session) error
-	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles []string) error
+	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
 }
 
 // New creates a new Orchestrator
@@ -223,9 +223,9 @@ func (o *Orchestrator) respawnInPlace(slotName string, sess *state.Session, issu
 
 func (o *Orchestrator) rebaseWorktree(worktreePath, branch string) error {
 	if o.rebaseWorktreeFn != nil {
-		return o.rebaseWorktreeFn(worktreePath, branch, o.cfg.AutoResolveFiles)
+		return o.rebaseWorktreeFn(worktreePath, branch, o.cfg.AutoResolveFiles, o.cfg.AutoRestoreFiles)
 	}
-	return worker.RebaseWorktree(worktreePath, branch, o.cfg.AutoResolveFiles)
+	return worker.RebaseWorktree(worktreePath, branch, o.cfg.AutoResolveFiles, o.cfg.AutoRestoreFiles)
 }
 
 func (o *Orchestrator) captureTmux(session string) (string, error) {
@@ -471,11 +471,11 @@ Focus on fixing the CI failures while still implementing the issue requirements.
 }
 
 // appendReviewFeedbackContext appends a section to the worker prompt with
-// Greptile code review findings from the previous failed attempt.
+// code review findings from the previous failed attempt.
 func appendReviewFeedbackContext(promptBase, feedback string) string {
 	return fmt.Sprintf(`%s
 
-### Code Review Findings (from Greptile)
+### Code Review Findings
 
 The following code review comments were left on the previous PR. Address ALL of these issues:
 
@@ -483,6 +483,26 @@ The following code review comments were left on the previous PR. Address ALL of 
 
 IMPORTANT: Address ALL code review findings above before creating a new PR.
 Do NOT repeat the same mistakes.
+`, promptBase, feedback)
+}
+
+// appendRebaseConflictContext appends a section to the worker prompt with
+// auto-rebase failure details so the retry worker can update the same PR branch.
+func appendRebaseConflictContext(promptBase, feedback string) string {
+	return fmt.Sprintf(`%s
+
+### Rebase Conflict
+
+Maestro tried to update the existing PR branch against origin/main, but git rebase hit conflicts.
+You are a retry worker running in the same worktree and branch.
+
+Resolve the conflicts, keep the PR focused on the original issue, run validation, commit the fix, and push to the existing PR branch.
+Do NOT open a second PR.
+
+Rebase failure details:
+`+"```"+`
+%s
+`+"```"+`
 `, promptBase, feedback)
 }
 
@@ -498,10 +518,40 @@ func (o *Orchestrator) canRetryIssue(s *state.State, sess *state.Session) bool {
 	return totalAttempts < maxRetries
 }
 
+func pendingRetryReservations(s *state.State) int {
+	count := 0
+	for _, sess := range s.Sessions {
+		if sess.Status == state.StatusDead && sess.NextRetryAt != nil {
+			count++
+		}
+	}
+	return count
+}
+
 // respawnDueRetries checks dead sessions with a scheduled retry time and
 // respawns them when the backoff period has elapsed.
-func (o *Orchestrator) respawnDueRetries(s *state.State) {
-	for slotName, sess := range s.Sessions {
+func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
+	if slots <= 0 {
+		if pending := pendingRetryReservations(s); pending > 0 {
+			log.Printf("[orch] retry queue has %d pending session(s), but no worker slots are available", pending)
+		}
+		return
+	}
+
+	slotNames := make([]string, 0, len(s.Sessions))
+	for slotName := range s.Sessions {
+		slotNames = append(slotNames, slotName)
+	}
+	sort.Strings(slotNames)
+
+	respawned := 0
+	for _, slotName := range slotNames {
+		if respawned >= slots {
+			log.Printf("[orch] retry queue still has pending session(s), but retry slots are exhausted")
+			return
+		}
+
+		sess := s.Sessions[slotName]
 		if sess.Status != state.StatusDead {
 			continue
 		}
@@ -538,22 +588,34 @@ func (o *Orchestrator) respawnDueRetries(s *state.State) {
 			sess.CIFailureOutput = "" // consumed — don't persist stale output
 		}
 		if sess.PreviousAttemptFeedback != "" {
-			promptBase = appendReviewFeedbackContext(promptBase, sess.PreviousAttemptFeedback)
+			if sess.PreviousAttemptFeedbackKind == "rebase_conflict" {
+				promptBase = appendRebaseConflictContext(promptBase, sess.PreviousAttemptFeedback)
+			} else {
+				promptBase = appendReviewFeedbackContext(promptBase, sess.PreviousAttemptFeedback)
+			}
 			sess.PreviousAttemptFeedback = "" // consumed — don't persist stale feedback
+			sess.PreviousAttemptFeedbackKind = ""
 		}
 
-		if err := o.respawnWorker(slotName, sess, issue, promptBase, sess.Backend); err != nil {
-			log.Printf("[orch] respawn worker %s: %v — marking as failed", slotName, err)
+		var respawnErr error
+		if sess.PRNumber != 0 && sess.Worktree != "" {
+			respawnErr = o.respawnInPlace(slotName, sess, issue, promptBase, sess.Backend)
+		} else {
+			respawnErr = o.respawnWorker(slotName, sess, issue, promptBase, sess.Backend)
+		}
+		if respawnErr != nil {
+			log.Printf("[orch] respawn worker %s: %v — marking as failed", slotName, respawnErr)
 			sess.Status = state.StatusFailed
 			now := time.Now().UTC()
 			sess.FinishedAt = &now
 			o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) respawn failed: %v",
-				slotName, sess.IssueNumber, sess.IssueTitle, err)
+				slotName, sess.IssueNumber, sess.IssueTitle, respawnErr)
 			continue
 		}
 
 		o.notifier.Sendf("🔄 maestro: retrying worker %s for issue #%d: %s (attempt %d)",
 			slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount)
+		respawned++
 	}
 }
 
@@ -635,7 +697,8 @@ func (o *Orchestrator) RunOnce() error {
 	o.checkSessions(s)
 
 	// Step 2b: Respawn dead sessions whose backoff has elapsed
-	o.respawnDueRetries(s)
+	retrySlots := availableSlots(o.cfg, s, len(s.ActiveSessions()))
+	o.respawnDueRetries(s, retrySlots)
 
 	// Step 3: Auto-merge green PRs
 	o.autoMergePRs(s)
@@ -661,6 +724,13 @@ func (o *Orchestrator) RunOnce() error {
 	// Step 5: Start new workers for available slots
 	active := len(s.ActiveSessions())
 	slots := availableSlots(o.cfg, s, active)
+	if reserved := pendingRetryReservations(s); reserved > 0 && slots > 0 {
+		if reserved > slots {
+			reserved = slots
+		}
+		slots -= reserved
+		log.Printf("[orch] reserving %d worker slot(s) for scheduled retries", reserved)
+	}
 	log.Printf("[orch] active=%d max=%d available_slots=%d", active, o.cfg.MaxParallel, slots)
 
 	if slots > 0 {
@@ -770,6 +840,14 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 	if newCfg.MergeIntervalSeconds != old.MergeIntervalSeconds {
 		changed = append(changed, fmt.Sprintf("merge_interval_seconds: %d→%d", old.MergeIntervalSeconds, newCfg.MergeIntervalSeconds))
 		o.cfg.MergeIntervalSeconds = newCfg.MergeIntervalSeconds
+	}
+	if newCfg.ReviewGate != old.ReviewGate {
+		changed = append(changed, fmt.Sprintf("review_gate: %s→%s", old.ReviewGate, newCfg.ReviewGate))
+		o.cfg.ReviewGate = newCfg.ReviewGate
+	}
+	if newCfg.AutoRetryReviewFeedback != old.AutoRetryReviewFeedback {
+		changed = append(changed, fmt.Sprintf("auto_retry_review_feedback: %v→%v", old.AutoRetryReviewFeedback, newCfg.AutoRetryReviewFeedback))
+		o.cfg.AutoRetryReviewFeedback = newCfg.AutoRetryReviewFeedback
 	}
 	if newCfg.DeployCmd != old.DeployCmd {
 		changed = append(changed, fmt.Sprintf("deploy_cmd: %q→%q", old.DeployCmd, newCfg.DeployCmd))
@@ -1076,12 +1154,18 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 			// Check if running session has opened a PR (worker still alive)
 			if pr, found := branchToPR[sess.Branch]; found {
-				log.Printf("[orch] worker %s opened PR #%d while still running — transitioning to pr_open", slotName, pr.Number)
-				sess.Status = state.StatusPROpen
-				sess.PRNumber = pr.Number
-				o.notifier.Sendf("🔀 maestro: worker %s opened PR #%d for issue #%d (%s)",
-					slotName, pr.Number, sess.IssueNumber, sess.IssueTitle)
-				continue
+				if sess.PRNumber == pr.Number {
+					// In-place review/CI retries intentionally keep working on an
+					// already-open PR. Do not transition back to pr_open until the
+					// worker exits, otherwise the fixer is interrupted mid-run.
+				} else {
+					log.Printf("[orch] worker %s opened PR #%d while still running — transitioning to pr_open", slotName, pr.Number)
+					sess.Status = state.StatusPROpen
+					sess.PRNumber = pr.Number
+					o.notifier.Sendf("🔀 maestro: worker %s opened PR #%d for issue #%d (%s)",
+						slotName, pr.Number, sess.IssueNumber, sess.IssueTitle)
+					continue
+				}
 			}
 
 			// Capture tmux pane output for token tracking, rate-limit detection,
@@ -1334,6 +1418,22 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			sess.LastNotifiedStatus = ""
 			sess.NotifiedCIFail = false // backward compat
 
+			if o.cfg.AutoRetryReviewFeedback {
+				reviewFeedback, err := o.collectPRReviewFeedback(pr.Number)
+				if err != nil {
+					log.Printf("[orch] warn: could not collect review feedback for PR #%d: %v", pr.Number, err)
+				} else if strings.TrimSpace(reviewFeedback) != "" {
+					log.Printf("[orch] PR #%d has review feedback; scheduling retry", pr.Number)
+					o.handleReviewFeedbackRetry(s, slotName, sess, pr, reviewFeedback)
+					continue
+				}
+			}
+
+			if o.reviewGate() == "none" {
+				ready = append(ready, mergeCandidate{slotName: slotName, sess: sess, pr: pr})
+				continue
+			}
+
 			greptileOK, greptilePending, err := o.prGreptileApproved(pr.Number)
 			if err != nil {
 				log.Printf("[orch] greptile check PR #%d: %v", pr.Number, err)
@@ -1404,6 +1504,60 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	}
 }
 
+// handleReviewFeedbackRetry schedules a retry worker with review feedback in
+// its prompt. When the PR worktree is still available, keep the PR open and
+// respawn in place so the fixer pushes updates to the same PR.
+func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string, sess *state.Session, pr github.PR, reviewFeedback string) {
+	maxRetries := o.cfg.MaxRetriesPerIssue
+	totalAttempts := s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount
+
+	if maxRetries > 0 && totalAttempts >= maxRetries {
+		log.Printf("[orch] review feedback on PR #%d — retry limit reached (%d/%d) for issue #%d",
+			pr.Number, totalAttempts, maxRetries, sess.IssueNumber)
+		s.MarkIssueRetryExhausted(sess.IssueNumber)
+		o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+		sess.Status = state.StatusRetryExhausted
+		sess.NextRetryAt = nil
+		sess.LastNotifiedStatus = "review_retry_exhausted"
+		now := time.Now().UTC()
+		sess.FinishedAt = &now
+		o.notifier.Sendf("💀 maestro: review feedback on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
+			pr.Number, sess.IssueNumber, sess.IssueTitle, totalAttempts)
+		return
+	}
+
+	if sess.Worktree == "" {
+		closeComment := fmt.Sprintf("Code review feedback detected, but the PR worktree is unavailable — maestro is closing this PR and respawning a worker to address it (attempt %d).\n\nReview feedback:\n\n%s",
+			sess.RetryCount+1, reviewFeedback)
+		if err := o.closePR(pr.Number, closeComment); err != nil {
+			log.Printf("[orch] warn: could not close PR #%d after review feedback: %v — skipping retry", pr.Number, err)
+			return
+		}
+		log.Printf("[orch] closed PR #%d due to review feedback (worktree unavailable)", pr.Number)
+		sess.PRNumber = 0
+	} else {
+		log.Printf("[orch] keeping PR #%d open and respawning %s in place to address review feedback", pr.Number, slotName)
+		sess.PRNumber = pr.Number
+	}
+
+	sess.CIFailureOutput = ""
+	sess.PreviousAttemptFeedback = reviewFeedback
+	sess.PreviousAttemptFeedbackKind = "review_feedback"
+
+	sess.RetryCount++
+	backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
+	retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
+	sess.NextRetryAt = &retryAt
+	sess.Status = state.StatusDead
+	now := time.Now().UTC()
+	sess.FinishedAt = &now
+
+	log.Printf("[orch] review feedback on PR #%d — scheduling retry %d in %dms for issue #%d",
+		pr.Number, sess.RetryCount, backoffMs, sess.IssueNumber)
+	o.notifier.Sendf("🔄 maestro: review feedback on PR #%d (issue #%d: %s), in-place retry %d scheduled in %ds",
+		pr.Number, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
+}
+
 // handleCIFailureRetry closes the failed PR, captures CI output, cleans up,
 // and schedules a retry for the worker (respecting max_retries_per_issue).
 func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, sess *state.Session, pr github.PR) {
@@ -1450,6 +1604,11 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 	// Store CI failure output and review feedback for the next worker
 	sess.CIFailureOutput = ciOutput
 	sess.PreviousAttemptFeedback = reviewFeedback
+	if strings.TrimSpace(reviewFeedback) != "" {
+		sess.PreviousAttemptFeedbackKind = "review_feedback"
+	} else {
+		sess.PreviousAttemptFeedbackKind = ""
+	}
 
 	// Schedule retry with exponential backoff
 	sess.RetryCount++
@@ -1465,6 +1624,15 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 		pr.Number, sess.RetryCount, backoffMs, sess.IssueNumber)
 	o.notifier.Sendf("🔄 maestro: CI failed on PR #%d (issue #%d: %s), retry %d scheduled in %ds",
 		pr.Number, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
+}
+
+func (o *Orchestrator) reviewGate() string {
+	switch strings.ToLower(strings.TrimSpace(o.cfg.ReviewGate)) {
+	case "none", "off", "disabled":
+		return "none"
+	default:
+		return "greptile"
+	}
 }
 
 func (o *Orchestrator) mergeStrategy() string {
@@ -1614,7 +1782,7 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 			log.Printf("[orch] PR #%d has conflicts, auto-rebasing %s", pr.Number, slotName)
 			if err := o.rebaseWorktree(sess.Worktree, sess.Branch); err != nil {
 				log.Printf("[orch] rebase failed for %s: %v", slotName, err)
-				o.markUnresolvableConflict(slotName, sess, pr.Number, err)
+				o.handleRebaseConflictRetry(s, slotName, sess, pr.Number, err)
 				continue
 			}
 			o.markRebaseQueued(slotName, sess, pr.Number)
@@ -1631,7 +1799,7 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 			log.Printf("[orch] retrying auto-rebase for conflict_failed session %s (PR #%d)", slotName, pr.Number)
 			if err := o.rebaseWorktree(sess.Worktree, sess.Branch); err != nil {
 				log.Printf("[orch] rebase retry failed for %s: %v", slotName, err)
-				o.markUnresolvableConflict(slotName, sess, pr.Number, err)
+				o.handleRebaseConflictRetry(s, slotName, sess, pr.Number, err)
 				continue
 			}
 			o.markRebaseQueued(slotName, sess, pr.Number)
@@ -1648,6 +1816,74 @@ func (o *Orchestrator) markRebaseQueued(slotName string, sess *state.Session, pr
 	sess.NotifiedCIFail = false
 	sess.LastNotifiedStatus = ""
 	o.notifier.Sendf("🔄 maestro: rebased %s (PR #%d) successfully; session moved to queued", slotName, prNumber)
+}
+
+func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string, sess *state.Session, prNumber int, cause error) {
+	if !o.cfg.AutoRetryReviewFeedback {
+		o.markUnresolvableConflict(slotName, sess, prNumber, cause)
+		return
+	}
+
+	maxRetries := o.cfg.MaxRetriesPerIssue
+	totalAttempts := s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount
+	if maxRetries > 0 && totalAttempts >= maxRetries {
+		log.Printf("[orch] rebase conflict on PR #%d — retry limit reached (%d/%d) for issue #%d",
+			prNumber, totalAttempts, maxRetries, sess.IssueNumber)
+		s.MarkIssueRetryExhausted(sess.IssueNumber)
+		o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+		sess.Status = state.StatusRetryExhausted
+		sess.NextRetryAt = nil
+		sess.LastNotifiedStatus = "rebase_conflict_retry_exhausted"
+		now := time.Now().UTC()
+		sess.FinishedAt = &now
+		o.notifier.Sendf("💀 maestro: rebase conflict on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
+			prNumber, sess.IssueNumber, sess.IssueTitle, totalAttempts)
+		return
+	}
+
+	if sess.Worktree == "" {
+		closeComment := fmt.Sprintf("Auto-rebase hit conflicts, but the PR worktree is unavailable — maestro is closing this PR and respawning a worker to resolve the conflict from a fresh branch (attempt %d).\n\nRebase failure:\n\n```\n%s\n```",
+			sess.RetryCount+1, rebaseConflictFeedback(prNumber, cause))
+		if err := o.closePR(prNumber, closeComment); err != nil {
+			log.Printf("[orch] warn: could not close PR #%d after rebase conflict: %v — marking conflict_failed", prNumber, err)
+			o.markUnresolvableConflict(slotName, sess, prNumber, cause)
+			return
+		}
+		log.Printf("[orch] closed PR #%d due to rebase conflict (worktree unavailable)", prNumber)
+		sess.PRNumber = 0
+	} else {
+		log.Printf("[orch] keeping PR #%d open and respawning %s in place to resolve rebase conflicts", prNumber, slotName)
+		sess.PRNumber = prNumber
+	}
+
+	sess.CIFailureOutput = ""
+	sess.PreviousAttemptFeedback = rebaseConflictFeedback(prNumber, cause)
+	sess.PreviousAttemptFeedbackKind = "rebase_conflict"
+
+	sess.RetryCount++
+	backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
+	retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
+	sess.NextRetryAt = &retryAt
+	sess.Status = state.StatusDead
+	sess.RebaseAttempted = true
+	now := time.Now().UTC()
+	sess.FinishedAt = &now
+
+	log.Printf("[orch] rebase conflict on PR #%d — scheduling retry %d in %dms for issue #%d",
+		prNumber, sess.RetryCount, backoffMs, sess.IssueNumber)
+	o.notifier.Sendf("🔄 maestro: rebase conflict on PR #%d (issue #%d: %s), in-place retry %d scheduled in %ds",
+		prNumber, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
+}
+
+func rebaseConflictFeedback(prNumber int, cause error) string {
+	msg := "(rebase failure unavailable)"
+	if cause != nil {
+		msg = strings.TrimSpace(cause.Error())
+	}
+	if len(msg) > 8000 {
+		msg = msg[:8000] + "\n... (truncated)"
+	}
+	return fmt.Sprintf("PR #%d failed to rebase onto origin/main.\n\n%s", prNumber, msg)
 }
 
 func (o *Orchestrator) markUnresolvableConflict(slotName string, sess *state.Session, prNumber int, cause error) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1002,6 +1002,196 @@ func TestAutoMergePRs_QueuedSessionsAreEligible(t *testing.T) {
 	}
 }
 
+func TestAutoMergePRs_ReviewGateNoneSkipsGreptileWait(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none"}
+	merged := make([]int, 0)
+	greptileChecks := 0
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghPRGreptileApprovedFn: func(prNumber int) (bool, bool, error) {
+			greptileChecks++
+			return false, true, nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = append(merged, prNumber)
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if greptileChecks != 0 {
+		t.Fatalf("greptile gate should not be checked when review_gate=none, got %d checks", greptileChecks)
+	}
+	if len(merged) != 1 || merged[0] != 10 {
+		t.Fatalf("merged = %v, want [10]", merged)
+	}
+}
+
+func TestAutoMergePRs_ReviewFeedbackKeepsPROpenAndSchedulesInPlaceRetry(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "parallel",
+		ReviewGate:              "none",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	merged := make([]int, 0)
+	closedPRs := make([]int, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
+		},
+		ghClosePRFn: func(prNumber int, comment string) error {
+			closedPRs = append(closedPRs, prNumber)
+			return nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = append(merged, prNumber)
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+	s := makeTestState(prs)
+	s.Sessions["slot-0"].Worktree = "/tmp/maestro-slot-0"
+
+	o.autoMergePRs(s)
+
+	if len(merged) != 0 {
+		t.Fatalf("expected review feedback to block merge, got merged=%v", merged)
+	}
+	if len(closedPRs) != 0 {
+		t.Fatalf("closedPRs = %v, want none", closedPRs)
+	}
+	sess := s.Sessions["slot-0"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set")
+	}
+	if sess.PreviousAttemptFeedback == "" {
+		t.Fatal("PreviousAttemptFeedback should be set")
+	}
+	if sess.PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want 10", sess.PRNumber)
+	}
+	if sess.Worktree == "" {
+		t.Fatal("Worktree should be preserved for in-place retry")
+	}
+}
+
+func TestAutoMergePRs_ReviewFeedbackFallsBackToCloseWhenWorktreeMissing(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "parallel",
+		ReviewGate:              "none",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	closedPRs := make([]int, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
+		},
+		ghClosePRFn: func(prNumber int, comment string) error {
+			closedPRs = append(closedPRs, prNumber)
+			return nil
+		},
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(closedPRs) != 1 || closedPRs[0] != 10 {
+		t.Fatalf("closedPRs = %v, want [10]", closedPRs)
+	}
+	if s.Sessions["slot-0"].PRNumber != 0 {
+		t.Fatalf("PRNumber = %d, want 0 after close fallback", s.Sessions["slot-0"].PRNumber)
+	}
+}
+
+func TestAutoMergePRs_ReviewFeedbackRetryLimitMarksTerminal(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "parallel",
+		ReviewGate:              "none",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
+		},
+	}
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.Worktree = "/tmp/maestro-slot-0"
+	sess.RetryCount = 3
+
+	o.autoMergePRs(s)
+
+	if sess.Status != state.StatusRetryExhausted {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRetryExhausted)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt should be nil after retry exhaustion")
+	}
+	if sess.LastNotifiedStatus != "review_retry_exhausted" {
+		t.Fatalf("LastNotifiedStatus = %q, want review_retry_exhausted", sess.LastNotifiedStatus)
+	}
+}
+
 func TestAutoMergePRs_CIFailureBlocksMerge(t *testing.T) {
 	prs := []github.PR{
 		{Number: 10, HeadRefName: "feat/a"},
@@ -1240,6 +1430,50 @@ func TestCheckSessions_TokensBelowLimit_WorkerSurvives(t *testing.T) {
 	}
 	if len(*stopped) != 0 {
 		t.Fatalf("stopped = %v, want empty", *stopped)
+	}
+}
+
+func TestCheckSessions_RunningInPlaceRetryKeepsWorkerRunning(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{{Number: 10, HeadRefName: "feat/existing"}}, nil
+		},
+		isIssueClosedFn: func(number int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return true
+		},
+		tmuxCaptureFn: func(session string) (string, error) {
+			return "worker still fixing review comments", nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "review retry",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-slot-0",
+		Branch:      "feat/existing",
+		PRNumber:    10,
+		StartedAt:   time.Now().Add(-1 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["slot-0"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+	if sess.PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want 10", sess.PRNumber)
 	}
 }
 
@@ -1506,7 +1740,7 @@ func TestMergeReadyPR_BehindMainTriggersRebase(t *testing.T) {
 		ghMergePRFn: func(prNumber int) error {
 			return fmt.Errorf("gh pr merge 10: the head branch is not up to date with the base branch")
 		},
-		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
 			rebased = true
 			return nil
 		},
@@ -1546,7 +1780,7 @@ func TestMergeReadyPR_BehindMainRebaseFailsMarksConflict(t *testing.T) {
 		ghMergePRFn: func(prNumber int) error {
 			return fmt.Errorf("gh pr merge 10: the head branch is not up to date with the base branch")
 		},
-		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
 			return fmt.Errorf("rebase failed: conflict in main.go")
 		},
 	}
@@ -1577,6 +1811,51 @@ func TestMergeReadyPR_BehindMainRebaseFailsMarksConflict(t *testing.T) {
 	}
 }
 
+func TestHandleRebaseConflictRetry_SchedulesInPlaceRetry(t *testing.T) {
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	o := &Orchestrator{cfg: cfg, notifier: &notify.Notifier{}}
+	s := state.NewState()
+	sess := &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "docs refresh",
+		Branch:      "feat/docs",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+		Backend:     "claude",
+	}
+	s.Sessions["slot-0"] = sess
+
+	o.handleRebaseConflictRetry(s, "slot-0", sess, 10, fmt.Errorf("CONFLICT (content): docs/FEATURES.md"))
+
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want 10", sess.PRNumber)
+	}
+	if sess.RetryCount != 1 {
+		t.Fatalf("RetryCount = %d, want 1", sess.RetryCount)
+	}
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set")
+	}
+	if !sess.RebaseAttempted {
+		t.Fatal("RebaseAttempted should be true")
+	}
+	if sess.PreviousAttemptFeedbackKind != "rebase_conflict" {
+		t.Fatalf("PreviousAttemptFeedbackKind = %q, want rebase_conflict", sess.PreviousAttemptFeedbackKind)
+	}
+	if !strings.Contains(sess.PreviousAttemptFeedback, "docs/FEATURES.md") {
+		t.Fatalf("PreviousAttemptFeedback should include conflict details, got %q", sess.PreviousAttemptFeedback)
+	}
+}
+
 func TestMergeReadyPR_BehindMainNoAutoRebase(t *testing.T) {
 	rebased := false
 	o := &Orchestrator{
@@ -1585,7 +1864,7 @@ func TestMergeReadyPR_BehindMainNoAutoRebase(t *testing.T) {
 		ghMergePRFn: func(prNumber int) error {
 			return fmt.Errorf("gh pr merge 10: the head branch is not up to date with the base branch")
 		},
-		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
 			rebased = true
 			return nil
 		},
@@ -1622,7 +1901,7 @@ func TestMergeReadyPR_OtherMergeErrorNoRebase(t *testing.T) {
 		ghMergePRFn: func(prNumber int) error {
 			return fmt.Errorf("gh pr merge 10: some other error")
 		},
-		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
 			rebased = true
 			return nil
 		},
@@ -3400,6 +3679,20 @@ func TestAvailableSlots_NonRunningLimitIgnoredForDispatch(t *testing.T) {
 	}
 }
 
+func TestPendingRetryReservations_CountsOnlyScheduledDeadRetries(t *testing.T) {
+	now := time.Now().UTC()
+	s := state.NewState()
+	s.Sessions["retry-due"] = &state.Session{Status: state.StatusDead, NextRetryAt: &now}
+	s.Sessions["retry-waiting"] = &state.Session{Status: state.StatusDead, NextRetryAt: &now}
+	s.Sessions["plain-dead"] = &state.Session{Status: state.StatusDead}
+	s.Sessions["running-with-retry"] = &state.Session{Status: state.StatusRunning, NextRetryAt: &now}
+
+	got := pendingRetryReservations(s)
+	if got != 2 {
+		t.Fatalf("pendingRetryReservations() = %d, want 2", got)
+	}
+}
+
 // --- blocker-aware dispatch tests ---
 
 func TestFindOpenBlockers_AllClosed(t *testing.T) {
@@ -3920,7 +4213,7 @@ func TestRespawnDueRetries_BackoffElapsed_Respawns(t *testing.T) {
 		Branch:      "feat/mae-12-112-test",
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if !respawned {
 		t.Fatal("expected worker to be respawned after backoff elapsed")
@@ -3931,6 +4224,120 @@ func TestRespawnDueRetries_BackoffElapsed_Respawns(t *testing.T) {
 	}
 	if sess.Status != state.StatusRunning {
 		t.Errorf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+}
+
+func TestRespawnDueRetries_RespectsAvailableSlots(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRetryBackoffMs: 300000,
+		MaxRuntimeMinutes: 999,
+	}
+	respawned := make([]string, 0)
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "test prompt",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return makeIssue(number, "test issue"), nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawned = append(respawned, slotName)
+			sess.Status = state.StatusRunning
+			sess.PID = 5555
+			return nil
+		},
+	}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	s := state.NewState()
+	s.Sessions["mae-12"] = &state.Session{
+		IssueNumber: 112,
+		IssueTitle:  "first retry",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/mae-12-112-test",
+	}
+	s.Sessions["mae-13"] = &state.Session{
+		IssueNumber: 113,
+		IssueTitle:  "second retry",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/mae-13-113-test",
+	}
+
+	o.respawnDueRetries(s, 1)
+
+	if len(respawned) != 1 {
+		t.Fatalf("respawned %d workers, want 1", len(respawned))
+	}
+	if s.Sessions["mae-12"].Status != state.StatusRunning {
+		t.Fatalf("mae-12 status = %q, want %q", s.Sessions["mae-12"].Status, state.StatusRunning)
+	}
+	if s.Sessions["mae-13"].Status != state.StatusDead {
+		t.Fatalf("mae-13 status = %q, want %q", s.Sessions["mae-13"].Status, state.StatusDead)
+	}
+	if s.Sessions["mae-13"].NextRetryAt == nil {
+		t.Fatal("mae-13 NextRetryAt should remain set when no retry slot is available")
+	}
+}
+
+func TestRespawnDueRetries_WithOpenPRRespawnsInPlace(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRetryBackoffMs: 300000,
+		MaxRuntimeMinutes: 999,
+	}
+	respawnedFresh := false
+	respawnedInPlace := false
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "test prompt",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return makeIssue(number, "test issue"), nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawnedFresh = true
+			return nil
+		},
+		respawnInPlaceFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawnedInPlace = true
+			sess.Status = state.StatusRunning
+			sess.PID = 5555
+			return nil
+		},
+	}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	s := state.NewState()
+	s.Sessions["mae-12"] = &state.Session{
+		IssueNumber:             112,
+		IssueTitle:              "review retry",
+		Status:                  state.StatusDead,
+		RetryCount:              1,
+		NextRetryAt:             &pastTime,
+		Branch:                  "feat/mae-12-112-test",
+		Worktree:                "/tmp/maestro-mae-12",
+		PRNumber:                10,
+		PreviousAttemptFeedback: "review feedback",
+	}
+
+	o.respawnDueRetries(s, 1)
+
+	if !respawnedInPlace {
+		t.Fatal("expected in-place respawn for retry with open PR and worktree")
+	}
+	if respawnedFresh {
+		t.Fatal("fresh respawn should not be used for retry with open PR and worktree")
+	}
+	if s.Sessions["mae-12"].PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want 10", s.Sessions["mae-12"].PRNumber)
+	}
+	if s.Sessions["mae-12"].PreviousAttemptFeedback != "" {
+		t.Fatal("PreviousAttemptFeedback should be consumed before respawn")
 	}
 }
 
@@ -3960,7 +4367,7 @@ func TestRespawnDueRetries_BackoffNotElapsed_Waits(t *testing.T) {
 		Branch:      "feat/mae-13-113-test",
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if respawned {
 		t.Fatal("worker should NOT be respawned while backoff is still pending")
@@ -4001,7 +4408,7 @@ func TestRespawnDueRetries_RespawnFails_MarksAsFailed(t *testing.T) {
 		Branch:      "feat/mae-14-114-test",
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	sess := s.Sessions["mae-14"]
 	if sess.Status != state.StatusFailed {
@@ -4440,7 +4847,7 @@ func TestRespawnDueRetries_CIFailureContext_IncludedInPrompt(t *testing.T) {
 		CIFailureOutput: "tests failed: FAIL main_test.go:15",
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if respawnedPrompt == "" {
 		t.Fatal("respawnWorkerFn should have been called")
@@ -4496,7 +4903,7 @@ func TestRespawnDueRetries_NoCIContext_NormalPrompt(t *testing.T) {
 		// No CIFailureOutput — normal dead worker retry
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if respawnedPrompt == "" {
 		t.Fatal("respawnWorkerFn should have been called")
@@ -4758,7 +5165,7 @@ func TestAppendReviewFeedbackContext_AddsSection(t *testing.T) {
 	if !strings.Contains(result, "You are a coding agent.") {
 		t.Error("result should contain original prompt base")
 	}
-	if !strings.Contains(result, "Code Review Findings (from Greptile)") {
+	if !strings.Contains(result, "Code Review Findings") {
 		t.Error("result should contain review feedback header")
 	}
 	if !strings.Contains(result, "enabled flag logic inverted") {
@@ -4819,7 +5226,7 @@ func TestRespawnDueRetries_ReviewFeedback_IncludedInPrompt(t *testing.T) {
 		PreviousAttemptFeedback: "Confidence 3/5\nP2: enabled flag inverted in bridge.rs",
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if respawnedPrompt == "" {
 		t.Fatal("respawnWorkerFn should have been called")
@@ -4827,11 +5234,11 @@ func TestRespawnDueRetries_ReviewFeedback_IncludedInPrompt(t *testing.T) {
 	if !strings.Contains(respawnedPrompt, "Previous CI Failure") {
 		t.Error("prompt should contain CI failure context")
 	}
-	if !strings.Contains(respawnedPrompt, "Code Review Findings (from Greptile)") {
+	if !strings.Contains(respawnedPrompt, "Code Review Findings") {
 		t.Error("prompt should contain review feedback section")
 	}
 	if !strings.Contains(respawnedPrompt, "enabled flag inverted") {
-		t.Error("prompt should contain actual Greptile feedback")
+		t.Error("prompt should contain actual review feedback")
 	}
 	if !strings.Contains(respawnedPrompt, "IMPORTANT: Address ALL code review findings") {
 		t.Error("prompt should contain instruction to fix review findings")
@@ -4844,6 +5251,69 @@ func TestRespawnDueRetries_ReviewFeedback_IncludedInPrompt(t *testing.T) {
 	}
 	if sess.PreviousAttemptFeedback != "" {
 		t.Errorf("PreviousAttemptFeedback should be cleared, got %q", sess.PreviousAttemptFeedback)
+	}
+}
+
+func TestRespawnDueRetries_RebaseConflict_IncludedInPrompt(t *testing.T) {
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRetriesPerIssue: 3,
+		MaxRetryBackoffMs:  300000,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	respawnedPrompt := ""
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "base prompt {{ISSUE_NUMBER}}",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: 42, Title: "test issue", Body: "fix this"}, nil
+		},
+		respawnInPlaceFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedPrompt = promptBase
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:                 42,
+		IssueTitle:                  "test issue",
+		Status:                      state.StatusDead,
+		RetryCount:                  1,
+		NextRetryAt:                 &retryAt,
+		Backend:                     "claude",
+		PRNumber:                    10,
+		Worktree:                    "/tmp/wt",
+		PreviousAttemptFeedback:     "CONFLICT (content): docs/FEATURES.md",
+		PreviousAttemptFeedbackKind: "rebase_conflict",
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if respawnedPrompt == "" {
+		t.Fatal("respawnInPlaceFn should have been called")
+	}
+	if !strings.Contains(respawnedPrompt, "Rebase Conflict") {
+		t.Error("prompt should contain rebase conflict section")
+	}
+	if !strings.Contains(respawnedPrompt, "docs/FEATURES.md") {
+		t.Error("prompt should contain conflict details")
+	}
+	if strings.Contains(respawnedPrompt, "Code Review Findings") {
+		t.Error("rebase conflict prompt should not be framed as review feedback")
+	}
+	sess := s.Sessions["slot-1"]
+	if sess.PreviousAttemptFeedback != "" {
+		t.Errorf("PreviousAttemptFeedback should be cleared, got %q", sess.PreviousAttemptFeedback)
+	}
+	if sess.PreviousAttemptFeedbackKind != "" {
+		t.Errorf("PreviousAttemptFeedbackKind should be cleared, got %q", sess.PreviousAttemptFeedbackKind)
 	}
 }
 
@@ -4885,7 +5355,7 @@ func TestRespawnDueRetries_NoReviewFeedback_OmitsSection(t *testing.T) {
 		PreviousAttemptFeedback: "", // no Greptile feedback
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if respawnedPrompt == "" {
 		t.Fatal("respawnWorkerFn should have been called")
@@ -4902,7 +5372,7 @@ func TestAutoMergePRs_CIFailure_CollectsReviewFeedback(t *testing.T) {
 	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000}
 	o, _, _ := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{10: "failure"})
 
-	// Override with Greptile feedback
+	// Override with review feedback
 	o.ghCollectPRReviewFeedbackFn = func(prNumber int) (string, error) {
 		return "Confidence 3/5 — Not safe to merge\nP2: null dereference on pool.interface", nil
 	}
@@ -4912,10 +5382,10 @@ func TestAutoMergePRs_CIFailure_CollectsReviewFeedback(t *testing.T) {
 
 	sess := s.Sessions["slot-0"]
 	if sess.PreviousAttemptFeedback == "" {
-		t.Fatal("PreviousAttemptFeedback should be set after CI failure with Greptile feedback")
+		t.Fatal("PreviousAttemptFeedback should be set after CI failure with review feedback")
 	}
 	if !strings.Contains(sess.PreviousAttemptFeedback, "null dereference") {
-		t.Errorf("PreviousAttemptFeedback should contain Greptile feedback, got %q", sess.PreviousAttemptFeedback)
+		t.Errorf("PreviousAttemptFeedback should contain review feedback, got %q", sess.PreviousAttemptFeedback)
 	}
 }
 
@@ -4926,7 +5396,7 @@ func TestAutoMergePRs_CIFailure_NoGreptileFeedback_FeedbackEmpty(t *testing.T) {
 	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000}
 	o, _, _ := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{10: "failure"})
 
-	// No Greptile feedback (returns empty)
+	// No review feedback (returns empty)
 	o.ghCollectPRReviewFeedbackFn = func(prNumber int) (string, error) {
 		return "", nil
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -33,36 +33,37 @@ const (
 )
 
 type Session struct {
-	IssueNumber             int           `json:"issue_number"`
-	IssueTitle              string        `json:"issue_title"`
-	Worktree                string        `json:"worktree"`
-	Branch                  string        `json:"branch"`
-	PID                     int           `json:"pid"`
-	TmuxSession             string        `json:"tmux_session,omitempty"`
-	LogFile                 string        `json:"log_file"`
-	StartedAt               time.Time     `json:"started_at"`
-	FinishedAt              *time.Time    `json:"finished_at,omitempty"`
-	Status                  SessionStatus `json:"status"`
-	PRNumber                int           `json:"pr_number,omitempty"`
-	Backend                 string        `json:"backend,omitempty"` // "claude", "codex", etc.
-	LongRunning             bool          `json:"long_running,omitempty"`
-	RebaseAttempted         bool          `json:"rebase_attempted,omitempty"`
-	NotifiedCIFail          bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
-	LastNotifiedStatus      string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
-	RetryCount              int           `json:"retry_count,omitempty"`          // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
-	NextRetryAt             *time.Time    `json:"next_retry_at,omitempty"`
-	LastOutputHash          string        `json:"last_output_hash,omitempty"`
-	LastOutputChangedAt     time.Time     `json:"last_output_changed_at,omitempty"`
-	TokensUsedAttempt       int           `json:"tokens_used_attempt,omitempty"`       // tokens consumed in current attempt (reset on respawn)
-	TokensUsedTotal         int           `json:"tokens_used_total,omitempty"`         // cumulative tokens across the issue lifecycle
-	RateLimitHit            bool          `json:"rate_limit_hit,omitempty"`            // true if worker was rate-limited (tmux detection, running worker)
-	TriedBackends           []string      `json:"tried_backends,omitempty"`            // backends already attempted (for rate-limit fallback)
-	Phase                   Phase         `json:"phase,omitempty"`                     // current pipeline phase (empty = legacy single-phase)
-	ValidationFails         int           `json:"validation_fails,omitempty"`          // number of failed validation attempts
-	ValidationFeedback      string        `json:"validation_feedback,omitempty"`       // feedback from last failed validation
-	CIFailureOutput         string        `json:"ci_failure_output,omitempty"`         // CI failure output captured before retry (passed to next worker as context)
-	PreviousAttemptFeedback string        `json:"previous_attempt_feedback,omitempty"` // Greptile review feedback from previous failed PR attempt
-	CheckpointFile          string        `json:"checkpoint_file,omitempty"`           // path to CHECKPOINT.md saved at soft token threshold
+	IssueNumber                 int           `json:"issue_number"`
+	IssueTitle                  string        `json:"issue_title"`
+	Worktree                    string        `json:"worktree"`
+	Branch                      string        `json:"branch"`
+	PID                         int           `json:"pid"`
+	TmuxSession                 string        `json:"tmux_session,omitempty"`
+	LogFile                     string        `json:"log_file"`
+	StartedAt                   time.Time     `json:"started_at"`
+	FinishedAt                  *time.Time    `json:"finished_at,omitempty"`
+	Status                      SessionStatus `json:"status"`
+	PRNumber                    int           `json:"pr_number,omitempty"`
+	Backend                     string        `json:"backend,omitempty"` // "claude", "codex", etc.
+	LongRunning                 bool          `json:"long_running,omitempty"`
+	RebaseAttempted             bool          `json:"rebase_attempted,omitempty"`
+	NotifiedCIFail              bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
+	LastNotifiedStatus          string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
+	RetryCount                  int           `json:"retry_count,omitempty"`          // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
+	NextRetryAt                 *time.Time    `json:"next_retry_at,omitempty"`
+	LastOutputHash              string        `json:"last_output_hash,omitempty"`
+	LastOutputChangedAt         time.Time     `json:"last_output_changed_at,omitempty"`
+	TokensUsedAttempt           int           `json:"tokens_used_attempt,omitempty"`            // tokens consumed in current attempt (reset on respawn)
+	TokensUsedTotal             int           `json:"tokens_used_total,omitempty"`              // cumulative tokens across the issue lifecycle
+	RateLimitHit                bool          `json:"rate_limit_hit,omitempty"`                 // true if worker was rate-limited (tmux detection, running worker)
+	TriedBackends               []string      `json:"tried_backends,omitempty"`                 // backends already attempted (for rate-limit fallback)
+	Phase                       Phase         `json:"phase,omitempty"`                          // current pipeline phase (empty = legacy single-phase)
+	ValidationFails             int           `json:"validation_fails,omitempty"`               // number of failed validation attempts
+	ValidationFeedback          string        `json:"validation_feedback,omitempty"`            // feedback from last failed validation
+	CIFailureOutput             string        `json:"ci_failure_output,omitempty"`              // CI failure output captured before retry (passed to next worker as context)
+	PreviousAttemptFeedback     string        `json:"previous_attempt_feedback,omitempty"`      // feedback from previous failed PR attempt
+	PreviousAttemptFeedbackKind string        `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
+	CheckpointFile              string        `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
 }
 
 // UnmarshalJSON implements custom unmarshalling to preserve the legacy

--- a/internal/worker/rebase_test.go
+++ b/internal/worker/rebase_test.go
@@ -1,6 +1,12 @@
 package worker
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestKeepBothSides_SimpleConflict(t *testing.T) {
 	input := "line1\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\nline2\n"
@@ -52,4 +58,104 @@ func TestKeepBothSides_UnterminatedConflict(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unterminated conflict")
 	}
+}
+
+func TestRestoreAllowedDirtyFiles_RestoresOnlyConfiguredPaths(t *testing.T) {
+	dir := t.TempDir()
+	gitTest(t, dir, "init")
+	gitTest(t, dir, "config", "user.email", "test@example.com")
+	gitTest(t, dir, "config", "user.name", "Test User")
+
+	writeTestFile(t, dir, "ok-gobot", "original binary")
+	writeTestFile(t, dir, "main.go", "package main\n")
+	gitTest(t, dir, "add", "-f", "ok-gobot", "main.go")
+	gitTest(t, dir, "commit", "-m", "initial")
+
+	writeTestFile(t, dir, "ok-gobot", "rebuilt binary")
+	writeTestFile(t, dir, "main.go", "package main\n\nfunc main() {}\n")
+
+	if err := restoreAllowedDirtyFiles(dir, []string{"ok-gobot"}); err != nil {
+		t.Fatalf("restoreAllowedDirtyFiles: %v", err)
+	}
+
+	if got := readTestFile(t, dir, "ok-gobot"); got != "original binary" {
+		t.Fatalf("ok-gobot = %q, want restored original binary", got)
+	}
+	if got := readTestFile(t, dir, "main.go"); got != "package main\n\nfunc main() {}\n" {
+		t.Fatalf("main.go = %q, want unrelated dirty file unchanged", got)
+	}
+
+	dirty, err := worktreeDirty(dir)
+	if err != nil {
+		t.Fatalf("worktreeDirty: %v", err)
+	}
+	if strings.Contains(dirty, "ok-gobot") {
+		t.Fatalf("ok-gobot should be clean after restore, dirty status:\n%s", dirty)
+	}
+	if !strings.Contains(dirty, "main.go") {
+		t.Fatalf("main.go should remain dirty, dirty status:\n%s", dirty)
+	}
+}
+
+func TestRestoreAllowedDirtyFiles_CleansConfiguredUntrackedPaths(t *testing.T) {
+	dir := t.TempDir()
+	gitTest(t, dir, "init")
+	gitTest(t, dir, "config", "user.email", "test@example.com")
+	gitTest(t, dir, "config", "user.name", "Test User")
+
+	writeTestFile(t, dir, "main.go", "package main\n")
+	gitTest(t, dir, "add", "main.go")
+	gitTest(t, dir, "commit", "-m", "initial")
+
+	writeTestFile(t, dir, "build/artifact.bin", "artifact")
+
+	if err := restoreAllowedDirtyFiles(dir, []string{"build"}); err != nil {
+		t.Fatalf("restoreAllowedDirtyFiles: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "build", "artifact.bin")); !os.IsNotExist(err) {
+		t.Fatalf("configured untracked artifact should be removed, stat err=%v", err)
+	}
+}
+
+func TestNormalizedGitPaths_TrimsDeduplicatesAndUsesSlash(t *testing.T) {
+	got := normalizedGitPaths([]string{" ok-gobot ", "build\\artifact.bin", "ok-gobot", ""})
+	want := []string{"ok-gobot", "build/artifact.bin"}
+	if len(got) != len(want) {
+		t.Fatalf("normalizedGitPaths = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("normalizedGitPaths[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func gitTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func writeTestFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	path := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readTestFile(t *testing.T, dir, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(data)
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -336,6 +336,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	// case Respawn is called from other paths.
 	sess.CIFailureOutput = ""
 	sess.PreviousAttemptFeedback = ""
+	sess.PreviousAttemptFeedbackKind = ""
 	sess.CheckpointFile = ""
 
 	return nil
@@ -447,7 +448,9 @@ func RemoveWorktree(localPath, worktreePath string) error {
 // both sides, continues the rebase, then force-pushes the branch.
 // autoResolveFiles is the list of file paths (relative to repo root) that may
 // be auto-resolved by keeping both sides; it comes from cfg.AutoResolveFiles.
-func RebaseWorktree(worktreePath, branch string, autoResolveFiles []string) error {
+// autoRestoreFiles is the list of dirty disposable paths that may be restored
+// before rebasing; it comes from cfg.AutoRestoreFiles.
+func RebaseWorktree(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
 	if strings.TrimSpace(worktreePath) == "" {
 		return fmt.Errorf("empty worktree path")
 	}
@@ -457,6 +460,14 @@ func RebaseWorktree(worktreePath, branch string, autoResolveFiles []string) erro
 
 	if _, err := runGit(worktreePath, "fetch", "origin"); err != nil {
 		return err
+	}
+	if err := restoreAllowedDirtyFiles(worktreePath, autoRestoreFiles); err != nil {
+		return err
+	}
+	if dirty, err := worktreeDirty(worktreePath); err != nil {
+		return err
+	} else if dirty != "" {
+		return fmt.Errorf("worktree has uncommitted changes after auto_restore_files; refusing rebase:\n%s", dirty)
 	}
 
 	if _, rebaseErr := runGit(worktreePath, "rebase", "origin/main"); rebaseErr != nil {
@@ -473,6 +484,82 @@ func RebaseWorktree(worktreePath, branch string, autoResolveFiles []string) erro
 	}
 
 	return nil
+}
+
+func restoreAllowedDirtyFiles(worktreePath string, autoRestoreFiles []string) error {
+	paths := normalizedGitPaths(autoRestoreFiles)
+	if len(paths) == 0 {
+		return nil
+	}
+	args := append([]string{"status", "--porcelain", "--"}, paths...)
+	dirty, err := runGit(worktreePath, args...)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(dirty) == "" {
+		return nil
+	}
+
+	log.Printf("[worker] restoring allowed dirty files before rebase in %s: %s", worktreePath, strings.Join(paths, ", "))
+	trackedPaths, err := trackedGitPaths(worktreePath, paths)
+	if err != nil {
+		return err
+	}
+	if len(trackedPaths) > 0 {
+		args = append([]string{"restore", "--"}, trackedPaths...)
+		if _, err := runGit(worktreePath, args...); err != nil {
+			return err
+		}
+	}
+	args = append([]string{"clean", "-fd", "--"}, paths...)
+	if _, err := runGit(worktreePath, args...); err != nil {
+		return err
+	}
+	return nil
+}
+
+func trackedGitPaths(worktreePath string, paths []string) ([]string, error) {
+	args := append([]string{"ls-files", "--"}, paths...)
+	out, err := runGit(worktreePath, args...)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(out, "\n")
+	tracked := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		tracked = append(tracked, toSlash(line))
+	}
+	return tracked, nil
+}
+
+func worktreeDirty(worktreePath string) (string, error) {
+	out, err := runGit(worktreePath, "status", "--porcelain")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func normalizedGitPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		path = toSlash(path)
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		normalized = append(normalized, path)
+	}
+	return normalized
 }
 
 func runGit(worktreePath string, args ...string) (string, error) {


### PR DESCRIPTION
## Summary\n- add configurable review gate and automatic retry on review feedback\n- reserve worker slots for scheduled retries and cap retry respawns by available slots\n- add coverage for review-gated retry and retry slot accounting\n\n## Test\n- go test ./...

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds configurable review-gate (`review_gate`) and automatic in-place retry on review feedback or rebase conflicts (`auto_retry_review_feedback`), with worker slot reservation for pending retries. One P1 bug was found in the slot reservation logic that can starve new issue dispatch.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the slot-reservation starvation bug; all other paths are well-tested.

One P1 logic bug: `pendingRetryReservations` counts future-backoff retries, which can prevent new work from being dispatched until those retries fire. All other new code paths are correct and well covered by tests.

internal/orchestrator/orchestrator.go — `pendingRetryReservations` and step-5 slot reservation logic

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Core logic changes: adds review-gated retry, rebase-conflict retry, slot reservation, and in-place respawn routing. Contains a P1 starvation bug in `pendingRetryReservations` and a P2 flag-coupling issue in `handleRebaseConflictRetry`. |
| internal/config/config.go | Adds `ReviewGate` and `AutoRetryReviewFeedback` config fields with normalisation, defaults, and hot-reload support. Straightforward and correct. |
| internal/state/state.go | Adds `PreviousAttemptFeedbackKind` field to `Session` struct with appropriate JSON tag; no logic changes. |
| internal/worker/worker.go | Extends `RebaseWorktree` with `autoRestoreFiles` support: restores known-disposable dirty files before rebasing and hard-fails if the worktree is still dirty afterwards. Otherwise clean. |
| internal/orchestrator/orchestrator_test.go | Comprehensive new tests for review-gate, review-feedback retry, rebase-conflict retry, in-place respawn, and slot accounting. |
| internal/worker/rebase_test.go | New tests for `restoreAllowedDirtyFiles` and `normalizedGitPaths` with real git repos; solid coverage. |
| internal/config/config_test.go | Adds tests for `ReviewGate` defaults/explicit values and `AutoRestoreFiles` parsing; all correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/orchestrator/orchestrator.go
Line: 521-529

Comment:
**Future-backoff retries starve new issue dispatch**

`pendingRetryReservations` counts every `StatusDead` session that has a `NextRetryAt` set, regardless of whether the backoff has already elapsed. `respawnDueRetries` correctly skips sessions whose `NextRetryAt` is still in the future (line 561: `time.Now().UTC().Before(*sess.NextRetryAt)`), but the reservation in step 5 of `RunOnce` still subtracts those future-scheduled retries from the available slots.

Concrete failure: `MaxParallel=2`, active=0, two sessions with `NextRetryAt` 5 minutes from now → `slots=2`, `reserved=2`, `slots=0`. No new work is dispatched for 5 minutes — and the same starvation repeats on every orchestration cycle until the backoffs finally elapse.

Only retries that are currently due need a reserved slot for the next cycle. Fix by applying the same timing filter used in `respawnDueRetries`:

```go
func pendingRetryReservations(s *state.State) int {
	now := time.Now().UTC()
	count := 0
	for _, sess := range s.Sessions {
		if sess.Status == state.StatusDead && sess.NextRetryAt != nil && !now.Before(*sess.NextRetryAt) {
			count++
		}
	}
	return count
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/orchestrator/orchestrator.go
Line: 1471-1475

Comment:
**`AutoRetryReviewFeedback` repurposed to gate rebase-conflict retry**

`AutoRetryReviewFeedback` is documented as "close PRs with review comments and respawn a fixer," yet `handleRebaseConflictRetry` uses it as the gate for rebase-conflict retries. A user who only wants one of these two behaviours cannot configure them independently — enabling rebase-conflict retry silently enables review-feedback retry and vice versa.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Improve review-gated auto retry orchestr..."](https://github.com/befeast/maestro/commit/ab3402529f8bfa30c24b217bbf6e096282d27a86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30153514)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->