### PR TITLE
fix(worker): deliver claude/gemini/cline prompt via stdin to remove latent E2BIG

### DIFF
--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -47,20 +47,24 @@ var knownBackends = map[string]Backend{
 type claudeBackend struct{}
 
 func (claudeBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
-	promptData, err := os.ReadFile(promptFile)
-	if err != nil {
-		return nil, "", fmt.Errorf("read prompt file: %w", err)
-	}
 	claudeCmd := cfg.Cmd
 	if claudeCmd == "" {
 		claudeCmd = "claude"
 	}
 	binary, cmdArgs := splitCmd(claudeCmd)
-	args := append(cmdArgs, "--dangerously-skip-permissions", "-p", string(promptData))
+	// Deliver the prompt via stdin, not as a CLI argument. Worker prompts are
+	// usually bounded but grow on retries (CI-failure context + Greptile review
+	// comments are appended), so a large PR can push a single argv past the
+	// Linux MAX_ARG_STRLEN limit (128 KiB) and fail fork/exec with "argument
+	// list too long". `claude -p` reads the prompt from stdin when no prompt
+	// argument is given; the runner script wires promptFile to stdin (mirrors
+	// the codex `-` path and the supervisor claude branch from #453).
+	args := append(cmdArgs, "--dangerously-skip-permissions", "-p")
 	args = append(args, cfg.ExtraArgs...)
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = worktree
-	return cmd, "", nil
+	// Stdin redirection is handled by the runner script — no file opened here.
+	return cmd, promptFile, nil
 }
 
 // --- Codex Backend ---
@@ -244,6 +248,12 @@ func BuildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, workt
 			geminiCmd = "gemini"
 		}
 		binary, cmdArgs := splitCmd(geminiCmd)
+		// NOTE: latent E2BIG ceiling. The gemini CLI takes its prompt via the
+		// `-p` argument, so a prompt approaching the Linux MAX_ARG_STRLEN limit
+		// (128 KiB) would fail fork/exec. Supervisor prompts are read-only and
+		// bounded, and the gemini CLI has no stable stdin-prompt contract to
+		// mirror the codex/claude `-`/`-p`-with-stdin paths, so this is left on
+		// argv delivery. Revisit if gemini gains stdin prompt support.
 		args := append(cmdArgs, "-p", string(promptData))
 		args = appendModelOptions(args, cfg)
 		cmd := exec.Command(binary, args...)
@@ -259,6 +269,10 @@ func BuildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, workt
 			clineCmd = "cline"
 		}
 		binary, cmdArgs := splitCmd(clineCmd)
+		// NOTE: latent E2BIG ceiling, same as the gemini case above. cline takes
+		// the task as a positional argument after `-y` with no stable
+		// stdin-prompt contract, so it is left on argv delivery. Supervisor
+		// prompts are read-only and bounded; revisit if cline gains stdin support.
 		args := append(cmdArgs, "-y", string(promptData))
 		args = appendModelOptions(args, cfg)
 		cmd := exec.Command(binary, args...)

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -25,21 +25,61 @@ func TestBuildWorkerCmd_Claude(t *testing.T) {
 	if cmd.Path == "" {
 		t.Fatal("cmd.Path is empty")
 	}
-	if stdinFile != "" {
-		t.Errorf("expected empty stdinFile for claude, got: %s", stdinFile)
+	// Prompt is delivered via stdin (not argv) to stay under the Linux
+	// single-argument size limit; the prompt file is returned as stdinFile.
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
 	}
 	args := strings.Join(cmd.Args, " ")
 	if !strings.Contains(args, "--dangerously-skip-permissions") {
 		t.Errorf("expected --dangerously-skip-permissions in args, got: %s", args)
 	}
-	if !strings.Contains(args, "do the thing") {
-		t.Errorf("expected prompt content in args, got: %s", args)
+	if strings.Contains(args, "do the thing") {
+		t.Errorf("prompt content must not appear in argv (stdin delivery): %s", args)
 	}
 	if !strings.Contains(args, "--model") {
 		t.Errorf("expected extra args in command, got: %s", args)
 	}
 	if cmd.Dir != worktree {
 		t.Errorf("expected Dir=%s, got %s", worktree, cmd.Dir)
+	}
+}
+
+// TestBuildWorkerCmd_ClaudeLargePromptViaStdin guards against the latent E2BIG
+// regression from #454: a worker claude prompt larger than the Linux
+// MAX_ARG_STRLEN single-argument limit (128 KiB) must be delivered via stdin,
+// never as a CLI argument, so fork/exec never sees "argument list too long".
+func TestBuildWorkerCmd_ClaudeLargePromptViaStdin(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	// 1 MiB + a little, far beyond the 128 KiB single-argument ceiling.
+	largePrompt := strings.Repeat("WORKER_PROMPT_PAYLOAD\n", (1<<20)/21+16)
+	if len(largePrompt) <= 1<<20 {
+		t.Fatalf("prompt should exceed 1 MiB, got %d bytes", len(largePrompt))
+	}
+	if err := os.WriteFile(promptFile, []byte(largePrompt), 0644); err != nil {
+		t.Fatal(err)
+	}
+	worktree := "/tmp/large-prompt-worktree"
+
+	cfg := BackendConfig{Cmd: "claude", ExtraArgs: []string{"--model", "opus"}}
+	cmd, stdinFile, err := BuildWorkerCmd("claude", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error building worker claude cmd with large prompt: %v", err)
+	}
+	// (a) prompt content must not appear anywhere in argv.
+	for i, a := range cmd.Args {
+		if strings.Contains(a, "WORKER_PROMPT_PAYLOAD") {
+			t.Fatalf("prompt content leaked into argv at index %d (E2BIG risk)", i)
+		}
+	}
+	// (b) the prompt file is returned as the stdin source.
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	// (c) cmd.Stdin stays nil — stdin redirection is handled by the runner script.
+	if cmd.Stdin != nil {
+		t.Error("expected cmd.Stdin to be nil (stdin handled by runner script)")
 	}
 }
 
@@ -60,8 +100,9 @@ func TestBuildWorkerCmd_ClaudeDefault(t *testing.T) {
 	if !strings.HasSuffix(cmd.Path, "claude") && !strings.Contains(cmd.Args[0], "claude") {
 		t.Errorf("expected claude command, got: %v", cmd.Args)
 	}
-	if stdinFile != "" {
-		t.Errorf("expected empty stdinFile for default claude, got: %s", stdinFile)
+	// claude delivers the prompt via stdin, so the prompt file is returned.
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
 	}
 }
 


### PR DESCRIPTION
Fixes #454. Follow-up to #453: mirror the supervisor stdin fix to the worker claude builder.

## Problem

The worker `claude` builder (`claudeBackend.BuildCmd` in `internal/worker/backend.go`) still passed the entire prompt as a single CLI argument (`claude ... -p "<prompt>"`), carrying the same latent E2BIG / `MAX_ARG_STRLEN` (128 KiB) ceiling that crash-looped the supervisor before #453. Worker prompts grow on retries (CI-failure context and Greptile review comments are appended), so a large PR can push that single argv past the limit and fail `fork/exec` with `argument list too long`. PR #453 deliberately left the worker claude path on argv delivery as a follow-up; this closes it.

## Change

- **Worker `claude` builder**: deliver the prompt via stdin instead of argv — pass a bare `-p`, drop the `os.ReadFile`/argv content, and return `promptFile` as `stdinFile`. This mirrors the supervisor claude branch from #453 and the codex `-` path.
- **No caller wiring change needed**: the existing worker runner script (`buildWorkerRunnerScript`) already redirects `stdinFile` to the process stdin (`exec <cmd> < <stdinFile>`), the same mechanism codex relies on. All four `BuildWorkerCmd` callers (`worker.go` x2, `checkpoint.go`, `phase.go`) pass `stdinFile` through `writeWorkerRunnerScript` unchanged.
- **Supervisor `gemini`/`cline` cases**: documented the remaining latent argv ceiling with `NOTE:` comments. These CLIs have no stable stdin-prompt contract to mirror the codex/claude paths, and their supervisor prompts are read-only and bounded, so they are intentionally left on argv delivery rather than changing an invocation contract that cannot be verified safe.

## Test

- Added `TestBuildWorkerCmd_ClaudeLargePromptViaStdin`: feeds a >1 MiB worker prompt and asserts (a) no error, (b) prompt content does not appear in `cmd.Args`, (c) `stdinFile == promptFile`, (d) `cmd.Stdin` stays nil (stdin handled by the runner script). Mirrors `TestBuildSupervisorCmd_ClaudeReadOnly`.
- Updated `TestBuildWorkerCmd_Claude` and `TestBuildWorkerCmd_ClaudeDefault` for the new stdin delivery (prompt absent from argv, `stdinFile == promptFile`).

## Verification (workshop, `go test`)

`go build ./cmd/maestro/`, `go vet ./internal/worker/`, and the full `go test ./...` suite are green; the new test runs (not cached) and passes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR mirrors the supervisor claude stdin fix (#453) to the worker `claudeBackend.BuildCmd`, replacing `os.ReadFile` + argv prompt delivery with a bare `-p` flag and returning `promptFile` as `stdinFile`. The existing `writeWorkerRunnerScript` already redirects `stdinFile` to process stdin, so no call-site changes are needed.

- **`internal/worker/backend.go`**: Removes the `os.ReadFile` call and the prompt string from `cmd.Args` in `claudeBackend.BuildCmd`; now returns `promptFile` as `stdinFile`. Adds `NOTE:` comments documenting the remaining argv ceiling on the gemini and cline supervisor paths.
- **`internal/worker/backend_test.go`**: Updates two existing Claude tests to assert stdin delivery (prompt absent from argv, `stdinFile == promptFile`), and adds `TestBuildWorkerCmd_ClaudeLargePromptViaStdin` which feeds a >1 MiB prompt and verifies none of it leaks into `cmd.Args`.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is a focused two-line delta in one backend function, with a clear existing precedent and working runner-script plumbing already in place.

The worker claude path now exactly mirrors the supervisor claude path established and validated in #453. The writeWorkerRunnerScript already handles a non-empty stdinFile by emitting exec <cmd> < <stdinFile>, confirmed in search_guardrail.go. The new regression test exercises the specific failure scenario (>1 MiB prompt, E2BIG) end-to-end at the BuildWorkerCmd layer. No callers required changes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/backend.go | Removes os.ReadFile + argv prompt delivery from claudeBackend.BuildCmd and returns promptFile as stdinFile; adds NOTE comments on gemini/cline argv ceiling. Clean mirror of the supervisor claude path from #453. |
| internal/worker/backend_test.go | Updates TestBuildWorkerCmd_Claude and TestBuildWorkerCmd_ClaudeDefault to assert stdin delivery; adds TestBuildWorkerCmd_ClaudeLargePromptViaStdin to guard against E2BIG regression with a >1 MiB prompt. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): deliver claude prompt via s..."](https://github.com/befeast/maestro/commit/f45bafc262b92910eb798f686697a2105b8cffec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34664586)</sub>

<!-- /greptile_comment -->