### PR TITLE
[codex] Surface GitHub rate budget blockers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -510,6 +510,7 @@ func parse(data []byte) (*Config, error) {
 			"monitor_open_pr",
 			"review_retry_exhausted",
 			"check_outcome_health",
+			"notify_red",
 			"spawn_worker",
 			"spawn_repair_worker",
 			"label_issue_ready",

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -62,6 +62,18 @@ type Client struct {
 	Repo string
 }
 
+type RateLimitBucket struct {
+	Limit     int `json:"limit"`
+	Remaining int `json:"remaining"`
+	Reset     int `json:"reset"`
+	Used      int `json:"used"`
+}
+
+type RateLimitStatus struct {
+	Core    RateLimitBucket `json:"core"`
+	GraphQL RateLimitBucket `json:"graphql"`
+}
+
 type restIssue struct {
 	Number int     `json:"number"`
 	Title  string  `json:"title"`
@@ -127,6 +139,34 @@ func ghAPI(endpoint string) ([]byte, error) {
 		return nil, fmt.Errorf("gh api %s: %w", endpoint, err)
 	}
 	return out, nil
+}
+
+func parseRateLimitStatus(out []byte) (RateLimitStatus, error) {
+	var payload struct {
+		Resources struct {
+			Core    RateLimitBucket `json:"core"`
+			GraphQL RateLimitBucket `json:"graphql"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return RateLimitStatus{}, err
+	}
+	return RateLimitStatus{
+		Core:    payload.Resources.Core,
+		GraphQL: payload.Resources.GraphQL,
+	}, nil
+}
+
+func (c *Client) RateLimit() (RateLimitStatus, error) {
+	out, err := ghAPI("rate_limit")
+	if err != nil {
+		return RateLimitStatus{}, err
+	}
+	status, err := parseRateLimitStatus(out)
+	if err != nil {
+		return RateLimitStatus{}, fmt.Errorf("parse rate limit: %w", err)
+	}
+	return status, nil
 }
 
 func parseRESTIssues(out []byte) ([]Issue, error) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -63,6 +63,23 @@ func TestParseRESTPullsMapsFields(t *testing.T) {
 	}
 }
 
+func TestParseRateLimitStatus(t *testing.T) {
+	body := `{
+		"resources": {
+			"core": {"limit": 5000, "remaining": 4990, "reset": 1779053364, "used": 10},
+			"graphql": {"limit": 5000, "remaining": 0, "reset": 1779052352, "used": 5000}
+		}
+	}`
+
+	got, err := parseRateLimitStatus([]byte(body))
+	if err != nil {
+		t.Fatalf("parseRateLimitStatus() error = %v", err)
+	}
+	if got.Core.Remaining != 4990 || got.GraphQL.Remaining != 0 || got.GraphQL.Used != 5000 {
+		t.Fatalf("parseRateLimitStatus() = %#v", got)
+	}
+}
+
 func TestGreptileCheckDecision(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2123,6 +2123,14 @@ func fleetOperatorStateFromSupervisor(project fleetProjectState) (fleetOperatorS
 	target := latest.Target
 	operator := fleetOperatorState{}
 	switch action {
+	case "notify_red":
+		operator = fleetOperatorState{
+			Kind:       "infra_blocker",
+			Tone:       "attention",
+			Label:      "Infra blocker",
+			Summary:    firstNonEmpty(summary, "A required source of truth is unavailable; Maestro must not report the project as healthy or idle."),
+			NextAction: "Restore the blocked dependency or wait for the documented reset before trusting queue/project reconciliation.",
+		}
 	case "check_outcome_health":
 		operator = fleetOperatorState{
 			Kind:       "outcome_drift",
@@ -2644,6 +2652,8 @@ func actionLabelServer(action string) string {
 		return "Review retry-exhausted work"
 	case "check_outcome_health":
 		return "Check runtime health"
+	case "notify_red":
+		return "Notify red"
 	case "wait_for_running_worker", "wait_for_worker":
 		return "Wait for worker"
 	case "wait_for_capacity":

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -338,6 +338,7 @@ func defaultAllowedActions() []string {
 		ActionMonitorOpenPR,
 		ActionReviewRetryExhausted,
 		ActionCheckOutcomeHealth,
+		ActionNotifyRed,
 		ActionSpawnWorker,
 		ActionSpawnRepairWorker,
 		ActionLabelIssueReady,
@@ -369,6 +370,8 @@ func canonicalAction(action string) string {
 		return ActionReviewRetryExhausted
 	case ActionCheckOutcomeHealth:
 		return ActionCheckOutcomeHealth
+	case ActionNotifyRed:
+		return ActionNotifyRed
 	case ActionSpawnWorker:
 		return ActionSpawnWorker
 	case ActionSpawnRepairWorker:

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -29,6 +29,7 @@ const (
 	ActionMonitorOpenPR        = "monitor_open_pr"
 	ActionReviewRetryExhausted = "review_retry_exhausted"
 	ActionCheckOutcomeHealth   = "check_outcome_health"
+	ActionNotifyRed            = "notify_red"
 	ActionSpawnWorker          = "spawn_worker"
 	ActionSpawnRepairWorker    = "spawn_repair_worker"
 	ActionLabelIssueReady      = "label_issue_ready"
@@ -93,16 +94,22 @@ type prGreptileReader interface {
 	PRGreptileApproved(prNumber int) (approved bool, pending bool, err error)
 }
 
+type rateLimitReader interface {
+	RateLimit() (github.RateLimitStatus, error)
+}
+
 // Engine makes deterministic supervisor decisions. It plans safe queue mutations
 // and emits structured stuck-state explanations.
 type Engine struct {
-	cfg      *config.Config
-	reader   Reader
-	llm      LLMClient
-	now      func() time.Time
-	pidAlive func(pid int) bool
-	stat     func(name string) (os.FileInfo, error)
-	lookPath func(file string) (string, error)
+	cfg                       *config.Config
+	reader                    Reader
+	llm                       LLMClient
+	now                       func() time.Time
+	pidAlive                  func(pid int) bool
+	stat                      func(name string) (os.FileInfo, error)
+	lookPath                  func(file string) (string, error)
+	rateBudgetChecked         bool
+	rateBudgetStuckStateCache []state.SupervisorStuckState
 }
 
 func NewEngine(cfg *config.Config, reader Reader) *Engine {
@@ -209,6 +216,19 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	}
 	projectState.OpenPRs = len(prs)
 	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false)
+
+	if stuck := githubProjectRateLimitStuckState(stuckStates); stuck != nil {
+		reasons := appendReasons(baseReasons,
+			stuck.Summary,
+			"GitHub Project sync is enabled, but ProjectV2 truth cannot be reconciled while the GraphQL bucket is exhausted",
+			"Supervisor must not report idle/no-work as healthy when an enabled source of truth is unavailable",
+		)
+		decision := e.decision(st, now, projectState, ActionNotifyRed,
+			"GitHub Project sync is blocked by API rate budget; do not treat the queue as healthy until it recovers.",
+			RiskSafe, 0.94, nil, PolicyRuleRuntimeState, reasons)
+		decision.StuckStates = stuckStates
+		return decision, nil
+	}
 
 	if slot, sess, pr, ok := sessionWithOpenPR(st, prs); ok {
 		if e.openPRNeedsRepair(st, stuckStates, slot, sess, pr) {
@@ -566,6 +586,7 @@ func (e *Engine) decision(st *state.State, now time.Time, ps state.SupervisorPro
 
 func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.PR, issues, eligible []github.Issue, skipped []string, issuesLoaded bool) []state.SupervisorStuckState {
 	var findings []state.SupervisorStuckState
+	findings = append(findings, e.detectRateBudgetStuckStates()...)
 	findings = append(findings, e.detectWorkerStuckStates(st, now)...)
 	findings = append(findings, e.detectPRStuckStates(st, prs)...)
 	if issuesLoaded {
@@ -575,6 +596,51 @@ func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.
 	findings = append(findings, e.detectEnvironmentStuckStates(st, eligible)...)
 	findings = append(findings, e.detectOutcomeStuckStates(st)...)
 	return compactStuckStates(findings)
+}
+
+func (e *Engine) detectRateBudgetStuckStates() []state.SupervisorStuckState {
+	if e.rateBudgetChecked {
+		return e.rateBudgetStuckStateCache
+	}
+	e.rateBudgetChecked = true
+	e.rateBudgetStuckStateCache = e.readRateBudgetStuckStates()
+	return e.rateBudgetStuckStateCache
+}
+
+func (e *Engine) readRateBudgetStuckStates() []state.SupervisorStuckState {
+	if e == nil || e.cfg == nil || !e.cfg.GitHubProjects.Enabled || e.cfg.GitHubProjects.ProjectNumber == 0 {
+		return nil
+	}
+	reader, ok := e.reader.(rateLimitReader)
+	if !ok {
+		return nil
+	}
+	rate, err := reader.RateLimit()
+	if err != nil {
+		return []state.SupervisorStuckState{stuckState("github_rate_budget_unknown", SeverityWarning,
+			"GitHub API rate budget could not be read.",
+			"Verify GitHub auth and rate-limit access before trusting Project reconciliation.", false, nil,
+			fmt.Sprintf("rate_limit_error=%v", err))}
+	}
+	if rate.GraphQL.Remaining > 0 {
+		return nil
+	}
+	return []state.SupervisorStuckState{stuckState("github_graphql_rate_exhausted", SeverityBlocked,
+		"GitHub GraphQL rate limit is exhausted, so Project truth cannot be reconciled.",
+		"Wait for the GraphQL reset or reduce ProjectV2 polling before treating Project state as healthy.", false, nil,
+		fmt.Sprintf("graphql_remaining=%d", rate.GraphQL.Remaining),
+		fmt.Sprintf("graphql_used=%d/%d", rate.GraphQL.Used, rate.GraphQL.Limit),
+		fmt.Sprintf("graphql_reset=%d", rate.GraphQL.Reset),
+		fmt.Sprintf("core_remaining=%d", rate.Core.Remaining))}
+}
+
+func githubProjectRateLimitStuckState(stuckStates []state.SupervisorStuckState) *state.SupervisorStuckState {
+	for i := range stuckStates {
+		if stuckStates[i].Code == "github_graphql_rate_exhausted" {
+			return &stuckStates[i]
+		}
+	}
+	return nil
 }
 
 func (e *Engine) outcomeStatus(st *state.State) outcome.Status {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -27,6 +27,8 @@ type fakeReader struct {
 	ciStatuses     map[int]string
 	greptileOK     map[int]bool
 	greptilePend   map[int]bool
+	rateLimit      *github.RateLimitStatus
+	rateLimitErr   error
 	issueCalls     int
 	addedLabels    []string
 	removedLabels  []string
@@ -116,6 +118,19 @@ func (f *fakeReader) PRGreptileApproved(prNumber int) (bool, bool, error) {
 	return approved, false, nil
 }
 
+func (f *fakeReader) RateLimit() (github.RateLimitStatus, error) {
+	if f.rateLimitErr != nil {
+		return github.RateLimitStatus{}, f.rateLimitErr
+	}
+	if f.rateLimit != nil {
+		return *f.rateLimit, nil
+	}
+	return github.RateLimitStatus{
+		Core:    github.RateLimitBucket{Limit: 5000, Remaining: 5000},
+		GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000},
+	}, nil
+}
+
 func testConfig(t *testing.T) *config.Config {
 	t.Helper()
 	return &config.Config{
@@ -148,6 +163,38 @@ func requireStuckState(t *testing.T, decision state.SupervisorDecision, code str
 	}
 	t.Fatalf("stuck state %q not found in %#v", code, decision.StuckStates)
 	return state.SupervisorStuckState{}
+}
+
+func TestDecide_ProjectGraphQLRateExhaustedDoesNotReportIdle(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.GitHubProjects.Enabled = true
+	cfg.GitHubProjects.ProjectNumber = 3
+	reader := &fakeReader{
+		rateLimit: &github.RateLimitStatus{
+			Core:    github.RateLimitBucket{Limit: 5000, Remaining: 4990, Used: 10},
+			GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 0, Used: 5000, Reset: 1779052352},
+		},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionNotifyRed {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionNotifyRed)
+	}
+	stuck := requireStuckState(t, decision, "github_graphql_rate_exhausted")
+	if stuck.Severity != SeverityBlocked {
+		t.Fatalf("severity = %q, want %q", stuck.Severity, SeverityBlocked)
+	}
+	if reader.issueCalls != 0 {
+		t.Fatalf("ListOpenIssues called %d time(s), want rate-budget gate before queue throughput", reader.issueCalls)
+	}
+	reasons := strings.Join(decision.Reasons, "\n")
+	if !strings.Contains(reasons, "must not report idle/no-work as healthy") {
+		t.Fatalf("reasons = %q, want explicit false-idle guardrail", reasons)
+	}
 }
 
 func testLLMEngine(cfg *config.Config, reader *fakeReader, llm *fakeLLM) *Engine {


### PR DESCRIPTION
## What changed
- Add a REST-backed GitHub rate budget read to the GitHub client.
- Make supervisor treat exhausted ProjectV2 GraphQL quota as a blocked red state (`notify_red`) instead of reporting `none` / idle.
- Add `notify_red` to supervisor allowed actions and fleet UI labels.
- Cover rate-limit parsing and the supervisor false-idle guardrail with tests.

## Why
The outcome-controlled loop must not report `no eligible issues` or idle when an enabled source of truth, GitHub ProjectV2, cannot be reconciled due to GraphQL quota exhaustion.

## Validation
- `go test ./internal/github ./internal/supervisor ./internal/server ./internal/config`
- `go test ./...`
- ok-gobot fake-rate dogfood: with `graphql_remaining=0`, supervisor returns `notify_red` and stuck state `github_graphql_rate_exhausted`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces GitHub GraphQL quota exhaustion as a first-class `notify_red` supervisor decision instead of silently reporting idle/no-work, preventing false-healthy outcomes when ProjectV2 cannot be reconciled.

- Adds `RateLimitBucket`/`RateLimitStatus` types and a `RateLimit()` REST method to the GitHub client, with a per-`Decide()` cache on `Engine` to avoid redundant `gh api rate_limit` calls when `detectStuckStates` is invoked multiple times within one decision cycle.
- Wires the new rate-budget detection into `decideDeterministic` as an early-return gate that emits `notify_red` (with a `github_graphql_rate_exhausted` stuck state) whenever `GitHubProjects` is enabled and the GraphQL bucket is zero, with coverage in both the GitHub client test and a new supervisor test that confirms `ListOpenIssues` is not called past the gate.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the primary goal; the GitHub client and fleet UI additions are clean, and the LLM guardrail correctly enforces notify_red through the LLM path too.

The two concerns worth watching are the Engine-level rate-budget cache (never reset, making the engine non-reusable — harmless today because RunOnce always constructs a fresh engine, but invisible to future callers) and the notify_red gate firing before the open-PR repair check (PR repair is REST-only and doesn't need ProjectV2 data, so a co-occurring stuck PR gets deferred until the rate limit resets). Neither changes existing behavior today, but both are worth addressing before the Engine pattern is extended.

internal/supervisor/supervisor.go — the cache fields and gate ordering deserve a second look; all other files are straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds RateLimitBucket/RateLimitStatus types and a RateLimit() method backed by `gh api rate_limit`; parsing is correct and error-wrapped cleanly. |
| internal/github/github_test.go | New test validates parseRateLimitStatus with a realistic payload including an exhausted GraphQL bucket; fields checked cover the key decision points. |
| internal/config/config.go | Adds notify_red to the allowed-actions list; trivial, one-line change consistent with all other action constants. |
| internal/server/fleet.go | Adds notify_red case to fleetOperatorStateFromSupervisor and actionLabelServer; messaging is clear and consistent with surrounding cases. |
| internal/supervisor/llm.go | Adds ActionNotifyRed to defaultAllowedActions and canonicalAction; validateLLMDecision enforces that the LLM cannot override a deterministic notify_red decision. |
| internal/supervisor/supervisor.go | Adds rate-budget detection, caching, and a notify_red early-return gate; the Engine-level cache fields create a stale-data footgun if Decide() is called more than once on the same instance, and the gate placement blocks PR-repair decisions that don't depend on ProjectV2. |
| internal/supervisor/supervisor_test.go | New test covers the exhausted-GraphQL → notify_red happy path and verifies ListOpenIssues is gated; the RateLimit error path (github_rate_budget_unknown) is not tested. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/supervisor/supervisor.go:111-112
**Engine rate-budget cache is never reset — stale on second `Decide()` call**

`rateBudgetChecked` is set to `true` on the first invocation of `detectRateBudgetStuckStates` and never cleared. If the same `Engine` instance is used for a second `Decide()` call (e.g., in a long-lived daemon loop, an integration test, or future refactors), the cached result — whether "exhausted" or "healthy" — will be served for every subsequent call regardless of what the actual rate limit is at that moment. A rate limit that recovered between calls would keep firing `notify_red`; one that became exhausted after the first call would never be detected. The cache is correctly scoped for the current `RunOnce`-creates-a-fresh-engine pattern, but the `Engine` struct is exported and `Decide` is public, so the constraint is invisible to callers.

### Issue 2 of 2
internal/supervisor/supervisor.go:220-231
**`notify_red` gate fires before open-PR repair check, deferring REST-only decisions**

The `githubProjectRateLimitStuckState` early return at line 220 runs before `sessionWithOpenPR` → `openPRNeedsRepair` is evaluated. A `spawn_repair_worker` recommendation (e.g., a draft PR that needs CI re-runs) relies exclusively on REST-based PR data — already loaded by `ListOpenPRs` a few lines above — and has no dependency on the GraphQL ProjectV2 budget. When the GraphQL bucket is exhausted, any open PR that requires repair will be silently deferred until the rate limit resets: the operator sees only `notify_red`, not the co-occurring PR issue. The stuck states do include PR-related entries (since `prs` was loaded before the gate), but the action itself is overridden to `notify_red` with no indication that a repair was also pending.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Surface GitHub rate budget blockers"](https://github.com/befeast/maestro/commit/db1a93617b32b4e456571304fc029bc2b195a907) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32530271)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->