### PR TITLE
Dynamic wave policy for supervisor issue selection

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -500,6 +500,9 @@ func printSupervisorDecision(decision state.SupervisorDecision, jsonOutput bool)
 			fmt.Printf("  - %s\n", reason)
 		}
 	}
+	if decision.QueueAnalysis != nil {
+		printQueueAnalysis(decision.QueueAnalysis, "")
+	}
 	if len(decision.Mutations) > 0 {
 		fmt.Println("Mutations:")
 		for _, mutation := range decision.Mutations {
@@ -529,6 +532,26 @@ func printSupervisorDecision(decision state.SupervisorDecision, jsonOutput bool)
 		}
 	}
 	fmt.Printf("Recorded: %s\n", decision.CreatedAt.Format(time.RFC3339))
+}
+
+func printQueueAnalysis(analysis *state.SupervisorQueueAnalysis, indent string) {
+	if analysis == nil {
+		return
+	}
+	fmt.Printf("%sQueue: open=%d eligible=%d excluded=%d non_runnable_project_status=%d\n", indent, analysis.OpenIssues, analysis.EligibleCandidates, analysis.ExcludedIssues, analysis.NonRunnableProjectStatusCount)
+	if analysis.SelectedCandidate != nil {
+		fmt.Printf("%sSelected candidate: issue #%d", indent, analysis.SelectedCandidate.Number)
+		if analysis.SelectedCandidate.PriorityLabel != "" {
+			fmt.Printf(" priority=%s", analysis.SelectedCandidate.PriorityLabel)
+		}
+		if analysis.SelectedCandidate.ProjectStatus != "" {
+			fmt.Printf(" project_status=%q", analysis.SelectedCandidate.ProjectStatus)
+		}
+		fmt.Println()
+	}
+	for _, reason := range analysis.SkippedReasons {
+		fmt.Printf("%sSkipped: %s\n", indent, reason)
+	}
 }
 
 func supervisorTargetParts(target *state.SupervisorTarget) []string {
@@ -962,6 +985,9 @@ func showLatestSupervisorDecision(s *state.State) {
 		if len(parts) > 0 {
 			fmt.Printf("  Target: %s\n", strings.Join(parts, ", "))
 		}
+	}
+	if decision.QueueAnalysis != nil {
+		printQueueAnalysis(decision.QueueAnalysis, "  ")
 	}
 	if len(decision.StuckStates) > 0 {
 		fmt.Printf("  Stuck states: %d", len(decision.StuckStates))

--- a/docs/PRD-gh-project-integration.md
+++ b/docs/PRD-gh-project-integration.md
@@ -114,7 +114,7 @@ It may still expose issue reads, but tracker-facing selection and workflow state
 
 ## Config Design
 
-Supervisor policy is a separate local safety layer from tracker configuration. It may be set in the top-level `supervisor:` block or in `.maestro/supervisor.yaml`, and covers queue order, ready/blocked labels, excluded issue types, safe actions, and approval-gated actions.
+Supervisor policy is a separate local safety layer from tracker configuration. It may be set in the top-level `supervisor:` block or in `.maestro/supervisor.yaml`, and covers queue order, dynamic wave selection, ready/blocked labels, excluded issue types, safe actions, and approval-gated actions.
 
 Add a new top-level block:
 

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -155,8 +155,12 @@ supervisor:
     issues:
       - 308
       - 306
+  dynamic_wave:
+    enabled: true
+    owns_ready_label: true
   safe_actions:
     - add_ready_label
+    - remove_ready_label
     - remove_blocked_label
     - add_issue_comment
   approval_required:
@@ -200,7 +204,7 @@ telegram:
 | `session_prefix` | Prefix for tmux session names |
 | `worker_prompt` | Path to the worker prompt template file |
 
-Supervisor policy can also live in `.maestro/supervisor.yaml` next to the project config or repository checkout. If an ordered queue is configured, only the first unfinished issue in that queue is eligible for supervisor dispatch.
+Supervisor policy can also live in `.maestro/supervisor.yaml` next to the project config or repository checkout. If an ordered queue is configured, only the first unfinished issue in that queue is eligible for supervisor dispatch until the queue is exhausted. `dynamic_wave` lets the supervisor select the next runnable open issue without listing issue numbers, using priority labels and conservative skip rules.
 
 ### Optional: versioning config
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type GitHubProjectsConfig struct {
 
 const (
 	SupervisorActionAddReadyLabel      = "add_ready_label"
+	SupervisorActionRemoveReadyLabel   = "remove_ready_label"
 	SupervisorActionRemoveBlockedLabel = "remove_blocked_label"
 	SupervisorActionAddIssueComment    = "add_issue_comment"
 	SupervisorActionMergePR            = "merge_pr"
@@ -73,6 +74,7 @@ type SupervisorConfig struct {
 	ExcludedLabels          []string                     `yaml:"excluded_labels" json:"excluded_labels,omitempty"`
 	AllowIssueTypes         []string                     `yaml:"allow_issue_types" json:"allow_issue_types,omitempty"`
 	OrderedQueue            SupervisorOrderedQueueConfig `yaml:"ordered_queue" json:"ordered_queue,omitempty"`
+	DynamicWave             SupervisorDynamicWaveConfig  `yaml:"dynamic_wave" json:"dynamic_wave,omitempty"`
 	SafeActions             []string                     `yaml:"safe_actions" json:"safe_actions,omitempty"`
 	ApprovalRequired        []string                     `yaml:"approval_required" json:"approval_required,omitempty"`
 	AllowedActions          []string                     `yaml:"allowed_actions" json:"allowed_actions,omitempty"`
@@ -87,6 +89,17 @@ type SupervisorOrderedQueueConfig struct {
 	Enabled    bool  `yaml:"enabled" json:"enabled"`
 	Issues     []int `yaml:"issues" json:"issues,omitempty"`
 	DoneIssues []int `yaml:"done_issues" json:"done_issues,omitempty"`
+}
+
+// SupervisorDynamicWaveConfig enables policy-driven issue selection without a
+// fixed issue-number list.
+type SupervisorDynamicWaveConfig struct {
+	Enabled        *bool `yaml:"enabled" json:"enabled,omitempty"`
+	OwnsReadyLabel bool  `yaml:"owns_ready_label" json:"owns_ready_label,omitempty"`
+}
+
+func (w SupervisorDynamicWaveConfig) Active() bool {
+	return w.Enabled == nil || *w.Enabled
 }
 
 func (q SupervisorOrderedQueueConfig) Active() bool {
@@ -675,6 +688,7 @@ func validateSupervisorActions(field string, actions []string) error {
 func knownSupervisorActions() map[string]bool {
 	return map[string]bool{
 		SupervisorActionAddReadyLabel:      true,
+		SupervisorActionRemoveReadyLabel:   true,
 		SupervisorActionRemoveBlockedLabel: true,
 		SupervisorActionAddIssueComment:    true,
 		SupervisorActionMergePR:            true,
@@ -687,6 +701,7 @@ func knownSupervisorActions() map[string]bool {
 func knownSupervisorActionNames() []string {
 	return []string{
 		SupervisorActionAddReadyLabel,
+		SupervisorActionRemoveReadyLabel,
 		SupervisorActionRemoveBlockedLabel,
 		SupervisorActionAddIssueComment,
 		SupervisorActionMergePR,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,6 +104,36 @@ supervisor:
 	}
 }
 
+func TestParse_SupervisorDynamicWaveWithoutOrderedQueue(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  ready_label: maestro-ready
+  dynamic_wave:
+    enabled: true
+    owns_ready_label: true
+  safe_actions:
+    - add_ready_label
+    - remove_ready_label
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Supervisor.OrderedQueue.Active() {
+		t.Fatal("OrderedQueue should not be active")
+	}
+	if !cfg.Supervisor.DynamicWave.Active() {
+		t.Fatal("DynamicWave should be active")
+	}
+	if !cfg.Supervisor.DynamicWave.OwnsReadyLabel {
+		t.Fatal("DynamicWave should own the ready label")
+	}
+	if cfg.Supervisor.ReadyLabel != "maestro-ready" {
+		t.Fatalf("ReadyLabel = %q, want maestro-ready", cfg.Supervisor.ReadyLabel)
+	}
+}
+
 func TestParse_AutoRestoreFiles(t *testing.T) {
 	yaml := `
 repo: owner/repo

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -33,6 +33,17 @@ type Issue struct {
 	Labels []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
+	ProjectItems []IssueProjectItem `json:"projectItems,omitempty"`
+}
+
+type IssueProjectItem struct {
+	Title  string                  `json:"title,omitempty"`
+	Status *IssueProjectItemStatus `json:"status,omitempty"`
+}
+
+type IssueProjectItemStatus struct {
+	Name     string `json:"name,omitempty"`
+	OptionID string `json:"optionId,omitempty"`
 }
 
 type PR struct {
@@ -87,7 +98,7 @@ func (c *Client) listOpenIssuesByLabel(label string) ([]Issue, error) {
 		"issue", "list",
 		"--repo", c.Repo,
 		"--state", "open",
-		"--json", "number,title,body,labels",
+		"--json", "number,title,body,labels,projectItems",
 		"--limit", "100",
 	}
 	if label != "" {
@@ -110,7 +121,7 @@ func (c *Client) listOpenIssuesByLabel(label string) ([]Issue, error) {
 func (c *Client) GetIssue(number int) (Issue, error) {
 	out, err := exec.Command("gh", "issue", "view", fmt.Sprint(number),
 		"--repo", c.Repo,
-		"--json", "number,title,body,labels").Output()
+		"--json", "number,title,body,labels,projectItems").Output()
 	if err != nil {
 		return Issue{}, fmt.Errorf("gh issue view %d: %w", number, err)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -128,6 +128,28 @@ type SupervisorProjectState struct {
 	AvailableSlots int `json:"available_slots"`
 }
 
+// SupervisorIssueCandidate describes the issue selected by queue policy without
+// exposing issue body content in persisted supervisor state.
+type SupervisorIssueCandidate struct {
+	Number        int      `json:"number"`
+	Title         string   `json:"title,omitempty"`
+	Labels        []string `json:"labels,omitempty"`
+	PriorityLabel string   `json:"priority_label,omitempty"`
+	ProjectStatus string   `json:"project_status,omitempty"`
+}
+
+// SupervisorQueueAnalysis captures explainable issue-selection counts for
+// Mission Control and --json output.
+type SupervisorQueueAnalysis struct {
+	PolicyRule                    string                    `json:"policy_rule,omitempty"`
+	OpenIssues                    int                       `json:"open_issues"`
+	EligibleCandidates            int                       `json:"eligible_candidates"`
+	ExcludedIssues                int                       `json:"excluded_issues"`
+	NonRunnableProjectStatusCount int                       `json:"non_runnable_project_status_count"`
+	SelectedCandidate             *SupervisorIssueCandidate `json:"selected_candidate,omitempty"`
+	SkippedReasons                []string                  `json:"skipped_reasons,omitempty"`
+}
+
 // SupervisorMutation records one durable GitHub mutation planned or attempted by
 // the supervisor queue action loop.
 type SupervisorMutation struct {
@@ -151,24 +173,25 @@ type SupervisorStuckState struct {
 
 // SupervisorDecision is a stable, machine-readable supervisor orchestration record.
 type SupervisorDecision struct {
-	ID                string                 `json:"id"`
-	CreatedAt         time.Time              `json:"created_at"`
-	Project           string                 `json:"project"`
-	Mode              string                 `json:"mode"`
-	PolicyRule        string                 `json:"policy_rule,omitempty"`
-	Status            string                 `json:"status,omitempty"`
-	Summary           string                 `json:"summary"`
-	RecommendedAction string                 `json:"recommended_action"`
-	Target            *SupervisorTarget      `json:"target,omitempty"`
-	Risk              string                 `json:"risk"`
-	Confidence        float64                `json:"confidence"`
-	ErrorClass        string                 `json:"error_class,omitempty"`
-	Reasons           []string               `json:"reasons,omitempty"`
-	RequiresApproval  bool                   `json:"requires_approval"`
-	Mutations         []SupervisorMutation   `json:"mutations,omitempty"`
-	StuckStates       []SupervisorStuckState `json:"stuck_states,omitempty"`
-	ProjectState      SupervisorProjectState `json:"project_state"`
-	ApprovalID        string                 `json:"approval_id,omitempty"`
+	ID                string                   `json:"id"`
+	CreatedAt         time.Time                `json:"created_at"`
+	Project           string                   `json:"project"`
+	Mode              string                   `json:"mode"`
+	PolicyRule        string                   `json:"policy_rule,omitempty"`
+	Status            string                   `json:"status,omitempty"`
+	Summary           string                   `json:"summary"`
+	RecommendedAction string                   `json:"recommended_action"`
+	Target            *SupervisorTarget        `json:"target,omitempty"`
+	Risk              string                   `json:"risk"`
+	Confidence        float64                  `json:"confidence"`
+	ErrorClass        string                   `json:"error_class,omitempty"`
+	Reasons           []string                 `json:"reasons,omitempty"`
+	RequiresApproval  bool                     `json:"requires_approval"`
+	Mutations         []SupervisorMutation     `json:"mutations,omitempty"`
+	StuckStates       []SupervisorStuckState   `json:"stuck_states,omitempty"`
+	ProjectState      SupervisorProjectState   `json:"project_state"`
+	QueueAnalysis     *SupervisorQueueAnalysis `json:"queue_analysis,omitempty"`
+	ApprovalID        string                   `json:"approval_id,omitempty"`
 }
 
 type ApprovalStatus string

--- a/internal/supervisor/packet.go
+++ b/internal/supervisor/packet.go
@@ -79,11 +79,12 @@ type supervisorSessionPacket struct {
 }
 
 type supervisorIssuePacket struct {
-	Position    int      `json:"position"`
-	Number      int      `json:"number"`
-	Title       string   `json:"title"`
-	Labels      []string `json:"labels,omitempty"`
-	BodyExcerpt string   `json:"body_excerpt,omitempty"`
+	Position      int      `json:"position"`
+	Number        int      `json:"number"`
+	Title         string   `json:"title"`
+	Labels        []string `json:"labels,omitempty"`
+	ProjectStatus string   `json:"project_status,omitempty"`
+	BodyExcerpt   string   `json:"body_excerpt,omitempty"`
 }
 
 type supervisorGitHubPacket struct {
@@ -223,11 +224,12 @@ func issuePackets(issues []github.Issue) []supervisorIssuePacket {
 	packets := make([]supervisorIssuePacket, 0, len(issues))
 	for i, issue := range issues {
 		packets = append(packets, supervisorIssuePacket{
-			Position:    i + 1,
-			Number:      issue.Number,
-			Title:       RedactSensitive(issue.Title),
-			Labels:      issueLabelNames(issue),
-			BodyExcerpt: truncateText(RedactSensitive(issue.Body), supervisorIssueBodyLimit),
+			Position:      i + 1,
+			Number:        issue.Number,
+			Title:         RedactSensitive(issue.Title),
+			Labels:        issueLabelNames(issue),
+			ProjectStatus: firstProjectStatus(issue),
+			BodyExcerpt:   truncateText(RedactSensitive(issue.Body), supervisorIssueBodyLimit),
 		})
 	}
 	return packets

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -37,6 +37,7 @@ const (
 	PolicyRuleOpenIssues     = "open_issues"
 	PolicyRuleIssueLabels    = "issue_labels"
 	PolicyRuleOrderedQueue   = "supervisor.ordered_queue"
+	PolicyRuleDynamicWave    = "supervisor.dynamic_wave"
 	PolicyRuleExcludedLabels = "supervisor.excluded_labels"
 
 	DecisionStatusRecommended = "recommended"
@@ -44,6 +45,7 @@ const (
 	DecisionStatusFailed      = "failed"
 
 	MutationAddReadyLabel      = "add_ready_label"
+	MutationRemoveReadyLabel   = "remove_ready_label"
 	MutationRemoveBlockedLabel = "remove_blocked_label"
 	MutationIssueComment       = config.SupervisorActionAddIssueComment
 
@@ -231,10 +233,16 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	}
 	projectState.OpenIssues = len(issues)
 
-	candidates, policySkipped, policyRule, err := e.policyCandidateIssues(st, issues)
+	policyResult, err := e.policyCandidateIssues(st, issues)
 	if err != nil {
 		return state.SupervisorDecision{}, err
 	}
+	if policyResult.dynamicWave {
+		return e.decideDynamicWave(st, now, projectState, baseReasons, prs, issues, policyResult)
+	}
+	candidates := policyResult.candidates
+	policySkipped := policyResult.skipped
+	policyRule := policyResult.policyRule
 	eligible, skipped, err := e.eligibleIssues(st, candidates, true)
 	if err != nil {
 		return state.SupervisorDecision{}, err
@@ -361,6 +369,106 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		"No action is currently recommended.", RiskSafe, 0.8, nil, policyRule, reasons)
 	decision.StuckStates = stuckStates
 	return decision, nil
+}
+
+func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState state.SupervisorProjectState, baseReasons []string, prs []github.PR, issues []github.Issue, result policyCandidateResult) (state.SupervisorDecision, error) {
+	candidates := result.candidates
+	analysis := result.analysis
+	if analysis == nil {
+		analysis = &state.SupervisorQueueAnalysis{PolicyRule: PolicyRuleDynamicWave, OpenIssues: len(issues), EligibleCandidates: len(candidates), SkippedReasons: firstN(result.skipped, 5)}
+		if len(candidates) > 0 {
+			analysis.SelectedCandidate = supervisorIssueCandidate(candidates[0])
+		}
+	}
+	stuckStates := e.detectStuckStates(st, now, prs, issues, candidates, result.skipped, true)
+	withAnalysis := func(decision state.SupervisorDecision) state.SupervisorDecision {
+		decision.QueueAnalysis = analysis
+		decision.StuckStates = stuckStates
+		return decision
+	}
+
+	if len(candidates) == 0 {
+		reasons := appendReasons(baseReasons,
+			fmt.Sprintf("Dynamic wave checked %d open issue(s)", len(issues)),
+			fmt.Sprintf("Dynamic wave found %d eligible candidate(s), %d excluded issue(s), and %d issue(s) in non-runnable project status", analysis.EligibleCandidates, analysis.ExcludedIssues, analysis.NonRunnableProjectStatusCount),
+		)
+		for _, reason := range firstN(result.skipped, 3) {
+			reasons = append(reasons, reason)
+		}
+		decision := e.decision(now, projectState, ActionNone,
+			"No issue is currently eligible under the dynamic wave policy.", RiskSafe, 0.8, nil, PolicyRuleDynamicWave, reasons)
+		return withAnalysis(decision), nil
+	}
+
+	issue := candidates[0]
+	if projectState.AvailableSlots <= 0 {
+		reasons := appendReasons(baseReasons,
+			fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
+			fmt.Sprintf("Issue #%d is eligible but no worker slot is available", issue.Number),
+		)
+		decision := e.decision(now, projectState, ActionWaitForCapacity,
+			fmt.Sprintf("Issue #%d is eligible, but all worker slots are occupied.", issue.Number),
+			RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+		return withAnalysis(decision), nil
+	}
+
+	hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number)
+	if err != nil {
+		return state.SupervisorDecision{}, fmt.Errorf("check open PR for issue #%d: %w", issue.Number, err)
+	}
+	if hasOpenPR {
+		reasons := appendReasons(baseReasons,
+			fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
+			fmt.Sprintf("Issue #%d already has an open PR", issue.Number),
+			"Supervisor mode should not dispatch duplicate work",
+		)
+		decision := e.decision(now, projectState, ActionMonitorOpenPR,
+			fmt.Sprintf("Issue #%d already has an open PR; monitor that PR instead of starting work.", issue.Number),
+			RiskSafe, 0.87, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+		return withAnalysis(decision), nil
+	}
+
+	queueCandidate := e.dynamicQueueActionCandidate(st, issue, issues)
+	if queueCandidate != nil {
+		mutations := queueCandidate.plannedMutations(e.cfg)
+		reasons := appendReasons(baseReasons,
+			queueLabelReason(queueCandidate.readyLabel, ""),
+			fmt.Sprintf("Dynamic wave selected issue #%d by priority and issue number", issue.Number),
+		)
+		risk := RiskMutating
+		if len(mutations) > 0 {
+			risk = RiskSafe
+			reasons = appendReasons(reasons, "Supervisor policy allows the planned safe queue mutation")
+		}
+		decision := e.decision(now, projectState, ActionLabelIssueReady,
+			fmt.Sprintf("Prepare issue #%d for the dynamic wave by %s.", issue.Number, plannedMutationPhrase(queueCandidate.neededMutations())),
+			risk, 0.82, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+		decision.Mutations = mutations
+		return withAnalysis(decision), nil
+	}
+
+	if !matchesRequiredLabels(issue, e.requiredIssueLabels()) {
+		reasons := appendReasons(baseReasons,
+			fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
+			"Selected issue is waiting for a ready label mutation to appear in GitHub issue data",
+		)
+		for _, reason := range firstN(result.skipped, 3) {
+			reasons = append(reasons, reason)
+		}
+		decision := e.decision(now, projectState, ActionNone,
+			"No action is currently recommended while the selected issue waits for its ready label.", RiskSafe, 0.8, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+		return withAnalysis(decision), nil
+	}
+
+	reasons := appendReasons(baseReasons,
+		issueLabelReason(e.requiredIssueLabels()),
+		fmt.Sprintf("Dynamic wave selected issue #%d by priority and issue number", issue.Number),
+		"Starting a worker would mutate local worktrees, so supervisor only records the recommendation",
+	)
+	decision := e.decision(now, projectState, ActionSpawnWorker,
+		fmt.Sprintf("Start a worker for issue #%d: %s", issue.Number, issue.Title),
+		RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+	return withAnalysis(decision), nil
 }
 
 func (e *Engine) decision(now time.Time, ps state.SupervisorProjectState, action, summary, risk string, confidence float64, target *state.SupervisorTarget, policyRule string, reasons []string) state.SupervisorDecision {
@@ -598,7 +706,7 @@ func (e *Engine) detectQueueStuckStates(st *state.State, prs []github.PR, issues
 	}
 
 	missingLabelCount := countSkipped(skipped, "missing configured ready label")
-	excludedCount := countSkipped(skipped, "excluded by configured label")
+	excludedCount := countSkipped(skipped, "excluded by configured label") + countSkipped(skipped, "skipped by dynamic wave policy: excluded")
 	var findings []state.SupervisorStuckState
 
 	if len(e.cfg.IssueLabels) > 0 && missingLabelCount > 0 {
@@ -750,12 +858,31 @@ func (e *Engine) projectState(st *state.State) state.SupervisorProjectState {
 	}
 }
 
-func (e *Engine) policyCandidateIssues(st *state.State, issues []github.Issue) ([]github.Issue, []string, string, error) {
+type policyCandidateResult struct {
+	candidates  []github.Issue
+	skipped     []string
+	policyRule  string
+	dynamicWave bool
+	analysis    *state.SupervisorQueueAnalysis
+}
+
+type dynamicSkipCategory string
+
+const (
+	dynamicSkipOther         dynamicSkipCategory = "other"
+	dynamicSkipExcluded      dynamicSkipCategory = "excluded"
+	dynamicSkipProjectStatus dynamicSkipCategory = "project_status"
+)
+
+func (e *Engine) policyCandidateIssues(st *state.State, issues []github.Issue) (policyCandidateResult, error) {
 	if !e.cfg.Supervisor.OrderedQueueActive() {
-		return issues, nil, e.defaultPolicyRule(), nil
+		if e.cfg.Supervisor.DynamicWave.Active() {
+			return e.dynamicWaveCandidateIssues(st, issues, nil)
+		}
+		return policyCandidateResult{candidates: issues, policyRule: e.defaultPolicyRule()}, nil
 	}
 	if err := validateOrderedQueueIssues(e.cfg.Supervisor.OrderedQueue.Issues); err != nil {
-		return nil, nil, "", err
+		return policyCandidateResult{}, err
 	}
 	issueByNumber := make(map[int]github.Issue, len(issues))
 	for _, issue := range issues {
@@ -765,7 +892,7 @@ func (e *Engine) policyCandidateIssues(st *state.State, issues []github.Issue) (
 	for _, issueNumber := range e.cfg.Supervisor.OrderedQueue.Issues {
 		done, reason, err := e.orderedQueueIssueDone(st, issueNumber)
 		if err != nil {
-			return nil, nil, "", fmt.Errorf("check ordered queue issue #%d: %w", issueNumber, err)
+			return policyCandidateResult{}, fmt.Errorf("check ordered queue issue #%d: %w", issueNumber, err)
 		}
 		if done {
 			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped by supervisor.ordered_queue: %s", issueNumber, reason))
@@ -773,11 +900,98 @@ func (e *Engine) policyCandidateIssues(st *state.State, issues []github.Issue) (
 		}
 		issue, ok := issueByNumber[issueNumber]
 		if !ok {
-			return nil, append(skipped, fmt.Sprintf("Issue #%d is first unfinished in supervisor.ordered_queue but was not returned by open issue listing", issueNumber)), PolicyRuleOrderedQueue, nil
+			return policyCandidateResult{skipped: append(skipped, fmt.Sprintf("Issue #%d is first unfinished in supervisor.ordered_queue but was not returned by open issue listing", issueNumber)), policyRule: PolicyRuleOrderedQueue}, nil
 		}
-		return []github.Issue{issue}, skipped, PolicyRuleOrderedQueue, nil
+		return policyCandidateResult{candidates: []github.Issue{issue}, skipped: skipped, policyRule: PolicyRuleOrderedQueue}, nil
 	}
-	return nil, append(skipped, "No unfinished issue remains in supervisor.ordered_queue"), PolicyRuleOrderedQueue, nil
+	skipped = append(skipped, "No unfinished issue remains in supervisor.ordered_queue")
+	if e.cfg.Supervisor.DynamicWave.Active() {
+		return e.dynamicWaveCandidateIssues(st, issues, skipped)
+	}
+	return policyCandidateResult{skipped: skipped, policyRule: PolicyRuleOrderedQueue}, nil
+}
+
+func (e *Engine) dynamicWaveCandidateIssues(st *state.State, issues []github.Issue, prefixSkipped []string) (policyCandidateResult, error) {
+	skipped := append([]string(nil), prefixSkipped...)
+	analysis := &state.SupervisorQueueAnalysis{
+		PolicyRule: PolicyRuleDynamicWave,
+		OpenIssues: len(issues),
+	}
+
+	candidates := make([]github.Issue, 0, len(issues))
+	for _, issue := range issues {
+		reason, category, err := e.dynamicWaveSkipReason(st, issue)
+		if err != nil {
+			return policyCandidateResult{}, err
+		}
+		if reason != "" {
+			if category == dynamicSkipExcluded {
+				analysis.ExcludedIssues++
+			}
+			if category == dynamicSkipProjectStatus {
+				analysis.NonRunnableProjectStatusCount++
+			}
+			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped by dynamic wave policy: %s", issue.Number, reason))
+			continue
+		}
+		candidates = append(candidates, issue)
+	}
+
+	sortDynamicWaveCandidates(candidates)
+	analysis.EligibleCandidates = len(candidates)
+	if len(candidates) > 0 {
+		analysis.SelectedCandidate = supervisorIssueCandidate(candidates[0])
+	}
+	analysis.SkippedReasons = firstN(skipped, 5)
+
+	return policyCandidateResult{
+		candidates:  candidates,
+		skipped:     skipped,
+		policyRule:  PolicyRuleDynamicWave,
+		dynamicWave: true,
+		analysis:    analysis,
+	}, nil
+}
+
+func (e *Engine) dynamicWaveSkipReason(st *state.State, issue github.Issue) (string, dynamicSkipCategory, error) {
+	if st.IssueInProgress(issue.Number) {
+		return "already in progress", dynamicSkipOther, nil
+	}
+	if st.IssueDone(issue.Number) {
+		return "already completed in state", dynamicSkipOther, nil
+	}
+	if st.IssueRetryExhausted(issue.Number) {
+		return "retry limit exhausted", dynamicSkipOther, nil
+	}
+	if e.cfg.MaxRetriesPerIssue > 0 && st.FailedAttemptsForIssue(issue.Number) >= e.cfg.MaxRetriesPerIssue {
+		return "retry limit exhausted", dynamicSkipOther, nil
+	}
+	if st.IsMissionParent(issue.Number) {
+		return "mission parent issue", dynamicSkipOther, nil
+	}
+	if e.cfg.Missions.Enabled && mission.IsMissionIssue(issue, e.cfg.Missions.Labels) && !st.IsMissionChild(issue.Number) {
+		return "mission issue awaits decomposition", dynamicSkipOther, nil
+	}
+	if titleLooksEpic(issue.Title) {
+		return "title indicates epic", dynamicSkipExcluded, nil
+	}
+	if label, ok := firstMatchingIssueLabel(issue, e.dynamicWaveExcludedLabels()); ok {
+		return fmt.Sprintf("excluded by label %q", label), dynamicSkipExcluded, nil
+	}
+	if status, ok := nonRunnableProjectStatus(issue); ok {
+		return fmt.Sprintf("project status %q is not runnable", status), dynamicSkipProjectStatus, nil
+	}
+	if len(e.cfg.BlockerPatterns) > 0 {
+		blockers := github.FindBlockers(issue.Body, e.cfg.BlockerPatterns)
+		openBlockers, err := e.openBlockers(blockers)
+		if err != nil {
+			return "", dynamicSkipOther, err
+		}
+		if len(openBlockers) > 0 {
+			return fmt.Sprintf("blocked by open issue(s) %s", issueRefs(openBlockers)), dynamicSkipOther, nil
+		}
+	}
+	return "", dynamicSkipOther, nil
 }
 
 func (e *Engine) orderedQueueIssueDone(st *state.State, issueNumber int) (bool, string, error) {
@@ -848,11 +1062,12 @@ func (e *Engine) shouldWaitForRunningWorker(st *state.State) bool {
 }
 
 type queueActionCandidate struct {
-	issue         github.Issue
-	readyLabel    string
-	blockedLabel  string
-	addReady      bool
-	removeBlocked bool
+	issue           github.Issue
+	readyLabel      string
+	blockedLabel    string
+	addReady        bool
+	removeReadyFrom []github.Issue
+	removeBlocked   bool
 }
 
 func (c queueActionCandidate) neededMutations() []state.SupervisorMutation {
@@ -861,6 +1076,14 @@ func (c queueActionCandidate) neededMutations() []state.SupervisorMutation {
 		mutations = append(mutations, state.SupervisorMutation{
 			Type:   MutationAddReadyLabel,
 			Issue:  c.issue.Number,
+			Label:  c.readyLabel,
+			Status: MutationStatusPlanned,
+		})
+	}
+	for _, issue := range c.removeReadyFrom {
+		mutations = append(mutations, state.SupervisorMutation{
+			Type:   MutationRemoveReadyLabel,
+			Issue:  issue.Number,
 			Label:  c.readyLabel,
 			Status: MutationStatusPlanned,
 		})
@@ -880,11 +1103,21 @@ func (c queueActionCandidate) plannedMutations(cfg *config.Config) []state.Super
 	needed := c.neededMutations()
 	mutations := make([]state.SupervisorMutation, 0, len(needed))
 	for _, mutation := range needed {
-		if safeActionAllowed(cfg, mutation.Type) {
+		if queueMutationAllowed(cfg, mutation) {
 			mutations = append(mutations, mutation)
 		}
 	}
 	return mutations
+}
+
+func queueMutationAllowed(cfg *config.Config, mutation state.SupervisorMutation) bool {
+	if safeActionAllowed(cfg, mutation.Type) {
+		return true
+	}
+	return mutation.Type == MutationRemoveReadyLabel &&
+		cfg != nil &&
+		cfg.Supervisor.DynamicWave.OwnsReadyLabel &&
+		safeActionAllowed(cfg, MutationAddReadyLabel)
 }
 
 func safeActionAllowed(cfg *config.Config, action string) bool {
@@ -927,6 +1160,40 @@ func (e *Engine) firstQueueActionCandidate(st *state.State, issues []github.Issu
 		return &candidate, nil
 	}
 	return nil, nil
+}
+
+func (e *Engine) dynamicQueueActionCandidate(st *state.State, selected github.Issue, openIssues []github.Issue) *queueActionCandidate {
+	readyLabel := e.readyLabel()
+	if readyLabel == "" {
+		return nil
+	}
+
+	hasReadyLabel := github.HasLabel(selected, []string{readyLabel})
+	candidate := queueActionCandidate{
+		issue:      selected,
+		readyLabel: readyLabel,
+		addReady:   !hasReadyLabel && !supervisorMutationSucceeded(st, selected.Number, MutationAddReadyLabel, readyLabel),
+	}
+
+	if e.cfg.Supervisor.DynamicWave.OwnsReadyLabel {
+		for _, issue := range openIssues {
+			if issue.Number == selected.Number || !github.HasLabel(issue, []string{readyLabel}) {
+				continue
+			}
+			if supervisorMutationSucceeded(st, issue.Number, MutationRemoveReadyLabel, readyLabel) {
+				continue
+			}
+			candidate.removeReadyFrom = append(candidate.removeReadyFrom, issue)
+		}
+		sort.Slice(candidate.removeReadyFrom, func(i, j int) bool {
+			return candidate.removeReadyFrom[i].Number < candidate.removeReadyFrom[j].Number
+		})
+	}
+
+	if !candidate.addReady && len(candidate.removeReadyFrom) == 0 {
+		return nil
+	}
+	return &candidate
 }
 
 func supervisorMutationSucceeded(st *state.State, issueNumber int, mutationType, label string) bool {
@@ -1133,6 +1400,124 @@ func (e *Engine) requiredIssueLabels() []string {
 	return append(labels, readyLabel)
 }
 
+func (e *Engine) dynamicWaveExcludedLabels() []string {
+	labels := []string{"blocked", "wontfix", "question", "duplicate", "invalid", "epic", "meta"}
+	labels = append(labels, e.cfg.ExcludeLabels...)
+	labels = append(labels, e.policyExcludedLabels()...)
+	if blockedLabel := strings.TrimSpace(e.cfg.Supervisor.BlockedLabel); blockedLabel != "" {
+		labels = append(labels, blockedLabel)
+	}
+	return uniqueLabelNames(labels)
+}
+
+func uniqueLabelNames(labels []string) []string {
+	unique := make([]string, 0, len(labels))
+	seen := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		key := strings.ToLower(label)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, label)
+	}
+	return unique
+}
+
+func firstMatchingIssueLabel(issue github.Issue, labels []string) (string, bool) {
+	for _, issueLabel := range issue.Labels {
+		for _, excluded := range labels {
+			if strings.EqualFold(strings.TrimSpace(issueLabel.Name), strings.TrimSpace(excluded)) {
+				return issueLabel.Name, true
+			}
+		}
+	}
+	return "", false
+}
+
+func titleLooksEpic(title string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(title)), "epic:")
+}
+
+func nonRunnableProjectStatus(issue github.Issue) (string, bool) {
+	for _, item := range issue.ProjectItems {
+		if item.Status == nil {
+			continue
+		}
+		status := strings.TrimSpace(item.Status.Name)
+		if status == "" || strings.EqualFold(status, "Todo") {
+			continue
+		}
+		return status, true
+	}
+	return "", false
+}
+
+func firstProjectStatus(issue github.Issue) string {
+	for _, item := range issue.ProjectItems {
+		if item.Status == nil {
+			continue
+		}
+		if status := strings.TrimSpace(item.Status.Name); status != "" {
+			return status
+		}
+	}
+	return ""
+}
+
+func sortDynamicWaveCandidates(issues []github.Issue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		leftPriority, _ := issuePriority(issues[i])
+		rightPriority, _ := issuePriority(issues[j])
+		if leftPriority != rightPriority {
+			return leftPriority < rightPriority
+		}
+		return issues[i].Number < issues[j].Number
+	})
+}
+
+func issuePriority(issue github.Issue) (int, string) {
+	bestRank := 4
+	bestLabel := ""
+	for _, label := range issue.Labels {
+		switch strings.ToLower(strings.TrimSpace(label.Name)) {
+		case "p0":
+			return 0, label.Name
+		case "p1":
+			if bestRank > 1 {
+				bestRank = 1
+				bestLabel = label.Name
+			}
+		case "p2":
+			if bestRank > 2 {
+				bestRank = 2
+				bestLabel = label.Name
+			}
+		case "p3":
+			if bestRank > 3 {
+				bestRank = 3
+				bestLabel = label.Name
+			}
+		}
+	}
+	return bestRank, bestLabel
+}
+
+func supervisorIssueCandidate(issue github.Issue) *state.SupervisorIssueCandidate {
+	_, priorityLabel := issuePriority(issue)
+	return &state.SupervisorIssueCandidate{
+		Number:        issue.Number,
+		Title:         RedactSensitive(issue.Title),
+		Labels:        issueLabelNames(issue),
+		PriorityLabel: priorityLabel,
+		ProjectStatus: firstProjectStatus(issue),
+	}
+}
+
 func (e *Engine) policySummaryReason() string {
 	mode := strings.TrimSpace(e.cfg.Supervisor.Mode)
 	if mode == "" {
@@ -1146,6 +1531,12 @@ func (e *Engine) policySummaryReason() string {
 	}
 	if e.cfg.Supervisor.OrderedQueueActive() {
 		parts = append(parts, fmt.Sprintf("ordered_queue=%d issue(s)", len(e.cfg.Supervisor.OrderedQueue.Issues)))
+	}
+	if e.cfg.Supervisor.DynamicWave.Active() {
+		parts = append(parts, "dynamic_wave=true")
+		if e.cfg.Supervisor.DynamicWave.OwnsReadyLabel {
+			parts = append(parts, "owns_ready_label=true")
+		}
 	}
 	if excludedLabels := e.policyExcludedLabels(); len(excludedLabels) > 0 {
 		parts = append(parts, "excluded_labels="+strings.Join(excludedLabels, ","))
@@ -1265,6 +1656,11 @@ func mutationDescription(mutation state.SupervisorMutation) string {
 	switch mutation.Type {
 	case MutationAddReadyLabel:
 		return fmt.Sprintf("adding `%s`", mutation.Label)
+	case MutationRemoveReadyLabel:
+		if mutation.Issue > 0 {
+			return fmt.Sprintf("removing stale `%s` from issue #%d", mutation.Label, mutation.Issue)
+		}
+		return fmt.Sprintf("removing stale `%s`", mutation.Label)
 	case MutationRemoveBlockedLabel:
 		return fmt.Sprintf("removing `%s`", mutation.Label)
 	case MutationIssueComment:
@@ -1317,6 +1713,8 @@ func applyQueueMutation(mutator Mutator, mutation state.SupervisorMutation) erro
 	switch mutation.Type {
 	case MutationAddReadyLabel:
 		return mutator.AddIssueLabel(mutation.Issue, mutation.Label)
+	case MutationRemoveReadyLabel:
+		return mutator.RemoveIssueLabel(mutation.Issue, mutation.Label)
 	case MutationRemoveBlockedLabel:
 		return mutator.RemoveIssueLabel(mutation.Issue, mutation.Label)
 	default:
@@ -1379,6 +1777,8 @@ func completedMutationPhrase(mutation state.SupervisorMutation) string {
 	switch mutation.Type {
 	case MutationAddReadyLabel:
 		return fmt.Sprintf("added `%s`", mutation.Label)
+	case MutationRemoveReadyLabel:
+		return fmt.Sprintf("removed stale `%s` from issue #%d", mutation.Label, mutation.Issue)
 	case MutationRemoveBlockedLabel:
 		return fmt.Sprintf("removed `%s`", mutation.Label)
 	default:
@@ -1519,6 +1919,7 @@ func firstMissingLabelTarget(issues []github.Issue, labels []string) *state.Supe
 
 func policySkipReason(reason string) bool {
 	return strings.Contains(reason, "excluded by configured label") ||
+		strings.Contains(reason, "skipped by dynamic wave policy") ||
 		strings.Contains(reason, "mission parent issue") ||
 		strings.Contains(reason, "mission issue awaits decomposition") ||
 		strings.Contains(reason, "blocked by open issue")

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -159,6 +159,16 @@ func testIssue(number int, title string, labels ...string) github.Issue {
 	return issue
 }
 
+func withProjectStatus(issue github.Issue, status string) github.Issue {
+	issue.ProjectItems = []github.IssueProjectItem{{
+		Title: "Maestro",
+		Status: &github.IssueProjectItemStatus{
+			Name: status,
+		},
+	}}
+	return issue
+}
+
 func TestDecide_IdleNoEligibleIssueRecommendsLabel(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
@@ -181,12 +191,14 @@ func TestDecide_IdleNoEligibleIssueRecommendsLabel(t *testing.T) {
 	if decision.Mode != ModeReadOnly {
 		t.Errorf("mode = %q, want %q", decision.Mode, ModeReadOnly)
 	}
-	stuck := requireStuckState(t, decision, "no_eligible_issues")
-	if stuck.Severity != SeverityWarning {
-		t.Errorf("severity = %q, want %q", stuck.Severity, SeverityWarning)
+	if decision.QueueAnalysis == nil {
+		t.Fatal("QueueAnalysis is nil")
 	}
-	if !stuck.SupervisorCanAct {
-		t.Error("expected SupervisorCanAct for label recommendation")
+	if decision.QueueAnalysis.OpenIssues != 1 || decision.QueueAnalysis.EligibleCandidates != 1 {
+		t.Fatalf("queue analysis = %#v, want one open eligible candidate", decision.QueueAnalysis)
+	}
+	if decision.QueueAnalysis.SelectedCandidate == nil || decision.QueueAnalysis.SelectedCandidate.Number != 308 {
+		t.Fatalf("selected candidate = %#v, want issue 308", decision.QueueAnalysis.SelectedCandidate)
 	}
 }
 
@@ -662,6 +674,8 @@ func TestDecide_ConfigExcludeLabelsStillHonored(t *testing.T) {
 func TestDecide_SupervisorReadyLabelActsAsRequiredLabel(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.Supervisor.ReadyLabel = "maestro-ready"
+	dynamicEnabled := false
+	cfg.Supervisor.DynamicWave.Enabled = &dynamicEnabled
 	reader := &fakeReader{issues: []github.Issue{
 		testIssue(1, "missing"),
 		testIssue(2, "ready", "maestro-ready"),
@@ -677,6 +691,114 @@ func TestDecide_SupervisorReadyLabelActsAsRequiredLabel(t *testing.T) {
 	}
 	if decision.PolicyRule != PolicyRuleIssueLabels {
 		t.Fatalf("PolicyRule = %q, want %q", decision.PolicyRule, PolicyRuleIssueLabels)
+	}
+}
+
+func TestDecide_DynamicWaveSortsByPriorityThenIssueNumber(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(30, "p2 work", "p2"),
+		testIssue(20, "p0 work", "P0"),
+		testIssue(10, "p0 lower number", "p0"),
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionLabelIssueReady {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionLabelIssueReady)
+	}
+	if decision.Target == nil || decision.Target.Issue != 10 {
+		t.Fatalf("target = %#v, want issue 10", decision.Target)
+	}
+	if decision.QueueAnalysis == nil || decision.QueueAnalysis.SelectedCandidate == nil {
+		t.Fatalf("queue analysis = %#v, want selected candidate", decision.QueueAnalysis)
+	}
+	if got := decision.QueueAnalysis.SelectedCandidate.PriorityLabel; !strings.EqualFold(got, "p0") {
+		t.Fatalf("priority label = %q, want p0", got)
+	}
+}
+
+func TestRunOnceDynamicWaveAddsReadyOnlyToBestCandidateAndCleansStale(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.DynamicWave.OwnsReadyLabel = true
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel}
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(10, "stale ready", "maestro-ready", "p3"),
+		testIssue(20, "best candidate", "p0"),
+	}}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.Status != DecisionStatusSucceeded {
+		t.Fatalf("status = %q, want %q", decision.Status, DecisionStatusSucceeded)
+	}
+	if decision.Target == nil || decision.Target.Issue != 20 {
+		t.Fatalf("target = %#v, want issue 20", decision.Target)
+	}
+	if got, want := strings.Join(reader.addedLabels, ","), "#20:maestro-ready"; got != want {
+		t.Fatalf("added labels = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(reader.removedLabels, ","), "#10:maestro-ready"; got != want {
+		t.Fatalf("removed labels = %q, want %q", got, want)
+	}
+	if len(decision.Mutations) != 2 {
+		t.Fatalf("mutations = %#v, want add selected and remove stale", decision.Mutations)
+	}
+}
+
+func TestDecide_DynamicWaveSkipsTitleEpic(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(1, "Epic: parent work", "p0"),
+		testIssue(2, "regular work", "p1"),
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 2 {
+		t.Fatalf("target = %#v, want issue 2", decision.Target)
+	}
+	if decision.QueueAnalysis == nil || decision.QueueAnalysis.ExcludedIssues != 1 {
+		t.Fatalf("queue analysis = %#v, want one excluded issue", decision.QueueAnalysis)
+	}
+	if len(decision.QueueAnalysis.SkippedReasons) == 0 || !strings.Contains(decision.QueueAnalysis.SkippedReasons[0], "title indicates epic") {
+		t.Fatalf("skipped reasons = %#v, want title epic reason", decision.QueueAnalysis.SkippedReasons)
+	}
+}
+
+func TestDecide_DynamicWaveSkipsNonRunnableProjectStatus(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{
+		withProjectStatus(testIssue(1, "already started", "p0"), "In Progress"),
+		withProjectStatus(testIssue(2, "todo work", "p1"), "Todo"),
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 2 {
+		t.Fatalf("target = %#v, want issue 2", decision.Target)
+	}
+	if decision.QueueAnalysis == nil || decision.QueueAnalysis.NonRunnableProjectStatusCount != 1 {
+		t.Fatalf("queue analysis = %#v, want one non-runnable project status", decision.QueueAnalysis)
+	}
+	if len(decision.QueueAnalysis.SkippedReasons) == 0 || !strings.Contains(decision.QueueAnalysis.SkippedReasons[0], "project status") {
+		t.Fatalf("skipped reasons = %#v, want project status reason", decision.QueueAnalysis.SkippedReasons)
 	}
 }
 
@@ -737,10 +859,11 @@ func TestRunOnceLabelsNextIssueReadyAndComments(t *testing.T) {
 	}
 }
 
-func TestRunOnceRemovesBlockedLabelWhenPolicyAllows(t *testing.T) {
+func TestRunOnceOrderedQueueRemovesBlockedLabelWhenPolicyAllows(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
 	cfg.ExcludeLabels = []string{"blocked"}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{42}}
 	cfg.Supervisor.SafeActions = []string{config.SupervisorActionRemoveBlockedLabel}
 	reader := &fakeReader{issues: []github.Issue{testIssue(42, "was blocked", "maestro-ready", "blocked")}}
 
@@ -763,10 +886,11 @@ func TestRunOnceRemovesBlockedLabelWhenPolicyAllows(t *testing.T) {
 	}
 }
 
-func TestRunOnceUsesConfiguredSupervisorBlockedLabel(t *testing.T) {
+func TestRunOnceOrderedQueueUsesConfiguredSupervisorBlockedLabel(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
 	cfg.Supervisor.BlockedLabel = "waiting"
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{Enabled: true, Issues: []int{42}}
 	cfg.Supervisor.SafeActions = []string{config.SupervisorActionRemoveBlockedLabel}
 	reader := &fakeReader{issues: []github.Issue{testIssue(42, "waiting work", "maestro-ready", "waiting")}}
 
@@ -783,6 +907,32 @@ func TestRunOnceUsesConfiguredSupervisorBlockedLabel(t *testing.T) {
 	}
 	if len(reader.addedLabels) != 0 {
 		t.Fatalf("added labels = %#v, want none", reader.addedLabels)
+	}
+}
+
+func TestRunOnceDynamicWaveNeverRemovesBlockedLabel(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.BlockedLabel = "blocked"
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel, config.SupervisorActionRemoveBlockedLabel}
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(1, "blocked high priority", "maestro-ready", "blocked", "p0"),
+		testIssue(2, "regular", "p1"),
+	}}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 2 {
+		t.Fatalf("target = %#v, want issue 2", decision.Target)
+	}
+	if got, want := strings.Join(reader.addedLabels, ","), "#2:maestro-ready"; got != want {
+		t.Fatalf("added labels = %q, want %q", got, want)
+	}
+	if len(reader.removedLabels) != 0 {
+		t.Fatalf("removed labels = %#v, want no blocked removal in dynamic mode", reader.removedLabels)
 	}
 }
 


### PR DESCRIPTION
Closes #280

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a dynamic wave policy that lets the supervisor select the next runnable open issue without a fixed ordered queue, using priority labels (`p0`–`p3`) and conservative skip rules (epic titles, excluded labels, non-runnable project statuses). It also adds `remove_ready_label` as a new mutation type so the supervisor can clean up stale ready labels when `owns_ready_label` is enabled.

Two issues worth resolving before merging:

- `SupervisorDynamicWaveConfig.Active()` returns `true` when `Enabled` is `nil`, making dynamic wave **implicitly on** for all existing configs that don't have a `dynamic_wave:` block. This silently changes filtering behaviour (excluded labels, project status checks) for existing deployments. An existing test had to explicitly opt out with `dynamicEnabled := false`.
- `nonRunnableProjectStatus` treats only `"Todo"` as a runnable project status. Any other GitHub Project status — including `"Backlog"`, `"Ready"`, or `"To Do"` — silently excludes the issue from candidates with no operator-visible warning.

<h3>Confidence Score: 3/5</h3>

Two P1 logic issues should be resolved before merging; dynamic wave activates by default and project status filtering is more aggressive than documented.

Two P1 findings: opt-out default for dynamic wave (breaking change for existing deployments) and a hard-coded project status allowlist that silently drops non-"Todo" issues. Neither is catastrophic but both can cause unexpected behaviour on upgrade.

internal/config/config.go (Active() default) and internal/supervisor/supervisor.go (nonRunnableProjectStatus allowlist)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds SupervisorDynamicWaveConfig and remove_ready_label action; Active() defaults to true when Enabled is nil, making dynamic wave implicitly on for all existing configs (breaking change) |
| internal/supervisor/supervisor.go | Core dynamic wave logic: candidate filtering, priority sorting, stale-label cleanup, and mutation permission; nonRunnableProjectStatus hard-codes only "Todo" as runnable, silently dropping all other project statuses |
| internal/supervisor/supervisor_test.go | Adds targeted tests for dynamic wave sorting, label cleanup, epic/project-status skipping, and blocked-label non-removal; confirms opt-out design via explicit flag in pre-existing test |
| internal/config/config_test.go | Adds TestParse_SupervisorDynamicWaveWithoutOrderedQueue; correctly validates config parsing, ordered-queue deactivation, and dynamic wave activation |
| internal/github/github.go | Adds ProjectItems and project item status structs to Issue; extends gh CLI JSON fields to include projectItems in both listOpenIssuesByLabel and GetIssue |
| internal/state/state.go | Adds SupervisorIssueCandidate and SupervisorQueueAnalysis types; adds QueueAnalysis field to SupervisorDecision for explainable issue selection output |
| internal/supervisor/packet.go | Adds ProjectStatus field to supervisorIssuePacket and populates it via firstProjectStatus; straightforward change |
| cmd/maestro/main.go | Adds printQueueAnalysis helper and wires QueueAnalysis into both printSupervisorDecision and showLatestSupervisorDecision display paths |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/config/config.go`, line 122-124 ([link](https://github.com/befeast/maestro/blob/9d753d48631e81e44677fad582995f329ed25f3f/internal/config/config.go#L122-L124)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Dynamic wave active by default — implicit opt-out, not opt-in**

   `Active()` returns `true` when `Enabled == nil`, so any deployment that has no `dynamic_wave:` block in its config will silently enter dynamic wave mode the next time the ordered queue is exhausted or if it has no ordered queue at all. The existing test `TestDecide_SupervisorReadyLabelActsAsRequiredLabel` had to explicitly set `dynamicEnabled := false` to opt out, confirming this is a breaking change for existing configs. Issues with labels like `"blocked"`, `"wontfix"`, `"epic"`, or non-`"Todo"` project statuses will be silently dropped from candidates.

   Consider defaulting to opt-in instead:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/config/config.go
   Line: 122-124

   Comment:
   **Dynamic wave active by default — implicit opt-out, not opt-in**

   `Active()` returns `true` when `Enabled == nil`, so any deployment that has no `dynamic_wave:` block in its config will silently enter dynamic wave mode the next time the ordered queue is exhausted or if it has no ordered queue at all. The existing test `TestDecide_SupervisorReadyLabelActsAsRequiredLabel` had to explicitly set `dynamicEnabled := false` to opt out, confirming this is a breaking change for existing configs. Issues with labels like `"blocked"`, `"wontfix"`, `"epic"`, or non-`"Todo"` project statuses will be silently dropped from candidates.

   Consider defaulting to opt-in instead:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/supervisor/supervisor.go`, line 789-801 ([link](https://github.com/befeast/maestro/blob/9d753d48631e81e44677fad582995f329ed25f3f/internal/supervisor/supervisor.go#L789-L801)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Only "Todo" is treated as a runnable project status — all other statuses silently exclude issues**

   `nonRunnableProjectStatus` skips any issue whose GitHub Project status is not empty and not `"Todo"` (case-insensitive). Statuses commonly used to mean "ready to pick up" — `"Backlog"`, `"Ready"`, `"To Do"` (with a space), `"New"` — are all treated as non-runnable and the issue is silently dropped from candidates with no warning to the operator. Any team that does not use GitHub Projects is unaffected, but teams with a multi-status board will find their non-`"Todo"` backlog issues permanently invisible to the dynamic wave policy.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/supervisor/supervisor.go
   Line: 789-801

   Comment:
   **Only "Todo" is treated as a runnable project status — all other statuses silently exclude issues**

   `nonRunnableProjectStatus` skips any issue whose GitHub Project status is not empty and not `"Todo"` (case-insensitive). Statuses commonly used to mean "ready to pick up" — `"Backlog"`, `"Ready"`, `"To Do"` (with a space), `"New"` — are all treated as non-runnable and the issue is silently dropped from candidates with no warning to the operator. Any team that does not use GitHub Projects is unaffected, but teams with a multi-status board will find their non-`"Todo"` backlog issues permanently invisible to the dynamic wave policy.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/config/config.go:122-124
**Dynamic wave active by default — implicit opt-out, not opt-in**

`Active()` returns `true` when `Enabled == nil`, so any deployment that has no `dynamic_wave:` block in its config will silently enter dynamic wave mode the next time the ordered queue is exhausted or if it has no ordered queue at all. The existing test `TestDecide_SupervisorReadyLabelActsAsRequiredLabel` had to explicitly set `dynamicEnabled := false` to opt out, confirming this is a breaking change for existing configs. Issues with labels like `"blocked"`, `"wontfix"`, `"epic"`, or non-`"Todo"` project statuses will be silently dropped from candidates.

Consider defaulting to opt-in instead:

```suggestion
func (w SupervisorDynamicWaveConfig) Active() bool {
	return w.Enabled != nil && *w.Enabled
}
```

### Issue 2 of 2
internal/supervisor/supervisor.go:789-801
**Only "Todo" is treated as a runnable project status — all other statuses silently exclude issues**

`nonRunnableProjectStatus` skips any issue whose GitHub Project status is not empty and not `"Todo"` (case-insensitive). Statuses commonly used to mean "ready to pick up" — `"Backlog"`, `"Ready"`, `"To Do"` (with a space), `"New"` — are all treated as non-runnable and the issue is silently dropped from candidates with no warning to the operator. Any team that does not use GitHub Projects is unaffected, but teams with a multi-status board will find their non-`"Todo"` backlog issues permanently invisible to the dynamic wave policy.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add dynamic supervisor wave policy"](https://github.com/befeast/maestro/commit/9d753d48631e81e44677fad582995f329ed25f3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30289288)</sub>

<!-- /greptile_comment -->