### PR TITLE
fix(orchestrator): reconcile-time rate-limit triggers fallover, not silent dead (#506)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1401,26 +1401,77 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		// the provider hit a rate / usage limit. Without this, the reconcile path
 		// races the main exit handler at the start of every cycle and burns the
 		// per-issue retry budget on what is really a transient backend block (#466).
+		// On rate-limit, attempt the same provider-limit fallover the main loop does
+		// (see :worker-died and :log-scanner paths) — select an available fallback
+		// backend and respawn the session there. Mark the session Dead only when no
+		// fallback is configured / available, or when the respawn itself fails (#506).
 		if o.isRateLimited(sess.LogFile) {
 			now := time.Now().UTC()
 			resetAt := o.rateLimitResetFromLog(sess.LogFile)
 			o.recordProviderLimit(s, slotName, sess, "log_rate_limit_reconcile", resetAt, now)
+			selection := o.selectProviderLimitFallback(s, sess, now)
+			sess.BackendSelection = &selection
 			oldPID := sess.PID
 			oldTmux := tmuxName
-			sess.PID = 0
-			sess.TmuxSession = ""
-			sess.FinishedAt = &now
-			sess.LastNotifiedStatus = "rate_limit"
-			sess.Status = state.StatusDead
-			reconciled = true
 			resetStr := "unknown"
 			if resetAt != nil {
 				resetStr = resetAt.Format(time.RFC3339)
 			}
-			log.Printf("[orch] reconcile: %s running->dead via provider rate limit on backend=%s reset=%s (%s); pid=%d tmux=%q",
-				slotName, sess.Backend, resetStr, strings.Join(reasons, ", "), oldPID, oldTmux)
-			o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) hit provider limit on %s; reset=%s",
-				slotName, sess.IssueNumber, sess.IssueTitle, sess.Backend, resetStr)
+			previousBackend := sess.Backend
+			nextBackend := selection.SelectedBackend
+
+			if nextBackend == "" {
+				sess.PID = 0
+				sess.TmuxSession = ""
+				sess.FinishedAt = &now
+				sess.LastNotifiedStatus = "rate_limit"
+				sess.Status = state.StatusDead
+				reconciled = true
+				log.Printf("[orch] reconcile: %s running->dead via provider rate limit on backend=%s reset=%s (no fallback available; %s); pid=%d tmux=%q",
+					slotName, previousBackend, resetStr, strings.Join(reasons, ", "), oldPID, oldTmux)
+				o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) hit provider limit on %s; reset=%s; no fallback available",
+					slotName, sess.IssueNumber, sess.IssueTitle, previousBackend, resetStr)
+				continue
+			}
+
+			issue, fetchErr := o.getIssue(sess.IssueNumber)
+			if fetchErr != nil {
+				sess.PID = 0
+				sess.TmuxSession = ""
+				sess.FinishedAt = &now
+				sess.LastNotifiedStatus = "rate_limit"
+				sess.Status = state.StatusDead
+				reconciled = true
+				log.Printf("[orch] reconcile: %s running->dead via provider rate limit on backend=%s reset=%s (fallback to %s aborted: could not fetch issue #%d: %v; %s); pid=%d tmux=%q",
+					slotName, previousBackend, resetStr, nextBackend, sess.IssueNumber, fetchErr, strings.Join(reasons, ", "), oldPID, oldTmux)
+				o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) hit provider limit on %s; fallback to %s failed (could not fetch issue): %v",
+					slotName, sess.IssueNumber, sess.IssueTitle, previousBackend, nextBackend, fetchErr)
+				continue
+			}
+
+			if previousBackend != "" {
+				sess.TriedBackends = append(sess.TriedBackends, previousBackend)
+			}
+			promptBase := o.selectPrompt(issue)
+			if respawnErr := o.respawnWorker(slotName, sess, issue, promptBase, nextBackend); respawnErr != nil {
+				sess.PID = 0
+				sess.TmuxSession = ""
+				sess.FinishedAt = &now
+				sess.LastNotifiedStatus = "rate_limit"
+				sess.Status = state.StatusDead
+				reconciled = true
+				log.Printf("[orch] reconcile: %s running->dead via provider rate limit on backend=%s reset=%s (fallback respawn on %s failed: %v; %s); pid=%d tmux=%q",
+					slotName, previousBackend, resetStr, nextBackend, respawnErr, strings.Join(reasons, ", "), oldPID, oldTmux)
+				o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) hit provider limit on %s; fallback to %s failed: %v",
+					slotName, sess.IssueNumber, sess.IssueTitle, previousBackend, nextBackend, respawnErr)
+				continue
+			}
+
+			reconciled = true
+			log.Printf("[orch] reconcile: %s rate-limited on backend=%s reset=%s — respawned with backend=%s (%s); old pid=%d tmux=%q",
+				slotName, previousBackend, resetStr, nextBackend, strings.Join(reasons, ", "), oldPID, oldTmux)
+			o.notifier.Sendf("🔄 maestro: worker %s (issue #%d: %s) hit provider limit on %s; reset=%s — respawned on %s",
+				slotName, sess.IssueNumber, sess.IssueTitle, previousBackend, resetStr, nextBackend)
 			continue
 		}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -448,6 +448,211 @@ func TestReconcileRunningSessions_RateLimitedDeadWorker_DoesNotBurnRetryBudget(t
 	}
 }
 
+// #506: when reconcile detects a rate-limited dead worker AND fallback_backends
+// is configured with a viable candidate, the session must be respawned on the
+// next backend (mirroring the main-loop fallover at orchestrator.go:1648),
+// not marked Dead.
+func TestReconcileRunningSessions_RateLimitedDeadWorker_FallsOverToNextBackend(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["sup-90"] = &state.Session{
+		IssueNumber: 471,
+		IssueTitle:  "P0: ciStatusFromREST returns pending forever",
+		Status:      state.StatusRunning,
+		PID:         424243,
+		TmuxSession: "maestro-sup-90",
+		Branch:      "feat/sup-90-471-ci",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-2 * time.Minute),
+		LogFile:     "/tmp/sup-90-rl.log",
+	}
+
+	respawnedBackends := []string{}
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			Model: config.ModelConfig{
+				Default:          "claude",
+				FallbackBackends: []string{"codex", "freellm"},
+				Backends: map[string]config.BackendDef{
+					"claude":  {Cmd: "claude"},
+					"codex":   {Cmd: "codex"},
+					"freellm": {Cmd: "freellm"},
+				},
+			},
+		},
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:     func(logFile string) bool { return true },
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "ciStatusFromREST returns pending forever"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedBackends = append(respawnedBackends, backendName)
+			sess.Status = state.StatusRunning
+			sess.PID = 9001
+			sess.Backend = backendName
+			sess.StartedAt = time.Now().UTC()
+			sess.FinishedAt = nil
+			return nil
+		},
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["sup-90"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (fallover should respawn the worker)", sess.Status, state.StatusRunning)
+	}
+	if got := len(respawnedBackends); got != 1 {
+		t.Fatalf("respawnWorkerFn called %d times, want 1; backends=%v", got, respawnedBackends)
+	}
+	if respawnedBackends[0] != "codex" {
+		t.Fatalf("fallback respawn used backend=%q, want %q (first in fallback_backends)", respawnedBackends[0], "codex")
+	}
+	if sess.Backend != "codex" {
+		t.Fatalf("session.Backend = %q after fallover, want %q", sess.Backend, "codex")
+	}
+	if len(sess.TriedBackends) != 1 || sess.TriedBackends[0] != "claude" {
+		t.Fatalf("TriedBackends = %v, want [claude] (the rate-limited backend)", sess.TriedBackends)
+	}
+	if !sess.RateLimitHit {
+		t.Fatal("RateLimitHit should be true after recordProviderLimit")
+	}
+	if sess.ProviderLimitBackend != "claude" {
+		t.Fatalf("ProviderLimitBackend = %q, want claude (the original)", sess.ProviderLimitBackend)
+	}
+	if sess.BackendSelection == nil || sess.BackendSelection.SelectedBackend != "codex" || sess.BackendSelection.SelectionReason != selectionReasonProviderLimitFallback {
+		t.Fatalf("BackendSelection = %+v, want SelectedBackend=codex SelectionReason=%s", sess.BackendSelection, selectionReasonProviderLimitFallback)
+	}
+	health, ok := s.BackendHealth["claude"]
+	if !ok || health.State != state.BackendHealthCooldown {
+		t.Fatalf("BackendHealth[claude] = %+v, want cooldown", health)
+	}
+}
+
+// #506: when fallback respawn itself fails (worktree busy, network, etc.),
+// the session must be marked Dead with rate_limit notification rather than
+// silently looping in StatusRunning.
+func TestReconcileRunningSessions_RateLimitedDeadWorker_FallbackRespawnFails_MarksDead(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["sup-91"] = &state.Session{
+		IssueNumber: 471,
+		Status:      state.StatusRunning,
+		PID:         424244,
+		TmuxSession: "maestro-sup-91",
+		Branch:      "feat/sup-91-471-ci",
+		Backend:     "claude",
+		LogFile:     "/tmp/sup-91-rl.log",
+	}
+
+	respawnAttempts := []string{}
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			Model: config.ModelConfig{
+				Default:          "claude",
+				FallbackBackends: []string{"codex"},
+				Backends: map[string]config.BackendDef{
+					"claude": {Cmd: "claude"},
+					"codex":  {Cmd: "codex"},
+				},
+			},
+		},
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:     func(logFile string) bool { return true },
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "ci"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnAttempts = append(respawnAttempts, backendName)
+			return fmt.Errorf("worktree busy")
+		},
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["sup-91"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (failed respawn must terminate the session)", sess.Status, state.StatusDead)
+	}
+	if got := len(respawnAttempts); got != 1 {
+		t.Fatalf("respawnWorkerFn called %d times, want 1; attempts=%v", got, respawnAttempts)
+	}
+	if sess.LastNotifiedStatus != "rate_limit" {
+		t.Fatalf("last_notified_status = %q, want %q", sess.LastNotifiedStatus, "rate_limit")
+	}
+}
+
+// #506: when the issue can't be fetched at fallover time (transient gh outage,
+// etc.), reconcile must not skip the dead-marking — otherwise the session
+// would be stuck in StatusRunning with no live process.
+func TestReconcileRunningSessions_RateLimitedDeadWorker_FetchIssueFails_MarksDead(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["sup-92"] = &state.Session{
+		IssueNumber: 471,
+		Status:      state.StatusRunning,
+		PID:         424245,
+		TmuxSession: "maestro-sup-92",
+		Branch:      "feat/sup-92-471-ci",
+		Backend:     "claude",
+		LogFile:     "/tmp/sup-92-rl.log",
+	}
+
+	respawned := false
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			Model: config.ModelConfig{
+				Default:          "claude",
+				FallbackBackends: []string{"codex"},
+				Backends: map[string]config.BackendDef{
+					"claude": {Cmd: "claude"},
+					"codex":  {Cmd: "codex"},
+				},
+			},
+		},
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:     func(logFile string) bool { return true },
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{}, fmt.Errorf("gh transient: rate limit")
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawned = true
+			return nil
+		},
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["sup-92"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (fetch-issue error must terminate the session)", sess.Status, state.StatusDead)
+	}
+	if respawned {
+		t.Fatal("respawnWorkerFn must NOT be called when getIssueFn fails")
+	}
+	if sess.LastNotifiedStatus != "rate_limit" {
+		t.Fatalf("last_notified_status = %q, want %q", sess.LastNotifiedStatus, "rate_limit")
+	}
+}
+
 func TestReconcileRunningSessions_MissingTmuxGetsMarkedDead(t *testing.T) {
 	s := state.NewState()
 	s.Sessions["pan-2"] = &state.Session{


### PR DESCRIPTION
## What

When a worker's CLI process (claude/codex) exits with a provider rate-limit error before Maestro's log-scanner samples the pty, the orchestrator's `reconcileRunningSessions` path was marking the session `Dead` and **never** consulting the configured `fallback_backends` chain. Found live (2026-05-30) — every worker death from exhausted paid quotas dropped its issue silently, no retry, no fallover. The freellm safety net was wired but unreachable on this code path.

This PR makes reconcile match the behaviour of the two existing fallover paths in the same file (worker-died main loop at `:1648`, log-scanner at `:1770`):

```
isRateLimited → recordProviderLimit
              → selectProviderLimitFallback
              → if SelectedBackend != "" → respawnWorker
              → else mark Dead
```

## Why this is P0

`fallback_backends` is the configured safety net for paid-credit exhaustion (claude/codex hitting their quota). On this code path it was inert. With paid models exhausted (e.g. user's account at quota limit, which is what triggered the discovery), every dogfood worker spawned on the default backend, the CLI exited fast with `rate_limit_exceeded`, and reconcile silently buried the session. The next supervisor cycle picked the next ready issue, repeated the same death — a quiet outage that looks like "no progress" on the dashboard.

## Behaviour matrix

| Configured fallback | Issue fetch | Respawn | Result |
|---|---|---|---|
| none / all candidates blocked | — | — | `Dead`, no retry burn (legacy invariant from #466 preserved) |
| viable candidate exists | OK | OK | `Running` on next backend; `TriedBackends` += rate-limited backend |
| viable candidate exists | fails | — | `Dead` (do not respawn against a stale issue) |
| viable candidate exists | OK | fails | `Dead` (don't loop on a broken worktree) |

Every error path logs the failing step by name; `last_notified_status=rate_limit` is preserved in all `Dead` cases so the dashboard rendering doesn't change.

## Tests

`internal/orchestrator/orchestrator_test.go`:

- `TestReconcileRunningSessions_RateLimitedDeadWorker_DoesNotBurnRetryBudget` (existing) — legacy no-fallback path still yields `Dead` without burning the retry budget. Re-validated to anchor the unchanged invariant.
- `TestReconcileRunningSessions_RateLimitedDeadWorker_FallsOverToNextBackend` (new) — happy path: claude rate-limited, `fallback_backends:[codex, freellm]` → respawned on `codex`; checks `TriedBackends`, `BackendSelection.SelectionReason=fallback_after_provider_limit`, `BackendHealth[claude]` cooldown.
- `TestReconcileRunningSessions_RateLimitedDeadWorker_FallbackRespawnFails_MarksDead` (new) — respawnFn returns error → `Dead` + `last_notified_status=rate_limit`.
- `TestReconcileRunningSessions_RateLimitedDeadWorker_FetchIssueFails_MarksDead` (new) — getIssueFn returns error → respawn NOT called, session ends `Dead`.

Verified on `workshop`: `go vet ./...`, `go test ./... -timeout 180s` (18/18 packages green), `go build ./cmd/maestro/` all clean.

## Out of scope (companion issue)

#507 — `maestro-freellm` shim is a non-agentic text completion. Even with this PR, setting `model.default: freellm` produces sessions that print `git commit && gh pr create ...` as text strings without executing them. That is a separate failure mode about the shim itself, not the orchestrator wiring.

Closes #506.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the `fallback_backends` fallover chain into the `reconcileRunningSessions` code path, which was previously marking rate-limited sessions `Dead` without consulting configured fallbacks. The fix mirrors the two existing fallover paths (main-loop worker-died and log-scanner) and covers all four terminal branches: no fallback available, issue-fetch failure, respawn failure, and successful respawn.

- **Reconcile path** now calls `selectProviderLimitFallback` before marking `Dead`, so sessions hit by a rate limit during reconcile get the same retry behaviour as sessions caught by the log-scanner or the main worker-exit handler.
- **Four new test cases** cover every branch of the new logic: the legacy no-fallback invariant (retry budget preserved), happy-path fallover to codex, respawn failure → `Dead`, and issue-fetch failure → `Dead`.
- **Consistency note**: `worker.Respawn` does not clear `RateLimitHit`; after a successful fallback, the log-scanner's rate-limit guard (`!sess.RateLimitHit`) is permanently blocked for that session, so a second rate limit on the new backend is only detectable via the reconcile path.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new reconcile branch faithfully reproduces the two existing fallover paths and is covered by tests for all four branches, including error cases.

The core logic change is small and structurally identical to the two already-exercised fallover paths in the same file. The four new tests cover every branch exhaustively. The only flag is that worker.Respawn does not clear RateLimitHit, which means a second rate limit on the fallback backend escapes the log-scanner guard and falls through to the reconcile path — a pre-existing behaviour that this PR does not worsen, but now surfaces on a third code path.

internal/orchestrator/orchestrator.go at the new reconcile block and internal/worker/worker.go's Respawn function (the RateLimitHit clearing omission).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds provider-limit fallover to the reconcile path — correctly mirrors the worker-died and log-scanner paths; one pre-existing concern around RateLimitHit not being cleared on respawn carries forward here |
| internal/orchestrator/orchestrator_test.go | Three new test functions cover the happy path, fetch-issue failure, and respawn failure; all four branches are exercised with clear assertions |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:1411-1413
**`RateLimitHit` persists through a successful respawn, silencing log-scanner re-detection on the next backend.**

`recordProviderLimit` sets `sess.RateLimitHit = true` (line 1411), and `worker.Respawn` deliberately clears many state fields but does **not** clear `RateLimitHit`. After a successful fallback to, say, `codex`, the log-scanner's guard at `:1804` (`!sess.RateLimitHit && sess.LastNotifiedStatus != "rate_limit"`) evaluates to `false`, so any rate-limit signal from `codex`'s output is silently skipped there. The reconcile path (this PR) will still detect the second limit once the codex process exits, so the session is not permanently stuck — but the real-time log-scanner path is bypassed for the second event.

The same pattern exists on the other two fallover paths (`:1697` and `:1817`), so this PR is consistent with the existing code. Noting it here because the reconcile path is now a third place that carries `RateLimitHit = true` into a live session, making the accumulation of this state more reachable. Clearing `RateLimitHit` (and `ProviderLimitBackend`) inside `worker.Respawn` — alongside the other already-cleared fields — would let all three paths re-arm the log-scanner guard for the new backend without affecting the `FailedAttemptsForIssue` guard that reads `RateLimitHit` only on terminal statuses.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): reconcile-time rate-l..."](https://github.com/befeast/maestro/commit/96d182e6a6c82d63b2ce9f21707d4e624fe72c48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34736184)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->