### PR TITLE
Fleet dashboard: approval-gated control affordances

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -371,7 +373,28 @@ func countLines(text string) int {
 }
 
 func (s *FleetServer) handleFleetAction(w http.ResponseWriter, r *http.Request) {
-	handleControlAction(w, r, s.readOnly, "fleet server")
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if s.readOnly {
+		writeError(w, http.StatusForbidden, "fleet server is read-only; write actions require approval-backed controls to be enabled in configuration")
+		return
+	}
+
+	var req controlActionRequest
+	if r.Body != nil {
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("decode action request: %v", err))
+			return
+		}
+	}
+	if project, ok := s.findProject(req.Project); ok && project.cfg != nil && project.cfg.Server.ReadOnly {
+		writeError(w, http.StatusForbidden, "fleet project is read-only; write actions require approval-backed controls to be enabled in configuration")
+		return
+	}
+	writeError(w, http.StatusNotImplemented, "approval-backed action endpoints are not implemented yet")
 }
 
 func (s *FleetServer) snapshot() fleetResponse {

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -144,6 +144,7 @@ func (s *FleetServer) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/fleet/worker", s.handleFleetWorker)
 	mux.HandleFunc("/api/v1/fleet", s.handleFleet)
+	mux.HandleFunc("/api/v1/fleet/actions", s.handleFleetAction)
 	mux.HandleFunc("/", s.handleFleetDashboard)
 
 	host := strings.TrimSpace(s.host)
@@ -189,55 +190,57 @@ type fleetSummary struct {
 }
 
 type fleetProjectState struct {
-	Name           string         `json:"name"`
-	Repo           string         `json:"repo"`
-	ConfigPath     string         `json:"config_path"`
-	DashboardURL   string         `json:"dashboard_url,omitempty"`
-	StateDir       string         `json:"state_dir,omitempty"`
-	MaxParallel    int            `json:"max_parallel"`
-	ReadOnly       bool           `json:"read_only"`
-	Summary        map[string]int `json:"summary"`
-	Running        int            `json:"running"`
-	PROpen         int            `json:"pr_open"`
-	Failed         int            `json:"failed"`
-	Sessions       int            `json:"sessions"`
-	NeedsAttention int            `json:"needs_attention"`
-	Active         []sessionInfo  `json:"active,omitempty"`
-	Attention      []sessionInfo  `json:"attention,omitempty"`
-	Supervisor     supervisorInfo `json:"supervisor"`
-	Error          string         `json:"error,omitempty"`
+	Name           string          `json:"name"`
+	Repo           string          `json:"repo"`
+	ConfigPath     string          `json:"config_path"`
+	DashboardURL   string          `json:"dashboard_url,omitempty"`
+	StateDir       string          `json:"state_dir,omitempty"`
+	MaxParallel    int             `json:"max_parallel"`
+	ReadOnly       bool            `json:"read_only"`
+	Summary        map[string]int  `json:"summary"`
+	Running        int             `json:"running"`
+	PROpen         int             `json:"pr_open"`
+	Failed         int             `json:"failed"`
+	Sessions       int             `json:"sessions"`
+	NeedsAttention int             `json:"needs_attention"`
+	Active         []sessionInfo   `json:"active,omitempty"`
+	Attention      []sessionInfo   `json:"attention,omitempty"`
+	Actions        []controlAction `json:"actions,omitempty"`
+	Supervisor     supervisorInfo  `json:"supervisor"`
+	Error          string          `json:"error,omitempty"`
 }
 
 type fleetWorkerState struct {
-	ProjectName       string `json:"project_name"`
-	ProjectRepo       string `json:"project_repo,omitempty"`
-	DashboardURL      string `json:"dashboard_url,omitempty"`
-	Slot              string `json:"slot"`
-	IssueNumber       int    `json:"issue_number"`
-	IssueTitle        string `json:"issue_title"`
-	IssueURL          string `json:"issue_url,omitempty"`
-	Status            string `json:"status"`
-	StatusReason      string `json:"status_reason,omitempty"`
-	NextAction        string `json:"next_action,omitempty"`
-	NeedsAttention    bool   `json:"needs_attention,omitempty"`
-	Backend           string `json:"backend,omitempty"`
-	PRNumber          int    `json:"pr_number,omitempty"`
-	PRURL             string `json:"pr_url,omitempty"`
-	TokensUsedAttempt int    `json:"tokens_used_attempt"`
-	TokensUsedTotal   int    `json:"tokens_used_total"`
-	Runtime           string `json:"runtime"`
-	RuntimeSeconds    int64  `json:"runtime_seconds"`
-	StartedAt         string `json:"started_at"`
-	FinishedAt        string `json:"finished_at,omitempty"`
-	NextRetryAt       string `json:"next_retry_at,omitempty"`
-	PID               int    `json:"pid,omitempty"`
-	Alive             *bool  `json:"alive,omitempty"`
-	Worktree          string `json:"worktree,omitempty"`
-	Branch            string `json:"branch,omitempty"`
-	TmuxSession       string `json:"tmux_session,omitempty"`
-	HasLog            bool   `json:"has_log"`
-	RetryCount        int    `json:"retry_count,omitempty"`
-	LastNotification  string `json:"last_notification,omitempty"`
+	ProjectName       string          `json:"project_name"`
+	ProjectRepo       string          `json:"project_repo,omitempty"`
+	DashboardURL      string          `json:"dashboard_url,omitempty"`
+	Slot              string          `json:"slot"`
+	IssueNumber       int             `json:"issue_number"`
+	IssueTitle        string          `json:"issue_title"`
+	IssueURL          string          `json:"issue_url,omitempty"`
+	Status            string          `json:"status"`
+	StatusReason      string          `json:"status_reason,omitempty"`
+	NextAction        string          `json:"next_action,omitempty"`
+	NeedsAttention    bool            `json:"needs_attention,omitempty"`
+	Backend           string          `json:"backend,omitempty"`
+	PRNumber          int             `json:"pr_number,omitempty"`
+	PRURL             string          `json:"pr_url,omitempty"`
+	TokensUsedAttempt int             `json:"tokens_used_attempt"`
+	TokensUsedTotal   int             `json:"tokens_used_total"`
+	Runtime           string          `json:"runtime"`
+	RuntimeSeconds    int64           `json:"runtime_seconds"`
+	StartedAt         string          `json:"started_at"`
+	FinishedAt        string          `json:"finished_at,omitempty"`
+	NextRetryAt       string          `json:"next_retry_at,omitempty"`
+	PID               int             `json:"pid,omitempty"`
+	Alive             *bool           `json:"alive,omitempty"`
+	Worktree          string          `json:"worktree,omitempty"`
+	Branch            string          `json:"branch,omitempty"`
+	TmuxSession       string          `json:"tmux_session,omitempty"`
+	HasLog            bool            `json:"has_log"`
+	RetryCount        int             `json:"retry_count,omitempty"`
+	LastNotification  string          `json:"last_notification,omitempty"`
+	Actions           []controlAction `json:"actions,omitempty"`
 }
 
 type fleetWorkerDetailResponse struct {
@@ -300,9 +303,11 @@ func (s *FleetServer) handleFleetWorker(w http.ResponseWriter, r *http.Request) 
 		Name:         project.Name,
 		Repo:         project.cfg.Repo,
 		DashboardURL: project.DashboardURL,
+		ReadOnly:     project.cfg.Server.ReadOnly || s.readOnly,
 	}
 	infos := []sessionInfo{makeSessionInfo(project.cfg.Repo, slot, sess)}
 	applySupervisorAttention(infos, st.LatestSupervisorDecision())
+	infos[0].Actions = workerActionAffordances(projectState.ReadOnly, "/api/v1/fleet/actions", infos[0])
 	worker := makeFleetWorkerState(projectState, infos[0])
 	lines := parsePositiveInt(r.URL.Query().Get("lines"), 260)
 	if lines > 1000 {
@@ -365,6 +370,10 @@ func countLines(text string) int {
 	return strings.Count(text, "\n") + 1
 }
 
+func (s *FleetServer) handleFleetAction(w http.ResponseWriter, r *http.Request) {
+	handleControlAction(w, r, s.readOnly, "fleet server")
+}
+
 func (s *FleetServer) snapshot() fleetResponse {
 	resp := fleetResponse{
 		ReadOnly: s.readOnly,
@@ -424,6 +433,7 @@ func (s *FleetServer) projectSnapshot(project FleetProject) (fleetProjectState, 
 	item.StateDir = cfg.StateDir
 	item.MaxParallel = cfg.MaxParallel
 	item.ReadOnly = cfg.Server.ReadOnly || s.readOnly
+	item.Actions = projectActionAffordances(item.ReadOnly, "/api/v1/fleet/actions")
 
 	st, err := state.Load(cfg.StateDir)
 	if err != nil {
@@ -439,6 +449,7 @@ func (s *FleetServer) projectSnapshot(project FleetProject) (fleetProjectState, 
 	item.Supervisor = projectState.Supervisor
 	workers := make([]fleetWorkerState, 0)
 	for _, worker := range projectState.All {
+		worker.Actions = workerActionAffordances(item.ReadOnly, "/api/v1/fleet/actions", worker)
 		if worker.NeedsAttention {
 			item.NeedsAttention++
 			item.Attention = append(item.Attention, worker)
@@ -496,6 +507,7 @@ func makeFleetWorkerState(project fleetProjectState, worker sessionInfo) fleetWo
 		HasLog:            worker.HasLog,
 		RetryCount:        worker.RetryCount,
 		LastNotification:  worker.LastNotification,
+		Actions:           worker.Actions,
 	}
 }
 
@@ -702,7 +714,7 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   .table-scroll { overflow-x: auto; }
   .worker-table {
     width: 100%;
-    min-width: 920px;
+    min-width: 1180px;
     border-collapse: collapse;
     table-layout: fixed;
   }
@@ -736,6 +748,7 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   .pr-col { width: 70px; }
   .runtime-col { width: 90px; }
   .tokens-col { width: 82px; text-align: right; }
+  .action-col { width: 270px; }
   .grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
@@ -772,7 +785,7 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   .metric:last-child { border-right: 0; }
   .metric strong { display: block; font-size: 16px; }
   .metric span { display: block; color: var(--muted); font-size: 11px; }
-  .supervisor, .workers { padding: 12px 14px; border-bottom: 1px solid var(--line); }
+  .supervisor, .workers, .project-actions { padding: 12px 14px; border-bottom: 1px solid var(--line); }
   .label { color: var(--muted); font-weight: 650; text-transform: uppercase; font-size: 12px; }
   .decision { margin-top: 5px; color: var(--text); }
   .decision small { color: var(--muted); }
@@ -799,6 +812,18 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   .s-done { color: var(--ok); border-color: rgba(63,185,80,.45); }
   .s-dead, .s-failed, .s-conflict_failed, .s-retry_exhausted { color: var(--bad); border-color: rgba(248,81,73,.45); }
   .attention { color: var(--bad); border-color: rgba(248,81,73,.45); }
+  .actions { display: flex; gap: 6px; flex-wrap: wrap; }
+  .action-btn {
+    height: 24px;
+    border: 1px solid rgba(210,153,34,.45);
+    border-radius: 6px;
+    background: rgba(210,153,34,.08);
+    color: var(--warn);
+    font: inherit;
+    font-size: 12px;
+    cursor: not-allowed;
+  }
+  .action-note { margin-top: 6px; color: var(--muted); font-size: 12px; white-space: normal; }
   .empty { color: var(--muted); margin-top: 8px; }
   .worker-table .empty { padding: 18px 14px; margin: 0; text-align: center; }
   .why-line {
@@ -824,7 +849,7 @@ const fleetDashboardHTML = `<!DOCTYPE html>
     .stats { width: 100%; }
     .worker-controls { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .worker-controls .search-control { grid-column: 1 / -1; }
-    .worker-table { min-width: 780px; }
+    .worker-table { min-width: 1080px; }
   }
   @media (max-width: 700px) {
     header { align-items: flex-start; flex-direction: column; }
@@ -878,6 +903,7 @@ const fleetDashboardHTML = `<!DOCTYPE html>
             <th class="pr-col">PR</th>
             <th class="runtime-col">Runtime</th>
             <th class="tokens-col">Tokens</th>
+            <th class="action-col">Actions</th>
           </tr>
         </thead>
         <tbody id="fleet-workers-body"></tbody>
@@ -930,6 +956,7 @@ const statusOrder = new Map([
 
 const fleetState = {
   selectedProject: "all",
+  readOnly: true,
   selectedWorkerKey: "",
   filters: {
     query: "",
@@ -963,6 +990,26 @@ function compactNumber(value) {
 function linkHTML(url, label) {
   if (!url) return escapeText(label);
   return '<a href="' + escapeText(url) + '" target="_blank" rel="noreferrer">' + escapeText(label) + '</a>';
+}
+
+function actionLabel(action) {
+  return String(action || "-").replace(/_/g, " ");
+}
+
+function actionDisabledReason(actions) {
+  const action = (actions || []).find(item => item.disabled_reason);
+  return action ? action.disabled_reason : "Write actions require approval-backed configuration.";
+}
+
+function renderActions(actions) {
+  const items = actions || [];
+  if (!items.length) return '<span class="empty">No controls.</span>';
+  return '<div class="actions">' + items.map(action =>
+    '<button type="button" class="action-btn" disabled aria-disabled="true" title="' +
+    escapeText(action.disabled_reason || "Write action unavailable") + '">' +
+    escapeText(action.label || actionLabel(action.id)) + '</button>'
+  ).join("") + '</div>' +
+  '<div class="action-note">' + escapeText(actionDisabledReason(items)) + '</div>';
 }
 
 function formatTimestamp(value) {
@@ -1277,7 +1324,7 @@ function renderFleetWorkers() {
       : fleetState.selectedProject === "all"
       ? "No active, recent, or attention workers across configured projects."
       : "No active, recent, or attention workers for " + fleetState.selectedProject + ".";
-    fleetWorkersEl.innerHTML = '<tr><td colspan="8" class="empty">' + escapeText(empty) + '</td></tr>';
+    fleetWorkersEl.innerHTML = '<tr><td colspan="9" class="empty">' + escapeText(empty) + '</td></tr>';
     return;
   }
 
@@ -1296,6 +1343,7 @@ function renderFleetWorkers() {
       '<td class="pr-col" title="' + escapeText(pr) + '">' + linkHTML(worker.pr_url, pr) + '</td>' +
       '<td class="runtime-col" title="' + escapeText(worker.runtime || "-") + '">' + escapeText(worker.runtime || "-") + '</td>' +
       '<td class="tokens-col">' + compactNumber(worker.tokens_used_total) + '</td>' +
+      '<td class="action-col">' + renderActions(worker.actions || []) + '</td>' +
     '</tr>';
   }).join("");
 
@@ -1396,6 +1444,7 @@ function renderWorkerDetail(data) {
     '<div class="' + noteClass + '"><strong>State</strong> ' + escapeText(reason) +
       (links.length ? '<div class="detail-links">' + links.join("") + '</div>' : "") +
     '</div>' +
+    '<div class="project-actions"><div class="label">Approval-gated controls</div>' + renderActions(worker.actions || []) + '</div>' +
     '<div class="log-tail">' +
       '<div class="log-tail-head"><strong>Recent log tail</strong><span>' + escapeText(logMeta) + '</span></div>' +
       '<pre>' + escapeText(logText) + '</pre>' +
@@ -1479,6 +1528,11 @@ function renderWorkers(project) {
   '</table></div>';
 }
 
+function renderProjectActions(project) {
+  return '<div class="project-actions"><div class="label">Approval-gated controls</div>' +
+    renderActions(project.actions || []) + '</div>';
+}
+
 function renderProject(project) {
   if (project.error) {
     return '<article class="project"><div class="project-head"><div><h2>' + escapeText(project.name) +
@@ -1499,6 +1553,7 @@ function renderProject(project) {
       '<div class="metric"><strong>' + escapeText(project.needs_attention || 0) + '</strong><span>Attention</span></div>' +
     '</div>' +
     renderProjectWhy(project) +
+    renderProjectActions(project) +
     renderSupervisor(project) +
     renderWorkers(project) +
   '</article>';
@@ -1553,13 +1608,15 @@ async function loadFleet() {
     const response = await fetch("/api/v1/fleet", { cache: "no-store" });
     if (!response.ok) throw new Error(await response.text());
     const data = await response.json();
+    fleetState.readOnly = data.read_only !== false;
     fleetState.projects = data.projects || [];
     fleetState.workers = fleetWorkersFromData(data);
     if (fleetState.selectedWorkerKey && !selectedWorker()) {
       fleetState.selectedWorkerKey = "";
       fleetState.detail = null;
     }
-    subtitleEl.textContent = fleetState.projects.length + " configured project" + (fleetState.projects.length === 1 ? "" : "s");
+    const controlMode = fleetState.readOnly ? "read-only controls disabled" : "controls require approval configuration";
+    subtitleEl.textContent = fleetState.projects.length + " configured project" + (fleetState.projects.length === 1 ? "" : "s") + " · " + controlMode;
     renderFilterOptions();
     syncFilterControls();
     renderStats(data.summary || {});
@@ -1570,7 +1627,7 @@ async function loadFleet() {
   } catch (err) {
     subtitleEl.textContent = "Fleet API error";
     workerSummaryEl.textContent = "Fleet API error";
-    fleetWorkersEl.innerHTML = '<tr><td colspan="8" class="empty">Unable to load fleet workers.</td></tr>';
+    fleetWorkersEl.innerHTML = '<tr><td colspan="9" class="empty">Unable to load fleet workers.</td></tr>';
     projectsEl.innerHTML = '<div class="error">' + escapeText(err.message) + '</div>';
   }
 }

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -441,6 +442,25 @@ func TestFleetDashboard(t *testing.T) {
 func TestFleetActionReadOnlyRejectsMutation(t *testing.T) {
 	srv := NewFleet(nil, "127.0.0.1", 8786, true)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/actions", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleetAction(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if !contains(w.Body.String(), "read-only") {
+		t.Fatalf("response = %q, want read-only explanation", w.Body.String())
+	}
+}
+
+func TestFleetActionProjectReadOnlyRejectsMutation(t *testing.T) {
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("One", "/tmp/one.yaml", "", &config.Config{
+			Repo:   "owner/one",
+			Server: config.ServerConfig{ReadOnly: true},
+		}),
+	}, "127.0.0.1", 8786, false)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/actions", bytes.NewBufferString(`{"action_id":"restart_worker","project":"One","slot":"one-1"}`))
 	w := httptest.NewRecorder()
 	srv.handleFleetAction(w, req)
 

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -141,6 +141,18 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	if worker.RuntimeSeconds <= 0 {
 		t.Fatalf("worker runtime_seconds = %d, want positive runtime", worker.RuntimeSeconds)
 	}
+	if len(worker.Actions) != 5 {
+		t.Fatalf("worker actions = %d, want 5", len(worker.Actions))
+	}
+	for _, action := range worker.Actions {
+		assertFleetReadOnlyAction(t, action)
+	}
+	if len(resp.Projects[0].Actions) != 2 {
+		t.Fatalf("project actions = %d, want 2", len(resp.Projects[0].Actions))
+	}
+	for _, action := range resp.Projects[0].Actions {
+		assertFleetReadOnlyAction(t, action)
+	}
 	attentionWorker := findFleetWorker(t, resp.Workers, "two-1")
 	if !attentionWorker.NeedsAttention {
 		t.Fatal("retry-exhausted worker should need attention")
@@ -417,10 +429,26 @@ func TestFleetDashboard(t *testing.T) {
 		"sortWorkers",
 		"filteredWorkers",
 		"URLSearchParams",
+		"renderActions",
+		"Approval-gated controls",
 	} {
 		if !contains(body, want) {
 			t.Fatalf("dashboard should contain %q", want)
 		}
+	}
+}
+
+func TestFleetActionReadOnlyRejectsMutation(t *testing.T) {
+	srv := NewFleet(nil, "127.0.0.1", 8786, true)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/actions", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleetAction(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if !contains(w.Body.String(), "read-only") {
+		t.Fatalf("response = %q, want read-only explanation", w.Body.String())
 	}
 }
 
@@ -443,5 +471,18 @@ func saveFleetTestState(t *testing.T, dir string, sessions map[string]*state.Ses
 	}
 	if err := state.Save(dir, st); err != nil {
 		t.Fatalf("save state: %v", err)
+	}
+}
+
+func assertFleetReadOnlyAction(t *testing.T, action controlAction) {
+	t.Helper()
+	if !action.Mutating || !action.RequiresApproval || !action.Disabled {
+		t.Fatalf("action %+v should be disabled mutating approval affordance", action)
+	}
+	if !contains(action.DisabledReason, "Read-only mode") {
+		t.Fatalf("disabled reason = %q, want read-only explanation", action.DisabledReason)
+	}
+	if action.Method != http.MethodPost || action.Endpoint != "/api/v1/fleet/actions" {
+		t.Fatalf("action endpoint = %s %s, want POST /api/v1/fleet/actions", action.Method, action.Endpoint)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -544,7 +544,7 @@ func projectActionAffordances(readOnly bool, endpoint string) []controlAction {
 func workerActionAffordances(readOnly bool, endpoint string, worker sessionInfo) []controlAction {
 	reason := controlActionDisabledReason(readOnly)
 	mergeReason := reason
-	if worker.PRNumber == 0 {
+	if !readOnly && worker.PRNumber == 0 {
 		mergeReason = "No PR is associated with this worker; merge approval will require approval-backed controls."
 	}
 	return []controlAction{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,6 +47,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/v1/workers", s.handleWorkers)
 	mux.HandleFunc("/api/v1/logs/", s.handleLog)
 	mux.HandleFunc("/api/v1/refresh", s.handleRefresh)
+	mux.HandleFunc("/api/v1/actions", s.handleAction)
 	mux.HandleFunc("/api/v1/", s.handleIssue)
 	mux.HandleFunc("/", s.handleDashboard)
 
@@ -97,6 +98,7 @@ type stateResponse struct {
 	Repo                string                       `json:"repo"`
 	MaxParallel         int                          `json:"max_parallel"`
 	ReadOnly            bool                         `json:"read_only"`
+	Actions             []controlAction              `json:"actions,omitempty"`
 	SupervisorPolicy    config.SupervisorConfig      `json:"supervisor_policy"`
 	All                 []sessionInfo                `json:"all"`
 	Running             []sessionInfo                `json:"running"`
@@ -171,33 +173,58 @@ type tokenTotalsInfo struct {
 	Total  int `json:"total"`
 }
 
+type controlAction struct {
+	ID               string `json:"id"`
+	Label            string `json:"label"`
+	Scope            string `json:"scope"`
+	Target           string `json:"target,omitempty"`
+	IssueNumber      int    `json:"issue_number,omitempty"`
+	PRNumber         int    `json:"pr_number,omitempty"`
+	Mutating         bool   `json:"mutating"`
+	RequiresApproval bool   `json:"requires_approval"`
+	Disabled         bool   `json:"disabled"`
+	DisabledReason   string `json:"disabled_reason,omitempty"`
+	Method           string `json:"method,omitempty"`
+	Endpoint         string `json:"endpoint,omitempty"`
+}
+
+type controlActionRequest struct {
+	ActionID    string `json:"action_id"`
+	Project     string `json:"project,omitempty"`
+	Slot        string `json:"slot,omitempty"`
+	IssueNumber int    `json:"issue_number,omitempty"`
+	PRNumber    int    `json:"pr_number,omitempty"`
+	ApprovalID  string `json:"approval_id,omitempty"`
+}
+
 type sessionInfo struct {
-	Slot              string `json:"slot"`
-	IssueNumber       int    `json:"issue_number"`
-	IssueTitle        string `json:"issue_title"`
-	IssueURL          string `json:"issue_url,omitempty"`
-	Status            string `json:"status"`
-	StatusReason      string `json:"status_reason,omitempty"`
-	NextAction        string `json:"next_action,omitempty"`
-	NeedsAttention    bool   `json:"needs_attention,omitempty"`
-	Backend           string `json:"backend,omitempty"`
-	PRNumber          int    `json:"pr_number,omitempty"`
-	PRURL             string `json:"pr_url,omitempty"`
-	TokensUsedAttempt int    `json:"tokens_used_attempt"`
-	TokensUsedTotal   int    `json:"tokens_used_total"`
-	Runtime           string `json:"runtime"`
-	RuntimeSeconds    int64  `json:"runtime_seconds"`
-	StartedAt         string `json:"started_at"`
-	FinishedAt        string `json:"finished_at,omitempty"`
-	NextRetryAt       string `json:"next_retry_at,omitempty"`
-	PID               int    `json:"pid,omitempty"`
-	Alive             *bool  `json:"alive,omitempty"`
-	Worktree          string `json:"worktree,omitempty"`
-	Branch            string `json:"branch,omitempty"`
-	TmuxSession       string `json:"tmux_session,omitempty"`
-	HasLog            bool   `json:"has_log"`
-	RetryCount        int    `json:"retry_count,omitempty"`
-	LastNotification  string `json:"last_notification,omitempty"`
+	Slot              string          `json:"slot"`
+	IssueNumber       int             `json:"issue_number"`
+	IssueTitle        string          `json:"issue_title"`
+	IssueURL          string          `json:"issue_url,omitempty"`
+	Status            string          `json:"status"`
+	StatusReason      string          `json:"status_reason,omitempty"`
+	NextAction        string          `json:"next_action,omitempty"`
+	NeedsAttention    bool            `json:"needs_attention,omitempty"`
+	Backend           string          `json:"backend,omitempty"`
+	PRNumber          int             `json:"pr_number,omitempty"`
+	PRURL             string          `json:"pr_url,omitempty"`
+	TokensUsedAttempt int             `json:"tokens_used_attempt"`
+	TokensUsedTotal   int             `json:"tokens_used_total"`
+	Runtime           string          `json:"runtime"`
+	RuntimeSeconds    int64           `json:"runtime_seconds"`
+	StartedAt         string          `json:"started_at"`
+	FinishedAt        string          `json:"finished_at,omitempty"`
+	NextRetryAt       string          `json:"next_retry_at,omitempty"`
+	PID               int             `json:"pid,omitempty"`
+	Alive             *bool           `json:"alive,omitempty"`
+	Worktree          string          `json:"worktree,omitempty"`
+	Branch            string          `json:"branch,omitempty"`
+	TmuxSession       string          `json:"tmux_session,omitempty"`
+	HasLog            bool            `json:"has_log"`
+	RetryCount        int             `json:"retry_count,omitempty"`
+	LastNotification  string          `json:"last_notification,omitempty"`
+	Actions           []controlAction `json:"actions,omitempty"`
 }
 
 func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
@@ -498,6 +525,61 @@ func supervisorStuckNeedsAttention(stuck state.SupervisorStuckState) bool {
 	return stuck.Severity == "blocked"
 }
 
+func sessionInfosWithActions(repo string, st *state.State, readOnly bool, endpoint string) []sessionInfo {
+	infos := allSessionInfos(repo, st)
+	for i := range infos {
+		infos[i].Actions = workerActionAffordances(readOnly, endpoint, infos[i])
+	}
+	return infos
+}
+
+func projectActionAffordances(readOnly bool, endpoint string) []controlAction {
+	reason := controlActionDisabledReason(readOnly)
+	return []controlAction{
+		newControlAction("mark_issue_ready", "Mark issue ready", "project", "", 0, 0, endpoint, reason),
+		newControlAction("mark_issue_blocked", "Mark issue blocked", "project", "", 0, 0, endpoint, reason),
+	}
+}
+
+func workerActionAffordances(readOnly bool, endpoint string, worker sessionInfo) []controlAction {
+	reason := controlActionDisabledReason(readOnly)
+	mergeReason := reason
+	if worker.PRNumber == 0 {
+		mergeReason = "No PR is associated with this worker; merge approval will require approval-backed controls."
+	}
+	return []controlAction{
+		newControlAction("restart_worker", "Restart worker", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
+		newControlAction("stop_worker", "Stop worker", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
+		newControlAction("mark_issue_ready", "Mark issue ready", "issue", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
+		newControlAction("mark_issue_blocked", "Mark issue blocked", "issue", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
+		newControlAction("approve_merge", "Approve merge", "pull_request", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, mergeReason),
+	}
+}
+
+func newControlAction(id, label, scope, target string, issueNumber, prNumber int, endpoint, disabledReason string) controlAction {
+	return controlAction{
+		ID:               id,
+		Label:            label,
+		Scope:            scope,
+		Target:           target,
+		IssueNumber:      issueNumber,
+		PRNumber:         prNumber,
+		Mutating:         true,
+		RequiresApproval: true,
+		Disabled:         true,
+		DisabledReason:   disabledReason,
+		Method:           http.MethodPost,
+		Endpoint:         endpoint,
+	}
+}
+
+func controlActionDisabledReason(readOnly bool) string {
+	if readOnly {
+		return "Read-only mode: write actions require approval-backed controls to be enabled in configuration."
+	}
+	return "Approval-backed controls are not implemented yet."
+}
+
 func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -519,6 +601,7 @@ func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 		Repo:                cfg.Repo,
 		MaxParallel:         cfg.MaxParallel,
 		ReadOnly:            cfg.Server.ReadOnly,
+		Actions:             projectActionAffordances(cfg.Server.ReadOnly, "/api/v1/actions"),
 		SupervisorPolicy:    cfg.Supervisor,
 		All:                 make([]sessionInfo, 0, len(st.Sessions)),
 		Running:             make([]sessionInfo, 0),
@@ -535,7 +618,7 @@ func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 	}
 
 	var activeTokens, totalTokens int
-	for _, info := range allSessionInfos(cfg.Repo, st) {
+	for _, info := range sessionInfosWithActions(cfg.Repo, st, cfg.Server.ReadOnly, "/api/v1/actions") {
 		resp.All = append(resp.All, info)
 		resp.Summary[info.Status]++
 		totalTokens += info.TokensUsedTotal
@@ -572,7 +655,7 @@ func (s *Server) handleWorkers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	workers := allSessionInfos(s.cfg.Repo, st)
+	workers := sessionInfosWithActions(s.cfg.Repo, st, s.cfg.Server.ReadOnly, "/api/v1/actions")
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"workers": workers,
@@ -617,9 +700,9 @@ func (s *Server) handleIssue(w http.ResponseWriter, r *http.Request) {
 		Sessions:    make([]sessionInfo, 0),
 	}
 
-	for slot, sess := range st.Sessions {
-		if sess.IssueNumber == issueNum {
-			resp.Sessions = append(resp.Sessions, makeSessionInfo(s.cfg.Repo, slot, sess))
+	for _, info := range sessionInfosWithActions(s.cfg.Repo, st, s.cfg.Server.ReadOnly, "/api/v1/actions") {
+		if info.IssueNumber == issueNum {
+			resp.Sessions = append(resp.Sessions, info)
 		}
 	}
 
@@ -765,6 +848,31 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeJSON(w, http.StatusOK, map[string]string{"status": "refresh already pending"})
 	}
+}
+
+func (s *Server) handleAction(w http.ResponseWriter, r *http.Request) {
+	handleControlAction(w, r, s.cfg.Server.ReadOnly, "server")
+}
+
+func handleControlAction(w http.ResponseWriter, r *http.Request, readOnly bool, scope string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if readOnly {
+		writeError(w, http.StatusForbidden, scope+" is read-only; write actions require approval-backed controls to be enabled in configuration")
+		return
+	}
+
+	var req controlActionRequest
+	if r.Body != nil {
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("decode action request: %v", err))
+			return
+		}
+	}
+	writeError(w, http.StatusNotImplemented, "approval-backed action endpoints are not implemented yet")
 }
 
 func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
@@ -1010,7 +1118,7 @@ const dashboardHTML = `<!DOCTYPE html>
     padding-left: 16px;
   }
   .supervisor-reasons li { margin: 2px 0; }
-  .supervisor-approval {
+  .supervisor-approval, .action-btn {
     height: 24px;
     border: 1px solid rgba(210,153,34,.45);
     border-radius: 6px;
@@ -1018,6 +1126,16 @@ const dashboardHTML = `<!DOCTYPE html>
     color: var(--warn);
     cursor: not-allowed;
   }
+  .worker-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+  }
+  .worker-actions span { color: var(--text); font-weight: 650; }
+  .action-list { display: inline-flex; gap: 6px; flex-wrap: wrap; }
+  .action-note { margin-top: 6px; color: var(--muted); }
   .supervisor-empty { color: var(--muted); }
   pre {
     margin: 0;
@@ -1151,6 +1269,27 @@ function linkHTML(url, label) {
 
 function actionLabel(action) {
   return String(action || "-").replace(/_/g, " ");
+}
+
+function actionDisabledReason(actions) {
+  const action = (actions || []).find(item => item.disabled_reason);
+  return action ? action.disabled_reason : "Write actions require approval-backed configuration.";
+}
+
+function renderActionButtons(actions) {
+  const items = actions || [];
+  if (!items.length) return "";
+  return '<div class="action-list">' + items.map(action =>
+    '<button type="button" class="action-btn" disabled aria-disabled="true" title="' +
+    escapeText(action.disabled_reason || "Write action unavailable") + '">' +
+    escapeText(action.label || actionLabel(action.id)) + '</button>'
+  ).join("") + '</div>';
+}
+
+function renderWorkerActions(actions) {
+  if (!actions || !actions.length) return "";
+  return '<div class="worker-actions"><span>Actions</span>' + renderActionButtons(actions) + '</div>' +
+    '<div class="action-note">' + escapeText(actionDisabledReason(actions)) + '</div>';
 }
 
 function formatTimestamp(value) {
@@ -1330,7 +1469,8 @@ function renderSelectedDetails() {
   const next = worker.next_action ? " Next: " + worker.next_action : "";
   statusNoteEl.innerHTML = '<strong>Why</strong>' +
     escapeText((worker.status_reason || "Waiting for next reconciliation cycle.") + retry + next) +
-    (links.length ? '<span class="links">' + links.join("") + '</span>' : "");
+    (links.length ? '<span class="links">' + links.join("") + '</span>' : "") +
+    renderWorkerActions(worker.actions || []);
   statusNoteEl.classList.add("visible");
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -168,6 +169,44 @@ func TestHandleState(t *testing.T) {
 	}
 	if len(resp.Supervisor.Latest.StuckReasons) != 1 {
 		t.Fatalf("supervisor latest stuck reasons = %#v, want one", resp.Supervisor.Latest.StuckReasons)
+	}
+}
+
+func TestHandleState_ReadOnlyActionsDisabled(t *testing.T) {
+	srv, cfg := setupTestServer(t)
+	cfg.Server.ReadOnly = true
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.handleState(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp stateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.ReadOnly {
+		t.Fatal("read_only = false, want true")
+	}
+	if len(resp.Actions) != 2 {
+		t.Fatalf("project actions = %d, want 2", len(resp.Actions))
+	}
+	for _, action := range resp.Actions {
+		assertReadOnlyAction(t, action)
+	}
+
+	worker := findSessionInfo(t, resp.All, "slot-2")
+	if len(worker.Actions) != 5 {
+		t.Fatalf("worker actions = %d, want 5", len(worker.Actions))
+	}
+	for _, action := range worker.Actions {
+		assertReadOnlyAction(t, action)
+	}
+	approve := findControlAction(t, worker.Actions, "approve_merge")
+	if approve.PRNumber != 10 {
+		t.Fatalf("approve_merge pr = %d, want 10", approve.PRNumber)
 	}
 }
 
@@ -703,6 +742,63 @@ func TestHandleRefresh_ReadOnly(t *testing.T) {
 	}
 }
 
+func TestHandleAction_ReadOnlyRejectsMutation(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: dir,
+		Server:   config.ServerConfig{Port: 8765, ReadOnly: true},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "Fix bug",
+		Status:      state.StatusRunning,
+		StartedAt:   time.Now().UTC(),
+	}
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	statePath := filepath.Join(dir, "state.json")
+	before, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state before: %v", err)
+	}
+
+	srv := New(cfg, make(chan struct{}, 1))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/actions", bytes.NewBufferString(`{"action_id":"restart_worker","slot":"slot-1"}`))
+	w := httptest.NewRecorder()
+	srv.handleAction(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if !contains(w.Body.String(), "read-only") {
+		t.Fatalf("response = %q, want read-only explanation", w.Body.String())
+	}
+	after, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("read-only action endpoint changed state")
+	}
+}
+
+func TestHandleAction_NotImplementedWhenWritable(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/actions", bytes.NewBufferString(`{"action_id":"stop_worker","slot":"slot-1"}`))
+	w := httptest.NewRecorder()
+	srv.handleAction(w, req)
+
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotImplemented)
+	}
+	if !contains(w.Body.String(), "approval-backed") {
+		t.Fatalf("response = %q, want approval-backed explanation", w.Body.String())
+	}
+}
+
 func TestHandleDashboard(t *testing.T) {
 	srv, _ := setupTestServer(t)
 
@@ -738,6 +834,9 @@ func TestHandleDashboard(t *testing.T) {
 	}
 	if !contains(body, "issue_url") || !contains(body, "pr_url") {
 		t.Error("dashboard should render GitHub issue/PR links from API fields")
+	}
+	if !contains(body, "renderWorkerActions") || !contains(body, "Write actions require approval-backed configuration") {
+		t.Error("dashboard should render disabled approval-gated action affordances")
 	}
 }
 
@@ -891,4 +990,42 @@ func hasTargetLink(links []targetLinkInfo, kind, url string) bool {
 		}
 	}
 	return false
+}
+
+func findSessionInfo(t *testing.T, sessions []sessionInfo, slot string) sessionInfo {
+	t.Helper()
+	for _, session := range sessions {
+		if session.Slot == slot {
+			return session
+		}
+	}
+	t.Fatalf("session %q not found in %+v", slot, sessions)
+	return sessionInfo{}
+}
+
+func findControlAction(t *testing.T, actions []controlAction, id string) controlAction {
+	t.Helper()
+	for _, action := range actions {
+		if action.ID == id {
+			return action
+		}
+	}
+	t.Fatalf("action %q not found in %+v", id, actions)
+	return controlAction{}
+}
+
+func assertReadOnlyAction(t *testing.T, action controlAction) {
+	t.Helper()
+	if !action.Mutating || !action.RequiresApproval {
+		t.Fatalf("action %+v should be mutating and approval-required", action)
+	}
+	if !action.Disabled {
+		t.Fatalf("action %+v should be disabled", action)
+	}
+	if !contains(action.DisabledReason, "Read-only mode") {
+		t.Fatalf("disabled reason = %q, want read-only explanation", action.DisabledReason)
+	}
+	if action.Method != http.MethodPost || action.Endpoint != "/api/v1/actions" {
+		t.Fatalf("action endpoint = %s %s, want POST /api/v1/actions", action.Method, action.Endpoint)
+	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -208,6 +208,9 @@ func TestHandleState_ReadOnlyActionsDisabled(t *testing.T) {
 	if approve.PRNumber != 10 {
 		t.Fatalf("approve_merge pr = %d, want 10", approve.PRNumber)
 	}
+	workerWithoutPR := findSessionInfo(t, resp.All, "slot-1")
+	approveWithoutPR := findControlAction(t, workerWithoutPR.Actions, "approve_merge")
+	assertReadOnlyAction(t, approveWithoutPR)
 }
 
 func TestHandleStateSupervisorRationale(t *testing.T) {


### PR DESCRIPTION
Closes #291

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires approval-gated control affordances into both the single-server and fleet dashboards: new `controlAction` / `controlActionRequest` types, `projectActionAffordances` / `workerActionAffordances` builders, stub `handleAction` and `handleFleetAction` endpoints (currently returning 403 for read-only and 501 otherwise), and corresponding UI rendering in the embedded HTML templates. Test coverage for the new paths is solid. The one minor inconsistency is that the `approve_merge` disabled reason for workers without a PR implies a PR is the only missing prerequisite, while workers with a PR also remain disabled (feature not yet implemented).

<h3>Confidence Score: 4/5</h3>

Safe to merge; all action endpoints return 403 or 501 so no write path is reachable yet.

No P0 issues. One pre-existing P1 design gap (per-project read-only enforcement requires the project name in the POST body, noted in the prior review thread) is still present but harmless while handlers return 501. The only new finding is a P2 wording inconsistency in the approve_merge disabled reason.

internal/server/fleet.go — the project-level read-only guard in handleFleetAction is skipped when the request body omits "project"; will need hard validation before any action is actually implemented.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/server.go | Adds controlAction/controlActionRequest types, project and worker affordance builders, handleAction endpoint, and threads actions into state/worker/issue responses; approve_merge disabled reason for no-PR writable workers uses future-tense wording that implies functionality will be unlocked, while other actions say "not implemented yet". |
| internal/server/fleet.go | Registers /api/v1/fleet/actions, adds project and worker affordances to fleet snapshots; per-project read-only check requires the project name in the request body, so a request omitting "project" bypasses the check (will matter once 501 stubs become real handlers). |
| internal/server/fleet_test.go | Adds tests for fleet-level and project-level read-only rejection and verifies affordance counts and disabled reasons; coverage is appropriate for the new stub handlers. |
| internal/server/server_test.go | Adds TestHandleState_ReadOnlyActionsDisabled, TestHandleAction_ReadOnlyRejectsMutation, and TestHandleAction_NotImplementedWhenWritable; helper assertReadOnlyAction correctly validates all affordance fields including endpoint path. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/server/server.go:588-591
**`approve_merge` disabled reason implies PR is the only missing prerequisite**

When `!readOnly && worker.PRNumber == 0` the `approve_merge` affordance carries the reason `"No PR is associated with this worker; merge approval will require approval-backed controls."` The phrasing implies that once a PR exists the action becomes available, but workers that _do_ have a PR are equally disabled — their tooltip reads `"Approval-backed controls are not implemented yet."` A user who reads the "No PR" tooltip may create or link a PR expecting the button to enable, only to discover nothing changed.

Consider making the no-PR case additive instead of replacing the "not implemented" baseline:

```go
if !readOnly && worker.PRNumber == 0 {
    mergeReason = "Approval-backed controls are not implemented yet; additionally, no PR is associated with this worker."
}
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix fleet read-only action gates"](https://github.com/befeast/maestro/commit/4263740ece0fe9fcf3af7b53a9279701f7854e2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30458764)</sub>

<!-- /greptile_comment -->