### PR TITLE
[codex] Use REST for GitHub list hot paths

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -3,6 +3,7 @@ package github
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -52,15 +53,126 @@ type PR struct {
 	State       string `json:"state"`
 	Mergeable   string `json:"mergeable"`
 	Title       string `json:"title"`
+	Body        string `json:"body,omitempty"`
 	IsDraft     bool   `json:"isDraft"`
+	MergedAt    string `json:"mergedAt,omitempty"`
 }
 
 type Client struct {
 	Repo string
 }
 
+type restIssue struct {
+	Number int     `json:"number"`
+	Title  string  `json:"title"`
+	Body   *string `json:"body"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+	PullRequest *struct{} `json:"pull_request,omitempty"`
+}
+
+type restPull struct {
+	Number int     `json:"number"`
+	Title  string  `json:"title"`
+	Body   *string `json:"body"`
+	State  string  `json:"state"`
+	Draft  bool    `json:"draft"`
+	Head   struct {
+		Ref string `json:"ref"`
+	} `json:"head"`
+	MergedAt *string `json:"merged_at"`
+}
+
+func (ri restIssue) issue() Issue {
+	body := ""
+	if ri.Body != nil {
+		body = *ri.Body
+	}
+	return Issue{
+		Number: ri.Number,
+		Title:  ri.Title,
+		Body:   body,
+		Labels: ri.Labels,
+	}
+}
+
+func (rp restPull) pr() PR {
+	body := ""
+	if rp.Body != nil {
+		body = *rp.Body
+	}
+	mergedAt := ""
+	if rp.MergedAt != nil {
+		mergedAt = *rp.MergedAt
+	}
+	return PR{
+		Number:      rp.Number,
+		HeadRefName: rp.Head.Ref,
+		State:       strings.ToUpper(rp.State),
+		Title:       rp.Title,
+		Body:        body,
+		IsDraft:     rp.Draft,
+		MergedAt:    mergedAt,
+	}
+}
+
 func New(repo string) *Client {
 	return &Client{Repo: repo}
+}
+
+func ghAPI(endpoint string) ([]byte, error) {
+	out, err := exec.Command("gh", "api", endpoint).Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh api %s: %w", endpoint, err)
+	}
+	return out, nil
+}
+
+func parseRESTIssues(out []byte) ([]Issue, error) {
+	var restIssues []restIssue
+	if err := json.Unmarshal(out, &restIssues); err != nil {
+		return nil, err
+	}
+	issues := make([]Issue, 0, len(restIssues))
+	for _, issue := range restIssues {
+		if issue.PullRequest != nil {
+			continue
+		}
+		issues = append(issues, issue.issue())
+	}
+	return issues, nil
+}
+
+func parseRESTIssue(out []byte) (Issue, error) {
+	var issue restIssue
+	if err := json.Unmarshal(out, &issue); err != nil {
+		return Issue{}, err
+	}
+	return issue.issue(), nil
+}
+
+func parseRESTPulls(out []byte) ([]PR, error) {
+	var restPulls []restPull
+	if err := json.Unmarshal(out, &restPulls); err != nil {
+		return nil, err
+	}
+	prs := make([]PR, 0, len(restPulls))
+	for _, pr := range restPulls {
+		prs = append(prs, pr.pr())
+	}
+	return prs, nil
+}
+
+func issueRefRegexp(issueNumber int) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf(`(?i)(^|[^0-9])#%d([^0-9]|$)`, issueNumber))
+}
+
+func prReferencesIssue(pr PR, issueNumber int) bool {
+	if issueNumber <= 0 {
+		return false
+	}
+	return issueRefRegexp(issueNumber).MatchString(pr.Title + "\n" + pr.Body)
 }
 
 // ListOpenIssues returns open issues matching any of the given labels (OR filter).
@@ -94,24 +206,18 @@ func (c *Client) ListOpenIssues(labels []string) ([]Issue, error) {
 }
 
 func (c *Client) listOpenIssuesByLabel(label string) ([]Issue, error) {
-	args := []string{
-		"issue", "list",
-		"--repo", c.Repo,
-		"--state", "open",
-		"--json", "number,title,body,labels,projectItems",
-		"--limit", "100",
-	}
+	endpoint := fmt.Sprintf("repos/%s/issues?state=open&per_page=100", c.Repo)
 	if label != "" {
-		args = append(args, "--label", label)
+		endpoint += "&labels=" + url.QueryEscape(label)
 	}
 
-	out, err := exec.Command("gh", args...).Output()
+	out, err := ghAPI(endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("gh issue list: %w", err)
+		return nil, fmt.Errorf("list open issues: %w", err)
 	}
 
-	var issues []Issue
-	if err := json.Unmarshal(out, &issues); err != nil {
+	issues, err := parseRESTIssues(out)
+	if err != nil {
 		return nil, fmt.Errorf("parse issues: %w", err)
 	}
 	return issues, nil
@@ -119,14 +225,12 @@ func (c *Client) listOpenIssuesByLabel(label string) ([]Issue, error) {
 
 // GetIssue fetches a single issue by number
 func (c *Client) GetIssue(number int) (Issue, error) {
-	out, err := exec.Command("gh", "issue", "view", fmt.Sprint(number),
-		"--repo", c.Repo,
-		"--json", "number,title,body,labels,projectItems").Output()
+	out, err := ghAPI(fmt.Sprintf("repos/%s/issues/%d", c.Repo, number))
 	if err != nil {
-		return Issue{}, fmt.Errorf("gh issue view %d: %w", number, err)
+		return Issue{}, fmt.Errorf("get issue %d: %w", number, err)
 	}
-	var issue Issue
-	if err := json.Unmarshal(out, &issue); err != nil {
+	issue, err := parseRESTIssue(out)
+	if err != nil {
 		return Issue{}, fmt.Errorf("parse issue %d: %w", number, err)
 	}
 	return issue, nil
@@ -134,11 +238,9 @@ func (c *Client) GetIssue(number int) (Issue, error) {
 
 // IsIssueClosed returns true if the issue is closed
 func (c *Client) IsIssueClosed(number int) (bool, error) {
-	out, err := exec.Command("gh", "issue", "view", fmt.Sprint(number),
-		"--repo", c.Repo,
-		"--json", "state").Output()
+	out, err := ghAPI(fmt.Sprintf("repos/%s/issues/%d", c.Repo, number))
 	if err != nil {
-		return false, fmt.Errorf("gh issue view %d: %w", number, err)
+		return false, fmt.Errorf("get issue %d: %w", number, err)
 	}
 	var result struct {
 		State string `json:"state"`
@@ -151,18 +253,26 @@ func (c *Client) IsIssueClosed(number int) (bool, error) {
 
 // ListOpenPRs returns all open PRs
 func (c *Client) ListOpenPRs() ([]PR, error) {
-	out, err := exec.Command("gh", "pr", "list",
-		"--repo", c.Repo,
-		"--state", "open",
-		"--json", "number,headRefName,state,mergeable,title,isDraft",
-		"--limit", "100").Output()
+	out, err := ghAPI(fmt.Sprintf("repos/%s/pulls?state=open&per_page=100", c.Repo))
 	if err != nil {
-		return nil, fmt.Errorf("gh pr list: %w", err)
+		return nil, fmt.Errorf("list open PRs: %w", err)
 	}
 
-	var prs []PR
-	if err := json.Unmarshal(out, &prs); err != nil {
+	prs, err := parseRESTPulls(out)
+	if err != nil {
 		return nil, fmt.Errorf("parse prs: %w", err)
+	}
+	return prs, nil
+}
+
+func (c *Client) listClosedPRs() ([]PR, error) {
+	out, err := ghAPI(fmt.Sprintf("repos/%s/pulls?state=closed&per_page=100&sort=updated&direction=desc", c.Repo))
+	if err != nil {
+		return nil, fmt.Errorf("list closed PRs: %w", err)
+	}
+	prs, err := parseRESTPulls(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse closed prs: %w", err)
 	}
 	return prs, nil
 }
@@ -214,23 +324,16 @@ func (c *Client) IsPRMerged(prNumber int) (bool, error) {
 
 // HasMergedPRForIssue returns true if a merged PR references the issue.
 func (c *Client) HasMergedPRForIssue(issueNumber int) (bool, error) {
-	query := fmt.Sprintf("#%d", issueNumber)
-	out, err := exec.Command("gh", "pr", "list",
-		"--repo", c.Repo,
-		"--state", "merged",
-		"--search", query,
-		"--json", "number",
-		"--limit", "1").Output()
+	prs, err := c.listClosedPRs()
 	if err != nil {
-		return false, fmt.Errorf("gh pr list --state merged --search: %w", err)
+		return false, err
 	}
-	var prs []struct {
-		Number int `json:"number"`
+	for _, pr := range prs {
+		if pr.MergedAt != "" && prReferencesIssue(pr, issueNumber) {
+			return true, nil
+		}
 	}
-	if err := json.Unmarshal(out, &prs); err != nil {
-		return false, fmt.Errorf("parse merged pr search results: %w", err)
-	}
-	return len(prs) > 0, nil
+	return false, nil
 }
 
 // PRCIStatus returns "success", "failure", "pending", or "unknown"
@@ -653,25 +756,17 @@ func (c *Client) CreateRelease(tag, title string) error {
 
 // HasOpenPRForIssue returns true if there is at least one open PR that
 // references the given issue number (e.g. "closes #N") in its body or title.
-// Uses GitHub search so it works regardless of branch naming.
 func (c *Client) HasOpenPRForIssue(issueNumber int) (bool, error) {
-	query := fmt.Sprintf("#%d", issueNumber)
-	out, err := exec.Command("gh", "pr", "list",
-		"--repo", c.Repo,
-		"--state", "open",
-		"--search", query,
-		"--json", "number",
-		"--limit", "1").Output()
+	prs, err := c.ListOpenPRs()
 	if err != nil {
-		return false, fmt.Errorf("gh pr list --search: %w", err)
+		return false, err
 	}
-	var prs []struct {
-		Number int `json:"number"`
+	for _, pr := range prs {
+		if prReferencesIssue(pr, issueNumber) {
+			return true, nil
+		}
 	}
-	if err := json.Unmarshal(out, &prs); err != nil {
-		return false, fmt.Errorf("parse pr search results: %w", err)
-	}
-	return len(prs) > 0, nil
+	return false, nil
 }
 
 // FindBlockers scans an issue body for blocker references matching the given
@@ -748,27 +843,16 @@ func (c *Client) EditIssueBody(number int, body string) error {
 // FindOpenPRForIssue returns the first open PR that references the given issue number.
 // Returns pr number, branch name, and whether one was found.
 func (c *Client) FindOpenPRForIssue(issueNumber int) (prNumber int, branch string, found bool, err error) {
-	query := fmt.Sprintf("#%d", issueNumber)
-	out, err := exec.Command("gh", "pr", "list",
-		"--repo", c.Repo,
-		"--state", "open",
-		"--search", query,
-		"--json", "number,headRefName",
-		"--limit", "1").Output()
+	prs, err := c.ListOpenPRs()
 	if err != nil {
-		return 0, "", false, fmt.Errorf("gh pr list --search: %w", err)
+		return 0, "", false, err
 	}
-	var prs []struct {
-		Number      int    `json:"number"`
-		HeadRefName string `json:"headRefName"`
+	for _, pr := range prs {
+		if prReferencesIssue(pr, issueNumber) {
+			return pr.Number, pr.HeadRefName, true, nil
+		}
 	}
-	if err := json.Unmarshal(out, &prs); err != nil {
-		return 0, "", false, fmt.Errorf("parse pr search: %w", err)
-	}
-	if len(prs) == 0 {
-		return 0, "", false, nil
-	}
-	return prs[0].Number, prs[0].HeadRefName, true, nil
+	return 0, "", false, nil
 }
 
 // ReviewComment is an exported review comment (from Greptile, Codex, or any reviewer).

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -7,6 +7,62 @@ import (
 	"testing"
 )
 
+func TestParseRESTIssuesSkipsPullRequests(t *testing.T) {
+	body := `[
+		{"number": 10, "title": "real issue", "body": null, "labels": [{"name": "maestro-ready"}]},
+		{"number": 11, "title": "pr issue", "body": "ignored", "labels": [], "pull_request": {}}
+	]`
+
+	got, err := parseRESTIssues([]byte(body))
+	if err != nil {
+		t.Fatalf("parseRESTIssues() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("parseRESTIssues() returned %d issues, want 1", len(got))
+	}
+	if got[0].Number != 10 || got[0].Title != "real issue" {
+		t.Fatalf("parseRESTIssues()[0] = %#v", got[0])
+	}
+	if len(got[0].Labels) != 1 || got[0].Labels[0].Name != "maestro-ready" {
+		t.Fatalf("labels = %#v, want maestro-ready", got[0].Labels)
+	}
+	if got[0].Body != "" {
+		t.Fatalf("null body should parse as empty string, got %q", got[0].Body)
+	}
+}
+
+func TestParseRESTPullsMapsFields(t *testing.T) {
+	body := `[
+		{
+			"number": 42,
+			"title": "Fixes #7",
+			"body": "Closes #7",
+			"state": "open",
+			"draft": true,
+			"head": {"ref": "feat/example"},
+			"merged_at": null
+		}
+	]`
+
+	got, err := parseRESTPulls([]byte(body))
+	if err != nil {
+		t.Fatalf("parseRESTPulls() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("parseRESTPulls() returned %d PRs, want 1", len(got))
+	}
+	pr := got[0]
+	if pr.Number != 42 || pr.HeadRefName != "feat/example" || pr.State != "OPEN" || !pr.IsDraft {
+		t.Fatalf("parsed PR = %#v", pr)
+	}
+	if !prReferencesIssue(pr, 7) {
+		t.Fatalf("expected PR to reference issue #7")
+	}
+	if prReferencesIssue(pr, 70) {
+		t.Fatalf("did not expect #7 to match issue #70")
+	}
+}
+
 func TestGreptileCheckDecision(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## What changed
- Replace hot-path `gh issue list` and `gh pr list` calls with REST-backed `gh api` reads.
- Keep ProjectV2 GraphQL usage isolated to explicit project-board operations.
- Add REST parser coverage for issues, PRs, null bodies, PR-as-issue filtering, and issue-reference matching.

## Why
`gh issue/pr list` uses GraphQL internally, so executor/supervisor queue discovery could stop seeing work when the GraphQL bucket was exhausted even while REST/core quota was still healthy.

## Validation
- `go test ./internal/github ./internal/orchestrator ./internal/supervisor`
- `go test ./...`
- Rebuilt ok-gobot dogfood binary and restarted ok-gobot Maestro services.
- Verified ok-gobot worker cycle no longer logs `gh issue list` / `gh pr list` / GraphQL rate-limit errors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces hot-path `gh issue list` / `gh pr list` (which use GraphQL internally) with direct REST calls via `gh api` to avoid GraphQL rate-limit exhaustion during executor/supervisor queue discovery.

- **`internal/github/github.go`**: New `restIssue`/`restPull` structs and parser functions replace the old `gh` CLI subcommands; `HasMergedPRForIssue`, `HasOpenPRForIssue`, and `FindOpenPRForIssue` now scan locally-fetched PR lists instead of delegating to GitHub search.
- **`internal/github/github_test.go`**: Adds parser unit tests for null-body handling, PR-as-issue filtering, field mapping, and the `prReferencesIssue` regex boundary behaviour.

<h3>Confidence Score: 2/5</h3>

The change introduces a definite always-false bug in `IsIssueClosed`, silently drops project-board status data that the supervisor uses to gate work assignment, and caps historical PR lookups at 100 entries — all on heavily-used code paths.

Three separate logic regressions on core paths: `IsIssueClosed` will never return true (REST state is lowercase, comparison is uppercase), project-status filtering in the supervisor is silently neutered because `ProjectItems` is not populated by the REST issues endpoint, and PR-reference queries now have a hard 100-result ceiling that did not exist before.

internal/github/github.go — the state comparison fix, project-items population, and PR-search pagination all need attention before this is safe to run in production.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/github/github.go | Replaces GraphQL-backed `gh issue/pr list` with REST `gh api` calls; introduces three logic bugs: `IsIssueClosed` always returns false (REST state is lowercase), `ProjectItems` is silently dropped breaking supervisor project-status filtering, and PR lookups are capped at 100 results missing older history. |
| internal/github/github_test.go | Adds unit tests for the new REST parsers (null body, PR-as-issue filtering, field mapping, issue-reference regex); tests are correct and cover the new parsing paths well. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/github/github.go`, line 251 ([link](https://github.com/befeast/maestro/blob/0f6b9e0821d8fd5a34e7cd8f3deb7ca8ac27507f/internal/github/github.go#L251)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=8" align="top"></a> The GitHub REST API returns issue state as lowercase `"open"` or `"closed"`, but this line compares against the uppercase string `"CLOSED"`. The comparison will never be true, so `IsIssueClosed` will always return `false` regardless of the actual issue state. The PR correctly normalizes PR state with `strings.ToUpper(rp.State)` in `restPull.pr()`, but that same normalization was not applied here.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/github/github.go
   Line: 251

   Comment:
   The GitHub REST API returns issue state as lowercase `"open"` or `"closed"`, but this line compares against the uppercase string `"CLOSED"`. The comparison will never be true, so `IsIssueClosed` will always return `false` regardless of the actual issue state. The PR correctly normalizes PR state with `strings.ToUpper(rp.State)` in `restPull.pr()`, but that same normalization was not applied here.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/github/github.go:251
The GitHub REST API returns issue state as lowercase `"open"` or `"closed"`, but this line compares against the uppercase string `"CLOSED"`. The comparison will never be true, so `IsIssueClosed` will always return `false` regardless of the actual issue state. The PR correctly normalizes PR state with `strings.ToUpper(rp.State)` in `restPull.pr()`, but that same normalization was not applied here.

```suggestion
	return strings.EqualFold(result.State, "closed"), nil
```

### Issue 2 of 3
internal/github/github.go:208-224
**`ProjectItems` silently dropped from issue results**

The old `gh issue list --json ...,projectItems` call populated `Issue.ProjectItems` for every fetched issue. The GitHub REST `/issues` endpoint does not return project membership, so `restIssue` has no `project_items` field and `restIssue.issue()` always sets `ProjectItems` to `nil`. Downstream in the supervisor, `nonRunnableProjectStatus(issue)` (called at `supervisor.go:1195`) and `firstProjectStatus(issue)` (called at `supervisor.go:1840`) iterate over `ProjectItems` — both will now always see an empty slice. This means issues with a non-runnable project board status (e.g. "In Progress", "Done") will no longer be skipped and could be picked up as work by the executor.

### Issue 3 of 3
internal/github/github.go:268-278
**`HasMergedPRForIssue` now misses PRs beyond the 100 most-recently-updated**

The previous implementation used `gh pr list --state merged --search "#N" --limit 1`, which ran a server-side full-text search across the entire merged-PR history of the repo. The new implementation calls `listClosedPRs()`, which fetches at most 100 closed PRs sorted by last-updated time, then scans them locally. On a repo with more than 100 closed PRs, a merged PR referencing an older issue will not be among the 100 returned and `HasMergedPRForIssue` will incorrectly return `false`. The same 100-PR ceiling applies to `HasOpenPRForIssue` and `FindOpenPRForIssue` via `ListOpenPRs`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Use REST for GitHub list hot paths"](https://github.com/befeast/maestro/commit/0f6b9e0821d8fd5a34e7cd8f3deb7ca8ac27507f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32529649)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->