### PR TITLE
Approvals inbox: reconcile stale spawn_worker approvals after worker starts

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -1070,8 +1070,25 @@ func showApprovals(s *state.State) {
 	sort.Slice(approvals, func(i, j int) bool {
 		return approvals[i].CreatedAt.After(approvals[j].CreatedAt)
 	})
-	fmt.Println("Approvals:")
+	var pending []state.Approval
+	historyCounts := make(map[state.ApprovalStatus]int)
+	historyTotal := 0
 	for _, approval := range approvals {
+		if approval.Status == state.ApprovalStatusPending {
+			pending = append(pending, approval)
+			continue
+		}
+		historyCounts[approval.Status]++
+		historyTotal++
+	}
+	if len(pending) == 0 {
+		if historyTotal > 0 {
+			fmt.Printf("Approvals: no pending approvals; %s.\n\n", approvalHistorySummary(historyCounts, historyTotal))
+		}
+		return
+	}
+	fmt.Println("Approvals:")
+	for _, approval := range pending {
 		target := "-"
 		parts := supervisorTargetParts(approval.Target)
 		if len(parts) > 0 {
@@ -1079,7 +1096,43 @@ func showApprovals(s *state.State) {
 		}
 		fmt.Printf("  %s  %s  %s  %s\n", approval.ID, approval.Status, approval.Action, target)
 	}
+	if historyTotal > 0 {
+		fmt.Printf("  %s.\n", approvalHistorySummary(historyCounts, historyTotal))
+	}
 	fmt.Println()
+}
+
+func approvalHistorySummary(counts map[state.ApprovalStatus]int, total int) string {
+	if total <= 0 {
+		return "0 historical approvals hidden"
+	}
+	noun := "approval"
+	if total != 1 {
+		noun = "approvals"
+	}
+	known := 0
+	var parts []string
+	for _, status := range []state.ApprovalStatus{
+		state.ApprovalStatusSuperseded,
+		state.ApprovalStatusStale,
+		state.ApprovalStatusApproved,
+		state.ApprovalStatusRejected,
+	} {
+		count := counts[status]
+		if count == 0 {
+			continue
+		}
+		known += count
+		parts = append(parts, fmt.Sprintf("%d %s", count, status))
+	}
+	if other := total - known; other > 0 {
+		parts = append(parts, fmt.Sprintf("%d other", other))
+	}
+	summary := fmt.Sprintf("%d historical %s hidden", total, noun)
+	if len(parts) > 0 {
+		summary += " (" + strings.Join(parts, ", ") + ")"
+	}
+	return summary
 }
 
 // watchPaneCmd builds a shell command for a watch pane.

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -154,7 +154,7 @@ PR states to watch:
 | `failing_checks` stuck state | Required checks failed | Inspect the check failure, retry intentionally if budget remains, or fix manually |
 | `unmergeable_pr` stuck state | GitHub reports conflicts or unknown mergeability | Wait for GitHub to compute mergeability, or rebase/resolve conflicts |
 
-Supervisor approvals are stale-sensitive. A pending approval becomes stale if the decision payload changes or the target session/PR state changes. Fleet Mission Control shows pending approvals first; stale, approved, and rejected approvals are audit history collapsed below the active inbox. Do not approve a stale approval. Re-run the supervisor, review the new decision, and approve or reject the new ID if appropriate.
+Supervisor approvals are stale-sensitive. A pending approval becomes stale if the decision payload changes or the target session/PR state changes, and pending `spawn_worker` approvals become superseded when a matching worker has already started. Fleet Mission Control shows pending approvals first; superseded, stale, approved, and rejected approvals are audit history collapsed below the active inbox. Do not approve a stale or superseded approval. Re-run the supervisor, review the new decision, and approve or reject the new ID if appropriate.
 
 ## Safe Commands
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -188,19 +188,21 @@ type fleetResponse struct {
 }
 
 type fleetSummary struct {
-	Projects          int `json:"projects"`
-	Stale             int `json:"stale"`
-	Errors            int `json:"errors"`
-	Running           int `json:"running"`
-	PROpen            int `json:"pr_open"`
-	Failed            int `json:"failed"`
-	Sessions          int `json:"sessions"`
-	NeedsAttention    int `json:"needs_attention"`
-	Approvals         int `json:"approvals"`
-	ApprovalsPending  int `json:"approvals_pending"`
-	ApprovalsStale    int `json:"approvals_stale"`
-	ApprovalsApproved int `json:"approvals_approved"`
-	ApprovalsRejected int `json:"approvals_rejected"`
+	Projects            int `json:"projects"`
+	Stale               int `json:"stale"`
+	Errors              int `json:"errors"`
+	Running             int `json:"running"`
+	PROpen              int `json:"pr_open"`
+	Failed              int `json:"failed"`
+	Sessions            int `json:"sessions"`
+	NeedsAttention      int `json:"needs_attention"`
+	Approvals           int `json:"approvals"`
+	ApprovalsPending    int `json:"approvals_pending"`
+	ApprovalsHistorical int `json:"approvals_historical"`
+	ApprovalsStale      int `json:"approvals_stale"`
+	ApprovalsSuperseded int `json:"approvals_superseded"`
+	ApprovalsApproved   int `json:"approvals_approved"`
+	ApprovalsRejected   int `json:"approvals_rejected"`
 }
 
 type fleetProjectFreshness struct {
@@ -636,16 +638,24 @@ func latestTime(left, right time.Time) time.Time {
 }
 
 func addFleetApprovalSummary(summary *fleetSummary, status string) {
-	summary.Approvals++
 	switch state.ApprovalStatus(status) {
 	case state.ApprovalStatusPending:
+		summary.Approvals++
 		summary.ApprovalsPending++
 	case state.ApprovalStatusStale:
+		summary.ApprovalsHistorical++
 		summary.ApprovalsStale++
+	case state.ApprovalStatusSuperseded:
+		summary.ApprovalsHistorical++
+		summary.ApprovalsSuperseded++
 	case state.ApprovalStatusApproved:
+		summary.ApprovalsHistorical++
 		summary.ApprovalsApproved++
 	case state.ApprovalStatusRejected:
+		summary.ApprovalsHistorical++
 		summary.ApprovalsRejected++
+	default:
+		summary.ApprovalsHistorical++
 	}
 }
 
@@ -943,14 +953,16 @@ func fleetApprovalStatusRank(status string) int {
 	switch state.ApprovalStatus(status) {
 	case state.ApprovalStatusPending:
 		return 0
-	case state.ApprovalStatusStale:
+	case state.ApprovalStatusSuperseded:
 		return 1
-	case state.ApprovalStatusApproved:
+	case state.ApprovalStatusStale:
 		return 2
-	case state.ApprovalStatusRejected:
+	case state.ApprovalStatusApproved:
 		return 3
-	default:
+	case state.ApprovalStatusRejected:
 		return 4
+	default:
+		return 5
 	}
 }
 
@@ -1117,6 +1129,7 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   }
   .approval-card.approval-pending { border-left-color: var(--warn); background: rgba(210,153,34,.08); }
   .approval-card.approval-stale { border-left-color: var(--line); background: rgba(139,148,158,.06); }
+  .approval-card.approval-superseded { border-left-color: var(--line); background: rgba(139,148,158,.06); }
   .approval-card.approval-approved { border-left-color: var(--ok); background: rgba(63,185,80,.06); }
   .approval-card.approval-rejected { border-left-color: var(--line); background: rgba(139,148,158,.05); }
   .approval-project,
@@ -1481,6 +1494,7 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   .s-dead, .s-failed, .s-conflict_failed, .s-retry_exhausted { color: var(--bad); border-color: rgba(248,81,73,.45); }
   .a-pending { color: var(--warn); border-color: rgba(210,153,34,.55); background: rgba(210,153,34,.08); }
   .a-stale { color: var(--muted); border-color: rgba(139,148,158,.45); background: rgba(139,148,158,.08); }
+  .a-superseded { color: var(--muted); border-color: rgba(139,148,158,.45); background: rgba(139,148,158,.08); }
   .a-approved { color: var(--ok); border-color: rgba(63,185,80,.55); background: rgba(63,185,80,.08); }
   .a-rejected { color: var(--muted); border-color: rgba(139,148,158,.45); background: rgba(139,148,158,.08); }
   .attention { color: var(--bad); border-color: rgba(248,81,73,.45); }
@@ -1797,10 +1811,11 @@ function renderActions(actions, options) {
 function approvalStatusRank(status) {
   switch (status) {
   case "pending": return 0;
-  case "stale": return 1;
-  case "approved": return 2;
-  case "rejected": return 3;
-  default: return 4;
+  case "superseded": return 1;
+  case "stale": return 2;
+  case "approved": return 3;
+  case "rejected": return 4;
+  default: return 5;
   }
 }
 
@@ -1865,8 +1880,9 @@ function approvalInboxSummaryText(activeCount, historicalCount) {
 }
 
 function approvalHistoryCountText(counts, historicalCount) {
-  const known = (counts.stale || 0) + (counts.approved || 0) + (counts.rejected || 0);
+  const known = (counts.superseded || 0) + (counts.stale || 0) + (counts.approved || 0) + (counts.rejected || 0);
   const parts = [
+    [counts.superseded || 0, "superseded"],
     [counts.stale || 0, "stale"],
     [counts.approved || 0, "approved"],
     [counts.rejected || 0, "rejected"],

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -537,8 +537,8 @@ func TestFleetAPIIncludesApprovalInboxMetadata(t *testing.T) {
 	if len(resp.Projects) != 1 || len(resp.Projects[0].Approvals) != 4 {
 		t.Fatalf("project approvals = %+v, want 4 approvals", resp.Projects)
 	}
-	if resp.Summary.Approvals != 4 || resp.Summary.ApprovalsPending != 1 || resp.Summary.ApprovalsStale != 1 || resp.Summary.ApprovalsApproved != 1 || resp.Summary.ApprovalsRejected != 1 {
-		t.Fatalf("approval summary = %+v, want one per lifecycle status", resp.Summary)
+	if resp.Summary.Approvals != 1 || resp.Summary.ApprovalsPending != 1 || resp.Summary.ApprovalsHistorical != 3 || resp.Summary.ApprovalsStale != 1 || resp.Summary.ApprovalsApproved != 1 || resp.Summary.ApprovalsRejected != 1 {
+		t.Fatalf("approval summary = %+v, want one active and three historical approvals", resp.Summary)
 	}
 	if resp.Projects[0].ApprovalSummary[string(state.ApprovalStatusPending)] != 1 || resp.Projects[0].ApprovalSummary[string(state.ApprovalStatusStale)] != 1 {
 		t.Fatalf("project approval summary = %+v, want pending and stale counts", resp.Projects[0].ApprovalSummary)
@@ -573,6 +573,26 @@ func TestFleetAPIIncludesApprovalInboxMetadata(t *testing.T) {
 	staleApproval := findFleetApproval(t, resp.Approvals, stale.ID)
 	if staleApproval.Status != string(state.ApprovalStatusStale) {
 		t.Fatalf("stale approval status = %q, want stale", staleApproval.Status)
+	}
+}
+
+func TestFleetApprovalSummaryCountsOnlyActivePendingApprovals(t *testing.T) {
+	var summary fleetSummary
+	for _, status := range []string{
+		string(state.ApprovalStatusPending),
+		string(state.ApprovalStatusSuperseded),
+		string(state.ApprovalStatusStale),
+		string(state.ApprovalStatusApproved),
+		string(state.ApprovalStatusRejected),
+	} {
+		addFleetApprovalSummary(&summary, status)
+	}
+
+	if summary.Approvals != 1 || summary.ApprovalsPending != 1 {
+		t.Fatalf("active approval summary = %+v, want one pending active approval", summary)
+	}
+	if summary.ApprovalsHistorical != 4 || summary.ApprovalsSuperseded != 1 || summary.ApprovalsStale != 1 || summary.ApprovalsApproved != 1 || summary.ApprovalsRejected != 1 {
+		t.Fatalf("historical approval summary = %+v, want one per historical status", summary)
 	}
 }
 
@@ -952,7 +972,10 @@ func TestFleetDashboard(t *testing.T) {
 		"const historyWasOpen = historyDetails ? historyDetails.open : false;",
 		"(historyWasOpen ? ' open' : '')",
 		".approval-card.approval-stale { border-left-color: var(--line);",
+		".approval-card.approval-superseded { border-left-color: var(--line);",
 		".a-stale { color: var(--muted);",
+		".a-superseded { color: var(--muted);",
+		"counts.superseded",
 		"renderAttentionInbox",
 		"attentionFromData",
 		"if (!Array.isArray(data.attention) && Array.isArray(data.workers))",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -554,12 +554,12 @@ func TestHandleState_IncludesApprovals(t *testing.T) {
 		CreatedAt:         now,
 		Project:           "test/repo",
 		Mode:              "read_only",
-		Summary:           "Start a worker for issue #42.",
+		Summary:           "Start a worker for issue #45.",
 		RecommendedAction: "spawn_worker",
-		Target:            &state.SupervisorTarget{Issue: 42},
+		Target:            &state.SupervisorTarget{Issue: 45},
 		Risk:              "mutating",
 		Confidence:        0.84,
-		Reasons:           []string{"Issue #42 is eligible"},
+		Reasons:           []string{"Issue #45 is eligible"},
 	}, now)
 	if err := state.Save(cfg.StateDir, st); err != nil {
 		t.Fatalf("save state: %v", err)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -319,6 +319,7 @@ var (
 	ErrApprovalNotFound        = errors.New("approval not found")
 	ErrApprovalNotPending      = errors.New("approval is not pending")
 	ErrApprovalStale           = errors.New("approval is stale")
+	ErrApprovalSuperseded      = errors.New("approval is superseded")
 	ErrApprovalPayloadMismatch = errors.New("approval payload changed")
 	ErrStateConflict           = errors.New("state write conflict")
 )
@@ -454,18 +455,22 @@ type SupervisorDecision struct {
 type ApprovalStatus string
 
 const (
-	ApprovalStatusPending  ApprovalStatus = "pending"
-	ApprovalStatusApproved ApprovalStatus = "approved"
-	ApprovalStatusRejected ApprovalStatus = "rejected"
-	ApprovalStatusStale    ApprovalStatus = "stale"
+	ApprovalStatusPending    ApprovalStatus = "pending"
+	ApprovalStatusApproved   ApprovalStatus = "approved"
+	ApprovalStatusRejected   ApprovalStatus = "rejected"
+	ApprovalStatusStale      ApprovalStatus = "stale"
+	ApprovalStatusSuperseded ApprovalStatus = "superseded"
 )
 
 const (
-	ApprovalAuditCreated  = "created"
-	ApprovalAuditApproved = "approved"
-	ApprovalAuditRejected = "rejected"
-	ApprovalAuditStale    = "stale"
+	ApprovalAuditCreated    = "created"
+	ApprovalAuditApproved   = "approved"
+	ApprovalAuditRejected   = "rejected"
+	ApprovalAuditStale      = "stale"
+	ApprovalAuditSuperseded = "superseded"
 )
+
+const approvalActionSpawnWorker = "spawn_worker"
 
 // Approval records a risky supervisor decision that needs explicit resolution.
 type Approval struct {
@@ -579,6 +584,7 @@ func saveLocked(stateDir string, s *State) error {
 		}
 		desired = merged
 	}
+	desired.ReconcileSpawnWorkerApprovalsForStartedWorkers(time.Now().UTC())
 
 	data, err := json.MarshalIndent(desired, "", "  ")
 	if err != nil {
@@ -1096,6 +1102,42 @@ func (s *State) MarkStaleApprovals(now time.Time) int {
 	return count
 }
 
+// ReconcileSpawnWorkerApprovalsForStartedWorkers marks pending spawn_worker approvals
+// as historical once a matching worker session has started for the same target.
+func (s *State) ReconcileSpawnWorkerApprovalsForStartedWorkers(now time.Time) int {
+	if s == nil || len(s.Approvals) == 0 || len(s.Sessions) == 0 {
+		return 0
+	}
+	count := 0
+	names := make([]string, 0, len(s.Sessions))
+	for name := range s.Sessions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		count += s.ReconcileSpawnWorkerApprovalsForStartedSession(name, s.Sessions[name], now)
+	}
+	return count
+}
+
+// ReconcileSpawnWorkerApprovalsForStartedSession supersedes pending spawn_worker
+// approvals that requested the worker represented by the started session.
+func (s *State) ReconcileSpawnWorkerApprovalsForStartedSession(slot string, sess *Session, now time.Time) int {
+	if s == nil || sess == nil || sess.IssueNumber <= 0 {
+		return 0
+	}
+	count := 0
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if !spawnWorkerApprovalMatchesSession(approval, slot, sess) {
+			continue
+		}
+		s.markApprovalSuperseded(approval, now, fmt.Sprintf("worker %s started for issue #%d", slot, sess.IssueNumber))
+		count++
+	}
+	return count
+}
+
 func (s *State) pendingApproval(id string) (*Approval, error) {
 	approval, ok := s.FindApproval(id)
 	if !ok {
@@ -1103,6 +1145,9 @@ func (s *State) pendingApproval(id string) (*Approval, error) {
 	}
 	if approval.Status == ApprovalStatusStale {
 		return approval, ErrApprovalStale
+	}
+	if approval.Status == ApprovalStatusSuperseded {
+		return approval, ErrApprovalSuperseded
 	}
 	if approval.Status != ApprovalStatusPending {
 		return approval, ErrApprovalNotPending
@@ -1136,6 +1181,60 @@ func (s *State) markApprovalStale(approval *Approval, now time.Time, reason stri
 		PayloadHash:     approval.PayloadHash,
 		TargetStateHash: s.ApprovalTargetStateHash(approval.Target),
 	})
+}
+
+func (s *State) markApprovalSuperseded(approval *Approval, now time.Time, reason string) {
+	if approval.Status != ApprovalStatusPending {
+		return
+	}
+	approval.Status = ApprovalStatusSuperseded
+	approval.UpdatedAt = normalizedTime(now)
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              approval.UpdatedAt,
+		Event:           ApprovalAuditSuperseded,
+		Reason:          reason,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: s.ApprovalTargetStateHash(approval.Target),
+	})
+}
+
+func spawnWorkerApprovalMatchesSession(approval *Approval, slot string, sess *Session) bool {
+	if approval == nil || sess == nil || approval.Status != ApprovalStatusPending || approval.Action != approvalActionSpawnWorker {
+		return false
+	}
+	if approval.Target == nil {
+		return false
+	}
+	target := approval.Target
+	matched := false
+	if target.Session != "" {
+		if target.Session != slot {
+			return false
+		}
+		matched = true
+	}
+	if target.Issue > 0 {
+		if target.Issue != sess.IssueNumber {
+			return false
+		}
+		matched = true
+	}
+	if target.PR > 0 {
+		if target.PR != sess.PRNumber {
+			return false
+		}
+		matched = true
+	}
+	if !matched {
+		return false
+	}
+	if sess.StartedAt.IsZero() {
+		return false
+	}
+	if approval.CreatedAt.IsZero() {
+		return true
+	}
+	return !sess.StartedAt.Before(approval.CreatedAt.UTC())
 }
 
 func (a Approval) ComputePayloadHash() string {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -1177,6 +1178,59 @@ func TestSaveMergesIndependentConcurrentUpdates(t *testing.T) {
 	}
 }
 
+func TestSaveReconcilesConcurrentSpawnApprovalWithStartedWorker(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 5, 1, 13, 46, 2, 0, time.UTC)
+	initial := NewState()
+	if err := Save(dir, initial); err != nil {
+		t.Fatalf("Save initial: %v", err)
+	}
+
+	runSnapshot, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load run snapshot: %v", err)
+	}
+	supervisorSnapshot, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load supervisor snapshot: %v", err)
+	}
+
+	approval := supervisorSnapshot.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+	if err := Save(dir, supervisorSnapshot); err != nil {
+		t.Fatalf("Save supervisor snapshot: %v", err)
+	}
+
+	runSnapshot.Sessions["slot-1"] = &Session{
+		IssueNumber: 42,
+		IssueTitle:  "ready work",
+		Status:      StatusRunning,
+		StartedAt:   now.Add(time.Minute),
+		PID:         1234,
+	}
+	if err := Save(dir, runSnapshot); err != nil {
+		t.Fatalf("Save stale run snapshot: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load merged state: %v", err)
+	}
+	loadedApproval, ok := loaded.FindApproval(approval.ID)
+	if !ok {
+		t.Fatalf("approval %q missing after merge", approval.ID)
+	}
+	if loadedApproval.Status != ApprovalStatusSuperseded {
+		t.Fatalf("approval status = %q, want %q", loadedApproval.Status, ApprovalStatusSuperseded)
+	}
+	last := loadedApproval.Audit[len(loadedApproval.Audit)-1]
+	if last.Event != ApprovalAuditSuperseded || !strings.Contains(last.Reason, "worker slot-1 started for issue #42") {
+		t.Fatalf("last audit = %#v, want superseded by started worker", last)
+	}
+	if _, err := loaded.ApproveApproval(approval.ID, now.Add(2*time.Minute), "test", "too late"); !errors.Is(err, ErrApprovalSuperseded) {
+		t.Fatalf("ApproveApproval superseded err = %v, want %v", err, ErrApprovalSuperseded)
+	}
+}
+
 func TestSaveRejectsConcurrentSameSessionConflict(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 5, 1, 13, 46, 2, 0, time.UTC)
@@ -1257,6 +1311,68 @@ func TestApprovalPendingPersistence(t *testing.T) {
 	}
 	if loadedApproval.PayloadHash != approval.PayloadHash {
 		t.Fatalf("payload hash = %q, want %q", loadedApproval.PayloadHash, approval.PayloadHash)
+	}
+}
+
+func TestReconcileSpawnWorkerApprovalsForStartedSession(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	matching := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+	matchingID := matching.ID
+	nonMatching := s.RecordPendingApprovalForDecision(SupervisorDecision{
+		ID:                "sup-other-issue",
+		CreatedAt:         now,
+		Project:           "owner/repo",
+		Summary:           "Start a worker for issue #43.",
+		RecommendedAction: "spawn_worker",
+		Target:            &SupervisorTarget{Issue: 43},
+		Risk:              "mutating",
+	}, now)
+	nonMatchingID := nonMatching.ID
+	nonSpawn := s.RecordPendingApprovalForDecision(SupervisorDecision{
+		ID:                "sup-merge",
+		CreatedAt:         now,
+		Project:           "owner/repo",
+		Summary:           "Merge PR #9.",
+		RecommendedAction: "approve_merge",
+		Target:            &SupervisorTarget{Issue: 42, PR: 9},
+		Risk:              "mutating",
+	}, now)
+	nonSpawnID := nonSpawn.ID
+
+	count := s.ReconcileSpawnWorkerApprovalsForStartedSession("slot-1", &Session{
+		IssueNumber: 42,
+		Status:      StatusRunning,
+		StartedAt:   now.Add(time.Minute),
+	}, now.Add(time.Minute))
+
+	if count != 1 {
+		t.Fatalf("reconciled approvals = %d, want 1", count)
+	}
+	matching, ok := s.FindApproval(matchingID)
+	if !ok {
+		t.Fatalf("matching approval %q missing", matchingID)
+	}
+	nonMatching, ok = s.FindApproval(nonMatchingID)
+	if !ok {
+		t.Fatalf("non-matching approval %q missing", nonMatchingID)
+	}
+	nonSpawn, ok = s.FindApproval(nonSpawnID)
+	if !ok {
+		t.Fatalf("non-spawn approval %q missing", nonSpawnID)
+	}
+	if matching.Status != ApprovalStatusSuperseded {
+		t.Fatalf("matching status = %q, want %q", matching.Status, ApprovalStatusSuperseded)
+	}
+	if nonMatching.Status != ApprovalStatusPending {
+		t.Fatalf("non-matching status = %q, want pending", nonMatching.Status)
+	}
+	if nonSpawn.Status != ApprovalStatusPending {
+		t.Fatalf("non-spawn status = %q, want pending", nonSpawn.Status)
+	}
+	last := matching.Audit[len(matching.Audit)-1]
+	if last.Event != ApprovalAuditSuperseded {
+		t.Fatalf("last audit = %#v, want superseded", last)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -162,6 +162,7 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 	log.Printf("[worker] started %s in tmux session %s (pane_pid=%d, log=%s)", slotName, tmuxName, pid, logFile)
 
 	// Save session to state
+	startedAt := time.Now().UTC()
 	s.Sessions[slotName] = &state.Session{
 		IssueNumber: issue.Number,
 		IssueTitle:  issue.Title,
@@ -170,10 +171,11 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		PID:         pid,
 		TmuxSession: tmuxName,
 		LogFile:     logFile,
-		StartedAt:   time.Now().UTC(),
+		StartedAt:   startedAt,
 		Status:      state.StatusRunning,
 		Backend:     backendName,
 	}
+	s.ReconcileSpawnWorkerApprovalsForStartedSession(slotName, s.Sessions[slotName], startedAt)
 
 	return slotName, nil
 }


### PR DESCRIPTION
Closes #318

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `superseded` approval status to handle the case where a `spawn_worker` approval sits pending in the inbox after the target worker has already started (e.g., due to a concurrent approve+start race). Reconciliation runs both eagerly in `worker.Start` and defensively in `saveLocked` on every merge, ensuring stale approvals are cleaned up regardless of which process wins the write.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic defects found; implementation is well-guarded and thoroughly tested.

All critical paths are covered: idempotent markApprovalSuperseded guard prevents double-marking, spawnWorkerApprovalMatchesSession correctly requires at least one dimension to match with the timing check (StartedAt >= CreatedAt) preventing false supersessions, and saveLocked reconciles concurrent saves. New and updated tests cover the concurrent scenario, unit matching logic, and fleet summary counters.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds ApprovalStatusSuperseded and ApprovalAuditSuperseded constants, ReconcileSpawnWorkerApprovalsForStartedWorkers/Session methods, spawnWorkerApprovalMatchesSession helper, and hooks reconciliation into saveLocked — logic is sound with correct guards and idempotency |
| internal/worker/worker.go | Captures startedAt once and calls ReconcileSpawnWorkerApprovalsForStartedSession immediately after session creation for fast-path reconciliation before state save |
| internal/server/fleet.go | Adds ApprovalsHistorical and ApprovalsSuperseded fields to fleetSummary, updates addFleetApprovalSummary so only pending approvals count toward Approvals, adds superseded CSS styles and rank ordering |
| internal/server/fleet_test.go | Updates assertion to reflect Approvals=1 (pending-only), adds TestFleetApprovalSummaryCountsOnlyActivePendingApprovals, and adds superseded style/CSS snippet checks to TestFleetDashboard |
| internal/state/state_test.go | Adds TestSaveReconcilesConcurrentSpawnApprovalWithStartedWorker (concurrent save scenario) and TestReconcileSpawnWorkerApprovalsForStartedSession (unit coverage for matching/non-matching approvals) |
| cmd/maestro/main.go | showApprovals now separates pending from historical and renders approvalHistorySummary; includes superseded in the history breakdown |
| internal/server/server_test.go | Changes approval fixture from issue #42 to #45 to avoid interference with the new testApprovalDecision helper (which targets issue #42) |
| docs/fleet-mission-control-runbook.md | Documents superseded status alongside stale in the runbook guidance |

</details>

<sub>Reviews (1): Last reviewed commit: ["Approvals: reconcile superseded spawn ap..."](https://github.com/befeast/maestro/commit/e4e9758af78289f703b27fbfb29921c5d65e931c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30498091)</sub>

<!-- /greptile_comment -->