### PR TITLE
docs: add PO spec workflow and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/spec.yml
+++ b/.github/ISSUE_TEMPLATE/spec.yml
@@ -1,0 +1,112 @@
+name: Spec
+description: Product Owner spec for a Maestro worker to implement hands-off
+title: "<type>: <short description>"
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Write the spec the way you want a worker to read it. Be specific about acceptance and verification.
+        Apply the `maestro-ready` label only when the spec is reviewed and ready for pickup.
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent epic / roadmap ID
+      description: Optional. Reference parent epic (e.g., `#350`) and roadmap ID (e.g., `M-013`) if applicable.
+      placeholder: "Parent: #350 — Roadmap ID: M-013"
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One paragraph stating what should change and where.
+      placeholder: |
+        Reconcile dead/stale supervisor sessions in the Fleet API so the attention surface only reflects current operational truth.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this matters
+      description: The operator-facing problem this fixes. If a memory or past incident motivates it, name it.
+      placeholder: |
+        Fleet currently shows 103 workers in state, most of which are historical noise. Operator burden goes up, signal goes down.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and constraints
+      description: Where the change lives, what stays out of scope, hard constraints (light theme, status-board direction, V2 confirmation gate, etc.).
+      placeholder: |
+        Touch internal/server/fleet.go and reconciler. Do NOT change the V2 confirmation scaffold.
+        Light theme only. Must not regress fleet refresh interval (3s).
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete checkboxes a reviewer can verify without asking the author.
+      value: |
+        - [ ] 
+        - [ ] 
+        - [ ] 
+    validations:
+      required: true
+
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test plan
+      description: Specific tests to add or run. Worker must run `go test ./...` and frontend bun build before PR.
+      value: |
+        - [ ] Unit tests for the new behavior
+        - [ ] `go test ./...` passes on workshop
+        - [ ] `bun build internal/server/web/static/fleet.js` succeeds (if UI touched)
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Runtime verification
+      description: Commands or visual checks the operator (or worker) runs after deploy to confirm the change works against the live fleet.
+      placeholder: |
+        - `curl -fsS http://127.0.0.1:8786/api/v1/fleet | jq '.workers | length'` is below baseline by N
+        - Fleet dashboard shows zero `Worker exited and is waiting for retry` entries older than 24h
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: Things that look related but must NOT be touched in this spec.
+      placeholder: |
+        - Do not change V2 confirmation modal copy.
+        - Do not introduce new dashboard sections.
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority hint
+      description: PO sets desired priority; reviewer applies the actual P-label.
+      options:
+        - P0 — critical, drop other work
+        - P1 — high, schedule next
+        - P2 — medium, queue normally
+        - P3 — low, opportunistic
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: po_checklist
+    attributes:
+      label: PO checklist before applying `maestro-ready`
+      options:
+        - label: Acceptance criteria are testable without re-asking the PO
+        - label: Verification works against live workshop services, not just unit tests
+        - label: Scope and non-goals are explicit enough that the worker won't drift
+        - label: Spec does not require coordination across multiple repos

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@
 *.yml
 # But keep CI workflows
 !.github/workflows/*.yml
+!.github/ISSUE_TEMPLATE/*.yml
 .claude/

--- a/docs/po-spec-workflow.md
+++ b/docs/po-spec-workflow.md
@@ -1,0 +1,77 @@
+# Product Owner spec workflow
+
+Source of truth for spec **drafts** is the Obsidian vault at `Dev/Areas/maestro/specs/`. This document describes the GitHub-side execution contract that workers and reviewers rely on.
+
+## Loop
+
+1. **Draft in Obsidian** — create a note in `Dev/Areas/maestro/specs/<kebab-case>.md` with frontmatter
+   `type: spec`, `status: draft`, and the same sections this template will eventually expect
+   (Summary / Why / Scope / Acceptance / Test Plan / Verification / Non-goals). Iterate until the spec
+   is testable without re-asking the PO.
+2. **Promote to GitHub** — open a new issue in `BeFeast/maestro` using the **Spec** template
+   (`.github/ISSUE_TEMPLATE/spec.yml`). Paste/adapt the body from the Obsidian draft. Set the priority
+   dropdown. Update the Obsidian note: `status: ready`, `gh_issue: <number>`.
+3. **Self-review on the issue** — walk the PO checklist at the bottom of the form. If any box does not
+   check, leave the issue unlabeled until it does.
+4. **Mark ready** — apply the `maestro-ready` label, or move the issue into the Maestro GitHub Project
+   (#5) in column `Todo` / `Ready` / `Backlog` / `New`. The supervisor will add the label automatically
+   (`owns_ready_label: true`). Update the Obsidian note: `status: in-flight`.
+5. **Walk away** — `maestro-supervisor-dogfood.service` polls every 2 minutes, picks the issue,
+   spawns a worker (Claude opus, xhigh effort) in `/mnt/storage/worktrees/maestro/<session>`,
+   and produces a PR. Update the Obsidian note: `gh_pr: <number>`.
+6. **Review** — check the PR on GitHub. Wait for CI and Greptile.
+   Address any P1/P2 Greptile findings before merge (per the hard rules in the handover).
+7. **Merge** — operator-only, the supervisor cannot merge by itself
+   (`approval_required: [merge_pr, ...]`). Update the Obsidian note: `status: merged`.
+8. **Deploy** — only if the change touches code paths that ship with `/usr/local/bin/maestro`.
+   See `maestro-handover-2026-05-03.md` for the deploy snippet.
+
+
+## Pickup contract (do not break by accident)
+
+The supervisor selects issues that match **all** of:
+
+- have label `maestro-ready`
+- do **not** have any of `blocked`, `wontfix`, `question`, `duplicate`, `invalid`, `epic`, `meta`
+- are **open**
+
+Source of truth: `~/.maestro/maestro.d/maestro-supervisor-dogfood.yaml`.
+
+If a spec needs to wait, add `blocked` and explain in a comment. Do not delete the issue — supervisor needs the
+audit trail.
+
+## What makes a good spec
+
+- **Acceptance criteria are testable without re-asking the PO.** If a worker has to guess, the spec is not done.
+- **Verification runs against live workshop services**, not just unit tests. Maestro is judged by what the
+  Fleet dashboard says after deploy, not by green CI.
+- **Scope and non-goals are explicit.** The worker prompt forbids "broad refactors"; specs that imply them get
+  partial implementations.
+- **No multi-repo coordination in one spec.** Split into per-repo specs.
+
+## What makes a bad spec
+
+- "Improve the dashboard" — not testable.
+- "Refactor X" with no observable behavior change — workers cannot prove done.
+- Specs that require running things off-workshop (laptop, NFS) — violates the hard operating rules.
+- Specs that re-introduce dense, nested, inspector-style UI — see the UI direction in the handover.
+
+## Operator commands
+
+Inspect the queue:
+
+```bash
+ssh workshop 'cd /mnt/storage/src/maestro && gh issue list --repo BeFeast/maestro --state open --label maestro-ready --limit 50'
+```
+
+Watch the live brief:
+
+```bash
+ssh workshop 'curl -fsS http://127.0.0.1:8786/api/v1/fleet | /usr/bin/jq .verdict.sentence'
+```
+
+Pause a single spec without losing it:
+
+```bash
+ssh workshop 'gh issue edit <NUM> --repo BeFeast/maestro --add-label blocked --remove-label maestro-ready'
+```


### PR DESCRIPTION
## Summary

- Adds a Product Owner spec workflow: drafts live in the Obsidian vault under `Dev/Areas/maestro/specs/`, get promoted to GitHub issues via a structured `Spec` issue template, and only become pickable by `maestro-supervisor-dogfood.service` when the operator applies `maestro-ready` (or moves the issue to a runnable column in Maestro Project #5).
- Documents the **pickup contract** so reviewers and future workers do not change it by accident: required label `maestro-ready`, excluded labels `blocked / wontfix / question / duplicate / invalid / epic / meta`, polling `maestro-supervisor-dogfood.yaml`.
- Fixes `.gitignore` so `.github/ISSUE_TEMPLATE/*.yml` is tracked despite the global `*.yml` exclude (mirrors the existing allow for `.github/workflows/*.yml`).

## What lands

- `.github/ISSUE_TEMPLATE/spec.yml` — form-based spec template with required Summary / Why / Acceptance Criteria / Runtime Verification, optional Scope / Test Plan / Non-goals, a priority dropdown, and a PO self-review checklist before `maestro-ready` is applied.
- `docs/po-spec-workflow.md` — Obsidian → GitHub loop, the pickup contract, and operator commands (queue inspection, brief, pause).
- `.gitignore` — adds `!.github/ISSUE_TEMPLATE/*.yml`.

## What does NOT land here

- The first two seed specs (stale session reconciliation, global operator brief). They live as drafts in Obsidian under `Dev/Areas/maestro/specs/` and will be filed as separate GitHub issues using this template once merged. Filing them now without `maestro-ready` would still queue safely, but waiting keeps the PR strictly about workflow plumbing.

## Test plan

- [x] `go test ./...` passes on workshop.
- [x] `go build ./cmd/maestro` passes on workshop.
- [ ] Reviewer confirms the issue template renders correctly on GitHub when filing a new issue.
- [ ] Reviewer confirms `.gitignore` change does not let other `.yml` files leak in.

Refs #350.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the PO spec workflow: a structured GitHub issue form template (`spec.yml`), the corresponding `.gitignore` negation to track it, and a doc (`po-spec-workflow.md`) describing the Obsidian → GitHub loop and supervisor pickup contract. All three files are self-consistent and the `.gitignore` change correctly mirrors the existing `!.github/workflows/*.yml` pattern.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive docs/config with no logic changes

All changes are documentation and configuration. The issue template is well-formed, the gitignore rule is consistent with existing patterns, and the workflow doc accurately describes the pickup contract. No logic errors found.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/spec.yml | New GitHub issue form template for PO specs; fields, validations, and required/optional designations all look correct |
| .gitignore | Adds negation rule for ISSUE_TEMPLATE/*.yml, consistent with the existing workflows/*.yml exception; covers the new spec.yml file correctly |
| docs/po-spec-workflow.md | New workflow doc covering the Obsidian→GitHub loop, pickup contract, and operator commands; content is internally consistent |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add PO spec workflow and issue tem..."](https://github.com/befeast/maestro/commit/a33f0e7ae7e7459169e6689ea421208fd50a2fdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30603186)</sub>

<!-- /greptile_comment -->