### PR TITLE
Supervisor dynamic waves should own dependency-based unblocking and Project enrollment

### DIFF
--- a/docs/handoff-epic-format.md
+++ b/docs/handoff-epic-format.md
@@ -195,3 +195,112 @@ supervisor:
 
 See also: [`ux-redesign-addendum-2026-05-25.md`](./ux-redesign-addendum-2026-05-25.md)
 for the Scribe redesign incident timeline that motivated this design.
+
+## Dependency-based dynamic waves (#442)
+
+A handoff epic that opens its wave of child issues up front (rather than
+one-at-a-time via the planner) needs a way for the supervisor to keep the
+board moving without an external cron. The dependency-unblock controller
+solves this:
+
+1. Every child issue in the wave is created with the configured `blocked`
+   label and a parseable dependency reference in its body.
+2. The supervisor scans blocked wave members each cycle, parses the
+   dependency references, and unblocks issues whose dependencies are all
+   complete (issue closed or linked PR merged).
+3. When `github_projects.enabled` is true, the supervisor enrolls every
+   blocked wave member onto the configured GitHub Project so operators can
+   see the upcoming wave before any item goes runnable.
+
+### Dependency reference shapes the supervisor understands
+
+```markdown
+Depends on: #147
+```
+
+```markdown
+Depends on: #148, #149
+```
+
+```markdown
+## Dependencies
+
+- #147 — design export landed
+- #148 — UX wave 1 issues filed
+```
+
+All three are recognised by `github.FindDependencies`. The structured
+section variant is preferred for wave epics because it survives template
+edits cleanly.
+
+### Config
+
+```yaml
+supervisor:
+  ready_label: maestro-ready
+  blocked_label: blocked
+  safe_actions:
+    - add_ready_label
+    - remove_ready_label
+    - remove_blocked_label
+    - add_issue_comment
+    - merge_pr
+    - close_issue
+  dynamic_wave:
+    enabled: true
+    owns_ready_label: false
+    runnable_project_statuses: [Todo, To Do, Ready, Backlog, New]
+    dependency_unblock:
+      enabled: true             # opt-in; default false
+      max_runnable: 5           # cap concurrent runnable wave members
+      enroll_in_project: true   # default true when projects are configured
+      announce_with_comment: true  # default true; comment lists dep evidence
+
+github_projects:
+  enabled: true
+  project_number: 6
+```
+
+### What the supervisor does each cycle
+
+1. List open issues.
+2. Pick out the ones carrying the configured `blocked_label` — those are
+   the blocked wave members. They are evaluated separately from runnable
+   pickup, so they never appear as worker candidates.
+3. If GitHub Projects is enabled, ensure every blocked wave member is on
+   the configured Project board (best-effort; subprocess errors are
+   logged, not raised).
+4. For each blocked member, parse its body for dependencies. Skip the
+   member if no parseable dependency reference exists.
+5. Resolve dependencies: every dependency must either be closed or have a
+   merged linked PR. If any dependency is still open, the member stays
+   blocked this cycle.
+6. When the runnable cap (`max_runnable`) is already met, skip further
+   unblocks for this cycle.
+7. When a member is ready to unblock, recommend `unblock_issue` with three
+   mutations: `remove_blocked_label`, `add_ready_label`, and an
+   `add_issue_comment` whose body lists the dependency evidence (e.g.
+   `- #147 closed`, `- #149 PR merged`).
+8. Mutations are idempotent: if supervisor state already records a
+   succeeded mutation for the same issue/label, no duplicate is planned.
+
+### Why the supervisor (and not the worker)
+
+The implementing worker prompt stops after PR creation by design — the
+worker is scoped to a single slice. Continuation across the wave belongs
+to the supervisor:
+
+- The supervisor sees every issue and PR in the repo, including the
+  blocked wave's dependency PRs.
+- Cron-based unblockers (the temporary `scribe-redesign-handoff-unblocker`
+  used during the Scribe redesign) duplicate this loop with weaker
+  guarantees: no idempotency against supervisor state, no project
+  enrollment, no max-runnable cap.
+- The supervisor's safe-actions policy is the single audit trail for
+  label changes; routing the same change through an external cron splits
+  the evidence between two systems.
+
+If your repo previously ran an external cron for this purpose, you can
+retire it once `supervisor.dynamic_wave.dependency_unblock.enabled` is
+true and `safe_actions` grants `remove_blocked_label`, `add_ready_label`,
+and `add_issue_comment`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -231,13 +231,60 @@ type SupervisorOrderedQueueConfig struct {
 // SupervisorDynamicWaveConfig enables policy-driven issue selection without a
 // fixed issue-number list.
 type SupervisorDynamicWaveConfig struct {
-	Enabled                 *bool    `yaml:"enabled" json:"enabled,omitempty"`
-	OwnsReadyLabel          bool     `yaml:"owns_ready_label" json:"owns_ready_label,omitempty"`
-	RunnableProjectStatuses []string `yaml:"runnable_project_statuses" json:"runnable_project_statuses,omitempty"`
+	Enabled                 *bool                             `yaml:"enabled" json:"enabled,omitempty"`
+	OwnsReadyLabel          bool                              `yaml:"owns_ready_label" json:"owns_ready_label,omitempty"`
+	RunnableProjectStatuses []string                          `yaml:"runnable_project_statuses" json:"runnable_project_statuses,omitempty"`
+	DependencyUnblock       SupervisorDependencyUnblockConfig `yaml:"dependency_unblock" json:"dependency_unblock,omitempty"`
 }
 
 func (w SupervisorDynamicWaveConfig) Active() bool {
 	return w.Enabled != nil && *w.Enabled
+}
+
+// SupervisorDependencyUnblockConfig configures the dependency-based dynamic
+// wave controller. When enabled, the supervisor evaluates issues carrying the
+// configured blocked label, parses dependency references from their body, and
+// unblocks them (remove blocked label, add ready label, leave evidence
+// comment) once every dependency is closed/merged. It also enrolls those
+// blocked issues into the configured GitHub Project so wave members are
+// visible before they go runnable.
+//
+// Default is disabled. The Scribe redesign handoff used an external cron
+// (`scribe-redesign-handoff-unblocker`) as a workaround; this config lets
+// supervisor own that handoff dev role directly. See issue #442.
+type SupervisorDependencyUnblockConfig struct {
+	Enabled             *bool `yaml:"enabled" json:"enabled,omitempty"`
+	MaxRunnable         int   `yaml:"max_runnable" json:"max_runnable,omitempty"`
+	EnrollInProject     *bool `yaml:"enroll_in_project" json:"enroll_in_project,omitempty"`
+	AnnounceWithComment *bool `yaml:"announce_with_comment" json:"announce_with_comment,omitempty"`
+}
+
+// Active reports whether the dependency-unblock controller should run. Disabled
+// by default so existing projects without the explicit opt-in stay unchanged.
+func (d SupervisorDependencyUnblockConfig) Active() bool {
+	return d.Enabled != nil && *d.Enabled
+}
+
+// EnrollInProjectEnabled reports whether blocked wave members should be
+// enrolled into the configured GitHub Project. Default true when the
+// dependency-unblock controller is active.
+func (d SupervisorDependencyUnblockConfig) EnrollInProjectEnabled() bool {
+	if d.EnrollInProject == nil {
+		return true
+	}
+	return *d.EnrollInProject
+}
+
+// AnnounceWithCommentEnabled reports whether every automatic unblock should
+// leave an issue comment with dependency evidence. Default true so operators
+// always have an audit trail of why a wave opened. See acceptance criterion
+// "Every automatic unblock leaves a GitHub comment describing dependency
+// evidence."
+func (d SupervisorDependencyUnblockConfig) AnnounceWithCommentEnabled() bool {
+	if d.AnnounceWithComment == nil {
+		return true
+	}
+	return *d.AnnounceWithComment
 }
 
 func (q SupervisorOrderedQueueConfig) Active() bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -205,6 +205,84 @@ supervisor:
 	}
 }
 
+func TestParse_SupervisorDependencyUnblock(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  ready_label: maestro-ready
+  blocked_label: blocked
+  dynamic_wave:
+    enabled: true
+    dependency_unblock:
+      enabled: true
+      max_runnable: 4
+      enroll_in_project: false
+      announce_with_comment: false
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	u := cfg.Supervisor.DynamicWave.DependencyUnblock
+	if !u.Active() {
+		t.Fatal("DependencyUnblock should be active")
+	}
+	if u.MaxRunnable != 4 {
+		t.Fatalf("MaxRunnable = %d, want 4", u.MaxRunnable)
+	}
+	if u.EnrollInProjectEnabled() {
+		t.Fatal("EnrollInProjectEnabled() should be false when explicitly disabled")
+	}
+	if u.AnnounceWithCommentEnabled() {
+		t.Fatal("AnnounceWithCommentEnabled() should be false when explicitly disabled")
+	}
+}
+
+func TestParse_SupervisorDependencyUnblockDefaults(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  ready_label: maestro-ready
+  blocked_label: blocked
+  dynamic_wave:
+    enabled: true
+    dependency_unblock:
+      enabled: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	u := cfg.Supervisor.DynamicWave.DependencyUnblock
+	if !u.Active() {
+		t.Fatal("DependencyUnblock should be active")
+	}
+	if !u.EnrollInProjectEnabled() {
+		t.Fatal("EnrollInProjectEnabled() should default to true")
+	}
+	if !u.AnnounceWithCommentEnabled() {
+		t.Fatal("AnnounceWithCommentEnabled() should default to true")
+	}
+}
+
+func TestParse_SupervisorDependencyUnblockDisabledByDefault(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  ready_label: maestro-ready
+  blocked_label: blocked
+  dynamic_wave:
+    enabled: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Supervisor.DynamicWave.DependencyUnblock.Active() {
+		t.Fatal("DependencyUnblock should require explicit opt-in")
+	}
+}
+
 func TestParse_OutcomeBrief(t *testing.T) {
 	yaml := `
 repo: owner/repo

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1108,6 +1108,130 @@ func (c *Client) HasOpenPRForIssue(issueNumber int) (bool, error) {
 	return false, nil
 }
 
+// dependencyInlinePattern matches `Depends on: #147` or
+// `Depends on: #148, #149` (case-insensitive, tolerant of leading/trailing
+// whitespace and trailing punctuation). Used by FindDependencies alongside a
+// scan of a structured `## Dependencies` section to extract every issue the
+// blocked wave member is waiting on.
+//
+// Kept narrow on purpose: handoff issue templates write "Depends on:" and
+// occasionally "Depends:". We don't pretend to understand free-form English.
+var dependencyInlinePattern = regexp.MustCompile(`(?im)^\s*depends(?:\s+on)?\s*[:\-]\s*([^\r\n]+)$`)
+
+// dependencyIssueNumber matches a `#147` reference inside a parsed dependency
+// line or section. Reused for both inline and structured forms.
+var dependencyIssueNumber = regexp.MustCompile(`#(\d+)`)
+
+// FindDependencies scans an issue body for dependency references in two
+// supported shapes (see issue #442):
+//
+//   - inline: `Depends on: #147` or `Depends on: #148, #149`
+//   - structured section: a `## Dependencies` (or `### Dependencies`) heading
+//     followed by lines containing `#NNN` issue references.
+//
+// Returns deduplicated issue numbers in the order they first appear. Returns
+// nil for the zero body. The function is intentionally tolerant of common
+// shapes (`Depends:` without `on`, mixed case, trailing punctuation) but does
+// not invent dependencies — only explicit `#N` references count.
+func FindDependencies(body string) []int {
+	if strings.TrimSpace(body) == "" {
+		return nil
+	}
+	seen := make(map[int]struct{})
+	var deps []int
+	add := func(n int) {
+		if n <= 0 {
+			return
+		}
+		if _, ok := seen[n]; ok {
+			return
+		}
+		seen[n] = struct{}{}
+		deps = append(deps, n)
+	}
+
+	// Inline `Depends on:` lines.
+	for _, match := range dependencyInlinePattern.FindAllStringSubmatch(body, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		for _, ref := range dependencyIssueNumber.FindAllStringSubmatch(match[1], -1) {
+			if len(ref) < 2 {
+				continue
+			}
+			n, err := strconv.Atoi(ref[1])
+			if err != nil {
+				continue
+			}
+			add(n)
+		}
+	}
+
+	// Structured `## Dependencies` / `### Dependencies` section. A section ends
+	// at the next markdown heading at the same-or-shallower level, or EOF.
+	for _, section := range extractDependenciesSections(body) {
+		for _, ref := range dependencyIssueNumber.FindAllStringSubmatch(section, -1) {
+			if len(ref) < 2 {
+				continue
+			}
+			n, err := strconv.Atoi(ref[1])
+			if err != nil {
+				continue
+			}
+			add(n)
+		}
+	}
+
+	return deps
+}
+
+// extractDependenciesSections returns the markdown body of every
+// "Dependencies" section in the given body. A section spans from a heading
+// line whose text equals "Dependencies" (case-insensitive, ignoring trailing
+// punctuation) until the next heading of equal-or-shallower depth, or end of
+// file.
+func extractDependenciesSections(body string) []string {
+	lines := strings.Split(body, "\n")
+	var sections []string
+	for i := 0; i < len(lines); i++ {
+		level, heading, ok := headingLevelAndText(lines[i])
+		if !ok || !strings.EqualFold(heading, "dependencies") {
+			continue
+		}
+		end := len(lines)
+		for j := i + 1; j < len(lines); j++ {
+			otherLevel, _, otherOK := headingLevelAndText(lines[j])
+			if otherOK && otherLevel <= level {
+				end = j
+				break
+			}
+		}
+		sections = append(sections, strings.Join(lines[i+1:end], "\n"))
+		i = end - 1
+	}
+	return sections
+}
+
+// headingLevelAndText returns the heading depth (1 for `#`, 2 for `##`, ...)
+// and trimmed text when line is a markdown ATX heading. Trailing colons and
+// whitespace are removed so "## Dependencies:" matches "Dependencies".
+func headingLevelAndText(line string) (int, string, bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, "#") {
+		return 0, "", false
+	}
+	level := 0
+	for level < len(trimmed) && trimmed[level] == '#' {
+		level++
+	}
+	if level == 0 || level >= len(trimmed) || (trimmed[level] != ' ' && trimmed[level] != '\t') {
+		return 0, "", false
+	}
+	text := strings.TrimSpace(trimmed[level:])
+	text = strings.TrimRight(text, " \t:")
+	return level, text, true
+}
+
 // FindBlockers scans an issue body for blocker references matching the given
 // regex patterns. Each pattern must contain a capture group for the issue number.
 // Returns deduplicated issue numbers referenced as blockers.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -596,6 +596,7 @@ type SupervisorMutation struct {
 	Type       string `json:"type"`
 	Issue      int    `json:"issue,omitempty"`
 	Label      string `json:"label,omitempty"`
+	Body       string `json:"body,omitempty"`
 	Status     string `json:"status"`
 	ErrorClass string `json:"error_class,omitempty"`
 }

--- a/internal/supervisor/dependency_unblock.go
+++ b/internal/supervisor/dependency_unblock.go
@@ -116,13 +116,11 @@ func (e *Engine) evaluateDependencyUnblock(st *state.State, issues []github.Issu
 			// supervisor work.
 			continue
 		}
-		resolved, unresolved, evidence, err := e.resolveDependencies(deps, cache)
-		if err != nil {
-			// Read errors should not crash the whole supervisor cycle —
-			// just skip this candidate this cycle.
-			continue
-		}
+		resolved, unresolved, evidence := e.resolveDependencies(deps, cache)
 		if len(unresolved) > 0 {
+			// unresolved includes deps whose lookup failed this cycle (the
+			// cache reports read errors as "not resolved"), so a transient
+			// GitHub error simply defers the unblock to the next cycle.
 			continue
 		}
 
@@ -178,25 +176,19 @@ func (e *Engine) evaluateDependencyUnblock(st *state.State, issues []github.Issu
 // linked PR is merged (resolved) and those that are still open (unresolved).
 // Evidence is a human-readable list of "#N closed" / "#N PR merged" lines
 // used in the unblock comment.
-func (e *Engine) resolveDependencies(deps []int, cache *resolutionCache) (resolved []int, unresolved []int, evidence []string, err error) {
+func (e *Engine) resolveDependencies(deps []int, cache *resolutionCache) (resolved []int, unresolved []int, evidence []string) {
 	if cache == nil {
 		cache = newResolutionCache(e.reader)
 	}
 	for _, dep := range deps {
-		closed, lookupErr := e.reader.IsIssueClosed(dep)
-		if lookupErr != nil {
-			return nil, nil, nil, fmt.Errorf("check dependency #%d closed: %w", dep, lookupErr)
-		}
-		if closed {
+		// Route reads through the shared cache so a dependency common to N
+		// blocked wave members is fetched at most once per cycle (#564 P1).
+		if cache.isIssueClosed(dep) {
 			resolved = append(resolved, dep)
 			evidence = append(evidence, fmt.Sprintf("#%d closed", dep))
 			continue
 		}
-		merged, lookupErr := e.reader.HasMergedPRForIssue(dep)
-		if lookupErr != nil {
-			return nil, nil, nil, fmt.Errorf("check dependency #%d merged PR: %w", dep, lookupErr)
-		}
-		if merged {
+		if cache.hasMergedPRForIssue(dep) {
 			resolved = append(resolved, dep)
 			evidence = append(evidence, fmt.Sprintf("#%d PR merged", dep))
 			continue
@@ -204,7 +196,7 @@ func (e *Engine) resolveDependencies(deps []int, cache *resolutionCache) (resolv
 		unresolved = append(unresolved, dep)
 		evidence = append(evidence, fmt.Sprintf("#%d still open", dep))
 	}
-	return resolved, unresolved, evidence, nil
+	return resolved, unresolved, evidence
 }
 
 func blockedWaveMembers(issues []github.Issue, blockedLabel string) []github.Issue {

--- a/internal/supervisor/dependency_unblock.go
+++ b/internal/supervisor/dependency_unblock.go
@@ -1,0 +1,291 @@
+package supervisor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// ActionUnblockIssue is the supervisor recommended action for the
+// dependency-unblock controller: every configured dependency has closed (or
+// its linked PR is merged), so the supervisor removes the blocked label and
+// adds the ready label for the next wave. See issue #442.
+const ActionUnblockIssue = "unblock_issue"
+
+// PolicyRuleDependencyUnblock identifies the supervisor policy rule that
+// generated a dependency-unblock decision in audit/state.
+const PolicyRuleDependencyUnblock = "supervisor.dependency_unblock"
+
+// ProjectEnroller adds a blocked wave member to the configured GitHub
+// Project board so the operator can see the upcoming wave even before the
+// supervisor unblocks it. Implementations are best-effort: errors are
+// logged, not surfaced as decision failures, because enrollment must not
+// block the supervisor cycle.
+type ProjectEnroller interface {
+	EnrollBlockedIssue(issueNumber int) error
+}
+
+// enrollBlockedWaveMembers walks every blocked wave member and asks the
+// configured enroller to add it to the GitHub Project. Returns the issues
+// that were attempted (regardless of success) so the decision Reasons can
+// list them. Safe to call with a nil enroller; this is just a no-op then.
+func (e *Engine) enrollBlockedWaveMembers(blocked []github.Issue) []int {
+	cfg := e.cfg
+	if cfg == nil || !cfg.GitHubProjects.Enabled {
+		return nil
+	}
+	unblock := cfg.Supervisor.DynamicWave.DependencyUnblock
+	if !unblock.Active() || !unblock.EnrollInProjectEnabled() {
+		return nil
+	}
+	if e.enroller == nil {
+		return nil
+	}
+	enrolled := make([]int, 0, len(blocked))
+	for _, issue := range blocked {
+		if err := e.enroller.EnrollBlockedIssue(issue.Number); err != nil {
+			// Best-effort: keep the supervisor cycle moving. The
+			// fake reader in tests can capture this through its own
+			// counter; production wiring logs via the gh client.
+			continue
+		}
+		enrolled = append(enrolled, issue.Number)
+	}
+	sort.Ints(enrolled)
+	return enrolled
+}
+
+// evaluateDependencyUnblock walks every open issue, finds those carrying the
+// configured blocked label, parses their `Depends on: #N` / `## Dependencies`
+// references, and recommends a label/comment mutation set when all
+// dependencies are resolved (closed or PR-merged). Returns nil when the
+// controller is inactive, when there are no blocked wave members, or when no
+// member is ready to unblock (e.g. still has open deps, capacity exhausted,
+// or another supervisor decision already ran the same mutation this cycle).
+func (e *Engine) evaluateDependencyUnblock(st *state.State, issues []github.Issue, baseReasons []string, projectState state.SupervisorProjectState, now time.Time, cache *resolutionCache) *state.SupervisorDecision {
+	if e == nil || e.cfg == nil {
+		return nil
+	}
+	cfg := e.cfg
+	unblockCfg := cfg.Supervisor.DynamicWave.DependencyUnblock
+	if !unblockCfg.Active() {
+		return nil
+	}
+	blockedLabel := e.blockedLabel()
+	readyLabel := e.readyLabel()
+	if blockedLabel == "" || readyLabel == "" {
+		return nil
+	}
+
+	// Respect max_runnable: we count current ready-labeled open issues so
+	// that supervising the wave never grows the runnable pool past the
+	// operator cap. Ordered/dynamic wave concurrency lives elsewhere; this
+	// cap is specific to the dependency-unblock controller.
+	if cap := unblockCfg.MaxRunnable; cap > 0 {
+		if currentlyReady := countOpenIssuesWithLabel(issues, readyLabel); currentlyReady >= cap {
+			return nil
+		}
+	}
+
+	candidates := blockedWaveMembers(issues, blockedLabel)
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// Project enrollment side-effect: surface blocked wave members on the
+	// configured GitHub Project so operators see the upcoming wave even
+	// before any one item is unblocked. Errors are best-effort.
+	enrolled := e.enrollBlockedWaveMembers(candidates)
+	if len(enrolled) > 0 {
+		baseReasons = appendReasons(baseReasons,
+			fmt.Sprintf("Enrolled %d blocked wave member(s) onto GitHub Project: %s", len(enrolled), dependencyRefs(enrolled)),
+		)
+	}
+
+	for _, issue := range candidates {
+		deps := github.FindDependencies(issue.Body)
+		if len(deps) == 0 {
+			// A blocked issue without parseable dependencies is operator-
+			// gated: we don't guess when it's safe to unblock. Skip silently
+			// so existing handoff items without the format don't appear as
+			// supervisor work.
+			continue
+		}
+		resolved, unresolved, evidence, err := e.resolveDependencies(deps, cache)
+		if err != nil {
+			// Read errors should not crash the whole supervisor cycle —
+			// just skip this candidate this cycle.
+			continue
+		}
+		if len(unresolved) > 0 {
+			continue
+		}
+
+		// Idempotency: do not re-emit if a previous decision already
+		// removed the blocked label or added the ready label for this
+		// exact issue/label pair. Prevents duplicate comments/labels.
+		removeBlocked := github.HasLabel(issue, []string{blockedLabel}) &&
+			!supervisorMutationSucceeded(st, issue.Number, MutationRemoveBlockedLabel, blockedLabel)
+		addReady := !github.HasLabel(issue, []string{readyLabel}) &&
+			!supervisorMutationSucceeded(st, issue.Number, MutationAddReadyLabel, readyLabel)
+		if !removeBlocked && !addReady {
+			continue
+		}
+
+		// Policy gate: the operator must explicitly allow the mutations we
+		// plan to execute. Without the safe-action grant we still surface
+		// the recommendation but mark it as mutating (approval-gated).
+		mutations := plannedDependencyUnblockMutations(cfg, issue.Number, readyLabel, blockedLabel, removeBlocked, addReady)
+		risk := RiskMutating
+		if len(mutations) > 0 && allMutationsAllowed(cfg, mutations) {
+			risk = RiskSafe
+		}
+
+		// Append the comment plan (dependency evidence) when the operator
+		// asked for it AND the comment safe-action is granted. Without the
+		// grant, the label mutations still go through and the audit trail
+		// lives in supervisor state instead of GitHub.
+		if unblockCfg.AnnounceWithCommentEnabled() && safeActionAllowed(cfg, config.SupervisorActionAddIssueComment) && risk == RiskSafe {
+			mutations = append(mutations, state.SupervisorMutation{
+				Type:   MutationIssueComment,
+				Issue:  issue.Number,
+				Body:   dependencyUnblockComment(issue, resolved, evidence),
+				Status: MutationStatusPlanned,
+			})
+		}
+
+		reasons := appendReasons(baseReasons,
+			fmt.Sprintf("Issue #%d is the next blocked wave member with all dependencies resolved", issue.Number),
+			fmt.Sprintf("Dependency evidence: %s", strings.Join(evidence, "; ")),
+			fmt.Sprintf("Plan: remove `%s`, add `%s`", blockedLabel, readyLabel),
+		)
+		summary := fmt.Sprintf("Unblock issue #%d: all dependencies (%s) are complete; add `%s` and remove `%s`.", issue.Number, dependencyRefs(deps), readyLabel, blockedLabel)
+		decision := e.decision(st, now, projectState, ActionUnblockIssue, summary, risk, 0.9,
+			&state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDependencyUnblock, reasons)
+		decision.Mutations = mutations
+		return &decision
+	}
+
+	return nil
+}
+
+// resolveDependencies returns the dependency issues that are closed or whose
+// linked PR is merged (resolved) and those that are still open (unresolved).
+// Evidence is a human-readable list of "#N closed" / "#N PR merged" lines
+// used in the unblock comment.
+func (e *Engine) resolveDependencies(deps []int, cache *resolutionCache) (resolved []int, unresolved []int, evidence []string, err error) {
+	if cache == nil {
+		cache = newResolutionCache(e.reader)
+	}
+	for _, dep := range deps {
+		closed, lookupErr := e.reader.IsIssueClosed(dep)
+		if lookupErr != nil {
+			return nil, nil, nil, fmt.Errorf("check dependency #%d closed: %w", dep, lookupErr)
+		}
+		if closed {
+			resolved = append(resolved, dep)
+			evidence = append(evidence, fmt.Sprintf("#%d closed", dep))
+			continue
+		}
+		merged, lookupErr := e.reader.HasMergedPRForIssue(dep)
+		if lookupErr != nil {
+			return nil, nil, nil, fmt.Errorf("check dependency #%d merged PR: %w", dep, lookupErr)
+		}
+		if merged {
+			resolved = append(resolved, dep)
+			evidence = append(evidence, fmt.Sprintf("#%d PR merged", dep))
+			continue
+		}
+		unresolved = append(unresolved, dep)
+		evidence = append(evidence, fmt.Sprintf("#%d still open", dep))
+	}
+	return resolved, unresolved, evidence, nil
+}
+
+func blockedWaveMembers(issues []github.Issue, blockedLabel string) []github.Issue {
+	if strings.TrimSpace(blockedLabel) == "" {
+		return nil
+	}
+	out := make([]github.Issue, 0)
+	for _, issue := range issues {
+		if github.HasLabel(issue, []string{blockedLabel}) {
+			out = append(out, issue)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Number < out[j].Number })
+	return out
+}
+
+func countOpenIssuesWithLabel(issues []github.Issue, label string) int {
+	if strings.TrimSpace(label) == "" {
+		return 0
+	}
+	count := 0
+	for _, issue := range issues {
+		if github.HasLabel(issue, []string{label}) {
+			count++
+		}
+	}
+	return count
+}
+
+func plannedDependencyUnblockMutations(cfg *config.Config, issueNumber int, readyLabel, blockedLabel string, removeBlocked, addReady bool) []state.SupervisorMutation {
+	var mutations []state.SupervisorMutation
+	if removeBlocked {
+		mutations = append(mutations, state.SupervisorMutation{
+			Type:   MutationRemoveBlockedLabel,
+			Issue:  issueNumber,
+			Label:  blockedLabel,
+			Status: MutationStatusPlanned,
+		})
+	}
+	if addReady {
+		mutations = append(mutations, state.SupervisorMutation{
+			Type:   MutationAddReadyLabel,
+			Issue:  issueNumber,
+			Label:  readyLabel,
+			Status: MutationStatusPlanned,
+		})
+	}
+	return mutations
+}
+
+func allMutationsAllowed(cfg *config.Config, mutations []state.SupervisorMutation) bool {
+	for _, m := range mutations {
+		if !safeActionAllowed(cfg, m.Type) {
+			return false
+		}
+	}
+	return true
+}
+
+func dependencyUnblockComment(issue github.Issue, resolved []int, evidence []string) string {
+	var b strings.Builder
+	b.WriteString("Maestro supervisor unblocked this issue: all configured dependencies are resolved.\n\n")
+	b.WriteString("Dependency evidence:\n")
+	for _, line := range evidence {
+		b.WriteString("- ")
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	if len(resolved) > 0 {
+		b.WriteString(fmt.Sprintf("\nResolved dependencies: %s\n", dependencyRefs(resolved)))
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func dependencyRefs(deps []int) string {
+	if len(deps) == 0 {
+		return ""
+	}
+	refs := make([]string, len(deps))
+	for i, n := range deps {
+		refs[i] = fmt.Sprintf("#%d", n)
+	}
+	return strings.Join(refs, ", ")
+}

--- a/internal/supervisor/dependency_unblock_test.go
+++ b/internal/supervisor/dependency_unblock_test.go
@@ -1,0 +1,471 @@
+package supervisor
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// fakeEnroller is a test ProjectEnroller that records every issue number it
+// was asked to enroll, plus an optional error to simulate transient failures.
+type fakeEnroller struct {
+	enrolled []int
+	err      error
+}
+
+func (f *fakeEnroller) EnrollBlockedIssue(issueNumber int) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.enrolled = append(f.enrolled, issueNumber)
+	return nil
+}
+
+// Helpers ---------------------------------------------------------------
+
+func enableDependencyUnblock(cfg *config.Config) {
+	enableDynamicWave(cfg)
+	cfg.Supervisor.ReadyLabel = "maestro-ready"
+	cfg.Supervisor.BlockedLabel = "blocked"
+	cfg.Supervisor.SafeActions = []string{
+		config.SupervisorActionAddReadyLabel,
+		config.SupervisorActionRemoveBlockedLabel,
+		config.SupervisorActionAddIssueComment,
+	}
+	on := true
+	cfg.Supervisor.DynamicWave.DependencyUnblock.Enabled = &on
+}
+
+func blockedIssue(number int, deps []int, extraLabels ...string) github.Issue {
+	labels := append([]string{"blocked"}, extraLabels...)
+	issue := testIssue(number, fmt.Sprintf("Issue %d", number), labels...)
+	if len(deps) > 0 {
+		refs := make([]string, len(deps))
+		for i, d := range deps {
+			refs[i] = fmt.Sprintf("#%d", d)
+		}
+		issue.Body = "Depends on: " + strings.Join(refs, ", ") + "\n"
+	}
+	return issue
+}
+
+// Test: FindDependencies parses inline + structured shapes ------------------
+
+func TestFindDependencies_InlineSingle(t *testing.T) {
+	got := github.FindDependencies("Depends on: #147")
+	want := []int{147}
+	if !equalInts(got, want) {
+		t.Fatalf("FindDependencies = %v, want %v", got, want)
+	}
+}
+
+func TestFindDependencies_InlineMultiple(t *testing.T) {
+	got := github.FindDependencies("Depends on: #148, #149")
+	want := []int{148, 149}
+	if !equalInts(got, want) {
+		t.Fatalf("FindDependencies = %v, want %v", got, want)
+	}
+}
+
+func TestFindDependencies_StructuredSection(t *testing.T) {
+	body := `
+## Dependencies
+
+- #147 — design export landed
+- #148 — UX issues filed
+
+## Notes
+
+Should not match here #999.
+`
+	got := github.FindDependencies(body)
+	want := []int{147, 148}
+	if !equalInts(got, want) {
+		t.Fatalf("FindDependencies = %v, want %v", got, want)
+	}
+}
+
+func TestFindDependencies_NoDuplicates(t *testing.T) {
+	body := `Depends on: #147
+
+## Dependencies
+
+- #147 (already mentioned above)
+- #148
+`
+	got := github.FindDependencies(body)
+	want := []int{147, 148}
+	if !equalInts(got, want) {
+		t.Fatalf("FindDependencies = %v, want %v", got, want)
+	}
+}
+
+func TestFindDependencies_NoneWhenEmpty(t *testing.T) {
+	if got := github.FindDependencies(""); got != nil {
+		t.Fatalf("FindDependencies(empty) = %v, want nil", got)
+	}
+	if got := github.FindDependencies("No deps here, just text."); got != nil {
+		t.Fatalf("FindDependencies(no marker) = %v, want nil", got)
+	}
+}
+
+// Test: blocked issues are NOT treated as worker candidates -----------------
+
+func TestEvaluate_BlockedIssuesAreNotSpawnCandidates(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	reader := &fakeReader{
+		issues: []github.Issue{
+			// Blocked wave member with unresolved dep — not a worker candidate.
+			blockedIssue(148, []int{147}, "maestro-ready"),
+		},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionSpawnWorker {
+		t.Fatalf("action = %q, want NOT spawn_worker for blocked dep #148", decision.RecommendedAction)
+	}
+}
+
+// Test: unblock fires when every dependency is closed ----------------------
+
+func TestEvaluate_UnblocksWhenAllDependenciesClosed(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	reader := &fakeReader{
+		issues:       []github.Issue{blockedIssue(148, []int{147})},
+		closedIssues: map[int]bool{147: true},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionUnblockIssue {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionUnblockIssue)
+	}
+	if decision.Target == nil || decision.Target.Issue != 148 {
+		t.Fatalf("target = %#v, want issue 148", decision.Target)
+	}
+	if decision.Risk != RiskSafe {
+		t.Fatalf("risk = %q, want safe (safe_actions cover the mutations)", decision.Risk)
+	}
+	hasRemoveBlocked, hasAddReady, hasComment := false, false, false
+	for _, m := range decision.Mutations {
+		switch m.Type {
+		case MutationRemoveBlockedLabel:
+			if m.Label != "blocked" {
+				t.Errorf("remove_blocked label = %q, want blocked", m.Label)
+			}
+			hasRemoveBlocked = true
+		case MutationAddReadyLabel:
+			if m.Label != "maestro-ready" {
+				t.Errorf("add_ready label = %q, want maestro-ready", m.Label)
+			}
+			hasAddReady = true
+		case MutationIssueComment:
+			if !strings.Contains(m.Body, "#147 closed") {
+				t.Errorf("comment body = %q, want dependency evidence for #147", m.Body)
+			}
+			hasComment = true
+		}
+	}
+	if !hasRemoveBlocked || !hasAddReady || !hasComment {
+		t.Fatalf("mutations = %#v, want remove_blocked + add_ready + comment", decision.Mutations)
+	}
+}
+
+// Test: dep merged-PR also resolves the dependency --------------------------
+
+func TestEvaluate_UnblocksWhenDependencyPRMerged(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	reader := &fakeReader{
+		issues:         []github.Issue{blockedIssue(149, []int{147})},
+		mergedPRIssues: map[int]bool{147: true},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionUnblockIssue {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionUnblockIssue)
+	}
+	commentSeen := false
+	for _, m := range decision.Mutations {
+		if m.Type == MutationIssueComment {
+			commentSeen = true
+			if !strings.Contains(m.Body, "#147 PR merged") {
+				t.Errorf("comment body = %q, want '#147 PR merged' evidence", m.Body)
+			}
+		}
+	}
+	if !commentSeen {
+		t.Fatalf("mutations = %#v, want a dependency-evidence comment", decision.Mutations)
+	}
+}
+
+// Test: open dep blocks unblock --------------------------------------------
+
+func TestEvaluate_DoesNotUnblockWhileDependencyStillOpen(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	// #147 stays open; supervisor must not unblock #148.
+	reader := &fakeReader{issues: []github.Issue{blockedIssue(148, []int{147})}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionUnblockIssue {
+		t.Fatalf("action = %q, want NOT unblock_issue while #147 is open", decision.RecommendedAction)
+	}
+}
+
+// Test: max_runnable cap stops further unblocks ----------------------------
+
+func TestEvaluate_MaxRunnableCapPreventsExtraUnblocks(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	cfg.Supervisor.DynamicWave.DependencyUnblock.MaxRunnable = 1
+
+	// One issue is already runnable (carries the ready label). The next
+	// blocked one with resolved deps must NOT be unblocked — cap is 1.
+	already := testIssue(140, "already runnable", "maestro-ready")
+	pending := blockedIssue(148, []int{147})
+	reader := &fakeReader{
+		issues:       []github.Issue{already, pending},
+		closedIssues: map[int]bool{147: true},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionUnblockIssue {
+		t.Fatalf("action = %q, want NOT unblock_issue (max_runnable=1 already met)", decision.RecommendedAction)
+	}
+}
+
+// Test: idempotency — once recorded as succeeded, no duplicate mutation ----
+
+func TestEvaluate_DoesNotRecommendDuplicateUnblockAfterSuccess(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	// Issue body still says "depends on #147" (#147 closed). But supervisor
+	// state already records succeeded remove_blocked + add_ready mutations
+	// for this issue. The labels on the issue should also have updated, but
+	// we test the idempotency guard separately: even with stale labels, a
+	// prior succeeded mutation must dedupe.
+	reader := &fakeReader{
+		issues:       []github.Issue{blockedIssue(148, []int{147})},
+		closedIssues: map[int]bool{147: true},
+	}
+	st := state.NewState()
+	st.SupervisorDecisions = []state.SupervisorDecision{{
+		Mutations: []state.SupervisorMutation{
+			{Type: MutationRemoveBlockedLabel, Issue: 148, Label: "blocked", Status: MutationStatusSucceeded},
+			{Type: MutationAddReadyLabel, Issue: 148, Label: "maestro-ready", Status: MutationStatusSucceeded},
+		},
+	}}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionUnblockIssue {
+		t.Fatalf("action = %q, want NOT a duplicate unblock_issue (succeeded mutation already recorded)", decision.RecommendedAction)
+	}
+}
+
+// Test: project enrollment for blocked items -------------------------------
+
+func TestEvaluate_EnrollsBlockedWaveMembersInProject(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	cfg.GitHubProjects.Enabled = true
+	cfg.GitHubProjects.ProjectNumber = 7
+
+	// #147 still open → #148 is blocked but should be enrolled regardless.
+	reader := &fakeReader{issues: []github.Issue{blockedIssue(148, []int{147})}}
+
+	enroller := &fakeEnroller{}
+	eng := testEngine(cfg, reader)
+	eng.SetProjectEnroller(enroller)
+	if _, err := eng.Decide(state.NewState()); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if !equalInts(enroller.enrolled, []int{148}) {
+		t.Fatalf("enrolled = %v, want [148]", enroller.enrolled)
+	}
+}
+
+// Test: enrollment respects enroll_in_project=false -------------------------
+
+func TestEvaluate_EnrollmentSkippedWhenDisabled(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	cfg.GitHubProjects.Enabled = true
+	cfg.GitHubProjects.ProjectNumber = 7
+	off := false
+	cfg.Supervisor.DynamicWave.DependencyUnblock.EnrollInProject = &off
+
+	reader := &fakeReader{issues: []github.Issue{blockedIssue(148, []int{147})}}
+	enroller := &fakeEnroller{}
+	eng := testEngine(cfg, reader)
+	eng.SetProjectEnroller(enroller)
+	if _, err := eng.Decide(state.NewState()); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if len(enroller.enrolled) != 0 {
+		t.Fatalf("enrolled = %v, want none (enroll_in_project=false)", enroller.enrolled)
+	}
+}
+
+// Test: enrollment failure does not crash the supervisor cycle --------------
+
+func TestEvaluate_EnrollmentFailureIsBestEffort(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	cfg.GitHubProjects.Enabled = true
+	cfg.GitHubProjects.ProjectNumber = 7
+
+	reader := &fakeReader{issues: []github.Issue{blockedIssue(148, []int{147})}}
+	enroller := &fakeEnroller{err: errors.New("graphql rate limited")}
+	eng := testEngine(cfg, reader)
+	eng.SetProjectEnroller(enroller)
+	if _, err := eng.Decide(state.NewState()); err != nil {
+		t.Fatalf("Decide failed despite best-effort enroller error: %v", err)
+	}
+}
+
+// Test: blocked issue without parseable deps is skipped silently -----------
+
+func TestEvaluate_BlockedIssueWithoutDepsIsLeftAlone(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+
+	// Body without "Depends on:" — operator-controlled, do not guess.
+	noDeps := testIssue(148, "manually blocked", "blocked")
+	noDeps.Body = "Free-form notes, no dependency marker."
+	reader := &fakeReader{issues: []github.Issue{noDeps}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionUnblockIssue {
+		t.Fatalf("action = %q, want NOT unblock_issue (no parseable deps)", decision.RecommendedAction)
+	}
+}
+
+// Test: controller inactive when feature flag is off ------------------------
+
+func TestEvaluate_InactiveWithoutFeatureFlag(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg) // No DependencyUnblock.Enabled set.
+	cfg.Supervisor.ReadyLabel = "maestro-ready"
+	cfg.Supervisor.BlockedLabel = "blocked"
+
+	reader := &fakeReader{
+		issues:       []github.Issue{blockedIssue(148, []int{147})},
+		closedIssues: map[int]bool{147: true},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionUnblockIssue {
+		t.Fatalf("action = %q, want NOT unblock_issue (feature flag off)", decision.RecommendedAction)
+	}
+}
+
+// Test: end-to-end through RunOnce executes the planned mutations ----------
+
+func TestRunOnce_DependencyUnblockExecutesMutations(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	reader := &fakeReader{
+		issues:       []github.Issue{blockedIssue(148, []int{147})},
+		closedIssues: map[int]bool{147: true},
+	}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if decision.Status != DecisionStatusSucceeded {
+		t.Fatalf("status = %q (summary=%q), want %q", decision.Status, decision.Summary, DecisionStatusSucceeded)
+	}
+	if got := reader.removedLabels; len(got) != 1 || got[0] != "#148:blocked" {
+		t.Fatalf("removed labels = %v, want [#148:blocked]", got)
+	}
+	if got := reader.addedLabels; len(got) != 1 || got[0] != "#148:maestro-ready" {
+		t.Fatalf("added labels = %v, want [#148:maestro-ready]", got)
+	}
+	if len(reader.comments) != 1 || !strings.Contains(reader.comments[0], "#147 closed") {
+		t.Fatalf("comments = %#v, want one comment with #147 closed evidence", reader.comments)
+	}
+
+	// Second cycle must be a no-op (idempotency).
+	if _, err := RunOnce(cfg, reader); err != nil {
+		t.Fatalf("RunOnce(2): %v", err)
+	}
+	if len(reader.removedLabels) != 1 || len(reader.addedLabels) != 1 || len(reader.comments) != 1 {
+		t.Fatalf("second RunOnce produced duplicates: removed=%v added=%v comments=%v", reader.removedLabels, reader.addedLabels, reader.comments)
+	}
+}
+
+// Test: default allowed actions include unblock_issue ----------------------
+
+func TestDefaultAllowedActions_IncludesUnblockIssue(t *testing.T) {
+	seen := map[string]bool{}
+	for _, a := range defaultAllowedActions() {
+		seen[a] = true
+	}
+	if !seen[ActionUnblockIssue] {
+		t.Errorf("defaultAllowedActions missing %q", ActionUnblockIssue)
+	}
+}
+
+func TestCanonicalAction_AliasesForUnblockIssue(t *testing.T) {
+	for _, in := range []string{"unblock_issue", "unblock", "remove_blocked_label_and_label_ready"} {
+		if got := canonicalAction(in); got != ActionUnblockIssue {
+			t.Errorf("canonicalAction(%q) = %q, want %q", in, got, ActionUnblockIssue)
+		}
+	}
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -355,6 +355,7 @@ func defaultAllowedActions() []string {
 		ActionLabelIssueReady,
 		ActionOpenChildIssue,
 		ActionPreflightFailed,
+		ActionUnblockIssue,
 	}
 }
 
@@ -396,6 +397,8 @@ func canonicalAction(action string) string {
 		return ActionOpenChildIssue
 	case ActionPreflightFailed:
 		return ActionPreflightFailed
+	case ActionUnblockIssue, "unblock", "remove_blocked_label_and_label_ready":
+		return ActionUnblockIssue
 	case ActionMergePR:
 		return ActionMergePR
 	case config.SupervisorActionCloseIssue:

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -156,6 +156,7 @@ type Engine struct {
 	stat      func(name string) (os.FileInfo, error)
 	lookPath  func(file string) (string, error)
 	preflight PreflightRunner
+	enroller  ProjectEnroller
 }
 
 func NewEngine(cfg *config.Config, reader Reader) *Engine {
@@ -171,10 +172,23 @@ func NewEngine(cfg *config.Config, reader Reader) *Engine {
 		lookPath:  exec.LookPath,
 		preflight: defaultPreflightRunner,
 	}
+	if enroller, ok := reader.(ProjectEnroller); ok {
+		eng.enroller = enroller
+	}
 	if cfg != nil && cfg.Supervisor.Enabled {
 		eng.llm = NewBackendLLMClient(cfg)
 	}
 	return eng
+}
+
+// SetProjectEnroller injects a custom ProjectEnroller (e.g. wired against a
+// real github.Client + ProjectField). Production callers use this; tests use
+// the fakeReader directly.
+func (e *Engine) SetProjectEnroller(enroller ProjectEnroller) {
+	if e == nil {
+		return
+	}
+	e.enroller = enroller
 }
 
 // defaultPreflightRunner shells out to `bash -c <command>` and returns
@@ -656,6 +670,16 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 		decision.QueueAnalysis = analysis
 		decision.StuckStates = stuckStates
 		return decision
+	}
+
+	// Dependency-unblock controller (#442): when an issue carries the blocked
+	// label, parse its dependency references and (when every dependency has
+	// closed or its linked PR merged) recommend removing the blocked label
+	// and adding the ready label so the next wave can pick it up. This runs
+	// BEFORE the candidate dispatch so an issue that just became ready does
+	// not have to wait an extra cycle.
+	if unblock := e.evaluateDependencyUnblock(st, issues, baseReasons, projectState, now, cache); unblock != nil {
+		return withAnalysis(*unblock), nil
 	}
 
 	if len(candidates) == 0 {
@@ -3022,7 +3046,7 @@ func applyQueueAction(cfg *config.Config, decision *state.SupervisorDecision, mu
 		completed = append(completed, completedMutationPhrase(mutation))
 	}
 
-	if cfg.Supervisor.QueueComments && safeActionAllowed(cfg, config.SupervisorActionAddIssueComment) && len(completed) > 0 && decision.Target != nil && decision.Target.Issue > 0 {
+	if cfg.Supervisor.QueueComments && safeActionAllowed(cfg, config.SupervisorActionAddIssueComment) && len(completed) > 0 && decision.Target != nil && decision.Target.Issue > 0 && !decisionAlreadyComments(decision, decision.Target.Issue) {
 		comment := state.SupervisorMutation{
 			Type:   MutationIssueComment,
 			Issue:  decision.Target.Issue,
@@ -3038,6 +3062,22 @@ func applyQueueAction(cfg *config.Config, decision *state.SupervisorDecision, mu
 	}
 }
 
+// decisionAlreadyComments reports whether the decision's mutations already
+// include an issue comment for the given issue. Used so applyQueueAction does
+// not stamp an extra "Maestro queue action" comment when the original
+// decision (e.g. dependency-unblock) carried its own evidence comment.
+func decisionAlreadyComments(decision *state.SupervisorDecision, issueNumber int) bool {
+	if decision == nil {
+		return false
+	}
+	for _, m := range decision.Mutations {
+		if m.Type == MutationIssueComment && m.Issue == issueNumber {
+			return true
+		}
+	}
+	return false
+}
+
 func applyQueueMutation(mutator Mutator, mutation state.SupervisorMutation) error {
 	switch mutation.Type {
 	case MutationAddReadyLabel:
@@ -3046,6 +3086,12 @@ func applyQueueMutation(mutator Mutator, mutation state.SupervisorMutation) erro
 		return mutator.RemoveIssueLabel(mutation.Issue, mutation.Label)
 	case MutationRemoveBlockedLabel:
 		return mutator.RemoveIssueLabel(mutation.Issue, mutation.Label)
+	case MutationIssueComment:
+		body := strings.TrimSpace(mutation.Body)
+		if body == "" {
+			return fmt.Errorf("issue comment mutation requires a non-empty body")
+		}
+		return mutator.CommentIssue(mutation.Issue, body)
 	default:
 		return fmt.Errorf("unsupported queue mutation %q", mutation.Type)
 	}


### PR DESCRIPTION
Refs #442

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the dependency-based dynamic wave controller: the supervisor now owns the full handoff lifecycle by scanning blocked wave members each cycle, evaluating their dependency references, and emitting `unblock_issue` decisions (remove blocked label + add ready label + evidence comment) when all dependencies are resolved. It also enrolls blocked wave members onto the configured GitHub Project board for operator visibility.

- **New `dependency_unblock` controller** (`dependency_unblock.go`, `supervisor.go`): resolves deps via the shared `resolutionCache`, respects a `max_runnable` cap, enforces idempotency against supervisor state, and runs before candidate dispatch so a newly-unblockable issue doesn't wait an extra cycle.
- **`FindDependencies`** (`github.go`): parses both inline `Depends on: #N` and structured `## Dependencies` section formats from issue bodies, with deduplication.
- **Config, state, LLM wiring** (`config.go`, `state.go`, `llm.go`): new `SupervisorDependencyUnblockConfig` with opt-in flag and default-true enrollment/comment toggles; `Body` field added to `SupervisorMutation`; `unblock_issue` registered as a default allowed action with aliases.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: GitHub Projects enrollment is skipped when the max_runnable cap is met, so blocked wave members may never appear on the Project board during an active wave.

The enrollment call sits below the early-return cap check, so in the common steady-state (cap perpetually full) blocked issues are never enrolled. All other logic — dependency parsing, idempotency, cache routing, comment deduplication — is correct and well tested.

internal/supervisor/dependency_unblock.go — the ordering of the cap check relative to enrollBlockedWaveMembers

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/dependency_unblock.go | New dependency-unblock controller implementing evaluation, enrollment, and mutation planning — contains a logic bug where GitHub Projects enrollment is skipped when max_runnable cap is already met |
| internal/supervisor/dependency_unblock_test.go | Comprehensive tests for the new controller; all major paths covered but missing a test verifying enrollment still occurs when max_runnable cap is met |
| internal/supervisor/supervisor.go | Wires in evaluateDependencyUnblock before candidate dispatch, adds decisionAlreadyComments guard to prevent duplicate comments, and adds MutationIssueComment case to applyQueueMutation |
| internal/config/config.go | Adds SupervisorDependencyUnblockConfig with Active/EnrollInProjectEnabled/AnnounceWithCommentEnabled accessors; defaults are correctly opt-in |
| internal/github/github.go | Adds FindDependencies with inline and structured-section parsing, plus extractDependenciesSections and headingLevelAndText helpers; implementation is clean |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/dependency_unblock.go:85-103
GitHub Projects enrollment is silently skipped whenever the `max_runnable` cap is already met. The documentation explicitly states enrollment should happen in step 3 (unconditionally), while the cap is a step-6 concern that only blocks label mutations. In a steady state where `max_runnable` is perpetually full — which is normal during an active wave — blocked wave members would never appear on the Project board, defeating the visibility purpose of enrollment.

```suggestion
	candidates := blockedWaveMembers(issues, blockedLabel)
	if len(candidates) == 0 {
		return nil
	}

	// Project enrollment side-effect: surface blocked wave members on the
	// configured GitHub Project so operators see the upcoming wave even
	// before any one item is unblocked. Errors are best-effort. This runs
	// unconditionally so enrollment is not gated on the max_runnable cap.
	enrolled := e.enrollBlockedWaveMembers(candidates)
	if len(enrolled) > 0 {
		baseReasons = appendReasons(baseReasons,
			fmt.Sprintf("Enrolled %d blocked wave member(s) onto GitHub Project: %s", len(enrolled), dependencyRefs(enrolled)),
		)
	}

	// Respect max_runnable: we count current ready-labeled open issues so
	// that supervising the wave never grows the runnable pool past the
	// operator cap. Ordered/dynamic wave concurrency lives elsewhere; this
	// cap is specific to the dependency-unblock controller.
	if cap := unblockCfg.MaxRunnable; cap > 0 {
		if currentlyReady := countOpenIssuesWithLabel(issues, readyLabel); currentlyReady >= cap {
			return nil
		}
	}
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(supervisor): route resolveDependenci..."](https://github.com/befeast/maestro/commit/af6b8af4a076d3d7542a335191dc105a93bcc403) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34983096)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->