### PR TITLE
Mark project sync cache when starting workers

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2943,7 +2943,9 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if initialPhase != state.PhaseNone {
 			s.Sessions[slotName].Phase = initialPhase
 		}
-		o.syncProject(issue.Number, github.ProjectStatusInProgress)
+		if o.syncProject(issue.Number, github.ProjectStatusInProgress) {
+			s.MarkProjectStatusSynced(issue.Number, string(github.ProjectStatusInProgress), time.Now().UTC())
+		}
 		o.notifier.Sendf("🚀 maestro: started worker %s for issue #%d: %s", slotName, issue.Number, issue.Title)
 		started++
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3024,6 +3024,38 @@ func TestStartNewWorkers_SkipsClosedIssueWithDoneSession(t *testing.T) {
 	}
 }
 
+func TestStartNewWorkers_RecordsProjectStatusSyncOnStart(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.GitHubProjects = config.GitHubProjectsConfig{Enabled: true, ProjectNumber: 3}
+	issues := []github.Issue{makeIssue(347, "ready issue")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.rateLimitFn = func() (github.RateLimitStatus, error) {
+		return github.RateLimitStatus{
+			GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000},
+		}, nil
+	}
+	o.syncProjectFn = func(issueNumber int, status github.ProjectStatus) bool {
+		if issueNumber != 347 {
+			t.Fatalf("sync issue = %d, want 347", issueNumber)
+		}
+		if status != github.ProjectStatusInProgress {
+			t.Fatalf("sync status = %q, want %q", status, github.ProjectStatusInProgress)
+		}
+		return true
+	}
+
+	s := state.NewState()
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 1 || (*started)[0] != 347 {
+		t.Fatalf("started = %v, want [347]", *started)
+	}
+	if !s.ProjectStatusSynced(347, string(github.ProjectStatusInProgress)) {
+		t.Fatal("startNewWorkers did not record project status sync")
+	}
+}
+
 func TestStartNewWorkers_SupervisorOwnedReadyLabelStartsOnlySelectedCandidate(t *testing.T) {
 	cfg := cfgWithBackends("claude", "claude")
 	cfg.IssueLabels = []string{"maestro-ready"}


### PR DESCRIPTION
Avoid a duplicate ProjectV2 write in the same cycle when a worker starts.

- record project_status_sync after successful start-time In Progress sync so reconcile skips the same status

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR avoids a duplicate `ProjectV2` GitHub write in the same reconcile cycle by calling `s.MarkProjectStatusSynced` after a successful `syncProject` call inside `startNewWorkers`, mirroring the pattern already used in the reconcile loop.

- **`orchestrator.go`**: The `syncProject` call at worker-start time is now conditional; on success (`true`), the issue's `InProgress` status is recorded in `State.ProjectStatusSync` so the reconcile loop's `ProjectStatusSynced` check can skip the redundant write.
- **`orchestrator_test.go`**: A new test (`TestStartNewWorkers_RecordsProjectStatusSyncOnStart`) exercises the happy path — a successful mock sync — and asserts the cache entry is present after `startNewWorkers` returns.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, isolated guard around an existing call with no new code paths that could regress.

The two-line production change follows an established pattern already present in the reconcile loop. The new test is well-wired (correct config, rate-limit stub, and a truthy syncProjectFn) and directly asserts the cache entry. Existing tests are unaffected because they rely on projects being disabled, so syncProject returns false before reaching MarkProjectStatusSynced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Wraps the existing syncProject call in a conditional so MarkProjectStatusSynced is recorded on success, preventing the reconcile loop from issuing a duplicate ProjectV2 write in the same cycle. |
| internal/orchestrator/orchestrator_test.go | Adds TestStartNewWorkers_RecordsProjectStatusSyncOnStart to verify the cache entry is written after a successful sync; correctly sets GitHubProjects config, rateLimitFn, and a truthy syncProjectFn. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Mark project sync cache when starting wo..."](https://github.com/befeast/maestro/commit/fdb0274b43d1115912cecf41177934dc131ed3b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32536901)</sub>

<!-- /greptile_comment -->