### PR TITLE
feat(state,config,worker): per-session backend attribution timeline (#513, Phase 1.7)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,17 @@ type BackendDef struct {
 	ExtraArgs  []string `yaml:"extra_args"`
 	PromptMode string   `yaml:"prompt_mode"` // how to deliver prompt: "arg" (last argument), "stdin" (via stdin), "file" (file path as argument)
 	Enabled    *bool    `yaml:"enabled"`     // nil means enabled for backward compatibility
+
+	// #513: optional per-backend attribution metadata. Lets the
+	// dashboard / commit trailer record which provider+model actually
+	// produced the work, beyond the shim name. All four are optional;
+	// absent fields render as "—" in UI and are omitted from commit
+	// trailers. Backends that don't set them keep working unchanged
+	// (legacy behaviour preserved).
+	Provider string `yaml:"provider,omitempty"` // e.g. "anthropic", "openai", "groq"
+	Model    string `yaml:"model,omitempty"`    // e.g. "opus-4.8", "gpt-5.5", "llama-3.3-70b-versatile"
+	Variant  string `yaml:"variant,omitempty"`  // e.g. "opus[1m]", "fast", "sonnet"
+	Effort   string `yaml:"effort,omitempty"`   // e.g. "xhigh", "medium", "low"
 }
 
 func (b BackendDef) IsEnabled() bool {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -136,6 +136,30 @@ type Session struct {
 	RetryReason                 string            `json:"retry_reason,omitempty"`                   // current retry lifecycle reason, e.g. review_feedback
 	CheckpointFile              string            `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
 	DeploymentFinishedAt        *time.Time        `json:"deployment_finished_at,omitempty"`         // set when the post-merge deploy hook succeeds
+
+	// #513: per-segment attribution timeline. Every spawn / respawn /
+	// fallover appends a new entry; the previous entry's EndedAt is
+	// closed at the same moment. Records who actually produced the
+	// commits (provider/model/variant/effort) so the dashboard +
+	// commit trailer can show "first 12m on claude opus-4.8 xhigh,
+	// then 4m on codex gpt-5.5 medium after rate-limit fallover".
+	Attribution []BackendAttribution `json:"attribution,omitempty"`
+}
+
+// BackendAttribution is one segment of a session's backend timeline.
+// A session has at least one (the initial spawn) and gains more if the
+// rate-limit fallover or pipeline-phase machinery respawns it on a
+// different backend.
+type BackendAttribution struct {
+	Backend   string     `json:"backend"`              // shim name (claude, codex, freellm, opencode, …)
+	Provider  string     `json:"provider,omitempty"`   // anthropic, openai, groq, …
+	Model     string     `json:"model,omitempty"`      // opus-4.8, gpt-5.5, llama-3.3-70b-versatile, …
+	Variant   string     `json:"variant,omitempty"`    // opus[1m], fast, sonnet, …
+	Effort    string     `json:"effort,omitempty"`     // xhigh, medium, low, …
+	StartedAt time.Time  `json:"started_at"`           // when this segment became active
+	EndedAt   *time.Time `json:"ended_at,omitempty"`   // when the segment was closed; nil if still active
+	EndReason string     `json:"end_reason,omitempty"` // why the segment closed: "completed", "provider_limit", "fallover", "in_place_respawn", "killed"
+	Reason    string     `json:"reason,omitempty"`     // why this segment was started: "initial_spawn", "fallover", "in_place_respawn", "phase_transition"
 }
 
 // SessionAttention explains why a session needs operator attention and the

--- a/internal/worker/attribution.go
+++ b/internal/worker/attribution.go
@@ -1,0 +1,59 @@
+package worker
+
+import (
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// recordBackendAttribution appends a new BackendAttribution segment to
+// sess.Attribution and closes the previous one's EndedAt + EndReason.
+// Called from every place that sets sess.Backend (Start, Respawn,
+// RespawnInPlace) so the timeline records who actually produced the
+// commits across the session lifecycle.
+//
+// The metadata snapshot (provider/model/variant/effort) comes from the
+// matching config.BackendDef; absent fields are kept empty and omit
+// from JSON output, so a backend that doesn't declare metadata keeps
+// working unchanged.
+//
+// reason is one of "initial_spawn", "fallover", "in_place_respawn",
+// "phase_transition" — names the cause of this segment becoming active.
+// previousEndReason is the symmetric label for the segment being closed
+// ("provider_limit" for fallover triggered by rate limit, "completed"
+// when the worker finished cleanly, "killed" for forced respawn, etc).
+//
+// If sess is nil or backendName is empty the call is a no-op — defensive
+// against the test harness path where sess.Backend is set without going
+// through any of the three real entry points.
+func recordBackendAttribution(cfg *config.Config, sess *state.Session, backendName, reason, previousEndReason string, now time.Time) {
+	if sess == nil || backendName == "" {
+		return
+	}
+	now = now.UTC()
+
+	// Close the previous open segment (if any).
+	if n := len(sess.Attribution); n > 0 && sess.Attribution[n-1].EndedAt == nil {
+		ts := now
+		sess.Attribution[n-1].EndedAt = &ts
+		if previousEndReason != "" {
+			sess.Attribution[n-1].EndReason = previousEndReason
+		}
+	}
+
+	seg := state.BackendAttribution{
+		Backend:   backendName,
+		StartedAt: now,
+		Reason:    reason,
+	}
+	if cfg != nil {
+		if def, ok := cfg.Model.Backends[backendName]; ok {
+			seg.Provider = def.Provider
+			seg.Model = def.Model
+			seg.Variant = def.Variant
+			seg.Effort = def.Effort
+		}
+	}
+	sess.Attribution = append(sess.Attribution, seg)
+}

--- a/internal/worker/attribution_test.go
+++ b/internal/worker/attribution_test.go
@@ -1,0 +1,155 @@
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func attribCfgWithBackends() *config.Config {
+	return &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {
+					Cmd:      "claude",
+					Provider: "anthropic",
+					Model:    "opus-4.8",
+					Variant:  "opus[1m]",
+					Effort:   "xhigh",
+				},
+				"codex": {
+					Cmd:      "codex",
+					Provider: "openai",
+					Model:    "gpt-5.5",
+					Effort:   "medium",
+				},
+				"freellm": {
+					Cmd: "/home/god/.maestro/bin/maestro-freellm",
+					// Intentionally no metadata — backends without
+					// declared attribution still work; UI shows "—".
+				},
+			},
+		},
+	}
+}
+
+func TestRecordBackendAttribution_FirstCall_SnapshotsMetadata(t *testing.T) {
+	cfg := attribCfgWithBackends()
+	sess := &state.Session{}
+	now := time.Date(2026, 5, 31, 17, 0, 0, 0, time.UTC)
+
+	recordBackendAttribution(cfg, sess, "claude", "initial_spawn", "", now)
+
+	if got := len(sess.Attribution); got != 1 {
+		t.Fatalf("len(Attribution) = %d, want 1", got)
+	}
+	seg := sess.Attribution[0]
+	if seg.Backend != "claude" {
+		t.Fatalf("Backend = %q, want claude", seg.Backend)
+	}
+	if seg.Provider != "anthropic" || seg.Model != "opus-4.8" || seg.Variant != "opus[1m]" || seg.Effort != "xhigh" {
+		t.Fatalf("snapshot = %+v, want anthropic/opus-4.8/opus[1m]/xhigh", seg)
+	}
+	if seg.Reason != "initial_spawn" {
+		t.Fatalf("Reason = %q, want initial_spawn", seg.Reason)
+	}
+	if seg.EndedAt != nil {
+		t.Fatalf("EndedAt = %v, want nil for active segment", seg.EndedAt)
+	}
+	if !seg.StartedAt.Equal(now) {
+		t.Fatalf("StartedAt = %v, want %v", seg.StartedAt, now)
+	}
+}
+
+func TestRecordBackendAttribution_SecondCall_ClosesPreviousAndAppends(t *testing.T) {
+	cfg := attribCfgWithBackends()
+	sess := &state.Session{}
+
+	t0 := time.Date(2026, 5, 31, 17, 0, 0, 0, time.UTC)
+	t1 := t0.Add(12 * time.Minute)
+
+	recordBackendAttribution(cfg, sess, "claude", "initial_spawn", "", t0)
+	recordBackendAttribution(cfg, sess, "codex", "fallover", "fallover", t1)
+
+	if got := len(sess.Attribution); got != 2 {
+		t.Fatalf("len(Attribution) = %d, want 2", got)
+	}
+
+	prev := sess.Attribution[0]
+	if prev.EndedAt == nil || !prev.EndedAt.Equal(t1) {
+		t.Fatalf("prev.EndedAt = %v, want %v", prev.EndedAt, t1)
+	}
+	if prev.EndReason != "fallover" {
+		t.Fatalf("prev.EndReason = %q, want fallover", prev.EndReason)
+	}
+
+	next := sess.Attribution[1]
+	if next.Backend != "codex" || next.Provider != "openai" || next.Model != "gpt-5.5" || next.Effort != "medium" {
+		t.Fatalf("next segment = %+v, want codex/openai/gpt-5.5/medium", next)
+	}
+	if next.Reason != "fallover" {
+		t.Fatalf("next.Reason = %q, want fallover", next.Reason)
+	}
+	if next.EndedAt != nil {
+		t.Fatalf("next.EndedAt should still be open")
+	}
+}
+
+func TestRecordBackendAttribution_BackendWithoutMetadata_StillWorks(t *testing.T) {
+	cfg := attribCfgWithBackends()
+	sess := &state.Session{}
+	now := time.Date(2026, 5, 31, 17, 0, 0, 0, time.UTC)
+
+	recordBackendAttribution(cfg, sess, "freellm", "fallover", "fallover", now)
+
+	if got := len(sess.Attribution); got != 1 {
+		t.Fatalf("len(Attribution) = %d, want 1", got)
+	}
+	seg := sess.Attribution[0]
+	if seg.Backend != "freellm" {
+		t.Fatalf("Backend = %q, want freellm", seg.Backend)
+	}
+	// All metadata fields are absent -> empty strings -> omitempty in JSON.
+	if seg.Provider != "" || seg.Model != "" || seg.Variant != "" || seg.Effort != "" {
+		t.Fatalf("expected empty metadata, got %+v", seg)
+	}
+}
+
+func TestRecordBackendAttribution_NilSession_NoOp(t *testing.T) {
+	cfg := attribCfgWithBackends()
+	// Should not panic.
+	recordBackendAttribution(cfg, nil, "claude", "initial_spawn", "", time.Now())
+}
+
+func TestRecordBackendAttribution_EmptyBackendName_NoOp(t *testing.T) {
+	cfg := attribCfgWithBackends()
+	sess := &state.Session{}
+	recordBackendAttribution(cfg, sess, "", "initial_spawn", "", time.Now())
+	if got := len(sess.Attribution); got != 0 {
+		t.Fatalf("len(Attribution) = %d, want 0 (empty backendName must be no-op)", got)
+	}
+}
+
+func TestRecordBackendAttribution_UnknownBackend_NoMetadata(t *testing.T) {
+	cfg := attribCfgWithBackends()
+	sess := &state.Session{}
+	now := time.Date(2026, 5, 31, 17, 0, 0, 0, time.UTC)
+
+	// Backend name not in cfg.Model.Backends — segment is still added,
+	// just without metadata snapshot.
+	recordBackendAttribution(cfg, sess, "ghost", "initial_spawn", "", now)
+
+	if got := len(sess.Attribution); got != 1 {
+		t.Fatalf("len(Attribution) = %d, want 1 (unknown backend still records segment)", got)
+	}
+	seg := sess.Attribution[0]
+	if seg.Backend != "ghost" {
+		t.Fatalf("Backend = %q, want ghost", seg.Backend)
+	}
+	if seg.Provider != "" || seg.Model != "" {
+		t.Fatalf("unknown backend should have empty metadata, got %+v", seg)
+	}
+}

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -190,6 +190,10 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 	sess.FinishedAt = nil
 	sess.Status = state.StatusRunning
 	sess.Backend = backendName
+	// #513: in-place respawn (post-checkpoint resume) — record a new
+	// segment so the timeline shows where the previous segment ended
+	// and the new one began.
+	recordBackendAttribution(cfg, sess, backendName, "in_place_respawn", "in_place_respawn", time.Now())
 	sess.TokensUsedAttempt = 0
 	sess.NotifiedCIFail = false
 	sess.LastNotifiedStatus = ""

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -175,6 +175,8 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		Status:      state.StatusRunning,
 		Backend:     backendName,
 	}
+	// #513: stamp the first attribution segment for this session.
+	recordBackendAttribution(cfg, s.Sessions[slotName], backendName, "initial_spawn", "", startedAt)
 	s.ReconcileSpawnWorkerApprovalsForStartedSession(slotName, s.Sessions[slotName], startedAt)
 
 	return slotName, nil
@@ -310,6 +312,8 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	sess.Status = state.StatusRunning
 	sess.PRNumber = 0
 	sess.Backend = backendName
+	// #513: stamp the fallover attribution segment.
+	recordBackendAttribution(cfg, sess, backendName, "fallover", "fallover", time.Now())
 	sess.NotifiedCIFail = false
 	sess.LastNotifiedStatus = ""
 	sess.LastOutputHash = ""


### PR DESCRIPTION
## What

Closes #513. Records per-segment attribution for every backend a session uses across its lifecycle. After PR #508 (#506 reconcile fallover), a single session can run on multiple backends in sequence — started on `claude opus-4.8 xhigh`, finished on `codex gpt-5.5 medium` after a rate-limit. Until now only the **last** backend was kept on `sess.Backend`; the previous segments were lost, and there was no record of which model produced which commits.

## User ask

> «я хочу знать точно, какой код какой моделью написан, e.g. `opus-4.8 fast effort xhigh`, provider anthropic»

## Shape

`config.BackendDef` gains four optional fields (`omitempty` — legacy configs keep working):

```yaml
backends:
  claude:
    cmd: "claude --model opus[1m] --effort xhigh"
    provider: anthropic       # NEW
    model: opus-4.8           # NEW
    variant: opus[1m]         # NEW
    effort: xhigh             # NEW
  codex:
    cmd: "/home/god/.bun/bin/codex --model gpt-5.5 -c model_reasoning_effort=medium"
    provider: openai
    model: gpt-5.5
    effort: medium
```

`state.Session` gains an `Attribution []BackendAttribution` slice. Each segment captures **what** (backend / provider / model / variant / effort), **when** (started_at / ended_at), **why** (reason / end_reason).

```go
type BackendAttribution struct {
    Backend   string     // shim name
    Provider  string     // anthropic, openai, groq, …
    Model     string     // opus-4.8, gpt-5.5, llama-3.3-70b-versatile, …
    Variant   string
    Effort    string
    StartedAt time.Time
    EndedAt   *time.Time // nil while active
    EndReason string     // "fallover", "in_place_respawn", "killed", …
    Reason    string     // "initial_spawn", "fallover", "in_place_respawn", …
}
```

## Implementation

A single helper `worker.recordBackendAttribution(cfg, sess, backend, reason, prevEndReason, now)` is the **only ingress** — it snapshots the matching `BackendDef` metadata, closes the previous open segment, and appends the new one.

Wired into all three `sess.Backend = backendName` sites:

- `worker.Start` → `reason="initial_spawn"` (no previous segment).
- `worker.Respawn` → `reason="fallover"`, prev `EndReason="fallover"`.
- `worker.RespawnInPlace` (checkpoint resume) → `reason="in_place_respawn"`, prev `EndReason="in_place_respawn"`.

`phase.go` (pipeline phase transitions) is intentionally NOT touched in this PR — phase changes don't change the backend, so a dedicated follow-up will decide whether they get their own segment kind.

### Defensive

- `nil sess` → no-op.
- empty backend → no-op.
- unknown backend (config drift) → segment still recorded with empty metadata, so the timeline doesn't lose entries when configs and state disagree.

## Tests

`internal/worker/attribution_test.go` — 6 cases covering:

- first call snapshots `BackendDef` metadata correctly.
- second call closes prev segment `EndedAt` + `EndReason` and appends the new segment with the new backend's metadata.
- backend declared in cfg but without metadata fields → empty fields.
- nil session and empty backend → no-op.
- unknown backend name → segment still recorded, no metadata.

Verified on workshop: `go vet ./...`, `go test ./... -timeout 240s` (18/18 packages green), `go build ./cmd/maestro/`.

## Out of scope (separate PRs / tasks)

- Annotating the actual `maestro.d/*.yaml` configs with the new metadata fields. Pure config change, deferred so the code change is reviewable in isolation. Tracked as Phase 1.7b in the local plan.
- Mission Control SPA rendering of `Attribution[]` (Phase 3 UX work).
- Commit-trailer `Maestro-Backend: <provider>/<model>/<variant>/<effort>` written by the worker. Will land separately so this PR stays scoped to data shape.

## Related

- #506 / PR #508 (merged) — reconcile fallover that creates the multi-backend timeline this PR records.
- #515 / PR #517 — awaiting_dispatch race fix (parallel).
- Phase 1 reliability plan: `Dev/Areas/maestro/handovers/2026-05-31-fleet-pause-resume-runbook.md`, `~/.claude/plans/serialized-gathering-perlis.md`.
- UX gap list: `Dev/Areas/maestro/specs/maestro-ui-flow-2026-05-31.md` Gap 3.

Found while user reviewed live MC UI today (2026-05-31) and noted «модель ВООБЩЕ нигде не указана».

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces per-segment backend attribution to `state.Session`, recording the provider/model/variant/effort metadata for each backend a session uses across its lifecycle. The core logic lives in a single `recordBackendAttribution` helper that is wired into the three spawn sites (`Start`, `Respawn`, `RespawnInPlace`).

- `config.BackendDef` gains four optional `omitempty` fields (`Provider`, `Model`, `Variant`, `Effort`), preserving backward compatibility with existing configs.
- `state.Session` gains an `Attribution []BackendAttribution` slice; each segment records what ran, when, why it started, and why it ended.
- Six table-driven tests cover the main paths: first-call snapshot, second-call close-and-append, metadata-free backend, nil session, empty name, and unknown backend.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the understanding that the split-clock discrepancy between sess.StartedAt and the attribution segment's StartedAt in Respawn and RespawnInPlace remains unresolved from the prior review cycle.

The core attribution helper and data model are correct. Start correctly shares a single captured timestamp. However, Respawn (worker.go) and RespawnInPlace (checkpoint.go) each call time.Now() twice — once for sess.StartedAt and once passed to recordBackendAttribution — so the attribution segment's StartedAt will always be slightly later than the session's own StartedAt for the same spawn event. This was flagged in the previous review and remains present in the diff.

internal/worker/worker.go (Respawn) and internal/worker/checkpoint.go (RespawnInPlace) — both still contain the dual time.Now() calls that cause the attribution segment's StartedAt to drift from sess.StartedAt.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/worker/attribution.go | New helper — correctly closes the previous open segment and appends the new one using the passed-in timestamp. Nil-safe and handles unknown backends gracefully. |
| internal/worker/worker.go | Start correctly passes a single captured startedAt to both sess.StartedAt and recordBackendAttribution. Respawn calls time.Now() twice — once for sess.StartedAt and once inside recordBackendAttribution — leaving the attribution segment's StartedAt strictly later than the session's StartedAt (flagged in prior review). |
| internal/worker/checkpoint.go | RespawnInPlace has the same split-clock problem as Respawn: sess.StartedAt and the attribution segment's StartedAt are captured by two separate time.Now() calls (flagged in prior review). |
| internal/config/config.go | Adds four omitempty attribution metadata fields to BackendDef; backward-compatible and cleanly structured. |
| internal/state/state.go | Adds Attribution slice and BackendAttribution type to Session; JSON tags are consistent and omitempty is applied correctly to optional fields. |
| internal/worker/attribution_test.go | Six focused tests cover the key paths; deterministic timestamps are used throughout, avoiding flakiness. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `internal/worker/worker.go`, line 310-316 ([link](https://github.com/befeast/maestro/blob/4793e551e2532bbec42574c274e4bcd5b28738f0/internal/worker/worker.go#L310-L316)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `sess.StartedAt` is set with one `time.Now()` call and then `recordBackendAttribution` is called with a second, separate `time.Now()` a few lines later. Any code running between those two calls (status/field assignments) advances the clock, so the attribution segment's `StartedAt` will be strictly later than `sess.StartedAt` for the same spawn event. `Start` avoids this correctly by capturing a single `startedAt` and passing it to both places. Using the same captured timestamp here keeps the session clock and the attribution timeline consistent.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/worker/worker.go
   Line: 310-316

   Comment:
   `sess.StartedAt` is set with one `time.Now()` call and then `recordBackendAttribution` is called with a second, separate `time.Now()` a few lines later. Any code running between those two calls (status/field assignments) advances the clock, so the attribution segment's `StartedAt` will be strictly later than `sess.StartedAt` for the same spawn event. `Start` avoids this correctly by capturing a single `startedAt` and passing it to both places. Using the same captured timestamp here keeps the session clock and the attribution timeline consistent.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/worker/checkpoint.go`, line 189-196 ([link](https://github.com/befeast/maestro/blob/4793e551e2532bbec42574c274e4bcd5b28738f0/internal/worker/checkpoint.go#L189-L196)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> Same split-clock issue as in `Respawn`: `sess.StartedAt` is captured first, then `recordBackendAttribution` is called with a fresh `time.Now()` after several intermediate assignments. The attribution segment's `StartedAt` ends up later than `sess.StartedAt` even though both are meant to mark the same instant. Capturing a single `now` and passing it to both eliminates the discrepancy.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/worker/checkpoint.go
   Line: 189-196

   Comment:
   Same split-clock issue as in `Respawn`: `sess.StartedAt` is captured first, then `recordBackendAttribution` is called with a fresh `time.Now()` after several intermediate assignments. The attribution segment's `StartedAt` ends up later than `sess.StartedAt` even though both are meant to mark the same instant. Capturing a single `now` and passing it to both eliminates the discrepancy.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `internal/worker/worker.go`, line 310-316 ([link](https://github.com/befeast/maestro/blob/34560381044959e541b6340e765ff86e0e7e48b8/internal/worker/worker.go#L310-L316)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `sess.StartedAt` is assigned from one `time.Now()` call and the attribution segment's `StartedAt` is captured by a second, separate `time.Now()` call a few lines later. Any work done between the two calls (status/field assignments) advances the clock, so the attribution segment will always start strictly *after* `sess.StartedAt` for the same spawn event. `Start` avoids this correctly by capturing a single `startedAt` and passing it to both. Using one shared timestamp here keeps `sess.StartedAt` and the segment boundary in sync.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/worker/worker.go
   Line: 310-316

   Comment:
   `sess.StartedAt` is assigned from one `time.Now()` call and the attribution segment's `StartedAt` is captured by a second, separate `time.Now()` call a few lines later. Any work done between the two calls (status/field assignments) advances the clock, so the attribution segment will always start strictly *after* `sess.StartedAt` for the same spawn event. `Start` avoids this correctly by capturing a single `startedAt` and passing it to both. Using one shared timestamp here keeps `sess.StartedAt` and the segment boundary in sync.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

4. `internal/worker/checkpoint.go`, line 189-196 ([link](https://github.com/befeast/maestro/blob/34560381044959e541b6340e765ff86e0e7e48b8/internal/worker/checkpoint.go#L189-L196)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `sess.StartedAt` is captured with one `time.Now()` call while the attribution segment's `StartedAt` is captured by a separate `time.Now()` call after several field assignments, making the segment's start timestamp strictly later than the session's `StartedAt`. The same split is present in `Respawn`; `Start` avoids it by capturing a single `startedAt`. Capturing one `now` here and passing it to both keeps the two timestamps identical.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/worker/checkpoint.go
   Line: 189-196

   Comment:
   `sess.StartedAt` is captured with one `time.Now()` call while the attribution segment's `StartedAt` is captured by a separate `time.Now()` call after several field assignments, making the segment's start timestamp strictly later than the session's `StartedAt`. The same split is present in `Respawn`; `Start` avoids it by capturing a single `startedAt`. Capturing one `now` here and passing it to both keeps the two timestamps identical.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["feat(state,config,worker): per-session b..."](https://github.com/befeast/maestro/commit/e73a78bbe80c8b70eae152446249ce7ab19614b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34804057)</sub>

<!-- /greptile_comment -->