### PR TITLE
feat(supervisor): merge_pr planner rule (#512, Phase 1.6) — closes hands-off blocker

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -35,6 +35,7 @@ const (
 	ActionSpawnWorker          = "spawn_worker"
 	ActionSpawnRepairWorker    = "spawn_repair_worker"
 	ActionLabelIssueReady      = "label_issue_ready"
+	ActionMergePR              = "merge_pr"
 	// ActionOpenChildIssue asks the supervisor (or operator) to create the
 	// next concrete child issue from an open handoff/epic when no runnable
 	// issue remains. Approval-gated in v1; the safe-action executor for
@@ -315,13 +316,33 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 			decision.StuckStates = stuckStates
 			return decision, nil
 		}
-		summary := fmt.Sprintf("Session %s already has open PR #%d; monitor review, CI, or merge readiness.", slot, pr.Number)
+		// #512 (Phase 1.6): if the PR is actually ready to merge — not draft,
+		// mergeable, CI green, Greptile approved (when configured) — recommend
+		// merge_pr (risk=mutating, cautious-gate gates approval). Without this
+		// rule, every CLEAN/SUCCESS PR sat in pr_open forever while supervisor
+		// emitted monitor_open_pr loops; the reasoning even claimed "Maestro will
+		// merge when the merge gate allows it" — aspirational, never implemented.
+		if ready, mergeReasons := e.openPRReadyToMerge(slot, sess, pr); ready {
+			summary := fmt.Sprintf("Merge PR #%d for issue #%d — checks green, mergeable, review gates passed.", pr.Number, sess.IssueNumber)
+			reasons := appendReasons(baseReasons, mergeReasons...)
+			decision := e.decision(st, now, projectState, ActionMergePR,
+				summary,
+				RiskMutating, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
+			decision.StuckStates = stuckStates
+			return decision, nil
+		}
+
+		// PR exists but is not yet merge-ready. Stay on monitor_open_pr but
+		// surface the actual blocker (CI pending, review missing, draft, etc.)
+		// in the summary instead of claiming auto-merge will happen.
+		monitorReasons := e.monitorOpenPRReasons(slot, sess, pr)
+		summary := fmt.Sprintf("Monitor PR #%d for issue #%d: %s", pr.Number, sess.IssueNumber, summarizeMonitorReasons(monitorReasons))
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Session %s is associated with open PR #%d", slot, pr.Number),
 			"No GitHub mutation is needed for supervisor mode",
 		)
+		reasons = appendReasons(reasons, monitorReasons...)
 		if sess.Status == state.StatusRetryExhausted {
-			summary = fmt.Sprintf("Issue #%d is retry exhausted, but PR #%d is still open; monitor checks and review, then merge when eligible.", sess.IssueNumber, pr.Number)
 			reasons = appendReasons(reasons,
 				fmt.Sprintf("Session %s is retry_exhausted but still has open PR #%d", slot, pr.Number),
 				"Retry exhaustion does not block normal PR merge flow when checks and review gates pass",
@@ -1909,6 +1930,120 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 		}
 	}
 	return false
+}
+
+// openPRReadyToMerge returns (true, reasons[]) when a session's open PR can
+// be safely merged: not a draft, mergeable, CI status success, Greptile
+// approved (when the reader exposes that signal). The bool is false on
+// any blocker; reasons is nil in that case (the caller falls through to
+// monitor_open_pr with a different reason set).
+//
+// Strict: an UNKNOWN mergeable, "pending" CI, or "unknown" review state
+// blocks the merge. We never speculate — a missing signal is treated as
+// "not ready" so we don't merge a PR whose state we couldn't read.
+func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.PR) (bool, []string) {
+	if sess == nil {
+		return false, nil
+	}
+	if pr.IsDraft {
+		return false, nil
+	}
+	mergeable := strings.ToUpper(strings.TrimSpace(pr.Mergeable))
+	if mergeable != "MERGEABLE" {
+		return false, nil
+	}
+
+	// CI must be green. PRCIStatus is an optional reader interface; when
+	// the reader does not implement it we conservatively refuse to merge.
+	ciReader, ok := e.reader.(prCIStatusReader)
+	if !ok {
+		return false, nil
+	}
+	ciStatus, err := ciReader.PRCIStatus(pr.Number)
+	if err != nil {
+		return false, nil
+	}
+	if strings.ToLower(strings.TrimSpace(ciStatus)) != "success" {
+		return false, nil
+	}
+
+	// Greptile gate — when the reader exposes Greptile signal, require
+	// approved=true and pending=false. Missing reader -> proceed (some
+	// projects don't use Greptile and the cautious gate still requires
+	// human approval before merge_pr executes).
+	if greptileReader, ok := e.reader.(prGreptileReader); ok {
+		approved, pending, err := greptileReader.PRGreptileApproved(pr.Number)
+		if err != nil {
+			return false, nil
+		}
+		if pending {
+			return false, nil
+		}
+		if !approved {
+			return false, nil
+		}
+	}
+
+	reasons := []string{
+		fmt.Sprintf("PR #%d is not draft", pr.Number),
+		fmt.Sprintf("PR #%d mergeable=%s", pr.Number, mergeable),
+		fmt.Sprintf("PR #%d CI status=success", pr.Number),
+	}
+	if _, ok := e.reader.(prGreptileReader); ok {
+		reasons = append(reasons, fmt.Sprintf("PR #%d Greptile review approved", pr.Number))
+	}
+	return true, reasons
+}
+
+// monitorOpenPRReasons returns a short list of human-readable reasons
+// describing WHY a PR is not yet merge-ready, used in the monitor_open_pr
+// summary. Mirrors the gates checked by openPRReadyToMerge but produces
+// honest text instead of a single "monitor" word.
+func (e *Engine) monitorOpenPRReasons(slot string, sess *state.Session, pr github.PR) []string {
+	var reasons []string
+	if pr.IsDraft {
+		reasons = append(reasons, "PR is still a draft")
+	}
+	mergeable := strings.ToUpper(strings.TrimSpace(pr.Mergeable))
+	if mergeable != "MERGEABLE" {
+		if mergeable == "" {
+			reasons = append(reasons, "PR mergeable state is unknown")
+		} else {
+			reasons = append(reasons, fmt.Sprintf("PR mergeable=%s", mergeable))
+		}
+	}
+	if ciReader, ok := e.reader.(prCIStatusReader); ok {
+		if status, err := ciReader.PRCIStatus(pr.Number); err == nil {
+			lc := strings.ToLower(strings.TrimSpace(status))
+			if lc != "success" {
+				reasons = append(reasons, fmt.Sprintf("CI status=%s", status))
+			}
+		} else {
+			reasons = append(reasons, "CI status could not be read")
+		}
+	}
+	if greptileReader, ok := e.reader.(prGreptileReader); ok {
+		if approved, pending, err := greptileReader.PRGreptileApproved(pr.Number); err == nil {
+			if pending {
+				reasons = append(reasons, "Greptile review pending")
+			} else if !approved {
+				reasons = append(reasons, "Greptile review not approved")
+			}
+		}
+	}
+	if len(reasons) == 0 {
+		reasons = append(reasons, "merge gate not yet evaluated this cycle")
+	}
+	return reasons
+}
+
+// summarizeMonitorReasons joins reasons into a single short phrase for the
+// SupervisorDecision.Summary field. Keeps the dashboard readable.
+func summarizeMonitorReasons(reasons []string) string {
+	if len(reasons) == 0 {
+		return "waiting"
+	}
+	return strings.Join(reasons, "; ")
 }
 
 func (e *Engine) hasLiveRunningSessionForIssue(st *state.State, issueNumber int) bool {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -447,7 +447,11 @@ func TestDecide_RetryExhaustedResolutionCachedPerDecisionCycle(t *testing.T) {
 	}
 }
 
-func TestDecide_RetryExhaustedOpenGreenPRExplainsMergeEligibility(t *testing.T) {
+// #512 (Phase 1.6): a retry-exhausted session whose PR is fully ready
+// (mergeable, CI green, review gate off) should now get an actionable
+// merge_pr decision rather than the old monitor_open_pr loop. The
+// retry-exhausted stuck-state info is still attached.
+func TestDecide_RetryExhaustedOpenGreenPRRecommendsMerge(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.ReviewGate = "none"
 	reader := &fakeReader{
@@ -469,18 +473,111 @@ func TestDecide_RetryExhaustedOpenGreenPRExplainsMergeEligibility(t *testing.T) 
 		t.Fatalf("Decide: %v", err)
 	}
 
-	if decision.RecommendedAction != ActionMonitorOpenPR {
-		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionMonitorOpenPR)
+	if decision.RecommendedAction != ActionMergePR {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionMergePR)
 	}
-	if !strings.Contains(strings.ToLower(decision.Summary), "retry exhausted") || !strings.Contains(strings.ToLower(decision.Summary), "merge") {
-		t.Fatalf("summary = %q, want retry exhausted merge eligibility", decision.Summary)
+	if decision.Risk != RiskMutating {
+		t.Fatalf("risk = %q, want %q (cautious gate must require approval for merge_pr)", decision.Risk, RiskMutating)
+	}
+	if decision.Target == nil || decision.Target.PR != 88 {
+		t.Fatalf("target = %#v, want PR=88", decision.Target)
 	}
 	stuck := requireStuckState(t, decision, "retry_exhausted_open_pr")
 	if stuck.Severity != SeverityInfo {
 		t.Errorf("severity = %q, want %q", stuck.Severity, SeverityInfo)
 	}
-	if !strings.Contains(strings.Join(stuck.Evidence, "\n"), "checks=success") {
-		t.Fatalf("evidence = %#v, want checks=success", stuck.Evidence)
+}
+
+// #512: PR has all gates green and a normal (non-retry-exhausted) session
+// → planner recommends merge_pr with mutating risk (cautious gate gates
+// the actual merge, but the recommendation surfaces a real button).
+func TestDecide_OpenPR_AllGreen_RecommendsMerge(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 99, HeadRefName: "feat/all-green", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{99: "success"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 200,
+		IssueTitle:  "ready PR",
+		Status:      state.StatusPROpen,
+		Branch:      "feat/all-green",
+		PRNumber:    99,
+		StartedAt:   time.Now().UTC().Add(-30 * time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMergePR {
+		t.Fatalf("action = %q, want merge_pr", decision.RecommendedAction)
+	}
+	if decision.Risk != RiskMutating {
+		t.Fatalf("risk = %q, want mutating", decision.Risk)
+	}
+}
+
+// #512: CI is still pending → planner stays on monitor_open_pr with a
+// summary that names the actual blocker, not the old aspirational text.
+func TestDecide_OpenPR_CIPending_StaysMonitor(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 100, HeadRefName: "feat/ci-pending", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{100: "pending"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 201,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/ci-pending",
+		PRNumber:    100,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr (CI pending must NOT trigger merge_pr)", decision.RecommendedAction)
+	}
+	if !strings.Contains(strings.ToLower(decision.Summary), "ci status=pending") {
+		t.Fatalf("summary = %q, want a substring naming CI status pending", decision.Summary)
+	}
+}
+
+// #512: PR is conflicting / dirty → planner stays on monitor_open_pr.
+// (The repair branch above already catches drafts, so we exercise
+// the post-repair-check fall-through here.)
+func TestDecide_OpenPR_Conflicting_StaysMonitor(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 101, HeadRefName: "feat/dirty", Mergeable: "CONFLICTING"}},
+		ciStatuses: map[int]string{101: "success"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 202,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/dirty",
+		PRNumber:    101,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr (CONFLICTING must NOT merge)", decision.RecommendedAction)
+	}
+	if !strings.Contains(decision.Summary, "CONFLICTING") {
+		t.Fatalf("summary = %q, want a substring naming CONFLICTING", decision.Summary)
 	}
 }
 


### PR DESCRIPTION
## What

Closes #512. Adds the missing `merge_pr` planner rule. Until now the supervisor's `decideDeterministic` had only `monitor_open_pr` for sessions with an open PR — the loop endlessly emitted "monitor, monitor, monitor..." even when CI was green, mergeable=CLEAN, and review gates passed. The reasoning text claimed «Maestro will merge when the merge gate allows it»; the planner had no `merge_pr` decision rule at all, so that promise was aspirational.

## Why P0

This was the actual blocker for hands-off operation discovered today (2026-05-31): dogfood PR #509 sat for ~20 minutes with all 3 checks SUCCESS / MERGEABLE / CLEAN, supervisor minted `monitor_open_pr` every cycle for it, and it had to be merged manually. As long as one such PR exists per active session, the slot stays held, no new worker for the next ready issue can spawn, and throughput is bounded by **operator merge cadence**. Opposite of the stated dogfood goal.

The executor side already implements `config.SupervisorActionMergePR` + `executeMergePR` (verified in `internal/approver/executor.go:172`). The gap was strictly in decision minting — supervisor never minted the verb the executor was waiting for.

## Behaviour

In `decideDeterministic`, between `openPRNeedsRepair` and the existing `monitor_open_pr` fall-through:

```
if openPRReadyToMerge(slot, sess, pr):
    decision = ActionMergePR (Risk=mutating, target=Issue/PR/Session, summary names gates passed)
```

The cautious gate keeps `merge_pr` approval-required — supervisor mints the approval, the operator approves it via dashboard or CLI, the existing executor performs the actual `gh pr merge`.

When the PR is **not** ready (CI pending, mergeable=DIRTY, draft, etc.), the planner stays on `monitor_open_pr` but the summary now names the real blocker — "CI status=pending", "PR mergeable=CONFLICTING", "Greptile review pending" — instead of the old aspirational text.

## openPRReadyToMerge gates

Strict — a missing or unknown signal blocks the merge (we never speculate on a state we couldn't read):

| Gate | Pass condition | Failure mode |
|---|---|---|
| `pr.IsDraft` | must be `false` | draft → not ready |
| `pr.Mergeable` | `MERGEABLE` | `CONFLICTING`, `UNKNOWN`, empty → not ready |
| `PRCIStatus(pr.Number)` | `"success"` | `pending`, `failure`, error → not ready; reader missing the optional interface → conservatively not ready |
| `PRGreptileApproved(pr.Number)` (when reader exposes it) | `approved=true && pending=false` | error / pending / not-approved → not ready |

Reader missing `prGreptileReader` → gate skipped — some projects don't use Greptile, and the cautious approval gate still guards the actual merge.

## Tests

`internal/supervisor/supervisor_test.go`:

- **`TestDecide_RetryExhaustedOpenGreenPRRecommendsMerge`** — replaces the old `TestDecide_RetryExhaustedOpenGreenPRExplainsMergeEligibility` which asserted the old monitor-only behaviour. Same fixture (retry-exhausted session, MERGEABLE PR, CI=success), now asserts `Action=merge_pr` + `Risk=mutating` + `retry_exhausted_open_pr` stuck state still attached.
- **`TestDecide_OpenPR_AllGreen_RecommendsMerge`** — happy path for a normal session.
- **`TestDecide_OpenPR_CIPending_StaysMonitor`** — CI pending must NOT trigger `merge_pr`; summary names the blocker.
- **`TestDecide_OpenPR_Conflicting_StaysMonitor`** — `mergeable=CONFLICTING` must NOT trigger merge; summary names CONFLICTING.

Verified on workshop: `go vet ./...`, `go test ./... -timeout 240s` (18/18 packages green), `go build ./cmd/maestro/`.

## Out of scope

- Auto-approve of `merge_pr` (cautious mode keeps approval-required; this PR only mints, executor still gates on operator approve).
- Mission Control UI affordances for the new merge_pr approval (Phase 3 UX work).
- `merge_pr` for non-cautious modes — planner change is mode-agnostic; mode handling lives in the existing approval pipeline.

## Related

- #506 / PR #508 (merged today) — reconcile fallover.
- Phase 1.1 / PR #510 (merged) — at-mint dedup.
- Phase 1.2 / PR #511 (merged) — supervise watchdog.
- Phase 1 reliability plan in `Dev/Areas/maestro/handovers/2026-05-31-fleet-pause-resume-runbook.md` and `~/.claude/plans/serialized-gathering-perlis.md`.

Found while observing dogfood live during Phase 1 work today; not a hypothetical premortem item.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the missing `merge_pr` planner rule to `decideDeterministic`: when a session's open PR is not a draft, has `mergeable=MERGEABLE`, CI=`success`, and Greptile approved (if configured), the supervisor now mints `ActionMergePR` with `RiskMutating` instead of looping on `monitor_open_pr` indefinitely.

- `openPRReadyToMerge` enforces strict all-gates-must-pass semantics; any missing or failed signal blocks merge rather than speculating on unknown state.
- `monitorOpenPRReasons` is introduced to surface the actual blocker (CI pending, CONFLICTING, Greptile not approved) in the monitor summary instead of the old aspirational placeholder text.
- Four new tests cover the happy path, CI-pending, CONFLICTING, and the retry-exhausted + green PR case; the old `TestDecide_RetryExhaustedOpenGreenPRExplainsMergeEligibility` is replaced with a test that now asserts `merge_pr` instead of `monitor_open_pr`.

<h3>Confidence Score: 4/5</h3>

The change is additive and the merge_pr action still requires operator approval through the cautious gate, so no unauthorized merges can occur.

The core logic in openPRReadyToMerge is conservative and correct — all gates must explicitly pass, missing signals block rather than allow. Minor gaps are the unused slot parameters in both helpers, the missing diagnostic message when prCIStatusReader is absent, and a Greptile read error silently swallowed in monitorOpenPRReasons. None affect correctness of the merge decision itself.

internal/supervisor/supervisor.go — specifically the monitorOpenPRReasons function and its handling of absent or erroring readers

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds ActionMergePR constant, openPRReadyToMerge/monitorOpenPRReasons helpers, and wires them into decideDeterministic; logic is correct but slot parameter goes unused in both helpers and monitorOpenPRReasons has diagnostic gaps where the real blocker is not surfaced |
| internal/supervisor/supervisor_test.go | Replaces old monitor-only assertion with four focused tests for the new merge_pr path; a pre-existing evidence check on the stuck state was dropped without replacement |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
internal/supervisor/supervisor.go:1944
Both `openPRReadyToMerge` and `monitorOpenPRReasons` accept a `slot string` parameter that is never read inside either function. Unused named parameters can be dropped or replaced with `_` to signal intent; leaving them named implies the function may rely on slot-scoped state, which is confusing.

```suggestion
func (e *Engine) openPRReadyToMerge(_ string, sess *state.Session, pr github.PR) (bool, []string) {
```

### Issue 2 of 4
internal/supervisor/supervisor.go:2002
The `monitorOpenPRReasons` signature also carries unused `slot string` and `sess *state.Session` parameters (same issue as `openPRReadyToMerge`).

```suggestion
func (e *Engine) monitorOpenPRReasons(_ string, _ *state.Session, pr github.PR) []string {
```

### Issue 3 of 4
internal/supervisor/supervisor.go:2015-2033
When `prCIStatusReader` is not implemented by the reader, `openPRReadyToMerge` conservatively returns `false`, but `monitorOpenPRReasons` adds no CI-related entry — the only output is the fallback `"merge gate not yet evaluated this cycle"`. Likewise, a `PRGreptileApproved` error is silently swallowed by the `if err == nil` guard. Operators watching the dashboard would have no way to tell that the merge is blocked by a missing interface or a transient Greptile error rather than a real review problem.

```suggestion
	if ciReader, ok := e.reader.(prCIStatusReader); ok {
		if status, err := ciReader.PRCIStatus(pr.Number); err == nil {
			lc := strings.ToLower(strings.TrimSpace(status))
			if lc != "success" {
				reasons = append(reasons, fmt.Sprintf("CI status=%s", status))
			}
		} else {
			reasons = append(reasons, "CI status could not be read")
		}
	} else {
		reasons = append(reasons, "CI status reader not available; merge blocked until CI reader is configured")
	}
	if greptileReader, ok := e.reader.(prGreptileReader); ok {
		if approved, pending, err := greptileReader.PRGreptileApproved(pr.Number); err == nil {
			if pending {
				reasons = append(reasons, "Greptile review pending")
			} else if !approved {
				reasons = append(reasons, "Greptile review not approved")
			}
		} else {
			reasons = append(reasons, fmt.Sprintf("Greptile review status could not be read: %v", err))
		}
	}
```

### Issue 4 of 4
internal/supervisor/supervisor_test.go:487-492
**Lost stuck-state evidence assertion**

The old test verified that the `retry_exhausted_open_pr` stuck state's `Evidence` slice contained `"checks=success"` — a concrete signal that the right diagnostic data was attached. The rewrite checks only `stuck.Severity == SeverityInfo`. If a future change accidentally clears or corrupts the evidence, this test will no longer catch it. Consider adding at least a `len(stuck.Evidence) > 0` guard, or restoring the `"checks=success"` substring check alongside the new `RiskMutating` assertion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(supervisor): merge\_pr planner rule ..."](https://github.com/befeast/maestro/commit/e8fba16f2a1f87e02c13f644a81456ab95734469) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34802238)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->