### PR TITLE
fix(approver): idempotent executor — per-approval lock + slot-reuse fence (#488)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -560,6 +560,7 @@ func superviseApprovalCmd(action string, args []string, defaultConfigPath string
 		GH:        github.New(cfg.Repo),
 		Worktrees: approver.WorktreeRemoverFunc(worker.RemoveWorktree),
 		Cfg:       cfg,
+		Sessions:  approver.SessionLookupFunc(st.SessionAt),
 	}
 	res := ex.Execute(approval)
 

--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
@@ -41,12 +42,46 @@ func (f WorktreeRemoverFunc) RemoveWorktree(localPath, worktreePath string) erro
 	return f(localPath, worktreePath)
 }
 
+// SessionLookup is the narrow surface the executor needs from a state
+// container to fence slot-reuse races (#488). state.State satisfies this
+// trivially via SessionLookupFunc(st.SessionAt); tests inject fakes.
+type SessionLookup interface {
+	// LookupSession returns the live session at the given slot if any.
+	// Returns (nil, false) when no session is bound.
+	LookupSession(slot string) (*state.Session, bool)
+}
+
+// SessionLookupFunc adapts a plain function to the SessionLookup
+// interface. Pass `approver.SessionLookupFunc(st.SessionAt)` from any
+// caller that already has a *state.State in hand.
+type SessionLookupFunc func(slot string) (*state.Session, bool)
+
+// LookupSession satisfies the SessionLookup interface.
+func (f SessionLookupFunc) LookupSession(slot string) (*state.Session, bool) {
+	if f == nil {
+		return nil, false
+	}
+	return f(slot)
+}
+
 // Executor carries the dependencies needed to run any of the four
 // cautious-gate verbs.
 type Executor struct {
 	GH        GitHubClient
 	Worktrees WorktreeRemover
 	Cfg       *config.Config
+
+	// Sessions, when non-nil, lets executeDeleteWorktree refuse to remove
+	// a slot that has been recycled to a different live issue between
+	// approval enqueue and execute (premortem failure mode #7). Optional;
+	// nil disables the fence.
+	Sessions SessionLookup
+
+	// locks serializes Execute(approval) per approval.ID within the same
+	// process. The second concurrent caller for the same ID returns
+	// ApprovalStatusExecutionSkipped without firing any side effect.
+	// Lazy-initialized.
+	locks sync.Map // approval.ID -> *sync.Mutex
 }
 
 // Result describes the outcome of executing one approval.
@@ -80,10 +115,38 @@ var ErrMissingTarget = errors.New("approval target is missing required fields")
 //
 // Execute does NOT validate the approval's status — callers must only
 // pass approvals in status=approved (use state.ListApprovedApprovals).
+//
+// Execute is safe under same-process concurrency: a per-approval-ID
+// advisory lock serializes calls. The second concurrent caller for the
+// same approval.ID short-circuits to ApprovalStatusExecutionSkipped
+// with a clear reason — no GH or fs side effect fires (#488).
 func (e *Executor) Execute(approval *state.Approval) Result {
 	if approval == nil {
 		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("nil approval")}
 	}
+
+	id := strings.TrimSpace(approval.ID)
+	if id != "" {
+		lockI, _ := e.locks.LoadOrStore(id, &sync.Mutex{})
+		lock := lockI.(*sync.Mutex)
+		if !lock.TryLock() {
+			// Another goroutine in this process is already executing the
+			// same approval. The bookkeeping idempotency check
+			// (MarkApproval*) protects against double state writes; this
+			// short-circuit additionally protects against a double SIDE
+			// EFFECT (gh.MergePR twice, RemoveWorktree on a recycled
+			// slot, etc.).
+			return Result{
+				Status:  state.ApprovalStatusExecutionSkipped,
+				Summary: fmt.Sprintf("approval %s already executing in another goroutine", id),
+			}
+		}
+		defer lock.Unlock()
+		// Drop the lock from the map after release so long-lived processes
+		// don't accumulate one mutex per ever-seen approval ID.
+		defer e.locks.Delete(id)
+	}
+
 	switch approval.Action {
 	case config.SupervisorActionMergePR:
 		return e.executeMergePR(approval)
@@ -181,6 +244,29 @@ func (e *Executor) executeDeleteWorktree(approval *state.Approval) Result {
 	if err != nil {
 		return Result{Status: state.ApprovalStatusExecutionFailed, Err: err}
 	}
+
+	// Slot-reuse fence (#488 / premortem #7). The approval payload names
+	// a slot, but slots are recycled — by the time we execute, this slot
+	// may be running a different worker on a different issue. Refuse to
+	// remove a worktree whose live session belongs to another issue.
+	// When the approval lacks a target issue (rare; older approvals), or
+	// the session lookup is not wired, fall through to the previous
+	// behaviour to preserve compatibility.
+	if e.Sessions != nil && approval.Target.Issue > 0 {
+		if live, ok := e.Sessions.LookupSession(slot); ok && live != nil {
+			if live.IssueNumber != approval.Target.Issue {
+				return Result{
+					Status: state.ApprovalStatusExecutionFailed,
+					Summary: fmt.Sprintf(
+						"slot %s now bound to issue #%d (approval expected #%d) — refusing to delete a recycled worktree",
+						slot, live.IssueNumber, approval.Target.Issue,
+					),
+					Err: fmt.Errorf("slot %s reused: live=#%d approval=#%d", slot, live.IssueNumber, approval.Target.Issue),
+				}
+			}
+		}
+	}
+
 	if err := e.Worktrees.RemoveWorktree(e.Cfg.LocalPath, worktreePath); err != nil {
 		return Result{
 			Status:  state.ApprovalStatusExecutionFailed,

--- a/internal/approver/idempotent_test.go
+++ b/internal/approver/idempotent_test.go
@@ -1,0 +1,181 @@
+package approver
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// fakeSessionLookup is a minimal in-memory SessionLookup implementation.
+type fakeSessionLookup map[string]*state.Session
+
+func (f fakeSessionLookup) LookupSession(slot string) (*state.Session, bool) {
+	s, ok := f[slot]
+	return s, ok
+}
+
+// blockingGH wraps fakeGH so we can hold MergePR mid-flight from a
+// test, exposing whether the OTHER goroutine called MergePR while we
+// held the per-approval lock.
+type blockingGH struct {
+	mu       sync.Mutex
+	gate     chan struct{} // closed when test is ready to release MergePR
+	released chan struct{} // closed when MergePR returns
+	calls    int32
+}
+
+func (b *blockingGH) MergePR(pr int) error {
+	atomic.AddInt32(&b.calls, 1)
+	if b.gate != nil {
+		<-b.gate
+	}
+	if b.released != nil {
+		close(b.released)
+	}
+	return nil
+}
+func (b *blockingGH) CloseIssue(issue int, comment string) error {
+	atomic.AddInt32(&b.calls, 1)
+	return nil
+}
+
+// --- #488: per-approval-ID lock (concurrent Execute) -----------------------
+
+func TestExecute_ConcurrentSameApproval_OnlyOneSideEffect(t *testing.T) {
+	gate := make(chan struct{})
+	released := make(chan struct{})
+	gh := &blockingGH{gate: gate, released: released}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+
+	results := make(chan Result, 2)
+	go func() { results <- ex.Execute(a) }()
+	// Tiny pause to make sure the first goroutine has acquired the lock
+	// before the second one races in. Using gh.calls as the rendezvous
+	// signal keeps the test independent of clock jitter.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&gh.calls) == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if atomic.LoadInt32(&gh.calls) == 0 {
+		t.Fatal("first goroutine never reached MergePR — deadlock or test setup bug")
+	}
+	go func() { results <- ex.Execute(a) }()
+
+	// The second goroutine returns immediately on TryLock failure.
+	first := <-results
+	if first.Status != state.ApprovalStatusExecutionSkipped {
+		t.Fatalf("expected first-completing goroutine to be skipped (TryLock loser); got %+v", first)
+	}
+
+	// Now release the held MergePR so the executing goroutine finishes.
+	close(gate)
+	<-released
+	second := <-results
+	if second.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("expected the held goroutine to land executed; got %+v", second)
+	}
+
+	if got := atomic.LoadInt32(&gh.calls); got != 1 {
+		t.Fatalf("expected MergePR called exactly once, got %d", got)
+	}
+}
+
+// --- #488: slot-reuse fence on delete_worktree ----------------------------
+
+func TestExecute_DeleteWorktree_SlotReuseRefused(t *testing.T) {
+	wt := &fakeWT{}
+	ex := &Executor{
+		Worktrees: wt,
+		Cfg:       newCfg(),
+		Sessions: fakeSessionLookup{
+			"sup-77": &state.Session{IssueNumber: 999}, // recycled to a different issue
+		},
+	}
+	a := mkApproval(config.SupervisorActionDeleteWorktree, &state.SupervisorTarget{Session: "sup-77", Issue: 812}, "stale", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("res = %+v, want execution_failed", res)
+	}
+	if len(wt.calls) != 0 {
+		t.Fatalf("RemoveWorktree was called %d times — fence failed", len(wt.calls))
+	}
+	if res.Err == nil {
+		t.Fatalf("expected non-nil Err, got nil")
+	}
+}
+
+func TestExecute_DeleteWorktree_SlotMatchesProceeds(t *testing.T) {
+	wt := &fakeWT{}
+	ex := &Executor{
+		Worktrees: wt,
+		Cfg:       newCfg(),
+		Sessions: fakeSessionLookup{
+			"sup-77": &state.Session{IssueNumber: 812}, // same issue — fine
+		},
+	}
+	a := mkApproval(config.SupervisorActionDeleteWorktree, &state.SupervisorTarget{Session: "sup-77", Issue: 812}, "stale", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed", res)
+	}
+	if len(wt.calls) != 1 {
+		t.Fatalf("expected 1 RemoveWorktree call, got %d", len(wt.calls))
+	}
+}
+
+func TestExecute_DeleteWorktree_NoSessionsLookupSkipsFence(t *testing.T) {
+	// Backward compat: callers that don't wire Sessions get the previous
+	// behaviour (no fence).
+	wt := &fakeWT{}
+	ex := &Executor{Worktrees: wt, Cfg: newCfg()} // Sessions: nil
+	a := mkApproval(config.SupervisorActionDeleteWorktree, &state.SupervisorTarget{Session: "sup-77", Issue: 812}, "stale", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed", res)
+	}
+}
+
+func TestExecute_DeleteWorktree_NoLiveSessionProceeds(t *testing.T) {
+	// Slot is empty / not bound — no race possible, fence is a no-op.
+	wt := &fakeWT{}
+	ex := &Executor{
+		Worktrees: wt,
+		Cfg:       newCfg(),
+		Sessions:  fakeSessionLookup{}, // empty
+	}
+	a := mkApproval(config.SupervisorActionDeleteWorktree, &state.SupervisorTarget{Session: "sup-77", Issue: 812}, "stale", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed", res)
+	}
+}
+
+func TestExecute_DeleteWorktree_NoTargetIssueSkipsFence(t *testing.T) {
+	// Older approvals may not carry Target.Issue. Don't trip the fence —
+	// fall through to the previous behaviour. (When #489 lands and
+	// stamps Issue on every approval, this case will be obsolete.)
+	wt := &fakeWT{}
+	ex := &Executor{
+		Worktrees: wt,
+		Cfg:       newCfg(),
+		Sessions: fakeSessionLookup{
+			"sup-77": &state.Session{IssueNumber: 999},
+		},
+	}
+	a := mkApproval(config.SupervisorActionDeleteWorktree, &state.SupervisorTarget{Session: "sup-77" /* Issue absent */}, "x", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed (fence must skip when approval lacks target issue)", res)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1679,6 +1679,22 @@ func (s *State) LiveSessionsAt(now time.Time) []*Session {
 	return live
 }
 
+
+// SessionAt returns the live session bound to slot, if any. Used by the
+// approver executor (#488 slot-reuse fence) to verify a delete_worktree
+// approval still targets the worker that was running when the approval
+// was queued.
+func (s *State) SessionAt(slot string) (*Session, bool) {
+	if s == nil || s.Sessions == nil {
+		return nil, false
+	}
+	sess, ok := s.Sessions[slot]
+	if !ok || sess == nil {
+		return nil, false
+	}
+	return sess, true
+}
+
 // SessionLive reports whether a session belongs in the default operator view.
 func SessionLive(sess *Session) bool {
 	return SessionLiveAt(sess, time.Now().UTC())

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2663,6 +2663,7 @@ func executeApprovedApprovals(cfg *config.Config, st *state.State, reader Reader
 		GH:        gh,
 		Worktrees: approver.WorktreeRemoverFunc(worker.RemoveWorktree),
 		Cfg:       cfg,
+		Sessions:  approver.SessionLookupFunc(st.SessionAt),
 	}
 	for _, a := range approvals {
 		res := ex.Execute(a)


### PR DESCRIPTION
fix(approver): idempotent executor — per-approval lock + slot-reuse fence (#488)

Closes the two coupled side-effect races identified by the dashboard
write-path premortem (failure modes #1 race CLI-inline vs supervisor-
poll, and #7 slot reuse during pending approval window).

Same-process per-approval-ID advisory lock
------------------------------------------
Executor.locks (sync.Map) holds one *sync.Mutex per approval.ID. Execute
acquires it via TryLock before any side effect; the second concurrent
caller for the same ID short-circuits to ApprovalStatusExecutionSkipped
with a clear summary — no GH/fs side effect fires. After release the
mutex is dropped from the map so long-lived processes don't accumulate
one mutex per ever-seen approval.

This protects against the scenario premortem #1 described: CLI approve
calls Execute inline while the supervisor poll's executeApprovedApprovals
also picks the same status=approved approval; the bookkeeping
idempotency (MarkApproval* returning ErrApprovalNotApproved) guarded
state writes but did NOT guard the side effect — gh.MergePR fired
twice, RemoveWorktree on a recycled slot, etc.

Slot-reuse fence in executeDeleteWorktree
-----------------------------------------
Executor.Sessions (new SessionLookup interface) lets the executor verify
that the slot named in the approval is still bound to the issue that
queued it. If the slot has been recycled to a different live issue,
RemoveWorktree is refused — execution_failed with a clear summary
("slot %s now bound to issue #%d (approval expected #%d) — refusing to
delete a recycled worktree"). When Sessions is nil (legacy callers) or
the approval lacks Target.Issue (older approvals — closed by #489 once
that lands), the fence is skipped to preserve compatibility.

Wiring
------
- internal/state/state.go gains SessionAt(slot) — read-only accessor.
- internal/approver/executor.go gains the SessionLookup interface and
  a SessionLookupFunc adapter so callers can pass `st.SessionAt`
  directly.
- internal/supervisor/supervisor.go executeApprovedApprovals + the
  CLI superviseApprovalCmd both wire `approver.SessionLookupFunc(st.SessionAt)`
  into the Executor they construct.

Tests (internal/approver/idempotent_test.go)
--------------------------------------------
- TestExecute_ConcurrentSameApproval_OnlyOneSideEffect: blocks one
  goroutine inside MergePR via a gate channel, fires a second goroutine
  with the same approval id, asserts the second returns
  execution_skipped and gh.MergePR was called exactly once total.
- TestExecute_DeleteWorktree_SlotReuseRefused: live session at the slot
  has IssueNumber=999 while approval.Target.Issue=812 → execution_failed,
  RemoveWorktree never called.
- TestExecute_DeleteWorktree_SlotMatchesProceeds: same issue → executed.
- TestExecute_DeleteWorktree_NoSessionsLookupSkipsFence: Sessions nil →
  executed (back-compat).
- TestExecute_DeleteWorktree_NoLiveSessionProceeds: empty lookup → executed.
- TestExecute_DeleteWorktree_NoTargetIssueSkipsFence: approval without
  Target.Issue → executed (back-compat until #489).

Verified on workshop: go build ./..., go vet ./..., go test ./... pass
(18/18 packages, no regressions).

Refs #488 (premortem #1, #7).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two concurrency safeguards to the approval executor: a per-approval-ID advisory lock (`sync.Map` of `*sync.Mutex`) that prevents the same approval from firing its side effect more than once concurrently, and a slot-reuse fence in `executeDeleteWorktree` that refuses to delete a worktree when the slot has been recycled to a different live issue.

- **Per-approval lock** (`executor.go`): `Execute` acquires a per-ID mutex via `TryLock`; a second concurrent caller short-circuits to `ApprovalStatusExecutionSkipped`. The mutex is cleaned up after execution. However, the two `defer` statements are registered in the wrong order — because Go defers execute LIFO, `e.locks.Delete(id)` fires before `lock.Unlock()`, creating a small window where a new goroutine can obtain a fresh mutex for the same ID and bypass the lock.
- **Slot-reuse fence** (`executor.go`, `state.go`): `SessionAt` exposes the slot→session binding; `executeDeleteWorktree` compares the live session's issue number against the approval's target issue before proceeding. Wired in both the supervisor poll path and the CLI `superviseApprovalCmd`.
- **Tests** (`idempotent_test.go`): Six new tests cover the concurrent-lock path, slot-match/mismatch, nil-Sessions back-compat, and missing `Target.Issue` back-compat.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the reversed defer order — the slot-reuse fence and wiring are correct, but the mutex cleanup creates a brief window that undermines the core idempotency guarantee.

The reversed defer order in executor.go means e.locks.Delete(id) removes the map entry before lock.Unlock() releases the mutex. In that narrow gap a new goroutine for the same approval ID gets a fresh unlocked mutex from LoadOrStore, succeeds on TryLock, and can begin executing the very side effect that the lock is intended to prevent from running twice. The existing test does not exercise this window, so the bug would not be caught by the test suite as written. The slot-reuse fence logic and all wiring changes are correct.

internal/approver/executor.go — specifically the defer ordering around the per-approval mutex cleanup.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/approver/executor.go | Adds per-approval-ID advisory lock and slot-reuse fence. The defer order for Delete/Unlock is reversed (LIFO), so the map entry is removed before the mutex is released — creating a small window where a new goroutine can bypass the lock for the same approval ID. |
| internal/approver/idempotent_test.go | New test file covering concurrent execution lock and slot-reuse fence. Tests are well-structured and deterministic (gate channel prevents clock-jitter flakes). Does not exercise the delete-before-unlock race window introduced by the wrong defer order. |
| internal/state/state.go | Adds SessionAt(slot) read-only accessor. Follows existing map-read conventions in the file. Doc comment says 'live session' but no liveness filter is applied — functionally correct for the fence use case but potentially misleading. |
| internal/supervisor/supervisor.go | Wires SessionLookupFunc(st.SessionAt) into the Executor constructed in executeApprovedApprovals. One-line change, correctly placed. |
| cmd/maestro/main.go | Wires SessionLookupFunc(st.SessionAt) into the Executor in superviseApprovalCmd. One-line change, correctly placed alongside the supervisor wiring. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/approver/executor.go:144-147
The two defers are registered in the wrong order. Go defers execute LIFO, so `e.locks.Delete(id)` (registered second) fires **before** `lock.Unlock()` (registered first). This is the opposite of what the comment says ("after release") and creates a correctness gap: between the moment the map entry is deleted and the moment the mutex is unlocked, a new goroutine for the same ID can call `LoadOrStore(id, &sync.Mutex{})`, get a brand-new unlocked mutex, succeed on `TryLock`, and start executing the side effect concurrently with the goroutine that hasn't unlocked yet. Swap the registration order so `Delete` is registered first (runs last).

```suggestion
		// Drop the lock from the map after release so long-lived processes
		// don't accumulate one mutex per ever-seen approval ID.
		defer e.locks.Delete(id)
		defer lock.Unlock()
```

### Issue 2 of 2
internal/state/state.go:1683-1696
**`SessionAt` comment says "live session" but returns any session regardless of status.** The doc comment reads "SessionAt returns the live session bound to slot" but the implementation returns the session at that slot regardless of its status (`running`, `done`, `failed`, `dead`, etc.) — it does not call `SessionLiveAt` or check `sess.Status`. For the slot-reuse fence this is actually the correct behaviour (a terminated session for issue #812 still indicates the slot was last bound to #812, which is what the executor needs), but the misleading comment could cause future callers to assume liveness filtering has already been applied.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(approver): idempotent executor — per..."](https://github.com/befeast/maestro/commit/3ace418cd1dec28c16ae13486cb82a10083cdcc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34716532)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->