### PR TITLE
fix: stop supervisor rate-limit polling

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -94,22 +94,16 @@ type prGreptileReader interface {
 	PRGreptileApproved(prNumber int) (approved bool, pending bool, err error)
 }
 
-type rateLimitReader interface {
-	RateLimit() (github.RateLimitStatus, error)
-}
-
 // Engine makes deterministic supervisor decisions. It plans safe queue mutations
 // and emits structured stuck-state explanations.
 type Engine struct {
-	cfg                       *config.Config
-	reader                    Reader
-	llm                       LLMClient
-	now                       func() time.Time
-	pidAlive                  func(pid int) bool
-	stat                      func(name string) (os.FileInfo, error)
-	lookPath                  func(file string) (string, error)
-	rateBudgetChecked         bool
-	rateBudgetStuckStateCache []state.SupervisorStuckState
+	cfg      *config.Config
+	reader   Reader
+	llm      LLMClient
+	now      func() time.Time
+	pidAlive func(pid int) bool
+	stat     func(name string) (os.FileInfo, error)
+	lookPath func(file string) (string, error)
 }
 
 func NewEngine(cfg *config.Config, reader Reader) *Engine {
@@ -216,19 +210,6 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	}
 	projectState.OpenPRs = len(prs)
 	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false)
-
-	if stuck := githubProjectRateLimitStuckState(stuckStates); stuck != nil {
-		reasons := appendReasons(baseReasons,
-			stuck.Summary,
-			"GitHub Project sync is enabled, but ProjectV2 truth cannot be reconciled while the GraphQL bucket is exhausted",
-			"Supervisor must not report idle/no-work as healthy when an enabled source of truth is unavailable",
-		)
-		decision := e.decision(st, now, projectState, ActionNotifyRed,
-			"GitHub Project sync is blocked by API rate budget; do not treat the queue as healthy until it recovers.",
-			RiskSafe, 0.94, nil, PolicyRuleRuntimeState, reasons)
-		decision.StuckStates = stuckStates
-		return decision, nil
-	}
 
 	if slot, sess, pr, ok := sessionWithOpenPR(st, prs); ok {
 		if e.openPRNeedsRepair(st, stuckStates, slot, sess, pr) {
@@ -586,7 +567,6 @@ func (e *Engine) decision(st *state.State, now time.Time, ps state.SupervisorPro
 
 func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.PR, issues, eligible []github.Issue, skipped []string, issuesLoaded bool) []state.SupervisorStuckState {
 	var findings []state.SupervisorStuckState
-	findings = append(findings, e.detectRateBudgetStuckStates()...)
 	findings = append(findings, e.detectWorkerStuckStates(st, now)...)
 	findings = append(findings, e.detectPRStuckStates(st, prs)...)
 	if issuesLoaded {
@@ -596,51 +576,6 @@ func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.
 	findings = append(findings, e.detectEnvironmentStuckStates(st, eligible)...)
 	findings = append(findings, e.detectOutcomeStuckStates(st)...)
 	return compactStuckStates(findings)
-}
-
-func (e *Engine) detectRateBudgetStuckStates() []state.SupervisorStuckState {
-	if e.rateBudgetChecked {
-		return e.rateBudgetStuckStateCache
-	}
-	e.rateBudgetChecked = true
-	e.rateBudgetStuckStateCache = e.readRateBudgetStuckStates()
-	return e.rateBudgetStuckStateCache
-}
-
-func (e *Engine) readRateBudgetStuckStates() []state.SupervisorStuckState {
-	if e == nil || e.cfg == nil || !e.cfg.GitHubProjects.Enabled || e.cfg.GitHubProjects.ProjectNumber == 0 {
-		return nil
-	}
-	reader, ok := e.reader.(rateLimitReader)
-	if !ok {
-		return nil
-	}
-	rate, err := reader.RateLimit()
-	if err != nil {
-		return []state.SupervisorStuckState{stuckState("github_rate_budget_unknown", SeverityWarning,
-			"GitHub API rate budget could not be read.",
-			"Verify GitHub auth and rate-limit access before trusting Project reconciliation.", false, nil,
-			fmt.Sprintf("rate_limit_error=%v", err))}
-	}
-	if rate.GraphQL.Remaining > 0 {
-		return nil
-	}
-	return []state.SupervisorStuckState{stuckState("github_graphql_rate_exhausted", SeverityBlocked,
-		"GitHub GraphQL rate limit is exhausted, so Project truth cannot be reconciled.",
-		"Wait for the GraphQL reset or reduce ProjectV2 polling before treating Project state as healthy.", false, nil,
-		fmt.Sprintf("graphql_remaining=%d", rate.GraphQL.Remaining),
-		fmt.Sprintf("graphql_used=%d/%d", rate.GraphQL.Used, rate.GraphQL.Limit),
-		fmt.Sprintf("graphql_reset=%d", rate.GraphQL.Reset),
-		fmt.Sprintf("core_remaining=%d", rate.Core.Remaining))}
-}
-
-func githubProjectRateLimitStuckState(stuckStates []state.SupervisorStuckState) *state.SupervisorStuckState {
-	for i := range stuckStates {
-		if stuckStates[i].Code == "github_graphql_rate_exhausted" {
-			return &stuckStates[i]
-		}
-	}
-	return nil
 }
 
 func (e *Engine) outcomeStatus(st *state.State) outcome.Status {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -29,6 +29,7 @@ type fakeReader struct {
 	greptilePend   map[int]bool
 	rateLimit      *github.RateLimitStatus
 	rateLimitErr   error
+	rateLimitCalls int
 	issueCalls     int
 	addedLabels    []string
 	removedLabels  []string
@@ -119,6 +120,7 @@ func (f *fakeReader) PRGreptileApproved(prNumber int) (bool, bool, error) {
 }
 
 func (f *fakeReader) RateLimit() (github.RateLimitStatus, error) {
+	f.rateLimitCalls++
 	if f.rateLimitErr != nil {
 		return github.RateLimitStatus{}, f.rateLimitErr
 	}
@@ -165,7 +167,7 @@ func requireStuckState(t *testing.T, decision state.SupervisorDecision, code str
 	return state.SupervisorStuckState{}
 }
 
-func TestDecide_ProjectGraphQLRateExhaustedDoesNotReportIdle(t *testing.T) {
+func TestDecide_DoesNotPollRateLimitEndpointForIdleDecision(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.GitHubProjects.Enabled = true
 	cfg.GitHubProjects.ProjectNumber = 3
@@ -181,19 +183,13 @@ func TestDecide_ProjectGraphQLRateExhaustedDoesNotReportIdle(t *testing.T) {
 		t.Fatalf("Decide: %v", err)
 	}
 
-	if decision.RecommendedAction != ActionNotifyRed {
-		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionNotifyRed)
+	if reader.rateLimitCalls != 0 {
+		t.Fatalf("RateLimit calls = %d, want 0; supervisor must not burn API budget to measure API budget", reader.rateLimitCalls)
 	}
-	stuck := requireStuckState(t, decision, "github_graphql_rate_exhausted")
-	if stuck.Severity != SeverityBlocked {
-		t.Fatalf("severity = %q, want %q", stuck.Severity, SeverityBlocked)
-	}
-	if reader.issueCalls != 0 {
-		t.Fatalf("ListOpenIssues called %d time(s), want rate-budget gate before queue throughput", reader.issueCalls)
-	}
-	reasons := strings.Join(decision.Reasons, "\n")
-	if !strings.Contains(reasons, "must not report idle/no-work as healthy") {
-		t.Fatalf("reasons = %q, want explicit false-idle guardrail", reasons)
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == "github_graphql_rate_exhausted" || stuck.Code == "github_rate_budget_unknown" {
+			t.Fatalf("unexpected proactive rate-budget stuck state: %+v", stuck)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop supervisor decisions from proactively calling GitHub rate_limit
- remove the false safety gate that burned API budget to measure API budget
- keep rate-limit handling on real REST/Project operations and mutation error classification

## Tests
- go test ./internal/supervisor ./internal/orchestrator ./internal/github
- go test ./...
- go build ./cmd/maestro

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the proactive `RateLimit()` polling that the supervisor was calling on every decision cycle to guard against false-idle reports when GitHub Projects' GraphQL bucket was exhausted. Rate-limit errors are now handled reactively, surfacing only when real Project or REST operations actually fail.

- **`supervisor.go`**: Deletes the `rateLimitReader` interface, the two memoisation fields (`rateBudgetChecked`, `rateBudgetStuckStateCache`), the three helper functions that implemented the proactive check, and the early-return guard in `decideDeterministic` that emitted `ActionNotifyRed` on GraphQL exhaustion.
- **`supervisor_test.go`**: Renames and inverts the existing test — it now asserts that `RateLimit()` is called zero times during an idle decision, and that no rate-budget stuck states appear in the result; a `rateLimitCalls` counter is added to `fakeReader` to support this assertion.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the deletion is internally consistent and the new test correctly validates the intended behavior.

The production code change is clean with no dangling references. The only minor issue is that the exhausted-GraphQL fixture in the test is now dead data — it is set up but never read, which could mislead future readers about what the test actually exercises.

`internal/supervisor/supervisor_test.go` — the `rateLimit` fixture (lines 175–178) is now unreachable and worth removing for clarity.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Removes proactive rate-limit polling from the supervisor decision engine: deletes `rateLimitReader` interface, two memoisation fields, `detectRateBudgetStuckStates`, `readRateBudgetStuckStates`, and `githubProjectRateLimitStuckState`, plus the early-return guard in `decideDeterministic`. The removal is internally consistent; no dangling references remain. |
| internal/supervisor/supervisor_test.go | Test renamed and inverted to assert zero `RateLimit` calls on an idle decision; adds `rateLimitCalls` counter to `fakeReader`. The exhausted-GraphQL fixture set up on lines 175–178 is now dead data and can be removed. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/supervisor/supervisor_test.go`, line 174-179 ([link](https://github.com/befeast/maestro/blob/90dc845aeea18eb1d1696d1f6730e6ec81fdc3a0/internal/supervisor/supervisor_test.go#L174-L179)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Dead test fixture data after behavior inversion**

   The `rateLimit` field on `fakeReader` (lines 175–178, with `GraphQL.Remaining: 0`) is now unreachable test data. Because the assertion checks that `rateLimitCalls == 0`, the `RateLimit()` method is never invoked, so the exhausted-bucket setup has no effect on the outcome. The fixture can be removed without changing the test's intent — keeping it implies future readers might think it participates in the assertion.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/supervisor/supervisor_test.go
   Line: 174-179

   Comment:
   **Dead test fixture data after behavior inversion**

   The `rateLimit` field on `fakeReader` (lines 175–178, with `GraphQL.Remaining: 0`) is now unreachable test data. Because the assertion checks that `rateLimitCalls == 0`, the `RateLimit()` method is never invoked, so the exhausted-bucket setup has no effect on the outcome. The fixture can be removed without changing the test's intent — keeping it implies future readers might think it participates in the assertion.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/supervisor_test.go:174-179
**Dead test fixture data after behavior inversion**

The `rateLimit` field on `fakeReader` (lines 175–178, with `GraphQL.Remaining: 0`) is now unreachable test data. Because the assertion checks that `rateLimitCalls == 0`, the `RateLimit()` method is never invoked, so the exhausted-bucket setup has no effect on the outcome. The fixture can be removed without changing the test's intent — keeping it implies future readers might think it participates in the assertion.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop supervisor rate-limit polling"](https://github.com/befeast/maestro/commit/90dc845aeea18eb1d1696d1f6730e6ec81fdc3a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32540070)</sub>

<!-- /greptile_comment -->