### PR TITLE
fix(orchestrator): run-loop hardening — config-reload signal, merged/closed spawn guard, --once slot cap

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -740,6 +740,13 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 	fmt.Printf("Session prefix: %s\n", cfg.SessionPrefix)
 	fmt.Printf("State file:     %s\n", state.StatePath(cfg.StateDir))
 	fmt.Printf("Max parallel:   %d\n", cfg.MaxParallel)
+	if s.RestartRequired {
+		reason := s.RestartRequiredReason
+		if reason == "" {
+			reason = "model/routing config changed"
+		}
+		fmt.Printf("Restart req.:   yes — %s (run `systemctl --user restart` to apply)\n", reason)
+	}
 	showOutcomeStatus(cfg, s)
 	showSupervisorPolicy(cfg)
 	if len(cfg.MaxConcurrentByState) > 0 {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -87,6 +87,14 @@ type Orchestrator struct {
 	// Config hot-reload channel (nil = disabled, safe in select)
 	configReloadCh <-chan *config.Config
 
+	// Restart-required signal. Some config fields (model.default, routing.*) cannot
+	// be hot-applied because the backend router is built once at startup. When such a
+	// field changes during a config reload we do not apply it; instead we raise this
+	// persistent flag so a long-running daemon surfaces "restart required" in
+	// `maestro status` and the Fleet API instead of silently ignoring the change.
+	restartRequired       bool
+	restartRequiredReason string
+
 	// Testing hooks for autoMergePRs / mergeReadyPR
 	ghPRCIStatusFn              func(prNumber int) (string, error)
 	ghPRGreptileApprovedFn      func(prNumber int) (approved bool, pending bool, err error)
@@ -1126,8 +1134,22 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 	if newCfg.Repo != old.Repo {
 		log.Printf("[orch] config reload: repo changed (%s → %s) — requires restart", old.Repo, newCfg.Repo)
 	}
+
+	// model.default and routing.* select the backend router, which is constructed
+	// once at startup and is not safe to re-init mid-flight. Detect a change against
+	// the live (startup) config, do NOT apply it, and raise a persistent
+	// restart-required signal so the operator sees it in `maestro status` / Fleet API
+	// rather than only a one-time log line. Keep o.cfg.Model/Routing unchanged so the
+	// warning keeps firing on every subsequent reload while the config still differs.
 	if newCfg.Model.Default != old.Model.Default {
-		log.Printf("[orch] config reload: model.default changed (%s → %s) — requires restart", old.Model.Default, newCfg.Model.Default)
+		o.markRestartRequired(fmt.Sprintf("model.default changed (%s → %s)", old.Model.Default, newCfg.Model.Default))
+		log.Printf("[orch] config reload: model.default changed (%s → %s) — requires restart (not applied)", old.Model.Default, newCfg.Model.Default)
+	}
+	if newCfg.Routing != old.Routing {
+		o.markRestartRequired(fmt.Sprintf("routing.* changed (router_model %s → %s, mode %s → %s)",
+			old.Routing.RouterModel, newCfg.Routing.RouterModel, old.Routing.Mode, newCfg.Routing.Mode))
+		log.Printf("[orch] config reload: routing.* changed (router_model %s → %s, mode %s → %s) — requires restart (not applied)",
+			old.Routing.RouterModel, newCfg.Routing.RouterModel, old.Routing.Mode, newCfg.Routing.Mode)
 	}
 
 	// Hot-reloadable fields
@@ -1232,6 +1254,39 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 		return
 	}
 	log.Printf("[orch] config reloaded — changed: %s", strings.Join(changed, ", "))
+}
+
+// markRestartRequired records a persistent restart-required signal both in memory
+// (so the running daemon keeps emitting the warning) and in the on-disk state file
+// (so a separate `maestro status` / Fleet API process can surface it without
+// grepping journals). Multiple reasons in a single reload are joined.
+func (o *Orchestrator) markRestartRequired(reason string) {
+	o.restartRequired = true
+	if o.restartRequiredReason == "" {
+		o.restartRequiredReason = reason
+	} else if !strings.Contains(o.restartRequiredReason, reason) {
+		o.restartRequiredReason = o.restartRequiredReason + "; " + reason
+	}
+	o.persistRestartRequired()
+}
+
+// persistRestartRequired mirrors the in-memory restart-required signal into the
+// state file. It is best-effort: a load/save failure is logged but never aborts the
+// reload (the in-memory warning still fires every cycle).
+func (o *Orchestrator) persistRestartRequired() {
+	s, err := state.Load(o.cfg.StateDir)
+	if err != nil {
+		log.Printf("[orch] warn: could not load state to persist restart-required signal: %v", err)
+		return
+	}
+	if s.RestartRequired == o.restartRequired && s.RestartRequiredReason == o.restartRequiredReason {
+		return
+	}
+	s.RestartRequired = o.restartRequired
+	s.RestartRequiredReason = o.restartRequiredReason
+	if err := state.Save(o.cfg.StateDir, s); err != nil {
+		log.Printf("[orch] warn: could not save restart-required signal to state: %v", err)
+	}
 }
 
 func strSliceEqual(a, b []string) bool {
@@ -3024,16 +3079,32 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 				continue
 			}
 		}
-		if s.IssueDone(issue.Number) {
-			closed, err := o.isIssueClosed(issue.Number)
-			if err != nil {
-				log.Printf("[orch] warn: could not verify closed issue #%d before dispatch: %v", issue.Number, err)
-			} else if closed {
-				log.Printf("[orch] skipping issue #%d: already closed with completed session", issue.Number)
-				o.syncProject(issue.Number, github.ProjectStatusDone)
-				continue
-			}
+
+		// Pre-spawn guard (issue #456): never start a new worker for an issue that is
+		// already closed or whose linked PR already merged, even when a stale
+		// maestro-ready label is still present and even for supervisor-selected repair
+		// spawns. This is an independent safety check on top of the supervisor's ready-
+		// label management: with the supervisor down, nothing strips the label, so the
+		// run loop must refuse already-finished work on its own. Errors are logged and
+		// treated as "not finished" so a transient GitHub failure cannot block dispatch.
+		if closed, err := o.isIssueClosed(issue.Number); err != nil {
+			log.Printf("[orch] warn: could not verify closed state for issue #%d before dispatch: %v", issue.Number, err)
+		} else if closed {
+			log.Printf("[orch] skipping issue #%d: already closed (stale ready label)", issue.Number)
+			o.syncProject(issue.Number, github.ProjectStatusDone)
+			continue
 		}
+		if merged, err := o.hasMergedPRForIssue(issue.Number); err != nil {
+			log.Printf("[orch] warn: could not verify merged PR for issue #%d before dispatch: %v", issue.Number, err)
+		} else if merged {
+			log.Printf("[orch] skipping issue #%d: has merged PR (stale ready label)", issue.Number)
+			o.syncProject(issue.Number, github.ProjectStatusDone)
+			continue
+		}
+
+		// NOTE: the closed/merged checks above (issue #456 pre-spawn guard) already
+		// cover the previous s.IssueDone() closed-issue case for every candidate, so a
+		// separate done-session closed-check here would be a redundant GitHub call.
 
 		// Skip mission parent issues — they are decomposed, not dispatched directly
 		if s.IsMissionParent(issue.Number) {
@@ -3086,7 +3157,20 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		// No available slots — sync remaining eligible issues as backlog/todo.
 		// This check is intentionally before hasOpenPRForIssue to avoid making
 		// a GitHub API call per backlogged issue when all slots are full.
+		//
+		// Two independent caps (issue #457):
+		//  1. `started >= slots` — never start more than the budget computed for this
+		//     dispatch pass (after retry reservations were subtracted).
+		//  2. `liveActive >= MaxParallel` — a hard backstop recomputed from live state
+		//     each iteration so that retry respawns (which already turned dead sessions
+		//     into running ones earlier in the cycle) plus fresh dispatch can never
+		//     exceed max_parallel, even if the precomputed `slots` budget was stale.
 		if started >= slots {
+			o.syncProject(issue.Number, github.ProjectStatusTodo)
+			continue
+		}
+		if liveActive := len(s.ActiveSessions()); o.cfg.MaxParallel > 0 && liveActive >= o.cfg.MaxParallel {
+			log.Printf("[orch] dispatch cap: %d active >= max_parallel %d — queueing issue #%d", liveActive, o.cfg.MaxParallel, issue.Number)
 			o.syncProject(issue.Number, github.ProjectStatusTodo)
 			continue
 		}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5081,9 +5081,10 @@ func TestStartNewWorkers_DispatchesWhenBlockersClosed(t *testing.T) {
 	}
 
 	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
-	// Blocker #10 is closed
+	// Blocker #10 is closed; the dispatched issue #42 is open (the pre-spawn guard
+	// from issue #456 also calls isIssueClosed on the candidate itself).
 	o.isIssueClosedFn = func(number int) (bool, error) {
-		return true, nil
+		return number == 10, nil
 	}
 
 	s := state.NewState()
@@ -7149,5 +7150,220 @@ func TestAutoMergePRs_CIFailure_NoGreptileFeedback_FeedbackEmpty(t *testing.T) {
 	sess := s.Sessions["slot-0"]
 	if sess.PreviousAttemptFeedback != "" {
 		t.Errorf("PreviousAttemptFeedback should be empty when no Greptile feedback, got %q", sess.PreviousAttemptFeedback)
+	}
+}
+
+// --- issue #455: restart-required signal for model.default / routing.* reloads ---
+
+// TestReloadConfig_ModelDefaultChangeSetsRestartRequired verifies that changing
+// model.default during a reload does NOT hot-apply (the backend router is built at
+// startup) but instead raises a persistent restart-required signal that is mirrored
+// into the state file so `maestro status` / Fleet API can surface it.
+func TestReloadConfig_ModelDefaultChangeSetsRestartRequired(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:     "owner/repo",
+		StateDir: dir,
+		Model: config.ModelConfig{
+			Default:  "codex",
+			Backends: map[string]config.BackendDef{"codex": {Cmd: "codex"}, "claude": {Cmd: "claude"}},
+		},
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: notify.NewWithToken("", "", "", ""),
+		router:   router.New(cfg),
+	}
+
+	newCfg := &config.Config{
+		Repo:     "owner/repo",
+		StateDir: dir,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"codex": {Cmd: "codex"}, "claude": {Cmd: "claude"}},
+		},
+	}
+
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	o.reloadConfig(newCfg, &ticker)
+
+	if !o.restartRequired {
+		t.Fatal("restartRequired not set after model.default change")
+	}
+	if !strings.Contains(o.restartRequiredReason, "model.default") {
+		t.Fatalf("restartRequiredReason = %q, want it to mention model.default", o.restartRequiredReason)
+	}
+	// model.default must NOT be hot-applied (restart-required, not live-applied)
+	if o.cfg.Model.Default != "codex" {
+		t.Fatalf("model.default = %q, want unchanged %q (restart required, not applied)", o.cfg.Model.Default, "codex")
+	}
+
+	// The signal must be persisted to the state file so a separate `maestro status`
+	// process observes it.
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if !st.RestartRequired {
+		t.Fatal("state.RestartRequired not persisted after model.default change")
+	}
+	if !strings.Contains(st.RestartRequiredReason, "model.default") {
+		t.Fatalf("state.RestartRequiredReason = %q, want it to mention model.default", st.RestartRequiredReason)
+	}
+
+	// A subsequent reload that still differs must keep the signal set (not a one-time log).
+	o.reloadConfig(newCfg, &ticker)
+	if !o.restartRequired {
+		t.Fatal("restartRequired cleared on a second reload while config still differs")
+	}
+}
+
+// TestReloadConfig_RoutingChangeSetsRestartRequired verifies that routing.* changes
+// (previously a fully silent no-op) now raise the restart-required signal too.
+func TestReloadConfig_RoutingChangeSetsRestartRequired(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:     "owner/repo",
+		StateDir: dir,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}, "codex": {Cmd: "codex"}},
+		},
+		Routing: config.RoutingConfig{Mode: "manual", RouterModel: "codex", RouterModelName: "x"},
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: notify.NewWithToken("", "", "", ""),
+		router:   router.New(cfg),
+	}
+
+	newCfg := &config.Config{
+		Repo:     "owner/repo",
+		StateDir: dir,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}, "codex": {Cmd: "codex"}},
+		},
+		Routing: config.RoutingConfig{Mode: "manual", RouterModel: "claude", RouterModelName: "x"},
+	}
+
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	o.reloadConfig(newCfg, &ticker)
+
+	if !o.restartRequired {
+		t.Fatal("restartRequired not set after routing.router_model change")
+	}
+	if !strings.Contains(o.restartRequiredReason, "routing") {
+		t.Fatalf("restartRequiredReason = %q, want it to mention routing", o.restartRequiredReason)
+	}
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if !st.RestartRequired || !strings.Contains(st.RestartRequiredReason, "routing") {
+		t.Fatalf("state restart-required not persisted for routing change: %+v", st)
+	}
+}
+
+// --- issue #456: pre-spawn guard for already-merged / closed issues ---
+
+// TestStartNewWorkers_SkipsIssueWithMergedPRDespiteStaleReadyLabel verifies that an
+// issue whose linked PR already merged is NOT dispatched even when it still carries a
+// stale maestro-ready label and the supervisor (which normally strips the label) is down.
+func TestStartNewWorkers_SkipsIssueWithMergedPRDespiteStaleReadyLabel(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	cfg.IssueLabels = []string{"maestro-ready"}
+	issues := []github.Issue{
+		makeIssue(248, "already merged, stale ready", "maestro-ready"),
+		makeIssue(247, "genuinely ready", "maestro-ready"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.hasMergedPRForIssueFn = func(issueNumber int) (bool, error) {
+		return issueNumber == 248, nil
+	}
+
+	var logs strings.Builder
+	prev := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(prev)
+
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	for _, n := range *started {
+		if n == 248 {
+			t.Fatalf("started worker for already-merged issue #248; started=%v", *started)
+		}
+	}
+	if len(*started) != 1 || (*started)[0] != 247 {
+		t.Fatalf("started = %v, want only [247]", *started)
+	}
+	if !strings.Contains(logs.String(), "skipping issue #248: has merged PR") {
+		t.Fatalf("logs missing merged-PR skip reason:\n%s", logs.String())
+	}
+}
+
+// TestStartNewWorkers_SkipsClosedIssueDespiteStaleReadyLabel verifies the same guard
+// for a closed issue that still carries a stale ready label and has no session at all.
+func TestStartNewWorkers_SkipsClosedIssueDespiteStaleReadyLabel(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	cfg.IssueLabels = []string{"maestro-ready"}
+	issues := []github.Issue{
+		makeIssue(249, "closed, stale ready", "maestro-ready"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.isIssueClosedFn = func(issueNumber int) (bool, error) {
+		return issueNumber == 249, nil
+	}
+
+	s := state.NewState() // no session for #249 — guard must not depend on session state
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 0 {
+		t.Fatalf("started = %v, want none for closed issue with stale ready label", *started)
+	}
+}
+
+// --- issue #457: --once dispatch must respect max_parallel ---
+
+// TestStartNewWorkers_RespectsMaxParallelHardCap verifies a single dispatch pass never
+// starts more workers than max_parallel even when more ready issues than slots exist.
+func TestStartNewWorkers_RespectsMaxParallelHardCap(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	cfg.MaxParallel = 3
+	issues := []github.Issue{
+		makeIssue(255, "ready a"),
+		makeIssue(254, "ready b"),
+		makeIssue(250, "ready c"),
+		makeIssue(249, "ready d"),
+		makeIssue(248, "ready e"),
+		makeIssue(247, "ready f"),
+	}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+
+	// availableSlots(cfg, s, active=0) == 3
+	slots := availableSlots(cfg, s, len(s.ActiveSessions()))
+	if slots != 3 {
+		t.Fatalf("precondition: availableSlots = %d, want 3", slots)
+	}
+
+	o.startNewWorkers(s, slots)
+
+	if len(*started) > cfg.MaxParallel {
+		t.Fatalf("started %d workers (%v), want at most max_parallel=%d", len(*started), *started, cfg.MaxParallel)
+	}
+	if len(*started) != 3 {
+		t.Fatalf("started %d workers (%v), want exactly 3", len(*started), *started)
+	}
+	if len(s.ActiveSessions()) > cfg.MaxParallel {
+		t.Fatalf("active sessions = %d, want at most max_parallel=%d", len(s.ActiveSessions()), cfg.MaxParallel)
 	}
 }

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -310,6 +310,12 @@ type fleetProjectState struct {
 	StateDir        string                `json:"state_dir,omitempty"`
 	MaxParallel     int                   `json:"max_parallel"`
 	ReadOnly        bool                  `json:"read_only"`
+
+	// RestartRequired/RestartRequiredReason mirror the orchestrator's restart-required
+	// signal (set when model.default / routing.* changed but cannot be hot-applied).
+	RestartRequired       bool   `json:"restart_required,omitempty"`
+	RestartRequiredReason string `json:"restart_required_reason,omitempty"`
+
 	OperatorState   fleetOperatorState    `json:"operator_state"`
 	Outcome         outcome.Status        `json:"outcome"`
 	Summary         map[string]int        `json:"summary"`
@@ -1676,6 +1682,8 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 		return item, nil
 	}
 	item.Freshness = fleetProjectFreshnessForState(cfg.StateDir, st, now)
+	item.RestartRequired = st.RestartRequired
+	item.RestartRequiredReason = st.RestartRequiredReason
 	projectState := buildStateResponse(cfg, st)
 	item.Summary = projectState.Summary
 	item.Outcome = projectState.Outcome

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -624,6 +624,13 @@ type State struct {
 	NextSlot            int                        `json:"next_slot"`
 	LastMergeAt         time.Time                  `json:"last_merge_at,omitempty"`
 
+	// RestartRequired is set by the running orchestrator when a config field that
+	// cannot be hot-applied (model.default, routing.*) changes during a reload. It is
+	// surfaced by `maestro status` and the Fleet API so an operator sees the pending
+	// restart without grepping the daemon journal. RestartRequiredReason explains why.
+	RestartRequired       bool   `json:"restart_required,omitempty"`
+	RestartRequiredReason string `json:"restart_required_reason,omitempty"`
+
 	loadedHash  string
 	loadedState *State
 }


### PR DESCRIPTION
Fixes #455. Fixes #456. Fixes #457.

These three issues all touch `internal/orchestrator/orchestrator.go` and the run loop, so they are fixed together to avoid conflicts. Each fix is independent and minimal.

## #455 — live model.default / routing.* change is a silent no-op
The backend router is constructed once at startup and is not safe to re-init mid-flight, so `model.default` / `routing.*` cannot be hot-applied. Previously `model.default` emitted a single startup-style log line (easy to miss on a multi-day daemon) and `routing.*` was a fully silent no-op. Now `reloadConfig` detects a change to `model.default` **or** any `routing.*` field, does **not** apply it, and raises a persistent restart-required signal (`Orchestrator.restartRequired` + a reason string). The warning keeps firing on every subsequent reload while the live config still differs. The signal is mirrored into the state file (`state.State.RestartRequired` / `RestartRequiredReason`) so a separate `maestro status` process and the Fleet API surface `restart required: model/routing changed (codex→claude)` without grepping journals. `routing.*` is no longer dropped silently.

## #456 — run loop re-spawns workers for already-merged/closed issues with a stale ready label
Added a pre-spawn guard in `startNewWorkers`: before starting a new worker for a candidate issue, it now skips the issue (with a one-line log) if `isIssueClosed(n)` **or** `hasMergedPRForIssue(n)` is true — independent of whether `maestro-ready` is still present and independent of the supervisor-owned-ready / dynamic-wave path. This means a stale ready label left on already-finished work (e.g. when the label-stripping supervisor is down) no longer causes duplicate / no-op workers. The guard subsumes the narrower done-session closed-check that ran before, so no extra GitHub calls are added for closed issues. GitHub errors are logged and treated as "not finished" so a transient failure cannot block dispatch.

## #457 — `maestro run --once` can exceed max_parallel
The dispatch loop now enforces `max_parallel` with two independent caps: the existing per-pass `started >= slots` budget, plus a hard `liveActive >= max_parallel` backstop recomputed from live state on each iteration. Because retry respawns earlier in the cycle turn dead sessions into running ones, the backstop guarantees that retry respawns plus fresh dispatch in a single cycle can never exceed `max_parallel`, even if the precomputed `slots` budget was stale.

## Tests (one per fix, in `internal/orchestrator/orchestrator_test.go`)
- #455: `TestReloadConfig_ModelDefaultChangeSetsRestartRequired` and `TestReloadConfig_RoutingChangeSetsRestartRequired` — a reload changing `model.default` / `routing.*` sets `restartRequired` with a reason, leaves the field unapplied, persists the signal to state, and keeps it set on a repeated reload.
- #456: `TestStartNewWorkers_SkipsIssueWithMergedPRDespiteStaleReadyLabel` and `TestStartNewWorkers_SkipsClosedIssueDespiteStaleReadyLabel` — an issue reported merged (or closed) with a stale ready label is not spawned, using the injectable `hasMergedPRForIssueFn` / `isIssueClosedFn`.
- #457: `TestStartNewWorkers_RespectsMaxParallelHardCap` — with `MaxParallel=3` and 6 ready issues, one dispatch cycle starts exactly 3 workers.

All tests green on `workshop` (Linux): `go build`, `go vet`, and `go test ./...` pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles three independent run-loop hardening fixes for the orchestrator: surfacing a persistent restart-required signal when non-hot-reloadable config fields (`model.default`, `routing.*`) change, adding a pre-spawn guard that skips stale-ready-label issues whose PR has already merged or whose issue is already closed, and adding a live-active hard cap to prevent `--once` dispatch from exceeding `max_parallel`.

- **#455**: `reloadConfig` now detects `model.default`/`routing.*` changes, refuses to apply them, and persists `restart_required` + a reason into the state file so `maestro status` and the Fleet API surface it without grepping journals.
- **#456**: `startNewWorkers` now calls `isIssueClosed` and `hasMergedPRForIssue` for every candidate issue before spawning, guarding against stale `maestro-ready` labels left by a down supervisor.
- **#457**: A secondary `liveActive >= max_parallel` backstop prevents retry respawns from making the precomputed budget stale within one dispatch cycle.

<h3>Confidence Score: 3/5</h3>

Two defects in the new orchestrator code affect long-running daemons and should be addressed before merge.

The restart-required signal written to the state file can never be cleared — there is no clear-on-startup or clear-on-revert path — so maestro status and the Fleet API permanently report a restart that has already been performed. The pre-spawn guard also places two live GitHub API calls per backlogged candidate before the slot cap, contrary to the established pattern documented in the same function.

internal/orchestrator/orchestrator.go — both the pre-spawn guard placement and the markRestartRequired/persistRestartRequired lifecycle need attention before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Three targeted run-loop fixes; two issues found: pre-spawn guard places GitHub API calls before the slot cap, and the restart-required signal in the state file is never cleared after restart or config revert. |
| internal/orchestrator/orchestrator_test.go | Adds six targeted tests for all three fixes; correctly scopes isIssueClosedFn to the blocker in the existing blocker test. |
| internal/state/state.go | Adds RestartRequired and RestartRequiredReason fields to State struct with omitempty JSON tags. |
| internal/server/fleet.go | Propagates RestartRequired/RestartRequiredReason from loaded state into the Fleet API snapshot response. |
| cmd/maestro/main.go | Adds a Restart req. line to showProjectStatus output when the state file signals a restart is needed. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:3090-3103
**Pre-spawn guard makes 2 GitHub API calls per backlogged issue**

`isIssueClosed` and `hasMergedPRForIssue` are now called unconditionally for every candidate issue — including all backlogged ones when no slots are available. This directly contradicts the established pattern a few lines below (lines 3157–3160), where the comment explicitly explains that `hasOpenPRForIssue` is placed *after* the `started >= slots` check to avoid one API call per backlogged issue when all slots are full. With the new guards placed before the slot cap, a deployment with 50 backlogged issues and 0 free slots will make 100 extra GitHub API calls every poll cycle — a regression that can trigger rate limiting, whose errors are then silently treated as "not finished", causing misleading log noise and potentially masking real dispatch failures.

### Issue 2 of 2
internal/orchestrator/orchestrator.go:1263-1271
**`restartRequired` signal in the state file is never cleared**

`markRestartRequired` (and `persistRestartRequired`) only ever write `true` into the state file. There is no code path that resets `s.RestartRequired = false` and flushes it. After the operator performs the requested restart, the new daemon process starts with `o.restartRequired = false`, but `persistRestartRequired` is only called from `markRestartRequired` — never on startup and never when a subsequent reload finds `newCfg == old`. The state file therefore retains `restart_required: true` indefinitely, so both `maestro status` and the Fleet API keep reporting a pending restart that has already been performed. The same staleness occurs if the operator reverts the config change before restarting: the comparison `newCfg.Model.Default == old.Model.Default` is then true, `markRestartRequired` is never called, and the signal in the state file is never cleared.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): run-loop hardening — ..."](https://github.com/befeast/maestro/commit/4c5a08f7f48d455c1fabbd568ed1d06a8f93a5df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34665377)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->