### PR TITLE
fix(supervisor): merge green PR with addressed review feedback instead of looping on repair

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1955,7 +1955,19 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 			}
 		}
 		switch stuck.Code {
-		case "failing_checks", "greptile_not_approved", "stale_review_feedback":
+		case "failing_checks", "greptile_not_approved":
+			return true
+		case "stale_review_feedback":
+			// Review feedback from a PREVIOUS attempt does not mean the
+			// current PR is broken. If the PR is now merge-ready (not draft,
+			// mergeable, CI green, review gate passed), the feedback was
+			// already addressed — fall through to the merge_pr rule (#512)
+			// instead of looping on spawn_repair_worker, which the executor
+			// refuses (not in the action registry) and wedges a green PR
+			// forever.
+			if ready, _ := e.openPRReadyToMerge(slot, sess, pr); ready {
+				return false
+			}
 			return true
 		case "retry_exhausted_open_pr":
 			return stuck.Severity == SeverityBlocked

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -520,6 +520,48 @@ func TestDecide_OpenPR_AllGreen_RecommendsMerge(t *testing.T) {
 	}
 }
 
+// Regression: a session whose PREVIOUS attempt was retried on review
+// feedback (PreviousAttemptFeedbackKind=review_feedback) used to wedge a
+// now-green PR forever — detectWorkerStuckStates raised
+// stale_review_feedback[blocked], openPRNeedsRepair short-circuited to
+// spawn_repair_worker, and the executor refuses that verb (not in the
+// registry). Once the feedback is addressed (PR green + mergeable), the
+// merge_pr rule (#512) must win.
+func TestDecide_StaleReviewFeedbackButGreenPRRecommendsMerge(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:          []github.PR{{Number: 548, HeadRefName: "feat/stale-review-green", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses:   map[int]string{548: "success"},
+		mergedPRs:    map[int]bool{548: false},
+		closedIssues: map[int]bool{532: false},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber:                 532,
+		IssueTitle:                  "project card actionable",
+		Status:                      state.StatusRetryExhausted,
+		Branch:                      "feat/stale-review-green",
+		PRNumber:                    548,
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		StartedAt:                   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMergePR {
+		t.Fatalf("action = %q, want %q (green mergeable PR with addressed review feedback must merge, not loop on spawn_repair_worker)", decision.RecommendedAction, ActionMergePR)
+	}
+	if decision.Risk != RiskMutating {
+		t.Fatalf("risk = %q, want %q", decision.Risk, RiskMutating)
+	}
+	if decision.Target == nil || decision.Target.PR != 548 {
+		t.Fatalf("target = %#v, want PR=548", decision.Target)
+	}
+}
+
 // #512: CI is still pending → planner stays on monitor_open_pr with a
 // summary that names the actual blocker, not the old aspirational text.
 func TestDecide_OpenPR_CIPending_StaysMonitor(t *testing.T) {


### PR DESCRIPTION
Fixes #553.

## Problem

The hands-off `merge_pr` chain never fired for a green, mergeable PR whose session had been retried at least once on **review feedback**. The supervisor looped on `spawn_repair_worker` (refused by the executor — not in the action registry, #505/#526), so the PR was wedged forever and no `merge_pr` approval was ever minted.

Live evidence (dogfood #532 / PR #548, every 5-min cycle): `stale_review_feedback [blocked]` + `retry_exhausted_open_pr [info]`, PR `MERGEABLE`, all checks SUCCESS, Greptile `COMMENTED` "safe to merge".

## Root cause

`decideDeterministic` runs `openPRNeedsRepair` before `openPRReadyToMerge`. In `openPRNeedsRepair`, `stale_review_feedback` short-circuited to `return true` (→ repair) without checking whether the feedback had been addressed (PR now green + mergeable). Review feedback on a *previous* attempt does not mean the *current* PR is broken.

## Fix

`stale_review_feedback` now defers to merge-readiness: if `openPRReadyToMerge` is true (not draft, mergeable, CI green, review gate passed) the PR does not need repair and falls through to the `merge_pr` rule (#512). `failing_checks` / `greptile_not_approved` keep short-circuiting to repair.

## Test

`TestDecide_StaleReviewFeedbackButGreenPRRecommendsMerge` — a `retry_exhausted` session with `PreviousAttemptFeedbackKind=review_feedback` and a green mergeable PR now yields `merge_pr` (risk=mutating), not `spawn_repair_worker`. `go build`, `go vet`, `gofmt`, full `go test ./internal/supervisor/` all green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a wedged-PR bug where a `retry_exhausted` session with `PreviousAttemptFeedbackKind=review_feedback` could never advance to `merge_pr` because `stale_review_feedback` always short-circuited `openPRNeedsRepair` to `spawn_repair_worker` — an action the executor refuses, looping forever.

- `stale_review_feedback` in `openPRNeedsRepair` now calls `openPRReadyToMerge`; if the PR is not draft, mergeable, CI green, and review-gate passed, it returns `false` so `decideDeterministic` falls through to the existing `merge_pr` rule. `failing_checks` and `greptile_not_approved` are unchanged and still short-circuit to repair.
- A regression test (`TestDecide_StaleReviewFeedbackButGreenPRRecommendsMerge`) verifies that a `retry_exhausted` session with stale review feedback and a green mergeable PR now yields `merge_pr`, not `spawn_repair_worker`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is narrowly scoped to one case in openPRNeedsRepair and is backed by a focused regression test.

The fix correctly unblocks green PRs that were permanently wedged by stale review-feedback state. The only observations are non-blocking: openPRReadyToMerge is called twice per cycle on the newly-fixed path (redundant API calls, no incorrect behavior), and the converse branch — stale feedback on a still-failing PR — lacks an explicit test.

Both changed files are straightforward; supervisor.go carries a small redundant-call note worth a follow-up but nothing blocking.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Single-case fix in openPRNeedsRepair: stale_review_feedback now defers to openPRReadyToMerge before returning true, unblocking green PRs that were wedged forever. Logic is correct; minor redundancy — openPRReadyToMerge is called twice per cycle on the fixed path. |
| internal/supervisor/supervisor_test.go | Regression test TestDecide_StaleReviewFeedbackButGreenPRRecommendsMerge covers the happy path; the converse case (stale feedback + failing CI → repair) is not tested. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/supervisor/supervisor_test.go:523-530
The new test validates the happy path (stale feedback + green PR → `merge_pr`) but the converse branch — `stale_review_feedback` raised while the PR is still not ready (e.g., CI failing) — falls through to `return true` in `openPRNeedsRepair` and is not covered by any test. Adding a sibling test would close that gap and guard against future regressions in the same switch block.

### Issue 2 of 2
internal/supervisor/supervisor.go:1968-1970
`openPRReadyToMerge` is called here to short-circuit, then called a second time at line 346 of `decideDeterministic` to obtain the merge reasons. Each call fetches up to three external endpoints (`PRMergeable`, `PRCIStatus`, `PRGreptileApproved`). For the specific path this PR fixes — `stale_review_feedback` on a green PR — both calls happen in every supervisor cycle. The result is functionally correct, but it doubles the API traffic for exactly the scenario we now want to succeed. Consider caching the result or restructuring `openPRNeedsRepair` to surface a merge-readiness signal to the caller so `decideDeterministic` can reuse it without refetching.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(supervisor): merge green PR with add..."](https://github.com/befeast/maestro/commit/0ffaa28cfd7f7032108149db98b1f869c998feea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34869348)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->