### PR TITLE
Gate supervisor queue completion on outcome pass

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1235,6 +1235,9 @@ func (e *Engine) dynamicWaveSkipReason(st *state.State, issue github.Issue) (str
 		return "already in progress", dynamicSkipOther, nil
 	}
 	if st.IssueDone(issue.Number) {
+		if !e.canTreatIssueDoneForOutcome(st) {
+			return "", dynamicSkipOther, nil
+		}
 		return "already completed in state", dynamicSkipOther, nil
 	}
 	if st.IssueRetryExhausted(issue.Number) {
@@ -1285,6 +1288,9 @@ func (e *Engine) orderedQueueIssueDone(st *state.State, issueNumber int) (bool, 
 		return false, "", fmt.Errorf("check issue closed: %w", err)
 	}
 	if closed {
+		if !e.canTreatIssueDoneForOutcome(st) {
+			return false, "issue is closed but outcome health is not verified", nil
+		}
 		return true, "issue is closed", nil
 	}
 
@@ -1298,7 +1304,11 @@ func (e *Engine) orderedQueueIssueDone(st *state.State, issueNumber int) (bool, 
 			return false, "", fmt.Errorf("check PR #%d merged: %w", sess.PRNumber, err)
 		}
 		if merged {
-			return true, fmt.Sprintf("session %s is %s with merged PR #%d", slot, sess.Status, sess.PRNumber), nil
+			reason := fmt.Sprintf("session %s is %s with merged PR #%d", slot, sess.Status, sess.PRNumber)
+			if !e.canTreatIssueDoneForOutcome(st) {
+				return false, reason + " but outcome health is not verified", nil
+			}
+			return true, reason, nil
 		}
 	}
 
@@ -1307,10 +1317,20 @@ func (e *Engine) orderedQueueIssueDone(st *state.State, issueNumber int) (bool, 
 		return false, "", fmt.Errorf("check merged PR for issue: %w", err)
 	}
 	if merged {
+		if !e.canTreatIssueDoneForOutcome(st) {
+			return false, "linked PR merged but outcome health is not verified", nil
+		}
 		return true, "linked PR merged", nil
 	}
 
 	return false, "", nil
+}
+
+func (e *Engine) canTreatIssueDoneForOutcome(st *state.State) bool {
+	if e == nil || e.cfg == nil || !e.cfg.Outcome.PassRequiredForDoneEnabled() {
+		return true
+	}
+	return e.outcomeStatus(st).HealthState == outcome.HealthHealthy
 }
 
 func validateOrderedQueueIssues(issues []int) error {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -214,6 +214,10 @@ func testIssue(number int, title string, labels ...string) github.Issue {
 	return issue
 }
 
+func boolPtr(v bool) *bool {
+	return &v
+}
+
 func withProjectStatus(issue github.Issue, status string) github.Issue {
 	issue.ProjectItems = []github.IssueProjectItem{{
 		Title: "Maestro",
@@ -1583,6 +1587,117 @@ func TestDecide_OrderedQueueSelectsFirstUnfinishedIssue(t *testing.T) {
 	}
 	if decision.Target == nil || decision.Target.Issue != 306 {
 		t.Fatalf("target = %#v, want issue 306", decision.Target)
+	}
+}
+
+func TestOrderedQueueIssueDone_ClosedIssueWaitsForOutcomeWhenRequired(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:      "Live app works",
+		VerifierCommand:     "check-live",
+		PassRequiredForDone: boolPtr(true),
+	}
+	reader := &fakeReader{closedIssues: map[int]bool{308: true}}
+	st := state.NewState()
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: time.Now().UTC(),
+		State:     outcome.HealthFailing,
+		Signal:    "healthcheck_command",
+		Summary:   "live verifier failed",
+	}
+
+	done, reason, err := testEngine(cfg, reader).orderedQueueIssueDone(st, 308)
+	if err != nil {
+		t.Fatalf("orderedQueueIssueDone: %v", err)
+	}
+	if done {
+		t.Fatalf("done = true, want false while outcome is failing")
+	}
+	if !strings.Contains(reason, "outcome health is not verified") {
+		t.Fatalf("reason = %q, want outcome gate reason", reason)
+	}
+}
+
+func TestOrderedQueueIssueDone_MergedPRWaitsForOutcomeWhenRequired(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:      "Live app works",
+		VerifierCommand:     "check-live",
+		PassRequiredForDone: boolPtr(true),
+	}
+	reader := &fakeReader{mergedPRIssues: map[int]bool{308: true}}
+	st := state.NewState()
+	st.LastMergeAt = time.Now().UTC().Add(-time.Minute)
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: time.Now().UTC(),
+		State:     outcome.HealthFailing,
+		Signal:    "healthcheck_command",
+		Summary:   "live verifier failed",
+	}
+
+	done, reason, err := testEngine(cfg, reader).orderedQueueIssueDone(st, 308)
+	if err != nil {
+		t.Fatalf("orderedQueueIssueDone: %v", err)
+	}
+	if done {
+		t.Fatalf("done = true, want false while outcome is failing")
+	}
+	if !strings.Contains(reason, "outcome health is not verified") {
+		t.Fatalf("reason = %q, want outcome gate reason", reason)
+	}
+}
+
+func TestOrderedQueueIssueDone_MergedPRAllowedAfterOutcomePass(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:      "Live app works",
+		VerifierCommand:     "check-live",
+		PassRequiredForDone: boolPtr(true),
+	}
+	reader := &fakeReader{mergedPRIssues: map[int]bool{308: true}}
+	st := state.NewState()
+	st.LastMergeAt = time.Now().UTC().Add(-time.Minute)
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: time.Now().UTC(),
+		State:     outcome.HealthHealthy,
+		Signal:    "healthcheck_command",
+		Summary:   "live verifier passed",
+	}
+
+	done, reason, err := testEngine(cfg, reader).orderedQueueIssueDone(st, 308)
+	if err != nil {
+		t.Fatalf("orderedQueueIssueDone: %v", err)
+	}
+	if !done {
+		t.Fatalf("done = false, want true after outcome pass")
+	}
+	if reason != "linked PR merged" {
+		t.Fatalf("reason = %q, want linked PR merged", reason)
+	}
+}
+
+func TestDynamicWaveDoneStateDoesNotSkipWhenOutcomeNotVerified(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:      "Live app works",
+		VerifierCommand:     "check-live",
+		PassRequiredForDone: boolPtr(true),
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{IssueNumber: 42, Status: state.StatusDone, PRNumber: 12}
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: time.Now().UTC(),
+		State:     outcome.HealthFailing,
+		Signal:    "healthcheck_command",
+		Summary:   "live verifier failed",
+	}
+
+	reason, _, err := testEngine(cfg, &fakeReader{}).dynamicWaveSkipReason(st, testIssue(42, "done issue", "maestro-ready"))
+	if err != nil {
+		t.Fatalf("dynamicWaveSkipReason: %v", err)
+	}
+	if reason != "" {
+		t.Fatalf("reason = %q, want no done-state skip until outcome passes", reason)
 	}
 }
 


### PR DESCRIPTION
Summary:
- gate supervisor ordered queue completion on outcome health when pass_required_for_done is enabled
- prevent closed issues, linked merged PRs, and state-done sessions from advancing queues without a current outcome pass
- add regression tests for failing and passing outcome states

Tests:
- go test ./internal/supervisor
- go test ./...

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates ordered-queue and dynamic-wave completion on a passing outcome health check when `pass_required_for_done` is enabled, preventing closed issues, sessions with merged PRs, and state-done entries from advancing the queue while the runtime outcome is unhealthy.

- Introduces `canTreatIssueDoneForOutcome`, which short-circuits to `true` when the feature flag is off and otherwise checks `outcome.HealthHealthy` against the current `outcomeStatus`.
- Applies the gate in four distinct `orderedQueueIssueDone` and `dynamicWaveSkipReason` code paths, each returning a descriptive \"outcome health is not verified\" reason string rather than a done signal.
- Adds four tests covering the closed-issue, linked-PR, and dynamic-wave-done paths under failing and healthy outcome states.

<h3>Confidence Score: 4/5</h3>

The core logic is consistent and the new helper correctly defers to the existing outcomeStatus machinery; the one untested path (session-loop PR merge) is low-risk but worth covering before this ships.

The session-loop branch inside orderedQueueIssueDone — where a done session with a merged PR is checked via IsPRMerged — received the same outcome gate as the other three paths but has no corresponding test. The other three gated paths are well-exercised by the new tests. All production logic changes are confined to the supervisor package.

internal/supervisor/supervisor_test.go — the session-loop IsPRMerged branch in orderedQueueIssueDone is changed but untested.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds `canTreatIssueDoneForOutcome` helper and gates four "done" conditions (closed issue, session-level merged PR, linked merged PR, dynamic-wave done state) on `PassRequiredForDone` outcome health; logic is consistent across the ordered-queue and dynamic-wave paths. |
| internal/supervisor/supervisor_test.go | Adds four regression tests for the new outcome gate; covers closed-issue, linked-PR, and dynamic-wave-done paths, but does not cover the session-loop `IsPRMerged` branch that was also changed. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/supervisor_test.go:1620-1648
**Session-level merged PR path not covered by tests**

`TestOrderedQueueIssueDone_MergedPRWaitsForOutcomeWhenRequired` and `TestOrderedQueueIssueDone_MergedPRAllowedAfterOutcomePass` both use `mergedPRIssues`, which drives the `HasMergedPRForIssue` branch at the bottom of `orderedQueueIssueDone`. The session-loop path — where `IsPRMerged(sess.PRNumber)` is called for sessions in `StatusDone`/`StatusCodeLanded` state — exercises different code and a different return message (`"session %s is %s with merged PR #%d … but outcome health is not verified"`). That path received the same outcome gate logic in this PR but has no test exercising the failing or passing outcome case. A test using `fakeReader{mergedPRs: map[int]bool{<prNumber>: true}}` with a matching done session in `st.Sessions` would cover it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Gate supervisor queue completion on outc..."](https://github.com/befeast/maestro/commit/f2562d2caedfe13260fdfe51b9551dbc2b285945) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32532489)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->