### PR TITLE
Fleet snapshot mis-reports attention (stale dead sessions surfaced as live; retry-exhausted open PR omitted) + project prs_open/workers_running null

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -354,20 +354,27 @@ type fleetOperatorState struct {
 }
 
 type fleetSummary struct {
-	Projects            int   `json:"projects"`
-	Stale               int   `json:"stale"`
-	Errors              int   `json:"errors"`
-	Active              int   `json:"active"`
-	MonitoringPR        int   `json:"monitoring_pr"`
-	DispatchPending     int   `json:"dispatch_pending"`
-	DispatchFailures    int   `json:"dispatch_failures"`
-	QueueBlocked        int   `json:"queue_blocked"`
-	NoEligibleIssues    int   `json:"no_eligible_issues"`
-	OutcomeMissing      int   `json:"outcome_missing"`
-	OutcomeDrift        int   `json:"outcome_drift"`
-	StaleWorkers        int   `json:"stale_workers"`
-	Running             int   `json:"running"`
-	PROpen              int   `json:"pr_open"`
+	Projects         int `json:"projects"`
+	Stale            int `json:"stale"`
+	Errors           int `json:"errors"`
+	Active           int `json:"active"`
+	MonitoringPR     int `json:"monitoring_pr"`
+	DispatchPending  int `json:"dispatch_pending"`
+	DispatchFailures int `json:"dispatch_failures"`
+	QueueBlocked     int `json:"queue_blocked"`
+	NoEligibleIssues int `json:"no_eligible_issues"`
+	OutcomeMissing   int `json:"outcome_missing"`
+	OutcomeDrift     int `json:"outcome_drift"`
+	StaleWorkers     int `json:"stale_workers"`
+	Running          int `json:"running"`
+	PROpen           int `json:"pr_open"`
+	// PRsOpen / WorkersRunning are truth-table mirrors expected by the
+	// SPA (#566). PRsOpen extends pr_open with retry_exhausted /
+	// failed / conflict_failed sessions whose PR is still open;
+	// WorkersRunning mirrors `running` under the stable field name the
+	// project card reads. Plain ints — never null.
+	PRsOpen             int   `json:"prs_open"`
+	WorkersRunning      int   `json:"workers_running"`
 	Failed              int   `json:"failed"`
 	Sessions            int   `json:"sessions"`
 	NeedsAttention      int   `json:"needs_attention"`
@@ -420,11 +427,22 @@ type fleetProjectState struct {
 	RestartRequired       bool   `json:"restart_required,omitempty"`
 	RestartRequiredReason string `json:"restart_required_reason,omitempty"`
 
-	OperatorState   fleetOperatorState    `json:"operator_state"`
-	Outcome         outcome.Status        `json:"outcome"`
-	Summary         map[string]int        `json:"summary"`
-	Running         int                   `json:"running"`
-	PROpen          int                   `json:"pr_open"`
+	OperatorState fleetOperatorState `json:"operator_state"`
+	Outcome       outcome.Status     `json:"outcome"`
+	Summary       map[string]int     `json:"summary"`
+	Running       int                `json:"running"`
+	PROpen        int                `json:"pr_open"`
+	// PRsOpen is the truthful count of open PRs for this project,
+	// including retry_exhausted (or otherwise terminal) sessions whose
+	// linked PR is still open and gate-blocked (#564). When the latest
+	// supervisor decision reports ProjectState.OpenPRs (the GitHub
+	// truth), that value is preferred over session-derived counts. The
+	// field is a plain int so it is never null (#566).
+	PRsOpen int `json:"prs_open"`
+	// WorkersRunning mirrors Running with a stable field name expected
+	// by the SPA project card (#566). It is the count of sessions in
+	// StatusRunning. Always non-null.
+	WorkersRunning  int                   `json:"workers_running"`
 	Failed          int                   `json:"failed"`
 	Sessions        int                   `json:"sessions"`
 	NeedsAttention  int                   `json:"needs_attention"`
@@ -895,6 +913,8 @@ func (s *FleetServer) snapshot() fleetResponse {
 		addFleetOperatorSummary(&resp.Summary, item.OperatorState)
 		resp.Summary.Running += item.Running
 		resp.Summary.PROpen += item.PROpen
+		resp.Summary.PRsOpen += item.PRsOpen
+		resp.Summary.WorkersRunning += item.WorkersRunning
 		resp.Summary.Failed += item.Failed
 		resp.Summary.Sessions += item.Sessions
 		resp.Summary.NeedsAttention += item.NeedsAttention
@@ -2065,6 +2085,8 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	item.Outcome = projectState.Outcome
 	item.Running = len(projectState.Running)
 	item.PROpen = len(projectState.PROpen)
+	item.WorkersRunning = item.Running
+	item.PRsOpen = fleetTruthfulOpenPRCount(projectState, st)
 	item.Failed = failedCount(projectState.Summary)
 	item.Sessions = len(projectState.All)
 	item.Supervisor = projectState.Supervisor
@@ -2943,6 +2965,48 @@ func failedCount(summary map[string]int) int {
 		summary[string(state.StatusFailed)] +
 		summary[string(state.StatusRetryExhausted)] +
 		summary[string(state.StatusConflictFailed)]
+}
+
+// fleetTruthfulOpenPRCount returns the project-level open-PR count expected
+// by the SPA project card (#566). It is broader than the legacy
+// `pr_open` (sessions in StatusPROpen): a session in StatusRetryExhausted
+// with PRNumber > 0 is exactly the "gate-blocked PR that needs a human"
+// case (#564) and must contribute to the count. When the latest supervisor
+// decision reports ProjectState.OpenPRs (the GitHub truth, populated from
+// ListOpenPRs), the larger of the two values wins so a transient session
+// drift never under-counts the dashboard while a stale supervisor decision
+// cannot over-count it.
+func fleetTruthfulOpenPRCount(projectState stateResponse, st *state.State) int {
+	count := len(projectState.PROpen)
+	if st != nil {
+		seen := make(map[int]struct{}, count)
+		for _, info := range projectState.PROpen {
+			if info.PRNumber > 0 {
+				seen[info.PRNumber] = struct{}{}
+			}
+		}
+		for _, sess := range st.Sessions {
+			if sess == nil || sess.PRNumber <= 0 {
+				continue
+			}
+			switch sess.Status {
+			case state.StatusRetryExhausted, state.StatusFailed, state.StatusConflictFailed:
+			default:
+				continue
+			}
+			if _, ok := seen[sess.PRNumber]; ok {
+				continue
+			}
+			seen[sess.PRNumber] = struct{}{}
+			count++
+		}
+	}
+	if latest := projectState.SupervisorLatest; latest != nil {
+		if latest.ProjectState.OpenPRs > count {
+			count = latest.ProjectState.OpenPRs
+		}
+	}
+	return count
 }
 
 func (s *FleetServer) handleFleetDashboard(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -2871,8 +2871,13 @@ func TestFleetAPIFiltersStaleSessionsFromAttention(t *testing.T) {
 		t.Fatalf("stale-1 status reason = %q, want reconciliation explanation", stale.StatusReason)
 	}
 
-	if !findFleetWorker(t, resp.Workers, "present-dead").NeedsAttention {
-		t.Fatalf("present-dead has a live worktree, must remain in attention")
+	// #566: a 30h-old dead worker ages past FleetAttentionTTL even when
+	// its worktree is still on disk — the reconciler keeps it in the
+	// workers list (it is not "stale session reconciled"), but the
+	// fleet-level TTL drops it from `needs_attention`. The recent-dead
+	// session (2h old) stays well inside the window.
+	if findFleetWorker(t, resp.Workers, "present-dead").NeedsAttention {
+		t.Fatalf("present-dead aged past TTL, must not remain in needs_attention")
 	}
 	if !findFleetWorker(t, resp.Workers, "recent-dead").NeedsAttention {
 		t.Fatalf("recent-dead is inside the idle window, must remain in attention")
@@ -2908,13 +2913,15 @@ func TestFleetAPIDisabledReconcilerKeepsAttention(t *testing.T) {
 	now := time.Now().UTC()
 	stateDir := filepath.Join(dir, "state")
 	missingWorktree := filepath.Join(dir, "missing-worktree")
-	finishedOld := now.Add(-30 * time.Hour)
+	// #566: keep this session well inside FleetAttentionTTL so the test
+	// exercises the reconciler-disabled path, not the TTL gate.
+	finishedRecent := now.Add(-90 * time.Minute)
 	saveFleetTestState(t, stateDir, map[string]*state.Session{
 		"stale-1": {
 			IssueNumber: 501,
 			Status:      state.StatusDead,
-			StartedAt:   finishedOld.Add(-time.Hour),
-			FinishedAt:  &finishedOld,
+			StartedAt:   finishedRecent.Add(-time.Hour),
+			FinishedAt:  &finishedRecent,
 			Worktree:    missingWorktree,
 		},
 	})
@@ -2940,6 +2947,228 @@ func TestFleetAPIDisabledReconcilerKeepsAttention(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(stateDir, "audit-log.jsonl")); !os.IsNotExist(err) {
 		t.Fatalf("disabled reconciler must not write audit entries; err = %v", err)
+	}
+}
+
+// TestFleetAPIStaleDeadSessionsAgeOutOfAttention pins the #471 regression
+// for #566: a `dead` session whose newest activity is older than
+// FleetAttentionTTL must NOT surface as `live, needs_attention`, regardless
+// of the stale-session reconciler config. The fleet verdict must stay
+// healthy when the only remaining attention candidates are stale dead
+// workers (the "Action required p1" verdict driven by 2-day-old sup-82/83/84
+// must go away).
+func TestFleetAPIStaleDeadSessionsAgeOutOfAttention(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "state")
+	// 2 days old, like the sup-82/83/84 sessions on #471.
+	finishedAncient := now.Add(-48 * time.Hour)
+	freshStarted := now.Add(-10 * time.Minute)
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"sup-82": {
+			IssueNumber: 82,
+			IssueTitle:  "Ancient dead worker on removed backend",
+			Status:      state.StatusDead,
+			Backend:     "freellm",
+			StartedAt:   finishedAncient.Add(-30 * time.Minute),
+			FinishedAt:  &finishedAncient,
+		},
+		"sup-83": {
+			IssueNumber: 83,
+			IssueTitle:  "Ancient dead worker (failed)",
+			Status:      state.StatusFailed,
+			StartedAt:   finishedAncient.Add(-30 * time.Minute),
+			FinishedAt:  &finishedAncient,
+		},
+		"sup-84": {
+			IssueNumber: 84,
+			IssueTitle:  "Ancient dead worker (conflict_failed)",
+			Status:      state.StatusConflictFailed,
+			StartedAt:   finishedAncient.Add(-30 * time.Minute),
+			FinishedAt:  &finishedAncient,
+		},
+		"fresh-done": {
+			IssueNumber: 90,
+			IssueTitle:  "Recently completed worker",
+			Status:      state.StatusDone,
+			StartedAt:   freshStarted.Add(-30 * time.Minute),
+			FinishedAt:  fleetTimePtr(freshStarted),
+		},
+	})
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("maestro", "/tmp/maestro.yaml", "", &config.Config{
+			Repo:        "befeast/maestro",
+			StateDir:    stateDir,
+			MaxParallel: 4,
+		}),
+	}, "127.0.0.1", 8786, true)
+	resp := srv.snapshot()
+
+	for _, slot := range []string{"sup-82", "sup-83", "sup-84"} {
+		worker := findFleetWorker(t, resp.Workers, slot)
+		if worker.NeedsAttention {
+			t.Fatalf("%s aged past TTL but still needs_attention: %+v", slot, worker)
+		}
+		if worker.Live {
+			t.Fatalf("%s aged past TTL but still Live=true: %+v", slot, worker)
+		}
+	}
+	for _, w := range resp.Attention {
+		switch w.Slot {
+		case "sup-82", "sup-83", "sup-84":
+			t.Fatalf("stale dead worker %s leaked into attention[]", w.Slot)
+		}
+	}
+	project := findFleetProject(t, resp.Projects, "maestro")
+	if project.NeedsAttention != 0 {
+		t.Fatalf("project needs_attention = %d, want 0 (stale dead sessions must not count)", project.NeedsAttention)
+	}
+}
+
+// TestFleetAPIRetryExhaustedWithOpenPRStaysActionable pins the #564 regression
+// for #566: a retry_exhausted session whose linked PR is still open is
+// always actionable regardless of age. The fleet verdict must stay
+// `attention` and the PR must surface in attention[].
+func TestFleetAPIRetryExhaustedWithOpenPRStaysActionable(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "state")
+	// 2 days old, like PR #564 in the dogfood log.
+	finishedAncient := now.Add(-48 * time.Hour)
+	saveFleetTestSnapshot(t, stateDir, map[string]*state.Session{
+		"sup-stuck": {
+			IssueNumber:        442,
+			IssueTitle:         "Greptile P1 retry-exhausted with open PR",
+			Status:             state.StatusRetryExhausted,
+			PRNumber:           564,
+			StartedAt:          finishedAncient.Add(-time.Hour),
+			FinishedAt:         &finishedAncient,
+			LastNotifiedStatus: "review_retry_exhausted",
+		},
+	}, []state.SupervisorDecision{
+		{
+			ID:                "dec-recent",
+			CreatedAt:         now.Add(-1 * time.Minute),
+			Project:           "maestro",
+			RecommendedAction: "monitor_open_pr",
+			Risk:              "safe",
+		},
+	})
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("maestro", "/tmp/maestro.yaml", "", &config.Config{
+			Repo:        "befeast/maestro",
+			StateDir:    stateDir,
+			MaxParallel: 4,
+		}),
+	}, "127.0.0.1", 8786, true)
+	resp := srv.snapshot()
+
+	stuck := findFleetWorker(t, resp.Workers, "sup-stuck")
+	if !stuck.NeedsAttention {
+		t.Fatalf("retry_exhausted with open PR must keep needs_attention regardless of age: %+v", stuck)
+	}
+	if !stuck.Live {
+		t.Fatalf("retry_exhausted with open PR must stay Live: %+v", stuck)
+	}
+	if stuck.PRNumber != 564 {
+		t.Fatalf("attention worker PR = %d, want 564", stuck.PRNumber)
+	}
+
+	foundInAttention := false
+	for _, w := range resp.Attention {
+		if w.Slot == "sup-stuck" {
+			foundInAttention = true
+			break
+		}
+	}
+	if !foundInAttention {
+		t.Fatalf("retry_exhausted with open PR must appear in attention[]: %+v", resp.Attention)
+	}
+
+	project := findFleetProject(t, resp.Projects, "maestro")
+	if project.PRsOpen < 1 {
+		t.Fatalf("project.prs_open = %d, want >=1 (retry_exhausted PR counts as open)", project.PRsOpen)
+	}
+	if resp.Summary.NeedsAttention < 1 {
+		t.Fatalf("summary needs_attention = %d, want >=1", resp.Summary.NeedsAttention)
+	}
+	if resp.Verdict.Tone != "attention" {
+		t.Fatalf("verdict tone = %q, want attention (stuck PR is exactly attention)", resp.Verdict.Tone)
+	}
+}
+
+// TestFleetAPIProjectCountersNonNull pins the #566 contract: per-project
+// prs_open and workers_running are plain ints that always serialise as
+// numbers — never null — so the SPA project card never falls back to
+// "PRS OPEN 0 / WORKERS 0" because of a missing key.
+func TestFleetAPIProjectCountersNonNull(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "state")
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"slot-running": {
+			IssueNumber: 1,
+			IssueTitle:  "Running",
+			Status:      state.StatusRunning,
+			StartedAt:   now.Add(-5 * time.Minute),
+		},
+		"slot-pr-open": {
+			IssueNumber: 2,
+			IssueTitle:  "Waiting on PR",
+			Status:      state.StatusPROpen,
+			PRNumber:    100,
+			StartedAt:   now.Add(-30 * time.Minute),
+		},
+		"slot-retry-pr": {
+			IssueNumber: 3,
+			IssueTitle:  "Retry exhausted with PR still open",
+			Status:      state.StatusRetryExhausted,
+			PRNumber:    101,
+			StartedAt:   now.Add(-10 * time.Minute),
+		},
+	})
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("maestro", "/tmp/maestro.yaml", "", &config.Config{
+			Repo:        "befeast/maestro",
+			StateDir:    stateDir,
+			MaxParallel: 4,
+		}),
+	}, "127.0.0.1", 8786, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleet(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+
+	// The raw JSON must include the keys with numeric values — `null`
+	// fails the contract.
+	body := w.Body.String()
+	if !strings.Contains(body, `"prs_open":`) {
+		t.Fatalf("response missing prs_open key: %s", body)
+	}
+	if !strings.Contains(body, `"workers_running":`) {
+		t.Fatalf("response missing workers_running key: %s", body)
+	}
+	if strings.Contains(body, `"prs_open":null`) || strings.Contains(body, `"workers_running":null`) {
+		t.Fatalf("counters must never be null: %s", body)
+	}
+
+	var resp fleetResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	project := findFleetProject(t, resp.Projects, "maestro")
+	if project.WorkersRunning != 1 {
+		t.Fatalf("workers_running = %d, want 1", project.WorkersRunning)
+	}
+	// PRsOpen includes both StatusPROpen and retry_exhausted-with-PR.
+	if project.PRsOpen < 2 {
+		t.Fatalf("prs_open = %d, want >=2 (StatusPROpen + retry_exhausted with PR)", project.PRsOpen)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -336,6 +336,16 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 	info.NextAction = attention.NextAction
 	info.NeedsAttention = attention.NeedsAttention
 
+	// #566: an old dead / failed / conflict_failed worker is reconcilable,
+	// not actionable. Drop `needs_attention` and the derived `live` flag
+	// once the session ages past FleetAttentionTTL so a 2-day-old zombie
+	// session cannot dominate the fleet verdict. retry_exhausted with an
+	// open PR (#564) and any session with a scheduled retry stay live.
+	if attention.NeedsAttention && !state.SessionAttentionActionableAt(sess, now) {
+		info.NeedsAttention = false
+		info.Live = false
+	}
+
 	return info
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2145,12 +2145,64 @@ func SessionLiveAt(sess *Session, now time.Time) bool {
 		return true
 	}
 
-	if SessionAttentionForAt(sess, nil, now).NeedsAttention {
+	if SessionAttentionForAt(sess, nil, now).NeedsAttention && SessionAttentionActionableAt(sess, now) {
 		return true
 	}
 
 	changedAt := SessionChangedAt(sess)
 	return !changedAt.IsZero() && now.Sub(changedAt.UTC()) <= LiveSessionRecentWindow
+}
+
+// FleetAttentionTTL is the freshness window during which a non-progressing
+// session (dead, failed, conflict_failed, or retry_exhausted without an open
+// PR) still counts as actionable operator attention. Older sessions are
+// reconcilable/archivable, not actionable, and must not be surfaced as
+// `live, needs_attention` on the fleet snapshot (#566).
+const FleetAttentionTTL = 24 * time.Hour
+
+// SessionAttentionActionableAt reports whether a session that
+// SessionAttentionForAt classifies as needs_attention is still inside the
+// actionable window for fleet surfaces.
+//
+// A retry_exhausted session that still has an open PR (PRNumber > 0) is
+// always actionable: a green-but-gate-blocked PR with no respawn is exactly
+// what a human needs to look at (#564). A session with a scheduled retry
+// (NextRetryAt set) is also always actionable. Beyond those, dead / failed /
+// conflict_failed / retry_exhausted-without-PR sessions age out after
+// FleetAttentionTTL so a deploy 2 days ago cannot dominate the verdict.
+//
+// Statuses that intrinsically represent live work (running, pr_open, queued)
+// are always actionable for as long as the session exists; they are not the
+// "stale dead worker" failure mode this gate guards against.
+func SessionAttentionActionableAt(sess *Session, now time.Time) bool {
+	return sessionAttentionActionableAt(sess, now, FleetAttentionTTL)
+}
+
+func sessionAttentionActionableAt(sess *Session, now time.Time, ttl time.Duration) bool {
+	if sess == nil {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	switch sess.Status {
+	case StatusRunning, StatusPROpen, StatusQueued, StatusCodeLanded:
+		return true
+	}
+	if sess.NextRetryAt != nil {
+		return true
+	}
+	if sess.Status == StatusRetryExhausted && sess.PRNumber > 0 {
+		return true
+	}
+	if ttl <= 0 {
+		return true
+	}
+	changedAt := SessionChangedAt(sess)
+	if changedAt.IsZero() {
+		return true
+	}
+	return now.Sub(changedAt) <= ttl
 }
 
 // SessionChangedAt returns the newest persisted activity timestamp for a session.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -773,13 +773,13 @@ func TestFailedAttemptsForIssue(t *testing.T) {
 	s := NewState()
 	s.Sessions["slot-1"] = &Session{IssueNumber: 42, Status: StatusDead, PRNumber: 0}
 	s.Sessions["slot-2"] = &Session{IssueNumber: 42, Status: StatusFailed, PRNumber: 0}
-	s.Sessions["slot-3"] = &Session{IssueNumber: 42, Status: StatusDone, PRNumber: 10}                   // success — not counted
-	s.Sessions["slot-4"] = &Session{IssueNumber: 42, Status: StatusDead, PRNumber: 5}                    // has PR — not counted
-	s.Sessions["slot-5"] = &Session{IssueNumber: 42, Status: StatusRetryExhausted, PRNumber: 0}          // counted
-	s.Sessions["slot-6"] = &Session{IssueNumber: 99, Status: StatusDead, PRNumber: 0}                    // different issue
-	s.Sessions["slot-7"] = &Session{IssueNumber: 42, Status: StatusRunning, PRNumber: 0, StartedAt: now} // running — not counted
-	s.Sessions["slot-8"] = &Session{IssueNumber: 42, Status: StatusConflictFailed, PRNumber: 0}          // conflict — not counted
-	s.Sessions["slot-9"] = &Session{IssueNumber: 42, Status: StatusDead, PRNumber: 0, RateLimitHit: true}    // rate-limited — not counted (#466)
+	s.Sessions["slot-3"] = &Session{IssueNumber: 42, Status: StatusDone, PRNumber: 10}                    // success — not counted
+	s.Sessions["slot-4"] = &Session{IssueNumber: 42, Status: StatusDead, PRNumber: 5}                     // has PR — not counted
+	s.Sessions["slot-5"] = &Session{IssueNumber: 42, Status: StatusRetryExhausted, PRNumber: 0}           // counted
+	s.Sessions["slot-6"] = &Session{IssueNumber: 99, Status: StatusDead, PRNumber: 0}                     // different issue
+	s.Sessions["slot-7"] = &Session{IssueNumber: 42, Status: StatusRunning, PRNumber: 0, StartedAt: now}  // running — not counted
+	s.Sessions["slot-8"] = &Session{IssueNumber: 42, Status: StatusConflictFailed, PRNumber: 0}           // conflict — not counted
+	s.Sessions["slot-9"] = &Session{IssueNumber: 42, Status: StatusDead, PRNumber: 0, RateLimitHit: true} // rate-limited — not counted (#466)
 
 	if got := s.FailedAttemptsForIssue(42); got != 3 {
 		t.Errorf("FailedAttemptsForIssue(42) = %d, want 3", got)
@@ -1175,6 +1175,78 @@ func TestSessionLiveAt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := SessionLiveAt(tt.sess, now); got != tt.want {
 				t.Fatalf("SessionLiveAt = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSessionAttentionActionableAt pins the #566 TTL semantics:
+// dead/failed/conflict_failed sessions without a scheduled retry age out
+// of attention after FleetAttentionTTL; retry_exhausted with an open PR
+// stays actionable regardless of age; live-status sessions are always
+// actionable.
+func TestSessionAttentionActionableAt(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	fresh := now.Add(-1 * time.Hour)
+	stale := now.Add(-FleetAttentionTTL - time.Hour)
+	future := now.Add(15 * time.Minute)
+
+	tests := []struct {
+		name string
+		sess *Session
+		want bool
+	}{
+		{
+			name: "running session is always actionable",
+			sess: &Session{Status: StatusRunning, StartedAt: stale},
+			want: true,
+		},
+		{
+			name: "pr_open session is always actionable",
+			sess: &Session{Status: StatusPROpen, StartedAt: stale, PRNumber: 1},
+			want: true,
+		},
+		{
+			name: "dead with scheduled retry is actionable",
+			sess: &Session{Status: StatusDead, StartedAt: stale, FinishedAt: &stale, NextRetryAt: &future},
+			want: true,
+		},
+		{
+			name: "fresh dead session is actionable",
+			sess: &Session{Status: StatusDead, StartedAt: fresh, FinishedAt: &fresh},
+			want: true,
+		},
+		{
+			name: "stale dead session ages out",
+			sess: &Session{Status: StatusDead, StartedAt: stale, FinishedAt: &stale},
+			want: false,
+		},
+		{
+			name: "stale failed session ages out",
+			sess: &Session{Status: StatusFailed, StartedAt: stale, FinishedAt: &stale},
+			want: false,
+		},
+		{
+			name: "stale conflict_failed session ages out",
+			sess: &Session{Status: StatusConflictFailed, StartedAt: stale, FinishedAt: &stale},
+			want: false,
+		},
+		{
+			name: "retry_exhausted with open PR never ages out",
+			sess: &Session{Status: StatusRetryExhausted, StartedAt: stale, FinishedAt: &stale, PRNumber: 564},
+			want: true,
+		},
+		{
+			name: "retry_exhausted without PR ages out",
+			sess: &Session{Status: StatusRetryExhausted, StartedAt: stale, FinishedAt: &stale},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SessionAttentionActionableAt(tt.sess, now); got != tt.want {
+				t.Fatalf("SessionAttentionActionableAt = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Refs #566

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two fleet snapshot mis-reporting bugs: stale `dead`/`failed` sessions older than 24 hours were surfacing as `live, needs_attention` (dominating the fleet verdict), and `retry_exhausted` sessions whose PR was still open were omitted from `prs_open`. It also converts `prs_open` and `workers_running` from `*int` to plain `int` so the SPA project card never receives `null`.

- `SessionAttentionActionableAt` introduces a 24-hour TTL gate: `dead`/`failed`/`conflict_failed`/`retry_exhausted`-without-PR sessions age out of attention, while `retry_exhausted`+open PR and sessions with a scheduled retry remain permanently actionable.
- `fleetTruthfulOpenPRCount` broadens `prs_open` beyond `StatusPROpen` to include terminal sessions with `PRNumber > 0`, then takes `max(session-derived, supervisor.OpenPRs)` as the authoritative count.
- Three new regression tests pin the TTL aging, the retry-exhausted-PR actionability, and the non-null counter contract; two existing tests are corrected to match the updated TTL semantics.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core TTL gate and null-fix changes are well-tested and address the described regressions without touching other critical paths.

The TTL logic in `SessionAttentionActionableAt` and the `server.go` override are correct and mutually consistent. The one wrinkle is in `fleetTruthfulOpenPRCount`: old `StatusFailed`/`StatusConflictFailed` sessions whose PRs have since been closed can permanently inflate `prs_open` because the `max(session, supervisor)` tiebreaker cannot correct a session-derived count that is already higher than the actual GitHub count. This is a display-only concern (it does not affect the attention verdict) but could mislead operators watching the project card counters.

`internal/server/fleet.go` — specifically the `fleetTruthfulOpenPRCount` function and its handling of aged-out failed/conflict-failed sessions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Introduces `FleetAttentionTTL`, `SessionAttentionActionableAt`, and an updated `SessionLiveAt` that gates the attention path through the new TTL check; logic is sound and well-tested |
| internal/server/fleet.go | Adds `PRsOpen`/`WorkersRunning` int fields (fixing null serialization), and `fleetTruthfulOpenPRCount` which conservatively overcounts `prs_open` for aged-out failed/conflict-failed sessions whose PRs may be closed |
| internal/server/server.go | Adds TTL gate in `makeSessionInfo` that clears `NeedsAttention` and `Live` for aged-out sessions; logically correct and consistent with `SessionLiveAt` |
| internal/server/fleet_test.go | Adds three new regression tests pinning the TTL aging, retry-exhausted open-PR actionability, and non-null counter contracts; also fixes two existing tests to match the new TTL semantics |
| internal/state/state_test.go | Adds `TestSessionAttentionActionableAt` covering all TTL edge cases; only other change is alignment whitespace in an existing test |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/server/fleet.go:2992-3009
**`prs_open` can permanently overcount when old failed/conflict-failed PRs are closed**

`fleetTruthfulOpenPRCount` adds any `StatusFailed` or `StatusConflictFailed` session with `PRNumber > 0` to the count unconditionally — no TTL filter. If a human merges/closes one of those PRs and the supervisor decision's `ProjectState.OpenPRs` value is *lower* than the session-derived count, the `max(session, supervisor)` tiebreaker keeps the higher (now stale) session value, so the overcounting is never corrected until the state is pruned. `StatusRetryExhausted` with a PR is intentionally permanent (those PRs are genuinely open), but `StatusFailed`/`StatusConflictFailed` sessions are aged out of `needs_attention` after `FleetAttentionTTL` — applying the same TTL guard before incrementing `count` for those two statuses would keep `prs_open` consistent with the attention verdict.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(fleet,state): age out stale dead wor..."](https://github.com/befeast/maestro/commit/fdcd724925052ccb6158a288586b6426ace45fc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35046615)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->