### PR TITLE
feat: reconcile stale supervisor sessions in Fleet API (#398)

### DIFF
--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -272,6 +272,28 @@ maestro supervise approve --config ~/.maestro/maestro-<project>.yaml --actor <op
 maestro supervise reject --config ~/.maestro/maestro-<project>.yaml --actor <operator> --reason "state changed" <approval-or-decision-id>
 ```
 
+### Stale supervisor sessions
+
+Mission Control indicators: `attention` shows old retry/dead sessions whose worktree has already been cleaned up or whose PR has been closed long ago, and `verdict.sentence` keeps reporting items needing attention even though no operator step is possible.
+
+Safe response:
+
+1. Confirm the project's `stale_session_reconciler` configuration before changing anything:
+   - `enabled` defaults to `true`.
+   - `idle_after_minutes` defaults to `1440` (24 hours).
+   - `require_worktree_missing` defaults to `true`.
+2. Sessions that pass all three checks (idle past the window AND a recorded worktree path AND that path is missing on disk) are removed from `attention` and recorded in `audit-log.jsonl` under the project's `state_dir` with action `stale_session_reconciled`. The sessions remain searchable in `workers` for drilldown.
+3. To temporarily disable filtering for a project, set `stale_session_reconciler.enabled: false` and restart the project runner.
+4. To tighten the window during dogfood/recovery, lower `idle_after_minutes` (for example `60` for one hour). Keep `require_worktree_missing: true` so a live worker is never reclaimed.
+5. Per-project `stale_session_reconciler` config example:
+
+```yaml
+stale_session_reconciler:
+  enabled: true
+  idle_after_minutes: 1440
+  require_worktree_missing: true
+```
+
 ### Project API failure
 
 Mission Control indicators: project card error, failed `maestro supervise`, failed `maestro status`, GraphQL/project item errors, or GitHub CLI authentication errors.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,54 +225,96 @@ type HooksConfig struct {
 	TimeoutMs    int    `yaml:"timeout_ms"`    // timeout for hook execution in milliseconds (default: 60000)
 }
 
+// StaleSessionReconcilerConfig configures filtering of stale supervisor
+// sessions out of the operator-facing attention list.
+//
+// Defaults are conservative so a worker that simply has not written state
+// for a few minutes is never reclassified as stale. A session is filtered
+// only when it has been idle for at least IdleAfterMinutes AND its
+// recorded worktree is missing on disk (when require_worktree_missing is
+// true, the default).
+type StaleSessionReconcilerConfig struct {
+	Enabled                *bool `yaml:"enabled"`                  // default: true
+	IdleAfterMinutes       int   `yaml:"idle_after_minutes"`       // default: 1440 (24h)
+	RequireWorktreeMissing *bool `yaml:"require_worktree_missing"` // default: true
+}
+
+// IsEnabled returns whether stale-session reconciliation runs.
+// Default is enabled when the field is unset.
+func (c StaleSessionReconcilerConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// WorktreeMissingRequired returns whether a session must also have a missing
+// worktree to be classified as stale. Default true.
+func (c StaleSessionReconcilerConfig) WorktreeMissingRequired() bool {
+	if c.RequireWorktreeMissing == nil {
+		return true
+	}
+	return *c.RequireWorktreeMissing
+}
+
+// IdleAfter returns the idle window after which a session is considered for
+// reconciliation. Default 24h when IdleAfterMinutes is unset or non-positive.
+func (c StaleSessionReconcilerConfig) IdleAfter() int {
+	if c.IdleAfterMinutes <= 0 {
+		return 24 * 60
+	}
+	return c.IdleAfterMinutes
+}
+
 type Config struct {
-	Server                     ServerConfig         `yaml:"server"`
-	Supervisor                 SupervisorConfig     `yaml:"supervisor"`
-	Repo                       string               `yaml:"repo"`
-	Outcome                    outcome.Brief        `yaml:"outcome"`
-	LocalPath                  string               `yaml:"local_path"`
-	WorktreeBase               string               `yaml:"worktree_base"`
-	MaxParallel                int                  `yaml:"max_parallel"`
-	MaxConcurrentByState       map[string]int       `yaml:"max_concurrent_by_state"`       // per-state concurrency limits (e.g. "running": 5, "pr_open": 2)
-	MaxRuntimeMinutes          int                  `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
-	WorkerSilentTimeoutMinutes int                  `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
-	WorkerMaxTokens            int                  `yaml:"worker_max_tokens"`             // kill worker when token usage exceeds this threshold (0 = unlimited)
-	WorkerSoftTokenThreshold   *float64             `yaml:"worker_soft_token_threshold"`   // fraction of worker_max_tokens to trigger checkpoint+respawn (default: 0.8, 0 = disabled)
-	MaxRetriesPerIssue         int                  `yaml:"max_retries_per_issue"`         // max failed worker sessions per issue before giving up (default: 3, 0 = unlimited)
-	AutoRebase                 bool                 `yaml:"auto_rebase"`                   // auto-attempt rebase for conflicting sessions (default: true)
-	ClaudeCmd                  string               `yaml:"claude_cmd"`                    // deprecated: use model.backends.claude.cmd
-	IssueLabel                 string               `yaml:"issue_label"`                   // deprecated: use issue_labels
-	IssueLabels                []string             `yaml:"issue_labels"`
-	ExcludeLabels              []string             `yaml:"exclude_labels"`
-	WorkerPrompt               string               `yaml:"worker_prompt"`
-	BugPrompt                  string               `yaml:"bug_prompt"`          // prompt template for issues with "bug" label
-	EnhancementPrompt          string               `yaml:"enhancement_prompt"`  // prompt template for issues with "enhancement" label
-	PromptSections             []string             `yaml:"prompt_sections"`     // additional prompt section files appended to the base prompt
-	ValidationContract         bool                 `yaml:"validation_contract"` // generate VALIDATION.md in worktree with test-first guidance
-	SessionPrefix              string               `yaml:"session_prefix"`      // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string               `yaml:"state_dir"`           // state/log directory (default: ~/.maestro/<repo-hash>)
-	Model                      ModelConfig          `yaml:"model"`
-	Routing                    RoutingConfig        `yaml:"routing"`
-	DeployCmd                  string               `yaml:"deploy_cmd"`                  // shell command to run after successful PR merge
-	DeployTimeoutMinutes       int                  `yaml:"deploy_timeout_minutes"`      // timeout for deploy command in minutes (default: 15)
-	MergeStrategy              string               `yaml:"merge_strategy"`              // "sequential" | "parallel"
-	MergeIntervalSeconds       int                  `yaml:"merge_interval_seconds"`      // minimum seconds between merges in sequential mode
-	ReviewGate                 string               `yaml:"review_gate"`                 // "greptile" (default) | "none"
-	AutoRetryReviewFeedback    bool                 `yaml:"auto_retry_review_feedback"`  // close PRs with review comments and respawn a fixer
-	AutoRetryRebaseConflicts   bool                 `yaml:"auto_retry_rebase_conflicts"` // retry PRs whose auto-rebase fails with conflicts
-	Telegram                   TelegramConfig       `yaml:"telegram"`
-	Versioning                 VersioningConfig     `yaml:"versioning"`
-	GitHubProjects             GitHubProjectsConfig `yaml:"github_projects"`
-	MaxRetryBackoffMs          int                  `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
-	AutoResolveFiles           []string             `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
-	AutoRestoreFiles           []string             `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase
-	CleanupWorktreesOnMerge    *bool                `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
-	Pipeline                   PipelineConfig       `yaml:"pipeline"`
-	Hooks                      HooksConfig          `yaml:"hooks"`
-	Missions                   MissionsConfig       `yaml:"missions"`
-	BlockerPatterns            []string             `yaml:"blocker_patterns"`      // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
-	PollIntervalSeconds        int                  `yaml:"poll_interval_seconds"` // override poll interval from config (0 = use CLI flag)
-	SourcePath                 string               `yaml:"-"`                     // path the config was loaded from (not serialized)
+	Server                     ServerConfig                 `yaml:"server"`
+	Supervisor                 SupervisorConfig             `yaml:"supervisor"`
+	Repo                       string                       `yaml:"repo"`
+	Outcome                    outcome.Brief                `yaml:"outcome"`
+	LocalPath                  string                       `yaml:"local_path"`
+	WorktreeBase               string                       `yaml:"worktree_base"`
+	MaxParallel                int                          `yaml:"max_parallel"`
+	MaxConcurrentByState       map[string]int               `yaml:"max_concurrent_by_state"`       // per-state concurrency limits (e.g. "running": 5, "pr_open": 2)
+	MaxRuntimeMinutes          int                          `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
+	WorkerSilentTimeoutMinutes int                          `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
+	WorkerMaxTokens            int                          `yaml:"worker_max_tokens"`             // kill worker when token usage exceeds this threshold (0 = unlimited)
+	WorkerSoftTokenThreshold   *float64                     `yaml:"worker_soft_token_threshold"`   // fraction of worker_max_tokens to trigger checkpoint+respawn (default: 0.8, 0 = disabled)
+	MaxRetriesPerIssue         int                          `yaml:"max_retries_per_issue"`         // max failed worker sessions per issue before giving up (default: 3, 0 = unlimited)
+	AutoRebase                 bool                         `yaml:"auto_rebase"`                   // auto-attempt rebase for conflicting sessions (default: true)
+	ClaudeCmd                  string                       `yaml:"claude_cmd"`                    // deprecated: use model.backends.claude.cmd
+	IssueLabel                 string                       `yaml:"issue_label"`                   // deprecated: use issue_labels
+	IssueLabels                []string                     `yaml:"issue_labels"`
+	ExcludeLabels              []string                     `yaml:"exclude_labels"`
+	WorkerPrompt               string                       `yaml:"worker_prompt"`
+	BugPrompt                  string                       `yaml:"bug_prompt"`          // prompt template for issues with "bug" label
+	EnhancementPrompt          string                       `yaml:"enhancement_prompt"`  // prompt template for issues with "enhancement" label
+	PromptSections             []string                     `yaml:"prompt_sections"`     // additional prompt section files appended to the base prompt
+	ValidationContract         bool                         `yaml:"validation_contract"` // generate VALIDATION.md in worktree with test-first guidance
+	SessionPrefix              string                       `yaml:"session_prefix"`      // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                   string                       `yaml:"state_dir"`           // state/log directory (default: ~/.maestro/<repo-hash>)
+	Model                      ModelConfig                  `yaml:"model"`
+	Routing                    RoutingConfig                `yaml:"routing"`
+	DeployCmd                  string                       `yaml:"deploy_cmd"`                  // shell command to run after successful PR merge
+	DeployTimeoutMinutes       int                          `yaml:"deploy_timeout_minutes"`      // timeout for deploy command in minutes (default: 15)
+	MergeStrategy              string                       `yaml:"merge_strategy"`              // "sequential" | "parallel"
+	MergeIntervalSeconds       int                          `yaml:"merge_interval_seconds"`      // minimum seconds between merges in sequential mode
+	ReviewGate                 string                       `yaml:"review_gate"`                 // "greptile" (default) | "none"
+	AutoRetryReviewFeedback    bool                         `yaml:"auto_retry_review_feedback"`  // close PRs with review comments and respawn a fixer
+	AutoRetryRebaseConflicts   bool                         `yaml:"auto_retry_rebase_conflicts"` // retry PRs whose auto-rebase fails with conflicts
+	Telegram                   TelegramConfig               `yaml:"telegram"`
+	Versioning                 VersioningConfig             `yaml:"versioning"`
+	GitHubProjects             GitHubProjectsConfig         `yaml:"github_projects"`
+	MaxRetryBackoffMs          int                          `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
+	AutoResolveFiles           []string                     `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
+	AutoRestoreFiles           []string                     `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase
+	CleanupWorktreesOnMerge    *bool                        `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
+	Pipeline                   PipelineConfig               `yaml:"pipeline"`
+	Hooks                      HooksConfig                  `yaml:"hooks"`
+	Missions                   MissionsConfig               `yaml:"missions"`
+	BlockerPatterns            []string                     `yaml:"blocker_patterns"`         // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
+	PollIntervalSeconds        int                          `yaml:"poll_interval_seconds"`    // override poll interval from config (0 = use CLI flag)
+	StaleSessionReconciler     StaleSessionReconcilerConfig `yaml:"stale_session_reconciler"` // filter stale supervisor sessions from operator attention
+	SourcePath                 string                       `yaml:"-"`                        // path the config was loaded from (not serialized)
 }
 
 // LoadFrom loads config from a specific path.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,48 @@ import (
 	"testing"
 )
 
+func TestParse_StaleSessionReconcilerDefaults(t *testing.T) {
+	yaml := `
+repo: owner/repo
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.StaleSessionReconciler.IsEnabled() {
+		t.Fatalf("default reconciler must be enabled")
+	}
+	if got := cfg.StaleSessionReconciler.IdleAfter(); got != 24*60 {
+		t.Fatalf("default idle after = %d minutes, want 1440", got)
+	}
+	if !cfg.StaleSessionReconciler.WorktreeMissingRequired() {
+		t.Fatalf("default reconciler must require worktree missing")
+	}
+}
+
+func TestParse_StaleSessionReconcilerExplicitOverride(t *testing.T) {
+	yaml := `
+repo: owner/repo
+stale_session_reconciler:
+  enabled: false
+  idle_after_minutes: 90
+  require_worktree_missing: false
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.StaleSessionReconciler.IsEnabled() {
+		t.Fatalf("explicit enabled=false must disable reconciler")
+	}
+	if got := cfg.StaleSessionReconciler.IdleAfter(); got != 90 {
+		t.Fatalf("idle after = %d minutes, want 90", got)
+	}
+	if cfg.StaleSessionReconciler.WorktreeMissingRequired() {
+		t.Fatalf("explicit require_worktree_missing=false should disable worktree gate")
+	}
+}
+
 func TestParse_IssueLabelsNew(t *testing.T) {
 	yaml := `
 repo: owner/repo

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -551,6 +551,11 @@ type fleetAuditLogEntry struct {
 
 var fleetAuditLogMu sync.Mutex
 
+var (
+	fleetStaleAuditMu      sync.Mutex
+	fleetStaleAuditEmitted = make(map[string]struct{})
+)
+
 func (s *FleetServer) handleFleetAuditLog(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -1490,14 +1495,32 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 			item.ApprovalSummary[approval.Status]++
 		}
 	}
+	staleAudits := reconcileStaleSessions(cfg, st, now)
+	staleSlots := make(map[string]state.StaleSessionAudit, len(staleAudits))
+	for _, audit := range staleAudits {
+		staleSlots[audit.Slot] = audit
+	}
+	if len(staleAudits) > 0 {
+		recordStaleSessionAudits(cfg.StateDir, project.Name, staleAudits)
+	}
 	workers := make([]fleetWorkerState, 0, len(projectState.All))
 	for _, worker := range projectState.All {
 		worker.Actions = workerActionAffordances(item.ReadOnly, "/api/v1/fleet/actions", worker)
+		if audit, isStale := staleSlots[worker.Slot]; isStale {
+			worker.NeedsAttention = false
+			if reason := strings.TrimSpace(audit.Reason); reason != "" {
+				worker.StatusReason = "stale session reconciled: " + reason
+			}
+			worker.NextAction = "No action required: this session was reconciled as stale by the fleet API."
+		}
 		if worker.NeedsAttention {
 			item.NeedsAttention++
 			item.Attention = append(item.Attention, worker)
 		}
 		workers = append(workers, makeFleetWorkerState(item, worker))
+		if _, isStale := staleSlots[worker.Slot]; isStale {
+			continue
+		}
 		if isFleetWorkerDefaultVisible(worker) {
 			if len(item.Active) >= 6 {
 				continue
@@ -1507,6 +1530,66 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	}
 	item.OperatorState = buildFleetProjectOperatorState(item)
 	return item, workers
+}
+
+func reconcileStaleSessions(cfg *config.Config, st *state.State, now time.Time) []state.StaleSessionAudit {
+	if cfg == nil || st == nil {
+		return nil
+	}
+	policy := state.StaleSessionPolicy{
+		Enabled:                cfg.StaleSessionReconciler.IsEnabled(),
+		IdleAfter:              time.Duration(cfg.StaleSessionReconciler.IdleAfter()) * time.Minute,
+		RequireWorktreeMissing: cfg.StaleSessionReconciler.WorktreeMissingRequired(),
+	}
+	if !policy.Enabled {
+		return nil
+	}
+	return st.ReconcileStaleSessions(now, policy, worktreeExistsOnDisk)
+}
+
+func worktreeExistsOnDisk(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+func recordStaleSessionAudits(stateDir, projectName string, audits []state.StaleSessionAudit) {
+	if strings.TrimSpace(stateDir) == "" || len(audits) == 0 {
+		return
+	}
+	project := strings.TrimSpace(projectName)
+	for _, audit := range audits {
+		key := project + "\x00" + audit.Slot + "\x00" + audit.Reason
+		fleetStaleAuditMu.Lock()
+		_, alreadyEmitted := fleetStaleAuditEmitted[key]
+		if !alreadyEmitted {
+			fleetStaleAuditEmitted[key] = struct{}{}
+		}
+		fleetStaleAuditMu.Unlock()
+		if alreadyEmitted {
+			continue
+		}
+		entry := fleetAuditLogEntry{
+			AuditID:   newFleetAuditID(),
+			Timestamp: audit.At.UTC().Format(time.RFC3339Nano),
+			Actor:     "fleet-reconciler",
+			Action:    "stale_session_reconciled",
+			Target:    audit.Slot,
+			Reason:    audit.Reason,
+			Project:   project,
+		}
+		if err := appendFleetAuditLogEntry(stateDir, entry); err != nil {
+			log.Printf("[fleet] stale-session audit write failed for %s: %v", audit.Slot, err)
+			fleetStaleAuditMu.Lock()
+			delete(fleetStaleAuditEmitted, key)
+			fleetStaleAuditMu.Unlock()
+		}
+	}
 }
 
 func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorState {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -2451,6 +2451,164 @@ func dashboardSnippet(t *testing.T, body, startMarker, endMarker string) string 
 	return rest[:end]
 }
 
+func TestFleetAPIFiltersStaleSessionsFromAttention(t *testing.T) {
+	resetFleetStaleAuditDedup()
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "state")
+	missingWorktree := filepath.Join(dir, "missing-worktree")
+	presentWorktree := filepath.Join(dir, "present-worktree")
+	if err := os.MkdirAll(presentWorktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	finishedOld := now.Add(-30 * time.Hour)
+	finishedRecent := now.Add(-2 * time.Hour)
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"stale-1": {
+			IssueNumber: 401,
+			IssueTitle:  "Old retry-exhausted with no worktree",
+			Status:      state.StatusDead,
+			StartedAt:   finishedOld.Add(-time.Hour),
+			FinishedAt:  &finishedOld,
+			Worktree:    missingWorktree,
+		},
+		"live-running": {
+			IssueNumber: 402,
+			IssueTitle:  "Healthy worker",
+			Status:      state.StatusRunning,
+			StartedAt:   now.Add(-2 * time.Minute),
+			Worktree:    presentWorktree,
+		},
+		"present-dead": {
+			IssueNumber: 403,
+			IssueTitle:  "Dead worker but worktree still present",
+			Status:      state.StatusDead,
+			StartedAt:   finishedOld.Add(-time.Hour),
+			FinishedAt:  &finishedOld,
+			Worktree:    presentWorktree,
+		},
+		"recent-dead": {
+			IssueNumber: 404,
+			IssueTitle:  "Recently dead worker, still inside idle window",
+			Status:      state.StatusDead,
+			StartedAt:   finishedRecent.Add(-30 * time.Minute),
+			FinishedAt:  &finishedRecent,
+			Worktree:    missingWorktree,
+		},
+	})
+
+	cfg := &config.Config{
+		Repo:        "owner/finance",
+		StateDir:    stateDir,
+		MaxParallel: 4,
+	}
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("finance", "/tmp/finance.yaml", "http://127.0.0.1:8788", cfg),
+	}, "127.0.0.1", 8786, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleet(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp fleetResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, worker := range resp.Attention {
+		if worker.Slot == "stale-1" {
+			t.Fatalf("stale-1 must not appear in attention list: %+v", worker)
+		}
+	}
+
+	stale := findFleetWorker(t, resp.Workers, "stale-1")
+	if stale.NeedsAttention {
+		t.Fatalf("stale-1 should be cleared from needs_attention but kept in workers list: %+v", stale)
+	}
+	if !contains(stale.StatusReason, "stale session reconciled") {
+		t.Fatalf("stale-1 status reason = %q, want reconciliation explanation", stale.StatusReason)
+	}
+
+	if !findFleetWorker(t, resp.Workers, "present-dead").NeedsAttention {
+		t.Fatalf("present-dead has a live worktree, must remain in attention")
+	}
+	if !findFleetWorker(t, resp.Workers, "recent-dead").NeedsAttention {
+		t.Fatalf("recent-dead is inside the idle window, must remain in attention")
+	}
+
+	auditPath := filepath.Join(stateDir, "audit-log.jsonl")
+	data, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	if !contains(string(data), "stale_session_reconciled") {
+		t.Fatalf("audit log missing reconciler entry: %s", data)
+	}
+	if !contains(string(data), "stale-1") {
+		t.Fatalf("audit log missing stale slot: %s", data)
+	}
+
+	// Second snapshot must not duplicate the audit entry.
+	w2 := httptest.NewRecorder()
+	srv.handleFleet(w2, httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil))
+	data2, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit log second pass: %v", err)
+	}
+	if !bytes.Equal(data, data2) {
+		t.Fatalf("audit log should be append-once for the same stale session.\nfirst:\n%s\nsecond:\n%s", data, data2)
+	}
+}
+
+func TestFleetAPIDisabledReconcilerKeepsAttention(t *testing.T) {
+	resetFleetStaleAuditDedup()
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "state")
+	missingWorktree := filepath.Join(dir, "missing-worktree")
+	finishedOld := now.Add(-30 * time.Hour)
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"stale-1": {
+			IssueNumber: 501,
+			Status:      state.StatusDead,
+			StartedAt:   finishedOld.Add(-time.Hour),
+			FinishedAt:  &finishedOld,
+			Worktree:    missingWorktree,
+		},
+	})
+
+	disabled := false
+	cfg := &config.Config{
+		Repo:        "owner/finance",
+		StateDir:    stateDir,
+		MaxParallel: 4,
+		StaleSessionReconciler: config.StaleSessionReconcilerConfig{
+			Enabled: &disabled,
+		},
+	}
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("finance", "/tmp/finance.yaml", "http://127.0.0.1:8788", cfg),
+	}, "127.0.0.1", 8786, true)
+
+	resp := srv.snapshot()
+	stale := findFleetWorker(t, resp.Workers, "stale-1")
+	if !stale.NeedsAttention {
+		t.Fatalf("disabled reconciler must not filter attention; got %+v", stale)
+	}
+
+	if _, err := os.Stat(filepath.Join(stateDir, "audit-log.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("disabled reconciler must not write audit entries; err = %v", err)
+	}
+}
+
+func resetFleetStaleAuditDedup() {
+	fleetStaleAuditMu.Lock()
+	fleetStaleAuditEmitted = make(map[string]struct{})
+	fleetStaleAuditMu.Unlock()
+}
+
 func TestFleetActionReadOnlyRejectsMutation(t *testing.T) {
 	srv := NewFleet(nil, "127.0.0.1", 8786, true)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/actions", nil)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1731,3 +1731,128 @@ func (s *State) PruneOldSessions(maxAge time.Duration) int {
 	}
 	return pruned
 }
+
+// StaleSessionPolicy controls reconciliation of sessions that have been idle
+// past their useful lifetime. The policy is intentionally conservative so a
+// live worker is never reclassified as stale.
+type StaleSessionPolicy struct {
+	// Enabled turns on stale-session reconciliation. When false, the helpers
+	// in this file always report sessions as live.
+	Enabled bool
+	// IdleAfter is the minimum time a session must be idle (no state writes,
+	// finished/started in the past) before it can be considered stale.
+	IdleAfter time.Duration
+	// RequireWorktreeMissing demands that the recorded worktree path does not
+	// exist on disk before a session is considered stale. Together with the
+	// idle window this prevents a live worker that simply has not written
+	// state recently from being filtered out.
+	RequireWorktreeMissing bool
+}
+
+// StaleSessionAudit records a single stale-session reconciliation event.
+// Callers persist this through a project's audit log; it is not stored in
+// state.json so historical records remain even if state is rewritten.
+type StaleSessionAudit struct {
+	Slot        string    `json:"slot"`
+	IssueNumber int       `json:"issue_number,omitempty"`
+	PRNumber    int       `json:"pr_number,omitempty"`
+	Status      string    `json:"status,omitempty"`
+	Reason      string    `json:"reason"`
+	IdleSeconds int64     `json:"idle_seconds"`
+	At          time.Time `json:"at"`
+}
+
+// SessionStale reports whether a session should be filtered from operator
+// attention because the recorded worker has clearly stopped progressing.
+// The optional worktreeExists callback lets callers inject filesystem checks
+// without leaking os.Stat into the state package boundary.
+func SessionStale(sess *Session, now time.Time, policy StaleSessionPolicy, worktreeExists func(string) bool) (StaleSessionAudit, bool) {
+	if sess == nil || !policy.Enabled {
+		return StaleSessionAudit{}, false
+	}
+	if policy.IdleAfter <= 0 {
+		return StaleSessionAudit{}, false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	// Live workers and waiting-for-CI sessions are never stale: they are
+	// actively progressing or expected to progress without operator help.
+	switch sess.Status {
+	case StatusRunning, StatusPROpen, StatusQueued, StatusCodeLanded, StatusDone:
+		return StaleSessionAudit{}, false
+	}
+	// Sessions with a scheduled retry are still "in flight" by policy.
+	if sess.NextRetryAt != nil && now.Before(sess.NextRetryAt.UTC()) {
+		return StaleSessionAudit{}, false
+	}
+
+	changedAt := SessionChangedAt(sess)
+	if changedAt.IsZero() {
+		return StaleSessionAudit{}, false
+	}
+	idle := now.Sub(changedAt)
+	if idle < policy.IdleAfter {
+		return StaleSessionAudit{}, false
+	}
+
+	if policy.RequireWorktreeMissing {
+		// We must have positive evidence (a recorded worktree path that no
+		// longer exists on disk) before reclassifying a session as stale.
+		// Without that evidence, the session is left alone so a live worker
+		// is never reclaimed by the reconciler.
+		worktreePath := strings.TrimSpace(sess.Worktree)
+		if worktreePath == "" || worktreeExists == nil || worktreeExists(worktreePath) {
+			return StaleSessionAudit{}, false
+		}
+	}
+
+	reason := stalenessReason(sess, idle, policy)
+	return StaleSessionAudit{
+		Slot:        "",
+		IssueNumber: sess.IssueNumber,
+		PRNumber:    sess.PRNumber,
+		Status:      string(sess.Status),
+		Reason:      reason,
+		IdleSeconds: int64(idle.Round(time.Second) / time.Second),
+		At:          now,
+	}, true
+}
+
+func stalenessReason(sess *Session, idle time.Duration, policy StaleSessionPolicy) string {
+	idleHours := int(idle.Round(time.Hour) / time.Hour)
+	if policy.RequireWorktreeMissing {
+		return fmt.Sprintf("idle %dh and worktree no longer present", idleHours)
+	}
+	return fmt.Sprintf("idle %dh past reconciliation window", idleHours)
+}
+
+// ReconcileStaleSessions returns audit records for every session in the state
+// that the policy classifies as stale. The state is not mutated: callers use
+// the audit list to decide what to filter from operator-facing surfaces and to
+// emit audit-log entries.
+func (s *State) ReconcileStaleSessions(now time.Time, policy StaleSessionPolicy, worktreeExists func(string) bool) []StaleSessionAudit {
+	if s == nil || !policy.Enabled {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	slots := make([]string, 0, len(s.Sessions))
+	for slot := range s.Sessions {
+		slots = append(slots, slot)
+	}
+	sort.Strings(slots)
+	audits := make([]StaleSessionAudit, 0)
+	for _, slot := range slots {
+		sess := s.Sessions[slot]
+		audit, stale := SessionStale(sess, now, policy, worktreeExists)
+		if !stale {
+			continue
+		}
+		audit.Slot = slot
+		audits = append(audits, audit)
+	}
+	return audits
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1636,6 +1636,176 @@ func TestApproveChangedApprovalPayloadFailsSafely(t *testing.T) {
 	}
 }
 
+func TestSessionStale_DeadIdleAndClosedPRWithMissingWorktree(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-30 * time.Hour)
+	sess := &Session{
+		IssueNumber: 101,
+		Status:      StatusDead,
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/missing-worktree",
+		PRNumber:    42,
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+	}
+	worktreeExists := func(path string) bool { return false }
+
+	audit, stale := SessionStale(sess, now, policy, worktreeExists)
+	if !stale {
+		t.Fatalf("session should be stale: %+v", audit)
+	}
+	if audit.IssueNumber != 101 || audit.PRNumber != 42 {
+		t.Fatalf("audit target = %+v, want issue=101 pr=42", audit)
+	}
+	if audit.IdleSeconds < int64(24*time.Hour/time.Second) {
+		t.Fatalf("audit idle seconds = %d, want >= 24h", audit.IdleSeconds)
+	}
+	if audit.Reason == "" {
+		t.Fatalf("audit reason should be populated")
+	}
+}
+
+func TestSessionStale_ActiveWorktreeKeepsSessionLive(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-30 * time.Hour)
+	sess := &Session{
+		IssueNumber: 102,
+		Status:      StatusDead,
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/active-worktree",
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+	}
+	worktreeExists := func(path string) bool { return true }
+
+	if _, stale := SessionStale(sess, now, policy, worktreeExists); stale {
+		t.Fatalf("session with present worktree must not be marked stale")
+	}
+}
+
+func TestSessionStale_RecentSessionIsNotStaleEvenWithMissingWorktree(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-3 * time.Hour)
+	sess := &Session{
+		IssueNumber: 103,
+		Status:      StatusDead,
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/missing",
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+	}
+	worktreeExists := func(path string) bool { return false }
+
+	if _, stale := SessionStale(sess, now, policy, worktreeExists); stale {
+		t.Fatalf("session within idle window must not be reclassified")
+	}
+}
+
+func TestSessionStale_RunningSessionIsNeverStale(t *testing.T) {
+	now := time.Now().UTC()
+	sess := &Session{
+		IssueNumber: 104,
+		Status:      StatusRunning,
+		StartedAt:   now.Add(-72 * time.Hour),
+		Worktree:    "/tmp/missing",
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+	}
+	if _, stale := SessionStale(sess, now, policy, func(string) bool { return false }); stale {
+		t.Fatalf("running session must never be marked stale")
+	}
+}
+
+func TestSessionStale_ScheduledRetryIsNotStale(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-30 * time.Hour)
+	retry := now.Add(15 * time.Minute)
+	sess := &Session{
+		IssueNumber: 105,
+		Status:      StatusDead,
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+		NextRetryAt: &retry,
+		Worktree:    "/tmp/missing",
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+	}
+	if _, stale := SessionStale(sess, now, policy, func(string) bool { return false }); stale {
+		t.Fatalf("session with pending retry must not be reclassified")
+	}
+}
+
+func TestReconcileStaleSessions_IsIdempotent(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-30 * time.Hour)
+	st := NewState()
+	st.Sessions["slot-stale"] = &Session{
+		IssueNumber: 201,
+		Status:      StatusDead,
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/missing-1",
+	}
+	st.Sessions["slot-live"] = &Session{
+		IssueNumber: 202,
+		Status:      StatusRunning,
+		StartedAt:   now.Add(-1 * time.Minute),
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+	}
+	worktreeExists := func(string) bool { return false }
+
+	first := st.ReconcileStaleSessions(now, policy, worktreeExists)
+	second := st.ReconcileStaleSessions(now, policy, worktreeExists)
+	if len(first) != 1 {
+		t.Fatalf("first pass audits = %d, want 1", len(first))
+	}
+	if len(second) != 1 || second[0].Slot != first[0].Slot {
+		t.Fatalf("second pass audits = %v, want identical to first", second)
+	}
+	if len(st.Sessions) != 2 {
+		t.Fatalf("state should not be mutated; sessions = %d", len(st.Sessions))
+	}
+}
+
+func TestReconcileStaleSessions_DisabledReturnsNothing(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-30 * time.Hour)
+	st := NewState()
+	st.Sessions["slot-1"] = &Session{
+		IssueNumber: 1,
+		Status:      StatusDead,
+		FinishedAt:  &finished,
+		StartedAt:   finished.Add(-time.Hour),
+		Worktree:    "/tmp/missing",
+	}
+	policy := StaleSessionPolicy{Enabled: false, IdleAfter: time.Hour, RequireWorktreeMissing: true}
+	if got := st.ReconcileStaleSessions(now, policy, func(string) bool { return false }); len(got) != 0 {
+		t.Fatalf("disabled policy returned %d audits, want 0", len(got))
+	}
+}
+
 func testApprovalDecision(now time.Time) SupervisorDecision {
 	return SupervisorDecision{
 		ID:                "sup-approval",

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -79,6 +79,16 @@ worker_prompt: /path/to/worker-prompt-template.md
 # deploy_cmd: "cd /path/to/repo && go build ./cmd/app/ && systemctl --user restart app"
 # deploy_timeout_minutes: 15         # timeout for deploy command in minutes (default: 15)
 
+# Stale supervisor sessions are filtered out of the Fleet API attention list
+# only when all three guards agree. Defaults are conservative so live workers
+# are never reclassified: enabled=true, idle_after_minutes=1440 (24h),
+# require_worktree_missing=true. Set enabled=false to keep every dead session
+# in `attention` (legacy behavior).
+# stale_session_reconciler:
+#   enabled: true
+#   idle_after_minutes: 1440
+#   require_worktree_missing: true
+
 # Telegram notifications
 telegram:
   target: "YOUR_TELEGRAM_CHAT_ID"


### PR DESCRIPTION
Implements #398

## Changes
- `internal/state/`: add `StaleSessionPolicy`, `SessionStale`, and `ReconcileStaleSessions` helpers. A session is classified stale only when it is in a non-running/non-PR-open state, idle past the configured window, and (by default) has a recorded worktree path that no longer exists on disk. The state is never mutated; callers receive audit records.
- `internal/server/fleet.go`: invoke the reconciler during `projectSnapshot`, drop matched slots from `attention`, leave them searchable in `workers`, and append a one-time `stale_session_reconciled` entry per slot to the project's `audit-log.jsonl`.
- `internal/config/`: add `stale_session_reconciler` (enabled, idle_after_minutes, require_worktree_missing). Defaults are conservative: enabled=true, 24h idle, worktree-missing required.
- Docs: add a Stale supervisor sessions section to `docs/fleet-mission-control-runbook.md` and the example config.

## Testing
- [x] `go test ./...`
- [x] `go build ./cmd/maestro/`
- [x] State unit tests: idle+missing worktree marks stale, active worktree keeps live, recent session stays live, running session is never stale, scheduled retry is never stale, reconciler is idempotent, disabled policy returns nothing.
- [x] Fleet API unit tests: stale session is removed from `attention` while remaining in `workers`, present-worktree session keeps attention, recent dead session keeps attention, audit log is append-once, disabled reconciler keeps attention untouched and writes no audit.

## Runtime verification still required
The dogfood/workshop verification steps in #398 (curl `/api/v1/fleet`, check that `workers` drops below the 103 baseline, confirm no `Worker exited and is waiting for retry` items older than 24h) must be run after deploy. No production state was touched by this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces stale-session reconciliation for the Fleet API: sessions that are idle past a configured window and (by default) have a missing worktree are removed from the operator `attention` list while remaining visible in `workers`, with one audit entry written per slot. The state-layer logic and config defaults are conservative and well-tested; the main issue is in the audit deduplication logic inside `fleet.go`.

- **P1 — audit-log writes one line per slot per hour**: The dedup key includes `audit.Reason`, which embeds the idle duration rounded to hours. Each time the rounded hour ticks over (24h → 25h → 26h…), a new key is generated, bypassing the seen-check and appending another `stale_session_reconciled` line indefinitely. The key should use only `project + slot`.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is; the P1 dedup bug will cause unbounded growth of audit-log entries for every stale session on a running server.

One P1 (dedup key includes mutable idle-hours string, breaking the append-once guarantee) plus one P2 (in-process dedup not restart-safe) pull the score below the P1 ceiling of 4. The rest of the implementation is solid.

internal/server/fleet.go — specifically the recordStaleSessionAudits dedup key construction

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds reconciler invocation inside projectSnapshot; contains a P1 dedup-key bug (reason includes mutable idle-hours) and a P2 issue (dedup map resets on restart), both affecting audit-log idempotency |
| internal/state/state.go | Adds StaleSessionPolicy, StaleSessionAudit, SessionStale, and ReconcileStaleSessions; logic is correct and conservative — running/PR-open/queued sessions and pending retries are protected |
| internal/config/config.go | Adds StaleSessionReconcilerConfig with nil-pointer-safe accessor methods and conservative defaults; straightforward and correct |
| internal/config/config_test.go | Adds two config-parse tests covering default values and explicit overrides; adequate coverage |
| internal/state/state_test.go | Adds seven unit tests covering all guard conditions and idempotency; thorough and well-structured |
| internal/server/fleet_test.go | Adds integration tests for attention filtering, audit-log idempotency, and disabled reconciler; covers the main happy paths but does not test cross-restart audit deduplication |
| docs/fleet-mission-control-runbook.md | Adds a Stale supervisor sessions runbook section with accurate defaults and operator guidance |
| maestro.yaml.example | Adds commented-out stale_session_reconciler example block with accurate defaults |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/server/fleet.go`, line 320 ([link](https://github.com/befeast/maestro/blob/df25b69913cacd75fc4e9dc88d2db6b89f0fa405/internal/server/fleet.go#L320)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Audit dedup key includes mutable idle-hour count, breaking append-once guarantee**

   The dedup key embeds `audit.Reason`, which contains the idle duration rounded to hours (e.g., `"idle 24h and worktree no longer present"`). Because `projectSnapshot` is called periodically and `idle` grows with every call, the reason — and therefore the key — changes every time the rounded hour ticks over. Once the in-memory entry for `"idle 24h …"` is registered, the next snapshot with `"idle 25h …"` produces a fresh key, bypasses the seen-check, and appends a second audit entry. In production this writes one new `stale_session_reconciled` line per slot per hour indefinitely, even though the session never changes.

   The fix is to key only on project + slot:

   ```go
   key := project + "\x00" + audit.Slot
   ```

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/fleet.go
   Line: 320

   Comment:
   **Audit dedup key includes mutable idle-hour count, breaking append-once guarantee**

   The dedup key embeds `audit.Reason`, which contains the idle duration rounded to hours (e.g., `"idle 24h and worktree no longer present"`). Because `projectSnapshot` is called periodically and `idle` grows with every call, the reason — and therefore the key — changes every time the rounded hour ticks over. Once the in-memory entry for `"idle 24h …"` is registered, the next snapshot with `"idle 25h …"` produces a fresh key, bypasses the seen-check, and appends a second audit entry. In production this writes one new `stale_session_reconciled` line per slot per hour indefinitely, even though the session never changes.

   The fix is to key only on project + slot:

   ```go
   key := project + "\x00" + audit.Slot
   ```

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/server/fleet.go`, line 243-246 ([link](https://github.com/befeast/maestro/blob/df25b69913cacd75fc4e9dc88d2db6b89f0fa405/internal/server/fleet.go#L243-L246)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **In-process dedup does not survive server restarts**

   `fleetStaleAuditEmitted` lives only in process memory. After any restart — deploy, crash, or manual restart — the map is empty and every currently-stale slot will generate a fresh audit entry, producing unbounded duplicates in the persistent `audit-log.jsonl`. The PR description promises "append-once `stale_session_reconciled` entry per slot," but that guarantee only holds within a single process lifetime.

   Consider persisting the emitted-set to disk (e.g., a sidecar file next to `audit-log.jsonl`) or, simpler, scanning `audit-log.jsonl` on startup to re-populate the in-memory set before the first snapshot runs.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/fleet.go
   Line: 243-246

   Comment:
   **In-process dedup does not survive server restarts**

   `fleetStaleAuditEmitted` lives only in process memory. After any restart — deploy, crash, or manual restart — the map is empty and every currently-stale slot will generate a fresh audit entry, producing unbounded duplicates in the persistent `audit-log.jsonl`. The PR description promises "append-once `stale_session_reconciled` entry per slot," but that guarantee only holds within a single process lifetime.

   Consider persisting the emitted-set to disk (e.g., a sidecar file next to `audit-log.jsonl`) or, simpler, scanning `audit-log.jsonl` on startup to re-populate the in-memory set before the first snapshot runs.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/fleet.go:320
**Audit dedup key includes mutable idle-hour count, breaking append-once guarantee**

The dedup key embeds `audit.Reason`, which contains the idle duration rounded to hours (e.g., `"idle 24h and worktree no longer present"`). Because `projectSnapshot` is called periodically and `idle` grows with every call, the reason — and therefore the key — changes every time the rounded hour ticks over. Once the in-memory entry for `"idle 24h …"` is registered, the next snapshot with `"idle 25h …"` produces a fresh key, bypasses the seen-check, and appends a second audit entry. In production this writes one new `stale_session_reconciled` line per slot per hour indefinitely, even though the session never changes.

The fix is to key only on project + slot:

```go
key := project + "\x00" + audit.Slot
```

```suggestion
		key := project + "\x00" + audit.Slot
```

### Issue 2 of 2
internal/server/fleet.go:243-246
**In-process dedup does not survive server restarts**

`fleetStaleAuditEmitted` lives only in process memory. After any restart — deploy, crash, or manual restart — the map is empty and every currently-stale slot will generate a fresh audit entry, producing unbounded duplicates in the persistent `audit-log.jsonl`. The PR description promises "append-once `stale_session_reconciled` entry per slot," but that guarantee only holds within a single process lifetime.

Consider persisting the emitted-set to disk (e.g., a sidecar file next to `audit-log.jsonl`) or, simpler, scanning `audit-log.jsonl` on startup to re-populate the in-memory set before the first snapshot runs.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: reconcile stale supervisor session..."](https://github.com/befeast/maestro/commit/df25b69913cacd75fc4e9dc88d2db6b89f0fa405) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30603894)</sub>

<!-- /greptile_comment -->