### PR TITLE
fix(github): ignore #N inside code blocks when linking PRs to issues

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -263,7 +263,63 @@ func prReferencesIssue(pr PR, issueNumber int) bool {
 	if issueNumber <= 0 {
 		return false
 	}
-	return issueRefRegexp(issueNumber).MatchString(pr.Title + "\n" + pr.Body)
+	// Match the title verbatim, but strip Markdown code (fenced blocks and
+	// inline spans) from the body first. PR bodies routinely paste log lines,
+	// command output, and tracebacks that mention OTHER issue numbers
+	// (e.g. "[orch] starting worker for issue #353"); those incidental
+	// mentions must not link the PR to that issue. See #468.
+	return issueRefRegexp(issueNumber).MatchString(pr.Title + "\n" + stripCodeForRefMatch(pr.Body))
+}
+
+var (
+	// A fence line is 3+ backticks or 3+ tildes, optionally indented, with an
+	// optional info string (only valid on the OPENING fence).
+	fenceLineRegexp = regexp.MustCompile("^\\s*(`{3,}|~{3,})\\s*(\\S.*)?$")
+	// Inline code spans: one or more backticks, content without a backtick or
+	// newline, then the same-or-more backticks. Approximate but sufficient for
+	// stripping `#123`-style mentions out of prose.
+	inlineCodeRegexp = regexp.MustCompile("`+[^`\\n]*`+")
+)
+
+// stripCodeForRefMatch removes fenced code blocks and inline code spans from
+// Markdown text so issue references buried in pasted logs/output do not produce
+// false positives in prReferencesIssue. Prose references such as "Refs #123"
+// or "Closes #123" (the Maestro worker convention) are preserved.
+func stripCodeForRefMatch(body string) string {
+	lines := strings.Split(body, "\n")
+	out := make([]string, 0, len(lines))
+	inFence := false
+	var fenceChar byte
+	var fenceLen int
+	for _, line := range lines {
+		if m := fenceLineRegexp.FindStringSubmatch(line); m != nil {
+			marker := m[1]
+			info := strings.TrimSpace(m[2])
+			ch := marker[0]
+			n := len(marker)
+			if !inFence {
+				// Opening fence — drop it and start skipping content.
+				inFence = true
+				fenceChar = ch
+				fenceLen = n
+				continue
+			}
+			// Inside a fence: a valid closing fence uses the same character,
+			// is at least as long as the opener, and carries no info string.
+			if ch == fenceChar && n >= fenceLen && info == "" {
+				inFence = false
+				continue
+			}
+			// A fence-looking line that is not a valid closer is fence content.
+			continue
+		}
+		if inFence {
+			continue
+		}
+		out = append(out, line)
+	}
+	cleaned := strings.Join(out, "\n")
+	return inlineCodeRegexp.ReplaceAllString(cleaned, " ")
 }
 
 func parseCheckRuns(out []byte) ([]greptileCheckRun, error) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -63,6 +63,46 @@ func TestParseRESTPullsMapsFields(t *testing.T) {
 	}
 }
 
+func TestPRReferencesIssue_IgnoresCodeAndLogs(t *testing.T) {
+	// #468: a #N mention that lives only inside a fenced code block or inline
+	// code span (pasted logs/output) must NOT link the PR to issue N, while a
+	// prose reference (the Maestro "Refs #N" convention) still must.
+	fencedBody := "Refs #466\n\n" +
+		"Live evidence:\n" +
+		"```\n" +
+		"[orch] starting worker for issue #353 ... (backend=codex ...)\n" +
+		"```\n"
+	inlineBody := "Refs #466. Unrelated log token `#353` pasted inline.\n"
+	proseBody := "This PR addresses the drift detector. Refs #353.\n"
+	longFenceBody := "Refs #466\n\n`````markdown\n" +
+		"see issue #353 in the log\n" +
+		"```\n" + // a shorter fence inside the longer fence is content, not a closer
+		"still #353 inside\n" +
+		"`````\n"
+
+	tests := []struct {
+		name  string
+		pr    PR
+		issue int
+		want  bool
+	}{
+		{"fenced #353 does not match", PR{Title: "fix: reconcile rate limit", Body: fencedBody}, 353, false},
+		{"fenced PR still matches its real issue 466", PR{Title: "fix: reconcile rate limit", Body: fencedBody}, 466, true},
+		{"inline-code #353 does not match", PR{Title: "fix", Body: inlineBody}, 353, false},
+		{"prose Refs #353 matches", PR{Title: "fix", Body: proseBody}, 353, true},
+		{"#353 inside a long ````` fence does not match", PR{Title: "fix", Body: longFenceBody}, 353, false},
+		{"title reference still matches", PR{Title: "Fixes #7", Body: ""}, 7, true},
+		{"word-boundary: #7 does not match #70", PR{Title: "Fixes #7", Body: ""}, 70, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := prReferencesIssue(tc.pr, tc.issue); got != tc.want {
+				t.Fatalf("prReferencesIssue(issue=%d) = %v, want %v", tc.issue, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRESTIssueStateClosedAcceptsRESTLowercase(t *testing.T) {
 	for _, state := range []string{"closed", "CLOSED", " Closed "} {
 		if !restIssueStateClosed(state) {


### PR DESCRIPTION
Refs #468

`prReferencesIssue` matched a hash-prefixed number anywhere in the PR title and full body, including inside fenced code blocks and inline code spans. PR bodies routinely paste log lines and command output that mention *other* issue numbers, so an unrelated merged PR could make `HasMergedPRForIssue` / `HasOpenPRForIssue` believe an issue already had a PR — the run-loop then skipped spawning a worker and synced the issue to `Done`, silently suppressing live work.

Observed live on workshop: merged PR 467 pasted a log line containing the digits 353 inside a fenced block; the dogfood loop then logged `skipping issue ...: has merged PR` and synced issue 353 (genuine, unimplemented P0) to Done.

Fix: strip Markdown code (CommonMark variable-length fenced blocks and inline code spans) from the body before matching. Title is matched verbatim. Prose references (the `Refs`/`Closes` worker convention) are preserved, so legitimate links are unaffected.

Test `TestPRReferencesIssue_IgnoresCodeAndLogs` covers: fenced ref (no match), content inside a longer nested fence (no match), inline-code ref (no match), prose Refs (match), title ref (match), and a 7-vs-70 word boundary.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a false-positive in `prReferencesIssue` where `#N` tokens inside fenced code blocks and inline code spans in PR bodies were matched as issue references, causing the run-loop to skip spawning workers and incorrectly sync issues to Done. The fix introduces `stripCodeForRefMatch`, which removes fenced blocks and inline code spans from the body before regex matching, while leaving prose `Refs`/`Closes` references intact.

- `stripCodeForRefMatch` handles CommonMark variable-length fenced blocks (backtick and tilde), nested shorter fences (treated as content, not closers), and inline code spans via a pair of pre-compiled regexps.
- `TestPRReferencesIssue_IgnoresCodeAndLogs` adds seven table-driven cases covering fenced, long-fence, inline-code, prose, title, and word-boundary scenarios.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix correctly strips code blocks from PR bodies before issue-ref matching and the tests cover the documented scenarios well.

The stripping logic is correct for well-formed Markdown, but an unterminated opening fence silently drops every line that follows it — including genuine `Refs #N` prose — which is the opposite of the bug being fixed. This edge case is undocumented and untested.

internal/github/github.go — specifically the unterminated-fence path in stripCodeForRefMatch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds stripCodeForRefMatch to remove fenced blocks and inline code spans from PR bodies before issue-reference matching; logic is correct for well-formed Markdown but an unclosed fence silently drops all subsequent prose. |
| internal/github/github_test.go | Adds TestPRReferencesIssue_IgnoresCodeAndLogs covering fenced, long-fence, inline-code, prose, title, and word-boundary cases; good coverage of the documented fix. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/github/github.go:288-322
**Unterminated fence silently swallows all subsequent prose**

If a PR body contains an unmatched opening fence (e.g., a lone ` ``` ` that was never closed), `inFence` stays `true` and every subsequent line — including genuine `Refs #N` prose — is dropped from `out`. The caller then sees no prose references, so `prReferencesIssue` returns `false` for a real linked issue, effectively inverting the bug being fixed. A test case (and possibly a guard) for this path would make the contract explicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(github): ignore #N inside code block..."](https://github.com/befeast/maestro/commit/c967c4de381d977a1a2e88d07379812d10117dd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34687020)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->