### PR TITLE
fix(supervisor): gate approval-required mutating verbs so merge_pr is minted (#545)

### DIFF
--- a/internal/supervisor/approval_gate_test.go
+++ b/internal/supervisor/approval_gate_test.go
@@ -1,0 +1,82 @@
+package supervisor
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #545: the supervise approval-gate must mint approvals for the four
+// operator-configured mutating verbs. Before the fix, decisionRequiresApproval
+// consulted ApprovalRequiredActions (the default list, which lacks these verbs)
+// and canonicalAction returned "" for them, so a merge_pr/RiskMutating decision
+// was silently dropped and hands-off merge never completed. The pre-existing
+// tests only asserted the decision (action + risk), never that an approval was
+// minted — which is how this slipped through.
+
+func cautiousApprovalCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Supervisor.Mode = "cautious"
+	cfg.Supervisor.ApprovalRequired = []string{
+		config.SupervisorActionMergePR,
+		config.SupervisorActionCloseIssue,
+		config.SupervisorActionDeleteWorktree,
+		config.SupervisorActionChangeGlobalConfig,
+	}
+	return cfg
+}
+
+func TestCanonicalAction_MutatingVerbsPassthrough(t *testing.T) {
+	verbs := []string{
+		config.SupervisorActionMergePR,
+		config.SupervisorActionCloseIssue,
+		config.SupervisorActionDeleteWorktree,
+		config.SupervisorActionChangeGlobalConfig,
+	}
+	for _, v := range verbs {
+		if got := canonicalAction(v); got != v {
+			t.Fatalf("canonicalAction(%q) = %q, want %q", v, got, v)
+		}
+		// case-insensitive + trimmed, matching the other verbs' contract
+		if got := canonicalAction("  " + v + "  "); got != v {
+			t.Fatalf("canonicalAction(padded %q) = %q, want %q", v, got, v)
+		}
+	}
+}
+
+func TestDecisionRequiresApproval_GatesMutatingVerbs(t *testing.T) {
+	cfg := cautiousApprovalCfg()
+	verbs := []string{
+		config.SupervisorActionMergePR,
+		config.SupervisorActionCloseIssue,
+		config.SupervisorActionDeleteWorktree,
+		config.SupervisorActionChangeGlobalConfig,
+	}
+	for _, v := range verbs {
+		d := state.SupervisorDecision{RecommendedAction: v, Risk: RiskMutating}
+		if !decisionRequiresApproval(cfg, d) {
+			t.Fatalf("decisionRequiresApproval(%q, mutating) = false, want true (cautious gate must mint)", v)
+		}
+	}
+}
+
+func TestDecisionRequiresApproval_SafeAndNoneNotGated(t *testing.T) {
+	cfg := cautiousApprovalCfg()
+	safe := state.SupervisorDecision{RecommendedAction: ActionMonitorOpenPR, Risk: RiskSafe}
+	if decisionRequiresApproval(cfg, safe) {
+		t.Fatal("RiskSafe decision must not require approval")
+	}
+	none := state.SupervisorDecision{RecommendedAction: ActionNone, Risk: RiskMutating}
+	if decisionRequiresApproval(cfg, none) {
+		t.Fatal("ActionNone must not require approval")
+	}
+}
+
+func TestNewSupervisorPolicy_ApprovalRequiredFoldedIn(t *testing.T) {
+	cfg := cautiousApprovalCfg()
+	p := newSupervisorPolicy(cfg)
+	if !p.requiresApproval(config.SupervisorActionMergePR) {
+		t.Fatal("newSupervisorPolicy must mark merge_pr approval-required from ApprovalRequired")
+	}
+}

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -316,6 +316,17 @@ func newSupervisorPolicy(cfg *config.Config) supervisorPolicy {
 			policy.approvalRequired[canonical] = struct{}{}
 		}
 	}
+	// #545: operator-configured approval-gated mutating verbs (merge_pr,
+	// close_issue, delete_worktree, change_global_config) live in
+	// ApprovalRequired, not ApprovalRequiredActions. Without folding them in
+	// here the LLM policy never marks them approval-required and the mint is
+	// skipped — the same class of gap that left the deterministic path unable
+	// to gate merge_pr.
+	for _, action := range cfg.Supervisor.ApprovalRequired {
+		if canonical := canonicalAction(action); canonical != "" {
+			policy.approvalRequired[canonical] = struct{}{}
+		}
+	}
 	return policy
 }
 
@@ -385,6 +396,14 @@ func canonicalAction(action string) string {
 		return ActionOpenChildIssue
 	case ActionPreflightFailed:
 		return ActionPreflightFailed
+	case ActionMergePR:
+		return ActionMergePR
+	case config.SupervisorActionCloseIssue:
+		return config.SupervisorActionCloseIssue
+	case config.SupervisorActionDeleteWorktree:
+		return config.SupervisorActionDeleteWorktree
+	case config.SupervisorActionChangeGlobalConfig:
+		return config.SupervisorActionChangeGlobalConfig
 	default:
 		return ""
 	}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1322,7 +1322,20 @@ func decisionRequiresApproval(cfg *config.Config, decision state.SupervisorDecis
 	if decision.RecommendedAction == ActionNone || decision.Risk == RiskSafe {
 		return false
 	}
-	if cfg == nil || cfg.Supervisor.ApprovalRequiredActions == nil {
+	if cfg == nil {
+		return true
+	}
+	// #545: operator-configured approval-gated mutating verbs (merge_pr,
+	// close_issue, delete_worktree, change_global_config) live in
+	// ApprovalRequired (yaml approval_required), NOT ApprovalRequiredActions.
+	// They are canonical verbs and must gate minting of the matching decision;
+	// without this loop the cautious gate silently dropped every merge_pr.
+	for _, action := range cfg.Supervisor.ApprovalRequired {
+		if canonicalAction(action) == decision.RecommendedAction {
+			return true
+		}
+	}
+	if cfg.Supervisor.ApprovalRequiredActions == nil {
 		return true
 	}
 	for _, action := range cfg.Supervisor.ApprovalRequiredActions {


### PR DESCRIPTION
Closes #545.

## Problem

After #543/#544 fixed mergeable detection, the deterministic supervisor correctly decides `merge_pr` for a green/mergeable PR — but **no pending approval is ever minted** (verified live on dogfood: PR #542 → `decision.recommended_action=merge_pr`, `risk=mutating`, yet `approval_id=None`, 0 pending, no error, no "refusing to mint" log). The cautious gate silently dropped every approval-required mutating verb. This is the real reason hands-off merge never completed.

## Root cause (3 spots, one cause)

1. `canonicalAction` (`internal/supervisor/llm.go`) had no `case` for `merge_pr` / `close_issue` / `delete_worktree` / `change_global_config` → `default: return ""`.
2. `decisionRequiresApproval` (`internal/supervisor/supervisor.go`) iterated `cfg.Supervisor.ApprovalRequiredActions` (default-filled with `review_retry_exhausted, spawn_worker, …` — no mutating verbs) and matched via `canonicalAction`, which returned `""` for the verbs. The operator policy lives in `cfg.Supervisor.ApprovalRequired` (yaml `approval_required`), which was never consulted.
3. `newSupervisorPolicy` (`internal/supervisor/llm.go`) had the same gap on the `supervisor.enabled=true` LLM path.

A config-only workaround is impossible — `canonicalAction` nukes the verbs to `""` regardless of which list they sit in.

## Fix

- `canonicalAction` passes the four mutating verbs through unchanged.
- `decisionRequiresApproval` also consults `cfg.Supervisor.ApprovalRequired`.
- `newSupervisorPolicy` folds `ApprovalRequired` into the approval-required set.

## Tests

New `approval_gate_test.go`:
- `decisionRequiresApproval` returns true for all four mutating verbs under a cautious config; false for `RiskSafe` / `ActionNone`.
- `canonicalAction` passthrough for all four verbs (incl. trim/lowercase).
- `newSupervisorPolicy` marks `merge_pr` approval-required from `ApprovalRequired`.

The pre-existing tests only asserted the decision (action + risk), never the mint — which is how this slipped through.

`go build ./cmd/maestro/`, `go vet`, and `go test ./...` all green on workshop (17 packages).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the root cause of hands-off merge never completing: the supervisor's approval-gate silently dropped every `merge_pr` (and related mutating verbs) because `canonicalAction` returned `""` for them and `decisionRequiresApproval` never consulted `cfg.Supervisor.ApprovalRequired`.

- **`canonicalAction` (`llm.go`)**: adds explicit `case` entries for `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config` so the switch no longer falls through to `default: return ""`.
- **`decisionRequiresApproval` (`supervisor.go`)**: splits the former combined nil-guard and inserts a loop over `cfg.Supervisor.ApprovalRequired`, so operator-configured mutating verbs are consulted before falling through to `ApprovalRequiredActions`.
- **`newSupervisorPolicy` (`llm.go`)**: folds `ApprovalRequired` into the LLM policy's `approvalRequired` map, closing the same class of gap on the `supervisor.enabled=true` path.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the three-point fix is narrow and well-targeted, and all four mutating verbs are already registered in the executor's KnownApprovalActions registry so the new minting path will not produce silent execution_failed loops.

The deterministic and LLM paths both receive the correct fix, tests cover all four verbs end-to-end for decisionRequiresApproval and canonicalAction, and the approver registry confirms the verbs are executable. Two minor gaps exist: the newSupervisorPolicy test only probes merge_pr for the fold-in assertion, and the canonicalAction switch mixes local and config-package constants for the same verb class.

internal/supervisor/approval_gate_test.go — TestNewSupervisorPolicy_ApprovalRequiredFoldedIn would benefit from covering all four verbs, not just merge_pr.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/llm.go | Adds merge_pr, close_issue, delete_worktree, change_global_config to canonicalAction switch and folds ApprovalRequired into the LLM policy's approvalRequired map; merge_pr case uses the local ActionMergePR constant while the other three use config.SupervisorAction* — inconsistent but functionally identical. |
| internal/supervisor/supervisor.go | Splits the old cfg==nil||ApprovalRequiredActions==nil guard and inserts a new loop that consults ApprovalRequired before falling through to the ApprovalRequiredActions nil check; logic is equivalent to the original for all prior cases and correctly gates the four mutating verbs. |
| internal/supervisor/approval_gate_test.go | New test file covering canonicalAction passthrough, decisionRequiresApproval gating for all four mutating verbs, and newSupervisorPolicy fold-in; TestNewSupervisorPolicy_ApprovalRequiredFoldedIn only asserts merge_pr, leaving the other three verbs unchecked. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/supervisor/llm.go:399-401
The `merge_pr` case uses the package-local `ActionMergePR` constant while the other three new cases use `config.SupervisorAction*` constants. Both resolve to the same string (`"merge_pr"`), but the inconsistency can mislead future readers about which constant is canonical for this package. Using the config constants uniformly here (as is done for the other three verbs and throughout `approver/` and `server/`) would make the pattern consistent.

```suggestion
	case config.SupervisorActionMergePR:
		return config.SupervisorActionMergePR
	case config.SupervisorActionCloseIssue:
```

### Issue 2 of 2
internal/supervisor/approval_gate_test.go:76-82
`TestNewSupervisorPolicy_ApprovalRequiredFoldedIn` only checks `merge_pr`. If the `ApprovalRequired` loop in `newSupervisorPolicy` were accidentally scoped to just the first entry (e.g. due to an off-by-one or early `break`), the other three verbs would not be caught. Covering all four verbs here matches the thoroughness already present in `TestDecisionRequiresApproval_GatesMutatingVerbs` and `TestCanonicalAction_MutatingVerbsPassthrough`.

```suggestion
func TestNewSupervisorPolicy_ApprovalRequiredFoldedIn(t *testing.T) {
	cfg := cautiousApprovalCfg()
	p := newSupervisorPolicy(cfg)
	verbs := []string{
		config.SupervisorActionMergePR,
		config.SupervisorActionCloseIssue,
		config.SupervisorActionDeleteWorktree,
		config.SupervisorActionChangeGlobalConfig,
	}
	for _, v := range verbs {
		if !p.requiresApproval(v) {
			t.Fatalf("newSupervisorPolicy must mark %q approval-required from ApprovalRequired", v)
		}
	}
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(supervisor): gate approval-required ..."](https://github.com/befeast/maestro/commit/3f658b7c41db3ff240d0135aa1cc483590ca43a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34822211)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->