### PR TITLE
fix(orchestrator): server-side update-branch fallback for behind-base merge (#565 robustness)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -99,6 +99,7 @@ type Orchestrator struct {
 	ghPRCIStatusFn              func(prNumber int) (string, error)
 	ghPRGreptileApprovedFn      func(prNumber int) (approved bool, pending bool, err error)
 	ghPRHasCriticalReviewFn     func(prNumber int) (bool, error)
+	ghUpdateBranchFn            func(prNumber int) error
 	ghMergePRFn                 func(prNumber int) error
 	ghClosePRFn                 func(prNumber int, comment string) error
 	ghPRChecksOutputFn          func(prNumber int) (string, error)
@@ -227,6 +228,16 @@ func (o *Orchestrator) prHasCriticalReview(prNumber int) (bool, error) {
 		return false, fmt.Errorf("no github client configured for critical-review check")
 	}
 	return o.gh.PRHasCriticalReviewOnHead(prNumber)
+}
+
+func (o *Orchestrator) updateBranch(prNumber int) error {
+	if o.ghUpdateBranchFn != nil {
+		return o.ghUpdateBranchFn(prNumber)
+	}
+	if o.gh == nil {
+		return fmt.Errorf("no github client configured for update-branch")
+	}
+	return o.gh.UpdateBranch(prNumber)
 }
 
 func (o *Orchestrator) mergePR(prNumber int) error {
@@ -2748,15 +2759,30 @@ func (o *Orchestrator) mergeReadyPR(s *state.State, slotName string, sess *state
 	if err := o.mergePR(pr.Number); err != nil {
 		log.Printf("[orch] merge PR #%d: %v", pr.Number, err)
 
-		// If the branch is behind main (not conflicting, just outdated), auto-rebase
+		// If the branch is behind main (not conflicting, just outdated),
+		// rebase the worktree when present; otherwise (worker already cleaned
+		// up, or the local rebase fails) fall back to server-side
+		// update-branch (#551) so a behind PR still converges to merge
+		// instead of dead-ending as an unresolvable conflict.
 		if strings.Contains(err.Error(), "not up to date") && o.cfg.AutoRebase {
-			log.Printf("[orch] PR #%d branch is behind main, auto-rebasing %s", pr.Number, slotName)
-			if rebaseErr := o.rebaseWorktree(sess.Worktree, sess.Branch); rebaseErr != nil {
-				log.Printf("[orch] auto-rebase failed for %s: %v", slotName, rebaseErr)
-				o.markUnresolvableConflict(slotName, sess, pr.Number, rebaseErr)
-			} else {
-				o.markRebaseQueued(slotName, sess, pr.Number)
+			log.Printf("[orch] PR #%d branch is behind main, updating %s", pr.Number, slotName)
+			rebased := false
+			if strings.TrimSpace(sess.Worktree) != "" {
+				if rebaseErr := o.rebaseWorktree(sess.Worktree, sess.Branch); rebaseErr != nil {
+					log.Printf("[orch] auto-rebase failed for %s: %v — falling back to server-side update-branch", slotName, rebaseErr)
+				} else {
+					rebased = true
+				}
 			}
+			if !rebased {
+				if upErr := o.updateBranch(pr.Number); upErr != nil {
+					log.Printf("[orch] update-branch fallback for PR #%d failed: %v", pr.Number, upErr)
+					o.markUnresolvableConflict(slotName, sess, pr.Number, upErr)
+					return false
+				}
+				log.Printf("[orch] PR #%d updated via server-side update-branch — re-validating next cycle", pr.Number)
+			}
+			o.markRebaseQueued(slotName, sess, pr.Number)
 			return false
 		}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -7961,3 +7961,29 @@ func TestAutoMergePRs_ConvergenceHoldsOnCritical(t *testing.T) {
 		t.Fatalf("convergence: a P0 finding on head must hard-block; merged = %v, want []", merged)
 	}
 }
+
+func TestMergeReadyPR_BehindBaseNoWorktreeFallsBackToUpdateBranch(t *testing.T) {
+	updateCalled := 0
+	cfg := &config.Config{Repo: "owner/repo", AutoRebase: true}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(int) error {
+			return fmt.Errorf("Pull request is not mergeable: the head branch is not up to date with the base branch")
+		},
+		ghUpdateBranchFn: func(int) error { updateCalled++; return nil },
+	}
+	sess := &state.Session{IssueNumber: 100, PRNumber: 10, Branch: "feat/a", Status: state.StatusRetryExhausted}
+	s := state.NewState()
+	s.Sessions["slot-0"] = sess
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	o.mergeReadyPR(s, "slot-0", sess, pr)
+
+	if updateCalled != 1 {
+		t.Fatalf("server-side update-branch called %d times, want 1 (behind base + no worktree)", updateCalled)
+	}
+	if sess.Status != state.StatusQueued {
+		t.Fatalf("status = %q, want queued for re-validation after update-branch", sess.Status)
+	}
+}


### PR DESCRIPTION
Sustained multi-PR hands-off hardening. A ready PR behind main was rebased via the worker worktree, which fails once the worker cleaned up (retry-exhausted / convergence PRs) → dead-ended as unresolvable conflict. Now falls back to server-side `gh pr update-branch` (Client.UpdateBranch, #551) when the worktree is gone or local rebase fails. Fail-safe wrapper. `go build/test/vet ./...` green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a server-side `gh pr update-branch` fallback in `mergeReadyPR` for PRs that are behind their base branch when the local worktree is absent or the local rebase fails. A new `updateBranch` wrapper (with an injectable `ghUpdateBranchFn` for tests) is added alongside a unit test covering the no-worktree case.

- `mergeReadyPR` now tries a local worktree rebase first (if `sess.Worktree` is non-empty), and silently falls back to server-side `updateBranch` if the worktree is missing or the local rebase fails, before calling `markRebaseQueued`.
- The new test verifies that `ghUpdateBranchFn` is called exactly once and session status becomes `StatusQueued` when the worktree field is empty and the merge error contains "not up to date".

<h3>Confidence Score: 4/5</h3>

The fallback logic is sound and the test covers the primary new path; the one concern is a misleading operator-facing notification when the server-side update-branch path is taken.

The state-machine wiring is correct — behind-base PRs now have a working fallback instead of dead-ending. The only issue is that `markRebaseQueued` is called unconditionally, so the notifier tells operators "rebased successfully" even when no local rebase ran; this could obscure what actually happened in incident investigations.

internal/orchestrator/orchestrator.go — specifically the end of the `mergeReadyPR` rebase block where `markRebaseQueued` is called after a server-side branch update.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds `ghUpdateBranchFn`/`updateBranch` wrapper and rewires `mergeReadyPR` to fall back to server-side `gh pr update-branch` when the worktree is absent or local rebase fails; the fallback path then calls `markRebaseQueued`, which emits a misleading "rebase succeeded" notification and log even though no local rebase occurred. |
| internal/orchestrator/orchestrator_test.go | Adds a focused unit test for the no-worktree server-side fallback path; verifies `updateBranch` is called exactly once and session status becomes `StatusQueued`, which is correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:2777-2785
When the server-side `updateBranch` path is taken (`rebased=false`), the code still calls `markRebaseQueued`, which logs "rebase succeeded for %s" and fires the notifier message "🔄 maestro: rebased ... successfully; session moved to queued". No local rebase occurred — a server-side branch update did. Operators monitoring the notification stream will see a false claim that a rebase succeeded, making it harder to diagnose issues later.

```suggestion
			if !rebased {
				if upErr := o.updateBranch(pr.Number); upErr != nil {
					log.Printf("[orch] update-branch fallback for PR #%d failed: %v", pr.Number, upErr)
					o.markUnresolvableConflict(slotName, sess, pr.Number, upErr)
					return false
				}
				log.Printf("[orch] PR #%d updated via server-side update-branch — re-validating next cycle", pr.Number)
				sess.Status = state.StatusQueued
				sess.RebaseAttempted = true
				sess.FinishedAt = nil
				sess.PRNumber = pr.Number
				sess.NotifiedCIFail = false
				sess.LastNotifiedStatus = ""
				o.notifier.Sendf("🔄 maestro: updated branch for PR #%d via server-side update-branch; session moved to queued", pr.Number)
				return false
			}
			o.markRebaseQueued(slotName, sess, pr.Number)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): server-side update-br..."](https://github.com/befeast/maestro/commit/648e8e1dd78ed4d870e3cad413c174ec42cbc6fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35014695)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->