### PR TITLE
feat(orchestrator): convergence-merge for retry-exhausted green PRs (#565)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -501,54 +501,55 @@ func (c StaleSessionReconcilerConfig) MergedPRDismissesEnabled() bool {
 }
 
 type Config struct {
-	Server                     ServerConfig                 `yaml:"server"`
-	Supervisor                 SupervisorConfig             `yaml:"supervisor"`
-	Repo                       string                       `yaml:"repo"`
-	Outcome                    outcome.Brief                `yaml:"outcome"`
-	LocalPath                  string                       `yaml:"local_path"`
-	WorktreeBase               string                       `yaml:"worktree_base"`
-	MaxParallel                int                          `yaml:"max_parallel"`
-	MaxConcurrentByState       map[string]int               `yaml:"max_concurrent_by_state"`       // per-state concurrency limits (e.g. "running": 5, "pr_open": 2)
-	MaxRuntimeMinutes          int                          `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
-	WorkerSilentTimeoutMinutes int                          `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
-	WorkerMaxTokens            int                          `yaml:"worker_max_tokens"`             // kill worker when token usage exceeds this threshold (0 = unlimited)
-	WorkerSoftTokenThreshold   *float64                     `yaml:"worker_soft_token_threshold"`   // fraction of worker_max_tokens to trigger checkpoint+respawn (default: 0.8, 0 = disabled)
-	MaxRetriesPerIssue         int                          `yaml:"max_retries_per_issue"`         // max failed worker sessions per issue before giving up (default: 3, 0 = unlimited)
-	AutoRebase                 bool                         `yaml:"auto_rebase"`                   // auto-attempt rebase for conflicting sessions (default: true)
-	ClaudeCmd                  string                       `yaml:"claude_cmd"`                    // deprecated: use model.backends.claude.cmd
-	IssueLabel                 string                       `yaml:"issue_label"`                   // deprecated: use issue_labels
-	IssueLabels                []string                     `yaml:"issue_labels"`
-	ExcludeLabels              []string                     `yaml:"exclude_labels"`
-	WorkerPrompt               string                       `yaml:"worker_prompt"`
-	BugPrompt                  string                       `yaml:"bug_prompt"`          // prompt template for issues with "bug" label
-	EnhancementPrompt          string                       `yaml:"enhancement_prompt"`  // prompt template for issues with "enhancement" label
-	PromptSections             []string                     `yaml:"prompt_sections"`     // additional prompt section files appended to the base prompt
-	ValidationContract         bool                         `yaml:"validation_contract"` // generate VALIDATION.md in worktree with test-first guidance
-	SessionPrefix              string                       `yaml:"session_prefix"`      // worker session name prefix (default: first 3 chars of repo name)
-	StateDir                   string                       `yaml:"state_dir"`           // state/log directory (default: ~/.maestro/<repo-hash>)
-	Model                      ModelConfig                  `yaml:"model"`
-	Routing                    RoutingConfig                `yaml:"routing"`
-	DeployCmd                  string                       `yaml:"deploy_cmd"`                  // shell command to run after successful PR merge
-	DeployTimeoutMinutes       int                          `yaml:"deploy_timeout_minutes"`      // timeout for deploy command in minutes (default: 15)
-	MergeStrategy              string                       `yaml:"merge_strategy"`              // "sequential" | "parallel"
-	MergeIntervalSeconds       int                          `yaml:"merge_interval_seconds"`      // minimum seconds between merges in sequential mode
-	ReviewGate                 string                       `yaml:"review_gate"`                 // "greptile" (default) | "none"
-	AutoRetryReviewFeedback    bool                         `yaml:"auto_retry_review_feedback"`  // close PRs with review comments and respawn a fixer
-	AutoRetryRebaseConflicts   bool                         `yaml:"auto_retry_rebase_conflicts"` // retry PRs whose auto-rebase fails with conflicts
-	Telegram                   TelegramConfig               `yaml:"telegram"`
-	Versioning                 VersioningConfig             `yaml:"versioning"`
-	GitHubProjects             GitHubProjectsConfig         `yaml:"github_projects"`
-	MaxRetryBackoffMs          int                          `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
-	AutoResolveFiles           []string                     `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
-	AutoRestoreFiles           []string                     `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase
-	CleanupWorktreesOnMerge    *bool                        `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
-	Pipeline                   PipelineConfig               `yaml:"pipeline"`
-	Hooks                      HooksConfig                  `yaml:"hooks"`
-	Missions                   MissionsConfig               `yaml:"missions"`
-	BlockerPatterns            []string                     `yaml:"blocker_patterns"`         // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
-	PollIntervalSeconds        int                          `yaml:"poll_interval_seconds"`    // override poll interval from config (0 = use CLI flag)
-	StaleSessionReconciler     StaleSessionReconcilerConfig `yaml:"stale_session_reconciler"` // filter stale supervisor sessions from operator attention
-	SourcePath                 string                       `yaml:"-"`                        // path the config was loaded from (not serialized)
+	Server                          ServerConfig                 `yaml:"server"`
+	Supervisor                      SupervisorConfig             `yaml:"supervisor"`
+	Repo                            string                       `yaml:"repo"`
+	Outcome                         outcome.Brief                `yaml:"outcome"`
+	LocalPath                       string                       `yaml:"local_path"`
+	WorktreeBase                    string                       `yaml:"worktree_base"`
+	MaxParallel                     int                          `yaml:"max_parallel"`
+	MaxConcurrentByState            map[string]int               `yaml:"max_concurrent_by_state"`       // per-state concurrency limits (e.g. "running": 5, "pr_open": 2)
+	MaxRuntimeMinutes               int                          `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
+	WorkerSilentTimeoutMinutes      int                          `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
+	WorkerMaxTokens                 int                          `yaml:"worker_max_tokens"`             // kill worker when token usage exceeds this threshold (0 = unlimited)
+	WorkerSoftTokenThreshold        *float64                     `yaml:"worker_soft_token_threshold"`   // fraction of worker_max_tokens to trigger checkpoint+respawn (default: 0.8, 0 = disabled)
+	MaxRetriesPerIssue              int                          `yaml:"max_retries_per_issue"`         // max failed worker sessions per issue before giving up (default: 3, 0 = unlimited)
+	AutoRebase                      bool                         `yaml:"auto_rebase"`                   // auto-attempt rebase for conflicting sessions (default: true)
+	ClaudeCmd                       string                       `yaml:"claude_cmd"`                    // deprecated: use model.backends.claude.cmd
+	IssueLabel                      string                       `yaml:"issue_label"`                   // deprecated: use issue_labels
+	IssueLabels                     []string                     `yaml:"issue_labels"`
+	ExcludeLabels                   []string                     `yaml:"exclude_labels"`
+	WorkerPrompt                    string                       `yaml:"worker_prompt"`
+	BugPrompt                       string                       `yaml:"bug_prompt"`          // prompt template for issues with "bug" label
+	EnhancementPrompt               string                       `yaml:"enhancement_prompt"`  // prompt template for issues with "enhancement" label
+	PromptSections                  []string                     `yaml:"prompt_sections"`     // additional prompt section files appended to the base prompt
+	ValidationContract              bool                         `yaml:"validation_contract"` // generate VALIDATION.md in worktree with test-first guidance
+	SessionPrefix                   string                       `yaml:"session_prefix"`      // worker session name prefix (default: first 3 chars of repo name)
+	StateDir                        string                       `yaml:"state_dir"`           // state/log directory (default: ~/.maestro/<repo-hash>)
+	Model                           ModelConfig                  `yaml:"model"`
+	Routing                         RoutingConfig                `yaml:"routing"`
+	DeployCmd                       string                       `yaml:"deploy_cmd"`                         // shell command to run after successful PR merge
+	DeployTimeoutMinutes            int                          `yaml:"deploy_timeout_minutes"`             // timeout for deploy command in minutes (default: 15)
+	MergeStrategy                   string                       `yaml:"merge_strategy"`                     // "sequential" | "parallel"
+	MergeIntervalSeconds            int                          `yaml:"merge_interval_seconds"`             // minimum seconds between merges in sequential mode
+	ReviewGate                      string                       `yaml:"review_gate"`                        // "greptile" (default) | "none"
+	AutoRetryReviewFeedback         bool                         `yaml:"auto_retry_review_feedback"`         // close PRs with review comments and respawn a fixer
+	MergeExhaustedNonCriticalReview *bool                        `yaml:"merge_exhausted_noncritical_review"` // #565: merge a green PR after review-feedback retries exhaust when only non-critical (P1/P2/P3) findings remain (no P0 on head). nil = default-on.
+	AutoRetryRebaseConflicts        bool                         `yaml:"auto_retry_rebase_conflicts"`        // retry PRs whose auto-rebase fails with conflicts
+	Telegram                        TelegramConfig               `yaml:"telegram"`
+	Versioning                      VersioningConfig             `yaml:"versioning"`
+	GitHubProjects                  GitHubProjectsConfig         `yaml:"github_projects"`
+	MaxRetryBackoffMs               int                          `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
+	AutoResolveFiles                []string                     `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
+	AutoRestoreFiles                []string                     `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase
+	CleanupWorktreesOnMerge         *bool                        `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
+	Pipeline                        PipelineConfig               `yaml:"pipeline"`
+	Hooks                           HooksConfig                  `yaml:"hooks"`
+	Missions                        MissionsConfig               `yaml:"missions"`
+	BlockerPatterns                 []string                     `yaml:"blocker_patterns"`         // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
+	PollIntervalSeconds             int                          `yaml:"poll_interval_seconds"`    // override poll interval from config (0 = use CLI flag)
+	StaleSessionReconciler          StaleSessionReconcilerConfig `yaml:"stale_session_reconciler"` // filter stale supervisor sessions from operator attention
+	SourcePath                      string                       `yaml:"-"`                        // path the config was loaded from (not serialized)
 }
 
 // LoadFrom loads config from a specific path.
@@ -1244,4 +1245,16 @@ func expandHome(path string) string {
 		return filepath.Join(os.Getenv("HOME"), path[2:])
 	}
 	return path
+}
+
+// MergeExhaustedNonCriticalReviewEnabled reports whether the orchestrator may
+// merge a green PR that exhausted its review-feedback retries when only
+// non-critical (P1/P2/P3) Greptile findings remain on head. Defaults to true
+// (nil) so hands-off delivery converges instead of dead-ending forever; set
+// `merge_exhausted_noncritical_review: false` to require manual handling.
+func (c *Config) MergeExhaustedNonCriticalReviewEnabled() bool {
+	if c == nil || c.MergeExhaustedNonCriticalReview == nil {
+		return true
+	}
+	return *c.MergeExhaustedNonCriticalReview
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -913,6 +913,55 @@ func isHighSeverity(body string) bool {
 	return false
 }
 
+// isCriticalSeverity reports whether a review comment is P0 (critical) only.
+// P1/P2/P3 are non-critical for the #565 convergence-merge escape.
+func isCriticalSeverity(body string) bool {
+	lower := strings.ToLower(body)
+	if strings.Contains(lower, "alt=\"p0\"") {
+		return true
+	}
+	if strings.Contains(lower, "/p0") {
+		return true
+	}
+	if strings.Contains(lower, "badge/p0") {
+		return true
+	}
+	return false
+}
+
+// hasGreptileCriticalCommentOnHead reports whether any Greptile inline comment
+// on the current head SHA is P0 (critical).
+func hasGreptileCriticalCommentOnHead(comments []greptileReviewComment, sha string) bool {
+	for _, comment := range comments {
+		if !isGreptileLogin(comment.User.Login) {
+			continue
+		}
+		if !reviewCommentTargetsHead(comment, sha) {
+			continue
+		}
+		if isCriticalSeverity(comment.Body) {
+			return true
+		}
+	}
+	return false
+}
+
+// PRHasCriticalReviewOnHead reports whether the PR has a P0 (critical) Greptile
+// inline comment on its current head SHA. Used by the orchestrator #565
+// convergence-merge escape: a retry-exhausted green PR with only non-critical
+// findings may merge, but a P0 on head hard-blocks.
+func (c *Client) PRHasCriticalReviewOnHead(prNumber int) (bool, error) {
+	sha, err := c.pullHeadSHA(prNumber)
+	if err != nil {
+		return false, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
+	}
+	comments, err := c.greptileReviewComments(prNumber)
+	if err != nil {
+		return false, fmt.Errorf("greptile review comments for PR %d: %w", prNumber, err)
+	}
+	return hasGreptileCriticalCommentOnHead(comments, sha), nil
+}
+
 func (c *Client) greptileReviewComments(prNumber int) ([]greptileReviewComment, error) {
 	out, err := exec.Command("gh", "api",
 		fmt.Sprintf("repos/%s/pulls/%d/comments", c.Repo, prNumber),

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -98,6 +98,7 @@ type Orchestrator struct {
 	// Testing hooks for autoMergePRs / mergeReadyPR
 	ghPRCIStatusFn              func(prNumber int) (string, error)
 	ghPRGreptileApprovedFn      func(prNumber int) (approved bool, pending bool, err error)
+	ghPRHasCriticalReviewFn     func(prNumber int) (bool, error)
 	ghMergePRFn                 func(prNumber int) error
 	ghClosePRFn                 func(prNumber int, comment string) error
 	ghPRChecksOutputFn          func(prNumber int) (string, error)
@@ -215,6 +216,17 @@ func (o *Orchestrator) prGreptileApproved(prNumber int) (bool, bool, error) {
 		return o.ghPRGreptileApprovedFn(prNumber)
 	}
 	return o.gh.PRGreptileApproved(prNumber)
+}
+
+func (o *Orchestrator) prHasCriticalReview(prNumber int) (bool, error) {
+	if o.ghPRHasCriticalReviewFn != nil {
+		return o.ghPRHasCriticalReviewFn(prNumber)
+	}
+	if o.gh == nil {
+		// Fail safe: cannot determine criticality -> caller must NOT auto-merge.
+		return false, fmt.Errorf("no github client configured for critical-review check")
+	}
+	return o.gh.PRHasCriticalReviewOnHead(prNumber)
 }
 
 func (o *Orchestrator) mergePR(prNumber int) error {
@@ -2147,6 +2159,22 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 					// has reached a stable terminal state that needs an
 					// operator decision, not another refused retry cycle.
 					if isSettledRetryExhausted(sess, pr.Number) {
+						// #565 convergence: the worker honestly exhausted its
+						// review-feedback retries. If no CRITICAL (P0) finding
+						// remains on head, do not dead-end — merge the green PR;
+						// residual P1/P2/P3 stay as advisory comments on the PR.
+						// A P0 on head still hard-blocks (operator/repair).
+						if o.cfg.MergeExhaustedNonCriticalReviewEnabled() {
+							hasCritical, cerr := o.prHasCriticalReview(pr.Number)
+							if cerr != nil {
+								log.Printf("[orch] convergence: critical-review check PR #%d failed: %v", pr.Number, cerr)
+							} else if !hasCritical {
+								log.Printf("[orch] convergence-merge: PR #%d retry-exhausted on review feedback but no P0 on head — merging green PR with residual advisory findings (#565)", pr.Number)
+								ready = append(ready, mergeCandidate{slotName: slotName, sess: sess, pr: pr})
+								continue
+							}
+							log.Printf("[orch] PR #%d retry-exhausted with a P0 finding on head — holding for operator/repair", pr.Number)
+						}
 						continue
 					}
 					log.Printf("[orch] PR #%d has review feedback; scheduling retry", pr.Number)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -7904,3 +7904,60 @@ func TestStartNewWorkers_RespectsMaxParallelHardCap(t *testing.T) {
 		t.Fatalf("active sessions = %d, want at most max_parallel=%d", len(s.ActiveSessions()), cfg.MaxParallel)
 	}
 }
+
+func TestAutoMergePRs_ConvergenceMergesRetryExhaustedNonCritical(t *testing.T) {
+	pr := github.PR{Number: 42, HeadRefName: "feat/x"}
+	merged := make([]int, 0)
+	cfg := &config.Config{Repo: "owner/repo", AutoRetryReviewFeedback: true, MergeStrategy: "parallel"}
+	o := &Orchestrator{
+		cfg:                         cfg,
+		notifier:                    &notify.Notifier{},
+		listOpenPRsFn:               func() ([]github.PR, error) { return []github.PR{pr}, nil },
+		ghPRCIStatusFn:              func(int) (string, error) { return "success", nil },
+		ghCollectPRReviewFeedbackFn: func(int) (string, error) { return "P1: non-blocking nit", nil },
+		ghPRHasCriticalReviewFn:     func(int) (bool, error) { return false, nil },
+		ghPRGreptileApprovedFn:      func(int) (bool, bool, error) { return false, false, nil },
+		ghMergePRFn:                 func(n int) error { merged = append(merged, n); return nil },
+		ghCloseIssueFn:              func(int, string) error { return nil },
+		workerStopFn:                func(*config.Config, string, *state.Session) error { return nil },
+	}
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 100, Status: state.StatusRetryExhausted, PRNumber: 42,
+		Branch: "feat/x", LastNotifiedStatus: "review_retry_exhausted",
+	}
+
+	o.autoMergePRs(s)
+
+	if len(merged) != 1 || merged[0] != 42 {
+		t.Fatalf("convergence: merged = %v, want [42] (retry-exhausted green PR, no P0 on head, must merge #565)", merged)
+	}
+}
+
+func TestAutoMergePRs_ConvergenceHoldsOnCritical(t *testing.T) {
+	pr := github.PR{Number: 42, HeadRefName: "feat/x"}
+	merged := make([]int, 0)
+	cfg := &config.Config{Repo: "owner/repo", AutoRetryReviewFeedback: true, MergeStrategy: "parallel"}
+	o := &Orchestrator{
+		cfg:                         cfg,
+		notifier:                    &notify.Notifier{},
+		listOpenPRsFn:               func() ([]github.PR, error) { return []github.PR{pr}, nil },
+		ghPRCIStatusFn:              func(int) (string, error) { return "success", nil },
+		ghCollectPRReviewFeedbackFn: func(int) (string, error) { return "P0: critical", nil },
+		ghPRHasCriticalReviewFn:     func(int) (bool, error) { return true, nil },
+		ghMergePRFn:                 func(n int) error { merged = append(merged, n); return nil },
+		ghCloseIssueFn:              func(int, string) error { return nil },
+		workerStopFn:                func(*config.Config, string, *state.Session) error { return nil },
+	}
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 100, Status: state.StatusRetryExhausted, PRNumber: 42,
+		Branch: "feat/x", LastNotifiedStatus: "review_retry_exhausted",
+	}
+
+	o.autoMergePRs(s)
+
+	if len(merged) != 0 {
+		t.Fatalf("convergence: a P0 finding on head must hard-block; merged = %v, want []", merged)
+	}
+}


### PR DESCRIPTION
**Hands-off keystone.** Retry-exhausted + green + mergeable + NO P0-on-head (only P1/P2/P3) → auto-merge instead of dead-ending. P0-on-head still hard-blocks. Breaks the Greptile-P1 whack-a-mole that blocked #564/#570/#573. Default-on via `merge_exhausted_noncritical_review`. Residual findings stay as advisory comments on the merged PR. Full `go test ./...` + `go vet` green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a \"convergence-merge\" escape hatch so that retry-exhausted green PRs are no longer stuck forever: when a session has exhausted its review-feedback retries, CI is green, and no P0 Greptile comment exists on the current head SHA, the orchestrator auto-merges instead of requiring operator intervention. The feature is default-on via the new `merge_exhausted_noncritical_review` config field.

- Adds `MergeExhaustedNonCriticalReview *bool` to `Config` (nil = true) with a matching accessor, and a `PRHasCriticalReviewOnHead` GitHub client method that checks only P0 badges.
- Wires the check into `autoMergePRs` inside the `isSettledRetryExhausted` branch; adds a new `ghPRHasCriticalReviewFn` test hook and two unit tests covering the merge and block paths.

<h3>Confidence Score: 3/5</h3>

The core merge path is fail-closed on API errors, but the gating predicate is broader than advertised and could auto-merge CI-exhausted or rebase-exhausted PRs without operator review.

The convergence-merge guard delegates to isSettledRetryExhausted, which returns true for ci_retry_exhausted and rebase_conflict_retry_exhausted sessions in addition to review_retry_exhausted. Any such session that has green CI and non-empty review feedback at poll time will be auto-merged under a config flag whose name explicitly says review. This is a broader blast radius than the PR description or config semantics imply, and neither exhausted state is exercised by the new tests.

internal/orchestrator/orchestrator.go — specifically the isSettledRetryExhausted branch and the error-path log in the convergence-merge block.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds convergence-merge logic inside autoMergePRs for retry-exhausted green PRs; isSettledRetryExhausted also matches ci/rebase-exhausted sessions which widens scope beyond the review-feedback use case, and the error-path log message falsely implies a P0 was found. |
| internal/github/github.go | Adds isCriticalSeverity, hasGreptileCriticalCommentOnHead, and PRHasCriticalReviewOnHead following the same string-matching pattern as the existing isHighSeverity helper; logic and structure look sound. |
| internal/config/config.go | Adds MergeExhaustedNonCriticalReview *bool field with a nil-defaults-to-true accessor; pattern matches existing *bool fields like CleanupWorktreesOnMerge. |
| internal/orchestrator/orchestrator_test.go | Two new table-style tests cover the non-critical (merge) and critical (hold) paths; the ci_retry_exhausted/rebase_conflict_retry_exhausted widened scope is not yet exercised by tests. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:2161-2178
**Convergence-merge fires for CI-exhausted and rebase-exhausted sessions too**

`isSettledRetryExhausted` accepts `"ci_retry_exhausted"` and `"rebase_conflict_retry_exhausted"` in addition to `"review_retry_exhausted"`. Because this block is reached only when CI is green and review feedback is non-empty, a session that burned through its CI-failure retries (and now happens to pass CI) or exhausted rebase-conflict retries would silently auto-merge under the `merge_exhausted_noncritical_review` flag — even though the config option name and PR description explicitly describe this as a review-feedback escape hatch. A `rebase_conflict_retry_exhausted` session in particular could be in an unexpected state; auto-merging it without human verification is risky.

### Issue 2 of 2
internal/orchestrator/orchestrator.go:2169-2176
**Misleading "P0 finding on head" log on API error**

When `prHasCriticalReview` returns an error, the code logs the failure correctly but then falls through to the unconditional `log.Printf` on line 2176: `"PR #%d retry-exhausted with a P0 finding on head — holding for operator/repair"`. That message implies a P0 comment was found, when the actual cause was an API/network error. Operators searching for the blocking P0 comment will find none and be confused. Moving the "P0 on head" log into an `else` branch (so it only fires when `cerr == nil && hasCritical`) would make the error vs. block distinction clear.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(orchestrator): convergence-merge fo..."](https://github.com/befeast/maestro/commit/7e1d759df8f3c0e41602e3e55fa1b4318ee59154) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35012245)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->