### PR TITLE
M-008: UI: collapse project rail rows; expand inline for queue + outcome + decision

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2198,7 +2198,7 @@ func fleetProjectRailSummary(projects []fleetProjectState) string {
 
 func renderFleetProjectRailRows(projects []fleetProjectState) string {
 	if len(projects) == 0 {
-		return `<tr class="project-rail-empty"><td colspan="7" class="empty">No configured projects are available in this fleet.</td></tr>`
+		return `<tr class="project-rail-empty"><td colspan="8" class="empty">No configured projects are available in this fleet.</td></tr>`
 	}
 	var b strings.Builder
 	for _, project := range projects {
@@ -2213,7 +2213,13 @@ func renderFleetProjectRailRow(project fleetProjectState) string {
 		rowClasses = append(rowClasses, "project-row--unconfigured")
 	}
 	rowClass := strings.Join(rowClasses, " ")
-	return `<tr class="` + html.EscapeString(rowClass) + `">` +
+	detailID := "rail-detail-" + cssTokenServer(project.Name)
+	toggleCell := `<td class="project-rail-toggle-cell">` +
+		`<button type="button" class="project-rail-toggle" data-rail-toggle="` + html.EscapeString(detailID) + `" aria-expanded="false" aria-controls="` + html.EscapeString(detailID) + `" aria-label="Expand project detail">` +
+		`<span class="project-rail-toggle-caret" aria-hidden="true">&#9656;</span>` +
+		`</button></td>`
+	mainRow := `<tr class="` + html.EscapeString(rowClass) + `" aria-controls="` + html.EscapeString(detailID) + `">` +
+		toggleCell +
 		`<td class="project-rail-project">` + renderFleetProjectIdentity(project) + `</td>` +
 		`<td class="project-rail-state-cell">` + renderFleetProjectRailState(project) + `</td>` +
 		`<td class="project-rail-queue-cell">` + renderFleetProjectRailQueue(project) + `</td>` +
@@ -2222,6 +2228,86 @@ func renderFleetProjectRailRow(project fleetProjectState) string {
 		`<td class="project-rail-freshness-cell">` + renderFleetProjectRailFreshness(project) + `</td>` +
 		`<td class="project-rail-links-cell">` + renderFleetProjectRailLinks(project) + `</td>` +
 		`</tr>`
+	detailRow := `<tr class="project-rail-detail-row" id="` + html.EscapeString(detailID) + `" hidden>` +
+		`<td colspan="8">` + renderFleetProjectRailDetail(project) + `</td>` +
+		`</tr>`
+	return mainRow + detailRow
+}
+
+func renderFleetProjectRailDetail(project fleetProjectState) string {
+	parts := []string{
+		`<div class="rail-detail-block rail-detail-queue"><div class="rail-detail-label">Queue</div>` + renderFleetProjectRailQueueDetail(project) + `</div>`,
+		`<div class="rail-detail-block rail-detail-outcome"><div class="rail-detail-label">Outcome</div>` + renderFleetProjectRailOutcomeDetail(project) + `</div>`,
+		`<div class="rail-detail-block rail-detail-decision"><div class="rail-detail-label">Last decision</div>` + renderFleetProjectRailDecisionDetail(project) + `</div>`,
+	}
+	return `<div class="project-rail-detail">` + strings.Join(parts, "") + `</div>`
+}
+
+func renderFleetProjectRailQueueDetail(project fleetProjectState) string {
+	q := project.QueueSnapshot
+	if q == nil {
+		return `<div class="rail-detail-empty">No queue snapshot.</div>`
+	}
+	open := q.Open
+	ready := q.Eligible
+	held := q.Held
+	readyPct := 0
+	heldPct := 0
+	if open > 0 {
+		readyPct = (ready * 100) / open
+		heldPct = (held * 100) / open
+		if readyPct > 100 {
+			readyPct = 100
+		}
+		if heldPct > 100 {
+			heldPct = 100
+		}
+	}
+	bar := `<div class="rail-detail-queue-bar" role="img" aria-label="Queue health">` +
+		`<span class="rail-detail-queue-bar-segment ready" style="width:` + fmt.Sprintf("%d", readyPct) + `%"></span>` +
+		`<span class="rail-detail-queue-bar-segment held" style="width:` + fmt.Sprintf("%d", heldPct) + `%"></span>` +
+		`</div>`
+	caption := fmt.Sprintf("%d ready · %d held · %d open", ready, held, open)
+	idle := strings.TrimSpace(q.IdleReason)
+	captionHTML := `<div class="rail-detail-queue-caption">` + html.EscapeString(caption) + `</div>`
+	if idle != "" {
+		captionHTML += `<div class="rail-detail-queue-idle">` + html.EscapeString(idle) + `</div>`
+	}
+	return bar + captionHTML
+}
+
+func renderFleetProjectRailOutcomeDetail(project fleetProjectState) string {
+	if fleetProjectUnconfigured(project) {
+		return `<div class="rail-detail-empty">No outcome brief configured.</div>`
+	}
+	o := project.Outcome
+	health := strings.TrimSpace(o.HealthState)
+	if health == "" {
+		health = "unknown"
+	}
+	goal := strings.TrimSpace(o.Goal)
+	if goal == "" {
+		goal = "No outcome brief configured"
+	}
+	return `<span class="pill outcome-` + html.EscapeString(cssTokenServer(health)) + `">` + html.EscapeString(strings.ReplaceAll(health, "_", " ")) + `</span>` +
+		`<div class="rail-detail-outcome-goal">` + html.EscapeString(goal) + `</div>`
+}
+
+func renderFleetProjectRailDecisionDetail(project fleetProjectState) string {
+	sup := project.Supervisor
+	if !sup.HasRun || sup.Latest == nil {
+		return `<div class="rail-detail-empty">No supervisor decision yet.</div>`
+	}
+	latest := sup.Latest
+	sentence := strings.TrimSpace(latest.OperatorSentence)
+	if sentence == "" {
+		sentence = supervisorOperatorSentence(latest.RecommendedAction, latest.Summary, latest.Target)
+	}
+	raw := strings.TrimSpace(latest.RecommendedAction)
+	if raw == "" {
+		raw = "none"
+	}
+	return `<div class="rail-detail-decision-sentence" title="Raw action: ` + html.EscapeString(raw) + `">` + html.EscapeString(sentence) + `</div>`
 }
 
 func renderFleetProjectIdentity(project fleetProjectState) string {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1751,6 +1751,8 @@ func TestFleetDashboard(t *testing.T) {
 		"No projects need attention right now",
 		"renderProjectRail",
 		"projectRailRowHTML",
+		"projectRailDetailHTML",
+		"toggleProjectRailDetail",
 		"projectOpenRailHTML",
 		"needs-you-rail",
 		"renderNeedsYouRail",
@@ -2015,6 +2017,29 @@ func TestFleetDashboardServerRendersProjectRailFixtures(t *testing.T) {
 				t.Fatal("10+ project fixture should render inside the scrollable rail container")
 			}
 		})
+	}
+}
+
+func TestFleetDashboardRailEmitsInlineDetailRow(t *testing.T) {
+	body := fleetDashboardBodyWithProjects(t, fleetDashboardFixtureProjects(t, 1))
+	rail := dashboardSnippet(t, body, `<tbody id="project-rail-body">`, `</tbody>`)
+
+	for _, want := range []string{
+		"project-rail-toggle-cell",
+		"data-rail-toggle=",
+		"aria-controls=\"rail-detail-",
+		"project-rail-detail-row",
+		"rail-detail-block rail-detail-queue",
+		"rail-detail-block rail-detail-outcome",
+		"rail-detail-block rail-detail-decision",
+		"rail-detail-queue-bar",
+	} {
+		if !contains(rail, want) {
+			t.Fatalf("rail should expose inline detail row markup %q in:\n%s", want, rail)
+		}
+	}
+	if mainCount, detailCount := strings.Count(rail, `class="project-rail-row`), strings.Count(rail, "project-rail-detail-row"); mainCount != detailCount {
+		t.Fatalf("expected one detail row per main row, got main=%d detail=%d in:\n%s", mainCount, detailCount, rail)
 	}
 }
 

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -320,6 +320,78 @@
     outline-offset: -2px;
   }
   .project-row-expanded { box-shadow: inset 3px 0 0 var(--brand-a); }
+  .project-rail-toggle-cell {
+    width: 28px;
+    padding: 0;
+    text-align: center;
+    vertical-align: middle;
+  }
+  .project-rail-toggle {
+    display: inline-flex;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    border-radius: 4px;
+  }
+  .project-rail-toggle:hover { background: rgba(15,23,42,.06); color: var(--text); }
+  .project-rail-toggle:focus-visible {
+    outline: 2px solid rgba(5,150,105,.45);
+    outline-offset: 1px;
+  }
+  .project-rail-toggle-caret {
+    display: inline-block;
+    transition: transform 120ms ease;
+    font-size: 11px;
+    line-height: 1;
+  }
+  .project-rail-toggle[aria-expanded="true"] .project-rail-toggle-caret {
+    transform: rotate(90deg);
+  }
+  .project-rail-row-expanded { background: rgba(15,23,42,.03); }
+  .project-rail-detail-row td {
+    padding: 12px 18px 16px 46px;
+    background: var(--panel-2, #f8fafc);
+    border-bottom: 1px solid var(--line);
+  }
+  .project-rail-detail {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1.4fr) minmax(0, 2fr);
+    gap: 18px;
+  }
+  .rail-detail-block { min-width: 0; }
+  .rail-detail-label {
+    font-size: 11px;
+    font-weight: 650;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: var(--muted);
+    margin-bottom: 6px;
+  }
+  .rail-detail-empty { color: var(--muted); font-size: 12px; font-style: italic; }
+  .rail-detail-queue-bar {
+    position: relative;
+    width: 100%;
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(148,163,184,.18);
+    overflow: hidden;
+    display: flex;
+  }
+  .rail-detail-queue-bar-segment.ready { background: var(--ok, #059669); }
+  .rail-detail-queue-bar-segment.held { background: var(--warn, #d97706); opacity: .8; }
+  .rail-detail-queue-caption { margin-top: 6px; font-size: 12px; color: var(--text); }
+  .rail-detail-queue-idle { margin-top: 4px; font-size: 12px; color: var(--muted); font-style: italic; }
+  .rail-detail-outcome-goal { margin-top: 6px; font-size: 12px; color: var(--text); overflow-wrap: anywhere; }
+  .rail-detail-decision-sentence { font-size: 12px; color: var(--text); overflow-wrap: anywhere; }
+  @media (max-width: 900px) {
+    .project-rail-detail { grid-template-columns: minmax(0, 1fr); }
+  }
   .project-rail-project-wrap {
     display: grid;
     grid-template-columns: 18px minmax(0, 1fr);

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -1491,11 +1491,12 @@ function projectRailRowHTML(project) {
   const key = projectStateKey(project);
   const modifier = projectIsUnconfigured(project) ? ' project-row--unconfigured' : '';
   const detailID = "rail-detail-" + cssToken(project.name || "project");
+  const expanded = fleetState.expandedProject === (project.name || "");
   const toggleCell = '<td class="project-rail-toggle-cell">' +
-    '<button type="button" class="project-rail-toggle" data-rail-toggle="' + escapeText(detailID) + '" aria-expanded="false" aria-controls="' + escapeText(detailID) + '" aria-label="Expand project detail">' +
+    '<button type="button" class="project-rail-toggle" data-rail-toggle="' + escapeText(detailID) + '" aria-expanded="' + (expanded ? "true" : "false") + '" aria-controls="' + escapeText(detailID) + '" aria-label="' + (expanded ? "Collapse" : "Expand") + ' project detail">' +
       '<span class="project-rail-toggle-caret" aria-hidden="true">&#9656;</span>' +
     '</button></td>';
-  const mainRow = '<tr class="project-rail-row project-row-' + cssToken(key) + modifier + '" data-project="' + escapeText(project.name || "") + '" data-url="' + escapeText(project.dashboard_url || githubRepoURL(project.repo) || "") + '" aria-controls="' + escapeText(detailID) + '" tabindex="0">' +
+  const mainRow = '<tr class="project-rail-row project-row-' + cssToken(key) + modifier + (expanded ? ' project-rail-row-expanded' : '') + '" data-project="' + escapeText(project.name || "") + '" data-url="' + escapeText(project.dashboard_url || githubRepoURL(project.repo) || "") + '" aria-controls="' + escapeText(detailID) + '" tabindex="0">' +
     toggleCell +
     '<td class="project-rail-project"><div class="project-rail-project-wrap"><div class="project-rail-project-copy">' + projectIdentityRailHTML(project) + '</div></div></td>' +
     '<td class="project-rail-state-cell">' + projectStateRailHTML(project) + '</td>' +
@@ -1505,7 +1506,7 @@ function projectRailRowHTML(project) {
     '<td class="project-rail-freshness-cell">' + projectFreshnessRailHTML(project) + '</td>' +
     '<td class="project-rail-links-cell">' + projectOpenRailHTML(project) + '</td>' +
   '</tr>';
-  const detailRow = '<tr class="project-rail-detail-row" id="' + escapeText(detailID) + '" hidden><td colspan="8">' + projectRailDetailHTML(project) + '</td></tr>';
+  const detailRow = '<tr class="project-rail-detail-row" id="' + escapeText(detailID) + '"' + (expanded ? '' : ' hidden') + '><td colspan="8">' + projectRailDetailHTML(project) + '</td></tr>';
   return mainRow + detailRow;
 }
 
@@ -1570,10 +1571,16 @@ function toggleProjectRailDetail(button) {
   const expanded = button.getAttribute("aria-expanded") === "true";
   const next = !expanded;
   button.setAttribute("aria-expanded", next ? "true" : "false");
+  button.setAttribute("aria-label", (next ? "Collapse" : "Expand") + " project detail");
   if (next) target.removeAttribute("hidden");
   else target.setAttribute("hidden", "");
   const row = button.closest("tr");
-  if (row) row.classList.toggle("project-rail-row-expanded", next);
+  if (row) {
+    row.classList.toggle("project-rail-row-expanded", next);
+    const projectName = row.dataset.project || "";
+    fleetState.expandedProject = next ? projectName : "";
+    writeStoredExpandedProject(fleetState.expandedProject);
+  }
 }
 
 function renderProjectRail() {

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -1490,7 +1490,13 @@ function projectOpenRailHTML(project) {
 function projectRailRowHTML(project) {
   const key = projectStateKey(project);
   const modifier = projectIsUnconfigured(project) ? ' project-row--unconfigured' : '';
-  return '<tr class="project-rail-row project-row-' + cssToken(key) + modifier + '" data-project="' + escapeText(project.name || "") + '" data-url="' + escapeText(project.dashboard_url || githubRepoURL(project.repo) || "") + '" tabindex="0">' +
+  const detailID = "rail-detail-" + cssToken(project.name || "project");
+  const toggleCell = '<td class="project-rail-toggle-cell">' +
+    '<button type="button" class="project-rail-toggle" data-rail-toggle="' + escapeText(detailID) + '" aria-expanded="false" aria-controls="' + escapeText(detailID) + '" aria-label="Expand project detail">' +
+      '<span class="project-rail-toggle-caret" aria-hidden="true">&#9656;</span>' +
+    '</button></td>';
+  const mainRow = '<tr class="project-rail-row project-row-' + cssToken(key) + modifier + '" data-project="' + escapeText(project.name || "") + '" data-url="' + escapeText(project.dashboard_url || githubRepoURL(project.repo) || "") + '" aria-controls="' + escapeText(detailID) + '" tabindex="0">' +
+    toggleCell +
     '<td class="project-rail-project"><div class="project-rail-project-wrap"><div class="project-rail-project-copy">' + projectIdentityRailHTML(project) + '</div></div></td>' +
     '<td class="project-rail-state-cell">' + projectStateRailHTML(project) + '</td>' +
     '<td class="project-rail-queue-cell">' + projectQueueRailHTML(project) + '</td>' +
@@ -1499,6 +1505,75 @@ function projectRailRowHTML(project) {
     '<td class="project-rail-freshness-cell">' + projectFreshnessRailHTML(project) + '</td>' +
     '<td class="project-rail-links-cell">' + projectOpenRailHTML(project) + '</td>' +
   '</tr>';
+  const detailRow = '<tr class="project-rail-detail-row" id="' + escapeText(detailID) + '" hidden><td colspan="8">' + projectRailDetailHTML(project) + '</td></tr>';
+  return mainRow + detailRow;
+}
+
+function projectRailDetailHTML(project) {
+  return '<div class="project-rail-detail">' +
+    '<div class="rail-detail-block rail-detail-queue"><div class="rail-detail-label">Queue</div>' + projectRailQueueDetailHTML(project) + '</div>' +
+    '<div class="rail-detail-block rail-detail-outcome"><div class="rail-detail-label">Outcome</div>' + projectRailOutcomeDetailHTML(project) + '</div>' +
+    '<div class="rail-detail-block rail-detail-decision"><div class="rail-detail-label">Last decision</div>' + projectRailDecisionDetailHTML(project) + '</div>' +
+  '</div>';
+}
+
+function projectRailQueueDetailHTML(project) {
+  const q = project.queue_snapshot;
+  if (!q) return '<div class="rail-detail-empty">No queue snapshot.</div>';
+  const open = Number(q.open || 0);
+  const ready = Number(q.eligible || 0);
+  const held = Number(q.held || q.held_issues || 0);
+  let readyPct = 0;
+  let heldPct = 0;
+  if (open > 0) {
+    readyPct = Math.min(100, Math.round((ready * 100) / open));
+    heldPct = Math.min(100, Math.round((held * 100) / open));
+  }
+  const bar = '<div class="rail-detail-queue-bar" role="img" aria-label="Queue health">' +
+    '<span class="rail-detail-queue-bar-segment ready" style="width:' + readyPct + '%"></span>' +
+    '<span class="rail-detail-queue-bar-segment held" style="width:' + heldPct + '%"></span>' +
+  '</div>';
+  const caption = ready + " ready · " + held + " held · " + open + " open";
+  const idle = String(q.idle_reason || "").trim();
+  return bar +
+    '<div class="rail-detail-queue-caption">' + escapeText(caption) + '</div>' +
+    (idle ? '<div class="rail-detail-queue-idle">' + escapeText(idle) + '</div>' : '');
+}
+
+function projectRailOutcomeDetailHTML(project) {
+  if (projectIsUnconfigured(project)) {
+    return '<div class="rail-detail-empty">No outcome brief configured.</div>';
+  }
+  const outcome = project.outcome || {};
+  const health = outcome.health_state || "unknown";
+  const goal = outcome.configured === true && outcome.goal ? outcome.goal : "No outcome brief configured";
+  return '<span class="pill outcome-' + cssToken(health) + '">' + escapeText(health.replace(/_/g, ' ')) + '</span>' +
+    '<div class="rail-detail-outcome-goal">' + escapeText(goal) + '</div>';
+}
+
+function projectRailDecisionDetailHTML(project) {
+  const sup = project && project.supervisor;
+  if (!sup || !sup.has_run || !sup.latest) {
+    return '<div class="rail-detail-empty">No supervisor decision yet.</div>';
+  }
+  const latest = sup.latest;
+  const sentence = supervisorOperatorSentence(latest);
+  const raw = rawSupervisorAction(latest.recommended_action);
+  return '<div class="rail-detail-decision-sentence" title="Raw action: ' + escapeText(raw) + '">' + escapeText(sentence) + '</div>';
+}
+
+function toggleProjectRailDetail(button) {
+  const targetID = button.dataset.railToggle || "";
+  if (!targetID) return;
+  const target = document.getElementById(targetID);
+  if (!target) return;
+  const expanded = button.getAttribute("aria-expanded") === "true";
+  const next = !expanded;
+  button.setAttribute("aria-expanded", next ? "true" : "false");
+  if (next) target.removeAttribute("hidden");
+  else target.setAttribute("hidden", "");
+  const row = button.closest("tr");
+  if (row) row.classList.toggle("project-rail-row-expanded", next);
 }
 
 function renderProjectRail() {
@@ -1510,7 +1585,7 @@ function renderProjectRail() {
   projectRailSummaryEl.textContent = projectRailSummaryText(projects, total);
   if (!projects.length) {
     const empty = total ? "No configured projects match the project search." : "No configured projects are available in this fleet.";
-    projectRailBodyEl.innerHTML = '<tr class="project-rail-empty"><td colspan="7" class="empty">' + escapeText(empty) + '</td></tr>';
+    projectRailBodyEl.innerHTML = '<tr class="project-rail-empty"><td colspan="8" class="empty">' + escapeText(empty) + '</td></tr>';
     return;
   }
 
@@ -1532,6 +1607,13 @@ function renderProjectRail() {
   projectRailBodyEl.querySelectorAll(".project-rail-row[data-project] a, .project-rail-row[data-project] button").forEach(control => {
     control.addEventListener("click", event => event.stopPropagation());
     control.addEventListener("keydown", event => event.stopPropagation());
+  });
+  projectRailBodyEl.querySelectorAll("button[data-rail-toggle]").forEach(button => {
+    button.addEventListener("click", event => {
+      event.stopPropagation();
+      event.preventDefault();
+      toggleProjectRailDetail(button);
+    });
   });
   projectRailBodyEl.querySelectorAll(".project-workers-link[data-project]").forEach(button => {
     button.addEventListener("click", event => {

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -81,6 +81,7 @@
       <table class="project-rail-table" aria-label="Configured project fleet rail">
         <thead>
           <tr>
+            <th class="project-rail-toggle-cell" aria-hidden="true"></th>
             <th class="project-rail-project">Project</th>
             <th class="project-rail-state-cell">State</th>
             <th class="project-rail-queue-cell">Queue</th>


### PR DESCRIPTION
## Summary
- Project rail rows now lead with a chevron toggle that expands a sibling detail row inside the same `<tbody>`.
- Detail row surfaces a queue health bar (ready/held), outcome pill + goal sentence, and last supervisor decision sentence (raw verb in `title` for debugging).
- Server-side renders both rows; JS mirrors the structure on rerender. Row click still navigates to the project dashboard.
- Legacy `project-diagnostics` block remains as a hidden inspector layer — out of scope to remove in this PR.

Implements §05 + §10 backlog item M-008 of the Maestro UI Audit (May 2026).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/server/...` passes (added `TestFleetDashboardRailEmitsInlineDetailRow`)
- [ ] On `/fleet`, click a row's chevron — confirm the detail row expands inline with queue bar + outcome + last decision
- [ ] Click anywhere else on the row — confirm it still navigates to the project dashboard

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an inline detail row to each project rail entry, surfacing a queue health bar, outcome pill, and last supervisor decision sentence behind a chevron toggle. Server and client rendering paths are kept in sync, `fleetState.expandedProject` preserves the expanded state across SSE refreshes (addressing the previous P1 collapse-on-refresh concern), and the new `TestFleetDashboardRailEmitsInlineDetailRow` test validates the structural markup.

- `toggleProjectRailDetail` does not enforce accordion behaviour: a user can expand multiple rows simultaneously, but only the last-expanded project name is stored in `fleetState.expandedProject`. On the next data refresh `renderProjectRail()` rebuilds all rows from stored state, silently collapsing every row except the stored one.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one P1 fix: enforce accordion collapse so visual state stays consistent with the single-slot `fleetState.expandedProject` store.

One P1 defect — multi-row expansion diverges from the stored single-project state, causing silent collapses on the next live refresh. All other logic (escaping, percentage math, event wiring) looks correct.

internal/server/web/static/fleet.js — `toggleProjectRailDetail` needs accordion enforcement before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds server-side rendering of toggle cell, main row, and inline detail row (queue bar, outcome pill, decision sentence). HTML-escaped throughout; percentage clamping is correct. `colspan` updated to 8. |
| internal/server/fleet_test.go | New test `TestFleetDashboardRailEmitsInlineDetailRow` verifies toggle markup, detail blocks, and 1:1 main/detail row ratio. Existing assertions updated for new JS function names. |
| internal/server/web/static/fleet.css | Adds toggle button, caret, detail row, queue bar, outcome, and decision styles. Responsive breakpoint at 900px collapses the three-column grid to single-column. No issues found. |
| internal/server/web/static/fleet.js | Adds client-side detail HTML builders and `toggleProjectRailDetail`. `fleetState.expandedProject` (single string) restores one row across refreshes, but `toggleProjectRailDetail` doesn't collapse other open rows, so multiple rows can be simultaneously expanded while only one is persisted — silently collapsing on next refresh. |
| internal/server/web/templates/fleet.html | Adds an `aria-hidden` `<th>` for the new toggle column. No issues found. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/server/web/static/fleet.js`, line 1592 ([link](https://github.com/befeast/maestro/blob/c941fcb0df104d5aab5da49c80e7d248ca37ef28/internal/server/web/static/fleet.js#L1592)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Expanded rows collapse on every data refresh**

   `renderProjectRail()` is called on every fleet state update (line 2289, inside the data-received handler). It unconditionally replaces `projectRailBodyEl.innerHTML` with fresh markup, so every row is rebuilt with `aria-expanded="false"` and the detail row re-hidden. Any row the user has expanded is silently collapsed the moment the next SSE/polling update arrives, making the detail panel unreliable during live operation.

   A minimal fix is to snapshot the set of currently-expanded `detailID` values before the overwrite and re-expand them afterward:

   ```js
   // before clobbering innerHTML
   const openIDs = new Set(
     [...projectRailBodyEl.querySelectorAll("button[aria-expanded='true'][data-rail-toggle]")]
       .map(b => b.dataset.railToggle)
   );

   projectRailBodyEl.innerHTML = projects.map(projectRailRowHTML).join("");

   // ... re-attach event listeners, then:
   openIDs.forEach(id => {
     const btn = projectRailBodyEl.querySelector(`button[data-rail-toggle="${CSS.escape(id)}"]`);
     if (btn) toggleProjectRailDetail(btn);
   });
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/web/static/fleet.js
   Line: 1592

   Comment:
   **Expanded rows collapse on every data refresh**

   `renderProjectRail()` is called on every fleet state update (line 2289, inside the data-received handler). It unconditionally replaces `projectRailBodyEl.innerHTML` with fresh markup, so every row is rebuilt with `aria-expanded="false"` and the detail row re-hidden. Any row the user has expanded is silently collapsed the moment the next SSE/polling update arrives, making the detail panel unreliable during live operation.

   A minimal fix is to snapshot the set of currently-expanded `detailID` values before the overwrite and re-expand them afterward:

   ```js
   // before clobbering innerHTML
   const openIDs = new Set(
     [...projectRailBodyEl.querySelectorAll("button[aria-expanded='true'][data-rail-toggle]")]
       .map(b => b.dataset.railToggle)
   );

   projectRailBodyEl.innerHTML = projects.map(projectRailRowHTML).join("");

   // ... re-attach event listeners, then:
   openIDs.forEach(id => {
     const btn = projectRailBodyEl.querySelector(`button[data-rail-toggle="${CSS.escape(id)}"]`);
     if (btn) toggleProjectRailDetail(btn);
   });
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/server/web/static/fleet.js:1565-1584
**No accordion enforcement — multi-expand diverges from stored state**

`toggleProjectRailDetail` only toggles the clicked row; it never collapses a previously-open row. `fleetState.expandedProject` can only hold one project name. If the user expands project A then project B, both detail rows are visible in the DOM, but `fleetState.expandedProject = "B"`. On the next data refresh `renderProjectRail()` rebuilds all rows with the stored state, so A's detail row silently collapses without user action.

Close the previously-open row before opening the new one:

```js
// at the top of toggleProjectRailDetail, before toggling `next`
if (next) {
  projectRailBodyEl.querySelectorAll("button[data-rail-toggle][aria-expanded='true']").forEach(other => {
    if (other === button) return;
    const otherId = other.dataset.railToggle || "";
    const otherTarget = document.getElementById(otherId);
    other.setAttribute("aria-expanded", "false");
    other.setAttribute("aria-label", "Expand project detail");
    if (otherTarget) otherTarget.setAttribute("hidden", "");
    const otherRow = other.closest("tr");
    if (otherRow) otherRow.classList.remove("project-rail-row-expanded");
  });
}
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: preserve expanded project rail row"](https://github.com/befeast/maestro/commit/a076b5a0f5a23d8ceb9cac3d4eb75bef65002298) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30596584)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->