### PR TITLE
Wave runner: feed ordered queues one issue at a time

### DIFF
--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -258,6 +258,11 @@ func buildInitYAML(cfg initYAMLConfig) string {
 	sb.WriteString("# exclude_labels:\n")
 	sb.WriteString("#   - wontfix\n")
 	sb.WriteString("#   - duplicate\n")
+	sb.WriteString("# supervisor:\n")
+	sb.WriteString("#   ordered_queue:\n")
+	sb.WriteString("#     enabled: true\n")
+	sb.WriteString("#     issues: [123, 124, 125]\n")
+	sb.WriteString("#     done_issues: []\n")
 	return sb.String()
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,8 +77,22 @@ type SupervisorConfig struct {
 
 // SupervisorOrderedQueueConfig pins supervisor selection to a fixed issue order.
 type SupervisorOrderedQueueConfig struct {
-	Enabled bool  `yaml:"enabled" json:"enabled"`
-	Issues  []int `yaml:"issues" json:"issues,omitempty"`
+	Enabled    bool  `yaml:"enabled" json:"enabled"`
+	Issues     []int `yaml:"issues" json:"issues,omitempty"`
+	DoneIssues []int `yaml:"done_issues" json:"done_issues,omitempty"`
+}
+
+func (q SupervisorOrderedQueueConfig) Active() bool {
+	return q.Enabled || len(q.Issues) > 0
+}
+
+func (q SupervisorOrderedQueueConfig) IsDone(number int) bool {
+	for _, done := range q.DoneIssues {
+		if done == number {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *SupervisorConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -100,7 +114,7 @@ func (s *SupervisorConfig) UnmarshalYAML(value *yaml.Node) error {
 }
 
 func (s SupervisorConfig) OrderedQueueActive() bool {
-	return s.OrderedQueue.Enabled || len(s.OrderedQueue.Issues) > 0
+	return s.OrderedQueue.Active()
 }
 
 func (s SupervisorConfig) AllowsSafeAction(action string) bool {
@@ -603,6 +617,11 @@ func validateSupervisorPolicy(policy SupervisorConfig) error {
 			return fmt.Errorf("config: supervisor.ordered_queue.issues[%d] duplicates issue #%d", i, issue)
 		}
 		seenIssues[issue] = struct{}{}
+	}
+	for i, issue := range policy.OrderedQueue.DoneIssues {
+		if issue <= 0 {
+			return fmt.Errorf("config: supervisor.ordered_queue.done_issues[%d] must be a positive issue number", i)
+		}
 	}
 	if err := validateSupervisorActions("safe_actions", policy.SafeActions); err != nil {
 		return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,6 +71,39 @@ issue_labels: []
 	}
 }
 
+func TestParse_SupervisorOrderedQueue(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  ordered_queue:
+    enabled: true
+    issues: [308, 306, 305]
+    done_issues: [308]
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.Supervisor.OrderedQueue.Active() {
+		t.Fatal("OrderedQueue should be active")
+	}
+	wantIssues := []int{308, 306, 305}
+	if len(cfg.Supervisor.OrderedQueue.Issues) != len(wantIssues) {
+		t.Fatalf("Issues = %v, want %v", cfg.Supervisor.OrderedQueue.Issues, wantIssues)
+	}
+	for i, want := range wantIssues {
+		if cfg.Supervisor.OrderedQueue.Issues[i] != want {
+			t.Errorf("Issues[%d] = %d, want %d", i, cfg.Supervisor.OrderedQueue.Issues[i], want)
+		}
+	}
+	if !cfg.Supervisor.OrderedQueue.IsDone(308) {
+		t.Error("OrderedQueue should mark issue #308 done by policy")
+	}
+	if cfg.Supervisor.OrderedQueue.IsDone(306) {
+		t.Error("OrderedQueue should not mark issue #306 done")
+	}
+}
+
 func TestParse_AutoRestoreFiles(t *testing.T) {
 	yaml := `
 repo: owner/repo

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -156,6 +156,45 @@ func (c *Client) ListOpenPRs() ([]PR, error) {
 	return prs, nil
 }
 
+// IsPRMerged returns true if the PR has been merged.
+func (c *Client) IsPRMerged(prNumber int) (bool, error) {
+	out, err := exec.Command("gh", "pr", "view", fmt.Sprint(prNumber),
+		"--repo", c.Repo,
+		"--json", "state,mergedAt").Output()
+	if err != nil {
+		return false, fmt.Errorf("gh pr view %d: %w", prNumber, err)
+	}
+	var result struct {
+		State    string `json:"state"`
+		MergedAt string `json:"mergedAt"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return false, fmt.Errorf("parse pr %d: %w", prNumber, err)
+	}
+	return result.State == "MERGED" || result.MergedAt != "", nil
+}
+
+// HasMergedPRForIssue returns true if a merged PR references the issue.
+func (c *Client) HasMergedPRForIssue(issueNumber int) (bool, error) {
+	query := fmt.Sprintf("#%d", issueNumber)
+	out, err := exec.Command("gh", "pr", "list",
+		"--repo", c.Repo,
+		"--state", "merged",
+		"--search", query,
+		"--json", "number",
+		"--limit", "1").Output()
+	if err != nil {
+		return false, fmt.Errorf("gh pr list --state merged --search: %w", err)
+	}
+	var prs []struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return false, fmt.Errorf("parse merged pr search results: %w", err)
+	}
+	return len(prs) > 0, nil
+}
+
 // PRCIStatus returns "success", "failure", "pending", or "unknown"
 func (c *Client) PRCIStatus(prNumber int) (string, error) {
 	out, err := exec.Command("gh", "pr", "checks",

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -38,6 +38,8 @@ type Orchestrator struct {
 	tmuxSessionExistsFn   func(name string) bool
 	listOpenPRsFn         func() ([]github.PR, error)
 	hasOpenPRForIssueFn   func(issueNumber int) (bool, error)
+	hasMergedPRForIssueFn func(issueNumber int) (bool, error)
+	isPRMergedFn          func(prNumber int) (bool, error)
 
 	// Testing hooks for checkSessions
 	captureTmuxFn   func(session string) (string, error)
@@ -132,6 +134,20 @@ func (o *Orchestrator) hasOpenPRForIssue(issueNumber int) (bool, error) {
 		return o.hasOpenPRForIssueFn(issueNumber)
 	}
 	return o.gh.HasOpenPRForIssue(issueNumber)
+}
+
+func (o *Orchestrator) hasMergedPRForIssue(issueNumber int) (bool, error) {
+	if o.hasMergedPRForIssueFn != nil {
+		return o.hasMergedPRForIssueFn(issueNumber)
+	}
+	return o.gh.HasMergedPRForIssue(issueNumber)
+}
+
+func (o *Orchestrator) isPRMerged(prNumber int) (bool, error) {
+	if o.isPRMergedFn != nil {
+		return o.isPRMergedFn(prNumber)
+	}
+	return o.gh.IsPRMerged(prNumber)
 }
 
 func (o *Orchestrator) prCIStatus(prNumber int) (string, error) {
@@ -1977,11 +1993,158 @@ func (o *Orchestrator) startWorker(s *state.State, issue github.Issue, promptBas
 	return worker.Start(o.cfg, s, o.repo, issue, promptBase, backend)
 }
 
+func (o *Orchestrator) orderedQueueIssueDone(s *state.State, issueNumber int) (bool, string, error) {
+	queue := o.cfg.Supervisor.OrderedQueue
+	if queue.IsDone(issueNumber) {
+		return true, "policy done override", nil
+	}
+
+	closed, err := o.isIssueClosed(issueNumber)
+	if err != nil {
+		return false, "", fmt.Errorf("check issue closed: %w", err)
+	}
+	if closed {
+		return true, "issue closed", nil
+	}
+
+	merged, err := o.hasMergedPRForIssue(issueNumber)
+	if err != nil {
+		return false, "", fmt.Errorf("check merged PR for issue: %w", err)
+	}
+	if merged {
+		return true, "linked PR merged", nil
+	}
+
+	for _, slotName := range sortedStateSessionNames(s) {
+		sess := s.Sessions[slotName]
+		if sess == nil || sess.IssueNumber != issueNumber || sess.Status != state.StatusDone || sess.PRNumber <= 0 {
+			continue
+		}
+		merged, err := o.isPRMerged(sess.PRNumber)
+		if err != nil {
+			return false, "", fmt.Errorf("check PR #%d merged: %w", sess.PRNumber, err)
+		}
+		if merged {
+			return true, fmt.Sprintf("session %s is done with merged PR #%d", slotName, sess.PRNumber), nil
+		}
+	}
+
+	return false, "", nil
+}
+
+func (o *Orchestrator) orderedQueueIssueNumberPauseReason(s *state.State, issueNumber int) string {
+	if s.IssueInProgress(issueNumber) {
+		return fmt.Sprintf("issue #%d already has an active session", issueNumber)
+	}
+
+	if hasOpenPR, err := o.hasOpenPRForIssue(issueNumber); err != nil {
+		return fmt.Sprintf("could not check open PRs for issue #%d: %v", issueNumber, err)
+	} else if hasOpenPR {
+		return fmt.Sprintf("issue #%d already has an open PR", issueNumber)
+	}
+
+	if s.IssueRetryExhausted(issueNumber) {
+		return fmt.Sprintf("issue #%d is retry-exhausted", issueNumber)
+	}
+	if o.cfg.MaxRetriesPerIssue > 0 {
+		failed := s.FailedAttemptsForIssue(issueNumber)
+		if failed >= o.cfg.MaxRetriesPerIssue {
+			if !s.IssueRetryExhausted(issueNumber) {
+				s.MarkIssueRetryExhausted(issueNumber)
+				o.notifier.Sendf("⚠️ Issue #%d hit max retries (%d) — needs manual review",
+					issueNumber, o.cfg.MaxRetriesPerIssue)
+			}
+			return fmt.Sprintf("issue #%d exhausted retries (%d/%d attempts)", issueNumber, failed, o.cfg.MaxRetriesPerIssue)
+		}
+	}
+
+	return ""
+}
+
+func (o *Orchestrator) orderedQueueIssuePauseReason(s *state.State, issue github.Issue) string {
+	if s.IsMissionParent(issue.Number) {
+		return fmt.Sprintf("issue #%d is a mission parent", issue.Number)
+	}
+	if o.cfg.Missions.Enabled && mission.IsMissionIssue(issue, o.cfg.Missions.Labels) && !s.IsMissionChild(issue.Number) {
+		return fmt.Sprintf("issue #%d is a mission issue awaiting decomposition", issue.Number)
+	}
+	if github.HasLabel(issue, o.cfg.ExcludeLabels) {
+		return fmt.Sprintf("issue #%d is excluded by configured label", issue.Number)
+	}
+	if len(o.cfg.BlockerPatterns) > 0 {
+		blockers := github.FindBlockers(issue.Body, o.cfg.BlockerPatterns)
+		if len(blockers) > 0 {
+			openBlockers := o.findOpenBlockers(blockers)
+			if len(openBlockers) > 0 {
+				return fmt.Sprintf("issue #%d is blocked by open issue(s) %v", issue.Number, openBlockers)
+			}
+		}
+	}
+	return ""
+}
+
+func (o *Orchestrator) applyOrderedQueueFilter(s *state.State, issues []github.Issue) ([]github.Issue, bool) {
+	queue := o.cfg.Supervisor.OrderedQueue
+	if !queue.Active() {
+		return issues, false
+	}
+
+	openByNumber := make(map[int]github.Issue, len(issues))
+	for _, issue := range issues {
+		openByNumber[issue.Number] = issue
+	}
+
+	for _, issueNumber := range queue.Issues {
+		done, reason, err := o.orderedQueueIssueDone(s, issueNumber)
+		if err != nil {
+			log.Printf("[orch] ordered queue paused at issue #%d: %v", issueNumber, err)
+			return nil, true
+		}
+		if done {
+			log.Printf("[orch] ordered queue skipping issue #%d: %s", issueNumber, reason)
+			continue
+		}
+
+		if reason := o.orderedQueueIssueNumberPauseReason(s, issueNumber); reason != "" {
+			log.Printf("[orch] ordered queue paused: %s", reason)
+			return nil, true
+		}
+
+		issue, ok := openByNumber[issueNumber]
+		if !ok {
+			log.Printf("[orch] ordered queue paused at issue #%d: issue is not open or does not match issue_labels", issueNumber)
+			return nil, true
+		}
+
+		if reason := o.orderedQueueIssuePauseReason(s, issue); reason != "" {
+			log.Printf("[orch] ordered queue paused: %s", reason)
+			return nil, true
+		}
+
+		return []github.Issue{issue}, true
+	}
+
+	log.Printf("[orch] ordered queue complete: all configured issues are done")
+	return nil, true
+}
+
+func sortedStateSessionNames(s *state.State) []string {
+	names := make([]string, 0, len(s.Sessions))
+	for name := range s.Sessions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 	issues, err := o.listOpenIssues(o.cfg.IssueLabels)
 	if err != nil {
 		log.Printf("[orch] list issues: %v", err)
 		return
+	}
+	if filtered, ordered := o.applyOrderedQueueFilter(s, issues); ordered {
+		issues = filtered
 	}
 
 	started := 0

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2469,6 +2469,12 @@ func newStartWorkersOrchestrator(cfg *config.Config, issues []github.Issue) (*Or
 		hasOpenPRForIssueFn: func(issueNumber int) (bool, error) {
 			return false, nil
 		},
+		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		isPRMergedFn: func(prNumber int) (bool, error) {
+			return false, nil
+		},
 		isIssueClosedFn: func(issueNumber int) (bool, error) {
 			return false, nil
 		},
@@ -2513,6 +2519,156 @@ func TestStartNewWorkers_SkipsClosedIssueWithDoneSession(t *testing.T) {
 
 	if len(*started) != 0 {
 		t.Fatalf("started %d workers, want 0 for already closed issue", len(*started))
+	}
+}
+
+func TestStartNewWorkers_OrderedQueueStartsOnlyFirstPendingIssue(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306, 305}}
+	issues := []github.Issue{
+		makeIssue(308, "first"),
+		makeIssue(306, "second"),
+		makeIssue(305, "third"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 {
+		t.Fatalf("started %d workers, want 1", len(*started))
+	}
+	if (*started)[0] != 308 {
+		t.Fatalf("started issue #%d, want #308", (*started)[0])
+	}
+}
+
+func TestStartNewWorkers_OrderedQueueWaitsWhileCurrentRunning(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
+	issues := []github.Issue{makeIssue(308, "current"), makeIssue(306, "next")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{IssueNumber: 308, Status: state.StatusRunning}
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 0 {
+		t.Fatalf("started %v, want no worker while ordered issue #308 is running", *started)
+	}
+}
+
+func TestStartNewWorkers_OrderedQueueAdvancesAfterClosedIssue(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
+	issues := []github.Issue{makeIssue(306, "next")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.isIssueClosedFn = func(issueNumber int) (bool, error) {
+		return issueNumber == 308, nil
+	}
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 || (*started)[0] != 306 {
+		t.Fatalf("started = %v, want [306]", *started)
+	}
+}
+
+func TestStartNewWorkers_OrderedQueuePausesOnBlockedCurrentIssue(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.BlockerPatterns = []string{`blocked by #(\d+)`}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
+	issues := []github.Issue{
+		{Number: 308, Title: "blocked", Body: "blocked by #100"},
+		makeIssue(306, "next"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.isIssueClosedFn = func(issueNumber int) (bool, error) {
+		return false, nil
+	}
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 0 {
+		t.Fatalf("started = %v, want none while #308 is blocked", *started)
+	}
+}
+
+func TestStartNewWorkers_OrderedQueuePausesOnRetryExhaustedCurrentIssue(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.MaxRetriesPerIssue = 2
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
+	issues := []github.Issue{makeIssue(308, "flaky"), makeIssue(306, "next")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+	now := time.Now().UTC()
+	for i := 0; i < 2; i++ {
+		finished := now.Add(-time.Duration(i+1) * time.Hour)
+		s.Sessions[fmt.Sprintf("old-%d", i)] = &state.Session{
+			IssueNumber: 308,
+			Status:      state.StatusDead,
+			FinishedAt:  &finished,
+		}
+	}
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 0 {
+		t.Fatalf("started = %v, want none while #308 is retry-exhausted", *started)
+	}
+	if !s.IssueRetryExhausted(308) {
+		t.Fatal("issue #308 should be marked retry_exhausted")
+	}
+}
+
+func TestStartNewWorkers_OrderedQueueAdvancesAfterLinkedPRMerged(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
+	issues := []github.Issue{makeIssue(306, "next")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.hasMergedPRForIssueFn = func(issueNumber int) (bool, error) {
+		return issueNumber == 308, nil
+	}
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 || (*started)[0] != 306 {
+		t.Fatalf("started = %v, want [306]", *started)
+	}
+}
+
+func TestStartNewWorkers_OrderedQueueAdvancesAfterDoneSessionPRMerged(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
+	issues := []github.Issue{makeIssue(306, "next")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.isPRMergedFn = func(prNumber int) (bool, error) {
+		return prNumber == 77, nil
+	}
+	s := state.NewState()
+	s.Sessions["old"] = &state.Session{IssueNumber: 308, Status: state.StatusDone, PRNumber: 77}
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 || (*started)[0] != 306 {
+		t.Fatalf("started = %v, want [306]", *started)
+	}
+}
+
+func TestStartNewWorkers_OrderedQueueAdvancesAfterPolicyDone(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}, DoneIssues: []int{308}}
+	issues := []github.Issue{makeIssue(306, "next")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 || (*started)[0] != 306 {
+		t.Fatalf("started = %v, want [306]", *started)
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -23,6 +23,7 @@ const (
 	ActionNone                 = "none"
 	ActionWaitForRunningWorker = "wait_for_running_worker"
 	ActionWaitForCapacity      = "wait_for_capacity"
+	ActionWaitForOrderedQueue  = "wait_for_ordered_queue"
 	ActionMonitorOpenPR        = "monitor_open_pr"
 	ActionReviewRetryExhausted = "review_retry_exhausted"
 	ActionSpawnWorker          = "spawn_worker"
@@ -66,7 +67,9 @@ type Reader interface {
 	ListOpenIssues(labels []string) ([]github.Issue, error)
 	ListOpenPRs() ([]github.PR, error)
 	HasOpenPRForIssue(issueNumber int) (bool, error)
+	HasMergedPRForIssue(issueNumber int) (bool, error)
 	IsIssueClosed(number int) (bool, error)
+	IsPRMerged(prNumber int) (bool, error)
 }
 
 // Mutator is the safe GitHub write surface used for supervisor queue actions.
@@ -188,7 +191,7 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 		return decision, nil
 	}
 
-	if slot, sess, ok := retryExhaustedSession(st); ok {
+	if slot, sess, ok := retryExhaustedSession(st); ok && !e.cfg.Supervisor.OrderedQueueActive() {
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Session %s for issue #%d is retry_exhausted", slot, sess.IssueNumber),
 			"Retry-exhausted work requires a human decision before more automation",
@@ -258,6 +261,26 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 		return decision, nil
 	}
 
+	if policyRule == PolicyRuleOrderedQueue && len(candidates) == 1 {
+		issue := candidates[0]
+		hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number)
+		if err != nil {
+			return state.SupervisorDecision{}, fmt.Errorf("check open PR for issue #%d: %w", issue.Number, err)
+		}
+		if hasOpenPR {
+			reasons := appendReasons(baseReasons,
+				fmt.Sprintf("Issue #%d is the first unfinished ordered issue", issue.Number),
+				fmt.Sprintf("Issue #%d already has an open PR", issue.Number),
+				"Ordered queue will not label or dispatch later issues while this PR is in review",
+			)
+			decision := e.decision(now, projectState, ActionMonitorOpenPR,
+				fmt.Sprintf("Ordered queue is paused at issue #%d because it already has an open PR.", issue.Number),
+				RiskSafe, 0.9, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
+			decision.StuckStates = stuckStates
+			return decision, nil
+		}
+	}
+
 	candidate, err := e.firstQueueActionCandidate(st, candidates)
 	if err != nil {
 		return state.SupervisorDecision{}, err
@@ -279,6 +302,30 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 		decision.Mutations = mutations
 		decision.StuckStates = stuckStates
 		return decision, nil
+	}
+
+	if policyRule == PolicyRuleOrderedQueue && len(candidates) == 1 {
+		issue := candidates[0]
+		if pauseReason := orderedQueuePauseReason(skipped, issue.Number); pauseReason != "" {
+			action := ActionWaitForOrderedQueue
+			risk := RiskSafe
+			confidence := 0.88
+			if strings.Contains(pauseReason, "retry limit exhausted") {
+				action = ActionReviewRetryExhausted
+				risk = RiskApprovalGated
+				confidence = 0.93
+			}
+			reasons := appendReasons(baseReasons,
+				fmt.Sprintf("Issue #%d is the first unfinished ordered issue", issue.Number),
+				pauseReason,
+				"Ordered queue will not advance until this issue is done or explicitly overridden",
+			)
+			decision := e.decision(now, projectState, action,
+				fmt.Sprintf("Ordered queue is paused at issue #%d: %s.", issue.Number, pauseReason),
+				risk, confidence, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
+			decision.StuckStates = stuckStates
+			return decision, nil
+		}
 	}
 
 	reasons := appendReasons(baseReasons,
@@ -670,16 +717,12 @@ func (e *Engine) policyCandidateIssues(st *state.State, issues []github.Issue) (
 	}
 	var skipped []string
 	for _, issueNumber := range e.cfg.Supervisor.OrderedQueue.Issues {
-		if st.IssueDone(issueNumber) {
-			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped by supervisor.ordered_queue: already completed in state", issueNumber))
-			continue
-		}
-		closed, err := e.reader.IsIssueClosed(issueNumber)
+		done, reason, err := e.orderedQueueIssueDone(st, issueNumber)
 		if err != nil {
 			return nil, nil, "", fmt.Errorf("check ordered queue issue #%d: %w", issueNumber, err)
 		}
-		if closed {
-			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped by supervisor.ordered_queue: issue is closed", issueNumber))
+		if done {
+			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped by supervisor.ordered_queue: %s", issueNumber, reason))
 			continue
 		}
 		issue, ok := issueByNumber[issueNumber]
@@ -689,6 +732,45 @@ func (e *Engine) policyCandidateIssues(st *state.State, issues []github.Issue) (
 		return []github.Issue{issue}, skipped, PolicyRuleOrderedQueue, nil
 	}
 	return nil, append(skipped, "No unfinished issue remains in supervisor.ordered_queue"), PolicyRuleOrderedQueue, nil
+}
+
+func (e *Engine) orderedQueueIssueDone(st *state.State, issueNumber int) (bool, string, error) {
+	queue := e.cfg.Supervisor.OrderedQueue
+	if queue.IsDone(issueNumber) {
+		return true, "policy done override", nil
+	}
+
+	closed, err := e.reader.IsIssueClosed(issueNumber)
+	if err != nil {
+		return false, "", fmt.Errorf("check issue closed: %w", err)
+	}
+	if closed {
+		return true, "issue is closed", nil
+	}
+
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess == nil || sess.IssueNumber != issueNumber || sess.Status != state.StatusDone || sess.PRNumber <= 0 {
+			continue
+		}
+		merged, err := e.reader.IsPRMerged(sess.PRNumber)
+		if err != nil {
+			return false, "", fmt.Errorf("check PR #%d merged: %w", sess.PRNumber, err)
+		}
+		if merged {
+			return true, fmt.Sprintf("session %s is done with merged PR #%d", slot, sess.PRNumber), nil
+		}
+	}
+
+	merged, err := e.reader.HasMergedPRForIssue(issueNumber)
+	if err != nil {
+		return false, "", fmt.Errorf("check merged PR for issue: %w", err)
+	}
+	if merged {
+		return true, "linked PR merged", nil
+	}
+
+	return false, "", nil
 }
 
 func validateOrderedQueueIssues(issues []int) error {
@@ -1394,6 +1476,20 @@ func policySkipReason(reason string) bool {
 		strings.Contains(reason, "mission parent issue") ||
 		strings.Contains(reason, "mission issue awaits decomposition") ||
 		strings.Contains(reason, "blocked by open issue")
+}
+
+func orderedQueuePauseReason(skipped []string, issueNumber int) string {
+	prefix := fmt.Sprintf("Issue #%d skipped: ", issueNumber)
+	for _, reason := range skipped {
+		if strings.HasPrefix(reason, prefix) {
+			pauseReason := strings.TrimSpace(strings.TrimPrefix(reason, prefix))
+			if strings.Contains(pauseReason, "missing configured ready label") {
+				return ""
+			}
+			return pauseReason
+		}
+	}
+	return ""
 }
 
 func targetFromSkipReason(reason string) *state.SupervisorTarget {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -16,7 +16,9 @@ type fakeReader struct {
 	issues         []github.Issue
 	prs            []github.PR
 	openPRIssues   map[int]bool
+	mergedPRIssues map[int]bool
 	closedIssues   map[int]bool
+	mergedPRs      map[int]bool
 	ciStatuses     map[int]string
 	greptileOK     map[int]bool
 	greptilePend   map[int]bool
@@ -42,8 +44,16 @@ func (f *fakeReader) HasOpenPRForIssue(issueNumber int) (bool, error) {
 	return f.openPRIssues[issueNumber], nil
 }
 
+func (f *fakeReader) HasMergedPRForIssue(issueNumber int) (bool, error) {
+	return f.mergedPRIssues[issueNumber], nil
+}
+
 func (f *fakeReader) IsIssueClosed(number int) (bool, error) {
 	return f.closedIssues[number], nil
+}
+
+func (f *fakeReader) IsPRMerged(prNumber int) (bool, error) {
+	return f.mergedPRs[prNumber], nil
 }
 
 func (f *fakeReader) AddIssueLabel(issueNumber int, label string) error {
@@ -459,7 +469,7 @@ func TestRunOnceRecordsPendingApprovalForRiskyDecision(t *testing.T) {
 	}
 }
 
-func TestDecide_OrderedQueueSelectsFirstUnfinishedIssue(t *testing.T) {
+func TestDecide_OrderedQueueAdvancesAfterClosedIssue(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
 	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
@@ -488,12 +498,15 @@ func TestDecide_OrderedQueueSkipsCompletedIssue(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
 	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{308, 306}}
-	reader := &fakeReader{issues: []github.Issue{
-		testIssue(306, "second wave", "maestro-ready"),
-		testIssue(308, "done wave", "maestro-ready"),
-	}}
+	reader := &fakeReader{
+		issues: []github.Issue{
+			testIssue(306, "second wave", "maestro-ready"),
+			testIssue(308, "done wave", "maestro-ready"),
+		},
+		mergedPRs: map[int]bool{77: true},
+	}
 	st := state.NewState()
-	st.Sessions["slot-1"] = &state.Session{IssueNumber: 308, Status: state.StatusDone, StartedAt: time.Now().UTC()}
+	st.Sessions["slot-1"] = &state.Session{IssueNumber: 308, Status: state.StatusDone, PRNumber: 77, StartedAt: time.Now().UTC()}
 
 	decision, err := testEngine(cfg, reader).Decide(st)
 	if err != nil {
@@ -819,5 +832,198 @@ func TestRunOnceGitHubFailureRecordsFailedMutation(t *testing.T) {
 	latest := st.LatestSupervisorDecision()
 	if latest == nil || latest.Status != DecisionStatusFailed || latest.ErrorClass != ErrorClassGitHubAPI {
 		t.Fatalf("latest decision = %#v, want failed github_api decision", latest)
+	}
+}
+
+func TestDecide_OrderedQueueSelectsFirstUnfinishedIssue(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{
+		Enabled: true,
+		Issues:  []int{308, 306},
+	}
+	reader := &fakeReader{
+		issues:       []github.Issue{testIssue(306, "second", "maestro-ready")},
+		closedIssues: map[int]bool{308: true},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Target == nil || decision.Target.Issue != 306 {
+		t.Fatalf("target = %#v, want issue 306", decision.Target)
+	}
+}
+
+func TestDecide_OrderedQueueDoesNotLabelNextIssueWhileCurrentHasOpenPR(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{
+		Enabled: true,
+		Issues:  []int{308, 306},
+	}
+	reader := &fakeReader{
+		issues:       []github.Issue{testIssue(308, "current"), testIssue(306, "next")},
+		openPRIssues: map[int]bool{308: true},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionMonitorOpenPR)
+	}
+	if decision.Target == nil || decision.Target.Issue != 308 {
+		t.Fatalf("target = %#v, want issue 308", decision.Target)
+	}
+}
+
+func TestDecide_OrderedQueuePausesOnBlockedIssue(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.BlockerPatterns = []string{`blocked by #(\d+)`}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{
+		Enabled: true,
+		Issues:  []int{308, 306},
+	}
+	reader := &fakeReader{
+		issues: []github.Issue{
+			{Number: 308, Title: "blocked", Body: "blocked by #100", Labels: []struct {
+				Name string `json:"name"`
+			}{{Name: "maestro-ready"}}},
+			testIssue(306, "next", "maestro-ready"),
+		},
+		closedIssues: map[int]bool{100: false},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionWaitForOrderedQueue {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionWaitForOrderedQueue)
+	}
+	if decision.Target == nil || decision.Target.Issue != 308 {
+		t.Fatalf("target = %#v, want issue 308", decision.Target)
+	}
+	if !strings.Contains(decision.Summary, "blocked") {
+		t.Fatalf("summary %q should explain blocked queue", decision.Summary)
+	}
+}
+
+func TestDecide_OrderedQueuePausesOnRetryExhaustedIssue(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.MaxRetriesPerIssue = 2
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{
+		Enabled: true,
+		Issues:  []int{308, 306},
+	}
+	reader := &fakeReader{
+		issues: []github.Issue{testIssue(308, "flaky", "maestro-ready"), testIssue(306, "next", "maestro-ready")},
+	}
+	st := state.NewState()
+	for i := 0; i < 2; i++ {
+		finished := time.Now().UTC().Add(-time.Duration(i+1) * time.Hour)
+		st.Sessions[time.Duration(i).String()] = &state.Session{
+			IssueNumber: 308,
+			Status:      state.StatusDead,
+			FinishedAt:  &finished,
+		}
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionReviewRetryExhausted {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionReviewRetryExhausted)
+	}
+	if decision.Target == nil || decision.Target.Issue != 308 {
+		t.Fatalf("target = %#v, want issue 308", decision.Target)
+	}
+}
+
+func TestDecide_OrderedQueueAdvancesAfterMergedPR(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{
+		Enabled: true,
+		Issues:  []int{308, 306},
+	}
+	reader := &fakeReader{
+		issues:         []github.Issue{testIssue(306, "next", "maestro-ready")},
+		mergedPRIssues: map[int]bool{308: true},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Target == nil || decision.Target.Issue != 306 {
+		t.Fatalf("target = %#v, want issue 306", decision.Target)
+	}
+}
+
+func TestDecide_OrderedQueueAdvancesAfterDoneSessionWithMergedPR(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{
+		Enabled: true,
+		Issues:  []int{308, 306},
+	}
+	reader := &fakeReader{
+		issues:    []github.Issue{testIssue(306, "next", "maestro-ready")},
+		mergedPRs: map[int]bool{77: true},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{IssueNumber: 308, Status: state.StatusDone, PRNumber: 77}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Target == nil || decision.Target.Issue != 306 {
+		t.Fatalf("target = %#v, want issue 306", decision.Target)
+	}
+}
+
+func TestDecide_OrderedQueueAdvancesAfterPolicyOverride(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{
+		Enabled:    true,
+		Issues:     []int{308, 306},
+		DoneIssues: []int{308},
+	}
+	reader := &fakeReader{issues: []github.Issue{testIssue(306, "next", "maestro-ready")}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Target == nil || decision.Target.Issue != 306 {
+		t.Fatalf("target = %#v, want issue 306", decision.Target)
 	}
 }


### PR DESCRIPTION
Closes #267

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the ordered-queue feature so it feeds issues one at a time by tracking "done" state through merged PRs (via session records and a broad GitHub text search) and an explicit `done_issues` policy override, in addition to the existing closed-issue check. Both the supervisor `Decide` engine and the orchestrator `startNewWorkers` path are updated, backed by thorough tests.

- **P1 – Retry-exhausted bypass (`supervisor.go:194`)**: When the ordered queue is active the global `retryExhaustedSession` check is skipped for the entire state, not just queue issues. A `retry_exhausted` session for an issue outside the ordered queue will never surface `ActionReviewRetryExhausted`, leaving it permanently unhandled.
- **P2 – Duplicate `orderedQueueIssueDone` implementations**: Orchestrator and supervisor each carry a copy with different check ordering; the orchestrator calls `hasMergedPRForIssue` (a network round-trip) before scanning session data, which is the reverse of the more efficient supervisor order.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the typical ordered-queue use case, but the global retry-exhausted bypass can silently drop alerts for non-queue sessions when the ordered queue is active.

One P1 finding (retry-exhausted bypass) caps the score at 4; the duplicated logic with an inverted check order further reduces confidence to 3.

internal/supervisor/supervisor.go (retry-exhausted bypass), internal/orchestrator/orchestrator.go (check-order inconsistency)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Core decision engine updated to advance ordered queue via merged-PR detection; global retry-exhausted check bypassed entirely when ordered queue is active, leaving non-queue retry-exhausted sessions permanently unhandled. |
| internal/orchestrator/orchestrator.go | Adds `applyOrderedQueueFilter` to `startNewWorkers`; implements a second copy of `orderedQueueIssueDone` with a different (less efficient) check order compared to the supervisor's version. |
| internal/config/config.go | Adds `DoneIssues` field with `IsDone`/`Active` helpers and basic validation; missing duplicate-entry check that `Issues` already performs. |
| internal/github/github.go | Adds `IsPRMerged` and `HasMergedPRForIssue` via `gh` CLI; `HasMergedPRForIssue` uses a text-search query consistent with its documented intent. |
| internal/supervisor/supervisor_test.go | Extends `fakeReader` with `HasMergedPRForIssue`/`IsPRMerged` and adds tests covering closed-issue advance, merged-PR advance, policy override, open-PR pause, blocked pause, and retry-exhausted pause. |
| internal/orchestrator/orchestrator_test.go | New ordered-queue tests cover the one-at-a-time invariant, wait-while-running, advance-after-closed, advance-after-merged, policy-done-override, and retry-exhausted pause scenarios. |
| internal/config/config_test.go | Adds round-trip parse test for the new `done_issues` config field; covers `Active()` and `IsDone()` helpers. |
| cmd/maestro/init.go | Adds commented-out `ordered_queue` scaffold (including the new `done_issues` field) to the generated init YAML template. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/supervisor/supervisor.go
Line: 194

Comment:
**Retry-exhausted sessions for non-queue issues silently skipped**

When `OrderedQueueActive()` returns true, the global `retryExhaustedSession` check is bypassed entirely. Any session in state that is `retry_exhausted` for an issue that is **not** in the ordered queue will never trigger `ActionReviewRetryExhausted` — the ordered queue's own retry-exhausted handling only activates for the *current* queue issue (the first non-done candidate). Sessions from issues outside the queue are silently ignored with no notification or action.

If the ordered queue is only ever used with issues exclusively managed by the queue this is harmless, but a mixed state (e.g., enabled mid-flight with legacy sessions) leaves those sessions permanently unhandled.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/orchestrator/orchestrator.go
Line: 1996-2033

Comment:
**Check order differs from supervisor's `orderedQueueIssueDone`**

The orchestrator's implementation calls `hasMergedPRForIssue` (a GitHub API search) *before* scanning session PRs, while the supervisor's equivalent method does the reverse — sessions first, then `HasMergedPRForIssue`. The supervisor's order is preferable: local session data is free, whereas the API call costs a round-trip. Consider aligning to the supervisor's order:

```
1. queue.IsDone (policy override)
2. isIssueClosed
3. check sessions for a Done+PRNumber session whose PR is merged
4. hasMergedPRForIssue (broad text search fallback)
```

As-is, every queue iteration in the orchestrator will always hit the API even when a session already records the merged PR.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/config/config.go
Line: 618-624

Comment:
**No duplicate detection for `done_issues`**

`Issues` validation (just above this block) uses a `seenIssues` map to catch duplicates, but the new `DoneIssues` validation only checks for non-positive values. A duplicate entry like `done_issues: [308, 308]` is accepted silently. Consistent with the rest of the validation, consider adding a similar duplicate check here.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add ordered queue wave runner (#26..."](https://github.com/befeast/maestro/commit/ab90578e93299a9ae5f905ade7105e58ecb2e2d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30242996)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->