### PR TITLE
Supervisor policy file and ordered queue model

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -543,6 +543,7 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 	fmt.Printf("Session prefix: %s\n", cfg.SessionPrefix)
 	fmt.Printf("State file:     %s\n", state.StatePath(cfg.StateDir))
 	fmt.Printf("Max parallel:   %d\n", cfg.MaxParallel)
+	showSupervisorPolicy(cfg)
 	if len(cfg.MaxConcurrentByState) > 0 {
 		// Sort keys for stable output
 		stateNames := make([]string, 0, len(cfg.MaxConcurrentByState))
@@ -690,6 +691,40 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 			}
 		}
 	}
+}
+
+func showSupervisorPolicy(cfg *config.Config) {
+	mode := strings.TrimSpace(cfg.Supervisor.Mode)
+	if mode == "" {
+		mode = "cautious"
+	}
+	fmt.Printf("Supervisor:     mode=%s enabled=%v\n", mode, cfg.Supervisor.Enabled)
+	if cfg.Supervisor.PolicyPath != "" {
+		fmt.Printf("Policy file:    %s\n", cfg.Supervisor.PolicyPath)
+	}
+	if cfg.Supervisor.ReadyLabel != "" || cfg.Supervisor.BlockedLabel != "" {
+		fmt.Printf("Policy labels:  ready=%s blocked=%s\n", valueOrDash(cfg.Supervisor.ReadyLabel), valueOrDash(cfg.Supervisor.BlockedLabel))
+	}
+	if len(cfg.Supervisor.ExcludedLabels) > 0 {
+		fmt.Printf("Policy exclude: %s\n", strings.Join(cfg.Supervisor.ExcludedLabels, ", "))
+	}
+	if cfg.Supervisor.OrderedQueueActive() {
+		fmt.Printf("Policy queue:   ordered (%d issue(s))\n", len(cfg.Supervisor.OrderedQueue.Issues))
+	}
+	if len(cfg.Supervisor.SafeActions) > 0 {
+		fmt.Printf("Safe actions:   %s\n", strings.Join(cfg.Supervisor.SafeActions, ", "))
+	}
+	if len(cfg.Supervisor.ApprovalRequired) > 0 {
+		fmt.Printf("Approval req.:  %s\n", strings.Join(cfg.Supervisor.ApprovalRequired, ", "))
+	}
+}
+
+func valueOrDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
 }
 
 func logsCmd(args []string) {

--- a/docs/PRD-gh-project-integration.md
+++ b/docs/PRD-gh-project-integration.md
@@ -114,6 +114,8 @@ It may still expose issue reads, but tracker-facing selection and workflow state
 
 ## Config Design
 
+Supervisor policy is a separate local safety layer from tracker configuration. It may be set in the top-level `supervisor:` block or in `.maestro/supervisor.yaml`, and covers queue order, ready/blocked labels, excluded issue types, safe actions, and approval-gated actions.
+
 Add a new top-level block:
 
 ```yaml

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -141,6 +141,30 @@ exclude_labels:
   - duplicate
   - invalid
 
+# Supervisor policy (optional)
+supervisor:
+  enabled: true
+  mode: cautious
+  ready_label: maestro-ready
+  blocked_label: blocked
+  excluded_labels:
+    - epic
+    - meta
+  ordered_queue:
+    enabled: true
+    issues:
+      - 308
+      - 306
+  safe_actions:
+    - add_ready_label
+    - remove_blocked_label
+    - add_issue_comment
+  approval_required:
+    - merge_pr
+    - close_issue
+    - delete_worktree
+    - change_global_config
+
 # Concurrency
 max_parallel: 5
 max_runtime_minutes: 120
@@ -170,10 +194,13 @@ telegram:
 | `worktree_base` | Directory where maestro creates per-worker worktrees |
 | `issue_labels` | Only pick issues with at least one of these labels (OR semantics) |
 | `exclude_labels` | Skip issues with any of these labels |
+| `supervisor` | Optional local policy for supervisor queue order, safe actions, and issue-type skips |
 | `max_parallel` | Maximum concurrent worker sessions |
 | `deploy_cmd` | Shell command maestro runs after merging a PR |
 | `session_prefix` | Prefix for tmux session names |
 | `worker_prompt` | Path to the worker prompt template file |
+
+Supervisor policy can also live in `.maestro/supervisor.yaml` next to the project config or repository checkout. If an ordered queue is configured, only the first unfinished issue in that queue is eligible for supervisor dispatch.
 
 ### Optional: versioning config
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,70 @@ type GitHubProjectsConfig struct {
 	ProjectNumber int  `yaml:"project_number"` // GitHub Project number (auto-detect from repo)
 }
 
+const (
+	SupervisorActionAddReadyLabel      = "add_ready_label"
+	SupervisorActionRemoveBlockedLabel = "remove_blocked_label"
+	SupervisorActionAddIssueComment    = "add_issue_comment"
+	SupervisorActionMergePR            = "merge_pr"
+	SupervisorActionCloseIssue         = "close_issue"
+	SupervisorActionDeleteWorktree     = "delete_worktree"
+	SupervisorActionChangeGlobalConfig = "change_global_config"
+)
+
+// SupervisorConfig defines local policy for supervisor decisions.
+type SupervisorConfig struct {
+	Enabled          bool                         `yaml:"enabled" json:"enabled"`
+	Mode             string                       `yaml:"mode" json:"mode"`
+	ReadyLabel       string                       `yaml:"ready_label" json:"ready_label,omitempty"`
+	BlockedLabel     string                       `yaml:"blocked_label" json:"blocked_label,omitempty"`
+	ExcludedLabels   []string                     `yaml:"excluded_labels" json:"excluded_labels,omitempty"`
+	AllowIssueTypes  []string                     `yaml:"allow_issue_types" json:"allow_issue_types,omitempty"`
+	OrderedQueue     SupervisorOrderedQueueConfig `yaml:"ordered_queue" json:"ordered_queue,omitempty"`
+	SafeActions      []string                     `yaml:"safe_actions" json:"safe_actions,omitempty"`
+	ApprovalRequired []string                     `yaml:"approval_required" json:"approval_required,omitempty"`
+	PolicyPath       string                       `yaml:"-" json:"policy_path,omitempty"`
+
+	excludedLabelsSet bool
+}
+
+// SupervisorOrderedQueueConfig pins supervisor selection to a fixed issue order.
+type SupervisorOrderedQueueConfig struct {
+	Enabled bool  `yaml:"enabled" json:"enabled"`
+	Issues  []int `yaml:"issues" json:"issues,omitempty"`
+}
+
+func (s *SupervisorConfig) UnmarshalYAML(value *yaml.Node) error {
+	type rawSupervisorConfig SupervisorConfig
+	var raw rawSupervisorConfig
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*s = SupervisorConfig(raw)
+	if value.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(value.Content); i += 2 {
+			if value.Content[i].Value == "excluded_labels" {
+				s.excludedLabelsSet = true
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (s SupervisorConfig) OrderedQueueActive() bool {
+	return s.OrderedQueue.Enabled || len(s.OrderedQueue.Issues) > 0
+}
+
+func (s SupervisorConfig) AllowsSafeAction(action string) bool {
+	action = normalizePolicyToken(action)
+	for _, configured := range s.SafeActions {
+		if configured == action {
+			return true
+		}
+	}
+	return false
+}
+
 // RoutingConfig controls automatic backend selection via LLM router.
 type RoutingConfig struct {
 	Mode            string `yaml:"mode"`              // "auto", "manual" (labels only)
@@ -158,6 +222,7 @@ type Config struct {
 	Telegram                   TelegramConfig       `yaml:"telegram"`
 	Versioning                 VersioningConfig     `yaml:"versioning"`
 	GitHubProjects             GitHubProjectsConfig `yaml:"github_projects"`
+	Supervisor                 SupervisorConfig     `yaml:"supervisor"`
 	MaxRetryBackoffMs          int                  `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
 	AutoResolveFiles           []string             `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
 	AutoRestoreFiles           []string             `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase
@@ -181,6 +246,9 @@ func LoadFrom(path string) (*Config, error) {
 		return nil, err
 	}
 	cfg.SourcePath = path
+	if err := loadSupervisorPolicyFile(path, cfg); err != nil {
+		return nil, err
+	}
 	return cfg, nil
 }
 
@@ -194,9 +262,11 @@ func Load() (*Config, error) {
 
 	var data []byte
 	var err error
+	var loadedPath string
 	for _, path := range candidates {
 		data, err = os.ReadFile(path)
 		if err == nil {
+			loadedPath = path
 			break
 		}
 	}
@@ -207,12 +277,9 @@ func Load() (*Config, error) {
 	if parseErr != nil {
 		return nil, parseErr
 	}
-	// Set SourcePath to the candidate that succeeded
-	for _, p := range candidates {
-		if _, e := os.Stat(p); e == nil {
-			cfg.SourcePath = p
-			break
-		}
+	cfg.SourcePath = loadedPath
+	if err := loadSupervisorPolicyFile(loadedPath, cfg); err != nil {
+		return nil, err
 	}
 	return cfg, nil
 }
@@ -405,7 +472,240 @@ func parse(data []byte) (*Config, error) {
 		}
 	}
 
+	if err := normalizeSupervisorPolicy(&cfg.Supervisor); err != nil {
+		return nil, err
+	}
+
 	return cfg, nil
+}
+
+// SupervisorPolicyCandidatePaths returns structured policy files that may live
+// beside the config or inside the configured repository checkout.
+func SupervisorPolicyCandidatePaths(configPath string, cfg *Config) []string {
+	var candidates []string
+	if configPath != "" {
+		dir := filepath.Dir(configPath)
+		candidates = appendSupervisorPolicyCandidates(candidates, dir)
+		candidates = appendSupervisorPolicyCandidates(candidates, filepath.Join(dir, ".maestro"))
+	}
+	if cfg != nil && strings.TrimSpace(cfg.LocalPath) != "" {
+		candidates = appendSupervisorPolicyCandidates(candidates, filepath.Join(cfg.LocalPath, ".maestro"))
+	}
+	return uniqueStrings(candidates)
+}
+
+func loadSupervisorPolicyFile(configPath string, cfg *Config) error {
+	for _, path := range SupervisorPolicyCandidatePaths(configPath, cfg) {
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("read supervisor policy %s: %w", path, err)
+		}
+		policy, ok, err := parseSupervisorPolicyFile(path, data)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		policy.PolicyPath = path
+		if err := normalizeSupervisorPolicy(&policy); err != nil {
+			return fmt.Errorf("load supervisor policy %s: %w", path, err)
+		}
+		cfg.Supervisor = policy
+		return nil
+	}
+	return nil
+}
+
+func parseSupervisorPolicyFile(path string, data []byte) (SupervisorConfig, bool, error) {
+	data, ok := supervisorPolicyYAML(path, data)
+	if !ok {
+		return SupervisorConfig{}, false, nil
+	}
+	var wrapped struct {
+		Supervisor *SupervisorConfig `yaml:"supervisor"`
+	}
+	if err := yaml.Unmarshal(data, &wrapped); err != nil {
+		return SupervisorConfig{}, false, fmt.Errorf("parse supervisor policy %s: %w", path, err)
+	}
+	if wrapped.Supervisor != nil {
+		return *wrapped.Supervisor, true, nil
+	}
+	var policy SupervisorConfig
+	if err := yaml.Unmarshal(data, &policy); err != nil {
+		return SupervisorConfig{}, false, fmt.Errorf("parse supervisor policy %s: %w", path, err)
+	}
+	return policy, true, nil
+}
+
+func supervisorPolicyYAML(path string, data []byte) ([]byte, bool) {
+	if strings.ToLower(filepath.Ext(path)) != ".md" {
+		return data, true
+	}
+	text := strings.TrimLeft(string(data), "\ufeff\r\n\t ")
+	if !strings.HasPrefix(text, "---") {
+		return nil, false
+	}
+	text = strings.TrimPrefix(text, "---")
+	text = strings.TrimPrefix(text, "\r\n")
+	text = strings.TrimPrefix(text, "\n")
+	end := strings.Index(text, "\n---")
+	if end < 0 {
+		return nil, false
+	}
+	return []byte(text[:end]), true
+}
+
+func appendSupervisorPolicyCandidates(candidates []string, dir string) []string {
+	if strings.TrimSpace(dir) == "" {
+		return candidates
+	}
+	return append(candidates,
+		filepath.Join(dir, "supervisor.yaml"),
+		filepath.Join(dir, "supervisor.yml"),
+		filepath.Join(dir, "supervisor.md"),
+	)
+}
+
+func normalizeSupervisorPolicy(policy *SupervisorConfig) error {
+	policy.Mode = normalizePolicyToken(policy.Mode)
+	if policy.Mode == "" {
+		policy.Mode = "cautious"
+	}
+	policy.ReadyLabel = strings.TrimSpace(policy.ReadyLabel)
+	policy.BlockedLabel = strings.TrimSpace(policy.BlockedLabel)
+	policy.ExcludedLabels = normalizeStringList(policy.ExcludedLabels)
+	policy.AllowIssueTypes = normalizeStringList(policy.AllowIssueTypes)
+	policy.SafeActions = normalizeActionList(policy.SafeActions)
+	policy.ApprovalRequired = normalizeActionList(policy.ApprovalRequired)
+
+	if !policy.excludedLabelsSet && len(policy.ExcludedLabels) == 0 {
+		policy.ExcludedLabels = []string{"epic", "meta"}
+	}
+	if len(policy.AllowIssueTypes) > 0 {
+		policy.ExcludedLabels = removeAllowedIssueTypes(policy.ExcludedLabels, policy.AllowIssueTypes)
+	}
+	return validateSupervisorPolicy(*policy)
+}
+
+func validateSupervisorPolicy(policy SupervisorConfig) error {
+	seenIssues := make(map[int]struct{}, len(policy.OrderedQueue.Issues))
+	for i, issue := range policy.OrderedQueue.Issues {
+		if issue <= 0 {
+			return fmt.Errorf("config: supervisor.ordered_queue.issues[%d] must be a positive issue number", i)
+		}
+		if _, ok := seenIssues[issue]; ok {
+			return fmt.Errorf("config: supervisor.ordered_queue.issues[%d] duplicates issue #%d", i, issue)
+		}
+		seenIssues[issue] = struct{}{}
+	}
+	if err := validateSupervisorActions("safe_actions", policy.SafeActions); err != nil {
+		return err
+	}
+	return validateSupervisorActions("approval_required", policy.ApprovalRequired)
+}
+
+func validateSupervisorActions(field string, actions []string) error {
+	for i, action := range actions {
+		if !knownSupervisorActions()[action] {
+			return fmt.Errorf("config: supervisor.%s[%d] has unknown action %q (allowed: %s)", field, i, action, strings.Join(knownSupervisorActionNames(), ", "))
+		}
+	}
+	return nil
+}
+
+func knownSupervisorActions() map[string]bool {
+	return map[string]bool{
+		SupervisorActionAddReadyLabel:      true,
+		SupervisorActionRemoveBlockedLabel: true,
+		SupervisorActionAddIssueComment:    true,
+		SupervisorActionMergePR:            true,
+		SupervisorActionCloseIssue:         true,
+		SupervisorActionDeleteWorktree:     true,
+		SupervisorActionChangeGlobalConfig: true,
+	}
+}
+
+func knownSupervisorActionNames() []string {
+	return []string{
+		SupervisorActionAddReadyLabel,
+		SupervisorActionRemoveBlockedLabel,
+		SupervisorActionAddIssueComment,
+		SupervisorActionMergePR,
+		SupervisorActionCloseIssue,
+		SupervisorActionDeleteWorktree,
+		SupervisorActionChangeGlobalConfig,
+	}
+}
+
+func normalizeActionList(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = normalizePolicyToken(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	return normalized
+}
+
+func normalizeStringList(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	return normalized
+}
+
+func normalizePolicyToken(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func removeAllowedIssueTypes(excluded, allowed []string) []string {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, label := range allowed {
+		allowedSet[strings.ToLower(label)] = struct{}{}
+	}
+	filtered := excluded[:0]
+	for _, label := range excluded {
+		if _, ok := allowedSet[strings.ToLower(label)]; ok {
+			continue
+		}
+		filtered = append(filtered, label)
+	}
+	return filtered
+}
+
+func uniqueStrings(values []string) []string {
+	unique := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
 }
 
 // LoadDir loads all YAML config files from a directory, sorted by filename.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -1351,5 +1352,139 @@ worker_soft_token_threshold: 0
 	}
 	if cfg.SoftTokenThreshold() != 0 {
 		t.Errorf("SoftTokenThreshold() = %f, want 0 (disabled)", cfg.SoftTokenThreshold())
+	}
+}
+
+func TestParse_SupervisorPolicySection(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  enabled: true
+  mode: cautious
+  ready_label: maestro-ready
+  blocked_label: blocked
+  excluded_labels:
+    - epic
+    - meta
+  ordered_queue:
+    enabled: true
+    issues:
+      - 308
+      - 306
+  safe_actions:
+    - add_ready_label
+    - remove_blocked_label
+    - add_issue_comment
+  approval_required:
+    - merge_pr
+    - close_issue
+    - delete_worktree
+    - change_global_config
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.Supervisor.Enabled {
+		t.Fatal("Supervisor.Enabled should be true")
+	}
+	if cfg.Supervisor.ReadyLabel != "maestro-ready" {
+		t.Errorf("ReadyLabel = %q, want maestro-ready", cfg.Supervisor.ReadyLabel)
+	}
+	if !cfg.Supervisor.OrderedQueueActive() {
+		t.Fatal("OrderedQueueActive() should be true")
+	}
+	if got := cfg.Supervisor.OrderedQueue.Issues; len(got) != 2 || got[0] != 308 || got[1] != 306 {
+		t.Fatalf("OrderedQueue.Issues = %v, want [308 306]", got)
+	}
+	if !cfg.Supervisor.AllowsSafeAction(SupervisorActionAddReadyLabel) {
+		t.Error("safe_actions should include add_ready_label")
+	}
+}
+
+func TestParse_SupervisorDefaultExcludesEpicMeta(t *testing.T) {
+	cfg, err := parse([]byte("repo: owner/repo\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"epic", "meta"}
+	if len(cfg.Supervisor.ExcludedLabels) != len(want) {
+		t.Fatalf("Supervisor.ExcludedLabels = %v, want %v", cfg.Supervisor.ExcludedLabels, want)
+	}
+	for i := range want {
+		if cfg.Supervisor.ExcludedLabels[i] != want[i] {
+			t.Errorf("Supervisor.ExcludedLabels[%d] = %q, want %q", i, cfg.Supervisor.ExcludedLabels[i], want[i])
+		}
+	}
+}
+
+func TestParse_SupervisorExplicitEmptyExcludedLabelsAllowsEpics(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  excluded_labels: []
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(cfg.Supervisor.ExcludedLabels) != 0 {
+		t.Fatalf("Supervisor.ExcludedLabels = %v, want empty", cfg.Supervisor.ExcludedLabels)
+	}
+}
+
+func TestParse_SupervisorInvalidIssueNumber(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  ordered_queue:
+    issues:
+      - 308
+      - 0
+`
+	_, err := parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("parse succeeded, want invalid issue number error")
+	}
+	if !strings.Contains(err.Error(), "supervisor.ordered_queue.issues[1]") {
+		t.Fatalf("error = %v, want supervisor ordered queue index", err)
+	}
+}
+
+func TestLoadFrom_LoadsColocatedSupervisorPolicyFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "maestro.yaml")
+	policyDir := filepath.Join(dir, ".maestro")
+	if err := os.Mkdir(policyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("repo: owner/repo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	policy := []byte(`
+supervisor:
+  enabled: true
+  ready_label: maestro-ready
+  ordered_queue:
+    issues:
+      - 262
+`)
+	policyPath := filepath.Join(policyDir, "supervisor.yaml")
+	if err := os.WriteFile(policyPath, policy, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if cfg.Supervisor.PolicyPath != policyPath {
+		t.Fatalf("Supervisor.PolicyPath = %q, want %q", cfg.Supervisor.PolicyPath, policyPath)
+	}
+	if cfg.Supervisor.ReadyLabel != "maestro-ready" {
+		t.Fatalf("Supervisor.ReadyLabel = %q, want maestro-ready", cfg.Supervisor.ReadyLabel)
+	}
+	if got := cfg.Supervisor.OrderedQueue.Issues; len(got) != 1 || got[0] != 262 {
+		t.Fatalf("OrderedQueue.Issues = %v, want [262]", got)
 	}
 }

--- a/internal/configwatch/watcher.go
+++ b/internal/configwatch/watcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
@@ -17,10 +18,11 @@ func Watch(ctx context.Context, path string, pollInterval time.Duration) <-chan 
 	go func() {
 		defer close(ch)
 
-		var lastModTime time.Time
-		if info, err := os.Stat(path); err == nil {
-			lastModTime = info.ModTime()
+		watchedPaths := watchedConfigPaths(path, nil)
+		if cfg, err := config.LoadFrom(path); err == nil {
+			watchedPaths = watchedConfigPaths(path, cfg)
 		}
+		lastModTimes := statModTimes(watchedPaths)
 
 		ticker := time.NewTicker(pollInterval)
 		defer ticker.Stop()
@@ -32,26 +34,20 @@ func Watch(ctx context.Context, path string, pollInterval time.Duration) <-chan 
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				info, err := os.Stat(path)
-				if err != nil {
-					continue
-				}
-				if !info.ModTime().After(lastModTime) {
+				if !hasConfigChange(watchedPaths, lastModTimes) {
 					continue
 				}
 				// Debounce: wait briefly for writes to settle
 				time.Sleep(500 * time.Millisecond)
-				if info2, err := os.Stat(path); err == nil {
-					lastModTime = info2.ModTime()
-				} else {
-					lastModTime = info.ModTime()
-				}
+				lastModTimes = statModTimes(watchedPaths)
 
 				cfg, err := config.LoadFrom(path)
 				if err != nil {
 					log.Printf("[configwatch] reload failed (keeping previous config): %v", err)
 					continue
 				}
+				watchedPaths = watchedConfigPaths(path, cfg)
+				lastModTimes = statModTimes(watchedPaths)
 
 				select {
 				case ch <- cfg:
@@ -62,4 +58,51 @@ func Watch(ctx context.Context, path string, pollInterval time.Duration) <-chan 
 		}
 	}()
 	return ch
+}
+
+func watchedConfigPaths(path string, cfg *config.Config) []string {
+	paths := []string{path}
+	paths = append(paths, config.SupervisorPolicyCandidatePaths(path, cfg)...)
+	return uniquePaths(paths)
+}
+
+func statModTimes(paths []string) map[string]time.Time {
+	modTimes := make(map[string]time.Time, len(paths))
+	for _, path := range paths {
+		if info, err := os.Stat(path); err == nil {
+			modTimes[filepath.Clean(path)] = info.ModTime()
+		}
+	}
+	return modTimes
+}
+
+func hasConfigChange(paths []string, last map[string]time.Time) bool {
+	for _, path := range paths {
+		clean := filepath.Clean(path)
+		info, err := os.Stat(path)
+		if err != nil {
+			if _, existed := last[clean]; existed {
+				return true
+			}
+			continue
+		}
+		if prev, ok := last[clean]; !ok || info.ModTime().After(prev) {
+			return true
+		}
+	}
+	return false
+}
+
+func uniquePaths(paths []string) []string {
+	unique := make([]string, 0, len(paths))
+	seen := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		clean := filepath.Clean(path)
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		unique = append(unique, path)
+	}
+	return unique
 }

--- a/internal/configwatch/watcher_test.go
+++ b/internal/configwatch/watcher_test.go
@@ -143,3 +143,38 @@ func TestWatch_MissingConfigOnReload(t *testing.T) {
 		// Expected
 	}
 }
+
+func TestWatch_DetectsSupervisorPolicyChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "maestro.yaml")
+	policyDir := filepath.Join(dir, ".maestro")
+	if err := os.Mkdir(policyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("repo: owner/repo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	policyPath := filepath.Join(policyDir, "supervisor.yaml")
+	if err := os.WriteFile(policyPath, []byte("ready_label: old-ready\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := Watch(ctx, path, 100*time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
+
+	if err := os.WriteFile(policyPath, []byte("ready_label: maestro-ready\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case cfg := <-ch:
+		if cfg.Supervisor.ReadyLabel != "maestro-ready" {
+			t.Errorf("Supervisor.ReadyLabel = %q, want maestro-ready", cfg.Supervisor.ReadyLabel)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for supervisor policy reload")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -832,6 +833,10 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 	if !strSliceEqual(newCfg.ExcludeLabels, old.ExcludeLabels) {
 		changed = append(changed, fmt.Sprintf("exclude_labels: %v→%v", old.ExcludeLabels, newCfg.ExcludeLabels))
 		o.cfg.ExcludeLabels = newCfg.ExcludeLabels
+	}
+	if !reflect.DeepEqual(newCfg.Supervisor, old.Supervisor) {
+		changed = append(changed, "supervisor policy")
+		o.cfg.Supervisor = newCfg.Supervisor
 	}
 	if newCfg.MergeStrategy != old.MergeStrategy {
 		changed = append(changed, fmt.Sprintf("merge_strategy: %s→%s", old.MergeStrategy, newCfg.MergeStrategy))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -97,6 +97,7 @@ type stateResponse struct {
 	Repo                string                     `json:"repo"`
 	MaxParallel         int                        `json:"max_parallel"`
 	ReadOnly            bool                       `json:"read_only"`
+	SupervisorPolicy    config.SupervisorConfig    `json:"supervisor_policy"`
 	All                 []sessionInfo              `json:"all"`
 	Running             []sessionInfo              `json:"running"`
 	PROpen              []sessionInfo              `json:"pr_open"`
@@ -282,6 +283,7 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 		Repo:                s.cfg.Repo,
 		MaxParallel:         s.cfg.MaxParallel,
 		ReadOnly:            s.cfg.Server.ReadOnly,
+		SupervisorPolicy:    s.cfg.Supervisor,
 		All:                 make([]sessionInfo, 0, len(st.Sessions)),
 		Running:             make([]sessionInfo, 0),
 		PROpen:              make([]sessionInfo, 0),

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -124,6 +124,7 @@ type SupervisorDecision struct {
 	CreatedAt         time.Time              `json:"created_at"`
 	Project           string                 `json:"project"`
 	Mode              string                 `json:"mode"`
+	PolicyRule        string                 `json:"policy_rule,omitempty"`
 	Summary           string                 `json:"summary"`
 	RecommendedAction string                 `json:"recommended_action"`
 	Target            *SupervisorTarget      `json:"target,omitempty"`

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -26,6 +26,12 @@ const (
 	RiskSafe          = "safe"
 	RiskMutating      = "mutating"
 	RiskApprovalGated = "approval_gated"
+
+	PolicyRuleRuntimeState   = "runtime_state"
+	PolicyRuleOpenIssues     = "open_issues"
+	PolicyRuleIssueLabels    = "issue_labels"
+	PolicyRuleOrderedQueue   = "supervisor.ordered_queue"
+	PolicyRuleExcludedLabels = "supervisor.excluded_labels"
 )
 
 // Reader is the read-only GitHub surface used by the supervisor engine.
@@ -82,6 +88,7 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 	baseReasons := []string{
 		fmt.Sprintf("State has %d session(s)", projectState.Sessions),
 		fmt.Sprintf("%d active session(s) count against %d max parallel slot(s)", len(st.ActiveSessions()), e.cfg.MaxParallel),
+		e.policySummaryReason(),
 	}
 
 	prs, err := e.reader.ListOpenPRs()
@@ -97,7 +104,7 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 		)
 		return e.decision(now, projectState, ActionMonitorOpenPR,
 			fmt.Sprintf("Session %s already has open PR #%d; monitor review, CI, or merge readiness.", slot, pr.Number),
-			RiskSafe, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, reasons), nil
+			RiskSafe, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons), nil
 	}
 
 	if slot, sess, ok := runningSession(st); ok {
@@ -107,7 +114,7 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 		)
 		return e.decision(now, projectState, ActionWaitForRunningWorker,
 			fmt.Sprintf("Worker %s is still running for issue #%d.", slot, sess.IssueNumber),
-			RiskSafe, 0.88, &state.SupervisorTarget{Issue: sess.IssueNumber, Session: slot}, reasons), nil
+			RiskSafe, 0.88, &state.SupervisorTarget{Issue: sess.IssueNumber, Session: slot}, PolicyRuleRuntimeState, reasons), nil
 	}
 
 	if slot, sess, ok := retryExhaustedSession(st); ok {
@@ -117,7 +124,7 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 		)
 		return e.decision(now, projectState, ActionReviewRetryExhausted,
 			fmt.Sprintf("Issue #%d exhausted its retry budget and needs manual review.", sess.IssueNumber),
-			RiskApprovalGated, 0.93, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}, reasons), nil
+			RiskApprovalGated, 0.93, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}, PolicyRuleRuntimeState, reasons), nil
 	}
 
 	issues, err := e.reader.ListOpenIssues(nil)
@@ -126,10 +133,15 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 	}
 	projectState.OpenIssues = len(issues)
 
-	eligible, skipped, err := e.eligibleIssues(st, issues, true)
+	candidates, policySkipped, policyRule, err := e.policyCandidateIssues(st, issues)
 	if err != nil {
 		return state.SupervisorDecision{}, err
 	}
+	eligible, skipped, err := e.eligibleIssues(st, candidates, true)
+	if err != nil {
+		return state.SupervisorDecision{}, err
+	}
+	skipped = append(policySkipped, skipped...)
 
 	if len(eligible) > 0 {
 		issue := eligible[0]
@@ -139,7 +151,7 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 			)
 			return e.decision(now, projectState, ActionWaitForCapacity,
 				fmt.Sprintf("Issue #%d is eligible, but all worker slots are occupied.", issue.Number),
-				RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, reasons), nil
+				RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons), nil
 		}
 
 		hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number)
@@ -153,32 +165,36 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 			)
 			return e.decision(now, projectState, ActionMonitorOpenPR,
 				fmt.Sprintf("Issue #%d already has an open PR; monitor that PR instead of starting work.", issue.Number),
-				RiskSafe, 0.87, &state.SupervisorTarget{Issue: issue.Number}, reasons), nil
+				RiskSafe, 0.87, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons), nil
 		}
 
 		reasons := appendReasons(baseReasons,
-			issueLabelReason(e.cfg.IssueLabels),
+			issueLabelReason(e.requiredIssueLabels()),
 			fmt.Sprintf("Issue #%d is the next eligible issue", issue.Number),
 			"Starting a worker would mutate local worktrees, so supervisor only records the recommendation",
 		)
 		return e.decision(now, projectState, ActionSpawnWorker,
 			fmt.Sprintf("Start a worker for issue #%d: %s", issue.Number, issue.Title),
-			RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, reasons), nil
+			RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons), nil
 	}
 
-	if len(e.cfg.IssueLabels) > 0 {
-		unlabeled, err := e.firstIssueMissingRequiredLabel(st, issues)
+	if labels := e.requiredIssueLabels(); len(labels) > 0 {
+		unlabeled, err := e.firstIssueMissingRequiredLabel(st, candidates)
 		if err != nil {
 			return state.SupervisorDecision{}, err
 		}
 		if unlabeled != nil {
 			reasons := appendReasons(baseReasons,
-				issueLabelReason(e.cfg.IssueLabels),
+				issueLabelReason(labels),
 				fmt.Sprintf("Issue #%d is open but does not have a configured ready label", unlabeled.Number),
 			)
+			risk := RiskMutating
+			if e.cfg.Supervisor.AllowsSafeAction(config.SupervisorActionAddReadyLabel) {
+				risk = RiskSafe
+			}
 			return e.decision(now, projectState, ActionLabelIssueReady,
 				fmt.Sprintf("No eligible issues because none have the configured ready label; issue #%d is next in the open queue.", unlabeled.Number),
-				RiskMutating, 0.82, &state.SupervisorTarget{Issue: unlabeled.Number}, reasons), nil
+				risk, 0.82, &state.SupervisorTarget{Issue: unlabeled.Number}, policyRule, reasons), nil
 		}
 	}
 
@@ -190,15 +206,17 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 		reasons = append(reasons, reason)
 	}
 	return e.decision(now, projectState, ActionNone,
-		"No action is currently recommended.", RiskSafe, 0.8, nil, reasons), nil
+		"No action is currently recommended.", RiskSafe, 0.8, nil, policyRule, reasons), nil
 }
 
-func (e *Engine) decision(now time.Time, ps state.SupervisorProjectState, action, summary, risk string, confidence float64, target *state.SupervisorTarget, reasons []string) state.SupervisorDecision {
+func (e *Engine) decision(now time.Time, ps state.SupervisorProjectState, action, summary, risk string, confidence float64, target *state.SupervisorTarget, policyRule string, reasons []string) state.SupervisorDecision {
+	reasons = appendReasons(reasons, policyRuleReason(policyRule))
 	return state.SupervisorDecision{
 		ID:                "sup-" + now.Format("20060102T150405.000000000Z"),
 		CreatedAt:         now,
 		Project:           e.cfg.Repo,
 		Mode:              ModeReadOnly,
+		PolicyRule:        policyRule,
 		Summary:           summary,
 		RecommendedAction: action,
 		Target:            target,
@@ -221,11 +239,67 @@ func (e *Engine) projectState(st *state.State) state.SupervisorProjectState {
 	}
 }
 
+func (e *Engine) policyCandidateIssues(st *state.State, issues []github.Issue) ([]github.Issue, []string, string, error) {
+	if !e.cfg.Supervisor.OrderedQueueActive() {
+		return issues, nil, e.defaultPolicyRule(), nil
+	}
+	if err := validateOrderedQueueIssues(e.cfg.Supervisor.OrderedQueue.Issues); err != nil {
+		return nil, nil, "", err
+	}
+	issueByNumber := make(map[int]github.Issue, len(issues))
+	for _, issue := range issues {
+		issueByNumber[issue.Number] = issue
+	}
+	var skipped []string
+	for _, issueNumber := range e.cfg.Supervisor.OrderedQueue.Issues {
+		if st.IssueDone(issueNumber) {
+			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped by supervisor.ordered_queue: already completed in state", issueNumber))
+			continue
+		}
+		closed, err := e.reader.IsIssueClosed(issueNumber)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("check ordered queue issue #%d: %w", issueNumber, err)
+		}
+		if closed {
+			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped by supervisor.ordered_queue: issue is closed", issueNumber))
+			continue
+		}
+		issue, ok := issueByNumber[issueNumber]
+		if !ok {
+			return nil, append(skipped, fmt.Sprintf("Issue #%d is first unfinished in supervisor.ordered_queue but was not returned by open issue listing", issueNumber)), PolicyRuleOrderedQueue, nil
+		}
+		return []github.Issue{issue}, skipped, PolicyRuleOrderedQueue, nil
+	}
+	return nil, append(skipped, "No unfinished issue remains in supervisor.ordered_queue"), PolicyRuleOrderedQueue, nil
+}
+
+func validateOrderedQueueIssues(issues []int) error {
+	seen := make(map[int]struct{}, len(issues))
+	for i, issueNumber := range issues {
+		if issueNumber <= 0 {
+			return fmt.Errorf("supervisor ordered_queue issue at index %d must be a positive issue number", i)
+		}
+		if _, ok := seen[issueNumber]; ok {
+			return fmt.Errorf("supervisor ordered_queue issue at index %d duplicates issue #%d", i, issueNumber)
+		}
+		seen[issueNumber] = struct{}{}
+	}
+	return nil
+}
+
+func (e *Engine) defaultPolicyRule() string {
+	if len(e.requiredIssueLabels()) > 0 {
+		return PolicyRuleIssueLabels
+	}
+	return PolicyRuleOpenIssues
+}
+
 func (e *Engine) eligibleIssues(st *state.State, issues []github.Issue, requireLabels bool) ([]github.Issue, []string, error) {
 	var eligible []github.Issue
 	var skipped []string
+	requiredLabels := e.requiredIssueLabels()
 	for _, issue := range issues {
-		if requireLabels && !matchesRequiredLabels(issue, e.cfg.IssueLabels) {
+		if requireLabels && !matchesRequiredLabels(issue, requiredLabels) {
 			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped: missing configured ready label", issue.Number))
 			continue
 		}
@@ -243,9 +317,10 @@ func (e *Engine) eligibleIssues(st *state.State, issues []github.Issue, requireL
 }
 
 func (e *Engine) firstIssueMissingRequiredLabel(st *state.State, issues []github.Issue) (*github.Issue, error) {
+	requiredLabels := e.requiredIssueLabels()
 	for i := range issues {
 		issue := &issues[i]
-		if matchesRequiredLabels(*issue, e.cfg.IssueLabels) {
+		if matchesRequiredLabels(*issue, requiredLabels) {
 			continue
 		}
 		reason, err := e.issueSkipReason(st, *issue)
@@ -280,6 +355,12 @@ func (e *Engine) issueSkipReason(st *state.State, issue github.Issue) (string, e
 	}
 	if github.HasLabel(issue, e.cfg.ExcludeLabels) {
 		return "excluded by configured label", nil
+	}
+	if blockedLabel := strings.TrimSpace(e.cfg.Supervisor.BlockedLabel); blockedLabel != "" && github.HasLabel(issue, []string{blockedLabel}) {
+		return "blocked by supervisor policy label", nil
+	}
+	if github.HasLabel(issue, e.policyExcludedLabels()) {
+		return "excluded by supervisor policy label", nil
 	}
 	if len(e.cfg.BlockerPatterns) > 0 {
 		blockers := github.FindBlockers(issue.Body, e.cfg.BlockerPatterns)
@@ -397,6 +478,60 @@ func matchesRequiredLabels(issue github.Issue, labels []string) bool {
 		return true
 	}
 	return github.HasLabel(issue, labels)
+}
+
+func (e *Engine) requiredIssueLabels() []string {
+	labels := append([]string(nil), e.cfg.IssueLabels...)
+	readyLabel := strings.TrimSpace(e.cfg.Supervisor.ReadyLabel)
+	if readyLabel == "" {
+		return labels
+	}
+	for _, label := range labels {
+		if strings.EqualFold(label, readyLabel) {
+			return labels
+		}
+	}
+	return append(labels, readyLabel)
+}
+
+func (e *Engine) policySummaryReason() string {
+	mode := strings.TrimSpace(e.cfg.Supervisor.Mode)
+	if mode == "" {
+		mode = "cautious"
+	}
+	parts := []string{
+		fmt.Sprintf("mode=%s", mode),
+	}
+	if e.cfg.Supervisor.Enabled {
+		parts = append(parts, "enabled=true")
+	}
+	if e.cfg.Supervisor.OrderedQueueActive() {
+		parts = append(parts, fmt.Sprintf("ordered_queue=%d issue(s)", len(e.cfg.Supervisor.OrderedQueue.Issues)))
+	}
+	if excludedLabels := e.policyExcludedLabels(); len(excludedLabels) > 0 {
+		parts = append(parts, "excluded_labels="+strings.Join(excludedLabels, ","))
+	}
+	if len(e.cfg.Supervisor.SafeActions) > 0 {
+		parts = append(parts, "safe_actions="+strings.Join(e.cfg.Supervisor.SafeActions, ","))
+	}
+	if len(e.cfg.Supervisor.ApprovalRequired) > 0 {
+		parts = append(parts, "approval_required="+strings.Join(e.cfg.Supervisor.ApprovalRequired, ","))
+	}
+	return "Supervisor policy: " + strings.Join(parts, "; ")
+}
+
+func (e *Engine) policyExcludedLabels() []string {
+	if e.cfg.Supervisor.ExcludedLabels == nil && len(e.cfg.Supervisor.AllowIssueTypes) == 0 {
+		return []string{"epic", "meta"}
+	}
+	return e.cfg.Supervisor.ExcludedLabels
+}
+
+func policyRuleReason(policyRule string) string {
+	if strings.TrimSpace(policyRule) == "" {
+		return ""
+	}
+	return "Policy rule: " + policyRule
 }
 
 func issueLabelReason(labels []string) string {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -231,3 +231,149 @@ func TestRunOnceRecordsDecision(t *testing.T) {
 		t.Fatalf("latest ID = %q, want %q", latest.ID, decision.ID)
 	}
 }
+
+func TestDecide_OrderedQueueSelectsFirstUnfinishedIssue(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(306, "second wave", "maestro-ready"),
+		testIssue(308, "first wave", "maestro-ready"),
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Target == nil || decision.Target.Issue != 308 {
+		t.Fatalf("target = %#v, want issue 308", decision.Target)
+	}
+	if decision.PolicyRule != PolicyRuleOrderedQueue {
+		t.Fatalf("PolicyRule = %q, want %q", decision.PolicyRule, PolicyRuleOrderedQueue)
+	}
+}
+
+func TestDecide_OrderedQueueSkipsCompletedIssue(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(306, "second wave", "maestro-ready"),
+		testIssue(308, "done wave", "maestro-ready"),
+	}}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{IssueNumber: 308, Status: state.StatusDone, StartedAt: time.Now().UTC()}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 306 {
+		t.Fatalf("target = %#v, want issue 306", decision.Target)
+	}
+}
+
+func TestDecide_OrderedQueueMissingLabelTargetsQueueHead(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(306, "ready later", "maestro-ready"),
+		testIssue(308, "missing label"),
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionLabelIssueReady {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionLabelIssueReady)
+	}
+	if decision.Target == nil || decision.Target.Issue != 308 {
+		t.Fatalf("target = %#v, want issue 308", decision.Target)
+	}
+}
+
+func TestDecide_SupervisorExcludedLabelsSkipIssue(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.ExcludedLabels = []string{"epic"}
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(1, "epic", "maestro-ready", "epic"),
+		testIssue(2, "regular", "maestro-ready"),
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 2 {
+		t.Fatalf("target = %#v, want issue 2", decision.Target)
+	}
+}
+
+func TestDecide_SupervisorBlockedLabelSkipsIssue(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.BlockedLabel = "blocked"
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(1, "blocked", "maestro-ready", "blocked"),
+		testIssue(2, "regular", "maestro-ready"),
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 2 {
+		t.Fatalf("target = %#v, want issue 2", decision.Target)
+	}
+}
+
+func TestDecide_ConfigExcludeLabelsStillHonored(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.ExcludeLabels = []string{"blocked"}
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(1, "blocked", "maestro-ready", "blocked"),
+		testIssue(2, "regular", "maestro-ready"),
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 2 {
+		t.Fatalf("target = %#v, want issue 2", decision.Target)
+	}
+}
+
+func TestDecide_SupervisorReadyLabelActsAsRequiredLabel(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Supervisor.ReadyLabel = "maestro-ready"
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(1, "missing"),
+		testIssue(2, "ready", "maestro-ready"),
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 2 {
+		t.Fatalf("target = %#v, want issue 2", decision.Target)
+	}
+	if decision.PolicyRule != PolicyRuleIssueLabels {
+		t.Fatalf("PolicyRule = %q, want %q", decision.PolicyRule, PolicyRuleIssueLabels)
+	}
+}


### PR DESCRIPTION
Closes #262

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `SupervisorConfig` struct and optional policy file (`.maestro/supervisor.yaml`) that govern supervisor queue ordering, label filtering, and action gating. The config watcher is extended to detect changes to the policy file alongside the main config.

Three logic issues are worth addressing before merge: `reflect.DeepEqual` over `SupervisorConfig` includes the unexported `excludedLabelsSet` sentinel field, causing spurious change notifications when a user switches between explicit and default `excluded_labels`; `policyExcludedLabels` contains a `nil` guard that is unreachable in production (after normalization) but active in tests, creating a divergence for any future test using `AllowIssueTypes`; and `loadSupervisorPolicyFile` silently replaces the inline `supervisor:` block without logging, which can quietly discard user-set fields like `enabled: true`.

<h3>Confidence Score: 3/5</h3>

Merge with caution — three logic issues could cause silent misconfiguration or misleading change logs in production

Multiple P1 findings: a false-positive config-change trigger from DeepEqual on an unexported field, dead-code nil guard that diverges between test and production, and silent discard of inline supervisor config when a policy file is present

internal/config/config.go (policy file override), internal/orchestrator/orchestrator.go (DeepEqual), internal/supervisor/supervisor.go (policyExcludedLabels)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds `SupervisorConfig` struct, policy file loading, and normalization; silent discard of inline supervisor block when a policy file is found is a logic concern |
| internal/orchestrator/orchestrator.go | Adds hot-reload of supervisor policy via `reflect.DeepEqual`; the unexported `excludedLabelsSet` field causes false positive change detections |
| internal/supervisor/supervisor.go | Adds ordered-queue candidate filtering, policy rule tagging, and excluded-label helpers; `policyExcludedLabels` nil guard is dead in production but diverges from test behavior for `AllowIssueTypes` |
| internal/configwatch/watcher.go | Extends config watcher to track supervisor policy candidate paths; change detection and path deduplication logic looks correct |
| internal/supervisor/supervisor_test.go | New tests cover ordered queue selection, skip logic, and label filtering; testConfig bypasses normalization which means AllowIssueTypes edge cases won't match production behavior |
| internal/configwatch/watcher_test.go | New test detects supervisor policy file changes; uses a fixed time.Sleep for synchronization which is a minor flakiness risk on slow hosts |
| internal/server/server.go | Exposes `SupervisorPolicy` in the state API response; straightforward addition |
| internal/state/state.go | Adds `PolicyRule` field to `SupervisorDecision` for traceability; no issues |
| internal/config/config_test.go | Good coverage for supervisor policy parsing, defaults, file loading, and validation; tests are clear and well-structured |
| cmd/maestro/main.go | Adds `showSupervisorPolicy` and `valueOrDash` for status display; straightforward and correct |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 799-802 ([link](https://github.com/befeast/maestro/blob/5cfe6d88e189c202fcd288f11a33109a853aa3d3/internal/orchestrator/orchestrator.go#L799-L802)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **False positive change detection via `reflect.DeepEqual` on unexported sentinel field**

   `SupervisorConfig` contains an unexported `excludedLabelsSet bool` field used to distinguish "user explicitly wrote `excluded_labels: []`" from "user omitted the key entirely." `reflect.DeepEqual` compares unexported fields, so two configs that are semantically identical — one with `excluded_labels: [epic, meta]` (`excludedLabelsSet=true`) and one without the key (`excludedLabelsSet=false`, then defaulted by normalization) — will compare as unequal. This triggers a spurious `"supervisor policy"` change log and unnecessary config copy on every reload where the user toggled between the explicit form and the implicit default.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 799-802

   Comment:
   **False positive change detection via `reflect.DeepEqual` on unexported sentinel field**

   `SupervisorConfig` contains an unexported `excludedLabelsSet bool` field used to distinguish "user explicitly wrote `excluded_labels: []`" from "user omitted the key entirely." `reflect.DeepEqual` compares unexported fields, so two configs that are semantically identical — one with `excluded_labels: [epic, meta]` (`excludedLabelsSet=true`) and one without the key (`excludedLabelsSet=false`, then defaulted by normalization) — will compare as unequal. This triggers a spurious `"supervisor policy"` change log and unnecessary config copy on every reload where the user toggled between the explicit form and the implicit default.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/config/config.go`, line 264-288 ([link](https://github.com/befeast/maestro/blob/5cfe6d88e189c202fcd288f11a33109a853aa3d3/internal/config/config.go#L264-L288)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Silent discard of inline `supervisor:` block when a policy file is found**

   `loadSupervisorPolicyFile` performs a full `cfg.Supervisor = policy` replacement. If a user has both an inline `supervisor:` block in their main config (e.g. `enabled: true`, a custom `mode:`) AND a `.maestro/supervisor.yaml` file, the main config's supervisor settings are silently lost. Nothing is logged. A user who sets `supervisor.enabled: true` in their YAML and later adds a policy file that doesn't repeat `enabled: true` will silently end up with `Enabled: false`.

   Consider logging a warning when a loaded policy file overrides a non-zero inline supervisor config, or document in code that the two sources are mutually exclusive.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/config/config.go
   Line: 264-288

   Comment:
   **Silent discard of inline `supervisor:` block when a policy file is found**

   `loadSupervisorPolicyFile` performs a full `cfg.Supervisor = policy` replacement. If a user has both an inline `supervisor:` block in their main config (e.g. `enabled: true`, a custom `mode:`) AND a `.maestro/supervisor.yaml` file, the main config's supervisor settings are silently lost. Nothing is logged. A user who sets `supervisor.enabled: true` in their YAML and later adds a policy file that doesn't repeat `enabled: true` will silently end up with `Enabled: false`.

   Consider logging a warning when a loaded policy file overrides a non-zero inline supervisor config, or document in code that the two sources are mutually exclusive.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/orchestrator/orchestrator.go
Line: 799-802

Comment:
**False positive change detection via `reflect.DeepEqual` on unexported sentinel field**

`SupervisorConfig` contains an unexported `excludedLabelsSet bool` field used to distinguish "user explicitly wrote `excluded_labels: []`" from "user omitted the key entirely." `reflect.DeepEqual` compares unexported fields, so two configs that are semantically identical — one with `excluded_labels: [epic, meta]` (`excludedLabelsSet=true`) and one without the key (`excludedLabelsSet=false`, then defaulted by normalization) — will compare as unequal. This triggers a spurious `"supervisor policy"` change log and unnecessary config copy on every reload where the user toggled between the explicit form and the implicit default.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/supervisor/supervisor.go
Line: 480-485

Comment:
**`nil` check in `policyExcludedLabels` is dead code for production, but diverges from test behaviour**

After any config load through `parse()` or `loadSupervisorPolicyFile`, `normalizeSupervisorPolicy` always assigns `ExcludedLabels` to `["epic", "meta"]` when the field was not set. This means `ExcludedLabels` is never `nil` at runtime; the fallback `return []string{"epic", "meta"}` inside `policyExcludedLabels` is unreachable for production configs.

`testConfig` constructs a `*config.Config` directly — bypassing normalization — so `ExcludedLabels` stays `nil`. Tests that set `AllowIssueTypes` without also setting `ExcludedLabels` will silently get an empty exclusion list (`AllowIssueTypes` suppresses the nil guard), whereas the same config flowing through production normalization would have the default labels with the allowed types removed. This creates a subtle gap between test and production filtering logic for any future test covering `AllowIssueTypes`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/config/config.go
Line: 264-288

Comment:
**Silent discard of inline `supervisor:` block when a policy file is found**

`loadSupervisorPolicyFile` performs a full `cfg.Supervisor = policy` replacement. If a user has both an inline `supervisor:` block in their main config (e.g. `enabled: true`, a custom `mode:`) AND a `.maestro/supervisor.yaml` file, the main config's supervisor settings are silently lost. Nothing is logged. A user who sets `supervisor.enabled: true` in their YAML and later adds a policy file that doesn't repeat `enabled: true` will silently end up with `Enabled: false`.

Consider logging a warning when a loaded policy file overrides a non-zero inline supervisor config, or document in code that the two sources are mutually exclusive.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add supervisor policy queue model ..."](https://github.com/befeast/maestro/commit/5cfe6d88e189c202fcd288f11a33109a853aa3d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30219950)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->