### PR TITLE
Docs: Fleet Mission Control operating runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ To watch Maestro from a browser, use the read-only Mission Control dashboard:
 maestro serve --config ./maestro.yaml --host 127.0.0.1 --port 8787 --read-only
 ```
 
+For multi-project Fleet Mission Control operations, see [`docs/fleet-mission-control-runbook.md`](docs/fleet-mission-control-runbook.md).
+
 Use `--host 0.0.0.0` only on a trusted network if you want to expose the dashboard to the LAN.
 
 To watch workers live in a tmux dashboard:
@@ -154,9 +156,9 @@ maestro watch
 Create `~/.maestro/config.yaml` or `./maestro.yaml`:
 
 ```yaml
-repo: BeFeast/panoptikon
-local_path: /home/shtrudel/src/panoptikon
-worktree_base: /home/shtrudel/.worktrees/panoptikon
+repo: OWNER/REPO
+local_path: /path/to/local/clone
+worktree_base: /path/to/worktrees/repo
 max_parallel: 5
 max_runtime_minutes: 120           # hard timeout per worker (default: 120)
 worker_silent_timeout_minutes: 0   # kill worker if tmux output is unchanged for N minutes (0 = disabled)
@@ -167,8 +169,8 @@ merge_interval_seconds: 30         # minimum seconds between merges in sequentia
 review_gate: greptile              # "greptile" (default) or "none"
 auto_retry_review_feedback: false  # retry PRs with actionable review comments
 auto_retry_rebase_conflicts: false # retry PRs whose auto-rebase fails with conflicts
-session_prefix: pan                # worker session name prefix (default: first 3 chars of repo name)
-state_dir: ~/.maestro/pan          # state/log directory (default: ~/.maestro/<repo-hash>)
+session_prefix: prj                # worker session name prefix (default: first 3 chars of repo name)
+state_dir: ~/.maestro/<project>    # state/log directory (default: ~/.maestro/<repo-hash>)
 claude_cmd: claude                 # deprecated: use model.backends.claude.cmd
 server:
   host: 127.0.0.1                  # bind address for `maestro serve`
@@ -179,7 +181,7 @@ issue_labels:                      # preferred label filter (OR semantics)
 exclude_labels:
   - blocked
 telegram:
-  target: "79510949"              # Telegram user ID
+  target: "YOUR_TELEGRAM_CHAT_ID" # Telegram user ID
   openclaw_url: "http://localhost:18789"  # OpenClaw gateway
 ```
 
@@ -263,15 +265,15 @@ maestro status --json   # JSON output
 
 Example output:
 ```
-Repo:           BeFeast/panoptikon
-Session prefix: pan
-State file:     /home/shtrudel/.maestro/d581c91d05cc/state.json
+Repo:           OWNER/REPO
+Session prefix: prj
+State file:     ~/.maestro/<repo-hash>/state.json
 Max parallel:   5
 
 SESSION  ISSUE  STATUS   PID    ALIVE  AGE    TITLE
 -------  -----  ------   ---    -----  ---    -----
-pan-1    #154   running  12345  yes    23m    Add asset inventory endpoint
-pan-2    #155   pr_open  12346  no     1h5m   Fix auth token refresh
+prj-1    #154   running  12345  yes    23m    Add asset inventory endpoint
+prj-2    #155   pr_open  12346  no     1h5m   Fix auth refresh
 ```
 
 ### `maestro spawn`
@@ -298,13 +300,13 @@ State is stored in `~/.maestro/<repo-hash>/state.json`:
 ```json
 {
   "sessions": {
-    "pan-1": {
+    "prj-1": {
       "issue_number": 154,
       "issue_title": "Add asset inventory endpoint",
-      "worktree": "/home/shtrudel/.worktrees/panoptikon/pan-1",
-      "branch": "feat/pan-1-154-add-asset-inventory-endpoint",
+      "worktree": "/path/to/worktrees/repo/prj-1",
+      "branch": "feat/prj-1-154-add-asset-inventory-endpoint",
       "pid": 12345,
-      "log_file": "/home/shtrudel/.maestro/.../logs/pan-1.log",
+      "log_file": "~/.maestro/<project>/logs/prj-1.log",
       "started_at": "2026-02-23T00:00:00Z",
       "status": "running"
     }
@@ -363,7 +365,7 @@ For automatic operation, run on a cron schedule:
 
 ```bash
 # ~/.config/cron/maestro.cron
-*/10 * * * * cd /home/shtrudel/src/panoptikon && /usr/local/bin/maestro run --once >> ~/.maestro/maestro.log 2>&1
+*/10 * * * * /usr/local/bin/maestro run --config ~/.maestro/maestro-<project>.yaml --once >> ~/.maestro/maestro-<project>.log 2>&1
 ```
 
 Or run as a daemon:

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -1,0 +1,273 @@
+# Fleet Mission Control Operating Runbook
+
+Use Fleet Mission Control as the primary operations surface for Maestro-managed repositories. The fleet dashboard shows one read-only view across project configs, runner state, supervisor decisions, approvals, stuck states, and active workers.
+
+This runbook is intentionally safe for shared docs. It uses placeholders for local paths and never requires printing tokens, environment variables, raw config dumps, or full worker logs.
+
+## Workshop Services
+
+Reserve these services and ports on the workshop host:
+
+| Service | Default bind | Port | Purpose | Notes |
+|---|---:|---:|---|---|
+| Fleet Mission Control | `127.0.0.1` | `8787` | Primary dashboard and `/api/v1/fleet` aggregate API | Start with `maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787 --read-only` |
+| Project Mission Control | `127.0.0.1` | `8788+` | Optional per-project dashboard and `/api/v1/state` API | Configure each project with a unique `server.port`; link it from `dashboard_url` in the fleet file |
+| Project runner | none by default | none | Runs `maestro run --config ...` and owns workers, worktrees, PR handling, and merge/deploy loops | It only serves HTTP when that project config has `server.port` set |
+| Supervisor loop | none | none | Runs `maestro supervise --config ...` to record decisions, safe queue label mutations, and approval requests | Can be manual, timer-driven, or a user service |
+| Worker sessions | none | none | tmux sessions and log files created under each project's `state_dir` | Inspect through Mission Control, `maestro status`, or `maestro logs` |
+| OpenClaw relay | `127.0.0.1` | `18789` | Optional Telegram relay endpoint when `telegram.mode: openclaw` is used | Not required for Mission Control |
+
+Keep Fleet Mission Control read-only until there is an explicit auth and audit model for mutating controls. Bind `0.0.0.0` only behind a trusted firewall or reverse proxy.
+
+## Config Boundaries
+
+Project config and fleet config have different jobs.
+
+| File | Loaded by | Owns | Does not own |
+|---|---|---|---|
+| `~/.maestro/maestro-<project>.yaml` | `maestro run`, `maestro supervise`, `maestro status`, `maestro logs`, single-project `maestro serve` | Repo, clone path, worktree path, state directory, session prefix, labels, supervisor policy, review gate, merge/deploy policy, optional project dashboard port | Other projects |
+| `~/.maestro/fleet.yaml` | `maestro serve --fleet` | Project display names, project config paths, optional dashboard links | Queue policy, labels, state directories, review gates, merge behavior |
+| `.maestro/supervisor.yaml`, `.maestro/supervisor.yml`, or `.maestro/supervisor.md` | Loaded beside the project config or inside `local_path/.maestro` | Supervisor policy when the team wants policy beside the repo | Fleet membership |
+
+Fleet config paths may be absolute, `~/...`, or relative to the fleet YAML file. A fleet file should not duplicate project settings. If a project needs a different label, review gate, state directory, runner interval, or dashboard port, change that project's config and restart that project's runner.
+
+Minimal project config shape:
+
+```yaml
+repo: OWNER/REPO
+local_path: /path/to/repos/<project>
+worktree_base: /path/to/worktrees/<project>
+state_dir: ~/.maestro/state/<project>
+session_prefix: prj
+
+issue_labels:
+  - maestro-ready
+exclude_labels:
+  - blocked
+
+review_gate: greptile
+
+server:
+  host: 127.0.0.1
+  port: 8788
+  read_only: true
+
+supervisor:
+  enabled: true
+  mode: cautious
+  ready_label: maestro-ready
+  blocked_label: blocked
+  dynamic_wave:
+    enabled: true
+    owns_ready_label: true
+    runnable_project_statuses:
+      - Todo
+      - To Do
+      - Ready
+      - Backlog
+      - New
+  safe_actions:
+    - add_ready_label
+    - remove_ready_label
+    - remove_blocked_label
+    - add_issue_comment
+  approval_required:
+    - merge_pr
+    - close_issue
+    - delete_worktree
+    - change_global_config
+```
+
+Minimal fleet config shape:
+
+```yaml
+projects:
+  - name: project-a
+    config: maestro-project-a.yaml
+    dashboard_url: http://127.0.0.1:8788
+  - name: project-b
+    config: maestro-project-b.yaml
+    dashboard_url: http://127.0.0.1:8789
+```
+
+## Operating Model
+
+Fleet Mission Control is an observation surface. It loads each project config, reads each project's state/log metadata, and returns one aggregate response from `/api/v1/fleet`. One project load error is shown on that project card without hiding the rest of the fleet.
+
+The project runner remains the execution surface. It starts workers, reconciles dead sessions, opens and monitors PRs, waits for review gates, merges eligible PRs, deploys when configured, and updates local state.
+
+The supervisor is the explainability and policy surface. It records queue analysis, selected candidates, stuck states, safe label mutations, and approval requests. Safe actions are limited to actions explicitly listed in `supervisor.safe_actions`. Risky recommendations are recorded for an operator; approving them with the CLI records the approval but does not execute the risky action by itself.
+
+Use this order during normal operations:
+
+1. Open Fleet Mission Control at `http://127.0.0.1:8787/`.
+2. Check fleet summary, stale project cards, attention cards, approvals, queue snapshots, and active workers.
+3. Open a project dashboard link only when the fleet card needs project-level detail.
+4. Use CLI commands with explicit `--config` paths when you need local state, logs, or a supervised decision.
+5. Restart services rather than editing state files by hand.
+
+## Queue Policy
+
+Maestro supports a fixed ordered queue and a dynamic wave policy. Use one ordered queue for tightly sequenced work. Use dynamic wave for continuous operations where Mission Control should explain why the next runnable issue was selected or skipped.
+
+Ordered queue policy:
+
+| Rule | Behavior |
+|---|---|
+| `supervisor.ordered_queue.issues` | Only the first unfinished issue is eligible |
+| Closed issue, merged linked PR, or `done_issues` override | Issue is considered finished and the queue advances |
+| First unfinished issue has an open PR | Queue pauses and Mission Control recommends monitoring that PR |
+| First unfinished issue is blocked, excluded, or retry exhausted | Queue pauses until an operator fixes the issue/policy or intentionally overrides it |
+| Ordered queue exhausted and `dynamic_wave.enabled: true` | Dynamic wave can pick the next issue |
+
+Dynamic wave policy:
+
+| Rule | Behavior |
+|---|---|
+| Candidate source | Open GitHub issues from the project repo |
+| Priority order | `p0`, `p1`, `p2`, `p3`, then unlabeled, with lower issue number as tie breaker |
+| Runnable project statuses | Defaults to `Todo`, `To Do`, `Ready`, `Backlog`, and `New`, unless `supervisor.dynamic_wave.runnable_project_statuses` is set |
+| Excluded labels | Built-ins include `blocked`, `wontfix`, `question`, `duplicate`, `invalid`, `epic`, and `meta`, plus `exclude_labels`, `supervisor.excluded_labels`, and `supervisor.blocked_label` |
+| Other skips | Already running, done, retry exhausted, mission parent, epic-like title, and open blockers detected by `blocker_patterns` |
+| Ready label | `supervisor.ready_label` is treated as a queue label and is added to selected work only when `add_ready_label` is allowed |
+| Owned ready label | When `owns_ready_label: true`, dynamic wave keeps the ready label on the selected issue and can remove it from other issues if policy allows |
+| Blocked label | `supervisor.blocked_label` makes an issue ineligible; it can be removed only when `remove_blocked_label` is an allowed safe action |
+
+Fleet cards surface `open`, `eligible`, `excluded`, `non_runnable_project_status`, selected candidate, and top skipped reason so operators can tell whether the queue is empty, held by policy, or waiting on project status.
+
+## Review And Approval Gates
+
+The default PR review gate is Greptile. A project with `review_gate: greptile` waits for CI and Greptile approval before merge. A project with `review_gate: none` skips the Greptile gate, but this should be an explicit per-project policy decision.
+
+PR states to watch:
+
+| State | Meaning | Operator response |
+|---|---|---|
+| `pr_open` | A worker opened a PR and Maestro is waiting for checks, review, mergeability, merge interval, or conflict handling | Monitor, do not spawn duplicate work for the same issue |
+| `queued` | A follow-up step or merge queue path is still pending | Check project dashboard and latest supervisor decision |
+| `greptile_pending` stuck state | Greptile has not finished | Wait or check the GitHub PR/check run if it remains pending unusually long |
+| `greptile_not_approved` stuck state | Greptile review found actionable feedback or no approval | Address feedback, allow the configured retry path, or make a deliberate project policy change |
+| `failing_checks` stuck state | Required checks failed | Inspect the check failure, retry intentionally if budget remains, or fix manually |
+| `unmergeable_pr` stuck state | GitHub reports conflicts or unknown mergeability | Wait for GitHub to compute mergeability, or rebase/resolve conflicts |
+
+Supervisor approvals are stale-sensitive. A pending approval becomes stale if the decision payload changes or the target session/PR state changes. Do not approve a stale approval. Re-run the supervisor, review the new decision, and approve or reject the new ID if appropriate.
+
+## Safe Commands
+
+Use explicit config paths for project commands. These commands are safe for local operation because they do not print token values or dump entire configs. Treat worker logs as potentially sensitive and avoid pasting full logs into PRs or issues.
+
+```bash
+# Fleet dashboard and API
+maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787 --read-only
+curl -fsS http://127.0.0.1:8787/api/v1/fleet
+
+# Project status and queue analysis
+maestro status --config ~/.maestro/maestro-<project>.yaml
+maestro status --config ~/.maestro/maestro-<project>.yaml --json
+maestro supervise --config ~/.maestro/maestro-<project>.yaml --once
+maestro supervise --config ~/.maestro/maestro-<project>.yaml --once --json
+
+# Worker logs through Maestro
+maestro logs --config ~/.maestro/maestro-<project>.yaml
+maestro logs --config ~/.maestro/maestro-<project>.yaml <session>
+
+# Service status and restart
+systemctl --user status maestro@<project>.service --no-pager
+journalctl --user -u maestro@<project>.service --since "30 minutes ago" --no-pager
+systemctl --user restart maestro@<project>.service
+systemctl --user status maestro-fleet.service --no-pager
+journalctl --user -u maestro-fleet.service --since "30 minutes ago" --no-pager
+systemctl --user restart maestro-fleet.service
+```
+
+Avoid these during incident handling unless you are deliberately debugging credentials: `env`, raw config dumps, `gh auth token`, shell history dumps, and full worker log pastebacks.
+
+## Recovery Playbook
+
+### No eligible issues
+
+Mission Control indicators: queue `eligible=0`, `no_eligible_issues`, `all_eligible_issues_excluded`, `ordered_queue_exhausted`, or a nonzero `non_runnable_project_status` count.
+
+Safe response:
+
+1. Run `maestro supervise --config ~/.maestro/maestro-<project>.yaml --once` and read the queue summary.
+2. If there are no open issues, add or wait for work.
+3. If issues are missing the ready label, add the configured `supervisor.ready_label` or let the supervisor add it when `add_ready_label` is allowed.
+4. If issues are excluded, remove the blocking/excluded label only after confirming the issue is actually runnable.
+5. If dynamic wave reports non-runnable project status, move one issue to a configured runnable status or update `supervisor.dynamic_wave.runnable_project_statuses` in the project config.
+6. Restart the project runner only if config changed: `systemctl --user restart maestro@<project>.service`.
+
+### Running but dead PID
+
+Mission Control indicators: status `running` with `alive=false`, CLI `ALIVE no`, or stuck state `dead_running_pid`.
+
+Safe response:
+
+1. Run `maestro status --config ~/.maestro/maestro-<project>.yaml` to confirm the session and PID.
+2. Inspect the session with `maestro logs --config ~/.maestro/maestro-<project>.yaml <session>`.
+3. Restart the project runner with `systemctl --user restart maestro@<project>.service` so the next reconciliation cycle can mark the session dead and retry if eligible.
+4. If you intentionally need to reconcile immediately, run `maestro run --config ~/.maestro/maestro-<project>.yaml --once` knowing it can progress orchestration for that project.
+5. Do not edit `state.json` manually.
+
+### PR open waiting Greptile
+
+Mission Control indicators: `pr_open`, stuck state `greptile_pending`, or a PR card with passing CI but no review approval yet.
+
+Safe response:
+
+1. Wait for Greptile if the pending state is fresh.
+2. Check the GitHub PR page if it remains pending unusually long.
+3. If Greptile is not approved, address the feedback or let the configured retry path handle review feedback.
+4. Do not spawn another worker for the same issue while the PR is open.
+5. Change `review_gate` only as an explicit project policy decision, then restart the project runner.
+
+### Retry exhausted
+
+Mission Control indicators: session status `retry_exhausted`, action `review_retry_exhausted`, or stuck state `retry_exhausted`.
+
+Safe response:
+
+1. Inspect the session status and logs with explicit `--config` commands.
+2. If a PR is still open, keep it in normal merge flow when checks and review gates pass.
+3. If checks failed or no usable PR exists, review failed attempts, split or clarify the issue, and retry intentionally.
+4. If retrying is appropriate, update the issue/config first, then start a new worker with `maestro spawn --config ~/.maestro/maestro-<project>.yaml --issue <number>`.
+5. Do not increase retry budgets globally just to clear one incident unless that is the intended project policy change.
+
+### Stale approval
+
+Mission Control indicators: approval status `stale` or CLI error `approval is stale` / `approval payload changed`.
+
+Safe response:
+
+1. Do not approve the stale approval.
+2. Run `maestro supervise --config ~/.maestro/maestro-<project>.yaml --once` to record a fresh decision.
+3. Review the new target, risk, reasons, and stuck states.
+4. Resolve the new approval ID if needed:
+
+```bash
+maestro supervise approve --config ~/.maestro/maestro-<project>.yaml <approval-or-decision-id> --actor <operator> --reason "approved after fresh status check"
+maestro supervise reject --config ~/.maestro/maestro-<project>.yaml <approval-or-decision-id> --actor <operator> --reason "state changed"
+```
+
+### Project API failure
+
+Mission Control indicators: project card error, failed `maestro supervise`, failed `maestro status`, GraphQL/project item errors, or GitHub CLI authentication errors.
+
+Safe response:
+
+1. Check only auth status, not token values: `gh auth status`.
+2. Confirm the GitHub user or app has access to the repo and project board.
+3. Retry after GitHub rate limits or project API incidents clear.
+4. If dynamic wave depends on project status, keep work paused until project item data is reliable or make an explicit temporary policy change in the project config.
+5. Restart only the affected project runner after config or auth is fixed.
+6. Do not paste raw GraphQL output, tokens, or local config contents into issues or PRs.
+
+## Operator Checklist
+
+- Fleet dashboard is reachable on `127.0.0.1:8787` and is read-only.
+- Every project in `~/.maestro/fleet.yaml` has a distinct `state_dir`, `session_prefix`, and optional project dashboard port.
+- Project commands use `--config ~/.maestro/maestro-<project>.yaml`.
+- Dynamic wave has known runnable statuses and clear ready/blocked label ownership.
+- Greptile gate policy is explicit per project.
+- Approvals are fresh before being approved or rejected.
+- Incident notes contain summaries and issue/PR numbers, not secrets, raw env output, full config files, or full logs.

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -37,7 +37,7 @@ Minimal project config shape:
 repo: OWNER/REPO
 local_path: /path/to/repos/<project>
 worktree_base: /path/to/worktrees/<project>
-state_dir: ~/.maestro/state/<project>
+state_dir: ~/.maestro/<project>
 session_prefix: prj
 
 issue_labels:
@@ -245,8 +245,8 @@ Safe response:
 4. Resolve the new approval ID if needed:
 
 ```bash
-maestro supervise approve --config ~/.maestro/maestro-<project>.yaml <approval-or-decision-id> --actor <operator> --reason "approved after fresh status check"
-maestro supervise reject --config ~/.maestro/maestro-<project>.yaml <approval-or-decision-id> --actor <operator> --reason "state changed"
+maestro supervise approve --config ~/.maestro/maestro-<project>.yaml --actor <operator> --reason "approved after fresh status check" <approval-or-decision-id>
+maestro supervise reject --config ~/.maestro/maestro-<project>.yaml --actor <operator> --reason "state changed" <approval-or-decision-id>
 ```
 
 ### Project API failure

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -253,6 +253,8 @@ systemctl --user enable --now maestro@myproject
 
 Use the fleet dashboard when one operator needs a read-only overview across multiple Maestro-managed repos without SSH spelunking. Each repo still has its own project config, state directory, `session_prefix`, and optional per-project dashboard; the fleet dashboard loads those configs, keeps them visible in project tabs, and aggregates active workers through `/api/v1/fleet`.
 
+For day-to-day operations, review gates, queue policy, approvals, and safe recovery steps, see the [Fleet Mission Control operating runbook](fleet-mission-control-runbook.md).
+
 Start read-only first, controls later: keep the fleet dashboard in `--read-only` mode while it is used for observation and dogfooding. Add mutating controls only after the auth, audit, and per-project safety model is explicit.
 
 To add a project:


### PR DESCRIPTION
Closes #311

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the Fleet Mission Control operating runbook (`docs/fleet-mission-control-runbook.md`), genericizes README examples by replacing hardcoded personal paths and session prefixes with placeholders, and adds cross-references from both the README and the project-setup runbook. The `state_dir` path pattern (`~/.maestro/<project>`) is now consistent across the README config example and the runbook's minimal project config, resolving the inconsistency flagged in a previous thread.

<h3>Confidence Score: 5/5</h3>

Documentation-only PR with no logic issues; safe to merge.

All examples are internally consistent, cross-references are correct, and the previously flagged state_dir discrepancy has been resolved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Replaces hardcoded personal paths/prefixes with generic placeholders and adds a link to the new fleet runbook; no logic issues |
| docs/fleet-mission-control-runbook.md | New runbook covering fleet dashboard setup, queue/approval policy, safe commands, and recovery playbooks; consistent with README examples and project-setup-runbook |
| docs/project-setup-runbook.md | Adds a single cross-reference link to the new fleet runbook; no issues |

</details>

<sub>Reviews (2): Last reviewed commit: ["Docs: Address fleet runbook review feedb..."](https://github.com/befeast/maestro/commit/2b9171c9e4c19f9c9bcfdf53694d59fb6815885e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30484580)</sub>

<!-- /greptile_comment -->