### PR TITLE
fix: display blocked worker history without failure red

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -2128,6 +2128,8 @@ func TestFleetDashboard(t *testing.T) {
 		"isVerificationAttention",
 		"verification-attention",
 		"row-verification",
+		"s-code_landed.attention",
+		"s-blocked",
 		"if (!Array.isArray(data.attention) && Array.isArray(data.workers))",
 		"No projects need attention right now",
 		"renderProjectRail",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -556,6 +556,7 @@ func allSessionInfos(repo string, st *state.State) []sessionInfo {
 		infos = append(infos, makeSessionInfo(repo, slot, sess))
 	}
 	applySupervisorAttention(infos, st.LatestSupervisorDecision())
+	applyProjectStatusDisplay(infos, st)
 	sort.Slice(infos, func(i, j int) bool {
 		left, right := infos[i], infos[j]
 		li := state.StatusPriority(state.SessionStatus(left.Status))
@@ -569,6 +570,35 @@ func allSessionInfos(repo string, st *state.State) []sessionInfo {
 		return left.Slot < right.Slot
 	})
 	return infos
+}
+
+func applyProjectStatusDisplay(infos []sessionInfo, st *state.State) {
+	if st == nil || len(st.ProjectStatusSync) == 0 {
+		return
+	}
+	for i := range infos {
+		record, ok := st.ProjectStatusSync[infos[i].IssueNumber]
+		if !ok || strings.TrimSpace(record.Status) != "blocked" {
+			continue
+		}
+		if !projectBlockedOverridesWorkerStatus(infos[i].Status) {
+			continue
+		}
+		infos[i].DisplayStatus = "blocked"
+		infos[i].NeedsAttention = false
+		infos[i].Live = false
+		infos[i].StatusReason = "Issue is blocked in GitHub Project; this previous worker attempt is not active work."
+		infos[i].NextAction = "Unblock the issue or move it to a runnable project status before starting new work."
+	}
+}
+
+func projectBlockedOverridesWorkerStatus(status string) bool {
+	switch state.SessionStatus(status) {
+	case state.StatusDead, state.StatusFailed, state.StatusConflictFailed, state.StatusRetryExhausted:
+		return true
+	default:
+		return false
+	}
 }
 
 func applySupervisorAttention(infos []sessionInfo, latest *state.SupervisorDecision) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -182,6 +182,56 @@ func TestHandleState(t *testing.T) {
 	}
 }
 
+func TestHandleStateProjectBlockedDisplaysDeadWorkerAsBlocked(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{Repo: "test/repo", MaxParallel: 1, StateDir: dir}
+	now := time.Now().UTC()
+	finished := now.Add(-2 * time.Minute)
+
+	st := state.NewState()
+	st.Sessions["slot-blocked"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "Blocked issue",
+		Status:      state.StatusDead,
+		Backend:     "claude",
+		StartedAt:   now.Add(-5 * time.Minute),
+		FinishedAt:  &finished,
+	}
+	st.MarkProjectStatusSynced(42, "blocked", now)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save test state: %v", err)
+	}
+
+	srv := New(cfg, make(chan struct{}, 1))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.handleState(w, req)
+
+	var resp stateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := resp.Summary["blocked"]; got != 1 {
+		t.Fatalf("blocked summary = %d, want 1; summary=%v", got, resp.Summary)
+	}
+	if got := resp.Summary["dead"]; got != 0 {
+		t.Fatalf("dead summary = %d, want 0; summary=%v", got, resp.Summary)
+	}
+	if len(resp.All) != 1 {
+		t.Fatalf("all sessions = %d, want 1", len(resp.All))
+	}
+	worker := resp.All[0]
+	if worker.Status != string(state.StatusDead) || worker.DisplayStatus != "blocked" {
+		t.Fatalf("status/display = %q/%q, want dead/blocked", worker.Status, worker.DisplayStatus)
+	}
+	if worker.NeedsAttention || worker.Live {
+		t.Fatalf("blocked worker attention/live = %v/%v, want false/false", worker.NeedsAttention, worker.Live)
+	}
+	if !contains(worker.StatusReason, "blocked in GitHub Project") {
+		t.Fatalf("status_reason = %q, want project blocked explanation", worker.StatusReason)
+	}
+}
+
 func TestHandleStateReviewRetryLifecycleDisplay(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{
@@ -1109,8 +1159,8 @@ func TestHandleDashboard(t *testing.T) {
 	if !contains(body, "status-note") {
 		t.Error("dashboard should include status explanation block")
 	}
-	if !contains(body, "isVerificationAttention") || !contains(body, "pill-verification") || !contains(body, "row-verification") {
-		t.Error("dashboard should render code_landed attention as verification-needed instead of failure-red")
+	if !contains(body, "isVerificationAttention") || !contains(body, "pill-verification") || !contains(body, "s-code_landed.pill-attention") || !contains(body, "row-verification") || !contains(body, "s-blocked") {
+		t.Error("dashboard should render code_landed attention as verification-needed and blocked project issues away from failure-red")
 	}
 	if !contains(body, "supervisor-panel") || !contains(body, "renderSupervisor") {
 		t.Error("dashboard should include supervisor rationale panel")

--- a/internal/server/web/static/dashboard.css
+++ b/internal/server/web/static/dashboard.css
@@ -107,6 +107,7 @@
   tbody tr.row-attention { background: var(--bad-bg); }
   tbody tr.row-attention:hover, tbody tr.row-attention.selected { background: var(--bad-bg-strong); }
   tbody tr.row-verification { background: rgba(210,153,34,.08); }
+  tbody tr.row-attention:has(.s-code_landed), tbody tr:has(.s-code_landed.pill-attention) { background: rgba(210,153,34,.08); }
   tbody tr.row-verification:hover, tbody tr.row-verification.selected { background: rgba(210,153,34,.14); }
   a {
     color: var(--accent);
@@ -154,9 +155,10 @@
   .s-review_retry_backoff, .s-review_retry_pending { color: var(--queued); border-color: rgba(163,113,247,.5); }
   .s-review_retry_recheck { color: var(--warn); border-color: rgba(210,153,34,.48); }
   .s-dead, .s-failed, .s-conflict_failed, .s-retry_exhausted { color: var(--bad); border-color: rgba(248,81,73,.5); }
-  .s-code_landed, .pill-verification { color: var(--warn); border-color: rgba(210,153,34,.58); }
+  .s-blocked { color: var(--muted); border-color: rgba(139,148,158,.45); }
   .s-done { color: var(--muted); }
   .pill-attention { color: var(--bad); border-color: rgba(248,81,73,.58); }
+  .s-code_landed, .pill-verification, .s-code_landed.pill-attention { color: var(--warn); border-color: rgba(210,153,34,.58); }
   .log-panel {
     min-width: 0;
     display: grid;

--- a/internal/server/web/static/dashboard.js
+++ b/internal/server/web/static/dashboard.js
@@ -16,11 +16,13 @@ const statusRank = {
   review_retry_pending: 2,
   review_retry_backoff: 2,
   queued: 2,
-  dead: 3,
-  failed: 4,
-  conflict_failed: 5,
-  retry_exhausted: 6,
-  done: 7
+  code_landed: 3,
+  dead: 4,
+  failed: 5,
+  conflict_failed: 6,
+  retry_exhausted: 7,
+  done: 8,
+  blocked: 9
 };
 
 const repoEl = document.getElementById("repo");

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -1127,7 +1127,8 @@
   .s-review_retry_backoff, .s-review_retry_pending { color: var(--queued); border-color: rgba(163,113,247,.5); }
   .s-review_retry_recheck { color: var(--accent); border-color: rgba(88,166,255,.45); }
   .s-dead, .s-failed, .s-conflict_failed, .s-retry_exhausted { color: var(--bad); border-color: rgba(248,81,73,.45); }
-  .s-code_landed, .verification-attention { color: var(--warn); border-color: rgba(210,153,34,.55); }
+  .s-blocked { color: var(--muted); border-color: rgba(139,148,158,.45); }
+  .s-code_landed, .verification-attention, .s-code_landed.attention { color: var(--warn); border-color: rgba(210,153,34,.55); }
   .a-pending { color: var(--warn); border-color: rgba(210,153,34,.55); background: rgba(210,153,34,.08); }
   .a-stale { color: var(--muted); border-color: rgba(139,148,158,.45); background: rgba(139,148,158,.08); }
   .a-superseded { color: var(--muted); border-color: rgba(139,148,158,.45); background: rgba(139,148,158,.08); }

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -60,11 +60,13 @@ const statusOrder = new Map([
   ["review_retry_pending", 2],
   ["review_retry_backoff", 2],
   ["queued", 2],
-  ["dead", 3],
-  ["failed", 4],
-  ["conflict_failed", 5],
-  ["retry_exhausted", 6],
-  ["done", 7]
+  ["code_landed", 3],
+  ["dead", 4],
+  ["failed", 5],
+  ["conflict_failed", 6],
+  ["retry_exhausted", 7],
+  ["done", 8],
+  ["blocked", 9]
 ]);
 
 const fleetState = {


### PR DESCRIPTION
## Summary
- render `code_landed` as verification amber even when an already-open dashboard tab still applies the old attention class
- map dead/failed/retry-exhausted worker attempts to `display_status=blocked` when the linked issue is Blocked in GitHub Project
- stop counting those blocked historical attempts as `dead` in dashboard summary/attention state

## Why
The live dashboards were still showing old Claude limit failures and code-landed verification rows as failure-red. Those rows were not current running work, but the UI made them look like active failures.

## Verification
- `/usr/local/bin/go test ./internal/server ./internal/state ./internal/orchestrator`
- `/usr/local/bin/go test ./...`
- live deployed binary checked through `/api/v1/state` on `:8788` and `:8791`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes false-positive red/failure displays in the live dashboard for two categories of historical worker rows: `code_landed` verification rows and dead/failed workers whose linked issue is marked "Blocked" in a GitHub Project.

- **Server (`server.go`)**: Adds `applyProjectStatusDisplay`, which runs after `applySupervisorAttention` in `allSessionInfos` and re-marks matching dead/failed/retry-exhausted workers as `display_status=\"blocked\"` with `needs_attention=false`, so the summary key, attention inbox, and fleet `NeedsAttention` counter all correctly exclude them.
- **JavaScript & CSS (`dashboard.js`, `fleet.js`, `dashboard.css`, `fleet.css`)**: Adds `blocked` to the status rank/order maps (rank 9, lowest), adds `.s-blocked` as a muted pill style, and adds backward-compatible CSS rules (`:has(.s-code_landed)` selectors) for open browser tabs running old JS that still emit `row-attention`/`pill-attention` for `code_landed` workers.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The server-side classification runs after all existing enrichment passes and only affects terminal-status workers whose issue is explicitly marked blocked; no active workers can be reclassified.

The Go logic is well-scoped and has a focused new test covering summary counts, display_status, needs_attention, and status_reason. The JavaScript rank changes are mirrored consistently across both dashboard and fleet views. The one area deserving a second look is the backward-compat CSS: the `:has()` rules in dashboard.css correct the background color for old-tab `code_landed`+`row-attention` rows, but the `:hover` rule for `row-attention` will still flash the red strong background on those rows because no corresponding hover override was added. This is a very narrow edge case only visible on a cached browser tab before it refreshes and does not affect any data correctness.

dashboard.css — the backward-compat `:has(.s-code_landed)` row rule has no hover counterpart, leaving a residual red hover flash on stale open tabs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/server.go | Adds `applyProjectStatusDisplay` (runs after supervisor attention) to re-classify blocked-issue workers; summary, attention, and fleet counts all flow from `DisplayStatus` correctly. |
| internal/server/server_test.go | New test verifies dead worker with blocked project status is reflected in summary, display_status, needs_attention, and status_reason; existing tests updated for new dashboard assertion strings. |
| internal/server/fleet_test.go | Test assertions extended with new CSS class strings present in the updated static files. |
| internal/server/web/static/dashboard.js | Adds `code_landed` (rank 3) and `blocked` (rank 9) to `statusRank`; `blocked` workers correctly sort to the bottom, and `displayStatus()` is used throughout for class/sort logic. |
| internal/server/web/static/fleet.js | Mirrors dashboard.js rank changes; `isVerificationAttention` and `workerNeedsAttention` already use `needs_attention` field so blocked workers are transparently excluded from the attention inbox. |
| internal/server/web/static/dashboard.css | Adds `.s-blocked` muted style and `:has(.s-code_landed)` backward-compat row rules; specificity is correct but `:has()` hover behavior on old-tab `row-attention` rows remains red, a minor visual edge case. |
| internal/server/web/static/fleet.css | Adds `.s-blocked` muted pill style and `.s-code_landed.attention` amber override for old-tab backward compat; consistent with dashboard.css changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: display blocked worker history with..."](https://github.com/befeast/maestro/commit/c17efecd3eb0c4f25b007409bb17d2b9eb4918a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33490007)</sub>

<!-- /greptile_comment -->