### PR TITLE
P1: drop per-project legacy dashboard ports — unify all projects under the single MC SPA on :8786 with scoped routes

### DIFF
--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -10,12 +10,13 @@ Reserve these services and ports on the workshop host:
 
 | Service | Default bind | Port | Purpose | Notes |
 |---|---:|---:|---|---|
-| Fleet Mission Control | `127.0.0.1` | `8787` | Primary dashboard and `/api/v1/fleet` aggregate API | Start with `maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787 --read-only` |
-| Project Mission Control | `127.0.0.1` | `8788+` | Optional per-project dashboard and `/api/v1/state` API | Configure each project with a unique `server.port`; link it from `dashboard_url` in the fleet file |
+| Fleet Mission Control | `127.0.0.1` | `8787` | The single dashboard for the whole fleet, plus the `/api/v1/fleet` aggregate API and project-scoped routes (`/project/<name>`) | Start with `maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787 --read-only` |
 | Project runner | none by default | none | Runs `maestro run --config ...` and owns workers, worktrees, PR handling, and merge/deploy loops | It only serves HTTP when that project config has `server.port` set |
 | Supervisor loop | none | none | Runs `maestro supervise --config ...` to record decisions, safe queue label mutations, and approval requests | Can be manual, timer-driven, or a user service |
 | Worker sessions | none | none | tmux sessions and log files created under each project's `state_dir` | Inspect through Mission Control, `maestro status`, or `maestro logs` |
 | OpenClaw relay | `127.0.0.1` | `18789` | Optional Telegram relay endpoint when `telegram.mode: openclaw` is used | Not required for Mission Control |
+
+> Per-project Mission Control ports (`8788+`) were retired in #516. Every project is now reachable through the fleet aggregator at `/project/<name>`. Old `maestro-<project>-web.service` user units can be stopped and disabled; their `server.port` settings in project YAMLs are honored only when a project runs its own single-tenant `maestro serve --config ...` outside the fleet.
 
 Mutating endpoints require app-level HTTP auth (#487). Configure `server.auth.token_env` in each project config (the fleet picks up the first project that sets it) and populate the named environment variable from your secret manager (Infisical, 1Password CLI, etc.) — never inline the token in YAML. When auth is configured, every `POST /api/v1/...` (`/actions`, `/approvals/.../{approve|reject}`, `/audit/log`, `/fleet/actions`) requires `Authorization: Bearer <token>` and returns `401` without it. Read-only GETs stay open. The LAN is no longer treated as trusted: do not skip the token, even on `127.0.0.1`, when other devices share the network.
 
@@ -25,11 +26,13 @@ Project config and fleet config have different jobs.
 
 | File | Loaded by | Owns | Does not own |
 |---|---|---|---|
-| `~/.maestro/maestro-<project>.yaml` | `maestro run`, `maestro supervise`, `maestro status`, `maestro logs`, single-project `maestro serve` | Repo, clone path, worktree path, state directory, session prefix, labels, supervisor policy, review gate, merge/deploy policy, optional project dashboard port | Other projects |
-| `~/.maestro/fleet.yaml` | `maestro serve --fleet` | Project display names, project config paths, optional dashboard links | Queue policy, labels, state directories, review gates, merge behavior |
+| `~/.maestro/maestro-<project>.yaml` | `maestro run`, `maestro supervise`, `maestro status`, `maestro logs`, single-project `maestro serve` | Repo, clone path, worktree path, state directory, session prefix, labels, supervisor policy, review gate, merge/deploy policy | Other projects |
+| `~/.maestro/fleet.yaml` | `maestro serve --fleet` | Project display names and project config paths | Queue policy, labels, state directories, review gates, merge behavior |
 | `.maestro/supervisor.yaml`, `.maestro/supervisor.yml`, or `.maestro/supervisor.md` | Loaded beside the project config or inside `local_path/.maestro` | Supervisor policy when the team wants policy beside the repo | Fleet membership |
 
-Fleet config paths may be absolute, `~/...`, or relative to the fleet YAML file. A fleet file should not duplicate project settings. If a project needs a different label, review gate, state directory, runner interval, or dashboard port, change that project's config and restart that project's runner.
+Fleet config paths may be absolute, `~/...`, or relative to the fleet YAML file. A fleet file should not duplicate project settings. If a project needs a different label, review gate, state directory, or runner interval, change that project's config and restart that project's runner.
+
+`dashboard_url` was historically used to link from the fleet card to a per-project dashboard on its own port. Those ports are retired (#516); the aggregator routes operators to `/project/<name>` instead. Any `dashboard_url` value still present in a fleet.yaml file is ignored and logged as deprecated on load.
 
 Minimal project config shape:
 
@@ -94,11 +97,11 @@ Minimal fleet config shape:
 projects:
   - name: project-a
     config: maestro-project-a.yaml
-    dashboard_url: http://127.0.0.1:8788
   - name: project-b
     config: maestro-project-b.yaml
-    dashboard_url: http://127.0.0.1:8789
 ```
+
+`dashboard_url:` is deprecated and silently ignored on load (#516). Every project is reachable at `/project/<name>` on the aggregator port.
 
 ## Operating Model
 

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -275,9 +275,8 @@ To add a project:
 
 1. Create or update `~/.maestro/maestro-<project>.yaml` using the config shape above.
 2. Use a distinct `state_dir` and `session_prefix` for each project so worker sessions and state files do not overlap.
-3. If you run a per-project Mission Control dashboard, set that project's `server.host`, `server.port`, and `server.read_only: true` in the project config.
-4. Add the project to `~/.maestro/fleet.yaml` with a human name, config path, and optional `dashboard_url`.
-5. Restart the fleet dashboard service and verify `/api/v1/fleet`.
+3. Add the project to `~/.maestro/fleet.yaml` with a human name and config path. Every project is reachable through the unified Mission Control aggregator at `/project/<name>` (#516); per-project dashboard ports are retired and no longer need a separate user unit.
+4. Restart the fleet dashboard service and verify `/api/v1/fleet`.
 
 Minimal two-project fleet file:
 
@@ -286,13 +285,11 @@ Minimal two-project fleet file:
 projects:
   - name: api
     config: maestro-api.yaml
-    dashboard_url: http://127.0.0.1:8788
   - name: web
     config: maestro-web.yaml
-    dashboard_url: http://127.0.0.1:8789
 ```
 
-`config` may be absolute, `~/...`, or relative to the fleet YAML file. `dashboard_url` is only a link target for the fleet UI; omit it when a project does not run its own dashboard. For dogfooding, add Maestro's own project config to the same fleet file so the team can watch Maestro manage Maestro alongside application repos.
+`config` may be absolute, `~/...`, or relative to the fleet YAML file. `dashboard_url` is deprecated (#516); any value still present is silently overridden with the project-scoped MC route on load. For dogfooding, add Maestro's own project config to the same fleet file so the team can watch Maestro manage Maestro alongside application repos.
 
 Run the fleet dashboard manually:
 
@@ -312,8 +309,8 @@ The fleet response includes `refreshed_at` plus per-project freshness metadata. 
 
 | Mode | Use it when | Notes |
 |---|---|---|
-| `maestro serve --fleet ~/.maestro/fleet.yaml --port 8787` | You want a stable operating model for a shared dashboard or systemd service | Supports project names, relative config paths, and `dashboard_url` links |
-| `maestro serve --config a.yaml --config b.yaml --port 8787` | You want a quick local aggregate view without writing a fleet file | Project names are derived from `repo`, and there is no place for `dashboard_url` metadata |
+| `maestro serve --fleet ~/.maestro/fleet.yaml --port 8787` | You want a stable operating model for a shared dashboard or systemd service | Supports human project names and relative config paths; project-scoped routes (`/project/<name>`) are served from the same port |
+| `maestro serve --config a.yaml --config b.yaml --port 8787` | You want a quick local aggregate view without writing a fleet file | Project names are derived from `repo` |
 
 For a persistent user service, create a dedicated fleet dashboard unit:
 

--- a/docs/ux-redesign-addendum-2026-05-25.md
+++ b/docs/ux-redesign-addendum-2026-05-25.md
@@ -32,7 +32,7 @@ The design export source files (`mc/*.jsx`, `mc/mc.css`) **are the implementatio
 - Do not enable write actions in V1 (settings toggles render read-only/disabled).
 - Do not rewrite supervisor or backend behavior.
 - Brand exploration, UI audit, and mock HTML files in the zip are reference only — not production routes.
-- Single-project `dashboard.html` unification is **deferred** to Wave 4; per-project `dashboard_url` ports remain until ProjectScreen proves parity.
+- Single-project `dashboard.html` unification is **deferred** to Wave 4; per-project `dashboard_url` ports were retired in #516 — every project is now reachable through the aggregator at `/project/<name>`.
 
 ## Route Replacement Map
 
@@ -40,11 +40,11 @@ The design export source files (`mc/*.jsx`, `mc/mc.css`) **are the implementatio
 |---|---|---|---|
 | `/`, `/fleet` | `mc/mc-fleet.jsx` → `FleetScreen` (tape layout only) | `GET /api/v1/fleet` | Same URLs; MC shell replaces inline layout |
 | (none) | `mc/mc-screens.jsx` → `WorkersScreen` | `GET /api/v1/fleet` (workers, attention) | New first-class route `/workers` |
-| (none) | `mc/mc-screens.jsx` → `ProjectScreen` | Per-project slice from fleet API | New route `/project/{slug}`; defers replacing `dashboard_url` |
+| (none) | `mc/mc-screens.jsx` → `ProjectScreen` | Per-project slice from fleet API | New route `/project/{slug}`; replaces the legacy `dashboard_url` redirect (#516) |
 | needs-you rail + `/approvals/audit` | `mc/mc-screens.jsx` → `ApprovalsScreen` | `GET /api/v1/fleet` (approvals) | Preserve audit access; integrate active vs history |
 | (none) | `mc/mc-screens.jsx` → `SettingsScreen` | New read-only config summary API (small) | Display-only in V1 |
 | Partial Cmd-K (`fleet.js`) | `mc/mc-shell.jsx` → `CommandPalette` | Loaded fleet data | Strip scenario/theme demo items; keep topbar theme toggle |
-| Per-project `dashboard_url` | Legacy `dashboard.html` | `/api/v1/state` | **Deferred** — unchanged until Wave 4 |
+| Per-project `dashboard_url` | Aggregator route `/project/<name>` | `/api/v1/fleet` (filtered slice) | Retired in #516; legacy `dashboard.html` is no longer the operator surface |
 
 ## Implementation Waves
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -32,6 +33,12 @@ const (
 )
 
 // FleetProject describes one Maestro project exposed in the fleet dashboard.
+//
+// DashboardURL is auto-derived from Name as the project-scoped MC route
+// (`/project/<name>`). Per-project legacy dashboard ports were retired in #516,
+// so any `dashboard_url` value supplied by a fleet.yaml is overwritten on
+// load. The field is retained on the snapshot for backward-compatibility with
+// external JSON consumers.
 type FleetProject struct {
 	Name         string `json:"name" yaml:"name"`
 	ConfigPath   string `json:"config_path" yaml:"config"`
@@ -67,16 +74,33 @@ func (p *FleetProject) Cfg() *config.Config {
 }
 
 // NewFleetProject wraps an already-loaded config for in-process fleet serving.
+//
+// The dashboardURL parameter is retained for source-compat with callers and
+// older fleet.yaml files but its value is ignored: every project is now
+// reachable at the project-scoped MC route on the aggregator port (#516).
+// DashboardURL on the returned FleetProject is auto-derived from name.
 func NewFleetProject(name, configPath, dashboardURL string, cfg *config.Config) FleetProject {
 	if strings.TrimSpace(name) == "" && cfg != nil {
 		name = defaultFleetProjectName(cfg.Repo)
 	}
+	trimmedName := strings.TrimSpace(name)
 	return FleetProject{
-		Name:         strings.TrimSpace(name),
+		Name:         trimmedName,
 		ConfigPath:   strings.TrimSpace(configPath),
-		DashboardURL: strings.TrimSpace(dashboardURL),
+		DashboardURL: fleetProjectScopedPath(trimmedName),
 		cfg:          cfg,
 	}
+}
+
+// fleetProjectScopedPath returns the SPA route that zooms in on a project on
+// the unified Mission Control aggregator (`/project/<name>`). Per-project
+// dashboard ports were retired in #516; this is the canonical address.
+func fleetProjectScopedPath(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	return "/project/" + url.PathEscape(name)
 }
 
 // FleetFile is the YAML shape accepted by maestro serve --fleet.
@@ -120,6 +144,11 @@ func LoadFleetProjects(path string) ([]FleetProject, error) {
 			project.Name = defaultFleetProjectName(cfg.Repo)
 		}
 		project.Name = strings.TrimSpace(project.Name)
+		if legacy := strings.TrimSpace(project.DashboardURL); legacy != "" {
+			log.Printf("[fleet] project %q: dashboard_url %q in %s is deprecated and ignored — the project is reachable at the unified MC route %s (#516)",
+				project.Name, legacy, path, fleetProjectScopedPath(project.Name))
+		}
+		project.DashboardURL = fleetProjectScopedPath(project.Name)
 		key := strings.ToLower(project.Name)
 		if _, exists := seen[key]; exists {
 			return nil, fmt.Errorf("duplicate fleet project name %q", project.Name)

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -45,8 +45,32 @@ func TestLoadFleetProjects(t *testing.T) {
 	if projects[0].cfg == nil || projects[0].cfg.Repo != "owner/project" {
 		t.Fatalf("resolved config = %+v", projects[0].cfg)
 	}
-	if projects[0].DashboardURL != "http://127.0.0.1:8787" {
-		t.Fatalf("dashboard url = %q", projects[0].DashboardURL)
+	// Per-project dashboard ports were retired in #516. The legacy
+	// dashboard_url in fleet.yaml is silently overridden with the scoped
+	// MC route on load, regardless of what value the YAML supplied.
+	if projects[0].DashboardURL != "/project/Project" {
+		t.Fatalf("dashboard url = %q, want unified MC scoped route", projects[0].DashboardURL)
+	}
+}
+
+func TestLoadFleetProjectsScopesDashboardURLToMC(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	configPath := filepath.Join(dir, "project.yaml")
+	if err := os.WriteFile(configPath, []byte("repo: owner/project\nstate_dir: "+stateDir+"\nsession_prefix: prj\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fleetPath := filepath.Join(dir, "fleet.yaml")
+	// Project name contains a space to verify path-escaping on the scoped MC route.
+	if err := os.WriteFile(fleetPath, []byte("projects:\n  - name: Has Space\n    config: project.yaml\n"), 0o644); err != nil {
+		t.Fatalf("write fleet: %v", err)
+	}
+	projects, err := LoadFleetProjects(fleetPath)
+	if err != nil {
+		t.Fatalf("LoadFleetProjects failed: %v", err)
+	}
+	if got, want := projects[0].DashboardURL, "/project/Has%20Space"; got != want {
+		t.Fatalf("scoped MC URL = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Refs #516

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR retires the per-project Mission Control dashboard ports (`8788+`) and routes every project through the single fleet aggregator SPA at `/project/<name>` on port `:8787`. The Go implementation introduces `fleetProjectScopedPath` to auto-derive a URL-escaped route from the project name, overrides any `dashboard_url` supplied via fleet YAML, and logs a deprecation warning on load.

- `fleet.go`: `NewFleetProject` and `LoadFleetProjects` now ignore the caller-supplied `dashboardURL` and always set `DashboardURL` to the scoped MC route; `LoadFleetProjects` emits a `log.Printf` deprecation warning when a legacy value is present.
- `fleet_test.go`: Adds `TestLoadFleetProjectsScopesDashboardURLToMC` to verify URL-escaping for project names with spaces; updates the existing fleet-load assertion to expect the new route format.
- All three docs are updated to remove `dashboard_url` examples and reference the unified `/project/<name>` route.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core retirement logic is correct and the new route is already handled by isFleetMCRoute. The only issues are documentation inconsistencies.

The fleet.go implementation is sound: fleetProjectScopedPath correctly uses url.PathEscape, LoadFleetProjects overwrites the legacy dashboard_url after logging the deprecation, and the /project/<name> route was already served by the SPA handler. The production caller of NewFleetProject passes an empty dashboardURL so there is no active breakage from the silent-drop asymmetry. What holds the score below 5 is that project-setup-runbook.md tells operators the override is silent when it actually logs, and the test comment repeats the same incorrect characterization — both could mislead operators who rely on documentation to understand log output from their fleet service.

The project-setup-runbook.md "silently overridden" wording and the matching test comment in fleet_test.go (lines 48-50) should be corrected to reflect that a deprecation log message is emitted.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Retires per-project dashboard ports by auto-deriving DashboardURL from project name via fleetProjectScopedPath; LoadFleetProjects logs a deprecation warning and overwrites any legacy dashboard_url on load. Logic is correct, but NewFleetProject silently drops a non-empty dashboardURL argument without logging, inconsistent with LoadFleetProjects. |
| internal/server/fleet_test.go | Updates TestLoadFleetProjects to assert the scoped MC route instead of the legacy port URL; adds TestLoadFleetProjectsScopesDashboardURLToMC for URL-escaping of spaces. Test comment at line 48-50 incorrectly says the override is silent when the code actually emits a log.Printf deprecation warning. |
| docs/fleet-mission-control-runbook.md | Removes the per-project dashboard port row from the service table, adds a retirement callout and deprecation note for dashboard_url. Correctly states values are logged as deprecated on load. |
| docs/project-setup-runbook.md | Collapses the three-step project-addition flow to two steps and removes dashboard_url from the example fleet YAML. Incorrectly describes the dashboard_url override as silent when LoadFleetProjects actually emits a log message. |
| docs/ux-redesign-addendum-2026-05-25.md | Updates the route replacement map and Wave 4 deferral note to reflect that per-project dashboard_url ports were retired in #516. Changes are consistent with the fleet.go implementation. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
docs/project-setup-runbook.md:288
**"Silently" claim contradicts the actual runtime behavior**

`LoadFleetProjects` emits a `log.Printf` deprecation warning whenever `dashboard_url` is present and non-empty. This runbook line says the override is *silent*, but the sibling runbook (`fleet-mission-control-runbook.md`, added in this same PR) correctly says the value is "logged as deprecated on load." Operators who rely on this runbook may not configure log monitoring to catch the deprecation message, or may be surprised by unexpected output in `journalctl` when they do have a legacy `dashboard_url` value present.

### Issue 2 of 3
internal/server/fleet_test.go:48-50
**Test comment contradicts code behavior**

The comment says the `dashboard_url` in the test YAML is "silently overridden", but the test YAML (line 31) includes `dashboard_url: http://127.0.0.1:8787`, which triggers the `log.Printf` deprecation warning inside `LoadFleetProjects`. The override is not silent — it produces a log line. The comment in the parallel `fleet-mission-control-runbook.md` correctly describes it as "logged as deprecated on load."

### Issue 3 of 3
internal/server/fleet.go:82-93
**`NewFleetProject` silently drops non-empty `dashboardURL` without warning**

`LoadFleetProjects` logs a deprecation message whenever a non-empty legacy `dashboard_url` is encountered, so operators running `maestro serve --fleet` will see it. But `NewFleetProject` (the in-process path, used e.g. by `maestro serve --config`) silently drops any non-empty `dashboardURL` argument with no log output. The current production caller in `cmd/maestro/main.go` passes `""`, so there is no active breakage, but the asymmetry makes the two code paths disagree on the observable behavior of the same conceptual operation.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(fleet): repurpose dashboard\_url to ..."](https://github.com/befeast/maestro/commit/995e19fa5b232b276793b0fba0d80e5ae1a29d33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35026219)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->