### PR TITLE
feat(server): HTTP approve/reject endpoints for approvals (#476A)

### DIFF
--- a/internal/server/approvals.go
+++ b/internal/server/approvals.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// approvalDecisionRequest is the JSON body accepted by approve/reject
+// endpoints. actor/reason are recorded in the approval audit; missing
+// fields default to "dashboard".
+type approvalDecisionRequest struct {
+	Actor  string `json:"actor,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// approvalDecisionResponse mirrors what handlers return on success.
+type approvalDecisionResponse struct {
+	OK       bool             `json:"ok"`
+	Approval *state.Approval `json:"approval"`
+}
+
+// approvalRoute is "approve" or "reject" parsed from the URL.
+type approvalRoute struct {
+	id     string
+	verb   string // "approve" | "reject"
+}
+
+// parseApprovalPath splits /<prefix>/{id}/{verb} into (id, verb). Returns
+// ok=false on any shape mismatch (extra segments, empty id, unknown verb).
+func parseApprovalPath(prefix, urlPath string) (approvalRoute, bool) {
+	rest := strings.TrimPrefix(urlPath, prefix)
+	if rest == urlPath {
+		return approvalRoute{}, false
+	}
+	parts := strings.Split(strings.Trim(rest, "/"), "/")
+	if len(parts) != 2 {
+		return approvalRoute{}, false
+	}
+	id := strings.TrimSpace(parts[0])
+	verb := strings.TrimSpace(parts[1])
+	if id == "" {
+		return approvalRoute{}, false
+	}
+	if verb != "approve" && verb != "reject" {
+		return approvalRoute{}, false
+	}
+	return approvalRoute{id: id, verb: verb}, true
+}
+
+// applyApprovalDecision is the shared body of every approve/reject
+// handler. It loads state from stateDir, calls the matching state
+// transition, persists, and writes the JSON response. Returns nil on a
+// path the handler must continue (none today; the body always responds).
+func applyApprovalDecision(w http.ResponseWriter, r *http.Request, readOnly bool, scope string, stateDir string, route approvalRoute) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if readOnly {
+		writeError(w, http.StatusForbidden, scope+" is read-only; approval write actions require approval-backed controls to be enabled in configuration")
+		return
+	}
+	if strings.TrimSpace(stateDir) == "" {
+		writeError(w, http.StatusInternalServerError, "no state dir is available to update the approval")
+		return
+	}
+
+	var req approvalDecisionRequest
+	if r.Body != nil {
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("decode approval request: %v", err))
+			return
+		}
+	}
+	actor := strings.TrimSpace(req.Actor)
+	if actor == "" {
+		actor = "dashboard"
+	}
+	reason := strings.TrimSpace(req.Reason)
+
+	st, err := state.Load(stateDir)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load state: %v", err))
+		return
+	}
+
+	now := time.Now().UTC()
+	var approval *state.Approval
+	switch route.verb {
+	case "approve":
+		approval, err = st.ApproveApproval(route.id, now, actor, reason)
+	case "reject":
+		approval, err = st.RejectApproval(route.id, now, actor, reason)
+	default:
+		// parseApprovalPath already enforces this; defensive fall-back.
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown approval verb %q", route.verb))
+		return
+	}
+	if err != nil {
+		// Persist any partial state changes (stale/superseded transitions
+		// can mutate even when the verb fails) before returning.
+		if persistErr := state.Save(stateDir, st); persistErr != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("save state after %s error %v: %v", route.verb, err, persistErr))
+			return
+		}
+		switch {
+		case errors.Is(err, state.ErrApprovalNotFound):
+			writeError(w, http.StatusNotFound, err.Error())
+		case errors.Is(err, state.ErrApprovalStale),
+			errors.Is(err, state.ErrApprovalSuperseded),
+			errors.Is(err, state.ErrApprovalNotPending):
+			writeError(w, http.StatusConflict, err.Error())
+		default:
+			writeError(w, http.StatusBadRequest, err.Error())
+		}
+		return
+	}
+	if err := state.Save(stateDir, st); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save state: %v", err))
+		return
+	}
+	writeJSON(w, http.StatusOK, approvalDecisionResponse{OK: true, Approval: approval})
+}
+
+// --- single-project server hookup -------------------------------------------
+
+func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
+	route, ok := parseApprovalPath("/api/v1/approvals/", r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusNotFound, "expected /api/v1/approvals/{id}/{approve|reject}")
+		return
+	}
+	stateDir := ""
+	cfg := s.cfg
+	if cfg != nil {
+		stateDir = cfg.StateDir
+	}
+	applyApprovalDecision(w, r, cfgServerReadOnly(cfg), "server", stateDir, route)
+}
+
+func cfgServerReadOnly(cfg *config.Config) bool {
+	if cfg == nil {
+		return true
+	}
+	return cfg.Server.ReadOnly
+}
+
+// --- fleet server hookup ----------------------------------------------------
+
+func (s *FleetServer) handleFleetApproval(w http.ResponseWriter, r *http.Request) {
+	route, ok := parseApprovalPath("/api/v1/fleet/approvals/", r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusNotFound, "expected /api/v1/fleet/approvals/{id}/{approve|reject}?project=...")
+		return
+	}
+	projectName := strings.TrimSpace(r.URL.Query().Get("project"))
+	if projectName == "" {
+		writeError(w, http.StatusBadRequest, "project query parameter is required")
+		return
+	}
+	project, ok := s.findProject(projectName)
+	if !ok {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("unknown project %q", projectName))
+		return
+	}
+
+	// Project-scoped read-only: either the global flag or the project's own.
+	readOnly := s.readOnly
+	if project.cfg != nil && project.cfg.Server.ReadOnly {
+		readOnly = true
+	}
+	stateDir := ""
+	if project.cfg != nil {
+		stateDir = project.cfg.StateDir
+	}
+	applyApprovalDecision(w, r, readOnly, fmt.Sprintf("fleet project %q", projectName), stateDir, route)
+}

--- a/internal/server/approvals_test.go
+++ b/internal/server/approvals_test.go
@@ -1,0 +1,242 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func enqueuedApproval(t *testing.T, dir, action string, target *state.SupervisorTarget) *state.Approval {
+	t.Helper()
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	now := time.Now().UTC()
+	dec := state.SupervisorDecision{
+		ID:                "synthetic-" + action,
+		CreatedAt:         now,
+		Project:           "owner/repo",
+		Mode:              "test",
+		Summary:           "test enqueue",
+		RecommendedAction: action,
+		Target:            target,
+		Risk:              "high",
+		Confidence:        1.0,
+		RequiresApproval:  true,
+	}
+	approval := st.RecordPendingApprovalForDecision(dec, now)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	return approval
+}
+
+func srvWithStateDir(t *testing.T) (*Server, string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:     "owner/repo",
+		StateDir: dir,
+		Server:   config.ServerConfig{ReadOnly: false, Port: 8788},
+	}
+	return New(cfg, nil), dir
+}
+
+// --- happy paths ------------------------------------------------------------
+
+func TestHandleApproval_Approve_HappyPath(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 12})
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/approvals/"+a.ID+"/approve",
+		bytes.NewBufferString(`{"actor":"oleg","reason":"green"}`))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp approvalDecisionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || resp.Approval == nil || resp.Approval.Status != state.ApprovalStatusApproved {
+		t.Fatalf("response = %+v", resp)
+	}
+	st, _ := state.Load(dir)
+	if st.Approvals[0].Status != state.ApprovalStatusApproved {
+		t.Fatalf("disk status = %q", st.Approvals[0].Status)
+	}
+}
+
+func TestHandleApproval_Reject_HappyPath(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	a := enqueuedApproval(t, dir, "close_issue", &state.SupervisorTarget{Issue: 7})
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/approvals/"+a.ID+"/reject",
+		bytes.NewBufferString(`{"actor":"oleg","reason":"do not close"}`))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	st, _ := state.Load(dir)
+	if st.Approvals[0].Status != state.ApprovalStatusRejected {
+		t.Fatalf("disk status = %q", st.Approvals[0].Status)
+	}
+}
+
+// --- error paths ------------------------------------------------------------
+
+func TestHandleApproval_NotFound_404(t *testing.T) {
+	srv, _ := srvWithStateDir(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/nope/approve", nil)
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleApproval_AlreadyApproved_409(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+	// pre-approve
+	st, _ := state.Load(dir)
+	if _, err := st.ApproveApproval(a.ID, time.Now().UTC(), "cli", "first"); err != nil {
+		t.Fatalf("pre-approve: %v", err)
+	}
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/"+a.ID+"/approve", nil)
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", w.Code)
+	}
+}
+
+func TestHandleApproval_BadRoute_404(t *testing.T) {
+	srv, _ := srvWithStateDir(t)
+	for _, p := range []string{
+		"/api/v1/approvals/",
+		"/api/v1/approvals//approve",
+		"/api/v1/approvals/foo",
+		"/api/v1/approvals/foo/banana",
+		"/api/v1/approvals/foo/approve/extra",
+	} {
+		req := httptest.NewRequest(http.MethodPost, p, nil)
+		w := httptest.NewRecorder()
+		srv.handleApproval(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("path %q: status = %d, want 404", p, w.Code)
+		}
+	}
+}
+
+func TestHandleApproval_GetIs405(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/approvals/"+a.ID+"/approve", nil)
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleApproval_ReadOnly_403(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	srv.cfg.Server.ReadOnly = true
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/"+a.ID+"/approve", nil)
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	st, _ := state.Load(dir)
+	if st.Approvals[0].Status != state.ApprovalStatusPending {
+		t.Fatalf("status changed under read-only: %q", st.Approvals[0].Status)
+	}
+}
+
+func TestHandleApproval_NoStateDir_500(t *testing.T) {
+	cfg := &config.Config{Repo: "owner/repo", Server: config.ServerConfig{ReadOnly: false}}
+	srv := New(cfg, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/nonexistent/approve", nil)
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+}
+
+// --- fleet variant ----------------------------------------------------------
+
+func newFleetForApprovalTest(t *testing.T) (*FleetServer, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	projectName := "scribe-service"
+	cfg := &config.Config{
+		Repo:     "owner/scribe-service",
+		StateDir: dir,
+		Server:   config.ServerConfig{ReadOnly: false},
+	}
+	proj := NewFleetProject(projectName, "/tmp/scribe.yaml", "", cfg)
+	srv := NewFleet([]FleetProject{proj}, "127.0.0.1", 0, false)
+	return srv, projectName, dir
+}
+
+func TestHandleFleetApproval_Approve_HappyPath(t *testing.T) {
+	srv, projectName, dir := newFleetForApprovalTest(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+
+	url := fmt.Sprintf("/api/v1/fleet/approvals/%s/approve?project=%s", a.ID, projectName)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(`{"actor":"web"}`))
+	w := httptest.NewRecorder()
+	srv.handleFleetApproval(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	st, _ := state.Load(dir)
+	if st.Approvals[0].Status != state.ApprovalStatusApproved {
+		t.Fatalf("status = %q", st.Approvals[0].Status)
+	}
+}
+
+func TestHandleFleetApproval_MissingProject_400(t *testing.T) {
+	srv, _, dir := newFleetForApprovalTest(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/approvals/"+a.ID+"/approve", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleetApproval(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleFleetApproval_UnknownProject_404(t *testing.T) {
+	srv, _, dir := newFleetForApprovalTest(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+	url := "/api/v1/fleet/approvals/" + a.ID + "/approve?project=ghost"
+	req := httptest.NewRequest(http.MethodPost, url, nil)
+	w := httptest.NewRecorder()
+	srv.handleFleetApproval(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -173,6 +173,7 @@ func (s *FleetServer) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/v1/fleet/worker", s.handleFleetWorker)
 	mux.HandleFunc("/api/v1/fleet", s.handleFleet)
 	mux.HandleFunc("/api/v1/fleet/actions", s.handleFleetAction)
+	mux.HandleFunc("/api/v1/fleet/approvals/", s.handleFleetApproval)
 	mux.HandleFunc("/api/v1/audit/log", s.handleFleetAuditLog)
 	mux.HandleFunc("/approvals/audit", s.handleFleetApprovalAudit)
 	mux.Handle("/static/", web.StaticHandler())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,6 +66,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/v1/logs/", s.handleLog)
 	mux.HandleFunc("/api/v1/refresh", s.handleRefresh)
 	mux.HandleFunc("/api/v1/actions", s.handleAction)
+	mux.HandleFunc("/api/v1/approvals/", s.handleApproval)
 	mux.HandleFunc("/api/v1/", s.handleIssue)
 	mux.Handle("/static/", web.StaticHandler())
 	mux.HandleFunc("/", s.handleDashboard)


### PR DESCRIPTION
## Summary

**#476A** adds the HTTP layer that lets the dashboard (and any other web client) move an approval from `pending` → `approved` / `rejected` directly. Until now the only approve/reject path was the CLI; the dashboard had nowhere to POST to. With **#475 part 2B** (#480) in main, an approved approval is then executed inline (CLI) or by the supervisor poll, so the full end-to-end web write-path is now functionally complete in the backend (the SPA buttons + confirm modal land in **#476B**).

## Endpoints

| Path | Scope |
|---|---|
| `POST /api/v1/approvals/{id}/{approve\|reject}` | single-project (`maestro serve --config`) |
| `POST /api/v1/fleet/approvals/{id}/{approve\|reject}?project=<name>` | fleet (`maestro serve --fleet`) |

**Body:** `{"actor":"<who>", "reason":"<why>"}` (both optional; actor defaults to `dashboard`). `reason` is recorded in the approval audit, exactly like the CLI `maestro supervise approve`.

**Success:** `200` + `{"ok":true,"approval":<full Approval JSON>}`.

| Status | When |
|---|---|
| 200 | transition recorded; full Approval body |
| 400 | bad route / fleet endpoint missing `project=` |
| 403 | server is read-only (default deployment) |
| 404 | approval id unknown / fleet project unknown |
| 405 | non-POST |
| 409 | approval is stale / superseded / not pending |
| 500 | no state dir / state load/save failure |

## Implementation

- `server.go` and `fleet.go` register the two new routes ahead of the existing `/api/v1/` catch-all (`handleIssue`) — Go's mux picks the longest match, but registering ahead also keeps the intent explicit.
- `parseApprovalPath` is a strict `/<prefix>/{id}/{verb}` parser that rejects extra segments, empty id, and unknown verbs (404).
- `applyApprovalDecision` is the shared body: load state → call `state.ApproveApproval` / `state.RejectApproval` → save state → JSON response. Stale/superseded transitions can mutate state even on a verb error; we save state first then return the error code, so the dashboard sees a consistent on-disk view.

## Tests

`internal/server/approvals_test.go` — 11 tests:

- approve / reject happy paths (single-project + fleet)
- 404 on unknown id, 404 on unknown fleet project
- 400 on missing project, 400 on five distinct bad routes
- 405 on GET
- 403 under `--read-only` (state on disk unchanged)
- 409 when the approval is already approved
- 500 when no state dir is configured

## Verification (on workshop)

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` — all **18 packages** pass

## Out of scope

- SPA un-disable + confirmation modal — **#476B**.
- Flipping `--read-only` on the LAN-bound serves — **#477**.

Refs #476.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `POST /api/v1/approvals/{id}/{approve|reject}` and `POST /api/v1/fleet/approvals/{id}/{approve|reject}?project=` endpoints so the dashboard can drive approval transitions without the CLI. The implementation is well-structured with a shared `applyApprovalDecision` body, a strict path parser, and good test coverage across all major status codes.

- `ErrApprovalPayloadMismatch` (returned when `ensureApprovalCurrent` detects a changed payload and marks the approval stale) is missing from the 409 switch arm and falls through to the default 400 response — callers expecting a 409 on any stale condition will misclassify this case.
- In `handleFleetApproval`, the project lookup runs before `applyApprovalDecision`'s method guard, so a non-POST to an unknown project returns 404 instead of 405; the single-project handler doesn't share this inconsistency.

<h3>Confidence Score: 3/5</h3>

The core state transitions are sound, but the error-classification bug means the approve endpoint silently returns the wrong status code for a real stale-approval scenario, which will surface as a mishandled error for any client that inspects the HTTP status to distinguish stale vs. bad-request.

The `ErrApprovalPayloadMismatch` → 400 mismatch is a concrete wrong-status-code defect on a live code path: when an approval's payload changes between recording and the HTTP approve call, `ensureApprovalCurrent` marks the approval stale in state and returns `ErrApprovalPayloadMismatch`, but the handler emits 400 instead of 409. Every downstream client (dashboard, CLI, integrations) that branches on the HTTP status to detect stale approvals will take the wrong path. The fix is one line, but the bug is present today.

internal/server/approvals.go — the error-classification switch at the heart of the shared handler needs the `ErrApprovalPayloadMismatch` arm added before this ships.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/approvals.go | New approve/reject HTTP handler; `ErrApprovalPayloadMismatch` is missing from the 409 switch arm and incorrectly returns 400 instead of Conflict; fleet method-check ordering is slightly inconsistent. |
| internal/server/approvals_test.go | 11 tests covering happy paths, 404/400/405/403/409/500 error cases; no test exercises the `ErrApprovalPayloadMismatch` → (incorrectly) 400 path. |
| internal/server/fleet.go | One-line route registration for the fleet approval endpoint; change is minimal and correct. |
| internal/server/server.go | One-line route registration for the single-project approval endpoint; change is minimal and correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/approvals.go:115-126
`ErrApprovalPayloadMismatch` falls through to the `default` 400 branch instead of the 409 conflict case, even though `ensureApprovalCurrent` already called `markApprovalStale` on the approval (mutating state) before returning this error. The client receives a misleading `400 Bad Request` — as if their request body was malformed — for what is actually a stale/conflict condition. Any client checking for 409 to detect stale approvals will silently mishandle this case.

```suggestion
		switch {
		case errors.Is(err, state.ErrApprovalNotFound):
			writeError(w, http.StatusNotFound, err.Error())
		case errors.Is(err, state.ErrApprovalStale),
			errors.Is(err, state.ErrApprovalSuperseded),
			errors.Is(err, state.ErrApprovalNotPending),
			errors.Is(err, state.ErrApprovalPayloadMismatch):
			writeError(w, http.StatusConflict, err.Error())
		default:
			writeError(w, http.StatusBadRequest, err.Error())
		}
		return
	}
```

### Issue 2 of 2
internal/server/approvals.go:159-172
**Method check order in fleet handler**

In `handleFleetApproval`, the project lookup happens before `applyApprovalDecision` runs its `r.Method != http.MethodPost` guard. A `GET` request to a valid route with an unknown `project=` value returns `404` (project not found) instead of `405` (method not allowed). The PR spec says `405 on non-POST`, but this path violates that for non-existent projects. The single-project `handleApproval` doesn't share this inconsistency because it jumps straight to `applyApprovalDecision` after the route parse.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(server): HTTP approve/reject endpoi..."](https://github.com/befeast/maestro/commit/b349d0578bbffa79a5835d90c3553c5ad4a9d56f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34708041)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->