### PR TITLE
fix: reconcile terminal sessions with opened PRs

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1412,6 +1412,19 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 	for slotName, sess := range s.Sessions {
 		switch sess.Status {
 		case state.StatusDone, state.StatusCodeLanded, state.StatusDead, state.StatusConflictFailed, state.StatusFailed, state.StatusRetryExhausted:
+			if sess.Status != state.StatusDone && sess.Status != state.StatusCodeLanded && prErr == nil {
+				if pr, found := branchToPR[sess.Branch]; found {
+					log.Printf("[orch] session %s %s->pr_open (PR #%d now open for branch %q)", slotName, sess.Status, pr.Number, sess.Branch)
+					sess.Status = state.StatusPROpen
+					sess.PRNumber = pr.Number
+					sess.PID = 0
+					sess.TmuxSession = ""
+					now := time.Now().UTC()
+					sess.FinishedAt = &now
+					o.syncProject(sess.IssueNumber, github.ProjectStatusInReview)
+					continue
+				}
+			}
 			// Zombie cleanup: if the underlying issue is closed, transition to done.
 			// This prevents conflict_failed/failed/dead/retry_exhausted sessions from lingering
 			// indefinitely when their issues are closed externally (#187).

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1941,6 +1941,50 @@ func newCheckSessionsOrchestrator(cfg *config.Config, tmuxOutput string) (*Orche
 	}, &stopped
 }
 
+func TestCheckSessions_TerminalSessionWithOpenBranchPRTransitionsToPROpen(t *testing.T) {
+	cfg := &config.Config{Repo: "owner/repo", MaxRuntimeMinutes: 999}
+	cfg.GitHubProjects.Enabled = true
+	cfg.GitHubProjects.ProjectNumber = 4
+	synced := make([]string, 0)
+	o, _ := newCheckSessionsOrchestrator(cfg, "")
+	o.listOpenPRsFn = func() ([]github.PR, error) {
+		return []github.PR{{
+			Number:      832,
+			HeadRefName: "feat/pan-74-808-remove-or-justify-duplicate-settings-ent",
+			State:       "OPEN",
+		}}, nil
+	}
+	o.rateLimitFn = func() (github.RateLimitStatus, error) {
+		return github.RateLimitStatus{GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000}}, nil
+	}
+	o.syncProjectFn = func(issueNumber int, status github.ProjectStatus) bool {
+		synced = append(synced, fmt.Sprintf("#%d:%s", issueNumber, status))
+		return true
+	}
+
+	s := state.NewState()
+	s.Sessions["pan-74"] = &state.Session{
+		IssueNumber: 808,
+		IssueTitle:  "dedupe settings",
+		Status:      state.StatusDead,
+		Branch:      "feat/pan-74-808-remove-or-justify-duplicate-settings-ent",
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["pan-74"]
+	if sess.Status != state.StatusPROpen {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusPROpen)
+	}
+	if sess.PRNumber != 832 {
+		t.Fatalf("PRNumber = %d, want 832", sess.PRNumber)
+	}
+	if len(synced) != 1 || synced[0] != "#808:in_review" {
+		t.Fatalf("synced = %v, want #808:in_review", synced)
+	}
+}
+
 func TestCheckSessions_TokenLimitExceeded_KillsWorker(t *testing.T) {
 	cfg := &config.Config{
 		Repo:              "owner/repo",


### PR DESCRIPTION
## Summary
- reconcile terminal sessions (`dead`/`failed`/`retry_exhausted`) back to `pr_open` when their branch now has an open PR
- sync the linked issue to Project `In Review` in that recovery path
- add regression coverage for the `pan-74` -> PR #832 handoff shape

## Why
Workers can finish or be marked dead before the PR handoff is visible to Maestro. Running-session rescue already handled this, but terminal sessions stayed blocked even after a PR existed for the branch. That made harvested work look dead instead of reviewable.

## Validation
- `/usr/local/bin/go test ./internal/orchestrator`
- `/usr/local/bin/go test ./...`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a gap in the session reconciliation loop: terminal sessions (`dead`, `failed`, `retry_exhausted`) that have a corresponding open PR on their branch are now promoted to `pr_open` and synced to the Project "In Review" column, matching the behaviour already present for running sessions.

- **`orchestrator.go`**: Adds an early-exit block at the top of the terminal-status switch case that checks the pre-fetched `branchToPR` map and, when a match is found, transitions the session to `pr_open`, clears PID/tmux fields, stamps `FinishedAt`, and calls `syncProject(InReview)`.
- **`orchestrator_test.go`**: Adds `TestCheckSessions_TerminalSessionWithOpenBranchPRTransitionsToPROpen` covering the pan-74 \u2192 PR #832 shape, asserting the status change, PR number assignment, and project sync call.

<h3>Confidence Score: 4/5</h3>

The change is narrow and well-tested; the only gaps are a missing operator notification on recovery and a theoretical empty-branch match, neither of which affects correctness of the state machine.

The recovery logic is a small, self-contained addition inside an existing switch case, uses the already-fetched branchToPR map, and is guarded by prErr == nil. The continue correctly skips zombie cleanup and worktree teardown for the newly-recovered session. The test covers the primary scenario. Two minor observations: the running-session death path sends a notifier message on PR recovery but this terminal-session recovery path does not, leaving operators without a signal; and an unguarded empty sess.Branch lookup could theoretically match a PR with an empty HeadRefName.

orchestrator.go — specifically the new recovery block and the absence of a notifier call.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds a recovery block inside the terminal-state switch case that transitions dead/failed/retry_exhausted sessions to pr_open when their branch has an open PR; logic is sound but a notification call is absent compared to the analogous running-session path. |
| internal/orchestrator/orchestrator_test.go | Adds a regression test covering the dead-session → pr_open transition for the pan-74/PR #832 shape; covers status, PRNumber, and syncProject assertions. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:1415-1426
**Missing user notification on terminal-session recovery**

The analogous running-session recovery path (when a live worker's process dies but a PR is already open) sends a notifier message so users know the work is reviewable. This new terminal-session recovery silently promotes the session to `pr_open` without any such notification. If the session had been dead for a while, there is no signal to the operator that the branch was reconciled — they would only discover it by observing state directly.

### Issue 2 of 2
internal/orchestrator/orchestrator.go:1415-1416
If `sess.Branch` is an empty string (e.g. a session that was never fully initialised), `branchToPR[""]` will match any PR whose `HeadRefName` is also empty, causing an incorrect recovery. A cheap guard prevents a spurious transition.

```suggestion
			if sess.Status != state.StatusDone && sess.Status != state.StatusCodeLanded && prErr == nil && sess.Branch != "" {
				if pr, found := branchToPR[sess.Branch]; found {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reconcile terminal sessions with op..."](https://github.com/befeast/maestro/commit/07470a4f629bb0ac2d6669a3814e5df530f1705d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33501612)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->