### PR TITLE
[codex] Require outcome pass before done

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/mission"
 	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/pipeline"
 	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
@@ -1262,8 +1263,10 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				if err != nil {
 					log.Printf("[orch] check issue #%d: %v", sess.IssueNumber, err)
 				} else if closed {
-					log.Printf("[orch] issue #%d closed, transitioning zombie session %s from %s to done", sess.IssueNumber, slotName, sess.Status)
-					done = true
+					if o.canMarkDoneForOutcome(s, sess, fmt.Sprintf("issue #%d is closed", sess.IssueNumber)) {
+						log.Printf("[orch] issue #%d closed, transitioning zombie session %s from %s to done", sess.IssueNumber, slotName, sess.Status)
+						done = true
+					}
 				}
 				if done {
 					o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
@@ -1308,6 +1311,9 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 			if err != nil {
 				log.Printf("[orch] check issue #%d: %v", sess.IssueNumber, err)
 			} else if closed {
+				if !o.canMarkDoneForOutcome(s, sess, fmt.Sprintf("issue #%d is closed", sess.IssueNumber)) {
+					continue
+				}
 				log.Printf("[orch] issue #%d closed, transitioning %s from %s to done", sess.IssueNumber, slotName, sess.Status)
 				o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
 				o.stopWorker(slotName, sess)
@@ -1324,6 +1330,9 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 			if err != nil {
 				log.Printf("[orch] check issue #%d: %v", sess.IssueNumber, err)
 			} else if closed {
+				if !o.canMarkDoneForOutcome(s, sess, fmt.Sprintf("issue #%d is closed", sess.IssueNumber)) {
+					continue
+				}
 				log.Printf("[orch] issue #%d closed, stopping worker %s", sess.IssueNumber, slotName)
 				o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
 				o.stopWorker(slotName, sess)
@@ -1657,6 +1666,12 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				continue
 			}
 			log.Printf("[orch] no open PR found for branch %s (slot %s) — assuming merged/closed", sess.Branch, slotName)
+			if !o.canMarkDoneForOutcome(s, sess, fmt.Sprintf("PR for branch %s is no longer open", sess.Branch)) {
+				if sess.PRNumber > 0 {
+					o.markCodeLanded(sess, sess.PRNumber)
+				}
+				continue
+			}
 			sess.Status = state.StatusDone
 			now := time.Now().UTC()
 			sess.FinishedAt = &now
@@ -1970,6 +1985,36 @@ func (o *Orchestrator) markCodeLanded(sess *state.Session, prNumber int) {
 	sess.Status = state.StatusCodeLanded
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
+}
+
+func (o *Orchestrator) canMarkDoneForOutcome(s *state.State, sess *state.Session, trigger string) bool {
+	if o == nil || o.cfg == nil || !o.cfg.Outcome.PassRequiredForDoneEnabled() {
+		return true
+	}
+	status := outcome.StatusFor(o.cfg.Outcome, s.DonePRCount(), s.LastMergeAt, outcomeHealthChecks(s)...)
+	if status.HealthState == outcome.HealthHealthy {
+		return true
+	}
+	issue := 0
+	if sess != nil {
+		issue = sess.IssueNumber
+	}
+	trigger = strings.TrimSpace(trigger)
+	if trigger == "" {
+		trigger = fmt.Sprintf("issue #%d reached a done-like state", issue)
+	}
+	log.Printf("[orch] %s, but outcome health is %s; keeping session out of done until live verification passes", trigger, status.HealthState)
+	if sess != nil && sess.Status == state.StatusCodeLanded {
+		o.syncProject(sess.IssueNumber, codeLandedProjectStatus(o.cfg.Outcome.RequiresDeploy))
+	}
+	return false
+}
+
+func outcomeHealthChecks(s *state.State) []outcome.HealthCheckResult {
+	if s == nil || s.OutcomeHealth == nil {
+		return nil
+	}
+	return []outcome.HealthCheckResult{*s.OutcomeHealth}
 }
 
 func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr github.PR) bool {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/supervisor"
@@ -24,6 +25,10 @@ func makeIssue(number int, title string, labels ...string) github.Issue {
 		}{Name: l})
 	}
 	return issue
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }
 
 func TestHashOutput_UsesLast50LinesOnly(t *testing.T) {
@@ -724,6 +729,36 @@ func makeTestState(prs []github.PR) *state.State {
 		}
 	}
 	return s
+}
+
+func TestAutoMergePRs_MissingOpenPRDoesNotBecomeDoneWhenOutcomePassRequiredFails(t *testing.T) {
+	cfg := &config.Config{
+		Repo:          "owner/repo",
+		MergeStrategy: "parallel",
+		Outcome: outcome.Brief{
+			DesiredOutcome:      "Live app works",
+			VerifierCommand:     "check-live",
+			PassRequiredForDone: boolPtr(true),
+		},
+	}
+	o, merged := newMergeTestOrchestrator(cfg, nil)
+	s := makeTestState([]github.PR{{Number: 10, HeadRefName: "feat/a"}})
+	s.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: time.Now().UTC(),
+		State:     outcome.HealthFailing,
+		Signal:    "verifier_command",
+		Summary:   "live verifier failed",
+	}
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 0 {
+		t.Fatalf("merged = %v, want no merge when PR is already missing", *merged)
+	}
+	sess := s.Sessions["slot-0"]
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q until live verification passes", sess.Status, state.StatusCodeLanded)
+	}
 }
 
 func TestAutoMergePRs_ParallelMergesAllReady(t *testing.T) {
@@ -3309,6 +3344,54 @@ func TestCheckSessions_FailedClosedIssue_TransitionsToDone(t *testing.T) {
 	sess := s.Sessions["pan-10"]
 	if sess.Status != state.StatusDone {
 		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
+	}
+}
+
+func TestCheckSessions_ClosedIssueDoesNotBecomeDoneWhenOutcomePassRequiredFails(t *testing.T) {
+	now := time.Now().UTC()
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:              "owner/repo",
+			MaxRuntimeMinutes: 120,
+			Outcome: outcome.Brief{
+				DesiredOutcome:      "Live app works",
+				VerifierCommand:     "check-live",
+				PassRequiredForDone: boolPtr(true),
+			},
+		},
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{}, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return true, nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			t.Fatalf("workerStopFn should not run before outcome verification passes")
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: now,
+		State:     outcome.HealthFailing,
+		Signal:    "verifier_command",
+		Summary:   "live verifier failed",
+	}
+	s.Sessions["pan-10"] = &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "failed worker",
+		Status:      state.StatusFailed,
+		Branch:      "feat/pan-10-100-failed",
+		FinishedAt:  &now,
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["pan-10"]
+	if sess.Status != state.StatusFailed {
+		t.Fatalf("status = %q, want %q until live verification passes", sess.Status, state.StatusFailed)
 	}
 }
 


### PR DESCRIPTION
## What changed
- Prevent closed issues or missing open PRs from moving Maestro sessions to `done` when `outcome.pass_required_for_done` is enabled and live outcome health is not healthy.
- Keep such work in non-terminal/runtime-verification state until the configured outcome verifier passes.
- Add orchestrator tests for closed-issue and missing-PR done-like paths.

## Why
The outcome-controlled loop must not treat issue closure or PR disappearance as product completion. `Done` now requires the accepted runtime outcome when the project config says so.

## Validation
- `go test ./internal/orchestrator`
- `go test ./...`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates all \"transition to done\" paths in `checkSessions` and `autoMergePRs` behind a new `canMarkDoneForOutcome` helper, preventing sessions from reaching `StatusDone` when `outcome.pass_required_for_done` is enabled and live outcome health is not healthy. Two new orchestrator tests cover the closed-issue and missing-PR cases.

- `canMarkDoneForOutcome` is inserted at every done-like branch (zombie cleanup, `StatusPROpen`/`StatusQueued` closed issue, `StatusRunning` closed issue, and the missing-open-PR path in `autoMergePRs`), with a side effect of re-syncing the project board to `code_landed` when blocking a `StatusCodeLanded` session.
- In `autoMergePRs`, when the outcome gate blocks done and the session has a PR number, the session is explicitly transitioned to `StatusCodeLanded` so progress is preserved until the verifier passes.

<h3>Confidence Score: 3/5</h3>

The StatusRunning dead-worker detection path is permanently bypassed when outcome is unhealthy and the issue is closed, which can strand a worker slot.

In the StatusRunning branch of checkSessions, the new continue that guards against premature done-marking also skips the PID liveness check that follows it. A worker whose process has already exited will never be noticed as dead — every tick short-circuits at the closed-issue+outcome gate — keeping the slot occupied as running for as long as the outcome verifier stays unhealthy.

internal/orchestrator/orchestrator.go — specifically the StatusRunning closed-issue block around line 1333

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds canMarkDoneForOutcome gate across four done-like transitions; the new continue in the StatusRunning branch skips PID liveness detection when outcome is unhealthy, causing dead workers to stay stuck as running indefinitely. |
| internal/orchestrator/orchestrator_test.go | Adds two new tests for closed-issue and missing-PR paths with outcome gate; minor IssueNumber mismatch (100 vs 10) in the closed-issue test is misleading but non-breaking. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:1333-1335
**Skipped PID-liveness check when outcome blocks done**

When a `StatusRunning` session's issue is closed but `canMarkDoneForOutcome` returns false, the `continue` exits the outer session loop entirely, bypassing the `sess.PID > 0 && !o.pidAlive(sess.PID)` check that follows at line 1346. If the worker process has already died (PID gone), it will never be detected as dead: every subsequent tick re-enters this same branch (`isIssueClosed→true`, outcome unhealthy, `continue`), permanently skipping the dead-worker path. The slot stays occupied as `StatusRunning` until outcome becomes healthy, blocking new work from being scheduled on it.

### Issue 2 of 2
internal/orchestrator/orchestrator_test.go:3382-3388
**Slot name / issue number mismatch in test setup**

The slot key `"pan-10"` implies issue 10, but `IssueNumber` is set to `100` and the branch is `"feat/pan-10-100-failed"`. Because `isIssueClosedFn` returns `true` for any number the test passes, but the inconsistency would hide a regression where the wrong issue number was forwarded to the close-check function. Consider aligning to `IssueNumber: 10` (and `Branch: "feat/pan-10-10-failed"`) so the fixture is self-consistent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Require outcome pass before done"](https://github.com/befeast/maestro/commit/b98267541accf3b0c9a8a728742b0da704ea0f40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32530529)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->