### PR TITLE
fix(state): validate Target.Session at every state-write ingress (#490)

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -311,11 +311,8 @@ func WorktreePathForSlot(cfg *config.Config, slot string) (string, error) {
 		return "", errors.New("cfg.worktree_base is not set")
 	}
 	clean := strings.TrimSpace(slot)
-	if clean == "" {
-		return "", errors.New("slot is empty")
-	}
-	if strings.ContainsAny(clean, "/\\") || clean == "." || clean == ".." {
-		return "", fmt.Errorf("slot %q contains a path separator or traversal segment; refusing", slot)
+	if err := state.ValidateSlotID(clean); err != nil {
+		return "", err
 	}
 	// filepath.Join intentionally not imported here — concatenate via "/"
 	// to keep the boundary explicit and predictable on the path.

--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -295,8 +295,8 @@ func validateApprovalRequest(id string, req controlActionRequest) error {
 			return errors.New("issue_number is required for close_issue")
 		}
 	case config.SupervisorActionDeleteWorktree:
-		if strings.TrimSpace(req.Slot) == "" {
-			return errors.New("slot is required for delete_worktree")
+		if err := state.ValidateSlotID(req.Slot); err != nil {
+			return fmt.Errorf("delete_worktree: %w", err)
 		}
 	case config.SupervisorActionChangeGlobalConfig:
 		if strings.TrimSpace(req.Reason) == "" {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1316,6 +1316,18 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 	if s == nil {
 		return nil
 	}
+	// #490: refuse malformed Target.Session at the state-write boundary.
+	// Otherwise a malformed slot from the supervisor LLM lands in state,
+	// is approved by an unsuspecting operator, and only the executor's
+	// WorktreePathForSlot catches it — too late for forensics. Validators
+	// live at every ingress.
+	if decision.Target != nil {
+		if sess := strings.TrimSpace(decision.Target.Session); sess != "" {
+			if err := ValidateSlotID(sess); err != nil {
+				return nil
+			}
+		}
+	}
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
@@ -2238,4 +2250,47 @@ func (s *State) MarkApprovalExecutionSkipped(id string, now time.Time, actor, re
 		TargetStateHash: approval.TargetStateHash,
 	})
 	return approval, nil
+}
+
+// ValidateSlotID is the canonical slot-id validator used at EVERY
+// state-write ingress (#490 / premortem #5). A slot id names a session
+// in `state.Sessions` and is later concatenated into a worktree path
+// under `cfg.WorktreeBase`; a malformed slot ("../etc/passwd", a NUL
+// byte, a backslash) would let an attacker (or a hallucinating
+// supervisor LLM) escape the worktree base and steer subsequent
+// `worker.RemoveWorktree` calls at unrelated paths.
+//
+// Validators live HERE, not at the executor-only boundary, so any
+// future refactor that adds a new write-path (HTTP, CLI, supervisor
+// LLM, replay tool) gets the check for free as long as it routes
+// through state.RecordPendingApprovalForDecision or another helper
+// that calls ValidateSlotID.
+//
+// Empty input is rejected. The shape is intentionally narrow: ASCII
+// letters / digits / `-` / `_`, length 1..96. We do NOT accept `/`,
+// `\`, `.`, `..`, NUL, or anything outside that ASCII set. Tests
+// in state_test.go enforce the negative cases.
+func ValidateSlotID(slot string) error {
+	s := strings.TrimSpace(slot)
+	if s == "" {
+		return errors.New("slot is empty")
+	}
+	if s == "." || s == ".." {
+		return errors.New("slot is a traversal segment")
+	}
+	if len(s) > 96 {
+		return errors.New("slot exceeds 96 bytes")
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '-' || c == '_':
+		default:
+			return fmt.Errorf("slot %q contains disallowed byte %q at index %d", slot, c, i)
+		}
+	}
+	return nil
 }

--- a/internal/state/validate_slot_test.go
+++ b/internal/state/validate_slot_test.go
@@ -1,0 +1,146 @@
+package state
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateSlotID_AcceptsCanonicalSlots(t *testing.T) {
+	for _, slot := range []string{"sup-77", "scr-241", "ok-1", "fin-99", "a", "abc-XYZ_42"} {
+		if err := ValidateSlotID(slot); err != nil {
+			t.Errorf("ValidateSlotID(%q) = %v, want nil", slot, err)
+		}
+	}
+}
+
+func TestValidateSlotID_RejectsTraversalAndSeparators(t *testing.T) {
+	cases := []string{
+		"",
+		" ",
+		".",
+		"..",
+		"../etc",
+		"a/b",
+		`a\b`,
+		"slot/",
+		"/slot",
+		"with space",
+		"abc.def",
+		"abc:def",
+		"foo;bar",
+		"<script>",
+	}
+	for _, slot := range cases {
+		if err := ValidateSlotID(slot); err == nil {
+			t.Errorf("ValidateSlotID(%q) = nil, want error", slot)
+		}
+	}
+}
+
+func TestValidateSlotID_RejectsNULAndControl(t *testing.T) {
+	cases := []string{
+		"a\x00b",
+		"a\nb",
+		"a\tb",
+		"a\rb",
+	}
+	for _, slot := range cases {
+		if err := ValidateSlotID(slot); err == nil {
+			t.Errorf("ValidateSlotID(%q) = nil, want error (control byte)", slot)
+		}
+	}
+}
+
+func TestValidateSlotID_RejectsOversize(t *testing.T) {
+	long := strings.Repeat("a", 97)
+	if err := ValidateSlotID(long); err == nil {
+		t.Errorf("ValidateSlotID(97-byte input) = nil, want error")
+	}
+	exact := strings.Repeat("a", 96)
+	if err := ValidateSlotID(exact); err != nil {
+		t.Errorf("ValidateSlotID(96-byte input) = %v, want nil", err)
+	}
+}
+
+// --- ingress: state-write boundary should refuse a malformed slot ----------
+
+func TestRecordPendingApprovalForDecision_RejectsMalformedSession(t *testing.T) {
+	for _, slot := range []string{"../etc/passwd", "a/b", `a\b`, "..", "."} {
+		s := NewState()
+		now := time.Now().UTC()
+		decision := SupervisorDecision{
+			ID:                "test-decision",
+			CreatedAt:         now,
+			RecommendedAction: "delete_worktree",
+			Risk:              "high",
+			RequiresApproval:  true,
+			Target:            &SupervisorTarget{Session: slot, Issue: 42},
+		}
+		approval := s.RecordPendingApprovalForDecision(decision, now)
+		if approval != nil {
+			t.Errorf("slot %q: RecordPendingApprovalForDecision returned %+v, want nil (malformed slot must be rejected at ingress)", slot, approval)
+		}
+		if len(s.Approvals) != 0 {
+			t.Errorf("slot %q: %d approvals were appended, want 0", slot, len(s.Approvals))
+		}
+	}
+}
+
+func TestRecordPendingApprovalForDecision_AcceptsValidSession(t *testing.T) {
+	s := NewState()
+	now := time.Now().UTC()
+	decision := SupervisorDecision{
+		ID:                "test-decision",
+		CreatedAt:         now,
+		RecommendedAction: "delete_worktree",
+		Risk:              "high",
+		RequiresApproval:  true,
+		Target:            &SupervisorTarget{Session: "sup-77", Issue: 42},
+	}
+	approval := s.RecordPendingApprovalForDecision(decision, now)
+	if approval == nil {
+		t.Fatalf("RecordPendingApprovalForDecision returned nil for valid slot")
+	}
+	if approval.Target.Session != "sup-77" {
+		t.Fatalf("approval.Target.Session = %q, want sup-77", approval.Target.Session)
+	}
+}
+
+func TestRecordPendingApprovalForDecision_NilTarget_NoSessionCheck(t *testing.T) {
+	// Decisions with no target (e.g. global config changes) skip the
+	// session check entirely.
+	s := NewState()
+	now := time.Now().UTC()
+	decision := SupervisorDecision{
+		ID:                "test-decision",
+		CreatedAt:         now,
+		RecommendedAction: "change_global_config",
+		Risk:              "high",
+		RequiresApproval:  true,
+		// Target is nil — common for non-session-targeted decisions.
+	}
+	approval := s.RecordPendingApprovalForDecision(decision, now)
+	if approval == nil {
+		t.Fatalf("RecordPendingApprovalForDecision returned nil for nil-target decision")
+	}
+}
+
+func TestRecordPendingApprovalForDecision_TargetWithoutSession_NoCheck(t *testing.T) {
+	// Target with PR/Issue but no Session — common for merge_pr / close_issue
+	// approvals. Validator must not trip on absent Session.
+	s := NewState()
+	now := time.Now().UTC()
+	decision := SupervisorDecision{
+		ID:                "test-decision",
+		CreatedAt:         now,
+		RecommendedAction: "merge_pr",
+		Risk:              "high",
+		RequiresApproval:  true,
+		Target:            &SupervisorTarget{Issue: 42, PR: 99},
+	}
+	approval := s.RecordPendingApprovalForDecision(decision, now)
+	if approval == nil {
+		t.Fatalf("RecordPendingApprovalForDecision returned nil for absent-session decision")
+	}
+}


### PR DESCRIPTION
fix(state): validate Target.Session at every state-write ingress (#490)

Closes premortem failure mode #5: today's slot-validator lives only in
the executor (WorktreePathForSlot's inline check). A future refactor
that moves the guard into a separate validator package and updates
just the HTTP ingress would let the supervisor LLM smuggle a
malformed Target.Session through RecordPendingApprovalForDecision.
By the time the executor catches it, an unsuspecting operator has
already approved a string nobody validated end-to-end.

Validators now live at every ingress, with one canonical implementation:

  * state.ValidateSlotID(slot) — the single source of truth. Accepts
    [a-zA-Z0-9_-] up to 96 bytes, rejects empty, ".", "..", path
    separators (`/`, `\`), NUL, control bytes, and anything outside
    the ASCII allowlist.

  * state.RecordPendingApprovalForDecision now rejects an approval
    whose Target.Session is malformed (returns nil, no append).

  * server.dispatchApprovalAction validates req.Slot for delete_worktree
    via state.ValidateSlotID at the HTTP boundary (was only "slot != ''").

  * approver.WorktreePathForSlot reuses state.ValidateSlotID instead of
    inlining the check — single source of truth, no drift.

The existing executor-level guard remains as defense in depth. Approvals
created before #490 land are unaffected (the validator runs only when a
slot is provided; merge_pr / close_issue / change_global_config carry
no Session and pass through unchanged).

Tests (internal/state/validate_slot_test.go) — 8 cases:

  * Accepts canonical "sup-77", "scr-241", "abc-XYZ_42", boundaries.
  * Rejects "", " ", ".", "..", "../etc", "a/b", `a\b`, leading/trailing
    slashes, ".:;<>", spaces.
  * Rejects NUL, \n, \t, \r control bytes.
  * Rejects > 96 bytes; accepts exactly 96.
  * RecordPendingApprovalForDecision: malformed slot → nil + no append.
  * Valid slot ("sup-77") → approval written.
  * nil Target → no session check.
  * Target without Session (PR/Issue only) → no session check.

Verified on workshop: go build ./..., go vet ./..., go test ./... pass
(18/18 packages, no regressions). Builds on #488 (idempotent executor)
and #489 (cross-project guard) — together they close premortem failure
modes #1, #3, #5, #7.

Refs #490 (premortem #5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralises slot-ID validation into a single `state.ValidateSlotID` function and wires it at every state-write ingress: `RecordPendingApprovalForDecision`, the HTTP `delete_worktree` handler, and `WorktreePathForSlot` (which previously inlined its own two-check guard). The approach is sound and the test coverage for the validator itself is thorough.

- `ValidateSlotID` enforces a strict ASCII allowlist (`[a-zA-Z0-9_-]`, max 96 bytes) and is now the single source of truth replacing two divergent inline guards.
- `RecordPendingApprovalForDecision` rejects approvals whose `Target.Session` fails validation before they are appended to state, blocking the malformed-slot path at the earliest possible boundary.
- Two minor correctness issues remain: the `"."` / `".."` early-exit guards inside `ValidateSlotID` are unreachable (both are already rejected by the character-loop), and the byte-index in the disallowed-byte error message is an index into the *trimmed* string while the error displays the *original* slot — misleading when the input has leading whitespace.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the executor and HTTP paths; the state-write boundary guard is correct but silently swallows rejections with no log or error return, creating an invisible audit gap for the exact attack scenario the PR is designed to prevent.

The validator logic and its wiring into WorktreePathForSlot and validateApprovalRequest are correct and well-tested. The concern is in RecordPendingApprovalForDecision: when ValidateSlotID rejects a malformed Target.Session, the error is discarded and nil is returned silently — no log, no metric, no returned error. A supervisor LLM injecting "../etc/passwd" would be quietly dropped at this boundary with no forensic trace, which runs counter to the PR's stated goal of early detection. The caller cannot distinguish a rejected slot from an uninitialized state receiver. Resolving this (even just a log line) would significantly raise confidence.

internal/state/state.go — specifically the new validation block inside RecordPendingApprovalForDecision and the ValidateSlotID implementation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds ValidateSlotID (canonical allowlist validator) and wires it into RecordPendingApprovalForDecision; the validation itself is correct, but rejected slots are silently returned as nil with no log or error propagation, and two dead-code checks for "." / ".." are unreachable. |
| internal/state/validate_slot_test.go | New test file; covers happy-path slots, traversal/separator rejections, control bytes, oversize input, and the RecordPendingApprovalForDecision ingress guard. Coverage is thorough for the happy/reject boundary. |
| internal/server/actions.go | Upgrades delete_worktree validation from an empty-string check to state.ValidateSlotID; straightforward and correct. |
| internal/approver/executor.go | WorktreePathForSlot now delegates to state.ValidateSlotID instead of the previous inline two-check guard; behaviour is equivalent and now tied to the single source of truth. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/state/state.go:1326-1328
**Silent rejection creates an invisible audit gap**

When `ValidateSlotID` rejects a malformed `Target.Session`, the function returns `nil` with the error completely discarded — no log line, no metric, no returned error. The PR's stated motivation is to give operators forensic visibility before a malformed slot reaches the executor; but a supervisor LLM that injects `"../etc/passwd"` into `Target.Session` will be silently dropped here, leaving no trace in logs or state. The caller receives the same `nil` it would get for a nil-receiver, so it cannot distinguish "slot was rejected" from "state was uninitialized". At minimum the error should be logged; ideally the function signature should be updated to return an error so callers can record why the approval was not created.

### Issue 2 of 3
internal/state/state.go:2278-2281
The `s == "."` and `s == ".."` guards are unreachable dead code. Both `.` and `..` contain the byte `'.'`, which is not in the allowlist `[a-zA-Z0-9_-]`; the character-loop below will always reject them first with a "disallowed byte" error. The checks add no protection and will confuse future readers into thinking they represent an independent guard.

```suggestion
	if len(s) > 96 {
```

### Issue 3 of 3
internal/state/state.go:2292
The error message reports `i` as an index into `s` (the TrimSpace'd value) while displaying the original `slot`. If `slot` has leading whitespace (e.g. `" bad"` → `s = "bad"`, `i = 0`), the message claims the offending byte is at index 0 of `"  bad"`, but in the original string it sits at index 2. Using `slot` (original) in the message with an index into `s` (trimmed) will produce misleading diagnostics. Either report the index relative to the original string or quote the trimmed value consistently.

```suggestion
			return fmt.Errorf("slot %q contains disallowed byte %q at index %d", s, c, i)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(state): validate Target.Session at e..."](https://github.com/befeast/maestro/commit/645fbd2a6fcc3b38ba4943d724f3860503baf147) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34719196)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->