### PR TITLE
feat: add shared UI primitives (#366)

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1377,6 +1377,8 @@ func TestFleetDashboard(t *testing.T) {
 		"/api/v1/fleet/worker",
 		"<html data-theme=\"light\">",
 		"/static/tokens.css",
+		"/static/components.css",
+		"/static/status-icons.svg",
 		"/static/maestro-mark.svg",
 		"/static/favicon-32.png",
 		"/static/apple-touch-icon-180.png",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1044,7 +1044,7 @@ func TestHandleDashboard(t *testing.T) {
 	if !contains(body, "renderWorkerActions") || !contains(body, "actionDetailHTML") || !contains(body, "manual approval required") {
 		t.Error("dashboard should render disabled approval-gated action affordances")
 	}
-	for _, want := range []string{"<html data-theme=\"light\">", "/static/tokens.css", "/static/maestro-mark.svg", "/static/favicon-32.png", "/static/apple-touch-icon-180.png", "/static/og-1200x630.png", "Inter Tight", "JetBrains Mono", "#059669", "#0891b2", "color-scheme: light"} {
+	for _, want := range []string{"<html data-theme=\"light\">", "/static/tokens.css", "/static/components.css", "/static/status-icons.svg", "/static/maestro-mark.svg", "/static/favicon-32.png", "/static/apple-touch-icon-180.png", "/static/og-1200x630.png", "Inter Tight", "JetBrains Mono", "#059669", "#0891b2", "color-scheme: light"} {
 		if !contains(body, want) {
 			t.Fatalf("dashboard design tokens should contain %q", want)
 		}
@@ -1065,6 +1065,21 @@ func TestBrandAssetsEmbedded(t *testing.T) {
 		data := []byte(web.MustReadStatic(name))
 		if !bytes.HasPrefix(data, []byte("\x89PNG\r\n\x1a\n")) {
 			t.Fatalf("%s is not an embedded PNG", name)
+		}
+	}
+}
+
+func TestComponentPrimitivesEmbedded(t *testing.T) {
+	components := web.MustReadStatic("components.css")
+	for _, want := range []string{".pill--ok", ".pill--warn", ".pill--bad", ".pill--idle", ".pill--policy", ".card", ".section", ".caption", ".status-icon"} {
+		if !contains(components, want) {
+			t.Fatalf("components.css should contain %q", want)
+		}
+	}
+	sprite := web.MustReadStatic("status-icons.svg")
+	for _, want := range []string{"status-ready", "status-running", "status-waiting", "status-blocked", "status-merged", "status-stale", "status-daemon", "status-queued"} {
+		if !contains(sprite, `id="`+want+`"`) {
+			t.Fatalf("status icon sprite should contain %q", want)
 		}
 	}
 }

--- a/internal/server/web/static/components.css
+++ b/internal/server/web/static/components.css
@@ -1,0 +1,89 @@
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  min-height: 24px;
+  padding: 2px 9px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pill--ok { color: var(--ok); border-color: rgba(5, 150, 105, .42); background: var(--ok-bg); }
+.pill--warn { color: var(--warn); border-color: rgba(194, 65, 12, .42); background: var(--warn-bg); }
+.pill--bad { color: var(--bad); border-color: rgba(185, 28, 28, .42); background: var(--bad-bg); }
+.pill--idle { color: var(--text-faint); border-color: var(--line); background: var(--panel-2); }
+.pill--policy { color: var(--queued); border-color: rgba(139, 92, 246, .42); background: rgba(139, 92, 246, .10); }
+
+.card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--card);
+  box-shadow: var(--shadow-soft);
+}
+
+.section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.section__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.caption {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.status-icon {
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  color: var(--muted);
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.status-icon--ready,
+.status-icon--merged { color: var(--ok); }
+.status-icon--running { color: var(--brand-a); }
+.status-icon--waiting,
+.status-icon--stale { color: var(--warn); }
+.status-icon--blocked { color: var(--bad); }
+.status-icon--daemon { color: var(--daemon); }
+.status-icon--queued { color: var(--text-mute); }
+
+.status-icon--ready { fill: currentColor; stroke: none; }
+
+@media (prefers-reduced-motion: no-preference) {
+  .status-icon--running {
+    animation: maestro-status-spin 1.2s linear infinite;
+    transform-origin: center;
+  }
+}
+
+@keyframes maestro-status-spin {
+  to { transform: rotate(360deg); }
+}

--- a/internal/server/web/static/status-icons.svg
+++ b/internal/server/web/static/status-icons.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <symbol id="status-ready" viewBox="0 0 20 20">
+    <circle cx="10" cy="10" r="4" fill="currentColor"/>
+  </symbol>
+  <symbol id="status-running" viewBox="0 0 20 20">
+    <circle cx="10" cy="10" r="6" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4 3"/>
+  </symbol>
+  <symbol id="status-waiting" viewBox="0 0 20 20">
+    <circle cx="10" cy="10" r="6" fill="none" stroke="currentColor" stroke-width="2"/>
+    <line x1="10" y1="10" x2="10" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <line x1="10" y1="10" x2="13" y2="10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  </symbol>
+  <symbol id="status-blocked" viewBox="0 0 20 20">
+    <circle cx="10" cy="10" r="6" fill="none" stroke="currentColor" stroke-width="2"/>
+    <line x1="6" y1="6" x2="14" y2="14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  </symbol>
+  <symbol id="status-merged" viewBox="0 0 20 20">
+    <path d="M5 6 L5 14 M5 10 L13 10 M13 7 L13 13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  </symbol>
+  <symbol id="status-stale" viewBox="0 0 20 20">
+    <circle cx="10" cy="10" r="6" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="2 2"/>
+  </symbol>
+  <symbol id="status-daemon" viewBox="0 0 20 20">
+    <rect x="5" y="5" width="10" height="10" rx="2" fill="none" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="status-queued" viewBox="0 0 20 20">
+    <circle cx="6" cy="10" r="1.5" fill="currentColor"/>
+    <circle cx="10" cy="10" r="1.5" fill="currentColor"/>
+    <circle cx="14" cy="10" r="1.5" fill="currentColor"/>
+  </symbol>
+</svg>

--- a/internal/server/web/templates/dashboard.html
+++ b/internal/server/web/templates/dashboard.html
@@ -14,7 +14,9 @@
 <link rel="icon" href="/static/favicon-32.png" type="image/png" sizes="32x32">
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
+<link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
 <link rel="stylesheet" href="/static/tokens.css">
+<link rel="stylesheet" href="/static/components.css">
 <link rel="stylesheet" href="/static/dashboard.css">
 
 </head>

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -14,7 +14,9 @@
 <link rel="icon" href="/static/favicon-32.png" type="image/png" sizes="32x32">
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
+<link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
 <link rel="stylesheet" href="/static/tokens.css">
+<link rel="stylesheet" href="/static/components.css">
 <link rel="stylesheet" href="/static/fleet.css">
 
 </head>


### PR DESCRIPTION
Implements #366

## Summary
- add shared components.css primitives for pills, cards, sections, captions, and status icons
- add the eight-glyph status-icons.svg sprite from the brand guide
- load component primitives and preload the sprite in both dashboard templates
- add tests for the primitive CSS and sprite contract

## Verification
- go test ./internal/server
- go test ./...
- go build -o /tmp/maestro ./cmd/maestro
- temporary serve smoke check for /fleet, /static/components.css, and /static/status-icons.svg

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces shared UI primitives — a `components.css` stylesheet with pill, card, section, caption, and status-icon classes, plus an eight-glyph `status-icons.svg` sprite — and loads them in both the `dashboard.html` and `fleet.html` templates. Contract tests covering every CSS class and SVG symbol ID are included and consistent with the added assets.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive static assets and tests with no logic changes to existing code paths.

All changes are new static files (CSS and SVG) plus template and test additions. No existing logic is modified, the new assets are well-formed, and the tests exhaustively assert the expected class names and symbol IDs.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/web/static/components.css | New CSS primitives for pills, cards, sections, captions, and status icons; well-structured with proper `prefers-reduced-motion` gating for the spin animation. |
| internal/server/web/static/status-icons.svg | New 8-glyph SVG sprite; all symbol IDs match what the tests assert and what the CSS modifier classes reference. |
| internal/server/web/templates/dashboard.html | Adds preload for the sprite and a stylesheet link for `components.css` in the correct order (after `tokens.css`, before the page-specific sheet). |
| internal/server/web/templates/fleet.html | Same template changes as `dashboard.html`; preload and stylesheet additions are consistent and correctly ordered. |
| internal/server/server_test.go | Adds `TestComponentPrimitivesEmbedded` that validates every expected CSS class and all eight SVG symbol IDs; also extends the dashboard token check to include the two new static assets. |
| internal/server/fleet_test.go | Updates `TestFleetDashboard` to assert that `components.css` and `status-icons.svg` are referenced by the fleet template. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add shared ui primitives"](https://github.com/befeast/maestro/commit/1290b1eea255b57a50d2816bcfc1a763a938eb09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30556234)</sub>

<!-- /greptile_comment -->