### PR TITLE
fix: dispatch supervisor-selected issue without waiting a full cycle (#354)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2349,6 +2349,35 @@ func (o *Orchestrator) applySupervisorOwnedReadyFilter(s *state.State, issues []
 	return filtered
 }
 
+func containsIssueNumber(issues []github.Issue, number int) bool {
+	for _, issue := range issues {
+		if issue.Number == number {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *Orchestrator) augmentWithSupervisorSelectedIssue(s *state.State, issues []github.Issue) []github.Issue {
+	if !o.supervisorOwnsDynamicReadyLabel() {
+		return issues
+	}
+
+	selected, ok := o.supervisorOwnedReadySelectedIssue(s)
+	if !ok || selected <= 0 || containsIssueNumber(issues, selected) {
+		return issues
+	}
+
+	issue, err := o.getIssue(selected)
+	if err != nil {
+		log.Printf("[orch] supervisor-selected candidate #%d could not be fetched for immediate dispatch: %v", selected, err)
+		return issues
+	}
+
+	log.Printf("[orch] fetched supervisor-selected candidate #%d directly for immediate dispatch", selected)
+	return append(issues, issue)
+}
+
 func sortedStateSessionNames(s *state.State) []string {
 	names := make([]string, 0, len(s.Sessions))
 	for name := range s.Sessions {
@@ -2364,6 +2393,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		log.Printf("[orch] list issues: %v", err)
 		return
 	}
+	issues = o.augmentWithSupervisorSelectedIssue(s, issues)
 	if filtered, ordered := o.applyOrderedQueueFilter(s, issues); ordered {
 		issues = filtered
 	} else {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2712,6 +2712,14 @@ func newStartWorkersOrchestrator(cfg *config.Config, issues []github.Issue) (*Or
 		isIssueClosedFn: func(issueNumber int) (bool, error) {
 			return false, nil
 		},
+		getIssueFn: func(number int) (github.Issue, error) {
+			for _, issue := range issues {
+				if issue.Number == number {
+					return issue, nil
+				}
+			}
+			return github.Issue{}, fmt.Errorf("issue #%d not found", number)
+		},
 		addIssueLabelFn: func(number int, label string) error {
 			labels = append(labels, fmt.Sprintf("#%d:%s", number, label))
 			return nil
@@ -2799,6 +2807,62 @@ func TestStartNewWorkers_SupervisorOwnedReadyLabelStartsOnlySelectedCandidate(t 
 	}
 	if !strings.Contains(logs.String(), "skipping issue #292: not supervisor-selected candidate #287") {
 		t.Fatalf("logs = %q, want skip reason for stale ready issue", logs.String())
+	}
+}
+
+func TestStartNewWorkers_SupervisorOwnedReadyLabelFetchesSelectedCandidateOutsideReadyListing(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.IssueLabels = []string{"maestro-ready"}
+	dynamicWaveEnabled := true
+	cfg.Supervisor.DynamicWave.Enabled = &dynamicWaveEnabled
+	cfg.Supervisor.DynamicWave.OwnsReadyLabel = true
+
+	listedIssues := []github.Issue{
+		makeIssue(292, "stale ready", "maestro-ready", "p0"),
+		makeIssue(291, "also stale", "maestro-ready", "p2"),
+	}
+	selectedIssue := makeIssue(287, "selected candidate not yet relisted", "p1")
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, listedIssues)
+	o.getIssueFn = func(number int) (github.Issue, error) {
+		if number == 287 {
+			return selectedIssue, nil
+		}
+		for _, issue := range listedIssues {
+			if issue.Number == number {
+				return issue, nil
+			}
+		}
+		return github.Issue{}, fmt.Errorf("issue #%d not found", number)
+	}
+
+	s := state.NewState()
+	s.RecordSupervisorDecision(state.SupervisorDecision{
+		CreatedAt:  time.Now().UTC(),
+		PolicyRule: supervisor.PolicyRuleDynamicWave,
+		QueueAnalysis: &state.SupervisorQueueAnalysis{
+			PolicyRule: supervisor.PolicyRuleDynamicWave,
+			SelectedCandidate: &state.SupervisorIssueCandidate{
+				Number: 287,
+			},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+
+	var logs strings.Builder
+	previousLogOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(previousLogOutput)
+
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 {
+		t.Fatalf("started = %v, want only fetched selected issue #287", *started)
+	}
+	if (*started)[0] != 287 {
+		t.Fatalf("started issue #%d, want #287", (*started)[0])
+	}
+	if !strings.Contains(logs.String(), "fetched supervisor-selected candidate #287 directly for immediate dispatch") {
+		t.Fatalf("logs = %q, want direct-fetch dispatch log", logs.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- fetch the supervisor-selected dynamic-wave candidate directly when issue label intake has not relisted it yet
- let the worker loop dispatch the selected issue in the same run cycle instead of waiting for another full poll
- add regression coverage for the ready-label relist race

## Verification
- /usr/local/bin/go test ./internal/orchestrator
- /usr/local/bin/go test ./...
- /usr/local/bin/go build -o /tmp/maestro ./cmd/maestro

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition where a supervisor-selected dynamic-wave candidate could not be dispatched in the same poll cycle because the ready label hadn't been relisted yet. It does so by fetching the selected issue directly and injecting it into the issues slice before the filter pipeline runs, and adds a regression test that exercises this exact scenario.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic defects found.

The augmentation is guarded by supervisorOwnsDynamicReadyLabel and only fires when the selected issue is absent from the listing; it feeds correctly into applySupervisorOwnedReadyFilter (which already filters to that exact number) and is a no-op in the ordered-queue path since applyOrderedQueueFilter only matches explicitly configured issue numbers. The change is minimal, isolated, and covered by a purpose-built regression test.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds augmentWithSupervisorSelectedIssue to fetch and inject the supervisor-selected issue before filters run, fixing the race where the ready-label hasn't been relisted yet; logic is sound and correctly integrates with both applySupervisorOwnedReadyFilter and applyOrderedQueueFilter. |
| internal/orchestrator/orchestrator_test.go | Adds getIssueFn to the shared test constructor (preventing nil-dereference in new cases) and a well-structured regression test covering the relist-race scenario; assertions cover started issue identity and log output. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: dispatch supervisor-selected issue ..."](https://github.com/befeast/maestro/commit/e54f2037349d2d52a896bda8a608314659709158) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30571304)</sub>

<!-- /greptile_comment -->