### PR TITLE
fix: keep fleet dashboard aligned at desktop widths (#335)

### DIFF
--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -193,13 +193,13 @@
   .project-rail-scroll { overflow: auto; }
   .project-rail-table {
     width: 100%;
-    min-width: 1040px;
+    min-width: 0;
     border-collapse: collapse;
     table-layout: fixed;
   }
   .project-rail-table th,
   .project-rail-table td {
-    padding: 17px 18px;
+    padding: 15px 14px;
     border-bottom: 1px solid rgba(215,222,232,.9);
     vertical-align: middle;
   }
@@ -218,13 +218,13 @@
   }
   .project-rail-table tbody tr:hover { background: #f8fafc; }
   .project-rail-table .empty { padding: 18px 14px; text-align: center; }
-  .project-rail-project { width: 220px; }
-  .project-rail-state-cell { width: 180px; }
-  .project-rail-queue-cell { width: 220px; }
-  .project-rail-pr-cell { width: 150px; }
-  .project-rail-outcome-cell { width: auto; }
-  .project-rail-freshness-cell { width: 150px; }
-  .project-rail-links-cell { width: 90px; text-align: right; }
+  .project-rail-project { width: 20%; }
+  .project-rail-state-cell { width: 17%; }
+  .project-rail-queue-cell { width: 18%; }
+  .project-rail-pr-cell { width: 11%; }
+  .project-rail-outcome-cell { width: 20%; }
+  .project-rail-freshness-cell { width: 8%; }
+  .project-rail-links-cell { width: 6%; text-align: right; }
   .project-row-attention { background: rgba(220,38,38,.045); }
   .project-row-working { background: rgba(22,128,60,.035); }
   .project-row-monitoring_pr, .project-row-pending_dispatch { background: rgba(37,99,235,.035); }
@@ -263,11 +263,11 @@
     white-space: normal;
   }
   .rail-subline { display: -webkit-box; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 2; white-space: normal; }
-  .rail-mainline { color: var(--text); font-size: 14px; line-height: 1.35; }
+  .rail-mainline { color: var(--text); font-size: 13px; line-height: 1.35; }
   .rail-alert { color: var(--bad); }
   .rail-warn { color: var(--warn); }
-  .rail-links { display: flex; flex-wrap: wrap; gap: 6px 10px; font-size: 13px; }
-  .rail-open-link { font-weight: 650; white-space: nowrap; }
+  .rail-links { display: flex; flex-wrap: wrap; gap: 6px 10px; font-size: 12px; }
+  .rail-open-link { font-size: 12px; font-weight: 650; white-space: nowrap; }
   .project-rail-row { cursor: pointer; }
   .project-rail-row:focus-visible {
     outline: 2px solid rgba(5,150,105,.45);
@@ -990,17 +990,20 @@
   .queue-idle { color: var(--warn); }
   .error { color: var(--bad); border: 1px solid rgba(248,81,73,.35); border-radius: 10px; background: rgba(248,81,73,.08); padding: 12px 14px; }
   @media (max-width: 980px) {
-    header { align-items: flex-start; flex-direction: column; }
-    .stats { width: 100%; }
+    .fleet-header { align-items: center; flex-direction: row; }
+    .stats { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+    .project-rail-controls { grid-template-columns: minmax(220px, 1fr) auto; }
     .worker-controls { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .worker-controls .search-control { grid-column: 1 / -1; }
     .worker-table { min-width: 1080px; }
   }
   @media (max-width: 700px) {
-    header { align-items: flex-start; flex-direction: column; }
+    .fleet-header { align-items: flex-start; flex-direction: column; }
     .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .stat { text-align: left; }
+    .stat { padding: 14px; }
     main { padding: 10px; }
+    .project-rail-controls { grid-template-columns: 1fr; justify-content: stretch; }
+    .project-segments { overflow-x: auto; }
     .section-head { flex-direction: column; }
     .section-note { text-align: left; }
     .worker-controls { grid-template-columns: 1fr; }


### PR DESCRIPTION
Updates #335.\n\nSummary:\n- Prevents the fleet header from collapsing into a centered vertical layout at desktop-ish widths.\n- Removes the project rail forced min-width that caused right-side columns to be clipped.\n- Converts project rail column widths to percentages so the table fits the visible container.\n- Tightens table padding and rail text scale to reduce overflow against the mock layout.\n\nVerification:\n- node --check internal/server/web/static/fleet.js\n- go test ./internal/server\n- go test ./...\n- go build -o /tmp/maestro ./cmd/maestro\n- temporary maestro serve smoke for /fleet CSS

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This CSS-only PR fixes the fleet dashboard header collapsing into a vertical layout at desktop-ish widths (≤980px) and stops the project-rail table from overflowing its container. The `header` element selector in both responsive breakpoints is correctly narrowed to the `.fleet-header` class, which matches the HTML template (`<header class="fleet-header">`), and the project-rail column widths are converted from fixed pixels to percentages that sum to 100%.

<h3>Confidence Score: 5/5</h3>

Safe to merge — CSS-only change with no logic errors; all column percentages sum to 100% and the selector rename matches the HTML template.

Single CSS file changed, no JavaScript or Go logic touched. The percentage-based column widths total exactly 100%, the `.fleet-header` class matches the live HTML, media query logic is coherent, and the changes directly address the stated layout regression without introducing new issues.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/web/static/fleet.css | Responsive layout fixes: replaces `header` element selector with `.fleet-header` class, switches project-rail table columns from fixed px to percentage widths (summing to 100%), removes forced min-width on the table, tightens padding/font sizes, and reorders media query breakpoint behaviour to keep the header in row layout at ≤980px while still collapsing at ≤700px. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep fleet dashboard aligned at des..."](https://github.com/befeast/maestro/commit/0017e6649e3cf65e36e7af0ea0f7738d95980dd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30562478)</sub>

<!-- /greptile_comment -->