### PR TITLE
fix: avoid duplicate repair workers

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2877,6 +2877,21 @@ func (o *Orchestrator) supervisorSelectedRepairSpawn(s *state.State, issueNumber
 	return true
 }
 
+func (o *Orchestrator) issueHasLiveRunningSession(s *state.State, issueNumber int) bool {
+	if s == nil || issueNumber <= 0 {
+		return false
+	}
+	for _, sess := range s.Sessions {
+		if sess == nil || sess.IssueNumber != issueNumber || sess.Status != state.StatusRunning {
+			continue
+		}
+		if sess.PID <= 0 || o.pidAlive(sess.PID) {
+			return true
+		}
+	}
+	return false
+}
+
 func (o *Orchestrator) supervisorOwnedReadySelectedIssue(s *state.State) (int, bool) {
 	if !o.supervisorOwnsDynamicReadyLabel() || s == nil {
 		return 0, false
@@ -2987,8 +3002,14 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 	started := 0
 	for _, issue := range issues {
 		repairSpawn := o.supervisorSelectedRepairSpawn(s, issue.Number)
-		if s.IssueInProgress(issue.Number) && !repairSpawn {
-			continue
+		if s.IssueInProgress(issue.Number) {
+			if !repairSpawn {
+				continue
+			}
+			if o.issueHasLiveRunningSession(s, issue.Number) {
+				log.Printf("[orch] skipping issue #%d: supervisor selected repair, but a worker is already running for this issue", issue.Number)
+				continue
+			}
 		}
 		if s.IssueDone(issue.Number) {
 			closed, err := o.isIssueClosed(issue.Number)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3217,6 +3217,40 @@ func TestStartNewWorkers_SupervisorRepairSpawnBypassesInProgressSession(t *testi
 	}
 }
 
+func TestStartNewWorkers_SupervisorRepairSpawnDoesNotDuplicateRunningWorker(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	issues := []github.Issue{makeIssue(808, "repair retry exhausted")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.pidAliveFn = func(pid int) bool { return pid == 5555 }
+
+	s := state.NewState()
+	s.Sessions["pan-74"] = &state.Session{
+		IssueNumber: 808,
+		IssueTitle:  "repair retry exhausted",
+		Status:      state.StatusRunning,
+		PID:         5555,
+	}
+	s.Sessions["pan-72"] = &state.Session{
+		IssueNumber: 808,
+		IssueTitle:  "repair retry exhausted",
+		Status:      state.StatusRetryExhausted,
+	}
+	s.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-repair",
+		CreatedAt:         time.Now().UTC(),
+		RecommendedAction: supervisor.ActionSpawnRepairWorker,
+		Risk:              supervisor.RiskMutating,
+		RequiresApproval:  false,
+		Target:            &state.SupervisorTarget{Issue: 808, Session: "pan-72"},
+	}, state.DefaultSupervisorDecisionLimit)
+
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 0 {
+		t.Fatalf("started = %v, want no duplicate worker while pan-74 is running", *started)
+	}
+}
+
 func TestStartNewWorkers_SupervisorOwnedReadyLabelStartsOnlySelectedCandidate(t *testing.T) {
 	cfg := cfgWithBackends("claude", "claude")
 	cfg.IssueLabels = []string{"maestro-ready"}


### PR DESCRIPTION
## Summary
- prevent supervisor repair-spawn from starting a second worker when the same issue already has a live running worker
- keep the existing ability to spawn a repair worker for stalled PR/open-review states when no worker is active
- add regression coverage for the duplicate `pan-74`/`pan-75` style failure

## Why
The repair-spawn bypass was too broad: it bypassed `IssueInProgress` for all repair decisions, including cases where a repair worker was already running. That could create duplicate workers for the same issue instead of hands-off convergence.

## Validation
- `/usr/local/bin/go test ./internal/orchestrator`
- `/usr/local/bin/go test ./...`
- live duplicate `pan-76` was stopped, leaving a single running `pan-74` for #808

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the repair-spawn bypass in `startNewWorkers` so that a supervisor repair decision is allowed to proceed only when no live worker is already running for the affected issue — preventing the duplicate `pan-74`/`pan-75` style workers described in the PR.

- Adds `issueHasLiveRunningSession`, which walks `s.Sessions` for any `StatusRunning` entry with a live (or PID-unknown) process for the given issue number, and gates the new repair-spawn path on its result.
- Refactors the in-progress branch in `startNewWorkers` into a nested `if` block that first allows repair bypass, then short-circuits if a live worker is already present.
- Adds `TestStartNewWorkers_SupervisorRepairSpawnDoesNotDuplicateRunningWorker` to cover the exact regression scenario with a live PID check.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, well-tested guard that only fires when a supervisor repair decision is active and a StatusRunning worker already exists for the same issue.

The new `issueHasLiveRunningSession` helper is straightforward: it conservatively returns `true` for sessions with a missing PID (avoiding spurious repair spawns) and correctly falls through only when a confirmed-dead PID is present. The existing `TestStartNewWorkers_SupervisorRepairSpawnBypassesInProgressSession` test is preserved and continues to verify that stalled PR-open states still get repair workers, while the new test directly exercises the duplicate-prevention path with a live PID check. No pre-existing behaviour outside the targeted duplicate scenario is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds `issueHasLiveRunningSession` helper and adjusts `startNewWorkers` guard; logic is correct and conservative for the PID-unknown case. |
| internal/orchestrator/orchestrator_test.go | Adds regression test covering the duplicate-worker scenario with a live PID; existing bypass test is preserved and still passes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid duplicate repair workers"](https://github.com/befeast/maestro/commit/0e3d5381412dbc1d29c1d7adee901f8ecdb84e72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33500024)</sub>

<!-- /greptile_comment -->