### PR TITLE
fix: keep merged sessions open for verification (#351)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1134,21 +1134,12 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 	for slotName, sess := range s.Sessions {
 		switch sess.Status {
-		case state.StatusDone, state.StatusDead, state.StatusConflictFailed, state.StatusFailed, state.StatusRetryExhausted:
+		case state.StatusDone, state.StatusCodeLanded, state.StatusDead, state.StatusConflictFailed, state.StatusFailed, state.StatusRetryExhausted:
 			// Zombie cleanup: if the underlying issue is closed, transition to done.
 			// This prevents conflict_failed/failed/dead/retry_exhausted sessions from lingering
 			// indefinitely when their issues are closed externally (#187).
 			if sess.Status != state.StatusDone {
 				done := false
-				if sess.PRNumber > 0 {
-					merged, err := o.isPRMerged(sess.PRNumber)
-					if err != nil {
-						log.Printf("[orch] check PR #%d merged: %v", sess.PRNumber, err)
-					} else if merged {
-						log.Printf("[orch] PR #%d merged, transitioning zombie session %s from %s to done", sess.PRNumber, slotName, sess.Status)
-						done = true
-					}
-				}
 				closed, err := o.isIssueClosed(sess.IssueNumber)
 				if err != nil {
 					log.Printf("[orch] check issue #%d: %v", sess.IssueNumber, err)
@@ -1162,6 +1153,14 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					if sess.FinishedAt == nil {
 						now := time.Now().UTC()
 						sess.FinishedAt = &now
+					}
+				} else if sess.Status != state.StatusCodeLanded && sess.PRNumber > 0 {
+					merged, err := o.isPRMerged(sess.PRNumber)
+					if err != nil {
+						log.Printf("[orch] check PR #%d merged: %v", sess.PRNumber, err)
+					} else if merged {
+						log.Printf("[orch] PR #%d merged, transitioning zombie session %s from %s to code_landed", sess.PRNumber, slotName, sess.Status)
+						o.markCodeLanded(sess, sess.PRNumber)
 					}
 				}
 			}
@@ -1845,6 +1844,16 @@ func (o *Orchestrator) mergeInterval() time.Duration {
 	return time.Duration(seconds) * time.Second
 }
 
+func (o *Orchestrator) markCodeLanded(sess *state.Session, prNumber int) {
+	if prNumber > 0 {
+		sess.PRNumber = prNumber
+	}
+	o.syncProject(sess.IssueNumber, github.ProjectStatusInProgress)
+	sess.Status = state.StatusCodeLanded
+	now := time.Now().UTC()
+	sess.FinishedAt = &now
+}
+
 func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr github.PR) bool {
 	log.Printf("[orch] merging PR #%d (branch %s)", pr.Number, sess.Branch)
 	if err := o.mergePR(pr.Number); err != nil {
@@ -1871,13 +1880,7 @@ func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr git
 	}
 
 	log.Printf("[orch] merged PR #%d ✓", pr.Number)
-	o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
-	if err := o.closeIssue(sess.IssueNumber, fmt.Sprintf("Implemented by PR #%d (auto-merged by maestro).", pr.Number)); err != nil {
-		log.Printf("[orch] warning: failed to close issue #%d: %v", sess.IssueNumber, err)
-	}
-	sess.Status = state.StatusDone
-	now := time.Now().UTC()
-	sess.FinishedAt = &now
+	o.markCodeLanded(sess, pr.Number)
 
 	if o.cfg.ShouldCleanupWorktrees() {
 		log.Printf("[orch] cleaning up worktree for %s after merge", slotName)
@@ -1887,7 +1890,7 @@ func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr git
 		log.Printf("[orch] skipping worktree cleanup for %s (cleanup_worktrees_on_merge=false)", slotName)
 	}
 
-	o.notifier.Sendf("✅ maestro: merged PR #%d for issue #%d (%s)", pr.Number, sess.IssueNumber, sess.IssueTitle)
+	o.notifier.Sendf("✅ maestro: merged PR #%d for issue #%d (%s); issue remains open for runtime verification", pr.Number, sess.IssueNumber, sess.IssueTitle)
 
 	// Auto version bump
 	if o.cfg.Versioning.Enabled {
@@ -2190,7 +2193,7 @@ func (o *Orchestrator) orderedQueueIssueDone(s *state.State, issueNumber int) (b
 
 	for _, slotName := range sortedStateSessionNames(s) {
 		sess := s.Sessions[slotName]
-		if sess == nil || sess.IssueNumber != issueNumber || sess.Status != state.StatusDone || sess.PRNumber <= 0 {
+		if sess == nil || sess.IssueNumber != issueNumber || (sess.Status != state.StatusDone && sess.Status != state.StatusCodeLanded) || sess.PRNumber <= 0 {
 			continue
 		}
 		merged, err := o.isPRMerged(sess.PRNumber)
@@ -2198,7 +2201,7 @@ func (o *Orchestrator) orderedQueueIssueDone(s *state.State, issueNumber int) (b
 			return false, "", fmt.Errorf("check PR #%d merged: %w", sess.PRNumber, err)
 		}
 		if merged {
-			return true, fmt.Sprintf("session %s is done with merged PR #%d", slotName, sess.PRNumber), nil
+			return true, fmt.Sprintf("session %s is %s with merged PR #%d", slotName, sess.Status, sess.PRNumber), nil
 		}
 	}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -763,10 +763,10 @@ func TestAutoMergePRs_ParallelUpdatesState(t *testing.T) {
 	before := time.Now()
 	o.autoMergePRs(s)
 
-	// All sessions should be marked done
+	// All sessions should be marked code_landed
 	for slotName, sess := range s.Sessions {
-		if sess.Status != state.StatusDone {
-			t.Errorf("session %s status = %q, want %q", slotName, sess.Status, state.StatusDone)
+		if sess.Status != state.StatusCodeLanded {
+			t.Errorf("session %s status = %q, want %q", slotName, sess.Status, state.StatusCodeLanded)
 		}
 		if sess.FinishedAt == nil {
 			t.Errorf("session %s has nil FinishedAt", slotName)
@@ -871,19 +871,19 @@ func TestAutoMergePRs_ParallelPartialFailure(t *testing.T) {
 		t.Errorf("merged = %v, want [10, 30]", merged)
 	}
 
-	// Verify state: sessions for PR 10 and 30 should be done, PR 20 should still be pr_open
-	doneCount := 0
+	// Verify state: sessions for PR 10 and 30 should be code_landed, PR 20 should still be pr_open
+	codeLandedCount := 0
 	openCount := 0
 	for _, sess := range s.Sessions {
-		if sess.Status == state.StatusDone {
-			doneCount++
+		if sess.Status == state.StatusCodeLanded {
+			codeLandedCount++
 		}
 		if sess.Status == state.StatusPROpen {
 			openCount++
 		}
 	}
-	if doneCount != 2 {
-		t.Errorf("expected 2 done sessions, got %d", doneCount)
+	if codeLandedCount != 2 {
+		t.Errorf("expected 2 code_landed sessions, got %d", codeLandedCount)
 	}
 	if openCount != 1 {
 		t.Errorf("expected 1 still-open session, got %d", openCount)
@@ -892,7 +892,7 @@ func TestAutoMergePRs_ParallelPartialFailure(t *testing.T) {
 
 func TestAutoMergePRs_ParallelStateConsistency(t *testing.T) {
 	// Verify that after parallel merges, the state is consistent:
-	// - All merged sessions are StatusDone with FinishedAt set
+	// - All merged sessions are StatusCodeLanded with FinishedAt set
 	// - LastMergeAt is recent
 	// - No session is in an inconsistent intermediate state
 	prs := []github.PR{
@@ -914,8 +914,8 @@ func TestAutoMergePRs_ParallelStateConsistency(t *testing.T) {
 	}
 
 	for slotName, sess := range s.Sessions {
-		if sess.Status != state.StatusDone {
-			t.Errorf("session %s: status = %q, want %q", slotName, sess.Status, state.StatusDone)
+		if sess.Status != state.StatusCodeLanded {
+			t.Errorf("session %s: status = %q, want %q", slotName, sess.Status, state.StatusCodeLanded)
 		}
 		if sess.FinishedAt == nil {
 			t.Errorf("session %s: FinishedAt is nil", slotName)
@@ -1319,8 +1319,8 @@ func TestAutoMergePRs_RetryExhaustedGreenPRNoFeedbackMerges(t *testing.T) {
 		t.Fatalf("merged = %v, want [10]", merged)
 	}
 	sess := s.Sessions["slot-0"]
-	if sess.Status != state.StatusDone {
-		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusCodeLanded)
 	}
 }
 
@@ -2433,8 +2433,8 @@ func TestMergeReadyPR_CleansUpWorktreeOnMerge(t *testing.T) {
 	if sess.Worktree != "" {
 		t.Errorf("Worktree = %q, want empty (should be cleared after cleanup)", sess.Worktree)
 	}
-	if sess.Status != state.StatusDone {
-		t.Errorf("Status = %q, want %q", sess.Status, state.StatusDone)
+	if sess.Status != state.StatusCodeLanded {
+		t.Errorf("Status = %q, want %q", sess.Status, state.StatusCodeLanded)
 	}
 }
 
@@ -2480,8 +2480,8 @@ func TestMergeReadyPR_SkipsCleanupWhenDisabled(t *testing.T) {
 	if sess.Worktree != "/tmp/wt" {
 		t.Errorf("Worktree = %q, want %q (should be preserved)", sess.Worktree, "/tmp/wt")
 	}
-	if sess.Status != state.StatusDone {
-		t.Errorf("Status = %q, want %q", sess.Status, state.StatusDone)
+	if sess.Status != state.StatusCodeLanded {
+		t.Errorf("Status = %q, want %q", sess.Status, state.StatusCodeLanded)
 	}
 }
 
@@ -3380,7 +3380,7 @@ func TestCheckSessions_RetryExhaustedClosedIssue_TransitionsToDone(t *testing.T)
 	}
 }
 
-func TestCheckSessions_RetryExhaustedMergedPR_TransitionsToDone(t *testing.T) {
+func TestCheckSessions_RetryExhaustedMergedPR_TransitionsToCodeLanded(t *testing.T) {
 	now := time.Now().UTC()
 	o := &Orchestrator{
 		cfg:      &config.Config{Repo: "owner/repo", MaxRuntimeMinutes: 120},
@@ -3412,8 +3412,8 @@ func TestCheckSessions_RetryExhaustedMergedPR_TransitionsToDone(t *testing.T) {
 	o.checkSessions(s)
 
 	sess := s.Sessions["pan-13"]
-	if sess.Status != state.StatusDone {
-		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusCodeLanded)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -22,6 +22,7 @@ const (
 	StatusQueued         SessionStatus = "queued"
 	StatusRunning        SessionStatus = "running"
 	StatusPROpen         SessionStatus = "pr_open"
+	StatusCodeLanded     SessionStatus = "code_landed"
 	StatusDone           SessionStatus = "done"
 	StatusFailed         SessionStatus = "failed"
 	StatusConflictFailed SessionStatus = "conflict_failed"
@@ -137,6 +138,19 @@ func SessionAttentionForAt(sess *Session, alive *bool, now time.Time) SessionAtt
 		return SessionAttention{
 			Reason:         "Session is waiting on an open PR, but no PR number is recorded yet.",
 			NextAction:     "Reconcile the session with the GitHub PR before dispatching duplicate work.",
+			NeedsAttention: true,
+		}
+	case StatusCodeLanded:
+		if sess.PRNumber > 0 {
+			return SessionAttention{
+				Reason:         fmt.Sprintf("PR #%d has merged; code landed, but runtime/deployment verification is still required before the issue can be closed.", sess.PRNumber),
+				NextAction:     "Run the required verification or deployment checks, then close the issue only after the outcome is confirmed.",
+				NeedsAttention: true,
+			}
+		}
+		return SessionAttention{
+			Reason:         "Code landed, but runtime/deployment verification is still required before the issue can be closed.",
+			NextAction:     "Run the required verification or deployment checks, then close the issue only after the outcome is confirmed.",
 			NeedsAttention: true,
 		}
 	case StatusQueued:
@@ -1521,7 +1535,7 @@ func (s *State) DonePRCount() int {
 	}
 	count := 0
 	for _, sess := range s.Sessions {
-		if sess != nil && sess.Status == StatusDone && sess.PRNumber > 0 {
+		if sess != nil && (sess.Status == StatusDone || sess.Status == StatusCodeLanded) && sess.PRNumber > 0 {
 			count++
 		}
 	}
@@ -1536,7 +1550,7 @@ func (s *State) IssueInProgress(issueNum int) bool {
 		if sess.IssueNumber != issueNum {
 			continue
 		}
-		if sess.Status == StatusRunning || sess.Status == StatusPROpen || sess.Status == StatusQueued {
+		if sess.Status == StatusRunning || sess.Status == StatusPROpen || sess.Status == StatusQueued || sess.Status == StatusCodeLanded {
 			return true
 		}
 		// Dead session with pending retry — still in progress
@@ -1618,18 +1632,20 @@ func StatusPriority(status SessionStatus) int {
 		return 1
 	case StatusQueued:
 		return 2
-	case StatusDead:
+	case StatusCodeLanded:
 		return 3
-	case StatusFailed:
+	case StatusDead:
 		return 4
-	case StatusConflictFailed:
+	case StatusFailed:
 		return 5
-	case StatusRetryExhausted:
+	case StatusConflictFailed:
 		return 6
-	case StatusDone:
+	case StatusRetryExhausted:
 		return 7
-	default:
+	case StatusDone:
 		return 8
+	default:
+		return 9
 	}
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -64,11 +64,12 @@ func TestDonePRCount(t *testing.T) {
 	s := NewState()
 	s.Sessions["merged-1"] = &Session{IssueNumber: 1, Status: StatusDone, PRNumber: 10}
 	s.Sessions["merged-2"] = &Session{IssueNumber: 2, Status: StatusDone, PRNumber: 11}
+	s.Sessions["code-landed"] = &Session{IssueNumber: 5, Status: StatusCodeLanded, PRNumber: 13}
 	s.Sessions["closed-issue"] = &Session{IssueNumber: 3, Status: StatusDone}
 	s.Sessions["open-pr"] = &Session{IssueNumber: 4, Status: StatusPROpen, PRNumber: 12}
 
-	if got := s.DonePRCount(); got != 2 {
-		t.Fatalf("DonePRCount = %d, want 2", got)
+	if got := s.DonePRCount(); got != 3 {
+		t.Fatalf("DonePRCount = %d, want 3", got)
 	}
 }
 
@@ -532,6 +533,15 @@ func TestIssueInProgress_QueuedCountsAsInProgress(t *testing.T) {
 	}
 }
 
+func TestIssueInProgress_CodeLandedCountsAsInProgress(t *testing.T) {
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{IssueNumber: 101, Status: StatusCodeLanded, PRNumber: 12}
+
+	if !s.IssueInProgress(101) {
+		t.Error("IssueInProgress should return true for code_landed session")
+	}
+}
+
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }
@@ -553,6 +563,7 @@ func TestIsTerminal(t *testing.T) {
 		{StatusQueued, false},
 		{StatusRunning, false},
 		{StatusPROpen, false},
+		{StatusCodeLanded, false},
 		{StatusDone, true},
 		{StatusFailed, true},
 		{StatusConflictFailed, true},
@@ -639,6 +650,12 @@ func TestPruneOldSessions(t *testing.T) {
 		StartedAt:   recent.Add(-time.Hour),
 		FinishedAt:  &recent,
 	}
+	s.Sessions["old-code-landed"] = &Session{
+		IssueNumber: 4,
+		Status:      StatusCodeLanded,
+		StartedAt:   old.Add(-time.Hour),
+		FinishedAt:  &old,
+	}
 	s.Sessions["running"] = &Session{
 		IssueNumber: 3,
 		Status:      StatusRunning,
@@ -656,6 +673,9 @@ func TestPruneOldSessions(t *testing.T) {
 	}
 	if _, ok := s.Sessions["recent-done"]; !ok {
 		t.Error("recent-done should still exist")
+	}
+	if _, ok := s.Sessions["old-code-landed"]; !ok {
+		t.Error("old-code-landed should still exist (not terminal)")
 	}
 	if _, ok := s.Sessions["running"]; !ok {
 		t.Error("running should still exist (not terminal)")
@@ -1036,10 +1056,11 @@ func TestLiveSessionsAt(t *testing.T) {
 	s.Sessions["running"] = &Session{Status: StatusRunning, StartedAt: old}
 	s.Sessions["recent-done"] = &Session{Status: StatusDone, StartedAt: old, FinishedAt: &recent}
 	s.Sessions["old-done"] = &Session{Status: StatusDone, StartedAt: old, FinishedAt: &old}
+	s.Sessions["recent-code-landed"] = &Session{Status: StatusCodeLanded, StartedAt: old, FinishedAt: &recent}
 
 	live := s.LiveSessionsAt(now)
-	if len(live) != 2 {
-		t.Fatalf("LiveSessionsAt len = %d, want 2", len(live))
+	if len(live) != 3 {
+		t.Fatalf("LiveSessionsAt len = %d, want 3", len(live))
 	}
 }
 
@@ -1049,8 +1070,9 @@ func TestCountByStatus(t *testing.T) {
 	s.Sessions["slot-2"] = &Session{IssueNumber: 2, Status: StatusRunning}
 	s.Sessions["slot-3"] = &Session{IssueNumber: 3, Status: StatusPROpen}
 	s.Sessions["slot-4"] = &Session{IssueNumber: 4, Status: StatusQueued}
-	s.Sessions["slot-5"] = &Session{IssueNumber: 5, Status: StatusDone}   // terminal — excluded
-	s.Sessions["slot-6"] = &Session{IssueNumber: 6, Status: StatusFailed} // terminal — excluded
+	s.Sessions["slot-5"] = &Session{IssueNumber: 5, Status: StatusDone}       // terminal — excluded
+	s.Sessions["slot-6"] = &Session{IssueNumber: 6, Status: StatusFailed}     // terminal — excluded
+	s.Sessions["slot-7"] = &Session{IssueNumber: 7, Status: StatusCodeLanded} // non-terminal — included
 
 	counts := s.CountByStatus()
 
@@ -1062,6 +1084,9 @@ func TestCountByStatus(t *testing.T) {
 	}
 	if counts[StatusQueued] != 1 {
 		t.Errorf("queued = %d, want 1", counts[StatusQueued])
+	}
+	if counts[StatusCodeLanded] != 1 {
+		t.Errorf("code_landed = %d, want 1", counts[StatusCodeLanded])
 	}
 	if counts[StatusDone] != 0 {
 		t.Errorf("done = %d, want 0 (terminal states excluded)", counts[StatusDone])
@@ -1079,6 +1104,10 @@ func TestStatusPriority(t *testing.T) {
 	// pr_open before queued
 	if StatusPriority(StatusPROpen) >= StatusPriority(StatusQueued) {
 		t.Error("pr_open should have lower priority value than queued")
+	}
+	// queued before code_landed
+	if StatusPriority(StatusQueued) >= StatusPriority(StatusCodeLanded) {
+		t.Error("queued should have lower priority value than code_landed")
 	}
 	// queued before terminal states
 	for _, terminal := range []SessionStatus{

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1183,7 +1183,7 @@ func (e *Engine) orderedQueueIssueDone(st *state.State, issueNumber int) (bool, 
 
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
-		if sess == nil || sess.IssueNumber != issueNumber || sess.Status != state.StatusDone || sess.PRNumber <= 0 {
+		if sess == nil || sess.IssueNumber != issueNumber || (sess.Status != state.StatusDone && sess.Status != state.StatusCodeLanded) || sess.PRNumber <= 0 {
 			continue
 		}
 		merged, err := e.reader.IsPRMerged(sess.PRNumber)
@@ -1191,7 +1191,7 @@ func (e *Engine) orderedQueueIssueDone(st *state.State, issueNumber int) (bool, 
 			return false, "", fmt.Errorf("check PR #%d merged: %w", sess.PRNumber, err)
 		}
 		if merged {
-			return true, fmt.Sprintf("session %s is done with merged PR #%d", slot, sess.PRNumber), nil
+			return true, fmt.Sprintf("session %s is %s with merged PR #%d", slot, sess.Status, sess.PRNumber), nil
 		}
 	}
 

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1602,6 +1602,33 @@ func TestDecide_OrderedQueueAdvancesAfterDoneSessionWithMergedPR(t *testing.T) {
 	}
 }
 
+func TestDecide_OrderedQueueAdvancesAfterCodeLandedSessionWithMergedPR(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.OrderedQueue = config.SupervisorOrderedQueueConfig{
+		Enabled: true,
+		Issues:  []int{308, 306},
+	}
+	reader := &fakeReader{
+		issues:    []github.Issue{testIssue(306, "next", "maestro-ready")},
+		mergedPRs: map[int]bool{77: true},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{IssueNumber: 308, Status: state.StatusCodeLanded, PRNumber: 77}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Target == nil || decision.Target.Issue != 306 {
+		t.Fatalf("target = %#v, want issue 306", decision.Target)
+	}
+}
+
 func TestDecide_OrderedQueueAdvancesAfterPolicyOverride(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}


### PR DESCRIPTION
Implements the remaining lifecycle half of #351.

## What changed
- add a non-terminal `code_landed` session status for merged PRs that still need runtime/outcome verification
- transition merged sessions into `code_landed` instead of auto-closing the issue
- keep ordered queue and supervisor progression aware of merged `code_landed` sessions
- keep `code_landed` sessions out of terminal pruning while still counting them in throughput

## Verification
- `go test ./internal/state ./internal/orchestrator ./internal/supervisor`
- `go test ./...`
- `go build -o /tmp/maestro ./cmd/maestro`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `StatusCodeLanded` as a new non-terminal session status for merged PRs that still need runtime/deployment verification before the issue can be closed. Instead of auto-closing the issue on merge, the orchestrator now calls `markCodeLanded`, keeping the issue open and the project board in "InProgress" until an operator manually closes it.

The lifecycle is well-integrated: `code_landed` sessions are correctly excluded from `ActiveSessions()` (so they don't consume worker slots), excluded from `IsTerminal()` / `PruneOldSessions`, included in `IssueInProgress` (preventing re-spawn for the same issue), and recognised by `orderedQueueIssueDone` so the ordered queue can still advance past them.

<h3>Confidence Score: 4/5</h3>

Safe to merge — no logic bugs found; all lifecycle paths for `code_landed` are consistently handled across state, orchestrator, and supervisor.

The implementation is correct: `code_landed` is correctly excluded from `ActiveSessions` and `IsTerminal`, preventing slot starvation and premature pruning. `IssueInProgress` blocks re-spawn, and `orderedQueueIssueDone` lets the queue advance. The only finding is a stale inline comment (P2).

No files require special attention beyond the stale comment in `internal/orchestrator/orchestrator.go`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Replaces auto-close-on-merge with `markCodeLanded`; correctly guards zombie re-processing with `sess.Status != state.StatusCodeLanded`; `code_landed` added to `checkSessions` switch alongside terminal states — stale comment says "Terminal states" but the logic itself is sound. |
| internal/state/state.go | Adds `StatusCodeLanded` constant and integrates it into `IssueInProgress`, `DonePRCount`, `StatusPriority`, `SessionAttentionForAt`, and `IsTerminal`/`PruneOldSessions` — all handled correctly; `code_landed` is non-terminal and triggers attention. |
| internal/supervisor/supervisor.go | Mirrors the orchestrator change: `orderedQueueIssueDone` now accepts `code_landed` in addition to `done` when checking for merged PRs. |
| internal/orchestrator/orchestrator_test.go | All merge-related test assertions updated from `StatusDone` to `StatusCodeLanded`; new test covers zombie `retry_exhausted → code_landed` transition. |
| internal/state/state_test.go | New tests for `IssueInProgress`, `DonePRCount`, `PruneOldSessions`, `LiveSessionsAt`, `CountByStatus`, `StatusPriority`, and `IsTerminal` all correctly exercise `code_landed`. |
| internal/supervisor/supervisor_test.go | New test `TestDecide_OrderedQueueAdvancesAfterCodeLandedSessionWithMergedPR` validates that the ordered queue advances past a `code_landed` session. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:1137-1138
**Stale comment after adding `code_landed` to this branch**

The comment immediately below the `case` line reads *"Zombie cleanup: if the underlying issue is closed, transition to done. This prevents `conflict_failed`/`failed`/`dead`/`retry_exhausted` sessions from lingering…"* — `code_landed` is now also handled here but isn't mentioned, which could confuse future readers about why a non-terminal status shares this branch. Consider updating the comment to also cover the `code_landed` path (e.g., "…and keeps `code_landed` sessions progressing to `done` once the issue is externally closed").

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep merged sessions open for verif..."](https://github.com/befeast/maestro/commit/b25bcd8d119e10245abbecad5e0a0d8bc12a45b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30572440)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->