### PR TITLE
fix(approver): stamp Repo on Approval; executor refuses cross-project mutation (#489)

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -147,6 +147,27 @@ func (e *Executor) Execute(approval *state.Approval) Result {
 		defer e.locks.Delete(id)
 	}
 
+	// Repo guard (#489 / premortem #3): refuse any approval whose
+	// stamped Repo does not match the executor's cfg.Repo. Defends
+	// against a refactor that pools Executors across projects and
+	// silently fires merge_pr against the wrong owner/repo. Empty
+	// approval.Repo is back-compat — approvals created before #489 had
+	// no stamp; we fall through to the existing behaviour to avoid
+	// breaking already-pending approvals on upgrade.
+	if strings.TrimSpace(approval.Repo) != "" && e.Cfg != nil {
+		cfgRepo := strings.TrimSpace(e.Cfg.Repo)
+		if cfgRepo != "" && approval.Repo != cfgRepo {
+			return Result{
+				Status: state.ApprovalStatusExecutionFailed,
+				Summary: fmt.Sprintf(
+					"approval %s is bound to repo %q but executor cfg.Repo is %q — refusing cross-project mutation",
+					approval.ID, approval.Repo, cfgRepo,
+				),
+				Err: fmt.Errorf("approval %s repo mismatch: approval=%s cfg=%s", approval.ID, approval.Repo, cfgRepo),
+			}
+		}
+	}
+
 	switch approval.Action {
 	case config.SupervisorActionMergePR:
 		return e.executeMergePR(approval)

--- a/internal/approver/repo_guard_test.go
+++ b/internal/approver/repo_guard_test.go
@@ -1,0 +1,83 @@
+package approver
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// --- #489: cross-project repo guard ---------------------------------------
+
+func TestExecute_CrossProjectMutation_Refused(t *testing.T) {
+	gh := &fakeGH{}
+	cfg := newCfg() // cfg.Repo = "owner/repo"
+	ex := &Executor{GH: gh, Cfg: cfg}
+
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a.Repo = "BeFeast/scribe-service" // mismatch
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("res = %+v, want execution_failed", res)
+	}
+	if len(gh.mergeCalls) != 0 {
+		t.Fatalf("MergePR was called %v — repo guard failed", gh.mergeCalls)
+	}
+	if res.Err == nil || !errors.Is(res.Err, res.Err) {
+		t.Fatalf("expected non-nil Err carrying the mismatch reason; got %v", res.Err)
+	}
+}
+
+func TestExecute_RepoMatch_Proceeds(t *testing.T) {
+	gh := &fakeGH{}
+	cfg := newCfg()
+	ex := &Executor{GH: gh, Cfg: cfg}
+
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a.Repo = cfg.Repo // explicit match
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed", res)
+	}
+	if len(gh.mergeCalls) != 1 {
+		t.Fatalf("expected 1 MergePR call, got %v", gh.mergeCalls)
+	}
+}
+
+func TestExecute_LegacyApprovalNoRepo_FallsThrough(t *testing.T) {
+	// Approvals created before #489 don't carry Repo. Don't break them
+	// on upgrade — fall through to the existing behaviour.
+	gh := &fakeGH{}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	// a.Repo intentionally left empty.
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed (back-compat for unstamped approvals)", res)
+	}
+	if len(gh.mergeCalls) != 1 {
+		t.Fatalf("expected 1 MergePR call, got %v", gh.mergeCalls)
+	}
+}
+
+func TestExecute_NoCfgRepo_SkipsGuard(t *testing.T) {
+	// Defensive: if cfg.Repo is somehow empty, don't trip the guard
+	// (we can't tell the operator anything useful).
+	gh := &fakeGH{}
+	cfg := newCfg()
+	cfg.Repo = ""
+	ex := &Executor{GH: gh, Cfg: cfg}
+
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a.Repo = "BeFeast/something" // irrelevant — cfg has nothing to compare against
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed (cfg.Repo empty -> guard skipped)", res)
+	}
+}

--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -337,6 +337,7 @@ func buildApprovalDecision(id string, req controlActionRequest, cfg *config.Conf
 		ID:                fmt.Sprintf("http-%s-%s-%s", id, now.UTC().Format("20060102T150405.000000000Z"), randomDecisionSuffix()),
 		CreatedAt:         now,
 		Project:           projectName,
+		Repo:              repoFromConfig(cfg),
 		Mode:              "http_enqueue",
 		Status:            "pending_approval",
 		Summary:           summary,
@@ -379,4 +380,14 @@ func randomDecisionSuffix() string {
 		return "x"
 	}
 	return hex.EncodeToString(b[:])
+}
+
+// repoFromConfig returns the trimmed cfg.Repo or "" if cfg is nil.
+// Used by buildApprovalDecision to stamp the project repo onto every
+// HTTP-enqueued approval (#489).
+func repoFromConfig(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.Repo)
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -577,6 +577,7 @@ type SupervisorDecision struct {
 	ID                string                   `json:"id"`
 	CreatedAt         time.Time                `json:"created_at"`
 	Project           string                   `json:"project"`
+	Repo              string                   `json:"repo,omitempty"`
 	Mode              string                   `json:"mode"`
 	PolicyRule        string                   `json:"policy_rule,omitempty"`
 	Status            string                   `json:"status,omitempty"`
@@ -637,6 +638,13 @@ type Approval struct {
 	PayloadHash     string            `json:"payload_hash"`
 	TargetStateHash string            `json:"target_state_hash,omitempty"`
 	Audit           []ApprovalAudit   `json:"audit,omitempty"`
+	// Repo + Project bind the approval to a specific project context at
+	// write-time (#489). The executor refuses any approval whose Repo
+	// does not match the executor's cfg.Repo, defending against
+	// cross-project mutation if Executor wiring drifts in the future.
+	// Both omitempty for back-compat with approvals created before #489.
+	Repo    string `json:"repo,omitempty"`
+	Project string `json:"project,omitempty"`
 }
 
 type ApprovalAudit struct {
@@ -1327,6 +1335,8 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 		Evidence:        append([]string(nil), decision.Reasons...),
 		Status:          ApprovalStatusPending,
 		TargetStateHash: s.ApprovalTargetStateHash(decision.Target),
+		Repo:            decision.Repo,
+		Project:         decision.Project,
 	}
 	approval.PayloadHash = approval.ComputePayloadHash()
 	approval.Audit = append(approval.Audit, ApprovalAudit{

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -200,6 +200,12 @@ func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 	}
 	outcomeStatus := e.outcomeStatus(st)
 	decision.Outcome = &outcomeStatus
+	// Stamp the project repo on every decision so RecordPendingApprovalForDecision
+	// carries it onto the Approval (#489). Defends against cross-project
+	// mutation if Executor wiring ever drifts.
+	if decision.Repo == "" {
+		decision.Repo = strings.TrimSpace(e.cfg.Repo)
+	}
 	return decision, nil
 }
 


### PR DESCRIPTION
fix(approver): stamp Repo on Approval; executor refuses cross-project mutation (#489)

Closes premortem failure mode #3: the approval payload identifies WHAT
to do (action + target) but not WHERE — `Repo` was implicit in the
executor's ambient `cfg.Repo`. A future refactor that hoists Executor
construction or pools workers across projects could fire `merge_pr`
for scribe-service PR #847 against `BeFeast/maestro` PR #847; the
cautious approval gate doesn't help because the approval is already
approved, and the wrong-repo binding bypasses every existing safety.

Changes
-------

  * state.Approval gains Repo + Project fields (omitempty for
    back-compat with approvals created before #489).
  * state.SupervisorDecision gains Repo (Project was already there).
  * RecordPendingApprovalForDecision copies Repo + Project from the
    decision into the new Approval.
  * supervisor.Engine.Decide stamps decision.Repo from e.cfg.Repo on
    every decision before it returns.
  * server.actions.go buildApprovalDecision stamps Repo from
    repoFromConfig(cfg) for every HTTP-enqueued approval.
  * approver.Executor.Execute compares approval.Repo with cfg.Repo
    BEFORE any side effect; mismatch returns ApprovalStatusExecutionFailed
    with a clear summary ("approval %s is bound to repo %q but executor
    cfg.Repo is %q — refusing cross-project mutation"). Empty
    approval.Repo (older approvals without the stamp) and empty
    cfg.Repo skip the guard for back-compat — both no-ops.

Tests (internal/approver/repo_guard_test.go)
--------------------------------------------

  * TestExecute_CrossProjectMutation_Refused: approval.Repo =
    "BeFeast/scribe-service", cfg.Repo = "owner/repo" → execution_failed,
    gh.MergePR not called.
  * TestExecute_RepoMatch_Proceeds: explicit repo match → executed.
  * TestExecute_LegacyApprovalNoRepo_FallsThrough: approval without
    Repo (pre-#489 enqueue) still executes — back-compat.
  * TestExecute_NoCfgRepo_SkipsGuard: defensive — cfg.Repo empty -> guard
    skipped.

Verified on workshop: go build ./..., go vet ./..., go test ./... pass
(18/18 packages, no regressions). Defends in depth alongside #488's
per-approval lock + slot-reuse fence.

Refs #489 (premortem #3).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defends against cross-project mutation (premortem #3) by stamping a `Repo` field onto approvals at write-time and having the executor refuse execution when the stamped repo doesn't match `cfg.Repo`.

- `state.Approval` and `state.SupervisorDecision` gain `Repo` (and `Project`) fields with `omitempty` for back-compat; `RecordPendingApprovalForDecision` propagates them; the supervisor's `Decide` and the HTTP action builder both stamp `cfg.Repo` onto every outgoing decision.
- `Executor.Execute` checks the stamped `Repo` before any side effect, returning `execution_failed` on mismatch; empty `approval.Repo` or empty `cfg.Repo` skip the guard for backward-compatibility with pre-#489 approvals.
- Four new unit tests cover the mismatch, match, legacy no-repo, and no-cfg-repo paths; the test for the mismatch path contains a tautological `errors.Is` assertion that is always true, leaving the error-type check as dead code.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the guard logic and stamping paths are correct, with two small inconsistencies that don't affect the happy path.

The production guard logic is sound and all four stamping paths are wired consistently. Two things need a look: the approval.Repo comparison in the executor uses the untrimmed value after already trimming it for the emptiness check, and a tautological errors.Is assertion in the test makes the error-type check permanently dead code.

internal/approver/repo_guard_test.go (tautological assertion), internal/approver/executor.go (trimming inconsistency in guard comparison)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/approver/executor.go | Adds repo guard before any side-effecting action; minor trimming inconsistency where approval.Repo is trimmed for emptiness check but compared raw. |
| internal/approver/repo_guard_test.go | New tests for repo guard; tautological errors.Is assertion makes the error-type check in TestExecute_CrossProjectMutation_Refused dead code. |
| internal/state/state.go | Adds Repo/Project fields to Approval and Repo to SupervisorDecision with omitempty for back-compat; RecordPendingApprovalForDecision propagates them correctly. |
| internal/supervisor/supervisor.go | Stamps decision.Repo from cfg at the end of Decide; conditional is safe because decideWithLLM never sets Repo (LLMDecision struct lacks the field and DisallowUnknownFields is set). |
| internal/server/actions.go | Stamps Repo on HTTP-enqueued decisions via repoFromConfig; nil-safe helper is correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/approver/repo_guard_test.go:28-30
The `errors.Is(res.Err, res.Err)` predicate is a tautology — `errors.Is(x, x)` is always `true` (Go checks identity first), so `!errors.Is(res.Err, res.Err)` is always `false`. The second branch of the `||` is dead code and the error-type assertion never executes. The test only ever checks `res.Err == nil`, making the comment about "carrying the mismatch reason" misleading.

```suggestion
	if res.Err == nil {
		t.Fatalf("expected non-nil Err carrying the mismatch reason; got %v", res.Err)
	}
```

### Issue 2 of 2
internal/approver/executor.go:157-159
`approval.Repo` is trimmed when checking for non-empty but compared raw against the already-trimmed `cfgRepo`. If a caller passes `approval.Repo` with surrounding whitespace, the guard would refuse a valid match. Consistently capture the trimmed value once and use it for both checks.

```suggestion
	approvalRepo := strings.TrimSpace(approval.Repo)
	if approvalRepo != "" && e.Cfg != nil {
		cfgRepo := strings.TrimSpace(e.Cfg.Repo)
		if cfgRepo != "" && approvalRepo != cfgRepo {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(approver): stamp Repo on Approval; e..."](https://github.com/befeast/maestro/commit/31933881fa7876371b6b7927fccbc7c4783e31a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34719078)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->