### PR TITLE
fix: support user-owned GitHub Projects

### DIFF
--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -32,21 +32,8 @@ type ProjectField struct {
 
 // DiscoverProject finds the GitHub Project board and returns its Status field options.
 func (c *Client) DiscoverProject(projectNumber int) (*ProjectField, error) {
-	org := strings.Split(c.Repo, "/")[0]
-
-	query := fmt.Sprintf(`query {
-		organization(login: %q) {
-			projectV2(number: %d) {
-				id
-				field(name: "Status") {
-					... on ProjectV2SingleSelectField {
-						id
-						options { id name }
-					}
-				}
-			}
-		}
-	}`, org, projectNumber)
+	owner := strings.Split(c.Repo, "/")[0]
+	query := discoverProjectQuery(owner, projectNumber)
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
@@ -55,9 +42,44 @@ func (c *Client) DiscoverProject(projectNumber int) (*ProjectField, error) {
 		return nil, fmt.Errorf("discover project %d: %w", projectNumber, err)
 	}
 
+	pf, err := parseDiscoverProjectResponse(owner, projectNumber, out)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[projects] discovered project %d for %s: %d status options (%v)", projectNumber, owner, len(pf.Options), keys(pf.Options))
+	return pf, nil
+}
+
+func discoverProjectQuery(owner string, projectNumber int) string {
+	projectFields := `{
+				id
+				field(name: "Status") {
+					... on ProjectV2SingleSelectField {
+						id
+						options { id name }
+					}
+				}
+			}`
+
+	return fmt.Sprintf(`query {
+		repositoryOwner(login: %q) {
+			__typename
+			... on User {
+				projectV2(number: %d) %s
+			}
+			... on Organization {
+				projectV2(number: %d) %s
+			}
+		}
+	}`, owner, projectNumber, projectFields, projectNumber, projectFields)
+}
+
+func parseDiscoverProjectResponse(owner string, projectNumber int, out []byte) (*ProjectField, error) {
 	var result struct {
 		Data struct {
-			Organization struct {
+			RepositoryOwner struct {
+				Typename  string `json:"__typename"`
 				ProjectV2 struct {
 					ID    string `json:"id"`
 					Field struct {
@@ -68,16 +90,16 @@ func (c *Client) DiscoverProject(projectNumber int) (*ProjectField, error) {
 						} `json:"options"`
 					} `json:"field"`
 				} `json:"projectV2"`
-			} `json:"organization"`
+			} `json:"repositoryOwner"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(out, &result); err != nil {
 		return nil, fmt.Errorf("parse project response: %w", err)
 	}
 
-	p := result.Data.Organization.ProjectV2
+	p := result.Data.RepositoryOwner.ProjectV2
 	if p.ID == "" {
-		return nil, fmt.Errorf("project %d not found", projectNumber)
+		return nil, fmt.Errorf("project %d not found for owner %q", projectNumber, owner)
 	}
 
 	pf := &ProjectField{
@@ -89,7 +111,6 @@ func (c *Client) DiscoverProject(projectNumber int) (*ProjectField, error) {
 		pf.Options[opt.Name] = opt.ID
 	}
 
-	log.Printf("[projects] discovered project %d: %d status options (%v)", projectNumber, len(pf.Options), keys(pf.Options))
 	return pf, nil
 }
 

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -9,6 +10,58 @@ func TestDiscoverProject_RequiresOrg(t *testing.T) {
 	c := New("owner/repo")
 	// DiscoverProject makes real API calls; just verify it doesn't panic
 	_ = c
+}
+
+func TestDiscoverProjectQuerySupportsUserAndOrganizationOwners(t *testing.T) {
+	query := discoverProjectQuery("kossoy", 2)
+
+	for _, want := range []string{
+		`repositoryOwner(login: "kossoy")`,
+		"... on User",
+		"... on Organization",
+		"projectV2(number: 2)",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("discoverProjectQuery() missing %q in:\n%s", want, query)
+		}
+	}
+	if strings.Contains(query, "organization(login:") {
+		t.Fatalf("discoverProjectQuery() still uses organization-only lookup:\n%s", query)
+	}
+}
+
+func TestParseDiscoverProjectResponse_UserOwner(t *testing.T) {
+	body := []byte(`{
+		"data": {
+			"repositoryOwner": {
+				"__typename": "User",
+				"projectV2": {
+					"id": "project-id",
+					"field": {
+						"id": "field-id",
+						"options": [
+							{"id": "todo-id", "name": "Todo"},
+							{"id": "progress-id", "name": "In Progress"}
+						]
+					}
+				}
+			}
+		}
+	}`)
+
+	pf, err := parseDiscoverProjectResponse("kossoy", 2, body)
+	if err != nil {
+		t.Fatalf("parseDiscoverProjectResponse() error = %v", err)
+	}
+	if pf.ProjectID != "project-id" {
+		t.Fatalf("ProjectID = %q, want project-id", pf.ProjectID)
+	}
+	if pf.FieldID != "field-id" {
+		t.Fatalf("FieldID = %q, want field-id", pf.FieldID)
+	}
+	if got := pf.Options["In Progress"]; got != "progress-id" {
+		t.Fatalf("Options[In Progress] = %q, want progress-id", got)
+	}
 }
 
 func TestSyncIssueStatus_NilProjectField(t *testing.T) {


### PR DESCRIPTION
## Summary
- discover GitHub Projects through repositoryOwner so both user-owned and org-owned ProjectV2 boards work
- parse the new response shape and keep status option discovery unchanged
- add unit coverage for user-owned project responses

## Test Plan
- go test ./...
- manual: /tmp/maestro-projectv2-user run --once --config /home/god/.maestro/maestro.d/finance-tracker.yaml discovered project 2 for kossoy

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `DiscoverProject` to support user-owned GitHub Projects by switching from the `organization` GraphQL field to `repositoryOwner` with `... on User` / `... on Organization` inline fragments, and splits the function into a query builder and a dedicated parser with unit tests covering the user-owner path.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only a P2 style concern about a misleading error message when the owner login doesn't exist.

All findings are P2. The core fix (repositoryOwner + inline fragments) is correct, the response parsing is structurally sound, and the new tests cover the added code paths.

internal/github/github_projects.go — parseDiscoverProjectResponse could surface a better error when repositoryOwner is null.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github_projects.go | Refactors DiscoverProject to use repositoryOwner with User/Organization inline fragments — correct approach. GraphQL errors field is still not checked in parseDiscoverProjectResponse (noted in prior thread); null repositoryOwner produces a misleading error message. |
| internal/github/github_projects_test.go | Adds tests for the new query structure and user-owner parse path; coverage is reasonable for the changed surface area. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/github/github_projects.go:100-103
**Misleading error when owner login doesn't exist**

When `repositoryOwner` is `null` in the GraphQL response (e.g. the login doesn't exist on GitHub), Go's JSON unmarshaler silently zeroes the struct, leaving `p.ID == ""`. The caller then sees `"project 2 not found for owner \"kossoy\""` when the real problem is that the owner wasn't found at all. The stored `Typename` field is never read, so no branch can distinguish the two failure modes. Surfacing a better error message here would save a lot of debugging time.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: support user-owned GitHub Projects"](https://github.com/befeast/maestro/commit/ea1bc86a993ffe2cc75f302d36681d0807009ef5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30459322)</sub>

<!-- /greptile_comment -->