### PR TITLE
fix(server): wire safe-action GH client when fleet is loaded from YAML

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -726,6 +726,13 @@ func serveCmd(args []string) {
 			if err != nil {
 				log.Fatalf("load fleet: %v", err)
 			}
+			// LoadFleetProjects can't import github (cycle); wire the
+			// per-project safe-action GH client here at the boundary.
+			for i := range projects {
+				if cfg := projects[i].Cfg(); cfg != nil {
+					projects[i].SetActionGH(github.New(cfg.Repo))
+				}
+			}
 		} else {
 			projects = fleetProjectsFromConfigs(cfgs)
 		}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -55,6 +55,17 @@ func (p *FleetProject) SetActionGH(gh actionGitHubClient) {
 	p.actionGH = gh
 }
 
+// Cfg exposes the loaded *config.Config so callers (cmd/maestro) that need
+// per-project values (e.g. repo) without importing internal/server's
+// internals can reach them. Returns nil if the project was created without
+// a config (tests).
+func (p *FleetProject) Cfg() *config.Config {
+	if p == nil {
+		return nil
+	}
+	return p.cfg
+}
+
 // NewFleetProject wraps an already-loaded config for in-process fleet serving.
 func NewFleetProject(name, configPath, dashboardURL string, cfg *config.Config) FleetProject {
 	if strings.TrimSpace(name) == "" && cfg != nil {


### PR DESCRIPTION
Closes a wiring gap from #475 part 1: safe-action endpoint returned 500 on the fleet --read-only=false path because LoadFleetProjects (the --fleet YAML loader) was missing the SetActionGH call that fleetProjectsFromConfigs already had. Verified on workshop. Refs #475, #477.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a wiring gap where `LoadFleetProjects` (the `--fleet` YAML path) was missing the `SetActionGH` call that `fleetProjectsFromConfigs` already performed, causing the safe-action endpoint to return 500 in non-read-only fleet mode.

- **`internal/server/fleet.go`**: Adds a `Cfg()` accessor on `*FleetProject` to expose the loaded `*config.Config`; needed because `internal/server` can't import `github` without a cycle, so the caller in `cmd/maestro` must do the wiring.
- **`cmd/maestro/main.go`**: After `LoadFleetProjects`, iterates over the project slice by index (correctly mutating slice elements) and calls `SetActionGH(github.New(cfg.Repo))` for each project with a non-nil config, exactly mirroring what `fleetProjectsFromConfigs` already did.

<h3>Confidence Score: 5/5</h3>

This is a minimal, targeted wiring fix that is safe to merge.

Both changed paths are small and well-contained. The new loop mirrors the identical pattern already used in `fleetProjectsFromConfigs`, and index-based iteration correctly mutates the slice elements rather than copies. The `Cfg()` accessor is straightforward, follows the existing nil-receiver guard convention of `SetActionGH`, and the calling code guards on `cfg != nil` before using it. No edge cases appear to be introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds a Cfg() accessor on *FleetProject to expose the loaded config to callers outside the package; nil-receiver guard is consistent with the existing SetActionGH pattern. |
| cmd/maestro/main.go | Wires SetActionGH for every project loaded from a fleet YAML file, mirroring the identical loop already present in fleetProjectsFromConfigs; index-based iteration correctly mutates slice elements. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): wire safe-action GH client ..."](https://github.com/befeast/maestro/commit/3cdad34195c754fc13e9a1ceaeaec7103cbd0d03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34708284)</sub>

<!-- /greptile_comment -->