### PR TITLE
M-012: V2: add confirmation dialog scaffold and audit-log endpoint

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -14,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
@@ -155,6 +158,7 @@ func (s *FleetServer) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/v1/fleet/worker", s.handleFleetWorker)
 	mux.HandleFunc("/api/v1/fleet", s.handleFleet)
 	mux.HandleFunc("/api/v1/fleet/actions", s.handleFleetAction)
+	mux.HandleFunc("/api/v1/audit/log", s.handleFleetAuditLog)
 	mux.HandleFunc("/approvals/audit", s.handleFleetApprovalAudit)
 	mux.Handle("/static/", web.StaticHandler())
 	mux.HandleFunc("/", s.handleFleetDashboard)
@@ -525,6 +529,114 @@ func (s *FleetServer) handleFleetAction(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	writeError(w, http.StatusNotImplemented, "approval-backed action endpoints are not implemented yet")
+}
+
+type fleetAuditLogRequest struct {
+	Actor   string `json:"actor"`
+	Action  string `json:"action"`
+	Target  string `json:"target,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+	Project string `json:"project,omitempty"`
+}
+
+type fleetAuditLogEntry struct {
+	AuditID   string `json:"audit_id"`
+	Timestamp string `json:"timestamp"`
+	Actor     string `json:"actor"`
+	Action    string `json:"action"`
+	Target    string `json:"target,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+	Project   string `json:"project,omitempty"`
+}
+
+var fleetAuditLogMu sync.Mutex
+
+func (s *FleetServer) handleFleetAuditLog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req fleetAuditLogRequest
+	if r.Body != nil {
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("decode audit log request: %v", err))
+			return
+		}
+	}
+	actor := strings.TrimSpace(req.Actor)
+	action := strings.TrimSpace(req.Action)
+	if actor == "" || action == "" {
+		writeError(w, http.StatusBadRequest, "actor and action are required")
+		return
+	}
+	stateDir := s.fleetAuditLogStateDir(req.Project)
+	if stateDir == "" {
+		writeError(w, http.StatusInternalServerError, "no state dir is available to record the audit entry")
+		return
+	}
+	entry := fleetAuditLogEntry{
+		AuditID:   newFleetAuditID(),
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Actor:     actor,
+		Action:    action,
+		Target:    strings.TrimSpace(req.Target),
+		Reason:    strings.TrimSpace(req.Reason),
+		Project:   strings.TrimSpace(req.Project),
+	}
+	if err := appendFleetAuditLogEntry(stateDir, entry); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("write audit log: %v", err))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"audit_id": entry.AuditID})
+}
+
+func (s *FleetServer) fleetAuditLogStateDir(projectName string) string {
+	projectName = strings.TrimSpace(projectName)
+	if projectName != "" {
+		if project, ok := s.findProject(projectName); ok && project.cfg != nil && strings.TrimSpace(project.cfg.StateDir) != "" {
+			return project.cfg.StateDir
+		}
+	}
+	for _, project := range s.projects {
+		if project.cfg != nil && strings.TrimSpace(project.cfg.StateDir) != "" {
+			return project.cfg.StateDir
+		}
+	}
+	return ""
+}
+
+func appendFleetAuditLogEntry(stateDir string, entry fleetAuditLogEntry) error {
+	if strings.TrimSpace(stateDir) == "" {
+		return fmt.Errorf("audit log state dir is empty")
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(stateDir, "audit-log.jsonl")
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	fleetAuditLogMu.Lock()
+	defer fleetAuditLogMu.Unlock()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(append(encoded, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func newFleetAuditID() string {
+	var buf [12]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return fmt.Sprintf("audit-%d", time.Now().UnixNano())
+	}
+	return "audit-" + hex.EncodeToString(buf[:])
 }
 
 func (s *FleetServer) snapshot() fleetResponse {

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -570,7 +570,11 @@ func (s *FleetServer) handleFleetAuditLog(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "actor and action are required")
 		return
 	}
-	stateDir := s.fleetAuditLogStateDir(req.Project)
+	stateDir, err := s.fleetAuditLogStateDir(req.Project)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	if stateDir == "" {
 		writeError(w, http.StatusInternalServerError, "no state dir is available to record the audit entry")
 		return
@@ -591,19 +595,24 @@ func (s *FleetServer) handleFleetAuditLog(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, map[string]string{"audit_id": entry.AuditID})
 }
 
-func (s *FleetServer) fleetAuditLogStateDir(projectName string) string {
+func (s *FleetServer) fleetAuditLogStateDir(projectName string) (string, error) {
 	projectName = strings.TrimSpace(projectName)
 	if projectName != "" {
-		if project, ok := s.findProject(projectName); ok && project.cfg != nil && strings.TrimSpace(project.cfg.StateDir) != "" {
-			return project.cfg.StateDir
+		project, ok := s.findProject(projectName)
+		if !ok {
+			return "", fmt.Errorf("unknown project %q", projectName)
 		}
+		if project.cfg != nil && strings.TrimSpace(project.cfg.StateDir) != "" {
+			return project.cfg.StateDir, nil
+		}
+		return "", nil
 	}
 	for _, project := range s.projects {
 		if project.cfg != nil && strings.TrimSpace(project.cfg.StateDir) != "" {
-			return project.cfg.StateDir
+			return project.cfg.StateDir, nil
 		}
 	}
-	return ""
+	return "", nil
 }
 
 func appendFleetAuditLogEntry(stateDir string, entry fleetAuditLogEntry) error {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -2195,6 +2195,90 @@ func TestFleetDashboardServesFleetPath(t *testing.T) {
 	}
 }
 
+func TestFleetDashboardEmbedsConfirmDialogScaffold(t *testing.T) {
+	body := fleetDashboardBody(t)
+	for _, want := range []string{
+		`id="confirm-dialog"`,
+		`id="confirm-dialog-title"`,
+		`id="confirm-dialog-body"`,
+		`id="confirm-dialog-reason"`,
+		`id="confirm-dialog-trigger"`,
+		"function openConfirmDialog",
+		"function postAuditLog",
+		"/api/v1/audit/log",
+		`params.get("v2") === "1"`,
+	} {
+		if !contains(body, want) {
+			t.Fatalf("dashboard should embed confirm dialog scaffold token %q", want)
+		}
+	}
+}
+
+func TestFleetAuditLogAppendsJSONLine(t *testing.T) {
+	stateDir := t.TempDir()
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("AuditTarget", "/tmp/audit-target.yaml", "", &config.Config{
+			Repo: "owner/audit", StateDir: stateDir, MaxParallel: 1,
+		}),
+	}, "127.0.0.1", 8786, true)
+
+	body := strings.NewReader(`{"actor":"operator","action":"v2_smoke_test","target":"project-x","reason":"smoke test entry","project":"AuditTarget"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/log", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleFleetAuditLog(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["audit_id"] == "" {
+		t.Fatalf("response missing audit_id: %s", w.Body.String())
+	}
+
+	logPath := filepath.Join(stateDir, "audit-log.jsonl")
+	contents, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	line := strings.TrimSpace(string(contents))
+	if line == "" {
+		t.Fatalf("audit log is empty")
+	}
+	var entry fleetAuditLogEntry
+	if err := json.Unmarshal([]byte(line), &entry); err != nil {
+		t.Fatalf("unmarshal audit line: %v\nline=%s", err, line)
+	}
+	if entry.Actor != "operator" || entry.Action != "v2_smoke_test" || entry.Reason != "smoke test entry" {
+		t.Fatalf("audit entry = %+v, want operator/v2_smoke_test/smoke test entry", entry)
+	}
+	if entry.AuditID != resp["audit_id"] {
+		t.Fatalf("audit_id mismatch: response=%q line=%q", resp["audit_id"], entry.AuditID)
+	}
+	if entry.Timestamp == "" {
+		t.Fatalf("audit entry missing timestamp")
+	}
+}
+
+func TestFleetAuditLogRequiresActorAndAction(t *testing.T) {
+	stateDir := t.TempDir()
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("AuditTarget", "/tmp/audit-target.yaml", "", &config.Config{
+			Repo: "owner/audit", StateDir: stateDir, MaxParallel: 1,
+		}),
+	}, "127.0.0.1", 8786, true)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/log", strings.NewReader(`{"action":"only_action"}`))
+	w := httptest.NewRecorder()
+	srv.handleFleetAuditLog(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("missing actor: status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestFleetDashboardServesApprovalAuditPath(t *testing.T) {
 	srv := NewFleet(nil, "127.0.0.1", 8786, true)
 	req := httptest.NewRequest(http.MethodGet, "/approvals/audit", nil)

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2212,6 +2213,11 @@ func TestFleetDashboardEmbedsConfirmDialogScaffold(t *testing.T) {
 			t.Fatalf("dashboard should embed confirm dialog scaffold token %q", want)
 		}
 	}
+	resolverIndex := strings.Index(body, "resolver(payload || { confirmed: false")
+	closeIndex := strings.Index(body, "confirmDialogEl.close()")
+	if resolverIndex < 0 || closeIndex < 0 || resolverIndex > closeIndex {
+		t.Fatalf("confirm dialog should resolve before close event can cancel it")
+	}
 }
 
 func TestFleetAuditLogAppendsJSONLine(t *testing.T) {
@@ -2276,6 +2282,28 @@ func TestFleetAuditLogRequiresActorAndAction(t *testing.T) {
 	srv.handleFleetAuditLog(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("missing actor: status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestFleetAuditLogRejectsUnknownProject(t *testing.T) {
+	stateDir := t.TempDir()
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("AuditTarget", "/tmp/audit-target.yaml", "", &config.Config{
+			Repo: "owner/audit", StateDir: stateDir, MaxParallel: 1,
+		}),
+	}, "127.0.0.1", 8786, true)
+
+	body := strings.NewReader(`{"actor":"operator","action":"v2_smoke_test","target":"project-x","reason":"smoke test entry","project":"MissingProject"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/log", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleFleetAuditLog(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("unknown project: status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "audit-log.jsonl")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unknown project should not write fallback audit log, stat err=%v", err)
 	}
 }
 

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -2702,3 +2702,58 @@
     background: transparent;
     object-fit: contain;
   }
+
+  .confirm-dialog {
+    width: min(480px, calc(100vw - 32px));
+    padding: 0;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: var(--surface, #fff);
+    color: var(--text);
+    box-shadow: 0 24px 60px rgba(15,23,42,.18);
+  }
+  .confirm-dialog::backdrop {
+    background: rgba(15,23,42,.32);
+    backdrop-filter: blur(2px);
+  }
+  .confirm-dialog-form { padding: 18px 20px; display: flex; flex-direction: column; gap: 12px; }
+  .confirm-dialog-title { margin: 0; font-size: 16px; font-weight: 650; }
+  .confirm-dialog-body { font-size: 13px; color: var(--text); line-height: 1.5; }
+  .confirm-dialog-reason { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--muted); }
+  .confirm-dialog-reason textarea {
+    width: 100%;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px;
+    font: inherit;
+    background: var(--input-bg, #fff);
+    color: var(--text);
+    resize: vertical;
+  }
+  .confirm-dialog-reason textarea:focus { outline: 2px solid rgba(5,150,105,.45); outline-offset: 1px; }
+  .confirm-dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
+  .confirm-dialog-cancel,
+  .confirm-dialog-confirm {
+    padding: 8px 14px;
+    border-radius: 6px;
+    border: 1px solid var(--line);
+    cursor: pointer;
+    font: inherit;
+  }
+  .confirm-dialog-cancel { background: transparent; color: var(--text); }
+  .confirm-dialog-confirm {
+    background: var(--brand-a, #059669);
+    color: #fff;
+    border-color: var(--brand-a, #059669);
+  }
+  .confirm-dialog-confirm:hover { filter: brightness(1.05); }
+  .confirm-dialog-trigger {
+    height: 32px;
+    padding: 0 10px;
+    border-radius: 6px;
+    border: 1px solid var(--line);
+    background: var(--panel-2, #f8fafc);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+  }

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -2402,3 +2402,118 @@ if (initialFleetData) {
 loadFleet();
 setInterval(loadFleet, 3000);
 setInterval(loadWorkerDetail, 2000);
+
+const confirmDialogEl = document.getElementById("confirm-dialog");
+const confirmDialogTitleEl = document.getElementById("confirm-dialog-title");
+const confirmDialogBodyEl = document.getElementById("confirm-dialog-body");
+const confirmDialogReasonWrapEl = document.getElementById("confirm-dialog-reason-wrap");
+const confirmDialogReasonEl = document.getElementById("confirm-dialog-reason");
+const confirmDialogConfirmEl = document.getElementById("confirm-dialog-confirm");
+const confirmDialogCancelEl = document.getElementById("confirm-dialog-cancel");
+const confirmDialogTriggerEl = document.getElementById("confirm-dialog-trigger");
+
+let confirmDialogResolver = null;
+
+function openConfirmDialog(options) {
+  if (!confirmDialogEl || typeof confirmDialogEl.showModal !== "function") {
+    return Promise.resolve({ confirmed: false, reason: "" });
+  }
+  const opts = options || {};
+  confirmDialogTitleEl.textContent = opts.title || "Confirm";
+  confirmDialogBodyEl.innerHTML = opts.bodyHTML || "";
+  confirmDialogConfirmEl.textContent = opts.confirmLabel || "Confirm";
+  const requireReason = opts.requireReason === true;
+  if (requireReason) {
+    confirmDialogReasonWrapEl.hidden = false;
+    confirmDialogReasonEl.value = "";
+    confirmDialogReasonEl.required = true;
+  } else {
+    confirmDialogReasonWrapEl.hidden = true;
+    confirmDialogReasonEl.value = "";
+    confirmDialogReasonEl.required = false;
+  }
+  confirmDialogConfirmEl.dataset.requireReason = requireReason ? "1" : "0";
+  confirmDialogEl.showModal();
+  return new Promise(resolve => {
+    confirmDialogResolver = resolve;
+  });
+}
+
+function closeConfirmDialog(payload) {
+  if (confirmDialogEl && confirmDialogEl.open) confirmDialogEl.close();
+  if (confirmDialogResolver) {
+    const resolver = confirmDialogResolver;
+    confirmDialogResolver = null;
+    resolver(payload || { confirmed: false, reason: "" });
+  }
+}
+
+if (confirmDialogConfirmEl) {
+  confirmDialogConfirmEl.addEventListener("click", event => {
+    event.preventDefault();
+    const requireReason = confirmDialogConfirmEl.dataset.requireReason === "1";
+    const reason = (confirmDialogReasonEl && confirmDialogReasonEl.value || "").trim();
+    if (requireReason && reason.length < 10) {
+      confirmDialogReasonEl.setCustomValidity("Reason must be at least 10 characters.");
+      confirmDialogReasonEl.reportValidity();
+      return;
+    }
+    if (confirmDialogReasonEl) confirmDialogReasonEl.setCustomValidity("");
+    closeConfirmDialog({ confirmed: true, reason });
+  });
+}
+if (confirmDialogCancelEl) {
+  confirmDialogCancelEl.addEventListener("click", event => {
+    event.preventDefault();
+    closeConfirmDialog({ confirmed: false, reason: "" });
+  });
+}
+if (confirmDialogEl) {
+  confirmDialogEl.addEventListener("cancel", event => {
+    event.preventDefault();
+    closeConfirmDialog({ confirmed: false, reason: "" });
+  });
+  confirmDialogEl.addEventListener("close", () => {
+    if (confirmDialogResolver) {
+      const resolver = confirmDialogResolver;
+      confirmDialogResolver = null;
+      resolver({ confirmed: false, reason: "" });
+    }
+  });
+}
+
+async function postAuditLog(payload) {
+  const response = await fetch("/api/v1/audit/log", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload || {})
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error("audit log post failed: " + text);
+  }
+  return response.json();
+}
+
+if (confirmDialogTriggerEl) {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("v2") === "1") {
+    confirmDialogTriggerEl.hidden = false;
+    confirmDialogTriggerEl.addEventListener("click", async () => {
+      const result = await openConfirmDialog({
+        title: "V2 confirmation scaffold",
+        bodyHTML: '<p>This is a smoke test of the V2 confirmation modal. No live action will run. ' +
+          'Provide a reason below to exercise the audit-log endpoint.</p>',
+        confirmLabel: "Record audit entry",
+        requireReason: true
+      });
+      if (!result.confirmed) return;
+      try {
+        const audit = await postAuditLog({ actor: "operator", action: "v2_smoke_test", reason: result.reason });
+        confirmDialogTriggerEl.title = "Recorded audit " + (audit.audit_id || "");
+      } catch (err) {
+        confirmDialogTriggerEl.title = "Audit log failed: " + err.message;
+      }
+    });
+  }
+}

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -2440,12 +2440,12 @@ function openConfirmDialog(options) {
 }
 
 function closeConfirmDialog(payload) {
-  if (confirmDialogEl && confirmDialogEl.open) confirmDialogEl.close();
   if (confirmDialogResolver) {
     const resolver = confirmDialogResolver;
     confirmDialogResolver = null;
     resolver(payload || { confirmed: false, reason: "" });
   }
+  if (confirmDialogEl && confirmDialogEl.open) confirmDialogEl.close();
 }
 
 if (confirmDialogConfirmEl) {

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -32,6 +32,7 @@
   <div class="header-actions">
     <span class="mode-pill">Read-only</span>
     <button type="button" class="fleet-search-trigger" id="fleet-search-trigger" aria-haspopup="dialog" aria-controls="fleet-search-dialog"><span>Search</span><kbd>Cmd/Ctrl K</kbd></button>
+    <button type="button" class="confirm-dialog-trigger" id="confirm-dialog-trigger" aria-haspopup="dialog" aria-controls="confirm-dialog" hidden>Test confirm</button>
     <button type="button" class="refresh-button" id="fleet-refresh" aria-label="Refresh fleet data">↻</button>
     <span class="user-chip" aria-label="Operator ko">ko</span>
   </div>
@@ -206,6 +207,20 @@
       <div class="empty">Select a fleet worker to show metadata and log output.</div>
     </div>
   </section>
+  <dialog class="confirm-dialog" id="confirm-dialog" aria-labelledby="confirm-dialog-title">
+    <form method="dialog" class="confirm-dialog-form">
+      <h2 class="confirm-dialog-title" id="confirm-dialog-title">Confirm</h2>
+      <div class="confirm-dialog-body" id="confirm-dialog-body"></div>
+      <label class="confirm-dialog-reason" id="confirm-dialog-reason-wrap" hidden>
+        <span>Reason for stopping (visible to your team)</span>
+        <textarea id="confirm-dialog-reason" rows="3" minlength="10" placeholder="At least 10 characters explaining why."></textarea>
+      </label>
+      <div class="confirm-dialog-actions">
+        <button type="button" class="confirm-dialog-cancel" id="confirm-dialog-cancel" value="cancel">Cancel</button>
+        <button type="button" class="confirm-dialog-confirm" id="confirm-dialog-confirm" value="confirm">Confirm</button>
+      </div>
+    </form>
+  </dialog>
 </main>
 <script type="application/json" id="fleet-initial-state">{{FLEET_INITIAL_STATE}}</script>
 <script src="/static/fleet.js?v=20260503-5"></script>


### PR DESCRIPTION
## Summary
- Adds a generic `<dialog>` confirm component (title / body / optional stop-reason textarea) with an `openConfirmDialog` Promise helper and a `postAuditLog` fetch helper.
- Server-side `POST /api/v1/audit/log` appends a JSONL line under the project state dir and returns the generated `audit_id`.
- The "Test confirm" trigger in the header is hidden by default and only revealed with `?v2=1` to keep the smoke caller out of sight.
- No live actions are wired — this is scaffolding so the eventual V2 control PRs (Mark ready / restart / approve / pause) stay small.

Implements §10 backlog item M-012 of the Maestro UI Audit (May 2026).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/server/...` passes (added `TestFleetAuditLogAppendsJSONLine`, `TestFleetAuditLogRequiresActorAndAction`, `TestFleetDashboardEmbedsConfirmDialogScaffold`)
- [ ] Visit `/fleet?v2=1` — click "Test confirm" — confirm dialog opens, ESC closes, optional stop-reason textarea enforces ≥10 chars
- [ ] `curl -X POST -d '{"actor":"me","action":"test","target":"x","reason":"smoke"}' /api/v1/audit/log` — confirm 200 + `audit_id`, JSONL line appears in state dir

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a generic `<dialog>` confirm component with `openConfirmDialog` / `postAuditLog` helpers and a server-side `POST /api/v1/audit/log` endpoint that appends JSONL entries. The resolver-before-close fix is correctly implemented. One security issue warrants attention before future V2 callers land:

- `confirmDialogBodyEl.innerHTML = opts.bodyHTML` in `openConfirmDialog` assigns untrusted markup without sanitization. Future callers that interpolate API-sourced strings (project names, worker IDs) will introduce XSS.

<h3>Confidence Score: 4/5</h3>

Safe to merge as scaffolding, but the `innerHTML` XSS path should be resolved before any V2 caller passes API-sourced data into `bodyHTML`.

One P1 security finding (innerHTML XSS) caps the score at 4. The rest of the logic is sound: the resolver-before-close fix is correctly applied, Go-side file writes are mutex-protected, and test coverage is thorough.

`internal/server/web/static/fleet.js` — the `innerHTML` assignment in `openConfirmDialog`.

<details open><summary><h3>Security Review</h3></summary>

- **XSS via `innerHTML`** (`fleet.js` line 2423): `opts.bodyHTML` is written directly to `confirmDialogBodyEl.innerHTML`. Future V2 callers that interpolate API-sourced data (project names, worker IDs) into `bodyHTML` without prior sanitization will produce exploitable XSS.
- **Unauthenticated audit-log endpoint**: `POST /api/v1/audit/log` has no auth check; any client reachable to the server can write arbitrary entries to the audit file. Likely acceptable for scaffolding but should be addressed before production use.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds `handleFleetAuditLog` endpoint with JSONL append, mutex-protected file writes, and hex audit IDs. Logic is sound; the no-project state-dir fallback iterates a likely-map structure with non-deterministic order. |
| internal/server/fleet_test.go | Three new tests cover the happy path, missing-actor validation, unknown-project rejection, and the resolver-before-close ordering in the dashboard HTML. Coverage is thorough. |
| internal/server/web/static/fleet.js | Adds confirm dialog helpers. The resolver-before-close fix (from the prior review thread) is correctly applied. `opts.bodyHTML` is assigned via `innerHTML`, creating an XSS risk for future callers that interpolate API data. |
| internal/server/web/templates/fleet.html | Adds `<dialog>` scaffold and hidden trigger button. The `hidden` attribute on the trigger correctly keeps it out of sight until `?v2=1` is present. |
| internal/server/web/static/fleet.css | Adds styling for the confirm dialog and trigger button. No issues found. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/web/static/fleet.js:2423
**`innerHTML` assignment opens XSS path for future callers**

`opts.bodyHTML` is assigned directly to `innerHTML`. The PR explicitly states that future V2 control PRs (mark-ready, restart, approve, pause) will reuse this dialog — those callers will almost certainly interpolate dynamic data from API responses (project names, worker IDs, job titles). If any of that data contains `<img onerror=…>` or similar, it executes in the page context. Since the parameter is named `bodyHTML` and implies caller-controlled markup, either enforce that callers must pre-sanitize, or expose a `bodyText` path that uses `textContent` for plain-text callsites and only fall through to `innerHTML` when the caller explicitly opts in.

### Issue 2 of 2
internal/server/fleet.go:611-619
**Non-deterministic fallback state dir**

When `projectName` is empty, the function iterates `s.projects` to find any entry with a non-empty `StateDir`. If `s.projects` is a `map`, Go's range order is randomised per run — the same request could write to different project directories depending on which project happens to be visited first. For the smoke test this may be acceptable, but once real V2 actions rely on the no-project fallback path the log could silently scatter entries across directories.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: make v2 confirmation audit safe"](https://github.com/befeast/maestro/commit/67b062ba41e7060a599adb48d415f6a3416c8a2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30596605)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->