### PR TITLE
ciStatusFromREST returns pending forever when commit has only check-runs (empty combined status) → blocks every loop PR at CI gate

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -339,11 +339,18 @@ func parseCombinedStatus(out []byte) (combinedStatusResponse, error) {
 }
 
 func ciStatusFromREST(checks []greptileCheckRun, combined combinedStatusResponse) string {
-	if strings.EqualFold(combined.State, "pending") {
-		return "pending"
-	}
-	if strings.EqualFold(combined.State, "failure") || strings.EqualFold(combined.State, "error") {
-		return "failure"
+	// GitHub's combined commit-status API returns state:"pending" with
+	// statuses:[] for any commit that has zero legacy commit statuses — the
+	// normal case for repos that report CI exclusively via check-runs.
+	// An empty combined status carries no signal and must not override the
+	// check-runs verdict; only honor pending/failure when statuses exist.
+	if len(combined.Statuses) > 0 {
+		if strings.EqualFold(combined.State, "pending") {
+			return "pending"
+		}
+		if strings.EqualFold(combined.State, "failure") || strings.EqualFold(combined.State, "error") {
+			return "failure"
+		}
 	}
 
 	hasSignal := len(checks) > 0 || len(combined.Statuses) > 0

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -146,8 +146,34 @@ func TestCIStatusFromREST(t *testing.T) {
 		{name: "failed check fails", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "failure"}}, want: "failure"},
 		{name: "cancelled check fails", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "cancelled"}}, want: "failure"},
 		{name: "success checks pass", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}}, want: "success"},
-		{name: "combined pending wins", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}}, combined: combinedStatusResponse{State: "pending"}, want: "pending"},
-		{name: "combined failure wins", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}}, combined: combinedStatusResponse{State: "failure"}, want: "failure"},
+		{
+			name:     "green checks with empty combined pending succeed",
+			checks:   []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}},
+			combined: combinedStatusResponse{State: "pending", Statuses: nil},
+			want:     "success",
+		},
+		{
+			name:   "combined pending wins when a status entry is pending",
+			checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}},
+			combined: combinedStatusResponse{State: "pending", Statuses: []struct {
+				Context     string `json:"context"`
+				State       string `json:"state"`
+				Description string `json:"description"`
+				TargetURL   string `json:"target_url"`
+			}{{Context: "ci/build", State: "pending"}}},
+			want: "pending",
+		},
+		{
+			name:   "combined failure wins when a status entry failed",
+			checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}},
+			combined: combinedStatusResponse{State: "failure", Statuses: []struct {
+				Context     string `json:"context"`
+				State       string `json:"state"`
+				Description string `json:"description"`
+				TargetURL   string `json:"target_url"`
+			}{{Context: "ci/build", State: "failure"}}},
+			want: "failure",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Refs #471

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `ciStatusFromREST` returned `"pending"` forever for repos that use only check-runs (no legacy commit statuses), because GitHub's combined-status API always returns `state: "pending"` with an empty `statuses` array in that case. The fix gates the early `pending`/`failure` returns on `len(combined.Statuses) > 0`, so an empty combined status is treated as carrying no signal.

- **`github.go`**: Wraps the `combined.State` checks in a `len(combined.Statuses) > 0` guard; the check-runs loop and final `"success"` return are unchanged.
- **`github_test.go`**: Replaces the two old combined-status test cases (which missed the `Statuses` field entirely) with three explicit cases: empty statuses no longer blocks a green result, and populated-statuses pending/failure still wins correctly.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it corrects a persistent false-pending outcome for any repo using only check-runs, with no risk of regressing repos that mix legacy statuses and check-runs.

The fix is minimal and targeted: a two-line guard on an existing early-return block, with the rest of the function left untouched. The three new test cases directly exercise the empty-statuses scenario that caused the hang and verify both real-statuses paths still produce the right verdict. No adjacent logic was restructured.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Guards `pending`/`failure` early-returns in `ciStatusFromREST` behind `len(combined.Statuses) > 0` so an empty combined status no longer overrides a passing check-runs verdict. |
| internal/github/github_test.go | Replaces two old test cases with three new ones covering the empty-statuses bug scenario plus the two real-statuses paths that must still work; coverage looks complete for the touched logic. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(github): treat empty combined commit..."](https://github.com/befeast/maestro/commit/4c33f1a807720874524fd7a204efac85c7755bee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34799500)</sub>

<!-- /greptile_comment -->