### PR TITLE
Keep project lifecycle statuses explicit

### DIFF
--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -42,9 +42,9 @@ func ProjectStatusCandidates(status ProjectStatus) []string {
 	case ProjectStatusBlocked:
 		return []string{"Blocked", "On Hold", "On hold", "Stuck", "Needs Attention", "Needs attention"}
 	case ProjectStatusDeploying:
-		return []string{"Deploying", "Deploy", "Deployment", "In Progress", "In progress"}
+		return []string{"Deploying", "Deploy", "Deployment"}
 	case ProjectStatusLiveVerify:
-		return []string{"Live Verification", "Live verification", "Verification", "Verifying", "QA", "In Progress", "In progress"}
+		return []string{"Live Verification", "Live verification", "Verification", "Verifying", "QA"}
 	case ProjectStatusDone:
 		return []string{"Done", "Completed", "Closed"}
 	default:

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -104,6 +104,8 @@ func TestProjectStatusCandidates(t *testing.T) {
 		{ProjectStatusInProgress, "In Progress"},
 		{ProjectStatusInReview, "In Review"},
 		{ProjectStatusBlocked, "Blocked"},
+		{ProjectStatusDeploying, "Deploying"},
+		{ProjectStatusLiveVerify, "Live Verification"},
 		{ProjectStatusDone, "Done"},
 	}
 	for _, tc := range tests {
@@ -113,6 +115,16 @@ func TestProjectStatusCandidates(t *testing.T) {
 		}
 		if got[0] != tc.wantFirst {
 			t.Errorf("ProjectStatusCandidates(%q) first = %q, want %q", tc.status, got[0], tc.wantFirst)
+		}
+	}
+}
+
+func TestProjectStatusCandidates_LifecycleStatusesDoNotCollapseToInProgress(t *testing.T) {
+	for _, status := range []ProjectStatus{ProjectStatusDeploying, ProjectStatusLiveVerify} {
+		for _, candidate := range ProjectStatusCandidates(status) {
+			if strings.EqualFold(strings.TrimSpace(candidate), "In Progress") {
+				t.Fatalf("ProjectStatusCandidates(%q) includes %q; lifecycle status must not silently collapse to In Progress", status, candidate)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Summary:
- stop mapping Deploying / Live Verification Project lifecycle intents to In Progress
- keep lifecycle Project sync explicit so missing board options show up as sync misses instead of false status

Tests:
- go test ./internal/github ./internal/orchestrator
- go test ./...

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the "In Progress" / "In progress" fallback candidates from `ProjectStatusDeploying` and `ProjectStatusLiveVerify` in `ProjectStatusCandidates`, ensuring boards that lack dedicated lifecycle columns are reported as sync misses rather than silently settling on the wrong status. A companion regression test guards against the removed mappings being reintroduced.

- **`github_projects.go`**: `Deploying` candidates trimmed to `[\"Deploying\", \"Deploy\", \"Deployment\"]`; `LiveVerify` candidates trimmed to `[\"Live Verification\", \"Live verification\", \"Verification\", \"Verifying\", \"QA\"]`.
- **`github_projects_test.go`**: New table-driven entries for both statuses, plus `TestProjectStatusCandidates_LifecycleStatusesDoNotCollapseToInProgress` which iterates all candidates and fails if any equals "In Progress" (case-insensitive).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes two fallback candidates from a lookup list and the regression test locks in the new behavior.

The modification is minimal and intentional: two string slices are shortened and a dedicated test prevents the removed entries from coming back. No callers are broken because boards missing the new, narrower candidates will now log a skip instead of setting a misleading status — which is exactly the desired outcome described in the PR.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github_projects.go | Removes "In Progress"/"In progress" fallback from Deploying and LiveVerify candidate lists, so boards without those columns surface a sync miss instead of silently mapping to a generic status. |
| internal/github/github_projects_test.go | Adds two new test cases for Deploying/LiveVerify in the existing table-driven test, plus a dedicated regression test asserting neither lifecycle status includes "In Progress" as a candidate. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Keep project lifecycle statuses explicit"](https://github.com/befeast/maestro/commit/a9c2dcc294a58b75857f587e6e6267fe6bc54842) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32531523)</sub>

<!-- /greptile_comment -->