### PR TITLE
feat(supervise): liveness watchdog (#499, Phase 1.2)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -498,6 +498,18 @@ func superviseCmd(args []string) {
 		cancel()
 	}()
 
+	// Phase 1.2 (#499): supervise-loop liveness watchdog.
+	//
+	// The main loop blocks on RunOnce; if RunOnce wedges (deadlock,
+	// runaway upstream call, network stall) the daemon emits no
+	// further log lines and there is no in-band signal that anything
+	// is wrong. A separate goroutine — running on its own ticker —
+	// reads state.json directly and warns when LastRunOnceAt has not
+	// been bumped in 3*interval. The warning persists into state
+	// (SupervisorStuck=true) so the Fleet API and dashboards can
+	// surface it without grepping the journal.
+	go superviseWatchdog(ctx, cfg.StateDir, *interval)
+
 	ticker := time.NewTicker(*interval)
 	defer ticker.Stop()
 	for {
@@ -507,6 +519,79 @@ func superviseCmd(args []string) {
 		case <-ticker.C:
 			runOnce()
 		}
+	}
+}
+
+// superviseWatchdog emits a loud log warning + persists SupervisorStuck=true
+// in state.json when the supervise loop has not stamped state.LastRunOnceAt
+// within 3*interval. It is a defense against silent wedges (#499).
+//
+// The ticker fires every interval (matching the supervise cadence so we
+// don't over-poll the state file). On startup we grant a 3*interval grace
+// before the first check, since LastRunOnceAt might be old after a daemon
+// restart.
+func superviseWatchdog(ctx context.Context, stateDir string, interval time.Duration) {
+	if interval <= 0 {
+		return
+	}
+	stuckThreshold := 3 * interval
+	startedAt := time.Now()
+
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+		}
+
+		// Startup grace: don't warn before we've had time to see one
+		// full cycle complete.
+		if time.Since(startedAt) < stuckThreshold {
+			continue
+		}
+
+		st, err := state.Load(stateDir)
+		if err != nil {
+			log.Printf("[supervise/watchdog] could not read state: %v (will retry)", err)
+			continue
+		}
+		if st.LastRunOnceAt.IsZero() {
+			// Daemon never completed a cycle. Loud warning, but only
+			// after the startup grace.
+			log.Printf("[supervise/watchdog] WARNING: no RunOnce has stamped state.LastRunOnceAt since the daemon started %s ago; check whether RunOnce is wedged",
+				time.Since(startedAt).Round(time.Second))
+			persistSupervisorStuck(stateDir, "no RunOnce has completed since daemon start")
+			continue
+		}
+		gap := time.Since(st.LastRunOnceAt)
+		if gap > stuckThreshold {
+			reason := fmt.Sprintf("LastRunOnceAt=%s is %s old (threshold %s)",
+				st.LastRunOnceAt.Format(time.RFC3339), gap.Round(time.Second), stuckThreshold)
+			log.Printf("[supervise/watchdog] WARNING: supervise loop appears stuck — %s", reason)
+			persistSupervisorStuck(stateDir, reason)
+		}
+	}
+}
+
+// persistSupervisorStuck flips SupervisorStuck=true in state.json so the
+// Fleet API surfaces it. Best-effort: a save failure is logged but does
+// not stop the watchdog.
+func persistSupervisorStuck(stateDir, reason string) {
+	st, err := state.Load(stateDir)
+	if err != nil {
+		log.Printf("[supervise/watchdog] persist: load state: %v", err)
+		return
+	}
+	if st.SupervisorStuck && st.SupervisorStuckReason == reason {
+		return // already set with the same reason; avoid log/save churn
+	}
+	st.SupervisorStuck = true
+	st.SupervisorStuckReason = reason
+	if err := state.Save(stateDir, st); err != nil {
+		log.Printf("[supervise/watchdog] persist: save state: %v", err)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -677,6 +677,22 @@ type State struct {
 	RestartRequired       bool   `json:"restart_required,omitempty"`
 	RestartRequiredReason string `json:"restart_required_reason,omitempty"`
 
+	// LastRunOnceAt is stamped by supervisor.RunOnce on every successful
+	// cycle (just before state.Save). The supervise daemon's watchdog
+	// reads this from state on its own ticker and emits a loud warning
+	// + sets SupervisorStuck=true if the gap is older than 3*interval.
+	// Used by Fleet API and by the systemd journal watcher to detect
+	// silent supervise-loop wedges (#499). Zero value means "no cycle
+	// has run since the daemon started" — handled by the watchdog's
+	// startup grace.
+	LastRunOnceAt time.Time `json:"last_run_once_at,omitempty"`
+
+	// SupervisorStuck is set by the watchdog when LastRunOnceAt is
+	// older than 3*interval. Cleared on any successful RunOnce that
+	// stamps LastRunOnceAt fresh.
+	SupervisorStuck       bool   `json:"supervisor_stuck,omitempty"`
+	SupervisorStuckReason string `json:"supervisor_stuck_reason,omitempty"`
+
 	loadedHash  string
 	loadedState *State
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -231,6 +231,14 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 			}
 		}
 		st.RecordSupervisorDecision(decision, state.DefaultSupervisorDecisionLimit)
+		// Phase 1.2 (#499): stamp the last-run heartbeat just before save
+		// so the watchdog goroutine in cmd/maestro can see this cycle
+		// completed. Also clear any stale SupervisorStuck flag set by a
+		// previous watchdog tick — a successful RunOnce is the only
+		// signal that unwedges the daemon.
+		st.LastRunOnceAt = time.Now().UTC()
+		st.SupervisorStuck = false
+		st.SupervisorStuckReason = ""
 		if err := state.Save(cfg.StateDir, st); err != nil {
 			return state.SupervisorDecision{}, fmt.Errorf("save state: %w", err)
 		}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1045,6 +1045,65 @@ func TestRunOnceRecordsDecision(t *testing.T) {
 	}
 }
 
+// Phase 1.2 (#499): a successful RunOnce stamps state.LastRunOnceAt
+// (used by the supervise watchdog goroutine to detect silent loop wedges).
+func TestRunOnce_StampsLastRunOnceAt(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+
+	before := time.Now().UTC()
+	if _, err := RunOnce(cfg, reader); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	after := time.Now().UTC()
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if st.LastRunOnceAt.IsZero() {
+		t.Fatal("LastRunOnceAt is zero after a successful RunOnce — watchdog will fire on a healthy daemon")
+	}
+	if st.LastRunOnceAt.Before(before) || st.LastRunOnceAt.After(after.Add(time.Second)) {
+		t.Fatalf("LastRunOnceAt=%s is outside the call window [%s, %s]",
+			st.LastRunOnceAt, before, after)
+	}
+}
+
+// Phase 1.2 (#499): a successful RunOnce clears any prior SupervisorStuck
+// flag set by the watchdog. This is the only signal that unwedges the
+// daemon — a healthy cycle is recovery.
+func TestRunOnce_ClearsSupervisorStuckFlag(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+
+	// Pre-seed state with SupervisorStuck = true (as the watchdog would).
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	st.SupervisorStuck = true
+	st.SupervisorStuckReason = "synthetic stuck for test"
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if _, err := RunOnce(cfg, reader); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	st, err = state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load 2: %v", err)
+	}
+	if st.SupervisorStuck {
+		t.Fatal("SupervisorStuck=true after a successful RunOnce; healthy cycle must clear the flag")
+	}
+	if st.SupervisorStuckReason != "" {
+		t.Fatalf("SupervisorStuckReason=%q; should be cleared", st.SupervisorStuckReason)
+	}
+}
+
 func TestRunOnceRecordsOutcomeHealth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
## What

Closes #499. Adds a liveness watchdog goroutine to the `supervise` daemon and persists a `SupervisorStuck` signal into state when the loop has not stamped `LastRunOnceAt` in the last 3*interval.

## Why this is P1

Until now `supervise` was a black box. If `RunOnce` wedged (deadlock, runaway upstream call, network stall, dependency hang) the daemon emitted no further log lines, no in-band signal that anything was wrong. Operators noticed only when downstream effects stopped appearing ("issues stuck on label change", "no decisions in journal for hours").

Today's freeze investigation surfaced this directly: I had to manually inspect `journalctl --since "30 min ago" | tail` to confirm the supervise loop was even alive. Phase 1.1 (PR #510) addresses the *content* of decisions; this PR addresses the *liveness* of the loop emitting them. They're complementary.

## Behaviour

- Stamping is bound to **RunOnce success**. Anywhere RunOnce returns without error, the cycle counts as alive.
- Watchdog goroutine runs on the same context as the main loop, with the same `interval`.
- Startup grace = 3 * interval. The first watchdog tick after that window does the first liveness check.
- Stuck threshold = 3 * interval. Standard cadence allows up to 2 missed cycles before the warning fires.
- Recovery is automatic: any successful RunOnce clears `SupervisorStuck` and the reason string.
- Save is best-effort. If the watchdog's own state.Save fails (filesystem hiccup, ENOSPC), it logs and keeps ticking — the goroutine never dies.

## Where ops sees it

- **Logs**: `[supervise/watchdog] WARNING: ...` lines in `journalctl --user -u maestro-<project>-supervise.service`.
- **State**: `state.json:.supervisor_stuck = true` + `.supervisor_stuck_reason`. Visible via `maestro status` and Fleet API once we surface it (separate UX issue under Phase 3).

## Implementation

- `internal/state/state.go` — three new fields on `State`: `LastRunOnceAt time.Time`, `SupervisorStuck bool`, `SupervisorStuckReason string`. JSON-tagged `omitempty` for back-compat.
- `internal/supervisor/supervisor.go` — `RunOnce` stamps `LastRunOnceAt` + clears `SupervisorStuck`/`SupervisorStuckReason` immediately before `state.Save`. Lives inside the `!cfg.Supervisor.DryRun` guard so dry-run doesn't trip the watchdog (dry-run never saves state).
- `cmd/maestro/main.go` — `superviseWatchdog(ctx, stateDir, interval)` goroutine in the `supervise` command branch. Uses its own `state.Load`/`state.Save` calls (deliberate — if the main loop holds state.json open during a wedge, we still want to detect it; the race is benign because save compares hashes and skips no-op writes).

## Tests

`internal/supervisor/supervisor_test.go` — 2 new:

- `TestRunOnce_StampsLastRunOnceAt` — RunOnce writes a timestamp inside the call window.
- `TestRunOnce_ClearsSupervisorStuckFlag` — pre-seed `SupervisorStuck=true`, run `RunOnce`, assert flag + reason are cleared.

The goroutine itself is exercised on dogfood (live integration); a future PR can add a fake-clock unit test if we want pure coverage.

Verified on workshop: `go vet ./...`, `go test ./... -timeout 240s` (18/18 packages green), `go build ./cmd/maestro/`.

Refs Phase 1 reliability plan
(`Dev/Areas/maestro/handovers/2026-05-31-fleet-pause-resume-runbook.md`,
`~/.claude/plans/serialized-gathering-perlis.md`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a liveness watchdog goroutine to the `supervise` daemon that detects silent wedges in `RunOnce` by checking `state.LastRunOnceAt` every `interval` and persisting `SupervisorStuck=true` when the stamp is older than `3*interval`.

- `internal/state/state.go` gains three `omitempty` fields (`LastRunOnceAt`, `SupervisorStuck`, `SupervisorStuckReason`) with full back-compat.
- `internal/supervisor/supervisor.go` stamps `LastRunOnceAt` and clears stuck fields inside the existing `!DryRun` guard, correctly tied to successful cycle completion.
- `cmd/maestro/main.go` launches `superviseWatchdog` unconditionally — without a dry-run guard — so a `--dry-run` daemon will emit false stuck warnings and write `supervisor_stuck=true` to `state.json` on every tick after the grace period (flagged in prior review and still open).

<h3>Confidence Score: 4/5</h3>

Core watchdog logic and state fields are sound; the open dry-run issue from the prior review should be addressed before merging to avoid false stuck state being written during dry-run operations.

The state-layer changes and supervisor stamping are clean and correctly guarded. The watchdog goroutine itself works correctly for normal operation. The outstanding concern — the watchdog being launched without a dry-run check — means any --dry-run invocation will permanently flip supervisor_stuck=true in state.json until the daemon is restarted in non-dry-run mode, which is a real behavioral defect on that code path.

cmd/maestro/main.go — the unconditional `go superviseWatchdog(...)` launch needs a `!cfg.Supervisor.DryRun` guard

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Adds superviseWatchdog goroutine and persistSupervisorStuck helper; watchdog is launched unconditionally without a dry-run guard, causing false stuck alerts and state writes in dry-run mode (flagged in prior review) |
| internal/supervisor/supervisor.go | Stamps LastRunOnceAt and clears SupervisorStuck fields inside the existing !DryRun guard; correct placement, no new issues |
| internal/state/state.go | Adds three new omitempty-tagged fields (LastRunOnceAt, SupervisorStuck, SupervisorStuckReason) to State struct; back-compat preserved, no issues |
| internal/supervisor/supervisor_test.go | Two new tests covering stamp and clear behaviour; test window bounds and assertions are correct |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cmd/maestro/main.go`, line 574-601 ([link](https://github.com/befeast/maestro/blob/2eeebd492c25870521b9d3a1fa60fd52552473b9/cmd/maestro/main.go#L574-L601)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Race between `persistSupervisorStuck` and a concurrent RunOnce recovery**

   The watchdog loads state to check `LastRunOnceAt` (line 556), then calls `persistSupervisorStuck` which does its own second `state.Load` + `state.Save`. If the main loop completes a successful `RunOnce` between those two loads (clearing `SupervisorStuck=false` and stamping a fresh `LastRunOnceAt`), `persistSupervisorStuck` will reload the now-clean state, see `SupervisorStuck == false` (so the early-return guard doesn't fire), and immediately re-set `SupervisorStuck=true`. The false-positive persists until the next successful `RunOnce` clears it — at most one extra interval.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/maestro/main.go
   Line: 574-601

   Comment:
   **Race between `persistSupervisorStuck` and a concurrent RunOnce recovery**

   The watchdog loads state to check `LastRunOnceAt` (line 556), then calls `persistSupervisorStuck` which does its own second `state.Load` + `state.Save`. If the main loop completes a successful `RunOnce` between those two loads (clearing `SupervisorStuck=false` and stamping a fresh `LastRunOnceAt`), `persistSupervisorStuck` will reload the now-clean state, see `SupervisorStuck == false` (so the early-return guard doesn't fire), and immediately re-set `SupervisorStuck=true`. The false-positive persists until the next successful `RunOnce` clears it — at most one extra interval.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["feat(supervise): liveness watchdog (#499..."](https://github.com/befeast/maestro/commit/dd99bbb5d6d4eb92af7998702a14bc718dd79578) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34800243)</sub>

<!-- /greptile_comment -->