### PR TITLE
feat(approver): execute approved approvals (#475 part 2B)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/server"
+	"github.com/befeast/maestro/internal/approver"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/supervisor"
 	"github.com/befeast/maestro/internal/versioning"
@@ -547,7 +548,56 @@ func superviseApprovalCmd(action string, args []string, defaultConfigPath string
 	if err := state.Save(cfg.StateDir, st); err != nil {
 		log.Fatalf("supervise %s: save state: %v", action, err)
 	}
-	fmt.Printf("Approval %s %s. No risky action was executed.\n", approval.ID, approval.Status)
+
+	if action != "approve" {
+		fmt.Printf("Approval %s %s.\n", approval.ID, approval.Status)
+		return
+	}
+
+	// Execute the now-approved approval. Synchronous and blocking; the
+	// caller (operator) sees the result on stdout and via exit code.
+	ex := &approver.Executor{
+		GH:        github.New(cfg.Repo),
+		Worktrees: approver.WorktreeRemoverFunc(worker.RemoveWorktree),
+		Cfg:       cfg,
+	}
+	res := ex.Execute(approval)
+
+	now = time.Now().UTC()
+	switch res.Status {
+	case state.ApprovalStatusExecuted:
+		if _, mErr := st.MarkApprovalExecuted(approval.ID, now, *actor, res.Summary); mErr != nil {
+			log.Fatalf("supervise approve: mark executed: %v", mErr)
+		}
+	case state.ApprovalStatusExecutionSkipped:
+		if _, mErr := st.MarkApprovalExecutionSkipped(approval.ID, now, *actor, res.Summary); mErr != nil {
+			log.Fatalf("supervise approve: mark skipped: %v", mErr)
+		}
+	default: // execution_failed
+		msg := res.Summary
+		if msg == "" && res.Err != nil {
+			msg = res.Err.Error()
+		}
+		if _, mErr := st.MarkApprovalExecutionFailed(approval.ID, now, *actor, msg); mErr != nil {
+			log.Fatalf("supervise approve: mark failed: %v", mErr)
+		}
+	}
+
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		log.Fatalf("supervise approve: save state after execution: %v", err)
+	}
+
+	switch res.Status {
+	case state.ApprovalStatusExecuted:
+		fmt.Printf("Approval %s executed: %s\n", approval.ID, res.Summary)
+	case state.ApprovalStatusExecutionSkipped:
+		fmt.Printf("Approval %s skipped: %s\n", approval.ID, res.Summary)
+	default:
+		if res.Err != nil {
+			log.Fatalf("Approval %s execution failed: %v", approval.ID, res.Err)
+		}
+		log.Fatalf("Approval %s execution failed: %s", approval.ID, res.Summary)
+	}
 }
 
 func printSupervisorDecision(decision state.SupervisorDecision, jsonOutput bool) {

--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -1,0 +1,219 @@
+// Package approver turns an approved supervisor Approval into the real
+// side-effecting action it represents (gh.MergePR, gh.CloseIssue,
+// worker.RemoveWorktree). It is the execution stage of the cautious gate;
+// state.go only records the transition, this package actually performs
+// the work.
+//
+// Execution is intentionally synchronous and blocking — callers (CLI
+// approve, supervisor poll) drive the loop, the executor never spawns
+// goroutines. Each verb returns a clear error or nil, and the caller is
+// responsible for transitioning state via MarkApprovalExecuted /
+// MarkApprovalExecutionFailed / MarkApprovalExecutionSkipped.
+package approver
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// GitHubClient is the surface the executor needs from a GitHub client.
+// *github.Client satisfies this; tests inject fakes.
+type GitHubClient interface {
+	MergePR(prNumber int) error
+	CloseIssue(number int, comment string) error
+}
+
+// WorktreeRemover removes a git worktree. *worker.RemoveWorktree-shaped
+// callers satisfy this. Tests inject a fake.
+type WorktreeRemover interface {
+	RemoveWorktree(localPath, worktreePath string) error
+}
+
+// WorktreeRemoverFunc adapts a plain function to the WorktreeRemover
+// interface (so cmd/maestro can pass worker.RemoveWorktree directly).
+type WorktreeRemoverFunc func(localPath, worktreePath string) error
+
+func (f WorktreeRemoverFunc) RemoveWorktree(localPath, worktreePath string) error {
+	return f(localPath, worktreePath)
+}
+
+// Executor carries the dependencies needed to run any of the four
+// cautious-gate verbs.
+type Executor struct {
+	GH        GitHubClient
+	Worktrees WorktreeRemover
+	Cfg       *config.Config
+}
+
+// Result describes the outcome of executing one approval.
+//
+//   - Status         — terminal state to transition the approval to:
+//                      executed | execution_failed | execution_skipped.
+//   - Summary        — short human-facing line for the audit entry and
+//                      CLI output.
+//   - Err            — non-nil only when Status == execution_failed; the
+//                      caller marks failure and surfaces err to its
+//                      operator (CLI exit code, supervisor log).
+type Result struct {
+	Status  state.ApprovalStatus
+	Summary string
+	Err     error
+}
+
+// ErrUnknownAction is returned when the approval's Action does not match
+// any of the four cautious-gate verbs the executor knows.
+var ErrUnknownAction = errors.New("unknown approval action")
+
+// ErrMissingTarget is returned when the approval lacks the per-verb
+// target field the executor needs (PR number, issue number, session).
+var ErrMissingTarget = errors.New("approval target is missing required fields")
+
+// Execute drives one approval to its real-world side effect. The caller
+// is responsible for the state transition (Mark*) using the returned
+// Result. Execute itself does NOT touch state — keeping state mutation
+// at the caller boundary makes the unit a pure function of (approval,
+// executor) and trivial to test.
+//
+// Execute does NOT validate the approval's status — callers must only
+// pass approvals in status=approved (use state.ListApprovedApprovals).
+func (e *Executor) Execute(approval *state.Approval) Result {
+	if approval == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("nil approval")}
+	}
+	switch approval.Action {
+	case config.SupervisorActionMergePR:
+		return e.executeMergePR(approval)
+	case config.SupervisorActionCloseIssue:
+		return e.executeCloseIssue(approval)
+	case config.SupervisorActionDeleteWorktree:
+		return e.executeDeleteWorktree(approval)
+	case config.SupervisorActionChangeGlobalConfig:
+		// Intentionally NOT implemented in this PR — the YAML mutation
+		// pipeline (whitelist, atomic write, restart coordination) is
+		// risky enough to warrant its own change. The approver records
+		// the intent; an operator still has to edit the config and
+		// restart the daemon. See follow-up issue.
+		return Result{
+			Status:  state.ApprovalStatusExecutionSkipped,
+			Summary: "change_global_config requires a manual edit + systemctl restart (executor not implemented)",
+		}
+	}
+	return Result{
+		Status:  state.ApprovalStatusExecutionFailed,
+		Summary: fmt.Sprintf("unknown approval action %q", approval.Action),
+		Err:     fmt.Errorf("%w: %s", ErrUnknownAction, approval.Action),
+	}
+}
+
+func (e *Executor) executeMergePR(approval *state.Approval) Result {
+	if approval.Target == nil || approval.Target.PR <= 0 {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: fmt.Errorf("%w: PR number missing", ErrMissingTarget)}
+	}
+	if e.GH == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no GitHub client wired into executor")}
+	}
+	pr := approval.Target.PR
+	if err := e.GH.MergePR(pr); err != nil {
+		return Result{
+			Status:  state.ApprovalStatusExecutionFailed,
+			Summary: fmt.Sprintf("merge PR #%d: %v", pr, err),
+			Err:     fmt.Errorf("merge PR #%d: %w", pr, err),
+		}
+	}
+	return Result{
+		Status:  state.ApprovalStatusExecuted,
+		Summary: fmt.Sprintf("merged PR #%d", pr),
+	}
+}
+
+func (e *Executor) executeCloseIssue(approval *state.Approval) Result {
+	if approval.Target == nil || approval.Target.Issue <= 0 {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: fmt.Errorf("%w: issue number missing", ErrMissingTarget)}
+	}
+	if e.GH == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no GitHub client wired into executor")}
+	}
+	issue := approval.Target.Issue
+	comment := strings.TrimSpace(approvalCloseIssueComment(approval))
+	if err := e.GH.CloseIssue(issue, comment); err != nil {
+		return Result{
+			Status:  state.ApprovalStatusExecutionFailed,
+			Summary: fmt.Sprintf("close issue #%d: %v", issue, err),
+			Err:     fmt.Errorf("close issue #%d: %w", issue, err),
+		}
+	}
+	return Result{
+		Status:  state.ApprovalStatusExecuted,
+		Summary: fmt.Sprintf("closed issue #%d", issue),
+	}
+}
+
+func approvalCloseIssueComment(approval *state.Approval) string {
+	// Prefer the operator's reason (it is the most recent audit entry's
+	// Reason for the Approve event). Fall back to the approval Summary.
+	for i := len(approval.Audit) - 1; i >= 0; i-- {
+		if approval.Audit[i].Event == state.ApprovalAuditApproved {
+			if r := strings.TrimSpace(approval.Audit[i].Reason); r != "" {
+				return r
+			}
+			break
+		}
+	}
+	return strings.TrimSpace(approval.Summary)
+}
+
+func (e *Executor) executeDeleteWorktree(approval *state.Approval) Result {
+	if approval.Target == nil || strings.TrimSpace(approval.Target.Session) == "" {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: fmt.Errorf("%w: session/slot missing", ErrMissingTarget)}
+	}
+	if e.Worktrees == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no worktree remover wired into executor")}
+	}
+	if e.Cfg == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no project config wired into executor")}
+	}
+	slot := approval.Target.Session
+	worktreePath, err := WorktreePathForSlot(e.Cfg, slot)
+	if err != nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: err}
+	}
+	if err := e.Worktrees.RemoveWorktree(e.Cfg.LocalPath, worktreePath); err != nil {
+		return Result{
+			Status:  state.ApprovalStatusExecutionFailed,
+			Summary: fmt.Sprintf("delete worktree %s: %v", worktreePath, err),
+			Err:     fmt.Errorf("delete worktree %s: %w", worktreePath, err),
+		}
+	}
+	return Result{
+		Status:  state.ApprovalStatusExecuted,
+		Summary: fmt.Sprintf("removed worktree for slot %s (%s)", slot, worktreePath),
+	}
+}
+
+// WorktreePathForSlot returns the absolute worktree path for a session
+// slot, anchored under cfg.WorktreeBase. Refuses paths that escape that
+// base — defensive guard against a malformed slot ("../etc", "/tmp/x")
+// being smuggled into delete_worktree.
+func WorktreePathForSlot(cfg *config.Config, slot string) (string, error) {
+	base := strings.TrimSpace(cfg.WorktreeBase)
+	if base == "" {
+		return "", errors.New("cfg.worktree_base is not set")
+	}
+	clean := strings.TrimSpace(slot)
+	if clean == "" {
+		return "", errors.New("slot is empty")
+	}
+	if strings.ContainsAny(clean, "/\\") || clean == "." || clean == ".." {
+		return "", fmt.Errorf("slot %q contains a path separator or traversal segment; refusing", slot)
+	}
+	// filepath.Join intentionally not imported here — concatenate via "/"
+	// to keep the boundary explicit and predictable on the path.
+	if strings.HasSuffix(base, "/") {
+		return base + clean, nil
+	}
+	return base + "/" + clean, nil
+}

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -1,0 +1,256 @@
+package approver
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// fakeGH lets tests stub MergePR and CloseIssue.
+type fakeGH struct {
+	mergeCalls  []int
+	closeCalls  []closeCall
+	mergeErr    error
+	closeErr    error
+}
+
+type closeCall struct {
+	issue   int
+	comment string
+}
+
+func (f *fakeGH) MergePR(pr int) error {
+	f.mergeCalls = append(f.mergeCalls, pr)
+	return f.mergeErr
+}
+func (f *fakeGH) CloseIssue(issue int, comment string) error {
+	f.closeCalls = append(f.closeCalls, closeCall{issue: issue, comment: comment})
+	return f.closeErr
+}
+
+type fakeWT struct {
+	calls []wtCall
+	err   error
+}
+type wtCall struct {
+	localPath, worktree string
+}
+
+func (f *fakeWT) RemoveWorktree(localPath, worktreePath string) error {
+	f.calls = append(f.calls, wtCall{localPath: localPath, worktree: worktreePath})
+	return f.err
+}
+
+func newCfg() *config.Config {
+	return &config.Config{
+		Repo:         "owner/repo",
+		LocalPath:    "/srv/maestro",
+		WorktreeBase: "/srv/wt",
+	}
+}
+
+func mkApproval(action string, target *state.SupervisorTarget, summary, approveReason string) *state.Approval {
+	now := time.Now().UTC()
+	a := &state.Approval{
+		ID:        "approval-test",
+		CreatedAt: now,
+		UpdatedAt: now,
+		Action:    action,
+		Target:    target,
+		Summary:   summary,
+		Risk:      "high",
+		Status:    state.ApprovalStatusApproved,
+	}
+	a.Audit = []state.ApprovalAudit{
+		{At: now, Event: state.ApprovalAuditCreated},
+	}
+	if approveReason != "" {
+		a.Audit = append(a.Audit, state.ApprovalAudit{At: now, Event: state.ApprovalAuditApproved, Actor: "cli", Reason: approveReason})
+	}
+	return a
+}
+
+// --- merge_pr ---------------------------------------------------------------
+
+func TestExecute_MergePR_HappyPath(t *testing.T) {
+	gh := &fakeGH{}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 99}, "merge me", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("status = %q, want executed; res=%+v", res.Status, res)
+	}
+	if !strings.Contains(res.Summary, "#99") {
+		t.Fatalf("summary = %q", res.Summary)
+	}
+	if len(gh.mergeCalls) != 1 || gh.mergeCalls[0] != 99 {
+		t.Fatalf("mergeCalls = %v", gh.mergeCalls)
+	}
+}
+
+func TestExecute_MergePR_RequiresPRTarget(t *testing.T) {
+	ex := &Executor{GH: &fakeGH{}, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionMergePR, nil, "no target", "")
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed || !errors.Is(res.Err, ErrMissingTarget) {
+		t.Fatalf("res = %+v, want execution_failed + ErrMissingTarget", res)
+	}
+}
+
+func TestExecute_MergePR_GHError_Surfaces(t *testing.T) {
+	gh := &fakeGH{mergeErr: errors.New("boom")}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 1}, "x", "")
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed || res.Err == nil {
+		t.Fatalf("res = %+v, want execution_failed", res)
+	}
+	if !strings.Contains(res.Err.Error(), "merge PR #1") {
+		t.Fatalf("err message lacks PR id: %v", res.Err)
+	}
+}
+
+func TestExecute_MergePR_NilGH(t *testing.T) {
+	ex := &Executor{Cfg: newCfg()} // no GH
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 1}, "x", "")
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed || res.Err == nil {
+		t.Fatalf("res = %+v, want execution_failed", res)
+	}
+}
+
+// --- close_issue ------------------------------------------------------------
+
+func TestExecute_CloseIssue_HappyPath_UsesApproveReasonAsComment(t *testing.T) {
+	gh := &fakeGH{}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionCloseIssue, &state.SupervisorTarget{Issue: 7}, "summary fallback", "obsolete after refactor")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v", res)
+	}
+	if len(gh.closeCalls) != 1 || gh.closeCalls[0].issue != 7 || gh.closeCalls[0].comment != "obsolete after refactor" {
+		t.Fatalf("closeCalls = %+v", gh.closeCalls)
+	}
+}
+
+func TestExecute_CloseIssue_NoApproveReason_UsesSummary(t *testing.T) {
+	gh := &fakeGH{}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionCloseIssue, &state.SupervisorTarget{Issue: 8}, "summary text", "")
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v", res)
+	}
+	if gh.closeCalls[0].comment != "summary text" {
+		t.Fatalf("expected summary fallback, got %q", gh.closeCalls[0].comment)
+	}
+}
+
+func TestExecute_CloseIssue_RequiresTarget(t *testing.T) {
+	ex := &Executor{GH: &fakeGH{}, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionCloseIssue, nil, "x", "")
+	res := ex.Execute(a)
+	if !errors.Is(res.Err, ErrMissingTarget) {
+		t.Fatalf("res = %+v, want ErrMissingTarget", res)
+	}
+}
+
+// --- delete_worktree --------------------------------------------------------
+
+func TestExecute_DeleteWorktree_HappyPath_AnchoredUnderBase(t *testing.T) {
+	wt := &fakeWT{}
+	cfg := newCfg()
+	ex := &Executor{Worktrees: wt, Cfg: cfg}
+	a := mkApproval(config.SupervisorActionDeleteWorktree, &state.SupervisorTarget{Session: "sup-77"}, "stale", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v", res)
+	}
+	if len(wt.calls) != 1 {
+		t.Fatalf("wt.calls = %v", wt.calls)
+	}
+	if wt.calls[0].localPath != "/srv/maestro" {
+		t.Fatalf("localPath = %q", wt.calls[0].localPath)
+	}
+	if wt.calls[0].worktree != "/srv/wt/sup-77" {
+		t.Fatalf("worktree = %q, want /srv/wt/sup-77", wt.calls[0].worktree)
+	}
+}
+
+func TestExecute_DeleteWorktree_RefusesPathTraversal(t *testing.T) {
+	wt := &fakeWT{}
+	ex := &Executor{Worktrees: wt, Cfg: newCfg()}
+	for _, evil := range []string{"../etc", "../../tmp", "/tmp/x", "a/b", "."} {
+		a := mkApproval(config.SupervisorActionDeleteWorktree, &state.SupervisorTarget{Session: evil}, "x", "")
+		res := ex.Execute(a)
+		if res.Status != state.ApprovalStatusExecutionFailed || res.Err == nil {
+			t.Fatalf("slot %q: res = %+v, want execution_failed", evil, res)
+		}
+		if len(wt.calls) != 0 {
+			t.Fatalf("slot %q: RemoveWorktree was called: %+v", evil, wt.calls)
+		}
+	}
+}
+
+func TestExecute_DeleteWorktree_RequiresWorktreeBase(t *testing.T) {
+	cfg := newCfg()
+	cfg.WorktreeBase = ""
+	ex := &Executor{Worktrees: &fakeWT{}, Cfg: cfg}
+	a := mkApproval(config.SupervisorActionDeleteWorktree, &state.SupervisorTarget{Session: "sup-1"}, "x", "")
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("res = %+v", res)
+	}
+}
+
+// --- change_global_config (intentionally skipped) ---------------------------
+
+func TestExecute_ChangeGlobalConfig_Skipped(t *testing.T) {
+	ex := &Executor{Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionChangeGlobalConfig, nil, "swap backend", "")
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionSkipped {
+		t.Fatalf("res = %+v, want execution_skipped", res)
+	}
+	if !strings.Contains(strings.ToLower(res.Summary), "manual") {
+		t.Fatalf("summary should explain manual edit, got %q", res.Summary)
+	}
+}
+
+// --- unknown / nil ----------------------------------------------------------
+
+func TestExecute_UnknownAction_Failed(t *testing.T) {
+	ex := &Executor{Cfg: newCfg()}
+	a := mkApproval("do_a_barrel_roll", nil, "x", "")
+	res := ex.Execute(a)
+	if !errors.Is(res.Err, ErrUnknownAction) {
+		t.Fatalf("res = %+v, want ErrUnknownAction", res)
+	}
+}
+
+func TestExecute_NilApproval(t *testing.T) {
+	ex := &Executor{}
+	res := ex.Execute(nil)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("res = %+v", res)
+	}
+}
+
+// --- WorktreePathForSlot edges --------------------------------------------
+
+func TestWorktreePathForSlot_TrailingSlashBase(t *testing.T) {
+	cfg := newCfg()
+	cfg.WorktreeBase = "/srv/wt/"
+	got, err := WorktreePathForSlot(cfg, "scr-99")
+	if err != nil || got != "/srv/wt/scr-99" {
+		t.Fatalf("got=%q err=%v", got, err)
+	}
+}

--- a/internal/state/approval_executed_test.go
+++ b/internal/state/approval_executed_test.go
@@ -1,0 +1,153 @@
+package state
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func mkApprovedApproval(id string) Approval {
+	now := time.Now().UTC()
+	return Approval{
+		ID:        id,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Action:    "merge_pr",
+		Status:    ApprovalStatusApproved,
+		Audit: []ApprovalAudit{
+			{At: now, Event: ApprovalAuditCreated},
+			{At: now, Event: ApprovalAuditApproved, Actor: "cli"},
+		},
+	}
+}
+
+func TestListApprovedApprovals_OldestFirst(t *testing.T) {
+	s := NewState()
+	t0 := time.Now().UTC()
+	mid := mkApprovedApproval("approval-mid")
+	mid.CreatedAt = t0.Add(-30 * time.Second)
+	old := mkApprovedApproval("approval-old")
+	old.CreatedAt = t0.Add(-60 * time.Second)
+	new_ := mkApprovedApproval("approval-new")
+	new_.CreatedAt = t0
+	s.Approvals = []Approval{mid, old, new_}
+
+	got := s.ListApprovedApprovals()
+	if len(got) != 3 {
+		t.Fatalf("len = %d", len(got))
+	}
+	if got[0].ID != "approval-old" || got[1].ID != "approval-mid" || got[2].ID != "approval-new" {
+		t.Fatalf("order: %s, %s, %s", got[0].ID, got[1].ID, got[2].ID)
+	}
+}
+
+func TestListApprovedApprovals_FiltersOnlyApproved(t *testing.T) {
+	s := NewState()
+	pending := mkApprovedApproval("pending")
+	pending.Status = ApprovalStatusPending
+	exec := mkApprovedApproval("done")
+	exec.Status = ApprovalStatusExecuted
+	rejected := mkApprovedApproval("rej")
+	rejected.Status = ApprovalStatusRejected
+	approved := mkApprovedApproval("approved")
+	s.Approvals = []Approval{pending, exec, rejected, approved}
+
+	got := s.ListApprovedApprovals()
+	if len(got) != 1 || got[0].ID != "approved" {
+		t.Fatalf("got=%+v, want only 'approved'", got)
+	}
+}
+
+func TestMarkApprovalExecuted_HappyPath(t *testing.T) {
+	s := NewState()
+	s.Approvals = []Approval{mkApprovedApproval("a1")}
+	now := time.Now().UTC()
+	a, err := s.MarkApprovalExecuted("a1", now, "cli", "merged PR #42")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if a.Status != ApprovalStatusExecuted {
+		t.Fatalf("status = %q", a.Status)
+	}
+	last := a.Audit[len(a.Audit)-1]
+	if last.Event != ApprovalAuditExecuted || last.Reason != "merged PR #42" {
+		t.Fatalf("last audit = %+v", last)
+	}
+}
+
+func TestMarkApprovalExecuted_IsIdempotent_AgainstAlreadyExecuted(t *testing.T) {
+	// concurrent CLI+supervisor scenario — second mark must NOT mutate.
+	s := NewState()
+	a := mkApprovedApproval("a1")
+	a.Status = ApprovalStatusExecuted
+	s.Approvals = []Approval{a}
+	now := time.Now().UTC()
+
+	got, err := s.MarkApprovalExecuted("a1", now, "supervisor", "rerun")
+	if !errors.Is(err, ErrApprovalNotApproved) {
+		t.Fatalf("err = %v, want ErrApprovalNotApproved", err)
+	}
+	if got.Status != ApprovalStatusExecuted {
+		t.Fatalf("status drifted: %q", got.Status)
+	}
+}
+
+func TestMarkApprovalExecuted_ErrApprovalNotFound(t *testing.T) {
+	s := NewState()
+	now := time.Now().UTC()
+	_, err := s.MarkApprovalExecuted("nope", now, "cli", "")
+	if !errors.Is(err, ErrApprovalNotFound) {
+		t.Fatalf("err = %v, want ErrApprovalNotFound", err)
+	}
+}
+
+func TestMarkApprovalExecutionFailed_HappyPath(t *testing.T) {
+	s := NewState()
+	s.Approvals = []Approval{mkApprovedApproval("a1")}
+	now := time.Now().UTC()
+	a, err := s.MarkApprovalExecutionFailed("a1", now, "cli", "boom")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if a.Status != ApprovalStatusExecutionFailed {
+		t.Fatalf("status = %q", a.Status)
+	}
+	if a.Audit[len(a.Audit)-1].Event != ApprovalAuditExecutionFailed {
+		t.Fatalf("audit = %+v", a.Audit)
+	}
+}
+
+func TestMarkApprovalExecutionSkipped_HappyPath(t *testing.T) {
+	s := NewState()
+	s.Approvals = []Approval{mkApprovedApproval("a1")}
+	now := time.Now().UTC()
+	a, err := s.MarkApprovalExecutionSkipped("a1", now, "supervisor", "manual edit required")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if a.Status != ApprovalStatusExecutionSkipped {
+		t.Fatalf("status = %q", a.Status)
+	}
+}
+
+func TestMarkApprovalExecution_RefusesPendingOrExecuted(t *testing.T) {
+	cases := []ApprovalStatus{
+		ApprovalStatusPending,
+		ApprovalStatusExecuted,
+		ApprovalStatusExecutionFailed,
+		ApprovalStatusExecutionSkipped,
+		ApprovalStatusRejected,
+		ApprovalStatusStale,
+		ApprovalStatusSuperseded,
+	}
+	now := time.Now().UTC()
+	for _, st := range cases {
+		s := NewState()
+		a := mkApprovedApproval("a1")
+		a.Status = st
+		s.Approvals = []Approval{a}
+		if _, err := s.MarkApprovalExecuted("a1", now, "cli", ""); !errors.Is(err, ErrApprovalNotApproved) {
+			t.Errorf("status %q: MarkApprovalExecuted err = %v, want ErrApprovalNotApproved", st, err)
+		}
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -599,19 +599,25 @@ type SupervisorDecision struct {
 type ApprovalStatus string
 
 const (
-	ApprovalStatusPending    ApprovalStatus = "pending"
-	ApprovalStatusApproved   ApprovalStatus = "approved"
-	ApprovalStatusRejected   ApprovalStatus = "rejected"
-	ApprovalStatusStale      ApprovalStatus = "stale"
-	ApprovalStatusSuperseded ApprovalStatus = "superseded"
+	ApprovalStatusPending          ApprovalStatus = "pending"
+	ApprovalStatusApproved         ApprovalStatus = "approved"
+	ApprovalStatusRejected         ApprovalStatus = "rejected"
+	ApprovalStatusStale            ApprovalStatus = "stale"
+	ApprovalStatusSuperseded       ApprovalStatus = "superseded"
+	ApprovalStatusExecuted         ApprovalStatus = "executed"
+	ApprovalStatusExecutionFailed  ApprovalStatus = "execution_failed"
+	ApprovalStatusExecutionSkipped ApprovalStatus = "execution_skipped"
 )
 
 const (
-	ApprovalAuditCreated    = "created"
-	ApprovalAuditApproved   = "approved"
-	ApprovalAuditRejected   = "rejected"
-	ApprovalAuditStale      = "stale"
-	ApprovalAuditSuperseded = "superseded"
+	ApprovalAuditCreated          = "created"
+	ApprovalAuditApproved         = "approved"
+	ApprovalAuditRejected         = "rejected"
+	ApprovalAuditStale            = "stale"
+	ApprovalAuditSuperseded       = "superseded"
+	ApprovalAuditExecuted         = "executed"
+	ApprovalAuditExecutionFailed  = "execution_failed"
+	ApprovalAuditExecutionSkipped = "execution_skipped"
 )
 
 const approvalActionSpawnWorker = "spawn_worker"
@@ -2111,4 +2117,99 @@ func (s *State) ReconcileStaleSessions(now time.Time, policy StaleSessionPolicy,
 		audits = append(audits, audit)
 	}
 	return audits
+}
+
+// ListApprovedApprovals returns approvals in status=approved (i.e. ready
+// to be executed by the approver pipeline). Order: oldest first by
+// CreatedAt, so the executor picks them up FIFO.
+func (s *State) ListApprovedApprovals() []*Approval {
+	if s == nil {
+		return nil
+	}
+	out := make([]*Approval, 0)
+	for i := range s.Approvals {
+		if s.Approvals[i].Status == ApprovalStatusApproved {
+			out = append(out, &s.Approvals[i])
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].CreatedAt.Before(out[j].CreatedAt) })
+	return out
+}
+
+// ErrApprovalNotApproved is returned when MarkApprovalExecuted /
+// MarkApprovalExecutionFailed / MarkApprovalExecutionSkipped is called on
+// an approval that is not in status=approved (e.g. already executed).
+var ErrApprovalNotApproved = errors.New("approval is not in status=approved")
+
+// MarkApprovalExecuted transitions an approval from approved → executed
+// and appends an audit entry. Idempotent at the caller boundary: if the
+// approval has already been executed (or moved to any non-approved
+// state), returns ErrApprovalNotApproved without mutating state — so a
+// concurrent executor cannot double-execute.
+func (s *State) MarkApprovalExecuted(id string, now time.Time, actor, summary string) (*Approval, error) {
+	approval, ok := s.FindApproval(id)
+	if !ok {
+		return nil, ErrApprovalNotFound
+	}
+	if approval.Status != ApprovalStatusApproved {
+		return approval, ErrApprovalNotApproved
+	}
+	approval.Status = ApprovalStatusExecuted
+	approval.UpdatedAt = normalizedTime(now)
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              approval.UpdatedAt,
+		Event:           ApprovalAuditExecuted,
+		Actor:           actor,
+		Reason:          summary,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: approval.TargetStateHash,
+	})
+	return approval, nil
+}
+
+// MarkApprovalExecutionFailed transitions approved → execution_failed.
+// Same idempotency guarantee as MarkApprovalExecuted.
+func (s *State) MarkApprovalExecutionFailed(id string, now time.Time, actor, errMsg string) (*Approval, error) {
+	approval, ok := s.FindApproval(id)
+	if !ok {
+		return nil, ErrApprovalNotFound
+	}
+	if approval.Status != ApprovalStatusApproved {
+		return approval, ErrApprovalNotApproved
+	}
+	approval.Status = ApprovalStatusExecutionFailed
+	approval.UpdatedAt = normalizedTime(now)
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              approval.UpdatedAt,
+		Event:           ApprovalAuditExecutionFailed,
+		Actor:           actor,
+		Reason:          errMsg,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: approval.TargetStateHash,
+	})
+	return approval, nil
+}
+
+// MarkApprovalExecutionSkipped transitions approved → execution_skipped
+// with an audit reason. Used for verbs the executor intentionally does
+// not run yet (e.g. change_global_config until the YAML pipeline lands).
+func (s *State) MarkApprovalExecutionSkipped(id string, now time.Time, actor, reason string) (*Approval, error) {
+	approval, ok := s.FindApproval(id)
+	if !ok {
+		return nil, ErrApprovalNotFound
+	}
+	if approval.Status != ApprovalStatusApproved {
+		return approval, ErrApprovalNotApproved
+	}
+	approval.Status = ApprovalStatusExecutionSkipped
+	approval.UpdatedAt = normalizedTime(now)
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              approval.UpdatedAt,
+		Event:           ApprovalAuditExecutionSkipped,
+		Actor:           actor,
+		Reason:          reason,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: approval.TargetStateHash,
+	})
+	return approval, nil
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -15,7 +15,9 @@ import (
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/mission"
 	"github.com/befeast/maestro/internal/outcome"
+	"github.com/befeast/maestro/internal/approver"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/worker"
 )
 
 const (
@@ -135,6 +137,11 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 	if reader == nil {
 		reader = github.New(cfg.Repo)
 	}
+
+	// Execute any approvals that were transitioned to status=approved
+	// outside this loop (CLI approve already executes inline; this pass
+	// catches web-driven approves and replays after a daemon restart).
+	executeApprovedApprovals(cfg, st, reader)
 	recordOutcomeHealth(cfg, st)
 
 	decision, err := NewEngine(cfg, reader).Decide(st)
@@ -2623,4 +2630,54 @@ func commandBinary(cmd, fallback string) string {
 		return ""
 	}
 	return fields[0]
+}
+
+// executeApprovedApprovals runs any approvals currently in status=approved
+// through the approver.Executor and persists the resulting state
+// transitions. Failures are logged but do not abort the supervisor cycle —
+// each approval gets its own audit entry so an operator can see what
+// happened.
+func executeApprovedApprovals(cfg *config.Config, st *state.State, reader Reader) {
+	approvals := st.ListApprovedApprovals()
+	if len(approvals) == 0 {
+		return
+	}
+	// approver.Executor only needs MergePR/CloseIssue from the GH client.
+	// Reader (the broader supervisor surface) is satisfied by *github.Client,
+	// which also satisfies approver.GitHubClient. We assert the narrower
+	// interface — when it fails (mocks/tests/Mutator-only), we still try to
+	// fall back to a fresh github.New(cfg.Repo).
+	var gh approver.GitHubClient
+	if candidate, ok := reader.(approver.GitHubClient); ok {
+		gh = candidate
+	} else {
+		gh = github.New(cfg.Repo)
+	}
+	ex := &approver.Executor{
+		GH:        gh,
+		Worktrees: approver.WorktreeRemoverFunc(worker.RemoveWorktree),
+		Cfg:       cfg,
+	}
+	now := time.Now().UTC()
+	for _, a := range approvals {
+		res := ex.Execute(a)
+		switch res.Status {
+		case state.ApprovalStatusExecuted:
+			if _, err := st.MarkApprovalExecuted(a.ID, now, "supervisor", res.Summary); err != nil {
+				fmt.Fprintf(os.Stderr, "[supervisor] mark approval %s executed: %v\n", a.ID, err)
+			}
+		case state.ApprovalStatusExecutionSkipped:
+			if _, err := st.MarkApprovalExecutionSkipped(a.ID, now, "supervisor", res.Summary); err != nil {
+				fmt.Fprintf(os.Stderr, "[supervisor] mark approval %s skipped: %v\n", a.ID, err)
+			}
+		default:
+			msg := res.Summary
+			if msg == "" && res.Err != nil {
+				msg = res.Err.Error()
+			}
+			if _, err := st.MarkApprovalExecutionFailed(a.ID, now, "supervisor", msg); err != nil {
+				fmt.Fprintf(os.Stderr, "[supervisor] mark approval %s failed: %v\n", a.ID, err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

**Part 2B** of #475 — closes the cautious-gate write-path. Approved approvals now actually execute (`gh.MergePR` / `gh.CloseIssue` / `worker.RemoveWorktree`) instead of CLI silently printing "No risky action was executed."

Builds on **#479** (part 2A): part 2A enqueues a pending Approval via HTTP; this PR turns an approved Approval into the real side effect.

## Changes

- **`internal/state`** — three terminal statuses (`executed` / `execution_failed` / `execution_skipped`), three audit events, three transition helpers (`MarkApprovalExecuted` / `MarkApprovalExecutionFailed` / `MarkApprovalExecutionSkipped`), all idempotent at the caller boundary (concurrent CLI approve + supervisor poll cannot double-execute). New `ListApprovedApprovals` returns approved approvals oldest-first.
- **`internal/approver`** *(new package)* — `Executor` with narrow `GitHubClient` / `WorktreeRemover` deps; pure `Execute(approval) -> Result` function (no state mutation; the caller drives the transition). Two drivers wire it up.
- **`cmd/maestro/main.go`** — `superviseApprovalCmd` "approve" branch runs the executor inline after `ApproveApproval`, persists the transition, prints the result. CLI approve is finally end-to-end.
- **`internal/supervisor/supervisor.go`** — `RunOnce` gains a single `executeApprovedApprovals` pass right after `MarkStaleApprovals`, catching approvals approved out-of-band (future web approve endpoint, or replay after a daemon restart).

## Verb semantics

| `action_id` | Target | Side effect | Failure → |
|---|---|---|---|
| `merge_pr` | PR #N | `gh.MergePR(N)` | `execution_failed` |
| `close_issue` | issue #N | `gh.CloseIssue(N, comment)` (comment = approve-event Reason → fallback to Summary) | `execution_failed` |
| `delete_worktree` | session/slot | `worker.RemoveWorktree(localPath, base/slot)` — path explicitly anchored under `cfg.WorktreeBase` via `WorktreePathForSlot`, refuses any slot with `/`, `\`, `.`, `..` | `execution_failed` |
| `change_global_config` | — | `execution_skipped` with a "manual edit + systemctl restart" summary | n/a |

`change_global_config` is **intentionally not implemented** in this PR — the YAML-mutation pipeline (whitelist, atomic write, restart coordination) is risky enough to deserve its own change. The approver records the intent; an operator still has to edit the config and restart the daemon. Follow-up issue can track that.

## Tests

- `internal/approver/executor_test.go` — **14** tests covering each verb's happy + error paths, the slot path-traversal guard (`../etc`, `/tmp/x`, `a/b`, `.`, `..` all rejected), missing-target / nil-gh / unknown-action rejections, and the `change_global_config` skip.
- `internal/state/approval_executed_test.go` — **8** tests covering FIFO ordering, the status=approved filter, the `Mark*` happy paths, and idempotency (every non-approved status returns `ErrApprovalNotApproved` without mutating state).

## Verification (on workshop)

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` — all **18 packages** pass; no regressions
- internal/approver — 14 new tests, all PASS
- internal/state — +8 tests on top of existing 70, all PASS

## Out of scope

- **Frontend enable / confirmation modal** — #476.
- **Flipping `--read-only` on the LAN-bound serves** — #477.
- **`change_global_config` execution** — needs a YAML-mutation pipeline; follow-up.

Refs #475 (closes the cautious-gate write-path).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the cautious-gate write-path by wiring up the `approver.Executor` so that approved approvals actually run their side effects (`gh.MergePR`, `gh.CloseIssue`, `worker.RemoveWorktree`) instead of printing a no-op message. State transitions, audit events, and an idempotency guard are added to `internal/state`, and two execution drivers are wired up (CLI inline and supervisor poll).

- **`internal/approver/executor.go`** (new): pure `Execute(approval) → Result` function with narrow interface dependencies and a path-traversal guard for `delete_worktree` slot values.
- **`internal/state/state.go`**: three new terminal statuses, three `Mark*` transition helpers with `ErrApprovalNotApproved` idempotency, and `ListApprovedApprovals` (FIFO ordered).
- **`cmd/maestro/main.go` / `internal/supervisor/supervisor.go`**: CLI approve now executes inline; supervisor `RunOnce` gains an `executeApprovedApprovals` pass — but this call is placed before the `DryRun` guard, meaning real side effects fire in dry-run mode and the resulting state transitions are never persisted, causing the same approvals to be re-executed on every subsequent cycle.

<h3>Confidence Score: 3/5</h3>

The new executor and state layers are solid, but the supervisor wiring has a placement bug that causes real destructive actions to fire in dry-run mode and prevents their state transitions from being persisted.

The `executeApprovedApprovals` call in `RunOnce` sits before the `if !cfg.Supervisor.DryRun` block. In dry-run mode this causes PR merges, issue closes, and worktree deletions to execute against real GitHub/filesystem targets. Because `state.Save` is inside that guard, none of the resulting status transitions are written to disk, so every subsequent `RunOnce` reloads the same `status=approved` records and re-executes them in a loop. The `internal/approver` and `internal/state` changes are well-designed and tested; the risk is isolated to the supervisor call-site ordering.

internal/supervisor/supervisor.go — the placement of `executeApprovedApprovals` relative to the `DryRun` guard needs to be corrected before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds `executeApprovedApprovals` call to `RunOnce`, but places it before the `DryRun` guard — real side effects fire in dry-run mode and state transitions are never persisted, causing repeated execution on every supervisor cycle. |
| internal/approver/executor.go | New package implementing approval execution with narrow interfaces; path-traversal guard for `delete_worktree` is sound, error propagation is clean, and `change_global_config` is intentionally skipped with clear audit trail. |
| cmd/maestro/main.go | CLI `approve` branch now executes inline and saves state twice (before and after execution) — correct sequencing; execution failure is reflected in both state and exit code. |
| internal/state/state.go | Three new terminal statuses and corresponding `Mark*` helpers; idempotency guard (`ErrApprovalNotApproved`) and `ListApprovedApprovals` FIFO ordering are correctly implemented. |
| internal/approver/executor_test.go | Good coverage: happy paths, missing targets, nil deps, path-traversal variants, and `change_global_config` skip all tested. |
| internal/state/approval_executed_test.go | FIFO ordering, status filter, all three `Mark*` happy paths, and idempotency across all non-approved statuses are covered. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/supervisor/supervisor.go:144
**Approval executor runs unconditionally in dry-run mode**

`executeApprovedApprovals` is called before the `if !cfg.Supervisor.DryRun` guard, so in dry-run mode it still fires real external side effects (`MergePR`, `CloseIssue`, `RemoveWorktree`). Compounding this, `state.Save` lives inside that guard (line 165), so the resulting status transitions (`executed`/`execution_failed`) are never persisted to disk. Every subsequent `RunOnce` call reloads the same `status=approved` entries and re-executes them, producing an infinite-execution loop.

### Issue 2 of 2
internal/supervisor/supervisor.go:2661-2682
**Single `now` timestamp for all approvals in the execute loop**

`now` is captured once before the loop, so if several approvals are executed sequentially (each potentially involving a GitHub API round-trip), all of them receive the same `UpdatedAt` and audit `At` value. The audit log will show simultaneous timestamps for actions that completed seconds apart, making post-incident tracing harder. Capturing the timestamp after each `Execute` call is a trivial fix.

```suggestion
	for _, a := range approvals {
		res := ex.Execute(a)
		now := time.Now().UTC()
		switch res.Status {
		case state.ApprovalStatusExecuted:
			if _, err := st.MarkApprovalExecuted(a.ID, now, "supervisor", res.Summary); err != nil {
				fmt.Fprintf(os.Stderr, "[supervisor] mark approval %s executed: %v\n", a.ID, err)
			}
		case state.ApprovalStatusExecutionSkipped:
			if _, err := st.MarkApprovalExecutionSkipped(a.ID, now, "supervisor", res.Summary); err != nil {
				fmt.Fprintf(os.Stderr, "[supervisor] mark approval %s skipped: %v\n", a.ID, err)
			}
		default:
			msg := res.Summary
			if msg == "" && res.Err != nil {
				msg = res.Err.Error()
			}
			if _, err := st.MarkApprovalExecutionFailed(a.ID, now, "supervisor", msg); err != nil {
				fmt.Fprintf(os.Stderr, "[supervisor] mark approval %s failed: %v\n", a.ID, err)
			}
		}
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(approver): execute approved approva..."](https://github.com/befeast/maestro/commit/2148e6d7f922ae9a12117ede9ed4b905e97f1750) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34707932)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->