### PR TITLE
Approval and audit model for risky supervisor actions

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -68,6 +69,8 @@ Supervise flags:
   --once                Run one supervisor decision and exit
   --interval duration   Loop interval (default 5m)
   --json                Output decision as JSON
+  maestro supervise approve <approval-or-decision-id>
+  maestro supervise reject <approval-or-decision-id>
 
 Serve flags:
   --host string         Host/interface to bind (default from config, then 127.0.0.1)
@@ -354,12 +357,30 @@ func runCmd(args []string) {
 }
 
 func superviseCmd(args []string) {
+	if len(args) > 0 {
+		switch args[0] {
+		case "approve", "reject":
+			superviseApprovalCmd(args[0], args[1:], "")
+			return
+		}
+	}
+
 	fs := flag.NewFlagSet("supervise", flag.ExitOnError)
 	configPath := fs.String("config", "", "Path to config file")
 	once := fs.Bool("once", false, "Run once and exit")
 	interval := fs.Duration("interval", 5*time.Minute, "Loop interval")
 	jsonOutput := fs.Bool("json", false, "Output decision as JSON")
 	fs.Parse(args)
+	if fs.NArg() > 0 {
+		subcmd := fs.Arg(0)
+		switch subcmd {
+		case "approve", "reject":
+			superviseApprovalCmd(subcmd, fs.Args()[1:], *configPath)
+			return
+		default:
+			log.Fatalf("supervise: unexpected argument %q", subcmd)
+		}
+	}
 
 	if !*once && *interval <= 0 {
 		log.Fatalf("supervise: --interval must be positive")
@@ -401,6 +422,47 @@ func superviseCmd(args []string) {
 	}
 }
 
+func superviseApprovalCmd(action string, args []string, defaultConfigPath string) {
+	fs := flag.NewFlagSet("supervise "+action, flag.ExitOnError)
+	configPath := fs.String("config", defaultConfigPath, "Path to config file")
+	actor := fs.String("actor", "cli", "Audit actor")
+	reason := fs.String("reason", "", "Audit reason")
+	fs.Parse(args)
+	if fs.NArg() != 1 {
+		log.Fatalf("supervise %s: expected approval or decision id", action)
+	}
+
+	cfg := loadConfig(*configPath)
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		log.Fatalf("supervise %s: load state: %v", action, err)
+	}
+
+	id := fs.Arg(0)
+	now := time.Now().UTC()
+	var approval *state.Approval
+	switch action {
+	case "approve":
+		approval, err = st.ApproveApproval(id, now, *actor, *reason)
+	case "reject":
+		approval, err = st.RejectApproval(id, now, *actor, *reason)
+	default:
+		log.Fatalf("supervise: unknown approval action %q", action)
+	}
+	if err != nil {
+		if errors.Is(err, state.ErrApprovalStale) || errors.Is(err, state.ErrApprovalPayloadMismatch) {
+			if saveErr := state.Save(cfg.StateDir, st); saveErr != nil {
+				log.Fatalf("supervise %s: save stale approval: %v", action, saveErr)
+			}
+		}
+		log.Fatalf("supervise %s: %v", action, err)
+	}
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		log.Fatalf("supervise %s: save state: %v", action, err)
+	}
+	fmt.Printf("Approval %s %s. No risky action was executed.\n", approval.ID, approval.Status)
+}
+
 func printSupervisorDecision(decision state.SupervisorDecision, jsonOutput bool) {
 	if jsonOutput {
 		enc := json.NewEncoder(os.Stdout)
@@ -418,6 +480,9 @@ func printSupervisorDecision(decision state.SupervisorDecision, jsonOutput bool)
 	fmt.Printf("Confidence: %.2f\n", decision.Confidence)
 	if decision.ErrorClass != "" {
 		fmt.Printf("Error class: %s\n", decision.ErrorClass)
+	}
+	if decision.ApprovalID != "" {
+		fmt.Printf("Approval: %s\n", decision.ApprovalID)
 	}
 	if decision.Target != nil {
 		parts := supervisorTargetParts(decision.Target)
@@ -595,6 +660,7 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 	}
 	fmt.Println()
 	showLatestSupervisorDecision(s)
+	showApprovals(s)
 
 	if len(s.Sessions) == 0 {
 		fmt.Println("No sessions.")
@@ -884,6 +950,9 @@ func showLatestSupervisorDecision(s *state.State) {
 		fmt.Printf("  Summary: %s\n", decision.Summary)
 	}
 	fmt.Printf("  Risk: %s  Confidence: %.2f\n", decision.Risk, decision.Confidence)
+	if decision.ApprovalID != "" {
+		fmt.Printf("  Approval: %s\n", decision.ApprovalID)
+	}
 	if decision.Target != nil {
 		parts := supervisorTargetParts(decision.Target)
 		if len(parts) > 0 {
@@ -897,6 +966,26 @@ func showLatestSupervisorDecision(s *state.State) {
 			fmt.Printf(" (top: %s/%s)", first.Code, first.Severity)
 		}
 		fmt.Println()
+	}
+	fmt.Println()
+}
+
+func showApprovals(s *state.State) {
+	if len(s.Approvals) == 0 {
+		return
+	}
+	approvals := append([]state.Approval(nil), s.Approvals...)
+	sort.Slice(approvals, func(i, j int) bool {
+		return approvals[i].CreatedAt.After(approvals[j].CreatedAt)
+	})
+	fmt.Println("Approvals:")
+	for _, approval := range approvals {
+		target := "-"
+		parts := supervisorTargetParts(approval.Target)
+		if len(parts) > 0 {
+			target = strings.Join(parts, ", ")
+		}
+		fmt.Printf("  %s  %s  %s  %s\n", approval.ID, approval.Status, approval.Action, target)
 	}
 	fmt.Println()
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -108,6 +108,7 @@ type stateResponse struct {
 	Supervisor          supervisorInfo               `json:"supervisor"`
 	SupervisorLatest    *state.SupervisorDecision    `json:"supervisor_latest,omitempty"`
 	SupervisorDecisions []state.SupervisorDecision   `json:"supervisor_decisions,omitempty"`
+	Approvals           []state.Approval             `json:"approvals,omitempty"`
 }
 
 type supervisorInfo struct {
@@ -138,6 +139,7 @@ type supervisorDecisionInfo struct {
 	StuckReasons      []string                     `json:"stuck_reasons,omitempty"`
 	ProjectState      state.SupervisorProjectState `json:"project_state"`
 	Queue             *supervisorQueueInfo         `json:"queue,omitempty"`
+	ApprovalID        string                       `json:"approval_id,omitempty"`
 }
 
 type supervisorActionInfo struct {
@@ -300,6 +302,7 @@ func makeSupervisorDecisionInfo(cfg *config.Config, st *state.State, decision st
 		StuckReasons:      supervisorStuckReasons(decision),
 		ProjectState:      decision.ProjectState,
 		Queue:             supervisorQueueInfoForDecision(cfg, st, decision),
+		ApprovalID:        decision.ApprovalID,
 	}
 }
 
@@ -502,6 +505,7 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 		Supervisor:          buildSupervisorInfo(s.cfg, st),
 		SupervisorLatest:    latestDecision,
 		SupervisorDecisions: st.SupervisorDecisions,
+		Approvals:           st.Approvals,
 	}
 	if latestDecision != nil {
 		resp.StuckStates = latestDecision.StuckStates

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -273,6 +273,51 @@ func TestHandleStateSupervisorRationale(t *testing.T) {
 	}
 }
 
+func TestHandleState_IncludesApprovals(t *testing.T) {
+	srv, cfg := setupTestServer(t)
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	approval := st.RecordPendingApprovalForDecision(state.SupervisorDecision{
+		ID:                "sup-approval",
+		CreatedAt:         now,
+		Project:           "test/repo",
+		Mode:              "read_only",
+		Summary:           "Start a worker for issue #42.",
+		RecommendedAction: "spawn_worker",
+		Target:            &state.SupervisorTarget{Issue: 42},
+		Risk:              "mutating",
+		Confidence:        0.84,
+		Reasons:           []string{"Issue #42 is eligible"},
+	}, now)
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.handleState(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp stateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Approvals) != 1 {
+		t.Fatalf("approvals = %d, want 1", len(resp.Approvals))
+	}
+	if resp.Approvals[0].ID != approval.ID {
+		t.Fatalf("approval ID = %q, want %q", resp.Approvals[0].ID, approval.ID)
+	}
+	if resp.Approvals[0].Status != state.ApprovalStatusPending {
+		t.Fatalf("approval status = %q, want %q", resp.Approvals[0].Status, state.ApprovalStatusPending)
+	}
+}
+
 func TestHandleState_MethodNotAllowed(t *testing.T) {
 	srv, _ := setupTestServer(t)
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,7 +1,10 @@
 package state
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -99,6 +102,13 @@ type Mission struct {
 
 const DefaultSupervisorDecisionLimit = 20
 
+var (
+	ErrApprovalNotFound        = errors.New("approval not found")
+	ErrApprovalNotPending      = errors.New("approval is not pending")
+	ErrApprovalStale           = errors.New("approval is stale")
+	ErrApprovalPayloadMismatch = errors.New("approval payload changed")
+)
+
 // SupervisorTarget identifies the primary object a supervisor decision refers to.
 type SupervisorTarget struct {
 	Issue   int    `json:"issue,omitempty"`
@@ -157,12 +167,56 @@ type SupervisorDecision struct {
 	Mutations         []SupervisorMutation   `json:"mutations,omitempty"`
 	StuckStates       []SupervisorStuckState `json:"stuck_states,omitempty"`
 	ProjectState      SupervisorProjectState `json:"project_state"`
+	ApprovalID        string                 `json:"approval_id,omitempty"`
+}
+
+type ApprovalStatus string
+
+const (
+	ApprovalStatusPending  ApprovalStatus = "pending"
+	ApprovalStatusApproved ApprovalStatus = "approved"
+	ApprovalStatusRejected ApprovalStatus = "rejected"
+	ApprovalStatusStale    ApprovalStatus = "stale"
+)
+
+const (
+	ApprovalAuditCreated  = "created"
+	ApprovalAuditApproved = "approved"
+	ApprovalAuditRejected = "rejected"
+	ApprovalAuditStale    = "stale"
+)
+
+// Approval records a risky supervisor decision that needs explicit resolution.
+type Approval struct {
+	ID              string            `json:"id"`
+	DecisionID      string            `json:"decision_id,omitempty"`
+	CreatedAt       time.Time         `json:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at,omitempty"`
+	Action          string            `json:"action"`
+	Target          *SupervisorTarget `json:"target,omitempty"`
+	Summary         string            `json:"summary"`
+	Risk            string            `json:"risk"`
+	Evidence        []string          `json:"evidence,omitempty"`
+	Status          ApprovalStatus    `json:"status"`
+	PayloadHash     string            `json:"payload_hash"`
+	TargetStateHash string            `json:"target_state_hash,omitempty"`
+	Audit           []ApprovalAudit   `json:"audit,omitempty"`
+}
+
+type ApprovalAudit struct {
+	At              time.Time `json:"at"`
+	Event           string    `json:"event"`
+	Actor           string    `json:"actor,omitempty"`
+	Reason          string    `json:"reason,omitempty"`
+	PayloadHash     string    `json:"payload_hash,omitempty"`
+	TargetStateHash string    `json:"target_state_hash,omitempty"`
 }
 
 type State struct {
 	Sessions            map[string]*Session  `json:"sessions"`
 	Missions            map[int]*Mission     `json:"missions,omitempty"` // parent issue number → mission
 	SupervisorDecisions []SupervisorDecision `json:"supervisor_decisions,omitempty"`
+	Approvals           []Approval           `json:"approvals,omitempty"`
 	NextSlot            int                  `json:"next_slot"`
 	LastMergeAt         time.Time            `json:"last_merge_at,omitempty"`
 }
@@ -251,6 +305,258 @@ func (s *State) LatestSupervisorDecision() *SupervisorDecision {
 		}
 	}
 	return &s.SupervisorDecisions[latest]
+}
+
+// RecordPendingApprovalForDecision creates a pending approval tied to a decision payload.
+func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, now time.Time) *Approval {
+	if s == nil {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	createdAt := decision.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+	approval := Approval{
+		ID:              approvalID(decision, createdAt),
+		DecisionID:      decision.ID,
+		CreatedAt:       createdAt,
+		UpdatedAt:       now,
+		Action:          decision.RecommendedAction,
+		Target:          cloneSupervisorTarget(decision.Target),
+		Summary:         decision.Summary,
+		Risk:            decision.Risk,
+		Evidence:        append([]string(nil), decision.Reasons...),
+		Status:          ApprovalStatusPending,
+		TargetStateHash: s.ApprovalTargetStateHash(decision.Target),
+	}
+	approval.PayloadHash = approval.ComputePayloadHash()
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              now,
+		Event:           ApprovalAuditCreated,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: approval.TargetStateHash,
+	})
+	s.Approvals = append(s.Approvals, approval)
+	return &s.Approvals[len(s.Approvals)-1]
+}
+
+func (s *State) FindApproval(id string) (*Approval, bool) {
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if approval.ID == id || approval.DecisionID == id {
+			return approval, true
+		}
+	}
+	return nil, false
+}
+
+func (s *State) ApproveApproval(id string, now time.Time, actor, reason string) (*Approval, error) {
+	approval, err := s.pendingApproval(id)
+	if err != nil {
+		return approval, err
+	}
+	if err := s.ensureApprovalCurrent(approval, now); err != nil {
+		return approval, err
+	}
+	approval.Status = ApprovalStatusApproved
+	approval.UpdatedAt = normalizedTime(now)
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              approval.UpdatedAt,
+		Event:           ApprovalAuditApproved,
+		Actor:           actor,
+		Reason:          reason,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: approval.TargetStateHash,
+	})
+	return approval, nil
+}
+
+func (s *State) RejectApproval(id string, now time.Time, actor, reason string) (*Approval, error) {
+	approval, err := s.pendingApproval(id)
+	if err != nil {
+		return approval, err
+	}
+	approval.Status = ApprovalStatusRejected
+	approval.UpdatedAt = normalizedTime(now)
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              approval.UpdatedAt,
+		Event:           ApprovalAuditRejected,
+		Actor:           actor,
+		Reason:          reason,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: approval.TargetStateHash,
+	})
+	return approval, nil
+}
+
+// MarkStaleApprovals marks pending approvals stale when their payload or target snapshot changes.
+func (s *State) MarkStaleApprovals(now time.Time) int {
+	count := 0
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if approval.Status != ApprovalStatusPending {
+			continue
+		}
+		if err := s.ensureApprovalCurrent(approval, now); err != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *State) pendingApproval(id string) (*Approval, error) {
+	approval, ok := s.FindApproval(id)
+	if !ok {
+		return nil, ErrApprovalNotFound
+	}
+	if approval.Status == ApprovalStatusStale {
+		return approval, ErrApprovalStale
+	}
+	if approval.Status != ApprovalStatusPending {
+		return approval, ErrApprovalNotPending
+	}
+	return approval, nil
+}
+
+func (s *State) ensureApprovalCurrent(approval *Approval, now time.Time) error {
+	if approval.PayloadHash != "" && approval.ComputePayloadHash() != approval.PayloadHash {
+		s.markApprovalStale(approval, now, "approval payload changed")
+		return ErrApprovalPayloadMismatch
+	}
+	currentTargetStateHash := s.ApprovalTargetStateHash(approval.Target)
+	if approval.TargetStateHash != "" && currentTargetStateHash != approval.TargetStateHash {
+		s.markApprovalStale(approval, now, "approval target state changed")
+		return ErrApprovalStale
+	}
+	return nil
+}
+
+func (s *State) markApprovalStale(approval *Approval, now time.Time, reason string) {
+	if approval.Status == ApprovalStatusStale {
+		return
+	}
+	approval.Status = ApprovalStatusStale
+	approval.UpdatedAt = normalizedTime(now)
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              approval.UpdatedAt,
+		Event:           ApprovalAuditStale,
+		Reason:          reason,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: s.ApprovalTargetStateHash(approval.Target),
+	})
+}
+
+func (a Approval) ComputePayloadHash() string {
+	return stableHash(approvalPayload{
+		DecisionID: a.DecisionID,
+		Action:     a.Action,
+		Target:     a.Target,
+		Summary:    a.Summary,
+		Risk:       a.Risk,
+		Evidence:   a.Evidence,
+	})
+}
+
+// ApprovalTargetStateHash returns a stable digest of state relevant to a target.
+func (s *State) ApprovalTargetStateHash(target *SupervisorTarget) string {
+	snapshot := approvalTargetStateSnapshot{Target: cloneSupervisorTarget(target)}
+	if s == nil || target == nil {
+		return stableHash(snapshot)
+	}
+	names := make([]string, 0, len(s.Sessions))
+	for name := range s.Sessions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		sess := s.Sessions[name]
+		if sess == nil || !approvalTargetMatches(target, name, sess) {
+			continue
+		}
+		snapshot.Sessions = append(snapshot.Sessions, approvalSessionSnapshot{
+			Slot:        name,
+			IssueNumber: sess.IssueNumber,
+			Status:      sess.Status,
+			Branch:      sess.Branch,
+			PRNumber:    sess.PRNumber,
+			FinishedAt:  sess.FinishedAt,
+			RetryCount:  sess.RetryCount,
+			NextRetryAt: sess.NextRetryAt,
+		})
+	}
+	return stableHash(snapshot)
+}
+
+type approvalPayload struct {
+	DecisionID string            `json:"decision_id,omitempty"`
+	Action     string            `json:"action"`
+	Target     *SupervisorTarget `json:"target,omitempty"`
+	Summary    string            `json:"summary"`
+	Risk       string            `json:"risk"`
+	Evidence   []string          `json:"evidence,omitempty"`
+}
+
+type approvalTargetStateSnapshot struct {
+	Target   *SupervisorTarget         `json:"target,omitempty"`
+	Sessions []approvalSessionSnapshot `json:"sessions,omitempty"`
+}
+
+type approvalSessionSnapshot struct {
+	Slot        string        `json:"slot"`
+	IssueNumber int           `json:"issue_number"`
+	Status      SessionStatus `json:"status"`
+	Branch      string        `json:"branch,omitempty"`
+	PRNumber    int           `json:"pr_number,omitempty"`
+	FinishedAt  *time.Time    `json:"finished_at,omitempty"`
+	RetryCount  int           `json:"retry_count,omitempty"`
+	NextRetryAt *time.Time    `json:"next_retry_at,omitempty"`
+}
+
+func approvalID(decision SupervisorDecision, createdAt time.Time) string {
+	if decision.ID != "" {
+		return "approval-" + decision.ID
+	}
+	return "approval-" + createdAt.UTC().Format("20060102T150405.000000000Z")
+}
+
+func approvalTargetMatches(target *SupervisorTarget, slot string, sess *Session) bool {
+	if target.Session != "" && target.Session == slot {
+		return true
+	}
+	if target.Issue > 0 && target.Issue == sess.IssueNumber {
+		return true
+	}
+	if target.PR > 0 && target.PR == sess.PRNumber {
+		return true
+	}
+	return false
+}
+
+func cloneSupervisorTarget(target *SupervisorTarget) *SupervisorTarget {
+	if target == nil {
+		return nil
+	}
+	clone := *target
+	return &clone
+}
+
+func stableHash(value interface{}) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizedTime(t time.Time) time.Time {
+	if t.IsZero() {
+		return time.Now().UTC()
+	}
+	return t.UTC()
 }
 
 // ActiveSessions returns sessions that are currently running

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -879,5 +880,159 @@ func TestRecordSupervisorDecisionPrunesOldRecords(t *testing.T) {
 	latest := s.LatestSupervisorDecision()
 	if latest == nil || latest.ID != "sup-4" {
 		t.Fatalf("latest = %#v, want sup-4", latest)
+	}
+}
+
+func TestApprovalPendingPersistence(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	approval := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+
+	if approval.Status != ApprovalStatusPending {
+		t.Fatalf("status = %q, want %q", approval.Status, ApprovalStatusPending)
+	}
+	if approval.Action != "spawn_worker" {
+		t.Fatalf("action = %q, want spawn_worker", approval.Action)
+	}
+	if approval.Target == nil || approval.Target.Issue != 42 {
+		t.Fatalf("target = %#v, want issue 42", approval.Target)
+	}
+	if approval.PayloadHash == "" {
+		t.Fatal("payload hash missing")
+	}
+	if approval.TargetStateHash == "" {
+		t.Fatal("target state hash missing")
+	}
+	if len(approval.Audit) != 1 || approval.Audit[0].Event != ApprovalAuditCreated {
+		t.Fatalf("audit = %#v, want created event", approval.Audit)
+	}
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	loadedApproval, ok := loaded.FindApproval(approval.ID)
+	if !ok {
+		t.Fatalf("approval %q missing after load", approval.ID)
+	}
+	if loadedApproval.PayloadHash != approval.PayloadHash {
+		t.Fatalf("payload hash = %q, want %q", loadedApproval.PayloadHash, approval.PayloadHash)
+	}
+}
+
+func TestApproveApprovalAuditsResolution(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	approval := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+
+	approved, err := s.ApproveApproval(approval.DecisionID, now.Add(time.Minute), "cli", "checks green")
+	if err != nil {
+		t.Fatalf("ApproveApproval: %v", err)
+	}
+	if approved.Status != ApprovalStatusApproved {
+		t.Fatalf("status = %q, want %q", approved.Status, ApprovalStatusApproved)
+	}
+	if len(approved.Audit) != 2 {
+		t.Fatalf("audit entries = %d, want 2", len(approved.Audit))
+	}
+	last := approved.Audit[len(approved.Audit)-1]
+	if last.Event != ApprovalAuditApproved || last.Actor != "cli" || last.Reason != "checks green" {
+		t.Fatalf("last audit = %#v, want approved by cli", last)
+	}
+}
+
+func TestRejectApprovalAuditsResolution(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	approval := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+
+	rejected, err := s.RejectApproval(approval.ID, now.Add(time.Minute), "cli", "needs review")
+	if err != nil {
+		t.Fatalf("RejectApproval: %v", err)
+	}
+	if rejected.Status != ApprovalStatusRejected {
+		t.Fatalf("status = %q, want %q", rejected.Status, ApprovalStatusRejected)
+	}
+	last := rejected.Audit[len(rejected.Audit)-1]
+	if last.Event != ApprovalAuditRejected || last.Actor != "cli" || last.Reason != "needs review" {
+		t.Fatalf("last audit = %#v, want rejected by cli", last)
+	}
+}
+
+func TestApproveMissingApprovalFailsSafely(t *testing.T) {
+	s := NewState()
+	_, err := s.ApproveApproval("approval-missing", time.Now().UTC(), "cli", "")
+	if !errors.Is(err, ErrApprovalNotFound) {
+		t.Fatalf("ApproveApproval missing err = %v, want %v", err, ErrApprovalNotFound)
+	}
+}
+
+func TestApproveStaleApprovalFailsSafely(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{IssueNumber: 77, Status: StatusRetryExhausted, PRNumber: 12}
+	decision := SupervisorDecision{
+		ID:                "sup-stale",
+		CreatedAt:         now,
+		Project:           "owner/repo",
+		Mode:              "read_only",
+		Summary:           "Review retry-exhausted issue #77.",
+		RecommendedAction: "review_retry_exhausted",
+		Target:            &SupervisorTarget{Issue: 77, PR: 12, Session: "slot-1"},
+		Risk:              "approval_gated",
+		Confidence:        0.93,
+		Reasons:           []string{"retry budget exhausted"},
+	}
+	approval := s.RecordPendingApprovalForDecision(decision, now)
+	s.Sessions["slot-1"].Status = StatusDone
+
+	_, err := s.ApproveApproval(approval.ID, now.Add(time.Minute), "cli", "")
+	if !errors.Is(err, ErrApprovalStale) {
+		t.Fatalf("ApproveApproval stale err = %v, want %v", err, ErrApprovalStale)
+	}
+	if s.Approvals[0].Status != ApprovalStatusStale {
+		t.Fatalf("status = %q, want %q", s.Approvals[0].Status, ApprovalStatusStale)
+	}
+	last := s.Approvals[0].Audit[len(s.Approvals[0].Audit)-1]
+	if last.Event != ApprovalAuditStale {
+		t.Fatalf("last audit = %#v, want stale event", last)
+	}
+}
+
+func TestApproveChangedApprovalPayloadFailsSafely(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	approval := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+	approval.Action = "merge_pr"
+
+	_, err := s.ApproveApproval(approval.ID, now.Add(time.Minute), "cli", "")
+	if !errors.Is(err, ErrApprovalPayloadMismatch) {
+		t.Fatalf("ApproveApproval payload err = %v, want %v", err, ErrApprovalPayloadMismatch)
+	}
+	if s.Approvals[0].Status != ApprovalStatusStale {
+		t.Fatalf("status = %q, want %q", s.Approvals[0].Status, ApprovalStatusStale)
+	}
+}
+
+func testApprovalDecision(now time.Time) SupervisorDecision {
+	return SupervisorDecision{
+		ID:                "sup-approval",
+		CreatedAt:         now,
+		Project:           "owner/repo",
+		Mode:              "read_only",
+		Summary:           "Start a worker for issue #42: ready work",
+		RecommendedAction: "spawn_worker",
+		Target:            &SupervisorTarget{Issue: 42},
+		Risk:              "mutating",
+		Confidence:        0.84,
+		Reasons:           []string{"Issue #42 is eligible", "Starting a worker mutates local worktrees"},
+		ProjectState: SupervisorProjectState{
+			OpenIssues:     1,
+			AvailableSlots: 1,
+		},
 	}
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -116,6 +116,7 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 	if err != nil {
 		return state.SupervisorDecision{}, fmt.Errorf("load state: %w", err)
 	}
+	st.MarkStaleApprovals(time.Now().UTC())
 	if reader == nil {
 		reader = github.New(cfg.Repo)
 	}
@@ -124,7 +125,11 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 	if err != nil {
 		return state.SupervisorDecision{}, err
 	}
-	if len(decision.Mutations) > 0 {
+	if decisionRequiresApproval(decision) {
+		approval := st.RecordPendingApprovalForDecision(decision, decision.CreatedAt)
+		decision.ApprovalID = approval.ID
+	}
+	if len(decision.Mutations) > 0 && decision.Risk == RiskSafe {
 		mutator, ok := reader.(Mutator)
 		if !ok {
 			markUnsupportedQueueAction(&decision)
@@ -634,6 +639,10 @@ func (e *Engine) detectMissingCLI() *state.SupervisorStuckState {
 		return &finding
 	}
 	return nil
+}
+
+func decisionRequiresApproval(decision state.SupervisorDecision) bool {
+	return decision.RecommendedAction != ActionNone && decision.Risk != RiskSafe
 }
 
 func (e *Engine) projectState(st *state.State) state.SupervisorProjectState {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -413,6 +413,50 @@ func TestRunOnceRecordsDecision(t *testing.T) {
 	if latest.ID != decision.ID {
 		t.Fatalf("latest ID = %q, want %q", latest.ID, decision.ID)
 	}
+	if len(st.Approvals) != 0 {
+		t.Fatalf("approvals = %d, want 0 for safe action", len(st.Approvals))
+	}
+}
+
+func TestRunOnceRecordsPendingApprovalForRiskyDecision(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.ApprovalID == "" {
+		t.Fatal("decision approval ID missing")
+	}
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(st.Approvals) != 1 {
+		t.Fatalf("approvals = %d, want 1", len(st.Approvals))
+	}
+	approval := st.Approvals[0]
+	if approval.ID != decision.ApprovalID {
+		t.Fatalf("approval ID = %q, want %q", approval.ID, decision.ApprovalID)
+	}
+	if approval.DecisionID != decision.ID {
+		t.Fatalf("decision ID = %q, want %q", approval.DecisionID, decision.ID)
+	}
+	if approval.Status != state.ApprovalStatusPending {
+		t.Fatalf("status = %q, want %q", approval.Status, state.ApprovalStatusPending)
+	}
+	if approval.Action != ActionSpawnWorker {
+		t.Fatalf("approval action = %q, want %q", approval.Action, ActionSpawnWorker)
+	}
+	if approval.Target == nil || approval.Target.Issue != 42 {
+		t.Fatalf("target = %#v, want issue 42", approval.Target)
+	}
 }
 
 func TestDecide_OrderedQueueSelectsFirstUnfinishedIssue(t *testing.T) {


### PR DESCRIPTION
Closes #266

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an approval and audit model for risky supervisor decisions: a new `Approval` type with payload/target-state hashing, CRUD state methods, CLI `approve`/`reject` subcommands, and API exposure. The state-layer logic is well-structured and the test coverage is thorough.

- **P1 — unbounded approval growth**: `RunOnce` unconditionally appends a new `Approval` on every loop tick for a risky decision without checking whether an identical pending approval already exists. `MarkStaleApprovals` only helps when payload or target state changes, so an unchanged risky recommendation accumulates ~288 new records per day.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is; the approval deduplication gap will silently corrupt state on long-running deployments.

A single P1 logic bug in the core approval-creation path (RunOnce creates a new pending approval every tick without deduplication) caps confidence at 4, and the practical impact — unbounded list growth in the primary daemon loop — pulls it to 3.

internal/supervisor/supervisor.go — the approval creation block in RunOnce needs a deduplication guard before appending to st.Approvals.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | RunOnce unconditionally creates a new pending approval for every risky decision without deduplicating against existing pending approvals of the same payload, causing unbounded accumulation on each loop tick. |
| internal/state/state.go | Adds Approval/ApprovalAudit types, status constants, error sentinels, and all CRUD methods (record, find, approve, reject, mark-stale) with payload and target-state hashing; logic is sound with one capped concern about unbounded growth driven from the caller. |
| cmd/maestro/main.go | Adds approve/reject CLI subcommands with flag parsing, state save-on-stale error handling, and display helpers for pending approvals; logic is correct. |
| internal/server/server.go | Exposes approvals in the state API response and threads ApprovalID through the supervisor decision info; straightforward, no issues. |
| internal/state/state_test.go | Good coverage of approval lifecycle: pending persistence, approve/reject audit trails, missing ID, stale-on-state-change, and payload-mismatch cases. |
| internal/supervisor/supervisor_test.go | Adds tests verifying no approval for safe decisions and a pending approval for risky spawn_worker decisions; adequate coverage for the new path. |
| internal/server/server_test.go | New test verifies that pending approvals are included in the /api/v1/state response; looks correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/supervisor/supervisor.go
Line: 128-131

Comment:
**Unbounded approval accumulation on each RunOnce loop**

`RunOnce` creates a new `Approval` record every time a risky decision is produced, with no guard against an already-pending approval for the same payload. `MarkStaleApprovals` only marks approvals stale when the payload or target-state hash *changes*, so if the supervisor loops every 5 minutes and the same risky action is recommended with no intervening state change, a brand-new pending approval is appended to `st.Approvals` on every tick — growing the list by ~288 records per day indefinitely.

The check should skip creating a new approval when a pending one with an identical `PayloadHash` already exists, or the existing pending approval should be staled/replaced before the new one is appended.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add supervisor approval audit mode..."](https://github.com/befeast/maestro/commit/73f505e9f44f9968f6d42d2704bf30450573da6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30238895)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->