### PR TITLE
fix: avoid retry reservation starvation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ worker_max_tokens: 0               # kill worker when cumulative token usage exc
 auto_rebase: true                  # auto-rebase conflicting PR branches (default: true)
 merge_strategy: sequential         # "sequential" (default) or "parallel"
 merge_interval_seconds: 30         # minimum seconds between merges in sequential mode
+review_gate: greptile              # "greptile" (default) or "none"
+auto_retry_review_feedback: false  # retry PRs with actionable review comments
+auto_retry_rebase_conflicts: false # retry PRs whose auto-rebase fails with conflicts
 session_prefix: pan                # worker session name prefix (default: first 3 chars of repo name)
 state_dir: ~/.maestro/pan          # state/log directory (default: ~/.maestro/<repo-hash>)
 claude_cmd: claude                 # deprecated: use model.backends.claude.cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -251,12 +251,13 @@ type Config struct {
 	StateDir                   string               `yaml:"state_dir"`           // state/log directory (default: ~/.maestro/<repo-hash>)
 	Model                      ModelConfig          `yaml:"model"`
 	Routing                    RoutingConfig        `yaml:"routing"`
-	DeployCmd                  string               `yaml:"deploy_cmd"`                 // shell command to run after successful PR merge
-	DeployTimeoutMinutes       int                  `yaml:"deploy_timeout_minutes"`     // timeout for deploy command in minutes (default: 15)
-	MergeStrategy              string               `yaml:"merge_strategy"`             // "sequential" | "parallel"
-	MergeIntervalSeconds       int                  `yaml:"merge_interval_seconds"`     // minimum seconds between merges in sequential mode
-	ReviewGate                 string               `yaml:"review_gate"`                // "greptile" (default) | "none"
-	AutoRetryReviewFeedback    bool                 `yaml:"auto_retry_review_feedback"` // close PRs with review comments and respawn a fixer
+	DeployCmd                  string               `yaml:"deploy_cmd"`                  // shell command to run after successful PR merge
+	DeployTimeoutMinutes       int                  `yaml:"deploy_timeout_minutes"`      // timeout for deploy command in minutes (default: 15)
+	MergeStrategy              string               `yaml:"merge_strategy"`              // "sequential" | "parallel"
+	MergeIntervalSeconds       int                  `yaml:"merge_interval_seconds"`      // minimum seconds between merges in sequential mode
+	ReviewGate                 string               `yaml:"review_gate"`                 // "greptile" (default) | "none"
+	AutoRetryReviewFeedback    bool                 `yaml:"auto_retry_review_feedback"`  // close PRs with review comments and respawn a fixer
+	AutoRetryRebaseConflicts   bool                 `yaml:"auto_retry_rebase_conflicts"` // retry PRs whose auto-rebase fails with conflicts
 	Telegram                   TelegramConfig       `yaml:"telegram"`
 	Versioning                 VersioningConfig     `yaml:"versioning"`
 	GitHubProjects             GitHubProjectsConfig `yaml:"github_projects"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -922,6 +922,9 @@ func TestParse_ReviewGateDefaults(t *testing.T) {
 	if cfg.AutoRetryReviewFeedback {
 		t.Error("AutoRetryReviewFeedback should default to false")
 	}
+	if cfg.AutoRetryRebaseConflicts {
+		t.Error("AutoRetryRebaseConflicts should default to false")
+	}
 }
 
 func TestParse_ReviewGateExplicitNone(t *testing.T) {
@@ -929,6 +932,7 @@ func TestParse_ReviewGateExplicitNone(t *testing.T) {
 repo: owner/repo
 review_gate: none
 auto_retry_review_feedback: true
+auto_retry_rebase_conflicts: true
 `
 	cfg, err := parse([]byte(yaml))
 	if err != nil {
@@ -939,6 +943,9 @@ auto_retry_review_feedback: true
 	}
 	if !cfg.AutoRetryReviewFeedback {
 		t.Error("AutoRetryReviewFeedback should be true when configured")
+	}
+	if !cfg.AutoRetryRebaseConflicts {
+		t.Error("AutoRetryRebaseConflicts should be true when configured")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -536,9 +536,10 @@ func (o *Orchestrator) canRetryIssue(s *state.State, sess *state.Session) bool {
 }
 
 func pendingRetryReservations(s *state.State) int {
+	now := time.Now().UTC()
 	count := 0
 	for _, sess := range s.Sessions {
-		if sess.Status == state.StatusDead && sess.NextRetryAt != nil {
+		if sess.Status == state.StatusDead && sess.NextRetryAt != nil && !now.Before(*sess.NextRetryAt) {
 			count++
 		}
 	}
@@ -869,6 +870,10 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 	if newCfg.AutoRetryReviewFeedback != old.AutoRetryReviewFeedback {
 		changed = append(changed, fmt.Sprintf("auto_retry_review_feedback: %v→%v", old.AutoRetryReviewFeedback, newCfg.AutoRetryReviewFeedback))
 		o.cfg.AutoRetryReviewFeedback = newCfg.AutoRetryReviewFeedback
+	}
+	if newCfg.AutoRetryRebaseConflicts != old.AutoRetryRebaseConflicts {
+		changed = append(changed, fmt.Sprintf("auto_retry_rebase_conflicts: %v→%v", old.AutoRetryRebaseConflicts, newCfg.AutoRetryRebaseConflicts))
+		o.cfg.AutoRetryRebaseConflicts = newCfg.AutoRetryRebaseConflicts
 	}
 	if newCfg.DeployCmd != old.DeployCmd {
 		changed = append(changed, fmt.Sprintf("deploy_cmd: %q→%q", old.DeployCmd, newCfg.DeployCmd))
@@ -1890,7 +1895,7 @@ func (o *Orchestrator) markRebaseQueued(slotName string, sess *state.Session, pr
 }
 
 func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string, sess *state.Session, prNumber int, cause error) {
-	if !o.cfg.AutoRetryReviewFeedback {
+	if !o.cfg.AutoRetryRebaseConflicts {
 		o.markUnresolvableConflict(slotName, sess, prNumber, cause)
 		return
 	}
@@ -1958,7 +1963,7 @@ func rebaseConflictFeedback(prNumber int, cause error) string {
 }
 
 func (o *Orchestrator) markUnresolvableConflict(slotName string, sess *state.Session, prNumber int, cause error) {
-	if err := o.gh.AddIssueLabel(sess.IssueNumber, "blocked"); err != nil {
+	if err := o.addIssueLabel(sess.IssueNumber, "blocked"); err != nil {
 		log.Printf("[orch] warn: could not label issue #%d as blocked: %v", sess.IssueNumber, err)
 	}
 	if cause != nil {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1921,10 +1921,10 @@ func TestMergeReadyPR_BehindMainRebaseFailsMarksConflict(t *testing.T) {
 
 func TestHandleRebaseConflictRetry_SchedulesInPlaceRetry(t *testing.T) {
 	cfg := &config.Config{
-		Repo:                    "owner/repo",
-		AutoRetryReviewFeedback: true,
-		MaxRetriesPerIssue:      3,
-		MaxRetryBackoffMs:       300000,
+		Repo:                     "owner/repo",
+		AutoRetryRebaseConflicts: true,
+		MaxRetriesPerIssue:       3,
+		MaxRetryBackoffMs:        300000,
 	}
 	o := &Orchestrator{cfg: cfg, notifier: &notify.Notifier{}}
 	s := state.NewState()
@@ -1961,6 +1961,42 @@ func TestHandleRebaseConflictRetry_SchedulesInPlaceRetry(t *testing.T) {
 	}
 	if !strings.Contains(sess.PreviousAttemptFeedback, "docs/FEATURES.md") {
 		t.Fatalf("PreviousAttemptFeedback should include conflict details, got %q", sess.PreviousAttemptFeedback)
+	}
+}
+
+func TestHandleRebaseConflictRetry_IndependentFromReviewFeedbackRetry(t *testing.T) {
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		addIssueLabelFn: func(number int, label string) error {
+			if number != 42 || label != "blocked" {
+				t.Fatalf("AddIssueLabel(%d, %q), want (42, blocked)", number, label)
+			}
+			return nil
+		},
+	}
+	s := state.NewState()
+	sess := &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "docs refresh",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	s.Sessions["slot-0"] = sess
+
+	o.handleRebaseConflictRetry(s, "slot-0", sess, 10, fmt.Errorf("CONFLICT (content): docs/FEATURES.md"))
+
+	if sess.Status != state.StatusConflictFailed {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusConflictFailed)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt should not be set when rebase retry is disabled")
 	}
 }
 
@@ -4041,9 +4077,12 @@ func TestAvailableSlots_NonRunningLimitIgnoredForDispatch(t *testing.T) {
 
 func TestPendingRetryReservations_CountsOnlyScheduledDeadRetries(t *testing.T) {
 	now := time.Now().UTC()
+	past := now.Add(-time.Second)
+	future := now.Add(time.Minute)
 	s := state.NewState()
-	s.Sessions["retry-due"] = &state.Session{Status: state.StatusDead, NextRetryAt: &now}
-	s.Sessions["retry-waiting"] = &state.Session{Status: state.StatusDead, NextRetryAt: &now}
+	s.Sessions["retry-due"] = &state.Session{Status: state.StatusDead, NextRetryAt: &past}
+	s.Sessions["retry-now"] = &state.Session{Status: state.StatusDead, NextRetryAt: &now}
+	s.Sessions["retry-waiting"] = &state.Session{Status: state.StatusDead, NextRetryAt: &future}
 	s.Sessions["plain-dead"] = &state.Session{Status: state.StatusDead}
 	s.Sessions["running-with-retry"] = &state.Session{Status: state.StatusRunning, NextRetryAt: &now}
 

--- a/internal/supervisor/packet.go
+++ b/internal/supervisor/packet.go
@@ -40,6 +40,8 @@ type supervisorProjectConfigPacket struct {
 	WorkerMaxTokens            int               `json:"worker_max_tokens,omitempty"`
 	MergeStrategy              string            `json:"merge_strategy"`
 	ReviewGate                 string            `json:"review_gate"`
+	AutoRetryReviewFeedback    bool              `json:"auto_retry_review_feedback"`
+	AutoRetryRebaseConflicts   bool              `json:"auto_retry_rebase_conflicts"`
 	GitHubProjectsEnabled      bool              `json:"github_projects_enabled"`
 	MissionsEnabled            bool              `json:"missions_enabled"`
 	Supervisor                 supervisorRuntime `json:"supervisor"`
@@ -171,6 +173,8 @@ func (e *Engine) projectConfigPacket() supervisorProjectConfigPacket {
 		WorkerMaxTokens:            e.cfg.WorkerMaxTokens,
 		MergeStrategy:              e.cfg.MergeStrategy,
 		ReviewGate:                 e.cfg.ReviewGate,
+		AutoRetryReviewFeedback:    e.cfg.AutoRetryReviewFeedback,
+		AutoRetryRebaseConflicts:   e.cfg.AutoRetryRebaseConflicts,
 		GitHubProjectsEnabled:      e.cfg.GitHubProjects.Enabled,
 		MissionsEnabled:            e.cfg.Missions.Enabled,
 		Supervisor: supervisorRuntime{

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -491,12 +491,17 @@ func restoreAllowedDirtyFiles(worktreePath string, autoRestoreFiles []string) er
 	if len(paths) == 0 {
 		return nil
 	}
-	args := append([]string{"status", "--porcelain", "--"}, paths...)
+	args := append([]string{"status", "--porcelain", "--untracked-files=all", "--"}, paths...)
 	dirty, err := runGit(worktreePath, args...)
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(dirty) == "" {
+	cleanArgs := append([]string{"clean", "-fdxn", "--"}, paths...)
+	cleanPreview, err := runGit(worktreePath, cleanArgs...)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(dirty) == "" && strings.TrimSpace(cleanPreview) == "" {
 		return nil
 	}
 
@@ -511,7 +516,7 @@ func restoreAllowedDirtyFiles(worktreePath string, autoRestoreFiles []string) er
 			return err
 		}
 	}
-	args = append([]string{"clean", "-fd", "--"}, paths...)
+	args = append([]string{"clean", "-fdx", "--"}, paths...)
 	if _, err := runGit(worktreePath, args...); err != nil {
 		return err
 	}

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -14,6 +14,9 @@ worker_max_tokens: 0               # kill worker when cumulative token usage exc
 auto_rebase: true                  # auto-rebase conflicting PR branches (default: true)
 merge_strategy: sequential         # "sequential" (default) or "parallel"
 merge_interval_seconds: 30         # minimum seconds between sequential merges (default: 30)
+review_gate: greptile              # "greptile" (default) or "none"
+auto_retry_review_feedback: false  # retry PRs with actionable review comments
+auto_retry_rebase_conflicts: false # retry PRs whose auto-rebase fails with conflicts
 
 # Files to auto-resolve conflicts by keeping both sides during rebase.
 # Useful for generated/aggregated files that accumulate changes from multiple branches.


### PR DESCRIPTION
## Summary
- reserve worker slots only for retry sessions whose backoff has elapsed
- split rebase-conflict retry behind `auto_retry_rebase_conflicts` instead of reusing review-feedback retry
- make auto_restore_files clean explicitly configured ignored artifacts and route blocked-label updates through the testable wrapper

## Test
- go test ./internal/config ./internal/orchestrator ./internal/supervisor ./internal/worker
- go test ./...
- go build ./cmd/maestro/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes retry-slot starvation by restricting `pendingRetryReservations` to only count dead sessions whose backoff has elapsed, preventing future-backoff sessions from consuming worker slots. It also splits rebase-conflict retry control behind its own `auto_retry_rebase_conflicts` flag (independent of `auto_retry_review_feedback`), routes the "blocked" label update in `markUnresolvableConflict` through the testable `addIssueLabel` wrapper, and extends `restoreAllowedDirtyFiles` to detect and clean gitignored artifacts via `git clean -fdx`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are targeted bug fixes with corresponding test coverage and no regressions identified.

All three bug fixes are narrowly scoped and well-tested. The pendingRetryReservations boundary condition is correctly handled (elapsed-or-equal sessions are counted), the config split is complete across config, orchestrator, supervisor packet, tests, and documentation, and the git clean -fdx change is intentionally destructive only within explicitly configured paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Three targeted fixes: pendingRetryReservations now excludes future-backoff sessions, handleRebaseConflictRetry gates on AutoRetryRebaseConflicts, markUnresolvableConflict routes through addIssueLabel wrapper |
| internal/orchestrator/orchestrator_test.go | Updated TestPendingRetryReservations to correctly distinguish past/now/future retry times; adds TestHandleRebaseConflictRetry_IndependentFromReviewFeedbackRetry covering the new config split |
| internal/worker/worker.go | restoreAllowedDirtyFiles now adds --untracked-files=all and a -fdxn dry-run preview to detect gitignored artifacts, then cleans them with -fdx |
| internal/config/config.go | Adds AutoRetryRebaseConflicts field; formatting-only alignment of existing comment columns |
| internal/supervisor/packet.go | Adds AutoRetryReviewFeedback and AutoRetryRebaseConflicts to the status packet for observability |
| internal/config/config_test.go | Default-false and explicit-true tests added for AutoRetryRebaseConflicts; straightforward coverage |
| README.md | Documents review_gate, auto_retry_review_feedback, and auto_retry_rebase_conflicts in the config reference |
| maestro.yaml.example | Adds the three new config fields to the annotated example file |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid retry reservation starvation"](https://github.com/befeast/maestro/commit/87ff68072f3519c824802ffea3731cb18bd27c56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30301867)</sub>

<!-- /greptile_comment -->