### PR TITLE
fix(state): at-mint dedup of pending approvals (Phase 1.1, closes #471 storm root cause)

### DIFF
--- a/internal/server/approval_action_test.go
+++ b/internal/server/approval_action_test.go
@@ -217,10 +217,15 @@ func TestApprovalAction_ReadOnlyShortCircuits(t *testing.T) {
 	}
 }
 
-// Two enqueues for the same payload create two distinct approvals (the
-// supervisor's superseded/payload-hash logic handles dedup elsewhere; HTTP
-// callers that need idempotency can read the returned approval_id and stop).
-func TestApprovalAction_SecondEnqueueIsDistinctApproval(t *testing.T) {
+// Two enqueues for the same (action, target) coalesce into ONE pending
+// approval (Phase 1.1 at-mint dedup, 2026-05-31). HTTP callers can re-POST
+// safely; idempotency is enforced at the state-write boundary, not by
+// callers reading the returned approval_id and stopping.
+//
+// This was the dogfood "approvals storm" root cause — the same
+// (action=spawn_worker, target.issue=471) was minted 56 times in 12h
+// because RecordPendingApprovalForDecision had no dedup at all.
+func TestApprovalAction_SecondEnqueueDedupsToSameApproval(t *testing.T) {
 	cfg, dir := approvalEnqueueCfg(t)
 	srv := New(cfg, nil)
 	srv.SetActionDeps(&fakeActionGH{}, nil)
@@ -231,8 +236,26 @@ func TestApprovalAction_SecondEnqueueIsDistinctApproval(t *testing.T) {
 		t.Fatalf("statuses = %d, %d", w1.Code, w2.Code)
 	}
 	st := loadStateAt(t, dir)
+	if len(st.Approvals) != 1 {
+		t.Fatalf("approvals = %d, want 1 (dedup must coalesce identical re-enqueue)", len(st.Approvals))
+	}
+}
+
+// Different targets (different PR numbers) for the same action MUST stay
+// distinct. Dedup is keyed on (Action, Target), not Action alone.
+func TestApprovalAction_DifferentTargetsCoexist(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w1 := postApprovalAction(t, srv, `{"action_id":"merge_pr","pr_number":1}`)
+	w2 := postApprovalAction(t, srv, `{"action_id":"merge_pr","pr_number":2}`)
+	if w1.Code != http.StatusAccepted || w2.Code != http.StatusAccepted {
+		t.Fatalf("statuses = %d, %d", w1.Code, w2.Code)
+	}
+	st := loadStateAt(t, dir)
 	if len(st.Approvals) != 2 {
-		t.Fatalf("approvals = %d, want 2", len(st.Approvals))
+		t.Fatalf("approvals = %d, want 2 (different targets must NOT dedup)", len(st.Approvals))
 	}
 	if st.Approvals[0].ID == st.Approvals[1].ID {
 		t.Fatalf("approvals share the same ID: %s", st.Approvals[0].ID)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1315,6 +1315,24 @@ func (s *State) LatestSupervisorDecision() *SupervisorDecision {
 }
 
 // RecordPendingApprovalForDecision creates a pending approval tied to a decision payload.
+//
+// Dedup contract (added 2026-05-31, fixes the #471 approvals storm where the
+// same (action, target) was minted 56 times in 12 hours):
+//
+//   - If an existing PENDING approval matches the same (Action, Target) AND
+//     the target snapshot (TargetStateHash) is unchanged, return the
+//     existing approval and do NOT append a new one. This is the storm
+//     case: supervisor recommended the same action again, but nothing
+//     downstream changed, so a duplicate would only add noise.
+//
+//   - If an existing PENDING approval matches the same (Action, Target) but
+//     the TargetStateHash has changed (e.g. session moved from running to
+//     dead, PR opened, retry count bumped), the existing approval is marked
+//     superseded and a new one is created. This is a legitimate re-emit
+//     against fresh state.
+//
+//   - If no existing PENDING approval matches, create new (legacy
+//     behaviour preserved).
 func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, now time.Time) *Approval {
 	if s == nil {
 		return nil
@@ -1338,6 +1356,40 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 	if createdAt.IsZero() {
 		createdAt = now
 	}
+
+	freshTargetStateHash := s.ApprovalTargetStateHash(decision.Target)
+
+	// Dedup: scan existing pending approvals for the same (Action, Target).
+	// Only PENDING records are considered — terminal-state approvals are
+	// out of scope and never block a re-emit.
+	var existingMatch *Approval
+	for i := range s.Approvals {
+		candidate := &s.Approvals[i]
+		if candidate.Status != ApprovalStatusPending {
+			continue
+		}
+		if candidate.Action != decision.RecommendedAction {
+			continue
+		}
+		if !approvalTargetsEqual(candidate.Target, decision.Target) {
+			continue
+		}
+		existingMatch = candidate
+		break
+	}
+
+	if existingMatch != nil {
+		if existingMatch.TargetStateHash == freshTargetStateHash {
+			// Same (action, target, target-state) — the storm case.
+			// Return the existing approval untouched.
+			return existingMatch
+		}
+		// Same (action, target) but state has moved on — supersede the
+		// stale record and fall through to create a fresh one.
+		s.markApprovalSuperseded(existingMatch, now,
+			"superseded by fresh re-emit: target state changed before approval")
+	}
+
 	approval := Approval{
 		ID:              approvalID(decision, createdAt),
 		DecisionID:      decision.ID,
@@ -1349,7 +1401,7 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 		Risk:            decision.Risk,
 		Evidence:        append([]string(nil), decision.Reasons...),
 		Status:          ApprovalStatusPending,
-		TargetStateHash: s.ApprovalTargetStateHash(decision.Target),
+		TargetStateHash: freshTargetStateHash,
 		Repo:            decision.Repo,
 		Project:         decision.Project,
 	}
@@ -1362,6 +1414,28 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 	})
 	s.Approvals = append(s.Approvals, approval)
 	return &s.Approvals[len(s.Approvals)-1]
+}
+
+// approvalTargetsEqual returns true if two SupervisorTarget pointers refer
+// to the same target identity (issue/pr/session). Used by the at-mint
+// dedup check in RecordPendingApprovalForDecision.
+func approvalTargetsEqual(a, b *SupervisorTarget) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Issue != b.Issue {
+		return false
+	}
+	if a.PR != b.PR {
+		return false
+	}
+	if strings.TrimSpace(a.Session) != strings.TrimSpace(b.Session) {
+		return false
+	}
+	return true
 }
 
 func (s *State) FindApproval(id string) (*Approval, bool) {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1612,6 +1612,168 @@ func TestApprovalPendingPersistence(t *testing.T) {
 	}
 }
 
+// 2026-05-31: at-mint dedup tests. The dogfood "approvals storm" was 56
+// duplicate spawn_worker pending approvals on issue #471 over 12h because
+// RecordPendingApprovalForDecision had no dedup at all and just appended.
+// These three tests pin the new contract.
+
+func TestRecordPendingApprovalDedupsIdenticalReEmit(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+
+	first := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+	if first == nil {
+		t.Fatal("first approval was nil")
+	}
+	firstID := first.ID
+
+	// Identical re-emit one minute later (same action+target, target state
+	// snapshot unchanged): supervisor recommended spawn_worker for #42 again
+	// because nothing has changed downstream. Should NOT create a duplicate.
+	later := now.Add(1 * time.Minute)
+	dup := s.RecordPendingApprovalForDecision(testApprovalDecision(later), later)
+	if dup == nil {
+		t.Fatal("dedup return must not be nil — should be the existing approval")
+	}
+	if dup.ID != firstID {
+		t.Fatalf("dedup ID = %q, want %q (returned a fresh approval — duplicate created)", dup.ID, firstID)
+	}
+
+	pending := 0
+	for _, a := range s.Approvals {
+		if a.Status == ApprovalStatusPending {
+			pending++
+		}
+	}
+	if pending != 1 {
+		t.Fatalf("pending count = %d, want 1 (storm prevention failed)", pending)
+	}
+	if got := len(s.Approvals); got != 1 {
+		t.Fatalf("len(s.Approvals) = %d, want 1 (no duplicate appended)", got)
+	}
+	if got := len(dup.Audit); got != 1 || dup.Audit[0].Event != ApprovalAuditCreated {
+		t.Fatalf("audit on existing approval mutated: %+v", dup.Audit)
+	}
+}
+
+func TestRecordPendingApprovalSupersedesOnTargetStateChange(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+
+	first := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+	if first == nil {
+		t.Fatal("first approval was nil")
+	}
+	firstID := first.ID
+	firstTargetHash := first.TargetStateHash
+
+	// Add a session for the same issue — this changes the target snapshot
+	// (ApprovalTargetStateHash includes session state for matching slots).
+	s.Sessions = map[string]*Session{
+		"sup-1": {
+			IssueNumber: 42,
+			Status:      StatusRunning,
+			Branch:      "feat/sup-1-42-x",
+			PRNumber:    0,
+		},
+	}
+
+	// Sanity: TargetStateHash for the same target must now differ.
+	freshHash := s.ApprovalTargetStateHash(testApprovalDecision(now).Target)
+	if freshHash == firstTargetHash {
+		t.Fatalf("ApprovalTargetStateHash should differ after session add: both were %q", freshHash)
+	}
+
+	later := now.Add(2 * time.Minute)
+	// Use a fresh decision ID — supervisor mints decisions with unique
+	// per-cycle IDs in production; testApprovalDecision reuses the same
+	// ID literal, so we'd otherwise collide on approvalID() output.
+	freshDecision := testApprovalDecision(later)
+	freshDecision.ID = "sup-approval-2"
+	second := s.RecordPendingApprovalForDecision(freshDecision, later)
+	if second == nil {
+		t.Fatal("second approval was nil")
+	}
+	if second.ID == firstID {
+		t.Fatalf("expected a fresh approval after target-state change; got the original ID %q", firstID)
+	}
+
+	// Old one must be superseded.
+	old, ok := s.FindApproval(firstID)
+	if !ok {
+		t.Fatalf("original approval %q missing", firstID)
+	}
+	if old.Status != ApprovalStatusSuperseded {
+		t.Fatalf("original status = %q, want superseded", old.Status)
+	}
+	gotSupersededAudit := false
+	for _, a := range old.Audit {
+		if a.Event == ApprovalAuditSuperseded {
+			gotSupersededAudit = true
+			break
+		}
+	}
+	if !gotSupersededAudit {
+		t.Fatalf("expected superseded audit entry on original; got %+v", old.Audit)
+	}
+
+	// New one must be pending and tied to the new target hash.
+	if second.Status != ApprovalStatusPending {
+		t.Fatalf("new approval status = %q, want pending", second.Status)
+	}
+	if second.TargetStateHash == firstTargetHash {
+		t.Fatalf("new TargetStateHash equal to old; expected fresh hash")
+	}
+
+	// Exactly one pending, one superseded.
+	var pending, superseded int
+	for _, a := range s.Approvals {
+		switch a.Status {
+		case ApprovalStatusPending:
+			pending++
+		case ApprovalStatusSuperseded:
+			superseded++
+		}
+	}
+	if pending != 1 || superseded != 1 {
+		t.Fatalf("counts = pending %d / superseded %d, want 1 / 1", pending, superseded)
+	}
+}
+
+func TestRecordPendingApprovalDifferentActionsCoexist(t *testing.T) {
+	// Two pending approvals with the SAME target but DIFFERENT actions
+	// must coexist — the dedup is keyed on (Action, Target), not Target alone.
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+
+	spawn := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+	if spawn == nil {
+		t.Fatal("spawn approval was nil")
+	}
+
+	closeDecision := SupervisorDecision{
+		ID:                "sup-close-42",
+		CreatedAt:         now,
+		Project:           "owner/repo",
+		Mode:              "read_only",
+		Summary:           "Close issue #42 (resolved)",
+		RecommendedAction: "close_issue",
+		Target:            &SupervisorTarget{Issue: 42},
+		Risk:              "high",
+	}
+	closeApp := s.RecordPendingApprovalForDecision(closeDecision, now)
+	if closeApp == nil {
+		t.Fatal("close approval was nil")
+	}
+	if closeApp.ID == spawn.ID {
+		t.Fatal("close action wrongly deduped against spawn action; they share Target but Action differs")
+	}
+
+	if got := len(s.Approvals); got != 2 {
+		t.Fatalf("len(s.Approvals) = %d, want 2 (different actions must coexist)", got)
+	}
+}
+
 func TestReconcileSpawnWorkerApprovalsForStartedSession(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
 	s := NewState()


### PR DESCRIPTION
## What

At-mint dedup of pending approvals in `state.RecordPendingApprovalForDecision`. Closes the dogfood "approvals storm" root cause directly: 56 pending `spawn_worker` approvals on issue #471 over ~12h were possible only because the function did `s.Approvals = append(...)` with no dedup at all.

## Why this is P0

The supervisor cycle correctly re-recommends the same `(action, target)` while the underlying state hasn't moved on (e.g. the issue is still ready, no worker has started yet). Without dedup at the state-write boundary, every cycle minted a fresh `pending` approval. The pending list grew unbounded; operators (or the `kossoy` dashboard actor) saw 56 buttons asking to do the same thing.

The previous test `TestApprovalAction_SecondEnqueueIsDistinctApproval` even had a comment claiming "the supervisor's superseded/payload-hash logic handles dedup elsewhere" — aspirational, never true. There was no dedup, anywhere. Now there is, at the lowest mint surface — both the supervisor planner and the HTTP enqueue path go through `RecordPendingApprovalForDecision`, so this single fix covers all callers.

## Contract

| Existing pending? | Target snapshot? | Result |
|---|---|---|
| No | — | Create new (legacy behaviour) |
| Yes (same Action, same Target) | Unchanged (`TargetStateHash` equal) | Return existing — **storm prevented** |
| Yes (same Action, same Target) | Changed (`TargetStateHash` differs) | Supersede existing with audit, create fresh — **legitimate re-emit** |

Keyed on `(Action, Target.Issue, Target.PR, Target.Session)`. Different actions on the same target coexist (e.g. `spawn_worker` and `close_issue` for issue #42). Different targets on the same action coexist (e.g. `merge_pr` for PR #1 and PR #2). Terminal-status approvals (executed, rejected, superseded, stale, execution_failed) never block a re-emit — only `pending` records are scanned.

## Implementation

- `internal/state/state.go`: rewrite `RecordPendingApprovalForDecision` with the dedup loop in front of the append. Fresh `TargetStateHash` is computed once and reused for the dedup check + new approval. Supersede branch reuses the existing `markApprovalSuperseded` helper.
- `internal/state/state.go`: new helper `approvalTargetsEqual` — nil-safe, trims session whitespace, compares `Issue`/`PR`/`Session` fields of `SupervisorTarget`.

## Tests

`internal/state/state_test.go` — 3 new:

- `TestRecordPendingApprovalDedupsIdenticalReEmit` — the storm case directly. Same decision minted twice; second call returns the existing approval, `len(s.Approvals) == 1`, audit on the existing untouched.
- `TestRecordPendingApprovalSupersedesOnTargetStateChange` — adds a `Session` that changes the target snapshot, then mints again with a fresh decision ID; expects 1 superseded + 1 pending, with the supersede audit entry on the original.
- `TestRecordPendingApprovalDifferentActionsCoexist` — same target, different actions (`spawn_worker` vs `close_issue`) must stay distinct.

`internal/server/approval_action_test.go` — 1 contract flip + 1 new:

- `TestApprovalAction_SecondEnqueueDedupsToSameApproval` (renamed from the now-incorrect `..._IsDistinctApproval`): asserts dedup at the HTTP boundary.
- `TestApprovalAction_DifferentTargetsCoexist` — two HTTP enqueues for different PR numbers must NOT dedup; pins the `(Action, Target)` key.

Verified on workshop: `go vet ./...`, `go test ./... -timeout 240s` (18/18 packages green), `go build ./cmd/maestro/`.

## Out of scope

- Storm cleanup of the existing 56 stale approvals in dogfood state was done out-of-band by `~/.maestro/scripts/supersede_stale_approvals.py` against the running state file (Phase 0.3 of the morning runbook).
- A supervise-loop liveness watchdog (Phase 1.2, closes #499) — separate PR.

Refs the dogfood freeze incident and Phase 1 reliability plan
(`Dev/Areas/maestro/handovers/2026-05-31-fleet-pause-resume-runbook.md`,
`~/.claude/plans/serialized-gathering-perlis.md`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds at-mint dedup to `RecordPendingApprovalForDecision`, preventing the approvals storm described in #471 where the same `(action, target)` was appended on every supervisor cycle with no coalescing. The new dedup loop returns the existing pending approval on a hash match, supersedes it on a hash change, and falls through to create a fresh one if no match is found.

- `approvalTargetsEqual` compares `Issue`/`PR`/`Session` from `SupervisorTarget` — but not `Repo` or `Project`, which are stored per-`Approval` and could differ within a single state file.
- Three new unit tests cover identical re-emit, target-state-change supersede, and different-actions coexistence; HTTP-boundary test contract-flipped to match new behaviour.

<h3>Confidence Score: 4/5</h3>

Safe to merge for single-project deployments; multi-repo state files would silently deduplicate approvals across different repos with the same issue number.

The dedup loop in RecordPendingApprovalForDecision keys on (Action, Target.Issue, Target.PR, Target.Session) but ignores the Repo and Project fields that are explicitly stored per-Approval to distinguish project context. If a state file holds approvals for more than one repo, a spawn_worker for issue #42 in repo A would match and suppress a spawn_worker for issue #42 in repo B, silently returning the wrong approval.

internal/state/state.go — the dedup key in the scan loop inside RecordPendingApprovalForDecision

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Core dedup logic added to RecordPendingApprovalForDecision and new approvalTargetsEqual helper; dedup key omits Repo/Project fields that are stored per-Approval, risking cross-repo collision in multi-project state |
| internal/state/state_test.go | Three new dedup unit tests covering identical re-emit, target-state-change supersede, and different-actions coexistence — all single-project scenarios; no cross-repo test added |
| internal/server/approval_action_test.go | HTTP-boundary dedup test renamed and contract-flipped correctly; new different-targets coexistence test added; both changes are correct |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/state/state.go:1371-1376
The dedup key is `(Action, Target.Issue, Target.PR, Target.Session)` but the `Approval` struct stores `Repo` and `Project` as first-class per-record fields (added in #489 specifically to bind each approval to its project context). In a state file that contains approvals for more than one repo — which the struct design explicitly supports — a pending `spawn_worker` for issue #42 in `owner/repoA` would be treated as identical to a `spawn_worker` for issue #42 in `owner/repoB`, and the second enqueue would silently return the first project's approval instead of creating a new one.

```suggestion
		if candidate.Action != decision.RecommendedAction {
			continue
		}
		if candidate.Repo != decision.Repo || candidate.Project != decision.Project {
			continue
		}
		if !approvalTargetsEqual(candidate.Target, decision.Target) {
			continue
		}
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(state): at-mint dedup of pending app..."](https://github.com/befeast/maestro/commit/1973b24d49cfa7018cb898713a4ddc8385ad3f30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34800052)</sub>

<!-- /greptile_comment -->