### PR TITLE
Fleet queue snapshot: classify held and blocker-dependency skips explicitly

### DIFF
--- a/docs/PRD-gh-project-integration.md
+++ b/docs/PRD-gh-project-integration.md
@@ -114,7 +114,7 @@ It may still expose issue reads, but tracker-facing selection and workflow state
 
 ## Config Design
 
-Supervisor policy is a separate local safety layer from tracker configuration. It may be set in the top-level `supervisor:` block or in `.maestro/supervisor.yaml`, and covers queue order, dynamic wave selection, ready/blocked labels, excluded issue types, safe actions, and approval-gated actions.
+Supervisor policy is a separate local safety layer from tracker configuration. It may be set in the top-level `supervisor:` block or in `.maestro/supervisor.yaml`, and covers queue order, dynamic wave selection, ready/blocked labels, held parent/meta work, blocker-dependency skips, excluded issue types, safe actions, and approval-gated actions.
 
 Add a new top-level block:
 

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -127,13 +127,15 @@ Dynamic wave policy:
 | Candidate source | Open GitHub issues from the project repo |
 | Priority order | `p0`, `p1`, `p2`, `p3`, then unlabeled, with lower issue number as tie breaker |
 | Runnable project statuses | Defaults to `Todo`, `To Do`, `Ready`, `Backlog`, and `New`, unless `supervisor.dynamic_wave.runnable_project_statuses` is set |
-| Excluded labels | Built-ins include `blocked`, `wontfix`, `question`, `duplicate`, `invalid`, `epic`, and `meta`, plus `exclude_labels`, `supervisor.excluded_labels`, and `supervisor.blocked_label` |
-| Other skips | Already running, done, retry exhausted, mission parent, epic-like title, and open blockers detected by `blocker_patterns` |
+| Excluded labels | Built-ins include `blocked`, `wontfix`, `question`, `duplicate`, and `invalid`, plus `exclude_labels`, `supervisor.excluded_labels`, and `supervisor.blocked_label` |
+| Held/meta skips | Mission parents, mission issues awaiting decomposition, epic-like titles, and `epic`/`meta` labels are counted separately from exclusions |
+| Blocker-dependency skips | Open blockers detected by `blocker_patterns` are counted separately from label-based blocked policy |
+| Other skips | Already running, done, and retry exhausted |
 | Ready label | `supervisor.ready_label` is treated as a queue label and is added to selected work only when `add_ready_label` is allowed |
 | Owned ready label | When `owns_ready_label: true`, dynamic wave keeps the ready label on the selected issue and can remove it from other issues if policy allows |
 | Blocked label | `supervisor.blocked_label` makes an issue ineligible; it can be removed only when `remove_blocked_label` is an allowed safe action |
 
-Fleet cards surface `open`, `eligible`, `excluded`, `non_runnable_project_status`, selected candidate, and top skipped reason so operators can tell whether the queue is empty, held by policy, or waiting on project status.
+Fleet cards surface `open`, `eligible`, `excluded`, `held/meta`, `blocked-deps`, `non_runnable_project_status`, selected candidate, and top skipped reason so operators can tell whether the queue is empty, held by parent/meta policy, blocked by dependencies, or waiting on project status.
 
 ## Review And Approval Gates
 
@@ -190,7 +192,7 @@ Avoid these during incident handling unless you are deliberately debugging crede
 
 ### No eligible issues
 
-Mission Control indicators: queue `eligible=0`, `no_eligible_issues`, `all_eligible_issues_excluded`, `ordered_queue_exhausted`, or a nonzero `non_runnable_project_status` count.
+Mission Control indicators: queue `eligible=0`, `no_eligible_issues`, `all_eligible_issues_excluded`, `ordered_queue_exhausted`, nonzero `held/meta` or `blocked-deps`, or a nonzero `non_runnable_project_status` count.
 
 Safe response:
 
@@ -198,8 +200,10 @@ Safe response:
 2. If there are no open issues, add or wait for work.
 3. If issues are missing the ready label, add the configured `supervisor.ready_label` or let the supervisor add it when `add_ready_label` is allowed.
 4. If issues are excluded, remove the blocking/excluded label only after confirming the issue is actually runnable.
-5. If dynamic wave reports non-runnable project status, move one issue to a configured runnable status or update `supervisor.dynamic_wave.runnable_project_statuses` in the project config.
-6. Restart the project runner only if config changed: `systemctl --user restart maestro@<project>.service`.
+5. If issues are held as parent/meta work, decompose or retitle/relabel only when the issue should become executable work.
+6. If issues are blocked by dependencies, close or resolve the blocker issue before expecting a worker to start.
+7. If dynamic wave reports non-runnable project status, move one issue to a configured runnable status or update `supervisor.dynamic_wave.runnable_project_statuses` in the project config.
+8. Restart the project runner only if config changed: `systemctl --user restart maestro@<project>.service`.
 
 ### Running but dead PID
 

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -292,7 +292,7 @@ Verify the API:
 curl -fsS http://127.0.0.1:8787/api/v1/fleet
 ```
 
-The fleet response includes `refreshed_at` plus per-project freshness metadata. Project cards show snapshot age and are marked stale when the latest state or log snapshot is older than 15 minutes; one project's load error is shown on that card without hiding the rest of the fleet.
+The fleet response includes `refreshed_at` plus per-project freshness metadata. Project cards show snapshot age and are marked stale when the latest state or log snapshot is older than 15 minutes; one project's load error is shown on that card without hiding the rest of the fleet. Queue snapshots split skipped work into `excluded`, `held/meta`, `blocked-deps`, and non-runnable project status counts so an idle project shows why no worker starts.
 
 `--fleet` versus repeated `--config`:
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -221,6 +221,8 @@ type fleetQueueSnapshot struct {
 	Open                          int                             `json:"open"`
 	Eligible                      int                             `json:"eligible"`
 	Excluded                      int                             `json:"excluded"`
+	Held                          int                             `json:"held"`
+	BlockedByDependency           int                             `json:"blocked_by_dependency"`
 	NonRunnableProjectStatusCount int                             `json:"non_runnable_project_status_count"`
 	SelectedCandidate             *state.SupervisorIssueCandidate `json:"selected_candidate,omitempty"`
 	TopSkippedReason              string                          `json:"top_skipped_reason,omitempty"`
@@ -593,6 +595,8 @@ func fleetQueueSnapshotFromSupervisor(info supervisorInfo) *fleetQueueSnapshot {
 		Open:                          analysis.OpenIssues,
 		Eligible:                      analysis.EligibleCandidates,
 		Excluded:                      analysis.ExcludedIssues,
+		Held:                          analysis.HeldIssues,
+		BlockedByDependency:           analysis.BlockedByDependencyIssues,
 		NonRunnableProjectStatusCount: analysis.NonRunnableProjectStatusCount,
 		TopSkippedReason:              analysis.TopSkippedReason(),
 		IdleReason:                    analysis.IdleReason(),
@@ -2560,11 +2564,17 @@ async function loadWorkerDetail() {
 function queueSnapshotHTML(project) {
   const q = project.queue_snapshot;
   if (!q) return "";
+  const excluded = Number(q.excluded || 0);
+  const held = Number(q.held || q.held_issues || 0);
+  const blockedByDependency = Number(q.blocked_by_dependency || q.blocked_by_dependency_issues || 0);
+  const nonRunnable = Number(q.non_runnable_project_status_count || 0);
   const parts = [
     "open=" + Number(q.open || 0),
     "eligible=" + Number(q.eligible || 0),
-    "excluded=" + Number(q.excluded || 0),
-    "non-runnable=" + Number(q.non_runnable_project_status_count || 0)
+    "excluded=" + excluded,
+    "held/meta=" + held,
+    "blocked-deps=" + blockedByDependency,
+    "non-runnable=" + nonRunnable
   ];
   const selected = q.selected_candidate && q.selected_candidate.number
     ? "selected #" + q.selected_candidate.number + (q.selected_candidate.title ? " " + q.selected_candidate.title : "")
@@ -2572,6 +2582,14 @@ function queueSnapshotHTML(project) {
   if (selected) parts.push(selected);
 
   const lines = ['<div class="queue-line"><strong>Queue</strong><span>' + escapeText(parts.join(" · ")) + '</span></div>'];
+  const skipped = [];
+  if (excluded) skipped.push(excluded + " excluded by label/policy");
+  if (held) skipped.push(held + " held parent/meta");
+  if (blockedByDependency) skipped.push(blockedByDependency + " blocked by open dependencies");
+  if (nonRunnable) skipped.push(nonRunnable + " in non-runnable project status");
+  if (skipped.length) {
+    lines.push('<div class="queue-line"><strong>Skipped</strong><span>' + escapeText(skipped.join(" · ")) + '</span></div>');
+  }
   const isIdle = (project.running || 0) === 0;
   let idleReason = isIdle ? (q.idle_reason || "") : "";
   const topSkip = isIdle && q.eligible === 0 && q.top_skipped_reason && !(idleReason || "").includes(q.top_skipped_reason)

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -275,12 +275,18 @@ func TestFleetAPIIncludesQueueSnapshotMetadata(t *testing.T) {
 		Risk:              "safe",
 		PolicyRule:        "supervisor.dynamic_wave",
 		QueueAnalysis: &state.SupervisorQueueAnalysis{
-			PolicyRule:         "supervisor.dynamic_wave",
-			OpenIssues:         11,
-			EligibleCandidates: 0,
-			ExcludedIssues:     11,
+			PolicyRule:                    "supervisor.dynamic_wave",
+			OpenIssues:                    4,
+			EligibleCandidates:            0,
+			ExcludedIssues:                1,
+			HeldIssues:                    1,
+			BlockedByDependencyIssues:     1,
+			NonRunnableProjectStatusCount: 1,
 			SkippedReasons: []string{
 				"Issue #24 skipped by dynamic wave policy: excluded by label \"blocked\"",
+				"Issue #25 skipped by dynamic wave policy: held/meta: mission parent issue",
+				"Issue #26 skipped by dynamic wave policy: blocked by dependency: open issue(s) #12",
+				"Issue #27 skipped by dynamic wave policy: project status \"In Progress\" is not runnable",
 			},
 		},
 	}, state.DefaultSupervisorDecisionLimit)
@@ -330,16 +336,16 @@ func TestFleetAPIIncludesQueueSnapshotMetadata(t *testing.T) {
 	if excluded.QueueSnapshot == nil {
 		t.Fatal("excluded project queue snapshot is nil")
 	}
-	if excluded.QueueSnapshot.Open != 11 || excluded.QueueSnapshot.Eligible != 0 || excluded.QueueSnapshot.Excluded != 11 {
-		t.Fatalf("excluded queue snapshot = %+v, want open=11 eligible=0 excluded=11", excluded.QueueSnapshot)
+	if excluded.QueueSnapshot.Open != 4 || excluded.QueueSnapshot.Eligible != 0 || excluded.QueueSnapshot.Excluded != 1 || excluded.QueueSnapshot.Held != 1 || excluded.QueueSnapshot.BlockedByDependency != 1 || excluded.QueueSnapshot.NonRunnableProjectStatusCount != 1 {
+		t.Fatalf("excluded queue snapshot = %+v, want classified skipped counts", excluded.QueueSnapshot)
 	}
-	if !contains(excluded.QueueSnapshot.IdleReason, "Policy excluded all 11 open issues") {
-		t.Fatalf("idle reason = %q, want all-excluded explanation", excluded.QueueSnapshot.IdleReason)
+	if !contains(excluded.QueueSnapshot.IdleReason, "Queue policy classified all 4 open issues") || !contains(excluded.QueueSnapshot.IdleReason, "blocked-by-dependency=1") {
+		t.Fatalf("idle reason = %q, want classified explanation", excluded.QueueSnapshot.IdleReason)
 	}
 	if !contains(excluded.QueueSnapshot.TopSkippedReason, "excluded by label") {
 		t.Fatalf("top skipped reason = %q, want excluded label reason", excluded.QueueSnapshot.TopSkippedReason)
 	}
-	if excluded.Supervisor.Latest == nil || excluded.Supervisor.Latest.QueueAnalysis == nil || excluded.Supervisor.Latest.QueueAnalysis.OpenIssues != 11 {
+	if excluded.Supervisor.Latest == nil || excluded.Supervisor.Latest.QueueAnalysis == nil || excluded.Supervisor.Latest.QueueAnalysis.OpenIssues != 4 || excluded.Supervisor.Latest.QueueAnalysis.HeldIssues != 1 {
 		t.Fatalf("supervisor latest queue analysis = %#v, want exposed analysis", excluded.Supervisor.Latest)
 	}
 
@@ -991,6 +997,9 @@ func TestFleetDashboard(t *testing.T) {
 		"Queue Snapshot",
 		"queueSnapshotHTML",
 		"queue-snapshot",
+		"held/meta",
+		"blocked-deps",
+		"blocked by open dependencies",
 		"next_action",
 		"sortWorkers",
 		"filteredWorkers",

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -360,6 +360,8 @@ type SupervisorQueueAnalysis struct {
 	OpenIssues                    int                       `json:"open_issues"`
 	EligibleCandidates            int                       `json:"eligible_candidates"`
 	ExcludedIssues                int                       `json:"excluded_issues"`
+	HeldIssues                    int                       `json:"held_issues"`
+	BlockedByDependencyIssues     int                       `json:"blocked_by_dependency_issues"`
 	NonRunnableProjectStatusCount int                       `json:"non_runnable_project_status_count"`
 	SelectedCandidate             *SupervisorIssueCandidate `json:"selected_candidate,omitempty"`
 	SkippedReasons                []string                  `json:"skipped_reasons,omitempty"`
@@ -389,16 +391,51 @@ func (q *SupervisorQueueAnalysis) IdleReason() string {
 	if q.ExcludedIssues >= q.OpenIssues {
 		return fmt.Sprintf("Policy excluded all %s.", openIssuePhrase(q.OpenIssues))
 	}
+	if q.HeldIssues >= q.OpenIssues {
+		return fmt.Sprintf("Held/meta policy held all %s.", openIssuePhrase(q.OpenIssues))
+	}
+	if q.BlockedByDependencyIssues >= q.OpenIssues {
+		return fmt.Sprintf("Open dependencies blocked all %s.", openIssuePhrase(q.OpenIssues))
+	}
 	if q.NonRunnableProjectStatusCount >= q.OpenIssues {
 		return fmt.Sprintf("All %s are in a non-runnable project status.", openIssuePhrase(q.OpenIssues))
 	}
-	if q.ExcludedIssues+q.NonRunnableProjectStatusCount >= q.OpenIssues {
-		return fmt.Sprintf("Policy excluded or held all %s.", openIssuePhrase(q.OpenIssues))
+	if q.classifiedSkipCount() >= q.OpenIssues {
+		return fmt.Sprintf("Queue policy classified all %s: %s.", openIssuePhrase(q.OpenIssues), strings.Join(q.skipCategorySummaries(), ", "))
 	}
 	if reason := q.TopSkippedReason(); reason != "" {
 		return "No issue is eligible: " + reason
 	}
 	return "No issue is eligible under the current supervisor policy."
+}
+
+func (q *SupervisorQueueAnalysis) classifiedSkipCount() int {
+	if q == nil {
+		return 0
+	}
+	return q.ExcludedIssues + q.HeldIssues + q.BlockedByDependencyIssues + q.NonRunnableProjectStatusCount
+}
+
+func (q *SupervisorQueueAnalysis) skipCategorySummaries() []string {
+	if q == nil {
+		return nil
+	}
+	categories := []struct {
+		label string
+		count int
+	}{
+		{label: "excluded", count: q.ExcludedIssues},
+		{label: "held/meta", count: q.HeldIssues},
+		{label: "blocked-by-dependency", count: q.BlockedByDependencyIssues},
+		{label: "non-runnable project status", count: q.NonRunnableProjectStatusCount},
+	}
+	summaries := make([]string, 0, len(categories))
+	for _, category := range categories {
+		if category.count > 0 {
+			summaries = append(summaries, fmt.Sprintf("%s=%d", category.label, category.count))
+		}
+	}
+	return summaries
 }
 
 func openIssuePhrase(count int) string {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1086,6 +1086,27 @@ func TestSupervisorQueueAnalysisIdleReasonExplainsAllExcluded(t *testing.T) {
 	}
 }
 
+func TestSupervisorQueueAnalysisIdleReasonExplainsSkipCategories(t *testing.T) {
+	analysis := &SupervisorQueueAnalysis{
+		OpenIssues:                    4,
+		EligibleCandidates:            0,
+		ExcludedIssues:                1,
+		HeldIssues:                    1,
+		BlockedByDependencyIssues:     1,
+		NonRunnableProjectStatusCount: 1,
+	}
+
+	want := "Queue policy classified all 4 open issues: excluded=1, held/meta=1, blocked-by-dependency=1, non-runnable project status=1."
+	if got := analysis.IdleReason(); got != want {
+		t.Fatalf("IdleReason = %q, want %q", got, want)
+	}
+
+	analysis = &SupervisorQueueAnalysis{OpenIssues: 2, BlockedByDependencyIssues: 2}
+	if got, want := analysis.IdleReason(), "Open dependencies blocked all 2 open issues."; got != want {
+		t.Fatalf("IdleReason = %q, want %q", got, want)
+	}
+}
+
 func TestRecordSupervisorDecisionPrunesOldRecords(t *testing.T) {
 	s := NewState()
 	now := time.Now().UTC()

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -404,7 +404,7 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 	if len(candidates) == 0 {
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Dynamic wave checked %d open issue(s)", len(issues)),
-			fmt.Sprintf("Dynamic wave found %d eligible candidate(s), %d excluded issue(s), and %d issue(s) in non-runnable project status", analysis.EligibleCandidates, analysis.ExcludedIssues, analysis.NonRunnableProjectStatusCount),
+			fmt.Sprintf("Dynamic wave found %d eligible candidate(s), %d excluded issue(s), %d held/meta issue(s), %d blocked-by-dependency issue(s), and %d issue(s) in non-runnable project status", analysis.EligibleCandidates, analysis.ExcludedIssues, analysis.HeldIssues, analysis.BlockedByDependencyIssues, analysis.NonRunnableProjectStatusCount),
 		)
 		for _, reason := range firstN(result.skipped, 3) {
 			reasons = append(reasons, reason)
@@ -885,6 +885,8 @@ type dynamicSkipCategory string
 const (
 	dynamicSkipOther         dynamicSkipCategory = "other"
 	dynamicSkipExcluded      dynamicSkipCategory = "excluded"
+	dynamicSkipHeldMeta      dynamicSkipCategory = "held_meta"
+	dynamicSkipBlockedDep    dynamicSkipCategory = "blocked_by_dependency"
 	dynamicSkipProjectStatus dynamicSkipCategory = "project_status"
 )
 
@@ -939,10 +941,14 @@ func (e *Engine) dynamicWaveCandidateIssues(st *state.State, issues []github.Iss
 			return policyCandidateResult{}, err
 		}
 		if reason != "" {
-			if category == dynamicSkipExcluded {
+			switch category {
+			case dynamicSkipExcluded:
 				analysis.ExcludedIssues++
-			}
-			if category == dynamicSkipProjectStatus {
+			case dynamicSkipHeldMeta:
+				analysis.HeldIssues++
+			case dynamicSkipBlockedDep:
+				analysis.BlockedByDependencyIssues++
+			case dynamicSkipProjectStatus:
 				analysis.NonRunnableProjectStatusCount++
 			}
 			skipped = append(skipped, fmt.Sprintf("Issue #%d skipped by dynamic wave policy: %s", issue.Number, reason))
@@ -981,13 +987,16 @@ func (e *Engine) dynamicWaveSkipReason(st *state.State, issue github.Issue) (str
 		return "retry limit exhausted", dynamicSkipOther, nil
 	}
 	if st.IsMissionParent(issue.Number) {
-		return "mission parent issue", dynamicSkipOther, nil
+		return heldMetaSkipReason("mission parent issue"), dynamicSkipHeldMeta, nil
 	}
 	if e.cfg.Missions.Enabled && mission.IsMissionIssue(issue, e.cfg.Missions.Labels) && !st.IsMissionChild(issue.Number) {
-		return "mission issue awaits decomposition", dynamicSkipOther, nil
+		return heldMetaSkipReason("mission issue awaits decomposition"), dynamicSkipHeldMeta, nil
 	}
 	if titleLooksEpic(issue.Title) {
-		return "title indicates epic", dynamicSkipExcluded, nil
+		return heldMetaSkipReason("title indicates epic"), dynamicSkipHeldMeta, nil
+	}
+	if label, ok := firstMatchingIssueLabel(issue, heldMetaLabels()); ok {
+		return heldMetaSkipReason(fmt.Sprintf("label %q", label)), dynamicSkipHeldMeta, nil
 	}
 	if label, ok := firstMatchingIssueLabel(issue, e.dynamicWaveExcludedLabels()); ok {
 		return fmt.Sprintf("excluded by label %q", label), dynamicSkipExcluded, nil
@@ -1002,7 +1011,7 @@ func (e *Engine) dynamicWaveSkipReason(st *state.State, issue github.Issue) (str
 			return "", dynamicSkipOther, err
 		}
 		if len(openBlockers) > 0 {
-			return fmt.Sprintf("blocked by open issue(s) %s", issueRefs(openBlockers)), dynamicSkipOther, nil
+			return blockedByDependencySkipReason(openBlockers), dynamicSkipBlockedDep, nil
 		}
 	}
 	return "", dynamicSkipOther, nil
@@ -1271,18 +1280,22 @@ func (e *Engine) issueSkipReasonWithExcludeLabels(st *state.State, issue github.
 		return "retry limit exhausted", nil
 	}
 	if st.IsMissionParent(issue.Number) {
-		return "mission parent issue", nil
+		return heldMetaSkipReason("mission parent issue"), nil
 	}
 	if e.cfg.Missions.Enabled && mission.IsMissionIssue(issue, e.cfg.Missions.Labels) && !st.IsMissionChild(issue.Number) {
-		return "mission issue awaits decomposition", nil
+		return heldMetaSkipReason("mission issue awaits decomposition"), nil
 	}
-	if github.HasLabel(issue, excludeLabels) {
+	policyExcludedLabels := excludeLabelsExcept(e.policyExcludedLabels(), ignoredBlockedLabel)
+	if label, ok := firstMatchingIssueLabel(issue, heldMetaLabels()); ok && (hasLabelName(excludeLabels, label) || hasLabelName(policyExcludedLabels, label)) {
+		return heldMetaSkipReason(fmt.Sprintf("label %q", label)), nil
+	}
+	if _, ok := firstMatchingIssueLabel(issue, excludeLabels); ok {
 		return "excluded by configured label", nil
 	}
 	if blockedLabel := strings.TrimSpace(e.cfg.Supervisor.BlockedLabel); blockedLabel != "" && !strings.EqualFold(blockedLabel, ignoredBlockedLabel) && github.HasLabel(issue, []string{blockedLabel}) {
 		return "blocked by supervisor policy label", nil
 	}
-	if github.HasLabel(issue, excludeLabelsExcept(e.policyExcludedLabels(), ignoredBlockedLabel)) {
+	if _, ok := firstMatchingIssueLabel(issue, policyExcludedLabels); ok {
 		return "excluded by supervisor policy label", nil
 	}
 	if len(e.cfg.BlockerPatterns) > 0 {
@@ -1292,7 +1305,7 @@ func (e *Engine) issueSkipReasonWithExcludeLabels(st *state.State, issue github.
 			return "", err
 		}
 		if len(openBlockers) > 0 {
-			return fmt.Sprintf("blocked by open issue(s) %s", issueRefs(openBlockers)), nil
+			return blockedByDependencySkipReason(openBlockers), nil
 		}
 	}
 	return "", nil
@@ -1415,13 +1428,29 @@ func (e *Engine) requiredIssueLabels() []string {
 }
 
 func (e *Engine) dynamicWaveExcludedLabels() []string {
-	labels := []string{"blocked", "wontfix", "question", "duplicate", "invalid", "epic", "meta"}
+	labels := []string{"blocked", "wontfix", "question", "duplicate", "invalid"}
 	labels = append(labels, e.cfg.ExcludeLabels...)
 	labels = append(labels, e.policyExcludedLabels()...)
 	if blockedLabel := strings.TrimSpace(e.cfg.Supervisor.BlockedLabel); blockedLabel != "" {
 		labels = append(labels, blockedLabel)
 	}
 	return uniqueLabelNames(labels)
+}
+
+func heldMetaLabels() []string {
+	return []string{"epic", "meta"}
+}
+
+func heldMetaSkipReason(reason string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return "held/meta"
+	}
+	return "held/meta: " + reason
+}
+
+func blockedByDependencySkipReason(openBlockers []int) string {
+	return fmt.Sprintf("blocked by dependency: open issue(s) %s", issueRefs(openBlockers))
 }
 
 func uniqueLabelNames(labels []string) []string {
@@ -1578,6 +1607,8 @@ func supervisorQueueAnalysis(policyRule string, openIssues int, eligible []githu
 		OpenIssues:                    openIssues,
 		EligibleCandidates:            len(eligible),
 		ExcludedIssues:                countQueueExcludedReasons(skipped),
+		HeldIssues:                    countQueueHeldReasons(skipped),
+		BlockedByDependencyIssues:     countQueueBlockedByDependencyReasons(skipped),
 		NonRunnableProjectStatusCount: countQueueNonRunnableReasons(skipped),
 		SkippedReasons:                firstN(skipped, 5),
 	}
@@ -1594,8 +1625,32 @@ func countQueueExcludedReasons(skipped []string) int {
 		if strings.Contains(lower, "excluded by configured label") ||
 			strings.Contains(lower, "excluded by supervisor policy label") ||
 			strings.Contains(lower, "blocked by supervisor policy label") ||
-			strings.Contains(lower, "skipped by dynamic wave policy: excluded") ||
+			strings.Contains(lower, "skipped by dynamic wave policy: excluded") {
+			count++
+		}
+	}
+	return count
+}
+
+func countQueueHeldReasons(skipped []string) int {
+	count := 0
+	for _, reason := range skipped {
+		lower := strings.ToLower(reason)
+		if strings.Contains(lower, "held/meta") ||
+			strings.Contains(lower, "mission parent issue") ||
+			strings.Contains(lower, "mission issue awaits decomposition") ||
 			strings.Contains(lower, "title indicates epic") {
+			count++
+		}
+	}
+	return count
+}
+
+func countQueueBlockedByDependencyReasons(skipped []string) int {
+	count := 0
+	for _, reason := range skipped {
+		lower := strings.ToLower(reason)
+		if strings.Contains(lower, "blocked by dependency") || strings.Contains(lower, "blocked by open issue") {
 			count++
 		}
 	}
@@ -2015,8 +2070,10 @@ func firstMissingLabelTarget(issues []github.Issue, labels []string) *state.Supe
 func policySkipReason(reason string) bool {
 	return strings.Contains(reason, "excluded by configured label") ||
 		strings.Contains(reason, "skipped by dynamic wave policy") ||
+		strings.Contains(reason, "held/meta") ||
 		strings.Contains(reason, "mission parent issue") ||
 		strings.Contains(reason, "mission issue awaits decomposition") ||
+		strings.Contains(reason, "blocked by dependency") ||
 		strings.Contains(reason, "blocked by open issue")
 }
 

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -810,7 +810,7 @@ func TestRunOnceDynamicWaveAddsReadyOnlyToBestCandidateAndCleansStale(t *testing
 	}
 }
 
-func TestDecide_DynamicWaveSkipsTitleEpic(t *testing.T) {
+func TestDecide_DynamicWaveClassifiesTitleEpicAsHeld(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
 	enableDynamicWave(cfg)
@@ -827,11 +827,55 @@ func TestDecide_DynamicWaveSkipsTitleEpic(t *testing.T) {
 	if decision.Target == nil || decision.Target.Issue != 2 {
 		t.Fatalf("target = %#v, want issue 2", decision.Target)
 	}
-	if decision.QueueAnalysis == nil || decision.QueueAnalysis.ExcludedIssues != 1 {
-		t.Fatalf("queue analysis = %#v, want one excluded issue", decision.QueueAnalysis)
+	if decision.QueueAnalysis == nil || decision.QueueAnalysis.HeldIssues != 1 || decision.QueueAnalysis.ExcludedIssues != 0 {
+		t.Fatalf("queue analysis = %#v, want one held issue and zero excluded issues", decision.QueueAnalysis)
 	}
 	if len(decision.QueueAnalysis.SkippedReasons) == 0 || !strings.Contains(decision.QueueAnalysis.SkippedReasons[0], "title indicates epic") {
 		t.Fatalf("skipped reasons = %#v, want title epic reason", decision.QueueAnalysis.SkippedReasons)
+	}
+}
+
+func TestDecide_DynamicWaveClassifiesAllSkipCategories(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.BlockerPatterns = []string{`blocked by #(\d+)`}
+	enableDynamicWave(cfg)
+	reader := &fakeReader{issues: []github.Issue{
+		testIssue(1, "excluded", "wontfix"),
+		testIssue(2, "mission parent"),
+		{Number: 3, Title: "blocked by dependency", Body: "blocked by #100"},
+		withProjectStatus(testIssue(4, "already started"), "In Progress"),
+	}}
+	st := state.NewState()
+	st.Missions[2] = &state.Mission{ParentIssue: 2, Status: "active"}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionNone {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionNone)
+	}
+	if decision.QueueAnalysis == nil {
+		t.Fatal("QueueAnalysis is nil")
+	}
+	if got, want := decision.QueueAnalysis.ExcludedIssues, 1; got != want {
+		t.Fatalf("excluded issues = %d, want %d", got, want)
+	}
+	if got, want := decision.QueueAnalysis.HeldIssues, 1; got != want {
+		t.Fatalf("held issues = %d, want %d", got, want)
+	}
+	if got, want := decision.QueueAnalysis.BlockedByDependencyIssues, 1; got != want {
+		t.Fatalf("blocked-by-dependency issues = %d, want %d", got, want)
+	}
+	if got, want := decision.QueueAnalysis.NonRunnableProjectStatusCount, 1; got != want {
+		t.Fatalf("non-runnable issues = %d, want %d", got, want)
+	}
+	rationale := strings.Join(decision.Reasons, "\n")
+	for _, want := range []string{"1 excluded issue", "1 held/meta issue", "1 blocked-by-dependency issue", "1 issue(s) in non-runnable project status"} {
+		if !strings.Contains(rationale, want) {
+			t.Fatalf("rationale = %q, want %q", rationale, want)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #320

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR classifies queue skips into four explicit categories — `excluded` (label/policy), `held/meta` (parent issues, mission issues awaiting decomposition, epic-like titles, epic/meta labels), `blocked-by-dependency` (open blocker issues), and `non-runnable project status` — replacing the previous single `excluded` bucket. The new fields are surfaced in fleet queue snapshots, the fleet dashboard UI, and the `IdleReason()` summary string so operators can distinguish why an idle project has no work starting.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no logic defects found in the new skip classification paths or IdleReason aggregation logic.

All four skip categories are counted by non-overlapping mechanisms (direct switch increments in the dynamic wave path; distinct string-pattern functions in the ordered queue path). The IdleReason() priority chain is correct, classifiedSkipCount() is nil-safe, and new fields are consistently reflected across the fleet snapshot struct, the JS renderer, and the runbook. Tests cover the mixed-category case, the single-category short-circuit paths, and the reclassification of epic-title issues from excluded to held/meta.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds HeldIssues and BlockedByDependencyIssues fields to SupervisorQueueAnalysis; IdleReason() correctly prioritises single-category short-circuit checks before the combined classifiedSkipCount() fallback; nil-receiver safety on both new helpers is correct. |
| internal/supervisor/supervisor.go | dynamicWaveSkipReason classifies epic/meta labels and titles as dynamicSkipHeldMeta instead of excluded; direct switch-based counting in dynamicWaveCandidateIssues and separate string-based counting in supervisorQueueAnalysis are non-overlapping paths with correct backwards-compat fallback strings in countQueueHeldReasons; policySkipReason updated to include both new and legacy reason substrings. |
| internal/server/fleet.go | fleetQueueSnapshot gains Held and BlockedByDependency fields mapped from the analysis object; JS reads from correct json field names (held, blocked_by_dependency) with harmless legacy fallbacks; new Skipped detail row rendered correctly. |
| internal/state/state_test.go | New TestSupervisorQueueAnalysisIdleReasonExplainsSkipCategories covers mixed-category and single-category (BlockedByDependencyIssues) paths; assertions are precise. |
| internal/supervisor/supervisor_test.go | TestDecide_DynamicWaveClassifiesAllSkipCategories exercises all four skip categories in one decision pass; TestDecide_DynamicWaveClassifiesTitleEpicAsHeld confirms the excluded→held reclassification for epic titles. |
| internal/server/fleet_test.go | Test inputs updated to 4 open issues with one per new skip category; assertions verify all four classified counts on the queue snapshot and check the combined IdleReason string format. |
| docs/fleet-mission-control-runbook.md | Runbook updated to reflect held/meta and blocked-deps as separate observable counters with operator remediation steps; step numbering renumbered correctly. |
| docs/PRD-gh-project-integration.md | Single-line config design update to mention held parent/meta work and blocker-dependency skips; no logic issues. |
| docs/project-setup-runbook.md | Fleet response description updated to mention the new split skip counts in queue snapshots. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fleet queue snapshot: classify held/depe..."](https://github.com/befeast/maestro/commit/cddffe4982b41cf4c769a415b5bd08e988256e19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30500204)</sub>

<!-- /greptile_comment -->