### PR TITLE
M-011: UI: separate active approvals from historical approval audit

### DIFF
--- a/internal/server/approval_audit_separation_test.go
+++ b/internal/server/approval_audit_separation_test.go
@@ -1,0 +1,241 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// fleetApprovalFixture is a small helper that builds a fleetApprovalState
+// for a given lifecycle status without touching disk. Tests use it to
+// pin the pending-only / history-only / mixed contracts the M-011 issue
+// requires for the approval surfaces.
+func fleetApprovalFixture(project, id, status string, age time.Duration, now time.Time) fleetApprovalState {
+	return fleetApprovalState{
+		ProjectName:  project,
+		ID:           id,
+		Action:       "approve_merge",
+		Status:       status,
+		Risk:         "approval_gated",
+		Summary:      "Fixture approval " + id + " (" + status + ").",
+		DashboardURL: "http://127.0.0.1:8788",
+		PRNumber:     1,
+		createdAt:    now.Add(-age),
+		updatedAt:    now.Add(-age),
+	}
+}
+
+// --- historicalFleetApprovals filter --------------------------------------
+
+func TestHistoricalFleetApprovalsFiltersPendingOut(t *testing.T) {
+	now := time.Now().UTC()
+	mixed := []fleetApprovalState{
+		fleetApprovalFixture("proj", "pending-1", string(state.ApprovalStatusPending), time.Minute, now),
+		fleetApprovalFixture("proj", "stale-1", string(state.ApprovalStatusStale), 2*time.Hour, now),
+		fleetApprovalFixture("proj", "approved-1", string(state.ApprovalStatusApproved), 3*time.Hour, now),
+		fleetApprovalFixture("proj", "rejected-1", string(state.ApprovalStatusRejected), 4*time.Hour, now),
+		fleetApprovalFixture("proj", "superseded-1", string(state.ApprovalStatusSuperseded), 5*time.Hour, now),
+	}
+
+	got := historicalFleetApprovals(mixed)
+	if len(got) != 4 {
+		t.Fatalf("historicalFleetApprovals len = %d, want 4 (all non-pending)", len(got))
+	}
+	for _, item := range got {
+		if state.ApprovalStatus(item.Status) == state.ApprovalStatusPending {
+			t.Fatalf("historicalFleetApprovals leaked pending approval %q", item.ID)
+		}
+	}
+}
+
+func TestHistoricalFleetApprovalsPendingOnlyReturnsEmpty(t *testing.T) {
+	now := time.Now().UTC()
+	pendingOnly := []fleetApprovalState{
+		fleetApprovalFixture("proj", "pending-1", string(state.ApprovalStatusPending), time.Minute, now),
+		fleetApprovalFixture("proj", "pending-2", string(state.ApprovalStatusPending), 2*time.Minute, now),
+	}
+	if got := historicalFleetApprovals(pendingOnly); len(got) != 0 {
+		t.Fatalf("historicalFleetApprovals len = %d, want 0 for pending-only input", len(got))
+	}
+}
+
+func TestHistoricalFleetApprovalsHistoryOnlyReturnsAll(t *testing.T) {
+	now := time.Now().UTC()
+	historyOnly := []fleetApprovalState{
+		fleetApprovalFixture("proj", "stale-1", string(state.ApprovalStatusStale), time.Hour, now),
+		fleetApprovalFixture("proj", "approved-1", string(state.ApprovalStatusApproved), 2*time.Hour, now),
+	}
+	if got := historicalFleetApprovals(historyOnly); len(got) != 2 {
+		t.Fatalf("historicalFleetApprovals len = %d, want 2 for history-only input", len(got))
+	}
+}
+
+// --- approvalAuditSummary copy --------------------------------------------
+
+func TestApprovalAuditSummaryCalmWhenNoHistory(t *testing.T) {
+	got := approvalAuditSummary(nil)
+	if got != "No historical approvals recorded." {
+		t.Fatalf("approvalAuditSummary(nil) = %q, want calm empty copy", got)
+	}
+	for _, alarmWord := range []string{"error", "alert", "blocked", "fail"} {
+		if strings.Contains(strings.ToLower(got), alarmWord) {
+			t.Fatalf("calm empty summary contains alarm word %q: %q", alarmWord, got)
+		}
+	}
+}
+
+func TestApprovalHistoryCountTextForAuditCounts(t *testing.T) {
+	counts := map[string]int{
+		string(state.ApprovalStatusSuperseded): 1,
+		string(state.ApprovalStatusStale):      2,
+		string(state.ApprovalStatusApproved):   3,
+		string(state.ApprovalStatusRejected):   4,
+	}
+	got := approvalHistoryCountTextForAudit(counts, 10)
+	for _, want := range []string{"1 superseded", "2 stale", "3 approved", "4 rejected"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("approvalHistoryCountTextForAudit missing %q in %q", want, got)
+		}
+	}
+	if !strings.Contains(got, "·") {
+		t.Fatalf("approvalHistoryCountTextForAudit should join parts with ·, got %q", got)
+	}
+}
+
+func TestApprovalHistoryCountTextForAuditOnlyUnknown(t *testing.T) {
+	got := approvalHistoryCountTextForAudit(map[string]int{}, 3)
+	if !strings.Contains(got, "3 other") {
+		t.Fatalf("unknown-only audit summary = %q, want 3 other", got)
+	}
+}
+
+// --- audit page rendering -------------------------------------------------
+
+func TestRenderFleetApprovalAuditRowsPendingOnlyShowsCalmEmpty(t *testing.T) {
+	now := time.Now().UTC()
+	pendingOnly := []fleetApprovalState{
+		fleetApprovalFixture("proj", "pending-1", string(state.ApprovalStatusPending), time.Minute, now),
+	}
+	html := renderFleetApprovalAuditRows(historicalFleetApprovals(pendingOnly))
+	if !strings.Contains(html, "No historical approvals have been recorded yet.") {
+		t.Fatalf("pending-only audit rows should render calm empty state, got:\n%s", html)
+	}
+	if strings.Contains(html, "approval-past-sla") {
+		t.Fatalf("pending-only audit rows should not surface SLA-styled cards, got:\n%s", html)
+	}
+}
+
+func TestRenderFleetApprovalAuditRowsHistoryOnlyRendersCards(t *testing.T) {
+	now := time.Now().UTC()
+	historyOnly := []fleetApprovalState{
+		fleetApprovalFixture("proj", "approved-1", string(state.ApprovalStatusApproved), 2*time.Hour, now),
+		fleetApprovalFixture("proj", "stale-1", string(state.ApprovalStatusStale), 3*time.Hour, now),
+	}
+	html := renderFleetApprovalAuditRows(historicalFleetApprovals(historyOnly))
+	for _, want := range []string{"approval-card-muted", "approval-approved", "approval-stale", "approved-1", "stale-1"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("history-only audit rows missing %q in:\n%s", want, html)
+		}
+	}
+	if strings.Contains(html, "No historical approvals have been recorded yet.") {
+		t.Fatalf("history-only audit rows should not render the empty state, got:\n%s", html)
+	}
+}
+
+func TestRenderFleetApprovalAuditRowsMixedDropsPending(t *testing.T) {
+	now := time.Now().UTC()
+	mixed := []fleetApprovalState{
+		fleetApprovalFixture("proj", "pending-keep-in-inbox", string(state.ApprovalStatusPending), time.Minute, now),
+		fleetApprovalFixture("proj", "stale-show-in-audit", string(state.ApprovalStatusStale), time.Hour, now),
+	}
+	html := renderFleetApprovalAuditRows(historicalFleetApprovals(mixed))
+	if strings.Contains(html, "pending-keep-in-inbox") {
+		t.Fatalf("audit page leaked pending approval id, got:\n%s", html)
+	}
+	if !strings.Contains(html, "stale-show-in-audit") {
+		t.Fatalf("audit page should keep stale approval id, got:\n%s", html)
+	}
+}
+
+// --- audit subtitle -------------------------------------------------------
+
+func TestApprovalAuditSubtitleReportsPendingCount(t *testing.T) {
+	snapshot := fleetResponse{
+		Summary: fleetSummary{
+			Projects:         3,
+			ApprovalsPending: 2,
+		},
+	}
+	got := approvalAuditSubtitle(snapshot)
+	for _, want := range []string{"3 configured projects", "2 active pending approvals"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("audit subtitle missing %q in %q", want, got)
+		}
+	}
+}
+
+// --- audit endpoint behaviour --------------------------------------------
+
+func TestHandleFleetApprovalAuditPendingOnlyRendersCalmEmpty(t *testing.T) {
+	srv, projectName, dir := newFleetForApprovalTest(t)
+	_ = projectName
+	enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+
+	req := httptest.NewRequest(http.MethodGet, "/approvals/audit", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleetApprovalAudit(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "No historical approvals have been recorded yet.") {
+		t.Fatalf("pending-only audit endpoint should render calm empty body, got:\n%s", body)
+	}
+	if !strings.Contains(body, "Historical Approvals") {
+		t.Fatalf("audit endpoint should keep header, got:\n%s", body)
+	}
+}
+
+// --- attention count contract --------------------------------------------
+
+func TestFleetAttentionSentenceIgnoresHistoricalApprovalCounts(t *testing.T) {
+	historicalOnly := fleetSummary{
+		ApprovalsHistorical: 12,
+		ApprovalsApproved:   4,
+		ApprovalsRejected:   4,
+		ApprovalsStale:      2,
+		ApprovalsSuperseded: 2,
+	}
+	if got := fleetAttentionSentence(historicalOnly); got != "No item needs attention." {
+		t.Fatalf("attention sentence with historical-only approvals = %q, want calm no-attention copy", got)
+	}
+
+	pendingOnly := fleetSummary{ApprovalsPending: 1, Approvals: 1}
+	if got := fleetAttentionSentence(pendingOnly); got != "1 item needs attention." {
+		t.Fatalf("attention sentence with pending approval = %q, want 1 item needs attention", got)
+	}
+}
+
+func TestFleetVerdictToneDoesNotEscalateOnHistoricalApprovals(t *testing.T) {
+	now := time.Now().UTC()
+	latest := &supervisorDecisionInfo{CreatedAt: now}
+
+	historicalOnly := fleetSummary{
+		ApprovalsHistorical: 50,
+		ApprovalsApproved:   40,
+		ApprovalsRejected:   10,
+	}
+	if tone := fleetVerdictTone(historicalOnly, latest, now); tone == "attention" {
+		t.Fatalf("verdict tone with historical-only approvals = %q, should not escalate to attention", tone)
+	}
+
+	pendingOnly := fleetSummary{ApprovalsPending: 1, Approvals: 1}
+	if tone := fleetVerdictTone(pendingOnly, latest, now); tone != "attention" {
+		t.Fatalf("verdict tone with pending approval = %q, want attention", tone)
+	}
+}


### PR DESCRIPTION
Refs #346

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a dedicated test file to validate the M-011 requirement that active (pending) approvals are separated from the historical approval audit view, covering both the filter function and the resulting UI/endpoint contracts.

- **Filter tests** (`historicalFleetApprovals`) verify that pending approvals are excluded from the audit list across pending-only, history-only, and mixed inputs, and the results propagate correctly through the HTML render path.
- **Attention/tone contract tests** (`fleetAttentionSentence`, `fleetVerdictTone`) confirm that historical approval counters (`ApprovalsHistorical`, `ApprovalsApproved`, etc.) do not escalate the dashboard tone, while `ApprovalsPending` correctly does.
- **Integration test** (`TestHandleFleetApprovalAuditPendingOnlyRendersCalmEmpty`) exercises the full `/approvals/audit` handler path with a real pending approval on disk and asserts the calm empty state is rendered.

<h3>Confidence Score: 5/5</h3>

Test-only change; no production code is modified. All test assertions match the current production implementations in fleet.go.

Every test assertion was traced against the production functions it exercises — filter logic, HTML rendering, subtitle formatting, count text, attention sentence, and verdict tone. No mismatch was found between what the tests assert and what the production code actually returns. The integration test correctly relies on the same disk-backed snapshot path used by existing fleet approval tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/approval_audit_separation_test.go | New test file covering M-011 audit/active approval separation: filter function, rendering, subtitle, endpoint behavior, attention count, and verdict tone contracts. All assertions align with the production implementations in fleet.go. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(server): pin pending/historical app..."](https://github.com/befeast/maestro/commit/d57994bd0375cab56d08d12ff0f06ce6369f57c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35055466)</sub>

<!-- /greptile_comment -->