### PR TITLE
fix(approver): update-branch BEHIND PRs instead of failing merge_pr (#547)

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -26,6 +26,18 @@ import (
 type GitHubClient interface {
 	MergePR(prNumber int) error
 	CloseIssue(number int, comment string) error
+
+	// PRMergeStatus returns the normalized mergeable verdict
+	// ("MERGEABLE"/"CONFLICTING"/"UNKNOWN") and the raw GitHub
+	// mergeable_state ("clean", "behind", "dirty", ...). executeMergePR
+	// uses it to tell a recoverable BEHIND PR apart from a real
+	// conflict before deciding whether to merge, update-branch, or fail
+	// (#547).
+	PRMergeStatus(prNumber int) (mergeable string, mergeStateStatus string, err error)
+
+	// UpdateBranch brings a BEHIND PR head up to date with its base
+	// branch (no --admin bypass). Used by executeMergePR (#547).
+	UpdateBranch(prNumber int) error
 }
 
 // WorktreeRemover removes a git worktree. *worker.RemoveWorktree-shaped
@@ -248,6 +260,52 @@ func (e *Executor) executeMergePR(approval *state.Approval) Result {
 		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no GitHub client wired into executor")}
 	}
 	pr := approval.Target.PR
+
+	// #547: a green PR that has fallen BEHIND main cannot merge under
+	// "branches must be up to date" protection — `gh pr merge` fails with
+	// "the head branch is not up to date". That is a recoverable state,
+	// not a genuine failure: bring the branch up to date (no --admin
+	// bypass) and let the next supervisor cycle re-validate and re-mint
+	// against the new head. Reserve execution_failed for PRs that are
+	// truly unmergeable (real conflicts).
+	//
+	// We inspect the fresh single-PR mergeable_state first. Only two
+	// states change behaviour here:
+	//   - "behind" + mergeable  -> UpdateBranch, return non-failure
+	//   - genuine conflict       -> execution_failed without touching GH
+	// Everything else (clean / blocked / unstable / unknown, or a status
+	// fetch error) falls through to the original MergePR path, so the
+	// happy path and `gh pr merge`'s own gating are preserved unchanged.
+	mergeable, mergeState, statusErr := e.GH.PRMergeStatus(pr)
+	if statusErr == nil {
+		switch {
+		case mergeState == "behind" && mergeable != "CONFLICTING":
+			if err := e.GH.UpdateBranch(pr); err != nil {
+				return Result{
+					Status:  state.ApprovalStatusExecutionFailed,
+					Summary: fmt.Sprintf("update branch for PR #%d (was behind main): %v", pr, err),
+					Err:     fmt.Errorf("update branch for PR #%d: %w", pr, err),
+				}
+			}
+			// Non-failure terminal status: the branch was updated, the
+			// head SHA moved, and this approval's target_state_hash is now
+			// stale. We deliberately do NOT poll CI or merge here. The next
+			// supervisor cycle re-evaluates against the new head and mints
+			// a fresh merge_pr (the at-mint dedup in
+			// RecordPendingApprovalForDecision supersedes this stale one).
+			return Result{
+				Status:  state.ApprovalStatusExecutionSkipped,
+				Summary: fmt.Sprintf("PR #%d was behind main; branch updated, will re-validate and merge on the next supervisor cycle", pr),
+			}
+		case mergeable == "CONFLICTING":
+			return Result{
+				Status:  state.ApprovalStatusExecutionFailed,
+				Summary: fmt.Sprintf("PR #%d is not mergeable (conflicts with base) — resolve conflicts before merging", pr),
+				Err:     fmt.Errorf("PR #%d unmergeable: mergeable_state=%q", pr, mergeState),
+			}
+		}
+	}
+
 	if err := e.GH.MergePR(pr); err != nil {
 		return Result{
 			Status:  state.ApprovalStatusExecutionFailed,

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -10,12 +10,26 @@ import (
 	"github.com/befeast/maestro/internal/state"
 )
 
-// fakeGH lets tests stub MergePR and CloseIssue.
+// fakeGH lets tests stub MergePR, CloseIssue, PRMergeStatus and
+// UpdateBranch.
+//
+// By default PRMergeStatus returns ("", "", nil) which executeMergePR
+// treats as "don't know, proceed to merge" — so the pre-#547 happy-path
+// tests keep merging without any extra setup. Tests that exercise the
+// #547 paths set mergeable/mergeState explicitly.
 type fakeGH struct {
-	mergeCalls []int
-	closeCalls []closeCall
-	mergeErr   error
-	closeErr   error
+	mergeCalls  []int
+	closeCalls  []closeCall
+	updateCalls []int
+	mergeErr    error
+	closeErr    error
+
+	// #547 stubs for PRMergeStatus.
+	mergeable      string
+	mergeState     string
+	mergeStatusErr error
+	// updateErr is returned by UpdateBranch.
+	updateErr error
 }
 
 type closeCall struct {
@@ -30,6 +44,13 @@ func (f *fakeGH) MergePR(pr int) error {
 func (f *fakeGH) CloseIssue(issue int, comment string) error {
 	f.closeCalls = append(f.closeCalls, closeCall{issue: issue, comment: comment})
 	return f.closeErr
+}
+func (f *fakeGH) PRMergeStatus(pr int) (string, string, error) {
+	return f.mergeable, f.mergeState, f.mergeStatusErr
+}
+func (f *fakeGH) UpdateBranch(pr int) error {
+	f.updateCalls = append(f.updateCalls, pr)
+	return f.updateErr
 }
 
 type fakeWT struct {
@@ -135,6 +156,139 @@ func TestExecute_MergePR_HappyPath(t *testing.T) {
 	}
 	if len(gh.mergeCalls) != 1 || gh.mergeCalls[0] != 99 {
 		t.Fatalf("mergeCalls = %v", gh.mergeCalls)
+	}
+}
+
+// --- #547: BEHIND-but-mergeable PR -> update-branch, do not fail --------------
+
+// TestExecute_MergePR_Behind_UpdatesBranchAndSkips verifies the core #547
+// fix: a green PR that has fallen behind main is brought up to date via
+// UpdateBranch and returns a NON-failure status (execution_skipped) with a
+// re-validate summary, WITHOUT calling MergePR. The next supervisor cycle
+// re-mints against the new head.
+func TestExecute_MergePR_Behind_UpdatesBranchAndSkips(t *testing.T) {
+	gh := &fakeGH{mergeable: "MERGEABLE", mergeState: "behind"}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 542}, "merge", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionSkipped {
+		t.Fatalf("status = %q, want execution_skipped; res=%+v", res.Status, res)
+	}
+	if len(gh.updateCalls) != 1 || gh.updateCalls[0] != 542 {
+		t.Fatalf("updateCalls = %v, want [542]", gh.updateCalls)
+	}
+	if len(gh.mergeCalls) != 0 {
+		t.Fatalf("MergePR must NOT be called when behind; got %v", gh.mergeCalls)
+	}
+	if res.Err != nil {
+		t.Fatalf("err = %v, want nil (behind is recoverable, not a failure)", res.Err)
+	}
+	if !strings.Contains(res.Summary, "#542") || !strings.Contains(strings.ToLower(res.Summary), "behind") {
+		t.Fatalf("summary = %q, want PR ref + behind explanation", res.Summary)
+	}
+	if !strings.Contains(strings.ToLower(res.Summary), "re-validate") && !strings.Contains(strings.ToLower(res.Summary), "next supervisor cycle") {
+		t.Fatalf("summary = %q, want hint about re-validation on next cycle", res.Summary)
+	}
+}
+
+// TestExecute_MergePR_Clean_Merges verifies a CLEAN+mergeable PR still
+// merges normally (no update-branch detour).
+func TestExecute_MergePR_Clean_Merges(t *testing.T) {
+	gh := &fakeGH{mergeable: "MERGEABLE", mergeState: "clean"}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 100}, "merge", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("status = %q, want executed; res=%+v", res.Status, res)
+	}
+	if len(gh.mergeCalls) != 1 || gh.mergeCalls[0] != 100 {
+		t.Fatalf("mergeCalls = %v, want [100]", gh.mergeCalls)
+	}
+	if len(gh.updateCalls) != 0 {
+		t.Fatalf("UpdateBranch must NOT be called for a clean PR; got %v", gh.updateCalls)
+	}
+}
+
+// TestExecute_MergePR_Conflicting_Fails verifies a genuinely unmergeable PR
+// (real conflict) returns execution_failed and never touches MergePR or
+// UpdateBranch — execution_failed is reserved for this case.
+func TestExecute_MergePR_Conflicting_Fails(t *testing.T) {
+	gh := &fakeGH{mergeable: "CONFLICTING", mergeState: "dirty"}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed || res.Err == nil {
+		t.Fatalf("res = %+v, want execution_failed with non-nil Err", res)
+	}
+	if len(gh.mergeCalls) != 0 {
+		t.Fatalf("MergePR must NOT be called for a conflicting PR; got %v", gh.mergeCalls)
+	}
+	if len(gh.updateCalls) != 0 {
+		t.Fatalf("UpdateBranch must NOT be called for a conflicting PR; got %v", gh.updateCalls)
+	}
+	if !strings.Contains(strings.ToLower(res.Summary), "conflict") {
+		t.Fatalf("summary = %q, want conflict explanation", res.Summary)
+	}
+}
+
+// TestExecute_MergePR_BehindButConflicting_DoesNotUpdate guards the AND in
+// the BEHIND branch: a PR reported behind but also CONFLICTING must fall to
+// the conflict failure, not silently update-branch.
+func TestExecute_MergePR_BehindButConflicting_DoesNotUpdate(t *testing.T) {
+	gh := &fakeGH{mergeable: "CONFLICTING", mergeState: "behind"}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 8}, "merge", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("res = %+v, want execution_failed", res)
+	}
+	if len(gh.updateCalls) != 0 {
+		t.Fatalf("UpdateBranch must NOT run for a conflicting PR; got %v", gh.updateCalls)
+	}
+}
+
+// TestExecute_MergePR_Behind_UpdateBranchError_Fails verifies that if the
+// update-branch call itself errors, that surfaces as execution_failed (so
+// the operator sees the real blocker) and MergePR is not attempted.
+func TestExecute_MergePR_Behind_UpdateBranchError_Fails(t *testing.T) {
+	gh := &fakeGH{mergeable: "MERGEABLE", mergeState: "behind", updateErr: errors.New("update boom")}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 9}, "merge", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed || res.Err == nil {
+		t.Fatalf("res = %+v, want execution_failed", res)
+	}
+	if len(gh.mergeCalls) != 0 {
+		t.Fatalf("MergePR must NOT be called after a failed update-branch; got %v", gh.mergeCalls)
+	}
+	if !strings.Contains(res.Err.Error(), "update branch for PR #9") {
+		t.Fatalf("err = %v, want update-branch context", res.Err)
+	}
+}
+
+// TestExecute_MergePR_StatusFetchError_StillMerges verifies that a failure
+// to fetch the merge status does NOT block the merge — we fall through to
+// the original MergePR path (gh pr merge does its own gating). This keeps
+// the change additive and avoids a status-endpoint flake stalling merges.
+func TestExecute_MergePR_StatusFetchError_StillMerges(t *testing.T) {
+	gh := &fakeGH{mergeStatusErr: errors.New("rate limited")}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 11}, "merge", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed (fall through on status error)", res)
+	}
+	if len(gh.mergeCalls) != 1 || gh.mergeCalls[0] != 11 {
+		t.Fatalf("mergeCalls = %v, want [11]", gh.mergeCalls)
+	}
+	if len(gh.updateCalls) != 0 {
+		t.Fatalf("UpdateBranch must NOT run on a status-fetch error; got %v", gh.updateCalls)
 	}
 }
 

--- a/internal/approver/idempotent_test.go
+++ b/internal/approver/idempotent_test.go
@@ -43,6 +43,17 @@ func (b *blockingGH) CloseIssue(issue int, comment string) error {
 	return nil
 }
 
+// PRMergeStatus returns the zero verdict so executeMergePR falls straight
+// through to MergePR — this test only exercises the per-approval lock, not
+// the #547 behind-branch path.
+func (b *blockingGH) PRMergeStatus(pr int) (string, string, error) {
+	return "", "", nil
+}
+func (b *blockingGH) UpdateBranch(pr int) error {
+	atomic.AddInt32(&b.calls, 1)
+	return nil
+}
+
 // --- #488: per-approval-ID lock (concurrent Execute) -----------------------
 
 func TestExecute_ConcurrentSameApproval_OnlyOneSideEffect(t *testing.T) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -300,14 +300,16 @@ func prClosesIssue(pr PR, issueNumber int) bool {
 // whitespace and an optional `:` between the keyword and the hash.
 //
 // Examples that match (issueNumber = 487):
-//   "Closes #487"        "fixes: #487"        "Resolved #487."
-//   "...closes #487\nThis PR ..."             "RESOLVES #487"
+//
+//	"Closes #487"        "fixes: #487"        "Resolved #487."
+//	"...closes #487\nThis PR ..."             "RESOLVES #487"
 //
 // Examples that do NOT match:
-//   "P0 #487: add HTTP auth ..."     (bare mention)
-//   "Refs #487"                      (Refs is not a closing keyword)
-//   "see #487 for context"
-//   "ticket-487"                     (no `#`, also no closing keyword)
+//
+//	"P0 #487: add HTTP auth ..."     (bare mention)
+//	"Refs #487"                      (Refs is not a closing keyword)
+//	"see #487 for context"
+//	"ticket-487"                     (no `#`, also no closing keyword)
 func closingKeywordRegexp(issueNumber int) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf(
 		`(?i)(?:^|[^a-z])(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#%d(?:[^0-9]|$)`,
@@ -729,6 +731,25 @@ func (c *Client) PRMergeable(prNumber int) (string, error) {
 	return mergeableFromRESTPull(pr), nil
 }
 
+// PRMergeStatus returns both the normalized mergeable verdict
+// ("MERGEABLE" / "CONFLICTING" / "UNKNOWN") AND the raw GitHub
+// mergeable_state ("clean", "behind", "blocked", "dirty", "unstable",
+// "unknown", "draft", "has_hooks") for a single PR, fetched from the
+// REST single-PR endpoint (reused by #543/#544 for a fresh mergeable
+// signal). The executor needs the raw state to distinguish a green PR
+// that has merely fallen BEHIND main (recoverable via update-branch)
+// from one with a real conflict (#547).
+//
+// mergeStateStatus is lower-cased and trimmed; "" means GitHub has not
+// computed it yet (caller should treat that as "don't know, proceed").
+func (c *Client) PRMergeStatus(prNumber int) (mergeable string, mergeStateStatus string, err error) {
+	pr, err := c.getRESTPull(prNumber)
+	if err != nil {
+		return "", "", fmt.Errorf("get pull %d: %w", prNumber, err)
+	}
+	return mergeableFromRESTPull(pr), strings.ToLower(strings.TrimSpace(pr.MergeableState)), nil
+}
+
 // PRGreptileApproved checks whether Greptile has approved the PR.
 //
 // Primary path: reads GitHub Check Runs for the PR's head SHA.
@@ -950,6 +971,26 @@ func (c *Client) MergePR(prNumber int) error {
 		"--delete-branch").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("gh pr merge %d: %w\n%s", prNumber, err, out)
+	}
+	return nil
+}
+
+// UpdateBranch merges the base branch into the PR's head branch so a
+// green-but-BEHIND PR becomes up to date with main, satisfying the
+// "branches must be up to date before merging" branch-protection rule.
+// It is the non-bypass alternative to `gh pr merge --admin`: the updated
+// head re-runs required checks and only merges once they pass.
+//
+// Updating the branch changes the PR head SHA, so any approval minted
+// against the old head becomes stale — callers must NOT merge in the
+// same pass; they should let the next supervisor cycle re-validate and
+// re-mint against the new state (#547).
+func (c *Client) UpdateBranch(prNumber int) error {
+	out, err := exec.Command("gh", "pr", "update-branch",
+		fmt.Sprint(prNumber),
+		"--repo", c.Repo).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh pr update-branch %d: %w\n%s", prNumber, err, out)
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

The cautious-gate executor cannot land a green PR that has fallen **BEHIND** `main`.
`Executor.executeMergePR` (`internal/approver/executor.go`) called `github.Client.MergePR`, which runs:

```
gh pr merge <N> --repo <repo> --squash --delete-branch
```

No `update-branch`, no `--admin`. Branch protection on `main` requires branches be up to date, so the moment any other PR merges, every open PR goes `mergeStateStatus=BEHIND` and the approved `merge_pr` fails `execution_failed` with *"the head branch is not up to date with the base branch."* The supervisor mints `merge_pr` and the operator approves, but the merge never lands.

Live evidence (2026-06-01): PR #542 was `mergeable=MERGEABLE` but `mergeStateStatus=BEHIND`; the minted `merge_pr` would have failed. It had to be `gh pr update-branch`'d manually before the approval could execute.

## Root cause

`executeMergePR` had no notion of the BEHIND-but-mergeable state. It treated every non-clean merge as a hard failure and never brought the branch up to date.

## Fix

`executeMergePR` now inspects the fresh single-PR `mergeable_state` (reusing the `#543/#544` single-PR refetch path) **before** merging:

- **BEHIND + mergeable** → call the new `github.Client.UpdateBranch` (`gh pr update-branch`, **no `--admin` bypass**) and return a **non-failure** status (`execution_skipped`) with a clear summary: *"PR #N was behind main; branch updated, will re-validate and merge on the next supervisor cycle."* It does **not** poll CI or merge in the same call — `update-branch` moves the head SHA, so this approval's `target_state_hash` is now stale. The next supervisor cycle re-evaluates against the new head and mints a fresh `merge_pr`; the at-mint dedup in `state.RecordPendingApprovalForDecision` supersedes the stale approval.
- **CONFLICTING / dirty** (genuine conflict) → `execution_failed`, without touching `MergePR` or `UpdateBranch`. `execution_failed` is now reserved for truly unmergeable PRs.
- **clean / blocked / unstable / unknown**, or a status-fetch error → fall through to the original `MergePR` path unchanged, so `gh pr merge`'s own gating and the existing happy path are preserved. A status-endpoint flake therefore never stalls a merge.

No `--admin` is used: a BEHIND branch is updated and re-validated against current `main` before it can merge.

### New surface

- `github.Client.PRMergeStatus(prNumber) (mergeable, mergeStateStatus string, err error)` — returns both the normalized verdict and the raw GitHub `mergeable_state`.
- `github.Client.UpdateBranch(prNumber) error` — `gh pr update-branch <N> --repo <repo>` (default merge-commit, no history rewrite).
- The approver `GitHubClient` interface gains `PRMergeStatus` + `UpdateBranch`; test fakes updated.

## Tests

Added unit tests in `internal/approver/executor_test.go` (mock GH client):

- `BEHIND + mergeable` → `UpdateBranch` called once, `MergePR` not called, status `execution_skipped`, no error, summary references re-validation.
- `CLEAN + mergeable` → `MergePR` called, status `executed`, no `UpdateBranch`.
- `CONFLICTING` → `execution_failed`, neither `MergePR` nor `UpdateBranch` called.
- `BEHIND + CONFLICTING` → falls to the conflict failure, no `UpdateBranch`.
- `UpdateBranch` error → `execution_failed`, `MergePR` not attempted.
- status-fetch error → falls through to `MergePR` (still merges).

`go build ./cmd/maestro/`, `go vet ./...`, and `go test ./...` all pass.

Closes #547

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the cautious-gate executor failing to merge PRs that are green but have fallen behind `main` under "branches must be up to date" branch protection. Instead of hard-failing, `executeMergePR` now inspects `mergeStateStatus` before attempting a merge.

- **BEHIND + non-conflicting**: calls the new `github.Client.UpdateBranch` (`gh pr update-branch`) and returns `execution_skipped` so the next supervisor cycle re-evaluates against the new head SHA and mints a fresh `merge_pr`. The operator must re-approve against the updated head.
- **CONFLICTING**: returns `execution_failed` immediately with a clear message, reserving that status for genuinely unmergeable PRs.
- **All other states / status-fetch errors**: fall through to the original `MergePR` path unchanged, keeping the happy path and `gh pr merge`'s own gating intact.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new BEHIND-branch path is additive and well-guarded; the existing MergePR happy path is untouched.

All three new code paths (UpdateBranch, CONFLICTING fast-fail, status-fetch fall-through) are exercised by dedicated unit tests. The change is strictly additive: a status-fetch error or any non-BEHIND/non-CONFLICTING state falls straight through to the original MergePR call. No confirmed logic defects were found in the changed files beyond those already discussed in prior review threads.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/approver/executor.go | Adds BEHIND-branch detection before MergePR: calls UpdateBranch and returns execution_skipped for recoverable state, fast-fails on CONFLICTING, and falls through on status-fetch errors. Logic is sound. |
| internal/approver/executor_test.go | Six new unit tests cover BEHIND→skip, CLEAN→merge, CONFLICTING→fail, BEHIND+CONFLICTING→fail, UpdateBranch error→fail, and status-fetch error→fall-through. Coverage is complete for the new decision tree. |
| internal/approver/idempotent_test.go | Adds PRMergeStatus/UpdateBranch stubs to blockingGH. UpdateBranch shares the b.calls counter with MergePR/CloseIssue (flagged in previous thread); safe today because UpdateBranch is never invoked by the concurrency test. |
| internal/github/github.go | Adds PRMergeStatus (reuses getRESTPull, normalises mergeStateStatus) and UpdateBranch (shells out to gh pr update-branch). Both implementations are consistent with the existing MergePR/PRMergeable patterns. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/547-executo..."](https://github.com/befeast/maestro/commit/887de898dcaf590828c0a300cfdc5a1f49b36d24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34824753)</sub>

<!-- /greptile_comment -->