### PR TITLE
Worker safety: constrain broad filesystem searches to the worktree

### DIFF
--- a/docs/gemini-backend.md
+++ b/docs/gemini-backend.md
@@ -85,6 +85,7 @@ gemini -p "<prompt content>" [extra_args...]
 - Prompt content is read from the prompt file and passed inline as a `-p` argument
 - Extra arguments from config are appended after the prompt
 - The working directory is set to the issue's git worktree
+- Worker runner scripts export `MAESTRO_WORKTREE` and wrap `rg`, `find`, and `grep` so broad-root searches warn and point back to the worktree
 - No stdin redirection is used (unlike the Codex backend)
 
 ## Per-issue routing

--- a/internal/pipeline/prompts.go
+++ b/internal/pipeline/prompts.go
@@ -27,6 +27,12 @@ const defaultPlannerPrompt = `You are a **planner** for a coding agent pipeline.
 - Worktree: {{WORKTREE}}
 - Branch: {{BRANCH}}
 
+## Search Safety
+
+- Use the worktree as the current directory before code search commands: ` + "`cd {{WORKTREE}}`" + `.
+- Do NOT run ` + "`rg`" + `, ` + "`find`" + `, or ` + "`grep`" + ` from broad filesystem roots such as ` + "`/`" + `, ` + "`/mnt`" + `, or ` + "`/home`" + `.
+- If a broad host search is intentional, set ` + "`MAESTRO_ALLOW_BROAD_SEARCH=1`" + ` for that single command.
+
 ## Instructions
 
 1. Read and understand the codebase relevant to this issue.
@@ -59,6 +65,12 @@ const defaultValidatorPrompt = `You are a **validator** for a coding agent pipel
 - Repo: {{REPO}}
 - Worktree: {{WORKTREE}}
 - Branch: {{BRANCH}}
+
+## Search Safety
+
+- Use the worktree as the current directory before code search commands: ` + "`cd {{WORKTREE}}`" + `.
+- Do NOT run ` + "`rg`" + `, ` + "`find`" + `, or ` + "`grep`" + ` from broad filesystem roots such as ` + "`/`" + `, ` + "`/mnt`" + `, or ` + "`/home`" + `.
+- If a broad host search is intentional, set ` + "`MAESTRO_ALLOW_BROAD_SEARCH=1`" + ` for that single command.
 
 ## Instructions
 

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -150,16 +150,8 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 
 	// Write runner script
 	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
-	var runnerContent string
-	if stdinFile != "" {
-		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s < %q 2>&1 | tee -a %q\n",
-			shellJoin(workerCmd.Args), stdinFile, logFile)
-	} else {
-		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s 2>&1 | tee -a %q\n",
-			shellJoin(workerCmd.Args), logFile)
-	}
-	if err := os.WriteFile(runnerPath, []byte(runnerContent), 0755); err != nil {
-		return fmt.Errorf("write runner script: %w", err)
+	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, sess.Worktree); err != nil {
+		return err
 	}
 
 	// Run before_run hook (fatal on failure)

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -65,16 +65,8 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 
 	// Write runner script
 	runnerPath := fmt.Sprintf("%s/%s-run.sh", cfg.StateDir, slotName)
-	var runnerContent string
-	if stdinFile != "" {
-		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s < %q 2>&1 | tee -a %q\n",
-			shellJoin(workerCmd.Args), stdinFile, logFile)
-	} else {
-		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s 2>&1 | tee -a %q\n",
-			shellJoin(workerCmd.Args), logFile)
-	}
-	if err := os.WriteFile(runnerPath, []byte(runnerContent), 0755); err != nil {
-		return fmt.Errorf("write runner script: %w", err)
+	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, sess.Worktree); err != nil {
+		return err
 	}
 
 	// Run before_run hook

--- a/internal/worker/search_guardrail.go
+++ b/internal/worker/search_guardrail.go
@@ -1,0 +1,199 @@
+package worker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type searchGuardrailReason string
+
+const (
+	searchGuardrailNone     searchGuardrailReason = "none"
+	searchGuardrailBroadCWD searchGuardrailReason = "broad_cwd"
+	searchGuardrailBroadArg searchGuardrailReason = "broad_arg"
+	searchGuardrailAllowed  searchGuardrailReason = "allowed"
+)
+
+type searchGuardrailDecision struct {
+	Warn   bool
+	Reason searchGuardrailReason
+}
+
+var searchGuardedCommands = []string{"rg", "find", "grep"}
+
+func classifySearchGuardrail(command, cwd, worktree string, args []string, allowBroad bool) searchGuardrailDecision {
+	if !isGuardedSearchCommand(command) {
+		return searchGuardrailDecision{Reason: searchGuardrailNone}
+	}
+	if allowBroad {
+		return searchGuardrailDecision{Reason: searchGuardrailAllowed}
+	}
+	if isBroadSearchPath(cwd, worktree) {
+		return searchGuardrailDecision{Warn: true, Reason: searchGuardrailBroadCWD}
+	}
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if isBroadSearchPath(arg, worktree) {
+			return searchGuardrailDecision{Warn: true, Reason: searchGuardrailBroadArg}
+		}
+	}
+	return searchGuardrailDecision{Reason: searchGuardrailNone}
+}
+
+func isGuardedSearchCommand(command string) bool {
+	name := filepath.Base(strings.TrimSpace(command))
+	for _, guarded := range searchGuardedCommands {
+		if name == guarded {
+			return true
+		}
+	}
+	return false
+}
+
+func isBroadSearchPath(path, worktree string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" || !filepath.IsAbs(path) {
+		return false
+	}
+	path = filepath.Clean(path)
+	if isWithinPath(path, worktree) {
+		return false
+	}
+
+	switch path {
+	case "/", "/mnt", "/home", "/Users", "/tmp", "/var", "/opt", "/usr", "/etc", "/proc", "/sys", "/dev":
+		return true
+	}
+	for _, prefix := range []string{"/mnt/", "/home/", "/Users/", "/tmp/", "/var/", "/opt/", "/usr/", "/etc/", "/proc/", "/sys/", "/dev/"} {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isWithinPath(path, root string) bool {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return false
+	}
+	path = filepath.Clean(path)
+	root = filepath.Clean(root)
+	if path == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return false
+	}
+	return true
+}
+
+func ensureSearchGuardrailWrappers(stateDir string) (string, error) {
+	if strings.TrimSpace(stateDir) == "" {
+		return "", fmt.Errorf("empty state dir")
+	}
+	guardDir := filepath.Join(stateDir, "search-guardrails")
+	if err := os.MkdirAll(guardDir, 0755); err != nil {
+		return "", fmt.Errorf("create search guardrail dir: %w", err)
+	}
+	for _, name := range searchGuardedCommands {
+		path := filepath.Join(guardDir, name)
+		if err := os.WriteFile(path, []byte(searchGuardrailWrapperScript), 0755); err != nil {
+			return "", fmt.Errorf("write search guardrail wrapper %s: %w", name, err)
+		}
+	}
+	return guardDir, nil
+}
+
+const searchGuardrailWrapperScript = `#!/bin/sh
+cmd=${0##*/}
+real_path=$(PATH="${MAESTRO_ORIGINAL_PATH:-$PATH}" command -v "$cmd" 2>/dev/null)
+if [ -z "$real_path" ]; then
+  echo "[maestro] search guardrail: unable to locate real $cmd" >&2
+  exit 127
+fi
+
+maestro_inside_worktree() {
+  [ -n "${MAESTRO_WORKTREE:-}" ] || return 1
+  case "$PWD" in
+    "$MAESTRO_WORKTREE"|"$MAESTRO_WORKTREE"/*) return 0 ;;
+  esac
+  return 1
+}
+
+maestro_path_inside_worktree() {
+  [ -n "${MAESTRO_WORKTREE:-}" ] || return 1
+  case "$1" in
+    "$MAESTRO_WORKTREE"|"$MAESTRO_WORKTREE"/*) return 0 ;;
+  esac
+  return 1
+}
+
+maestro_broad_path() {
+  case "$1" in
+    /|/mnt|/mnt/*|/home|/home/*|/Users|/Users/*|/tmp|/tmp/*|/var|/var/*|/opt|/opt/*|/usr|/usr/*|/etc|/etc/*|/proc|/proc/*|/sys|/sys/*|/dev|/dev/*) return 0 ;;
+  esac
+  return 1
+}
+
+if [ -z "${MAESTRO_ALLOW_BROAD_SEARCH:-}" ]; then
+  for arg in "$@"; do
+    case "$arg" in
+      -*) continue ;;
+    esac
+    if maestro_broad_path "$arg" && ! maestro_path_inside_worktree "$arg"; then
+      echo "[maestro] search guardrail: $cmd was given a broad filesystem path; search the assigned worktree instead: $MAESTRO_WORKTREE" >&2
+      exit 2
+    fi
+  done
+
+  if ! maestro_inside_worktree && maestro_broad_path "$PWD"; then
+    echo "[maestro] search guardrail: $cmd was launched from a broad filesystem root; rerunning from worktree: $MAESTRO_WORKTREE" >&2
+    cd "$MAESTRO_WORKTREE" || exit 1
+  fi
+fi
+
+exec "$real_path" "$@"
+`
+
+func buildWorkerRunnerScript(args []string, stdinFile, logFile, worktree, guardDir string) string {
+	var b strings.Builder
+	b.WriteString("#!/bin/bash\n")
+	b.WriteString("export MAESTRO_WORKTREE=" + shellQuote(worktree) + "\n")
+	b.WriteString("export MAESTRO_SEARCH_GUARDRAIL_DIR=" + shellQuote(guardDir) + "\n")
+	b.WriteString("export MAESTRO_ORIGINAL_PATH=\"${PATH:-}\"\n")
+	b.WriteString("export PATH=\"$MAESTRO_SEARCH_GUARDRAIL_DIR:$MAESTRO_ORIGINAL_PATH\"\n")
+	b.WriteString("cd \"$MAESTRO_WORKTREE\" || exit 1\n")
+	b.WriteString("printf '[maestro] worker worktree: %s\\n' \"$MAESTRO_WORKTREE\" | tee -a " + shellQuote(logFile) + "\n")
+	if stdinFile != "" {
+		b.WriteString(fmt.Sprintf("exec %s < %s 2>&1 | tee -a %s\n", shellJoin(args), shellQuote(stdinFile), shellQuote(logFile)))
+	} else {
+		b.WriteString(fmt.Sprintf("exec %s 2>&1 | tee -a %s\n", shellJoin(args), shellQuote(logFile)))
+	}
+	return b.String()
+}
+
+func writeWorkerRunnerScript(stateDir, runnerPath string, args []string, stdinFile, logFile, worktree string) error {
+	guardDir, err := ensureSearchGuardrailWrappers(stateDir)
+	if err != nil {
+		return err
+	}
+	runnerContent := buildWorkerRunnerScript(args, stdinFile, logFile, worktree, guardDir)
+	if err := os.WriteFile(runnerPath, []byte(runnerContent), 0755); err != nil {
+		return fmt.Errorf("write runner script: %w", err)
+	}
+	return nil
+}
+
+func workerSearchSafetyPromptSection(worktreePath string) string {
+	return fmt.Sprintf("\n\n---\n\n## Worker Search Safety\n\n"+
+		"- The assigned worktree is `%s`; use it as the current directory before running code search commands.\n"+
+		"- Do NOT run `rg`, `find`, or `grep` from broad filesystem roots such as `/`, `/mnt`, or `/home`.\n"+
+		"- If you intentionally need a broad host search, set `MAESTRO_ALLOW_BROAD_SEARCH=1` for that single command.\n",
+		worktreePath)
+}

--- a/internal/worker/search_guardrail.go
+++ b/internal/worker/search_guardrail.go
@@ -7,91 +7,7 @@ import (
 	"strings"
 )
 
-type searchGuardrailReason string
-
-const (
-	searchGuardrailNone     searchGuardrailReason = "none"
-	searchGuardrailBroadCWD searchGuardrailReason = "broad_cwd"
-	searchGuardrailBroadArg searchGuardrailReason = "broad_arg"
-	searchGuardrailAllowed  searchGuardrailReason = "allowed"
-)
-
-type searchGuardrailDecision struct {
-	Warn   bool
-	Reason searchGuardrailReason
-}
-
 var searchGuardedCommands = []string{"rg", "find", "grep"}
-
-func classifySearchGuardrail(command, cwd, worktree string, args []string, allowBroad bool) searchGuardrailDecision {
-	if !isGuardedSearchCommand(command) {
-		return searchGuardrailDecision{Reason: searchGuardrailNone}
-	}
-	if allowBroad {
-		return searchGuardrailDecision{Reason: searchGuardrailAllowed}
-	}
-	if isBroadSearchPath(cwd, worktree) {
-		return searchGuardrailDecision{Warn: true, Reason: searchGuardrailBroadCWD}
-	}
-	for _, arg := range args {
-		if strings.HasPrefix(arg, "-") {
-			continue
-		}
-		if isBroadSearchPath(arg, worktree) {
-			return searchGuardrailDecision{Warn: true, Reason: searchGuardrailBroadArg}
-		}
-	}
-	return searchGuardrailDecision{Reason: searchGuardrailNone}
-}
-
-func isGuardedSearchCommand(command string) bool {
-	name := filepath.Base(strings.TrimSpace(command))
-	for _, guarded := range searchGuardedCommands {
-		if name == guarded {
-			return true
-		}
-	}
-	return false
-}
-
-func isBroadSearchPath(path, worktree string) bool {
-	path = strings.TrimSpace(path)
-	if path == "" || !filepath.IsAbs(path) {
-		return false
-	}
-	path = filepath.Clean(path)
-	if isWithinPath(path, worktree) {
-		return false
-	}
-
-	switch path {
-	case "/", "/mnt", "/home", "/Users", "/tmp", "/var", "/opt", "/usr", "/etc", "/proc", "/sys", "/dev":
-		return true
-	}
-	for _, prefix := range []string{"/mnt/", "/home/", "/Users/", "/tmp/", "/var/", "/opt/", "/usr/", "/etc/", "/proc/", "/sys/", "/dev/"} {
-		if strings.HasPrefix(path, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
-func isWithinPath(path, root string) bool {
-	root = strings.TrimSpace(root)
-	if root == "" {
-		return false
-	}
-	path = filepath.Clean(path)
-	root = filepath.Clean(root)
-	if path == root {
-		return true
-	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
-		return false
-	}
-	return true
-}
 
 func ensureSearchGuardrailWrappers(stateDir string) (string, error) {
 	if strings.TrimSpace(stateDir) == "" {
@@ -141,20 +57,194 @@ maestro_broad_path() {
   return 1
 }
 
-if [ -z "${MAESTRO_ALLOW_BROAD_SEARCH:-}" ]; then
+maestro_reject_broad_arg() {
+  if maestro_broad_path "$1" && ! maestro_path_inside_worktree "$1"; then
+    echo "[maestro] search guardrail: $cmd was given a broad filesystem path; search the assigned worktree instead: $MAESTRO_WORKTREE" >&2
+    return 2
+  fi
+  return 0
+}
+
+maestro_check_rg_args() {
+  rg_after_options=0
+  rg_paths_only=0
+  rg_saw_pattern=0
+  rg_skip_next=0
+
   for arg in "$@"; do
-    case "$arg" in
-      -*) continue ;;
-    esac
-    if maestro_broad_path "$arg" && ! maestro_path_inside_worktree "$arg"; then
-      echo "[maestro] search guardrail: $cmd was given a broad filesystem path; search the assigned worktree instead: $MAESTRO_WORKTREE" >&2
-      exit 2
+    if [ "$rg_skip_next" = "1" ]; then
+      rg_skip_next=0
+      continue
     fi
+
+    if [ "$rg_after_options" = "0" ]; then
+      case "$arg" in
+        --)
+          rg_after_options=1
+          continue
+          ;;
+        --files)
+          rg_paths_only=1
+          continue
+          ;;
+        --regexp|--file)
+          rg_saw_pattern=1
+          rg_skip_next=1
+          continue
+          ;;
+        --regexp=*|--file=*)
+          rg_saw_pattern=1
+          continue
+          ;;
+        --after-context|--before-context|--color|--colors|--context|--context-separator|--dfa-size-limit|--encoding|--engine|--field-context-separator|--field-match-separator|--glob|--hostname-bin|--hyperlink-format|--iglob|--ignore-file|--max-columns|--max-count|--max-depth|--max-filesize|--path-separator|--pre|--pre-glob|--regex-size-limit|--replace|--sort|--sortr|--threads|--type|--type-add|--type-clear|--type-not)
+          rg_skip_next=1
+          continue
+          ;;
+        --*=*)
+          continue
+          ;;
+        -e|-f)
+          rg_saw_pattern=1
+          rg_skip_next=1
+          continue
+          ;;
+        -e?*|-f?*)
+          rg_saw_pattern=1
+          continue
+          ;;
+        -A|-B|-C|-E|-g|-j|-m|-M|-r|-t|-T)
+          rg_skip_next=1
+          continue
+          ;;
+        -A?*|-B?*|-C?*|-E?*|-g?*|-j?*|-m?*|-M?*|-r?*|-t?*|-T?*)
+          continue
+          ;;
+        -*)
+          continue
+          ;;
+      esac
+    fi
+
+    if [ "$rg_paths_only" = "1" ]; then
+      maestro_reject_broad_arg "$arg" || return $?
+      continue
+    fi
+    if [ "$rg_saw_pattern" = "0" ]; then
+      rg_saw_pattern=1
+      continue
+    fi
+    maestro_reject_broad_arg "$arg" || return $?
   done
+  return 0
+}
+
+maestro_check_grep_args() {
+  grep_after_options=0
+  grep_saw_pattern=0
+  grep_skip_next=0
+
+  for arg in "$@"; do
+    if [ "$grep_skip_next" = "1" ]; then
+      grep_skip_next=0
+      continue
+    fi
+
+    if [ "$grep_after_options" = "0" ]; then
+      case "$arg" in
+        --)
+          grep_after_options=1
+          continue
+          ;;
+        --regexp|--file)
+          grep_saw_pattern=1
+          grep_skip_next=1
+          continue
+          ;;
+        --regexp=*|--file=*)
+          grep_saw_pattern=1
+          continue
+          ;;
+        --after-context|--before-context|--binary-files|--context|--devices|--directories|--exclude|--exclude-dir|--exclude-from|--group-separator|--include|--label|--max-count)
+          grep_skip_next=1
+          continue
+          ;;
+        --*=*)
+          continue
+          ;;
+        -e|-f)
+          grep_saw_pattern=1
+          grep_skip_next=1
+          continue
+          ;;
+        -e?*|-f?*)
+          grep_saw_pattern=1
+          continue
+          ;;
+        -A|-B|-C|-D|-d|-m)
+          grep_skip_next=1
+          continue
+          ;;
+        -A?*|-B?*|-C?*|-D?*|-d?*|-m?*)
+          continue
+          ;;
+        -*)
+          continue
+          ;;
+      esac
+    fi
+
+    if [ "$grep_saw_pattern" = "0" ]; then
+      grep_saw_pattern=1
+      continue
+    fi
+    maestro_reject_broad_arg "$arg" || return $?
+  done
+  return 0
+}
+
+maestro_check_find_args() {
+  find_skip_next=0
+
+  for arg in "$@"; do
+    if [ "$find_skip_next" = "1" ]; then
+      find_skip_next=0
+      continue
+    fi
+
+    case "$arg" in
+      --|-H|-L|-P)
+        continue
+        ;;
+      -D|-O)
+        find_skip_next=1
+        continue
+        ;;
+      -D?*|-O?*)
+        continue
+        ;;
+      -*)
+        return 0
+        ;;
+      '!'|'('|')'|',')
+        return 0
+        ;;
+    esac
+
+    maestro_reject_broad_arg "$arg" || return $?
+  done
+  return 0
+}
+
+if [ -z "${MAESTRO_ALLOW_BROAD_SEARCH:-}" ]; then
+  case "$cmd" in
+    rg) maestro_check_rg_args "$@" || exit $? ;;
+    grep) maestro_check_grep_args "$@" || exit $? ;;
+    find) maestro_check_find_args "$@" || exit $? ;;
+  esac
 
   if ! maestro_inside_worktree && maestro_broad_path "$PWD"; then
-    echo "[maestro] search guardrail: $cmd was launched from a broad filesystem root; rerunning from worktree: $MAESTRO_WORKTREE" >&2
-    cd "$MAESTRO_WORKTREE" || exit 1
+    echo "[maestro] search guardrail: $cmd was launched from a broad filesystem root; run it from the assigned worktree instead: $MAESTRO_WORKTREE" >&2
+    exit 2
   fi
 fi
 

--- a/internal/worker/search_guardrail_test.go
+++ b/internal/worker/search_guardrail_test.go
@@ -2,79 +2,198 @@ package worker
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestClassifySearchGuardrail(t *testing.T) {
-	worktree := "/mnt/storage/worktrees/repo/sup-27"
+type searchGuardrailHarness struct {
+	guardDir string
+	fakeDir  string
+	worktree string
+}
+
+func newSearchGuardrailHarness(t *testing.T) searchGuardrailHarness {
+	t.Helper()
+
+	baseDir := t.TempDir()
+	worktree := filepath.Join(baseDir, "worktree")
+	fakeDir := filepath.Join(baseDir, "fake-bin")
+	if err := os.MkdirAll(worktree, 0755); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	if err := os.MkdirAll(fakeDir, 0755); err != nil {
+		t.Fatalf("create fake bin: %v", err)
+	}
+
+	guardDir, err := ensureSearchGuardrailWrappers(filepath.Join(baseDir, "state"))
+	if err != nil {
+		t.Fatalf("ensureSearchGuardrailWrappers: %v", err)
+	}
+
+	fakeScript := `#!/bin/sh
+printf 'real:%s:%s\n' "$0" "$PWD"
+printf 'args:'
+for arg in "$@"; do
+  printf '<%s>' "$arg"
+done
+printf '\n'
+`
+	for _, name := range searchGuardedCommands {
+		if err := os.WriteFile(filepath.Join(fakeDir, name), []byte(fakeScript), 0755); err != nil {
+			t.Fatalf("write fake %s: %v", name, err)
+		}
+	}
+
+	return searchGuardrailHarness{
+		guardDir: guardDir,
+		fakeDir:  fakeDir,
+		worktree: worktree,
+	}
+}
+
+func (h searchGuardrailHarness) run(t *testing.T, name, cwd string, allowBroad bool, args ...string) (string, int) {
+	t.Helper()
+
+	cmd := exec.Command(filepath.Join(h.guardDir, name), args...)
+	cmd.Dir = cwd
+	cmd.Env = []string{
+		"MAESTRO_WORKTREE=" + h.worktree,
+		"MAESTRO_ORIGINAL_PATH=" + h.fakeDir,
+		"PATH=" + h.guardDir + string(os.PathListSeparator) + h.fakeDir,
+	}
+	if allowBroad {
+		cmd.Env = append(cmd.Env, "MAESTRO_ALLOW_BROAD_SEARCH=1")
+	} else {
+		cmd.Env = append(cmd.Env, "MAESTRO_ALLOW_BROAD_SEARCH=")
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return string(output), 0
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("run guarded %s: %v", name, err)
+	}
+	return string(output), exitErr.ExitCode()
+}
+
+func TestSearchGuardrailWrapperAllowsBroadLookingPatterns(t *testing.T) {
+	h := newSearchGuardrailHarness(t)
 	tests := []struct {
-		name       string
-		command    string
-		cwd        string
-		args       []string
-		allowBroad bool
-		wantWarn   bool
-		wantReason searchGuardrailReason
+		name    string
+		command string
+		args    []string
 	}{
 		{
-			name:       "rg from root warns",
-			command:    "rg",
-			cwd:        "/",
-			wantWarn:   true,
-			wantReason: searchGuardrailBroadCWD,
+			name:    "rg positional pattern",
+			command: "rg",
+			args:    []string{"/home/", "."},
 		},
 		{
-			name:       "find from mnt warns",
-			command:    "find",
-			cwd:        "/mnt",
-			wantWarn:   true,
-			wantReason: searchGuardrailBroadCWD,
+			name:    "rg regexp option pattern",
+			command: "rg",
+			args:    []string{"--regexp", "/tmp/", "."},
 		},
 		{
-			name:       "grep from home user warns",
-			command:    "grep",
-			cwd:        "/home/dev",
-			wantWarn:   true,
-			wantReason: searchGuardrailBroadCWD,
+			name:    "grep positional pattern",
+			command: "grep",
+			args:    []string{"/tmp/", "file.txt"},
 		},
 		{
-			name:       "search inside worktree is allowed",
-			command:    "rg",
-			cwd:        "/mnt/storage/worktrees/repo/sup-27/internal/worker",
-			wantReason: searchGuardrailNone,
+			name:    "grep regexp option pattern",
+			command: "grep",
+			args:    []string{"-e", "/home/", "file.txt"},
 		},
 		{
-			name:       "explicit broad search path warns",
-			command:    "rg",
-			cwd:        worktree,
-			args:       []string{"guardrail", "/"},
-			wantWarn:   true,
-			wantReason: searchGuardrailBroadArg,
-		},
-		{
-			name:       "explicit allow suppresses warning",
-			command:    "rg",
-			cwd:        "/",
-			allowBroad: true,
-			wantReason: searchGuardrailAllowed,
-		},
-		{
-			name:       "non search command ignored",
-			command:    "go",
-			cwd:        "/",
-			wantReason: searchGuardrailNone,
+			name:    "find expression pattern",
+			command: "find",
+			args:    []string{".", "-name", "/tmp/*"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classifySearchGuardrail(tt.command, tt.cwd, worktree, tt.args, tt.allowBroad)
-			if got.Warn != tt.wantWarn || got.Reason != tt.wantReason {
-				t.Fatalf("classifySearchGuardrail() = %+v, want warn=%v reason=%s", got, tt.wantWarn, tt.wantReason)
+			output, code := h.run(t, tt.command, h.worktree, false, tt.args...)
+			if code != 0 {
+				t.Fatalf("guarded %s exited %d, output:\n%s", tt.command, code, output)
+			}
+			if !strings.Contains(output, "real:") {
+				t.Fatalf("guarded %s did not run real command, output:\n%s", tt.command, output)
 			}
 		})
+	}
+}
+
+func TestSearchGuardrailWrapperRejectsBroadSearchScopes(t *testing.T) {
+	h := newSearchGuardrailHarness(t)
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+	}{
+		{
+			name:    "rg path operand",
+			command: "rg",
+			args:    []string{"needle", "/"},
+		},
+		{
+			name:    "rg files mode path operand",
+			command: "rg",
+			args:    []string{"--files", "/tmp"},
+		},
+		{
+			name:    "grep file operand",
+			command: "grep",
+			args:    []string{"needle", "/tmp"},
+		},
+		{
+			name:    "find path operand",
+			command: "find",
+			args:    []string{"/tmp", "-name", "needle"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, code := h.run(t, tt.command, h.worktree, false, tt.args...)
+			if code != 2 {
+				t.Fatalf("guarded %s exited %d, want 2, output:\n%s", tt.command, code, output)
+			}
+			if !strings.Contains(output, "broad filesystem path") || !strings.Contains(output, h.worktree) {
+				t.Fatalf("guarded %s did not point back to worktree, output:\n%s", tt.command, output)
+			}
+			if strings.Contains(output, "real:") {
+				t.Fatalf("guarded %s ran real command after rejection, output:\n%s", tt.command, output)
+			}
+		})
+	}
+}
+
+func TestSearchGuardrailWrapperRejectsBroadCWD(t *testing.T) {
+	h := newSearchGuardrailHarness(t)
+	output, code := h.run(t, "rg", "/tmp", false, "needle")
+	if code != 2 {
+		t.Fatalf("guarded rg exited %d, want 2, output:\n%s", code, output)
+	}
+	if !strings.Contains(output, "broad filesystem root") || !strings.Contains(output, h.worktree) {
+		t.Fatalf("guarded rg did not point back to worktree, output:\n%s", output)
+	}
+	if strings.Contains(output, "real:") {
+		t.Fatalf("guarded rg ran real command after rejection, output:\n%s", output)
+	}
+}
+
+func TestSearchGuardrailWrapperAllowsExplicitBroadSearch(t *testing.T) {
+	h := newSearchGuardrailHarness(t)
+	output, code := h.run(t, "rg", "/tmp", true, "needle", "/")
+	if code != 0 {
+		t.Fatalf("guarded rg exited %d, output:\n%s", code, output)
+	}
+	if !strings.Contains(output, "real:") {
+		t.Fatalf("guarded rg did not run real command, output:\n%s", output)
 	}
 }
 

--- a/internal/worker/search_guardrail_test.go
+++ b/internal/worker/search_guardrail_test.go
@@ -1,0 +1,130 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestClassifySearchGuardrail(t *testing.T) {
+	worktree := "/mnt/storage/worktrees/repo/sup-27"
+	tests := []struct {
+		name       string
+		command    string
+		cwd        string
+		args       []string
+		allowBroad bool
+		wantWarn   bool
+		wantReason searchGuardrailReason
+	}{
+		{
+			name:       "rg from root warns",
+			command:    "rg",
+			cwd:        "/",
+			wantWarn:   true,
+			wantReason: searchGuardrailBroadCWD,
+		},
+		{
+			name:       "find from mnt warns",
+			command:    "find",
+			cwd:        "/mnt",
+			wantWarn:   true,
+			wantReason: searchGuardrailBroadCWD,
+		},
+		{
+			name:       "grep from home user warns",
+			command:    "grep",
+			cwd:        "/home/dev",
+			wantWarn:   true,
+			wantReason: searchGuardrailBroadCWD,
+		},
+		{
+			name:       "search inside worktree is allowed",
+			command:    "rg",
+			cwd:        "/mnt/storage/worktrees/repo/sup-27/internal/worker",
+			wantReason: searchGuardrailNone,
+		},
+		{
+			name:       "explicit broad search path warns",
+			command:    "rg",
+			cwd:        worktree,
+			args:       []string{"guardrail", "/"},
+			wantWarn:   true,
+			wantReason: searchGuardrailBroadArg,
+		},
+		{
+			name:       "explicit allow suppresses warning",
+			command:    "rg",
+			cwd:        "/",
+			allowBroad: true,
+			wantReason: searchGuardrailAllowed,
+		},
+		{
+			name:       "non search command ignored",
+			command:    "go",
+			cwd:        "/",
+			wantReason: searchGuardrailNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifySearchGuardrail(tt.command, tt.cwd, worktree, tt.args, tt.allowBroad)
+			if got.Warn != tt.wantWarn || got.Reason != tt.wantReason {
+				t.Fatalf("classifySearchGuardrail() = %+v, want warn=%v reason=%s", got, tt.wantWarn, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestBuildWorkerRunnerScriptIncludesSearchGuardrails(t *testing.T) {
+	script := buildWorkerRunnerScript(
+		[]string{"codex", "exec", "-"},
+		"/tmp/prompt.md",
+		"/tmp/worker.log",
+		"/tmp/worktree",
+		"/tmp/state/search-guardrails",
+	)
+
+	for _, want := range []string{
+		"export MAESTRO_WORKTREE='/tmp/worktree'",
+		"export MAESTRO_SEARCH_GUARDRAIL_DIR='/tmp/state/search-guardrails'",
+		"export PATH=\"$MAESTRO_SEARCH_GUARDRAIL_DIR:$MAESTRO_ORIGINAL_PATH\"",
+		"cd \"$MAESTRO_WORKTREE\" || exit 1",
+		"[maestro] worker worktree:",
+		"exec codex exec - < '/tmp/prompt.md' 2>&1 | tee -a '/tmp/worker.log'",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("runner script missing %q\nscript:\n%s", want, script)
+		}
+	}
+}
+
+func TestEnsureSearchGuardrailWrappers(t *testing.T) {
+	guardDir, err := ensureSearchGuardrailWrappers(t.TempDir())
+	if err != nil {
+		t.Fatalf("ensureSearchGuardrailWrappers: %v", err)
+	}
+
+	for _, name := range searchGuardedCommands {
+		path := filepath.Join(guardDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("missing wrapper %s: %v", name, err)
+		}
+		if info.Mode()&0111 == 0 {
+			t.Fatalf("wrapper %s is not executable: %v", name, info.Mode())
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read wrapper %s: %v", name, err)
+		}
+		content := string(data)
+		for _, want := range []string{"MAESTRO_WORKTREE", "MAESTRO_ALLOW_BROAD_SEARCH", "broad filesystem"} {
+			if !strings.Contains(content, want) {
+				t.Fatalf("wrapper %s missing %q\n%s", name, want, content)
+			}
+		}
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -133,18 +133,8 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 
 	// Write runner script
 	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
-	var runnerContent string
-	if stdinFile != "" {
-		// Stdin-based backends (e.g. codex): redirect prompt file to stdin via shell
-		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s < %q 2>&1 | tee -a %q\n",
-			shellJoin(workerCmd.Args), stdinFile, logFile)
-	} else {
-		// Arg-based backends (e.g. claude): prompt is already in args
-		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s 2>&1 | tee -a %q\n",
-			shellJoin(workerCmd.Args), logFile)
-	}
-	if err := os.WriteFile(runnerPath, []byte(runnerContent), 0755); err != nil {
-		return "", fmt.Errorf("write runner script: %w", err)
+	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, worktreePath); err != nil {
+		return "", err
 	}
 
 	// Run before_run hook (fatal on failure)
@@ -279,16 +269,8 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 
 	// Write runner script
 	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
-	var runnerContent string
-	if stdinFile != "" {
-		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s < %q 2>&1 | tee -a %q\n",
-			shellJoin(workerCmd.Args), stdinFile, logFile)
-	} else {
-		runnerContent = fmt.Sprintf("#!/bin/bash\nexec %s 2>&1 | tee -a %q\n",
-			shellJoin(workerCmd.Args), logFile)
-	}
-	if err := os.WriteFile(runnerPath, []byte(runnerContent), 0755); err != nil {
-		return fmt.Errorf("write runner script: %w", err)
+	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, worktreePath); err != nil {
+		return err
 	}
 
 	// Run before_run hook (fatal on failure)
@@ -740,11 +722,15 @@ func shellJoin(args []string) string {
 	for i, a := range args {
 		// Simple quoting: wrap in single quotes, escape existing single quotes
 		if strings.ContainsAny(a, " \t\n'\"\\$`!#&|;(){}[]<>?*~") {
-			a = "'" + strings.ReplaceAll(a, "'", "'\\''") + "'"
+			a = shellQuote(a)
 		}
 		quoted[i] = a
 	}
 	return strings.Join(quoted, " ")
+}
+
+func shellQuote(arg string) string {
+	return "'" + strings.ReplaceAll(arg, "'", "'\\''") + "'"
 }
 
 func slugify(title string) string {
@@ -812,7 +798,7 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 		}
 
 		r := strings.NewReplacer(replacements...)
-		result := r.Replace(base)
+		result := r.Replace(base) + workerSearchSafetyPromptSection(worktreePath)
 		return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, contractInlined)
 	}
 
@@ -856,6 +842,7 @@ Always rebase on origin/main immediately before creating the PR.
 		issue.Title,
 		issue.Number,
 	)
+	result += workerSearchSafetyPromptSection(worktreePath)
 	return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, false)
 }
 

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -33,6 +33,24 @@ func TestAssemblePromptIncludesSecretSafetyGuardrails(t *testing.T) {
 	}
 }
 
+func TestAssemblePromptIncludesSearchSafetyGuardrails(t *testing.T) {
+	cfg := &config.Config{Repo: "BeFeast/maestro"}
+	issue := github.Issue{Number: 319, Title: "worker safety", Body: "Constrain broad searches."}
+
+	prompt := assemblePrompt("base prompt", issue, "/tmp/worktree", "feat/safety", cfg)
+
+	for _, want := range []string{
+		"## Worker Search Safety",
+		"The assigned worktree is `/tmp/worktree`",
+		"Do NOT run `rg`, `find`, or `grep` from broad filesystem roots such as `/`, `/mnt`, or `/home`.",
+		"MAESTRO_ALLOW_BROAD_SEARCH=1",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("assemblePrompt() missing %q\nprompt:\n%s", want, prompt)
+		}
+	}
+}
+
 // --- Tests from main: validation contract placeholder ---
 
 func TestAssemblePrompt_ValidationContractFromFile(t *testing.T) {


### PR DESCRIPTION
Closes #319

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR constrains worker filesystem searches to the assigned worktree by injecting `rg`/`find`/`grep` shell wrapper scripts into PATH via the runner script, and appending a search-safety prompt section to all worker and planner prompts. The runner-script generation is consolidated into a single `writeWorkerRunnerScript` helper used across `Start`, `Respawn`, `RespawnInPlace`, and `StartPhase`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; one minor edge case in the `find` arg parser but it requires non-standard invocation and does not affect the common path

All P2 findings; the only logic gap is the `find` expression-before-path bypass which requires deliberately non-standard argument ordering unlikely to be used by an AI agent in practice

internal/worker/search_guardrail.go — `maestro_check_find_args` early-return on `-*` tokens

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/search_guardrail.go | New file: shell wrapper scripts + Go helpers that enforce worktree-scoped searches; `find` arg parser has a minor bypass when expression flags precede path arguments |
| internal/worker/worker.go | Runner-script generation refactored into shared helper; search-safety prompt section appended to both legacy and template prompt paths |
| internal/worker/checkpoint.go | Inline runner-script generation replaced with `writeWorkerRunnerScript`; functionally identical, error propagation is unchanged |
| internal/worker/phase.go | Same refactor as checkpoint.go — delegates to `writeWorkerRunnerScript` |
| internal/worker/search_guardrail_test.go | Comprehensive integration tests for the shell wrapper; exercises allow-list, reject, CWD block, and explicit bypass scenarios |
| internal/pipeline/prompts.go | Search-safety section added to planner and validator prompt templates |
| internal/worker/worker_prompt_test.go | New test asserts that `assemblePrompt` emits the search-safety section |
| docs/gemini-backend.md | Docs updated to mention the new guardrail wrappers |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/worker/search_guardrail.go:225-227
**`find` guardrail exits early on first expression flag, missing later path arguments**

`maestro_check_find_args` returns 0 the moment it hits any unrecognised `-*` token. Standard `find` places all paths before the expression, so this is correct for the common case. However, GNU `find` accepts invocations like `find -name "*.go" /` (expression first, path last), and on those commands the function returns 0 before ever reaching the `/` argument — silently allowing a broad-root search. If an AI agent learns to front-load expression flags, the path check is fully bypassed. Accepting path arguments after a `-*` expression token (rather than stopping at the first expression flag) would close this gap.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix search guardrail argument parsing"](https://github.com/befeast/maestro/commit/c1e4e950ddeba86e07ad0cda90be99913f91aac9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30486988)</sub>

<!-- /greptile_comment -->