### PR TITLE
Supervisor mode: read-only decision loop and records

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/server"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/supervisor"
 	"github.com/befeast/maestro/internal/versioning"
 	"github.com/befeast/maestro/internal/watch"
 	"github.com/befeast/maestro/internal/worker"
@@ -38,6 +39,7 @@ Usage:
 Commands:
   init          Interactive setup wizard for new projects
   run           Run the orchestration loop
+  supervise     Run read-only supervisor decision loop
   serve         Run Mission Control read-only web dashboard/API
   status        Show current state
   logs          Show worker logs (tail -f)
@@ -61,6 +63,11 @@ Run flags:
   --interval duration   Loop interval (default 10m)
   --once                Run once and exit
   --prompt string       Path to worker prompt base file
+
+Supervise flags:
+  --once                Run one read-only decision and exit
+  --interval duration   Loop interval (default 5m)
+  --json                Output decision as JSON
 
 Serve flags:
   --host string         Host/interface to bind (default from config, then 127.0.0.1)
@@ -157,6 +164,8 @@ func main() {
 		initCmd(args)
 	case "run":
 		runCmd(args)
+	case "supervise":
+		superviseCmd(args)
 	case "serve":
 		serveCmd(args)
 	case "status":
@@ -344,6 +353,98 @@ func runCmd(args []string) {
 	wg.Wait()
 }
 
+func superviseCmd(args []string) {
+	fs := flag.NewFlagSet("supervise", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to config file")
+	once := fs.Bool("once", false, "Run once and exit")
+	interval := fs.Duration("interval", 5*time.Minute, "Loop interval")
+	jsonOutput := fs.Bool("json", false, "Output decision as JSON")
+	fs.Parse(args)
+
+	if !*once && *interval <= 0 {
+		log.Fatalf("supervise: --interval must be positive")
+	}
+
+	cfg := loadConfig(*configPath)
+	gh := github.New(cfg.Repo)
+	runOnce := func() {
+		decision, err := supervisor.RunOnce(cfg, gh)
+		if err != nil {
+			log.Fatalf("supervise: %v", err)
+		}
+		printSupervisorDecision(decision, *jsonOutput)
+	}
+
+	runOnce()
+	if *once {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	ticker := time.NewTicker(*interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			runOnce()
+		}
+	}
+}
+
+func printSupervisorDecision(decision state.SupervisorDecision, jsonOutput bool) {
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(decision)
+		return
+	}
+
+	fmt.Printf("Supervisor decision: %s\n", decision.RecommendedAction)
+	fmt.Printf("Summary: %s\n", decision.Summary)
+	fmt.Printf("Risk: %s\n", decision.Risk)
+	fmt.Printf("Confidence: %.2f\n", decision.Confidence)
+	if decision.Target != nil {
+		parts := supervisorTargetParts(decision.Target)
+		if len(parts) > 0 {
+			fmt.Printf("Target: %s\n", strings.Join(parts, ", "))
+		}
+	}
+	if len(decision.Reasons) > 0 {
+		fmt.Println("Reasons:")
+		for _, reason := range decision.Reasons {
+			fmt.Printf("  - %s\n", reason)
+		}
+	}
+	fmt.Printf("Recorded: %s\n", decision.CreatedAt.Format(time.RFC3339))
+}
+
+func supervisorTargetParts(target *state.SupervisorTarget) []string {
+	if target == nil {
+		return nil
+	}
+	var parts []string
+	if target.Issue > 0 {
+		parts = append(parts, fmt.Sprintf("issue #%d", target.Issue))
+	}
+	if target.PR > 0 {
+		parts = append(parts, fmt.Sprintf("PR #%d", target.PR))
+	}
+	if strings.TrimSpace(target.Session) != "" {
+		parts = append(parts, "session "+target.Session)
+	}
+	return parts
+}
+
 func serveCmd(args []string) {
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 	var configs multiFlag
@@ -458,6 +559,7 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 		}
 	}
 	fmt.Println()
+	showLatestSupervisorDecision(s)
 
 	if len(s.Sessions) == 0 {
 		fmt.Println("No sessions.")
@@ -700,6 +802,26 @@ func logsCmd(args []string) {
 		fmt.Println()
 		fmt.Printf("To watch all logs:\n  tail -f %s/%s-*.log\n", entries[0].logDir, entries[0].prefix)
 	}
+}
+
+func showLatestSupervisorDecision(s *state.State) {
+	decision := s.LatestSupervisorDecision()
+	if decision == nil {
+		return
+	}
+	fmt.Println("Supervisor:")
+	fmt.Printf("  Latest action: %s (%s)\n", decision.RecommendedAction, formatRelativeTime(decision.CreatedAt))
+	if decision.Summary != "" {
+		fmt.Printf("  Summary: %s\n", decision.Summary)
+	}
+	fmt.Printf("  Risk: %s  Confidence: %.2f\n", decision.Risk, decision.Confidence)
+	if decision.Target != nil {
+		parts := supervisorTargetParts(decision.Target)
+		if len(parts) > 0 {
+			fmt.Printf("  Target: %s\n", strings.Join(parts, ", "))
+		}
+	}
+	fmt.Println()
 }
 
 // watchPaneCmd builds a shell command for a watch pane.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -94,15 +94,17 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 
 // stateResponse is the JSON shape for GET /api/v1/state.
 type stateResponse struct {
-	Repo        string          `json:"repo"`
-	MaxParallel int             `json:"max_parallel"`
-	ReadOnly    bool            `json:"read_only"`
-	All         []sessionInfo   `json:"all"`
-	Running     []sessionInfo   `json:"running"`
-	PROpen      []sessionInfo   `json:"pr_open"`
-	Queued      []sessionInfo   `json:"queued"`
-	TokenTotals tokenTotalsInfo `json:"token_totals"`
-	Summary     map[string]int  `json:"summary"`
+	Repo                string                     `json:"repo"`
+	MaxParallel         int                        `json:"max_parallel"`
+	ReadOnly            bool                       `json:"read_only"`
+	All                 []sessionInfo              `json:"all"`
+	Running             []sessionInfo              `json:"running"`
+	PROpen              []sessionInfo              `json:"pr_open"`
+	Queued              []sessionInfo              `json:"queued"`
+	TokenTotals         tokenTotalsInfo            `json:"token_totals"`
+	Summary             map[string]int             `json:"summary"`
+	SupervisorLatest    *state.SupervisorDecision  `json:"supervisor_latest,omitempty"`
+	SupervisorDecisions []state.SupervisorDecision `json:"supervisor_decisions,omitempty"`
 }
 
 type tokenTotalsInfo struct {
@@ -277,14 +279,16 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := stateResponse{
-		Repo:        s.cfg.Repo,
-		MaxParallel: s.cfg.MaxParallel,
-		ReadOnly:    s.cfg.Server.ReadOnly,
-		All:         make([]sessionInfo, 0, len(st.Sessions)),
-		Running:     make([]sessionInfo, 0),
-		PROpen:      make([]sessionInfo, 0),
-		Queued:      make([]sessionInfo, 0),
-		Summary:     make(map[string]int),
+		Repo:                s.cfg.Repo,
+		MaxParallel:         s.cfg.MaxParallel,
+		ReadOnly:            s.cfg.Server.ReadOnly,
+		All:                 make([]sessionInfo, 0, len(st.Sessions)),
+		Running:             make([]sessionInfo, 0),
+		PROpen:              make([]sessionInfo, 0),
+		Queued:              make([]sessionInfo, 0),
+		Summary:             make(map[string]int),
+		SupervisorLatest:    st.LatestSupervisorDecision(),
+		SupervisorDecisions: st.SupervisorDecisions,
 	}
 
 	var activeTokens, totalTokens int

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -97,11 +97,48 @@ type Mission struct {
 	Status      string `json:"status"` // "active", "done"
 }
 
+const DefaultSupervisorDecisionLimit = 20
+
+// SupervisorTarget identifies the primary object a supervisor decision refers to.
+type SupervisorTarget struct {
+	Issue   int    `json:"issue,omitempty"`
+	PR      int    `json:"pr,omitempty"`
+	Session string `json:"session,omitempty"`
+}
+
+// SupervisorProjectState captures the read-only state snapshot behind a decision.
+type SupervisorProjectState struct {
+	Sessions       int `json:"sessions"`
+	Running        int `json:"running"`
+	PROpen         int `json:"pr_open"`
+	Queued         int `json:"queued"`
+	RetryExhausted int `json:"retry_exhausted"`
+	OpenIssues     int `json:"open_issues"`
+	OpenPRs        int `json:"open_prs"`
+	AvailableSlots int `json:"available_slots"`
+}
+
+// SupervisorDecision is a stable, machine-readable read-only orchestration record.
+type SupervisorDecision struct {
+	ID                string                 `json:"id"`
+	CreatedAt         time.Time              `json:"created_at"`
+	Project           string                 `json:"project"`
+	Mode              string                 `json:"mode"`
+	Summary           string                 `json:"summary"`
+	RecommendedAction string                 `json:"recommended_action"`
+	Target            *SupervisorTarget      `json:"target,omitempty"`
+	Risk              string                 `json:"risk"`
+	Confidence        float64                `json:"confidence"`
+	Reasons           []string               `json:"reasons,omitempty"`
+	ProjectState      SupervisorProjectState `json:"project_state"`
+}
+
 type State struct {
-	Sessions    map[string]*Session `json:"sessions"`
-	Missions    map[int]*Mission    `json:"missions,omitempty"` // parent issue number → mission
-	NextSlot    int                 `json:"next_slot"`
-	LastMergeAt time.Time           `json:"last_merge_at,omitempty"`
+	Sessions            map[string]*Session  `json:"sessions"`
+	Missions            map[int]*Mission     `json:"missions,omitempty"` // parent issue number → mission
+	SupervisorDecisions []SupervisorDecision `json:"supervisor_decisions,omitempty"`
+	NextSlot            int                  `json:"next_slot"`
+	LastMergeAt         time.Time            `json:"last_merge_at,omitempty"`
 }
 
 func NewState() *State {
@@ -163,6 +200,31 @@ func (s *State) NextSlotName(prefix string) string {
 	name := fmt.Sprintf("%s-%d", prefix, s.NextSlot)
 	s.NextSlot++
 	return name
+}
+
+// RecordSupervisorDecision appends a supervisor decision and keeps only recent records.
+func (s *State) RecordSupervisorDecision(decision SupervisorDecision, limit int) {
+	if limit <= 0 {
+		limit = DefaultSupervisorDecisionLimit
+	}
+	s.SupervisorDecisions = append(s.SupervisorDecisions, decision)
+	if len(s.SupervisorDecisions) > limit {
+		s.SupervisorDecisions = append([]SupervisorDecision(nil), s.SupervisorDecisions[len(s.SupervisorDecisions)-limit:]...)
+	}
+}
+
+// LatestSupervisorDecision returns the newest supervisor decision by creation time.
+func (s *State) LatestSupervisorDecision() *SupervisorDecision {
+	if len(s.SupervisorDecisions) == 0 {
+		return nil
+	}
+	latest := 0
+	for i := 1; i < len(s.SupervisorDecisions); i++ {
+		if s.SupervisorDecisions[i].CreatedAt.After(s.SupervisorDecisions[latest].CreatedAt) {
+			latest = i
+		}
+	}
+	return &s.SupervisorDecisions[latest]
 }
 
 // ActiveSessions returns sessions that are currently running

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -784,5 +785,72 @@ func TestCountByStatus_Empty(t *testing.T) {
 	counts := s.CountByStatus()
 	if len(counts) != 0 {
 		t.Errorf("expected empty map for empty state, got %v", counts)
+	}
+}
+
+func TestSupervisorDecisionPersistence(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	s := NewState()
+	s.RecordSupervisorDecision(SupervisorDecision{
+		ID:                "sup-test",
+		CreatedAt:         now,
+		Project:           "owner/repo",
+		Mode:              "read_only",
+		Summary:           "Start a worker for issue #42.",
+		RecommendedAction: "spawn_worker",
+		Target:            &SupervisorTarget{Issue: 42},
+		Risk:              "mutating",
+		Confidence:        0.84,
+		Reasons:           []string{"Issue #42 is eligible"},
+		ProjectState: SupervisorProjectState{
+			Sessions:       0,
+			OpenIssues:     1,
+			AvailableSlots: 1,
+		},
+	}, DefaultSupervisorDecisionLimit)
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	latest := loaded.LatestSupervisorDecision()
+	if latest == nil {
+		t.Fatal("latest supervisor decision missing")
+	}
+	if latest.ID != "sup-test" {
+		t.Fatalf("ID = %q, want sup-test", latest.ID)
+	}
+	if latest.Target == nil || latest.Target.Issue != 42 {
+		t.Fatalf("target = %#v, want issue 42", latest.Target)
+	}
+	if latest.ProjectState.OpenIssues != 1 {
+		t.Fatalf("open issues = %d, want 1", latest.ProjectState.OpenIssues)
+	}
+}
+
+func TestRecordSupervisorDecisionPrunesOldRecords(t *testing.T) {
+	s := NewState()
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		s.RecordSupervisorDecision(SupervisorDecision{
+			ID:        fmt.Sprintf("sup-%d", i),
+			CreatedAt: now.Add(time.Duration(i) * time.Minute),
+		}, 3)
+	}
+
+	if len(s.SupervisorDecisions) != 3 {
+		t.Fatalf("decisions = %d, want 3", len(s.SupervisorDecisions))
+	}
+	if s.SupervisorDecisions[0].ID != "sup-2" {
+		t.Fatalf("first retained ID = %q, want sup-2", s.SupervisorDecisions[0].ID)
+	}
+	latest := s.LatestSupervisorDecision()
+	if latest == nil || latest.ID != "sup-4" {
+		t.Fatalf("latest = %#v, want sup-4", latest)
 	}
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1,0 +1,445 @@
+package supervisor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/mission"
+	"github.com/befeast/maestro/internal/state"
+)
+
+const (
+	ModeReadOnly = "read_only"
+
+	ActionNone                 = "none"
+	ActionWaitForRunningWorker = "wait_for_running_worker"
+	ActionWaitForCapacity      = "wait_for_capacity"
+	ActionMonitorOpenPR        = "monitor_open_pr"
+	ActionReviewRetryExhausted = "review_retry_exhausted"
+	ActionSpawnWorker          = "spawn_worker"
+	ActionLabelIssueReady      = "label_issue_ready"
+
+	RiskSafe          = "safe"
+	RiskMutating      = "mutating"
+	RiskApprovalGated = "approval_gated"
+)
+
+// Reader is the read-only GitHub surface used by the supervisor engine.
+type Reader interface {
+	ListOpenIssues(labels []string) ([]github.Issue, error)
+	ListOpenPRs() ([]github.PR, error)
+	HasOpenPRForIssue(issueNumber int) (bool, error)
+	IsIssueClosed(number int) (bool, error)
+}
+
+// Engine makes deterministic read-only supervisor decisions.
+type Engine struct {
+	cfg    *config.Config
+	reader Reader
+	now    func() time.Time
+}
+
+func NewEngine(cfg *config.Config, reader Reader) *Engine {
+	if reader == nil {
+		reader = github.New(cfg.Repo)
+	}
+	return &Engine{
+		cfg:    cfg,
+		reader: reader,
+		now:    func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// RunOnce records one read-only supervisor decision in Maestro state.
+func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error) {
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		return state.SupervisorDecision{}, fmt.Errorf("load state: %w", err)
+	}
+
+	decision, err := NewEngine(cfg, reader).Decide(st)
+	if err != nil {
+		return state.SupervisorDecision{}, err
+	}
+	st.RecordSupervisorDecision(decision, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		return state.SupervisorDecision{}, fmt.Errorf("save state: %w", err)
+	}
+	return decision, nil
+}
+
+// Decide observes state and GitHub read-only data, then returns the next recommendation.
+func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
+	if st == nil {
+		st = state.NewState()
+	}
+	now := e.now().UTC()
+	projectState := e.projectState(st)
+	baseReasons := []string{
+		fmt.Sprintf("State has %d session(s)", projectState.Sessions),
+		fmt.Sprintf("%d active session(s) count against %d max parallel slot(s)", len(st.ActiveSessions()), e.cfg.MaxParallel),
+	}
+
+	prs, err := e.reader.ListOpenPRs()
+	if err != nil {
+		return state.SupervisorDecision{}, fmt.Errorf("list open PRs: %w", err)
+	}
+	projectState.OpenPRs = len(prs)
+
+	if slot, sess, pr, ok := sessionWithOpenPR(st, prs); ok {
+		reasons := appendReasons(baseReasons,
+			fmt.Sprintf("Session %s is associated with open PR #%d", slot, pr.Number),
+			"No GitHub mutation is needed for supervisor mode",
+		)
+		return e.decision(now, projectState, ActionMonitorOpenPR,
+			fmt.Sprintf("Session %s already has open PR #%d; monitor review, CI, or merge readiness.", slot, pr.Number),
+			RiskSafe, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, reasons), nil
+	}
+
+	if slot, sess, ok := runningSession(st); ok {
+		reasons := appendReasons(baseReasons,
+			fmt.Sprintf("Session %s is running for issue #%d", slot, sess.IssueNumber),
+			"Starting another worker is not recommended while a worker is active",
+		)
+		return e.decision(now, projectState, ActionWaitForRunningWorker,
+			fmt.Sprintf("Worker %s is still running for issue #%d.", slot, sess.IssueNumber),
+			RiskSafe, 0.88, &state.SupervisorTarget{Issue: sess.IssueNumber, Session: slot}, reasons), nil
+	}
+
+	if slot, sess, ok := retryExhaustedSession(st); ok {
+		reasons := appendReasons(baseReasons,
+			fmt.Sprintf("Session %s for issue #%d is retry_exhausted", slot, sess.IssueNumber),
+			"Retry-exhausted work requires a human decision before more automation",
+		)
+		return e.decision(now, projectState, ActionReviewRetryExhausted,
+			fmt.Sprintf("Issue #%d exhausted its retry budget and needs manual review.", sess.IssueNumber),
+			RiskApprovalGated, 0.93, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}, reasons), nil
+	}
+
+	issues, err := e.reader.ListOpenIssues(nil)
+	if err != nil {
+		return state.SupervisorDecision{}, fmt.Errorf("list open issues: %w", err)
+	}
+	projectState.OpenIssues = len(issues)
+
+	eligible, skipped, err := e.eligibleIssues(st, issues, true)
+	if err != nil {
+		return state.SupervisorDecision{}, err
+	}
+
+	if len(eligible) > 0 {
+		issue := eligible[0]
+		if projectState.AvailableSlots <= 0 {
+			reasons := appendReasons(baseReasons,
+				fmt.Sprintf("Issue #%d is eligible but no worker slot is available", issue.Number),
+			)
+			return e.decision(now, projectState, ActionWaitForCapacity,
+				fmt.Sprintf("Issue #%d is eligible, but all worker slots are occupied.", issue.Number),
+				RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, reasons), nil
+		}
+
+		hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number)
+		if err != nil {
+			return state.SupervisorDecision{}, fmt.Errorf("check open PR for issue #%d: %w", issue.Number, err)
+		}
+		if hasOpenPR {
+			reasons := appendReasons(baseReasons,
+				fmt.Sprintf("Issue #%d is eligible but GitHub already has an open PR referencing it", issue.Number),
+				"Supervisor mode should not dispatch duplicate work",
+			)
+			return e.decision(now, projectState, ActionMonitorOpenPR,
+				fmt.Sprintf("Issue #%d already has an open PR; monitor that PR instead of starting work.", issue.Number),
+				RiskSafe, 0.87, &state.SupervisorTarget{Issue: issue.Number}, reasons), nil
+		}
+
+		reasons := appendReasons(baseReasons,
+			issueLabelReason(e.cfg.IssueLabels),
+			fmt.Sprintf("Issue #%d is the next eligible issue", issue.Number),
+			"Starting a worker would mutate local worktrees, so supervisor only records the recommendation",
+		)
+		return e.decision(now, projectState, ActionSpawnWorker,
+			fmt.Sprintf("Start a worker for issue #%d: %s", issue.Number, issue.Title),
+			RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, reasons), nil
+	}
+
+	if len(e.cfg.IssueLabels) > 0 {
+		unlabeled, err := e.firstIssueMissingRequiredLabel(st, issues)
+		if err != nil {
+			return state.SupervisorDecision{}, err
+		}
+		if unlabeled != nil {
+			reasons := appendReasons(baseReasons,
+				issueLabelReason(e.cfg.IssueLabels),
+				fmt.Sprintf("Issue #%d is open but does not have a configured ready label", unlabeled.Number),
+			)
+			return e.decision(now, projectState, ActionLabelIssueReady,
+				fmt.Sprintf("No eligible issues because none have the configured ready label; issue #%d is next in the open queue.", unlabeled.Number),
+				RiskMutating, 0.82, &state.SupervisorTarget{Issue: unlabeled.Number}, reasons), nil
+		}
+	}
+
+	reasons := appendReasons(baseReasons,
+		fmt.Sprintf("Checked %d open issue(s)", len(issues)),
+		"No worker is running, no PR needs attention, and no eligible issue is ready",
+	)
+	for _, reason := range firstN(skipped, 3) {
+		reasons = append(reasons, reason)
+	}
+	return e.decision(now, projectState, ActionNone,
+		"No action is currently recommended.", RiskSafe, 0.8, nil, reasons), nil
+}
+
+func (e *Engine) decision(now time.Time, ps state.SupervisorProjectState, action, summary, risk string, confidence float64, target *state.SupervisorTarget, reasons []string) state.SupervisorDecision {
+	return state.SupervisorDecision{
+		ID:                "sup-" + now.Format("20060102T150405.000000000Z"),
+		CreatedAt:         now,
+		Project:           e.cfg.Repo,
+		Mode:              ModeReadOnly,
+		Summary:           summary,
+		RecommendedAction: action,
+		Target:            target,
+		Risk:              risk,
+		Confidence:        confidence,
+		Reasons:           compactReasons(reasons),
+		ProjectState:      ps,
+	}
+}
+
+func (e *Engine) projectState(st *state.State) state.SupervisorProjectState {
+	counts := st.CountByStatus()
+	return state.SupervisorProjectState{
+		Sessions:       len(st.Sessions),
+		Running:        counts[state.StatusRunning],
+		PROpen:         counts[state.StatusPROpen],
+		Queued:         counts[state.StatusQueued],
+		RetryExhausted: countSessions(st, state.StatusRetryExhausted),
+		AvailableSlots: availableSlots(e.cfg, st),
+	}
+}
+
+func (e *Engine) eligibleIssues(st *state.State, issues []github.Issue, requireLabels bool) ([]github.Issue, []string, error) {
+	var eligible []github.Issue
+	var skipped []string
+	for _, issue := range issues {
+		if requireLabels && !matchesRequiredLabels(issue, e.cfg.IssueLabels) {
+			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped: missing configured ready label", issue.Number))
+			continue
+		}
+		reason, err := e.issueSkipReason(st, issue)
+		if err != nil {
+			return nil, nil, err
+		}
+		if reason != "" {
+			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped: %s", issue.Number, reason))
+			continue
+		}
+		eligible = append(eligible, issue)
+	}
+	return eligible, skipped, nil
+}
+
+func (e *Engine) firstIssueMissingRequiredLabel(st *state.State, issues []github.Issue) (*github.Issue, error) {
+	for i := range issues {
+		issue := &issues[i]
+		if matchesRequiredLabels(*issue, e.cfg.IssueLabels) {
+			continue
+		}
+		reason, err := e.issueSkipReason(st, *issue)
+		if err != nil {
+			return nil, err
+		}
+		if reason == "" {
+			return issue, nil
+		}
+	}
+	return nil, nil
+}
+
+func (e *Engine) issueSkipReason(st *state.State, issue github.Issue) (string, error) {
+	if st.IssueInProgress(issue.Number) {
+		return "already in progress", nil
+	}
+	if st.IssueDone(issue.Number) {
+		return "already completed in state", nil
+	}
+	if st.IssueRetryExhausted(issue.Number) {
+		return "retry limit exhausted", nil
+	}
+	if e.cfg.MaxRetriesPerIssue > 0 && st.FailedAttemptsForIssue(issue.Number) >= e.cfg.MaxRetriesPerIssue {
+		return "retry limit exhausted", nil
+	}
+	if st.IsMissionParent(issue.Number) {
+		return "mission parent issue", nil
+	}
+	if e.cfg.Missions.Enabled && mission.IsMissionIssue(issue, e.cfg.Missions.Labels) && !st.IsMissionChild(issue.Number) {
+		return "mission issue awaits decomposition", nil
+	}
+	if github.HasLabel(issue, e.cfg.ExcludeLabels) {
+		return "excluded by configured label", nil
+	}
+	if len(e.cfg.BlockerPatterns) > 0 {
+		blockers := github.FindBlockers(issue.Body, e.cfg.BlockerPatterns)
+		openBlockers, err := e.openBlockers(blockers)
+		if err != nil {
+			return "", err
+		}
+		if len(openBlockers) > 0 {
+			return fmt.Sprintf("blocked by open issue(s) %s", issueRefs(openBlockers)), nil
+		}
+	}
+	return "", nil
+}
+
+func (e *Engine) openBlockers(blockers []int) ([]int, error) {
+	var open []int
+	for _, blocker := range blockers {
+		closed, err := e.reader.IsIssueClosed(blocker)
+		if err != nil {
+			return nil, fmt.Errorf("check blocker #%d: %w", blocker, err)
+		}
+		if !closed {
+			open = append(open, blocker)
+		}
+	}
+	return open, nil
+}
+
+func sessionWithOpenPR(st *state.State, prs []github.PR) (string, *state.Session, github.PR, bool) {
+	branchToPR := make(map[string]github.PR, len(prs))
+	numberToPR := make(map[int]github.PR, len(prs))
+	for _, pr := range prs {
+		branchToPR[pr.HeadRefName] = pr
+		numberToPR[pr.Number] = pr
+	}
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess == nil {
+			continue
+		}
+		if sess.Branch != "" {
+			if pr, ok := branchToPR[sess.Branch]; ok {
+				return slot, sess, pr, true
+			}
+		}
+		if sess.PRNumber > 0 {
+			if pr, ok := numberToPR[sess.PRNumber]; ok {
+				return slot, sess, pr, true
+			}
+			if sess.Status == state.StatusPROpen {
+				return slot, sess, github.PR{Number: sess.PRNumber, HeadRefName: sess.Branch, State: "OPEN", Title: sess.IssueTitle}, true
+			}
+		}
+	}
+	return "", nil, github.PR{}, false
+}
+
+func runningSession(st *state.State) (string, *state.Session, bool) {
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess != nil && sess.Status == state.StatusRunning {
+			return slot, sess, true
+		}
+	}
+	return "", nil, false
+}
+
+func retryExhaustedSession(st *state.State) (string, *state.Session, bool) {
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess != nil && sess.Status == state.StatusRetryExhausted {
+			return slot, sess, true
+		}
+	}
+	return "", nil, false
+}
+
+func sortedSessionNames(st *state.State) []string {
+	names := make([]string, 0, len(st.Sessions))
+	for name := range st.Sessions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func availableSlots(cfg *config.Config, st *state.State) int {
+	maxParallel := cfg.MaxParallel
+	active := len(st.ActiveSessions())
+	slots := maxParallel - active
+	if limit, ok := cfg.MaxConcurrentByState["running"]; ok && limit > 0 {
+		runningSlots := limit - st.CountByStatus()[state.StatusRunning]
+		if runningSlots < slots {
+			slots = runningSlots
+		}
+	}
+	if slots < 0 {
+		return 0
+	}
+	return slots
+}
+
+func countSessions(st *state.State, status state.SessionStatus) int {
+	count := 0
+	for _, sess := range st.Sessions {
+		if sess != nil && sess.Status == status {
+			count++
+		}
+	}
+	return count
+}
+
+func matchesRequiredLabels(issue github.Issue, labels []string) bool {
+	if len(labels) == 0 {
+		return true
+	}
+	return github.HasLabel(issue, labels)
+}
+
+func issueLabelReason(labels []string) string {
+	if len(labels) == 0 {
+		return "Config has no issue label filter"
+	}
+	return "Config requires one of issue_labels: " + strings.Join(labels, ", ")
+}
+
+func issueRefs(numbers []int) string {
+	refs := make([]string, len(numbers))
+	for i, n := range numbers {
+		refs[i] = fmt.Sprintf("#%d", n)
+	}
+	return strings.Join(refs, ", ")
+}
+
+func appendReasons(base []string, extra ...string) []string {
+	reasons := append([]string(nil), base...)
+	reasons = append(reasons, extra...)
+	return compactReasons(reasons)
+}
+
+func compactReasons(reasons []string) []string {
+	seen := make(map[string]struct{}, len(reasons))
+	compact := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		reason = strings.TrimSpace(reason)
+		if reason == "" {
+			continue
+		}
+		if _, ok := seen[reason]; ok {
+			continue
+		}
+		seen[reason] = struct{}{}
+		compact = append(compact, reason)
+	}
+	return compact
+}
+
+func firstN(values []string, n int) []string {
+	if len(values) <= n {
+		return values
+	}
+	return values[:n]
+}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,0 +1,233 @@
+package supervisor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+type fakeReader struct {
+	issues       []github.Issue
+	prs          []github.PR
+	openPRIssues map[int]bool
+	closedIssues map[int]bool
+	issueCalls   int
+}
+
+func (f *fakeReader) ListOpenIssues(labels []string) ([]github.Issue, error) {
+	f.issueCalls++
+	return f.issues, nil
+}
+
+func (f *fakeReader) ListOpenPRs() ([]github.PR, error) {
+	return f.prs, nil
+}
+
+func (f *fakeReader) HasOpenPRForIssue(issueNumber int) (bool, error) {
+	return f.openPRIssues[issueNumber], nil
+}
+
+func (f *fakeReader) IsIssueClosed(number int) (bool, error) {
+	return f.closedIssues[number], nil
+}
+
+func testConfig(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{
+		Repo:               "owner/repo",
+		StateDir:           t.TempDir(),
+		MaxParallel:        1,
+		MaxRetriesPerIssue: 3,
+	}
+}
+
+func testEngine(cfg *config.Config, reader *fakeReader) *Engine {
+	eng := NewEngine(cfg, reader)
+	eng.now = func() time.Time { return time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC) }
+	return eng
+}
+
+func testIssue(number int, title string, labels ...string) github.Issue {
+	issue := github.Issue{Number: number, Title: title}
+	for _, label := range labels {
+		issue.Labels = append(issue.Labels, struct {
+			Name string `json:"name"`
+		}{Name: label})
+	}
+	return issue
+}
+
+func TestDecide_IdleNoEligibleIssueRecommendsLabel(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{testIssue(308, "implement supervisor")}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionLabelIssueReady {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionLabelIssueReady)
+	}
+	if decision.Target == nil || decision.Target.Issue != 308 {
+		t.Fatalf("target = %#v, want issue 308", decision.Target)
+	}
+	if decision.Risk != RiskMutating {
+		t.Errorf("risk = %q, want %q", decision.Risk, RiskMutating)
+	}
+	if decision.Mode != ModeReadOnly {
+		t.Errorf("mode = %q, want %q", decision.Mode, ModeReadOnly)
+	}
+}
+
+func TestDecide_RunningWorkerWaits(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "work in progress",
+		Status:      state.StatusRunning,
+		StartedAt:   time.Now().UTC(),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionWaitForRunningWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionWaitForRunningWorker)
+	}
+	if decision.Target == nil || decision.Target.Session != "slot-1" || decision.Target.Issue != 42 {
+		t.Fatalf("target = %#v, want slot-1 issue 42", decision.Target)
+	}
+	if reader.issueCalls != 0 {
+		t.Fatalf("ListOpenIssues called %d time(s), want 0 for running-worker decision", reader.issueCalls)
+	}
+}
+
+func TestDecide_RetryExhaustedNeedsReview(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+	st := state.NewState()
+	st.Sessions["slot-2"] = &state.Session{
+		IssueNumber: 77,
+		IssueTitle:  "flaky work",
+		Status:      state.StatusRetryExhausted,
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionReviewRetryExhausted {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionReviewRetryExhausted)
+	}
+	if decision.Risk != RiskApprovalGated {
+		t.Errorf("risk = %q, want %q", decision.Risk, RiskApprovalGated)
+	}
+	if decision.Target == nil || decision.Target.Issue != 77 {
+		t.Fatalf("target = %#v, want issue 77", decision.Target)
+	}
+}
+
+func TestDecide_PRExistsForSessionMonitorsPR(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{prs: []github.PR{{Number: 12, HeadRefName: "mae-1-42-fix", State: "OPEN"}}}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "fix bug",
+		Status:      state.StatusDead,
+		Branch:      "mae-1-42-fix",
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionMonitorOpenPR)
+	}
+	if decision.Target == nil || decision.Target.PR != 12 || decision.Target.Session != "slot-1" {
+		t.Fatalf("target = %#v, want PR 12 for slot-1", decision.Target)
+	}
+	if reader.issueCalls != 0 {
+		t.Fatalf("ListOpenIssues called %d time(s), want 0 for PR-session decision", reader.issueCalls)
+	}
+}
+
+func TestDecide_EligibleIssueRecommendsSpawn(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Target == nil || decision.Target.Issue != 42 {
+		t.Fatalf("target = %#v, want issue 42", decision.Target)
+	}
+	if decision.Risk != RiskMutating {
+		t.Errorf("risk = %q, want %q", decision.Risk, RiskMutating)
+	}
+}
+
+func TestDecide_EmptyStateNoAction(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionNone {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionNone)
+	}
+	if decision.Target != nil {
+		t.Fatalf("target = %#v, want nil", decision.Target)
+	}
+	if decision.ProjectState.OpenIssues != 0 || decision.ProjectState.OpenPRs != 0 {
+		t.Fatalf("project state = %#v, want no open issues or PRs", decision.ProjectState)
+	}
+}
+
+func TestRunOnceRecordsDecision(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if decision.RecommendedAction != ActionNone {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionNone)
+	}
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	latest := st.LatestSupervisorDecision()
+	if latest == nil {
+		t.Fatal("latest supervisor decision missing")
+	}
+	if latest.ID != decision.ID {
+		t.Fatalf("latest ID = %q, want %q", latest.ID, decision.ID)
+	}
+}


### PR DESCRIPTION
Closes #261

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a read-only `supervise` command backed by a new deterministic `Engine` that inspects GitHub and local state to produce structured `SupervisorDecision` records, which are persisted in state and surfaced through the server API and `status` output.

- **P1 — `cmd/maestro/main.go`**: `runOnce` uses `log.Fatalf` on error, so any transient failure (GitHub rate limit, network blip, state-file lock) permanently kills the recurring supervision daemon instead of logging and retrying on the next tick.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without addressing the fatal-on-error behaviour in the recurring supervision loop.

One P1 defect: `log.Fatalf` inside the `runOnce` closure terminates the long-running supervise process on any transient error, making the recurring-loop mode unreliable in practice. The decision engine and state layer are solid, pulling the score slightly below the P1 ceiling.

`cmd/maestro/main.go` — the `superviseCmd` error-handling closure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Adds `supervise` CLI command and display helpers; `log.Fatalf` inside the recurring-loop closure will kill the process on any transient error. |
| internal/supervisor/supervisor.go | New deterministic read-only decision engine with well-structured priority chain; logic is sound. |
| internal/state/state.go | Adds `SupervisorDecision` types plus `RecordSupervisorDecision`/`LatestSupervisorDecision`; pruning and linear-scan logic are correct. |
| internal/server/server.go | Exposes supervisor latest and history in the state API response; straightforward and non-breaking change. |
| internal/state/state_test.go | Covers persistence round-trip and pruning behaviour; tests are correct. |
| internal/supervisor/supervisor_test.go | Good coverage of all decision branches using a fake reader; deterministic clock injected correctly. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cmd/maestro/main.go`, line 60-66 ([link](https://github.com/befeast/maestro/blob/8dc586a0651ba760ff91427bff306f383cc1ae6a/cmd/maestro/main.go#L60-L66)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`log.Fatalf` terminates the recurring supervision loop on any transient error**

   `runOnce` calls `log.Fatalf` on any `supervisor.RunOnce` error, which exits the process. For the recurring-loop path (i.e., when `--once` is not set), a transient failure — GitHub rate limit, network blip, or a momentary state-file lock — will permanently kill the supervision daemon instead of logging the error and retrying on the next tick.

   ```go
   runOnce := func() {
       decision, err := supervisor.RunOnce(cfg, gh)
       if err != nil {
           log.Printf("supervise: %v", err)
           return
       }
       printSupervisorDecision(decision, *jsonOutput)
   }
   ```
   Using `log.Printf` + `return` keeps the loop alive through transient failures. If hard-exit behavior is desired only for `--once` mode, a boolean parameter or separate closures could distinguish the two paths.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/maestro/main.go
   Line: 60-66

   Comment:
   **`log.Fatalf` terminates the recurring supervision loop on any transient error**

   `runOnce` calls `log.Fatalf` on any `supervisor.RunOnce` error, which exits the process. For the recurring-loop path (i.e., when `--once` is not set), a transient failure — GitHub rate limit, network blip, or a momentary state-file lock — will permanently kill the supervision daemon instead of logging the error and retrying on the next tick.

   ```go
   runOnce := func() {
       decision, err := supervisor.RunOnce(cfg, gh)
       if err != nil {
           log.Printf("supervise: %v", err)
           return
       }
       printSupervisorDecision(decision, *jsonOutput)
   }
   ```
   Using `log.Printf` + `return` keeps the loop alive through transient failures. If hard-exit behavior is desired only for `--once` mode, a boolean parameter or separate closures could distinguish the two paths.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: cmd/maestro/main.go
Line: 60-66

Comment:
**`log.Fatalf` terminates the recurring supervision loop on any transient error**

`runOnce` calls `log.Fatalf` on any `supervisor.RunOnce` error, which exits the process. For the recurring-loop path (i.e., when `--once` is not set), a transient failure — GitHub rate limit, network blip, or a momentary state-file lock — will permanently kill the supervision daemon instead of logging the error and retrying on the next tick.

```go
runOnce := func() {
    decision, err := supervisor.RunOnce(cfg, gh)
    if err != nil {
        log.Printf("supervise: %v", err)
        return
    }
    printSupervisorDecision(decision, *jsonOutput)
}
```
Using `log.Printf` + `return` keeps the loop alive through transient failures. If hard-exit behavior is desired only for `--once` mode, a boolean parameter or separate closures could distinguish the two paths.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add read-only supervisor decisions"](https://github.com/befeast/maestro/commit/8dc586a0651ba760ff91427bff306f383cc1ae6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30214135)</sub>

<!-- /greptile_comment -->