### PR TITLE
P0: global operator brief that replaces per-project supervisor watching

### DIFF
--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -102,7 +102,7 @@ projects:
 
 ## Operating Model
 
-Fleet Mission Control is an observation surface. It loads each project config, reads each project's state/log metadata, and returns one aggregate response from `/api/v1/fleet`. One project load error is shown on that project card without hiding the rest of the fleet.
+Fleet Mission Control is an observation surface. It loads each project config, reads each project's state/log metadata, and returns one aggregate response from `/api/v1/fleet`. The header starts with one global operator brief across every configured project; project cards, supervisor details, queues, and worker logs are drilldown/debug data after that brief. One project load error is shown on that project card without hiding the rest of the fleet.
 
 The project runner remains the execution surface. It starts workers, reconciles dead sessions, opens and monitors PRs, waits for review gates, merges eligible PRs, deploys when configured, and updates local state.
 
@@ -110,13 +110,16 @@ The supervisor is the explainability and policy surface. It records queue analys
 
 Each project card shows an outcome status: goal, runtime target, health state, and next action. If no `outcome` brief is configured, Mission Control says so explicitly because merged PR throughput is not the same as a working runtime. If PRs keep merging while runtime health is unknown or failing, the supervisor records `no_outcome_progress` and recommends a read-only deploy/runtime check instead of mutating production.
 
+The global brief names one state for the whole fleet: healthy idle, running work, waiting for CI/review, no eligible issues, dispatch failure, stale worker, runtime outcome drift, or the single highest-priority action that needs an operator. When no human action is needed, it says so explicitly.
+
 Use this order during normal operations:
 
 1. Open Fleet Mission Control at `http://127.0.0.1:8787/`.
-2. Check fleet summary, stale project cards, attention cards, approvals, queue snapshots, and active workers.
-3. Open a project dashboard link only when the fleet card needs project-level detail.
-4. Use CLI commands with explicit `--config` paths when you need local state, logs, or a supervised decision.
-5. Restart services rather than editing state files by hand.
+2. Read the global operator brief first; if it says no action is needed, treat the rest of the page as supporting detail.
+3. If the brief names an action, follow that project, issue/PR/session, and reason before scanning lower-priority cards.
+4. Open a project dashboard link only when the fleet card needs project-level detail.
+5. Use CLI commands with explicit `--config` paths when you need local state, logs, or a supervised decision.
+6. Restart services rather than editing state files by hand.
 
 ## Queue Policy
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -203,16 +203,18 @@ type fleetVerdict struct {
 }
 
 type fleetOperatorBrief struct {
-	Tone        string `json:"tone"`
-	Sentence    string `json:"sentence"`
-	Project     string `json:"project,omitempty"`
-	Kind        string `json:"kind,omitempty"`
-	NextAction  string `json:"next_action,omitempty"`
-	IssueNumber int    `json:"issue_number,omitempty"`
-	IssueURL    string `json:"issue_url,omitempty"`
-	PRNumber    int    `json:"pr_number,omitempty"`
-	PRURL       string `json:"pr_url,omitempty"`
-	Session     string `json:"session,omitempty"`
+	Tone           string `json:"tone"`
+	Sentence       string `json:"sentence"`
+	Project        string `json:"project,omitempty"`
+	Kind           string `json:"kind,omitempty"`
+	Reason         string `json:"reason,omitempty"`
+	NextAction     string `json:"next_action,omitempty"`
+	ActionRequired bool   `json:"action_required,omitempty"`
+	IssueNumber    int    `json:"issue_number,omitempty"`
+	IssueURL       string `json:"issue_url,omitempty"`
+	PRNumber       int    `json:"pr_number,omitempty"`
+	PRURL          string `json:"pr_url,omitempty"`
+	Session        string `json:"session,omitempty"`
 }
 
 type fleetOperatorState struct {
@@ -235,8 +237,12 @@ type fleetSummary struct {
 	Active              int   `json:"active"`
 	MonitoringPR        int   `json:"monitoring_pr"`
 	DispatchPending     int   `json:"dispatch_pending"`
+	DispatchFailures    int   `json:"dispatch_failures"`
 	QueueBlocked        int   `json:"queue_blocked"`
+	NoEligibleIssues    int   `json:"no_eligible_issues"`
 	OutcomeMissing      int   `json:"outcome_missing"`
+	OutcomeDrift        int   `json:"outcome_drift"`
+	StaleWorkers        int   `json:"stale_workers"`
 	Running             int   `json:"running"`
 	PROpen              int   `json:"pr_open"`
 	Failed              int   `json:"failed"`
@@ -606,7 +612,7 @@ func (s *FleetServer) snapshot() fleetResponse {
 		return left.Slot < right.Slot
 	})
 	sortFleetApprovals(resp.Approvals)
-	resp.OperatorBrief = buildFleetOperatorBrief(resp.Projects, now)
+	resp.OperatorBrief = buildFleetOperatorBrief(resp.Projects, resp.Approvals, now)
 	resp.Verdict = buildFleetVerdict(resp, now)
 	return resp
 }
@@ -635,7 +641,7 @@ func fleetVerdictTone(summary fleetSummary, latest *supervisorDecisionInfo, now 
 	if latest == nil || supervisorHeartbeatStale(latest, now) {
 		return "daemon-down"
 	}
-	if summary.Stale > 0 || summary.Errors > 0 || summary.NeedsAttention > 0 || summary.ApprovalsPending > 0 {
+	if summary.Stale > 0 || summary.Errors > 0 || summary.NeedsAttention > 0 || summary.ApprovalsPending > 0 || summary.DispatchFailures > 0 || summary.OutcomeDrift > 0 || summary.NoEligibleIssues > 0 {
 		return "attention"
 	}
 	if summary.Running > 0 {
@@ -726,7 +732,7 @@ func fleetPRSentence(prOpen int) string {
 }
 
 func fleetAttentionSentence(summary fleetSummary) string {
-	items := summary.NeedsAttention + summary.ApprovalsPending + summary.Errors + summary.Stale
+	items := summary.NeedsAttention + summary.ApprovalsPending + summary.Errors + summary.Stale + summary.DispatchFailures + summary.OutcomeDrift + summary.NoEligibleIssues
 	switch items {
 	case 0:
 		return "No item needs attention."
@@ -747,10 +753,17 @@ func addFleetOperatorSummary(summary *fleetSummary, operator fleetOperatorState)
 		summary.MonitoringPR++
 	case "pending_dispatch":
 		summary.DispatchPending++
-	case "queue_blocked":
+	case "dispatch_failure":
+		summary.DispatchFailures++
+	case "queue_blocked", "no_eligible_issues":
 		summary.QueueBlocked++
+		summary.NoEligibleIssues++
 	case "outcome_missing":
 		summary.OutcomeMissing++
+	case "outcome_drift":
+		summary.OutcomeDrift++
+	case "stale_worker":
+		summary.StaleWorkers++
 	}
 }
 
@@ -763,20 +776,55 @@ func fleetOperatorStateIsActive(kind string) bool {
 	}
 }
 
-func buildFleetOperatorBrief(projects []fleetProjectState, now time.Time) fleetOperatorBrief {
+func buildFleetOperatorBrief(projects []fleetProjectState, approvals []fleetApprovalState, now time.Time) fleetOperatorBrief {
 	_ = now
 	if len(projects) == 0 {
-		return fleetOperatorBrief{Tone: "muted", Sentence: "No projects are configured in this fleet."}
+		return fleetOperatorBrief{Tone: "muted", Sentence: "Global brief: no projects are configured in this fleet."}
 	}
-	var selected *fleetProjectState
+
+	var action *fleetProjectState
 	for i := range projects {
 		project := &projects[i]
-		if selected == nil || fleetOperatorStatePriority(project.OperatorState.Kind) < fleetOperatorStatePriority(selected.OperatorState.Kind) {
-			selected = project
+		if !fleetOperatorKindNeedsAction(project.OperatorState.Kind) {
+			continue
+		}
+		if action == nil || fleetOperatorStatePriority(project.OperatorState.Kind) < fleetOperatorStatePriority(action.OperatorState.Kind) {
+			action = project
 		}
 	}
-	if selected == nil {
-		return fleetOperatorBrief{Tone: "muted", Sentence: "No project state is available."}
+	if action != nil {
+		state := action.OperatorState
+		brief := fleetOperatorBrief{
+			Tone:           fleetActionTone(state.Tone),
+			Project:        action.Name,
+			Kind:           state.Kind,
+			Reason:         state.Summary,
+			NextAction:     state.NextAction,
+			ActionRequired: true,
+			IssueNumber:    state.IssueNumber,
+			IssueURL:       state.IssueURL,
+			PRNumber:       state.PRNumber,
+			PRURL:          state.PRURL,
+			Session:        state.Session,
+		}
+		brief.Sentence = fleetActionRequiredSentence(action.Name, state.Label, state.Summary, state.NextAction, state.IssueNumber, state.PRNumber, state.Session)
+		return brief
+	}
+	if approval := highestPriorityPendingFleetApproval(approvals); approval != nil {
+		return fleetOperatorBrief{
+			Tone:           "attention",
+			Sentence:       fleetActionRequiredSentence(approval.ProjectName, "Approval pending", approval.Summary, "Approve or reject the pending supervisor approval after checking the target state.", approval.IssueNumber, approval.PRNumber, approval.Session),
+			Project:        approval.ProjectName,
+			Kind:           "approval_pending",
+			Reason:         truncateFleetOperatorText(approval.Summary, 150),
+			NextAction:     "Approve or reject the pending supervisor approval after checking the target state.",
+			ActionRequired: true,
+			IssueNumber:    approval.IssueNumber,
+			IssueURL:       approval.IssueURL,
+			PRNumber:       approval.PRNumber,
+			PRURL:          approval.PRURL,
+			Session:        approval.Session,
+		}
 	}
 
 	working, monitoring, pending, attention := 0, 0, 0, 0
@@ -792,67 +840,118 @@ func buildFleetOperatorBrief(projects []fleetProjectState, now time.Time) fleetO
 			attention++
 		}
 	}
-	state := selected.OperatorState
-	brief := fleetOperatorBrief{
-		Tone:        state.Tone,
-		Project:     selected.Name,
-		Kind:        state.Kind,
-		NextAction:  state.NextAction,
-		IssueNumber: state.IssueNumber,
-		IssueURL:    state.IssueURL,
-		PRNumber:    state.PRNumber,
-		PRURL:       state.PRURL,
-		Session:     state.Session,
-	}
-	if attention > 0 || state.Tone == "attention" || state.Tone == "error" || state.Tone == "warn" {
-		brief.Sentence = fmt.Sprintf("Operator brief: %s: %s — %s", selected.Name, state.Label, state.Summary)
-		if next := strings.TrimSpace(state.NextAction); next != "" {
-			brief.Sentence += "; next: " + next
-		}
-		return brief
-	}
 	parts := make([]string, 0, 3)
 	if working > 0 {
-		parts = append(parts, fleetCountPhrase(working, "working", "working"))
+		parts = append(parts, fleetCountPhrase(working, "project running work", "projects running work"))
 	}
 	if monitoring > 0 {
-		parts = append(parts, fleetCountPhrase(monitoring, "monitoring PR", "monitoring PRs"))
+		parts = append(parts, fleetCountPhrase(monitoring, "project waiting for CI/review", "projects waiting for CI/review"))
 	}
 	if pending > 0 {
-		parts = append(parts, fleetCountPhrase(pending, "dispatch pending", "dispatch pending"))
+		parts = append(parts, fleetCountPhrase(pending, "project dispatch pending", "projects dispatch pending"))
 	}
 	if len(parts) == 0 {
-		brief.Tone = "healthy"
-		brief.Sentence = "Operator brief: all projects are idle by policy; no operator action is pending."
-		return brief
+		return fleetOperatorBrief{Tone: "healthy", Kind: "idle", Sentence: "Global brief: all projects are healthy idle; no operator action is needed right now."}
 	}
-	brief.Tone = "busy"
-	brief.Sentence = "Operator brief: " + strings.Join(parts, " · ") + "; no operator action is pending."
-	return brief
+	if attention > 0 {
+		parts = append(parts, fleetCountPhrase(attention, "project with passive attention", "projects with passive attention"))
+	}
+	return fleetOperatorBrief{Tone: "busy", Kind: "active", Sentence: "Global brief: " + strings.Join(parts, "; ") + "; no operator action is needed right now."}
+}
+
+func highestPriorityPendingFleetApproval(approvals []fleetApprovalState) *fleetApprovalState {
+	var selected *fleetApprovalState
+	for i := range approvals {
+		approval := &approvals[i]
+		if state.ApprovalStatus(approval.Status) != state.ApprovalStatusPending {
+			continue
+		}
+		if selected == nil || fleetApprovalStatusRank(approval.Status) < fleetApprovalStatusRank(selected.Status) || approval.createdAt.Before(selected.createdAt) {
+			selected = approval
+		}
+	}
+	return selected
+}
+
+func fleetOperatorKindNeedsAction(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case "error", "dispatch_failure", "stale_worker", "attention", "stale", "outcome_drift", "no_eligible_issues", "queue_blocked":
+		return true
+	default:
+		return false
+	}
+}
+
+func fleetActionTone(tone string) string {
+	switch strings.TrimSpace(tone) {
+	case "error", "daemon-down":
+		return "daemon-down"
+	case "busy":
+		return "busy"
+	case "healthy":
+		return "healthy"
+	default:
+		return "attention"
+	}
+}
+
+func fleetActionRequiredSentence(project, label, reason, next string, issueNumber, prNumber int, session string) string {
+	project = firstNonEmpty(project, "project")
+	label = firstNonEmpty(label, "Operator action")
+	reason = firstNonEmpty(reason, "Maestro needs an operator decision.")
+	sentence := fmt.Sprintf("Global brief: action required in %s", project)
+	if target := fleetBriefTargetPhrase(issueNumber, prNumber, session); target != "" {
+		sentence += " on " + target
+	}
+	sentence += fmt.Sprintf(": %s. Reason: %s", label, reason)
+	if next = strings.TrimSpace(next); next != "" {
+		sentence += " Next: " + next
+	}
+	return sentence
+}
+
+func fleetBriefTargetPhrase(issueNumber, prNumber int, session string) string {
+	parts := make([]string, 0, 3)
+	if issueNumber > 0 {
+		parts = append(parts, fmt.Sprintf("issue #%d", issueNumber))
+	}
+	if prNumber > 0 {
+		parts = append(parts, fmt.Sprintf("PR #%d", prNumber))
+	}
+	if session = strings.TrimSpace(session); session != "" {
+		parts = append(parts, "session "+session)
+	}
+	return strings.Join(parts, ", ")
 }
 
 func fleetOperatorStatePriority(kind string) int {
 	switch strings.TrimSpace(kind) {
 	case "error":
 		return 0
-	case "attention":
+	case "dispatch_failure":
 		return 1
-	case "stale":
+	case "stale_worker":
 		return 2
-	case "pending_dispatch":
+	case "attention":
 		return 3
-	case "working":
+	case "outcome_drift":
 		return 4
-	case "monitoring_pr":
+	case "stale":
 		return 5
-	case "outcome_missing":
+	case "pending_dispatch":
 		return 6
-	case "queue_blocked":
+	case "working":
 		return 7
-	case "idle":
+	case "monitoring_pr":
 		return 8
-	default:
+	case "no_eligible_issues", "queue_blocked":
 		return 9
+	case "outcome_missing":
+		return 10
+	case "idle":
+		return 11
+	default:
+		return 12
 	}
 }
 
@@ -1245,6 +1344,9 @@ func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorStat
 			NextAction: "Fix the project state/config load error before Maestro can supervise it.",
 		}
 	}
+	if state, ok := fleetDispatchFailureOperatorState(project); ok {
+		return state
+	}
 	if project.NeedsAttention > 0 {
 		state := fleetOperatorState{
 			Kind:       "attention",
@@ -1254,7 +1356,11 @@ func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorStat
 			NextAction: "Open the worker detail and resolve the first blocking reason.",
 		}
 		if len(project.Attention) > 0 {
-			worker := project.Attention[0]
+			worker := highestPriorityAttentionSession(project.Attention)
+			if fleetSessionLooksStale(worker) {
+				state.Kind = "stale_worker"
+				state.Label = "Stale worker"
+			}
 			state.Session = worker.Slot
 			state.IssueNumber = worker.IssueNumber
 			state.IssueURL = firstNonEmpty(worker.IssueURL, githubIssueURL(project.Repo, worker.IssueNumber))
@@ -1281,6 +1387,9 @@ func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorStat
 			Summary:    summary,
 			NextAction: "Check the project supervisor service and state writer.",
 		}
+	}
+	if state, ok := fleetOutcomeDriftOperatorState(project); ok {
+		return state
 	}
 	if project.Running > 0 {
 		state := fleetOperatorState{
@@ -1339,7 +1448,7 @@ func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorStat
 		return fleetOperatorState{Kind: "idle", Tone: "muted", Label: "Idle", Summary: "No queue snapshot is available yet."}
 	}
 	if q.Open == 0 {
-		return fleetOperatorState{Kind: "idle", Tone: "healthy", Label: "Idle", Summary: "No open issues are available."}
+		return fleetOperatorState{Kind: "idle", Tone: "healthy", Label: "Healthy idle", Summary: "No open issues are available."}
 	}
 	if q.Eligible > 0 {
 		state := fleetOperatorState{
@@ -1361,11 +1470,138 @@ func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorStat
 		summary = "Open issues exist, but none are runnable under the current policy."
 	}
 	return fleetOperatorState{
-		Kind:       "queue_blocked",
-		Tone:       "muted",
-		Label:      "Held by policy",
+		Kind:       "no_eligible_issues",
+		Tone:       "warn",
+		Label:      "No eligible issues",
 		Summary:    summary,
 		NextAction: "Change labels/dependencies/project status if these issues should run now.",
+	}
+}
+
+func highestPriorityAttentionSession(workers []sessionInfo) sessionInfo {
+	if len(workers) == 0 {
+		return sessionInfo{}
+	}
+	selected := workers[0]
+	for _, worker := range workers[1:] {
+		left := fleetSessionAttentionSeverity(worker)
+		right := fleetSessionAttentionSeverity(selected)
+		if left < right {
+			selected = worker
+			continue
+		}
+		if left == right && worker.StartedAt > selected.StartedAt {
+			selected = worker
+		}
+	}
+	return selected
+}
+
+func fleetSessionAttentionSeverity(worker sessionInfo) int {
+	if text := strings.ToLower(worker.Status + " " + worker.StatusReason + " " + worker.NextAction); strings.Contains(text, "blocked") {
+		return 0
+	}
+	switch state.SessionStatus(worker.Status) {
+	case state.StatusDead, state.StatusFailed, state.StatusConflictFailed, state.StatusRetryExhausted:
+		return 0
+	case state.StatusRunning:
+		return 1
+	case state.StatusPROpen, state.StatusQueued:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func fleetSessionLooksStale(worker sessionInfo) bool {
+	if state.SessionStatus(worker.Status) != state.StatusRunning {
+		return false
+	}
+	text := strings.ToLower(worker.StatusReason + " " + worker.NextAction)
+	return strings.Contains(text, "not alive") || strings.Contains(text, "no pid") || strings.Contains(text, "not produced new output") || strings.Contains(text, "silent worker") || strings.Contains(text, "stale") || strings.Contains(text, "timeout")
+}
+
+func fleetDispatchFailureOperatorState(project fleetProjectState) (fleetOperatorState, bool) {
+	latest := project.Supervisor.Latest
+	if latest == nil {
+		return fleetOperatorState{}, false
+	}
+	if strings.TrimSpace(latest.Status) != "failed" && strings.TrimSpace(latest.ErrorClass) == "" {
+		return fleetOperatorState{}, false
+	}
+	operator := fleetOperatorState{
+		Kind:       "dispatch_failure",
+		Tone:       "error",
+		Label:      "Dispatch failure",
+		Summary:    firstNonEmpty(latest.Summary, "Supervisor dispatch or queue action failed."),
+		NextAction: fleetDispatchFailureNextAction(latest.ErrorClass),
+	}
+	return applyFleetOperatorTarget(project, operator, latest.Target), true
+}
+
+func fleetDispatchFailureNextAction(errorClass string) string {
+	switch strings.TrimSpace(errorClass) {
+	case "github_auth":
+		return "Fix GitHub authentication/permissions, then rerun the project supervisor."
+	case "github_rate_limited":
+		return "Wait for GitHub rate limits to clear, then rerun the project supervisor."
+	case "github_not_found":
+		return "Check the target issue/project exists and is accessible, then rerun the project supervisor."
+	default:
+		return "Fix the failed supervisor queue action, then rerun the project supervisor."
+	}
+}
+
+func fleetOutcomeDriftOperatorState(project fleetProjectState) (fleetOperatorState, bool) {
+	if !project.Outcome.Configured {
+		return fleetOperatorState{}, false
+	}
+	if latest := project.Supervisor.Latest; latest != nil {
+		if strings.TrimSpace(latest.RecommendedAction) == "check_outcome_health" {
+			operator := fleetOperatorState{
+				Kind:       "outcome_drift",
+				Tone:       "attention",
+				Label:      "Outcome drift",
+				Summary:    firstNonEmpty(latest.Summary, "Runtime outcome health needs verification."),
+				NextAction: firstNonEmpty(project.Outcome.NextAction, "Run the configured runtime/deploy healthcheck before dispatching more issue work."),
+			}
+			return applyFleetOperatorTarget(project, operator, latest.Target), true
+		}
+		for _, stuck := range latest.StuckStates {
+			if stuck.Code != state.StuckNoOutcomeProgress {
+				continue
+			}
+			operator := fleetOperatorState{
+				Kind:       "outcome_drift",
+				Tone:       "attention",
+				Label:      "Outcome drift",
+				Summary:    firstNonEmpty(stuck.Summary, "Runtime outcome health has not caught up with merged PRs."),
+				NextAction: firstNonEmpty(stuck.RecommendedAction, project.Outcome.NextAction),
+			}
+			return applyFleetOperatorTarget(project, operator, stuck.Target), true
+		}
+	}
+
+	health := strings.TrimSpace(project.Outcome.HealthState)
+	switch health {
+	case outcome.HealthFailing:
+		return fleetOutcomeHealthState(project, health), true
+	case outcome.HealthUnknown, outcome.HealthUnmonitored:
+		if project.Outcome.MergedPRs > 0 {
+			return fleetOutcomeHealthState(project, health), true
+		}
+	}
+	return fleetOperatorState{}, false
+}
+
+func fleetOutcomeHealthState(project fleetProjectState, health string) fleetOperatorState {
+	goal := firstNonEmpty(project.Outcome.Goal, project.Outcome.DesiredOutcome, "the configured runtime outcome")
+	return fleetOperatorState{
+		Kind:       "outcome_drift",
+		Tone:       "attention",
+		Label:      "Outcome drift",
+		Summary:    fmt.Sprintf("Runtime outcome health is %s for %s.", strings.ReplaceAll(firstNonEmpty(health, outcome.HealthUnknown), "_", " "), goal),
+		NextAction: firstNonEmpty(project.Outcome.NextAction, "Run the configured runtime/deploy healthcheck before dispatching more issue work."),
 	}
 }
 
@@ -1379,6 +1615,14 @@ func fleetOperatorStateFromSupervisor(project fleetProjectState) (fleetOperatorS
 	target := latest.Target
 	operator := fleetOperatorState{}
 	switch action {
+	case "check_outcome_health":
+		operator = fleetOperatorState{
+			Kind:       "outcome_drift",
+			Tone:       "attention",
+			Label:      "Outcome drift",
+			Summary:    firstNonEmpty(summary, "Runtime outcome health needs verification before more issue throughput."),
+			NextAction: firstNonEmpty(project.Outcome.NextAction, "Run the configured runtime/deploy healthcheck before dispatching more issue work."),
+		}
 	case "monitor_open_pr", "approve_merge":
 		operator = fleetOperatorState{
 			Kind:       "monitoring_pr",

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -782,6 +782,23 @@ func buildFleetOperatorBrief(projects []fleetProjectState, approvals []fleetAppr
 		return fleetOperatorBrief{Tone: "muted", Sentence: "Global brief: no projects are configured in this fleet."}
 	}
 
+	if approval := highestPriorityPendingFleetApproval(approvals); approval != nil {
+		return fleetOperatorBrief{
+			Tone:           "attention",
+			Sentence:       fleetActionRequiredSentence(approval.ProjectName, "Approval pending", approval.Summary, approval.IssueNumber, approval.PRNumber, approval.Session),
+			Project:        approval.ProjectName,
+			Kind:           "approval_pending",
+			Reason:         truncateFleetOperatorText(approval.Summary, 150),
+			NextAction:     "Approve or reject the pending supervisor approval after checking the target state.",
+			ActionRequired: true,
+			IssueNumber:    approval.IssueNumber,
+			IssueURL:       approval.IssueURL,
+			PRNumber:       approval.PRNumber,
+			PRURL:          approval.PRURL,
+			Session:        approval.Session,
+		}
+	}
+
 	var action *fleetProjectState
 	for i := range projects {
 		project := &projects[i]
@@ -807,24 +824,8 @@ func buildFleetOperatorBrief(projects []fleetProjectState, approvals []fleetAppr
 			PRURL:          state.PRURL,
 			Session:        state.Session,
 		}
-		brief.Sentence = fleetActionRequiredSentence(action.Name, state.Label, state.Summary, state.NextAction, state.IssueNumber, state.PRNumber, state.Session)
+		brief.Sentence = fleetActionRequiredSentence(action.Name, state.Label, state.Summary, state.IssueNumber, state.PRNumber, state.Session)
 		return brief
-	}
-	if approval := highestPriorityPendingFleetApproval(approvals); approval != nil {
-		return fleetOperatorBrief{
-			Tone:           "attention",
-			Sentence:       fleetActionRequiredSentence(approval.ProjectName, "Approval pending", approval.Summary, "Approve or reject the pending supervisor approval after checking the target state.", approval.IssueNumber, approval.PRNumber, approval.Session),
-			Project:        approval.ProjectName,
-			Kind:           "approval_pending",
-			Reason:         truncateFleetOperatorText(approval.Summary, 150),
-			NextAction:     "Approve or reject the pending supervisor approval after checking the target state.",
-			ActionRequired: true,
-			IssueNumber:    approval.IssueNumber,
-			IssueURL:       approval.IssueURL,
-			PRNumber:       approval.PRNumber,
-			PRURL:          approval.PRURL,
-			Session:        approval.Session,
-		}
 	}
 
 	working, monitoring, pending, attention := 0, 0, 0, 0
@@ -866,7 +867,13 @@ func highestPriorityPendingFleetApproval(approvals []fleetApprovalState) *fleetA
 		if state.ApprovalStatus(approval.Status) != state.ApprovalStatusPending {
 			continue
 		}
-		if selected == nil || fleetApprovalStatusRank(approval.Status) < fleetApprovalStatusRank(selected.Status) || approval.createdAt.Before(selected.createdAt) {
+		if selected == nil {
+			selected = approval
+			continue
+		}
+		approvalRank := fleetApprovalStatusRank(approval.Status)
+		selectedRank := fleetApprovalStatusRank(selected.Status)
+		if approvalRank < selectedRank || (approvalRank == selectedRank && fleetApprovalRecency(*approval).After(fleetApprovalRecency(*selected))) {
 			selected = approval
 		}
 	}
@@ -895,7 +902,7 @@ func fleetActionTone(tone string) string {
 	}
 }
 
-func fleetActionRequiredSentence(project, label, reason, next string, issueNumber, prNumber int, session string) string {
+func fleetActionRequiredSentence(project, label, reason string, issueNumber, prNumber int, session string) string {
 	project = firstNonEmpty(project, "project")
 	label = firstNonEmpty(label, "Operator action")
 	reason = firstNonEmpty(reason, "Maestro needs an operator decision.")
@@ -904,9 +911,6 @@ func fleetActionRequiredSentence(project, label, reason, next string, issueNumbe
 		sentence += " on " + target
 	}
 	sentence += fmt.Sprintf(": %s. Reason: %s", label, reason)
-	if next = strings.TrimSpace(next); next != "" {
-		sentence += " Next: " + next
-	}
 	return sentence
 }
 
@@ -1870,14 +1874,8 @@ func sortFleetApprovals(items []fleetApprovalState) {
 		if li != ri {
 			return li < ri
 		}
-		lt := left.updatedAt
-		if lt.IsZero() {
-			lt = left.createdAt
-		}
-		rt := right.updatedAt
-		if rt.IsZero() {
-			rt = right.createdAt
-		}
+		lt := fleetApprovalRecency(left)
+		rt := fleetApprovalRecency(right)
 		if !lt.Equal(rt) {
 			return lt.After(rt)
 		}
@@ -1886,6 +1884,13 @@ func sortFleetApprovals(items []fleetApprovalState) {
 		}
 		return left.ID < right.ID
 	})
+}
+
+func fleetApprovalRecency(approval fleetApprovalState) time.Time {
+	if !approval.updatedAt.IsZero() {
+		return approval.updatedAt
+	}
+	return approval.createdAt
 }
 
 func fleetApprovalStatusRank(status string) int {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -580,6 +580,144 @@ func TestFleetAPIOperatorStateExplainsZeroRunningActiveWork(t *testing.T) {
 	}
 }
 
+func TestFleetOperatorBriefNamesSingleHighestPriorityAction(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	staleWorkerStateDir := filepath.Join(dir, "stale-worker")
+	noEligibleStateDir := filepath.Join(dir, "no-eligible")
+	runningStateDir := filepath.Join(dir, "running")
+
+	saveFleetTestState(t, staleWorkerStateDir, map[string]*state.Session{
+		"stale-1": {
+			IssueNumber: 42,
+			IssueTitle:  "Stale worker",
+			Status:      state.StatusRunning,
+			StartedAt:   now.Add(-12 * time.Minute),
+			PID:         0,
+		},
+	})
+	noEligibleState := state.NewState()
+	noEligibleState.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-no-eligible",
+		CreatedAt:         now,
+		Project:           "owner/no-eligible",
+		Summary:           "No issue is eligible under policy.",
+		RecommendedAction: "none",
+		Risk:              "safe",
+		QueueAnalysis: &state.SupervisorQueueAnalysis{
+			OpenIssues:         2,
+			EligibleCandidates: 0,
+			ExcludedIssues:     2,
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(noEligibleStateDir, noEligibleState); err != nil {
+		t.Fatalf("save no eligible state: %v", err)
+	}
+	saveFleetTestState(t, runningStateDir, map[string]*state.Session{
+		"run-1": {
+			IssueNumber: 77,
+			IssueTitle:  "Running worker",
+			Status:      state.StatusRunning,
+			StartedAt:   now.Add(-time.Minute),
+			PID:         os.Getpid(),
+		},
+	})
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("NoEligible", "/tmp/no-eligible.yaml", "", &config.Config{
+			Repo:        "owner/no-eligible",
+			StateDir:    noEligibleStateDir,
+			MaxParallel: 1,
+			Outcome:     outcome.Brief{DesiredOutcome: "No eligible outcome"},
+		}),
+		NewFleetProject("Running", "/tmp/running.yaml", "", &config.Config{
+			Repo:        "owner/running",
+			StateDir:    runningStateDir,
+			MaxParallel: 1,
+			Outcome:     outcome.Brief{DesiredOutcome: "Running outcome"},
+		}),
+		NewFleetProject("StaleWorker", "/tmp/stale-worker.yaml", "", &config.Config{
+			Repo:        "owner/stale-worker",
+			StateDir:    staleWorkerStateDir,
+			MaxParallel: 1,
+			Outcome:     outcome.Brief{DesiredOutcome: "Stale worker outcome"},
+		}),
+	}, "127.0.0.1", 8786, true)
+
+	resp := srv.snapshot()
+	brief := resp.OperatorBrief
+	if !brief.ActionRequired || brief.Kind != "stale_worker" || brief.Project != "StaleWorker" {
+		t.Fatalf("operator brief = %+v, want stale worker action for StaleWorker", brief)
+	}
+	if brief.IssueNumber != 42 || brief.Session != "stale-1" || !contains(brief.Reason, "PID is not alive") {
+		t.Fatalf("operator brief target/reason = %+v, want issue/session/dead PID", brief)
+	}
+	for _, want := range []string{"Global brief: action required", "StaleWorker", "issue #42", "session stale-1", "Reason:"} {
+		if !contains(brief.Sentence, want) {
+			t.Fatalf("operator brief sentence = %q, want %q", brief.Sentence, want)
+		}
+	}
+	if contains(brief.Sentence, "issue #77") {
+		t.Fatalf("operator brief should name one highest-priority action, got %q", brief.Sentence)
+	}
+	if resp.Summary.StaleWorkers != 1 || resp.Summary.NoEligibleIssues != 1 {
+		t.Fatalf("summary = %+v, want stale worker and no eligible counts", resp.Summary)
+	}
+}
+
+func TestFleetProjectOperatorStateDistinguishesBriefStates(t *testing.T) {
+	now := time.Now().UTC()
+	configuredOutcome := outcome.Status{Configured: true, Goal: "Runtime is healthy", HealthState: outcome.HealthHealthy}
+
+	dispatch := buildFleetProjectOperatorState(fleetProjectState{
+		Name:    "Dispatch",
+		Repo:    "owner/dispatch",
+		Outcome: configuredOutcome,
+		Supervisor: supervisorInfo{Latest: &supervisorDecisionInfo{
+			CreatedAt:         now,
+			Status:            "failed",
+			ErrorClass:        "github_api",
+			Summary:           "Supervisor queue action failed for issue #9.",
+			RecommendedAction: "label_issue_ready",
+			Target:            &state.SupervisorTarget{Issue: 9},
+		}},
+	})
+	if dispatch.Kind != "dispatch_failure" || dispatch.IssueNumber != 9 {
+		t.Fatalf("dispatch operator state = %+v, want dispatch failure for issue #9", dispatch)
+	}
+
+	drift := buildFleetProjectOperatorState(fleetProjectState{
+		Name: "Runtime",
+		Outcome: outcome.Status{
+			Configured:  true,
+			Goal:        "Runtime is healthy",
+			HealthState: outcome.HealthFailing,
+		},
+		QueueSnapshot: &fleetQueueSnapshot{Open: 0},
+	})
+	if drift.Kind != "outcome_drift" || !contains(drift.Summary, "failing") {
+		t.Fatalf("drift operator state = %+v, want runtime outcome drift", drift)
+	}
+
+	blocked := buildFleetProjectOperatorState(fleetProjectState{
+		Name:          "BlockedQueue",
+		Outcome:       configuredOutcome,
+		QueueSnapshot: &fleetQueueSnapshot{Open: 3, Eligible: 0, Excluded: 3, IdleReason: "Policy excluded all 3 open issues."},
+	})
+	if blocked.Kind != "no_eligible_issues" || !contains(blocked.Summary, "Policy excluded") {
+		t.Fatalf("blocked queue operator state = %+v, want no eligible issues", blocked)
+	}
+
+	idle := buildFleetProjectOperatorState(fleetProjectState{
+		Name:          "Idle",
+		Outcome:       configuredOutcome,
+		QueueSnapshot: &fleetQueueSnapshot{Open: 0, IdleReason: "No open issues are available."},
+	})
+	if idle.Kind != "idle" || idle.Label != "Healthy idle" {
+		t.Fatalf("idle operator state = %+v, want healthy idle", idle)
+	}
+}
+
 func TestFleetVerdictCoversHeaderStates(t *testing.T) {
 	now := time.Now().UTC()
 	tests := []struct {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -665,6 +665,73 @@ func TestFleetOperatorBriefNamesSingleHighestPriorityAction(t *testing.T) {
 	}
 }
 
+func TestFleetOperatorBriefPrioritizesPendingApproval(t *testing.T) {
+	now := time.Now().UTC()
+	brief := buildFleetOperatorBrief([]fleetProjectState{{
+		Name: "BlockedQueue",
+		OperatorState: fleetOperatorState{
+			Kind:        "no_eligible_issues",
+			Tone:        "attention",
+			Label:       "No eligible issues",
+			Summary:     "No issue is eligible under policy.",
+			NextAction:  "Adjust labels or policy so a worker can run.",
+			IssueNumber: 15,
+		},
+	}}, []fleetApprovalState{{
+		ProjectName: "ApprovalProject",
+		Status:      string(state.ApprovalStatusPending),
+		Summary:     "Supervisor approval is waiting for operator review.",
+		PRNumber:    44,
+		Session:     "approval-44",
+		createdAt:   now.Add(-time.Minute),
+		updatedAt:   now,
+	}}, now)
+
+	if !brief.ActionRequired || brief.Kind != "approval_pending" || brief.Project != "ApprovalProject" {
+		t.Fatalf("operator brief = %+v, want pending approval action for ApprovalProject", brief)
+	}
+	if brief.PRNumber != 44 || brief.Session != "approval-44" {
+		t.Fatalf("operator brief target = %+v, want PR #44 and approval-44 session", brief)
+	}
+	if !contains(brief.NextAction, "Approve or reject") {
+		t.Fatalf("operator brief next action = %q, want approval guidance", brief.NextAction)
+	}
+	if contains(brief.Sentence, "Next:") {
+		t.Fatalf("operator brief sentence = %q, should leave next action for structured rendering", brief.Sentence)
+	}
+}
+
+func TestHighestPriorityPendingFleetApprovalSelectsNewestPending(t *testing.T) {
+	now := time.Now().UTC()
+	selected := highestPriorityPendingFleetApproval([]fleetApprovalState{
+		{
+			ProjectName: "OldApproval",
+			ID:          "old",
+			Status:      string(state.ApprovalStatusPending),
+			createdAt:   now.Add(-2 * time.Hour),
+			updatedAt:   now.Add(-2 * time.Hour),
+		},
+		{
+			ProjectName: "ApprovedApproval",
+			ID:          "approved",
+			Status:      string(state.ApprovalStatusApproved),
+			createdAt:   now,
+			updatedAt:   now,
+		},
+		{
+			ProjectName: "NewApproval",
+			ID:          "new",
+			Status:      string(state.ApprovalStatusPending),
+			createdAt:   now.Add(-time.Hour),
+			updatedAt:   now.Add(-5 * time.Minute),
+		},
+	})
+
+	if selected == nil || selected.ProjectName != "NewApproval" {
+		t.Fatalf("selected approval = %+v, want newest pending approval", selected)
+	}
+}
+
 func TestFleetProjectOperatorStateDistinguishesBriefStates(t *testing.T) {
 	now := time.Now().UTC()
 	configuredOutcome := outcome.Status{Configured: true, Goal: "Runtime is healthy", HealthState: outcome.HealthHealthy}

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -66,8 +66,9 @@
   .fleet-verdict {
     position: relative;
     min-height: 72px;
-    display: flex;
-    align-items: center;
+    display: grid;
+    align-content: center;
+    gap: 5px;
     padding: 16px 18px 16px 64px;
     border: 1px solid var(--line);
     border-left: 4px solid var(--brand-a);
@@ -79,6 +80,29 @@
     font-weight: 650;
     line-height: 1.35;
   }
+
+  .fleet-brief-label {
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+  }
+
+  .fleet-brief-sentence { font-size: 17px; font-weight: 650; }
+
+  .fleet-brief-meta,
+  .fleet-brief-next {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 10px;
+    color: var(--muted);
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  .fleet-brief-next strong { color: var(--text); font-weight: 650; }
   .fleet-verdict::before {
     content: "";
     position: absolute;
@@ -239,10 +263,10 @@
   .project-rail-outcome-cell { width: 20%; }
   .project-rail-freshness-cell { width: 8%; }
   .project-rail-links-cell { width: 6%; text-align: right; }
-  .project-row-attention { background: rgba(220,38,38,.045); }
+  .project-row-attention, .project-row-stale_worker, .project-row-dispatch_failure, .project-row-outcome_drift { background: rgba(220,38,38,.045); }
   .project-row-working { background: rgba(22,128,60,.035); }
   .project-row-monitoring_pr, .project-row-pending_dispatch { background: rgba(37,99,235,.035); }
-  .project-row-queue_blocked, .project-row-outcome_missing, .project-row-stale { background: rgba(161,98,7,.045); }
+  .project-row-queue_blocked, .project-row-no_eligible_issues, .project-row-outcome_missing, .project-row-stale { background: rgba(161,98,7,.045); }
   .project-row-unconfigured,
   .project-row--unconfigured { background: rgba(100,116,139,.045); }
   .project-row--unconfigured {
@@ -377,8 +401,8 @@
   }
   .rail-state-working, .outcome-healthy { color: var(--ok); border-color: rgba(22,128,60,.5); background: rgba(22,128,60,.08); }
   .rail-state-monitoring_pr, .rail-state-pending_dispatch, .outcome-unknown { color: var(--accent); border-color: rgba(37,99,235,.45); background: rgba(37,99,235,.07); }
-  .rail-state-attention, .rail-state-error, .outcome-failing { color: var(--bad); border-color: rgba(220,38,38,.45); background: rgba(220,38,38,.07); }
-  .rail-state-stale, .rail-state-queue_blocked, .rail-state-outcome_missing { color: var(--warn); border-color: rgba(161,98,7,.45); background: rgba(161,98,7,.08); }
+  .rail-state-attention, .rail-state-error, .rail-state-stale_worker, .rail-state-dispatch_failure, .rail-state-outcome_drift, .outcome-failing { color: var(--bad); border-color: rgba(220,38,38,.45); background: rgba(220,38,38,.07); }
+  .rail-state-stale, .rail-state-queue_blocked, .rail-state-no_eligible_issues, .rail-state-outcome_missing { color: var(--warn); border-color: rgba(161,98,7,.45); background: rgba(161,98,7,.08); }
   .rail-state-unconfigured { color: var(--muted); border-color: rgba(100,116,139,.45); background: rgba(100,116,139,.08); }
   .rail-state-idle, .outcome-not_configured, .outcome-unmonitored { color: var(--muted); border-color: rgba(100,116,139,.45); background: rgba(100,116,139,.08); }
   .rail-setup-copy,
@@ -1300,8 +1324,12 @@
     text-overflow: ellipsis;
   }
 
-  .project-row-attention { background: rgba(220, 38, 38, .038); }
+  .project-row-attention,
+  .project-row-stale_worker,
+  .project-row-dispatch_failure,
+  .project-row-outcome_drift { background: rgba(220, 38, 38, .038); }
   .project-row-queue_blocked,
+  .project-row-no_eligible_issues,
   .project-row-outcome_missing,
   .project-row-stale { background: rgba(245, 158, 11, .055); }
   .project-row-unconfigured,

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -73,6 +73,7 @@ const fleetState = {
   attention: [],
   workers: [],
   detail: null,
+  operatorBrief: null,
   verdict: null,
   refreshedAt: ""
 };
@@ -803,12 +804,39 @@ function countFailed(project) {
   return project.failed || 0;
 }
 
-function renderFleetVerdict(verdict) {
-  const tones = new Set(["healthy", "busy", "attention", "daemon-down"]);
-  const tone = verdict && tones.has(verdict.tone) ? verdict.tone : "attention";
-  const sentence = verdict && verdict.sentence ? verdict.sentence : "Supervisor status unavailable. No worker state or attention state could be confirmed.";
+function fleetBriefToneClass(tone) {
+  switch (String(tone || "").trim()) {
+  case "healthy":
+  case "busy":
+  case "attention":
+  case "daemon-down":
+    return tone;
+  case "error":
+    return "daemon-down";
+  default:
+    return "attention";
+  }
+}
+
+function fleetBriefTargetHTML(brief) {
+  if (!brief) return "";
+  const parts = [];
+  if (brief.project) parts.push('<span>Project ' + escapeText(brief.project) + '</span>');
+  if (brief.issue_number) parts.push(linkHTML(brief.issue_url, "Issue #" + brief.issue_number));
+  if (brief.pr_number) parts.push(linkHTML(brief.pr_url, "PR #" + brief.pr_number));
+  if (brief.session) parts.push('<span>Session ' + escapeText(brief.session) + '</span>');
+  return parts.length ? '<div class="fleet-brief-meta">' + parts.join(" ") + '</div>' : "";
+}
+
+function renderFleetVerdict(brief, verdict) {
+  const source = brief && brief.sentence ? brief : verdict;
+  const tone = fleetBriefToneClass(source && source.tone);
+  const sentence = source && source.sentence ? source.sentence : "Supervisor status unavailable. No worker state or attention state could be confirmed.";
+  const next = brief && brief.next_action ? '<div class="fleet-brief-next"><strong>Next:</strong> ' + escapeText(brief.next_action) + '</div>' : "";
   fleetVerdictEl.className = "fleet-verdict verdict-" + tone;
-  fleetVerdictEl.textContent = sentence;
+  fleetVerdictEl.innerHTML = '<div class="fleet-brief-label">Global operator brief</div>' +
+    '<div class="fleet-brief-sentence">' + escapeText(sentence) + '</div>' +
+    fleetBriefTargetHTML(brief) + next;
 }
 
 function renderStats(summary) {
@@ -817,7 +845,8 @@ function renderStats(summary) {
   const prOpen = Number(summary.pr_open || 0);
   const monitoring = Number(summary.monitoring_pr || 0);
   const failed = Number(summary.failed || 0);
-  const attention = Number(summary.needs_attention || 0);
+  const attention = Number(summary.needs_attention || 0) + Number(summary.approvals_pending || 0) + Number(summary.errors || 0) +
+    Number(summary.stale || 0) + Number(summary.dispatch_failures || 0) + Number(summary.outcome_drift || 0) + Number(summary.no_eligible_issues || 0);
   const throughputMerged = Number(summary.throughput_merged_7d || 0);
   const throughputDaily = Array.isArray(summary.throughput_daily_7d)
     ? summary.throughput_daily_7d.map(value => Number(value || 0))
@@ -1738,6 +1767,7 @@ function applyFleetData(data) {
   fleetState.workers = fleetWorkersFromData(data);
   fleetState.approvals = approvalsFromData(data);
   fleetState.attention = attentionFromData(data);
+  fleetState.operatorBrief = data.operator_brief || null;
   fleetState.verdict = data.verdict || null;
   if (!fleetState.selectedWorkerKey && fleetState.requestedWorker) {
     const requested = resolveWorkerQuery(fleetState.requestedWorker);
@@ -1760,7 +1790,7 @@ function applyFleetData(data) {
     (alerts.length ? " · " + alerts.join(" · ") : "");
   renderFilterOptions();
   syncFilterControls();
-  renderFleetVerdict(fleetState.verdict);
+  renderFleetVerdict(fleetState.operatorBrief, fleetState.verdict);
   renderStats(summary);
   renderProjectRail();
   renderProjectOverview();

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -36,8 +36,8 @@
   </div>
 </header>
 <main>
-  <section class="fleet-verdict-shell" aria-live="polite">
-    <div class="fleet-verdict verdict-healthy" id="fleet-verdict">Loading supervisor heartbeat...</div>
+  <section class="fleet-verdict-shell" aria-live="polite" aria-label="Global operator brief">
+    <div class="fleet-verdict verdict-healthy" id="fleet-verdict">Loading global operator brief...</div>
   </section>
   <section class="stats stats-strip" id="stats" aria-label="Fleet summary"></section>
   <section class="project-rail" id="project-rail" aria-live="polite">


### PR DESCRIPTION
Refs #352

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces per-project supervisor watching with a single global operator brief that surfaces the highest-priority action across all configured projects: pending approvals first, then action-required project states (`dispatch_failure`, `stale_worker`, `outcome_drift`, `no_eligible_issues`) ranked by priority, falling back to a plain busy/idle prose sentence. The UI is updated to render the brief as a structured label/sentence/meta/next-action block instead of a single text node.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor caveats — no data-loss or runtime breakage identified; two P2 concerns worth addressing before broader API consumers rely on the new summary fields.

No P0/P1 bugs found. Two P2 issues: (1) QueueBlocked is now over-counted in the JSON summary because both queue_blocked and no_eligible_issues operator kinds increment it; (2) fleetDispatchFailureOperatorState fires on any non-empty ErrorClass regardless of Status, which could mask a project's real running state. Core brief logic, approval prioritization fix, and test coverage are solid.

internal/server/fleet.go — summary stat double-counting and dispatch-failure guard condition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Major refactor: adds global operator brief with dispatch_failure, stale_worker, outcome_drift, no_eligible_issues states and approval-prioritization; one summary stat double-counting concern. |
| internal/server/fleet_test.go | Adds four thorough new tests covering priority selection, approval precedence, and brief state discrimination; good coverage of the new behavior. |
| internal/server/web/static/fleet.js | Renders global operator brief with separate label/sentence/meta/next-action divs; proper escaping throughout; attention counter expanded to include new summary fields. |
| internal/server/web/static/fleet.css | Adds styles for new brief sub-elements and new operator-kind row/state classes; layout changed from flex to grid for the verdict container. |
| internal/server/web/templates/fleet.html | Updates placeholder text and aria-label to reflect global operator brief; minimal change. |
| docs/fleet-mission-control-runbook.md | Documents the new global brief and updated operating order; accurate description of the new behavior. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/fleet.go:758-761
**`QueueBlocked` over-counts `no_eligible_issues` projects**

Both `"queue_blocked"` and `"no_eligible_issues"` increment `QueueBlocked`, so the JSON field `queue_blocked` in the API response now equals `len(queue_blocked projects) + len(no_eligible_issues projects)`. Any external consumer that reads both `queue_blocked` and `no_eligible_issues` from the response and adds them together will double-count projects that carry the `no_eligible_issues` kind. If `queue_blocked` is meant to be a legacy alias for the same concept, consider only incrementing `NoEligibleIssues` and leaving `QueueBlocked` for literal `"queue_blocked"` kinds, or document the overlap in the struct comment.

### Issue 2 of 2
internal/server/fleet.go:1530-1533
**Dispatch-failure guard triggers on any non-empty `ErrorClass`**

The early-return condition is `Status != "failed" && ErrorClass == ""`, which means the function also proceeds (returning a `dispatch_failure` state) when `Status` is anything other than `"failed"` but `ErrorClass` is non-empty — for example a `"running"` or `"pending"` decision that briefly carries a diagnostic error class. In that edge case `fleetDispatchFailureOperatorState` fires first (it is checked before `NeedsAttention`, running workers, etc.) and would mask the project's real state for the entire next render cycle. Consider restricting the trigger to `Status == "failed"` and handling the non-failed-with-error-class case separately if intentional.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: prioritize pending fleet approvals"](https://github.com/befeast/maestro/commit/67de38bfa85a354f5fe374033edaf4f8231d733e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30573204)</sub>

<!-- /greptile_comment -->