### PR TITLE
M-011: UI: separate active and historical approvals with strict severity

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -782,22 +782,31 @@ func buildFleetOperatorBrief(projects []fleetProjectState, approvals []fleetAppr
 		return fleetOperatorBrief{Tone: "muted", Sentence: "Global brief: no projects are configured in this fleet."}
 	}
 
-	if approval := highestPriorityPendingFleetApproval(approvals); approval != nil {
-		tone := "attention"
-		label := "Approval pending"
-		nextAction := "Approve or reject the pending supervisor approval after checking the target state."
-		if approvalPastSLA(approval, now) {
-			tone = "daemon-down"
-			label = "Approval past SLA"
-			nextAction = "Pending approval is past the " + fleetApprovalSLAText() + " SLA. Approve or reject it now."
-		}
+	if approval := oldestPastSLAPendingFleetApproval(approvals, now); approval != nil {
 		return fleetOperatorBrief{
-			Tone:           tone,
-			Sentence:       fleetActionRequiredSentence(approval.ProjectName, label, approval.Summary, approval.IssueNumber, approval.PRNumber, approval.Session),
+			Tone:           "daemon-down",
+			Sentence:       fleetActionRequiredSentence(approval.ProjectName, "Approval past SLA", approval.Summary, approval.IssueNumber, approval.PRNumber, approval.Session),
 			Project:        approval.ProjectName,
 			Kind:           "approval_pending",
 			Reason:         truncateFleetOperatorText(approval.Summary, 150),
-			NextAction:     nextAction,
+			NextAction:     "Pending approval is past the " + fleetApprovalSLAText() + " SLA. Approve or reject it now.",
+			ActionRequired: true,
+			IssueNumber:    approval.IssueNumber,
+			IssueURL:       approval.IssueURL,
+			PRNumber:       approval.PRNumber,
+			PRURL:          approval.PRURL,
+			Session:        approval.Session,
+		}
+	}
+
+	if approval := highestPriorityPendingFleetApproval(approvals); approval != nil {
+		return fleetOperatorBrief{
+			Tone:           "attention",
+			Sentence:       fleetActionRequiredSentence(approval.ProjectName, "Approval pending", approval.Summary, approval.IssueNumber, approval.PRNumber, approval.Session),
+			Project:        approval.ProjectName,
+			Kind:           "approval_pending",
+			Reason:         truncateFleetOperatorText(approval.Summary, 150),
+			NextAction:     "Approve or reject the pending supervisor approval after checking the target state.",
 			ActionRequired: true,
 			IssueNumber:    approval.IssueNumber,
 			IssueURL:       approval.IssueURL,
@@ -885,6 +894,20 @@ func approvalPastSLA(approval *fleetApprovalState, now time.Time) bool {
 		return true
 	}
 	return false
+}
+
+func oldestPastSLAPendingFleetApproval(approvals []fleetApprovalState, now time.Time) *fleetApprovalState {
+	var selected *fleetApprovalState
+	for i := range approvals {
+		approval := &approvals[i]
+		if state.ApprovalStatus(approval.Status) != state.ApprovalStatusPending || !approvalPastSLA(approval, now) {
+			continue
+		}
+		if selected == nil || fleetApprovalRecency(*approval).Before(fleetApprovalRecency(*selected)) {
+			selected = approval
+		}
+	}
+	return selected
 }
 
 func highestPriorityPendingFleetApproval(approvals []fleetApprovalState) *fleetApprovalState {
@@ -2103,11 +2126,18 @@ func renderFleetApprovalCard(approval fleetApprovalState, muted bool) string {
 	if muted {
 		classes = append(classes, "approval-card-muted")
 	}
+	if approval.PastSLA {
+		classes = append(classes, "approval-past-sla")
+	}
+	slaLabelAttr := ""
+	if approval.PastSLA {
+		slaLabelAttr = ` data-sla-label="` + html.EscapeString(fleetApprovalSLAText()) + `"`
+	}
 	return `<article class="` + strings.Join(classes, " ") + `" title="` + summary + `">` +
 		`<div class="approval-project"><strong title="` + project + `">` + linkHTMLServer(approval.DashboardURL, project) + `</strong>` +
 		`<div class="approval-meta"><span title="` + id + `">` + id + `</span></div></div>` +
 		`<div class="approval-action"><strong title="` + action + `">` + action + `</strong>` +
-		`<div class="approval-meta"><span class="` + approvalStatusClassServer(approval.Status) + `">` + html.EscapeString(firstNonEmpty(approval.Status, "unknown")) + `</span></div></div>` +
+		`<div class="approval-meta"` + slaLabelAttr + `><span class="` + approvalStatusClassServer(approval.Status) + `">` + html.EscapeString(firstNonEmpty(approval.Status, "unknown")) + `</span></div></div>` +
 		`<div class="approval-target">` + renderFleetApprovalTargetHTML(approval) + sessionStatus + `</div>` +
 		`<div class="approval-main"><div class="approval-age"><span>Created ` + createdAge + ` ago</span><span>Updated ` + updatedAge + ` ago</span></div>` +
 		`<div class="approval-risk"><span>` + risk + `</span></div>` +

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -334,6 +334,7 @@ type fleetApprovalState struct {
 	UpdatedAgeSeconds int64                   `json:"updated_age_seconds,omitempty"`
 	Risk              string                  `json:"risk,omitempty"`
 	Summary           string                  `json:"summary,omitempty"`
+	PastSLA           bool                    `json:"past_sla,omitempty"`
 
 	createdAt time.Time
 	updatedAt time.Time
@@ -777,19 +778,26 @@ func fleetOperatorStateIsActive(kind string) bool {
 }
 
 func buildFleetOperatorBrief(projects []fleetProjectState, approvals []fleetApprovalState, now time.Time) fleetOperatorBrief {
-	_ = now
 	if len(projects) == 0 {
 		return fleetOperatorBrief{Tone: "muted", Sentence: "Global brief: no projects are configured in this fleet."}
 	}
 
 	if approval := highestPriorityPendingFleetApproval(approvals); approval != nil {
+		tone := "attention"
+		label := "Approval pending"
+		nextAction := "Approve or reject the pending supervisor approval after checking the target state."
+		if approvalPastSLA(approval, now) {
+			tone = "daemon-down"
+			label = "Approval past SLA"
+			nextAction = "Pending approval is past the " + fleetApprovalSLAText() + " SLA. Approve or reject it now."
+		}
 		return fleetOperatorBrief{
-			Tone:           "attention",
-			Sentence:       fleetActionRequiredSentence(approval.ProjectName, "Approval pending", approval.Summary, approval.IssueNumber, approval.PRNumber, approval.Session),
+			Tone:           tone,
+			Sentence:       fleetActionRequiredSentence(approval.ProjectName, label, approval.Summary, approval.IssueNumber, approval.PRNumber, approval.Session),
 			Project:        approval.ProjectName,
 			Kind:           "approval_pending",
 			Reason:         truncateFleetOperatorText(approval.Summary, 150),
-			NextAction:     "Approve or reject the pending supervisor approval after checking the target state.",
+			NextAction:     nextAction,
 			ActionRequired: true,
 			IssueNumber:    approval.IssueNumber,
 			IssueURL:       approval.IssueURL,
@@ -858,6 +866,25 @@ func buildFleetOperatorBrief(projects []fleetProjectState, approvals []fleetAppr
 		parts = append(parts, fleetCountPhrase(attention, "project with passive attention", "projects with passive attention"))
 	}
 	return fleetOperatorBrief{Tone: "busy", Kind: "active", Sentence: "Global brief: " + strings.Join(parts, "; ") + "; no operator action is needed right now."}
+}
+
+const fleetApprovalSLASeconds int64 = 30 * 60
+
+func fleetApprovalSLAText() string {
+	return "30m"
+}
+
+func approvalPastSLA(approval *fleetApprovalState, now time.Time) bool {
+	if approval == nil {
+		return false
+	}
+	if approval.CreatedAgeSeconds > fleetApprovalSLASeconds {
+		return true
+	}
+	if !approval.createdAt.IsZero() && now.Sub(approval.createdAt) > time.Duration(fleetApprovalSLASeconds)*time.Second {
+		return true
+	}
+	return false
 }
 
 func highestPriorityPendingFleetApproval(approvals []fleetApprovalState) *fleetApprovalState {
@@ -1778,6 +1805,9 @@ func makeFleetApprovalState(project fleetProjectState, st *state.State, approval
 		UpdatedAgeSeconds: fleetAgeSeconds(updatedAt, now),
 		createdAt:         createdAt,
 		updatedAt:         updatedAt,
+	}
+	if approval.Status == state.ApprovalStatusPending {
+		item.PastSLA = approvalPastSLA(&item, now)
 	}
 	item.TargetLinks = fleetApprovalTargetLinks(project.Repo, item)
 	return item

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -739,6 +739,30 @@ func TestFleetOperatorBriefPrioritizesPendingApproval(t *testing.T) {
 	}
 }
 
+func TestFleetOperatorBriefEscalatesPendingApprovalPastSLA(t *testing.T) {
+	now := time.Now().UTC()
+	brief := buildFleetOperatorBrief([]fleetProjectState{{
+		Name: "ApprovalProject",
+	}}, []fleetApprovalState{{
+		ProjectName: "ApprovalProject",
+		Status:      string(state.ApprovalStatusPending),
+		Summary:     "Supervisor approval is waiting past SLA.",
+		PRNumber:    101,
+		createdAt:   now.Add(-45 * time.Minute),
+		updatedAt:   now.Add(-45 * time.Minute),
+	}}, now)
+
+	if brief.Tone != "daemon-down" {
+		t.Fatalf("brief.Tone = %q, want daemon-down for past-SLA approval", brief.Tone)
+	}
+	if !contains(brief.Sentence, "Approval past SLA") {
+		t.Fatalf("brief.Sentence = %q, want past SLA label", brief.Sentence)
+	}
+	if !contains(brief.NextAction, "30m") {
+		t.Fatalf("brief.NextAction = %q, want 30m SLA mention", brief.NextAction)
+	}
+}
+
 func TestHighestPriorityPendingFleetApprovalSelectsNewestPending(t *testing.T) {
 	now := time.Now().UTC()
 	selected := highestPriorityPendingFleetApproval([]fleetApprovalState{
@@ -1738,12 +1762,15 @@ func TestFleetDashboard(t *testing.T) {
 		"approval-audit-link",
 		"approval-history-link-card",
 		"Open full approval audit",
+		"Pending approvals",
 		"Safe recommendation",
 		"Starting worker",
-		".approval-card.approval-stale { border-left-color: var(--line);",
-		".approval-card.approval-superseded { border-left-color: var(--line);",
+		".approval-card.approval-stale,",
+		".approval-card.approval-superseded,",
+		".approval-card.approval-rejected {",
 		".a-stale { color: var(--muted);",
 		".a-superseded { color: var(--muted);",
+		".approval-card.approval-pending.approval-past-sla {",
 		"counts.superseded",
 		"renderAttentionInbox",
 		"attentionFromData",

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -763,6 +763,34 @@ func TestFleetOperatorBriefEscalatesPendingApprovalPastSLA(t *testing.T) {
 	}
 }
 
+func TestFleetOperatorBriefEscalatesAnyPastSLAPendingApproval(t *testing.T) {
+	now := time.Now().UTC()
+	brief := buildFleetOperatorBrief([]fleetProjectState{{
+		Name: "ApprovalProject",
+	}}, []fleetApprovalState{
+		{
+			ProjectName: "NewApproval",
+			Status:      string(state.ApprovalStatusPending),
+			Summary:     "New approval is still within SLA.",
+			PRNumber:    102,
+			createdAt:   now.Add(-5 * time.Minute),
+			updatedAt:   now.Add(-5 * time.Minute),
+		},
+		{
+			ProjectName: "OldApproval",
+			Status:      string(state.ApprovalStatusPending),
+			Summary:     "Old approval breached SLA.",
+			PRNumber:    101,
+			createdAt:   now.Add(-45 * time.Minute),
+			updatedAt:   now.Add(-45 * time.Minute),
+		},
+	}, now)
+
+	if brief.Tone != "daemon-down" || brief.Project != "OldApproval" {
+		t.Fatalf("brief = %+v, want oldest past-SLA approval escalated", brief)
+	}
+}
+
 func TestHighestPriorityPendingFleetApprovalSelectsNewestPending(t *testing.T) {
 	now := time.Now().UTC()
 	selected := highestPriorityPendingFleetApproval([]fleetApprovalState{

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -576,7 +576,7 @@
     border-left-color: var(--bad, #dc2626);
     background: rgba(220,38,38,.08);
   }
-  .approval-card.approval-pending.approval-past-sla .approval-meta::after {
+  .approval-card.approval-pending.approval-past-sla .approval-action .approval-meta::after {
     content: "past " attr(data-sla-label) " SLA";
     margin-left: 8px;
     color: var(--bad, #dc2626);

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -572,10 +572,32 @@
     background: rgba(255,255,255,.92);
   }
   .approval-card.approval-pending { border-left-color: var(--warn); background: rgba(210,153,34,.08); }
-  .approval-card.approval-stale { border-left-color: var(--line); background: rgba(139,148,158,.06); }
-  .approval-card.approval-superseded { border-left-color: var(--line); background: rgba(139,148,158,.06); }
+  .approval-card.approval-pending.approval-past-sla {
+    border-left-color: var(--bad, #dc2626);
+    background: rgba(220,38,38,.08);
+  }
+  .approval-card.approval-pending.approval-past-sla .approval-meta::after {
+    content: "past " attr(data-sla-label) " SLA";
+    margin-left: 8px;
+    color: var(--bad, #dc2626);
+    font-weight: 650;
+    text-transform: uppercase;
+    font-size: 11px;
+    letter-spacing: .04em;
+  }
+  .approval-card.approval-stale,
+  .approval-card.approval-superseded,
+  .approval-card.approval-rejected {
+    border-left-color: var(--line);
+    background: rgba(139,148,158,.06);
+    color: var(--muted);
+  }
+  .approval-card.approval-stale .approval-action strong,
+  .approval-card.approval-superseded .approval-action strong,
+  .approval-card.approval-rejected .approval-action strong {
+    text-decoration: line-through;
+  }
   .approval-card.approval-approved { border-left-color: var(--ok); background: rgba(63,185,80,.06); }
-  .approval-card.approval-rejected { border-left-color: var(--line); background: rgba(139,148,158,.05); }
   .approval-card.approval-card-muted { background: rgba(255,255,255,.78); }
   .approval-project,
   .approval-action,

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -266,7 +266,9 @@ function approvalStatusClass(approval) {
 }
 
 function approvalCardClass(approval) {
-  return "approval-card approval-" + cssToken(approval.status || "unknown");
+  let cls = "approval-card approval-" + cssToken(approval.status || "unknown");
+  if (approval.past_sla === true) cls += " approval-past-sla";
+  return cls;
 }
 
 function isPendingApproval(approval) {

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -338,11 +338,12 @@ function approvalCardHTML(approval) {
   const createdAge = approval.created_age || "-";
   const updatedAge = approval.updated_age || "-";
   const sessionStatus = approval.session_status ? "Status " + approval.session_status : "";
+  const slaLabelAttr = approval.past_sla === true ? ' data-sla-label="30m"' : "";
   return '<article class="' + approvalCardClass(approval) + '" title="' + escapeText(approval.summary || "") + '">' +
     '<div class="approval-project"><strong title="' + escapeText(project) + '">' + linkHTML(approval.dashboard_url, project) + '</strong>' +
       '<div class="approval-meta"><span title="' + escapeText(id) + '">' + escapeText(id) + '</span></div></div>' +
     '<div class="approval-action"><strong title="' + escapeText(action) + '">' + escapeText(action) + '</strong>' +
-      '<div class="approval-meta"><span class="' + approvalStatusClass(approval) + '">' + escapeText(approval.status || "unknown") + '</span></div></div>' +
+      '<div class="approval-meta"' + slaLabelAttr + '><span class="' + approvalStatusClass(approval) + '">' + escapeText(approval.status || "unknown") + '</span></div></div>' +
     '<div class="approval-target">' + approvalTargetHTML(approval) + (sessionStatus ? '<span>' + escapeText(sessionStatus) + '</span>' : "") + '</div>' +
     '<div class="approval-main"><div class="approval-age"><span>Created ' + escapeText(createdAge) + ' ago</span><span>Updated ' + escapeText(updatedAge) + ' ago</span></div>' +
       '<div class="approval-risk"><span>' + escapeText(supervisorRiskLabel(approval.risk || "-")) + '</span></div>' +

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -122,8 +122,8 @@
   <section class="approval-inbox" id="approval-inbox" aria-live="polite" hidden>
     <div class="section-head">
       <div>
-        <h2>Approval Inbox</h2>
-        <div class="sub">Pending supervisor approvals that need review now. Historical approvals live in audit history.</div>
+        <h2>Pending approvals</h2>
+        <div class="sub">Active supervisor approvals waiting on you. Resolved or stale approvals live in audit history.</div>
       </div>
       <div class="section-note-group">
         <a class="scope-reset-button" id="approval-audit-link" href="/approvals/audit" hidden>Open audit history</a>


### PR DESCRIPTION
## Summary
- Renames "Approval Inbox" header to "Pending approvals" with refreshed sub-copy.
- Adds a 30-minute SLA threshold: pending approvals past SLA flip the operator brief to daemon-down (red) tone with "Approval past SLA" label and "30m SLA" copy in the next-action sentence.
- `PastSLA` flag now flows from server to JSON to `fleet.js` where the approval card adds an `approval-past-sla` modifier.
- CSS paints past-SLA cards red and tightens stale / superseded / rejected approvals into a single gray + line-through visual contract.

Implements §08 + §10 backlog item M-011 of the Maestro UI Audit (May 2026).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/server/...` passes (added `TestFleetOperatorBriefEscalatesPendingApprovalPastSLA`)
- [ ] On `/fleet` with a pending approval >30m old, confirm verdict bar turns red and approval card gets the past-SLA modifier
- [ ] On `/approvals/audit` confirm stale / superseded / rejected rows render gray with strikethrough

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the M-011 UI audit item: it escalates past-SLA pending approvals to `daemon-down` tone, wires the `PastSLA` flag from Go → JSON → JS → CSS, and unifies the stale/superseded/rejected visual contract into a single gray + line-through rule. The previous P1 finding (`data-sla-label` attribute never written, leaving the badge as "past  SLA") is resolved — both `fleet.go` (`renderFleetApprovalCard`) and `fleet.js` (`approvalCardHTML`) now inject `data-sla-label="30m"` when `past_sla` is true.

<h3>Confidence Score: 5/5</h3>

Safe to merge — previous P1 is fixed and no new logic bugs are present

The data-sla-label P1 from the prior review is addressed in both the server-side renderer and the JS client. The SLA detection logic (dual check: pre-computed CreatedAgeSeconds OR live now.Sub(createdAt)) is correct — stale cached age can only delay detection, never produce false positives. The only remaining feedback is a P2 about keeping fleetApprovalSLAText() derived from fleetApprovalSLASeconds.

No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds PastSLA field, approvalPastSLA/oldestPastSLAPendingFleetApproval helpers, SLA-escalation branch in buildFleetOperatorBrief, and data-sla-label attribute in renderFleetApprovalCard — logic is sound |
| internal/server/fleet_test.go | Two new tests cover SLA escalation (single approval) and multi-approval oldest-wins selection; assertions are correct |
| internal/server/web/static/fleet.css | Consolidates stale/superseded/rejected card styles, adds past-SLA red treatment and pseudo-element badge using data-sla-label attribute |
| internal/server/web/static/fleet.js | approvalCardClass adds approval-past-sla modifier and approvalCardHTML injects data-sla-label="30m" when past_sla is true, matching the CSS pseudo-element contract |
| internal/server/web/templates/fleet.html | Renames "Approval Inbox" → "Pending approvals" and refreshes sub-copy — trivial copy change |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/server/web/static/fleet.js`, line 336-345 ([link](https://github.com/befeast/maestro/blob/e65d226d0a358d6aaa8e5b9bd6991ee111bfe3a5/internal/server/web/static/fleet.js#L336-L345)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`data-sla-label` attribute never set — badge renders "past  SLA"**

   The CSS pseudo-element uses `content: "past " attr(data-sla-label) " SLA"` (fleet.css line 508), but `approvalCardHTML` never writes a `data-sla-label` attribute onto either `.approval-meta` element. When the attribute is absent, `attr()` returns an empty string, so the badge renders as `"past  SLA"` with a blank where `"30m"` should appear.

   The simplest fix is to inject the attribute on the second `.approval-meta` (inside `.approval-action`) when `approval.past_sla` is true:

   ```js
   '<div class="approval-action"><strong title="' + escapeText(action) + '">' + escapeText(action) + '</strong>' +
     '<div class="approval-meta"' + (approval.past_sla ? ' data-sla-label="30m"' : '') + '><span class="' + approvalStatusClass(approval) + '">' + escapeText(approval.status || "unknown") + '</span></div></div>' +
   ```

   Alternatively, replace `attr(data-sla-label)` in the CSS with the hardcoded string `"30m"` if the label will never need to vary.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/web/static/fleet.js
   Line: 336-345

   Comment:
   **`data-sla-label` attribute never set — badge renders "past  SLA"**

   The CSS pseudo-element uses `content: "past " attr(data-sla-label) " SLA"` (fleet.css line 508), but `approvalCardHTML` never writes a `data-sla-label` attribute onto either `.approval-meta` element. When the attribute is absent, `attr()` returns an empty string, so the badge renders as `"past  SLA"` with a blank where `"30m"` should appear.

   The simplest fix is to inject the attribute on the second `.approval-meta` (inside `.approval-action`) when `approval.past_sla` is true:

   ```js
   '<div class="approval-action"><strong title="' + escapeText(action) + '">' + escapeText(action) + '</strong>' +
     '<div class="approval-meta"' + (approval.past_sla ? ' data-sla-label="30m"' : '') + '><span class="' + approvalStatusClass(approval) + '">' + escapeText(approval.status || "unknown") + '</span></div></div>' +
   ```

   Alternatively, replace `attr(data-sla-label)` in the CSS with the hardcoded string `"30m"` if the label will never need to vary.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/server/fleet.go:882-884
**SLA constant and display text are separate declarations**

`fleetApprovalSLASeconds` (line 880) and `fleetApprovalSLAText()` (line 882) are independent. If the threshold is ever changed (e.g. to 60 minutes) the displayed "30m" copy in the badge, `NextAction` sentence, and test assertions must all be updated manually — there's no compile-time link keeping them in sync. Deriving the text from the constant would eliminate the drift risk:

```go
func fleetApprovalSLAText() string {
    minutes := fleetApprovalSLASeconds / 60
    return fmt.Sprintf("%dm", minutes)
}
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: escalate overdue pending approvals"](https://github.com/befeast/maestro/commit/a427f2ea045224dba904a0603fada9de8367eb61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30596595)</sub>

<!-- /greptile_comment -->