### PR TITLE
M-009: UI: add 7-day issue throughput sparkline to fleet stats

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -205,25 +206,62 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	}
 }
 
-func TestFleetThroughputBucketsCountRecentMergedPRs(t *testing.T) {
+func TestFleetThroughputBucketsAggregateSevenDayWindows(t *testing.T) {
 	now := time.Date(2026, 5, 2, 15, 0, 0, 0, time.UTC)
-	buckets := newFleetThroughputBuckets(now, 7)
-	workers := []fleetWorkerState{
+	donePR := func(pr int, finishedAt time.Time) fleetWorkerState {
+		return fleetWorkerState{Status: string(state.StatusDone), PRNumber: pr, FinishedAt: finishedAt.Format(time.RFC3339)}
+	}
+	fullWindow := make([]fleetWorkerState, 0, 7)
+	for daysAgo := 6; daysAgo >= 0; daysAgo-- {
+		fullWindow = append(fullWindow, donePR(100+daysAgo, now.AddDate(0, 0, -daysAgo)))
+	}
+	partialWindow := []fleetWorkerState{
 		{Status: string(state.StatusDone), PRNumber: 10, FinishedAt: now.Add(-2 * time.Hour).Format(time.RFC3339)},
 		{Status: string(state.StatusDone), PRNumber: 11, FinishedAt: now.Add(-24 * time.Hour).Format(time.RFC3339)},
 		{Status: string(state.StatusDone), PRNumber: 12, FinishedAt: now.Add(-6 * 24 * time.Hour).Format(time.RFC3339)},
 		{Status: string(state.StatusDone), PRNumber: 13, FinishedAt: now.Add(-8 * 24 * time.Hour).Format(time.RFC3339)},
 		{Status: string(state.StatusFailed), PRNumber: 14, FinishedAt: now.Add(-time.Hour).Format(time.RFC3339)},
 		{Status: string(state.StatusDone), PRNumber: 0, FinishedAt: now.Add(-time.Hour).Format(time.RFC3339)},
+		{Status: string(state.StatusDone), PRNumber: 15, FinishedAt: "not-a-time"},
 	}
 
-	addFleetThroughputSummary(buckets, workers)
-
-	if buckets.Total() != 3 {
-		t.Fatalf("total = %d, want 3", buckets.Total())
+	tests := []struct {
+		name    string
+		workers []fleetWorkerState
+		want    []int
+	}{
+		{
+			name: "zero data",
+			want: []int{0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:    "partial window",
+			workers: partialWindow,
+			want:    []int{1, 0, 0, 0, 0, 1, 1},
+		},
+		{
+			name:    "full window",
+			workers: fullWindow,
+			want:    []int{1, 1, 1, 1, 1, 1, 1},
+		},
 	}
-	if got := buckets.Counts(); len(got) != 7 || got[0] != 1 || got[5] != 1 || got[6] != 1 {
-		t.Fatalf("counts = %v, want [1 0 0 0 0 1 1]", got)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buckets := newFleetThroughputBuckets(now, 7)
+			addFleetThroughputSummary(buckets, tc.workers)
+
+			if got := buckets.Counts(); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("counts = %v, want %v", got, tc.want)
+			}
+			wantTotal := 0
+			for _, count := range tc.want {
+				wantTotal += count
+			}
+			if buckets.Total() != wantTotal {
+				t.Fatalf("total = %d, want %d", buckets.Total(), wantTotal)
+			}
+		})
 	}
 }
 
@@ -1647,6 +1685,10 @@ func TestFleetDashboard(t *testing.T) {
 		"fleet-refresh",
 		"stat-label",
 		"Projects",
+		"Merged PRs",
+		"done sessions with PRs",
+		"Counts done Maestro sessions that recorded a PR number",
+		"stat-sparkline-empty",
 		"projectIsUnconfigured",
 		"project-row--unconfigured",
 		"rail-state-unconfigured",

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -136,7 +136,9 @@
     padding: 18px 22px;
     border-right: 1px solid var(--line);
   }
+  .stat[title] { cursor: help; }
   .stat:last-child { border-right: 0; }
+  .stat-neutral .stat-value strong { color: var(--text-mute); }
   .stat-label {
     display: block;
     color: var(--text-faint);
@@ -163,6 +165,10 @@
     border-radius: 999px 999px 3px 3px;
     background: linear-gradient(180deg, rgba(56,189,248,.9), rgba(37,99,235,.82));
     box-shadow: inset 0 1px 0 rgba(255,255,255,.45);
+  }
+  .stat-sparkline-empty .stat-sparkline-bar {
+    background: rgba(148,163,184,.28);
+    box-shadow: none;
   }
   .project-rail {
     margin-bottom: 20px;

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -851,15 +851,24 @@ function renderStats(summary) {
   const throughputDaily = Array.isArray(summary.throughput_daily_7d)
     ? summary.throughput_daily_7d.map(value => Number(value || 0))
     : [];
+  const throughputTitle = "Counts done Maestro sessions that recorded a PR number, bucketed by finished date over the last 7 days.";
   const items = [
     { label: "Running", value: running, suffix: "of " + projects, note: projects ? "worker slots" : "no projects" },
     { label: "PRs in flight", value: prOpen, suffix: "", note: monitoring + " monitored" },
     { label: "Failed", value: failed, suffix: "", note: "current fleet" },
     { label: "Attention", value: attention, suffix: "", note: attention ? "waiting" : "nothing waiting" },
-    { label: "Issue throughput", value: throughputMerged, suffix: "", note: "merged · last 7d", sparkline: throughputDaily }
+    {
+      label: "Merged PRs",
+      value: throughputMerged,
+      suffix: "",
+      note: throughputMerged ? "done sessions with PRs · last 7d" : "no done PR sessions · last 7d",
+      sparkline: throughputDaily,
+      title: throughputTitle,
+      neutral: throughputMerged === 0
+    }
   ];
   statsEl.innerHTML = items.map(item =>
-    '<div class="stat"><span class="stat-label">' + escapeText(item.label) + '</span>' +
+    '<div class="stat' + (item.neutral ? ' stat-neutral' : '') + '"' + (item.title ? ' title="' + escapeText(item.title) + '"' : '') + '><span class="stat-label">' + escapeText(item.label) + '</span>' +
       '<div class="stat-value"><strong>' + escapeText(item.value) + '</strong>' +
       (item.suffix ? '<span class="stat-suffix">' + escapeText(item.suffix) + '</span>' : '') + '</div>' +
       (item.sparkline ? renderStatSparkline(item.sparkline) : '') +
@@ -871,11 +880,20 @@ function renderStatSparkline(values) {
   const bars = Array.isArray(values) ? values.map(value => Number(value || 0)) : [];
   if (!bars.length) return "";
   const max = Math.max(...bars, 1);
+  const empty = bars.every(value => value === 0);
   const columns = bars.map((value, index) => {
     const height = Math.max(6, Math.round((value / max) * 28));
-    return '<span class="stat-sparkline-bar" style="height:' + height + 'px" title="Day ' + String(index + 1) + ': ' + String(value) + ' merged"></span>';
+    return '<span class="stat-sparkline-bar" style="height:' + height + 'px" title="' +
+      escapeText(throughputDayLabel(index, bars.length) + ': ' + pluralize(value, 'merged PR')) + '"></span>';
   }).join("");
-  return '<div class="stat-sparkline" aria-hidden="true">' + columns + '</div>';
+  return '<div class="stat-sparkline' + (empty ? ' stat-sparkline-empty' : '') + '" role="img" aria-label="Merged PR throughput for the last 7 days">' + columns + '</div>';
+}
+
+function throughputDayLabel(index, total) {
+  const daysAgo = Math.max(0, Number(total || 0) - Number(index || 0) - 1);
+  if (daysAgo === 0) return "today";
+  if (daysAgo === 1) return "yesterday";
+  return String(daysAgo) + " days ago";
 }
 
 function ensureSelectedProject() {


### PR DESCRIPTION
Refs #344

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a 7-day merged-PR throughput sparkline to the fleet stats panel. The stat card gains a tooltip, a neutral/muted visual state when the count is zero, human-readable day labels on bar hover, an empty-bar CSS variant, and improved `role="img"` accessibility. Tests are refactored into a table-driven suite covering zero-data, partial-window, full-window, and invalid-timestamp cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge — isolated UI enhancement with no logic errors found.

All three changed files are straightforward and self-contained. The JS logic (throughputDayLabel, empty-state detection, escaping) is correct, the CSS additions are additive, and the refactored tests improve coverage without breaking existing assertions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet_test.go | Refactors single throughput test into table-driven suite; adds zero-data, partial, and full 7-day window cases, plus invalid-timestamp coverage. |
| internal/server/web/static/fleet.js | Renames "Issue throughput" to "Merged PRs", adds tooltip, neutral/empty sparkline state, human-readable day labels, and improved aria attributes. |
| internal/server/web/static/fleet.css | Adds cursor: help for titled stat cards, muted value color for neutral state, and dimmed bar styling for the empty sparkline variant. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: clarify fleet throughput sparkline"](https://github.com/befeast/maestro/commit/0ab14b2cd30b0985c1c55fc5935ee3aba963f497) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30575085)</sub>

<!-- /greptile_comment -->