### PR TITLE
Fix dynamic wave policy defaults

### DIFF
--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -160,6 +160,7 @@ supervisor:
     owns_ready_label: true
     runnable_project_statuses:
       - Todo
+      - To Do
       - Ready
       - Backlog
       - New

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -158,6 +158,11 @@ supervisor:
   dynamic_wave:
     enabled: true
     owns_ready_label: true
+    runnable_project_statuses:
+      - Todo
+      - Ready
+      - Backlog
+      - New
   safe_actions:
     - add_ready_label
     - remove_ready_label
@@ -204,7 +209,7 @@ telegram:
 | `session_prefix` | Prefix for tmux session names |
 | `worker_prompt` | Path to the worker prompt template file |
 
-Supervisor policy can also live in `.maestro/supervisor.yaml` next to the project config or repository checkout. If an ordered queue is configured, only the first unfinished issue in that queue is eligible for supervisor dispatch until the queue is exhausted. `dynamic_wave` lets the supervisor select the next runnable open issue without listing issue numbers, using priority labels and conservative skip rules.
+Supervisor policy can also live in `.maestro/supervisor.yaml` next to the project config or repository checkout. If an ordered queue is configured, only the first unfinished issue in that queue is eligible for supervisor dispatch until the queue is exhausted. `dynamic_wave` is explicit opt-in and lets the supervisor select the next runnable open issue without listing issue numbers, using priority labels and conservative skip rules.
 
 ### Optional: versioning config
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,12 +94,13 @@ type SupervisorOrderedQueueConfig struct {
 // SupervisorDynamicWaveConfig enables policy-driven issue selection without a
 // fixed issue-number list.
 type SupervisorDynamicWaveConfig struct {
-	Enabled        *bool `yaml:"enabled" json:"enabled,omitempty"`
-	OwnsReadyLabel bool  `yaml:"owns_ready_label" json:"owns_ready_label,omitempty"`
+	Enabled                 *bool    `yaml:"enabled" json:"enabled,omitempty"`
+	OwnsReadyLabel          bool     `yaml:"owns_ready_label" json:"owns_ready_label,omitempty"`
+	RunnableProjectStatuses []string `yaml:"runnable_project_statuses" json:"runnable_project_statuses,omitempty"`
 }
 
 func (w SupervisorDynamicWaveConfig) Active() bool {
-	return w.Enabled == nil || *w.Enabled
+	return w.Enabled != nil && *w.Enabled
 }
 
 func (q SupervisorOrderedQueueConfig) Active() bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -112,6 +112,10 @@ supervisor:
   dynamic_wave:
     enabled: true
     owns_ready_label: true
+    runnable_project_statuses:
+      - Todo
+      - Ready
+      - Backlog
   safe_actions:
     - add_ready_label
     - remove_ready_label
@@ -129,8 +133,26 @@ supervisor:
 	if !cfg.Supervisor.DynamicWave.OwnsReadyLabel {
 		t.Fatal("DynamicWave should own the ready label")
 	}
+	if got := cfg.Supervisor.DynamicWave.RunnableProjectStatuses; len(got) != 3 || got[1] != "Ready" {
+		t.Fatalf("RunnableProjectStatuses = %#v, want Todo/Ready/Backlog", got)
+	}
 	if cfg.Supervisor.ReadyLabel != "maestro-ready" {
 		t.Fatalf("ReadyLabel = %q, want maestro-ready", cfg.Supervisor.ReadyLabel)
+	}
+}
+
+func TestParse_SupervisorDynamicWaveDefaultInactive(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  ready_label: maestro-ready
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Supervisor.DynamicWave.Active() {
+		t.Fatal("DynamicWave should require explicit opt-in")
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -978,7 +978,7 @@ func (e *Engine) dynamicWaveSkipReason(st *state.State, issue github.Issue) (str
 	if label, ok := firstMatchingIssueLabel(issue, e.dynamicWaveExcludedLabels()); ok {
 		return fmt.Sprintf("excluded by label %q", label), dynamicSkipExcluded, nil
 	}
-	if status, ok := nonRunnableProjectStatus(issue); ok {
+	if status, ok := e.nonRunnableProjectStatus(issue); ok {
 		return fmt.Sprintf("project status %q is not runnable", status), dynamicSkipProjectStatus, nil
 	}
 	if len(e.cfg.BlockerPatterns) > 0 {
@@ -1443,18 +1443,58 @@ func titleLooksEpic(title string) bool {
 	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(title)), "epic:")
 }
 
-func nonRunnableProjectStatus(issue github.Issue) (string, bool) {
+func (e *Engine) nonRunnableProjectStatus(issue github.Issue) (string, bool) {
 	for _, item := range issue.ProjectItems {
 		if item.Status == nil {
 			continue
 		}
 		status := strings.TrimSpace(item.Status.Name)
-		if status == "" || strings.EqualFold(status, "Todo") {
+		if status == "" || projectStatusIsRunnable(status, e.runnableProjectStatuses()) {
 			continue
 		}
 		return status, true
 	}
 	return "", false
+}
+
+func (e *Engine) runnableProjectStatuses() []string {
+	if e == nil || e.cfg == nil {
+		return defaultRunnableProjectStatuses()
+	}
+	configured := trimNonEmpty(e.cfg.Supervisor.DynamicWave.RunnableProjectStatuses)
+	if len(configured) > 0 {
+		return configured
+	}
+	return defaultRunnableProjectStatuses()
+}
+
+func defaultRunnableProjectStatuses() []string {
+	return []string{"Todo", "To Do", "Ready", "Backlog", "New"}
+}
+
+func projectStatusIsRunnable(status string, runnable []string) bool {
+	normalized := normalizeProjectStatus(status)
+	for _, candidate := range runnable {
+		if normalizeProjectStatus(candidate) == normalized {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeProjectStatus(status string) string {
+	fields := strings.Fields(strings.ToLower(strings.TrimSpace(status)))
+	return strings.Join(fields, " ")
+}
+
+func trimNonEmpty(values []string) []string {
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			trimmed = append(trimmed, value)
+		}
+	}
+	return trimmed
 }
 
 func firstProjectStatus(issue github.Issue) string {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -123,6 +123,11 @@ func testConfig(t *testing.T) *config.Config {
 	}
 }
 
+func enableDynamicWave(cfg *config.Config) {
+	enabled := true
+	cfg.Supervisor.DynamicWave.Enabled = &enabled
+}
+
 func testEngine(cfg *config.Config, reader *fakeReader) *Engine {
 	eng := NewEngine(cfg, reader)
 	eng.now = func() time.Time { return time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC) }
@@ -172,6 +177,7 @@ func withProjectStatus(issue github.Issue, status string) github.Issue {
 func TestDecide_IdleNoEligibleIssueRecommendsLabel(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
 	reader := &fakeReader{issues: []github.Issue{testIssue(308, "implement supervisor")}}
 
 	decision, err := testEngine(cfg, reader).Decide(state.NewState())
@@ -697,6 +703,7 @@ func TestDecide_SupervisorReadyLabelActsAsRequiredLabel(t *testing.T) {
 func TestDecide_DynamicWaveSortsByPriorityThenIssueNumber(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
 	reader := &fakeReader{issues: []github.Issue{
 		testIssue(30, "p2 work", "p2"),
 		testIssue(20, "p0 work", "P0"),
@@ -725,6 +732,7 @@ func TestDecide_DynamicWaveSortsByPriorityThenIssueNumber(t *testing.T) {
 func TestRunOnceDynamicWaveAddsReadyOnlyToBestCandidateAndCleansStale(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
 	cfg.Supervisor.DynamicWave.OwnsReadyLabel = true
 	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel}
 	reader := &fakeReader{issues: []github.Issue{
@@ -757,6 +765,7 @@ func TestRunOnceDynamicWaveAddsReadyOnlyToBestCandidateAndCleansStale(t *testing
 func TestDecide_DynamicWaveSkipsTitleEpic(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
 	reader := &fakeReader{issues: []github.Issue{
 		testIssue(1, "Epic: parent work", "p0"),
 		testIssue(2, "regular work", "p1"),
@@ -781,9 +790,10 @@ func TestDecide_DynamicWaveSkipsTitleEpic(t *testing.T) {
 func TestDecide_DynamicWaveSkipsNonRunnableProjectStatus(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
 	reader := &fakeReader{issues: []github.Issue{
 		withProjectStatus(testIssue(1, "already started", "p0"), "In Progress"),
-		withProjectStatus(testIssue(2, "todo work", "p1"), "Todo"),
+		withProjectStatus(testIssue(2, "ready work", "p1"), "Ready"),
 	}}
 
 	decision, err := testEngine(cfg, reader).Decide(state.NewState())
@@ -799,6 +809,29 @@ func TestDecide_DynamicWaveSkipsNonRunnableProjectStatus(t *testing.T) {
 	}
 	if len(decision.QueueAnalysis.SkippedReasons) == 0 || !strings.Contains(decision.QueueAnalysis.SkippedReasons[0], "project status") {
 		t.Fatalf("skipped reasons = %#v, want project status reason", decision.QueueAnalysis.SkippedReasons)
+	}
+}
+
+func TestDecide_DynamicWaveSupportsConfiguredRunnableProjectStatus(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
+	cfg.Supervisor.DynamicWave.RunnableProjectStatuses = []string{"Selected"}
+	reader := &fakeReader{issues: []github.Issue{
+		withProjectStatus(testIssue(1, "todo is not configured", "p0"), "Todo"),
+		withProjectStatus(testIssue(2, "selected work", "p1"), "Selected"),
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 2 {
+		t.Fatalf("target = %#v, want issue 2", decision.Target)
+	}
+	if decision.QueueAnalysis == nil || decision.QueueAnalysis.NonRunnableProjectStatusCount != 1 {
+		t.Fatalf("queue analysis = %#v, want one non-runnable project status", decision.QueueAnalysis)
 	}
 }
 
@@ -913,6 +946,7 @@ func TestRunOnceOrderedQueueUsesConfiguredSupervisorBlockedLabel(t *testing.T) {
 func TestRunOnceDynamicWaveNeverRemovesBlockedLabel(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
 	cfg.Supervisor.BlockedLabel = "blocked"
 	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel, config.SupervisorActionRemoveBlockedLabel}
 	reader := &fakeReader{issues: []github.Issue{


### PR DESCRIPTION
Fixes follow-up review feedback from #281.\n\n- Makes supervisor dynamic wave explicit opt-in instead of default-on.\n- Adds configurable runnable project statuses with defaults for Todo, To Do, Ready, Backlog, and New.\n- Updates tests and docs.\n\nVerification:\n- go test ./...\n- go build ./cmd/maestro/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `dynamic_wave` an explicit opt-in (changing `Active()` from default-true to requiring `enabled: true`), adds a configurable `runnable_project_statuses` field with five sensible defaults, and updates tests and docs accordingly. The implementation is clean: normalization via `strings.Fields` correctly handles multi-word statuses like "To Do", the nil-guard in `runnableProjectStatuses()` is defensive but harmless, and all affected test paths are updated.

<h3>Confidence Score: 5/5</h3>

Safe to merge — intentional behavioral change is well-tested and docs are consistent.

No logic errors found. The opt-in flip and configurable statuses are implemented correctly, normalization handles edge cases, and the test suite covers the new opt-in default and custom-statuses override path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Added `RunnableProjectStatuses []string` to `SupervisorDynamicWaveConfig`; flipped `Active()` from default-on to explicit opt-in (`Enabled != nil && *Enabled`). |
| internal/config/config_test.go | Added parsing test for `RunnableProjectStatuses` and a new `TestParse_SupervisorDynamicWaveDefaultInactive` test confirming the opt-in change. |
| internal/supervisor/supervisor.go | Converted `nonRunnableProjectStatus` to a method on `*Engine`; added `runnableProjectStatuses()`, `defaultRunnableProjectStatuses()`, `projectStatusIsRunnable()`, `normalizeProjectStatus()`, and `trimNonEmpty()` helpers with correct nil-guard and normalization logic. |
| internal/supervisor/supervisor_test.go | Added `enableDynamicWave` helper; updated existing tests to opt in; added `TestDecide_DynamicWaveSupportsConfiguredRunnableProjectStatus` covering the custom-statuses override path. |
| docs/project-setup-runbook.md | Added `runnable_project_statuses` example (all 5 defaults) and updated prose to describe `dynamic_wave` as explicit opt-in. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: include to do dynamic wave status"](https://github.com/befeast/maestro/commit/a0999a44e4aafa25b77bb685f92dc675858d697e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30300216)</sub>

<!-- /greptile_comment -->