### PR TITLE
feat(server): implement safe action endpoints (#475 part 1)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -351,6 +351,7 @@ func runCmd(args []string) {
 		// Start HTTP server if configured
 		if cfg.Server.Port > 0 {
 			srv := server.New(cfg, refreshCh)
+			srv.SetActionDeps(github.New(cfg.Repo), nil)
 			go func() {
 				if err := srv.Start(context.Background()); err != nil {
 					log.Printf("[server] error: %v", err)
@@ -408,6 +409,7 @@ func runCmd(args []string) {
 			// Start HTTP server if configured
 			if c.Server.Port > 0 {
 				srv := server.New(c, refreshCh)
+				srv.SetActionDeps(github.New(c.Repo), nil)
 				go func() {
 					if err := srv.Start(ctx); err != nil {
 						log.Printf("[%s][server] error: %v", c.SessionPrefix, err)
@@ -729,7 +731,9 @@ func serveCmd(args []string) {
 
 	refreshCh := make(chan struct{}, 1)
 	log.Printf("serving dashboard — repo=%s addr=%s:%d read_only=%v", cfg.Repo, cfg.Server.Host, cfg.Server.Port, cfg.Server.ReadOnly)
-	if err := server.New(cfg, refreshCh).Start(ctx); err != nil {
+	srv := server.New(cfg, refreshCh)
+	srv.SetActionDeps(github.New(cfg.Repo), nil)
+	if err := srv.Start(ctx); err != nil {
 		log.Fatalf("serve: %v", err)
 	}
 }
@@ -737,7 +741,9 @@ func serveCmd(args []string) {
 func fleetProjectsFromConfigs(cfgs []*config.Config) []server.FleetProject {
 	projects := make([]server.FleetProject, 0, len(cfgs))
 	for _, cfg := range cfgs {
-		projects = append(projects, server.NewFleetProject(defaultFleetProjectName(cfg.Repo), cfg.ResolvePath(), "", cfg))
+		proj := server.NewFleetProject(defaultFleetProjectName(cfg.Repo), cfg.ResolvePath(), "", cfg)
+		proj.SetActionGH(github.New(cfg.Repo))
+		projects = append(projects, proj)
 	}
 	return projects
 }

--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// actionGitHubClient is the narrow surface the safe-action dispatcher needs
+// from a GitHub client. The real *github.Client satisfies this; tests inject
+// a fake. Keeping the interface here (next to the dispatcher) avoids dragging
+// internal/server into a hard dep on internal/github.
+type actionGitHubClient interface {
+	AddIssueLabel(issueNumber int, label string) error
+	RemoveIssueLabel(issueNumber int, label string) error
+	CommentIssue(issueNumber int, body string) error
+}
+
+// actionAuditRecorder appends an audit-log entry for a successfully executed
+// action. The fleet server passes a closure that writes to the per-project
+// audit file; the single-project server can pass the same shape (or nil if
+// the audit log is not configured).
+type actionAuditRecorder func(actor, action, target, reason string) error
+
+// safeActionResult is the dispatcher's verdict.
+//
+//   - handled=false → the action was NOT one of the safe verbs we own here;
+//     the caller must fall through to its existing 501/approval handling.
+//   - handled=true with err==nil → action executed; status is the HTTP code
+//     to return (typically 200) and body is the JSON payload.
+//   - handled=true with err!=nil → action was claimed by us but failed;
+//     status is the HTTP code to return and body carries the error message.
+type safeActionResult struct {
+	handled bool
+	status  int
+	body    any
+	err     error
+}
+
+// safeActionResponse is the JSON body returned on a successful safe action.
+type safeActionResponse struct {
+	OK       bool   `json:"ok"`
+	ActionID string `json:"action_id"`
+	Target   string `json:"target,omitempty"`
+	AuditID  string `json:"audit_id,omitempty"`
+}
+
+// dispatchSafeAction routes a controlActionRequest to the matching GitHub
+// helper for the three safe verbs (add_ready_label, remove_ready_label,
+// add_issue_comment). Approval-required action_ids return handled=false so
+// the caller can keep its 501 response. Unknown action_ids return a 400.
+//
+// readOnly is checked by the caller before this is invoked; we assume here
+// that the request has already cleared the read-only gate.
+func dispatchSafeAction(req controlActionRequest, cfg *config.Config, gh actionGitHubClient, audit actionAuditRecorder) safeActionResult {
+	id := strings.TrimSpace(req.ActionID)
+	if id == "" {
+		return safeActionResult{handled: true, status: http.StatusBadRequest, body: map[string]string{"error": "action_id is required"}, err: errors.New("missing action_id")}
+	}
+	if isApprovalRequiredAction(id) {
+		// Not our responsibility — caller falls back to its 501 / approval path.
+		return safeActionResult{handled: false}
+	}
+	if !isSafeAction(id) {
+		return safeActionResult{handled: true, status: http.StatusBadRequest, body: map[string]string{"error": fmt.Sprintf("unknown action_id %q", id)}, err: fmt.Errorf("unknown action_id %q", id)}
+	}
+	if gh == nil {
+		return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "no GitHub client configured for this server"}, err: errors.New("nil github client")}
+	}
+	if req.IssueNumber <= 0 {
+		return safeActionResult{handled: true, status: http.StatusBadRequest, body: map[string]string{"error": "issue_number is required for safe actions"}, err: errors.New("missing issue_number")}
+	}
+
+	readyLabel := safeActionReadyLabel(cfg)
+	blockedLabel := safeActionBlockedLabel(cfg)
+	target := fmt.Sprintf("issue #%d", req.IssueNumber)
+
+	switch id {
+	case config.SupervisorActionAddReadyLabel:
+		if readyLabel == "" {
+			return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "no ready label configured (cfg.Supervisor.ReadyLabel / cfg.IssueLabels)"}, err: errors.New("no ready label")}
+		}
+		if err := gh.AddIssueLabel(req.IssueNumber, readyLabel); err != nil {
+			return safeActionResult{handled: true, status: http.StatusBadGateway, body: map[string]string{"error": fmt.Sprintf("add ready label: %v", err)}, err: err}
+		}
+		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target, audit, req, fmt.Sprintf("+label %s", readyLabel))}
+	case config.SupervisorActionRemoveReadyLabel:
+		if readyLabel == "" {
+			return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "no ready label configured"}, err: errors.New("no ready label")}
+		}
+		if err := gh.RemoveIssueLabel(req.IssueNumber, readyLabel); err != nil {
+			return safeActionResult{handled: true, status: http.StatusBadGateway, body: map[string]string{"error": fmt.Sprintf("remove ready label: %v", err)}, err: err}
+		}
+		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target, audit, req, fmt.Sprintf("-label %s", readyLabel))}
+	case config.SupervisorActionRemoveBlockedLabel:
+		if blockedLabel == "" {
+			return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "no blocked label configured (cfg.Supervisor.BlockedLabel)"}, err: errors.New("no blocked label")}
+		}
+		if err := gh.RemoveIssueLabel(req.IssueNumber, blockedLabel); err != nil {
+			return safeActionResult{handled: true, status: http.StatusBadGateway, body: map[string]string{"error": fmt.Sprintf("remove blocked label: %v", err)}, err: err}
+		}
+		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target, audit, req, fmt.Sprintf("-label %s", blockedLabel))}
+	case config.SupervisorActionAddIssueComment:
+		body := strings.TrimSpace(req.Body)
+		if body == "" {
+			return safeActionResult{handled: true, status: http.StatusBadRequest, body: map[string]string{"error": "body is required for add_issue_comment"}, err: errors.New("missing body")}
+		}
+		if err := gh.CommentIssue(req.IssueNumber, body); err != nil {
+			return safeActionResult{handled: true, status: http.StatusBadGateway, body: map[string]string{"error": fmt.Sprintf("comment issue: %v", err)}, err: err}
+		}
+		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target, audit, req, "+comment")}
+	}
+
+	// Defensive: should be unreachable given isSafeAction filter above.
+	return safeActionResult{handled: true, status: http.StatusBadRequest, body: map[string]string{"error": fmt.Sprintf("unhandled safe action %q", id)}, err: fmt.Errorf("unhandled safe action %q", id)}
+}
+
+// isSafeAction reports whether the action_id is one this dispatcher executes
+// directly (no approval). Mirrors cfg.Supervisor.SafeActions defaults.
+func isSafeAction(id string) bool {
+	switch id {
+	case config.SupervisorActionAddReadyLabel,
+		config.SupervisorActionRemoveReadyLabel,
+		config.SupervisorActionRemoveBlockedLabel,
+		config.SupervisorActionAddIssueComment:
+		return true
+	}
+	return false
+}
+
+// isApprovalRequiredAction reports whether the action_id must go through the
+// cautious approval gate. These return handled=false from this dispatcher so
+// the existing 501 response is preserved (until the approval enqueue path
+// lands as part 2 of the dashboard write-path).
+func isApprovalRequiredAction(id string) bool {
+	switch id {
+	case "merge_pr", "close_issue", "delete_worktree", "change_global_config",
+		// Existing UI affordances that are mutating but not in our safe set:
+		"approve_merge", "restart_worker", "stop_worker",
+		"mark_issue_ready", "mark_issue_blocked":
+		return true
+	}
+	return false
+}
+
+func safeActionReadyLabel(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if l := strings.TrimSpace(cfg.Supervisor.ReadyLabel); l != "" {
+		return l
+	}
+	for _, l := range cfg.IssueLabels {
+		if t := strings.TrimSpace(l); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+func safeActionBlockedLabel(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.Supervisor.BlockedLabel)
+}
+
+func makeSafeOK(id, target string, audit actionAuditRecorder, req controlActionRequest, summary string) safeActionResponse {
+	resp := safeActionResponse{OK: true, ActionID: id, Target: target}
+	if audit != nil {
+		actor := strings.TrimSpace(req.Actor)
+		if actor == "" {
+			actor = "dashboard"
+		}
+		reason := strings.TrimSpace(req.Reason)
+		if reason == "" {
+			reason = summary
+		}
+		// Best-effort: audit failures must not poison a successful action.
+		_ = audit(actor, id, target, reason)
+	}
+	return resp
+}

--- a/internal/server/actions_test.go
+++ b/internal/server/actions_test.go
@@ -1,0 +1,238 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// fakeActionGH records calls + lets tests stub errors.
+type fakeActionGH struct {
+	addLabelCalls    []labelCall
+	removeLabelCalls []labelCall
+	commentCalls     []commentCall
+
+	addLabelErr    error
+	removeLabelErr error
+	commentErr     error
+}
+
+type labelCall struct {
+	issue int
+	label string
+}
+type commentCall struct {
+	issue int
+	body  string
+}
+
+func (f *fakeActionGH) AddIssueLabel(issue int, label string) error {
+	f.addLabelCalls = append(f.addLabelCalls, labelCall{issue: issue, label: label})
+	return f.addLabelErr
+}
+func (f *fakeActionGH) RemoveIssueLabel(issue int, label string) error {
+	f.removeLabelCalls = append(f.removeLabelCalls, labelCall{issue: issue, label: label})
+	return f.removeLabelErr
+}
+func (f *fakeActionGH) CommentIssue(issue int, body string) error {
+	f.commentCalls = append(f.commentCalls, commentCall{issue: issue, body: body})
+	return f.commentErr
+}
+
+func newSafeActionTestCfg() *config.Config {
+	return &config.Config{
+		Repo: "owner/repo",
+		Server: config.ServerConfig{
+			Port:     8788,
+			ReadOnly: false,
+		},
+		Supervisor: config.SupervisorConfig{
+			ReadyLabel:   "maestro-ready",
+			BlockedLabel: "blocked",
+		},
+	}
+}
+
+func postAction(t *testing.T, srv *Server, payload string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/actions", bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleAction(w, req)
+	return w
+}
+
+func TestSafeAction_AddReadyLabel_Executes(t *testing.T) {
+	gh := &fakeActionGH{}
+	auditCalls := 0
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, func(actor, action, target, reason string) error {
+		auditCalls++
+		if action != config.SupervisorActionAddReadyLabel {
+			t.Errorf("audit action = %q, want %q", action, config.SupervisorActionAddReadyLabel)
+		}
+		if !strings.Contains(target, "#42") {
+			t.Errorf("audit target = %q, want to mention #42", target)
+		}
+		return nil
+	})
+
+	w := postAction(t, srv, `{"action_id":"add_ready_label","issue_number":42}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if len(gh.addLabelCalls) != 1 || gh.addLabelCalls[0].issue != 42 || gh.addLabelCalls[0].label != "maestro-ready" {
+		t.Fatalf("addLabelCalls = %+v", gh.addLabelCalls)
+	}
+	if auditCalls != 1 {
+		t.Fatalf("audit recorded %d times, want 1", auditCalls)
+	}
+	var resp safeActionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if !resp.OK || resp.ActionID != "add_ready_label" {
+		t.Fatalf("response = %+v", resp)
+	}
+}
+
+func TestSafeAction_RemoveReadyLabel_Executes(t *testing.T) {
+	gh := &fakeActionGH{}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, nil)
+
+	w := postAction(t, srv, `{"action_id":"remove_ready_label","issue_number":99}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	if len(gh.removeLabelCalls) != 1 || gh.removeLabelCalls[0].issue != 99 || gh.removeLabelCalls[0].label != "maestro-ready" {
+		t.Fatalf("removeLabelCalls = %+v", gh.removeLabelCalls)
+	}
+}
+
+func TestSafeAction_RemoveBlockedLabel_Executes(t *testing.T) {
+	gh := &fakeActionGH{}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, nil)
+
+	w := postAction(t, srv, `{"action_id":"remove_blocked_label","issue_number":7}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	if len(gh.removeLabelCalls) != 1 || gh.removeLabelCalls[0].label != "blocked" {
+		t.Fatalf("removeLabelCalls = %+v", gh.removeLabelCalls)
+	}
+}
+
+func TestSafeAction_AddIssueComment_Executes(t *testing.T) {
+	gh := &fakeActionGH{}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, nil)
+
+	w := postAction(t, srv, `{"action_id":"add_issue_comment","issue_number":12,"body":"hello"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	if len(gh.commentCalls) != 1 || gh.commentCalls[0].issue != 12 || gh.commentCalls[0].body != "hello" {
+		t.Fatalf("commentCalls = %+v", gh.commentCalls)
+	}
+}
+
+func TestSafeAction_AddIssueComment_RequiresBody(t *testing.T) {
+	gh := &fakeActionGH{}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, nil)
+
+	w := postAction(t, srv, `{"action_id":"add_issue_comment","issue_number":12}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if len(gh.commentCalls) != 0 {
+		t.Fatalf("commentCalls = %+v, want none", gh.commentCalls)
+	}
+}
+
+func TestSafeAction_RequiresIssueNumber(t *testing.T) {
+	gh := &fakeActionGH{}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, nil)
+
+	w := postAction(t, srv, `{"action_id":"add_ready_label"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestSafeAction_ApprovalRequiredFallsThroughTo501(t *testing.T) {
+	// merge_pr is approval-required (#475 part 2 territory). It must NOT be
+	// executed by this dispatcher; the handler must still respond with 501.
+	gh := &fakeActionGH{}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, nil)
+
+	for _, id := range []string{"merge_pr", "close_issue", "delete_worktree", "change_global_config",
+		"approve_merge", "restart_worker", "stop_worker", "mark_issue_ready", "mark_issue_blocked"} {
+		w := postAction(t, srv, fmt.Sprintf(`{"action_id":%q,"issue_number":1}`, id))
+		if w.Code != http.StatusNotImplemented {
+			t.Fatalf("action %q: status = %d, want 501; body=%s", id, w.Code, w.Body.String())
+		}
+		if len(gh.addLabelCalls) != 0 || len(gh.removeLabelCalls) != 0 || len(gh.commentCalls) != 0 {
+			t.Fatalf("action %q: dispatcher unexpectedly called gh: add=%v rm=%v cmt=%v", id, gh.addLabelCalls, gh.removeLabelCalls, gh.commentCalls)
+		}
+	}
+}
+
+func TestSafeAction_UnknownActionID_Rejected(t *testing.T) {
+	gh := &fakeActionGH{}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, nil)
+
+	w := postAction(t, srv, `{"action_id":"do_a_barrel_roll","issue_number":1}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSafeAction_ReadOnlyStillWins(t *testing.T) {
+	// Even with safe-action wiring in place, --read-only must keep returning
+	// 403 — no behavior change in the default deployment.
+	cfg := newSafeActionTestCfg()
+	cfg.Server.ReadOnly = true
+	gh := &fakeActionGH{}
+	srv := New(cfg, nil)
+	srv.SetActionDeps(gh, nil)
+
+	w := postAction(t, srv, `{"action_id":"add_ready_label","issue_number":42}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if len(gh.addLabelCalls) != 0 {
+		t.Fatalf("addLabelCalls = %+v, want none (read-only must short-circuit)", gh.addLabelCalls)
+	}
+}
+
+func TestSafeAction_GHFailureSurfacesAsBadGateway(t *testing.T) {
+	gh := &fakeActionGH{addLabelErr: errors.New("403 from github")}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, nil)
+
+	w := postAction(t, srv, `{"action_id":"add_ready_label","issue_number":42}`)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSafeAction_NoGHClientReturns500(t *testing.T) {
+	srv := New(newSafeActionTestCfg(), nil) // no SetActionDeps
+	w := postAction(t, srv, `{"action_id":"add_ready_label","issue_number":42}`)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -38,6 +38,21 @@ type FleetProject struct {
 	DashboardURL string `json:"dashboard_url,omitempty" yaml:"dashboard_url"`
 
 	cfg *config.Config
+
+	// actionGH is the GitHub client used by handleFleetAction's safe-action
+	// dispatcher when the project is not in read-only mode. nil disables
+	// safe actions for this project. Tests inject a fake via SetActionGH.
+	actionGH actionGitHubClient
+}
+
+// SetActionGH wires the per-project GitHub client used by the safe-action
+// dispatcher. Call this on startup; nil leaves safe actions disabled for the
+// project (handler falls through to 501).
+func (p *FleetProject) SetActionGH(gh actionGitHubClient) {
+	if p == nil {
+		return
+	}
+	p.actionGH = gh
 }
 
 // NewFleetProject wraps an already-loaded config for in-process fleet serving.
@@ -545,10 +560,32 @@ func (s *FleetServer) handleFleetAction(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	}
-	if project, ok := s.findProject(req.Project); ok && project.cfg != nil && project.cfg.Server.ReadOnly {
+
+	project, projectOK := s.findProject(req.Project)
+	if projectOK && project.cfg != nil && project.cfg.Server.ReadOnly {
 		writeError(w, http.StatusForbidden, "fleet project is read-only; write actions require approval-backed controls to be enabled in configuration")
 		return
 	}
+
+	var (
+		gh    actionGitHubClient
+		audit actionAuditRecorder
+		cfg   *config.Config
+	)
+	if projectOK {
+		cfg = project.cfg
+		gh = project.actionGH
+		audit = s.fleetActionAudit(project)
+	}
+
+	if res := dispatchSafeAction(req, cfg, gh, audit); res.handled {
+		if res.err != nil {
+			log.Printf("[fleet] safe action %q for project %q failed: %v", req.ActionID, req.Project, res.err)
+		}
+		writeJSON(w, res.status, res.body)
+		return
+	}
+
 	writeError(w, http.StatusNotImplemented, "approval-backed action endpoints are not implemented yet")
 }
 
@@ -3114,4 +3151,27 @@ func pluralSuffix(count int) string {
 		return ""
 	}
 	return "s"
+}
+
+// fleetActionAudit returns an audit recorder closure for the given project,
+// or nil if the project has no usable state dir. The closure writes to the
+// project's audit log via the same mechanism as handleFleetAuditLog.
+func (s *FleetServer) fleetActionAudit(project FleetProject) actionAuditRecorder {
+	stateDir, err := s.fleetAuditLogStateDir(project.Name)
+	if err != nil || strings.TrimSpace(stateDir) == "" {
+		return nil
+	}
+	projectName := project.Name
+	return func(actor, action, target, reason string) error {
+		entry := fleetAuditLogEntry{
+			AuditID:   newFleetAuditID(),
+			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+			Actor:     actor,
+			Action:    action,
+			Target:    target,
+			Reason:    reason,
+			Project:   projectName,
+		}
+		return appendFleetAuditLogEntry(stateDir, entry)
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,22 @@ type Server struct {
 	cfg       *config.Config
 	refreshCh chan<- struct{}
 	srv       *http.Server
+
+	// gh is the GitHub client used by the safe-action dispatcher when the
+	// server is not in read-only mode. nil disables safe actions (handlers
+	// fall through to 501). Tests inject a fake via SetActionDeps.
+	gh actionGitHubClient
+	// audit, when non-nil, records executed safe actions. nil disables
+	// auditing without disabling the action.
+	audit actionAuditRecorder
+}
+
+// SetActionDeps wires the GitHub client and (optional) audit recorder used
+// by the safe-action dispatcher. Call this on startup before Serve, or in
+// tests to inject a fake gh client.
+func (s *Server) SetActionDeps(gh actionGitHubClient, audit actionAuditRecorder) {
+	s.gh = gh
+	s.audit = audit
 }
 
 // New creates a new Server. refreshCh is used to trigger immediate poll cycles.
@@ -206,6 +222,12 @@ type controlActionRequest struct {
 	IssueNumber int    `json:"issue_number,omitempty"`
 	PRNumber    int    `json:"pr_number,omitempty"`
 	ApprovalID  string `json:"approval_id,omitempty"`
+
+	// Body is the comment text for add_issue_comment safe actions.
+	Body string `json:"body,omitempty"`
+	// Actor / Reason are recorded in the audit log for executed actions.
+	Actor  string `json:"actor,omitempty"`
+	Reason string `json:"reason,omitempty"`
 }
 
 type sessionInfo struct {
@@ -1012,10 +1034,10 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAction(w http.ResponseWriter, r *http.Request) {
-	handleControlAction(w, r, s.cfg.Server.ReadOnly, "server")
+	handleControlAction(w, r, s.cfg.Server.ReadOnly, "server", s.cfg, s.gh, s.audit)
 }
 
-func handleControlAction(w http.ResponseWriter, r *http.Request, readOnly bool, scope string) {
+func handleControlAction(w http.ResponseWriter, r *http.Request, readOnly bool, scope string, cfg *config.Config, gh actionGitHubClient, audit actionAuditRecorder) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -1033,6 +1055,15 @@ func handleControlAction(w http.ResponseWriter, r *http.Request, readOnly bool, 
 			return
 		}
 	}
+
+	if res := dispatchSafeAction(req, cfg, gh, audit); res.handled {
+		if res.err != nil {
+			log.Printf("[server] safe action %q failed: %v", req.ActionID, res.err)
+		}
+		writeJSON(w, res.status, res.body)
+		return
+	}
+
 	writeError(w, http.StatusNotImplemented, "approval-backed action endpoints are not implemented yet")
 }
 


### PR DESCRIPTION
## Summary

Implements the **safe-action** half of #475 (the 3-verb subset the supervisor policy already runs without approval). The four approval-required verbs (`merge_pr`, `close_issue`, `delete_worktree`, `change_global_config`) and the existing UI affordances that aren't in the safe set (`approve_merge`, `restart_worker`, `stop_worker`, `mark_issue_ready`, `mark_issue_blocked`) keep returning 501 — that is part 2 (cautious approval enqueue).

Safe verbs implemented:
- `add_ready_label`
- `remove_ready_label`
- `remove_blocked_label`
- `add_issue_comment`

Each one calls the existing `*github.Client` helper (`AddIssueLabel` / `RemoveIssueLabel` / `CommentIssue`) and writes a per-project audit-log entry via the same `appendFleetAuditLogEntry` path used by `/api/v1/audit/log`.

## Behavior

- **Read-only servers (the default `--read-only=true`)** still return **403** before the dispatcher runs, so this is **shippable behind the default flag with zero behavior change in the deployed dashboards**. The flip itself is #477.
- **Writable servers**:
  - safe `action_id` → executes, returns `200` + `{ok, action_id, target}`
  - approval-required `action_id` → `501` (unchanged; preserved for #475 part 2)
  - unknown `action_id` → `400`
  - missing `issue_number` (or missing `body` for `add_issue_comment`) → `400`
  - GitHub error → `502`
  - no GH client wired → `500`

## Wiring

- `controlActionRequest` gains optional `body` / `actor` / `reason` fields.
- `Server` gains `SetActionDeps(gh, audit)`; the three production `Server.New(...)` call sites in `cmd/maestro/main.go` now wire `github.New(cfg.Repo)` into it.
- `FleetProject` gains `SetActionGH`; `fleetProjectsFromConfigs` wires per-project.
- `FleetServer.fleetActionAudit` returns a per-project audit recorder closure that reuses `fleetAuditLogStateDir` + `appendFleetAuditLogEntry`.

## Verification (on workshop)

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` — all 17 packages pass; new `actions_test.go` adds 11 tests, all green:
  - each safe verb executes (audit invoked exactly once each)
  - all 9 non-safe `action_id`s fall through to 501 with no GH calls
  - `--read-only=true` short-circuits to 403 (no GH calls)
  - missing `issue_number` / missing `body` → 400
  - GH failure → 502; nil GH client → 500
  - unknown `action_id` → 400
- Built binary still embeds the MC SPA bundle (`strings | grep static/mc/assets/index-DAFl6kEe.js` → 2)
- Design guards (`scripts/check-design-tokens.sh`, `check-design-recipes.sh`) pass

## Out of scope (this PR)

- Approval-required action enqueue (cautious gate) — **#475 part 2**.
- Frontend enable / confirmation modal — **#476**.
- Flipping `--read-only` on the LAN-bound serves — **#477**.

Refs #475.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements the safe-action half of the dashboard write-path (#475 part 1): four label/comment verbs (`add_ready_label`, `remove_ready_label`, `remove_blocked_label`, `add_issue_comment`) are now executed directly against GitHub when the server is not in read-only mode, with per-project audit logging and a 403 short-circuit that keeps the default deployment unchanged.

- `internal/server/actions.go` introduces `dispatchSafeAction`, the narrow `actionGitHubClient` interface, and helper functions; wired into both the single-project and fleet action handlers.
- `internal/server/fleet.go` extends `FleetProject` with `SetActionGH` and adds `fleetActionAudit` to produce per-project audit closures reusing existing append logic.
- `cmd/maestro/main.go` threads `github.New(cfg.Repo)` into all three server startup paths and into each fleet project.

<h3>Confidence Score: 3/5</h3>

The default read-only flag keeps deployed dashboards unaffected, but actions.go contains a label-selection bug that can silently mutate the wrong label in writable deployments.

The safeActionReadyLabel function falls back to the first element of cfg.IssueLabels when no ReadyLabel is configured. IssueLabels is the set of labels maestro uses to filter which issues it tracks — using one of those as a readiness label means remove_ready_label could strip a filter label from an issue, silently removing it from maestro's tracking scope.

internal/server/actions.go — specifically safeActionReadyLabel and isApprovalRequiredAction

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/actions.go | New safe-action dispatcher; contains a logic bug where safeActionReadyLabel falls back to cfg.IssueLabels when ReadyLabel is unset, which could remove filter labels from issues. Also uses hardcoded strings for approval-required verbs where constants exist, and never populates AuditID in the response. |
| internal/server/actions_test.go | Comprehensive test coverage for all safe verbs, read-only gate, missing fields, GH failures, nil client, unknown/approval-required action IDs. |
| internal/server/fleet.go | Wires dispatchSafeAction into handleFleetAction with per-project GH client and audit closure; fleetActionAudit correctly reuses existing audit-log infrastructure. |
| internal/server/server.go | Adds gh/audit fields and SetActionDeps; threads them through handleControlAction. Clean and minimal change. |
| cmd/maestro/main.go | Wires github.New(cfg.Repo) into all three server startup paths and into each fleet project; straightforward plumbing. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/server/actions.go:149-162
`safeActionReadyLabel` falls back to the first element of `cfg.IssueLabels` when `cfg.Supervisor.ReadyLabel` is empty. `IssueLabels` is the set of labels used to *filter which issues maestro tracks* (e.g., `["bug", "feature"]`), not the readiness signal. If a user has `IssueLabels: ["bug"]` but no `ReadyLabel` configured, calling `remove_ready_label` would remove the `"bug"` label from the issue — effectively de-listing it from maestro's tracking scope entirely. The fallback should be dropped; an empty `ReadyLabel` should surface as the existing 500 "no ready label configured" error.

```suggestion
func safeActionReadyLabel(cfg *config.Config) string {
	if cfg == nil {
		return ""
	}
	return strings.TrimSpace(cfg.Supervisor.ReadyLabel)
}
```

### Issue 2 of 3
internal/server/actions.go:138-147
The four core approval-required verbs have typed constants in `internal/config` (`config.SupervisorActionMergePR`, etc.) but `isApprovalRequiredAction` uses bare string literals for them. If a constant value is ever changed, only the safe-action set would be updated and these strings would silently stop matching, causing approval-required actions to fall through to the unknown-action 400 branch instead of the intended 501.

```suggestion
func isApprovalRequiredAction(id string) bool {
	switch id {
	case config.SupervisorActionMergePR, config.SupervisorActionCloseIssue,
		config.SupervisorActionDeleteWorktree, config.SupervisorActionChangeGlobalConfig,
		// Existing UI affordances that are mutating but not in our safe set:
		"approve_merge", "restart_worker", "stop_worker",
		"mark_issue_ready", "mark_issue_blocked":
		return true
	}
	return false
}
```

### Issue 3 of 3
internal/server/actions.go:44-49
`safeActionResponse.AuditID` is declared with a JSON tag but `makeSafeOK` never sets it — callers always receive `"audit_id": ""` (or the field is omitted due to `omitempty`). If any consumer tries to use the returned `audit_id` to correlate actions with audit-log entries, it will always get an empty string. The `newFleetAuditID()` value generated inside the `fleetActionAudit` closure is never surfaced back to the caller.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(server): implement safe action endp..."](https://github.com/befeast/maestro/commit/995723cf0faef6faed18752d5bd0032752316e01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34705653)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->