### PR TITLE
Handle lowercase REST issue closed state

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -192,6 +192,10 @@ func parseRESTIssue(out []byte) (Issue, error) {
 	return issue.issue(), nil
 }
 
+func restIssueStateClosed(state string) bool {
+	return strings.EqualFold(strings.TrimSpace(state), "closed")
+}
+
 func parseRESTPulls(out []byte) ([]PR, error) {
 	var restPulls []restPull
 	if err := json.Unmarshal(out, &restPulls); err != nil {
@@ -288,7 +292,7 @@ func (c *Client) IsIssueClosed(number int) (bool, error) {
 	if err := json.Unmarshal(out, &result); err != nil {
 		return false, err
 	}
-	return result.State == "CLOSED", nil
+	return restIssueStateClosed(result.State), nil
 }
 
 // ListOpenPRs returns all open PRs

--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -232,7 +232,7 @@ func (c *Client) ListNonDoneProjectItems(pf *ProjectField) ([]ProjectItem, error
 		}
 		items = append(items, ProjectItem{
 			IssueNumber: node.Content.Number,
-			IssueClosed: node.Content.State == "CLOSED",
+			IssueClosed: strings.EqualFold(strings.TrimSpace(node.Content.State), "closed"),
 			HasStatus:   node.FieldValueByName != nil && node.FieldValueByName.OptionID != "",
 		})
 	}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -63,6 +63,19 @@ func TestParseRESTPullsMapsFields(t *testing.T) {
 	}
 }
 
+func TestRESTIssueStateClosedAcceptsRESTLowercase(t *testing.T) {
+	for _, state := range []string{"closed", "CLOSED", " Closed "} {
+		if !restIssueStateClosed(state) {
+			t.Fatalf("restIssueStateClosed(%q) = false, want true", state)
+		}
+	}
+	for _, state := range []string{"open", "", "merged"} {
+		if restIssueStateClosed(state) {
+			t.Fatalf("restIssueStateClosed(%q) = true, want false", state)
+		}
+	}
+}
+
 func TestParseRateLimitStatus(t *testing.T) {
 	body := `{
 		"resources": {


### PR DESCRIPTION
Fix REST issue closed-state detection so closed GitHub issues unblock Maestro dependency and lifecycle checks.

- GitHub REST returns lowercase "closed"; normalize state before comparison
- make Project item closed detection case-insensitive too

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `IsIssueClosed` and the project-items check were comparing issue state against `"CLOSED"` while the GitHub REST API actually returns lowercase `"closed"`, causing closed issues to never be recognized as such.

- Introduces a `restIssueStateClosed` helper in `github.go` that uses `strings.EqualFold` + `strings.TrimSpace` for robust case-insensitive matching, and plugs it into `IsIssueClosed`.
- Applies the same case-insensitive comparison inline in `ListNonDoneProjectItems` (`github_projects.go`).
- Adds a focused unit test covering lowercase, uppercase, mixed-case/padded, and non-closed state values.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted correctness fix with no side effects on other code paths.

The original `== "CLOSED"` comparison against a REST response that always returns lowercase was a clear functional bug. Both changed call sites are now correct, and no other hardcoded `"CLOSED"` comparisons remain in the package. The new helper is well-tested with positive and negative cases.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds `restIssueStateClosed` helper using `strings.EqualFold`+`strings.TrimSpace` and wires it into `IsIssueClosed`, fixing the REST lowercase mismatch |
| internal/github/github_projects.go | Applies the same case-insensitive comparison for project item closed-state detection; change is correct and defensive |
| internal/github/github_test.go | Adds unit test for `restIssueStateClosed` covering lowercase, uppercase, mixed-case, trimmed, and non-closed states |

</details>

<sub>Reviews (1): Last reviewed commit: ["Handle lowercase REST issue closed state"](https://github.com/befeast/maestro/commit/fbdf15edb3138f6c0fc01022878d2ec486788c02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32536549)</sub>

<!-- /greptile_comment -->