### PR TITLE
feat: add fleet throughput sparkline (#335)

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -228,26 +228,28 @@ type fleetOperatorState struct {
 }
 
 type fleetSummary struct {
-	Projects            int `json:"projects"`
-	Stale               int `json:"stale"`
-	Errors              int `json:"errors"`
-	Active              int `json:"active"`
-	MonitoringPR        int `json:"monitoring_pr"`
-	DispatchPending     int `json:"dispatch_pending"`
-	QueueBlocked        int `json:"queue_blocked"`
-	OutcomeMissing      int `json:"outcome_missing"`
-	Running             int `json:"running"`
-	PROpen              int `json:"pr_open"`
-	Failed              int `json:"failed"`
-	Sessions            int `json:"sessions"`
-	NeedsAttention      int `json:"needs_attention"`
-	Approvals           int `json:"approvals"`
-	ApprovalsPending    int `json:"approvals_pending"`
-	ApprovalsHistorical int `json:"approvals_historical"`
-	ApprovalsStale      int `json:"approvals_stale"`
-	ApprovalsSuperseded int `json:"approvals_superseded"`
-	ApprovalsApproved   int `json:"approvals_approved"`
-	ApprovalsRejected   int `json:"approvals_rejected"`
+	Projects            int   `json:"projects"`
+	Stale               int   `json:"stale"`
+	Errors              int   `json:"errors"`
+	Active              int   `json:"active"`
+	MonitoringPR        int   `json:"monitoring_pr"`
+	DispatchPending     int   `json:"dispatch_pending"`
+	QueueBlocked        int   `json:"queue_blocked"`
+	OutcomeMissing      int   `json:"outcome_missing"`
+	Running             int   `json:"running"`
+	PROpen              int   `json:"pr_open"`
+	Failed              int   `json:"failed"`
+	Sessions            int   `json:"sessions"`
+	NeedsAttention      int   `json:"needs_attention"`
+	Approvals           int   `json:"approvals"`
+	ApprovalsPending    int   `json:"approvals_pending"`
+	ApprovalsHistorical int   `json:"approvals_historical"`
+	ApprovalsStale      int   `json:"approvals_stale"`
+	ApprovalsSuperseded int   `json:"approvals_superseded"`
+	ApprovalsApproved   int   `json:"approvals_approved"`
+	ApprovalsRejected   int   `json:"approvals_rejected"`
+	ThroughputMerged7D  int   `json:"throughput_merged_7d"`
+	ThroughputDaily7D   []int `json:"throughput_daily_7d,omitempty"`
 }
 
 type fleetProjectFreshness struct {
@@ -527,6 +529,7 @@ func (s *FleetServer) snapshot() fleetResponse {
 		Attention:   make([]fleetWorkerState, 0),
 		Approvals:   make([]fleetApprovalState, 0),
 	}
+	throughputBuckets := newFleetThroughputBuckets(now, 7)
 	for _, project := range s.projects {
 		item, workers := s.projectSnapshot(project, now)
 		resp.Projects = append(resp.Projects, item)
@@ -548,10 +551,13 @@ func (s *FleetServer) snapshot() fleetResponse {
 		resp.Summary.Failed += item.Failed
 		resp.Summary.Sessions += item.Sessions
 		resp.Summary.NeedsAttention += item.NeedsAttention
+		addFleetThroughputSummary(throughputBuckets, workers)
 		for _, approval := range item.Approvals {
 			addFleetApprovalSummary(&resp.Summary, approval.Status)
 		}
 	}
+	resp.Summary.ThroughputDaily7D = throughputBuckets.Counts()
+	resp.Summary.ThroughputMerged7D = throughputBuckets.Total()
 	sort.Slice(resp.Projects, func(i, j int) bool {
 		li := fleetOperatorStatePriority(resp.Projects[i].OperatorState.Kind)
 		ri := fleetOperatorStatePriority(resp.Projects[j].OperatorState.Kind)
@@ -1065,6 +1071,79 @@ func addFleetApprovalSummary(summary *fleetSummary, status string) {
 		summary.ApprovalsRejected++
 	default:
 		summary.ApprovalsHistorical++
+	}
+}
+
+type fleetThroughputBuckets struct {
+	days  int
+	start time.Time
+	end   time.Time
+	total int
+	items []int
+}
+
+func newFleetThroughputBuckets(now time.Time, days int) *fleetThroughputBuckets {
+	if days <= 0 {
+		days = 7
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	end := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	start := end.AddDate(0, 0, -(days - 1))
+	return &fleetThroughputBuckets{
+		days:  days,
+		start: start,
+		end:   end,
+		items: make([]int, days),
+	}
+}
+
+func (b *fleetThroughputBuckets) Add(ts time.Time) {
+	if b == nil || ts.IsZero() {
+		return
+	}
+	day := time.Date(ts.UTC().Year(), ts.UTC().Month(), ts.UTC().Day(), 0, 0, 0, 0, time.UTC)
+	if day.Before(b.start) || day.After(b.end) {
+		return
+	}
+	offset := int(day.Sub(b.start) / (24 * time.Hour))
+	if offset < 0 || offset >= len(b.items) {
+		return
+	}
+	b.items[offset]++
+	b.total++
+}
+
+func (b *fleetThroughputBuckets) Counts() []int {
+	if b == nil {
+		return nil
+	}
+	out := make([]int, len(b.items))
+	copy(out, b.items)
+	return out
+}
+
+func (b *fleetThroughputBuckets) Total() int {
+	if b == nil {
+		return 0
+	}
+	return b.total
+}
+
+func addFleetThroughputSummary(buckets *fleetThroughputBuckets, workers []fleetWorkerState) {
+	if buckets == nil {
+		return
+	}
+	for _, worker := range workers {
+		if worker.Status != string(state.StatusDone) || worker.PRNumber <= 0 || strings.TrimSpace(worker.FinishedAt) == "" {
+			continue
+		}
+		finishedAt, err := time.Parse(time.RFC3339, worker.FinishedAt)
+		if err != nil {
+			continue
+		}
+		buckets.Add(finishedAt)
 	}
 }
 

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -53,6 +53,10 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	now := time.Now().UTC()
 	firstStateDir := filepath.Join(dir, "one")
 	secondStateDir := filepath.Join(dir, "two")
+	finishedOne := now.Add(-20 * time.Hour)
+	startedDoneOne := finishedOne.Add(-2 * time.Hour)
+	finishedTwo := now.Add(-48 * time.Hour)
+	startedDoneTwo := finishedTwo.Add(-3 * time.Hour)
 	saveFleetTestState(t, firstStateDir, map[string]*state.Session{
 		"one-1": {
 			IssueNumber:     1,
@@ -65,8 +69,9 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 		"one-2": {
 			IssueNumber:     2,
 			IssueTitle:      "Review thing",
-			Status:          state.StatusPROpen,
-			StartedAt:       now.Add(-2 * time.Minute),
+			Status:          state.StatusDone,
+			StartedAt:       startedDoneOne,
+			FinishedAt:      &finishedOne,
 			PRNumber:        12,
 			TokensUsedTotal: 42000,
 		},
@@ -79,6 +84,14 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 			StartedAt:       now.Add(-3 * time.Minute),
 			PRNumber:        31,
 			CIFailureOutput: "tests failed",
+		},
+		"two-2": {
+			IssueNumber: 4,
+			IssueTitle:  "Merged thing",
+			Status:      state.StatusDone,
+			StartedAt:   startedDoneTwo,
+			FinishedAt:  &finishedTwo,
+			PRNumber:    44,
 		},
 	})
 
@@ -113,8 +126,14 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if resp.Summary.Projects != 2 || resp.Summary.Running != 1 || resp.Summary.PROpen != 1 || resp.Summary.Failed != 1 || resp.Summary.Sessions != 3 || resp.Summary.NeedsAttention != 2 {
+	if resp.Summary.Projects != 2 || resp.Summary.Running != 1 || resp.Summary.PROpen != 0 || resp.Summary.Failed != 1 || resp.Summary.Sessions != 4 || resp.Summary.NeedsAttention != 2 {
 		t.Fatalf("unexpected summary: %+v", resp.Summary)
+	}
+	if resp.Summary.ThroughputMerged7D != 2 {
+		t.Fatalf("throughput merged 7d = %d, want 2", resp.Summary.ThroughputMerged7D)
+	}
+	if len(resp.Summary.ThroughputDaily7D) != 7 {
+		t.Fatalf("throughput daily len = %d, want 7", len(resp.Summary.ThroughputDaily7D))
 	}
 	visibleAttention := 0
 	for _, worker := range resp.Workers {
@@ -137,8 +156,8 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	if !resp.Projects[0].Outcome.Configured || resp.Projects[0].Outcome.Goal != "One is deployed" || resp.Projects[0].Outcome.HealthState != outcome.HealthUnknown {
 		t.Fatalf("project outcome = %+v, want configured unknown health", resp.Projects[0].Outcome)
 	}
-	if len(resp.Workers) != 3 {
-		t.Fatalf("fleet workers len = %d, want 3", len(resp.Workers))
+	if len(resp.Workers) != 4 {
+		t.Fatalf("fleet workers len = %d, want 4", len(resp.Workers))
 	}
 	worker := findFleetWorker(t, resp.Workers, "one-2")
 	if worker.ProjectName != "One" || worker.ProjectRepo != "owner/one" {
@@ -183,6 +202,28 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	}
 	if resp.Projects[1].NeedsAttention != len(resp.Projects[1].Attention) {
 		t.Fatalf("project attention count = %d, reasons = %d", resp.Projects[1].NeedsAttention, len(resp.Projects[1].Attention))
+	}
+}
+
+func TestFleetThroughputBucketsCountRecentMergedPRs(t *testing.T) {
+	now := time.Date(2026, 5, 2, 15, 0, 0, 0, time.UTC)
+	buckets := newFleetThroughputBuckets(now, 7)
+	workers := []fleetWorkerState{
+		{Status: string(state.StatusDone), PRNumber: 10, FinishedAt: now.Add(-2 * time.Hour).Format(time.RFC3339)},
+		{Status: string(state.StatusDone), PRNumber: 11, FinishedAt: now.Add(-24 * time.Hour).Format(time.RFC3339)},
+		{Status: string(state.StatusDone), PRNumber: 12, FinishedAt: now.Add(-6 * 24 * time.Hour).Format(time.RFC3339)},
+		{Status: string(state.StatusDone), PRNumber: 13, FinishedAt: now.Add(-8 * 24 * time.Hour).Format(time.RFC3339)},
+		{Status: string(state.StatusFailed), PRNumber: 14, FinishedAt: now.Add(-time.Hour).Format(time.RFC3339)},
+		{Status: string(state.StatusDone), PRNumber: 0, FinishedAt: now.Add(-time.Hour).Format(time.RFC3339)},
+	}
+
+	addFleetThroughputSummary(buckets, workers)
+
+	if buckets.Total() != 3 {
+		t.Fatalf("total = %d, want 3", buckets.Total())
+	}
+	if got := buckets.Counts(); len(got) != 7 || got[0] != 1 || got[5] != 1 || got[6] != 1 {
+		t.Fatalf("counts = %v, want [1 0 0 0 0 1 1]", got)
 	}
 }
 

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -126,6 +126,20 @@
   .stat strong { display: block; color: var(--text); font-size: 36px; font-weight: 650; line-height: 1; font-variant-numeric: tabular-nums; }
   .stat-suffix { color: var(--muted); font-size: 16px; }
   .stat-note { display: block; margin-top: 6px; color: var(--muted); font-family: var(--font-mono); font-size: 12px; }
+  .stat-sparkline {
+    display: flex;
+    align-items: end;
+    gap: 4px;
+    height: 32px;
+    margin-top: 10px;
+  }
+  .stat-sparkline-bar {
+    flex: 1 1 0;
+    min-width: 0;
+    border-radius: 999px 999px 3px 3px;
+    background: linear-gradient(180deg, rgba(56,189,248,.9), rgba(37,99,235,.82));
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.45);
+  }
   .project-rail {
     margin-bottom: 20px;
     overflow: hidden;
@@ -1112,6 +1126,11 @@
   .stat strong { font-size: 44px; font-weight: 650; letter-spacing: 0; }
   .stat-suffix { font-size: 18px; }
   .stat-note { margin-top: 8px; font-size: 13px; }
+  .stat-sparkline {
+    height: 36px;
+    margin-top: 12px;
+    gap: 5px;
+  }
 
   .project-rail,
   .approval-inbox,

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -793,20 +793,35 @@ function renderStats(summary) {
   const monitoring = Number(summary.monitoring_pr || 0);
   const failed = Number(summary.failed || 0);
   const attention = Number(summary.needs_attention || 0);
-  const sessions = Number(summary.sessions || 0);
+  const throughputMerged = Number(summary.throughput_merged_7d || 0);
+  const throughputDaily = Array.isArray(summary.throughput_daily_7d)
+    ? summary.throughput_daily_7d.map(value => Number(value || 0))
+    : [];
   const items = [
     { label: "Running", value: running, suffix: "of " + projects, note: projects ? "worker slots" : "no projects" },
     { label: "PRs in flight", value: prOpen, suffix: "", note: monitoring + " monitored" },
     { label: "Failed", value: failed, suffix: "", note: "current fleet" },
     { label: "Attention", value: attention, suffix: "", note: attention ? "waiting" : "nothing waiting" },
-    { label: "Sessions", value: sessions, suffix: "", note: "active + recent" }
+    { label: "Issue throughput", value: throughputMerged, suffix: "", note: "merged · last 7d", sparkline: throughputDaily }
   ];
   statsEl.innerHTML = items.map(item =>
     '<div class="stat"><span class="stat-label">' + escapeText(item.label) + '</span>' +
       '<div class="stat-value"><strong>' + escapeText(item.value) + '</strong>' +
       (item.suffix ? '<span class="stat-suffix">' + escapeText(item.suffix) + '</span>' : '') + '</div>' +
+      (item.sparkline ? renderStatSparkline(item.sparkline) : '') +
       '<span class="stat-note">' + escapeText(item.note) + '</span></div>'
   ).join("");
+}
+
+function renderStatSparkline(values) {
+  const bars = Array.isArray(values) ? values.map(value => Number(value || 0)) : [];
+  if (!bars.length) return "";
+  const max = Math.max(...bars, 1);
+  const columns = bars.map((value, index) => {
+    const height = Math.max(6, Math.round((value / max) * 28));
+    return '<span class="stat-sparkline-bar" style="height:' + height + 'px" title="Day ' + String(index + 1) + ': ' + String(value) + ' merged"></span>';
+  }).join("");
+  return '<div class="stat-sparkline" aria-hidden="true">' + columns + '</div>';
 }
 
 function ensureSelectedProject() {

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -15,9 +15,9 @@
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
 <link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
-<link rel="stylesheet" href="/static/tokens.css?v=20260502-5">
-<link rel="stylesheet" href="/static/components.css?v=20260502-5">
-<link rel="stylesheet" href="/static/fleet.css?v=20260502-5">
+<link rel="stylesheet" href="/static/tokens.css?v=20260502-6">
+<link rel="stylesheet" href="/static/components.css?v=20260502-6">
+<link rel="stylesheet" href="/static/fleet.css?v=20260502-6">
 
 </head>
 <body data-page="fleet">
@@ -162,7 +162,7 @@
   </section>
 </main>
 <script type="application/json" id="fleet-initial-state">{{FLEET_INITIAL_STATE}}</script>
-<script src="/static/fleet.js?v=20260502-5"></script>
+<script src="/static/fleet.js?v=20260502-6"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the Fleet summary Sessions tile with a 7-day issue throughput tile and sparkline
- aggregate completed merged PR throughput directly in the fleet snapshot
- add coverage for 7-day throughput bucketing and fleet aggregate response
- bump Fleet static asset version to 20260502-6

## Verification
- /usr/bin/node --check internal/server/web/static/fleet.js
- /usr/local/bin/go test ./internal/server
- /usr/local/bin/go test ./...
- /usr/local/bin/go build -o /tmp/maestro ./cmd/maestro
- smoke served /fleet on :8798 and verified the throughput tile rendered with a 7-day sparkline

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the Fleet summary Sessions tile with a 7-day issue throughput sparkline tile. The `fleetThroughputBuckets` implementation uses UTC-normalized midnight arithmetic for correct DST-safe day bucketing, aggregates `StatusDone + PRNumber > 0` workers across all projects, and is well covered by both a deterministic unit test and the existing integration test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic defects found across backend bucketing, JSON serialization, or frontend rendering.

All five changed files are clean: bucket arithmetic is correct, UTC normalization avoids DST issues, the JS sparkline handles empty/zero arrays safely, and both the unit test and integration test assertions are arithmetically verified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds `fleetThroughputBuckets` struct and helpers to count StatusDone+PRNumber>0 workers per day over a 7-day UTC window; aggregates across all projects in `snapshot()`; bucketing arithmetic is correct and DST-safe. |
| internal/server/fleet_test.go | Adds unit test for bucket counting with deterministic clock and integration test assertions for the aggregated 7-day throughput fields; test expectations are arithmetically verified correct. |
| internal/server/web/static/fleet.js | Replaces sessions stat tile with throughput tile; adds `renderStatSparkline` helper that safely handles empty arrays and scales bar heights with a 6px minimum; no XSS risk as values are numbers and labels use `escapeText`. |
| internal/server/web/static/fleet.css | Adds `.stat-sparkline` and `.stat-sparkline-bar` classes with a responsive media-query override; purely additive, no regressions. |
| internal/server/web/templates/fleet.html | Bumps static asset cache-buster version from `20260502-5` to `20260502-6` for CSS and JS; no structural changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add fleet throughput sparkline (#3..."](https://github.com/befeast/maestro/commit/94d6deb73ae63a5e7e4a4d12b459be4ee61b9284) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30566379)</sub>

<!-- /greptile_comment -->