### PR TITLE
Fleet attention: suppress stale review-feedback items after PR merge

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -259,6 +259,88 @@ func TestFleetAPIReviewRetryLifecycleDisplay(t *testing.T) {
 	}
 }
 
+func TestFleetAPISuppressesResolvedStaleReviewFeedback(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	finished := now.Add(-5 * time.Minute)
+	stateDir := filepath.Join(dir, "resolved-review-feedback")
+	st := state.NewState()
+	st.Sessions["merged-done"] = &state.Session{
+		IssueNumber:                 359,
+		IssueTitle:                  "Merged review feedback",
+		Status:                      state.StatusDone,
+		StartedAt:                   now.Add(-2 * time.Hour),
+		FinishedAt:                  &finished,
+		PRNumber:                    375,
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		RetryReason:                 state.RetryReasonReviewFeedback,
+	}
+	st.Sessions["open-feedback"] = &state.Session{
+		IssueNumber:                 360,
+		IssueTitle:                  "Open review feedback",
+		Status:                      state.StatusPROpen,
+		StartedAt:                   now.Add(-time.Hour),
+		PRNumber:                    376,
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+	}
+	st.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:        "sup-review-feedback",
+		CreatedAt: now,
+		Project:   "owner/resolved-review-feedback",
+		StuckStates: []state.SupervisorStuckState{
+			{
+				Code:              "stale_review_feedback",
+				Severity:          "blocked",
+				Summary:           "Issue #359 has review feedback, but no worker is currently fixing it.",
+				RecommendedAction: "Respawn a worker with the saved review feedback or resolve the feedback manually.",
+				Target:            &state.SupervisorTarget{Issue: 359, PR: 375, Session: "merged-done"},
+			},
+			{
+				Code:              "stale_review_feedback",
+				Severity:          "blocked",
+				Summary:           "Issue #360 has review feedback, but no worker is currently fixing it.",
+				RecommendedAction: "Respawn a worker with the saved review feedback or resolve the feedback manually.",
+				Target:            &state.SupervisorTarget{Issue: 360, PR: 376, Session: "open-feedback"},
+			},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(stateDir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	cfg := &config.Config{Repo: "owner/resolved-review-feedback", StateDir: stateDir, MaxParallel: 2}
+
+	single := buildStateResponse(cfg, st)
+	singleDone := findSessionInfo(t, single.All, "merged-done")
+	if singleDone.NeedsAttention || singleDone.DisplayStatus != "" || !contains(singleDone.StatusReason, "Issue is complete") {
+		t.Fatalf("single-project done session = %+v, want neutral historical status", singleDone)
+	}
+	singleOpen := findSessionInfo(t, single.All, "open-feedback")
+	if !singleOpen.NeedsAttention || !contains(singleOpen.StatusReason, "review feedback") {
+		t.Fatalf("single-project open feedback = %+v, want attention", singleOpen)
+	}
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("ResolvedReviewFeedback", "/tmp/resolved-review-feedback.yaml", "", cfg),
+	}, "127.0.0.1", 8786, true)
+	resp := srv.snapshot()
+
+	doneWorker := findFleetWorker(t, resp.Workers, "merged-done")
+	if doneWorker.NeedsAttention || doneWorker.DisplayStatus != "" || !contains(doneWorker.StatusReason, "Issue is complete") {
+		t.Fatalf("fleet done worker = %+v, want neutral historical status", doneWorker)
+	}
+	openWorker := findFleetWorker(t, resp.Workers, "open-feedback")
+	if !openWorker.NeedsAttention || !contains(openWorker.StatusReason, "review feedback") {
+		t.Fatalf("fleet open feedback worker = %+v, want attention", openWorker)
+	}
+	project := findFleetProject(t, resp.Projects, "ResolvedReviewFeedback")
+	if project.NeedsAttention != 1 || resp.Summary.NeedsAttention != 1 || len(resp.Attention) != 1 {
+		t.Fatalf("attention counts = project %d fleet %d inbox %d, want only open feedback", project.NeedsAttention, resp.Summary.NeedsAttention, len(resp.Attention))
+	}
+	if resp.Attention[0].Slot != "open-feedback" {
+		t.Fatalf("attention inbox = %+v, want only open-feedback", resp.Attention)
+	}
+}
+
 func TestFleetAPIIncludesQueueSnapshotMetadata(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now().UTC()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -493,6 +493,9 @@ func applySupervisorAttention(infos []sessionInfo, latest *state.SupervisorDecis
 			if !stuckTargetsSession(stuck, infos[i]) {
 				continue
 			}
+			if staleReviewFeedbackResolved(stuck, infos[i]) {
+				continue
+			}
 			attention := supervisorStuckNeedsAttention(stuck)
 			if !attention {
 				continue
@@ -509,6 +512,10 @@ func applySupervisorAttention(infos []sessionInfo, latest *state.SupervisorDecis
 			break
 		}
 	}
+}
+
+func staleReviewFeedbackResolved(stuck state.SupervisorStuckState, info sessionInfo) bool {
+	return stuck.Code == "stale_review_feedback" && state.SessionStatus(info.Status) == state.StatusDone
 }
 
 func stuckTargetsSession(stuck state.SupervisorStuckState, info sessionInfo) bool {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -515,7 +515,14 @@ func applySupervisorAttention(infos []sessionInfo, latest *state.SupervisorDecis
 }
 
 func staleReviewFeedbackResolved(stuck state.SupervisorStuckState, info sessionInfo) bool {
-	return stuck.Code == "stale_review_feedback" && state.SessionStatus(info.Status) == state.StatusDone
+	if stuck.Code != "stale_review_feedback" {
+		return false
+	}
+	status := state.SessionStatus(info.Status)
+	if status == state.StatusDone {
+		return true
+	}
+	return state.IsTerminal(status) && stuck.Target != nil && info.PRNumber > 0 && stuck.Target.PR == info.PRNumber
 }
 
 func stuckTargetsSession(stuck state.SupervisorStuckState, info sessionInfo) bool {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -487,6 +487,65 @@ func TestApplySupervisorAttentionSessionTargetDoesNotFallback(t *testing.T) {
 	}
 }
 
+func TestApplySupervisorAttentionSuppressesResolvedStaleReviewFeedback(t *testing.T) {
+	infos := []sessionInfo{
+		{
+			Slot:           "slot-1",
+			IssueNumber:    359,
+			PRNumber:       375,
+			Status:         string(state.StatusDone),
+			StatusReason:   "Issue is complete; PR merged or issue was closed and the session is terminal.",
+			NeedsAttention: false,
+		},
+	}
+	decision := &state.SupervisorDecision{
+		StuckStates: []state.SupervisorStuckState{
+			{
+				Code:              "stale_review_feedback",
+				Severity:          "blocked",
+				Summary:           "Issue #359 has review feedback, but no worker is currently fixing it.",
+				RecommendedAction: "Respawn a worker with the saved review feedback or resolve the feedback manually.",
+				Target:            &state.SupervisorTarget{Issue: 359, PR: 375, Session: "slot-1"},
+			},
+		},
+	}
+
+	applySupervisorAttention(infos, decision)
+
+	if infos[0].NeedsAttention {
+		t.Fatalf("resolved stale feedback should not need attention: %#v", infos[0])
+	}
+	if !contains(infos[0].StatusReason, "Issue is complete") || infos[0].NextAction != "" {
+		t.Fatalf("resolved reason/action = %q/%q, want neutral historical status", infos[0].StatusReason, infos[0].NextAction)
+	}
+}
+
+func TestApplySupervisorAttentionKeepsOpenReviewFeedbackAttention(t *testing.T) {
+	infos := []sessionInfo{
+		{Slot: "slot-1", IssueNumber: 360, PRNumber: 376, Status: string(state.StatusPROpen)},
+	}
+	decision := &state.SupervisorDecision{
+		StuckStates: []state.SupervisorStuckState{
+			{
+				Code:              "stale_review_feedback",
+				Severity:          "blocked",
+				Summary:           "Issue #360 has review feedback, but no worker is currently fixing it.",
+				RecommendedAction: "Respawn a worker with the saved review feedback or resolve the feedback manually.",
+				Target:            &state.SupervisorTarget{Issue: 360, PR: 376, Session: "slot-1"},
+			},
+		},
+	}
+
+	applySupervisorAttention(infos, decision)
+
+	if !infos[0].NeedsAttention {
+		t.Fatalf("open review feedback should still need attention: %#v", infos[0])
+	}
+	if !contains(infos[0].StatusReason, "review feedback") || !contains(infos[0].NextAction, "Respawn a worker") {
+		t.Fatalf("attention reason/action = %q/%q, want review feedback guidance", infos[0].StatusReason, infos[0].NextAction)
+	}
+}
+
 func TestApplySupervisorAttentionSkipsInformationalStuckStates(t *testing.T) {
 	baseReason := "State says running, but the worker PID is not alive."
 	baseAction := "Run a Maestro reconciliation cycle."

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -520,6 +520,52 @@ func TestApplySupervisorAttentionSuppressesResolvedStaleReviewFeedback(t *testin
 	}
 }
 
+func TestApplySupervisorAttentionDoesNotOverwriteTerminalPRTargetedStaleReviewFeedback(t *testing.T) {
+	tests := []struct {
+		name   string
+		status state.SessionStatus
+	}{
+		{name: "dead", status: state.StatusDead},
+		{name: "retry exhausted", status: state.StatusRetryExhausted},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			infos := []sessionInfo{
+				{
+					Slot:           "slot-1",
+					IssueNumber:    359,
+					PRNumber:       375,
+					Status:         string(tt.status),
+					StatusReason:   "Existing terminal session state.",
+					NextAction:     "Handle the terminal session state.",
+					NeedsAttention: true,
+				},
+			}
+			decision := &state.SupervisorDecision{
+				StuckStates: []state.SupervisorStuckState{
+					{
+						Code:              "stale_review_feedback",
+						Severity:          "blocked",
+						Summary:           "Issue #359 has review feedback, but no worker is currently fixing it.",
+						RecommendedAction: "Respawn a worker with the saved review feedback or resolve the feedback manually.",
+						Target:            &state.SupervisorTarget{Issue: 359, PR: 375, Session: "slot-1"},
+					},
+				},
+			}
+
+			applySupervisorAttention(infos, decision)
+
+			if infos[0].StatusReason != "Existing terminal session state." || infos[0].NextAction != "Handle the terminal session state." {
+				t.Fatalf("terminal reason/action = %q/%q, want existing session state", infos[0].StatusReason, infos[0].NextAction)
+			}
+			if !infos[0].NeedsAttention {
+				t.Fatalf("terminal session attention should be preserved: %#v", infos[0])
+			}
+		})
+	}
+}
+
 func TestApplySupervisorAttentionKeepsOpenReviewFeedbackAttention(t *testing.T) {
 	infos := []sessionInfo{
 		{Slot: "slot-1", IssueNumber: 360, PRNumber: 376, Status: string(state.StatusPROpen)},

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -927,6 +927,27 @@ func TestSessionAttentionFor_ReviewFeedbackRetryCopy(t *testing.T) {
 	}
 }
 
+func TestSessionAttentionFor_DoneReviewFeedbackIsHistorical(t *testing.T) {
+	sess := &Session{
+		IssueNumber:                 359,
+		Status:                      StatusDone,
+		PRNumber:                    375,
+		PreviousAttemptFeedbackKind: RetryReasonReviewFeedback,
+		RetryReason:                 RetryReasonReviewFeedback,
+	}
+
+	attention := SessionAttentionFor(sess, nil)
+	if attention.NeedsAttention {
+		t.Fatalf("done session with stale review feedback should not need attention: %+v", attention)
+	}
+	if !containsString(attention.Reason, "Issue is complete") {
+		t.Fatalf("reason = %q, want completed historical status", attention.Reason)
+	}
+	if got := SessionDisplayStatusFor(sess, nil); got != string(StatusDone) {
+		t.Fatalf("display status = %q, want done", got)
+	}
+}
+
 func TestCountByStatus(t *testing.T) {
 	s := NewState()
 	s.Sessions["slot-1"] = &Session{IssueNumber: 1, Status: StatusRunning}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -571,7 +571,7 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time) []state
 				fmt.Sprintf("Session %s status=retry_exhausted retry_count=%d", slot, sess.RetryCount)))
 		}
 
-		if sess.PreviousAttemptFeedbackKind == "review_feedback" && sess.Status != state.StatusRunning {
+		if sess.PreviousAttemptFeedbackKind == state.RetryReasonReviewFeedback && e.staleReviewFeedbackNeedsAttention(sess) {
 			canAct := sess.Status == state.StatusDead && sess.NextRetryAt != nil
 			findings = append(findings, stuckState("stale_review_feedback", SeverityBlocked,
 				fmt.Sprintf("Issue #%d has review feedback, but no worker is currently fixing it.", sess.IssueNumber),
@@ -580,6 +580,25 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time) []state
 		}
 	}
 	return findings
+}
+
+func (e *Engine) staleReviewFeedbackNeedsAttention(sess *state.Session) bool {
+	if sess == nil || sess.Status == state.StatusRunning || sess.Status == state.StatusDone {
+		return false
+	}
+	if sess.PRNumber > 0 {
+		merged, err := e.reader.IsPRMerged(sess.PRNumber)
+		if err == nil && merged {
+			return false
+		}
+	}
+	if sess.IssueNumber > 0 {
+		closed, err := e.reader.IsIssueClosed(sess.IssueNumber)
+		if err == nil && closed {
+			return false
+		}
+	}
+	return true
 }
 
 func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR) []state.SupervisorStuckState {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -388,6 +388,16 @@ func TestDetectWorkerStuckStates_SuppressesResolvedReviewFeedback(t *testing.T) 
 			},
 		},
 		{
+			name:   "retry exhausted merged PR",
+			reader: &fakeReader{mergedPRs: map[int]bool{375: true}},
+			sess: &state.Session{
+				IssueNumber:                 359,
+				Status:                      state.StatusRetryExhausted,
+				PRNumber:                    375,
+				PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+			},
+		},
+		{
 			name:   "closed issue",
 			reader: &fakeReader{closedIssues: map[int]bool{359: true}},
 			sess: &state.Session{

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -360,6 +360,87 @@ func TestDecide_StaleWorkerLogsExplained(t *testing.T) {
 	}
 }
 
+func TestDetectWorkerStuckStates_SuppressesResolvedReviewFeedback(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		reader *fakeReader
+		sess   *state.Session
+	}{
+		{
+			name:   "done session",
+			reader: &fakeReader{mergedPRs: map[int]bool{375: true}},
+			sess: &state.Session{
+				IssueNumber:                 359,
+				Status:                      state.StatusDone,
+				PRNumber:                    375,
+				PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+			},
+		},
+		{
+			name:   "merged PR",
+			reader: &fakeReader{mergedPRs: map[int]bool{375: true}},
+			sess: &state.Session{
+				IssueNumber:                 359,
+				Status:                      state.StatusDead,
+				PRNumber:                    375,
+				PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+			},
+		},
+		{
+			name:   "closed issue",
+			reader: &fakeReader{closedIssues: map[int]bool{359: true}},
+			sess: &state.Session{
+				IssueNumber:                 359,
+				Status:                      state.StatusDead,
+				PRNumber:                    375,
+				PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := state.NewState()
+			st.Sessions["slot-1"] = tt.sess
+
+			findings := testEngine(testConfig(t), tt.reader).detectWorkerStuckStates(st, now)
+
+			for _, stuck := range findings {
+				if stuck.Code == "stale_review_feedback" {
+					t.Fatalf("resolved review feedback should not create stale_review_feedback: %#v", findings)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectWorkerStuckStates_OpenReviewFeedbackNeedsAttention(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{
+		prs:          []github.PR{{Number: 376, State: "OPEN"}},
+		mergedPRs:    map[int]bool{376: false},
+		closedIssues: map[int]bool{360: false},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber:                 360,
+		Status:                      state.StatusPROpen,
+		PRNumber:                    376,
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	stuck := requireStuckState(t, decision, "stale_review_feedback")
+	if stuck.Severity != SeverityBlocked || stuck.Target == nil || stuck.Target.PR != 376 {
+		t.Fatalf("stale review feedback stuck state = %#v, want blocked PR #376", stuck)
+	}
+}
+
 func TestDecide_ClosedPRWithActiveSessionExplained(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{}


### PR DESCRIPTION
Closes #328

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two-layer suppression for stale `stale_review_feedback` attention items after a PR is merged or issue is closed: (1) in the supervisor (`staleReviewFeedbackNeedsAttention`) by skipping stuck-state generation when the PR is merged or issue is closed via live API calls, and (2) in the server (`staleReviewFeedbackResolved`) by dropping supervisor-persisted stuck states from the UI when the session has reached `StatusDone` or any other terminal status with a matching PR number. Both layers are exercised by a comprehensive set of new unit and integration tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic bugs found; both suppression layers are consistent with each other and well-covered by tests.

All changed paths are exercised by targeted tests; the supervisor's live-API suppression and the server's lag-window heuristic are complementary and handle the full lifecycle (done, merged PR, closed issue, open/active cases). No P0 or P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds `staleReviewFeedbackNeedsAttention` helper that gates stuck-state generation on live PR-merged / issue-closed API results; the safe default (return true on API error) is correct. |
| internal/server/server.go | Adds `staleReviewFeedbackResolved` to suppress stale supervisor-cached stuck states on the UI path; covers `StatusDone` and the terminal+matching-PR case as a lag-window heuristic. |
| internal/server/server_test.go | Three new focused tests cover: done-session suppression, non-overwrite for dead/retry-exhausted terminal sessions, and persistence of open-feedback attention. |
| internal/supervisor/supervisor_test.go | Table-driven test covers done, merged-PR, retry-exhausted-merged-PR, and closed-issue suppression cases; positive case test confirms open PR+open issue still fires the stuck state. |
| internal/server/fleet_test.go | End-to-end fleet snapshot test validates that only the genuinely open review-feedback slot appears in the attention inbox and project/fleet counts. |
| internal/state/state_test.go | Adds state-layer test confirming a `StatusDone` session with `RetryReasonReviewFeedback` is treated as historical (no attention, correct display status). |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fleet attention: align stale review supp..."](https://github.com/befeast/maestro/commit/78b66852b1cb68ff4e818d917e2fc15f0dd8b966) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30504074)</sub>

<!-- /greptile_comment -->