### PR TITLE
feat: add fleet dashboard for multiple projects

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -73,6 +73,7 @@ Supervise flags:
   maestro supervise reject <approval-or-decision-id>
 
 Serve flags:
+  --fleet string        Path to fleet YAML file for multi-project dashboard
   --host string         Host/interface to bind (default from config, then 127.0.0.1)
   --port int            Port to bind (overrides server.port)
   --read-only           Disable mutating HTTP endpoints (default true)
@@ -575,12 +576,52 @@ func serveCmd(args []string) {
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 	var configs multiFlag
 	fs.Var(&configs, "config", "Path to config file")
+	fleetPath := fs.String("fleet", "", "Path to fleet YAML file")
 	host := fs.String("host", "", "Host/interface to bind")
 	port := fs.Int("port", 0, "Port to bind")
 	readOnly := fs.Bool("read-only", true, "Disable mutating HTTP endpoints")
 	fs.Parse(args)
 
-	cfgs := loadConfigs(configs)
+	var cfgs []*config.Config
+	if strings.TrimSpace(*fleetPath) == "" {
+		cfgs = loadConfigs(configs)
+	}
+	if strings.TrimSpace(*fleetPath) != "" || len(cfgs) > 1 {
+		var projects []server.FleetProject
+		var err error
+		if strings.TrimSpace(*fleetPath) != "" {
+			projects, err = server.LoadFleetProjects(*fleetPath)
+			if err != nil {
+				log.Fatalf("load fleet: %v", err)
+			}
+		} else {
+			projects = fleetProjectsFromConfigs(cfgs)
+		}
+		fleetHost := *host
+		if strings.TrimSpace(fleetHost) == "" {
+			fleetHost = "127.0.0.1"
+		}
+		if *port <= 0 {
+			log.Fatalf("serve fleet requires --port")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			<-sigCh
+			cancel()
+		}()
+
+		log.Printf("serving fleet dashboard — projects=%d addr=%s:%d read_only=%v", len(projects), fleetHost, *port, *readOnly)
+		if err := server.NewFleet(projects, fleetHost, *port, *readOnly).Start(ctx); err != nil {
+			log.Fatalf("serve fleet: %v", err)
+		}
+		return
+	}
+
 	if len(cfgs) != 1 {
 		log.Fatalf("serve requires exactly one config, got %d", len(cfgs))
 	}
@@ -611,6 +652,23 @@ func serveCmd(args []string) {
 	if err := server.New(cfg, refreshCh).Start(ctx); err != nil {
 		log.Fatalf("serve: %v", err)
 	}
+}
+
+func fleetProjectsFromConfigs(cfgs []*config.Config) []server.FleetProject {
+	projects := make([]server.FleetProject, 0, len(cfgs))
+	for _, cfg := range cfgs {
+		projects = append(projects, server.NewFleetProject(defaultFleetProjectName(cfg.Repo), cfg.ResolvePath(), "", cfg))
+	}
+	return projects
+}
+
+func defaultFleetProjectName(repo string) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return "project"
+	}
+	parts := strings.Split(repo, "/")
+	return parts[len(parts)-1]
 }
 
 func statusCmd(args []string) {

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1,0 +1,536 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+	"gopkg.in/yaml.v3"
+)
+
+// FleetProject describes one Maestro project exposed in the fleet dashboard.
+type FleetProject struct {
+	Name         string `json:"name" yaml:"name"`
+	ConfigPath   string `json:"config_path" yaml:"config"`
+	DashboardURL string `json:"dashboard_url,omitempty" yaml:"dashboard_url"`
+
+	cfg *config.Config
+}
+
+// NewFleetProject wraps an already-loaded config for in-process fleet serving.
+func NewFleetProject(name, configPath, dashboardURL string, cfg *config.Config) FleetProject {
+	if strings.TrimSpace(name) == "" && cfg != nil {
+		name = defaultFleetProjectName(cfg.Repo)
+	}
+	return FleetProject{
+		Name:         strings.TrimSpace(name),
+		ConfigPath:   strings.TrimSpace(configPath),
+		DashboardURL: strings.TrimSpace(dashboardURL),
+		cfg:          cfg,
+	}
+}
+
+// FleetFile is the YAML shape accepted by maestro serve --fleet.
+type FleetFile struct {
+	Projects []FleetProject `yaml:"projects"`
+}
+
+// LoadFleetProjects loads a fleet YAML file and resolves every project config.
+func LoadFleetProjects(path string) ([]FleetProject, error) {
+	path = expandFleetPath(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read fleet file %s: %w", path, err)
+	}
+	var file FleetFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("parse fleet file %s: %w", path, err)
+	}
+	if len(file.Projects) == 0 {
+		return nil, fmt.Errorf("fleet file %s has no projects", path)
+	}
+
+	baseDir := filepath.Dir(path)
+	seen := make(map[string]struct{}, len(file.Projects))
+	projects := make([]FleetProject, 0, len(file.Projects))
+	for i, project := range file.Projects {
+		configPath := expandFleetPath(project.ConfigPath)
+		if configPath == "" {
+			return nil, fmt.Errorf("fleet project %d: config is required", i+1)
+		}
+		if !filepath.IsAbs(configPath) {
+			configPath = filepath.Join(baseDir, configPath)
+		}
+		project.ConfigPath = configPath
+		cfg, err := config.LoadFrom(project.ConfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("fleet project %d config %s: %w", i+1, project.ConfigPath, err)
+		}
+		project.cfg = cfg
+		if strings.TrimSpace(project.Name) == "" {
+			project.Name = defaultFleetProjectName(cfg.Repo)
+		}
+		project.Name = strings.TrimSpace(project.Name)
+		key := strings.ToLower(project.Name)
+		if _, exists := seen[key]; exists {
+			return nil, fmt.Errorf("duplicate fleet project name %q", project.Name)
+		}
+		seen[key] = struct{}{}
+		projects = append(projects, project)
+	}
+	return projects, nil
+}
+
+func expandFleetPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || path == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return path
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}
+
+func defaultFleetProjectName(repo string) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return "project"
+	}
+	parts := strings.Split(repo, "/")
+	return parts[len(parts)-1]
+}
+
+// FleetServer exposes a read-only dashboard/API across multiple Maestro configs.
+type FleetServer struct {
+	projects []FleetProject
+	host     string
+	port     int
+	readOnly bool
+	srv      *http.Server
+}
+
+// NewFleet creates a FleetServer.
+func NewFleet(projects []FleetProject, host string, port int, readOnly bool) *FleetServer {
+	return &FleetServer{
+		projects: projects,
+		host:     host,
+		port:     port,
+		readOnly: readOnly,
+	}
+}
+
+// Start begins serving the fleet dashboard. It blocks until shutdown.
+func (s *FleetServer) Start(ctx context.Context) error {
+	if s.port == 0 {
+		return nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/fleet", s.handleFleet)
+	mux.HandleFunc("/", s.handleFleetDashboard)
+
+	host := strings.TrimSpace(s.host)
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	addr := net.JoinHostPort(host, strconv.Itoa(s.port))
+	s.srv = &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s.srv.Shutdown(shutdownCtx)
+	}()
+
+	log.Printf("[fleet] listening on %s", addr)
+	if err := s.srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("fleet server: %w", err)
+	}
+	return nil
+}
+
+type fleetResponse struct {
+	ReadOnly bool                `json:"read_only"`
+	Projects []fleetProjectState `json:"projects"`
+	Summary  fleetSummary        `json:"summary"`
+}
+
+type fleetSummary struct {
+	Projects       int `json:"projects"`
+	Running        int `json:"running"`
+	PROpen         int `json:"pr_open"`
+	Failed         int `json:"failed"`
+	Sessions       int `json:"sessions"`
+	NeedsAttention int `json:"needs_attention"`
+}
+
+type fleetProjectState struct {
+	Name           string         `json:"name"`
+	Repo           string         `json:"repo"`
+	ConfigPath     string         `json:"config_path"`
+	DashboardURL   string         `json:"dashboard_url,omitempty"`
+	StateDir       string         `json:"state_dir,omitempty"`
+	MaxParallel    int            `json:"max_parallel"`
+	ReadOnly       bool           `json:"read_only"`
+	Summary        map[string]int `json:"summary"`
+	Running        int            `json:"running"`
+	PROpen         int            `json:"pr_open"`
+	Failed         int            `json:"failed"`
+	Sessions       int            `json:"sessions"`
+	NeedsAttention int            `json:"needs_attention"`
+	Active         []sessionInfo  `json:"active,omitempty"`
+	Supervisor     supervisorInfo `json:"supervisor"`
+	Error          string         `json:"error,omitempty"`
+}
+
+func (s *FleetServer) handleFleet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	writeJSON(w, http.StatusOK, s.snapshot())
+}
+
+func (s *FleetServer) snapshot() fleetResponse {
+	resp := fleetResponse{
+		ReadOnly: s.readOnly,
+		Projects: make([]fleetProjectState, 0, len(s.projects)),
+	}
+	for _, project := range s.projects {
+		item := s.projectSnapshot(project)
+		resp.Projects = append(resp.Projects, item)
+		resp.Summary.Projects++
+		resp.Summary.Running += item.Running
+		resp.Summary.PROpen += item.PROpen
+		resp.Summary.Failed += item.Failed
+		resp.Summary.Sessions += item.Sessions
+		resp.Summary.NeedsAttention += item.NeedsAttention
+	}
+	sort.Slice(resp.Projects, func(i, j int) bool {
+		if resp.Projects[i].Running != resp.Projects[j].Running {
+			return resp.Projects[i].Running > resp.Projects[j].Running
+		}
+		return resp.Projects[i].Name < resp.Projects[j].Name
+	})
+	return resp
+}
+
+func (s *FleetServer) projectSnapshot(project FleetProject) fleetProjectState {
+	cfg := project.cfg
+	item := fleetProjectState{
+		Name:         project.Name,
+		ConfigPath:   project.ConfigPath,
+		DashboardURL: project.DashboardURL,
+	}
+	if cfg == nil {
+		item.Error = "missing resolved project config"
+		return item
+	}
+	item.Repo = cfg.Repo
+	item.StateDir = cfg.StateDir
+	item.MaxParallel = cfg.MaxParallel
+	item.ReadOnly = cfg.Server.ReadOnly || s.readOnly
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		item.Error = err.Error()
+		return item
+	}
+	projectState := buildStateResponse(cfg, st)
+	item.Summary = projectState.Summary
+	item.Running = len(projectState.Running)
+	item.PROpen = len(projectState.PROpen)
+	item.Failed = failedCount(projectState.Summary)
+	item.Sessions = len(projectState.All)
+	item.Supervisor = projectState.Supervisor
+	for _, worker := range projectState.All {
+		if worker.NeedsAttention {
+			item.NeedsAttention++
+		}
+		if worker.Status == string(state.StatusRunning) || worker.Status == string(state.StatusPROpen) || worker.NeedsAttention {
+			item.Active = append(item.Active, worker)
+		}
+		if len(item.Active) >= 6 {
+			break
+		}
+	}
+	return item
+}
+
+func failedCount(summary map[string]int) int {
+	return summary[string(state.StatusDead)] +
+		summary[string(state.StatusFailed)] +
+		summary[string(state.StatusRetryExhausted)] +
+		summary[string(state.StatusConflictFailed)]
+}
+
+func (s *FleetServer) handleFleetDashboard(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, fleetDashboardHTML)
+}
+
+const fleetDashboardHTML = `<!DOCTYPE html>
+<html>
+<head>
+<title>maestro fleet</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    color-scheme: dark;
+    --bg: #0d1117;
+    --panel: #151b23;
+    --panel-2: #10161d;
+    --line: #29313d;
+    --text: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --ok: #3fb950;
+    --warn: #d29922;
+    --bad: #f85149;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  header {
+    min-height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--line);
+    background: #0b1016;
+  }
+  h1 { margin: 0; font-size: 19px; letter-spacing: 0; }
+  .sub { color: var(--muted); font-size: 13px; }
+  .stats { display: flex; gap: 18px; flex-wrap: wrap; justify-content: flex-end; }
+  .stat { text-align: right; min-width: 64px; }
+  .stat strong { display: block; font-size: 18px; }
+  .stat span { color: var(--muted); font-size: 12px; }
+  main { padding: 18px; }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+    gap: 14px;
+  }
+  .project {
+    border: 1px solid var(--line);
+    background: var(--panel);
+    min-height: 260px;
+  }
+  .project-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 14px;
+    padding: 14px 14px 10px;
+    border-bottom: 1px solid var(--line);
+  }
+  .project h2 { margin: 0; font-size: 17px; }
+  .repo { color: var(--muted); margin-top: 2px; font-size: 13px; }
+  .links { display: flex; gap: 10px; white-space: nowrap; font-size: 13px; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .metric-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    border-bottom: 1px solid var(--line);
+  }
+  .metric {
+    padding: 10px 8px;
+    border-right: 1px solid var(--line);
+    text-align: center;
+  }
+  .metric:last-child { border-right: 0; }
+  .metric strong { display: block; font-size: 16px; }
+  .metric span { display: block; color: var(--muted); font-size: 11px; }
+  .supervisor, .workers { padding: 12px 14px; border-bottom: 1px solid var(--line); }
+  .label { color: var(--muted); font-weight: 650; text-transform: uppercase; font-size: 12px; }
+  .decision { margin-top: 5px; color: var(--text); }
+  .decision small { color: var(--muted); }
+  table { width: 100%; border-collapse: collapse; margin-top: 8px; table-layout: fixed; }
+  td {
+    padding: 7px 0;
+    border-top: 1px solid rgba(41,49,61,.7);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  td:nth-child(1) { width: 78px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  td:nth-child(2) { width: 74px; }
+  td:nth-child(4) { width: 70px; text-align: right; color: var(--muted); }
+  .pill {
+    display: inline-block;
+    padding: 1px 8px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    font-size: 12px;
+  }
+  .s-running { color: var(--ok); border-color: rgba(63,185,80,.45); }
+  .s-pr_open { color: var(--accent); border-color: rgba(88,166,255,.45); }
+  .attention { color: var(--bad); border-color: rgba(248,81,73,.45); }
+  .empty { color: var(--muted); margin-top: 8px; }
+  .error { color: var(--bad); padding: 12px 14px; }
+  @media (max-width: 700px) {
+    header { align-items: flex-start; flex-direction: column; }
+    .stats { justify-content: flex-start; }
+    main { padding: 10px; }
+    .grid { grid-template-columns: 1fr; }
+    .metric-row { grid-template-columns: repeat(2, 1fr); }
+  }
+</style>
+</head>
+<body>
+<header>
+  <div>
+    <h1>Maestro Fleet</h1>
+    <div class="sub" id="subtitle">Loading projects...</div>
+  </div>
+  <div class="stats" id="stats"></div>
+</header>
+<main>
+  <div class="grid" id="projects"></div>
+</main>
+<script>
+const projectsEl = document.getElementById("projects");
+const statsEl = document.getElementById("stats");
+const subtitleEl = document.getElementById("subtitle");
+
+function escapeText(value) {
+  return String(value ?? "").replace(/[&<>"']/g, ch => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;"
+  }[ch]));
+}
+
+function linkHTML(url, label) {
+  if (!url) return escapeText(label);
+  return '<a href="' + escapeText(url) + '" target="_blank" rel="noreferrer">' + escapeText(label) + '</a>';
+}
+
+function statusClass(worker) {
+  let cls = "pill s-" + escapeText(worker.status || "unknown");
+  if (worker.needs_attention || (worker.status === "running" && worker.alive === false)) cls += " attention";
+  return cls;
+}
+
+function countFailed(project) {
+  return project.failed || 0;
+}
+
+function renderStats(summary) {
+  const items = [
+    ["Projects", summary.projects || 0],
+    ["Running", summary.running || 0],
+    ["PR open", summary.pr_open || 0],
+    ["Failed", summary.failed || 0],
+    ["Attention", summary.needs_attention || 0]
+  ];
+  statsEl.innerHTML = items.map(([label, value]) =>
+    '<div class="stat"><strong>' + escapeText(value) + '</strong><span>' + escapeText(label) + '</span></div>'
+  ).join("");
+}
+
+function renderSupervisor(project) {
+  const sup = project.supervisor;
+  if (!sup || !sup.has_run || !sup.latest) {
+    return '<div class="supervisor"><div class="label">Supervisor</div><div class="empty">No supervisor decision yet.</div></div>';
+  }
+  const latest = sup.latest;
+  const reasons = (latest.stuck_reasons && latest.stuck_reasons.length ? latest.stuck_reasons : latest.reasons || []).slice(0, 2);
+  return '<div class="supervisor">' +
+    '<div class="label">Supervisor</div>' +
+    '<div class="decision"><strong>' + escapeText(latest.recommended_action || "none") + '</strong> · ' +
+    escapeText(latest.summary || "") + '<br><small>Risk ' + escapeText(latest.risk || "-") +
+    (latest.confidence ? " · Confidence " + Number(latest.confidence).toFixed(2) : "") + '</small></div>' +
+    (reasons.length ? '<div class="empty">' + reasons.map(escapeText).join("<br>") + '</div>' : "") +
+  '</div>';
+}
+
+function renderWorkers(project) {
+  const workers = project.active || [];
+  if (!workers.length) {
+    return '<div class="workers"><div class="label">Active / attention</div><div class="empty">No active workers or attention states.</div></div>';
+  }
+  return '<div class="workers"><div class="label">Active / attention</div><table>' +
+    workers.map(worker => '<tr>' +
+      '<td>' + escapeText(worker.slot) + '</td>' +
+      '<td><span class="' + statusClass(worker) + '">' + escapeText(worker.status || "-") + '</span></td>' +
+      '<td>' + linkHTML(worker.issue_url, "#" + worker.issue_number) + ' ' + escapeText(worker.issue_title || "") + '</td>' +
+      '<td>' + escapeText(worker.runtime || "-") + '</td>' +
+    '</tr>').join("") +
+  '</table></div>';
+}
+
+function renderProject(project) {
+  if (project.error) {
+    return '<article class="project"><div class="project-head"><div><h2>' + escapeText(project.name) +
+      '</h2><div class="repo">' + escapeText(project.config_path || "") + '</div></div></div>' +
+      '<div class="error">State error: ' + escapeText(project.error) + '</div></article>';
+  }
+  const failed = countFailed(project);
+  return '<article class="project">' +
+    '<div class="project-head"><div><h2>' + escapeText(project.name) + '</h2><div class="repo">' +
+    escapeText(project.repo || "") + '</div></div><div class="links">' +
+    linkHTML(project.dashboard_url, "Dashboard") + " " + linkHTML(project.repo ? "https://github.com/" + project.repo : "", "GitHub") +
+    '</div></div>' +
+    '<div class="metric-row">' +
+      '<div class="metric"><strong>' + escapeText(project.running || 0) + " / " + escapeText(project.max_parallel || 0) + '</strong><span>Running</span></div>' +
+      '<div class="metric"><strong>' + escapeText(project.pr_open || 0) + '</strong><span>PR open</span></div>' +
+      '<div class="metric"><strong>' + escapeText(failed) + '</strong><span>Failed</span></div>' +
+      '<div class="metric"><strong>' + escapeText(project.sessions || 0) + '</strong><span>Sessions</span></div>' +
+      '<div class="metric"><strong>' + escapeText(project.needs_attention || 0) + '</strong><span>Attention</span></div>' +
+    '</div>' +
+    renderSupervisor(project) +
+    renderWorkers(project) +
+  '</article>';
+}
+
+async function loadFleet() {
+  try {
+    const response = await fetch("/api/v1/fleet", { cache: "no-store" });
+    if (!response.ok) throw new Error(await response.text());
+    const data = await response.json();
+    subtitleEl.textContent = (data.projects || []).length + " configured project" + ((data.projects || []).length === 1 ? "" : "s");
+    renderStats(data.summary || {});
+    projectsEl.innerHTML = (data.projects || []).map(renderProject).join("");
+  } catch (err) {
+    subtitleEl.textContent = "Fleet API error";
+    projectsEl.innerHTML = '<div class="error">' + escapeText(err.message) + '</div>';
+  }
+}
+
+loadFleet();
+setInterval(loadFleet, 3000);
+</script>
+</body>
+</html>`

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestLoadFleetProjects(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	configPath := filepath.Join(dir, "project.yaml")
+	if err := os.WriteFile(configPath, []byte("repo: owner/project\nstate_dir: "+stateDir+"\nsession_prefix: prj\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fleetPath := filepath.Join(dir, "fleet.yaml")
+	if err := os.WriteFile(fleetPath, []byte("projects:\n  - name: Project\n    config: project.yaml\n    dashboard_url: http://127.0.0.1:8787\n"), 0o644); err != nil {
+		t.Fatalf("write fleet: %v", err)
+	}
+
+	projects, err := LoadFleetProjects(fleetPath)
+	if err != nil {
+		t.Fatalf("LoadFleetProjects failed: %v", err)
+	}
+	if len(projects) != 1 {
+		t.Fatalf("projects len = %d, want 1", len(projects))
+	}
+	if projects[0].Name != "Project" {
+		t.Fatalf("project name = %q", projects[0].Name)
+	}
+	if projects[0].cfg == nil || projects[0].cfg.Repo != "owner/project" {
+		t.Fatalf("resolved config = %+v", projects[0].cfg)
+	}
+	if projects[0].DashboardURL != "http://127.0.0.1:8787" {
+		t.Fatalf("dashboard url = %q", projects[0].DashboardURL)
+	}
+}
+
+func TestFleetAPIAggregatesProjects(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	firstStateDir := filepath.Join(dir, "one")
+	secondStateDir := filepath.Join(dir, "two")
+	saveFleetTestState(t, firstStateDir, map[string]*state.Session{
+		"one-1": {
+			IssueNumber: 1,
+			IssueTitle:  "Build thing",
+			Status:      state.StatusRunning,
+			StartedAt:   now.Add(-time.Minute),
+			PID:         999999,
+			Backend:     "opencode",
+		},
+		"one-2": {
+			IssueNumber: 2,
+			IssueTitle:  "Review thing",
+			Status:      state.StatusPROpen,
+			StartedAt:   now.Add(-2 * time.Minute),
+			PRNumber:    12,
+		},
+	})
+	saveFleetTestState(t, secondStateDir, map[string]*state.Session{
+		"two-1": {
+			IssueNumber: 3,
+			IssueTitle:  "Broken thing",
+			Status:      state.StatusRetryExhausted,
+			StartedAt:   now.Add(-3 * time.Minute),
+		},
+	})
+
+	projects := []FleetProject{
+		NewFleetProject("One", "/tmp/one.yaml", "http://127.0.0.1:8787", &config.Config{
+			Repo:        "owner/one",
+			StateDir:    firstStateDir,
+			MaxParallel: 2,
+			Server:      config.ServerConfig{ReadOnly: true},
+		}),
+		NewFleetProject("Two", "/tmp/two.yaml", "", &config.Config{
+			Repo:        "owner/two",
+			StateDir:    secondStateDir,
+			MaxParallel: 1,
+		}),
+	}
+	srv := NewFleet(projects, "127.0.0.1", 8786, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleet(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp fleetResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Summary.Projects != 2 || resp.Summary.Running != 1 || resp.Summary.PROpen != 1 || resp.Summary.Failed != 1 || resp.Summary.Sessions != 3 {
+		t.Fatalf("unexpected summary: %+v", resp.Summary)
+	}
+	if resp.Projects[0].Name != "One" {
+		t.Fatalf("first project = %q, want One", resp.Projects[0].Name)
+	}
+	if len(resp.Projects[0].Active) != 2 {
+		t.Fatalf("project active len = %d, want 2", len(resp.Projects[0].Active))
+	}
+}
+
+func TestFleetDashboard(t *testing.T) {
+	srv := NewFleet(nil, "127.0.0.1", 8786, true)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleetDashboard(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("content-type = %q, want text/html", ct)
+	}
+	for _, want := range []string{"Maestro Fleet", "/api/v1/fleet", "renderProject"} {
+		if !contains(body, want) {
+			t.Fatalf("dashboard should contain %q", want)
+		}
+	}
+}
+
+func saveFleetTestState(t *testing.T, dir string, sessions map[string]*state.Session) {
+	t.Helper()
+	st := state.NewState()
+	for name, sess := range sessions {
+		st.Sessions[name] = sess
+	}
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -491,18 +491,22 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	writeJSON(w, http.StatusOK, buildStateResponse(s.cfg, st))
+}
+
+func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 	latestDecision := st.LatestSupervisorDecision()
 	resp := stateResponse{
-		Repo:                s.cfg.Repo,
-		MaxParallel:         s.cfg.MaxParallel,
-		ReadOnly:            s.cfg.Server.ReadOnly,
-		SupervisorPolicy:    s.cfg.Supervisor,
+		Repo:                cfg.Repo,
+		MaxParallel:         cfg.MaxParallel,
+		ReadOnly:            cfg.Server.ReadOnly,
+		SupervisorPolicy:    cfg.Supervisor,
 		All:                 make([]sessionInfo, 0, len(st.Sessions)),
 		Running:             make([]sessionInfo, 0),
 		PROpen:              make([]sessionInfo, 0),
 		Queued:              make([]sessionInfo, 0),
 		Summary:             make(map[string]int),
-		Supervisor:          buildSupervisorInfo(s.cfg, st),
+		Supervisor:          buildSupervisorInfo(cfg, st),
 		SupervisorLatest:    latestDecision,
 		SupervisorDecisions: st.SupervisorDecisions,
 		Approvals:           st.Approvals,
@@ -512,7 +516,7 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var activeTokens, totalTokens int
-	for _, info := range allSessionInfos(s.cfg.Repo, st) {
+	for _, info := range allSessionInfos(cfg.Repo, st) {
 		resp.All = append(resp.All, info)
 		resp.Summary[info.Status]++
 		totalTokens += info.TokensUsedTotal
@@ -534,7 +538,7 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 		Total:  totalTokens,
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	return resp
 }
 
 func (s *Server) handleWorkers(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- add `maestro serve --fleet` for a read-only multi-project dashboard
- expose `/api/v1/fleet` with per-project summaries, active workers, PR counts, and supervisor snapshots
- add fleet YAML loading plus tests for config resolution, API aggregation, and dashboard HTML

## Test plan
- `go test ./...`

## Workshop preview
- http://10.10.0.18:8786

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `maestro serve --fleet`, a read-only multi-project dashboard backed by `/api/v1/fleet`, along with YAML-based fleet config loading and an in-process aggregation path. The `server.go` refactor to extract `buildStateResponse` is clean. Two logic bugs in `fleet.go` need to be fixed before merging:

- `expandFleetPath(\"\")` returns the user's home directory instead of `\"\"`, which silently bypasses the `\"config is required\"` validation when a fleet YAML entry omits the `config` field.
- The `NeedsAttention` counter shares the same loop that breaks when `len(item.Active) >= 6`, causing attention counts to be underreported for busy projects.

<h3>Confidence Score: 3/5</h3>

Two P1 logic bugs in the core fleet aggregation file should be fixed before merging.

Two P1 findings are present: a path-expansion bug that silently skips required-field validation, and a counter that gets cut short by an unrelated loop cap. Both affect correctness of the new feature's core data path.

internal/server/fleet.go — `expandFleetPath` and `projectSnapshot` both need fixes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | New fleet server: two logic bugs — `expandFleetPath("")` resolves to home dir (bypasses "config required" guard), and `NeedsAttention` is undercounted when Active workers exceed the cap of 6. |
| cmd/maestro/main.go | Adds `--fleet` flag and fleet/multi-config branching logic; `defaultFleetProjectName` is duplicated from `fleet.go` but no functional bugs in the command routing. |
| internal/server/fleet_test.go | Tests cover config loading, API aggregation, and dashboard rendering; does not exercise the NeedsAttention-count edge case or a missing `config` field in fleet YAML. |
| internal/server/server.go | Refactors `handleState` to extract `buildStateResponse` for reuse by the fleet layer; straightforward and correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/fleet.go:96-101
**`expandFleetPath("")` silently expands to home directory**

When a fleet YAML entry omits the `config` field, `project.ConfigPath` is an empty string. `expandFleetPath("")` matches the `path == ""` branch and returns `os.UserHomeDir()` instead of `""`. This causes the `configPath == ""` guard below to be skipped, and `config.LoadFrom` is invoked against the user's home directory — producing a confusing error (or silently loading an unintended config) rather than the expected `"config is required"` message.

```suggestion
func expandFleetPath(path string) string {
	path = strings.TrimSpace(path)
	if path == "" {
		return path
	}
	if path == "~" {
		if home, err := os.UserHomeDir(); err == nil {
			return home
		}
		return path
	}
```

### Issue 2 of 2
internal/server/fleet.go:268-278
**`NeedsAttention` count is capped by the Active-workers limit**

The `break` at `len(item.Active) >= 6` exits the loop entirely, so any worker beyond the first six active entries never increments `item.NeedsAttention`. The per-project count and the fleet-level `summary.needs_attention` total are therefore underreported whenever a project has more than 6 active/attention workers. The fix is to count `NeedsAttention` in a separate pass before building the capped `Active` slice.

```suggestion
	for _, worker := range projectState.All {
		if worker.NeedsAttention {
			item.NeedsAttention++
		}
	}
	for _, worker := range projectState.All {
		if worker.Status == string(state.StatusRunning) || worker.Status == string(state.StatusPROpen) || worker.NeedsAttention {
			item.Active = append(item.Active, worker)
		}
		if len(item.Active) >= 6 {
			break
		}
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add fleet dashboard for multiple p..."](https://github.com/befeast/maestro/commit/73a25f3cfd7d23a86adf3b5a7c41c46b309d0223) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30450330)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->