### PR TITLE
Wave 0: MC foundation — mc.css recipes, React build, CI guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: bash scripts/check-design-tokens.sh
       - name: Design recipe guard
         run: bash scripts/check-design-recipes.sh
+      - name: Design recipe nesting guard
+        run: bash scripts/check-design-recipe-nesting.sh
       - name: Build MC bundle
         working-directory: internal/server/web/mc
         run: bun run build
@@ -35,6 +37,7 @@ jobs:
           fi
 
   build:
+    needs: frontend-build
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4

--- a/scripts/check-design-recipe-nesting.sh
+++ b/scripts/check-design-recipe-nesting.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Block nesting an outer-tier recipe inside itself.
+# Outer recipes define one border + surface; nesting two outers produces a
+# double border that does not exist in the design source. The accepted
+# pattern is outer (`.<recipe>`) + second-tier (`.<recipe>-2`) for any
+# inner card. See docs/design-export-to-ux-issues-runbook.md.
+set -euo pipefail
+
+ROOT="${1:-internal/server/web/mc/src}"
+RECIPES='card|panel|tape|appv|section|hb|sb|stat'
+
+if [ ! -d "$ROOT" ]; then
+  echo "ERROR: design recipe nesting guard: root '$ROOT' is not a directory" >&2
+  exit 1
+fi
+
+mapfile -d '' FILES < <(find "$ROOT" -type f \( -name '*.jsx' -o -name '*.tsx' \) \
+  ! -name '*.test.*' ! -name '*.spec.*' -print0)
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo "OK: no JSX/TSX sources under $ROOT"
+  exit 0
+fi
+
+VIOLATIONS=$(awk -v recipes="$RECIPES" '
+  FNR == 1 {
+    delete stack_ind
+    delete stack_rec
+    delete stack_line
+    n = 0
+  }
+  {
+    indent = 0
+    for (i = 1; i <= length($0); i++) {
+      c = substr($0, i, 1)
+      if (c == " ") indent++
+      else if (c == "\t") indent += 2
+      else break
+    }
+    while (n > 0 && stack_ind[n] >= indent) {
+      delete stack_ind[n]
+      delete stack_rec[n]
+      delete stack_line[n]
+      n--
+    }
+    rest = $0
+    while (match(rest, /className="[^"]*"/)) {
+      val = substr(rest, RSTART, RLENGTH)
+      rest = substr(rest, RSTART + RLENGTH)
+      sub(/^className="/, "", val)
+      sub(/"$/, "", val)
+      m = split(val, classes, " ")
+      for (j = 1; j <= m; j++) {
+        cls = classes[j]
+        if (cls ~ ("^(" recipes ")$")) {
+          for (k = 1; k <= n; k++) {
+            if (stack_rec[k] == cls) {
+              print FILENAME ":" FNR ": nested recipe \"" cls "\" inside ancestor at line " stack_line[k]
+            }
+          }
+          n++
+          stack_ind[n] = indent
+          stack_rec[n] = cls
+          stack_line[n] = FNR
+        }
+      }
+    }
+  }
+' "${FILES[@]}")
+
+if [ -n "$VIOLATIONS" ]; then
+  echo "ERROR: nested same-recipe usage detected. Use the second-tier '-2' recipe variant when nesting outer recipes (e.g. .card-2 inside .card)." >&2
+  echo "$VIOLATIONS" >&2
+  exit 1
+fi
+echo "OK: no nested same-recipe usage in $ROOT"


### PR DESCRIPTION
Refs #446

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new bash CI guard (`check-design-recipe-nesting.sh`) that uses awk-based indentation tracking to detect when an outer-tier MC recipe class (e.g. `card`, `panel`) is nested inside itself, and wires it into the `frontend-build` job. It also gates the Go `build` job behind `frontend-build` via `needs`.

- The nesting script uses indentation levels to infer JSX nesting, which is a reasonable heuristic for typical code but does not filter comment lines — commented-out recipe elements can end up on the ancestor stack and cause false-positive CI failures on valid code.
- The `className` regex only matches statically double-quoted attributes, so violations expressed via braces or template literals will not be caught.
- Adding `needs: frontend-build` to the Go job means any frontend failure (including guard false positives) blocks all backend CI.

<h3>Confidence Score: 3/5</h3>

The CI guard can produce false-positive failures on valid code and should not be merged without the comment-filtering fix.

The awk script does not strip comment lines before matching classNames, so a developer who leaves a stale commented-out recipe element above an actual recipe element at deeper indentation will see CI fail on a clean branch. That is a real, reproducible breakage path for the new guard step, compounded by the `needs` change that lets a frontend false positive also block all Go tests.

scripts/check-design-recipe-nesting.sh needs comment-line filtering before the guard is safe to rely on in CI.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the new nesting-guard step and gates the Go build/test job behind frontend-build via `needs`; functional but the new dependency blocks all backend CI when the frontend job fails for any reason. |
| scripts/check-design-recipe-nesting.sh | New awk-based nesting guard; indentation tracking is reasonable for typical JSX but the script does not filter out comment lines, which can cause false-positive CI failures, and misses non-double-quoted className patterns. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
scripts/check-design-recipe-nesting.sh:23-68
**Comment lines can trigger false-positive CI failures**

The awk script does not skip single-line (`// ...`) or JSX (`{/* ... */}`) comment lines before applying the `className` regex. A commented-out recipe element at a lower indent than a live one will be pushed onto the stack and then matched as an "ancestor" when the real element is parsed at greater indentation — causing CI to fail on perfectly valid code. For example, a stale `// <div className="card">` above an actual `<div className="card">` nested inside it would trip the guard.

### Issue 2 of 3
scripts/check-design-recipe-nesting.sh:47-52
**Guard misses non-double-quoted `className` patterns**

The regex `match(rest, /className="[^"]*"/)` only captures statically double-quoted class strings. Patterns like `className={'card'}`, `className={"card"}`, and template literals all evade detection. This is a false-negative gap — violations using these forms will silently pass the guard.

### Issue 3 of 3
.github/workflows/ci.yml:39-40
**Go CI now blocked by any frontend failure**

Adding `needs: frontend-build` means that if the frontend job fails for any reason (a flaky bun install, an unrelated recipe-guard false positive, etc.), `go build`, `go vet`, and `go test` are all skipped for that run. Backend contributors working on Go-only changes will see their CI silently withheld until the frontend job is green. This is intentional if the embedded bundle correctness is a hard invariant, but worth confirming it is the desired trade-off.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(mc): add nested same-recipe card guar..."](https://github.com/befeast/maestro/commit/d3892bcc1c13b6582c007b6c7452bd1babc60597) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34732175)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->