### PR TITLE
fix: bust dashboard static asset cache (#335)

### DIFF
--- a/internal/server/web/templates/dashboard.html
+++ b/internal/server/web/templates/dashboard.html
@@ -15,9 +15,9 @@
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
 <link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
-<link rel="stylesheet" href="/static/tokens.css">
-<link rel="stylesheet" href="/static/components.css">
-<link rel="stylesheet" href="/static/dashboard.css">
+<link rel="stylesheet" href="/static/tokens.css?v=20260502-2">
+<link rel="stylesheet" href="/static/components.css?v=20260502-2">
+<link rel="stylesheet" href="/static/dashboard.css?v=20260502-2">
 
 </head>
 <body data-page="dashboard">
@@ -64,7 +64,7 @@
   </section>
 </main>
 <script>window.MAESTRO_REPO = __REPO_JSON__;</script>
-<script src="/static/dashboard.js"></script>
+<script src="/static/dashboard.js?v=20260502-2"></script>
 
 </body>
 </html>

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -15,9 +15,9 @@
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
 <link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
-<link rel="stylesheet" href="/static/tokens.css">
-<link rel="stylesheet" href="/static/components.css">
-<link rel="stylesheet" href="/static/fleet.css">
+<link rel="stylesheet" href="/static/tokens.css?v=20260502-2">
+<link rel="stylesheet" href="/static/components.css?v=20260502-2">
+<link rel="stylesheet" href="/static/fleet.css?v=20260502-2">
 
 </head>
 <body data-page="fleet">
@@ -162,7 +162,7 @@
   </section>
 </main>
 <script type="application/json" id="fleet-initial-state">{{FLEET_INITIAL_STATE}}</script>
-<script src="/static/fleet.js"></script>
+<script src="/static/fleet.js?v=20260502-2"></script>
 
 </body>
 </html>

--- a/internal/server/web/web.go
+++ b/internal/server/web/web.go
@@ -36,5 +36,9 @@ func StaticHandler() http.Handler {
 	if err != nil {
 		panic(fmt.Sprintf("open embedded static fs: %v", err))
 	}
-	return http.StripPrefix("/static/", http.FileServer(http.FS(static)))
+	server := http.StripPrefix("/static/", http.FileServer(http.FS(static)))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-cache, max-age=0")
+		server.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
## Summary
- add explicit static asset version query strings for fleet/dashboard CSS and JS
- serve embedded /static assets with no-cache headers so already-open browsers pick up the deployed UI

## Verification
- git diff --check
- /usr/bin/node --check internal/server/web/static/fleet.js
- /usr/local/bin/go test ./internal/server
- /usr/local/bin/go test ./...
- /usr/local/bin/go build -o /tmp/maestro ./cmd/maestro
- smoke: /fleet references /static/fleet.css?v=20260502-2 and CSS response has Cache-Control: no-cache, max-age=0

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR busts the dashboard/fleet static asset cache by appending a hardcoded version query string (`?v=20260502-2`) to all CSS/JS references in both HTML templates, and by wrapping the embedded static file server to always send `Cache-Control: no-cache, max-age=0`.

- The `no-cache` revalidation path is unreliable for `embed.FS`: embedded files always expose `ModTime = time.Time{}`, so Go's `http.FileServer` produces ETags derived only from file size — a CSS/JS change that preserves byte size will yield an identical ETag and return a stale `304 Not Modified` despite the `no-cache` directive. The version string is the only dependable mechanism, but it is hardcoded in both templates and must be manually incremented on every future deployment that touches these assets.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the immediate cache-bust goal, but the no-cache fallback is structurally unreliable for embed.FS and the version string requires manual upkeep on every future deploy.

One P1 logic finding: the Cache-Control revalidation strategy is undermined by embed.FS always reporting zero ModTime, making ETags size-only and potentially returning stale 304s on same-size file edits. The hardcoded version string is the only fully reliable bust path but has no enforcement mechanism.

internal/server/web/web.go — the StaticHandler no-cache wrapper; both HTML templates for the hardcoded version strings

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/web/web.go | Wraps FileServer to inject Cache-Control: no-cache, max-age=0; revalidation unreliable for embed.FS because ETags are based on zero modtime + file size only |
| internal/server/web/templates/dashboard.html | Adds hardcoded ?v=20260502-2 query strings to CSS/JS references for one-time cache bust; string must be manually updated on every future deploy |
| internal/server/web/templates/fleet.html | Same hardcoded ?v=20260502-2 cache-bust query strings applied to fleet CSS/JS references |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/server/web/web.go:41
**`no-cache` revalidation unreliable with `embed.FS`**

`embed.FS` files always report `ModTime = time.Time{}` (year 1). Go's `http.FileServer` computes ETags as `"<modtime_unix>-<size>"` — since modtime is fixed, the ETag only changes when file size changes. A deployment that edits CSS/JS without altering its byte size will produce the same ETag, so `no-cache` revalidation returns `304 Not Modified` with stale content. The version query string in the templates is the only reliable bust mechanism, but it is hardcoded and must be manually incremented on every future deployment that touches these assets.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bust dashboard static asset cache (..."](https://github.com/befeast/maestro/commit/b216738034fc0ae83acbdd1a22c02b6c3ccb154f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30562888)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->