### PR TITLE
Supervisor targets stale retry-exhausted session after issue is closed

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -209,7 +209,8 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		return state.SupervisorDecision{}, fmt.Errorf("list open PRs: %w", err)
 	}
 	projectState.OpenPRs = len(prs)
-	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false)
+	cache := newResolutionCache(e.reader)
+	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false, cache)
 
 	if slot, sess, pr, ok := sessionWithOpenPR(st, prs); ok {
 		if e.openPRNeedsRepair(st, stuckStates, slot, sess, pr) {
@@ -255,16 +256,18 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		return decision, nil
 	}
 
-	if slot, sess, ok := e.retryExhaustedSession(st); ok && !e.cfg.Supervisor.OrderedQueueActive() {
-		reasons := appendReasons(baseReasons,
-			fmt.Sprintf("Session %s for issue #%d is retry_exhausted", slot, sess.IssueNumber),
-			"Retry-exhausted work requires a human decision before more automation",
-		)
-		decision := e.decision(st, now, projectState, ActionReviewRetryExhausted,
-			fmt.Sprintf("Issue #%d exhausted its retry budget and needs manual review.", sess.IssueNumber),
-			RiskApprovalGated, 0.93, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}, PolicyRuleRuntimeState, reasons)
-		decision.StuckStates = stuckStates
-		return decision, nil
+	if !e.cfg.Supervisor.OrderedQueueActive() {
+		if slot, sess, ok := e.retryExhaustedSession(st, cache); ok {
+			reasons := appendReasons(baseReasons,
+				fmt.Sprintf("Session %s for issue #%d is retry_exhausted", slot, sess.IssueNumber),
+				"Retry-exhausted work requires a human decision before more automation",
+			)
+			decision := e.decision(st, now, projectState, ActionReviewRetryExhausted,
+				fmt.Sprintf("Issue #%d exhausted its retry budget and needs manual review.", sess.IssueNumber),
+				RiskApprovalGated, 0.93, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}, PolicyRuleRuntimeState, reasons)
+			decision.StuckStates = stuckStates
+			return decision, nil
+		}
 	}
 
 	if stuck := noOutcomeProgressStuckState(stuckStates); stuck != nil && len(st.ActiveSessions()) == 0 {
@@ -291,7 +294,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		return state.SupervisorDecision{}, err
 	}
 	if policyResult.dynamicWave {
-		return e.decideDynamicWave(st, now, projectState, baseReasons, prs, issues, policyResult)
+		return e.decideDynamicWave(st, now, projectState, baseReasons, prs, issues, policyResult, cache)
 	}
 	candidates := policyResult.candidates
 	policySkipped := policyResult.skipped
@@ -301,7 +304,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		return state.SupervisorDecision{}, err
 	}
 	skipped = append(policySkipped, skipped...)
-	stuckStates = e.detectStuckStates(st, now, prs, issues, eligible, skipped, true)
+	stuckStates = e.detectStuckStates(st, now, prs, issues, eligible, skipped, true, cache)
 	analysis := supervisorQueueAnalysis(policyRule, len(issues), eligible, skipped)
 	withAnalysis := func(decision state.SupervisorDecision) state.SupervisorDecision {
 		decision.QueueAnalysis = analysis
@@ -440,7 +443,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	return withAnalysis(decision), nil
 }
 
-func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState state.SupervisorProjectState, baseReasons []string, prs []github.PR, issues []github.Issue, result policyCandidateResult) (state.SupervisorDecision, error) {
+func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState state.SupervisorProjectState, baseReasons []string, prs []github.PR, issues []github.Issue, result policyCandidateResult, cache *resolutionCache) (state.SupervisorDecision, error) {
 	candidates := result.candidates
 	analysis := result.analysis
 	outcomeStatus := e.outcomeStatus(st)
@@ -450,7 +453,7 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 			analysis.SelectedCandidate = supervisorIssueCandidate(candidates[0])
 		}
 	}
-	stuckStates := e.detectStuckStates(st, now, prs, issues, candidates, result.skipped, true)
+	stuckStates := e.detectStuckStates(st, now, prs, issues, candidates, result.skipped, true, cache)
 	withAnalysis := func(decision state.SupervisorDecision) state.SupervisorDecision {
 		decision.QueueAnalysis = analysis
 		decision.StuckStates = stuckStates
@@ -565,9 +568,9 @@ func (e *Engine) decision(st *state.State, now time.Time, ps state.SupervisorPro
 	}
 }
 
-func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.PR, issues, eligible []github.Issue, skipped []string, issuesLoaded bool) []state.SupervisorStuckState {
+func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.PR, issues, eligible []github.Issue, skipped []string, issuesLoaded bool, cache *resolutionCache) []state.SupervisorStuckState {
 	var findings []state.SupervisorStuckState
-	findings = append(findings, e.detectWorkerStuckStates(st, now)...)
+	findings = append(findings, e.detectWorkerStuckStates(st, now, cache)...)
 	findings = append(findings, e.detectPRStuckStates(st, prs)...)
 	if issuesLoaded {
 		findings = append(findings, e.detectQueueStuckStates(st, prs, issues, eligible, skipped)...)
@@ -679,7 +682,7 @@ func noOutcomeProgressStuckState(stuckStates []state.SupervisorStuckState) *stat
 	return nil
 }
 
-func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time) []state.SupervisorStuckState {
+func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time, cache *resolutionCache) []state.SupervisorStuckState {
 	var findings []state.SupervisorStuckState
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
@@ -726,7 +729,7 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time) []state
 			}
 		}
 
-		if sess.Status == state.StatusRetryExhausted && sess.PRNumber == 0 && !e.retryExhaustedSessionResolvedOnGitHub(sess) {
+		if sess.Status == state.StatusRetryExhausted && sess.PRNumber == 0 && !e.retryExhaustedSessionResolvedOnGitHub(sess, cache) {
 			findings = append(findings, stuckState("retry_exhausted", SeverityBlocked,
 				fmt.Sprintf("Issue #%d exhausted its retry budget.", sess.IssueNumber),
 				"Review the failed attempts, adjust the issue or retry budget, then restart intentionally.", false, target,
@@ -1622,13 +1625,13 @@ func (e *Engine) hasLiveRunningSessionForIssue(st *state.State, issueNumber int)
 	return false
 }
 
-func (e *Engine) retryExhaustedSession(st *state.State) (string, *state.Session, bool) {
+func (e *Engine) retryExhaustedSession(st *state.State, cache *resolutionCache) (string, *state.Session, bool) {
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
 		if sess == nil || sess.Status != state.StatusRetryExhausted {
 			continue
 		}
-		if e.retryExhaustedSessionResolvedOnGitHub(sess) {
+		if e.retryExhaustedSessionResolvedOnGitHub(sess, cache) {
 			continue
 		}
 		return slot, sess, true
@@ -1640,25 +1643,89 @@ func (e *Engine) retryExhaustedSession(st *state.State) (string, *state.Session,
 // is closed or has been resolved by a merged PR, so the supervisor should
 // ignore the stale retry-exhausted session record instead of recommending
 // review or worker spawning for the already-resolved issue.
-func (e *Engine) retryExhaustedSessionResolvedOnGitHub(sess *state.Session) bool {
+func (e *Engine) retryExhaustedSessionResolvedOnGitHub(sess *state.Session, cache *resolutionCache) bool {
 	if sess == nil {
 		return false
 	}
-	if sess.PRNumber > 0 {
-		if merged, err := e.reader.IsPRMerged(sess.PRNumber); err == nil && merged {
-			return true
-		}
+	if sess.PRNumber > 0 && cache.isPRMerged(sess.PRNumber) {
+		return true
 	}
 	if sess.IssueNumber <= 0 {
 		return false
 	}
-	if closed, err := e.reader.IsIssueClosed(sess.IssueNumber); err == nil && closed {
+	if cache.isIssueClosed(sess.IssueNumber) {
 		return true
 	}
-	if merged, err := e.reader.HasMergedPRForIssue(sess.IssueNumber); err == nil && merged {
+	if cache.hasMergedPRForIssue(sess.IssueNumber) {
 		return true
 	}
 	return false
+}
+
+// resolutionCache memoizes the read-only GitHub lookups used to detect that a
+// retry-exhausted session has already been resolved upstream. Within a single
+// supervisor decision cycle the same issue or PR may be inspected from
+// multiple call sites (e.g. detectWorkerStuckStates and retryExhaustedSession);
+// the cache ensures each underlying API call is issued at most once.
+type resolutionCache struct {
+	reader           Reader
+	issueClosed      map[int]bool
+	mergedPRForIssue map[int]bool
+	prMerged         map[int]bool
+}
+
+func newResolutionCache(reader Reader) *resolutionCache {
+	return &resolutionCache{
+		reader:           reader,
+		issueClosed:      make(map[int]bool),
+		mergedPRForIssue: make(map[int]bool),
+		prMerged:         make(map[int]bool),
+	}
+}
+
+func (c *resolutionCache) isIssueClosed(number int) bool {
+	if c == nil || c.reader == nil || number <= 0 {
+		return false
+	}
+	if v, ok := c.issueClosed[number]; ok {
+		return v
+	}
+	closed, err := c.reader.IsIssueClosed(number)
+	if err != nil {
+		return false
+	}
+	c.issueClosed[number] = closed
+	return closed
+}
+
+func (c *resolutionCache) hasMergedPRForIssue(number int) bool {
+	if c == nil || c.reader == nil || number <= 0 {
+		return false
+	}
+	if v, ok := c.mergedPRForIssue[number]; ok {
+		return v
+	}
+	merged, err := c.reader.HasMergedPRForIssue(number)
+	if err != nil {
+		return false
+	}
+	c.mergedPRForIssue[number] = merged
+	return merged
+}
+
+func (c *resolutionCache) isPRMerged(prNumber int) bool {
+	if c == nil || c.reader == nil || prNumber <= 0 {
+		return false
+	}
+	if v, ok := c.prMerged[prNumber]; ok {
+		return v
+	}
+	merged, err := c.reader.IsPRMerged(prNumber)
+	if err != nil {
+		return false
+	}
+	c.prMerged[prNumber] = merged
+	return merged
 }
 
 func sortedSessionNames(st *state.State) []string {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -255,7 +255,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		return decision, nil
 	}
 
-	if slot, sess, ok := retryExhaustedSession(st); ok && !e.cfg.Supervisor.OrderedQueueActive() {
+	if slot, sess, ok := e.retryExhaustedSession(st); ok && !e.cfg.Supervisor.OrderedQueueActive() {
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Session %s for issue #%d is retry_exhausted", slot, sess.IssueNumber),
 			"Retry-exhausted work requires a human decision before more automation",
@@ -726,7 +726,7 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time) []state
 			}
 		}
 
-		if sess.Status == state.StatusRetryExhausted && sess.PRNumber == 0 {
+		if sess.Status == state.StatusRetryExhausted && sess.PRNumber == 0 && !e.retryExhaustedSessionResolvedOnGitHub(sess) {
 			findings = append(findings, stuckState("retry_exhausted", SeverityBlocked,
 				fmt.Sprintf("Issue #%d exhausted its retry budget.", sess.IssueNumber),
 				"Review the failed attempts, adjust the issue or retry budget, then restart intentionally.", false, target,
@@ -1622,14 +1622,43 @@ func (e *Engine) hasLiveRunningSessionForIssue(st *state.State, issueNumber int)
 	return false
 }
 
-func retryExhaustedSession(st *state.State) (string, *state.Session, bool) {
+func (e *Engine) retryExhaustedSession(st *state.State) (string, *state.Session, bool) {
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
-		if sess != nil && sess.Status == state.StatusRetryExhausted {
-			return slot, sess, true
+		if sess == nil || sess.Status != state.StatusRetryExhausted {
+			continue
 		}
+		if e.retryExhaustedSessionResolvedOnGitHub(sess) {
+			continue
+		}
+		return slot, sess, true
 	}
 	return "", nil, false
+}
+
+// retryExhaustedSessionResolvedOnGitHub returns true when the underlying issue
+// is closed or has been resolved by a merged PR, so the supervisor should
+// ignore the stale retry-exhausted session record instead of recommending
+// review or worker spawning for the already-resolved issue.
+func (e *Engine) retryExhaustedSessionResolvedOnGitHub(sess *state.Session) bool {
+	if sess == nil {
+		return false
+	}
+	if sess.PRNumber > 0 {
+		if merged, err := e.reader.IsPRMerged(sess.PRNumber); err == nil && merged {
+			return true
+		}
+	}
+	if sess.IssueNumber <= 0 {
+		return false
+	}
+	if closed, err := e.reader.IsIssueClosed(sess.IssueNumber); err == nil && closed {
+		return true
+	}
+	if merged, err := e.reader.HasMergedPRForIssue(sess.IssueNumber); err == nil && merged {
+		return true
+	}
+	return false
 }
 
 func sortedSessionNames(st *state.State) []string {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -320,6 +320,95 @@ func TestDecide_RetryExhaustedNeedsReview(t *testing.T) {
 	}
 }
 
+func TestDecide_RetryExhaustedSkippedWhenIssueClosed(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{
+		closedIssues: map[int]bool{768: true},
+	}
+	st := state.NewState()
+	st.Sessions["pan-56"] = &state.Session{
+		IssueNumber: 768,
+		IssueTitle:  "stale exhausted work",
+		Status:      state.StatusRetryExhausted,
+		StartedAt:   time.Now().UTC().Add(-2 * time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction == ActionReviewRetryExhausted {
+		t.Fatalf("action = %q, must not recommend reviewing a stale retry-exhausted session for a closed issue", decision.RecommendedAction)
+	}
+	if decision.Target != nil && decision.Target.Session == "pan-56" {
+		t.Fatalf("target = %#v, must not target stale session pan-56 once issue #768 is closed", decision.Target)
+	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == "retry_exhausted" {
+			t.Fatalf("stuck state retry_exhausted should not be reported for closed issue: %#v", stuck)
+		}
+	}
+}
+
+func TestDecide_RetryExhaustedSkippedWhenIssueHasMergedWinningPR(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{
+		mergedPRIssues: map[int]bool{768: true},
+	}
+	st := state.NewState()
+	st.Sessions["pan-56"] = &state.Session{
+		IssueNumber: 768,
+		IssueTitle:  "stale exhausted work, winner merged",
+		Status:      state.StatusRetryExhausted,
+		StartedAt:   time.Now().UTC().Add(-2 * time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction == ActionReviewRetryExhausted {
+		t.Fatalf("action = %q, must not recommend reviewing a stale retry-exhausted session once a winning PR is merged", decision.RecommendedAction)
+	}
+	if decision.Target != nil && decision.Target.Session == "pan-56" {
+		t.Fatalf("target = %#v, must not target stale session pan-56 once issue #768 has a merged winner", decision.Target)
+	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == "retry_exhausted" {
+			t.Fatalf("stuck state retry_exhausted should not be reported for issue resolved by merged PR: %#v", stuck)
+		}
+	}
+}
+
+func TestDecide_RetryExhaustedSkippedWhenSessionPRIsMerged(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{
+		mergedPRs: map[int]bool{820: true},
+	}
+	st := state.NewState()
+	st.Sessions["pan-56"] = &state.Session{
+		IssueNumber: 768,
+		IssueTitle:  "merged work tagged retry_exhausted",
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    820,
+		StartedAt:   time.Now().UTC().Add(-2 * time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction == ActionReviewRetryExhausted {
+		t.Fatalf("action = %q, must not recommend reviewing a retry-exhausted session whose own PR has merged", decision.RecommendedAction)
+	}
+	if decision.Target != nil && decision.Target.Session == "pan-56" {
+		t.Fatalf("target = %#v, must not target session pan-56 once its PR #820 is merged", decision.Target)
+	}
+}
+
 func TestDecide_RetryExhaustedOpenGreenPRExplainsMergeEligibility(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.ReviewGate = "none"

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -18,25 +18,28 @@ import (
 )
 
 type fakeReader struct {
-	issues         []github.Issue
-	prs            []github.PR
-	openPRIssues   map[int]bool
-	mergedPRIssues map[int]bool
-	closedIssues   map[int]bool
-	mergedPRs      map[int]bool
-	ciStatuses     map[int]string
-	greptileOK     map[int]bool
-	greptilePend   map[int]bool
-	rateLimit      *github.RateLimitStatus
-	rateLimitErr   error
-	rateLimitCalls int
-	issueCalls     int
-	addedLabels    []string
-	removedLabels  []string
-	comments       []string
-	addLabelErr    error
-	removeLabelErr error
-	commentErr     error
+	issues             []github.Issue
+	prs                []github.PR
+	openPRIssues       map[int]bool
+	mergedPRIssues     map[int]bool
+	closedIssues       map[int]bool
+	mergedPRs          map[int]bool
+	ciStatuses         map[int]string
+	greptileOK         map[int]bool
+	greptilePend       map[int]bool
+	rateLimit          *github.RateLimitStatus
+	rateLimitErr       error
+	rateLimitCalls     int
+	issueCalls         int
+	closedIssueCalls   map[int]int
+	mergedPRIssueCalls map[int]int
+	mergedPRCalls      map[int]int
+	addedLabels        []string
+	removedLabels      []string
+	comments           []string
+	addLabelErr        error
+	removeLabelErr     error
+	commentErr         error
 }
 
 type fakeLLM struct {
@@ -69,14 +72,26 @@ func (f *fakeReader) HasOpenPRForIssue(issueNumber int) (bool, error) {
 }
 
 func (f *fakeReader) HasMergedPRForIssue(issueNumber int) (bool, error) {
+	if f.mergedPRIssueCalls == nil {
+		f.mergedPRIssueCalls = map[int]int{}
+	}
+	f.mergedPRIssueCalls[issueNumber]++
 	return f.mergedPRIssues[issueNumber], nil
 }
 
 func (f *fakeReader) IsIssueClosed(number int) (bool, error) {
+	if f.closedIssueCalls == nil {
+		f.closedIssueCalls = map[int]int{}
+	}
+	f.closedIssueCalls[number]++
 	return f.closedIssues[number], nil
 }
 
 func (f *fakeReader) IsPRMerged(prNumber int) (bool, error) {
+	if f.mergedPRCalls == nil {
+		f.mergedPRCalls = map[int]int{}
+	}
+	f.mergedPRCalls[prNumber]++
 	return f.mergedPRs[prNumber], nil
 }
 
@@ -409,6 +424,29 @@ func TestDecide_RetryExhaustedSkippedWhenSessionPRIsMerged(t *testing.T) {
 	}
 }
 
+func TestDecide_RetryExhaustedResolutionCachedPerDecisionCycle(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+	st := state.NewState()
+	st.Sessions["pan-56"] = &state.Session{
+		IssueNumber: 768,
+		IssueTitle:  "stale exhausted work checked in two places",
+		Status:      state.StatusRetryExhausted,
+		StartedAt:   time.Now().UTC().Add(-2 * time.Hour),
+	}
+
+	if _, err := testEngine(cfg, reader).Decide(st); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if got := reader.closedIssueCalls[768]; got > 1 {
+		t.Fatalf("IsIssueClosed(#768) called %d times in one decision cycle; want at most 1", got)
+	}
+	if got := reader.mergedPRIssueCalls[768]; got > 1 {
+		t.Fatalf("HasMergedPRForIssue(#768) called %d times in one decision cycle; want at most 1", got)
+	}
+}
+
 func TestDecide_RetryExhaustedOpenGreenPRExplainsMergeEligibility(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.ReviewGate = "none"
@@ -553,7 +591,8 @@ func TestDetectWorkerStuckStates_SuppressesResolvedReviewFeedback(t *testing.T) 
 			st := state.NewState()
 			st.Sessions["slot-1"] = tt.sess
 
-			findings := testEngine(testConfig(t), tt.reader).detectWorkerStuckStates(st, now)
+			eng := testEngine(testConfig(t), tt.reader)
+			findings := eng.detectWorkerStuckStates(st, now, newResolutionCache(eng.reader))
 
 			for _, stuck := range findings {
 				if stuck.Code == "stale_review_feedback" {


### PR DESCRIPTION
Refs #434

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the supervisor would recommend manual review or report a stuck state for a `retry_exhausted` session whose underlying issue had already been closed or resolved by a merged PR on GitHub. It introduces a `resolutionCache` that memoizes `IsIssueClosed`, `HasMergedPRForIssue`, and `IsPRMerged` lookups so each GitHub API call is issued at most once per decision cycle regardless of how many code paths inspect the same session.

- `retryExhaustedSession` is promoted from a plain function to an engine method and now skips any session whose issue is closed, has a merged winning PR, or whose own PR number is already merged.
- `detectWorkerStuckStates` gains the same guard so the `retry_exhausted` stuck-state entry is suppressed for resolved sessions.
- Four new test cases verify each resolution path and confirm the cache prevents duplicate API calls within a single cycle.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to filtering stale retry-exhausted sessions and adds no new write paths.

The resolution logic is correct in all three cases (closed issue, merged winning PR, merged session PR), error returns from GitHub are handled conservatively by not caching and defaulting to non-resolved, and the cache is threaded consistently through every call site including the dynamic-wave path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Introduces resolutionCache to memoize IsIssueClosed/HasMergedPRForIssue/IsPRMerged per decision cycle; retryExhaustedSession and detectWorkerStuckStates now skip sessions whose underlying issue/PR is already resolved on GitHub. Logic is correct and cache is propagated consistently through all call sites. |
| internal/supervisor/supervisor_test.go | Adds per-call counters to fakeReader and four new test cases covering: issue closed, winning PR merged, session's own PR merged, and cache deduplication within a single decision cycle. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(supervisor): cache resolution lookup..."](https://github.com/befeast/maestro/commit/5c82c25c764ddcff192348ab3cfc92ed90ce3bdf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33468728)</sub>

<!-- /greptile_comment -->