### PR TITLE
feat: add Mint Console design tokens (#362)

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1367,7 +1367,7 @@ func TestFleetDashboard(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 	}
-	body := w.Body.String() + web.MustReadStatic("fleet.js") + web.MustReadStatic("fleet.css")
+	body := w.Body.String() + web.MustReadStatic("tokens.css") + web.MustReadStatic("fleet.js") + web.MustReadStatic("fleet.css")
 	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
 		t.Errorf("content-type = %q, want text/html", ct)
 	}
@@ -1375,6 +1375,12 @@ func TestFleetDashboard(t *testing.T) {
 		"Maestro Fleet",
 		"/api/v1/fleet",
 		"/api/v1/fleet/worker",
+		"<html data-theme=\"light\">",
+		"/static/tokens.css",
+		"Inter Tight",
+		"JetBrains Mono",
+		"#059669",
+		"#0891b2",
 		"color-scheme: light",
 		"fleet-initial-state",
 		"project-rail",
@@ -1676,7 +1682,7 @@ func fleetDashboardBodyWithProjects(t *testing.T, projects []FleetProject) strin
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 	}
-	return w.Body.String() + web.MustReadStatic("fleet.js") + web.MustReadStatic("fleet.css")
+	return w.Body.String() + web.MustReadStatic("tokens.css") + web.MustReadStatic("fleet.js") + web.MustReadStatic("fleet.css")
 }
 
 func fleetDashboardFixtureProjects(t *testing.T, count int) []FleetProject {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1010,7 +1010,7 @@ func TestHandleDashboard(t *testing.T) {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 	}
 
-	body := w.Body.String() + web.MustReadStatic("dashboard.js") + web.MustReadStatic("dashboard.css")
+	body := w.Body.String() + web.MustReadStatic("tokens.css") + web.MustReadStatic("dashboard.js") + web.MustReadStatic("dashboard.css")
 	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
 		t.Errorf("content-type = %q, want text/html", ct)
 	}
@@ -1043,6 +1043,11 @@ func TestHandleDashboard(t *testing.T) {
 	}
 	if !contains(body, "renderWorkerActions") || !contains(body, "actionDetailHTML") || !contains(body, "manual approval required") {
 		t.Error("dashboard should render disabled approval-gated action affordances")
+	}
+	for _, want := range []string{"<html data-theme=\"light\">", "/static/tokens.css", "Inter Tight", "JetBrains Mono", "#059669", "#0891b2", "color-scheme: light"} {
+		if !contains(body, want) {
+			t.Fatalf("dashboard design tokens should contain %q", want)
+		}
 	}
 	for _, want := range []string{"Scope", "Target", "Approval", "Disabled", "replace(/^Would\\s+/i"} {
 		if !contains(body, want) {

--- a/internal/server/web/static/dashboard.css
+++ b/internal/server/web/static/dashboard.css
@@ -1,24 +1,10 @@
-  :root {
-    color-scheme: dark;
-    --bg: #0d1117;
-    --panel: #151b23;
-    --panel-2: #10161d;
-    --line: #29313d;
-    --text: #e6edf3;
-    --muted: #8b949e;
-    --accent: #58a6ff;
-    --ok: #3fb950;
-    --warn: #d29922;
-    --bad: #f85149;
-    --queued: #a371f7;
-  }
   * { box-sizing: border-box; }
   body {
     margin: 0;
     min-width: 320px;
-    background: var(--bg);
+    background: linear-gradient(180deg, #ffffff 0, var(--bg) 220px);
     color: var(--text);
-    font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font: 14px/1.45 var(--font-display);
   }
   header {
     height: 56px;
@@ -28,7 +14,8 @@
     gap: 20px;
     padding: 0 18px;
     border-bottom: 1px solid var(--line);
-    background: #0b1016;
+    background: var(--surface);
+    box-shadow: var(--shadow-soft);
   }
   h1 {
     margin: 0;
@@ -81,7 +68,7 @@
     height: 30px;
     border: 1px solid var(--line);
     border-radius: 6px;
-    background: #0b1016;
+    background: var(--input-bg);
     color: var(--text);
     padding: 0 10px;
     outline: none;
@@ -115,15 +102,15 @@
     text-align: left;
   }
   tbody tr { cursor: pointer; }
-  tbody tr:hover, tbody tr.selected { background: #18212c; }
-  tbody tr.row-attention { background: rgba(248,81,73,.07); }
-  tbody tr.row-attention:hover, tbody tr.row-attention.selected { background: rgba(248,81,73,.13); }
+  tbody tr:hover, tbody tr.selected { background: var(--hover-bg); }
+  tbody tr.row-attention { background: var(--bad-bg); }
+  tbody tr.row-attention:hover, tbody tr.row-attention.selected { background: var(--bad-bg-strong); }
   a {
     color: var(--accent);
     text-decoration: none;
   }
   a:hover { text-decoration: underline; }
-  .slot { width: 92px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .slot { width: 92px; font-family: var(--font-mono); }
   .issue { width: auto; }
   .status { width: 128px; }
   .backend { width: 102px; }
@@ -171,7 +158,7 @@
     display: grid;
     grid-template-rows: 48px auto auto auto minmax(0, 1fr);
     overflow: hidden;
-    background: #080c11;
+    background: var(--card);
   }
   .log-head {
     padding: 0 14px;
@@ -195,7 +182,7 @@
     display: none;
     padding: 10px 14px;
     border-bottom: 1px solid var(--line);
-    background: #0b1016;
+    background: var(--panel-2);
     color: var(--muted);
     font-size: 12px;
     max-height: 220px;
@@ -218,12 +205,12 @@
   }
   .supervisor-panel, .outcome-panel {
 	border-bottom: 1px solid var(--line);
-	background: #0b1016;
+	background: var(--surface);
 	padding: 12px 14px;
 	font-size: 12px;
 	color: var(--muted);
   }
-  .outcome-panel { background: #0f151c; }
+  .outcome-panel { background: var(--panel-2); }
   .outcome-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -292,8 +279,8 @@
     min-height: 0;
     overflow: auto;
     padding: 14px;
-    color: #d1d7e0;
-    font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    color: var(--code-text);
+    font: 12px/1.5 var(--font-mono);
     white-space: pre-wrap;
     word-break: break-word;
   }

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -1,23 +1,9 @@
-  :root {
-    color-scheme: light;
-    --bg: #f6f8fb;
-    --panel: #ffffff;
-    --panel-2: #f8fafc;
-    --line: #d7dee8;
-    --text: #172033;
-    --muted: #64748b;
-    --accent: #2563eb;
-    --ok: #16803c;
-    --warn: #a16207;
-    --bad: #dc2626;
-    --queued: #7c3aed;
-  }
   * { box-sizing: border-box; }
   body {
     margin: 0;
-    background: linear-gradient(180deg, #fbfdff 0, var(--bg) 220px);
+    background: var(--page-gradient);
     color: var(--text);
-    font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font: 14px/1.45 var(--font-display);
   }
   header {
     min-height: 64px;
@@ -86,7 +72,7 @@
     width: 100%;
     border: 1px solid var(--line);
     border-radius: 8px;
-    background: #ffffff;
+    background: var(--input-bg);
     color: var(--text);
     font: inherit;
     padding: 7px 9px;
@@ -392,9 +378,9 @@
     padding: 12px;
     overflow: auto;
     border: 1px solid rgba(215,222,232,.9);
-    background: #05080d;
-    color: #dbe7f3;
-    font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: var(--code-bg);
+    color: var(--code-text);
+    font: 12px/1.45 var(--font-mono);
     white-space: pre-wrap;
   }
   .section-head {
@@ -516,7 +502,7 @@
   }
   .history-row-action:hover { border-color: rgba(88,166,255,.65); }
   .project-col { width: 140px; font-weight: 650; }
-  .slot-col { width: 92px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .slot-col { width: 92px; font-family: var(--font-mono); }
   .issue-col { width: auto; }
   .status-col { width: 132px; }
   .backend-col { width: 108px; }
@@ -608,7 +594,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .project-worker-slot { width: 68px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .project-worker-slot { width: 68px; font-family: var(--font-mono); }
   .project-worker-status { width: 124px; padding-right: 8px; }
   .project-worker-issue { min-width: 0; padding-right: 8px; }
   .project-worker-runtime { width: 64px; text-align: right; color: var(--muted); }

--- a/internal/server/web/static/tokens.css
+++ b/internal/server/web/static/tokens.css
@@ -1,0 +1,100 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;650;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap");
+
+:root,
+:root[data-theme="light"],
+html[data-theme="light"],
+body[data-theme="light"] {
+  color-scheme: light;
+
+  --maestro-bg: #f7fafa;
+  --maestro-surface: #ffffff;
+  --maestro-card: #ffffff;
+  --maestro-border: #dde6e3;
+  --maestro-border-hi: #c4d1cc;
+  --maestro-text: #0c1413;
+  --maestro-text-dim: #2c3633;
+  --maestro-text-mute: #4d5957;
+  --maestro-text-faint: #828b89;
+  --maestro-brand-a: #059669;
+  --maestro-brand-b: #0891b2;
+  --maestro-ok: #059669;
+  --maestro-warn: #c2410c;
+  --maestro-bad: #b91c1c;
+  --maestro-daemon: #6b7280;
+
+  --bg: var(--maestro-bg);
+  --surface: var(--maestro-surface);
+  --card: var(--maestro-card);
+  --panel: var(--maestro-surface);
+  --panel-2: #eef5f3;
+  --line: var(--maestro-border);
+  --border: var(--maestro-border);
+  --border-hi: var(--maestro-border-hi);
+  --text: var(--maestro-text);
+  --text-dim: var(--maestro-text-dim);
+  --text-mute: var(--maestro-text-mute);
+  --text-faint: var(--maestro-text-faint);
+  --muted: var(--maestro-text-mute);
+  --accent: var(--maestro-brand-b);
+  --brand-a: var(--maestro-brand-a);
+  --brand-b: var(--maestro-brand-b);
+  --ok: var(--maestro-ok);
+  --warn: var(--maestro-warn);
+  --bad: var(--maestro-bad);
+  --queued: #8b5cf6;
+  --daemon: var(--maestro-daemon);
+
+  --page-gradient: linear-gradient(180deg, #ffffff 0, var(--bg) 240px);
+  --input-bg: #ffffff;
+  --hover-bg: rgba(5, 150, 105, .07);
+  --ok-bg: rgba(5, 150, 105, .10);
+  --accent-bg: rgba(8, 145, 178, .10);
+  --warn-bg: rgba(194, 65, 12, .10);
+  --bad-bg: rgba(185, 28, 28, .08);
+  --bad-bg-strong: rgba(185, 28, 28, .13);
+  --code-bg: #f9fbfa;
+  --code-text: #172033;
+  --shadow-soft: 0 1px 0 rgba(12, 20, 19, .04), 0 8px 24px rgba(12, 20, 19, .05);
+  --focus-ring: 0 0 0 3px rgba(8, 145, 178, .18);
+  --font-display: "Inter Tight", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+:root[data-theme="dark"],
+html[data-theme="dark"],
+body[data-theme="dark"] {
+  color-scheme: dark;
+
+  --bg: #0d1117;
+  --surface: #151b23;
+  --card: #080c11;
+  --panel: #151b23;
+  --panel-2: #10161d;
+  --line: #29313d;
+  --border: #29313d;
+  --border-hi: #3b4554;
+  --text: #e6edf3;
+  --text-dim: #c9d1d9;
+  --text-mute: #8b949e;
+  --text-faint: #6e7681;
+  --muted: #8b949e;
+  --accent: #58a6ff;
+  --brand-a: #3fb950;
+  --brand-b: #58a6ff;
+  --ok: #3fb950;
+  --warn: #d29922;
+  --bad: #f85149;
+  --queued: #a371f7;
+  --daemon: #8b949e;
+  --page-gradient: var(--bg);
+  --input-bg: #0b1016;
+  --hover-bg: #18212c;
+  --ok-bg: rgba(63, 185, 80, .10);
+  --accent-bg: rgba(88, 166, 255, .10);
+  --warn-bg: rgba(210, 153, 34, .10);
+  --bad-bg: rgba(248, 81, 73, .07);
+  --bad-bg-strong: rgba(248, 81, 73, .13);
+  --code-bg: #05080d;
+  --code-text: #dbe7f3;
+  --shadow-soft: none;
+}

--- a/internal/server/web/templates/dashboard.html
+++ b/internal/server/web/templates/dashboard.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="light">
 <head>
 <title>maestro</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="/static/tokens.css">
 <link rel="stylesheet" href="/static/dashboard.css">
 
 </head>

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="light">
 <head>
 <title>maestro fleet</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="/static/tokens.css">
 <link rel="stylesheet" href="/static/fleet.css">
 
 </head>


### PR DESCRIPTION
Implements #362

## Summary
- add shared embedded /static/tokens.css with Mint Console light tokens and dark fallback tokens
- make both dashboard templates opt into light default and load tokens before page CSS
- move page CSS away from local root palettes and hard-coded dark dashboard defaults
- extend dashboard tests to assert token and light-default contract

## Verification
- go test ./internal/server
- go test ./...
- go build -o /tmp/maestro ./cmd/maestro
- temporary serve smoke check for /fleet, /static/tokens.css, /static/dashboard.css

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared `tokens.css` design-token file with Mint Console light and dark palettes, removes hardcoded `:root` blocks from `dashboard.css` and `fleet.css`, pins both HTML templates to `data-theme="light"`, and extends the Go test suite to assert the token and light-default contract.

<h3>Confidence Score: 4/5</h3>

Safe to merge; only P2 style/consistency findings, no runtime breakage.

Both findings are P2: the hardcoded gradient stop in dashboard.css diverges from the shared token but doesn't break the current fixed light-mode UI, and the missing --focus-ring in the dark block falls through correctly today. No P0/P1 issues found.

internal/server/web/static/dashboard.css — body gradient should use --page-gradient token; internal/server/web/static/tokens.css — --focus-ring should be added to the dark theme block.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/server/web/static/tokens.css | New shared design-token file; well-structured with light/dark blocks, but `--focus-ring` is missing from the dark theme overrides. |
| internal/server/web/static/dashboard.css | Removes local `:root` palette and switches to token variables; body gradient is hardcoded rather than using the shared `--page-gradient` token, diverging from fleet.css and the token's defined stop value. |
| internal/server/web/static/fleet.css | Removes local `:root` palette and correctly adopts token variables including `--page-gradient` and `--font-mono`. |
| internal/server/web/templates/dashboard.html | Adds `data-theme="light"` to `<html>` and loads `tokens.css` before page CSS as intended. |
| internal/server/web/templates/fleet.html | Adds `data-theme="light"` to `<html>` and loads `tokens.css` before page CSS as intended. |
| internal/server/server_test.go | Extends dashboard test to concatenate tokens.css into body and assert light-default contract (theme attribute, font names, brand colours). |
| internal/server/fleet_test.go | Mirrors the same tokens.css inclusion and light-default assertions for the fleet dashboard test. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/server/web/static/dashboard.css`, line 9-11 ([link](https://github.com/befeast/maestro/blob/4415c1b1b14ecd4b999e482813d39c5093cb76c8/internal/server/web/static/dashboard.css#L9-L11)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Hardcoded gradient instead of `--page-gradient` token**

   `dashboard.css` uses a hardcoded `linear-gradient(180deg, #ffffff 0, var(--bg) 220px)` while `fleet.css` correctly uses `var(--page-gradient)`. This is inconsistent with the design token system: the token in `tokens.css` resolves to a flat `var(--bg)` in dark mode and uses a `240px` stop in light mode, so both the gradient stop value (`220px` vs `240px`) and the dark-mode behavior diverge from the shared definition.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/web/static/dashboard.css
   Line: 9-11

   Comment:
   **Hardcoded gradient instead of `--page-gradient` token**

   `dashboard.css` uses a hardcoded `linear-gradient(180deg, #ffffff 0, var(--bg) 220px)` while `fleet.css` correctly uses `var(--page-gradient)`. This is inconsistent with the design token system: the token in `tokens.css` resolves to a flat `var(--bg)` in dark mode and uses a `240px` stop in light mode, so both the gradient stop value (`220px` vs `240px`) and the dark-mode behavior diverge from the shared definition.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/web/static/dashboard.css:9-11
**Hardcoded gradient instead of `--page-gradient` token**

`dashboard.css` uses a hardcoded `linear-gradient(180deg, #ffffff 0, var(--bg) 220px)` while `fleet.css` correctly uses `var(--page-gradient)`. This is inconsistent with the design token system: the token in `tokens.css` resolves to a flat `var(--bg)` in dark mode and uses a `240px` stop in light mode, so both the gradient stop value (`220px` vs `240px`) and the dark-mode behavior diverge from the shared definition.

```suggestion
    background: var(--page-gradient);
```

### Issue 2 of 2
internal/server/web/static/tokens.css:63-100
**`--focus-ring` missing from dark theme block**

`--focus-ring` is defined in the light-theme `:root` block (line 58) but is absent from the `[data-theme="dark"]` overrides. While cascade ensures the light value falls through today (since `:root` always matches), the dark theme block is intended to be the complete set of overrides — omitting it here means any future dark-mode focus style won't be updated when the palette changes, and the light-blue glow (`rgba(8, 145, 178, .18)`) will silently persist in dark contexts.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add mint console design tokens"](https://github.com/befeast/maestro/commit/4415c1b1b14ecd4b999e482813d39c5093cb76c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30555475)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->