### PR TITLE
fix(router): honor backend command prefix args when routing

### DIFF
--- a/internal/router/resolve_test.go
+++ b/internal/router/resolve_test.go
@@ -2,6 +2,9 @@ package router
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/befeast/maestro/internal/config"
@@ -289,6 +292,126 @@ func TestResolveBackend_AutoRoutingViaRouteFn(t *testing.T) {
 	if reason != "simple fix" {
 		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "simple fix")
 	}
+}
+
+func TestRoute_UsesBackendCommandPrefixArgs(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	cliPath := filepath.Join(dir, "router-cli")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + shellQuote(argsPath) + "\nprintf '{\"backend\":\"gemini\",\"reason\":\"docs task\"}'\n"
+	if err := os.WriteFile(cliPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake router cli: %v", err)
+	}
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: cliPath + " --temperature 0"},
+				"gemini": {Cmd: "gemini"},
+			},
+		},
+		Routing: config.RoutingConfig{
+			Mode:            "auto",
+			RouterModel:     "claude",
+			RouterModelName: "router-model",
+		},
+	}
+
+	name, reason, err := New(cfg).Route(github.Issue{Number: 47, Title: "Update docs", Body: "Small docs cleanup"})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if name != "gemini" || reason != "docs task" {
+		t.Fatalf("Route() = (%q, %q), want (gemini, docs task)", name, reason)
+	}
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(argsData)), "\n")
+	want := []string{"--temperature", "0", "-p"}
+	if len(args) < len(want) {
+		t.Fatalf("args = %v, want prefix %v", args, want)
+	}
+	for i, arg := range want {
+		if args[i] != arg {
+			t.Fatalf("args[%d] = %q, want %q; all args=%v", i, args[i], arg, args)
+		}
+	}
+	if !containsArgPair(args, "--model", "router-model") {
+		t.Fatalf("args = %v, want router model argument", args)
+	}
+}
+
+func TestRoute_DoesNotAppendRouterModelWhenCommandPinsModel(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	cliPath := filepath.Join(dir, "router-cli")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + shellQuote(argsPath) + "\nprintf '{\"backend\":\"codex\",\"reason\":\"implementation\"}'\n"
+	if err := os.WriteFile(cliPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake router cli: %v", err)
+	}
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: cliPath + " --model pinned-router --effort high"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+		Routing: config.RoutingConfig{
+			Mode:            "auto",
+			RouterModel:     "claude",
+			RouterModelName: "default-router-model",
+		},
+	}
+
+	if _, _, err := New(cfg).Route(github.Issue{Number: 48, Title: "Implement feature"}); err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(argsData)), "\n")
+	if countArg(args, "--model") != 1 {
+		t.Fatalf("args = %v, want exactly one --model from backend command", args)
+	}
+	if containsArg(args, "default-router-model") {
+		t.Fatalf("args = %v, router_model_name should not be appended when cmd pins --model", args)
+	}
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArgPair(args []string, key string, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == key && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func countArg(args []string, want string) int {
+	count := 0
+	for _, arg := range args {
+		if arg == want {
+			count++
+		}
+	}
+	return count
 }
 
 // --- ResolveBackendForRole tests ---

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -95,23 +95,45 @@ func (r *Router) callModel(prompt string) (string, error) {
 		return "", fmt.Errorf("router backend %q not found in model.backends", backendName)
 	}
 
-	cmdPath := backend.Cmd
-	if cmdPath == "" {
-		cmdPath = backendName
+	cmdSpec := strings.TrimSpace(backend.Cmd)
+	if cmdSpec == "" {
+		cmdSpec = backendName
 	}
 
-	args := []string{"-p", prompt}
-	if r.cfg.Routing.RouterModelName != "" {
+	cmdPath, args := splitRouterCmd(cmdSpec)
+	if cmdPath == "" {
+		return "", fmt.Errorf("router backend %q has empty command", backendName)
+	}
+	args = append(args, backend.ExtraArgs...)
+	args = append(args, "-p", prompt)
+	if r.cfg.Routing.RouterModelName != "" && !hasModelArg(args) {
 		args = append(args, "--model", r.cfg.Routing.RouterModelName)
 	}
 
-	log.Printf("[router] calling %s --model %s", cmdPath, r.cfg.Routing.RouterModelName)
-	out, err := exec.Command(cmdPath, args...).Output()
+	log.Printf("[router] calling %s for backend %s", cmdPath, backendName)
+	out, err := exec.Command(cmdPath, args...).CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("exec %s: %w", cmdPath, err)
+		return "", fmt.Errorf("exec %s: %w\n%s", cmdPath, err, out)
 	}
 
 	return strings.TrimSpace(string(out)), nil
+}
+
+func splitRouterCmd(cmd string) (binary string, prefixArgs []string) {
+	parts := strings.Fields(cmd)
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return parts[0], parts[1:]
+}
+
+func hasModelArg(args []string) bool {
+	for _, arg := range args {
+		if arg == "--model" || arg == "-m" || strings.HasPrefix(arg, "--model=") {
+			return true
+		}
+	}
+	return false
 }
 
 // parseResponse extracts a JSON object from the model output.


### PR DESCRIPTION
## Summary
- Recovered from stale dirty checkout drift during checkout recovery (20260525T000826Z).
- Ports the only still-useful dirty change: router now splits backend `cmd` into prefix args before appending router prompt flags, and skips duplicate `--model` when the backend command already pins one.
- Adds regression tests for prefix-arg routing and model de-duplication.

## Context
Workshop and local canonical checkouts were reset to `origin/main` (`59ca36e`). Dirty WIP from rescue branches `rescue/workshop-dirty-20260525T000826Z` / `rescue/local-dirty-20260525T000826Z` was classified; all other dirty files were obsolete relative to current main.

## Test plan
- [x] `go test ./...`
- [x] `go build ./cmd/maestro/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the router's `callModel` function to correctly handle backend commands that include prefix arguments (e.g. `claude --temperature 0`), and skips appending `--model` when the command already pins one. It also switches from `Output()` to `CombinedOutput()` so stderr is visible on failures.

- `splitRouterCmd` splits `backend.Cmd` via `strings.Fields` into a binary and prefix args, then appends `ExtraArgs`, the prompt, and optionally `--model <RouterModelName>`.
- `hasModelArg` detects `--model`, `-m`, or `--model=<val>` in the accumulated args to avoid duplicate model flags.
- Two new regression tests validate prefix-arg forwarding and model deduplication using a shell-script stub.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new routing logic is correct for the common case, with two minor edge cases worth addressing in follow-up.

The prefix-arg splitting works for typical commands, but strings.Fields will silently mangle any Cmd path or argument that contains spaces. Additionally, --model is appended after -p prompt, which could cause incorrect flag parsing with CLIs that treat -p as consuming the rest of the command line.

internal/router/router.go — specifically the splitRouterCmd function and the arg-ordering around -p and --model

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/router/router.go | Adds prefix-arg splitting and model-dedup logic; `strings.Fields` won't parse shell-quoted args, and `--model` is appended after `-p prompt` which could cause ordering issues with some CLIs |
| internal/router/resolve_test.go | Adds two regression tests covering prefix-arg routing and model deduplication using a shell-script stub; logic and assertions look correct |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/router/router.go:122-128
**`strings.Fields` cannot handle shell-quoted arguments**

`splitRouterCmd` splits on whitespace only, so a `Cmd` value containing a binary path with spaces (e.g. `"/usr/local/AI Tools/claude" --temperature 0`) would be incorrectly split: the path would become two tokens and the quoted argument would never be reconstructed correctly. Any user whose tool path contains a space will silently get a "binary not found" error or invoke the wrong binary.

### Issue 2 of 2
internal/router/router.go:107-111
**`--model` appended after `-p prompt`, and `hasModelArg` checked against the wrong slice**

`-p` and the prompt value are pushed onto `args` before `hasModelArg` is called, so the check is run against a slice that already includes the prompt string. While the prompt is unlikely to equal exactly `"--model"`, the intent is to test only the command prefix. More practically, appending `--model <name>` after `-p <prompt>` means some CLIs that parse `-p` as consuming everything to its right will silently embed `--model router-model` inside the prompt rather than treating it as a separate flag. Moving the model-pinning check and append to before `-p` is appended makes the logic unambiguous and future-proof.

```suggestion
	args = append(args, backend.ExtraArgs...)
	if r.cfg.Routing.RouterModelName != "" && !hasModelArg(args) {
		args = append(args, "--model", r.cfg.Routing.RouterModelName)
	}
	args = append(args, "-p", prompt)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(router): honor backend command prefi..."](https://github.com/befeast/maestro/commit/95fb4c035d849c9c34837c43ddafaf748f0c4bd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33692656)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->