### PR TITLE
Mission Control supervisor rationale panel

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,8 +105,63 @@ type stateResponse struct {
 	TokenTotals         tokenTotalsInfo              `json:"token_totals"`
 	Summary             map[string]int               `json:"summary"`
 	StuckStates         []state.SupervisorStuckState `json:"stuck_states,omitempty"`
+	Supervisor          supervisorInfo               `json:"supervisor"`
 	SupervisorLatest    *state.SupervisorDecision    `json:"supervisor_latest,omitempty"`
 	SupervisorDecisions []state.SupervisorDecision   `json:"supervisor_decisions,omitempty"`
+}
+
+type supervisorInfo struct {
+	HasRun          bool                    `json:"has_run"`
+	EmptyState      string                  `json:"empty_state,omitempty"`
+	Latest          *supervisorDecisionInfo `json:"latest,omitempty"`
+	LastSafeAction  *supervisorActionInfo   `json:"last_safe_action,omitempty"`
+	ApprovalActions []supervisorActionInfo  `json:"approval_actions,omitempty"`
+}
+
+type supervisorDecisionInfo struct {
+	ID                string                       `json:"id"`
+	CreatedAt         time.Time                    `json:"created_at"`
+	Project           string                       `json:"project"`
+	Mode              string                       `json:"mode"`
+	PolicyRule        string                       `json:"policy_rule,omitempty"`
+	Status            string                       `json:"status,omitempty"`
+	Summary           string                       `json:"summary"`
+	RecommendedAction string                       `json:"recommended_action"`
+	Target            *state.SupervisorTarget      `json:"target,omitempty"`
+	TargetLinks       []targetLinkInfo             `json:"target_links,omitempty"`
+	Risk              string                       `json:"risk"`
+	Confidence        float64                      `json:"confidence"`
+	ErrorClass        string                       `json:"error_class,omitempty"`
+	Reasons           []string                     `json:"reasons,omitempty"`
+	Mutations         []state.SupervisorMutation   `json:"mutations,omitempty"`
+	StuckStates       []state.SupervisorStuckState `json:"stuck_states,omitempty"`
+	StuckReasons      []string                     `json:"stuck_reasons,omitempty"`
+	ProjectState      state.SupervisorProjectState `json:"project_state"`
+	Queue             *supervisorQueueInfo         `json:"queue,omitempty"`
+}
+
+type supervisorActionInfo struct {
+	Action         string                  `json:"action"`
+	Summary        string                  `json:"summary"`
+	Risk           string                  `json:"risk"`
+	CreatedAt      time.Time               `json:"created_at"`
+	Target         *state.SupervisorTarget `json:"target,omitempty"`
+	TargetLinks    []targetLinkInfo        `json:"target_links,omitempty"`
+	Disabled       bool                    `json:"disabled"`
+	DisabledReason string                  `json:"disabled_reason,omitempty"`
+}
+
+type targetLinkInfo struct {
+	Kind  string `json:"kind"`
+	Label string `json:"label"`
+	URL   string `json:"url,omitempty"`
+}
+
+type supervisorQueueInfo struct {
+	Enabled  bool   `json:"enabled"`
+	Label    string `json:"label,omitempty"`
+	Position int    `json:"position,omitempty"`
+	Total    int    `json:"total,omitempty"`
 }
 
 type tokenTotalsInfo struct {
@@ -195,6 +250,159 @@ func githubPRURL(repo string, prNumber int) string {
 		return ""
 	}
 	return fmt.Sprintf("https://github.com/%s/pull/%d", strings.TrimSpace(repo), prNumber)
+}
+
+func buildSupervisorInfo(cfg *config.Config, st *state.State) supervisorInfo {
+	info := supervisorInfo{
+		HasRun:          len(st.SupervisorDecisions) > 0,
+		EmptyState:      "No Supervisor has run yet. Run the supervisor to record orchestration rationale.",
+		ApprovalActions: make([]supervisorActionInfo, 0),
+	}
+	if !info.HasRun {
+		return info
+	}
+
+	latest := st.LatestSupervisorDecision()
+	if latest != nil {
+		info.EmptyState = ""
+		info.Latest = makeSupervisorDecisionInfo(cfg, st, *latest)
+		if latest.Risk != "" && latest.Risk != "safe" && latest.RecommendedAction != "" {
+			info.ApprovalActions = append(info.ApprovalActions, makeSupervisorActionInfo(cfg, *latest, true,
+				"Supervisor controls are not implemented yet; this read-only panel only shows the required action."))
+		}
+	}
+
+	if safe := latestSafeSupervisorDecision(st); safe != nil {
+		action := makeSupervisorActionInfo(cfg, *safe, false, "")
+		info.LastSafeAction = &action
+	}
+	return info
+}
+
+func makeSupervisorDecisionInfo(cfg *config.Config, st *state.State, decision state.SupervisorDecision) *supervisorDecisionInfo {
+	return &supervisorDecisionInfo{
+		ID:                decision.ID,
+		CreatedAt:         decision.CreatedAt,
+		Project:           decision.Project,
+		Mode:              decision.Mode,
+		PolicyRule:        decision.PolicyRule,
+		Status:            decision.Status,
+		Summary:           decision.Summary,
+		RecommendedAction: decision.RecommendedAction,
+		Target:            decision.Target,
+		TargetLinks:       supervisorTargetLinks(cfg.Repo, decision.Target),
+		Risk:              decision.Risk,
+		Confidence:        decision.Confidence,
+		ErrorClass:        decision.ErrorClass,
+		Reasons:           decision.Reasons,
+		Mutations:         decision.Mutations,
+		StuckStates:       decision.StuckStates,
+		StuckReasons:      supervisorStuckReasons(decision),
+		ProjectState:      decision.ProjectState,
+		Queue:             supervisorQueueInfoForDecision(cfg, st, decision),
+	}
+}
+
+func makeSupervisorActionInfo(cfg *config.Config, decision state.SupervisorDecision, disabled bool, disabledReason string) supervisorActionInfo {
+	return supervisorActionInfo{
+		Action:         decision.RecommendedAction,
+		Summary:        decision.Summary,
+		Risk:           decision.Risk,
+		CreatedAt:      decision.CreatedAt,
+		Target:         decision.Target,
+		TargetLinks:    supervisorTargetLinks(cfg.Repo, decision.Target),
+		Disabled:       disabled,
+		DisabledReason: disabledReason,
+	}
+}
+
+func latestSafeSupervisorDecision(st *state.State) *state.SupervisorDecision {
+	var latest *state.SupervisorDecision
+	for i := range st.SupervisorDecisions {
+		decision := &st.SupervisorDecisions[i]
+		if decision.Risk != "safe" {
+			continue
+		}
+		if latest == nil || decision.CreatedAt.After(latest.CreatedAt) {
+			latest = decision
+		}
+	}
+	return latest
+}
+
+func supervisorTargetLinks(repo string, target *state.SupervisorTarget) []targetLinkInfo {
+	if target == nil {
+		return nil
+	}
+	links := make([]targetLinkInfo, 0, 3)
+	if target.Issue > 0 {
+		links = append(links, targetLinkInfo{
+			Kind:  "issue",
+			Label: fmt.Sprintf("Issue #%d", target.Issue),
+			URL:   githubIssueURL(repo, target.Issue),
+		})
+	}
+	if target.PR > 0 {
+		links = append(links, targetLinkInfo{
+			Kind:  "pr",
+			Label: fmt.Sprintf("PR #%d", target.PR),
+			URL:   githubPRURL(repo, target.PR),
+		})
+	}
+	if strings.TrimSpace(target.Session) != "" {
+		links = append(links, targetLinkInfo{
+			Kind:  "session",
+			Label: "Session " + strings.TrimSpace(target.Session),
+		})
+	}
+	return links
+}
+
+func supervisorStuckReasons(decision state.SupervisorDecision) []string {
+	if len(decision.StuckStates) > 0 {
+		reasons := make([]string, 0, len(decision.StuckStates))
+		for _, stuck := range decision.StuckStates {
+			if strings.TrimSpace(stuck.Summary) != "" {
+				reasons = append(reasons, stuck.Summary)
+			}
+		}
+		return reasons
+	}
+
+	action := strings.TrimSpace(decision.RecommendedAction)
+	if action == "none" || strings.HasPrefix(action, "wait_") || decision.Risk == "approval_gated" {
+		return decision.Reasons
+	}
+
+	var reasons []string
+	for _, reason := range decision.Reasons {
+		lower := strings.ToLower(reason)
+		if strings.Contains(lower, "blocked") || strings.Contains(lower, "skipped") || strings.Contains(lower, "exhausted") || strings.Contains(lower, "no eligible") || strings.Contains(lower, "no worker slot") || strings.Contains(lower, "missing") {
+			reasons = append(reasons, reason)
+		}
+	}
+	return reasons
+}
+
+func supervisorQueueInfoForDecision(cfg *config.Config, st *state.State, decision state.SupervisorDecision) *supervisorQueueInfo {
+	if cfg == nil || !cfg.Supervisor.OrderedQueueActive() {
+		return nil
+	}
+	queue := &supervisorQueueInfo{
+		Enabled: true,
+		Label:   "Supervisor ordered issue queue",
+		Total:   len(cfg.Supervisor.OrderedQueue.Issues),
+	}
+	if decision.Target == nil || decision.Target.Issue <= 0 {
+		return queue
+	}
+	for i, issue := range cfg.Supervisor.OrderedQueue.Issues {
+		if issue == decision.Target.Issue {
+			queue.Position = i + 1
+			return queue
+		}
+	}
+	return queue
 }
 
 func validGitHubRepo(repo string) bool {
@@ -291,6 +499,7 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 		PROpen:              make([]sessionInfo, 0),
 		Queued:              make([]sessionInfo, 0),
 		Summary:             make(map[string]int),
+		Supervisor:          buildSupervisorInfo(s.cfg, st),
 		SupervisorLatest:    latestDecision,
 		SupervisorDecisions: st.SupervisorDecisions,
 	}
@@ -705,7 +914,7 @@ const dashboardHTML = `<!DOCTYPE html>
   .log-panel {
     min-width: 0;
     display: grid;
-    grid-template-rows: 48px auto minmax(0, 1fr);
+    grid-template-rows: 48px auto auto minmax(0, 1fr);
     background: #080c11;
   }
   .log-head {
@@ -744,6 +953,45 @@ const dashboardHTML = `<!DOCTYPE html>
     gap: 10px;
     margin-left: 10px;
   }
+  .supervisor-panel {
+    border-bottom: 1px solid var(--line);
+    background: #0b1016;
+    padding: 12px 14px;
+    font-size: 12px;
+    color: var(--muted);
+  }
+  .supervisor-head, .supervisor-main, .supervisor-meta, .supervisor-links, .supervisor-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .supervisor-head { justify-content: space-between; margin-bottom: 6px; }
+  .supervisor-title { color: var(--text); font-weight: 650; }
+  .supervisor-time { white-space: nowrap; }
+  .supervisor-action {
+    color: var(--text);
+    font-weight: 650;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .supervisor-summary { margin-top: 4px; color: var(--text); }
+  .supervisor-meta, .supervisor-links, .supervisor-actions { flex-wrap: wrap; margin-top: 6px; }
+  .supervisor-reasons {
+    margin: 6px 0 0;
+    padding-left: 16px;
+  }
+  .supervisor-reasons li { margin: 2px 0; }
+  .supervisor-approval {
+    height: 24px;
+    border: 1px solid rgba(210,153,34,.45);
+    border-radius: 6px;
+    background: rgba(210,153,34,.08);
+    color: var(--warn);
+    cursor: not-allowed;
+  }
+  .supervisor-empty { color: var(--muted); }
   pre {
     margin: 0;
     min-height: 0;
@@ -807,6 +1055,7 @@ const dashboardHTML = `<!DOCTYPE html>
       <div class="log-title" id="log-title">Log <span></span></div>
       <div class="log-meta" id="log-meta"></div>
     </div>
+    <div class="supervisor-panel" id="supervisor-panel"></div>
     <div class="status-note" id="status-note"></div>
     <pre id="log"><span class="muted">Select a worker.</span></pre>
   </section>
@@ -816,6 +1065,7 @@ window.MAESTRO_REPO = __REPO_JSON__;
 
 const state = {
   workers: [],
+  supervisor: null,
   selected: "",
   filter: "",
   lastLog: null
@@ -840,6 +1090,7 @@ const logEl = document.getElementById("log");
 const logTitleEl = document.getElementById("log-title");
 const logMetaEl = document.getElementById("log-meta");
 const statusNoteEl = document.getElementById("status-note");
+const supervisorPanelEl = document.getElementById("supervisor-panel");
 
 repoEl.textContent = window.MAESTRO_REPO || "";
 
@@ -869,6 +1120,34 @@ function compactNumber(value) {
 function linkHTML(url, label) {
   if (!url) return escapeText(label);
   return '<a href="' + escapeText(url) + '" target="_blank" rel="noreferrer">' + escapeText(label) + '</a>';
+}
+
+function actionLabel(action) {
+  return String(action || "-").replace(/_/g, " ");
+}
+
+function formatTimestamp(value) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  const seconds = Math.max(0, Math.round((Date.now() - date.getTime()) / 1000));
+  let relative = seconds + "s ago";
+  if (seconds >= 86400) relative = Math.floor(seconds / 86400) + "d ago";
+  else if (seconds >= 3600) relative = Math.floor(seconds / 3600) + "h ago";
+  else if (seconds >= 60) relative = Math.floor(seconds / 60) + "m ago";
+  return date.toLocaleString() + " (" + relative + ")";
+}
+
+function targetLinksHTML(links) {
+  return (links || []).map(link => linkHTML(link.url, link.label)).join("");
+}
+
+function queueText(queue) {
+  if (!queue || !queue.enabled) return "";
+  const label = queue.label || "Queue";
+  if (queue.position && queue.total) return label + ": " + queue.position + " of " + queue.total;
+  if (queue.total) return label + ": " + queue.total + " item" + (queue.total === 1 ? "" : "s");
+  return label + ": empty";
 }
 
 function statusLabel(worker) {
@@ -915,6 +1194,55 @@ function renderStats(summary, total, maxParallel, readOnly) {
   statsEl.innerHTML = items.map(([label, value]) =>
     '<div class="stat"><strong>' + escapeText(value) + '</strong><span>' + escapeText(label) + '</span></div>'
   ).join("");
+}
+
+function renderSupervisor(info) {
+  if (!info || !info.has_run || !info.latest) {
+    const empty = info && info.empty_state ? info.empty_state : "No Supervisor has run yet.";
+    supervisorPanelEl.innerHTML = '<div class="supervisor-head">' +
+      '<span class="supervisor-title">Supervisor</span>' +
+      '<span class="supervisor-time">empty</span>' +
+      '</div>' +
+      '<div class="supervisor-empty">' + escapeText(empty) + '</div>';
+    return;
+  }
+
+  const latest = info.latest;
+  const links = targetLinksHTML(latest.target_links);
+  const queue = queueText(latest.queue);
+  const meta = [
+    latest.risk ? "Risk " + latest.risk : "",
+    latest.confidence ? "Confidence " + Number(latest.confidence).toFixed(2) : "",
+    queue
+  ].filter(Boolean);
+  const reasons = (latest.stuck_reasons && latest.stuck_reasons.length ? latest.stuck_reasons : latest.reasons || []).slice(0, 3);
+  const reasonHTML = reasons.length ? '<ul class="supervisor-reasons">' + reasons.map(reason =>
+    '<li>' + escapeText(reason) + '</li>'
+  ).join("") + '</ul>' : "";
+  const lastSafe = info.last_safe_action ? '<div class="supervisor-meta">' +
+    '<span>Last safe action: ' + escapeText(actionLabel(info.last_safe_action.action)) + '</span>' +
+    '<span>' + escapeText(formatTimestamp(info.last_safe_action.created_at)) + '</span>' +
+    '</div>' : "";
+  const approvals = (info.approval_actions || []).length ? '<div class="supervisor-actions">' +
+    '<span>Requires approval:</span>' +
+    (info.approval_actions || []).map(action =>
+      '<button class="supervisor-approval" disabled title="' + escapeText(action.disabled_reason || "Controls not available yet") + '">' +
+      escapeText(actionLabel(action.action)) +
+      '</button>'
+    ).join("") +
+    '</div>' : "";
+
+  supervisorPanelEl.innerHTML = '<div class="supervisor-head">' +
+    '<span class="supervisor-title">Supervisor</span>' +
+    '<span class="supervisor-time">' + escapeText(formatTimestamp(latest.created_at)) + '</span>' +
+    '</div>' +
+    '<div class="supervisor-main">' +
+    '<span class="supervisor-action">' + escapeText(actionLabel(latest.recommended_action)) + '</span>' +
+    (links ? '<span class="supervisor-links">' + links + '</span>' : "") +
+    '</div>' +
+    (latest.summary ? '<div class="supervisor-summary">' + escapeText(latest.summary) + '</div>' : "") +
+    (meta.length ? '<div class="supervisor-meta">' + meta.map(item => '<span>' + escapeText(item) + '</span>').join("") + '</div>' : "") +
+    reasonHTML + lastSafe + approvals;
 }
 
 function renderWorkers() {
@@ -984,7 +1312,9 @@ async function loadState() {
     if (!response.ok) throw new Error(await response.text());
     const data = await response.json();
     state.workers = data.all || [];
+    state.supervisor = data.supervisor || null;
     renderStats(data.summary || {}, state.workers.length, data.max_parallel || 0, data.read_only);
+    renderSupervisor(state.supervisor);
     if (!state.selected && state.workers.length) state.selected = sortWorkers(state.workers)[0].slot;
     if (state.selected && !state.workers.some(worker => worker.slot === state.selected)) {
       state.selected = state.workers.length ? sortWorkers(state.workers)[0].slot : "";

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -157,6 +157,120 @@ func TestHandleState(t *testing.T) {
 	if resp.SupervisorLatest == nil || len(resp.SupervisorLatest.StuckStates) != 1 {
 		t.Fatalf("supervisor_latest stuck states missing: %#v", resp.SupervisorLatest)
 	}
+	if !resp.Supervisor.HasRun {
+		t.Fatal("supervisor.has_run = false, want true")
+	}
+	if resp.Supervisor.Latest == nil || resp.Supervisor.Latest.ID != "sup-test" {
+		t.Fatalf("supervisor.latest = %#v, want sup-test", resp.Supervisor.Latest)
+	}
+	if len(resp.Supervisor.Latest.StuckReasons) != 1 {
+		t.Fatalf("supervisor latest stuck reasons = %#v, want one", resp.Supervisor.Latest.StuckReasons)
+	}
+}
+
+func TestHandleStateSupervisorRationale(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:        "test/repo",
+		MaxParallel: 3,
+		StateDir:    dir,
+		Supervisor: config.SupervisorConfig{
+			OrderedQueue: config.SupervisorOrderedQueueConfig{Issues: []int{42, 43}},
+		},
+		Server: config.ServerConfig{Port: 8765},
+	}
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "first PR",
+		Status:      state.StatusPROpen,
+		StartedAt:   now.Add(-2 * time.Hour),
+		PRNumber:    12,
+	}
+	st.Sessions["slot-2"] = &state.Session{
+		IssueNumber: 43,
+		IssueTitle:  "second PR",
+		Status:      state.StatusQueued,
+		StartedAt:   now.Add(-1 * time.Hour),
+		PRNumber:    20,
+	}
+	st.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-safe",
+		CreatedAt:         now.Add(-30 * time.Minute),
+		Project:           "test/repo",
+		Mode:              "read_only",
+		Summary:           "Session slot-1 already has open PR #12.",
+		RecommendedAction: "monitor_open_pr",
+		Target:            &state.SupervisorTarget{Issue: 42, PR: 12, Session: "slot-1"},
+		Risk:              "safe",
+		Confidence:        0.9,
+		Reasons:           []string{"Session slot-1 is associated with open PR #12"},
+		ProjectState:      state.SupervisorProjectState{Sessions: 2, PROpen: 1, Queued: 1, OpenPRs: 2},
+	}, state.DefaultSupervisorDecisionLimit)
+	st.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-latest",
+		CreatedAt:         now,
+		Project:           "test/repo",
+		Mode:              "read_only",
+		Summary:           "Issue #43 exhausted its retry budget and needs manual review.",
+		RecommendedAction: "review_retry_exhausted",
+		Target:            &state.SupervisorTarget{Issue: 43, PR: 20, Session: "slot-2"},
+		Risk:              "approval_gated",
+		Confidence:        0.93,
+		Reasons: []string{
+			"Session slot-2 for issue #43 is retry_exhausted",
+			"Retry-exhausted work requires a human decision before more automation",
+		},
+		ProjectState: state.SupervisorProjectState{Sessions: 2, PROpen: 1, Queued: 1, OpenPRs: 2},
+	}, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	srv := New(cfg, make(chan struct{}, 1))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.handleState(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp stateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !resp.Supervisor.HasRun {
+		t.Fatal("supervisor.has_run = false, want true")
+	}
+	if resp.Supervisor.Latest == nil {
+		t.Fatal("supervisor.latest missing")
+	}
+	if resp.Supervisor.Latest.RecommendedAction != "review_retry_exhausted" {
+		t.Fatalf("latest action = %q", resp.Supervisor.Latest.RecommendedAction)
+	}
+	if len(resp.Supervisor.Latest.StuckReasons) != 2 {
+		t.Fatalf("stuck reasons = %d, want 2", len(resp.Supervisor.Latest.StuckReasons))
+	}
+	if !hasTargetLink(resp.Supervisor.Latest.TargetLinks, "issue", "https://github.com/test/repo/issues/43") {
+		t.Fatalf("latest target links = %#v, want issue link", resp.Supervisor.Latest.TargetLinks)
+	}
+	if !hasTargetLink(resp.Supervisor.Latest.TargetLinks, "pr", "https://github.com/test/repo/pull/20") {
+		t.Fatalf("latest target links = %#v, want PR link", resp.Supervisor.Latest.TargetLinks)
+	}
+	if resp.Supervisor.Latest.Queue == nil || !resp.Supervisor.Latest.Queue.Enabled || resp.Supervisor.Latest.Queue.Position != 2 || resp.Supervisor.Latest.Queue.Total != 2 {
+		t.Fatalf("queue = %#v, want position 2 of 2", resp.Supervisor.Latest.Queue)
+	}
+	if resp.Supervisor.LastSafeAction == nil || resp.Supervisor.LastSafeAction.Action != "monitor_open_pr" {
+		t.Fatalf("last safe action = %#v", resp.Supervisor.LastSafeAction)
+	}
+	if len(resp.Supervisor.ApprovalActions) != 1 || !resp.Supervisor.ApprovalActions[0].Disabled {
+		t.Fatalf("approval actions = %#v, want one disabled action", resp.Supervisor.ApprovalActions)
+	}
+	if resp.SupervisorLatest == nil || resp.SupervisorLatest.ID != "sup-latest" {
+		t.Fatalf("legacy supervisor_latest = %#v, want sup-latest", resp.SupervisorLatest)
+	}
 }
 
 func TestHandleState_MethodNotAllowed(t *testing.T) {
@@ -426,6 +540,12 @@ func TestHandleDashboard(t *testing.T) {
 	if !contains(body, "status-note") {
 		t.Error("dashboard should include status explanation block")
 	}
+	if !contains(body, "supervisor-panel") || !contains(body, "renderSupervisor") {
+		t.Error("dashboard should include supervisor rationale panel")
+	}
+	if !contains(body, "No Supervisor has run yet") {
+		t.Error("dashboard should include supervisor empty state text")
+	}
 	if !contains(body, "issue_url") || !contains(body, "pr_url") {
 		t.Error("dashboard should render GitHub issue/PR links from API fields")
 	}
@@ -485,6 +605,15 @@ func TestHandleState_EmptyState(t *testing.T) {
 	}
 	if resp.TokenTotals.Total != 0 {
 		t.Errorf("total tokens = %d, want 0", resp.TokenTotals.Total)
+	}
+	if resp.Supervisor.HasRun {
+		t.Error("supervisor.has_run = true, want false")
+	}
+	if resp.Supervisor.EmptyState == "" {
+		t.Error("supervisor empty state should explain that no supervisor has run")
+	}
+	if resp.Supervisor.Latest != nil {
+		t.Fatalf("supervisor.latest = %#v, want nil", resp.Supervisor.Latest)
 	}
 }
 
@@ -559,6 +688,15 @@ func contains(s, substr string) bool {
 func containsSubstr(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func hasTargetLink(links []targetLinkInfo, kind, url string) bool {
+	for _, link := range links {
+		if link.Kind == kind && link.URL == url {
 			return true
 		}
 	}


### PR DESCRIPTION
Closes #265

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a read-only "Supervisor rationale" panel in the Mission Control dashboard. The Go side adds `supervisorInfo` and companion types populated by `buildSupervisorInfo`, exposing the latest decision, last-safe action, approval actions, target links, and queue position. The front-end renders this via a new `renderSupervisor` function with proper HTML escaping throughout. No logic issues found; the new `TestHandleStateSupervisorRationale` test validates the key fields end-to-end.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic or security issues found.

All new code paths are nil-guarded, HTML escaping is applied consistently via `escapeText` (with `value ?? ""` null-coalescing), `linkHTML` handles URL-less session links correctly, and the new test provides solid end-to-end coverage of the API surface.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/server.go | Adds `supervisorInfo` struct, builder functions, and inline dashboard JS/CSS to render a read-only supervisor rationale panel in Mission Control. Logic is well-guarded (nil cfg, nil target, empty queues); HTML escaping is consistent. |
| internal/server/server_test.go | Adds `TestHandleStateSupervisorRationale` and assertions in existing tests covering has_run, latest decision, stuck reasons, target links, queue position, last safe action, and approval actions. Coverage is thorough and assertions are tight. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add supervisor rationale panel (#2..."](https://github.com/befeast/maestro/commit/f119eecd2634f1839084e1126aefd33750e700a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30236143)</sub>

<!-- /greptile_comment -->