### PR TITLE
style: tighten fleet visual hierarchy (#335)

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1392,7 +1392,15 @@ func TestFleetDashboard(t *testing.T) {
 		"project-rail",
 		"project-rail-body",
 		"project-filter",
-		"Project Rail",
+		"project-segments",
+		"project-count-all",
+		"project-count-running",
+		"project-count-attention",
+		"project-count-idle",
+		"mode-pill",
+		"fleet-refresh",
+		"stat-label",
+		"Projects",
 		"projectIsUnconfigured",
 		"project-row--unconfigured",
 		"rail-state-unconfigured",
@@ -1402,7 +1410,7 @@ func TestFleetDashboard(t *testing.T) {
 		"supervisorOperatorSentence",
 		"raw-action",
 		"Last activity",
-		"Links/actions",
+		"Open",
 		"fleet-verdict",
 		"renderFleetVerdict",
 		"verdict-healthy",
@@ -1454,6 +1462,7 @@ func TestFleetDashboard(t *testing.T) {
 		"renderProjectRail",
 		"projectRailRowHTML",
 		"projectExpandedRailHTML",
+		"projectOpenRailHTML",
 		"projectQueueBarHTML",
 		"queue-bar-segment",
 		"toggleExpandedProject",
@@ -1576,7 +1585,7 @@ func TestFleetDashboardServerRendersProjectRailFixtures(t *testing.T) {
 			body := fleetDashboardBodyWithProjects(t, fleetDashboardFixtureProjects(t, tc.projects))
 			rail := dashboardSnippet(t, body, `<tbody id="project-rail-body">`, `</tbody>`)
 
-			for _, want := range []string{"Project", "State", "Queue", "PR", "Outcome", "Last activity", "Links/actions"} {
+			for _, want := range []string{"Project", "State", "Queue", "PR", "Outcome", "Last activity", "Open"} {
 				if !contains(body, want) {
 					t.Fatalf("dashboard rail should contain column %q", want)
 				}
@@ -1702,7 +1711,7 @@ func TestFleetDashboardServesFleetPath(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 	}
-	if !contains(w.Body.String(), "Project Rail") {
+	if !contains(w.Body.String(), "Projects") {
 		t.Fatal("/fleet should serve the fleet dashboard")
 	}
 }

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -1,120 +1,230 @@
   * { box-sizing: border-box; }
   body {
     margin: 0;
-    background: var(--page-gradient);
+    background: #f7fafa;
     color: var(--text);
-    font: 14px/1.45 var(--font-display);
+    font: 15px/1.45 var(--font-display);
   }
-  header {
-    min-height: 64px;
+  .fleet-header {
+    min-height: 84px;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 18px;
-    padding: 12px 20px;
+    padding: 22px 28px;
     border-bottom: 1px solid var(--line);
-    background: rgba(255,255,255,.92);
-    box-shadow: 0 1px 0 rgba(15,23,42,.04);
+    background: rgba(255,255,255,.96);
+    box-shadow: 0 1px 0 rgba(12,20,19,.04);
   }
-  .brand-heading { display: flex; align-items: center; gap: 10px; }
+  .brand-heading { display: flex; align-items: center; gap: 12px; min-width: 0; }
   .brand-mark { width: 34px; height: 34px; flex: 0 0 auto; }
-  h1 { margin: 0; font-size: 19px; letter-spacing: 0; }
-  .sub { color: var(--muted); font-size: 13px; }
+  h1 { display: flex; gap: 7px; align-items: baseline; margin: 0; font-size: 22px; letter-spacing: 0; }
+  .title-slash { color: var(--text-faint); font-weight: 500; }
+  .sub { color: var(--muted); font-size: 14px; }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex: 0 0 auto;
+  }
+  .mode-pill,
+  .refresh-button,
+  .user-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border-hi);
+    background: #fff;
+    color: var(--text-mute);
+    font-weight: 650;
+  }
+  .mode-pill {
+    min-height: 30px;
+    padding: 3px 12px;
+    border-radius: 999px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+  }
+  .refresh-button {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 20px;
+    line-height: 1;
+  }
+  .refresh-button:hover { border-color: var(--brand-b); color: var(--brand-b); }
+  .user-chip {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: #eef2f7;
+    color: var(--text-dim);
+  }
+  main { padding: 24px 28px 32px; }
+  .fleet-verdict-shell { margin-bottom: 18px; }
   .fleet-verdict {
-    max-width: 780px;
-    margin-top: 8px;
-    padding: 9px 12px;
+    position: relative;
+    min-height: 72px;
+    display: flex;
+    align-items: center;
+    padding: 16px 18px 16px 64px;
     border: 1px solid var(--line);
-    border-left-width: 4px;
-    border-radius: 12px;
-    background: rgba(88,166,255,.08);
+    border-left: 4px solid var(--brand-a);
+    border-radius: 8px;
+    background: #fff;
     color: var(--text);
-    font-size: 14px;
+    box-shadow: var(--shadow-soft);
+    font-size: 17px;
     font-weight: 650;
     line-height: 1.35;
   }
-  .fleet-verdict.verdict-healthy { border-left-color: var(--ok); background: rgba(63,185,80,.09); }
-  .fleet-verdict.verdict-busy { border-left-color: var(--accent); background: rgba(88,166,255,.1); }
-  .fleet-verdict.verdict-attention { border-left-color: var(--warn); background: rgba(210,153,34,.11); }
-  .fleet-verdict.verdict-daemon-down { border-left-color: var(--bad); background: rgba(248,81,73,.12); }
+  .fleet-verdict::before {
+    content: "";
+    position: absolute;
+    left: 34px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--brand-a);
+    box-shadow: 0 0 18px rgba(5,150,105,.45);
+  }
+  .fleet-verdict.verdict-healthy { border-left-color: var(--ok); background: #fff; }
+  .fleet-verdict.verdict-healthy::before { background: var(--ok); }
+  .fleet-verdict.verdict-busy { border-left-color: var(--accent); background: #fff; }
+  .fleet-verdict.verdict-busy::before { background: var(--accent); box-shadow: 0 0 18px rgba(8,145,178,.42); }
+  .fleet-verdict.verdict-attention { border-left-color: var(--warn); background: #fffaf1; }
+  .fleet-verdict.verdict-attention::before { background: var(--warn); box-shadow: 0 0 18px rgba(194,65,12,.32); }
+  .fleet-verdict.verdict-daemon-down { border-left-color: var(--bad); background: #fff5f5; }
+  .fleet-verdict.verdict-daemon-down::before { background: var(--bad); box-shadow: 0 0 18px rgba(185,28,28,.32); }
   .stats {
     display: grid;
-    grid-template-columns: repeat(5, minmax(68px, 1fr));
-    gap: 10px;
-    width: min(520px, 100%);
-  }
-  .stat { text-align: right; min-width: 0; }
-  .stat strong { display: block; font-size: 18px; font-variant-numeric: tabular-nums; }
-  .stat span { color: var(--muted); font-size: 12px; }
-  main { padding: 18px; }
-  .project-rail {
-    margin-bottom: 16px;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    overflow: hidden;
+    margin-bottom: 22px;
     border: 1px solid var(--line);
-    background: var(--panel);
-    box-shadow: 0 8px 24px rgba(15,23,42,.05);
+    border-radius: 8px;
+    background: #fff;
+    box-shadow: var(--shadow-soft);
   }
-  .project-rail-controls {
-    display: grid;
-    grid-template-columns: minmax(220px, 360px) minmax(0, 1fr);
-    gap: 12px;
-    align-items: end;
-    padding: 12px 14px;
-    border-bottom: 1px solid var(--line);
-    background: var(--panel-2);
+  .stat {
+    min-width: 0;
+    padding: 18px 22px;
+    border-right: 1px solid var(--line);
   }
-  .project-rail-controls label { display: grid; gap: 4px; min-width: 0; }
-  .project-rail-controls span {
-    color: var(--muted);
-    font-size: 11px;
+  .stat:last-child { border-right: 0; }
+  .stat-label {
+    display: block;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+    font-size: 12px;
     font-weight: 650;
+    letter-spacing: .08em;
     text-transform: uppercase;
   }
+  .stat-value { display: flex; align-items: baseline; gap: 6px; margin-top: 8px; }
+  .stat strong { display: block; color: var(--text); font-size: 36px; font-weight: 650; line-height: 1; font-variant-numeric: tabular-nums; }
+  .stat-suffix { color: var(--muted); font-size: 16px; }
+  .stat-note { display: block; margin-top: 6px; color: var(--muted); font-family: var(--font-mono); font-size: 12px; }
+  .project-rail {
+    margin-bottom: 20px;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--panel);
+    box-shadow: var(--shadow-soft);
+  }
+  .project-rail-head { align-items: flex-end; }
+  .project-rail-head h2 { font-size: 20px; }
+  .project-rail-controls {
+    display: grid;
+    grid-template-columns: minmax(260px, 360px) minmax(340px, auto);
+    gap: 12px;
+    justify-content: end;
+    align-items: center;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--line);
+    background: #fff;
+  }
+  .project-rail-controls label { display: grid; min-width: 0; }
+  .project-search-control span { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
   .project-rail-controls input {
     min-width: 0;
     width: 100%;
-    border: 1px solid var(--line);
+    height: 36px;
+    border: 1px solid var(--border-hi);
     border-radius: 8px;
     background: var(--input-bg);
     color: var(--text);
     font: inherit;
-    padding: 7px 9px;
+    padding: 7px 12px;
   }
-  .project-rail-help { color: var(--muted); font-size: 13px; text-align: right; }
-  .project-rail-scroll {
-    max-height: min(58vh, 720px);
-    overflow: auto;
+  .project-segments {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    min-height: 36px;
+    padding: 3px;
+    border: 1px solid var(--border-hi);
+    border-radius: 8px;
+    background: #fff;
   }
+  .segment {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 28px;
+    padding: 0 10px;
+    border-radius: 6px;
+    color: var(--muted);
+    font-size: 13px;
+    white-space: nowrap;
+  }
+  .segment.is-active { background: #eef2f7; color: var(--text); }
+  .segment b {
+    min-width: 18px;
+    padding: 1px 5px;
+    border-radius: 6px;
+    background: rgba(148,163,184,.16);
+    color: var(--text-mute);
+    font-size: 12px;
+    text-align: center;
+  }
+  .project-rail-scroll { overflow: auto; }
   .project-rail-table {
     width: 100%;
-    min-width: 1120px;
+    min-width: 1040px;
     border-collapse: collapse;
     table-layout: fixed;
   }
   .project-rail-table th,
   .project-rail-table td {
-    padding: 10px 12px;
-    border-bottom: 1px solid rgba(215,222,232,.85);
-    vertical-align: top;
+    padding: 17px 18px;
+    border-bottom: 1px solid rgba(215,222,232,.9);
+    vertical-align: middle;
   }
   .project-rail-table th {
     position: sticky;
     top: 0;
     z-index: 1;
-    color: var(--muted);
+    color: var(--text-faint);
+    font-family: var(--font-mono);
     font-size: 12px;
-    font-weight: 700;
+    font-weight: 650;
+    letter-spacing: .08em;
     text-align: left;
-    background: #f8fafc;
+    text-transform: uppercase;
+    background: #f1f5f7;
   }
   .project-rail-table tbody tr:hover { background: #f8fafc; }
   .project-rail-table .empty { padding: 18px 14px; text-align: center; }
-  .project-rail-project { width: 190px; }
-  .project-rail-state-cell { width: 150px; }
-  .project-rail-queue-cell { width: 250px; }
-  .project-rail-pr-cell { width: 130px; }
-  .project-rail-outcome-cell { width: 220px; }
+  .project-rail-project { width: 220px; }
+  .project-rail-state-cell { width: 180px; }
+  .project-rail-queue-cell { width: 220px; }
+  .project-rail-pr-cell { width: 150px; }
+  .project-rail-outcome-cell { width: auto; }
   .project-rail-freshness-cell { width: 150px; }
-  .project-rail-links-cell { width: 150px; }
+  .project-rail-links-cell { width: 90px; text-align: right; }
   .project-row-attention { background: rgba(220,38,38,.045); }
   .project-row-working { background: rgba(22,128,60,.035); }
   .project-row-monitoring_pr, .project-row-pending_dispatch { background: rgba(37,99,235,.035); }
@@ -146,14 +256,18 @@
   .rail-note,
   .rail-warn,
   .rail-alert {
+    display: -webkit-box;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    white-space: normal;
   }
-  .rail-mainline { color: var(--text); font-size: 13px; line-height: 1.35; }
+  .rail-subline { display: -webkit-box; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 2; white-space: normal; }
+  .rail-mainline { color: var(--text); font-size: 14px; line-height: 1.35; }
   .rail-alert { color: var(--bad); }
   .rail-warn { color: var(--warn); }
-  .rail-links { display: flex; flex-wrap: wrap; gap: 6px 10px; font-size: 12px; }
+  .rail-links { display: flex; flex-wrap: wrap; gap: 6px 10px; font-size: 13px; }
+  .rail-open-link { font-weight: 650; white-space: nowrap; }
   .project-rail-row { cursor: pointer; }
   .project-rail-row:focus-visible {
     outline: 2px solid rgba(5,150,105,.45);
@@ -191,15 +305,17 @@
   }
   .project-expand-grid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 10px;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 12px;
   }
   .project-expand-card {
     min-width: 0;
     border: 1px solid rgba(215,222,232,.95);
+    border-radius: 6px;
     background: rgba(255,255,255,.82);
-    padding: 10px;
+    padding: 12px;
   }
+  .project-expand-card-supervisor { grid-column: 1 / -1; }
   .project-expand-card .queue-snapshot,
   .project-expand-card .outcome-status,
   .project-expand-card .supervisor,
@@ -770,13 +886,17 @@
     white-space: nowrap;
   }
   .pill {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     max-width: 100%;
+    min-height: 26px;
     overflow: hidden;
-    padding: 1px 8px;
+    padding: 2px 11px;
     border: 1px solid var(--line);
     border-radius: 999px;
+    font-family: var(--font-mono);
     font-size: 12px;
+    font-weight: 650;
     text-overflow: ellipsis;
     vertical-align: middle;
     white-space: nowrap;

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -3,6 +3,10 @@ const projectSummaryEl = document.getElementById("project-summary");
 const projectRailBodyEl = document.getElementById("project-rail-body");
 const projectRailSummaryEl = document.getElementById("project-rail-summary");
 const projectFilterEl = document.getElementById("project-filter");
+const projectCountAllEl = document.getElementById("project-count-all");
+const projectCountRunningEl = document.getElementById("project-count-running");
+const projectCountAttentionEl = document.getElementById("project-count-attention");
+const projectCountIdleEl = document.getElementById("project-count-idle");
 const statsEl = document.getElementById("stats");
 const subtitleEl = document.getElementById("subtitle");
 const fleetVerdictEl = document.getElementById("fleet-verdict");
@@ -26,6 +30,7 @@ const prFilterEl = document.getElementById("pr-filter");
 const workerSortEl = document.getElementById("worker-sort");
 const sortDirectionEl = document.getElementById("sort-direction");
 const initialStateEl = document.getElementById("fleet-initial-state");
+const fleetRefreshEl = document.getElementById("fleet-refresh");
 const expandedProjectStorageKey = "maestro.fleet.expandedProject";
 
 const defaultSortDirections = { status: "asc", project: "asc", issue: "asc", runtime: "desc", pr: "asc" };
@@ -780,15 +785,25 @@ function renderFleetVerdict(verdict) {
 }
 
 function renderStats(summary) {
+  const projects = Number(summary.projects || 0);
+  const running = Number(summary.running || 0);
+  const prOpen = Number(summary.pr_open || 0);
+  const monitoring = Number(summary.monitoring_pr || 0);
+  const failed = Number(summary.failed || 0);
+  const attention = Number(summary.needs_attention || 0);
+  const sessions = Number(summary.sessions || 0);
   const items = [
-    ["Projects", summary.projects || 0],
-    ["Active", summary.active || 0],
-    ["PR open", summary.pr_open || 0],
-    ["Failed", summary.failed || 0],
-    ["Attention", summary.needs_attention || 0]
+    { label: "Running", value: running, suffix: "of " + projects, note: projects ? "worker slots" : "no projects" },
+    { label: "PRs in flight", value: prOpen, suffix: "", note: monitoring + " monitored" },
+    { label: "Failed", value: failed, suffix: "", note: "current fleet" },
+    { label: "Attention", value: attention, suffix: "", note: attention ? "waiting" : "nothing waiting" },
+    { label: "Sessions", value: sessions, suffix: "", note: "active + recent" }
   ];
-  statsEl.innerHTML = items.map(([label, value]) =>
-    '<div class="stat"><strong>' + escapeText(value) + '</strong><span>' + escapeText(label) + '</span></div>'
+  statsEl.innerHTML = items.map(item =>
+    '<div class="stat"><span class="stat-label">' + escapeText(item.label) + '</span>' +
+      '<div class="stat-value"><strong>' + escapeText(item.value) + '</strong>' +
+      (item.suffix ? '<span class="stat-suffix">' + escapeText(item.suffix) + '</span>' : '') + '</div>' +
+      '<span class="stat-note">' + escapeText(item.note) + '</span></div>'
   ).join("");
 }
 
@@ -856,6 +871,22 @@ function projectRailSummaryText(projects, total) {
   const filtered = projects.length === total ? "" : " shown from " + total;
   return projects.length + " project" + (projects.length === 1 ? "" : "s") + filtered +
     " · " + active + " active · " + attention + " attention";
+}
+
+function setProjectCount(el, value) {
+  if (el) el.textContent = String(value);
+}
+
+function updateProjectSegmentCounts(projects) {
+  const items = projects || [];
+  const activeKinds = new Set(["working", "monitoring_pr", "pending_dispatch"]);
+  const running = items.filter(project => activeKinds.has(projectStateKey(project))).length;
+  const attention = items.reduce((sum, project) => sum + Number(project.needs_attention || 0), 0);
+  const idle = items.filter(project => !activeKinds.has(projectStateKey(project)) && Number(project.needs_attention || 0) === 0).length;
+  setProjectCount(projectCountAllEl, items.length);
+  setProjectCount(projectCountRunningEl, running);
+  setProjectCount(projectCountAttentionEl, attention);
+  setProjectCount(projectCountIdleEl, idle);
 }
 
 function githubRepoURL(repo) {
@@ -975,6 +1006,12 @@ function projectLinksRailHTML(project) {
   return '<div class="rail-links">' + links.join(' ') + '</div>';
 }
 
+function projectOpenRailHTML(project) {
+  const url = project.dashboard_url || githubRepoURL(project.repo);
+  const label = projectIsUnconfigured(project) ? "Set up" : "Open";
+  return '<div class="rail-open-link">' + linkHTML(url, label + " ›") + '</div>';
+}
+
 function projectQueueBarHTML(project) {
   const q = project.queue_snapshot || {};
   const segments = [
@@ -1026,7 +1063,7 @@ function projectRailRowHTML(project) {
     '<td class="project-rail-pr-cell">' + projectPRRailHTML(project) + '</td>' +
     '<td class="project-rail-outcome-cell">' + projectOutcomeRailHTML(project) + '</td>' +
     '<td class="project-rail-freshness-cell">' + projectFreshnessRailHTML(project) + '</td>' +
-    '<td class="project-rail-links-cell">' + projectLinksRailHTML(project) + '</td>' +
+    '<td class="project-rail-links-cell">' + projectOpenRailHTML(project) + '</td>' +
   '</tr>';
   return row + (expanded ? projectExpandedRailHTML(project) : '');
 }
@@ -1040,8 +1077,10 @@ function toggleExpandedProject(projectName) {
 
 function renderProjectRail() {
   ensureSelectedProject();
-  const total = (fleetState.projects || []).length;
+  const allProjects = fleetState.projects || [];
+  const total = allProjects.length;
   const projects = visibleProjects();
+  updateProjectSegmentCounts(allProjects);
   projectRailSummaryEl.textContent = projectRailSummaryText(projects, total);
   if (!projects.length) {
     const empty = total ? "No configured projects match the project search." : "No configured projects are available in this fleet.";
@@ -1568,6 +1607,7 @@ function clearWorkerProjectScope() {
 }
 
 workerProjectResetEl.addEventListener("click", clearWorkerProjectScope);
+if (fleetRefreshEl) fleetRefreshEl.addEventListener("click", loadFleet);
 
 projectFilterEl.addEventListener("input", () => {
   fleetState.projectQuery = projectFilterEl.value.trim();

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -21,29 +21,41 @@
 
 </head>
 <body data-page="fleet">
-<header>
-  <div>
-    <div class="brand-heading">
-      <img class="brand-mark" src="/static/maestro-mark.svg" alt="" aria-hidden="true">
-      <h1>Maestro Fleet</h1>
+<header class="fleet-header">
+  <div class="brand-heading">
+    <img class="brand-mark" src="/static/maestro-mark.svg" alt="" aria-hidden="true">
+    <div>
+      <h1 aria-label="Maestro Fleet"><span>Maestro</span><span class="title-slash">/</span><span>Fleet</span></h1>
+      <div class="sub" id="subtitle">Loading projects...</div>
     </div>
-    <div class="sub" id="subtitle">Loading projects...</div>
-    <div class="fleet-verdict verdict-healthy" id="fleet-verdict">Loading supervisor heartbeat...</div>
   </div>
-  <div class="stats" id="stats"></div>
+  <div class="header-actions">
+    <span class="mode-pill">Read-only</span>
+    <button type="button" class="refresh-button" id="fleet-refresh" aria-label="Refresh fleet data">↻</button>
+    <span class="user-chip" aria-label="Operator ko">ko</span>
+  </div>
 </header>
 <main>
+  <section class="fleet-verdict-shell" aria-live="polite">
+    <div class="fleet-verdict verdict-healthy" id="fleet-verdict">Loading supervisor heartbeat...</div>
+  </section>
+  <section class="stats stats-strip" id="stats" aria-label="Fleet summary"></section>
   <section class="project-rail" id="project-rail" aria-live="polite">
-    <div class="section-head">
+    <div class="section-head project-rail-head">
       <div>
-        <h2>Project Rail</h2>
-        <div class="sub">All configured projects in one scan-friendly view: state, queue, PRs, outcome, freshness, and links.</div>
+        <h2>Projects</h2>
+        <div class="sub">Scan project state, queue, PRs, outcome, and last activity.</div>
       </div>
       <div class="section-note" id="project-rail-summary">{{FLEET_PROJECT_RAIL_SUMMARY}}</div>
     </div>
     <div class="project-rail-controls">
-      <label for="project-filter"><span>Project Search</span><input id="project-filter" type="search" placeholder="Filter by project, repo, state, queue, or outcome"></label>
-      <div class="project-rail-help">Search narrows the rail only; the rail remains the primary fleet overview.</div>
+      <label class="project-search-control" for="project-filter"><span>Project Search</span><input id="project-filter" type="search" placeholder="Filter projects"></label>
+      <div class="project-segments" aria-label="Project state summary">
+        <span class="segment is-active">All <b id="project-count-all">0</b></span>
+        <span class="segment">Running <b id="project-count-running">0</b></span>
+        <span class="segment">Attention <b id="project-count-attention">0</b></span>
+        <span class="segment">Idle <b id="project-count-idle">0</b></span>
+      </div>
     </div>
     <div class="project-rail-scroll">
       <table class="project-rail-table" aria-label="Configured project fleet rail">
@@ -55,7 +67,7 @@
             <th class="project-rail-pr-cell">PR</th>
             <th class="project-rail-outcome-cell">Outcome</th>
             <th class="project-rail-freshness-cell">Last activity</th>
-            <th class="project-rail-links-cell">Links/actions</th>
+            <th class="project-rail-links-cell">Open</th>
           </tr>
         </thead>
         <tbody id="project-rail-body">{{FLEET_PROJECT_RAIL_ROWS}}</tbody>


### PR DESCRIPTION
Updates #335.\n\nSummary:\n- Moves fleet verdict and stats into dedicated light-theme surface sections closer to the redesign mock.\n- Adds header read-only mode, refresh button, and operator chip.\n- Converts project controls into a compact search + state summary segmented strip.\n- Reduces project rail link clutter with a single Open column while keeping full links in expanded rows.\n- Improves project rail spacing, typography, row rhythm, and expanded-row layout.\n\nVerification:\n- node --check internal/server/web/static/fleet.js\n- go test ./internal/server\n- go test ./...\n- go build -o /tmp/maestro ./cmd/maestro\n- temporary maestro serve smoke for /fleet and static assets

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the fleet dashboard's visual hierarchy: it moves verdict and stats into dedicated card surfaces, adds a header refresh button and mode pill, converts the project controls into a search + segmented-count strip, and collapses the links column to a single "Open" link (with full links preserved in expanded rows). The changes are largely presentational with one functional addition (the refresh button wiring in JS).

- **P1 — Hardcoded operator chip**: `fleet.html` line 35 renders `\"ko\"` and `aria-label=\"Operator ko\"` as literal strings. `FleetServer` has no operator-identity field and no template token substitutes this value, so every user of the fleet UI will see the same incorrect initials.

<h3>Confidence Score: 3/5</h3>

Safe to merge after resolving the hardcoded operator chip or explicitly marking it as a known placeholder.

One P1 finding: the "ko" initials in the user chip are hardcoded in the shared template with no substitution mechanism, so they will be wrong for all operators other than the author. Everything else (CSS, JS logic, test updates) looks correct and well-scoped. Score is 3 rather than the P1 ceiling of 4 because the chip is visible on every page load and misleads users about operator identity.

internal/server/web/templates/fleet.html — hardcoded operator chip at line 35.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet_test.go | Test strings updated to match new UI labels (segment counts, "Open" column, "Projects" heading); coverage looks aligned with the new JS/HTML surface. |
| internal/server/web/static/fleet.css | Substantial visual refresh — new surface sections, stat-strip layout, segment strip, refined typography and spacing; no logic concerns. |
| internal/server/web/static/fleet.js | New segment-count helpers, revised stat rendering using valid server fields (running/sessions), and projectOpenRailHTML collapse the links column to a single link; logic is sound. Segment counts reflect unfiltered fleet totals, not the filtered view, which is likely intentional but could be confusing. |
| internal/server/web/templates/fleet.html | Header restructured with mode pill, refresh button, and operator chip — but the chip's "ko" initials and aria-label are hardcoded strings with no server-side substitution, making them incorrect for any operator other than the author. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/server/web/templates/fleet.html:35
**Hardcoded operator initials in shared template**

The user chip renders `"ko"` and `aria-label="Operator ko"` as literal strings with no server-side template variable. Because `FleetServer` carries no operator-identity field and the template uses no substitution token here (unlike `{{FLEET_INITIAL_STATE}}`), every operator who opens `/fleet` will see the same "ko" chip regardless of who they are. The `fleetSummary` and `fleetResponse` structs have no equivalent field to supply the correct initials.

Either drive this from a template variable injected by the server, or remove the chip until operator identity is plumbed through the fleet config.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style: tighten fleet visual hierarchy (#..."](https://github.com/befeast/maestro/commit/d214191ce02215b62824b1f40b207bca464317e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30561744)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->