### PR TITLE
Supervisor LLM contract, prompt, and backend integration

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -370,6 +370,7 @@ func superviseCmd(args []string) {
 	once := fs.Bool("once", false, "Run once and exit")
 	interval := fs.Duration("interval", 5*time.Minute, "Loop interval")
 	jsonOutput := fs.Bool("json", false, "Output decision as JSON")
+	dryRun := fs.Bool("dry-run", false, "Compute decision without recording state")
 	fs.Parse(args)
 	if fs.NArg() > 0 {
 		subcmd := fs.Arg(0)
@@ -387,6 +388,9 @@ func superviseCmd(args []string) {
 	}
 
 	cfg := loadConfig(*configPath)
+	if *dryRun {
+		cfg.Supervisor.DryRun = true
+	}
 	gh := github.New(cfg.Repo)
 	runOnce := func() {
 		decision, err := supervisor.RunOnce(cfg, gh)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,18 +59,25 @@ const (
 
 // SupervisorConfig defines local policy for supervisor decisions.
 type SupervisorConfig struct {
-	Enabled          bool                         `yaml:"enabled" json:"enabled"`
-	Mode             string                       `yaml:"mode" json:"mode"`
-	ReadyLabel       string                       `yaml:"ready_label" json:"ready_label,omitempty"`
-	BlockedLabel     string                       `yaml:"blocked_label" json:"blocked_label,omitempty"`
-	QueueComments    bool                         `yaml:"queue_comments" json:"queue_comments,omitempty"`
-	OneAtATime       bool                         `yaml:"one_at_a_time" json:"one_at_a_time,omitempty"`
-	ExcludedLabels   []string                     `yaml:"excluded_labels" json:"excluded_labels,omitempty"`
-	AllowIssueTypes  []string                     `yaml:"allow_issue_types" json:"allow_issue_types,omitempty"`
-	OrderedQueue     SupervisorOrderedQueueConfig `yaml:"ordered_queue" json:"ordered_queue,omitempty"`
-	SafeActions      []string                     `yaml:"safe_actions" json:"safe_actions,omitempty"`
-	ApprovalRequired []string                     `yaml:"approval_required" json:"approval_required,omitempty"`
-	PolicyPath       string                       `yaml:"-" json:"policy_path,omitempty"`
+	Enabled                 bool                         `yaml:"enabled" json:"enabled"`
+	Backend                 string                       `yaml:"backend" json:"backend,omitempty"`
+	Model                   string                       `yaml:"model" json:"model,omitempty"`
+	Effort                  string                       `yaml:"effort" json:"effort,omitempty"`
+	Prompt                  string                       `yaml:"prompt" json:"prompt,omitempty"`
+	DryRun                  bool                         `yaml:"dry_run" json:"dry_run,omitempty"`
+	Mode                    string                       `yaml:"mode" json:"mode"`
+	ReadyLabel              string                       `yaml:"ready_label" json:"ready_label,omitempty"`
+	BlockedLabel            string                       `yaml:"blocked_label" json:"blocked_label,omitempty"`
+	QueueComments           bool                         `yaml:"queue_comments" json:"queue_comments,omitempty"`
+	OneAtATime              bool                         `yaml:"one_at_a_time" json:"one_at_a_time,omitempty"`
+	ExcludedLabels          []string                     `yaml:"excluded_labels" json:"excluded_labels,omitempty"`
+	AllowIssueTypes         []string                     `yaml:"allow_issue_types" json:"allow_issue_types,omitempty"`
+	OrderedQueue            SupervisorOrderedQueueConfig `yaml:"ordered_queue" json:"ordered_queue,omitempty"`
+	SafeActions             []string                     `yaml:"safe_actions" json:"safe_actions,omitempty"`
+	ApprovalRequired        []string                     `yaml:"approval_required" json:"approval_required,omitempty"`
+	AllowedActions          []string                     `yaml:"allowed_actions" json:"allowed_actions,omitempty"`
+	ApprovalRequiredActions []string                     `yaml:"approval_required_actions" json:"approval_required_actions,omitempty"`
+	PolicyPath              string                       `yaml:"-" json:"policy_path,omitempty"`
 
 	excludedLabelsSet bool
 }
@@ -359,6 +366,7 @@ func parse(data []byte) (*Config, error) {
 	cfg.EnhancementPrompt = expandHome(cfg.EnhancementPrompt)
 	cfg.Pipeline.Planner.Prompt = expandHome(cfg.Pipeline.Planner.Prompt)
 	cfg.Pipeline.Validator.Prompt = expandHome(cfg.Pipeline.Validator.Prompt)
+	cfg.Supervisor.Prompt = expandHome(cfg.Supervisor.Prompt)
 	for i, s := range cfg.PromptSections {
 		cfg.PromptSections[i] = expandHome(s)
 	}
@@ -410,6 +418,32 @@ func parse(data []byte) (*Config, error) {
 	// Ensure the default backend is always present in the map
 	if _, ok := cfg.Model.Backends[cfg.Model.Default]; !ok {
 		cfg.Model.Backends[cfg.Model.Default] = BackendDef{Cmd: cfg.Model.Default}
+	}
+
+	// Supervisor defaults
+	if cfg.Supervisor.Backend == "" {
+		cfg.Supervisor.Backend = cfg.Model.Default
+	}
+	if cfg.Supervisor.AllowedActions == nil {
+		cfg.Supervisor.AllowedActions = []string{
+			"none",
+			"wait_for_running_worker",
+			"wait_for_capacity",
+			"wait_for_ordered_queue",
+			"monitor_open_pr",
+			"review_retry_exhausted",
+			"spawn_worker",
+			"label_issue_ready",
+			"add_ready_label",
+		}
+	}
+	if cfg.Supervisor.ApprovalRequiredActions == nil {
+		cfg.Supervisor.ApprovalRequiredActions = []string{
+			"review_retry_exhausted",
+			"spawn_worker",
+			"label_issue_ready",
+			"add_ready_label",
+		}
 	}
 
 	// Routing defaults

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -462,6 +462,15 @@ func TestParse_ModelConfigDefaults(t *testing.T) {
 	if _, ok := cfg.Model.Backends["claude"]; !ok {
 		t.Error("expected claude backend to be present in map")
 	}
+	if cfg.Supervisor.Enabled {
+		t.Error("Supervisor.Enabled should default to false")
+	}
+	if cfg.Supervisor.Backend != "claude" {
+		t.Errorf("Supervisor.Backend = %q, want claude", cfg.Supervisor.Backend)
+	}
+	if len(cfg.Supervisor.AllowedActions) == 0 {
+		t.Error("Supervisor.AllowedActions should have safe defaults")
+	}
 }
 
 func TestParse_ModelConfigExplicit(t *testing.T) {
@@ -525,6 +534,62 @@ model:
 	}
 	if len(gemini.ExtraArgs) != 2 || gemini.ExtraArgs[0] != "--sandbox" {
 		t.Errorf("expected gemini extra_args=[--sandbox none], got %v", gemini.ExtraArgs)
+	}
+	if cfg.Supervisor.Backend != "gemini" {
+		t.Errorf("Supervisor.Backend = %q, want gemini", cfg.Supervisor.Backend)
+	}
+}
+
+func TestParse_SupervisorConfigExplicit(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: claude
+  backends:
+    claude:
+      cmd: claude
+    gemini:
+      cmd: gemini
+supervisor:
+  enabled: true
+  backend: gemini
+  model: gemini-2.5-pro
+  effort: high
+  prompt: ~/prompts/supervisor.md
+  dry_run: true
+  allowed_actions:
+    - none
+    - spawn_worker
+  approval_required_actions:
+    - spawn_worker
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.Supervisor.Enabled {
+		t.Error("Supervisor.Enabled should be true")
+	}
+	if cfg.Supervisor.Backend != "gemini" {
+		t.Errorf("Supervisor.Backend = %q, want gemini", cfg.Supervisor.Backend)
+	}
+	if cfg.Supervisor.Model != "gemini-2.5-pro" {
+		t.Errorf("Supervisor.Model = %q, want gemini-2.5-pro", cfg.Supervisor.Model)
+	}
+	if cfg.Supervisor.Effort != "high" {
+		t.Errorf("Supervisor.Effort = %q, want high", cfg.Supervisor.Effort)
+	}
+	if cfg.Supervisor.Prompt != filepath.Join(os.Getenv("HOME"), "prompts/supervisor.md") {
+		t.Errorf("Supervisor.Prompt = %q", cfg.Supervisor.Prompt)
+	}
+	if !cfg.Supervisor.DryRun {
+		t.Error("Supervisor.DryRun should be true")
+	}
+	if len(cfg.Supervisor.AllowedActions) != 2 || cfg.Supervisor.AllowedActions[1] != "spawn_worker" {
+		t.Errorf("Supervisor.AllowedActions = %v", cfg.Supervisor.AllowedActions)
+	}
+	if len(cfg.Supervisor.ApprovalRequiredActions) != 1 || cfg.Supervisor.ApprovalRequiredActions[0] != "spawn_worker" {
+		t.Errorf("Supervisor.ApprovalRequiredActions = %v", cfg.Supervisor.ApprovalRequiredActions)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -164,6 +164,7 @@ type SupervisorDecision struct {
 	Confidence        float64                `json:"confidence"`
 	ErrorClass        string                 `json:"error_class,omitempty"`
 	Reasons           []string               `json:"reasons,omitempty"`
+	RequiresApproval  bool                   `json:"requires_approval"`
 	Mutations         []SupervisorMutation   `json:"mutations,omitempty"`
 	StuckStates       []SupervisorStuckState `json:"stuck_states,omitempty"`
 	ProjectState      SupervisorProjectState `json:"project_state"`

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -1,0 +1,397 @@
+package supervisor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/worker"
+)
+
+const defaultSupervisorPrompt = `You are the Maestro Supervisor LLM.
+
+You receive a redacted state packet for one Maestro project. Synthesize the state, but do not invent permissions or actions.
+
+Rules:
+- Return one JSON object only. Do not include Markdown, comments, or prose outside JSON.
+- recommended_action must be one of supervisor_policy.allowed_actions.
+- If recommended_action is in supervisor_policy.approval_required_actions, requires_approval must be true.
+- Do not request actions outside the packet policy.
+- Treat deterministic detector output as a guardrail. Do not recommend an action that conflicts with it.
+- The runtime will validate this JSON against policy before any action is recorded or executed.
+
+Required JSON shape:
+{
+  "summary": "one sentence",
+  "recommended_action": "one allowed action",
+  "target": {"issue": 0, "pr": 0, "session": ""},
+  "risk": "safe|mutating|approval_gated",
+  "confidence": 0.0,
+  "reasons": ["short reason"],
+  "requires_approval": false
+}
+
+State packet:
+{{STATE_PACKET}}
+`
+
+// LLMClient is the small backend surface Supervisor needs for one prompt.
+type LLMClient interface {
+	Complete(prompt string) (string, error)
+}
+
+type backendLLMClient struct {
+	cfg *config.Config
+}
+
+func NewBackendLLMClient(cfg *config.Config) LLMClient {
+	return &backendLLMClient{cfg: cfg}
+}
+
+func (c *backendLLMClient) Complete(prompt string) (string, error) {
+	backendName, backendDef, err := supervisorBackend(c.cfg)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(c.cfg.StateDir, 0755); err != nil {
+		return "", fmt.Errorf("create state dir: %w", err)
+	}
+	promptFile, err := os.CreateTemp(c.cfg.StateDir, "supervisor-prompt-*.md")
+	if err != nil {
+		return "", fmt.Errorf("create supervisor prompt file: %w", err)
+	}
+	promptPath := promptFile.Name()
+	defer os.Remove(promptPath)
+	if _, err := promptFile.WriteString(prompt); err != nil {
+		promptFile.Close()
+		return "", fmt.Errorf("write supervisor prompt file: %w", err)
+	}
+	if err := promptFile.Close(); err != nil {
+		return "", fmt.Errorf("close supervisor prompt file: %w", err)
+	}
+
+	backendCfg := worker.BackendConfig{
+		Cmd:        backendDef.Cmd,
+		ExtraArgs:  backendDef.ExtraArgs,
+		PromptMode: backendDef.PromptMode,
+		Model:      c.cfg.Supervisor.Model,
+		Effort:     c.cfg.Supervisor.Effort,
+	}
+	worktree := c.cfg.LocalPath
+	if strings.TrimSpace(worktree) == "" {
+		worktree = "."
+	}
+	cmd, stdinFile, err := worker.BuildSupervisorCmd(backendName, backendCfg, promptPath, worktree)
+	if err != nil {
+		return "", fmt.Errorf("build supervisor backend cmd: %w", err)
+	}
+	if stdinFile != "" {
+		in, err := os.Open(stdinFile)
+		if err != nil {
+			return "", fmt.Errorf("open supervisor prompt stdin: %w", err)
+		}
+		defer in.Close()
+		cmd.Stdin = in
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("run supervisor backend %q: %w", backendName, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func supervisorBackend(cfg *config.Config) (string, config.BackendDef, error) {
+	backendName := strings.TrimSpace(cfg.Supervisor.Backend)
+	if backendName == "" {
+		backendName = cfg.Model.Default
+	}
+	backendDef, ok := cfg.Model.Backends[backendName]
+	if !ok {
+		return "", config.BackendDef{}, fmt.Errorf("supervisor backend %q not found in model.backends", backendName)
+	}
+	return backendName, backendDef, nil
+}
+
+func (e *Engine) decideWithLLM(st *state.State) (state.SupervisorDecision, error) {
+	if st == nil {
+		st = state.NewState()
+	}
+	deterministic, err := e.decideDeterministic(st)
+	if err != nil {
+		return state.SupervisorDecision{}, err
+	}
+
+	policy := newSupervisorPolicy(e.cfg)
+	packet, err := e.buildStatePacket(st, deterministic, policy)
+	if err != nil {
+		return state.SupervisorDecision{}, err
+	}
+	prompt, err := buildSupervisorPrompt(e.cfg, packet)
+	if err != nil {
+		return state.SupervisorDecision{}, err
+	}
+
+	client := e.llm
+	if client == nil {
+		client = NewBackendLLMClient(e.cfg)
+	}
+	output, err := client.Complete(prompt)
+	if err != nil {
+		return state.SupervisorDecision{}, err
+	}
+	llmDecision, err := ParseLLMDecision(output)
+	if err != nil {
+		return state.SupervisorDecision{}, err
+	}
+	return validateLLMDecision(llmDecision, deterministic, policy)
+}
+
+func buildSupervisorPrompt(cfg *config.Config, packet supervisorStatePacket) (string, error) {
+	packetJSON, err := json.MarshalIndent(packet, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal supervisor state packet: %w", err)
+	}
+	statePacket := RedactSensitive(string(packetJSON))
+
+	tmpl := defaultSupervisorPrompt
+	if strings.TrimSpace(cfg.Supervisor.Prompt) != "" {
+		data, err := os.ReadFile(cfg.Supervisor.Prompt)
+		if err != nil {
+			return "", fmt.Errorf("read supervisor prompt %s: %w", cfg.Supervisor.Prompt, err)
+		}
+		tmpl = string(data)
+	}
+	if strings.Contains(tmpl, "{{STATE_PACKET}}") {
+		return strings.ReplaceAll(tmpl, "{{STATE_PACKET}}", statePacket), nil
+	}
+	return strings.TrimRight(tmpl, "\n") + "\n\nState packet:\n" + statePacket + "\n", nil
+}
+
+// LLMDecision is the strict JSON contract returned by the Supervisor LLM.
+type LLMDecision struct {
+	Summary           string                  `json:"summary"`
+	RecommendedAction string                  `json:"recommended_action"`
+	Target            *state.SupervisorTarget `json:"target"`
+	Risk              string                  `json:"risk"`
+	Confidence        float64                 `json:"confidence"`
+	Reasons           []string                `json:"reasons"`
+	RequiresApproval  bool                    `json:"requires_approval"`
+}
+
+func ParseLLMDecision(output string) (LLMDecision, error) {
+	trimmed := strings.TrimSpace(output)
+	decision, err := decodeLLMDecision(trimmed)
+	if err == nil {
+		return decision, validateLLMContractFields(decision)
+	}
+	if jsonText, ok := extractJSONObject(trimmed); ok && jsonText != trimmed {
+		decision, err = decodeLLMDecision(jsonText)
+		if err == nil {
+			return decision, validateLLMContractFields(decision)
+		}
+	}
+	return LLMDecision{}, fmt.Errorf("parse supervisor LLM decision: invalid JSON contract")
+}
+
+func decodeLLMDecision(raw string) (LLMDecision, error) {
+	var decision LLMDecision
+	decoder := json.NewDecoder(bytes.NewBufferString(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&decision); err != nil {
+		return LLMDecision{}, err
+	}
+	var extra struct{}
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return LLMDecision{}, fmt.Errorf("extra content after JSON object")
+	}
+	return decision, nil
+}
+
+func extractJSONObject(output string) (string, bool) {
+	start := strings.Index(output, "{")
+	end := strings.LastIndex(output, "}")
+	if start < 0 || end <= start {
+		return "", false
+	}
+	return output[start : end+1], true
+}
+
+func validateLLMContractFields(decision LLMDecision) error {
+	if strings.TrimSpace(decision.Summary) == "" {
+		return fmt.Errorf("parse supervisor LLM decision: summary is required")
+	}
+	if strings.TrimSpace(decision.RecommendedAction) == "" {
+		return fmt.Errorf("parse supervisor LLM decision: recommended_action is required")
+	}
+	if riskRank(decision.Risk) < 0 {
+		return fmt.Errorf("parse supervisor LLM decision: unknown risk %q", decision.Risk)
+	}
+	if decision.Confidence < 0 || decision.Confidence > 1 {
+		return fmt.Errorf("parse supervisor LLM decision: confidence must be between 0 and 1")
+	}
+	if len(compactReasons(decision.Reasons)) == 0 {
+		return fmt.Errorf("parse supervisor LLM decision: at least one reason is required")
+	}
+	return nil
+}
+
+func validateLLMDecision(llm LLMDecision, deterministic state.SupervisorDecision, policy supervisorPolicy) (state.SupervisorDecision, error) {
+	action := canonicalAction(llm.RecommendedAction)
+	if action == "" || !policy.isAllowed(action) {
+		return state.SupervisorDecision{}, fmt.Errorf("supervisor LLM action %q is not allowed by policy", llm.RecommendedAction)
+	}
+	if action != deterministic.RecommendedAction {
+		return state.SupervisorDecision{}, fmt.Errorf("supervisor LLM action %q disagrees with deterministic guardrail %q", action, deterministic.RecommendedAction)
+	}
+	if !targetsAgree(llm.Target, deterministic.Target) {
+		return state.SupervisorDecision{}, fmt.Errorf("supervisor LLM target disagrees with deterministic guardrail")
+	}
+	if riskRank(llm.Risk) < riskRank(deterministic.Risk) {
+		return state.SupervisorDecision{}, fmt.Errorf("supervisor LLM risk %q is lower than deterministic guardrail %q", llm.Risk, deterministic.Risk)
+	}
+	requiresApproval := policy.requiresApproval(action)
+	if requiresApproval && !llm.RequiresApproval {
+		return state.SupervisorDecision{}, fmt.Errorf("supervisor LLM action %q requires approval by policy", action)
+	}
+
+	decision := deterministic
+	decision.Summary = RedactSensitive(strings.TrimSpace(llm.Summary))
+	decision.RecommendedAction = action
+	decision.Target = copyTarget(llm.Target)
+	decision.Risk = llm.Risk
+	decision.Confidence = llm.Confidence
+	decision.Reasons = redactReasons(llm.Reasons)
+	decision.RequiresApproval = llm.RequiresApproval || requiresApproval
+	return decision, nil
+}
+
+func redactReasons(reasons []string) []string {
+	redacted := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		redacted = append(redacted, RedactSensitive(reason))
+	}
+	return compactReasons(redacted)
+}
+
+type supervisorPolicy struct {
+	allowed          map[string]struct{}
+	approvalRequired map[string]struct{}
+}
+
+func newSupervisorPolicy(cfg *config.Config) supervisorPolicy {
+	allowedActions := cfg.Supervisor.AllowedActions
+	if allowedActions == nil {
+		allowedActions = defaultAllowedActions()
+	}
+	approvalActions := cfg.Supervisor.ApprovalRequiredActions
+	if approvalActions == nil {
+		approvalActions = defaultApprovalRequiredActions()
+	}
+	policy := supervisorPolicy{
+		allowed:          make(map[string]struct{}, len(allowedActions)),
+		approvalRequired: make(map[string]struct{}, len(approvalActions)),
+	}
+	for _, action := range allowedActions {
+		if canonical := canonicalAction(action); canonical != "" {
+			policy.allowed[canonical] = struct{}{}
+		}
+	}
+	for _, action := range approvalActions {
+		if canonical := canonicalAction(action); canonical != "" {
+			policy.approvalRequired[canonical] = struct{}{}
+		}
+	}
+	return policy
+}
+
+func (p supervisorPolicy) isAllowed(action string) bool {
+	_, ok := p.allowed[action]
+	return ok
+}
+
+func (p supervisorPolicy) requiresApproval(action string) bool {
+	_, ok := p.approvalRequired[action]
+	return ok
+}
+
+func defaultAllowedActions() []string {
+	return []string{
+		ActionNone,
+		ActionWaitForRunningWorker,
+		ActionWaitForCapacity,
+		ActionWaitForOrderedQueue,
+		ActionMonitorOpenPR,
+		ActionReviewRetryExhausted,
+		ActionSpawnWorker,
+		ActionLabelIssueReady,
+	}
+}
+
+func defaultApprovalRequiredActions() []string {
+	return []string{
+		ActionReviewRetryExhausted,
+		ActionSpawnWorker,
+		ActionLabelIssueReady,
+	}
+}
+
+func canonicalAction(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case ActionNone:
+		return ActionNone
+	case ActionWaitForRunningWorker:
+		return ActionWaitForRunningWorker
+	case ActionWaitForCapacity:
+		return ActionWaitForCapacity
+	case ActionWaitForOrderedQueue:
+		return ActionWaitForOrderedQueue
+	case ActionMonitorOpenPR:
+		return ActionMonitorOpenPR
+	case ActionReviewRetryExhausted:
+		return ActionReviewRetryExhausted
+	case ActionSpawnWorker:
+		return ActionSpawnWorker
+	case ActionLabelIssueReady, "add_ready_label":
+		return ActionLabelIssueReady
+	default:
+		return ""
+	}
+}
+
+func riskRank(risk string) int {
+	switch strings.ToLower(strings.TrimSpace(risk)) {
+	case RiskSafe:
+		return 0
+	case RiskMutating:
+		return 1
+	case RiskApprovalGated:
+		return 2
+	default:
+		return -1
+	}
+}
+
+func targetsAgree(got, want *state.SupervisorTarget) bool {
+	if want == nil {
+		return got == nil || (got.Issue == 0 && got.PR == 0 && strings.TrimSpace(got.Session) == "")
+	}
+	if got == nil {
+		return false
+	}
+	return got.Issue == want.Issue && got.PR == want.PR && strings.TrimSpace(got.Session) == strings.TrimSpace(want.Session)
+}
+
+func copyTarget(target *state.SupervisorTarget) *state.SupervisorTarget {
+	if target == nil {
+		return nil
+	}
+	copy := *target
+	copy.Session = strings.TrimSpace(copy.Session)
+	return &copy
+}

--- a/internal/supervisor/packet.go
+++ b/internal/supervisor/packet.go
@@ -1,0 +1,437 @@
+package supervisor
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+const (
+	supervisorIssueBodyLimit = 1600
+	supervisorLogTailLimit   = 4096
+	supervisorRecentLimit    = 3
+)
+
+type supervisorStatePacket struct {
+	ProjectConfig          supervisorProjectConfigPacket `json:"project_config"`
+	Policy                 supervisorPolicyPacket        `json:"supervisor_policy"`
+	CurrentSessions        []supervisorSessionPacket     `json:"current_maestro_sessions"`
+	OrderedQueue           []supervisorIssuePacket       `json:"ordered_queue_state"`
+	GitHub                 supervisorGitHubPacket        `json:"github_metadata"`
+	WorkerLogExcerpts      []supervisorLogExcerpt        `json:"recent_worker_log_excerpts,omitempty"`
+	StuckStateDetectors    []supervisorDetectorPacket    `json:"stuck_state_detector_outputs"`
+	RecentSupervisorEvents []supervisorRecentDecision    `json:"recent_supervisor_decisions,omitempty"`
+}
+
+type supervisorProjectConfigPacket struct {
+	Repo                       string            `json:"repo"`
+	MaxParallel                int               `json:"max_parallel"`
+	MaxConcurrentByState       map[string]int    `json:"max_concurrent_by_state,omitempty"`
+	MaxRetriesPerIssue         int               `json:"max_retries_per_issue"`
+	IssueLabels                []string          `json:"issue_labels,omitempty"`
+	ExcludeLabels              []string          `json:"exclude_labels,omitempty"`
+	WorkerSilentTimeoutMinutes int               `json:"worker_silent_timeout_minutes,omitempty"`
+	WorkerMaxTokens            int               `json:"worker_max_tokens,omitempty"`
+	MergeStrategy              string            `json:"merge_strategy"`
+	ReviewGate                 string            `json:"review_gate"`
+	GitHubProjectsEnabled      bool              `json:"github_projects_enabled"`
+	MissionsEnabled            bool              `json:"missions_enabled"`
+	Supervisor                 supervisorRuntime `json:"supervisor"`
+}
+
+type supervisorRuntime struct {
+	Enabled bool   `json:"enabled"`
+	Backend string `json:"backend"`
+	Model   string `json:"model,omitempty"`
+	Effort  string `json:"effort,omitempty"`
+	DryRun  bool   `json:"dry_run"`
+}
+
+type supervisorPolicyPacket struct {
+	AllowedActions          []string `json:"allowed_actions"`
+	ApprovalRequiredActions []string `json:"approval_required_actions"`
+}
+
+type supervisorSessionPacket struct {
+	Name                 string              `json:"name"`
+	Issue                int                 `json:"issue"`
+	Title                string              `json:"title,omitempty"`
+	Status               state.SessionStatus `json:"status"`
+	PR                   int                 `json:"pr,omitempty"`
+	Branch               string              `json:"branch,omitempty"`
+	Backend              string              `json:"backend,omitempty"`
+	Phase                state.Phase         `json:"phase,omitempty"`
+	RetryCount           int                 `json:"retry_count,omitempty"`
+	LastNotifiedStatus   string              `json:"last_notified_status,omitempty"`
+	RateLimitHit         bool                `json:"rate_limit_hit,omitempty"`
+	TokensUsedAttempt    int                 `json:"tokens_used_attempt,omitempty"`
+	TokensUsedTotal      int                 `json:"tokens_used_total,omitempty"`
+	StartedAt            time.Time           `json:"started_at,omitempty"`
+	FinishedAt           *time.Time          `json:"finished_at,omitempty"`
+	LastOutputChangedAt  time.Time           `json:"last_output_changed_at,omitempty"`
+	PreviousFeedbackKind string              `json:"previous_attempt_feedback_kind,omitempty"`
+}
+
+type supervisorIssuePacket struct {
+	Position    int      `json:"position"`
+	Number      int      `json:"number"`
+	Title       string   `json:"title"`
+	Labels      []string `json:"labels,omitempty"`
+	BodyExcerpt string   `json:"body_excerpt,omitempty"`
+}
+
+type supervisorGitHubPacket struct {
+	OpenIssues       int                  `json:"open_issues"`
+	OpenPullRequests int                  `json:"open_pull_requests"`
+	PullRequests     []supervisorPRPacket `json:"pull_requests,omitempty"`
+}
+
+type supervisorPRPacket struct {
+	Number        int    `json:"number"`
+	Title         string `json:"title,omitempty"`
+	HeadRefName   string `json:"head_ref_name,omitempty"`
+	State         string `json:"state,omitempty"`
+	Mergeable     string `json:"mergeable,omitempty"`
+	CIStatus      string `json:"ci_status,omitempty"`
+	ChecksExcerpt string `json:"checks_excerpt,omitempty"`
+}
+
+type supervisorLogExcerpt struct {
+	Session string `json:"session"`
+	Issue   int    `json:"issue"`
+	Status  string `json:"status"`
+	Excerpt string `json:"excerpt"`
+}
+
+type supervisorDetectorPacket struct {
+	Name              string                  `json:"name"`
+	Status            string                  `json:"status"`
+	RecommendedAction string                  `json:"recommended_action,omitempty"`
+	Risk              string                  `json:"risk,omitempty"`
+	Confidence        float64                 `json:"confidence,omitempty"`
+	Target            *state.SupervisorTarget `json:"target,omitempty"`
+	Reasons           []string                `json:"reasons,omitempty"`
+}
+
+type supervisorRecentDecision struct {
+	CreatedAt         time.Time               `json:"created_at"`
+	Summary           string                  `json:"summary"`
+	RecommendedAction string                  `json:"recommended_action"`
+	Target            *state.SupervisorTarget `json:"target,omitempty"`
+	Risk              string                  `json:"risk"`
+	RequiresApproval  bool                    `json:"requires_approval"`
+}
+
+type prChecksReader interface {
+	PRCIStatus(prNumber int) (string, error)
+}
+
+type prChecksOutputReader interface {
+	PRChecksOutput(prNumber int) (string, error)
+}
+
+func (e *Engine) buildStatePacket(st *state.State, deterministic state.SupervisorDecision, policy supervisorPolicy) (supervisorStatePacket, error) {
+	issues, err := e.reader.ListOpenIssues(nil)
+	if err != nil {
+		return supervisorStatePacket{}, fmt.Errorf("list open issues for supervisor state packet: %w", err)
+	}
+	prs, err := e.reader.ListOpenPRs()
+	if err != nil {
+		return supervisorStatePacket{}, fmt.Errorf("list open PRs for supervisor state packet: %w", err)
+	}
+
+	return supervisorStatePacket{
+		ProjectConfig:          e.projectConfigPacket(),
+		Policy:                 policy.packet(),
+		CurrentSessions:        sessionPackets(st),
+		OrderedQueue:           issuePackets(issues),
+		GitHub:                 e.githubPacket(issues, prs),
+		WorkerLogExcerpts:      logExcerpts(st),
+		StuckStateDetectors:    e.detectorPackets(st, deterministic),
+		RecentSupervisorEvents: recentDecisionPackets(st),
+	}, nil
+}
+
+func (e *Engine) projectConfigPacket() supervisorProjectConfigPacket {
+	return supervisorProjectConfigPacket{
+		Repo:                       e.cfg.Repo,
+		MaxParallel:                e.cfg.MaxParallel,
+		MaxConcurrentByState:       copyStringIntMap(e.cfg.MaxConcurrentByState),
+		MaxRetriesPerIssue:         e.cfg.MaxRetriesPerIssue,
+		IssueLabels:                append([]string(nil), e.cfg.IssueLabels...),
+		ExcludeLabels:              append([]string(nil), e.cfg.ExcludeLabels...),
+		WorkerSilentTimeoutMinutes: e.cfg.WorkerSilentTimeoutMinutes,
+		WorkerMaxTokens:            e.cfg.WorkerMaxTokens,
+		MergeStrategy:              e.cfg.MergeStrategy,
+		ReviewGate:                 e.cfg.ReviewGate,
+		GitHubProjectsEnabled:      e.cfg.GitHubProjects.Enabled,
+		MissionsEnabled:            e.cfg.Missions.Enabled,
+		Supervisor: supervisorRuntime{
+			Enabled: e.cfg.Supervisor.Enabled,
+			Backend: e.cfg.Supervisor.Backend,
+			Model:   e.cfg.Supervisor.Model,
+			Effort:  e.cfg.Supervisor.Effort,
+			DryRun:  e.cfg.Supervisor.DryRun,
+		},
+	}
+}
+
+func (p supervisorPolicy) packet() supervisorPolicyPacket {
+	return supervisorPolicyPacket{
+		AllowedActions:          withActionAliases(sortedKeys(p.allowed)),
+		ApprovalRequiredActions: withActionAliases(sortedKeys(p.approvalRequired)),
+	}
+}
+
+func sessionPackets(st *state.State) []supervisorSessionPacket {
+	packets := make([]supervisorSessionPacket, 0, len(st.Sessions))
+	for _, name := range sortedSessionNames(st) {
+		sess := st.Sessions[name]
+		if sess == nil {
+			continue
+		}
+		packets = append(packets, supervisorSessionPacket{
+			Name:                 name,
+			Issue:                sess.IssueNumber,
+			Title:                RedactSensitive(sess.IssueTitle),
+			Status:               sess.Status,
+			PR:                   sess.PRNumber,
+			Branch:               sess.Branch,
+			Backend:              sess.Backend,
+			Phase:                sess.Phase,
+			RetryCount:           sess.RetryCount,
+			LastNotifiedStatus:   sess.LastNotifiedStatus,
+			RateLimitHit:         sess.RateLimitHit,
+			TokensUsedAttempt:    sess.TokensUsedAttempt,
+			TokensUsedTotal:      sess.TokensUsedTotal,
+			StartedAt:            sess.StartedAt,
+			FinishedAt:           sess.FinishedAt,
+			LastOutputChangedAt:  sess.LastOutputChangedAt,
+			PreviousFeedbackKind: sess.PreviousAttemptFeedbackKind,
+		})
+	}
+	return packets
+}
+
+func issuePackets(issues []github.Issue) []supervisorIssuePacket {
+	packets := make([]supervisorIssuePacket, 0, len(issues))
+	for i, issue := range issues {
+		packets = append(packets, supervisorIssuePacket{
+			Position:    i + 1,
+			Number:      issue.Number,
+			Title:       RedactSensitive(issue.Title),
+			Labels:      issueLabelNames(issue),
+			BodyExcerpt: truncateText(RedactSensitive(issue.Body), supervisorIssueBodyLimit),
+		})
+	}
+	return packets
+}
+
+func (e *Engine) githubPacket(issues []github.Issue, prs []github.PR) supervisorGitHubPacket {
+	packet := supervisorGitHubPacket{
+		OpenIssues:       len(issues),
+		OpenPullRequests: len(prs),
+		PullRequests:     make([]supervisorPRPacket, 0, len(prs)),
+	}
+	checksReader, canReadChecks := e.reader.(prChecksReader)
+	checksOutputReader, canReadChecksOutput := e.reader.(prChecksOutputReader)
+	for _, pr := range prs {
+		prPacket := supervisorPRPacket{
+			Number:      pr.Number,
+			Title:       RedactSensitive(pr.Title),
+			HeadRefName: pr.HeadRefName,
+			State:       pr.State,
+			Mergeable:   pr.Mergeable,
+		}
+		if canReadChecks {
+			if status, err := checksReader.PRCIStatus(pr.Number); err == nil {
+				prPacket.CIStatus = status
+			} else {
+				prPacket.CIStatus = "unknown"
+			}
+		}
+		if canReadChecksOutput {
+			if output, err := checksOutputReader.PRChecksOutput(pr.Number); err == nil {
+				prPacket.ChecksExcerpt = truncateText(RedactSensitive(output), supervisorLogTailLimit)
+			}
+		}
+		packet.PullRequests = append(packet.PullRequests, prPacket)
+	}
+	return packet
+}
+
+func logExcerpts(st *state.State) []supervisorLogExcerpt {
+	excerpts := make([]supervisorLogExcerpt, 0, len(st.Sessions))
+	for _, name := range sortedSessionNames(st) {
+		sess := st.Sessions[name]
+		if sess == nil || strings.TrimSpace(sess.LogFile) == "" {
+			continue
+		}
+		data, err := os.ReadFile(sess.LogFile)
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		excerpt := tailText(string(data), supervisorLogTailLimit)
+		excerpt = strings.TrimSpace(RedactSensitive(excerpt))
+		if excerpt == "" {
+			continue
+		}
+		excerpts = append(excerpts, supervisorLogExcerpt{
+			Session: name,
+			Issue:   sess.IssueNumber,
+			Status:  string(sess.Status),
+			Excerpt: excerpt,
+		})
+	}
+	return excerpts
+}
+
+func (e *Engine) detectorPackets(st *state.State, deterministic state.SupervisorDecision) []supervisorDetectorPacket {
+	detectors := []supervisorDetectorPacket{{
+		Name:              "deterministic_supervisor",
+		Status:            "ok",
+		RecommendedAction: deterministic.RecommendedAction,
+		Risk:              deterministic.Risk,
+		Confidence:        deterministic.Confidence,
+		Target:            deterministic.Target,
+		Reasons:           deterministic.Reasons,
+	}}
+	if e.cfg.WorkerSilentTimeoutMinutes <= 0 {
+		return detectors
+	}
+	timeout := time.Duration(e.cfg.WorkerSilentTimeoutMinutes) * time.Minute
+	now := e.now().UTC()
+	for _, name := range sortedSessionNames(st) {
+		sess := st.Sessions[name]
+		if sess == nil || sess.Status != state.StatusRunning {
+			continue
+		}
+		status := "unknown"
+		if !sess.LastOutputChangedAt.IsZero() {
+			status = "not_stuck"
+			if now.Sub(sess.LastOutputChangedAt) > timeout {
+				status = "stuck"
+			}
+		}
+		detectors = append(detectors, supervisorDetectorPacket{
+			Name:   "worker_silent_timeout",
+			Status: status,
+			Target: &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: name},
+			Reasons: []string{
+				fmt.Sprintf("worker_silent_timeout_minutes=%d", e.cfg.WorkerSilentTimeoutMinutes),
+			},
+		})
+	}
+	return detectors
+}
+
+func recentDecisionPackets(st *state.State) []supervisorRecentDecision {
+	if len(st.SupervisorDecisions) == 0 {
+		return nil
+	}
+	decisions := append([]state.SupervisorDecision(nil), st.SupervisorDecisions...)
+	sort.Slice(decisions, func(i, j int) bool {
+		return decisions[i].CreatedAt.Before(decisions[j].CreatedAt)
+	})
+	if len(decisions) > supervisorRecentLimit {
+		decisions = decisions[len(decisions)-supervisorRecentLimit:]
+	}
+	packets := make([]supervisorRecentDecision, 0, len(decisions))
+	for _, decision := range decisions {
+		packets = append(packets, supervisorRecentDecision{
+			CreatedAt:         decision.CreatedAt,
+			Summary:           RedactSensitive(decision.Summary),
+			RecommendedAction: decision.RecommendedAction,
+			Target:            decision.Target,
+			Risk:              decision.Risk,
+			RequiresApproval:  decision.RequiresApproval,
+		})
+	}
+	return packets
+}
+
+var sensitiveRedactions = []struct {
+	re   *regexp.Regexp
+	repl string
+}{
+	{regexp.MustCompile(`(?i)\bAuthorization\s*:\s*[^\n\r]+`), "Authorization: [REDACTED]"},
+	{regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+`), "Bearer [REDACTED]"},
+	{regexp.MustCompile(`(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|PRIVATE[_-]?KEY)[A-Z0-9_]*)\s*[:=]\s*("[^"\n]*"|'[^'\n]*'|[^\s\n]+)`), "${1}=[REDACTED]"},
+	{regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9_]{20,}\b`), "[REDACTED_GITHUB_TOKEN]"},
+	{regexp.MustCompile(`\bsk-[A-Za-z0-9]{20,}\b`), "[REDACTED_API_KEY]"},
+	{regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{20,}\b`), "[REDACTED_SLACK_TOKEN]"},
+}
+
+// RedactSensitive removes common credential shapes before data reaches prompts or state records.
+func RedactSensitive(text string) string {
+	redacted := text
+	for _, item := range sensitiveRedactions {
+		redacted = item.re.ReplaceAllString(redacted, item.repl)
+	}
+	return redacted
+}
+
+func issueLabelNames(issue github.Issue) []string {
+	labels := make([]string, 0, len(issue.Labels))
+	for _, label := range issue.Labels {
+		labels = append(labels, label.Name)
+	}
+	return labels
+}
+
+func truncateText(text string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	return string(runes[:limit]) + "\n... (truncated)"
+}
+
+func tailText(text string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	return "... (truncated)\n" + string(runes[len(runes)-limit:])
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func withActionAliases(actions []string) []string {
+	for _, action := range actions {
+		if action == ActionLabelIssueReady {
+			return append(actions, "add_ready_label")
+		}
+	}
+	return actions
+}
+
+func copyStringIntMap(values map[string]int) map[string]int {
+	if len(values) == 0 {
+		return nil
+	}
+	copy := make(map[string]int, len(values))
+	for key, value := range values {
+		copy[key] = value
+	}
+	return copy
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -92,6 +92,7 @@ type prGreptileReader interface {
 type Engine struct {
 	cfg      *config.Config
 	reader   Reader
+	llm      LLMClient
 	now      func() time.Time
 	pidAlive func(pid int) bool
 	stat     func(name string) (os.FileInfo, error)
@@ -102,7 +103,7 @@ func NewEngine(cfg *config.Config, reader Reader) *Engine {
 	if reader == nil {
 		reader = github.New(cfg.Repo)
 	}
-	return &Engine{
+	eng := &Engine{
 		cfg:      cfg,
 		reader:   reader,
 		now:      func() time.Time { return time.Now().UTC() },
@@ -110,6 +111,10 @@ func NewEngine(cfg *config.Config, reader Reader) *Engine {
 		stat:     os.Stat,
 		lookPath: exec.LookPath,
 	}
+	if cfg != nil && cfg.Supervisor.Enabled {
+		eng.llm = NewBackendLLMClient(cfg)
+	}
+	return eng
 }
 
 // RunOnce records one supervisor decision in Maestro state and applies any safe
@@ -128,27 +133,36 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 	if err != nil {
 		return state.SupervisorDecision{}, err
 	}
-	if decisionRequiresApproval(decision) {
-		approval := st.RecordPendingApprovalForDecision(decision, decision.CreatedAt)
-		decision.ApprovalID = approval.ID
-	}
-	if len(decision.Mutations) > 0 && decision.Risk == RiskSafe {
-		mutator, ok := reader.(Mutator)
-		if !ok {
-			markUnsupportedQueueAction(&decision)
-		} else {
-			applyQueueAction(cfg, &decision, mutator)
+	if !cfg.Supervisor.DryRun {
+		if decisionRequiresApproval(decision) {
+			approval := st.RecordPendingApprovalForDecision(decision, decision.CreatedAt)
+			decision.ApprovalID = approval.ID
 		}
-	}
-	st.RecordSupervisorDecision(decision, state.DefaultSupervisorDecisionLimit)
-	if err := state.Save(cfg.StateDir, st); err != nil {
-		return state.SupervisorDecision{}, fmt.Errorf("save state: %w", err)
+		if len(decision.Mutations) > 0 && decision.Risk == RiskSafe {
+			mutator, ok := reader.(Mutator)
+			if !ok {
+				markUnsupportedQueueAction(&decision)
+			} else {
+				applyQueueAction(cfg, &decision, mutator)
+			}
+		}
+		st.RecordSupervisorDecision(decision, state.DefaultSupervisorDecisionLimit)
+		if err := state.Save(cfg.StateDir, st); err != nil {
+			return state.SupervisorDecision{}, fmt.Errorf("save state: %w", err)
+		}
 	}
 	return decision, nil
 }
 
 // Decide observes state and GitHub read-only data, then returns the next recommendation.
 func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
+	if e.cfg.Supervisor.Enabled {
+		return e.decideWithLLM(st)
+	}
+	return e.decideDeterministic(st)
+}
+
+func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision, error) {
 	if st == nil {
 		st = state.NewState()
 	}
@@ -356,6 +370,7 @@ func (e *Engine) decision(now time.Time, ps state.SupervisorProjectState, action
 		Risk:              risk,
 		Confidence:        confidence,
 		Reasons:           compactReasons(reasons),
+		RequiresApproval:  risk == RiskApprovalGated,
 		ProjectState:      ps,
 	}
 }

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1087,7 +1087,7 @@ func TestDecideWithLLM_ValidDecision(t *testing.T) {
 }`}
 	st := state.NewState()
 	logPath := filepath.Join(t.TempDir(), "worker.log")
-	if err := os.WriteFile(logPath, []byte("Authorization: Bearer redact-me\nAPI_KEY=redact-me\n"), 0644); err != nil {
+	if err := os.WriteFile(logPath, []byte("Authorization: redact-me\nAPI_KEY=redact-me\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	st.Sessions["slot-dead"] = &state.Session{
@@ -1118,7 +1118,7 @@ func TestDecideWithLLM_ValidDecision(t *testing.T) {
 	if decision.Target == nil || decision.Target.Issue != 42 {
 		t.Fatalf("target = %#v, want issue 42", decision.Target)
 	}
-	for _, secret := range []string{"SERVICE_TOKEN=redact-me", "Bearer redact-me", "API_KEY=redact-me"} {
+	for _, secret := range []string{"SERVICE_TOKEN=redact-me", "Authorization: redact-me", "API_KEY=redact-me"} {
 		if strings.Contains(llm.prompt, secret) {
 			t.Fatalf("prompt contained unredacted secret %q", secret)
 		}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -3,6 +3,8 @@ package supervisor
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +31,22 @@ type fakeReader struct {
 	addLabelErr    error
 	removeLabelErr error
 	commentErr     error
+}
+
+type fakeLLM struct {
+	output string
+	prompt string
+	calls  int
+	err    error
+}
+
+func (f *fakeLLM) Complete(prompt string) (string, error) {
+	f.calls++
+	f.prompt = prompt
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.output, nil
 }
 
 func (f *fakeReader) ListOpenIssues(labels []string) ([]github.Issue, error) {
@@ -122,6 +140,13 @@ func requireStuckState(t *testing.T, decision state.SupervisorDecision, code str
 	}
 	t.Fatalf("stuck state %q not found in %#v", code, decision.StuckStates)
 	return state.SupervisorStuckState{}
+}
+
+func testLLMEngine(cfg *config.Config, reader *fakeReader, llm *fakeLLM) *Engine {
+	cfg.Supervisor.Enabled = true
+	eng := testEngine(cfg, reader)
+	eng.llm = llm
+	return eng
 }
 
 func testIssue(number int, title string, labels ...string) github.Issue {
@@ -1025,5 +1050,181 @@ func TestDecide_OrderedQueueAdvancesAfterPolicyOverride(t *testing.T) {
 	}
 	if decision.Target == nil || decision.Target.Issue != 306 {
 		t.Fatalf("target = %#v, want issue 306", decision.Target)
+	}
+}
+
+func TestRunOnceDryRunDoesNotRecordDecision(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Supervisor.DryRun = true
+	reader := &fakeReader{}
+
+	if _, err := RunOnce(cfg, reader); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if latest := st.LatestSupervisorDecision(); latest != nil {
+		t.Fatalf("latest supervisor decision = %#v, want nil for dry run", latest)
+	}
+}
+
+func TestDecideWithLLM_ValidDecision(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	issue := testIssue(42, "ready work", "maestro-ready")
+	issue.Body = "Implement this. SERVICE_TOKEN=redact-me"
+	reader := &fakeReader{issues: []github.Issue{issue}}
+	llm := &fakeLLM{output: `{
+  "summary": "Issue #42 is ready to feed; no worker is running.",
+  "recommended_action": "spawn_worker",
+  "target": {"issue": 42},
+  "risk": "mutating",
+  "confidence": 0.87,
+  "reasons": ["ordered queue points to #42", "no active worker"],
+  "requires_approval": true
+}`}
+	st := state.NewState()
+	logPath := filepath.Join(t.TempDir(), "worker.log")
+	if err := os.WriteFile(logPath, []byte("Authorization: Bearer redact-me\nAPI_KEY=redact-me\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	st.Sessions["slot-dead"] = &state.Session{
+		IssueNumber: 99,
+		IssueTitle:  "previous failure",
+		Status:      state.StatusDead,
+		LogFile:     logPath,
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if llm.calls != 1 {
+		t.Fatalf("LLM calls = %d, want 1", llm.calls)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Summary != "Issue #42 is ready to feed; no worker is running." {
+		t.Fatalf("summary = %q", decision.Summary)
+	}
+	if !decision.RequiresApproval {
+		t.Fatal("RequiresApproval = false, want true")
+	}
+	if decision.Target == nil || decision.Target.Issue != 42 {
+		t.Fatalf("target = %#v, want issue 42", decision.Target)
+	}
+	for _, secret := range []string{"SERVICE_TOKEN=redact-me", "Bearer redact-me", "API_KEY=redact-me"} {
+		if strings.Contains(llm.prompt, secret) {
+			t.Fatalf("prompt contained unredacted secret %q", secret)
+		}
+	}
+	if !strings.Contains(llm.prompt, "ordered_queue_state") || !strings.Contains(llm.prompt, "[REDACTED") {
+		t.Fatalf("prompt did not include expected redacted state packet: %s", llm.prompt)
+	}
+}
+
+func TestDecideWithLLM_UnknownActionRejected(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
+	llm := &fakeLLM{output: `{
+  "summary": "Delete the repo.",
+  "recommended_action": "delete_repo",
+  "target": {"issue": 42},
+  "risk": "mutating",
+  "confidence": 0.9,
+  "reasons": ["not allowed"],
+  "requires_approval": true
+}`}
+
+	_, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("Decide error = %v, want not allowed", err)
+	}
+}
+
+func TestDecideWithLLM_ApprovalRequiredActionRejectedWithoutApproval(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
+	llm := &fakeLLM{output: `{
+  "summary": "Issue #42 is ready to feed.",
+  "recommended_action": "spawn_worker",
+  "target": {"issue": 42},
+  "risk": "mutating",
+  "confidence": 0.87,
+  "reasons": ["ordered queue points to #42"],
+  "requires_approval": false
+}`}
+
+	_, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err == nil || !strings.Contains(err.Error(), "requires approval") {
+		t.Fatalf("Decide error = %v, want requires approval", err)
+	}
+}
+
+func TestDecideWithLLM_MalformedOutputRejected(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
+	llm := &fakeLLM{output: `not json`}
+
+	_, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err == nil || !strings.Contains(err.Error(), "invalid JSON contract") {
+		t.Fatalf("Decide error = %v, want invalid JSON contract", err)
+	}
+}
+
+func TestDecideWithLLM_DetectorDisagreementRejected(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work")}}
+	llm := &fakeLLM{output: `{
+  "summary": "Start a new worker anyway.",
+  "recommended_action": "spawn_worker",
+  "target": {"issue": 42},
+  "risk": "mutating",
+  "confidence": 0.87,
+  "reasons": ["LLM wants more work"],
+  "requires_approval": true
+}`}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 77,
+		IssueTitle:  "already running",
+		Status:      state.StatusRunning,
+		StartedAt:   time.Now().UTC(),
+	}
+
+	_, err := testLLMEngine(cfg, reader, llm).Decide(st)
+	if err == nil || !strings.Contains(err.Error(), "disagrees with deterministic guardrail") {
+		t.Fatalf("Decide error = %v, want detector disagreement", err)
+	}
+}
+
+func TestDecideWithLLM_AddReadyLabelAliasAccepted(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{testIssue(308, "needs label")}}
+	llm := &fakeLLM{output: `{
+  "summary": "Issue #308 is ready to label.",
+  "recommended_action": "add_ready_label",
+  "target": {"issue": 308},
+  "risk": "mutating",
+  "confidence": 0.82,
+  "reasons": ["no eligible issue has the configured ready label"],
+  "requires_approval": true
+}`}
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionLabelIssueReady {
+		t.Fatalf("action = %q, want canonical %q", decision.RecommendedAction, ActionLabelIssueReady)
 	}
 }

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -22,6 +22,8 @@ type BackendConfig struct {
 	Cmd        string   // binary name (e.g. "claude", "codex", "gemini")
 	ExtraArgs  []string // additional args from config
 	PromptMode string   // how to deliver prompt: "arg", "stdin", "file"
+	Model      string   // optional model name for role-specific backend calls
+	Effort     string   // optional reasoning effort for role-specific backend calls
 }
 
 // Backend builds the exec.Cmd for a specific model CLI.
@@ -167,6 +169,17 @@ func (genericBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (
 	return cmd, stdinFile, nil
 }
 
+func appendModelOptions(args []string, cfg BackendConfig) []string {
+	args = append(args, cfg.ExtraArgs...)
+	if strings.TrimSpace(cfg.Model) != "" {
+		args = append(args, "--model", strings.TrimSpace(cfg.Model))
+	}
+	if strings.TrimSpace(cfg.Effort) != "" {
+		args = append(args, "--effort", strings.TrimSpace(cfg.Effort))
+	}
+	return args
+}
+
 // BuildWorkerCmd creates the right exec.Cmd based on backend name.
 // Known backends (claude, codex, gemini) use their specific command builders.
 // Unknown backends use the generic builder with prompt_mode from config.
@@ -183,6 +196,106 @@ func BuildWorkerCmd(backendName string, cfg BackendConfig, promptFile, worktree 
 
 	// Fallback: use generic backend for unknown backends
 	return (genericBackend{}).BuildCmd(cfg, promptFile, worktree)
+}
+
+// BuildSupervisorCmd creates a read-only model command for supervisor decisions.
+// It reuses backend prompt delivery semantics but intentionally avoids worker-only
+// permission bypass flags.
+func BuildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, worktree string) (cmd *exec.Cmd, stdinFile string, err error) {
+	if backendName == "" {
+		backendName = "claude"
+	}
+
+	switch backendName {
+	case "claude":
+		promptData, err := os.ReadFile(promptFile)
+		if err != nil {
+			return nil, "", fmt.Errorf("read prompt file: %w", err)
+		}
+		claudeCmd := cfg.Cmd
+		if claudeCmd == "" {
+			claudeCmd = "claude"
+		}
+		binary, cmdArgs := splitCmd(claudeCmd)
+		args := append(cmdArgs, "-p", string(promptData))
+		args = appendModelOptions(args, cfg)
+		cmd := exec.Command(binary, args...)
+		cmd.Dir = worktree
+		return cmd, "", nil
+	case "codex":
+		codexCmd := cfg.Cmd
+		if codexCmd == "" {
+			codexCmd = "codex"
+		}
+		binary, cmdArgs := splitCmd(codexCmd)
+		args := append(cmdArgs, "exec", "-C", worktree, "-")
+		args = appendModelOptions(args, cfg)
+		cmd := exec.Command(binary, args...)
+		cmd.Dir = worktree
+		return cmd, promptFile, nil
+	case "gemini":
+		promptData, err := os.ReadFile(promptFile)
+		if err != nil {
+			return nil, "", fmt.Errorf("read prompt file: %w", err)
+		}
+		geminiCmd := cfg.Cmd
+		if geminiCmd == "" {
+			geminiCmd = "gemini"
+		}
+		binary, cmdArgs := splitCmd(geminiCmd)
+		args := append(cmdArgs, "-p", string(promptData))
+		args = appendModelOptions(args, cfg)
+		cmd := exec.Command(binary, args...)
+		cmd.Dir = worktree
+		return cmd, "", nil
+	case "cline":
+		promptData, err := os.ReadFile(promptFile)
+		if err != nil {
+			return nil, "", fmt.Errorf("read prompt file: %w", err)
+		}
+		clineCmd := cfg.Cmd
+		if clineCmd == "" {
+			clineCmd = "cline"
+		}
+		binary, cmdArgs := splitCmd(clineCmd)
+		args := append(cmdArgs, "-y", string(promptData))
+		args = appendModelOptions(args, cfg)
+		cmd := exec.Command(binary, args...)
+		cmd.Dir = worktree
+		return cmd, "", nil
+	default:
+		return buildGenericSupervisorCmd(cfg, promptFile, worktree)
+	}
+}
+
+func buildGenericSupervisorCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
+	if cfg.Cmd == "" {
+		return nil, "", fmt.Errorf("generic backend requires cmd to be set")
+	}
+	binary, cmdArgs := splitCmd(cfg.Cmd)
+	mode := cfg.PromptMode
+	if mode == "" {
+		mode = "arg"
+	}
+	args := appendModelOptions(append([]string(nil), cmdArgs...), cfg)
+	stdinFile := ""
+	switch mode {
+	case "arg":
+		promptData, err := os.ReadFile(promptFile)
+		if err != nil {
+			return nil, "", fmt.Errorf("read prompt file: %w", err)
+		}
+		args = append(args, string(promptData))
+	case "stdin":
+		stdinFile = promptFile
+	case "file":
+		args = append(args, promptFile)
+	default:
+		return nil, "", fmt.Errorf("unknown prompt_mode %q (supported: arg, stdin, file)", mode)
+	}
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = worktree
+	return cmd, stdinFile, nil
 }
 
 // KnownBackends returns a list of built-in backend names.

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -202,6 +202,55 @@ func TestBuildWorkerCmd_ClineDefaultCmd(t *testing.T) {
 	}
 }
 
+func TestBuildSupervisorCmd_ClaudeReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("decide safely"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BackendConfig{Cmd: "claude", Model: "sonnet", Effort: "medium"}
+	cmd, stdinFile, err := BuildSupervisorCmd("claude", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdinFile != "" {
+		t.Errorf("stdinFile = %q, want empty", stdinFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if strings.Contains(args, "dangerously") || strings.Contains(args, "bypass") {
+		t.Errorf("supervisor command should not include worker permission bypass flags: %s", args)
+	}
+	for _, want := range []string{"-p", "decide safely", "--model", "sonnet", "--effort", "medium"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("expected %q in args, got: %s", want, args)
+		}
+	}
+}
+
+func TestBuildSupervisorCmd_CodexReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("decide safely"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, stdinFile, err := BuildSupervisorCmd("codex", BackendConfig{Cmd: "codex"}, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "exec") || !strings.Contains(args, "-C") {
+		t.Errorf("expected codex exec args, got: %s", args)
+	}
+	if strings.Contains(args, "dangerously") || strings.Contains(args, "bypass") {
+		t.Errorf("supervisor command should not include worker permission bypass flags: %s", args)
+	}
+}
+
 func TestBuildWorkerCmd_GeminiPromptFileError(t *testing.T) {
 	cfg := BackendConfig{Cmd: "gemini"}
 	_, _, err := BuildWorkerCmd("gemini", cfg, "/nonexistent/prompt.md", "/tmp/wt")


### PR DESCRIPTION
Closes #268

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires an LLM into the supervisor decision path: when `supervisor.enabled` is true, `Decide` calls `decideWithLLM`, which runs the existing deterministic engine as a guardrail, builds a redacted state packet, invokes the configured backend, and validates the LLM output against the deterministic result before recording it. A `--dry-run` flag skips state recording. The infrastructure is well-structured and the policy/validation layer is thorough, but there are two P1 logic issues in the LLM path that can silently disable supervision entirely.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: two P1 logic issues in the LLM decision path can silently disable supervision on transient failures or target mismatches.

Two P1 findings: (1) no fallback to the deterministic path when the LLM errors or disagrees, causing RunOnce to propagate an error and skip state recording entirely; (2) strict target-agreement check can reject semantically correct LLM decisions that include extra target fields. Both issues affect the new LLM-enabled code path exclusively.

internal/supervisor/llm.go (validateLLMDecision target check and missing fallback) and internal/supervisor/supervisor.go (Decide routing with no error recovery)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/llm.go | New file implementing LLM-backed supervisor decisions; contains two P1 logic issues (strict target-agreement check causes false rejections, no fallback on LLM failure) and two P2 issues (naive JSON extraction, dead-code default action lists). |
| internal/supervisor/supervisor.go | Routes `Decide` through LLM when enabled and adds `decideDeterministic` wrapper; P1: no fallback to deterministic on LLM error/disagreement; dry-run guard and `RequiresApproval` propagation are correct. |
| internal/supervisor/packet.go | New file building the supervisor state packet; redaction of sensitive data is applied throughout, log/issue truncation limits are enforced, and serialisation helpers are clean. |
| internal/worker/backend.go | Adds `BuildSupervisorCmd` and `appendModelOptions`; correctly omits worker-specific permission bypass flags; prompt content is read into a CLI arg for claude/gemini/cline (same pattern as existing worker commands). |
| internal/config/config.go | Adds Backend, Model, Effort, Prompt, DryRun, AllowedActions, and ApprovalRequiredActions fields to SupervisorConfig with correct defaults set in parse(). |
| cmd/maestro/main.go | Adds --dry-run CLI flag that propagates into cfg.Supervisor.DryRun; straightforward and correct. |
| internal/state/state.go | Adds RequiresApproval field to SupervisorDecision; minimal and non-breaking change. |
| internal/supervisor/supervisor_test.go | Good coverage of LLM decision path: unknown action rejection, approval-required enforcement, malformed output, detector disagreement, and alias acceptance are all tested. |
| internal/config/config_test.go | New tests cover explicit supervisor config parsing and verify defaults; no issues. |
| internal/worker/backend_test.go | Verifies BuildSupervisorCmd for claude and codex backends; correctly asserts absence of worker permission bypass flags. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/supervisor/supervisor.go
Line: 158-162

Comment:
**No fallback to deterministic path on LLM failure**

When `Supervisor.Enabled` is true, `Decide` calls `decideWithLLM`, which fails hard (returning an error) on any LLM-side problem: network error, bad JSON, action disagreement with the deterministic guardrail, or missing `requires_approval`. In all of those cases the deterministic result is computed first (it's the guardrail) but then silently discarded, and `RunOnce` propagates the error — skipping state recording entirely. A single transient LLM failure therefore blocks supervision for that entire cycle with no recovery path.

The deterministic result is already available inside `decideWithLLM`; an error from `validateLLMDecision` or `client.Complete` could fall back to it rather than propagating the error.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/supervisor/llm.go
Line: 249-254

Comment:
**`targetsAgree` can produce a false rejection when LLM enriches target**

`validateLLMDecision` requires `targetsAgree(llm.Target, deterministic.Target)` to hold. For actions like `ActionMonitorOpenPR`, the deterministic engine sets a specific `{Issue, PR, Session}` triple. If the LLM's target matches on issue and session but includes a different (even plausibly correct) PR number — for example because it sees a new PR in the `github_metadata` packet that the deterministic snapshot hadn't captured — `targetsAgree` returns false and the entire decision is rejected with an error. This silently breaks supervision even when the LLM chose the correct action.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/supervisor/llm.go
Line: 216-223

Comment:
**`extractJSONObject` extraction is brace-count-unaware**

The fallback extracts the span between the first `{` and the **last** `}` in the output. If the LLM emits prose after the JSON object that happens to contain a closing brace (e.g. `"...use option {A}."`), `end` advances past the real closing brace and the extracted substring is invalid JSON — the fallback fails for a recoverable case. A depth-counting scan would be more robust here.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/supervisor/llm.go
Line: 287-295

Comment:
**`defaultAllowedActions` / `defaultApprovalRequiredActions` are unreachable in practice**

`config.parse()` unconditionally initialises `AllowedActions` and `ApprovalRequiredActions` to non-nil slices, so `newSupervisorPolicy`'s `nil` guards (lines 289–294) are never triggered through the normal config path. Additionally, `defaultAllowedActions()` here omits `"add_ready_label"` while the config-level default includes it, creating a silent discrepancy if a `Config` is ever constructed without going through `parse()`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: avoid credential-like supervisor f..."](https://github.com/befeast/maestro/commit/c09bd264366519a2d7d228ed5eed488867a5a1fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30246545)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->