### PR TITLE
Auto review-repair respawn: green+retry_exhausted PR with Greptile P0/P1-on-head should spawn a scoped opus repair worker, not dead-end

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -254,6 +254,27 @@ func (e *Executor) dispatchAction(approval *state.Approval) Result {
 			Status:  state.ApprovalStatusAwaitingDispatch,
 			Summary: summary,
 		}
+	case "spawn_review_repair":
+		// #565: same dispatcher shape as spawn_worker. The supervisor
+		// records the intent; the orchestrator's dispatcher loop owns
+		// the actual worker spawn and gates idempotency on
+		// (pr_number, head_sha). Returning AwaitingDispatch keeps the
+		// approval effective so RecordPendingApprovalForDecision's
+		// at-mint dedup coalesces fresh recommendations for the same
+		// (action, target) until the dispatcher resolves it.
+		pr, issue := 0, 0
+		if approval.Target != nil {
+			pr = approval.Target.PR
+			issue = approval.Target.Issue
+		}
+		summary := "spawn_review_repair approval recorded; next dispatcher loop will start the scoped repair worker"
+		if pr > 0 {
+			summary = fmt.Sprintf("spawn_review_repair for PR #%d (issue #%d) approved; next dispatcher loop will start the scoped repair worker (no extra command required)", pr, issue)
+		}
+		return Result{
+			Status:  state.ApprovalStatusAwaitingDispatch,
+			Summary: summary,
+		}
 	case "open_child_issue":
 		// Same shape as spawn_worker: the v1 supervisor records the
 		// intent, but the safe-action executor for create_issue lands

--- a/internal/approver/registry.go
+++ b/internal/approver/registry.go
@@ -23,12 +23,18 @@ package approver
 // here, by enumerating the verbs and checking each one routes through
 // Execute() without falling into default).
 var KnownApprovalActions = map[string]struct{}{
-	"merge_pr":              {},
-	"close_issue":           {},
-	"delete_worktree":       {},
-	"change_global_config":  {}, // executor returns execution_skipped pending YAML pipeline
-	"spawn_worker":          {}, // executor returns awaiting_dispatch (#515)
-	"open_child_issue":      {}, // executor returns awaiting_dispatch (#515)
+	"merge_pr":             {},
+	"close_issue":          {},
+	"delete_worktree":      {},
+	"change_global_config": {}, // executor returns execution_skipped pending YAML pipeline
+	"spawn_worker":         {}, // executor returns awaiting_dispatch (#515)
+	"open_child_issue":     {}, // executor returns awaiting_dispatch (#515)
+	// #565: auto review-repair respawn. Executor returns awaiting_dispatch
+	// — the orchestrator's dispatcher spawns a scoped opus repair worker
+	// keyed on (pr_number, head_sha) so the same head is never
+	// re-attempted. Replaces the refused `spawn_repair_worker` verb for
+	// the green+retry_exhausted+P0/P1-on-head case.
+	"spawn_review_repair": {},
 }
 
 // KnownSafeActions is the canonical set of safe (non-approval-gated)
@@ -37,10 +43,10 @@ var KnownApprovalActions = map[string]struct{}{
 // for symmetry but the at-mint guard does not gate them — safe actions
 // never mint pending approvals.
 var KnownSafeActions = map[string]struct{}{
-	"add_ready_label":       {},
-	"remove_ready_label":    {},
-	"remove_blocked_label":  {},
-	"add_issue_comment":     {},
+	"add_ready_label":      {},
+	"remove_ready_label":   {},
+	"remove_blocked_label": {},
+	"add_issue_comment":    {},
 }
 
 // IsKnownApprovalAction returns true if the verb is implemented by the

--- a/internal/approver/registry_test.go
+++ b/internal/approver/registry_test.go
@@ -48,8 +48,10 @@ func TestRegistry_IsKnownApprovalAction(t *testing.T) {
 		{"change_global_config", true},
 		{"spawn_worker", true},
 		{"open_child_issue", true},
+		{"spawn_review_repair", true}, // #565: auto review-repair respawn
 
 		// Negative cases — the live-found bugs.
+		{"spawn_repair_repair", false},
 		{"spawn_repair_worker", false}, // dogfood 2026-05-30: minted by LLM, never implemented
 		{"approve_merge", false},       // hypothetical drift
 		{"add_ready_label", false},     // safe action, NOT in approval registry

--- a/internal/approver/review_repair_test.go
+++ b/internal/approver/review_repair_test.go
@@ -1,0 +1,49 @@
+package approver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #565: spawn_review_repair must NOT fall into the unknown-action
+// default. It is awaiting_dispatch (the orchestrator dispatcher owns
+// the actual side effect) with an actionable summary so the operator
+// sees who is going to do what next.
+func TestExecute_SpawnReviewRepair_ReturnsAwaitingDispatch(t *testing.T) {
+	ex := &Executor{Cfg: newCfg()}
+	a := mkApproval("spawn_review_repair", &state.SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "deadbeef"}, "fix P1 review feedback", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("status = %q, want %q (#565)", res.Status, state.ApprovalStatusAwaitingDispatch)
+	}
+	if !strings.Contains(res.Summary, "PR #564") {
+		t.Fatalf("summary = %q, want PR #564 reference", res.Summary)
+	}
+	if !strings.Contains(res.Summary, "#442") {
+		t.Fatalf("summary = %q, want issue #442 reference", res.Summary)
+	}
+	if !strings.Contains(strings.ToLower(res.Summary), "dispatcher") {
+		t.Fatalf("summary = %q, want dispatcher mention so operator knows next step", res.Summary)
+	}
+	if res.Err != nil {
+		t.Fatalf("err = %v, want nil for awaiting-dispatch", res.Err)
+	}
+}
+
+// Negative: the refused legacy verb stays refused — the registry's job
+// is to surface the failure loudly at mint, not silently.
+func TestExecute_SpawnRepairWorker_StillUnknownAction(t *testing.T) {
+	ex := &Executor{Cfg: newCfg()}
+	a := mkApproval("spawn_repair_worker", &state.SupervisorTarget{Issue: 442, PR: 564}, "legacy verb", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("status = %q, want execution_failed (legacy verb must not silently land)", res.Status)
+	}
+	if res.Err == nil {
+		t.Fatal("err = nil, want unknown-action error")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,13 @@ const (
 	SupervisorActionCloseIssue         = "close_issue"
 	SupervisorActionDeleteWorktree     = "delete_worktree"
 	SupervisorActionChangeGlobalConfig = "change_global_config"
+	// SupervisorActionSpawnReviewRepair is the auto review-repair respawn verb
+	// minted by the supervisor when a green+mergeable PR is settled
+	// retry_exhausted on review feedback and at least one Greptile P0/P1
+	// inline comment is still on the head SHA (#565). The orchestrator
+	// dispatcher spawns a scoped opus repair worker keyed on
+	// (pr_number, head_sha) so the same head is never re-attempted.
+	SupervisorActionSpawnReviewRepair = "spawn_review_repair"
 )
 
 // SupervisorConfig defines local policy for supervisor decisions.
@@ -105,6 +112,7 @@ type SupervisorConfig struct {
 	OrderedQueue            SupervisorOrderedQueueConfig    `yaml:"ordered_queue" json:"ordered_queue,omitempty"`
 	DynamicWave             SupervisorDynamicWaveConfig     `yaml:"dynamic_wave" json:"dynamic_wave,omitempty"`
 	HandoffPlanner          SupervisorHandoffPlannerConfig  `yaml:"handoff_planner" json:"handoff_planner,omitempty"`
+	ReviewRepair            SupervisorReviewRepairConfig    `yaml:"review_repair" json:"review_repair,omitempty"`
 	PreflightCommand        string                          `yaml:"preflight_command" json:"preflight_command,omitempty"`
 	CompletionGates         SupervisorCompletionGatesConfig `yaml:"completion_gates" json:"completion_gates,omitempty"`
 	SafeActions             []string                        `yaml:"safe_actions" json:"safe_actions,omitempty"`
@@ -153,6 +161,82 @@ func (h SupervisorHandoffPlannerConfig) EffectiveSourceLabels() []string {
 		return h.SourceIssueLabels
 	}
 	return []string{"epic", "design-handoff"}
+}
+
+// SupervisorReviewRepairConfig governs the auto review-repair respawn
+// (#565). When a green+mergeable PR is settled retry_exhausted on review
+// feedback AND ≥1 Greptile P0/P1 inline comment is still on the current
+// head SHA, the supervisor mints a spawn_review_repair action so a fresh
+// worker scoped to those comments — running on the configured strong
+// backend — can address them. A separate retry budget keeps the main
+// retries-per-issue budget independent.
+//
+// Default is enabled when the SupervisorConfig is otherwise live (review
+// feedback retry exhaustion is the dogfood failure mode this config
+// targets; an explicit nil means "default on").
+type SupervisorReviewRepairConfig struct {
+	// Enabled gates the entire feature. nil = default on so the dogfood
+	// failure mode (#564, #555, #535) is fixed without explicit opt-in.
+	Enabled *bool `yaml:"enabled" json:"enabled,omitempty"`
+	// Backend names the worker backend used for review repair. Empty =
+	// "claude" so the strongest backend addresses the residual P0/P1.
+	Backend string `yaml:"backend" json:"backend,omitempty"`
+	// Model and Effort are forwarded to the backend selection when set.
+	Model  string `yaml:"model" json:"model,omitempty"`
+	Effort string `yaml:"effort" json:"effort,omitempty"`
+	// MaxRetries caps how many review-repair workers can be spawned for a
+	// single (pr_number, head_sha) before falling through to operator
+	// review. Default 1: the head SHA changes after every push, so a
+	// single retry is enough to either land the fix or surface to the
+	// operator. Set 0 to disable spawning entirely.
+	MaxRetries int `yaml:"max_retries" json:"max_retries,omitempty"`
+	// FallThroughToMergeApproval, when true, makes the supervisor emit a
+	// merge_pr decision after the review-repair budget exhausts so the
+	// cautious gate mints an approval and the operator can sign off on
+	// the residual P0/P1. When false (default) the supervisor stays on
+	// monitor_open_pr with an attention stuck state. Either way the PR
+	// never dead-ends silently.
+	FallThroughToMergeApproval *bool `yaml:"fall_through_to_merge_approval" json:"fall_through_to_merge_approval,omitempty"`
+}
+
+// Active reports whether the auto review-repair respawn should fire.
+// Default true — the feature exists to close a hands-off ceiling, and
+// every project that does not want it can flip Enabled to false.
+func (r SupervisorReviewRepairConfig) Active() bool {
+	if r.Enabled == nil {
+		return true
+	}
+	return *r.Enabled
+}
+
+// EffectiveBackend returns the configured backend or "claude" (the
+// default strong backend per the issue's acceptance criteria).
+func (r SupervisorReviewRepairConfig) EffectiveBackend() string {
+	if b := strings.TrimSpace(r.Backend); b != "" {
+		return b
+	}
+	return "claude"
+}
+
+// EffectiveMaxRetries returns the configured retry cap or 1 when unset.
+// MaxRetries==0 is treated literally (disable spawning) — the default is
+// applied at parse time so callers see the operator's intent verbatim.
+func (r SupervisorReviewRepairConfig) EffectiveMaxRetries() int {
+	if r.MaxRetries < 0 {
+		return 0
+	}
+	return r.MaxRetries
+}
+
+// FallThroughMergeEnabled reports whether the supervisor should mint a
+// merge_pr decision (cautious-gate approval) once the review-repair
+// budget exhausts. Default false: the supervisor surfaces the residual
+// findings via stuck states instead.
+func (r SupervisorReviewRepairConfig) FallThroughMergeEnabled() bool {
+	if r.FallThroughToMergeApproval == nil {
+		return false
+	}
+	return *r.FallThroughToMergeApproval
 }
 
 // SupervisorCompletionGatesConfig configures the issue-specific completion
@@ -756,6 +840,7 @@ func parse(data []byte) (*Config, error) {
 			"notify_red",
 			"spawn_worker",
 			"spawn_repair_worker",
+			"spawn_review_repair",
 			"label_issue_ready",
 			"add_ready_label",
 			"open_child_issue",
@@ -767,10 +852,18 @@ func parse(data []byte) (*Config, error) {
 			"review_retry_exhausted",
 			"spawn_worker",
 			"spawn_repair_worker",
+			"spawn_review_repair",
 			"label_issue_ready",
 			"add_ready_label",
 			"open_child_issue",
 		}
+	}
+	// #565 default budget: 1 review-repair attempt per (pr_number, head_sha).
+	// The head SHA changes after every push, so a single repair worker is
+	// enough to either land the fix or surface to operator review. Operators
+	// can override per-project via supervisor.review_repair.max_retries.
+	if cfg.Supervisor.ReviewRepair.MaxRetries == 0 {
+		cfg.Supervisor.ReviewRepair.MaxRetries = 1
 	}
 
 	// Routing defaults
@@ -1094,6 +1187,7 @@ func knownSupervisorActions() map[string]bool {
 		SupervisorActionCloseIssue:         true,
 		SupervisorActionDeleteWorktree:     true,
 		SupervisorActionChangeGlobalConfig: true,
+		SupervisorActionSpawnReviewRepair:  true,
 	}
 }
 
@@ -1107,6 +1201,7 @@ func knownSupervisorActionNames() []string {
 		SupervisorActionCloseIssue,
 		SupervisorActionDeleteWorktree,
 		SupervisorActionChangeGlobalConfig,
+		SupervisorActionSpawnReviewRepair,
 	}
 }
 

--- a/internal/config/review_repair_test.go
+++ b/internal/config/review_repair_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"testing"
+)
+
+// #565: supervisor.review_repair defaults — enabled by default, "claude"
+// backend, MaxRetries=1 (one repair worker per pr_number, head_sha).
+func TestParse_ReviewRepairDefaults(t *testing.T) {
+	cfg, err := parse([]byte("repo: owner/repo\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.Supervisor.ReviewRepair.Active() {
+		t.Fatal("supervisor.review_repair.enabled must default to true")
+	}
+	if got := cfg.Supervisor.ReviewRepair.EffectiveBackend(); got != "claude" {
+		t.Errorf("EffectiveBackend = %q, want claude", got)
+	}
+	if got := cfg.Supervisor.ReviewRepair.EffectiveMaxRetries(); got != 1 {
+		t.Errorf("EffectiveMaxRetries = %d, want 1 (one attempt per pr+head)", got)
+	}
+	// fall_through_to_merge_approval defaults to false (attention path).
+	if cfg.Supervisor.ReviewRepair.FallThroughMergeEnabled() {
+		t.Error("FallThroughMergeEnabled must default to false")
+	}
+
+	// Default policy lists must contain spawn_review_repair so cautious
+	// mode gates it and the executor registry mints it.
+	wantInAllowed := false
+	for _, a := range cfg.Supervisor.AllowedActions {
+		if a == SupervisorActionSpawnReviewRepair {
+			wantInAllowed = true
+			break
+		}
+	}
+	if !wantInAllowed {
+		t.Errorf("AllowedActions missing %q: %v", SupervisorActionSpawnReviewRepair, cfg.Supervisor.AllowedActions)
+	}
+	wantInApprovalRequired := false
+	for _, a := range cfg.Supervisor.ApprovalRequiredActions {
+		if a == SupervisorActionSpawnReviewRepair {
+			wantInApprovalRequired = true
+			break
+		}
+	}
+	if !wantInApprovalRequired {
+		t.Errorf("ApprovalRequiredActions missing %q: %v", SupervisorActionSpawnReviewRepair, cfg.Supervisor.ApprovalRequiredActions)
+	}
+}
+
+// Explicit YAML overrides — operators can flip the feature off, swap the
+// backend, change the budget, and route to merge_pr instead of attention.
+func TestParse_ReviewRepairExplicitOverrides(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  review_repair:
+    enabled: false
+    backend: codex
+    model: opus-4.8
+    effort: high
+    max_retries: 3
+    fall_through_to_merge_approval: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Supervisor.ReviewRepair.Active() {
+		t.Fatal("enabled=false must disable the feature")
+	}
+	if got := cfg.Supervisor.ReviewRepair.EffectiveBackend(); got != "codex" {
+		t.Errorf("backend = %q, want codex", got)
+	}
+	if got := cfg.Supervisor.ReviewRepair.Model; got != "opus-4.8" {
+		t.Errorf("model = %q, want opus-4.8", got)
+	}
+	if got := cfg.Supervisor.ReviewRepair.Effort; got != "high" {
+		t.Errorf("effort = %q, want high", got)
+	}
+	if got := cfg.Supervisor.ReviewRepair.EffectiveMaxRetries(); got != 3 {
+		t.Errorf("max_retries = %d, want 3", got)
+	}
+	if !cfg.Supervisor.ReviewRepair.FallThroughMergeEnabled() {
+		t.Error("fall_through_to_merge_approval=true must flip the flag")
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -962,6 +962,43 @@ func (c *Client) PRHasCriticalReviewOnHead(prNumber int) (bool, error) {
 	return hasGreptileCriticalCommentOnHead(comments, sha), nil
 }
 
+// PRHighSeverityReviewOnHead returns the head SHA and the list of P0/P1
+// Greptile inline comments still on that head. Used by the #565
+// auto-review-repair pipeline: the supervisor scopes the repair worker's
+// prompt to exactly these comments (path / line / body) so the worker is
+// not asked to re-implement the whole issue. Returns hasFindings=false
+// when no high-severity comment remains on head (the convergence-merge
+// path takes over) and a non-nil error only when the upstream lookups
+// fail — never use error as a "no findings" signal.
+func (c *Client) PRHighSeverityReviewOnHead(prNumber int) (sha string, findings []ReviewComment, hasFindings bool, err error) {
+	sha, err = c.pullHeadSHA(prNumber)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
+	}
+	comments, err := c.greptileReviewComments(prNumber)
+	if err != nil {
+		return sha, nil, false, fmt.Errorf("greptile review comments for PR %d: %w", prNumber, err)
+	}
+	for _, cm := range comments {
+		if !isGreptileLogin(cm.User.Login) {
+			continue
+		}
+		if !reviewCommentTargetsHead(cm, sha) {
+			continue
+		}
+		if !isHighSeverity(cm.Body) {
+			continue
+		}
+		findings = append(findings, ReviewComment{
+			Path: cm.Path,
+			Line: cm.Line,
+			Body: cm.Body,
+			User: cm.User.Login,
+		})
+	}
+	return sha, findings, len(findings) > 0, nil
+}
+
 func (c *Client) greptileReviewComments(prNumber int) ([]greptileReviewComment, error) {
 	out, err := exec.Command("gh", "api",
 		fmt.Sprintf("repos/%s/pulls/%d/comments", c.Repo, prNumber),

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3284,13 +3284,135 @@ func (o *Orchestrator) supervisorSelectedRepairSpawn(s *state.State, issueNumber
 		return false
 	}
 	decision := s.LatestSupervisorDecision()
-	if decision == nil || decision.RecommendedAction != supervisor.ActionSpawnRepairWorker {
+	if decision == nil {
+		return false
+	}
+	switch decision.RecommendedAction {
+	case supervisor.ActionSpawnRepairWorker, supervisor.ActionSpawnReviewRepair:
+	default:
 		return false
 	}
 	if decision.RequiresApproval || decision.Risk == supervisor.RiskApprovalGated {
-		return false
+		// #565: when cautious mode gates the spawn behind an approval, an
+		// approved or awaiting_dispatch approval also unlocks dispatch.
+		if !o.hasEffectiveApprovalForDecision(s, decision) {
+			return false
+		}
 	}
 	if decision.Target == nil || decision.Target.Issue != issueNumber {
+		return false
+	}
+	return true
+}
+
+// tryClaimReviewRepairSlot bumps the (pr_number, head_sha) attempt counter
+// and reports whether this dispatcher tick is allowed to spawn a worker.
+// Returns false when the budget for the (pr,head_sha) pair has already
+// been spent — the caller must NOT spawn, so the supervisor's next
+// cycle observes the exhaust and emits the fall-through decision.
+//
+// This is the per-(pr,head_sha) idempotency guard called out in the
+// #565 acceptance criteria: a new head pushed by the repair worker
+// does not re-trigger on the already-handled SHA, and a settled repair
+// does not loop.
+func (o *Orchestrator) tryClaimReviewRepairSlot(s *state.State, target *state.SupervisorTarget, payload *state.SupervisorReviewRepairPayload) bool {
+	if s == nil || target == nil || payload == nil {
+		return false
+	}
+	now := time.Now().UTC()
+	max := payload.MaxRetries
+	if max <= 0 {
+		max = o.cfg.Supervisor.ReviewRepair.EffectiveMaxRetries()
+	}
+	_, spawned := s.RecordReviewRepairAttempt(target.PR, payload.HeadSHA, target.Issue, "", max, now)
+	if !spawned {
+		log.Printf("[orch] auto review-repair: refusing duplicate spawn for PR #%d head %s — budget exhausted", target.PR, shortReviewRepairSHA(payload.HeadSHA))
+		return false
+	}
+	return true
+}
+
+// shortReviewRepairSHA trims a SHA for log messages — keeps the path
+// dependency-free from internal/supervisor's shortSHA helper.
+func shortReviewRepairSHA(sha string) string {
+	sha = strings.TrimSpace(sha)
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
+}
+
+// supervisorSelectedReviewRepair returns the spawn_review_repair payload
+// for the given issue when the supervisor has minted (and the cautious
+// gate has cleared) such a decision. nil means "no review-repair spawn
+// applies to this issue right now". The (pr_number, head_sha) idempotency
+// check is the caller's responsibility — this only resolves the LATEST
+// supervisor decision.
+func (o *Orchestrator) supervisorSelectedReviewRepair(s *state.State, issueNumber int) (*state.SupervisorReviewRepairPayload, *state.SupervisorTarget) {
+	if s == nil || issueNumber <= 0 {
+		return nil, nil
+	}
+	decision := s.LatestSupervisorDecision()
+	if decision == nil || decision.RecommendedAction != supervisor.ActionSpawnReviewRepair {
+		return nil, nil
+	}
+	if decision.Target == nil || decision.Target.Issue != issueNumber {
+		return nil, nil
+	}
+	if decision.RequiresApproval || decision.Risk == supervisor.RiskApprovalGated {
+		if !o.hasEffectiveApprovalForDecision(s, decision) {
+			return nil, nil
+		}
+	}
+	if decision.ReviewRepair == nil {
+		return nil, decision.Target
+	}
+	return decision.ReviewRepair, decision.Target
+}
+
+// hasEffectiveApprovalForDecision reports whether the supervisor decision
+// has a matching approval that is currently effective (approved or
+// awaiting_dispatch). Used to gate cautious-mode dispatch on the
+// operator's signoff. The match is by (Action, Target) — the same
+// identity used by RecordPendingApprovalForDecision's at-mint dedup.
+func (o *Orchestrator) hasEffectiveApprovalForDecision(s *state.State, decision *state.SupervisorDecision) bool {
+	if s == nil || decision == nil {
+		return false
+	}
+	for i := range s.Approvals {
+		a := &s.Approvals[i]
+		if a.Action != decision.RecommendedAction {
+			continue
+		}
+		if !approvalTargetSameAsDecision(a.Target, decision.Target) {
+			continue
+		}
+		switch a.Status {
+		case state.ApprovalStatusApproved, state.ApprovalStatusAwaitingDispatch, state.ApprovalStatusExecutionSkipped:
+			return true
+		}
+	}
+	return false
+}
+
+// approvalTargetSameAsDecision compares two SupervisorTargets by the
+// identity fields the executor cares about (issue, pr, head_sha,
+// session). Mirrors approvalTargetsEqual in the state package, kept
+// here so the orchestrator does not need to reach into state internals.
+func approvalTargetSameAsDecision(a, b *state.SupervisorTarget) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Issue != b.Issue || a.PR != b.PR {
+		return false
+	}
+	if strings.TrimSpace(a.HeadSHA) != strings.TrimSpace(b.HeadSHA) {
+		return false
+	}
+	if strings.TrimSpace(a.Session) != strings.TrimSpace(b.Session) {
 		return false
 	}
 	return true
@@ -3554,7 +3676,25 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		initialPhase := pipeline.InitialPhase(o.cfg)
 		var backendName string
 		var promptBase string
-		if initialPhase != state.PhaseNone && initialPhase != state.PhaseImplement {
+
+		// #565: when the supervisor selected spawn_review_repair for this
+		// issue, override backend + prompt with the strong backend and
+		// the scoped Greptile-finding prompt. Skip the pipeline preamble
+		// — the review-repair worker is a focused, single-phase fixer
+		// (not a planner/implementer/validator pass).
+		if reviewRepair, repairTarget := o.supervisorSelectedReviewRepair(s, issue.Number); reviewRepair != nil && repairTarget != nil {
+			if !o.tryClaimReviewRepairSlot(s, repairTarget, reviewRepair) {
+				continue
+			}
+			backendName = reviewRepair.Backend
+			if backendName == "" {
+				backendName = o.cfg.Supervisor.ReviewRepair.EffectiveBackend()
+			}
+			promptBase = supervisor.FormatReviewRepairPromptFromPayload(issue.Number, repairTarget.PR, reviewRepair)
+			initialPhase = state.PhaseNone
+			log.Printf("[orch] starting auto review-repair worker for issue #%d (PR #%d, head %s, backend=%s, %d findings)",
+				issue.Number, repairTarget.PR, shortReviewRepairSHA(reviewRepair.HeadSHA), backendName, len(reviewRepair.Findings))
+		} else if initialPhase != state.PhaseNone && initialPhase != state.PhaseImplement {
 			// Pipeline mode with planner — use planner backend and raw template
 			// (worker.Start → assemblePrompt will substitute {{WORKTREE}} etc.)
 			backendName = pipeline.BackendForPhase(o.cfg, initialPhase)

--- a/internal/orchestrator/review_repair_test.go
+++ b/internal/orchestrator/review_repair_test.go
@@ -1,0 +1,131 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/supervisor"
+)
+
+// reviewRepairCfg returns a minimal config with review-repair on and
+// MaxRetries set to a deterministic value.
+func reviewRepairCfg(maxRetries int) *config.Config {
+	cfg := &config.Config{Repo: "owner/repo", MaxParallel: 5}
+	enabled := true
+	cfg.Supervisor.ReviewRepair.Enabled = &enabled
+	cfg.Supervisor.ReviewRepair.MaxRetries = maxRetries
+	cfg.Supervisor.ReviewRepair.Backend = "claude"
+	return cfg
+}
+
+// #565 acceptance criterion: exactly one review-repair worker per
+// (pr_number, head_sha). The orchestrator's tryClaimReviewRepairSlot
+// honours the configured budget and refuses subsequent claims for the
+// same head SHA.
+func TestTryClaimReviewRepairSlot_HonoursBudget(t *testing.T) {
+	o := &Orchestrator{cfg: reviewRepairCfg(1)}
+	s := state.NewState()
+	target := &state.SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "deadbeef0000"}
+	payload := &state.SupervisorReviewRepairPayload{HeadSHA: "deadbeef0000", MaxRetries: 1, Backend: "claude"}
+
+	if !o.tryClaimReviewRepairSlot(s, target, payload) {
+		t.Fatal("first claim must succeed")
+	}
+	if o.tryClaimReviewRepairSlot(s, target, payload) {
+		t.Fatal("second claim against same (pr,head) must be refused once budget=1 is exhausted")
+	}
+	track, _ := s.LookupReviewRepairTrack(564, "deadbeef0000")
+	if !track.Exhausted {
+		t.Fatalf("track.Exhausted=false after refusal: %+v", track)
+	}
+}
+
+// A new head SHA on the same PR (the repair worker pushed a fix) opens
+// a fresh budget. The orchestrator must allow the next claim.
+func TestTryClaimReviewRepairSlot_NewHeadSHAFreshBudget(t *testing.T) {
+	o := &Orchestrator{cfg: reviewRepairCfg(1)}
+	s := state.NewState()
+	target := &state.SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "old"}
+	payload := &state.SupervisorReviewRepairPayload{HeadSHA: "old", MaxRetries: 1, Backend: "claude"}
+	if !o.tryClaimReviewRepairSlot(s, target, payload) {
+		t.Fatal("first claim on old head must succeed")
+	}
+
+	// Same (pr) but new head SHA: budget for the new head starts at 0.
+	newTarget := &state.SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "new"}
+	newPayload := &state.SupervisorReviewRepairPayload{HeadSHA: "new", MaxRetries: 1, Backend: "claude"}
+	if !o.tryClaimReviewRepairSlot(s, newTarget, newPayload) {
+		t.Fatal("claim on new head SHA must start a fresh budget")
+	}
+}
+
+// supervisorSelectedReviewRepair must resolve the latest decision when
+// the cautious gate is permissive (no approval required).
+func TestSupervisorSelectedReviewRepair_PermissivePicksLatestDecision(t *testing.T) {
+	o := &Orchestrator{cfg: reviewRepairCfg(1)}
+	s := state.NewState()
+	now := time.Now().UTC()
+	dec := state.SupervisorDecision{
+		ID:                "test-1",
+		CreatedAt:         now,
+		RecommendedAction: supervisor.ActionSpawnReviewRepair,
+		Risk:              supervisor.RiskMutating,
+		RequiresApproval:  false,
+		Target:            &state.SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "deadbeef"},
+		ReviewRepair: &state.SupervisorReviewRepairPayload{
+			HeadSHA: "deadbeef",
+			Backend: "claude",
+			Findings: []state.SupervisorReviewFinding{
+				{Path: "internal/foo.go", Line: 1, Body: "P1: bad", Severity: "P1"},
+			},
+		},
+	}
+	s.RecordSupervisorDecision(dec, state.DefaultSupervisorDecisionLimit)
+
+	payload, target := o.supervisorSelectedReviewRepair(s, 442)
+	if payload == nil || target == nil {
+		t.Fatal("expected payload + target for issue 442")
+	}
+	if target.PR != 564 || target.HeadSHA != "deadbeef" {
+		t.Fatalf("target = %+v", target)
+	}
+	if len(payload.Findings) != 1 || payload.Findings[0].Path != "internal/foo.go" {
+		t.Fatalf("payload findings = %+v", payload.Findings)
+	}
+}
+
+// Cautious gate: with RequiresApproval=true and no matching approved
+// approval, the orchestrator must NOT dispatch yet.
+func TestSupervisorSelectedReviewRepair_RequiresEffectiveApproval(t *testing.T) {
+	o := &Orchestrator{cfg: reviewRepairCfg(1)}
+	s := state.NewState()
+	now := time.Now().UTC()
+	dec := state.SupervisorDecision{
+		ID:                "test-1",
+		CreatedAt:         now,
+		RecommendedAction: supervisor.ActionSpawnReviewRepair,
+		Risk:              supervisor.RiskApprovalGated,
+		RequiresApproval:  true,
+		Target:            &state.SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "deadbeef"},
+		ReviewRepair:      &state.SupervisorReviewRepairPayload{HeadSHA: "deadbeef", Backend: "claude"},
+	}
+	s.RecordSupervisorDecision(dec, state.DefaultSupervisorDecisionLimit)
+
+	if payload, _ := o.supervisorSelectedReviewRepair(s, 442); payload != nil {
+		t.Fatalf("approval-gated decision without effective approval must NOT dispatch; got payload=%+v", payload)
+	}
+
+	// Adding an awaiting_dispatch approval for the same (action, target)
+	// makes the dispatch eligible.
+	s.Approvals = append(s.Approvals, state.Approval{
+		ID:     "ap-1",
+		Action: supervisor.ActionSpawnReviewRepair,
+		Status: state.ApprovalStatusAwaitingDispatch,
+		Target: &state.SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "deadbeef"},
+	})
+	if payload, _ := o.supervisorSelectedReviewRepair(s, 442); payload == nil {
+		t.Fatal("expected dispatch after awaiting_dispatch approval was recorded")
+	}
+}

--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -156,7 +156,7 @@ func isSafeAction(id string) bool {
 	return false
 }
 
-// isApprovalRequiredAction reports whether the action_id is one of the four
+// isApprovalRequiredAction reports whether the action_id is one of the
 // cautious-gate verbs that must be enqueued as a pending Approval rather
 // than executed synchronously. dispatchApprovalAction handles these.
 func isApprovalRequiredAction(id string) bool {
@@ -164,7 +164,11 @@ func isApprovalRequiredAction(id string) bool {
 	case config.SupervisorActionMergePR,
 		config.SupervisorActionCloseIssue,
 		config.SupervisorActionDeleteWorktree,
-		config.SupervisorActionChangeGlobalConfig:
+		config.SupervisorActionChangeGlobalConfig,
+		// #565: review-repair respawn is approval-gated (RiskMutating);
+		// the orchestrator dispatcher loop spawns the actual worker once
+		// the cautious gate approves.
+		config.SupervisorActionSpawnReviewRepair:
 		return true
 	}
 	return false
@@ -349,6 +353,14 @@ func validateApprovalRequest(id string, req controlActionRequest) error {
 	case config.SupervisorActionChangeGlobalConfig:
 		if strings.TrimSpace(req.Reason) == "" {
 			return errors.New("reason is required for change_global_config")
+		}
+	case config.SupervisorActionSpawnReviewRepair:
+		// #565: the dispatcher needs a PR number to spawn the scoped
+		// repair worker; the head SHA is observed at decision time and
+		// can be empty for the HTTP enqueue (operators may invoke this
+		// manually against the latest head).
+		if req.PRNumber <= 0 {
+			return errors.New("pr_number is required for spawn_review_repair")
 		}
 	}
 	return nil

--- a/internal/server/review_repair_test.go
+++ b/internal/server/review_repair_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #565: HTTP enqueue for spawn_review_repair must (a) accept the verb
+// (no 400 "unknown action"), (b) require pr_number, (c) record a
+// pending approval bound to the supervisor target so the cautious gate
+// path is reusable from the dashboard.
+func TestApprovalAction_SpawnReviewRepair_Enqueues202(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"spawn_review_repair","pr_number":564,"issue_number":442,"reason":"Greptile P1 unresolved"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	var resp approvalEnqueueResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ActionID != "spawn_review_repair" {
+		t.Fatalf("action_id = %q, want spawn_review_repair", resp.ActionID)
+	}
+
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(st.Approvals) != 1 {
+		t.Fatalf("approvals = %d, want 1", len(st.Approvals))
+	}
+	if got := st.Approvals[0].Action; got != "spawn_review_repair" {
+		t.Fatalf("approval action = %q, want spawn_review_repair", got)
+	}
+	if got := st.Approvals[0].Target; got == nil || got.PR != 564 || got.Issue != 442 {
+		t.Fatalf("target = %+v, want PR=564 issue=442", got)
+	}
+}
+
+// spawn_review_repair without pr_number must 400 — the dispatcher
+// needs the PR to spawn the scoped worker.
+func TestApprovalAction_SpawnReviewRepair_RequiresPRNumber(t *testing.T) {
+	cfg, _ := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+	w := postApprovalAction(t, srv, `{"action_id":"spawn_review_repair","issue_number":442}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -711,7 +711,7 @@ func stuckTargetsSession(stuck state.SupervisorStuckState, info sessionInfo) boo
 
 func supervisorStuckNeedsAttention(stuck state.SupervisorStuckState) bool {
 	switch stuck.Code {
-	case "retry_exhausted", "retry_exhausted_open_pr", "dead_running_pid", "stale_worker_logs", "worker_timeout", "failing_checks", "closed_pr_with_active_session", "unmergeable_pr", "stale_review_feedback", "greptile_not_approved", state.StuckPolicyBlocksMerge:
+	case "retry_exhausted", "retry_exhausted_open_pr", "dead_running_pid", "stale_worker_logs", "worker_timeout", "failing_checks", "closed_pr_with_active_session", "unmergeable_pr", "stale_review_feedback", "greptile_not_approved", state.StuckPolicyBlocksMerge, state.StuckReviewRepairSpawned, state.StuckReviewRepairExhausted:
 		return true
 	}
 	return stuck.Severity == "blocked"

--- a/internal/state/review_repair_test.go
+++ b/internal/state/review_repair_test.go
@@ -1,0 +1,116 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+// #565 — per-(pr_number, head_sha) idempotency. Repeated calls inside a
+// budget bump the attempt counter; once the budget is exhausted, further
+// attempts return spawned=false so the dispatcher can fall through to
+// operator review instead of silently looping.
+func TestRecordReviewRepairAttempt_BudgetIdempotency(t *testing.T) {
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	st := NewState()
+	pr, headSHA, issue := 564, "deadbeef1234", 442
+
+	// First attempt within budget=2 should succeed.
+	track, spawned := st.RecordReviewRepairAttempt(pr, headSHA, issue, "approval-1", 2, now)
+	if !spawned || track.Attempts != 1 || track.Exhausted {
+		t.Fatalf("first attempt: track=%+v spawned=%v, want Attempts=1 spawned=true", track, spawned)
+	}
+
+	// Second attempt also within budget.
+	track, spawned = st.RecordReviewRepairAttempt(pr, headSHA, issue, "approval-2", 2, now)
+	if !spawned || track.Attempts != 2 {
+		t.Fatalf("second attempt: track=%+v spawned=%v, want Attempts=2 spawned=true", track, spawned)
+	}
+
+	// Third attempt: budget exhausted — must NOT spawn.
+	track, spawned = st.RecordReviewRepairAttempt(pr, headSHA, issue, "approval-3", 2, now)
+	if spawned {
+		t.Fatalf("third attempt spawned despite exhausted budget: track=%+v", track)
+	}
+	if !track.Exhausted {
+		t.Fatalf("track.Exhausted=false after budget exhaust: %+v", track)
+	}
+}
+
+// A new head SHA on the same PR creates a fresh (pr,head_sha) budget —
+// the repair worker pushed an update and the supervisor should be able
+// to retry on the new head.
+func TestRecordReviewRepairAttempt_NewHeadSHASeparateBudget(t *testing.T) {
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	st := NewState()
+	pr, oldHead, newHead, issue := 564, "deadbeef1111", "deadbeef2222", 442
+
+	// Exhaust the old head's budget.
+	_, _ = st.RecordReviewRepairAttempt(pr, oldHead, issue, "a1", 1, now)
+	_, spawned := st.RecordReviewRepairAttempt(pr, oldHead, issue, "a1", 1, now)
+	if spawned {
+		t.Fatalf("expected old-head budget to be exhausted")
+	}
+
+	// The new head has its own budget.
+	track, spawned := st.RecordReviewRepairAttempt(pr, newHead, issue, "a2", 1, now)
+	if !spawned || track.Attempts != 1 {
+		t.Fatalf("new head: track=%+v spawned=%v, want fresh budget", track, spawned)
+	}
+}
+
+// Lookup must return the recorded track for the (pr,head_sha) pair, and
+// only that pair — distinct heads do not collide.
+func TestLookupReviewRepairTrack_KeyIsolation(t *testing.T) {
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	st := NewState()
+	st.RecordReviewRepairAttempt(564, "head-a", 442, "x", 5, now)
+	st.RecordReviewRepairAttempt(564, "head-b", 442, "x", 5, now)
+
+	a, ok := st.LookupReviewRepairTrack(564, "head-a")
+	if !ok || a.HeadSHA != "head-a" || a.Attempts != 1 {
+		t.Fatalf("lookup head-a: ok=%v track=%+v", ok, a)
+	}
+	b, ok := st.LookupReviewRepairTrack(564, "head-b")
+	if !ok || b.HeadSHA != "head-b" || b.Attempts != 1 {
+		t.Fatalf("lookup head-b: ok=%v track=%+v", ok, b)
+	}
+	if _, ok := st.LookupReviewRepairTrack(564, "missing"); ok {
+		t.Fatal("lookup for unknown head must return ok=false")
+	}
+}
+
+// MarkReviewRepairExhausted flips the terminal flag and records the
+// unresolved summary; calling twice does not duplicate the timestamp.
+func TestMarkReviewRepairExhausted_Idempotent(t *testing.T) {
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	st := NewState()
+	pr, headSHA := 564, "deadbeef"
+	track := st.MarkReviewRepairExhausted(pr, headSHA, "1 P0 finding unresolved", now)
+	if !track.Exhausted || track.UnresolvedSummary != "1 P0 finding unresolved" {
+		t.Fatalf("first mark: %+v", track)
+	}
+	stamp := track.ExhaustedAt
+	track2 := st.MarkReviewRepairExhausted(pr, headSHA, "different summary", now.Add(time.Hour))
+	if !track2.ExhaustedAt.Equal(stamp) {
+		t.Fatalf("second mark moved ExhaustedAt from %v to %v", stamp, track2.ExhaustedAt)
+	}
+	if track2.UnresolvedSummary != "different summary" {
+		t.Fatalf("second mark should refresh summary; got %q", track2.UnresolvedSummary)
+	}
+}
+
+// approvalTargetsEqual now considers HeadSHA — two decisions for the
+// same (action, pr) with different head SHAs must NOT coalesce at mint.
+// This is the dispatcher-side guarantee that a new push retires the
+// stale recommendation.
+func TestApprovalTargetsEqual_HeadSHADifferentiates(t *testing.T) {
+	a := &SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "deadbeef"}
+	b := &SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "cafebabe"}
+	if approvalTargetsEqual(a, b) {
+		t.Fatalf("distinct head SHAs must not be equal: a=%+v b=%+v", a, b)
+	}
+	c := &SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "deadbeef"}
+	if !approvalTargetsEqual(a, c) {
+		t.Fatalf("identical targets should be equal: a=%+v c=%+v", a, c)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -452,8 +452,14 @@ var (
 
 // SupervisorTarget identifies the primary object a supervisor decision refers to.
 type SupervisorTarget struct {
-	Issue   int    `json:"issue,omitempty"`
-	PR      int    `json:"pr,omitempty"`
+	Issue int `json:"issue,omitempty"`
+	PR    int `json:"pr,omitempty"`
+	// HeadSHA stamps the PR head SHA at decision time. Used by the
+	// review-repair pipeline (#565) so a decision is keyed on the exact
+	// head it observed; a new push that moves head invalidates a pending
+	// spawn_review_repair recommendation automatically (dedup hashes
+	// include the target).
+	HeadSHA string `json:"head_sha,omitempty"`
 	Session string `json:"session,omitempty"`
 }
 
@@ -487,6 +493,18 @@ const (
 	// yet cleared. Lets the dashboard render a specific "waiting on checks"
 	// state instead of conflating it with policy or repair gating.
 	StuckPendingChecks = "pending_checks"
+	// StuckReviewRepairSpawned is emitted when the supervisor mints a
+	// spawn_review_repair decision: a green+mergeable+retry_exhausted PR
+	// carries ≥1 Greptile P0/P1 inline comment on its current head SHA
+	// and a scoped repair worker should run. Surfaces as an attention
+	// item so operators see the auto-respawn instead of a silent
+	// monitor_open_pr loop (#565).
+	StuckReviewRepairSpawned = "review_repair_spawned"
+	// StuckReviewRepairExhausted is emitted when the (pr,head_sha) repair
+	// budget is exhausted but Greptile P0/P1 findings remain on head. The
+	// PR is held for operator review with the unresolved comments
+	// surfaced as evidence. NEVER a silent dead-end (#565).
+	StuckReviewRepairExhausted = "review_repair_exhausted"
 )
 
 // SupervisorIssueCandidate describes the issue selected by queue policy without
@@ -636,6 +654,37 @@ type SupervisorDecision struct {
 	ProjectState      SupervisorProjectState   `json:"project_state"`
 	QueueAnalysis     *SupervisorQueueAnalysis `json:"queue_analysis,omitempty"`
 	ApprovalID        string                   `json:"approval_id,omitempty"`
+	// ReviewRepair carries the scoped findings and backend choice for a
+	// spawn_review_repair decision (#565). The orchestrator dispatcher
+	// uses this payload to build the worker prompt and pick the strong
+	// backend without re-fetching review comments from GitHub. nil for
+	// every non-review-repair decision.
+	ReviewRepair *SupervisorReviewRepairPayload `json:"review_repair,omitempty"`
+}
+
+// SupervisorReviewRepairPayload carries the auto-review-repair payload
+// on a SupervisorDecision (#565). The orchestrator dispatcher reads it
+// to build the scoped worker prompt and pick the configured strong
+// backend.
+type SupervisorReviewRepairPayload struct {
+	HeadSHA    string                    `json:"head_sha"`
+	Backend    string                    `json:"backend,omitempty"`
+	Model      string                    `json:"model,omitempty"`
+	Effort     string                    `json:"effort,omitempty"`
+	MaxRetries int                       `json:"max_retries,omitempty"`
+	Attempts   int                       `json:"attempts,omitempty"`
+	Findings   []SupervisorReviewFinding `json:"findings,omitempty"`
+}
+
+// SupervisorReviewFinding is one Greptile inline P0/P1 comment scoped
+// onto a spawn_review_repair decision. Carries enough context for the
+// worker prompt to address the comment without re-fetching from GitHub.
+type SupervisorReviewFinding struct {
+	Path     string `json:"path,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Body     string `json:"body,omitempty"`
+	Severity string `json:"severity,omitempty"`
+	User     string `json:"user,omitempty"`
 }
 
 type ApprovalStatus string
@@ -747,8 +796,123 @@ type State struct {
 	SpawnDrain   bool      `json:"spawn_drain,omitempty"`
 	SpawnDrainAt time.Time `json:"spawn_drain_at,omitempty"`
 
+	// ReviewRepairTracks records per-(pr_number,head_sha) idempotency for
+	// the #565 auto review-repair respawn. Each spawn bumps the Attempts
+	// counter; the supervisor refuses to mint a fresh recommendation once
+	// the counter reaches the configured budget. Keyed on
+	// "PR#<n>@<head_sha>" to keep the map JSON-stable; HeadSHA is the
+	// short SHA observed when the decision was recorded.
+	ReviewRepairTracks map[string]ReviewRepairTrack `json:"review_repair_tracks,omitempty"`
+
 	loadedHash  string
 	loadedState *State
+}
+
+// ReviewRepairTrack is one (pr_number, head_sha) idempotency record for
+// the auto review-repair respawn (#565). It carries the count of repair
+// workers spawned for this exact head and the terminal state once the
+// budget is exhausted, so the supervisor neither double-spawns nor loops
+// after the head SHA has been retired.
+type ReviewRepairTrack struct {
+	PRNumber          int       `json:"pr_number"`
+	HeadSHA           string    `json:"head_sha"`
+	IssueNumber       int       `json:"issue_number,omitempty"`
+	Attempts          int       `json:"attempts"`
+	LastDecisionAt    time.Time `json:"last_decision_at,omitempty"`
+	LastApprovalID    string    `json:"last_approval_id,omitempty"`
+	Exhausted         bool      `json:"exhausted,omitempty"`
+	ExhaustedAt       time.Time `json:"exhausted_at,omitempty"`
+	UnresolvedSummary string    `json:"unresolved_summary,omitempty"`
+}
+
+// reviewRepairTrackKey is the JSON-stable key used in ReviewRepairTracks.
+// Empty headSHA falls back to a sentinel so a missing SHA never collapses
+// two distinct heads under the same key.
+func reviewRepairTrackKey(pr int, headSHA string) string {
+	head := strings.TrimSpace(headSHA)
+	if head == "" {
+		head = "unknown"
+	}
+	return fmt.Sprintf("PR#%d@%s", pr, head)
+}
+
+// LookupReviewRepairTrack returns the existing (pr,head_sha) record if
+// any. Callers use this to gate a fresh recommendation (already at
+// budget → fall through to operator) or to bump the attempt counter on
+// dispatch.
+func (s *State) LookupReviewRepairTrack(prNumber int, headSHA string) (ReviewRepairTrack, bool) {
+	if s == nil || prNumber <= 0 {
+		return ReviewRepairTrack{}, false
+	}
+	track, ok := s.ReviewRepairTracks[reviewRepairTrackKey(prNumber, headSHA)]
+	return track, ok
+}
+
+// RecordReviewRepairAttempt increments the attempt counter for the given
+// (pr,head_sha) pair, capping at maxAttempts. Returns (track, spawned)
+// where spawned reports whether this call actually took a slot (false
+// when the budget was already exhausted). When spawned=true, the caller
+// is free to dispatch the worker; when false the caller should leave the
+// PR for operator review.
+func (s *State) RecordReviewRepairAttempt(prNumber int, headSHA string, issueNumber int, approvalID string, maxAttempts int, now time.Time) (ReviewRepairTrack, bool) {
+	if s == nil || prNumber <= 0 {
+		return ReviewRepairTrack{}, false
+	}
+	if s.ReviewRepairTracks == nil {
+		s.ReviewRepairTracks = make(map[string]ReviewRepairTrack)
+	}
+	key := reviewRepairTrackKey(prNumber, headSHA)
+	track := s.ReviewRepairTracks[key]
+	track.PRNumber = prNumber
+	track.HeadSHA = strings.TrimSpace(headSHA)
+	if issueNumber > 0 {
+		track.IssueNumber = issueNumber
+	}
+	if track.Exhausted || (maxAttempts > 0 && track.Attempts >= maxAttempts) {
+		track.Exhausted = true
+		if track.ExhaustedAt.IsZero() {
+			track.ExhaustedAt = normalizedTime(now)
+		}
+		s.ReviewRepairTracks[key] = track
+		return track, false
+	}
+	track.Attempts++
+	track.LastDecisionAt = normalizedTime(now)
+	if strings.TrimSpace(approvalID) != "" {
+		track.LastApprovalID = approvalID
+	}
+	if maxAttempts > 0 && track.Attempts >= maxAttempts {
+		// Budget reached this attempt — leave Exhausted=false so the
+		// dispatched worker can land its fix; the next supervisor cycle
+		// that still sees a P0/P1 on this head will flip Exhausted.
+	}
+	s.ReviewRepairTracks[key] = track
+	return track, true
+}
+
+// MarkReviewRepairExhausted records that a (pr,head_sha) pair has run
+// out of repair attempts and the operator must take over. Idempotent —
+// calling twice does not multiply the timestamp.
+func (s *State) MarkReviewRepairExhausted(prNumber int, headSHA string, summary string, now time.Time) ReviewRepairTrack {
+	if s == nil || prNumber <= 0 {
+		return ReviewRepairTrack{}
+	}
+	if s.ReviewRepairTracks == nil {
+		s.ReviewRepairTracks = make(map[string]ReviewRepairTrack)
+	}
+	key := reviewRepairTrackKey(prNumber, headSHA)
+	track := s.ReviewRepairTracks[key]
+	track.PRNumber = prNumber
+	track.HeadSHA = strings.TrimSpace(headSHA)
+	if !track.Exhausted {
+		track.Exhausted = true
+		track.ExhaustedAt = normalizedTime(now)
+	}
+	if strings.TrimSpace(summary) != "" {
+		track.UnresolvedSummary = summary
+	}
+	s.ReviewRepairTracks[key] = track
+	return track
 }
 
 type ProjectStatusSync struct {
@@ -1509,8 +1673,11 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 }
 
 // approvalTargetsEqual returns true if two SupervisorTarget pointers refer
-// to the same target identity (issue/pr/session). Used by the at-mint
-// dedup check in RecordPendingApprovalForDecision.
+// to the same target identity (issue/pr/head_sha/session). Used by the
+// at-mint dedup check in RecordPendingApprovalForDecision. HeadSHA is
+// part of the identity (#565) so a new head SHA — i.e. the repair worker
+// pushed an update — produces a distinct approval instead of being
+// coalesced as a duplicate of the stale one.
 func approvalTargetsEqual(a, b *SupervisorTarget) bool {
 	if a == nil && b == nil {
 		return true
@@ -1522,6 +1689,9 @@ func approvalTargetsEqual(a, b *SupervisorTarget) bool {
 		return false
 	}
 	if a.PR != b.PR {
+		return false
+	}
+	if strings.TrimSpace(a.HeadSHA) != strings.TrimSpace(b.HeadSHA) {
 		return false
 	}
 	if strings.TrimSpace(a.Session) != strings.TrimSpace(b.Session) {

--- a/internal/supervisor/review_repair.go
+++ b/internal/supervisor/review_repair.go
@@ -1,0 +1,396 @@
+package supervisor
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// PolicyRuleReviewRepair identifies the supervisor policy rule that
+// generated an auto-review-repair recommendation in audit/state.
+const PolicyRuleReviewRepair = "supervisor.review_repair"
+
+// reviewRepairCandidate is the result of inspecting one (session, PR)
+// pair for the #565 auto review-repair pipeline.
+type reviewRepairCandidate struct {
+	HeadSHA  string
+	Findings []github.ReviewComment
+	// Exhausted reports whether the (pr,head_sha) repair budget already
+	// ran out. When true the supervisor falls through to a visible
+	// operator decision (merge_pr approval or attention stuck state) —
+	// never a silent dead-end.
+	Exhausted bool
+	// Track is the current ReviewRepairTrack record (zero-valued when
+	// no track exists yet). Useful for the stuck-state evidence.
+	Track state.ReviewRepairTrack
+}
+
+// evaluateAutoReviewRepair inspects an open PR + its bound session and
+// returns a candidate when the auto-review-repair branch should fire.
+// Returns (nil, "") when the branch does not apply.
+//
+// The branch fires only when ALL the following hold (matches the #565
+// acceptance criteria):
+//
+//   - SupervisorReviewRepairConfig.Active() (default on).
+//   - The session is settled retry_exhausted on review feedback.
+//   - The PR is not draft, mergeable, CI green, AND the Greptile gate
+//     is "not approved" only because of inline P0/P1 findings on head.
+//   - The Greptile reader exposes PRHighSeverityReviewOnHead and reports
+//     at least one P0/P1 inline finding on the current head SHA.
+//
+// When the budget for the (pr,head_sha) pair is exhausted the candidate
+// is returned with Exhausted=true so the caller can choose a fall-
+// through (merge_pr approval, attention stuck state).
+func (e *Engine) evaluateAutoReviewRepair(st *state.State, sess *state.Session, pr github.PR) *reviewRepairCandidate {
+	if e == nil || e.cfg == nil || st == nil || sess == nil {
+		return nil
+	}
+	if !e.cfg.Supervisor.ReviewRepair.Active() {
+		return nil
+	}
+	if pr.Number <= 0 {
+		return nil
+	}
+	if pr.IsDraft {
+		return nil
+	}
+	if !reviewRepairSessionSettled(sess, pr.Number) {
+		return nil
+	}
+
+	mergeable := strings.ToUpper(strings.TrimSpace(pr.Mergeable))
+	if mr, ok := e.reader.(prMergeableReader); ok {
+		if fresh, err := mr.PRMergeable(pr.Number); err == nil {
+			mergeable = strings.ToUpper(strings.TrimSpace(fresh))
+		}
+	}
+	if mergeable != "MERGEABLE" {
+		return nil
+	}
+
+	if ciReader, ok := e.reader.(prCIStatusReader); ok {
+		if ciStatus, err := ciReader.PRCIStatus(pr.Number); err == nil {
+			ciLower := strings.ToLower(strings.TrimSpace(ciStatus))
+			if ciLower != "success" {
+				if !mergeStateAllowsMerge(e.reader, pr.Number) {
+					return nil
+				}
+			}
+		} else {
+			return nil
+		}
+	} else {
+		return nil
+	}
+
+	reader, ok := e.reader.(prHighSeverityReviewReader)
+	if !ok {
+		return nil
+	}
+	sha, findings, hasFindings, err := reader.PRHighSeverityReviewOnHead(pr.Number)
+	if err != nil {
+		return nil
+	}
+	if !hasFindings {
+		return nil
+	}
+
+	track, _ := st.LookupReviewRepairTrack(pr.Number, sha)
+	maxRetries := e.cfg.Supervisor.ReviewRepair.EffectiveMaxRetries()
+	candidate := &reviewRepairCandidate{
+		HeadSHA:  sha,
+		Findings: findings,
+		Track:    track,
+	}
+	if maxRetries <= 0 {
+		candidate.Exhausted = true
+		return candidate
+	}
+	if track.Exhausted || track.Attempts >= maxRetries {
+		candidate.Exhausted = true
+		return candidate
+	}
+	return candidate
+}
+
+// reviewRepairSessionSettled reports whether the session has reached the
+// "settled retry_exhausted on review feedback" state — i.e. the worker
+// has spent its retry budget on review-feedback fixes and the orchestrator
+// has stopped scheduling fresh retries. Mirrors the orchestrator's
+// isSettledRetryExhausted contract so the two surfaces agree on the same
+// terminal condition.
+func reviewRepairSessionSettled(sess *state.Session, prNumber int) bool {
+	if sess == nil {
+		return false
+	}
+	if sess.Status != state.StatusRetryExhausted {
+		return false
+	}
+	if prNumber <= 0 || sess.PRNumber != prNumber {
+		return false
+	}
+	// The orchestrator stamps LastNotifiedStatus = "review_retry_exhausted"
+	// when the review-feedback retry budget ran out (#556). That's the
+	// signal we use to scope the auto-review-repair branch — CI
+	// retry-exhausted or rebase-conflict retry-exhausted are different
+	// failure modes and are not in scope here.
+	if sess.LastNotifiedStatus == "review_retry_exhausted" {
+		return true
+	}
+	// Back-compat: an older session may carry the review-feedback
+	// PreviousAttemptFeedbackKind without the LastNotifiedStatus stamp.
+	return sess.PreviousAttemptFeedbackKind == state.RetryReasonReviewFeedback
+}
+
+// buildReviewRepairDecision constructs the spawn_review_repair decision
+// for a candidate. The decision is RiskMutating (approval-gated under
+// cautious mode) and carries the per-finding evidence so the dispatcher
+// can scope the worker prompt to exactly the inline comments returned by
+// the Greptile reader (#565: "scoped to the specific Greptile comments,
+// not the whole issue restatement").
+func (e *Engine) buildReviewRepairDecision(st *state.State, now time.Time, projectState state.SupervisorProjectState, baseReasons []string, slot string, sess *state.Session, pr github.PR, candidate *reviewRepairCandidate) state.SupervisorDecision {
+	target := &state.SupervisorTarget{
+		Issue:   sess.IssueNumber,
+		PR:      pr.Number,
+		HeadSHA: candidate.HeadSHA,
+		Session: slot,
+	}
+	reasons := appendReasons(baseReasons,
+		fmt.Sprintf("PR #%d is green and mergeable but Greptile flags %d P0/P1 inline comment(s) on head %s", pr.Number, len(candidate.Findings), shortSHA(candidate.HeadSHA)),
+		fmt.Sprintf("Session %s is settled retry_exhausted on review feedback (#565: would otherwise dead-end)", slot),
+		fmt.Sprintf("Review-repair budget: attempt %d of %d for (PR #%d, head %s)", candidate.Track.Attempts+1, e.cfg.Supervisor.ReviewRepair.EffectiveMaxRetries(), pr.Number, shortSHA(candidate.HeadSHA)),
+	)
+	reasons = appendReasons(reasons, formatReviewRepairFindings(candidate.Findings)...)
+	summary := fmt.Sprintf("Spawn a scoped review-repair worker for PR #%d to address %d Greptile P0/P1 inline comment(s) on head %s", pr.Number, len(candidate.Findings), shortSHA(candidate.HeadSHA))
+	decision := e.decision(st, now, projectState, ActionSpawnReviewRepair, summary,
+		RiskMutating, 0.9, target, PolicyRuleReviewRepair, reasons)
+	decision.StuckStates = append(decision.StuckStates, reviewRepairSpawnedStuckState(target, candidate))
+	decision.ReviewRepair = e.buildReviewRepairPayload(candidate)
+	return decision
+}
+
+// buildReviewRepairPayload converts the in-memory candidate into the
+// serializable payload carried on the supervisor decision. The
+// dispatcher reads back the same payload to build the worker prompt.
+func (e *Engine) buildReviewRepairPayload(candidate *reviewRepairCandidate) *state.SupervisorReviewRepairPayload {
+	cfg := e.cfg.Supervisor.ReviewRepair
+	payload := &state.SupervisorReviewRepairPayload{
+		HeadSHA:    candidate.HeadSHA,
+		Backend:    cfg.EffectiveBackend(),
+		Model:      strings.TrimSpace(cfg.Model),
+		Effort:     strings.TrimSpace(cfg.Effort),
+		MaxRetries: cfg.EffectiveMaxRetries(),
+		Attempts:   candidate.Track.Attempts,
+	}
+	for _, f := range candidate.Findings {
+		payload.Findings = append(payload.Findings, state.SupervisorReviewFinding{
+			Path:     f.Path,
+			Line:     f.Line,
+			Body:     f.Body,
+			Severity: severityLabel(f.Body),
+			User:     f.User,
+		})
+	}
+	return payload
+}
+
+// buildReviewRepairExhaustedDecision builds a fall-through decision when
+// the (pr,head_sha) repair budget is exhausted but Greptile P0/P1 findings
+// remain on head. Per #565 acceptance criteria the supervisor MUST NOT
+// silently dead-end — it either routes to a merge_pr approval (when
+// supervisor.review_repair.fall_through_to_merge_approval=true) or
+// surfaces a review_repair_exhausted stuck state so the operator sees the
+// unresolved comments listed in the MC attention queue.
+func (e *Engine) buildReviewRepairExhaustedDecision(st *state.State, now time.Time, projectState state.SupervisorProjectState, baseReasons []string, slot string, sess *state.Session, pr github.PR, candidate *reviewRepairCandidate) state.SupervisorDecision {
+	target := &state.SupervisorTarget{
+		Issue:   sess.IssueNumber,
+		PR:      pr.Number,
+		HeadSHA: candidate.HeadSHA,
+		Session: slot,
+	}
+	reasons := appendReasons(baseReasons,
+		fmt.Sprintf("PR #%d retry-exhausted on review feedback; review-repair budget for (PR #%d, head %s) is also exhausted", pr.Number, pr.Number, shortSHA(candidate.HeadSHA)),
+		fmt.Sprintf("%d Greptile P0/P1 inline comment(s) remain unaddressed on head %s — operator decision required", len(candidate.Findings), shortSHA(candidate.HeadSHA)),
+	)
+	reasons = appendReasons(reasons, formatReviewRepairFindings(candidate.Findings)...)
+
+	if e.cfg.Supervisor.ReviewRepair.FallThroughMergeEnabled() {
+		summary := fmt.Sprintf("Review-repair budget exhausted for PR #%d on head %s — fall through to operator merge approval (residual P0/P1 advisory)", pr.Number, shortSHA(candidate.HeadSHA))
+		decision := e.decision(st, now, projectState, ActionMergePR, summary,
+			RiskMutating, 0.85, target, PolicyRuleReviewRepair, reasons)
+		decision.StuckStates = append(decision.StuckStates, reviewRepairExhaustedStuckState(target, candidate))
+		return decision
+	}
+
+	summary := fmt.Sprintf("Hold PR #%d for operator review: review-repair budget exhausted on head %s with %d residual P0/P1 finding(s)", pr.Number, shortSHA(candidate.HeadSHA), len(candidate.Findings))
+	decision := e.decision(st, now, projectState, ActionMonitorOpenPR, summary,
+		RiskSafe, 0.9, target, PolicyRuleReviewRepair, reasons)
+	decision.StuckStates = append(decision.StuckStates, reviewRepairExhaustedStuckState(target, candidate))
+	return decision
+}
+
+func reviewRepairSpawnedStuckState(target *state.SupervisorTarget, candidate *reviewRepairCandidate) state.SupervisorStuckState {
+	summary := fmt.Sprintf("Auto review-repair worker queued for PR #%d (head %s): %d Greptile P0/P1 finding(s) on head", target.PR, shortSHA(candidate.HeadSHA), len(candidate.Findings))
+	return state.SupervisorStuckState{
+		Code:              state.StuckReviewRepairSpawned,
+		Severity:          SeverityWarning,
+		Summary:           summary,
+		Evidence:          reviewRepairEvidence(candidate.Findings),
+		RecommendedAction: ActionSpawnReviewRepair,
+		Target:            target,
+	}
+}
+
+func reviewRepairExhaustedStuckState(target *state.SupervisorTarget, candidate *reviewRepairCandidate) state.SupervisorStuckState {
+	summary := fmt.Sprintf("Review-repair budget exhausted for PR #%d on head %s — %d Greptile P0/P1 finding(s) unresolved; operator decision required", target.PR, shortSHA(candidate.HeadSHA), len(candidate.Findings))
+	return state.SupervisorStuckState{
+		Code:              state.StuckReviewRepairExhausted,
+		Severity:          SeverityBlocked,
+		Summary:           summary,
+		Evidence:          reviewRepairEvidence(candidate.Findings),
+		RecommendedAction: ActionMonitorOpenPR,
+		Target:            target,
+	}
+}
+
+// formatReviewRepairFindings returns a short, decision-Reasons-friendly
+// summary of each finding ("internal/foo.go:42 P1: <body>"). Truncates
+// bodies so the reason list does not balloon when Greptile pastes large
+// suggestion blocks.
+func formatReviewRepairFindings(findings []github.ReviewComment) []string {
+	out := make([]string, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, "Greptile finding: "+formatReviewCommentLine(f))
+	}
+	return out
+}
+
+// reviewRepairEvidence returns a denser per-finding evidence list used in
+// the stuck-state, with the same truncation so dashboards stay readable.
+func reviewRepairEvidence(findings []github.ReviewComment) []string {
+	out := make([]string, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, formatReviewCommentLine(f))
+	}
+	return out
+}
+
+func formatReviewCommentLine(f github.ReviewComment) string {
+	path := strings.TrimSpace(f.Path)
+	body := compactReviewBody(f.Body)
+	sev := severityLabel(f.Body)
+	switch {
+	case path != "" && f.Line > 0:
+		return fmt.Sprintf("%s:%d %s: %s", path, f.Line, sev, body)
+	case path != "":
+		return fmt.Sprintf("%s %s: %s", path, sev, body)
+	default:
+		return fmt.Sprintf("%s: %s", sev, body)
+	}
+}
+
+// severityLabel extracts P0/P1 from a Greptile comment body. Defaults to
+// "P?" when no marker is found — the comment must already be a known
+// high-severity finding to reach this code path.
+func severityLabel(body string) string {
+	lower := strings.ToLower(body)
+	switch {
+	case strings.Contains(lower, "alt=\"p0\""), strings.Contains(lower, "/p0"), strings.Contains(lower, "badge/p0"):
+		return "P0"
+	case strings.Contains(lower, "alt=\"p1\""), strings.Contains(lower, "/p1"), strings.Contains(lower, "badge/p1"):
+		return "P1"
+	}
+	return "P?"
+}
+
+const reviewRepairBodyTruncate = 240
+
+func compactReviewBody(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	body = strings.ReplaceAll(body, "\r\n", " ")
+	body = strings.ReplaceAll(body, "\n", " ")
+	body = strings.Join(strings.Fields(body), " ")
+	if len(body) > reviewRepairBodyTruncate {
+		return body[:reviewRepairBodyTruncate] + "…"
+	}
+	return body
+}
+
+func shortSHA(sha string) string {
+	sha = strings.TrimSpace(sha)
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
+}
+
+// FormatReviewRepairPromptFromPayload builds the worker prompt from the
+// review-repair payload carried on a SupervisorDecision. Used by the
+// orchestrator dispatcher when starting the scoped repair worker; it
+// avoids a fresh GitHub round-trip.
+func FormatReviewRepairPromptFromPayload(issueNumber, prNumber int, payload *state.SupervisorReviewRepairPayload) string {
+	if payload == nil {
+		return ""
+	}
+	findings := make([]github.ReviewComment, 0, len(payload.Findings))
+	for _, f := range payload.Findings {
+		findings = append(findings, github.ReviewComment{
+			Path: f.Path,
+			Line: f.Line,
+			Body: f.Body,
+			User: f.User,
+		})
+	}
+	return FormatReviewRepairPrompt(issueNumber, prNumber, payload.HeadSHA, findings)
+}
+
+// FormatReviewRepairPrompt builds the worker prompt for a spawn_review_repair
+// dispatch. The prompt is scoped to the specific Greptile findings (path /
+// line / body) so the worker addresses only the comments — not a restatement
+// of the original issue. Used by the orchestrator when starting the scoped
+// repair worker.
+func FormatReviewRepairPrompt(issueNumber int, prNumber int, headSHA string, findings []github.ReviewComment) string {
+	var b strings.Builder
+	b.WriteString("# Auto review-repair worker\n\n")
+	b.WriteString(fmt.Sprintf("You are addressing Greptile review feedback on PR #%d (issue #%d) at head %s.\n\n", prNumber, issueNumber, shortSHA(headSHA)))
+	b.WriteString("The previous worker for this issue exhausted its review-feedback retry budget on this PR.\n")
+	b.WriteString("Your scope is NARROW: resolve EACH of the inline Greptile P0/P1 comments listed below.\n")
+	b.WriteString("Do NOT re-implement the original issue. Do NOT refactor outside the touched files.\n\n")
+	b.WriteString("Per finding:\n")
+	b.WriteString("  1. Read the comment context (path, line, body).\n")
+	b.WriteString("  2. Make the minimal code change that resolves the comment.\n")
+	b.WriteString("  3. Push to the existing PR branch (do not open a new PR).\n\n")
+	b.WriteString("## Unresolved Greptile P0/P1 inline comments on head ")
+	b.WriteString(shortSHA(headSHA))
+	b.WriteString("\n\n")
+	for i, f := range findings {
+		b.WriteString(fmt.Sprintf("### Finding %d (%s)\n", i+1, severityLabel(f.Body)))
+		path := strings.TrimSpace(f.Path)
+		if path != "" {
+			if f.Line > 0 {
+				b.WriteString(fmt.Sprintf("- Location: `%s:%d`\n", path, f.Line))
+			} else {
+				b.WriteString(fmt.Sprintf("- Location: `%s`\n", path))
+			}
+		}
+		body := strings.TrimSpace(f.Body)
+		if body != "" {
+			b.WriteString("- Comment:\n\n")
+			for _, line := range strings.Split(body, "\n") {
+				b.WriteString("    ")
+				b.WriteString(line)
+				b.WriteString("\n")
+			}
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("After every fix, run the project's test suite locally to confirm the change does not regress green CI.\n")
+	return b.String()
+}

--- a/internal/supervisor/review_repair_test.go
+++ b/internal/supervisor/review_repair_test.go
@@ -1,0 +1,275 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #565 — green+mergeable+settled-retry_exhausted PR with ≥1 Greptile
+// P0/P1 inline comment on head must trigger a spawn_review_repair
+// recommendation. The verb MUST be in the executor registry — the
+// "refused at mint" loop the issue calls out only fires on
+// spawn_repair_worker, never on spawn_review_repair.
+func TestDecide_RetryExhaustedGreenPR_WithGreptileP1OnHead_SpawnsReviewRepair(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	enabled := true
+	cfg.Supervisor.ReviewRepair.Enabled = &enabled
+	cfg.Supervisor.ReviewRepair.MaxRetries = 1
+
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 564, HeadRefName: "feat/sup-111", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{564: "success"},
+		highSeverityHeadSHA: map[int]string{
+			564: "deadbeefcafebabe1234567890abcdef12345678",
+		},
+		highSeverityFindings: map[int][]github.ReviewComment{
+			564: {
+				{
+					Path: "internal/supervisor/dependency_unblock.go",
+					Line: 42,
+					Body: `<img alt="P1">P1: resolutionCache parameter is never consulted`,
+					User: "greptile-apps",
+				},
+			},
+		},
+	}
+	st := state.NewState()
+	st.Sessions["sup-111"] = &state.Session{
+		IssueNumber:                 442,
+		IssueTitle:                  "scribe redesign",
+		Status:                      state.StatusRetryExhausted,
+		Branch:                      "feat/sup-111",
+		PRNumber:                    564,
+		RetryCount:                  2,
+		LastNotifiedStatus:          "review_retry_exhausted",
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		StartedAt:                   time.Now().UTC().Add(-2 * time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnReviewRepair {
+		t.Fatalf("action = %q, want %q (green PR with P0/P1 on head must auto-spawn review-repair)", decision.RecommendedAction, ActionSpawnReviewRepair)
+	}
+	if decision.Risk != RiskMutating {
+		t.Fatalf("risk = %q, want %q", decision.Risk, RiskMutating)
+	}
+	if decision.Target == nil || decision.Target.PR != 564 || decision.Target.Issue != 442 {
+		t.Fatalf("target = %#v, want PR=564 issue=442", decision.Target)
+	}
+	if decision.Target.HeadSHA == "" {
+		t.Fatalf("target.HeadSHA is empty — review-repair decisions must stamp the head SHA for (pr, head) idempotency")
+	}
+	if decision.ReviewRepair == nil {
+		t.Fatalf("decision.ReviewRepair payload missing — dispatcher cannot build the scoped prompt")
+	}
+	if len(decision.ReviewRepair.Findings) != 1 {
+		t.Fatalf("review-repair findings count = %d, want 1", len(decision.ReviewRepair.Findings))
+	}
+	if decision.ReviewRepair.Findings[0].Path != "internal/supervisor/dependency_unblock.go" {
+		t.Fatalf("finding path = %q, want internal/supervisor/dependency_unblock.go", decision.ReviewRepair.Findings[0].Path)
+	}
+	if decision.ReviewRepair.Backend == "" {
+		t.Fatalf("review-repair backend is empty; want the configured strong backend")
+	}
+	stuck := requireStuckState(t, decision, state.StuckReviewRepairSpawned)
+	if stuck.Severity != SeverityWarning {
+		t.Errorf("stuck severity = %q, want warning", stuck.Severity)
+	}
+	if !strings.Contains(strings.ToLower(stuck.Summary), "auto review-repair") {
+		t.Errorf("stuck summary = %q, want it to name the auto review-repair branch", stuck.Summary)
+	}
+}
+
+// Negative: the review-repair branch must NOT fire on a green PR that
+// has no Greptile P0/P1 findings on head (convergence-merge handles
+// that case).
+func TestDecide_RetryExhaustedGreenPR_NoP0P1Findings_DoesNotSpawnReviewRepair(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:                  []github.PR{{Number: 564, HeadRefName: "feat/sup-111", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses:           map[int]string{564: "success"},
+		highSeverityHeadSHA:  map[int]string{564: "abc123"},
+		highSeverityFindings: map[int][]github.ReviewComment{
+			// no findings -> nil
+		},
+	}
+	st := state.NewState()
+	st.Sessions["sup-111"] = &state.Session{
+		IssueNumber:                 442,
+		Status:                      state.StatusRetryExhausted,
+		Branch:                      "feat/sup-111",
+		PRNumber:                    564,
+		LastNotifiedStatus:          "review_retry_exhausted",
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		StartedAt:                   time.Now().UTC().Add(-time.Hour),
+	}
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionSpawnReviewRepair {
+		t.Fatalf("review-repair must not fire without P0/P1 findings; got %+v", decision)
+	}
+}
+
+// Disabled config: even with findings, the feature stays off.
+func TestDecide_ReviewRepairDisabled_DoesNotSpawn(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	disabled := false
+	cfg.Supervisor.ReviewRepair.Enabled = &disabled
+	cfg.Supervisor.ReviewRepair.MaxRetries = 1
+
+	reader := &fakeReader{
+		prs:                 []github.PR{{Number: 564, HeadRefName: "feat/sup-111", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses:          map[int]string{564: "success"},
+		highSeverityHeadSHA: map[int]string{564: "deadbeef"},
+		highSeverityFindings: map[int][]github.ReviewComment{
+			564: {{Path: "x.go", Line: 1, Body: "P1: bad", User: "greptile-apps"}},
+		},
+	}
+	st := state.NewState()
+	st.Sessions["sup-111"] = &state.Session{
+		IssueNumber:        442,
+		Status:             state.StatusRetryExhausted,
+		Branch:             "feat/sup-111",
+		PRNumber:           564,
+		LastNotifiedStatus: "review_retry_exhausted",
+		StartedAt:          time.Now().UTC().Add(-time.Hour),
+	}
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionSpawnReviewRepair {
+		t.Fatalf("disabled review-repair must not fire; got %q", decision.RecommendedAction)
+	}
+}
+
+// Exhausted budget per (pr,head_sha): supervisor must fall through to
+// a visible operator decision, NEVER a silent dead-end.
+func TestDecide_ReviewRepairExhausted_FallsThroughToAttention(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	cfg.Supervisor.ReviewRepair.MaxRetries = 1
+	reader := &fakeReader{
+		prs:                 []github.PR{{Number: 564, HeadRefName: "feat/sup-111", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses:          map[int]string{564: "success"},
+		highSeverityHeadSHA: map[int]string{564: "deadbeef0000"},
+		highSeverityFindings: map[int][]github.ReviewComment{
+			564: {{Path: "internal/foo.go", Line: 12, Body: "P0: nil panic", User: "greptile-apps"}},
+		},
+	}
+	st := state.NewState()
+	st.Sessions["sup-111"] = &state.Session{
+		IssueNumber:        442,
+		Status:             state.StatusRetryExhausted,
+		Branch:             "feat/sup-111",
+		PRNumber:           564,
+		LastNotifiedStatus: "review_retry_exhausted",
+		StartedAt:          time.Now().UTC().Add(-time.Hour),
+	}
+	// Simulate one attempt already burnt.
+	st.RecordReviewRepairAttempt(564, "deadbeef0000", 442, "approval-1", cfg.Supervisor.ReviewRepair.MaxRetries, time.Now().UTC())
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionSpawnReviewRepair {
+		t.Fatalf("exhausted budget must not respawn; got %q", decision.RecommendedAction)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR && decision.RecommendedAction != ActionMergePR {
+		t.Fatalf("expected fall-through to monitor_open_pr or merge_pr, got %q", decision.RecommendedAction)
+	}
+	stuck := requireStuckState(t, decision, state.StuckReviewRepairExhausted)
+	if !strings.Contains(strings.ToLower(stuck.Summary), "exhausted") {
+		t.Errorf("stuck summary = %q, want it to name exhausted", stuck.Summary)
+	}
+	if len(stuck.Evidence) == 0 {
+		t.Errorf("stuck evidence is empty; operators need the unresolved findings listed")
+	}
+}
+
+// Fall-through to merge_pr approval: explicit opt-in routes the residual
+// findings to a cautious-gate merge instead of a hold-for-review.
+func TestDecide_ReviewRepairExhausted_FallThroughMergeEnabled_EmitsMergePR(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	cfg.Supervisor.ReviewRepair.MaxRetries = 1
+	on := true
+	cfg.Supervisor.ReviewRepair.FallThroughToMergeApproval = &on
+
+	reader := &fakeReader{
+		prs:                 []github.PR{{Number: 564, HeadRefName: "feat/sup-111", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses:          map[int]string{564: "success"},
+		highSeverityHeadSHA: map[int]string{564: "deadbeef0000"},
+		highSeverityFindings: map[int][]github.ReviewComment{
+			564: {{Path: "internal/foo.go", Line: 12, Body: "P0: nil panic", User: "greptile-apps"}},
+		},
+	}
+	st := state.NewState()
+	st.Sessions["sup-111"] = &state.Session{
+		IssueNumber:        442,
+		Status:             state.StatusRetryExhausted,
+		Branch:             "feat/sup-111",
+		PRNumber:           564,
+		LastNotifiedStatus: "review_retry_exhausted",
+		StartedAt:          time.Now().UTC().Add(-time.Hour),
+	}
+	st.RecordReviewRepairAttempt(564, "deadbeef0000", 442, "approval-1", cfg.Supervisor.ReviewRepair.MaxRetries, time.Now().UTC())
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMergePR {
+		t.Fatalf("fall_through_to_merge_approval=true must emit merge_pr; got %q", decision.RecommendedAction)
+	}
+}
+
+// The dispatched prompt must mention the specific Greptile finding(s)
+// — not a generic issue restatement (#565 acceptance criterion).
+func TestFormatReviewRepairPrompt_ScopedToFindings(t *testing.T) {
+	findings := []github.ReviewComment{
+		{Path: "internal/foo.go", Line: 42, Body: "P1: nil pointer in resolve()", User: "greptile-apps"},
+		{Path: "internal/bar.go", Line: 10, Body: "P0: missing rollback on error", User: "greptile-apps"},
+	}
+	prompt := FormatReviewRepairPrompt(442, 564, "deadbeef000000000000000000000000", findings)
+	for _, want := range []string{
+		"PR #564",
+		"issue #442",
+		"internal/foo.go:42",
+		"internal/bar.go:10",
+		"P1", "P0",
+		"nil pointer in resolve()",
+		"missing rollback on error",
+		"Do NOT re-implement the original issue",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q\nprompt:\n%s", want, prompt)
+		}
+	}
+}
+
+// The verb must be a registry-supported action; the supervisor's
+// at-mint guard wraps approver.IsKnownApprovalAction over this exact
+// constant.
+func TestSpawnReviewRepair_VerbConstant(t *testing.T) {
+	if ActionSpawnReviewRepair != "spawn_review_repair" {
+		t.Fatalf("ActionSpawnReviewRepair = %q, want spawn_review_repair", ActionSpawnReviewRepair)
+	}
+	if config.SupervisorActionSpawnReviewRepair != ActionSpawnReviewRepair {
+		t.Fatalf("config constant drift: config=%q supervisor=%q", config.SupervisorActionSpawnReviewRepair, ActionSpawnReviewRepair)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -35,8 +35,14 @@ const (
 	ActionNotifyRed            = "notify_red"
 	ActionSpawnWorker          = "spawn_worker"
 	ActionSpawnRepairWorker    = "spawn_repair_worker"
-	ActionLabelIssueReady      = "label_issue_ready"
-	ActionMergePR              = "merge_pr"
+	// ActionSpawnReviewRepair is the auto review-repair respawn (#565).
+	// Emitted when a green+mergeable+retry_exhausted PR carries ≥1
+	// Greptile P0/P1 inline comment on its current head SHA — a fresh
+	// scoped worker on the strong backend addresses the comments
+	// instead of the silent dead-end the issue describes.
+	ActionSpawnReviewRepair = config.SupervisorActionSpawnReviewRepair
+	ActionLabelIssueReady   = "label_issue_ready"
+	ActionMergePR           = "merge_pr"
 	// ActionOpenChildIssue asks the supervisor (or operator) to create the
 	// next concrete child issue from an open handoff/epic when no runnable
 	// issue remains. Approval-gated in v1; the safe-action executor for
@@ -126,6 +132,18 @@ type prMergeableReader interface {
 // check verdict and is therefore authoritative. #425 (sup-98).
 type prMergeStateReader interface {
 	PRMergeStatus(prNumber int) (mergeable string, mergeStateStatus string, err error)
+}
+
+// prHighSeverityReviewReader exposes the Greptile P0/P1 inline comments
+// still on the current head SHA. The supervisor uses it for the #565
+// auto review-repair branch: when a PR is green+mergeable+settled
+// retry_exhausted AND this returns hasFindings=true, the supervisor
+// mints a spawn_review_repair decision scoped to the returned
+// findings. Optional — when the reader does not implement it the
+// branch is a no-op and the existing convergence-merge path keeps the
+// PR moving.
+type prHighSeverityReviewReader interface {
+	PRHighSeverityReviewOnHead(prNumber int) (sha string, findings []github.ReviewComment, hasFindings bool, err error)
 }
 
 // PreflightResult is the outcome of running a configured preflight command.
@@ -357,6 +375,26 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false, cache)
 
 	if slot, sess, pr, ok := e.sessionWithOpenPR(st, prs, cache); ok {
+		// #565: auto review-repair respawn. When a green+mergeable PR is
+		// settled retry_exhausted on review feedback AND Greptile flags
+		// ≥1 P0/P1 inline comment on its current head SHA, mint a
+		// spawn_review_repair recommendation instead of dead-ending. The
+		// branch runs BEFORE openPRNeedsRepair so the deterministic
+		// repair-spawn does not fire the refused spawn_repair_worker
+		// verb for the same PR.
+		if candidate := e.evaluateAutoReviewRepair(st, sess, pr); candidate != nil {
+			if !candidate.Exhausted {
+				decision := e.buildReviewRepairDecision(st, now, projectState, baseReasons, slot, sess, pr, candidate)
+				decision.StuckStates = appendStuck(stuckStates, decision.StuckStates...)
+				return decision, nil
+			}
+			// Budget exhausted: fall through to a visible operator
+			// decision (merge_pr approval or attention stuck state).
+			decision := e.buildReviewRepairExhaustedDecision(st, now, projectState, baseReasons, slot, sess, pr, candidate)
+			decision.StuckStates = appendStuck(stuckStates, decision.StuckStates...)
+			return decision, nil
+		}
+
 		if e.openPRNeedsRepair(st, stuckStates, slot, sess, pr) {
 			reasons := appendReasons(baseReasons,
 				fmt.Sprintf("Session %s is associated with open PR #%d, but the PR is not progressing", slot, pr.Number),

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -18,29 +18,31 @@ import (
 )
 
 type fakeReader struct {
-	issues             []github.Issue
-	prs                []github.PR
-	openPRIssues       map[int]bool
-	mergedPRIssues     map[int]bool
-	closedIssues       map[int]bool
-	mergedPRs          map[int]bool
-	ciStatuses         map[int]string
-	greptileOK         map[int]bool
-	greptilePend       map[int]bool
-	mergeStates        map[int]string
-	rateLimit          *github.RateLimitStatus
-	rateLimitErr       error
-	rateLimitCalls     int
-	issueCalls         int
-	closedIssueCalls   map[int]int
-	mergedPRIssueCalls map[int]int
-	mergedPRCalls      map[int]int
-	addedLabels        []string
-	removedLabels      []string
-	comments           []string
-	addLabelErr        error
-	removeLabelErr     error
-	commentErr         error
+	issues               []github.Issue
+	prs                  []github.PR
+	openPRIssues         map[int]bool
+	mergedPRIssues       map[int]bool
+	closedIssues         map[int]bool
+	mergedPRs            map[int]bool
+	ciStatuses           map[int]string
+	greptileOK           map[int]bool
+	greptilePend         map[int]bool
+	mergeStates          map[int]string
+	highSeverityHeadSHA  map[int]string
+	highSeverityFindings map[int][]github.ReviewComment
+	rateLimit            *github.RateLimitStatus
+	rateLimitErr         error
+	rateLimitCalls       int
+	issueCalls           int
+	closedIssueCalls     map[int]int
+	mergedPRIssueCalls   map[int]int
+	mergedPRCalls        map[int]int
+	addedLabels          []string
+	removedLabels        []string
+	comments             []string
+	addLabelErr          error
+	removeLabelErr       error
+	commentErr           error
 }
 
 type fakeLLM struct {
@@ -144,6 +146,15 @@ func (f *fakeReader) PRGreptileApproved(prNumber int) (bool, bool, error) {
 		return true, false, nil
 	}
 	return approved, false, nil
+}
+
+// PRHighSeverityReviewOnHead lets the supervisor #565 auto-review-repair
+// branch peek at fake P0/P1 inline findings. Returns the configured head
+// SHA + findings for prNumber; missing entries are no findings.
+func (f *fakeReader) PRHighSeverityReviewOnHead(prNumber int) (string, []github.ReviewComment, bool, error) {
+	sha := f.highSeverityHeadSHA[prNumber]
+	findings := f.highSeverityFindings[prNumber]
+	return sha, findings, len(findings) > 0, nil
 }
 
 func (f *fakeReader) RateLimit() (github.RateLimitStatus, error) {


### PR DESCRIPTION
Refs #565

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the auto review-repair respawn feature (#565): when a green, mergeable PR is settled `retry_exhausted` on review feedback and Greptile still flags ≥1 P0/P1 inline comment on the current head SHA, the supervisor now mints a `spawn_review_repair` decision instead of dead-ending.

- **New `spawn_review_repair` verb** registered across the executor, approver registry, config constants, cautious-gate server actions, and supervisor action table; the orchestrator dispatcher picks it up to start a scoped opus repair worker keyed on `(pr_number, head_sha)`.
- **Per-`(pr, head_sha)` idempotency** via `ReviewRepairTracks` in state: `RecordReviewRepairAttempt` caps spawns at the configured `MaxRetries`; a new push retires the stale track and opens a fresh budget.
- **Exhausted-budget fall-through**: when the repair budget is spent but findings remain, the supervisor emits a visible `review_repair_exhausted` stuck state (or optionally a `merge_pr` approval) — never a silent dead-end.

<h3>Confidence Score: 3/5</h3>

The core feature logic and idempotency mechanics are well-structured and covered by tests, but the config API promises a disable-via-zero behaviour that the parser actively breaks.

The MaxRetries field is documented as 'Set 0 to disable spawning entirely,' yet parse() unconditionally converts any 0 to 1. An operator who follows the documented API to disable auto-repair spawning will silently get the opposite — one spawn attempt per (pr, head_sha). The EffectiveMaxRetries method's negative-value branch is also dead code for any config that goes through the parser.

internal/config/config.go — the MaxRetries parse-time default and the EffectiveMaxRetries method need to be reconciled so that max_retries=0 behaves as documented.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds SupervisorReviewRepairConfig with documented support for max_retries=0 to disable spawning, but parse() converts 0→1, making that disable path unreachable. |
| internal/supervisor/review_repair.go | New file implementing the full auto review-repair pipeline: eligibility check, decision building, prompt formatting, and stuck-state helpers. Logic is sound and well-tested. |
| internal/orchestrator/orchestrator.go | Adds supervisorSelectedReviewRepair, tryClaimReviewRepairSlot, and hasEffectiveApprovalForDecision; extends supervisorSelectedRepairSpawn to cover both spawn_repair_worker and spawn_review_repair with cautious-gate approval checking. |
| internal/state/state.go | Adds ReviewRepairTracks map, ReviewRepairTrack/SupervisorReviewRepairPayload/SupervisorReviewFinding types, and HeadSHA to SupervisorTarget; approvalTargetsEqual now includes HeadSHA in identity for spawn_review_repair dedup. |
| internal/supervisor/supervisor.go | Adds ActionSpawnReviewRepair constant, prHighSeverityReviewReader interface, and wires evaluateAutoReviewRepair into decideDeterministic before the existing repair-spawn branch. |
| internal/github/github.go | Adds PRHighSeverityReviewOnHead returning the head SHA and filtered list of P0/P1 Greptile inline comments still on that head. |
| internal/approver/executor.go | Adds spawn_review_repair case returning ApprovalStatusAwaitingDispatch with a PR-scoped summary; mirrors the existing spawn_worker shape. |
| internal/server/actions.go | Adds spawn_review_repair to isApprovalRequiredAction and validates pr_number is present in validateApprovalRequest. |
| internal/server/server.go | Adds StuckReviewRepairSpawned and StuckReviewRepairExhausted to the supervisorStuckNeedsAttention switch so both codes surface as attention items in the dashboard. |
| internal/approver/registry.go | Registers spawn_review_repair in KnownApprovalActions; alignment-only reformatting of existing entries. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/config/config.go:187-192
**`max_retries: 0` silently becomes 1, contradicting the field's own docs**

The field comment says "Set 0 to disable spawning entirely," but `parse()` (line 865–867) unconditionally replaces any `MaxRetries == 0` with `1`, so an operator who sets `max_retries: 0` in their YAML will still get one auto-repair attempt per `(pr, head_sha)` — the opposite of the documented intent. `EffectiveMaxRetries()` also dead-codes the `r.MaxRetries < 0 → return 0` branch because `parse()` has already resolved `0` before callers reach the method. The only reliable disable path is `enabled: false`, but the public API promises a `0`-budget path that doesn't exist.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(supervisor,approver,state): auto re..."](https://github.com/befeast/maestro/commit/8b4d7c081c80d851bac2074e0bf9bff481a6a2fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35042836)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->