### PR TITLE
Supervisor-owned ready label dispatch race

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/befeast/maestro/internal/pipeline"
 	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/supervisor"
 	"github.com/befeast/maestro/internal/versioning"
 	"github.com/befeast/maestro/internal/worker"
 )
@@ -2296,6 +2297,54 @@ func (o *Orchestrator) applyOrderedQueueFilter(s *state.State, issues []github.I
 	return nil, true
 }
 
+func (o *Orchestrator) supervisorOwnsDynamicReadyLabel() bool {
+	return o.cfg != nil && o.cfg.Supervisor.DynamicWave.Active() && o.cfg.Supervisor.DynamicWave.OwnsReadyLabel
+}
+
+func (o *Orchestrator) supervisorOwnedReadySelectedIssue(s *state.State) (int, bool) {
+	if !o.supervisorOwnsDynamicReadyLabel() || s == nil {
+		return 0, false
+	}
+	decision := s.LatestSupervisorDecision()
+	if decision == nil || decision.PolicyRule != supervisor.PolicyRuleDynamicWave {
+		return 0, false
+	}
+	if decision.QueueAnalysis != nil && decision.QueueAnalysis.SelectedCandidate != nil && decision.QueueAnalysis.SelectedCandidate.Number > 0 {
+		return decision.QueueAnalysis.SelectedCandidate.Number, true
+	}
+	if decision.Target != nil && decision.Target.Issue > 0 {
+		return decision.Target.Issue, true
+	}
+	return 0, false
+}
+
+func (o *Orchestrator) applySupervisorOwnedReadyFilter(s *state.State, issues []github.Issue) []github.Issue {
+	if !o.supervisorOwnsDynamicReadyLabel() || len(issues) == 0 {
+		return issues
+	}
+
+	selected, ok := o.supervisorOwnedReadySelectedIssue(s)
+	if !ok {
+		for _, issue := range issues {
+			log.Printf("[orch] skipping issue #%d: supervisor-owned ready label has no selected dynamic-wave candidate yet", issue.Number)
+		}
+		return nil
+	}
+
+	filtered := make([]github.Issue, 0, 1)
+	for _, issue := range issues {
+		if issue.Number == selected {
+			filtered = append(filtered, issue)
+			continue
+		}
+		log.Printf("[orch] skipping issue #%d: not supervisor-selected candidate #%d for supervisor-owned ready label", issue.Number, selected)
+	}
+	if len(filtered) == 0 {
+		log.Printf("[orch] supervisor-owned ready label selected issue #%d, but it is not currently returned by issue_labels", selected)
+	}
+	return filtered
+}
+
 func sortedStateSessionNames(s *state.State) []string {
 	names := make([]string, 0, len(s.Sessions))
 	for name := range s.Sessions {
@@ -2313,6 +2362,8 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 	}
 	if filtered, ordered := o.applyOrderedQueueFilter(s, issues); ordered {
 		issues = filtered
+	} else {
+		issues = o.applySupervisorOwnedReadyFilter(s, issues)
 	}
 
 	started := 0

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/supervisor"
 )
 
 func makeIssue(number int, title string, labels ...string) github.Issue {
@@ -2751,6 +2753,80 @@ func TestStartNewWorkers_SkipsClosedIssueWithDoneSession(t *testing.T) {
 
 	if len(*started) != 0 {
 		t.Fatalf("started %d workers, want 0 for already closed issue", len(*started))
+	}
+}
+
+func TestStartNewWorkers_SupervisorOwnedReadyLabelStartsOnlySelectedCandidate(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.IssueLabels = []string{"maestro-ready"}
+	dynamicWaveEnabled := true
+	cfg.Supervisor.DynamicWave.Enabled = &dynamicWaveEnabled
+	cfg.Supervisor.DynamicWave.OwnsReadyLabel = true
+	issues := []github.Issue{
+		makeIssue(292, "stale ready", "maestro-ready", "p0"),
+		makeIssue(287, "selected ready", "maestro-ready", "p1"),
+		makeIssue(291, "also stale", "maestro-ready", "p2"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+	s.RecordSupervisorDecision(state.SupervisorDecision{
+		CreatedAt:  time.Now().UTC(),
+		PolicyRule: supervisor.PolicyRuleDynamicWave,
+		QueueAnalysis: &state.SupervisorQueueAnalysis{
+			PolicyRule: supervisor.PolicyRuleDynamicWave,
+			SelectedCandidate: &state.SupervisorIssueCandidate{
+				Number: 287,
+			},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+
+	var logs strings.Builder
+	previousLogOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(previousLogOutput)
+
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 {
+		t.Fatalf("started = %v, want only selected issue #287", *started)
+	}
+	if (*started)[0] != 287 {
+		t.Fatalf("started issue #%d, want #287", (*started)[0])
+	}
+	if strings.Contains(logs.String(), "starting worker for issue #292") {
+		t.Fatalf("logs show stale issue #292 started:\n%s", logs.String())
+	}
+	if !strings.Contains(logs.String(), "skipping issue #292: not supervisor-selected candidate #287") {
+		t.Fatalf("logs = %q, want skip reason for stale ready issue", logs.String())
+	}
+}
+
+func TestStartNewWorkers_ManualIssueLabelsUnchangedWhenSupervisorDoesNotOwnReadyLabel(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.IssueLabels = []string{"maestro-ready"}
+	issues := []github.Issue{
+		makeIssue(292, "first ready", "maestro-ready"),
+		makeIssue(287, "second ready", "maestro-ready"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+	s.RecordSupervisorDecision(state.SupervisorDecision{
+		CreatedAt:  time.Now().UTC(),
+		PolicyRule: supervisor.PolicyRuleDynamicWave,
+		QueueAnalysis: &state.SupervisorQueueAnalysis{
+			PolicyRule: supervisor.PolicyRuleDynamicWave,
+			SelectedCandidate: &state.SupervisorIssueCandidate{
+				Number: 287,
+			},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+
+	o.startNewWorkers(s, 5)
+
+	if got, want := fmt.Sprint(*started), "[292 287]"; got != want {
+		t.Fatalf("started = %s, want %s", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #293

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a dispatch race where the orchestrator could start workers for issues carrying a stale ready label that the supervisor had not selected. When `DynamicWave.OwnsReadyLabel` is true, `startNewWorkers` now filters the issue list down to only the candidate named in the latest supervisor decision, blocking all other ready-labeled issues from being picked up until the supervisor explicitly selects them.

<h3>Confidence Score: 5/5</h3>

Safe to merge — logic is correct and well-bounded; all edge cases (no decision yet, stale candidate, missing from issue list) are handled safely.

No logic bugs found. The filter correctly handles every reachable state: no supervisor decision, a decision with no selected candidate, a decision whose candidate has been closed/removed from the label list, and the happy-path dispatch. The else-branch placement ensures the filter is a no-op when the ordered queue takes precedence.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds three new methods to gate issue dispatch behind the supervisor's selected DynamicWave candidate; integrated cleanly into startNewWorkers in the else-branch of applyOrderedQueueFilter |
| internal/orchestrator/orchestrator_test.go | Adds two focused tests covering the filtered-dispatch path and the passthrough path; the case where the selected candidate is absent from the issue list (warning log path) is not tested |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): gate supervisor-owned..."](https://github.com/befeast/maestro/commit/34f014ed9ec288021d460afffcdfb36a90218bcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30451833)</sub>

<!-- /greptile_comment -->