### PR TITLE
M-001: UI: add supervisor heartbeat and verdict sentence to fleet header

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -21,7 +21,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const fleetProjectStaleAfter = 15 * time.Minute
+const (
+	fleetProjectStaleAfter             = 15 * time.Minute
+	fleetSupervisorHeartbeatStaleAfter = fleetProjectStaleAfter
+)
 
 // FleetProject describes one Maestro project exposed in the fleet dashboard.
 type FleetProject struct {
@@ -181,11 +184,17 @@ func (s *FleetServer) Start(ctx context.Context) error {
 type fleetResponse struct {
 	ReadOnly    bool                 `json:"read_only"`
 	RefreshedAt string               `json:"refreshed_at"`
+	Verdict     fleetVerdict         `json:"verdict"`
 	Projects    []fleetProjectState  `json:"projects"`
 	Summary     fleetSummary         `json:"summary"`
 	Workers     []fleetWorkerState   `json:"workers"`
 	Attention   []fleetWorkerState   `json:"attention"`
 	Approvals   []fleetApprovalState `json:"approvals,omitempty"`
+}
+
+type fleetVerdict struct {
+	Tone     string `json:"tone"`
+	Sentence string `json:"sentence"`
 }
 
 type fleetSummary struct {
@@ -547,7 +556,207 @@ func (s *FleetServer) snapshot() fleetResponse {
 		return left.Slot < right.Slot
 	})
 	sortFleetApprovals(resp.Approvals)
+	resp.Verdict = buildFleetVerdict(resp, now)
 	return resp
+}
+
+func buildFleetVerdict(resp fleetResponse, now time.Time) fleetVerdict {
+	latest := latestFleetSupervisorDecision(resp.Projects)
+	tone := fleetVerdictTone(resp.Summary, latest, now)
+	parts := []string{
+		fleetLivenessSentence(resp.Summary, resp.Projects, latest, now),
+		fleetRunningSentence(resp.Summary.Running, fleetIdleByPolicy(resp.Projects)),
+	}
+	if pr := fleetPRSentence(resp.Summary.PROpen); pr != "" {
+		parts = append(parts, pr)
+	}
+	parts = append(parts, fleetAttentionSentence(resp.Summary))
+	return fleetVerdict{
+		Tone:     tone,
+		Sentence: strings.Join(parts, " "),
+	}
+}
+
+func fleetVerdictTone(summary fleetSummary, latest *supervisorDecisionInfo, now time.Time) string {
+	if summary.Stale > 0 || latest == nil || supervisorHeartbeatStale(latest, now) {
+		return "daemon-down"
+	}
+	if summary.Errors > 0 || summary.NeedsAttention > 0 || summary.ApprovalsPending > 0 {
+		return "attention"
+	}
+	if summary.Running > 0 {
+		return "busy"
+	}
+	return "healthy"
+}
+
+func fleetLivenessSentence(summary fleetSummary, projects []fleetProjectState, latest *supervisorDecisionInfo, now time.Time) string {
+	if latest == nil || latest.CreatedAt.IsZero() {
+		return "Supervisor heartbeat unavailable."
+	}
+	if summary.Stale > 0 {
+		return fmt.Sprintf("Supervisor heartbeat stale for %s.", projectCountPhrase(summary.Stale))
+	}
+	if supervisorHeartbeatStale(latest, now) {
+		sentence := fmt.Sprintf("Supervisor heartbeat lost %s ago.", formatFleetVerdictAge(latest.CreatedAt, now))
+		if lastSafe := latestFleetSafeSupervisorAction(projects); lastSafe != nil {
+			if safe := fleetLastSafeActionSentence(*lastSafe, now); safe != "" {
+				sentence += " " + safe
+			}
+		}
+		return sentence
+	}
+	return "Supervisor healthy."
+}
+
+func supervisorHeartbeatStale(latest *supervisorDecisionInfo, now time.Time) bool {
+	if latest == nil || latest.CreatedAt.IsZero() {
+		return true
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return now.Sub(latest.CreatedAt) > fleetSupervisorHeartbeatStaleAfter
+}
+
+func fleetRunningSentence(running int, idleByPolicy bool) string {
+	switch running {
+	case 0:
+		if idleByPolicy {
+			return "No worker is running by policy."
+		}
+		return "No worker is running."
+	case 1:
+		return "1 worker is running."
+	default:
+		return fmt.Sprintf("%d workers are running.", running)
+	}
+}
+
+func fleetPRSentence(prOpen int) string {
+	switch prOpen {
+	case 0:
+		return ""
+	case 1:
+		return "1 PR is waiting for review."
+	default:
+		return fmt.Sprintf("%d PRs are waiting for review.", prOpen)
+	}
+}
+
+func fleetAttentionSentence(summary fleetSummary) string {
+	items := summary.NeedsAttention + summary.ApprovalsPending + summary.Errors
+	switch items {
+	case 0:
+		return "No item needs attention."
+	case 1:
+		return "1 item needs attention."
+	default:
+		return fmt.Sprintf("%d items need attention.", items)
+	}
+}
+
+func latestFleetSupervisorDecision(projects []fleetProjectState) *supervisorDecisionInfo {
+	var latest *supervisorDecisionInfo
+	for i := range projects {
+		decision := projects[i].Supervisor.Latest
+		if decision == nil || decision.CreatedAt.IsZero() {
+			continue
+		}
+		if latest == nil || decision.CreatedAt.After(latest.CreatedAt) {
+			latest = decision
+		}
+	}
+	return latest
+}
+
+func latestFleetSafeSupervisorAction(projects []fleetProjectState) *supervisorActionInfo {
+	var latest *supervisorActionInfo
+	for i := range projects {
+		action := projects[i].Supervisor.LastSafeAction
+		if action == nil || action.CreatedAt.IsZero() {
+			continue
+		}
+		if latest == nil || action.CreatedAt.After(latest.CreatedAt) {
+			latest = action
+		}
+	}
+	return latest
+}
+
+func fleetLastSafeActionSentence(action supervisorActionInfo, now time.Time) string {
+	summary := strings.TrimSpace(strings.Join(strings.Fields(action.Summary), " "))
+	if summary == "" {
+		summary = strings.TrimSpace(action.Action)
+	}
+	if summary == "" {
+		return ""
+	}
+	if len([]rune(summary)) > 120 {
+		runes := []rune(summary)
+		summary = string(runes[:117]) + "..."
+	}
+	if action.CreatedAt.IsZero() {
+		return fmt.Sprintf("Last safe action was %s.", strconv.Quote(summary))
+	}
+	return fmt.Sprintf("Last safe action was %s %s ago.", strconv.Quote(summary), formatFleetVerdictAge(action.CreatedAt, now))
+}
+
+func fleetIdleByPolicy(projects []fleetProjectState) bool {
+	sawPolicy := false
+	for _, project := range projects {
+		if project.Error != "" {
+			return false
+		}
+		if project.Running > 0 {
+			return false
+		}
+		if project.QueueSnapshot == nil || strings.TrimSpace(project.QueueSnapshot.IdleReason) == "" {
+			continue
+		}
+		sawPolicy = true
+	}
+	return sawPolicy
+}
+
+func projectCountPhrase(count int) string {
+	if count == 1 {
+		return "1 project"
+	}
+	return fmt.Sprintf("%d projects", count)
+}
+
+func formatFleetVerdictAge(t, now time.Time) string {
+	if t.IsZero() {
+		return "unknown"
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	d := now.Sub(t).Round(time.Second)
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Minute {
+		seconds := int(d / time.Second)
+		if seconds <= 0 {
+			return "just now"
+		}
+		return fmt.Sprintf("%ds", seconds)
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Round(time.Minute)/time.Minute))
+	}
+	if d < 24*time.Hour {
+		rounded := d.Round(time.Minute)
+		hours := int(rounded / time.Hour)
+		minutes := int((rounded % time.Hour) / time.Minute)
+		if minutes == 0 {
+			return fmt.Sprintf("%dh", hours)
+		}
+		return fmt.Sprintf("%dh%dm", hours, minutes)
+	}
+	return fmt.Sprintf("%dd", int(d.Round(24*time.Hour)/(24*time.Hour)))
 }
 
 func newFleetProjectFreshness() fleetProjectFreshness {
@@ -1037,6 +1246,7 @@ const fleetDashboardHTML = `<!DOCTYPE html>
     --ok: #3fb950;
     --warn: #d29922;
     --bad: #f85149;
+    --queued: #a371f7;
   }
   * { box-sizing: border-box; }
   body {
@@ -1057,6 +1267,23 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   }
   h1 { margin: 0; font-size: 19px; letter-spacing: 0; }
   .sub { color: var(--muted); font-size: 13px; }
+  .fleet-verdict {
+    max-width: 780px;
+    margin-top: 8px;
+    padding: 9px 12px;
+    border: 1px solid var(--line);
+    border-left-width: 4px;
+    border-radius: 12px;
+    background: rgba(88,166,255,.08);
+    color: var(--text);
+    font-size: 14px;
+    font-weight: 650;
+    line-height: 1.35;
+  }
+  .fleet-verdict.verdict-healthy { border-left-color: var(--ok); background: rgba(63,185,80,.09); }
+  .fleet-verdict.verdict-busy { border-left-color: var(--accent); background: rgba(88,166,255,.1); }
+  .fleet-verdict.verdict-attention { border-left-color: var(--warn); background: rgba(210,153,34,.11); }
+  .fleet-verdict.verdict-daemon-down { border-left-color: var(--bad); background: rgba(248,81,73,.12); }
   .stats {
     display: grid;
     grid-template-columns: repeat(5, minmax(68px, 1fr));
@@ -1632,6 +1859,7 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   <div>
     <h1>Maestro Fleet</h1>
     <div class="sub" id="subtitle">Loading projects...</div>
+    <div class="fleet-verdict verdict-healthy" id="fleet-verdict">Loading supervisor heartbeat...</div>
   </div>
   <div class="stats" id="stats"></div>
 </header>
@@ -1721,6 +1949,7 @@ const projectsEl = document.getElementById("projects");
 const projectSummaryEl = document.getElementById("project-summary");
 const statsEl = document.getElementById("stats");
 const subtitleEl = document.getElementById("subtitle");
+const fleetVerdictEl = document.getElementById("fleet-verdict");
 const tabsEl = document.getElementById("project-tabs");
 const approvalListEl = document.getElementById("approval-list");
 const approvalSummaryEl = document.getElementById("approval-summary");
@@ -1774,6 +2003,7 @@ const fleetState = {
   attention: [],
   workers: [],
   detail: null,
+  verdict: null,
   refreshedAt: ""
 };
 
@@ -2419,6 +2649,14 @@ function countFailed(project) {
   return project.failed || 0;
 }
 
+function renderFleetVerdict(verdict) {
+  const tones = new Set(["healthy", "busy", "attention", "daemon-down"]);
+  const tone = verdict && tones.has(verdict.tone) ? verdict.tone : "attention";
+  const sentence = verdict && verdict.sentence ? verdict.sentence : "Supervisor status unavailable. No worker state or attention state could be confirmed.";
+  fleetVerdictEl.className = "fleet-verdict verdict-" + tone;
+  fleetVerdictEl.textContent = sentence;
+}
+
 function renderStats(summary) {
   const items = [
     ["Projects", summary.projects || 0],
@@ -2931,6 +3169,7 @@ async function loadFleet() {
     fleetState.workers = fleetWorkersFromData(data);
     fleetState.approvals = approvalsFromData(data);
     fleetState.attention = attentionFromData(data);
+    fleetState.verdict = data.verdict || null;
     if (fleetState.selectedWorkerKey && !selectedWorker()) {
       fleetState.selectedWorkerKey = "";
       fleetState.detail = null;
@@ -2945,6 +3184,7 @@ async function loadFleet() {
       (alerts.length ? " · " + alerts.join(" · ") : "");
     renderFilterOptions();
     syncFilterControls();
+    renderFleetVerdict(fleetState.verdict);
     renderStats(summary);
     renderProjectTabs();
     renderProjectOverview();
@@ -2954,6 +3194,7 @@ async function loadFleet() {
     renderWorkerDetail(fleetState.detail);
   } catch (err) {
     subtitleEl.textContent = "Fleet API error" + (fleetState.refreshedAt ? " · Last successful refresh " + formatTimestamp(fleetState.refreshedAt) : "");
+    renderFleetVerdict({ tone: "daemon-down", sentence: "Fleet API error. Supervisor heartbeat unavailable; worker state and attention state could not be confirmed." });
     approvalSummaryEl.textContent = "Fleet API error";
     approvalListEl.innerHTML = '<div class="error">Unable to load approval inbox.</div>';
     attentionSummaryEl.textContent = "Fleet API error";

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -578,10 +578,10 @@ func buildFleetVerdict(resp fleetResponse, now time.Time) fleetVerdict {
 }
 
 func fleetVerdictTone(summary fleetSummary, latest *supervisorDecisionInfo, now time.Time) string {
-	if summary.Stale > 0 || latest == nil || supervisorHeartbeatStale(latest, now) {
+	if latest == nil || supervisorHeartbeatStale(latest, now) {
 		return "daemon-down"
 	}
-	if summary.Errors > 0 || summary.NeedsAttention > 0 || summary.ApprovalsPending > 0 {
+	if summary.Stale > 0 || summary.Errors > 0 || summary.NeedsAttention > 0 || summary.ApprovalsPending > 0 {
 		return "attention"
 	}
 	if summary.Running > 0 {
@@ -594,9 +594,6 @@ func fleetLivenessSentence(summary fleetSummary, projects []fleetProjectState, l
 	if latest == nil || latest.CreatedAt.IsZero() {
 		return "Supervisor heartbeat unavailable."
 	}
-	if summary.Stale > 0 {
-		return fmt.Sprintf("Supervisor heartbeat stale for %s.", projectCountPhrase(summary.Stale))
-	}
 	if supervisorHeartbeatStale(latest, now) {
 		sentence := fmt.Sprintf("Supervisor heartbeat lost %s ago.", formatFleetVerdictAge(latest.CreatedAt, now))
 		if lastSafe := latestFleetSafeSupervisorAction(projects); lastSafe != nil {
@@ -605,6 +602,9 @@ func fleetLivenessSentence(summary fleetSummary, projects []fleetProjectState, l
 			}
 		}
 		return sentence
+	}
+	if summary.Stale > 0 {
+		return fmt.Sprintf("Supervisor healthy. %s.", staleProjectSnapshotPhrase(summary.Stale))
 	}
 	return "Supervisor healthy."
 }
@@ -645,7 +645,7 @@ func fleetPRSentence(prOpen int) string {
 }
 
 func fleetAttentionSentence(summary fleetSummary) string {
-	items := summary.NeedsAttention + summary.ApprovalsPending + summary.Errors
+	items := summary.NeedsAttention + summary.ApprovalsPending + summary.Errors + summary.Stale
 	switch items {
 	case 0:
 		return "No item needs attention."
@@ -703,7 +703,9 @@ func fleetLastSafeActionSentence(action supervisorActionInfo, now time.Time) str
 }
 
 func fleetIdleByPolicy(projects []fleetProjectState) bool {
-	sawPolicy := false
+	if len(projects) == 0 {
+		return false
+	}
 	for _, project := range projects {
 		if project.Error != "" {
 			return false
@@ -712,18 +714,17 @@ func fleetIdleByPolicy(projects []fleetProjectState) bool {
 			return false
 		}
 		if project.QueueSnapshot == nil || strings.TrimSpace(project.QueueSnapshot.IdleReason) == "" {
-			continue
+			return false
 		}
-		sawPolicy = true
 	}
-	return sawPolicy
+	return true
 }
 
-func projectCountPhrase(count int) string {
+func staleProjectSnapshotPhrase(count int) string {
 	if count == 1 {
-		return "1 project"
+		return "1 project snapshot is stale"
 	}
-	return fmt.Sprintf("%d projects", count)
+	return fmt.Sprintf("%d project snapshots are stale", count)
 }
 
 func formatFleetVerdictAge(t, now time.Time) string {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -449,6 +449,117 @@ func TestFleetAPIIncludesQueueSnapshotMetadata(t *testing.T) {
 	}
 }
 
+func TestFleetVerdictCoversHeaderStates(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name      string
+		sessions  map[string]*state.Session
+		decisions []state.SupervisorDecision
+		wantTone  string
+		wantText  []string
+	}{
+		{
+			name: "healthy idle by policy",
+			decisions: []state.SupervisorDecision{{
+				ID:                "sup-healthy-idle",
+				CreatedAt:         now,
+				Project:           "owner/healthy-idle",
+				Summary:           "No open issues match the configured ready labels.",
+				RecommendedAction: "none",
+				Risk:              "safe",
+				QueueAnalysis: &state.SupervisorQueueAnalysis{
+					OpenIssues:         1,
+					EligibleCandidates: 0,
+					ExcludedIssues:     1,
+				},
+			}},
+			wantTone: "healthy",
+			wantText: []string{"Supervisor healthy.", "No worker is running by policy.", "No item needs attention."},
+		},
+		{
+			name: "busy running worker",
+			sessions: map[string]*state.Session{
+				"busy-1": {
+					IssueNumber: 11,
+					IssueTitle:  "Build busy thing",
+					Status:      state.StatusRunning,
+					StartedAt:   now.Add(-time.Minute),
+					PID:         os.Getpid(),
+				},
+			},
+			decisions: []state.SupervisorDecision{{
+				ID:                "sup-busy",
+				CreatedAt:         now,
+				Project:           "owner/busy",
+				Summary:           "Worker is already running.",
+				RecommendedAction: "wait_for_worker",
+				Risk:              "safe",
+			}},
+			wantTone: "busy",
+			wantText: []string{"Supervisor healthy.", "1 worker is running.", "No item needs attention."},
+		},
+		{
+			name: "attention required",
+			sessions: map[string]*state.Session{
+				"dead-1": {
+					IssueNumber: 12,
+					IssueTitle:  "Dead worker",
+					Status:      state.StatusDead,
+					StartedAt:   now.Add(-2 * time.Minute),
+				},
+			},
+			decisions: []state.SupervisorDecision{{
+				ID:                "sup-attention",
+				CreatedAt:         now,
+				Project:           "owner/attention",
+				Summary:           "Worker needs reconciliation.",
+				RecommendedAction: "wait_for_reconciliation",
+				Risk:              "safe",
+			}},
+			wantTone: "attention",
+			wantText: []string{"Supervisor healthy.", "No worker is running.", "1 item needs attention."},
+		},
+		{
+			name: "daemon down stale heartbeat",
+			decisions: []state.SupervisorDecision{{
+				ID:                "sup-stale",
+				CreatedAt:         now.Add(-fleetSupervisorHeartbeatStaleAfter - time.Minute),
+				Project:           "owner/stale",
+				Summary:           "No worker slot is available.",
+				RecommendedAction: "none",
+				Risk:              "safe",
+			}},
+			wantTone: "daemon-down",
+			wantText: []string{"Supervisor heartbeat lost", "Last safe action was", "No worker is running.", "No item needs attention."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			stateDir := filepath.Join(dir, "state")
+			saveFleetTestSnapshot(t, stateDir, tt.sessions, tt.decisions)
+			srv := NewFleet([]FleetProject{
+				NewFleetProject("Project", "/tmp/project.yaml", "", &config.Config{
+					Repo:        "owner/project",
+					StateDir:    stateDir,
+					MaxParallel: 1,
+				}),
+			}, "127.0.0.1", 8786, true)
+
+			resp := srv.snapshot()
+			if resp.Verdict.Tone != tt.wantTone {
+				t.Fatalf("verdict tone = %q, want %q; sentence=%q", resp.Verdict.Tone, tt.wantTone, resp.Verdict.Sentence)
+			}
+			for _, want := range tt.wantText {
+				if !contains(resp.Verdict.Sentence, want) {
+					t.Fatalf("verdict sentence = %q, want %q", resp.Verdict.Sentence, want)
+				}
+			}
+		})
+	}
+}
+
 func TestFleetAPISurfacesProjectErrorsAndStaleFreshness(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now().UTC()
@@ -1041,6 +1152,10 @@ func TestFleetDashboard(t *testing.T) {
 		"/api/v1/fleet",
 		"/api/v1/fleet/worker",
 		"project-tabs",
+		"fleet-verdict",
+		"renderFleetVerdict",
+		"verdict-healthy",
+		"verdict-daemon-down",
 		"approval-inbox",
 		"approval-list",
 		"approval-summary",
@@ -1194,9 +1309,17 @@ func findFleetApproval(t *testing.T, approvals []fleetApprovalState, id string) 
 
 func saveFleetTestState(t *testing.T, dir string, sessions map[string]*state.Session) {
 	t.Helper()
+	saveFleetTestSnapshot(t, dir, sessions, nil)
+}
+
+func saveFleetTestSnapshot(t *testing.T, dir string, sessions map[string]*state.Session, decisions []state.SupervisorDecision) {
+	t.Helper()
 	st := state.NewState()
 	for name, sess := range sessions {
 		st.Sessions[name] = sess
+	}
+	for _, decision := range decisions {
+		st.RecordSupervisorDecision(decision, state.DefaultSupervisorDecisionLimit)
 	}
 	if err := state.Save(dir, st); err != nil {
 		t.Fatalf("save state: %v", err)

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -560,6 +560,42 @@ func TestFleetVerdictCoversHeaderStates(t *testing.T) {
 	}
 }
 
+func TestFleetVerdictDoesNotTreatProjectFreshnessStaleAsHeartbeatStale(t *testing.T) {
+	now := time.Now().UTC()
+	latest := &supervisorDecisionInfo{CreatedAt: now}
+	resp := fleetResponse{
+		Summary: fleetSummary{Projects: 1, Stale: 1},
+		Projects: []fleetProjectState{{
+			Supervisor: supervisorInfo{Latest: latest},
+		}},
+	}
+
+	verdict := buildFleetVerdict(resp, now)
+	if verdict.Tone != "attention" {
+		t.Fatalf("verdict tone = %q, want attention; sentence=%q", verdict.Tone, verdict.Sentence)
+	}
+	if contains(verdict.Sentence, "heartbeat stale") || contains(verdict.Sentence, "heartbeat lost") {
+		t.Fatalf("verdict sentence = %q, should not label stale snapshots as stale heartbeat", verdict.Sentence)
+	}
+	for _, want := range []string{"Supervisor healthy.", "1 project snapshot is stale.", "1 item needs attention."} {
+		if !contains(verdict.Sentence, want) {
+			t.Fatalf("verdict sentence = %q, want %q", verdict.Sentence, want)
+		}
+	}
+}
+
+func TestFleetIdleByPolicyRequiresEveryIdleProjectReason(t *testing.T) {
+	policyIdle := fleetProjectState{QueueSnapshot: &fleetQueueSnapshot{IdleReason: "Policy excluded all 1 open issue."}}
+	alsoPolicyIdle := fleetProjectState{QueueSnapshot: &fleetQueueSnapshot{IdleReason: "No open issues are available."}}
+
+	if !fleetIdleByPolicy([]fleetProjectState{policyIdle, alsoPolicyIdle}) {
+		t.Fatal("fleetIdleByPolicy = false, want true when every idle project has a policy reason")
+	}
+	if fleetIdleByPolicy([]fleetProjectState{policyIdle, {}}) {
+		t.Fatal("fleetIdleByPolicy = true, want false when another idle project lacks a policy reason")
+	}
+}
+
 func TestFleetAPISurfacesProjectErrorsAndStaleFreshness(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now().UTC()


### PR DESCRIPTION
Closes #336

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a supervisor heartbeat indicator and verdict sentence to the fleet dashboard header. It introduces `fleetVerdict` (tone + sentence) computed from the latest supervisor decision timestamp, worker running count, idle-by-policy status, open PRs, and attention items, surfaced both in the JSON API and rendered as a colour-coded banner in the frontend.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all new logic is well-guarded, edge cases are covered, and the feature is purely additive.

No logic bugs found. All four verdict tones are reachable and tested; nil/zero-time guards are consistently applied; `fleetIdleByPolicy` correctly requires every project to satisfy the policy-idle condition; Unicode truncation uses rune slicing; the verdict is computed after the full response is built. The JS fallback on unknown tones is also correct.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds `fleetVerdict` struct, builds supervisor heartbeat/verdict sentence via `buildFleetVerdict` and helpers, inlines CSS classes and JS rendering for the new fleet header widget — logic is well-structured and edge cases (nil latest, stale heartbeat, idle-by-policy, Unicode truncation) are handled correctly. |
| internal/server/fleet_test.go | Adds four table-driven verdict tests covering all four tones, a focused test preventing confusion between project-snapshot staleness and heartbeat staleness, and a unit test for `fleetIdleByPolicy`; also extends `saveFleetTestState` to accept supervisor decisions. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: correct fleet verdict stale handlin..."](https://github.com/befeast/maestro/commit/037d908add97ce90a5e5f8f412f7c73282c2f2a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30550176)</sub>

<!-- /greptile_comment -->