### PR TITLE
fix: avoid idle ProjectV2 rate checks

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -443,13 +443,16 @@ func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus)
 	if !o.cfg.GitHubProjects.Enabled || o.cfg.GitHubProjects.ProjectNumber == 0 {
 		return false
 	}
-	if !o.projectGraphQLBudgetAvailable() {
-		return false
-	}
 	if o.syncProjectFn != nil {
+		if !o.projectGraphQLBudgetAvailable() {
+			return false
+		}
 		return o.syncProjectFn(issueNumber, status)
 	}
 	o.ensureProjectField()
+	if o.projectField == nil {
+		return false
+	}
 	candidates := github.ProjectStatusCandidates(status)
 	if len(candidates) == 0 {
 		candidates = []string{string(status)}
@@ -457,6 +460,9 @@ func (o *Orchestrator) syncProject(issueNumber int, status github.ProjectStatus)
 	if !github.HasProjectStatusCandidate(o.projectField, candidates) {
 		log.Printf("[projects] none of statuses %v found in project; treating issue #%d status=%q as handled", candidates, issueNumber, status)
 		return true
+	}
+	if !o.projectGraphQLBudgetAvailable() {
+		return false
 	}
 	return o.gh.TrySyncIssueStatusOneOf(o.projectField, issueNumber, candidates...)
 }
@@ -535,9 +541,6 @@ func (o *Orchestrator) reconcileProjectBoard(s *state.State) bool {
 	if !o.cfg.GitHubProjects.Enabled || o.cfg.GitHubProjects.ProjectNumber == 0 {
 		return false
 	}
-	if !o.projectGraphQLBudgetAvailable() {
-		return false
-	}
 	o.ensureProjectField()
 	if o.projectField == nil {
 		return false
@@ -547,6 +550,9 @@ func (o *Orchestrator) reconcileProjectBoard(s *state.State) bool {
 
 	now := time.Now().UTC()
 	if !o.projectBoardSweepDue(now) {
+		return changed
+	}
+	if !o.projectGraphQLBudgetAvailable() {
 		return changed
 	}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5499,6 +5499,38 @@ func TestSyncProject_MissingLifecycleStatusIsHandled(t *testing.T) {
 	}
 }
 
+func TestSyncProject_MissingLifecycleStatusDoesNotCheckRateBudgetWhenFieldKnown(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		GitHubProjects: config.GitHubProjectsConfig{
+			Enabled:       true,
+			ProjectNumber: 3,
+		},
+	}
+	rateCalls := 0
+	o := &Orchestrator{
+		cfg: cfg,
+		projectField: &github.ProjectField{
+			ProjectID: "PVT_test",
+			FieldID:   "FIELD_test",
+			Options:   map[string]string{"Todo": "opt-todo", "In Progress": "opt-progress", "Done": "opt-done"},
+		},
+		rateLimitFn: func() (github.RateLimitStatus, error) {
+			rateCalls++
+			return github.RateLimitStatus{
+				GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 0, Used: 5000},
+			}, nil
+		},
+	}
+
+	if !o.syncProject(42, github.ProjectStatusLiveVerify) {
+		t.Fatal("syncProject should report handled when board lacks lifecycle status candidates")
+	}
+	if rateCalls != 0 {
+		t.Fatalf("rateLimit calls = %d, want 0 for unsupported status with known project field", rateCalls)
+	}
+}
+
 func TestReconcileSessionsToProjectBoard_SkipsAlreadySyncedStatus(t *testing.T) {
 	cfg := &config.Config{
 		Repo: "owner/repo",
@@ -5636,6 +5668,44 @@ func TestRunOncePersistsProjectStatusSyncAfterReconcile(t *testing.T) {
 	}
 	if syncCalls != 1 {
 		t.Fatalf("sync calls = %d, want 1 after cached second pass", syncCalls)
+	}
+}
+
+func TestReconcileProjectBoard_DoesNotCheckRateLimitWhenSweepThrottled(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		GitHubProjects: config.GitHubProjectsConfig{
+			Enabled:       true,
+			ProjectNumber: 3,
+		},
+	}
+
+	rateCalls := 0
+	o := &Orchestrator{
+		cfg: cfg,
+		projectField: &github.ProjectField{
+			ProjectID: "PVT_test",
+			FieldID:   "FIELD_test",
+			Options:   map[string]string{"Todo": "opt-todo", "In Progress": "opt-progress", "Done": "opt-done"},
+		},
+		projectItemsSweepAt: time.Now().UTC(),
+		rateLimitFn: func() (github.RateLimitStatus, error) {
+			rateCalls++
+			return github.RateLimitStatus{
+				GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000},
+			}, nil
+		},
+		listNonDoneProjectItemsFn: func(pf *github.ProjectField) ([]github.ProjectItem, error) {
+			t.Fatal("throttled reconcile should not sweep project items")
+			return nil, nil
+		},
+	}
+
+	if o.reconcileProjectBoard(state.NewState()) {
+		t.Fatal("throttled reconcile without session transitions should be unchanged")
+	}
+	if rateCalls != 0 {
+		t.Fatalf("rateLimit calls = %d, want 0 while sweep is throttled", rateCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- avoid probing GitHub rate_limit on every idle ProjectV2 reconcile cycle
- only check GraphQL budget before actual broad sweeps or status mutations
- treat unsupported lifecycle statuses without a budget probe when project fields are already cached

## Tests
- go test ./internal/orchestrator ./internal/github ./internal/supervisor
- go test ./...
- go build ./cmd/maestro

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defers the GitHub GraphQL rate-limit probe until an actual API call is imminent, eliminating the `rate_limit` check on every idle ProjectV2 reconcile cycle where no mutations or sweeps are needed.

- In `syncProject`, the budget check is moved to just before `TrySyncIssueStatusOneOf`; if the project field is already cached and no candidate matches the lifecycle status, the function returns early without touching the rate API at all.
- In `reconcileProjectBoard`, the upfront budget check is removed; session reconciliation and the sweep-due guard both run first, and the budget is only probed when a sweep is actually about to execute.
- Two new targeted tests confirm the idle-no-probe behavior for both the missing-lifecycle-status and throttled-sweep cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all actual GitHub API call sites retain a budget check, and the optimization only skips the probe on paths that were already no-ops.

The refactoring is narrowly scoped: ensureProjectField already had an internal budget check for the field-discovery path, so removing the outer check does not expose any unguarded API call. Every path that reaches TrySyncIssueStatusOneOf or listNonDoneProjectItems still goes through projectGraphQLBudgetAvailable, and the 1-minute cache means repeated calls within a reconcile cycle are free. The new tests faithfully reproduce the two optimized paths and assert the absence of rate calls.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Budget check moved after field cache hit and sweep-due guard; new `projectField == nil` guard added in syncProject; logic is correct and all real API call paths retain a budget check. |
| internal/orchestrator/orchestrator_test.go | Two new tests covering the idle-no-probe paths; assertions are correct and test setup accurately reflects the optimized code paths. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid idle ProjectV2 rate checks"](https://github.com/befeast/maestro/commit/b47b8f66a2ba812dadd711fc51a53d62058e36c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32539360)</sub>

<!-- /greptile_comment -->