### PR TITLE
Gate project sync on GraphQL budget

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -26,6 +26,8 @@ import (
 	"github.com/befeast/maestro/internal/worker"
 )
 
+const minProjectGraphQLRemaining = 100
+
 // Orchestrator coordinates all agent sessions
 type Orchestrator struct {
 	cfg                   *config.Config
@@ -69,6 +71,9 @@ type Orchestrator struct {
 	// Cached project board field (discovered once per run cycle, nil if disabled)
 	projectField           *github.ProjectField
 	projectDiscoverRetryAt time.Time
+	projectRateCheckedAt   time.Time
+	projectRateAllowed     bool
+	projectRateRetryAt     time.Time
 
 	// Mission processor (nil when missions disabled)
 	missionProc *mission.Processor
@@ -88,6 +93,7 @@ type Orchestrator struct {
 	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
 	outcomeCheckFn              func(context.Context, outcome.Brief) outcome.HealthCheckResult
 	syncProjectFn               func(issueNumber int, status github.ProjectStatus) bool
+	rateLimitFn                 func() (github.RateLimitStatus, error)
 }
 
 // New creates a new Orchestrator
@@ -270,6 +276,13 @@ func (o *Orchestrator) checkOutcome(ctx context.Context) outcome.HealthCheckResu
 	return outcome.Checker{}.Check(ctx, o.cfg.Outcome)
 }
 
+func (o *Orchestrator) rateLimit() (github.RateLimitStatus, error) {
+	if o.rateLimitFn != nil {
+		return o.rateLimitFn()
+	}
+	return o.gh.RateLimit()
+}
+
 func (o *Orchestrator) respawnInPlace(slotName string, sess *state.Session, issue github.Issue, promptBase string, backendName string) error {
 	if o.respawnInPlaceFn != nil {
 		return o.respawnInPlaceFn(o.cfg, slotName, sess, o.repo, issue, promptBase, backendName)
@@ -364,6 +377,9 @@ func (o *Orchestrator) ensureProjectField() {
 	if o.projectField != nil {
 		return
 	}
+	if !o.projectGraphQLBudgetAvailable() {
+		return
+	}
 	if !o.projectDiscoverRetryAt.IsZero() && time.Now().Before(o.projectDiscoverRetryAt) {
 		return
 	}
@@ -377,10 +393,50 @@ func (o *Orchestrator) ensureProjectField() {
 	o.projectDiscoverRetryAt = time.Time{}
 }
 
+func (o *Orchestrator) projectGraphQLBudgetAvailable() bool {
+	now := time.Now()
+	if !o.projectRateCheckedAt.IsZero() && now.Sub(o.projectRateCheckedAt) < time.Minute {
+		return o.projectRateAllowed
+	}
+	if !o.projectRateRetryAt.IsZero() && now.Before(o.projectRateRetryAt) {
+		o.projectRateCheckedAt = now
+		o.projectRateAllowed = false
+		return false
+	}
+	rate, err := o.rateLimit()
+	o.projectRateCheckedAt = now
+	if err != nil {
+		o.projectRateAllowed = false
+		o.projectRateRetryAt = now.Add(time.Minute)
+		log.Printf("[projects] could not read GitHub rate budget; skipping ProjectV2 sync until %s: %v", o.projectRateRetryAt.Format(time.RFC3339), err)
+		return false
+	}
+	if rate.GraphQL.Remaining <= minProjectGraphQLRemaining {
+		retryAt := now.Add(10 * time.Minute)
+		if rate.GraphQL.Reset > 0 {
+			resetAt := time.Unix(int64(rate.GraphQL.Reset), 0)
+			if resetAt.After(now) {
+				retryAt = resetAt
+			}
+		}
+		o.projectRateAllowed = false
+		o.projectRateRetryAt = retryAt
+		log.Printf("[projects] GraphQL budget too low for ProjectV2 sync (remaining=%d <= %d, used=%d/%d); backing off until %s",
+			rate.GraphQL.Remaining, minProjectGraphQLRemaining, rate.GraphQL.Used, rate.GraphQL.Limit, retryAt.Format(time.RFC3339))
+		return false
+	}
+	o.projectRateAllowed = true
+	o.projectRateRetryAt = time.Time{}
+	return true
+}
+
 // syncProject syncs an issue's status to the configured GitHub Project board.
 // No-op if github_projects is not enabled.
 func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus) bool {
 	if !o.cfg.GitHubProjects.Enabled || o.cfg.GitHubProjects.ProjectNumber == 0 {
+		return false
+	}
+	if !o.projectGraphQLBudgetAvailable() {
 		return false
 	}
 	if o.syncProjectFn != nil {
@@ -449,6 +505,9 @@ func projectStatusForSession(sess *state.Session, requiresDeploy bool) (github.P
 // merge-then-verify policy required by ops.
 func (o *Orchestrator) reconcileProjectBoard(s *state.State) {
 	if !o.cfg.GitHubProjects.Enabled || o.cfg.GitHubProjects.ProjectNumber == 0 {
+		return
+	}
+	if !o.projectGraphQLBudgetAvailable() {
 		return
 	}
 	o.ensureProjectField()

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5410,6 +5410,36 @@ func TestSyncProject_DisabledWhenNoProjectNumber(t *testing.T) {
 	o.syncProject(42, github.ProjectStatusInProgress)
 }
 
+func TestSyncProject_SkipsWhenGraphQLBudgetLow(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		GitHubProjects: config.GitHubProjectsConfig{
+			Enabled:       true,
+			ProjectNumber: 3,
+		},
+	}
+	calls := 0
+	o := &Orchestrator{
+		cfg: cfg,
+		rateLimitFn: func() (github.RateLimitStatus, error) {
+			return github.RateLimitStatus{
+				GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 0, Used: 5000},
+			}, nil
+		},
+		syncProjectFn: func(issueNumber int, status github.ProjectStatus) bool {
+			calls++
+			return true
+		},
+	}
+
+	if o.syncProject(42, github.ProjectStatusInProgress) {
+		t.Fatal("syncProject returned true, want false when GraphQL budget is depleted")
+	}
+	if calls != 0 {
+		t.Fatalf("syncProjectFn calls = %d, want 0 when budget is depleted", calls)
+	}
+}
+
 func TestReconcileSessionsToProjectBoard_SkipsAlreadySyncedStatus(t *testing.T) {
 	cfg := &config.Config{
 		Repo: "owner/repo",
@@ -5422,6 +5452,11 @@ func TestReconcileSessionsToProjectBoard_SkipsAlreadySyncedStatus(t *testing.T) 
 	var lastStatus github.ProjectStatus
 	o := &Orchestrator{
 		cfg: cfg,
+		rateLimitFn: func() (github.RateLimitStatus, error) {
+			return github.RateLimitStatus{
+				GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000},
+			}, nil
+		},
 		syncProjectFn: func(issueNumber int, status github.ProjectStatus) bool {
 			calls++
 			lastStatus = status


### PR DESCRIPTION
Summary:
- skip ProjectV2 discovery/read/write when GraphQL remaining is at or below 100
- cache the rate decision briefly and back off until reset/10m when depleted
- add regression coverage that syncProject does not call Project sync under depleted GraphQL budget

Tests:
- go test ./internal/orchestrator
- go test ./...

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates all `ProjectV2` GitHub API calls (`ensureProjectField`, `syncProject`, `reconcileProjectBoard`) on a real-time GraphQL rate-limit check, with a 1-minute in-memory cache and a back-off period tied to the rate-limit reset timestamp (or 10 minutes as a fallback).

- `projectGraphQLBudgetAvailable()` is the new gating function: it caches the allow/deny decision for 1 minute, backs off until `projectRateRetryAt` when the budget is at or below 100 remaining, and delegates to a swappable `rateLimitFn` for testability.
- A new regression test (`TestSyncProject_SkipsWhenGraphQLBudgetLow`) verifies that `syncProject` returns false and does not invoke the inner sync function when `GraphQL.Remaining == 0`; the existing reconcile test is updated with a healthy `rateLimitFn` so it continues to exercise the sync path.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the budget gate is additive and the core project-sync paths are correctly guarded.

The gating logic works correctly in the common cases. The subtle issue is that the 1-minute cache check sits above the projectRateRetryAt expiry check, and the retry-window branch refreshes projectRateCheckedAt, so recovery after the back-off window can be delayed by an additional cache TTL. This is a small timing quirk rather than a functional breakage.

internal/orchestrator/orchestrator.go — specifically the cache ordering in projectGraphQLBudgetAvailable()

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds GraphQL budget gating via projectGraphQLBudgetAvailable(); minor cache ordering means recovery can be delayed up to ~1 extra minute after projectRateRetryAt expires. |
| internal/orchestrator/orchestrator_test.go | Adds TestSyncProject_SkipsWhenGraphQLBudgetLow covering the depleted-budget path; updates existing reconcile test with a passing rateLimitFn. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:401-405
The 1-minute short-circuit cache is evaluated **before** the `projectRateRetryAt` check. The retry-window path refreshes `projectRateCheckedAt`, so when `projectRateRetryAt` finally expires, a recently-cached `false` result will be returned for up to ~1 more minute before the function falls through to a fresh `rateLimit()` call. Removing the `projectRateCheckedAt` assignment from the retry-window branch avoids this: callers blocked by `projectRateRetryAt` always reach the time comparison cheaply; once the window expires they immediately fall through to a live check.

```suggestion
	if !o.projectRateRetryAt.IsZero() && now.Before(o.projectRateRetryAt) {
		return false
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Gate project sync on GraphQL budget"](https://github.com/befeast/maestro/commit/973a1f79ae3092cec61a4668c40b31b07f4ad1ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32533239)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->