### PR TITLE
P0: Project card on home screen — actionable «Needs attention» with reason + jump-to-attention + healthy state pill

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2961,7 +2961,11 @@ func renderFleetProjectRailRow(project fleetProjectState) string {
 		`<button type="button" class="project-rail-toggle" data-rail-toggle="` + html.EscapeString(detailID) + `" aria-expanded="false" aria-controls="` + html.EscapeString(detailID) + `" aria-label="Expand project detail">` +
 		`<span class="project-rail-toggle-caret" aria-hidden="true">&#9656;</span>` +
 		`</button></td>`
-	mainRow := `<tr class="` + html.EscapeString(rowClass) + `" aria-controls="` + html.EscapeString(detailID) + `">` +
+	needsAttention := "0"
+	if fleetProjectHasAttentionCTA(project) {
+		needsAttention = "1"
+	}
+	mainRow := `<tr class="` + html.EscapeString(rowClass) + `" data-project="` + html.EscapeString(project.Name) + `" data-needs-attention="` + needsAttention + `" aria-controls="` + html.EscapeString(detailID) + `">` +
 		toggleCell +
 		`<td class="project-rail-project">` + renderFleetProjectIdentity(project) + `</td>` +
 		`<td class="project-rail-state-cell">` + renderFleetProjectRailState(project) + `</td>` +
@@ -3093,7 +3097,11 @@ func renderFleetProjectRailState(project fleetProjectState) string {
 	}
 	parts := []string{
 		`<span class="pill ` + html.EscapeString(fleetProjectStatePillClass(project)) + `">` + html.EscapeString(label) + `</span>`,
-		`<div class="rail-subline" title="` + html.EscapeString(summary) + `">` + html.EscapeString(summary) + `</div>`,
+	}
+	if structured := renderFleetProjectRailStructured(project, summary); structured != "" {
+		parts = append(parts, structured)
+	} else {
+		parts = append(parts, `<div class="rail-subline" title="`+html.EscapeString(summary)+`">`+html.EscapeString(summary)+`</div>`)
 	}
 	if project.Error != "" {
 		parts = append(parts, `<div class="rail-alert" title="`+html.EscapeString(project.Error)+`">State error</div>`)
@@ -3102,6 +3110,42 @@ func renderFleetProjectRailState(project fleetProjectState) string {
 		parts = append(parts, `<div class="rail-warn">Stale snapshot</div>`)
 	}
 	return strings.Join(parts, "")
+}
+
+func renderFleetProjectRailStructured(project fleetProjectState, summary string) string {
+	op := project.OperatorState
+	issueNumber := op.IssueNumber
+	session := strings.TrimSpace(op.Session)
+	issueURL := strings.TrimSpace(op.IssueURL)
+	nextAction := strings.TrimSpace(op.NextAction)
+	if issueNumber == 0 && session == "" && nextAction == "" {
+		return ""
+	}
+	parts := make([]string, 0, 2)
+	if issueNumber > 0 {
+		issueLabel := fmt.Sprintf("issue #%d", issueNumber)
+		if issueURL != "" {
+			parts = append(parts, `<a class="rail-structured-issue" href="`+html.EscapeString(issueURL)+`" target="_blank" rel="noreferrer">`+html.EscapeString(issueLabel)+`</a>`)
+		} else {
+			parts = append(parts, `<span class="rail-structured-issue">`+html.EscapeString(issueLabel)+`</span>`)
+		}
+	}
+	if session != "" {
+		parts = append(parts, `<button type="button" class="link-button rail-structured-session" data-project="`+html.EscapeString(project.Name)+`" data-slot="`+html.EscapeString(session)+`" title="Open session `+html.EscapeString(session)+`">`+html.EscapeString("("+session+")")+`</button>`)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	lead := strings.Join(parts, " ")
+	reason := nextAction
+	if reason == "" {
+		reason = summary
+	}
+	reasonHTML := ""
+	if reason != "" {
+		reasonHTML = ` · <span class="rail-structured-reason" title="` + html.EscapeString(reason) + `">` + html.EscapeString(reason) + `</span>`
+	}
+	return `<div class="rail-subline rail-structured" title="` + html.EscapeString(summary) + `">` + lead + reasonHTML + `</div>`
 }
 
 func renderFleetProjectRailQueue(project fleetProjectState) string {
@@ -3204,26 +3248,61 @@ func renderFleetProjectRailOutcome(project fleetProjectState) string {
 
 func renderFleetProjectRailFreshness(project fleetProjectState) string {
 	freshness := project.Freshness
-	age := strings.TrimSpace(freshness.SnapshotAge)
-	if age == "" {
-		age = "No snapshot yet"
-	} else {
-		age = "Snapshot " + age + " ago"
+	ageLabel := formatFleetFreshnessAge(freshness.SnapshotAge, freshness.SnapshotAgeSeconds)
+	text := "No snapshot yet"
+	if ageLabel != "" {
+		text = "Snapshot " + ageLabel + " ago"
 	}
-	details := make([]string, 0, 3)
-	if freshness.StateUpdatedAt != "" {
-		details = append(details, "State "+freshness.StateUpdatedAt)
+	tooltipParts := make([]string, 0, 3)
+	if strings.TrimSpace(freshness.SnapshotAt) != "" {
+		tooltipParts = append(tooltipParts, "Snapshot at "+freshness.SnapshotAt)
 	}
-	if freshness.LogUpdatedAt != "" {
-		details = append(details, "Logs "+freshness.LogUpdatedAt)
+	if strings.TrimSpace(freshness.Reason) != "" {
+		tooltipParts = append(tooltipParts, freshness.Reason)
 	}
-	if freshness.Reason != "" {
-		details = append(details, freshness.Reason)
+	tooltip := strings.Join(tooltipParts, " · ")
+	if tooltip == "" {
+		tooltip = text
 	}
-	return `<div class="rail-mainline" title="` + html.EscapeString(strings.Join(details, " · ")) + `">` + html.EscapeString(age) + `</div>`
+	return `<div class="rail-mainline" title="` + html.EscapeString(tooltip) + `">` + html.EscapeString(text) + `</div>`
+}
+
+func formatFleetFreshnessAge(rawAge string, ageSeconds int64) string {
+	if ageSeconds >= 3600 {
+		return formatClockDuration(ageSeconds)
+	}
+	if trimmed := strings.TrimSpace(rawAge); trimmed != "" {
+		return trimmed
+	}
+	if ageSeconds > 0 {
+		return fmt.Sprintf("%ds", ageSeconds)
+	}
+	return ""
+}
+
+func formatClockDuration(totalSeconds int64) string {
+	if totalSeconds < 0 {
+		totalSeconds = 0
+	}
+	h := totalSeconds / 3600
+	m := (totalSeconds % 3600) / 60
+	s := totalSeconds % 60
+	return fmt.Sprintf("%d:%02d:%02d", h, m, s)
 }
 
 func renderFleetProjectRailLinks(project fleetProjectState) string {
+	if fleetProjectHasAttentionCTA(project) {
+		op := project.OperatorState
+		reason := strings.TrimSpace(op.NextAction)
+		if reason == "" {
+			reason = strings.TrimSpace(op.Summary)
+		}
+		if reason == "" {
+			reason = "Open the attention tab for this project."
+		}
+		label := fleetProjectAttentionCTALabel(project)
+		return `<button type="button" class="rail-cta rail-cta-attention project-attention-cta" data-project="` + html.EscapeString(project.Name) + `" title="` + html.EscapeString(reason) + `">` + html.EscapeString(label) + ` &rarr;</button>`
+	}
 	url := strings.TrimSpace(project.DashboardURL)
 	if url == "" {
 		url = fleetProjectGitHubURL(project.Repo)
@@ -3242,32 +3321,72 @@ func fleetProjectStateLabel(project fleetProjectState) string {
 	if fleetProjectUnconfigured(project) {
 		return "setup"
 	}
-	if label := strings.TrimSpace(project.OperatorState.Label); label != "" {
+	op := project.OperatorState
+	if (strings.TrimSpace(op.Kind) == "" || op.Kind == "idle") && op.Tone == "healthy" {
+		return "Idle · healthy"
+	}
+	if label := strings.TrimSpace(op.Label); label != "" {
 		return label
 	}
 	return "Idle"
+}
+
+func fleetProjectStateKindKey(project fleetProjectState) string {
+	op := project.OperatorState
+	key := strings.TrimSpace(op.Kind)
+	if key == "" {
+		key = "idle"
+	}
+	if key == "idle" && op.Tone == "healthy" {
+		key = "healthy_idle"
+	}
+	return key
 }
 
 func fleetProjectStatePillClass(project fleetProjectState) string {
 	if fleetProjectUnconfigured(project) {
 		return "rail-state-unconfigured"
 	}
-	key := strings.TrimSpace(project.OperatorState.Kind)
-	if key == "" {
-		key = "idle"
-	}
-	return "rail-state-" + fleetCSSClassToken(key)
+	return "rail-state-" + fleetCSSClassToken(fleetProjectStateKindKey(project))
 }
 
 func fleetProjectRailStateClass(project fleetProjectState) string {
 	if fleetProjectUnconfigured(project) {
 		return "project-row-unconfigured"
 	}
-	key := strings.TrimSpace(project.OperatorState.Kind)
-	if key == "" {
-		key = "idle"
+	return "project-row-" + fleetCSSClassToken(fleetProjectStateKindKey(project))
+}
+
+func fleetProjectHasAttentionCTA(project fleetProjectState) bool {
+	if fleetProjectUnconfigured(project) {
+		return false
 	}
-	return "project-row-" + fleetCSSClassToken(key)
+	if project.NeedsAttention > 0 {
+		return true
+	}
+	switch strings.TrimSpace(project.OperatorState.Kind) {
+	case "attention", "stale_worker", "dispatch_failure", "error":
+		return true
+	}
+	return false
+}
+
+func fleetProjectAttentionCTALabel(project fleetProjectState) string {
+	op := project.OperatorState
+	switch strings.TrimSpace(op.Kind) {
+	case "attention":
+		return "Open attention"
+	case "stale_worker":
+		return "Review stale worker"
+	case "dispatch_failure":
+		return "Resolve dispatch"
+	case "error":
+		return "Fix project error"
+	}
+	if label := strings.TrimSpace(op.Label); label != "" {
+		return "Open " + label
+	}
+	return "Open attention"
 }
 
 func fleetProjectUnconfigured(project fleetProjectState) bool {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -2302,6 +2302,128 @@ func TestFleetDashboardRendersUnconfiguredProjectAsSetupState(t *testing.T) {
 	}
 }
 
+func TestFleetDashboardProjectCardRendersStructuredAttentionBody(t *testing.T) {
+	project := fleetProjectState{
+		Name:           "maestro",
+		Repo:           "BeFeast/maestro",
+		DashboardURL:   "http://127.0.0.1:8787",
+		MaxParallel:    2,
+		NeedsAttention: 1,
+		OperatorState: fleetOperatorState{
+			Kind:        "attention",
+			Tone:        "attention",
+			Label:       "Needs attention",
+			Summary:     "Worker exited and is waiting for retry.",
+			NextAction:  "Run a Maestro reconciliation cycle or review the failed attempt.",
+			IssueNumber: 471,
+			IssueURL:    "https://github.com/BeFeast/maestro/issues/471",
+			Session:     "sup-84",
+		},
+		Outcome: outcome.Status{Configured: true, Goal: "Healthy", HealthState: outcome.HealthHealthy},
+	}
+	row := renderFleetProjectRailRow(project)
+	for _, want := range []string{
+		`data-needs-attention="1"`,
+		`rail-structured`,
+		`href="https://github.com/BeFeast/maestro/issues/471"`,
+		`issue #471`,
+		`rail-structured-session`,
+		`data-project="maestro"`,
+		`data-slot="sup-84"`,
+		`(sup-84)`,
+		`Run a Maestro reconciliation cycle`,
+		`rail-cta rail-cta-attention project-attention-cta`,
+		`Open attention &rarr;`,
+	} {
+		if !contains(row, want) {
+			t.Fatalf("attention rail row should contain %q, got:\n%s", want, row)
+		}
+	}
+}
+
+func TestFleetDashboardProjectCardRendersHealthyIdlePill(t *testing.T) {
+	project := fleetProjectState{
+		Name:          "healthy",
+		Repo:          "owner/healthy",
+		DashboardURL:  "http://127.0.0.1:8787",
+		MaxParallel:   1,
+		OperatorState: fleetOperatorState{Kind: "idle", Tone: "healthy", Label: "Healthy idle", Summary: "No open issues."},
+		Outcome:       outcome.Status{Configured: true, Goal: "Healthy", HealthState: outcome.HealthHealthy},
+	}
+	row := renderFleetProjectRailRow(project)
+	if !contains(row, `rail-state-healthy_idle`) {
+		t.Fatalf("healthy idle row should use rail-state-healthy_idle pill, got:\n%s", row)
+	}
+	if !contains(row, "Idle · healthy") {
+		t.Fatalf("healthy idle row should display 'Idle · healthy' label, got:\n%s", row)
+	}
+	if contains(row, "project-attention-cta") {
+		t.Fatalf("healthy idle row must not render attention CTA, got:\n%s", row)
+	}
+}
+
+func TestFleetDashboardProjectCardFreshnessShowsAbsoluteTooltipAndClockForLongAges(t *testing.T) {
+	project := fleetProjectState{
+		Name:          "longidle",
+		Repo:          "owner/longidle",
+		DashboardURL:  "http://127.0.0.1:8787",
+		MaxParallel:   1,
+		OperatorState: fleetOperatorState{Kind: "idle", Tone: "healthy", Label: "Healthy idle"},
+		Outcome:       outcome.Status{Configured: true, Goal: "Healthy", HealthState: outcome.HealthHealthy},
+		Freshness: fleetProjectFreshness{
+			SnapshotAt:         "2026-05-31T12:00:00Z",
+			SnapshotAge:        "2h0m0s",
+			SnapshotAgeSeconds: 7325,
+		},
+	}
+	row := renderFleetProjectRailFreshness(project)
+	if !contains(row, "2:02:05") {
+		t.Fatalf("freshness > 1h should render hh:mm:ss, got:\n%s", row)
+	}
+	if !contains(row, "Snapshot at 2026-05-31T12:00:00Z") {
+		t.Fatalf("freshness tooltip should include absolute snapshot timestamp, got:\n%s", row)
+	}
+
+	short := fleetProjectState{
+		Name:    "shortidle",
+		Outcome: outcome.Status{Configured: true},
+		Freshness: fleetProjectFreshness{
+			SnapshotAt:         "2026-05-31T12:00:00Z",
+			SnapshotAge:        "50s",
+			SnapshotAgeSeconds: 50,
+		},
+	}
+	shortRow := renderFleetProjectRailFreshness(short)
+	if !contains(shortRow, "50s") {
+		t.Fatalf("freshness < 1h should keep humanized age, got:\n%s", shortRow)
+	}
+	if contains(shortRow, ":50") {
+		t.Fatalf("freshness < 1h should not render hh:mm:ss form, got:\n%s", shortRow)
+	}
+	if !contains(shortRow, "Snapshot at 2026-05-31T12:00:00Z") {
+		t.Fatalf("short freshness tooltip should still include absolute snapshot timestamp, got:\n%s", shortRow)
+	}
+}
+
+func TestFleetDashboardProjectCardClickHandlerOpensAttentionScope(t *testing.T) {
+	js := legacyFleetJS(t)
+	for _, want := range []string{
+		`function openProjectAttentionDrawer(projectName)`,
+		`fleetState.filters.scope = "attention"`,
+		`row.dataset.needsAttention === "1"`,
+		`projectHasAttentionCTA`,
+		`projectStateStructuredHTML`,
+		`rail-structured-session`,
+		`function formatClockDuration(totalSeconds)`,
+		`"Snapshot at "`,
+		`Idle · healthy`,
+	} {
+		if !contains(js, want) {
+			t.Fatalf("fleet.js should expose %q for project card behavior", want)
+		}
+	}
+}
+
 func TestFleetDashboardProjectRailPlaceholdersAreNotReplacedFromProjectData(t *testing.T) {
 	snapshot := fleetResponse{
 		Projects: []fleetProjectState{{

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -495,12 +495,34 @@
     font-size: 13px;
     line-height: 1.45;
   }
-  .rail-state-working, .outcome-healthy { color: var(--ok); border-color: rgba(22,128,60,.5); background: rgba(22,128,60,.08); }
+  .rail-state-working, .outcome-healthy, .rail-state-healthy_idle { color: var(--ok); border-color: rgba(22,128,60,.5); background: rgba(22,128,60,.08); }
   .rail-state-monitoring_pr, .rail-state-pending_dispatch, .outcome-unknown { color: var(--accent); border-color: rgba(37,99,235,.45); background: rgba(37,99,235,.07); }
   .rail-state-attention, .rail-state-error, .rail-state-stale_worker, .rail-state-dispatch_failure, .rail-state-outcome_drift, .outcome-failing { color: var(--bad); border-color: rgba(220,38,38,.45); background: rgba(220,38,38,.07); }
   .rail-state-stale, .rail-state-queue_blocked, .rail-state-no_eligible_issues, .rail-state-outcome_missing { color: var(--warn); border-color: rgba(161,98,7,.45); background: rgba(161,98,7,.08); }
   .rail-state-unconfigured { color: var(--muted); border-color: rgba(100,116,139,.45); background: rgba(100,116,139,.08); }
   .rail-state-idle, .outcome-not_configured, .outcome-unmonitored { color: var(--muted); border-color: rgba(100,116,139,.45); background: rgba(100,116,139,.08); }
+  .rail-structured { display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px; }
+  .rail-structured-issue { font-weight: 650; color: var(--accent); text-decoration: none; }
+  .rail-structured-issue:hover { text-decoration: underline; }
+  .rail-structured-session { padding: 0; margin: 0; border: 0; background: none; color: var(--text-dim); font-weight: 600; font-size: inherit; cursor: pointer; }
+  .rail-structured-session:hover { color: var(--accent); text-decoration: underline; }
+  .rail-structured-reason { color: var(--text-dim); }
+  .rail-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 10px;
+    border: 1px solid var(--bad);
+    border-radius: 6px;
+    background: rgba(220,38,38,.06);
+    color: var(--bad);
+    font-size: 12px;
+    font-weight: 650;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .rail-cta:hover { background: rgba(220,38,38,.12); }
+  .rail-cta-attention:focus-visible { outline: 2px solid var(--bad); outline-offset: 2px; }
   .rail-setup-copy,
   .rail-setup-link,
   .setup-link { color: var(--muted); font-weight: 650; }

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -1387,12 +1387,15 @@ function projectIsUnconfigured(project) {
 function projectStateKey(project) {
   if (projectIsUnconfigured(project)) return "unconfigured";
   const operator = project.operator_state || {};
-  return operator.kind || "idle";
+  const kind = operator.kind || "idle";
+  if (kind === "idle" && operator.tone === "healthy") return "healthy_idle";
+  return kind;
 }
 
 function projectStateLabel(project) {
   if (projectIsUnconfigured(project)) return "setup";
   const operator = project.operator_state || {};
+  if ((operator.kind || "idle") === "idle" && operator.tone === "healthy") return "Idle · healthy";
   return operator.label || "Idle";
 }
 
@@ -1481,8 +1484,37 @@ function projectStateRailHTML(project) {
   const key = projectStateKey(project);
   const operator = project.operator_state || {};
   const summary = String(operator.summary || ((project.running || 0) + '/' + (project.max_parallel || 0) + ' worker process(es) running.'));
-  return '<span class="pill rail-state-' + cssToken(key) + '">' + escapeText(projectStateLabel(project)) + '</span>' +
-    '<div class="rail-subline" title="' + escapeText(summary) + '">' + escapeText(summary) + '</div>';
+  const pill = '<span class="pill rail-state-' + cssToken(key) + '">' + escapeText(projectStateLabel(project)) + '</span>';
+  const structured = projectStateStructuredHTML(project, operator, summary);
+  if (structured) return pill + structured;
+  return pill + '<div class="rail-subline" title="' + escapeText(summary) + '">' + escapeText(summary) + '</div>';
+}
+
+function projectStateStructuredHTML(project, operator, summary) {
+  const issueNumber = Number(operator.issue_number || 0);
+  const session = String(operator.session || "").trim();
+  const issueURL = String(operator.issue_url || "").trim();
+  const nextAction = String(operator.next_action || "").trim();
+  if (!issueNumber && !session && !nextAction) return "";
+  const parts = [];
+  if (issueNumber) {
+    const issueLabel = "issue #" + issueNumber;
+    parts.push(issueURL
+      ? '<a class="rail-structured-issue" href="' + escapeText(issueURL) + '" target="_blank" rel="noreferrer">' + escapeText(issueLabel) + '</a>'
+      : '<span class="rail-structured-issue">' + escapeText(issueLabel) + '</span>');
+  }
+  if (session) {
+    parts.push('<button type="button" class="link-button rail-structured-session" data-project="' +
+      escapeText(project.name || "") + '" data-slot="' + escapeText(session) + '" title="Open session ' +
+      escapeText(session) + '">' + escapeText("(" + session + ")") + '</button>');
+  }
+  if (parts.length === 0) return "";
+  const lead = parts.join(' ');
+  const reason = nextAction || summary;
+  const reasonHTML = reason
+    ? ' · <span class="rail-structured-reason" title="' + escapeText(reason) + '">' + escapeText(reason) + '</span>'
+    : '';
+  return '<div class="rail-subline rail-structured" title="' + escapeText(summary) + '">' + lead + reasonHTML + '</div>';
 }
 
 function projectQueueRailHTML(project) {
@@ -1532,8 +1564,31 @@ function projectOutcomeRailHTML(project) {
 
 function projectFreshnessRailHTML(project) {
   const freshness = project.freshness || {};
-  const age = freshness.snapshot_age ? "Snapshot " + freshness.snapshot_age + " ago" : "No snapshot yet";
-  return '<div class="rail-mainline" title="' + escapeText(freshness.reason || age) + '">' + escapeText(age) + '</div>';
+  const ageSeconds = Number(freshness.snapshot_age_seconds || 0);
+  const ageLabel = formatFreshnessAge(freshness.snapshot_age, ageSeconds);
+  const text = ageLabel ? "Snapshot " + ageLabel + " ago" : "No snapshot yet";
+  const tooltipParts = [];
+  if (freshness.snapshot_at) tooltipParts.push("Snapshot at " + formatTimestamp(freshness.snapshot_at));
+  if (freshness.reason) tooltipParts.push(freshness.reason);
+  const tooltip = tooltipParts.length ? tooltipParts.join(" · ") : text;
+  return '<div class="rail-mainline" title="' + escapeText(tooltip) + '">' + escapeText(text) + '</div>';
+}
+
+function formatFreshnessAge(rawAge, ageSeconds) {
+  if (ageSeconds >= 3600) return formatClockDuration(ageSeconds);
+  const trimmed = String(rawAge || "").trim();
+  if (trimmed) return trimmed;
+  if (ageSeconds > 0) return Math.round(ageSeconds) + "s";
+  return "";
+}
+
+function formatClockDuration(totalSeconds) {
+  const seconds = Math.max(0, Math.floor(Number(totalSeconds) || 0));
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  const pad = n => (n < 10 ? "0" + n : String(n));
+  return h + ":" + pad(m) + ":" + pad(s);
 }
 
 function projectLinksRailHTML(project) {
@@ -1549,9 +1604,52 @@ function projectLinksRailHTML(project) {
 }
 
 function projectOpenRailHTML(project) {
+  const cta = projectNextActionCTAHTML(project);
+  if (cta) return cta;
   const url = project.dashboard_url || githubRepoURL(project.repo);
   const label = projectIsUnconfigured(project) ? "Set up" : "Open";
   return '<div class="rail-open-link">' + linkHTML(url, label + " →") + '</div>';
+}
+
+function projectNextActionCTAHTML(project) {
+  if (!projectHasAttentionCTA(project)) return "";
+  const operator = project.operator_state || {};
+  const kind = String(operator.kind || "").trim();
+  const reason = String(operator.next_action || operator.summary || "Open the attention tab for this project.").trim();
+  const label = ctaLabelForOperatorKind(kind, operator.label);
+  return '<button type="button" class="rail-cta rail-cta-attention project-attention-cta" data-project="' +
+    escapeText(project.name || "") + '" title="' + escapeText(reason) + '">' +
+    escapeText(label) + ' →</button>';
+}
+
+function projectHasAttentionCTA(project) {
+  if (projectIsUnconfigured(project)) return false;
+  const operator = project.operator_state || {};
+  const attention = Number(project.needs_attention || 0);
+  const kind = String(operator.kind || "").trim();
+  if (attention > 0) return true;
+  return kind === "attention" || kind === "stale_worker" || kind === "dispatch_failure" || kind === "error";
+}
+
+function openProjectAttentionDrawer(projectName) {
+  if (!projectName) return;
+  fleetState.selectedProject = projectName;
+  fleetState.filters.scope = "attention";
+  syncFilterControls();
+  updateQueryState();
+  renderFleetWorkers();
+  if (fleetWorkersShellEl) fleetWorkersShellEl.open = true;
+  fleetWorkersShellEl?.scrollIntoView({ block: "start", behavior: "smooth" });
+}
+
+function ctaLabelForOperatorKind(kind, label) {
+  switch (String(kind || "").trim()) {
+  case "attention": return "Open attention";
+  case "stale_worker": return "Review stale worker";
+  case "dispatch_failure": return "Resolve dispatch";
+  case "error": return "Fix project error";
+  default: return label ? "Open " + label : "Open attention";
+  }
 }
 
 function projectRailRowHTML(project) {
@@ -1563,7 +1661,8 @@ function projectRailRowHTML(project) {
     '<button type="button" class="project-rail-toggle" data-rail-toggle="' + escapeText(detailID) + '" aria-expanded="' + (expanded ? "true" : "false") + '" aria-controls="' + escapeText(detailID) + '" aria-label="' + (expanded ? "Collapse" : "Expand") + ' project detail">' +
       '<span class="project-rail-toggle-caret" aria-hidden="true">&#9656;</span>' +
     '</button></td>';
-  const mainRow = '<tr class="project-rail-row project-row-' + cssToken(key) + modifier + (expanded ? ' project-rail-row-expanded' : '') + '" data-project="' + escapeText(project.name || "") + '" data-url="' + escapeText(project.dashboard_url || githubRepoURL(project.repo) || "") + '" aria-controls="' + escapeText(detailID) + '" tabindex="0">' +
+  const needsAttention = projectHasAttentionCTA(project) ? "1" : "0";
+  const mainRow = '<tr class="project-rail-row project-row-' + cssToken(key) + modifier + (expanded ? ' project-rail-row-expanded' : '') + '" data-project="' + escapeText(project.name || "") + '" data-url="' + escapeText(project.dashboard_url || githubRepoURL(project.repo) || "") + '" data-needs-attention="' + needsAttention + '" aria-controls="' + escapeText(detailID) + '" tabindex="0">' +
     toggleCell +
     '<td class="project-rail-project"><div class="project-rail-project-wrap"><div class="project-rail-project-copy">' + projectIdentityRailHTML(project) + '</div></div></td>' +
     '<td class="project-rail-state-cell">' + projectStateRailHTML(project) + '</td>' +
@@ -1665,16 +1764,23 @@ function renderProjectRail() {
 
   projectRailBodyEl.innerHTML = projects.map(projectRailRowHTML).join("");
   projectRailBodyEl.querySelectorAll(".project-rail-row[data-project]").forEach(row => {
-    row.addEventListener("click", event => {
+    const handleActivate = event => {
       if (event.target.closest("a, button")) return;
+      const projectName = row.dataset.project || "";
+      const needsAttention = row.dataset.needsAttention === "1";
+      if (needsAttention && projectName) {
+        event.preventDefault();
+        openProjectAttentionDrawer(projectName);
+        return;
+      }
       const url = row.dataset.url || "";
       if (url) window.open(url, "_blank", "noopener,noreferrer");
-    });
+    };
+    row.addEventListener("click", handleActivate);
     row.addEventListener("keydown", event => {
       if ((event.key === "Enter" || event.key === " ") && !event.target.closest("a, button")) {
         event.preventDefault();
-        const url = row.dataset.url || "";
-        if (url) window.open(url, "_blank", "noopener,noreferrer");
+        handleActivate(event);
       }
     });
   });
@@ -1697,6 +1803,23 @@ function renderProjectRail() {
       renderFleetWorkers();
       if (fleetWorkersShellEl) fleetWorkersShellEl.open = true;
       fleetWorkersShellEl?.scrollIntoView({ block: "start", behavior: "smooth" });
+    });
+  });
+  projectRailBodyEl.querySelectorAll(".project-attention-cta[data-project]").forEach(button => {
+    button.addEventListener("click", event => {
+      event.preventDefault();
+      event.stopPropagation();
+      openProjectAttentionDrawer(button.dataset.project || "");
+    });
+  });
+  projectRailBodyEl.querySelectorAll(".rail-structured-session[data-project][data-slot]").forEach(button => {
+    button.addEventListener("click", event => {
+      event.preventDefault();
+      event.stopPropagation();
+      const projectName = button.dataset.project || "";
+      const slot = button.dataset.slot || "";
+      if (projectName) openProjectAttentionDrawer(projectName);
+      if (projectName && slot) selectWorker(projectName, slot);
     });
   });
 }

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -15,9 +15,9 @@
 <link rel="icon" href="/static/favicon-48.png" type="image/png" sizes="48x48">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon-180.png" sizes="180x180">
 <link rel="preload" href="/static/status-icons.svg" as="image" type="image/svg+xml">
-<link rel="stylesheet" href="/static/tokens.css?v=20260503-2">
-<link rel="stylesheet" href="/static/components.css?v=20260503-2">
-<link rel="stylesheet" href="/static/fleet.css?v=20260503-5">
+<link rel="stylesheet" href="/static/tokens.css?v=20260531-1">
+<link rel="stylesheet" href="/static/components.css?v=20260531-1">
+<link rel="stylesheet" href="/static/fleet.css?v=20260531-1">
 
 </head>
 <body data-page="fleet">
@@ -223,7 +223,7 @@
   </dialog>
 </main>
 <script type="application/json" id="fleet-initial-state">{{FLEET_INITIAL_STATE}}</script>
-<script src="/static/fleet.js?v=20260503-5"></script>
+<script src="/static/fleet.js?v=20260531-1"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Refs #532

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades each project card on the fleet home screen with an actionable "Needs attention" CTA, a structured subline showing linked issue and session, a jump-to-attention click handler, and a green "Idle · healthy" pill for healthy-idle projects. The freshness cell is also updated to display elapsed time in `h:mm:ss` clock format for ages over one hour, with an absolute snapshot timestamp in the tooltip.

- `renderFleetProjectRailStructured` (Go) and `projectStateStructuredHTML` (JS) both gate the structured subline on having at least an issue number or session present; a `next_action`-only operator state correctly falls back to the plain summary subline in both renderers.
- `fleetProjectHasAttentionCTA` / `projectHasAttentionCTA` check both `NeedsAttention > 0` and the operator kind, and the Go/JS implementations agree on every case; row click and keydown handlers are updated consistently to open the attention drawer instead of navigating away when the flag is set.
- Four new tests cover the structured attention body, the healthy-idle pill, the clock-format freshness age, and the JS function surface.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all new rendering paths have parity between Go SSR and JS CSR, escaping is applied correctly throughout, and the new click handler correctly guards against double-firing on nested buttons and links.

The changed logic is straightforward and well-exercised by the new tests. Go and JS implementations agree on the structured subline guard, the attention CTA condition, the clock-format threshold, and the healthy-idle key/label. No existing behavior is removed without a direct replacement.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds structured attention subline rendering, attention CTA button, healthy-idle state key/label, clock-format freshness age, and helper functions; Go and JS implementations are well-paired and escaping is correct throughout |
| internal/server/fleet_test.go | Four new tests covering structured attention body, healthy-idle pill, long-age clock formatting, and JS click-handler presence; all assertions exercise the new code paths correctly |
| internal/server/web/static/fleet.js | Adds projectStateStructuredHTML, projectHasAttentionCTA, openProjectAttentionDrawer, formatClockDuration, and updated click/keydown row handlers; logic mirrors the Go SSR path faithfully |
| internal/server/web/static/fleet.css | Adds rail-state-healthy_idle, rail-structured, rail-cta, and focus-visible styles for the new structured subline and attention CTA button |
| internal/server/web/templates/fleet.html | Version query strings bumped on CSS and JS assets to bust caches; no other template logic changed |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-91-532..."](https://github.com/befeast/maestro/commit/0e23496195d65ff5e4abfb2003c7c8bd29a2d912) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34823968)</sub>

<!-- /greptile_comment -->