### PR TITLE
ProjectV2 status must mirror worker runtime and outcome DoD

### DIFF
--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -31,20 +31,23 @@ const (
 // applying a high-level ProjectStatus to a real GitHub Project board. Boards
 // often customize column names (e.g. "Review" vs "In Review", "On Hold" vs
 // "Blocked"); the first option present in the board's Status field wins.
+// Comparison is case-insensitive and whitespace-tolerant inside
+// resolveProjectStatusOption, so this list only needs one entry per logical
+// column name.
 func ProjectStatusCandidates(status ProjectStatus) []string {
 	switch status {
 	case ProjectStatusTodo:
-		return []string{"Todo", "To do", "To Do", "Backlog"}
+		return []string{"Todo", "To do", "Backlog"}
 	case ProjectStatusInProgress:
-		return []string{"In Progress", "In progress", "Doing"}
+		return []string{"In Progress", "Doing"}
 	case ProjectStatusInReview:
-		return []string{"In Review", "In review", "Review", "Reviewing", "Code Review", "In Progress", "In progress"}
+		return []string{"In Review", "Review", "Reviewing", "Code Review", "In Progress"}
 	case ProjectStatusBlocked:
-		return []string{"Blocked", "On Hold", "On hold", "Stuck", "Needs Attention", "Needs attention"}
+		return []string{"Blocked", "On Hold", "Stuck", "Needs Attention"}
 	case ProjectStatusDeploying:
 		return []string{"Deploying", "Deploy", "Deployment"}
 	case ProjectStatusLiveVerify:
-		return []string{"Live Verification", "Live verification", "Verification", "Verifying", "QA"}
+		return []string{"Live Verification", "Verification", "Verifying", "QA"}
 	case ProjectStatusDone:
 		return []string{"Done", "Completed", "Closed"}
 	default:
@@ -152,12 +155,15 @@ type ProjectItem struct {
 
 // ListNonDoneProjectItems fetches all project items not in Done status
 // and returns their linked issue numbers along with whether they are closed.
+// "Done" is resolved against every candidate column name (Done/Completed/Closed)
+// so boards that label their terminal column differently still filter out
+// already-finished items instead of leaking them back into the reconciler.
 func (c *Client) ListNonDoneProjectItems(pf *ProjectField) ([]ProjectItem, error) {
 	if pf == nil {
 		return nil, fmt.Errorf("nil ProjectField")
 	}
 
-	doneOptionID := pf.Options["Done"]
+	_, doneOptionID, _ := resolveProjectStatusOption(pf, ProjectStatusCandidates(ProjectStatusDone))
 
 	query := fmt.Sprintf(`{
   node(id: %q) {
@@ -190,7 +196,10 @@ func (c *Client) ListNonDoneProjectItems(pf *ProjectField) ([]ProjectItem, error
 		}
 		return nil, fmt.Errorf("graphql project items: %w", err)
 	}
+	return parseNonDoneProjectItemsResponse(out, doneOptionID)
+}
 
+func parseNonDoneProjectItemsResponse(out []byte, doneOptionID string) ([]ProjectItem, error) {
 	var resp struct {
 		Data struct {
 			Node struct {

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -78,6 +78,91 @@ func TestListNonDoneProjectItems_NilProjectField(t *testing.T) {
 	}
 }
 
+// parseNonDoneProjectItemsResponse must drop already-terminal items even when
+// the board's terminal column is "Completed" or "Closed" rather than "Done".
+// Without this, every finished item leaks back into reconcileProjectBoard and
+// generates one redundant Done sync per RunOnce cycle (regression from #405
+// review).
+func TestParseNonDoneProjectItemsResponse_FiltersTerminalOptionID(t *testing.T) {
+	body := []byte(`{
+		"data": {
+			"node": {
+				"items": {
+					"nodes": [
+						{"fieldValueByName": {"optionId": "opt-progress"}, "content": {"number": 10, "state": "OPEN"}},
+						{"fieldValueByName": {"optionId": "opt-completed"}, "content": {"number": 11, "state": "CLOSED"}},
+						{"fieldValueByName": null, "content": {"number": 12, "state": "OPEN"}},
+						{"fieldValueByName": {"optionId": "opt-progress"}, "content": null}
+					]
+				}
+			}
+		}
+	}`)
+
+	items, err := parseNonDoneProjectItemsResponse(body, "opt-completed")
+	if err != nil {
+		t.Fatalf("parseNonDoneProjectItemsResponse: %v", err)
+	}
+
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2 (terminal-column item must be filtered, dangling node skipped); got %+v", len(items), items)
+	}
+	if items[0].IssueNumber != 10 || !items[0].HasStatus || items[0].IssueClosed {
+		t.Fatalf("items[0] = %+v, want issue 10 open with status", items[0])
+	}
+	if items[1].IssueNumber != 12 || items[1].HasStatus || items[1].IssueClosed {
+		t.Fatalf("items[1] = %+v, want issue 12 open without status", items[1])
+	}
+}
+
+func TestParseNonDoneProjectItemsResponse_NoDoneOptionKeepsTerminalItems(t *testing.T) {
+	body := []byte(`{
+		"data": {
+			"node": {
+				"items": {
+					"nodes": [
+						{"fieldValueByName": {"optionId": "opt-closed"}, "content": {"number": 7, "state": "CLOSED"}}
+					]
+				}
+			}
+		}
+	}`)
+
+	items, err := parseNonDoneProjectItemsResponse(body, "")
+	if err != nil {
+		t.Fatalf("parseNonDoneProjectItemsResponse: %v", err)
+	}
+	if len(items) != 1 || items[0].IssueNumber != 7 || !items[0].IssueClosed {
+		t.Fatalf("items = %+v, want one closed item when terminal optionID is empty", items)
+	}
+}
+
+func TestParseNonDoneProjectItemsResponse_GraphQLErrors(t *testing.T) {
+	body := []byte(`{"errors":[{"message":"boom"}]}`)
+	if _, err := parseNonDoneProjectItemsResponse(body, ""); err == nil {
+		t.Fatal("parseNonDoneProjectItemsResponse should surface graphql errors")
+	}
+}
+
+// ListNonDoneProjectItems must resolve the terminal-column option ID through
+// ProjectStatusCandidates so a board whose Done column is named "Completed"
+// or "Closed" still filters out finished items. The unit-test angle: ensure
+// every Done candidate normalizes to a recognized board column name in
+// resolveProjectStatusOption.
+func TestProjectStatusCandidatesDoneResolvesCommonTerminalColumns(t *testing.T) {
+	for _, columnName := range []string{"Done", "Completed", "Closed", "completed", "DONE"} {
+		pf := &ProjectField{
+			ProjectID: "p",
+			FieldID:   "f",
+			Options:   map[string]string{columnName: "opt-terminal"},
+		}
+		_, id, ok := resolveProjectStatusOption(pf, ProjectStatusCandidates(ProjectStatusDone))
+		if !ok || id != "opt-terminal" {
+			t.Fatalf("Done candidates failed to resolve board column %q (ok=%v, id=%q)", columnName, ok, id)
+		}
+	}
+}
+
 func TestGhTimeout_IsReasonable(t *testing.T) {
 	if ghTimeout < 5*time.Second {
 		t.Errorf("ghTimeout = %v, want >= 5s", ghTimeout)


### PR DESCRIPTION
Refs #404

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a reconciler leak where project items in terminal columns named "Completed" or "Closed" (instead of the default "Done") were never filtered out by `ListNonDoneProjectItems`, causing them to re-enter the reconciler on every `RunOnce` cycle. The fix routes terminal-column resolution through the existing `resolveProjectStatusOption` helper with the full set of Done candidates.

- `ListNonDoneProjectItems` now calls `resolveProjectStatusOption(pf, ProjectStatusCandidates(ProjectStatusDone))` instead of the bare `pf.Options[\"Done\"]` map lookup, so any of "Done", "Completed", or "Closed" (case-insensitive) is recognized as a terminal column.
- `ProjectStatusCandidates` is simplified by removing case-variant duplicates already handled by `resolveProjectStatusOption`'s case-insensitive normalization.
- `parseNonDoneProjectItemsResponse` is extracted into a standalone function enabling four new unit tests without a live API call.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the terminal-column fix is correct and well-tested, with one minor observability gap when the board uses a completely custom column name not in the Done candidates list.

The core change is straightforward and the new tests exercise the important edge cases. The only gap is that when resolveProjectStatusOption returns ok=false the caller silently falls back to returning all items with no log, making it hard to diagnose boards with custom terminal column names in production.

internal/github/github_projects.go around the silent ok=false discard on line 166

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github_projects.go | Replaces direct pf.Options["Done"] lookup with resolveProjectStatusOption across all Done candidates; removes case-variant duplicates from ProjectStatusCandidates; extracts parseNonDoneProjectItemsResponse for testability. Logic is correct; one minor silent-fallback path has no observability. |
| internal/github/github_projects_test.go | Adds four targeted tests covering terminal-column filtering, the empty-doneOptionID fallback, GraphQL error surfacing, and case-insensitive Done-candidate resolution across common board column names. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/github/github_projects.go:166
**Silent fallback when no terminal column is found**

When `resolveProjectStatusOption` returns `ok=false` (e.g. the board uses a custom terminal column like "Finished" or "Merged" that isn't in the Done candidates), `doneOptionID` is silently set to `""` and `parseNonDoneProjectItemsResponse` skips all filtering. Every terminal item then leaks into the reconciler every cycle — which is the exact bug this PR fixes for the common case, but it remains silent for any board with a truly custom terminal column name. A log line here (e.g. `log.Printf("[projects] no terminal column found in project %q; non-done filter inactive", pf.ProjectID)`) would make the fallback visible to operators.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(github): resolve Done column for boa..."](https://github.com/befeast/maestro/commit/233da97799bb1d4b45ac317996f515bfffe3ae87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34910597)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->