### PR TITLE
fix(write-path): greptile P1 batch on #478–#481 (label-fallback, ID collision, dry-run executor, 409 mapping)

### DIFF
--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -165,15 +167,13 @@ func safeActionReadyLabel(cfg *config.Config) string {
 	if cfg == nil {
 		return ""
 	}
-	if l := strings.TrimSpace(cfg.Supervisor.ReadyLabel); l != "" {
-		return l
-	}
-	for _, l := range cfg.IssueLabels {
-		if t := strings.TrimSpace(l); t != "" {
-			return t
-		}
-	}
-	return ""
+	// Only honour cfg.Supervisor.ReadyLabel — NEVER fall back to
+	// cfg.IssueLabels, which is the FILTER set ("bug", "feature", etc.)
+	// used to decide which issues maestro tracks. Falling back to the
+	// first IssueLabels entry would let `remove_ready_label` strip a
+	// tracking label off an issue, silently de-listing it. Greptile P1
+	// on #478.
+	return strings.TrimSpace(cfg.Supervisor.ReadyLabel)
 }
 
 func safeActionBlockedLabel(cfg *config.Config) string {
@@ -334,7 +334,7 @@ func buildApprovalDecision(id string, req controlActionRequest, cfg *config.Conf
 	}
 
 	decision := state.SupervisorDecision{
-		ID:                fmt.Sprintf("http-%s-%s", id, now.UTC().Format("20060102T150405.000000000Z")),
+		ID:                fmt.Sprintf("http-%s-%s-%s", id, now.UTC().Format("20060102T150405.000000000Z"), randomDecisionSuffix()),
 		CreatedAt:         now,
 		Project:           projectName,
 		Mode:              "http_enqueue",
@@ -365,4 +365,18 @@ func approvalTargetSummary(target *state.SupervisorTarget) string {
 		parts = append(parts, "session "+target.Session)
 	}
 	return strings.Join(parts, " ")
+}
+
+// randomDecisionSuffix returns a short random hex token used to
+// disambiguate decision IDs minted in the same nanosecond. Greptile P1
+// on #479: two concurrent enqueues at the same OS clock tick would
+// otherwise produce identical Approval IDs. Falling back to a
+// timestamp-only string on read failure keeps the path deterministic
+// in the (effectively impossible) case crypto/rand returns an error.
+func randomDecisionSuffix() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "x"
+	}
+	return hex.EncodeToString(b[:])
 }

--- a/internal/server/approvals.go
+++ b/internal/server/approvals.go
@@ -117,7 +117,13 @@ func applyApprovalDecision(w http.ResponseWriter, r *http.Request, readOnly bool
 			writeError(w, http.StatusNotFound, err.Error())
 		case errors.Is(err, state.ErrApprovalStale),
 			errors.Is(err, state.ErrApprovalSuperseded),
-			errors.Is(err, state.ErrApprovalNotPending):
+			errors.Is(err, state.ErrApprovalNotPending),
+			errors.Is(err, state.ErrApprovalPayloadMismatch):
+			// Greptile P1 on #481: PayloadMismatch is also a stale-
+			// conflict condition (the approval payload changed under
+			// the client). Map to 409 so dashboards can detect it
+			// uniformly with the other conflict cases instead of
+			// receiving a misleading 400 Bad Request.
 			writeError(w, http.StatusConflict, err.Error())
 		default:
 			writeError(w, http.StatusBadRequest, err.Error())
@@ -157,6 +163,12 @@ func cfgServerReadOnly(cfg *config.Config) bool {
 // --- fleet server hookup ----------------------------------------------------
 
 func (s *FleetServer) handleFleetApproval(w http.ResponseWriter, r *http.Request) {
+	// Greptile P2 on #481: enforce 405 BEFORE the project lookup so a
+	// GET against an unknown project returns 405, not 404.
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
 	route, ok := parseApprovalPath("/api/v1/fleet/approvals/", r.URL.Path)
 	if !ok {
 		writeError(w, http.StatusNotFound, "expected /api/v1/fleet/approvals/{id}/{approve|reject}?project=...")

--- a/internal/server/greptile_review_test.go
+++ b/internal/server/greptile_review_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// Greptile P1 #478 — safeActionReadyLabel must NOT fall back to
+// cfg.IssueLabels[0] (which is the FILTER set, not the readiness
+// signal). A bare "bug"/"feature" entry there must not become the
+// label `remove_ready_label` strips off an issue.
+func TestSafeActionReadyLabel_NoIssueLabelsFallback(t *testing.T) {
+	cfg := &config.Config{
+		Supervisor:  config.SupervisorConfig{ReadyLabel: ""},
+		IssueLabels: []string{"bug", "feature"},
+	}
+	if got := safeActionReadyLabel(cfg); got != "" {
+		t.Fatalf("safeActionReadyLabel should return empty when ReadyLabel is empty, got %q", got)
+	}
+}
+
+func TestSafeActionReadyLabel_HonoursExplicitReadyLabel(t *testing.T) {
+	cfg := &config.Config{
+		Supervisor:  config.SupervisorConfig{ReadyLabel: "maestro-ready"},
+		IssueLabels: []string{"bug"},
+	}
+	if got := safeActionReadyLabel(cfg); got != "maestro-ready" {
+		t.Fatalf("got %q, want maestro-ready", got)
+	}
+}
+
+// Greptile P1 #479 — buildApprovalDecision must produce DISTINCT IDs
+// even when two requests land in the same nanosecond (clock-tick
+// collision). The crypto/rand suffix makes the chance vanishingly low.
+func TestBuildApprovalDecision_IDsDistinctOnSameTimestamp(t *testing.T) {
+	cfg := &config.Config{Repo: "owner/repo"}
+	now := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	req := controlActionRequest{ActionID: "merge_pr", PRNumber: 1, Project: "p"}
+
+	a := buildApprovalDecision("merge_pr", req, cfg, now)
+	b := buildApprovalDecision("merge_pr", req, cfg, now)
+	if a.ID == b.ID {
+		t.Fatalf("two decisions at the same `now` produced identical ID %q (greptile P1 #479)", a.ID)
+	}
+	// The ID must still carry the timestamp prefix so existing log
+	// formatting / sort behaviour is preserved.
+	if !strings.Contains(a.ID, "20260530T120000") || !strings.Contains(b.ID, "20260530T120000") {
+		t.Fatalf("IDs lost the timestamp prefix: %q / %q", a.ID, b.ID)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -137,11 +137,11 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 	if reader == nil {
 		reader = github.New(cfg.Repo)
 	}
-
-	// Execute any approvals that were transitioned to status=approved
-	// outside this loop (CLI approve already executes inline; this pass
-	// catches web-driven approves and replays after a daemon restart).
-	executeApprovedApprovals(cfg, st, reader)
+	// NOTE: approval execution must NOT run in dry-run mode (greptile
+	// P1 on #480) — the side effects are real GH/fs operations and the
+	// state.Save that records the executed/failed transition lives
+	// inside the !DryRun guard below, so dry-run would also re-execute
+	// the same approvals on every cycle. We move the call there.
 	recordOutcomeHealth(cfg, st)
 
 	decision, err := NewEngine(cfg, reader).Decide(st)
@@ -149,6 +149,12 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 		return state.SupervisorDecision{}, err
 	}
 	if !cfg.Supervisor.DryRun {
+		// Execute any approvals that were transitioned to status=approved
+		// outside this loop (CLI approve already executes inline; this
+		// pass catches web-driven approves and replays after a daemon
+		// restart). Lives inside the dry-run guard so the resulting
+		// state transitions are persisted by the state.Save below.
+		executeApprovedApprovals(cfg, st, reader)
 		if decisionRequiresApproval(cfg, decision) {
 			approval := st.RecordPendingApprovalForDecision(decision, decision.CreatedAt)
 			decision.ApprovalID = approval.ID
@@ -2658,9 +2664,9 @@ func executeApprovedApprovals(cfg *config.Config, st *state.State, reader Reader
 		Worktrees: approver.WorktreeRemoverFunc(worker.RemoveWorktree),
 		Cfg:       cfg,
 	}
-	now := time.Now().UTC()
 	for _, a := range approvals {
 		res := ex.Execute(a)
+		now := time.Now().UTC()
 		switch res.Status {
 		case state.ApprovalStatusExecuted:
 			if _, err := st.MarkApprovalExecuted(a.ID, now, "supervisor", res.Summary); err != nil {


### PR DESCRIPTION
fix(write-path): address greptile P1 batch on #478-#484

Six fixes from greptile reviews of today's dashboard write-path PRs.
Four are functionally critical (data corruption / dry-run safety / API
contract). Two are minor but mirrored from the same review.

  P1 (#478) safeActionReadyLabel — drop the cfg.IssueLabels[0]
  fallback. IssueLabels is the FILTER set ("bug", "feature") that
  picks which issues maestro tracks; falling back to it would let
  remove_ready_label silently strip a tracking label off an issue and
  de-list it. Empty cfg.Supervisor.ReadyLabel must surface as the
  existing 500 "no ready label configured" error, not produce a wrong
  label removal. Test: TestSafeActionReadyLabel_NoIssueLabelsFallback.

  P1 (#479) buildApprovalDecision — collision-proof Approval IDs.
  Decision IDs were derived from a UTC timestamp alone; two concurrent
  HTTP enqueues at the same nanosecond produced identical IDs and
  RecordPendingApprovalForDecision happily appended both, so any
  later FindApproval silently conflated them. Add an 8-byte
  crypto/rand suffix (hex). Test:
  TestBuildApprovalDecision_IDsDistinctOnSameTimestamp.

  P1 (#480) supervisor.RunOnce — move executeApprovedApprovals INSIDE
  the !cfg.Supervisor.DryRun guard. Two coupled bugs: dry-run was
  firing real GH/fs side effects, and state.Save (also inside the
  guard) wasn't persisting the resulting executed/execution_failed
  transitions, so every cycle re-executed the same approvals (infinite
  loop). The executor now sits next to the persistence path. Capture
  `now` per-approval inside the loop so audit timestamps reflect each
  step's wall-clock time, not the loop's start.

  P1 (#481) approvals.go — map state.ErrApprovalPayloadMismatch to 409
  Conflict. ensureApprovalCurrent already mutates the approval to
  stale before returning this error, so it's a conflict signal, not a
  malformed-request signal. Clients monitoring 409 to detect stale
  approvals were silently misclassifying it as 400.

  P2 (#481) handleFleetApproval — enforce method-not-allowed (405)
  BEFORE the project lookup. A GET against a valid route with an
  unknown project= returned 404, contradicting the documented
  "405 on non-POST" rule.

Verified on workshop: go build / go vet / go test ./... pass; the new
internal/server/greptile_review_test.go covers the two P1 server-side
fixes that have a unit-testable surface.

Refs #478, #479, #480, #481.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses four write-path correctness fixes across the server and supervisor layers: removing an unsafe `IssueLabels` fallback in the ready-label helper, adding a crypto/rand suffix to prevent approval decision ID collisions, moving approval execution inside the dry-run guard (fixing infinite re-execution and missed state persistence), and mapping `ErrApprovalPayloadMismatch` to 409 for consistent conflict signaling.

- **`safeActionReadyLabel`** now returns empty string when `ReadyLabel` is unset instead of falling back to the filter label set, preventing silent issue de-listing.
- **`buildApprovalDecision`** appends an 8-byte random hex suffix to each ID; `executeApprovedApprovals` is moved inside `!DryRun` so side effects and their state transitions are co-located; `now` is captured per-approval inside the loop for accurate audit timestamps.
- **`approvals.go`** maps `ErrApprovalPayloadMismatch` to 409 and adds 405 enforcement to the fleet approval handler; the single-project `Server.handleApproval` still lacks the equivalent method check.

<h3>Confidence Score: 4/5</h3>

The core fixes are all correct and well-targeted; the two remaining gaps are minor and low-risk in practice.

All four functional fixes are implemented correctly. The randomDecisionSuffix fallback returns a constant "x" rather than a unique value, meaning a crypto/rand failure would reintroduce collision risk. Server.handleApproval still lacks the 405 method guard added to its fleet counterpart, leaving the non-fleet approval endpoint inconsistent with the documented API contract.

internal/server/approvals.go (missing 405 check in Server.handleApproval) and internal/server/actions.go (randomDecisionSuffix fallback)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/server/actions.go | Removes IssueLabels fallback from safeActionReadyLabel (correct); adds crypto/rand suffix to decision IDs to prevent collision — fallback returns constant "x" on rand failure, which could reintroduce collisions in a degenerate environment. |
| internal/server/approvals.go | Maps ErrApprovalPayloadMismatch to 409 (correct); adds 405 enforcement to FleetServer.handleFleetApproval but Server.handleApproval at /api/v1/approvals/ still lacks the same check. |
| internal/supervisor/supervisor.go | Moves executeApprovedApprovals inside the !DryRun guard — correctly prevents real side-effects in dry-run and fixes the infinite re-execution loop; now captured per iteration. |
| internal/server/greptile_review_test.go | New test file covering the label-fallback fix and ID-collision fix; tests are correct and targeted. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/server/approvals.go`, line 142-154 ([link](https://github.com/befeast/maestro/blob/428dfd5b93902f5738de28b2291a7d4d57a7858e/internal/server/approvals.go#L142-L154)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`Server.handleApproval` still missing 405 check**

   The PR adds method-not-allowed enforcement to `handleFleetApproval`, but the parallel single-project handler `Server.handleApproval` (registered at `/api/v1/approvals/`) has no `r.Method != http.MethodPost` guard. A GET against a valid approval URL on the non-fleet server still returns 404 instead of 405, leaving the documented "405 on non-POST" contract inconsistently enforced across both server types.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/approvals.go
   Line: 142-154

   Comment:
   **`Server.handleApproval` still missing 405 check**

   The PR adds method-not-allowed enforcement to `handleFleetApproval`, but the parallel single-project handler `Server.handleApproval` (registered at `/api/v1/approvals/`) has no `r.Method != http.MethodPost` guard. A GET against a valid approval URL on the non-fleet server still returns 404 instead of 405, leaving the documented "405 on non-POST" contract inconsistently enforced across both server types.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/approvals.go:142-154
**`Server.handleApproval` still missing 405 check**

The PR adds method-not-allowed enforcement to `handleFleetApproval`, but the parallel single-project handler `Server.handleApproval` (registered at `/api/v1/approvals/`) has no `r.Method != http.MethodPost` guard. A GET against a valid approval URL on the non-fleet server still returns 404 instead of 405, leaving the documented "405 on non-POST" contract inconsistently enforced across both server types.

### Issue 2 of 2
internal/server/actions.go:376-382
The `"x"` fallback on `rand.Read` failure is a deterministic constant, so if `rand.Read` were to fail for all callers in the same cycle (e.g., entropy pool exhaustion in a constrained environment), every decision ID would share the same suffix and the collision problem returns. A per-call nonce derived from a cheaper source — or even a monotonic counter — would eliminate the reintroduction of the original bug for that path.

```suggestion
func randomDecisionSuffix() string {
	var b [8]byte
	if _, err := rand.Read(b[:]); err != nil {
		// Fallback: use UnixNano so concurrent failures still produce
		// distinct suffixes rather than all colliding on "x".
		return fmt.Sprintf("%016x", time.Now().UnixNano())
	}
	return hex.EncodeToString(b[:])
}
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(write-path): address greptile P1 bat..."](https://github.com/befeast/maestro/commit/428dfd5b93902f5738de28b2291a7d4d57a7858e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34709515)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->