### PR TITLE
fix: prevent PR auto-close before runtime verification (#351)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1115,6 +1115,8 @@ func autoCreatedPRBody(sess *state.Session, branch string, reasons []string) str
 
 Maestro auto-created this PR because the worker pushed branch %s but exited before opening a pull request.
 
+This intentionally uses a non-closing issue reference; runtime/deployment/operator verification may still be required before the issue is closed.
+
 Observed worker state: %s.
 `, sess.IssueNumber, branch, reasonText)
 }
@@ -1134,34 +1136,33 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 	for slotName, sess := range s.Sessions {
 		switch sess.Status {
-		case state.StatusDone, state.StatusDead, state.StatusConflictFailed, state.StatusFailed, state.StatusRetryExhausted:
+		case state.StatusDone, state.StatusCodeLanded, state.StatusDead, state.StatusConflictFailed, state.StatusFailed, state.StatusRetryExhausted:
 			// Zombie cleanup: if the underlying issue is closed, transition to done.
 			// This prevents conflict_failed/failed/dead/retry_exhausted sessions from lingering
 			// indefinitely when their issues are closed externally (#187).
 			if sess.Status != state.StatusDone {
-				done := false
-				if sess.PRNumber > 0 {
-					merged, err := o.isPRMerged(sess.PRNumber)
-					if err != nil {
-						log.Printf("[orch] check PR #%d merged: %v", sess.PRNumber, err)
-					} else if merged {
-						log.Printf("[orch] PR #%d merged, transitioning zombie session %s from %s to done", sess.PRNumber, slotName, sess.Status)
-						done = true
-					}
-				}
+				issueClosed := false
 				closed, err := o.isIssueClosed(sess.IssueNumber)
 				if err != nil {
 					log.Printf("[orch] check issue #%d: %v", sess.IssueNumber, err)
 				} else if closed {
 					log.Printf("[orch] issue #%d closed, transitioning zombie session %s from %s to done", sess.IssueNumber, slotName, sess.Status)
-					done = true
+					issueClosed = true
 				}
-				if done {
+				if issueClosed {
 					o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
 					sess.Status = state.StatusDone
 					if sess.FinishedAt == nil {
 						now := time.Now().UTC()
 						sess.FinishedAt = &now
+					}
+				} else if sess.Status != state.StatusCodeLanded && sess.PRNumber > 0 {
+					merged, err := o.isPRMerged(sess.PRNumber)
+					if err != nil {
+						log.Printf("[orch] check PR #%d merged: %v", sess.PRNumber, err)
+					} else if merged {
+						log.Printf("[orch] PR #%d merged, transitioning zombie session %s from %s to code_landed", sess.PRNumber, slotName, sess.Status)
+						o.markCodeLanded(sess, sess.PRNumber)
 					}
 				}
 			}
@@ -1686,6 +1687,16 @@ func mergeFlowPRForSession(sess *state.Session, byBranch map[string]github.PR, b
 	return github.PR{}, false
 }
 
+func (o *Orchestrator) markCodeLanded(sess *state.Session, prNumber int) {
+	if prNumber > 0 {
+		sess.PRNumber = prNumber
+	}
+	o.syncProject(sess.IssueNumber, github.ProjectStatusInProgress)
+	sess.Status = state.StatusCodeLanded
+	now := time.Now().UTC()
+	sess.FinishedAt = &now
+}
+
 // handleReviewFeedbackRetry schedules a retry worker with review feedback in
 // its prompt. When the PR worktree is still available, keep the PR open and
 // respawn in place so the fixer pushes updates to the same PR.
@@ -1871,13 +1882,7 @@ func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr git
 	}
 
 	log.Printf("[orch] merged PR #%d ✓", pr.Number)
-	o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
-	if err := o.closeIssue(sess.IssueNumber, fmt.Sprintf("Implemented by PR #%d (auto-merged by maestro).", pr.Number)); err != nil {
-		log.Printf("[orch] warning: failed to close issue #%d: %v", sess.IssueNumber, err)
-	}
-	sess.Status = state.StatusDone
-	now := time.Now().UTC()
-	sess.FinishedAt = &now
+	o.markCodeLanded(sess, pr.Number)
 
 	if o.cfg.ShouldCleanupWorktrees() {
 		log.Printf("[orch] cleaning up worktree for %s after merge", slotName)
@@ -1887,7 +1892,7 @@ func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr git
 		log.Printf("[orch] skipping worktree cleanup for %s (cleanup_worktrees_on_merge=false)", slotName)
 	}
 
-	o.notifier.Sendf("✅ maestro: merged PR #%d for issue #%d (%s)", pr.Number, sess.IssueNumber, sess.IssueTitle)
+	o.notifier.Sendf("✅ maestro: merged PR #%d for issue #%d (%s); issue remains open for runtime verification", pr.Number, sess.IssueNumber, sess.IssueTitle)
 
 	// Auto version bump
 	if o.cfg.Versioning.Enabled {
@@ -2190,7 +2195,7 @@ func (o *Orchestrator) orderedQueueIssueDone(s *state.State, issueNumber int) (b
 
 	for _, slotName := range sortedStateSessionNames(s) {
 		sess := s.Sessions[slotName]
-		if sess == nil || sess.IssueNumber != issueNumber || sess.Status != state.StatusDone || sess.PRNumber <= 0 {
+		if sess == nil || sess.IssueNumber != issueNumber || (sess.Status != state.StatusDone && sess.Status != state.StatusCodeLanded) || sess.PRNumber <= 0 {
 			continue
 		}
 		merged, err := o.isPRMerged(sess.PRNumber)
@@ -2198,7 +2203,7 @@ func (o *Orchestrator) orderedQueueIssueDone(s *state.State, issueNumber int) (b
 			return false, "", fmt.Errorf("check PR #%d merged: %w", sess.PRNumber, err)
 		}
 		if merged {
-			return true, fmt.Sprintf("session %s is done with merged PR #%d", slotName, sess.PRNumber), nil
+			return true, fmt.Sprintf("session %s is %s with merged PR #%d", slotName, sess.Status, sess.PRNumber), nil
 		}
 	}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -264,8 +264,13 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 	if !strings.Contains(gotTitle, "add branch rescue") || !strings.Contains(gotTitle, "(#108)") {
 		t.Fatalf("unexpected title %q", gotTitle)
 	}
-	if !strings.Contains(gotBody, "Refs #108") || strings.Contains(gotBody, "Closes #108") || !strings.Contains(gotBody, "auto-created") {
+	if !strings.Contains(gotBody, "Refs #108") || !strings.Contains(gotBody, "auto-created") {
 		t.Fatalf("unexpected body %q", gotBody)
+	}
+	for _, forbidden := range []string{"Closes #108", "Fixes #108", "Resolves #108", "closes #108", "fixes #108", "resolves #108"} {
+		if strings.Contains(gotBody, forbidden) {
+			t.Fatalf("auto-created PR body contains auto-closing reference %q: %q", forbidden, gotBody)
+		}
 	}
 	if !s.IssueInProgress(108) {
 		t.Fatal("IssueInProgress(108) must remain true after auto-created PR")
@@ -763,10 +768,10 @@ func TestAutoMergePRs_ParallelUpdatesState(t *testing.T) {
 	before := time.Now()
 	o.autoMergePRs(s)
 
-	// All sessions should be marked done
+	// All sessions should be marked code_landed until runtime verification closes the issue
 	for slotName, sess := range s.Sessions {
-		if sess.Status != state.StatusDone {
-			t.Errorf("session %s status = %q, want %q", slotName, sess.Status, state.StatusDone)
+		if sess.Status != state.StatusCodeLanded {
+			t.Errorf("session %s status = %q, want %q", slotName, sess.Status, state.StatusCodeLanded)
 		}
 		if sess.FinishedAt == nil {
 			t.Errorf("session %s has nil FinishedAt", slotName)
@@ -871,19 +876,19 @@ func TestAutoMergePRs_ParallelPartialFailure(t *testing.T) {
 		t.Errorf("merged = %v, want [10, 30]", merged)
 	}
 
-	// Verify state: sessions for PR 10 and 30 should be done, PR 20 should still be pr_open
-	doneCount := 0
+	// Verify state: sessions for PR 10 and 30 should be code_landed, PR 20 should still be pr_open
+	landedCount := 0
 	openCount := 0
 	for _, sess := range s.Sessions {
-		if sess.Status == state.StatusDone {
-			doneCount++
+		if sess.Status == state.StatusCodeLanded {
+			landedCount++
 		}
 		if sess.Status == state.StatusPROpen {
 			openCount++
 		}
 	}
-	if doneCount != 2 {
-		t.Errorf("expected 2 done sessions, got %d", doneCount)
+	if landedCount != 2 {
+		t.Errorf("expected 2 code_landed sessions, got %d", landedCount)
 	}
 	if openCount != 1 {
 		t.Errorf("expected 1 still-open session, got %d", openCount)
@@ -892,7 +897,7 @@ func TestAutoMergePRs_ParallelPartialFailure(t *testing.T) {
 
 func TestAutoMergePRs_ParallelStateConsistency(t *testing.T) {
 	// Verify that after parallel merges, the state is consistent:
-	// - All merged sessions are StatusDone with FinishedAt set
+	// - All merged sessions are StatusCodeLanded with FinishedAt set
 	// - LastMergeAt is recent
 	// - No session is in an inconsistent intermediate state
 	prs := []github.PR{
@@ -914,8 +919,8 @@ func TestAutoMergePRs_ParallelStateConsistency(t *testing.T) {
 	}
 
 	for slotName, sess := range s.Sessions {
-		if sess.Status != state.StatusDone {
-			t.Errorf("session %s: status = %q, want %q", slotName, sess.Status, state.StatusDone)
+		if sess.Status != state.StatusCodeLanded {
+			t.Errorf("session %s: status = %q, want %q", slotName, sess.Status, state.StatusCodeLanded)
 		}
 		if sess.FinishedAt == nil {
 			t.Errorf("session %s: FinishedAt is nil", slotName)
@@ -1319,8 +1324,8 @@ func TestAutoMergePRs_RetryExhaustedGreenPRNoFeedbackMerges(t *testing.T) {
 		t.Fatalf("merged = %v, want [10]", merged)
 	}
 	sess := s.Sessions["slot-0"]
-	if sess.Status != state.StatusDone {
-		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusCodeLanded)
 	}
 }
 
@@ -2394,6 +2399,7 @@ func TestCheckSessions_SilentTimeoutSecondKill_LabelsBlocked(t *testing.T) {
 func TestMergeReadyPR_CleansUpWorktreeOnMerge(t *testing.T) {
 	cleanupTrue := true
 	stopped := false
+	closedIssue := false
 	o := &Orchestrator{
 		cfg: &config.Config{
 			Repo:                    "owner/repo",
@@ -2404,6 +2410,7 @@ func TestMergeReadyPR_CleansUpWorktreeOnMerge(t *testing.T) {
 			return nil
 		},
 		ghCloseIssueFn: func(number int, comment string) error {
+			closedIssue = true
 			return nil
 		},
 		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
@@ -2430,11 +2437,14 @@ func TestMergeReadyPR_CleansUpWorktreeOnMerge(t *testing.T) {
 	if !stopped {
 		t.Fatal("worker should be stopped when cleanup_worktrees_on_merge is true")
 	}
+	if closedIssue {
+		t.Fatal("mergeReadyPR must not close the issue before runtime verification")
+	}
 	if sess.Worktree != "" {
 		t.Errorf("Worktree = %q, want empty (should be cleared after cleanup)", sess.Worktree)
 	}
-	if sess.Status != state.StatusDone {
-		t.Errorf("Status = %q, want %q", sess.Status, state.StatusDone)
+	if sess.Status != state.StatusCodeLanded {
+		t.Errorf("Status = %q, want %q", sess.Status, state.StatusCodeLanded)
 	}
 }
 
@@ -2480,8 +2490,8 @@ func TestMergeReadyPR_SkipsCleanupWhenDisabled(t *testing.T) {
 	if sess.Worktree != "/tmp/wt" {
 		t.Errorf("Worktree = %q, want %q (should be preserved)", sess.Worktree, "/tmp/wt")
 	}
-	if sess.Status != state.StatusDone {
-		t.Errorf("Status = %q, want %q", sess.Status, state.StatusDone)
+	if sess.Status != state.StatusCodeLanded {
+		t.Errorf("Status = %q, want %q", sess.Status, state.StatusCodeLanded)
 	}
 }
 
@@ -3316,7 +3326,7 @@ func TestCheckSessions_RetryExhaustedClosedIssue_TransitionsToDone(t *testing.T)
 	}
 }
 
-func TestCheckSessions_RetryExhaustedMergedPR_TransitionsToDone(t *testing.T) {
+func TestCheckSessions_RetryExhaustedMergedPR_TransitionsToCodeLanded(t *testing.T) {
 	now := time.Now().UTC()
 	o := &Orchestrator{
 		cfg:      &config.Config{Repo: "owner/repo", MaxRuntimeMinutes: 120},
@@ -3348,6 +3358,40 @@ func TestCheckSessions_RetryExhaustedMergedPR_TransitionsToDone(t *testing.T) {
 	o.checkSessions(s)
 
 	sess := s.Sessions["pan-13"]
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusCodeLanded)
+	}
+}
+
+func TestCheckSessions_CodeLandedClosedIssue_TransitionsToDone(t *testing.T) {
+	now := time.Now().UTC()
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", MaxRuntimeMinutes: 120},
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return true, nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["pan-14"] = &state.Session{
+		IssueNumber: 104,
+		IssueTitle:  "runtime verified",
+		Status:      state.StatusCodeLanded,
+		Branch:      "feat/pan-14-104-runtime",
+		PRNumber:    78,
+		FinishedAt:  &now,
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["pan-14"]
 	if sess.Status != state.StatusDone {
 		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
 	}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -194,6 +195,28 @@ func TestMaxRuntimeForPhase(t *testing.T) {
 	}
 	if got := MaxRuntimeForPhase(cfg, state.PhaseValidate); got != 45 {
 		t.Errorf("validate runtime: got %d, want 45", got)
+	}
+}
+
+func TestDefaultPipelinePromptsForbidAutoClosingReferences(t *testing.T) {
+	cfg := &config.Config{Repo: "owner/repo"}
+	issue := github.Issue{Number: 351, Title: "runtime verification", Body: "Keep the issue open until runtime is verified."}
+
+	for _, phase := range []state.Phase{state.PhasePlan, state.PhaseValidate} {
+		prompt := PromptForPhase(cfg, phase, issue, "/tmp/wt", "feat/runtime")
+		if !strings.Contains(prompt, "Refs #351") || !strings.Contains(prompt, "auto-closing keywords") {
+			t.Fatalf("phase %s prompt missing non-closing PR reference guidance:\n%s", phase, prompt)
+		}
+		for _, forbidden := range []string{"Closes #351", "Fixes #351", "Resolves #351"} {
+			if strings.Contains(prompt, forbidden) {
+				t.Fatalf("phase %s prompt contains closing reference %q:\n%s", phase, forbidden, prompt)
+			}
+		}
+	}
+
+	preamble := ImplementerPreamble(&state.Session{})
+	if !strings.Contains(preamble, "non-closing issue references") || !strings.Contains(preamble, "Refs #N") {
+		t.Fatalf("implementer preamble missing non-closing PR guidance:\n%s", preamble)
 	}
 }
 

--- a/internal/pipeline/prompts.go
+++ b/internal/pipeline/prompts.go
@@ -50,6 +50,7 @@ const defaultPlannerPrompt = `You are a **planner** for a coding agent pipeline.
 4. Commit both files with message: "plan: add implementation plan for #{{ISSUE_NUMBER}}"
 5. Do NOT implement the issue. Only plan and define validation criteria.
 6. Do NOT create a PR.
+7. If your plan mentions PR creation, require non-closing issue references such as ` + "`Refs #{{ISSUE_NUMBER}}`" + `; never recommend GitHub auto-closing keywords (` + "`Closes`, `Fixes`, `Resolves`" + `, or variants), especially for deployment/runtime/operator-verification work.
 `
 
 const defaultValidatorPrompt = `You are a **validator** for a coding agent pipeline. Your job is to verify that an implementation meets the validation contract.
@@ -87,6 +88,7 @@ const defaultValidatorPrompt = `You are a **validator** for a coding agent pipel
 5. Commit the result file.
 6. Do NOT modify implementation code.
 7. Do NOT create a PR.
+8. Treat any generated PR body or instruction that uses GitHub auto-closing keywords (` + "`Closes`, `Fixes`, `Resolves`" + `, or variants) as invalid for deployment/runtime/operator-verification issues; use non-closing references such as ` + "`Refs #{{ISSUE_NUMBER}}`" + ` instead.
 `
 
 const validatorRetryPreamble = `## Previous Validation Feedback
@@ -141,6 +143,7 @@ func ImplementerPreamble(sess *state.Session) string {
 	sb.WriteString("This issue is being worked on in pipeline mode. ")
 	sb.WriteString("Read `MAESTRO_PLAN.md` in the worktree root for the implementation plan.\n")
 	sb.WriteString("Follow the plan steps in order.\n\n")
+	sb.WriteString("Use non-closing issue references in PR bodies, such as `Refs #N`; do not use GitHub auto-closing keywords (`Closes`, `Fixes`, `Resolves`, or variants) for deployment/runtime/operator-verification issues.\n\n")
 
 	if sess.ValidationFeedback != "" {
 		sb.WriteString(fmt.Sprintf(validatorRetryPreamble, sess.ValidationFeedback))

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -22,6 +22,7 @@ const (
 	StatusQueued         SessionStatus = "queued"
 	StatusRunning        SessionStatus = "running"
 	StatusPROpen         SessionStatus = "pr_open"
+	StatusCodeLanded     SessionStatus = "code_landed"
 	StatusDone           SessionStatus = "done"
 	StatusFailed         SessionStatus = "failed"
 	StatusConflictFailed SessionStatus = "conflict_failed"
@@ -137,6 +138,19 @@ func SessionAttentionForAt(sess *Session, alive *bool, now time.Time) SessionAtt
 		return SessionAttention{
 			Reason:         "Session is waiting on an open PR, but no PR number is recorded yet.",
 			NextAction:     "Reconcile the session with the GitHub PR before dispatching duplicate work.",
+			NeedsAttention: true,
+		}
+	case StatusCodeLanded:
+		if sess.PRNumber > 0 {
+			return SessionAttention{
+				Reason:         fmt.Sprintf("PR #%d has merged; code has landed, but runtime/deployment/operator verification is still required before closing the issue.", sess.PRNumber),
+				NextAction:     "Run the required deployment/runtime/operator verification, then close or update the issue only after the outcome is verified.",
+				NeedsAttention: true,
+			}
+		}
+		return SessionAttention{
+			Reason:         "Code has landed, but runtime/deployment/operator verification is still required before closing the issue.",
+			NextAction:     "Run the required deployment/runtime/operator verification, then close or update the issue only after the outcome is verified.",
 			NeedsAttention: true,
 		}
 	case StatusQueued:
@@ -1513,7 +1527,7 @@ func (s *State) CountByStatus() map[SessionStatus]int {
 	return counts
 }
 
-// DonePRCount counts completed sessions that produced a PR. It is a conservative
+// DonePRCount counts sessions whose code landed through a PR. It is a conservative
 // proxy for issue throughput that may still fail to advance the runtime outcome.
 func (s *State) DonePRCount() int {
 	if s == nil {
@@ -1521,7 +1535,7 @@ func (s *State) DonePRCount() int {
 	}
 	count := 0
 	for _, sess := range s.Sessions {
-		if sess != nil && sess.Status == StatusDone && sess.PRNumber > 0 {
+		if sess != nil && (sess.Status == StatusDone || sess.Status == StatusCodeLanded) && sess.PRNumber > 0 {
 			count++
 		}
 	}
@@ -1536,7 +1550,7 @@ func (s *State) IssueInProgress(issueNum int) bool {
 		if sess.IssueNumber != issueNum {
 			continue
 		}
-		if sess.Status == StatusRunning || sess.Status == StatusPROpen || sess.Status == StatusQueued {
+		if sess.Status == StatusRunning || sess.Status == StatusPROpen || sess.Status == StatusQueued || sess.Status == StatusCodeLanded {
 			return true
 		}
 		// Dead session with pending retry — still in progress
@@ -1618,24 +1632,26 @@ func StatusPriority(status SessionStatus) int {
 		return 1
 	case StatusQueued:
 		return 2
-	case StatusDead:
+	case StatusCodeLanded:
 		return 3
-	case StatusFailed:
+	case StatusDead:
 		return 4
-	case StatusConflictFailed:
+	case StatusFailed:
 		return 5
-	case StatusRetryExhausted:
+	case StatusConflictFailed:
 		return 6
-	case StatusDone:
+	case StatusRetryExhausted:
 		return 7
-	default:
+	case StatusDone:
 		return 8
+	default:
+		return 9
 	}
 }
 
 func IsTerminal(status SessionStatus) bool {
 	switch status {
-	case StatusDone, StatusFailed, StatusConflictFailed, StatusDead, StatusRetryExhausted:
+	case StatusDone, StatusCodeLanded, StatusFailed, StatusConflictFailed, StatusDead, StatusRetryExhausted:
 		return true
 	}
 	return false

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -63,7 +63,7 @@ func TestNotifiedCIFail_Persistence(t *testing.T) {
 func TestDonePRCount(t *testing.T) {
 	s := NewState()
 	s.Sessions["merged-1"] = &Session{IssueNumber: 1, Status: StatusDone, PRNumber: 10}
-	s.Sessions["merged-2"] = &Session{IssueNumber: 2, Status: StatusDone, PRNumber: 11}
+	s.Sessions["merged-2"] = &Session{IssueNumber: 2, Status: StatusCodeLanded, PRNumber: 11}
 	s.Sessions["closed-issue"] = &Session{IssueNumber: 3, Status: StatusDone}
 	s.Sessions["open-pr"] = &Session{IssueNumber: 4, Status: StatusPROpen, PRNumber: 12}
 
@@ -532,6 +532,18 @@ func TestIssueInProgress_QueuedCountsAsInProgress(t *testing.T) {
 	}
 }
 
+func TestIssueInProgress_CodeLandedCountsAsInProgress(t *testing.T) {
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{IssueNumber: 100, Status: StatusCodeLanded, PRNumber: 10}
+
+	if !s.IssueInProgress(100) {
+		t.Error("IssueInProgress should return true for code_landed session")
+	}
+	if s.IssueDone(100) {
+		t.Error("IssueDone should remain false while runtime verification is pending")
+	}
+}
+
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }
@@ -553,6 +565,7 @@ func TestIsTerminal(t *testing.T) {
 		{StatusQueued, false},
 		{StatusRunning, false},
 		{StatusPROpen, false},
+		{StatusCodeLanded, true},
 		{StatusDone, true},
 		{StatusFailed, true},
 		{StatusConflictFailed, true},
@@ -960,6 +973,21 @@ func TestSessionAttentionFor_DoneReviewFeedbackIsHistorical(t *testing.T) {
 	}
 }
 
+func TestSessionAttentionFor_CodeLandedNeedsRuntimeVerification(t *testing.T) {
+	sess := &Session{IssueNumber: 351, Status: StatusCodeLanded, PRNumber: 99}
+
+	attention := SessionAttentionFor(sess, nil)
+	if !attention.NeedsAttention {
+		t.Fatalf("code_landed session should need runtime verification attention: %+v", attention)
+	}
+	if !containsString(attention.Reason, "code has landed") || !containsString(attention.Reason, "runtime/deployment/operator verification") {
+		t.Fatalf("reason = %q, want code landed runtime verification copy", attention.Reason)
+	}
+	if got := SessionDisplayStatusFor(sess, nil); got != string(StatusCodeLanded) {
+		t.Fatalf("display status = %q, want code_landed", got)
+	}
+}
+
 func TestSessionLiveAt(t *testing.T) {
 	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	future := now.Add(10 * time.Minute)
@@ -1049,8 +1077,9 @@ func TestCountByStatus(t *testing.T) {
 	s.Sessions["slot-2"] = &Session{IssueNumber: 2, Status: StatusRunning}
 	s.Sessions["slot-3"] = &Session{IssueNumber: 3, Status: StatusPROpen}
 	s.Sessions["slot-4"] = &Session{IssueNumber: 4, Status: StatusQueued}
-	s.Sessions["slot-5"] = &Session{IssueNumber: 5, Status: StatusDone}   // terminal — excluded
-	s.Sessions["slot-6"] = &Session{IssueNumber: 6, Status: StatusFailed} // terminal — excluded
+	s.Sessions["slot-5"] = &Session{IssueNumber: 5, Status: StatusDone}                     // terminal — excluded
+	s.Sessions["slot-6"] = &Session{IssueNumber: 6, Status: StatusFailed}                   // terminal — excluded
+	s.Sessions["slot-7"] = &Session{IssueNumber: 7, Status: StatusCodeLanded, PRNumber: 10} // terminal — excluded
 
 	counts := s.CountByStatus()
 
@@ -1065,6 +1094,9 @@ func TestCountByStatus(t *testing.T) {
 	}
 	if counts[StatusDone] != 0 {
 		t.Errorf("done = %d, want 0 (terminal states excluded)", counts[StatusDone])
+	}
+	if counts[StatusCodeLanded] != 0 {
+		t.Errorf("code_landed = %d, want 0 (terminal states excluded)", counts[StatusCodeLanded])
 	}
 	if counts[StatusFailed] != 0 {
 		t.Errorf("failed = %d, want 0 (terminal states excluded)", counts[StatusFailed])
@@ -1082,7 +1114,7 @@ func TestStatusPriority(t *testing.T) {
 	}
 	// queued before terminal states
 	for _, terminal := range []SessionStatus{
-		StatusDead, StatusFailed, StatusConflictFailed,
+		StatusCodeLanded, StatusDead, StatusFailed, StatusConflictFailed,
 		StatusRetryExhausted, StatusDone,
 	} {
 		if StatusPriority(StatusQueued) >= StatusPriority(terminal) {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2188,7 +2188,7 @@ func openPRForSession(sess *state.Session, byNumber map[int]github.PR, byBranch 
 
 func sessionCanStillBlockProgress(status state.SessionStatus) bool {
 	switch status {
-	case state.StatusRunning, state.StatusPROpen, state.StatusQueued, state.StatusCodeLanded, state.StatusFailed, state.StatusDead, state.StatusRetryExhausted:
+	case state.StatusRunning, state.StatusPROpen, state.StatusQueued, state.StatusFailed, state.StatusDead, state.StatusRetryExhausted:
 		return true
 	}
 	return false

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1183,7 +1183,7 @@ func (e *Engine) orderedQueueIssueDone(st *state.State, issueNumber int) (bool, 
 
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
-		if sess == nil || sess.IssueNumber != issueNumber || sess.Status != state.StatusDone || sess.PRNumber <= 0 {
+		if sess == nil || sess.IssueNumber != issueNumber || (sess.Status != state.StatusDone && sess.Status != state.StatusCodeLanded) || sess.PRNumber <= 0 {
 			continue
 		}
 		merged, err := e.reader.IsPRMerged(sess.PRNumber)
@@ -1191,7 +1191,7 @@ func (e *Engine) orderedQueueIssueDone(st *state.State, issueNumber int) (bool, 
 			return false, "", fmt.Errorf("check PR #%d merged: %w", sess.PRNumber, err)
 		}
 		if merged {
-			return true, fmt.Sprintf("session %s is done with merged PR #%d", slot, sess.PRNumber), nil
+			return true, fmt.Sprintf("session %s is %s with merged PR #%d", slot, sess.Status, sess.PRNumber), nil
 		}
 	}
 
@@ -2188,7 +2188,7 @@ func openPRForSession(sess *state.Session, byNumber map[int]github.PR, byBranch 
 
 func sessionCanStillBlockProgress(status state.SessionStatus) bool {
 	switch status {
-	case state.StatusRunning, state.StatusPROpen, state.StatusQueued, state.StatusFailed, state.StatusDead, state.StatusRetryExhausted:
+	case state.StatusRunning, state.StatusPROpen, state.StatusQueued, state.StatusCodeLanded, state.StatusFailed, state.StatusDead, state.StatusRetryExhausted:
 		return true
 	}
 	return false

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -478,6 +478,31 @@ func TestDecide_ClosedPRWithActiveSessionExplained(t *testing.T) {
 	}
 }
 
+func TestDecide_ClosedPRWithCodeLandedSessionDoesNotBlock(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 93,
+		IssueTitle:  "merged pr",
+		Status:      state.StatusCodeLanded,
+		PRNumber:    17,
+		Branch:      "feat/merged-pr",
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == "closed_pr_with_active_session" {
+			t.Fatalf("code_landed session should not block on a closed PR: %#v", stuck)
+		}
+	}
+}
+
 func TestDecide_FailingChecksExplained(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{

--- a/internal/worker/checkpoint_test.go
+++ b/internal/worker/checkpoint_test.go
@@ -119,6 +119,9 @@ func TestAssemblePromptWithCheckpoint_WithCheckpoint(t *testing.T) {
 	if !strings.Contains(result, "continue where the previous session left off") {
 		t.Error("should contain continuation instructions")
 	}
+	if !strings.Contains(result, "Refs #1") || containsAutoClosingIssueReference(result) {
+		t.Fatalf("checkpoint prompt should preserve non-closing PR reference guidance, got:\n%s", result)
+	}
 }
 
 func TestReadTailLines(t *testing.T) {

--- a/internal/worker/search_guardrail.go
+++ b/internal/worker/search_guardrail.go
@@ -4,10 +4,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
 var searchGuardedCommands = []string{"rg", "find", "grep"}
+
+var autoClosingIssueReferencePattern = regexp.MustCompile(`(?i)\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+\b`)
+
+func containsAutoClosingIssueReference(text string) bool {
+	return autoClosingIssueReferencePattern.MatchString(text)
+}
 
 func ensureSearchGuardrailWrappers(stateDir string) (string, error) {
 	if strings.TrimSpace(stateDir) == "" {
@@ -286,4 +293,12 @@ func workerSearchSafetyPromptSection(worktreePath string) string {
 		"- Do NOT run `rg`, `find`, or `grep` from broad filesystem roots such as `/`, `/mnt`, or `/home`.\n"+
 		"- If you intentionally need a broad host search, set `MAESTRO_ALLOW_BROAD_SEARCH=1` for that single command.\n",
 		worktreePath)
+}
+
+func workerPRReferenceSafetyPromptSection(issueNumber int) string {
+	return fmt.Sprintf("\n\n---\n\n## PR Issue Reference Safety\n\n"+
+		"- Use non-closing issue references in PR titles, bodies, comments, and helper commands, such as `Refs #%d`.\n"+
+		"- Do NOT use GitHub auto-closing keywords (`Closes`, `Fixes`, `Resolves`, or variants) for deployment/runtime/operator-verification issues.\n"+
+		"- Code landing is not outcome completion; leave issues open until deployment/runtime/operator verification is complete.\n",
+		issueNumber)
 }

--- a/internal/worker/search_guardrail_test.go
+++ b/internal/worker/search_guardrail_test.go
@@ -220,6 +220,21 @@ func TestBuildWorkerRunnerScriptIncludesSearchGuardrails(t *testing.T) {
 	}
 }
 
+func TestWorkerPRReferenceSafetyPromptSectionUsesNonClosingReference(t *testing.T) {
+	section := workerPRReferenceSafetyPromptSection(351)
+	if !strings.Contains(section, "Refs #351") {
+		t.Fatalf("PR reference safety section missing Refs #351:\n%s", section)
+	}
+	if containsAutoClosingIssueReference(section) {
+		t.Fatalf("PR reference safety section contains auto-closing issue reference:\n%s", section)
+	}
+	for _, want := range []string{"auto-closing keywords", "deployment/runtime/operator-verification", "Code landing is not outcome completion"} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("PR reference safety section missing %q:\n%s", want, section)
+		}
+	}
+}
+
 func TestEnsureSearchGuardrailWrappers(t *testing.T) {
 	guardDir, err := ensureSearchGuardrailWrappers(t.TempDir())
 	if err != nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -800,7 +800,7 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 		}
 
 		r := strings.NewReplacer(replacements...)
-		result := r.Replace(base) + workerSearchSafetyPromptSection(worktreePath)
+		result := r.Replace(base) + workerPRReferenceSafetyPromptSection(issue.Number) + workerSearchSafetyPromptSection(worktreePath)
 		return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, contractInlined)
 	}
 
@@ -828,7 +828,7 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 3. Write tests if applicable.
 4. Commit your changes with a clear message.
 5. Before committing or opening a PR, check for accidental secrets and generated artifacts. Do NOT commit or mention API keys, bearer tokens, oauth tokens, bot tokens, env values, raw config dumps, or diagnostic logs. Do NOT commit temp/debug artifacts such as tmp/, _tmp/, *.log, *.logs, *.test, or *.test.json unless the issue explicitly requires them.
-6. Keep the PR body minimal and safe. Use: gh pr create --repo %s --title "%s" --body "Closes #%d". Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.
+6. Keep the PR body minimal and safe. Use: gh pr create --repo %s --title "%s" --body "Refs #%d". Do NOT use GitHub auto-closing keywords (`+"`Closes`, `Fixes`, `Resolves`"+`, or variants) for deployment/runtime/operator-verification issues. Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.
 7. After creating the PR, you are done. Do NOT merge it yourself.
 
 Important: Always run cargo fmt --all before committing if this is a Rust project.
@@ -844,6 +844,7 @@ Always rebase on origin/main immediately before creating the PR.
 		issue.Title,
 		issue.Number,
 	)
+	result += workerPRReferenceSafetyPromptSection(issue.Number)
 	result += workerSearchSafetyPromptSection(worktreePath)
 	return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, false)
 }

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -24,11 +24,36 @@ func TestAssemblePromptIncludesSecretSafetyGuardrails(t *testing.T) {
 		"Do NOT commit or mention API keys",
 		"Do NOT commit temp/debug artifacts such as tmp/, _tmp/, *.log, *.logs, *.test, or *.test.json",
 		"Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.",
-		`gh pr create --repo BeFeast/ok-gobot --title "security hardening" --body "Closes #157"`,
+		`gh pr create --repo BeFeast/ok-gobot --title "security hardening" --body "Refs #157"`,
+		"Do NOT use GitHub auto-closing keywords",
+		"Code landing is not outcome completion",
 	}
 	for _, want := range required {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("assemblePrompt() missing %q\nprompt:\n%s", want, prompt)
+		}
+	}
+	if containsAutoClosingIssueReference(prompt) {
+		t.Fatalf("assemblePrompt() contains auto-closing issue reference:\n%s", prompt)
+	}
+}
+
+func TestContainsAutoClosingIssueReference(t *testing.T) {
+	tests := []struct {
+		text string
+		want bool
+	}{
+		{`Closes #157`, true},
+		{`fixes #157`, true},
+		{`Resolved #157`, true},
+		{`Refs #157`, false},
+		{`Implements #157`, false},
+		{`Do NOT use Closes, Fixes, or Resolves.`, false},
+	}
+
+	for _, tt := range tests {
+		if got := containsAutoClosingIssueReference(tt.text); got != tt.want {
+			t.Fatalf("containsAutoClosingIssueReference(%q) = %v, want %v", tt.text, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
Implements #351

## Changes
- Use non-closing issue references in Maestro-generated PR guidance and auto-created PR bodies.
- Keep merged-code sessions in a code_landed state until runtime/operator verification closes the issue.
- Add tests guarding prompt/body text against auto-closing references.

## Testing
- /usr/local/go/bin/gofmt on changed Go files
- go test ./...
- go build ./cmd/maestro/
- .maestro/verify.sh

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `code_landed` intermediate state that keeps sessions — and their associated issues — open after a PR merges, until runtime/operator verification explicitly closes the issue. It also updates all LLM-facing prompts to emit `Refs #N` instead of auto-closing keywords, and adds a guardrail regex + tests to enforce this across the prompt-assembly pipeline.

The state-machine wiring in `checkSessions` and `markCodeLanded` is correct: `IssueInProgress` blocks re-dispatch while in `code_landed`, and the `code_landed → done` transition fires only when the issue is externally closed. Two concerns noted in earlier review comments remain unresolved in this diff: `IsTerminal` returning `true` for `code_landed` makes sessions eligible for `PruneOldSessions` before verification completes, and the auto-closing keyword regex misses the `Closes: #N` (colon-prefixed) GitHub variant.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the understanding that the two flagged concerns from the previous review round remain open

The core state-machine changes are correct and well-tested. The ceiling is 4/5 because the P1 noted in the previous review (IsTerminal=true for code_landed, enabling PruneOldSessions to silently delete sessions still awaiting verification) is still present in this diff. The P2 regex gap for colon-prefixed keywords is a minor hardening issue. No new critical logic issues were found.

internal/state/state.go — the IsTerminal classification of StatusCodeLanded remains the key risk

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds StatusCodeLanded as a new waiting state; IsTerminal returns true for it, making PruneOldSessions eligible to delete still-active sessions before runtime verification completes |
| internal/orchestrator/orchestrator.go | Stops closing issues on PR merge; introduces markCodeLanded helper and rewires checkSessions to transition code_landed → done only after the issue is externally closed |
| internal/worker/search_guardrail.go | Adds autoClosingIssueReferencePattern regex and workerPRReferenceSafetyPromptSection; regex misses the colon-prefixed variant Closes: #N (pre-existing note in previous review) |
| internal/worker/worker.go | Replaces Closes #N with Refs #N in the default worker PR-creation instruction and appends the new PR reference safety section to all prompt paths |
| internal/supervisor/supervisor.go | Updates orderedQueueIssueDone to accept code_landed sessions; sessionCanStillBlockProgress correctly excludes code_landed, preventing false closed-PR stuck-state alerts |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/state/state.go`, line 1652-1658 ([link](https://github.com/befeast/maestro/blob/92441bf9b5aa4aa7ba35f58ccb989584fc5076c3/internal/state/state.go#L1652-L1658)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`StatusCodeLanded` classified as terminal, eligible for pruning before issue is closed**

   `IsTerminal` returning `true` for `StatusCodeLanded` causes `PruneOldSessions` and `CompletedSessions` to treat it as a finished session. But `code_landed` is specifically designed to be a *waiting* state — it must transition to `done` once the operator/runtime closes the issue. If `PruneOldSessions` runs (the docs suggest calling it "every 10 cycles") before the issue is closed, the session is silently deleted. After pruning, `IssueInProgress` returns `false`, and the orchestrator can re-dispatch a new worker for the still-open issue — producing duplicate work.

   The fix is either to exclude `StatusCodeLanded` from `IsTerminal` (treating it like `StatusPROpen`) while keeping it in `sessionCanStillBlockProgress`, or to add an explicit guard in `PruneOldSessions` that skips `code_landed` sessions.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/state/state.go
   Line: 1652-1658

   Comment:
   **`StatusCodeLanded` classified as terminal, eligible for pruning before issue is closed**

   `IsTerminal` returning `true` for `StatusCodeLanded` causes `PruneOldSessions` and `CompletedSessions` to treat it as a finished session. But `code_landed` is specifically designed to be a *waiting* state — it must transition to `done` once the operator/runtime closes the issue. If `PruneOldSessions` runs (the docs suggest calling it "every 10 cycles") before the issue is closed, the session is silently deleted. After pruning, `IssueInProgress` returns `false`, and the orchestrator can re-dispatch a new worker for the still-open issue — producing duplicate work.

   The fix is either to exclude `StatusCodeLanded` from `IsTerminal` (treating it like `StatusPROpen`) while keeping it in `sessionCanStillBlockProgress`, or to add an explicit guard in `PruneOldSessions` that skips `code_landed` sessions.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/worker/search_guardrail.go`, line 620 ([link](https://github.com/befeast/maestro/blob/92441bf9b5aa4aa7ba35f58ccb989584fc5076c3/internal/worker/search_guardrail.go#L620)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Regex misses `Closes: #N` colon-prefixed auto-closing variant**

   GitHub also accepts `Closes: #157` (with a colon between the keyword and the issue reference). The current pattern `\s+#\d+` requires whitespace immediately after the keyword, so `Closes: #157` would not be detected. This leaves a gap in the guardrail that an LLM-generated PR body could inadvertently use.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/worker/search_guardrail.go
   Line: 620

   Comment:
   **Regex misses `Closes: #N` colon-prefixed auto-closing variant**

   GitHub also accepts `Closes: #157` (with a colon between the keyword and the issue reference). The current pattern `\s+#\d+` requires whitespace immediately after the keyword, so `Closes: #157` would not be detected. This leaves a gap in the guardrail that an LLM-generated PR body could inadvertently use.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: exclude code-landed sessions from c..."](https://github.com/befeast/maestro/commit/237d5881485d01211bb09d0cdcb71560e961aad5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30553186)</sub>

<!-- /greptile_comment -->