### PR TITLE
[codex] Back off failed project discovery

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -66,7 +66,8 @@ type Orchestrator struct {
 	workerStartFn    func(cfg *config.Config, s *state.State, repo string, issue github.Issue, promptBase, backend string) (string, error)
 
 	// Cached project board field (discovered once per run cycle, nil if disabled)
-	projectField *github.ProjectField
+	projectField           *github.ProjectField
+	projectDiscoverRetryAt time.Time
 
 	// Mission processor (nil when missions disabled)
 	missionProc *mission.Processor
@@ -353,12 +354,17 @@ func (o *Orchestrator) ensureProjectField() {
 	if o.projectField != nil {
 		return
 	}
+	if !o.projectDiscoverRetryAt.IsZero() && time.Now().Before(o.projectDiscoverRetryAt) {
+		return
+	}
 	pf, err := o.gh.DiscoverProject(o.cfg.GitHubProjects.ProjectNumber)
 	if err != nil {
-		log.Printf("[orch] discover project: %v", err)
+		o.projectDiscoverRetryAt = time.Now().Add(10 * time.Minute)
+		log.Printf("[orch] discover project: %v (backing off until %s)", err, o.projectDiscoverRetryAt.Format(time.RFC3339))
 		return
 	}
 	o.projectField = pf
+	o.projectDiscoverRetryAt = time.Time{}
 }
 
 // syncProject syncs an issue's status to the configured GitHub Project board.


### PR DESCRIPTION
## What changed
- Add a 10-minute retry backoff after failed GitHub ProjectV2 discovery.

## Why
When GraphQL is depleted, Project board discovery should not retry every Maestro cycle and keep burning the same exhausted bucket. Queue discovery is already REST-backed; this keeps the remaining ProjectV2-only path from becoming a tight failure loop.

## Validation
- `go test ./internal/orchestrator ./internal/github`
- `go test ./...`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a 10-minute in-memory retry backoff to `ensureProjectField` so that a failed GitHub ProjectV2 GraphQL discovery does not hammer the already-exhausted rate-limit bucket on every Maestro cycle.

- `projectDiscoverRetryAt` is set to `time.Now().Add(10 * time.Minute)` on any `DiscoverProject` error; subsequent calls return early until the deadline passes, then retry.
- On a successful discovery the timestamp is cleared; callers that receive a nil `projectField` during the backoff window are already safe because `SyncIssueStatusOneOf` has an early-return nil guard and `reconcileProjectBoard` has its own nil-check.
- The backoff is in-process only, so a process restart resets it — this is acceptable and matches the intent of stopping tight per-cycle retries within a single run.

<h3>Confidence Score: 5/5</h3>

The change is isolated to a single method and only affects behaviour when project discovery fails; the happy path is untouched.

The backoff logic is simple and correct: callers that hit a nil `projectField` during the backoff window already handle nil gracefully, the timestamp is cleared on success, and there are no concurrency concerns in this single-goroutine path. No existing behaviour is regressed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds a 10-minute in-memory backoff after a failed ProjectV2 discovery to prevent tight retry loops when the GraphQL rate-limit bucket is exhausted. Logic is correct: the nil-guard on `SyncIssueStatusOneOf` already handles a nil `projectField` gracefully, and `reconcileProjectBoard` has its own nil-check after `ensureProjectField`. Clearing `projectDiscoverRetryAt` on success is good hygiene. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Back off failed project discovery"](https://github.com/befeast/maestro/commit/bdf6f106f0b23773807b250fb1a8ac812c99fa16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32529865)</sub>

<!-- /greptile_comment -->