### PR TITLE
fix: unblock retry-exhausted repair selection

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -256,7 +256,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		return decision, nil
 	}
 
-	if !e.cfg.Supervisor.OrderedQueueActive() {
+	if !e.cfg.Supervisor.OrderedQueueActive() && !e.cfg.Supervisor.DynamicWave.Active() {
 		if slot, sess, ok := e.retryExhaustedSession(st, cache); ok {
 			reasons := appendReasons(baseReasons,
 				fmt.Sprintf("Session %s for issue #%d is retry_exhausted", slot, sess.IssueNumber),
@@ -288,6 +288,22 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		return state.SupervisorDecision{}, fmt.Errorf("list open issues: %w", err)
 	}
 	projectState.OpenIssues = len(issues)
+
+	if slot, sess, issue, ok, err := e.retryExhaustedRepairCandidate(st, issues, cache); err != nil {
+		return state.SupervisorDecision{}, err
+	} else if ok {
+		reasons := appendReasons(baseReasons,
+			fmt.Sprintf("Session %s for issue #%d is retry_exhausted with no usable PR", slot, sess.IssueNumber),
+			"Ready-labeled issue is still open and has no dependency/blocking label reason",
+			"Retry exhaustion may have moved the project item to Blocked, but supervisor can start one intentional repair worker instead of dead-ending the queue",
+			"Starting a repair worker would mutate local worktrees, so supervisor records an explicit repair recommendation",
+		)
+		decision := e.decision(st, now, projectState, ActionSpawnRepairWorker,
+			fmt.Sprintf("Start a repair worker for retry-exhausted issue #%d: %s", issue.Number, issue.Title),
+			RiskMutating, 0.88, &state.SupervisorTarget{Issue: issue.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
+		decision.StuckStates = stuckStates
+		return decision, nil
+	}
 
 	policyResult, err := e.policyCandidateIssues(st, issues)
 	if err != nil {
@@ -1484,6 +1500,45 @@ func (e *Engine) issueQueueSkipReason(st *state.State, issue github.Issue, block
 	return e.issueSkipReasonWithExcludeLabels(st, issue, excludeLabelsExcept(e.excludeLabels(), blockedLabel), blockedLabel)
 }
 
+func (e *Engine) issueRepairSkipReason(st *state.State, issue github.Issue) (string, error) {
+	if st.IssueInProgress(issue.Number) {
+		return "already in progress", nil
+	}
+	if st.IssueDone(issue.Number) {
+		return "already completed in state", nil
+	}
+	if st.IsMissionParent(issue.Number) {
+		return heldMetaSkipReason("mission parent issue"), nil
+	}
+	if e.cfg.Missions.Enabled && mission.IsMissionIssue(issue, e.cfg.Missions.Labels) && !st.IsMissionChild(issue.Number) {
+		return heldMetaSkipReason("mission issue awaits decomposition"), nil
+	}
+	policyExcludedLabels := e.policyExcludedLabels()
+	if label, ok := firstMatchingIssueLabel(issue, heldMetaLabels()); ok && (hasLabelName(e.excludeLabels(), label) || hasLabelName(policyExcludedLabels, label)) {
+		return heldMetaSkipReason(fmt.Sprintf("label %q", label)), nil
+	}
+	if _, ok := firstMatchingIssueLabel(issue, e.excludeLabels()); ok {
+		return "excluded by configured label", nil
+	}
+	if blockedLabel := strings.TrimSpace(e.cfg.Supervisor.BlockedLabel); blockedLabel != "" && github.HasLabel(issue, []string{blockedLabel}) {
+		return "blocked by supervisor policy label", nil
+	}
+	if _, ok := firstMatchingIssueLabel(issue, policyExcludedLabels); ok {
+		return "excluded by supervisor policy label", nil
+	}
+	if len(e.cfg.BlockerPatterns) > 0 {
+		blockers := github.FindBlockers(issue.Body, e.cfg.BlockerPatterns)
+		openBlockers, err := e.openBlockers(blockers)
+		if err != nil {
+			return "", err
+		}
+		if len(openBlockers) > 0 {
+			return blockedByDependencySkipReason(openBlockers), nil
+		}
+	}
+	return "", nil
+}
+
 func (e *Engine) issueSkipReasonWithExcludeLabels(st *state.State, issue github.Issue, excludeLabels []string, ignoredBlockedLabel string) (string, error) {
 	if st.IssueInProgress(issue.Number) {
 		return "already in progress", nil
@@ -1666,6 +1721,41 @@ func (e *Engine) retryExhaustedSession(st *state.State, cache *resolutionCache) 
 		return slot, sess, true
 	}
 	return "", nil, false
+}
+
+func (e *Engine) retryExhaustedRepairCandidate(st *state.State, issues []github.Issue, cache *resolutionCache) (string, *state.Session, github.Issue, bool, error) {
+	if availableSlots(e.cfg, st) <= 0 {
+		return "", nil, github.Issue{}, false, nil
+	}
+	issueByNumber := make(map[int]github.Issue, len(issues))
+	for _, issue := range issues {
+		issueByNumber[issue.Number] = issue
+	}
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess == nil || sess.Status != state.StatusRetryExhausted || sess.PRNumber > 0 {
+			continue
+		}
+		if e.hasLiveRunningSessionForIssue(st, sess.IssueNumber) || e.retryExhaustedSessionResolvedOnGitHub(sess, cache) {
+			continue
+		}
+		issue, ok := issueByNumber[sess.IssueNumber]
+		if !ok || !matchesRequiredLabels(issue, e.requiredIssueLabels()) {
+			continue
+		}
+		if hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number); err != nil {
+			return "", nil, github.Issue{}, false, fmt.Errorf("check open PR for issue #%d: %w", issue.Number, err)
+		} else if hasOpenPR {
+			continue
+		}
+		if reason, err := e.issueRepairSkipReason(st, issue); err != nil {
+			return "", nil, github.Issue{}, false, err
+		} else if reason != "" {
+			continue
+		}
+		return slot, sess, issue, true, nil
+	}
+	return "", nil, github.Issue{}, false, nil
 }
 
 // retryExhaustedSessionResolvedOnGitHub returns true when the underlying issue

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -721,6 +721,41 @@ func TestDecide_DeadSessionWithDraftFailingPRRecommendsRepairWorker(t *testing.T
 	}
 }
 
+func TestDecide_RetryExhaustedReadyIssueSpawnsRepairWorkerEvenWhenProjectBlocked(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
+	reader := &fakeReader{issues: []github.Issue{
+		withProjectStatus(testIssue(808, "duplicate settings entry", "maestro-ready"), "Blocked"),
+	}}
+	st := state.NewState()
+	st.Sessions["pan-72"] = &state.Session{
+		IssueNumber: 808,
+		IssueTitle:  "duplicate settings entry",
+		Status:      state.StatusRetryExhausted,
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnRepairWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnRepairWorker)
+	}
+	if decision.RequiresApproval {
+		t.Fatalf("RequiresApproval = true, want false for policy-allowed repair spawn")
+	}
+	if decision.Target == nil || decision.Target.Issue != 808 || decision.Target.Session != "pan-72" {
+		t.Fatalf("target = %#v, want issue 808 pan-72", decision.Target)
+	}
+	rationale := strings.Join(decision.Reasons, "\n")
+	if !strings.Contains(rationale, "retry_exhausted") || !strings.Contains(rationale, "Blocked") {
+		t.Fatalf("reasons = %q, want retry_exhausted and Blocked rationale", rationale)
+	}
+}
+
 func TestDecide_PRExistsForSessionMonitorsPR(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{prs: []github.PR{{Number: 12, HeadRefName: "mae-1-42-fix", State: "OPEN"}}}


### PR DESCRIPTION
## Summary
- allow dynamic-wave supervisor mode to select one `spawn_repair_worker` for retry-exhausted ready issues
- bypass ProjectV2 `Blocked` dead-ends when the issue is still open, ready-labeled, has no open PR, and has no blocking label/dependency reason
- keep traditional read-only/manual `review_retry_exhausted` behavior for non-dynamic supervisor mode

## Why
Retry exhaustion could move an issue into Project `Blocked`; dynamic-wave supervision then treated that same issue as non-runnable and returned no action. That created a closed loop where Maestro itself prevented hands-off repair.

## Validation
- `/usr/local/bin/go test ./internal/supervisor`
- `/usr/local/bin/go test ./...`
- added regression coverage for a retry-exhausted, ready-labeled issue whose project item is `Blocked`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a closed loop in dynamic-wave supervision where retry-exhausted issues that land in a `Blocked` project status were dead-ended: the dynamic wave would skip them (via `nonRunnableProjectStatus`), and the existing `retryExhaustedSession` path was already gated out for dynamic-wave mode, so no action was ever taken.

- Adds `retryExhaustedRepairCandidate`, which checks for retry-exhausted sessions with no associated PR, verifies the issue still meets label and dependency requirements, and returns `ActionSpawnRepairWorker` while intentionally bypassing the project-status check.
- Adjusts the `retryExhaustedSession` guard so it only fires in traditional (non-ordered-queue, non-dynamic-wave) mode, preserving the manual-review path there.
- The new repair candidate call is placed unconditionally after `ListOpenIssues`, meaning it also activates in ordered-queue-only mode (no dynamic wave), which is outside the stated scope and can preempt the next ordered-queue item in a supervisor cycle.

<h3>Confidence Score: 3/5</h3>

The dynamic-wave repair path works as described, but the unconditional placement of retryExhaustedRepairCandidate also changes behavior in ordered-queue-only mode, where it can preempt normal queue processing unexpectedly.

The fix correctly unblocks dynamic-wave retry exhaustion, but the retryExhaustedRepairCandidate call sits outside any DynamicWave.Active() guard. In ordered-queue-only mode a retry-exhausted eligible issue will now claim an available slot before the ordered queue is consulted, silently changing scheduling behavior in a mode the PR does not mention and for which there is no test coverage.

internal/supervisor/supervisor.go — specifically the placement of the retryExhaustedRepairCandidate call relative to the mode guards

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Core logic change: adds retryExhaustedRepairCandidate path that bypasses Blocked project status for retry-exhausted issues; the path is unconditional (not guarded by DynamicWave.Active()), meaning it silently activates in ordered-queue-only mode too |
| internal/supervisor/supervisor_test.go | Adds one regression test covering the intended dynamic-wave + Blocked project status scenario; no coverage for ordered-queue-only mode behavior change |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/supervisor.go:292-306
**Repair candidate path fires in ordered-queue-only mode**

`retryExhaustedRepairCandidate` is called unconditionally — it has no `DynamicWave.Active()` guard — but the PR description scopes this change to "dynamic-wave supervisor mode." In `ordered_queue`-only mode (dynamic wave disabled), the previous code intentionally skipped `retryExhaustedSession` and left retry-exhausted sessions unhandled. Now, if a slot is available and a retry-exhausted issue passes the repair eligibility checks, the supervisor returns `ActionSpawnRepairWorker` before ever calling `policyCandidateIssues`, preempting the next ordered-queue item in that cycle. If the guard change was only meant for dynamic wave, wrapping this block with `if e.cfg.Supervisor.DynamicWave.Active()` would match the stated intent.

```suggestion
	if e.cfg.Supervisor.DynamicWave.Active() {
		if slot, sess, issue, ok, err := e.retryExhaustedRepairCandidate(st, issues, cache); err != nil {
			return state.SupervisorDecision{}, err
		} else if ok {
			reasons := appendReasons(baseReasons,
				fmt.Sprintf("Session %s for issue #%d is retry_exhausted with no usable PR", slot, sess.IssueNumber),
				"Ready-labeled issue is still open and has no dependency/blocking label reason",
				"Retry exhaustion may have moved the project item to Blocked, but supervisor can start one intentional repair worker instead of dead-ending the queue",
				"Starting a repair worker would mutate local worktrees, so supervisor records an explicit repair recommendation",
			)
			decision := e.decision(st, now, projectState, ActionSpawnRepairWorker,
				fmt.Sprintf("Start a repair worker for retry-exhausted issue #%d: %s", issue.Number, issue.Title),
				RiskMutating, 0.88, &state.SupervisorTarget{Issue: issue.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
			decision.StuckStates = stuckStates
			return decision, nil
		}
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: unblock retry-exhausted repair sele..."](https://github.com/befeast/maestro/commit/7e4616b54449d502032c2df669d79b3632a87144) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33498042)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->