### PR TITLE
M-002: UI: hide approval-gated controls in read-only mode

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -2128,11 +2128,14 @@ func TestFleetDashboardServesApprovalAuditPath(t *testing.T) {
 func TestFleetDashboardReadOnlyProjectControlsRenderQuietNote(t *testing.T) {
 	body := fleetDashboardBody(t)
 	readOnlyBranch := dashboardSnippet(t, body,
-		"if (project.read_only === true)",
+		"if (project.read_only === true || fleetState.readOnly)",
 		"return '<div class=\"project-actions\"><div class=\"label\">Approval-gated controls</div>'")
 
-	if !contains(readOnlyBranch, "Write controls are disabled in read-only mode.") {
-		t.Fatalf("read-only project controls should render disabled-write explanation, got:\n%s", readOnlyBranch)
+	if !contains(readOnlyBranch, "Write controls disabled in read-only mode.") {
+		t.Fatalf("read-only project controls should render disabled-write footer, got:\n%s", readOnlyBranch)
+	}
+	if !contains(readOnlyBranch, "project-actions-readonly") {
+		t.Fatalf("read-only project controls should use project-actions-readonly class, got:\n%s", readOnlyBranch)
 	}
 	for _, unwanted := range []string{"action-btn", "<button", "renderActions("} {
 		if contains(readOnlyBranch, unwanted) {

--- a/internal/server/web/static/dashboard.css
+++ b/internal/server/web/static/dashboard.css
@@ -280,6 +280,12 @@
   }
   .action-detail strong { color: var(--text); font-weight: 650; }
   .action-note { margin-top: 6px; color: var(--muted); }
+  .project-actions-readonly {
+    margin-top: 8px;
+    color: var(--muted);
+    font-style: italic;
+    font-size: 12px;
+  }
   .supervisor-empty { color: var(--muted); }
   pre {
     margin: 0;

--- a/internal/server/web/static/dashboard.js
+++ b/internal/server/web/static/dashboard.js
@@ -4,7 +4,8 @@ const state = {
   outcome: null,
   selected: "",
   filter: "",
-  lastLog: null
+  lastLog: null,
+  readOnly: true
 };
 
 const statusRank = {
@@ -164,6 +165,9 @@ function renderActionButtons(actions, showDetails) {
 }
 
 function renderWorkerActions(actions) {
+  if (state.readOnly) {
+    return '<div class="project-actions-readonly">Write controls disabled in read-only mode.</div>';
+  }
   if (!actions || !actions.length) return "";
   return '<div class="worker-actions"><span>Actions</span>' + renderActionButtons(actions, false) + '</div>' +
     '<div class="action-note">' + escapeText(actionDisabledReason(actions)) + '</div>';
@@ -389,6 +393,7 @@ async function loadState() {
 	state.workers = data.all || [];
 	state.supervisor = data.supervisor || null;
 	state.outcome = data.outcome || null;
+	state.readOnly = data.read_only !== false;
 	renderStats(data.summary || {}, state.workers.length, data.max_parallel || 0, data.read_only);
 	renderSupervisor(state.supervisor);
 	renderOutcome(state.outcome);

--- a/internal/server/web/static/dashboard.js
+++ b/internal/server/web/static/dashboard.js
@@ -393,7 +393,7 @@ async function loadState() {
 	state.workers = data.all || [];
 	state.supervisor = data.supervisor || null;
 	state.outcome = data.outcome || null;
-	state.readOnly = data.read_only !== false;
+	state.readOnly = data.read_only === true;
 	renderStats(data.summary || {}, state.workers.length, data.max_parallel || 0, data.read_only);
 	renderSupervisor(state.supervisor);
 	renderOutcome(state.outcome);

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -1021,6 +1021,13 @@
   }
   .action-detail strong { color: var(--text); font-weight: 650; }
   .action-note { margin-top: 6px; color: var(--muted); font-size: 12px; white-space: normal; }
+  .project-actions-readonly {
+    padding: 8px 14px;
+    border-bottom: 1px solid var(--line);
+    color: var(--fg-3, var(--muted));
+    font-style: italic;
+    font-size: 12px;
+  }
   .more-row {
     margin-top: 7px;
     color: var(--muted);

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -2175,7 +2175,7 @@ document.addEventListener("keydown", event => {
 });
 
 function applyFleetData(data) {
-  fleetState.readOnly = data.read_only !== false;
+  fleetState.readOnly = data.read_only === true;
   fleetState.refreshedAt = data.refreshed_at || "";
   fleetState.summary = data.summary || {};
   fleetState.projects = data.projects || [];

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -1779,11 +1779,14 @@ function renderWorkerDetail(data) {
     ? (log.truncated ? "tail, " : "") + (log.updated_at || "")
     : "unavailable";
 
+  const workerActionsHTML = fleetState.readOnly
+    ? '<div class="project-actions-readonly">Write controls disabled in read-only mode.</div>'
+    : '<div class="project-actions"><div class="label">Approval-gated controls</div>' + renderActions(worker.actions || [], { details: false }) + '</div>';
   workerDetailBodyEl.innerHTML = '<div class="detail-grid">' + fields + '</div>' +
     '<div class="' + noteClass + '"><strong>State</strong> ' + escapeText(reason) +
       (links.length ? '<div class="detail-links">' + links.join("") + '</div>' : "") +
     '</div>' +
-    '<div class="project-actions"><div class="label">Approval-gated controls</div>' + renderActions(worker.actions || [], { details: false }) + '</div>' +
+    workerActionsHTML +
     '<div class="log-tail">' +
       '<div class="log-tail-head"><strong>Recent log tail</strong><span>' + escapeText(logMeta) + '</span></div>' +
       '<pre>' + escapeText(logText) + '</pre>' +
@@ -1975,8 +1978,8 @@ function renderWorkers(project) {
 }
 
 function renderProjectActions(project) {
-  if (project.read_only === true) {
-    return '<div class="project-actions"><div class="action-note">Write controls are disabled in read-only mode.</div></div>';
+  if (project.read_only === true || fleetState.readOnly) {
+    return '<div class="project-actions-readonly">Write controls disabled in read-only mode.</div>';
   }
   return '<div class="project-actions"><div class="label">Approval-gated controls</div>' +
     renderActions(project.actions || [], { details: false }) + '</div>';


### PR DESCRIPTION
## Summary
- Replaces per-project / per-worker "Approval-gated controls" buttons with a single italic footer line "Write controls disabled in read-only mode." when the dashboard is read-only.
- Adds `.project-actions-readonly` CSS rule in `fleet.css` and `dashboard.css`.
- Server-side action records are left untouched — the change is render-only so the underlying state still flows for the eventual V2.

Implements §10 backlog item M-002 of the Maestro UI Audit (May 2026).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/server/...` passes
- [ ] Visit `/fleet` in read-only mode — confirm no Mark ready / Mark blocked buttons render and the italic footer appears in their place

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces per-project and per-worker "Approval-gated controls" buttons with a single italic "Write controls disabled in read-only mode." footer when the dashboard is in read-only mode. The previously flagged `data.read_only !== false` guard in `fleet.js` is correctly fixed to `=== true`, and `dashboard.js` adopts the same strict comparison, making both files consistent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are render-only, no server-side state is affected, and the previously flagged fail-open guard is now fixed.

No P0 or P1 findings. The main regression risk (fail-open `!== false` guard) is addressed. Both JS files use the same `=== true` strict check on assignment and share the same fail-closed `readOnly: true` initial default, which is an existing, consistent pattern in the codebase. CSS additions are additive and scoped to the new class.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/server/fleet_test.go | Test updated to reflect new class name `project-actions-readonly`, new message text, and the expanded OR condition; coverage looks correct. |
| internal/server/web/static/dashboard.js | Adds `readOnly: true` initial state, guards `renderWorkerActions` behind `state.readOnly`, and correctly uses `=== true` on assignment from the API response. |
| internal/server/web/static/fleet.js | Fixes previously flagged `!== false` → `=== true` assignment; `renderProjectActions` and `renderWorkerDetail` now branch on `fleetState.readOnly` with the new CSS class. |
| internal/server/web/static/dashboard.css | Adds `.project-actions-readonly` rule with muted, italic, small-font styling; no issues. |
| internal/server/web/static/fleet.css | Adds `.project-actions-readonly` rule with padding and border; uses CSS variable fallback `var(--fg-3, var(--muted))`; no issues. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/server/web/static/fleet.js`, line 2178 ([link](https://github.com/befeast/maestro/blob/81525d838a511d77838a7104514a81f32647bfdb/internal/server/web/static/fleet.js#L2178)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Same fail-closed default as `dashboard.js`**

   `data.read_only !== false` will be `true` whenever `read_only` is absent or null, permanently hiding all project and worker action controls without any visible error. `renderProjectActions` and `renderWorkerDetail` both branch on `fleetState.readOnly`, so the impact here is wider than in the dashboard. Using `=== true` keeps the guard consistent with the per-project strict check already present in the condition on line 1981.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/web/static/fleet.js
   Line: 2178

   Comment:
   **Same fail-closed default as `dashboard.js`**

   `data.read_only !== false` will be `true` whenever `read_only` is absent or null, permanently hiding all project and worker action controls without any visible error. `renderProjectActions` and `renderWorkerDetail` both branch on `fleetState.readOnly`, so the impact here is wider than in the dashboard. Using `=== true` keeps the guard consistent with the per-project strict check already present in the condition on line 1981.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: keep read-only detection explicit"](https://github.com/befeast/maestro/commit/147f86e840deb17637f79045835b1f529cf9522b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30596568)</sub>

<!-- /greptile_comment -->