### PR TITLE
feat(orchestrator): graceful drain mode — maestro drain blocks new spawns, waits for in-flight workers, exits clean (#541)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -48,6 +48,7 @@ Commands:
   logs          Show worker logs (tail -f)
   watch         Open tmux dashboard with live worker output
   spawn         Spawn a worker for a specific issue number
+  drain         Stop spawning new workers and wait for in-flight workers to finish
   stop          Stop a worker session
   kill          Kill a worker session by slot name
   import        Seed state from existing worktrees
@@ -83,6 +84,16 @@ Serve flags:
 Spawn flags:
   --issue int           Issue number to work on
   --prompt string       Path to worker prompt base file
+
+Drain flags:
+  --timeout duration    Max wait for in-flight workers to finish (default 30m)
+
+  Graceful drain (#541): sets a state flag so the running supervisor stops
+  spawning new workers, then waits for in-flight workers to finish. Exit 0 once
+  drained, exit 1 on timeout (the flag is left set so you can investigate). Wire
+  it as the systemd ExecStop so "systemctl --user restart" drains first:
+    ExecStop=/usr/local/bin/maestro drain --config <cfg> --timeout 30m
+  The drain flag clears automatically when the supervisor next starts.
 
 Stop flags:
   --session string      Session name to stop (e.g. pan-1)
@@ -263,6 +274,8 @@ func main() {
 		watchCmd(args)
 	case "spawn":
 		spawnCmd(args)
+	case "drain":
+		drainCmd(args)
 	case "stop":
 		stopCmd(args)
 	case "kill":
@@ -1681,6 +1694,111 @@ func spawnCmd(args []string) {
 	}
 
 	fmt.Printf("Started worker %s for issue #%d: %s\n", slotName, *issueNum, targetIssue.Title)
+}
+
+// drainDefaultTimeout is the default ceiling drain waits for in-flight workers.
+const drainDefaultTimeout = 30 * time.Minute
+
+// drainPollInterval is how often drain re-reads state to see if running
+// workers have finished.
+var drainPollInterval = 5 * time.Second
+
+// errDrainTimeout is returned by drainWait when the timeout elapses before all
+// in-flight workers finish.
+var errDrainTimeout = errors.New("drain timed out with workers still running")
+
+// drainWait blocks until runningCount() reports zero in-flight workers or the
+// timeout elapses, polling on the given interval. It is the testable core of
+// `maestro drain`: the CLI injects a state-backed runningCount and the real
+// clock, tests inject a deterministic counter and a fake clock. progress is
+// called once per observation (after the initial check and after each poll) so
+// the CLI can log progress; it may be nil. Returns errDrainTimeout on timeout.
+func drainWait(runningCount func() (int, error), timeout, interval time.Duration, now func() time.Time, sleep func(time.Duration), progress func(running int)) error {
+	if interval <= 0 {
+		interval = drainPollInterval
+	}
+	deadline := now().Add(timeout)
+	for {
+		running, err := runningCount()
+		if err != nil {
+			return err
+		}
+		if progress != nil {
+			progress(running)
+		}
+		if running == 0 {
+			return nil
+		}
+		if !now().Before(deadline) {
+			return errDrainTimeout
+		}
+		// Do not overshoot the deadline on the final sleep.
+		wait := interval
+		if remaining := deadline.Sub(now()); remaining < wait {
+			wait = remaining
+		}
+		if wait <= 0 {
+			return errDrainTimeout
+		}
+		sleep(wait)
+	}
+}
+
+func drainCmd(args []string) {
+	fs := flag.NewFlagSet("drain", flag.ExitOnError)
+	var configs multiFlag
+	fs.Var(&configs, "config", "Path to config file (can be repeated)")
+	timeout := fs.Duration("timeout", drainDefaultTimeout, "Max time to wait for in-flight workers to finish")
+	fs.Parse(reorderArgs(fs, args))
+
+	cfgs := loadConfigs(configs)
+	if len(cfgs) > 1 {
+		fmt.Fprintln(os.Stderr, "error: drain requires a single --config (one project at a time; see #541 out-of-scope)")
+		os.Exit(1)
+	}
+	cfg := cfgs[0]
+
+	// Set the drain flag so the running orchestrator stops spawning new
+	// workers on its next cycle. This is a load-then-save under the state
+	// lock; a concurrent orchestrator save resolves latest-write-wins.
+	s, err := state.Load(cfg.StateDir)
+	if err != nil {
+		log.Fatalf("load state: %v", err)
+	}
+	s.SetSpawnDrain(time.Now().UTC())
+	if err := state.Save(cfg.StateDir, s); err != nil {
+		log.Fatalf("save state (set drain): %v", err)
+	}
+
+	initialRunning := s.RunningSessionCount()
+	fmt.Printf("Drain requested for %s — no new workers will be spawned. Waiting up to %s for %d in-flight worker(s) to finish...\n",
+		cfg.Repo, timeout.String(), initialRunning)
+
+	runningCount := func() (int, error) {
+		cur, err := state.Load(cfg.StateDir)
+		if err != nil {
+			return 0, fmt.Errorf("load state: %w", err)
+		}
+		return cur.RunningSessionCount(), nil
+	}
+	lastReported := -1
+	progress := func(running int) {
+		if running != lastReported {
+			fmt.Printf("  in-flight workers running: %d\n", running)
+			lastReported = running
+		}
+	}
+
+	err = drainWait(runningCount, *timeout, drainPollInterval, time.Now, time.Sleep, progress)
+	if errors.Is(err, errDrainTimeout) {
+		fmt.Fprintf(os.Stderr, "drain: timed out after %s with workers still running; drain flag left set so you can investigate (maestro status) or kill the stuck worker\n", timeout.String())
+		os.Exit(1)
+	}
+	if err != nil {
+		log.Fatalf("drain: %v", err)
+	}
+
+	fmt.Printf("Drained: no in-flight workers remain. Safe to restart the supervisor (the drain flag clears automatically on startup).\n")
 }
 
 func stopCmd(args []string) {

--- a/cmd/maestro/main_drain_test.go
+++ b/cmd/maestro/main_drain_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeClock advances only when sleep is called, making drainWait fully
+// deterministic and instant under test.
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time        { return c.now }
+func (c *fakeClock) Sleep(d time.Duration) { c.now = c.now.Add(d) }
+
+func TestDrainWait_ReturnsWhenWorkersFinish(t *testing.T) {
+	clk := &fakeClock{now: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)}
+	// 3 -> 3 -> 1 -> 0 across successive observations.
+	counts := []int{3, 3, 1, 0}
+	idx := 0
+	runningCount := func() (int, error) {
+		v := counts[idx]
+		if idx < len(counts)-1 {
+			idx++
+		}
+		return v, nil
+	}
+
+	var observed []int
+	err := drainWait(runningCount, 10*time.Minute, time.Second, clk.Now, clk.Sleep, func(r int) {
+		observed = append(observed, r)
+	})
+	if err != nil {
+		t.Fatalf("drainWait returned %v, want nil once workers reached 0", err)
+	}
+	if got := observed[len(observed)-1]; got != 0 {
+		t.Fatalf("last observed running = %d, want 0", got)
+	}
+	// Should have slept 3 times (after 3, 3, 1) before observing 0.
+	wantElapsed := 3 * time.Second
+	if elapsed := clk.now.Sub(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)); elapsed != wantElapsed {
+		t.Fatalf("elapsed = %v, want %v", elapsed, wantElapsed)
+	}
+}
+
+func TestDrainWait_ReturnsImmediatelyWhenNoWorkers(t *testing.T) {
+	clk := &fakeClock{now: time.Unix(0, 0).UTC()}
+	calls := 0
+	runningCount := func() (int, error) {
+		calls++
+		return 0, nil
+	}
+
+	err := drainWait(runningCount, time.Hour, time.Second, clk.Now, clk.Sleep, nil)
+	if err != nil {
+		t.Fatalf("drainWait = %v, want nil with no running workers", err)
+	}
+	if calls != 1 {
+		t.Fatalf("runningCount called %d times, want 1 (no polling needed)", calls)
+	}
+	if !clk.now.Equal(time.Unix(0, 0).UTC()) {
+		t.Fatal("drainWait slept despite zero workers")
+	}
+}
+
+func TestDrainWait_TimesOutWithWorkersStillRunning(t *testing.T) {
+	clk := &fakeClock{now: time.Unix(0, 0).UTC()}
+	runningCount := func() (int, error) {
+		return 2, nil // never drains
+	}
+
+	err := drainWait(runningCount, 10*time.Second, 3*time.Second, clk.Now, clk.Sleep, nil)
+	if !errors.Is(err, errDrainTimeout) {
+		t.Fatalf("drainWait = %v, want errDrainTimeout", err)
+	}
+	// Must not overshoot the deadline.
+	if elapsed := clk.now.Sub(time.Unix(0, 0).UTC()); elapsed > 10*time.Second {
+		t.Fatalf("elapsed = %v overshot the 10s timeout", elapsed)
+	}
+}
+
+func TestDrainWait_PropagatesCountError(t *testing.T) {
+	clk := &fakeClock{now: time.Unix(0, 0).UTC()}
+	wantErr := errors.New("boom")
+	runningCount := func() (int, error) {
+		return 0, wantErr
+	}
+
+	err := drainWait(runningCount, time.Hour, time.Second, clk.Now, clk.Sleep, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("drainWait = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/orchestrator/orch_drain_test.go
+++ b/internal/orchestrator/orch_drain_test.go
@@ -1,0 +1,100 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// TestStartNewWorkers_DrainBlocksNewSpawns verifies the #541 graceful-drain
+// gate: while state.SpawnDrain is set, startNewWorkers must not list issues or
+// spawn any worker, even when slots and ready issues are available.
+func TestStartNewWorkers_DrainBlocksNewSpawns(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	issues := []github.Issue{makeIssue(541, "ready issue")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	listed := false
+	o.listOpenIssuesFn = func(labelFilter []string) ([]github.Issue, error) {
+		listed = true
+		return issues, nil
+	}
+
+	s := state.NewState()
+	s.SetSpawnDrain(time.Now().UTC())
+
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 0 {
+		t.Fatalf("started %d workers while draining, want 0", len(*started))
+	}
+	if listed {
+		t.Fatal("startNewWorkers listed issues while draining; drain must stop claiming work before any GitHub call")
+	}
+}
+
+// TestStartNewWorkers_NoDrainStillSpawns is a control: without a drain set the
+// same wiring spawns the ready issue, proving the gate (not the harness) is
+// what blocks spawns in the drain test above.
+func TestStartNewWorkers_NoDrainStillSpawns(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	issues := []github.Issue{makeIssue(541, "ready issue")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 || (*started)[0] != 541 {
+		t.Fatalf("started = %v, want [541] when not draining", *started)
+	}
+}
+
+// TestClearSpawnDrainOnStartup_ClearsLeftoverFlag verifies that a freshly
+// started daemon lifts a leftover drain flag so it resumes normal spawning.
+func TestClearSpawnDrainOnStartup_ClearsLeftoverFlag(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.StateDir = t.TempDir()
+
+	s := state.NewState()
+	s.SetSpawnDrain(time.Now().UTC().Add(-time.Minute))
+	if err := state.Save(cfg.StateDir, s); err != nil {
+		t.Fatalf("save drained state: %v", err)
+	}
+
+	o := &Orchestrator{cfg: cfg}
+	o.clearSpawnDrainOnStartup()
+
+	reloaded, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("reload state: %v", err)
+	}
+	if reloaded.DrainActive() {
+		t.Fatal("drain flag still set after clearSpawnDrainOnStartup")
+	}
+}
+
+// TestClearSpawnDrainOnStartup_NoopWhenNotDraining verifies the startup clear
+// is a no-op (no spurious state write churn) when no drain is set.
+func TestClearSpawnDrainOnStartup_NoopWhenNotDraining(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.StateDir = t.TempDir()
+
+	s := state.NewState()
+	if err := state.Save(cfg.StateDir, s); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	o := &Orchestrator{cfg: cfg}
+	o.clearSpawnDrainOnStartup()
+
+	reloaded, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("reload state: %v", err)
+	}
+	if reloaded.DrainActive() {
+		t.Fatal("drain unexpectedly active after no-op startup clear")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1112,6 +1112,13 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 		// mirroring still runs, and the broad sweep can wait for the normal
 		// throttle window.
 		o.deferProjectBoardSweep(time.Now().UTC())
+
+		// Graceful drain (#541) is a one-shot "drain then restart" request. A
+		// fresh daemon must start in normal (non-drained) mode, so clear any
+		// leftover drain flag before the first cycle. Only the long-running
+		// daemon clears it — a `run --once` reconcile tick must not lift a
+		// drain that an operator is mid-way through.
+		o.clearSpawnDrainOnStartup()
 	}
 	if err := o.RunOnce(); err != nil {
 		log.Printf("[orch] run error: %v", err)
@@ -1146,6 +1153,25 @@ func (o *Orchestrator) deferProjectBoardSweep(now time.Time) {
 		return
 	}
 	o.projectItemsSweepAt = now.UTC()
+}
+
+// clearSpawnDrainOnStartup lifts any leftover graceful-drain flag (#541) so a
+// freshly started daemon begins in normal mode. A no-op when no drain is set.
+func (o *Orchestrator) clearSpawnDrainOnStartup() {
+	s, err := state.Load(o.cfg.StateDir)
+	if err != nil {
+		log.Printf("[orch] drain: load state to clear drain flag: %v", err)
+		return
+	}
+	if !s.DrainActive() {
+		return
+	}
+	s.ClearSpawnDrain(time.Now().UTC())
+	if err := state.Save(o.cfg.StateDir, s); err != nil {
+		log.Printf("[orch] drain: clear drain flag on startup: %v", err)
+		return
+	}
+	log.Printf("[orch] drain flag cleared on startup — resuming normal spawns")
 }
 
 // reloadConfig applies non-destructive config changes at runtime.
@@ -3157,6 +3183,17 @@ func sortedStateSessionNames(s *state.State) []string {
 }
 
 func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
+	// Graceful drain (#541): while a drain is requested, refuse to claim new
+	// issues or spawn new workers. In-flight workers keep running; the
+	// operator runs `maestro drain` before a restart so a `systemctl restart`
+	// no longer kills mid-flight workers. The flag is cleared automatically on
+	// the next orchestrator startup. Return before listing issues so drain is
+	// a true "stop accepting new work" gate, not just a per-issue skip.
+	if s.DrainActive() {
+		log.Printf("[orch] drain active (since %s): not spawning new workers (running=%d)",
+			s.SpawnDrainAt.Format(time.RFC3339), s.RunningSessionCount())
+		return
+	}
 	issues, err := o.listOpenIssues(o.cfg.IssueLabels)
 	if err != nil {
 		log.Printf("[orch] list issues: %v", err)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -724,6 +724,15 @@ type State struct {
 	SupervisorStuck       bool   `json:"supervisor_stuck,omitempty"`
 	SupervisorStuckReason string `json:"supervisor_stuck_reason,omitempty"`
 
+	// SpawnDrain requests a graceful drain of the run loop (#541): while it
+	// is set, the orchestrator refuses to claim new issues or spawn new
+	// workers but lets in-flight workers finish. It is set by `maestro
+	// drain` and cleared automatically when the orchestrator starts, so a
+	// drain never persists across a legitimate restart. SpawnDrainAt records
+	// when the drain was requested (UTC).
+	SpawnDrain   bool      `json:"spawn_drain,omitempty"`
+	SpawnDrainAt time.Time `json:"spawn_drain_at,omitempty"`
+
 	loadedHash  string
 	loadedState *State
 }
@@ -919,6 +928,8 @@ func (s *State) copyFrom(src *State) {
 	s.BackendHealth = src.BackendHealth
 	s.NextSlot = src.NextSlot
 	s.LastMergeAt = src.LastMergeAt
+	s.SpawnDrain = src.SpawnDrain
+	s.SpawnDrainAt = src.SpawnDrainAt
 }
 
 func cloneState(s *State) *State {
@@ -960,7 +971,23 @@ func mergeStateSnapshots(base, current, ours *State) (*State, error) {
 	merged.BackendHealth = mergeBackendHealth(current.BackendHealth, ours.BackendHealth)
 	merged.NextSlot = mergeMonotonicInt(base.NextSlot, current.NextSlot, ours.NextSlot)
 	merged.LastMergeAt = mergeLatestTime(base.LastMergeAt, current.LastMergeAt, ours.LastMergeAt)
+	mergeSpawnDrain(merged, current, ours)
 	return merged, nil
+}
+
+// mergeSpawnDrain resolves the drain flag (#541) latest-write-wins by
+// SpawnDrainAt. The drain CLI sets SpawnDrain=true and the orchestrator clears
+// it (SpawnDrain=false) — both stamp SpawnDrainAt — so picking the snapshot
+// with the newer timestamp keeps a concurrent orchestrator save from clobbering
+// a fresh drain request, and a fresh clear from being undone by a stale set.
+func mergeSpawnDrain(merged, current, ours *State) {
+	if ours.SpawnDrainAt.After(current.SpawnDrainAt) {
+		merged.SpawnDrain = ours.SpawnDrain
+		merged.SpawnDrainAt = ours.SpawnDrainAt
+		return
+	}
+	merged.SpawnDrain = current.SpawnDrain
+	merged.SpawnDrainAt = current.SpawnDrainAt
 }
 
 func mergeProjectStatusSync(current, ours map[int]ProjectStatusSync) map[int]ProjectStatusSync {
@@ -1818,6 +1845,56 @@ func (s *State) ActiveSessions() []*Session {
 	return active
 }
 
+// RunningSessions returns the in-flight worker sessions — those whose tmux
+// worker process is actively executing (StatusRunning). Drain (#541) waits for
+// this set to empty; pr_open sessions are intentionally excluded because they
+// have no live worker and are re-attached by the next supervisor's reconcile
+// path after a restart.
+func (s *State) RunningSessions() []*Session {
+	if s == nil {
+		return nil
+	}
+	var running []*Session
+	for _, sess := range s.Sessions {
+		if sess != nil && sess.Status == StatusRunning {
+			running = append(running, sess)
+		}
+	}
+	return running
+}
+
+// RunningSessionCount returns the number of in-flight worker sessions.
+func (s *State) RunningSessionCount() int {
+	return len(s.RunningSessions())
+}
+
+// SetSpawnDrain requests a graceful drain (#541): the run loop stops claiming
+// new issues and spawning new workers but lets in-flight workers finish. The
+// timestamp is stamped so concurrent state writers resolve drain on/off by
+// latest-write-wins.
+func (s *State) SetSpawnDrain(at time.Time) {
+	if s == nil {
+		return
+	}
+	s.SpawnDrain = true
+	s.SpawnDrainAt = normalizedTime(at)
+}
+
+// ClearSpawnDrain lifts a graceful drain. The orchestrator calls this on
+// startup so a drain never persists across a legitimate restart.
+func (s *State) ClearSpawnDrain(at time.Time) {
+	if s == nil {
+		return
+	}
+	s.SpawnDrain = false
+	s.SpawnDrainAt = normalizedTime(at)
+}
+
+// DrainActive reports whether a graceful drain is currently requested.
+func (s *State) DrainActive() bool {
+	return s != nil && s.SpawnDrain
+}
+
 // LiveSessions returns sessions that belong in the default operator view.
 func (s *State) LiveSessions() []*Session {
 	return s.LiveSessionsAt(time.Now().UTC())
@@ -1837,7 +1914,6 @@ func (s *State) LiveSessionsAt(now time.Time) []*Session {
 	}
 	return live
 }
-
 
 // SessionAt returns the live session bound to slot, if any. Used by the
 // approver executor (#488 slot-reuse fence) to verify a delete_worktree

--- a/internal/state/state_drain_test.go
+++ b/internal/state/state_drain_test.go
@@ -1,0 +1,106 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRunningSessions_OnlyCountsRunning(t *testing.T) {
+	s := NewState()
+	s.Sessions["a"] = &Session{Status: StatusRunning}
+	s.Sessions["b"] = &Session{Status: StatusRunning}
+	s.Sessions["c"] = &Session{Status: StatusPROpen} // active but no live worker
+	s.Sessions["d"] = &Session{Status: StatusDone}
+	s.Sessions["e"] = &Session{Status: StatusDead}
+
+	if got := s.RunningSessionCount(); got != 2 {
+		t.Fatalf("RunningSessionCount() = %d, want 2 (pr_open/done/dead must not count)", got)
+	}
+	if got := len(s.RunningSessions()); got != 2 {
+		t.Fatalf("len(RunningSessions()) = %d, want 2", got)
+	}
+}
+
+func TestSetAndClearSpawnDrain(t *testing.T) {
+	s := NewState()
+	if s.DrainActive() {
+		t.Fatal("new state should not be draining")
+	}
+
+	at := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	s.SetSpawnDrain(at)
+	if !s.DrainActive() {
+		t.Fatal("DrainActive() false after SetSpawnDrain")
+	}
+	if !s.SpawnDrainAt.Equal(at) {
+		t.Fatalf("SpawnDrainAt = %v, want %v", s.SpawnDrainAt, at)
+	}
+
+	later := at.Add(time.Minute)
+	s.ClearSpawnDrain(later)
+	if s.DrainActive() {
+		t.Fatal("DrainActive() true after ClearSpawnDrain")
+	}
+	if !s.SpawnDrainAt.Equal(later) {
+		t.Fatalf("SpawnDrainAt = %v, want %v after clear", s.SpawnDrainAt, later)
+	}
+}
+
+func TestSpawnDrain_SurvivesSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := NewState()
+	at := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s.SetSpawnDrain(at)
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	reloaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !reloaded.DrainActive() {
+		t.Fatal("drain flag lost across save/load")
+	}
+	if !reloaded.SpawnDrainAt.Equal(at) {
+		t.Fatalf("SpawnDrainAt = %v, want %v after round trip", reloaded.SpawnDrainAt, at)
+	}
+}
+
+// TestMergeSpawnDrain_LatestWriteWins covers the concurrent-save path: a drain
+// request must survive an orchestrator save that does not carry the flag (older
+// timestamp), and a fresh clear must not be undone by a stale set.
+func TestMergeSpawnDrain_LatestWriteWins(t *testing.T) {
+	t0 := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+
+	t.Run("fresh drain beats stale current", func(t *testing.T) {
+		base := NewState()
+		current := NewState() // orchestrator's on-disk snapshot, no drain
+		ours := NewState()
+		ours.SetSpawnDrain(t0.Add(time.Minute)) // drain CLI's newer write
+
+		merged, err := mergeStateSnapshots(base, current, ours)
+		if err != nil {
+			t.Fatalf("merge: %v", err)
+		}
+		if !merged.DrainActive() {
+			t.Fatal("fresh drain request lost to stale concurrent save")
+		}
+	})
+
+	t.Run("fresh clear beats stale set", func(t *testing.T) {
+		base := NewState()
+		current := NewState()
+		current.ClearSpawnDrain(t0.Add(2 * time.Minute)) // daemon's fresh clear
+		ours := NewState()
+		ours.SetSpawnDrain(t0) // a stale set
+
+		merged, err := mergeStateSnapshots(base, current, ours)
+		if err != nil {
+			t.Fatalf("merge: %v", err)
+		}
+		if merged.DrainActive() {
+			t.Fatal("stale set undid a fresh clear")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`systemctl --user restart maestro-supervisor-dogfood.service` kills in-flight workers. The default `KillMode=control-group` SIGTERMs the entire cgroup — the run-loop **and** its tmux worker children — so a restart-to-deploy throws away mid-flight workers (sup-86/87 died this way on #487, 2026-05-31).

The obvious "fix" `KillMode=process` is worse: it orphans the tmux workers, the restarted supervisor doesn't know about them and spawns duplicates on top, the stack grows unbounded, paid quota burns. The right shape is **drain → restart**.

## Approach

A graceful drain coordinated through `state.json` — the simplest robust mechanism, since the orchestrator already loads/saves state every cycle under a file lock with merge logic.

- **`maestro drain --config <cfg> --timeout <dur>`** (default `30m`) sets a `SpawnDrain` flag (+ `SpawnDrainAt` timestamp) in `state.json`, then polls state until no in-flight worker sessions remain. Exit `0` once drained; exit `1` on timeout, leaving the flag set so the operator can investigate or kill the stuck worker (forced kill on timeout is intentionally out of scope per the issue).
- **`Orchestrator.startNewWorkers` checks `SpawnDrain` first** and returns before listing issues or spawning anything, so drain is a true "stop accepting new work" gate, not just a per-issue skip.
- **The flag is cleared automatically when the long-running daemon starts** (`clearSpawnDrainOnStartup`), so a drain never persists across a legitimate restart. A `run --once` reconcile tick does **not** lift an in-progress drain.
- **"In-flight" = `StatusRunning` sessions** (live tmux workers). `pr_open` sessions are intentionally excluded: they have no live worker process and are re-attached by the next supervisor's reconcile path after restart.
- **`SpawnDrain` merges latest-write-wins** (by `SpawnDrainAt`) so a concurrent orchestrator state save can't clobber a fresh drain request, and a fresh clear isn't undone by a stale set.

## How to wire `ExecStop` (no live unit files modified in this PR)

Add to `maestro-supervisor-dogfood.service` (and any other `maestro run` daemon unit) so `systemctl --user restart` drains before stopping:

```ini
[Service]
TimeoutStopSec=35m
ExecStop=/usr/local/bin/maestro drain --config /home/god/.maestro/maestro.d/maestro-supervisor-dogfood.yaml --timeout 30m
```

`TimeoutStopSec` must exceed the drain `--timeout` so systemd waits for the drain instead of SIGKILLing the cgroup. With this in place, `systemctl --user restart` runs `ExecStop` (drain → wait for workers to finish) → then stops → the fresh daemon clears the flag on startup and resumes normal spawns.

Operator shorthand without changing the unit:

```bash
maestro drain --config <cfg> && systemctl --user restart maestro-supervisor-dogfood.service
```

## Tests

All deterministic and fast (no real sleeps / no network):

- **State helpers**: `RunningSessions`/`RunningSessionCount` count only `StatusRunning`; set/clear drain; survives save/load round-trip; concurrent-merge resolves latest-write-wins for both set-beats-stale and clear-beats-stale.
- **Orchestrator**: `startNewWorkers` does not list issues or spawn while draining (with a no-drain control that **does** spawn the same ready issue, proving the gate is what blocks); startup clears a leftover flag and is a no-op otherwise.
- **CLI `drainWait`**: returns when workers reach 0, returns immediately when none running (single state read, no sleep), times out without overshooting the deadline, and propagates count errors — all via an injected counter and a fake clock.

`go build ./cmd/maestro/`, `go vet ./...`, and `go test ./...` all pass. Manually smoke-tested the built binary against throwaway temp state: empty state drains immediately (exit 0); a seeded stuck `running` session times out (exit 1, flag left set).

## Scope

Closes #541. All non-optional acceptance criteria are implemented. Documented follow-ups (the issue marks these optional / out of scope):

- SIGUSR1/SIGUSR2 to toggle drain on/off on the running process, so `systemctl --user kill --signal=USR1` works without a separate CLI call.
- Operator runbook note in the Maestro PM home.
- Multi-project / fleet-wide drain (this PR is one project at a time, as the issue specifies).

Live systemd unit files were **not** modified by this PR; the `ExecStop` wiring above is for the operator to apply.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a graceful drain mode for Maestro's orchestrator (#541): a new `maestro drain` CLI command sets a `SpawnDrain` flag in `state.json` so the running daemon stops accepting new issues, then polls until all `StatusRunning` sessions finish. The long-running daemon clears the flag on startup so a restart always resumes normal operation.

- **State layer** (`state.go`): adds `SpawnDrain`/`SpawnDrainAt` fields with `SetSpawnDrain`, `ClearSpawnDrain`, `DrainActive`, `RunningSessions`, and `RunningSessionCount` helpers; a `mergeSpawnDrain` latest-write-wins resolver (by timestamp) is wired into `mergeStateSnapshots` so a concurrent orchestrator save cannot clobber a fresh drain request or prevent a fresh clear.
- **Orchestrator** (`orchestrator.go`): `startNewWorkers` returns early while `DrainActive()` is true; `clearSpawnDrainOnStartup` runs once at daemon start (not on `--once` ticks) to lift any leftover flag before the first cycle.
- **CLI** (`main.go`): `drainWait` is a fully injectable function (counter, clock, sleep) making it deterministic under test; `drainCmd` wires it to a state-backed counter with 5 s polling and a configurable timeout (default 30 m).

<h3>Confidence Score: 4/5</h3>

Safe to merge with one open issue in drainCmd that can leave the daemon permanently idle if the operator skips the restart after a successful drain.

The state layer and orchestrator integration are solid — the merge logic, nil guards, and latest-write-wins resolution are all correct and well-tested. The one functional gap lives in drainCmd: after drainWait returns nil (all workers drained), the SpawnDrain flag is never cleared from state.json, so the running orchestrator keeps hitting the early-return gate on every subsequent cycle and stops picking up new work indefinitely. A restart clears it via clearSpawnDrainOnStartup, but the success message frames restart as optional rather than required, which creates a real operational footgun. Prior review rounds flagged this and a nil-index panic when loadConfigs returns an empty slice; both remain open in the current diff.

cmd/maestro/main.go — drainCmd success path and the cfgs slice index

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Adds drainCmd and drainWait; drainWait logic is well-tested and handles deadline overshooting correctly; drainCmd has known issues flagged in prior review rounds (drain flag retained on success path, potential nil-index panic on empty config slice) |
| cmd/maestro/main_drain_test.go | New test file; covers success, zero-worker immediate return, timeout without overshoot, and error propagation — all deterministic via fakeClock |
| internal/orchestrator/orch_drain_test.go | New test file; drain-blocks-spawns and no-drain-control tests, plus startup-clear tests for both leftover-flag and no-op cases; all deterministic via injected mocks |
| internal/orchestrator/orchestrator.go | Adds clearSpawnDrainOnStartup (long-running daemon only) and a DrainActive gate at the top of startNewWorkers; implementation is correct and the once-only guard is properly scoped |
| internal/state/state.go | Adds SpawnDrain/SpawnDrainAt fields, RunningSessions/RunningSessionCount helpers, SetSpawnDrain/ClearSpawnDrain/DrainActive methods, and mergeSpawnDrain latest-write-wins merge logic; all well-implemented with correct nil guards |
| internal/state/state_drain_test.go | New test file; covers RunningSessions count filtering, set/clear cycle, save/load round-trip, and concurrent-merge latest-write-wins for both set-beats-stale and clear-beats-stale scenarios |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/541-gracefu..."](https://github.com/befeast/maestro/commit/7732cd0efceff048bc18557fa39d1189e454f7e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34824754)</sub>

<!-- /greptile_comment -->