### PR TITLE
fix(supervisor): deliver claude prompt via stdin to avoid E2BIG on large prompts

### DIFF
--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -208,20 +208,21 @@ func BuildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, workt
 
 	switch backendName {
 	case "claude":
-		promptData, err := os.ReadFile(promptFile)
-		if err != nil {
-			return nil, "", fmt.Errorf("read prompt file: %w", err)
-		}
 		claudeCmd := cfg.Cmd
 		if claudeCmd == "" {
 			claudeCmd = "claude"
 		}
 		binary, cmdArgs := splitCmd(claudeCmd)
-		args := append(cmdArgs, "-p", string(promptData))
+		// Deliver the prompt via stdin, not as a CLI argument. Supervisor
+		// prompts embed live PR/issue/review context and routinely exceed the
+		// Linux MAX_ARG_STRLEN single-argument limit (128 KiB), which fails
+		// fork/exec with "argument list too long". `claude -p` reads the prompt
+		// from stdin when no prompt argument is given (mirrors the codex `-` path).
+		args := append(cmdArgs, "-p")
 		args = appendModelOptions(args, cfg)
 		cmd := exec.Command(binary, args...)
 		cmd.Dir = worktree
-		return cmd, "", nil
+		return cmd, promptFile, nil
 	case "codex":
 		codexCmd := cfg.Cmd
 		if codexCmd == "" {

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -214,14 +214,19 @@ func TestBuildSupervisorCmd_ClaudeReadOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if stdinFile != "" {
-		t.Errorf("stdinFile = %q, want empty", stdinFile)
+	// Prompt is delivered via stdin (not argv) to stay under the Linux
+	// single-argument size limit; the prompt file is returned as stdinFile.
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
 	}
 	args := strings.Join(cmd.Args, " ")
 	if strings.Contains(args, "dangerously") || strings.Contains(args, "bypass") {
 		t.Errorf("supervisor command should not include worker permission bypass flags: %s", args)
 	}
-	for _, want := range []string{"-p", "decide safely", "--model", "sonnet", "--effort", "medium"} {
+	if strings.Contains(args, "decide safely") {
+		t.Errorf("prompt content must not appear in argv (stdin delivery): %s", args)
+	}
+	for _, want := range []string{"-p", "--model", "sonnet", "--effort", "medium"} {
 		if !strings.Contains(args, want) {
 			t.Errorf("expected %q in args, got: %s", want, args)
 		}


### PR DESCRIPTION
fix(supervisor): deliver claude prompt via stdin to avoid E2BIG on large prompts

BuildSupervisorCmd's "claude" case passed the entire supervisor prompt as a
CLI argument (`-p <content>`). Supervisor prompts embed live PR/issue/review
context and grow with queue/state size, routinely exceeding the Linux
MAX_ARG_STRLEN single-argument limit (128 KiB). fork/exec then failed with
"argument list too long", crash-looping the supervisor (Restart=on-failure)
whenever a project had several open PRs or bloated state — which is why the
supervisor had to be disabled to stop the noise.

Mirror the codex path: pass `-p` with no prompt argument and pipe the prompt
file via stdin (`claude -p` reads the prompt from stdin when no prompt
argument is given). This removes the argv size ceiling entirely.

Only the supervisor claude branch is changed; the worker claude builder still
uses arg delivery (worker prompts are bounded, but it carries the same latent
ceiling and can follow up separately).

Tests: TestBuildSupervisorCmd_ClaudeReadOnly now asserts stdin delivery
(stdinFile == promptFile) and that the prompt content does not appear in argv.

Verified on BeFeast/scribe-service: with this binary the supervisor runs as a
service without crashing (decision=monitor_open_pr, risk=safe, confidence=0.90,
deterministic guardrail agrees) where it previously failed with
"fork/exec /usr/bin/claude: argument list too long".

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a crash-loop in the supervisor by switching the Claude backend's prompt delivery from a CLI argument (`-p <content>`) to stdin, eliminating the Linux `MAX_ARG_STRLEN` (128 KiB) ceiling that caused `fork/exec: argument list too long` on large supervisor prompts.

- `BuildSupervisorCmd` for the `"claude"` case now passes bare `-p` and returns `promptFile` as `stdinFile`, matching the existing codex stdin pattern; the caller is responsible for wiring the file to the process's stdin.
- The worker `claudeBackend.BuildCmd` path is intentionally unchanged (acknowledged as a follow-up), so the same latent ceiling exists for worker prompts.
- Tests are correctly updated to assert stdin delivery and that prompt content no longer appears in argv.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is minimal and directly mirrors the existing codex stdin pattern that already works in production.

The core mechanism — passing bare `-p` and expecting the Claude CLI to read from stdin — is author-verified in production but depends on CLI behaviour that is not enforced by any explicit contract. A future CLI version changing this optional-argument handling would cause silent prompt loss rather than a loud error. The test gap (no `cmd.Stdin == nil` assertion) is a minor regression guard that is easy to miss. Both are non-blocking quality observations.

No files require special attention beyond the noted test gap in `internal/worker/backend_test.go`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/backend.go | Supervisor's claude branch now returns `promptFile` as `stdinFile` and passes bare `-p` (no content argument), mirroring the existing codex stdin path. The `os.ReadFile` call for the claude supervisor case is correctly removed; the `os` import remains used by other backends. |
| internal/worker/backend_test.go | TestBuildSupervisorCmd_ClaudeReadOnly is updated to assert stdin delivery (stdinFile == promptFile) and that prompt content is absent from argv. The new assertions are correct; a minor consistency gap remains compared to the codex test (no cmd.Stdin == nil check). |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/worker/backend.go:221-225
**Undocumented CLI convention for stdin fallback**

The fix depends on `claude -p` (with no following value) causing the Claude CLI to read the prompt from stdin. The command built is `claude -p --model sonnet --effort medium …`. A safer and more conventional Unix idiom for signalling "read from stdin" is an explicit `-p -`, which is unambiguous regardless of how the CLI's option parser treats a missing argument for `-p`. If a future Claude CLI release changes this optional-argument behaviour, the supervisor would silently receive an empty prompt or a parse error rather than the expected stdin content. Consider using `-p -` to make the stdin intent explicit, matching the codex path's use of the literal `-` sentinel.

### Issue 2 of 2
internal/worker/backend_test.go:217-223
The updated test verifies that `stdinFile == promptFile` (stdin delivery) but doesn't assert `cmd.Stdin == nil`, unlike the codex test which explicitly checks this. Without it, a future change that accidentally sets `cmd.Stdin` in the builder (bypassing the caller's responsibility) would go undetected.

```suggestion
	// Prompt is delivered via stdin (not argv) to stay under the Linux
	// single-argument size limit; the prompt file is returned as stdinFile.
	if stdinFile != promptFile {
		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
	}
	if cmd.Stdin != nil {
		t.Error("expected cmd.Stdin to be nil (stdin handled by caller via stdinFile)")
	}
	args := strings.Join(cmd.Args, " ")
	if strings.Contains(args, "dangerously") || strings.Contains(args, "bypass") {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(supervisor): deliver claude prompt v..."](https://github.com/befeast/maestro/commit/1e60f0b419e55d083ee526defc3b962ae801d1ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34649021)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->