### PR TITLE
feat: dismiss dead sessions when linked PR is merged (#402)

### DIFF
--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -322,16 +322,23 @@ Safe response:
    - `enabled` defaults to `true`.
    - `idle_after_minutes` defaults to `1440` (24 hours).
    - `require_worktree_missing` defaults to `true`.
-2. Sessions that pass all three checks (idle past the window AND a recorded worktree path AND that path is missing on disk) are removed from `attention` and recorded in `audit-log.jsonl` under the project's `state_dir` with action `stale_session_reconciled`. The sessions remain searchable in `workers` for drilldown.
-3. To temporarily disable filtering for a project, set `stale_session_reconciler.enabled: false` and restart the project runner.
-4. To tighten the window during dogfood/recovery, lower `idle_after_minutes` (for example `60` for one hour). Keep `require_worktree_missing: true` so a live worker is never reclaimed.
-5. Per-project `stale_session_reconciler` config example:
+   - `merged_pr_dismisses` defaults to `true`.
+2. A dead session is filtered from `attention` when **either** condition holds:
+   - **Idle/worktree path:** the session is past `idle_after_minutes` AND, when `require_worktree_missing` is true, its recorded worktree path is missing on disk.
+   - **Linked-PR-merged path:** the session's branch (head ref recorded as `branch` in the API, e.g. `feat/sup-44-346-…`) maps to a PR that the project state already classifies as merged. This path fires regardless of idle time, so a freshly retry-exhausted session whose PR has just merged stops haunting `attention` immediately.
+3. Reconciled sessions are recorded in `audit-log.jsonl` under the project's `state_dir` with action `stale_session_reconciled`. The audit `reason` field carries the trigger (`linked PR merged` for the new path, otherwise the legacy idle-window reason). Sessions remain searchable in `workers` for drilldown.
+4. To temporarily disable filtering for a project, set `stale_session_reconciler.enabled: false` and restart the project runner.
+5. To keep only the legacy idle/worktree behaviour from PR #400, set `stale_session_reconciler.merged_pr_dismisses: false`.
+6. To tighten the idle path during dogfood/recovery, lower `idle_after_minutes` (for example `60` for one hour). Keep `require_worktree_missing: true` so a live worker is never reclaimed.
+7. The reconciler reads PR state from the existing project state snapshot (sessions already transitioned to `done`/`code_landed`); it does not issue ad-hoc `gh` calls in the snapshot path.
+8. Per-project `stale_session_reconciler` config example:
 
 ```yaml
 stale_session_reconciler:
   enabled: true
   idle_after_minutes: 1440
   require_worktree_missing: true
+  merged_pr_dismisses: true
 ```
 
 ### Project API failure

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -237,6 +237,7 @@ type StaleSessionReconcilerConfig struct {
 	Enabled                *bool `yaml:"enabled"`                  // default: true
 	IdleAfterMinutes       int   `yaml:"idle_after_minutes"`       // default: 1440 (24h)
 	RequireWorktreeMissing *bool `yaml:"require_worktree_missing"` // default: true
+	MergedPRDismisses      *bool `yaml:"merged_pr_dismisses"`      // default: true
 }
 
 // IsEnabled returns whether stale-session reconciliation runs.
@@ -264,6 +265,16 @@ func (c StaleSessionReconcilerConfig) IdleAfter() int {
 		return 24 * 60
 	}
 	return c.IdleAfterMinutes
+}
+
+// MergedPRDismissesEnabled reports whether a dead session whose linked PR is
+// merged should be dismissed independently of the idle/worktree window.
+// Default true.
+func (c StaleSessionReconcilerConfig) MergedPRDismissesEnabled() bool {
+	if c.MergedPRDismisses == nil {
+		return true
+	}
+	return *c.MergedPRDismisses
 }
 
 type Config struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,6 +24,9 @@ repo: owner/repo
 	if !cfg.StaleSessionReconciler.WorktreeMissingRequired() {
 		t.Fatalf("default reconciler must require worktree missing")
 	}
+	if !cfg.StaleSessionReconciler.MergedPRDismissesEnabled() {
+		t.Fatalf("default reconciler must enable merged_pr_dismisses")
+	}
 }
 
 func TestParse_StaleSessionReconcilerExplicitOverride(t *testing.T) {
@@ -33,6 +36,7 @@ stale_session_reconciler:
   enabled: false
   idle_after_minutes: 90
   require_worktree_missing: false
+  merged_pr_dismisses: false
 `
 	cfg, err := parse([]byte(yaml))
 	if err != nil {
@@ -46,6 +50,9 @@ stale_session_reconciler:
 	}
 	if cfg.StaleSessionReconciler.WorktreeMissingRequired() {
 		t.Fatalf("explicit require_worktree_missing=false should disable worktree gate")
+	}
+	if cfg.StaleSessionReconciler.MergedPRDismissesEnabled() {
+		t.Fatalf("explicit merged_pr_dismisses=false must disable linked-PR path")
 	}
 }
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1737,11 +1737,50 @@ func reconcileStaleSessions(cfg *config.Config, st *state.State, now time.Time) 
 		Enabled:                cfg.StaleSessionReconciler.IsEnabled(),
 		IdleAfter:              time.Duration(cfg.StaleSessionReconciler.IdleAfter()) * time.Minute,
 		RequireWorktreeMissing: cfg.StaleSessionReconciler.WorktreeMissingRequired(),
+		MergedPRDismisses:      cfg.StaleSessionReconciler.MergedPRDismissesEnabled(),
 	}
 	if !policy.Enabled {
 		return nil
 	}
+	if policy.MergedPRDismisses {
+		policy.PRStateForBranch = mergedBranchLookupFromState(st)
+	}
 	return st.ReconcileStaleSessions(now, policy, worktreeExistsOnDisk)
+}
+
+// mergedBranchLookupFromState derives a branch -> PR state lookup from the
+// session table already persisted in state. A branch is reported as "MERGED"
+// when any session in state for that branch has reached StatusDone or
+// StatusCodeLanded — both terminal states are only entered after the
+// orchestrator has observed the linked PR as merged. The lookup uses no
+// network calls, so the snapshot path stays fast and side-effect free.
+func mergedBranchLookupFromState(st *state.State) func(string) string {
+	if st == nil {
+		return nil
+	}
+	merged := make(map[string]struct{})
+	for _, sess := range st.Sessions {
+		if sess == nil {
+			continue
+		}
+		branch := strings.TrimSpace(sess.Branch)
+		if branch == "" {
+			continue
+		}
+		switch sess.Status {
+		case state.StatusDone, state.StatusCodeLanded:
+			merged[branch] = struct{}{}
+		}
+	}
+	if len(merged) == 0 {
+		return func(string) string { return "" }
+	}
+	return func(branch string) string {
+		if _, ok := merged[strings.TrimSpace(branch)]; ok {
+			return "MERGED"
+		}
+		return ""
+	}
 }
 
 func worktreeExistsOnDisk(path string) bool {

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1743,40 +1743,54 @@ func reconcileStaleSessions(cfg *config.Config, st *state.State, now time.Time) 
 		return nil
 	}
 	if policy.MergedPRDismisses {
-		policy.PRStateForBranch = mergedBranchLookupFromState(st)
+		policy.PRStateForBranchPR = mergedBranchLookupFromState(st)
 	}
 	return st.ReconcileStaleSessions(now, policy, worktreeExistsOnDisk)
 }
 
-// mergedBranchLookupFromState derives a branch -> PR state lookup from the
-// session table already persisted in state. A branch is reported as "MERGED"
-// when any session in state for that branch has reached StatusDone or
-// StatusCodeLanded — both terminal states are only entered after the
-// orchestrator has observed the linked PR as merged. The lookup uses no
-// network calls, so the snapshot path stays fast and side-effect free.
-func mergedBranchLookupFromState(st *state.State) func(string) string {
+// mergedBranchLookupFromState derives a (branch, PRNumber) -> PR state lookup
+// from the session table already persisted in state. Only StatusCodeLanded
+// sessions contribute to the set: that is the one terminal status the
+// orchestrator sets exclusively after observing the linked PR as merged.
+// StatusDone is intentionally excluded because the orchestrator also reaches
+// it on non-merge paths (issue closed externally) and would otherwise produce
+// false dismissals.
+//
+// The lookup is keyed by (branch, PRNumber) so a stale CodeLanded record on
+// the same branch but with a different PRNumber (e.g. after the original
+// issue was re-opened and a new session retried on the same branch) cannot
+// poison a live retry. The lookup uses no network calls, so the snapshot
+// path stays fast and side-effect free.
+func mergedBranchLookupFromState(st *state.State) func(string, int) string {
 	if st == nil {
 		return nil
 	}
-	merged := make(map[string]struct{})
+	type key struct {
+		branch   string
+		prNumber int
+	}
+	merged := make(map[key]struct{})
 	for _, sess := range st.Sessions {
 		if sess == nil {
 			continue
 		}
-		branch := strings.TrimSpace(sess.Branch)
-		if branch == "" {
+		if sess.Status != state.StatusCodeLanded {
 			continue
 		}
-		switch sess.Status {
-		case state.StatusDone, state.StatusCodeLanded:
-			merged[branch] = struct{}{}
+		branch := strings.TrimSpace(sess.Branch)
+		if branch == "" || sess.PRNumber <= 0 {
+			continue
 		}
+		merged[key{branch: branch, prNumber: sess.PRNumber}] = struct{}{}
 	}
 	if len(merged) == 0 {
-		return func(string) string { return "" }
+		return func(string, int) string { return "" }
 	}
-	return func(branch string) string {
-		if _, ok := merged[strings.TrimSpace(branch)]; ok {
+	return func(branch string, prNumber int) string {
+		if prNumber <= 0 {
+			return ""
+		}
+		if _, ok := merged[key{branch: strings.TrimSpace(branch), prNumber: prNumber}]; ok {
 			return "MERGED"
 		}
 		return ""

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -2925,6 +2925,144 @@ func TestFleetAPIDisabledReconcilerKeepsAttention(t *testing.T) {
 	}
 }
 
+func TestFleetAPIDismissesDeadSessionWhenLinkedPRMerged(t *testing.T) {
+	resetFleetStaleAuditDedup()
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "state")
+	presentWorktree := filepath.Join(dir, "present-worktree")
+	if err := os.MkdirAll(presentWorktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	finishedRecent := now.Add(-15 * time.Minute) // inside idle window
+	branch := "feat/sup-46-347-confirmation-dialog"
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"sup-46": {
+			IssueNumber: 347,
+			IssueTitle:  "Confirmation dialog",
+			PRNumber:    396,
+			Status:      state.StatusRetryExhausted,
+			Branch:      branch,
+			StartedAt:   finishedRecent.Add(-time.Hour),
+			FinishedAt:  &finishedRecent,
+			Worktree:    presentWorktree,
+		},
+		"sup-44": {
+			IssueNumber: 347,
+			IssueTitle:  "Confirmation dialog (merged sibling)",
+			PRNumber:    396,
+			Status:      state.StatusDone,
+			Branch:      branch,
+			StartedAt:   finishedRecent.Add(-2 * time.Hour),
+			FinishedAt:  &finishedRecent,
+		},
+	})
+
+	cfg := &config.Config{
+		Repo:        "owner/finance",
+		StateDir:    stateDir,
+		MaxParallel: 4,
+	}
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("finance", "/tmp/finance.yaml", "http://127.0.0.1:8788", cfg),
+	}, "127.0.0.1", 8786, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleet(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp fleetResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, worker := range resp.Attention {
+		if worker.Slot == "sup-46" {
+			t.Fatalf("sup-46 must drop out of attention when its linked PR is merged: %+v", worker)
+		}
+	}
+
+	stale := findFleetWorker(t, resp.Workers, "sup-46")
+	if stale.NeedsAttention {
+		t.Fatalf("sup-46 needs_attention should be cleared; got %+v", stale)
+	}
+	if !contains(stale.StatusReason, state.MergedPRReason) {
+		t.Fatalf("sup-46 status reason = %q, want %q reflected", stale.StatusReason, state.MergedPRReason)
+	}
+
+	auditPath := filepath.Join(stateDir, "audit-log.jsonl")
+	data, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	if !contains(string(data), state.MergedPRReason) {
+		t.Fatalf("audit log missing %q reason: %s", state.MergedPRReason, data)
+	}
+
+	// Second snapshot must not duplicate the audit entry.
+	srv.handleFleet(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil))
+	data2, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit log second pass: %v", err)
+	}
+	if !bytes.Equal(data, data2) {
+		t.Fatalf("audit log should be append-once for the same merged-PR reconciliation.\nfirst:\n%s\nsecond:\n%s", data, data2)
+	}
+}
+
+func TestFleetAPIMergedPRDismissesDisabledKeepsAttention(t *testing.T) {
+	resetFleetStaleAuditDedup()
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "state")
+	presentWorktree := filepath.Join(dir, "present-worktree")
+	if err := os.MkdirAll(presentWorktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	finishedRecent := now.Add(-15 * time.Minute) // inside idle window
+	branch := "feat/sup-46-347-confirmation-dialog"
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"sup-46": {
+			IssueNumber: 347,
+			PRNumber:    396,
+			Status:      state.StatusRetryExhausted,
+			Branch:      branch,
+			StartedAt:   finishedRecent.Add(-time.Hour),
+			FinishedAt:  &finishedRecent,
+			Worktree:    presentWorktree,
+		},
+		"sup-44": {
+			IssueNumber: 347,
+			PRNumber:    396,
+			Status:      state.StatusDone,
+			Branch:      branch,
+			StartedAt:   finishedRecent.Add(-2 * time.Hour),
+			FinishedAt:  &finishedRecent,
+		},
+	})
+
+	mergedDisabled := false
+	cfg := &config.Config{
+		Repo:        "owner/finance",
+		StateDir:    stateDir,
+		MaxParallel: 4,
+		StaleSessionReconciler: config.StaleSessionReconcilerConfig{
+			MergedPRDismisses: &mergedDisabled,
+		},
+	}
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("finance", "/tmp/finance.yaml", "http://127.0.0.1:8788", cfg),
+	}, "127.0.0.1", 8786, true)
+
+	resp := srv.snapshot()
+	stale := findFleetWorker(t, resp.Workers, "sup-46")
+	if !stale.NeedsAttention {
+		t.Fatalf("merged_pr_dismisses=false must preserve PR-#400 behavior; got %+v", stale)
+	}
+}
+
 func resetFleetStaleAuditDedup() {
 	fleetStaleAuditMu.Lock()
 	fleetStaleAuditEmitted = make(map[string]struct{})

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -2951,7 +2951,7 @@ func TestFleetAPIDismissesDeadSessionWhenLinkedPRMerged(t *testing.T) {
 			IssueNumber: 347,
 			IssueTitle:  "Confirmation dialog (merged sibling)",
 			PRNumber:    396,
-			Status:      state.StatusDone,
+			Status:      state.StatusCodeLanded,
 			Branch:      branch,
 			StartedAt:   finishedRecent.Add(-2 * time.Hour),
 			FinishedAt:  &finishedRecent,
@@ -3036,7 +3036,7 @@ func TestFleetAPIMergedPRDismissesDisabledKeepsAttention(t *testing.T) {
 		"sup-44": {
 			IssueNumber: 347,
 			PRNumber:    396,
-			Status:      state.StatusDone,
+			Status:      state.StatusCodeLanded,
 			Branch:      branch,
 			StartedAt:   finishedRecent.Add(-2 * time.Hour),
 			FinishedAt:  &finishedRecent,
@@ -3060,6 +3060,118 @@ func TestFleetAPIMergedPRDismissesDisabledKeepsAttention(t *testing.T) {
 	stale := findFleetWorker(t, resp.Workers, "sup-46")
 	if !stale.NeedsAttention {
 		t.Fatalf("merged_pr_dismisses=false must preserve PR-#400 behavior; got %+v", stale)
+	}
+}
+
+// TestFleetAPIDoesNotDismissOnStaleDoneSibling guards against the
+// non-merge StatusDone path (issue closed externally) being misread as
+// "linked PR merged" by the reconciler. A sibling session on the same
+// branch in StatusDone — with no StatusCodeLanded record anywhere — must
+// not contribute to the merged-branch set.
+func TestFleetAPIDoesNotDismissOnStaleDoneSibling(t *testing.T) {
+	resetFleetStaleAuditDedup()
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "state")
+	presentWorktree := filepath.Join(dir, "present-worktree")
+	if err := os.MkdirAll(presentWorktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	finishedRecent := now.Add(-15 * time.Minute) // inside idle window
+	branch := "feat/sup-46-347-confirmation-dialog"
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"sup-46": {
+			IssueNumber: 347,
+			PRNumber:    396,
+			Status:      state.StatusRetryExhausted,
+			Branch:      branch,
+			StartedAt:   finishedRecent.Add(-time.Hour),
+			FinishedAt:  &finishedRecent,
+			Worktree:    presentWorktree,
+		},
+		// Sibling reached StatusDone via a non-merge transition (issue
+		// closed externally). It must not be treated as evidence that
+		// PR #396 actually merged.
+		"sup-44": {
+			IssueNumber: 347,
+			PRNumber:    396,
+			Status:      state.StatusDone,
+			Branch:      branch,
+			StartedAt:   finishedRecent.Add(-2 * time.Hour),
+			FinishedAt:  &finishedRecent,
+		},
+	})
+
+	cfg := &config.Config{
+		Repo:        "owner/finance",
+		StateDir:    stateDir,
+		MaxParallel: 4,
+	}
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("finance", "/tmp/finance.yaml", "http://127.0.0.1:8788", cfg),
+	}, "127.0.0.1", 8786, true)
+
+	resp := srv.snapshot()
+	stale := findFleetWorker(t, resp.Workers, "sup-46")
+	if !stale.NeedsAttention {
+		t.Fatalf("sup-46 must remain in attention when no StatusCodeLanded sibling proves PR-merge; got %+v", stale)
+	}
+}
+
+// TestFleetAPIDoesNotDismissWhenBranchReusedForDifferentPR guards
+// against the issue-reopen scenario: an old session on branch X with PR
+// 100 reached StatusCodeLanded; the issue was re-opened and a new
+// session on the SAME branch but a DIFFERENT PR (200, still open)
+// reached StatusRetryExhausted. The new session must not be dismissed
+// just because the old PR on the same branch was merged.
+func TestFleetAPIDoesNotDismissWhenBranchReusedForDifferentPR(t *testing.T) {
+	resetFleetStaleAuditDedup()
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "state")
+	presentWorktree := filepath.Join(dir, "present-worktree")
+	if err := os.MkdirAll(presentWorktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	finishedRecent := now.Add(-15 * time.Minute)
+	branch := "feat/sup-46-347-confirmation-dialog"
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		// Old, properly-merged session on this branch.
+		"sup-44": {
+			IssueNumber: 347,
+			PRNumber:    100,
+			Status:      state.StatusCodeLanded,
+			Branch:      branch,
+			StartedAt:   finishedRecent.Add(-3 * time.Hour),
+			FinishedAt:  &finishedRecent,
+		},
+		// Issue re-opened, new retry on the same branch with a NEW PR
+		// that is still open; the retry exhausted. Must remain in
+		// attention.
+		"sup-46": {
+			IssueNumber: 347,
+			PRNumber:    200,
+			Status:      state.StatusRetryExhausted,
+			Branch:      branch,
+			StartedAt:   finishedRecent.Add(-time.Hour),
+			FinishedAt:  &finishedRecent,
+			Worktree:    presentWorktree,
+		},
+	})
+
+	cfg := &config.Config{
+		Repo:        "owner/finance",
+		StateDir:    stateDir,
+		MaxParallel: 4,
+	}
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("finance", "/tmp/finance.yaml", "http://127.0.0.1:8788", cfg),
+	}, "127.0.0.1", 8786, true)
+
+	resp := srv.snapshot()
+	stale := findFleetWorker(t, resp.Workers, "sup-46")
+	if !stale.NeedsAttention {
+		t.Fatalf("sup-46 must keep needs_attention when its own PR (200) is not the merged one (100); got %+v", stale)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1747,7 +1747,19 @@ type StaleSessionPolicy struct {
 	// idle window this prevents a live worker that simply has not written
 	// state recently from being filtered out.
 	RequireWorktreeMissing bool
+	// MergedPRDismisses, when true, treats a dead session whose linked PR is
+	// known to be MERGED as completed regardless of idle time or worktree
+	// presence. PRStateForBranch supplies the lookup; when nil, this path
+	// has no effect.
+	MergedPRDismisses bool
+	// PRStateForBranch returns the known PR state ("MERGED", "OPEN", ...) for
+	// the given session branch name. An empty string means unknown.
+	PRStateForBranch func(branch string) string
 }
+
+// MergedPRReason is the audit reason emitted when a session is dismissed
+// because its linked PR is known to be merged.
+const MergedPRReason = "linked PR merged"
 
 // StaleSessionAudit records a single stale-session reconciliation event.
 // Callers persist this through a project's audit log; it is not stored in
@@ -1770,9 +1782,6 @@ func SessionStale(sess *Session, now time.Time, policy StaleSessionPolicy, workt
 	if sess == nil || !policy.Enabled {
 		return StaleSessionAudit{}, false
 	}
-	if policy.IdleAfter <= 0 {
-		return StaleSessionAudit{}, false
-	}
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
@@ -1789,10 +1798,41 @@ func SessionStale(sess *Session, now time.Time, policy StaleSessionPolicy, workt
 	}
 
 	changedAt := SessionChangedAt(sess)
+	idle := time.Duration(0)
+	if !changedAt.IsZero() {
+		idle = now.Sub(changedAt)
+	}
+
+	// Linked-PR-merged path: when enabled, a dead session whose branch maps
+	// to a MERGED PR is dismissed regardless of idle time or worktree
+	// presence. The audit carries an explicit "linked PR merged" reason so
+	// operators can see which condition fired.
+	if policy.MergedPRDismisses && policy.PRStateForBranch != nil {
+		branch := strings.TrimSpace(sess.Branch)
+		if branch != "" {
+			if state := strings.ToUpper(strings.TrimSpace(policy.PRStateForBranch(branch))); state == "MERGED" {
+				idleSeconds := int64(0)
+				if idle > 0 {
+					idleSeconds = int64(idle.Round(time.Second) / time.Second)
+				}
+				return StaleSessionAudit{
+					IssueNumber: sess.IssueNumber,
+					PRNumber:    sess.PRNumber,
+					Status:      string(sess.Status),
+					Reason:      MergedPRReason,
+					IdleSeconds: idleSeconds,
+					At:          now,
+				}, true
+			}
+		}
+	}
+
+	if policy.IdleAfter <= 0 {
+		return StaleSessionAudit{}, false
+	}
 	if changedAt.IsZero() {
 		return StaleSessionAudit{}, false
 	}
-	idle := now.Sub(changedAt)
 	if idle < policy.IdleAfter {
 		return StaleSessionAudit{}, false
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1749,12 +1749,16 @@ type StaleSessionPolicy struct {
 	RequireWorktreeMissing bool
 	// MergedPRDismisses, when true, treats a dead session whose linked PR is
 	// known to be MERGED as completed regardless of idle time or worktree
-	// presence. PRStateForBranch supplies the lookup; when nil, this path
+	// presence. PRStateForBranchPR supplies the lookup; when nil, this path
 	// has no effect.
 	MergedPRDismisses bool
-	// PRStateForBranch returns the known PR state ("MERGED", "OPEN", ...) for
-	// the given session branch name. An empty string means unknown.
-	PRStateForBranch func(branch string) string
+	// PRStateForBranchPR returns the known PR state ("MERGED", "OPEN", ...)
+	// for the given session branch name and the candidate session's own
+	// PRNumber. The PRNumber match guards against false dismissals when an
+	// issue is re-opened: a stale CodeLanded record on the same branch but
+	// with a different PRNumber must not poison a live retry. An empty
+	// return value means unknown.
+	PRStateForBranchPR func(branch string, prNumber int) string
 }
 
 // MergedPRReason is the audit reason emitted when a session is dismissed
@@ -1803,14 +1807,17 @@ func SessionStale(sess *Session, now time.Time, policy StaleSessionPolicy, workt
 		idle = now.Sub(changedAt)
 	}
 
-	// Linked-PR-merged path: when enabled, a dead session whose branch maps
-	// to a MERGED PR is dismissed regardless of idle time or worktree
-	// presence. The audit carries an explicit "linked PR merged" reason so
-	// operators can see which condition fired.
-	if policy.MergedPRDismisses && policy.PRStateForBranch != nil {
+	// Linked-PR-merged path: when enabled, a dead session whose own PR is
+	// known to be MERGED is dismissed regardless of idle time or worktree
+	// presence. The lookup must match on (branch, PRNumber) so a stale
+	// CodeLanded record on the same branch but for a different PR (e.g.
+	// after the issue was re-opened) cannot poison a live retry. The audit
+	// carries an explicit "linked PR merged" reason so operators can see
+	// which condition fired.
+	if policy.MergedPRDismisses && policy.PRStateForBranchPR != nil && sess.PRNumber > 0 {
 		branch := strings.TrimSpace(sess.Branch)
 		if branch != "" {
-			if state := strings.ToUpper(strings.TrimSpace(policy.PRStateForBranch(branch))); state == "MERGED" {
+			if state := strings.ToUpper(strings.TrimSpace(policy.PRStateForBranchPR(branch, sess.PRNumber))); state == "MERGED" {
 				idleSeconds := int64(0)
 				if idle > 0 {
 					idleSeconds = int64(idle.Round(time.Second) / time.Second)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1789,6 +1789,179 @@ func TestReconcileStaleSessions_IsIdempotent(t *testing.T) {
 	}
 }
 
+func TestSessionStale_LinkedMergedPRDismissesRegardlessOfIdle(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-15 * time.Minute) // well below IdleAfter window
+	sess := &Session{
+		IssueNumber: 347,
+		PRNumber:    396,
+		Status:      StatusRetryExhausted,
+		Branch:      "feat/sup-46-347-confirmation-dialog",
+		StartedAt:   finished.Add(-5 * time.Minute),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/sup-46",
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+		MergedPRDismisses:      true,
+		PRStateForBranch: func(b string) string {
+			if b == "feat/sup-46-347-confirmation-dialog" {
+				return "MERGED"
+			}
+			return ""
+		},
+	}
+	worktreeExists := func(string) bool { return true } // worktree present and idle window unmet — old policy would not fire
+
+	audit, stale := SessionStale(sess, now, policy, worktreeExists)
+	if !stale {
+		t.Fatalf("session with MERGED linked PR should be reconciled regardless of idle/worktree")
+	}
+	if audit.Reason != MergedPRReason {
+		t.Fatalf("audit reason = %q, want %q", audit.Reason, MergedPRReason)
+	}
+	if audit.IssueNumber != 347 || audit.PRNumber != 396 {
+		t.Fatalf("audit target = %+v, want issue=347 pr=396", audit)
+	}
+}
+
+func TestSessionStale_NoLinkedPRFollowsLegacyPolicy(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-30 * time.Hour)
+	sess := &Session{
+		IssueNumber: 101,
+		Status:      StatusDead,
+		Branch:      "feat/sup-44-101-no-pr-yet",
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/missing-44",
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+		MergedPRDismisses:      true,
+		PRStateForBranch:       func(string) string { return "" }, // no link known
+	}
+	worktreeExists := func(string) bool { return false }
+
+	audit, stale := SessionStale(sess, now, policy, worktreeExists)
+	if !stale {
+		t.Fatalf("session with no linked PR but stale-by-idle should still reconcile via legacy policy")
+	}
+	if audit.Reason == MergedPRReason {
+		t.Fatalf("audit reason should reflect legacy policy, got %q", audit.Reason)
+	}
+
+	// And: a session within the idle window with no linked PR is not dismissed.
+	freshFinished := now.Add(-5 * time.Minute)
+	fresh := &Session{
+		IssueNumber: 102,
+		Status:      StatusDead,
+		Branch:      "feat/sup-44-102",
+		StartedAt:   freshFinished.Add(-time.Hour),
+		FinishedAt:  &freshFinished,
+		Worktree:    "/tmp/missing-fresh",
+	}
+	if _, stale := SessionStale(fresh, now, policy, worktreeExists); stale {
+		t.Fatalf("session within idle window and no linked PR must not be reconciled")
+	}
+}
+
+func TestSessionStale_LinkedOpenPRIsNotDismissed(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-15 * time.Minute)
+	sess := &Session{
+		IssueNumber: 200,
+		PRNumber:    500,
+		Status:      StatusRetryExhausted,
+		Branch:      "feat/sup-1-200-still-open",
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/sup-1",
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+		MergedPRDismisses:      true,
+		PRStateForBranch:       func(string) string { return "OPEN" },
+	}
+	if _, stale := SessionStale(sess, now, policy, func(string) bool { return true }); stale {
+		t.Fatalf("session whose linked PR is OPEN must not be dismissed by the merged-PR path")
+	}
+}
+
+func TestSessionStale_MergedPRDismissesDisabledIgnoresLookup(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-15 * time.Minute)
+	sess := &Session{
+		IssueNumber: 347,
+		PRNumber:    396,
+		Status:      StatusRetryExhausted,
+		Branch:      "feat/sup-46-347-confirmation-dialog",
+		StartedAt:   finished.Add(-5 * time.Minute),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/sup-46",
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+		MergedPRDismisses:      false, // disabled — must match legacy behavior
+		PRStateForBranch:       func(string) string { return "MERGED" },
+	}
+	if _, stale := SessionStale(sess, now, policy, func(string) bool { return true }); stale {
+		t.Fatalf("merged_pr_dismisses=false must disable the linked-PR path")
+	}
+}
+
+func TestReconcileStaleSessions_LinkedMergedPRIsIdempotent(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-15 * time.Minute)
+	st := NewState()
+	st.Sessions["sup-46"] = &Session{
+		IssueNumber: 347,
+		PRNumber:    396,
+		Status:      StatusRetryExhausted,
+		Branch:      "feat/sup-46-347-confirmation-dialog",
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/sup-46",
+	}
+	st.Sessions["sup-99"] = &Session{
+		IssueNumber: 999,
+		Status:      StatusRunning,
+		StartedAt:   now.Add(-time.Minute),
+	}
+	lookup := func(b string) string {
+		if b == "feat/sup-46-347-confirmation-dialog" {
+			return "MERGED"
+		}
+		return ""
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+		MergedPRDismisses:      true,
+		PRStateForBranch:       lookup,
+	}
+	first := st.ReconcileStaleSessions(now, policy, func(string) bool { return true })
+	second := st.ReconcileStaleSessions(now, policy, func(string) bool { return true })
+	if len(first) != 1 || first[0].Slot != "sup-46" || first[0].Reason != MergedPRReason {
+		t.Fatalf("first pass = %+v, want one sup-46 audit with merged-PR reason", first)
+	}
+	if len(second) != 1 || second[0].Slot != first[0].Slot || second[0].Reason != first[0].Reason {
+		t.Fatalf("second pass = %+v, want identical to first", second)
+	}
+	if len(st.Sessions) != 2 {
+		t.Fatalf("state must not be mutated; sessions = %d", len(st.Sessions))
+	}
+}
+
 func TestReconcileStaleSessions_DisabledReturnsNothing(t *testing.T) {
 	now := time.Now().UTC()
 	finished := now.Add(-30 * time.Hour)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1806,8 +1806,8 @@ func TestSessionStale_LinkedMergedPRDismissesRegardlessOfIdle(t *testing.T) {
 		IdleAfter:              24 * time.Hour,
 		RequireWorktreeMissing: true,
 		MergedPRDismisses:      true,
-		PRStateForBranch: func(b string) string {
-			if b == "feat/sup-46-347-confirmation-dialog" {
+		PRStateForBranchPR: func(b string, pr int) string {
+			if b == "feat/sup-46-347-confirmation-dialog" && pr == 396 {
 				return "MERGED"
 			}
 			return ""
@@ -1843,7 +1843,7 @@ func TestSessionStale_NoLinkedPRFollowsLegacyPolicy(t *testing.T) {
 		IdleAfter:              24 * time.Hour,
 		RequireWorktreeMissing: true,
 		MergedPRDismisses:      true,
-		PRStateForBranch:       func(string) string { return "" }, // no link known
+		PRStateForBranchPR:     func(string, int) string { return "" }, // no link known
 	}
 	worktreeExists := func(string) bool { return false }
 
@@ -1887,10 +1887,79 @@ func TestSessionStale_LinkedOpenPRIsNotDismissed(t *testing.T) {
 		IdleAfter:              24 * time.Hour,
 		RequireWorktreeMissing: true,
 		MergedPRDismisses:      true,
-		PRStateForBranch:       func(string) string { return "OPEN" },
+		PRStateForBranchPR:     func(string, int) string { return "OPEN" },
 	}
 	if _, stale := SessionStale(sess, now, policy, func(string) bool { return true }); stale {
 		t.Fatalf("session whose linked PR is OPEN must not be dismissed by the merged-PR path")
+	}
+}
+
+// TestSessionStale_MergedPRRequiresPRNumberMatch guards against false
+// dismissals after issue re-open: a session on the same branch as a
+// previously-merged PR but with its own (different) PRNumber must not be
+// dismissed by the merged-PR path. Lookup is keyed by (branch, PRNumber).
+func TestSessionStale_MergedPRRequiresPRNumberMatch(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-15 * time.Minute)
+	sess := &Session{
+		IssueNumber: 347,
+		PRNumber:    200, // new PR after issue re-opened
+		Status:      StatusRetryExhausted,
+		Branch:      "feat/sup-46-347-confirmation-dialog",
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/sup-46",
+	}
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+		MergedPRDismisses:      true,
+		// Branch matches but only the OLD PR (100) is merged.
+		PRStateForBranchPR: func(b string, pr int) string {
+			if b == "feat/sup-46-347-confirmation-dialog" && pr == 100 {
+				return "MERGED"
+			}
+			return ""
+		},
+	}
+	if _, stale := SessionStale(sess, now, policy, func(string) bool { return true }); stale {
+		t.Fatalf("session whose own PR (200) is not merged must not be dismissed by branch reuse")
+	}
+}
+
+// TestSessionStale_MergedPRSkippedWhenPRNumberZero ensures sessions
+// without a recorded PRNumber are never dismissed via the merged-PR
+// path. Without a PRNumber there is no way to distinguish a stale match
+// from a live retry on the same branch.
+func TestSessionStale_MergedPRSkippedWhenPRNumberZero(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-15 * time.Minute)
+	sess := &Session{
+		IssueNumber: 347,
+		PRNumber:    0, // unknown
+		Status:      StatusRetryExhausted,
+		Branch:      "feat/sup-46-347-confirmation-dialog",
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+		Worktree:    "/tmp/sup-46",
+	}
+	called := false
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              24 * time.Hour,
+		RequireWorktreeMissing: true,
+		MergedPRDismisses:      true,
+		PRStateForBranchPR: func(string, int) string {
+			called = true
+			return "MERGED"
+		},
+	}
+	if _, stale := SessionStale(sess, now, policy, func(string) bool { return true }); stale {
+		t.Fatalf("session with PRNumber=0 must not be dismissed by merged-PR path")
+	}
+	if called {
+		t.Fatalf("lookup must not be called when PRNumber=0 — there is nothing to match")
 	}
 }
 
@@ -1911,7 +1980,7 @@ func TestSessionStale_MergedPRDismissesDisabledIgnoresLookup(t *testing.T) {
 		IdleAfter:              24 * time.Hour,
 		RequireWorktreeMissing: true,
 		MergedPRDismisses:      false, // disabled — must match legacy behavior
-		PRStateForBranch:       func(string) string { return "MERGED" },
+		PRStateForBranchPR:     func(string, int) string { return "MERGED" },
 	}
 	if _, stale := SessionStale(sess, now, policy, func(string) bool { return true }); stale {
 		t.Fatalf("merged_pr_dismisses=false must disable the linked-PR path")
@@ -1936,8 +2005,8 @@ func TestReconcileStaleSessions_LinkedMergedPRIsIdempotent(t *testing.T) {
 		Status:      StatusRunning,
 		StartedAt:   now.Add(-time.Minute),
 	}
-	lookup := func(b string) string {
-		if b == "feat/sup-46-347-confirmation-dialog" {
+	lookup := func(b string, pr int) string {
+		if b == "feat/sup-46-347-confirmation-dialog" && pr == 396 {
 			return "MERGED"
 		}
 		return ""
@@ -1947,7 +2016,7 @@ func TestReconcileStaleSessions_LinkedMergedPRIsIdempotent(t *testing.T) {
 		IdleAfter:              24 * time.Hour,
 		RequireWorktreeMissing: true,
 		MergedPRDismisses:      true,
-		PRStateForBranch:       lookup,
+		PRStateForBranchPR:     lookup,
 	}
 	first := st.ReconcileStaleSessions(now, policy, func(string) bool { return true })
 	second := st.ReconcileStaleSessions(now, policy, func(string) bool { return true })

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -80,14 +80,18 @@ worker_prompt: /path/to/worker-prompt-template.md
 # deploy_timeout_minutes: 15         # timeout for deploy command in minutes (default: 15)
 
 # Stale supervisor sessions are filtered out of the Fleet API attention list
-# only when all three guards agree. Defaults are conservative so live workers
-# are never reclassified: enabled=true, idle_after_minutes=1440 (24h),
-# require_worktree_missing=true. Set enabled=false to keep every dead session
-# in `attention` (legacy behavior).
+# under two independent conditions: (a) idle past idle_after_minutes AND the
+# recorded worktree is missing on disk (when require_worktree_missing=true),
+# or (b) the session's linked PR (matched by branch headRef) is MERGED.
+# Defaults are conservative so live workers are never reclassified:
+# enabled=true, idle_after_minutes=1440 (24h), require_worktree_missing=true,
+# merged_pr_dismisses=true. Set merged_pr_dismisses=false to keep behavior
+# limited to the idle/worktree path.
 # stale_session_reconciler:
 #   enabled: true
 #   idle_after_minutes: 1440
 #   require_worktree_missing: true
+#   merged_pr_dismisses: true
 
 # Telegram notifications
 telegram:


### PR DESCRIPTION
Implements #402

## Changes

- `internal/state/state.go`: extend `StaleSessionPolicy` with `MergedPRDismisses` and a `PRStateForBranch` lookup. `SessionStale` now treats a dead session whose branch maps to a `MERGED` PR as completed, emitting an audit with `reason="linked PR merged"` independently of the idle/worktree checks.
- `internal/server/fleet.go`: derive a branch -> PR-state lookup from the session table already in state (sessions at `done`/`code_landed` mark their branch as `MERGED`). No `gh` calls added to the snapshot path.
- `internal/config/config.go`: add `stale_session_reconciler.merged_pr_dismisses` (default `true`); set to `false` to keep the PR #400 idle/worktree-only behaviour.
- `docs/fleet-mission-control-runbook.md` and `maestro.yaml.example`: document the new condition and config flag.

## Testing

- `go test ./...` (all packages green)
- `go build ./cmd/maestro/`
- New unit coverage in `internal/state/state_test.go`:
  - merged-PR path dismisses regardless of idle/worktree
  - no linked PR continues to follow legacy 24h+worktree policy
  - linked OPEN PR is not dismissed
  - `merged_pr_dismisses=false` disables the path
  - reconciler is idempotent on the merged-PR path
- New fleet integration tests in `internal/server/fleet_test.go` cover end-to-end audit emission, dedup, and the disabled flag.
- Config defaults and explicit override covered in `internal/config/config_test.go`.

## Runtime verification

After deploy on workshop, run the verification script from the issue and confirm:

- `attention` drops by the count of dead sessions whose linked PR is merged.
- `next_action.target_url` no longer points at a ghost issue solely because of a merged PR.
- Visit `http://10.10.0.18:8786/fleet` to confirm the brief reflects a real operator task.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a second dismissal condition to the stale-session reconciler: dead sessions whose linked PR is known to be merged are immediately removed from `attention`, bypassing the idle-time and worktree-presence checks. The merged-PR evidence is derived entirely from `StatusCodeLanded` sibling sessions already in state (no new network calls), keyed by `(branch, PRNumber)` to prevent false dismissals on branch reuse or issue re-open — directly resolving the concern raised in the previous review thread.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic defects found; the (branch, PRNumber) composite key and StatusCodeLanded-only evidence set are correctly implemented and thoroughly tested.

All edge cases (open PR, zero PRNumber, branch reuse, StatusDone sibling, disabled flag, idempotency) are covered by unit and integration tests. The previous thread concern about branch-name-only keying was addressed. No P1 or P0 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds merged-PR fast path to SessionStale; moves IdleAfter guard below the new check; idle computation extracted earlier for reuse. Logic is correct and guards are tight. |
| internal/server/fleet.go | Adds mergedBranchLookupFromState keyed by (branch, PRNumber) using only StatusCodeLanded sessions; wires it into reconcileStaleSessions behind the MergedPRDismisses flag. |
| internal/config/config.go | Adds MergedPRDismisses pointer field with MergedPRDismissesEnabled() accessor defaulting to true; consistent with existing Enabled/WorktreeMissingRequired pattern. |
| internal/state/state_test.go | Thorough unit coverage: merged-PR dismisses regardless of idle/worktree, legacy path unaffected, open-PR not dismissed, PRNumber-match required, zero-PRNumber skipped, disabled flag respected, idempotency. |
| internal/server/fleet_test.go | Integration tests cover audit emission, dedup on second snapshot, disabled flag, StatusDone-sibling non-dismissal, and branch-reuse-with-different-PR guard. |
| internal/config/config_test.go | Adds default-true and explicit-false coverage for MergedPRDismissesEnabled; straightforward and correct. |
| docs/fleet-mission-control-runbook.md | Updated runbook accurately documents both dismissal conditions, the new config flag, and its default. |
| maestro.yaml.example | Example config updated with merged_pr_dismisses flag and revised comment block reflecting the two-condition dismissal model. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: require StatusCodeLanded + PRNumber..."](https://github.com/befeast/maestro/commit/bff8a192b5e5a2cae5e50af22de1f23e9de349ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30622508)</sub>

<!-- /greptile_comment -->