### PR TITLE
fix: use REST for PR read paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ maestro run --config ~/.maestro/maestro-myapp.yaml
 
 - Verify your `issue_labels` config (or deprecated `issue_label`) matches existing issue labels on GitHub
 - Check that issues aren't already assigned or have `exclude_labels`
-- Run `gh issue list --label enhancement` to confirm matching issues exist
+- Run `gh api 'repos/OWNER/REPO/issues?state=open&labels=enhancement' --jq '.[].number'` to confirm matching issues exist
 
 ### tmux errors
 

--- a/docs/PRD-gh-project-integration.md
+++ b/docs/PRD-gh-project-integration.md
@@ -254,7 +254,7 @@ type TransitionOptions struct {
 ### Why this shape
 
 - `ListCandidates` replaces label-based selection inside `orchestrator`.
-- `GetByIssueNumber` replaces direct `gh issue view/list` usage in `spawn`, retries, and fallback flows.
+- `GetByIssueNumber` replaces direct issue-subcommand usage in `spawn`, retries, and fallback flows.
 - `IsClosed` keeps the zombie-cleanup behavior without exposing raw GitHub issue APIs.
 - `Transition` centralizes status sync and optional side effects.
 

--- a/docs/po-spec-workflow.md
+++ b/docs/po-spec-workflow.md
@@ -61,7 +61,7 @@ audit trail.
 Inspect the queue:
 
 ```bash
-ssh workshop 'cd /mnt/storage/src/maestro && gh issue list --repo BeFeast/maestro --state open --label maestro-ready --limit 50'
+ssh workshop 'cd /mnt/storage/src/maestro && gh api "repos/BeFeast/maestro/issues?state=open&labels=maestro-ready&per_page=50" --jq ".[].number"'
 ```
 
 Watch the live brief:

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -11,9 +11,31 @@ import (
 )
 
 type greptileCheckRun struct {
+	ID         int64  `json:"id"`
 	Name       string `json:"name"`
 	Status     string `json:"status"`
 	Conclusion string `json:"conclusion"`
+	HTMLURL    string `json:"html_url"`
+	DetailsURL string `json:"details_url"`
+	Output     struct {
+		Title   string `json:"title"`
+		Summary string `json:"summary"`
+		Text    string `json:"text"`
+	} `json:"output"`
+}
+
+type checkRunsResponse struct {
+	CheckRuns []greptileCheckRun `json:"check_runs"`
+}
+
+type combinedStatusResponse struct {
+	State    string `json:"state"`
+	Statuses []struct {
+		Context     string `json:"context"`
+		State       string `json:"state"`
+		Description string `json:"description"`
+		TargetURL   string `json:"target_url"`
+	} `json:"statuses"`
 }
 
 type greptileReviewComment struct {
@@ -23,6 +45,13 @@ type greptileReviewComment struct {
 	CommitID         string `json:"commit_id"`
 	OriginalCommitID string `json:"original_commit_id"`
 	User             struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+type issueComment struct {
+	Body string `json:"body"`
+	User struct {
 		Login string `json:"login"`
 	} `json:"user"`
 }
@@ -85,15 +114,28 @@ type restIssue struct {
 }
 
 type restPull struct {
-	Number int     `json:"number"`
-	Title  string  `json:"title"`
-	Body   *string `json:"body"`
-	State  string  `json:"state"`
-	Draft  bool    `json:"draft"`
-	Head   struct {
+	Number         int     `json:"number"`
+	Title          string  `json:"title"`
+	Body           *string `json:"body"`
+	State          string  `json:"state"`
+	Draft          bool    `json:"draft"`
+	Mergeable      *bool   `json:"mergeable"`
+	MergeableState string  `json:"mergeable_state"`
+	Head           struct {
 		Ref string `json:"ref"`
+		SHA string `json:"sha"`
 	} `json:"head"`
 	MergedAt *string `json:"merged_at"`
+}
+
+type prLabel struct {
+	Name string `json:"name"`
+}
+
+type prCommit struct {
+	Commit struct {
+		Message string `json:"message"`
+	} `json:"commit"`
 }
 
 func (ri restIssue) issue() Issue {
@@ -134,7 +176,12 @@ func New(repo string) *Client {
 }
 
 func ghAPI(endpoint string) ([]byte, error) {
-	out, err := exec.Command("gh", "api", endpoint).Output()
+	return ghAPIWithArgs(endpoint)
+}
+
+func ghAPIWithArgs(endpoint string, args ...string) ([]byte, error) {
+	cmdArgs := append([]string{"api", endpoint}, args...)
+	out, err := exec.Command("gh", cmdArgs...).Output()
 	if err != nil {
 		return nil, fmt.Errorf("gh api %s: %w", endpoint, err)
 	}
@@ -217,6 +264,135 @@ func prReferencesIssue(pr PR, issueNumber int) bool {
 		return false
 	}
 	return issueRefRegexp(issueNumber).MatchString(pr.Title + "\n" + pr.Body)
+}
+
+func parseCheckRuns(out []byte) ([]greptileCheckRun, error) {
+	var payload checkRunsResponse
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return nil, err
+	}
+	return payload.CheckRuns, nil
+}
+
+func parseCombinedStatus(out []byte) (combinedStatusResponse, error) {
+	var payload combinedStatusResponse
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return combinedStatusResponse{}, err
+	}
+	return payload, nil
+}
+
+func ciStatusFromREST(checks []greptileCheckRun, combined combinedStatusResponse) string {
+	if strings.EqualFold(combined.State, "pending") {
+		return "pending"
+	}
+	if strings.EqualFold(combined.State, "failure") || strings.EqualFold(combined.State, "error") {
+		return "failure"
+	}
+
+	hasSignal := len(checks) > 0 || len(combined.Statuses) > 0
+	for _, check := range checks {
+		status := strings.ToLower(strings.TrimSpace(check.Status))
+		conclusion := strings.ToLower(strings.TrimSpace(check.Conclusion))
+		if status == "queued" || status == "in_progress" || status == "waiting" || status == "requested" || (status != "completed" && conclusion == "") {
+			return "pending"
+		}
+		switch conclusion {
+		case "failure", "timed_out", "cancelled", "action_required", "startup_failure", "stale":
+			return "failure"
+		}
+	}
+	if !hasSignal {
+		return "success"
+	}
+	return "success"
+}
+
+func formatChecksOverview(checks []greptileCheckRun, combined combinedStatusResponse) string {
+	var lines []string
+	for _, check := range checks {
+		state := strings.TrimSpace(check.Conclusion)
+		if state == "" {
+			state = strings.TrimSpace(check.Status)
+		}
+		if state == "" {
+			state = "unknown"
+		}
+		lines = append(lines, fmt.Sprintf("%s\t%s", check.Name, state))
+	}
+	for _, status := range combined.Statuses {
+		name := status.Context
+		if name == "" {
+			name = "commit-status"
+		}
+		state := status.State
+		if state == "" {
+			state = "unknown"
+		}
+		if status.Description != "" {
+			lines = append(lines, fmt.Sprintf("%s\t%s\t%s", name, state, status.Description))
+		} else {
+			lines = append(lines, fmt.Sprintf("%s\t%s", name, state))
+		}
+	}
+	if len(lines) == 0 {
+		return "no checks\n"
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func mergeableFromRESTPull(pr restPull) string {
+	if pr.Mergeable != nil {
+		if *pr.Mergeable {
+			return "MERGEABLE"
+		}
+		return "CONFLICTING"
+	}
+	switch strings.ToLower(strings.TrimSpace(pr.MergeableState)) {
+	case "dirty":
+		return "CONFLICTING"
+	case "", "unknown":
+		return "UNKNOWN"
+	default:
+		return "MERGEABLE"
+	}
+}
+
+func parseIssueComments(out []byte) ([]issueComment, error) {
+	var comments []issueComment
+	if err := json.Unmarshal(out, &comments); err != nil {
+		return nil, err
+	}
+	return comments, nil
+}
+
+func parsePRLabels(out []byte) ([]string, error) {
+	var labels []prLabel
+	if err := json.Unmarshal(out, &labels); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(labels))
+	for _, label := range labels {
+		names = append(names, label.Name)
+	}
+	return names, nil
+}
+
+func parsePRCommits(out []byte) ([]string, error) {
+	var commits []prCommit
+	if err := json.Unmarshal(out, &commits); err != nil {
+		return nil, err
+	}
+	msgs := make([]string, 0, len(commits))
+	for _, commit := range commits {
+		message := strings.TrimSpace(commit.Commit.Message)
+		if message == "" {
+			continue
+		}
+		headline := strings.SplitN(message, "\n", 2)[0]
+		msgs = append(msgs, headline)
+	}
+	return msgs, nil
 }
 
 // ListOpenIssues returns open issues matching any of the given labels (OR filter).
@@ -321,6 +497,54 @@ func (c *Client) listClosedPRs() ([]PR, error) {
 	return prs, nil
 }
 
+func (c *Client) getRESTPull(prNumber int) (restPull, error) {
+	out, err := ghAPI(fmt.Sprintf("repos/%s/pulls/%d", c.Repo, prNumber))
+	if err != nil {
+		return restPull{}, err
+	}
+	var pr restPull
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return restPull{}, err
+	}
+	return pr, nil
+}
+
+func (c *Client) pullHeadSHA(prNumber int) (string, error) {
+	pr, err := c.getRESTPull(prNumber)
+	if err != nil {
+		return "", err
+	}
+	sha := strings.TrimSpace(pr.Head.SHA)
+	if sha == "" {
+		return "", fmt.Errorf("empty head sha for PR %d", prNumber)
+	}
+	return sha, nil
+}
+
+func (c *Client) checkRunsForSHA(sha string) ([]greptileCheckRun, error) {
+	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/commits/%s/check-runs?per_page=100", c.Repo, sha), "--paginate")
+	if err != nil {
+		return nil, err
+	}
+	checks, err := parseCheckRuns(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse check runs for %s: %w", sha, err)
+	}
+	return checks, nil
+}
+
+func (c *Client) combinedStatusForSHA(sha string) (combinedStatusResponse, error) {
+	out, err := ghAPI(fmt.Sprintf("repos/%s/commits/%s/status", c.Repo, sha))
+	if err != nil {
+		return combinedStatusResponse{}, err
+	}
+	status, err := parseCombinedStatus(out)
+	if err != nil {
+		return combinedStatusResponse{}, fmt.Errorf("parse combined status for %s: %w", sha, err)
+	}
+	return status, nil
+}
+
 // CreatePR opens a pull request and returns its number.
 func (c *Client) CreatePR(title, body, base, head string) (int, error) {
 	args := []string{
@@ -350,20 +574,11 @@ func (c *Client) CreatePR(title, body, base, head string) (int, error) {
 
 // IsPRMerged returns true if the PR has been merged.
 func (c *Client) IsPRMerged(prNumber int) (bool, error) {
-	out, err := exec.Command("gh", "pr", "view", fmt.Sprint(prNumber),
-		"--repo", c.Repo,
-		"--json", "state,mergedAt").Output()
+	pr, err := c.getRESTPull(prNumber)
 	if err != nil {
-		return false, fmt.Errorf("gh pr view %d: %w", prNumber, err)
+		return false, fmt.Errorf("get pull %d: %w", prNumber, err)
 	}
-	var result struct {
-		State    string `json:"state"`
-		MergedAt string `json:"mergedAt"`
-	}
-	if err := json.Unmarshal(out, &result); err != nil {
-		return false, fmt.Errorf("parse pr %d: %w", prNumber, err)
-	}
-	return result.State == "MERGED" || result.MergedAt != "", nil
+	return strings.EqualFold(pr.State, "closed") && pr.MergedAt != nil, nil
 }
 
 // HasMergedPRForIssue returns true if a merged PR references the issue.
@@ -382,50 +597,25 @@ func (c *Client) HasMergedPRForIssue(issueNumber int) (bool, error) {
 
 // PRCIStatus returns "success", "failure", "pending", or "unknown"
 func (c *Client) PRCIStatus(prNumber int) (string, error) {
-	out, err := exec.Command("gh", "pr", "checks",
-		fmt.Sprint(prNumber),
-		"--repo", c.Repo).CombinedOutput()
+	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
-		// gh pr checks exits non-zero when checks fail
-		outStr := string(out)
-		if strings.Contains(outStr, "fail") || strings.Contains(outStr, "✗") {
-			return "failure", nil
-		}
-		if strings.Contains(outStr, "pending") || strings.Contains(outStr, "in_progress") {
-			return "pending", nil
-		}
-		// No checks configured
-		if strings.Contains(outStr, "no checks") {
-			return "success", nil
-		}
-		return "unknown", nil
+		return "unknown", fmt.Errorf("get pull %d head sha: %w", prNumber, err)
 	}
-	outStr := string(out)
-	if strings.Contains(outStr, "fail") || strings.Contains(outStr, "✗") {
-		return "failure", nil
+	checks, checksErr := c.checkRunsForSHA(sha)
+	combined, statusErr := c.combinedStatusForSHA(sha)
+	if checksErr != nil && statusErr != nil {
+		return "unknown", fmt.Errorf("get checks for PR %d: check-runs: %v; statuses: %v", prNumber, checksErr, statusErr)
 	}
-	if strings.Contains(outStr, "pending") || strings.Contains(outStr, "in_progress") {
-		return "pending", nil
-	}
-	return "success", nil
+	return ciStatusFromREST(checks, combined), nil
 }
 
 // PRMergeable returns the mergeable state: "MERGEABLE", "CONFLICTING", "UNKNOWN"
 func (c *Client) PRMergeable(prNumber int) (string, error) {
-	out, err := exec.Command("gh", "pr", "view",
-		fmt.Sprint(prNumber),
-		"--repo", c.Repo,
-		"--json", "mergeable").Output()
+	pr, err := c.getRESTPull(prNumber)
 	if err != nil {
-		return "", fmt.Errorf("gh pr view %d: %w", prNumber, err)
+		return "", fmt.Errorf("get pull %d: %w", prNumber, err)
 	}
-	var result struct {
-		Mergeable string `json:"mergeable"`
-	}
-	if err := json.Unmarshal(out, &result); err != nil {
-		return "", err
-	}
-	return result.Mergeable, nil
+	return mergeableFromRESTPull(pr), nil
 }
 
 // PRGreptileApproved checks whether Greptile has approved the PR.
@@ -443,39 +633,20 @@ func (c *Client) PRMergeable(prNumber int) (string, error) {
 //   - no greptile signal at all → pending=true
 func (c *Client) PRGreptileApproved(prNumber int) (approved bool, pending bool, err error) {
 	// --- 1. Get head SHA of the PR ---
-	prOut, err := exec.Command("gh", "api",
-		fmt.Sprintf("repos/%s/pulls/%d", c.Repo, prNumber)).Output()
+	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
-		return false, false, fmt.Errorf("gh api pulls/%d: %w", prNumber, err)
+		return false, false, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
 	}
-	var prData struct {
-		Head struct {
-			SHA string `json:"sha"`
-		} `json:"head"`
-	}
-	if err := json.Unmarshal(prOut, &prData); err != nil {
-		return false, false, fmt.Errorf("parse pr %d head sha: %w", prNumber, err)
-	}
-	sha := prData.Head.SHA
 
 	// --- 2. Get check runs for the head SHA ---
-	checksOut, err := exec.Command("gh", "api",
-		fmt.Sprintf("repos/%s/commits/%s/check-runs", c.Repo, sha),
-		"--paginate").Output()
+	checkRuns, err := c.checkRunsForSHA(sha)
 	if err != nil {
 		// Non-fatal: fall through to comment fallback
 		goto commentFallback
 	}
 
 	{
-		var checksData struct {
-			CheckRuns []greptileCheckRun `json:"check_runs"`
-		}
-		if err := json.Unmarshal(checksOut, &checksData); err != nil {
-			goto commentFallback
-		}
-
-		found, approved, pending := greptileCheckDecision(checksData.CheckRuns)
+		found, approved, pending := greptileCheckDecision(checkRuns)
 		if found {
 			if pending {
 				return false, true, nil
@@ -497,26 +668,18 @@ func (c *Client) PRGreptileApproved(prNumber int) (approved bool, pending bool, 
 
 commentFallback:
 	// --- 3. Fallback: check PR comments (legacy Greptile comment-mode) ---
-	commentsOut, err := exec.Command("gh", "pr", "view",
-		fmt.Sprint(prNumber),
-		"--repo", c.Repo,
-		"--comments",
-		"--json", "comments").Output()
+	commentsOut, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
-		return false, false, fmt.Errorf("gh pr view %d comments: %w", prNumber, err)
+		return false, false, fmt.Errorf("list issue comments for PR %d: %w", prNumber, err)
 	}
 
-	var commentsResult struct {
-		Comments []struct {
-			Body string `json:"body"`
-		} `json:"comments"`
-	}
-	if err := json.Unmarshal(commentsOut, &commentsResult); err != nil {
+	comments, err := parseIssueComments(commentsOut)
+	if err != nil {
 		return false, false, fmt.Errorf("parse pr %d comments: %w", prNumber, err)
 	}
 
 	foundGreptile := false
-	for _, comment := range commentsResult.Comments {
+	for _, comment := range comments {
 		bodyLower := strings.ToLower(comment.Body)
 		if !strings.Contains(bodyLower, "greptile") {
 			continue
@@ -652,17 +815,19 @@ func (c *Client) ClosePR(prNumber int, comment string) error {
 	return nil
 }
 
-// PRChecksOutput returns the full output of `gh pr checks` for a PR,
-// useful for capturing CI failure details to pass to retry workers.
+// PRChecksOutput returns a REST-derived check overview for a PR, useful for
+// capturing CI failure details to pass to retry workers.
 func (c *Client) PRChecksOutput(prNumber int) (string, error) {
-	out, err := exec.Command("gh", "pr", "checks",
-		fmt.Sprint(prNumber),
-		"--repo", c.Repo).CombinedOutput()
-	// gh pr checks exits non-zero when checks fail, but the output is still useful
+	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
-		return string(out), nil
+		return "", fmt.Errorf("get pull %d head sha: %w", prNumber, err)
 	}
-	return string(out), nil
+	checks, checksErr := c.checkRunsForSHA(sha)
+	combined, statusErr := c.combinedStatusForSHA(sha)
+	if checksErr != nil && statusErr != nil {
+		return "", fmt.Errorf("get checks for PR %d: check-runs: %v; statuses: %v", prNumber, checksErr, statusErr)
+	}
+	return formatChecksOverview(checks, combined), nil
 }
 
 // MergePR squash-merges a PR
@@ -739,48 +904,26 @@ func (c *Client) CommentIssue(issueNumber int, body string) error {
 
 // PRLabels returns the labels on a PR.
 func (c *Client) PRLabels(prNumber int) ([]string, error) {
-	out, err := exec.Command("gh", "pr", "view",
-		fmt.Sprint(prNumber),
-		"--repo", c.Repo,
-		"--json", "labels").Output()
+	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/labels?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
-		return nil, fmt.Errorf("gh pr view %d labels: %w", prNumber, err)
+		return nil, fmt.Errorf("list PR %d labels: %w", prNumber, err)
 	}
-	var result struct {
-		Labels []struct {
-			Name string `json:"name"`
-		} `json:"labels"`
-	}
-	if err := json.Unmarshal(out, &result); err != nil {
+	names, err := parsePRLabels(out)
+	if err != nil {
 		return nil, err
-	}
-	names := make([]string, len(result.Labels))
-	for i, l := range result.Labels {
-		names[i] = l.Name
 	}
 	return names, nil
 }
 
 // PRCommits returns commit messages for a PR.
 func (c *Client) PRCommits(prNumber int) ([]string, error) {
-	out, err := exec.Command("gh", "pr", "view",
-		fmt.Sprint(prNumber),
-		"--repo", c.Repo,
-		"--json", "commits").Output()
+	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/commits?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
-		return nil, fmt.Errorf("gh pr view %d commits: %w", prNumber, err)
+		return nil, fmt.Errorf("list PR %d commits: %w", prNumber, err)
 	}
-	var result struct {
-		Commits []struct {
-			MessageHeadline string `json:"messageHeadline"`
-		} `json:"commits"`
-	}
-	if err := json.Unmarshal(out, &result); err != nil {
+	msgs, err := parsePRCommits(out)
+	if err != nil {
 		return nil, err
-	}
-	msgs := make([]string, len(result.Commits))
-	for i, c := range result.Commits {
-		msgs[i] = c.MessageHeadline
 	}
 	return msgs, nil
 }
@@ -1084,50 +1227,54 @@ func FormatReviewFeedback(comments []ReviewComment) string {
 // CIFailureSummary gets the CI check run failure summary for a PR.
 func (c *Client) CIFailureSummary(prNumber int) (string, error) {
 	// 1. Get check overview
-	overview, _ := exec.Command("gh", "pr", "checks", fmt.Sprint(prNumber), "--repo", c.Repo).CombinedOutput()
-
-	// 2. Find failed job IDs and fetch their logs
-	runsOut, _ := exec.Command("gh", "api",
-		fmt.Sprintf("repos/%s/pulls/%d", c.Repo, prNumber),
-		"--jq", ".head.sha").Output()
-	sha := strings.TrimSpace(string(runsOut))
-	if sha == "" {
-		return string(overview), nil
+	overview, err := c.PRChecksOutput(prNumber)
+	if err != nil {
+		overview = err.Error()
 	}
 
-	jqExpr := `.check_runs[] | select(.conclusion == "failure") | "\(.id) \(.name)"`
-	checksOut, err := exec.Command("gh", "api",
-		fmt.Sprintf("repos/%s/commits/%s/check-runs", c.Repo, sha),
-		"--jq", jqExpr).Output()
-	if err != nil || len(checksOut) == 0 {
-		return string(overview), nil
+	// 2. Find failed job IDs and fetch their logs
+	sha, err := c.pullHeadSHA(prNumber)
+	if err != nil || sha == "" {
+		return overview, nil
+	}
+
+	checks, err := c.checkRunsForSHA(sha)
+	if err != nil {
+		return overview, nil
+	}
+	var failed []greptileCheckRun
+	for _, check := range checks {
+		switch strings.ToLower(strings.TrimSpace(check.Conclusion)) {
+		case "failure", "timed_out", "cancelled", "action_required", "startup_failure", "stale":
+			failed = append(failed, check)
+		}
+	}
+	if len(failed) == 0 {
+		return overview, nil
 	}
 
 	var result strings.Builder
 	result.WriteString("CI Check Overview:\n")
-	result.Write(overview)
+	result.WriteString(overview)
 	result.WriteString("\n\n")
 
-	for _, line := range strings.Split(strings.TrimSpace(string(checksOut)), "\n") {
-		parts := strings.SplitN(line, " ", 2)
-		if len(parts) < 2 {
-			continue
+	for _, check := range failed {
+		result.WriteString(fmt.Sprintf("=== Failed check: %s ===\n", check.Name))
+		if check.Output.Summary != "" {
+			result.WriteString(check.Output.Summary)
+			result.WriteString("\n")
 		}
-		jobID, jobName := parts[0], parts[1]
-		result.WriteString(fmt.Sprintf("=== Failed job: %s ===\n", jobName))
-		logOut, err := exec.Command("gh", "api",
-			fmt.Sprintf("repos/%s/actions/jobs/%s/logs", c.Repo, jobID)).Output()
-		if err != nil {
-			result.WriteString("(could not fetch logs)\n")
-			continue
+		if check.Output.Text != "" {
+			result.WriteString(check.Output.Text)
+			result.WriteString("\n")
 		}
-		lines := strings.Split(string(logOut), "\n")
-		start := len(lines) - 80
-		if start < 0 {
-			start = 0
-		}
-		for _, l := range lines[start:] {
-			result.WriteString(l)
+		if check.DetailsURL != "" {
+			result.WriteString("Details: ")
+			result.WriteString(check.DetailsURL)
+			result.WriteString("\n")
+		} else if check.HTMLURL != "" {
+			result.WriteString("Details: ")
+			result.WriteString(check.HTMLURL)
 			result.WriteString("\n")
 		}
 		result.WriteString("\n")

--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -294,22 +294,28 @@ func (c *Client) TrySyncIssueStatusOneOf(pf *ProjectField, issueNumber int, cand
 func (c *Client) getIssueNodeID(issueNumber int) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "gh", "issue", "view", fmt.Sprint(issueNumber),
-		"--repo", c.Repo,
-		"--json", "id").Output()
+	out, err := exec.CommandContext(ctx, "gh", "api", fmt.Sprintf("repos/%s/issues/%d", c.Repo, issueNumber)).Output()
 	if err != nil {
-		return "", fmt.Errorf("gh issue view %d --json id: %w", issueNumber, err)
+		return "", fmt.Errorf("gh api issue %d: %w", issueNumber, err)
 	}
+	nodeID, err := parseIssueNodeID(issueNumber, out)
+	if err != nil {
+		return "", err
+	}
+	return nodeID, nil
+}
+
+func parseIssueNodeID(issueNumber int, out []byte) (string, error) {
 	var result struct {
-		ID string `json:"id"`
+		NodeID string `json:"node_id"`
 	}
 	if err := json.Unmarshal(out, &result); err != nil {
 		return "", fmt.Errorf("parse issue %d node id: %w", issueNumber, err)
 	}
-	if result.ID == "" {
+	if result.NodeID == "" {
 		return "", fmt.Errorf("empty node ID for issue #%d", issueNumber)
 	}
-	return result.ID, nil
+	return result.NodeID, nil
 }
 
 // addToProject adds an issue to a GitHub Project and returns the project item ID.
@@ -433,6 +439,14 @@ func resolveProjectStatusOption(pf *ProjectField, candidates []string) (string, 
 		}
 	}
 	return "", "", false
+}
+
+// HasProjectStatusCandidate reports whether any candidate can be represented by
+// the board's Status field. Callers use this to avoid repeated ProjectV2 item
+// lookups for lifecycle states the board does not support.
+func HasProjectStatusCandidate(pf *ProjectField, candidates []string) bool {
+	_, _, ok := resolveProjectStatusOption(pf, candidates)
+	return ok
 }
 
 func normalizeProjectStatusKey(name string) string {

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -222,6 +222,20 @@ func TestTrySyncIssueStatusOneOf_NilProjectField(t *testing.T) {
 	}
 }
 
+func TestParseIssueNodeIDUsesRESTNodeID(t *testing.T) {
+	got, err := parseIssueNodeID(42, []byte(`{"node_id":"I_kwDOExample"}`))
+	if err != nil {
+		t.Fatalf("parseIssueNodeID() error = %v", err)
+	}
+	if got != "I_kwDOExample" {
+		t.Fatalf("node id = %q, want I_kwDOExample", got)
+	}
+
+	if _, err := parseIssueNodeID(42, []byte(`{"id":123}`)); err == nil {
+		t.Fatal("parseIssueNodeID() should reject missing REST node_id")
+	}
+}
+
 func TestNormalizeProjectStatusKey(t *testing.T) {
 	tests := []struct {
 		in, want string

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -93,6 +93,78 @@ func TestParseRateLimitStatus(t *testing.T) {
 	}
 }
 
+func TestCIStatusFromREST(t *testing.T) {
+	tests := []struct {
+		name     string
+		checks   []greptileCheckRun
+		combined combinedStatusResponse
+		want     string
+	}{
+		{name: "no checks means success", want: "success"},
+		{name: "queued check pending", checks: []greptileCheckRun{{Name: "test", Status: "queued"}}, want: "pending"},
+		{name: "in progress check pending", checks: []greptileCheckRun{{Name: "test", Status: "in_progress"}}, want: "pending"},
+		{name: "failed check fails", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "failure"}}, want: "failure"},
+		{name: "cancelled check fails", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "cancelled"}}, want: "failure"},
+		{name: "success checks pass", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}}, want: "success"},
+		{name: "combined pending wins", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}}, combined: combinedStatusResponse{State: "pending"}, want: "pending"},
+		{name: "combined failure wins", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}}, combined: combinedStatusResponse{State: "failure"}, want: "failure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ciStatusFromREST(tt.checks, tt.combined); got != tt.want {
+				t.Fatalf("ciStatusFromREST() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeableFromRESTPull(t *testing.T) {
+	yes := true
+	no := false
+	tests := []struct {
+		name string
+		pr   restPull
+		want string
+	}{
+		{name: "mergeable bool true", pr: restPull{Mergeable: &yes}, want: "MERGEABLE"},
+		{name: "mergeable bool false", pr: restPull{Mergeable: &no}, want: "CONFLICTING"},
+		{name: "dirty state conflicts", pr: restPull{MergeableState: "dirty"}, want: "CONFLICTING"},
+		{name: "unknown state unknown", pr: restPull{MergeableState: "unknown"}, want: "UNKNOWN"},
+		{name: "unstable still mergeable", pr: restPull{MergeableState: "unstable"}, want: "MERGEABLE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeableFromRESTPull(tt.pr); got != tt.want {
+				t.Fatalf("mergeableFromRESTPull() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePRLabelsAndCommits(t *testing.T) {
+	labels, err := parsePRLabels([]byte(`[{"name":"ready"},{"name":"bug"}]`))
+	if err != nil {
+		t.Fatalf("parsePRLabels() error = %v", err)
+	}
+	if !reflect.DeepEqual(labels, []string{"ready", "bug"}) {
+		t.Fatalf("labels = %#v", labels)
+	}
+
+	commits, err := parsePRCommits([]byte(`[
+		{"commit":{"message":"first line\n\nbody"}},
+		{"commit":{"message":"single line"}},
+		{"commit":{"message":""}}
+	]`))
+	if err != nil {
+		t.Fatalf("parsePRCommits() error = %v", err)
+	}
+	if !reflect.DeepEqual(commits, []string{"first line", "single line"}) {
+		t.Fatalf("commits = %#v", commits)
+	}
+}
+
 func TestGreptileCheckDecision(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -454,6 +454,10 @@ func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus)
 	if len(candidates) == 0 {
 		candidates = []string{string(status)}
 	}
+	if !github.HasProjectStatusCandidate(o.projectField, candidates) {
+		log.Printf("[projects] none of statuses %v found in project; treating issue #%d status=%q as handled", candidates, issueNumber, status)
+		return true
+	}
 	return o.gh.TrySyncIssueStatusOneOf(o.projectField, issueNumber, candidates...)
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5472,6 +5472,33 @@ func TestSyncProject_SkipsWhenGraphQLBudgetLow(t *testing.T) {
 	}
 }
 
+func TestSyncProject_MissingLifecycleStatusIsHandled(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		GitHubProjects: config.GitHubProjectsConfig{
+			Enabled:       true,
+			ProjectNumber: 3,
+		},
+	}
+	o := &Orchestrator{
+		cfg: cfg,
+		projectField: &github.ProjectField{
+			ProjectID: "PVT_test",
+			FieldID:   "FIELD_test",
+			Options:   map[string]string{"Todo": "opt-todo", "In Progress": "opt-progress", "Done": "opt-done"},
+		},
+		rateLimitFn: func() (github.RateLimitStatus, error) {
+			return github.RateLimitStatus{
+				GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000},
+			}, nil
+		},
+	}
+
+	if !o.syncProject(42, github.ProjectStatusLiveVerify) {
+		t.Fatal("syncProject should report handled when board lacks lifecycle status candidates")
+	}
+}
+
 func TestReconcileSessionsToProjectBoard_SkipsAlreadySyncedStatus(t *testing.T) {
 	cfg := &config.Config{
 		Repo: "owner/repo",

--- a/scripts/generate-validation.sh
+++ b/scripts/generate-validation.sh
@@ -30,9 +30,9 @@ fi
 
 echo "[generate-validation] Generating VALIDATION.md for ${REPO}#${ISSUE_NUMBER}"
 
-# Fetch issue title and body
-ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title --jq '.title' 2>/dev/null || echo "")
-ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+# Fetch issue title and body via REST. Avoid issue subcommands; they may use GraphQL.
+ISSUE_TITLE=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.title // ""' 2>/dev/null || echo "")
+ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body // ""' 2>/dev/null || echo "")
 
 if [ -z "$ISSUE_TITLE" ]; then
   echo "[generate-validation] WARN: could not fetch issue #${ISSUE_NUMBER}, skipping" >&2

--- a/worker-prompt-template.md
+++ b/worker-prompt-template.md
@@ -91,7 +91,8 @@ When rebasing conflicts in these files: **keep BOTH sides**. Your additions + wh
 
 ### 7. Done means done
 Once you've opened a PR:
-- Verify CI started (gh pr checks)
+- Verify CI started with REST only:
+  `sha=$(gh api repos/OWNER/REPO/pulls/PR_NUMBER --jq .head.sha) && gh api repos/OWNER/REPO/commits/$sha/check-runs --jq '.check_runs[] | {name,status,conclusion}'`
 - Write a brief summary of what you did
 - Stop. Don't keep adding things.
 


### PR DESCRIPTION
Replaces remaining Maestro PR read paths that used gh pr view/checks with REST gh api calls for PR state, mergeability, CI/check-runs, labels, commits, and Greptile comment fallback. Updates the worker prompt CI verification example to use REST check-runs.\n\nVerification:\n- go test ./internal/github ./internal/orchestrator ./internal/supervisor\n- go test ./...\n- go build ./cmd/maestro

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces remaining `gh pr view`/`gh pr checks` CLI subcommand calls with direct REST API calls (`gh api`) for PR state, mergeability, CI check-runs, labels, commits, and the Greptile comment fallback. New typed structs, parse helpers, and decision functions are added to `internal/github/github.go` with corresponding unit tests.

- New REST helpers (`checkRunsForSHA`, `combinedStatusForSHA`, `PRLabels`, `PRCommits`, `PRMergeable`, `mergeableFromRESTPull`, `ciStatusFromREST`) replace the previous GraphQL/subcommand paths across the client.
- The `PRGreptileApproved` comment-fallback path is migrated to use `ghAPIWithArgs` and a new `parseIssueComments` helper.
- Documentation, worker prompt template, and spec files are updated to show REST equivalents for troubleshooting commands.

<h3>Confidence Score: 3/5</h3>

Safe to merge for repositories with fewer than 100 check-runs per commit; risks silent CI-status degradation in large monorepos with many parallel jobs.

The `checkRunsForSHA` function passes `--paginate` to an endpoint that returns a JSON object rather than an array. On repos that exceed 100 check-runs per commit, `gh api --paginate` emits multiple JSON documents and `json.Unmarshal` fails, causing every caller to silently fall back: `PRCIStatus` drops to combined-status only, `PRGreptileApproved` skips to the comment path, and `CIFailureSummary` omits per-check detail. For the common case the bug is dormant, but in CI-heavy repos the merge gate and failure diagnosis would quietly stop working.

internal/github/github.go — specifically the `checkRunsForSHA` function and the redundant success returns in `ciStatusFromREST`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Core refactor: replaces gh-CLI subcommands with REST API calls for PR state, CI, labels, and commits. New parsers are well-tested, but `checkRunsForSHA` misuses `--paginate` on an object-returning endpoint, which breaks JSON parsing if a repo has >100 check-runs on a single commit. |
| internal/github/github_test.go | Comprehensive unit tests for all new REST parsers and decision helpers; covers mergeable logic, CI status matrix, greptile check decision, and inline-comment severity filtering. |
| internal/orchestrator/orchestrator.go | Adds delegation hooks for the new REST-based github functions; no logic changes, purely plumbing for test-overridable paths. |
| internal/orchestrator/orchestrator_test.go | Tests updated to use new hook names; logic is unchanged. |
| README.md | Troubleshooting example updated from `gh issue list` to `gh api` REST call. |
| worker-prompt-template.md | CI verification example updated to show REST check-runs query instead of `gh pr checks`. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/github/github.go:524-534
**`--paginate` breaks JSON parsing for check-runs**

The `/commits/{sha}/check-runs` endpoint returns a JSON **object** (`{"total_count": N, "check_runs": [...]}`), not an array. When `gh api --paginate` finds a next-page `Link` header, it emits each page as a separate JSON document separated by a newline — e.g., `{...100 items...}\n{...50 items...}`. `json.Unmarshal` then fails with `invalid character after top-level value`, `checkRunsForSHA` returns an error, and every caller degrades silently: `PRCIStatus` falls back to combined-status only, `PRGreptileApproved` jumps to comment fallback, and `CIFailureSummary` returns the overview without per-check details. The `--paginate` flag is safe only on array-returning endpoints (labels, commits, issue comments); it should be removed here since `per_page=100` already caps a single page at the API maximum.

### Issue 2 of 2
internal/github/github.go:305-308
Dead code: the `if !hasSignal` branch and the trailing return both produce `"success"`, so one of them is unreachable. Collapsing them makes the intent clearer.

```suggestion
	return "success"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use REST for PR read paths"](https://github.com/befeast/maestro/commit/f30519100af301cc91946c8c8e1776227c2f649c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32537802)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->