### PR TITLE
fix: defer startup project board sweeps

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1063,6 +1063,13 @@ func (o *Orchestrator) SetConfigReloadCh(ch <-chan *config.Config) {
 // The context can be used to stop the loop (e.g. for multi-project shutdown).
 // An optional refreshCh triggers an immediate poll cycle when a value is received.
 func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once bool, refreshCh <-chan struct{}) error {
+	if !once {
+		// Full ProjectV2 item sweeps are expensive and only repair board drift.
+		// Do not run one immediately after every daemon restart; session-state
+		// mirroring still runs, and the broad sweep can wait for the normal
+		// throttle window.
+		o.deferProjectBoardSweep(time.Now().UTC())
+	}
 	if err := o.RunOnce(); err != nil {
 		log.Printf("[orch] run error: %v", err)
 	}
@@ -1089,6 +1096,13 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 			o.reloadConfig(newCfg, &ticker)
 		}
 	}
+}
+
+func (o *Orchestrator) deferProjectBoardSweep(now time.Time) {
+	if o == nil || !o.projectItemsSweepAt.IsZero() {
+		return
+	}
+	o.projectItemsSweepAt = now.UTC()
 }
 
 // reloadConfig applies non-destructive config changes at runtime.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5702,6 +5702,29 @@ func TestReconcileProjectBoard_ThrottlesNonDoneItemSweep(t *testing.T) {
 	}
 }
 
+func TestDeferProjectBoardSweepDelaysOnlyBroadSweep(t *testing.T) {
+	o := &Orchestrator{}
+	now := time.Now().UTC()
+
+	if !o.projectBoardSweepDue(now) {
+		t.Fatal("zero-value orchestrator should allow initial sweep")
+	}
+
+	o.deferProjectBoardSweep(now)
+	if o.projectBoardSweepDue(now.Add(projectBoardSweepInterval - time.Second)) {
+		t.Fatal("deferred startup sweep should wait for throttle interval")
+	}
+	if !o.projectBoardSweepDue(now.Add(projectBoardSweepInterval + time.Second)) {
+		t.Fatal("deferred startup sweep should become due after throttle interval")
+	}
+
+	first := o.projectItemsSweepAt
+	o.deferProjectBoardSweep(now.Add(time.Hour))
+	if !o.projectItemsSweepAt.Equal(first) {
+		t.Fatal("deferProjectBoardSweep should not overwrite an existing sweep timestamp")
+	}
+}
+
 func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
 	soon := time.Now().UTC().Add(30 * time.Second)
 	deployed := time.Now().UTC()


### PR DESCRIPTION
Avoid running the expensive full ProjectV2 non-Done item sweep immediately after every long-running Maestro daemon restart. Session-state mirroring still runs on startup; the broad board-drift sweep waits for the normal throttle interval.\n\nVerification:\n- go test ./internal/orchestrator ./internal/github ./internal/supervisor\n- go test ./...\n- go build ./cmd/maestro

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defers the expensive full ProjectV2 non-Done item sweep on daemon restart by pre-setting `projectItemsSweepAt` to the current time before the first `RunOnce` call, so `projectBoardSweepDue` skips the broad sweep until one full throttle interval (30 min) has elapsed. Session-state mirroring via `reconcileSessionsToProjectBoard` is unaffected and still runs on every cycle.

- `deferProjectBoardSweep` is a small, idempotent helper that only fires when `projectItemsSweepAt` is still zero, preventing any pre-existing timestamp (e.g. from a prior sweep) from being overwritten.
- The `once=true` code path is intentionally excluded from the deferral, so single-shot runs still execute the full sweep immediately.
- The new test exercises all three cases: initial sweep eligibility, throttle enforcement during the interval, post-interval eligibility, and idempotency of repeated calls.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, well-tested, and touches only the startup path of the daemon loop.

The deferral logic correctly uses the existing projectBoardSweepDue throttle mechanism without altering any other sweep path. The once=true path is intentionally excluded. The idempotency guard prevents accidental timestamp clobbering. The new test covers all meaningful states. No concurrency concerns since all field accesses happen on the single Run goroutine.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds deferProjectBoardSweep helper and calls it on non-once startup to delay the expensive ProjectV2 sweep by one throttle interval; logic is correct and well-guarded. |
| internal/orchestrator/orchestrator_test.go | New test covers zero-value sweep-due check, deferred startup throttle, post-interval expiry, and idempotency of repeated deferral calls. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: defer startup project board sweeps"](https://github.com/befeast/maestro/commit/784f4a20b56568888897df66a8a94cdc5d561338) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32538760)</sub>

<!-- /greptile_comment -->