### PR TITLE
style: simplify dashboard navbar stats

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -590,10 +590,7 @@ const dashboardHTML = `<!DOCTYPE html>
   .stats { flex-wrap: wrap; justify-content: flex-end; }
   .stat {
     min-width: 72px;
-    padding: 6px 10px;
-    border: 1px solid var(--line);
-    background: var(--panel-2);
-    border-radius: 6px;
+    padding: 2px 4px;
     text-align: right;
   }
   .stat strong { display: block; font-size: 15px; }


### PR DESCRIPTION
## Changes
- Remove boxed chrome from Mission Control navbar stats.
- Keep the existing compact metric labels and values.

## Testing
- go test ./...
- go build ./cmd/maestro/

Live dashboards on workshop were rebuilt and restarted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the boxed styling (border, background, border-radius, and excess padding) from the Mission Control navbar stats in the embedded dashboard HTML, leaving only compact metric labels and values.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a four-line CSS-only cosmetic change with no logic impact.

No logic, security, or correctness issues. The change removes visual chrome from a few CSS rules inside an embedded HTML string and has no effect on any Go code paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/server.go | Pure CSS change — removes border, background, border-radius, and reduces padding on `.stat` elements in the embedded dashboard HTML. |

</details>

<sub>Reviews (1): Last reviewed commit: ["style: simplify dashboard navbar stats"](https://github.com/befeast/maestro/commit/763409387171e9ea677efb9af8d5e004eb2a731b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30213514)</sub>

<!-- /greptile_comment -->