### PR TITLE
feat: distinguish unconfigured fleet projects (#340)

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1673,7 +1673,11 @@ func renderFleetProjectRailRows(projects []fleetProjectState) string {
 }
 
 func renderFleetProjectRailRow(project fleetProjectState) string {
-	rowClass := "project-rail-row " + fleetProjectRailStateClass(project)
+	rowClasses := []string{"project-rail-row", fleetProjectRailStateClass(project)}
+	if fleetProjectUnconfigured(project) {
+		rowClasses = append(rowClasses, "project-row--unconfigured")
+	}
+	rowClass := strings.Join(rowClasses, " ")
 	return `<tr class="` + html.EscapeString(rowClass) + `">` +
 		`<td class="project-rail-project">` + renderFleetProjectIdentity(project) + `</td>` +
 		`<td class="project-rail-state-cell">` + renderFleetProjectRailState(project) + `</td>` +
@@ -1703,6 +1707,21 @@ func renderFleetProjectIdentity(project fleetProjectState) string {
 }
 
 func renderFleetProjectRailState(project fleetProjectState) string {
+	if fleetProjectUnconfigured(project) {
+		parts := []string{
+			`<span class="pill rail-state-unconfigured">setup</span>`,
+			`<div class="rail-subline" title="No outcome brief configured">No outcome brief configured</div>`,
+			`<div class="rail-note rail-setup-link">Set up &rarr;</div>`,
+		}
+		if project.Error != "" {
+			parts = append(parts, `<div class="rail-alert" title="`+html.EscapeString(project.Error)+`">State error</div>`)
+		}
+		if project.Freshness.Stale {
+			parts = append(parts, `<div class="rail-warn">Stale snapshot</div>`)
+		}
+		return strings.Join(parts, "")
+	}
+
 	operator := project.OperatorState
 	label := fleetProjectStateLabel(project)
 	summary := strings.TrimSpace(operator.Summary)
@@ -1810,6 +1829,15 @@ func fleetProjectPRLinks(project fleetProjectState, limit int) []string {
 }
 
 func renderFleetProjectRailOutcome(project fleetProjectState) string {
+	if fleetProjectUnconfigured(project) {
+		next := strings.TrimSpace(project.Outcome.NextAction)
+		if next == "" {
+			next = "Add an outcome brief to this project's Maestro config."
+		}
+		return `<div class="rail-subline rail-setup-copy" title="No outcome brief configured">No outcome brief configured</div>` +
+			`<div class="rail-note rail-setup-link" title="` + html.EscapeString(next) + `">Set up &rarr;</div>`
+	}
+
 	health := strings.TrimSpace(project.Outcome.HealthState)
 	if health == "" {
 		health = outcome.HealthUnknown
@@ -1851,6 +1879,13 @@ func renderFleetProjectRailFreshness(project fleetProjectState) string {
 
 func renderFleetProjectRailLinks(project fleetProjectState) string {
 	links := make([]string, 0, 3)
+	if fleetProjectUnconfigured(project) {
+		if setupURL := strings.TrimSpace(project.DashboardURL); setupURL != "" {
+			links = append(links, `<a class="setup-link" href="`+html.EscapeString(setupURL)+`" target="_blank" rel="noreferrer">Set up &rarr;</a>`)
+		} else if setupURL := fleetProjectGitHubURL(project.Repo); setupURL != "" {
+			links = append(links, `<a class="setup-link" href="`+html.EscapeString(setupURL)+`" target="_blank" rel="noreferrer">Set up &rarr;</a>`)
+		}
+	}
 	if strings.TrimSpace(project.DashboardURL) != "" {
 		links = append(links, `<a href="`+html.EscapeString(project.DashboardURL)+`" target="_blank" rel="noreferrer">Dashboard</a>`)
 	}
@@ -1862,6 +1897,9 @@ func renderFleetProjectRailLinks(project fleetProjectState) string {
 }
 
 func fleetProjectStateLabel(project fleetProjectState) string {
+	if fleetProjectUnconfigured(project) {
+		return "setup"
+	}
 	if label := strings.TrimSpace(project.OperatorState.Label); label != "" {
 		return label
 	}
@@ -1869,6 +1907,9 @@ func fleetProjectStateLabel(project fleetProjectState) string {
 }
 
 func fleetProjectStatePillClass(project fleetProjectState) string {
+	if fleetProjectUnconfigured(project) {
+		return "rail-state-unconfigured"
+	}
 	key := strings.TrimSpace(project.OperatorState.Kind)
 	if key == "" {
 		key = "idle"
@@ -1877,11 +1918,18 @@ func fleetProjectStatePillClass(project fleetProjectState) string {
 }
 
 func fleetProjectRailStateClass(project fleetProjectState) string {
+	if fleetProjectUnconfigured(project) {
+		return "project-row-unconfigured"
+	}
 	key := strings.TrimSpace(project.OperatorState.Kind)
 	if key == "" {
 		key = "idle"
 	}
 	return "project-row-" + fleetCSSClassToken(key)
+}
+
+func fleetProjectUnconfigured(project fleetProjectState) bool {
+	return !project.Outcome.Configured
 }
 
 func fleetProjectGitHubURL(repo string) string {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1393,6 +1393,11 @@ func TestFleetDashboard(t *testing.T) {
 		"project-rail-body",
 		"project-filter",
 		"Project Rail",
+		"projectIsUnconfigured",
+		"project-row--unconfigured",
+		"rail-state-unconfigured",
+		"badge-setup",
+		"Set up &rarr;",
 		"Last activity",
 		"Links/actions",
 		"fleet-verdict",
@@ -1583,6 +1588,43 @@ func TestFleetDashboardServerRendersProjectRailFixtures(t *testing.T) {
 				t.Fatal("10+ project fixture should render inside the scrollable rail container")
 			}
 		})
+	}
+}
+
+func TestFleetDashboardRendersUnconfiguredProjectAsSetupState(t *testing.T) {
+	stateDir := t.TempDir()
+	saveFleetTestSnapshot(t, stateDir, map[string]*state.Session{}, nil)
+	projectConfig := &config.Config{
+		Repo:        "owner/setup-needed",
+		StateDir:    stateDir,
+		MaxParallel: 1,
+		Server:      config.ServerConfig{ReadOnly: true},
+	}
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("Setup Needed", "/tmp/setup-needed.yaml", "http://127.0.0.1:8787", projectConfig),
+	}, "127.0.0.1", 8786, true)
+	snapshot := srv.snapshot()
+	project := findFleetProject(t, snapshot.Projects, "Setup Needed")
+
+	if !fleetProjectUnconfigured(project) {
+		t.Fatalf("project should be treated as unconfigured: %+v", project.Outcome)
+	}
+	row := renderFleetProjectRailRow(project)
+	for _, want := range []string{
+		"project-row--unconfigured",
+		"project-row-unconfigured",
+		"rail-state-unconfigured",
+		"setup",
+		"No outcome brief configured",
+		"Set up &rarr;",
+		"setup-link",
+	} {
+		if !contains(row, want) {
+			t.Fatalf("unconfigured rail row should contain %q, got:\n%s", want, row)
+		}
+	}
+	if outcomeHTML := renderFleetProjectRailOutcome(project); contains(outcomeHTML, `<span class="pill`) {
+		t.Fatalf("unconfigured outcome rail should not render a health pill, got:\n%s", outcomeHTML)
 	}
 }
 

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -119,6 +119,12 @@
   .project-row-working { background: rgba(22,128,60,.035); }
   .project-row-monitoring_pr, .project-row-pending_dispatch { background: rgba(37,99,235,.035); }
   .project-row-queue_blocked, .project-row-outcome_missing, .project-row-stale { background: rgba(161,98,7,.045); }
+  .project-row-unconfigured,
+  .project-row--unconfigured { background: rgba(100,116,139,.045); }
+  .project-row--unconfigured {
+    outline: 1px dashed rgba(100,116,139,.45);
+    outline-offset: -3px;
+  }
   .project-row-error { background: rgba(220,38,38,.075); }
   .rail-project-name {
     overflow: hidden;
@@ -152,7 +158,11 @@
   .rail-state-monitoring_pr, .rail-state-pending_dispatch, .outcome-unknown { color: var(--accent); border-color: rgba(37,99,235,.45); background: rgba(37,99,235,.07); }
   .rail-state-attention, .rail-state-error, .outcome-failing { color: var(--bad); border-color: rgba(220,38,38,.45); background: rgba(220,38,38,.07); }
   .rail-state-stale, .rail-state-queue_blocked, .rail-state-outcome_missing { color: var(--warn); border-color: rgba(161,98,7,.45); background: rgba(161,98,7,.08); }
+  .rail-state-unconfigured { color: var(--muted); border-color: rgba(100,116,139,.45); background: rgba(100,116,139,.08); }
   .rail-state-idle, .outcome-not_configured, .outcome-unmonitored { color: var(--muted); border-color: rgba(100,116,139,.45); background: rgba(100,116,139,.08); }
+  .rail-setup-copy,
+  .rail-setup-link,
+  .setup-link { color: var(--muted); font-weight: 650; }
   .project-overview {
     margin-bottom: 16px;
     border: 1px solid var(--line);
@@ -522,6 +532,11 @@
     background: var(--panel);
     min-height: 220px;
   }
+  .project.project-unconfigured {
+    border-color: rgba(100,116,139,.55);
+    border-style: dashed;
+    background: linear-gradient(180deg, rgba(255,255,255,.98), rgba(248,250,252,.92));
+  }
   .project.project-stale { border-color: rgba(210,153,34,.55); }
   .project.project-error { border-color: rgba(248,81,73,.55); }
   .project-head {
@@ -565,6 +580,8 @@
   }
   .badge-stale { color: var(--warn); border-color: rgba(210,153,34,.55); background: rgba(210,153,34,.08); }
   .badge-error { color: var(--bad); border-color: rgba(248,81,73,.55); background: rgba(248,81,73,.08); }
+  .badge-setup { color: var(--muted); border-color: rgba(100,116,139,.45); background: rgba(100,116,139,.08); }
+  .project-unconfigured .outcome-status { background: rgba(100,116,139,.045); }
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
   .metric-row {

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -747,12 +747,18 @@ function ensureSelectedProject() {
   }
 }
 
+function projectIsUnconfigured(project) {
+  return !((project.outcome || {}).configured === true);
+}
+
 function projectStateKey(project) {
+  if (projectIsUnconfigured(project)) return "unconfigured";
   const operator = project.operator_state || {};
   return operator.kind || "idle";
 }
 
 function projectStateLabel(project) {
+  if (projectIsUnconfigured(project)) return "setup";
   const operator = project.operator_state || {};
   return operator.label || "Idle";
 }
@@ -818,6 +824,17 @@ function projectIdentityRailHTML(project) {
 }
 
 function projectStateRailHTML(project) {
+  if (projectIsUnconfigured(project)) {
+    const parts = [
+      '<span class="pill rail-state-unconfigured">setup</span>',
+      '<div class="rail-subline" title="No outcome brief configured">No outcome brief configured</div>',
+      '<div class="rail-note rail-setup-link">Set up &rarr;</div>'
+    ];
+    if (project.error) parts.push('<div class="rail-alert" title="' + escapeText(project.error) + '">State error</div>');
+    if (project.freshness && project.freshness.stale) parts.push('<div class="rail-warn">Stale snapshot</div>');
+    return parts.join("");
+  }
+
   const key = projectStateKey(project);
   const operator = project.operator_state || {};
   const summary = String(operator.summary || ((project.running || 0) + '/' + (project.max_parallel || 0) + ' worker process(es) running.'));
@@ -868,6 +885,12 @@ function projectPRRailHTML(project) {
 }
 
 function projectOutcomeRailHTML(project) {
+  if (projectIsUnconfigured(project)) {
+    const next = (project.outcome && project.outcome.next_action) || "Add an outcome brief to this project's Maestro config.";
+    return '<div class="rail-subline rail-setup-copy" title="No outcome brief configured">No outcome brief configured</div>' +
+      '<div class="rail-note rail-setup-link" title="' + escapeText(next) + '">Set up &rarr;</div>';
+  }
+
   const outcome = project.outcome || {};
   const health = outcome.health_state || "unknown";
   const goal = outcome.configured === true && outcome.goal ? outcome.goal : "No outcome brief configured";
@@ -889,6 +912,10 @@ function projectFreshnessRailHTML(project) {
 
 function projectLinksRailHTML(project) {
   const links = [];
+  const setupURL = project.dashboard_url || githubRepoURL(project.repo);
+  if (projectIsUnconfigured(project) && setupURL) {
+    links.push('<a class="setup-link" href="' + escapeText(setupURL) + '" target="_blank" rel="noreferrer">Set up &rarr;</a>');
+  }
   if (project.dashboard_url) links.push(linkHTML(project.dashboard_url, "Dashboard"));
   if (githubRepoURL(project.repo)) links.push(linkHTML(githubRepoURL(project.repo), "GitHub"));
   links.push('<button type="button" class="link-button project-workers-link" data-project="' + escapeText(project.name || "") + '">Workers</button>');
@@ -897,7 +924,8 @@ function projectLinksRailHTML(project) {
 
 function projectRailRowHTML(project) {
   const key = projectStateKey(project);
-  return '<tr class="project-rail-row project-row-' + cssToken(key) + '" data-project="' + escapeText(project.name || "") + '">' +
+  const modifier = projectIsUnconfigured(project) ? ' project-row--unconfigured' : '';
+  return '<tr class="project-rail-row project-row-' + cssToken(key) + modifier + '" data-project="' + escapeText(project.name || "") + '">' +
     '<td class="project-rail-project">' + projectIdentityRailHTML(project) + '</td>' +
     '<td class="project-rail-state-cell">' + projectStateRailHTML(project) + '</td>' +
     '<td class="project-rail-queue-cell">' + projectQueueRailHTML(project) + '</td>' +
@@ -1308,6 +1336,9 @@ function projectFreshnessHTML(project) {
 
 function projectBadgesHTML(project) {
   const badges = [];
+  if (projectIsUnconfigured(project)) {
+    badges.push('<span class="badge badge-setup">setup</span>');
+  }
   if (project.error) {
     badges.push('<span class="badge badge-error">State error</span>');
   }
@@ -1320,6 +1351,7 @@ function projectBadgesHTML(project) {
 
 function projectClass(project) {
   let cls = "project";
+  if (projectIsUnconfigured(project)) cls += " project-unconfigured";
   if (project.error) cls += " project-error";
   if (project.freshness && project.freshness.stale) cls += " project-stale";
   return cls;


### PR DESCRIPTION
Implements #340.\n\nSummary:\n- renders unconfigured fleet projects with a dashed row/card treatment and gray setup state\n- removes the outcome health pill for unconfigured project rail rows\n- adds setup affordances in server-rendered HTML and hydrated JS\n\nVerification:\n- /usr/bin/node --check internal/server/web/static/fleet.js\n- go test ./internal/server\n- go test ./...\n- go build -o /tmp/maestro ./cmd/maestro\n- temporary smoke: /tmp/maestro serve --fleet /home/god/.maestro/fleet.yaml --host 127.0.0.1 --port 8792 --read-only

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces visual differentiation for unconfigured fleet projects — dashed row/card styling, a gray "setup" state pill, and "Set up →" affordances — implemented symmetrically in both the Go server-rendering path and the JS hydration path. The `fleetProjectUnconfigured` / `projectIsUnconfigured` helpers provide a clean, consistent gate for all render branches, HTML escaping is applied correctly throughout, and the new test covers the key rendering assertions end-to-end.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic defects found in either the Go or JS rendering paths.

All changed render functions guard correctly on the unconfigured flag, HTML escaping is applied consistently, Go and JS implementations are symmetric, and the new test validates the critical assertions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds `fleetProjectUnconfigured` helper and gates all rail-rendering functions on it; HTML escaping is applied correctly throughout. |
| internal/server/fleet_test.go | New `TestFleetDashboardRendersUnconfiguredProjectAsSetupState` covers the key rendering assertions; `TestFleetDashboard` gains smoke checks for the new JS identifiers. |
| internal/server/web/static/fleet.js | JS hydration mirrors the Go server-rendering path faithfully with `projectIsUnconfigured`; `escapeText` is used correctly for HTML attribute values. |
| internal/server/web/static/fleet.css | New CSS classes (`project-row--unconfigured`, `rail-state-unconfigured`, `badge-setup`, `project-unconfigured`) added with consistent muted-gray palette. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: distinguish unconfigured fleet pro..."](https://github.com/befeast/maestro/commit/8a4d906b4beb5d75ded8e16561351ca058695f40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30557503)</sub>

<!-- /greptile_comment -->