### PR TITLE
fix(ratelimit): detect Codex/OpenAI usage-limit signature + parse reset time

### DIFF
--- a/internal/orchestrator/backend_selector.go
+++ b/internal/orchestrator/backend_selector.go
@@ -10,7 +10,12 @@ import (
 
 const selectionReasonProviderLimitFallback = "fallback_after_provider_limit"
 
-func (o *Orchestrator) recordProviderLimit(st *state.State, slotName string, sess *state.Session, pattern string, now time.Time) {
+// recordProviderLimit marks the session's backend as rate-limited and puts it
+// into cooldown. resetAt, when non-nil, is the provider-stated reset time
+// parsed from the limit message ("try again at ..."); it is surfaced on the
+// session and used as the backend's RetryAfter so the fallback selector treats
+// the backend as available again once the reset time passes (auto-resume).
+func (o *Orchestrator) recordProviderLimit(st *state.State, slotName string, sess *state.Session, pattern string, resetAt *time.Time, now time.Time) {
 	if st == nil || sess == nil || sess.Backend == "" {
 		return
 	}
@@ -23,13 +28,19 @@ func (o *Orchestrator) recordProviderLimit(st *state.State, slotName string, ses
 	sess.RateLimitHit = true
 	sess.ProviderLimitBackend = sess.Backend
 	sess.ProviderLimitReason = pattern
-	st.BackendHealth[sess.Backend] = state.BackendHealth{
+	sess.ProviderLimitResetAt = resetAt
+	health := state.BackendHealth{
 		State:       state.BackendHealthCooldown,
 		Reason:      state.BackendBlockProviderLimit,
 		Pattern:     pattern,
 		Since:       now.UTC(),
 		LastSession: slotName,
 	}
+	if resetAt != nil {
+		retryAfter := resetAt.UTC()
+		health.RetryAfter = &retryAfter
+	}
+	st.BackendHealth[sess.Backend] = health
 }
 
 func (o *Orchestrator) selectProviderLimitFallback(st *state.State, sess *state.Session, now time.Time) state.BackendSelection {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -335,6 +335,24 @@ func (o *Orchestrator) isRateLimited(logFile string) bool {
 	return worker.IsRateLimited(logFile)
 }
 
+// rateLimitResetFromLog reads a dead worker's log file and parses the
+// provider-stated reset time ("try again at ...") if present. It returns nil
+// when the log is unreadable or carries no parseable reset hint, so callers can
+// fall back to a reasonable default cooldown.
+func (o *Orchestrator) rateLimitResetFromLog(logFile string) *time.Time {
+	if logFile == "" {
+		return nil
+	}
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		return nil
+	}
+	if reset, ok := worker.ParseRateLimitReset(string(data)); ok {
+		return &reset
+	}
+	return nil
+}
+
 // runAfterRunHook executes the after_run hook for a session (best-effort, never fatal).
 func (o *Orchestrator) runAfterRunHook(sess *state.Session) {
 	if o.cfg.Hooks.AfterRun == "" {
@@ -1535,7 +1553,8 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				} else if o.isRateLimited(sess.LogFile) {
 					// Provider capacity limit detected — gate this backend and select a fallback.
 					now := time.Now().UTC()
-					o.recordProviderLimit(s, slotName, sess, "log_rate_limit", now)
+					resetAt := o.rateLimitResetFromLog(sess.LogFile)
+					o.recordProviderLimit(s, slotName, sess, "log_rate_limit", resetAt, now)
 					selection := o.selectProviderLimitFallback(s, sess, now)
 					sess.BackendSelection = &selection
 					nextBackend := selection.SelectedBackend
@@ -1651,7 +1670,11 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 								log.Printf("[orch] warn: could not stop rate-limited worker %s: %v", slotName, err)
 							}
 							now := time.Now().UTC()
-							o.recordProviderLimit(s, slotName, sess, pattern, now)
+							var resetAt *time.Time
+							if reset, ok := worker.ParseRateLimitReset(output); ok {
+								resetAt = &reset
+							}
+							o.recordProviderLimit(s, slotName, sess, pattern, resetAt, now)
 							selection := o.selectProviderLimitFallback(s, sess, now)
 							sess.BackendSelection = &selection
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -37,6 +37,11 @@ const (
 	DisplayReviewRetryPending SessionDisplayStatus = "review_retry_pending"
 	DisplayReviewRetryRunning SessionDisplayStatus = "review_retry_running"
 	DisplayReviewRetryRecheck SessionDisplayStatus = "review_retry_recheck"
+	// DisplayBackendRateLimited marks a session whose worker exited because its
+	// backend hit a provider usage limit with no fallback available. It is a
+	// distinct, non-failure display token so operators do not confuse a
+	// rate-limited backend with a genuine retry_exhausted code failure.
+	DisplayBackendRateLimited SessionDisplayStatus = "backend_rate_limited"
 	LiveSessionRecentWindow                        = 24 * time.Hour
 )
 
@@ -120,6 +125,7 @@ type Session struct {
 	TriedBackends               []string          `json:"tried_backends,omitempty"`                 // backends already attempted (for rate-limit fallback)
 	ProviderLimitBackend        string            `json:"provider_limit_backend,omitempty"`         // backend that hit a provider capacity limit
 	ProviderLimitReason         string            `json:"provider_limit_reason,omitempty"`          // provider limit signature or class
+	ProviderLimitResetAt        *time.Time        `json:"provider_limit_reset_at,omitempty"`        // provider-stated reset time parsed from the limit message ("try again at ..."), UTC
 	BackendSelection            *BackendSelection `json:"backend_selection,omitempty"`              // latest backend selection audit record
 	Phase                       Phase             `json:"phase,omitempty"`                          // current pipeline phase (empty = legacy single-phase)
 	ValidationFails             int               `json:"validation_fails,omitempty"`               // number of failed validation attempts
@@ -282,7 +288,30 @@ func SessionDisplayStatusForAt(sess *Session, alive *bool, now time.Time) string
 	if display := reviewFeedbackRetryDisplayStatus(sess, now); display != "" {
 		return string(display)
 	}
+	if backendRateLimitedDisplayStatus(sess) {
+		return string(DisplayBackendRateLimited)
+	}
 	return string(sess.Status)
+}
+
+// backendRateLimitedDisplayStatus reports whether a session represents a worker
+// that exited because its backend hit a provider usage limit with no fallback
+// available. Such a session is marked Dead but, unlike a real failure, did not
+// burn the per-issue retry budget; it must be shown distinctly so operators do
+// not mistake it for retry_exhausted.
+func backendRateLimitedDisplayStatus(sess *Session) bool {
+	if sess == nil {
+		return false
+	}
+	if sess.Status != StatusDead && sess.Status != StatusRetryExhausted {
+		return false
+	}
+	// A scheduled retry takes precedence: the worker is going to respawn, so it
+	// is not blocked on a provider limit even if an earlier attempt was.
+	if sess.NextRetryAt != nil {
+		return false
+	}
+	return sess.RateLimitHit && strings.TrimSpace(sess.ProviderLimitBackend) != ""
 }
 
 func reviewFeedbackRetryAttention(sess *Session, alive *bool, now time.Time) (SessionAttention, bool) {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -976,6 +976,71 @@ func TestSessionDisplayStatusFor_StaleReviewRetryWorkerStaysRunning(t *testing.T
 	}
 }
 
+func TestSessionDisplayStatusFor_BackendRateLimited(t *testing.T) {
+	now := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	reset := time.Date(2026, 5, 30, 20, 13, 0, 0, time.UTC)
+	future := now.Add(5 * time.Minute)
+
+	tests := []struct {
+		name string
+		sess *Session
+		want string
+	}{
+		{
+			name: "dead with provider limit and no retry scheduled",
+			sess: &Session{
+				Status:               StatusDead,
+				RateLimitHit:         true,
+				ProviderLimitBackend: "codex",
+				ProviderLimitResetAt: &reset,
+			},
+			want: string(DisplayBackendRateLimited),
+		},
+		{
+			name: "retry_exhausted purely from provider limit",
+			sess: &Session{
+				Status:               StatusRetryExhausted,
+				RateLimitHit:         true,
+				ProviderLimitBackend: "codex",
+			},
+			want: string(DisplayBackendRateLimited),
+		},
+		{
+			name: "scheduled retry takes precedence over provider limit",
+			sess: &Session{
+				Status:               StatusDead,
+				RateLimitHit:         true,
+				ProviderLimitBackend: "codex",
+				NextRetryAt:          &future,
+			},
+			want: string(StatusDead),
+		},
+		{
+			name: "rate-limit flag without backend is not surfaced",
+			sess: &Session{
+				Status:       StatusDead,
+				RateLimitHit: true,
+			},
+			want: string(StatusDead),
+		},
+		{
+			name: "generic dead session is unaffected",
+			sess: &Session{
+				Status: StatusDead,
+			},
+			want: string(StatusDead),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SessionDisplayStatusForAt(tt.sess, nil, now); got != tt.want {
+				t.Fatalf("display status = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSessionAttentionFor_ReviewFeedbackRetryCopy(t *testing.T) {
 	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	future := now.Add(5 * time.Minute)

--- a/internal/worker/ratelimit.go
+++ b/internal/worker/ratelimit.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // rateLimitPatterns holds compiled regexes for detecting rate-limit / quota
@@ -12,6 +13,10 @@ import (
 //
 // Supported patterns (case-insensitive):
 //   - "You've hit your limit" (Claude web / API)
+//   - "You've hit your usage limit" (Codex / OpenAI) — the inserted "usage"
+//     word is matched by the optional "(usage )?" group, so both Claude and
+//     Codex signatures hit the same label
+//   - "chatgpt.com/codex/settings/usage" marker (Codex usage-limit URL)
 //   - HTTP 429 status codes
 //   - "rate limit exceeded" (generic)
 //   - "quota exceeded" (Google / generic)
@@ -21,7 +26,8 @@ var rateLimitPatterns = []struct {
 	label string
 	re    *regexp.Regexp
 }{
-	{"hit_limit", regexp.MustCompile(`(?i)you'?ve hit your limit`)},
+	{"hit_limit", regexp.MustCompile(`(?i)you'?ve hit your (usage )?limit`)},
+	{"codex_usage_limit", regexp.MustCompile(`(?i)(chatgpt\.com/)?codex/settings/usage`)},
 	{"http_429", regexp.MustCompile(`\b429\b`)},
 	{"rate_limit_exceeded", regexp.MustCompile(`(?i)rate.limit.exceeded`)},
 	{"quota_exceeded", regexp.MustCompile(`(?i)quota.exceeded`)},
@@ -34,6 +40,10 @@ var rateLimitPatterns = []struct {
 var rateLimitSubstrings = []string{
 	"you've hit your limit",
 	"you have hit your limit",
+	"you've hit your usage limit",
+	"you have hit your usage limit",
+	"chatgpt.com/codex/settings/usage",
+	"codex/settings/usage",
 	"rate limit",
 	"rate_limit",
 	"too many requests",
@@ -41,6 +51,33 @@ var rateLimitSubstrings = []string{
 	"resource_exhausted",
 	"429",
 }
+
+// rateLimitResetRe extracts the human-readable reset hint emitted after a
+// provider usage-limit error, e.g.
+//
+//	"... try again at May 30th, 2026 8:13 PM."
+//
+// The capture is greedy to the end of the line; parseResetTimestamp trims a
+// trailing sentence period and surrounding whitespace before parsing.
+var rateLimitResetRe = regexp.MustCompile(`(?i)try again (?:at|after)\s+([^\n]+)`)
+
+// resetLayouts are the timestamp layouts ParseRateLimitReset attempts, in
+// order, against the cleaned "try again at <when>" capture. The Codex signature
+// uses a "May 30th, 2026 8:13 PM" shape; ordinal suffixes (st/nd/rd/th) are
+// stripped before parsing so the standard reference layouts apply.
+var resetLayouts = []string{
+	"January 2, 2006 3:04 PM",
+	"January 2, 2006 3:04PM",
+	"January 2, 2006 15:04",
+	"Jan 2, 2006 3:04 PM",
+	"Jan 2, 2006 15:04",
+	"2006-01-02 15:04:05",
+	time.RFC3339,
+}
+
+// ordinalSuffixRe matches day ordinals like "30th", "1st", "2nd", "3rd" so we
+// can drop the suffix before parsing ("May 30th" -> "May 30").
+var ordinalSuffixRe = regexp.MustCompile(`(?i)(\d{1,2})(st|nd|rd|th)`)
 
 // DetectRateLimit scans multi-line output for known rate-limit / quota error
 // patterns. Returns true and the matching pattern label on the first match,
@@ -86,4 +123,43 @@ func IsRateLimited(logFile string) bool {
 		return false
 	}
 	return OutputContainsRateLimit(string(data))
+}
+
+// ParseRateLimitReset extracts the provider-stated reset time from output that
+// contains a "try again at <date/time>" hint (as emitted by the Codex/OpenAI
+// usage-limit error). It returns the parsed time and ok=true when a hint is
+// present and parseable, or ok=false when no hint is found or the timestamp
+// cannot be parsed.
+//
+// The provider message carries no timezone, so the returned time is
+// interpreted in UTC. Callers that need wall-clock precision should treat the
+// result as a best-effort lower bound for the cooldown, not an exact instant.
+func ParseRateLimitReset(output string) (time.Time, bool) {
+	m := rateLimitResetRe.FindStringSubmatch(output)
+	if m == nil {
+		return time.Time{}, false
+	}
+	return parseResetTimestamp(m[1])
+}
+
+// parseResetTimestamp normalizes and parses a single "<when>" capture extracted
+// from a "try again at <when>" hint. Day ordinals are stripped and whitespace
+// is collapsed before trying each layout in resetLayouts.
+func parseResetTimestamp(raw string) (time.Time, bool) {
+	// Drop a trailing sentence period and surrounding whitespace ("... 8:13 PM."
+	// -> "... 8:13 PM").
+	cleaned := strings.TrimRight(strings.TrimSpace(raw), ". ")
+	if cleaned == "" {
+		return time.Time{}, false
+	}
+	// Drop day ordinals: "May 30th, 2026" -> "May 30, 2026".
+	cleaned = ordinalSuffixRe.ReplaceAllString(cleaned, "$1")
+	// Collapse runs of whitespace to single spaces so "8:13  PM" parses.
+	cleaned = strings.Join(strings.Fields(cleaned), " ")
+	for _, layout := range resetLayouts {
+		if ts, err := time.ParseInLocation(layout, cleaned, time.UTC); err == nil {
+			return ts.UTC(), true
+		}
+	}
+	return time.Time{}, false
 }

--- a/internal/worker/ratelimit_test.go
+++ b/internal/worker/ratelimit_test.go
@@ -4,7 +4,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
+
+// codexUsageLimitSignature is the exact OpenAI/Codex usage-limit message that
+// issue #458 reported slipping past detection. The inserted word "usage" breaks
+// the contiguous "you've hit your limit" match, so it must be caught by the
+// "(usage )?" group and/or the codex/settings/usage marker.
+const codexUsageLimitSignature = "ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to see your usage. You can try again at May 30th, 2026 8:13 PM."
 
 func TestDetectRateLimit(t *testing.T) {
 	tests := []struct {
@@ -22,6 +29,18 @@ func TestDetectRateLimit(t *testing.T) {
 		{
 			name:      "hit your limit without apostrophe",
 			input:     "Youve hit your limit",
+			wantHit:   true,
+			wantLabel: "hit_limit",
+		},
+		{
+			name:      "codex usage limit signature (issue #458)",
+			input:     codexUsageLimitSignature,
+			wantHit:   true,
+			wantLabel: "hit_limit",
+		},
+		{
+			name:      "hit your usage limit standalone",
+			input:     "You've hit your usage limit.",
 			wantHit:   true,
 			wantLabel: "hit_limit",
 		},
@@ -207,5 +226,130 @@ func TestOutputContainsRateLimit_ResourceExhausted(t *testing.T) {
 	output := "gRPC error: RESOURCE_EXHAUSTED: quota exceeded"
 	if !OutputContainsRateLimit(output) {
 		t.Error("should detect 'resource_exhausted'")
+	}
+}
+
+// TestRateLimit_CodexSignature exercises every detection entry point against
+// the exact Codex/OpenAI usage-limit string from issue #458, ensuring the
+// "usage" variant is recognised end to end.
+func TestRateLimit_CodexSignature(t *testing.T) {
+	if hit, label := DetectRateLimit(codexUsageLimitSignature); !hit {
+		t.Errorf("DetectRateLimit should recognise the codex usage-limit signature, got hit=false")
+	} else if label != "hit_limit" {
+		t.Errorf("DetectRateLimit label = %q, want %q", label, "hit_limit")
+	}
+
+	if !OutputContainsRateLimit(codexUsageLimitSignature) {
+		t.Error("OutputContainsRateLimit should recognise the codex usage-limit signature")
+	}
+
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "codex.log")
+	content := "Starting worker...\nProcessing issue #247\n" + codexUsageLimitSignature + "\n"
+	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write log file: %v", err)
+	}
+	if !IsRateLimited(logFile) {
+		t.Error("IsRateLimited should recognise the codex usage-limit signature from a log file")
+	}
+}
+
+// TestRateLimit_CodexUsageURLOnly verifies the codex/settings/usage marker is
+// detected even when the "you've hit your ... limit" phrasing is absent (e.g.
+// only the help URL is logged).
+func TestRateLimit_CodexUsageURLOnly(t *testing.T) {
+	output := "See https://chatgpt.com/codex/settings/usage for details."
+	if hit, label := DetectRateLimit(output); !hit {
+		t.Error("DetectRateLimit should match the codex/settings/usage marker")
+	} else if label != "codex_usage_limit" {
+		t.Errorf("DetectRateLimit label = %q, want %q", label, "codex_usage_limit")
+	}
+	if !OutputContainsRateLimit(output) {
+		t.Error("OutputContainsRateLimit should match the codex/settings/usage marker")
+	}
+}
+
+// TestRateLimit_ClaudeStillMatches guards against regression: the original
+// Claude "You've hit your limit" phrasing (no "usage" word) must still match.
+func TestRateLimit_ClaudeStillMatches(t *testing.T) {
+	output := "You've hit your limit"
+	if hit, label := DetectRateLimit(output); !hit {
+		t.Error("DetectRateLimit should still match the Claude 'You've hit your limit' phrasing")
+	} else if label != "hit_limit" {
+		t.Errorf("DetectRateLimit label = %q, want %q", label, "hit_limit")
+	}
+	if !OutputContainsRateLimit(output) {
+		t.Error("OutputContainsRateLimit should still match the Claude phrasing")
+	}
+}
+
+func TestParseRateLimitReset_CodexSignature(t *testing.T) {
+	got, ok := ParseRateLimitReset(codexUsageLimitSignature)
+	if !ok {
+		t.Fatal("ParseRateLimitReset should parse the reset hint from the codex signature")
+	}
+	want := time.Date(2026, time.May, 30, 20, 13, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("ParseRateLimitReset = %v, want %v", got, want)
+	}
+}
+
+func TestParseRateLimitReset_Variants(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+		ok    bool
+	}{
+		{
+			name:  "ordinal with PM",
+			input: "try again at May 30th, 2026 8:13 PM.",
+			want:  time.Date(2026, time.May, 30, 20, 13, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "ordinal AM",
+			input: "Please try again at January 1st, 2027 9:05 AM",
+			want:  time.Date(2027, time.January, 1, 9, 5, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "try again after wording",
+			input: "Rate limited; try again after June 3rd, 2026 12:00 PM.",
+			want:  time.Date(2026, time.June, 3, 12, 0, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "iso 8601",
+			input: "you've hit your limit; try again at 2026-05-30T20:13:00Z",
+			want:  time.Date(2026, time.May, 30, 20, 13, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "no reset hint",
+			input: "You've hit your usage limit.",
+			ok:    false,
+		},
+		{
+			name:  "unparseable timestamp",
+			input: "try again at some point soon.",
+			ok:    false,
+		},
+		{
+			name:  "empty",
+			input: "",
+			ok:    false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseRateLimitReset(tc.input)
+			if ok != tc.ok {
+				t.Fatalf("ParseRateLimitReset ok = %v, want %v (got %v)", ok, tc.ok, got)
+			}
+			if tc.ok && !got.Equal(tc.want) {
+				t.Errorf("ParseRateLimitReset = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #458. Closes the pattern-set gap left by completed #432 / #183 / #185.

## Problem

The Codex/OpenAI usage-limit error

```
ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage ... try again at May 30th, 2026 8:13 PM.
```

slipped past the rate-limit detector: the inserted word **usage** breaks the contiguous `you've hit your limit` match, and none of `rate limit / quota exceeded / 429 / too many requests / resource_exhausted` appear in the codex message. So `isRateLimited()` returned `false`, the dead-worker exit path fell through to `canRetryIssue()` → `RetryCount++`, and the issue burned its per-issue retry budget to `retry_exhausted` — indistinguishable from a real code failure (issues #247-250 hit `retry_exhausted (4/4)` purely from codex rate-limiting). The provider-limit framework from #432 was wired correctly; only the detection patterns were missing the codex signature.

## Fix

- **`internal/worker/ratelimit.go`**
  - Make `usage` optional in the hit-limit regex: `(?i)you'?ve hit your (usage )?limit` — matches **both** Claude (`You've hit your limit`) and Codex (`You've hit your usage limit`).
  - Add `chatgpt.com/codex/settings/usage` / `codex/settings/usage` markers to both the regex set (`codex_usage_limit`) and the substring scan, so the codex signature is caught even if only the help URL is logged.
  - Keep every existing pattern (no regressions).
  - Add `ParseRateLimitReset(output) (time.Time, bool)` extracting the `try again at <date/time>` reset hint. It tolerates ordinal day suffixes (`30th`), 12h (`8:13 PM`) and ISO-8601 forms. The provider message carries **no timezone**, so the reset is interpreted as UTC and documented as a best-effort lower bound for the cooldown; `ok=false` when no hint is present or it is unparseable.

- **`internal/orchestrator`**
  - Parse the reset at both rate-limit branches (live tmux output and dead-worker log file via a new `rateLimitResetFromLog` helper) and pass it into `recordProviderLimit`.
  - `recordProviderLimit` now stores the parsed reset on the session (`ProviderLimitResetAt`) and sets the backend's `BackendHealth.RetryAfter`, so the existing fallback selector treats the backend as available again once the reset time passes — i.e. **auto-resume** with no manual state surgery.

- **`internal/state`**
  - Add a distinct `backend_rate_limited` display status (`SessionDisplayStatusFor`) for a Dead/retry_exhausted session that hit a provider limit with no fallback, so operators do not mistake a rate-limited backend for a genuine `retry_exhausted` code failure. A scheduled retry still takes precedence.

## Tests

`internal/worker/ratelimit_test.go`:
- `TestRateLimit_CodexSignature` — the EXACT codex string from #458 is recognised by `DetectRateLimit`, `OutputContainsRateLimit`, and `IsRateLimited`.
- `TestRateLimit_CodexUsageURLOnly` — the `codex/settings/usage` marker matches on its own.
- `TestRateLimit_ClaudeStillMatches` — Claude `You've hit your limit` (no "usage") still matches (no regression).
- `TestParseRateLimitReset_CodexSignature` / `TestParseRateLimitReset_Variants` — reset parsing across ordinal/12h/ISO forms, with negative cases (no hint, unparseable, empty).
- Plus a new case in the `TestDetectRateLimit` table.

`internal/state/state_test.go`:
- `TestSessionDisplayStatusFor_BackendRateLimited` — the new display status fires for a rate-limited Dead/retry_exhausted session, but not when a retry is scheduled, when the backend is unknown, or for a generic dead session.

## Verification (workshop, Linux)

```
go build ./cmd/maestro/        # BUILD_OK
go vet ./internal/{worker,state,orchestrator}/   # VET_OK
go test ./internal/worker/     # ok
go test ./...                  # all packages ok
```

Note: `TestSearchGuardrailWrapperRejectsBroadCWD` fails only on the macOS reference checkout (a `/tmp` symlink / CWD-guardrail quirk) and fails identically on pristine `origin/main`; it passes on the Linux workshop checkout. It is unrelated to this change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the detection gap that let Codex/OpenAI usage-limit errors slip past `isRateLimited`, causing affected sessions to burn their per-issue retry budget as if they were genuine code failures. It also adds `ParseRateLimitReset` to extract the provider-stated cooldown time and wire it into `BackendHealth.RetryAfter`, enabling auto-resume once the reset time passes.

- `ratelimit.go`: makes `usage` optional in the existing `hit_limit` regex, adds a `codex_usage_limit` regex and four new substrings, and introduces `ParseRateLimitReset` with ordinal-suffix stripping and multi-layout parsing (12h, 24h, ISO-8601).
- `orchestrator.go` / `backend_selector.go`: both rate-limit detection branches (live tmux output and dead-worker log) now parse and propagate `resetAt` into `sess.ProviderLimitResetAt` and `BackendHealth.RetryAfter`.
- `state.go`: adds `DisplayBackendRateLimited` so operators can distinguish a rate-limited backend from a genuine `retry_exhausted` code failure.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the detection and reset-parsing changes are well-isolated and covered by targeted tests, and no existing behaviour is removed.

The orchestrator's dead-worker path reads the log file twice — once in `isRateLimited` and again in `rateLimitResetFromLog` — which leaves a narrow window where a cleanup race could return a nil reset even after the rate-limit check succeeded. The consequence is only a missing cooldown hint rather than a crash or incorrect state, so the risk is low, but the redundant I/O is worth addressing.

internal/orchestrator/orchestrator.go — the dual `os.ReadFile` calls in the dead-worker branch could be collapsed into a single read.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/ratelimit.go | Adds Codex/OpenAI detection patterns (regex + substring), and `ParseRateLimitReset` with ordinal-stripping and multi-layout timestamp parsing. Logic is sound and well-tested. |
| internal/worker/ratelimit_test.go | Comprehensive tests for the new Codex signature, URL-only matching, Claude non-regression, and all `ParseRateLimitReset` variants including negative cases. |
| internal/orchestrator/backend_selector.go | Adds `resetAt *time.Time` parameter to `recordProviderLimit`; correctly sets both `sess.ProviderLimitResetAt` and `health.RetryAfter` when non-nil. |
| internal/orchestrator/orchestrator.go | Adds `rateLimitResetFromLog` helper and threads `resetAt` into both rate-limit branches; the dead-worker path reads the log file twice (once in `isRateLimited`, once in `rateLimitResetFromLog`). |
| internal/state/state.go | Adds `ProviderLimitResetAt` field, `DisplayBackendRateLimited` constant, and `backendRateLimitedDisplayStatus` helper; ordering and guard conditions in `SessionDisplayStatusForAt` are correct. |
| internal/state/state_test.go | New `TestSessionDisplayStatusFor_BackendRateLimited` table covers all four guard conditions, including the scheduled-retry precedence and the no-backend edge case. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:1553-1557
**Redundant log-file read in dead-worker path**

`isRateLimited(sess.LogFile)` already calls `os.ReadFile` inside `IsRateLimited`, and `rateLimitResetFromLog(sess.LogFile)` immediately calls `os.ReadFile` on the same path. For a dead worker the file won't change between the two reads, but it does double the I/O and leaves a narrow window for a cleanup race (if a log-rotation or temp-cleanup job deletes the file between calls, `rateLimitResetFromLog` silently returns `nil` while `isRateLimited` already returned `true`). A single read that feeds both `OutputContainsRateLimit` and `ParseRateLimitReset` would eliminate both concerns.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ratelimit): detect Codex/OpenAI usag..."](https://github.com/befeast/maestro/commit/9913a5b5eba12adb76f33987e3453eba161fe5f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34665081)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->