### PR TITLE
fix(state,approver): awaiting_dispatch status closes post-approve race (#515, Phase 1.8)

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -201,8 +201,14 @@ func (e *Executor) Execute(approval *state.Approval) Result {
 		if issue > 0 {
 			summary = fmt.Sprintf("spawn_worker for issue #%d approved; next dispatcher loop will start the worker (no extra command required)", issue)
 		}
+		// #515: AwaitingDispatch (not ExecutionSkipped). The dispatcher
+		// loop owns the actual worker.Start; until it runs we keep this
+		// approval as "still effective" so the at-mint dedup in
+		// RecordPendingApprovalForDecision coalesces fresh supervisor
+		// recommendations on the same (action, target) instead of
+		// minting a duplicate pending in the race window.
 		return Result{
-			Status:  state.ApprovalStatusExecutionSkipped,
+			Status:  state.ApprovalStatusAwaitingDispatch,
 			Summary: summary,
 		}
 	case "open_child_issue":
@@ -218,8 +224,12 @@ func (e *Executor) Execute(approval *state.Approval) Result {
 		if issue > 0 {
 			summary = fmt.Sprintf("open_child_issue for handoff epic #%d approved; operator must create the next child issue manually until the safe-action executor lands", issue)
 		}
+		// #515: AwaitingDispatch — the side effect is "operator must
+		// create the next child issue manually". Until it lands as a
+		// real GitHub issue, we keep this record effective so dedup
+		// suppresses fresh duplicates on the same handoff target.
 		return Result{
-			Status:  state.ApprovalStatusExecutionSkipped,
+			Status:  state.ApprovalStatusAwaitingDispatch,
 			Summary: summary,
 		}
 	}

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -76,18 +76,21 @@ func mkApproval(action string, target *state.SupervisorTarget, summary, approveR
 
 // --- spawn_worker / open_child_issue approval semantics --------------------
 
-// TestExecute_SpawnWorker_ReturnsExecutionSkippedWithActionableSummary verifies
-// the fix for issue #443: approving a spawn_worker approval used to print
-// "No risky action was executed". The executor now records the approval as
-// execution_skipped with a clear summary so the operator knows the next
-// dispatcher loop will start the worker.
-func TestExecute_SpawnWorker_ReturnsExecutionSkippedWithActionableSummary(t *testing.T) {
+// TestExecute_SpawnWorker_ReturnsAwaitingDispatchWithActionableSummary verifies
+// the post-#515 contract: approving a spawn_worker approval moves it to
+// status=awaiting_dispatch (not execution_skipped) so the at-mint dedup in
+// state.RecordPendingApprovalForDecision still treats it as effective and
+// supervisor does not mint a fresh pending duplicate while the dispatcher
+// loop has not yet ticked. (Original #443 fix preserved: the operator
+// still sees an actionable summary, never the old "No risky action was
+// executed" line.)
+func TestExecute_SpawnWorker_ReturnsAwaitingDispatchWithActionableSummary(t *testing.T) {
 	ex := &Executor{Cfg: newCfg()}
 	a := mkApproval("spawn_worker", &state.SupervisorTarget{Issue: 170}, "spawn me", "")
 
 	res := ex.Execute(a)
-	if res.Status != state.ApprovalStatusExecutionSkipped {
-		t.Fatalf("status = %q, want %q", res.Status, state.ApprovalStatusExecutionSkipped)
+	if res.Status != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("status = %q, want %q (#515)", res.Status, state.ApprovalStatusAwaitingDispatch)
 	}
 	if !strings.Contains(res.Summary, "#170") {
 		t.Fatalf("summary = %q, want issue ref", res.Summary)
@@ -96,17 +99,17 @@ func TestExecute_SpawnWorker_ReturnsExecutionSkippedWithActionableSummary(t *tes
 		t.Fatalf("summary = %q, want operator-facing hint about dispatcher loop", res.Summary)
 	}
 	if res.Err != nil {
-		t.Fatalf("err = %v, want nil for skipped-status", res.Err)
+		t.Fatalf("err = %v, want nil for awaiting-dispatch", res.Err)
 	}
 }
 
-func TestExecute_OpenChildIssue_ReturnsExecutionSkippedWithActionableSummary(t *testing.T) {
+func TestExecute_OpenChildIssue_ReturnsAwaitingDispatchWithActionableSummary(t *testing.T) {
 	ex := &Executor{Cfg: newCfg()}
 	a := mkApproval("open_child_issue", &state.SupervisorTarget{Issue: 146}, "create child", "")
 
 	res := ex.Execute(a)
-	if res.Status != state.ApprovalStatusExecutionSkipped {
-		t.Fatalf("status = %q, want %q", res.Status, state.ApprovalStatusExecutionSkipped)
+	if res.Status != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("status = %q, want %q (#515)", res.Status, state.ApprovalStatusAwaitingDispatch)
 	}
 	if !strings.Contains(res.Summary, "#146") {
 		t.Fatalf("summary = %q, want epic ref", res.Summary)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -611,6 +611,12 @@ const (
 	ApprovalStatusExecuted         ApprovalStatus = "executed"
 	ApprovalStatusExecutionFailed  ApprovalStatus = "execution_failed"
 	ApprovalStatusExecutionSkipped ApprovalStatus = "execution_skipped"
+	// ApprovalStatusAwaitingDispatch marks an approval that the operator
+	// has approved but whose side effect lives on a separate loop
+	// (e.g. spawn_worker — the dispatcher tick allocates the slot).
+	// Distinct from execution_skipped (which means "no action will
+	// happen") so dedup can keep it as a still-effective record.
+	ApprovalStatusAwaitingDispatch ApprovalStatus = "awaiting_dispatch"
 )
 
 const (
@@ -622,6 +628,7 @@ const (
 	ApprovalAuditExecuted         = "executed"
 	ApprovalAuditExecutionFailed  = "execution_failed"
 	ApprovalAuditExecutionSkipped = "execution_skipped"
+	ApprovalAuditAwaitingDispatch = "awaiting_dispatch"
 )
 
 const approvalActionSpawnWorker = "spawn_worker"
@@ -1381,7 +1388,11 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 	var existingMatch *Approval
 	for i := range s.Approvals {
 		candidate := &s.Approvals[i]
-		if candidate.Status != ApprovalStatusPending {
+		// #515: also coalesce against awaiting_dispatch — operator
+		// approved an earlier mint, the side-effect (spawn) is still
+		// in flight on the dispatcher loop, supervisor must not mint
+		// a fresh pending for the same target in this race window.
+		if candidate.Status != ApprovalStatusPending && candidate.Status != ApprovalStatusAwaitingDispatch {
 			continue
 		}
 		if candidate.Action != decision.RecommendedAction {
@@ -1600,7 +1611,10 @@ func (s *State) markApprovalStale(approval *Approval, now time.Time, reason stri
 }
 
 func (s *State) markApprovalSuperseded(approval *Approval, now time.Time, reason string) {
-	if approval.Status != ApprovalStatusPending {
+	// #515: AwaitingDispatch is "still in flight on a separate loop";
+	// reconcile must be allowed to supersede it once the side effect
+	// it's awaiting actually lands (e.g. spawn_worker -> worker started).
+	if approval.Status != ApprovalStatusPending && approval.Status != ApprovalStatusAwaitingDispatch {
 		return
 	}
 	approval.Status = ApprovalStatusSuperseded
@@ -1615,7 +1629,13 @@ func (s *State) markApprovalSuperseded(approval *Approval, now time.Time, reason
 }
 
 func spawnWorkerApprovalMatchesSession(approval *Approval, slot string, sess *Session) bool {
-	if approval == nil || sess == nil || approval.Status != ApprovalStatusPending || approval.Action != approvalActionSpawnWorker {
+	if approval == nil || sess == nil || approval.Action != approvalActionSpawnWorker {
+		return false
+	}
+	// #515: both pending (not yet approved) and awaiting_dispatch (approved
+	// but dispatcher hasn't ticked yet) records are still effective; both
+	// must be superseded once the worker really starts.
+	if approval.Status != ApprovalStatusPending && approval.Status != ApprovalStatusAwaitingDispatch {
 		return false
 	}
 	if approval.Target == nil {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1774,6 +1774,81 @@ func TestRecordPendingApprovalDifferentActionsCoexist(t *testing.T) {
 	}
 }
 
+// #515: dedup must coalesce against an awaiting_dispatch record too.
+// Scenario: supervisor mints a pending; operator approves it; executor
+// transitions it to awaiting_dispatch (spawn_worker side-effect on the
+// dispatcher loop). Before the dispatcher ticks, supervisor cycles and
+// would re-recommend spawn_worker for the same issue. Without #515,
+// dedup only scanned pending and a fresh duplicate was minted. With
+// #515, the dedup loop also checks awaiting_dispatch and returns the
+// existing record, suppressing the duplicate.
+func TestRecordPendingApprovalDedupsAgainstAwaitingDispatch(t *testing.T) {
+	now := time.Date(2026, 5, 31, 16, 18, 0, 0, time.UTC)
+	s := NewState()
+
+	first := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+	if first == nil {
+		t.Fatal("first approval was nil")
+	}
+	firstID := first.ID
+
+	// Simulate the executor transition to awaiting_dispatch.
+	first.Status = ApprovalStatusAwaitingDispatch
+
+	// Supervisor cycles 30s later, would re-recommend the same target
+	// (different decision ID — like supervisor mints fresh decisions
+	// per cycle).
+	later := now.Add(30 * time.Second)
+	freshDecision := testApprovalDecision(later)
+	freshDecision.ID = "sup-approval-2"
+	dup := s.RecordPendingApprovalForDecision(freshDecision, later)
+	if dup == nil {
+		t.Fatal("dedup return must not be nil — should be the awaiting_dispatch existing approval")
+	}
+	if dup.ID != firstID {
+		t.Fatalf("dedup ID = %q, want %q (race window: fresh duplicate minted while awaiting_dispatch was effective)", dup.ID, firstID)
+	}
+	if got := len(s.Approvals); got != 1 {
+		t.Fatalf("len(s.Approvals) = %d, want 1 (no fresh pending duplicate)", got)
+	}
+	if dup.Status != ApprovalStatusAwaitingDispatch {
+		t.Fatalf("returned approval status = %q, want %q (must keep awaiting_dispatch unchanged)", dup.Status, ApprovalStatusAwaitingDispatch)
+	}
+}
+
+// #515: ReconcileSpawnWorkerApprovalsForStartedSession must supersede
+// awaiting_dispatch records too, not just pending ones — once the
+// worker actually starts, the awaiting record has done its job.
+func TestReconcileSpawnWorkerApprovalsSupersedesAwaitingDispatch(t *testing.T) {
+	now := time.Date(2026, 5, 31, 16, 18, 0, 0, time.UTC)
+	s := NewState()
+	a := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+	if a == nil {
+		t.Fatal("approval was nil")
+	}
+	a.Status = ApprovalStatusAwaitingDispatch
+
+	sess := &Session{
+		IssueNumber: 42,
+		Status:      StatusRunning,
+		PRNumber:    0,
+		Branch:      "feat/sup-1-42-x",
+		// StartedAt > approval.CreatedAt — matches the gate inside
+		// spawnWorkerApprovalMatchesSession (only sessions started
+		// AFTER the approval are considered "spawned by it").
+		StartedAt: now.Add(30 * time.Second),
+	}
+	s.Sessions = map[string]*Session{"sup-1": sess}
+
+	count := s.ReconcileSpawnWorkerApprovalsForStartedSession("sup-1", sess, now.Add(time.Minute))
+	if count != 1 {
+		t.Fatalf("reconciled count = %d, want 1 (must supersede awaiting_dispatch)", count)
+	}
+	if got := s.Approvals[0].Status; got != ApprovalStatusSuperseded {
+		t.Fatalf("approval status = %q, want %q", got, ApprovalStatusSuperseded)
+	}
+}
+
 func TestReconcileSpawnWorkerApprovalsForStartedSession(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
 	s := NewState()


### PR DESCRIPTION
## What

Closes #515. Introduces a new `awaiting_dispatch` approval status to close the post-approve race that PR #510 (Phase 1.1 at-mint dedup) left open.

## Live finding

2026-05-31 16:18 UTC, ~10 min after #510 deployed. Operator approves the only pending `spawn_worker` approval for issue #487 from the dashboard. Seconds later a fresh card for the same `(spawn_worker, #487)` appears at age `0m`. Looks like a duplicate; it's a race.

Sequence:
1. Supervisor mints approval A (`spawn_worker`, issue=487), `status=pending`.
2. Operator approves A. Approver runs, returns `Status=ApprovalStatusExecutionSkipped` with reason «spawn_worker for issue #487 approved; next dispatcher loop will start the worker» (the actual `worker.Start` lives on a separate dispatcher loop). State on disk: `A=execution_skipped`.
3. Supervisor cycle (which had loaded state slightly **before** step 2) calls `RecordPendingApprovalForDecision` for the same target. The #510 dedup loop scans only `pending` records; A is now `execution_skipped`, so the loop misses it and a fresh `pending` B is appended.
4. Dashboard shows B at age `0m`, immediately after the operator thought they were done.

Net: #510 closed the storm of duplicates between two unapproved `pending` records, but missed the post-approve window where the side effect is in flight on a separate loop.

## Why a new status is the right shape

- `execution_skipped` semantically means **«no further action will happen»** (e.g. `change_global_config` requires a manual edit). Dedup must **not** treat these as effective; a fresh recommendation should create a new pending.
- `awaiting_dispatch` semantically means **«approval done, side effect is in flight on a separate loop»**. Dedup **must** treat these as effective until reconcile supersedes them once the side effect lands.

Conflating both into `execution_skipped` was the bug. Two distinct states, two distinct rules.

## Implementation

`internal/state/state.go`:
- new const `ApprovalStatusAwaitingDispatch ApprovalStatus = "awaiting_dispatch"`
- new audit event const `ApprovalAuditAwaitingDispatch = "awaiting_dispatch"`
- `markApprovalSuperseded` accepts both `Pending` and `AwaitingDispatch` (so reconcile can supersede them once the side effect lands).
- `spawnWorkerApprovalMatchesSession` matches both `Pending` and `AwaitingDispatch` (so `ReconcileSpawnWorkerApprovalsForStartedSession` sweeps both).
- `RecordPendingApprovalForDecision` dedup loop scans both `Pending` and `AwaitingDispatch` (closes the race window).

`internal/approver/executor.go`:
- `spawn_worker` and `open_child_issue` branches return `state.ApprovalStatusAwaitingDispatch` instead of `state.ApprovalStatusExecutionSkipped`. Summary text unchanged.

## Tests

`internal/state/state_test.go`:
- **`TestRecordPendingApprovalDedupsAgainstAwaitingDispatch`** — exact race scenario: approve A, flip to `awaiting_dispatch`, mint decision with fresh ID for the same target. Dedup returns A; no fresh pending created.
- **`TestReconcileSpawnWorkerApprovalsSupersedesAwaitingDispatch`** — `awaiting_dispatch` record gets superseded once the matching worker session is observed.

`internal/approver/executor_test.go`:
- Renamed `TestExecute_SpawnWorker_ReturnsExecutionSkippedWithActionableSummary` → `TestExecute_SpawnWorker_ReturnsAwaitingDispatchWithActionableSummary`, same fixture, asserts the new status.
- Same rename for `OpenChildIssue`.

Verified on workshop: `go vet ./...`, `go test ./... -timeout 240s` (18/18 packages green), `go build ./cmd/maestro/`.

## Out of scope

- Mission Control rendering of the `awaiting_dispatch` state distinctly («approved · waiting dispatcher» badge instead of treating it as another generic non-pending status). Small follow-up SPA change, separate from this Go-side fix.
- Race against two HTTP approve endpoints firing on the same approval ID — already covered by the existing payload_hash mismatch guard.

## Related

- #510 (PR merged today) — at-mint dedup for plain `pending` ↔ `pending` case. Necessary but not sufficient; this PR completes the dedup contract.
- #506 / PR #508 — reconcile-time rate-limit fallover.
- #511 — supervise watchdog.
- #512 / PR #514 — merge_pr planner rule.
- Phase 1 reliability plan: `Dev/Areas/maestro/handovers/2026-05-31-fleet-pause-resume-runbook.md`, `~/.claude/plans/serialized-gathering-perlis.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `ApprovalStatusAwaitingDispatch` to distinguish "approved, side-effect pending on a separate loop" from `execution_skipped` ("no action will happen"), then wires the dedup path and reconcile path in `state.go` to treat the new status as still-effective — closing the post-approve race where a fresh duplicate `pending` approval could be minted while the dispatcher hadn't yet ticked.

- **`internal/state/state.go`**: new `awaiting_dispatch` status constant; `markApprovalSuperseded`, `spawnWorkerApprovalMatchesSession`, and the `RecordPendingApprovalForDecision` dedup loop all extended to accept `AwaitingDispatch` alongside `Pending`.
- **`internal/approver/executor.go`**: `spawn_worker` and `open_child_issue` branches return `ApprovalStatusAwaitingDispatch` instead of `ApprovalStatusExecutionSkipped`.
- **Tests**: two new state-layer tests cover the race and reconcile scenarios; executor tests updated to assert the new status. However, the `executeApprovedApprovals` switch in `supervisor.go` is not updated and has no `case` for the new status, so the new status is never persisted — approvals currently land in the `default` branch and get written as `execution_failed` instead, leaving the race window open in production.

<h3>Confidence Score: 1/5</h3>

The fix is structurally incomplete: the status the executor returns is never written to disk because the caller switch in supervisor.go has no handler for it.

The `executeApprovedApprovals` function in `supervisor.go` is the only call site that translates executor results into state transitions. It handles `executed` and `execution_skipped` explicitly, then falls to a `default` that calls `MarkApprovalExecutionFailed`. With no case added for `awaiting_dispatch`, every `spawn_worker` and `open_child_issue` approval will be written as `execution_failed` — the same outcome as before this PR — and the dedup guard and reconcile changes in `state.go` will never trigger. The operator also now sees a misleading `execution_failed` status on what was a successful approval.

The unchanged `internal/supervisor/supervisor.go` (`executeApprovedApprovals`, lines 3132-3149) needs a new `case state.ApprovalStatusAwaitingDispatch` branch and a corresponding `MarkApprovalAwaitingDispatch` method in `state.go` before this fix is effective.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Not modified in this PR, but the unchanged switch in executeApprovedApprovals has no case for ApprovalStatusAwaitingDispatch — the new status is silently mapped to execution_failed at runtime, making the entire fix ineffective. |
| internal/state/state.go | Adds ApprovalStatusAwaitingDispatch const and extends markApprovalSuperseded, spawnWorkerApprovalMatchesSession, and RecordPendingApprovalForDecision dedup to include the new status; logic is correct in isolation but unreachable because the supervisor never writes the status to disk. |
| internal/approver/executor.go | spawn_worker and open_child_issue branches now return ApprovalStatusAwaitingDispatch instead of ApprovalStatusExecutionSkipped; the returned value is correct but the caller (supervisor.go) does not handle it. |
| internal/approver/executor_test.go | Renames and updates two existing tests to assert the new AwaitingDispatch status; coverage is correct and complete for the executor layer. |
| internal/state/state_test.go | Adds two well-structured tests covering the dedup-against-awaiting_dispatch and reconcile-supersedes-awaiting_dispatch cases; both tests directly mutate approval.Status in-memory to simulate the transition, so they pass today but would also pass before the supervisor.go fix lands — they do not catch the missing write path. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/state/state.go:631
**`ApprovalAuditAwaitingDispatch` is declared but never emitted**

The constant is defined alongside the other `ApprovalAudit*` peers, but no code path calls it. The parallel constants (`ApprovalAuditExecutionSkipped`, etc.) are all emitted inside the corresponding `MarkApproval*` methods; the missing `MarkApprovalAwaitingDispatch` method (see the `supervisor.go` comment) would be the natural site to emit this event. Until that method is added, the audit trail has no record of the `approved → awaiting_dispatch` transition.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(state,approver): introduce awaiting\_..."](https://github.com/befeast/maestro/commit/75db2a8505dee466d8c8be7ca9997589917741be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34803085)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->