### PR TITLE
fix: dedupe terminal retry notifications

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1557,8 +1557,12 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 
 		switch ciStatus {
 		case "success":
-			// Reset notification status when CI goes green
-			sess.LastNotifiedStatus = ""
+			// Reset CI-failure notification state when CI goes green. Keep
+			// review retry-exhausted markers so actionable feedback does not
+			// re-notify on every orchestration cycle.
+			if sess.LastNotifiedStatus == "ci_failure" || sess.LastNotifiedStatus == "ci_retry_exhausted" {
+				sess.LastNotifiedStatus = ""
+			}
 			sess.NotifiedCIFail = false // backward compat
 
 			if o.cfg.AutoRetryReviewFeedback {
@@ -1598,7 +1602,7 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				sess.Status = state.StatusPROpen
 			}
 			// Auto-retry on CI failure: close the PR, capture CI output, and schedule retry
-			if sess.LastNotifiedStatus != "ci_failure" {
+			if sess.LastNotifiedStatus != "ci_failure" && sess.LastNotifiedStatus != "ci_retry_exhausted" {
 				sess.NotifiedCIFail = true // backward compat
 
 				o.handleCIFailureRetry(s, slotName, sess, pr)
@@ -1688,6 +1692,7 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 	if maxRetries > 0 && totalAttempts >= maxRetries {
 		log.Printf("[orch] review feedback on PR #%d — retry limit reached (%d/%d) for issue #%d",
 			pr.Number, totalAttempts, maxRetries, sess.IssueNumber)
+		alreadyNotified := sess.LastNotifiedStatus == "review_retry_exhausted"
 		s.MarkIssueRetryExhausted(sess.IssueNumber)
 		o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
 		sess.Status = state.StatusRetryExhausted
@@ -1695,8 +1700,10 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 		sess.LastNotifiedStatus = "review_retry_exhausted"
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
-		o.notifier.Sendf("💀 maestro: review feedback on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
-			pr.Number, sess.IssueNumber, sess.IssueTitle, totalAttempts)
+		if !alreadyNotified {
+			o.notifier.Sendf("💀 maestro: review feedback on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
+				pr.Number, sess.IssueNumber, sess.IssueTitle, totalAttempts)
+		}
 		return
 	}
 
@@ -1741,11 +1748,19 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 	if maxRetries > 0 && totalAttempts >= maxRetries {
 		log.Printf("[orch] CI failure on PR #%d — retry limit reached (%d/%d) for issue #%d",
 			pr.Number, totalAttempts, maxRetries, sess.IssueNumber)
+		alreadyNotified := sess.LastNotifiedStatus == "ci_retry_exhausted"
 		// auto-label blocked disabled
 		s.MarkIssueRetryExhausted(sess.IssueNumber)
 		o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
-		o.notifier.Sendf("💀 maestro: CI failing on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
-			pr.Number, sess.IssueNumber, sess.IssueTitle, totalAttempts)
+		sess.Status = state.StatusRetryExhausted
+		sess.NextRetryAt = nil
+		sess.LastNotifiedStatus = "ci_retry_exhausted"
+		now := time.Now().UTC()
+		sess.FinishedAt = &now
+		if !alreadyNotified {
+			o.notifier.Sendf("💀 maestro: CI failing on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
+				pr.Number, sess.IssueNumber, sess.IssueTitle, totalAttempts)
+		}
 		return
 	}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1224,9 +1224,11 @@ func TestAutoMergePRs_ReviewFeedbackRetryLimitMarksTerminal(t *testing.T) {
 		MaxRetriesPerIssue:      3,
 		MaxRetryBackoffMs:       300000,
 	}
+	notifier := notify.NewWithToken("", "123", "", "")
+	notifier.SetDigestMode(true)
 	o := &Orchestrator{
 		cfg:      cfg,
-		notifier: &notify.Notifier{},
+		notifier: notifier,
 		listOpenPRsFn: func() ([]github.PR, error) {
 			return prs, nil
 		},
@@ -1252,6 +1254,15 @@ func TestAutoMergePRs_ReviewFeedbackRetryLimitMarksTerminal(t *testing.T) {
 	}
 	if sess.LastNotifiedStatus != "review_retry_exhausted" {
 		t.Fatalf("LastNotifiedStatus = %q, want review_retry_exhausted", sess.LastNotifiedStatus)
+	}
+	if notifier.Buffered() != 1 {
+		t.Fatalf("notifications buffered = %d, want 1", notifier.Buffered())
+	}
+
+	o.autoMergePRs(s)
+
+	if notifier.Buffered() != 1 {
+		t.Fatalf("duplicate terminal notification buffered; got %d, want 1", notifier.Buffered())
 	}
 }
 
@@ -1322,9 +1333,11 @@ func TestAutoMergePRs_RetryExhaustedActionableFeedbackStillBlocks(t *testing.T) 
 		MaxRetryBackoffMs:       300000,
 	}
 	merged := make([]int, 0)
+	notifier := notify.NewWithToken("", "123", "", "")
+	notifier.SetDigestMode(true)
 	o := &Orchestrator{
 		cfg:      cfg,
-		notifier: &notify.Notifier{},
+		notifier: notifier,
 		listOpenPRsFn: func() ([]github.PR, error) {
 			return prs, nil
 		},
@@ -1360,6 +1373,18 @@ func TestAutoMergePRs_RetryExhaustedActionableFeedbackStillBlocks(t *testing.T) 
 	}
 	if sess.LastNotifiedStatus != "review_retry_exhausted" {
 		t.Fatalf("LastNotifiedStatus = %q, want review_retry_exhausted", sess.LastNotifiedStatus)
+	}
+	if notifier.Buffered() != 1 {
+		t.Fatalf("notifications buffered = %d, want 1", notifier.Buffered())
+	}
+
+	o.autoMergePRs(s)
+
+	if len(merged) != 0 {
+		t.Fatalf("actionable review feedback should still block merge, got merged=%v", merged)
+	}
+	if notifier.Buffered() != 1 {
+		t.Fatalf("duplicate terminal notification buffered; got %d, want 1", notifier.Buffered())
 	}
 }
 
@@ -5036,6 +5061,9 @@ func TestAutoMergePRs_CIFailure_RetryLimitExhausted_NoRetry(t *testing.T) {
 	}
 	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", MaxRetriesPerIssue: 2, MaxRetryBackoffMs: 300000}
 	o, _, closedPRs := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{10: "failure"})
+	notifier := notify.NewWithToken("", "123", "", "")
+	notifier.SetDigestMode(true)
+	o.notifier = notifier
 	s := makeTestState(prs)
 
 	// Simulate 2 prior failed attempts for this issue
@@ -5059,10 +5087,31 @@ func TestAutoMergePRs_CIFailure_RetryLimitExhausted_NoRetry(t *testing.T) {
 		t.Fatalf("closedPRs = %v, want empty (retry limit exhausted)", *closedPRs)
 	}
 
-	// Session should still be pr_open (no retry scheduled)
+	// Session should be terminal, but keep the PR open for manual review/merge.
 	sess := s.Sessions["slot-0"]
-	if sess.Status != state.StatusPROpen {
-		t.Fatalf("status = %q, want %q (retry limit exhausted, PR stays open)", sess.Status, state.StatusPROpen)
+	if sess.Status != state.StatusRetryExhausted {
+		t.Fatalf("status = %q, want %q (retry limit exhausted, PR stays open)", sess.Status, state.StatusRetryExhausted)
+	}
+	if sess.PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want 10 (retry-exhausted PR remains open)", sess.PRNumber)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt should be nil after retry exhaustion")
+	}
+	if sess.LastNotifiedStatus != "ci_retry_exhausted" {
+		t.Fatalf("LastNotifiedStatus = %q, want ci_retry_exhausted", sess.LastNotifiedStatus)
+	}
+	if notifier.Buffered() != 1 {
+		t.Fatalf("notifications buffered = %d, want 1", notifier.Buffered())
+	}
+
+	o.autoMergePRs(s)
+
+	if len(*closedPRs) != 0 {
+		t.Fatalf("closedPRs after duplicate cycle = %v, want empty", *closedPRs)
+	}
+	if notifier.Buffered() != 1 {
+		t.Fatalf("duplicate terminal notification buffered; got %d, want 1", notifier.Buffered())
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep retry-exhausted notifications one-shot for CI and review feedback loops
- preserve review retry-exhausted markers across green CI cycles so actionable feedback does not spam every run
- mark CI retry-exhausted PR sessions terminal while keeping their PR open for manual review or later merge

## Test Plan
- go test ./...

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents duplicate terminal notifications for both CI-retry and review-feedback-retry exhaustion by introducing an `alreadyNotified` guard that checks `LastNotifiedStatus` before sending, and extends the `autoMergePRs` failure guard to skip re-entering `handleCIFailureRetry` once a session is `ci_retry_exhausted`. A secondary fix marks CI-exhausted sessions as `StatusRetryExhausted` (previously left as `StatusPROpen`) while keeping the GitHub PR open for manual review, consistent with the existing review-exhaustion behaviour.

<h3>Confidence Score: 5/5</h3>

Safe to merge — logic is correct, state transitions are consistent, and the new one-shot notification invariant is verified by updated tests.

No P0 or P1 issues found. The `alreadyNotified` guards are captured before the state mutation, the CI-green reset correctly preserves `review_retry_exhausted` while clearing CI-specific markers, and the `autoMergePRs` entry guard prevents re-calling `handleCIFailureRetry` after exhaustion. Tests are meaningfully extended with buffered-count assertions over two orchestration cycles.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Three targeted fixes: CI-green reset now preserves `review_retry_exhausted`; CI-failure guard extended to skip re-entry when already `ci_retry_exhausted`; `handleCIFailureRetry` now marks the session `StatusRetryExhausted` and gates notification with `alreadyNotified`, making exhaustion one-shot. |
| internal/orchestrator/orchestrator_test.go | Tests updated to use a real `notify.Notifier` in digest mode so buffered-count assertions can verify the one-shot notification guarantee; existing expectations updated to `StatusRetryExhausted` to match the new terminal state for CI exhaustion. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): dedupe terminal retry..."](https://github.com/befeast/maestro/commit/fbcb15f8746c9580f14236e7dd85a1939648e91f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30353933)</sub>

<!-- /greptile_comment -->