### PR TITLE
Recover green PRs stuck after review retry exhaustion

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -247,8 +247,8 @@ func (c *Client) PRMergeable(prNumber int) (string, error) {
 //
 // Primary path: reads GitHub Check Runs for the PR's head SHA.
 //   - Looks for a check whose name contains "greptile" (case-insensitive).
-//   - conclusion == "success" or "neutral" only approves when there are no
-//     Greptile inline review comments on the current head SHA.
+//   - conclusion == "success" or "neutral" approves when there are no high
+//     severity Greptile inline review comments on the current head SHA.
 //   - check found, other conclusion → approved=false, pending=false
 //   - check not found → falls through to comment-based fallback
 //
@@ -299,8 +299,12 @@ func (c *Client) PRGreptileApproved(prNumber int) (approved bool, pending bool, 
 				return false, false, nil
 			}
 
-			// Greptile check run passed — trust the verdict.
-			// Inline comments are advisory; the check run is the authority.
+			// Greptile check run passed, but high-severity inline comments on
+			// the current head are still actionable and should block the gate.
+			comments, err := c.greptileReviewComments(prNumber)
+			if err == nil && hasGreptileInlineCommentOnHead(comments, sha) {
+				return false, false, nil
+			}
 			return true, false, nil
 		}
 		// No greptile check run found → fall through to comment fallback
@@ -334,6 +338,10 @@ commentFallback:
 		}
 
 		foundGreptile = true
+
+		if strings.Contains(bodyLower, "not safe to merge") || strings.Contains(bodyLower, "unsafe to merge") {
+			return false, false, nil
+		}
 
 		if strings.Contains(bodyLower, "safe to merge") {
 			return true, false, nil
@@ -370,6 +378,11 @@ func greptileCheckDecision(checkRuns []greptileCheckRun) (found bool, approved b
 
 func isGreptileLogin(login string) bool {
 	return strings.Contains(strings.ToLower(strings.TrimSpace(login)), "greptile")
+}
+
+func isReviewBotLogin(login string) bool {
+	lower := strings.ToLower(strings.TrimSpace(login))
+	return strings.Contains(lower, "greptile") || strings.Contains(lower, "codex")
 }
 
 func hasGreptileInlineCommentOnHead(comments []greptileReviewComment, sha string) bool {
@@ -728,7 +741,9 @@ type ReviewComment struct {
 	User string `json:"user"`
 }
 
-// CollectReviewFeedback collects all inline review comments from Greptile and Codex on a PR.
+var reviewLocationPattern = regexp.MustCompile(`(?mi)(^|\s)([A-Za-z0-9_./-]+\.[A-Za-z0-9]+:\d+|file:\s*\S+)`)
+
+// CollectReviewFeedback collects actionable inline review comments from Greptile and Codex on a PR.
 func (c *Client) CollectReviewFeedback(prNumber int) ([]ReviewComment, error) {
 	// Get HEAD SHA — only return comments on the latest commit
 	prOut, _ := exec.Command("gh", "api",
@@ -743,21 +758,134 @@ func (c *Client) CollectReviewFeedback(prNumber int) ([]ReviewComment, error) {
 	var result []ReviewComment
 	for _, cm := range comments {
 		login := cm.User.Login
-		if !strings.Contains(login, "greptile") && !strings.Contains(login, "codex") {
+		if !isReviewBotLogin(login) {
 			continue
 		}
 		// Skip comments that were originally left on older commits — they may already be fixed.
 		if !reviewCommentTargetsHead(cm, headSHA) {
 			continue
 		}
-		result = append(result, ReviewComment{
+		comment := ReviewComment{
 			Path: cm.Path,
 			Line: cm.Line,
 			Body: cm.Body,
 			User: login,
-		})
+		}
+		if !isActionableReviewComment(comment) {
+			continue
+		}
+		result = append(result, comment)
 	}
 	return result, nil
+}
+
+func isActionableReviewComment(comment ReviewComment) bool {
+	body := strings.TrimSpace(comment.Body)
+	if body == "" || isNonActionableReviewText(body) {
+		return false
+	}
+	if strings.TrimSpace(comment.Path) != "" || comment.Line > 0 {
+		return true
+	}
+	return isActionableReviewSummary(body)
+}
+
+func isActionableReviewSummary(body string) bool {
+	body = strings.TrimSpace(body)
+	if body == "" || isNonActionableReviewText(body) {
+		return false
+	}
+	return hasActionableReviewMarker(body)
+}
+
+func isNonActionableReviewText(body string) bool {
+	lower := normalizedReviewText(body)
+	if lower == "" {
+		return true
+	}
+	if strings.Contains(lower, "not safe to merge") || strings.Contains(lower, "unsafe to merge") {
+		return false
+	}
+
+	nonActionable := []string{
+		"no actionable comments",
+		"no actionable feedback",
+		"no actionable issues",
+		"no blocking issues",
+		"no bugs found",
+		"no changes requested",
+		"no findings",
+		"no issues found",
+		"no issues were found",
+		"no review comments",
+		"nothing to fix",
+		"review complete with no findings",
+		"review passed",
+		"safe to merge",
+		"looks good to me",
+		"looks good",
+		"lgtm",
+		"found 0 issues",
+		"0 issues found",
+	}
+	for _, phrase := range nonActionable {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+
+	if strings.Contains(lower, "codex") && strings.Contains(lower, "reviewed") &&
+		(strings.Contains(lower, "left comments") || strings.Contains(lower, "review comments")) &&
+		!hasActionableReviewMarker(body) {
+		return true
+	}
+
+	return false
+}
+
+func hasActionableReviewMarker(body string) bool {
+	if reviewLocationPattern.MatchString(body) {
+		return true
+	}
+	lower := normalizedReviewText(body)
+	markers := []string{
+		"not safe to merge",
+		"unsafe to merge",
+		"changes requested",
+		"must fix",
+		"please fix",
+		"needs fix",
+		"action required",
+		"blocking",
+		"regression",
+		"bug",
+		"crash",
+		"panic",
+		"nil pointer",
+		"data race",
+		"security",
+		"vulnerability",
+		"incorrect",
+		"broken",
+		"failing",
+		"leak",
+		"deadlock",
+		"p0",
+		"p1",
+		"p2",
+		"p3",
+		"severity:",
+	}
+	for _, marker := range markers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizedReviewText(body string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(body)), " "))
 }
 
 // FormatReviewFeedback formats review comments into a text block for worker prompts.
@@ -846,10 +974,10 @@ func (c *Client) CIFailureSummary(prNumber int) (string, error) {
 	return s, nil
 }
 
-// CollectPRReviewFeedback collects all Greptile review feedback from a PR,
-// including both inline review comments and issue-level summary comments.
+// CollectPRReviewFeedback collects actionable Greptile/Codex review feedback
+// from a PR, including inline review comments and issue-level summary comments.
 // Returns a formatted string ready to inject into a worker prompt, or empty
-// string if no Greptile feedback exists.
+// string if no actionable review feedback exists.
 func (c *Client) CollectPRReviewFeedback(prNumber int) (string, error) {
 	var sections []string
 
@@ -866,7 +994,7 @@ func (c *Client) CollectPRReviewFeedback(prNumber int) (string, error) {
 		}
 		if json.Unmarshal(issueCommentsOut, &comments) == nil {
 			for _, cm := range comments {
-				if isGreptileLogin(cm.User.Login) && strings.TrimSpace(cm.Body) != "" {
+				if isReviewBotLogin(cm.User.Login) && isActionableReviewSummary(cm.Body) {
 					sections = append(sections, cm.Body)
 				}
 			}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -259,6 +259,48 @@ func TestFormatReviewFeedback_Empty(t *testing.T) {
 	}
 }
 
+func TestIsActionableReviewComment_IgnoresCodexWrapper(t *testing.T) {
+	comment := ReviewComment{
+		Path: "internal/foo.go",
+		Line: 42,
+		Body: "Codex reviewed this pull request and left comments for the author to consider.",
+		User: "chatgpt-codex-connector[bot]",
+	}
+	if isActionableReviewComment(comment) {
+		t.Fatal("generic Codex wrapper text should not be actionable review feedback")
+	}
+}
+
+func TestIsActionableReviewSummary_IgnoresEmptyGreptileReview(t *testing.T) {
+	body := `## Greptile Review
+
+No issues found. Safe to merge.
+
+Confidence Score: 5/5`
+	if isActionableReviewSummary(body) {
+		t.Fatal("empty Greptile review summary should not be actionable review feedback")
+	}
+}
+
+func TestIsActionableReviewComment_KeepsCurrentHeadInlineFinding(t *testing.T) {
+	comment := ReviewComment{
+		Path: "internal/foo.go",
+		Line: 42,
+		Body: "P1: nil pointer panic when the worker has no PR number",
+		User: "greptile-apps[bot]",
+	}
+	if !isActionableReviewComment(comment) {
+		t.Fatal("real inline review finding should be actionable")
+	}
+}
+
+func TestIsActionableReviewSummary_KeepsConcreteSummaryFinding(t *testing.T) {
+	body := "Confidence Score: 3/5\nNot safe to merge. P2: internal/foo.go:42 has inverted retry logic."
+	if !isActionableReviewSummary(body) {
+		t.Fatal("concrete review summary finding should be actionable")
+	}
+}
+
 func TestIsGreptileLogin(t *testing.T) {
 	tests := []struct {
 		login string

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1027,16 +1027,29 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 	for slotName, sess := range s.Sessions {
 		switch sess.Status {
-		case state.StatusDone, state.StatusDead, state.StatusConflictFailed, state.StatusFailed:
+		case state.StatusDone, state.StatusDead, state.StatusConflictFailed, state.StatusFailed, state.StatusRetryExhausted:
 			// Zombie cleanup: if the underlying issue is closed, transition to done.
-			// This prevents conflict_failed/failed/dead sessions from lingering
+			// This prevents conflict_failed/failed/dead/retry_exhausted sessions from lingering
 			// indefinitely when their issues are closed externally (#187).
 			if sess.Status != state.StatusDone {
+				done := false
+				if sess.PRNumber > 0 {
+					merged, err := o.isPRMerged(sess.PRNumber)
+					if err != nil {
+						log.Printf("[orch] check PR #%d merged: %v", sess.PRNumber, err)
+					} else if merged {
+						log.Printf("[orch] PR #%d merged, transitioning zombie session %s from %s to done", sess.PRNumber, slotName, sess.Status)
+						done = true
+					}
+				}
 				closed, err := o.isIssueClosed(sess.IssueNumber)
 				if err != nil {
 					log.Printf("[orch] check issue #%d: %v", sess.IssueNumber, err)
 				} else if closed {
 					log.Printf("[orch] issue #%d closed, transitioning zombie session %s from %s to done", sess.IssueNumber, slotName, sess.Status)
+					done = true
+				}
+				if done {
 					o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
 					sess.Status = state.StatusDone
 					if sess.FinishedAt == nil {
@@ -1392,10 +1405,12 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		return
 	}
 
-	// Build branch → PR map
+	// Build branch/number → PR maps
 	branchToPR := make(map[string]github.PR)
+	numberToPR := make(map[int]github.PR)
 	for _, pr := range prs {
 		branchToPR[pr.HeadRefName] = pr
+		numberToPR[pr.Number] = pr
 	}
 
 	type mergeCandidate struct {
@@ -1407,12 +1422,16 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	ready := make([]mergeCandidate, 0)
 
 	for slotName, sess := range s.Sessions {
-		if sess.Status != state.StatusPROpen && sess.Status != state.StatusQueued {
+		if !mergeFlowEligibleStatus(sess) {
 			continue
 		}
 
-		pr, found := branchToPR[sess.Branch]
+		pr, found := mergeFlowPRForSession(sess, branchToPR, numberToPR)
 		if !found {
+			if sess.Status == state.StatusRetryExhausted {
+				log.Printf("[orch] retry_exhausted session %s records PR #%d, but no open PR was found — waiting for reconciliation", slotName, sess.PRNumber)
+				continue
+			}
 			log.Printf("[orch] no open PR found for branch %s (slot %s) — assuming merged/closed", sess.Branch, slotName)
 			sess.Status = state.StatusDone
 			now := time.Now().UTC()
@@ -1523,6 +1542,37 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	if len(ready) > 1 {
 		log.Printf("[orch] sequential merge mode: deferring %d additional ready PR(s) to next cycle", len(ready)-1)
 	}
+}
+
+func mergeFlowEligibleStatus(sess *state.Session) bool {
+	if sess == nil {
+		return false
+	}
+	switch sess.Status {
+	case state.StatusPROpen, state.StatusQueued:
+		return true
+	case state.StatusRetryExhausted:
+		return sess.PRNumber > 0 || strings.TrimSpace(sess.Branch) != ""
+	default:
+		return false
+	}
+}
+
+func mergeFlowPRForSession(sess *state.Session, byBranch map[string]github.PR, byNumber map[int]github.PR) (github.PR, bool) {
+	if sess == nil {
+		return github.PR{}, false
+	}
+	if sess.PRNumber > 0 {
+		if pr, ok := byNumber[sess.PRNumber]; ok {
+			return pr, true
+		}
+	}
+	if strings.TrimSpace(sess.Branch) != "" {
+		if pr, ok := byBranch[sess.Branch]; ok {
+			return pr, true
+		}
+	}
+	return github.PR{}, false
 }
 
 // handleReviewFeedbackRetry schedules a retry worker with review feedback in

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1192,6 +1192,114 @@ func TestAutoMergePRs_ReviewFeedbackRetryLimitMarksTerminal(t *testing.T) {
 	}
 }
 
+func TestAutoMergePRs_RetryExhaustedGreenPRNoFeedbackMerges(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a", Mergeable: "MERGEABLE"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "parallel",
+		ReviewGate:              "none",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	merged := make([]int, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "", nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = append(merged, prNumber)
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber:        100,
+		IssueTitle:         "green after retry exhaustion",
+		Branch:             "feat/a",
+		Status:             state.StatusRetryExhausted,
+		PRNumber:           10,
+		RetryCount:         3,
+		LastNotifiedStatus: "review_retry_exhausted",
+	}
+
+	o.autoMergePRs(s)
+
+	if len(merged) != 1 || merged[0] != 10 {
+		t.Fatalf("merged = %v, want [10]", merged)
+	}
+	sess := s.Sessions["slot-0"]
+	if sess.Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
+	}
+}
+
+func TestAutoMergePRs_RetryExhaustedActionableFeedbackStillBlocks(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a", Mergeable: "MERGEABLE"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "parallel",
+		ReviewGate:              "none",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	merged := make([]int, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "## Review Feedback\n\ninternal/foo.go:42 P1: nil pointer panic", nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = append(merged, prNumber)
+			return nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "green with current-head comments",
+		Branch:      "feat/a",
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    10,
+		RetryCount:  3,
+	}
+
+	o.autoMergePRs(s)
+
+	if len(merged) != 0 {
+		t.Fatalf("actionable review feedback should block merge, got merged=%v", merged)
+	}
+	sess := s.Sessions["slot-0"]
+	if sess.Status != state.StatusRetryExhausted {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRetryExhausted)
+	}
+	if sess.LastNotifiedStatus != "review_retry_exhausted" {
+		t.Fatalf("LastNotifiedStatus = %q, want review_retry_exhausted", sess.LastNotifiedStatus)
+	}
+}
+
 func TestAutoMergePRs_CIFailureBlocksMerge(t *testing.T) {
 	prs := []github.PR{
 		{Number: 10, HeadRefName: "feat/a"},
@@ -2970,6 +3078,76 @@ func TestCheckSessions_DeadClosedIssue_TransitionsToDone(t *testing.T) {
 	o.checkSessions(s)
 
 	sess := s.Sessions["pan-11"]
+	if sess.Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
+	}
+}
+
+func TestCheckSessions_RetryExhaustedClosedIssue_TransitionsToDone(t *testing.T) {
+	now := time.Now().UTC()
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", MaxRuntimeMinutes: 120},
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return true, nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["pan-12"] = &state.Session{
+		IssueNumber: 102,
+		IssueTitle:  "retry exhausted but closed",
+		Status:      state.StatusRetryExhausted,
+		Branch:      "feat/pan-12-102-retry",
+		FinishedAt:  &now,
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["pan-12"]
+	if sess.Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
+	}
+}
+
+func TestCheckSessions_RetryExhaustedMergedPR_TransitionsToDone(t *testing.T) {
+	now := time.Now().UTC()
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", MaxRuntimeMinutes: 120},
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isPRMergedFn: func(prNumber int) (bool, error) {
+			return prNumber == 77, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["pan-13"] = &state.Session{
+		IssueNumber: 103,
+		IssueTitle:  "retry exhausted but merged",
+		Status:      state.StatusRetryExhausted,
+		Branch:      "feat/pan-13-103-retry",
+		PRNumber:    77,
+		FinishedAt:  &now,
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["pan-13"]
 	if sess.Status != state.StatusDone {
 		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -438,7 +438,7 @@ func sessionStatusReason(sess *state.Session, alive *bool) (string, bool) {
 		return "Worker exited and is waiting for retry or reconciliation.", true
 	case state.StatusRetryExhausted:
 		if sess.PRNumber > 0 {
-			return "Retry limit exhausted with a PR still open; inspect review feedback or increase the retry budget.", true
+			return "Retry limit exhausted with a PR still open; Maestro can still merge it when checks and review gates pass, but action is needed if checks fail or actionable review feedback remains.", true
 		}
 		return "Retry limit exhausted before a usable PR was produced.", true
 	case state.StatusFailed:

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -182,12 +182,20 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false)
 
 	if slot, sess, pr, ok := sessionWithOpenPR(st, prs); ok {
+		summary := fmt.Sprintf("Session %s already has open PR #%d; monitor review, CI, or merge readiness.", slot, pr.Number)
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Session %s is associated with open PR #%d", slot, pr.Number),
 			"No GitHub mutation is needed for supervisor mode",
 		)
+		if sess.Status == state.StatusRetryExhausted {
+			summary = fmt.Sprintf("Issue #%d is retry exhausted, but PR #%d is still open; monitor checks and review, then merge when eligible.", sess.IssueNumber, pr.Number)
+			reasons = appendReasons(reasons,
+				fmt.Sprintf("Session %s is retry_exhausted but still has open PR #%d", slot, pr.Number),
+				"Retry exhaustion does not block normal PR merge flow when checks and review gates pass",
+			)
+		}
 		decision := e.decision(now, projectState, ActionMonitorOpenPR,
-			fmt.Sprintf("Session %s already has open PR #%d; monitor review, CI, or merge readiness.", slot, pr.Number),
+			summary,
 			RiskSafe, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
 		decision.StuckStates = stuckStates
 		return decision, nil
@@ -434,7 +442,7 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time) []state
 			}
 		}
 
-		if sess.Status == state.StatusRetryExhausted {
+		if sess.Status == state.StatusRetryExhausted && sess.PRNumber == 0 {
 			findings = append(findings, stuckState("retry_exhausted", SeverityBlocked,
 				fmt.Sprintf("Issue #%d exhausted its retry budget.", sess.IssueNumber),
 				"Review the failed attempts, adjust the issue or retry budget, then restart intentionally.", false, target,
@@ -522,6 +530,29 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR) []state.S
 		}
 
 		ciStatus := ciStatuses[pr.Number]
+		if sess.Status == state.StatusRetryExhausted {
+			checks := ciStatus
+			if checks == "" {
+				checks = "unknown"
+			}
+			severity := SeverityWarning
+			recommended := "Refresh the PR status; if checks and review gates pass, the PR remains eligible for normal merge flow."
+			switch checks {
+			case "success":
+				severity = SeverityInfo
+				recommended = "No retry is needed if review gates pass; keep the PR in normal merge flow."
+			case "pending":
+				severity = SeverityInfo
+				recommended = "Wait for checks to finish; if they pass and no actionable review feedback remains, merge normally."
+			case "failure":
+				severity = SeverityBlocked
+				recommended = "Fix failing checks or retry intentionally before this PR can merge."
+			}
+			findings = append(findings, stuckState("retry_exhausted_open_pr", severity,
+				fmt.Sprintf("Issue #%d is retry exhausted, but PR #%d is still open; checks=%s.", sess.IssueNumber, pr.Number, checks),
+				recommended, true, target,
+				fmt.Sprintf("Session %s status=retry_exhausted pr=%d checks=%s", slot, pr.Number, checks)))
+		}
 		if ciStatus == "failure" {
 			findings = append(findings, stuckState("failing_checks", SeverityBlocked,
 				fmt.Sprintf("PR #%d has failing checks.", pr.Number),

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -252,6 +252,43 @@ func TestDecide_RetryExhaustedNeedsReview(t *testing.T) {
 	}
 }
 
+func TestDecide_RetryExhaustedOpenGreenPRExplainsMergeEligibility(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 88, HeadRefName: "feat/retry-green", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{88: "success"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-2"] = &state.Session{
+		IssueNumber: 77,
+		IssueTitle:  "green work",
+		Status:      state.StatusRetryExhausted,
+		Branch:      "feat/retry-green",
+		PRNumber:    88,
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionMonitorOpenPR)
+	}
+	if !strings.Contains(strings.ToLower(decision.Summary), "retry exhausted") || !strings.Contains(strings.ToLower(decision.Summary), "merge") {
+		t.Fatalf("summary = %q, want retry exhausted merge eligibility", decision.Summary)
+	}
+	stuck := requireStuckState(t, decision, "retry_exhausted_open_pr")
+	if stuck.Severity != SeverityInfo {
+		t.Errorf("severity = %q, want %q", stuck.Severity, SeverityInfo)
+	}
+	if !strings.Contains(strings.Join(stuck.Evidence, "\n"), "checks=success") {
+		t.Fatalf("evidence = %#v, want checks=success", stuck.Evidence)
+	}
+}
+
 func TestDecide_DeadRunningPIDExplained(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{}


### PR DESCRIPTION
Closes #278

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR allows `retry_exhausted` sessions that still have an open PR to re-enter the normal merge flow: if CI is green and no actionable review feedback remains, the PR is merged automatically; if actionable feedback is still present, merge is blocked. The supervisor and server status-reason messages are also updated to reflect the new behavior.

- **P1 — notification spam**: in `autoMergePRs`, `sess.LastNotifiedStatus` is unconditionally reset to `\"\"` at the top of the `\"success\"` CI branch (line 1458), before `handleReviewFeedbackRetry` is called. For a `retry_exhausted` session where review feedback persists, this causes the \"💀 retry limit exhausted\" notification to fire on every orchestrator cycle instead of just once. `sess.FinishedAt` is also overwritten each cycle.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without addressing the notification-spam regression for retry-exhausted sessions with remaining review feedback.

A single P1 defect (repeated notifications and FinishedAt churn on every orchestrator tick) warrants a score below the P1 ceiling. The core merge-recovery logic is correct and well-tested, but the existing test only runs one cycle and misses the regression.

internal/orchestrator/orchestrator.go — the "success" CI branch in autoMergePRs unconditionally clears LastNotifiedStatus before calling handleReviewFeedbackRetry.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds retry_exhausted to the merge flow via mergeFlowEligibleStatus/mergeFlowPRForSession; zombie cleanup now also triggers on merged PRs. Contains a notification-spam bug: LastNotifiedStatus is unconditionally cleared on every "success" CI tick, causing handleReviewFeedbackRetry to re-fire the exhausted notification each cycle. |
| internal/github/github.go | Introduces isActionableReviewComment / isActionableReviewSummary heuristics to filter non-actionable review noise; adds "not safe to merge" / "unsafe to merge" blocking in comment-fallback path; extends hasGreptileInlineCommentOnHead to use the existing isHighSeverity filter. Logic appears correct. |
| internal/orchestrator/orchestrator_test.go | Adds four new test cases covering the retry-exhausted merge and blocking paths; tests are well-structured but the blocking-feedback test only runs one cycle and therefore does not expose the notification-spam regression. |
| internal/github/github_test.go | New unit tests for isActionableReviewComment and isActionableReviewSummary cover the Codex-wrapper and concrete-finding cases correctly. |
| internal/supervisor/supervisor.go | retry_exhausted sessions with an open PR are now emitted as retry_exhausted_open_pr stuck states with severity scaled to CI status; the stuck-state entry for retry_exhausted without a PR is preserved. Changes look correct. |
| internal/supervisor/supervisor_test.go | New test for the green retry-exhausted open-PR path verifies ActionMonitorOpenPR decision and SeverityInfo stuck state; correct. |
| internal/server/server.go | Status-reason string for retry_exhausted with an open PR updated to reflect that automatic merge is still possible. Cosmetic change only. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 1456-1470 ([link](https://github.com/befeast/maestro/blob/b4764c7aab4571f943b02c452224833e11559aa8/internal/orchestrator/orchestrator.go#L1456-L1470)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Notification spam for retry-exhausted sessions with actionable feedback**

   When `sess.Status == StatusRetryExhausted` and CI is green with review feedback still present, `sess.LastNotifiedStatus` is unconditionally reset to `""` (line 1458) before `handleReviewFeedbackRetry` is called. Inside that function, `totalAttempts >= maxRetries` triggers the "💀 retry limit exhausted" notification and sets `LastNotifiedStatus = "review_retry_exhausted"`. On the next orchestrator cycle the same session re-enters, `LastNotifiedStatus` is cleared again, and the notification fires once more — repeating on every tick. `sess.FinishedAt` is also overwritten each cycle.

   Guard the reset so it only clears CI-related notification state:

   ```go
   case "success":
       // Reset notification status when CI goes green, but do not clobber
       // review_retry_exhausted — that guard is only cleared if feedback resolves.
       if sess.LastNotifiedStatus != "review_retry_exhausted" {
           sess.LastNotifiedStatus = ""
       }
       sess.NotifiedCIFail = false
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 1456-1470

   Comment:
   **Notification spam for retry-exhausted sessions with actionable feedback**

   When `sess.Status == StatusRetryExhausted` and CI is green with review feedback still present, `sess.LastNotifiedStatus` is unconditionally reset to `""` (line 1458) before `handleReviewFeedbackRetry` is called. Inside that function, `totalAttempts >= maxRetries` triggers the "💀 retry limit exhausted" notification and sets `LastNotifiedStatus = "review_retry_exhausted"`. On the next orchestrator cycle the same session re-enters, `LastNotifiedStatus` is cleared again, and the notification fires once more — repeating on every tick. `sess.FinishedAt` is also overwritten each cycle.

   Guard the reset so it only clears CI-related notification state:

   ```go
   case "success":
       // Reset notification status when CI goes green, but do not clobber
       // review_retry_exhausted — that guard is only cleared if feedback resolves.
       if sess.LastNotifiedStatus != "review_retry_exhausted" {
           sess.LastNotifiedStatus = ""
       }
       sess.NotifiedCIFail = false
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/orchestrator/orchestrator.go
Line: 1456-1470

Comment:
**Notification spam for retry-exhausted sessions with actionable feedback**

When `sess.Status == StatusRetryExhausted` and CI is green with review feedback still present, `sess.LastNotifiedStatus` is unconditionally reset to `""` (line 1458) before `handleReviewFeedbackRetry` is called. Inside that function, `totalAttempts >= maxRetries` triggers the "💀 retry limit exhausted" notification and sets `LastNotifiedStatus = "review_retry_exhausted"`. On the next orchestrator cycle the same session re-enters, `LastNotifiedStatus` is cleared again, and the notification fires once more — repeating on every tick. `sess.FinishedAt` is also overwritten each cycle.

Guard the reset so it only clears CI-related notification state:

```go
case "success":
    // Reset notification status when CI goes green, but do not clobber
    // review_retry_exhausted — that guard is only cleared if feedback resolves.
    if sess.LastNotifiedStatus != "review_retry_exhausted" {
        sess.LastNotifiedStatus = ""
    }
    sess.NotifiedCIFail = false
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: recover retry-exhausted green PRs"](https://github.com/befeast/maestro/commit/b4764c7aab4571f943b02c452224833e11559aa8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30253388)</sub>

<!-- /greptile_comment -->