### PR TITLE
P1: retry-exhausted PR with unaddressed review feedback flip-flops board status + re-recommends refused spawn_repair_worker each poll

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1638,6 +1638,19 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 		case state.StatusDone, state.StatusCodeLanded, state.StatusDead, state.StatusConflictFailed, state.StatusFailed, state.StatusRetryExhausted:
 			if sess.Status != state.StatusDone && sess.Status != state.StatusCodeLanded && prErr == nil {
 				if pr, found := branchToPR[sess.Branch]; found {
+					// #556: when a retry-exhausted session has already been
+					// settled on this exact PR (status+PRNumber+notified),
+					// do NOT flip it back to pr_open every cycle. The merge
+					// flow already processes retry_exhausted sessions
+					// directly (mergeFlowEligibleStatus), so the flip is
+					// redundant — and it produces the board flip-flop
+					// (`In Review` ↔ `Blocked`) the dogfood log captured,
+					// plus a log line per cycle.
+					if isSettledRetryExhausted(sess, pr.Number) {
+						// Stay in the terminal retry_exhausted state. No
+						// log, no project sync, no FinishedAt churn.
+						continue
+					}
 					log.Printf("[orch] session %s %s->pr_open (PR #%d now open for branch %q)", slotName, sess.Status, pr.Number, sess.Branch)
 					sess.Status = state.StatusPROpen
 					sess.PRNumber = pr.Number
@@ -2128,6 +2141,14 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				if err != nil {
 					log.Printf("[orch] warn: could not collect review feedback for PR #%d: %v", pr.Number, err)
 				} else if strings.TrimSpace(reviewFeedback) != "" {
+					// #556: once we've already marked this PR retry-exhausted
+					// for review feedback, do NOT re-emit "scheduling retry"
+					// or re-sync the project board every poll. The session
+					// has reached a stable terminal state that needs an
+					// operator decision, not another refused retry cycle.
+					if isSettledRetryExhausted(sess, pr.Number) {
+						continue
+					}
 					log.Printf("[orch] PR #%d has review feedback; scheduling retry", pr.Number)
 					o.handleReviewFeedbackRetry(s, slotName, sess, pr, reviewFeedback)
 					continue
@@ -2218,6 +2239,24 @@ func mergeFlowEligibleStatus(sess *state.Session) bool {
 	}
 }
 
+// isSettledRetryExhausted reports whether a session has already been marked
+// retry_exhausted for this exact PR and notified. Used to suppress the
+// retry_exhausted ↔ pr_open flip-flop (#556) and idempotent re-emission of
+// "scheduling retry" / project board sync calls.
+func isSettledRetryExhausted(sess *state.Session, prNumber int) bool {
+	if sess == nil || sess.Status != state.StatusRetryExhausted {
+		return false
+	}
+	if prNumber <= 0 || sess.PRNumber != prNumber {
+		return false
+	}
+	switch sess.LastNotifiedStatus {
+	case "review_retry_exhausted", "ci_retry_exhausted", "rebase_conflict_retry_exhausted":
+		return true
+	}
+	return false
+}
+
 func mergeFlowPRForSession(sess *state.Session, byBranch map[string]github.PR, byNumber map[int]github.PR) (github.PR, bool) {
 	if sess == nil {
 		return github.PR{}, false
@@ -2243,6 +2282,15 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 	totalAttempts := s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount
 
 	if maxRetries > 0 && totalAttempts >= maxRetries {
+		// #556: when the session is already settled retry-exhausted on
+		// this PR, short-circuit so the orchestrator does not re-emit
+		// the retry-limit log, re-sync the project board, or churn
+		// FinishedAt on every poll. The caller in mergeFlow already
+		// guards this path; we re-check here so any direct callers stay
+		// idempotent too.
+		if isSettledRetryExhausted(sess, pr.Number) {
+			return
+		}
 		log.Printf("[orch] review feedback on PR #%d — retry limit reached (%d/%d) for issue #%d",
 			pr.Number, totalAttempts, maxRetries, sess.IssueNumber)
 		alreadyNotified := sess.LastNotifiedStatus == "review_retry_exhausted"

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2048,6 +2048,157 @@ func TestAutoMergePRs_RetryExhaustedActionableFeedbackStillBlocks(t *testing.T) 
 	}
 }
 
+// #556: once a session is settled in retry_exhausted for a specific PR
+// with unaddressed review feedback, subsequent autoMergePRs cycles must
+// NOT re-emit "scheduling retry", re-sync the project board, or churn
+// FinishedAt. Live dogfood (2026-06-01, issue #535 / PR #555) showed the
+// pre-fix loop syncing Blocked → InReview → Blocked every poll.
+func TestAutoMergePRs_RetryExhaustedFeedback_NoReSyncAfterSettled(t *testing.T) {
+	prs := []github.PR{{Number: 555, HeadRefName: "feat/sup-92", Mergeable: "MERGEABLE"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "parallel",
+		ReviewGate:              "none",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      2,
+		MaxRetryBackoffMs:       300000,
+	}
+	cfg.GitHubProjects.Enabled = true
+	cfg.GitHubProjects.ProjectNumber = 4
+	notifier := notify.NewWithToken("", "123", "", "")
+	notifier.SetDigestMode(true)
+	syncs := make([]string, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: notifier,
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "## Review Feedback\n\ninternal/foo.go:42 P1: unaddressed nil pointer", nil
+		},
+		syncProjectFn: func(issueNumber int, status github.ProjectStatus) bool {
+			syncs = append(syncs, fmt.Sprintf("#%d:%s", issueNumber, status))
+			return true
+		},
+	}
+	s := state.NewState()
+	s.Sessions["sup-92"] = &state.Session{
+		IssueNumber: 535,
+		IssueTitle:  "review feedback PR",
+		Branch:      "feat/sup-92",
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    555,
+		RetryCount:  2,
+	}
+
+	// First cycle marks the session retry-exhausted (one project sync).
+	o.autoMergePRs(s)
+
+	sess := s.Sessions["sup-92"]
+	if sess.Status != state.StatusRetryExhausted {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRetryExhausted)
+	}
+	if sess.LastNotifiedStatus != "review_retry_exhausted" {
+		t.Fatalf("LastNotifiedStatus = %q, want review_retry_exhausted", sess.LastNotifiedStatus)
+	}
+	if len(syncs) != 1 || syncs[0] != "#535:blocked" {
+		t.Fatalf("syncs after first cycle = %v, want [#535:blocked]", syncs)
+	}
+	settledFinishedAt := sess.FinishedAt
+	if settledFinishedAt == nil {
+		t.Fatalf("FinishedAt must be set after first cycle")
+	}
+
+	// Second cycle: same conditions. No additional project sync, no extra
+	// notification, FinishedAt does not churn.
+	o.autoMergePRs(s)
+
+	if len(syncs) != 1 {
+		t.Fatalf("project syncs after second cycle = %d (%v), want 1 (idempotent)", len(syncs), syncs)
+	}
+	if notifier.Buffered() != 1 {
+		t.Fatalf("notifications buffered = %d, want 1 (no duplicate terminal notification)", notifier.Buffered())
+	}
+	if sess.FinishedAt != settledFinishedAt {
+		t.Fatalf("FinishedAt churned across cycles: was %v, now %v", settledFinishedAt, sess.FinishedAt)
+	}
+
+	// Third cycle to be sure the loop has truly stabilised.
+	o.autoMergePRs(s)
+	if len(syncs) != 1 {
+		t.Fatalf("project syncs after third cycle = %d (%v), want 1", len(syncs), syncs)
+	}
+}
+
+// #556: checkSessions must not flip a settled retry_exhausted session
+// back to pr_open every cycle. Doing so syncs the project to InReview,
+// which in combination with autoMergePRs' Blocked sync produces the
+// observed In Review ↔ Blocked flip-flop.
+func TestCheckSessions_SettledRetryExhausted_NoFlipFlop(t *testing.T) {
+	cfg := &config.Config{Repo: "owner/repo", MaxRuntimeMinutes: 999}
+	cfg.GitHubProjects.Enabled = true
+	cfg.GitHubProjects.ProjectNumber = 4
+	synced := make([]string, 0)
+	o, _ := newCheckSessionsOrchestrator(cfg, "")
+	o.listOpenPRsFn = func() ([]github.PR, error) {
+		return []github.PR{{
+			Number:      555,
+			HeadRefName: "feat/sup-92",
+			State:       "OPEN",
+		}}, nil
+	}
+	o.rateLimitFn = func() (github.RateLimitStatus, error) {
+		return github.RateLimitStatus{GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000}}, nil
+	}
+	o.syncProjectFn = func(issueNumber int, status github.ProjectStatus) bool {
+		synced = append(synced, fmt.Sprintf("#%d:%s", issueNumber, status))
+		return true
+	}
+
+	s := state.NewState()
+	finishedAt := time.Now().UTC().Add(-5 * time.Minute)
+	s.Sessions["sup-92"] = &state.Session{
+		IssueNumber:        535,
+		IssueTitle:         "review feedback PR",
+		Status:             state.StatusRetryExhausted,
+		Branch:             "feat/sup-92",
+		PRNumber:           555,
+		RetryCount:         2,
+		LastNotifiedStatus: "review_retry_exhausted",
+		FinishedAt:         &finishedAt,
+		StartedAt:          time.Now().UTC().Add(-10 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["sup-92"]
+	if sess.Status != state.StatusRetryExhausted {
+		t.Fatalf("status = %q, want %q (settled session must NOT be flipped to pr_open)", sess.Status, state.StatusRetryExhausted)
+	}
+	if sess.PRNumber != 555 {
+		t.Fatalf("PRNumber = %d, want 555", sess.PRNumber)
+	}
+	if len(synced) != 0 {
+		t.Fatalf("syncProject calls = %v, want none (settled state must not re-sync InReview)", synced)
+	}
+	if sess.FinishedAt == nil || !sess.FinishedAt.Equal(finishedAt) {
+		t.Fatalf("FinishedAt churned: was %v, now %v", finishedAt, sess.FinishedAt)
+	}
+
+	// Second cycle: still settled. Still no flip, no sync.
+	o.checkSessions(s)
+	if sess.Status != state.StatusRetryExhausted {
+		t.Fatalf("status after second cycle = %q, want %q", sess.Status, state.StatusRetryExhausted)
+	}
+	if len(synced) != 0 {
+		t.Fatalf("syncProject calls after second cycle = %v, want none", synced)
+	}
+}
+
 func TestAutoMergePRs_CIFailureBlocksMerge(t *testing.T) {
 	prs := []github.PR{
 		{Number: 10, HeadRefName: "feat/a"},

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1942,6 +1942,15 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 	if availableSlots(e.cfg, st) <= 0 {
 		return false
 	}
+	// #556: a retry-exhausted session has spent its retry budget — spawning
+	// another repair worker would not be effective, and the executor refuses
+	// `spawn_repair_worker` because the verb is not in the action registry.
+	// Falling through here lets the deterministic path land on
+	// monitor_open_pr (or merge_pr when the feedback was addressed and the
+	// PR is now green) instead of looping on the refused verb each cycle.
+	if sess.Status == state.StatusRetryExhausted {
+		return false
+	}
 	if pr.IsDraft {
 		return true
 	}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -562,6 +562,46 @@ func TestDecide_StaleReviewFeedbackButGreenPRRecommendsMerge(t *testing.T) {
 	}
 }
 
+// #556: a retry-exhausted session with an open PR and unaddressed review
+// feedback must NOT recommend `spawn_repair_worker`. That verb is not in
+// the executor's action registry, so the supervisor's at-mint guard
+// refuses it every cycle (logged as "refusing to mint approval"), which
+// is the dogfood loop the issue calls out. The decision must fall
+// through to a registry-supported / non-mutating recommendation such as
+// `monitor_open_pr`.
+func TestDecide_RetryExhaustedUnaddressedFeedback_DoesNotRecommendSpawnRepairWorker(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:          []github.PR{{Number: 555, HeadRefName: "feat/sup-92", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses:   map[int]string{555: "success"},
+		mergedPRs:    map[int]bool{555: false},
+		closedIssues: map[int]bool{535: false},
+	}
+	st := state.NewState()
+	st.Sessions["sup-92"] = &state.Session{
+		IssueNumber:                 535,
+		IssueTitle:                  "unaddressed P1 review",
+		Status:                      state.StatusRetryExhausted,
+		Branch:                      "feat/sup-92",
+		PRNumber:                    555,
+		RetryCount:                  2,
+		LastNotifiedStatus:          "review_retry_exhausted",
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		PreviousAttemptFeedback:     "## Review Feedback\n\ninternal/foo.go:42 P1: nil pointer panic",
+		StartedAt:                   time.Now().UTC().Add(-2 * time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction == ActionSpawnRepairWorker {
+		t.Fatalf("action = %q, must NOT recommend spawn_repair_worker for retry_exhausted (verb is refused at mint, leads to dogfood loop)", decision.RecommendedAction)
+	}
+}
+
 // #512: CI is still pending → planner stays on monitor_open_pr with a
 // summary that names the actual blocker, not the old aspirational text.
 func TestDecide_OpenPR_CIPending_StaysMonitor(t *testing.T) {


### PR DESCRIPTION
Refs #556

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related loops introduced when a retry-exhausted PR with unaddressed review feedback is present: `checkSessions` was flipping the session back to `pr_open` (causing an `In Review` ↔ `Blocked` board flip on every poll), and `autoMergePRs`/`handleReviewFeedbackRetry` were re-emitting "scheduling retry" and re-syncing the project board each cycle.

- Introduces `isSettledRetryExhausted` — a focused predicate that gates on `Status`, `PRNumber`, and one of three terminal `LastNotifiedStatus` values — and inserts it as a guard in `checkSessions`, `autoMergePRs`, and `handleReviewFeedbackRetry` to make all three paths idempotent once the terminal state is reached.
- Adds a matching guard in `openPRNeedsRepair` (supervisor) so `spawn_repair_worker` is no longer recommended for retry-exhausted sessions, stopping the \"refusing to mint approval\" loop the executor emits each cycle.
- Both fixes are covered by regression tests that assert stable `FinishedAt`, zero extra project syncs, and zero extra notifications after the first settling cycle.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are well-scoped guards on an already-terminal session state, backed by regression tests that pass three poll cycles without additional side effects.

The core fix is correct and test coverage is thorough. The `ci_retry_exhausted` case in `isSettledRetryExhausted` is unreachable on the CI-success path due to an earlier `LastNotifiedStatus` reset (benign), and sessions persisted without `LastNotifiedStatus` will see one extra board sync on first restart before stabilising. Neither causes recurring incorrect behaviour.

internal/orchestrator/orchestrator.go — the interaction between the `LastNotifiedStatus` reset at line 2134 and the `isSettledRetryExhausted` call on the CI-success path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds `isSettledRetryExhausted` guard in `checkSessions`, `autoMergePRs`, and `handleReviewFeedbackRetry`. Logic is correct; one edge case around first-cycle behaviour for persisted state lacking `LastNotifiedStatus`. |
| internal/orchestrator/orchestrator_test.go | Adds two targeted regression tests covering the flip-flop and re-sync loops, including the transitional case where `LastNotifiedStatus` is initially unset. |
| internal/supervisor/supervisor.go | Early-returns false from `openPRNeedsRepair` for `StatusRetryExhausted` sessions, stopping the `spawn_repair_worker` recommendation loop. |
| internal/supervisor/supervisor_test.go | New test verifies `Decide` does not return `ActionSpawnRepairWorker` for a retry_exhausted session with unaddressed feedback. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:2253-2257
**`ci_retry_exhausted` guard may be pre-empted by the `LastNotifiedStatus` reset above it**

In `autoMergePRs`, when CI turns green the code at line 2134 clears `LastNotifiedStatus` for both `"ci_failure"` and `"ci_retry_exhausted"` before the `isSettledRetryExhausted` call is reached. For a session settled as `ci_retry_exhausted`, this means `isSettledRetryExhausted` will always return `false` on the CI-success path — the `"ci_retry_exhausted"` case in the switch is unreachable from that call site. The guard in `checkSessions` does protect it, so there is no flip-flop regression; the only observable effect is that if review feedback is simultaneously present, `handleReviewFeedbackRetry` will fire once more and re-settle with `LastNotifiedStatus = "review_retry_exhausted"`. This is benign today but worth documenting so a future caller doesn't assume `ci_retry_exhausted` is guarded on the CI-success path.

### Issue 2 of 2
internal/orchestrator/orchestrator.go:1648-1653
**First poll after upgrade will still produce one flip for sessions missing `LastNotifiedStatus`**

A persisted session with `Status = retry_exhausted` and an empty `LastNotifiedStatus` (state written before this fix ships) will pass through `isSettledRetryExhausted → false`, flip to `pr_open` in `checkSessions`, and then be re-settled by `handleReviewFeedbackRetry` in the same poll cycle. The loop is broken after that single extra board-sync, so this is only a one-shot issue rather than the recurring loop the PR title describes. It may be worth a comment in `isSettledRetryExhausted` noting the intentional migration behaviour, so operators aren't surprised by one extra "Blocked" event on first restart.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): settle retry\_exhauste..."](https://github.com/befeast/maestro/commit/37e1fb9b710785791d5b3ad0e20b34d720040a82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34898566)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->