### PR TITLE
Run outcome verifier after merge deploy

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -86,6 +86,7 @@ type Orchestrator struct {
 	ghCloseIssueFn              func(number int, comment string) error
 	workerStopFn                func(cfg *config.Config, slotName string, sess *state.Session) error
 	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
+	outcomeCheckFn              func(context.Context, outcome.Brief) outcome.HealthCheckResult
 }
 
 // New creates a new Orchestrator
@@ -261,6 +262,13 @@ func (o *Orchestrator) saveCheckpoint(sess *state.Session) (string, error) {
 	return worker.SaveCheckpoint(sess)
 }
 
+func (o *Orchestrator) checkOutcome(ctx context.Context) outcome.HealthCheckResult {
+	if o.outcomeCheckFn != nil {
+		return o.outcomeCheckFn(ctx, o.cfg.Outcome)
+	}
+	return outcome.Checker{}.Check(ctx, o.cfg.Outcome)
+}
+
 func (o *Orchestrator) respawnInPlace(slotName string, sess *state.Session, issue github.Issue, promptBase string, backendName string) error {
 	if o.respawnInPlaceFn != nil {
 		return o.respawnInPlaceFn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
@@ -408,7 +416,7 @@ func projectStatusForSession(sess *state.Session, requiresDeploy bool) (github.P
 	case state.StatusQueued, state.StatusPROpen:
 		return github.ProjectStatusInReview, true
 	case state.StatusCodeLanded:
-		return codeLandedProjectStatus(requiresDeploy), true
+		return codeLandedProjectStatusForSession(sess, requiresDeploy), true
 	case state.StatusDone:
 		return github.ProjectStatusDone, true
 	case state.StatusRetryExhausted, state.StatusConflictFailed, state.StatusFailed:
@@ -506,6 +514,13 @@ func codeLandedProjectStatus(requiresDeploy bool) github.ProjectStatus {
 		return github.ProjectStatusDeploying
 	}
 	return github.ProjectStatusLiveVerify
+}
+
+func codeLandedProjectStatusForSession(sess *state.Session, requiresDeploy bool) github.ProjectStatus {
+	if requiresDeploy && sess != nil && sess.DeploymentFinishedAt != nil {
+		return github.ProjectStatusLiveVerify
+	}
+	return codeLandedProjectStatus(requiresDeploy)
 }
 
 func sessionRecency(sess *state.Session) time.Time {
@@ -1761,9 +1776,7 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	strategy := o.mergeStrategy()
 	if strategy == "parallel" {
 		for _, candidate := range ready {
-			if o.mergeReadyPR(candidate.slotName, candidate.sess, candidate.pr) {
-				s.LastMergeAt = time.Now().UTC()
-			}
+			o.mergeReadyPR(s, candidate.slotName, candidate.sess, candidate.pr)
 		}
 		return
 	}
@@ -1778,10 +1791,7 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	}
 
 	candidate := ready[0]
-	merged := o.mergeReadyPR(candidate.slotName, candidate.sess, candidate.pr)
-	if merged {
-		s.LastMergeAt = time.Now().UTC()
-	}
+	o.mergeReadyPR(s, candidate.slotName, candidate.sess, candidate.pr)
 	if len(ready) > 1 {
 		log.Printf("[orch] sequential merge mode: deferring %d additional ready PR(s) to next cycle", len(ready)-1)
 	}
@@ -1981,17 +1991,48 @@ func (o *Orchestrator) markCodeLanded(sess *state.Session, prNumber int) {
 	if prNumber > 0 {
 		sess.PRNumber = prNumber
 	}
+	sess.DeploymentFinishedAt = nil
 	o.syncProject(sess.IssueNumber, codeLandedProjectStatus(o.cfg.Outcome.RequiresDeploy))
 	sess.Status = state.StatusCodeLanded
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
 }
 
+func (o *Orchestrator) markDeploymentFinished(sess *state.Session) {
+	if sess == nil {
+		return
+	}
+	now := time.Now().UTC()
+	sess.DeploymentFinishedAt = &now
+	if sess.Status == state.StatusCodeLanded {
+		o.syncProject(sess.IssueNumber, github.ProjectStatusLiveVerify)
+	}
+}
+
+func (o *Orchestrator) markDoneAfterOutcomePass(sess *state.Session, prNumber int) {
+	if sess == nil {
+		return
+	}
+	if prNumber > 0 {
+		sess.PRNumber = prNumber
+	}
+	sess.Status = state.StatusDone
+	now := time.Now().UTC()
+	sess.FinishedAt = &now
+	o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
+}
+
 func (o *Orchestrator) canMarkDoneForOutcome(s *state.State, sess *state.Session, trigger string) bool {
 	if o == nil || o.cfg == nil || !o.cfg.Outcome.PassRequiredForDoneEnabled() {
 		return true
 	}
-	status := outcome.StatusFor(o.cfg.Outcome, s.DonePRCount(), s.LastMergeAt, outcomeHealthChecks(s)...)
+	donePRs := 0
+	var lastMergeAt time.Time
+	if s != nil {
+		donePRs = s.DonePRCount()
+		lastMergeAt = s.LastMergeAt
+	}
+	status := outcome.StatusFor(o.cfg.Outcome, donePRs, lastMergeAt, outcomeHealthChecks(s)...)
 	if status.HealthState == outcome.HealthHealthy {
 		return true
 	}
@@ -2010,6 +2051,14 @@ func (o *Orchestrator) canMarkDoneForOutcome(s *state.State, sess *state.Session
 	return false
 }
 
+func (o *Orchestrator) canTreatIssueDoneForQueue(s *state.State, issueNumber int, reason string) bool {
+	if o.canMarkDoneForOutcome(s, nil, fmt.Sprintf("ordered queue saw issue #%d as done via %s", issueNumber, reason)) {
+		return true
+	}
+	log.Printf("[orch] ordered queue will not advance past issue #%d: %s is not enough until outcome verification passes", issueNumber, reason)
+	return false
+}
+
 func outcomeHealthChecks(s *state.State) []outcome.HealthCheckResult {
 	if s == nil || s.OutcomeHealth == nil {
 		return nil
@@ -2017,7 +2066,7 @@ func outcomeHealthChecks(s *state.State) []outcome.HealthCheckResult {
 	return []outcome.HealthCheckResult{*s.OutcomeHealth}
 }
 
-func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr github.PR) bool {
+func (o *Orchestrator) mergeReadyPR(s *state.State, slotName string, sess *state.Session, pr github.PR) bool {
 	log.Printf("[orch] merging PR #%d (branch %s)", pr.Number, sess.Branch)
 	if err := o.mergePR(pr.Number); err != nil {
 		log.Printf("[orch] merge PR #%d: %v", pr.Number, err)
@@ -2043,6 +2092,9 @@ func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr git
 	}
 
 	log.Printf("[orch] merged PR #%d ✓", pr.Number)
+	if s != nil {
+		s.LastMergeAt = time.Now().UTC()
+	}
 	o.markCodeLanded(sess, pr.Number)
 
 	if o.cfg.ShouldCleanupWorktrees() {
@@ -2066,16 +2118,59 @@ func (o *Orchestrator) mergeReadyPR(slotName string, sess *state.Session, pr git
 	}
 
 	// Deploy hook
+	deploySucceeded := false
 	if o.cfg.DeployCmd != "" {
 		if err := o.runDeployCmd(pr.Number); err != nil {
 			log.Printf("[orch] deploy command failed for PR #%d: %v", pr.Number, err)
 			o.notifier.Sendf("⚠️ maestro: deploy failed after PR #%d merge: %v", pr.Number, err)
 		} else {
+			deploySucceeded = true
+			o.markDeploymentFinished(sess)
 			o.notifier.Sendf("🚀 maestro: deploy succeeded after PR #%d merge", pr.Number)
 		}
+	} else if !o.cfg.Outcome.RequiresDeploy {
+		deploySucceeded = true
+	}
+
+	if o.shouldVerifyOutcomeAfterMerge(deploySucceeded) {
+		o.verifyOutcomeAfterMerge(s, sess, pr.Number)
 	}
 
 	return true
+}
+
+func (o *Orchestrator) shouldVerifyOutcomeAfterMerge(deploySucceeded bool) bool {
+	if o == nil || o.cfg == nil {
+		return false
+	}
+	if !o.cfg.Outcome.PassRequiredForDoneEnabled() || !o.cfg.Outcome.HasHealthSignal() {
+		return false
+	}
+	if o.cfg.Outcome.RequiresDeploy && !deploySucceeded {
+		log.Printf("[orch] skipping immediate outcome verification after merge: deploy is required and has not succeeded yet")
+		return false
+	}
+	return true
+}
+
+func (o *Orchestrator) verifyOutcomeAfterMerge(s *state.State, sess *state.Session, prNumber int) {
+	if s == nil || sess == nil {
+		return
+	}
+	log.Printf("[orch] running outcome verifier after PR #%d merge", prNumber)
+	result := o.checkOutcome(context.Background())
+	s.OutcomeHealth = &result
+	if result.State == outcome.HealthHealthy {
+		log.Printf("[orch] outcome verifier passed after PR #%d; marking issue #%d done", prNumber, sess.IssueNumber)
+		o.markDoneAfterOutcomePass(sess, prNumber)
+		o.notifier.Sendf("✅ maestro: outcome verifier passed after PR #%d; issue #%d can be treated as done", prNumber, sess.IssueNumber)
+		return
+	}
+	if sess.Status == state.StatusCodeLanded {
+		o.syncProject(sess.IssueNumber, github.ProjectStatusLiveVerify)
+	}
+	log.Printf("[orch] outcome verifier after PR #%d is %s: %s", prNumber, result.State, result.Summary)
+	o.notifier.Sendf("⚠️ maestro: outcome verifier after PR #%d is %s: %s", prNumber, result.State, result.Summary)
 }
 
 // runDeployCmd executes the configured deploy command with a configurable timeout.
@@ -2343,6 +2438,9 @@ func (o *Orchestrator) orderedQueueIssueDone(s *state.State, issueNumber int) (b
 		return false, "", fmt.Errorf("check issue closed: %w", err)
 	}
 	if closed {
+		if !o.canTreatIssueDoneForQueue(s, issueNumber, "closed issue") {
+			return false, "issue closed but outcome health is not verified", nil
+		}
 		return true, "issue closed", nil
 	}
 
@@ -2351,6 +2449,9 @@ func (o *Orchestrator) orderedQueueIssueDone(s *state.State, issueNumber int) (b
 		return false, "", fmt.Errorf("check merged PR for issue: %w", err)
 	}
 	if merged {
+		if !o.canTreatIssueDoneForQueue(s, issueNumber, "linked PR merged") {
+			return false, "linked PR merged but outcome health is not verified", nil
+		}
 		return true, "linked PR merged", nil
 	}
 
@@ -2364,7 +2465,11 @@ func (o *Orchestrator) orderedQueueIssueDone(s *state.State, issueNumber int) (b
 			return false, "", fmt.Errorf("check PR #%d merged: %w", sess.PRNumber, err)
 		}
 		if merged {
-			return true, fmt.Sprintf("session %s is %s with merged PR #%d", slotName, sess.Status, sess.PRNumber), nil
+			reason := fmt.Sprintf("session %s is %s with merged PR #%d", slotName, sess.Status, sess.PRNumber)
+			if !o.canTreatIssueDoneForQueue(s, issueNumber, reason) {
+				return false, reason + " but outcome health is not verified", nil
+			}
+			return true, reason, nil
 		}
 	}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -758,6 +759,230 @@ func TestAutoMergePRs_MissingOpenPRDoesNotBecomeDoneWhenOutcomePassRequiredFails
 	sess := s.Sessions["slot-0"]
 	if sess.Status != state.StatusCodeLanded {
 		t.Fatalf("status = %q, want %q until live verification passes", sess.Status, state.StatusCodeLanded)
+	}
+}
+
+func TestMergeReadyPR_RunsOutcomeVerifierAndMarksDoneOnPass(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Outcome: outcome.Brief{
+			DesiredOutcome:      "Live app works",
+			VerifierCommand:     "check-live",
+			PassRequiredForDone: boolPtr(true),
+		},
+	}
+	o, merged := newMergeTestOrchestrator(cfg, []github.PR{{Number: 10, HeadRefName: "feat/a"}})
+	checked := false
+	o.outcomeCheckFn = func(_ context.Context, _ outcome.Brief) outcome.HealthCheckResult {
+		checked = true
+		return outcome.HealthCheckResult{
+			CheckedAt: time.Now().UTC(),
+			State:     outcome.HealthHealthy,
+			Signal:    "healthcheck_command",
+			Summary:   "live verifier passed",
+		}
+	}
+	s := makeTestState([]github.PR{{Number: 10, HeadRefName: "feat/a"}})
+	sess := s.Sessions["slot-0"]
+
+	if !o.mergeReadyPR(s, "slot-0", sess, github.PR{Number: 10, HeadRefName: "feat/a"}) {
+		t.Fatal("mergeReadyPR should return true on successful merge")
+	}
+	if len(*merged) != 1 || (*merged)[0] != 10 {
+		t.Fatalf("merged = %v, want [10]", *merged)
+	}
+	if !checked {
+		t.Fatal("outcome verifier was not run after merge")
+	}
+	if s.OutcomeHealth == nil || s.OutcomeHealth.State != outcome.HealthHealthy {
+		t.Fatalf("OutcomeHealth = %+v, want healthy", s.OutcomeHealth)
+	}
+	if sess.Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q after verifier pass", sess.Status, state.StatusDone)
+	}
+}
+
+func TestMergeReadyPR_KeepsCodeLandedWhenOutcomeVerifierFails(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Outcome: outcome.Brief{
+			DesiredOutcome:      "Live app works",
+			VerifierCommand:     "check-live",
+			PassRequiredForDone: boolPtr(true),
+		},
+	}
+	o, _ := newMergeTestOrchestrator(cfg, []github.PR{{Number: 10, HeadRefName: "feat/a"}})
+	o.outcomeCheckFn = func(_ context.Context, _ outcome.Brief) outcome.HealthCheckResult {
+		return outcome.HealthCheckResult{
+			CheckedAt: time.Now().UTC(),
+			State:     outcome.HealthFailing,
+			Signal:    "healthcheck_command",
+			Summary:   "live verifier failed",
+		}
+	}
+	s := makeTestState([]github.PR{{Number: 10, HeadRefName: "feat/a"}})
+	sess := s.Sessions["slot-0"]
+
+	if !o.mergeReadyPR(s, "slot-0", sess, github.PR{Number: 10, HeadRefName: "feat/a"}) {
+		t.Fatal("mergeReadyPR should return true on successful merge")
+	}
+	if s.OutcomeHealth == nil || s.OutcomeHealth.State != outcome.HealthFailing {
+		t.Fatalf("OutcomeHealth = %+v, want failing", s.OutcomeHealth)
+	}
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q until verifier passes", sess.Status, state.StatusCodeLanded)
+	}
+}
+
+func TestMergeReadyPR_SkipsImmediateOutcomeVerifierWhenDeployRequiredButNotDone(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Outcome: outcome.Brief{
+			DesiredOutcome:      "Live app works",
+			VerifierCommand:     "check-live",
+			RequiresDeploy:      true,
+			PassRequiredForDone: boolPtr(true),
+		},
+	}
+	o, _ := newMergeTestOrchestrator(cfg, []github.PR{{Number: 10, HeadRefName: "feat/a"}})
+	o.outcomeCheckFn = func(_ context.Context, _ outcome.Brief) outcome.HealthCheckResult {
+		t.Fatal("outcome verifier should wait until deploy succeeds")
+		return outcome.HealthCheckResult{}
+	}
+	s := makeTestState([]github.PR{{Number: 10, HeadRefName: "feat/a"}})
+	sess := s.Sessions["slot-0"]
+
+	if !o.mergeReadyPR(s, "slot-0", sess, github.PR{Number: 10, HeadRefName: "feat/a"}) {
+		t.Fatal("mergeReadyPR should return true on successful merge")
+	}
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q while deploy is pending", sess.Status, state.StatusCodeLanded)
+	}
+	if sess.DeploymentFinishedAt != nil {
+		t.Fatalf("DeploymentFinishedAt = %v, want nil before deploy succeeds", sess.DeploymentFinishedAt)
+	}
+	if s.OutcomeHealth != nil {
+		t.Fatalf("OutcomeHealth = %+v, want nil before deploy succeeds", s.OutcomeHealth)
+	}
+}
+
+func TestMergeReadyPR_RunsOutcomeVerifierAfterDeploySucceeds(t *testing.T) {
+	cfg := &config.Config{
+		Repo:                 "owner/repo",
+		DeployCmd:            "true",
+		DeployTimeoutMinutes: 1,
+		Outcome: outcome.Brief{
+			DesiredOutcome:      "Live app works",
+			VerifierCommand:     "check-live",
+			RequiresDeploy:      true,
+			PassRequiredForDone: boolPtr(true),
+		},
+	}
+	o, _ := newMergeTestOrchestrator(cfg, []github.PR{{Number: 10, HeadRefName: "feat/a"}})
+	checked := false
+	o.outcomeCheckFn = func(_ context.Context, _ outcome.Brief) outcome.HealthCheckResult {
+		checked = true
+		return outcome.HealthCheckResult{
+			CheckedAt: time.Now().UTC(),
+			State:     outcome.HealthHealthy,
+			Signal:    "healthcheck_command",
+			Summary:   "live verifier passed",
+		}
+	}
+	s := makeTestState([]github.PR{{Number: 10, HeadRefName: "feat/a"}})
+	sess := s.Sessions["slot-0"]
+
+	if !o.mergeReadyPR(s, "slot-0", sess, github.PR{Number: 10, HeadRefName: "feat/a"}) {
+		t.Fatal("mergeReadyPR should return true on successful merge")
+	}
+	if !checked {
+		t.Fatal("outcome verifier was not run after deploy succeeded")
+	}
+	if sess.DeploymentFinishedAt == nil {
+		t.Fatal("DeploymentFinishedAt should be recorded after deploy succeeds")
+	}
+	if sess.Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q after deploy and verifier pass", sess.Status, state.StatusDone)
+	}
+}
+
+func TestOrderedQueueIssueDone_MergedPRWaitsForOutcomeWhenPassRequired(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Outcome: outcome.Brief{
+			DesiredOutcome:      "Live app works",
+			VerifierCommand:     "check-live",
+			PassRequiredForDone: boolPtr(true),
+		},
+	}
+	o := &Orchestrator{
+		cfg: cfg,
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
+			return true, nil
+		},
+	}
+	mergedAt := time.Now().UTC().Add(-time.Minute)
+	s := state.NewState()
+	s.LastMergeAt = mergedAt
+	s.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: time.Now().UTC(),
+		State:     outcome.HealthFailing,
+		Signal:    "healthcheck_command",
+		Summary:   "live verifier failed",
+	}
+
+	done, reason, err := o.orderedQueueIssueDone(s, 42)
+	if err != nil {
+		t.Fatalf("orderedQueueIssueDone error: %v", err)
+	}
+	if done {
+		t.Fatalf("done = true, want false while outcome is failing")
+	}
+	if !strings.Contains(reason, "outcome health is not verified") {
+		t.Fatalf("reason = %q, want outcome gate reason", reason)
+	}
+}
+
+func TestOrderedQueueIssueDone_MergedPRAllowedAfterOutcomePass(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Outcome: outcome.Brief{
+			DesiredOutcome:      "Live app works",
+			VerifierCommand:     "check-live",
+			PassRequiredForDone: boolPtr(true),
+		},
+	}
+	o := &Orchestrator{
+		cfg: cfg,
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
+			return true, nil
+		},
+	}
+	mergedAt := time.Now().UTC().Add(-time.Minute)
+	s := state.NewState()
+	s.LastMergeAt = mergedAt
+	s.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: time.Now().UTC(),
+		State:     outcome.HealthHealthy,
+		Signal:    "healthcheck_command",
+		Summary:   "live verifier passed",
+	}
+
+	done, reason, err := o.orderedQueueIssueDone(s, 42)
+	if err != nil {
+		t.Fatalf("orderedQueueIssueDone error: %v", err)
+	}
+	if !done {
+		t.Fatalf("done = false, want true after outcome pass")
+	}
+	if reason != "linked PR merged" {
+		t.Fatalf("reason = %q, want linked PR merged", reason)
 	}
 }
 
@@ -1989,7 +2214,7 @@ func TestMergeReadyPR_BehindMainTriggersRebase(t *testing.T) {
 	}
 	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
 
-	result := o.mergeReadyPR("slot-0", sess, pr)
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
 
 	if result {
 		t.Fatal("mergeReadyPR should return false when merge fails")
@@ -2028,7 +2253,7 @@ func TestMergeReadyPR_BehindMainRebaseFailsMarksConflict(t *testing.T) {
 	}
 	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
 
-	result := o.mergeReadyPR("slot-0", sess, pr)
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
 
 	if result {
 		t.Fatal("mergeReadyPR should return false when rebase fails")
@@ -2149,7 +2374,7 @@ func TestMergeReadyPR_BehindMainNoAutoRebase(t *testing.T) {
 	}
 	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
 
-	result := o.mergeReadyPR("slot-0", sess, pr)
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
 
 	if result {
 		t.Fatal("mergeReadyPR should return false")
@@ -2186,7 +2411,7 @@ func TestMergeReadyPR_OtherMergeErrorNoRebase(t *testing.T) {
 	}
 	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
 
-	result := o.mergeReadyPR("slot-0", sess, pr)
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
 
 	if result {
 		t.Fatal("mergeReadyPR should return false")
@@ -2457,7 +2682,7 @@ func TestMergeReadyPR_CleansUpWorktreeOnMerge(t *testing.T) {
 	}
 	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
 
-	result := o.mergeReadyPR("slot-0", sess, pr)
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
 
 	if !result {
 		t.Fatal("mergeReadyPR should return true on successful merge")
@@ -2504,7 +2729,7 @@ func TestMergeReadyPR_SkipsCleanupWhenDisabled(t *testing.T) {
 	}
 	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
 
-	result := o.mergeReadyPR("slot-0", sess, pr)
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
 
 	if !result {
 		t.Fatal("mergeReadyPR should return true on successful merge")
@@ -2550,7 +2775,7 @@ func TestMergeReadyPR_DefaultConfigCleansUp(t *testing.T) {
 	}
 	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
 
-	result := o.mergeReadyPR("slot-0", sess, pr)
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
 
 	if !result {
 		t.Fatal("mergeReadyPR should return true on successful merge")
@@ -5187,6 +5412,7 @@ func TestSyncProject_DisabledWhenNoProjectNumber(t *testing.T) {
 
 func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
 	soon := time.Now().UTC().Add(30 * time.Second)
+	deployed := time.Now().UTC()
 
 	tests := []struct {
 		name           string
@@ -5201,6 +5427,7 @@ func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
 		{name: "pr_open -> in_review", sess: &state.Session{IssueNumber: 3, Status: state.StatusPROpen, PRNumber: 9}, want: github.ProjectStatusInReview, wantOK: true},
 		{name: "code_landed -> live_verification without deploy", sess: &state.Session{IssueNumber: 4, Status: state.StatusCodeLanded, PRNumber: 10}, want: github.ProjectStatusLiveVerify, wantOK: true},
 		{name: "code_landed -> deploying when deploy required", sess: &state.Session{IssueNumber: 4, Status: state.StatusCodeLanded, PRNumber: 10}, requiresDeploy: true, want: github.ProjectStatusDeploying, wantOK: true},
+		{name: "code_landed -> live_verification after deploy succeeds", sess: &state.Session{IssueNumber: 4, Status: state.StatusCodeLanded, PRNumber: 10, DeploymentFinishedAt: &deployed}, requiresDeploy: true, want: github.ProjectStatusLiveVerify, wantOK: true},
 		{name: "done -> done", sess: &state.Session{IssueNumber: 5, Status: state.StatusDone}, want: github.ProjectStatusDone, wantOK: true},
 		{name: "retry_exhausted -> blocked", sess: &state.Session{IssueNumber: 6, Status: state.StatusRetryExhausted}, want: github.ProjectStatusBlocked, wantOK: true},
 		{name: "conflict_failed -> blocked", sess: &state.Session{IssueNumber: 7, Status: state.StatusConflictFailed}, want: github.ProjectStatusBlocked, wantOK: true},

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -85,6 +85,7 @@ type Session struct {
 	PreviousAttemptFeedbackKind string        `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
 	RetryReason                 string        `json:"retry_reason,omitempty"`                   // current retry lifecycle reason, e.g. review_feedback
 	CheckpointFile              string        `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
+	DeploymentFinishedAt        *time.Time    `json:"deployment_finished_at,omitempty"`         // set when the post-merge deploy hook succeeds
 }
 
 // SessionAttention explains why a session needs operator attention and the


### PR DESCRIPTION
Summary:
- run outcome verifier immediately after merge when deploy is not required
- after a successful deploy hook, record deployment_finished_at, move Project to Live Verification, and mark Done only on verifier pass
- keep deploy-required merged work out of Done until deploy is proven
- keep ordered queue from advancing on merged PR / closed issue unless outcome pass is current when pass_required_for_done is enabled

Tests:
- go test ./internal/orchestrator
- go test ./...

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the outcome verifier directly into the merge path: for no-deploy configs it runs immediately after merge, and for deploy-required configs it runs after a successful deploy hook, recording `DeploymentFinishedAt` and advancing the project card to Live Verification before marking Done only on verifier pass.

- `mergeReadyPR` now accepts `*state.State`, sets `LastMergeAt` internally, and calls `verifyOutcomeAfterMerge` when conditions are met; new helpers `markDeploymentFinished` and `markDoneAfterOutcomePass` manage the state transitions cleanly.
- `codeLandedProjectStatusForSession` makes the project-card sync aware of whether a deploy has already finished, so subsequent reconciliation cycles reflect the correct phase.
- `orderedQueueIssueDone` now gates queue advancement behind `canTreatIssueDoneForQueue`, blocking the ordered queue from advancing past an issue until the global outcome health is verified.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all state transitions and queue gates behave correctly under the new flow, with good test coverage for the key scenarios.

The core logic is sound. The three findings are all in notification/sync behaviour: a remains-open message is sent before the verifier runs and can be immediately contradicted when the verifier passes in the same call; the redundant syncProject call in the failure path fires on every verifier miss even though the project card is already in the correct state; and the done-notification wording says can be treated as done after the transition has already completed. None of these affect persistent state correctness or the Done/CodeLanded status machine.

internal/orchestrator/orchestrator.go — specifically the notification ordering in mergeReadyPR and the redundant sync in verifyOutcomeAfterMerge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Core merge flow updated to run the outcome verifier synchronously after merge (and optionally after deploy). New helpers correctly gate Done status behind verifier pass. A redundant syncProject call exists in the verifier-failure path, and the unconditional remains-open notification can be immediately contradicted when the verifier passes in the same call. |
| internal/orchestrator/orchestrator_test.go | Six new focused test cases cover the key scenarios: no-deploy verifier pass/fail, deploy-required skip, deploy-succeeded verifier run, and ordered-queue gate blocking/allowing. Existing tests updated to pass the new state argument to mergeReadyPR. |
| internal/state/state.go | Adds DeploymentFinishedAt *time.Time to Session for tracking successful post-merge deploy hook completion; field is optional and JSON-omitted when nil. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 2108 ([link](https://github.com/befeast/maestro/blob/8b7b2355124fe5e2475a38cbe31938e86f804b04/internal/orchestrator/orchestrator.go#L2108)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Misleading merge notification precedes immediate done marking**

   The "issue remains open for runtime verification" message is sent unconditionally before `verifyOutcomeAfterMerge` is called. When no deploy is required and the outcome verifier passes immediately, the user receives this "remains open" notification followed almost instantly by the "outcome verifier passed; issue can be treated as done" notification. In practice this contradicts the first message and can confuse humans or downstream automation that monitors for the "remains open" signal as a final state.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 2108

   Comment:
   **Misleading merge notification precedes immediate done marking**

   The "issue remains open for runtime verification" message is sent unconditionally before `verifyOutcomeAfterMerge` is called. When no deploy is required and the outcome verifier passes immediately, the user receives this "remains open" notification followed almost instantly by the "outcome verifier passed; issue can be treated as done" notification. In practice this contradicts the first message and can confuse humans or downstream automation that monitors for the "remains open" signal as a final state.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/orchestrator/orchestrator.go:2108
**Misleading merge notification precedes immediate done marking**

The "issue remains open for runtime verification" message is sent unconditionally before `verifyOutcomeAfterMerge` is called. When no deploy is required and the outcome verifier passes immediately, the user receives this "remains open" notification followed almost instantly by the "outcome verifier passed; issue can be treated as done" notification. In practice this contradicts the first message and can confuse humans or downstream automation that monitors for the "remains open" signal as a final state.

### Issue 2 of 3
internal/orchestrator/orchestrator.go:2169-2171
**Redundant `syncProject` call in failure path**

By the time execution reaches this block, the project card is already in `LiveVerify`. On the no-deploy path `markCodeLanded` already called `syncProject(…, ProjectStatusLiveVerify)`. On the deploy-succeeded path `markDeploymentFinished` did the same. Because `StatusCodeLanded` is still set here (status is only changed to Done on pass), the guard condition is always true and the call always fires, causing an unnecessary redundant GitHub Projects API round-trip on every verifier failure.

### Issue 3 of 3
internal/orchestrator/orchestrator.go:2166
**Notification phrasing is stale at send time**

`markDoneAfterOutcomePass` has already set `sess.Status = state.StatusDone` and called `syncProject(…, ProjectStatusDone)` before this `Sendf` fires. The message "can be treated as done" implies the transition is pending, but it has already occurred. The phrasing should reflect the completed state (e.g. "has been marked done").


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Run outcome verifier after merge deploy"](https://github.com/befeast/maestro/commit/8b7b2355124fe5e2475a38cbe31938e86f804b04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32531074)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->