### PR TITLE
style: tighten fleet project rail layout (#335)

### DIFF
--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -1124,7 +1124,7 @@
   }
 
   .section-head {
-    padding: 22px 26px;
+    padding: 20px 24px;
     align-items: center;
   }
 
@@ -1145,7 +1145,7 @@
   .project-rail-controls {
     grid-template-columns: minmax(260px, 420px) auto;
     gap: 16px;
-    padding: 18px 26px;
+    padding: 16px 24px;
     background: #f7fbfa;
   }
 
@@ -1170,7 +1170,7 @@
   .segment.is-active { background: #e9eef2; }
 
   .project-rail-table th {
-    padding: 18px 26px;
+    padding: 15px 18px;
     background: #f1f5f6;
     color: #7d8784;
     font-size: 13px;
@@ -1178,19 +1178,19 @@
   }
 
   .project-rail-table td {
-    padding: 24px 26px;
+    padding: 18px 18px;
     vertical-align: top;
   }
 
   .project-rail-table tbody tr:hover { background: #fbfdfd; }
 
-  .project-rail-project { width: 19%; }
-  .project-rail-state-cell { width: 17%; }
-  .project-rail-queue-cell { width: 19%; }
-  .project-rail-pr-cell { width: 11%; }
-  .project-rail-outcome-cell { width: 22%; }
+  .project-rail-project { width: 18%; }
+  .project-rail-state-cell { width: 16%; }
+  .project-rail-queue-cell { width: 18%; }
+  .project-rail-pr-cell { width: 12%; }
+  .project-rail-outcome-cell { width: 21%; }
   .project-rail-freshness-cell { width: 8%; }
-  .project-rail-links-cell { width: 4%; }
+  .project-rail-links-cell { width: 7%; min-width: 72px; }
 
   .project-rail-project-wrap {
     grid-template-columns: 22px minmax(0, 1fr);
@@ -1206,7 +1206,7 @@
   }
 
   .rail-project-name {
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 760;
   }
 
@@ -1215,13 +1215,13 @@
   .rail-note,
   .rail-warn,
   .rail-alert {
-    margin-top: 7px;
-    font-size: 13.5px;
+    margin-top: 6px;
+    font-size: 13px;
     line-height: 1.42;
   }
 
   .rail-mainline {
-    font-size: 14.5px;
+    font-size: 13.5px;
     line-height: 1.42;
   }
 
@@ -1242,6 +1242,9 @@
     min-height: 30px;
     color: #0f91a8;
     font-size: 13px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .project-row-attention { background: rgba(220, 38, 38, .038); }
@@ -1339,7 +1342,15 @@
     margin-right: 8px;
   }
 
-  @media (max-width: 1180px) {
+  @media (max-width: 1500px) {
+    .project-rail-table th,
+    .project-rail-table td { padding-inline: 14px; }
+    .project-rail-outcome-cell { width: 18%; }
+    .project-rail-freshness-cell { width: 9%; }
+    .project-rail-links-cell { width: 8%; min-width: 72px; }
+  }
+
+  @media (max-width: 1320px) {
     main { padding-inline: 20px; }
     .fleet-header { padding-inline: 22px; }
     .project-rail-controls { grid-template-columns: 1fr; justify-content: stretch; }

--- a/internal/server/web/templates/dashboard.html
+++ b/internal/server/web/templates/dashboard.html
@@ -15,9 +15,9 @@
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
 <link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
-<link rel="stylesheet" href="/static/tokens.css?v=20260502-4">
-<link rel="stylesheet" href="/static/components.css?v=20260502-4">
-<link rel="stylesheet" href="/static/dashboard.css?v=20260502-4">
+<link rel="stylesheet" href="/static/tokens.css?v=20260502-5">
+<link rel="stylesheet" href="/static/components.css?v=20260502-5">
+<link rel="stylesheet" href="/static/dashboard.css?v=20260502-5">
 
 </head>
 <body data-page="dashboard">
@@ -64,7 +64,7 @@
   </section>
 </main>
 <script>window.MAESTRO_REPO = __REPO_JSON__;</script>
-<script src="/static/dashboard.js?v=20260502-4"></script>
+<script src="/static/dashboard.js?v=20260502-5"></script>
 
 </body>
 </html>

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -15,9 +15,9 @@
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
 <link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
-<link rel="stylesheet" href="/static/tokens.css?v=20260502-4">
-<link rel="stylesheet" href="/static/components.css?v=20260502-4">
-<link rel="stylesheet" href="/static/fleet.css?v=20260502-4">
+<link rel="stylesheet" href="/static/tokens.css?v=20260502-5">
+<link rel="stylesheet" href="/static/components.css?v=20260502-5">
+<link rel="stylesheet" href="/static/fleet.css?v=20260502-5">
 
 </head>
 <body data-page="fleet">
@@ -162,7 +162,7 @@
   </section>
 </main>
 <script type="application/json" id="fleet-initial-state">{{FLEET_INITIAL_STATE}}</script>
-<script src="/static/fleet.js?v=20260502-4"></script>
+<script src="/static/fleet.js?v=20260502-5"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reduce project rail table padding and type scale so the light Fleet UI fits real browser widths
- give the Open/action column enough space on desktop instead of clipping the right edge
- collapse secondary project rail columns earlier on medium windows
- bump static asset versions to 20260502-5

## Verification
- git diff --check
- /usr/bin/node --check internal/server/web/static/fleet.js
- /usr/local/bin/go test ./internal/server
- /usr/local/bin/go test ./...
- /usr/local/bin/go build -o /tmp/maestro ./cmd/maestro
- smoke served /fleet on :8797
- Chrome headless screenshots at 1440x1100 and 980x1100: no clipped right column, medium layout collapses secondary columns

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the Fleet project rail table layout by reducing cell padding, font sizes, and column widths, then redistributes the recovered space to the Open/action column via `min-width: 72px`. It also adds a new 1500px responsive breakpoint and raises the secondary-column-collapse breakpoint from 1180px to 1320px, with asset versions bumped to `20260502-5`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure CSS layout adjustments with no logic, data, or security impact.

All changes are presentational CSS and cache-busting version strings. Column widths sum correctly, media query cascade is consistent, and no functional code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/web/static/fleet.css | CSS-only layout tightening: reduced table cell padding, font sizes, adjusted column width percentages, added min-width/overflow/ellipsis to the links cell, added a new 1500px media query breakpoint, and raised the secondary-column-collapse breakpoint from 1180px to 1320px. Column widths sum to 100%; cascade order is consistent. |
| internal/server/web/templates/dashboard.html | Static asset query-string version bumped from 20260502-4 to 20260502-5 for CSS and JS; no other changes. |
| internal/server/web/templates/fleet.html | Static asset query-string version bumped from 20260502-4 to 20260502-5 for CSS and JS; no other changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["style: tighten fleet project rail layout..."](https://github.com/befeast/maestro/commit/0e33a57bddf050a4334434d0642ed38584564138) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30565718)</sub>

<!-- /greptile_comment -->