### PR TITLE
M-009: UI: add 7-day issue throughput sparkline to fleet stats

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -266,6 +266,38 @@ func TestFleetThroughputBucketsAggregateSevenDayWindows(t *testing.T) {
 	}
 }
 
+// Throughput is summed across projects: addFleetThroughputSummary is invoked
+// once per project in snapshot(), so the bucket counts must accumulate rather
+// than reset between calls.
+func TestFleetThroughputBucketsAggregateAcrossProjects(t *testing.T) {
+	now := time.Date(2026, 5, 2, 15, 0, 0, 0, time.UTC)
+	donePR := func(pr int, finishedAt time.Time) fleetWorkerState {
+		return fleetWorkerState{Status: string(state.StatusDone), PRNumber: pr, FinishedAt: finishedAt.Format(time.RFC3339)}
+	}
+	projectOne := []fleetWorkerState{
+		donePR(101, now.Add(-2*time.Hour)),
+		donePR(102, now.Add(-24*time.Hour)),
+	}
+	projectTwo := []fleetWorkerState{
+		donePR(201, now.Add(-2*time.Hour)),
+		donePR(202, now.Add(-6*24*time.Hour)),
+	}
+	projectThree := []fleetWorkerState(nil)
+
+	buckets := newFleetThroughputBuckets(now, 7)
+	addFleetThroughputSummary(buckets, projectOne)
+	addFleetThroughputSummary(buckets, projectTwo)
+	addFleetThroughputSummary(buckets, projectThree)
+
+	wantCounts := []int{1, 0, 0, 0, 0, 1, 2}
+	if got := buckets.Counts(); !reflect.DeepEqual(got, wantCounts) {
+		t.Fatalf("counts = %v, want %v", got, wantCounts)
+	}
+	if buckets.Total() != 4 {
+		t.Fatalf("total = %d, want 4", buckets.Total())
+	}
+}
+
 func TestFleetAPIReviewRetryLifecycleDisplay(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now().UTC()

--- a/internal/server/web/design-source/mc/mc-atoms.jsx
+++ b/internal/server/web/design-source/mc/mc-atoms.jsx
@@ -85,9 +85,9 @@ function Sparkline({ data, warm = false }) {
 // ============================================================
 // Stat tile
 // ============================================================
-function Stat({ label, value, of, sub, tone = "info", live, sparkline, sparkWarm, onClick }) {
+function Stat({ label, value, of, sub, tone = "info", live, sparkline, sparkWarm, tooltip, onClick }) {
   return (
-    <div className={`stat ${tone}`} onClick={onClick} style={{ cursor: onClick ? "pointer" : "default" }}>
+    <div className={`stat ${tone}`} onClick={onClick} title={tooltip || undefined} style={{ cursor: onClick ? "pointer" : "default" }}>
       <div className="stat-label">
         {label}
         {live && <span className="stat-live" />}

--- a/internal/server/web/design-source/mc/mc-fleet.jsx
+++ b/internal/server/web/design-source/mc/mc-fleet.jsx
@@ -89,9 +89,10 @@ function FleetScreen({ scenarioKey, layout, now, navigate, setLayout }) {
           label="Throughput"
           value="49"
           tone="ok"
-          sub="merged / 7d"
+          sub="merged PRs · 7d"
           sparkline={genSpark(scenarioKey, 1)}
           sparkWarm={scenarioKey === "attention"}
+          tooltip="Merged PRs across all projects in the last 7 days (UTC). Bars show per-day counts, oldest on the left."
         />
       </div>
 

--- a/internal/server/web/mc/src/atoms.jsx
+++ b/internal/server/web/mc/src/atoms.jsx
@@ -70,9 +70,9 @@ export function Sparkline({ data, warm = false }) {
   );
 }
 
-export function Stat({ label, value, of, sub, tone = "info", live, sparkline, sparkWarm, onClick }) {
+export function Stat({ label, value, of, sub, tone = "info", live, sparkline, sparkWarm, tooltip, onClick }) {
   return (
-    <div className={`stat ${tone}`} onClick={onClick} style={{ cursor: onClick ? "pointer" : "default" }}>
+    <div className={`stat ${tone}`} onClick={onClick} title={tooltip || undefined} style={{ cursor: onClick ? "pointer" : "default" }}>
       <div className="stat-label">
         {label}
         {live && <span className="stat-live" />}

--- a/internal/server/web/mc/src/fleet.jsx
+++ b/internal/server/web/mc/src/fleet.jsx
@@ -103,9 +103,10 @@ export function FleetScreen({ navigate }) {
           label="Throughput"
           value={String(fleet.throughputMerged7d)}
           tone="ok"
-          sub="merged / 7d"
+          sub="merged PRs · 7d"
           sparkline={fleet.throughputDaily7d.length ? fleet.throughputDaily7d : [0, 0, 0, 0, 0, 0, 0]}
           sparkWarm={tone === "watch"}
+          tooltip="Merged PRs across all projects in the last 7 days (UTC). Bars show per-day counts, oldest on the left."
         />
       </div>
 


### PR DESCRIPTION
Refs #344

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a 7-day issue throughput sparkline to the fleet stats UI, with a native `title` tooltip on the Stat tile and a sub-label update. A new Go test verifies that bucket counts accumulate correctly when `addFleetThroughputSummary` is called once per project.

- **`Stat` component** (`atoms.jsx` / `mc-atoms.jsx`): accepts an optional `tooltip` prop rendered as `title` on the outer div; `|| undefined` guard prevents an empty string from producing a blank title attribute.
- **Fleet screen** (`fleet.jsx` / `mc-fleet.jsx`): passes the tooltip string and updates the sub-label to "merged PRs · 7d".
- **`TestFleetThroughputBucketsAggregateAcrossProjects`**: exercises the multi-project accumulation path with a nil-slice third project; expected counts and total are arithmetically correct.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely additive UI polish and a new test with no impact on existing paths.

All five files contain small, isolated additions: a new optional prop on the Stat component, two tooltip strings in fleet screens, and a new Go test. No existing logic is modified, the test arithmetic is correct, and both the production and design-source copies are kept in sync.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet_test.go | Adds TestFleetThroughputBucketsAggregateAcrossProjects to verify that bucket counts accumulate correctly across multiple addFleetThroughputSummary calls; logic and expected counts are correct. |
| internal/server/web/mc/src/atoms.jsx | Adds optional `tooltip` prop to the Stat component, rendered as a native HTML `title` attribute; the `|| undefined` guard correctly prevents an empty string from being set as a title. |
| internal/server/web/mc/src/fleet.jsx | Passes tooltip text to the Throughput Stat and updates sub-label from "merged / 7d" to "merged PRs · 7d"; no logic changes. |
| internal/server/web/design-source/mc/mc-atoms.jsx | Design-source mirror of atoms.jsx changes — same tooltip prop and title attribute added to Stat. |
| internal/server/web/design-source/mc/mc-fleet.jsx | Design-source mirror of fleet.jsx changes — tooltip and sub-label update applied to the Throughput tile. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(fleet): clarify 7-day throughput sp..."](https://github.com/befeast/maestro/commit/ecf41c99006ff5a6415af5ad3892d7cedd559429) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34817407)</sub>

<!-- /greptile_comment -->