### PR TITLE
M-003: UI: collapse worker history into a single expandable group

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1818,13 +1818,14 @@ func TestFleetDashboard(t *testing.T) {
 func TestFleetDashboardRendersHistoryCollapseControls(t *testing.T) {
 	body := fleetDashboardBody(t)
 	for _, want := range []string{
-		"function historySummaryRowHTML(workers)",
+		"function historySummaryRowHTML(workers, expanded)",
+		"function historySummaryText(count, expanded)",
 		"function toggleWorkerHistoryRows(button)",
 		"worker-history-summary-row",
 		"worker-history-row",
 		"data-history-toggle",
-		"aria-expanded=\"false\"",
-		"click to expand",
+		"aria-expanded=\"",
+		"click to \" + (expanded ? \"collapse\" : \"expand\")",
 		"history collapsed",
 		"hasWorkerDrilldownFilters",
 		"worker.live === true",

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1819,12 +1819,15 @@ func TestFleetDashboardRendersHistoryCollapseControls(t *testing.T) {
 	body := fleetDashboardBody(t)
 	for _, want := range []string{
 		"function historySummaryRowHTML(workers)",
-		"class=\"history-row\"",
-		"data-history-scope=\"recent\"",
+		"function toggleWorkerHistoryRows(button)",
+		"worker-history-summary-row",
+		"worker-history-row",
+		"data-history-toggle",
+		"aria-expanded=\"false\"",
+		"click to expand",
 		"history collapsed",
 		"hasWorkerDrilldownFilters",
 		"worker.live === true",
-		"Search or switch scope to inspect every session.",
 	} {
 		if !contains(body, want) {
 			t.Fatalf("dashboard history collapse renderer should contain %q", want)

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -846,6 +846,35 @@
     padding: 5px 10px;
   }
   .history-row-action:hover { border-color: rgba(88,166,255,.65); }
+  .history-row-toggle {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+  .history-row-toggle:hover { color: var(--accent); }
+  .history-row-toggle .history-row-toggle-caret {
+    display: inline-block;
+    transition: transform 120ms ease;
+    color: var(--muted);
+    font-size: 11px;
+  }
+  .history-row-toggle[aria-expanded="true"] .history-row-toggle-caret {
+    transform: rotate(90deg);
+  }
+  .worker-table tbody tr.worker-history-row {
+    background: var(--bg-2, rgba(139,148,158,.04));
+    color: var(--muted);
+  }
+  .worker-table tbody tr.worker-history-summary-row td {
+    border-top: 1px solid var(--line);
+  }
   .project-col { width: 140px; font-weight: 650; }
   .slot-col { width: 92px; font-family: var(--font-mono); }
   .issue-col { width: auto; }

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -1583,12 +1583,14 @@ function renderFleetWorkers() {
     return;
   }
 
-  const rows = visible.map(worker => {
+  const renderRow = (worker, extraClass) => {
     const pr = worker.pr_number ? "#" + worker.pr_number : "-";
     const project = worker.project_name || "-";
     const issueText = issueSummaryText(worker);
     const selected = workerKey(worker) === fleetState.selectedWorkerKey ? " selected" : "";
-    return '<tr class="' + rowClass(worker) + selected + '" data-project="' + escapeText(worker.project_name || "") + '" data-slot="' + escapeText(worker.slot || "") + '" tabindex="0">' +
+    const cls = rowClass(worker) + selected + (extraClass ? " " + extraClass : "");
+    const hiddenAttr = extraClass === "worker-history-row" ? ' hidden' : '';
+    return '<tr class="' + cls + '" data-project="' + escapeText(worker.project_name || "") + '" data-slot="' + escapeText(worker.slot || "") + '" tabindex="0"' + hiddenAttr + '>' +
       '<td class="project-col" title="' + escapeText(project) + '">' + linkHTML(worker.dashboard_url, project) + '</td>' +
       '<td class="slot-col" title="' + escapeText(worker.slot || "-") + '">' + escapeText(worker.slot || "-") + '</td>' +
       '<td class="issue-col" title="' + escapeText(issueText) + '">' + issueSummaryHTML(worker) + workerWhyHTML(worker) + '</td>' +
@@ -1599,9 +1601,11 @@ function renderFleetWorkers() {
       '<td class="tokens-col">' + compactNumber(worker.tokens_used_total) + '</td>' +
       '<td class="action-col">' + renderActions(worker.actions || [], { details: false }) + '</td>' +
     '</tr>';
-  });
+  };
+  const rows = visible.map(worker => renderRow(worker, ""));
   if (hiddenHistory.length) {
     rows.push(historySummaryRowHTML(hiddenHistory));
+    hiddenHistory.forEach(worker => rows.push(renderRow(worker, "worker-history-row")));
   }
   fleetWorkersEl.innerHTML = rows.join("");
 
@@ -1612,6 +1616,12 @@ function renderFleetWorkers() {
         event.preventDefault();
         selectWorker(row.dataset.project || "", row.dataset.slot || "");
       }
+    });
+  });
+  fleetWorkersEl.querySelectorAll("button[data-history-toggle]").forEach(button => {
+    button.addEventListener("click", event => {
+      event.stopPropagation();
+      toggleWorkerHistoryRows(button);
     });
   });
   fleetWorkersEl.querySelectorAll("button[data-history-scope]").forEach(button => {
@@ -1629,11 +1639,28 @@ function renderFleetWorkers() {
 function historySummaryRowHTML(workers) {
   const count = workers.length;
   const sample = workers.slice(0, 3).map(worker => (worker.project_name || "-") + " / " + (worker.slot || "-")).join(", ");
-  const note = "Done/stale sessions are collapsed by default." + (sample ? " Examples: " + sample + "." : "") + " Search or switch scope to inspect every session.";
-  return '<tr class="history-row"><td colspan="9"><div class="history-row-content">' +
-    '<div><strong>' + escapeText(count + " historical worker" + (count === 1 ? "" : "s")) + '</strong><span> ' + escapeText(note) + '</span></div>' +
-    '<button type="button" class="history-row-action" data-history-scope="recent">Show history</button>' +
+  const note = "Done/stale sessions are collapsed by default." + (sample ? " Examples: " + sample + "." : "");
+  const summaryText = count + " done/historical worker" + (count === 1 ? "" : "s") + " · click to expand";
+  return '<tr class="history-row worker-history-summary-row"><td colspan="9"><div class="history-row-content">' +
+    '<button type="button" class="history-row-toggle" data-history-toggle aria-expanded="false">' +
+      '<span class="history-row-toggle-caret" aria-hidden="true">&#9656;</span>' +
+      '<strong>' + escapeText(summaryText) + '</strong>' +
+      '<span> ' + escapeText(note) + '</span>' +
+    '</button>' +
+    '<button type="button" class="history-row-action" data-history-scope="recent">Open in history scope</button>' +
     '</div></td></tr>';
+}
+
+function toggleWorkerHistoryRows(button) {
+  const expanded = button.getAttribute("aria-expanded") === "true";
+  const next = !expanded;
+  button.setAttribute("aria-expanded", next ? "true" : "false");
+  const tbody = button.closest("tbody");
+  if (!tbody) return;
+  tbody.querySelectorAll("tr.worker-history-row").forEach(row => {
+    if (next) row.removeAttribute("hidden");
+    else row.setAttribute("hidden", "");
+  });
 }
 
 function showHistoryScope(scope) {

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -87,6 +87,7 @@ const fleetState = {
   approvals: [],
   attention: [],
   workers: [],
+  historyExpanded: false,
   summary: {},
   detail: null,
   operatorBrief: null,
@@ -1589,7 +1590,7 @@ function renderFleetWorkers() {
     const issueText = issueSummaryText(worker);
     const selected = workerKey(worker) === fleetState.selectedWorkerKey ? " selected" : "";
     const cls = rowClass(worker) + selected + (extraClass ? " " + extraClass : "");
-    const hiddenAttr = extraClass === "worker-history-row" ? ' hidden' : '';
+    const hiddenAttr = extraClass === "worker-history-row" && !fleetState.historyExpanded ? ' hidden' : '';
     return '<tr class="' + cls + '" data-project="' + escapeText(worker.project_name || "") + '" data-slot="' + escapeText(worker.slot || "") + '" tabindex="0"' + hiddenAttr + '>' +
       '<td class="project-col" title="' + escapeText(project) + '">' + linkHTML(worker.dashboard_url, project) + '</td>' +
       '<td class="slot-col" title="' + escapeText(worker.slot || "-") + '">' + escapeText(worker.slot || "-") + '</td>' +
@@ -1604,7 +1605,7 @@ function renderFleetWorkers() {
   };
   const rows = visible.map(worker => renderRow(worker, ""));
   if (hiddenHistory.length) {
-    rows.push(historySummaryRowHTML(hiddenHistory));
+    rows.push(historySummaryRowHTML(hiddenHistory, fleetState.historyExpanded));
     hiddenHistory.forEach(worker => rows.push(renderRow(worker, "worker-history-row")));
   }
   fleetWorkersEl.innerHTML = rows.join("");
@@ -1636,25 +1637,32 @@ function renderFleetWorkers() {
   });
 }
 
-function historySummaryRowHTML(workers) {
+function historySummaryRowHTML(workers, expanded) {
   const count = workers.length;
   const sample = workers.slice(0, 3).map(worker => (worker.project_name || "-") + " / " + (worker.slot || "-")).join(", ");
   const note = "Done/stale sessions are collapsed by default." + (sample ? " Examples: " + sample + "." : "");
-  const summaryText = count + " done/historical worker" + (count === 1 ? "" : "s") + " · click to expand";
+  const summaryText = historySummaryText(count, expanded);
   return '<tr class="history-row worker-history-summary-row"><td colspan="9"><div class="history-row-content">' +
-    '<button type="button" class="history-row-toggle" data-history-toggle aria-expanded="false">' +
+    '<button type="button" class="history-row-toggle" data-history-toggle data-history-count="' + count + '" aria-expanded="' + (expanded ? "true" : "false") + '">' +
       '<span class="history-row-toggle-caret" aria-hidden="true">&#9656;</span>' +
-      '<strong>' + escapeText(summaryText) + '</strong>' +
+      '<strong data-history-toggle-label>' + escapeText(summaryText) + '</strong>' +
       '<span> ' + escapeText(note) + '</span>' +
     '</button>' +
     '<button type="button" class="history-row-action" data-history-scope="recent">Open in history scope</button>' +
     '</div></td></tr>';
 }
 
+function historySummaryText(count, expanded) {
+  return count + " done/historical worker" + (count === 1 ? "" : "s") + " · click to " + (expanded ? "collapse" : "expand");
+}
+
 function toggleWorkerHistoryRows(button) {
   const expanded = button.getAttribute("aria-expanded") === "true";
   const next = !expanded;
+  fleetState.historyExpanded = next;
   button.setAttribute("aria-expanded", next ? "true" : "false");
+  const label = button.querySelector("[data-history-toggle-label]");
+  if (label) label.textContent = historySummaryText(Number(button.dataset.historyCount || 0), next);
   const tbody = button.closest("tbody");
   if (!tbody) return;
   tbody.querySelectorAll("tr.worker-history-row").forEach(row => {


### PR DESCRIPTION
## Summary
- Historical worker rows now render inline in the same `<tbody>` behind a single summary row labeled "N done/historical workers · click to expand".
- A toggle button flips `aria-expanded` and shows/hides the history rows in place — never out of sight, never in the way.
- "Open in history scope" link kept as a secondary affordance.

Implements §10 backlog item M-003 of the Maestro UI Audit (May 2026).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/server/...` passes (added `TestFleetDashboardRendersHistoryCollapseControls`)
- [ ] Visit `/fleet` with a fleet that has both live and done workers — confirm the live group renders first, the summary row sits between them, click expands the history rows inline

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the M-003 backlog item by rendering done/historical workers inline in the `<tbody>` behind a collapsible summary row instead of a separate block. The two previously flagged issues — stale "click to expand" label and expanded state resetting on re-render — are both properly addressed: `historySummaryText(count, expanded)` drives the label at render time and in `toggleWorkerHistoryRows`, and `fleetState.historyExpanded` persists the toggle state across re-render cycles.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic defects found and the two previously raised issues are resolved.

All changes are additive and well-scoped. The expanded-state persistence via fleetState.historyExpanded is correct, the toggle label update path covers both the initial render and the in-place toggle, and the test assertions match the actual implementation. No P1 or P0 issues were identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/web/static/fleet.js | Core logic for collapsible history rows; expands renderFleetWorkers to use renderRow for both visible and history workers, adds toggleWorkerHistoryRows, and persists expanded state in fleetState.historyExpanded — no logic issues found. |
| internal/server/web/static/fleet.css | Adds styling for .history-row-toggle (button reset + caret rotation), .worker-history-row (subdued background), and .worker-history-summary-row separator; changes are additive and correct. |
| internal/server/fleet_test.go | Test assertions updated to match new function signatures and DOM markers; all expected strings are present in the implementation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: keep worker history toggle state st..."](https://github.com/befeast/maestro/commit/cb8e5cc3da7cece2e1b7e2f640e938987e0f5432) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30596571)</sub>

<!-- /greptile_comment -->