### PR TITLE
P0: detect outcome drift after merge or issue close

### DIFF
--- a/internal/outcome/drift.go
+++ b/internal/outcome/drift.go
@@ -1,0 +1,169 @@
+package outcome
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// CompletedWork is one "GitHub says done" record — a merged PR and/or closed
+// issue — that the drift detector evaluates against the configured runtime
+// outcome signals.
+//
+// The shape is intentionally decoupled from internal/state so this package
+// stays a leaf any caller can adapt.
+type CompletedWork struct {
+	Session     string
+	MergedPR    int
+	ClosedIssue int
+	FinishedAt  time.Time
+}
+
+// Drift records the state "GitHub says done, but project outcome/runtime says
+// not done" for one completed work record. It is what Fleet renders as an
+// active drift item and what supervisor policy turns into a stuck state.
+type Drift struct {
+	Session          string    `json:"session,omitempty"`
+	MergedPR         int       `json:"merged_pr,omitempty"`
+	ClosedIssue      int       `json:"closed_issue,omitempty"`
+	Signal           string    `json:"signal,omitempty"`
+	HealthState      string    `json:"health_state"`
+	Summary          string    `json:"summary"`
+	NextAction       string    `json:"next_action"`
+	RequiresApproval bool      `json:"requires_approval,omitempty"`
+	FinishedAt       time.Time `json:"finished_at,omitempty"`
+}
+
+// DetectDrift returns drift items for completed work whose runtime outcome
+// cannot be confirmed by the latest health check. It is read-only and never
+// runs commands; callers must execute outcome.Checker separately.
+//
+// A drift item is emitted when any of the following holds for a completed
+// record:
+//   - The outcome brief is configured but no health signal is configured
+//     (HealthUnmonitored).
+//   - No health check has been recorded yet (HealthUnknown).
+//   - The latest health check is in HealthFailing or HealthUnknown state.
+//   - The latest check is healthy but its CheckedAt predates the record's
+//     FinishedAt, so it cannot prove the runtime caught up with the merge.
+//
+// A healthy check whose CheckedAt is at-or-after the record's FinishedAt
+// clears that record. Records without a recorded FinishedAt fall back to the
+// latest known health state without a per-record staleness check.
+//
+// If the brief is not configured at all, DetectDrift returns nil — that case
+// is surfaced as a separate "missing outcome brief" stuck state by the
+// supervisor.
+func DetectDrift(brief Brief, completed []CompletedWork, latest *HealthCheckResult) []Drift {
+	if len(completed) == 0 {
+		return nil
+	}
+	brief = brief.Normalized()
+	if !brief.Configured() {
+		return nil
+	}
+	signal := configuredSignalName(brief)
+	health, healthCheckedAt := evaluateLatestHealth(brief, latest)
+
+	out := make([]Drift, 0, len(completed))
+	for _, work := range completed {
+		if work.MergedPR == 0 && work.ClosedIssue == 0 {
+			continue
+		}
+		recordHealth := health
+		if recordHealth == HealthHealthy && !work.FinishedAt.IsZero() && healthCheckedAt.Before(work.FinishedAt) {
+			recordHealth = HealthUnknown
+		}
+		if recordHealth == HealthHealthy {
+			continue
+		}
+		drift := Drift{
+			Session:     strings.TrimSpace(work.Session),
+			MergedPR:    work.MergedPR,
+			ClosedIssue: work.ClosedIssue,
+			Signal:      signal,
+			HealthState: recordHealth,
+			FinishedAt:  work.FinishedAt,
+		}
+		drift.Summary = driftSummary(brief, work, recordHealth)
+		drift.NextAction = driftNextAction(brief, recordHealth)
+		out = append(out, drift)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].MergedPR != out[j].MergedPR {
+			return out[i].MergedPR < out[j].MergedPR
+		}
+		if out[i].ClosedIssue != out[j].ClosedIssue {
+			return out[i].ClosedIssue < out[j].ClosedIssue
+		}
+		return out[i].Session < out[j].Session
+	})
+	return out
+}
+
+func configuredSignalName(brief Brief) string {
+	switch {
+	case brief.HealthcheckURL != "":
+		return "healthcheck_url"
+	case brief.HealthcheckCommand != "":
+		return "healthcheck_command"
+	case brief.DeploymentStatusCommand != "":
+		return "deployment_status_command"
+	default:
+		return ""
+	}
+}
+
+func evaluateLatestHealth(brief Brief, latest *HealthCheckResult) (string, time.Time) {
+	if !brief.HasHealthSignal() {
+		return HealthUnmonitored, time.Time{}
+	}
+	if latest == nil || latest.CheckedAt.IsZero() {
+		return HealthUnknown, time.Time{}
+	}
+	return normalizedHealthState(latest.State), latest.CheckedAt
+}
+
+func driftSummary(brief Brief, work CompletedWork, health string) string {
+	goal := strings.TrimSpace(brief.Goal())
+	if goal == "" {
+		goal = "the configured runtime outcome"
+	}
+	subject := workSubject(work)
+	switch health {
+	case HealthFailing:
+		return fmt.Sprintf("%s landed, but the configured runtime check is failing for %s.", subject, goal)
+	case HealthUnmonitored:
+		return fmt.Sprintf("%s landed, but no runtime health signal is configured to verify %s.", subject, goal)
+	default:
+		return fmt.Sprintf("%s landed, but runtime outcome health is %s for %s.", subject, strings.ReplaceAll(health, "_", " "), goal)
+	}
+}
+
+func driftNextAction(brief Brief, health string) string {
+	switch health {
+	case HealthUnmonitored:
+		return "Configure a read-only deployment status or healthcheck command/URL so Maestro can verify the runtime outcome."
+	case HealthFailing:
+		return "Fix the failing runtime/deploy health signal before treating this merge as truly done."
+	default:
+		if brief.HasHealthSignal() {
+			return "Re-run the configured runtime healthcheck and prioritize runtime/deploy fixes until it passes."
+		}
+		return "Configure a runtime health signal and verify the runtime target before treating this work as complete."
+	}
+}
+
+func workSubject(work CompletedWork) string {
+	switch {
+	case work.MergedPR > 0 && work.ClosedIssue > 0:
+		return fmt.Sprintf("PR #%d (issue #%d)", work.MergedPR, work.ClosedIssue)
+	case work.MergedPR > 0:
+		return fmt.Sprintf("PR #%d", work.MergedPR)
+	case work.ClosedIssue > 0:
+		return fmt.Sprintf("Issue #%d", work.ClosedIssue)
+	default:
+		return "Completed work"
+	}
+}

--- a/internal/outcome/drift_test.go
+++ b/internal/outcome/drift_test.go
@@ -1,0 +1,152 @@
+package outcome
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectDriftClosedIssueWithFailingRuntime(t *testing.T) {
+	finished := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	drifts := DetectDrift(
+		Brief{DesiredOutcome: "App is live", HealthcheckURL: "https://app.example.com/healthz"},
+		[]CompletedWork{{Session: "w1", ClosedIssue: 42, FinishedAt: finished}},
+		&HealthCheckResult{CheckedAt: finished.Add(time.Minute), State: HealthFailing, Signal: "healthcheck_url"},
+	)
+	if len(drifts) != 1 {
+		t.Fatalf("len(drifts) = %d, want 1", len(drifts))
+	}
+	d := drifts[0]
+	if d.ClosedIssue != 42 || d.MergedPR != 0 {
+		t.Fatalf("drift target = %+v, want closed issue 42 only", d)
+	}
+	if d.HealthState != HealthFailing {
+		t.Fatalf("HealthState = %q, want %q", d.HealthState, HealthFailing)
+	}
+	if d.Signal != "healthcheck_url" {
+		t.Fatalf("Signal = %q, want healthcheck_url", d.Signal)
+	}
+	if !strings.Contains(d.Summary, "Issue #42") || !strings.Contains(d.Summary, "App is live") {
+		t.Fatalf("Summary = %q, want issue number and goal", d.Summary)
+	}
+	if d.NextAction == "" {
+		t.Fatalf("NextAction is empty, want a recommendation")
+	}
+}
+
+func TestDetectDriftMergedPRWithUnknownRuntime(t *testing.T) {
+	finished := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	drifts := DetectDrift(
+		Brief{DesiredOutcome: "App is live", HealthcheckCommand: "status.sh"},
+		[]CompletedWork{{Session: "w1", MergedPR: 99, ClosedIssue: 42, FinishedAt: finished}},
+		nil,
+	)
+	if len(drifts) != 1 {
+		t.Fatalf("len(drifts) = %d, want 1", len(drifts))
+	}
+	d := drifts[0]
+	if d.HealthState != HealthUnknown {
+		t.Fatalf("HealthState = %q, want %q", d.HealthState, HealthUnknown)
+	}
+	if d.MergedPR != 99 || d.ClosedIssue != 42 {
+		t.Fatalf("drift target = %+v, want merged PR 99 and closed issue 42", d)
+	}
+	if d.Signal != "healthcheck_command" {
+		t.Fatalf("Signal = %q, want healthcheck_command", d.Signal)
+	}
+	if !strings.Contains(d.Summary, "PR #99") || !strings.Contains(d.Summary, "issue #42") {
+		t.Fatalf("Summary = %q, want PR and issue numbers", d.Summary)
+	}
+	if !strings.Contains(d.NextAction, "healthcheck") {
+		t.Fatalf("NextAction = %q, want healthcheck guidance", d.NextAction)
+	}
+}
+
+func TestDetectDriftClearedByHealthyCheckAfterFinish(t *testing.T) {
+	finished := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	drifts := DetectDrift(
+		Brief{DesiredOutcome: "App is live", HealthcheckURL: "https://app.example.com/healthz"},
+		[]CompletedWork{
+			{Session: "w1", MergedPR: 99, ClosedIssue: 42, FinishedAt: finished},
+			{Session: "w2", MergedPR: 100, ClosedIssue: 43, FinishedAt: finished.Add(-time.Minute)},
+		},
+		&HealthCheckResult{CheckedAt: finished.Add(2 * time.Minute), State: HealthHealthy, Signal: "healthcheck_url"},
+	)
+	if len(drifts) != 0 {
+		t.Fatalf("len(drifts) = %d, want 0 (healthy check after both finish times clears drift)", len(drifts))
+	}
+}
+
+func TestDetectDriftStaleHealthyCheckCountsAsUnknown(t *testing.T) {
+	finished := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	drifts := DetectDrift(
+		Brief{DesiredOutcome: "App is live", HealthcheckURL: "https://app.example.com/healthz"},
+		[]CompletedWork{{Session: "w1", MergedPR: 99, ClosedIssue: 42, FinishedAt: finished}},
+		&HealthCheckResult{CheckedAt: finished.Add(-time.Hour), State: HealthHealthy, Signal: "healthcheck_url"},
+	)
+	if len(drifts) != 1 {
+		t.Fatalf("len(drifts) = %d, want 1 (healthy check before finish should not clear drift)", len(drifts))
+	}
+	if drifts[0].HealthState != HealthUnknown {
+		t.Fatalf("HealthState = %q, want %q for stale healthy check", drifts[0].HealthState, HealthUnknown)
+	}
+}
+
+func TestDetectDriftUnmonitoredBrief(t *testing.T) {
+	drifts := DetectDrift(
+		Brief{DesiredOutcome: "App is live"},
+		[]CompletedWork{{Session: "w1", MergedPR: 99, ClosedIssue: 42}},
+		nil,
+	)
+	if len(drifts) != 1 {
+		t.Fatalf("len(drifts) = %d, want 1", len(drifts))
+	}
+	if drifts[0].HealthState != HealthUnmonitored {
+		t.Fatalf("HealthState = %q, want %q", drifts[0].HealthState, HealthUnmonitored)
+	}
+	if drifts[0].Signal != "" {
+		t.Fatalf("Signal = %q, want empty for unmonitored brief", drifts[0].Signal)
+	}
+	if !strings.Contains(drifts[0].NextAction, "Configure") {
+		t.Fatalf("NextAction = %q, want configure guidance", drifts[0].NextAction)
+	}
+}
+
+func TestDetectDriftMissingBriefReturnsNil(t *testing.T) {
+	drifts := DetectDrift(
+		Brief{},
+		[]CompletedWork{{Session: "w1", MergedPR: 99}},
+		&HealthCheckResult{State: HealthFailing},
+	)
+	if len(drifts) != 0 {
+		t.Fatalf("len(drifts) = %d, want 0 (missing brief is a separate stuck state)", len(drifts))
+	}
+}
+
+func TestDetectDriftIgnoresRecordsWithoutTarget(t *testing.T) {
+	drifts := DetectDrift(
+		Brief{DesiredOutcome: "App is live", HealthcheckURL: "https://app.example.com/healthz"},
+		[]CompletedWork{{Session: "w1"}},
+		&HealthCheckResult{State: HealthFailing},
+	)
+	if len(drifts) != 0 {
+		t.Fatalf("len(drifts) = %d, want 0 for record with no PR or issue", len(drifts))
+	}
+}
+
+func TestDetectDriftSortsByTargetForStableUI(t *testing.T) {
+	drifts := DetectDrift(
+		Brief{DesiredOutcome: "App is live", HealthcheckURL: "https://app.example.com/healthz"},
+		[]CompletedWork{
+			{Session: "b", MergedPR: 20, ClosedIssue: 200},
+			{Session: "a", MergedPR: 10, ClosedIssue: 100},
+		},
+		nil,
+	)
+	if len(drifts) != 2 {
+		t.Fatalf("len(drifts) = %d, want 2", len(drifts))
+	}
+	if drifts[0].MergedPR != 10 || drifts[1].MergedPR != 20 {
+		t.Fatalf("drifts = %+v, want sorted by merged PR ascending", drifts)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -624,12 +624,19 @@ func outcomeIssueReason(status outcome.Status, issue github.Issue) string {
 }
 
 func (e *Engine) detectOutcomeStuckStates(st *state.State) []state.SupervisorStuckState {
-	status := e.outcomeStatus(st)
-	if !status.Configured {
+	if e == nil || e.cfg == nil {
+		return nil
+	}
+	if !e.cfg.Outcome.Configured() {
 		return []state.SupervisorStuckState{stuckState(state.StuckMissingOutcomeBrief, SeverityWarning,
 			"No outcome brief is configured for this project.",
 			"Add an outcome brief with the desired runtime goal, target, health signal, and non-goals before treating issue throughput as success.", false, nil,
 			"Outcome brief configured: false")}
+	}
+	status := e.outcomeStatus(st)
+	findings := e.outcomeDriftStuckStates(st)
+	if len(findings) > 0 {
+		return findings
 	}
 	switch status.HealthState {
 	case outcome.HealthFailing:
@@ -645,6 +652,70 @@ func (e *Engine) detectOutcomeStuckStates(st *state.State) []state.SupervisorStu
 	default:
 		return nil
 	}
+}
+
+func (e *Engine) outcomeDriftStuckStates(st *state.State) []state.SupervisorStuckState {
+	if st == nil {
+		return nil
+	}
+	completed := completedWorkFromSessions(st)
+	if len(completed) == 0 {
+		return nil
+	}
+	drifts := outcome.DetectDrift(e.cfg.Outcome, completed, st.OutcomeHealth)
+	if len(drifts) == 0 {
+		return nil
+	}
+	findings := make([]state.SupervisorStuckState, 0, len(drifts))
+	for _, drift := range drifts {
+		target := &state.SupervisorTarget{
+			Issue:   drift.ClosedIssue,
+			PR:      drift.MergedPR,
+			Session: drift.Session,
+		}
+		evidence := []string{fmt.Sprintf("health_state=%s", drift.HealthState)}
+		if drift.Signal != "" {
+			evidence = append(evidence, "signal="+drift.Signal)
+		}
+		if drift.MergedPR > 0 {
+			evidence = append(evidence, fmt.Sprintf("merged_pr=%d", drift.MergedPR))
+		}
+		if drift.ClosedIssue > 0 {
+			evidence = append(evidence, fmt.Sprintf("closed_issue=%d", drift.ClosedIssue))
+		}
+		findings = append(findings, stuckState(state.StuckNoOutcomeProgress, SeverityBlocked,
+			drift.Summary, drift.NextAction, false, target, evidence...))
+	}
+	return findings
+}
+
+func completedWorkFromSessions(st *state.State) []outcome.CompletedWork {
+	if st == nil {
+		return nil
+	}
+	work := make([]outcome.CompletedWork, 0, len(st.Sessions))
+	for slot, sess := range st.Sessions {
+		if sess == nil {
+			continue
+		}
+		if sess.Status != state.StatusDone && sess.Status != state.StatusCodeLanded {
+			continue
+		}
+		if sess.PRNumber == 0 && sess.IssueNumber == 0 {
+			continue
+		}
+		finishedAt := time.Time{}
+		if sess.FinishedAt != nil {
+			finishedAt = sess.FinishedAt.UTC()
+		}
+		work = append(work, outcome.CompletedWork{
+			Session:     slot,
+			MergedPR:    sess.PRNumber,
+			ClosedIssue: sess.IssueNumber,
+			FinishedAt:  finishedAt,
+		})
+	}
+	return work
 }
 
 func (e *Engine) outcomeProgressStuckState(st *state.State, status outcome.Status, canAct bool) state.SupervisorStuckState {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -744,6 +744,85 @@ func TestDecide_FailingOutcomeImmediatelyBlocksFalseGreen(t *testing.T) {
 	}
 }
 
+func TestDecide_SingleMergeWithFailingOutcomeRecordsDriftTarget(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome: "Hosted app responds to users",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	finished := now.Add(-15 * time.Minute)
+	st := state.NewState()
+	st.LastMergeAt = finished
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: finished.Add(-time.Hour),
+		Signal:    "healthcheck_url",
+		State:     outcome.HealthFailing,
+		Summary:   "GET returned 503",
+	}
+	st.Sessions["done-1"] = &state.Session{
+		IssueNumber: 7,
+		IssueTitle:  "first",
+		Status:      state.StatusDone,
+		PRNumber:    42,
+		StartedAt:   finished.Add(-2 * time.Hour),
+		FinishedAt:  &finished,
+	}
+
+	decision, err := testEngine(cfg, &fakeReader{}).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionCheckOutcomeHealth {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionCheckOutcomeHealth)
+	}
+	stuck := requireStuckState(t, decision, state.StuckNoOutcomeProgress)
+	if stuck.Target == nil || stuck.Target.PR != 42 || stuck.Target.Issue != 7 {
+		t.Fatalf("stuck target = %#v, want PR 42 / issue 7", stuck.Target)
+	}
+	evidenceJoined := strings.Join(stuck.Evidence, " ")
+	if !strings.Contains(evidenceJoined, "merged_pr=42") || !strings.Contains(evidenceJoined, "closed_issue=7") {
+		t.Fatalf("stuck evidence = %v, want merged_pr and closed_issue", stuck.Evidence)
+	}
+	if !strings.Contains(evidenceJoined, "signal=healthcheck_url") {
+		t.Fatalf("stuck evidence = %v, want healthcheck_url signal", stuck.Evidence)
+	}
+}
+
+func TestDecide_ClosedIssueWithoutPRDriftsOnFailingRuntime(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:     "Hosted app responds to users",
+		HealthcheckCommand: "status.sh",
+	}
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	finished := now.Add(-time.Hour)
+	st := state.NewState()
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: finished.Add(time.Minute),
+		Signal:    "healthcheck_command",
+		State:     outcome.HealthFailing,
+	}
+	st.Sessions["done-closed"] = &state.Session{
+		IssueNumber: 8,
+		IssueTitle:  "closed without PR",
+		Status:      state.StatusDone,
+		FinishedAt:  &finished,
+	}
+
+	decision, err := testEngine(cfg, &fakeReader{}).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	stuck := requireStuckState(t, decision, state.StuckNoOutcomeProgress)
+	if stuck.Target == nil || stuck.Target.Issue != 8 || stuck.Target.PR != 0 {
+		t.Fatalf("stuck target = %#v, want issue 8 only", stuck.Target)
+	}
+	if !strings.Contains(stuck.Summary, "Issue #8") {
+		t.Fatalf("stuck summary = %q, want Issue #8 reference", stuck.Summary)
+	}
+}
+
 func TestDecideDeterministic_OutcomeUsesStateMergeHistory(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.Outcome = outcome.Brief{


### PR DESCRIPTION
Refs #353

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces outcome drift detection: after a PR is merged or an issue is closed, Maestro now checks whether the configured runtime health signal has confirmed the post-merge state, and surfaces a `StuckNoOutcomeProgress` stuck state for each session whose runtime outcome cannot be verified.

- `internal/outcome/drift.go` adds `DetectDrift`, which compares completed-work records against the latest `HealthCheckResult` and emits per-session `Drift` items when health is failing, unknown, unmonitored, or predates the merge.
- `internal/supervisor/supervisor.go` wires drift into `detectOutcomeStuckStates` via `outcomeDriftStuckStates` and `completedWorkFromSessions`, and adds a nil-guard on `e` and `e.cfg` that was previously absent.

<h3>Confidence Score: 3/5</h3>

The new drift path in supervisor.go has two correctness gaps that could surface incorrect stuck states for real projects before this is considered safe to merge.

completedWorkFromSessions sets ClosedIssue: sess.IssueNumber for StatusCodeLanded sessions even though that status only guarantees the PR merged, not that the associated issue was closed. Separately, the early return on drift findings short-circuits before the HealthFailing switch case, bypassing the explicit return nil for projects that opted out of health-failure blocking via FailRequiresVisibleWork = false.

internal/supervisor/supervisor.go — specifically completedWorkFromSessions (the StatusCodeLanded / ClosedIssue mapping) and the early-return ordering in detectOutcomeStuckStates.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/outcome/drift.go | New file implementing `DetectDrift` and helpers; logic is clean and well-commented. Minor issue: `Drift.RequiresApproval` is declared but never populated. |
| internal/outcome/drift_test.go | Good coverage across the main drift scenarios (failing, unknown, stale-healthy, unmonitored, missing brief, empty target, sort stability). No issues found. |
| internal/supervisor/supervisor.go | Two logic issues: (1) early drift return bypasses the `FailRequiresVisibleWork = false` suppression path; (2) `StatusCodeLanded` sessions map `IssueNumber` to `ClosedIssue` even when the associated issue may not be closed. |
| internal/supervisor/supervisor_test.go | Two new integration tests exercise the primary drift scenarios (merged PR + closed issue, closed issue only). No test covers the `StatusCodeLanded` path or the `FailRequiresVisibleWork = false` interaction. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/supervisor/supervisor.go`, line 636-645 ([link](https://github.com/befeast/maestro/blob/d145f57dd8d481d51f7a346ccf61f83e887795db/internal/supervisor/supervisor.go#L636-L645)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Drift early-return silently bypasses `FailRequiresVisibleWork = false`**

   When `outcomeDriftStuckStates` returns at least one finding, `detectOutcomeStuckStates` returns those findings without ever reaching the `HealthFailing` switch case. That switch case has an explicit `return nil` path for projects where `FailRequiresVisibleWork` is explicitly set to `false` — meaning the operator opted out of health-failure blocking. Any project in that configuration will still receive drift stuck states for every completed session with an unhealthy runtime, contrary to the intent of the opt-out.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/supervisor/supervisor.go
   Line: 636-645

   Comment:
   **Drift early-return silently bypasses `FailRequiresVisibleWork = false`**

   When `outcomeDriftStuckStates` returns at least one finding, `detectOutcomeStuckStates` returns those findings without ever reaching the `HealthFailing` switch case. That switch case has an explicit `return nil` path for projects where `FailRequiresVisibleWork` is explicitly set to `false` — meaning the operator opted out of health-failure blocking. Any project in that configuration will still receive drift stuck states for every completed session with an unhealthy runtime, contrary to the intent of the opt-out.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/supervisor/supervisor.go:636-645
**Drift early-return silently bypasses `FailRequiresVisibleWork = false`**

When `outcomeDriftStuckStates` returns at least one finding, `detectOutcomeStuckStates` returns those findings without ever reaching the `HealthFailing` switch case. That switch case has an explicit `return nil` path for projects where `FailRequiresVisibleWork` is explicitly set to `false` — meaning the operator opted out of health-failure blocking. Any project in that configuration will still receive drift stuck states for every completed session with an unhealthy runtime, contrary to the intent of the opt-out.

### Issue 2 of 3
internal/supervisor/supervisor.go:697-716
**`StatusCodeLanded` sessions treated as having a closed issue**

`StatusCodeLanded` means the PR was merged; it does not guarantee the associated issue was closed (e.g., a PR without a `closes #N` keyword, or a manually-tracked issue). Setting `ClosedIssue: sess.IssueNumber` for these sessions passes a potentially-open issue number through to `CompletedWork.ClosedIssue`, which then surfaces as `"closed_issue=%d"` in the supervisor evidence string and as `SupervisorTarget.Issue` in the stuck state. An operator following up on the stuck state would look for a closed issue that may still be open.

### Issue 3 of 3
internal/outcome/drift.go:27-36
**`RequiresApproval` field is declared but never populated**

`Drift.RequiresApproval` is a JSON-serializable struct field, but nothing in this PR sets it — `outcomeDriftStuckStates` passes the approval flag as a hardcoded `false` literal rather than reading `drift.RequiresApproval`. Any consumer serialising a `Drift` to JSON will always see `"requires_approval": false` (or the field omitted because it's `omitempty`) regardless of any future intent. If this field is meant to be a future hook, a comment explaining that would prevent confusion; if it is not needed, it should be removed.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: detect outcome drift per merged PR..."](https://github.com/befeast/maestro/commit/d145f57dd8d481d51f7a346ccf61f83e887795db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33331399)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->