### PR TITLE
fix: restore fleet brand mark

### DIFF
--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -2563,3 +2563,12 @@
   body[data-page="fleet"] .project-rail-outcome-cell { width: 23%; }
   body[data-page="fleet"] .project-rail-freshness-cell { width: 9%; }
   body[data-page="fleet"] .project-rail-links-cell { width: 6%; }
+
+  body[data-page="fleet"] .brand-mark {
+    display: block;
+    width: 34px;
+    height: 34px;
+    border-radius: 0;
+    background: transparent;
+    object-fit: contain;
+  }

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -17,13 +17,13 @@
 <link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
 <link rel="stylesheet" href="/static/tokens.css?v=20260503-2">
 <link rel="stylesheet" href="/static/components.css?v=20260503-2">
-<link rel="stylesheet" href="/static/fleet.css?v=20260503-4">
+<link rel="stylesheet" href="/static/fleet.css?v=20260503-5">
 
 </head>
 <body data-page="fleet">
 <header class="fleet-header">
   <div class="brand-heading">
-    <span class="brand-mark brand-mark-letter" aria-hidden="true">M</span>
+    <img class="brand-mark" src="/static/maestro-mark.svg" alt="" aria-hidden="true">
     <div>
       <h1 aria-label="Maestro Fleet"><span>Maestro</span><span class="title-slash">/</span><span>Fleet</span></h1>
       <div class="sub" id="subtitle">Loading projects...</div>
@@ -207,7 +207,7 @@
   </section>
 </main>
 <script type="application/json" id="fleet-initial-state">{{FLEET_INITIAL_STATE}}</script>
-<script src="/static/fleet.js?v=20260503-4"></script>
+<script src="/static/fleet.js?v=20260503-5"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Restores the real Maestro brand mark in the Fleet header after the light-reference pass accidentally replaced it with the mock placeholder M. Keeps the compact light-theme sizing and cache-busts Fleet assets.\n\nVerification:\n- bun build internal/server/web/static/fleet.js --target=browser --outfile=/tmp/maestro-fleet-check.js\n- go test ./internal/server ./cmd/maestro\n- go test ./...\n- go build ./cmd/maestro\n- live screenshot on workshop

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores the real `maestro-mark.svg` brand mark in the Fleet header, replacing the accidental placeholder `M` span introduced during a previous light-theme pass. The SVG asset exists at `internal/server/web/static/maestro-mark.svg`, the new CSS rules size it correctly, and the cache-bust version is bumped consistently across both CSS and JS references.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted fix with the referenced asset confirmed present and no logic regressions.

Both changed files are straightforward: the HTML swaps a placeholder span for an existing SVG image, and the CSS scopes the sizing rule to the fleet page. The maestro-mark.svg asset is confirmed present in the static directory. Cache-bust versions are incremented consistently. No logic, security, or data issues identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/web/templates/fleet.html | Replaces the placeholder <span>M</span> brand mark with the real <img src="/static/maestro-mark.svg"> and bumps the CSS/JS cache-bust version to v5. |
| internal/server/web/static/fleet.css | Adds fleet-page-scoped .brand-mark styles (34x34px, no border-radius, transparent background, object-fit: contain) to size the restored SVG correctly. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: restore fleet brand mark"](https://github.com/befeast/maestro/commit/df4d94481b0cf4bc1abcf05848ee1484fd90a345) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30594333)</sub>

<!-- /greptile_comment -->