### PR TITLE
fix: keep completed workers out of live fleet scope (#335)

### DIFF
--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -1315,6 +1315,30 @@
   .issue-title { font-size: 14px; }
   .why-line { margin-top: 6px; }
 
+  .fleet-workers .table-scroll {
+    max-height: min(48vh, 520px);
+  }
+
+  .fleet-workers .section-head {
+    border-bottom-color: #e5ecea;
+  }
+
+  .worker-table tbody tr.history-row {
+    background: #f8fbfb;
+  }
+
+  .worker-table tbody tr.history-row td {
+    padding: 18px 24px;
+  }
+
+  .history-row-content {
+    color: #687371;
+  }
+
+  .history-row-content strong {
+    margin-right: 8px;
+  }
+
   @media (max-width: 1180px) {
     main { padding-inline: 20px; }
     .fleet-header { padding-inline: 22px; }
@@ -1322,13 +1346,14 @@
     .project-segments { justify-content: space-between; }
     .project-rail-table th,
     .project-rail-table td { padding-inline: 16px; }
-    .project-rail-project { width: 20%; }
-    .project-rail-state-cell { width: 19%; }
-    .project-rail-queue-cell { width: 20%; }
-    .project-rail-pr-cell { width: 11%; }
-    .project-rail-outcome-cell { width: 20%; }
-    .project-rail-freshness-cell { width: 7%; }
-    .project-rail-links-cell { width: 3%; }
+    .project-rail-table { min-width: 0; }
+    .project-rail-outcome-cell,
+    .project-rail-freshness-cell,
+    .project-rail-links-cell { display: none; }
+    .project-rail-project { width: 25%; }
+    .project-rail-state-cell { width: 24%; }
+    .project-rail-queue-cell { width: 31%; }
+    .project-rail-pr-cell { width: 20%; }
   }
 
   @media (max-width: 860px) {
@@ -1343,6 +1368,10 @@
     .stat strong { font-size: 36px; }
     .fleet-verdict { padding-left: 64px; font-size: 16px; }
     .fleet-verdict::before { left: 30px; }
-    .project-rail-scroll { overflow-x: auto; }
-    .project-rail-table { min-width: 980px; }
+    .project-rail-scroll { overflow-x: visible; }
+    .project-rail-table { min-width: 0; }
+    .project-rail-queue-cell { display: none; }
+    .project-rail-project { width: 42%; }
+    .project-rail-state-cell { width: 34%; }
+    .project-rail-pr-cell { width: 24%; }
   }

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -502,8 +502,10 @@ function workerMatchesFilters(worker) {
 }
 
 function isLiveWorker(worker) {
-  if (worker.live === true) return true;
   const displayed = displayStatus(worker);
+  const terminal = new Set(["done", "failed", "dead", "conflict_failed", "retry_exhausted"]);
+  if (terminal.has(displayed) || terminal.has(worker.status || "")) return false;
+  if (worker.live === true) return true;
   return ["running", "pr_open", "queued", "review_retry_running", "review_retry_recheck", "review_retry_pending", "review_retry_backoff"].includes(displayed) ||
     ["running", "pr_open", "queued"].includes(worker.status || "");
 }

--- a/internal/server/web/templates/dashboard.html
+++ b/internal/server/web/templates/dashboard.html
@@ -15,9 +15,9 @@
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
 <link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
-<link rel="stylesheet" href="/static/tokens.css?v=20260502-3">
-<link rel="stylesheet" href="/static/components.css?v=20260502-3">
-<link rel="stylesheet" href="/static/dashboard.css?v=20260502-3">
+<link rel="stylesheet" href="/static/tokens.css?v=20260502-4">
+<link rel="stylesheet" href="/static/components.css?v=20260502-4">
+<link rel="stylesheet" href="/static/dashboard.css?v=20260502-4">
 
 </head>
 <body data-page="dashboard">
@@ -64,7 +64,7 @@
   </section>
 </main>
 <script>window.MAESTRO_REPO = __REPO_JSON__;</script>
-<script src="/static/dashboard.js?v=20260502-3"></script>
+<script src="/static/dashboard.js?v=20260502-4"></script>
 
 </body>
 </html>

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -15,9 +15,9 @@
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
 <link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
-<link rel="stylesheet" href="/static/tokens.css?v=20260502-3">
-<link rel="stylesheet" href="/static/components.css?v=20260502-3">
-<link rel="stylesheet" href="/static/fleet.css?v=20260502-3">
+<link rel="stylesheet" href="/static/tokens.css?v=20260502-4">
+<link rel="stylesheet" href="/static/components.css?v=20260502-4">
+<link rel="stylesheet" href="/static/fleet.css?v=20260502-4">
 
 </head>
 <body data-page="fleet">
@@ -162,7 +162,7 @@
   </section>
 </main>
 <script type="application/json" id="fleet-initial-state">{{FLEET_INITIAL_STATE}}</script>
-<script src="/static/fleet.js?v=20260502-3"></script>
+<script src="/static/fleet.js?v=20260502-4"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep terminal sessions out of the live Fleet Workers scope even if older state still marks them live
- collapse completed/history rows so the operator sees actual attention/live work first
- hide secondary project rail columns at medium widths to avoid clipped layouts
- bump Fleet/Dashboard static asset versions to 20260502-4

## Verification
- git diff --check
- /usr/bin/node --check internal/server/web/static/fleet.js
- /usr/local/bin/go test ./internal/server
- /usr/local/bin/go test ./...
- /usr/local/bin/go build -o /tmp/maestro ./cmd/maestro
- smoke served /fleet on :8796 and verified no-cache static assets
- visual QA: Fleet Workers showed 1 real attention/live worker and 94 historical workers collapsed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The core fix moves the terminal-status guard before the `worker.live` flag check in `isLiveWorker`, so workers with stale `live: true` state but a terminal `display_status`/`status` are correctly excluded from the live fleet scope. Accompanying changes add collapsed history rows for completed workers in the default operator view and replace horizontal scroll with column-hiding at narrower breakpoints in the project rail.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the logic change is minimal, well-scoped, and consistent with the rest of the filtering model.

The `isLiveWorker` reordering is correct: terminal statuses are checked before the `live` flag, preventing stale state from leaking into the live scope. No logic regressions were found in the rendering pipeline, the colspan value matches the actual column count, and the CSS/template changes are straightforward.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/web/static/fleet.js | Reorders `isLiveWorker` checks so terminal-state workers are excluded before the `worker.live` flag is consulted — correctly fixes the stale-live-flag bug. Also adds `historySummaryRowHTML` and `showHistoryScope` for collapsed-history UI. |
| internal/server/web/static/fleet.css | Adds styling for `.history-row` collapsed summary, constrains fleet-workers table height, and replaces fixed-width percentage columns + horizontal scroll with column-hiding at medium/small breakpoints. |
| internal/server/web/templates/fleet.html | Static asset version bumped from 20260502-3 to 20260502-4 for cache-busting; no structural changes. |
| internal/server/web/templates/dashboard.html | Static asset version bumped from 20260502-3 to 20260502-4 for cache-busting; no structural changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep completed workers out of live ..."](https://github.com/befeast/maestro/commit/5a1b0c187bd1c5edfd55afc886c9a13cb8f27e20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30565288)</sub>

<!-- /greptile_comment -->