### PR TITLE
M-006: UI: pair supervisor verbs with operator sentences

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1739,7 +1739,7 @@ func TestFleetDashboard(t *testing.T) {
 		"approval-history-link-card",
 		"Open full approval audit",
 		"Safe recommendation",
-		"Start worker",
+		"Starting worker",
 		".approval-card.approval-stale { border-left-color: var(--line);",
 		".approval-card.approval-superseded { border-left-color: var(--line);",
 		".a-stale { color: var(--muted);",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -389,8 +389,12 @@ func supervisorOperatorSentence(action, summary string, target *state.Supervisor
 		return "Skipped this tick because no safe action was available."
 	case "monitor_open_pr":
 		return fmt.Sprintf("Watching %s until checks and review pass.", pr)
+	case "merge_pr":
+		return fmt.Sprintf("Merging %s now that checks and review allow it.", pr)
 	case "approve_merge":
 		return fmt.Sprintf("Ready to merge %s when approval and checks allow it.", pr)
+	case "skip_wave":
+		return "Skipped this tick because the wave policy held the next worker."
 	case "spawn_worker":
 		return fmt.Sprintf("Starting a worker for %s.", issue)
 	case "label_issue_ready":
@@ -402,6 +406,10 @@ func supervisorOperatorSentence(action, summary string, target *state.Supervisor
 		return fmt.Sprintf("Reviewing retry-exhausted work for %s before dispatching again.", issue)
 	case "check_outcome_health":
 		return "Checking runtime outcome health before sending more work."
+	case "wait_for_review":
+		return fmt.Sprintf("Waiting on review for %s.", pr)
+	case "wait_for_ci":
+		return fmt.Sprintf("Waiting on CI for %s.", pr)
 	case "wait_for_running_worker", "wait_for_worker":
 		return fmt.Sprintf("Waiting for %s to finish.", session)
 	case "wait_for_capacity":

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -453,6 +453,29 @@ func TestSupervisorOperatorSentence(t *testing.T) {
 			want:   "Checking runtime outcome health before sending more work.",
 		},
 		{
+			name:   "merge pr",
+			action: "merge_pr",
+			target: &state.SupervisorTarget{PR: 12},
+			want:   "Merging PR #12 now that checks and review allow it.",
+		},
+		{
+			name:   "skip wave",
+			action: "skip_wave",
+			want:   "Skipped this tick because the wave policy held the next worker.",
+		},
+		{
+			name:   "wait for review",
+			action: "wait_for_review",
+			target: &state.SupervisorTarget{PR: 12},
+			want:   "Waiting on review for PR #12.",
+		},
+		{
+			name:   "wait for ci",
+			action: "wait_for_ci",
+			target: &state.SupervisorTarget{PR: 12},
+			want:   "Waiting on CI for PR #12.",
+		},
+		{
 			name:    "unknown keeps raw action",
 			action:  "custom_new_action",
 			summary: "worker paused for external system",

--- a/internal/server/web/static/dashboard.js
+++ b/internal/server/web/static/dashboard.js
@@ -76,17 +76,21 @@ function issueSummaryText(worker) {
 
 function actionLabel(action) {
   switch (String(action || "").trim()) {
-  case "none": return "Skip tick";
-  case "monitor_open_pr": return "Watch PR";
-  case "approve_merge": return "Merge PR";
-  case "spawn_worker": return "Start worker";
+  case "none": return "Skipped tick";
+  case "monitor_open_pr": return "Watching PR";
+  case "merge_pr": return "Merging PR";
+  case "approve_merge": return "Merging PR";
+  case "skip_wave": return "Skipped tick";
+  case "spawn_worker": return "Starting worker";
   case "label_issue_ready": return "Mark issue ready";
   case "review_retry_exhausted": return "Review retry-exhausted work";
   case "check_outcome_health": return "Check runtime health";
+  case "wait_for_review": return "Waiting on review";
+  case "wait_for_ci": return "Waiting on CI";
   case "wait_for_running_worker":
-  case "wait_for_worker": return "Wait for worker";
-  case "wait_for_capacity": return "Wait for free slot";
-  case "wait_for_ordered_queue": return "Wait for queue order";
+  case "wait_for_worker": return "Waiting for worker";
+  case "wait_for_capacity": return "Waiting for free slot";
+  case "wait_for_ordered_queue": return "Waiting for queue order";
   default:
     return String(action || "-").replace(/_/g, " ");
   }
@@ -118,7 +122,16 @@ function supervisorDecisionMetaText(item) {
 function supervisorOperatorSentence(item) {
   if (item && item.operator_sentence) return item.operator_sentence;
   const raw = rawSupervisorAction(item && (item.recommended_action || item.action));
-  if (raw === "none") return "Skipped this tick because no safe action was available.";
+  switch (raw) {
+  case "none": return "Skipped this tick because no safe action was available.";
+  case "monitor_open_pr": return "Watching the open PR until checks and review pass.";
+  case "merge_pr": return "Merging the PR now that checks and review allow it.";
+  case "approve_merge": return "Ready to merge the PR when approval and checks allow it.";
+  case "skip_wave": return "Skipped this tick because the wave policy held the next worker.";
+  case "spawn_worker": return "Starting a worker for the selected issue.";
+  case "wait_for_review": return "Waiting on review for the open PR.";
+  case "wait_for_ci": return "Waiting on CI for the open PR.";
+  }
   const summary = String(item && item.summary || "").trim();
   if (summary) return "Supervisor chose " + raw + ". " + summary;
   return "Supervisor chose " + raw + ". Inspect diagnostics for details.";

--- a/internal/server/web/static/dashboard.js
+++ b/internal/server/web/static/dashboard.js
@@ -79,7 +79,7 @@ function actionLabel(action) {
   case "none": return "Skipped tick";
   case "monitor_open_pr": return "Watching PR";
   case "merge_pr": return "Merging PR";
-  case "approve_merge": return "Merging PR";
+  case "approve_merge": return "Ready to merge PR";
   case "skip_wave": return "Skipped tick";
   case "spawn_worker": return "Starting worker";
   case "label_issue_ready": return "Mark issue ready";

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -152,7 +152,7 @@ function actionLabel(action) {
   case "none": return "Skipped tick";
   case "monitor_open_pr": return "Watching PR";
   case "merge_pr": return "Merging PR";
-  case "approve_merge": return "Merging PR";
+  case "approve_merge": return "Ready to merge PR";
   case "skip_wave": return "Skipped tick";
   case "spawn_worker": return "Starting worker";
   case "label_issue_ready": return "Mark issue ready";

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -149,17 +149,21 @@ function issueSummaryText(worker) {
 
 function actionLabel(action) {
   switch (String(action || "").trim()) {
-  case "none": return "Skip tick";
-  case "monitor_open_pr": return "Watch PR";
-  case "approve_merge": return "Merge PR";
-  case "spawn_worker": return "Start worker";
+  case "none": return "Skipped tick";
+  case "monitor_open_pr": return "Watching PR";
+  case "merge_pr": return "Merging PR";
+  case "approve_merge": return "Merging PR";
+  case "skip_wave": return "Skipped tick";
+  case "spawn_worker": return "Starting worker";
   case "label_issue_ready": return "Mark issue ready";
   case "review_retry_exhausted": return "Review retry-exhausted work";
   case "check_outcome_health": return "Check runtime health";
+  case "wait_for_review": return "Waiting on review";
+  case "wait_for_ci": return "Waiting on CI";
   case "wait_for_running_worker":
-  case "wait_for_worker": return "Wait for worker";
-  case "wait_for_capacity": return "Wait for free slot";
-  case "wait_for_ordered_queue": return "Wait for queue order";
+  case "wait_for_worker": return "Waiting for worker";
+  case "wait_for_capacity": return "Waiting for free slot";
+  case "wait_for_ordered_queue": return "Waiting for queue order";
   default:
     return String(action || "-").replace(/_/g, " ");
   }
@@ -1902,7 +1906,16 @@ function supervisorDecisionMetaText(item) {
 function supervisorOperatorSentence(item) {
   if (item && item.operator_sentence) return item.operator_sentence;
   const raw = rawSupervisorAction(item && (item.recommended_action || item.action));
-  if (raw === "none") return "Skipped this tick because no safe action was available.";
+  switch (raw) {
+  case "none": return "Skipped this tick because no safe action was available.";
+  case "monitor_open_pr": return "Watching the open PR until checks and review pass.";
+  case "merge_pr": return "Merging the PR now that checks and review allow it.";
+  case "approve_merge": return "Ready to merge the PR when approval and checks allow it.";
+  case "skip_wave": return "Skipped this tick because the wave policy held the next worker.";
+  case "spawn_worker": return "Starting a worker for the selected issue.";
+  case "wait_for_review": return "Waiting on review for the open PR.";
+  case "wait_for_ci": return "Waiting on CI for the open PR.";
+  }
   const summary = String(item && item.summary || "").trim();
   if (summary) return "Supervisor chose " + raw + ". " + summary;
   return "Supervisor chose " + raw + ". Inspect diagnostics for details.";


### PR DESCRIPTION
## Summary
- Server-side `supervisorOperatorSentence` (server.go) now covers `merge_pr`, `skip_wave`, `wait_for_review`, `wait_for_ci` in addition to `monitor_open_pr` / `none`.
- JS fallbacks in `fleet.js` and `dashboard.js` mirror the new mapping and use sentence-form labels for action button copy.
- Existing `title="Raw action: ..."` tooltips on supervisor decisions surface the raw verb for debugging.

Implements §07 + §10 backlog item M-006 of the Maestro UI Audit (May 2026).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/server/...` passes (added 4 new sentence cases)
- [ ] On `/fleet`, hover a supervisor decision — confirm the human sentence renders and the raw verb appears in the tooltip

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `supervisorOperatorSentence` on the server side and its JS fallbacks to cover four previously-unhandled verbs (`merge_pr`, `skip_wave`, `wait_for_review`, `wait_for_ci`), and updates `actionLabel` in both JS files to use present-participle sentence-form copy. The `approve_merge` / `merge_pr` label confusion flagged in the previous review is correctly resolved here.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive label/copy improvements with no logic regressions.

All new switch cases are covered by corresponding tests, server and JS fallbacks are consistent, and no pre-existing handled paths are altered. No P1 or P0 findings identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/server.go | Added 4 new cases to supervisorOperatorSentence (merge_pr, skip_wave, wait_for_review, wait_for_ci); all use appropriate pr/session phrase helpers and match the test expectations exactly. |
| internal/server/server_test.go | Four new table-driven test cases added for the new verbs; expected strings align with server.go output. |
| internal/server/fleet_test.go | Single assertion updated from "Start worker" to "Starting worker" to track the renamed actionLabel; correct. |
| internal/server/web/static/dashboard.js | actionLabel updated to present-participle forms and new verbs added; supervisorOperatorSentence fallback switch expanded to cover the new verbs with correct prose. |
| internal/server/web/static/fleet.js | Mirrors the same dashboard.js changes; actionLabel and supervisorOperatorSentence fallback are in sync between both files. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: distinguish merge-ready label from ..."](https://github.com/befeast/maestro/commit/61e71dcc6d8f31b9d60cb0b550dfcac04c1fd0de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30596574)</sub>

<!-- /greptile_comment -->