### PR TITLE
Supervisor stuck-state detectors and explanations

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -450,6 +450,15 @@ func printSupervisorDecision(decision state.SupervisorDecision, jsonOutput bool)
 			fmt.Println()
 		}
 	}
+	if len(decision.StuckStates) > 0 {
+		fmt.Println("Stuck states:")
+		for _, stuck := range decision.StuckStates {
+			fmt.Printf("  - %s [%s]: %s\n", stuck.Code, stuck.Severity, stuck.Summary)
+			if stuck.RecommendedAction != "" {
+				fmt.Printf("    next: %s\n", stuck.RecommendedAction)
+			}
+		}
+	}
 	fmt.Printf("Recorded: %s\n", decision.CreatedAt.Format(time.RFC3339))
 }
 
@@ -880,6 +889,14 @@ func showLatestSupervisorDecision(s *state.State) {
 		if len(parts) > 0 {
 			fmt.Printf("  Target: %s\n", strings.Join(parts, ", "))
 		}
+	}
+	if len(decision.StuckStates) > 0 {
+		fmt.Printf("  Stuck states: %d", len(decision.StuckStates))
+		first := decision.StuckStates[0]
+		if first.Code != "" {
+			fmt.Printf(" (top: %s/%s)", first.Code, first.Severity)
+		}
+		fmt.Println()
 	}
 	fmt.Println()
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -41,6 +41,7 @@ type PR struct {
 	State       string `json:"state"`
 	Mergeable   string `json:"mergeable"`
 	Title       string `json:"title"`
+	IsDraft     bool   `json:"isDraft"`
 }
 
 type Client struct {
@@ -142,7 +143,7 @@ func (c *Client) ListOpenPRs() ([]PR, error) {
 	out, err := exec.Command("gh", "pr", "list",
 		"--repo", c.Repo,
 		"--state", "open",
-		"--json", "number,headRefName,state,mergeable,title",
+		"--json", "number,headRefName,state,mergeable,title,isDraft",
 		"--limit", "100").Output()
 	if err != nil {
 		return nil, fmt.Errorf("gh pr list: %w", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -94,18 +94,19 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 
 // stateResponse is the JSON shape for GET /api/v1/state.
 type stateResponse struct {
-	Repo                string                     `json:"repo"`
-	MaxParallel         int                        `json:"max_parallel"`
-	ReadOnly            bool                       `json:"read_only"`
-	SupervisorPolicy    config.SupervisorConfig    `json:"supervisor_policy"`
-	All                 []sessionInfo              `json:"all"`
-	Running             []sessionInfo              `json:"running"`
-	PROpen              []sessionInfo              `json:"pr_open"`
-	Queued              []sessionInfo              `json:"queued"`
-	TokenTotals         tokenTotalsInfo            `json:"token_totals"`
-	Summary             map[string]int             `json:"summary"`
-	SupervisorLatest    *state.SupervisorDecision  `json:"supervisor_latest,omitempty"`
-	SupervisorDecisions []state.SupervisorDecision `json:"supervisor_decisions,omitempty"`
+	Repo                string                       `json:"repo"`
+	MaxParallel         int                          `json:"max_parallel"`
+	ReadOnly            bool                         `json:"read_only"`
+	SupervisorPolicy    config.SupervisorConfig      `json:"supervisor_policy"`
+	All                 []sessionInfo                `json:"all"`
+	Running             []sessionInfo                `json:"running"`
+	PROpen              []sessionInfo                `json:"pr_open"`
+	Queued              []sessionInfo                `json:"queued"`
+	TokenTotals         tokenTotalsInfo              `json:"token_totals"`
+	Summary             map[string]int               `json:"summary"`
+	StuckStates         []state.SupervisorStuckState `json:"stuck_states,omitempty"`
+	SupervisorLatest    *state.SupervisorDecision    `json:"supervisor_latest,omitempty"`
+	SupervisorDecisions []state.SupervisorDecision   `json:"supervisor_decisions,omitempty"`
 }
 
 type tokenTotalsInfo struct {
@@ -279,6 +280,7 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	latestDecision := st.LatestSupervisorDecision()
 	resp := stateResponse{
 		Repo:                s.cfg.Repo,
 		MaxParallel:         s.cfg.MaxParallel,
@@ -289,8 +291,11 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 		PROpen:              make([]sessionInfo, 0),
 		Queued:              make([]sessionInfo, 0),
 		Summary:             make(map[string]int),
-		SupervisorLatest:    st.LatestSupervisorDecision(),
+		SupervisorLatest:    latestDecision,
 		SupervisorDecisions: st.SupervisorDecisions,
+	}
+	if latestDecision != nil {
+		resp.StuckStates = latestDecision.StuckStates
 	}
 
 	var activeTokens, totalTokens int

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -70,6 +70,25 @@ func setupTestServer(t *testing.T) (*Server, *config.Config) {
 		PRNumber:        11,
 		TokensUsedTotal: 3000,
 	}
+	st.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-test",
+		CreatedAt:         now,
+		Project:           "test/repo",
+		Mode:              "read_only",
+		Summary:           "No eligible issues.",
+		RecommendedAction: "none",
+		Risk:              "safe",
+		Confidence:        0.8,
+		StuckStates: []state.SupervisorStuckState{
+			{
+				Code:              "no_eligible_issues",
+				Severity:          "warning",
+				Summary:           "No open issues match the configured ready labels.",
+				RecommendedAction: "Add a ready label or update config.",
+				SupervisorCanAct:  true,
+			},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
 
 	if err := state.Save(dir, st); err != nil {
 		t.Fatalf("save test state: %v", err)
@@ -131,6 +150,12 @@ func TestHandleState(t *testing.T) {
 	}
 	if resp.PROpen[0].PRURL != "https://github.com/test/repo/pull/10" {
 		t.Errorf("pr_url = %q", resp.PROpen[0].PRURL)
+	}
+	if len(resp.StuckStates) != 1 || resp.StuckStates[0].Code != "no_eligible_issues" {
+		t.Fatalf("stuck_states = %#v, want latest no_eligible_issues", resp.StuckStates)
+	}
+	if resp.SupervisorLatest == nil || len(resp.SupervisorLatest.StuckStates) != 1 {
+		t.Fatalf("supervisor_latest stuck states missing: %#v", resp.SupervisorLatest)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -128,6 +128,17 @@ type SupervisorMutation struct {
 	ErrorClass string `json:"error_class,omitempty"`
 }
 
+// SupervisorStuckState explains a specific reason Maestro is not progressing.
+type SupervisorStuckState struct {
+	Code              string            `json:"code"`
+	Severity          string            `json:"severity"`
+	Summary           string            `json:"summary"`
+	Evidence          []string          `json:"evidence,omitempty"`
+	RecommendedAction string            `json:"recommended_action"`
+	SupervisorCanAct  bool              `json:"supervisor_can_act"`
+	Target            *SupervisorTarget `json:"target,omitempty"`
+}
+
 // SupervisorDecision is a stable, machine-readable supervisor orchestration record.
 type SupervisorDecision struct {
 	ID                string                 `json:"id"`
@@ -144,6 +155,7 @@ type SupervisorDecision struct {
 	ErrorClass        string                 `json:"error_class,omitempty"`
 	Reasons           []string               `json:"reasons,omitempty"`
 	Mutations         []SupervisorMutation   `json:"mutations,omitempty"`
+	StuckStates       []SupervisorStuckState `json:"stuck_states,omitempty"`
 	ProjectState      SupervisorProjectState `json:"project_state"`
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -810,6 +810,17 @@ func TestSupervisorDecisionPersistence(t *testing.T) {
 			Status: "succeeded",
 		}},
 		Reasons: []string{"Issue #42 is eligible"},
+		StuckStates: []SupervisorStuckState{
+			{
+				Code:              "no_eligible_issues",
+				Severity:          "warning",
+				Summary:           "No open issues match the configured ready labels.",
+				Evidence:          []string{"Configured issue_labels: maestro-ready"},
+				RecommendedAction: "Add one of the configured ready labels to an issue.",
+				SupervisorCanAct:  true,
+				Target:            &SupervisorTarget{Issue: 42},
+			},
+		},
 		ProjectState: SupervisorProjectState{
 			Sessions:       0,
 			OpenIssues:     1,
@@ -840,6 +851,12 @@ func TestSupervisorDecisionPersistence(t *testing.T) {
 	}
 	if latest.Status != "succeeded" || len(latest.Mutations) != 1 || latest.Mutations[0].Label != "maestro-ready" {
 		t.Fatalf("latest audit fields = %#v, want persisted status and mutation", latest)
+	}
+	if len(latest.StuckStates) != 1 {
+		t.Fatalf("stuck states = %d, want 1", len(latest.StuckStates))
+	}
+	if latest.StuckStates[0].Code != "no_eligible_issues" {
+		t.Fatalf("stuck state code = %q, want no_eligible_issues", latest.StuckStates[0].Code)
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2,8 +2,12 @@ package supervisor
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
@@ -51,6 +55,10 @@ const (
 	ErrorClassGitHubNotFound    = "github_not_found"
 	ErrorClassGitHubRateLimited = "github_rate_limited"
 	ErrorClassUnsupportedClient = "unsupported_client"
+
+	SeverityInfo    = "info"
+	SeverityWarning = "warning"
+	SeverityBlocked = "blocked"
 )
 
 // Reader is the read-only GitHub surface used by the supervisor engine.
@@ -68,12 +76,23 @@ type Mutator interface {
 	CommentIssue(issueNumber int, body string) error
 }
 
+type prCIStatusReader interface {
+	PRCIStatus(prNumber int) (string, error)
+}
+
+type prGreptileReader interface {
+	PRGreptileApproved(prNumber int) (approved bool, pending bool, err error)
+}
+
 // Engine makes deterministic supervisor decisions. It plans safe queue mutations
-// but does not execute them.
+// and emits structured stuck-state explanations.
 type Engine struct {
-	cfg    *config.Config
-	reader Reader
-	now    func() time.Time
+	cfg      *config.Config
+	reader   Reader
+	now      func() time.Time
+	pidAlive func(pid int) bool
+	stat     func(name string) (os.FileInfo, error)
+	lookPath func(file string) (string, error)
 }
 
 func NewEngine(cfg *config.Config, reader Reader) *Engine {
@@ -81,9 +100,12 @@ func NewEngine(cfg *config.Config, reader Reader) *Engine {
 		reader = github.New(cfg.Repo)
 	}
 	return &Engine{
-		cfg:    cfg,
-		reader: reader,
-		now:    func() time.Time { return time.Now().UTC() },
+		cfg:      cfg,
+		reader:   reader,
+		now:      func() time.Time { return time.Now().UTC() },
+		pidAlive: pidAlive,
+		stat:     os.Stat,
+		lookPath: exec.LookPath,
 	}
 }
 
@@ -135,15 +157,18 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 		return state.SupervisorDecision{}, fmt.Errorf("list open PRs: %w", err)
 	}
 	projectState.OpenPRs = len(prs)
+	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false)
 
 	if slot, sess, pr, ok := sessionWithOpenPR(st, prs); ok {
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Session %s is associated with open PR #%d", slot, pr.Number),
 			"No GitHub mutation is needed for supervisor mode",
 		)
-		return e.decision(now, projectState, ActionMonitorOpenPR,
+		decision := e.decision(now, projectState, ActionMonitorOpenPR,
 			fmt.Sprintf("Session %s already has open PR #%d; monitor review, CI, or merge readiness.", slot, pr.Number),
-			RiskSafe, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons), nil
+			RiskSafe, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
+		decision.StuckStates = stuckStates
+		return decision, nil
 	}
 
 	if slot, sess, ok := runningSession(st); ok && e.shouldWaitForRunningWorker(st) {
@@ -151,9 +176,11 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 			fmt.Sprintf("Session %s is running for issue #%d", slot, sess.IssueNumber),
 			"Starting another worker is not recommended while a worker is active",
 		)
-		return e.decision(now, projectState, ActionWaitForRunningWorker,
+		decision := e.decision(now, projectState, ActionWaitForRunningWorker,
 			fmt.Sprintf("Worker %s is still running for issue #%d.", slot, sess.IssueNumber),
-			RiskSafe, 0.88, &state.SupervisorTarget{Issue: sess.IssueNumber, Session: slot}, PolicyRuleRuntimeState, reasons), nil
+			RiskSafe, 0.88, &state.SupervisorTarget{Issue: sess.IssueNumber, Session: slot}, PolicyRuleRuntimeState, reasons)
+		decision.StuckStates = stuckStates
+		return decision, nil
 	}
 
 	if slot, sess, ok := retryExhaustedSession(st); ok {
@@ -161,9 +188,11 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 			fmt.Sprintf("Session %s for issue #%d is retry_exhausted", slot, sess.IssueNumber),
 			"Retry-exhausted work requires a human decision before more automation",
 		)
-		return e.decision(now, projectState, ActionReviewRetryExhausted,
+		decision := e.decision(now, projectState, ActionReviewRetryExhausted,
 			fmt.Sprintf("Issue #%d exhausted its retry budget and needs manual review.", sess.IssueNumber),
-			RiskApprovalGated, 0.93, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}, PolicyRuleRuntimeState, reasons), nil
+			RiskApprovalGated, 0.93, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}, PolicyRuleRuntimeState, reasons)
+		decision.StuckStates = stuckStates
+		return decision, nil
 	}
 
 	issues, err := e.reader.ListOpenIssues(nil)
@@ -181,6 +210,7 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 		return state.SupervisorDecision{}, err
 	}
 	skipped = append(policySkipped, skipped...)
+	stuckStates = e.detectStuckStates(st, now, prs, issues, eligible, skipped, true)
 
 	if len(eligible) > 0 {
 		issue := eligible[0]
@@ -188,9 +218,11 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 			reasons := appendReasons(baseReasons,
 				fmt.Sprintf("Issue #%d is eligible but no worker slot is available", issue.Number),
 			)
-			return e.decision(now, projectState, ActionWaitForCapacity,
+			decision := e.decision(now, projectState, ActionWaitForCapacity,
 				fmt.Sprintf("Issue #%d is eligible, but all worker slots are occupied.", issue.Number),
-				RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons), nil
+				RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
+			decision.StuckStates = stuckStates
+			return decision, nil
 		}
 
 		hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number)
@@ -202,9 +234,11 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 				fmt.Sprintf("Issue #%d is eligible but GitHub already has an open PR referencing it", issue.Number),
 				"Supervisor mode should not dispatch duplicate work",
 			)
-			return e.decision(now, projectState, ActionMonitorOpenPR,
+			decision := e.decision(now, projectState, ActionMonitorOpenPR,
 				fmt.Sprintf("Issue #%d already has an open PR; monitor that PR instead of starting work.", issue.Number),
-				RiskSafe, 0.87, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons), nil
+				RiskSafe, 0.87, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
+			decision.StuckStates = stuckStates
+			return decision, nil
 		}
 
 		reasons := appendReasons(baseReasons,
@@ -212,9 +246,11 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 			fmt.Sprintf("Issue #%d is the next eligible issue", issue.Number),
 			"Starting a worker would mutate local worktrees, so supervisor only records the recommendation",
 		)
-		return e.decision(now, projectState, ActionSpawnWorker,
+		decision := e.decision(now, projectState, ActionSpawnWorker,
 			fmt.Sprintf("Start a worker for issue #%d: %s", issue.Number, issue.Title),
-			RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons), nil
+			RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
+		decision.StuckStates = stuckStates
+		return decision, nil
 	}
 
 	candidate, err := e.firstQueueActionCandidate(st, candidates)
@@ -236,6 +272,7 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 			fmt.Sprintf("Prepare issue #%d for the queue by %s.", candidate.issue.Number, plannedMutationPhrase(candidate.neededMutations())),
 			risk, 0.82, &state.SupervisorTarget{Issue: candidate.issue.Number}, policyRule, reasons)
 		decision.Mutations = mutations
+		decision.StuckStates = stuckStates
 		return decision, nil
 	}
 
@@ -246,8 +283,10 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 	for _, reason := range firstN(skipped, 3) {
 		reasons = append(reasons, reason)
 	}
-	return e.decision(now, projectState, ActionNone,
-		"No action is currently recommended.", RiskSafe, 0.8, nil, policyRule, reasons), nil
+	decision := e.decision(now, projectState, ActionNone,
+		"No action is currently recommended.", RiskSafe, 0.8, nil, policyRule, reasons)
+	decision.StuckStates = stuckStates
+	return decision, nil
 }
 
 func (e *Engine) decision(now time.Time, ps state.SupervisorProjectState, action, summary, risk string, confidence float64, target *state.SupervisorTarget, policyRule string, reasons []string) state.SupervisorDecision {
@@ -267,6 +306,334 @@ func (e *Engine) decision(now time.Time, ps state.SupervisorProjectState, action
 		Reasons:           compactReasons(reasons),
 		ProjectState:      ps,
 	}
+}
+
+func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.PR, issues, eligible []github.Issue, skipped []string, issuesLoaded bool) []state.SupervisorStuckState {
+	var findings []state.SupervisorStuckState
+	findings = append(findings, e.detectWorkerStuckStates(st, now)...)
+	findings = append(findings, e.detectPRStuckStates(st, prs)...)
+	if issuesLoaded {
+		findings = append(findings, e.detectQueueStuckStates(st, prs, issues, eligible, skipped)...)
+		findings = append(findings, detectPolicyStuckStates(skipped)...)
+	}
+	findings = append(findings, e.detectEnvironmentStuckStates(st, eligible)...)
+	return compactStuckStates(findings)
+}
+
+func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time) []state.SupervisorStuckState {
+	var findings []state.SupervisorStuckState
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess == nil {
+			continue
+		}
+		target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}
+
+		if sess.Status == state.StatusRunning {
+			if sess.PID <= 0 {
+				findings = append(findings, stuckState("dead_running_pid", SeverityBlocked,
+					fmt.Sprintf("Worker %s is marked running, but no live process is recorded.", slot),
+					"Run a Maestro reconciliation cycle or inspect the worker before dispatching more work.", true, target,
+					fmt.Sprintf("Session %s status=running pid=%d", slot, sess.PID)))
+			} else if !e.pidAlive(sess.PID) {
+				findings = append(findings, stuckState("dead_running_pid", SeverityBlocked,
+					fmt.Sprintf("Worker %s is marked running, but PID %d is not alive.", slot, sess.PID),
+					"Run a Maestro reconciliation cycle so the session can be marked dead and retried if eligible.", true, target,
+					fmt.Sprintf("Session %s status=running pid=%d alive=false", slot, sess.PID)))
+			}
+
+			maxMinutes := e.cfg.MaxRuntimeMinutes
+			if sess.LongRunning {
+				maxMinutes *= 2
+			}
+			if maxMinutes > 0 {
+				maxRuntime := time.Duration(maxMinutes) * time.Minute
+				if age := now.Sub(sess.StartedAt); age > maxRuntime {
+					findings = append(findings, stuckState("worker_timeout", SeverityBlocked,
+						fmt.Sprintf("Worker %s exceeded the configured runtime limit.", slot),
+						"Stop the timed-out worker and decide whether to retry or split the issue.", true, target,
+						fmt.Sprintf("Runtime %s exceeds limit %s", age.Round(time.Second), maxRuntime)))
+				}
+			}
+
+			if e.cfg.WorkerSilentTimeoutMinutes > 0 && !sess.LastOutputChangedAt.IsZero() {
+				timeout := time.Duration(e.cfg.WorkerSilentTimeoutMinutes) * time.Minute
+				if silentFor := now.Sub(sess.LastOutputChangedAt); silentFor > timeout {
+					findings = append(findings, stuckState("stale_worker_logs", SeverityBlocked,
+						fmt.Sprintf("Worker %s has not produced new output within the silent timeout.", slot),
+						"Restart or stop the silent worker so the issue can continue.", true, target,
+						fmt.Sprintf("Last output changed %s ago; timeout is %s", silentFor.Round(time.Second), timeout)))
+				}
+			}
+		}
+
+		if sess.Status == state.StatusRetryExhausted {
+			findings = append(findings, stuckState("retry_exhausted", SeverityBlocked,
+				fmt.Sprintf("Issue #%d exhausted its retry budget.", sess.IssueNumber),
+				"Review the failed attempts, adjust the issue or retry budget, then restart intentionally.", false, target,
+				fmt.Sprintf("Session %s status=retry_exhausted retry_count=%d", slot, sess.RetryCount)))
+		}
+
+		if sess.PreviousAttemptFeedbackKind == "review_feedback" && sess.Status != state.StatusRunning {
+			canAct := sess.Status == state.StatusDead && sess.NextRetryAt != nil
+			findings = append(findings, stuckState("stale_review_feedback", SeverityBlocked,
+				fmt.Sprintf("Issue #%d has review feedback, but no worker is currently fixing it.", sess.IssueNumber),
+				"Respawn a worker with the saved review feedback or resolve the feedback manually.", canAct, target,
+				fmt.Sprintf("Session %s status=%s previous_feedback_kind=review_feedback", slot, sess.Status)))
+		}
+	}
+	return findings
+}
+
+func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR) []state.SupervisorStuckState {
+	byNumber := make(map[int]github.PR, len(prs))
+	byBranch := make(map[string]github.PR, len(prs))
+	for _, pr := range prs {
+		byNumber[pr.Number] = pr
+		if strings.TrimSpace(pr.HeadRefName) != "" {
+			byBranch[pr.HeadRefName] = pr
+		}
+	}
+
+	ciStatuses := make(map[int]string)
+	if ciReader, ok := e.reader.(prCIStatusReader); ok {
+		for _, pr := range prs {
+			status, err := ciReader.PRCIStatus(pr.Number)
+			if err == nil {
+				ciStatuses[pr.Number] = status
+			}
+		}
+	}
+
+	var findings []state.SupervisorStuckState
+	seenPRs := make(map[int]struct{})
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess == nil {
+			continue
+		}
+		pr, found := openPRForSession(sess, byNumber, byBranch)
+		target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}
+
+		if sess.PRNumber > 0 && !found && sessionCanStillBlockProgress(sess.Status) {
+			findings = append(findings, stuckState("closed_pr_with_active_session", SeverityBlocked,
+				fmt.Sprintf("Session %s records PR #%d, but that PR is not open.", slot, sess.PRNumber),
+				"Reconcile the session with the closed PR state before starting duplicate work.", true, target,
+				fmt.Sprintf("Session %s status=%s recorded_pr=%d", slot, sess.Status, sess.PRNumber),
+				fmt.Sprintf("Open PRs observed: %d", len(prs))))
+			continue
+		}
+		if !found {
+			continue
+		}
+		if sess.PRNumber == 0 {
+			target.PR = pr.Number
+		}
+		if _, ok := seenPRs[pr.Number]; ok {
+			continue
+		}
+		seenPRs[pr.Number] = struct{}{}
+
+		if pr.IsDraft {
+			findings = append(findings, stuckState("draft_pr", SeverityInfo,
+				fmt.Sprintf("PR #%d is still a draft.", pr.Number),
+				"Mark the PR ready for review when implementation is complete.", false, target,
+				fmt.Sprintf("PR #%d isDraft=true", pr.Number)))
+		}
+
+		switch strings.ToUpper(strings.TrimSpace(pr.Mergeable)) {
+		case "CONFLICTING":
+			findings = append(findings, stuckState("unmergeable_pr", SeverityBlocked,
+				fmt.Sprintf("PR #%d has merge conflicts.", pr.Number),
+				"Rebase or resolve conflicts before the PR can merge.", e.cfg.AutoRebase, target,
+				fmt.Sprintf("PR #%d mergeable=CONFLICTING", pr.Number)))
+		case "UNKNOWN":
+			findings = append(findings, stuckState("unmergeable_pr", SeverityWarning,
+				fmt.Sprintf("PR #%d mergeability is unknown.", pr.Number),
+				"Wait for GitHub to finish computing mergeability or refresh the PR state.", true, target,
+				fmt.Sprintf("PR #%d mergeable=UNKNOWN", pr.Number)))
+		}
+
+		ciStatus := ciStatuses[pr.Number]
+		if ciStatus == "failure" {
+			findings = append(findings, stuckState("failing_checks", SeverityBlocked,
+				fmt.Sprintf("PR #%d has failing checks.", pr.Number),
+				"Capture the failing check output and retry the worker if the retry budget allows.", true, target,
+				fmt.Sprintf("PR #%d checks=failure", pr.Number)))
+		}
+
+		if e.cfg.ReviewGate == "greptile" && (ciStatus == "" || ciStatus == "success") {
+			if greptileReader, ok := e.reader.(prGreptileReader); ok {
+				approved, pending, err := greptileReader.PRGreptileApproved(pr.Number)
+				if err == nil {
+					switch {
+					case pending:
+						findings = append(findings, stuckState("greptile_pending", SeverityInfo,
+							fmt.Sprintf("PR #%d is waiting for Greptile review.", pr.Number),
+							"Wait for Greptile to finish before merging.", true, target,
+							fmt.Sprintf("PR #%d greptile=pending", pr.Number)))
+					case !approved:
+						findings = append(findings, stuckState("greptile_not_approved", SeverityBlocked,
+							fmt.Sprintf("PR #%d is not approved by Greptile.", pr.Number),
+							"Address Greptile feedback or disable the Greptile review gate for this project.", e.cfg.AutoRetryReviewFeedback, target,
+							fmt.Sprintf("PR #%d greptile=not_approved", pr.Number)))
+					}
+				}
+			}
+		}
+	}
+	return findings
+}
+
+func (e *Engine) detectQueueStuckStates(st *state.State, prs []github.PR, issues, eligible []github.Issue, skipped []string) []state.SupervisorStuckState {
+	if len(issues) == 0 {
+		if len(st.ActiveSessions()) == 0 && len(prs) == 0 {
+			return []state.SupervisorStuckState{stuckState("no_open_issues", SeverityInfo,
+				"No open issues are available for Maestro.",
+				"Open a GitHub issue or wait for new work to enter the queue.", false, nil,
+				"Open issues observed: 0")}
+		}
+		return nil
+	}
+	if len(eligible) > 0 {
+		return nil
+	}
+
+	missingLabelCount := countSkipped(skipped, "missing configured ready label")
+	excludedCount := countSkipped(skipped, "excluded by configured label")
+	var findings []state.SupervisorStuckState
+
+	if len(e.cfg.IssueLabels) > 0 && missingLabelCount > 0 {
+		evidence := append([]string{
+			fmt.Sprintf("Configured issue_labels: %s", strings.Join(e.cfg.IssueLabels, ", ")),
+			fmt.Sprintf("Open issues observed: %d", len(issues)),
+		}, firstEvidence(skipped)...)
+		findings = append(findings, stuckState("no_eligible_issues", SeverityWarning,
+			"No open issues match the configured ready labels.",
+			"Add one of the configured ready labels to an issue or update issue_labels in config.", true, firstMissingLabelTarget(issues, e.cfg.IssueLabels),
+			evidence...))
+	}
+
+	if excludedCount == len(issues) {
+		findings = append(findings, stuckState("all_eligible_issues_excluded", SeverityWarning,
+			"Every open issue is excluded by policy labels.",
+			"Remove an exclude label from an issue or update exclude_labels in config.", false, nil,
+			fmt.Sprintf("Configured exclude_labels: %s", strings.Join(e.cfg.ExcludeLabels, ", ")),
+			fmt.Sprintf("Open issues observed: %d", len(issues))))
+	}
+
+	if len(skipped) > 0 {
+		findings = append(findings, stuckState("ordered_queue_exhausted", SeverityInfo,
+			"The ordered issue queue was checked, but every issue was skipped.",
+			"Review skipped reasons and make one issue eligible for dispatch.", false, nil,
+			append([]string{fmt.Sprintf("Skipped issues: %d", len(skipped))}, firstEvidence(skipped)...)...))
+	}
+
+	return findings
+}
+
+func detectPolicyStuckStates(skipped []string) []state.SupervisorStuckState {
+	var findings []state.SupervisorStuckState
+	for _, reason := range firstN(skipped, 3) {
+		if !policySkipReason(reason) {
+			continue
+		}
+		findings = append(findings, stuckState("issue_excluded_by_policy", SeverityInfo,
+			"An issue was skipped because of Supervisor policy.",
+			"Change the issue labels/type or adjust Maestro policy config if the issue should run.", false, targetFromSkipReason(reason), reason))
+	}
+	return findings
+}
+
+func (e *Engine) detectEnvironmentStuckStates(st *state.State, eligible []github.Issue) []state.SupervisorStuckState {
+	var findings []state.SupervisorStuckState
+	if shouldCheckRuntimeEnvironment(st, eligible) {
+		findings = append(findings, e.detectPromptStuckStates()...)
+		if missingCLI := e.detectMissingCLI(); missingCLI != nil {
+			findings = append(findings, *missingCLI)
+		}
+	}
+
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess == nil || strings.TrimSpace(sess.Worktree) == "" || strings.TrimSpace(e.cfg.WorktreeBase) == "" {
+			continue
+		}
+		if !pathWithinBase(sess.Worktree, e.cfg.WorktreeBase) {
+			findings = append(findings, stuckState("unexpected_worktree_path", SeverityWarning,
+				fmt.Sprintf("Session %s uses a worktree outside the configured worktree base.", slot),
+				"Move the worktree under worktree_base or update worktree_base to the intended storage location.", false,
+				&state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot},
+				fmt.Sprintf("worktree=%s", sess.Worktree),
+				fmt.Sprintf("worktree_base=%s", e.cfg.WorktreeBase)))
+		}
+	}
+
+	return findings
+}
+
+func (e *Engine) detectPromptStuckStates() []state.SupervisorStuckState {
+	paths := []struct {
+		name string
+		path string
+	}{
+		{name: "worker_prompt", path: e.cfg.WorkerPrompt},
+		{name: "bug_prompt", path: e.cfg.BugPrompt},
+		{name: "enhancement_prompt", path: e.cfg.EnhancementPrompt},
+		{name: "pipeline.planner.prompt", path: e.cfg.Pipeline.Planner.Prompt},
+		{name: "pipeline.validator.prompt", path: e.cfg.Pipeline.Validator.Prompt},
+	}
+	for i, path := range e.cfg.PromptSections {
+		paths = append(paths, struct {
+			name string
+			path string
+		}{name: fmt.Sprintf("prompt_sections[%d]", i), path: path})
+	}
+
+	var findings []state.SupervisorStuckState
+	for _, item := range paths {
+		path := strings.TrimSpace(item.path)
+		if path == "" {
+			continue
+		}
+		if _, err := e.stat(path); err != nil {
+			code := "missing_prompt"
+			severity := SeverityWarning
+			summary := fmt.Sprintf("Configured prompt file for %s is not readable.", item.name)
+			if os.IsPermission(err) {
+				code = "permission_denied"
+				severity = SeverityBlocked
+				summary = fmt.Sprintf("Configured prompt file for %s cannot be read due to permissions.", item.name)
+			} else if os.IsNotExist(err) {
+				summary = fmt.Sprintf("Configured prompt file for %s does not exist.", item.name)
+			}
+			findings = append(findings, stuckState(code, severity, summary,
+				"Fix the prompt path or file permissions in Maestro config before dispatching more workers.", false, nil,
+				fmt.Sprintf("%s=%s", item.name, path)))
+		}
+	}
+	return findings
+}
+
+func (e *Engine) detectMissingCLI() *state.SupervisorStuckState {
+	backendName := strings.TrimSpace(e.cfg.Model.Default)
+	if backendName == "" {
+		backendName = "claude"
+	}
+	backendDef := e.cfg.Model.Backends[backendName]
+	binary := commandBinary(backendDef.Cmd, backendName)
+	if binary == "" {
+		return nil
+	}
+	if _, err := e.lookPath(binary); err != nil {
+		finding := stuckState("missing_cli", SeverityBlocked,
+			fmt.Sprintf("Default backend CLI %q is not available.", binary),
+			"Install the backend CLI or update model.default/model.backends in config.", false, nil,
+			fmt.Sprintf("model.default=%s", backendName),
+			fmt.Sprintf("cmd=%s", binary))
+		return &finding
+	}
+	return nil
 }
 
 func (e *Engine) projectState(st *state.State) state.SupervisorProjectState {
@@ -547,9 +914,6 @@ func sessionWithOpenPR(st *state.State, prs []github.PR) (string, *state.Session
 		if sess.PRNumber > 0 {
 			if pr, ok := numberToPR[sess.PRNumber]; ok {
 				return slot, sess, pr, true
-			}
-			if sess.Status == state.StatusPROpen {
-				return slot, sess, github.PR{Number: sess.PRNumber, HeadRefName: sess.Branch, State: "OPEN", Title: sess.IssueTitle}, true
 			}
 		}
 	}
@@ -917,4 +1281,159 @@ func firstN(values []string, n int) []string {
 		return values
 	}
 	return values[:n]
+}
+
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func stuckState(code, severity, summary, recommendedAction string, supervisorCanAct bool, target *state.SupervisorTarget, evidence ...string) state.SupervisorStuckState {
+	return state.SupervisorStuckState{
+		Code:              code,
+		Severity:          severity,
+		Summary:           summary,
+		Evidence:          compactReasons(evidence),
+		RecommendedAction: recommendedAction,
+		SupervisorCanAct:  supervisorCanAct,
+		Target:            target,
+	}
+}
+
+func compactStuckStates(findings []state.SupervisorStuckState) []state.SupervisorStuckState {
+	seen := make(map[string]struct{}, len(findings))
+	compact := make([]state.SupervisorStuckState, 0, len(findings))
+	for _, finding := range findings {
+		finding.Code = strings.TrimSpace(finding.Code)
+		finding.Severity = strings.TrimSpace(finding.Severity)
+		finding.Summary = strings.TrimSpace(finding.Summary)
+		finding.RecommendedAction = strings.TrimSpace(finding.RecommendedAction)
+		finding.Evidence = compactReasons(finding.Evidence)
+		if finding.Code == "" || finding.Summary == "" {
+			continue
+		}
+		key := finding.Code + "|" + supervisorTargetKey(finding.Target) + "|" + finding.Summary
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		compact = append(compact, finding)
+	}
+	return compact
+}
+
+func supervisorTargetKey(target *state.SupervisorTarget) string {
+	if target == nil {
+		return ""
+	}
+	return fmt.Sprintf("issue=%d/pr=%d/session=%s", target.Issue, target.PR, target.Session)
+}
+
+func openPRForSession(sess *state.Session, byNumber map[int]github.PR, byBranch map[string]github.PR) (github.PR, bool) {
+	if sess.PRNumber > 0 {
+		if pr, ok := byNumber[sess.PRNumber]; ok {
+			return pr, true
+		}
+	}
+	if strings.TrimSpace(sess.Branch) != "" {
+		if pr, ok := byBranch[sess.Branch]; ok {
+			return pr, true
+		}
+	}
+	return github.PR{}, false
+}
+
+func sessionCanStillBlockProgress(status state.SessionStatus) bool {
+	switch status {
+	case state.StatusRunning, state.StatusPROpen, state.StatusQueued, state.StatusFailed, state.StatusDead, state.StatusRetryExhausted:
+		return true
+	}
+	return false
+}
+
+func countSkipped(skipped []string, contains string) int {
+	count := 0
+	for _, reason := range skipped {
+		if strings.Contains(reason, contains) {
+			count++
+		}
+	}
+	return count
+}
+
+func firstEvidence(values []string) []string {
+	return firstN(values, 3)
+}
+
+func firstMissingLabelTarget(issues []github.Issue, labels []string) *state.SupervisorTarget {
+	for _, issue := range issues {
+		if !matchesRequiredLabels(issue, labels) {
+			return &state.SupervisorTarget{Issue: issue.Number}
+		}
+	}
+	return nil
+}
+
+func policySkipReason(reason string) bool {
+	return strings.Contains(reason, "excluded by configured label") ||
+		strings.Contains(reason, "mission parent issue") ||
+		strings.Contains(reason, "mission issue awaits decomposition") ||
+		strings.Contains(reason, "blocked by open issue")
+}
+
+func targetFromSkipReason(reason string) *state.SupervisorTarget {
+	var issue int
+	if _, err := fmt.Sscanf(reason, "Issue #%d", &issue); err == nil && issue > 0 {
+		return &state.SupervisorTarget{Issue: issue}
+	}
+	return nil
+}
+
+func shouldCheckRuntimeEnvironment(st *state.State, eligible []github.Issue) bool {
+	if len(eligible) > 0 {
+		return true
+	}
+	for _, sess := range st.Sessions {
+		if sess == nil {
+			continue
+		}
+		if sess.Status == state.StatusQueued || (sess.Status == state.StatusDead && sess.NextRetryAt != nil) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathWithinBase(path, base string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return true
+	}
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return true
+	}
+	rel, err := filepath.Rel(absBase, absPath)
+	if err != nil {
+		return true
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+func commandBinary(cmd, fallback string) string {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		cmd = strings.TrimSpace(fallback)
+	}
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -17,6 +17,9 @@ type fakeReader struct {
 	prs            []github.PR
 	openPRIssues   map[int]bool
 	closedIssues   map[int]bool
+	ciStatuses     map[int]string
+	greptileOK     map[int]bool
+	greptilePend   map[int]bool
 	issueCalls     int
 	addedLabels    []string
 	removedLabels  []string
@@ -67,6 +70,21 @@ func (f *fakeReader) CommentIssue(issueNumber int, body string) error {
 	return nil
 }
 
+func (f *fakeReader) PRCIStatus(prNumber int) (string, error) {
+	return f.ciStatuses[prNumber], nil
+}
+
+func (f *fakeReader) PRGreptileApproved(prNumber int) (bool, bool, error) {
+	if f.greptilePend[prNumber] {
+		return false, true, nil
+	}
+	approved, ok := f.greptileOK[prNumber]
+	if !ok {
+		return true, false, nil
+	}
+	return approved, false, nil
+}
+
 func testConfig(t *testing.T) *config.Config {
 	t.Helper()
 	return &config.Config{
@@ -80,7 +98,20 @@ func testConfig(t *testing.T) *config.Config {
 func testEngine(cfg *config.Config, reader *fakeReader) *Engine {
 	eng := NewEngine(cfg, reader)
 	eng.now = func() time.Time { return time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC) }
+	eng.pidAlive = func(pid int) bool { return true }
+	eng.lookPath = func(file string) (string, error) { return file, nil }
 	return eng
+}
+
+func requireStuckState(t *testing.T, decision state.SupervisorDecision, code string) state.SupervisorStuckState {
+	t.Helper()
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == code {
+			return stuck
+		}
+	}
+	t.Fatalf("stuck state %q not found in %#v", code, decision.StuckStates)
+	return state.SupervisorStuckState{}
 }
 
 func testIssue(number int, title string, labels ...string) github.Issue {
@@ -115,6 +146,13 @@ func TestDecide_IdleNoEligibleIssueRecommendsLabel(t *testing.T) {
 	if decision.Mode != ModeReadOnly {
 		t.Errorf("mode = %q, want %q", decision.Mode, ModeReadOnly)
 	}
+	stuck := requireStuckState(t, decision, "no_eligible_issues")
+	if stuck.Severity != SeverityWarning {
+		t.Errorf("severity = %q, want %q", stuck.Severity, SeverityWarning)
+	}
+	if !stuck.SupervisorCanAct {
+		t.Error("expected SupervisorCanAct for label recommendation")
+	}
 }
 
 func TestDecide_RunningWorkerWaits(t *testing.T) {
@@ -125,6 +163,7 @@ func TestDecide_RunningWorkerWaits(t *testing.T) {
 		IssueNumber: 42,
 		IssueTitle:  "work in progress",
 		Status:      state.StatusRunning,
+		PID:         12345,
 		StartedAt:   time.Now().UTC(),
 	}
 
@@ -168,6 +207,117 @@ func TestDecide_RetryExhaustedNeedsReview(t *testing.T) {
 	}
 	if decision.Target == nil || decision.Target.Issue != 77 {
 		t.Fatalf("target = %#v, want issue 77", decision.Target)
+	}
+	stuck := requireStuckState(t, decision, "retry_exhausted")
+	if stuck.Severity != SeverityBlocked {
+		t.Errorf("severity = %q, want %q", stuck.Severity, SeverityBlocked)
+	}
+	if stuck.SupervisorCanAct {
+		t.Error("retry_exhausted should require manual action")
+	}
+}
+
+func TestDecide_DeadRunningPIDExplained(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 91,
+		IssueTitle:  "lost worker",
+		Status:      state.StatusRunning,
+		PID:         424242,
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+	eng := testEngine(cfg, reader)
+	eng.pidAlive = func(pid int) bool { return false }
+
+	decision, err := eng.Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	stuck := requireStuckState(t, decision, "dead_running_pid")
+	if stuck.Severity != SeverityBlocked {
+		t.Errorf("severity = %q, want %q", stuck.Severity, SeverityBlocked)
+	}
+	if !stuck.SupervisorCanAct {
+		t.Error("dead running PID should be automatically reconcilable")
+	}
+}
+
+func TestDecide_StaleWorkerLogsExplained(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.WorkerSilentTimeoutMinutes = 10
+	reader := &fakeReader{}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber:         92,
+		IssueTitle:          "silent worker",
+		Status:              state.StatusRunning,
+		PID:                 12345,
+		StartedAt:           time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC),
+		LastOutputChangedAt: time.Date(2026, 4, 29, 11, 40, 0, 0, time.UTC),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	stuck := requireStuckState(t, decision, "stale_worker_logs")
+	if stuck.Target == nil || stuck.Target.Session != "slot-1" {
+		t.Fatalf("target = %#v, want slot-1", stuck.Target)
+	}
+}
+
+func TestDecide_ClosedPRWithActiveSessionExplained(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 93,
+		IssueTitle:  "closed pr",
+		Status:      state.StatusPROpen,
+		PRNumber:    17,
+		Branch:      "feat/closed-pr",
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	stuck := requireStuckState(t, decision, "closed_pr_with_active_session")
+	if stuck.Target == nil || stuck.Target.PR != 17 {
+		t.Fatalf("target = %#v, want PR 17", stuck.Target)
+	}
+}
+
+func TestDecide_FailingChecksExplained(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 31, HeadRefName: "feat/checks", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{31: "failure"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 94,
+		IssueTitle:  "failing checks",
+		Status:      state.StatusPROpen,
+		PRNumber:    31,
+		Branch:      "feat/checks",
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	stuck := requireStuckState(t, decision, "failing_checks")
+	if stuck.Severity != SeverityBlocked {
+		t.Errorf("severity = %q, want %q", stuck.Severity, SeverityBlocked)
 	}
 }
 


### PR DESCRIPTION
Closes #264

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces structured stuck-state detection to the Supervisor engine, covering dead workers, timed-out workers, PR-level blockers (draft, conflicts, CI failures, Greptile gate), queue/policy gaps, and environment issues (missing prompts, missing CLI binary). The new `SupervisorStuckState` type is added to `SupervisorDecision` and surfaced through the state API and CLI.

<h3>Confidence Score: 4/5</h3>

Safe to merge; issues are diagnostic false-positives rather than operational breakage.

All three findings are P2: a POSIX EPERM edge case in pidAlive (unlikely with same-user workers), a shared stuck-state code for two semantically distinct mergeability states, and stale_review_feedback potentially firing for terminal session statuses. None cause data loss or block core paths.

internal/supervisor/supervisor.go — the three logic issues are all in the new detector functions in this file.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Core change: adds ~330 lines of stuck-state detection logic across worker, PR, queue, policy, and environment detectors. Three logic issues: EPERM false-negative in pidAlive, shared code for UNKNOWN/CONFLICTING mergeability, and stale_review_feedback firing for terminal statuses. |
| internal/state/state.go | Adds SupervisorStuckState struct and StuckStates field to SupervisorDecision; straightforward data model additions, no issues found. |
| internal/server/server.go | Hoists LatestSupervisorDecision call to avoid double invocation and surfaces StuckStates directly on the state response; clean change. |
| internal/github/github.go | Adds IsDraft field to PR struct and includes isDraft in the gh pr list --json flags; straightforward. |
| cmd/maestro/main.go | Adds CLI display of StuckStates in both printSupervisorDecision and showLatestSupervisorDecision; no issues found. |
| internal/supervisor/supervisor_test.go | Adds fakeReader CI/Greptile methods and six new test cases covering dead PID, stale logs, closed PR, and failing checks scenarios; good coverage. |
| internal/state/state_test.go | Extends persistence test to verify StuckStates round-trips correctly through JSON serialization; no issues. |
| internal/server/server_test.go | Adds a SupervisorDecision with StuckStates to test setup and asserts both the top-level stuck_states field and the embedded supervisor_latest copy; no issues. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/supervisor/supervisor.go`, line 773 ([link](https://github.com/befeast/maestro/blob/e00a371d830076286a0b2e1529821e5449457b24/internal/supervisor/supervisor.go#L773)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`pidAlive` treats `EPERM` as dead**

   On POSIX systems, `proc.Signal(syscall.Signal(0))` returns `syscall.EPERM` when the process exists but belongs to a different user — the process is alive, not dead. Returning `false` here would emit a false `dead_running_pid` stuck state for any worker whose UID differs from Maestro's. In practice, workers are spawned by Maestro and share the same user, so this is rare, but the check is semantically wrong.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/supervisor/supervisor.go
   Line: 773

   Comment:
   **`pidAlive` treats `EPERM` as dead**

   On POSIX systems, `proc.Signal(syscall.Signal(0))` returns `syscall.EPERM` when the process exists but belongs to a different user — the process is alive, not dead. Returning `false` here would emit a false `dead_running_pid` stuck state for any worker whose UID differs from Maestro's. In practice, workers are spawned by Maestro and share the same user, so this is rare, but the check is semantically wrong.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/supervisor/supervisor.go
Line: 773

Comment:
**`pidAlive` treats `EPERM` as dead**

On POSIX systems, `proc.Signal(syscall.Signal(0))` returns `syscall.EPERM` when the process exists but belongs to a different user — the process is alive, not dead. Returning `false` here would emit a false `dead_running_pid` stuck state for any worker whose UID differs from Maestro's. In practice, workers are spawned by Maestro and share the same user, so this is rare, but the check is semantically wrong.

```suggestion
	err := proc.Signal(syscall.Signal(0))
	return err == nil || errors.Is(err, syscall.EPERM)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/supervisor/supervisor.go
Line: 450-454

Comment:
**`unmergeable_pr` code shared by two distinct states**

Both `CONFLICTING` (merge conflicts exist, action required) and `UNKNOWN` (GitHub hasn't computed mergeability yet, just wait) emit `code: "unmergeable_pr"`. Programmatic consumers that branch on `stuck.Code` will conflate "rebase needed" with "transient GitHub state" and may take the wrong automated action. A distinct code like `"mergeability_unknown"` for the `UNKNOWN` branch would prevent this ambiguity.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/supervisor/supervisor.go
Line: 477-491

Comment:
**`stale_review_feedback` fires for terminal statuses**

The condition `sess.Status != state.StatusRunning` matches every terminal status, including `StatusDone` and `StatusConflictFailed`. If a session reaches `StatusDone` with `PreviousAttemptFeedbackKind == "review_feedback"` still set (because it was an earlier retry's field), a `SeverityBlocked` `stale_review_feedback` stuck state is emitted for already-completed work. Consider excluding `StatusDone` (and possibly `StatusConflictFailed`) from this check, or clearing `PreviousAttemptFeedbackKind` when a session transitions to a terminal done state.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add supervisor stuck-state explana..."](https://github.com/befeast/maestro/commit/e00a371d830076286a0b2e1529821e5449457b24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30233269)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->