### PR TITLE
[codex] Add outcome-controlled supervisor gates

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -511,6 +511,7 @@ func parse(data []byte) (*Config, error) {
 			"review_retry_exhausted",
 			"check_outcome_health",
 			"spawn_worker",
+			"spawn_repair_worker",
 			"label_issue_ready",
 			"add_ready_label",
 		}
@@ -519,6 +520,7 @@ func parse(data []byte) (*Config, error) {
 		cfg.Supervisor.ApprovalRequiredActions = []string{
 			"review_retry_exhausted",
 			"spawn_worker",
+			"spawn_repair_worker",
 			"label_issue_ready",
 			"add_ready_label",
 		}

--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -22,6 +22,8 @@ const (
 	ProjectStatusInProgress ProjectStatus = "in_progress"
 	ProjectStatusInReview   ProjectStatus = "in_review"
 	ProjectStatusBlocked    ProjectStatus = "blocked"
+	ProjectStatusDeploying  ProjectStatus = "deploying"
+	ProjectStatusLiveVerify ProjectStatus = "live_verification"
 	ProjectStatusDone       ProjectStatus = "done"
 )
 
@@ -39,6 +41,10 @@ func ProjectStatusCandidates(status ProjectStatus) []string {
 		return []string{"In Review", "In review", "Review", "Reviewing", "Code Review", "In Progress", "In progress"}
 	case ProjectStatusBlocked:
 		return []string{"Blocked", "On Hold", "On hold", "Stuck", "Needs Attention", "Needs attention"}
+	case ProjectStatusDeploying:
+		return []string{"Deploying", "Deploy", "Deployment", "In Progress", "In progress"}
+	case ProjectStatusLiveVerify:
+		return []string{"Live Verification", "Live verification", "Verification", "Verifying", "QA", "In Progress", "In progress"}
 	case ProjectStatusDone:
 		return []string{"Done", "Completed", "Closed"}
 	default:

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -383,15 +383,15 @@ func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus)
 // Mapping:
 //   - running               => In Progress
 //   - queued / pr_open      => In Review
-//   - code_landed           => In Progress (issue remains open until runtime
-//     verification closes it; only then does it move to Done)
+//   - code_landed           => Deploying or Live Verification (depending on
+//     whether the outcome contract requires deploy)
 //   - done                  => Done
 //   - retry_exhausted /
 //     conflict_failed /
 //     failed                => Blocked
 //   - dead with no retry    => Blocked
 //   - dead awaiting retry   => In Progress (work is still active)
-func projectStatusForSession(sess *state.Session) (github.ProjectStatus, bool) {
+func projectStatusForSession(sess *state.Session, requiresDeploy bool) (github.ProjectStatus, bool) {
 	if sess == nil {
 		return "", false
 	}
@@ -401,7 +401,7 @@ func projectStatusForSession(sess *state.Session) (github.ProjectStatus, bool) {
 	case state.StatusQueued, state.StatusPROpen:
 		return github.ProjectStatusInReview, true
 	case state.StatusCodeLanded:
-		return github.ProjectStatusInProgress, true
+		return codeLandedProjectStatus(requiresDeploy), true
 	case state.StatusDone:
 		return github.ProjectStatusDone, true
 	case state.StatusRetryExhausted, state.StatusConflictFailed, state.StatusFailed:
@@ -480,7 +480,7 @@ func (o *Orchestrator) reconcileSessionsToProjectBoard(s *state.State) {
 		}
 	}
 	for issue, sess := range freshest {
-		status, ok := projectStatusForSession(sess)
+		status, ok := projectStatusForSession(sess, o.cfg.Outcome.RequiresDeploy)
 		if !ok {
 			continue
 		}
@@ -492,6 +492,13 @@ func (o *Orchestrator) reconcileSessionsToProjectBoard(s *state.State) {
 		}
 		o.syncProject(issue, status)
 	}
+}
+
+func codeLandedProjectStatus(requiresDeploy bool) github.ProjectStatus {
+	if requiresDeploy {
+		return github.ProjectStatusDeploying
+	}
+	return github.ProjectStatusLiveVerify
 }
 
 func sessionRecency(sess *state.Session) time.Time {
@@ -1953,7 +1960,7 @@ func (o *Orchestrator) markCodeLanded(sess *state.Session, prNumber int) {
 	if prNumber > 0 {
 		sess.PRNumber = prNumber
 	}
-	o.syncProject(sess.IssueNumber, github.ProjectStatusInProgress)
+	o.syncProject(sess.IssueNumber, codeLandedProjectStatus(o.cfg.Outcome.RequiresDeploy))
 	sess.Status = state.StatusCodeLanded
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
@@ -2413,6 +2420,23 @@ func (o *Orchestrator) supervisorOwnsDynamicReadyLabel() bool {
 	return o.cfg != nil && o.cfg.Supervisor.DynamicWave.Active() && o.cfg.Supervisor.DynamicWave.OwnsReadyLabel
 }
 
+func (o *Orchestrator) supervisorSelectedRepairSpawn(s *state.State, issueNumber int) bool {
+	if s == nil || issueNumber <= 0 {
+		return false
+	}
+	decision := s.LatestSupervisorDecision()
+	if decision == nil || decision.RecommendedAction != supervisor.ActionSpawnRepairWorker {
+		return false
+	}
+	if decision.RequiresApproval || decision.Risk == supervisor.RiskApprovalGated {
+		return false
+	}
+	if decision.Target == nil || decision.Target.Issue != issueNumber {
+		return false
+	}
+	return true
+}
+
 func (o *Orchestrator) supervisorOwnedReadySelectedIssue(s *state.State) (int, bool) {
 	if !o.supervisorOwnsDynamicReadyLabel() || s == nil {
 		return 0, false
@@ -2475,6 +2499,13 @@ func (o *Orchestrator) augmentWithSupervisorSelectedIssue(s *state.State, issues
 	if !ok || selected <= 0 || containsIssueNumber(issues, selected) {
 		return issues
 	}
+	return o.appendFetchedSupervisorIssue(issues, selected)
+}
+
+func (o *Orchestrator) appendFetchedSupervisorIssue(issues []github.Issue, selected int) []github.Issue {
+	if selected <= 0 || containsIssueNumber(issues, selected) {
+		return issues
+	}
 
 	issue, err := o.getIssue(selected)
 	if err != nil {
@@ -2500,6 +2531,11 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 	if err != nil {
 		log.Printf("[orch] list issues: %v", err)
 		return
+	}
+	if decision := s.LatestSupervisorDecision(); decision != nil && decision.RecommendedAction == supervisor.ActionSpawnRepairWorker && decision.Target != nil {
+		if !decision.RequiresApproval && decision.Risk != supervisor.RiskApprovalGated {
+			issues = o.appendFetchedSupervisorIssue(issues, decision.Target.Issue)
+		}
 	}
 	issues = o.augmentWithSupervisorSelectedIssue(s, issues)
 	if filtered, ordered := o.applyOrderedQueueFilter(s, issues); ordered {
@@ -2543,16 +2579,20 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if o.cfg.MaxRetriesPerIssue > 0 {
 			failed := s.FailedAttemptsForIssue(issue.Number)
 			if failed >= o.cfg.MaxRetriesPerIssue {
-				if !s.IssueRetryExhausted(issue.Number) {
-					// First time hitting the limit — mark, label, and notify
-					s.MarkIssueRetryExhausted(issue.Number)
-					// auto-label blocked disabled
-					o.notifier.Sendf("⚠️ Issue #%d hit max retries (%d) — needs manual review",
-						issue.Number, o.cfg.MaxRetriesPerIssue)
+				if o.supervisorSelectedRepairSpawn(s, issue.Number) {
+					log.Printf("[orch] allowing repair worker for issue #%d despite retry limit because supervisor selected spawn_repair_worker", issue.Number)
+				} else {
+					if !s.IssueRetryExhausted(issue.Number) {
+						// First time hitting the limit — mark, label, and notify
+						s.MarkIssueRetryExhausted(issue.Number)
+						// auto-label blocked disabled
+						o.notifier.Sendf("⚠️ Issue #%d hit max retries (%d) — needs manual review",
+							issue.Number, o.cfg.MaxRetriesPerIssue)
+					}
+					log.Printf("[orch] skipping issue #%d: retry limit exhausted (%d/%d attempts)",
+						issue.Number, failed, o.cfg.MaxRetriesPerIssue)
+					continue
 				}
-				log.Printf("[orch] skipping issue #%d: retry limit exhausted (%d/%d attempts)",
-					issue.Number, failed, o.cfg.MaxRetriesPerIssue)
-				continue
 			}
 		}
 
@@ -2582,8 +2622,11 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if hasOpenPR, err := o.hasOpenPRForIssue(issue.Number); err != nil {
 			log.Printf("[orch] warn: could not check open PRs for issue #%d: %v", issue.Number, err)
 		} else if hasOpenPR {
-			log.Printf("[orch] skipping issue #%d: open PR already exists", issue.Number)
-			continue
+			if !o.supervisorSelectedRepairSpawn(s, issue.Number) {
+				log.Printf("[orch] skipping issue #%d: open PR already exists", issue.Number)
+				continue
+			}
+			log.Printf("[orch] allowing repair worker for issue #%d despite open PR because supervisor selected spawn_repair_worker", issue.Number)
 		}
 
 		// Determine initial phase and backend

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5106,28 +5106,30 @@ func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
 	soon := time.Now().UTC().Add(30 * time.Second)
 
 	tests := []struct {
-		name   string
-		sess   *state.Session
-		want   github.ProjectStatus
-		wantOK bool
+		name           string
+		sess           *state.Session
+		requiresDeploy bool
+		want           github.ProjectStatus
+		wantOK         bool
 	}{
-		{"nil session is no-op", nil, "", false},
-		{"running -> in_progress", &state.Session{IssueNumber: 1, Status: state.StatusRunning}, github.ProjectStatusInProgress, true},
-		{"queued -> in_review", &state.Session{IssueNumber: 2, Status: state.StatusQueued}, github.ProjectStatusInReview, true},
-		{"pr_open -> in_review", &state.Session{IssueNumber: 3, Status: state.StatusPROpen, PRNumber: 9}, github.ProjectStatusInReview, true},
-		{"code_landed keeps in_progress (issue stays open)", &state.Session{IssueNumber: 4, Status: state.StatusCodeLanded, PRNumber: 10}, github.ProjectStatusInProgress, true},
-		{"done -> done", &state.Session{IssueNumber: 5, Status: state.StatusDone}, github.ProjectStatusDone, true},
-		{"retry_exhausted -> blocked", &state.Session{IssueNumber: 6, Status: state.StatusRetryExhausted}, github.ProjectStatusBlocked, true},
-		{"conflict_failed -> blocked", &state.Session{IssueNumber: 7, Status: state.StatusConflictFailed}, github.ProjectStatusBlocked, true},
-		{"failed -> blocked", &state.Session{IssueNumber: 8, Status: state.StatusFailed}, github.ProjectStatusBlocked, true},
-		{"dead awaiting retry stays in_progress", &state.Session{IssueNumber: 9, Status: state.StatusDead, NextRetryAt: &soon}, github.ProjectStatusInProgress, true},
-		{"dead without retry -> blocked", &state.Session{IssueNumber: 10, Status: state.StatusDead}, github.ProjectStatusBlocked, true},
-		{"unknown status returns no mapping", &state.Session{IssueNumber: 11, Status: state.SessionStatus("weird")}, "", false},
+		{name: "nil session is no-op", want: "", wantOK: false},
+		{name: "running -> in_progress", sess: &state.Session{IssueNumber: 1, Status: state.StatusRunning}, want: github.ProjectStatusInProgress, wantOK: true},
+		{name: "queued -> in_review", sess: &state.Session{IssueNumber: 2, Status: state.StatusQueued}, want: github.ProjectStatusInReview, wantOK: true},
+		{name: "pr_open -> in_review", sess: &state.Session{IssueNumber: 3, Status: state.StatusPROpen, PRNumber: 9}, want: github.ProjectStatusInReview, wantOK: true},
+		{name: "code_landed -> live_verification without deploy", sess: &state.Session{IssueNumber: 4, Status: state.StatusCodeLanded, PRNumber: 10}, want: github.ProjectStatusLiveVerify, wantOK: true},
+		{name: "code_landed -> deploying when deploy required", sess: &state.Session{IssueNumber: 4, Status: state.StatusCodeLanded, PRNumber: 10}, requiresDeploy: true, want: github.ProjectStatusDeploying, wantOK: true},
+		{name: "done -> done", sess: &state.Session{IssueNumber: 5, Status: state.StatusDone}, want: github.ProjectStatusDone, wantOK: true},
+		{name: "retry_exhausted -> blocked", sess: &state.Session{IssueNumber: 6, Status: state.StatusRetryExhausted}, want: github.ProjectStatusBlocked, wantOK: true},
+		{name: "conflict_failed -> blocked", sess: &state.Session{IssueNumber: 7, Status: state.StatusConflictFailed}, want: github.ProjectStatusBlocked, wantOK: true},
+		{name: "failed -> blocked", sess: &state.Session{IssueNumber: 8, Status: state.StatusFailed}, want: github.ProjectStatusBlocked, wantOK: true},
+		{name: "dead awaiting retry stays in_progress", sess: &state.Session{IssueNumber: 9, Status: state.StatusDead, NextRetryAt: &soon}, want: github.ProjectStatusInProgress, wantOK: true},
+		{name: "dead without retry -> blocked", sess: &state.Session{IssueNumber: 10, Status: state.StatusDead}, want: github.ProjectStatusBlocked, wantOK: true},
+		{name: "unknown status returns no mapping", sess: &state.Session{IssueNumber: 11, Status: state.SessionStatus("weird")}, want: "", wantOK: false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := projectStatusForSession(tc.sess)
+			got, ok := projectStatusForSession(tc.sess, tc.requiresDeploy)
 			if ok != tc.wantOK {
 				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
 			}

--- a/internal/outcome/outcome.go
+++ b/internal/outcome/outcome.go
@@ -18,12 +18,18 @@ const (
 type Brief struct {
 	DesiredOutcome          string   `yaml:"desired_outcome" json:"desired_outcome,omitempty"`
 	RuntimeTarget           string   `yaml:"runtime_target" json:"runtime_target,omitempty"`
+	RuntimeURL              string   `yaml:"runtime_url" json:"runtime_url,omitempty"`
 	DeploymentStatusCommand string   `yaml:"deployment_status_command" json:"deployment_status_command,omitempty"`
 	DeployStatusCommand     string   `yaml:"deploy_status_command" json:"-"`
 	HealthcheckCommand      string   `yaml:"healthcheck_command" json:"healthcheck_command,omitempty"`
+	VerifierCommand         string   `yaml:"verifier_command" json:"verifier_command,omitempty"`
 	HealthcheckURL          string   `yaml:"healthcheck_url" json:"healthcheck_url,omitempty"`
 	SourceRepoPath          string   `yaml:"source_repo_path" json:"source_repo_path,omitempty"`
 	RuntimeHost             string   `yaml:"runtime_host" json:"runtime_host,omitempty"`
+	RequiredRoutes          []string `yaml:"required_routes" json:"required_routes,omitempty"`
+	RequiresDeploy          bool     `yaml:"requires_deploy" json:"requires_deploy,omitempty"`
+	PassRequiredForDone     *bool    `yaml:"pass_required_for_done" json:"-"`
+	FailRequiresVisibleWork *bool    `yaml:"fail_requires_visible_work" json:"-"`
 	NonGoals                []string `yaml:"non_goals" json:"non_goals,omitempty"`
 }
 
@@ -33,6 +39,7 @@ type Status struct {
 	Goal                    string   `json:"goal,omitempty"`
 	DesiredOutcome          string   `json:"desired_outcome,omitempty"`
 	RuntimeTarget           string   `json:"runtime_target,omitempty"`
+	RuntimeURL              string   `json:"runtime_url,omitempty"`
 	RuntimeHost             string   `json:"runtime_host,omitempty"`
 	HealthState             string   `json:"health_state"`
 	HealthCheckedAt         string   `json:"health_checked_at,omitempty"`
@@ -44,8 +51,13 @@ type Status struct {
 	DeploymentStatusCommand string   `json:"deployment_status_command,omitempty"`
 	DeployStatusCommand     string   `json:"deploy_status_command,omitempty"`
 	HealthcheckCommand      string   `json:"healthcheck_command,omitempty"`
+	VerifierCommand         string   `json:"verifier_command,omitempty"`
 	HealthcheckURL          string   `json:"healthcheck_url,omitempty"`
+	RequiredRoutes          []string `json:"required_routes,omitempty"`
+	RequiresDeploy          bool     `json:"requires_deploy,omitempty"`
 	NonGoals                []string `json:"non_goals,omitempty"`
+	PassRequiredForDone     bool     `json:"pass_required_for_done,omitempty"`
+	FailRequiresVisibleWork bool     `json:"fail_requires_visible_work,omitempty"`
 	MergedPRs               int      `json:"merged_prs,omitempty"`
 	LastMergeAt             string   `json:"last_merge_at,omitempty"`
 }
@@ -65,15 +77,30 @@ type HealthCheckResult struct {
 func (b Brief) Normalized() Brief {
 	b.DesiredOutcome = strings.TrimSpace(b.DesiredOutcome)
 	b.RuntimeTarget = strings.TrimSpace(b.RuntimeTarget)
+	b.RuntimeURL = strings.TrimSpace(b.RuntimeURL)
+	if b.RuntimeTarget == "" {
+		b.RuntimeTarget = b.RuntimeURL
+	}
+	if b.RuntimeURL == "" {
+		b.RuntimeURL = b.RuntimeTarget
+	}
 	b.DeploymentStatusCommand = strings.TrimSpace(b.DeploymentStatusCommand)
 	b.DeployStatusCommand = strings.TrimSpace(b.DeployStatusCommand)
 	if b.DeploymentStatusCommand == "" {
 		b.DeploymentStatusCommand = b.DeployStatusCommand
 	}
 	b.HealthcheckCommand = strings.TrimSpace(b.HealthcheckCommand)
+	b.VerifierCommand = strings.TrimSpace(b.VerifierCommand)
+	if b.HealthcheckCommand == "" {
+		b.HealthcheckCommand = b.VerifierCommand
+	}
+	if b.VerifierCommand == "" {
+		b.VerifierCommand = b.HealthcheckCommand
+	}
 	b.HealthcheckURL = strings.TrimSpace(b.HealthcheckURL)
 	b.SourceRepoPath = strings.TrimSpace(b.SourceRepoPath)
 	b.RuntimeHost = strings.TrimSpace(b.RuntimeHost)
+	b.RequiredRoutes = compactStrings(b.RequiredRoutes)
 	b.NonGoals = compactStrings(b.NonGoals)
 	return b
 }
@@ -90,6 +117,22 @@ func (b Brief) Goal() string {
 func (b Brief) HasHealthSignal() bool {
 	b = b.Normalized()
 	return b.DeploymentStatusCommand != "" || b.HealthcheckCommand != "" || b.HealthcheckURL != ""
+}
+
+func (b Brief) PassRequiredForDoneEnabled() bool {
+	b = b.Normalized()
+	if b.PassRequiredForDone != nil {
+		return *b.PassRequiredForDone
+	}
+	return b.Configured()
+}
+
+func (b Brief) FailRequiresVisibleWorkEnabled() bool {
+	b = b.Normalized()
+	if b.FailRequiresVisibleWork != nil {
+		return *b.FailRequiresVisibleWork
+	}
+	return b.Configured()
 }
 
 // StatusFor returns the current known outcome status. Callers may pass the
@@ -109,13 +152,19 @@ func StatusFor(brief Brief, mergedPRs int, lastMergeAt time.Time, checks ...Heal
 		Goal:                    brief.Goal(),
 		DesiredOutcome:          brief.Goal(),
 		RuntimeTarget:           brief.RuntimeTarget,
+		RuntimeURL:              brief.RuntimeURL,
 		RuntimeHost:             brief.RuntimeHost,
 		SourceRepoPath:          brief.SourceRepoPath,
 		DeploymentStatusCommand: brief.DeploymentStatusCommand,
 		DeployStatusCommand:     brief.DeploymentStatusCommand,
 		HealthcheckCommand:      brief.HealthcheckCommand,
+		VerifierCommand:         brief.VerifierCommand,
 		HealthcheckURL:          brief.HealthcheckURL,
+		RequiredRoutes:          append([]string(nil), brief.RequiredRoutes...),
+		RequiresDeploy:          brief.RequiresDeploy,
 		NonGoals:                append([]string(nil), brief.NonGoals...),
+		PassRequiredForDone:     brief.PassRequiredForDoneEnabled(),
+		FailRequiresVisibleWork: brief.FailRequiresVisibleWorkEnabled(),
 		MergedPRs:               mergedPRs,
 	}
 	if !lastMergeAt.IsZero() {

--- a/internal/outcome/outcome_test.go
+++ b/internal/outcome/outcome_test.go
@@ -63,6 +63,42 @@ func TestStatusForConfiguredBriefUnknownHealth(t *testing.T) {
 	}
 }
 
+func TestBriefSupportsOutcomeControlledDeliveryAliases(t *testing.T) {
+	passRequired := true
+	failRequiresWork := true
+	brief := Brief{
+		DesiredOutcome:          "Accepted runtime route matches the design artifact",
+		RuntimeURL:              "https://app.example.com",
+		VerifierCommand:         "./verify-live.sh",
+		RequiredRoutes:          []string{"/", "/", " /settings "},
+		RequiresDeploy:          true,
+		PassRequiredForDone:     &passRequired,
+		FailRequiresVisibleWork: &failRequiresWork,
+	}
+
+	normalized := brief.Normalized()
+	if normalized.RuntimeTarget != "https://app.example.com" || normalized.RuntimeURL != "https://app.example.com" {
+		t.Fatalf("runtime aliases = %q/%q, want both populated", normalized.RuntimeTarget, normalized.RuntimeURL)
+	}
+	if normalized.HealthcheckCommand != "./verify-live.sh" || normalized.VerifierCommand != "./verify-live.sh" {
+		t.Fatalf("verifier aliases = %q/%q, want both populated", normalized.HealthcheckCommand, normalized.VerifierCommand)
+	}
+
+	status := StatusFor(brief, 0, time.Time{})
+	if status.RuntimeTarget != "https://app.example.com" || status.RuntimeURL != "https://app.example.com" {
+		t.Fatalf("status runtime aliases = %+v, want runtime target/url", status)
+	}
+	if status.HealthcheckCommand != "./verify-live.sh" || status.VerifierCommand != "./verify-live.sh" {
+		t.Fatalf("status verifier aliases = %+v, want command aliases", status)
+	}
+	if !status.RequiresDeploy || !status.PassRequiredForDone || !status.FailRequiresVisibleWork {
+		t.Fatalf("status policy flags = %+v, want enabled", status)
+	}
+	if len(status.RequiredRoutes) != 2 || status.RequiredRoutes[0] != "/" || status.RequiredRoutes[1] != "/settings" {
+		t.Fatalf("RequiredRoutes = %#v, want compacted routes", status.RequiredRoutes)
+	}
+}
+
 func TestStatusForUsesFreshHealthCheck(t *testing.T) {
 	lastMerge := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	status := StatusFor(Brief{

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2147,6 +2147,14 @@ func fleetOperatorStateFromSupervisor(project fleetProjectState) (fleetOperatorS
 			Summary:    firstNonEmpty(summary, "Supervisor selected an issue and should start a worker."),
 			NextAction: "A worker should start on the next supervisor cycle; escalate if this exceeds the dispatch SLA.",
 		}
+	case "spawn_repair_worker":
+		operator = fleetOperatorState{
+			Kind:       "pending_dispatch",
+			Tone:       "attention",
+			Label:      "Repair pending",
+			Summary:    firstNonEmpty(summary, "Supervisor selected repair work for a failing PR or outcome."),
+			NextAction: "Start or approve the repair worker; the existing PR/outcome is not sufficient for completion.",
+		}
 	case "wait_for_worker":
 		return fleetOperatorState{Kind: "working", Tone: "busy", Label: "Working", Summary: firstNonEmpty(summary, "Supervisor is waiting for a worker to finish.")}, true
 	default:

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -339,6 +339,7 @@ func defaultAllowedActions() []string {
 		ActionReviewRetryExhausted,
 		ActionCheckOutcomeHealth,
 		ActionSpawnWorker,
+		ActionSpawnRepairWorker,
 		ActionLabelIssueReady,
 	}
 }
@@ -347,6 +348,7 @@ func defaultApprovalRequiredActions() []string {
 	return []string{
 		ActionReviewRetryExhausted,
 		ActionSpawnWorker,
+		ActionSpawnRepairWorker,
 		ActionLabelIssueReady,
 	}
 }
@@ -369,6 +371,8 @@ func canonicalAction(action string) string {
 		return ActionCheckOutcomeHealth
 	case ActionSpawnWorker:
 		return ActionSpawnWorker
+	case ActionSpawnRepairWorker:
+		return ActionSpawnRepairWorker
 	case ActionLabelIssueReady, "add_ready_label":
 		return ActionLabelIssueReady
 	default:

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -30,6 +30,7 @@ const (
 	ActionReviewRetryExhausted = "review_retry_exhausted"
 	ActionCheckOutcomeHealth   = "check_outcome_health"
 	ActionSpawnWorker          = "spawn_worker"
+	ActionSpawnRepairWorker    = "spawn_repair_worker"
 	ActionLabelIssueReady      = "label_issue_ready"
 
 	RiskSafe          = "safe"
@@ -140,7 +141,7 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 		return state.SupervisorDecision{}, err
 	}
 	if !cfg.Supervisor.DryRun {
-		if decisionRequiresApproval(decision) {
+		if decisionRequiresApproval(cfg, decision) {
 			approval := st.RecordPendingApprovalForDecision(decision, decision.CreatedAt)
 			decision.ApprovalID = approval.ID
 		}
@@ -210,6 +211,18 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false)
 
 	if slot, sess, pr, ok := sessionWithOpenPR(st, prs); ok {
+		if e.openPRNeedsRepair(st, stuckStates, slot, sess, pr) {
+			reasons := appendReasons(baseReasons,
+				fmt.Sprintf("Session %s is associated with open PR #%d, but the PR is not progressing", slot, pr.Number),
+				"The worker is not actively repairing this PR while it is draft, failing checks, blocked by review, or the live outcome is still failing",
+				"Starting a repair worker would mutate local worktrees, so supervisor records an explicit repair recommendation",
+			)
+			decision := e.decision(st, now, projectState, ActionSpawnRepairWorker,
+				fmt.Sprintf("Start a repair worker for issue #%d; PR #%d is not enough to prove the live outcome.", sess.IssueNumber, pr.Number),
+				RiskMutating, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
+			decision.StuckStates = stuckStates
+			return decision, nil
+		}
 		summary := fmt.Sprintf("Session %s already has open PR #%d; monitor review, CI, or merge readiness.", slot, pr.Number)
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Session %s is associated with open PR #%d", slot, pr.Number),
@@ -253,9 +266,10 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		return decision, nil
 	}
 
-	if stuck := noOutcomeProgressStuckState(stuckStates); stuck != nil && len(st.ActiveSessions()) == 0 && len(prs) == 0 {
+	if stuck := noOutcomeProgressStuckState(stuckStates); stuck != nil && len(st.ActiveSessions()) == 0 {
 		reasons := appendReasons(baseReasons,
 			stuck.Summary,
+			fmt.Sprintf("Open PRs observed: %d; PR presence does not prove the live outcome is fixed", len(prs)),
 			"Supervisor remains read-only; it recommends outcome verification but does not run deploy or runtime commands",
 		)
 		decision := e.decision(st, now, projectState, ActionCheckOutcomeHealth,
@@ -616,27 +630,43 @@ func (e *Engine) detectOutcomeStuckStates(st *state.State) []state.SupervisorStu
 			"Add an outcome brief with the desired runtime goal, target, health signal, and non-goals before treating issue throughput as success.", false, nil,
 			"Outcome brief configured: false")}
 	}
-	if st == nil || st.DonePRCount() < 2 {
-		return nil
-	}
 	switch status.HealthState {
-	case outcome.HealthUnknown, outcome.HealthUnmonitored, outcome.HealthFailing:
-		goal := strings.TrimSpace(status.Goal)
-		if goal == "" {
-			goal = "the configured outcome"
+	case outcome.HealthFailing:
+		if !status.FailRequiresVisibleWork {
+			return nil
 		}
-		health := status.HealthState
-		if health == "" {
-			health = outcome.HealthUnknown
+		return []state.SupervisorStuckState{e.outcomeProgressStuckState(st, status, false)}
+	case outcome.HealthUnknown, outcome.HealthUnmonitored:
+		if st == nil || st.DonePRCount() < 2 {
+			return nil
 		}
-		return []state.SupervisorStuckState{stuckState(state.StuckNoOutcomeProgress, SeverityBlocked,
-			fmt.Sprintf("Workers have merged PRs, but runtime outcome health is still %s for %s.", health, goal),
-			"Run the configured deployment status or healthcheck, then prioritize deploy/runtime fixes before dispatching more issue work.", false, nil,
-			fmt.Sprintf("done_pr_sessions=%d", st.DonePRCount()),
-			fmt.Sprintf("health_state=%s", health))}
+		return []state.SupervisorStuckState{e.outcomeProgressStuckState(st, status, false)}
 	default:
 		return nil
 	}
+}
+
+func (e *Engine) outcomeProgressStuckState(st *state.State, status outcome.Status, canAct bool) state.SupervisorStuckState {
+	goal := strings.TrimSpace(status.Goal)
+	if goal == "" {
+		goal = "the configured outcome"
+	}
+	health := status.HealthState
+	if health == "" {
+		health = outcome.HealthUnknown
+	}
+	donePRs := 0
+	if st != nil {
+		donePRs = st.DonePRCount()
+	}
+	summary := fmt.Sprintf("Runtime outcome health is %s for %s.", health, goal)
+	if health != outcome.HealthFailing {
+		summary = fmt.Sprintf("Workers have merged PRs, but runtime outcome health is still %s for %s.", health, goal)
+	}
+	return stuckState(state.StuckNoOutcomeProgress, SeverityBlocked, summary,
+		"Run the configured deployment status or healthcheck, then prioritize deploy/runtime fixes before dispatching more issue work.", canAct, nil,
+		fmt.Sprintf("done_pr_sessions=%d", donePRs),
+		fmt.Sprintf("health_state=%s", health))
 }
 
 func noOutcomeProgressStuckState(stuckStates []state.SupervisorStuckState) *state.SupervisorStuckState {
@@ -1006,8 +1036,19 @@ func (e *Engine) detectMissingCLI() *state.SupervisorStuckState {
 	return nil
 }
 
-func decisionRequiresApproval(decision state.SupervisorDecision) bool {
-	return decision.RecommendedAction != ActionNone && decision.Risk != RiskSafe
+func decisionRequiresApproval(cfg *config.Config, decision state.SupervisorDecision) bool {
+	if decision.RecommendedAction == ActionNone || decision.Risk == RiskSafe {
+		return false
+	}
+	if cfg == nil || cfg.Supervisor.ApprovalRequiredActions == nil {
+		return true
+	}
+	for _, action := range cfg.Supervisor.ApprovalRequiredActions {
+		if canonicalAction(action) == decision.RecommendedAction {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *Engine) projectState(st *state.State) state.SupervisorProjectState {
@@ -1509,6 +1550,55 @@ func runningSession(st *state.State) (string, *state.Session, bool) {
 		}
 	}
 	return "", nil, false
+}
+
+func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.SupervisorStuckState, slot string, sess *state.Session, pr github.PR) bool {
+	if sess == nil {
+		return false
+	}
+	if e.hasLiveRunningSessionForIssue(st, sess.IssueNumber) {
+		return false
+	}
+	if availableSlots(e.cfg, st) <= 0 {
+		return false
+	}
+	if pr.IsDraft {
+		return true
+	}
+	for _, stuck := range stuckStates {
+		if stuck.Target != nil {
+			if stuck.Target.Session != "" && stuck.Target.Session != slot {
+				continue
+			}
+			if stuck.Target.PR != 0 && stuck.Target.PR != pr.Number {
+				continue
+			}
+		}
+		switch stuck.Code {
+		case "failing_checks", "greptile_not_approved", "stale_review_feedback":
+			return true
+		case "retry_exhausted_open_pr":
+			return stuck.Severity == SeverityBlocked
+		case state.StuckNoOutcomeProgress:
+			return e.outcomeStatus(st).HealthState == outcome.HealthFailing
+		}
+	}
+	return false
+}
+
+func (e *Engine) hasLiveRunningSessionForIssue(st *state.State, issueNumber int) bool {
+	if st == nil || issueNumber <= 0 {
+		return false
+	}
+	for _, sess := range st.Sessions {
+		if sess == nil || sess.IssueNumber != issueNumber || sess.Status != state.StatusRunning {
+			continue
+		}
+		if sess.PID == 0 || e.pidAlive(sess.PID) {
+			return true
+		}
+	}
+	return false
 }
 
 func retryExhaustedSession(st *state.State) (string, *state.Session, bool) {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -213,7 +213,7 @@ func TestDecide_IdleNoEligibleIssueRecommendsLabel(t *testing.T) {
 
 func TestDecide_RunningWorkerWaits(t *testing.T) {
 	cfg := testConfig(t)
-	reader := &fakeReader{}
+	reader := &fakeReader{prs: []github.PR{{Number: 55, HeadRefName: "untracked-open-pr", State: "OPEN"}}}
 	st := state.NewState()
 	st.Sessions["slot-1"] = &state.Session{
 		IssueNumber: 42,
@@ -241,7 +241,7 @@ func TestDecide_RunningWorkerWaits(t *testing.T) {
 
 func TestDecide_RetryExhaustedNeedsReview(t *testing.T) {
 	cfg := testConfig(t)
-	reader := &fakeReader{}
+	reader := &fakeReader{prs: []github.PR{{Number: 55, HeadRefName: "untracked-open-pr", State: "OPEN"}}}
 	st := state.NewState()
 	st.Sessions["slot-2"] = &state.Session{
 		IssueNumber: 77,
@@ -505,6 +505,47 @@ func TestDecide_FailingChecksExplained(t *testing.T) {
 	}
 }
 
+func TestDecide_DeadSessionWithDraftFailingPRRecommendsRepairWorker(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{
+		prs: []github.PR{{
+			Number:      31,
+			HeadRefName: "feat/checks",
+			State:       "OPEN",
+			Mergeable:   "MERGEABLE",
+			IsDraft:     true,
+		}},
+		ciStatuses: map[int]string{31: "failure"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 94,
+		IssueTitle:  "failing checks",
+		Status:      state.StatusDead,
+		PRNumber:    31,
+		Branch:      "feat/checks",
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnRepairWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnRepairWorker)
+	}
+	if decision.Risk != RiskMutating {
+		t.Fatalf("risk = %q, want %q", decision.Risk, RiskMutating)
+	}
+	if decision.Target == nil || decision.Target.Issue != 94 || decision.Target.PR != 31 || decision.Target.Session != "slot-1" {
+		t.Fatalf("target = %#v, want issue 94 PR 31 slot-1", decision.Target)
+	}
+	if !strings.Contains(strings.ToLower(decision.Summary), "repair worker") {
+		t.Fatalf("summary = %q, want repair worker", decision.Summary)
+	}
+}
+
 func TestDecide_PRExistsForSessionMonitorsPR(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{prs: []github.PR{{Number: 12, HeadRefName: "mae-1-42-fix", State: "OPEN"}}}
@@ -612,6 +653,47 @@ func TestDecide_NoOutcomeProgressRecommendsRuntimeCheck(t *testing.T) {
 	}
 	if reader.issueCalls != 0 {
 		t.Fatalf("ListOpenIssues called %d time(s), want runtime check before more issue throughput", reader.issueCalls)
+	}
+}
+
+func TestDecide_FailingOutcomeImmediatelyBlocksFalseGreen(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome: "Hosted app responds to users",
+		RuntimeTarget:  "https://app.example.com",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}
+	reader := &fakeReader{prs: []github.PR{{Number: 55, HeadRefName: "untracked-open-pr", State: "OPEN"}}}
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: now.Add(-time.Minute),
+		Signal:    "healthcheck_url",
+		State:     outcome.HealthFailing,
+		Summary:   "GET returned 500",
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionCheckOutcomeHealth {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionCheckOutcomeHealth)
+	}
+	stuck := requireStuckState(t, decision, state.StuckNoOutcomeProgress)
+	if stuck.Severity != SeverityBlocked {
+		t.Fatalf("severity = %q, want %q", stuck.Severity, SeverityBlocked)
+	}
+	if !strings.Contains(stuck.Summary, "failing") {
+		t.Fatalf("stuck summary = %q, want failing outcome", stuck.Summary)
+	}
+	if reader.issueCalls != 0 {
+		t.Fatalf("ListOpenIssues called %d time(s), want failing outcome gate before issue throughput", reader.issueCalls)
+	}
+	reasons := strings.Join(decision.Reasons, "\n")
+	if !strings.Contains(reasons, "Open PRs observed: 1") {
+		t.Fatalf("reasons = %q, want open PRs to be treated as insufficient proof", reasons)
 	}
 }
 

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -24,10 +24,17 @@ auto_retry_rebase_conflicts: false # retry PRs whose auto-rebase fails with conf
 # outcome:
 #   desired_outcome: Maestro can supervise its own development and show a live Mission Control dashboard.
 #   runtime_target: http://127.0.0.1:8786
+#   runtime_url: http://127.0.0.1:8786          # alias for runtime_target
 #   deployment_status_command: systemctl --user status maestro.service
 #   healthcheck_url: http://127.0.0.1:8786/api/v1/state
+#   verifier_command: ./scripts/verify-live-outcome.sh  # alias for healthcheck_command
 #   source_repo_path: /path/to/local/maestro
 #   runtime_host: local developer workstation
+#   required_routes:
+#     - /
+#   requires_deploy: true
+#   pass_required_for_done: true
+#   fail_requires_visible_work: true
 #   non_goals:
 #     - Mutate production deploys without explicit approval controls
 #     - Generate broad issue waves automatically


### PR DESCRIPTION
## Summary

- add outcome-controlled config aliases for `runtime_url`, `verifier_command`, required routes, deploy requirement, and false-green policy flags
- make failing outcome health an immediate blocked supervisor state instead of waiting for merged PR history
- add `spawn_repair_worker` decisions for draft/failing/stale PR states and expose repair pending in Fleet
- map merged-but-not-verified work to Deploying or Live Verification on GitHub Projects

## Why

The supervisor could still look idle or green while the accepted runtime outcome was failing. The new gates make outcome health first-class and keep worker/PR/project state from being treated as product completion.

## Validation

- `go test ./internal/outcome ./internal/supervisor ./internal/orchestrator ./internal/config ./internal/github`
- `go test ./...`
- `git diff --check`

## Dogfood Plan

Dogfood is being applied on `ok-gobot` on `workshop`, not Panoptikon: build this branch binary, point only ok-gobot user services at it, add the ok-gobot verifier, restart ok-gobot units, and verify the dashboard API reports the new outcome contract.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces outcome-controlled supervisor gates: failing runtime health now blocks immediately (instead of waiting for 2+ merged PRs), a new `spawn_repair_worker` action handles draft/failing/stale PRs, and `code_landed` maps to Deploying or Live Verification on the project board based on `requires_deploy`. New config aliases (`runtime_url`, `verifier_command`, `required_routes`) are added with bidirectional normalization.

- `decisionRequiresApproval` is refactored to consult `cfg.Supervisor.ApprovalRequiredActions` instead of relying solely on risk level; this promotes the list from an LLM-context hint to the actual approval gate, which silently changes behavior for any deployment with a custom `approval_required_actions` YAML value.
- `openPRNeedsRepair` fires for any non-`StatusRunning` session with a draft PR, including normal `StatusPROpen` sessions \u2014 the draft check short-circuits before session status is considered.

<h3>Confidence Score: 3/5</h3>

The approval-gating change in `decisionRequiresApproval` could let mutating supervisor actions execute without human review for deployments with a custom `approval_required_actions` YAML list.

The `ApprovalRequiredActions` list went from being an informational LLM hint (no runtime effect) to being the sole gate controlling whether a decision is held for approval. Deployments with a custom list that omits an action including `review_retry_exhausted` with `RiskApprovalGated` will silently lose their approval requirement after the upgrade. The rest of the PR is straightforward and well-tested.

internal/supervisor/supervisor.go deserves another look, specifically `decisionRequiresApproval` and `openPRNeedsRepair`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Core logic changes: `decisionRequiresApproval` now gates on `ApprovalRequiredActions` list (previously ignored), `openPRNeedsRepair` added to trigger repair workers for draft/failing PRs, `detectOutcomeStuckStates` makes HealthFailing an immediate block. Two logic concerns flagged. |
| internal/orchestrator/orchestrator.go | Adds repair-worker injection into `startNewWorkers`, bypasses retry-limit and open-PR guards when supervisor selected `spawn_repair_worker`, and maps `code_landed` to Deploying/LiveVerify project states. Refactored `appendFetchedSupervisorIssue` correctly; nil-state guards are safe. |
| internal/outcome/outcome.go | Adds RuntimeURL/VerifierCommand aliases, RequiredRoutes, RequiresDeploy, and policy flags. Normalization and aliasing logic is correct and idempotent. |
| internal/github/github_projects.go | Adds ProjectStatusDeploying and ProjectStatusLiveVerify constants with fallback candidate lists. No logic issues. |
| internal/supervisor/supervisor_test.go | New tests cover draft/failing PR repair and immediate failing-outcome blocking. No test for StatusPROpen + draft PR case. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/supervisor/supervisor.go:1039-1052
**`ApprovalRequiredActions` silently promoted from LLM hint to approval gate**

Previously `decisionRequiresApproval` used only the decision's `Risk` level — `ApprovalRequiredActions` was passed to the LLM for context in `llm.go` but had zero effect on whether approval was actually required. After this change, when the list is non-nil (i.e. whenever `parse()` runs or a user has set it in YAML), the list is the sole gate: any non-safe action absent from the list executes without approval, regardless of its risk level.

A deployment that previously worked with a custom `approval_required_actions: ["spawn_worker"]` (which had no runtime effect before) will now silently stop requiring approval for `review_retry_exhausted` (`RiskApprovalGated`) and any other non-listed mutating actions when this binary is deployed.

### Issue 2 of 2
internal/supervisor/supervisor.go:1555-1567
**Draft-PR repair triggers for `StatusPROpen` sessions, not just dead workers**

`hasLiveRunningSessionForIssue` returns false for any session that is not in `StatusRunning`, including normal `StatusPROpen` sessions (worker finished, PR is open, waiting for review). The `pr.IsDraft` short-circuit at line 1565 fires before any status check, so a `StatusPROpen` session whose worker intentionally created a draft PR will immediately produce a `spawn_repair_worker` recommendation. Given that `spawn_repair_worker` is approval-gated by default this is not catastrophic, but in a deployment where the action has been whitelisted it would automatically spawn a second worker against a functioning PR.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add outcome-controlled supervisor gates"](https://github.com/befeast/maestro/commit/3b5db81d299bc61b25ee2eb4a4bd19aceb497be1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32528009)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->