### PR TITLE
fix: auto-create PR for pushed worker branch

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -167,6 +167,33 @@ func (c *Client) ListOpenPRs() ([]PR, error) {
 	return prs, nil
 }
 
+// CreatePR opens a pull request and returns its number.
+func (c *Client) CreatePR(title, body, base, head string) (int, error) {
+	args := []string{
+		"pr", "create",
+		"--repo", c.Repo,
+		"--title", title,
+		"--body", body,
+		"--base", base,
+		"--head", head,
+	}
+	out, err := exec.Command("gh", args...).CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("gh pr create: %w\n%s", err, out)
+	}
+
+	output := strings.TrimSpace(string(out))
+	match := regexp.MustCompile(`/pull/([0-9]+)`).FindStringSubmatch(output)
+	if len(match) != 2 {
+		return 0, fmt.Errorf("unexpected gh pr create output: %s", output)
+	}
+	n, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, fmt.Errorf("parse PR number from %q: %w", output, err)
+	}
+	return n, nil
+}
+
 // IsPRMerged returns true if the PR has been merged.
 func (c *Client) IsPRMerged(prNumber int) (bool, error) {
 	out, err := exec.Command("gh", "pr", "view", fmt.Sprint(prNumber),

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -37,6 +37,8 @@ type Orchestrator struct {
 	pidAliveFn            func(pid int) bool
 	tmuxSessionExistsFn   func(name string) bool
 	listOpenPRsFn         func() ([]github.PR, error)
+	remoteBranchExistsFn  func(branch string) (bool, error)
+	createPRFn            func(title, body, base, head string) (int, error)
 	hasOpenPRForIssueFn   func(issueNumber int) (bool, error)
 	hasMergedPRForIssueFn func(issueNumber int) (bool, error)
 	isPRMergedFn          func(prNumber int) (bool, error)
@@ -127,6 +129,31 @@ func (o *Orchestrator) listOpenPRs() ([]github.PR, error) {
 		return o.listOpenPRsFn()
 	}
 	return o.gh.ListOpenPRs()
+}
+
+func (o *Orchestrator) remoteBranchExists(branch string) (bool, error) {
+	if o.remoteBranchExistsFn != nil {
+		return o.remoteBranchExistsFn(branch)
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == "" || o.cfg == nil || strings.TrimSpace(o.cfg.LocalPath) == "" {
+		return false, nil
+	}
+	out, err := exec.Command("git", "-C", o.cfg.LocalPath, "ls-remote", "--exit-code", "--heads", "origin", branch).CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+			return false, nil
+		}
+		return false, fmt.Errorf("git ls-remote --heads origin %s: %w\n%s", branch, err, out)
+	}
+	return true, nil
+}
+
+func (o *Orchestrator) createPR(title, body, base, head string) (int, error) {
+	if o.createPRFn != nil {
+		return o.createPRFn(title, body, base, head)
+	}
+	return o.gh.CreatePR(title, body, base, head)
 }
 
 func (o *Orchestrator) hasOpenPRForIssue(issueNumber int) (bool, error) {
@@ -1001,6 +1028,14 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 			reconciled = true
 			continue
 		}
+		if prErr == nil {
+			if prNumber, ok := o.tryCreatePRForPushedBranch(slotName, sess, reasons); ok {
+				log.Printf("[orch] reconcile: %s running->pr_open (auto-created PR #%d for pushed branch %q; %s)",
+					slotName, prNumber, sess.Branch, strings.Join(reasons, ", "))
+				reconciled = true
+				continue
+			}
+		}
 
 		oldPID := sess.PID
 		oldTmux := tmuxName
@@ -1015,6 +1050,69 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 			slotName, strings.Join(reasons, ", "), oldPID, oldTmux)
 	}
 	return reconciled
+}
+
+func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.Session, reasons []string) (int, bool) {
+	branch := strings.TrimSpace(sess.Branch)
+	if branch == "" {
+		return 0, false
+	}
+	exists, err := o.remoteBranchExists(branch)
+	if err != nil {
+		log.Printf("[orch] reconcile: could not check remote branch %q for %s: %v", branch, slotName, err)
+		return 0, false
+	}
+	if !exists {
+		return 0, false
+	}
+
+	title := autoCreatedPRTitle(sess)
+	body := autoCreatedPRBody(sess, branch, reasons)
+	prNumber, err := o.createPR(title, body, "main", branch)
+	if err != nil {
+		log.Printf("[orch] reconcile: could not auto-create PR for %s branch %q: %v", slotName, branch, err)
+		return 0, false
+	}
+
+	sess.Status = state.StatusPROpen
+	sess.PRNumber = prNumber
+	sess.PID = 0
+	sess.TmuxSession = ""
+	now := time.Now().UTC()
+	sess.FinishedAt = &now
+	if o.notifier != nil {
+		o.notifier.Sendf("🔀 maestro: worker %s pushed branch %s and exited before opening a PR; auto-created PR #%d for issue #%d (%s)",
+			slotName, branch, prNumber, sess.IssueNumber, sess.IssueTitle)
+	}
+	return prNumber, true
+}
+
+func autoCreatedPRTitle(sess *state.Session) string {
+	title := strings.TrimSpace(sess.IssueTitle)
+	if title == "" {
+		title = "Maestro worker result"
+	}
+	suffix := fmt.Sprintf(" (#%d)", sess.IssueNumber)
+	if !strings.Contains(title, suffix) {
+		title += suffix
+	}
+	if len(title) > 180 {
+		title = strings.TrimSpace(title[:180-len(suffix)]) + suffix
+	}
+	return title
+}
+
+func autoCreatedPRBody(sess *state.Session, branch string, reasons []string) string {
+	reasonText := strings.TrimSpace(strings.Join(reasons, ", "))
+	if reasonText == "" {
+		reasonText = "worker process exited before PR creation was observed"
+	}
+	return fmt.Sprintf(`Closes #%d
+
+Maestro auto-created this PR because the worker pushed branch %s but exited before opening a pull request.
+
+Observed worker state: %s.
+`, sess.IssueNumber, branch, reasonText)
 }
 
 // checkSessions inspects all sessions and updates their status

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -207,6 +207,69 @@ func TestReconcileRunningSessions_DeadWorkerWithOpenPR_TransitionsToPROpen(t *te
 	}
 }
 
+func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["mae-8"] = &state.Session{
+		IssueNumber: 108,
+		IssueTitle:  "add branch rescue",
+		Status:      state.StatusRunning,
+		PID:         8080,
+		TmuxSession: "maestro-mae-8",
+		Branch:      "feat/mae-8-108-add-branch-rescue",
+	}
+
+	var gotTitle, gotBody, gotBase, gotHead string
+	o := &Orchestrator{
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		remoteBranchExistsFn: func(branch string) (bool, error) {
+			return branch == "feat/mae-8-108-add-branch-rescue", nil
+		},
+		createPRFn: func(title, body, base, head string) (int, error) {
+			gotTitle, gotBody, gotBase, gotHead = title, body, base, head
+			return 144, nil
+		},
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["mae-8"]
+	if sess.Status != state.StatusPROpen {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusPROpen)
+	}
+	if sess.PRNumber != 144 {
+		t.Fatalf("pr_number = %d, want 144", sess.PRNumber)
+	}
+	if sess.PID != 0 {
+		t.Fatalf("pid = %d, want 0", sess.PID)
+	}
+	if sess.TmuxSession != "" {
+		t.Fatalf("tmux_session = %q, want empty", sess.TmuxSession)
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("finished_at should be set")
+	}
+	if gotBase != "main" {
+		t.Fatalf("base = %q, want main", gotBase)
+	}
+	if gotHead != "feat/mae-8-108-add-branch-rescue" {
+		t.Fatalf("head = %q", gotHead)
+	}
+	if !strings.Contains(gotTitle, "add branch rescue") || !strings.Contains(gotTitle, "(#108)") {
+		t.Fatalf("unexpected title %q", gotTitle)
+	}
+	if !strings.Contains(gotBody, "Closes #108") || !strings.Contains(gotBody, "auto-created") {
+		t.Fatalf("unexpected body %q", gotBody)
+	}
+	if !s.IssueInProgress(108) {
+		t.Fatal("IssueInProgress(108) must remain true after auto-created PR")
+	}
+}
+
 // TestReconcileRunningSessions_DeadWorkerNoPR_TransitionsToDead verifies that
 // the existing behaviour is preserved when no PR exists for the dead worker.
 func TestReconcileRunningSessions_DeadWorkerNoPR_TransitionsToDead(t *testing.T) {


### PR DESCRIPTION
## Summary
- detect stale running sessions whose branch was already pushed but has no PR
- auto-create a minimal PR for the pushed branch and transition the session to `pr_open`
- add regression coverage for the pushed-branch/no-PR rescue path

## Test
- go test ./internal/orchestrator -run TestReconcileRunningSessions -count=1
- go test ./internal/github ./internal/orchestrator
- go test ./...
- go build ./cmd/maestro/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a reconciliation rescue path that detects stale `running` sessions whose branch was pushed to the remote but no PR was opened, then auto-creates a minimal PR and transitions the session to `pr_open`. The implementation is well-structured with injectable function fields for testing, a dedicated notification message, and a new regression test.

- **P1 – hardcoded base branch**: `tryCreatePRForPushedBranch` calls `o.createPR(..., \"main\", branch)` unconditionally. For repositories whose default branch is `master` or another name, `gh pr create --base main` will fail, the function will return `(0, false)`, and the session will be marked dead — the exact regression this PR aims to prevent.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: the hardcoded base branch will silently defeat the rescue path on any repo not using `main`.

A single P1 defect — hardcoded `"main"` base branch — directly undermines the core purpose of this PR on non-`main` repos. The rest of the logic is sound and well-tested.

`internal/orchestrator/orchestrator.go` — specifically `tryCreatePRForPushedBranch` where the base branch is hardcoded.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds `CreatePR` method wrapping `gh pr create`; parses PR number from URL in output. Regex is compiled on every call (minor) but logic is sound. |
| internal/orchestrator/orchestrator.go | Adds `tryCreatePRForPushedBranch` rescue path and supporting helpers; base branch is hardcoded to `"main"` which will break for repos using `master` or other default branches. |
| internal/orchestrator/orchestrator_test.go | Adds regression test for the pushed-branch/no-PR rescue path; covers state transitions, PR arguments, and `IssueInProgress` invariant. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:1071
**Hardcoded base branch will fail for non-`main` repos**

The base branch is hardcoded to `"main"`, but `Config` has no `BaseBranch`/`DefaultBranch` field. For repositories whose default branch is `master` or anything else, `gh pr create --base main` will return an error, and `tryCreatePRForPushedBranch` will silently fall through to marking the session dead — the exact failure mode this PR is trying to prevent. The base branch should be derived from the repo or made configurable.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: auto-create PR for pushed worker br..."](https://github.com/befeast/maestro/commit/6904325c86c4f8fd01ea5363c367bc83a7aca563) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30303830)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->