### PR TITLE
Fleet dashboard: per-project queue snapshot and skipped reasons

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -214,6 +214,17 @@ type fleetProjectFreshness struct {
 	StaleAfterSeconds  int64  `json:"stale_after_seconds"`
 }
 
+type fleetQueueSnapshot struct {
+	PolicyRule                    string                          `json:"policy_rule,omitempty"`
+	Open                          int                             `json:"open"`
+	Eligible                      int                             `json:"eligible"`
+	Excluded                      int                             `json:"excluded"`
+	NonRunnableProjectStatusCount int                             `json:"non_runnable_project_status_count"`
+	SelectedCandidate             *state.SupervisorIssueCandidate `json:"selected_candidate,omitempty"`
+	TopSkippedReason              string                          `json:"top_skipped_reason,omitempty"`
+	IdleReason                    string                          `json:"idle_reason,omitempty"`
+}
+
 type fleetProjectState struct {
 	Name            string                `json:"name"`
 	Repo            string                `json:"repo"`
@@ -234,6 +245,7 @@ type fleetProjectState struct {
 	ApprovalSummary map[string]int        `json:"approval_summary,omitempty"`
 	Actions         []controlAction       `json:"actions,omitempty"`
 	Supervisor      supervisorInfo        `json:"supervisor"`
+	QueueSnapshot   *fleetQueueSnapshot   `json:"queue_snapshot,omitempty"`
 	Freshness       fleetProjectFreshness `json:"freshness"`
 	Error           string                `json:"error,omitempty"`
 }
@@ -564,6 +576,31 @@ func fleetProjectFreshnessForState(stateDir string, st *state.State, now time.Ti
 	return freshness
 }
 
+func fleetQueueSnapshotFromSupervisor(info supervisorInfo) *fleetQueueSnapshot {
+	if info.Latest == nil || info.Latest.QueueAnalysis == nil {
+		return nil
+	}
+	analysis := info.Latest.QueueAnalysis
+	policyRule := strings.TrimSpace(analysis.PolicyRule)
+	if policyRule == "" {
+		policyRule = strings.TrimSpace(info.Latest.PolicyRule)
+	}
+	snapshot := &fleetQueueSnapshot{
+		PolicyRule:                    policyRule,
+		Open:                          analysis.OpenIssues,
+		Eligible:                      analysis.EligibleCandidates,
+		Excluded:                      analysis.ExcludedIssues,
+		NonRunnableProjectStatusCount: analysis.NonRunnableProjectStatusCount,
+		TopSkippedReason:              analysis.TopSkippedReason(),
+		IdleReason:                    analysis.IdleReason(),
+	}
+	if analysis.SelectedCandidate != nil {
+		candidate := *analysis.SelectedCandidate
+		snapshot.SelectedCandidate = &candidate
+	}
+	return snapshot
+}
+
 func latestProjectLogModTime(st *state.State) time.Time {
 	if st == nil {
 		return time.Time{}
@@ -667,6 +704,7 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	item.Failed = failedCount(projectState.Summary)
 	item.Sessions = len(projectState.All)
 	item.Supervisor = projectState.Supervisor
+	item.QueueSnapshot = fleetQueueSnapshotFromSupervisor(item.Supervisor)
 	item.Approvals = makeFleetApprovalStates(item, st, now)
 	if len(item.Approvals) > 0 {
 		item.ApprovalSummary = make(map[string]int)
@@ -1446,6 +1484,22 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   }
   .why-item { margin-top: 7px; color: var(--muted); font-size: 12px; line-height: 1.4; }
   .why-item strong { color: var(--text); }
+  .queue-snapshot {
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--line);
+    background: rgba(88,166,255,.04);
+  }
+  .queue-line {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 10px;
+    margin-top: 6px;
+    color: var(--muted);
+    font-size: 12px;
+    line-height: 1.35;
+  }
+  .queue-line strong { color: var(--text); font-weight: 650; }
+  .queue-idle { color: var(--warn); }
   .error { color: var(--bad); border: 1px solid rgba(248,81,73,.35); border-radius: 10px; background: rgba(248,81,73,.08); padding: 12px 14px; }
   @media (max-width: 980px) {
     header { align-items: flex-start; flex-direction: column; }
@@ -2368,6 +2422,35 @@ async function loadWorkerDetail() {
   }
 }
 
+function queueSnapshotHTML(project) {
+  const q = project.queue_snapshot;
+  if (!q) return "";
+  const parts = [
+    "open=" + Number(q.open || 0),
+    "eligible=" + Number(q.eligible || 0),
+    "excluded=" + Number(q.excluded || 0),
+    "non-runnable=" + Number(q.non_runnable_project_status_count || 0)
+  ];
+  const selected = q.selected_candidate && q.selected_candidate.number
+    ? "selected #" + q.selected_candidate.number + (q.selected_candidate.title ? " " + q.selected_candidate.title : "")
+    : "";
+  if (selected) parts.push(selected);
+
+  const lines = ['<div class="queue-line"><strong>Queue</strong><span>' + escapeText(parts.join(" · ")) + '</span></div>'];
+  const isIdle = (project.running || 0) === 0;
+  let idleReason = isIdle ? (q.idle_reason || "") : "";
+  const topSkip = isIdle && q.eligible === 0 && q.top_skipped_reason && !(idleReason || "").includes(q.top_skipped_reason)
+    ? q.top_skipped_reason
+    : "";
+  if (topSkip) {
+    idleReason = idleReason ? idleReason + " Top skip: " + topSkip : "Top skip: " + topSkip;
+  }
+  if (idleReason) {
+    lines.push('<div class="queue-line queue-idle"><strong>Idle</strong><span>' + escapeText(idleReason) + '</span></div>');
+  }
+  return '<div class="queue-snapshot"><div class="label">Queue Snapshot</div>' + lines.join("") + '</div>';
+}
+
 function renderSupervisor(project) {
   const sup = project.supervisor;
   if (!sup || !sup.has_run || !sup.latest) {
@@ -2399,6 +2482,9 @@ function renderProjectWhy(project) {
       attention.map(worker => '<div class="why-item"><strong>' + escapeText(worker.slot || "-") + '</strong> ' +
         escapeText(workerWhyText(worker) || "Needs operator review.") + '</div>').join("") +
       '</div>';
+  }
+  if ((project.running || 0) === 0 && project.queue_snapshot && project.queue_snapshot.idle_reason) {
+    return "";
   }
   const why = supervisorWhyText(project);
   if ((project.running || 0) === 0 && why) {
@@ -2480,6 +2566,7 @@ function renderProject(project) {
       '<div class="metric"><strong>' + escapeText(project.sessions || 0) + '</strong><span>Sessions</span></div>' +
       '<div class="metric"><strong>' + escapeText(project.needs_attention || 0) + '</strong><span>Attention</span></div>' +
     '</div>' +
+    queueSnapshotHTML(project) +
     renderProjectWhy(project) +
     renderProjectActions(project) +
     renderSupervisor(project) +

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -172,6 +172,99 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	}
 }
 
+func TestFleetAPIIncludesQueueSnapshotMetadata(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	excludedStateDir := filepath.Join(dir, "excluded")
+	candidateStateDir := filepath.Join(dir, "candidate")
+
+	excludedState := state.NewState()
+	excludedState.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-excluded",
+		CreatedAt:         now,
+		Project:           "owner/excluded",
+		Summary:           "No issue is currently eligible under the dynamic wave policy.",
+		RecommendedAction: "none",
+		Risk:              "safe",
+		PolicyRule:        "supervisor.dynamic_wave",
+		QueueAnalysis: &state.SupervisorQueueAnalysis{
+			PolicyRule:         "supervisor.dynamic_wave",
+			OpenIssues:         11,
+			EligibleCandidates: 0,
+			ExcludedIssues:     11,
+			SkippedReasons: []string{
+				"Issue #24 skipped by dynamic wave policy: excluded by label \"blocked\"",
+			},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(excludedStateDir, excludedState); err != nil {
+		t.Fatalf("save excluded state: %v", err)
+	}
+
+	candidateState := state.NewState()
+	candidateState.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-candidate",
+		CreatedAt:         now,
+		Project:           "owner/candidate",
+		Summary:           "Start a worker for issue #309.",
+		RecommendedAction: "spawn_worker",
+		Risk:              "mutating",
+		PolicyRule:        "supervisor.dynamic_wave",
+		QueueAnalysis: &state.SupervisorQueueAnalysis{
+			PolicyRule:         "supervisor.dynamic_wave",
+			OpenIssues:         3,
+			EligibleCandidates: 2,
+			ExcludedIssues:     1,
+			SelectedCandidate: &state.SupervisorIssueCandidate{
+				Number: 309,
+				Title:  "Selected fleet card candidate",
+			},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(candidateStateDir, candidateState); err != nil {
+		t.Fatalf("save candidate state: %v", err)
+	}
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("Excluded", "/tmp/excluded.yaml", "", &config.Config{
+			Repo:        "owner/excluded",
+			StateDir:    excludedStateDir,
+			MaxParallel: 1,
+		}),
+		NewFleetProject("Candidate", "/tmp/candidate.yaml", "", &config.Config{
+			Repo:        "owner/candidate",
+			StateDir:    candidateStateDir,
+			MaxParallel: 1,
+		}),
+	}, "127.0.0.1", 8786, true)
+	resp := srv.snapshot()
+
+	excluded := findFleetProject(t, resp.Projects, "Excluded")
+	if excluded.QueueSnapshot == nil {
+		t.Fatal("excluded project queue snapshot is nil")
+	}
+	if excluded.QueueSnapshot.Open != 11 || excluded.QueueSnapshot.Eligible != 0 || excluded.QueueSnapshot.Excluded != 11 {
+		t.Fatalf("excluded queue snapshot = %+v, want open=11 eligible=0 excluded=11", excluded.QueueSnapshot)
+	}
+	if !contains(excluded.QueueSnapshot.IdleReason, "Policy excluded all 11 open issues") {
+		t.Fatalf("idle reason = %q, want all-excluded explanation", excluded.QueueSnapshot.IdleReason)
+	}
+	if !contains(excluded.QueueSnapshot.TopSkippedReason, "excluded by label") {
+		t.Fatalf("top skipped reason = %q, want excluded label reason", excluded.QueueSnapshot.TopSkippedReason)
+	}
+	if excluded.Supervisor.Latest == nil || excluded.Supervisor.Latest.QueueAnalysis == nil || excluded.Supervisor.Latest.QueueAnalysis.OpenIssues != 11 {
+		t.Fatalf("supervisor latest queue analysis = %#v, want exposed analysis", excluded.Supervisor.Latest)
+	}
+
+	candidate := findFleetProject(t, resp.Projects, "Candidate")
+	if candidate.QueueSnapshot == nil || candidate.QueueSnapshot.SelectedCandidate == nil || candidate.QueueSnapshot.SelectedCandidate.Number != 309 {
+		t.Fatalf("candidate queue snapshot = %+v, want selected issue #309", candidate.QueueSnapshot)
+	}
+	if candidate.QueueSnapshot.IdleReason != "" {
+		t.Fatalf("candidate idle reason = %q, want empty when eligible", candidate.QueueSnapshot.IdleReason)
+	}
+}
+
 func TestFleetAPISurfacesProjectErrorsAndStaleFreshness(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now().UTC()
@@ -778,6 +871,9 @@ func TestFleetDashboard(t *testing.T) {
 		"issue-title",
 		"Why Attention",
 		"Why Not Running",
+		"Queue Snapshot",
+		"queueSnapshotHTML",
+		"queue-snapshot",
 		"next_action",
 		"sortWorkers",
 		"filteredWorkers",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -122,26 +122,27 @@ type supervisorInfo struct {
 }
 
 type supervisorDecisionInfo struct {
-	ID                string                       `json:"id"`
-	CreatedAt         time.Time                    `json:"created_at"`
-	Project           string                       `json:"project"`
-	Mode              string                       `json:"mode"`
-	PolicyRule        string                       `json:"policy_rule,omitempty"`
-	Status            string                       `json:"status,omitempty"`
-	Summary           string                       `json:"summary"`
-	RecommendedAction string                       `json:"recommended_action"`
-	Target            *state.SupervisorTarget      `json:"target,omitempty"`
-	TargetLinks       []targetLinkInfo             `json:"target_links,omitempty"`
-	Risk              string                       `json:"risk"`
-	Confidence        float64                      `json:"confidence"`
-	ErrorClass        string                       `json:"error_class,omitempty"`
-	Reasons           []string                     `json:"reasons,omitempty"`
-	Mutations         []state.SupervisorMutation   `json:"mutations,omitempty"`
-	StuckStates       []state.SupervisorStuckState `json:"stuck_states,omitempty"`
-	StuckReasons      []string                     `json:"stuck_reasons,omitempty"`
-	ProjectState      state.SupervisorProjectState `json:"project_state"`
-	Queue             *supervisorQueueInfo         `json:"queue,omitempty"`
-	ApprovalID        string                       `json:"approval_id,omitempty"`
+	ID                string                         `json:"id"`
+	CreatedAt         time.Time                      `json:"created_at"`
+	Project           string                         `json:"project"`
+	Mode              string                         `json:"mode"`
+	PolicyRule        string                         `json:"policy_rule,omitempty"`
+	Status            string                         `json:"status,omitempty"`
+	Summary           string                         `json:"summary"`
+	RecommendedAction string                         `json:"recommended_action"`
+	Target            *state.SupervisorTarget        `json:"target,omitempty"`
+	TargetLinks       []targetLinkInfo               `json:"target_links,omitempty"`
+	Risk              string                         `json:"risk"`
+	Confidence        float64                        `json:"confidence"`
+	ErrorClass        string                         `json:"error_class,omitempty"`
+	Reasons           []string                       `json:"reasons,omitempty"`
+	Mutations         []state.SupervisorMutation     `json:"mutations,omitempty"`
+	StuckStates       []state.SupervisorStuckState   `json:"stuck_states,omitempty"`
+	StuckReasons      []string                       `json:"stuck_reasons,omitempty"`
+	ProjectState      state.SupervisorProjectState   `json:"project_state"`
+	QueueAnalysis     *state.SupervisorQueueAnalysis `json:"queue_analysis,omitempty"`
+	Queue             *supervisorQueueInfo           `json:"queue,omitempty"`
+	ApprovalID        string                         `json:"approval_id,omitempty"`
 }
 
 type supervisorActionInfo struct {
@@ -335,6 +336,7 @@ func makeSupervisorDecisionInfo(cfg *config.Config, st *state.State, decision st
 		StuckStates:       decision.StuckStates,
 		StuckReasons:      supervisorStuckReasons(decision),
 		ProjectState:      decision.ProjectState,
+		QueueAnalysis:     decision.QueueAnalysis,
 		Queue:             supervisorQueueInfoForDecision(cfg, st, decision),
 		ApprovalID:        decision.ApprovalID,
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -257,6 +257,49 @@ type SupervisorQueueAnalysis struct {
 	SkippedReasons                []string                  `json:"skipped_reasons,omitempty"`
 }
 
+// TopSkippedReason returns the first concise queue skip reason available for UI cards.
+func (q *SupervisorQueueAnalysis) TopSkippedReason() string {
+	if q == nil {
+		return ""
+	}
+	for _, reason := range q.SkippedReasons {
+		if reason = strings.TrimSpace(reason); reason != "" {
+			return reason
+		}
+	}
+	return ""
+}
+
+// IdleReason summarizes why a supervisor-controlled project has no eligible work.
+func (q *SupervisorQueueAnalysis) IdleReason() string {
+	if q == nil || q.EligibleCandidates > 0 {
+		return ""
+	}
+	if q.OpenIssues == 0 {
+		return "No open issues are available."
+	}
+	if q.ExcludedIssues >= q.OpenIssues {
+		return fmt.Sprintf("Policy excluded all %s.", openIssuePhrase(q.OpenIssues))
+	}
+	if q.NonRunnableProjectStatusCount >= q.OpenIssues {
+		return fmt.Sprintf("All %s are in a non-runnable project status.", openIssuePhrase(q.OpenIssues))
+	}
+	if q.ExcludedIssues+q.NonRunnableProjectStatusCount >= q.OpenIssues {
+		return fmt.Sprintf("Policy excluded or held all %s.", openIssuePhrase(q.OpenIssues))
+	}
+	if reason := q.TopSkippedReason(); reason != "" {
+		return "No issue is eligible: " + reason
+	}
+	return "No issue is eligible under the current supervisor policy."
+}
+
+func openIssuePhrase(count int) string {
+	if count == 1 {
+		return "1 open issue"
+	}
+	return fmt.Sprintf("%d open issues", count)
+}
+
 // SupervisorMutation records one durable GitHub mutation planned or attempted by
 // the supervisor queue action loop.
 type SupervisorMutation struct {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -878,6 +878,11 @@ func TestSupervisorDecisionPersistence(t *testing.T) {
 			OpenIssues:     1,
 			AvailableSlots: 1,
 		},
+		QueueAnalysis: &SupervisorQueueAnalysis{
+			OpenIssues:         1,
+			EligibleCandidates: 1,
+			SelectedCandidate:  &SupervisorIssueCandidate{Number: 42, Title: "Start worker"},
+		},
 	}, DefaultSupervisorDecisionLimit)
 
 	if err := Save(dir, s); err != nil {
@@ -909,6 +914,32 @@ func TestSupervisorDecisionPersistence(t *testing.T) {
 	}
 	if latest.StuckStates[0].Code != "no_eligible_issues" {
 		t.Fatalf("stuck state code = %q, want no_eligible_issues", latest.StuckStates[0].Code)
+	}
+	if latest.QueueAnalysis == nil || latest.QueueAnalysis.SelectedCandidate == nil || latest.QueueAnalysis.SelectedCandidate.Number != 42 {
+		t.Fatalf("queue analysis = %#v, want selected issue 42", latest.QueueAnalysis)
+	}
+}
+
+func TestSupervisorQueueAnalysisIdleReasonExplainsAllExcluded(t *testing.T) {
+	analysis := &SupervisorQueueAnalysis{
+		OpenIssues:         11,
+		EligibleCandidates: 0,
+		ExcludedIssues:     11,
+		SkippedReasons: []string{
+			"Issue #24 skipped by dynamic wave policy: excluded by label \"blocked\"",
+		},
+	}
+
+	if got, want := analysis.IdleReason(), "Policy excluded all 11 open issues."; got != want {
+		t.Fatalf("IdleReason = %q, want %q", got, want)
+	}
+	if got, want := analysis.TopSkippedReason(), "Issue #24 skipped by dynamic wave policy: excluded by label \"blocked\""; got != want {
+		t.Fatalf("TopSkippedReason = %q, want %q", got, want)
+	}
+
+	analysis.EligibleCandidates = 1
+	if got := analysis.IdleReason(); got != "" {
+		t.Fatalf("IdleReason with eligible candidate = %q, want empty", got)
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -249,6 +249,11 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	}
 	skipped = append(policySkipped, skipped...)
 	stuckStates = e.detectStuckStates(st, now, prs, issues, eligible, skipped, true)
+	analysis := supervisorQueueAnalysis(policyRule, len(issues), eligible, skipped)
+	withAnalysis := func(decision state.SupervisorDecision) state.SupervisorDecision {
+		decision.QueueAnalysis = analysis
+		return decision
+	}
 
 	if len(eligible) > 0 {
 		issue := eligible[0]
@@ -260,7 +265,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 				fmt.Sprintf("Issue #%d is eligible, but all worker slots are occupied.", issue.Number),
 				RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
 			decision.StuckStates = stuckStates
-			return decision, nil
+			return withAnalysis(decision), nil
 		}
 
 		hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number)
@@ -276,7 +281,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 				fmt.Sprintf("Issue #%d already has an open PR; monitor that PR instead of starting work.", issue.Number),
 				RiskSafe, 0.87, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
 			decision.StuckStates = stuckStates
-			return decision, nil
+			return withAnalysis(decision), nil
 		}
 
 		reasons := appendReasons(baseReasons,
@@ -288,7 +293,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 			fmt.Sprintf("Start a worker for issue #%d: %s", issue.Number, issue.Title),
 			RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
 		decision.StuckStates = stuckStates
-		return decision, nil
+		return withAnalysis(decision), nil
 	}
 
 	if policyRule == PolicyRuleOrderedQueue && len(candidates) == 1 {
@@ -307,7 +312,10 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 				fmt.Sprintf("Ordered queue is paused at issue #%d because it already has an open PR.", issue.Number),
 				RiskSafe, 0.9, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
 			decision.StuckStates = stuckStates
-			return decision, nil
+			if analysis.SelectedCandidate == nil {
+				analysis.SelectedCandidate = supervisorIssueCandidate(issue)
+			}
+			return withAnalysis(decision), nil
 		}
 	}
 
@@ -316,6 +324,9 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		return state.SupervisorDecision{}, err
 	}
 	if candidate != nil {
+		if analysis.SelectedCandidate == nil {
+			analysis.SelectedCandidate = supervisorIssueCandidate(candidate.issue)
+		}
 		mutations := candidate.plannedMutations(e.cfg)
 		reasons := appendReasons(baseReasons,
 			queueLabelReason(candidate.readyLabel, candidate.blockedLabel),
@@ -331,7 +342,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 			risk, 0.82, &state.SupervisorTarget{Issue: candidate.issue.Number}, policyRule, reasons)
 		decision.Mutations = mutations
 		decision.StuckStates = stuckStates
-		return decision, nil
+		return withAnalysis(decision), nil
 	}
 
 	if policyRule == PolicyRuleOrderedQueue && len(candidates) == 1 {
@@ -354,7 +365,10 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 				fmt.Sprintf("Ordered queue is paused at issue #%d: %s.", issue.Number, pauseReason),
 				risk, confidence, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
 			decision.StuckStates = stuckStates
-			return decision, nil
+			if analysis.SelectedCandidate == nil {
+				analysis.SelectedCandidate = supervisorIssueCandidate(issue)
+			}
+			return withAnalysis(decision), nil
 		}
 	}
 
@@ -368,7 +382,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	decision := e.decision(now, projectState, ActionNone,
 		"No action is currently recommended.", RiskSafe, 0.8, nil, policyRule, reasons)
 	decision.StuckStates = stuckStates
-	return decision, nil
+	return withAnalysis(decision), nil
 }
 
 func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState state.SupervisorProjectState, baseReasons []string, prs []github.PR, issues []github.Issue, result policyCandidateResult) (state.SupervisorDecision, error) {
@@ -1556,6 +1570,46 @@ func supervisorIssueCandidate(issue github.Issue) *state.SupervisorIssueCandidat
 		PriorityLabel: priorityLabel,
 		ProjectStatus: firstProjectStatus(issue),
 	}
+}
+
+func supervisorQueueAnalysis(policyRule string, openIssues int, eligible []github.Issue, skipped []string) *state.SupervisorQueueAnalysis {
+	analysis := &state.SupervisorQueueAnalysis{
+		PolicyRule:                    policyRule,
+		OpenIssues:                    openIssues,
+		EligibleCandidates:            len(eligible),
+		ExcludedIssues:                countQueueExcludedReasons(skipped),
+		NonRunnableProjectStatusCount: countQueueNonRunnableReasons(skipped),
+		SkippedReasons:                firstN(skipped, 5),
+	}
+	if len(eligible) > 0 {
+		analysis.SelectedCandidate = supervisorIssueCandidate(eligible[0])
+	}
+	return analysis
+}
+
+func countQueueExcludedReasons(skipped []string) int {
+	count := 0
+	for _, reason := range skipped {
+		lower := strings.ToLower(reason)
+		if strings.Contains(lower, "excluded by configured label") ||
+			strings.Contains(lower, "excluded by supervisor policy label") ||
+			strings.Contains(lower, "skipped by dynamic wave policy: excluded") ||
+			strings.Contains(lower, "title indicates epic") {
+			count++
+		}
+	}
+	return count
+}
+
+func countQueueNonRunnableReasons(skipped []string) int {
+	count := 0
+	for _, reason := range skipped {
+		lower := strings.ToLower(reason)
+		if strings.Contains(lower, "project status") && strings.Contains(lower, "not runnable") {
+			count++
+		}
+	}
+	return count
 }
 
 func (e *Engine) policySummaryReason() string {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1593,6 +1593,7 @@ func countQueueExcludedReasons(skipped []string) int {
 		lower := strings.ToLower(reason)
 		if strings.Contains(lower, "excluded by configured label") ||
 			strings.Contains(lower, "excluded by supervisor policy label") ||
+			strings.Contains(lower, "blocked by supervisor policy label") ||
 			strings.Contains(lower, "skipped by dynamic wave policy: excluded") ||
 			strings.Contains(lower, "title indicates epic") {
 			count++

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -835,6 +835,19 @@ func TestDecide_DynamicWaveSkipsTitleEpic(t *testing.T) {
 	}
 }
 
+func TestSupervisorQueueAnalysisCountsBlockedPolicyLabelAsExcluded(t *testing.T) {
+	analysis := supervisorQueueAnalysis("supervisor.default", 1, nil, []string{
+		"Issue #24 skipped: blocked by supervisor policy label",
+	})
+
+	if analysis.ExcludedIssues != 1 {
+		t.Fatalf("excluded issues = %d, want 1", analysis.ExcludedIssues)
+	}
+	if got, want := analysis.IdleReason(), "Policy excluded all 1 open issue."; got != want {
+		t.Fatalf("IdleReason = %q, want %q", got, want)
+	}
+}
+
 func TestDecide_DynamicWaveSkipsNonRunnableProjectStatus(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}


### PR DESCRIPTION
Closes #309

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a per-project queue snapshot to the fleet dashboard — exposing `open`, `eligible`, `excluded`, and `non_runnable` counts, the selected candidate, and human-readable idle/skip reasons. `QueueAnalysis` is now attached to every return path in `decideDeterministic`, and the pre-existing `decideDynamicWave` path continues to use the analysis built by `dynamicWaveCandidateIssues`. The `BlockedLabel` counting gap noted in the prior thread is correctly addressed by adding the `"blocked by supervisor policy label"` pattern to `countQueueExcludedReasons`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues; one minor P2 about incomplete skip-reason classification for missions and blocker dependencies.

All critical paths are covered: both the deterministic and dynamic-wave supervisor paths now populate `QueueAnalysis`, XSS protection is correctly applied in the JS template, and the prior `BlockedLabel` gap has been addressed with a targeted fix and a regression test. The only finding is a P2 observation that mission-related and blocker-dependency skip reasons are not counted toward `ExcludedIssues`, leaving the counter slightly understated in edge cases.

internal/supervisor/supervisor.go — `countQueueExcludedReasons` does not cover mission or blocker-dependency skip reasons.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds `supervisorQueueAnalysis`, `countQueueExcludedReasons`, and `countQueueNonRunnableReasons` helpers and wires `QueueAnalysis` into every return path of `decideDeterministic`; mission-related and blocker-dependency skip reasons are not matched by either counting helper. |
| internal/server/fleet.go | Adds `fleetQueueSnapshot` struct, `fleetQueueSnapshotFromSupervisor` builder, CSS, and JS to expose per-project queue stats on the dashboard; XSS protection via `escapeText` is correct. |
| internal/state/state.go | Adds `TopSkippedReason()` and `IdleReason()` methods on `SupervisorQueueAnalysis`; logic and edge cases are all handled correctly. |
| internal/server/server.go | Adds `QueueAnalysis` field to `supervisorDecisionInfo` and populates it in `makeSupervisorDecisionInfo`; clean pass-through with no issues. |
| internal/server/fleet_test.go | New `TestFleetAPIIncludesQueueSnapshotMetadata` covers both the all-excluded and has-candidate cases; assertions are thorough. |
| internal/state/state_test.go | Adds persistence and `IdleReason`/`TopSkippedReason` unit tests; complete and correct. |
| internal/supervisor/supervisor_test.go | New test confirms 'blocked by supervisor policy label' is counted as excluded and propagates correctly to `IdleReason`; directly addresses the prior thread finding. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/supervisor.go:1590-1614
**Mission and blocker-dependency skips not counted in `ExcludedIssues`**

`countQueueExcludedReasons` matches label-based policy exclusions but misses three other skip reasons produced by `issueSkipReasonWithExcludeLabels`: `"mission parent issue"`, `"mission issue awaits decomposition"`, and `"blocked by open issue(s) …"`. When all open issues are in one of these states and no label-based exclusions apply, `ExcludedIssues` stays 0 and `IdleReason()` falls through to the generic `"No issue is eligible under the current supervisor policy."` instead of a more specific message. The `TopSkippedReason` fallback partially mitigates this (the raw skip string is still surfaced), but the `Excluded` counter shown in the queue snapshot will be understated for missions-heavy projects.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fleet dashboard: count blocked policy ex..."](https://github.com/befeast/maestro/commit/c34cd0905db06cb63fff014e319792ddae55da64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30479166)</sub>

<!-- /greptile_comment -->