### PR TITLE
Persist project sync cache after reconcile

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -93,6 +93,7 @@ type Orchestrator struct {
 	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
 	outcomeCheckFn              func(context.Context, outcome.Brief) outcome.HealthCheckResult
 	syncProjectFn               func(issueNumber int, status github.ProjectStatus) bool
+	listNonDoneProjectItemsFn   func(pf *github.ProjectField) ([]github.ProjectItem, error)
 	rateLimitFn                 func() (github.RateLimitStatus, error)
 }
 
@@ -450,6 +451,13 @@ func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus)
 	return o.gh.TrySyncIssueStatusOneOf(o.projectField, issueNumber, candidates...)
 }
 
+func (o *Orchestrator) listNonDoneProjectItems(pf *github.ProjectField) ([]github.ProjectItem, error) {
+	if o.listNonDoneProjectItemsFn != nil {
+		return o.listNonDoneProjectItemsFn(pf)
+	}
+	return o.gh.ListNonDoneProjectItems(pf)
+}
+
 // projectStatusForSession returns the ProjectStatus that should mirror this
 // session on the GitHub Project board, plus whether a sync should happen.
 // Sessions that have no clear board-level status (transient/unknown) return
@@ -503,44 +511,52 @@ func projectStatusForSession(sess *state.Session, requiresDeploy bool) (github.P
 // merging a PR alone keeps the item in In Progress until runtime/deploy
 // verification closes the issue (see markCodeLanded). This preserves the
 // merge-then-verify policy required by ops.
-func (o *Orchestrator) reconcileProjectBoard(s *state.State) {
+func (o *Orchestrator) reconcileProjectBoard(s *state.State) bool {
 	if !o.cfg.GitHubProjects.Enabled || o.cfg.GitHubProjects.ProjectNumber == 0 {
-		return
+		return false
 	}
 	if !o.projectGraphQLBudgetAvailable() {
-		return
+		return false
 	}
 	o.ensureProjectField()
 	if o.projectField == nil {
-		return
+		return false
 	}
 
-	o.reconcileSessionsToProjectBoard(s)
+	changed := o.reconcileSessionsToProjectBoard(s)
 
-	items, err := o.gh.ListNonDoneProjectItems(o.projectField)
+	items, err := o.listNonDoneProjectItems(o.projectField)
 	if err != nil {
 		log.Printf("[orch] reconcile project board: %v", err)
-		return
+		return changed
 	}
 
 	for _, item := range items {
 		if item.IssueClosed {
 			log.Printf("[orch] reconcile: issue #%d is closed, moving to Done", item.IssueNumber)
-			o.syncProject(item.IssueNumber, github.ProjectStatusDone)
+			if o.syncProject(item.IssueNumber, github.ProjectStatusDone) {
+				s.MarkProjectStatusSynced(item.IssueNumber, string(github.ProjectStatusDone), time.Now().UTC())
+				changed = true
+			}
 		} else if !item.HasStatus {
 			log.Printf("[orch] reconcile: issue #%d has no status, setting to Todo", item.IssueNumber)
-			o.syncProject(item.IssueNumber, github.ProjectStatusTodo)
+			if o.syncProject(item.IssueNumber, github.ProjectStatusTodo) {
+				s.MarkProjectStatusSynced(item.IssueNumber, string(github.ProjectStatusTodo), time.Now().UTC())
+				changed = true
+			}
 		}
 	}
+	return changed
 }
 
 // reconcileSessionsToProjectBoard pushes each Maestro session's status onto the
 // project board so the board mirrors the runtime even when an earlier sync was
 // missed (project discovery failed, network blip, board reset, …).
-func (o *Orchestrator) reconcileSessionsToProjectBoard(s *state.State) {
+func (o *Orchestrator) reconcileSessionsToProjectBoard(s *state.State) bool {
 	if s == nil {
-		return
+		return false
 	}
+	changed := false
 	// Pick the freshest session per issue so a running worker always wins over
 	// an older terminal record for the same issue.
 	freshest := make(map[int]*state.Session, len(s.Sessions))
@@ -573,8 +589,10 @@ func (o *Orchestrator) reconcileSessionsToProjectBoard(s *state.State) {
 		}
 		if o.syncProject(issue, status) {
 			s.MarkProjectStatusSynced(issue, string(status), time.Now().UTC())
+			changed = true
 		}
 	}
+	return changed
 }
 
 func codeLandedProjectStatus(requiresDeploy bool) github.ProjectStatus {
@@ -992,7 +1010,11 @@ func (o *Orchestrator) RunOnce() error {
 	// Step 6: Reconcile project board — mirror Maestro session state onto the
 	// board (active workers visible as In Progress, open PRs as In Review,
 	// blocked sessions as Blocked) and move externally-closed issues to Done.
-	o.reconcileProjectBoard(s)
+	if o.reconcileProjectBoard(s) {
+		if err := state.Save(o.cfg.StateDir, s); err != nil {
+			return fmt.Errorf("save state after project reconcile: %w", err)
+		}
+	}
 
 	// Flush digest buffer (no-op if digest mode is off or buffer is empty)
 	if err := o.notifier.Flush(); err != nil {
@@ -2268,7 +2290,7 @@ func (o *Orchestrator) runDeployCmd(prNumber int) error {
 //  1. Auto-rebase (if enabled)
 //  2. Label issue as blocked + keep session in conflict_failed permanently
 func (o *Orchestrator) rebaseConflicts(s *state.State) {
-	prs, err := o.gh.ListOpenPRs()
+	prs, err := o.listOpenPRs()
 	if err != nil {
 		log.Printf("[orch] list PRs (rebase): %v", err)
 		return

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5485,6 +5485,101 @@ func TestReconcileSessionsToProjectBoard_SkipsAlreadySyncedStatus(t *testing.T) 
 	}
 }
 
+func TestRunOncePersistsProjectStatusSyncAfterReconcile(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		StateDir:          t.TempDir(),
+		MaxParallel:       1,
+		MaxRuntimeMinutes: 60,
+		GitHubProjects: config.GitHubProjectsConfig{
+			Enabled:       true,
+			ProjectNumber: 3,
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "Persist project sync",
+		Status:      state.StatusRunning,
+		PID:         1234,
+		Branch:      "codex/persist-project-sync",
+		TmuxSession: "maestro-slot-1",
+		StartedAt:   time.Now().UTC(),
+	}
+	if err := state.Save(cfg.StateDir, s); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	syncCalls := 0
+	o := &Orchestrator{
+		cfg:      cfg,
+		gh:       github.New(cfg.Repo),
+		notifier: &notify.Notifier{},
+		router:   router.New(cfg),
+		repo:     cfg.Repo,
+		projectField: &github.ProjectField{
+			ProjectID: "PVT_test",
+			FieldID:   "FIELD_test",
+			Options:   map[string]string{"In Progress": "opt-progress"},
+		},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return nil, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		pidAliveFn: func(pid int) bool {
+			return true
+		},
+		tmuxSessionExistsFn: func(name string) bool {
+			return true
+		},
+		captureTmuxFn: func(session string) (string, error) {
+			return "", nil
+		},
+		rateLimitFn: func() (github.RateLimitStatus, error) {
+			return github.RateLimitStatus{
+				GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000},
+			}, nil
+		},
+		syncProjectFn: func(issueNumber int, status github.ProjectStatus) bool {
+			if issueNumber != 42 {
+				t.Fatalf("sync issue = %d, want 42", issueNumber)
+			}
+			if status != github.ProjectStatusInProgress {
+				t.Fatalf("sync status = %q, want %q", status, github.ProjectStatusInProgress)
+			}
+			syncCalls++
+			return true
+		},
+		listNonDoneProjectItemsFn: func(pf *github.ProjectField) ([]github.ProjectItem, error) {
+			return nil, nil
+		},
+	}
+
+	if err := o.RunOnce(); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if syncCalls != 1 {
+		t.Fatalf("sync calls = %d, want 1", syncCalls)
+	}
+	loaded, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if !loaded.ProjectStatusSynced(42, string(github.ProjectStatusInProgress)) {
+		t.Fatal("RunOnce did not persist reconciled project status sync")
+	}
+
+	if err := o.RunOnce(); err != nil {
+		t.Fatalf("RunOnce second pass: %v", err)
+	}
+	if syncCalls != 1 {
+		t.Fatalf("sync calls = %d, want 1 after cached second pass", syncCalls)
+	}
+}
+
 func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
 	soon := time.Now().UTC().Add(30 * time.Second)
 	deployed := time.Now().UTC()


### PR DESCRIPTION
Fixes a Project sync cache persistence hole introduced by transition-based ProjectV2 sync.

- persist project_status_sync after reconcile mutates it
- cover RunOnce so repeated cycles do not re-sync the same status

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a state-persistence hole where `reconcileProjectBoard` was mutating `s` (via `MarkProjectStatusSynced`) without ever saving those mutations to disk, meaning repeated cycles would re-sync the same project statuses on every run.

- `reconcileProjectBoard` and `reconcileSessionsToProjectBoard` are refactored to return a `bool` tracking whether any sync occurred; `RunOnce` now saves state immediately when that flag is true.
- The items loop in `reconcileProjectBoard` gains `MarkProjectStatusSynced` calls that were missing before (only `reconcileSessionsToProjectBoard` had them), and a new `listNonDoneProjectItemsFn` injection point mirrors the existing injectable pattern.
- `rebaseConflicts` is updated to call `o.listOpenPRs()` (the injectable wrapper) instead of `o.gh.ListOpenPRs()` directly, fixing a testability inconsistency needed by the new end-to-end test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped, the new save is guarded by the changed flag so it only fires when a sync actually occurred, and the test exercises both persistence and deduplication end-to-end.

Both functions mutate state correctly, the changed flag propagates through all branches (including the error-exit path in reconcileProjectBoard which preserves changes already made by reconcileSessionsToProjectBoard), and the new test confirms the cache suppresses duplicate syncs across RunOnce cycles.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | reconcileProjectBoard now returns bool and saves state when syncs occurred; items-loop gains MarkProjectStatusSynced calls; rebaseConflicts switches to injectable listOpenPRs wrapper for test consistency |
| internal/orchestrator/orchestrator_test.go | Adds TestRunOncePersistsProjectStatusSyncAfterReconcile: verifies state is written after reconcile and that a second RunOnce cycle skips already-synced issues |

</details>

<sub>Reviews (1): Last reviewed commit: ["Persist project sync cache after reconci..."](https://github.com/befeast/maestro/commit/5cbaa3a18c709ad4a1dc9a2cfc0988ca0cef9f49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32534907)</sub>

<!-- /greptile_comment -->