### PR TITLE
dependency-unblock: blocked wave members not enrolled onto Project board when max_runnable cap is reached

### DIFF
--- a/internal/supervisor/dependency_unblock.go
+++ b/internal/supervisor/dependency_unblock.go
@@ -82,16 +82,6 @@ func (e *Engine) evaluateDependencyUnblock(st *state.State, issues []github.Issu
 		return nil
 	}
 
-	// Respect max_runnable: we count current ready-labeled open issues so
-	// that supervising the wave never grows the runnable pool past the
-	// operator cap. Ordered/dynamic wave concurrency lives elsewhere; this
-	// cap is specific to the dependency-unblock controller.
-	if cap := unblockCfg.MaxRunnable; cap > 0 {
-		if currentlyReady := countOpenIssuesWithLabel(issues, readyLabel); currentlyReady >= cap {
-			return nil
-		}
-	}
-
 	candidates := blockedWaveMembers(issues, blockedLabel)
 	if len(candidates) == 0 {
 		return nil
@@ -99,12 +89,25 @@ func (e *Engine) evaluateDependencyUnblock(st *state.State, issues []github.Issu
 
 	// Project enrollment side-effect: surface blocked wave members on the
 	// configured GitHub Project so operators see the upcoming wave even
-	// before any one item is unblocked. Errors are best-effort.
+	// before any one item is unblocked. Errors are best-effort. Runs ahead
+	// of the max_runnable gate so an at-cap pool does not silently hide the
+	// upcoming wave from operators (issue #568).
 	enrolled := e.enrollBlockedWaveMembers(candidates)
 	if len(enrolled) > 0 {
 		baseReasons = appendReasons(baseReasons,
 			fmt.Sprintf("Enrolled %d blocked wave member(s) onto GitHub Project: %s", len(enrolled), dependencyRefs(enrolled)),
 		)
+	}
+
+	// Respect max_runnable: we count current ready-labeled open issues so
+	// that supervising the wave never grows the runnable pool past the
+	// operator cap. Ordered/dynamic wave concurrency lives elsewhere; this
+	// cap is specific to the dependency-unblock controller. Gated AFTER
+	// enrollment so visibility still happens when the pool is at cap.
+	if cap := unblockCfg.MaxRunnable; cap > 0 {
+		if currentlyReady := countOpenIssuesWithLabel(issues, readyLabel); currentlyReady >= cap {
+			return nil
+		}
 	}
 
 	for _, issue := range candidates {

--- a/internal/supervisor/dependency_unblock_test.go
+++ b/internal/supervisor/dependency_unblock_test.go
@@ -261,6 +261,42 @@ func TestEvaluate_MaxRunnableCapPreventsExtraUnblocks(t *testing.T) {
 	}
 }
 
+// Test: cap reached → enrollment still happens, but no unblock (issue #568) -
+
+func TestEvaluate_MaxRunnableCapStillEnrollsBlockedWaveMembers(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	cfg.Supervisor.DynamicWave.DependencyUnblock.MaxRunnable = 1
+	cfg.GitHubProjects.Enabled = true
+	cfg.GitHubProjects.ProjectNumber = 7
+
+	// Pool already at cap (one ready-labeled issue). #148 is the next blocked
+	// wave member with a resolved dep — supervisor must not unblock it, but
+	// must still enroll it onto the Project board so operators see the
+	// upcoming wave even when the runnable pool is saturated.
+	already := testIssue(140, "already runnable", "maestro-ready")
+	pending := blockedIssue(148, []int{147})
+	reader := &fakeReader{
+		issues:       []github.Issue{already, pending},
+		closedIssues: map[int]bool{147: true},
+	}
+
+	enroller := &fakeEnroller{}
+	eng := testEngine(cfg, reader)
+	eng.SetProjectEnroller(enroller)
+	decision, err := eng.Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == ActionUnblockIssue {
+		t.Fatalf("action = %q, want NOT unblock_issue (cap reached)", decision.RecommendedAction)
+	}
+	if !equalInts(enroller.enrolled, []int{148}) {
+		t.Fatalf("enrolled = %v, want [148] (visibility must happen even at cap)", enroller.enrolled)
+	}
+}
+
 // Test: idempotency — once recorded as succeeded, no duplicate mutation ----
 
 func TestEvaluate_DoesNotRecommendDuplicateUnblockAfterSuccess(t *testing.T) {


### PR DESCRIPTION
Refs #568

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issue #568 by reordering two blocks inside `evaluateDependencyUnblock`: Project-board enrollment is now executed before the `max_runnable` capacity gate, so blocked wave members are always surfaced to operators even when the runnable pool is full.

- `dependency_unblock.go`: `enrollBlockedWaveMembers` is called immediately after candidates are identified, before the `MaxRunnable >= currentlyReady` early-return; the cap gate continues to prevent label mutations.
- `dependency_unblock_test.go`: a new test (`TestEvaluate_MaxRunnableCapStillEnrollsBlockedWaveMembers`) verifies that with cap=1 and the pool full, the engine does not emit `unblock_issue` but does enroll issue #148 onto the Project board.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the reordering is a targeted, well-tested change with no impact on label mutations or decision output.

The only behavioural change is that `enrollBlockedWaveMembers` now runs unconditionally when candidates exist, before the capacity gate. Enrollment is explicitly a best-effort side-effect with no mutation impact, and the new test directly exercises the at-cap enrollment path. All pre-existing tests still pass against the reordered logic.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/dependency_unblock.go | Moves the `enrollBlockedWaveMembers` call ahead of the `max_runnable` cap gate so Project-board visibility always happens even when the pool is saturated; logic is sound and idiomatic. |
| internal/supervisor/dependency_unblock_test.go | Adds `TestEvaluate_MaxRunnableCapStillEnrollsBlockedWaveMembers` to cover the at-cap enrollment path; test setup mirrors the existing enrollment and cap tests and correctly asserts both the no-unblock and the enrollment side-effect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(supervisor): enroll blocked wave mem..."](https://github.com/befeast/maestro/commit/8487caa4414f7bfa879ec87f8a931181c2c3ba22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35048426)</sub>

<!-- /greptile_comment -->