### PR TITLE
P1: idempotent executor — same-process lock + slot-reuse fence (premortem #1, #7)

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -153,10 +153,17 @@ func (e *Executor) Execute(approval *state.Approval) Result {
 				Summary: fmt.Sprintf("approval %s already executing in another goroutine", id),
 			}
 		}
-		defer lock.Unlock()
-		// Drop the lock from the map after release so long-lived processes
-		// don't accumulate one mutex per ever-seen approval ID.
+		// Defers are LIFO: register Delete first so it runs LAST (after
+		// Unlock). The inverse ordering — Delete runs first, then Unlock —
+		// would leave a window in which a second goroutine for the same ID
+		// calls LoadOrStore and receives a brand-new unlocked mutex,
+		// succeeds on TryLock against that fresh entry, and proceeds to
+		// fire the side effect concurrently with this still-locked one.
+		// Unlock-then-Delete keeps map and mutex state aligned: while the
+		// mutex is held, the map entry is also present, so every concurrent
+		// caller observes the same locked mutex and short-circuits.
 		defer e.locks.Delete(id)
+		defer lock.Unlock()
 	}
 
 	// Repo guard (#489 / premortem #3): refuse any approval whose

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1929,10 +1929,17 @@ func (s *State) LiveSessionsAt(now time.Time) []*Session {
 	return live
 }
 
-// SessionAt returns the live session bound to slot, if any. Used by the
-// approver executor (#488 slot-reuse fence) to verify a delete_worktree
-// approval still targets the worker that was running when the approval
-// was queued.
+// SessionAt returns the session currently bound to slot, if any —
+// regardless of session status (running, done, failed, dead). No
+// liveness filter is applied; callers that need one must compose with
+// SessionLive / SessionLiveAt explicitly.
+//
+// Used by the approver executor (#488 slot-reuse fence) to verify a
+// delete_worktree approval still targets the issue that was running
+// when the approval was queued. The fence intentionally treats any
+// session at the slot — including a freshly-terminated one — as the
+// authoritative slot owner, since a terminated session for issue #N
+// still indicates the slot was most recently bound to #N.
 func (s *State) SessionAt(slot string) (*Session, bool) {
 	if s == nil || s.Sessions == nil {
 		return nil, false


### PR DESCRIPTION
Refs #488

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the defer ordering in `executor.go` so `lock.Unlock()` fires before `e.locks.Delete(id)` (LIFO), closing the window where a concurrent goroutine could receive a brand-new unlocked mutex from `LoadOrStore` and fire a duplicate side effect. `state.go` receives a doc-only update aligning `SessionAt`'s comment with its real behaviour of returning any session regardless of status.

- **`executor.go`**: Registers `Delete` before `Unlock` so the map entry stays present and locked for the full duration of execution; concurrent callers always observe the locked mutex and short-circuit to `ExecutionSkipped`.
- **`state.go`**: Clarifies that `SessionAt` performs no liveness filtering and that callers needing a live-only view must compose with `SessionLive`/`SessionLiveAt`.

<h3>Confidence Score: 4/5</h3>

Safe to merge for its stated goal; the narrow Unlock→Delete race window flagged in a prior thread remains and warrants a follow-up.

The defer-order fix is logically correct and substantially closes the double-execution window. A narrow residual window between lock.Unlock() and e.locks.Delete(id) still exists where a concurrent caller can slip in with the now-unlocked mutex and re-execute the side effect. The state.go change is documentation-only and carries no risk.

internal/approver/executor.go — the Unlock→Delete ordering is correct, but the post-unlock/pre-delete window means the in-process idempotency guarantee is probabilistic rather than absolute for very tight concurrent calls on the same approval ID.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/approver/executor.go | Swaps defer order so Unlock fires before Delete, preventing the previously-described concurrent TryLock-on-fresh-mutex window; residual nanosecond race already noted in prior thread. |
| internal/state/state.go | Doc-only update aligning SessionAt's comment with its always-any-status implementation; no behaviour change. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/approver/executor.go`, line 61-63 ([link](https://github.com/befeast/maestro/blob/1d8595bb1df2d1e761179721fdb057478f139f56/internal/approver/executor.go#L61-L63)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`SessionLookup` interface contract now contradicts its own implementation**

   The interface doc still says `LookupSession` returns "the live session at the given slot", but the canonical wiring (`SessionLookupFunc(st.SessionAt)`) intentionally returns any session regardless of liveness — this PR's `state.go` change makes that explicit. An alternative implementation that honours the "live" wording and filters out terminated sessions would silently defeat the slot-reuse fence: a deleted worktree approval queued while issue #N was running would bypass the guard the moment the #N session transitions to `done`, allowing the delete to proceed on a slot that may have since been recycled to #M.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/approver/executor.go
   Line: 61-63

   Comment:
   **`SessionLookup` interface contract now contradicts its own implementation**

   The interface doc still says `LookupSession` returns "the live session at the given slot", but the canonical wiring (`SessionLookupFunc(st.SessionAt)`) intentionally returns any session regardless of liveness — this PR's `state.go` change makes that explicit. An alternative implementation that honours the "live" wording and filters out terminated sessions would silently defeat the slot-reuse fence: a deleted worktree approval queued while issue #N was running would bypass the guard the moment the #N session transitions to `done`, allowing the delete to proceed on a slot that may have since been recycled to #M.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(approver): correct LIFO defer order ..."](https://github.com/befeast/maestro/commit/a17423989de1c95d68901fa36c5da1a5e8915331) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35007625)</sub>

<!-- /greptile_comment -->