### PR TITLE
P0: detect outcome drift after merge or issue close

### DIFF
--- a/internal/outcome/drift.go
+++ b/internal/outcome/drift.go
@@ -1,0 +1,224 @@
+package outcome
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DriftActionPolicy describes how Maestro should respond to a drift item.
+const (
+	// DriftActionPolicyApprovalRequired marks an action that mutates GitHub
+	// (comment, reopen, label) and must therefore be operator-approved.
+	DriftActionPolicyApprovalRequired = "approval_required"
+	// DriftActionPolicyReadOnly marks an action that requires no mutation —
+	// the operator simply runs the configured healthcheck.
+	DriftActionPolicyReadOnly = "read_only"
+)
+
+// DriftSession is the minimal session view consumed by the drift detector.
+// State packages can build these without leaking the full session type into
+// the outcome package.
+type DriftSession struct {
+	Slot        string
+	IssueNumber int
+	IssueTitle  string
+	PRNumber    int
+	PRMerged    bool
+	IssueClosed bool
+	LandedAt    time.Time
+}
+
+// DriftItem describes a unit of work GitHub considers complete (PR merged or
+// issue closed) whose runtime/deploy outcome is failing, unknown, or missing.
+// Drift items belong on the active Fleet surface, not in history.
+type DriftItem struct {
+	Slot              string    `json:"slot,omitempty"`
+	IssueNumber       int       `json:"issue_number,omitempty"`
+	IssueTitle        string    `json:"issue_title,omitempty"`
+	PRNumber          int       `json:"pr_number,omitempty"`
+	PRMerged          bool      `json:"pr_merged,omitempty"`
+	IssueClosed       bool      `json:"issue_closed,omitempty"`
+	LandedAt          time.Time `json:"landed_at,omitempty"`
+	HealthState       string    `json:"health_state"`
+	HealthSignal      string    `json:"health_signal,omitempty"`
+	HealthCheckedAt   time.Time `json:"health_checked_at,omitempty"`
+	HealthSummary     string    `json:"health_summary,omitempty"`
+	Reason            string    `json:"reason"`
+	RecommendedAction string    `json:"recommended_action"`
+	ActionPolicy      string    `json:"action_policy,omitempty"`
+}
+
+// DetectDrifts returns active drift items for the given sessions. A drift
+// exists when a session has merged code or a closed issue but the latest
+// outcome check is missing, stale, unknown, or failing. A healthy post-merge
+// check suppresses the drift.
+//
+// Callers without a configured brief get no drift items: drift detection is
+// only meaningful once the project has declared a runtime outcome.
+func DetectDrifts(brief Brief, sessions []DriftSession, latestCheck *HealthCheckResult, now time.Time) []DriftItem {
+	brief = brief.Normalized()
+	if !brief.Configured() {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	hasSignal := brief.HasHealthSignal()
+	drifts := make([]DriftItem, 0, len(sessions))
+	for _, sess := range sessions {
+		if !sess.PRMerged && !sess.IssueClosed {
+			continue
+		}
+		item, ok := buildDriftItem(brief, sess, latestCheck, hasSignal)
+		if !ok {
+			continue
+		}
+		drifts = append(drifts, item)
+	}
+	sortDrifts(drifts)
+	return drifts
+}
+
+func buildDriftItem(brief Brief, sess DriftSession, latestCheck *HealthCheckResult, hasSignal bool) (DriftItem, bool) {
+	item := DriftItem{
+		Slot:        strings.TrimSpace(sess.Slot),
+		IssueNumber: sess.IssueNumber,
+		IssueTitle:  strings.TrimSpace(sess.IssueTitle),
+		PRNumber:    sess.PRNumber,
+		PRMerged:    sess.PRMerged && sess.PRNumber > 0,
+		IssueClosed: sess.IssueClosed,
+		LandedAt:    sess.LandedAt.UTC(),
+	}
+
+	if !hasSignal {
+		item.HealthState = HealthUnmonitored
+		item.Reason = driftReason(item, brief, HealthUnmonitored, "no runtime/deploy health signal is configured")
+		item.RecommendedAction = "Add a read-only deployment status or healthcheck command/URL, then verify the runtime outcome."
+		item.ActionPolicy = DriftActionPolicyReadOnly
+		return item, true
+	}
+
+	if latestCheck != nil && !latestCheck.CheckedAt.IsZero() {
+		item.HealthSignal = strings.TrimSpace(latestCheck.Signal)
+		item.HealthCheckedAt = latestCheck.CheckedAt.UTC()
+		item.HealthSummary = strings.TrimSpace(latestCheck.Summary)
+		state := normalizedHealthState(latestCheck.State)
+		// A check that landed before this session's merge/close cannot prove
+		// the runtime outcome for it.
+		if !item.LandedAt.IsZero() && latestCheck.CheckedAt.Before(item.LandedAt) {
+			item.HealthState = HealthUnknown
+			item.Reason = driftReason(item, brief, HealthUnknown, fmt.Sprintf("the most recent runtime check (%s) ran before this work landed", latestCheck.CheckedAt.UTC().Format(time.RFC3339)))
+			item.RecommendedAction = driftMutatingRecommendedAction(item)
+			item.ActionPolicy = DriftActionPolicyApprovalRequired
+			return item, true
+		}
+		switch state {
+		case HealthHealthy:
+			return DriftItem{}, false
+		case HealthFailing:
+			item.HealthState = HealthFailing
+			item.Reason = driftReason(item, brief, HealthFailing, firstNonEmpty(item.HealthSummary, "the runtime healthcheck is failing"))
+			item.RecommendedAction = driftMutatingRecommendedAction(item)
+			item.ActionPolicy = DriftActionPolicyApprovalRequired
+			return item, true
+		default:
+			item.HealthState = HealthUnknown
+			item.Reason = driftReason(item, brief, HealthUnknown, "the runtime healthcheck has not confirmed the outcome")
+			item.RecommendedAction = driftMutatingRecommendedAction(item)
+			item.ActionPolicy = DriftActionPolicyApprovalRequired
+			return item, true
+		}
+	}
+
+	item.HealthState = HealthUnknown
+	item.Reason = driftReason(item, brief, HealthUnknown, "no runtime healthcheck has been recorded for this work")
+	item.RecommendedAction = driftMutatingRecommendedAction(item)
+	item.ActionPolicy = DriftActionPolicyApprovalRequired
+	return item, true
+}
+
+func driftReason(item DriftItem, brief Brief, state, detail string) string {
+	subject := driftSubject(item)
+	goal := strings.TrimSpace(brief.Goal())
+	if goal == "" {
+		goal = "the configured runtime outcome"
+	}
+	stateLabel := strings.ReplaceAll(state, "_", " ")
+	if detail = strings.TrimSpace(detail); detail != "" {
+		return fmt.Sprintf("%s but runtime outcome health is %s for %s: %s.", subject, stateLabel, goal, detail)
+	}
+	return fmt.Sprintf("%s but runtime outcome health is %s for %s.", subject, stateLabel, goal)
+}
+
+func driftSubject(item DriftItem) string {
+	switch {
+	case item.PRMerged && item.PRNumber > 0 && item.IssueClosed && item.IssueNumber > 0:
+		return fmt.Sprintf("PR #%d merged and issue #%d closed", item.PRNumber, item.IssueNumber)
+	case item.PRMerged && item.PRNumber > 0:
+		if item.IssueNumber > 0 {
+			return fmt.Sprintf("PR #%d for issue #%d merged", item.PRNumber, item.IssueNumber)
+		}
+		return fmt.Sprintf("PR #%d merged", item.PRNumber)
+	case item.IssueClosed && item.IssueNumber > 0:
+		return fmt.Sprintf("Issue #%d closed", item.IssueNumber)
+	default:
+		return "Work landed"
+	}
+}
+
+func driftMutatingRecommendedAction(item DriftItem) string {
+	// All follow-ups (comment, reopen, label) mutate GitHub state, so the
+	// supervisor should request approval before applying them. The text gives
+	// the operator the concrete safe and mutating options.
+	switch {
+	case item.PRMerged && item.PRNumber > 0 && item.IssueNumber > 0:
+		return fmt.Sprintf("Run the configured runtime healthcheck; if it stays unhealthy, request approval to comment on PR #%d, reopen issue #%d, or relabel it for follow-up.", item.PRNumber, item.IssueNumber)
+	case item.PRMerged && item.PRNumber > 0:
+		return fmt.Sprintf("Run the configured runtime healthcheck; if it stays unhealthy, request approval to comment on PR #%d for follow-up.", item.PRNumber)
+	case item.IssueClosed && item.IssueNumber > 0:
+		return fmt.Sprintf("Run the configured runtime healthcheck; if it stays unhealthy, request approval to reopen or relabel issue #%d.", item.IssueNumber)
+	default:
+		return "Run the configured runtime healthcheck; if it stays unhealthy, request approval before mutating GitHub state."
+	}
+}
+
+func sortDrifts(drifts []DriftItem) {
+	sort.SliceStable(drifts, func(i, j int) bool {
+		si, sj := driftSeverity(drifts[i].HealthState), driftSeverity(drifts[j].HealthState)
+		if si != sj {
+			return si < sj
+		}
+		ti, tj := drifts[i].LandedAt, drifts[j].LandedAt
+		if !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+		if drifts[i].PRNumber != drifts[j].PRNumber {
+			return drifts[i].PRNumber < drifts[j].PRNumber
+		}
+		return drifts[i].IssueNumber < drifts[j].IssueNumber
+	})
+}
+
+func driftSeverity(state string) int {
+	switch state {
+	case HealthFailing:
+		return 0
+	case HealthUnknown:
+		return 1
+	case HealthUnmonitored:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if v := strings.TrimSpace(value); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/outcome/drift_test.go
+++ b/internal/outcome/drift_test.go
@@ -1,0 +1,213 @@
+package outcome
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDetectDriftsClosedIssueWithFailingRuntime(t *testing.T) {
+	landed := time.Date(2026, 5, 10, 9, 0, 0, 0, time.UTC)
+	brief := Brief{
+		DesiredOutcome:     "App is live",
+		HealthcheckCommand: "status.sh",
+	}
+	sessions := []DriftSession{{
+		Slot:        "slot-1",
+		IssueNumber: 99,
+		IssueTitle:  "Ship feature",
+		IssueClosed: true,
+		LandedAt:    landed,
+	}}
+	check := &HealthCheckResult{
+		CheckedAt: landed.Add(time.Minute),
+		Signal:    "healthcheck_command",
+		State:     HealthFailing,
+		Summary:   "status.sh exited 1",
+	}
+
+	drifts := DetectDrifts(brief, sessions, check, landed.Add(2*time.Minute))
+	if len(drifts) != 1 {
+		t.Fatalf("len(drifts) = %d, want 1: %+v", len(drifts), drifts)
+	}
+	drift := drifts[0]
+	if drift.HealthState != HealthFailing {
+		t.Fatalf("HealthState = %q, want %q", drift.HealthState, HealthFailing)
+	}
+	if !drift.IssueClosed || drift.IssueNumber != 99 {
+		t.Fatalf("drift = %+v, want closed issue #99", drift)
+	}
+	if drift.HealthSignal != "healthcheck_command" || drift.HealthSummary == "" {
+		t.Fatalf("drift = %+v, want runtime signal/summary populated", drift)
+	}
+	if drift.ActionPolicy != DriftActionPolicyApprovalRequired {
+		t.Fatalf("ActionPolicy = %q, want %q", drift.ActionPolicy, DriftActionPolicyApprovalRequired)
+	}
+	if drift.RecommendedAction == "" {
+		t.Fatal("RecommendedAction should describe a follow-up")
+	}
+	if drift.Reason == "" || !contains(drift.Reason, "failing") {
+		t.Fatalf("Reason = %q, want failing runtime reason", drift.Reason)
+	}
+}
+
+func TestDetectDriftsMergedPRWithUnknownRuntime(t *testing.T) {
+	landed := time.Date(2026, 5, 11, 8, 0, 0, 0, time.UTC)
+	brief := Brief{
+		DesiredOutcome: "App is live",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}
+	sessions := []DriftSession{{
+		Slot:        "slot-2",
+		IssueNumber: 101,
+		PRNumber:    42,
+		PRMerged:    true,
+		LandedAt:    landed,
+	}}
+
+	drifts := DetectDrifts(brief, sessions, nil, landed.Add(time.Hour))
+	if len(drifts) != 1 {
+		t.Fatalf("len(drifts) = %d, want 1: %+v", len(drifts), drifts)
+	}
+	drift := drifts[0]
+	if drift.HealthState != HealthUnknown {
+		t.Fatalf("HealthState = %q, want %q", drift.HealthState, HealthUnknown)
+	}
+	if drift.PRNumber != 42 || !drift.PRMerged {
+		t.Fatalf("drift = %+v, want merged PR #42", drift)
+	}
+	if drift.IssueNumber != 101 {
+		t.Fatalf("drift.IssueNumber = %d, want 101", drift.IssueNumber)
+	}
+	if drift.ActionPolicy != DriftActionPolicyApprovalRequired {
+		t.Fatalf("ActionPolicy = %q, want %q", drift.ActionPolicy, DriftActionPolicyApprovalRequired)
+	}
+	if drift.RecommendedAction == "" || !contains(drift.RecommendedAction, "PR #42") {
+		t.Fatalf("RecommendedAction = %q, want to mention PR #42", drift.RecommendedAction)
+	}
+	if drift.Reason == "" || !contains(drift.Reason, "unknown") {
+		t.Fatalf("Reason = %q, want unknown runtime reason", drift.Reason)
+	}
+}
+
+func TestDetectDriftsHealthyOutcomeReturnsNoDrifts(t *testing.T) {
+	landed := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	brief := Brief{
+		DesiredOutcome: "App is live",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}
+	sessions := []DriftSession{{
+		Slot:        "slot-3",
+		IssueNumber: 5,
+		PRNumber:    7,
+		PRMerged:    true,
+		IssueClosed: true,
+		LandedAt:    landed,
+	}}
+	check := &HealthCheckResult{
+		CheckedAt: landed.Add(time.Minute),
+		Signal:    "healthcheck_url",
+		State:     HealthHealthy,
+		Summary:   "GET /healthz returned 200 OK",
+	}
+
+	drifts := DetectDrifts(brief, sessions, check, landed.Add(5*time.Minute))
+	if len(drifts) != 0 {
+		t.Fatalf("len(drifts) = %d, want 0 for healthy outcome: %+v", len(drifts), drifts)
+	}
+}
+
+func TestDetectDriftsStaleHealthCheckBeforeLandedIsUnknownDrift(t *testing.T) {
+	landed := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	brief := Brief{
+		DesiredOutcome: "App is live",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}
+	sessions := []DriftSession{{
+		Slot:        "slot-4",
+		IssueNumber: 8,
+		PRNumber:    9,
+		PRMerged:    true,
+		LandedAt:    landed,
+	}}
+	check := &HealthCheckResult{
+		CheckedAt: landed.Add(-time.Hour),
+		Signal:    "healthcheck_url",
+		State:     HealthHealthy,
+		Summary:   "GET /healthz returned 200 OK",
+	}
+
+	drifts := DetectDrifts(brief, sessions, check, landed.Add(time.Minute))
+	if len(drifts) != 1 {
+		t.Fatalf("len(drifts) = %d, want 1: %+v", len(drifts), drifts)
+	}
+	if drifts[0].HealthState != HealthUnknown {
+		t.Fatalf("HealthState = %q, want %q for stale check", drifts[0].HealthState, HealthUnknown)
+	}
+	if drifts[0].ActionPolicy != DriftActionPolicyApprovalRequired {
+		t.Fatalf("ActionPolicy = %q, want approval-required for stale check", drifts[0].ActionPolicy)
+	}
+}
+
+func TestDetectDriftsMissingHealthSignalIsReadOnly(t *testing.T) {
+	landed := time.Date(2026, 5, 14, 14, 0, 0, 0, time.UTC)
+	brief := Brief{DesiredOutcome: "App is live"} // no health signal configured
+	sessions := []DriftSession{{
+		Slot:        "slot-5",
+		IssueNumber: 12,
+		IssueClosed: true,
+		LandedAt:    landed,
+	}}
+
+	drifts := DetectDrifts(brief, sessions, nil, landed)
+	if len(drifts) != 1 {
+		t.Fatalf("len(drifts) = %d, want 1: %+v", len(drifts), drifts)
+	}
+	if drifts[0].HealthState != HealthUnmonitored {
+		t.Fatalf("HealthState = %q, want %q", drifts[0].HealthState, HealthUnmonitored)
+	}
+	if drifts[0].ActionPolicy != DriftActionPolicyReadOnly {
+		t.Fatalf("ActionPolicy = %q, want read-only", drifts[0].ActionPolicy)
+	}
+}
+
+func TestDetectDriftsIgnoresWorkNotLanded(t *testing.T) {
+	landed := time.Date(2026, 5, 15, 16, 0, 0, 0, time.UTC)
+	brief := Brief{
+		DesiredOutcome: "App is live",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}
+	sessions := []DriftSession{
+		{Slot: "slot-running", IssueNumber: 20, PRNumber: 21, PRMerged: false, IssueClosed: false, LandedAt: landed},
+		{Slot: "slot-merged", IssueNumber: 22, PRNumber: 23, PRMerged: true, LandedAt: landed},
+	}
+
+	drifts := DetectDrifts(brief, sessions, nil, landed.Add(time.Hour))
+	if len(drifts) != 1 {
+		t.Fatalf("len(drifts) = %d, want 1 (only the merged PR): %+v", len(drifts), drifts)
+	}
+	if drifts[0].Slot != "slot-merged" {
+		t.Fatalf("slot = %q, want %q", drifts[0].Slot, "slot-merged")
+	}
+}
+
+func TestDetectDriftsRequiresConfiguredBrief(t *testing.T) {
+	landed := time.Date(2026, 5, 16, 18, 0, 0, 0, time.UTC)
+	sessions := []DriftSession{{IssueNumber: 1, PRNumber: 2, PRMerged: true, LandedAt: landed}}
+
+	drifts := DetectDrifts(Brief{}, sessions, nil, landed)
+	if drifts != nil {
+		t.Fatalf("DetectDrifts without configured brief = %+v, want nil", drifts)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/outcome/outcome.go
+++ b/internal/outcome/outcome.go
@@ -35,31 +35,32 @@ type Brief struct {
 
 // Status is the concise outcome state exposed by CLI/API/dashboard surfaces.
 type Status struct {
-	Configured              bool     `json:"configured"`
-	Goal                    string   `json:"goal,omitempty"`
-	DesiredOutcome          string   `json:"desired_outcome,omitempty"`
-	RuntimeTarget           string   `json:"runtime_target,omitempty"`
-	RuntimeURL              string   `json:"runtime_url,omitempty"`
-	RuntimeHost             string   `json:"runtime_host,omitempty"`
-	HealthState             string   `json:"health_state"`
-	HealthCheckedAt         string   `json:"health_checked_at,omitempty"`
-	HealthSignal            string   `json:"health_signal,omitempty"`
-	HealthSummary           string   `json:"health_summary,omitempty"`
-	HealthDetail            string   `json:"health_detail,omitempty"`
-	NextAction              string   `json:"next_action,omitempty"`
-	SourceRepoPath          string   `json:"source_repo_path,omitempty"`
-	DeploymentStatusCommand string   `json:"deployment_status_command,omitempty"`
-	DeployStatusCommand     string   `json:"deploy_status_command,omitempty"`
-	HealthcheckCommand      string   `json:"healthcheck_command,omitempty"`
-	VerifierCommand         string   `json:"verifier_command,omitempty"`
-	HealthcheckURL          string   `json:"healthcheck_url,omitempty"`
-	RequiredRoutes          []string `json:"required_routes,omitempty"`
-	RequiresDeploy          bool     `json:"requires_deploy,omitempty"`
-	NonGoals                []string `json:"non_goals,omitempty"`
-	PassRequiredForDone     bool     `json:"pass_required_for_done,omitempty"`
-	FailRequiresVisibleWork bool     `json:"fail_requires_visible_work,omitempty"`
-	MergedPRs               int      `json:"merged_prs,omitempty"`
-	LastMergeAt             string   `json:"last_merge_at,omitempty"`
+	Configured              bool        `json:"configured"`
+	Goal                    string      `json:"goal,omitempty"`
+	DesiredOutcome          string      `json:"desired_outcome,omitempty"`
+	RuntimeTarget           string      `json:"runtime_target,omitempty"`
+	RuntimeURL              string      `json:"runtime_url,omitempty"`
+	RuntimeHost             string      `json:"runtime_host,omitempty"`
+	HealthState             string      `json:"health_state"`
+	HealthCheckedAt         string      `json:"health_checked_at,omitempty"`
+	HealthSignal            string      `json:"health_signal,omitempty"`
+	HealthSummary           string      `json:"health_summary,omitempty"`
+	HealthDetail            string      `json:"health_detail,omitempty"`
+	NextAction              string      `json:"next_action,omitempty"`
+	SourceRepoPath          string      `json:"source_repo_path,omitempty"`
+	DeploymentStatusCommand string      `json:"deployment_status_command,omitempty"`
+	DeployStatusCommand     string      `json:"deploy_status_command,omitempty"`
+	HealthcheckCommand      string      `json:"healthcheck_command,omitempty"`
+	VerifierCommand         string      `json:"verifier_command,omitempty"`
+	HealthcheckURL          string      `json:"healthcheck_url,omitempty"`
+	RequiredRoutes          []string    `json:"required_routes,omitempty"`
+	RequiresDeploy          bool        `json:"requires_deploy,omitempty"`
+	NonGoals                []string    `json:"non_goals,omitempty"`
+	PassRequiredForDone     bool        `json:"pass_required_for_done,omitempty"`
+	FailRequiresVisibleWork bool        `json:"fail_requires_visible_work,omitempty"`
+	MergedPRs               int         `json:"merged_prs,omitempty"`
+	LastMergeAt             string      `json:"last_merge_at,omitempty"`
+	Drifts                  []DriftItem `json:"drifts,omitempty"`
 }
 
 // HealthCheckResult is the durable result of a read-only runtime/deploy health

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2064,6 +2064,21 @@ func fleetOutcomeDriftOperatorState(project fleetProjectState) (fleetOperatorSta
 	if !project.Outcome.Configured {
 		return fleetOperatorState{}, false
 	}
+	if drift, ok := topOutcomeDrift(project.Outcome.Drifts); ok {
+		operator := fleetOperatorState{
+			Kind:       "outcome_drift",
+			Tone:       "attention",
+			Label:      "Outcome drift",
+			Summary:    firstNonEmpty(drift.Reason, "Runtime outcome health has not caught up with landed work."),
+			NextAction: firstNonEmpty(drift.RecommendedAction, project.Outcome.NextAction, "Run the configured runtime/deploy healthcheck before treating the work as fully complete."),
+		}
+		target := &state.SupervisorTarget{
+			Issue:   drift.IssueNumber,
+			PR:      drift.PRNumber,
+			Session: drift.Slot,
+		}
+		return applyFleetOperatorTarget(project, operator, target), true
+	}
 	if latest := project.Supervisor.Latest; latest != nil {
 		if strings.TrimSpace(latest.RecommendedAction) == "check_outcome_health" {
 			operator := fleetOperatorState{
@@ -2100,6 +2115,16 @@ func fleetOutcomeDriftOperatorState(project fleetProjectState) (fleetOperatorSta
 		}
 	}
 	return fleetOperatorState{}, false
+}
+
+// topOutcomeDrift returns the highest-severity drift item from the project's
+// outcome status. DetectDrifts already sorts by severity (failing first), so
+// callers can take the first item without re-scanning.
+func topOutcomeDrift(drifts []outcome.DriftItem) (outcome.DriftItem, bool) {
+	if len(drifts) == 0 {
+		return outcome.DriftItem{}, false
+	}
+	return drifts[0], true
 }
 
 func fleetOutcomeHealthState(project fleetProjectState, health string) fleetOperatorState {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1179,6 +1179,36 @@ func TestFleetProjectOperatorStateDistinguishesBriefStates(t *testing.T) {
 		t.Fatalf("drift operator state = %+v, want runtime outcome drift", drift)
 	}
 
+	driftItem := buildFleetProjectOperatorState(fleetProjectState{
+		Name: "DriftItem",
+		Repo: "owner/drift",
+		Outcome: outcome.Status{
+			Configured:  true,
+			Goal:        "Runtime is healthy",
+			HealthState: outcome.HealthHealthy,
+			Drifts: []outcome.DriftItem{{
+				Slot:              "slot-1",
+				IssueNumber:       99,
+				PRNumber:          42,
+				PRMerged:          true,
+				HealthState:       outcome.HealthFailing,
+				HealthSignal:      "healthcheck_url",
+				Reason:            "PR #42 for issue #99 merged but runtime outcome health is failing for Runtime is healthy: status.sh exited 1.",
+				RecommendedAction: "Run the configured runtime healthcheck; if it stays unhealthy, request approval to comment on PR #42, reopen issue #99, or relabel it for follow-up.",
+				ActionPolicy:      outcome.DriftActionPolicyApprovalRequired,
+			}},
+		},
+	})
+	if driftItem.Kind != "outcome_drift" {
+		t.Fatalf("drift item operator state kind = %q, want outcome_drift", driftItem.Kind)
+	}
+	if driftItem.PRNumber != 42 || driftItem.IssueNumber != 99 {
+		t.Fatalf("drift item operator state = %+v, want PR #42/issue #99 target", driftItem)
+	}
+	if !contains(driftItem.NextAction, "approval") {
+		t.Fatalf("drift item next action = %q, want approval-gated follow-up", driftItem.NextAction)
+	}
+
 	blocked := buildFleetProjectOperatorState(fleetProjectState{
 		Name:          "BlockedQueue",
 		Outcome:       configuredOutcome,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -764,10 +764,14 @@ func outcomeStatusForState(cfg *config.Config, st *state.State) outcome.Status {
 	if cfg == nil || st == nil {
 		return outcome.StatusFor(outcome.Brief{}, 0, time.Time{})
 	}
+	var status outcome.Status
 	if st.OutcomeHealth != nil {
-		return outcome.StatusFor(cfg.Outcome, st.DonePRCount(), st.LastMergeAt, *st.OutcomeHealth)
+		status = outcome.StatusFor(cfg.Outcome, st.DonePRCount(), st.LastMergeAt, *st.OutcomeHealth)
+	} else {
+		status = outcome.StatusFor(cfg.Outcome, st.DonePRCount(), st.LastMergeAt)
 	}
-	return outcome.StatusFor(cfg.Outcome, st.DonePRCount(), st.LastMergeAt)
+	status.Drifts = outcome.DetectDrifts(cfg.Outcome, st.DriftSessions(), st.OutcomeHealth, time.Now().UTC())
+	return status
 }
 
 func (s *Server) handleWorkers(w http.ResponseWriter, r *http.Request) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1612,6 +1612,57 @@ func (s *State) DonePRCount() int {
 	return count
 }
 
+// DriftSessions returns the list of sessions that count as "GitHub-side done"
+// for outcome drift detection: PRs that landed (code_landed/done with a PR
+// number) and issues that closed without producing a PR. Each entry carries
+// the minimum fields the outcome package needs to render an active drift item.
+func (s *State) DriftSessions() []outcome.DriftSession {
+	if s == nil {
+		return nil
+	}
+	slots := make([]string, 0, len(s.Sessions))
+	for slot := range s.Sessions {
+		slots = append(slots, slot)
+	}
+	sort.Strings(slots)
+	drifts := make([]outcome.DriftSession, 0, len(s.Sessions))
+	for _, slot := range slots {
+		sess := s.Sessions[slot]
+		if sess == nil {
+			continue
+		}
+		landed := sess.StartedAt
+		if sess.FinishedAt != nil && sess.FinishedAt.After(landed) {
+			landed = *sess.FinishedAt
+		}
+		switch sess.Status {
+		case StatusCodeLanded:
+			if sess.PRNumber <= 0 {
+				continue
+			}
+			drifts = append(drifts, outcome.DriftSession{
+				Slot:        slot,
+				IssueNumber: sess.IssueNumber,
+				IssueTitle:  sess.IssueTitle,
+				PRNumber:    sess.PRNumber,
+				PRMerged:    true,
+				LandedAt:    landed.UTC(),
+			})
+		case StatusDone:
+			drifts = append(drifts, outcome.DriftSession{
+				Slot:        slot,
+				IssueNumber: sess.IssueNumber,
+				IssueTitle:  sess.IssueTitle,
+				PRNumber:    sess.PRNumber,
+				PRMerged:    sess.PRNumber > 0,
+				IssueClosed: true,
+				LandedAt:    landed.UTC(),
+			})
+		}
+	}
+	return drifts
+}
+
 // IssueInProgress returns true if the given issue is already being handled.
 // This includes dead sessions with a pending retry (NextRetryAt set) to prevent
 // duplicate worker spawns during backoff periods.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -91,6 +91,42 @@ func TestProjectStatusSynced(t *testing.T) {
 	}
 }
 
+func TestDriftSessionsIncludesLandedAndClosed(t *testing.T) {
+	s := NewState()
+	finished := time.Date(2026, 5, 10, 9, 0, 0, 0, time.UTC)
+	s.Sessions["code-landed"] = &Session{IssueNumber: 5, IssueTitle: "Ship feature", Status: StatusCodeLanded, PRNumber: 13, FinishedAt: &finished}
+	s.Sessions["merged-done"] = &Session{IssueNumber: 2, Status: StatusDone, PRNumber: 11, FinishedAt: &finished}
+	s.Sessions["closed-issue"] = &Session{IssueNumber: 3, Status: StatusDone, FinishedAt: &finished}
+	s.Sessions["running"] = &Session{IssueNumber: 4, Status: StatusRunning, PRNumber: 12, StartedAt: finished}
+
+	drifts := s.DriftSessions()
+	if len(drifts) != 3 {
+		t.Fatalf("len(drifts) = %d, want 3: %+v", len(drifts), drifts)
+	}
+	bySlot := make(map[string]struct {
+		merged, closed bool
+		pr             int
+	}, len(drifts))
+	for _, d := range drifts {
+		bySlot[d.Slot] = struct {
+			merged, closed bool
+			pr             int
+		}{d.PRMerged, d.IssueClosed, d.PRNumber}
+	}
+	if got := bySlot["code-landed"]; !got.merged || got.closed || got.pr != 13 {
+		t.Fatalf("code-landed drift = %+v, want merged PR only", got)
+	}
+	if got := bySlot["merged-done"]; !got.merged || !got.closed || got.pr != 11 {
+		t.Fatalf("merged-done drift = %+v, want merged PR and closed issue", got)
+	}
+	if got := bySlot["closed-issue"]; got.merged || !got.closed || got.pr != 0 {
+		t.Fatalf("closed-issue drift = %+v, want closed issue only", got)
+	}
+	if _, ok := bySlot["running"]; ok {
+		t.Fatalf("running session should not appear in drift sessions: %+v", drifts)
+	}
+}
+
 func TestNotifiedCIFail_OmittedWhenFalse(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -588,10 +588,16 @@ func (e *Engine) outcomeStatus(st *state.State) outcome.Status {
 		mergedPRs = st.DonePRCount()
 		lastMergeAt = st.LastMergeAt
 	}
+	var status outcome.Status
 	if st != nil && st.OutcomeHealth != nil {
-		return outcome.StatusFor(e.cfg.Outcome, mergedPRs, lastMergeAt, *st.OutcomeHealth)
+		status = outcome.StatusFor(e.cfg.Outcome, mergedPRs, lastMergeAt, *st.OutcomeHealth)
+	} else {
+		status = outcome.StatusFor(e.cfg.Outcome, mergedPRs, lastMergeAt)
 	}
-	return outcome.StatusFor(e.cfg.Outcome, mergedPRs, lastMergeAt)
+	if st != nil {
+		status.Drifts = outcome.DetectDrifts(e.cfg.Outcome, st.DriftSessions(), st.OutcomeHealth, e.now())
+	}
+	return status
 }
 
 func outcomeDecisionReason(status outcome.Status) string {


### PR DESCRIPTION
Refs #353

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces outcome drift detection — identifying sessions where GitHub considers work done (PR merged or issue closed) but the runtime/deploy health check is missing, stale, or failing. Drift items are computed on every status read and surfaced on the Fleet operator surface with approval-gated recommended actions.

- `internal/outcome/drift.go`: new `DetectDrifts` / `buildDriftItem` pipeline classifying each landed session as `failing`, `unknown`, or `unmonitored`.
- `internal/state/state.go`: new `DriftSessions()` method maps `StatusCodeLanded` and `StatusDone` sessions into the minimal `DriftSession` view.
- `internal/server/server.go` + `internal/supervisor/supervisor.go`: both refactored to attach `Drifts` to the returned `outcome.Status`.

<h3>Confidence Score: 3/5</h3>

The core drift detection logic is solid, but two defects in the data pipeline can produce actively wrong operator guidance.

The recommended-action text for a merged PR with a still-open linked issue incorrectly tells the operator to reopen an issue that was never closed, and the LandedAt fallback to StartedAt can allow pre-merge health checks to silently suppress legitimate drift items.

internal/outcome/drift.go and internal/state/state.go both need fixes before the feature behaves correctly end-to-end.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/outcome/drift.go | New drift-detection module; `driftMutatingRecommendedAction` first case omits the `IssueClosed` guard, producing "reopen issue" advice for sessions where the issue is still open. |
| internal/state/state.go | New `DriftSessions()` method; uses `StartedAt` as fallback for `LandedAt` when `FinishedAt` is nil, which can incorrectly accept pre-merge health checks as post-landing evidence. |
| internal/outcome/drift_test.go | Good coverage of core drift scenarios; the merged-PR-with-open-issue case is not tested. |
| internal/server/fleet.go | Adds `topOutcomeDrift` helper and wires drift items into `fleetOutcomeDriftOperatorState`; logic is correct. |
| internal/server/server.go | Minor refactor to attach `Drifts` after `StatusFor`; nil guards are correct. |
| internal/supervisor/supervisor.go | Same refactor as server.go; `st != nil` guard before `DriftSessions()` is correct. |
| internal/outcome/outcome.go | Adds `Drifts []DriftItem` field to `Status`; no logic changes. |
| internal/server/fleet_test.go | New test for the drift-item operator state; correctly verifies kind, target, and approval gating. |
| internal/state/state_test.go | New `TestDriftSessionsIncludesLandedAndClosed` covers the three expected session types. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/outcome/drift.go:175-178
The first `case` matches whenever a PR is merged and an issue number is present, regardless of whether the issue is actually closed. A `StatusCodeLanded` session (PR merged, issue still open) has `item.PRMerged = true`, `item.PRNumber > 0`, `item.IssueNumber > 0`, and `item.IssueClosed = false`, so it falls into this branch and the operator receives "reopen issue #X" advice for an issue that was never closed. Compare `driftSubject`, which correctly guards the same first branch with `item.IssueClosed`.

```suggestion
	switch {
	case item.PRMerged && item.PRNumber > 0 && item.IssueClosed && item.IssueNumber > 0:
		return fmt.Sprintf("Run the configured runtime healthcheck; if it stays unhealthy, request approval to comment on PR #%d, reopen issue #%d, or relabel it for follow-up.", item.PRNumber, item.IssueNumber)
	case item.PRMerged && item.PRNumber > 0:
```

### Issue 2 of 2
internal/state/state.go:1634-1636
`StartedAt` is when the worker session was spawned, not when the PR was actually merged or the issue was closed. If `FinishedAt` is nil (e.g., for sessions persisted before that field was tracked), `landed` is set to session start time. Any health check taken between session start and the real merge/close would then pass the `latestCheck.CheckedAt.Before(item.LandedAt)` staleness guard in `buildDriftItem`, letting a pre-merge check suppress a legitimate drift item. A zero fallback (`time.Time{}`) would be safer, since `item.LandedAt.IsZero()` is already handled by skipping the staleness gate entirely.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: detect outcome drift after merge o..."](https://github.com/befeast/maestro/commit/c6081954f2c455e39708f790733b3860c797b062) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33337187)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->