### PR TITLE
Throttle GitHub project item sweeps

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -26,7 +26,11 @@ import (
 	"github.com/befeast/maestro/internal/worker"
 )
 
-const minProjectGraphQLRemaining = 100
+const (
+	minProjectGraphQLRemaining = 100
+	projectBoardSweepInterval  = 30 * time.Minute
+	projectBoardSweepRetry     = 10 * time.Minute
+)
 
 // Orchestrator coordinates all agent sessions
 type Orchestrator struct {
@@ -68,12 +72,14 @@ type Orchestrator struct {
 	listOpenIssuesFn func(labels []string) ([]github.Issue, error)
 	workerStartFn    func(cfg *config.Config, s *state.State, repo string, issue github.Issue, promptBase, backend string) (string, error)
 
-	// Cached project board field (discovered once per run cycle, nil if disabled)
+	// Cached project board metadata and sweep cadence.
 	projectField           *github.ProjectField
 	projectDiscoverRetryAt time.Time
 	projectRateCheckedAt   time.Time
 	projectRateAllowed     bool
 	projectRateRetryAt     time.Time
+	projectItemsSweepAt    time.Time
+	projectItemsSweepRetry time.Time
 
 	// Mission processor (nil when missions disabled)
 	missionProc *mission.Processor
@@ -458,6 +464,16 @@ func (o *Orchestrator) listNonDoneProjectItems(pf *github.ProjectField) ([]githu
 	return o.gh.ListNonDoneProjectItems(pf)
 }
 
+func (o *Orchestrator) projectBoardSweepDue(now time.Time) bool {
+	if !o.projectItemsSweepRetry.IsZero() && now.Before(o.projectItemsSweepRetry) {
+		return false
+	}
+	if !o.projectItemsSweepAt.IsZero() && now.Sub(o.projectItemsSweepAt) < projectBoardSweepInterval {
+		return false
+	}
+	return true
+}
+
 // projectStatusForSession returns the ProjectStatus that should mirror this
 // session on the GitHub Project board, plus whether a sync should happen.
 // Sessions that have no clear board-level status (transient/unknown) return
@@ -525,11 +541,19 @@ func (o *Orchestrator) reconcileProjectBoard(s *state.State) bool {
 
 	changed := o.reconcileSessionsToProjectBoard(s)
 
+	now := time.Now().UTC()
+	if !o.projectBoardSweepDue(now) {
+		return changed
+	}
+
 	items, err := o.listNonDoneProjectItems(o.projectField)
 	if err != nil {
+		o.projectItemsSweepRetry = now.Add(projectBoardSweepRetry)
 		log.Printf("[orch] reconcile project board: %v", err)
 		return changed
 	}
+	o.projectItemsSweepAt = now
+	o.projectItemsSweepRetry = time.Time{}
 
 	for _, item := range items {
 		if item.IssueClosed {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5580,6 +5580,69 @@ func TestRunOncePersistsProjectStatusSyncAfterReconcile(t *testing.T) {
 	}
 }
 
+func TestReconcileProjectBoard_ThrottlesNonDoneItemSweep(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		GitHubProjects: config.GitHubProjectsConfig{
+			Enabled:       true,
+			ProjectNumber: 3,
+		},
+	}
+
+	sweeps := 0
+	synced := make(map[int]github.ProjectStatus)
+	o := &Orchestrator{
+		cfg: cfg,
+		projectField: &github.ProjectField{
+			ProjectID: "PVT_test",
+			FieldID:   "FIELD_test",
+			Options:   map[string]string{"Todo": "opt-todo", "In Progress": "opt-progress"},
+		},
+		rateLimitFn: func() (github.RateLimitStatus, error) {
+			return github.RateLimitStatus{
+				GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000},
+			}, nil
+		},
+		syncProjectFn: func(issueNumber int, status github.ProjectStatus) bool {
+			synced[issueNumber] = status
+			return true
+		},
+		listNonDoneProjectItemsFn: func(pf *github.ProjectField) ([]github.ProjectItem, error) {
+			sweeps++
+			return []github.ProjectItem{{IssueNumber: 99, HasStatus: false}}, nil
+		},
+	}
+
+	s := state.NewState()
+	if !o.reconcileProjectBoard(s) {
+		t.Fatal("first reconcile should record no-status project item sync")
+	}
+	if sweeps != 1 {
+		t.Fatalf("sweeps = %d, want 1", sweeps)
+	}
+	if synced[99] != github.ProjectStatusTodo {
+		t.Fatalf("issue #99 status = %q, want %q", synced[99], github.ProjectStatusTodo)
+	}
+
+	if o.reconcileProjectBoard(s) {
+		t.Fatal("second reconcile should be a no-op while project item sweep is throttled")
+	}
+	if sweeps != 1 {
+		t.Fatalf("sweeps = %d, want 1 while throttled", sweeps)
+	}
+
+	s.Sessions["slot-1"] = &state.Session{IssueNumber: 42, Status: state.StatusRunning}
+	if !o.reconcileProjectBoard(s) {
+		t.Fatal("session transition sync should still run while item sweep is throttled")
+	}
+	if sweeps != 1 {
+		t.Fatalf("sweeps = %d, want 1 after transition-only sync", sweeps)
+	}
+	if synced[42] != github.ProjectStatusInProgress {
+		t.Fatalf("issue #42 status = %q, want %q", synced[42], github.ProjectStatusInProgress)
+	}
+}
+
 func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
 	soon := time.Now().UTC().Add(30 * time.Second)
 	deployed := time.Now().UTC()


### PR DESCRIPTION
Reduce GitHub ProjectV2 GraphQL burn by throttling the full non-Done item sweep.

- keep transition-based session status sync every cycle
- run the expensive ProjectV2 item sweep at most every 30 minutes, with retry backoff on errors

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR throttles the expensive `ListNonDoneProjectItems` GraphQL call inside `reconcileProjectBoard` to at most once every 30 minutes, while keeping per-cycle session-status sync intact. A retry backoff of 10 minutes is intended for error cases.

- **Throttle gate** (`projectBoardSweepDue`): two new fields — `projectItemsSweepAt` (last success timestamp) and `projectItemsSweepRetry` (next allowed retry after an error) — gate the sweep inside `reconcileProjectBoard`.
- **Retry-timer override bug**: when an error sets `projectItemsSweepRetry` but a prior success already populated `projectItemsSweepAt`, the 30-min interval check suppresses the retry. The advertised 10-min backoff only takes effect during cold-start (when `projectItemsSweepAt` is zero).

<h3>Confidence Score: 3/5</h3>

Safe to merge with a small fix — the throttling itself works correctly; only the error-retry path misbehaves in the mid-interval failure scenario.

The projectBoardSweepDue function has a control-flow defect: once projectItemsSweepAt is set, a subsequent error that populates projectItemsSweepRetry will never actually control the retry cadence — the 30-min interval from the last success always wins. A transient API failure that occurs 5 minutes into a 30-minute window will silently wait the full remaining 25 minutes instead of the intended 10-minute backoff.

orchestrator.go — specifically the projectBoardSweepDue function and the error branch in reconcileProjectBoard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds sweep throttling with a 30-min interval and a 10-min error-retry timer, but the retry timer is silently overridden by the interval check when a previous sweep has succeeded. |
| internal/orchestrator/orchestrator_test.go | Adds a test covering the throttle happy-path and the session-transition bypass; does not exercise the error/retry path, which is where the logic bug in projectBoardSweepDue lives. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:467-475
When an error occurs after a recent successful sweep, `projectItemsSweepRetry` is set but the interval check (`now.Sub(o.projectItemsSweepAt) < projectBoardSweepInterval`) will still block the retry until the full 30-minute window from the last _success_ expires. For example: sweep succeeds at T=0, fails at T=5min → retry is set for T=15min. At T=15min the retry timer has expired, but the interval check returns false because only 15 of 30 minutes have passed since the last success. The retry fires at T=30min instead of T=15min, so `projectItemsSweepRetry` has no effect and the PR's "retry backoff on errors" semantics only hold during cold-start (when `projectItemsSweepAt` is zero). Restructuring to treat a non-zero retry as authoritative (bypassing the interval check) gives the intended behaviour.

```suggestion
func (o *Orchestrator) projectBoardSweepDue(now time.Time) bool {
	if !o.projectItemsSweepRetry.IsZero() {
		return !now.Before(o.projectItemsSweepRetry)
	}
	if !o.projectItemsSweepAt.IsZero() && now.Sub(o.projectItemsSweepAt) < projectBoardSweepInterval {
		return false
	}
	return true
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Throttle GitHub project item sweeps"](https://github.com/befeast/maestro/commit/27cfce902cd89613a9fd2d112de21d3723bed336) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32535455)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->