### PR TITLE
feat(server): enqueue approvals for cautious-gate verbs (#475 part 2A)

### DIFF
--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
 )
 
 // actionGitHubClient is the narrow surface the safe-action dispatcher needs
@@ -60,8 +62,9 @@ func dispatchSafeAction(req controlActionRequest, cfg *config.Config, gh actionG
 	if id == "" {
 		return safeActionResult{handled: true, status: http.StatusBadRequest, body: map[string]string{"error": "action_id is required"}, err: errors.New("missing action_id")}
 	}
-	if isApprovalRequiredAction(id) {
-		// Not our responsibility — caller falls back to its 501 / approval path.
+	if isApprovalRequiredAction(id) || isUIOnlyAffordance(id) {
+		// Not our responsibility — caller dispatches to dispatchApprovalAction
+		// for the cautious-gate verbs, or falls back to 501 for UI-only.
 		return safeActionResult{handled: false}
 	}
 	if !isSafeAction(id) {
@@ -131,15 +134,27 @@ func isSafeAction(id string) bool {
 	return false
 }
 
-// isApprovalRequiredAction reports whether the action_id must go through the
-// cautious approval gate. These return handled=false from this dispatcher so
-// the existing 501 response is preserved (until the approval enqueue path
-// lands as part 2 of the dashboard write-path).
+// isApprovalRequiredAction reports whether the action_id is one of the four
+// cautious-gate verbs that must be enqueued as a pending Approval rather
+// than executed synchronously. dispatchApprovalAction handles these.
 func isApprovalRequiredAction(id string) bool {
 	switch id {
-	case "merge_pr", "close_issue", "delete_worktree", "change_global_config",
-		// Existing UI affordances that are mutating but not in our safe set:
-		"approve_merge", "restart_worker", "stop_worker",
+	case config.SupervisorActionMergePR,
+		config.SupervisorActionCloseIssue,
+		config.SupervisorActionDeleteWorktree,
+		config.SupervisorActionChangeGlobalConfig:
+		return true
+	}
+	return false
+}
+
+// isUIOnlyAffordance reports whether the action_id is a legacy UI-affordance
+// verb that is mutating but not yet wired into either dispatcher. These keep
+// returning 501 until they are migrated to safe or approval-required
+// semantics.
+func isUIOnlyAffordance(id string) bool {
+	switch id {
+	case "approve_merge", "restart_worker", "stop_worker",
 		"mark_issue_ready", "mark_issue_blocked":
 		return true
 	}
@@ -183,4 +198,171 @@ func makeSafeOK(id, target string, audit actionAuditRecorder, req controlActionR
 		_ = audit(actor, id, target, reason)
 	}
 	return resp
+}
+
+// approvalEnqueueResponse is the JSON body returned on a successful enqueue.
+type approvalEnqueueResponse struct {
+	OK         bool   `json:"ok"`
+	ActionID   string `json:"action_id"`
+	ApprovalID string `json:"approval_id"`
+	Status     string `json:"status"`
+	Target     string `json:"target,omitempty"`
+}
+
+// dispatchApprovalAction enqueues a pending Approval for one of the four
+// cautious-gate verbs (merge_pr, close_issue, delete_worktree,
+// change_global_config). It does NOT execute the action — that is the
+// approver/executor pipeline (#475 part 2 PR B).
+//
+// The HTTP caller must have cleared the read-only gate before this is
+// invoked.
+//
+// Returns 202 Accepted on success with the approval id, so callers can
+// distinguish enqueued-pending (202) from executed (200, safe actions).
+//
+// stateDir is the per-project state directory. nil cfg or empty stateDir
+// produce a 500 — the dashboard cannot enqueue without persistence.
+func dispatchApprovalAction(req controlActionRequest, cfg *config.Config, stateDir string, audit actionAuditRecorder) safeActionResult {
+	id := strings.TrimSpace(req.ActionID)
+	if !isApprovalRequiredAction(id) {
+		return safeActionResult{handled: false}
+	}
+	if cfg == nil {
+		return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "no project config bound to this server"}, err: errors.New("nil cfg")}
+	}
+	if strings.TrimSpace(stateDir) == "" {
+		return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "no state dir is available to record the approval"}, err: errors.New("empty state dir")}
+	}
+
+	// Per-verb argument validation — fail fast if the request is malformed.
+	if err := validateApprovalRequest(id, req); err != nil {
+		return safeActionResult{handled: true, status: http.StatusBadRequest, body: map[string]string{"error": err.Error()}, err: err}
+	}
+
+	st, err := state.Load(stateDir)
+	if err != nil {
+		return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": fmt.Sprintf("load state: %v", err)}, err: err}
+	}
+
+	now := time.Now().UTC()
+	decision := buildApprovalDecision(id, req, cfg, now)
+	approval := st.RecordPendingApprovalForDecision(decision, now)
+	if approval == nil {
+		return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "failed to record approval"}, err: errors.New("RecordPendingApprovalForDecision returned nil")}
+	}
+
+	if err := state.Save(stateDir, st); err != nil {
+		return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": fmt.Sprintf("save state: %v", err)}, err: err}
+	}
+
+	target := approvalTargetSummary(decision.Target)
+	if audit != nil {
+		actor := strings.TrimSpace(req.Actor)
+		if actor == "" {
+			actor = "dashboard"
+		}
+		reason := strings.TrimSpace(req.Reason)
+		if reason == "" {
+			reason = "enqueued by dashboard"
+		}
+		// Best-effort.
+		_ = audit(actor, "enqueue:"+id, target, reason)
+	}
+
+	return safeActionResult{
+		handled: true,
+		status:  http.StatusAccepted,
+		body: approvalEnqueueResponse{
+			OK:         true,
+			ActionID:   id,
+			ApprovalID: approval.ID,
+			Status:     string(approval.Status),
+			Target:     target,
+		},
+	}
+}
+
+// validateApprovalRequest enforces the per-verb required fields BEFORE we
+// touch state, so a 400 cannot leave a half-written approval.
+func validateApprovalRequest(id string, req controlActionRequest) error {
+	switch id {
+	case config.SupervisorActionMergePR:
+		if req.PRNumber <= 0 {
+			return errors.New("pr_number is required for merge_pr")
+		}
+	case config.SupervisorActionCloseIssue:
+		if req.IssueNumber <= 0 {
+			return errors.New("issue_number is required for close_issue")
+		}
+	case config.SupervisorActionDeleteWorktree:
+		if strings.TrimSpace(req.Slot) == "" {
+			return errors.New("slot is required for delete_worktree")
+		}
+	case config.SupervisorActionChangeGlobalConfig:
+		if strings.TrimSpace(req.Reason) == "" {
+			return errors.New("reason is required for change_global_config")
+		}
+	}
+	return nil
+}
+
+// buildApprovalDecision constructs a synthetic SupervisorDecision so the
+// HTTP enqueue path uses the same approval pipeline as the LLM supervisor.
+// The decision is recorded in state as the approval source.
+func buildApprovalDecision(id string, req controlActionRequest, cfg *config.Config, now time.Time) state.SupervisorDecision {
+	actor := strings.TrimSpace(req.Actor)
+	if actor == "" {
+		actor = "dashboard"
+	}
+	summary := strings.TrimSpace(req.Reason)
+	if summary == "" {
+		summary = fmt.Sprintf("HTTP enqueue of %s", id)
+	}
+
+	target := &state.SupervisorTarget{
+		Issue:   req.IssueNumber,
+		PR:      req.PRNumber,
+		Session: strings.TrimSpace(req.Slot),
+	}
+	if target.Issue == 0 && target.PR == 0 && target.Session == "" {
+		target = nil
+	}
+
+	projectName := strings.TrimSpace(req.Project)
+	if projectName == "" && cfg != nil {
+		projectName = cfg.Repo
+	}
+
+	decision := state.SupervisorDecision{
+		ID:                fmt.Sprintf("http-%s-%s", id, now.UTC().Format("20060102T150405.000000000Z")),
+		CreatedAt:         now,
+		Project:           projectName,
+		Mode:              "http_enqueue",
+		Status:            "pending_approval",
+		Summary:           summary,
+		RecommendedAction: id,
+		Target:            target,
+		Risk:              "high",
+		Confidence:        1.0,
+		Reasons:           []string{fmt.Sprintf("enqueued by %s via /api/v1/.../actions", actor)},
+		RequiresApproval:  true,
+	}
+	return decision
+}
+
+func approvalTargetSummary(target *state.SupervisorTarget) string {
+	if target == nil {
+		return ""
+	}
+	parts := []string{}
+	if target.Issue > 0 {
+		parts = append(parts, fmt.Sprintf("issue #%d", target.Issue))
+	}
+	if target.PR > 0 {
+		parts = append(parts, fmt.Sprintf("PR #%d", target.PR))
+	}
+	if target.Session != "" {
+		parts = append(parts, "session "+target.Session)
+	}
+	return strings.Join(parts, " ")
 }

--- a/internal/server/actions_test.go
+++ b/internal/server/actions_test.go
@@ -170,15 +170,16 @@ func TestSafeAction_RequiresIssueNumber(t *testing.T) {
 	}
 }
 
-func TestSafeAction_ApprovalRequiredFallsThroughTo501(t *testing.T) {
-	// merge_pr is approval-required (#475 part 2 territory). It must NOT be
-	// executed by this dispatcher; the handler must still respond with 501.
+func TestSafeAction_UIOnlyAffordancesStill501(t *testing.T) {
+	// The 5 legacy UI-affordance verbs are still 501. They are not in the
+	// "safe" set (no GH call) and not yet wired into the cautious-gate
+	// dispatcher; we surface the same response the dashboard shipped before.
 	gh := &fakeActionGH{}
 	srv := New(newSafeActionTestCfg(), nil)
 	srv.SetActionDeps(gh, nil)
 
-	for _, id := range []string{"merge_pr", "close_issue", "delete_worktree", "change_global_config",
-		"approve_merge", "restart_worker", "stop_worker", "mark_issue_ready", "mark_issue_blocked"} {
+	for _, id := range []string{"approve_merge", "restart_worker", "stop_worker",
+		"mark_issue_ready", "mark_issue_blocked"} {
 		w := postAction(t, srv, fmt.Sprintf(`{"action_id":%q,"issue_number":1}`, id))
 		if w.Code != http.StatusNotImplemented {
 			t.Fatalf("action %q: status = %d, want 501; body=%s", id, w.Code, w.Body.String())

--- a/internal/server/approval_action_test.go
+++ b/internal/server/approval_action_test.go
@@ -1,0 +1,240 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// approvalEnqueueCfg returns a config bound to a fresh per-test state dir,
+// suitable for dispatchApprovalAction tests.
+func approvalEnqueueCfg(t *testing.T) (*config.Config, string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := newSafeActionTestCfg()
+	cfg.StateDir = dir
+	return cfg, dir
+}
+
+func postApprovalAction(t *testing.T, srv *Server, payload string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/actions", bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleAction(w, req)
+	return w
+}
+
+func loadStateAt(t *testing.T, dir string) *state.State {
+	t.Helper()
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state at %q: %v", dir, err)
+	}
+	return st
+}
+
+// --- enqueue happy paths -----------------------------------------------------
+
+func TestApprovalAction_MergePR_Enqueues202(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	gh := &fakeActionGH{}
+	auditCalls := 0
+	srv := New(cfg, nil)
+	srv.SetActionDeps(gh, func(actor, action, target, reason string) error {
+		auditCalls++
+		if action != "enqueue:merge_pr" {
+			t.Errorf("audit action = %q, want enqueue:merge_pr", action)
+		}
+		return nil
+	})
+
+	w := postApprovalAction(t, srv, `{"action_id":"merge_pr","pr_number":42,"issue_number":99,"actor":"oleg","reason":"PR is green, gates clear"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+
+	var resp approvalEnqueueResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || resp.ActionID != "merge_pr" || resp.ApprovalID == "" || resp.Status != "pending" {
+		t.Fatalf("response = %+v", resp)
+	}
+	if auditCalls != 1 {
+		t.Fatalf("audit calls = %d, want 1", auditCalls)
+	}
+
+	// gh client must NOT have been touched: enqueue must not execute.
+	if len(gh.addLabelCalls)+len(gh.removeLabelCalls)+len(gh.commentCalls) != 0 {
+		t.Fatalf("gh was unexpectedly called during enqueue")
+	}
+
+	// state on disk has exactly one pending approval for merge_pr.
+	st := loadStateAt(t, dir)
+	if len(st.Approvals) != 1 {
+		t.Fatalf("approvals = %d, want 1", len(st.Approvals))
+	}
+	got := st.Approvals[0]
+	if got.Status != state.ApprovalStatusPending {
+		t.Fatalf("approval status = %q, want pending", got.Status)
+	}
+	if got.Action != "merge_pr" {
+		t.Fatalf("approval action = %q, want merge_pr", got.Action)
+	}
+	if got.Target == nil || got.Target.PR != 42 {
+		t.Fatalf("approval target = %+v, want PR=42", got.Target)
+	}
+	// state file should exist.
+	if _, err := filepath.Abs(filepath.Join(dir, "state.json")); err != nil {
+		t.Fatalf("state path: %v", err)
+	}
+}
+
+func TestApprovalAction_CloseIssue_Enqueues202(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"close_issue","issue_number":7,"reason":"obsolete"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	st := loadStateAt(t, dir)
+	if len(st.Approvals) != 1 || st.Approvals[0].Action != "close_issue" || st.Approvals[0].Target.Issue != 7 {
+		t.Fatalf("state.Approvals = %+v", st.Approvals)
+	}
+}
+
+func TestApprovalAction_DeleteWorktree_Enqueues202(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"delete_worktree","slot":"sup-77","reason":"stale codex"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	st := loadStateAt(t, dir)
+	if len(st.Approvals) != 1 || st.Approvals[0].Action != "delete_worktree" || st.Approvals[0].Target.Session != "sup-77" {
+		t.Fatalf("state.Approvals = %+v", st.Approvals)
+	}
+}
+
+func TestApprovalAction_ChangeGlobalConfig_Enqueues202(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"change_global_config","reason":"swap default backend"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	st := loadStateAt(t, dir)
+	if len(st.Approvals) != 1 || st.Approvals[0].Action != "change_global_config" {
+		t.Fatalf("state.Approvals = %+v", st.Approvals)
+	}
+}
+
+// --- enqueue error paths ----------------------------------------------------
+
+func TestApprovalAction_MergePR_RequiresPRNumber(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"merge_pr","issue_number":1}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if st := loadStateAt(t, dir); len(st.Approvals) != 0 {
+		t.Fatalf("approvals leaked on bad request: %+v", st.Approvals)
+	}
+}
+
+func TestApprovalAction_CloseIssue_RequiresIssueNumber(t *testing.T) {
+	cfg, _ := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"close_issue"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestApprovalAction_DeleteWorktree_RequiresSlot(t *testing.T) {
+	cfg, _ := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"delete_worktree"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestApprovalAction_ChangeGlobalConfig_RequiresReason(t *testing.T) {
+	cfg, _ := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"change_global_config"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestApprovalAction_NoStateDirReturns500(t *testing.T) {
+	cfg := newSafeActionTestCfg() // no StateDir set
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"merge_pr","pr_number":1}`)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestApprovalAction_ReadOnlyShortCircuits(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	cfg.Server.ReadOnly = true
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"merge_pr","pr_number":1}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if st := loadStateAt(t, dir); len(st.Approvals) != 0 {
+		t.Fatalf("approvals recorded under --read-only: %+v", st.Approvals)
+	}
+}
+
+// Two enqueues for the same payload create two distinct approvals (the
+// supervisor's superseded/payload-hash logic handles dedup elsewhere; HTTP
+// callers that need idempotency can read the returned approval_id and stop).
+func TestApprovalAction_SecondEnqueueIsDistinctApproval(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w1 := postApprovalAction(t, srv, `{"action_id":"merge_pr","pr_number":1}`)
+	w2 := postApprovalAction(t, srv, `{"action_id":"merge_pr","pr_number":1}`)
+	if w1.Code != http.StatusAccepted || w2.Code != http.StatusAccepted {
+		t.Fatalf("statuses = %d, %d", w1.Code, w2.Code)
+	}
+	st := loadStateAt(t, dir)
+	if len(st.Approvals) != 2 {
+		t.Fatalf("approvals = %d, want 2", len(st.Approvals))
+	}
+	if st.Approvals[0].ID == st.Approvals[1].ID {
+		t.Fatalf("approvals share the same ID: %s", st.Approvals[0].ID)
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -586,6 +586,18 @@ func (s *FleetServer) handleFleetAction(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	stateDir := ""
+	if cfg != nil {
+		stateDir = cfg.StateDir
+	}
+	if res := dispatchApprovalAction(req, cfg, stateDir, audit); res.handled {
+		if res.err != nil {
+			log.Printf("[fleet] approval enqueue %q for project %q failed: %v", req.ActionID, req.Project, res.err)
+		}
+		writeJSON(w, res.status, res.body)
+		return
+	}
+
 	writeError(w, http.StatusNotImplemented, "approval-backed action endpoints are not implemented yet")
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1034,10 +1034,14 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAction(w http.ResponseWriter, r *http.Request) {
-	handleControlAction(w, r, s.cfg.Server.ReadOnly, "server", s.cfg, s.gh, s.audit)
+	stateDir := ""
+	if s.cfg != nil {
+		stateDir = s.cfg.StateDir
+	}
+	handleControlAction(w, r, s.cfg.Server.ReadOnly, "server", s.cfg, stateDir, s.gh, s.audit)
 }
 
-func handleControlAction(w http.ResponseWriter, r *http.Request, readOnly bool, scope string, cfg *config.Config, gh actionGitHubClient, audit actionAuditRecorder) {
+func handleControlAction(w http.ResponseWriter, r *http.Request, readOnly bool, scope string, cfg *config.Config, stateDir string, gh actionGitHubClient, audit actionAuditRecorder) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -1059,6 +1063,14 @@ func handleControlAction(w http.ResponseWriter, r *http.Request, readOnly bool, 
 	if res := dispatchSafeAction(req, cfg, gh, audit); res.handled {
 		if res.err != nil {
 			log.Printf("[server] safe action %q failed: %v", req.ActionID, res.err)
+		}
+		writeJSON(w, res.status, res.body)
+		return
+	}
+
+	if res := dispatchApprovalAction(req, cfg, stateDir, audit); res.handled {
+		if res.err != nil {
+			log.Printf("[server] approval enqueue %q failed: %v", req.ActionID, res.err)
 		}
 		writeJSON(w, res.status, res.body)
 		return


### PR DESCRIPTION
## Summary

**Part 2A** of #475 (the cautious-gate write-path) — wires the four approval-required `action_id`s into the existing approval pipeline (`state.RecordPendingApprovalForDecision`), so an HTTP POST creates a **pending** approval and returns **202 Accepted** with the `approval_id`. **Part 2B** (the executor that turns approved approvals into real `gh.MergePR` / `gh.CloseIssue` / `worker.RemoveWorktree` calls) is the next PR.

| `action_id` | required field | enqueue side effect |
|---|---|---|
| `merge_pr` | `pr_number` | pending Approval, target = PR |
| `close_issue` | `issue_number` | pending Approval, target = issue |
| `delete_worktree` | `slot` | pending Approval, target = session |
| `change_global_config` | `reason` | pending Approval, no concrete target |

## HTTP semantics

- **202 Accepted** — approval enqueued; body `{ok, action_id, approval_id, status:"pending", target}`.
- **400** — missing per-verb required field; nothing written to state.
- **403** — `--read-only` short-circuits before the dispatcher (default deployment behavior, unchanged).
- **500** — server has no state dir to persist the approval.
- The GH client is **never** touched: enqueue must not execute. Until part 2B lands, approving an enqueued approval still says "No risky action was executed" — same as the CLI does today.

## Layering

`handleControlAction` / `handleFleetAction` now call:

1. `dispatchSafeAction` (safe verbs — direct execute, 200) — landed in #478
2. `dispatchApprovalAction` (4 cautious verbs — enqueue, 202) — **this PR**
3. fallback 501 for legacy UI-affordance verbs (`approve_merge`, `restart_worker`, `stop_worker`, `mark_issue_*`)

`isApprovalRequiredAction` now strictly matches the four cautious-gate verbs; the new `isUIOnlyAffordance` helper covers the legacy UI verbs that still 501.

## Verification (on workshop)

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` — all 17 packages pass
- 11 new tests in `approval_action_test.go` (each verb enqueues, per-verb 400 paths, read-only short-circuits, missing state dir → 500, gh never called, two enqueues create two distinct approvals)
- existing `TestSafeAction_*` regressions pass; the old "all approval-required → 501" test split into `TestSafeAction_UIOnlyAffordancesStill501` (5 verbs) plus the new approval enqueue tests for the 4 cautious verbs

## Out of scope (this PR)

- **Executor (part 2B):** turning an approved Approval into a real `gh.MergePR` / `gh.CloseIssue` / `worker.RemoveWorktree` / config diff. Until that ships, approve is still inert by design — same as today.
- Frontend enable / confirmation modal — **#476**.
- Flipping `--read-only` on the LAN-bound serves — **#477**.

Refs #475.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the four cautious-gate action verbs (`merge_pr`, `close_issue`, `delete_worktree`, `change_global_config`) into the existing approval pipeline, so an HTTP POST to the actions endpoint creates a pending `Approval` in state and returns 202 Accepted with the `approval_id`. Execution (part 2B) is explicitly deferred.

- `dispatchApprovalAction` is added alongside `dispatchSafeAction`; it validates per-verb required fields before touching state, calls `state.RecordPendingApprovalForDecision`, persists via `state.Save`, and returns a structured 202 body.
- `isApprovalRequiredAction` is tightened to only the four cautious-gate verbs, and a new `isUIOnlyAffordance` helper covers the five legacy UI verbs that remain 501.
- Both the single-project server and the fleet server get symmetric `stateDir` wiring and identical dispatcher call order.

<h3>Confidence Score: 3/5</h3>

The enqueue path is correct for sequential requests, but the time-based decision ID is not safe against two concurrent POSTs arriving at the same OS clock tick, which can silently produce two approvals sharing one ID in state.

The new `buildApprovalDecision` constructs its ID exclusively from a nanosecond timestamp. On a loaded server or in a CI environment with a coarser system clock, two concurrent enqueue requests can capture the same `time.Now()` value, yielding duplicate `Approval.ID`s in state. `RecordPendingApprovalForDecision` appends unconditionally, so both approvals are persisted, but any lookup (e.g., the part-2B executor) will always resolve to the first one, silently conflating two separate pending actions.

The ID-generation logic in `buildApprovalDecision` in `internal/server/actions.go` needs attention before this is used under real concurrent load.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/actions.go | Adds `dispatchApprovalAction` and supporting helpers to enqueue the four cautious-gate verbs as pending approvals; decision ID is time-based with nanosecond precision, creating a collision window for concurrent requests. |
| internal/server/approval_action_test.go | 11 new tests covering all four enqueue paths, per-verb 400s, read-only 403, missing state dir 500, and double-enqueue distinctness; one assertion uses `filepath.Abs` instead of `os.Stat` and never actually checks file existence. |
| internal/server/actions_test.go | Existing safe-action test renamed and narrowed to only the 5 legacy UI-only affordances; the 4 cautious-gate verbs are correctly removed from the 501 check. |
| internal/server/server.go | Wires `stateDir` from `s.cfg.StateDir` and threads it through to `handleControlAction`; `dispatchApprovalAction` is now called between the safe-action dispatcher and the 501 fallback. |
| internal/server/fleet.go | Fleet handler gets the same `stateDir`/`dispatchApprovalAction` wiring as the single-project server handler; change is symmetric and correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/actions.go:337
**Approval ID collision under concurrent requests**

The decision ID is derived solely from `now` (nanosecond-precision timestamp). Two concurrent HTTP POST requests hitting the server at the same OS clock tick produce identical IDs (`http-merge_pr-<same-timestamp>`), which `approvalID` maps to the same `approval-http-merge_pr-<same-timestamp>`. Because `RecordPendingApprovalForDecision` appends unconditionally without a uniqueness check, both approvals land in `s.Approvals` with the same `ID`. Any subsequent `FindApproval` call (e.g., in the part-2B executor) will always resolve to the first one, silently conflating two distinct pending actions. Adding a random suffix (e.g., `fmt.Sprintf("%s-%s", prefix, uuid())` or `crypto/rand`) would make the ID collision-proof.

### Issue 2 of 2
internal/server/approval_action_test.go:94-97
`filepath.Abs` never returns an error for a valid path (it only fails if the working-directory lookup itself fails, which is effectively never). The assertion always passes regardless of whether `state.json` was actually written to disk. The intent seems to be to check file existence, which requires `os.Stat`.

```suggestion
	// state file should exist.
	if _, err := os.Stat(filepath.Join(dir, "state.json")); err != nil {
		t.Fatalf("state file: %v", err)
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(server): enqueue approvals for caut..."](https://github.com/befeast/maestro/commit/b2a2dcd385a625e53006ba4cad49eaa9c396d63a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34707581)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->