### PR TITLE
P0: detect outcome drift after merge or issue close

### DIFF
--- a/internal/outcome/drift.go
+++ b/internal/outcome/drift.go
@@ -1,0 +1,299 @@
+package outcome
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Drift recommended actions exposed by DetectDrift. They map to supervisor
+// queue mutations and Fleet operator-state controls.
+const (
+	DriftActionNone            = "none"
+	DriftActionCommentPR       = "comment_pr"
+	DriftActionCommentIssue    = "comment_issue"
+	DriftActionReopenIssue     = "reopen_issue"
+	DriftActionLabelIssue      = "label_issue"
+	DriftActionRequestApproval = "request_approval"
+	DriftActionCheckHealth     = "check_outcome_health"
+)
+
+// DriftPolicy controls how Maestro responds when outcome drift is detected
+// after a PR merge or issue close. Mutating actions (reopen, label, comment)
+// require explicit approval unless AutoApprove is set.
+type DriftPolicy struct {
+	CommentPR    bool     `yaml:"comment_pr" json:"comment_pr,omitempty"`
+	CommentIssue bool     `yaml:"comment_issue" json:"comment_issue,omitempty"`
+	ReopenIssue  bool     `yaml:"reopen_issue" json:"reopen_issue,omitempty"`
+	Labels       []string `yaml:"labels" json:"labels,omitempty"`
+	AutoApprove  bool     `yaml:"auto_approve" json:"auto_approve,omitempty"`
+}
+
+// DriftPR identifies a merged pull request that may not have actually
+// delivered the configured runtime outcome.
+type DriftPR struct {
+	Number   int       `json:"number"`
+	Title    string    `json:"title,omitempty"`
+	URL      string    `json:"url,omitempty"`
+	MergedAt time.Time `json:"merged_at,omitempty"`
+}
+
+// DriftIssue identifies a closed issue that may not have actually delivered
+// the configured runtime outcome.
+type DriftIssue struct {
+	Number   int       `json:"number"`
+	Title    string    `json:"title,omitempty"`
+	URL      string    `json:"url,omitempty"`
+	ClosedAt time.Time `json:"closed_at,omitempty"`
+}
+
+// DriftInput collects everything DetectDrift needs to decide whether
+// outcome drift is active for the project.
+type DriftInput struct {
+	Brief        Brief
+	LastMergeAt  time.Time
+	MergedPRs    []DriftPR
+	ClosedIssues []DriftIssue
+	Health       *HealthCheckResult
+	Policy       DriftPolicy
+}
+
+// DriftItem is the active outcome-drift item exposed to Fleet/CLI surfaces.
+// It contains the merged PR, the closed issue, the failing or missing
+// runtime signal, and the recommended next action.
+type DriftItem struct {
+	HealthState       string       `json:"health_state"`
+	Signal            string       `json:"signal,omitempty"`
+	SignalSummary     string       `json:"signal_summary,omitempty"`
+	SignalDetail      string       `json:"signal_detail,omitempty"`
+	HealthCheckedAt   string       `json:"health_checked_at,omitempty"`
+	Goal              string       `json:"goal,omitempty"`
+	Summary           string       `json:"summary"`
+	NextAction        string       `json:"next_action"`
+	RecommendedAction string       `json:"recommended_action,omitempty"`
+	RequiresApproval  bool         `json:"requires_approval,omitempty"`
+	Labels            []string     `json:"labels,omitempty"`
+	MergedPRs         []DriftPR    `json:"merged_prs,omitempty"`
+	ClosedIssues      []DriftIssue `json:"closed_issues,omitempty"`
+}
+
+// DetectDrift returns the active drift item when GitHub reports work as done
+// (a merged PR or closed issue) but the configured outcome/runtime signal
+// says otherwise. It returns nil when there is no drift to report.
+func DetectDrift(input DriftInput) *DriftItem {
+	brief := input.Brief.Normalized()
+	if !brief.Configured() {
+		return nil
+	}
+
+	mergedPRs := sortedMergedPRs(input.MergedPRs)
+	closedIssues := sortedClosedIssues(input.ClosedIssues)
+	if len(mergedPRs) == 0 && len(closedIssues) == 0 {
+		return nil
+	}
+
+	health := classifyDriftHealth(brief, input.Health, input.LastMergeAt)
+	if health.state == HealthHealthy {
+		return nil
+	}
+
+	goal := brief.Goal()
+	if goal == "" {
+		goal = "the configured runtime outcome"
+	}
+
+	item := &DriftItem{
+		HealthState:     health.state,
+		Signal:          health.signal,
+		SignalSummary:   health.summary,
+		SignalDetail:    health.detail,
+		HealthCheckedAt: health.checkedAt,
+		Goal:            goal,
+		MergedPRs:       mergedPRs,
+		ClosedIssues:    closedIssues,
+	}
+	item.Summary = driftSummary(health.state, goal, mergedPRs, closedIssues)
+	item.NextAction = driftNextAction(brief, health.state)
+	item.RecommendedAction, item.RequiresApproval, item.Labels = applyDriftPolicy(input.Policy, mergedPRs, closedIssues)
+	return item
+}
+
+type driftHealth struct {
+	state     string
+	signal    string
+	summary   string
+	detail    string
+	checkedAt string
+}
+
+func classifyDriftHealth(brief Brief, health *HealthCheckResult, lastMergeAt time.Time) driftHealth {
+	if !brief.HasHealthSignal() {
+		return driftHealth{state: HealthUnmonitored}
+	}
+	if health == nil || health.CheckedAt.IsZero() {
+		return driftHealth{state: HealthUnknown}
+	}
+	if !lastMergeAt.IsZero() && health.CheckedAt.Before(lastMergeAt) {
+		return driftHealth{state: HealthUnknown}
+	}
+	return driftHealth{
+		state:     normalizedHealthState(health.State),
+		signal:    health.Signal,
+		summary:   health.Summary,
+		detail:    health.Detail,
+		checkedAt: health.CheckedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func driftSummary(healthState, goal string, prs []DriftPR, issues []DriftIssue) string {
+	descriptor := healthDescriptor(healthState)
+	mergedPart := joinPRNumbers(prs)
+	closedPart := joinIssueNumbers(issues)
+	switch {
+	case mergedPart != "" && closedPart != "":
+		return fmt.Sprintf("GitHub reports PR %s merged and issue %s closed, but runtime outcome health is %s for %s.", mergedPart, closedPart, descriptor, goal)
+	case mergedPart != "":
+		return fmt.Sprintf("GitHub reports PR %s merged, but runtime outcome health is %s for %s.", mergedPart, descriptor, goal)
+	case closedPart != "":
+		return fmt.Sprintf("GitHub reports issue %s closed, but runtime outcome health is %s for %s.", closedPart, descriptor, goal)
+	default:
+		return fmt.Sprintf("Runtime outcome health is %s for %s.", descriptor, goal)
+	}
+}
+
+func driftNextAction(brief Brief, healthState string) string {
+	switch healthState {
+	case HealthFailing:
+		if cmd := strings.TrimSpace(brief.HealthcheckCommand); cmd != "" {
+			return fmt.Sprintf("Runtime outcome is failing; re-run %q and fix the runtime/deploy regression before treating the merged work as done.", cmd)
+		}
+		if url := strings.TrimSpace(brief.HealthcheckURL); url != "" {
+			return fmt.Sprintf("Runtime outcome is failing; re-check %s and fix the runtime/deploy regression before treating the merged work as done.", url)
+		}
+		return "Runtime outcome is failing; fix the runtime/deploy regression before treating the merged work as done."
+	case HealthUnknown:
+		return "Run the configured outcome healthcheck before treating the merged PR or closed issue as fully delivered."
+	case HealthUnmonitored:
+		return "Add a read-only outcome health signal (deployment status / healthcheck command or URL), then verify the runtime target."
+	default:
+		return "Verify the configured runtime outcome before treating the merged PR or closed issue as fully delivered."
+	}
+}
+
+func applyDriftPolicy(policy DriftPolicy, prs []DriftPR, issues []DriftIssue) (action string, requiresApproval bool, labels []string) {
+	labels = compactStrings(policy.Labels)
+	switch {
+	case policy.ReopenIssue && len(issues) > 0:
+		action = DriftActionReopenIssue
+	case len(labels) > 0 && len(issues) > 0:
+		action = DriftActionLabelIssue
+	case policy.CommentIssue && len(issues) > 0:
+		action = DriftActionCommentIssue
+	case policy.CommentPR && len(prs) > 0:
+		action = DriftActionCommentPR
+	default:
+		return DriftActionCheckHealth, false, labels
+	}
+	if policy.AutoApprove {
+		return action, false, labels
+	}
+	return DriftActionRequestApproval, true, labels
+}
+
+func healthDescriptor(healthState string) string {
+	switch healthState {
+	case HealthFailing:
+		return "failing"
+	case HealthUnknown:
+		return "unknown"
+	case HealthUnmonitored:
+		return "not monitored"
+	case HealthHealthy:
+		return "healthy"
+	case HealthNotConfigured:
+		return "not configured"
+	default:
+		return strings.ReplaceAll(healthState, "_", " ")
+	}
+}
+
+func joinPRNumbers(prs []DriftPR) string {
+	parts := make([]string, 0, len(prs))
+	for _, pr := range prs {
+		if pr.Number <= 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("#%d", pr.Number))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func joinIssueNumbers(issues []DriftIssue) string {
+	parts := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		if issue.Number <= 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("#%d", issue.Number))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func sortedMergedPRs(prs []DriftPR) []DriftPR {
+	out := make([]DriftPR, 0, len(prs))
+	seen := make(map[int]struct{}, len(prs))
+	for _, pr := range prs {
+		if pr.Number <= 0 {
+			continue
+		}
+		if _, ok := seen[pr.Number]; ok {
+			continue
+		}
+		seen[pr.Number] = struct{}{}
+		out = append(out, pr)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		ai, aj := out[i].MergedAt, out[j].MergedAt
+		if ai.IsZero() && aj.IsZero() {
+			return out[i].Number < out[j].Number
+		}
+		if ai.IsZero() {
+			return false
+		}
+		if aj.IsZero() {
+			return true
+		}
+		return ai.After(aj)
+	})
+	return out
+}
+
+func sortedClosedIssues(issues []DriftIssue) []DriftIssue {
+	out := make([]DriftIssue, 0, len(issues))
+	seen := make(map[int]struct{}, len(issues))
+	for _, issue := range issues {
+		if issue.Number <= 0 {
+			continue
+		}
+		if _, ok := seen[issue.Number]; ok {
+			continue
+		}
+		seen[issue.Number] = struct{}{}
+		out = append(out, issue)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		ai, aj := out[i].ClosedAt, out[j].ClosedAt
+		if ai.IsZero() && aj.IsZero() {
+			return out[i].Number < out[j].Number
+		}
+		if ai.IsZero() {
+			return false
+		}
+		if aj.IsZero() {
+			return true
+		}
+		return ai.After(aj)
+	})
+	return out
+}

--- a/internal/outcome/drift_test.go
+++ b/internal/outcome/drift_test.go
@@ -1,0 +1,258 @@
+package outcome
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectDriftClosedIssueWithFailingRuntime(t *testing.T) {
+	closedAt := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	checkedAt := closedAt.Add(time.Minute)
+	item := DetectDrift(DriftInput{
+		Brief: Brief{
+			DesiredOutcome:     "App is live at /settings",
+			HealthcheckCommand: "./verify-live.sh",
+		},
+		LastMergeAt: time.Time{},
+		ClosedIssues: []DriftIssue{
+			{Number: 353, Title: "P0 outcome drift", ClosedAt: closedAt},
+		},
+		Health: &HealthCheckResult{
+			CheckedAt: checkedAt,
+			Signal:    "healthcheck_command",
+			State:     HealthFailing,
+			Summary:   "verify-live.sh exited 7",
+			Detail:    "route /settings missing",
+		},
+		Policy: DriftPolicy{CommentIssue: true},
+	})
+	if item == nil {
+		t.Fatal("DetectDrift = nil, want active drift item")
+	}
+	if item.HealthState != HealthFailing {
+		t.Fatalf("HealthState = %q, want %q", item.HealthState, HealthFailing)
+	}
+	if !strings.Contains(item.Summary, "#353") || !strings.Contains(item.Summary, "failing") {
+		t.Fatalf("Summary = %q, want closed issue + failing runtime", item.Summary)
+	}
+	if !strings.Contains(item.NextAction, "verify-live.sh") {
+		t.Fatalf("NextAction = %q, want healthcheck command guidance", item.NextAction)
+	}
+	if item.RecommendedAction != DriftActionRequestApproval || !item.RequiresApproval {
+		t.Fatalf("RecommendedAction/RequiresApproval = %q/%v, want approval-gated mutating action", item.RecommendedAction, item.RequiresApproval)
+	}
+	if item.SignalSummary != "verify-live.sh exited 7" || item.SignalDetail == "" {
+		t.Fatalf("Signal metadata = %+v, want failing signal details", item)
+	}
+	if len(item.ClosedIssues) != 1 || item.ClosedIssues[0].Number != 353 {
+		t.Fatalf("ClosedIssues = %+v, want issue #353", item.ClosedIssues)
+	}
+}
+
+func TestDetectDriftMergedPRWithUnknownRuntime(t *testing.T) {
+	mergedAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	item := DetectDrift(DriftInput{
+		Brief: Brief{
+			DesiredOutcome:     "App is live",
+			HealthcheckCommand: "./status.sh",
+		},
+		LastMergeAt: mergedAt,
+		MergedPRs: []DriftPR{
+			{Number: 468, Title: "fix(github): ignore #N inside code blocks", MergedAt: mergedAt},
+		},
+		Health: nil,
+	})
+	if item == nil {
+		t.Fatal("DetectDrift = nil, want active drift item for unknown runtime")
+	}
+	if item.HealthState != HealthUnknown {
+		t.Fatalf("HealthState = %q, want %q", item.HealthState, HealthUnknown)
+	}
+	if !strings.Contains(item.Summary, "#468") || !strings.Contains(item.Summary, "unknown") {
+		t.Fatalf("Summary = %q, want merged PR + unknown runtime", item.Summary)
+	}
+	if item.RecommendedAction != DriftActionCheckHealth || item.RequiresApproval {
+		t.Fatalf("RecommendedAction/RequiresApproval = %q/%v, want read-only check action", item.RecommendedAction, item.RequiresApproval)
+	}
+	if len(item.MergedPRs) != 1 || item.MergedPRs[0].Number != 468 {
+		t.Fatalf("MergedPRs = %+v, want PR #468", item.MergedPRs)
+	}
+}
+
+func TestDetectDriftStaleHealthCheckTreatedAsUnknown(t *testing.T) {
+	lastMerge := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	item := DetectDrift(DriftInput{
+		Brief: Brief{
+			DesiredOutcome: "App is live",
+			HealthcheckURL: "https://app.example.com/healthz",
+		},
+		LastMergeAt: lastMerge,
+		MergedPRs:   []DriftPR{{Number: 99, MergedAt: lastMerge}},
+		Health: &HealthCheckResult{
+			CheckedAt: lastMerge.Add(-time.Hour),
+			State:     HealthHealthy,
+		},
+	})
+	if item == nil {
+		t.Fatal("DetectDrift = nil, want unknown drift when health check predates merge")
+	}
+	if item.HealthState != HealthUnknown {
+		t.Fatalf("HealthState = %q, want %q", item.HealthState, HealthUnknown)
+	}
+}
+
+func TestDetectDriftHealthyOutcomeReturnsNil(t *testing.T) {
+	mergedAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	checkedAt := mergedAt.Add(time.Minute)
+	item := DetectDrift(DriftInput{
+		Brief: Brief{
+			DesiredOutcome: "App is live",
+			HealthcheckURL: "https://app.example.com/healthz",
+		},
+		LastMergeAt: mergedAt,
+		MergedPRs:   []DriftPR{{Number: 470, MergedAt: mergedAt}},
+		ClosedIssues: []DriftIssue{
+			{Number: 353, ClosedAt: mergedAt},
+		},
+		Health: &HealthCheckResult{
+			CheckedAt: checkedAt,
+			Signal:    "healthcheck_url",
+			State:     HealthHealthy,
+			Summary:   "GET returned 200 OK",
+		},
+	})
+	if item != nil {
+		t.Fatalf("DetectDrift = %+v, want nil for healthy outcome", item)
+	}
+}
+
+func TestDetectDriftNoActivityReturnsNil(t *testing.T) {
+	item := DetectDrift(DriftInput{
+		Brief: Brief{
+			DesiredOutcome:     "App is live",
+			HealthcheckCommand: "./status.sh",
+		},
+		Health: &HealthCheckResult{
+			CheckedAt: time.Now(),
+			State:     HealthFailing,
+			Summary:   "still failing",
+		},
+	})
+	if item != nil {
+		t.Fatalf("DetectDrift = %+v, want nil when no PR was merged or issue closed", item)
+	}
+}
+
+func TestDetectDriftMissingBriefReturnsNil(t *testing.T) {
+	item := DetectDrift(DriftInput{
+		Brief:        Brief{},
+		ClosedIssues: []DriftIssue{{Number: 12, ClosedAt: time.Now()}},
+		Health: &HealthCheckResult{
+			CheckedAt: time.Now(),
+			State:     HealthFailing,
+		},
+	})
+	if item != nil {
+		t.Fatalf("DetectDrift = %+v, want nil when no outcome brief is configured", item)
+	}
+}
+
+func TestDetectDriftPolicyReopenRequiresApproval(t *testing.T) {
+	closedAt := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	policy := DriftPolicy{
+		ReopenIssue: true,
+		Labels:      []string{"outcome-drift", "", "outcome-drift"},
+	}
+	item := DetectDrift(DriftInput{
+		Brief: Brief{
+			DesiredOutcome:     "App is live",
+			HealthcheckCommand: "./status.sh",
+		},
+		ClosedIssues: []DriftIssue{{Number: 99, ClosedAt: closedAt}},
+		Health: &HealthCheckResult{
+			CheckedAt: closedAt.Add(time.Minute),
+			State:     HealthFailing,
+			Summary:   "verify failed",
+		},
+		Policy: policy,
+	})
+	if item == nil {
+		t.Fatal("DetectDrift = nil, want drift item with reopen action")
+	}
+	if item.RecommendedAction != DriftActionRequestApproval || !item.RequiresApproval {
+		t.Fatalf("recommended/approval = %q/%v, want approval-gated mutating action", item.RecommendedAction, item.RequiresApproval)
+	}
+	if len(item.Labels) != 1 || item.Labels[0] != "outcome-drift" {
+		t.Fatalf("Labels = %#v, want compacted [outcome-drift]", item.Labels)
+	}
+}
+
+func TestDetectDriftPolicyAutoApproveSkipsApproval(t *testing.T) {
+	closedAt := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	item := DetectDrift(DriftInput{
+		Brief: Brief{
+			DesiredOutcome:     "App is live",
+			HealthcheckCommand: "./status.sh",
+		},
+		ClosedIssues: []DriftIssue{{Number: 99, ClosedAt: closedAt}},
+		Health: &HealthCheckResult{
+			CheckedAt: closedAt.Add(time.Minute),
+			State:     HealthFailing,
+		},
+		Policy: DriftPolicy{ReopenIssue: true, AutoApprove: true},
+	})
+	if item == nil {
+		t.Fatal("DetectDrift = nil, want drift item")
+	}
+	if item.RecommendedAction != DriftActionReopenIssue || item.RequiresApproval {
+		t.Fatalf("recommended/approval = %q/%v, want direct reopen without approval", item.RecommendedAction, item.RequiresApproval)
+	}
+}
+
+func TestDetectDriftUnmonitoredSignal(t *testing.T) {
+	mergedAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	item := DetectDrift(DriftInput{
+		Brief: Brief{
+			DesiredOutcome: "App is live",
+		},
+		LastMergeAt: mergedAt,
+		MergedPRs:   []DriftPR{{Number: 200, MergedAt: mergedAt}},
+	})
+	if item == nil {
+		t.Fatal("DetectDrift = nil, want drift item for unmonitored outcome")
+	}
+	if item.HealthState != HealthUnmonitored {
+		t.Fatalf("HealthState = %q, want %q", item.HealthState, HealthUnmonitored)
+	}
+	if !strings.Contains(item.NextAction, "outcome health signal") {
+		t.Fatalf("NextAction = %q, want unmonitored guidance", item.NextAction)
+	}
+}
+
+func TestDetectDriftSortsMergedPRsRecentFirst(t *testing.T) {
+	older := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	item := DetectDrift(DriftInput{
+		Brief: Brief{
+			DesiredOutcome:     "App is live",
+			HealthcheckCommand: "./status.sh",
+		},
+		LastMergeAt: newer,
+		MergedPRs: []DriftPR{
+			{Number: 1, MergedAt: older},
+			{Number: 2, MergedAt: newer},
+			{Number: 2, MergedAt: newer}, // duplicate
+		},
+		Health: &HealthCheckResult{
+			CheckedAt: newer.Add(time.Minute),
+			State:     HealthFailing,
+		},
+	})
+	if item == nil {
+		t.Fatal("DetectDrift = nil")
+	}
+	if len(item.MergedPRs) != 2 || item.MergedPRs[0].Number != 2 || item.MergedPRs[1].Number != 1 {
+		t.Fatalf("MergedPRs = %+v, want newest first deduped", item.MergedPRs)
+	}
+}


### PR DESCRIPTION
Refs #353

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `DetectDrift`, a new function that identifies outcome drift when GitHub records work as complete (PR merged or issue closed) but the configured runtime health signal says otherwise. It adds supporting types (`DriftInput`, `DriftItem`, `DriftPolicy`, etc.) and a full test suite covering nil cases, health states, policy enforcement, deduplication, and sorting.

- `classifyDriftHealth` marks the health result as stale when it predates the last PR merge, but does not apply the same staleness check against closed-issue timestamps — a health check done between the last merge and a later issue close will be treated as fresh, producing misleading \"failing\" drift reports for that issue.
- `applyDriftPolicy` correctly gates mutating actions behind `DriftActionRequestApproval` when `AutoApprove` is false, and the deduplication/sorting helpers match the expected behaviour verified by the tests.

<h3>Confidence Score: 3/5</h3>

The drift detector can report an actionable health state based on data that predates the most recent issue close, which would cause supervisors to act on stale signals.

The staleness guard in classifyDriftHealth is asymmetric: it protects against health data that predates a PR merge but has no equivalent protection when issues are closed after the last health check. This means DetectDrift can return a HealthFailing or HealthHealthy drift item whose health signal was recorded before the issue close that triggered the drift scan.

internal/outcome/drift.go — specifically the classifyDriftHealth call site in DetectDrift and the staleness logic inside classifyDriftHealth itself.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/outcome/drift.go | New file implementing outcome-drift detection. Core logic is clean, but classifyDriftHealth only checks health staleness against LastMergeAt and ignores ClosedIssues timestamps, so a health check predating an issue close is treated as fresh and produces misleading drift reports. |
| internal/outcome/drift_test.go | Good coverage for happy paths, nil cases, deduplication, sorting, and policy variants. Missing a test for the stale-health-check-vs-issue-close scenario (parallel to TestDetectDriftStaleHealthCheckTreatedAsUnknown for the PR-merge path). |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/outcome/drift.go:119-128
**Stale health check not detected when issue closed after last health check**

`classifyDriftHealth` guards against a health check that predates a PR merge via `lastMergeAt`, but there is no equivalent guard for closed issues. If an issue was closed at `T3`, the last merge was at `T1`, and the health check ran at `T2` where `T1 < T2 < T3`, the function returns the actual health state (e.g., `HealthFailing`) even though the health data predates the issue close. The resulting drift item summary then incorrectly reads "issue #N closed, but health is failing" based on a stale signal. The fix is to derive a `latestActivityAt` in `DetectDrift` as the maximum of `input.LastMergeAt` and the latest `ClosedAt` across `closedIssues`, and pass that value to `classifyDriftHealth` instead of `input.LastMergeAt` alone. The existing test `TestDetectDriftStaleHealthCheckTreatedAsUnknown` only covers the PR-merge path; there is no counterpart covering the issue-close path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(outcome): add post-merge/close drif..."](https://github.com/befeast/maestro/commit/09b220057bff2a66bb5a7eece720ca6bee288321) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34687390)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->