### PR TITLE
fix(state,supervisor): wire AwaitingDispatch through executor switch (#515 follow-up; closes the zombie spawn_worker loop)

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2390,6 +2390,34 @@ func (s *State) MarkApprovalExecutionSkipped(id string, now time.Time, actor, re
 	return approval, nil
 }
 
+// MarkApprovalAwaitingDispatch transitions approved → awaiting_dispatch
+// with an audit reason. Used for verbs whose side effect lives on a
+// separate loop (spawn_worker — the dispatcher tick allocates the slot;
+// open_child_issue — the operator creates the child until the
+// safe-action executor lands). Distinct from ExecutionSkipped: a
+// dispatcher loop will resolve this approval, dedup must keep treating
+// it as effective until then.
+func (s *State) MarkApprovalAwaitingDispatch(id string, now time.Time, actor, reason string) (*Approval, error) {
+	approval, ok := s.FindApproval(id)
+	if !ok {
+		return nil, ErrApprovalNotFound
+	}
+	if approval.Status != ApprovalStatusApproved {
+		return approval, ErrApprovalNotApproved
+	}
+	approval.Status = ApprovalStatusAwaitingDispatch
+	approval.UpdatedAt = normalizedTime(now)
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              approval.UpdatedAt,
+		Event:           ApprovalAuditAwaitingDispatch,
+		Actor:           actor,
+		Reason:          reason,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: approval.TargetStateHash,
+	})
+	return approval, nil
+}
+
 // ValidateSlotID is the canonical slot-id validator used at EVERY
 // state-write ingress (#490 / premortem #5). A slot id names a session
 // in `state.Sessions` and is later concatenated into a worktree path

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1849,6 +1849,45 @@ func TestReconcileSpawnWorkerApprovalsSupersedesAwaitingDispatch(t *testing.T) {
 	}
 }
 
+// #515 follow-up: MarkApprovalAwaitingDispatch transitions an approved
+// approval to awaiting_dispatch with an audit entry, mirroring the
+// existing MarkApprovalExecuted/Failed/Skipped helpers. Idempotency
+// guarantee: not-approved input returns ErrApprovalNotApproved.
+func TestMarkApprovalAwaitingDispatch_TransitionsApprovedToAwaiting(t *testing.T) {
+	now := time.Date(2026, 5, 31, 17, 0, 0, 0, time.UTC)
+	s := NewState()
+	a := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+	if a == nil {
+		t.Fatal("approval was nil")
+	}
+	a.Status = ApprovalStatusApproved
+
+	updated, err := s.MarkApprovalAwaitingDispatch(a.ID, now.Add(time.Minute), "supervisor", "test reason")
+	if err != nil {
+		t.Fatalf("MarkApprovalAwaitingDispatch: %v", err)
+	}
+	if updated.Status != ApprovalStatusAwaitingDispatch {
+		t.Fatalf("status = %q, want awaiting_dispatch", updated.Status)
+	}
+	if got := updated.Audit[len(updated.Audit)-1].Event; got != ApprovalAuditAwaitingDispatch {
+		t.Fatalf("last audit event = %q, want awaiting_dispatch", got)
+	}
+	if got := updated.Audit[len(updated.Audit)-1].Reason; got != "test reason" {
+		t.Fatalf("audit reason = %q, want %q", got, "test reason")
+	}
+}
+
+func TestMarkApprovalAwaitingDispatch_RefusesNonApproved(t *testing.T) {
+	now := time.Date(2026, 5, 31, 17, 0, 0, 0, time.UTC)
+	s := NewState()
+	a := s.RecordPendingApprovalForDecision(testApprovalDecision(now), now)
+	// Status stays Pending; helper must refuse.
+	_, err := s.MarkApprovalAwaitingDispatch(a.ID, now, "supervisor", "x")
+	if err != ErrApprovalNotApproved {
+		t.Fatalf("err = %v, want ErrApprovalNotApproved", err)
+	}
+}
+
 func TestReconcileSpawnWorkerApprovalsForStartedSession(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
 	s := NewState()

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -3138,6 +3138,17 @@ func executeApprovedApprovals(cfg *config.Config, st *state.State, reader Reader
 			if _, err := st.MarkApprovalExecutionSkipped(a.ID, now, "supervisor", res.Summary); err != nil {
 				fmt.Fprintf(os.Stderr, "[supervisor] mark approval %s skipped: %v\n", a.ID, err)
 			}
+		case state.ApprovalStatusAwaitingDispatch:
+			// #515 follow-up: spawn_worker / open_child_issue executor
+			// returns AwaitingDispatch so dedup keeps treating the
+			// approval as effective until the dispatcher loop resolves
+			// it. Without this case the default branch flipped these
+			// to execution_failed and the next supervisor cycle minted
+			// a duplicate pending — exact zombie loop seen on dogfood
+			// 2026-05-31 17:45–17:55 UTC for issue #487.
+			if _, err := st.MarkApprovalAwaitingDispatch(a.ID, now, "supervisor", res.Summary); err != nil {
+				fmt.Fprintf(os.Stderr, "[supervisor] mark approval %s awaiting_dispatch: %v\n", a.ID, err)
+			}
 		default:
 			msg := res.Summary
 			if msg == "" && res.Err != nil {


### PR DESCRIPTION
## What

Live regression: PR #517 (introduce `ApprovalStatusAwaitingDispatch`) wired the new status into the executor return path but missed the supervisor's `executeApprovedApprovals` switch — `default` fell through to `MarkApprovalExecutionFailed`. Spawn_worker / open_child_issue approvals went `approved` → `execution_failed` instead of `awaiting_dispatch`. Dedup couldn't see execution_failed as effective, fresh pending duplicate appeared on next cycle. Zombie loop — see today's `approval-sup-20260531T162300` for #487.

## Fix

- `state.MarkApprovalAwaitingDispatch` helper (mirrors ExecutionSkipped shape, refuses non-approved input with `ErrApprovalNotApproved`).
- `supervisor.executeApprovedApprovals` switch gains explicit case for `ApprovalStatusAwaitingDispatch` → `MarkApprovalAwaitingDispatch`.

## Tests

`internal/state/state_test.go`:
- `TestMarkApprovalAwaitingDispatch_TransitionsApprovedToAwaiting` — happy path.
- `TestMarkApprovalAwaitingDispatch_RefusesNonApproved` — idempotency guarantee.

End-to-end on dogfood after this lands: approve spawn_worker, observe approval transition to `awaiting_dispatch` (not execution_failed); next supervisor cycle's dedup returns the existing record instead of minting a duplicate.

Verified on workshop: `go vet`, `go test ./...` (18/18 green), `go build`.

## Out of scope

Whether `Result.Status -> Mark... helper` should be a single registry so this class of "new status added to executor, switch left behind" can't recur. Filed separately if it's worth the abstraction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a live zombie loop where `spawn_worker` and `open_child_issue` approvals were incorrectly landing in `execution_failed` instead of `awaiting_dispatch`, causing the dedup logic to treat them as non-effective and mint a fresh duplicate on every supervisor cycle.

- Adds `MarkApprovalAwaitingDispatch` to `state.go`, mirroring the existing `MarkApprovalExecutionSkipped` shape with an `approved`-only guard and a full audit entry.
- Wires `ApprovalStatusAwaitingDispatch` as an explicit case in `executeApprovedApprovals`' switch so it no longer falls through to the `default` / `MarkApprovalExecutionFailed` branch.
- Covers the new helper with a happy-path test and an idempotency-guard test.

<h3>Confidence Score: 5/5</h3>

Targeted two-site fix; the new state helper and switch case are consistent with every existing pattern in the file.

The change is minimal and mechanical: a new Mark* helper that follows the exact same structure as its siblings, and one new switch case that routes to it. The guard (approved-only) and audit-entry shape are identical to the adjacent helpers. Tests cover both the transition and the guard. No pre-existing invariants are disturbed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds MarkApprovalAwaitingDispatch helper mirroring the existing Mark* pattern; correctly guards against non-approved input and appends an audit entry. |
| internal/state/state_test.go | Two focused unit tests covering the happy path and the ErrApprovalNotApproved guard; no gaps relative to the helper's contract. |
| internal/supervisor/supervisor.go | Adds explicit ApprovalStatusAwaitingDispatch case to the executeApprovedApprovals switch, routing to MarkApprovalAwaitingDispatch instead of falling through to MarkApprovalExecutionFailed. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(state,supervisor): wire AwaitingDisp..."](https://github.com/befeast/maestro/commit/57fd5b7ecceb268983b759dd479489ad3c797772) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34809020)</sub>

<!-- /greptile_comment -->