### PR TITLE
Fleet dashboard: explain attention states and supervisor reasons

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -203,6 +203,7 @@ type fleetProjectState struct {
 	Sessions       int            `json:"sessions"`
 	NeedsAttention int            `json:"needs_attention"`
 	Active         []sessionInfo  `json:"active,omitempty"`
+	Attention      []sessionInfo  `json:"attention,omitempty"`
 	Supervisor     supervisorInfo `json:"supervisor"`
 	Error          string         `json:"error,omitempty"`
 }
@@ -217,6 +218,7 @@ type fleetWorkerState struct {
 	IssueURL          string `json:"issue_url,omitempty"`
 	Status            string `json:"status"`
 	StatusReason      string `json:"status_reason,omitempty"`
+	NextAction        string `json:"next_action,omitempty"`
 	NeedsAttention    bool   `json:"needs_attention,omitempty"`
 	Backend           string `json:"backend,omitempty"`
 	PRNumber          int    `json:"pr_number,omitempty"`
@@ -298,7 +300,9 @@ func (s *FleetServer) handleFleetWorker(w http.ResponseWriter, r *http.Request) 
 		Repo:         project.cfg.Repo,
 		DashboardURL: project.DashboardURL,
 	}
-	worker := makeFleetWorkerState(projectState, makeSessionInfo(project.cfg.Repo, slot, sess))
+	infos := []sessionInfo{makeSessionInfo(project.cfg.Repo, slot, sess)}
+	applySupervisorAttention(infos, st.LatestSupervisorDecision())
+	worker := makeFleetWorkerState(projectState, infos[0])
 	lines := parsePositiveInt(r.URL.Query().Get("lines"), 260)
 	if lines > 1000 {
 		lines = 1000
@@ -436,6 +440,7 @@ func (s *FleetServer) projectSnapshot(project FleetProject) (fleetProjectState, 
 	for _, worker := range projectState.All {
 		if worker.NeedsAttention {
 			item.NeedsAttention++
+			item.Attention = append(item.Attention, worker)
 		}
 		if isFleetWorkerVisible(worker) {
 			workers = append(workers, makeFleetWorkerState(item, worker))
@@ -470,6 +475,7 @@ func makeFleetWorkerState(project fleetProjectState, worker sessionInfo) fleetWo
 		IssueURL:          worker.IssueURL,
 		Status:            worker.Status,
 		StatusReason:      worker.StatusReason,
+		NextAction:        worker.NextAction,
 		NeedsAttention:    worker.NeedsAttention,
 		Backend:           worker.Backend,
 		PRNumber:          worker.PRNumber,
@@ -758,6 +764,23 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   .attention { color: var(--bad); border-color: rgba(248,81,73,.45); }
   .empty { color: var(--muted); margin-top: 8px; }
   .worker-table .empty { padding: 18px 14px; margin: 0; text-align: center; }
+  .why-line {
+    margin-top: 3px;
+    color: var(--muted);
+    font-size: 12px;
+    line-height: 1.35;
+    white-space: normal;
+    overflow: hidden;
+    text-overflow: clip;
+  }
+  .why-line strong { color: var(--warn); font-weight: 650; }
+  .project-why {
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--line);
+    background: #0b1016;
+  }
+  .why-item { margin-top: 7px; color: var(--muted); font-size: 12px; line-height: 1.4; }
+  .why-item strong { color: var(--text); }
   .error { color: var(--bad); border: 1px solid rgba(248,81,73,.35); border-radius: 10px; background: rgba(248,81,73,.08); padding: 12px 14px; }
   @media (max-width: 700px) {
     header { align-items: flex-start; flex-direction: column; }
@@ -892,6 +915,20 @@ function rowClass(worker) {
   return "";
 }
 
+function workerWhyText(worker) {
+  const reason = worker.status_reason || "";
+  const action = worker.next_action || "";
+  if (!reason && !action) return "";
+  return reason + (action ? " Next: " + action : "");
+}
+
+function workerWhyHTML(worker) {
+  if (!worker.needs_attention && worker.status === "running") return "";
+  const why = workerWhyText(worker);
+  if (!why) return "";
+  return '<div class="why-line"><strong>Why:</strong> ' + escapeText(why) + '</div>';
+}
+
 function fleetWorkersFromData(data) {
   if (Array.isArray(data.workers)) return data.workers;
   return (data.projects || []).flatMap(project => (project.active || []).map(worker => ({
@@ -962,7 +999,9 @@ function renderFleetWorkers() {
   // The API response is already sorted with the server's authoritative status order.
   const visible = workers;
   const projectLabel = selected === "all" ? "all projects" : selected;
-  workerSummaryEl.textContent = visible.length + " active / recent / attention worker" + (visible.length === 1 ? "" : "s") + " in " + projectLabel;
+  const attentionCount = visible.filter(worker => worker.needs_attention).length;
+  workerSummaryEl.textContent = visible.length + " active / recent / attention worker" + (visible.length === 1 ? "" : "s") + " in " + projectLabel +
+    (attentionCount ? " · " + attentionCount + " need attention" : "");
 
   if (visible.length === 0) {
     const empty = selected === "all"
@@ -979,7 +1018,7 @@ function renderFleetWorkers() {
     return '<tr class="' + rowClass(worker) + selected + '" data-project="' + escapeText(worker.project_name || "") + '" data-slot="' + escapeText(worker.slot || "") + '" tabindex="0">' +
       '<td class="project-col">' + linkHTML(worker.dashboard_url, worker.project_name || "-") + '</td>' +
       '<td class="slot-col">' + escapeText(worker.slot || "-") + '</td>' +
-      '<td class="issue-col">' + linkHTML(worker.issue_url, issue) + ' ' + escapeText(worker.issue_title || "") + '</td>' +
+      '<td class="issue-col">' + linkHTML(worker.issue_url, issue) + ' ' + escapeText(worker.issue_title || "") + workerWhyHTML(worker) + '</td>' +
       '<td class="status-col"><span class="' + statusClass(worker) + '">' + escapeText(statusLabel(worker)) + '</span></td>' +
       '<td class="backend-col">' + escapeText(worker.backend || "-") + '</td>' +
       '<td class="pr-col">' + linkHTML(worker.pr_url, pr) + '</td>' +
@@ -1075,7 +1114,7 @@ function renderWorkerDetail(data) {
   ].join("");
 
   const noteClass = worker.needs_attention || (worker.status === "running" && worker.alive === false) ? " detail-note attention" : "detail-note";
-  const reason = worker.status_reason || "Waiting for the next Maestro reconciliation cycle.";
+  const reason = workerWhyText(worker) || "Waiting for the next Maestro reconciliation cycle.";
   const logText = log.available ? (log.text || emptyLogText(worker)) : (log.reason || "Log output is unavailable for this session.");
   const logMeta = log.available
     ? (log.truncated ? "tail, " : "") + (log.updated_at || "")
@@ -1129,6 +1168,30 @@ function renderSupervisor(project) {
   '</div>';
 }
 
+function supervisorWhyText(project) {
+  const latest = project && project.supervisor && project.supervisor.latest;
+  if (!latest) return "";
+  if (latest.summary) return latest.summary;
+  const reasons = latest.stuck_reasons && latest.stuck_reasons.length ? latest.stuck_reasons : latest.reasons || [];
+  return reasons.length ? reasons[0] : "";
+}
+
+function renderProjectWhy(project) {
+  const attention = project.attention || [];
+  if (attention.length) {
+    return '<div class="project-why"><div class="label">Why Attention</div>' +
+      attention.map(worker => '<div class="why-item"><strong>' + escapeText(worker.slot || "-") + '</strong> ' +
+        escapeText(workerWhyText(worker) || "Needs operator review.") + '</div>').join("") +
+      '</div>';
+  }
+  const why = supervisorWhyText(project);
+  if ((project.running || 0) === 0 && why) {
+    return '<div class="project-why"><div class="label">Why Not Running</div>' +
+      '<div class="why-item">' + escapeText(why) + '</div></div>';
+  }
+  return "";
+}
+
 function renderWorkers(project) {
   const workers = project.active || [];
   if (!workers.length) {
@@ -1138,7 +1201,7 @@ function renderWorkers(project) {
     workers.map(worker => '<tr>' +
       '<td>' + escapeText(worker.slot) + '</td>' +
       '<td><span class="' + statusClass(worker) + '">' + escapeText(statusLabel(worker)) + '</span></td>' +
-      '<td>' + linkHTML(worker.issue_url, "#" + worker.issue_number) + ' ' + escapeText(worker.issue_title || "") + '</td>' +
+      '<td>' + linkHTML(worker.issue_url, "#" + worker.issue_number) + ' ' + escapeText(worker.issue_title || "") + workerWhyHTML(worker) + '</td>' +
       '<td>' + escapeText(worker.runtime || "-") + '</td>' +
     '</tr>').join("") +
   '</table></div>';
@@ -1163,6 +1226,7 @@ function renderProject(project) {
       '<div class="metric"><strong>' + escapeText(project.sessions || 0) + '</strong><span>Sessions</span></div>' +
       '<div class="metric"><strong>' + escapeText(project.needs_attention || 0) + '</strong><span>Attention</span></div>' +
     '</div>' +
+    renderProjectWhy(project) +
     renderSupervisor(project) +
     renderWorkers(project) +
   '</article>';

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -916,10 +916,12 @@ function rowClass(worker) {
 }
 
 function workerWhyText(worker) {
-  const reason = worker.status_reason || "";
-  const action = worker.next_action || "";
+  const reason = (worker.status_reason || "").trim();
+  const action = (worker.next_action || "").trim();
   if (!reason && !action) return "";
-  return reason + (action ? " Next: " + action : "");
+  if (!reason) return "Next: " + action;
+  const sep = reason.endsWith(".") || reason.endsWith("!") || reason.endsWith("?") ? " " : ". ";
+  return reason + (action ? sep + "Next: " + action : "");
 }
 
 function workerWhyHTML(worker) {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -69,10 +69,12 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	})
 	saveFleetTestState(t, secondStateDir, map[string]*state.Session{
 		"two-1": {
-			IssueNumber: 3,
-			IssueTitle:  "Broken thing",
-			Status:      state.StatusRetryExhausted,
-			StartedAt:   now.Add(-3 * time.Minute),
+			IssueNumber:     3,
+			IssueTitle:      "Broken thing",
+			Status:          state.StatusRetryExhausted,
+			StartedAt:       now.Add(-3 * time.Minute),
+			PRNumber:        31,
+			CIFailureOutput: "tests failed",
 		},
 	})
 
@@ -105,6 +107,15 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	if resp.Summary.Projects != 2 || resp.Summary.Running != 1 || resp.Summary.PROpen != 1 || resp.Summary.Failed != 1 || resp.Summary.Sessions != 3 || resp.Summary.NeedsAttention != 2 {
 		t.Fatalf("unexpected summary: %+v", resp.Summary)
 	}
+	visibleAttention := 0
+	for _, worker := range resp.Workers {
+		if worker.NeedsAttention {
+			visibleAttention++
+		}
+	}
+	if resp.Summary.NeedsAttention != visibleAttention {
+		t.Fatalf("summary attention = %d, visible attention rows = %d", resp.Summary.NeedsAttention, visibleAttention)
+	}
 	if resp.Projects[0].Name != "One" {
 		t.Fatalf("first project = %q, want One", resp.Projects[0].Name)
 	}
@@ -130,6 +141,15 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	attentionWorker := findFleetWorker(t, resp.Workers, "two-1")
 	if !attentionWorker.NeedsAttention {
 		t.Fatal("retry-exhausted worker should need attention")
+	}
+	if !contains(attentionWorker.StatusReason, "checks failed") || !contains(attentionWorker.StatusReason, "PR #31 remains open") {
+		t.Fatalf("attention status_reason = %q, want failed checks and open PR", attentionWorker.StatusReason)
+	}
+	if !contains(attentionWorker.NextAction, "Fix failing checks") {
+		t.Fatalf("attention next_action = %q, want fix checks guidance", attentionWorker.NextAction)
+	}
+	if resp.Projects[1].NeedsAttention != len(resp.Projects[1].Attention) {
+		t.Fatalf("project attention count = %d, reasons = %d", resp.Projects[1].NeedsAttention, len(resp.Projects[1].Attention))
 	}
 }
 
@@ -371,7 +391,7 @@ func TestFleetDashboard(t *testing.T) {
 	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
 		t.Errorf("content-type = %q, want text/html", ct)
 	}
-	for _, want := range []string{"Maestro Fleet", "/api/v1/fleet", "/api/v1/fleet/worker", "project-tabs", "fleet-workers-body", "worker-detail", "renderFleetWorkers", "renderWorkerDetail", "renderProject"} {
+	for _, want := range []string{"Maestro Fleet", "/api/v1/fleet", "/api/v1/fleet/worker", "project-tabs", "fleet-workers-body", "worker-detail", "renderFleetWorkers", "renderWorkerDetail", "renderProject", "Why Attention", "Why Not Running", "next_action"} {
 		if !contains(body, want) {
 			t.Fatalf("dashboard should contain %q", want)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -456,7 +456,7 @@ func applySupervisorAttention(infos []sessionInfo, latest *state.SupervisorDecis
 				continue
 			}
 			attention := supervisorStuckNeedsAttention(stuck)
-			if !infos[i].NeedsAttention && !attention {
+			if !attention {
 				continue
 			}
 			if strings.TrimSpace(stuck.Summary) != "" {
@@ -478,8 +478,8 @@ func stuckTargetsSession(stuck state.SupervisorStuckState, info sessionInfo) boo
 	if target == nil {
 		return false
 	}
-	if strings.TrimSpace(target.Session) != "" && target.Session == info.Slot {
-		return true
+	if session := strings.TrimSpace(target.Session); session != "" {
+		return session == info.Slot
 	}
 	if target.PR > 0 && target.PR == info.PRNumber {
 		return true

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -178,6 +178,7 @@ type sessionInfo struct {
 	IssueURL          string `json:"issue_url,omitempty"`
 	Status            string `json:"status"`
 	StatusReason      string `json:"status_reason,omitempty"`
+	NextAction        string `json:"next_action,omitempty"`
 	NeedsAttention    bool   `json:"needs_attention,omitempty"`
 	Backend           string `json:"backend,omitempty"`
 	PRNumber          int    `json:"pr_number,omitempty"`
@@ -235,7 +236,10 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 	if sess.NextRetryAt != nil {
 		info.NextRetryAt = sess.NextRetryAt.Format(time.RFC3339)
 	}
-	info.StatusReason, info.NeedsAttention = sessionStatusReason(sess, info.Alive)
+	attention := state.SessionAttentionFor(sess, info.Alive)
+	info.StatusReason = attention.Reason
+	info.NextAction = attention.NextAction
+	info.NeedsAttention = attention.NeedsAttention
 
 	return info
 }
@@ -414,44 +418,6 @@ func validGitHubRepo(repo string) bool {
 	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
 }
 
-func sessionStatusReason(sess *state.Session, alive *bool) (string, bool) {
-	switch sess.Status {
-	case state.StatusRunning:
-		if alive != nil && !*alive {
-			return "State says running, but the worker PID is not alive. Maestro should reconcile it on the next cycle.", true
-		}
-		if sess.PID == 0 {
-			return "Worker is marked running, but no PID is recorded.", true
-		}
-		return "Worker process is alive and writing to its session log.", false
-	case state.StatusPROpen:
-		if sess.PRNumber > 0 {
-			return "PR is open; Maestro is waiting for CI, review gate, merge interval, or conflict handling.", false
-		}
-		return "Session is waiting on an open PR, but no PR number is recorded yet.", true
-	case state.StatusQueued:
-		return "Worker is queued for follow-up processing before it can be merged.", false
-	case state.StatusDead:
-		if sess.NextRetryAt != nil {
-			return "Worker exited; a retry is scheduled after the current backoff.", true
-		}
-		return "Worker exited and is waiting for retry or reconciliation.", true
-	case state.StatusRetryExhausted:
-		if sess.PRNumber > 0 {
-			return "Retry limit exhausted with a PR still open; Maestro can still merge it when checks and review gates pass, but action is needed if checks fail or actionable review feedback remains.", true
-		}
-		return "Retry limit exhausted before a usable PR was produced.", true
-	case state.StatusFailed:
-		return "Worker failed after the configured retry policy.", true
-	case state.StatusConflictFailed:
-		return "Automatic conflict resolution failed; the branch needs manual rebase/conflict handling.", true
-	case state.StatusDone:
-		return "Issue is complete; PR merged or issue was closed and the session is terminal.", false
-	default:
-		return "Session is waiting for the next Maestro reconciliation cycle.", false
-	}
-}
-
 func watchSessionName(slot string, sess *state.Session) string {
 	if strings.TrimSpace(sess.TmuxSession) != "" {
 		return sess.TmuxSession
@@ -464,6 +430,7 @@ func allSessionInfos(repo string, st *state.State) []sessionInfo {
 	for slot, sess := range st.Sessions {
 		infos = append(infos, makeSessionInfo(repo, slot, sess))
 	}
+	applySupervisorAttention(infos, st.LatestSupervisorDecision())
 	sort.Slice(infos, func(i, j int) bool {
 		left, right := infos[i], infos[j]
 		li := state.StatusPriority(state.SessionStatus(left.Status))
@@ -477,6 +444,55 @@ func allSessionInfos(repo string, st *state.State) []sessionInfo {
 		return left.Slot < right.Slot
 	})
 	return infos
+}
+
+func applySupervisorAttention(infos []sessionInfo, latest *state.SupervisorDecision) {
+	if latest == nil || len(latest.StuckStates) == 0 {
+		return
+	}
+	for i := range infos {
+		for _, stuck := range latest.StuckStates {
+			if !stuckTargetsSession(stuck, infos[i]) {
+				continue
+			}
+			attention := supervisorStuckNeedsAttention(stuck)
+			if !infos[i].NeedsAttention && !attention {
+				continue
+			}
+			if strings.TrimSpace(stuck.Summary) != "" {
+				infos[i].StatusReason = stuck.Summary
+			}
+			if strings.TrimSpace(stuck.RecommendedAction) != "" {
+				infos[i].NextAction = stuck.RecommendedAction
+			}
+			if attention {
+				infos[i].NeedsAttention = true
+			}
+			break
+		}
+	}
+}
+
+func stuckTargetsSession(stuck state.SupervisorStuckState, info sessionInfo) bool {
+	target := stuck.Target
+	if target == nil {
+		return false
+	}
+	if strings.TrimSpace(target.Session) != "" && target.Session == info.Slot {
+		return true
+	}
+	if target.PR > 0 && target.PR == info.PRNumber {
+		return true
+	}
+	return target.Issue > 0 && target.Issue == info.IssueNumber
+}
+
+func supervisorStuckNeedsAttention(stuck state.SupervisorStuckState) bool {
+	switch stuck.Code {
+	case "retry_exhausted", "retry_exhausted_open_pr", "dead_running_pid", "stale_worker_logs", "worker_timeout", "failing_checks", "closed_pr_with_active_session", "unmergeable_pr", "stale_review_feedback", "greptile_not_approved":
+		return true
+	}
+	return stuck.Severity == "blocked"
 }
 
 func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
@@ -1308,8 +1324,9 @@ function renderSelectedDetails() {
   if (worker.issue_url) links.push(linkHTML(worker.issue_url, "Issue #" + worker.issue_number));
   if (worker.pr_url) links.push(linkHTML(worker.pr_url, "PR #" + worker.pr_number));
   const retry = worker.next_retry_at ? " Next retry: " + worker.next_retry_at + "." : "";
+  const next = worker.next_action ? " Next: " + worker.next_action : "";
   statusNoteEl.innerHTML = '<strong>Why</strong>' +
-    escapeText((worker.status_reason || "Waiting for next reconciliation cycle.") + retry) +
+    escapeText((worker.status_reason || "Waiting for next reconciliation cycle.") + retry + next) +
     (links.length ? '<span class="links">' + links.join("") + '</span>' : "");
   statusNoteEl.classList.add("visible");
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -336,6 +336,88 @@ func TestHandleStateMapsSupervisorAttentionToWorker(t *testing.T) {
 	}
 }
 
+func TestApplySupervisorAttentionSessionTargetDoesNotFallback(t *testing.T) {
+	infos := []sessionInfo{
+		{Slot: "slot-1", IssueNumber: 77, PRNumber: 31},
+		{Slot: "slot-2", IssueNumber: 77, PRNumber: 31},
+	}
+	decision := &state.SupervisorDecision{
+		StuckStates: []state.SupervisorStuckState{
+			{
+				Code:              "failing_checks",
+				Severity:          "blocked",
+				Summary:           "Slot 1 checks failed",
+				RecommendedAction: "Fix slot 1 checks.",
+				Target:            &state.SupervisorTarget{Issue: 77, PR: 31, Session: "slot-1"},
+			},
+		},
+	}
+
+	applySupervisorAttention(infos, decision)
+
+	if !infos[0].NeedsAttention || infos[0].StatusReason != "Slot 1 checks failed" {
+		t.Fatalf("slot-1 attention = %#v, want targeted supervisor reason", infos[0])
+	}
+	if infos[1].NeedsAttention || infos[1].StatusReason != "" || infos[1].NextAction != "" {
+		t.Fatalf("slot-2 attention = %#v, want no session-targeted fallback", infos[1])
+	}
+}
+
+func TestApplySupervisorAttentionSkipsInformationalStuckStates(t *testing.T) {
+	baseReason := "State says running, but the worker PID is not alive."
+	baseAction := "Run a Maestro reconciliation cycle."
+	infos := []sessionInfo{
+		{Slot: "slot-1", IssueNumber: 77, PRNumber: 31, NeedsAttention: true, StatusReason: baseReason, NextAction: baseAction},
+	}
+	decision := &state.SupervisorDecision{
+		StuckStates: []state.SupervisorStuckState{
+			{
+				Code:              "draft_pr",
+				Severity:          "info",
+				Summary:           "PR is still a draft.",
+				RecommendedAction: "Wait for the author to mark the PR ready.",
+				Target:            &state.SupervisorTarget{Issue: 77, PR: 31, Session: "slot-1"},
+			},
+		},
+	}
+
+	applySupervisorAttention(infos, decision)
+
+	if infos[0].StatusReason != baseReason || infos[0].NextAction != baseAction {
+		t.Fatalf("attention reason/action = %q/%q, want base dead-PID reason/action", infos[0].StatusReason, infos[0].NextAction)
+	}
+}
+
+func TestApplySupervisorAttentionUsesLaterAttentionStuckState(t *testing.T) {
+	infos := []sessionInfo{
+		{Slot: "slot-1", IssueNumber: 77, PRNumber: 31, NeedsAttention: true, StatusReason: "Base reason.", NextAction: "Base action."},
+	}
+	decision := &state.SupervisorDecision{
+		StuckStates: []state.SupervisorStuckState{
+			{
+				Code:              "draft_pr",
+				Severity:          "info",
+				Summary:           "PR is still a draft.",
+				RecommendedAction: "Wait for the author to mark the PR ready.",
+				Target:            &state.SupervisorTarget{Issue: 77, PR: 31, Session: "slot-1"},
+			},
+			{
+				Code:              "failing_checks",
+				Severity:          "blocked",
+				Summary:           "Checks are failing.",
+				RecommendedAction: "Fix failing checks.",
+				Target:            &state.SupervisorTarget{Issue: 77, PR: 31, Session: "slot-1"},
+			},
+		},
+	}
+
+	applySupervisorAttention(infos, decision)
+
+	if infos[0].StatusReason != "Checks are failing." || infos[0].NextAction != "Fix failing checks." {
+		t.Fatalf("attention reason/action = %q/%q, want later blocked stuck state", infos[0].StatusReason, infos[0].NextAction)
+	}
+}
+
 func TestHandleState_IncludesApprovals(t *testing.T) {
 	srv, cfg := setupTestServer(t)
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -148,6 +148,9 @@ func TestHandleState(t *testing.T) {
 	if !contains(resp.Running[0].StatusReason, "PID is not alive") {
 		t.Errorf("status_reason = %q, want dead PID hint", resp.Running[0].StatusReason)
 	}
+	if !contains(resp.Running[0].NextAction, "reconciliation cycle") {
+		t.Errorf("next_action = %q, want reconciliation guidance", resp.Running[0].NextAction)
+	}
 	if resp.PROpen[0].PRURL != "https://github.com/test/repo/pull/10" {
 		t.Errorf("pr_url = %q", resp.PROpen[0].PRURL)
 	}
@@ -270,6 +273,66 @@ func TestHandleStateSupervisorRationale(t *testing.T) {
 	}
 	if resp.SupervisorLatest == nil || resp.SupervisorLatest.ID != "sup-latest" {
 		t.Fatalf("legacy supervisor_latest = %#v, want sup-latest", resp.SupervisorLatest)
+	}
+}
+
+func TestHandleStateMapsSupervisorAttentionToWorker(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{Repo: "test/repo", MaxParallel: 2, StateDir: dir, Server: config.ServerConfig{Port: 8765}}
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber:     77,
+		IssueTitle:      "fix checks",
+		Status:          state.StatusRetryExhausted,
+		StartedAt:       now.Add(-time.Hour),
+		PRNumber:        31,
+		CIFailureOutput: "go test failed",
+	}
+	st.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-checks",
+		CreatedAt:         now,
+		Project:           "test/repo",
+		Mode:              "read_only",
+		Summary:           "Issue #77 is retry exhausted, but PR #31 is still open; checks=failure.",
+		RecommendedAction: "review_retry_exhausted",
+		Target:            &state.SupervisorTarget{Issue: 77, PR: 31, Session: "slot-1"},
+		Risk:              "approval_gated",
+		Confidence:        0.93,
+		StuckStates: []state.SupervisorStuckState{
+			{
+				Code:              "retry_exhausted_open_pr",
+				Severity:          "blocked",
+				Summary:           "Issue #77 is retry exhausted, but PR #31 is still open; checks=failure.",
+				RecommendedAction: "Fix failing checks or retry intentionally before this PR can merge.",
+				Target:            &state.SupervisorTarget{Issue: 77, PR: 31, Session: "slot-1"},
+			},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	srv := New(cfg, make(chan struct{}, 1))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.handleState(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp stateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.All) != 1 || !resp.All[0].NeedsAttention {
+		t.Fatalf("worker attention mapping missing: %#v", resp.All)
+	}
+	if !contains(resp.All[0].StatusReason, "PR #31 is still open") || !contains(resp.All[0].StatusReason, "checks=failure") {
+		t.Fatalf("status_reason = %q, want open PR and failing checks", resp.All[0].StatusReason)
+	}
+	if !contains(resp.All[0].NextAction, "Fix failing checks") {
+		t.Fatalf("next_action = %q, want fix checks guidance", resp.All[0].NextAction)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -67,6 +68,109 @@ type Session struct {
 	PreviousAttemptFeedback     string        `json:"previous_attempt_feedback,omitempty"`      // feedback from previous failed PR attempt
 	PreviousAttemptFeedbackKind string        `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
 	CheckpointFile              string        `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
+}
+
+// SessionAttention explains why a session needs operator attention and the
+// safest next action Maestro can infer from persisted state.
+type SessionAttention struct {
+	Reason         string
+	NextAction     string
+	NeedsAttention bool
+}
+
+// SessionAttentionFor returns a concise, state-backed explanation for a session.
+// The alive pointer should be provided only when the caller has checked the
+// recorded running process.
+func SessionAttentionFor(sess *Session, alive *bool) SessionAttention {
+	if sess == nil {
+		return SessionAttention{}
+	}
+
+	switch sess.Status {
+	case StatusRunning:
+		if alive != nil && !*alive {
+			return SessionAttention{
+				Reason:         "State says running, but the worker PID is not alive.",
+				NextAction:     "Run a Maestro reconciliation cycle so the session can be marked dead and retried if eligible.",
+				NeedsAttention: true,
+			}
+		}
+		if sess.PID == 0 {
+			return SessionAttention{
+				Reason:         "Worker is marked running, but no PID is recorded.",
+				NextAction:     "Run a Maestro reconciliation cycle or inspect the worker before dispatching more work.",
+				NeedsAttention: true,
+			}
+		}
+		return SessionAttention{Reason: "Worker process is alive and writing to its session log."}
+	case StatusPROpen:
+		if sess.PRNumber > 0 {
+			return SessionAttention{Reason: "PR is open; Maestro is waiting for CI, review gate, merge interval, or conflict handling."}
+		}
+		return SessionAttention{
+			Reason:         "Session is waiting on an open PR, but no PR number is recorded yet.",
+			NextAction:     "Reconcile the session with the GitHub PR before dispatching duplicate work.",
+			NeedsAttention: true,
+		}
+	case StatusQueued:
+		return SessionAttention{Reason: "Worker is queued for follow-up processing before it can be merged."}
+	case StatusDead:
+		if sess.NextRetryAt != nil {
+			return SessionAttention{
+				Reason:         "Worker exited; a retry is scheduled after the current backoff.",
+				NextAction:     "Wait for the scheduled retry or inspect the failed attempt if it should not retry.",
+				NeedsAttention: true,
+			}
+		}
+		return SessionAttention{
+			Reason:         "Worker exited and is waiting for retry or reconciliation.",
+			NextAction:     "Run a Maestro reconciliation cycle or review the failed attempt.",
+			NeedsAttention: true,
+		}
+	case StatusRetryExhausted:
+		if sess.PRNumber > 0 {
+			if sessionHasFailedCheckEvidence(sess) {
+				return SessionAttention{
+					Reason:         fmt.Sprintf("Retry limit exhausted after checks failed; PR #%d remains open.", sess.PRNumber),
+					NextAction:     "Fix failing checks or retry intentionally before this PR can merge.",
+					NeedsAttention: true,
+				}
+			}
+			return SessionAttention{
+				Reason:         fmt.Sprintf("Retry limit exhausted with PR #%d still open.", sess.PRNumber),
+				NextAction:     "Keep the PR in normal merge flow if checks and review gates pass; otherwise retry intentionally.",
+				NeedsAttention: true,
+			}
+		}
+		return SessionAttention{
+			Reason:         "Retry limit exhausted before a usable PR was produced.",
+			NextAction:     "Review the failed attempts, adjust the issue or retry budget, then restart intentionally.",
+			NeedsAttention: true,
+		}
+	case StatusFailed:
+		return SessionAttention{
+			Reason:         "Worker failed after the configured retry policy.",
+			NextAction:     "Review the failure and restart intentionally when the issue is ready.",
+			NeedsAttention: true,
+		}
+	case StatusConflictFailed:
+		return SessionAttention{
+			Reason:         "Automatic conflict resolution failed; the branch needs manual rebase/conflict handling.",
+			NextAction:     "Rebase or resolve conflicts before retrying or merging.",
+			NeedsAttention: true,
+		}
+	case StatusDone:
+		return SessionAttention{Reason: "Issue is complete; PR merged or issue was closed and the session is terminal."}
+	default:
+		return SessionAttention{Reason: "Session is waiting for the next Maestro reconciliation cycle."}
+	}
+}
+
+func sessionHasFailedCheckEvidence(sess *Session) bool {
+	if strings.TrimSpace(sess.CIFailureOutput) != "" {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(sess.LastNotifiedStatus), "ci_failure")
 }
 
 // UnmarshalJSON implements custom unmarshalling to preserve the legacy

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -733,6 +733,57 @@ func TestMarkIssueRetryExhausted_NoSessions(t *testing.T) {
 	s.MarkIssueRetryExhausted(42)
 }
 
+func TestSessionAttentionFor_RetryExhaustedPRWithFailedChecks(t *testing.T) {
+	sess := &Session{
+		Status:          StatusRetryExhausted,
+		PRNumber:        12,
+		CIFailureOutput: "unit tests failed",
+	}
+
+	attention := SessionAttentionFor(sess, nil)
+	if !attention.NeedsAttention {
+		t.Fatal("retry-exhausted PR with failed checks should need attention")
+	}
+	if !containsString(attention.Reason, "checks failed") {
+		t.Fatalf("reason = %q, want failed checks", attention.Reason)
+	}
+	if !containsString(attention.Reason, "PR #12 remains open") {
+		t.Fatalf("reason = %q, want open PR", attention.Reason)
+	}
+	if !containsString(attention.NextAction, "Fix failing checks") {
+		t.Fatalf("next action = %q, want fix checks", attention.NextAction)
+	}
+}
+
+func TestSessionAttentionFor_StaleRunningWorker(t *testing.T) {
+	alive := false
+	sess := &Session{Status: StatusRunning, PID: 999999}
+
+	attention := SessionAttentionFor(sess, &alive)
+	if !attention.NeedsAttention {
+		t.Fatal("running worker with alive=false should need attention")
+	}
+	if !containsString(attention.Reason, "PID is not alive") {
+		t.Fatalf("reason = %q, want dead PID explanation", attention.Reason)
+	}
+	if !containsString(attention.NextAction, "reconciliation cycle") {
+		t.Fatalf("next action = %q, want reconciliation guidance", attention.NextAction)
+	}
+}
+
+func TestSessionAttentionFor_RunningWorkerAliveDoesNotNeedAttention(t *testing.T) {
+	alive := true
+	sess := &Session{Status: StatusRunning, PID: 1234}
+
+	attention := SessionAttentionFor(sess, &alive)
+	if attention.NeedsAttention {
+		t.Fatal("running worker with alive=true should not need attention")
+	}
+	if attention.NextAction != "" {
+		t.Fatalf("next action = %q, want empty for healthy running worker", attention.NextAction)
+	}
+}
+
 func TestCountByStatus(t *testing.T) {
 	s := NewState()
 	s.Sessions["slot-1"] = &Session{IssueNumber: 1, Status: StatusRunning}


### PR DESCRIPTION
Closes #289

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces attention-state explanations and supervisor rationale in both the fleet and single-project dashboards. It refactors `sessionStatusReason` into a richer `SessionAttentionFor` in the state package (adding `NextAction`), introduces `applySupervisorAttention` to overlay supervisor stuck-state context onto session infos, and adds new fleet dashboard UI sections ("Why Attention" / "Why Not Running") backed by the new `Attention []sessionInfo` field on the project snapshot.

The logic is well-tested with focused unit tests covering targeting, informational-state skipping, and priority ordering. Two minor style issues were noted in `server.go`: a redundant always-true guard in `applySupervisorAttention` and a missing sentence separator in the server dashboard's detail-panel JS.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style suggestions with no functional impact.

Both issues are cosmetic: the dead-code guard is harmless, and the separator difference produces readable (if slightly informal) text. Core logic, data flow, and test coverage are solid.

No files require special attention beyond the two P2 notes in `internal/server/server.go`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Extracts session status reasoning into a new `SessionAttentionFor` function returning a `SessionAttention` struct with `Reason`, `NextAction`, and `NeedsAttention`; adds `sessionHasFailedCheckEvidence` helper for CI failure detection. |
| internal/server/server.go | Adds `NextAction` to `sessionInfo`, moves reason logic to state package, adds `applySupervisorAttention` / `stuckTargetsSession` / `supervisorStuckNeedsAttention` helpers; contains a redundant always-true guard in `applySupervisorAttention` and a missing-separator issue in the server dashboard JS. |
| internal/server/fleet.go | Adds `Attention []sessionInfo` to `fleetProjectState`, `NextAction` to `fleetWorkerState`, and new JS helpers (`workerWhyText`, `workerWhyHTML`, `supervisorWhyText`, `renderProjectWhy`) to surface attention reasons and supervisor rationale in the fleet dashboard. |
| internal/server/fleet_test.go | Extends existing fleet API tests to assert `StatusReason`/`NextAction` content, attention count parity, and dashboard HTML presence of new UI strings. |
| internal/server/server_test.go | Adds four new tests covering supervisor-to-worker attention mapping, session-targeted fallback prevention, informational stuck-state skipping, and later attention-state priority; thorough coverage of the new logic. |
| internal/state/state_test.go | Adds three `SessionAttentionFor` unit tests covering retry-exhausted with failed checks, stale running worker, and healthy running worker; all cases are correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/server.go:468-470
**Redundant `if attention` guard — always `true` here**

The `if !attention { continue }` on line 459 guarantees that execution only reaches line 468 when `attention == true`, so the inner guard is dead code. `infos[i].NeedsAttention = true` can be assigned unconditionally.

```suggestion
			infos[i].NeedsAttention = true
```

### Issue 2 of 2
internal/server/server.go:1371-1374
**Missing sentence separator before "Next:" in server dashboard detail panel**

When a supervisor's `stuck.Summary` is used as `status_reason` (free-form text that may not end with `.`/`!`/`?`), concatenating `" Next: " + next_action` produces run-together text such as `"PR is stuck Next: Fix failing checks"`. The fleet dashboard's `workerWhyText` already handles this with a conditional separator (`". "` vs `" "`); the same guard is missing here.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(server): tighten supervisor attentio..."](https://github.com/befeast/maestro/commit/3624910fde783cf5099432444a861c2e6969cd21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30455756)</sub>

<!-- /greptile_comment -->