### PR TITLE
fix: stop worker prompts from auto-closing issues (#351)

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -828,7 +828,7 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 3. Write tests if applicable.
 4. Commit your changes with a clear message.
 5. Before committing or opening a PR, check for accidental secrets and generated artifacts. Do NOT commit or mention API keys, bearer tokens, oauth tokens, bot tokens, env values, raw config dumps, or diagnostic logs. Do NOT commit temp/debug artifacts such as tmp/, _tmp/, *.log, *.logs, *.test, or *.test.json unless the issue explicitly requires them.
-6. Keep the PR body minimal and safe. Use: gh pr create --repo %s --title "%s" --body "Closes #%d". Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.
+6. Keep the PR body minimal and safe. Use: gh pr create --repo %s --title "%s" --body "Refs #%d". Never use closing keywords such as Closes/Fixes/Resolves in PR bodies for Maestro-managed work. Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.
 7. After creating the PR, you are done. Do NOT merge it yourself.
 
 Important: Always run cargo fmt --all before committing if this is a Rust project.

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -24,7 +24,8 @@ func TestAssemblePromptIncludesSecretSafetyGuardrails(t *testing.T) {
 		"Do NOT commit or mention API keys",
 		"Do NOT commit temp/debug artifacts such as tmp/, _tmp/, *.log, *.logs, *.test, or *.test.json",
 		"Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.",
-		`gh pr create --repo BeFeast/ok-gobot --title "security hardening" --body "Closes #157"`,
+		"Never use closing keywords such as Closes/Fixes/Resolves in PR bodies for Maestro-managed work.",
+		`gh pr create --repo BeFeast/ok-gobot --title "security hardening" --body "Refs #157"`,
 	}
 	for _, want := range required {
 		if !strings.Contains(prompt, want) {

--- a/worker-prompt-go.md
+++ b/worker-prompt-go.md
@@ -51,7 +51,7 @@ Binary must build successfully before creating PR.
 gh pr create \
   --repo {{REPO}} \
   --title "feat: <short description> (#{{ISSUE_NUMBER}})" \
-  --body "Implements #{{ISSUE_NUMBER}}
+  --body "Refs #{{ISSUE_NUMBER}}
 
 ## Changes
 <describe what changed and why>
@@ -64,6 +64,8 @@ gh pr create \
 
 ### 6. After PR is created — STOP
 Do not wait for CI. Do not merge. Just stop.
+
+Never use closing keywords such as `Closes`, `Fixes`, or `Resolves` in PR bodies for Maestro-managed work.
 
 ---
 

--- a/worker-prompt-template.md
+++ b/worker-prompt-template.md
@@ -59,7 +59,7 @@ git rebase origin/main        # IMMEDIATELY before create, not just at session s
 cargo fmt --all               # in server/ directory
 cargo check -p panoptikon-server 2>&1 | grep "^error" | head -5
 git push --force-with-lease origin {{BRANCH}}
-gh pr create --repo {{REPO}} --title "feat: {{ISSUE_TITLE}} (#{{ISSUE_NUMBER}})" --body "Closes #{{ISSUE_NUMBER}}"
+gh pr create --repo {{REPO}} --title "feat: {{ISSUE_TITLE}} (#{{ISSUE_NUMBER}})" --body "Refs #{{ISSUE_NUMBER}}"
 ```
 
 ### 3. Code quality
@@ -86,6 +86,7 @@ When rebasing conflicts in these files: **keep BOTH sides**. Your additions + wh
 ### 6. When stuck
 - If a dependency is missing → check if there's an open issue for it, comment on yours that it's blocked
 - If the issue is ambiguous → make a reasonable interpretation and document it in the PR body
+- Never use closing keywords such as `Closes`, `Fixes`, or `Resolves` in PR bodies for Maestro-managed work
 - If CI fails → fix it before anything else, don't leave broken builds
 
 ### 7. Done means done


### PR DESCRIPTION
## Summary
- replace closing PR body examples in built-in worker prompts with non-closing references
- explicitly forbid Closes/Fixes/Resolves in Maestro-managed worker prompts
- add regression coverage so closing keywords do not creep back into the default prompt path

## Verification
- /usr/local/bin/go test ./internal/worker ./internal/orchestrator
- /usr/local/bin/go test ./...
- /usr/local/bin/go build -o /tmp/maestro ./cmd/maestro

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents Maestro worker agents from inadvertently auto-closing GitHub issues by replacing `Closes`/`Implements` keywords with `Refs` in all built-in prompt templates and adding an explicit prohibition. Regression coverage is added to `TestAssemblePromptIncludesSecretSafetyGuardrails` to lock in both the new example command and the prohibition string.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are narrowly scoped text replacements with matching test coverage.

No logic errors found. The new string literals in worker.go match the test assertions exactly, and the markdown templates are updated consistently. No behavioral regressions are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/worker.go | Replaces `Closes #%d` with `Refs #%d` in the built-in prompt template and appends a prohibition against closing keywords; straightforward and correct. |
| internal/worker/worker_prompt_test.go | Updates `TestAssemblePromptIncludesSecretSafetyGuardrails` to assert the new `Refs #157` example and the closing-keyword prohibition string; both strings match worker.go exactly. |
| worker-prompt-go.md | Switches the PR-body example from `Implements #{{ISSUE_NUMBER}}` to `Refs #{{ISSUE_NUMBER}}` and appends a closing-keyword prohibition after the "After PR is created" step. |
| worker-prompt-template.md | Replaces `Closes #{{ISSUE_NUMBER}}` with `Refs #{{ISSUE_NUMBER}}` in the `gh pr create` example and adds a closing-keyword prohibition under "When stuck". |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop worker prompts from auto-closi..."](https://github.com/befeast/maestro/commit/9af079cb95c17e1f32c2fcfd69ce22b49400650d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30571546)</sub>

<!-- /greptile_comment -->