### PR TITLE
M-010: UI: add Cmd-K search across projects, sessions, issues, and PRs

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1909,6 +1909,24 @@ func TestFleetDashboardSearchIndexUsesLoadedFleetData(t *testing.T) {
 	}
 }
 
+func TestFleetDashboardSearchRanksDefaultResultsBeforeLimit(t *testing.T) {
+	body := fleetDashboardBody(t)
+	searchSnippet := dashboardSnippet(t, body, "function searchFleetResults(query)", "function searchResultID")
+	for _, want := range []string{
+		"const limit = searchTerms(query).length ? 12 : 10;",
+		"scoreFleetSearchResult(result, query)",
+		".sort((left, right) => {",
+		".slice(0, limit)",
+	} {
+		if !contains(searchSnippet, want) {
+			t.Fatalf("search results should contain %q in:\n%s", want, searchSnippet)
+		}
+	}
+	if contains(searchSnippet, "if (!searchTerms(query).length) return index.slice(0, 10);") {
+		t.Fatalf("default search results should be ranked before truncating in:\n%s", searchSnippet)
+	}
+}
+
 func TestFleetDashboardSearchKeyboardAndSelectionAreReadOnly(t *testing.T) {
 	body := fleetDashboardBody(t)
 	for _, want := range []string{
@@ -1924,6 +1942,11 @@ func TestFleetDashboardSearchKeyboardAndSelectionAreReadOnly(t *testing.T) {
 		if !contains(body, want) {
 			t.Fatalf("search keyboard support should contain %q", want)
 		}
+	}
+
+	inputKeydownSnippet := dashboardSnippet(t, body, `searchInputEl.addEventListener("keydown"`, `projectFilterEl.addEventListener`)
+	if !contains(inputKeydownSnippet, "event.stopPropagation();") {
+		t.Fatalf("search input Escape handler should stop propagation in:\n%s", inputKeydownSnippet)
 	}
 
 	selectionSnippet := dashboardSnippet(t, body, "function openSearchURL(url)", "function workerSearchText(worker)")

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1857,6 +1857,92 @@ func TestFleetDashboardCanClearProjectWorkerScope(t *testing.T) {
 	}
 }
 
+func TestFleetDashboardRendersReadOnlySearchPalette(t *testing.T) {
+	body := fleetDashboardBody(t)
+	for _, want := range []string{
+		`id="fleet-search-trigger"`,
+		`aria-controls="fleet-search-dialog"`,
+		`id="fleet-search-dialog"`,
+		`role="dialog"`,
+		`id="fleet-search-input"`,
+		`id="fleet-search-results"`,
+		`role="listbox"`,
+		"Cmd/Ctrl K",
+		"Project slug, session slot, issue #, PR #, or dashboard",
+		"No write actions run from search.",
+		"buildFleetSearchIndex",
+		"scoreFleetSearchResult",
+		"selectFleetSearchResult",
+		"fleet-search-open",
+	} {
+		if !contains(body, want) {
+			t.Fatalf("dashboard search palette should contain %q", want)
+		}
+	}
+}
+
+func TestFleetDashboardSearchIndexUsesLoadedFleetData(t *testing.T) {
+	body := fleetDashboardBody(t)
+	indexSnippet := dashboardSnippet(t, body, "function buildFleetSearchIndex()", "function fuzzySearchMatch")
+	for _, want := range []string{
+		"for (const project of fleetState.projects || [])",
+		"for (const worker of fleetState.workers || [])",
+		"for (const approval of fleetState.approvals || [])",
+		`kind: "Project"`,
+		`kind: "Dashboard"`,
+		`kind: "Session"`,
+		`kind: "Issue"`,
+		`kind: "PR"`,
+		"project.dashboard_url",
+		"const url = searchProjectURL(project);",
+		"worker.slot",
+		"worker.issue_number",
+		"worker.pr_number",
+		`searchNumberAliases("issue", worker.issue_number)`,
+		`searchNumberAliases("pr", worker.pr_number)`,
+		"approval.issue_number",
+		"approval.pr_number",
+	} {
+		if !contains(indexSnippet, want) {
+			t.Fatalf("search index should contain %q in:\n%s", want, indexSnippet)
+		}
+	}
+}
+
+func TestFleetDashboardSearchKeyboardAndSelectionAreReadOnly(t *testing.T) {
+	body := fleetDashboardBody(t)
+	for _, want := range []string{
+		"function isSearchShortcut(event)",
+		"(event.metaKey || event.ctrlKey)",
+		`toLowerCase() === "k"`,
+		"openSearchPalette();",
+		`event.key === "ArrowDown"`,
+		`event.key === "ArrowUp"`,
+		`event.key === "Enter"`,
+		`event.key === "Escape"`,
+	} {
+		if !contains(body, want) {
+			t.Fatalf("search keyboard support should contain %q", want)
+		}
+	}
+
+	selectionSnippet := dashboardSnippet(t, body, "function openSearchURL(url)", "function workerSearchText(worker)")
+	for _, want := range []string{
+		`window.open(target, "_blank", "noopener,noreferrer")`,
+		"selectWorker(result.project, result.slot)",
+		"scopeSearchProject(result.project)",
+	} {
+		if !contains(selectionSnippet, want) {
+			t.Fatalf("search selection should contain %q in:\n%s", want, selectionSnippet)
+		}
+	}
+	for _, unwanted := range []string{"fetch(", "/api/v1/fleet/actions", "renderActions", "action-btn", http.MethodPost} {
+		if contains(selectionSnippet, unwanted) {
+			t.Fatalf("search selection should not expose write behavior %q in:\n%s", unwanted, selectionSnippet)
+		}
+	}
+}
+
 func TestFleetDashboardServerRendersProjectRailFixtures(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -1866,3 +1866,205 @@
       grid-template-columns: 1fr;
     }
   }
+
+  body.fleet-search-open { overflow: hidden; }
+
+  .fleet-search-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 38px;
+    padding: 0 12px;
+    border: 1px solid var(--border-hi);
+    border-radius: 10px;
+    background: #fff;
+    color: var(--text-mute);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 650;
+  }
+
+  .fleet-search-trigger:hover,
+  .fleet-search-trigger:focus-visible {
+    border-color: var(--brand-b);
+    color: var(--brand-b);
+  }
+
+  .fleet-search-trigger kbd {
+    padding: 2px 6px;
+    border: 1px solid rgba(148,163,184,.55);
+    border-radius: 6px;
+    background: #f8fafc;
+    color: var(--muted);
+    font: 11px/1.2 var(--font-mono);
+  }
+
+  .fleet-search-backdrop[hidden],
+  .fleet-search-dialog[hidden] {
+    display: none !important;
+  }
+
+  .fleet-search-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 70;
+    background: rgba(15, 23, 42, .28);
+    backdrop-filter: blur(2px);
+  }
+
+  .fleet-search-dialog {
+    position: fixed;
+    top: min(72px, 8vh);
+    left: 50%;
+    z-index: 75;
+    width: min(740px, calc(100vw - 32px));
+    transform: translateX(-50%);
+  }
+
+  .fleet-search-shell {
+    overflow: hidden;
+    border: 1px solid rgba(148,163,184,.38);
+    border-radius: 16px;
+    background: rgba(255,255,255,.98);
+    box-shadow: 0 24px 90px rgba(15,23,42,.22);
+  }
+
+  .fleet-search-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 14px;
+    padding: 18px 20px 14px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .fleet-search-head h2 {
+    margin: 0;
+    color: var(--text);
+    font-size: 22px;
+    line-height: 1.1;
+  }
+
+  .fleet-search-input-label {
+    display: grid;
+    gap: 6px;
+    padding: 16px 20px 10px;
+  }
+
+  .fleet-search-input-label span {
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 650;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+  }
+
+  .fleet-search-input-label input {
+    width: 100%;
+    height: 48px;
+    border: 1px solid var(--border-hi);
+    border-radius: 12px;
+    background: #fff;
+    color: var(--text);
+    font: inherit;
+    font-size: 18px;
+    padding: 10px 14px;
+  }
+
+  .fleet-search-input-label input:focus {
+    outline: 2px solid rgba(5,150,105,.24);
+    border-color: rgba(5,150,105,.55);
+  }
+
+  .fleet-search-summary,
+  .fleet-search-note {
+    padding: 0 20px 10px;
+    color: var(--muted);
+    font-size: 13px;
+  }
+
+  .fleet-search-results {
+    display: grid;
+    gap: 6px;
+    max-height: min(56vh, 520px);
+    overflow: auto;
+    padding: 0 12px 12px;
+  }
+
+  .fleet-search-result {
+    display: grid;
+    grid-template-columns: 96px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    border: 1px solid transparent;
+    border-radius: 12px;
+    background: transparent;
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    padding: 11px 12px;
+    text-align: left;
+  }
+
+  .fleet-search-result:hover,
+  .fleet-search-result.is-active {
+    border-color: rgba(5,150,105,.2);
+    background: rgba(5,150,105,.07);
+  }
+
+  .fleet-search-kind {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 28px;
+    border: 1px solid rgba(148,163,184,.45);
+    border-radius: 999px;
+    background: #fff;
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 650;
+  }
+
+  .fleet-search-copy {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .fleet-search-copy strong,
+  .fleet-search-copy span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .fleet-search-copy strong {
+    font-weight: 720;
+  }
+
+  .fleet-search-copy span,
+  .fleet-search-target {
+    color: var(--muted);
+    font-size: 12px;
+  }
+
+  .fleet-search-target {
+    white-space: nowrap;
+  }
+
+  .fleet-search-empty {
+    padding: 22px 14px 26px;
+    color: var(--muted);
+    text-align: center;
+  }
+
+  @media (max-width: 700px) {
+    .fleet-search-trigger { width: 100%; justify-content: space-between; }
+    .fleet-search-dialog { top: 10px; width: calc(100vw - 20px); }
+    .fleet-search-head { align-items: stretch; flex-direction: column; }
+    .fleet-search-result { grid-template-columns: 76px minmax(0, 1fr); }
+    .fleet-search-target { grid-column: 2; }
+  }

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -757,7 +757,7 @@ function renderSearchPalette() {
   if (search.activeIndex >= search.results.length) {
     search.activeIndex = Math.max(0, search.results.length - 1);
   }
-  if (searchInputEl && searchInputEl.value !== search.query) {
+  if (searchInputEl && searchInputEl.value.trim() !== search.query) {
     searchInputEl.value = search.query;
   }
   const hasQuery = searchTerms(search.query).length > 0;

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -39,6 +39,13 @@ const workerSortEl = document.getElementById("worker-sort");
 const sortDirectionEl = document.getElementById("sort-direction");
 const initialStateEl = document.getElementById("fleet-initial-state");
 const fleetRefreshEl = document.getElementById("fleet-refresh");
+const searchTriggerEl = document.getElementById("fleet-search-trigger");
+const searchDialogEl = document.getElementById("fleet-search-dialog");
+const searchBackdropEl = document.getElementById("fleet-search-backdrop");
+const searchInputEl = document.getElementById("fleet-search-input");
+const searchResultsEl = document.getElementById("fleet-search-results");
+const searchSummaryEl = document.getElementById("fleet-search-summary");
+const searchCloseEl = document.getElementById("fleet-search-close");
 const projectDiagnosticsEl = document.getElementById("project-diagnostics");
 const expandedProjectStorageKey = "maestro.fleet.expandedProject";
 
@@ -84,7 +91,13 @@ const fleetState = {
   detail: null,
   operatorBrief: null,
   verdict: null,
-  refreshedAt: ""
+  refreshedAt: "",
+  search: {
+    open: false,
+    query: "",
+    activeIndex: 0,
+    results: []
+  }
 };
 
 loadStateFromQuery();
@@ -504,6 +517,335 @@ function syncFilterControls() {
 
 function normalizedSearchText(value) {
   return String(value ?? "").trim().toLowerCase();
+}
+
+function compactSearchText(value) {
+  return normalizedSearchText(value).replace(/[^a-z0-9]+/g, "");
+}
+
+function searchTerms(value) {
+  return normalizedSearchText(value).split(/\s+/).filter(Boolean);
+}
+
+function searchTokens(value) {
+  return normalizedSearchText(value).split(/[^a-z0-9#]+/).map(compactSearchText).filter(Boolean);
+}
+
+function searchNumberAliases(label, number) {
+  const value = Number(number || 0);
+  if (!Number.isFinite(value) || value <= 0) return [];
+  const text = String(value);
+  const prefix = String(label || "").trim();
+  return [text, "#" + text, prefix + " " + text, prefix + " #" + text, prefix + text];
+}
+
+function searchMetaText(parts) {
+  return parts.map(value => String(value ?? "").trim()).filter(Boolean).join(" · ");
+}
+
+function makeFleetSearchResult(input) {
+  const terms = input.terms || [];
+  const text = [input.kind, input.title, input.meta, input.project, input.slot, input.url].concat(terms).map(normalizedSearchText).join(" ");
+  return {
+    id: input.id,
+    kind: input.kind,
+    title: input.title,
+    meta: input.meta || "",
+    action: input.action || "url",
+    url: input.url || "",
+    project: input.project || "",
+    slot: input.slot || "",
+    rank: Number(input.rank || 0),
+    searchText: text,
+    searchCompact: compactSearchText(text),
+    tokens: new Set(searchTokens(text))
+  };
+}
+
+function addFleetSearchResult(results, seen, input) {
+  if (!input || !input.id || seen.has(input.id)) return;
+  seen.add(input.id);
+  results.push(makeFleetSearchResult(input));
+}
+
+function searchProjectURL(project) {
+  return (project && project.dashboard_url) || githubRepoURL(project && project.repo) || "";
+}
+
+function buildFleetSearchIndex() {
+  const results = [];
+  const seen = new Set();
+  for (const project of fleetState.projects || []) {
+    const name = project.name || "project";
+    const url = searchProjectURL(project);
+    addFleetSearchResult(results, seen, {
+      id: "project:" + name,
+      kind: "Project",
+      title: name,
+      meta: searchMetaText([project.repo, projectStateLabel(project), project.operator_state && project.operator_state.summary]),
+      action: url ? "url" : "project",
+      url,
+      project: name,
+      rank: 40,
+      terms: ["project", "slug", project.config_path, projectSearchText(project)]
+    });
+    if (project.dashboard_url) {
+      addFleetSearchResult(results, seen, {
+        id: "dashboard:" + name,
+        kind: "Dashboard",
+        title: name + " dashboard",
+        meta: searchMetaText([project.repo, project.dashboard_url]),
+        action: "url",
+        url: project.dashboard_url,
+        project: name,
+        rank: 35,
+        terms: ["dashboard", "project dashboard", name, project.repo]
+      });
+    }
+  }
+
+  for (const worker of fleetState.workers || []) {
+    const project = worker.project_name || "";
+    const slot = worker.slot || "";
+    const issueAliases = searchNumberAliases("issue", worker.issue_number);
+    const prAliases = searchNumberAliases("pr", worker.pr_number);
+    const workerRank = (worker.needs_attention ? 70 : 0) + (worker.live ? 55 : 20);
+    addFleetSearchResult(results, seen, {
+      id: "session:" + project + ":" + slot,
+      kind: "Session",
+      title: searchMetaText([project, slot]) || "Worker session",
+      meta: searchMetaText([
+        worker.issue_number ? "Issue #" + worker.issue_number : "No issue",
+        worker.pr_number ? "PR #" + worker.pr_number : "No PR",
+        statusLabel(worker)
+      ]),
+      action: "worker",
+      project,
+      slot,
+      rank: workerRank,
+      terms: ["worker", "session", workerSearchText(worker)].concat(issueAliases, prAliases)
+    });
+    if (worker.issue_number) {
+      addFleetSearchResult(results, seen, {
+        id: "issue:" + project + ":" + worker.issue_number + ":" + slot,
+        kind: "Issue",
+        title: "Issue #" + worker.issue_number,
+        meta: searchMetaText([project, slot, worker.issue_title]),
+        action: worker.issue_url ? "url" : "worker",
+        url: worker.issue_url || "",
+        project,
+        slot,
+        rank: workerRank - 5,
+        terms: [worker.issue_title, workerSearchText(worker)].concat(issueAliases)
+      });
+    }
+    if (worker.pr_number) {
+      addFleetSearchResult(results, seen, {
+        id: "pr:" + project + ":" + worker.pr_number + ":" + slot,
+        kind: "PR",
+        title: "PR #" + worker.pr_number,
+        meta: searchMetaText([project, slot, worker.issue_number ? "Issue #" + worker.issue_number : ""]),
+        action: worker.pr_url ? "url" : "worker",
+        url: worker.pr_url || "",
+        project,
+        slot,
+        rank: workerRank - 10,
+        terms: [worker.issue_title, workerSearchText(worker)].concat(prAliases)
+      });
+    }
+  }
+
+  for (const approval of fleetState.approvals || []) {
+    const targets = [];
+    if (approval.issue_number) targets.push("Issue #" + approval.issue_number);
+    if (approval.pr_number) targets.push("PR #" + approval.pr_number);
+    if (approval.session) targets.push("Session " + approval.session);
+    const project = approval.project_name || "";
+    addFleetSearchResult(results, seen, {
+      id: "approval:" + (approval.id || targets.join(":")),
+      kind: "Approval",
+      title: targets.length ? "Approval " + targets.join(" / ") : "Approval " + (approval.id || "target"),
+      meta: searchMetaText([project, actionLabel(approval.action), approval.status, approval.summary]),
+      action: approval.pr_url || approval.issue_url ? "url" : (approval.session ? "worker" : "project"),
+      url: approval.pr_url || approval.issue_url || approval.dashboard_url || "",
+      project,
+      slot: approval.session || "",
+      rank: approval.status === "pending" ? 65 : 15,
+      terms: [approval.id, approval.decision_id, approval.summary, approval.action]
+        .concat(searchNumberAliases("issue", approval.issue_number), searchNumberAliases("pr", approval.pr_number))
+    });
+  }
+  return results;
+}
+
+function fuzzySearchMatch(haystack, needle) {
+  if (!needle) return true;
+  let index = 0;
+  for (const ch of haystack) {
+    if (ch === needle[index]) index++;
+    if (index === needle.length) return true;
+  }
+  return false;
+}
+
+function scoreFleetSearchResult(result, query) {
+  const terms = searchTerms(query);
+  if (!terms.length) return result.rank;
+  let score = result.rank;
+  for (const term of terms) {
+    const normalized = normalizedSearchText(term);
+    const compact = compactSearchText(term);
+    if (!compact) continue;
+    if (result.tokens.has(compact)) {
+      score += 100;
+    } else if (result.searchText.includes(normalized)) {
+      score += 75;
+    } else if (result.searchCompact.includes(compact)) {
+      score += 55;
+    } else if (fuzzySearchMatch(result.searchCompact, compact)) {
+      score += 20;
+    } else {
+      return -1;
+    }
+  }
+  return score;
+}
+
+function searchFleetResults(query) {
+  const index = buildFleetSearchIndex();
+  if (!searchTerms(query).length) return index.slice(0, 10);
+  return index.map(result => ({ result, score: scoreFleetSearchResult(result, query) }))
+    .filter(entry => entry.score >= 0)
+    .sort((left, right) => {
+      if (left.score !== right.score) return right.score - left.score;
+      return compareText(left.result.title, right.result.title);
+    })
+    .slice(0, 12)
+    .map(entry => entry.result);
+}
+
+function searchResultID(index) {
+  return "fleet-search-result-" + index;
+}
+
+function searchResultActionText(result) {
+  if (result.action === "worker") return "Opens worker detail";
+  if (result.action === "project") return "Scopes worker table";
+  return "Opens link";
+}
+
+function searchResultHTML(result, index) {
+  const active = index === fleetState.search.activeIndex;
+  const cls = "fleet-search-result" + (active ? " is-active" : "");
+  return '<button type="button" id="' + searchResultID(index) + '" class="' + cls + '" role="option" aria-selected="' + (active ? "true" : "false") + '" data-search-result="' + index + '">' +
+    '<span class="fleet-search-kind">' + escapeText(result.kind) + '</span>' +
+    '<span class="fleet-search-copy"><strong>' + escapeText(result.title) + '</strong>' +
+      '<span>' + escapeText(result.meta || searchResultActionText(result)) + '</span></span>' +
+    '<span class="fleet-search-target">' + escapeText(searchResultActionText(result)) + '</span>' +
+  '</button>';
+}
+
+function renderSearchPalette() {
+  if (!searchDialogEl || !searchBackdropEl || !searchResultsEl || !searchSummaryEl) return;
+  const search = fleetState.search;
+  searchDialogEl.hidden = !search.open;
+  searchBackdropEl.hidden = !search.open;
+  document.body.classList.toggle("fleet-search-open", search.open);
+  if (!search.open) return;
+
+  search.results = searchFleetResults(search.query);
+  if (search.activeIndex >= search.results.length) {
+    search.activeIndex = Math.max(0, search.results.length - 1);
+  }
+  if (searchInputEl && searchInputEl.value !== search.query) {
+    searchInputEl.value = search.query;
+  }
+  const hasQuery = searchTerms(search.query).length > 0;
+  searchSummaryEl.textContent = search.results.length
+    ? (hasQuery ? search.results.length + " result" + (search.results.length === 1 ? "" : "s") : "Top loaded fleet results")
+    : (hasQuery ? "No matching loaded fleet data" : "Type to search projects, sessions, issues, PRs, and dashboards");
+  searchResultsEl.innerHTML = search.results.length
+    ? search.results.map(searchResultHTML).join("")
+    : '<div class="fleet-search-empty" role="status">No matching projects, sessions, issues, or PRs are loaded in this fleet snapshot.</div>';
+
+  if (searchInputEl) {
+    if (search.results.length) searchInputEl.setAttribute("aria-activedescendant", searchResultID(search.activeIndex));
+    else searchInputEl.removeAttribute("aria-activedescendant");
+  }
+  searchResultsEl.querySelectorAll("button[data-search-result]").forEach(button => {
+    button.addEventListener("click", () => {
+      const result = search.results[Number(button.dataset.searchResult || 0)];
+      selectFleetSearchResult(result);
+    });
+  });
+}
+
+function openSearchPalette() {
+  if (!searchDialogEl) return;
+  fleetState.search.open = true;
+  fleetState.search.activeIndex = 0;
+  renderSearchPalette();
+  window.setTimeout(() => {
+    if (searchInputEl) {
+      searchInputEl.focus();
+      searchInputEl.select();
+    }
+  }, 0);
+}
+
+function closeSearchPalette(returnFocus) {
+  fleetState.search.open = false;
+  renderSearchPalette();
+  if (returnFocus !== false && searchTriggerEl) searchTriggerEl.focus();
+}
+
+function isSearchShortcut(event) {
+  return !event.defaultPrevented && (event.metaKey || event.ctrlKey) && !event.altKey && String(event.key || "").toLowerCase() === "k";
+}
+
+function scrollSearchActiveResultIntoView() {
+  const active = document.getElementById(searchResultID(fleetState.search.activeIndex));
+  if (active) active.scrollIntoView({ block: "nearest" });
+}
+
+function moveSearchActive(delta) {
+  const count = fleetState.search.results.length;
+  if (!count) return;
+  fleetState.search.activeIndex = (fleetState.search.activeIndex + delta + count) % count;
+  renderSearchPalette();
+  scrollSearchActiveResultIntoView();
+}
+
+function openSearchURL(url) {
+  const target = String(url || "").trim();
+  if (!target) return false;
+  window.open(target, "_blank", "noopener,noreferrer");
+  return true;
+}
+
+function scopeSearchProject(projectName) {
+  if (!projectName) return false;
+  fleetState.selectedProject = projectName;
+  updateQueryState();
+  renderFleetWorkers();
+  document.querySelector(".fleet-workers")?.scrollIntoView({ block: "start", behavior: "smooth" });
+  return true;
+}
+
+function selectFleetSearchResult(result) {
+  if (!result) return;
+  closeSearchPalette(false);
+  if (result.action === "worker" && result.project && result.slot) {
+    selectWorker(result.project, result.slot);
+    return;
+  }
+  if (result.action === "project" && scopeSearchProject(result.project)) return;
+  if (openSearchURL(result.url)) return;
+  if (result.project && result.slot) {
+    selectWorker(result.project, result.slot);
+    return;
+  }
+  scopeSearchProject(result.project);
 }
 
 function workerSearchText(worker) {
@@ -1744,6 +2086,31 @@ function clearWorkerProjectScope() {
 
 workerProjectResetEl.addEventListener("click", clearWorkerProjectScope);
 if (fleetRefreshEl) fleetRefreshEl.addEventListener("click", loadFleet);
+if (searchTriggerEl) searchTriggerEl.addEventListener("click", openSearchPalette);
+if (searchCloseEl) searchCloseEl.addEventListener("click", () => closeSearchPalette());
+if (searchBackdropEl) searchBackdropEl.addEventListener("click", () => closeSearchPalette());
+if (searchInputEl) {
+  searchInputEl.addEventListener("input", () => {
+    fleetState.search.query = searchInputEl.value.trim();
+    fleetState.search.activeIndex = 0;
+    renderSearchPalette();
+  });
+  searchInputEl.addEventListener("keydown", event => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveSearchActive(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveSearchActive(-1);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      selectFleetSearchResult(fleetState.search.results[fleetState.search.activeIndex]);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      closeSearchPalette();
+    }
+  });
+}
 
 projectFilterEl.addEventListener("input", () => {
   fleetState.projectQuery = projectFilterEl.value.trim();
@@ -1797,6 +2164,16 @@ sortDirectionEl.addEventListener("click", () => {
 workerDetailCloseEl.addEventListener("click", closeWorkerDetail);
 workerDetailBackdropEl.addEventListener("click", closeWorkerDetail);
 document.addEventListener("keydown", event => {
+  if (isSearchShortcut(event)) {
+    event.preventDefault();
+    openSearchPalette();
+    return;
+  }
+  if (event.key === "Escape" && fleetState.search.open) {
+    event.preventDefault();
+    closeSearchPalette();
+    return;
+  }
   if (event.key === "Escape" && fleetState.selectedWorkerKey) {
     closeWorkerDetail();
   }
@@ -1841,6 +2218,7 @@ function applyFleetData(data) {
   renderAttentionInbox();
   renderNeedsYouRail();
   renderFleetWorkers();
+  if (fleetState.search.open) renderSearchPalette();
   const needsDetailLoad = fleetState.selectedWorkerKey && (!fleetState.detail || !fleetState.detail.worker || workerKey(fleetState.detail.worker) !== fleetState.selectedWorkerKey);
   if (needsDetailLoad) {
     const worker = selectedWorker();

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -713,14 +713,14 @@ function scoreFleetSearchResult(result, query) {
 
 function searchFleetResults(query) {
   const index = buildFleetSearchIndex();
-  if (!searchTerms(query).length) return index.slice(0, 10);
+  const limit = searchTerms(query).length ? 12 : 10;
   return index.map(result => ({ result, score: scoreFleetSearchResult(result, query) }))
     .filter(entry => entry.score >= 0)
     .sort((left, right) => {
       if (left.score !== right.score) return right.score - left.score;
       return compareText(left.result.title, right.result.title);
     })
-    .slice(0, 12)
+    .slice(0, limit)
     .map(entry => entry.result);
 }
 
@@ -2107,6 +2107,7 @@ if (searchInputEl) {
       selectFleetSearchResult(fleetState.search.results[fleetState.search.activeIndex]);
     } else if (event.key === "Escape") {
       event.preventDefault();
+      event.stopPropagation();
       closeSearchPalette();
     }
   });

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -31,10 +31,30 @@
   </div>
   <div class="header-actions">
     <span class="mode-pill">Read-only</span>
+    <button type="button" class="fleet-search-trigger" id="fleet-search-trigger" aria-haspopup="dialog" aria-controls="fleet-search-dialog"><span>Search</span><kbd>Cmd/Ctrl K</kbd></button>
     <button type="button" class="refresh-button" id="fleet-refresh" aria-label="Refresh fleet data">↻</button>
     <span class="user-chip" aria-label="Operator ko">ko</span>
   </div>
 </header>
+<div class="fleet-search-backdrop" id="fleet-search-backdrop" hidden></div>
+<section class="fleet-search-dialog" id="fleet-search-dialog" role="dialog" aria-modal="true" aria-labelledby="fleet-search-title" hidden>
+  <div class="fleet-search-shell">
+    <div class="fleet-search-head">
+      <div>
+        <h2 id="fleet-search-title">Search Fleet</h2>
+        <div class="sub">Jump to projects, sessions, issues, PRs, and dashboards from loaded data.</div>
+      </div>
+      <button type="button" class="drawer-close-button" id="fleet-search-close" aria-label="Close search palette">Close</button>
+    </div>
+    <label class="fleet-search-input-label" for="fleet-search-input">
+      <span>Search</span>
+      <input id="fleet-search-input" type="search" autocomplete="off" placeholder="Project slug, session slot, issue #, PR #, or dashboard" role="combobox" aria-expanded="true" aria-controls="fleet-search-results">
+    </label>
+    <div class="fleet-search-summary" id="fleet-search-summary">Type to search loaded fleet data.</div>
+    <div class="fleet-search-results" id="fleet-search-results" role="listbox" aria-label="Fleet search results"></div>
+    <div class="fleet-search-note">Read-only search only. No write actions run from search.</div>
+  </div>
+</section>
 <main>
   <section class="fleet-verdict-shell" aria-live="polite" aria-label="Global operator brief">
     <div class="fleet-verdict verdict-healthy" id="fleet-verdict">Loading global operator brief...</div>


### PR DESCRIPTION
Refs #345

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Cmd/Ctrl-K search palette to the fleet dashboard covering projects, sessions, issues, PRs, and dashboards, built entirely from loaded state with no write actions. Both issues raised in the previous review round (`event.stopPropagation()` on the input Escape handler and the `.trim()` sync guard in `renderSearchPalette`) are correctly implemented in this version.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic bugs identified; previously flagged issues are resolved.

No P0 or P1 findings. Both concerns from the prior review thread are addressed: stopPropagation is in place on the input Escape handler (line 2110), and the renderSearchPalette sync guard correctly uses .trim() comparison (line 760) to avoid overwriting trailing spaces mid-typing. Test coverage is thorough across palette rendering, index content, ranking order, and read-only selection invariants.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet_test.go | Adds four focused tests covering palette rendering, search index content, ranking/truncation order, and keyboard/selection read-only invariants — good coverage of the new feature. |
| internal/server/web/static/fleet.css | Adds search palette styles — backdrop, dialog, input, result rows, and responsive overrides — scoped cleanly to new BEM classes with no collisions. |
| internal/server/web/static/fleet.js | Adds full search palette logic: index building, fuzzy scoring, render/open/close lifecycle, keyboard navigation, and result selection — both previously flagged issues (stopPropagation and trim guard) are correctly addressed in this version. |
| internal/server/web/templates/fleet.html | Adds the search trigger button and dialog markup with proper ARIA attributes (role=dialog, aria-modal, aria-labelledby, combobox/listbox pattern). |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: normalize fleet search palette inpu..."](https://github.com/befeast/maestro/commit/c2885f09a6f0764ab4dce4883afca499196fb74f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30575652)</sub>

<!-- /greptile_comment -->