### PR TITLE
Already-done / no-PR issue halts the dynamic-wave queue (retry_exhausted with PR #0 → 'waiting for reconciliation' forever)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2120,6 +2120,19 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		pr, found := mergeFlowPRForSession(sess, branchToPR, numberToPR)
 		if !found {
 			if sess.Status == state.StatusRetryExhausted {
+				if sess.PRNumber == 0 {
+					// #577: worker exhausted retries without ever producing a PR
+					// (e.g. the issue was already implemented by a prior merge via
+					// `Refs #N`, so the worker found zero diff). Without action the
+					// orchestrator would log "waiting for reconciliation" forever
+					// and the dynamic-wave queue would halt at max_parallel=1.
+					// Reconcile once: either close the issue (when a merged PR
+					// already closes it and auto-close is allowed) or label it
+					// blocked so the supervisor's dynamic-wave drops it and picks
+					// the next eligible candidate.
+					o.reconcileNoPRRetryExhausted(slotName, sess)
+					continue
+				}
 				log.Printf("[orch] retry_exhausted session %s records PR #%d, but no open PR was found — waiting for reconciliation", slotName, sess.PRNumber)
 				continue
 			}
@@ -2311,6 +2324,91 @@ func mergeFlowPRForSession(sess *state.Session, byBranch map[string]github.PR, b
 		}
 	}
 	return github.PR{}, false
+}
+
+// noPRReconciledStatus marks a retry_exhausted session whose worker never
+// produced a PR as having been reconciled by autoMergePRs. The marker keeps
+// the reconciliation idempotent so subsequent cycles do not re-label, re-close,
+// or re-notify, and so the "waiting for reconciliation" log stops firing.
+const noPRReconciledStatus = "no_pr_reconciled"
+
+// reconcileNoPRRetryExhausted handles the #577 deadlock: a worker exhausted
+// retries without opening a PR (often because the issue was already
+// implemented by a prior merge via `Refs #N`), so the merge flow has nothing
+// to advance, the session is terminal, and at max_parallel=1 the dynamic-wave
+// queue halts. This helper runs once per session: it auto-closes the issue
+// when a merged PR already closes it (and close_issue is a configured safe
+// action), otherwise it adds the configured blocked label so the supervisor
+// drops the issue from the wave and selects the next eligible candidate.
+func (o *Orchestrator) reconcileNoPRRetryExhausted(slotName string, sess *state.Session) {
+	if sess == nil || sess.IssueNumber <= 0 {
+		return
+	}
+	if sess.LastNotifiedStatus == noPRReconciledStatus {
+		// Already reconciled — suppress duplicate side-effects and the
+		// "waiting for reconciliation" log spam.
+		return
+	}
+
+	merged, err := o.hasMergedPRForIssue(sess.IssueNumber)
+	if err != nil {
+		// Don't mark reconciled on transient GitHub failure; try again next
+		// cycle. Log so operators can correlate with API errors.
+		log.Printf("[orch] no-PR retry_exhausted: could not check merged PR for issue #%d (slot %s): %v", sess.IssueNumber, slotName, err)
+		return
+	}
+
+	if merged {
+		// The work was already landed by another PR (closing-keyword link).
+		// Auto-close when the operator has granted close_issue as a safe
+		// action without an approval gate; otherwise surface it as a
+		// close-candidate via notification.
+		comment := fmt.Sprintf("Maestro: closing this issue because worker session %s exhausted retries without producing a PR (the work appears to be implemented by an already-merged PR).", slotName)
+		if o.supervisorActionAllowed(config.SupervisorActionCloseIssue) && !o.supervisorActionRequiresApproval(config.SupervisorActionCloseIssue) {
+			if cerr := o.closeIssue(sess.IssueNumber, comment); cerr != nil {
+				log.Printf("[orch] no-PR retry_exhausted: auto-close failed for issue #%d (slot %s): %v", sess.IssueNumber, slotName, cerr)
+				if o.notifier != nil {
+					o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted with no PR (work appears merged); auto-close failed: %v", sess.IssueNumber, cerr)
+				}
+				return
+			}
+			log.Printf("[orch] no-PR retry_exhausted: auto-closed issue #%d (slot %s) — merged PR already implements it", sess.IssueNumber, slotName)
+			if o.notifier != nil {
+				o.notifier.Sendf("✅ maestro: closed issue #%d after retry_exhausted with no PR (already implemented by a merged PR)", sess.IssueNumber)
+			}
+			o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
+		} else {
+			log.Printf("[orch] no-PR retry_exhausted: issue #%d (slot %s) has a merged PR — surfaced as operator close-candidate", sess.IssueNumber, slotName)
+			if o.notifier != nil {
+				o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted with no PR; a merged PR already implements it — operator close-candidate", sess.IssueNumber)
+			}
+		}
+	} else {
+		// No merged PR detected — apply the configured blocked label so the
+		// supervisor's dynamic-wave skips this issue on the next cycle and
+		// the run-loop advances to the next eligible candidate.
+		if blockedLabel := strings.TrimSpace(o.cfg.Supervisor.BlockedLabel); blockedLabel != "" {
+			if lerr := o.addIssueLabel(sess.IssueNumber, blockedLabel); lerr != nil {
+				log.Printf("[orch] no-PR retry_exhausted: could not add %q label to issue #%d (slot %s): %v", blockedLabel, sess.IssueNumber, slotName, lerr)
+				if o.notifier != nil {
+					o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted with no PR; could not apply %q label: %v", sess.IssueNumber, blockedLabel, lerr)
+				}
+				return
+			}
+			log.Printf("[orch] no-PR retry_exhausted: labelled issue #%d %q (slot %s, no PR produced and no merged PR detected)", sess.IssueNumber, blockedLabel, slotName)
+		} else {
+			log.Printf("[orch] no-PR retry_exhausted: issue #%d (slot %s) produced no PR and no merged PR detected — operator review required (no blocked_label configured)", sess.IssueNumber, slotName)
+		}
+		if o.notifier != nil {
+			o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted with no PR — needs operator review", sess.IssueNumber)
+		}
+		o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
+	}
+
+	// Mark the session reconciled so future cycles short-circuit. The status
+	// stays retry_exhausted (terminal) but the marker prevents repeated
+	// labels, close attempts, or notifications.
+	sess.LastNotifiedStatus = noPRReconciledStatus
 }
 
 // handleReviewFeedbackRetry schedules a retry worker with review feedback in

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -7987,3 +7987,204 @@ func TestMergeReadyPR_BehindBaseNoWorktreeFallsBackToUpdateBranch(t *testing.T) 
 		t.Fatalf("status = %q, want queued for re-validation after update-branch", sess.Status)
 	}
 }
+
+// #577: a worker that exhausts retries without ever opening a PR (e.g. because
+// the issue was already implemented by a prior `Refs #N` merge) used to leave
+// autoMergePRs logging "waiting for reconciliation" every cycle with no
+// recovery action, halting the dynamic-wave queue at max_parallel=1. The
+// reconciler must apply the configured blocked label so the supervisor's
+// dynamic-wave drops the issue and selects the next candidate.
+func TestAutoMergePRs_NoPRRetryExhaustedAppliesBlockedLabel(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Supervisor: config.SupervisorConfig{
+			BlockedLabel: "blocked",
+		},
+	}
+	addedLabels := make(map[int]string)
+	o := &Orchestrator{
+		cfg:           cfg,
+		notifier:      &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			addedLabels[number] = label
+			return nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["sup-7"] = &state.Session{
+		IssueNumber: 488,
+		IssueTitle:  "already-done issue",
+		Branch:      "feat/sup-7-already-done",
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    0,
+	}
+
+	o.autoMergePRs(s)
+
+	if got, want := addedLabels[488], "blocked"; got != want {
+		t.Fatalf("issue #488 label = %q, want %q (no-PR retry_exhausted must mark blocked)", got, want)
+	}
+	sess := s.Sessions["sup-7"]
+	if sess.LastNotifiedStatus != noPRReconciledStatus {
+		t.Fatalf("LastNotifiedStatus = %q, want %q (reconciler must mark idempotent)", sess.LastNotifiedStatus, noPRReconciledStatus)
+	}
+
+	// Second autoMergePRs cycle must NOT re-apply the label or re-notify.
+	clear(addedLabels)
+	o.autoMergePRs(s)
+	if len(addedLabels) != 0 {
+		t.Fatalf("second cycle re-applied labels = %v, want none (idempotency)", addedLabels)
+	}
+}
+
+// #577: when a merged PR already closes the issue (closing-keyword link),
+// the reconciler should auto-close the issue if close_issue is allowed as a
+// safe action without an approval gate. The dynamic-wave queue then sees
+// the issue as closed and advances.
+func TestAutoMergePRs_NoPRRetryExhaustedAutoClosesWhenMergedPRDetected(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Supervisor: config.SupervisorConfig{
+			BlockedLabel: "blocked",
+			SafeActions:  []string{config.SupervisorActionCloseIssue},
+		},
+	}
+	closed := make(map[int]string)
+	labelled := 0
+	o := &Orchestrator{
+		cfg:           cfg,
+		notifier:      &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
+			return issueNumber == 490, nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			closed[number] = comment
+			return nil
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labelled++
+			return nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["sup-9"] = &state.Session{
+		IssueNumber: 490,
+		IssueTitle:  "merged via Refs only",
+		Branch:      "feat/sup-9-merged-elsewhere",
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    0,
+	}
+
+	o.autoMergePRs(s)
+
+	if _, ok := closed[490]; !ok {
+		t.Fatalf("issue #490 not auto-closed; closed=%v (merged PR detected + close_issue safe action must close)", closed)
+	}
+	if labelled != 0 {
+		t.Fatalf("blocked label was applied %d times, want 0 (auto-close branch must not also label)", labelled)
+	}
+	if sess := s.Sessions["sup-9"]; sess.LastNotifiedStatus != noPRReconciledStatus {
+		t.Fatalf("LastNotifiedStatus = %q, want %q", sess.LastNotifiedStatus, noPRReconciledStatus)
+	}
+}
+
+// #577: when close_issue is not granted as a safe action (or requires
+// approval) the reconciler must surface the merged-elsewhere issue as a
+// close-candidate without silently re-spawning workers — it must still
+// idempotently mark the session reconciled so the queue advances.
+func TestAutoMergePRs_NoPRRetryExhaustedMergedPRSurfacesCloseCandidate(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Supervisor: config.SupervisorConfig{
+			BlockedLabel: "blocked",
+			ApprovalRequired: []string{
+				config.SupervisorActionCloseIssue,
+			},
+		},
+	}
+	closeCalls := 0
+	labelled := 0
+	o := &Orchestrator{
+		cfg:           cfg,
+		notifier:      &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
+			return true, nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			closeCalls++
+			return nil
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labelled++
+			return nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["sup-11"] = &state.Session{
+		IssueNumber: 491,
+		IssueTitle:  "merged via Refs; close gated",
+		Branch:      "feat/sup-11",
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    0,
+	}
+
+	o.autoMergePRs(s)
+
+	if closeCalls != 0 {
+		t.Fatalf("close_issue without safe-action grant must not auto-close; calls=%d", closeCalls)
+	}
+	if labelled != 0 {
+		t.Fatalf("merged-elsewhere branch must not apply blocked label; labelled=%d", labelled)
+	}
+	if sess := s.Sessions["sup-11"]; sess.LastNotifiedStatus != noPRReconciledStatus {
+		t.Fatalf("LastNotifiedStatus = %q, want %q (must still mark reconciled to stop log spam)", sess.LastNotifiedStatus, noPRReconciledStatus)
+	}
+}
+
+// #577: a transient GitHub failure when probing for a merged PR must NOT
+// mark the session reconciled — the next cycle should try again instead of
+// silently dropping the issue.
+func TestAutoMergePRs_NoPRRetryExhaustedHasMergedPRErrorDefersReconcile(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Supervisor: config.SupervisorConfig{
+			BlockedLabel: "blocked",
+		},
+	}
+	o := &Orchestrator{
+		cfg:           cfg,
+		notifier:      &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
+			return false, fmt.Errorf("gh: transient API failure")
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			t.Fatalf("addIssueLabel(%d, %q) must not run when merged-PR probe failed", number, label)
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			t.Fatalf("closeIssue(%d) must not run when merged-PR probe failed", number)
+			return nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["sup-13"] = &state.Session{
+		IssueNumber: 492,
+		IssueTitle:  "transient gh failure",
+		Branch:      "feat/sup-13",
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    0,
+	}
+
+	o.autoMergePRs(s)
+
+	if sess := s.Sessions["sup-13"]; sess.LastNotifiedStatus == noPRReconciledStatus {
+		t.Fatalf("transient probe failure must not mark reconciled; LastNotifiedStatus=%q", sess.LastNotifiedStatus)
+	}
+}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1638,6 +1638,57 @@ func TestRunOnceDynamicWaveAddsReadyOnlyToBestCandidateAndCleansStale(t *testing
 	}
 }
 
+// #577 regression: when the most recent dynamic-wave candidate exhausted
+// retries without ever producing a PR, the wave must skip that issue and
+// select the next eligible candidate so max_parallel=1 does not halt the
+// queue waiting for the dead session to reconcile. The retry-exhausted-
+// repair-candidate path is suppressed here by signalling the failed issue
+// as merged-elsewhere (the scenario from #577: a prior PR landed via
+// `Refs #N`), forcing supervisor to fall through to dynamic-wave eval.
+func TestDecide_DynamicWaveSkipsNoPRRetryExhaustedAndAdvances(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
+	reader := &fakeReader{
+		issues: []github.Issue{
+			testIssue(488, "already-done candidate", "maestro-ready", "p0"),
+			testIssue(490, "next eligible candidate", "maestro-ready", "p1"),
+		},
+		mergedPRIssues: map[int]bool{488: true},
+	}
+	st := state.NewState()
+	st.Sessions["sup-114"] = &state.Session{
+		IssueNumber: 488,
+		IssueTitle:  "already-done candidate",
+		Branch:      "feat/sup-114",
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    0,
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.QueueAnalysis == nil || decision.QueueAnalysis.SelectedCandidate == nil {
+		t.Fatalf("queue analysis = %#v, want selected candidate (got action=%q)", decision.QueueAnalysis, decision.RecommendedAction)
+	}
+	if got := decision.QueueAnalysis.SelectedCandidate.Number; got != 490 {
+		t.Fatalf("selected candidate = #%d, want #490 (next eligible after #488 retry_exhausted no-PR)", got)
+	}
+	foundSkipReason := false
+	for _, reason := range decision.QueueAnalysis.SkippedReasons {
+		if strings.Contains(reason, "#488") && strings.Contains(reason, "retry limit exhausted") {
+			foundSkipReason = true
+			break
+		}
+	}
+	if !foundSkipReason {
+		t.Fatalf("expected #488 retry_exhausted skip reason in %#v", decision.QueueAnalysis.SkippedReasons)
+	}
+}
+
 func TestDecide_DynamicWaveClassifiesTitleEpicAsHeld(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}


### PR DESCRIPTION
Refs #577

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the #577 deadlock where a worker that exhausts its retry budget without ever opening a PR (e.g. because a `Refs #N` merge already implemented the issue) caused `autoMergePRs` to log "waiting for reconciliation" forever, halting the dynamic-wave queue at `max_parallel=1`. The fix adds `reconcileNoPRRetryExhausted`, which runs once per affected session and either auto-closes the issue (when a merged PR is detected and `close_issue` is a permitted safe action) or applies the configured `blocked_label` to unblock the wave.

- **Core fix in `autoMergePRs`**: sessions with `PRNumber == 0` and `StatusRetryExhausted` where no open PR is found are now routed to `reconcileNoPRRetryExhausted` instead of the "waiting for reconciliation" log loop; idempotency is enforced via `sess.LastNotifiedStatus = \"no_pr_reconciled\"`.
- **Four orchestrator test cases** cover the blocked-label path, auto-close, the operator close-candidate path (close requires approval), and transient GitHub API errors that should defer reconciliation.
- **Supervisor regression test** confirms the dynamic-wave skips the retry-exhausted no-PR issue and advances to the next eligible candidate.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the new reconciliation path is idempotent and exits early on transient failures without marking sessions reconciled, so the worst-case regression is a repeated log line rather than data loss.

The orchestrator logic is well-guarded and the tests are comprehensive. Two small gaps in the new reconciler — no project-board sync when close_issue requires approval, and no deduplication for the auto-close-failure notification — are operational quality issues rather than correctness bugs, but they could cause noticeable friction in the scenarios they affect.

internal/orchestrator/orchestrator.go — specifically the operator close-candidate branch (line 2380–2385) and the auto-close failure return path (line 2368–2374).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds reconcileNoPRRetryExhausted to handle the #577 deadlock; idempotency and error handling are sound, but the operator close-candidate branch skips syncProject and the auto-close-failure path has no notification deduplication. |
| internal/orchestrator/orchestrator_test.go | Four new test cases cover the blocked-label path, auto-close, operator close-candidate, and transient GitHub error deferral; idempotency is verified with a second autoMergePRs cycle. |
| internal/supervisor/supervisor_test.go | Adds a regression test verifying the supervisor's dynamic-wave skips a retry_exhausted / no-PR issue and advances to the next eligible candidate; exercises pre-existing retryExhaustedSessionResolvedOnGitHub logic. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:2380-2385
**Missing `syncProject` in the operator close-candidate branch**

When a merged PR is detected but `close_issue` is not in `safe_actions` (or requires approval), the function notifies the operator but never calls `syncProject`. The auto-close success path syncs to `Done`, the no-merged-PR path syncs to `Blocked`, but this branch leaves the project board in whatever stale state it was (e.g., "In Review" or "Blocked"), even though the work has already landed. After `sess.LastNotifiedStatus` is set to `noPRReconciledStatus` the board will never be updated by this reconciler again.

### Issue 2 of 2
internal/orchestrator/orchestrator.go:2368-2374
**Notification spam on persistent auto-close failures**

When `closeIssue` fails, the function returns early without setting `sess.LastNotifiedStatus = noPRReconciledStatus`. That is intentional so the reconciler retries, but it means `o.notifier.Sendf("auto-close failed: ...")` fires on every orchestration cycle for as long as the GitHub API keeps rejecting the close. If the issue is systematically not closable (e.g. a bot permission problem), the operator receives a flood of "auto-close failed" alerts with no back-off or deduplication guard. A separate status like `"close_failed_notified"` (cleared when auto-close succeeds) would cap repeated alerts while still allowing retries.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): reconcile retry\_exhau..."](https://github.com/befeast/maestro/commit/67798a8b495658cc54dd0d2de75578391f48efa2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35051298)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->