### PR TITLE
P1: stamp repo/project on every Approval; executor refuses mismatched repo (premortem #3)

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -105,10 +105,14 @@ type Executor struct {
 //   - Err            — non-nil only when Status == execution_failed; the
 //     caller marks failure and surfaces err to its
 //     operator (CLI exit code, supervisor log).
+//   - Warning        — non-fatal advisory the caller should log out-of-band
+//     (#489: unstamped legacy approval fell through the repo
+//     guard). Empty in the happy path.
 type Result struct {
 	Status  state.ApprovalStatus
 	Summary string
 	Err     error
+	Warning string
 }
 
 // ErrUnknownAction is returned when the approval's Action does not match
@@ -171,22 +175,42 @@ func (e *Executor) Execute(approval *state.Approval) Result {
 	// against a refactor that pools Executors across projects and
 	// silently fires merge_pr against the wrong owner/repo. Empty
 	// approval.Repo is back-compat — approvals created before #489 had
-	// no stamp; we fall through to the existing behaviour to avoid
-	// breaking already-pending approvals on upgrade.
-	if strings.TrimSpace(approval.Repo) != "" && e.Cfg != nil {
+	// no stamp; we fall through to the existing behaviour (with a
+	// deprecation warning) so already-pending approvals don't abort on
+	// upgrade. state.MigrateApprovalsBindRepo back-fills the stamp on
+	// each supervisor cycle, so the unstamped window is narrow.
+	var legacyWarning string
+	stampedRepo := strings.TrimSpace(approval.Repo)
+	if stampedRepo != "" && e.Cfg != nil {
 		cfgRepo := strings.TrimSpace(e.Cfg.Repo)
-		if cfgRepo != "" && approval.Repo != cfgRepo {
+		if cfgRepo != "" && stampedRepo != cfgRepo {
 			return Result{
 				Status: state.ApprovalStatusExecutionFailed,
 				Summary: fmt.Sprintf(
 					"approval %s is bound to repo %q but executor cfg.Repo is %q — refusing cross-project mutation",
-					approval.ID, approval.Repo, cfgRepo,
+					approval.ID, stampedRepo, cfgRepo,
 				),
-				Err: fmt.Errorf("approval %s repo mismatch: approval=%s cfg=%s", approval.ID, approval.Repo, cfgRepo),
+				Err: fmt.Errorf("approval %s repo mismatch: approval=%s cfg=%s", approval.ID, stampedRepo, cfgRepo),
 			}
 		}
+	} else if stampedRepo == "" && e.Cfg != nil && strings.TrimSpace(e.Cfg.Repo) != "" {
+		legacyWarning = fmt.Sprintf(
+			"approval %s has no Repo stamp (pre-#489); executing against ambient cfg.Repo=%q — back-fill via state.MigrateApprovalsBindRepo",
+			approval.ID, strings.TrimSpace(e.Cfg.Repo),
+		)
 	}
 
+	res := e.dispatchAction(approval)
+	if legacyWarning != "" && res.Warning == "" {
+		res.Warning = legacyWarning
+	}
+	return res
+}
+
+// dispatchAction is the post-guard verb switch, kept separate so the
+// repo-guard / legacy-warning prelude in Execute can decorate the
+// returned Result uniformly.
+func (e *Executor) dispatchAction(approval *state.Approval) Result {
 	switch approval.Action {
 	case config.SupervisorActionMergePR:
 		return e.executeMergePR(approval)

--- a/internal/approver/repo_guard_test.go
+++ b/internal/approver/repo_guard_test.go
@@ -2,6 +2,7 @@ package approver
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/befeast/maestro/internal/config"
@@ -79,5 +80,46 @@ func TestExecute_NoCfgRepo_SkipsGuard(t *testing.T) {
 	res := ex.Execute(a)
 	if res.Status != state.ApprovalStatusExecuted {
 		t.Fatalf("res = %+v, want executed (cfg.Repo empty -> guard skipped)", res)
+	}
+}
+
+// #489: when a pre-#489 approval (no Repo stamp) falls through the guard,
+// Execute must succeed AND surface a deprecation warning on Result so the
+// caller can log it for operator visibility.
+func TestExecute_LegacyApprovalNoRepo_EmitsDeprecationWarning(t *testing.T) {
+	gh := &fakeGH{}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	// a.Repo intentionally left empty — simulates a pre-#489 approval.
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed (legacy approval must not abort)", res)
+	}
+	if res.Warning == "" {
+		t.Fatalf("res.Warning is empty, want deprecation advisory for unstamped legacy approval")
+	}
+	if !strings.Contains(res.Warning, "MigrateApprovalsBindRepo") {
+		t.Fatalf("res.Warning = %q, want hint to call MigrateApprovalsBindRepo", res.Warning)
+	}
+}
+
+// #489: a freshly-stamped, matching approval must execute clean — no
+// stray legacy warning.
+func TestExecute_RepoMatch_NoLegacyWarning(t *testing.T) {
+	gh := &fakeGH{}
+	cfg := newCfg()
+	ex := &Executor{GH: gh, Cfg: cfg}
+
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a.Repo = cfg.Repo
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed", res)
+	}
+	if res.Warning != "" {
+		t.Fatalf("res.Warning = %q, want empty (no legacy fall-through)", res.Warning)
 	}
 }

--- a/internal/server/approval_action_test.go
+++ b/internal/server/approval_action_test.go
@@ -91,6 +91,17 @@ func TestApprovalAction_MergePR_Enqueues202(t *testing.T) {
 	if got.Target == nil || got.Target.PR != 42 {
 		t.Fatalf("approval target = %+v, want PR=42", got.Target)
 	}
+	// #489: enqueued approvals must be stamped with cfg.Repo so the
+	// executor's cross-project guard can fence against future Executor
+	// pooling regressions (premortem failure mode #3).
+	if got.Repo != cfg.Repo {
+		t.Fatalf("approval.Repo = %q, want %q (HTTP enqueue must stamp cfg.Repo)", got.Repo, cfg.Repo)
+	}
+	// HTTP request omitted "project"; the dispatcher defaults Project to
+	// cfg.Repo so the stamp is never blank.
+	if got.Project == "" {
+		t.Fatalf("approval.Project = %q, want non-empty fallback", got.Project)
+	}
 	// state file should exist.
 	if _, err := filepath.Abs(filepath.Join(dir, "state.json")); err != nil {
 		t.Fatalf("state path: %v", err)

--- a/internal/state/migrate_approvals_bind_repo_test.go
+++ b/internal/state/migrate_approvals_bind_repo_test.go
@@ -1,0 +1,105 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+// #489: MigrateApprovalsBindRepo back-fills the Repo stamp on in-flight
+// approvals that predate the cross-project guard. Terminal-status
+// approvals are not retroactively rewritten — their audit trail is final.
+
+func TestMigrateApprovalsBindRepo_StampsInFlightApprovals(t *testing.T) {
+	s := NewState()
+	now := time.Now().UTC()
+	s.Approvals = []Approval{
+		{ID: "a1", Status: ApprovalStatusPending, CreatedAt: now},
+		{ID: "a2", Status: ApprovalStatusApproved, CreatedAt: now},
+		{ID: "a3", Status: ApprovalStatusAwaitingDispatch, CreatedAt: now},
+	}
+
+	n := s.MigrateApprovalsBindRepo("BeFeast/maestro")
+	if n != 3 {
+		t.Fatalf("migrated = %d, want 3", n)
+	}
+	for _, a := range s.Approvals {
+		if a.Repo != "BeFeast/maestro" {
+			t.Fatalf("approval %s repo = %q, want stamped", a.ID, a.Repo)
+		}
+	}
+}
+
+func TestMigrateApprovalsBindRepo_LeavesTerminalApprovalsAlone(t *testing.T) {
+	s := NewState()
+	terminal := []ApprovalStatus{
+		ApprovalStatusExecuted,
+		ApprovalStatusExecutionFailed,
+		ApprovalStatusExecutionSkipped,
+		ApprovalStatusRejected,
+		ApprovalStatusStale,
+		ApprovalStatusSuperseded,
+	}
+	for i, st := range terminal {
+		s.Approvals = append(s.Approvals, Approval{
+			ID:     "t" + string(rune('1'+i)),
+			Status: st,
+		})
+	}
+
+	n := s.MigrateApprovalsBindRepo("BeFeast/maestro")
+	if n != 0 {
+		t.Fatalf("migrated = %d, want 0 (terminal records must not be rewritten)", n)
+	}
+	for _, a := range s.Approvals {
+		if a.Repo != "" {
+			t.Fatalf("terminal approval %s was rewritten with repo=%q", a.ID, a.Repo)
+		}
+	}
+}
+
+func TestMigrateApprovalsBindRepo_PreservesAlreadyStamped(t *testing.T) {
+	s := NewState()
+	s.Approvals = []Approval{
+		{ID: "a1", Status: ApprovalStatusPending, Repo: "BeFeast/scribe-service"},
+		{ID: "a2", Status: ApprovalStatusPending},
+	}
+
+	n := s.MigrateApprovalsBindRepo("BeFeast/maestro")
+	if n != 1 {
+		t.Fatalf("migrated = %d, want 1 (a1 already stamped)", n)
+	}
+	if s.Approvals[0].Repo != "BeFeast/scribe-service" {
+		t.Fatalf("a1 repo = %q, must not be overwritten", s.Approvals[0].Repo)
+	}
+	if s.Approvals[1].Repo != "BeFeast/maestro" {
+		t.Fatalf("a2 repo = %q, want stamped", s.Approvals[1].Repo)
+	}
+}
+
+func TestMigrateApprovalsBindRepo_NoRepo_NoOp(t *testing.T) {
+	s := NewState()
+	s.Approvals = []Approval{{ID: "a1", Status: ApprovalStatusPending}}
+	if n := s.MigrateApprovalsBindRepo("   "); n != 0 {
+		t.Fatalf("migrated = %d, want 0 when repo is blank", n)
+	}
+	if s.Approvals[0].Repo != "" {
+		t.Fatalf("a1 repo = %q, want empty when repo arg is blank", s.Approvals[0].Repo)
+	}
+}
+
+func TestMigrateApprovalsBindRepo_Idempotent(t *testing.T) {
+	s := NewState()
+	s.Approvals = []Approval{{ID: "a1", Status: ApprovalStatusPending}}
+	first := s.MigrateApprovalsBindRepo("BeFeast/maestro")
+	second := s.MigrateApprovalsBindRepo("BeFeast/maestro")
+	if first != 1 || second != 0 {
+		t.Fatalf("first=%d second=%d, want 1 then 0 (idempotent)", first, second)
+	}
+}
+
+func TestMigrateApprovalsBindRepo_NilState_NoOp(t *testing.T) {
+	var s *State
+	if n := s.MigrateApprovalsBindRepo("BeFeast/maestro"); n != 0 {
+		t.Fatalf("nil receiver migrated = %d, want 0", n)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2539,6 +2539,62 @@ func (s *State) MarkApprovalAwaitingDispatch(id string, now time.Time, actor, re
 	return approval, nil
 }
 
+// MigrateApprovalsBindRepo back-fills the Repo stamp on any in-flight
+// approval that predates #489 (premortem failure mode #3).
+//
+// Approvals created before #489 were not bound to a project at write-time
+// — the executor trusted ambient cfg.Repo. After #489 every fresh approval
+// carries Repo + Project (see RecordPendingApprovalForDecision +
+// dispatchApprovalAction), and the executor refuses any approval whose
+// Repo does not match its cfg.Repo. To roll #489 out without aborting
+// already-pending approvals on upgrade, this migration walks Approvals
+// that are still in a non-terminal status (pending, awaiting_dispatch,
+// approved) and stamps the missing Repo from the caller-supplied repo
+// slug. Project stays blank when we cannot infer it — the executor only
+// fences on Repo.
+//
+// Returns the number of approvals stamped. The intended call site is
+// once per supervisor cycle: the operation is idempotent (already-stamped
+// approvals are skipped), cheap (a single in-memory pass), and converges
+// fresh after a daemon restart so a long-running daemon and a freshly
+// loaded daemon agree.
+//
+// Terminal-status approvals (executed / execution_failed / rejected /
+// stale / superseded / execution_skipped) are deliberately NOT migrated
+// — they are historical records that have already had their side effect
+// adjudicated, and rewriting them retroactively would muddy the audit
+// trail.
+//
+// Takes a plain repo string (not *config.Config) on purpose: the state
+// package must not depend on internal/config, which would invert the
+// existing layering.
+func (s *State) MigrateApprovalsBindRepo(repo string) int {
+	if s == nil {
+		return 0
+	}
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return 0
+	}
+	migrated := 0
+	for i := range s.Approvals {
+		a := &s.Approvals[i]
+		switch a.Status {
+		case ApprovalStatusPending,
+			ApprovalStatusAwaitingDispatch,
+			ApprovalStatusApproved:
+		default:
+			continue
+		}
+		if strings.TrimSpace(a.Repo) != "" {
+			continue
+		}
+		a.Repo = repo
+		migrated++
+	}
+	return migrated
+}
+
 // ValidateSlotID is the canonical slot-id validator used at EVERY
 // state-write ingress (#490 / premortem #5). A slot id names a session
 // in `state.Sessions` and is later concatenated into a worktree path

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -234,6 +234,12 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 		return state.SupervisorDecision{}, fmt.Errorf("load state: %w", err)
 	}
 	st.MarkStaleApprovals(time.Now().UTC())
+	// #489 migration: stamp Repo on any pre-#489 approval still in
+	// flight so the executor's cross-project guard can fence reliably.
+	// Idempotent — no-op once every in-flight approval is stamped.
+	if migrated := st.MigrateApprovalsBindRepo(cfg.Repo); migrated > 0 {
+		fmt.Fprintf(os.Stderr, "[supervisor] migrated %d unstamped approval(s) to repo=%s (#489)\n", migrated, cfg.Repo)
+	}
 	if reader == nil {
 		reader = github.New(cfg.Repo)
 	}
@@ -3396,6 +3402,12 @@ func executeApprovedApprovals(cfg *config.Config, st *state.State, reader Reader
 	}
 	for _, a := range approvals {
 		res := ex.Execute(a)
+		if res.Warning != "" {
+			// #489 deprecation: legacy unstamped approval fell through the
+			// repo guard. Surface loudly so the operator notices the next
+			// MigrateApprovalsBindRepo pass should close the window.
+			fmt.Fprintf(os.Stderr, "[supervisor] approver warning: %s\n", res.Warning)
+		}
 		now := time.Now().UTC()
 		switch res.Status {
 		case state.ApprovalStatusExecuted:


### PR DESCRIPTION
Refs #489

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements premortem failure mode #3 from issue #489: every Approval is now stamped with `Repo` and `Project` at creation time, and the Executor refuses to run any approval whose stamped `Repo` differs from its own `cfg.Repo`. A `MigrateApprovalsBindRepo` migration back-fills the stamp on legacy in-flight approvals once per supervisor cycle to avoid aborting pending approvals on upgrade.

- `state.MigrateApprovalsBindRepo` stamps non-terminal approvals that predate #489, is idempotent, and handles nil-receiver/blank-repo edge cases correctly.
- `Executor.Execute` is split into a repo-guard prelude (which may emit a `Result.Warning` deprecation advisory for unstamped approvals) and the new `dispatchAction` verb switch; `supervisor.go` logs any non-empty `Warning` to stderr.
- Test coverage is thorough: migration idempotency, terminal-status preservation, legacy-warning emission, repo-match happy path, and the HTTP-enqueue stamp assertion are all exercised.

<h3>Confidence Score: 4/5</h3>

Safe to merge for production deployments; the core guard and migration logic are correct. Two minor issues are worth a follow-up.

The repo-guard and stamp-on-create paths work correctly end-to-end. In dry-run mode the migration never persists so operators with legacy in-flight approvals see the migration log line fire every cycle with no way to resolve it. The legacyWarning is also silently dropped when dispatchAction returns a non-empty Warning; no current handler sets that field, but the silent precedence logic is a maintenance trap for future contributors.

internal/supervisor/supervisor.go (dry-run migration persistence) and internal/approver/executor.go (Warning field precedence logic).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/approver/executor.go | Adds Warning field to Result, extracts dispatchAction, and tightens the repo guard to emit a deprecation advisory for legacy unstamped approvals; silent drop of legacyWarning when dispatchAction sets Warning. |
| internal/state/state.go | Adds MigrateApprovalsBindRepo to back-fill the Repo stamp on non-terminal in-flight approvals; logic is correct and idempotent, nil-receiver and blank-repo guards are present, terminal statuses are correctly excluded. |
| internal/supervisor/supervisor.go | Calls MigrateApprovalsBindRepo once per RunOnce cycle and logs res.Warning from executor; migration runs but is never persisted in dry-run mode, causing repeated log noise. |
| internal/approver/repo_guard_test.go | Adds two targeted tests for the legacy-approval deprecation warning and the clean matched-repo path; both test cases are correct and cover the new behaviour. |
| internal/state/migrate_approvals_bind_repo_test.go | Comprehensive new test file covering all key contract points of MigrateApprovalsBindRepo: stamps in-flight, skips terminal, preserves already-stamped, no-ops on blank repo, idempotency, and nil-receiver safety. |
| internal/server/approval_action_test.go | Extends the HTTP enqueue test to assert Repo and Project stamps are set on the persisted approval; the filepath.Abs assertion for state file existence was pre-existing and is a no-op (does not check disk presence). |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/supervisor/supervisor.go:237-242
**Migration log fires on every dry-run cycle**

`MigrateApprovalsBindRepo` mutates the in-memory `st`, but `state.Save` is inside the `!cfg.Supervisor.DryRun` guard so the stamps are never written to disk in dry-run mode. On the next `RunOnce` call, `state.Load` reloads the same unmigrated state, the migration mutates it again, and the log line fires again — indefinitely, for every supervisor cycle that has legacy in-flight approvals. The "idempotent — no-op once every in-flight approval is stamped" comment only holds when the persisted state converges. Wrapping the migration block in the same `!DryRun` condition (or running it but suppressing the log when in dry-run) would close the gap.

### Issue 2 of 2
internal/approver/executor.go:203-207
**Legacy deprecation warning silently dropped when action also sets `Warning`**

`legacyWarning` is attached to the result only when `res.Warning == ""`. If a future action handler sets a non-empty `Warning` (e.g., a partial-success advisory from `executeMergePR`), the legacy deprecation is silently discarded — the supervisor never logs it, and the operator has no indication that an unstamped pre-#489 approval just ran. Both warnings carry independent operational meaning. Concatenating them (e.g., joining with `"\n"`) or using a `[]string` field would preserve all advisory information without introducing precedence logic.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(state,approver,supervisor): finish ..."](https://github.com/befeast/maestro/commit/c5c3b1928335066d256e1eb9869d3e62c2a246a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35015262)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->