### PR TITLE
M-002: UI: hide approval-gated controls in read-only mode

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -3032,6 +3032,9 @@ function renderWorkers(project) {
 }
 
 function renderProjectActions(project) {
+  if (project.read_only === true) {
+    return '<div class="project-actions"><div class="action-note">Write controls are disabled in read-only mode.</div></div>';
+  }
   return '<div class="project-actions"><div class="label">Approval-gated controls</div>' +
     renderActions(project.actions || [], { details: false }) + '</div>';
 }

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1275,6 +1276,64 @@ func TestFleetDashboard(t *testing.T) {
 			t.Fatalf("dashboard should not render stale approval history with alarming styling %q", oldAlarm)
 		}
 	}
+}
+
+func TestFleetDashboardReadOnlyProjectControlsRenderQuietNote(t *testing.T) {
+	body := fleetDashboardBody(t)
+	readOnlyBranch := dashboardSnippet(t, body,
+		"if (project.read_only === true)",
+		"return '<div class=\"project-actions\"><div class=\"label\">Approval-gated controls</div>'")
+
+	if !contains(readOnlyBranch, "Write controls are disabled in read-only mode.") {
+		t.Fatalf("read-only project controls should render disabled-write explanation, got:\n%s", readOnlyBranch)
+	}
+	for _, unwanted := range []string{"action-btn", "<button", "renderActions("} {
+		if contains(readOnlyBranch, unwanted) {
+			t.Fatalf("read-only project controls should not render button-like controls %q in:\n%s", unwanted, readOnlyBranch)
+		}
+	}
+}
+
+func TestFleetDashboardWritableProjectControlsKeepApprovalDiagnostics(t *testing.T) {
+	body := fleetDashboardBody(t)
+	writableBranch := dashboardSnippet(t, body,
+		"return '<div class=\"project-actions\"><div class=\"label\">Approval-gated controls</div>'",
+		"function projectFreshnessHTML")
+
+	for _, want := range []string{
+		"Approval-gated controls",
+		"renderActions(project.actions || [], { details: false })",
+	} {
+		if !contains(writableBranch, want) {
+			t.Fatalf("writable project controls should preserve %q in:\n%s", want, writableBranch)
+		}
+	}
+}
+
+func fleetDashboardBody(t *testing.T) string {
+	t.Helper()
+	srv := NewFleet(nil, "127.0.0.1", 8786, true)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleetDashboard(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	return w.Body.String()
+}
+
+func dashboardSnippet(t *testing.T, body, startMarker, endMarker string) string {
+	t.Helper()
+	start := strings.Index(body, startMarker)
+	if start < 0 {
+		t.Fatalf("dashboard missing start marker %q", startMarker)
+	}
+	rest := body[start:]
+	end := strings.Index(rest, endMarker)
+	if end < 0 {
+		t.Fatalf("dashboard missing end marker %q after %q", endMarker, startMarker)
+	}
+	return rest[:end]
 }
 
 func TestFleetActionReadOnlyRejectsMutation(t *testing.T) {


### PR DESCRIPTION
Closes #337

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an early-return guard in `renderProjectActions` (a JavaScript function embedded in the Go fleet dashboard template) so that read-only projects display a plain informational note instead of the approval-gated action buttons. Two new tests verify both the read-only and writable rendering paths via `dashboardSnippet`, a helper that slices the served JS source by text markers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — change is minimal, well-tested, and carries no logic risk.

The production change is three lines with a trivially correct boolean guard. Tests cover both branches and confirm no button controls leak through the read-only path. No P0/P1 findings identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds a 3-line early return in `renderProjectActions` that replaces approval-gated controls with a plain note when `project.read_only === true`; no logic issues. |
| internal/server/fleet_test.go | Adds two focused tests and two helpers (`fleetDashboardBody`, `dashboardSnippet`) that assert read-only and writable branches render correctly by slicing the served JS source; `contains` is the shared helper from `server_test.go`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: hide read-only project controls"](https://github.com/befeast/maestro/commit/7f74d1c11c74a3d98bd784dcea67235332b752f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30550871)</sub>

<!-- /greptile_comment -->