### PR TITLE
[codex] Handle provider limit backend fallback

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,11 @@ type BackendDef struct {
 	Cmd        string   `yaml:"cmd"`
 	ExtraArgs  []string `yaml:"extra_args"`
 	PromptMode string   `yaml:"prompt_mode"` // how to deliver prompt: "arg" (last argument), "stdin" (via stdin), "file" (file path as argument)
+	Enabled    *bool    `yaml:"enabled"`     // nil means enabled for backward compatibility
+}
+
+func (b BackendDef) IsEnabled() bool {
+	return b.Enabled == nil || *b.Enabled
 }
 
 // ModelConfig holds multi-backend configuration.

--- a/internal/orchestrator/backend_selector.go
+++ b/internal/orchestrator/backend_selector.go
@@ -1,0 +1,153 @@
+package orchestrator
+
+import (
+	"sort"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+const selectionReasonProviderLimitFallback = "fallback_after_provider_limit"
+
+func (o *Orchestrator) recordProviderLimit(st *state.State, slotName string, sess *state.Session, pattern string, now time.Time) {
+	if st == nil || sess == nil || sess.Backend == "" {
+		return
+	}
+	if st.BackendHealth == nil {
+		st.BackendHealth = make(map[string]state.BackendHealth)
+	}
+	if pattern == "" {
+		pattern = state.BackendBlockProviderLimit
+	}
+	sess.RateLimitHit = true
+	sess.ProviderLimitBackend = sess.Backend
+	sess.ProviderLimitReason = pattern
+	st.BackendHealth[sess.Backend] = state.BackendHealth{
+		State:       state.BackendHealthCooldown,
+		Reason:      state.BackendBlockProviderLimit,
+		Pattern:     pattern,
+		Since:       now.UTC(),
+		LastSession: slotName,
+	}
+}
+
+func (o *Orchestrator) selectProviderLimitFallback(st *state.State, sess *state.Session, now time.Time) state.BackendSelection {
+	selection := state.BackendSelection{
+		SelectionReason: selectionReasonProviderLimitFallback,
+		PreviousBackend: backendName(sess),
+	}
+	for _, candidate := range o.backendFallbackCandidates(sess) {
+		entry := state.BackendCandidate{Backend: candidate, Fit: 0.5, Policy: 0.5, Final: 0.5}
+		if candidate == "" {
+			continue
+		}
+		backendDef, ok := o.cfg.Model.Backends[candidate]
+		if !ok {
+			entry.Available = false
+			entry.BlockedBy = state.BackendBlockUnknown
+			selection.CandidateScores = append(selection.CandidateScores, entry)
+			continue
+		}
+		if !backendDef.IsEnabled() {
+			entry.Available = false
+			entry.BlockedBy = state.BackendBlockDisabled
+			selection.CandidateScores = append(selection.CandidateScores, entry)
+			continue
+		}
+		if candidate == backendName(sess) {
+			entry.Available = false
+			entry.BlockedBy = state.BackendBlockCurrent
+			selection.CandidateScores = append(selection.CandidateScores, entry)
+			continue
+		}
+		if stringInSlice(candidate, sess.TriedBackends) {
+			entry.Available = false
+			entry.BlockedBy = state.BackendBlockAlreadyTried
+			selection.CandidateScores = append(selection.CandidateScores, entry)
+			continue
+		}
+		if health, ok := st.BackendHealth[candidate]; ok && health.State == state.BackendHealthCooldown {
+			if health.RetryAfter == nil || now.Before(*health.RetryAfter) {
+				entry.Available = false
+				entry.BlockedBy = health.Reason
+				if health.RetryAfter != nil {
+					entry.RetryAfter = health.RetryAfter.Format(time.RFC3339)
+				}
+				selection.CandidateScores = append(selection.CandidateScores, entry)
+				continue
+			}
+		}
+
+		entry.Available = true
+		entry.Fit = backendFitScore(candidate, o.cfg)
+		entry.Policy = backendPolicyScore(candidate, o.cfg)
+		entry.Final = (entry.Fit + entry.Policy) / 2
+		selection.CandidateScores = append(selection.CandidateScores, entry)
+		if selection.SelectedBackend == "" {
+			selection.SelectedBackend = candidate
+		}
+	}
+	return selection
+}
+
+func (o *Orchestrator) backendFallbackCandidates(sess *state.Session) []string {
+	seen := make(map[string]bool)
+	ordered := make([]string, 0, len(o.cfg.Model.Backends)+len(o.cfg.Model.FallbackBackends)+1)
+	add := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		ordered = append(ordered, name)
+	}
+	for _, name := range o.cfg.Model.FallbackBackends {
+		add(name)
+	}
+	if len(o.cfg.Model.FallbackBackends) > 0 {
+		return ordered
+	}
+	add(o.cfg.Model.Default)
+
+	remaining := make([]string, 0, len(o.cfg.Model.Backends))
+	for name := range o.cfg.Model.Backends {
+		if !seen[name] {
+			remaining = append(remaining, name)
+		}
+	}
+	sort.Strings(remaining)
+	for _, name := range remaining {
+		add(name)
+	}
+	return ordered
+}
+
+func backendFitScore(name string, cfg *config.Config) float64 {
+	if name == cfg.Model.Default {
+		return 0.8
+	}
+	return 0.6
+}
+
+func backendPolicyScore(name string, cfg *config.Config) float64 {
+	if name == cfg.Model.Default {
+		return 0.9
+	}
+	return 0.6
+}
+
+func backendName(sess *state.Session) string {
+	if sess == nil {
+		return ""
+	}
+	return sess.Backend
+}
+
+func stringInSlice(needle string, values []string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1514,9 +1514,22 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					sess.PRNumber = pr.Number
 					o.notifier.Sendf("🔀 maestro: worker %s completed, PR #%d open for issue #%d (%s)",
 						slotName, pr.Number, sess.IssueNumber, sess.IssueTitle)
-				} else if o.isRateLimited(sess.LogFile) && o.nextFallbackBackend(sess) != "" {
-					// Rate-limit detected — try next fallback backend
-					nextBackend := o.nextFallbackBackend(sess)
+				} else if o.isRateLimited(sess.LogFile) {
+					// Provider capacity limit detected — gate this backend and select a fallback.
+					now := time.Now().UTC()
+					o.recordProviderLimit(s, slotName, sess, "log_rate_limit", now)
+					selection := o.selectProviderLimitFallback(s, sess, now)
+					sess.BackendSelection = &selection
+					nextBackend := selection.SelectedBackend
+					if nextBackend == "" {
+						log.Printf("[orch] worker %s (backend=%s) hit provider limit; no fallback backend available", slotName, sess.Backend)
+						sess.Status = state.StatusDead
+						sess.LastNotifiedStatus = "rate_limit"
+						sess.FinishedAt = &now
+						o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) hit provider limit; no fallback backend available",
+							slotName, sess.IssueNumber, sess.IssueTitle)
+						continue
+					}
 					log.Printf("[orch] worker %s (backend=%s) hit rate limit, falling back to %s",
 						slotName, sess.Backend, nextBackend)
 
@@ -1531,7 +1544,10 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						continue
 					}
 
-					sess.TriedBackends = append(sess.TriedBackends, sess.Backend)
+					previousBackend := sess.Backend
+					if previousBackend != "" {
+						sess.TriedBackends = append(sess.TriedBackends, previousBackend)
+					}
 					promptBase := o.selectPrompt(issue)
 					if err := o.respawnWorker(slotName, sess, issue, promptBase, nextBackend); err != nil {
 						log.Printf("[orch] fallback respawn worker %s with %s: %v — marking as failed", slotName, nextBackend, err)
@@ -1544,7 +1560,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					}
 
 					o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) rate-limited on %s, switched to %s",
-						slotName, sess.IssueNumber, sess.TriedBackends[len(sess.TriedBackends)-1], nextBackend)
+						slotName, sess.IssueNumber, previousBackend, nextBackend)
 				} else if o.canRetryIssue(s, sess) {
 					// Schedule retry with exponential backoff (respects max_retries_per_issue)
 					sess.RetryCount++
@@ -1616,10 +1632,13 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 							if err := o.stopWorker(slotName, sess); err != nil {
 								log.Printf("[orch] warn: could not stop rate-limited worker %s: %v", slotName, err)
 							}
-							sess.RateLimitHit = true
+							now := time.Now().UTC()
+							o.recordProviderLimit(s, slotName, sess, pattern, now)
+							selection := o.selectProviderLimitFallback(s, sess, now)
+							sess.BackendSelection = &selection
 
-							// Attempt fallback: respawn with next fallback backend if configured
-							if fallback := o.nextFallbackBackend(sess); fallback != "" {
+							// Attempt fallback: respawn with the best currently available backend.
+							if fallback := selection.SelectedBackend; fallback != "" {
 								issue, fetchErr := o.getIssue(sess.IssueNumber)
 								if fetchErr != nil {
 									log.Printf("[orch] fetch issue #%d for rate-limit fallback: %v — marking dead", sess.IssueNumber, fetchErr)
@@ -1632,7 +1651,10 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 									continue
 								}
 
-								sess.TriedBackends = append(sess.TriedBackends, sess.Backend)
+								previousBackend := sess.Backend
+								if previousBackend != "" {
+									sess.TriedBackends = append(sess.TriedBackends, previousBackend)
+								}
 								promptBase := o.selectPrompt(issue)
 								if respawnErr := o.respawnWorker(slotName, sess, issue, promptBase, fallback); respawnErr != nil {
 									log.Printf("[orch] rate-limit fallback respawn %s: %v — marking dead", slotName, respawnErr)
@@ -1654,7 +1676,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 							// No fallback available — mark dead
 							sess.Status = state.StatusDead
 							sess.LastNotifiedStatus = "rate_limit"
-							now := time.Now().UTC()
+							now = time.Now().UTC()
 							sess.FinishedAt = &now
 							o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); no fallback configured",
 								slotName, sess.IssueNumber, pattern)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -4087,6 +4087,104 @@ func TestCheckSessions_RateLimitDetected_WithFallback_Respawns(t *testing.T) {
 	}
 }
 
+func TestCheckSessions_RateLimitDetected_DefaultBackendFallback_Respawns(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+		Model: config.ModelConfig{
+			Default: "codex",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+	}
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "Error: You've hit your limit for today.")
+
+	s := state.NewState()
+	s.Sessions["mae-default"] = &state.Session{
+		IssueNumber: 142,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         4242,
+		TmuxSession: "maestro-mae-default",
+		Branch:      "feat/mae-default-142-test",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-default"]
+	if len(*stopped) != 1 || (*stopped)[0] != "mae-default" {
+		t.Fatalf("stopped = %v, want [mae-default]", *stopped)
+	}
+	if len(*respawned) != 1 || (*respawned)[0][1] != "codex" {
+		t.Fatalf("respawned = %v, want fallback to codex", *respawned)
+	}
+	if sess.Backend != "codex" || sess.Status != state.StatusRunning {
+		t.Fatalf("session backend/status = %q/%q, want codex/running", sess.Backend, sess.Status)
+	}
+	if sess.ProviderLimitBackend != "claude" || sess.ProviderLimitReason == "" {
+		t.Fatalf("provider limit = %q/%q, want claude with reason", sess.ProviderLimitBackend, sess.ProviderLimitReason)
+	}
+	if health := s.BackendHealth["claude"]; health.State != state.BackendHealthCooldown || health.Reason != state.BackendBlockProviderLimit {
+		t.Fatalf("claude health = %+v, want provider-limit cooldown", health)
+	}
+	if sess.BackendSelection == nil {
+		t.Fatal("backend selection should be recorded")
+	}
+	if sess.BackendSelection.SelectedBackend != "codex" || sess.BackendSelection.SelectionReason != selectionReasonProviderLimitFallback {
+		t.Fatalf("selection = %+v, want codex provider-limit fallback", sess.BackendSelection)
+	}
+}
+
+func TestCheckSessions_RateLimitDetected_NoAvailableFallback_RecordsSelection(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+			},
+		},
+	}
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "Error: You've hit your limit for today.")
+
+	s := state.NewState()
+	s.Sessions["mae-none"] = &state.Session{
+		IssueNumber: 143,
+		IssueTitle:  "test issue",
+		Status:      state.StatusRunning,
+		PID:         4343,
+		TmuxSession: "maestro-mae-none",
+		Branch:      "feat/mae-none-143-test",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-none"]
+	if len(*stopped) != 1 || (*stopped)[0] != "mae-none" {
+		t.Fatalf("stopped = %v, want [mae-none]", *stopped)
+	}
+	if len(*respawned) != 0 {
+		t.Fatalf("respawned = %v, want no fallback", *respawned)
+	}
+	if sess.Status != state.StatusDead || sess.LastNotifiedStatus != "rate_limit" {
+		t.Fatalf("session status/notification = %q/%q, want dead/rate_limit", sess.Status, sess.LastNotifiedStatus)
+	}
+	if sess.BackendSelection == nil || sess.BackendSelection.SelectedBackend != "" {
+		t.Fatalf("selection = %+v, want no selected backend", sess.BackendSelection)
+	}
+	attention := state.SessionAttentionFor(sess, nil)
+	if !attention.NeedsAttention || !strings.Contains(attention.Reason, "provider capacity limit") {
+		t.Fatalf("attention = %+v, want provider capacity attention", attention)
+	}
+}
+
 func TestCheckSessions_RateLimitDetected_AlreadyOnFallback_MarksDead(t *testing.T) {
 	cfg := &config.Config{
 		Repo:              "owner/repo",
@@ -4347,18 +4445,21 @@ func TestCheckSessions_RateLimitNoFallbackAvailable_NormalRetry(t *testing.T) {
 	o.checkSessions(s)
 
 	sess2 := s.Sessions["mae-1"]
-	// Should schedule retry with backoff (not immediate respawn)
+	// Provider capacity is not a code failure; it should not consume normal retry budget.
 	if sess2.Status != state.StatusDead {
-		t.Fatalf("status = %q, want %q (should schedule backoff)", sess2.Status, state.StatusDead)
+		t.Fatalf("status = %q, want %q", sess2.Status, state.StatusDead)
 	}
-	if sess2.NextRetryAt == nil {
-		t.Fatal("NextRetryAt should be set for scheduled retry")
+	if sess2.NextRetryAt != nil {
+		t.Fatal("NextRetryAt should not be set for provider-capacity exhaustion")
 	}
 	if len(*respawned) != 0 {
-		t.Fatalf("respawned = %v, want [] (retry is scheduled, not immediate)", *respawned)
+		t.Fatalf("respawned = %v, want []", *respawned)
 	}
-	if sess2.RetryCount != 1 {
-		t.Fatalf("retry_count = %d, want 1", sess2.RetryCount)
+	if sess2.RetryCount != 0 {
+		t.Fatalf("retry_count = %d, want 0", sess2.RetryCount)
+	}
+	if sess2.LastNotifiedStatus != "rate_limit" {
+		t.Fatalf("last_notified_status = %q, want rate_limit", sess2.LastNotifiedStatus)
 	}
 }
 
@@ -4400,7 +4501,7 @@ func TestCheckSessions_NoRateLimit_NormalRetry(t *testing.T) {
 	}
 }
 
-func TestCheckSessions_RateLimitNoFallbackConfigured_NormalRetry(t *testing.T) {
+func TestCheckSessions_RateLimitNoFallbackConfigured_UsesDefaultFallback(t *testing.T) {
 	cfg := cfgWithBackends("claude", "claude", "codex")
 	// No fallback_backends configured
 	cfg.MaxRuntimeMinutes = 999
@@ -4423,18 +4524,17 @@ func TestCheckSessions_RateLimitNoFallbackConfigured_NormalRetry(t *testing.T) {
 	o.checkSessions(s)
 
 	sess2 := s.Sessions["mae-1"]
-	// No fallback backends configured, so should schedule retry with backoff
-	if sess2.Status != state.StatusDead {
-		t.Fatalf("status = %q, want %q (should schedule backoff)", sess2.Status, state.StatusDead)
+	if sess2.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want running after default fallback", sess2.Status)
 	}
-	if sess2.NextRetryAt == nil {
-		t.Fatal("NextRetryAt should be set for scheduled retry")
+	if sess2.Backend != "codex" {
+		t.Fatalf("backend = %q, want codex", sess2.Backend)
 	}
-	if len(*respawned) != 0 {
-		t.Fatalf("respawned = %v, want [] (retry is scheduled, not immediate)", *respawned)
+	if len(*respawned) != 1 || (*respawned)[0] != "codex" {
+		t.Fatalf("respawned = %v, want [codex]", *respawned)
 	}
-	if sess2.RetryCount != 1 {
-		t.Fatalf("retry_count = %d, want 1", sess2.RetryCount)
+	if sess2.RetryCount != 0 {
+		t.Fatalf("retry_count = %d, want 0", sess2.RetryCount)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -98,23 +98,24 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 
 // stateResponse is the JSON shape for GET /api/v1/state.
 type stateResponse struct {
-	Repo                string                       `json:"repo"`
-	MaxParallel         int                          `json:"max_parallel"`
-	ReadOnly            bool                         `json:"read_only"`
-	Outcome             outcome.Status               `json:"outcome"`
-	Actions             []controlAction              `json:"actions,omitempty"`
-	SupervisorPolicy    config.SupervisorConfig      `json:"supervisor_policy"`
-	All                 []sessionInfo                `json:"all"`
-	Running             []sessionInfo                `json:"running"`
-	PROpen              []sessionInfo                `json:"pr_open"`
-	Queued              []sessionInfo                `json:"queued"`
-	TokenTotals         tokenTotalsInfo              `json:"token_totals"`
-	Summary             map[string]int               `json:"summary"`
-	StuckStates         []state.SupervisorStuckState `json:"stuck_states,omitempty"`
-	Supervisor          supervisorInfo               `json:"supervisor"`
-	SupervisorLatest    *state.SupervisorDecision    `json:"supervisor_latest,omitempty"`
-	SupervisorDecisions []state.SupervisorDecision   `json:"supervisor_decisions,omitempty"`
-	Approvals           []state.Approval             `json:"approvals,omitempty"`
+	Repo                string                         `json:"repo"`
+	MaxParallel         int                            `json:"max_parallel"`
+	ReadOnly            bool                           `json:"read_only"`
+	Outcome             outcome.Status                 `json:"outcome"`
+	Actions             []controlAction                `json:"actions,omitempty"`
+	SupervisorPolicy    config.SupervisorConfig        `json:"supervisor_policy"`
+	All                 []sessionInfo                  `json:"all"`
+	Running             []sessionInfo                  `json:"running"`
+	PROpen              []sessionInfo                  `json:"pr_open"`
+	Queued              []sessionInfo                  `json:"queued"`
+	TokenTotals         tokenTotalsInfo                `json:"token_totals"`
+	Summary             map[string]int                 `json:"summary"`
+	StuckStates         []state.SupervisorStuckState   `json:"stuck_states,omitempty"`
+	Supervisor          supervisorInfo                 `json:"supervisor"`
+	SupervisorLatest    *state.SupervisorDecision      `json:"supervisor_latest,omitempty"`
+	SupervisorDecisions []state.SupervisorDecision     `json:"supervisor_decisions,omitempty"`
+	Approvals           []state.Approval               `json:"approvals,omitempty"`
+	BackendHealth       map[string]state.BackendHealth `json:"backend_health,omitempty"`
 }
 
 type supervisorInfo struct {
@@ -208,35 +209,36 @@ type controlActionRequest struct {
 }
 
 type sessionInfo struct {
-	Slot              string          `json:"slot"`
-	IssueNumber       int             `json:"issue_number"`
-	IssueTitle        string          `json:"issue_title"`
-	IssueURL          string          `json:"issue_url,omitempty"`
-	Status            string          `json:"status"`
-	DisplayStatus     string          `json:"display_status,omitempty"`
-	StatusReason      string          `json:"status_reason,omitempty"`
-	NextAction        string          `json:"next_action,omitempty"`
-	NeedsAttention    bool            `json:"needs_attention,omitempty"`
-	Live              bool            `json:"live"`
-	Backend           string          `json:"backend,omitempty"`
-	PRNumber          int             `json:"pr_number,omitempty"`
-	PRURL             string          `json:"pr_url,omitempty"`
-	TokensUsedAttempt int             `json:"tokens_used_attempt"`
-	TokensUsedTotal   int             `json:"tokens_used_total"`
-	Runtime           string          `json:"runtime"`
-	RuntimeSeconds    int64           `json:"runtime_seconds"`
-	StartedAt         string          `json:"started_at"`
-	FinishedAt        string          `json:"finished_at,omitempty"`
-	NextRetryAt       string          `json:"next_retry_at,omitempty"`
-	PID               int             `json:"pid,omitempty"`
-	Alive             *bool           `json:"alive,omitempty"`
-	Worktree          string          `json:"worktree,omitempty"`
-	Branch            string          `json:"branch,omitempty"`
-	TmuxSession       string          `json:"tmux_session,omitempty"`
-	HasLog            bool            `json:"has_log"`
-	RetryCount        int             `json:"retry_count,omitempty"`
-	LastNotification  string          `json:"last_notification,omitempty"`
-	Actions           []controlAction `json:"actions,omitempty"`
+	Slot              string                  `json:"slot"`
+	IssueNumber       int                     `json:"issue_number"`
+	IssueTitle        string                  `json:"issue_title"`
+	IssueURL          string                  `json:"issue_url,omitempty"`
+	Status            string                  `json:"status"`
+	DisplayStatus     string                  `json:"display_status,omitempty"`
+	StatusReason      string                  `json:"status_reason,omitempty"`
+	NextAction        string                  `json:"next_action,omitempty"`
+	NeedsAttention    bool                    `json:"needs_attention,omitempty"`
+	Live              bool                    `json:"live"`
+	Backend           string                  `json:"backend,omitempty"`
+	PRNumber          int                     `json:"pr_number,omitempty"`
+	PRURL             string                  `json:"pr_url,omitempty"`
+	TokensUsedAttempt int                     `json:"tokens_used_attempt"`
+	TokensUsedTotal   int                     `json:"tokens_used_total"`
+	Runtime           string                  `json:"runtime"`
+	RuntimeSeconds    int64                   `json:"runtime_seconds"`
+	StartedAt         string                  `json:"started_at"`
+	FinishedAt        string                  `json:"finished_at,omitempty"`
+	NextRetryAt       string                  `json:"next_retry_at,omitempty"`
+	PID               int                     `json:"pid,omitempty"`
+	Alive             *bool                   `json:"alive,omitempty"`
+	Worktree          string                  `json:"worktree,omitempty"`
+	Branch            string                  `json:"branch,omitempty"`
+	TmuxSession       string                  `json:"tmux_session,omitempty"`
+	HasLog            bool                    `json:"has_log"`
+	RetryCount        int                     `json:"retry_count,omitempty"`
+	LastNotification  string                  `json:"last_notification,omitempty"`
+	BackendSelection  *state.BackendSelection `json:"backend_selection,omitempty"`
+	Actions           []controlAction         `json:"actions,omitempty"`
 }
 
 func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
@@ -259,6 +261,7 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 		HasLog:            strings.TrimSpace(sess.LogFile) != "",
 		RetryCount:        sess.RetryCount,
 		LastNotification:  sess.LastNotifiedStatus,
+		BackendSelection:  sess.BackendSelection,
 		Live:              state.SessionLiveAt(sess, now),
 	}
 
@@ -715,6 +718,7 @@ func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 		ReadOnly:            cfg.Server.ReadOnly,
 		Outcome:             outcomeStatusForState(cfg, st),
 		Actions:             projectActionAffordances(cfg.Server.ReadOnly, "/api/v1/actions", cfg.Repo),
+		BackendHealth:       st.BackendHealth,
 		SupervisorPolicy:    cfg.Supervisor,
 		All:                 make([]sessionInfo, 0, len(st.Sessions)),
 		Running:             make([]sessionInfo, 0),

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -42,6 +42,47 @@ const (
 
 const RetryReasonReviewFeedback = "review_feedback"
 
+const (
+	BackendHealthAvailable = "available"
+	BackendHealthCooldown  = "cooldown"
+
+	BackendBlockProviderLimit = "provider_limit"
+	BackendBlockDisabled      = "disabled"
+	BackendBlockAlreadyTried  = "already_tried"
+	BackendBlockCurrent       = "current_backend"
+	BackendBlockUnknown       = "unknown_backend"
+)
+
+// BackendHealth records cross-session availability for a configured backend.
+type BackendHealth struct {
+	State       string     `json:"state"`
+	Reason      string     `json:"reason,omitempty"`
+	Pattern     string     `json:"pattern,omitempty"`
+	Since       time.Time  `json:"since,omitempty"`
+	RetryAfter  *time.Time `json:"retry_after,omitempty"`
+	LastSession string     `json:"last_session,omitempty"`
+}
+
+// BackendCandidate explains why one backend was or was not selectable.
+type BackendCandidate struct {
+	Backend    string  `json:"backend"`
+	Available  bool    `json:"available"`
+	BlockedBy  string  `json:"blocked_by,omitempty"`
+	RetryAfter string  `json:"retry_after,omitempty"`
+	Fit        float64 `json:"fit,omitempty"`
+	Policy     float64 `json:"policy,omitempty"`
+	Final      float64 `json:"final,omitempty"`
+}
+
+// BackendSelection is an audit record for worker backend choice.
+type BackendSelection struct {
+	SelectedBackend string             `json:"selected_backend,omitempty"`
+	SelectionReason string             `json:"selection_reason"`
+	CandidateScores []BackendCandidate `json:"candidate_scores,omitempty"`
+	HardPin         bool               `json:"hard_pin,omitempty"`
+	PreviousBackend string             `json:"previous_backend,omitempty"`
+}
+
 // Phase represents which pipeline phase a session is currently in.
 type Phase string
 
@@ -53,39 +94,42 @@ const (
 )
 
 type Session struct {
-	IssueNumber                 int           `json:"issue_number"`
-	IssueTitle                  string        `json:"issue_title"`
-	Worktree                    string        `json:"worktree"`
-	Branch                      string        `json:"branch"`
-	PID                         int           `json:"pid"`
-	TmuxSession                 string        `json:"tmux_session,omitempty"`
-	LogFile                     string        `json:"log_file"`
-	StartedAt                   time.Time     `json:"started_at"`
-	FinishedAt                  *time.Time    `json:"finished_at,omitempty"`
-	Status                      SessionStatus `json:"status"`
-	PRNumber                    int           `json:"pr_number,omitempty"`
-	Backend                     string        `json:"backend,omitempty"` // "claude", "codex", etc.
-	LongRunning                 bool          `json:"long_running,omitempty"`
-	RebaseAttempted             bool          `json:"rebase_attempted,omitempty"`
-	NotifiedCIFail              bool          `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
-	LastNotifiedStatus          string        `json:"last_notified_status,omitempty"` // dedup: last notification type sent
-	RetryCount                  int           `json:"retry_count,omitempty"`          // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
-	NextRetryAt                 *time.Time    `json:"next_retry_at,omitempty"`
-	LastOutputHash              string        `json:"last_output_hash,omitempty"`
-	LastOutputChangedAt         time.Time     `json:"last_output_changed_at,omitempty"`
-	TokensUsedAttempt           int           `json:"tokens_used_attempt,omitempty"`            // tokens consumed in current attempt (reset on respawn)
-	TokensUsedTotal             int           `json:"tokens_used_total,omitempty"`              // cumulative tokens across the issue lifecycle
-	RateLimitHit                bool          `json:"rate_limit_hit,omitempty"`                 // true if worker was rate-limited (tmux detection, running worker)
-	TriedBackends               []string      `json:"tried_backends,omitempty"`                 // backends already attempted (for rate-limit fallback)
-	Phase                       Phase         `json:"phase,omitempty"`                          // current pipeline phase (empty = legacy single-phase)
-	ValidationFails             int           `json:"validation_fails,omitempty"`               // number of failed validation attempts
-	ValidationFeedback          string        `json:"validation_feedback,omitempty"`            // feedback from last failed validation
-	CIFailureOutput             string        `json:"ci_failure_output,omitempty"`              // CI failure output captured before retry (passed to next worker as context)
-	PreviousAttemptFeedback     string        `json:"previous_attempt_feedback,omitempty"`      // feedback from previous failed PR attempt
-	PreviousAttemptFeedbackKind string        `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
-	RetryReason                 string        `json:"retry_reason,omitempty"`                   // current retry lifecycle reason, e.g. review_feedback
-	CheckpointFile              string        `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
-	DeploymentFinishedAt        *time.Time    `json:"deployment_finished_at,omitempty"`         // set when the post-merge deploy hook succeeds
+	IssueNumber                 int               `json:"issue_number"`
+	IssueTitle                  string            `json:"issue_title"`
+	Worktree                    string            `json:"worktree"`
+	Branch                      string            `json:"branch"`
+	PID                         int               `json:"pid"`
+	TmuxSession                 string            `json:"tmux_session,omitempty"`
+	LogFile                     string            `json:"log_file"`
+	StartedAt                   time.Time         `json:"started_at"`
+	FinishedAt                  *time.Time        `json:"finished_at,omitempty"`
+	Status                      SessionStatus     `json:"status"`
+	PRNumber                    int               `json:"pr_number,omitempty"`
+	Backend                     string            `json:"backend,omitempty"` // "claude", "codex", etc.
+	LongRunning                 bool              `json:"long_running,omitempty"`
+	RebaseAttempted             bool              `json:"rebase_attempted,omitempty"`
+	NotifiedCIFail              bool              `json:"notified_ci_fail,omitempty"`     // deprecated: use LastNotifiedStatus
+	LastNotifiedStatus          string            `json:"last_notified_status,omitempty"` // dedup: last notification type sent
+	RetryCount                  int               `json:"retry_count,omitempty"`          // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
+	NextRetryAt                 *time.Time        `json:"next_retry_at,omitempty"`
+	LastOutputHash              string            `json:"last_output_hash,omitempty"`
+	LastOutputChangedAt         time.Time         `json:"last_output_changed_at,omitempty"`
+	TokensUsedAttempt           int               `json:"tokens_used_attempt,omitempty"`            // tokens consumed in current attempt (reset on respawn)
+	TokensUsedTotal             int               `json:"tokens_used_total,omitempty"`              // cumulative tokens across the issue lifecycle
+	RateLimitHit                bool              `json:"rate_limit_hit,omitempty"`                 // true if worker was rate-limited (tmux detection, running worker)
+	TriedBackends               []string          `json:"tried_backends,omitempty"`                 // backends already attempted (for rate-limit fallback)
+	ProviderLimitBackend        string            `json:"provider_limit_backend,omitempty"`         // backend that hit a provider capacity limit
+	ProviderLimitReason         string            `json:"provider_limit_reason,omitempty"`          // provider limit signature or class
+	BackendSelection            *BackendSelection `json:"backend_selection,omitempty"`              // latest backend selection audit record
+	Phase                       Phase             `json:"phase,omitempty"`                          // current pipeline phase (empty = legacy single-phase)
+	ValidationFails             int               `json:"validation_fails,omitempty"`               // number of failed validation attempts
+	ValidationFeedback          string            `json:"validation_feedback,omitempty"`            // feedback from last failed validation
+	CIFailureOutput             string            `json:"ci_failure_output,omitempty"`              // CI failure output captured before retry (passed to next worker as context)
+	PreviousAttemptFeedback     string            `json:"previous_attempt_feedback,omitempty"`      // feedback from previous failed PR attempt
+	PreviousAttemptFeedbackKind string            `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
+	RetryReason                 string            `json:"retry_reason,omitempty"`                   // current retry lifecycle reason, e.g. review_feedback
+	CheckpointFile              string            `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
+	DeploymentFinishedAt        *time.Time        `json:"deployment_finished_at,omitempty"`         // set when the post-merge deploy hook succeeds
 }
 
 // SessionAttention explains why a session needs operator attention and the
@@ -164,6 +208,17 @@ func SessionAttentionForAt(sess *Session, alive *bool, now time.Time) SessionAtt
 			return SessionAttention{
 				Reason:         "Worker exited; a retry is scheduled after the current backoff.",
 				NextAction:     "Wait for the scheduled retry or inspect the failed attempt if it should not retry.",
+				NeedsAttention: true,
+			}
+		}
+		if sess.RateLimitHit {
+			backend := sess.ProviderLimitBackend
+			if backend == "" {
+				backend = sess.Backend
+			}
+			return SessionAttention{
+				Reason:         fmt.Sprintf("Backend %s hit a provider capacity limit; no fallback backend is currently available or allowed.", backend),
+				NextAction:     "Wait for provider capacity to recover, enable another backend, or change routing policy before retrying.",
 				NeedsAttention: true,
 			}
 		}
@@ -564,6 +619,7 @@ type State struct {
 	SupervisorDecisions []SupervisorDecision       `json:"supervisor_decisions,omitempty"`
 	Approvals           []Approval                 `json:"approvals,omitempty"`
 	OutcomeHealth       *outcome.HealthCheckResult `json:"outcome_health,omitempty"`
+	BackendHealth       map[string]BackendHealth   `json:"backend_health,omitempty"`
 	ProjectStatusSync   map[int]ProjectStatusSync  `json:"project_status_sync,omitempty"`
 	NextSlot            int                        `json:"next_slot"`
 	LastMergeAt         time.Time                  `json:"last_merge_at,omitempty"`
@@ -582,6 +638,7 @@ func NewState() *State {
 		Sessions:          make(map[string]*Session),
 		Missions:          make(map[int]*Mission),
 		ProjectStatusSync: make(map[int]ProjectStatusSync),
+		BackendHealth:     make(map[string]BackendHealth),
 		NextSlot:          1,
 	}
 }
@@ -744,6 +801,9 @@ func (s *State) normalize() {
 	if s.ProjectStatusSync == nil {
 		s.ProjectStatusSync = make(map[int]ProjectStatusSync)
 	}
+	if s.BackendHealth == nil {
+		s.BackendHealth = make(map[string]BackendHealth)
+	}
 	if s.NextSlot == 0 {
 		s.NextSlot = 1
 	}
@@ -756,6 +816,7 @@ func (s *State) copyFrom(src *State) {
 	s.Approvals = src.Approvals
 	s.OutcomeHealth = src.OutcomeHealth
 	s.ProjectStatusSync = src.ProjectStatusSync
+	s.BackendHealth = src.BackendHealth
 	s.NextSlot = src.NextSlot
 	s.LastMergeAt = src.LastMergeAt
 }
@@ -796,6 +857,7 @@ func mergeStateSnapshots(base, current, ours *State) (*State, error) {
 	}
 	merged.OutcomeHealth = mergeOutcomeHealth(base.OutcomeHealth, current.OutcomeHealth, ours.OutcomeHealth)
 	merged.ProjectStatusSync = mergeProjectStatusSync(current.ProjectStatusSync, ours.ProjectStatusSync)
+	merged.BackendHealth = mergeBackendHealth(current.BackendHealth, ours.BackendHealth)
 	merged.NextSlot = mergeMonotonicInt(base.NextSlot, current.NextSlot, ours.NextSlot)
 	merged.LastMergeAt = mergeLatestTime(base.LastMergeAt, current.LastMergeAt, ours.LastMergeAt)
 	return merged, nil
@@ -820,6 +882,42 @@ func mergeProjectStatusSync(current, ours map[int]ProjectStatusSync) map[int]Pro
 		}
 	}
 	return merged
+}
+
+func mergeBackendHealth(current, ours map[string]BackendHealth) map[string]BackendHealth {
+	merged := make(map[string]BackendHealth)
+	for _, key := range unionBackendHealthKeys(current, ours) {
+		currentValue, currentOK := current[key]
+		oursValue, oursOK := ours[key]
+		switch {
+		case currentOK && oursOK:
+			if oursValue.Since.After(currentValue.Since) {
+				merged[key] = oursValue
+			} else {
+				merged[key] = currentValue
+			}
+		case currentOK:
+			merged[key] = currentValue
+		case oursOK:
+			merged[key] = oursValue
+		}
+	}
+	return merged
+}
+
+func unionBackendHealthKeys(maps ...map[string]BackendHealth) []string {
+	seen := make(map[string]struct{})
+	for _, m := range maps {
+		for k := range m {
+			seen[k] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func unionProjectStatusSyncKeys(maps ...map[int]ProjectStatusSync) []int {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -91,6 +91,54 @@ func TestProjectStatusSynced(t *testing.T) {
 	}
 }
 
+func TestBackendHealthPersistence(t *testing.T) {
+	dir := t.TempDir()
+	since := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	retryAfter := since.Add(2 * time.Hour)
+
+	s := NewState()
+	s.BackendHealth["claude"] = BackendHealth{
+		State:       BackendHealthCooldown,
+		Reason:      BackendBlockProviderLimit,
+		Pattern:     "limit for today",
+		Since:       since,
+		RetryAfter:  &retryAfter,
+		LastSession: "scr-54",
+	}
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	health := loaded.BackendHealth["claude"]
+	if health.State != BackendHealthCooldown || health.Reason != BackendBlockProviderLimit {
+		t.Fatalf("health = %+v, want provider-limit cooldown", health)
+	}
+	if health.RetryAfter == nil || !health.RetryAfter.Equal(retryAfter) {
+		t.Fatalf("retry_after = %v, want %s", health.RetryAfter, retryAfter)
+	}
+}
+
+func TestBackendHealthMergeKeepsLatest(t *testing.T) {
+	base := NewState()
+	current := NewState()
+	ours := NewState()
+	current.BackendHealth["claude"] = BackendHealth{State: BackendHealthCooldown, Reason: BackendBlockProviderLimit, Since: time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)}
+	ours.BackendHealth["claude"] = BackendHealth{State: BackendHealthAvailable, Reason: "manual_clear", Since: time.Date(2026, 5, 22, 11, 0, 0, 0, time.UTC)}
+
+	merged, err := mergeStateSnapshots(base, current, ours)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if got := merged.BackendHealth["claude"]; got.State != BackendHealthAvailable || got.Reason != "manual_clear" {
+		t.Fatalf("merged claude health = %+v, want latest ours value", got)
+	}
+}
+
 func TestNotifiedCIFail_OmittedWhenFalse(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Implements the first vertical slice for #432: Maestro now treats provider/rate limits as backend availability events instead of generic worker failures.

## Changes

- Records provider-limit health per backend in persisted state as `backend_health`.
- Adds per-session `backend_selection` audit records with candidate availability, block reason, fit score, policy score, and selected backend.
- Switches rate-limited workers to the best available fallback backend, including `model.default` when `fallback_backends` is not explicitly configured.
- Respects explicit `fallback_backends` when present and skips disabled, current, already-tried, unknown, or cooldown backends.
- Exposes backend health and selection audit data through `/api/v1/state`.
- Marks provider-capacity exhaustion as operator attention without consuming normal retry budget.

## Validation

- `/usr/local/bin/go test ./...`

Closes #432.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements provider rate-limit events as backend availability state rather than generic worker failures. When a worker hits a capacity limit, Maestro now records a cooldown entry in persisted `backend_health`, selects the best available fallback backend (using explicit `fallback_backends` or the `model.default` + sorted remainder), and respawns without consuming normal retry budget.

- Adds `BackendHealth`, `BackendCandidate`, and `BackendSelection` types to `state.go`; propagates `BackendHealth` through merge, normalize, and copyFrom; exposes both maps via `/api/v1/state`.
- Extracts selection logic into `backend_selector.go` with `recordProviderLimit` and `selectProviderLimitFallback`; updates both the tmux-based (running worker) and log-file-based (dead worker) rate-limit code paths in `orchestrator.go`.
- Adds `Enabled *bool` to `BackendDef` with an `IsEnabled()` helper; disabled backends are excluded from fallback candidates.

<h3>Confidence Score: 5/5</h3>

Safe to merge; both rate-limit code paths correctly stop workers before fallback, provider-capacity events no longer consume retry budget, and the new state is fully round-tripped through persistence and merge.

The orchestrator changes are well-scoped: the tmux-based (running worker) path calls stopWorker before recording health and selecting a fallback, the log-file-based (dead worker) path needs no stop call, and both paths guard against nil/empty backends. The BackendHealth merge uses a latest-Since policy that correctly handles concurrent processes. Test coverage spans the new default-fallback path, the no-fallback-available path, and the behavior change around retry budget. No new state is written without a corresponding read path.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/backend_selector.go | New file implementing provider-limit recording and fallback selection logic; candidate scoring is computed for audit only — selection is first-available in deterministic candidate order, which aligns with Default-first ordering but leaves scores inoperative as a selection driver. |
| internal/orchestrator/orchestrator.go | Both rate-limit code paths (tmux-based for running workers; log-file-based for dead workers) updated to call recordProviderLimit + selectProviderLimitFallback; provider-capacity exhaustion no longer consumes retry budget; stopWorker is correctly called before fallback in the running-worker path. |
| internal/state/state.go | Adds BackendHealth, BackendCandidate, BackendSelection types; integrates BackendHealth into NewState, normalize, copyFrom, and mergeStateSnapshots with a latest-Since merge policy; SessionAttentionForAt extended for RateLimitHit. |
| internal/state/state_test.go | New persistence and merge-conflict tests for BackendHealth; merge test verifies that a newer BackendHealthAvailable entry beats an older cooldown, covering the full state round-trip. |
| internal/orchestrator/orchestrator_test.go | Two new tests added (default-backend fallback and no-available-fallback paths); existing tests updated to reflect that provider-capacity exhaustion no longer consumes retry budget (RetryCount stays 0, NextRetryAt not set). |
| internal/server/server.go | BackendHealth added to stateResponse and BackendSelection added to sessionInfo; both wired through buildStateResponse and makeSessionInfo with no logic changes. |
| internal/config/config.go | Adds optional Enabled *bool field to BackendDef with IsEnabled() treating nil as enabled for backward compatibility. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 353-377 ([link](https://github.com/befeast/maestro/blob/2f61dc69e02792464ddb1349235e73d245562b9f/internal/orchestrator/orchestrator.go#L353-L377)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead production code — `nextFallbackBackend` is no longer called**

   `nextFallbackBackend` was superseded by `selectProviderLimitFallback` / `backendFallbackCandidates` in this PR. No production code path in `orchestrator.go` calls it any longer; it is referenced only by its own unit tests. Keeping it alongside the new function will confuse future readers about which selection path is active, and the two functions disagree on behavior (e.g., `nextFallbackBackend` does not consult `BackendHealth` or disabled state). The function and its dedicated tests should be removed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 353-377

   Comment:
   **Dead production code — `nextFallbackBackend` is no longer called**

   `nextFallbackBackend` was superseded by `selectProviderLimitFallback` / `backendFallbackCandidates` in this PR. No production code path in `orchestrator.go` calls it any longer; it is referenced only by its own unit tests. Keeping it alongside the new function will confuse future readers about which selection path is active, and the two functions disagree on behavior (e.g., `nextFallbackBackend` does not consult `BackendHealth` or disabled state). The function and its dedicated tests should be removed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Handle provider limit backend fallback"](https://github.com/befeast/maestro/commit/357b507aad9274d005a14e4f258b606a88e3f152) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33484443)</sub>

<!-- /greptile_comment -->