### PR TITLE
Prevent state lost-update between run and supervise loops

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/befeast/maestro
 
 go 1.22.2
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/gofrs/flock v0.12.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require golang.org/x/sys v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
+github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -10,8 +10,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
+
+	"github.com/gofrs/flock"
 )
 
 type SessionStatus string
@@ -429,16 +430,9 @@ func saveLocked(stateDir string, s *State) error {
 		desired = merged
 	}
 
-	data, err := json.MarshalIndent(s, "", "  ")
+	data, err := json.MarshalIndent(desired, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal state: %w", err)
-	}
-
-	if desired != s {
-		data, err = json.MarshalIndent(desired, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal state: %w", err)
-		}
 	}
 
 	tmp := path + ".tmp"
@@ -457,17 +451,12 @@ func saveLocked(stateDir string, s *State) error {
 
 func lockState(stateDir string) (func(), error) {
 	lockPath := filepath.Join(stateDir, ".state.lock")
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
-	if err != nil {
-		return nil, fmt.Errorf("open state lock: %w", err)
-	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		f.Close()
+	stateLock := flock.New(lockPath)
+	if err := stateLock.Lock(); err != nil {
 		return nil, fmt.Errorf("lock state: %w", err)
 	}
 	return func() {
-		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		_ = f.Close()
+		_ = stateLock.Unlock()
 	}, nil
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -211,6 +212,7 @@ var (
 	ErrApprovalNotPending      = errors.New("approval is not pending")
 	ErrApprovalStale           = errors.New("approval is stale")
 	ErrApprovalPayloadMismatch = errors.New("approval payload changed")
+	ErrStateConflict           = errors.New("state write conflict")
 )
 
 // SupervisorTarget identifies the primary object a supervisor decision refers to.
@@ -347,6 +349,9 @@ type State struct {
 	Approvals           []Approval           `json:"approvals,omitempty"`
 	NextSlot            int                  `json:"next_slot"`
 	LastMergeAt         time.Time            `json:"last_merge_at,omitempty"`
+
+	loadedHash  string
+	loadedState *State
 }
 
 func NewState() *State {
@@ -369,7 +374,9 @@ func Load(stateDir string) (*State, error) {
 	path := StatePath(stateDir)
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
-		return NewState(), nil
+		s := NewState()
+		s.rememberLoaded(nil)
+		return s, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("read state: %w", err)
@@ -379,6 +386,8 @@ func Load(stateDir string) (*State, error) {
 	if err := json.Unmarshal(data, s); err != nil {
 		return nil, fmt.Errorf("parse state: %w", err)
 	}
+	s.normalize()
+	s.rememberLoaded(data)
 	return s, nil
 }
 
@@ -386,13 +395,52 @@ func Save(stateDir string, s *State) error {
 	if err := os.MkdirAll(stateDir, 0755); err != nil {
 		return fmt.Errorf("create state dir: %w", err)
 	}
+	unlock, err := lockState(stateDir)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	return saveLocked(stateDir, s)
+}
+
+func saveLocked(stateDir string, s *State) error {
+	if s == nil {
+		s = NewState()
+	}
+	s.normalize()
+
+	path := StatePath(stateDir)
+	current, currentData, err := readStateFile(path)
+	if err != nil {
+		return err
+	}
+	currentHash := hashBytes(currentData)
+	desired := s
+	if currentHash != s.loadedHash {
+		base := s.loadedState
+		if base == nil {
+			base = NewState()
+		}
+		merged, err := mergeStateSnapshots(base, current, s)
+		if err != nil {
+			return err
+		}
+		desired = merged
+	}
 
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal state: %w", err)
 	}
 
-	path := StatePath(stateDir)
+	if desired != s {
+		data, err = json.MarshalIndent(desired, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal state: %w", err)
+		}
+	}
+
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0644); err != nil {
 		return fmt.Errorf("write temp state: %w", err)
@@ -400,7 +448,381 @@ func Save(stateDir string, s *State) error {
 	if err := os.Rename(tmp, path); err != nil {
 		return fmt.Errorf("atomic rename state: %w", err)
 	}
+	if desired != s {
+		s.copyFrom(desired)
+	}
+	s.rememberLoaded(data)
 	return nil
+}
+
+func lockState(stateDir string) (func(), error) {
+	lockPath := filepath.Join(stateDir, ".state.lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open state lock: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("lock state: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}
+
+func readStateFile(path string) (*State, []byte, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return NewState(), nil, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("read state: %w", err)
+	}
+	s := NewState()
+	if err := json.Unmarshal(data, s); err != nil {
+		return nil, nil, fmt.Errorf("parse state: %w", err)
+	}
+	s.normalize()
+	return s, data, nil
+}
+
+func (s *State) rememberLoaded(data []byte) {
+	s.loadedHash = hashBytes(data)
+	s.loadedState = cloneState(s)
+}
+
+func hashBytes(data []byte) string {
+	if data == nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *State) normalize() {
+	if s.Sessions == nil {
+		s.Sessions = make(map[string]*Session)
+	}
+	if s.Missions == nil {
+		s.Missions = make(map[int]*Mission)
+	}
+	if s.NextSlot == 0 {
+		s.NextSlot = 1
+	}
+}
+
+func (s *State) copyFrom(src *State) {
+	s.Sessions = src.Sessions
+	s.Missions = src.Missions
+	s.SupervisorDecisions = src.SupervisorDecisions
+	s.Approvals = src.Approvals
+	s.NextSlot = src.NextSlot
+	s.LastMergeAt = src.LastMergeAt
+}
+
+func cloneState(s *State) *State {
+	if s == nil {
+		return NewState()
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return NewState()
+	}
+	clone := NewState()
+	if err := json.Unmarshal(data, clone); err != nil {
+		return NewState()
+	}
+	clone.normalize()
+	return clone
+}
+
+func mergeStateSnapshots(base, current, ours *State) (*State, error) {
+	base = cloneState(base)
+	current = cloneState(current)
+	ours = cloneState(ours)
+	merged := cloneState(current)
+
+	if err := mergeSessions(merged, base, current, ours); err != nil {
+		return nil, err
+	}
+	if err := mergeMissions(merged, base, current, ours); err != nil {
+		return nil, err
+	}
+	if err := mergeApprovals(merged, base, current, ours); err != nil {
+		return nil, err
+	}
+	if err := mergeSupervisorDecisions(merged, base, current, ours); err != nil {
+		return nil, err
+	}
+	merged.NextSlot = mergeMonotonicInt(base.NextSlot, current.NextSlot, ours.NextSlot)
+	merged.LastMergeAt = mergeLatestTime(base.LastMergeAt, current.LastMergeAt, ours.LastMergeAt)
+	return merged, nil
+}
+
+func mergeSessions(merged, base, current, ours *State) error {
+	for _, key := range unionKeys(base.Sessions, current.Sessions, ours.Sessions) {
+		baseValue := base.Sessions[key]
+		currentValue := current.Sessions[key]
+		oursValue := ours.Sessions[key]
+		resolved, keep, err := resolveSnapshotValue("session "+key, baseValue, currentValue, oursValue)
+		if err != nil {
+			return err
+		}
+		if keep {
+			merged.Sessions[key] = resolved.(*Session)
+		} else {
+			delete(merged.Sessions, key)
+		}
+	}
+	return nil
+}
+
+func mergeMissions(merged, base, current, ours *State) error {
+	for _, key := range unionIntKeys(base.Missions, current.Missions, ours.Missions) {
+		baseValue := base.Missions[key]
+		currentValue := current.Missions[key]
+		oursValue := ours.Missions[key]
+		resolved, keep, err := resolveSnapshotValue(fmt.Sprintf("mission %d", key), baseValue, currentValue, oursValue)
+		if err != nil {
+			return err
+		}
+		if keep {
+			merged.Missions[key] = resolved.(*Mission)
+		} else {
+			delete(merged.Missions, key)
+		}
+	}
+	return nil
+}
+
+func mergeApprovals(merged, base, current, ours *State) error {
+	merged.Approvals = cloneState(current).Approvals
+	keys := unionStringSets(approvalKeys(base.Approvals), approvalKeys(current.Approvals), approvalKeys(ours.Approvals))
+	for _, key := range keys {
+		baseValue, baseOK := approvalByKey(base.Approvals, key)
+		currentValue, currentOK := approvalByKey(current.Approvals, key)
+		oursValue, oursOK := approvalByKey(ours.Approvals, key)
+		resolved, keep, err := resolveListValue("approval "+key, baseValue, baseOK, currentValue, currentOK, oursValue, oursOK)
+		if err != nil {
+			return err
+		}
+		if keep {
+			merged.Approvals = upsertApproval(merged.Approvals, resolved.(Approval))
+		} else {
+			merged.Approvals = deleteApproval(merged.Approvals, key)
+		}
+	}
+	return nil
+}
+
+func mergeSupervisorDecisions(merged, base, current, ours *State) error {
+	merged.SupervisorDecisions = cloneState(current).SupervisorDecisions
+	keys := unionStringSets(decisionKeys(base.SupervisorDecisions), decisionKeys(current.SupervisorDecisions), decisionKeys(ours.SupervisorDecisions))
+	for _, key := range keys {
+		baseValue, baseOK := decisionByKey(base.SupervisorDecisions, key)
+		currentValue, currentOK := decisionByKey(current.SupervisorDecisions, key)
+		oursValue, oursOK := decisionByKey(ours.SupervisorDecisions, key)
+		resolved, keep, err := resolveListValue("supervisor decision "+key, baseValue, baseOK, currentValue, currentOK, oursValue, oursOK)
+		if err != nil {
+			return err
+		}
+		if keep {
+			merged.SupervisorDecisions = upsertDecision(merged.SupervisorDecisions, resolved.(SupervisorDecision))
+		} else {
+			merged.SupervisorDecisions = deleteDecision(merged.SupervisorDecisions, key)
+		}
+	}
+	if len(merged.SupervisorDecisions) > DefaultSupervisorDecisionLimit {
+		merged.SupervisorDecisions = append([]SupervisorDecision(nil), merged.SupervisorDecisions[len(merged.SupervisorDecisions)-DefaultSupervisorDecisionLimit:]...)
+	}
+	return nil
+}
+
+func resolveSnapshotValue(name string, baseValue, currentValue, oursValue interface{}) (interface{}, bool, error) {
+	baseOK := !jsonEqual(baseValue, nil)
+	currentOK := !jsonEqual(currentValue, nil)
+	oursOK := !jsonEqual(oursValue, nil)
+	return resolveListValue(name, baseValue, baseOK, currentValue, currentOK, oursValue, oursOK)
+}
+
+func resolveListValue(name string, baseValue interface{}, baseOK bool, currentValue interface{}, currentOK bool, oursValue interface{}, oursOK bool) (interface{}, bool, error) {
+	oursChanged := baseOK != oursOK || !jsonEqual(baseValue, oursValue)
+	currentChanged := baseOK != currentOK || !jsonEqual(baseValue, currentValue)
+	switch {
+	case !oursChanged:
+		return currentValue, currentOK, nil
+	case !currentChanged:
+		return oursValue, oursOK, nil
+	case currentOK == oursOK && jsonEqual(currentValue, oursValue):
+		return currentValue, currentOK, nil
+	default:
+		return nil, false, fmt.Errorf("%w: %s changed concurrently", ErrStateConflict, name)
+	}
+}
+
+func jsonEqual(a, b interface{}) bool {
+	return stableHash(a) == stableHash(b)
+}
+
+func mergeMonotonicInt(base, current, ours int) int {
+	if ours == base {
+		return current
+	}
+	if current == base {
+		return ours
+	}
+	if ours > current {
+		return ours
+	}
+	return current
+}
+
+func mergeLatestTime(base, current, ours time.Time) time.Time {
+	if ours.Equal(base) {
+		return current
+	}
+	if current.Equal(base) || ours.After(current) {
+		return ours
+	}
+	return current
+}
+
+func unionKeys(maps ...map[string]*Session) []string {
+	seen := make(map[string]bool)
+	for _, m := range maps {
+		for key := range m {
+			seen[key] = true
+		}
+	}
+	return sortedStringKeys(seen)
+}
+
+func unionIntKeys(maps ...map[int]*Mission) []int {
+	seen := make(map[int]bool)
+	for _, m := range maps {
+		for key := range m {
+			seen[key] = true
+		}
+	}
+	keys := make([]int, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Ints(keys)
+	return keys
+}
+
+func unionStringSets(sets ...map[string]bool) []string {
+	seen := make(map[string]bool)
+	for _, set := range sets {
+		for key := range set {
+			seen[key] = true
+		}
+	}
+	return sortedStringKeys(seen)
+}
+
+func sortedStringKeys(seen map[string]bool) []string {
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func approvalKeys(approvals []Approval) map[string]bool {
+	keys := make(map[string]bool)
+	for _, approval := range approvals {
+		keys[approvalKey(approval)] = true
+	}
+	return keys
+}
+
+func approvalByKey(approvals []Approval, key string) (Approval, bool) {
+	for _, approval := range approvals {
+		if approvalKey(approval) == key {
+			return approval, true
+		}
+	}
+	return Approval{}, false
+}
+
+func approvalKey(approval Approval) string {
+	if approval.ID != "" {
+		return approval.ID
+	}
+	if approval.DecisionID != "" {
+		return "decision:" + approval.DecisionID
+	}
+	return stableHash(approval)
+}
+
+func upsertApproval(approvals []Approval, approval Approval) []Approval {
+	key := approvalKey(approval)
+	for i := range approvals {
+		if approvalKey(approvals[i]) == key {
+			approvals[i] = approval
+			return approvals
+		}
+	}
+	return append(approvals, approval)
+}
+
+func deleteApproval(approvals []Approval, key string) []Approval {
+	filtered := approvals[:0]
+	for _, approval := range approvals {
+		if approvalKey(approval) != key {
+			filtered = append(filtered, approval)
+		}
+	}
+	return filtered
+}
+
+func decisionKeys(decisions []SupervisorDecision) map[string]bool {
+	keys := make(map[string]bool)
+	for _, decision := range decisions {
+		keys[decisionKey(decision)] = true
+	}
+	return keys
+}
+
+func decisionByKey(decisions []SupervisorDecision, key string) (SupervisorDecision, bool) {
+	for _, decision := range decisions {
+		if decisionKey(decision) == key {
+			return decision, true
+		}
+	}
+	return SupervisorDecision{}, false
+}
+
+func decisionKey(decision SupervisorDecision) string {
+	if decision.ID != "" {
+		return decision.ID
+	}
+	return stableHash(decision)
+}
+
+func upsertDecision(decisions []SupervisorDecision, decision SupervisorDecision) []SupervisorDecision {
+	key := decisionKey(decision)
+	for i := range decisions {
+		if decisionKey(decisions[i]) == key {
+			decisions[i] = decision
+			return decisions
+		}
+	}
+	return append(decisions, decision)
+}
+
+func deleteDecision(decisions []SupervisorDecision, key string) []SupervisorDecision {
+	filtered := decisions[:0]
+	for _, decision := range decisions {
+		if decisionKey(decision) != key {
+			filtered = append(filtered, decision)
+		}
+	}
+	return filtered
 }
 
 // NextSlotName returns "{prefix}-N" for the next available slot

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -934,6 +934,118 @@ func TestRecordSupervisorDecisionPrunesOldRecords(t *testing.T) {
 	}
 }
 
+func TestSaveMergesIndependentConcurrentUpdates(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 5, 1, 13, 46, 2, 0, time.UTC)
+	initial := NewState()
+	if err := Save(dir, initial); err != nil {
+		t.Fatalf("Save initial: %v", err)
+	}
+
+	runSnapshot, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load run snapshot: %v", err)
+	}
+	supervisorSnapshot, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load supervisor snapshot: %v", err)
+	}
+
+	decision := SupervisorDecision{
+		ID:                "sup-20260501T134602.103131758Z",
+		CreatedAt:         now,
+		Project:           "BeFeast/maestro",
+		Mode:              "read_only",
+		Summary:           "Start a worker for issue #302: Prevent state lost-update.",
+		RecommendedAction: "spawn_worker",
+		Target:            &SupervisorTarget{Issue: 302},
+		Risk:              "mutating",
+		Confidence:        0.84,
+		Reasons:           []string{"Issue #302 is eligible"},
+	}
+	approval := supervisorSnapshot.RecordPendingApprovalForDecision(decision, now)
+	decision.ApprovalID = approval.ID
+	supervisorSnapshot.RecordSupervisorDecision(decision, DefaultSupervisorDecisionLimit)
+	if err := Save(dir, supervisorSnapshot); err != nil {
+		t.Fatalf("Save supervisor snapshot: %v", err)
+	}
+
+	runSnapshot.Sessions["slot-1"] = &Session{
+		IssueNumber: 17,
+		IssueTitle:  "existing run-loop work",
+		Status:      StatusRunning,
+		StartedAt:   now,
+		PID:         1234,
+	}
+	if err := Save(dir, runSnapshot); err != nil {
+		t.Fatalf("Save stale run snapshot: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load merged state: %v", err)
+	}
+	if loaded.Sessions["slot-1"] == nil {
+		t.Fatal("run-loop session missing after merge")
+	}
+	latest := loaded.LatestSupervisorDecision()
+	if latest == nil || latest.ID != decision.ID || latest.Target == nil || latest.Target.Issue != 302 {
+		t.Fatalf("latest decision = %#v, want supervisor decision for issue #302", latest)
+	}
+	loadedApproval, ok := loaded.FindApproval(approval.ID)
+	if !ok {
+		t.Fatalf("approval %q missing after stale run-loop save", approval.ID)
+	}
+	if loadedApproval.Status != ApprovalStatusPending {
+		t.Fatalf("approval status = %q, want pending", loadedApproval.Status)
+	}
+	if _, err := loaded.ApproveApproval(approval.ID, now.Add(time.Minute), "test", "race preserved"); err != nil {
+		t.Fatalf("ApproveApproval after merge: %v", err)
+	}
+}
+
+func TestSaveRejectsConcurrentSameSessionConflict(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 5, 1, 13, 46, 2, 0, time.UTC)
+	initial := NewState()
+	initial.Sessions["slot-1"] = &Session{
+		IssueNumber: 42,
+		IssueTitle:  "same session",
+		Status:      StatusRunning,
+		StartedAt:   now,
+		PID:         100,
+	}
+	if err := Save(dir, initial); err != nil {
+		t.Fatalf("Save initial: %v", err)
+	}
+
+	first, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load first: %v", err)
+	}
+	second, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load second: %v", err)
+	}
+
+	first.Sessions["slot-1"].PID = 200
+	if err := Save(dir, first); err != nil {
+		t.Fatalf("Save first: %v", err)
+	}
+	second.Sessions["slot-1"].PID = 300
+	if err := Save(dir, second); !errors.Is(err, ErrStateConflict) {
+		t.Fatalf("Save second err = %v, want %v", err, ErrStateConflict)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load after conflict: %v", err)
+	}
+	if got := loaded.Sessions["slot-1"].PID; got != 200 {
+		t.Fatalf("PID = %d, want first writer value 200", got)
+	}
+}
+
 func TestApprovalPendingPersistence(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -549,6 +549,54 @@ func TestRunOnceRecordsPendingApprovalForRiskyDecision(t *testing.T) {
 	}
 }
 
+func TestRunOnceDecisionSurvivesStaleRunLoopSave(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	runSnapshot, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load run snapshot: %v", err)
+	}
+
+	reader := &fakeReader{issues: []github.Issue{testIssue(302, "Prevent state lost-update", "maestro-ready")}}
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker || decision.ApprovalID == "" {
+		t.Fatalf("decision = %#v, want approval-gated spawn_worker", decision)
+	}
+
+	runSnapshot.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 17,
+		IssueTitle:  "run-loop reconciliation",
+		Status:      state.StatusRunning,
+		StartedAt:   time.Now().UTC(),
+		PID:         1234,
+	}
+	if err := state.Save(cfg.StateDir, runSnapshot); err != nil {
+		t.Fatalf("Save stale run snapshot: %v", err)
+	}
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load merged state: %v", err)
+	}
+	latest := st.LatestSupervisorDecision()
+	if latest == nil || latest.ID != decision.ID || latest.Target == nil || latest.Target.Issue != 302 {
+		t.Fatalf("latest decision = %#v, want decision for issue #302", latest)
+	}
+	approval, ok := st.FindApproval(decision.ApprovalID)
+	if !ok {
+		t.Fatalf("approval %q missing after stale run-loop save", decision.ApprovalID)
+	}
+	if approval.Status != state.ApprovalStatusPending {
+		t.Fatalf("approval status = %q, want pending", approval.Status)
+	}
+	if _, err := st.ApproveApproval(decision.ApprovalID, time.Now().UTC(), "test", "race preserved"); err != nil {
+		t.Fatalf("ApproveApproval after race: %v", err)
+	}
+}
+
 func TestDecide_OrderedQueueAdvancesAfterClosedIssue(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}


### PR DESCRIPTION
Closes #303

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents the lost-update race between the run and supervise loops by introducing an advisory file lock (`gofrs/flock`) around state writes and a 3-way merge strategy. When `Save` detects that the file has changed since the state was loaded (via a SHA-256 hash of the raw bytes stored at load time), it merges independent concurrent changes and returns `ErrStateConflict` when the same entity was modified by both writers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the locking, hash-detection, and 3-way merge logic are all correct, and the new tests directly cover the targeted race scenarios.

No logic bugs found. Load is correctly lock-free (atomic rename guarantees readers always see a consistent file). saveLocked re-reads under the lock so the hash comparison is race-free. The four-case merge resolution (only-ours-changed, only-current-changed, both-changed-same, both-changed-different/conflict) handles every combination correctly. copyFrom + rememberLoaded correctly updates the caller's snapshot after a merge so subsequent saves use the right base. The switch from syscall.Flock to gofrs/flock also resolves the portability concern flagged in an earlier review round.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Core change: adds `gofrs/flock` advisory file lock around writes, a hash-based change-detection mechanism (loadedHash/loadedState), and a full 3-way merge for sessions, missions, approvals, and supervisor decisions. Logic is sound — concurrent independent writes merge cleanly, concurrent conflicting writes return ErrStateConflict. |
| internal/state/state_test.go | Adds two focused integration tests: one verifying that independent concurrent writes (supervisor decision + run-loop session) merge cleanly, and one verifying that concurrent conflicting writes to the same session return ErrStateConflict with the first writer's value preserved. |
| internal/supervisor/supervisor_test.go | Adds an end-to-end regression test for the specific lost-update scenario described in the PR: RunOnce writes a supervisor decision, a stale run-loop snapshot is saved, and the test asserts that the decision and its pending approval both survive the merge. |
| go.mod | Adds github.com/gofrs/flock v0.12.1 as a direct dependency and golang.org/x/sys v0.22.0 as a transitive dependency; addresses the Unix portability concern raised previously by switching from syscall.Flock to the cross-platform flock library. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address state save review feedback"](https://github.com/befeast/maestro/commit/e0cbefe8542a32873fa1c4ed2405248c8a8a7b24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30464836)</sub>

<!-- /greptile_comment -->