### PR TITLE
fix(cli): accept global flags after positional args (kill/approve/reject/spawn)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -152,6 +152,85 @@ func (f *multiFlag) Set(value string) error {
 	return nil
 }
 
+// reorderArgs moves flag tokens ahead of positional arguments so that flags
+// can be supplied in any position on the command line. Go's stdlib flag
+// package stops parsing at the first non-flag argument, which makes the
+// intuitive `maestro kill <slot> --config <path>` order fail. Reordering args
+// before handing them to a FlagSet lets flags follow positionals.
+//
+// fs is used only to inspect which flags are registered and which are
+// boolean (value-less); it is not parsed here. A literal `--` terminates
+// reordering: it and everything after it is treated as positional and kept in
+// place. Bare tokens that do not name a registered flag stay positional, so an
+// unknown `--foo` is left untouched for the FlagSet to report.
+func reorderArgs(fs *flag.FlagSet, args []string) []string {
+	flags := make([]string, 0, len(args))
+	positionals := make([]string, 0, len(args))
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		// A literal `--` ends flag processing; keep the rest verbatim.
+		if arg == "--" {
+			positionals = append(positionals, args[i:]...)
+			break
+		}
+
+		name, hasValue := flagToken(arg)
+		if name == "" {
+			// Not a flag-looking token (e.g. a positional, "-", or "").
+			positionals = append(positionals, arg)
+			continue
+		}
+
+		f := fs.Lookup(name)
+		if f == nil {
+			// Unknown flag: leave it in place so the FlagSet can report it.
+			positionals = append(positionals, arg)
+			continue
+		}
+
+		flags = append(flags, arg)
+
+		// A non-boolean flag in `--flag value` form consumes the next token as
+		// its value; pull it along so it is not stranded as a positional.
+		if !hasValue && i+1 < len(args) && !isBoolFlag(f) {
+			i++
+			flags = append(flags, args[i])
+		}
+	}
+
+	return append(flags, positionals...)
+}
+
+// flagToken reports the flag name for a `-flag`, `--flag`, `-flag=value`, or
+// `--flag=value` token. It returns an empty name for non-flag tokens. hasValue
+// is true when the token carries an inline `=value`.
+func flagToken(arg string) (name string, hasValue bool) {
+	if len(arg) < 2 || arg[0] != '-' {
+		return "", false
+	}
+	body := arg[1:]
+	if body[0] == '-' {
+		body = body[1:]
+	}
+	// "--" (now empty body) or "-" are not flags.
+	if body == "" || body[0] == '-' {
+		return "", false
+	}
+	if eq := strings.IndexByte(body, '='); eq >= 0 {
+		return body[:eq], true
+	}
+	return body, false
+}
+
+// isBoolFlag reports whether a registered flag is boolean, i.e. it does not
+// consume a following argument as its value.
+func isBoolFlag(f *flag.Flag) bool {
+	bf, ok := f.Value.(interface{ IsBoolFlag() bool })
+	return ok && bf.IsBoolFlag()
+}
+
 func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmsgprefix)
 	log.SetPrefix("[maestro] ")
@@ -433,7 +512,7 @@ func superviseApprovalCmd(action string, args []string, defaultConfigPath string
 	configPath := fs.String("config", defaultConfigPath, "Path to config file")
 	actor := fs.String("actor", "cli", "Audit actor")
 	reason := fs.String("reason", "", "Audit reason")
-	fs.Parse(args)
+	fs.Parse(reorderArgs(fs, args))
 	if fs.NArg() != 1 {
 		log.Fatalf("supervise %s: expected approval or decision id", action)
 	}
@@ -1357,7 +1436,7 @@ func spawnCmd(args []string) {
 	fs.Var(&configs, "config", "Path to config file (can be repeated)")
 	issueNum := fs.Int("issue", 0, "Issue number")
 	promptPath := fs.String("prompt", "", "Path to worker prompt base file")
-	fs.Parse(args)
+	fs.Parse(reorderArgs(fs, args))
 
 	if *issueNum == 0 {
 		fmt.Fprintln(os.Stderr, "error: --issue is required")
@@ -1430,7 +1509,7 @@ func stopCmd(args []string) {
 	var configs multiFlag
 	fs.Var(&configs, "config", "Path to config file (can be repeated)")
 	sessionName := fs.String("session", "", "Session name to stop")
-	fs.Parse(args)
+	fs.Parse(reorderArgs(fs, args))
 
 	if *sessionName == "" {
 		fmt.Fprintln(os.Stderr, "error: --session is required")
@@ -1470,7 +1549,7 @@ func killCmd(args []string) {
 	fs := flag.NewFlagSet("kill", flag.ExitOnError)
 	var configs multiFlag
 	fs.Var(&configs, "config", "Path to config file (can be repeated)")
-	fs.Parse(args)
+	fs.Parse(reorderArgs(fs, args))
 	args = fs.Args()
 
 	if len(args) == 0 || args[0] == "" {

--- a/cmd/maestro/main_test.go
+++ b/cmd/maestro/main_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+)
+
+// newKillFlagSet mirrors the flags registered by killCmd so reorderArgs can be
+// exercised against a realistic FlagSet.
+func newKillFlagSet() (*flag.FlagSet, *multiFlag) {
+	fs := flag.NewFlagSet("kill", flag.ContinueOnError)
+	var configs multiFlag
+	fs.Var(&configs, "config", "Path to config file (can be repeated)")
+	return fs, &configs
+}
+
+func TestReorderArgs(t *testing.T) {
+	// boolFS registers a boolean flag to verify value-less flags do not consume
+	// the following token.
+	boolFS := func() *flag.FlagSet {
+		fs := flag.NewFlagSet("once", flag.ContinueOnError)
+		var configs multiFlag
+		fs.Var(&configs, "config", "Path to config file (can be repeated)")
+		fs.Bool("force", false, "force")
+		return fs
+	}
+
+	tests := []struct {
+		name string
+		fs   *flag.FlagSet
+		in   []string
+		want []string
+	}{
+		{
+			name: "flag after positional, space form",
+			in:   []string{"scr-223", "--config", "/p/x.yaml"},
+			want: []string{"--config", "/p/x.yaml", "scr-223"},
+		},
+		{
+			name: "flag after positional, equals form",
+			in:   []string{"scr-223", "--config=/p/x.yaml"},
+			want: []string{"--config=/p/x.yaml", "scr-223"},
+		},
+		{
+			name: "single dash flag",
+			in:   []string{"scr-223", "-config", "/p/x.yaml"},
+			want: []string{"-config", "/p/x.yaml", "scr-223"},
+		},
+		{
+			name: "flags already first are unchanged",
+			in:   []string{"--config", "/p/x.yaml", "scr-223"},
+			want: []string{"--config", "/p/x.yaml", "scr-223"},
+		},
+		{
+			name: "double dash terminator keeps trailing tokens positional",
+			in:   []string{"scr-223", "--", "--config", "/p/x.yaml"},
+			want: []string{"scr-223", "--", "--config", "/p/x.yaml"},
+		},
+		{
+			name: "unknown flag stays in place",
+			in:   []string{"scr-223", "--bogus", "v"},
+			want: []string{"scr-223", "--bogus", "v"},
+		},
+		{
+			name: "repeated config flags both lifted",
+			in:   []string{"scr-223", "--config", "/a.yaml", "--config", "/b.yaml"},
+			want: []string{"--config", "/a.yaml", "--config", "/b.yaml", "scr-223"},
+		},
+		{
+			name: "bool flag does not consume next token",
+			fs:   boolFS(),
+			in:   []string{"slot", "--force", "--config", "/a.yaml"},
+			want: []string{"--force", "--config", "/a.yaml", "slot"},
+		},
+		{
+			name: "lone dash is positional",
+			in:   []string{"-", "--config", "/a.yaml"},
+			want: []string{"--config", "/a.yaml", "-"},
+		},
+		{
+			name: "empty args",
+			in:   []string{},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := tt.fs
+			if fs == nil {
+				fs, _ = newKillFlagSet()
+			}
+			got := reorderArgs(fs, tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("reorderArgs(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReorderArgsParseEquivalence asserts that parsing flags-after-positional
+// yields the same result as flags-first, which is the behavior #459 requires.
+func TestReorderArgsParseEquivalence(t *testing.T) {
+	cases := []struct {
+		name       string
+		after      []string
+		first      []string
+		wantConfig []string
+		wantArgs   []string
+	}{
+		{
+			name:       "space form",
+			after:      []string{"scr-223", "--config", "/p/x.yaml"},
+			first:      []string{"--config", "/p/x.yaml", "scr-223"},
+			wantConfig: []string{"/p/x.yaml"},
+			wantArgs:   []string{"scr-223"},
+		},
+		{
+			name:       "equals form",
+			after:      []string{"scr-223", "--config=/p/x.yaml"},
+			first:      []string{"--config=/p/x.yaml", "scr-223"},
+			wantConfig: []string{"/p/x.yaml"},
+			wantArgs:   []string{"scr-223"},
+		},
+		{
+			name:       "terminator keeps flag-looking positional",
+			after:      []string{"--config", "/p/x.yaml", "--", "-weird-slot"},
+			first:      []string{"--config", "/p/x.yaml", "--", "-weird-slot"},
+			wantConfig: []string{"/p/x.yaml"},
+			wantArgs:   []string{"-weird-slot"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			parse := func(args []string) (multiFlag, []string) {
+				fs, configs := newKillFlagSet()
+				if err := fs.Parse(reorderArgs(fs, args)); err != nil {
+					t.Fatalf("parse %q: %v", args, err)
+				}
+				return *configs, fs.Args()
+			}
+
+			afterConfig, afterArgs := parse(tt.after)
+			firstConfig, firstArgs := parse(tt.first)
+
+			if !reflect.DeepEqual([]string(afterConfig), tt.wantConfig) {
+				t.Errorf("after-positional config = %q, want %q", afterConfig, tt.wantConfig)
+			}
+			if !reflect.DeepEqual(afterArgs, tt.wantArgs) {
+				t.Errorf("after-positional args = %q, want %q", afterArgs, tt.wantArgs)
+			}
+			if !reflect.DeepEqual([]string(afterConfig), []string(firstConfig)) {
+				t.Errorf("config mismatch: after=%q first=%q", afterConfig, firstConfig)
+			}
+			if !reflect.DeepEqual(afterArgs, firstArgs) {
+				t.Errorf("args mismatch: after=%q first=%q", afterArgs, firstArgs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #459.

## Problem

Go's stdlib `flag` package stops parsing at the first non-flag (positional) argument. Every subcommand parses its own `flag.FlagSet`, so the intuitive order `maestro kill <slot> --config <path>` never parsed the trailing `--config` and fell back to default config discovery → `no config file found`. This forced the "flags before the positional/issue id" wart documented across the CLI (`kill` / `approve` / `reject` / `spawn`).

## Fix

Add a small `reorderArgs(fs *flag.FlagSet, args []string)` helper that lifts registered flag tokens (and, for non-boolean flags, their values) ahead of positionals before handing args to the FlagSet. It is conservative:

- Uses the FlagSet to know which flags are registered and which are boolean, so it never strands a `--flag value` pair and never over-consumes a boolean flag's successor.
- Handles `--flag value`, `--flag=value`, and single-dash `-flag` forms.
- Stops at a literal `--` terminator (it and everything after stay positional, in place).
- Leaves unknown/bare tokens in place so the FlagSet still reports unknown flags.

Flag *semantics* are unchanged; flags are only allowed to interleave with positionals. Applied to `kill`, `stop`, `spawn`, and `supervise approve`/`reject`.

## Tests

`cmd/maestro/main_test.go`:

- `TestReorderArgs` — table-driven unit on the helper: space form, `=value` form, single-dash, already-flags-first, `--` terminator, unknown flag untouched, repeated `--config`, boolean flag not consuming the next token, lone `-`, empty args.
- `TestReorderArgsParseEquivalence` — parses through a real FlagSet and asserts flags-after-positional yields the *same* `--config` values and remaining args as flags-first, for `--config value`, `--config=value`, and the `--` terminator case.

## Verification (on workshop)

```
$ go build ./cmd/maestro/   # ok
$ go vet ./cmd/...           # ok
$ go test ./cmd/...
ok  	github.com/befeast/maestro/cmd/maestro
$ go test ./...              # entire suite green
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a `reorderArgs` helper that lifts registered flag tokens ahead of positional arguments before passing `args` to each subcommand's `FlagSet`, allowing `maestro kill <slot> --config <path>` and similar invocations to work correctly. The helper is well-designed: it consults the `FlagSet` to distinguish boolean from value-consuming flags, handles `--flag=value` and single-dash forms, and stops at a literal `--` terminator.

- `reorderArgs`, `flagToken`, and `isBoolFlag` are added to `main.go` and applied to `killCmd`, `stopCmd`, `spawnCmd`, and `superviseApprovalCmd`.
- `logsCmd` also accepts a positional slot name but was not updated; `maestro logs <slot> --config <path>` still silently drops the config flag.
- `main_test.go` is a new file with table-driven and parse-equivalence tests covering the key edge cases of the helper.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the four fixed commands, but logsCmd retains the original broken behavior for flags placed after its positional slot argument.

The `reorderArgs` helper itself is correct and well-tested. However, `logsCmd` — which also takes a positional slot name — was omitted from the fix. A user following the new convention (`maestro logs myslot --config /p/x.yaml`) will get silent config-discovery fallback, the same bug the PR intended to eliminate.

cmd/maestro/main.go — specifically the logsCmd function around line 1052.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Adds reorderArgs/flagToken/isBoolFlag helpers and applies reorderArgs to killCmd, stopCmd, spawnCmd, and superviseApprovalCmd — but logsCmd, which also accepts a positional slot name, was not updated. |
| cmd/maestro/main_test.go | New file with table-driven unit tests for reorderArgs (TestReorderArgs) and parse-equivalence tests (TestReorderArgsParseEquivalence); good coverage of the helper. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cmd/maestro/main.go`, line 1048-1053 ([link](https://github.com/befeast/maestro/blob/329fc31f8844c771e3f9e9599f137b16aa025f16/cmd/maestro/main.go#L1048-L1053)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `logsCmd` accepts an optional positional slot name (`maestro logs <slot> --config <path>`) but was not updated to use `reorderArgs`. This means `maestro logs myslot --config /p/x.yaml` still silently drops the `--config` flag and falls back to default config discovery — the exact regression this PR was written to fix.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/maestro/main.go
   Line: 1048-1053

   Comment:
   `logsCmd` accepts an optional positional slot name (`maestro logs <slot> --config <path>`) but was not updated to use `reorderArgs`. This means `maestro logs myslot --config /p/x.yaml` still silently drops the `--config` flag and falls back to default config discovery — the exact regression this PR was written to fix.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
cmd/maestro/main.go:1048-1053
`logsCmd` accepts an optional positional slot name (`maestro logs <slot> --config <path>`) but was not updated to use `reorderArgs`. This means `maestro logs myslot --config /p/x.yaml` still silently drops the `--config` flag and falls back to default config discovery — the exact regression this PR was written to fix.

```suggestion
func logsCmd(args []string) {
	fs := flag.NewFlagSet("logs", flag.ExitOnError)
	var configs multiFlag
	fs.Var(&configs, "config", "Path to config file (can be repeated)")
	fs.Parse(reorderArgs(fs, args))
	args = fs.Args() // remaining args after flags
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): accept global flags after posi..."](https://github.com/befeast/maestro/commit/329fc31f8844c771e3f9e9599f137b16aa025f16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34664658)</sub>

<!-- /greptile_comment -->