### PR TITLE
M-003: UI: default Fleet Workers to live scope and collapse history

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1111,7 +1111,7 @@ func autoCreatedPRBody(sess *state.Session, branch string, reasons []string) str
 	if reasonText == "" {
 		reasonText = "worker process exited before PR creation was observed"
 	}
-	return fmt.Sprintf(`Closes #%d
+	return fmt.Sprintf(`Refs #%d
 
 Maestro auto-created this PR because the worker pushed branch %s but exited before opening a pull request.
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -264,7 +264,7 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 	if !strings.Contains(gotTitle, "add branch rescue") || !strings.Contains(gotTitle, "(#108)") {
 		t.Fatalf("unexpected title %q", gotTitle)
 	}
-	if !strings.Contains(gotBody, "Closes #108") || !strings.Contains(gotBody, "auto-created") {
+	if !strings.Contains(gotBody, "Refs #108") || strings.Contains(gotBody, "Closes #108") || !strings.Contains(gotBody, "auto-created") {
 		t.Fatalf("unexpected body %q", gotBody)
 	}
 	if !s.IssueInProgress(108) {

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -307,6 +307,7 @@ type fleetWorkerState struct {
 	StatusReason      string          `json:"status_reason,omitempty"`
 	NextAction        string          `json:"next_action,omitempty"`
 	NeedsAttention    bool            `json:"needs_attention,omitempty"`
+	Live              bool            `json:"live"`
 	Backend           string          `json:"backend,omitempty"`
 	PRNumber          int             `json:"pr_number,omitempty"`
 	PRURL             string          `json:"pr_url,omitempty"`
@@ -941,15 +942,15 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 			item.ApprovalSummary[approval.Status]++
 		}
 	}
-	workers := make([]fleetWorkerState, 0)
+	workers := make([]fleetWorkerState, 0, len(projectState.All))
 	for _, worker := range projectState.All {
 		worker.Actions = workerActionAffordances(item.ReadOnly, "/api/v1/fleet/actions", worker)
 		if worker.NeedsAttention {
 			item.NeedsAttention++
 			item.Attention = append(item.Attention, worker)
 		}
-		if isFleetWorkerVisible(worker) {
-			workers = append(workers, makeFleetWorkerState(item, worker))
+		workers = append(workers, makeFleetWorkerState(item, worker))
+		if isFleetWorkerDefaultVisible(worker) {
 			if len(item.Active) >= 6 {
 				continue
 			}
@@ -959,18 +960,8 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	return item, workers
 }
 
-func isFleetWorkerVisible(worker sessionInfo) bool {
-	if worker.DisplayStatus != "" && worker.DisplayStatus != worker.Status {
-		return true
-	}
-	if worker.Status == string(state.StatusRunning) || worker.Status == string(state.StatusPROpen) || worker.NeedsAttention {
-		return true
-	}
-	if worker.Status == string(state.StatusDone) {
-		finishedAt, err := time.Parse(time.RFC3339, worker.FinishedAt)
-		return err == nil && time.Since(finishedAt) <= 24*time.Hour
-	}
-	return false
+func isFleetWorkerDefaultVisible(worker sessionInfo) bool {
+	return worker.NeedsAttention || worker.Live
 }
 
 func makeFleetWorkerState(project fleetProjectState, worker sessionInfo) fleetWorkerState {
@@ -987,6 +978,7 @@ func makeFleetWorkerState(project fleetProjectState, worker sessionInfo) fleetWo
 		StatusReason:      worker.StatusReason,
 		NextAction:        worker.NextAction,
 		NeedsAttention:    worker.NeedsAttention,
+		Live:              worker.Live,
 		Backend:           worker.Backend,
 		PRNumber:          worker.PRNumber,
 		PRURL:             worker.PRURL,
@@ -1613,9 +1605,31 @@ const fleetDashboardHTML = `<!DOCTYPE html>
   .worker-table tbody tr.row-running { background: rgba(63,185,80,.055); }
   .worker-table tbody tr.row-pr { background: rgba(88,166,255,.055); }
   .worker-table tbody tr.row-attention { background: rgba(248,81,73,.1); }
+  .worker-table tbody tr.history-row { background: rgba(139,148,158,.08); }
+  .worker-table tbody tr.history-row td { white-space: normal; }
   .worker-table tbody tr.selected { outline: 1px solid rgba(88,166,255,.65); outline-offset: -1px; }
   .worker-table tbody tr:hover { background: #18212c; }
+  .worker-table tbody tr.history-row:hover { background: rgba(139,148,158,.12); }
   .worker-table tbody tr[data-slot] { cursor: pointer; }
+  .history-row-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .history-row-content strong { color: var(--text); }
+  .history-row-content span { color: var(--muted); font-size: 12px; }
+  .history-row-action {
+    flex: 0 0 auto;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: var(--panel-2);
+    color: var(--accent);
+    cursor: pointer;
+    font: inherit;
+    padding: 5px 10px;
+  }
+  .history-row-action:hover { border-color: rgba(88,166,255,.65); }
   .project-col { width: 140px; font-weight: 650; }
   .slot-col { width: 92px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
   .issue-col { width: auto; }
@@ -2373,7 +2387,8 @@ function workerSearchText(worker) {
 }
 
 function workerMatchesFilters(worker) {
-  if (!workerMatchesScope(worker)) return false;
+  const drilldown = hasWorkerDrilldownFilters();
+  if (!workerMatchesScope(worker) && !(fleetState.filters.scope === "operator" && drilldown)) return false;
   if (fleetState.filters.status !== "all" && displayStatus(worker) !== fleetState.filters.status) return false;
   if (fleetState.filters.backend !== "all" && (worker.backend || "") !== fleetState.filters.backend) return false;
   if (fleetState.filters.pr === "with" && !worker.pr_number) return false;
@@ -2385,9 +2400,14 @@ function workerMatchesFilters(worker) {
 }
 
 function isLiveWorker(worker) {
+  if (worker.live === true) return true;
   const displayed = displayStatus(worker);
   return ["running", "pr_open", "queued", "review_retry_running", "review_retry_recheck", "review_retry_pending", "review_retry_backoff"].includes(displayed) ||
     ["running", "pr_open", "queued"].includes(worker.status || "");
+}
+
+function defaultWorkerVisible(worker) {
+  return workerNeedsAttention(worker) || isLiveWorker(worker);
 }
 
 function workerMatchesScope(worker) {
@@ -2419,7 +2439,11 @@ function selectedProjectWorkers() {
 }
 
 function hasWorkerFilters() {
-  return fleetState.filters.query !== "" || fleetState.filters.scope !== "operator" || fleetState.filters.status !== "all" || fleetState.filters.backend !== "all" || fleetState.filters.pr !== "all";
+  return fleetState.filters.scope !== "operator" || hasWorkerDrilldownFilters();
+}
+
+function hasWorkerDrilldownFilters() {
+  return fleetState.filters.query !== "" || fleetState.filters.status !== "all" || fleetState.filters.backend !== "all" || fleetState.filters.pr !== "all";
 }
 
 function workerNeedsAttention(worker) {
@@ -2713,22 +2737,26 @@ function renderProjectTabs() {
 function renderFleetWorkers() {
   const base = selectedProjectWorkers();
   const visible = sortWorkers(filteredWorkers(true));
+  const showingDefaultScope = fleetState.filters.scope === "operator" && !hasWorkerDrilldownFilters();
+  const hiddenHistory = showingDefaultScope ? base.filter(worker => !defaultWorkerVisible(worker)) : [];
+  const rowCount = visible.length + (hiddenHistory.length ? 1 : 0);
   const table = fleetWorkersEl.closest("table");
-  if (table) table.classList.toggle("worker-table-empty", visible.length === 0);
+  if (table) table.classList.toggle("worker-table-empty", rowCount === 0);
   const projectLabel = fleetState.selectedProject === "all" ? "all projects" : fleetState.selectedProject;
   const scopeLabel = scopeLabelText(fleetState.filters.scope);
   const filterText = hasWorkerFilters() ? " · " + visible.length + " shown from " + base.length + " total" : " · " + base.length + " total";
   const attentionCount = visible.filter(worker => worker.needs_attention).length;
   workerSummaryEl.textContent = scopeLabel + " · " + visible.length + " worker" + (visible.length === 1 ? "" : "s") + " in " + projectLabel +
-    filterText + (attentionCount ? " · " + attentionCount + " need attention" : "");
+    filterText + (hiddenHistory.length ? " · " + hiddenHistory.length + " historical collapsed" : "") +
+    (attentionCount ? " · " + attentionCount + " need attention" : "");
 
-  if (visible.length === 0) {
+  if (rowCount === 0) {
     const empty = fleetEmptyText(projectLabel, base.length);
     fleetWorkersEl.innerHTML = '<tr><td colspan="9" class="empty">' + escapeText(empty) + '</td></tr>';
     return;
   }
 
-  fleetWorkersEl.innerHTML = visible.map(worker => {
+  const rows = visible.map(worker => {
     const pr = worker.pr_number ? "#" + worker.pr_number : "-";
     const project = worker.project_name || "-";
     const issueText = issueSummaryText(worker);
@@ -2744,7 +2772,11 @@ function renderFleetWorkers() {
       '<td class="tokens-col">' + compactNumber(worker.tokens_used_total) + '</td>' +
       '<td class="action-col">' + renderActions(worker.actions || [], { details: false }) + '</td>' +
     '</tr>';
-  }).join("");
+  });
+  if (hiddenHistory.length) {
+    rows.push(historySummaryRowHTML(hiddenHistory));
+  }
+  fleetWorkersEl.innerHTML = rows.join("");
 
   fleetWorkersEl.querySelectorAll("tr[data-slot]").forEach(row => {
     row.addEventListener("click", () => selectWorker(row.dataset.project || "", row.dataset.slot || ""));
@@ -2755,6 +2787,31 @@ function renderFleetWorkers() {
       }
     });
   });
+  fleetWorkersEl.querySelectorAll("button[data-history-scope]").forEach(button => {
+    button.addEventListener("click", event => {
+      event.stopPropagation();
+      showHistoryScope(button.dataset.historyScope || "recent");
+    });
+  });
+}
+
+function historySummaryRowHTML(workers) {
+  const count = workers.length;
+  const sample = workers.slice(0, 3).map(worker => (worker.project_name || "-") + " / " + (worker.slot || "-")).join(", ");
+  const note = "Done/stale sessions are collapsed by default." + (sample ? " Examples: " + sample + "." : "") + " Search or switch scope to inspect every session.";
+  return '<tr class="history-row"><td colspan="9"><div class="history-row-content">' +
+    '<div><strong>' + escapeText(count + " historical worker" + (count === 1 ? "" : "s")) + '</strong><span> ' + escapeText(note) + '</span></div>' +
+    '<button type="button" class="history-row-action" data-history-scope="recent">Show history</button>' +
+    '</div></td></tr>';
+}
+
+function showHistoryScope(scope) {
+  fleetState.filters.scope = scope;
+  syncFilterControls();
+  updateQueryState();
+  renderProjectTabs();
+  renderProjectOverview();
+  renderFleetWorkers();
 }
 
 function scopeLabelText(scope) {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1017,6 +1017,104 @@ func TestFleetWorkersIncludeRecentlyCompletedDoneRows(t *testing.T) {
 	}
 }
 
+func TestFleetWorkersKeepHistoricalSessionsSearchableButOutOfDefaultScope(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	old := now.Add(-72 * time.Hour)
+	stateDir := filepath.Join(dir, "state")
+	sessions := make(map[string]*state.Session)
+	for i := 1; i <= 55; i++ {
+		finished := old.Add(-time.Duration(i) * time.Minute)
+		slot := "hist-" + strconv.Itoa(i)
+		sessions[slot] = &state.Session{
+			IssueNumber: 1000 + i,
+			IssueTitle:  "Historical done session",
+			Status:      state.StatusDone,
+			StartedAt:   finished.Add(-30 * time.Minute),
+			FinishedAt:  fleetTimePtr(finished),
+		}
+	}
+	recentFinished := now.Add(-15 * time.Minute)
+	retryAt := now.Add(30 * time.Minute)
+	sessions["live-running"] = &state.Session{
+		IssueNumber: 1,
+		IssueTitle:  "Running worker",
+		Status:      state.StatusRunning,
+		StartedAt:   now.Add(-time.Hour),
+	}
+	sessions["live-pr"] = &state.Session{
+		IssueNumber: 2,
+		IssueTitle:  "Open PR worker",
+		Status:      state.StatusPROpen,
+		StartedAt:   now.Add(-2 * time.Hour),
+		PRNumber:    22,
+	}
+	sessions["live-retry"] = &state.Session{
+		IssueNumber: 3,
+		IssueTitle:  "Retry worker",
+		Status:      state.StatusDead,
+		StartedAt:   old,
+		FinishedAt:  fleetTimePtr(old.Add(time.Hour)),
+		NextRetryAt: &retryAt,
+	}
+	sessions["live-recent"] = &state.Session{
+		IssueNumber: 4,
+		IssueTitle:  "Recently completed worker",
+		Status:      state.StatusDone,
+		StartedAt:   now.Add(-45 * time.Minute),
+		FinishedAt:  &recentFinished,
+	}
+	saveFleetTestState(t, stateDir, sessions)
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("One", "/tmp/one.yaml", "", &config.Config{
+			Repo:        "owner/one",
+			StateDir:    stateDir,
+			MaxParallel: 4,
+		}),
+	}, "127.0.0.1", 8786, true)
+	resp := srv.snapshot()
+
+	if len(resp.Workers) != 59 {
+		t.Fatalf("fleet workers len = %d, want all 59 searchable sessions", len(resp.Workers))
+	}
+	project := findFleetProject(t, resp.Projects, "One")
+	if project.Sessions != 59 {
+		t.Fatalf("project sessions = %d, want 59", project.Sessions)
+	}
+	if len(project.Active) != 4 {
+		t.Fatalf("project active len = %d, want live default set", len(project.Active))
+	}
+
+	defaultVisible := 0
+	visibleAttention := 0
+	historical := 0
+	for _, worker := range resp.Workers {
+		if worker.Live || worker.NeedsAttention {
+			defaultVisible++
+			if worker.NeedsAttention {
+				visibleAttention++
+			}
+		} else {
+			historical++
+		}
+	}
+	if defaultVisible != 4 || historical != 55 {
+		t.Fatalf("default/history counts = %d/%d, want 4/55", defaultVisible, historical)
+	}
+	if resp.Summary.NeedsAttention != visibleAttention {
+		t.Fatalf("summary attention = %d, visible default attention = %d", resp.Summary.NeedsAttention, visibleAttention)
+	}
+
+	oldWorker := findFleetWorker(t, resp.Workers, "hist-1")
+	if oldWorker.Live || oldWorker.NeedsAttention {
+		t.Fatalf("old historical worker = %+v, want searchable but outside default live scope", oldWorker)
+	}
+	if !findFleetWorker(t, resp.Workers, "live-recent").Live {
+		t.Fatal("recently changed done worker should stay in the default live scope")
+	}
+}
+
 func TestFleetWorkerDetailIncludesMetadataAndLog(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now().UTC()
@@ -1278,6 +1376,23 @@ func TestFleetDashboard(t *testing.T) {
 	}
 }
 
+func TestFleetDashboardRendersHistoryCollapseControls(t *testing.T) {
+	body := fleetDashboardBody(t)
+	for _, want := range []string{
+		"function historySummaryRowHTML(workers)",
+		"class=\"history-row\"",
+		"data-history-scope=\"recent\"",
+		"historical collapsed",
+		"hasWorkerDrilldownFilters",
+		"worker.live === true",
+		"Search or switch scope to inspect every session.",
+	} {
+		if !contains(body, want) {
+			t.Fatalf("dashboard history collapse renderer should contain %q", want)
+		}
+	}
+}
+
 func TestFleetDashboardReadOnlyProjectControlsRenderQuietNote(t *testing.T) {
 	body := fleetDashboardBody(t)
 	readOnlyBranch := dashboardSnippet(t, body,
@@ -1419,6 +1534,10 @@ func saveFleetTestSnapshot(t *testing.T, dir string, sessions map[string]*state.
 	if err := state.Save(dir, st); err != nil {
 		t.Fatalf("save state: %v", err)
 	}
+}
+
+func fleetTimePtr(t time.Time) *time.Time {
+	return &t
 }
 
 func assertFleetReadOnlyAction(t *testing.T, action controlAction) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -213,6 +213,7 @@ type sessionInfo struct {
 	StatusReason      string          `json:"status_reason,omitempty"`
 	NextAction        string          `json:"next_action,omitempty"`
 	NeedsAttention    bool            `json:"needs_attention,omitempty"`
+	Live              bool            `json:"live"`
 	Backend           string          `json:"backend,omitempty"`
 	PRNumber          int             `json:"pr_number,omitempty"`
 	PRURL             string          `json:"pr_url,omitempty"`
@@ -235,6 +236,7 @@ type sessionInfo struct {
 }
 
 func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
+	now := time.Now().UTC()
 	info := sessionInfo{
 		Slot:              slot,
 		IssueNumber:       sess.IssueNumber,
@@ -253,10 +255,11 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 		HasLog:            strings.TrimSpace(sess.LogFile) != "",
 		RetryCount:        sess.RetryCount,
 		LastNotification:  sess.LastNotifiedStatus,
+		Live:              state.SessionLiveAt(sess, now),
 	}
 
 	// Calculate runtime
-	end := time.Now()
+	end := now
 	if sess.FinishedAt != nil {
 		end = *sess.FinishedAt
 		info.FinishedAt = sess.FinishedAt.Format(time.RFC3339)
@@ -273,8 +276,8 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 	if sess.NextRetryAt != nil {
 		info.NextRetryAt = sess.NextRetryAt.Format(time.RFC3339)
 	}
-	attention := state.SessionAttentionFor(sess, info.Alive)
-	if displayStatus := state.SessionDisplayStatusFor(sess, info.Alive); displayStatus != "" && displayStatus != info.Status {
+	attention := state.SessionAttentionForAt(sess, info.Alive, now)
+	if displayStatus := state.SessionDisplayStatusForAt(sess, info.Alive, now); displayStatus != "" && displayStatus != info.Status {
 		info.DisplayStatus = displayStatus
 	}
 	info.StatusReason = attention.Reason

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -36,6 +36,7 @@ const (
 	DisplayReviewRetryPending SessionDisplayStatus = "review_retry_pending"
 	DisplayReviewRetryRunning SessionDisplayStatus = "review_retry_running"
 	DisplayReviewRetryRecheck SessionDisplayStatus = "review_retry_recheck"
+	LiveSessionRecentWindow                        = 24 * time.Hour
 )
 
 const RetryReasonReviewFeedback = "review_feedback"
@@ -1432,6 +1433,73 @@ func (s *State) ActiveSessions() []*Session {
 		}
 	}
 	return active
+}
+
+// LiveSessions returns sessions that belong in the default operator view.
+func (s *State) LiveSessions() []*Session {
+	return s.LiveSessionsAt(time.Now().UTC())
+}
+
+// LiveSessionsAt returns sessions that are running, actionable, still in PR or
+// retry review flow, or changed within the recent live window.
+func (s *State) LiveSessionsAt(now time.Time) []*Session {
+	if s == nil {
+		return nil
+	}
+	live := make([]*Session, 0)
+	for _, sess := range s.Sessions {
+		if SessionLiveAt(sess, now) {
+			live = append(live, sess)
+		}
+	}
+	return live
+}
+
+// SessionLive reports whether a session belongs in the default operator view.
+func SessionLive(sess *Session) bool {
+	return SessionLiveAt(sess, time.Now().UTC())
+}
+
+// SessionLiveAt is SessionLive with an explicit clock for tests.
+func SessionLiveAt(sess *Session, now time.Time) bool {
+	if sess == nil {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	switch sess.Status {
+	case StatusRunning, StatusPROpen, StatusQueued:
+		return true
+	}
+
+	switch SessionDisplayStatus(SessionDisplayStatusForAt(sess, nil, now)) {
+	case DisplayReviewRetryBackoff, DisplayReviewRetryPending, DisplayReviewRetryRunning, DisplayReviewRetryRecheck:
+		return true
+	}
+
+	if SessionAttentionForAt(sess, nil, now).NeedsAttention {
+		return true
+	}
+
+	changedAt := SessionChangedAt(sess)
+	return !changedAt.IsZero() && now.Sub(changedAt.UTC()) <= LiveSessionRecentWindow
+}
+
+// SessionChangedAt returns the newest persisted activity timestamp for a session.
+func SessionChangedAt(sess *Session) time.Time {
+	if sess == nil {
+		return time.Time{}
+	}
+	changedAt := sess.StartedAt
+	if sess.FinishedAt != nil && sess.FinishedAt.After(changedAt) {
+		changedAt = *sess.FinishedAt
+	}
+	if !sess.LastOutputChangedAt.IsZero() && sess.LastOutputChangedAt.After(changedAt) {
+		changedAt = sess.LastOutputChangedAt
+	}
+	return changedAt.UTC()
 }
 
 // CountByStatus returns a map of session status → count for all non-terminal sessions.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -960,6 +960,89 @@ func TestSessionAttentionFor_DoneReviewFeedbackIsHistorical(t *testing.T) {
 	}
 }
 
+func TestSessionLiveAt(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	future := now.Add(10 * time.Minute)
+	recent := now.Add(-LiveSessionRecentWindow + time.Minute)
+	old := now.Add(-LiveSessionRecentWindow - time.Minute)
+
+	tests := []struct {
+		name string
+		sess *Session
+		want bool
+	}{
+		{
+			name: "running",
+			sess: &Session{Status: StatusRunning, StartedAt: old},
+			want: true,
+		},
+		{
+			name: "open PR",
+			sess: &Session{Status: StatusPROpen, StartedAt: old, PRNumber: 10},
+			want: true,
+		},
+		{
+			name: "queued",
+			sess: &Session{Status: StatusQueued, StartedAt: old},
+			want: true,
+		},
+		{
+			name: "review retry backoff",
+			sess: &Session{
+				Status:                      StatusDead,
+				StartedAt:                   old,
+				NextRetryAt:                 &future,
+				PreviousAttemptFeedbackKind: RetryReasonReviewFeedback,
+				RetryReason:                 RetryReasonReviewFeedback,
+			},
+			want: true,
+		},
+		{
+			name: "retry needs attention",
+			sess: &Session{Status: StatusDead, StartedAt: old, NextRetryAt: &future},
+			want: true,
+		},
+		{
+			name: "recently finished done",
+			sess: &Session{Status: StatusDone, StartedAt: old, FinishedAt: &recent},
+			want: true,
+		},
+		{
+			name: "recent output on old done",
+			sess: &Session{Status: StatusDone, StartedAt: old, FinishedAt: &old, LastOutputChangedAt: recent},
+			want: true,
+		},
+		{
+			name: "old done",
+			sess: &Session{Status: StatusDone, StartedAt: old, FinishedAt: &old},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SessionLiveAt(tt.sess, now); got != tt.want {
+				t.Fatalf("SessionLiveAt = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLiveSessionsAt(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-LiveSessionRecentWindow - time.Hour)
+	recent := now.Add(-time.Hour)
+	s := NewState()
+	s.Sessions["running"] = &Session{Status: StatusRunning, StartedAt: old}
+	s.Sessions["recent-done"] = &Session{Status: StatusDone, StartedAt: old, FinishedAt: &recent}
+	s.Sessions["old-done"] = &Session{Status: StatusDone, StartedAt: old, FinishedAt: &old}
+
+	live := s.LiveSessionsAt(now)
+	if len(live) != 2 {
+		t.Fatalf("LiveSessionsAt len = %d, want 2", len(live))
+	}
+}
+
 func TestCountByStatus(t *testing.T) {
 	s := NewState()
 	s.Sessions["slot-1"] = &Session{IssueNumber: 1, Status: StatusRunning}


### PR DESCRIPTION
Closes #338

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defaults the Fleet Workers UI to a "live" scope that shows only active, recently-changed, or attention-needing workers, collapsing older historical sessions into a single summary row with a "Show history" button. It also ships a companion `SessionLiveAt` function in `state.go` that backs the server-side `live` flag, and changes auto-created rescue-PR bodies from `Closes #N` to `Refs #N` to avoid auto-closing the originating issue on merge.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic bugs found; the live/historical split is well-tested end-to-end.

All changes are covered by targeted tests, the new SessionLiveAt logic correctly handles every relevant status transition, and the JS history-collapse path uses escapeText for all user-derived content. No P0 or P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds SessionLiveAt, SessionLive, LiveSessions/LiveSessionsAt, and SessionChangedAt helpers that define the "live" operator scope; logic is well-tested and correctly passes nil for the alive pointer (safe, since running sessions short-circuit before the alive-sensitive paths). |
| internal/server/server.go | Adds Live field to sessionInfo, computed once with a shared now value; also reuses now for the runtime calculation, removing a second time.Now() call — clean refactor. |
| internal/server/fleet.go | Replaces isFleetWorkerVisible with isFleetWorkerDefaultVisible (delegates entirely to worker.Live and worker.NeedsAttention), returns all workers to the snapshot instead of pre-filtering, and adds the JS history-collapse UI including historySummaryRowHTML with properly escaped output. |
| internal/orchestrator/orchestrator.go | Changes auto-created PR body from "Closes #N" to "Refs #N", preventing the rescued branch's PR from auto-closing the originating issue on merge. |
| internal/server/fleet_test.go | Adds two new tests covering the historical-collapse behavior and the dashboard JS fragment; introduces a fleetTimePtr helper; thorough coverage of live vs historical classification. |
| internal/state/state_test.go | Adds TestSessionLiveAt and TestLiveSessionsAt covering all edge cases (running, queued, retry, recently finished, old done, recent output on old done session). |
| internal/orchestrator/orchestrator_test.go | Updates test assertion to verify "Refs #N" is present and "Closes #N" is absent in auto-created PR bodies. |

</details>

<sub>Reviews (1): Last reviewed commit: ["M-003: default fleet workers to live sco..."](https://github.com/befeast/maestro/commit/d9634e3dafba456453eafaa6d6c051a8962aa5b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30551331)</sub>

<!-- /greptile_comment -->