### PR TITLE
Dashboard: show review retry lifecycle as first-class state

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -796,13 +796,17 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 	for _, name := range names {
 		sess := s.Sessions[name]
 		alive := "-"
+		var alivePtr *bool
 		if sess.Status == state.StatusRunning {
-			if worker.IsAlive(sess.PID) {
+			isAlive := worker.IsAlive(sess.PID)
+			alivePtr = &isAlive
+			if isAlive {
 				alive = "yes"
 			} else {
 				alive = "no"
 			}
 		}
+		displayStatus := state.SessionDisplayStatusFor(sess, alivePtr)
 		age := time.Since(sess.StartedAt).Round(time.Minute)
 		retries := "-"
 		if sess.RetryCount > 0 {
@@ -827,7 +831,7 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 			backend = "-"
 		}
 		fmt.Fprintf(w, "%s\t#%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\n",
-			name, sess.IssueNumber, sess.Status, backend, pr, ci, sess.PID, alive, age, retries, tokens, truncate(sess.IssueTitle, 50))
+			name, sess.IssueNumber, displayStatus, backend, pr, ci, sess.PID, alive, age, retries, tokens, truncate(sess.IssueTitle, 50))
 	}
 	w.Flush()
 

--- a/docs/comparison-symphony-vs-maestro.md
+++ b/docs/comparison-symphony-vs-maestro.md
@@ -41,7 +41,7 @@ The PRD for Maestro's GitHub Project Integration proposes extracting a `tracker`
 | LLM-based auto-routing for backend selection | `gh` CLI shelling for every GitHub operation (process spawn overhead) |
 | Telegram notifications with digest mode | Sequential orchestration loop — no parallelism within a cycle |
 | Git worktree isolation (real branch per issue) | Config has Rust-specific defaults (`auto_resolve_files`) |
-| Rich session state (tokens, rate limits, silent detection, PID tracking) | No tracker abstraction — adding GitHub Projects requires touching orchestrator directly |
+| Rich session state (tokens, rate limits, silent detection, PID tracking, review retry lifecycle display) | No tracker abstraction — adding GitHub Projects requires touching orchestrator directly |
 | Persistent state across restarts via JSON file | State file grows indefinitely without automatic pruning |
 | Blocker detection via regex patterns in issue body | Workspace hook environment is minimal (no issue metadata beyond number) |
 | Per-state concurrency limits | No multi-turn agent support within a single worker session |

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -145,6 +145,10 @@ PR states to watch:
 |---|---|---|
 | `pr_open` | A worker opened a PR and Maestro is waiting for checks, review, mergeability, merge interval, or conflict handling | Monitor, do not spawn duplicate work for the same issue |
 | `queued` | A follow-up step or merge queue path is still pending | Check project dashboard and latest supervisor decision |
+| `review_retry_backoff` | Actionable review feedback scheduled an in-place retry and Maestro is waiting for backoff | Wait for the scheduled retry worker unless the feedback should be handled manually |
+| `review_retry_pending` | Backoff elapsed and Maestro is waiting for an available retry worker slot | Wait for the next orchestration cycle or free a worker slot |
+| `review_retry_running` | The retry worker is updating the existing PR in place | Wait for the worker to finish and push updates |
+| `review_retry_recheck` | The retry updated the PR and Maestro is waiting for CI, Greptile, or the merge gate | Monitor checks/review; Maestro will merge when gates allow it |
 | `greptile_pending` stuck state | Greptile has not finished | Wait or check the GitHub PR/check run if it remains pending unusually long |
 | `greptile_not_approved` stuck state | Greptile review found actionable feedback or no approval | Address feedback, allow the configured retry path, or make a deliberate project policy change |
 | `failing_checks` stuck state | Required checks failed | Inspect the check failure, retry intentionally if budget remains, or fix manually |

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -637,6 +637,9 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 			if sess.PreviousAttemptFeedbackKind == "rebase_conflict" {
 				promptBase = appendRebaseConflictContext(promptBase, sess.PreviousAttemptFeedback)
 			} else {
+				if sess.PreviousAttemptFeedbackKind == state.RetryReasonReviewFeedback {
+					sess.RetryReason = state.RetryReasonReviewFeedback
+				}
 				promptBase = appendReviewFeedbackContext(promptBase, sess.PreviousAttemptFeedback)
 			}
 			sess.PreviousAttemptFeedback = "" // consumed — don't persist stale feedback
@@ -1724,7 +1727,8 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 
 	sess.CIFailureOutput = ""
 	sess.PreviousAttemptFeedback = reviewFeedback
-	sess.PreviousAttemptFeedbackKind = "review_feedback"
+	sess.PreviousAttemptFeedbackKind = state.RetryReasonReviewFeedback
+	sess.RetryReason = state.RetryReasonReviewFeedback
 
 	sess.RetryCount++
 	backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -288,6 +288,7 @@ type fleetWorkerState struct {
 	IssueTitle        string          `json:"issue_title"`
 	IssueURL          string          `json:"issue_url,omitempty"`
 	Status            string          `json:"status"`
+	DisplayStatus     string          `json:"display_status,omitempty"`
 	StatusReason      string          `json:"status_reason,omitempty"`
 	NextAction        string          `json:"next_action,omitempty"`
 	NeedsAttention    bool            `json:"needs_attention,omitempty"`
@@ -731,6 +732,9 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 }
 
 func isFleetWorkerVisible(worker sessionInfo) bool {
+	if worker.DisplayStatus != "" && worker.DisplayStatus != worker.Status {
+		return true
+	}
 	if worker.Status == string(state.StatusRunning) || worker.Status == string(state.StatusPROpen) || worker.NeedsAttention {
 		return true
 	}
@@ -751,6 +755,7 @@ func makeFleetWorkerState(project fleetProjectState, worker sessionInfo) fleetWo
 		IssueTitle:        worker.IssueTitle,
 		IssueURL:          worker.IssueURL,
 		Status:            worker.Status,
+		DisplayStatus:     worker.DisplayStatus,
 		StatusReason:      worker.StatusReason,
 		NextAction:        worker.NextAction,
 		NeedsAttention:    worker.NeedsAttention,
@@ -1468,9 +1473,11 @@ const fleetDashboardHTML = `<!DOCTYPE html>
     vertical-align: middle;
     white-space: nowrap;
   }
-  .s-running { color: var(--ok); border-color: rgba(63,185,80,.45); }
+  .s-running, .s-review_retry_running { color: var(--ok); border-color: rgba(63,185,80,.45); }
   .s-pr_open { color: var(--accent); border-color: rgba(88,166,255,.45); }
   .s-done { color: var(--ok); border-color: rgba(63,185,80,.45); }
+  .s-review_retry_backoff, .s-review_retry_pending { color: var(--queued); border-color: rgba(163,113,247,.5); }
+  .s-review_retry_recheck { color: var(--accent); border-color: rgba(88,166,255,.45); }
   .s-dead, .s-failed, .s-conflict_failed, .s-retry_exhausted { color: var(--bad); border-color: rgba(248,81,73,.45); }
   .a-pending { color: var(--warn); border-color: rgba(210,153,34,.55); background: rgba(210,153,34,.08); }
   .a-stale { color: var(--muted); border-color: rgba(139,148,158,.45); background: rgba(139,148,158,.08); }
@@ -1672,8 +1679,12 @@ const defaultSortDirections = { status: "asc", project: "asc", issue: "asc", run
 const validSortKeys = new Set(["status", "project", "issue", "runtime", "pr"]);
 const validSortDirs = new Set(["asc", "desc"]);
 const statusOrder = new Map([
+  ["review_retry_running", 0],
   ["running", 0],
+  ["review_retry_recheck", 1],
   ["pr_open", 1],
+  ["review_retry_pending", 2],
+  ["review_retry_backoff", 2],
   ["queued", 2],
   ["dead", 3],
   ["failed", 4],
@@ -2022,7 +2033,7 @@ function selectOptionsHTML(allLabel, values, selectedValue) {
 }
 
 function renderFilterOptions() {
-  statusFilterEl.innerHTML = selectOptionsHTML("All statuses", uniqueSorted((fleetState.workers || []).map(worker => worker.status)), fleetState.filters.status);
+  statusFilterEl.innerHTML = selectOptionsHTML("All statuses", uniqueSorted((fleetState.workers || []).map(displayStatus)), fleetState.filters.status);
   backendFilterEl.innerHTML = selectOptionsHTML("All backends", uniqueSorted((fleetState.workers || []).map(worker => worker.backend)), fleetState.filters.backend);
 }
 
@@ -2051,6 +2062,7 @@ function workerSearchText(worker) {
     issueNumber ? "#" + issueNumber : "",
     worker.issue_title,
     worker.status,
+    displayStatus(worker),
     statusLabel(worker),
     worker.backend,
     prNumber,
@@ -2060,7 +2072,7 @@ function workerSearchText(worker) {
 }
 
 function workerMatchesFilters(worker) {
-  if (fleetState.filters.status !== "all" && worker.status !== fleetState.filters.status) return false;
+  if (fleetState.filters.status !== "all" && displayStatus(worker) !== fleetState.filters.status) return false;
   if (fleetState.filters.backend !== "all" && (worker.backend || "") !== fleetState.filters.backend) return false;
   if (fleetState.filters.pr === "with" && !worker.pr_number) return false;
   if (fleetState.filters.pr === "without" && worker.pr_number) return false;
@@ -2092,7 +2104,8 @@ function workerNeedsAttention(worker) {
 
 function statusRank(worker) {
   const attention = workerNeedsAttention(worker) ? 0 : 1;
-  const rank = statusOrder.has(worker.status) ? statusOrder.get(worker.status) : 99;
+  const displayed = displayStatus(worker);
+  const rank = statusOrder.has(displayed) ? statusOrder.get(displayed) : 99;
   return attention * 100 + rank;
 }
 
@@ -2141,21 +2154,26 @@ function sortWorkers(workers) {
     .map(entry => entry.worker);
 }
 
+function displayStatus(worker) {
+  return worker.display_status || worker.status || "-";
+}
+
 function statusLabel(worker) {
   if (worker.status === "running" && worker.alive === false) return "running stale";
-  return worker.status || "-";
+  return displayStatus(worker);
 }
 
 function statusClass(worker) {
-  let cls = "pill s-" + escapeText(worker.status || "unknown");
+  let cls = "pill s-" + cssToken(displayStatus(worker) || "unknown");
   if (worker.needs_attention || (worker.status === "running" && worker.alive === false)) cls += " attention";
   return cls;
 }
 
 function rowClass(worker) {
   if (worker.needs_attention || (worker.status === "running" && worker.alive === false)) return "row-attention";
-  if (worker.status === "running") return "row-running";
-  if (worker.status === "pr_open") return "row-pr";
+  const displayed = displayStatus(worker);
+  if (worker.status === "running" || displayed === "review_retry_running") return "row-running";
+  if (worker.status === "pr_open" || displayed === "review_retry_recheck") return "row-pr";
   return "";
 }
 
@@ -2169,7 +2187,7 @@ function workerWhyText(worker) {
 }
 
 function workerWhyHTML(worker) {
-  if (!worker.needs_attention && worker.status === "running") return "";
+  if (!worker.needs_attention && displayStatus(worker) === "running") return "";
   const why = workerWhyText(worker);
   if (!why) return "";
   return '<div class="why-line"><strong>Why:</strong> ' + escapeText(why) + '</div>';
@@ -2185,7 +2203,7 @@ function startedAtMillis(worker) {
 }
 
 function attentionSeverityRank(worker) {
-  const text = [worker.status, worker.status_reason, worker.next_action].map(normalizedSearchText).join(" ");
+  const text = [displayStatus(worker), worker.status, worker.status_reason, worker.next_action].map(normalizedSearchText).join(" ");
   if (text.includes("blocked") || ["dead", "failed", "conflict_failed", "retry_exhausted"].includes(worker.status)) return 0;
   if (worker.status === "running") return 1;
   if (worker.status === "pr_open" || worker.status === "queued") return 2;

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -175,6 +175,71 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	}
 }
 
+func TestFleetAPIReviewRetryLifecycleDisplay(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	retryAt := now.Add(10 * time.Minute)
+	stateDir := filepath.Join(dir, "review-retry")
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"retry-backoff": {
+			IssueNumber:                 42,
+			IssueTitle:                  "Address review feedback",
+			Status:                      state.StatusDead,
+			StartedAt:                   now.Add(-20 * time.Minute),
+			FinishedAt:                  &now,
+			PRNumber:                    12,
+			RetryCount:                  1,
+			NextRetryAt:                 &retryAt,
+			PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		},
+		"retry-recheck": {
+			IssueNumber: 43,
+			IssueTitle:  "Wait for recheck",
+			Status:      state.StatusPROpen,
+			StartedAt:   now.Add(-30 * time.Minute),
+			PRNumber:    13,
+			RetryCount:  1,
+			RetryReason: state.RetryReasonReviewFeedback,
+		},
+	})
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("ReviewRetry", "/tmp/review-retry.yaml", "", &config.Config{
+			Repo:        "owner/review-retry",
+			StateDir:    stateDir,
+			MaxParallel: 2,
+		}),
+	}, "127.0.0.1", 8786, true)
+	resp := srv.snapshot()
+
+	backoff := findFleetWorker(t, resp.Workers, "retry-backoff")
+	if backoff.DisplayStatus != string(state.DisplayReviewRetryBackoff) {
+		t.Fatalf("backoff display_status = %q, want review retry backoff", backoff.DisplayStatus)
+	}
+	if backoff.NeedsAttention {
+		t.Fatal("review retry backoff should not need fleet attention")
+	}
+	if !contains(backoff.StatusReason, "waiting for the retry backoff") || !contains(backoff.NextAction, "scheduled retry worker") {
+		t.Fatalf("backoff why = %q / %q, want retry worker wording", backoff.StatusReason, backoff.NextAction)
+	}
+
+	recheck := findFleetWorker(t, resp.Workers, "retry-recheck")
+	if recheck.DisplayStatus != string(state.DisplayReviewRetryRecheck) {
+		t.Fatalf("recheck display_status = %q, want review retry recheck", recheck.DisplayStatus)
+	}
+	if !contains(recheck.StatusReason, "waiting for CI, Greptile, or the merge gate") {
+		t.Fatalf("recheck status_reason = %q, want CI/Greptile/merge gate wording", recheck.StatusReason)
+	}
+
+	project := findFleetProject(t, resp.Projects, "ReviewRetry")
+	if project.Failed != 0 || resp.Summary.Failed != 0 {
+		t.Fatalf("failed counts = project %d fleet %d, want review retry excluded", project.Failed, resp.Summary.Failed)
+	}
+	if project.NeedsAttention != 0 || resp.Summary.NeedsAttention != 0 {
+		t.Fatalf("attention counts = project %d fleet %d, want none", project.NeedsAttention, resp.Summary.NeedsAttention)
+	}
+}
+
 func TestFleetAPIIncludesQueueSnapshotMetadata(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now().UTC()

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -191,6 +191,7 @@ func TestFleetAPIReviewRetryLifecycleDisplay(t *testing.T) {
 			RetryCount:                  1,
 			NextRetryAt:                 &retryAt,
 			PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+			RetryReason:                 state.RetryReasonReviewFeedback,
 		},
 		"retry-recheck": {
 			IssueNumber: 43,
@@ -200,6 +201,17 @@ func TestFleetAPIReviewRetryLifecycleDisplay(t *testing.T) {
 			PRNumber:    13,
 			RetryCount:  1,
 			RetryReason: state.RetryReasonReviewFeedback,
+		},
+		"ci-retry": {
+			IssueNumber:                 44,
+			IssueTitle:                  "Retry failing checks",
+			Status:                      state.StatusDead,
+			StartedAt:                   now.Add(-40 * time.Minute),
+			FinishedAt:                  &now,
+			RetryCount:                  1,
+			NextRetryAt:                 &retryAt,
+			PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+			CIFailureOutput:             "checks failed",
 		},
 	})
 
@@ -230,13 +242,20 @@ func TestFleetAPIReviewRetryLifecycleDisplay(t *testing.T) {
 	if !contains(recheck.StatusReason, "waiting for CI, Greptile, or the merge gate") {
 		t.Fatalf("recheck status_reason = %q, want CI/Greptile/merge gate wording", recheck.StatusReason)
 	}
+	ciRetry := findFleetWorker(t, resp.Workers, "ci-retry")
+	if ciRetry.DisplayStatus != "" {
+		t.Fatalf("ci retry display_status = %q, want raw dead state", ciRetry.DisplayStatus)
+	}
+	if !ciRetry.NeedsAttention || !contains(ciRetry.StatusReason, "retry is scheduled") {
+		t.Fatalf("ci retry why = %q / attention %v, want dead retry guidance", ciRetry.StatusReason, ciRetry.NeedsAttention)
+	}
 
 	project := findFleetProject(t, resp.Projects, "ReviewRetry")
-	if project.Failed != 0 || resp.Summary.Failed != 0 {
-		t.Fatalf("failed counts = project %d fleet %d, want review retry excluded", project.Failed, resp.Summary.Failed)
+	if project.Failed != 1 || resp.Summary.Failed != 1 {
+		t.Fatalf("failed counts = project %d fleet %d, want only CI retry counted", project.Failed, resp.Summary.Failed)
 	}
-	if project.NeedsAttention != 0 || resp.Summary.NeedsAttention != 0 {
-		t.Fatalf("attention counts = project %d fleet %d, want none", project.NeedsAttention, resp.Summary.NeedsAttention)
+	if project.NeedsAttention != 1 || resp.Summary.NeedsAttention != 1 {
+		t.Fatalf("attention counts = project %d fleet %d, want only CI retry attention", project.NeedsAttention, resp.Summary.NeedsAttention)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -206,6 +206,7 @@ type sessionInfo struct {
 	IssueTitle        string          `json:"issue_title"`
 	IssueURL          string          `json:"issue_url,omitempty"`
 	Status            string          `json:"status"`
+	DisplayStatus     string          `json:"display_status,omitempty"`
 	StatusReason      string          `json:"status_reason,omitempty"`
 	NextAction        string          `json:"next_action,omitempty"`
 	NeedsAttention    bool            `json:"needs_attention,omitempty"`
@@ -270,6 +271,9 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 		info.NextRetryAt = sess.NextRetryAt.Format(time.RFC3339)
 	}
 	attention := state.SessionAttentionFor(sess, info.Alive)
+	if displayStatus := state.SessionDisplayStatusFor(sess, info.Alive); displayStatus != "" && displayStatus != info.Status {
+		info.DisplayStatus = displayStatus
+	}
 	info.StatusReason = attention.Reason
 	info.NextAction = attention.NextAction
 	info.NeedsAttention = attention.NeedsAttention
@@ -630,7 +634,11 @@ func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 	var activeTokens, totalTokens int
 	for _, info := range sessionInfosWithActions(cfg.Repo, st, cfg.Server.ReadOnly, "/api/v1/actions") {
 		resp.All = append(resp.All, info)
-		resp.Summary[info.Status]++
+		summaryStatus := info.Status
+		if info.DisplayStatus != "" {
+			summaryStatus = info.DisplayStatus
+		}
+		resp.Summary[summaryStatus]++
 		totalTokens += info.TokensUsedTotal
 
 		switch state.SessionStatus(info.Status) {
@@ -1067,9 +1075,11 @@ const dashboardHTML = `<!DOCTYPE html>
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .s-running { color: var(--ok); border-color: rgba(63,185,80,.42); }
+  .s-running, .s-review_retry_running { color: var(--ok); border-color: rgba(63,185,80,.42); }
   .s-pr_open { color: var(--warn); border-color: rgba(210,153,34,.48); }
   .s-queued { color: var(--queued); border-color: rgba(163,113,247,.5); }
+  .s-review_retry_backoff, .s-review_retry_pending { color: var(--queued); border-color: rgba(163,113,247,.5); }
+  .s-review_retry_recheck { color: var(--warn); border-color: rgba(210,153,34,.48); }
   .s-dead, .s-failed, .s-conflict_failed, .s-retry_exhausted { color: var(--bad); border-color: rgba(248,81,73,.5); }
   .s-done { color: var(--muted); }
   .pill-attention { color: var(--bad); border-color: rgba(248,81,73,.58); }
@@ -1259,8 +1269,12 @@ const state = {
 };
 
 const statusRank = {
+  review_retry_running: 0,
   running: 0,
+  review_retry_recheck: 1,
   pr_open: 1,
+  review_retry_pending: 2,
+  review_retry_backoff: 2,
   queued: 2,
   dead: 3,
   failed: 4,
@@ -1393,13 +1407,17 @@ function queueText(queue) {
   return label + ": empty";
 }
 
+function displayStatus(worker) {
+  return worker.display_status || worker.status || "-";
+}
+
 function statusLabel(worker) {
   if (worker.status === "running" && worker.alive === false) return "running stale";
-  return worker.status || "-";
+  return displayStatus(worker);
 }
 
 function pillClass(worker) {
-  const base = "pill s-" + escapeText(worker.status || "unknown");
+  const base = "pill s-" + escapeText(displayStatus(worker) || "unknown");
   if (worker.needs_attention || (worker.status === "running" && worker.alive === false)) {
     return base + " pill-attention";
   }
@@ -1408,7 +1426,7 @@ function pillClass(worker) {
 
 function workerMatches(worker) {
   if (!state.filter) return true;
-  const text = [worker.slot, worker.issue_number, worker.issue_title, worker.status, worker.backend, worker.pr_number]
+  const text = [worker.slot, worker.issue_number, worker.issue_title, worker.status, displayStatus(worker), worker.backend, worker.pr_number]
     .join(" ")
     .toLowerCase();
   return text.includes(state.filter);
@@ -1416,16 +1434,16 @@ function workerMatches(worker) {
 
 function sortWorkers(workers) {
   return [...workers].sort((a, b) => {
-    const ar = statusRank[a.status] ?? 99;
-    const br = statusRank[b.status] ?? 99;
+    const ar = statusRank[displayStatus(a)] ?? 99;
+    const br = statusRank[displayStatus(b)] ?? 99;
     if (ar !== br) return ar - br;
     return String(b.started_at || "").localeCompare(String(a.started_at || ""));
   });
 }
 
 function renderStats(summary, total, maxParallel, readOnly) {
-  const running = summary.running || 0;
-  const prOpen = summary.pr_open || 0;
+  const running = (summary.running || 0) + (summary.review_retry_running || 0);
+  const prOpen = (summary.pr_open || 0) + (summary.review_retry_recheck || 0);
   const failed = (summary.dead || 0) + (summary.failed || 0) + (summary.retry_exhausted || 0) + (summary.conflict_failed || 0);
   const items = [
     ["Running", running + " / " + maxParallel],

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -192,6 +192,7 @@ func TestHandleStateReviewRetryLifecycleDisplay(t *testing.T) {
 		RetryCount:                  1,
 		NextRetryAt:                 &retryAt,
 		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		RetryReason:                 state.RetryReasonReviewFeedback,
 	}
 	st.Sessions["slot-recheck"] = &state.Session{
 		IssueNumber: 43,
@@ -201,6 +202,17 @@ func TestHandleStateReviewRetryLifecycleDisplay(t *testing.T) {
 		PRNumber:    13,
 		RetryCount:  1,
 		RetryReason: state.RetryReasonReviewFeedback,
+	}
+	st.Sessions["slot-ci-retry"] = &state.Session{
+		IssueNumber:                 44,
+		IssueTitle:                  "Retry failing checks",
+		Status:                      state.StatusDead,
+		StartedAt:                   now.Add(-40 * time.Minute),
+		FinishedAt:                  &now,
+		RetryCount:                  1,
+		NextRetryAt:                 &retryAt,
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		CIFailureOutput:             "checks failed",
 	}
 	if err := state.Save(dir, st); err != nil {
 		t.Fatalf("save state: %v", err)
@@ -224,8 +236,15 @@ func TestHandleStateReviewRetryLifecycleDisplay(t *testing.T) {
 	if !contains(recheck.StatusReason, "waiting for CI, Greptile, or the merge gate") {
 		t.Fatalf("recheck status_reason = %q, want CI/Greptile/merge gate wording", recheck.StatusReason)
 	}
-	if resp.Summary[string(state.StatusDead)] != 0 {
-		t.Fatalf("summary dead = %d, want review retry excluded from dead count", resp.Summary[string(state.StatusDead)])
+	ciRetry := findSessionInfo(t, resp.All, "slot-ci-retry")
+	if ciRetry.DisplayStatus != "" {
+		t.Fatalf("ci retry display_status = %q, want raw dead state", ciRetry.DisplayStatus)
+	}
+	if !ciRetry.NeedsAttention || !contains(ciRetry.StatusReason, "retry is scheduled") {
+		t.Fatalf("ci retry why = %q / attention %v, want dead retry guidance", ciRetry.StatusReason, ciRetry.NeedsAttention)
+	}
+	if resp.Summary[string(state.StatusDead)] != 1 {
+		t.Fatalf("summary dead = %d, want CI retry counted as dead", resp.Summary[string(state.StatusDead)])
 	}
 	if resp.Summary[string(state.DisplayReviewRetryBackoff)] != 1 {
 		t.Fatalf("summary review_retry_backoff = %d, want 1", resp.Summary[string(state.DisplayReviewRetryBackoff)])

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -172,6 +172,66 @@ func TestHandleState(t *testing.T) {
 	}
 }
 
+func TestHandleStateReviewRetryLifecycleDisplay(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:        "test/repo",
+		MaxParallel: 3,
+		StateDir:    dir,
+	}
+	now := time.Now().UTC()
+	retryAt := now.Add(10 * time.Minute)
+	st := state.NewState()
+	st.Sessions["slot-backoff"] = &state.Session{
+		IssueNumber:                 42,
+		IssueTitle:                  "Address review feedback",
+		Status:                      state.StatusDead,
+		StartedAt:                   now.Add(-20 * time.Minute),
+		FinishedAt:                  &now,
+		PRNumber:                    12,
+		RetryCount:                  1,
+		NextRetryAt:                 &retryAt,
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+	}
+	st.Sessions["slot-recheck"] = &state.Session{
+		IssueNumber: 43,
+		IssueTitle:  "Wait for recheck",
+		Status:      state.StatusPROpen,
+		StartedAt:   now.Add(-30 * time.Minute),
+		PRNumber:    13,
+		RetryCount:  1,
+		RetryReason: state.RetryReasonReviewFeedback,
+	}
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	resp := buildStateResponse(cfg, st)
+	backoff := findSessionInfo(t, resp.All, "slot-backoff")
+	if backoff.DisplayStatus != string(state.DisplayReviewRetryBackoff) {
+		t.Fatalf("backoff display_status = %q, want review retry backoff", backoff.DisplayStatus)
+	}
+	if backoff.NeedsAttention {
+		t.Fatal("review retry backoff should not need attention")
+	}
+	if !contains(backoff.StatusReason, "waiting for the retry backoff") || !contains(backoff.NextAction, "scheduled retry worker") {
+		t.Fatalf("backoff why = %q / %q, want retry worker wording", backoff.StatusReason, backoff.NextAction)
+	}
+	recheck := findSessionInfo(t, resp.All, "slot-recheck")
+	if recheck.DisplayStatus != string(state.DisplayReviewRetryRecheck) {
+		t.Fatalf("recheck display_status = %q, want review retry recheck", recheck.DisplayStatus)
+	}
+	if !contains(recheck.StatusReason, "waiting for CI, Greptile, or the merge gate") {
+		t.Fatalf("recheck status_reason = %q, want CI/Greptile/merge gate wording", recheck.StatusReason)
+	}
+	if resp.Summary[string(state.StatusDead)] != 0 {
+		t.Fatalf("summary dead = %d, want review retry excluded from dead count", resp.Summary[string(state.StatusDead)])
+	}
+	if resp.Summary[string(state.DisplayReviewRetryBackoff)] != 1 {
+		t.Fatalf("summary review_retry_backoff = %d, want 1", resp.Summary[string(state.DisplayReviewRetryBackoff)])
+	}
+}
+
 func TestHandleState_ReadOnlyActionsDisabled(t *testing.T) {
 	srv, cfg := setupTestServer(t)
 	cfg.Server.ReadOnly = true

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -28,6 +28,17 @@ const (
 	StatusRetryExhausted SessionStatus = "retry_exhausted" // max retries reached, needs manual review
 )
 
+type SessionDisplayStatus string
+
+const (
+	DisplayReviewRetryBackoff SessionDisplayStatus = "review_retry_backoff"
+	DisplayReviewRetryPending SessionDisplayStatus = "review_retry_pending"
+	DisplayReviewRetryRunning SessionDisplayStatus = "review_retry_running"
+	DisplayReviewRetryRecheck SessionDisplayStatus = "review_retry_recheck"
+)
+
+const RetryReasonReviewFeedback = "review_feedback"
+
 // Phase represents which pipeline phase a session is currently in.
 type Phase string
 
@@ -69,6 +80,7 @@ type Session struct {
 	CIFailureOutput             string        `json:"ci_failure_output,omitempty"`              // CI failure output captured before retry (passed to next worker as context)
 	PreviousAttemptFeedback     string        `json:"previous_attempt_feedback,omitempty"`      // feedback from previous failed PR attempt
 	PreviousAttemptFeedbackKind string        `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
+	RetryReason                 string        `json:"retry_reason,omitempty"`                   // current retry lifecycle reason, e.g. review_feedback
 	CheckpointFile              string        `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
 }
 
@@ -84,8 +96,16 @@ type SessionAttention struct {
 // The alive pointer should be provided only when the caller has checked the
 // recorded running process.
 func SessionAttentionFor(sess *Session, alive *bool) SessionAttention {
+	return SessionAttentionForAt(sess, alive, time.Now().UTC())
+}
+
+// SessionAttentionForAt is SessionAttentionFor with an explicit clock for tests.
+func SessionAttentionForAt(sess *Session, alive *bool, now time.Time) SessionAttention {
 	if sess == nil {
 		return SessionAttention{}
+	}
+	if attention, ok := reviewFeedbackRetryAttention(sess, alive, now); ok {
+		return attention
 	}
 
 	switch sess.Status {
@@ -107,7 +127,10 @@ func SessionAttentionFor(sess *Session, alive *bool) SessionAttention {
 		return SessionAttention{Reason: "Worker process is alive and writing to its session log."}
 	case StatusPROpen:
 		if sess.PRNumber > 0 {
-			return SessionAttention{Reason: "PR is open; Maestro is waiting for CI, review gate, merge interval, or conflict handling."}
+			return SessionAttention{
+				Reason:     fmt.Sprintf("PR #%d is open; Maestro is waiting for CI, Greptile review, or the merge gate.", sess.PRNumber),
+				NextAction: "Wait for checks and review gates to pass; Maestro will merge when the merge gate allows it.",
+			}
 		}
 		return SessionAttention{
 			Reason:         "Session is waiting on an open PR, but no PR number is recorded yet.",
@@ -115,7 +138,10 @@ func SessionAttentionFor(sess *Session, alive *bool) SessionAttention {
 			NeedsAttention: true,
 		}
 	case StatusQueued:
-		return SessionAttention{Reason: "Worker is queued for follow-up processing before it can be merged."}
+		return SessionAttention{
+			Reason:     "Worker follow-up is queued; Maestro is waiting for CI, Greptile, or the merge gate before merging.",
+			NextAction: "Wait for the queued PR checks and merge gate to clear.",
+		}
 	case StatusDead:
 		if sess.NextRetryAt != nil {
 			return SessionAttention{
@@ -166,6 +192,87 @@ func SessionAttentionFor(sess *Session, alive *bool) SessionAttention {
 	default:
 		return SessionAttention{Reason: "Session is waiting for the next Maestro reconciliation cycle."}
 	}
+}
+
+// SessionDisplayStatusFor returns the status token dashboards should display.
+func SessionDisplayStatusFor(sess *Session, alive *bool) string {
+	return SessionDisplayStatusForAt(sess, alive, time.Now().UTC())
+}
+
+// SessionDisplayStatusForAt is SessionDisplayStatusFor with an explicit clock for tests.
+func SessionDisplayStatusForAt(sess *Session, alive *bool, now time.Time) string {
+	if sess == nil {
+		return ""
+	}
+	if sess.Status == StatusRunning && alive != nil && !*alive {
+		return string(sess.Status)
+	}
+	if display := reviewFeedbackRetryDisplayStatus(sess, now); display != "" {
+		return string(display)
+	}
+	return string(sess.Status)
+}
+
+func reviewFeedbackRetryAttention(sess *Session, alive *bool, now time.Time) (SessionAttention, bool) {
+	if sess == nil || (sess.Status == StatusRunning && alive != nil && !*alive) {
+		return SessionAttention{}, false
+	}
+	switch reviewFeedbackRetryDisplayStatus(sess, now) {
+	case DisplayReviewRetryBackoff:
+		return SessionAttention{
+			Reason:     "Review feedback retry is scheduled; Maestro is waiting for the retry backoff before starting the in-place retry worker.",
+			NextAction: "Wait for the scheduled retry worker to start, or inspect the review feedback if it should not retry.",
+		}, true
+	case DisplayReviewRetryPending:
+		return SessionAttention{
+			Reason:     "Review feedback retry is ready; Maestro is waiting for an available retry worker slot.",
+			NextAction: "Wait for the retry worker to start in the next orchestration cycle.",
+		}, true
+	case DisplayReviewRetryRunning:
+		return SessionAttention{
+			Reason:     "Review feedback retry worker is running; Maestro is updating the existing PR in place.",
+			NextAction: "Wait for the retry worker to finish and push updates to the PR.",
+		}, true
+	case DisplayReviewRetryRecheck:
+		return SessionAttention{
+			Reason:     "Review feedback retry updated the PR; Maestro is waiting for CI, Greptile, or the merge gate to recheck it.",
+			NextAction: "Wait for checks and review gates to pass; Maestro will merge when the merge gate allows it.",
+		}, true
+	default:
+		return SessionAttention{}, false
+	}
+}
+
+func reviewFeedbackRetryDisplayStatus(sess *Session, now time.Time) SessionDisplayStatus {
+	if !hasReviewFeedbackRetry(sess) {
+		return ""
+	}
+	switch sess.Status {
+	case StatusDead:
+		if sess.NextRetryAt == nil {
+			return ""
+		}
+		if now.IsZero() {
+			now = time.Now().UTC()
+		}
+		if now.Before(*sess.NextRetryAt) {
+			return DisplayReviewRetryBackoff
+		}
+		return DisplayReviewRetryPending
+	case StatusRunning:
+		return DisplayReviewRetryRunning
+	case StatusPROpen, StatusQueued:
+		return DisplayReviewRetryRecheck
+	default:
+		return ""
+	}
+}
+
+func hasReviewFeedbackRetry(sess *Session) bool {
+	if sess == nil {
+		return false
+	}
+	return strings.TrimSpace(sess.RetryReason) == RetryReasonReviewFeedback || strings.TrimSpace(sess.PreviousAttemptFeedbackKind) == RetryReasonReviewFeedback
 }
 
 func sessionHasFailedCheckEvidence(sess *Session) bool {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -272,7 +272,7 @@ func hasReviewFeedbackRetry(sess *Session) bool {
 	if sess == nil {
 		return false
 	}
-	return strings.TrimSpace(sess.RetryReason) == RetryReasonReviewFeedback || strings.TrimSpace(sess.PreviousAttemptFeedbackKind) == RetryReasonReviewFeedback
+	return strings.TrimSpace(sess.RetryReason) == RetryReasonReviewFeedback
 }
 
 func sessionHasFailedCheckEvidence(sess *Session) bool {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -784,6 +784,136 @@ func TestSessionAttentionFor_RunningWorkerAliveDoesNotNeedAttention(t *testing.T
 	}
 }
 
+func TestSessionDisplayStatusFor_ReviewFeedbackRetryLifecycle(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	future := now.Add(5 * time.Minute)
+	past := now.Add(-time.Minute)
+	alive := true
+
+	tests := []struct {
+		name string
+		sess *Session
+		want string
+	}{
+		{
+			name: "backoff",
+			sess: &Session{
+				Status:                      StatusDead,
+				NextRetryAt:                 &future,
+				PreviousAttemptFeedbackKind: RetryReasonReviewFeedback,
+			},
+			want: string(DisplayReviewRetryBackoff),
+		},
+		{
+			name: "pending retry worker",
+			sess: &Session{
+				Status:                      StatusDead,
+				NextRetryAt:                 &past,
+				PreviousAttemptFeedbackKind: RetryReasonReviewFeedback,
+			},
+			want: string(DisplayReviewRetryPending),
+		},
+		{
+			name: "running retry worker",
+			sess: &Session{
+				Status:      StatusRunning,
+				PID:         1234,
+				RetryReason: RetryReasonReviewFeedback,
+			},
+			want: string(DisplayReviewRetryRunning),
+		},
+		{
+			name: "pending recheck",
+			sess: &Session{
+				Status:      StatusPROpen,
+				PRNumber:    12,
+				RetryReason: RetryReasonReviewFeedback,
+			},
+			want: string(DisplayReviewRetryRecheck),
+		},
+		{
+			name: "genuine dead remains dead",
+			sess: &Session{Status: StatusDead},
+			want: string(StatusDead),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SessionDisplayStatusForAt(tt.sess, &alive, now)
+			if got != tt.want {
+				t.Fatalf("display status = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionDisplayStatusFor_StaleReviewRetryWorkerStaysRunning(t *testing.T) {
+	alive := false
+	sess := &Session{
+		Status:      StatusRunning,
+		PID:         999999,
+		RetryReason: RetryReasonReviewFeedback,
+	}
+
+	got := SessionDisplayStatusForAt(sess, &alive, time.Now().UTC())
+	if got != string(StatusRunning) {
+		t.Fatalf("display status = %q, want raw running for stale worker", got)
+	}
+	attention := SessionAttentionForAt(sess, &alive, time.Now().UTC())
+	if !attention.NeedsAttention || !containsString(attention.Reason, "PID is not alive") {
+		t.Fatalf("attention = %+v, want stale PID attention", attention)
+	}
+}
+
+func TestSessionAttentionFor_ReviewFeedbackRetryCopy(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	future := now.Add(5 * time.Minute)
+
+	tests := []struct {
+		name       string
+		sess       *Session
+		wantReason string
+		wantAction string
+	}{
+		{
+			name: "backoff",
+			sess: &Session{
+				Status:                      StatusDead,
+				NextRetryAt:                 &future,
+				PreviousAttemptFeedbackKind: RetryReasonReviewFeedback,
+			},
+			wantReason: "waiting for the retry backoff",
+			wantAction: "scheduled retry worker",
+		},
+		{
+			name: "pending recheck",
+			sess: &Session{
+				Status:      StatusPROpen,
+				PRNumber:    12,
+				RetryReason: RetryReasonReviewFeedback,
+			},
+			wantReason: "waiting for CI, Greptile, or the merge gate",
+			wantAction: "merge gate allows it",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attention := SessionAttentionForAt(tt.sess, nil, now)
+			if attention.NeedsAttention {
+				t.Fatalf("review retry lifecycle should not need attention: %+v", attention)
+			}
+			if !containsString(attention.Reason, tt.wantReason) {
+				t.Fatalf("reason = %q, want %q", attention.Reason, tt.wantReason)
+			}
+			if !containsString(attention.NextAction, tt.wantAction) {
+				t.Fatalf("next action = %q, want %q", attention.NextAction, tt.wantAction)
+			}
+		})
+	}
+}
+
 func TestCountByStatus(t *testing.T) {
 	s := NewState()
 	s.Sessions["slot-1"] = &Session{IssueNumber: 1, Status: StatusRunning}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -801,6 +801,7 @@ func TestSessionDisplayStatusFor_ReviewFeedbackRetryLifecycle(t *testing.T) {
 				Status:                      StatusDead,
 				NextRetryAt:                 &future,
 				PreviousAttemptFeedbackKind: RetryReasonReviewFeedback,
+				RetryReason:                 RetryReasonReviewFeedback,
 			},
 			want: string(DisplayReviewRetryBackoff),
 		},
@@ -810,6 +811,7 @@ func TestSessionDisplayStatusFor_ReviewFeedbackRetryLifecycle(t *testing.T) {
 				Status:                      StatusDead,
 				NextRetryAt:                 &past,
 				PreviousAttemptFeedbackKind: RetryReasonReviewFeedback,
+				RetryReason:                 RetryReasonReviewFeedback,
 			},
 			want: string(DisplayReviewRetryPending),
 		},
@@ -834,6 +836,15 @@ func TestSessionDisplayStatusFor_ReviewFeedbackRetryLifecycle(t *testing.T) {
 		{
 			name: "genuine dead remains dead",
 			sess: &Session{Status: StatusDead},
+			want: string(StatusDead),
+		},
+		{
+			name: "ci retry carrying review feedback remains dead",
+			sess: &Session{
+				Status:                      StatusDead,
+				NextRetryAt:                 &future,
+				PreviousAttemptFeedbackKind: RetryReasonReviewFeedback,
+			},
 			want: string(StatusDead),
 		},
 	}
@@ -882,6 +893,7 @@ func TestSessionAttentionFor_ReviewFeedbackRetryCopy(t *testing.T) {
 				Status:                      StatusDead,
 				NextRetryAt:                 &future,
 				PreviousAttemptFeedbackKind: RetryReasonReviewFeedback,
+				RetryReason:                 RetryReasonReviewFeedback,
 			},
 			wantReason: "waiting for the retry backoff",
 			wantAction: "scheduled retry worker",


### PR DESCRIPTION
Closes #317

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `display_status` field that overlays the raw session status with four review-retry lifecycle states (`review_retry_backoff`, `review_retry_pending`, `review_retry_running`, `review_retry_recheck`) in both the single-project and fleet dashboards, the CLI status table, and the `/api` summary map. The implementation is well-structured — `RetryReason` is the single source of truth, the new `SessionDisplayStatusFor` helpers are clock-injectable for tests, and coverage is thorough.

The outstanding P1 flagged in the previous review remains unresolved: `handleCIFailureRetry` and `handleRebaseConflictRetry` never clear `sess.RetryReason`, so a session that went through a review-feedback retry and then hits a CI failure or rebase conflict will continue to display `review_retry_*` states indefinitely instead of the correct raw status.

<h3>Confidence Score: 3/5</h3>

Safe to merge once the RetryReason-not-cleared P1 in the orchestrator is fixed.

The P1 from the prior review (RetryReason not cleared in handleCIFailureRetry and handleRebaseConflictRetry) is confirmed still present in this diff and would cause persistent incorrect display states for sessions that cycle through review-feedback and then CI/rebase retries. No new P0s were found; all other changes are correct.

internal/orchestrator/orchestrator.go — handleCIFailureRetry and handleRebaseConflictRetry need sess.RetryReason = "" before scheduling the retry.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Sets RetryReason = "review_feedback" in handleReviewFeedbackRetry and in respawnDueRetries, but neither handleCIFailureRetry nor handleRebaseConflictRetry clears it — the outstanding P1 from the prior review. |
| internal/state/state.go | Core of the PR: adds SessionDisplayStatus type, RetryReason field, and SessionDisplayStatusFor/reviewFeedbackRetryDisplayStatus helpers. Logic is correct for the covered cases; the unresolved P1 originates in orchestrator.go, not here. |
| internal/server/server.go | Propagates DisplayStatus through sessionInfo/buildStateResponse and updates JS dashboard (CSS classes, sort order, stats counters, filter/search). Changes are consistent and correct. |
| internal/server/fleet.go | Fleet dashboard gains display_status field, new CSS classes, updated status filter/search/sort, and displayStatus() JS helper. cssToken is defined at line 1752. Logic is consistent with the server dashboard changes. |
| cmd/maestro/main.go | CLI status table now calls SessionDisplayStatusFor and passes the result as the displayed status column — straightforward and correct. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Dashboard: gate review retry display on ..."](https://github.com/befeast/maestro/commit/2d134243d64700b09fab81e6da898a4dad86a31c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30493743)</sub>

<!-- /greptile_comment -->