### PR TITLE
fix(config): reject non_agentic backends in worker chain (#507, Phase 1.4)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,18 @@ type BackendDef struct {
 	Model    string `yaml:"model,omitempty"`    // e.g. "opus-4.8", "gpt-5.5", "llama-3.3-70b-versatile"
 	Variant  string `yaml:"variant,omitempty"`  // e.g. "opus[1m]", "fast", "sonnet"
 	Effort   string `yaml:"effort,omitempty"`   // e.g. "xhigh", "medium", "low"
+
+	// #507: NonAgentic marks a backend that is a TEXT-COMPLETION helper,
+	// not an agentic CLI capable of producing a real PR. Such a backend
+	// MUST NOT be used as model.default or in model.fallback_backends —
+	// the worker prompt assumes file reads/writes, bash exec, git/gh
+	// operations. A non-agentic backend running as a worker emits the
+	// steps as TEXT into its log, never executes them, and the
+	// supervisor reconciles to dead with no PR. Found live 2026-05-30
+	// (sup-84 wrote a plausible Go test scaffold + git/gh commands as
+	// strings, no commits or PR materialised). config.parse rejects
+	// any config that wires a NonAgentic backend into the worker chain.
+	NonAgentic bool `yaml:"non_agentic,omitempty"`
 }
 
 func (b BackendDef) IsEnabled() bool {
@@ -619,6 +631,25 @@ func parse(data []byte) (*Config, error) {
 	// Ensure the default backend is always present in the map
 	if _, ok := cfg.Model.Backends[cfg.Model.Default]; !ok {
 		cfg.Model.Backends[cfg.Model.Default] = BackendDef{Cmd: cfg.Model.Default}
+	}
+
+	// #507: refuse to start when a non-agentic backend is wired into the
+	// worker chain. A non-agentic backend (e.g. the maestro-freellm
+	// text-completion shim) must be available for supervisor sub-tasks,
+	// but spawning a worker against it produces fake-PR sessions —
+	// instructions emitted as text, never executed. Fail fast at config
+	// parse so the daemon never even tries.
+	if def, ok := cfg.Model.Backends[cfg.Model.Default]; ok && def.NonAgentic {
+		return nil, fmt.Errorf("config: model.default = %q which is marked non_agentic; non-agentic backends cannot drive workers (they emit instructions as text, never execute git/gh). Pick an agentic backend (claude, codex, opencode, ...) and keep the non-agentic helper available for supervisor sub-tasks only", cfg.Model.Default)
+	}
+	for _, fb := range cfg.Model.FallbackBackends {
+		def, ok := cfg.Model.Backends[fb]
+		if !ok {
+			continue // unknown backend names are caught elsewhere; we only gate non-agentic here.
+		}
+		if def.NonAgentic {
+			return nil, fmt.Errorf("config: model.fallback_backends includes %q which is marked non_agentic; the fallback chain is the worker chain — a non-agentic entry would produce fake-PR sessions when paid backends are exhausted. Remove %q from fallback_backends and use it only for supervisor sub-tasks", fb, fb)
+		}
 	}
 
 	// Supervisor defaults

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1344,6 +1344,93 @@ model:
 	}
 }
 
+// #507: a backend marked non_agentic must not appear as model.default.
+// Parse-time validation rejects the config so the daemon never starts
+// with a fake-PR generator wired as the worker entry point.
+func TestParse_RejectsNonAgenticAsDefault(t *testing.T) {
+	yaml := []byte(`
+repo: owner/repo
+local_path: /tmp/repo
+worktree_base: /tmp/worktrees
+session_prefix: x
+model:
+  default: freellm
+  backends:
+    freellm:
+      cmd: /bin/echo
+      non_agentic: true
+    claude:
+      cmd: claude
+`)
+	if _, err := parse(yaml); err == nil {
+		t.Fatal("expected parse to refuse default=freellm with non_agentic=true")
+	} else if !strings.Contains(err.Error(), "non_agentic") {
+		t.Fatalf("error = %v, want substring \"non_agentic\"", err)
+	}
+}
+
+// #507: a non-agentic backend in fallback_backends is also rejected —
+// the fallback chain IS the worker chain.
+func TestParse_RejectsNonAgenticInFallback(t *testing.T) {
+	yaml := []byte(`
+repo: owner/repo
+local_path: /tmp/repo
+worktree_base: /tmp/worktrees
+session_prefix: x
+model:
+  default: claude
+  fallback_backends: [codex, freellm]
+  backends:
+    claude:
+      cmd: claude
+    codex:
+      cmd: codex
+    freellm:
+      cmd: /bin/echo
+      non_agentic: true
+`)
+	if _, err := parse(yaml); err == nil {
+		t.Fatal("expected parse to refuse freellm in fallback_backends when non_agentic=true")
+	} else if !strings.Contains(err.Error(), "non_agentic") {
+		t.Fatalf("error = %v, want substring \"non_agentic\"", err)
+	} else if !strings.Contains(err.Error(), "freellm") {
+		t.Fatalf("error = %v, want substring \"freellm\"", err)
+	}
+}
+
+// #507: a non-agentic backend that is NOT in the worker chain (only
+// declared in backends, neither default nor fallback) is allowed —
+// supervisor sub-tasks (label classify, summary) can still call it.
+func TestParse_AllowsNonAgenticOutsideWorkerChain(t *testing.T) {
+	yaml := []byte(`
+repo: owner/repo
+local_path: /tmp/repo
+worktree_base: /tmp/worktrees
+session_prefix: x
+model:
+  default: claude
+  fallback_backends: [codex]
+  backends:
+    claude:
+      cmd: claude
+    codex:
+      cmd: codex
+    freellm:
+      cmd: /bin/echo
+      non_agentic: true
+`)
+	cfg, err := parse(yaml)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Model.Backends["freellm"].NonAgentic != true {
+		t.Fatal("freellm NonAgentic flag was lost")
+	}
+	if cfg.Model.Default != "claude" {
+		t.Fatalf("Default = %q, want claude", cfg.Model.Default)
+	}
+}
+
 func TestParse_MaxConcurrentByStateDefault(t *testing.T) {
 	yaml := `repo: owner/repo`
 	cfg, err := parse([]byte(yaml))


### PR DESCRIPTION
Closes #507. `config.BackendDef` gains `NonAgentic bool` (yaml: `non_agentic`). `config.parse` refuses configs that wire a non-agentic backend as `model.default` or in `model.fallback_backends`. Backends declared in `backends:` but not in the worker chain are allowed (so freellm stays available as a text-completion helper for supervisor sub-tasks).

Live finding 2026-05-30: emergency flip to default=freellm produced sup-84 that wrote agentic instructions as TEXT into its log (`git commit`, `gh pr create` commands as strings, no execution). Supervisor reconciled to dead, fleet looked healthy but produced nothing. The validator is the cheapest defense — startup error instead of fake-PR loop.

3 new tests in `config_test.go` cover: default rejection, fallback rejection, allow outside worker chain (NonAgentic flag preserved). `go test ./...` 18/18 green, `go vet` clean.

Companion ops change (separate from this PR diff): `workshop:/home/god/.maestro/maestro.d/maestro-supervisor-dogfood.yaml` has `non_agentic: true` set on the freellm backend and freellm dropped from `fallback_backends`. Same change pending for the four .paused configs as part of the resume runbook in `Dev/Areas/maestro/handovers/2026-05-31-fleet-pause-resume-runbook.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `NonAgentic bool` field to `BackendDef` and a parse-time validator that rejects configs wiring a non-agentic backend as `model.default` or in `model.fallback_backends`, addressing the live incident where `default=freellm` caused a supervisor to emit git/gh instructions as text without executing them.

- `config.go`: `NonAgentic` field added with clear doc comment; two guard blocks in `parse` return descriptive errors for the default and fallback cases, placed immediately after the auto-inject block so the map lookup at the default guard is always a hit.
- `config_test.go`: three tests cover default rejection, fallback rejection (checking both the error substring and the backend name), and confirmed pass-through for a non-agentic backend declared outside the worker chain with flag preservation verified.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, guarded entirely inside parse, and fails fast on startup rather than touching any runtime path.

Both changed files are self-contained: the new field defaults to false (zero value), so existing configs that omit non_agentic are unaffected. The validation logic is straightforward and the three new tests exercise every branch of the guard. No runtime behaviour is changed; the only new outcome is a startup error for configs that were already silently broken.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds NonAgentic field to BackendDef and two parse-time guards rejecting non-agentic backends as model.default or in fallback_backends; logic is correct and the ok-check at the default guard is harmlessly redundant (default is always guaranteed in the map by the auto-inject block above it). |
| internal/config/config_test.go | Three targeted tests cover the three meaningful cases: default rejection, fallback rejection, and allow-outside-worker-chain with flag preservation; all are well-structured and the test file does not import the yaml package so there is no identifier shadowing issue. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(config): reject non\_agentic backends..."](https://github.com/befeast/maestro/commit/509a3c85229d9e1916e629b7fabb3bbd58dd4b3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34811167)</sub>

<!-- /greptile_comment -->