### PR TITLE
feat: persist outcome health checks

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -717,7 +717,7 @@ func buildProjectStatusJSON(cfg *config.Config, s *state.State) projectStatusJSO
 	return projectStatusJSON{
 		Repo:    cfg.Repo,
 		Prefix:  cfg.SessionPrefix,
-		Outcome: outcome.StatusFor(cfg.Outcome, s.DonePRCount(), s.LastMergeAt),
+		Outcome: outcomeStatusForState(cfg, s),
 		State:   s,
 	}
 }
@@ -923,7 +923,7 @@ func showSupervisorPolicy(cfg *config.Config) {
 }
 
 func showOutcomeStatus(cfg *config.Config, s *state.State) {
-	status := outcome.StatusFor(cfg.Outcome, s.DonePRCount(), s.LastMergeAt)
+	status := outcomeStatusForState(cfg, s)
 	if !status.Configured {
 		fmt.Println("Outcome:        not configured (issue throughput alone is not enough)")
 		fmt.Printf("Outcome next:   %s\n", status.NextAction)
@@ -937,9 +937,25 @@ func showOutcomeStatus(cfg *config.Config, s *state.State) {
 	fmt.Printf("Outcome:        %s\n", goal)
 	fmt.Printf("Runtime target: %s\n", runtimeTarget)
 	fmt.Printf("Outcome health: %s\n", valueOrDash(status.HealthState))
+	if status.HealthCheckedAt != "" {
+		fmt.Printf("Outcome checked: %s\n", status.HealthCheckedAt)
+	}
+	if status.HealthSummary != "" {
+		fmt.Printf("Outcome check:  %s\n", status.HealthSummary)
+	}
 	if status.NextAction != "" {
 		fmt.Printf("Outcome next:   %s\n", status.NextAction)
 	}
+}
+
+func outcomeStatusForState(cfg *config.Config, s *state.State) outcome.Status {
+	if cfg == nil || s == nil {
+		return outcome.StatusFor(outcome.Brief{}, 0, time.Time{})
+	}
+	if s.OutcomeHealth != nil {
+		return outcome.StatusFor(cfg.Outcome, s.DonePRCount(), s.LastMergeAt, *s.OutcomeHealth)
+	}
+	return outcome.StatusFor(cfg.Outcome, s.DonePRCount(), s.LastMergeAt)
 }
 
 func valueOrDash(value string) string {

--- a/internal/outcome/checker.go
+++ b/internal/outcome/checker.go
@@ -1,0 +1,180 @@
+package outcome
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultCheckTimeout = 15 * time.Second
+	maxCheckDetailBytes = 4000
+)
+
+// Checker executes configured read-only outcome signals and returns a compact
+// result that can be persisted in Maestro state.
+type Checker struct {
+	HTTPClient     *http.Client
+	CommandTimeout time.Duration
+	Now            func() time.Time
+	RunCommand     func(ctx context.Context, command, dir string) ([]byte, int, error)
+}
+
+func (c Checker) Check(ctx context.Context, brief Brief) HealthCheckResult {
+	brief = brief.Normalized()
+	start := c.now()
+	result := HealthCheckResult{
+		CheckedAt: start,
+		State:     HealthUnknown,
+	}
+	if !brief.Configured() {
+		result.State = HealthNotConfigured
+		result.Summary = "No outcome brief is configured."
+		return result
+	}
+	if !brief.HasHealthSignal() {
+		result.State = HealthUnmonitored
+		result.Summary = "No outcome health signal is configured."
+		return result
+	}
+	if strings.TrimSpace(brief.HealthcheckURL) != "" {
+		result = c.checkURL(ctx, brief.HealthcheckURL)
+	} else if strings.TrimSpace(brief.HealthcheckCommand) != "" {
+		result = c.checkCommand(ctx, brief.HealthcheckCommand, brief.SourceRepoPath, "healthcheck_command")
+	} else {
+		result = c.checkCommand(ctx, brief.DeploymentStatusCommand, brief.SourceRepoPath, "deployment_status_command")
+	}
+	if result.CheckedAt.IsZero() {
+		result.CheckedAt = start
+	}
+	if result.DurationMillis == 0 {
+		result.DurationMillis = int64(c.now().Sub(start) / time.Millisecond)
+	}
+	result.Detail = compactDetail(result.Detail)
+	return result
+}
+
+func (c Checker) checkURL(ctx context.Context, rawURL string) HealthCheckResult {
+	start := c.now()
+	ctx, cancel := context.WithTimeout(ctx, c.timeout())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return c.result(start, "healthcheck_url", HealthFailing, fmt.Sprintf("Invalid healthcheck URL: %v", err), "", 0)
+	}
+	req.Header.Set("User-Agent", "maestro-outcome-check/1")
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return c.result(start, "healthcheck_url", HealthFailing, fmt.Sprintf("GET %s failed: %v", rawURL, err), "", 0)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxCheckDetailBytes+1))
+	state := HealthHealthy
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		state = HealthFailing
+	}
+	detail := ""
+	if state == HealthFailing {
+		detail = string(body)
+	}
+	return c.result(start, "healthcheck_url", state, fmt.Sprintf("GET %s returned %s", rawURL, resp.Status), detail, 0)
+}
+
+func (c Checker) checkCommand(ctx context.Context, command, dir, signal string) HealthCheckResult {
+	start := c.now()
+	ctx, cancel := context.WithTimeout(ctx, c.timeout())
+	defer cancel()
+
+	output, exitCode, err := c.runCommand(ctx, command, dir)
+	if err != nil {
+		summary := fmt.Sprintf("%s failed", signal)
+		if ctx.Err() == context.DeadlineExceeded {
+			summary = fmt.Sprintf("%s timed out after %s", signal, c.timeout().String())
+		} else if strings.TrimSpace(err.Error()) != "" {
+			summary = fmt.Sprintf("%s failed: %v", signal, err)
+		}
+		return c.result(start, signal, HealthFailing, summary, string(output), exitCode)
+	}
+	return c.result(start, signal, HealthHealthy, fmt.Sprintf("%s passed", signal), "", exitCode)
+}
+
+func (c Checker) runCommand(ctx context.Context, command, dir string) ([]byte, int, error) {
+	if c.RunCommand != nil {
+		return c.RunCommand(ctx, command, dir)
+	}
+	cmd := exec.CommandContext(ctx, "sh", "-lc", command)
+	if strings.TrimSpace(dir) != "" {
+		cmd.Dir = dir
+	}
+	output, err := cmd.CombinedOutput()
+	return output, exitCode(err), err
+}
+
+func (c Checker) result(start time.Time, signal, state, summary, detail string, exitCode int) HealthCheckResult {
+	return HealthCheckResult{
+		CheckedAt:      start,
+		Signal:         signal,
+		State:          state,
+		Summary:        strings.TrimSpace(summary),
+		Detail:         compactDetail(detail),
+		ExitCode:       exitCode,
+		DurationMillis: int64(c.now().Sub(start) / time.Millisecond),
+	}
+}
+
+func (c Checker) timeout() time.Duration {
+	if c.CommandTimeout > 0 {
+		return c.CommandTimeout
+	}
+	return defaultCheckTimeout
+}
+
+func (c Checker) now() time.Time {
+	if c.Now != nil {
+		return c.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return -1
+	}
+	if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+		return status.ExitStatus()
+	}
+	return -1
+}
+
+func compactDetail(detail string) string {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return ""
+	}
+	data := []byte(detail)
+	if len(data) <= maxCheckDetailBytes {
+		return detail
+	}
+	var buf bytes.Buffer
+	buf.Write(data[:maxCheckDetailBytes])
+	buf.WriteString("\n... truncated ...")
+	return buf.String()
+}

--- a/internal/outcome/outcome.go
+++ b/internal/outcome/outcome.go
@@ -9,6 +9,7 @@ const (
 	HealthNotConfigured = "not_configured"
 	HealthUnmonitored   = "unmonitored"
 	HealthUnknown       = "unknown"
+	HealthHealthy       = "healthy"
 	HealthFailing       = "failing"
 )
 
@@ -34,6 +35,10 @@ type Status struct {
 	RuntimeTarget           string   `json:"runtime_target,omitempty"`
 	RuntimeHost             string   `json:"runtime_host,omitempty"`
 	HealthState             string   `json:"health_state"`
+	HealthCheckedAt         string   `json:"health_checked_at,omitempty"`
+	HealthSignal            string   `json:"health_signal,omitempty"`
+	HealthSummary           string   `json:"health_summary,omitempty"`
+	HealthDetail            string   `json:"health_detail,omitempty"`
 	NextAction              string   `json:"next_action,omitempty"`
 	SourceRepoPath          string   `json:"source_repo_path,omitempty"`
 	DeploymentStatusCommand string   `json:"deployment_status_command,omitempty"`
@@ -43,6 +48,18 @@ type Status struct {
 	NonGoals                []string `json:"non_goals,omitempty"`
 	MergedPRs               int      `json:"merged_prs,omitempty"`
 	LastMergeAt             string   `json:"last_merge_at,omitempty"`
+}
+
+// HealthCheckResult is the durable result of a read-only runtime/deploy health
+// check. It is intentionally compact because it is stored in Maestro state.
+type HealthCheckResult struct {
+	CheckedAt      time.Time `json:"checked_at,omitempty"`
+	Signal         string    `json:"signal,omitempty"`
+	State          string    `json:"state"`
+	Summary        string    `json:"summary,omitempty"`
+	Detail         string    `json:"detail,omitempty"`
+	ExitCode       int       `json:"exit_code,omitempty"`
+	DurationMillis int64     `json:"duration_ms,omitempty"`
 }
 
 func (b Brief) Normalized() Brief {
@@ -75,10 +92,9 @@ func (b Brief) HasHealthSignal() bool {
 	return b.DeploymentStatusCommand != "" || b.HealthcheckCommand != "" || b.HealthcheckURL != ""
 }
 
-// StatusFor returns the current known outcome status. V1 intentionally does
-// not execute configured commands or URLs; it records whether health is known
-// enough to keep dispatching issue work with confidence.
-func StatusFor(brief Brief, mergedPRs int, lastMergeAt time.Time) Status {
+// StatusFor returns the current known outcome status. Callers may pass the
+// latest persisted health check result; StatusFor never executes checks itself.
+func StatusFor(brief Brief, mergedPRs int, lastMergeAt time.Time, checks ...HealthCheckResult) Status {
 	brief = brief.Normalized()
 	if !brief.Configured() {
 		return Status{
@@ -106,6 +122,26 @@ func StatusFor(brief Brief, mergedPRs int, lastMergeAt time.Time) Status {
 		status.LastMergeAt = lastMergeAt.UTC().Format(time.RFC3339)
 	}
 
+	check, hasCheck := latestCheck(checks)
+	if hasCheck {
+		status.HealthCheckedAt = check.CheckedAt.UTC().Format(time.RFC3339)
+		status.HealthSignal = check.Signal
+		status.HealthSummary = check.Summary
+		status.HealthDetail = check.Detail
+		if lastMergeAt.IsZero() || !check.CheckedAt.Before(lastMergeAt) {
+			status.HealthState = normalizedHealthState(check.State)
+			switch status.HealthState {
+			case HealthHealthy:
+				status.NextAction = "Runtime outcome health is passing; continue normal supervisor policy."
+			case HealthFailing:
+				status.NextAction = "Fix runtime/deploy health before dispatching more issue work."
+			default:
+				status.NextAction = "Re-run the configured runtime healthcheck before dispatching more issue throughput."
+			}
+			return status
+		}
+	}
+
 	if brief.HasHealthSignal() {
 		status.HealthState = HealthUnknown
 		status.NextAction = "Run the configured deployment status or healthcheck and prioritize runtime/deploy fixes until it passes."
@@ -117,6 +153,37 @@ func StatusFor(brief Brief, mergedPRs int, lastMergeAt time.Time) Status {
 		status.NextAction = "Verify the configured runtime outcome before dispatching more issue throughput."
 	}
 	return status
+}
+
+func latestCheck(checks []HealthCheckResult) (HealthCheckResult, bool) {
+	var latest HealthCheckResult
+	for _, check := range checks {
+		if check.CheckedAt.IsZero() {
+			continue
+		}
+		if latest.CheckedAt.IsZero() || check.CheckedAt.After(latest.CheckedAt) {
+			latest = check
+		}
+	}
+	if latest.CheckedAt.IsZero() {
+		return HealthCheckResult{}, false
+	}
+	return latest, true
+}
+
+func normalizedHealthState(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case HealthHealthy:
+		return HealthHealthy
+	case HealthFailing:
+		return HealthFailing
+	case HealthUnknown:
+		return HealthUnknown
+	case HealthUnmonitored:
+		return HealthUnmonitored
+	default:
+		return HealthUnknown
+	}
 }
 
 func compactStrings(values []string) []string {

--- a/internal/outcome/outcome_test.go
+++ b/internal/outcome/outcome_test.go
@@ -1,6 +1,9 @@
 package outcome
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -57,5 +60,73 @@ func TestStatusForConfiguredBriefUnknownHealth(t *testing.T) {
 	}
 	if len(status.NonGoals) != 1 || status.NonGoals[0] != "Rewrite" {
 		t.Fatalf("NonGoals = %#v, want compacted", status.NonGoals)
+	}
+}
+
+func TestStatusForUsesFreshHealthCheck(t *testing.T) {
+	lastMerge := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	status := StatusFor(Brief{
+		DesiredOutcome: "App is live",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}, 2, lastMerge, HealthCheckResult{
+		CheckedAt: lastMerge.Add(time.Minute),
+		Signal:    "healthcheck_url",
+		State:     HealthHealthy,
+		Summary:   "GET returned 200 OK",
+	})
+	if status.HealthState != HealthHealthy {
+		t.Fatalf("HealthState = %q, want %q", status.HealthState, HealthHealthy)
+	}
+	if status.HealthCheckedAt == "" || status.HealthSignal != "healthcheck_url" || status.HealthSummary == "" {
+		t.Fatalf("health metadata = %+v, want persisted check metadata", status)
+	}
+	if status.NextAction == "" {
+		t.Fatal("NextAction should explain healthy outcome")
+	}
+}
+
+func TestStatusForIgnoresHealthCheckBeforeLastMerge(t *testing.T) {
+	lastMerge := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	status := StatusFor(Brief{
+		DesiredOutcome: "App is live",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}, 2, lastMerge, HealthCheckResult{
+		CheckedAt: lastMerge.Add(-time.Minute),
+		State:     HealthHealthy,
+	})
+	if status.HealthState != HealthUnknown {
+		t.Fatalf("HealthState = %q, want %q for stale check", status.HealthState, HealthUnknown)
+	}
+}
+
+func TestCheckerHealthcheckURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	result := Checker{}.Check(context.Background(), Brief{
+		DesiredOutcome: "App is live",
+		HealthcheckURL: server.URL,
+	})
+	if result.State != HealthHealthy {
+		t.Fatalf("State = %q, want %q: %+v", result.State, HealthHealthy, result)
+	}
+	if result.Signal != "healthcheck_url" || result.Summary == "" {
+		t.Fatalf("result = %+v, want URL signal summary", result)
+	}
+}
+
+func TestCheckerCommandFailure(t *testing.T) {
+	result := Checker{
+		RunCommand: func(ctx context.Context, command, dir string) ([]byte, int, error) {
+			return []byte("not healthy"), 7, context.DeadlineExceeded
+		},
+	}.Check(context.Background(), Brief{
+		DesiredOutcome:     "App is live",
+		HealthcheckCommand: "status.sh",
+	})
+	if result.State != HealthFailing || result.ExitCode != 7 || result.Detail != "not healthy" {
+		t.Fatalf("result = %+v, want failing command result", result)
 	}
 }

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2620,11 +2620,15 @@ function outcomeHTML(project) {
   const host = o.runtime_host ? " · " + o.runtime_host : "";
   const health = o.health_state || (configured ? "unknown" : "not_configured");
   const next = o.next_action || (configured ? "Verify runtime health." : "Add an outcome brief to config.");
+  const checked = o.health_checked_at ? formatTimestamp(o.health_checked_at) : "-";
+  const summary = o.health_summary || "";
   return '<div class="outcome-status"><div class="label">Outcome Status</div>' +
     '<div class="outcome-lines">' +
       '<div class="outcome-line"><strong>Goal</strong> ' + escapeText(goal) + '</div>' +
       '<div class="outcome-line"><strong>Runtime</strong> ' + escapeText(target + host) + '</div>' +
       '<div class="outcome-line"><strong>Health</strong> ' + escapeText(health.replace(/_/g, " ")) + '</div>' +
+      '<div class="outcome-line"><strong>Checked</strong> ' + escapeText(checked) + '</div>' +
+      (summary ? '<div class="outcome-line"><strong>Signal</strong> ' + escapeText(summary) + '</div>' : "") +
       '<div class="outcome-line"><strong>Next</strong> ' + escapeText(next) + '</div>' +
     '</div></div>';
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -633,7 +633,7 @@ func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 		Repo:                cfg.Repo,
 		MaxParallel:         cfg.MaxParallel,
 		ReadOnly:            cfg.Server.ReadOnly,
-		Outcome:             outcome.StatusFor(cfg.Outcome, st.DonePRCount(), st.LastMergeAt),
+		Outcome:             outcomeStatusForState(cfg, st),
 		Actions:             projectActionAffordances(cfg.Server.ReadOnly, "/api/v1/actions", cfg.Repo),
 		SupervisorPolicy:    cfg.Supervisor,
 		All:                 make([]sessionInfo, 0, len(st.Sessions)),
@@ -678,6 +678,16 @@ func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 	}
 
 	return resp
+}
+
+func outcomeStatusForState(cfg *config.Config, st *state.State) outcome.Status {
+	if cfg == nil || st == nil {
+		return outcome.StatusFor(outcome.Brief{}, 0, time.Time{})
+	}
+	if st.OutcomeHealth != nil {
+		return outcome.StatusFor(cfg.Outcome, st.DonePRCount(), st.LastMergeAt, *st.OutcomeHealth)
+	}
+	return outcome.StatusFor(cfg.Outcome, st.DonePRCount(), st.LastMergeAt)
 }
 
 func (s *Server) handleWorkers(w http.ResponseWriter, r *http.Request) {
@@ -1545,6 +1555,8 @@ function renderOutcome(outcome) {
   const health = o.health_state || (configured ? "unknown" : "not_configured");
   const next = o.next_action || (configured ? "Verify runtime health." : "Add an outcome brief to config.");
   const host = o.runtime_host ? " · " + o.runtime_host : "";
+  const checked = o.health_checked_at ? formatTimestamp(o.health_checked_at) : "-";
+  const summary = o.health_summary || "";
   outcomePanelEl.innerHTML = '<div class="supervisor-head">' +
     '<span class="supervisor-title">Outcome</span>' +
     '<span class="supervisor-time">' + escapeText(health.replace(/_/g, " ")) + '</span>' +
@@ -1554,6 +1566,8 @@ function renderOutcome(outcome) {
       '<div class="outcome-line" title="' + escapeText(target + host) + '"><strong>Runtime</strong> ' + escapeText(target + host) + '</div>' +
       '<div class="outcome-line" title="' + escapeText(next) + '"><strong>Next</strong> ' + escapeText(next) + '</div>' +
       '<div class="outcome-line"><strong>Health</strong> ' + escapeText(health.replace(/_/g, " ")) + '</div>' +
+      '<div class="outcome-line"><strong>Checked</strong> ' + escapeText(checked) + '</div>' +
+      (summary ? '<div class="outcome-line" title="' + escapeText(summary) + '"><strong>Signal</strong> ' + escapeText(summary) + '</div>' : "") +
     '</div>';
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -543,12 +543,13 @@ type ApprovalAudit struct {
 }
 
 type State struct {
-	Sessions            map[string]*Session  `json:"sessions"`
-	Missions            map[int]*Mission     `json:"missions,omitempty"` // parent issue number → mission
-	SupervisorDecisions []SupervisorDecision `json:"supervisor_decisions,omitempty"`
-	Approvals           []Approval           `json:"approvals,omitempty"`
-	NextSlot            int                  `json:"next_slot"`
-	LastMergeAt         time.Time            `json:"last_merge_at,omitempty"`
+	Sessions            map[string]*Session        `json:"sessions"`
+	Missions            map[int]*Mission           `json:"missions,omitempty"` // parent issue number → mission
+	SupervisorDecisions []SupervisorDecision       `json:"supervisor_decisions,omitempty"`
+	Approvals           []Approval                 `json:"approvals,omitempty"`
+	OutcomeHealth       *outcome.HealthCheckResult `json:"outcome_health,omitempty"`
+	NextSlot            int                        `json:"next_slot"`
+	LastMergeAt         time.Time                  `json:"last_merge_at,omitempty"`
 
 	loadedHash  string
 	loadedState *State
@@ -706,6 +707,7 @@ func (s *State) copyFrom(src *State) {
 	s.Missions = src.Missions
 	s.SupervisorDecisions = src.SupervisorDecisions
 	s.Approvals = src.Approvals
+	s.OutcomeHealth = src.OutcomeHealth
 	s.NextSlot = src.NextSlot
 	s.LastMergeAt = src.LastMergeAt
 }
@@ -744,6 +746,7 @@ func mergeStateSnapshots(base, current, ours *State) (*State, error) {
 	if err := mergeSupervisorDecisions(merged, base, current, ours); err != nil {
 		return nil, err
 	}
+	merged.OutcomeHealth = mergeOutcomeHealth(base.OutcomeHealth, current.OutcomeHealth, ours.OutcomeHealth)
 	merged.NextSlot = mergeMonotonicInt(base.NextSlot, current.NextSlot, ours.NextSlot)
 	merged.LastMergeAt = mergeLatestTime(base.LastMergeAt, current.LastMergeAt, ours.LastMergeAt)
 	return merged, nil
@@ -875,6 +878,35 @@ func mergeLatestTime(base, current, ours time.Time) time.Time {
 		return ours
 	}
 	return current
+}
+
+func mergeOutcomeHealth(base, current, ours *outcome.HealthCheckResult) *outcome.HealthCheckResult {
+	candidate := latestOutcomeHealth(current, ours)
+	if candidate != nil {
+		return candidate
+	}
+	return cloneOutcomeHealth(base)
+}
+
+func latestOutcomeHealth(values ...*outcome.HealthCheckResult) *outcome.HealthCheckResult {
+	var latest *outcome.HealthCheckResult
+	for _, value := range values {
+		if value == nil || value.CheckedAt.IsZero() {
+			continue
+		}
+		if latest == nil || value.CheckedAt.After(latest.CheckedAt) {
+			latest = value
+		}
+	}
+	return cloneOutcomeHealth(latest)
+}
+
+func cloneOutcomeHealth(value *outcome.HealthCheckResult) *outcome.HealthCheckResult {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }
 
 func unionKeys(maps ...map[string]*Session) []string {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -132,6 +133,7 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 	if reader == nil {
 		reader = github.New(cfg.Repo)
 	}
+	recordOutcomeHealth(cfg, st)
 
 	decision, err := NewEngine(cfg, reader).Decide(st)
 	if err != nil {
@@ -156,6 +158,17 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 		}
 	}
 	return decision, nil
+}
+
+func recordOutcomeHealth(cfg *config.Config, st *state.State) {
+	if cfg == nil || st == nil {
+		return
+	}
+	if !cfg.Outcome.Configured() || !cfg.Outcome.HasHealthSignal() {
+		return
+	}
+	result := outcome.Checker{}.Check(context.Background(), cfg.Outcome)
+	st.OutcomeHealth = &result
 }
 
 // Decide observes state and GitHub read-only data, then returns the next recommendation.
@@ -559,6 +572,9 @@ func (e *Engine) outcomeStatus(st *state.State) outcome.Status {
 	if st != nil {
 		mergedPRs = st.DonePRCount()
 		lastMergeAt = st.LastMergeAt
+	}
+	if st != nil && st.OutcomeHealth != nil {
+		return outcome.StatusFor(e.cfg.Outcome, mergedPRs, lastMergeAt, *st.OutcomeHealth)
 	}
 	return outcome.StatusFor(e.cfg.Outcome, mergedPRs, lastMergeAt)
 }

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -3,6 +3,8 @@ package supervisor
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -637,6 +639,43 @@ func TestDecideDeterministic_OutcomeUsesStateMergeHistory(t *testing.T) {
 	}
 }
 
+func TestDecide_HealthyOutcomeAllowsIssueWorkAfterMerges(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome: "Hosted app responds to users",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "next outcome step", "maestro-ready")}}
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.LastMergeAt = now.Add(-10 * time.Minute)
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: now.Add(-time.Minute),
+		Signal:    "healthcheck_url",
+		State:     outcome.HealthHealthy,
+		Summary:   "GET returned 200 OK",
+	}
+	st.Sessions["done-1"] = &state.Session{IssueNumber: 1, IssueTitle: "first", Status: state.StatusDone, PRNumber: 10}
+	st.Sessions["done-2"] = &state.Session{IssueNumber: 2, IssueTitle: "second", Status: state.StatusDone, PRNumber: 11}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Outcome == nil || decision.Outcome.HealthState != outcome.HealthHealthy {
+		t.Fatalf("Outcome = %+v, want healthy persisted outcome", decision.Outcome)
+	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == state.StuckNoOutcomeProgress {
+			t.Fatalf("unexpected no_outcome_progress stuck state: %+v", stuck)
+		}
+	}
+}
+
 func TestDecide_EmptyStateNoAction(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{}
@@ -682,6 +721,36 @@ func TestRunOnceRecordsDecision(t *testing.T) {
 	}
 	if len(st.Approvals) != 0 {
 		t.Fatalf("approvals = %d, want 0 for safe action", len(st.Approvals))
+	}
+}
+
+func TestRunOnceRecordsOutcomeHealth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	cfg := testConfig(t)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome: "Hosted app responds to users",
+		HealthcheckURL: server.URL,
+	}
+	reader := &fakeReader{}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if decision.Outcome == nil || decision.Outcome.HealthState != outcome.HealthHealthy {
+		t.Fatalf("decision outcome = %+v, want healthy", decision.Outcome)
+	}
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if st.OutcomeHealth == nil || st.OutcomeHealth.State != outcome.HealthHealthy {
+		t.Fatalf("stored outcome health = %+v, want healthy", st.OutcomeHealth)
 	}
 }
 


### PR DESCRIPTION
## Summary
- execute configured outcome health signals during supervisor runs
- persist the latest health result in Maestro state and surface it in CLI/API/dashboard
- let supervisor continue issue policy when the runtime outcome is freshly healthy

## Test Plan
- go test ./...
- live smoke on workshop: maestro supervise --once --config /home/god/.maestro/maestro.d/maestro-supervisor-dogfood.yaml shows outcome health healthy

Follow-up to #329.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires outcome health checks into the supervisor loop: a new `Checker` type executes configured URL/command signals, the result is persisted in `State.OutcomeHealth`, and `StatusFor` uses it to let the supervisor continue normal issue dispatch when runtime health is freshly passing.

- **`recordOutcomeHealth` blocks `RunOnce` synchronously** for up to 15 s (`defaultCheckTimeout`) when the health endpoint is slow or unreachable (TCP timeout), stalling every supervisor run until the check resolves.
- **`checkCommand` treats `err == nil` as healthy** regardless of exit code — a custom `RunCommand` returning a non-zero code with `nil` error will be silently reported as `HealthHealthy`.

<h3>Confidence Score: 3/5</h3>

Two P1 logic issues present: synchronous blocking health check in the supervisor hot path, and an exit-code-not-checked footgun in the Checker API.

Two independent P1 findings cap the score below 4. The synchronous 15-second block directly affects supervisor responsiveness every run when a health endpoint is unavailable, and the RunCommand nil-error/non-zero-exit case silently reports healthy. Neither is catastrophic data-loss, but both are real present defects on the changed path.

internal/supervisor/supervisor.go (blocking health check in RunOnce) and internal/outcome/checker.go (checkCommand exit-code handling).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds `recordOutcomeHealth` that runs a synchronous health check (up to 15 s) inside `RunOnce` before the decision engine; could block supervisor on slow/unreachable endpoints. |
| internal/outcome/checker.go | New `Checker` type handles URL and command health signals; `checkCommand` treats `err == nil` as healthy without inspecting exit code, creating a footgun for custom `RunCommand` implementations. |
| internal/outcome/outcome.go | Extends `StatusFor` with variadic `HealthCheckResult` and adds staleness guard (`lastMergeAt` comparison); logic is clean and well-tested. |
| internal/state/state.go | Adds `OutcomeHealth *outcome.HealthCheckResult` field with correct 3-way merge (prefer latest `CheckedAt` of current/ours, fall back to base). |
| internal/server/server.go | Adds `outcomeStatusForState` helper and surfaces `health_checked_at`/`health_summary` in the embedded dashboard JS; mirrors `cmd/maestro/main.go` helper. |
| cmd/maestro/main.go | Switches CLI/API outcome rendering to `outcomeStatusForState` and shows `HealthCheckedAt`/`HealthSummary` in the status output; straightforward. |
| internal/outcome/outcome_test.go | Good coverage of freshness, staleness, URL check, and command failure paths for the new Checker and StatusFor overloads. |
| internal/supervisor/supervisor_test.go | New integration tests cover healthy outcome allowing issue dispatch and `RunOnce` persisting health state; well-structured. |
| internal/server/fleet.go | Adds `Checked` and `Signal` rows to the fleet dashboard HTML; changes are cosmetic and safe. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/supervisor/supervisor.go:170-171
**Synchronous health check blocks every supervisor run**

`recordOutcomeHealth` is called synchronously in `RunOnce` before `Decide`. With `context.Background()` and a `defaultCheckTimeout` of 15 s, a sluggish or unreachable health endpoint will stall the entire supervisor run for 15 seconds on every invocation. When the target host is simply slow to refuse (e.g. TCP timeout rather than ECONNREFUSED), callers can observe repeated 15-second delays every time `maestro supervise` runs.

Consider running the check in a goroutine with a separate short deadline, or treating a context-cancelled check as `HealthUnknown` without blocking `Decide`.

### Issue 2 of 2
internal/outcome/checker.go:102-112
**Custom `RunCommand` with non-zero exit code and nil error treated as healthy**

When a caller supplies a custom `RunCommand` that returns `(output, nonZeroCode, nil)`, `checkCommand` takes the `err == nil` path and reports `HealthHealthy`. The built-in path is safe because `exec.Cmd.CombinedOutput()` always returns a non-nil `*exec.ExitError` on non-zero exit, but the `RunCommand` field is part of the public `Checker` API and this contract is not documented or enforced. A test or integration stub that returns a failing exit code with `nil` error will silently produce a healthy result.

Consider checking `exitCode != 0` alongside `err != nil`:
```go
if err != nil || exitCode != 0 {
    // mark HealthFailing
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: persist outcome health checks"](https://github.com/befeast/maestro/commit/9ba7f489d58ea42f9bd20057978823749bc54434) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30521240)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->