### PR TITLE
Fleet dashboard: approval-gated controls UX guardrails

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1737,7 +1737,7 @@ function actionPolicyText(action) {
 }
 
 function actionDetailHTML(action) {
-  const description = action.description ? '<div><strong>Would</strong> ' + escapeText(action.description) + '</div>' : "";
+  const description = action.description ? '<div><strong>Would</strong> ' + escapeText(action.description.replace(/^Would\s+/i, "")) + '</div>' : "";
   return '<div class="action-detail">' + description +
     '<div><strong>Scope</strong> ' + escapeText(actionLabel(action.scope || "unknown")) + '</div>' +
     '<div><strong>Target</strong> ' + escapeText(actionTargetText(action)) + '</div>' +

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -688,7 +688,7 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	item.StateDir = cfg.StateDir
 	item.MaxParallel = cfg.MaxParallel
 	item.ReadOnly = cfg.Server.ReadOnly || s.readOnly
-	item.Actions = projectActionAffordances(item.ReadOnly, "/api/v1/fleet/actions")
+	item.Actions = projectActionAffordances(item.ReadOnly, "/api/v1/fleet/actions", item.Name)
 	item.Freshness = fleetProjectFreshnessForState(cfg.StateDir, nil, now)
 
 	st, err := state.Load(cfg.StateDir)
@@ -1456,6 +1456,7 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   .actions { display: flex; gap: 6px; flex-wrap: wrap; }
   .action-btn {
     height: 24px;
+    max-width: 150px;
     border: 1px solid rgba(210,153,34,.45);
     border-radius: 6px;
     background: rgba(210,153,34,.08);
@@ -1463,7 +1464,22 @@ const fleetDashboardHTML = `<!DOCTYPE html>
     font: inherit;
     font-size: 12px;
     cursor: not-allowed;
+    overflow: hidden;
+    padding: 0 8px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
+  .action-item { min-width: 118px; max-width: 210px; }
+  .action-detail {
+    display: grid;
+    gap: 2px;
+    margin-top: 4px;
+    color: var(--muted);
+    font-size: 11px;
+    line-height: 1.3;
+    white-space: normal;
+  }
+  .action-detail strong { color: var(--text); font-weight: 650; }
   .action-note { margin-top: 6px; color: var(--muted); font-size: 12px; white-space: normal; }
   .empty { color: var(--muted); margin-top: 8px; }
   .worker-table .empty { padding: 18px 14px; margin: 0; text-align: center; }
@@ -1707,13 +1723,38 @@ function actionDisabledReason(actions) {
   return action ? action.disabled_reason : "Write actions require approval-backed configuration.";
 }
 
-function renderActions(actions) {
+function actionTargetText(action) {
+  const parts = [];
+  if (action.target) parts.push(action.target);
+  if (action.issue_number) parts.push("issue #" + action.issue_number);
+  if (action.pr_number) parts.push("PR #" + action.pr_number);
+  return parts.length ? parts.join(" · ") : "project";
+}
+
+function actionPolicyText(action) {
+  if (action.approval_policy) return actionLabel(action.approval_policy);
+  return action.requires_approval ? "manual approval required" : "none";
+}
+
+function actionDetailHTML(action) {
+  const description = action.description ? '<div><strong>Would</strong> ' + escapeText(action.description) + '</div>' : "";
+  return '<div class="action-detail">' + description +
+    '<div><strong>Scope</strong> ' + escapeText(actionLabel(action.scope || "unknown")) + '</div>' +
+    '<div><strong>Target</strong> ' + escapeText(actionTargetText(action)) + '</div>' +
+    '<div><strong>Approval</strong> ' + escapeText(actionPolicyText(action)) + '</div>' +
+    '<div><strong>Disabled</strong> ' + escapeText(action.disabled_reason || "Write action unavailable") + '</div>' +
+    '</div>';
+}
+
+function renderActions(actions, options) {
   const items = actions || [];
   if (!items.length) return '<span class="empty">No controls.</span>';
+  const showDetails = !options || options.details !== false;
   return '<div class="actions">' + items.map(action =>
-    '<button type="button" class="action-btn" disabled aria-disabled="true" title="' +
+    '<div class="action-item"><button type="button" class="action-btn" disabled aria-disabled="true" title="' +
     escapeText(action.disabled_reason || "Write action unavailable") + '">' +
-    escapeText(action.label || actionLabel(action.id)) + '</button>'
+    escapeText(action.label || actionLabel(action.id)) + '</button>' +
+    (showDetails ? actionDetailHTML(action) : "") + '</div>'
   ).join("") + '</div>' +
   '<div class="action-note">' + escapeText(actionDisabledReason(items)) + '</div>';
 }
@@ -2291,7 +2332,7 @@ function renderFleetWorkers() {
       '<td class="pr-col" title="' + escapeText(pr) + '">' + linkHTML(worker.pr_url, pr) + '</td>' +
       '<td class="runtime-col" title="' + escapeText(worker.runtime || "-") + '">' + escapeText(worker.runtime || "-") + '</td>' +
       '<td class="tokens-col">' + compactNumber(worker.tokens_used_total) + '</td>' +
-      '<td class="action-col">' + renderActions(worker.actions || []) + '</td>' +
+      '<td class="action-col">' + renderActions(worker.actions || [], { details: false }) + '</td>' +
     '</tr>';
   }).join("");
 

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -156,6 +156,9 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	}
 	for _, action := range resp.Projects[0].Actions {
 		assertFleetReadOnlyAction(t, action)
+		if action.Target != "One" {
+			t.Fatalf("project action target = %q, want project name One", action.Target)
+		}
 	}
 	attentionWorker := findFleetWorker(t, resp.Workers, "two-1")
 	if !attentionWorker.NeedsAttention {
@@ -883,6 +886,12 @@ func TestFleetDashboard(t *testing.T) {
 		"badge-stale",
 		"State error",
 		"renderActions",
+		"actionDetailHTML",
+		"manual approval required",
+		"Scope",
+		"Target",
+		"Approval",
+		"Disabled",
 		"Approval-gated controls",
 	} {
 		if !contains(body, want) {
@@ -970,8 +979,30 @@ func saveFleetTestState(t *testing.T, dir string, sessions map[string]*state.Ses
 
 func assertFleetReadOnlyAction(t *testing.T, action controlAction) {
 	t.Helper()
+	wantLabels := map[string]string{
+		"restart_worker":     "Restart",
+		"stop_worker":        "Stop",
+		"mark_issue_ready":   "Mark ready",
+		"mark_issue_blocked": "Mark blocked",
+		"approve_merge":      "Approve merge",
+	}
+	if want, ok := wantLabels[action.ID]; ok && action.Label != want {
+		t.Fatalf("action %s label = %q, want %q", action.ID, action.Label, want)
+	}
+	if len(action.Label) > len("Approve merge") {
+		t.Fatalf("action %s label = %q, want concise non-wrapping label", action.ID, action.Label)
+	}
+	if action.Description == "" {
+		t.Fatalf("action %+v should describe the disabled operation", action)
+	}
+	if action.Scope == "" || action.Target == "" {
+		t.Fatalf("action %+v should include scope and target metadata", action)
+	}
 	if !action.Mutating || !action.RequiresApproval || !action.Disabled {
 		t.Fatalf("action %+v should be disabled mutating approval affordance", action)
+	}
+	if action.ApprovalPolicy != controlApprovalPolicyManual {
+		t.Fatalf("approval policy = %q, want %q", action.ApprovalPolicy, controlApprovalPolicyManual)
 	}
 	if !contains(action.DisabledReason, "Read-only mode") {
 		t.Fatalf("disabled reason = %q, want read-only explanation", action.DisabledReason)

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -892,6 +892,7 @@ func TestFleetDashboard(t *testing.T) {
 		"Target",
 		"Approval",
 		"Disabled",
+		"replace(/^Would\\s+/i",
 		"Approval-gated controls",
 	} {
 		if !contains(body, want) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -177,12 +177,14 @@ type tokenTotalsInfo struct {
 type controlAction struct {
 	ID               string `json:"id"`
 	Label            string `json:"label"`
+	Description      string `json:"description,omitempty"`
 	Scope            string `json:"scope"`
 	Target           string `json:"target,omitempty"`
 	IssueNumber      int    `json:"issue_number,omitempty"`
 	PRNumber         int    `json:"pr_number,omitempty"`
 	Mutating         bool   `json:"mutating"`
 	RequiresApproval bool   `json:"requires_approval"`
+	ApprovalPolicy   string `json:"approval_policy,omitempty"`
 	Disabled         bool   `json:"disabled"`
 	DisabledReason   string `json:"disabled_reason,omitempty"`
 	Method           string `json:"method,omitempty"`
@@ -535,11 +537,13 @@ func sessionInfosWithActions(repo string, st *state.State, readOnly bool, endpoi
 	return infos
 }
 
-func projectActionAffordances(readOnly bool, endpoint string) []controlAction {
+const controlApprovalPolicyManual = "manual_approval_required"
+
+func projectActionAffordances(readOnly bool, endpoint, target string) []controlAction {
 	reason := controlActionDisabledReason(readOnly)
 	return []controlAction{
-		newControlAction("mark_issue_ready", "Mark issue ready", "project", "", 0, 0, endpoint, reason),
-		newControlAction("mark_issue_blocked", "Mark issue blocked", "project", "", 0, 0, endpoint, reason),
+		newControlAction("mark_issue_ready", "Mark ready", "Would mark a selected issue ready for Maestro.", "project", target, 0, 0, endpoint, reason),
+		newControlAction("mark_issue_blocked", "Mark blocked", "Would mark a selected issue blocked for Maestro.", "project", target, 0, 0, endpoint, reason),
 	}
 }
 
@@ -547,27 +551,31 @@ func workerActionAffordances(readOnly bool, endpoint string, worker sessionInfo)
 	reason := controlActionDisabledReason(readOnly)
 	mergeReason := reason
 	if !readOnly && worker.PRNumber == 0 {
-		mergeReason = "No PR is associated with this worker; merge approval will require approval-backed controls."
+		mergeReason = "No PR is associated with this worker; merge approval will require approval-backed controls after a PR exists."
+	} else if readOnly && worker.PRNumber == 0 {
+		mergeReason = reason + " This worker has no PR to approve."
 	}
 	return []controlAction{
-		newControlAction("restart_worker", "Restart worker", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
-		newControlAction("stop_worker", "Stop worker", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
-		newControlAction("mark_issue_ready", "Mark issue ready", "issue", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
-		newControlAction("mark_issue_blocked", "Mark issue blocked", "issue", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
-		newControlAction("approve_merge", "Approve merge", "pull_request", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, mergeReason),
+		newControlAction("restart_worker", "Restart", "Would restart this worker in place.", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
+		newControlAction("stop_worker", "Stop", "Would stop this worker session.", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
+		newControlAction("mark_issue_ready", "Mark ready", "Would mark this issue ready for Maestro.", "issue", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
+		newControlAction("mark_issue_blocked", "Mark blocked", "Would mark this issue blocked for Maestro.", "issue", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, reason),
+		newControlAction("approve_merge", "Approve merge", "Would approve merge for this PR.", "pull_request", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, mergeReason),
 	}
 }
 
-func newControlAction(id, label, scope, target string, issueNumber, prNumber int, endpoint, disabledReason string) controlAction {
+func newControlAction(id, label, description, scope, target string, issueNumber, prNumber int, endpoint, disabledReason string) controlAction {
 	return controlAction{
 		ID:               id,
 		Label:            label,
+		Description:      description,
 		Scope:            scope,
 		Target:           target,
 		IssueNumber:      issueNumber,
 		PRNumber:         prNumber,
 		Mutating:         true,
 		RequiresApproval: true,
+		ApprovalPolicy:   controlApprovalPolicyManual,
 		Disabled:         true,
 		DisabledReason:   disabledReason,
 		Method:           http.MethodPost,
@@ -577,7 +585,7 @@ func newControlAction(id, label, scope, target string, issueNumber, prNumber int
 
 func controlActionDisabledReason(readOnly bool) string {
 	if readOnly {
-		return "Read-only mode: write actions require approval-backed controls to be enabled in configuration."
+		return "Read-only mode keeps write actions disabled until approval-backed controls are configured."
 	}
 	return "Approval-backed controls are not implemented yet."
 }
@@ -603,7 +611,7 @@ func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 		Repo:                cfg.Repo,
 		MaxParallel:         cfg.MaxParallel,
 		ReadOnly:            cfg.Server.ReadOnly,
-		Actions:             projectActionAffordances(cfg.Server.ReadOnly, "/api/v1/actions"),
+		Actions:             projectActionAffordances(cfg.Server.ReadOnly, "/api/v1/actions", cfg.Repo),
 		SupervisorPolicy:    cfg.Supervisor,
 		All:                 make([]sessionInfo, 0, len(st.Sessions)),
 		Running:             make([]sessionInfo, 0),
@@ -1139,21 +1147,36 @@ const dashboardHTML = `<!DOCTYPE html>
   .supervisor-reasons li { margin: 2px 0; }
   .supervisor-approval, .action-btn {
     height: 24px;
+    max-width: 150px;
     border: 1px solid rgba(210,153,34,.45);
     border-radius: 6px;
     background: rgba(210,153,34,.08);
     color: var(--warn);
     cursor: not-allowed;
+    overflow: hidden;
+    padding: 0 8px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .worker-actions {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 8px;
     flex-wrap: wrap;
     margin-top: 8px;
   }
   .worker-actions span { color: var(--text); font-weight: 650; }
   .action-list { display: inline-flex; gap: 6px; flex-wrap: wrap; }
+  .action-item { min-width: 134px; max-width: 210px; }
+  .action-detail {
+    display: grid;
+    gap: 2px;
+    margin-top: 4px;
+    color: var(--muted);
+    font-size: 11px;
+    line-height: 1.3;
+  }
+  .action-detail strong { color: var(--text); font-weight: 650; }
   .action-note { margin-top: 6px; color: var(--muted); }
   .supervisor-empty { color: var(--muted); }
   pre {
@@ -1306,19 +1329,43 @@ function actionDisabledReason(actions) {
   return action ? action.disabled_reason : "Write actions require approval-backed configuration.";
 }
 
-function renderActionButtons(actions) {
+function actionTargetText(action) {
+  const parts = [];
+  if (action.target) parts.push(action.target);
+  if (action.issue_number) parts.push("issue #" + action.issue_number);
+  if (action.pr_number) parts.push("PR #" + action.pr_number);
+  return parts.length ? parts.join(" · ") : "project";
+}
+
+function actionPolicyText(action) {
+  if (action.approval_policy) return actionLabel(action.approval_policy);
+  return action.requires_approval ? "manual approval required" : "none";
+}
+
+function actionDetailHTML(action) {
+  const description = action.description ? '<div><strong>Would</strong> ' + escapeText(action.description) + '</div>' : "";
+  return '<div class="action-detail">' + description +
+    '<div><strong>Scope</strong> ' + escapeText(actionLabel(action.scope || "unknown")) + '</div>' +
+    '<div><strong>Target</strong> ' + escapeText(actionTargetText(action)) + '</div>' +
+    '<div><strong>Approval</strong> ' + escapeText(actionPolicyText(action)) + '</div>' +
+    '<div><strong>Disabled</strong> ' + escapeText(action.disabled_reason || "Write action unavailable") + '</div>' +
+    '</div>';
+}
+
+function renderActionButtons(actions, showDetails) {
   const items = actions || [];
   if (!items.length) return "";
   return '<div class="action-list">' + items.map(action =>
-    '<button type="button" class="action-btn" disabled aria-disabled="true" title="' +
+    '<div class="action-item"><button type="button" class="action-btn" disabled aria-disabled="true" title="' +
     escapeText(action.disabled_reason || "Write action unavailable") + '">' +
-    escapeText(action.label || actionLabel(action.id)) + '</button>'
+    escapeText(action.label || actionLabel(action.id)) + '</button>' +
+    (showDetails ? actionDetailHTML(action) : "") + '</div>'
   ).join("") + '</div>';
 }
 
 function renderWorkerActions(actions) {
   if (!actions || !actions.length) return "";
-  return '<div class="worker-actions"><span>Actions</span>' + renderActionButtons(actions) + '</div>' +
+  return '<div class="worker-actions"><span>Actions</span>' + renderActionButtons(actions, true) + '</div>' +
     '<div class="action-note">' + escapeText(actionDisabledReason(actions)) + '</div>';
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1343,7 +1343,7 @@ function actionPolicyText(action) {
 }
 
 function actionDetailHTML(action) {
-  const description = action.description ? '<div><strong>Would</strong> ' + escapeText(action.description) + '</div>' : "";
+  const description = action.description ? '<div><strong>Would</strong> ' + escapeText(action.description.replace(/^Would\s+/i, "")) + '</div>' : "";
   return '<div class="action-detail">' + description +
     '<div><strong>Scope</strong> ' + escapeText(actionLabel(action.scope || "unknown")) + '</div>' +
     '<div><strong>Target</strong> ' + escapeText(actionTargetText(action)) + '</div>' +

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -847,7 +847,7 @@ func TestHandleDashboard(t *testing.T) {
 	if !contains(body, "renderWorkerActions") || !contains(body, "actionDetailHTML") || !contains(body, "manual approval required") {
 		t.Error("dashboard should render disabled approval-gated action affordances")
 	}
-	for _, want := range []string{"Scope", "Target", "Approval", "Disabled"} {
+	for _, want := range []string{"Scope", "Target", "Approval", "Disabled", "replace(/^Would\\s+/i"} {
 		if !contains(body, want) {
 			t.Fatalf("dashboard action guardrails should contain %q", want)
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -211,6 +211,9 @@ func TestHandleState_ReadOnlyActionsDisabled(t *testing.T) {
 	workerWithoutPR := findSessionInfo(t, resp.All, "slot-1")
 	approveWithoutPR := findControlAction(t, workerWithoutPR.Actions, "approve_merge")
 	assertReadOnlyAction(t, approveWithoutPR)
+	if !contains(approveWithoutPR.DisabledReason, "no PR") {
+		t.Fatalf("approve_merge without PR reason = %q, want target-specific no-PR explanation", approveWithoutPR.DisabledReason)
+	}
 }
 
 func TestHandleStateSupervisorRationale(t *testing.T) {
@@ -841,8 +844,13 @@ func TestHandleDashboard(t *testing.T) {
 	if !contains(body, "issueSummaryHTML") || !contains(body, "issue-main") || !contains(body, "issue-title") {
 		t.Error("dashboard should keep issue links visible while truncating long titles")
 	}
-	if !contains(body, "renderWorkerActions") || !contains(body, "Write actions require approval-backed configuration") {
+	if !contains(body, "renderWorkerActions") || !contains(body, "actionDetailHTML") || !contains(body, "manual approval required") {
 		t.Error("dashboard should render disabled approval-gated action affordances")
+	}
+	for _, want := range []string{"Scope", "Target", "Approval", "Disabled"} {
+		if !contains(body, want) {
+			t.Fatalf("dashboard action guardrails should contain %q", want)
+		}
 	}
 }
 
@@ -1022,8 +1030,30 @@ func findControlAction(t *testing.T, actions []controlAction, id string) control
 
 func assertReadOnlyAction(t *testing.T, action controlAction) {
 	t.Helper()
+	wantLabels := map[string]string{
+		"restart_worker":     "Restart",
+		"stop_worker":        "Stop",
+		"mark_issue_ready":   "Mark ready",
+		"mark_issue_blocked": "Mark blocked",
+		"approve_merge":      "Approve merge",
+	}
+	if want, ok := wantLabels[action.ID]; ok && action.Label != want {
+		t.Fatalf("action %s label = %q, want %q", action.ID, action.Label, want)
+	}
+	if len(action.Label) > len("Approve merge") {
+		t.Fatalf("action %s label = %q, want concise non-wrapping label", action.ID, action.Label)
+	}
+	if action.Description == "" {
+		t.Fatalf("action %+v should describe the disabled operation", action)
+	}
+	if action.Scope == "" || action.Target == "" {
+		t.Fatalf("action %+v should include scope and target metadata", action)
+	}
 	if !action.Mutating || !action.RequiresApproval {
 		t.Fatalf("action %+v should be mutating and approval-required", action)
+	}
+	if action.ApprovalPolicy != controlApprovalPolicyManual {
+		t.Fatalf("approval policy = %q, want %q", action.ApprovalPolicy, controlApprovalPolicyManual)
 	}
 	if !action.Disabled {
 		t.Fatalf("action %+v should be disabled", action)


### PR DESCRIPTION
Closes #310

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the fleet dashboard's action affordances by adding `Description` and `ApprovalPolicy` fields to `controlAction`, threading the project name as `target` into `projectActionAffordances`, and rendering expandable detail panels (`actionDetailHTML`) below each disabled action button. The previously reported double-"Would" rendering bug is already fixed here via `description.replace(/^Would\s+/i, "")`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all call sites updated, new fields are additive, XSS is guarded by escapeText throughout.

No logic errors found. All callers of the changed function signatures were updated consistently in both server.go and fleet.go. The double-Would issue from the previous review thread is resolved. Dynamic data in JS templates is consistently passed through escapeText. Tests cover the new fields and edge cases.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/server.go | Adds `Description` and `ApprovalPolicy` fields to `controlAction`, threads `target` through `projectActionAffordances`, and adds `actionDetailHTML` + updated `renderActionButtons` JS for expanded action detail panels. Logic is sound; double-"Would" issue from the previous thread is already resolved by the `replace(/^Would\s+/i, "")` strip. |
| internal/server/fleet.go | Mirrors server.go changes for fleet: passes `item.Name` as target to `projectActionAffordances`, adds `actionDetailHTML` JS, updates `renderActions` to accept an `options` object. The `action-note` div is always rendered even when `details: false`; looks like an intentional design choice for the compact table view. |
| internal/server/server_test.go | Expands `assertReadOnlyAction` to validate new label, description, scope, target, and approval-policy fields; adds a targeted check that the no-PR `approve_merge` reason contains "no PR". |
| internal/server/fleet_test.go | Mirrors server_test.go: expands `assertFleetReadOnlyAction`, checks project action target equals the project name, and asserts new JS identifiers appear in the rendered dashboard. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: normalize approval action copy (#31..."](https://github.com/befeast/maestro/commit/ab735dee8fec5049fd93b86d9f3e1c6bee234ff9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30482139)</sub>

<!-- /greptile_comment -->