### PR TITLE
fix(orchestrator): clear stale restart_required flag on daemon start (#549)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1107,6 +1107,14 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 	worker.SweepStaleVisualQA()
 
 	if !once {
+		// The long-running daemon just (re)started — that is the "restart" the
+		// restart-required banner asks for. Reconcile any stale restart_required
+		// flag persisted by a previous process into this process's reality (the
+		// in-memory signal is false on a clean start) so the banner does not
+		// survive the very restart it requested. A genuine post-start config
+		// change still re-raises the signal via reloadConfig.
+		o.clearStaleRestartRequired()
+
 		// Full ProjectV2 item sweeps are expensive and only repair board drift.
 		// Do not run one immediately after every daemon restart; session-state
 		// mirroring still runs, and the broad sweep can wait for the normal
@@ -1310,6 +1318,39 @@ func (o *Orchestrator) persistRestartRequired() {
 	s.RestartRequiredReason = o.restartRequiredReason
 	if err := state.Save(o.cfg.StateDir, s); err != nil {
 		log.Printf("[orch] warn: could not save restart-required signal to state: %v", err)
+	}
+}
+
+// clearStaleRestartRequired reconciles a stale restart-required flag from a
+// previous process into the freshly-started daemon's reality. The restart-required
+// signal asks the operator to restart the daemon; once the daemon actually (re)starts
+// it is loaded from whatever config is now on disk, so the in-memory restartRequired
+// is the truth (false on a clean start). Nothing else clears the persisted flag — not
+// a fresh start and not a config revert — so without this it survives the very restart
+// it requested and produces a false banner in `maestro status` / the Fleet dashboard.
+//
+// This is only safe to call from the long-running daemon startup (Run with once=false),
+// which is the actual "restart" the banner refers to. A genuine post-start config change
+// still re-raises the signal through markRestartRequired in reloadConfig, so the real
+// signal is preserved. Best-effort: a load/save failure is logged but never aborts start.
+func (o *Orchestrator) clearStaleRestartRequired() {
+	if o.restartRequired {
+		// A real signal was already raised in-process before start completed; keep it.
+		return
+	}
+	s, err := state.Load(o.cfg.StateDir)
+	if err != nil {
+		log.Printf("[orch] warn: could not load state to clear stale restart-required signal: %v", err)
+		return
+	}
+	if !s.RestartRequired && s.RestartRequiredReason == "" {
+		return
+	}
+	log.Printf("[orch] clearing stale restart-required signal from previous process (was: %q)", s.RestartRequiredReason)
+	s.RestartRequired = false
+	s.RestartRequiredReason = ""
+	if err := state.Save(o.cfg.StateDir, s); err != nil {
+		log.Printf("[orch] warn: could not save cleared restart-required signal to state: %v", err)
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -7538,6 +7538,120 @@ func TestReloadConfig_RoutingChangeSetsRestartRequired(t *testing.T) {
 	}
 }
 
+// TestClearStaleRestartRequired_ClearsOnFreshStart verifies that a restart_required
+// flag persisted by a previous process is reconciled away on a fresh daemon start
+// (issue #549). The banner must not survive the very restart it asked the operator to
+// perform. A genuine config change after start must still re-raise the signal.
+func TestClearStaleRestartRequired_ClearsOnFreshStart(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:     "owner/repo",
+		StateDir: dir,
+		Model: config.ModelConfig{
+			Default:  "codex",
+			Backends: map[string]config.BackendDef{"codex": {Cmd: "codex"}, "claude": {Cmd: "claude"}},
+		},
+	}
+
+	// Seed state.json with a stale restart-required flag left over from a previous
+	// process (e.g. a model.default change that has since been reverted).
+	s, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	s.RestartRequired = true
+	s.RestartRequiredReason = "model.default changed (claude → freellm)"
+	if err := state.Save(dir, s); err != nil {
+		t.Fatalf("save seed state: %v", err)
+	}
+
+	// Fresh orchestrator: in-memory restartRequired is the zero value (false), which
+	// is the truth right after a (re)start.
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: notify.NewWithToken("", "", "", ""),
+		router:   router.New(cfg),
+	}
+
+	o.clearStaleRestartRequired()
+
+	if o.restartRequired {
+		t.Fatal("in-memory restartRequired unexpectedly set on a fresh start")
+	}
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("reload state: %v", err)
+	}
+	if st.RestartRequired {
+		t.Fatalf("state.RestartRequired = true, want cleared after fresh start; reason=%q", st.RestartRequiredReason)
+	}
+	if st.RestartRequiredReason != "" {
+		t.Fatalf("state.RestartRequiredReason = %q, want empty after fresh start", st.RestartRequiredReason)
+	}
+
+	// A real config change applied AFTER start must still surface the signal — the
+	// fix clears stale state, it must not break the live signal.
+	newCfg := &config.Config{
+		Repo:     "owner/repo",
+		StateDir: dir,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"codex": {Cmd: "codex"}, "claude": {Cmd: "claude"}},
+		},
+	}
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	o.reloadConfig(newCfg, &ticker)
+
+	if !o.restartRequired {
+		t.Fatal("restartRequired not re-raised by a real config change after start")
+	}
+	st, err = state.Load(dir)
+	if err != nil {
+		t.Fatalf("reload state after change: %v", err)
+	}
+	if !st.RestartRequired || !strings.Contains(st.RestartRequiredReason, "model.default") {
+		t.Fatalf("state restart-required not re-persisted after real change: %+v", st)
+	}
+}
+
+// TestClearStaleRestartRequired_PreservesInProcessSignal verifies that if a real
+// restart-required signal was already raised within this process before start
+// completes, clearStaleRestartRequired keeps it (it only reconciles stale state from a
+// PREVIOUS process, never a live in-process signal).
+func TestClearStaleRestartRequired_PreservesInProcessSignal(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:     "owner/repo",
+		StateDir: dir,
+		Model: config.ModelConfig{
+			Default:  "codex",
+			Backends: map[string]config.BackendDef{"codex": {Cmd: "codex"}},
+		},
+	}
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: notify.NewWithToken("", "", "", ""),
+		router:   router.New(cfg),
+	}
+	o.markRestartRequired("model.default changed (codex → claude)")
+
+	o.clearStaleRestartRequired()
+
+	if !o.restartRequired {
+		t.Fatal("clearStaleRestartRequired wiped a live in-process restart-required signal")
+	}
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if !st.RestartRequired {
+		t.Fatal("state restart-required cleared despite a live in-process signal")
+	}
+}
+
 // --- issue #456: pre-spawn guard for already-merged / closed issues ---
 
 // TestStartNewWorkers_SkipsIssueWithMergedPRDespiteStaleReadyLabel verifies that an


### PR DESCRIPTION
## Problem

The `restart_required` signal persisted in `state.json` was **never cleared**. Once `markRestartRequired()` set `restart_required: true` (on a `model.default` / `routing.*` change detected during a config reload), nothing ever reset it — not a fresh process start, not reverting the offending config back to its original value. The result was a false "restart required" banner in `maestro status` and the Fleet Mission Control dashboard that survived the very restart it asked the operator to perform.

Verified live (2026-06-01, dogfood on `workshop`): after a `model.default` edit was reverted **and** after a full `systemctl --user restart`, `maestro status` still showed `Restart req.: yes — model.default changed (claude → freellm)`.

See #549 for the full diagnosis and file:line citations.

## Fix

A fresh long-running daemon start *is* the "restart" the banner asks for: at that point the in-memory `restartRequired` is `false` (the daemon was just (re)started from whatever config is on disk), which is the truth. This PR adds `clearStaleRestartRequired()` and calls it from `Run()` on the daemon path (`once == false`) before the first cycle, so a stale flag persisted by a previous process is reconciled away.

The real signal is preserved:

- **Only the long-running daemon path clears.** The `--once` short-lived path (used by `maestro status`-style commands) does NOT clear, since the flag exists precisely to survive across those short-lived processes until the daemon itself is restarted.
- **A genuine `model.default` / `routing.*` change applied after start still re-raises the signal** through `markRestartRequired` in `reloadConfig`.
- **`clearStaleRestartRequired` refuses to wipe a live in-process signal** (it only reconciles stale state from a previous process).

## Tests

- `TestClearStaleRestartRequired_ClearsOnFreshStart` — state loaded with `restart_required: true` at a fresh start is cleared; a real config change after start re-raises it (signal not broken).
- `TestClearStaleRestartRequired_PreservesInProcessSignal` — a signal raised in this process before start completes is kept.

## Verification

On `workshop` from the feature branch worktree:

```
go fmt ./...   # clean
go build ./cmd/maestro/   # BUILD OK
go vet ./...   # VET ALL OK
go test ./...  # all packages ok (orchestrator + full suite green)
```

## Acceptance (from #549)

- After a daemon restart with no config drift, `restart_required` is `false` in `state.json` and `maestro status` shows no `Restart req.` line. ✅
- A real `model.default` / `routing.*` change after start still surfaces the flag. ✅
- Unit test covering both directions. ✅

Closes #549

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a persistent false-positive "restart required" banner in `maestro status` and the Fleet dashboard by clearing the stale `restart_required` flag in `state.json` when the long-running daemon starts up — the moment that constitutes the restart the flag was asking for.

- Adds `clearStaleRestartRequired()`, which no-ops if an in-process signal is already live, otherwise loads `state.json`, and clears the flag if it was set by a previous process. Best-effort: load/save failures are logged but never abort startup.
- Calls the new function from `Run()` on the `once=false` (daemon) path only, before the first `RunOnce()`, so `--once` callers (e.g. `maestro status`) still read the persisted flag until the daemon itself restarts.
- Adds two focused unit tests: one verifying the stale flag is cleared on fresh start while a real post-start config change still re-raises it, and one verifying a live in-process signal is never wiped.

<h3>Confidence Score: 5/5</h3>

The change is narrow, well-guarded, and best-effort — a disk failure during clear logs a warning but does not abort the daemon. No existing behavior is altered on the --once path.

The new function is called before any concurrent work begins, so there is no ordering ambiguity with reloadConfig. The in-process guard correctly preserves a live signal raised before startup completes. Both directions are unit-tested, and the fix matches the described root cause exactly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds clearStaleRestartRequired() called at daemon startup (once=false) to reconcile a stale restart_required flag in state.json; logic, guard, and placement are correct |
| internal/orchestrator/orchestrator_test.go | Adds two unit tests covering both directions of clearStaleRestartRequired: clearing stale disk state on fresh start and preserving a live in-process signal |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): clear stale restart\_r..."](https://github.com/befeast/maestro/commit/5755428c273f225599aee157c1c120dcaefadfa0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34824490)</sub>

<!-- /greptile_comment -->