### PR TITLE
Cache project status sync transitions

### DIFF
--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -252,37 +252,42 @@ func (c *Client) SyncIssueStatus(pf *ProjectField, issueNumber int, statusName s
 // that use a different label ("Review", "Code Review"). When no candidate
 // matches, the call is a no-op so the worker runtime keeps making progress.
 func (c *Client) SyncIssueStatusOneOf(pf *ProjectField, issueNumber int, candidates ...string) {
+	_ = c.TrySyncIssueStatusOneOf(pf, issueNumber, candidates...)
+}
+
+func (c *Client) TrySyncIssueStatusOneOf(pf *ProjectField, issueNumber int, candidates ...string) bool {
 	if pf == nil {
-		return
+		return false
 	}
 
 	statusName, optionID, ok := resolveProjectStatusOption(pf, candidates)
 	if !ok {
 		log.Printf("[projects] none of statuses %v found in project (have: %v), skipping issue #%d", candidates, keys(pf.Options), issueNumber)
-		return
+		return false
 	}
 
 	// Step 1: Get issue node ID
 	nodeID, err := c.getIssueNodeID(issueNumber)
 	if err != nil {
 		log.Printf("[projects] could not get node ID for issue #%d: %v", issueNumber, err)
-		return
+		return false
 	}
 
 	// Step 2: Add issue to project (idempotent)
 	itemID, err := c.addToProject(pf.ProjectID, nodeID)
 	if err != nil {
 		log.Printf("[projects] could not add issue #%d to project: %v", issueNumber, err)
-		return
+		return false
 	}
 
 	// Step 3: Set status field
 	if err := c.setProjectItemStatus(pf.ProjectID, itemID, pf.FieldID, optionID); err != nil {
 		log.Printf("[projects] could not set status for issue #%d: %v", issueNumber, err)
-		return
+		return false
 	}
 
 	log.Printf("[projects] synced issue #%d status=%q", issueNumber, statusName)
+	return true
 }
 
 // getIssueNodeID retrieves the GraphQL node ID for an issue.

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -215,6 +215,13 @@ func TestSyncIssueStatusOneOf_NilProjectField(t *testing.T) {
 	c.SyncIssueStatusOneOf(nil, 1, "In Review", "Review", "In Progress")
 }
 
+func TestTrySyncIssueStatusOneOf_NilProjectField(t *testing.T) {
+	c := New("owner/repo")
+	if c.TrySyncIssueStatusOneOf(nil, 1, "In Review") {
+		t.Fatal("TrySyncIssueStatusOneOf should report false for nil project field")
+	}
+}
+
 func TestNormalizeProjectStatusKey(t *testing.T) {
 	tests := []struct {
 		in, want string

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -87,6 +87,7 @@ type Orchestrator struct {
 	workerStopFn                func(cfg *config.Config, slotName string, sess *state.Session) error
 	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
 	outcomeCheckFn              func(context.Context, outcome.Brief) outcome.HealthCheckResult
+	syncProjectFn               func(issueNumber int, status github.ProjectStatus) bool
 }
 
 // New creates a new Orchestrator
@@ -378,16 +379,19 @@ func (o *Orchestrator) ensureProjectField() {
 
 // syncProject syncs an issue's status to the configured GitHub Project board.
 // No-op if github_projects is not enabled.
-func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus) {
+func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus) bool {
 	if !o.cfg.GitHubProjects.Enabled || o.cfg.GitHubProjects.ProjectNumber == 0 {
-		return
+		return false
+	}
+	if o.syncProjectFn != nil {
+		return o.syncProjectFn(issueNumber, status)
 	}
 	o.ensureProjectField()
 	candidates := github.ProjectStatusCandidates(status)
 	if len(candidates) == 0 {
 		candidates = []string{string(status)}
 	}
-	o.gh.SyncIssueStatusOneOf(o.projectField, issueNumber, candidates...)
+	return o.gh.TrySyncIssueStatusOneOf(o.projectField, issueNumber, candidates...)
 }
 
 // projectStatusForSession returns the ProjectStatus that should mirror this
@@ -505,7 +509,12 @@ func (o *Orchestrator) reconcileSessionsToProjectBoard(s *state.State) {
 		if status == github.ProjectStatusDone {
 			continue
 		}
-		o.syncProject(issue, status)
+		if s.ProjectStatusSynced(issue, string(status)) {
+			continue
+		}
+		if o.syncProject(issue, status) {
+			s.MarkProjectStatusSynced(issue, string(status), time.Now().UTC())
+		}
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5410,6 +5410,46 @@ func TestSyncProject_DisabledWhenNoProjectNumber(t *testing.T) {
 	o.syncProject(42, github.ProjectStatusInProgress)
 }
 
+func TestReconcileSessionsToProjectBoard_SkipsAlreadySyncedStatus(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		GitHubProjects: config.GitHubProjectsConfig{
+			Enabled:       true,
+			ProjectNumber: 3,
+		},
+	}
+	calls := 0
+	var lastStatus github.ProjectStatus
+	o := &Orchestrator{
+		cfg: cfg,
+		syncProjectFn: func(issueNumber int, status github.ProjectStatus) bool {
+			calls++
+			lastStatus = status
+			return true
+		},
+	}
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{IssueNumber: 42, Status: state.StatusRunning}
+	s.MarkProjectStatusSynced(42, string(github.ProjectStatusInProgress), time.Now().UTC())
+
+	o.reconcileSessionsToProjectBoard(s)
+	if calls != 0 {
+		t.Fatalf("sync calls = %d, want 0 for already-synced status", calls)
+	}
+
+	s.Sessions["slot-1"].Status = state.StatusPROpen
+	o.reconcileSessionsToProjectBoard(s)
+	if calls != 1 {
+		t.Fatalf("sync calls = %d, want 1 after status transition", calls)
+	}
+	if lastStatus != github.ProjectStatusInReview {
+		t.Fatalf("last status = %q, want %q", lastStatus, github.ProjectStatusInReview)
+	}
+	if !s.ProjectStatusSynced(42, string(github.ProjectStatusInReview)) {
+		t.Fatal("state did not record synced in_review status")
+	}
+}
+
 func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
 	soon := time.Now().UTC().Add(30 * time.Second)
 	deployed := time.Now().UTC()

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -564,6 +564,7 @@ type State struct {
 	SupervisorDecisions []SupervisorDecision       `json:"supervisor_decisions,omitempty"`
 	Approvals           []Approval                 `json:"approvals,omitempty"`
 	OutcomeHealth       *outcome.HealthCheckResult `json:"outcome_health,omitempty"`
+	ProjectStatusSync   map[int]ProjectStatusSync  `json:"project_status_sync,omitempty"`
 	NextSlot            int                        `json:"next_slot"`
 	LastMergeAt         time.Time                  `json:"last_merge_at,omitempty"`
 
@@ -571,11 +572,38 @@ type State struct {
 	loadedState *State
 }
 
+type ProjectStatusSync struct {
+	Status   string    `json:"status"`
+	SyncedAt time.Time `json:"synced_at,omitempty"`
+}
+
 func NewState() *State {
 	return &State{
-		Sessions: make(map[string]*Session),
-		Missions: make(map[int]*Mission),
-		NextSlot: 1,
+		Sessions:          make(map[string]*Session),
+		Missions:          make(map[int]*Mission),
+		ProjectStatusSync: make(map[int]ProjectStatusSync),
+		NextSlot:          1,
+	}
+}
+
+func (s *State) ProjectStatusSynced(issueNumber int, status string) bool {
+	if s == nil || issueNumber <= 0 || strings.TrimSpace(status) == "" {
+		return false
+	}
+	record, ok := s.ProjectStatusSync[issueNumber]
+	return ok && record.Status == status
+}
+
+func (s *State) MarkProjectStatusSynced(issueNumber int, status string, syncedAt time.Time) {
+	if s == nil || issueNumber <= 0 || strings.TrimSpace(status) == "" {
+		return
+	}
+	if s.ProjectStatusSync == nil {
+		s.ProjectStatusSync = make(map[int]ProjectStatusSync)
+	}
+	s.ProjectStatusSync[issueNumber] = ProjectStatusSync{
+		Status:   status,
+		SyncedAt: syncedAt.UTC(),
 	}
 }
 
@@ -713,6 +741,9 @@ func (s *State) normalize() {
 	if s.Missions == nil {
 		s.Missions = make(map[int]*Mission)
 	}
+	if s.ProjectStatusSync == nil {
+		s.ProjectStatusSync = make(map[int]ProjectStatusSync)
+	}
 	if s.NextSlot == 0 {
 		s.NextSlot = 1
 	}
@@ -724,6 +755,7 @@ func (s *State) copyFrom(src *State) {
 	s.SupervisorDecisions = src.SupervisorDecisions
 	s.Approvals = src.Approvals
 	s.OutcomeHealth = src.OutcomeHealth
+	s.ProjectStatusSync = src.ProjectStatusSync
 	s.NextSlot = src.NextSlot
 	s.LastMergeAt = src.LastMergeAt
 }
@@ -763,9 +795,46 @@ func mergeStateSnapshots(base, current, ours *State) (*State, error) {
 		return nil, err
 	}
 	merged.OutcomeHealth = mergeOutcomeHealth(base.OutcomeHealth, current.OutcomeHealth, ours.OutcomeHealth)
+	merged.ProjectStatusSync = mergeProjectStatusSync(current.ProjectStatusSync, ours.ProjectStatusSync)
 	merged.NextSlot = mergeMonotonicInt(base.NextSlot, current.NextSlot, ours.NextSlot)
 	merged.LastMergeAt = mergeLatestTime(base.LastMergeAt, current.LastMergeAt, ours.LastMergeAt)
 	return merged, nil
+}
+
+func mergeProjectStatusSync(current, ours map[int]ProjectStatusSync) map[int]ProjectStatusSync {
+	merged := make(map[int]ProjectStatusSync)
+	for _, key := range unionProjectStatusSyncKeys(current, ours) {
+		currentValue, currentOK := current[key]
+		oursValue, oursOK := ours[key]
+		switch {
+		case currentOK && oursOK:
+			if oursValue.SyncedAt.After(currentValue.SyncedAt) {
+				merged[key] = oursValue
+			} else {
+				merged[key] = currentValue
+			}
+		case currentOK:
+			merged[key] = currentValue
+		case oursOK:
+			merged[key] = oursValue
+		}
+	}
+	return merged
+}
+
+func unionProjectStatusSyncKeys(maps ...map[int]ProjectStatusSync) []int {
+	seen := make(map[int]struct{})
+	for _, m := range maps {
+		for k := range m {
+			seen[k] = struct{}{}
+		}
+	}
+	keys := make([]int, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	return keys
 }
 
 func mergeSessions(merged, base, current, ours *State) error {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -73,6 +73,24 @@ func TestDonePRCount(t *testing.T) {
 	}
 }
 
+func TestProjectStatusSynced(t *testing.T) {
+	s := NewState()
+	if s.ProjectStatusSynced(42, "in_progress") {
+		t.Fatal("ProjectStatusSynced should be false before mark")
+	}
+	syncedAt := time.Now().UTC()
+	s.MarkProjectStatusSynced(42, "in_progress", syncedAt)
+	if !s.ProjectStatusSynced(42, "in_progress") {
+		t.Fatal("ProjectStatusSynced should be true for recorded status")
+	}
+	if s.ProjectStatusSynced(42, "in_review") {
+		t.Fatal("ProjectStatusSynced should be false for a different status")
+	}
+	if got := s.ProjectStatusSync[42].SyncedAt; !got.Equal(syncedAt) {
+		t.Fatalf("SyncedAt = %s, want %s", got, syncedAt)
+	}
+}
+
 func TestNotifiedCIFail_OmittedWhenFalse(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
Summary:
- return success/failure from Project status sync so callers can track real writes
- persist per-issue Project status sync state and skip repeated reconcile writes until the status changes
- add regression coverage for skipped repeat syncs and state persistence

Tests:
- go test ./internal/github ./internal/state ./internal/orchestrator
- go test ./...

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces per-issue project-status sync caching: `syncProject` now returns a `bool`, a new `ProjectStatusSync` map in `State` records the last successfully synced status per issue, and `reconcileSessionsToProjectBoard` skips the GitHub API call when the status hasn't changed.

- `TrySyncIssueStatusOneOf` is extracted from the old void method so callers can observe write success; the original method becomes a thin wrapper.
- `State` gains `ProjectStatusSync`, `MarkProjectStatusSynced`, and `ProjectStatusSynced` helpers with nil-safe guards, normalization, and a latest-timestamp-wins snapshot merge.
- The closed-issue loop in `reconcileProjectBoard` calls `syncProject(..., Done)` and `syncProject(..., Todo)` without updating `ProjectStatusSync`, so a re-opened issue whose previous cached status was `in_progress` will have its new `in_progress` sync skipped — leaving the board stuck at \"Done\" until the session transitions to a different status.

<h3>Confidence Score: 3/5</h3>

The caching logic is correct for the steady-state path but the closed-issue Done sync in `reconcileProjectBoard` never calls `MarkProjectStatusSynced`, leaving a stale cache entry that causes re-opened issues to be silently skipped.

The closed-issue loop syncs issues to Done without updating the cache. After an issue is closed and re-opened with a new session in the same previously-cached status (e.g., `in_progress`), `ProjectStatusSynced` returns true and the board update is skipped, leaving the board stuck at Done while Maestro considers the issue active.

Lines 470 and 473 of `orchestrator.go` need to call `MarkProjectStatusSynced` on successful sync, mirroring the pattern in `reconcileSessionsToProjectBoard`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds `syncProjectFn` injection point, makes `syncProject` return bool, and gates reconcile writes behind `ProjectStatusSynced` — but the closed-issue Done sync at line 470 does not update `ProjectStatusSync`, leaving a stale cache entry that suppresses re-sync after issue re-open. |
| internal/state/state.go | Adds `ProjectStatusSync` map with `MarkProjectStatusSynced`/`ProjectStatusSynced` helpers and a 2-way `mergeProjectStatusSync` (latest timestamp wins); all new functions guard against nil/zero inputs and map initialization is handled in `normalize()`. |
| internal/github/github_projects.go | Extracts `TrySyncIssueStatusOneOf` returning bool; old `SyncIssueStatusOneOf` becomes a thin wrapper — clean refactor with no logic changes. |
| internal/orchestrator/orchestrator_test.go | New test `TestReconcileSessionsToProjectBoard_SkipsAlreadySyncedStatus` covers the happy-path skip and status-transition re-sync; does not cover the re-open-after-close scenario. |
| internal/state/state_test.go | Adds `TestProjectStatusSynced` covering mark, check, wrong-status check, and SyncedAt precision — adequate unit coverage for the new state helpers. |
| internal/github/github_projects_test.go | Adds a targeted nil-field test for `TrySyncIssueStatusOneOf`; minimal but sufficient for the new public API surface. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 467-475 ([link](https://github.com/befeast/maestro/blob/725b0540f579c1f1879b4498810b09f58fe72630/internal/orchestrator/orchestrator.go#L467-L475)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Re-opened issues stuck at "Done" on project board**

   When a closed issue is synced to `ProjectStatusDone` (line 470), `MarkProjectStatusSynced` is never called for that transition. If the issue is then re-opened and a new session starts at `in_progress`, `ProjectStatusSynced(issue, "in_progress")` returns `true` (the stale record from the previous session), so `reconcileSessionsToProjectBoard` skips the sync. The board remains at "Done" for the re-opened issue until the session advances to a new status (e.g., `in_review`) that differs from the cached value.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 467-475

   Comment:
   **Re-opened issues stuck at "Done" on project board**

   When a closed issue is synced to `ProjectStatusDone` (line 470), `MarkProjectStatusSynced` is never called for that transition. If the issue is then re-opened and a new session starts at `in_progress`, `ProjectStatusSynced(issue, "in_progress")` returns `true` (the stale record from the previous session), so `reconcileSessionsToProjectBoard` skips the sync. The board remains at "Done" for the re-opened issue until the session advances to a new status (e.g., `in_review`) that differs from the cached value.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:467-475
**Re-opened issues stuck at "Done" on project board**

When a closed issue is synced to `ProjectStatusDone` (line 470), `MarkProjectStatusSynced` is never called for that transition. If the issue is then re-opened and a new session starts at `in_progress`, `ProjectStatusSynced(issue, "in_progress")` returns `true` (the stale record from the previous session), so `reconcileSessionsToProjectBoard` skips the sync. The board remains at "Done" for the re-opened issue until the session advances to a new status (e.g., `in_review`) that differs from the cached value.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Cache project status sync transitions"](https://github.com/befeast/maestro/commit/725b0540f579c1f1879b4498810b09f58fe72630) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32532730)</sub>

<!-- /greptile_comment -->