### PR TITLE
spec: collapse global brief into one canonical next action (#399)

### DIFF
--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -112,6 +112,46 @@ Each project card shows an outcome status: goal, runtime target, health state, a
 
 The global brief names one state for the whole fleet: healthy idle, running work, waiting for CI/review, no eligible issues, dispatch failure, stale worker, runtime outcome drift, or the single highest-priority action that needs an operator. When no human action is needed, it says so explicitly.
 
+## Global Next Action Selection
+
+Fleet Mission Control collapses the global brief into one canonical next operator action. `/api/v1/fleet` exposes it as the structured `next_action` field, or `null` when no action is needed. The legacy `verdict.sentence` and `operator_brief` fields stay populated for backward compatibility within this release.
+
+`next_action` shape:
+
+```json
+{
+  "project": "<project name>",
+  "kind": "<operator state kind>",
+  "target_url": "<PR or issue or dashboard URL>",
+  "reason": "<one-sentence reason>",
+  "priority": "P0",
+  "picked_at": "<RFC3339 timestamp>"
+}
+```
+
+Selection algorithm (deterministic, code-readable in `internal/server/fleet.go: buildFleetNextAction`):
+
+1. Build a candidate list from approvals and per-project operator state.
+2. Bucket each candidate into a priority tier:
+
+   | Tier | Sources |
+   |---|---|
+   | P0 | project `error`, `dispatch_failure`, `stale_worker`; pending approval past the 30m SLA |
+   | P1 | project `attention`; pending approval inside SLA |
+   | P2 | project `outcome_drift`, `stale`, `no_eligible_issues`, `queue_blocked` |
+   | P3 | project `outcome_missing` |
+
+   Non-actionable kinds (`working`, `monitoring_pr`, `pending_dispatch`, `idle`, ...) are excluded.
+
+3. Sort by priority ascending (P0 first).
+4. Within the highest-occupied tier the **oldest by `updated_at`** wins. The "updated_at" comes from the underlying input — the worker session `started_at` for worker-driven kinds, the supervisor decision `created_at` for queue/dispatch/drift kinds, the approval `updated_at` for approvals — never from the snapshot timestamp. That keeps the choice stable across consecutive snapshots while the input is unchanged.
+5. The remaining ties are broken by a deterministic key (`approval|project|id` or `project|name|kind`).
+6. `picked_at` echoes the winner's `updated_at`, so reloading the dashboard while nothing changes returns the same `picked_at` and the UI text does not flicker.
+
+The frontend (`internal/server/web/static/fleet.js: renderFleetVerdict`) renders one "What needs me now" line plus one CTA link to `target_url`. When `next_action` is `null` the dashboard shows a single `Quiet. Nothing needs you.` message — there are no expanding sections in the brief.
+
+This algorithm is intentionally explicit and explainable. There is no ML priority picker; if the order changes you can read the tier mapping above and the candidate list in the Project Rail to see why.
+
 Use this order during normal operations:
 
 1. Open Fleet Mission Control at `http://127.0.0.1:8787/`.

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1051,16 +1051,35 @@ func fleetNextActionPriorityForKind(kind string) (int, bool) {
 }
 
 // fleetProjectOperatorUpdatedAt returns a stable timestamp for a project's
-// current operator state. The choice is "stable" in the sense that it does
-// not depend on `now`, so a snapshot computed twice over the same input
-// returns the same picked_at.
+// current operator state. The source is chosen from the operator-state kind
+// so that the timestamp matches the signal that drove the state — e.g. a
+// dispatch_failure should age from the supervisor decision, not from an
+// older attention session that the dispatch failure already preempted in
+// buildFleetProjectOperatorState. The choice is "stable" in the sense that
+// it does not depend on `now`, so a snapshot computed twice over the same
+// input returns the same picked_at.
 func fleetProjectOperatorUpdatedAt(project fleetProjectState) time.Time {
-	if len(project.Attention) > 0 {
-		worker := highestPriorityAttentionSession(project.Attention)
-		if t := parseFleetWorkerTime(worker.StartedAt); !t.IsZero() {
+	kind := strings.TrimSpace(project.OperatorState.Kind)
+	switch kind {
+	case "attention", "stale_worker":
+		if len(project.Attention) > 0 {
+			worker := highestPriorityAttentionSession(project.Attention)
+			if t := parseFleetWorkerTime(worker.StartedAt); !t.IsZero() {
+				return t
+			}
+		}
+	case "dispatch_failure", "outcome_drift", "queue_blocked", "no_eligible_issues":
+		if project.Supervisor.Latest != nil && !project.Supervisor.Latest.CreatedAt.IsZero() {
+			return project.Supervisor.Latest.CreatedAt.UTC()
+		}
+	case "stale":
+		if t := parseFleetWorkerTime(project.Freshness.SnapshotAt); !t.IsZero() {
 			return t
 		}
 	}
+	// Fallbacks for kinds without a primary source, or when the primary
+	// source is empty: prefer the most recent supervisor decision, then the
+	// snapshot freshness timestamp.
 	if project.Supervisor.Latest != nil && !project.Supervisor.Latest.CreatedAt.IsZero() {
 		return project.Supervisor.Latest.CreatedAt.UTC()
 	}
@@ -1153,9 +1172,10 @@ func buildFleetNextAction(projects []fleetProjectState, approvals []fleetApprova
 		if l.Priority != r.Priority {
 			return l.Priority < r.Priority
 		}
-		// Within a tier the oldest item wins. Treat zero timestamps as
-		// "older than any known time" so a candidate without an updated_at
-		// loses to a candidate with one.
+		// Within a tier the oldest known timestamp wins. A zero/unknown
+		// timestamp is treated as "newer than any known time" so a candidate
+		// with no updated_at loses to a candidate that has one — otherwise a
+		// project missing input data would always grab the brief.
 		switch {
 		case l.UpdatedAt.IsZero() && r.UpdatedAt.IsZero():
 			// fall through to the deterministic tie breaker

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -192,6 +192,7 @@ func (s *FleetServer) Start(ctx context.Context) error {
 type fleetResponse struct {
 	ReadOnly      bool                 `json:"read_only"`
 	RefreshedAt   string               `json:"refreshed_at"`
+	NextAction    *fleetNextAction     `json:"next_action"`
 	Verdict       fleetVerdict         `json:"verdict"`
 	OperatorBrief fleetOperatorBrief   `json:"operator_brief"`
 	Projects      []fleetProjectState  `json:"projects"`
@@ -199,6 +200,20 @@ type fleetResponse struct {
 	Workers       []fleetWorkerState   `json:"workers"`
 	Attention     []fleetWorkerState   `json:"attention"`
 	Approvals     []fleetApprovalState `json:"approvals,omitempty"`
+}
+
+// fleetNextAction names the single canonical operator action across the fleet.
+// The selection algorithm is deterministic: items are bucketed into priority
+// tiers P0..P3 and the oldest item by updated_at within the highest-occupied
+// tier wins. picked_at echoes that underlying timestamp so the choice is
+// stable across snapshots while the input is unchanged.
+type fleetNextAction struct {
+	Project   string `json:"project"`
+	Kind      string `json:"kind"`
+	TargetURL string `json:"target_url,omitempty"`
+	Reason    string `json:"reason"`
+	Priority  string `json:"priority"`
+	PickedAt  string `json:"picked_at,omitempty"`
 }
 
 type fleetVerdict struct {
@@ -740,6 +755,7 @@ func (s *FleetServer) snapshot() fleetResponse {
 	})
 	sortFleetApprovals(resp.Approvals)
 	resp.OperatorBrief = buildFleetOperatorBrief(resp.Projects, resp.Approvals, now)
+	resp.NextAction = buildFleetNextAction(resp.Projects, resp.Approvals, now)
 	resp.Verdict = buildFleetVerdict(resp, now)
 	return resp
 }
@@ -1001,6 +1017,167 @@ func buildFleetOperatorBrief(projects []fleetProjectState, approvals []fleetAppr
 		parts = append(parts, fleetCountPhrase(attention, "project with passive attention", "projects with passive attention"))
 	}
 	return fleetOperatorBrief{Tone: "busy", Kind: "active", Sentence: "Global brief: " + strings.Join(parts, "; ") + "; no operator action is needed right now."}
+}
+
+// fleetNextActionCandidate is one possible "what needs me now" item before
+// priority/age sorting picks the canonical winner.
+type fleetNextActionCandidate struct {
+	Project   string
+	Kind      string
+	TargetURL string
+	Reason    string
+	Priority  int
+	UpdatedAt time.Time
+	tieKey    string
+}
+
+// fleetNextActionPriorityForKind maps an operator-state kind onto a priority
+// tier (lower number = higher priority). The second return value reports
+// whether the kind is a "needs operator" candidate at all; non-actionable
+// kinds (working, monitoring_pr, idle, ...) are excluded from the brief.
+func fleetNextActionPriorityForKind(kind string) (int, bool) {
+	switch strings.TrimSpace(kind) {
+	case "error", "dispatch_failure", "stale_worker":
+		return 0, true
+	case "attention":
+		return 1, true
+	case "outcome_drift", "stale", "no_eligible_issues", "queue_blocked":
+		return 2, true
+	case "outcome_missing":
+		return 3, true
+	default:
+		return 0, false
+	}
+}
+
+// fleetProjectOperatorUpdatedAt returns a stable timestamp for a project's
+// current operator state. The choice is "stable" in the sense that it does
+// not depend on `now`, so a snapshot computed twice over the same input
+// returns the same picked_at.
+func fleetProjectOperatorUpdatedAt(project fleetProjectState) time.Time {
+	if len(project.Attention) > 0 {
+		worker := highestPriorityAttentionSession(project.Attention)
+		if t := parseFleetWorkerTime(worker.StartedAt); !t.IsZero() {
+			return t
+		}
+	}
+	if project.Supervisor.Latest != nil && !project.Supervisor.Latest.CreatedAt.IsZero() {
+		return project.Supervisor.Latest.CreatedAt.UTC()
+	}
+	if t := parseFleetWorkerTime(project.Freshness.SnapshotAt); !t.IsZero() {
+		return t
+	}
+	return time.Time{}
+}
+
+func parseFleetWorkerTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t.UTC()
+	}
+	return time.Time{}
+}
+
+// buildFleetNextAction picks the single canonical next operator action across
+// the fleet using the priority + age algorithm documented in
+// docs/fleet-mission-control-runbook.md. Returns nil when nothing needs the
+// operator right now.
+func buildFleetNextAction(projects []fleetProjectState, approvals []fleetApprovalState, now time.Time) *fleetNextAction {
+	candidates := make([]fleetNextActionCandidate, 0, len(projects)+len(approvals))
+
+	for i := range approvals {
+		approval := &approvals[i]
+		if state.ApprovalStatus(approval.Status) != state.ApprovalStatusPending {
+			continue
+		}
+		priority := 1
+		reason := "Approve or reject the pending supervisor approval after checking the target state."
+		if approvalPastSLA(approval, now) {
+			priority = 0
+			reason = "Pending approval is past the " + fleetApprovalSLAText() + " SLA. Approve or reject it now."
+		}
+		if summary := strings.TrimSpace(approval.Summary); summary != "" {
+			reason = summary + " " + reason
+		}
+		target := firstNonEmpty(approval.PRURL, approval.IssueURL, approval.DashboardURL)
+		candidates = append(candidates, fleetNextActionCandidate{
+			Project:   approval.ProjectName,
+			Kind:      "approval_pending",
+			TargetURL: target,
+			Reason:    truncateFleetOperatorText(reason, 200),
+			Priority:  priority,
+			UpdatedAt: fleetApprovalRecency(*approval),
+			tieKey:    "approval|" + approval.ProjectName + "|" + approval.ID,
+		})
+	}
+
+	for i := range projects {
+		project := &projects[i]
+		kind := strings.TrimSpace(project.OperatorState.Kind)
+		priority, ok := fleetNextActionPriorityForKind(kind)
+		if !ok {
+			continue
+		}
+		reason := strings.TrimSpace(project.OperatorState.NextAction)
+		if reason == "" {
+			reason = strings.TrimSpace(project.OperatorState.Summary)
+		}
+		if reason == "" {
+			reason = strings.TrimSpace(project.OperatorState.Label)
+		}
+		target := firstNonEmpty(
+			project.OperatorState.PRURL,
+			project.OperatorState.IssueURL,
+			project.DashboardURL,
+		)
+		candidates = append(candidates, fleetNextActionCandidate{
+			Project:   project.Name,
+			Kind:      kind,
+			TargetURL: target,
+			Reason:    truncateFleetOperatorText(reason, 200),
+			Priority:  priority,
+			UpdatedAt: fleetProjectOperatorUpdatedAt(*project),
+			tieKey:    "project|" + project.Name + "|" + kind,
+		})
+	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		l, r := candidates[i], candidates[j]
+		if l.Priority != r.Priority {
+			return l.Priority < r.Priority
+		}
+		// Within a tier the oldest item wins. Treat zero timestamps as
+		// "older than any known time" so a candidate without an updated_at
+		// loses to a candidate with one.
+		switch {
+		case l.UpdatedAt.IsZero() && r.UpdatedAt.IsZero():
+			// fall through to the deterministic tie breaker
+		case l.UpdatedAt.IsZero():
+			return false
+		case r.UpdatedAt.IsZero():
+			return true
+		case !l.UpdatedAt.Equal(r.UpdatedAt):
+			return l.UpdatedAt.Before(r.UpdatedAt)
+		}
+		return l.tieKey < r.tieKey
+	})
+
+	winner := candidates[0]
+	return &fleetNextAction{
+		Project:   winner.Project,
+		Kind:      winner.Kind,
+		TargetURL: winner.TargetURL,
+		Reason:    winner.Reason,
+		Priority:  fmt.Sprintf("P%d", winner.Priority),
+		PickedAt:  formatFleetTime(winner.UpdatedAt),
+	}
 }
 
 const fleetApprovalSLASeconds int64 = 30 * 60

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -823,6 +823,284 @@ func TestHighestPriorityPendingFleetApprovalSelectsNewestPending(t *testing.T) {
 	}
 }
 
+func TestBuildFleetNextActionEmptyFleetReturnsNil(t *testing.T) {
+	now := time.Now().UTC()
+	if got := buildFleetNextAction(nil, nil, now); got != nil {
+		t.Fatalf("buildFleetNextAction empty fleet = %+v, want nil", got)
+	}
+	idleProjects := []fleetProjectState{
+		{Name: "Idle", OperatorState: fleetOperatorState{Kind: "idle"}},
+		{Name: "Running", OperatorState: fleetOperatorState{Kind: "working"}},
+		{Name: "Monitoring", OperatorState: fleetOperatorState{Kind: "monitoring_pr"}},
+	}
+	if got := buildFleetNextAction(idleProjects, nil, now); got != nil {
+		t.Fatalf("buildFleetNextAction idle fleet = %+v, want nil", got)
+	}
+}
+
+func TestBuildFleetNextActionPrefersP0OverOlderLowerTier(t *testing.T) {
+	now := time.Now().UTC()
+	startedRecent := now.Add(-2 * time.Minute).Format(time.RFC3339)
+	startedAncient := now.Add(-6 * time.Hour).Format(time.RFC3339)
+
+	projects := []fleetProjectState{
+		{
+			Name: "OldP2",
+			OperatorState: fleetOperatorState{
+				Kind:       "no_eligible_issues",
+				Summary:    "All open issues are excluded by policy.",
+				NextAction: "Adjust labels or policy so a worker can run.",
+			},
+			Supervisor: supervisorInfo{Latest: &supervisorDecisionInfo{CreatedAt: now.Add(-6 * time.Hour)}},
+		},
+		{
+			Name: "RecentP0",
+			OperatorState: fleetOperatorState{
+				Kind:       "stale_worker",
+				Summary:    "Worker PID is not alive.",
+				NextAction: "Restart the worker.",
+			},
+			Attention: []sessionInfo{{Slot: "stale-1", Status: string(state.StatusRunning), StartedAt: startedRecent}},
+		},
+		{
+			Name: "DispatchP0",
+			OperatorState: fleetOperatorState{
+				Kind:       "dispatch_failure",
+				Summary:    "Supervisor dispatch failed.",
+				NextAction: "Check supervisor logs.",
+			},
+			Supervisor: supervisorInfo{Latest: &supervisorDecisionInfo{CreatedAt: now.Add(-30 * time.Minute)}},
+		},
+		{
+			Name: "AncientAttention",
+			OperatorState: fleetOperatorState{
+				Kind:       "attention",
+				Summary:    "Worker needs review.",
+				NextAction: "Open the worker detail.",
+			},
+			Attention: []sessionInfo{{Slot: "old-1", Status: string(state.StatusRunning), StartedAt: startedAncient}},
+		},
+	}
+
+	got := buildFleetNextAction(projects, nil, now)
+	if got == nil {
+		t.Fatalf("buildFleetNextAction = nil, want a P0 candidate")
+	}
+	if got.Priority != "P0" {
+		t.Fatalf("priority = %q, want P0 (a P0 must beat any older P1/P2)", got.Priority)
+	}
+	if got.Project != "DispatchP0" {
+		t.Fatalf("project = %q, want DispatchP0 (the older of the two P0 candidates)", got.Project)
+	}
+	if got.Kind != "dispatch_failure" {
+		t.Fatalf("kind = %q, want dispatch_failure", got.Kind)
+	}
+}
+
+func TestBuildFleetNextActionWithinTierOldestUpdatedAtWins(t *testing.T) {
+	now := time.Now().UTC()
+	older := now.Add(-3 * time.Hour).Format(time.RFC3339)
+	newer := now.Add(-30 * time.Minute).Format(time.RFC3339)
+
+	projects := []fleetProjectState{
+		{
+			Name: "NewerP1",
+			OperatorState: fleetOperatorState{
+				Kind:       "attention",
+				Summary:    "Worker needs review.",
+				NextAction: "Open the worker detail.",
+			},
+			Attention: []sessionInfo{{Slot: "newer-1", Status: string(state.StatusRunning), StartedAt: newer}},
+		},
+		{
+			Name: "OlderP1",
+			OperatorState: fleetOperatorState{
+				Kind:       "attention",
+				Summary:    "Older worker needs review.",
+				NextAction: "Open the older worker detail.",
+			},
+			Attention: []sessionInfo{{Slot: "older-1", Status: string(state.StatusRunning), StartedAt: older}},
+		},
+	}
+	got := buildFleetNextAction(projects, nil, now)
+	if got == nil {
+		t.Fatalf("buildFleetNextAction = nil, want a P1 candidate")
+	}
+	if got.Priority != "P1" {
+		t.Fatalf("priority = %q, want P1", got.Priority)
+	}
+	if got.Project != "OlderP1" {
+		t.Fatalf("project = %q, want OlderP1 (the oldest by updated_at within P1)", got.Project)
+	}
+}
+
+func TestBuildFleetNextActionApprovalPastSLABeatsRegularPending(t *testing.T) {
+	now := time.Now().UTC()
+	approvals := []fleetApprovalState{
+		{
+			ProjectName: "Fresh",
+			ID:          "fresh",
+			Status:      string(state.ApprovalStatusPending),
+			Summary:     "Fresh approval is waiting.",
+			PRURL:       "https://github.com/owner/fresh/pull/9",
+			createdAt:   now.Add(-5 * time.Minute),
+			updatedAt:   now.Add(-5 * time.Minute),
+		},
+		{
+			ProjectName: "PastSLA",
+			ID:          "past-sla",
+			Status:      string(state.ApprovalStatusPending),
+			Summary:     "Approval breached the SLA.",
+			PRURL:       "https://github.com/owner/past-sla/pull/12",
+			createdAt:   now.Add(-45 * time.Minute),
+			updatedAt:   now.Add(-45 * time.Minute),
+		},
+	}
+	got := buildFleetNextAction(nil, approvals, now)
+	if got == nil {
+		t.Fatalf("buildFleetNextAction = nil, want a past-SLA approval winner")
+	}
+	if got.Priority != "P0" || got.Project != "PastSLA" {
+		t.Fatalf("got = %+v, want P0 PastSLA", got)
+	}
+	if got.Kind != "approval_pending" {
+		t.Fatalf("kind = %q, want approval_pending", got.Kind)
+	}
+	if got.TargetURL != "https://github.com/owner/past-sla/pull/12" {
+		t.Fatalf("target_url = %q, want PR URL", got.TargetURL)
+	}
+}
+
+func TestBuildFleetNextActionPickedAtIsStableAcrossSnapshots(t *testing.T) {
+	now := time.Now().UTC()
+	startedAt := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	projects := []fleetProjectState{
+		{
+			Name: "AttentionProject",
+			OperatorState: fleetOperatorState{
+				Kind:       "attention",
+				Summary:    "Worker needs review.",
+				NextAction: "Open the worker detail.",
+			},
+			Attention: []sessionInfo{{Slot: "att-1", Status: string(state.StatusRunning), StartedAt: startedAt}},
+		},
+	}
+	first := buildFleetNextAction(projects, nil, now)
+	second := buildFleetNextAction(projects, nil, now.Add(2*time.Minute))
+	if first == nil || second == nil {
+		t.Fatalf("snapshots returned nil: first=%v second=%v", first, second)
+	}
+	if first.PickedAt == "" {
+		t.Fatalf("picked_at is empty; want a stable timestamp derived from the input")
+	}
+	if first.PickedAt != second.PickedAt {
+		t.Fatalf("picked_at = %q vs %q across snapshots; want stability when input is unchanged", first.PickedAt, second.PickedAt)
+	}
+	if first.Project != second.Project || first.Kind != second.Kind {
+		t.Fatalf("selection drifted between snapshots: %+v vs %+v", first, second)
+	}
+}
+
+func TestFleetAPISnapshotIncludesNextAction(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "needs-attention")
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"stuck-1": {
+			IssueNumber: 7,
+			IssueTitle:  "Stuck",
+			Status:      state.StatusRetryExhausted,
+			StartedAt:   now.Add(-30 * time.Minute),
+			PRNumber:    71,
+		},
+	})
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("StuckProject", "/tmp/stuck.yaml", "http://127.0.0.1:8787", &config.Config{
+			Repo:        "owner/stuck",
+			StateDir:    stateDir,
+			MaxParallel: 1,
+			Outcome:     outcome.Brief{DesiredOutcome: "Stuck outcome"},
+		}),
+	}, "127.0.0.1", 8786, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleet(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp fleetResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.NextAction == nil {
+		t.Fatalf("next_action = nil, want a structured object")
+	}
+	if resp.NextAction.Project != "StuckProject" {
+		t.Fatalf("next_action.project = %q, want StuckProject", resp.NextAction.Project)
+	}
+	if resp.NextAction.Priority == "" || resp.NextAction.Kind == "" || resp.NextAction.Reason == "" {
+		t.Fatalf("next_action missing required fields: %+v", resp.NextAction)
+	}
+	// The verdict.sentence stays for backward compatibility.
+	if strings.TrimSpace(resp.Verdict.Sentence) == "" {
+		t.Fatalf("verdict.sentence is empty; expected backward-compatible sentence to remain populated")
+	}
+
+	// Snapshot the JSON top-level keys to lock the shape.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if _, ok := raw["next_action"]; !ok {
+		t.Fatalf("/api/v1/fleet body missing top-level next_action key")
+	}
+	if _, ok := raw["verdict"]; !ok {
+		t.Fatalf("/api/v1/fleet body missing top-level verdict key (backward-compat regression)")
+	}
+}
+
+func TestFleetAPISnapshotNextActionIsNullWhenQuiet(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "quiet")
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"runner-1": {
+			IssueNumber: 1,
+			IssueTitle:  "Quiet runner",
+			Status:      state.StatusRunning,
+			StartedAt:   now.Add(-time.Minute),
+			PID:         os.Getpid(),
+		},
+	})
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("Quiet", "/tmp/quiet.yaml", "", &config.Config{
+			Repo:        "owner/quiet",
+			StateDir:    stateDir,
+			MaxParallel: 1,
+			Outcome:     outcome.Brief{DesiredOutcome: "Quiet outcome"},
+		}),
+	}, "127.0.0.1", 8786, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleet(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	body, ok := raw["next_action"]
+	if !ok {
+		t.Fatalf("next_action key missing from response")
+	}
+	if string(body) != "null" {
+		t.Fatalf("next_action = %s, want null when no operator action is needed", string(body))
+	}
+}
+
 func TestFleetProjectOperatorStateDistinguishesBriefStates(t *testing.T) {
 	now := time.Now().UTC()
 	configuredOutcome := outcome.Status{Configured: true, Goal: "Runtime is healthy", HealthState: outcome.HealthHealthy}

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -971,6 +971,50 @@ func TestBuildFleetNextActionApprovalPastSLABeatsRegularPending(t *testing.T) {
 	}
 }
 
+func TestBuildFleetNextActionDispatchFailureUsesSupervisorTimestamp(t *testing.T) {
+	now := time.Now().UTC()
+	ancientAttention := now.Add(-12 * time.Hour).Format(time.RFC3339)
+	recentDecision := now.Add(-5 * time.Minute)
+	olderDecision := now.Add(-2 * time.Hour)
+
+	projects := []fleetProjectState{
+		{
+			Name: "RecentDispatchFailure",
+			OperatorState: fleetOperatorState{
+				Kind:       "dispatch_failure",
+				Summary:    "Supervisor dispatch failed.",
+				NextAction: "Check supervisor logs.",
+			},
+			// An old attention session must NOT artificially backdate the
+			// dispatch failure: buildFleetProjectOperatorState already returned
+			// dispatch_failure ahead of attention, so the picked_at should
+			// follow the supervisor decision that produced the failure.
+			Attention:  []sessionInfo{{Slot: "ghost", Status: string(state.StatusRunning), StartedAt: ancientAttention}},
+			Supervisor: supervisorInfo{Latest: &supervisorDecisionInfo{CreatedAt: recentDecision}},
+		},
+		{
+			Name: "OlderDispatchFailure",
+			OperatorState: fleetOperatorState{
+				Kind:       "dispatch_failure",
+				Summary:    "Supervisor dispatch failed earlier.",
+				NextAction: "Check supervisor logs.",
+			},
+			Supervisor: supervisorInfo{Latest: &supervisorDecisionInfo{CreatedAt: olderDecision}},
+		},
+	}
+
+	got := buildFleetNextAction(projects, nil, now)
+	if got == nil {
+		t.Fatalf("buildFleetNextAction = nil, want a P0 candidate")
+	}
+	if got.Priority != "P0" || got.Kind != "dispatch_failure" {
+		t.Fatalf("got = %+v, want P0 dispatch_failure", got)
+	}
+	if got.Project != "OlderDispatchFailure" {
+		t.Fatalf("project = %q, want OlderDispatchFailure (older supervisor decision wins, ancient attention session must not pull RecentDispatchFailure backwards)", got.Project)
+	}
+}
+
 func TestBuildFleetNextActionPickedAtIsStableAcrossSnapshots(t *testing.T) {
 	now := time.Now().UTC()
 	startedAt := now.Add(-10 * time.Minute).Format(time.RFC3339)

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -123,6 +123,22 @@
   .fleet-verdict.verdict-attention::before { background: var(--warn); box-shadow: 0 0 18px rgba(194,65,12,.32); }
   .fleet-verdict.verdict-daemon-down { border-left-color: var(--bad); background: #fff5f5; }
   .fleet-verdict.verdict-daemon-down::before { background: var(--bad); box-shadow: 0 0 18px rgba(185,28,28,.32); }
+  .fleet-verdict { grid-template-columns: 1fr auto; align-items: center; }
+  .fleet-verdict-copy { min-width: 0; }
+  .fleet-next-action-cta {
+    align-self: center;
+    justify-self: end;
+    padding: 8px 14px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: #fff;
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .fleet-next-action-cta:hover { border-color: var(--text-dim); background: #f8fafc; }
   .stats {
     display: grid;
     grid-template-columns: repeat(5, minmax(0, 1fr));

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -1260,9 +1260,24 @@ function fleetNextActionKindLabel(kind) {
   }
 }
 
-function renderFleetVerdict(nextAction) {
+function fleetSafeTargetURL(value) {
+  const trimmed = String(value || "").trim();
+  if (!trimmed) return "";
+  return /^https?:\/\//i.test(trimmed) ? trimmed : "";
+}
+
+function renderFleetVerdict(nextAction, verdict) {
   if (!fleetVerdictEl) return;
   if (!nextAction || !nextAction.reason) {
+    const fallback = fleetDegradedVerdictFallback(verdict);
+    if (fallback) {
+      fleetVerdictEl.className = "fleet-verdict verdict-" + fallback.tone;
+      fleetVerdictEl.innerHTML = '<div class="fleet-verdict-copy">' +
+        '<div class="fleet-verdict-headline">' + escapeText(fallback.headline) + '</div>' +
+        '<div class="fleet-verdict-meta">' + escapeText(fallback.meta) + '</div>' +
+      '</div>';
+      return;
+    }
     fleetVerdictEl.className = "fleet-verdict verdict-healthy";
     fleetVerdictEl.innerHTML = '<div class="fleet-verdict-copy">' +
       '<div class="fleet-verdict-headline">Quiet. Nothing needs you.</div>' +
@@ -1278,15 +1293,27 @@ function renderFleetVerdict(nextAction) {
   metaParts.push(String(nextAction.priority || "P1").toUpperCase() + " · " + fleetNextActionKindLabel(nextAction.kind));
   if (fleetState.refreshedAt) metaParts.push("Last sync " + formatTimestamp(fleetState.refreshedAt));
   if (nextAction.picked_at) metaParts.push("Since " + formatTimestamp(nextAction.picked_at));
-  const target = String(nextAction.target_url || "").trim();
-  const cta = target
-    ? '<a class="fleet-next-action-cta" href="' + escapeText(target) + '" target="_blank" rel="noopener">Open ' + escapeText(fleetNextActionKindLabel(nextAction.kind)) + '</a>'
+  const safeTarget = fleetSafeTargetURL(nextAction.target_url);
+  const cta = safeTarget
+    ? '<a class="fleet-next-action-cta" href="' + escapeText(safeTarget) + '" target="_blank" rel="noopener">Open ' + escapeText(fleetNextActionKindLabel(nextAction.kind)) + '</a>'
     : '';
   fleetVerdictEl.className = "fleet-verdict verdict-" + tone;
   fleetVerdictEl.innerHTML = '<div class="fleet-verdict-copy">' +
     '<div class="fleet-verdict-headline">What needs me now: ' + escapeText(headline) + '</div>' +
     '<div class="fleet-verdict-meta">' + escapeText(metaParts.join(" · ")) + '</div>' +
   '</div>' + cta;
+}
+
+function fleetDegradedVerdictFallback(verdict) {
+  if (!verdict) return null;
+  const tone = String(verdict.tone || "").trim();
+  const sentence = String(verdict.sentence || "").trim();
+  if (tone !== "daemon-down" && tone !== "error") return null;
+  return {
+    tone: fleetBriefToneClass(tone),
+    headline: sentence || "Supervisor heartbeat unavailable.",
+    meta: fleetState.refreshedAt ? "Last sync " + formatTimestamp(fleetState.refreshedAt) : "No data yet"
+  };
 }
 
 function renderStats(summary) {
@@ -2370,7 +2397,7 @@ function applyFleetData(data) {
     (alerts.length ? " · " + alerts.join(" · ") : "");
   renderFilterOptions();
   syncFilterControls();
-  renderFleetVerdict(fleetState.nextAction);
+  renderFleetVerdict(fleetState.nextAction, fleetState.verdict);
   renderStats(summary);
   renderProjectRail();
   renderProjectOverview();
@@ -2396,7 +2423,7 @@ async function loadFleet() {
     applyFleetData(await response.json());
   } catch (err) {
     subtitleEl.textContent = "Fleet API error" + (fleetState.refreshedAt ? " · Last successful refresh " + formatTimestamp(fleetState.refreshedAt) : "");
-    renderFleetVerdict({ priority: "P0", kind: "error", project: "Fleet API", reason: "Fleet API error. Supervisor heartbeat unavailable; worker state and attention state could not be confirmed." });
+    renderFleetVerdict({ priority: "P0", kind: "error", project: "Fleet API", reason: "Fleet API error. Supervisor heartbeat unavailable; worker state and attention state could not be confirmed." }, null);
     approvalSummaryEl.textContent = "Fleet API error";
     approvalListEl.innerHTML = '<div class="error">Unable to load approval inbox.</div>';
     attentionSummaryEl.textContent = "Fleet API error";

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -92,6 +92,7 @@ const fleetState = {
   detail: null,
   operatorBrief: null,
   verdict: null,
+  nextAction: null,
   refreshedAt: "",
   search: {
     open: false,
@@ -1229,40 +1230,63 @@ function fleetBriefToneClass(tone) {
   }
 }
 
-function renderFleetVerdict(brief, verdict) {
-  const source = brief && brief.sentence ? brief : verdict;
-  const tone = fleetBriefToneClass(source && source.tone);
-  const summary = fleetState.summary || {};
-  const running = Number(summary.running || 0);
-  const attention = Number(summary.needs_attention || 0);
-  const approvals = Number(summary.approvals_pending || 0);
-  let headline = "Supervisor status unavailable.";
-  if (attention > 0 || approvals > 0) {
-    const parts = [];
-    if (attention > 0) parts.push(pluralize(attention, "item") + " need attention");
-    if (approvals > 0) parts.push(pluralize(approvals, "approval") + " wait for review");
-    headline = parts.join(" · ") + ".";
-  } else if (running > 0) {
-    headline = pluralize(running, "worker") + " " + (running === 1 ? "is" : "are") + " running. No operator action is pending.";
-  } else {
-    headline = "All quiet. No operator action is pending.";
+function fleetNextActionToneClass(priority) {
+  switch (String(priority || "").trim().toUpperCase()) {
+  case "P0":
+    return "daemon-down";
+  case "P1":
+    return "attention";
+  case "P2":
+  case "P3":
+    return "attention";
+  default:
+    return "attention";
   }
+}
+
+function fleetNextActionKindLabel(kind) {
+  switch (String(kind || "").trim()) {
+  case "approval_pending": return "Approval pending";
+  case "error": return "Project error";
+  case "dispatch_failure": return "Dispatch failure";
+  case "stale_worker": return "Stale worker";
+  case "attention": return "Worker needs attention";
+  case "outcome_drift": return "Outcome drift";
+  case "stale": return "Stale snapshot";
+  case "no_eligible_issues": return "No eligible issues";
+  case "queue_blocked": return "Queue blocked";
+  case "outcome_missing": return "Outcome brief missing";
+  default: return kind ? String(kind) : "Operator action";
+  }
+}
+
+function renderFleetVerdict(nextAction) {
+  if (!fleetVerdictEl) return;
+  if (!nextAction || !nextAction.reason) {
+    fleetVerdictEl.className = "fleet-verdict verdict-healthy";
+    fleetVerdictEl.innerHTML = '<div class="fleet-verdict-copy">' +
+      '<div class="fleet-verdict-headline">Quiet. Nothing needs you.</div>' +
+      '<div class="fleet-verdict-meta">' + escapeText(fleetState.refreshedAt ? "Last sync " + formatTimestamp(fleetState.refreshedAt) : "No data yet") + '</div>' +
+    '</div>';
+    return;
+  }
+  const tone = fleetNextActionToneClass(nextAction.priority);
+  const project = String(nextAction.project || "").trim();
+  const reason = String(nextAction.reason || "").trim();
+  const headline = (project ? project + " · " : "") + reason;
   const metaParts = [];
+  metaParts.push(String(nextAction.priority || "P1").toUpperCase() + " · " + fleetNextActionKindLabel(nextAction.kind));
   if (fleetState.refreshedAt) metaParts.push("Last sync " + formatTimestamp(fleetState.refreshedAt));
-  if (attention > 0 || approvals > 0) {
-    metaParts.push("Review Needs You below");
-  } else if (running > 0) {
-    metaParts.push("Workers are in flight");
-  } else {
-    metaParts.push("Supervisor heartbeat is current");
-  }
-  if (summary.projects) metaParts.push(pluralize(Number(summary.projects || 0), "project") + " monitored");
-  if (brief && brief.project) metaParts.push("Focus: " + brief.project);
+  if (nextAction.picked_at) metaParts.push("Since " + formatTimestamp(nextAction.picked_at));
+  const target = String(nextAction.target_url || "").trim();
+  const cta = target
+    ? '<a class="fleet-next-action-cta" href="' + escapeText(target) + '" target="_blank" rel="noopener">Open ' + escapeText(fleetNextActionKindLabel(nextAction.kind)) + '</a>'
+    : '';
   fleetVerdictEl.className = "fleet-verdict verdict-" + tone;
   fleetVerdictEl.innerHTML = '<div class="fleet-verdict-copy">' +
-    '<div class="fleet-verdict-headline">' + escapeText(headline) + '</div>' +
+    '<div class="fleet-verdict-headline">What needs me now: ' + escapeText(headline) + '</div>' +
     '<div class="fleet-verdict-meta">' + escapeText(metaParts.join(" · ")) + '</div>' +
-  '</div>';
+  '</div>' + cta;
 }
 
 function renderStats(summary) {
@@ -2324,6 +2348,7 @@ function applyFleetData(data) {
   fleetState.attention = attentionFromData(data);
   fleetState.operatorBrief = data.operator_brief || null;
   fleetState.verdict = data.verdict || null;
+  fleetState.nextAction = data.next_action || null;
   if (!fleetState.selectedWorkerKey && fleetState.requestedWorker) {
     const requested = resolveWorkerQuery(fleetState.requestedWorker);
     if (requested) fleetState.selectedWorkerKey = workerKey(requested);
@@ -2345,7 +2370,7 @@ function applyFleetData(data) {
     (alerts.length ? " · " + alerts.join(" · ") : "");
   renderFilterOptions();
   syncFilterControls();
-  renderFleetVerdict(fleetState.operatorBrief, fleetState.verdict);
+  renderFleetVerdict(fleetState.nextAction);
   renderStats(summary);
   renderProjectRail();
   renderProjectOverview();
@@ -2371,7 +2396,7 @@ async function loadFleet() {
     applyFleetData(await response.json());
   } catch (err) {
     subtitleEl.textContent = "Fleet API error" + (fleetState.refreshedAt ? " · Last successful refresh " + formatTimestamp(fleetState.refreshedAt) : "");
-    renderFleetVerdict({ tone: "daemon-down", sentence: "Fleet API error. Supervisor heartbeat unavailable; worker state and attention state could not be confirmed." });
+    renderFleetVerdict({ priority: "P0", kind: "error", project: "Fleet API", reason: "Fleet API error. Supervisor heartbeat unavailable; worker state and attention state could not be confirmed." });
     approvalSummaryEl.textContent = "Fleet API error";
     approvalListEl.innerHTML = '<div class="error">Unable to load approval inbox.</div>';
     attentionSummaryEl.textContent = "Fleet API error";

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -1268,7 +1268,7 @@ function fleetSafeTargetURL(value) {
 
 function renderFleetVerdict(nextAction, verdict) {
   if (!fleetVerdictEl) return;
-  if (!nextAction || !nextAction.reason) {
+  if (!nextAction) {
     const fallback = fleetDegradedVerdictFallback(verdict);
     if (fallback) {
       fleetVerdictEl.className = "fleet-verdict verdict-" + fallback.tone;
@@ -1287,7 +1287,7 @@ function renderFleetVerdict(nextAction, verdict) {
   }
   const tone = fleetNextActionToneClass(nextAction.priority);
   const project = String(nextAction.project || "").trim();
-  const reason = String(nextAction.reason || "").trim();
+  const reason = String(nextAction.reason || "").trim() || "Operator action required.";
   const headline = (project ? project + " · " : "") + reason;
   const metaParts = [];
   metaParts.push(String(nextAction.priority || "P1").toUpperCase() + " · " + fleetNextActionKindLabel(nextAction.kind));


### PR DESCRIPTION
Refs #399

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR collapses the fleet global brief into a single structured `next_action` field on `/api/v1/fleet`, selected by a deterministic priority-tier + oldest-timestamp algorithm. The legacy `verdict.sentence` and `operator_brief` fields are preserved for backward compatibility. The frontend is updated to consume `next_action` directly, with a safe URL scheme validator (`fleetSafeTargetURL`) that closes the `javascript:` XSS vector flagged in prior review, and empty-reason is now handled gracefully with an "Operator action required." fallback rather than an early exit.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues found; previously flagged security and logic bugs are addressed.

Algorithm is correct and well-tested (8 targeted tests covering priority ordering, age ordering, SLA escalation, timestamp source, and snapshot stability). The security fix for javascript: URL injection is in place. The empty-reason early-exit bug from prior review is resolved. CSS display: grid was already established in the base rule, so the new grid-template-columns applies correctly. No regressions identified in backward-compatible fields.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds buildFleetNextAction with deterministic priority-tier + oldest-timestamp selection; new fleetNextAction struct and helpers; well-structured fallback chains; no logic errors found. |
| internal/server/fleet_test.go | Eight new focused tests covering nil/idle, priority ordering, within-tier age ordering, SLA escalation, timestamp source correctness, and snapshot stability; good coverage of the new algorithm. |
| internal/server/web/static/fleet.js | Refactors renderFleetVerdict to consume the new next_action field; adds fleetSafeTargetURL scheme validation (fixes prior javascript: XSS vector); fleetDegradedVerdictFallback correctly maps error tone via existing fleetBriefToneClass; no issues found. |
| internal/server/web/static/fleet.css | Adds two-column grid layout (1fr + auto) and CTA button styles inside the existing media query; display: grid is already established in the base rule so grid-template-columns applies correctly. |
| docs/fleet-mission-control-runbook.md | Adds accurate documentation for the selection algorithm, tier table, and next_action JSON shape; matches the implementation faithfully. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: render next action even when reason..."](https://github.com/befeast/maestro/commit/42f354710bd7b1a1c9e96a1b3d4444c09056d140) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30604386)</sub>

<!-- /greptile_comment -->