### PR TITLE
fix(supervisor): surface policy_blocks_merge for green PRs (#425)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -314,7 +314,17 @@ func loadConfig(configPath string) *config.Config {
 	if err != nil {
 		log.Fatalf("load config: %v", err)
 	}
+	logConfigWarnings(cfg)
 	return cfg
+}
+
+// logConfigWarnings emits any non-fatal configuration issues at WARN
+// level so an operator notices a hands-off project that has merge_pr in
+// approval_required (etc.) without grepping the daemon journal. #425.
+func logConfigWarnings(cfg *config.Config) {
+	for _, msg := range cfg.Warnings() {
+		log.Printf("warn: %s", msg)
+	}
 }
 
 // loadConfigs resolves multiple config paths, maestro.d/ directory, or default discovery.
@@ -326,6 +336,7 @@ func loadConfigs(paths []string) []*config.Config {
 			if err != nil {
 				log.Fatalf("load config %s: %v", p, err)
 			}
+			logConfigWarnings(cfg)
 			cfgs = append(cfgs, cfg)
 		}
 		return cfgs
@@ -336,6 +347,9 @@ func loadConfigs(paths []string) []*config.Config {
 		cfgs, err := config.LoadDir("maestro.d")
 		if err != nil {
 			log.Fatalf("load configs from maestro.d/: %v", err)
+		}
+		for _, cfg := range cfgs {
+			logConfigWarnings(cfg)
 		}
 		return cfgs
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -969,6 +969,73 @@ func validateSupervisorActions(field string, actions []string) error {
 	return nil
 }
 
+// Warnings returns non-fatal configuration issues an operator should
+// address. Each entry is a single-line human-readable sentence; callers
+// log them on startup / hot-reload. Returns nil when nothing is wrong so
+// callers can early-out without checking length.
+//
+// #425 (sup-98): hands-off projects (`review_gate` configured for
+// auto-merge AND no human in the loop) silently broke when
+// `merge_pr` was in `approval_required` — the supervisor recommended
+// `merge_pr`, the cautious gate minted an approval, and nothing ever
+// merged because nobody was around to click. The warning makes the
+// misconfiguration loud at config load time.
+func (c *Config) Warnings() []string {
+	if c == nil {
+		return nil
+	}
+	var warnings []string
+	if msg := c.handsOffMergeApprovalWarning(); msg != "" {
+		warnings = append(warnings, msg)
+	}
+	return warnings
+}
+
+func (c *Config) handsOffMergeApprovalWarning() string {
+	if c == nil {
+		return ""
+	}
+	gate := strings.ToLower(strings.TrimSpace(c.ReviewGate))
+	// Hands-off here means the project relies on Maestro to drive PRs
+	// through the merge gate without a human in the loop. The greptile /
+	// none gates are both compatible with hands-off operation; what
+	// matters is whether an operator is expected to click the merge
+	// button. Today that signal lives in approval_required.
+	if gate == "" {
+		return ""
+	}
+	gated := mergeApprovalGatedVerbs(c.Supervisor.ApprovalRequired)
+	if len(gated) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"config: hands-off project (review_gate=%s) has %s in supervisor.approval_required — the supervisor will mint an approval for every green PR and merge will block until a human acts. Remove from approval_required or accept the manual step.",
+		gate,
+		strings.Join(gated, "/"),
+	)
+}
+
+func mergeApprovalGatedVerbs(approvalRequired []string) []string {
+	wanted := map[string]struct{}{
+		SupervisorActionMergePR:    {},
+		SupervisorActionCloseIssue: {},
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, raw := range approvalRequired {
+		v := strings.ToLower(strings.TrimSpace(raw))
+		if _, ok := wanted[v]; !ok {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
 func knownSupervisorActions() map[string]bool {
 	return map[string]bool{
 		SupervisorActionAddReadyLabel:      true,

--- a/internal/config/warnings_test.go
+++ b/internal/config/warnings_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #425 (sup-98): a hands-off project that gates merge_pr in
+// approval_required will mint an approval for every green PR and stop
+// merging until a human acts. Warnings() must surface this loud at load
+// time so the operator notices without grepping the daemon journal.
+func TestConfig_Warnings_HandsOffMergeApprovalRequired(t *testing.T) {
+	cfg := &Config{ReviewGate: "greptile"}
+	cfg.Supervisor.ApprovalRequired = []string{
+		SupervisorActionMergePR,
+		SupervisorActionCloseIssue,
+		SupervisorActionDeleteWorktree,
+	}
+	warnings := cfg.Warnings()
+	if len(warnings) == 0 {
+		t.Fatalf("Warnings() = nil, want at least one warning for hands-off + merge_pr in approval_required")
+	}
+	found := false
+	for _, msg := range warnings {
+		if strings.Contains(msg, "merge_pr") && strings.Contains(msg, "approval_required") && strings.Contains(msg, "review_gate=greptile") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Warnings() = %v, want a message naming merge_pr, approval_required, and review_gate", warnings)
+	}
+}
+
+func TestConfig_Warnings_NoApprovalRequired(t *testing.T) {
+	cfg := &Config{ReviewGate: "greptile"}
+	if warnings := cfg.Warnings(); len(warnings) != 0 {
+		t.Fatalf("Warnings() = %v, want none when merge_pr is not in approval_required", warnings)
+	}
+}
+
+// delete_worktree is approval_required but does not gate the green-PR
+// completion path, so it must not trigger the hands-off warning.
+func TestConfig_Warnings_NonMergeVerbDoesNotWarn(t *testing.T) {
+	cfg := &Config{ReviewGate: "greptile"}
+	cfg.Supervisor.ApprovalRequired = []string{SupervisorActionDeleteWorktree, SupervisorActionChangeGlobalConfig}
+	if warnings := cfg.Warnings(); len(warnings) != 0 {
+		t.Fatalf("Warnings() = %v, want none for non-merge-gating verbs", warnings)
+	}
+}
+
+// Nil config must be safe to call (callers iterate freshly-loaded configs).
+func TestConfig_Warnings_NilSafe(t *testing.T) {
+	var cfg *Config
+	if warnings := cfg.Warnings(); warnings != nil {
+		t.Fatalf("Warnings() on nil cfg = %v, want nil", warnings)
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2352,6 +2352,32 @@ func fleetOperatorStateFromSupervisor(project fleetProjectState) (fleetOperatorS
 			Summary:    firstNonEmpty(summary, "A PR is in checks/review/merge gate; no code worker is expected right now."),
 			NextAction: "Wait for checks and review gates, then merge or respawn from feedback.",
 		}
+	case "merge_pr":
+		// #425 (sup-98): the supervisor recommended a merge but the
+		// project policy lists merge_pr in approval_required, so a human
+		// must click. Surface as "approval required" instead of the
+		// generic "monitoring PR" so the dashboard shows the operator the
+		// blocker, not a passive "monitoring" pill.
+		if stuck, ok := findStuckState(latest.StuckStates, state.StuckPolicyBlocksMerge); ok {
+			operator = fleetOperatorState{
+				Kind:       "approval_required",
+				Tone:       "attention",
+				Label:      "Approval required",
+				Summary:    firstNonEmpty(stuck.Summary, summary, "PR is ready to merge but supervisor policy requires operator approval."),
+				NextAction: "Open the PR or the approvals queue and approve the merge so Maestro can complete the green-PR path.",
+			}
+			if stuck.Target != nil {
+				target = stuck.Target
+			}
+		} else {
+			operator = fleetOperatorState{
+				Kind:       "merge_ready",
+				Tone:       "busy",
+				Label:      "Ready to merge",
+				Summary:    firstNonEmpty(summary, "PR is ready to merge; supervisor will execute on the next cycle."),
+				NextAction: "Wait for the supervisor's next tick to merge the PR.",
+			}
+		}
 	case "spawn_worker":
 		operator = fleetOperatorState{
 			Kind:       "pending_dispatch",
@@ -2407,6 +2433,15 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func findStuckState(stucks []state.SupervisorStuckState, code string) (state.SupervisorStuckState, bool) {
+	for _, stuck := range stucks {
+		if stuck.Code == code {
+			return stuck, true
+		}
+	}
+	return state.SupervisorStuckState{}, false
 }
 
 func truncateFleetOperatorText(value string, limit int) string {

--- a/internal/server/policy_blocks_merge_test.go
+++ b/internal/server/policy_blocks_merge_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #425 (sup-98): policy_blocks_merge from the supervisor must flow into
+// the session-level "needs attention" pill so the dashboard surfaces the
+// operator-required merge approval instead of a passive "monitoring PR"
+// indication.
+func TestApplySupervisorAttention_PolicyBlocksMerge_NeedsAttention(t *testing.T) {
+	infos := []sessionInfo{{
+		Slot:        "scribe-1",
+		IssueNumber: 200,
+		PRNumber:    115,
+		Status:      string(state.StatusPROpen),
+	}}
+	decision := &state.SupervisorDecision{
+		RecommendedAction: "merge_pr",
+		StuckStates: []state.SupervisorStuckState{{
+			Code:              state.StuckPolicyBlocksMerge,
+			Severity:          "warning",
+			Summary:           "PR #115 is ready to merge but project policy requires operator approval for merge_pr.",
+			RecommendedAction: "merge_pr",
+			Target:            &state.SupervisorTarget{Issue: 200, PR: 115, Session: "scribe-1"},
+		}},
+	}
+
+	applySupervisorAttention(infos, decision)
+
+	if !infos[0].NeedsAttention {
+		t.Fatalf("policy_blocks_merge must flag NeedsAttention: %#v", infos[0])
+	}
+	if !strings.Contains(infos[0].StatusReason, "operator approval") {
+		t.Fatalf("status reason = %q, want it to name operator approval", infos[0].StatusReason)
+	}
+}
+
+// supervisorStuckNeedsAttention must classify policy_blocks_merge as an
+// attention state so it cannot regress to "informational".
+func TestSupervisorStuckNeedsAttention_PolicyBlocksMerge(t *testing.T) {
+	stuck := state.SupervisorStuckState{Code: state.StuckPolicyBlocksMerge, Severity: "warning"}
+	if !supervisorStuckNeedsAttention(stuck) {
+		t.Fatal("policy_blocks_merge must require attention")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -697,7 +697,7 @@ func stuckTargetsSession(stuck state.SupervisorStuckState, info sessionInfo) boo
 
 func supervisorStuckNeedsAttention(stuck state.SupervisorStuckState) bool {
 	switch stuck.Code {
-	case "retry_exhausted", "retry_exhausted_open_pr", "dead_running_pid", "stale_worker_logs", "worker_timeout", "failing_checks", "closed_pr_with_active_session", "unmergeable_pr", "stale_review_feedback", "greptile_not_approved":
+	case "retry_exhausted", "retry_exhausted_open_pr", "dead_running_pid", "stale_worker_logs", "worker_timeout", "failing_checks", "closed_pr_with_active_session", "unmergeable_pr", "stale_review_feedback", "greptile_not_approved", state.StuckPolicyBlocksMerge:
 		return true
 	}
 	return stuck.Severity == "blocked"

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -474,6 +474,18 @@ const (
 	StuckHandoffEpicNeedsChild  = "handoff_epic_needs_child"
 	StuckPreflightFailed        = "preflight_failed"
 	StuckIssueNeedsVerification = "issue_needs_verification"
+	// StuckPolicyBlocksMerge is emitted when an open PR is fully ready to
+	// merge (not draft, mergeable, CI green, review gate passed) but the
+	// project policy lists merge_pr (or close_issue) in approval_required.
+	// The supervisor still emits the merge_pr recommendation (which mints
+	// the approval), but the dashboard/CLI needs to see this code so it can
+	// show "operator approval required" instead of a passive "monitoring".
+	StuckPolicyBlocksMerge = "policy_blocks_merge"
+	// StuckPendingChecks is emitted when an open PR is being monitored
+	// because at least one gate (draft / mergeable / CI / review) has not
+	// yet cleared. Lets the dashboard render a specific "waiting on checks"
+	// state instead of conflating it with policy or repair gating.
+	StuckPendingChecks = "pending_checks"
 )
 
 // SupervisorIssueCandidate describes the issue selected by queue policy without

--- a/internal/supervisor/policy_blocks_merge_test.go
+++ b/internal/supervisor/policy_blocks_merge_test.go
@@ -1,0 +1,233 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #425 (sup-98): when an open PR is fully ready to merge but the project
+// policy lists merge_pr in approval_required, the supervisor must
+// recommend merge_pr (so the cautious gate mints an approval) AND attach
+// a policy_blocks_merge stuck state so the dashboard/CLI can show the
+// operator that a human click is the missing link. Before the fix the
+// supervisor either looped on monitor_open_pr or showed a passive
+// "monitoring PR" tile with no indication that approval was required.
+func TestDecide_OpenPRGreen_PolicyBlocksMerge_SurfacesStuckState(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	cfg.Supervisor.ApprovalRequired = []string{
+		config.SupervisorActionMergePR,
+		config.SupervisorActionCloseIssue,
+		config.SupervisorActionDeleteWorktree,
+	}
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 115, HeadRefName: "feat/auth-wave", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{115: "success"},
+	}
+	st := state.NewState()
+	st.Sessions["scribe-1"] = &state.Session{
+		IssueNumber: 200,
+		IssueTitle:  "auth wave PR",
+		Status:      state.StatusPROpen,
+		Branch:      "feat/auth-wave",
+		PRNumber:    115,
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionMergePR {
+		t.Fatalf("action = %q, want merge_pr (ready PR, cautious gate mints approval)", decision.RecommendedAction)
+	}
+	stuck := requireStuckState(t, decision, state.StuckPolicyBlocksMerge)
+	if stuck.Severity != SeverityWarning {
+		t.Errorf("severity = %q, want warning", stuck.Severity)
+	}
+	if stuck.Target == nil || stuck.Target.PR != 115 {
+		t.Errorf("target = %#v, want PR=115", stuck.Target)
+	}
+	if !strings.Contains(stuck.Summary, "merge_pr") {
+		t.Errorf("summary = %q, want it to name the gated verb (merge_pr)", stuck.Summary)
+	}
+	// close_issue is also approval-required and should appear in the same
+	// stuck state so the operator sees the full gate set in one place.
+	if !strings.Contains(stuck.Summary, "close_issue") {
+		t.Errorf("summary = %q, want it to also name close_issue", stuck.Summary)
+	}
+	// delete_worktree is approval-required but does NOT block the
+	// green-PR completion path, so it must not surface here.
+	if strings.Contains(stuck.Summary, "delete_worktree") {
+		t.Errorf("summary = %q, must not name delete_worktree (not a merge-gating verb)", stuck.Summary)
+	}
+}
+
+// When merge_pr is NOT in approval_required, the supervisor still emits
+// merge_pr but does NOT attach a policy_blocks_merge stuck state — the
+// gate is policy-permissive and the executor will merge on the next tick.
+func TestDecide_OpenPRGreen_AutomergeAllowed_NoPolicyStuckState(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	// Only delete_worktree gated — does not block merge.
+	cfg.Supervisor.ApprovalRequired = []string{
+		config.SupervisorActionDeleteWorktree,
+	}
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 116, HeadRefName: "feat/auto", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{116: "success"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 201,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/auto",
+		PRNumber:    116,
+		StartedAt:   time.Now().UTC().Add(-30 * time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionMergePR {
+		t.Fatalf("action = %q, want merge_pr", decision.RecommendedAction)
+	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == state.StuckPolicyBlocksMerge {
+			t.Fatalf("policy_blocks_merge must NOT be present when merge_pr is not approval-required: %#v", stuck)
+		}
+	}
+}
+
+// pending_checks must be attached when the supervisor stays on
+// monitor_open_pr so the dashboard can render the specific blocker
+// (CI pending, mergeable unknown, draft, ...) instead of a generic tile.
+func TestDecide_OpenPR_PendingCI_AttachesPendingChecksStuckState(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 117, HeadRefName: "feat/pending", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{117: "pending"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 202,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/pending",
+		PRNumber:    117,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr", decision.RecommendedAction)
+	}
+	stuck := requireStuckState(t, decision, state.StuckPendingChecks)
+	if stuck.Target == nil || stuck.Target.PR != 117 {
+		t.Errorf("target = %#v, want PR=117", stuck.Target)
+	}
+	if stuck.Severity != SeverityInfo {
+		t.Errorf("severity = %q, want info", stuck.Severity)
+	}
+	if !strings.Contains(strings.ToLower(stuck.Summary), "ci status=pending") {
+		t.Errorf("summary = %q, want it to name CI pending", stuck.Summary)
+	}
+}
+
+// #425 evidence loop: PRCIStatus="pending" because a legacy commit
+// status hangs, but the per-PR mergeable_state is "clean" (all required
+// checks passed). Supervisor must trust the GitHub-computed
+// mergeable_state and recommend merge_pr instead of looping on
+// monitor_open_pr.
+func TestDecide_OpenPR_CIAggregateStaleButMergeStateClean_Merges(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:         []github.PR{{Number: 115, HeadRefName: "feat/auth", Mergeable: "MERGEABLE"}},
+		ciStatuses:  map[int]string{115: "pending"},
+		mergeStates: map[int]string{115: "clean"},
+	}
+	st := state.NewState()
+	st.Sessions["scribe-1"] = &state.Session{
+		IssueNumber: 200,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/auth",
+		PRNumber:    115,
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMergePR {
+		t.Fatalf("action = %q, want merge_pr (mergeable_state=clean must override stale aggregate CI=pending)", decision.RecommendedAction)
+	}
+}
+
+// mergeable_state="blocked" means a required check is still failing;
+// stay on monitor_open_pr even if a legacy commit status would otherwise
+// have been pending-but-not-failure.
+func TestDecide_OpenPR_CIPendingAndMergeStateBlocked_StaysMonitor(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:         []github.PR{{Number: 118, HeadRefName: "feat/blocked", Mergeable: "MERGEABLE"}},
+		ciStatuses:  map[int]string{118: "pending"},
+		mergeStates: map[int]string{118: "blocked"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 203,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/blocked",
+		PRNumber:    118,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr (mergeable_state=blocked must not override pending CI)", decision.RecommendedAction)
+	}
+}
+
+func TestMergeGatedApprovalVerbs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "empty", in: nil, want: nil},
+		{name: "only merge", in: []string{"merge_pr"}, want: []string{"merge_pr"}},
+		{name: "merge and close, dedup", in: []string{"merge_pr", "close_issue", "merge_pr"}, want: []string{"close_issue", "merge_pr"}},
+		{name: "non-merge verbs ignored", in: []string{"delete_worktree", "change_global_config"}, want: nil},
+		{name: "mixed", in: []string{"merge_pr", "delete_worktree", "close_issue"}, want: []string{"close_issue", "merge_pr"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeGatedApprovalVerbs(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -116,6 +116,18 @@ type prMergeableReader interface {
 	PRMergeable(prNumber int) (string, error)
 }
 
+// prMergeStateReader is the optional reader interface for GitHub's raw
+// per-PR mergeable_state ("clean" / "unstable" / "blocked" / "behind" /
+// "dirty" / "unknown" / "draft" / "has_hooks"). Used as a tie-breaker
+// when PRCIStatus returns "pending" — the aggregate CI signal can be
+// stale (e.g. a long-lived legacy commit-status hangs in pending while
+// every check-run completes successfully), but GitHub's own
+// mergeable_state "clean" / "unstable" already encodes the per-required-
+// check verdict and is therefore authoritative. #425 (sup-98).
+type prMergeStateReader interface {
+	PRMergeStatus(prNumber int) (mergeable string, mergeStateStatus string, err error)
+}
+
 // PreflightResult is the outcome of running a configured preflight command.
 // Ok=true means the gate passed and the supervisor may continue dispatching
 // spawn/open-child actions. Ok=false carries a human-readable Reason that is
@@ -346,10 +358,11 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		if ready, mergeReasons := e.openPRReadyToMerge(slot, sess, pr); ready {
 			summary := fmt.Sprintf("Merge PR #%d for issue #%d — checks green, mergeable, review gates passed.", pr.Number, sess.IssueNumber)
 			reasons := appendReasons(baseReasons, mergeReasons...)
+			target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
 			decision := e.decision(st, now, projectState, ActionMergePR,
 				summary,
-				RiskMutating, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
-			decision.StuckStates = stuckStates
+				RiskMutating, 0.9, target, PolicyRuleRuntimeState, reasons)
+			decision.StuckStates = appendStuck(stuckStates, e.policyBlockerStuckStates(target, sess, pr)...)
 			return decision, nil
 		}
 
@@ -369,10 +382,11 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 				"Retry exhaustion does not block normal PR merge flow when checks and review gates pass",
 			)
 		}
+		target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
 		decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
 			summary,
-			RiskSafe, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
-		decision.StuckStates = stuckStates
+			RiskSafe, 0.9, target, PolicyRuleRuntimeState, reasons)
+		decision.StuckStates = appendStuck(stuckStates, pendingChecksStuckState(target, pr, monitorReasons))
 		return decision, nil
 	}
 
@@ -2027,8 +2041,19 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 	if err != nil {
 		return false, nil
 	}
-	if strings.ToLower(strings.TrimSpace(ciStatus)) != "success" {
-		return false, nil
+	ciLower := strings.ToLower(strings.TrimSpace(ciStatus))
+	if ciLower != "success" {
+		// #425 (sup-98): the aggregate PRCIStatus can stick at "pending"
+		// long after every required check has gone green — the most common
+		// cause is a legacy commit-status (used by some review bots) that
+		// never resolves. GitHub's own mergeable_state already encodes the
+		// required-check verdict, so treat "clean" / "unstable" as the
+		// authoritative override before recommending passive monitoring.
+		// "blocked" / "behind" / "dirty" / "" / "unknown" all stay
+		// not-ready.
+		if !mergeStateAllowsMerge(e.reader, pr.Number) {
+			return false, nil
+		}
 	}
 
 	// Greptile gate — when the reader exposes Greptile signal, require
@@ -2051,7 +2076,15 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 	reasons := []string{
 		fmt.Sprintf("PR #%d is not draft", pr.Number),
 		fmt.Sprintf("PR #%d mergeable=%s", pr.Number, mergeable),
-		fmt.Sprintf("PR #%d CI status=success", pr.Number),
+	}
+	if ciLower == "success" {
+		reasons = append(reasons, fmt.Sprintf("PR #%d CI status=success", pr.Number))
+	} else {
+		// CI status was stale but mergeable_state confirmed all required
+		// checks passed. Record both so the journal explains the override.
+		reasons = append(reasons,
+			fmt.Sprintf("PR #%d aggregate CI status=%s; mergeable_state confirms required checks passed", pr.Number, ciStatus),
+		)
 	}
 	if _, ok := e.reader.(prGreptileReader); ok {
 		reasons = append(reasons, fmt.Sprintf("PR #%d Greptile review approved", pr.Number))
@@ -2108,6 +2141,28 @@ func (e *Engine) monitorOpenPRReasons(slot string, sess *state.Session, pr githu
 	return reasons
 }
 
+// mergeStateAllowsMerge consults the optional prMergeStateReader for the
+// raw GitHub mergeable_state. Returns true when GitHub itself reports
+// the PR as "clean" (every required check passed) or "unstable" (only
+// non-required checks failing) — both are safe to merge. Any other
+// state, or a reader that does not expose the signal, returns false so
+// the caller stays conservative. #425.
+func mergeStateAllowsMerge(reader Reader, prNumber int) bool {
+	r, ok := reader.(prMergeStateReader)
+	if !ok {
+		return false
+	}
+	_, mergeState, err := r.PRMergeStatus(prNumber)
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(mergeState)) {
+	case "clean", "unstable":
+		return true
+	}
+	return false
+}
+
 // summarizeMonitorReasons joins reasons into a single short phrase for the
 // SupervisorDecision.Summary field. Keeps the dashboard readable.
 func summarizeMonitorReasons(reasons []string) string {
@@ -2115,6 +2170,102 @@ func summarizeMonitorReasons(reasons []string) string {
 		return "waiting"
 	}
 	return strings.Join(reasons, "; ")
+}
+
+// policyBlockerStuckStates returns a slice of policy_blocks_merge stuck
+// states for each operator-gated verb (merge_pr, close_issue) the project
+// policy lists in approval_required, given a green/merge-ready PR. #425
+// (sup-98): without this signal a hands-off project where merge_pr is
+// approval-required surfaced only "monitor_open_pr / no mutation needed"
+// in the dashboard, and the operator had no idea their approval was the
+// missing link. The decision still recommends merge_pr — the cautious gate
+// mints the approval; this stuck state is the operator-visible "why am I
+// blocked" alongside it.
+func (e *Engine) policyBlockerStuckStates(target *state.SupervisorTarget, sess *state.Session, pr github.PR) []state.SupervisorStuckState {
+	if e == nil || e.cfg == nil {
+		return nil
+	}
+	gated := mergeGatedApprovalVerbs(e.cfg.Supervisor.ApprovalRequired)
+	if len(gated) == 0 {
+		return nil
+	}
+	verbList := strings.Join(gated, ", ")
+	summary := fmt.Sprintf("PR #%d is ready to merge but project policy requires operator approval for %s.", pr.Number, verbList)
+	evidence := []string{
+		fmt.Sprintf("approval_required=%s", verbList),
+		fmt.Sprintf("PR #%d mergeable + checks green", pr.Number),
+	}
+	if sess != nil && sess.IssueNumber > 0 {
+		evidence = append(evidence, fmt.Sprintf("issue=#%d", sess.IssueNumber))
+	}
+	return []state.SupervisorStuckState{{
+		Code:              state.StuckPolicyBlocksMerge,
+		Severity:          SeverityWarning,
+		Summary:           summary,
+		Evidence:          evidence,
+		RecommendedAction: ActionMergePR,
+		SupervisorCanAct:  false,
+		Target:            target,
+	}}
+}
+
+// pendingChecksStuckState returns the pending_checks stuck state attached
+// to a monitor_open_pr decision so the dashboard can render the exact gate
+// that is still red (CI pending, mergeable unknown, etc.) instead of the
+// generic "monitoring PR" string. #425.
+func pendingChecksStuckState(target *state.SupervisorTarget, pr github.PR, reasons []string) state.SupervisorStuckState {
+	return state.SupervisorStuckState{
+		Code:              state.StuckPendingChecks,
+		Severity:          SeverityInfo,
+		Summary:           fmt.Sprintf("PR #%d is not yet merge-ready: %s", pr.Number, summarizeMonitorReasons(reasons)),
+		Evidence:          append([]string(nil), reasons...),
+		RecommendedAction: ActionMonitorOpenPR,
+		SupervisorCanAct:  true,
+		Target:            target,
+	}
+}
+
+// mergeGatedApprovalVerbs returns the subset of operator-configured
+// approval_required verbs that gate the green-PR completion path
+// (merge_pr, close_issue). Other verbs (delete_worktree,
+// change_global_config) do not block a ready-to-merge PR and are not
+// surfaced as policy blockers for it.
+func mergeGatedApprovalVerbs(approvalRequired []string) []string {
+	if len(approvalRequired) == 0 {
+		return nil
+	}
+	wanted := map[string]struct{}{
+		config.SupervisorActionMergePR:    {},
+		config.SupervisorActionCloseIssue: {},
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, raw := range approvalRequired {
+		canonical := canonicalAction(raw)
+		if _, ok := wanted[canonical]; !ok {
+			continue
+		}
+		if _, dup := seen[canonical]; dup {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		out = append(out, canonical)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// appendStuck appends one or more stuck states to a base slice, skipping
+// zero-value entries. Returns a fresh slice so callers can safely chain.
+func appendStuck(base []state.SupervisorStuckState, more ...state.SupervisorStuckState) []state.SupervisorStuckState {
+	out := append([]state.SupervisorStuckState(nil), base...)
+	for _, item := range more {
+		if strings.TrimSpace(item.Code) == "" {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
 }
 
 func (e *Engine) hasLiveRunningSessionForIssue(st *state.State, issueNumber int) bool {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -27,6 +27,7 @@ type fakeReader struct {
 	ciStatuses         map[int]string
 	greptileOK         map[int]bool
 	greptilePend       map[int]bool
+	mergeStates        map[int]string
 	rateLimit          *github.RateLimitStatus
 	rateLimitErr       error
 	rateLimitCalls     int
@@ -121,6 +122,17 @@ func (f *fakeReader) CommentIssue(issueNumber int, body string) error {
 
 func (f *fakeReader) PRCIStatus(prNumber int) (string, error) {
 	return f.ciStatuses[prNumber], nil
+}
+
+func (f *fakeReader) PRMergeStatus(prNumber int) (string, string, error) {
+	mergeable := ""
+	for _, pr := range f.prs {
+		if pr.Number == prNumber {
+			mergeable = pr.Mergeable
+			break
+		}
+	}
+	return mergeable, f.mergeStates[prNumber], nil
 }
 
 func (f *fakeReader) PRGreptileApproved(prNumber int) (bool, bool, error) {


### PR DESCRIPTION
Refs #425

## Changes
- `internal/state`: add `StuckPolicyBlocksMerge` and `StuckPendingChecks` codes.
- `internal/supervisor`: attach `policy_blocks_merge` (warning) to the `merge_pr` decision when `merge_pr`/`close_issue` is in `approval_required`, and `pending_checks` (info) to `monitor_open_pr`. Treat GitHub's per-PR `mergeable_state` (`clean`/`unstable`) as authoritative when the aggregate `PRCIStatus` is stale (`pending` while every required check has gone green) — the scribe-service auth wave loop where a legacy commit-status hung in pending and PR #115 sat idle.
- `internal/config`: add `Config.Warnings()` that flags hands-off projects where `review_gate` is configured but `merge_pr`/`close_issue` is approval-required. `cmd/maestro` logs these on startup and per-project hot-reload.
- `internal/server`: classify `policy_blocks_merge` as needs-attention; render the fleet operator tile as "Approval required" (with click-through next-action) instead of the generic "Monitoring PR".

## Testing
- `go test ./...`
- `go build ./cmd/maestro/`
- New unit tests:
  - `internal/supervisor/policy_blocks_merge_test.go` — covers all three branches: ready_to_merge, policy_blocks_merge, pending_checks, plus the `mergeable_state=clean` override on stale CI.
  - `internal/config/warnings_test.go` — warns/doesn't warn matrix on hands-off + approval_required combos.
  - `internal/server/policy_blocks_merge_test.go` — dashboard attention propagation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces `policy_blocks_merge` (warning) and `pending_checks` (info) stuck states so the dashboard and CLI can show operators actionable "Approval required" tiles instead of a passive "Monitoring PR" pill when a green PR is blocked by `approval_required` policy. It also adds a `Config.Warnings()` API that fires at startup/hot-reload for the hands-off+approval-required misconfiguration, and uses GitHub's per-PR `mergeable_state` ("clean"/"unstable") as an authoritative override when the aggregate CI status is stale-pending.

- **`internal/supervisor`**: `openPRReadyToMerge` now falls back to `mergeStateAllowsMerge` when CI is non-success; `policyBlockerStuckStates` and `pendingChecksStuckState` are attached to `merge_pr`/`monitor_open_pr` decisions respectively; `mergeGatedApprovalVerbs` filters `approval_required` to only the merge-gating verbs.
- **`internal/server`**: `supervisorStuckNeedsAttention` registers `StuckPolicyBlocksMerge` as attention-worthy; `fleetOperatorStateFromSupervisor` adds a dedicated `case "merge_pr":` that renders "Approval required" (with stuck-state target click-through) or "Ready to merge" instead of falling through to `default`.
- **`internal/config`**: `Config.Warnings()` and `handsOffMergeApprovalWarning` detect the hands-off+approval-required misconfiguration; `cmd/maestro/main.go` logs warnings on every config load path.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are additive and conservative in their defaults, with good test coverage across all new branches.

The `mergeStateAllowsMerge` tie-breaker is strictly opt-in and conservative. Stuck-state enrichment is additive and backward-compatible. The two verb-filter implementations (`config.go` and `supervisor.go`) are near-duplicates with subtly different sort behavior that could drift over time, but pose no current correctness risk.

The two verb-filter implementations (`config.go:mergeApprovalGatedVerbs` and `supervisor.go:mergeGatedApprovalVerbs`) are worth consolidating in a follow-up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Core logic change: adds `mergeStateAllowsMerge` tie-breaker and two new stuck-state builders; code is conservative and well-guarded, minor duplication with config.go's verb filter |
| internal/server/fleet.go | Adds dedicated `case "merge_pr":` with policy-blocker branch; `findStuckState` helper is clean; `target` fallback to `latest.Target` in the merge-ready branch is correct |
| internal/config/config.go | Adds `Warnings()`/`handsOffMergeApprovalWarning`; `mergeApprovalGatedVerbs` is near-duplicate of supervisor's `mergeGatedApprovalVerbs` with different sort behavior and normalization path |
| internal/server/server.go | Adds `state.StuckPolicyBlocksMerge` to the hardcoded attention-needs set; change is minimal and correct |
| internal/state/state.go | Two new exported stuck-state constants with clear godoc; no behavioral change |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(supervisor): surface policy\_blocks\_m..."](https://github.com/befeast/maestro/commit/96d3516a62a921fcb19cca9023fdb6e5fea96197) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34959742)</sub>

<!-- /greptile_comment -->