### PR TITLE
fix(server): audit-fail-closed for write-path mutations (#491)

### DIFF
--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -88,35 +88,50 @@ func dispatchSafeAction(req controlActionRequest, cfg *config.Config, gh actionG
 		if readyLabel == "" {
 			return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "no ready label configured (cfg.Supervisor.ReadyLabel / cfg.IssueLabels)"}, err: errors.New("no ready label")}
 		}
+		summary := fmt.Sprintf("+label %s", readyLabel)
+		if err := auditOrAbort(audit, req, id, target, summary); err != nil {
+			return auditFailureResult(id, target, err)
+		}
 		if err := gh.AddIssueLabel(req.IssueNumber, readyLabel); err != nil {
 			return safeActionResult{handled: true, status: http.StatusBadGateway, body: map[string]string{"error": fmt.Sprintf("add ready label: %v", err)}, err: err}
 		}
-		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target, audit, req, fmt.Sprintf("+label %s", readyLabel))}
+		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target)}
 	case config.SupervisorActionRemoveReadyLabel:
 		if readyLabel == "" {
 			return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "no ready label configured"}, err: errors.New("no ready label")}
 		}
+		summary := fmt.Sprintf("-label %s", readyLabel)
+		if err := auditOrAbort(audit, req, id, target, summary); err != nil {
+			return auditFailureResult(id, target, err)
+		}
 		if err := gh.RemoveIssueLabel(req.IssueNumber, readyLabel); err != nil {
 			return safeActionResult{handled: true, status: http.StatusBadGateway, body: map[string]string{"error": fmt.Sprintf("remove ready label: %v", err)}, err: err}
 		}
-		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target, audit, req, fmt.Sprintf("-label %s", readyLabel))}
+		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target)}
 	case config.SupervisorActionRemoveBlockedLabel:
 		if blockedLabel == "" {
 			return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "no blocked label configured (cfg.Supervisor.BlockedLabel)"}, err: errors.New("no blocked label")}
 		}
+		summary := fmt.Sprintf("-label %s", blockedLabel)
+		if err := auditOrAbort(audit, req, id, target, summary); err != nil {
+			return auditFailureResult(id, target, err)
+		}
 		if err := gh.RemoveIssueLabel(req.IssueNumber, blockedLabel); err != nil {
 			return safeActionResult{handled: true, status: http.StatusBadGateway, body: map[string]string{"error": fmt.Sprintf("remove blocked label: %v", err)}, err: err}
 		}
-		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target, audit, req, fmt.Sprintf("-label %s", blockedLabel))}
+		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target)}
 	case config.SupervisorActionAddIssueComment:
 		body := strings.TrimSpace(req.Body)
 		if body == "" {
 			return safeActionResult{handled: true, status: http.StatusBadRequest, body: map[string]string{"error": "body is required for add_issue_comment"}, err: errors.New("missing body")}
 		}
+		if err := auditOrAbort(audit, req, id, target, "+comment"); err != nil {
+			return auditFailureResult(id, target, err)
+		}
 		if err := gh.CommentIssue(req.IssueNumber, body); err != nil {
 			return safeActionResult{handled: true, status: http.StatusBadGateway, body: map[string]string{"error": fmt.Sprintf("comment issue: %v", err)}, err: err}
 		}
-		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target, audit, req, "+comment")}
+		return safeActionResult{handled: true, status: http.StatusOK, body: makeSafeOK(id, target)}
 	}
 
 	// Defensive: should be unreachable given isSafeAction filter above.
@@ -183,21 +198,47 @@ func safeActionBlockedLabel(cfg *config.Config) string {
 	return strings.TrimSpace(cfg.Supervisor.BlockedLabel)
 }
 
-func makeSafeOK(id, target string, audit actionAuditRecorder, req controlActionRequest, summary string) safeActionResponse {
-	resp := safeActionResponse{OK: true, ActionID: id, Target: target}
-	if audit != nil {
-		actor := strings.TrimSpace(req.Actor)
-		if actor == "" {
-			actor = "dashboard"
-		}
-		reason := strings.TrimSpace(req.Reason)
-		if reason == "" {
-			reason = summary
-		}
-		// Best-effort: audit failures must not poison a successful action.
-		_ = audit(actor, id, target, reason)
+// auditOrAbort writes the "attempted" audit entry for a write-path
+// action. Audit BEFORE the side effect: if audit fails, the caller
+// MUST NOT proceed with the gh / state mutation. Returns nil on
+// success or when the recorder is nil (no auditing configured).
+//
+// #491: closes premortem failure mode #9. Previously the audit call was
+// fire-and-forget after the side effect; a filesystem hiccup or wrong
+// permissions silently dropped the audit record while the gh mutation
+// went through, leaving forensics with no way to distinguish a
+// filesystem error from an attacker covering tracks.
+func auditOrAbort(audit actionAuditRecorder, req controlActionRequest, action, target, summary string) error {
+	if audit == nil {
+		return nil
 	}
-	return resp
+	actor := strings.TrimSpace(req.Actor)
+	if actor == "" {
+		actor = "dashboard"
+	}
+	reason := strings.TrimSpace(req.Reason)
+	if reason == "" {
+		reason = summary
+	}
+	return audit(actor, action, target, reason)
+}
+
+// auditFailureResult turns an audit-write error into a 500 result the
+// HTTP handler can return as-is. Used by both dispatchSafeAction and
+// dispatchApprovalAction so the audit-fail-closed contract is uniform.
+func auditFailureResult(action, target string, err error) safeActionResult {
+	return safeActionResult{
+		handled: true,
+		status:  http.StatusInternalServerError,
+		body: map[string]string{
+			"error": fmt.Sprintf("audit write failed for %s on %s: %v — refusing to proceed without an audit record", action, target, err),
+		},
+		err: fmt.Errorf("audit write failed for %s: %w", action, err),
+	}
+}
+
+func makeSafeOK(id, target string) safeActionResponse {
+	return safeActionResponse{OK: true, ActionID: id, Target: target}
 }
 
 // approvalEnqueueResponse is the JSON body returned on a successful enqueue.
@@ -251,22 +292,17 @@ func dispatchApprovalAction(req controlActionRequest, cfg *config.Config, stateD
 		return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "failed to record approval"}, err: errors.New("RecordPendingApprovalForDecision returned nil")}
 	}
 
+	target := approvalTargetSummary(decision.Target)
+	// #491 audit-fail-closed: record the audit BEFORE persisting to disk.
+	// If the audit append fails, on-disk state stays unchanged (no orphan
+	// pending approval that has no audit record). The in-memory state was
+	// already mutated by RecordPendingApprovalForDecision but it is not
+	// observable until state.Save below; the next Load discards it.
+	if err := auditOrAbort(audit, req, "enqueue:"+id, target, "enqueued by dashboard"); err != nil {
+		return auditFailureResult("enqueue:"+id, target, err)
+	}
 	if err := state.Save(stateDir, st); err != nil {
 		return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": fmt.Sprintf("save state: %v", err)}, err: err}
-	}
-
-	target := approvalTargetSummary(decision.Target)
-	if audit != nil {
-		actor := strings.TrimSpace(req.Actor)
-		if actor == "" {
-			actor = "dashboard"
-		}
-		reason := strings.TrimSpace(req.Reason)
-		if reason == "" {
-			reason = "enqueued by dashboard"
-		}
-		// Best-effort.
-		_ = audit(actor, "enqueue:"+id, target, reason)
 	}
 
 	return safeActionResult{

--- a/internal/server/audit_failclosed_test.go
+++ b/internal/server/audit_failclosed_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// auditAlwaysFails returns the same error for every audit append.
+// Used to exercise the audit-fail-closed contract (#491).
+func auditAlwaysFails(actor, action, target, reason string) error {
+	return errors.New("audit fs hiccup: ENOSPC")
+}
+
+func TestSafeAction_AuditFailureAbortsBeforeGH(t *testing.T) {
+	gh := &fakeActionGH{}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, auditAlwaysFails)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/actions",
+		bytes.NewBufferString(`{"action_id":"add_ready_label","issue_number":42}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleAction(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (audit-fail-closed); body=%s", w.Code, w.Body.String())
+	}
+	if len(gh.addLabelCalls) != 0 {
+		t.Fatalf("gh.AddIssueLabel was called %v — must NOT fire when audit fails", gh.addLabelCalls)
+	}
+	if !strings.Contains(w.Body.String(), "audit write failed") {
+		t.Fatalf("response body did not surface the audit-failure reason: %s", w.Body.String())
+	}
+}
+
+func TestSafeAction_AuditFailureBlocksAllSafeVerbs(t *testing.T) {
+	for _, tc := range []struct {
+		actionID string
+		body     string
+	}{
+		{"add_ready_label", `{"action_id":"add_ready_label","issue_number":1}`},
+		{"remove_ready_label", `{"action_id":"remove_ready_label","issue_number":2}`},
+		{"remove_blocked_label", `{"action_id":"remove_blocked_label","issue_number":3}`},
+		{"add_issue_comment", `{"action_id":"add_issue_comment","issue_number":4,"body":"hello"}`},
+	} {
+		gh := &fakeActionGH{}
+		srv := New(newSafeActionTestCfg(), nil)
+		srv.SetActionDeps(gh, auditAlwaysFails)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/actions",
+			bytes.NewBufferString(tc.body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.handleAction(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("verb %s: status = %d, want 500", tc.actionID, w.Code)
+		}
+		if len(gh.addLabelCalls)+len(gh.removeLabelCalls)+len(gh.commentCalls) != 0 {
+			t.Errorf("verb %s: gh was called despite audit failure", tc.actionID)
+		}
+	}
+}
+
+func TestApprovalEnqueue_AuditFailureLeavesStateUnchanged(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	gh := &fakeActionGH{}
+	srv := New(cfg, nil)
+	srv.SetActionDeps(gh, auditAlwaysFails)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/actions",
+		bytes.NewBufferString(`{"action_id":"merge_pr","pr_number":42}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleAction(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", w.Code, w.Body.String())
+	}
+	// Most importantly: state on DISK must have NO approval written.
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(st.Approvals) != 0 {
+		t.Fatalf("on-disk approvals = %d, want 0 (audit-fail must roll back persistence)", len(st.Approvals))
+	}
+}
+
+func TestSafeAction_AuditNilStillExecutes(t *testing.T) {
+	// Defensive: when the server was wired without an audit recorder
+	// (audit == nil), actions still execute normally — the fail-closed
+	// guard fires only when an audit recorder IS configured and FAILS.
+	gh := &fakeActionGH{}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, nil) // no audit
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/actions",
+		bytes.NewBufferString(`{"action_id":"add_ready_label","issue_number":42}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleAction(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (no audit configured -> action proceeds)", w.Code)
+	}
+	if len(gh.addLabelCalls) != 1 {
+		t.Fatalf("gh not called with audit=nil: %v", gh.addLabelCalls)
+	}
+}
+


### PR DESCRIPTION
fix(server): audit-fail-closed for write-path mutations (#491)

Closes premortem failure mode #9: today's `_ = audit(...)` swallowed
errors and called the recorder AFTER the gh side effect. A filesystem
hiccup (NFS mount loss, ENOSPC, chmod regression) silently dropped the
audit record while the gh mutation went through. After an actual
incident there was no way to distinguish a filesystem hiccup from an
attacker covering tracks.

The fix flips the contract:

  audit BEFORE the side effect — abort if audit fails

A failed audit guarantees the side effect did NOT happen. A successful
audit guarantees we attempted the side effect; the side effect's
outcome lives in the gh / state response. No more silent gaps.

Implementation
--------------

  * `auditOrAbort(audit, req, action, target, summary)` — single
    helper for the entire write-path. Returns nil if audit==nil (no
    auditing configured) or the recorder succeeded; otherwise returns
    the audit error. Caller uses this directly: `if err := ...; err != nil { return auditFailureResult(...) }`.

  * `auditFailureResult(action, target, err)` — uniform 500 response
    body. Both safe-action and approval-enqueue dispatchers reuse it.

  * `dispatchSafeAction` (4 verbs: add_ready_label, remove_ready_label,
    remove_blocked_label, add_issue_comment): audit BEFORE the gh call.
    Audit fail → 500, gh untouched. Replaces the previous `_ = audit(...)`
    that was called AFTER gh.

  * `dispatchApprovalAction` (cautious-gate enqueue): audit BEFORE
    state.Save. Audit fail → 500, state on disk unchanged. The
    in-memory append (RecordPendingApprovalForDecision) is discarded
    because we never persist; next state.Load drops it.

  * `makeSafeOK(id, target)` reduced to a pure response builder; audit
    no longer routed through it.

Behavior
--------

  * audit==nil (no recorder wired): every action proceeds as before.
  * audit OK: every action proceeds as before; the audit entry exists.
  * audit fails: 500 to caller, gh / state.Save not invoked.

Tests (internal/server/audit_failclosed_test.go) — 4 cases:

  * TestSafeAction_AuditFailureAbortsBeforeGH: audit recorder always
    returns error → 500, gh.AddIssueLabel never called, response body
    surfaces the audit-failure reason.
  * TestSafeAction_AuditFailureBlocksAllSafeVerbs: same for the other
    three safe verbs.
  * TestApprovalEnqueue_AuditFailureLeavesStateUnchanged: audit fails
    on enqueue → 500, on-disk state.json has zero approvals (in-memory
    append rolled back by the missing state.Save).
  * TestSafeAction_AuditNilStillExecutes: defensive — when no audit
    recorder is wired (audit=nil), actions still execute.

Verified on workshop: go build ./..., go vet ./..., go test ./... pass
(18/18 packages, no regressions).

Refs #491 (premortem #9). Builds on #487 (auth, P0), #488 (idempotent
executor + slot fence), #489 (cross-project guard), #490 (slot ingress
validator) — together these close premortem failure modes #1, #3, #5,
#7, #9.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the write-path audit contract by moving audit calls from a best-effort post-effect position to a mandatory pre-effect gate: if the audit recorder fails, the GH mutation or state save is never invoked, eliminating the forensic gap where a filesystem failure could drop an audit record while a mutation silently went through.

- `auditOrAbort` replaces the four scattered `_ = audit(...)` calls in `dispatchSafeAction` and the fire-and-forget call in `dispatchApprovalAction`, returning a uniform error that the caller treats as an abort signal before touching GitHub or disk.
- `auditFailureResult` centralises the 500 response body so both dispatchers surface the same error shape, and `makeSafeOK` is reduced to a pure response builder with no side effects.
- Four new tests in `audit_failclosed_test.go` verify the core contract: audit failure blocks all four safe verbs, audit failure on enqueue leaves on-disk state unchanged, and a nil recorder still allows execution.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core fail-closed invariant is correctly implemented and tested. The two quality gaps are observable but not blocking.

The AuditID field in safeActionResponse is never populated, and the audit-before-side-effect ordering produces entries for GH operations that subsequently fail — intentional but untested and potentially misleading for auditors.

internal/server/actions.go — the AuditID field and audit-entry semantics on GH failure deserve a second look before downstream consumers build on this API shape.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/server/actions.go | Flips audit ordering from post-effect best-effort to pre-effect fail-closed; introduces auditOrAbort and auditFailureResult helpers. The AuditID field in safeActionResponse remains permanently empty and audit entries do not indicate whether the subsequent side effect succeeded. |
| internal/server/audit_failclosed_test.go | Adds four targeted tests for the fail-closed contract. Missing coverage for the audit-succeeds-but-GH-fails path, which is the scenario that produces an orphaned audit entry for a mutation that did not occur. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/server/actions.go`, line 48-53 ([link](https://github.com/befeast/maestro/blob/4cab98004efdfc0c15f5c026e90382bda9fd7ad5/internal/server/actions.go#L48-L53)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`AuditID` in `safeActionResponse` is permanently empty**

   `makeSafeOK` now only sets `OK`, `ActionID`, and `Target`. The `AuditID` field is never populated — the `actionAuditRecorder` signature returns only `error`, so there is no path to retrieve an audit ID and surface it to the caller. Any client that reads `audit_id` from this response will always receive an empty string. If callers depend on `audit_id` for tracing (as the fleet layer does for its own responses), this is a silent contract break. Either wire the recorder to return an ID, or remove the field from this struct to prevent misleading API consumers.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/actions.go
   Line: 48-53

   Comment:
   **`AuditID` in `safeActionResponse` is permanently empty**

   `makeSafeOK` now only sets `OK`, `ActionID`, and `Target`. The `AuditID` field is never populated — the `actionAuditRecorder` signature returns only `error`, so there is no path to retrieve an audit ID and surface it to the caller. Any client that reads `audit_id` from this response will always receive an empty string. If callers depend on `audit_id` for tracing (as the fleet layer does for its own responses), this is a silent contract break. Either wire the recorder to return an ID, or remove the field from this struct to prevent misleading API consumers.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/server/actions.go:92-96
**Audit record does not distinguish "attempted" from "completed"**

`auditOrAbort` writes a record whose text (e.g. `+label maestro-ready`) looks like a completion entry, but the GH call that follows can still fail with a 502. An auditor querying the log after the fact sees an entry that reads identically whether the label was successfully added or the GitHub API rejected it. The PR description acknowledges the semantic shift ("a successful audit guarantees we *attempted* the side effect") but the entry body carries no indication of that intent — there is no `attempted:` prefix, status field, or outcome annotation. During incident triage this could lead to the wrong conclusion that a mutation took place when it did not. Consider either (a) annotating entries with an `"attempted"` marker, or (b) adding a follow-up audit call on GH failure to record the actual outcome.

### Issue 2 of 3
internal/server/actions.go:48-53
**`AuditID` in `safeActionResponse` is permanently empty**

`makeSafeOK` now only sets `OK`, `ActionID`, and `Target`. The `AuditID` field is never populated — the `actionAuditRecorder` signature returns only `error`, so there is no path to retrieve an audit ID and surface it to the caller. Any client that reads `audit_id` from this response will always receive an empty string. If callers depend on `audit_id` for tracing (as the fleet layer does for its own responses), this is a silent contract break. Either wire the recorder to return an ID, or remove the field from this struct to prevent misleading API consumers.

### Issue 3 of 3
internal/server/audit_failclosed_test.go:20-40
**No test covers the "audit succeeds, GH call fails" path**

The four new tests cover audit-nil, audit-fail-before-GH, and audit-fail-before-state-save. There is no test for the scenario where `auditOrAbort` returns nil (success) and then the GH call subsequently returns an error. This is the path that produces an audit record for a mutation that did not occur, and the intentional behaviour should be asserted explicitly — both to verify the 502 response and to document that an orphaned audit entry is the expected outcome.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): audit-fail-closed for write..."](https://github.com/befeast/maestro/commit/4cab98004efdfc0c15f5c026e90382bda9fd7ad5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34719592)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->