### PR TITLE
Safe GitHub queue actions for ready/blocked labels

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -39,7 +39,7 @@ Usage:
 Commands:
   init          Interactive setup wizard for new projects
   run           Run the orchestration loop
-  supervise     Run read-only supervisor decision loop
+  supervise     Run supervisor decision loop with safe queue actions
   serve         Run Mission Control read-only web dashboard/API
   status        Show current state
   logs          Show worker logs (tail -f)
@@ -65,7 +65,7 @@ Run flags:
   --prompt string       Path to worker prompt base file
 
 Supervise flags:
-  --once                Run one read-only decision and exit
+  --once                Run one supervisor decision and exit
   --interval duration   Loop interval (default 5m)
   --json                Output decision as JSON
 
@@ -410,9 +410,15 @@ func printSupervisorDecision(decision state.SupervisorDecision, jsonOutput bool)
 	}
 
 	fmt.Printf("Supervisor decision: %s\n", decision.RecommendedAction)
+	if decision.Status != "" {
+		fmt.Printf("Status: %s\n", decision.Status)
+	}
 	fmt.Printf("Summary: %s\n", decision.Summary)
 	fmt.Printf("Risk: %s\n", decision.Risk)
 	fmt.Printf("Confidence: %.2f\n", decision.Confidence)
+	if decision.ErrorClass != "" {
+		fmt.Printf("Error class: %s\n", decision.ErrorClass)
+	}
 	if decision.Target != nil {
 		parts := supervisorTargetParts(decision.Target)
 		if len(parts) > 0 {
@@ -423,6 +429,25 @@ func printSupervisorDecision(decision state.SupervisorDecision, jsonOutput bool)
 		fmt.Println("Reasons:")
 		for _, reason := range decision.Reasons {
 			fmt.Printf("  - %s\n", reason)
+		}
+	}
+	if len(decision.Mutations) > 0 {
+		fmt.Println("Mutations:")
+		for _, mutation := range decision.Mutations {
+			fmt.Printf("  - %s", mutation.Type)
+			if mutation.Issue > 0 {
+				fmt.Printf(" issue #%d", mutation.Issue)
+			}
+			if mutation.Label != "" {
+				fmt.Printf(" label %q", mutation.Label)
+			}
+			if mutation.Status != "" {
+				fmt.Printf(" status %s", mutation.Status)
+			}
+			if mutation.ErrorClass != "" {
+				fmt.Printf(" error_class %s", mutation.ErrorClass)
+			}
+			fmt.Println()
 		}
 	}
 	fmt.Printf("Recorded: %s\n", decision.CreatedAt.Format(time.RFC3339))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,8 @@ type SupervisorConfig struct {
 	Mode             string                       `yaml:"mode" json:"mode"`
 	ReadyLabel       string                       `yaml:"ready_label" json:"ready_label,omitempty"`
 	BlockedLabel     string                       `yaml:"blocked_label" json:"blocked_label,omitempty"`
+	QueueComments    bool                         `yaml:"queue_comments" json:"queue_comments,omitempty"`
+	OneAtATime       bool                         `yaml:"one_at_a_time" json:"one_at_a_time,omitempty"`
 	ExcludedLabels   []string                     `yaml:"excluded_labels" json:"excluded_labels,omitempty"`
 	AllowIssueTypes  []string                     `yaml:"allow_issue_types" json:"allow_issue_types,omitempty"`
 	OrderedQueue     SupervisorOrderedQueueConfig `yaml:"ordered_queue" json:"ordered_queue,omitempty"`
@@ -189,6 +191,7 @@ type HooksConfig struct {
 
 type Config struct {
 	Server                     ServerConfig         `yaml:"server"`
+	Supervisor                 SupervisorConfig     `yaml:"supervisor"`
 	Repo                       string               `yaml:"repo"`
 	LocalPath                  string               `yaml:"local_path"`
 	WorktreeBase               string               `yaml:"worktree_base"`
@@ -222,7 +225,6 @@ type Config struct {
 	Telegram                   TelegramConfig       `yaml:"telegram"`
 	Versioning                 VersioningConfig     `yaml:"versioning"`
 	GitHubProjects             GitHubProjectsConfig `yaml:"github_projects"`
-	Supervisor                 SupervisorConfig     `yaml:"supervisor"`
 	MaxRetryBackoffMs          int                  `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
 	AutoResolveFiles           []string             `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
 	AutoRestoreFiles           []string             `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -829,6 +829,33 @@ server:
 	}
 }
 
+func TestParse_SupervisorConfig(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  ready_label: maestro-ready
+  blocked_label: waiting
+  queue_comments: true
+  one_at_a_time: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Supervisor.ReadyLabel != "maestro-ready" {
+		t.Errorf("Supervisor.ReadyLabel = %q, want maestro-ready", cfg.Supervisor.ReadyLabel)
+	}
+	if cfg.Supervisor.BlockedLabel != "waiting" {
+		t.Errorf("Supervisor.BlockedLabel = %q, want waiting", cfg.Supervisor.BlockedLabel)
+	}
+	if !cfg.Supervisor.QueueComments {
+		t.Error("Supervisor.QueueComments should be true")
+	}
+	if !cfg.Supervisor.OneAtATime {
+		t.Error("Supervisor.OneAtATime should be true")
+	}
+}
+
 func TestParse_BlockerPatternsDefault(t *testing.T) {
 	yaml := `repo: owner/repo`
 	cfg, err := parse([]byte(yaml))

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -473,6 +473,32 @@ func (c *Client) AddIssueLabel(issueNumber int, label string) error {
 	return nil
 }
 
+// RemoveIssueLabel removes a label from an issue.
+func (c *Client) RemoveIssueLabel(issueNumber int, label string) error {
+	out, err := exec.Command("gh", "issue", "edit",
+		strconv.Itoa(issueNumber),
+		"--repo", c.Repo,
+		"--remove-label", label,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh issue edit --remove-label: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// CommentIssue leaves a comment on an issue.
+func (c *Client) CommentIssue(issueNumber int, body string) error {
+	out, err := exec.Command("gh", "issue", "comment",
+		strconv.Itoa(issueNumber),
+		"--repo", c.Repo,
+		"--body", body,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh issue comment: %w\n%s", err, out)
+	}
+	return nil
+}
+
 // PRLabels returns the labels on a PR.
 func (c *Client) PRLabels(prNumber int) ([]string, error) {
 	out, err := exec.Command("gh", "pr", "view",

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -118,19 +118,32 @@ type SupervisorProjectState struct {
 	AvailableSlots int `json:"available_slots"`
 }
 
-// SupervisorDecision is a stable, machine-readable read-only orchestration record.
+// SupervisorMutation records one durable GitHub mutation planned or attempted by
+// the supervisor queue action loop.
+type SupervisorMutation struct {
+	Type       string `json:"type"`
+	Issue      int    `json:"issue,omitempty"`
+	Label      string `json:"label,omitempty"`
+	Status     string `json:"status"`
+	ErrorClass string `json:"error_class,omitempty"`
+}
+
+// SupervisorDecision is a stable, machine-readable supervisor orchestration record.
 type SupervisorDecision struct {
 	ID                string                 `json:"id"`
 	CreatedAt         time.Time              `json:"created_at"`
 	Project           string                 `json:"project"`
 	Mode              string                 `json:"mode"`
 	PolicyRule        string                 `json:"policy_rule,omitempty"`
+	Status            string                 `json:"status,omitempty"`
 	Summary           string                 `json:"summary"`
 	RecommendedAction string                 `json:"recommended_action"`
 	Target            *SupervisorTarget      `json:"target,omitempty"`
 	Risk              string                 `json:"risk"`
 	Confidence        float64                `json:"confidence"`
+	ErrorClass        string                 `json:"error_class,omitempty"`
 	Reasons           []string               `json:"reasons,omitempty"`
+	Mutations         []SupervisorMutation   `json:"mutations,omitempty"`
 	ProjectState      SupervisorProjectState `json:"project_state"`
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -797,12 +797,19 @@ func TestSupervisorDecisionPersistence(t *testing.T) {
 		CreatedAt:         now,
 		Project:           "owner/repo",
 		Mode:              "read_only",
+		Status:            "succeeded",
 		Summary:           "Start a worker for issue #42.",
 		RecommendedAction: "spawn_worker",
 		Target:            &SupervisorTarget{Issue: 42},
 		Risk:              "mutating",
 		Confidence:        0.84,
-		Reasons:           []string{"Issue #42 is eligible"},
+		Mutations: []SupervisorMutation{{
+			Type:   "add_ready_label",
+			Issue:  42,
+			Label:  "maestro-ready",
+			Status: "succeeded",
+		}},
+		Reasons: []string{"Issue #42 is eligible"},
 		ProjectState: SupervisorProjectState{
 			Sessions:       0,
 			OpenIssues:     1,
@@ -830,6 +837,9 @@ func TestSupervisorDecisionPersistence(t *testing.T) {
 	}
 	if latest.ProjectState.OpenIssues != 1 {
 		t.Fatalf("open issues = %d, want 1", latest.ProjectState.OpenIssues)
+	}
+	if latest.Status != "succeeded" || len(latest.Mutations) != 1 || latest.Mutations[0].Label != "maestro-ready" {
+		t.Fatalf("latest audit fields = %#v, want persisted status and mutation", latest)
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	ModeReadOnly = "read_only"
+	ModeReadOnly    = "read_only"
+	ModeSafeActions = "safe_actions"
 
 	ActionNone                 = "none"
 	ActionWaitForRunningWorker = "wait_for_running_worker"
@@ -32,6 +33,24 @@ const (
 	PolicyRuleIssueLabels    = "issue_labels"
 	PolicyRuleOrderedQueue   = "supervisor.ordered_queue"
 	PolicyRuleExcludedLabels = "supervisor.excluded_labels"
+
+	DecisionStatusRecommended = "recommended"
+	DecisionStatusSucceeded   = "succeeded"
+	DecisionStatusFailed      = "failed"
+
+	MutationAddReadyLabel      = "add_ready_label"
+	MutationRemoveBlockedLabel = "remove_blocked_label"
+	MutationIssueComment       = config.SupervisorActionAddIssueComment
+
+	MutationStatusPlanned   = "planned"
+	MutationStatusSucceeded = "succeeded"
+	MutationStatusFailed    = "failed"
+
+	ErrorClassGitHubAPI         = "github_api"
+	ErrorClassGitHubAuth        = "github_auth"
+	ErrorClassGitHubNotFound    = "github_not_found"
+	ErrorClassGitHubRateLimited = "github_rate_limited"
+	ErrorClassUnsupportedClient = "unsupported_client"
 )
 
 // Reader is the read-only GitHub surface used by the supervisor engine.
@@ -42,7 +61,15 @@ type Reader interface {
 	IsIssueClosed(number int) (bool, error)
 }
 
-// Engine makes deterministic read-only supervisor decisions.
+// Mutator is the safe GitHub write surface used for supervisor queue actions.
+type Mutator interface {
+	AddIssueLabel(issueNumber int, label string) error
+	RemoveIssueLabel(issueNumber int, label string) error
+	CommentIssue(issueNumber int, body string) error
+}
+
+// Engine makes deterministic supervisor decisions. It plans safe queue mutations
+// but does not execute them.
 type Engine struct {
 	cfg    *config.Config
 	reader Reader
@@ -60,16 +87,28 @@ func NewEngine(cfg *config.Config, reader Reader) *Engine {
 	}
 }
 
-// RunOnce records one read-only supervisor decision in Maestro state.
+// RunOnce records one supervisor decision in Maestro state and applies any safe
+// queue mutations selected by the decision.
 func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error) {
 	st, err := state.Load(cfg.StateDir)
 	if err != nil {
 		return state.SupervisorDecision{}, fmt.Errorf("load state: %w", err)
 	}
+	if reader == nil {
+		reader = github.New(cfg.Repo)
+	}
 
 	decision, err := NewEngine(cfg, reader).Decide(st)
 	if err != nil {
 		return state.SupervisorDecision{}, err
+	}
+	if len(decision.Mutations) > 0 {
+		mutator, ok := reader.(Mutator)
+		if !ok {
+			markUnsupportedQueueAction(&decision)
+		} else {
+			applyQueueAction(cfg, &decision, mutator)
+		}
 	}
 	st.RecordSupervisorDecision(decision, state.DefaultSupervisorDecisionLimit)
 	if err := state.Save(cfg.StateDir, st); err != nil {
@@ -107,7 +146,7 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 			RiskSafe, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons), nil
 	}
 
-	if slot, sess, ok := runningSession(st); ok {
+	if slot, sess, ok := runningSession(st); ok && e.shouldWaitForRunningWorker(st) {
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Session %s is running for issue #%d", slot, sess.IssueNumber),
 			"Starting another worker is not recommended while a worker is active",
@@ -178,24 +217,26 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 			RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons), nil
 	}
 
-	if labels := e.requiredIssueLabels(); len(labels) > 0 {
-		unlabeled, err := e.firstIssueMissingRequiredLabel(st, candidates)
-		if err != nil {
-			return state.SupervisorDecision{}, err
+	candidate, err := e.firstQueueActionCandidate(st, candidates)
+	if err != nil {
+		return state.SupervisorDecision{}, err
+	}
+	if candidate != nil {
+		mutations := candidate.plannedMutations(e.cfg)
+		reasons := appendReasons(baseReasons,
+			queueLabelReason(candidate.readyLabel, candidate.blockedLabel),
+			fmt.Sprintf("Issue #%d is the next queue issue eligible for safe label mutation", candidate.issue.Number),
+		)
+		risk := RiskMutating
+		if len(mutations) > 0 {
+			risk = RiskSafe
+			reasons = appendReasons(reasons, "Supervisor policy allows the planned safe queue mutation")
 		}
-		if unlabeled != nil {
-			reasons := appendReasons(baseReasons,
-				issueLabelReason(labels),
-				fmt.Sprintf("Issue #%d is open but does not have a configured ready label", unlabeled.Number),
-			)
-			risk := RiskMutating
-			if e.cfg.Supervisor.AllowsSafeAction(config.SupervisorActionAddReadyLabel) {
-				risk = RiskSafe
-			}
-			return e.decision(now, projectState, ActionLabelIssueReady,
-				fmt.Sprintf("No eligible issues because none have the configured ready label; issue #%d is next in the open queue.", unlabeled.Number),
-				risk, 0.82, &state.SupervisorTarget{Issue: unlabeled.Number}, policyRule, reasons), nil
-		}
+		decision := e.decision(now, projectState, ActionLabelIssueReady,
+			fmt.Sprintf("Prepare issue #%d for the queue by %s.", candidate.issue.Number, plannedMutationPhrase(candidate.neededMutations())),
+			risk, 0.82, &state.SupervisorTarget{Issue: candidate.issue.Number}, policyRule, reasons)
+		decision.Mutations = mutations
+		return decision, nil
 	}
 
 	reasons := appendReasons(baseReasons,
@@ -217,6 +258,7 @@ func (e *Engine) decision(now time.Time, ps state.SupervisorProjectState, action
 		Project:           e.cfg.Repo,
 		Mode:              ModeReadOnly,
 		PolicyRule:        policyRule,
+		Status:            DecisionStatusRecommended,
 		Summary:           summary,
 		RecommendedAction: action,
 		Target:            target,
@@ -294,6 +336,112 @@ func (e *Engine) defaultPolicyRule() string {
 	return PolicyRuleOpenIssues
 }
 
+func (e *Engine) shouldWaitForRunningWorker(st *state.State) bool {
+	if e.cfg.Supervisor.OneAtATime {
+		return true
+	}
+	return availableSlots(e.cfg, st) <= 0
+}
+
+type queueActionCandidate struct {
+	issue         github.Issue
+	readyLabel    string
+	blockedLabel  string
+	addReady      bool
+	removeBlocked bool
+}
+
+func (c queueActionCandidate) neededMutations() []state.SupervisorMutation {
+	var mutations []state.SupervisorMutation
+	if c.addReady {
+		mutations = append(mutations, state.SupervisorMutation{
+			Type:   MutationAddReadyLabel,
+			Issue:  c.issue.Number,
+			Label:  c.readyLabel,
+			Status: MutationStatusPlanned,
+		})
+	}
+	if c.removeBlocked {
+		mutations = append(mutations, state.SupervisorMutation{
+			Type:   MutationRemoveBlockedLabel,
+			Issue:  c.issue.Number,
+			Label:  c.blockedLabel,
+			Status: MutationStatusPlanned,
+		})
+	}
+	return mutations
+}
+
+func (c queueActionCandidate) plannedMutations(cfg *config.Config) []state.SupervisorMutation {
+	needed := c.neededMutations()
+	mutations := make([]state.SupervisorMutation, 0, len(needed))
+	for _, mutation := range needed {
+		if safeActionAllowed(cfg, mutation.Type) {
+			mutations = append(mutations, mutation)
+		}
+	}
+	return mutations
+}
+
+func safeActionAllowed(cfg *config.Config, action string) bool {
+	if cfg == nil {
+		return false
+	}
+	return cfg.Supervisor.AllowsSafeAction(action)
+}
+
+func (e *Engine) firstQueueActionCandidate(st *state.State, issues []github.Issue) (*queueActionCandidate, error) {
+	readyLabel := e.readyLabel()
+	blockedLabel := e.blockedLabel()
+	if readyLabel == "" && blockedLabel == "" {
+		return nil, nil
+	}
+
+	for _, issue := range issues {
+		hasReadyLabel := readyLabel == "" || github.HasLabel(issue, []string{readyLabel})
+		hasBlockedLabel := blockedLabel != "" && github.HasLabel(issue, []string{blockedLabel})
+		addReady := readyLabel != "" && !hasReadyLabel && !supervisorMutationSucceeded(st, issue.Number, MutationAddReadyLabel, readyLabel)
+		removeBlocked := hasBlockedLabel && !supervisorMutationSucceeded(st, issue.Number, MutationRemoveBlockedLabel, blockedLabel)
+		candidate := queueActionCandidate{
+			issue:         issue,
+			readyLabel:    readyLabel,
+			blockedLabel:  blockedLabel,
+			addReady:      addReady,
+			removeBlocked: removeBlocked,
+		}
+		if !candidate.addReady && !candidate.removeBlocked {
+			continue
+		}
+
+		reason, err := e.issueQueueSkipReason(st, issue, blockedLabel)
+		if err != nil {
+			return nil, err
+		}
+		if reason != "" {
+			continue
+		}
+		return &candidate, nil
+	}
+	return nil, nil
+}
+
+func supervisorMutationSucceeded(st *state.State, issueNumber int, mutationType, label string) bool {
+	if st == nil {
+		return false
+	}
+	for _, decision := range st.SupervisorDecisions {
+		for _, mutation := range decision.Mutations {
+			if mutation.Status != MutationStatusSucceeded {
+				continue
+			}
+			if mutation.Issue == issueNumber && mutation.Type == mutationType && strings.EqualFold(mutation.Label, label) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (e *Engine) eligibleIssues(st *state.State, issues []github.Issue, requireLabels bool) ([]github.Issue, []string, error) {
 	var eligible []github.Issue
 	var skipped []string
@@ -316,25 +464,15 @@ func (e *Engine) eligibleIssues(st *state.State, issues []github.Issue, requireL
 	return eligible, skipped, nil
 }
 
-func (e *Engine) firstIssueMissingRequiredLabel(st *state.State, issues []github.Issue) (*github.Issue, error) {
-	requiredLabels := e.requiredIssueLabels()
-	for i := range issues {
-		issue := &issues[i]
-		if matchesRequiredLabels(*issue, requiredLabels) {
-			continue
-		}
-		reason, err := e.issueSkipReason(st, *issue)
-		if err != nil {
-			return nil, err
-		}
-		if reason == "" {
-			return issue, nil
-		}
-	}
-	return nil, nil
+func (e *Engine) issueSkipReason(st *state.State, issue github.Issue) (string, error) {
+	return e.issueSkipReasonWithExcludeLabels(st, issue, e.excludeLabels(), "")
 }
 
-func (e *Engine) issueSkipReason(st *state.State, issue github.Issue) (string, error) {
+func (e *Engine) issueQueueSkipReason(st *state.State, issue github.Issue, blockedLabel string) (string, error) {
+	return e.issueSkipReasonWithExcludeLabels(st, issue, excludeLabelsExcept(e.excludeLabels(), blockedLabel), blockedLabel)
+}
+
+func (e *Engine) issueSkipReasonWithExcludeLabels(st *state.State, issue github.Issue, excludeLabels []string, ignoredBlockedLabel string) (string, error) {
 	if st.IssueInProgress(issue.Number) {
 		return "already in progress", nil
 	}
@@ -353,13 +491,13 @@ func (e *Engine) issueSkipReason(st *state.State, issue github.Issue) (string, e
 	if e.cfg.Missions.Enabled && mission.IsMissionIssue(issue, e.cfg.Missions.Labels) && !st.IsMissionChild(issue.Number) {
 		return "mission issue awaits decomposition", nil
 	}
-	if github.HasLabel(issue, e.cfg.ExcludeLabels) {
+	if github.HasLabel(issue, excludeLabels) {
 		return "excluded by configured label", nil
 	}
-	if blockedLabel := strings.TrimSpace(e.cfg.Supervisor.BlockedLabel); blockedLabel != "" && github.HasLabel(issue, []string{blockedLabel}) {
+	if blockedLabel := strings.TrimSpace(e.cfg.Supervisor.BlockedLabel); blockedLabel != "" && !strings.EqualFold(blockedLabel, ignoredBlockedLabel) && github.HasLabel(issue, []string{blockedLabel}) {
 		return "blocked by supervisor policy label", nil
 	}
-	if github.HasLabel(issue, e.policyExcludedLabels()) {
+	if github.HasLabel(issue, excludeLabelsExcept(e.policyExcludedLabels(), ignoredBlockedLabel)) {
 		return "excluded by supervisor policy label", nil
 	}
 	if len(e.cfg.BlockerPatterns) > 0 {
@@ -541,12 +679,214 @@ func issueLabelReason(labels []string) string {
 	return "Config requires one of issue_labels: " + strings.Join(labels, ", ")
 }
 
+func (e *Engine) readyLabel() string {
+	if label := strings.TrimSpace(e.cfg.Supervisor.ReadyLabel); label != "" {
+		return label
+	}
+	for _, label := range e.cfg.IssueLabels {
+		if label = strings.TrimSpace(label); label != "" {
+			return label
+		}
+	}
+	return ""
+}
+
+func (e *Engine) blockedLabel() string {
+	if label := strings.TrimSpace(e.cfg.Supervisor.BlockedLabel); label != "" {
+		return label
+	}
+	for _, label := range e.cfg.ExcludeLabels {
+		label = strings.TrimSpace(label)
+		if strings.EqualFold(label, "blocked") {
+			return label
+		}
+	}
+	return ""
+}
+
+func (e *Engine) excludeLabels() []string {
+	labels := append([]string(nil), e.cfg.ExcludeLabels...)
+	blockedLabel := strings.TrimSpace(e.cfg.Supervisor.BlockedLabel)
+	if blockedLabel != "" && !hasLabelName(labels, blockedLabel) {
+		labels = append(labels, blockedLabel)
+	}
+	return labels
+}
+
+func hasLabelName(labels []string, target string) bool {
+	target = strings.TrimSpace(target)
+	for _, label := range labels {
+		if strings.EqualFold(strings.TrimSpace(label), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func queueLabelReason(readyLabel, blockedLabel string) string {
+	var parts []string
+	if readyLabel != "" {
+		parts = append(parts, "ready label: "+readyLabel)
+	}
+	if blockedLabel != "" {
+		parts = append(parts, "blocked label: "+blockedLabel)
+	}
+	if len(parts) == 0 {
+		return "No supervisor queue labels are configured"
+	}
+	return "Supervisor queue labels configured (" + strings.Join(parts, ", ") + ")"
+}
+
+func excludeLabelsExcept(labels []string, except string) []string {
+	except = strings.TrimSpace(except)
+	if except == "" {
+		return labels
+	}
+	filtered := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if strings.EqualFold(strings.TrimSpace(label), except) {
+			continue
+		}
+		filtered = append(filtered, label)
+	}
+	return filtered
+}
+
+func plannedMutationPhrase(mutations []state.SupervisorMutation) string {
+	descriptions := make([]string, 0, len(mutations))
+	for _, mutation := range mutations {
+		descriptions = append(descriptions, mutationDescription(mutation))
+	}
+	return strings.Join(descriptions, " and ")
+}
+
+func mutationDescription(mutation state.SupervisorMutation) string {
+	switch mutation.Type {
+	case MutationAddReadyLabel:
+		return fmt.Sprintf("adding `%s`", mutation.Label)
+	case MutationRemoveBlockedLabel:
+		return fmt.Sprintf("removing `%s`", mutation.Label)
+	case MutationIssueComment:
+		return "adding an issue comment"
+	default:
+		return mutation.Type
+	}
+}
+
 func issueRefs(numbers []int) string {
 	refs := make([]string, len(numbers))
 	for i, n := range numbers {
 		refs[i] = fmt.Sprintf("#%d", n)
 	}
 	return strings.Join(refs, ", ")
+}
+
+func applyQueueAction(cfg *config.Config, decision *state.SupervisorDecision, mutator Mutator) {
+	decision.Mode = ModeSafeActions
+	decision.Status = DecisionStatusSucceeded
+
+	completed := make([]string, 0, len(decision.Mutations))
+	for i := range decision.Mutations {
+		mutation := decision.Mutations[i]
+		if err := applyQueueMutation(mutator, mutation); err != nil {
+			markQueueActionFailed(decision, i, classifyGitHubError(err))
+			return
+		}
+		decision.Mutations[i].Status = MutationStatusSucceeded
+		completed = append(completed, completedMutationPhrase(mutation))
+	}
+
+	if cfg.Supervisor.QueueComments && safeActionAllowed(cfg, config.SupervisorActionAddIssueComment) && len(completed) > 0 && decision.Target != nil && decision.Target.Issue > 0 {
+		comment := state.SupervisorMutation{
+			Type:   MutationIssueComment,
+			Issue:  decision.Target.Issue,
+			Status: MutationStatusPlanned,
+		}
+		decision.Mutations = append(decision.Mutations, comment)
+		commentIndex := len(decision.Mutations) - 1
+		if err := mutator.CommentIssue(decision.Target.Issue, queueActionComment(completed)); err != nil {
+			markQueueActionFailed(decision, commentIndex, classifyGitHubError(err))
+			return
+		}
+		decision.Mutations[commentIndex].Status = MutationStatusSucceeded
+	}
+}
+
+func applyQueueMutation(mutator Mutator, mutation state.SupervisorMutation) error {
+	switch mutation.Type {
+	case MutationAddReadyLabel:
+		return mutator.AddIssueLabel(mutation.Issue, mutation.Label)
+	case MutationRemoveBlockedLabel:
+		return mutator.RemoveIssueLabel(mutation.Issue, mutation.Label)
+	default:
+		return fmt.Errorf("unsupported queue mutation %q", mutation.Type)
+	}
+}
+
+func markUnsupportedQueueAction(decision *state.SupervisorDecision) {
+	decision.Mode = ModeSafeActions
+	decision.Status = DecisionStatusFailed
+	decision.ErrorClass = ErrorClassUnsupportedClient
+	decision.Summary = "Supervisor queue action could not run because the GitHub client does not support safe mutations."
+	for i := range decision.Mutations {
+		if decision.Mutations[i].Status == MutationStatusPlanned {
+			decision.Mutations[i].Status = MutationStatusFailed
+			decision.Mutations[i].ErrorClass = ErrorClassUnsupportedClient
+			break
+		}
+	}
+	decision.Reasons = appendReasons(decision.Reasons, "Supervisor queue mutation failed with error class: "+ErrorClassUnsupportedClient)
+}
+
+func markQueueActionFailed(decision *state.SupervisorDecision, mutationIndex int, errorClass string) {
+	decision.Status = DecisionStatusFailed
+	decision.ErrorClass = errorClass
+	if mutationIndex >= 0 && mutationIndex < len(decision.Mutations) {
+		decision.Mutations[mutationIndex].Status = MutationStatusFailed
+		decision.Mutations[mutationIndex].ErrorClass = errorClass
+	}
+	issue := 0
+	if decision.Target != nil {
+		issue = decision.Target.Issue
+	}
+	if issue > 0 {
+		decision.Summary = fmt.Sprintf("Supervisor queue action failed for issue #%d (%s).", issue, errorClass)
+	} else {
+		decision.Summary = fmt.Sprintf("Supervisor queue action failed (%s).", errorClass)
+	}
+	decision.Reasons = appendReasons(decision.Reasons, "Supervisor queue mutation failed with error class: "+errorClass)
+}
+
+func classifyGitHubError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "rate limit") || strings.Contains(msg, "secondary rate"):
+		return ErrorClassGitHubRateLimited
+	case strings.Contains(msg, "not found") || strings.Contains(msg, "404"):
+		return ErrorClassGitHubNotFound
+	case strings.Contains(msg, "unauthorized") || strings.Contains(msg, "authentication") || strings.Contains(msg, "permission") || strings.Contains(msg, "403") || strings.Contains(msg, "401"):
+		return ErrorClassGitHubAuth
+	default:
+		return ErrorClassGitHubAPI
+	}
+}
+
+func completedMutationPhrase(mutation state.SupervisorMutation) string {
+	switch mutation.Type {
+	case MutationAddReadyLabel:
+		return fmt.Sprintf("added `%s`", mutation.Label)
+	case MutationRemoveBlockedLabel:
+		return fmt.Sprintf("removed `%s`", mutation.Label)
+	default:
+		return mutation.Type
+	}
+}
+
+func queueActionComment(actions []string) string {
+	return "Maestro queue action: " + strings.Join(actions, "; ") + "."
 }
 
 func appendReasons(base []string, extra ...string) []string {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,6 +1,9 @@
 package supervisor
 
 import (
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,11 +13,17 @@ import (
 )
 
 type fakeReader struct {
-	issues       []github.Issue
-	prs          []github.PR
-	openPRIssues map[int]bool
-	closedIssues map[int]bool
-	issueCalls   int
+	issues         []github.Issue
+	prs            []github.PR
+	openPRIssues   map[int]bool
+	closedIssues   map[int]bool
+	issueCalls     int
+	addedLabels    []string
+	removedLabels  []string
+	comments       []string
+	addLabelErr    error
+	removeLabelErr error
+	commentErr     error
 }
 
 func (f *fakeReader) ListOpenIssues(labels []string) ([]github.Issue, error) {
@@ -32,6 +41,30 @@ func (f *fakeReader) HasOpenPRForIssue(issueNumber int) (bool, error) {
 
 func (f *fakeReader) IsIssueClosed(number int) (bool, error) {
 	return f.closedIssues[number], nil
+}
+
+func (f *fakeReader) AddIssueLabel(issueNumber int, label string) error {
+	if f.addLabelErr != nil {
+		return f.addLabelErr
+	}
+	f.addedLabels = append(f.addedLabels, fmt.Sprintf("#%d:%s", issueNumber, label))
+	return nil
+}
+
+func (f *fakeReader) RemoveIssueLabel(issueNumber int, label string) error {
+	if f.removeLabelErr != nil {
+		return f.removeLabelErr
+	}
+	f.removedLabels = append(f.removedLabels, fmt.Sprintf("#%d:%s", issueNumber, label))
+	return nil
+}
+
+func (f *fakeReader) CommentIssue(issueNumber int, body string) error {
+	if f.commentErr != nil {
+		return f.commentErr
+	}
+	f.comments = append(f.comments, fmt.Sprintf("#%d:%s", issueNumber, body))
+	return nil
 }
 
 func testConfig(t *testing.T) *config.Config {
@@ -375,5 +408,222 @@ func TestDecide_SupervisorReadyLabelActsAsRequiredLabel(t *testing.T) {
 	}
 	if decision.PolicyRule != PolicyRuleIssueLabels {
 		t.Fatalf("PolicyRule = %q, want %q", decision.PolicyRule, PolicyRuleIssueLabels)
+	}
+}
+
+func TestRunOnceLabelsNextIssueReadyAndComments(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel, config.SupervisorActionAddIssueComment}
+	cfg.Supervisor.QueueComments = true
+	reader := &fakeReader{issues: []github.Issue{testIssue(308, "implement supervisor")}}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionLabelIssueReady {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionLabelIssueReady)
+	}
+	if decision.Status != DecisionStatusSucceeded {
+		t.Fatalf("status = %q, want %q", decision.Status, DecisionStatusSucceeded)
+	}
+	if decision.Mode != ModeSafeActions {
+		t.Fatalf("mode = %q, want %q", decision.Mode, ModeSafeActions)
+	}
+	if got, want := strings.Join(reader.addedLabels, ","), "#308:maestro-ready"; got != want {
+		t.Fatalf("added labels = %q, want %q", got, want)
+	}
+	if len(reader.comments) != 1 || !strings.Contains(reader.comments[0], "maestro-ready") {
+		t.Fatalf("comments = %#v, want one ready-label comment", reader.comments)
+	}
+	if len(decision.Mutations) != 2 {
+		t.Fatalf("mutations = %#v, want label + comment", decision.Mutations)
+	}
+	for _, mutation := range decision.Mutations {
+		if mutation.Status != MutationStatusSucceeded {
+			t.Fatalf("mutation %#v status = %q, want %q", mutation, mutation.Status, MutationStatusSucceeded)
+		}
+	}
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	latest := st.LatestSupervisorDecision()
+	if latest == nil || latest.Status != DecisionStatusSucceeded || len(latest.Mutations) != 2 {
+		t.Fatalf("latest decision = %#v, want succeeded decision with mutations", latest)
+	}
+
+	second, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("second RunOnce: %v", err)
+	}
+	if len(second.Mutations) != 0 {
+		t.Fatalf("second mutations = %#v, want none", second.Mutations)
+	}
+	if len(reader.addedLabels) != 1 || len(reader.comments) != 1 {
+		t.Fatalf("added labels = %#v comments = %#v, want no duplicate queue action", reader.addedLabels, reader.comments)
+	}
+}
+
+func TestRunOnceRemovesBlockedLabelWhenPolicyAllows(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.ExcludeLabels = []string{"blocked"}
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionRemoveBlockedLabel}
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "was blocked", "maestro-ready", "blocked")}}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.Status != DecisionStatusSucceeded {
+		t.Fatalf("status = %q, want %q", decision.Status, DecisionStatusSucceeded)
+	}
+	if len(reader.addedLabels) != 0 {
+		t.Fatalf("added labels = %#v, want none", reader.addedLabels)
+	}
+	if got, want := strings.Join(reader.removedLabels, ","), "#42:blocked"; got != want {
+		t.Fatalf("removed labels = %q, want %q", got, want)
+	}
+	if len(decision.Mutations) != 1 || decision.Mutations[0].Type != MutationRemoveBlockedLabel {
+		t.Fatalf("mutations = %#v, want one blocked-label removal", decision.Mutations)
+	}
+}
+
+func TestRunOnceUsesConfiguredSupervisorBlockedLabel(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.BlockedLabel = "waiting"
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionRemoveBlockedLabel}
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "waiting work", "maestro-ready", "waiting")}}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.Status != DecisionStatusSucceeded {
+		t.Fatalf("status = %q, want %q", decision.Status, DecisionStatusSucceeded)
+	}
+	if got, want := strings.Join(reader.removedLabels, ","), "#42:waiting"; got != want {
+		t.Fatalf("removed labels = %q, want %q", got, want)
+	}
+	if len(reader.addedLabels) != 0 {
+		t.Fatalf("added labels = %#v, want none", reader.addedLabels)
+	}
+}
+
+func TestRunOnceDoesNotRemoveBlockedLabelWithOpenBlocker(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.ExcludeLabels = []string{"blocked"}
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionRemoveBlockedLabel}
+	cfg.BlockerPatterns = []string{`blocked by #(\d+)`}
+	issue := testIssue(42, "blocked work", "maestro-ready", "blocked")
+	issue.Body = "blocked by #10"
+	reader := &fakeReader{
+		issues:       []github.Issue{issue},
+		closedIssues: map[int]bool{10: false},
+	}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionNone {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionNone)
+	}
+	if len(reader.removedLabels) != 0 || len(decision.Mutations) != 0 {
+		t.Fatalf("removed labels = %#v mutations = %#v, want no mutation", reader.removedLabels, decision.Mutations)
+	}
+}
+
+func TestRunOnceRunningWorkerDoesNotLabelAtCapacity(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "work in progress",
+		Status:      state.StatusRunning,
+		StartedAt:   time.Now().UTC(),
+	}
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	reader := &fakeReader{issues: []github.Issue{testIssue(308, "next")}}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionWaitForRunningWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionWaitForRunningWorker)
+	}
+	if len(reader.addedLabels) != 0 || len(decision.Mutations) != 0 {
+		t.Fatalf("added labels = %#v mutations = %#v, want no mutation", reader.addedLabels, decision.Mutations)
+	}
+	if reader.issueCalls != 0 {
+		t.Fatalf("ListOpenIssues called %d time(s), want 0", reader.issueCalls)
+	}
+}
+
+func TestRunOnceAlreadyReadyDoesNotDuplicateQueueAction(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel, config.SupervisorActionAddIssueComment}
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if len(reader.addedLabels) != 0 || len(reader.comments) != 0 || len(decision.Mutations) != 0 {
+		t.Fatalf("labels = %#v comments = %#v mutations = %#v, want no queue mutation", reader.addedLabels, reader.comments, decision.Mutations)
+	}
+}
+
+func TestRunOnceGitHubFailureRecordsFailedMutation(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel}
+	reader := &fakeReader{
+		issues:      []github.Issue{testIssue(308, "implement supervisor")},
+		addLabelErr: errors.New("boom"),
+	}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.Status != DecisionStatusFailed {
+		t.Fatalf("status = %q, want %q", decision.Status, DecisionStatusFailed)
+	}
+	if decision.ErrorClass != ErrorClassGitHubAPI {
+		t.Fatalf("error class = %q, want %q", decision.ErrorClass, ErrorClassGitHubAPI)
+	}
+	if len(decision.Mutations) != 1 || decision.Mutations[0].Status != MutationStatusFailed || decision.Mutations[0].ErrorClass != ErrorClassGitHubAPI {
+		t.Fatalf("mutations = %#v, want failed github_api mutation", decision.Mutations)
+	}
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	latest := st.LatestSupervisorDecision()
+	if latest == nil || latest.Status != DecisionStatusFailed || latest.ErrorClass != ErrorClassGitHubAPI {
+		t.Fatalf("latest decision = %#v, want failed github_api decision", latest)
 	}
 }


### PR DESCRIPTION
Closes #263

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes the supervisor from a read-only advisory loop into one that can apply safe GitHub queue actions — adding a `ready` label, removing a `blocked` label, and optionally posting a comment — when the corresponding entries are present in `safe_actions`. New config fields (`queue_comments`, `one_at_a_time`) and a `Mutator` interface are introduced alongside an audit trail of `SupervisorMutation` records persisted with each decision.

- **P1 – `markUnsupportedQueueAction` only marks the first planned mutation as `failed`**: when the GitHub client doesn't implement `Mutator` and multiple mutations were planned (e.g., `add_ready_label` + `remove_blocked_label`), the `break` causes subsequent mutations to remain as `planned` in the persisted decision. `supervisorMutationSucceeded` never finds a `succeeded` record for those mutations, so every subsequent run re-plans and re-fails them, accumulating corrupt audit entries indefinitely.

<h3>Confidence Score: 3/5</h3>

The P1 logic bug in markUnsupportedQueueAction causes persistent audit corruption when multiple mutations are planned and the client doesn't implement Mutator; fix is a one-line change (remove break).

A single targeted P1 is present (stale planned mutations on unsupported-client path) but the rest of the implementation is well-tested and correct; the bug is isolated to an uncommon failure path and is trivially fixable.

internal/supervisor/supervisor.go — markUnsupportedQueueAction (line 835)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Core logic for queue actions — adds Mutator interface, applyQueueAction, markUnsupportedQueueAction; the latter has a break bug that leaves multi-mutation decisions with stale "planned" state after an unsupported-client failure |
| internal/state/state.go | Adds SupervisorMutation struct and new fields to SupervisorDecision; Status field lacks omitempty unlike other optional fields but is intentional as it always has a value |
| internal/github/github.go | Adds RemoveIssueLabel and CommentIssue methods; both use exec.Command with separate args (no shell injection risk) |
| internal/supervisor/supervisor_test.go | Extends fakeReader to implement Mutator; adds comprehensive tests for queue labeling, blocked-label removal, duplicate-prevention, and failure recording |
| internal/config/config.go | Adds QueueComments and OneAtATime to SupervisorConfig; moves Supervisor field higher in Config struct (cosmetic reorder, no functional change) |
| internal/config/config_test.go | Adds TestParse_SupervisorConfig covering the two new boolean fields; looks correct |
| internal/state/state_test.go | Updates persistence test to include Status and Mutations fields; assertions are correct |
| cmd/maestro/main.go | Updates help text and printSupervisorDecision to display new Status, ErrorClass, and Mutations fields |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/supervisor/supervisor.go
Line: 831-836

Comment:
**`break` leaves subsequent planned mutations in stale "planned" state**

When a decision has multiple planned mutations (e.g., `add_ready_label` + `remove_blocked_label`) and the client doesn't implement `Mutator`, only the first planned mutation is marked `failed`. The remaining mutations stay as `planned` in the persisted audit record. On the next run, `supervisorMutationSucceeded` won't find a `succeeded` entry for any of them, so both get re-planned — but `markUnsupportedQueueAction` will again only mark the first one, perpetuating corrupt audit state.

Removing the `break` fixes this by marking all planned mutations as failed:

```suggestion
for i := range decision.Mutations {
		if decision.Mutations[i].Status == MutationStatusPlanned {
			decision.Mutations[i].Status = MutationStatusFailed
			decision.Mutations[i].ErrorClass = ErrorClassUnsupportedClient
		}
	}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add safe supervisor queue actions"](https://github.com/befeast/maestro/commit/7ab1f73a2006c843cac57e9dc01038d7411fc340) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30230622)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->