### PR TITLE
ProjectV2 status must mirror worker runtime and outcome DoD

### DIFF
--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -20,8 +20,31 @@ type ProjectStatus string
 const (
 	ProjectStatusTodo       ProjectStatus = "todo"
 	ProjectStatusInProgress ProjectStatus = "in_progress"
+	ProjectStatusInReview   ProjectStatus = "in_review"
+	ProjectStatusBlocked    ProjectStatus = "blocked"
 	ProjectStatusDone       ProjectStatus = "done"
 )
+
+// ProjectStatusCandidates returns the ordered list of column names to try when
+// applying a high-level ProjectStatus to a real GitHub Project board. Boards
+// often customize column names (e.g. "Review" vs "In Review", "On Hold" vs
+// "Blocked"); the first option present in the board's Status field wins.
+func ProjectStatusCandidates(status ProjectStatus) []string {
+	switch status {
+	case ProjectStatusTodo:
+		return []string{"Todo", "To do", "To Do", "Backlog"}
+	case ProjectStatusInProgress:
+		return []string{"In Progress", "In progress", "Doing"}
+	case ProjectStatusInReview:
+		return []string{"In Review", "In review", "Review", "Reviewing", "Code Review", "In Progress", "In progress"}
+	case ProjectStatusBlocked:
+		return []string{"Blocked", "On Hold", "On hold", "Stuck", "Needs Attention", "Needs attention"}
+	case ProjectStatusDone:
+		return []string{"Done", "Completed", "Closed"}
+	default:
+		return nil
+	}
+}
 
 // ProjectField holds the Status field metadata for a GitHub Project, discovered at runtime.
 type ProjectField struct {
@@ -214,13 +237,22 @@ func (c *Client) ListNonDoneProjectItems(pf *ProjectField) ([]ProjectItem, error
 // SyncIssueStatus adds an issue to the project (if not already) and sets its Status.
 // Best-effort: errors are logged, never returned.
 func (c *Client) SyncIssueStatus(pf *ProjectField, issueNumber int, statusName string) {
+	c.SyncIssueStatusOneOf(pf, issueNumber, statusName)
+}
+
+// SyncIssueStatusOneOf is SyncIssueStatus that tries each candidate column name
+// in order and uses the first that exists on the project board. This lets
+// callers express logical intent (e.g. "In Review") while tolerating boards
+// that use a different label ("Review", "Code Review"). When no candidate
+// matches, the call is a no-op so the worker runtime keeps making progress.
+func (c *Client) SyncIssueStatusOneOf(pf *ProjectField, issueNumber int, candidates ...string) {
 	if pf == nil {
 		return
 	}
 
-	optionID, ok := pf.Options[statusName]
+	statusName, optionID, ok := resolveProjectStatusOption(pf, candidates)
 	if !ok {
-		log.Printf("[projects] status %q not found in project (have: %v), skipping issue #%d", statusName, keys(pf.Options), issueNumber)
+		log.Printf("[projects] none of statuses %v found in project (have: %v), skipping issue #%d", candidates, keys(pf.Options), issueNumber)
 		return
 	}
 
@@ -361,4 +393,43 @@ func keys(m map[string]string) []string {
 		ks = append(ks, k)
 	}
 	return ks
+}
+
+// resolveProjectStatusOption finds the first candidate status name that exists
+// on the project's Status field, comparing case-insensitively and ignoring
+// surrounding whitespace. Returns the canonical (board) name and its option ID.
+func resolveProjectStatusOption(pf *ProjectField, candidates []string) (string, string, bool) {
+	if pf == nil || len(pf.Options) == 0 {
+		return "", "", false
+	}
+
+	normalized := make(map[string]string, len(pf.Options))
+	for name := range pf.Options {
+		normalized[normalizeProjectStatusKey(name)] = name
+	}
+
+	for _, candidate := range candidates {
+		key := normalizeProjectStatusKey(candidate)
+		if key == "" {
+			continue
+		}
+		// Exact match (case sensitive) first to preserve historical behavior.
+		if id, ok := pf.Options[candidate]; ok {
+			return candidate, id, true
+		}
+		if name, ok := normalized[key]; ok {
+			return name, pf.Options[name], true
+		}
+	}
+	return "", "", false
+}
+
+func normalizeProjectStatusKey(name string) string {
+	out := strings.ToLower(strings.TrimSpace(name))
+	out = strings.ReplaceAll(out, "_", " ")
+	out = strings.ReplaceAll(out, "-", " ")
+	for strings.Contains(out, "  ") {
+		out = strings.ReplaceAll(out, "  ", " ")
+	}
+	return out
 }

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -94,3 +94,127 @@ func TestKeys(t *testing.T) {
 		t.Errorf("keys() returned %d items, want 2", len(ks))
 	}
 }
+
+func TestProjectStatusCandidates(t *testing.T) {
+	tests := []struct {
+		status    ProjectStatus
+		wantFirst string
+	}{
+		{ProjectStatusTodo, "Todo"},
+		{ProjectStatusInProgress, "In Progress"},
+		{ProjectStatusInReview, "In Review"},
+		{ProjectStatusBlocked, "Blocked"},
+		{ProjectStatusDone, "Done"},
+	}
+	for _, tc := range tests {
+		got := ProjectStatusCandidates(tc.status)
+		if len(got) == 0 {
+			t.Fatalf("ProjectStatusCandidates(%q) returned no candidates", tc.status)
+		}
+		if got[0] != tc.wantFirst {
+			t.Errorf("ProjectStatusCandidates(%q) first = %q, want %q", tc.status, got[0], tc.wantFirst)
+		}
+	}
+}
+
+func TestResolveProjectStatusOption(t *testing.T) {
+	pf := &ProjectField{
+		ProjectID: "p",
+		FieldID:   "f",
+		Options: map[string]string{
+			"Todo":        "id-todo",
+			"In Progress": "id-progress",
+			"Review":      "id-review",
+			"On Hold":     "id-hold",
+			"Done":        "id-done",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		candidates []string
+		wantName   string
+		wantID     string
+		wantOK     bool
+	}{
+		{
+			name:       "exact match preferred",
+			candidates: []string{"Todo"},
+			wantName:   "Todo",
+			wantID:     "id-todo",
+			wantOK:     true,
+		},
+		{
+			name:       "case-insensitive fallback",
+			candidates: []string{"in progress"},
+			wantName:   "In Progress",
+			wantID:     "id-progress",
+			wantOK:     true,
+		},
+		{
+			name:       "first candidate wins when present",
+			candidates: []string{"In Review", "Review"},
+			wantName:   "Review",
+			wantID:     "id-review",
+			wantOK:     true,
+		},
+		{
+			name:       "second candidate fills gap",
+			candidates: ProjectStatusCandidates(ProjectStatusBlocked),
+			wantName:   "On Hold",
+			wantID:     "id-hold",
+			wantOK:     true,
+		},
+		{
+			name:       "none match",
+			candidates: []string{"Backlog", "Triage"},
+			wantOK:     false,
+		},
+		{
+			name:       "empty candidate ignored",
+			candidates: []string{"", "Todo"},
+			wantName:   "Todo",
+			wantID:     "id-todo",
+			wantOK:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name, id, ok := resolveProjectStatusOption(pf, tc.candidates)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if name != tc.wantName {
+				t.Errorf("name = %q, want %q", name, tc.wantName)
+			}
+			if id != tc.wantID {
+				t.Errorf("id = %q, want %q", id, tc.wantID)
+			}
+		})
+	}
+}
+
+func TestSyncIssueStatusOneOf_NilProjectField(t *testing.T) {
+	c := New("owner/repo")
+	c.SyncIssueStatusOneOf(nil, 1, "In Review", "Review", "In Progress")
+}
+
+func TestNormalizeProjectStatusKey(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"In Progress", "in progress"},
+		{"in_progress", "in progress"},
+		{"  In   Review  ", "in review"},
+		{"on-hold", "on hold"},
+	}
+	for _, tc := range tests {
+		if got := normalizeProjectStatusKey(tc.in); got != tc.want {
+			t.Errorf("normalizeProjectStatusKey(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -152,7 +152,7 @@ func TestResolveProjectStatusOption(t *testing.T) {
 			wantOK:     true,
 		},
 		{
-			name:       "first candidate wins when present",
+			name:       "falls through to next candidate when first is absent",
 			candidates: []string{"In Review", "Review"},
 			wantName:   "Review",
 			wantID:     "id-review",

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -416,19 +416,6 @@ func projectStatusForSession(sess *state.Session) (github.ProjectStatus, bool) {
 	}
 }
 
-// syncProjectForSession mirrors session runtime state to the Project board.
-// Best-effort; logs and continues so worker scheduling is never blocked.
-func (o *Orchestrator) syncProjectForSession(sess *state.Session) {
-	if sess == nil || sess.IssueNumber <= 0 {
-		return
-	}
-	status, ok := projectStatusForSession(sess)
-	if !ok {
-		return
-	}
-	o.syncProject(sess.IssueNumber, status)
-}
-
 // reconcileProjectBoard reconciles the GitHub Project board against Maestro
 // state so the board never contradicts the runtime:
 //   - every active session (running/queued/pr_open/code_landed/blocked) has its

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -368,21 +368,80 @@ func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus)
 		return
 	}
 	o.ensureProjectField()
-	// Map old ProjectStatus constants to real column names
-	statusName := map[github.ProjectStatus]string{
-		github.ProjectStatusTodo:       "Todo",
-		github.ProjectStatusInProgress: "In Progress",
-		github.ProjectStatusDone:       "Done",
-	}[status]
-	if statusName == "" {
-		statusName = string(status)
+	candidates := github.ProjectStatusCandidates(status)
+	if len(candidates) == 0 {
+		candidates = []string{string(status)}
 	}
-	o.gh.SyncIssueStatus(o.projectField, issueNumber, statusName)
+	o.gh.SyncIssueStatusOneOf(o.projectField, issueNumber, candidates...)
 }
 
-// reconcileProjectBoard moves closed issues to Done on the project board.
-// This catches issues closed externally (manual merge, GitHub auto-close, manual close).
-func (o *Orchestrator) reconcileProjectBoard() {
+// projectStatusForSession returns the ProjectStatus that should mirror this
+// session on the GitHub Project board, plus whether a sync should happen.
+// Sessions that have no clear board-level status (transient/unknown) return
+// false so the existing board state is left alone.
+//
+// Mapping:
+//   - running               => In Progress
+//   - queued / pr_open      => In Review
+//   - code_landed           => In Progress (issue remains open until runtime
+//     verification closes it; only then does it move to Done)
+//   - done                  => Done
+//   - retry_exhausted /
+//     conflict_failed /
+//     failed                => Blocked
+//   - dead with no retry    => Blocked
+//   - dead awaiting retry   => In Progress (work is still active)
+func projectStatusForSession(sess *state.Session) (github.ProjectStatus, bool) {
+	if sess == nil {
+		return "", false
+	}
+	switch sess.Status {
+	case state.StatusRunning:
+		return github.ProjectStatusInProgress, true
+	case state.StatusQueued, state.StatusPROpen:
+		return github.ProjectStatusInReview, true
+	case state.StatusCodeLanded:
+		return github.ProjectStatusInProgress, true
+	case state.StatusDone:
+		return github.ProjectStatusDone, true
+	case state.StatusRetryExhausted, state.StatusConflictFailed, state.StatusFailed:
+		return github.ProjectStatusBlocked, true
+	case state.StatusDead:
+		if sess.NextRetryAt != nil {
+			return github.ProjectStatusInProgress, true
+		}
+		return github.ProjectStatusBlocked, true
+	default:
+		return "", false
+	}
+}
+
+// syncProjectForSession mirrors session runtime state to the Project board.
+// Best-effort; logs and continues so worker scheduling is never blocked.
+func (o *Orchestrator) syncProjectForSession(sess *state.Session) {
+	if sess == nil || sess.IssueNumber <= 0 {
+		return
+	}
+	status, ok := projectStatusForSession(sess)
+	if !ok {
+		return
+	}
+	o.syncProject(sess.IssueNumber, status)
+}
+
+// reconcileProjectBoard reconciles the GitHub Project board against Maestro
+// state so the board never contradicts the runtime:
+//   - every active session (running/queued/pr_open/code_landed/blocked) has its
+//     status mirrored on the board so a live worker is always visible as
+//     active work (no manual "panoptikon-project-sync" timer needed);
+//   - items whose underlying issue is closed move to Done;
+//   - items with no Status fall back to Todo so they show up in the backlog.
+//
+// "Done" is only set on the board when the underlying GitHub issue is closed —
+// merging a PR alone keeps the item in In Progress until runtime/deploy
+// verification closes the issue (see markCodeLanded). This preserves the
+// merge-then-verify policy required by ops.
+func (o *Orchestrator) reconcileProjectBoard(s *state.State) {
 	if !o.cfg.GitHubProjects.Enabled || o.cfg.GitHubProjects.ProjectNumber == 0 {
 		return
 	}
@@ -390,6 +449,8 @@ func (o *Orchestrator) reconcileProjectBoard() {
 	if o.projectField == nil {
 		return
 	}
+
+	o.reconcileSessionsToProjectBoard(s)
 
 	items, err := o.gh.ListNonDoneProjectItems(o.projectField)
 	if err != nil {
@@ -400,12 +461,67 @@ func (o *Orchestrator) reconcileProjectBoard() {
 	for _, item := range items {
 		if item.IssueClosed {
 			log.Printf("[orch] reconcile: issue #%d is closed, moving to Done", item.IssueNumber)
-			o.gh.SyncIssueStatus(o.projectField, item.IssueNumber, "Done")
+			o.syncProject(item.IssueNumber, github.ProjectStatusDone)
 		} else if !item.HasStatus {
 			log.Printf("[orch] reconcile: issue #%d has no status, setting to Todo", item.IssueNumber)
-			o.gh.SyncIssueStatus(o.projectField, item.IssueNumber, "Todo")
+			o.syncProject(item.IssueNumber, github.ProjectStatusTodo)
 		}
 	}
+}
+
+// reconcileSessionsToProjectBoard pushes each Maestro session's status onto the
+// project board so the board mirrors the runtime even when an earlier sync was
+// missed (project discovery failed, network blip, board reset, …).
+func (o *Orchestrator) reconcileSessionsToProjectBoard(s *state.State) {
+	if s == nil {
+		return
+	}
+	// Pick the freshest session per issue so a running worker always wins over
+	// an older terminal record for the same issue.
+	freshest := make(map[int]*state.Session, len(s.Sessions))
+	for _, sess := range s.Sessions {
+		if sess == nil || sess.IssueNumber <= 0 {
+			continue
+		}
+		current, ok := freshest[sess.IssueNumber]
+		if !ok {
+			freshest[sess.IssueNumber] = sess
+			continue
+		}
+		if sessionRecency(sess).After(sessionRecency(current)) {
+			freshest[sess.IssueNumber] = sess
+		}
+	}
+	for issue, sess := range freshest {
+		status, ok := projectStatusForSession(sess)
+		if !ok {
+			continue
+		}
+		// Done is only set elsewhere (closed issue or merge-then-close
+		// reconciliation), so skip Done here even if the session is marked
+		// done — the closed-issue pass below will confirm it.
+		if status == github.ProjectStatusDone {
+			continue
+		}
+		o.syncProject(issue, status)
+	}
+}
+
+func sessionRecency(sess *state.Session) time.Time {
+	if sess == nil {
+		return time.Time{}
+	}
+	candidates := []time.Time{sess.LastOutputChangedAt, sess.StartedAt}
+	if sess.FinishedAt != nil {
+		candidates = append(candidates, *sess.FinishedAt)
+	}
+	var latest time.Time
+	for _, t := range candidates {
+		if t.After(latest) {
+			latest = t
+		}
+	}
+	return latest
 }
 
 func readLastLines(path string, limit int) (string, error) {
@@ -789,8 +905,10 @@ func (o *Orchestrator) RunOnce() error {
 		}
 	}
 
-	// Step 6: Reconcile project board — move externally-closed issues to Done
-	o.reconcileProjectBoard()
+	// Step 6: Reconcile project board — mirror Maestro session state onto the
+	// board (active workers visible as In Progress, open PRs as In Review,
+	// blocked sessions as Blocked) and move externally-closed issues to Done.
+	o.reconcileProjectBoard(s)
 
 	// Flush digest buffer (no-op if digest mode is off or buffer is empty)
 	if err := o.notifier.Flush(); err != nil {
@@ -1282,7 +1400,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					// Retry limit reached — mark as permanently failed
 					log.Printf("[orch] worker %s (pid=%d) permanently failed after %d retries", slotName, sess.PID, sess.RetryCount)
 					// auto-label blocked disabled
-					o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+					o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
 					sess.Status = state.StatusFailed
 					now := time.Now().UTC()
 					sess.FinishedAt = &now
@@ -1491,7 +1609,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					log.Printf("[orch] warn: could not stop timed-out worker %s: %v", slotName, err)
 				}
 				// auto-label blocked disabled
-				o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+				o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
 				sess.Status = state.StatusFailed
 				now := time.Now().UTC()
 				sess.FinishedAt = &now
@@ -1697,7 +1815,7 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 			pr.Number, totalAttempts, maxRetries, sess.IssueNumber)
 		alreadyNotified := sess.LastNotifiedStatus == "review_retry_exhausted"
 		s.MarkIssueRetryExhausted(sess.IssueNumber)
-		o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+		o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
 		sess.Status = state.StatusRetryExhausted
 		sess.NextRetryAt = nil
 		sess.LastNotifiedStatus = "review_retry_exhausted"
@@ -1755,7 +1873,7 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 		alreadyNotified := sess.LastNotifiedStatus == "ci_retry_exhausted"
 		// auto-label blocked disabled
 		s.MarkIssueRetryExhausted(sess.IssueNumber)
-		o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+		o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
 		sess.Status = state.StatusRetryExhausted
 		sess.NextRetryAt = nil
 		sess.LastNotifiedStatus = "ci_retry_exhausted"
@@ -2027,7 +2145,7 @@ func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string
 		log.Printf("[orch] rebase conflict on PR #%d — retry limit reached (%d/%d) for issue #%d",
 			prNumber, totalAttempts, maxRetries, sess.IssueNumber)
 		s.MarkIssueRetryExhausted(sess.IssueNumber)
-		o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+		o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
 		sess.Status = state.StatusRetryExhausted
 		sess.NextRetryAt = nil
 		sess.LastNotifiedStatus = "rebase_conflict_retry_exhausted"

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5102,6 +5102,61 @@ func TestSyncProject_DisabledWhenNoProjectNumber(t *testing.T) {
 	o.syncProject(42, github.ProjectStatusInProgress)
 }
 
+func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
+	soon := time.Now().UTC().Add(30 * time.Second)
+
+	tests := []struct {
+		name   string
+		sess   *state.Session
+		want   github.ProjectStatus
+		wantOK bool
+	}{
+		{"nil session is no-op", nil, "", false},
+		{"running -> in_progress", &state.Session{IssueNumber: 1, Status: state.StatusRunning}, github.ProjectStatusInProgress, true},
+		{"queued -> in_review", &state.Session{IssueNumber: 2, Status: state.StatusQueued}, github.ProjectStatusInReview, true},
+		{"pr_open -> in_review", &state.Session{IssueNumber: 3, Status: state.StatusPROpen, PRNumber: 9}, github.ProjectStatusInReview, true},
+		{"code_landed keeps in_progress (issue stays open)", &state.Session{IssueNumber: 4, Status: state.StatusCodeLanded, PRNumber: 10}, github.ProjectStatusInProgress, true},
+		{"done -> done", &state.Session{IssueNumber: 5, Status: state.StatusDone}, github.ProjectStatusDone, true},
+		{"retry_exhausted -> blocked", &state.Session{IssueNumber: 6, Status: state.StatusRetryExhausted}, github.ProjectStatusBlocked, true},
+		{"conflict_failed -> blocked", &state.Session{IssueNumber: 7, Status: state.StatusConflictFailed}, github.ProjectStatusBlocked, true},
+		{"failed -> blocked", &state.Session{IssueNumber: 8, Status: state.StatusFailed}, github.ProjectStatusBlocked, true},
+		{"dead awaiting retry stays in_progress", &state.Session{IssueNumber: 9, Status: state.StatusDead, NextRetryAt: &soon}, github.ProjectStatusInProgress, true},
+		{"dead without retry -> blocked", &state.Session{IssueNumber: 10, Status: state.StatusDead}, github.ProjectStatusBlocked, true},
+		{"unknown status returns no mapping", &state.Session{IssueNumber: 11, Status: state.SessionStatus("weird")}, "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := projectStatusForSession(tc.sess)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("status = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSessionRecency_PicksFreshestSignal(t *testing.T) {
+	now := time.Now().UTC()
+	finished := now.Add(-time.Minute)
+	older := now.Add(-time.Hour)
+
+	sess := &state.Session{
+		StartedAt:           older,
+		LastOutputChangedAt: now,
+		FinishedAt:          &finished,
+	}
+
+	if got := sessionRecency(sess); !got.Equal(now) {
+		t.Fatalf("sessionRecency = %v, want freshest signal %v", got, now)
+	}
+	if got := sessionRecency(nil); !got.IsZero() {
+		t.Fatalf("sessionRecency(nil) = %v, want zero", got)
+	}
+}
+
 // --- CI failure retry tests (#226) ---
 
 // newCIFailureRetryOrchestrator creates an Orchestrator wired with test fakes


### PR DESCRIPTION
Refs #404

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires two new project-board statuses (`InReview`, `Blocked`) into the Maestro runtime and makes column-name resolution flexible by introducing `ProjectStatusCandidates` + `resolveProjectStatusOption` (case-insensitive, fallthrough matching). The five call sites that previously mapped retry-exhausted/timeout/conflict failures to `Todo` are corrected to `Blocked`, and a new `reconcileSessionsToProjectBoard` pass mirrors every live session's state onto the board on each `RunOnce` cycle.

- `projectStatusForSession` and `sessionRecency` drive the per-session board sync; the mapping covers all Maestro session states and is backed by a comprehensive test matrix.
- `ListNonDoneProjectItems` (unchanged in this PR) still resolves the \"Done\" filter option with the literal key `pf.Options[\"Done\"]`, so boards using \"Completed\" or \"Closed\" as their terminal column return every item — including those already at Done — to the new `reconcileSessionsToProjectBoard` loop, producing a redundant sync call per item per cycle.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the new status-mapping and board-sync logic; one unresolved pre-existing issue in ListNonDoneProjectItems causes unnecessary redundant API writes on boards using Completed or Closed as their terminal column.

The new reconcileSessionsToProjectBoard loop is correct and well-tested. However, ListNonDoneProjectItems still hardcodes Done as the filter key, so on boards with a differently-named terminal column every already-Done item leaks into the returned list and receives a redundant sync call on every RunOnce cycle. This defect predates the PR but is now exercised on a much hotter code path.

internal/github/github_projects.go — the ListNonDoneProjectItems function's hardcoded Done option lookup at line 154.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/github/github_projects.go | Adds ProjectStatusInReview/Blocked constants, ProjectStatusCandidates, resolveProjectStatusOption (case-insensitive multi-name lookup), and SyncIssueStatusOneOf; ListNonDoneProjectItems still hardcodes "Done" as the filter key. |
| internal/github/github_projects_test.go | Adds thorough unit tests for ProjectStatusCandidates, resolveProjectStatusOption, SyncIssueStatusOneOf nil guard, and normalizeProjectStatusKey. |
| internal/orchestrator/orchestrator.go | Introduces projectStatusForSession, reconcileSessionsToProjectBoard, and sessionRecency; corrects five Blocked-state call sites that previously fell back to Todo. |
| internal/orchestrator/orchestrator_test.go | Adds TestProjectStatusForSession_MirrorsRuntime and TestSessionRecency_PicksFreshestSignal; coverage is comprehensive. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/github/github_projects.go`, line 154 ([link](https://github.com/befeast/maestro/blob/95cbbcb5ec5dd67abd573271d4e80ff164ebde15/internal/github/github_projects.go#L154)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **`ListNonDoneProjectItems` still hardcodes `"Done"` as the filter key**

   `resolveProjectStatusOption` and `ProjectStatusCandidates` now let boards use "Completed" or "Closed" as their terminal column, but `ListNonDoneProjectItems` still resolves the done option ID with the literal key `pf.Options["Done"]`. On a board using "Completed", `doneOptionID` is an empty string, the guard `doneOptionID != ""` evaluates to false, and every board item — including those already in the "Completed" column — is returned. `reconcileProjectBoard` will then re-call `syncProject(Done)` on every item whose issue is closed, generating one redundant API round-trip per item every `RunOnce` cycle.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/github/github_projects.go
   Line: 154

   Comment:
   **`ListNonDoneProjectItems` still hardcodes `"Done"` as the filter key**

   `resolveProjectStatusOption` and `ProjectStatusCandidates` now let boards use "Completed" or "Closed" as their terminal column, but `ListNonDoneProjectItems` still resolves the done option ID with the literal key `pf.Options["Done"]`. On a board using "Completed", `doneOptionID` is an empty string, the guard `doneOptionID != ""` evaluates to false, and every board item — including those already in the "Completed" column — is returned. `reconcileProjectBoard` will then re-call `syncProject(Done)` on every item whose issue is closed, generating one redundant API round-trip per item every `RunOnce` cycle.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/github/github_projects.go`, line 154 ([link](https://github.com/befeast/maestro/blob/4228bbd7b0603afb6736c638507bd69d3780db31/internal/github/github_projects.go#L154)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> `ListNonDoneProjectItems` still resolves the done-column option ID with the literal key `pf.Options["Done"]`. On a board whose terminal column is "Completed" or "Closed" (both now listed as valid Done candidates in `ProjectStatusCandidates`), this returns an empty string, the guard on line 224 (`doneOptionID != ""`) is always false, and every item — including those already in the terminal column — leaks into the returned list. `reconcileSessionsToProjectBoard` (new in this PR) then issues a redundant sync call per already-terminal item on every `RunOnce` cycle.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/github/github_projects.go
   Line: 154

   Comment:
   `ListNonDoneProjectItems` still resolves the done-column option ID with the literal key `pf.Options["Done"]`. On a board whose terminal column is "Completed" or "Closed" (both now listed as valid Done candidates in `ProjectStatusCandidates`), this returns an empty string, the guard on line 224 (`doneOptionID != ""`) is always false, and every item — including those already in the terminal column — leaks into the returned list. `reconcileSessionsToProjectBoard` (new in this PR) then issues a redundant sync call per already-terminal item on every `RunOnce` cycle.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/github/github_projects.go:38-39
Redundant case-variants in `ProjectStatusInReview` candidates: `"In review"` and `"In progress"` normalize to the same key as their properly-capitalised predecessors (`"In Review"` and `"In Progress"`) inside `resolveProjectStatusOption`, so they can never be reached as a distinct match. The list is misleading and slightly increases allocation size on every call.

```suggestion
	case ProjectStatusInReview:
		return []string{"In Review", "Review", "Reviewing", "Code Review", "In Progress"}
```

### Issue 2 of 2
internal/github/github_projects.go:154
`ListNonDoneProjectItems` still resolves the done-column option ID with the literal key `pf.Options["Done"]`. On a board whose terminal column is "Completed" or "Closed" (both now listed as valid Done candidates in `ProjectStatusCandidates`), this returns an empty string, the guard on line 224 (`doneOptionID != ""`) is always false, and every item — including those already in the terminal column — leaks into the returned list. `reconcileSessionsToProjectBoard` (new in this PR) then issues a redundant sync call per already-terminal item on every `RunOnce` cycle.

```suggestion
	_, doneOptionID, _ := resolveProjectStatusOption(pf, ProjectStatusCandidates(ProjectStatusDone))
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address PR #405 review feedback"](https://github.com/befeast/maestro/commit/4228bbd7b0603afb6736c638507bd69d3780db31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32500238)</sub>

<!-- /greptile_comment -->