### PR TITLE
feat(cmd): night-start subcommand with hands-off preflight (Phase 1.3)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -251,6 +251,8 @@ func main() {
 		runCmd(args)
 	case "supervise":
 		superviseCmd(args)
+	case "night-start":
+		nightStartCmd(args)
 	case "serve":
 		serveCmd(args)
 	case "status":

--- a/cmd/maestro/night.go
+++ b/cmd/maestro/night.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// Phase 1.3: hands-off night-start command. Adds a preflight gate
+// before delegating to runCmd, logs the result bundle, and refuses to
+// spin if any precondition fails so an unattended run can't burn
+// claude credits on a known-broken state.
+
+type nightPreflight struct {
+	StartedAt        time.Time         `json:"started_at"`
+	ConfigPath       string            `json:"config_path"`
+	BackendsChecked  map[string]string `json:"backends_checked"` // backend -> "ok" | "missing" | "exhausted" | "skipped: ..."
+	StatePath        string            `json:"state_path"`
+	StateRead        bool              `json:"state_read"`
+	StuckSupervisor  bool              `json:"stuck_supervisor"`
+	StalePending     int               `json:"stale_pending_approvals"`
+	MaxRuntimeMin    int               `json:"max_runtime_minutes"`
+	MaxRetriesIssue  int               `json:"max_retries_per_issue"`
+	WorkerChain      []string          `json:"worker_chain"`
+	OK               bool              `json:"ok"`
+	Reason           string            `json:"reason,omitempty"`
+}
+
+// nightStartCmd is the entry point bound to "maestro night-start <args>".
+func nightStartCmd(args []string) {
+	fs := flag.NewFlagSet("night-start", flag.ExitOnError)
+	configPath := fs.String("config", "", "Path to project config")
+	dryRun := fs.Bool("dry-run", false, "Run preflight only, do not start the loop")
+	interval := fs.Duration("interval", 2*time.Minute, "Reconciliation interval (passed to runCmd)")
+	fs.Parse(reorderArgs(fs, args))
+
+	if strings.TrimSpace(*configPath) == "" {
+		log.Fatalf("night-start: --config is required")
+	}
+	cfg, err := config.LoadFrom(*configPath)
+	if err != nil {
+		log.Fatalf("night-start: load config: %v", err)
+	}
+
+	report := nightPreflight{
+		StartedAt:       time.Now().UTC(),
+		ConfigPath:      *configPath,
+		BackendsChecked: make(map[string]string),
+		StatePath:       cfg.StateDir,
+		MaxRuntimeMin:   cfg.MaxRuntimeMinutes,
+		MaxRetriesIssue: cfg.MaxRetriesPerIssue,
+	}
+
+	// 1. Worker chain — default + fallbacks. Each one we can probe at all,
+	//    we probe; missing is a non-fatal warning, exhausted is a soft fail
+	//    (we can still rely on later fallbacks if any of them are ok).
+	chain := []string{cfg.Model.Default}
+	chain = append(chain, cfg.Model.FallbackBackends...)
+	report.WorkerChain = chain
+
+	anyAgentic := false
+	for _, name := range chain {
+		def, ok := cfg.Model.Backends[name]
+		if !ok {
+			report.BackendsChecked[name] = "missing: not declared in config.Model.Backends"
+			continue
+		}
+		if def.NonAgentic {
+			// Should have been rejected by config.parse already, but
+			// defensive double-check.
+			report.BackendsChecked[name] = "skipped: non_agentic helper, not a worker driver"
+			continue
+		}
+		status := probeBackend(name, def)
+		report.BackendsChecked[name] = status
+		if status == "ok" {
+			anyAgentic = true
+		}
+	}
+
+	// 2. State checks.
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		report.StateRead = false
+		report.Reason = fmt.Sprintf("state.Load failed: %v", err)
+	} else {
+		report.StateRead = true
+		report.StuckSupervisor = st.SupervisorStuck
+		// Count pending approvals older than 2h — that is "stale" by any
+		// reasonable SLA. A non-zero count means a previous run left
+		// orphaned mints; refuse to start so the operator triages first.
+		now := time.Now().UTC()
+		stale := 0
+		for _, a := range st.Approvals {
+			if a.Status != state.ApprovalStatusPending {
+				continue
+			}
+			if now.Sub(a.CreatedAt) > 2*time.Hour {
+				stale++
+			}
+		}
+		report.StalePending = stale
+	}
+
+	// 3. Reason synthesis — first failing precondition wins.
+	if !anyAgentic {
+		report.OK = false
+		if report.Reason == "" {
+			report.Reason = "no agentic backend available in worker chain (all entries missing/exhausted/non-agentic)"
+		}
+	} else if !report.StateRead {
+		report.OK = false
+		// Reason already set above.
+	} else if report.StuckSupervisor {
+		report.OK = false
+		report.Reason = "state.SupervisorStuck=true from previous run — investigate before unattended start"
+	} else if report.StalePending > 0 {
+		report.OK = false
+		report.Reason = fmt.Sprintf("%d pending approval(s) older than 2h — clear before unattended start", report.StalePending)
+	} else if report.MaxRuntimeMin <= 0 {
+		report.OK = false
+		report.Reason = "config.max_runtime_minutes is unbounded — refuse to run unattended without a runtime ceiling"
+	} else {
+		report.OK = true
+	}
+
+	// 4. Persist the preflight bundle.
+	dir := filepath.Join(os.Getenv("HOME"), ".maestro", "night-runs")
+	_ = os.MkdirAll(dir, 0o755)
+	path := filepath.Join(dir, fmt.Sprintf("%s.json", report.StartedAt.Format("2006-01-02T150405Z")))
+	bundle, _ := json.MarshalIndent(report, "", "  ")
+	_ = os.WriteFile(path, bundle, 0o644)
+
+	// 5. Print to operator.
+	fmt.Println(string(bundle))
+	if !report.OK {
+		log.Fatalf("night-start: preflight FAILED — %s\n  bundle: %s", report.Reason, path)
+	}
+	fmt.Fprintf(os.Stderr, "\n[night-start] preflight OK · bundle %s\n", path)
+	if *dryRun {
+		fmt.Fprintln(os.Stderr, "[night-start] --dry-run: not entering run-loop")
+		return
+	}
+
+	// 6. Delegate to runCmd with the same config + interval. runCmd has
+	//    its own flag set; we re-marshal what it expects.
+	runArgs := []string{"--config", *configPath, "--interval", interval.String()}
+	fmt.Fprintf(os.Stderr, "[night-start] entering run-loop (interval=%s) — Ctrl+C to stop\n", interval)
+	runCmd(runArgs)
+}
+
+// probeBackend runs a tiny "say hi" probe against the backend's CLI.
+// Returns "ok", "missing: …", "exhausted: …", or "unknown error: …".
+// Non-agentic backends are caught upstream; this only sees worker-chain
+// backends. We use a 10s timeout so a hung CLI doesn't stall the
+// whole preflight.
+func probeBackend(name string, def config.BackendDef) string {
+	cmdLine := strings.TrimSpace(def.Cmd)
+	if cmdLine == "" {
+		return "missing: empty cmd"
+	}
+	parts := strings.Fields(cmdLine)
+	if len(parts) == 0 {
+		return "missing: empty cmd"
+	}
+	binary := parts[0]
+	if _, err := exec.LookPath(binary); err != nil {
+		return fmt.Sprintf("missing: %v", err)
+	}
+	// Probe via stdin "hi", 10s timeout. We do NOT actually verify the
+	// response is correct — only that the CLI doesn't immediately exit
+	// with a known rate-limit signature. This keeps probe cost minimal
+	// while still catching the common "claude exhausted overnight" case.
+	cmd := exec.Command(binary, parts[1:]...)
+	cmd.Stdin = strings.NewReader("hi")
+	timer := time.AfterFunc(10*time.Second, func() {
+		_ = cmd.Process.Kill()
+	})
+	defer timer.Stop()
+	out, _ := cmd.CombinedOutput()
+	output := strings.ToLower(string(out))
+	if strings.Contains(output, "you've hit your") ||
+		strings.Contains(output, "rate.limit") ||
+		strings.Contains(output, "quota.exceeded") ||
+		strings.Contains(output, "usage limit") {
+		return "exhausted: " + truncForReport(string(out))
+	}
+	return "ok"
+}
+
+func truncForReport(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 120 {
+		s = s[:120] + "…"
+	}
+	// Strip newlines for single-line JSON value.
+	s = strings.ReplaceAll(s, "\n", " · ")
+	return s
+}


### PR DESCRIPTION
Closes Phase 1.3. New `maestro night-start --config <cfg>` subcommand: preflight gate before delegating to runCmd, persists the result bundle, refuses to spin if any precondition fails.

## Preflight checks

1. Worker chain has at least one agentic backend whose CLI is on PATH and answers a 10s probe without a rate-limit signature.
2. State file readable.
3. `state.SupervisorStuck == false` (watchdog flag from #511).
4. No pending approvals older than 2h.
5. `config.max_runtime_minutes > 0`.

First failing precondition wins, full bundle persisted to `~/.maestro/night-runs/<timestamp>.json`.

## Live verified on workshop

```
$ maestro night-start --config /home/god/.maestro/maestro.d/maestro-supervisor-dogfood.yaml --dry-run
{
  "backends_checked": {"claude": "ok", "codex": "ok", "opencode": "ok"},
  "state_read": true, "stuck_supervisor": false,
  "stale_pending_approvals": 0,
  "max_runtime_minutes": 120,
  "worker_chain": ["claude", "codex", "opencode"],
  "ok": true
}
[night-start] preflight OK · bundle /home/god/.maestro/night-runs/2026-05-31T201820Z.json
```

Closes Phase 1.3 of the reliability plan. `go vet`, `go test ./...` (18/18 packages green), `go build`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `maestro night-start` subcommand that runs a preflight gate — probing backends, reading state, checking for stuck supervisors and stale approvals — before delegating to `runCmd`, so unattended overnight runs abort early on known-broken conditions rather than burning API credits.

- `cmd/maestro/night.go` (new): implements `nightStartCmd`, `probeBackend`, and the preflight bundle serialization to `~/.maestro/night-runs/<timestamp>.json`.
- `cmd/maestro/main.go`: routes the `night-start` token to `nightStartCmd` in the existing command switch.

<h3>Confidence Score: 3/5</h3>

Two concrete defects in night.go need fixing before this is safe to run unattended: a silent bundle write failure that misleads the operator, and a reason-synthesis inversion that reports the wrong precondition when both the backend chain and state-load fail at the same time.

The bundle write path always announces a file path to the operator regardless of whether the write succeeded, so in disk-full or permission-error scenarios the operator has a stale/missing audit trail but believes one exists. The reason-synthesis block populates report.Reason from the state-load error before the synthesis block runs, so when both backend and state checks fail the reported reason is the lower-priority state-load error, not the higher-priority backend failure.

cmd/maestro/night.go — the two logic defects and the narrower nil-pointer / HOME-env concerns all live here.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/maestro/night.go | New file implementing the `night-start` preflight gate. Two logic defects: bundle write errors are silently swallowed while the path is announced, and the reason-synthesis block inverts the intended check-priority when both backend probe and state-load fail simultaneously. Also has a narrow nil-pointer panic risk in the AfterFunc kill callback and uses `os.Getenv("HOME")` instead of the more robust `os.UserHomeDir()`. |
| cmd/maestro/main.go | Adds the `night-start` case to the command switch; one-line addition, no issues. The `night-start` command is omitted from the `const usage` help string, so it won't appear in `maestro --help` output. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
cmd/maestro/night.go:136-141
**Bundle write errors silently swallowed while path is announced**

Both `os.MkdirAll` and `os.WriteFile` results are discarded with `_`. If the directory can't be created (e.g. `$HOME` is unset, disk-full, or a permissions issue), the code still reaches line 148 and prints `[night-start] preflight OK · bundle /…/…json` — but the file does not exist. An operator acting on that path (re-reading the bundle in a later script or incident review) gets a misleading reference to a file that was never written. The failure mode is silent and only noticed when the bundle is looked up.

### Issue 2 of 4
cmd/maestro/night.go:114-134
**Reason synthesis inverts the intended check-1 priority when state-load also fails**

The PR specifies that the worker-chain check is precondition #1 and state-readability is precondition #2, so a dead backend chain should be the reported reason even if the state file is also unreadable. However, `report.Reason` is unconditionally populated with the `state.Load` error message in section 2 (lines 93-94), before the synthesis block runs. When `!anyAgentic` is evaluated first in the synthesis block (line 115), its `if report.Reason == ""` guard finds the string already set to `"state.Load failed: …"` and skips the backend message entirely. An operator seeing the bundle would conclude the problem is a missing state file, not a missing backend — which is backwards from the declared priority ordering and may lead to wasted triage time.

### Issue 3 of 4
cmd/maestro/night.go:183-188
**`cmd.Process` nil-pointer dereference in the `AfterFunc` goroutine**

`time.AfterFunc` schedules the kill callback in a separate goroutine. If `cmd.CombinedOutput()` → `cmd.Start()` returns an error (e.g., a TOCTOU between `exec.LookPath` and the actual exec, or an `ENOEXEC`), `cmd.Process` remains `nil`. If the 10-second timer has already fired and the callback goroutine is scheduled but not yet executed at the moment `timer.Stop()` returns `false`, the goroutine will call `nil.Kill()` and panic the entire `maestro night-start` process. The standard fix is to guard against this by checking `cmd.Process != nil` inside the AfterFunc closure before calling `Kill`.

### Issue 4 of 4
cmd/maestro/night.go:137
**`os.Getenv("HOME")` returns an empty string in several real environments**

Non-login shells, some container runtimes, `sudo` without `-H`, and certain CI runners do not set `$HOME`. When `HOME` is empty, `filepath.Join("", ".maestro", "night-runs")` resolves to the relative path `.maestro/night-runs` in the current working directory — likely not where the operator expects bundles to land, and it silently diverges from where every other `~/.maestro/…` path in the codebase resolves. `os.UserHomeDir()` consults `HOME` first but falls back to the passwd entry, making it significantly more robust in these environments.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cmd): night-start subcommand with h..."](https://github.com/befeast/maestro/commit/1f7c79a389e0aab2ed0a6352373b26a8ebaa09ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34817579)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->