### PR TITLE
fix(orchestrator): handle provider rate-limit in reconcile path

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1397,6 +1397,33 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 			}
 		}
 
+		// Before marking the session dead, check whether the worker died because
+		// the provider hit a rate / usage limit. Without this, the reconcile path
+		// races the main exit handler at the start of every cycle and burns the
+		// per-issue retry budget on what is really a transient backend block (#466).
+		if o.isRateLimited(sess.LogFile) {
+			now := time.Now().UTC()
+			resetAt := o.rateLimitResetFromLog(sess.LogFile)
+			o.recordProviderLimit(s, slotName, sess, "log_rate_limit_reconcile", resetAt, now)
+			oldPID := sess.PID
+			oldTmux := tmuxName
+			sess.PID = 0
+			sess.TmuxSession = ""
+			sess.FinishedAt = &now
+			sess.LastNotifiedStatus = "rate_limit"
+			sess.Status = state.StatusDead
+			reconciled = true
+			resetStr := "unknown"
+			if resetAt != nil {
+				resetStr = resetAt.Format(time.RFC3339)
+			}
+			log.Printf("[orch] reconcile: %s running->dead via provider rate limit on backend=%s reset=%s (%s); pid=%d tmux=%q",
+				slotName, sess.Backend, resetStr, strings.Join(reasons, ", "), oldPID, oldTmux)
+			o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) hit provider limit on %s; reset=%s",
+				slotName, sess.IssueNumber, sess.IssueTitle, sess.Backend, resetStr)
+			continue
+		}
+
 		oldPID := sess.PID
 		oldTmux := tmuxName
 		sess.Status = state.StatusDead

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -384,6 +384,70 @@ func TestReconcileRunningSessions_DeadPIDGetsMarkedDead(t *testing.T) {
 	}
 }
 
+// TestReconcileRunningSessions_RateLimitedDeadWorker_DoesNotBurnRetryBudget
+// guards #466: when reconcile observes a dead worker whose log carries a
+// provider rate-limit signature, it must record the provider limit and skip
+// counting the session as a failed attempt for the issue, so the per-issue
+// retry budget is preserved through transient backend blocks.
+func TestReconcileRunningSessions_RateLimitedDeadWorker_DoesNotBurnRetryBudget(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["sup-77"] = &state.Session{
+		IssueNumber: 353,
+		IssueTitle:  "P0: detect outcome drift",
+		Status:      state.StatusRunning,
+		PID:         424242,
+		TmuxSession: "maestro-sup-77",
+		Branch:      "feat/sup-77-353-detect-outcome-drift",
+		Backend:     "codex",
+		StartedAt:   time.Now().Add(-2 * time.Minute),
+		LogFile:     "/tmp/sup-77-rl.log",
+	}
+
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			Model: config.ModelConfig{
+				Default:  "codex",
+				Backends: map[string]config.BackendDef{"codex": {Cmd: "codex"}},
+			},
+		},
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:     func(logFile string) bool { return true },
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["sup-77"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if !sess.RateLimitHit {
+		t.Fatal("RateLimitHit should be true so retry budget is preserved")
+	}
+	if sess.LastNotifiedStatus != "rate_limit" {
+		t.Fatalf("last_notified_status = %q, want %q", sess.LastNotifiedStatus, "rate_limit")
+	}
+	if sess.ProviderLimitBackend != "codex" {
+		t.Fatalf("provider_limit_backend = %q, want codex", sess.ProviderLimitBackend)
+	}
+	if failed := s.FailedAttemptsForIssue(353); failed != 0 {
+		t.Fatalf("FailedAttemptsForIssue(353) = %d, want 0 — rate-limited dead session must not burn retry budget", failed)
+	}
+	health, ok := s.BackendHealth["codex"]
+	if !ok {
+		t.Fatal("BackendHealth[codex] should be recorded by recordProviderLimit")
+	}
+	if health.State != state.BackendHealthCooldown {
+		t.Fatalf("BackendHealth[codex].State = %q, want cooldown", health.State)
+	}
+}
+
 func TestReconcileRunningSessions_MissingTmuxGetsMarkedDead(t *testing.T) {
 	s := state.NewState()
 	s.Sessions["pan-2"] = &state.Session{

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1777,11 +1777,16 @@ func (s *State) IssueDone(issueNum int) bool {
 
 // FailedAttemptsForIssue counts sessions for the given issue that ended
 // without producing a PR (dead, failed, or retry_exhausted).
+//
+// Sessions marked as rate-limited (RateLimitHit) are NOT counted as failed
+// attempts: a transient backend block must not consume the per-issue retry
+// budget. See #432 / #458 / #466.
 func (s *State) FailedAttemptsForIssue(issueNum int) int {
 	count := 0
 	for _, sess := range s.Sessions {
 		if sess.IssueNumber == issueNum && sess.PRNumber == 0 &&
-			(sess.Status == StatusDead || sess.Status == StatusFailed || sess.Status == StatusRetryExhausted) {
+			(sess.Status == StatusDead || sess.Status == StatusFailed || sess.Status == StatusRetryExhausted) &&
+			!sess.RateLimitHit {
 			count++
 		}
 	}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -779,6 +779,7 @@ func TestFailedAttemptsForIssue(t *testing.T) {
 	s.Sessions["slot-6"] = &Session{IssueNumber: 99, Status: StatusDead, PRNumber: 0}                    // different issue
 	s.Sessions["slot-7"] = &Session{IssueNumber: 42, Status: StatusRunning, PRNumber: 0, StartedAt: now} // running — not counted
 	s.Sessions["slot-8"] = &Session{IssueNumber: 42, Status: StatusConflictFailed, PRNumber: 0}          // conflict — not counted
+	s.Sessions["slot-9"] = &Session{IssueNumber: 42, Status: StatusDead, PRNumber: 0, RateLimitHit: true}    // rate-limited — not counted (#466)
 
 	if got := s.FailedAttemptsForIssue(42); got != 3 {
 		t.Errorf("FailedAttemptsForIssue(42) = %d, want 3", got)


### PR DESCRIPTION
Refs #466

`reconcileRunningSessions` runs at the start of every cycle and marks dead-PID sessions `StatusDead` before the main exit handler can inspect their logs. Codex usage-limit kills hit in ~5s while the supervisor polls every 1–2 minutes, so in practice reconcile always wins and the rate-limit detection added in #432/#458/#464 is bypassed.

This PR:

- adds an `isRateLimited(sess.LogFile)` check inside `reconcileRunningSessions` before the raw `StatusDead` transition; on a hit it calls `recordProviderLimit` (so `BackendHealth[backend] = cooldown` with `ParseRateLimitReset` time) and flags the session with `RateLimitHit` + `LastNotifiedStatus = "rate_limit"`.
- excludes `RateLimitHit` sessions from `FailedAttemptsForIssue` so a transient backend block never consumes the per-issue retry budget, regardless of which path (reconcile vs main exit handler) observed the dead PID.

Tests:
- `TestReconcileRunningSessions_RateLimitedDeadWorker_DoesNotBurnRetryBudget` — reproduces the timing window: dead PID + missing tmux + rate-limit log → asserts `StatusDead` with `RateLimitHit=true`, `BackendHealth[codex]=cooldown`, `FailedAttemptsForIssue=0`.
- `TestFailedAttemptsForIssue` — extended with a rate-limited dead session that must not be counted.

Live evidence on workshop today (`v0.1.1-0.20260529221552-4b1dca8e3202`):
```
[orch] reconcile: sup-77 running->dead (pid 384725 dead, tmux session "maestro-sup-77" missing)
...
[orch] starting worker for issue #353 ... (backend=codex ...)
```
The codex usage-limit signature was sitting in `logs/sup-77.log` ("You've hit your usage limit ... try again at May 30th, 2026 8:13 PM"), but reconcile got there first.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a timing race where `reconcileRunningSessions` would mark a rate-limited dead worker as `StatusDead` before the main exit handler could detect the rate-limit signal, silently burning the per-issue retry budget on what is really a transient backend block.

- **`reconcileRunningSessions`** now calls `isRateLimited` / `recordProviderLimit` before the raw `StatusDead` transition, setting `RateLimitHit=true` and placing the backend in cooldown — mirroring the detection logic in the main exit handler.
- **`FailedAttemptsForIssue`** is updated to exclude sessions with `RateLimitHit=true`, so rate-limited dead sessions never consume the per-issue retry budget regardless of which code path observed the dead PID.
- Two new tests cover the core scenario: a dead-PID worker whose log carries a rate-limit signature must not count against the retry budget, and `BackendHealth` must enter cooldown.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core bug fix is correct and well-tested, with one behavioural asymmetry worth a second look.

The retry-budget fix is correct and well-tested. The reconcile branch omits selectProviderLimitFallback, meaning users with a fallback backend configured lose the immediate same-cycle failover behavior — rate-limited sessions always wait one full orchestration cycle before being retried on a fallback.

internal/orchestrator/orchestrator.go — the new rate-limit block in reconcileRunningSessions should be reviewed for whether the missing fallback-selection step is intentional.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds rate-limit detection in reconcileRunningSessions before the StatusDead transition; correctly calls recordProviderLimit and sets RateLimitHit, but omits selectProviderLimitFallback, so the immediate fallback retry from the main exit handler is not replicated. |
| internal/orchestrator/orchestrator_test.go | Adds TestReconcileRunningSessions_RateLimitedDeadWorker_DoesNotBurnRetryBudget covering the core timing-window scenario; assertions are thorough (status, RateLimitHit, ProviderLimitBackend, FailedAttemptsForIssue, BackendHealth). |
| internal/state/state.go | FailedAttemptsForIssue now excludes sessions with RateLimitHit=true; the change is minimal, correctly placed, and well-commented with issue references. |
| internal/state/state_test.go | Adds slot-9 (RateLimitHit=true, StatusDead) to TestFailedAttemptsForIssue to confirm the exclusion; expected count remains 3, correctly unchanged. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:1404-1425
**Reconcile path skips immediate fallback selection**

When the main exit handler detects a rate-limited worker it calls `selectProviderLimitFallback` and immediately starts a new worker on the fallback backend (same cycle). The new reconcile branch records the limit and marks the session `StatusDead`, but never invokes `selectProviderLimitFallback`. Since the PR itself notes that reconcile "always wins" this race, the automatic same-cycle fallback retry introduced in earlier fixes is effectively dead code — a rate-limited session will always sit dead until the next `startNewWorkers` call one full cycle (1–2 minutes) later.

This may be intentional (simpler path, next cycle handles it), but it is a behavioural asymmetry worth making explicit: if a fallback backend is configured, users no longer get immediate failover on rate limits.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): handle provider rate-..."](https://github.com/befeast/maestro/commit/9996a9949bcd1cde8779fa4d62112847bcdbfa08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34671503)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->