### PR TITLE
fix: advance landed code and repair decisions

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1004,6 +1004,11 @@ func (o *Orchestrator) RunOnce() error {
 	// Step 3: Auto-merge green PRs
 	o.autoMergePRs(s)
 
+	// Step 3b: Reconcile already-landed code with the live outcome gate. This
+	// covers sessions that reached code_landed before the verifier was available
+	// or where the verifier passed on a later cycle.
+	o.reconcileCodeLandedSessions(s)
+
 	// Step 4: Rebase conflicting PRs
 	o.rebaseConflicts(s)
 
@@ -2180,6 +2185,125 @@ func (o *Orchestrator) markDoneAfterOutcomePass(sess *state.Session, prNumber in
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
 	o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
+	o.closeVerifiedIssueIfAllowed(sess, prNumber)
+}
+
+func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
+	if o == nil || o.cfg == nil || s == nil {
+		return
+	}
+
+	codeLanded := make([]*state.Session, 0)
+	for _, slotName := range sortedStateSessionNames(s) {
+		sess := s.Sessions[slotName]
+		if sess != nil && sess.Status == state.StatusCodeLanded {
+			codeLanded = append(codeLanded, sess)
+		}
+	}
+	if len(codeLanded) == 0 {
+		return
+	}
+
+	if o.cfg.Outcome.PassRequiredForDoneEnabled() {
+		if !o.cfg.Outcome.HasHealthSignal() {
+			log.Printf("[orch] %d code_landed session(s) need outcome verification, but no health signal is configured", len(codeLanded))
+			return
+		}
+		result := o.checkOutcome(context.Background())
+		s.OutcomeHealth = &result
+		if result.State != outcome.HealthHealthy {
+			log.Printf("[orch] code_landed reconcile held: outcome verifier is %s: %s", result.State, result.Summary)
+			for _, sess := range codeLanded {
+				o.syncProject(sess.IssueNumber, github.ProjectStatusLiveVerify)
+			}
+			return
+		}
+	}
+
+	for _, sess := range codeLanded {
+		if !o.codeLandedPRMerged(sess) {
+			continue
+		}
+		log.Printf("[orch] code_landed session for issue #%d passed outcome reconciliation; marking done", sess.IssueNumber)
+		o.markDoneAfterOutcomePass(sess, sess.PRNumber)
+	}
+}
+
+func (o *Orchestrator) codeLandedPRMerged(sess *state.Session) bool {
+	if sess == nil {
+		return false
+	}
+	if sess.PRNumber > 0 {
+		merged, err := o.isPRMerged(sess.PRNumber)
+		if err != nil {
+			log.Printf("[orch] code_landed reconcile could not check PR #%d: %v", sess.PRNumber, err)
+			return false
+		}
+		if !merged {
+			log.Printf("[orch] code_landed session for issue #%d records PR #%d, but GitHub does not report it merged", sess.IssueNumber, sess.PRNumber)
+			return false
+		}
+		return true
+	}
+	merged, err := o.hasMergedPRForIssue(sess.IssueNumber)
+	if err != nil {
+		log.Printf("[orch] code_landed reconcile could not check merged PR for issue #%d: %v", sess.IssueNumber, err)
+		return false
+	}
+	return merged
+}
+
+func (o *Orchestrator) closeVerifiedIssueIfAllowed(sess *state.Session, prNumber int) {
+	if o == nil || o.cfg == nil || sess == nil || sess.IssueNumber <= 0 {
+		return
+	}
+	if !o.supervisorActionAllowed(config.SupervisorActionCloseIssue) || o.supervisorActionRequiresApproval(config.SupervisorActionCloseIssue) {
+		return
+	}
+	closed, err := o.isIssueClosed(sess.IssueNumber)
+	if err != nil {
+		log.Printf("[orch] verified issue #%d was not auto-closed because issue state could not be checked: %v", sess.IssueNumber, err)
+		return
+	}
+	if closed {
+		return
+	}
+	comment := "Maestro verified the configured runtime outcome after code landed; closing this issue as done."
+	if prNumber > 0 {
+		comment = fmt.Sprintf("Maestro verified the configured runtime outcome after PR #%d landed; closing this issue as done.", prNumber)
+	}
+	if err := o.closeIssue(sess.IssueNumber, comment); err != nil {
+		log.Printf("[orch] verified issue #%d was not auto-closed: %v", sess.IssueNumber, err)
+		if o.notifier != nil {
+			o.notifier.Sendf("⚠️ maestro: verified issue #%d is done but auto-close failed: %v", sess.IssueNumber, err)
+		}
+		return
+	}
+	if o.notifier != nil {
+		o.notifier.Sendf("✅ maestro: closed verified issue #%d after code_landed outcome pass", sess.IssueNumber)
+	}
+}
+
+func (o *Orchestrator) supervisorActionAllowed(action string) bool {
+	return o != nil && o.cfg != nil && o.cfg.Supervisor.AllowsSafeAction(action)
+}
+
+func (o *Orchestrator) supervisorActionRequiresApproval(action string) bool {
+	if o == nil || o.cfg == nil {
+		return true
+	}
+	action = strings.TrimSpace(action)
+	for _, configured := range o.cfg.Supervisor.ApprovalRequired {
+		if strings.TrimSpace(configured) == action {
+			return true
+		}
+	}
+	for _, configured := range o.cfg.Supervisor.ApprovalRequiredActions {
+		if strings.TrimSpace(configured) == action {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *Orchestrator) canMarkDoneForOutcome(s *state.State, sess *state.Session, trigger string) bool {
@@ -2862,7 +2986,8 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 
 	started := 0
 	for _, issue := range issues {
-		if s.IssueInProgress(issue.Number) {
+		repairSpawn := o.supervisorSelectedRepairSpawn(s, issue.Number)
+		if s.IssueInProgress(issue.Number) && !repairSpawn {
 			continue
 		}
 		if s.IssueDone(issue.Number) {
@@ -2895,7 +3020,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if o.cfg.MaxRetriesPerIssue > 0 {
 			failed := s.FailedAttemptsForIssue(issue.Number)
 			if failed >= o.cfg.MaxRetriesPerIssue {
-				if o.supervisorSelectedRepairSpawn(s, issue.Number) {
+				if repairSpawn {
 					log.Printf("[orch] allowing repair worker for issue #%d despite retry limit because supervisor selected spawn_repair_worker", issue.Number)
 				} else {
 					if !s.IssueRetryExhausted(issue.Number) {
@@ -2938,7 +3063,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if hasOpenPR, err := o.hasOpenPRForIssue(issue.Number); err != nil {
 			log.Printf("[orch] warn: could not check open PRs for issue #%d: %v", issue.Number, err)
 		} else if hasOpenPR {
-			if !o.supervisorSelectedRepairSpawn(s, issue.Number) {
+			if !repairSpawn {
 				log.Printf("[orch] skipping issue #%d: open PR already exists", issue.Number)
 				continue
 			}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -802,6 +802,135 @@ func TestMergeReadyPR_RunsOutcomeVerifierAndMarksDoneOnPass(t *testing.T) {
 	}
 }
 
+func TestReconcileCodeLandedSessionsMarksDoneAfterOutcomePass(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Outcome: outcome.Brief{
+			DesiredOutcome:      "Live app works",
+			VerifierCommand:     "check-live",
+			PassRequiredForDone: boolPtr(true),
+		},
+	}
+	checked := false
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		outcomeCheckFn: func(_ context.Context, _ outcome.Brief) outcome.HealthCheckResult {
+			checked = true
+			return outcome.HealthCheckResult{
+				CheckedAt: time.Now().UTC(),
+				State:     outcome.HealthHealthy,
+				Signal:    "healthcheck_command",
+				Summary:   "live verifier passed",
+			}
+		},
+		isPRMergedFn: func(prNumber int) (bool, error) {
+			return prNumber == 10, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "landed issue",
+		Status:      state.StatusCodeLanded,
+		PRNumber:    10,
+	}
+
+	o.reconcileCodeLandedSessions(s)
+
+	if !checked {
+		t.Fatal("outcome verifier was not run")
+	}
+	if s.OutcomeHealth == nil || s.OutcomeHealth.State != outcome.HealthHealthy {
+		t.Fatalf("OutcomeHealth = %+v, want healthy", s.OutcomeHealth)
+	}
+	if s.Sessions["slot-0"].Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q", s.Sessions["slot-0"].Status, state.StatusDone)
+	}
+}
+
+func TestReconcileCodeLandedSessionsKeepsCodeLandedWhenOutcomeFails(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Outcome: outcome.Brief{
+			DesiredOutcome:      "Live app works",
+			VerifierCommand:     "check-live",
+			PassRequiredForDone: boolPtr(true),
+		},
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		outcomeCheckFn: func(_ context.Context, _ outcome.Brief) outcome.HealthCheckResult {
+			return outcome.HealthCheckResult{
+				CheckedAt: time.Now().UTC(),
+				State:     outcome.HealthFailing,
+				Signal:    "healthcheck_command",
+				Summary:   "live verifier failed",
+			}
+		},
+	}
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "landed issue",
+		Status:      state.StatusCodeLanded,
+		PRNumber:    10,
+	}
+
+	o.reconcileCodeLandedSessions(s)
+
+	if s.Sessions["slot-0"].Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q", s.Sessions["slot-0"].Status, state.StatusCodeLanded)
+	}
+}
+
+func TestReconcileCodeLandedSessionsClosesIssueWhenPolicyAllows(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Supervisor: config.SupervisorConfig{
+			SafeActions: []string{config.SupervisorActionCloseIssue},
+		},
+	}
+	closedIssue := 0
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		isPRMergedFn: func(prNumber int) (bool, error) {
+			return prNumber == 10, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			closedIssue = number
+			if !strings.Contains(comment, "PR #10") {
+				t.Fatalf("close comment = %q, want PR reference", comment)
+			}
+			return nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "landed issue",
+		Status:      state.StatusCodeLanded,
+		PRNumber:    10,
+	}
+
+	o.reconcileCodeLandedSessions(s)
+
+	if s.Sessions["slot-0"].Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q", s.Sessions["slot-0"].Status, state.StatusDone)
+	}
+	if closedIssue != 42 {
+		t.Fatalf("closed issue = %d, want 42", closedIssue)
+	}
+}
+
 func TestMergeReadyPR_KeepsCodeLandedWhenOutcomeVerifierFails(t *testing.T) {
 	cfg := &config.Config{
 		Repo: "owner/repo",
@@ -3053,6 +3182,38 @@ func TestStartNewWorkers_RecordsProjectStatusSyncOnStart(t *testing.T) {
 	}
 	if !s.ProjectStatusSynced(347, string(github.ProjectStatusInProgress)) {
 		t.Fatal("startNewWorkers did not record project status sync")
+	}
+}
+
+func TestStartNewWorkers_SupervisorRepairSpawnBypassesInProgressSession(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	issues := []github.Issue{makeIssue(767, "repair stale PR")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.hasOpenPRForIssueFn = func(issueNumber int) (bool, error) {
+		return issueNumber == 767, nil
+	}
+
+	s := state.NewState()
+	s.Sessions["pan-12"] = &state.Session{
+		IssueNumber: 767,
+		IssueTitle:  "repair stale PR",
+		Status:      state.StatusPROpen,
+		PRNumber:    769,
+		Branch:      "codex/old-pr",
+	}
+	s.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-repair",
+		CreatedAt:         time.Now().UTC(),
+		RecommendedAction: supervisor.ActionSpawnRepairWorker,
+		Risk:              supervisor.RiskMutating,
+		RequiresApproval:  false,
+		Target:            &state.SupervisorTarget{Issue: 767, PR: 769, Session: "pan-12"},
+	}, state.DefaultSupervisorDecisionLimit)
+
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 1 || (*started)[0] != 767 {
+		t.Fatalf("started = %v, want [767] for supervisor-selected repair", *started)
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -212,7 +212,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	cache := newResolutionCache(e.reader)
 	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false, cache)
 
-	if slot, sess, pr, ok := sessionWithOpenPR(st, prs); ok {
+	if slot, sess, pr, ok := e.sessionWithOpenPR(st, prs, cache); ok {
 		if e.openPRNeedsRepair(st, stuckStates, slot, sess, pr) {
 			reasons := appendReasons(baseReasons,
 				fmt.Sprintf("Session %s is associated with open PR #%d, but the PR is not progressing", slot, pr.Number),
@@ -571,7 +571,7 @@ func (e *Engine) decision(st *state.State, now time.Time, ps state.SupervisorPro
 func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.PR, issues, eligible []github.Issue, skipped []string, issuesLoaded bool, cache *resolutionCache) []state.SupervisorStuckState {
 	var findings []state.SupervisorStuckState
 	findings = append(findings, e.detectWorkerStuckStates(st, now, cache)...)
-	findings = append(findings, e.detectPRStuckStates(st, prs)...)
+	findings = append(findings, e.detectPRStuckStates(st, prs, cache)...)
 	if issuesLoaded {
 		findings = append(findings, e.detectQueueStuckStates(st, prs, issues, eligible, skipped)...)
 		findings = append(findings, detectPolicyStuckStates(skipped)...)
@@ -766,7 +766,7 @@ func (e *Engine) staleReviewFeedbackNeedsAttention(sess *state.Session) bool {
 	return true
 }
 
-func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR) []state.SupervisorStuckState {
+func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *resolutionCache) []state.SupervisorStuckState {
 	byNumber := make(map[int]github.PR, len(prs))
 	byBranch := make(map[string]github.PR, len(prs))
 	for _, pr := range prs {
@@ -791,6 +791,9 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR) []state.S
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
 		if sess == nil {
+			continue
+		}
+		if e.sessionResolvedOnGitHub(sess, cache) {
 			continue
 		}
 		pr, found := openPRForSession(sess, byNumber, byBranch)
@@ -1566,6 +1569,32 @@ func sessionWithOpenPR(st *state.State, prs []github.PR) (string, *state.Session
 	return "", nil, github.PR{}, false
 }
 
+func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *resolutionCache) (string, *state.Session, github.PR, bool) {
+	branchToPR := make(map[string]github.PR, len(prs))
+	numberToPR := make(map[int]github.PR, len(prs))
+	for _, pr := range prs {
+		branchToPR[pr.HeadRefName] = pr
+		numberToPR[pr.Number] = pr
+	}
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess == nil || e.sessionResolvedOnGitHub(sess, cache) {
+			continue
+		}
+		if sess.Branch != "" {
+			if pr, ok := branchToPR[sess.Branch]; ok {
+				return slot, sess, pr, true
+			}
+		}
+		if sess.PRNumber > 0 {
+			if pr, ok := numberToPR[sess.PRNumber]; ok {
+				return slot, sess, pr, true
+			}
+		}
+	}
+	return "", nil, github.PR{}, false
+}
+
 func runningSession(st *state.State) (string, *state.Session, bool) {
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
@@ -1644,8 +1673,15 @@ func (e *Engine) retryExhaustedSession(st *state.State, cache *resolutionCache) 
 // ignore the stale retry-exhausted session record instead of recommending
 // review or worker spawning for the already-resolved issue.
 func (e *Engine) retryExhaustedSessionResolvedOnGitHub(sess *state.Session, cache *resolutionCache) bool {
+	return e.sessionResolvedOnGitHub(sess, cache)
+}
+
+func (e *Engine) sessionResolvedOnGitHub(sess *state.Session, cache *resolutionCache) bool {
 	if sess == nil {
 		return false
+	}
+	if cache == nil {
+		cache = newResolutionCache(e.reader)
 	}
 	if sess.PRNumber > 0 && cache.isPRMerged(sess.PRNumber) {
 		return true

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -872,6 +872,35 @@ func TestDecide_FailingOutcomeImmediatelyBlocksFalseGreen(t *testing.T) {
 	}
 }
 
+func TestDecide_IgnoresOpenPRWhenIssueAlreadyClosed(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{
+		prs:          []github.PR{{Number: 769, HeadRefName: "codex/old-pr", IsDraft: true, State: "OPEN"}},
+		closedIssues: map[int]bool{767: true},
+	}
+	st := state.NewState()
+	st.Sessions["pan-12"] = &state.Session{
+		IssueNumber: 767,
+		IssueTitle:  "already closed",
+		Status:      state.StatusPROpen,
+		PRNumber:    769,
+		Branch:      "codex/old-pr",
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionSpawnRepairWorker || decision.RecommendedAction == ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want no open-PR work for closed issue", decision.RecommendedAction)
+	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Target != nil && stuck.Target.Issue == 767 {
+			t.Fatalf("stuck state targets closed issue: %+v", stuck)
+		}
+	}
+}
+
 func TestDecideDeterministic_OutcomeUsesStateMergeHistory(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.Outcome = outcome.Brief{


### PR DESCRIPTION
## Summary
- reconcile stale `code_landed` sessions after the configured runtime outcome is healthy, marking sessions done instead of leaving them as verification limbo
- let supervisor-selected `spawn_repair_worker` decisions bypass stale in-progress/retry/open-PR guards when approval is not required
- stop supervisor from targeting sessions whose linked issue is already closed or has a merged PR

## Why
The fleet could look "handled" while still not doing hands-off development: landed code stayed outside `done`, and repair recommendations could be generated by the supervisor but skipped by the scheduler. That left dashboards full of `blocked`, `retry_exhausted`, or stale `dead` history instead of a real worker/PR/close path.

## Validation
- `/usr/local/bin/go test ./...`
- deployed this build to workshop `/usr/local/bin/maestro` and restarted dogfood/panoptikon/scribe Maestro services
- live dogfood state moved from `code_landed` history to `done: 51`, `code_landed: 0`
- live panoptikon supervisor stopped recommending closed #767/#769 repair work and started a real Codex worker for #808

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two fleet-management gaps: `code_landed` sessions were never advanced to `done` once the runtime outcome gate passed, and supervisor `spawn_repair_worker` decisions were being dropped by scheduler guards that didn't distinguish repair intent from normal in-progress/retry/open-PR states.

- **Orchestrator**: adds `reconcileCodeLandedSessions` (called in `RunOnce` step 3b) to sweep stale `code_landed` sessions, run the outcome verifier if configured, and call `markDoneAfterOutcomePass` for sessions whose PR is confirmed merged; adds `closeVerifiedIssueIfAllowed` (now part of the `markDoneAfterOutcomePass` flow) to auto-close the linked GitHub issue when the policy permits; hoists the `supervisorSelectedRepairSpawn` check before all three bypass-able guards in `startNewWorkers`.
- **Supervisor**: promotes `retryExhaustedSessionResolvedOnGitHub` to a general `sessionResolvedOnGitHub` helper; threads a shared `resolutionCache` into `detectPRStuckStates` and the new `e.sessionWithOpenPR` method so closed-issue and merged-PR sessions are filtered before any open-PR repair recommendation is generated.
- Both changed packages include new targeted tests covering the happy path, outcome-fail hold, close-issue policy, and repair-spawn bypass.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the logic is well-guarded and the new code paths are directly tested. The one leftover is an unused package-level function that should be deleted.

The orchestrator and supervisor changes are tightly scoped, the new reconciliation path correctly gates on both PR-merge state and outcome health before advancing sessions, and the repair-spawn bypass is properly conditioned on a non-approval-gated supervisor decision. The only leftover is the old standalone sessionWithOpenPR function in supervisor.go, which is now unreachable and diverges from the new method version by lacking the sessionResolvedOnGitHub skip — a cleanup item rather than a correctness problem.

internal/supervisor/supervisor.go — the old sessionWithOpenPR standalone function at line 1546 is dead code and should be removed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds reconcileCodeLandedSessions to advance stale code_landed sessions to done; adds closeVerifiedIssueIfAllowed called from the existing markDoneAfterOutcomePass path; refactors repairSpawn guard to hoist the supervisorSelectedRepairSpawn check before all three bypass-able guards (in-progress, retry-limit, open-PR). |
| internal/orchestrator/orchestrator_test.go | Adds three tests for reconcileCodeLandedSessions (outcome pass, outcome fail, close-issue policy) and one test for repair-spawn bypassing an in-progress/open-PR session; all paths appear well covered. |
| internal/supervisor/supervisor.go | Promotes sessionResolvedOnGitHub to a shared helper; threads a resolutionCache into detectPRStuckStates and the new e.sessionWithOpenPR method so both filter out already-resolved sessions; old standalone sessionWithOpenPR at line 1546 is now dead code. |
| internal/supervisor/supervisor_test.go | Adds TestDecide_IgnoresOpenPRWhenIssueAlreadyClosed to verify the supervisor skips closed-issue sessions; straightforward and looks correct. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/supervisor/supervisor.go`, line 1546-1570 ([link](https://github.com/befeast/maestro/blob/9427486775fa02b54d503e71f841a1f0ec4de60f/internal/supervisor/supervisor.go#L1546-L1570)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead code: standalone `sessionWithOpenPR` is now unreachable**

   The old package-level `sessionWithOpenPR` function is no longer called anywhere. The call site at line 215 was updated to use the new `e.sessionWithOpenPR` method, but the original function was not removed. It will silently diverge from the method version over time (e.g., it still lacks the `sessionResolvedOnGitHub` skip) and could cause confusion about which implementation is canonical.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/supervisor/supervisor.go
   Line: 1546-1570

   Comment:
   **Dead code: standalone `sessionWithOpenPR` is now unreachable**

   The old package-level `sessionWithOpenPR` function is no longer called anywhere. The call site at line 215 was updated to use the new `e.sessionWithOpenPR` method, but the original function was not removed. It will silently diverge from the method version over time (e.g., it still lacks the `sessionResolvedOnGitHub` skip) and could cause confusion about which implementation is canonical.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/supervisor.go:1546-1570
**Dead code: standalone `sessionWithOpenPR` is now unreachable**

The old package-level `sessionWithOpenPR` function is no longer called anywhere. The call site at line 215 was updated to use the new `e.sessionWithOpenPR` method, but the original function was not removed. It will silently diverge from the method version over time (e.g., it still lacks the `sessionResolvedOnGitHub` skip) and could cause confusion about which implementation is canonical.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: advance landed code and repair deci..."](https://github.com/befeast/maestro/commit/9427486775fa02b54d503e71f841a1f0ec4de60f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33496697)</sub>

<!-- /greptile_comment -->