### PR TITLE
feat: add read-only Mission Control dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ maestro run --once
 # 5. Check status
 maestro status
 
-# 6. When ready, run continuously
+# 6. Watch the read-only web dashboard
+maestro serve --port 8787 --read-only
+
+# 7. When ready, run continuously
 maestro run
 ```
 
@@ -133,6 +136,13 @@ To manually spawn a worker for a specific issue:
 ```bash
 maestro spawn --issue 42
 ```
+
+To watch Maestro from a browser, use the read-only Mission Control dashboard:
+```bash
+maestro serve --config ./maestro.yaml --host 127.0.0.1 --port 8787 --read-only
+```
+
+Use `--host 0.0.0.0` only on a trusted network if you want to expose the dashboard to the LAN.
 
 To watch workers live in a tmux dashboard:
 ```bash
@@ -157,6 +167,10 @@ merge_interval_seconds: 30         # minimum seconds between merges in sequentia
 session_prefix: pan                # worker session name prefix (default: first 3 chars of repo name)
 state_dir: ~/.maestro/pan          # state/log directory (default: ~/.maestro/<repo-hash>)
 claude_cmd: claude                 # deprecated: use model.backends.claude.cmd
+server:
+  host: 127.0.0.1                  # bind address for `maestro serve`
+  port: 8787                       # 0 = disabled for `maestro run`
+  read_only: true                  # dashboard mode: block mutating HTTP endpoints
 issue_labels:                      # preferred label filter (OR semantics)
   - enhancement
 exclude_labels:

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -38,6 +38,7 @@ Usage:
 Commands:
   init          Interactive setup wizard for new projects
   run           Run the orchestration loop
+  serve         Run Mission Control read-only web dashboard/API
   status        Show current state
   logs          Show worker logs (tail -f)
   watch         Open tmux dashboard with live worker output
@@ -60,6 +61,11 @@ Run flags:
   --interval duration   Loop interval (default 10m)
   --once                Run once and exit
   --prompt string       Path to worker prompt base file
+
+Serve flags:
+  --host string         Host/interface to bind (default from config, then 127.0.0.1)
+  --port int            Port to bind (overrides server.port)
+  --read-only           Disable mutating HTTP endpoints (default true)
 
 Spawn flags:
   --issue int           Issue number to work on
@@ -151,6 +157,8 @@ func main() {
 		initCmd(args)
 	case "run":
 		runCmd(args)
+	case "serve":
+		serveCmd(args)
 	case "status":
 		statusCmd(args)
 	case "logs":
@@ -334,6 +342,48 @@ func runCmd(args []string) {
 		}(cfg)
 	}
 	wg.Wait()
+}
+
+func serveCmd(args []string) {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	var configs multiFlag
+	fs.Var(&configs, "config", "Path to config file")
+	host := fs.String("host", "", "Host/interface to bind")
+	port := fs.Int("port", 0, "Port to bind")
+	readOnly := fs.Bool("read-only", true, "Disable mutating HTTP endpoints")
+	fs.Parse(args)
+
+	cfgs := loadConfigs(configs)
+	if len(cfgs) != 1 {
+		log.Fatalf("serve requires exactly one config, got %d", len(cfgs))
+	}
+	cfg := cfgs[0]
+	if strings.TrimSpace(*host) != "" {
+		cfg.Server.Host = *host
+	}
+	if *port > 0 {
+		cfg.Server.Port = *port
+	}
+	cfg.Server.ReadOnly = *readOnly
+	if cfg.Server.Port <= 0 {
+		log.Fatalf("serve requires server.port in config or --port")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	refreshCh := make(chan struct{}, 1)
+	log.Printf("serving dashboard — repo=%s addr=%s:%d read_only=%v", cfg.Repo, cfg.Server.Host, cfg.Server.Port, cfg.Server.ReadOnly)
+	if err := server.New(cfg, refreshCh).Start(ctx); err != nil {
+		log.Fatalf("serve: %v", err)
+	}
 }
 
 func statusCmd(args []string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,15 +147,18 @@ type Config struct {
 	StateDir                   string               `yaml:"state_dir"`           // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig          `yaml:"model"`
 	Routing                    RoutingConfig        `yaml:"routing"`
-	DeployCmd                  string               `yaml:"deploy_cmd"`             // shell command to run after successful PR merge
-	DeployTimeoutMinutes       int                  `yaml:"deploy_timeout_minutes"` // timeout for deploy command in minutes (default: 15)
-	MergeStrategy              string               `yaml:"merge_strategy"`         // "sequential" | "parallel"
-	MergeIntervalSeconds       int                  `yaml:"merge_interval_seconds"` // minimum seconds between merges in sequential mode
+	DeployCmd                  string               `yaml:"deploy_cmd"`                 // shell command to run after successful PR merge
+	DeployTimeoutMinutes       int                  `yaml:"deploy_timeout_minutes"`     // timeout for deploy command in minutes (default: 15)
+	MergeStrategy              string               `yaml:"merge_strategy"`             // "sequential" | "parallel"
+	MergeIntervalSeconds       int                  `yaml:"merge_interval_seconds"`     // minimum seconds between merges in sequential mode
+	ReviewGate                 string               `yaml:"review_gate"`                // "greptile" (default) | "none"
+	AutoRetryReviewFeedback    bool                 `yaml:"auto_retry_review_feedback"` // close PRs with review comments and respawn a fixer
 	Telegram                   TelegramConfig       `yaml:"telegram"`
 	Versioning                 VersioningConfig     `yaml:"versioning"`
 	GitHubProjects             GitHubProjectsConfig `yaml:"github_projects"`
 	MaxRetryBackoffMs          int                  `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
 	AutoResolveFiles           []string             `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
+	AutoRestoreFiles           []string             `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase
 	CleanupWorktreesOnMerge    *bool                `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
 	Pipeline                   PipelineConfig       `yaml:"pipeline"`
 	Hooks                      HooksConfig          `yaml:"hooks"`
@@ -223,6 +226,7 @@ func parse(data []byte) (*Config, error) {
 		ClaudeCmd:            "claude",
 		MergeStrategy:        "sequential",
 		MergeIntervalSeconds: 30,
+		ReviewGate:           "greptile",
 		AutoResolveFiles: []string{
 			"server/src/api/mod.rs",
 			"web/src/lib/api.ts",
@@ -356,6 +360,16 @@ func parse(data []byte) (*Config, error) {
 	}
 	if cfg.MergeIntervalSeconds <= 0 {
 		cfg.MergeIntervalSeconds = 30
+	}
+
+	// Review gate defaults
+	switch strings.ToLower(strings.TrimSpace(cfg.ReviewGate)) {
+	case "", "greptile":
+		cfg.ReviewGate = "greptile"
+	case "none", "off", "disabled":
+		cfg.ReviewGate = "none"
+	default:
+		cfg.ReviewGate = "greptile"
 	}
 
 	// Default hooks timeout

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,7 +63,9 @@ type RoutingConfig struct {
 
 // ServerConfig controls the optional HTTP API server.
 type ServerConfig struct {
-	Port int `yaml:"port"` // 0 = disabled (default)
+	Host     string `yaml:"host"`      // host/interface to bind; default: 127.0.0.1
+	Port     int    `yaml:"port"`      // 0 = disabled (default)
+	ReadOnly bool   `yaml:"read_only"` // disable mutating HTTP endpoints when true
 }
 
 // RoleConfig defines settings for a single pipeline role (planner, validator).
@@ -303,6 +305,9 @@ func parse(data []byte) (*Config, error) {
 
 	if cfg.Telegram.Mode == "" {
 		cfg.Telegram.Mode = "direct"
+	}
+	if strings.TrimSpace(cfg.Server.Host) == "" {
+		cfg.Server.Host = "127.0.0.1"
 	}
 
 	// Model backend defaults

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -70,6 +70,28 @@ issue_labels: []
 	}
 }
 
+func TestParse_AutoRestoreFiles(t *testing.T) {
+	yaml := `
+repo: owner/repo
+auto_restore_files:
+  - ok-gobot
+  - build/output.bin
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"ok-gobot", "build/output.bin"}
+	if len(cfg.AutoRestoreFiles) != len(want) {
+		t.Fatalf("AutoRestoreFiles = %v, want %v", cfg.AutoRestoreFiles, want)
+	}
+	for i, file := range cfg.AutoRestoreFiles {
+		if file != want[i] {
+			t.Errorf("AutoRestoreFiles[%d] = %q, want %q", i, file, want[i])
+		}
+	}
+}
+
 func TestParse_IssueLabelsLegacyMerged(t *testing.T) {
 	yaml := `
 repo: owner/repo
@@ -734,6 +756,38 @@ merge_interval_seconds: 45
 	}
 	if cfg.MergeIntervalSeconds != 45 {
 		t.Errorf("MergeIntervalSeconds = %d, want 45", cfg.MergeIntervalSeconds)
+	}
+}
+
+func TestParse_ReviewGateDefaults(t *testing.T) {
+	yaml := `repo: owner/repo`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.ReviewGate != "greptile" {
+		t.Errorf("ReviewGate = %q, want %q", cfg.ReviewGate, "greptile")
+	}
+	if cfg.AutoRetryReviewFeedback {
+		t.Error("AutoRetryReviewFeedback should default to false")
+	}
+}
+
+func TestParse_ReviewGateExplicitNone(t *testing.T) {
+	yaml := `
+repo: owner/repo
+review_gate: none
+auto_retry_review_feedback: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.ReviewGate != "none" {
+		t.Errorf("ReviewGate = %q, want %q", cfg.ReviewGate, "none")
+	}
+	if !cfg.AutoRetryReviewFeedback {
+		t.Error("AutoRetryReviewFeedback should be true when configured")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -797,23 +797,34 @@ func TestParse_ServerPortDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
+	if cfg.Server.Host != "127.0.0.1" {
+		t.Errorf("Server.Host = %q, want 127.0.0.1", cfg.Server.Host)
+	}
 	if cfg.Server.Port != 0 {
 		t.Errorf("Server.Port = %d, want 0 (disabled)", cfg.Server.Port)
 	}
 }
 
-func TestParse_ServerPortExplicit(t *testing.T) {
+func TestParse_ServerExplicit(t *testing.T) {
 	yaml := `
 repo: owner/repo
 server:
+  host: 0.0.0.0
   port: 8765
+  read_only: true
 `
 	cfg, err := parse([]byte(yaml))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
+	if cfg.Server.Host != "0.0.0.0" {
+		t.Errorf("Server.Host = %q, want 0.0.0.0", cfg.Server.Host)
+	}
 	if cfg.Server.Port != 8765 {
 		t.Errorf("Server.Port = %d, want 8765", cfg.Server.Port)
+	}
+	if !cfg.Server.ReadOnly {
+		t.Error("Server.ReadOnly should be true when configured")
 	}
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -16,11 +16,12 @@ type greptileCheckRun struct {
 }
 
 type greptileReviewComment struct {
-	Body     string `json:"body"`
-	Path     string `json:"path"`
-	Line     int    `json:"line"`
-	CommitID string `json:"commit_id"`
-	User     struct {
+	Body             string `json:"body"`
+	Path             string `json:"path"`
+	Line             int    `json:"line"`
+	CommitID         string `json:"commit_id"`
+	OriginalCommitID string `json:"original_commit_id"`
+	User             struct {
 		Login string `json:"login"`
 	} `json:"user"`
 }
@@ -336,8 +337,8 @@ func hasGreptileInlineCommentOnHead(comments []greptileReviewComment, sha string
 		if !isGreptileLogin(comment.User.Login) {
 			continue
 		}
-		if strings.TrimSpace(sha) != "" && strings.TrimSpace(comment.CommitID) != strings.TrimSpace(sha) {
-			continue // comment is on an older commit, skip
+		if !reviewCommentTargetsHead(comment, sha) {
+			continue
 		}
 		// Only block on P0 or P1 severity — P2/P3 are non-blocking
 		if isHighSeverity(comment.Body) {
@@ -345,6 +346,22 @@ func hasGreptileInlineCommentOnHead(comments []greptileReviewComment, sha string
 		}
 	}
 	return false
+}
+
+func reviewCommentTargetsHead(comment greptileReviewComment, sha string) bool {
+	head := strings.TrimSpace(sha)
+	if head == "" {
+		return true
+	}
+	original := strings.TrimSpace(comment.OriginalCommitID)
+	if original != "" {
+		return original == head
+	}
+	commit := strings.TrimSpace(comment.CommitID)
+	if commit == "" {
+		return true
+	}
+	return commit == head
 }
 
 // isHighSeverity checks if a review comment is P0 or P1 severity.
@@ -663,8 +680,8 @@ func (c *Client) CollectReviewFeedback(prNumber int) ([]ReviewComment, error) {
 		if !strings.Contains(login, "greptile") && !strings.Contains(login, "codex") {
 			continue
 		}
-		// Skip comments on older commits — they may already be fixed
-		if headSHA != "" && strings.TrimSpace(cm.CommitID) != "" && strings.TrimSpace(cm.CommitID) != headSHA {
+		// Skip comments that were originally left on older commits — they may already be fixed.
+		if !reviewCommentTargetsHead(cm, headSHA) {
 			continue
 		}
 		result = append(result, ReviewComment{

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -59,6 +59,7 @@ func TestHasGreptileInlineCommentOnHead(t *testing.T) {
 	makeComment := func(login, sha, body string) greptileReviewComment {
 		var c greptileReviewComment
 		c.CommitID = sha
+		c.OriginalCommitID = sha
 		c.User.Login = login
 		c.Body = body
 		return c
@@ -83,6 +84,14 @@ func TestHasGreptileInlineCommentOnHead(t *testing.T) {
 	// Comments on different SHA should not block
 	if hasGreptileInlineCommentOnHead(p0Comments, "different-sha") {
 		t.Fatal("did not expect greptile comment from another head to block")
+	}
+
+	// GitHub may report commit_id as the current head for outdated review
+	// comments, so original_commit_id is the safer source of truth.
+	outdatedComment := makeComment("greptile-apps[bot]", "head-sha", "![alt=\"P1\"] Old issue")
+	outdatedComment.CommitID = "new-head-sha"
+	if hasGreptileInlineCommentOnHead([]greptileReviewComment{outdatedComment}, "new-head-sha") {
+		t.Fatal("did not expect review comment originally left on an older commit to block")
 	}
 
 	if !isGreptileLogin("greptile-apps[bot]") {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -77,7 +77,7 @@ type Orchestrator struct {
 	ghCollectPRReviewFeedbackFn func(prNumber int) (string, error)
 	ghCloseIssueFn              func(number int, comment string) error
 	workerStopFn                func(cfg *config.Config, slotName string, sess *state.Session) error
-	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles []string) error
+	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
 }
 
 // New creates a new Orchestrator
@@ -223,9 +223,9 @@ func (o *Orchestrator) respawnInPlace(slotName string, sess *state.Session, issu
 
 func (o *Orchestrator) rebaseWorktree(worktreePath, branch string) error {
 	if o.rebaseWorktreeFn != nil {
-		return o.rebaseWorktreeFn(worktreePath, branch, o.cfg.AutoResolveFiles)
+		return o.rebaseWorktreeFn(worktreePath, branch, o.cfg.AutoResolveFiles, o.cfg.AutoRestoreFiles)
 	}
-	return worker.RebaseWorktree(worktreePath, branch, o.cfg.AutoResolveFiles)
+	return worker.RebaseWorktree(worktreePath, branch, o.cfg.AutoResolveFiles, o.cfg.AutoRestoreFiles)
 }
 
 func (o *Orchestrator) captureTmux(session string) (string, error) {
@@ -471,11 +471,11 @@ Focus on fixing the CI failures while still implementing the issue requirements.
 }
 
 // appendReviewFeedbackContext appends a section to the worker prompt with
-// Greptile code review findings from the previous failed attempt.
+// code review findings from the previous failed attempt.
 func appendReviewFeedbackContext(promptBase, feedback string) string {
 	return fmt.Sprintf(`%s
 
-### Code Review Findings (from Greptile)
+### Code Review Findings
 
 The following code review comments were left on the previous PR. Address ALL of these issues:
 
@@ -483,6 +483,26 @@ The following code review comments were left on the previous PR. Address ALL of 
 
 IMPORTANT: Address ALL code review findings above before creating a new PR.
 Do NOT repeat the same mistakes.
+`, promptBase, feedback)
+}
+
+// appendRebaseConflictContext appends a section to the worker prompt with
+// auto-rebase failure details so the retry worker can update the same PR branch.
+func appendRebaseConflictContext(promptBase, feedback string) string {
+	return fmt.Sprintf(`%s
+
+### Rebase Conflict
+
+Maestro tried to update the existing PR branch against origin/main, but git rebase hit conflicts.
+You are a retry worker running in the same worktree and branch.
+
+Resolve the conflicts, keep the PR focused on the original issue, run validation, commit the fix, and push to the existing PR branch.
+Do NOT open a second PR.
+
+Rebase failure details:
+`+"```"+`
+%s
+`+"```"+`
 `, promptBase, feedback)
 }
 
@@ -498,10 +518,40 @@ func (o *Orchestrator) canRetryIssue(s *state.State, sess *state.Session) bool {
 	return totalAttempts < maxRetries
 }
 
+func pendingRetryReservations(s *state.State) int {
+	count := 0
+	for _, sess := range s.Sessions {
+		if sess.Status == state.StatusDead && sess.NextRetryAt != nil {
+			count++
+		}
+	}
+	return count
+}
+
 // respawnDueRetries checks dead sessions with a scheduled retry time and
 // respawns them when the backoff period has elapsed.
-func (o *Orchestrator) respawnDueRetries(s *state.State) {
-	for slotName, sess := range s.Sessions {
+func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
+	if slots <= 0 {
+		if pending := pendingRetryReservations(s); pending > 0 {
+			log.Printf("[orch] retry queue has %d pending session(s), but no worker slots are available", pending)
+		}
+		return
+	}
+
+	slotNames := make([]string, 0, len(s.Sessions))
+	for slotName := range s.Sessions {
+		slotNames = append(slotNames, slotName)
+	}
+	sort.Strings(slotNames)
+
+	respawned := 0
+	for _, slotName := range slotNames {
+		if respawned >= slots {
+			log.Printf("[orch] retry queue still has pending session(s), but retry slots are exhausted")
+			return
+		}
+
+		sess := s.Sessions[slotName]
 		if sess.Status != state.StatusDead {
 			continue
 		}
@@ -538,22 +588,34 @@ func (o *Orchestrator) respawnDueRetries(s *state.State) {
 			sess.CIFailureOutput = "" // consumed — don't persist stale output
 		}
 		if sess.PreviousAttemptFeedback != "" {
-			promptBase = appendReviewFeedbackContext(promptBase, sess.PreviousAttemptFeedback)
+			if sess.PreviousAttemptFeedbackKind == "rebase_conflict" {
+				promptBase = appendRebaseConflictContext(promptBase, sess.PreviousAttemptFeedback)
+			} else {
+				promptBase = appendReviewFeedbackContext(promptBase, sess.PreviousAttemptFeedback)
+			}
 			sess.PreviousAttemptFeedback = "" // consumed — don't persist stale feedback
+			sess.PreviousAttemptFeedbackKind = ""
 		}
 
-		if err := o.respawnWorker(slotName, sess, issue, promptBase, sess.Backend); err != nil {
-			log.Printf("[orch] respawn worker %s: %v — marking as failed", slotName, err)
+		var respawnErr error
+		if sess.PRNumber != 0 && sess.Worktree != "" {
+			respawnErr = o.respawnInPlace(slotName, sess, issue, promptBase, sess.Backend)
+		} else {
+			respawnErr = o.respawnWorker(slotName, sess, issue, promptBase, sess.Backend)
+		}
+		if respawnErr != nil {
+			log.Printf("[orch] respawn worker %s: %v — marking as failed", slotName, respawnErr)
 			sess.Status = state.StatusFailed
 			now := time.Now().UTC()
 			sess.FinishedAt = &now
 			o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) respawn failed: %v",
-				slotName, sess.IssueNumber, sess.IssueTitle, err)
+				slotName, sess.IssueNumber, sess.IssueTitle, respawnErr)
 			continue
 		}
 
 		o.notifier.Sendf("🔄 maestro: retrying worker %s for issue #%d: %s (attempt %d)",
 			slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount)
+		respawned++
 	}
 }
 
@@ -635,7 +697,8 @@ func (o *Orchestrator) RunOnce() error {
 	o.checkSessions(s)
 
 	// Step 2b: Respawn dead sessions whose backoff has elapsed
-	o.respawnDueRetries(s)
+	retrySlots := availableSlots(o.cfg, s, len(s.ActiveSessions()))
+	o.respawnDueRetries(s, retrySlots)
 
 	// Step 3: Auto-merge green PRs
 	o.autoMergePRs(s)
@@ -661,6 +724,13 @@ func (o *Orchestrator) RunOnce() error {
 	// Step 5: Start new workers for available slots
 	active := len(s.ActiveSessions())
 	slots := availableSlots(o.cfg, s, active)
+	if reserved := pendingRetryReservations(s); reserved > 0 && slots > 0 {
+		if reserved > slots {
+			reserved = slots
+		}
+		slots -= reserved
+		log.Printf("[orch] reserving %d worker slot(s) for scheduled retries", reserved)
+	}
 	log.Printf("[orch] active=%d max=%d available_slots=%d", active, o.cfg.MaxParallel, slots)
 
 	if slots > 0 {
@@ -770,6 +840,14 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 	if newCfg.MergeIntervalSeconds != old.MergeIntervalSeconds {
 		changed = append(changed, fmt.Sprintf("merge_interval_seconds: %d→%d", old.MergeIntervalSeconds, newCfg.MergeIntervalSeconds))
 		o.cfg.MergeIntervalSeconds = newCfg.MergeIntervalSeconds
+	}
+	if newCfg.ReviewGate != old.ReviewGate {
+		changed = append(changed, fmt.Sprintf("review_gate: %s→%s", old.ReviewGate, newCfg.ReviewGate))
+		o.cfg.ReviewGate = newCfg.ReviewGate
+	}
+	if newCfg.AutoRetryReviewFeedback != old.AutoRetryReviewFeedback {
+		changed = append(changed, fmt.Sprintf("auto_retry_review_feedback: %v→%v", old.AutoRetryReviewFeedback, newCfg.AutoRetryReviewFeedback))
+		o.cfg.AutoRetryReviewFeedback = newCfg.AutoRetryReviewFeedback
 	}
 	if newCfg.DeployCmd != old.DeployCmd {
 		changed = append(changed, fmt.Sprintf("deploy_cmd: %q→%q", old.DeployCmd, newCfg.DeployCmd))
@@ -1076,12 +1154,18 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 			// Check if running session has opened a PR (worker still alive)
 			if pr, found := branchToPR[sess.Branch]; found {
-				log.Printf("[orch] worker %s opened PR #%d while still running — transitioning to pr_open", slotName, pr.Number)
-				sess.Status = state.StatusPROpen
-				sess.PRNumber = pr.Number
-				o.notifier.Sendf("🔀 maestro: worker %s opened PR #%d for issue #%d (%s)",
-					slotName, pr.Number, sess.IssueNumber, sess.IssueTitle)
-				continue
+				if sess.PRNumber == pr.Number {
+					// In-place review/CI retries intentionally keep working on an
+					// already-open PR. Do not transition back to pr_open until the
+					// worker exits, otherwise the fixer is interrupted mid-run.
+				} else {
+					log.Printf("[orch] worker %s opened PR #%d while still running — transitioning to pr_open", slotName, pr.Number)
+					sess.Status = state.StatusPROpen
+					sess.PRNumber = pr.Number
+					o.notifier.Sendf("🔀 maestro: worker %s opened PR #%d for issue #%d (%s)",
+						slotName, pr.Number, sess.IssueNumber, sess.IssueTitle)
+					continue
+				}
 			}
 
 			// Capture tmux pane output for token tracking, rate-limit detection,
@@ -1334,6 +1418,22 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			sess.LastNotifiedStatus = ""
 			sess.NotifiedCIFail = false // backward compat
 
+			if o.cfg.AutoRetryReviewFeedback {
+				reviewFeedback, err := o.collectPRReviewFeedback(pr.Number)
+				if err != nil {
+					log.Printf("[orch] warn: could not collect review feedback for PR #%d: %v", pr.Number, err)
+				} else if strings.TrimSpace(reviewFeedback) != "" {
+					log.Printf("[orch] PR #%d has review feedback; scheduling retry", pr.Number)
+					o.handleReviewFeedbackRetry(s, slotName, sess, pr, reviewFeedback)
+					continue
+				}
+			}
+
+			if o.reviewGate() == "none" {
+				ready = append(ready, mergeCandidate{slotName: slotName, sess: sess, pr: pr})
+				continue
+			}
+
 			greptileOK, greptilePending, err := o.prGreptileApproved(pr.Number)
 			if err != nil {
 				log.Printf("[orch] greptile check PR #%d: %v", pr.Number, err)
@@ -1404,6 +1504,60 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	}
 }
 
+// handleReviewFeedbackRetry schedules a retry worker with review feedback in
+// its prompt. When the PR worktree is still available, keep the PR open and
+// respawn in place so the fixer pushes updates to the same PR.
+func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string, sess *state.Session, pr github.PR, reviewFeedback string) {
+	maxRetries := o.cfg.MaxRetriesPerIssue
+	totalAttempts := s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount
+
+	if maxRetries > 0 && totalAttempts >= maxRetries {
+		log.Printf("[orch] review feedback on PR #%d — retry limit reached (%d/%d) for issue #%d",
+			pr.Number, totalAttempts, maxRetries, sess.IssueNumber)
+		s.MarkIssueRetryExhausted(sess.IssueNumber)
+		o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+		sess.Status = state.StatusRetryExhausted
+		sess.NextRetryAt = nil
+		sess.LastNotifiedStatus = "review_retry_exhausted"
+		now := time.Now().UTC()
+		sess.FinishedAt = &now
+		o.notifier.Sendf("💀 maestro: review feedback on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
+			pr.Number, sess.IssueNumber, sess.IssueTitle, totalAttempts)
+		return
+	}
+
+	if sess.Worktree == "" {
+		closeComment := fmt.Sprintf("Code review feedback detected, but the PR worktree is unavailable — maestro is closing this PR and respawning a worker to address it (attempt %d).\n\nReview feedback:\n\n%s",
+			sess.RetryCount+1, reviewFeedback)
+		if err := o.closePR(pr.Number, closeComment); err != nil {
+			log.Printf("[orch] warn: could not close PR #%d after review feedback: %v — skipping retry", pr.Number, err)
+			return
+		}
+		log.Printf("[orch] closed PR #%d due to review feedback (worktree unavailable)", pr.Number)
+		sess.PRNumber = 0
+	} else {
+		log.Printf("[orch] keeping PR #%d open and respawning %s in place to address review feedback", pr.Number, slotName)
+		sess.PRNumber = pr.Number
+	}
+
+	sess.CIFailureOutput = ""
+	sess.PreviousAttemptFeedback = reviewFeedback
+	sess.PreviousAttemptFeedbackKind = "review_feedback"
+
+	sess.RetryCount++
+	backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
+	retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
+	sess.NextRetryAt = &retryAt
+	sess.Status = state.StatusDead
+	now := time.Now().UTC()
+	sess.FinishedAt = &now
+
+	log.Printf("[orch] review feedback on PR #%d — scheduling retry %d in %dms for issue #%d",
+		pr.Number, sess.RetryCount, backoffMs, sess.IssueNumber)
+	o.notifier.Sendf("🔄 maestro: review feedback on PR #%d (issue #%d: %s), in-place retry %d scheduled in %ds",
+		pr.Number, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
+}
+
 // handleCIFailureRetry closes the failed PR, captures CI output, cleans up,
 // and schedules a retry for the worker (respecting max_retries_per_issue).
 func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, sess *state.Session, pr github.PR) {
@@ -1450,6 +1604,11 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 	// Store CI failure output and review feedback for the next worker
 	sess.CIFailureOutput = ciOutput
 	sess.PreviousAttemptFeedback = reviewFeedback
+	if strings.TrimSpace(reviewFeedback) != "" {
+		sess.PreviousAttemptFeedbackKind = "review_feedback"
+	} else {
+		sess.PreviousAttemptFeedbackKind = ""
+	}
 
 	// Schedule retry with exponential backoff
 	sess.RetryCount++
@@ -1465,6 +1624,15 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 		pr.Number, sess.RetryCount, backoffMs, sess.IssueNumber)
 	o.notifier.Sendf("🔄 maestro: CI failed on PR #%d (issue #%d: %s), retry %d scheduled in %ds",
 		pr.Number, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
+}
+
+func (o *Orchestrator) reviewGate() string {
+	switch strings.ToLower(strings.TrimSpace(o.cfg.ReviewGate)) {
+	case "none", "off", "disabled":
+		return "none"
+	default:
+		return "greptile"
+	}
 }
 
 func (o *Orchestrator) mergeStrategy() string {
@@ -1614,7 +1782,7 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 			log.Printf("[orch] PR #%d has conflicts, auto-rebasing %s", pr.Number, slotName)
 			if err := o.rebaseWorktree(sess.Worktree, sess.Branch); err != nil {
 				log.Printf("[orch] rebase failed for %s: %v", slotName, err)
-				o.markUnresolvableConflict(slotName, sess, pr.Number, err)
+				o.handleRebaseConflictRetry(s, slotName, sess, pr.Number, err)
 				continue
 			}
 			o.markRebaseQueued(slotName, sess, pr.Number)
@@ -1631,7 +1799,7 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 			log.Printf("[orch] retrying auto-rebase for conflict_failed session %s (PR #%d)", slotName, pr.Number)
 			if err := o.rebaseWorktree(sess.Worktree, sess.Branch); err != nil {
 				log.Printf("[orch] rebase retry failed for %s: %v", slotName, err)
-				o.markUnresolvableConflict(slotName, sess, pr.Number, err)
+				o.handleRebaseConflictRetry(s, slotName, sess, pr.Number, err)
 				continue
 			}
 			o.markRebaseQueued(slotName, sess, pr.Number)
@@ -1648,6 +1816,74 @@ func (o *Orchestrator) markRebaseQueued(slotName string, sess *state.Session, pr
 	sess.NotifiedCIFail = false
 	sess.LastNotifiedStatus = ""
 	o.notifier.Sendf("🔄 maestro: rebased %s (PR #%d) successfully; session moved to queued", slotName, prNumber)
+}
+
+func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string, sess *state.Session, prNumber int, cause error) {
+	if !o.cfg.AutoRetryReviewFeedback {
+		o.markUnresolvableConflict(slotName, sess, prNumber, cause)
+		return
+	}
+
+	maxRetries := o.cfg.MaxRetriesPerIssue
+	totalAttempts := s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount
+	if maxRetries > 0 && totalAttempts >= maxRetries {
+		log.Printf("[orch] rebase conflict on PR #%d — retry limit reached (%d/%d) for issue #%d",
+			prNumber, totalAttempts, maxRetries, sess.IssueNumber)
+		s.MarkIssueRetryExhausted(sess.IssueNumber)
+		o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+		sess.Status = state.StatusRetryExhausted
+		sess.NextRetryAt = nil
+		sess.LastNotifiedStatus = "rebase_conflict_retry_exhausted"
+		now := time.Now().UTC()
+		sess.FinishedAt = &now
+		o.notifier.Sendf("💀 maestro: rebase conflict on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
+			prNumber, sess.IssueNumber, sess.IssueTitle, totalAttempts)
+		return
+	}
+
+	if sess.Worktree == "" {
+		closeComment := fmt.Sprintf("Auto-rebase hit conflicts, but the PR worktree is unavailable — maestro is closing this PR and respawning a worker to resolve the conflict from a fresh branch (attempt %d).\n\nRebase failure:\n\n```\n%s\n```",
+			sess.RetryCount+1, rebaseConflictFeedback(prNumber, cause))
+		if err := o.closePR(prNumber, closeComment); err != nil {
+			log.Printf("[orch] warn: could not close PR #%d after rebase conflict: %v — marking conflict_failed", prNumber, err)
+			o.markUnresolvableConflict(slotName, sess, prNumber, cause)
+			return
+		}
+		log.Printf("[orch] closed PR #%d due to rebase conflict (worktree unavailable)", prNumber)
+		sess.PRNumber = 0
+	} else {
+		log.Printf("[orch] keeping PR #%d open and respawning %s in place to resolve rebase conflicts", prNumber, slotName)
+		sess.PRNumber = prNumber
+	}
+
+	sess.CIFailureOutput = ""
+	sess.PreviousAttemptFeedback = rebaseConflictFeedback(prNumber, cause)
+	sess.PreviousAttemptFeedbackKind = "rebase_conflict"
+
+	sess.RetryCount++
+	backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
+	retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
+	sess.NextRetryAt = &retryAt
+	sess.Status = state.StatusDead
+	sess.RebaseAttempted = true
+	now := time.Now().UTC()
+	sess.FinishedAt = &now
+
+	log.Printf("[orch] rebase conflict on PR #%d — scheduling retry %d in %dms for issue #%d",
+		prNumber, sess.RetryCount, backoffMs, sess.IssueNumber)
+	o.notifier.Sendf("🔄 maestro: rebase conflict on PR #%d (issue #%d: %s), in-place retry %d scheduled in %ds",
+		prNumber, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
+}
+
+func rebaseConflictFeedback(prNumber int, cause error) string {
+	msg := "(rebase failure unavailable)"
+	if cause != nil {
+		msg = strings.TrimSpace(cause.Error())
+	}
+	if len(msg) > 8000 {
+		msg = msg[:8000] + "\n... (truncated)"
+	}
+	return fmt.Sprintf("PR #%d failed to rebase onto origin/main.\n\n%s", prNumber, msg)
 }
 
 func (o *Orchestrator) markUnresolvableConflict(slotName string, sess *state.Session, prNumber int, cause error) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1984,6 +1984,16 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if s.IssueInProgress(issue.Number) {
 			continue
 		}
+		if s.IssueDone(issue.Number) {
+			closed, err := o.isIssueClosed(issue.Number)
+			if err != nil {
+				log.Printf("[orch] warn: could not verify closed issue #%d before dispatch: %v", issue.Number, err)
+			} else if closed {
+				log.Printf("[orch] skipping issue #%d: already closed with completed session", issue.Number)
+				o.syncProject(issue.Number, github.ProjectStatusDone)
+				continue
+			}
+		}
 
 		// Skip mission parent issues — they are decomposed, not dispatched directly
 		if s.IsMissionParent(issue.Number) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2469,6 +2469,9 @@ func newStartWorkersOrchestrator(cfg *config.Config, issues []github.Issue) (*Or
 		hasOpenPRForIssueFn: func(issueNumber int) (bool, error) {
 			return false, nil
 		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
 		addIssueLabelFn: func(number int, label string) error {
 			labels = append(labels, fmt.Sprintf("#%d:%s", number, label))
 			return nil
@@ -2488,6 +2491,29 @@ func newStartWorkersOrchestrator(cfg *config.Config, issues []github.Issue) (*Or
 			return slotName, nil
 		},
 	}, &started, &labels
+}
+
+func TestStartNewWorkers_SkipsClosedIssueWithDoneSession(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	issues := []github.Issue{
+		makeIssue(283, "already merged issue"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.isIssueClosedFn = func(issueNumber int) (bool, error) {
+		return issueNumber == 283, nil
+	}
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 283,
+		Status:      state.StatusDone,
+	}
+
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 0 {
+		t.Fatalf("started %d workers, want 0 for already closed issue", len(*started))
+	}
 }
 
 func TestStartNewWorkers_SkipsRetryExhaustedIssue(t *testing.T) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1002,6 +1002,196 @@ func TestAutoMergePRs_QueuedSessionsAreEligible(t *testing.T) {
 	}
 }
 
+func TestAutoMergePRs_ReviewGateNoneSkipsGreptileWait(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none"}
+	merged := make([]int, 0)
+	greptileChecks := 0
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghPRGreptileApprovedFn: func(prNumber int) (bool, bool, error) {
+			greptileChecks++
+			return false, true, nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = append(merged, prNumber)
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if greptileChecks != 0 {
+		t.Fatalf("greptile gate should not be checked when review_gate=none, got %d checks", greptileChecks)
+	}
+	if len(merged) != 1 || merged[0] != 10 {
+		t.Fatalf("merged = %v, want [10]", merged)
+	}
+}
+
+func TestAutoMergePRs_ReviewFeedbackKeepsPROpenAndSchedulesInPlaceRetry(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "parallel",
+		ReviewGate:              "none",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	merged := make([]int, 0)
+	closedPRs := make([]int, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
+		},
+		ghClosePRFn: func(prNumber int, comment string) error {
+			closedPRs = append(closedPRs, prNumber)
+			return nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = append(merged, prNumber)
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+	s := makeTestState(prs)
+	s.Sessions["slot-0"].Worktree = "/tmp/maestro-slot-0"
+
+	o.autoMergePRs(s)
+
+	if len(merged) != 0 {
+		t.Fatalf("expected review feedback to block merge, got merged=%v", merged)
+	}
+	if len(closedPRs) != 0 {
+		t.Fatalf("closedPRs = %v, want none", closedPRs)
+	}
+	sess := s.Sessions["slot-0"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set")
+	}
+	if sess.PreviousAttemptFeedback == "" {
+		t.Fatal("PreviousAttemptFeedback should be set")
+	}
+	if sess.PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want 10", sess.PRNumber)
+	}
+	if sess.Worktree == "" {
+		t.Fatal("Worktree should be preserved for in-place retry")
+	}
+}
+
+func TestAutoMergePRs_ReviewFeedbackFallsBackToCloseWhenWorktreeMissing(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "parallel",
+		ReviewGate:              "none",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	closedPRs := make([]int, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
+		},
+		ghClosePRFn: func(prNumber int, comment string) error {
+			closedPRs = append(closedPRs, prNumber)
+			return nil
+		},
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(closedPRs) != 1 || closedPRs[0] != 10 {
+		t.Fatalf("closedPRs = %v, want [10]", closedPRs)
+	}
+	if s.Sessions["slot-0"].PRNumber != 0 {
+		t.Fatalf("PRNumber = %d, want 0 after close fallback", s.Sessions["slot-0"].PRNumber)
+	}
+}
+
+func TestAutoMergePRs_ReviewFeedbackRetryLimitMarksTerminal(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "parallel",
+		ReviewGate:              "none",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
+		},
+	}
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.Worktree = "/tmp/maestro-slot-0"
+	sess.RetryCount = 3
+
+	o.autoMergePRs(s)
+
+	if sess.Status != state.StatusRetryExhausted {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRetryExhausted)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt should be nil after retry exhaustion")
+	}
+	if sess.LastNotifiedStatus != "review_retry_exhausted" {
+		t.Fatalf("LastNotifiedStatus = %q, want review_retry_exhausted", sess.LastNotifiedStatus)
+	}
+}
+
 func TestAutoMergePRs_CIFailureBlocksMerge(t *testing.T) {
 	prs := []github.PR{
 		{Number: 10, HeadRefName: "feat/a"},
@@ -1240,6 +1430,50 @@ func TestCheckSessions_TokensBelowLimit_WorkerSurvives(t *testing.T) {
 	}
 	if len(*stopped) != 0 {
 		t.Fatalf("stopped = %v, want empty", *stopped)
+	}
+}
+
+func TestCheckSessions_RunningInPlaceRetryKeepsWorkerRunning(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{{Number: 10, HeadRefName: "feat/existing"}}, nil
+		},
+		isIssueClosedFn: func(number int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return true
+		},
+		tmuxCaptureFn: func(session string) (string, error) {
+			return "worker still fixing review comments", nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "review retry",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-slot-0",
+		Branch:      "feat/existing",
+		PRNumber:    10,
+		StartedAt:   time.Now().Add(-1 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["slot-0"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+	if sess.PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want 10", sess.PRNumber)
 	}
 }
 
@@ -1506,7 +1740,7 @@ func TestMergeReadyPR_BehindMainTriggersRebase(t *testing.T) {
 		ghMergePRFn: func(prNumber int) error {
 			return fmt.Errorf("gh pr merge 10: the head branch is not up to date with the base branch")
 		},
-		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
 			rebased = true
 			return nil
 		},
@@ -1546,7 +1780,7 @@ func TestMergeReadyPR_BehindMainRebaseFailsMarksConflict(t *testing.T) {
 		ghMergePRFn: func(prNumber int) error {
 			return fmt.Errorf("gh pr merge 10: the head branch is not up to date with the base branch")
 		},
-		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
 			return fmt.Errorf("rebase failed: conflict in main.go")
 		},
 	}
@@ -1577,6 +1811,51 @@ func TestMergeReadyPR_BehindMainRebaseFailsMarksConflict(t *testing.T) {
 	}
 }
 
+func TestHandleRebaseConflictRetry_SchedulesInPlaceRetry(t *testing.T) {
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	o := &Orchestrator{cfg: cfg, notifier: &notify.Notifier{}}
+	s := state.NewState()
+	sess := &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "docs refresh",
+		Branch:      "feat/docs",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+		Backend:     "claude",
+	}
+	s.Sessions["slot-0"] = sess
+
+	o.handleRebaseConflictRetry(s, "slot-0", sess, 10, fmt.Errorf("CONFLICT (content): docs/FEATURES.md"))
+
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want 10", sess.PRNumber)
+	}
+	if sess.RetryCount != 1 {
+		t.Fatalf("RetryCount = %d, want 1", sess.RetryCount)
+	}
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set")
+	}
+	if !sess.RebaseAttempted {
+		t.Fatal("RebaseAttempted should be true")
+	}
+	if sess.PreviousAttemptFeedbackKind != "rebase_conflict" {
+		t.Fatalf("PreviousAttemptFeedbackKind = %q, want rebase_conflict", sess.PreviousAttemptFeedbackKind)
+	}
+	if !strings.Contains(sess.PreviousAttemptFeedback, "docs/FEATURES.md") {
+		t.Fatalf("PreviousAttemptFeedback should include conflict details, got %q", sess.PreviousAttemptFeedback)
+	}
+}
+
 func TestMergeReadyPR_BehindMainNoAutoRebase(t *testing.T) {
 	rebased := false
 	o := &Orchestrator{
@@ -1585,7 +1864,7 @@ func TestMergeReadyPR_BehindMainNoAutoRebase(t *testing.T) {
 		ghMergePRFn: func(prNumber int) error {
 			return fmt.Errorf("gh pr merge 10: the head branch is not up to date with the base branch")
 		},
-		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
 			rebased = true
 			return nil
 		},
@@ -1622,7 +1901,7 @@ func TestMergeReadyPR_OtherMergeErrorNoRebase(t *testing.T) {
 		ghMergePRFn: func(prNumber int) error {
 			return fmt.Errorf("gh pr merge 10: some other error")
 		},
-		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles []string) error {
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
 			rebased = true
 			return nil
 		},
@@ -3400,6 +3679,20 @@ func TestAvailableSlots_NonRunningLimitIgnoredForDispatch(t *testing.T) {
 	}
 }
 
+func TestPendingRetryReservations_CountsOnlyScheduledDeadRetries(t *testing.T) {
+	now := time.Now().UTC()
+	s := state.NewState()
+	s.Sessions["retry-due"] = &state.Session{Status: state.StatusDead, NextRetryAt: &now}
+	s.Sessions["retry-waiting"] = &state.Session{Status: state.StatusDead, NextRetryAt: &now}
+	s.Sessions["plain-dead"] = &state.Session{Status: state.StatusDead}
+	s.Sessions["running-with-retry"] = &state.Session{Status: state.StatusRunning, NextRetryAt: &now}
+
+	got := pendingRetryReservations(s)
+	if got != 2 {
+		t.Fatalf("pendingRetryReservations() = %d, want 2", got)
+	}
+}
+
 // --- blocker-aware dispatch tests ---
 
 func TestFindOpenBlockers_AllClosed(t *testing.T) {
@@ -3920,7 +4213,7 @@ func TestRespawnDueRetries_BackoffElapsed_Respawns(t *testing.T) {
 		Branch:      "feat/mae-12-112-test",
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if !respawned {
 		t.Fatal("expected worker to be respawned after backoff elapsed")
@@ -3931,6 +4224,120 @@ func TestRespawnDueRetries_BackoffElapsed_Respawns(t *testing.T) {
 	}
 	if sess.Status != state.StatusRunning {
 		t.Errorf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+}
+
+func TestRespawnDueRetries_RespectsAvailableSlots(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRetryBackoffMs: 300000,
+		MaxRuntimeMinutes: 999,
+	}
+	respawned := make([]string, 0)
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "test prompt",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return makeIssue(number, "test issue"), nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawned = append(respawned, slotName)
+			sess.Status = state.StatusRunning
+			sess.PID = 5555
+			return nil
+		},
+	}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	s := state.NewState()
+	s.Sessions["mae-12"] = &state.Session{
+		IssueNumber: 112,
+		IssueTitle:  "first retry",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/mae-12-112-test",
+	}
+	s.Sessions["mae-13"] = &state.Session{
+		IssueNumber: 113,
+		IssueTitle:  "second retry",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/mae-13-113-test",
+	}
+
+	o.respawnDueRetries(s, 1)
+
+	if len(respawned) != 1 {
+		t.Fatalf("respawned %d workers, want 1", len(respawned))
+	}
+	if s.Sessions["mae-12"].Status != state.StatusRunning {
+		t.Fatalf("mae-12 status = %q, want %q", s.Sessions["mae-12"].Status, state.StatusRunning)
+	}
+	if s.Sessions["mae-13"].Status != state.StatusDead {
+		t.Fatalf("mae-13 status = %q, want %q", s.Sessions["mae-13"].Status, state.StatusDead)
+	}
+	if s.Sessions["mae-13"].NextRetryAt == nil {
+		t.Fatal("mae-13 NextRetryAt should remain set when no retry slot is available")
+	}
+}
+
+func TestRespawnDueRetries_WithOpenPRRespawnsInPlace(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRetryBackoffMs: 300000,
+		MaxRuntimeMinutes: 999,
+	}
+	respawnedFresh := false
+	respawnedInPlace := false
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "test prompt",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return makeIssue(number, "test issue"), nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawnedFresh = true
+			return nil
+		},
+		respawnInPlaceFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawnedInPlace = true
+			sess.Status = state.StatusRunning
+			sess.PID = 5555
+			return nil
+		},
+	}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	s := state.NewState()
+	s.Sessions["mae-12"] = &state.Session{
+		IssueNumber:             112,
+		IssueTitle:              "review retry",
+		Status:                  state.StatusDead,
+		RetryCount:              1,
+		NextRetryAt:             &pastTime,
+		Branch:                  "feat/mae-12-112-test",
+		Worktree:                "/tmp/maestro-mae-12",
+		PRNumber:                10,
+		PreviousAttemptFeedback: "review feedback",
+	}
+
+	o.respawnDueRetries(s, 1)
+
+	if !respawnedInPlace {
+		t.Fatal("expected in-place respawn for retry with open PR and worktree")
+	}
+	if respawnedFresh {
+		t.Fatal("fresh respawn should not be used for retry with open PR and worktree")
+	}
+	if s.Sessions["mae-12"].PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want 10", s.Sessions["mae-12"].PRNumber)
+	}
+	if s.Sessions["mae-12"].PreviousAttemptFeedback != "" {
+		t.Fatal("PreviousAttemptFeedback should be consumed before respawn")
 	}
 }
 
@@ -3960,7 +4367,7 @@ func TestRespawnDueRetries_BackoffNotElapsed_Waits(t *testing.T) {
 		Branch:      "feat/mae-13-113-test",
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if respawned {
 		t.Fatal("worker should NOT be respawned while backoff is still pending")
@@ -4001,7 +4408,7 @@ func TestRespawnDueRetries_RespawnFails_MarksAsFailed(t *testing.T) {
 		Branch:      "feat/mae-14-114-test",
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	sess := s.Sessions["mae-14"]
 	if sess.Status != state.StatusFailed {
@@ -4440,7 +4847,7 @@ func TestRespawnDueRetries_CIFailureContext_IncludedInPrompt(t *testing.T) {
 		CIFailureOutput: "tests failed: FAIL main_test.go:15",
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if respawnedPrompt == "" {
 		t.Fatal("respawnWorkerFn should have been called")
@@ -4496,7 +4903,7 @@ func TestRespawnDueRetries_NoCIContext_NormalPrompt(t *testing.T) {
 		// No CIFailureOutput — normal dead worker retry
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if respawnedPrompt == "" {
 		t.Fatal("respawnWorkerFn should have been called")
@@ -4758,7 +5165,7 @@ func TestAppendReviewFeedbackContext_AddsSection(t *testing.T) {
 	if !strings.Contains(result, "You are a coding agent.") {
 		t.Error("result should contain original prompt base")
 	}
-	if !strings.Contains(result, "Code Review Findings (from Greptile)") {
+	if !strings.Contains(result, "Code Review Findings") {
 		t.Error("result should contain review feedback header")
 	}
 	if !strings.Contains(result, "enabled flag logic inverted") {
@@ -4819,7 +5226,7 @@ func TestRespawnDueRetries_ReviewFeedback_IncludedInPrompt(t *testing.T) {
 		PreviousAttemptFeedback: "Confidence 3/5\nP2: enabled flag inverted in bridge.rs",
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if respawnedPrompt == "" {
 		t.Fatal("respawnWorkerFn should have been called")
@@ -4827,11 +5234,11 @@ func TestRespawnDueRetries_ReviewFeedback_IncludedInPrompt(t *testing.T) {
 	if !strings.Contains(respawnedPrompt, "Previous CI Failure") {
 		t.Error("prompt should contain CI failure context")
 	}
-	if !strings.Contains(respawnedPrompt, "Code Review Findings (from Greptile)") {
+	if !strings.Contains(respawnedPrompt, "Code Review Findings") {
 		t.Error("prompt should contain review feedback section")
 	}
 	if !strings.Contains(respawnedPrompt, "enabled flag inverted") {
-		t.Error("prompt should contain actual Greptile feedback")
+		t.Error("prompt should contain actual review feedback")
 	}
 	if !strings.Contains(respawnedPrompt, "IMPORTANT: Address ALL code review findings") {
 		t.Error("prompt should contain instruction to fix review findings")
@@ -4844,6 +5251,69 @@ func TestRespawnDueRetries_ReviewFeedback_IncludedInPrompt(t *testing.T) {
 	}
 	if sess.PreviousAttemptFeedback != "" {
 		t.Errorf("PreviousAttemptFeedback should be cleared, got %q", sess.PreviousAttemptFeedback)
+	}
+}
+
+func TestRespawnDueRetries_RebaseConflict_IncludedInPrompt(t *testing.T) {
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRetriesPerIssue: 3,
+		MaxRetryBackoffMs:  300000,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	respawnedPrompt := ""
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "base prompt {{ISSUE_NUMBER}}",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: 42, Title: "test issue", Body: "fix this"}, nil
+		},
+		respawnInPlaceFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedPrompt = promptBase
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:                 42,
+		IssueTitle:                  "test issue",
+		Status:                      state.StatusDead,
+		RetryCount:                  1,
+		NextRetryAt:                 &retryAt,
+		Backend:                     "claude",
+		PRNumber:                    10,
+		Worktree:                    "/tmp/wt",
+		PreviousAttemptFeedback:     "CONFLICT (content): docs/FEATURES.md",
+		PreviousAttemptFeedbackKind: "rebase_conflict",
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if respawnedPrompt == "" {
+		t.Fatal("respawnInPlaceFn should have been called")
+	}
+	if !strings.Contains(respawnedPrompt, "Rebase Conflict") {
+		t.Error("prompt should contain rebase conflict section")
+	}
+	if !strings.Contains(respawnedPrompt, "docs/FEATURES.md") {
+		t.Error("prompt should contain conflict details")
+	}
+	if strings.Contains(respawnedPrompt, "Code Review Findings") {
+		t.Error("rebase conflict prompt should not be framed as review feedback")
+	}
+	sess := s.Sessions["slot-1"]
+	if sess.PreviousAttemptFeedback != "" {
+		t.Errorf("PreviousAttemptFeedback should be cleared, got %q", sess.PreviousAttemptFeedback)
+	}
+	if sess.PreviousAttemptFeedbackKind != "" {
+		t.Errorf("PreviousAttemptFeedbackKind should be cleared, got %q", sess.PreviousAttemptFeedbackKind)
 	}
 }
 
@@ -4885,7 +5355,7 @@ func TestRespawnDueRetries_NoReviewFeedback_OmitsSection(t *testing.T) {
 		PreviousAttemptFeedback: "", // no Greptile feedback
 	}
 
-	o.respawnDueRetries(s)
+	o.respawnDueRetries(s, 10)
 
 	if respawnedPrompt == "" {
 		t.Fatal("respawnWorkerFn should have been called")
@@ -4902,7 +5372,7 @@ func TestAutoMergePRs_CIFailure_CollectsReviewFeedback(t *testing.T) {
 	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000}
 	o, _, _ := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{10: "failure"})
 
-	// Override with Greptile feedback
+	// Override with review feedback
 	o.ghCollectPRReviewFeedbackFn = func(prNumber int) (string, error) {
 		return "Confidence 3/5 — Not safe to merge\nP2: null dereference on pool.interface", nil
 	}
@@ -4912,10 +5382,10 @@ func TestAutoMergePRs_CIFailure_CollectsReviewFeedback(t *testing.T) {
 
 	sess := s.Sessions["slot-0"]
 	if sess.PreviousAttemptFeedback == "" {
-		t.Fatal("PreviousAttemptFeedback should be set after CI failure with Greptile feedback")
+		t.Fatal("PreviousAttemptFeedback should be set after CI failure with review feedback")
 	}
 	if !strings.Contains(sess.PreviousAttemptFeedback, "null dereference") {
-		t.Errorf("PreviousAttemptFeedback should contain Greptile feedback, got %q", sess.PreviousAttemptFeedback)
+		t.Errorf("PreviousAttemptFeedback should contain review feedback, got %q", sess.PreviousAttemptFeedback)
 	}
 }
 
@@ -4926,7 +5396,7 @@ func TestAutoMergePRs_CIFailure_NoGreptileFeedback_FeedbackEmpty(t *testing.T) {
 	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000}
 	o, _, _ := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{10: "failure"})
 
-	// No Greptile feedback (returns empty)
+	// No review feedback (returns empty)
 	o.ghCollectPRReviewFeedbackFn = func(prNumber int) (string, error) {
 		return "", nil
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"net"
 	"net/http"
+	"os"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -40,11 +45,16 @@ func (s *Server) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/state", s.handleState)
 	mux.HandleFunc("/api/v1/workers", s.handleWorkers)
+	mux.HandleFunc("/api/v1/logs/", s.handleLog)
 	mux.HandleFunc("/api/v1/refresh", s.handleRefresh)
 	mux.HandleFunc("/api/v1/", s.handleIssue)
 	mux.HandleFunc("/", s.handleDashboard)
 
-	addr := fmt.Sprintf(":%d", s.cfg.Server.Port)
+	host := strings.TrimSpace(s.cfg.Server.Host)
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	addr := net.JoinHostPort(host, strconv.Itoa(s.cfg.Server.Port))
 	s.srv = &http.Server{
 		Addr:         addr,
 		Handler:      mux,
@@ -86,6 +96,8 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 type stateResponse struct {
 	Repo        string          `json:"repo"`
 	MaxParallel int             `json:"max_parallel"`
+	ReadOnly    bool            `json:"read_only"`
+	All         []sessionInfo   `json:"all"`
 	Running     []sessionInfo   `json:"running"`
 	PROpen      []sessionInfo   `json:"pr_open"`
 	Queued      []sessionInfo   `json:"queued"`
@@ -102,35 +114,48 @@ type sessionInfo struct {
 	Slot              string `json:"slot"`
 	IssueNumber       int    `json:"issue_number"`
 	IssueTitle        string `json:"issue_title"`
+	IssueURL          string `json:"issue_url,omitempty"`
 	Status            string `json:"status"`
+	StatusReason      string `json:"status_reason,omitempty"`
+	NeedsAttention    bool   `json:"needs_attention,omitempty"`
 	Backend           string `json:"backend,omitempty"`
 	PRNumber          int    `json:"pr_number,omitempty"`
+	PRURL             string `json:"pr_url,omitempty"`
 	TokensUsedAttempt int    `json:"tokens_used_attempt"`
 	TokensUsedTotal   int    `json:"tokens_used_total"`
 	Runtime           string `json:"runtime"`
 	StartedAt         string `json:"started_at"`
 	FinishedAt        string `json:"finished_at,omitempty"`
+	NextRetryAt       string `json:"next_retry_at,omitempty"`
 	PID               int    `json:"pid,omitempty"`
 	Alive             *bool  `json:"alive,omitempty"`
 	Worktree          string `json:"worktree,omitempty"`
 	Branch            string `json:"branch,omitempty"`
+	TmuxSession       string `json:"tmux_session,omitempty"`
+	HasLog            bool   `json:"has_log"`
 	RetryCount        int    `json:"retry_count,omitempty"`
+	LastNotification  string `json:"last_notification,omitempty"`
 }
 
-func makeSessionInfo(slot string, sess *state.Session) sessionInfo {
+func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 	info := sessionInfo{
 		Slot:              slot,
 		IssueNumber:       sess.IssueNumber,
 		IssueTitle:        sess.IssueTitle,
+		IssueURL:          githubIssueURL(repo, sess.IssueNumber),
 		Status:            string(sess.Status),
 		Backend:           sess.Backend,
 		PRNumber:          sess.PRNumber,
+		PRURL:             githubPRURL(repo, sess.PRNumber),
 		TokensUsedAttempt: sess.TokensUsedAttempt,
 		TokensUsedTotal:   sess.TokensUsedTotal,
 		StartedAt:         sess.StartedAt.Format(time.RFC3339),
 		Worktree:          sess.Worktree,
 		Branch:            sess.Branch,
+		TmuxSession:       watchSessionName(slot, sess),
+		HasLog:            strings.TrimSpace(sess.LogFile) != "",
 		RetryCount:        sess.RetryCount,
+		LastNotification:  sess.LastNotifiedStatus,
 	}
 
 	// Calculate runtime
@@ -146,8 +171,97 @@ func makeSessionInfo(slot string, sess *state.Session) sessionInfo {
 		alive := worker.IsAlive(sess.PID)
 		info.Alive = &alive
 	}
+	if sess.NextRetryAt != nil {
+		info.NextRetryAt = sess.NextRetryAt.Format(time.RFC3339)
+	}
+	info.StatusReason, info.NeedsAttention = sessionStatusReason(sess, info.Alive)
 
 	return info
+}
+
+func githubIssueURL(repo string, issueNumber int) string {
+	if issueNumber <= 0 || !validGitHubRepo(repo) {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/%s/issues/%d", strings.TrimSpace(repo), issueNumber)
+}
+
+func githubPRURL(repo string, prNumber int) string {
+	if prNumber <= 0 || !validGitHubRepo(repo) {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/%s/pull/%d", strings.TrimSpace(repo), prNumber)
+}
+
+func validGitHubRepo(repo string) bool {
+	repo = strings.TrimSpace(repo)
+	parts := strings.Split(repo, "/")
+	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
+}
+
+func sessionStatusReason(sess *state.Session, alive *bool) (string, bool) {
+	switch sess.Status {
+	case state.StatusRunning:
+		if alive != nil && !*alive {
+			return "State says running, but the worker PID is not alive. Maestro should reconcile it on the next cycle.", true
+		}
+		if sess.PID == 0 {
+			return "Worker is marked running, but no PID is recorded.", true
+		}
+		return "Worker process is alive and writing to its session log.", false
+	case state.StatusPROpen:
+		if sess.PRNumber > 0 {
+			return "PR is open; Maestro is waiting for CI, review gate, merge interval, or conflict handling.", false
+		}
+		return "Session is waiting on an open PR, but no PR number is recorded yet.", true
+	case state.StatusQueued:
+		return "Worker is queued for follow-up processing before it can be merged.", false
+	case state.StatusDead:
+		if sess.NextRetryAt != nil {
+			return "Worker exited; a retry is scheduled after the current backoff.", true
+		}
+		return "Worker exited and is waiting for retry or reconciliation.", true
+	case state.StatusRetryExhausted:
+		if sess.PRNumber > 0 {
+			return "Retry limit exhausted with a PR still open; inspect review feedback or increase the retry budget.", true
+		}
+		return "Retry limit exhausted before a usable PR was produced.", true
+	case state.StatusFailed:
+		return "Worker failed after the configured retry policy.", true
+	case state.StatusConflictFailed:
+		return "Automatic conflict resolution failed; the branch needs manual rebase/conflict handling.", true
+	case state.StatusDone:
+		return "Issue is complete; PR merged or issue was closed and the session is terminal.", false
+	default:
+		return "Session is waiting for the next Maestro reconciliation cycle.", false
+	}
+}
+
+func watchSessionName(slot string, sess *state.Session) string {
+	if strings.TrimSpace(sess.TmuxSession) != "" {
+		return sess.TmuxSession
+	}
+	return worker.TmuxSessionName(slot)
+}
+
+func allSessionInfos(repo string, st *state.State) []sessionInfo {
+	infos := make([]sessionInfo, 0, len(st.Sessions))
+	for slot, sess := range st.Sessions {
+		infos = append(infos, makeSessionInfo(repo, slot, sess))
+	}
+	sort.Slice(infos, func(i, j int) bool {
+		left, right := infos[i], infos[j]
+		li := state.StatusPriority(state.SessionStatus(left.Status))
+		ri := state.StatusPriority(state.SessionStatus(right.Status))
+		if li != ri {
+			return li < ri
+		}
+		if left.StartedAt != right.StartedAt {
+			return left.StartedAt > right.StartedAt
+		}
+		return left.Slot < right.Slot
+	})
+	return infos
 }
 
 func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
@@ -165,6 +279,8 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 	resp := stateResponse{
 		Repo:        s.cfg.Repo,
 		MaxParallel: s.cfg.MaxParallel,
+		ReadOnly:    s.cfg.Server.ReadOnly,
+		All:         make([]sessionInfo, 0, len(st.Sessions)),
 		Running:     make([]sessionInfo, 0),
 		PROpen:      make([]sessionInfo, 0),
 		Queued:      make([]sessionInfo, 0),
@@ -172,18 +288,18 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var activeTokens, totalTokens int
-	for slot, sess := range st.Sessions {
-		info := makeSessionInfo(slot, sess)
-		resp.Summary[string(sess.Status)]++
-		totalTokens += sess.TokensUsedTotal
+	for _, info := range allSessionInfos(s.cfg.Repo, st) {
+		resp.All = append(resp.All, info)
+		resp.Summary[info.Status]++
+		totalTokens += info.TokensUsedTotal
 
-		switch sess.Status {
+		switch state.SessionStatus(info.Status) {
 		case state.StatusRunning:
 			resp.Running = append(resp.Running, info)
-			activeTokens += sess.TokensUsedTotal
+			activeTokens += info.TokensUsedTotal
 		case state.StatusPROpen:
 			resp.PROpen = append(resp.PROpen, info)
-			activeTokens += sess.TokensUsedTotal
+			activeTokens += info.TokensUsedTotal
 		case state.StatusQueued:
 			resp.Queued = append(resp.Queued, info)
 		}
@@ -209,10 +325,7 @@ func (s *Server) handleWorkers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	workers := make([]sessionInfo, 0, len(st.Sessions))
-	for slot, sess := range st.Sessions {
-		workers = append(workers, makeSessionInfo(slot, sess))
-	}
+	workers := allSessionInfos(s.cfg.Repo, st)
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"workers": workers,
@@ -259,7 +372,7 @@ func (s *Server) handleIssue(w http.ResponseWriter, r *http.Request) {
 
 	for slot, sess := range st.Sessions {
 		if sess.IssueNumber == issueNum {
-			resp.Sessions = append(resp.Sessions, makeSessionInfo(slot, sess))
+			resp.Sessions = append(resp.Sessions, makeSessionInfo(s.cfg.Repo, slot, sess))
 		}
 	}
 
@@ -271,9 +384,131 @@ func (s *Server) handleIssue(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+type logResponse struct {
+	Slot      string `json:"slot"`
+	Lines     int    `json:"lines"`
+	Truncated bool   `json:"truncated"`
+	Text      string `json:"text"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+
+func (s *Server) handleLog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	slot := strings.TrimPrefix(r.URL.Path, "/api/v1/logs/")
+	slot = strings.Trim(slot, "/")
+	if slot == "" || strings.Contains(slot, "/") {
+		writeError(w, http.StatusBadRequest, "slot required")
+		return
+	}
+
+	st, err := s.loadState()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load state: %v", err))
+		return
+	}
+	sess, ok := st.Sessions[slot]
+	if !ok {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("session %q not found", slot))
+		return
+	}
+	if strings.TrimSpace(sess.LogFile) == "" {
+		writeJSON(w, http.StatusOK, logResponse{
+			Slot:      slot,
+			Lines:     0,
+			Text:      "",
+			UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+		})
+		return
+	}
+
+	lines := parsePositiveInt(r.URL.Query().Get("lines"), 240)
+	if lines > 1000 {
+		lines = 1000
+	}
+	text, truncated, err := tailFile(sess.LogFile, lines, 512*1024)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("read log: %v", err))
+		return
+	}
+	text = stripANSI(text)
+	writeJSON(w, http.StatusOK, logResponse{
+		Slot:      slot,
+		Lines:     lines,
+		Truncated: truncated,
+		Text:      text,
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func stripANSI(text string) string {
+	return ansiEscapeRE.ReplaceAllString(text, "")
+}
+
+func parsePositiveInt(raw string, fallback int) int {
+	if strings.TrimSpace(raw) == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return fallback
+	}
+	return n
+}
+
+func tailFile(path string, maxLines int, maxBytes int64) (string, bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return "", false, err
+	}
+	start := int64(0)
+	truncated := false
+	if info.Size() > maxBytes {
+		start = info.Size() - maxBytes
+		truncated = true
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return "", false, err
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return "", false, err
+	}
+	text := string(data)
+	if truncated {
+		if idx := strings.IndexByte(text, '\n'); idx >= 0 {
+			text = text[idx+1:]
+		}
+	}
+	lines := strings.Split(text, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if maxLines > 0 && len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+		truncated = true
+	}
+	return strings.Join(lines, "\n"), truncated, nil
+}
+
 func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if s.cfg.Server.ReadOnly {
+		writeError(w, http.StatusForbidden, "server is read-only")
 		return
 	}
 
@@ -291,61 +526,492 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	st, err := s.loadState()
+	repo, err := json.Marshal(s.cfg.Repo)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("load state: %v", err), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("marshal repo: %v", err), http.StatusInternalServerError)
 		return
 	}
-
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, `<!DOCTYPE html>
+	page := strings.ReplaceAll(dashboardHTML, "__REPO_JSON__", string(repo))
+	fmt.Fprint(w, page)
+}
+
+const dashboardHTML = `<!DOCTYPE html>
 <html>
 <head>
-<title>maestro — %s</title>
-<meta http-equiv="refresh" content="10">
+<title>maestro</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
-  body { font-family: monospace; background: #1a1a2e; color: #e0e0e0; margin: 2em; }
-  h1 { color: #00d4ff; }
-  table { border-collapse: collapse; width: 100%%; margin-top: 1em; }
-  th, td { padding: 6px 12px; text-align: left; border-bottom: 1px solid #333; }
-  th { color: #00d4ff; }
-  .running { color: #00ff88; }
-  .pr_open { color: #ffaa00; }
-  .done { color: #888; }
-  .dead, .failed { color: #ff4444; }
-  .queued { color: #aaaaff; }
-  a { color: #00d4ff; }
+  :root {
+    color-scheme: dark;
+    --bg: #0d1117;
+    --panel: #151b23;
+    --panel-2: #10161d;
+    --line: #29313d;
+    --text: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --ok: #3fb950;
+    --warn: #d29922;
+    --bad: #f85149;
+    --queued: #a371f7;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-width: 320px;
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  header {
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 0 18px;
+    border-bottom: 1px solid var(--line);
+    background: #0b1016;
+  }
+  h1 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 650;
+    letter-spacing: 0;
+  }
+  .repo { color: var(--muted); font-size: 13px; }
+  .topline, .stats, .workspace, .split, .log-head, .status-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .topline { min-width: 0; }
+  .stats { flex-wrap: wrap; justify-content: flex-end; }
+  .stat {
+    min-width: 72px;
+    padding: 6px 10px;
+    border: 1px solid var(--line);
+    background: var(--panel-2);
+    border-radius: 6px;
+    text-align: right;
+  }
+  .stat strong { display: block; font-size: 15px; }
+  .stat span { display: block; color: var(--muted); font-size: 11px; }
+  main {
+    height: calc(100vh - 56px);
+    display: grid;
+    grid-template-columns: minmax(520px, 1fr) minmax(420px, 0.72fr);
+  }
+  section {
+    min-width: 0;
+    min-height: 0;
+    border-right: 1px solid var(--line);
+  }
+  section:last-child { border-right: 0; }
+  .toolbar {
+    height: 48px;
+    padding: 0 14px;
+    border-bottom: 1px solid var(--line);
+    background: var(--panel);
+    justify-content: space-between;
+  }
+  .toolbar h2 {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 650;
+    color: var(--muted);
+    text-transform: uppercase;
+  }
+  .filter input {
+    width: min(260px, 36vw);
+    height: 30px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: #0b1016;
+    color: var(--text);
+    padding: 0 10px;
+    outline: none;
+  }
+  .filter input:focus { border-color: var(--accent); }
+  .table-wrap {
+    height: calc(100% - 48px);
+    overflow: auto;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+  }
+  th, td {
+    padding: 9px 10px;
+    border-bottom: 1px solid var(--line);
+    vertical-align: middle;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--panel);
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 600;
+    text-align: left;
+  }
+  tbody tr { cursor: pointer; }
+  tbody tr:hover, tbody tr.selected { background: #18212c; }
+  tbody tr.row-attention { background: rgba(248,81,73,.07); }
+  tbody tr.row-attention:hover, tbody tr.row-attention.selected { background: rgba(248,81,73,.13); }
+  a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+  a:hover { text-decoration: underline; }
+  .slot { width: 92px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .issue { width: auto; }
+  .status { width: 128px; }
+  .backend { width: 102px; }
+  .pr { width: 64px; }
+  .runtime { width: 88px; }
+  .tokens { width: 78px; text-align: right; }
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    height: 22px;
+    padding: 0 8px;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    font-size: 12px;
+    font-weight: 650;
+  }
+  .s-running { color: var(--ok); border-color: rgba(63,185,80,.42); }
+  .s-pr_open { color: var(--warn); border-color: rgba(210,153,34,.48); }
+  .s-queued { color: var(--queued); border-color: rgba(163,113,247,.5); }
+  .s-dead, .s-failed, .s-conflict_failed, .s-retry_exhausted { color: var(--bad); border-color: rgba(248,81,73,.5); }
+  .s-done { color: var(--muted); }
+  .pill-attention { color: var(--bad); border-color: rgba(248,81,73,.58); }
+  .log-panel {
+    min-width: 0;
+    display: grid;
+    grid-template-rows: 48px auto minmax(0, 1fr);
+    background: #080c11;
+  }
+  .log-head {
+    padding: 0 14px;
+    border-bottom: 1px solid var(--line);
+    background: var(--panel);
+    justify-content: space-between;
+    min-width: 0;
+  }
+  .log-title { min-width: 0; font-weight: 650; }
+  .log-title span {
+    color: var(--muted);
+    font-weight: 500;
+    margin-left: 8px;
+  }
+  .log-meta {
+    color: var(--muted);
+    font-size: 12px;
+    white-space: nowrap;
+  }
+  .status-note {
+    display: none;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--line);
+    background: #0b1016;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  .status-note.visible { display: block; }
+  .status-note strong {
+    color: var(--text);
+    margin-right: 6px;
+  }
+  .status-note .links {
+    display: inline-flex;
+    gap: 10px;
+    margin-left: 10px;
+  }
+  pre {
+    margin: 0;
+    min-height: 0;
+    overflow: auto;
+    padding: 14px;
+    color: #d1d7e0;
+    font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .empty {
+    padding: 24px;
+    color: var(--muted);
+  }
+  .muted { color: var(--muted); }
+  .error { color: var(--bad); }
+  @media (max-width: 980px) {
+    header { height: auto; align-items: flex-start; flex-direction: column; padding: 12px 14px; }
+    .stats { justify-content: flex-start; }
+    main { height: auto; min-height: calc(100vh - 112px); grid-template-columns: 1fr; }
+    section { border-right: 0; border-bottom: 1px solid var(--line); }
+    .table-wrap { height: 52vh; }
+    .log-panel { height: 48vh; }
+    .backend, .tokens { display: none; }
+  }
 </style>
 </head>
 <body>
-<h1>maestro — %s</h1>
-<p>Sessions: %d | Max parallel: %d</p>
-<table>
-<tr><th>Slot</th><th>Issue</th><th>Status</th><th>Backend</th><th>PR</th><th>Tokens</th><th>Runtime</th></tr>
-`, s.cfg.Repo, s.cfg.Repo, len(st.Sessions), s.cfg.MaxParallel)
+<header>
+  <div class="topline">
+    <h1>Maestro</h1>
+    <div class="repo" id="repo"></div>
+  </div>
+  <div class="stats" id="stats"></div>
+</header>
+<main>
+  <section>
+    <div class="toolbar workspace">
+      <h2>Workers</h2>
+      <label class="filter"><input id="filter" type="search" placeholder="Filter"></label>
+    </div>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th class="slot">Slot</th>
+            <th class="issue">Issue</th>
+            <th class="status">Status</th>
+            <th class="backend">Backend</th>
+            <th class="pr">PR</th>
+            <th class="runtime">Runtime</th>
+            <th class="tokens">Tokens</th>
+          </tr>
+        </thead>
+        <tbody id="workers"></tbody>
+      </table>
+    </div>
+  </section>
+  <section class="log-panel">
+    <div class="log-head">
+      <div class="log-title" id="log-title">Log <span></span></div>
+      <div class="log-meta" id="log-meta"></div>
+    </div>
+    <div class="status-note" id="status-note"></div>
+    <pre id="log"><span class="muted">Select a worker.</span></pre>
+  </section>
+</main>
+<script>
+window.MAESTRO_REPO = __REPO_JSON__;
 
-	for slot, sess := range st.Sessions {
-		end := time.Now()
-		if sess.FinishedAt != nil {
-			end = *sess.FinishedAt
-		}
-		runtime := end.Sub(sess.StartedAt).Round(time.Second)
-		pr := "-"
-		if sess.PRNumber > 0 {
-			pr = fmt.Sprintf("#%d", sess.PRNumber)
-		}
-		tokens := worker.FormatTokens(sess.TokensUsedTotal)
-		fmt.Fprintf(w, `<tr class="%s"><td>%s</td><td>#%d %s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>
-`,
-			sess.Status, slot, sess.IssueNumber, escapeHTML(sess.IssueTitle),
-			sess.Status, sess.Backend, pr, tokens, runtime)
-	}
+const state = {
+  workers: [],
+  selected: "",
+  filter: "",
+  lastLog: ""
+};
 
-	fmt.Fprintf(w, `</table>
-<p style="margin-top:2em; color:#666">Auto-refreshes every 10s | <a href="/api/v1/state">JSON API</a></p>
-</body>
-</html>`)
+const statusRank = {
+  running: 0,
+  pr_open: 1,
+  queued: 2,
+  dead: 3,
+  failed: 4,
+  conflict_failed: 5,
+  retry_exhausted: 6,
+  done: 7
+};
+
+const repoEl = document.getElementById("repo");
+const statsEl = document.getElementById("stats");
+const workersEl = document.getElementById("workers");
+const filterEl = document.getElementById("filter");
+const logEl = document.getElementById("log");
+const logTitleEl = document.getElementById("log-title");
+const logMetaEl = document.getElementById("log-meta");
+const statusNoteEl = document.getElementById("status-note");
+
+repoEl.textContent = window.MAESTRO_REPO || "";
+
+filterEl.addEventListener("input", () => {
+  state.filter = filterEl.value.toLowerCase();
+  renderWorkers();
+});
+
+function escapeText(value) {
+  return String(value ?? "").replace(/[&<>"']/g, ch => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    "\"": "&quot;",
+    "'": "&#39;"
+  }[ch]));
 }
+
+function compactNumber(value) {
+  const n = Number(value || 0);
+  if (!n) return "-";
+  if (n < 1000) return String(n);
+  if (n < 1000000) return (n / 1000).toFixed(n < 10000 ? 1 : 0).replace(/\.0$/, "") + "k";
+  return (n / 1000000).toFixed(1).replace(/\.0$/, "") + "M";
+}
+
+function linkHTML(url, label) {
+  if (!url) return escapeText(label);
+  return '<a href="' + escapeText(url) + '" target="_blank" rel="noreferrer">' + escapeText(label) + '</a>';
+}
+
+function statusLabel(worker) {
+  if (worker.status === "running" && worker.alive === false) return "running stale";
+  return worker.status || "-";
+}
+
+function pillClass(worker) {
+  const base = "pill s-" + escapeText(worker.status || "unknown");
+  if (worker.needs_attention || (worker.status === "running" && worker.alive === false)) {
+    return base + " pill-attention";
+  }
+  return base;
+}
+
+function workerMatches(worker) {
+  if (!state.filter) return true;
+  const text = [worker.slot, worker.issue_number, worker.issue_title, worker.status, worker.backend, worker.pr_number]
+    .join(" ")
+    .toLowerCase();
+  return text.includes(state.filter);
+}
+
+function sortWorkers(workers) {
+  return [...workers].sort((a, b) => {
+    const ar = statusRank[a.status] ?? 99;
+    const br = statusRank[b.status] ?? 99;
+    if (ar !== br) return ar - br;
+    return String(b.started_at || "").localeCompare(String(a.started_at || ""));
+  });
+}
+
+function renderStats(summary, total, maxParallel, readOnly) {
+  const running = summary.running || 0;
+  const prOpen = summary.pr_open || 0;
+  const failed = (summary.dead || 0) + (summary.failed || 0) + (summary.retry_exhausted || 0) + (summary.conflict_failed || 0);
+  const items = [
+    ["Running", running + " / " + maxParallel],
+    ["PR open", prOpen],
+    ["Failed", failed],
+    ["Sessions", total],
+    ["Mode", readOnly ? "Read-only" : "Control"]
+  ];
+  statsEl.innerHTML = items.map(([label, value]) =>
+    '<div class="stat"><strong>' + escapeText(value) + '</strong><span>' + escapeText(label) + '</span></div>'
+  ).join("");
+}
+
+function renderWorkers() {
+  const visible = sortWorkers(state.workers).filter(workerMatches);
+  if (visible.length === 0) {
+    workersEl.innerHTML = '<tr><td colspan="7" class="empty">No workers.</td></tr>';
+    return;
+  }
+  workersEl.innerHTML = visible.map(worker => {
+    const selected = worker.slot === state.selected ? " selected" : "";
+    const attention = worker.needs_attention ? " row-attention" : "";
+    const issue = "#" + worker.issue_number;
+    const pr = worker.pr_number ? "#" + worker.pr_number : "-";
+    return '<tr class="' + selected + attention + '" data-slot="' + escapeText(worker.slot) + '">' +
+      '<td class="slot">' + escapeText(worker.slot) + '</td>' +
+      '<td class="issue">' + linkHTML(worker.issue_url, issue) + ' ' + escapeText(worker.issue_title) + '</td>' +
+      '<td class="status"><span class="' + pillClass(worker) + '">' + escapeText(statusLabel(worker)) + '</span></td>' +
+      '<td class="backend">' + escapeText(worker.backend || "-") + '</td>' +
+      '<td class="pr">' + linkHTML(worker.pr_url, pr) + '</td>' +
+      '<td class="runtime">' + escapeText(worker.runtime || "-") + '</td>' +
+      '<td class="tokens">' + compactNumber(worker.tokens_used_total) + '</td>' +
+    '</tr>';
+  }).join("");
+  workersEl.querySelectorAll("tr[data-slot]").forEach(row => {
+    row.addEventListener("click", () => selectWorker(row.dataset.slot));
+  });
+}
+
+function selectWorker(slot) {
+  state.selected = slot;
+  state.lastLog = "";
+  renderWorkers();
+  renderSelectedDetails();
+  loadLog();
+}
+
+function renderSelectedDetails() {
+  const worker = state.workers.find(item => item.slot === state.selected);
+  if (!worker) {
+    statusNoteEl.classList.remove("visible");
+    statusNoteEl.innerHTML = "";
+    return;
+  }
+
+  const links = [];
+  if (worker.issue_url) links.push(linkHTML(worker.issue_url, "Issue #" + worker.issue_number));
+  if (worker.pr_url) links.push(linkHTML(worker.pr_url, "PR #" + worker.pr_number));
+  const retry = worker.next_retry_at ? " Next retry: " + worker.next_retry_at + "." : "";
+  statusNoteEl.innerHTML = '<strong>Why</strong>' +
+    escapeText((worker.status_reason || "Waiting for next reconciliation cycle.") + retry) +
+    (links.length ? '<span class="links">' + links.join("") + '</span>' : "");
+  statusNoteEl.classList.add("visible");
+}
+
+async function loadState() {
+  try {
+    const response = await fetch("/api/v1/state", { cache: "no-store" });
+    if (!response.ok) throw new Error(await response.text());
+    const data = await response.json();
+    state.workers = data.all || [];
+    renderStats(data.summary || {}, state.workers.length, data.max_parallel || 0, data.read_only);
+    if (!state.selected && state.workers.length) state.selected = sortWorkers(state.workers)[0].slot;
+    if (state.selected && !state.workers.some(worker => worker.slot === state.selected)) {
+      state.selected = state.workers.length ? sortWorkers(state.workers)[0].slot : "";
+      state.lastLog = "";
+    }
+    renderWorkers();
+    renderSelectedDetails();
+  } catch (err) {
+    statsEl.innerHTML = '<span class="error">' + escapeText(err.message) + '</span>';
+  }
+}
+
+async function loadLog() {
+  if (!state.selected) {
+    logTitleEl.innerHTML = 'Log <span></span>';
+    logMetaEl.textContent = "";
+    logEl.textContent = "Select a worker.";
+    renderSelectedDetails();
+    return;
+  }
+  const worker = state.workers.find(item => item.slot === state.selected);
+  logTitleEl.innerHTML = 'Log <span>' + escapeText(state.selected) + (worker ? " #" + escapeText(worker.issue_number) : "") + '</span>';
+  try {
+    const response = await fetch("/api/v1/logs/" + encodeURIComponent(state.selected) + "?lines=260", { cache: "no-store" });
+    if (!response.ok) throw new Error(await response.text());
+    const data = await response.json();
+    const text = data.text || "";
+    logMetaEl.textContent = (data.truncated ? "tail " : "") + (data.updated_at || "");
+    if (text !== state.lastLog) {
+      state.lastLog = text;
+      logEl.textContent = text || "No log output yet.";
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+  } catch (err) {
+    logEl.textContent = "Log error: " + err.message;
+  }
+}
+
+loadState().then(loadLog);
+setInterval(loadState, 3000);
+setInterval(loadLog, 2000);
+</script>
+</body>
+</html>`
 
 func escapeHTML(s string) string {
 	s = strings.ReplaceAll(s, "&", "&amp;")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -810,7 +810,7 @@ const state = {
   workers: [],
   selected: "",
   filter: "",
-  lastLog: ""
+  lastLog: null
 };
 
 const statusRank = {
@@ -937,10 +937,19 @@ function renderWorkers() {
 
 function selectWorker(slot) {
   state.selected = slot;
-  state.lastLog = "";
+  state.lastLog = null;
   renderWorkers();
   renderSelectedDetails();
   loadLog();
+}
+
+function emptyLogText(worker) {
+  if (!worker) return "No log output yet.";
+  if (worker.status === "running" && worker.backend === "claude") {
+    return "No log output yet. Claude print mode may stay quiet until it finishes.";
+  }
+  if (worker.status === "running") return "No log output yet. Worker is still running.";
+  return "No log output.";
 }
 
 function renderSelectedDetails() {
@@ -971,7 +980,7 @@ async function loadState() {
     if (!state.selected && state.workers.length) state.selected = sortWorkers(state.workers)[0].slot;
     if (state.selected && !state.workers.some(worker => worker.slot === state.selected)) {
       state.selected = state.workers.length ? sortWorkers(state.workers)[0].slot : "";
-      state.lastLog = "";
+      state.lastLog = null;
     }
     renderWorkers();
     renderSelectedDetails();
@@ -998,7 +1007,7 @@ async function loadLog() {
     logMetaEl.textContent = (data.truncated ? "tail " : "") + (data.updated_at || "");
     if (text !== state.lastLog) {
       state.lastLog = text;
-      logEl.textContent = text || "No log output yet.";
+      logEl.textContent = text || emptyLogText(worker);
       logEl.scrollTop = logEl.scrollHeight;
     }
   } catch (err) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -27,6 +27,13 @@ func setupTestServer(t *testing.T) (*Server, *config.Config) {
 	// Write test state
 	st := state.NewState()
 	now := time.Now().UTC()
+	logFile := filepath.Join(dir, "logs", "slot-1.log")
+	if err := os.MkdirAll(filepath.Dir(logFile), 0755); err != nil {
+		t.Fatalf("create log dir: %v", err)
+	}
+	if err := os.WriteFile(logFile, []byte("line one\nline two\nline three\n"), 0644); err != nil {
+		t.Fatalf("write test log: %v", err)
+	}
 	st.Sessions["slot-1"] = &state.Session{
 		IssueNumber:     42,
 		IssueTitle:      "Fix bug",
@@ -36,7 +43,8 @@ func setupTestServer(t *testing.T) (*Server, *config.Config) {
 		Worktree:        "/tmp/worktrees/slot-1",
 		StartedAt:       now.Add(-10 * time.Minute),
 		TokensUsedTotal: 5000,
-		PID:             1, // non-zero but won't be alive in tests
+		PID:             999999,
+		LogFile:         logFile,
 	}
 	finished := now.Add(-5 * time.Minute)
 	st.Sessions["slot-2"] = &state.Session{
@@ -97,6 +105,9 @@ func TestHandleState(t *testing.T) {
 	if len(resp.Running) != 1 {
 		t.Errorf("running sessions = %d, want 1", len(resp.Running))
 	}
+	if len(resp.All) != 3 {
+		t.Errorf("all sessions = %d, want 3", len(resp.All))
+	}
 	if len(resp.PROpen) != 1 {
 		t.Errorf("pr_open sessions = %d, want 1", len(resp.PROpen))
 	}
@@ -105,6 +116,21 @@ func TestHandleState(t *testing.T) {
 	}
 	if resp.TokenTotals.Active != 13000 {
 		t.Errorf("active tokens = %d, want 13000", resp.TokenTotals.Active)
+	}
+	if resp.Running[0].IssueURL != "https://github.com/test/repo/issues/42" {
+		t.Errorf("issue_url = %q", resp.Running[0].IssueURL)
+	}
+	if resp.Running[0].Alive == nil || *resp.Running[0].Alive {
+		t.Fatalf("running worker should expose alive=false for dead test PID")
+	}
+	if !resp.Running[0].NeedsAttention {
+		t.Error("running worker with alive=false should need attention")
+	}
+	if !contains(resp.Running[0].StatusReason, "PID is not alive") {
+		t.Errorf("status_reason = %q, want dead PID hint", resp.Running[0].StatusReason)
+	}
+	if resp.PROpen[0].PRURL != "https://github.com/test/repo/pull/10" {
+		t.Errorf("pr_url = %q", resp.PROpen[0].PRURL)
 	}
 }
 
@@ -144,6 +170,56 @@ func TestHandleWorkers(t *testing.T) {
 	workers := resp["workers"].([]interface{})
 	if len(workers) != 3 {
 		t.Errorf("workers array len = %d, want 3", len(workers))
+	}
+}
+
+func TestHandleLog(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/slot-1?lines=2", nil)
+	w := httptest.NewRecorder()
+	srv.handleLog(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp logResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Slot != "slot-1" {
+		t.Errorf("slot = %q, want slot-1", resp.Slot)
+	}
+	if contains(resp.Text, "line one") {
+		t.Error("tail should not include older lines beyond requested limit")
+	}
+	if !contains(resp.Text, "line two") || !contains(resp.Text, "line three") {
+		t.Errorf("tail text = %q, want last two lines", resp.Text)
+	}
+}
+
+func TestHandleLog_NotFound(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/missing", nil)
+	w := httptest.NewRecorder()
+	srv.handleLog(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleLog_MethodNotAllowed(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/slot-1", nil)
+	w := httptest.NewRecorder()
+	srv.handleLog(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
 	}
 }
 
@@ -273,6 +349,31 @@ func TestHandleRefresh_MethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestHandleRefresh_ReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: dir,
+		Server:   config.ServerConfig{Port: 8765, ReadOnly: true},
+	}
+
+	refreshCh := make(chan struct{}, 1)
+	srv := New(cfg, refreshCh)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/refresh", nil)
+	w := httptest.NewRecorder()
+	srv.handleRefresh(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	select {
+	case <-refreshCh:
+		t.Error("refresh channel should not receive signal in read-only mode")
+	default:
+	}
+}
+
 func TestHandleDashboard(t *testing.T) {
 	srv, _ := setupTestServer(t)
 
@@ -291,8 +392,29 @@ func TestHandleDashboard(t *testing.T) {
 	if !contains(body, "test/repo") {
 		t.Error("dashboard should contain repo name")
 	}
-	if !contains(body, "Fix bug") {
-		t.Error("dashboard should contain issue titles")
+	if !contains(body, "api/v1/logs") {
+		t.Error("dashboard should include log API polling")
+	}
+	if !contains(body, "Workers") {
+		t.Error("dashboard should render worker table shell")
+	}
+	if !contains(body, "status-note") {
+		t.Error("dashboard should include status explanation block")
+	}
+	if !contains(body, "issue_url") || !contains(body, "pr_url") {
+		t.Error("dashboard should render GitHub issue/PR links from API fields")
+	}
+}
+
+func TestGitHubURLs(t *testing.T) {
+	if got := githubIssueURL("owner/repo", 42); got != "https://github.com/owner/repo/issues/42" {
+		t.Errorf("githubIssueURL() = %q", got)
+	}
+	if got := githubPRURL("owner/repo", 10); got != "https://github.com/owner/repo/pull/10" {
+		t.Errorf("githubPRURL() = %q", got)
+	}
+	if got := githubIssueURL("not-a-repo", 42); got != "" {
+		t.Errorf("githubIssueURL(invalid) = %q, want empty", got)
 	}
 }
 
@@ -370,6 +492,13 @@ func TestEscapeHTML(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("escapeHTML(%q) = %q, want %q", tt.in, got, tt.want)
 		}
+	}
+}
+
+func TestStripANSI(t *testing.T) {
+	got := stripANSI("\x1b[0mhello \x1b[90mgrey\x1b[0m")
+	if got != "hello grey" {
+		t.Errorf("stripANSI() = %q, want hello grey", got)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -206,6 +206,16 @@ func (s *State) IssueInProgress(issueNum int) bool {
 	return false
 }
 
+// IssueDone returns true if the given issue already has a completed session.
+func (s *State) IssueDone(issueNum int) bool {
+	for _, sess := range s.Sessions {
+		if sess.IssueNumber == issueNum && sess.Status == StatusDone {
+			return true
+		}
+	}
+	return false
+}
+
 // FailedAttemptsForIssue counts sessions for the given issue that ended
 // without producing a PR (dead, failed, or retry_exhausted).
 func (s *State) FailedAttemptsForIssue(issueNum int) int {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -33,36 +33,37 @@ const (
 )
 
 type Session struct {
-	IssueNumber             int           `json:"issue_number"`
-	IssueTitle              string        `json:"issue_title"`
-	Worktree                string        `json:"worktree"`
-	Branch                  string        `json:"branch"`
-	PID                     int           `json:"pid"`
-	TmuxSession             string        `json:"tmux_session,omitempty"`
-	LogFile                 string        `json:"log_file"`
-	StartedAt               time.Time     `json:"started_at"`
-	FinishedAt              *time.Time    `json:"finished_at,omitempty"`
-	Status                  SessionStatus `json:"status"`
-	PRNumber                int           `json:"pr_number,omitempty"`
-	Backend                 string        `json:"backend,omitempty"` // "claude", "codex", etc.
-	LongRunning             bool          `json:"long_running,omitempty"`
-	RebaseAttempted         bool          `json:"rebase_attempted,omitempty"`
-	NotifiedCIFail          bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
-	LastNotifiedStatus      string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
-	RetryCount              int           `json:"retry_count,omitempty"`          // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
-	NextRetryAt             *time.Time    `json:"next_retry_at,omitempty"`
-	LastOutputHash          string        `json:"last_output_hash,omitempty"`
-	LastOutputChangedAt     time.Time     `json:"last_output_changed_at,omitempty"`
-	TokensUsedAttempt       int           `json:"tokens_used_attempt,omitempty"`       // tokens consumed in current attempt (reset on respawn)
-	TokensUsedTotal         int           `json:"tokens_used_total,omitempty"`         // cumulative tokens across the issue lifecycle
-	RateLimitHit            bool          `json:"rate_limit_hit,omitempty"`            // true if worker was rate-limited (tmux detection, running worker)
-	TriedBackends           []string      `json:"tried_backends,omitempty"`            // backends already attempted (for rate-limit fallback)
-	Phase                   Phase         `json:"phase,omitempty"`                     // current pipeline phase (empty = legacy single-phase)
-	ValidationFails         int           `json:"validation_fails,omitempty"`          // number of failed validation attempts
-	ValidationFeedback      string        `json:"validation_feedback,omitempty"`       // feedback from last failed validation
-	CIFailureOutput         string        `json:"ci_failure_output,omitempty"`         // CI failure output captured before retry (passed to next worker as context)
-	PreviousAttemptFeedback string        `json:"previous_attempt_feedback,omitempty"` // Greptile review feedback from previous failed PR attempt
-	CheckpointFile          string        `json:"checkpoint_file,omitempty"`           // path to CHECKPOINT.md saved at soft token threshold
+	IssueNumber                 int           `json:"issue_number"`
+	IssueTitle                  string        `json:"issue_title"`
+	Worktree                    string        `json:"worktree"`
+	Branch                      string        `json:"branch"`
+	PID                         int           `json:"pid"`
+	TmuxSession                 string        `json:"tmux_session,omitempty"`
+	LogFile                     string        `json:"log_file"`
+	StartedAt                   time.Time     `json:"started_at"`
+	FinishedAt                  *time.Time    `json:"finished_at,omitempty"`
+	Status                      SessionStatus `json:"status"`
+	PRNumber                    int           `json:"pr_number,omitempty"`
+	Backend                     string        `json:"backend,omitempty"` // "claude", "codex", etc.
+	LongRunning                 bool          `json:"long_running,omitempty"`
+	RebaseAttempted             bool          `json:"rebase_attempted,omitempty"`
+	NotifiedCIFail              bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
+	LastNotifiedStatus          string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
+	RetryCount                  int           `json:"retry_count,omitempty"`          // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
+	NextRetryAt                 *time.Time    `json:"next_retry_at,omitempty"`
+	LastOutputHash              string        `json:"last_output_hash,omitempty"`
+	LastOutputChangedAt         time.Time     `json:"last_output_changed_at,omitempty"`
+	TokensUsedAttempt           int           `json:"tokens_used_attempt,omitempty"`            // tokens consumed in current attempt (reset on respawn)
+	TokensUsedTotal             int           `json:"tokens_used_total,omitempty"`              // cumulative tokens across the issue lifecycle
+	RateLimitHit                bool          `json:"rate_limit_hit,omitempty"`                 // true if worker was rate-limited (tmux detection, running worker)
+	TriedBackends               []string      `json:"tried_backends,omitempty"`                 // backends already attempted (for rate-limit fallback)
+	Phase                       Phase         `json:"phase,omitempty"`                          // current pipeline phase (empty = legacy single-phase)
+	ValidationFails             int           `json:"validation_fails,omitempty"`               // number of failed validation attempts
+	ValidationFeedback          string        `json:"validation_feedback,omitempty"`            // feedback from last failed validation
+	CIFailureOutput             string        `json:"ci_failure_output,omitempty"`              // CI failure output captured before retry (passed to next worker as context)
+	PreviousAttemptFeedback     string        `json:"previous_attempt_feedback,omitempty"`      // feedback from previous failed PR attempt
+	PreviousAttemptFeedbackKind string        `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
+	CheckpointFile              string        `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
 }
 
 // UnmarshalJSON implements custom unmarshalling to preserve the legacy

--- a/internal/worker/rebase_test.go
+++ b/internal/worker/rebase_test.go
@@ -1,6 +1,12 @@
 package worker
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestKeepBothSides_SimpleConflict(t *testing.T) {
 	input := "line1\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\nline2\n"
@@ -52,4 +58,104 @@ func TestKeepBothSides_UnterminatedConflict(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unterminated conflict")
 	}
+}
+
+func TestRestoreAllowedDirtyFiles_RestoresOnlyConfiguredPaths(t *testing.T) {
+	dir := t.TempDir()
+	gitTest(t, dir, "init")
+	gitTest(t, dir, "config", "user.email", "test@example.com")
+	gitTest(t, dir, "config", "user.name", "Test User")
+
+	writeTestFile(t, dir, "ok-gobot", "original binary")
+	writeTestFile(t, dir, "main.go", "package main\n")
+	gitTest(t, dir, "add", "-f", "ok-gobot", "main.go")
+	gitTest(t, dir, "commit", "-m", "initial")
+
+	writeTestFile(t, dir, "ok-gobot", "rebuilt binary")
+	writeTestFile(t, dir, "main.go", "package main\n\nfunc main() {}\n")
+
+	if err := restoreAllowedDirtyFiles(dir, []string{"ok-gobot"}); err != nil {
+		t.Fatalf("restoreAllowedDirtyFiles: %v", err)
+	}
+
+	if got := readTestFile(t, dir, "ok-gobot"); got != "original binary" {
+		t.Fatalf("ok-gobot = %q, want restored original binary", got)
+	}
+	if got := readTestFile(t, dir, "main.go"); got != "package main\n\nfunc main() {}\n" {
+		t.Fatalf("main.go = %q, want unrelated dirty file unchanged", got)
+	}
+
+	dirty, err := worktreeDirty(dir)
+	if err != nil {
+		t.Fatalf("worktreeDirty: %v", err)
+	}
+	if strings.Contains(dirty, "ok-gobot") {
+		t.Fatalf("ok-gobot should be clean after restore, dirty status:\n%s", dirty)
+	}
+	if !strings.Contains(dirty, "main.go") {
+		t.Fatalf("main.go should remain dirty, dirty status:\n%s", dirty)
+	}
+}
+
+func TestRestoreAllowedDirtyFiles_CleansConfiguredUntrackedPaths(t *testing.T) {
+	dir := t.TempDir()
+	gitTest(t, dir, "init")
+	gitTest(t, dir, "config", "user.email", "test@example.com")
+	gitTest(t, dir, "config", "user.name", "Test User")
+
+	writeTestFile(t, dir, "main.go", "package main\n")
+	gitTest(t, dir, "add", "main.go")
+	gitTest(t, dir, "commit", "-m", "initial")
+
+	writeTestFile(t, dir, "build/artifact.bin", "artifact")
+
+	if err := restoreAllowedDirtyFiles(dir, []string{"build"}); err != nil {
+		t.Fatalf("restoreAllowedDirtyFiles: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "build", "artifact.bin")); !os.IsNotExist(err) {
+		t.Fatalf("configured untracked artifact should be removed, stat err=%v", err)
+	}
+}
+
+func TestNormalizedGitPaths_TrimsDeduplicatesAndUsesSlash(t *testing.T) {
+	got := normalizedGitPaths([]string{" ok-gobot ", "build\\artifact.bin", "ok-gobot", ""})
+	want := []string{"ok-gobot", "build/artifact.bin"}
+	if len(got) != len(want) {
+		t.Fatalf("normalizedGitPaths = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("normalizedGitPaths[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func gitTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func writeTestFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	path := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readTestFile(t *testing.T, dir, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(data)
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -336,6 +336,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	// case Respawn is called from other paths.
 	sess.CIFailureOutput = ""
 	sess.PreviousAttemptFeedback = ""
+	sess.PreviousAttemptFeedbackKind = ""
 	sess.CheckpointFile = ""
 
 	return nil
@@ -447,7 +448,9 @@ func RemoveWorktree(localPath, worktreePath string) error {
 // both sides, continues the rebase, then force-pushes the branch.
 // autoResolveFiles is the list of file paths (relative to repo root) that may
 // be auto-resolved by keeping both sides; it comes from cfg.AutoResolveFiles.
-func RebaseWorktree(worktreePath, branch string, autoResolveFiles []string) error {
+// autoRestoreFiles is the list of dirty disposable paths that may be restored
+// before rebasing; it comes from cfg.AutoRestoreFiles.
+func RebaseWorktree(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
 	if strings.TrimSpace(worktreePath) == "" {
 		return fmt.Errorf("empty worktree path")
 	}
@@ -457,6 +460,14 @@ func RebaseWorktree(worktreePath, branch string, autoResolveFiles []string) erro
 
 	if _, err := runGit(worktreePath, "fetch", "origin"); err != nil {
 		return err
+	}
+	if err := restoreAllowedDirtyFiles(worktreePath, autoRestoreFiles); err != nil {
+		return err
+	}
+	if dirty, err := worktreeDirty(worktreePath); err != nil {
+		return err
+	} else if dirty != "" {
+		return fmt.Errorf("worktree has uncommitted changes after auto_restore_files; refusing rebase:\n%s", dirty)
 	}
 
 	if _, rebaseErr := runGit(worktreePath, "rebase", "origin/main"); rebaseErr != nil {
@@ -473,6 +484,82 @@ func RebaseWorktree(worktreePath, branch string, autoResolveFiles []string) erro
 	}
 
 	return nil
+}
+
+func restoreAllowedDirtyFiles(worktreePath string, autoRestoreFiles []string) error {
+	paths := normalizedGitPaths(autoRestoreFiles)
+	if len(paths) == 0 {
+		return nil
+	}
+	args := append([]string{"status", "--porcelain", "--"}, paths...)
+	dirty, err := runGit(worktreePath, args...)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(dirty) == "" {
+		return nil
+	}
+
+	log.Printf("[worker] restoring allowed dirty files before rebase in %s: %s", worktreePath, strings.Join(paths, ", "))
+	trackedPaths, err := trackedGitPaths(worktreePath, paths)
+	if err != nil {
+		return err
+	}
+	if len(trackedPaths) > 0 {
+		args = append([]string{"restore", "--"}, trackedPaths...)
+		if _, err := runGit(worktreePath, args...); err != nil {
+			return err
+		}
+	}
+	args = append([]string{"clean", "-fd", "--"}, paths...)
+	if _, err := runGit(worktreePath, args...); err != nil {
+		return err
+	}
+	return nil
+}
+
+func trackedGitPaths(worktreePath string, paths []string) ([]string, error) {
+	args := append([]string{"ls-files", "--"}, paths...)
+	out, err := runGit(worktreePath, args...)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(out, "\n")
+	tracked := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		tracked = append(tracked, toSlash(line))
+	}
+	return tracked, nil
+}
+
+func worktreeDirty(worktreePath string) (string, error) {
+	out, err := runGit(worktreePath, "status", "--porcelain")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func normalizedGitPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		path = toSlash(path)
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		normalized = append(normalized, path)
+	}
+	return normalized
 }
 
 func runGit(worktreePath string, args ...string) (string, error) {


### PR DESCRIPTION
## Summary

- add `maestro serve` for a read-only Mission Control web dashboard/API
- expose worker logs, GitHub issue/PR links, status reasons, and stale-running attention state
- make the dashboard bind host configurable and read-only by default
- ignore stale review comments by `original_commit_id` so old Greptile/Codex comments do not re-block fixed PRs
- prevent dispatching a new worker for an issue already completed and closed
- document `maestro serve` as the primary browser dashboard

## Verification

- `go test ./internal/server ./internal/state ./internal/github ./internal/orchestrator ./cmd/maestro`
- `go test ./...` on workshop Linux
- installed on workshop and verified `maestro-ok-gobot.service` and `maestro-ok-gobot-web.service` are active
- verified `/api/v1/state` returns issue/PR URLs and status reason fields
- verified read-only `/api/v1/refresh` returns HTTP 403

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a read-only `maestro serve` web dashboard with a polished JS SPA frontend, exposes worker logs and GitHub issue/PR links via API, and introduces several orchestrator improvements: review-feedback/rebase-conflict in-place retries, a configurable `review_gate`, `auto_restore_files` pre-rebase cleanup, slot reservation for pending retries, and a fix to skip already-closed issues on dispatch.

- **P1 — `refreshCh` never drained in `serveCmd`**: `make(chan struct{}, 1)` is passed to the server but nothing consumes it in the standalone `serve` process. With `--read-only=false`, `POST /api/v1/refresh` returns HTTP 200 but triggers no refresh; subsequent calls return 429 because the buffer is permanently full. Since the default is `--read-only=true` (which returns 403), normal usage is safe — but the non-default mode is silently misleading.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the default read-only dashboard use case; the --read-only=false refresh no-op is a minor misleading behaviour in a non-default mode.

One P1 finding (refreshCh never drained in serveCmd) caps the score at 4. The default --read-only=true mode is unaffected and the rest of the changes are well-tested and logically sound.

cmd/maestro/main.go — serveCmd refresh channel handling

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | New `serveCmd` starts the HTTP server in standalone mode; `refreshCh` is never consumed, making `--read-only=false`'s refresh endpoint silently a no-op. |
| internal/server/server.go | Dashboard rewritten as a JS SPA; new `/api/v1/logs/` endpoint added with proper slot validation; read-only guard added to `/api/v1/refresh`; URL construction and ANSI stripping are correct. |
| internal/github/github.go | New `reviewCommentTargetsHead` correctly prioritises `original_commit_id` over `commit_id` to ignore stale review comments; logic and tests are sound. |
| internal/orchestrator/orchestrator.go | Large addition of review-feedback retry, rebase-conflict retry, slot reservation, and review-gate bypass; well-covered by new tests. The `AutoRetryReviewFeedback` flag gates rebase retries too — a minor naming mismatch, but intentional. |
| internal/worker/worker.go | New `auto_restore_files` pre-rebase cleanup is correctly scoped: tracked paths are restored and untracked paths are cleaned; dirty-check guard prevents rebasing with leftover changes. |
| internal/state/state.go | New `PreviousAttemptFeedbackKind` field and `IssueDone` / `StatusPriority` helpers added cleanly; backward-compatible JSON serialisation preserved. |
| internal/config/config.go | New `ServerConfig.Host`, `ReadOnly`, `ReviewGate`, `AutoRetryReviewFeedback`, and `AutoRestoreFiles` fields added with correct defaults and normalisation. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `cmd/maestro/main.go`, line 114-118 ([link](https://github.com/befeast/maestro/blob/5d44a6a19e6d96a59ca945c98f90b4883f80590a/cmd/maestro/main.go#L114-L118)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`/api/v1/refresh` silently succeeds when `--read-only=false` is passed to `serve`**

   In `serveCmd`, `refreshCh` is created with `make(chan struct{}, 1)` but nothing consumes from it — the orchestrator loop is not running. With `--read-only=false`, the first `POST /api/v1/refresh` sends to the buffered channel and returns HTTP 200 (`{"ok": true}`), but no actual state refresh occurs. Callers get a success response for a no-op operation. Subsequent calls return 429 ("refresh already pending") since the buffer stays full with no consumer to drain it.

   The default of `--read-only=true` hides this, but the flag deliberately allows `--read-only=false`, and the HTTP 200 response is actively misleading in that mode.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/maestro/main.go
   Line: 114-118

   Comment:
   **`/api/v1/refresh` silently succeeds when `--read-only=false` is passed to `serve`**

   In `serveCmd`, `refreshCh` is created with `make(chan struct{}, 1)` but nothing consumes from it — the orchestrator loop is not running. With `--read-only=false`, the first `POST /api/v1/refresh` sends to the buffered channel and returns HTTP 200 (`{"ok": true}`), but no actual state refresh occurs. Callers get a success response for a no-op operation. Subsequent calls return 429 ("refresh already pending") since the buffer stays full with no consumer to drain it.

   The default of `--read-only=true` hides this, but the flag deliberately allows `--read-only=false`, and the HTTP 200 response is actively misleading in that mode.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `cmd/maestro/main.go`, line 114-118 ([link](https://github.com/befeast/maestro/blob/37a9c35c69000dc38f4fdd4fc44c728e4d4e7f91/cmd/maestro/main.go#L114-L118)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`refreshCh` is never drained in `serveCmd` — `POST /api/v1/refresh` silently no-ops when `--read-only=false`**

   `refreshCh` is created here but no goroutine ever reads from it; the orchestrator loop is not running in `serveCmd`. With `--read-only=false`, the first `POST /api/v1/refresh` writes to the buffered channel and returns HTTP 200 `{"ok":true}`, but no state refresh ever happens. Every subsequent call returns HTTP 429 "refresh already pending" because the buffer stays permanently full. The flag deliberately exposes `--read-only=false`, so callers can unknowingly receive a success response for a no-op.

   Either prevent the non-read-only path from being reachable in `serve` (enforce `ReadOnly = true` unconditionally for this command, removing the flag), or document that `--read-only=false` is not functional in standalone `serve` mode.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/maestro/main.go
   Line: 114-118

   Comment:
   **`refreshCh` is never drained in `serveCmd` — `POST /api/v1/refresh` silently no-ops when `--read-only=false`**

   `refreshCh` is created here but no goroutine ever reads from it; the orchestrator loop is not running in `serveCmd`. With `--read-only=false`, the first `POST /api/v1/refresh` writes to the buffered channel and returns HTTP 200 `{"ok":true}`, but no state refresh ever happens. Every subsequent call returns HTTP 429 "refresh already pending" because the buffer stays permanently full. The flag deliberately exposes `--read-only=false`, so callers can unknowingly receive a success response for a no-op.

   Either prevent the non-read-only path from being reachable in `serve` (enforce `ReadOnly = true` unconditionally for this command, removing the flag), or document that `--read-only=false` is not functional in standalone `serve` mode.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: cmd/maestro/main.go
Line: 114-118

Comment:
**`refreshCh` is never drained in `serveCmd` — `POST /api/v1/refresh` silently no-ops when `--read-only=false`**

`refreshCh` is created here but no goroutine ever reads from it; the orchestrator loop is not running in `serveCmd`. With `--read-only=false`, the first `POST /api/v1/refresh` writes to the buffered channel and returns HTTP 200 `{"ok":true}`, but no state refresh ever happens. Every subsequent call returns HTTP 429 "refresh already pending" because the buffer stays permanently full. The flag deliberately exposes `--read-only=false`, so callers can unknowingly receive a success response for a no-op.

Either prevent the non-read-only path from being reachable in `serve` (enforce `ReadOnly = true` unconditionally for this command, removing the flag), or document that `--read-only=false` is not functional in standalone `serve` mode.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: show empty log state for quiet work..."](https://github.com/befeast/maestro/commit/37a9c35c69000dc38f4fdd4fc44c728e4d4e7f91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30203539)</sub>

<!-- /greptile_comment -->