### PR TITLE
Dashboard runtime should not conflate agent runtime with PR/CI waiting

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -921,6 +921,7 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 			sess.Status = state.StatusFailed
 			now := time.Now().UTC()
 			sess.FinishedAt = &now
+			state.MarkWorkerEnded(sess, now)
 			o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) retry failed (could not fetch issue)",
 				slotName, sess.IssueNumber, sess.IssueTitle)
 			continue
@@ -958,6 +959,7 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 			sess.Status = state.StatusFailed
 			now := time.Now().UTC()
 			sess.FinishedAt = &now
+			state.MarkWorkerEnded(sess, now)
 			o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) respawn failed: %v",
 				slotName, sess.IssueNumber, sess.IssueTitle, respawnErr)
 			continue
@@ -1475,6 +1477,8 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 			sess.TmuxSession = ""
 			now := time.Now().UTC()
 			sess.FinishedAt = &now
+			state.MarkWorkerEnded(sess, now)
+			state.MarkPROpened(sess, now)
 			reconciled = true
 			continue
 		}
@@ -1514,6 +1518,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 				sess.PID = 0
 				sess.TmuxSession = ""
 				sess.FinishedAt = &now
+				state.MarkWorkerEnded(sess, now)
 				sess.LastNotifiedStatus = "rate_limit"
 				sess.Status = state.StatusDead
 				reconciled = true
@@ -1529,6 +1534,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 				sess.PID = 0
 				sess.TmuxSession = ""
 				sess.FinishedAt = &now
+				state.MarkWorkerEnded(sess, now)
 				sess.LastNotifiedStatus = "rate_limit"
 				sess.Status = state.StatusDead
 				reconciled = true
@@ -1547,6 +1553,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 				sess.PID = 0
 				sess.TmuxSession = ""
 				sess.FinishedAt = &now
+				state.MarkWorkerEnded(sess, now)
 				sess.LastNotifiedStatus = "rate_limit"
 				sess.Status = state.StatusDead
 				reconciled = true
@@ -1572,6 +1579,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		sess.TmuxSession = ""
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		reconciled = true
 
 		log.Printf("[orch] reconcile: %s running->dead (%s); pid=%d tmux=%q",
@@ -1608,6 +1616,8 @@ func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.S
 	sess.TmuxSession = ""
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
+	state.MarkWorkerEnded(sess, now)
+	state.MarkPROpened(sess, now)
 	if o.notifier != nil {
 		o.notifier.Sendf("🔀 maestro: worker %s pushed branch %s and exited before opening a PR; auto-created PR #%d for issue #%d (%s)",
 			slotName, branch, prNumber, sess.IssueNumber, sess.IssueTitle)
@@ -1681,6 +1691,8 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					sess.TmuxSession = ""
 					now := time.Now().UTC()
 					sess.FinishedAt = &now
+					state.MarkWorkerEnded(sess, now)
+					state.MarkPROpened(sess, now)
 					o.syncProject(sess.IssueNumber, github.ProjectStatusInReview)
 					continue
 				}
@@ -1705,6 +1717,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					if sess.FinishedAt == nil {
 						now := time.Now().UTC()
 						sess.FinishedAt = &now
+						state.MarkWorkerEnded(sess, now)
 					}
 				} else if sess.Status != state.StatusCodeLanded && sess.PRNumber > 0 {
 					merged, err := o.isPRMerged(sess.PRNumber)
@@ -1751,6 +1764,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				sess.Status = state.StatusDone
 				now := time.Now().UTC()
 				sess.FinishedAt = &now
+				state.MarkWorkerEnded(sess, now)
 				continue
 			}
 		}
@@ -1770,6 +1784,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				sess.Status = state.StatusDone
 				now := time.Now().UTC()
 				sess.FinishedAt = &now
+				state.MarkWorkerEnded(sess, now)
 				continue
 			}
 
@@ -1790,6 +1805,9 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					log.Printf("[orch] worker %s exited but PR #%d is open — transitioning to pr_open", slotName, pr.Number)
 					sess.Status = state.StatusPROpen
 					sess.PRNumber = pr.Number
+					now := time.Now().UTC()
+					state.MarkWorkerEnded(sess, now)
+					state.MarkPROpened(sess, now)
 					o.notifier.Sendf("🔀 maestro: worker %s completed, PR #%d open for issue #%d (%s)",
 						slotName, pr.Number, sess.IssueNumber, sess.IssueTitle)
 				} else if o.isRateLimited(sess.LogFile) {
@@ -1805,6 +1823,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						sess.Status = state.StatusDead
 						sess.LastNotifiedStatus = "rate_limit"
 						sess.FinishedAt = &now
+						state.MarkWorkerEnded(sess, now)
 						o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) hit provider limit; no fallback backend available",
 							slotName, sess.IssueNumber, sess.IssueTitle)
 						continue
@@ -1818,6 +1837,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						sess.Status = state.StatusFailed
 						now := time.Now().UTC()
 						sess.FinishedAt = &now
+						state.MarkWorkerEnded(sess, now)
 						o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) rate-limited and fallback failed (could not fetch issue)",
 							slotName, sess.IssueNumber, sess.IssueTitle)
 						continue
@@ -1833,6 +1853,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						sess.Status = state.StatusFailed
 						now := time.Now().UTC()
 						sess.FinishedAt = &now
+						state.MarkWorkerEnded(sess, now)
 						o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) rate-limited and fallback to %s failed: %v",
 							slotName, sess.IssueNumber, sess.IssueTitle, nextBackend, err)
 						continue
@@ -1849,6 +1870,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					sess.Status = state.StatusDead
 					now := time.Now().UTC()
 					sess.FinishedAt = &now
+					state.MarkWorkerEnded(sess, now)
 					log.Printf("[orch] worker %s (pid=%d) died, scheduling retry %d in %dms",
 						slotName, sess.PID, sess.RetryCount, backoffMs)
 					o.notifier.Sendf("🔄 maestro: worker %s (issue #%d: %s) died, retry %d scheduled in %ds",
@@ -1861,6 +1883,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					sess.Status = state.StatusFailed
 					now := time.Now().UTC()
 					sess.FinishedAt = &now
+					state.MarkWorkerEnded(sess, now)
 					o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) permanently failed after %d retries.\nCheck log: %s",
 						slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, sess.LogFile)
 				}
@@ -1877,6 +1900,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					log.Printf("[orch] worker %s opened PR #%d while still running — transitioning to pr_open", slotName, pr.Number)
 					sess.Status = state.StatusPROpen
 					sess.PRNumber = pr.Number
+					state.MarkPROpened(sess, time.Now().UTC())
 					o.notifier.Sendf("🔀 maestro: worker %s opened PR #%d for issue #%d (%s)",
 						slotName, pr.Number, sess.IssueNumber, sess.IssueTitle)
 					continue
@@ -1929,6 +1953,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 									sess.LastNotifiedStatus = "rate_limit"
 									now := time.Now().UTC()
 									sess.FinishedAt = &now
+									state.MarkWorkerEnded(sess, now)
 									o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); fallback failed (could not fetch issue)",
 										slotName, sess.IssueNumber, pattern)
 									continue
@@ -1945,6 +1970,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 									sess.LastNotifiedStatus = "rate_limit"
 									now := time.Now().UTC()
 									sess.FinishedAt = &now
+									state.MarkWorkerEnded(sess, now)
 									o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); fallback to %s failed: %v",
 										slotName, sess.IssueNumber, pattern, fallback, respawnErr)
 									continue
@@ -1961,6 +1987,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 							sess.LastNotifiedStatus = "rate_limit"
 							now = time.Now().UTC()
 							sess.FinishedAt = &now
+							state.MarkWorkerEnded(sess, now)
 							o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d) hit rate limit (%s); no fallback configured",
 								slotName, sess.IssueNumber, pattern)
 							continue
@@ -2012,6 +2039,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						sess.Status = state.StatusDead
 						sess.LastNotifiedStatus = "token_limit"
 						sess.FinishedAt = &now
+						state.MarkWorkerEnded(sess, now)
 						o.notifier.Sendf("⚠️ Worker %s (issue #%d) exceeded token limit: %s tokens used (attempt), %s total",
 							slotName, sess.IssueNumber, worker.FormatTokens(sess.TokensUsedAttempt), worker.FormatTokens(sess.TokensUsedTotal))
 						continue
@@ -2041,6 +2069,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 								sess.Status = state.StatusDead
 								sess.LastNotifiedStatus = "silent_timeout"
 								sess.FinishedAt = &now
+								state.MarkWorkerEnded(sess, now)
 
 								if prevSilentKills > 0 {
 									// auto-label blocked disabled
@@ -2080,6 +2109,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				sess.Status = state.StatusFailed
 				now := time.Now().UTC()
 				sess.FinishedAt = &now
+				state.MarkWorkerEnded(sess, now)
 
 				o.notifier.Sendf("⏱️ maestro: worker %s (issue #%d: %s) timed out after %d min.\nLast log lines:\n%s",
 					slotName, sess.IssueNumber, sess.IssueTitle, maxMinutes, logTail)
@@ -2146,6 +2176,7 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			sess.Status = state.StatusDone
 			now := time.Now().UTC()
 			sess.FinishedAt = &now
+			state.MarkWorkerEnded(sess, now)
 			continue
 		}
 
@@ -2438,6 +2469,7 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 		sess.LastNotifiedStatus = "review_retry_exhausted"
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		if !alreadyNotified {
 			o.notifier.Sendf("💀 maestro: review feedback on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
 				pr.Number, sess.IssueNumber, sess.IssueTitle, totalAttempts)
@@ -2471,6 +2503,7 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 	sess.Status = state.StatusDead
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
+	state.MarkWorkerEnded(sess, now)
 
 	log.Printf("[orch] review feedback on PR #%d — scheduling retry %d in %dms for issue #%d",
 		pr.Number, sess.RetryCount, backoffMs, sess.IssueNumber)
@@ -2496,6 +2529,7 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 		sess.LastNotifiedStatus = "ci_retry_exhausted"
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		if !alreadyNotified {
 			o.notifier.Sendf("💀 maestro: CI failing on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
 				pr.Number, sess.IssueNumber, sess.IssueTitle, totalAttempts)
@@ -2547,6 +2581,7 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 	sess.PRNumber = 0
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
+	state.MarkWorkerEnded(sess, now)
 
 	log.Printf("[orch] CI failure on PR #%d — scheduling retry %d in %dms for issue #%d",
 		pr.Number, sess.RetryCount, backoffMs, sess.IssueNumber)
@@ -2588,6 +2623,7 @@ func (o *Orchestrator) markCodeLanded(sess *state.Session, prNumber int) {
 	sess.Status = state.StatusCodeLanded
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
+	state.MarkWorkerEnded(sess, now)
 }
 
 func (o *Orchestrator) markDeploymentFinished(sess *state.Session) {
@@ -2621,6 +2657,7 @@ func (o *Orchestrator) markDoneAfterOutcomePass(sess *state.Session, prNumber in
 	sess.Status = state.StatusDone
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
+	state.MarkWorkerEnded(sess, now)
 	o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
 	o.closeVerifiedIssueIfAllowed(sess, prNumber)
 }
@@ -3092,6 +3129,7 @@ func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string
 		sess.LastNotifiedStatus = "rebase_conflict_retry_exhausted"
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		o.notifier.Sendf("💀 maestro: rebase conflict on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
 			prNumber, sess.IssueNumber, sess.IssueTitle, totalAttempts)
 		return
@@ -3124,6 +3162,7 @@ func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string
 	sess.RebaseAttempted = true
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
+	state.MarkWorkerEnded(sess, now)
 
 	log.Printf("[orch] rebase conflict on PR #%d — scheduling retry %d in %dms for issue #%d",
 		prNumber, sess.RetryCount, backoffMs, sess.IssueNumber)
@@ -3155,6 +3194,7 @@ func (o *Orchestrator) markUnresolvableConflict(slotName string, sess *state.Ses
 	sess.PRNumber = prNumber
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
+	state.MarkWorkerEnded(sess, now)
 	o.notifier.Sendf("⚠️ Worker %s (issue #%d) has unresolvable conflicts — manual intervention needed", slotName, sess.IssueNumber)
 }
 

--- a/internal/orchestrator/pipeline.go
+++ b/internal/orchestrator/pipeline.go
@@ -40,6 +40,7 @@ func (o *Orchestrator) handlePlanComplete(slotName string, sess *state.Session) 
 		sess.Status = state.StatusDead
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		o.notifier.Sendf("⚠️ maestro: planner %s (issue #%d) failed — no plan artifacts produced",
 			slotName, sess.IssueNumber)
 		return true
@@ -54,6 +55,7 @@ func (o *Orchestrator) handlePlanComplete(slotName string, sess *state.Session) 
 		sess.Status = state.StatusDead
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		return true
 	}
 
@@ -65,6 +67,7 @@ func (o *Orchestrator) handlePlanComplete(slotName string, sess *state.Session) 
 		sess.Status = state.StatusDead
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		return true
 	}
 
@@ -94,6 +97,7 @@ func (o *Orchestrator) handleImplementComplete(slotName string, sess *state.Sess
 		sess.Status = state.StatusDead
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		return true
 	}
 
@@ -105,6 +109,7 @@ func (o *Orchestrator) handleImplementComplete(slotName string, sess *state.Sess
 		sess.Status = state.StatusDead
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		return true
 	}
 
@@ -142,6 +147,7 @@ func (o *Orchestrator) handleValidateComplete(slotName string, sess *state.Sessi
 		sess.Status = state.StatusFailed
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		o.notifier.Sendf("❌ maestro: %s (issue #%d) failed validation %d times — giving up",
 			slotName, sess.IssueNumber, sess.ValidationFails)
 		return true
@@ -155,6 +161,7 @@ func (o *Orchestrator) handleValidateComplete(slotName string, sess *state.Sessi
 		sess.Status = state.StatusDead
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		return true
 	}
 
@@ -166,6 +173,7 @@ func (o *Orchestrator) handleValidateComplete(slotName string, sess *state.Sessi
 		sess.Status = state.StatusDead
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
 		return true
 	}
 

--- a/internal/orchestrator/runtime_breakdown_test.go
+++ b/internal/orchestrator/runtime_breakdown_test.go
@@ -1,0 +1,108 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// TestReconcileRecordsWorkerEndedAndPROpened verifies that a session moving
+// running -> pr_open via the reconcile path captures the agent-exit moment
+// (#426). Without WorkerEndedAt + PROpenedAt the API cannot distinguish
+// agent runtime from PR/CI waiting once `code_landed` / `done` rewrite
+// FinishedAt.
+func TestReconcileRecordsWorkerEndedAndPROpened(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber: 426,
+		IssueTitle:  "runtime breakdown",
+		Status:      state.StatusRunning,
+		PID:         4242,
+		TmuxSession: "maestro-mae-1",
+		Branch:      "feat/runtime-breakdown",
+		StartedAt:   time.Now().UTC().Add(-3 * time.Minute),
+	}
+
+	openPRs := []github.PR{{Number: 426, HeadRefName: "feat/runtime-breakdown"}}
+
+	o := &Orchestrator{
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return openPRs, nil },
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["mae-1"]
+	if sess.Status != state.StatusPROpen {
+		t.Fatalf("status = %q, want pr_open", sess.Status)
+	}
+	if sess.WorkerEndedAt == nil {
+		t.Fatal("WorkerEndedAt must be set when worker exits — without it, agent runtime is unrecoverable once FinishedAt is rewritten")
+	}
+	if sess.PROpenedAt == nil {
+		t.Fatal("PROpenedAt must be set on first transition into pr_open")
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("FinishedAt must also be set (workflow-level timestamp)")
+	}
+	if !sess.WorkerEndedAt.Equal(*sess.PROpenedAt) {
+		t.Errorf("worker_ended_at=%v differs from pr_opened_at=%v on the same reconcile pass; expected the same `now` to be used",
+			*sess.WorkerEndedAt, *sess.PROpenedAt)
+	}
+}
+
+// TestPROpenToDoneDoesNotMoveWorkerEndedAt mirrors the scribe-service scenario
+// from #426: the worker exits quickly, the session sits in pr_open for over an
+// hour waiting on CI/Greptile/merge, and is finally marked done by a later
+// orchestrator pass. The dashboard must still be able to tell that the agent
+// only ran for the early part — WorkerEndedAt must not slide to the
+// done-transition time.
+func TestPROpenToDoneDoesNotMoveWorkerEndedAt(t *testing.T) {
+	startedAt := time.Date(2026, 5, 21, 14, 57, 24, 0, time.UTC)
+	workerEnded := startedAt.Add(3 * time.Minute)
+
+	sess := &state.Session{
+		IssueNumber:   106,
+		Status:        state.StatusPROpen,
+		Branch:        "feat/scr-46",
+		StartedAt:     startedAt,
+		WorkerEndedAt: &workerEnded,
+		PROpenedAt:    &workerEnded,
+		FinishedAt:    &workerEnded,
+		PRNumber:      115,
+	}
+
+	// Simulate the markDoneAfterOutcomePass / markCodeLanded path setting
+	// FinishedAt a second time (much later) AND calling MarkWorkerEnded
+	// (idempotently) — WorkerEndedAt must remain pinned to the first call.
+	doneAt := time.Date(2026, 5, 21, 16, 43, 27, 0, time.UTC)
+	sess.FinishedAt = &doneAt
+	state.MarkWorkerEnded(sess, doneAt)
+	sess.Status = state.StatusDone
+
+	if sess.WorkerEndedAt == nil {
+		t.Fatal("WorkerEndedAt unexpectedly cleared")
+	}
+	if !sess.WorkerEndedAt.Equal(workerEnded) {
+		t.Errorf("WorkerEndedAt slid to %v; want pinned to %v", *sess.WorkerEndedAt, workerEnded)
+	}
+
+	// Agent ran for 3 minutes; full workflow elapsed for 1h46m3s. The PR/CI
+	// waiting attributable to orchestration latency is the delta.
+	workerDur := sess.WorkerEndedAt.Sub(sess.StartedAt)
+	workflowDur := sess.FinishedAt.Sub(sess.StartedAt)
+	if workerDur != 3*time.Minute {
+		t.Errorf("agent runtime = %v, want 3m", workerDur)
+	}
+	if workflowDur != 1*time.Hour+46*time.Minute+3*time.Second {
+		t.Errorf("workflow elapsed = %v, want 1h46m3s", workflowDur)
+	}
+	if workflowDur-workerDur < time.Hour {
+		t.Errorf("pr/ci waiting = %v, want > 1h (the actual orchestration latency)", workflowDur-workerDur)
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -539,19 +539,31 @@ type fleetWorkerState struct {
 	PRURL             string `json:"pr_url,omitempty"`
 	TokensUsedAttempt int    `json:"tokens_used_attempt"`
 	TokensUsedTotal   int    `json:"tokens_used_total"`
-	Runtime           string `json:"runtime"`
-	RuntimeSeconds    int64  `json:"runtime_seconds"`
-	StartedAt         string `json:"started_at"`
-	FinishedAt        string `json:"finished_at,omitempty"`
-	NextRetryAt       string `json:"next_retry_at,omitempty"`
-	PID               int    `json:"pid,omitempty"`
-	Alive             *bool  `json:"alive,omitempty"`
-	Worktree          string `json:"worktree,omitempty"`
-	Branch            string `json:"branch,omitempty"`
-	TmuxSession       string `json:"tmux_session,omitempty"`
-	HasLog            bool   `json:"has_log"`
-	RetryCount        int    `json:"retry_count,omitempty"`
-	LastNotification  string `json:"last_notification,omitempty"`
+	// Runtime / RuntimeSeconds (legacy fields, kept for backwards
+	// compatibility) reflect workflow elapsed time and include PR-open /
+	// CI / Greptile / merge waiting. See #426 — WorkerRuntimeSeconds is
+	// the agent's wall-clock; WorkflowRuntimeSeconds is the full session.
+	Runtime                string `json:"runtime"`
+	RuntimeSeconds         int64  `json:"runtime_seconds"`
+	WorkerRuntime          string `json:"worker_runtime"`
+	WorkerRuntimeSeconds   int64  `json:"worker_runtime_seconds"`
+	WorkflowRuntime        string `json:"workflow_runtime"`
+	WorkflowRuntimeSeconds int64  `json:"workflow_runtime_seconds"`
+	PROpenRuntime          string `json:"pr_open_runtime,omitempty"`
+	PROpenRuntimeSeconds   int64  `json:"pr_open_runtime_seconds,omitempty"`
+	StartedAt              string `json:"started_at"`
+	FinishedAt             string `json:"finished_at,omitempty"`
+	WorkerEndedAt          string `json:"worker_ended_at,omitempty"`
+	PROpenedAt             string `json:"pr_opened_at,omitempty"`
+	NextRetryAt            string `json:"next_retry_at,omitempty"`
+	PID                    int    `json:"pid,omitempty"`
+	Alive                  *bool  `json:"alive,omitempty"`
+	Worktree               string `json:"worktree,omitempty"`
+	Branch                 string `json:"branch,omitempty"`
+	TmuxSession            string `json:"tmux_session,omitempty"`
+	HasLog                 bool   `json:"has_log"`
+	RetryCount             int    `json:"retry_count,omitempty"`
+	LastNotification       string `json:"last_notification,omitempty"`
 	// Attribution is the per-segment backend timeline for this session
 	// (#513 / #534). The SPA renders the active segment inline on the card
 	// and the complete list with EndReason between segments inside the
@@ -2661,39 +2673,47 @@ func isFleetWorkerDefaultVisible(worker sessionInfo) bool {
 
 func makeFleetWorkerState(project fleetProjectState, worker sessionInfo) fleetWorkerState {
 	return fleetWorkerState{
-		ProjectName:       project.Name,
-		ProjectRepo:       project.Repo,
-		DashboardURL:      project.DashboardURL,
-		Slot:              worker.Slot,
-		IssueNumber:       worker.IssueNumber,
-		IssueTitle:        worker.IssueTitle,
-		IssueURL:          worker.IssueURL,
-		Status:            worker.Status,
-		DisplayStatus:     worker.DisplayStatus,
-		StatusReason:      worker.StatusReason,
-		NextAction:        worker.NextAction,
-		NeedsAttention:    worker.NeedsAttention,
-		Live:              worker.Live,
-		Backend:           worker.Backend,
-		PRNumber:          worker.PRNumber,
-		PRURL:             worker.PRURL,
-		TokensUsedAttempt: worker.TokensUsedAttempt,
-		TokensUsedTotal:   worker.TokensUsedTotal,
-		Runtime:           worker.Runtime,
-		RuntimeSeconds:    worker.RuntimeSeconds,
-		StartedAt:         worker.StartedAt,
-		FinishedAt:        worker.FinishedAt,
-		NextRetryAt:       worker.NextRetryAt,
-		PID:               worker.PID,
-		Alive:             worker.Alive,
-		Worktree:          worker.Worktree,
-		Branch:            worker.Branch,
-		TmuxSession:       worker.TmuxSession,
-		HasLog:            worker.HasLog,
-		RetryCount:        worker.RetryCount,
-		LastNotification:  worker.LastNotification,
-		Attribution:       worker.Attribution,
-		Actions:           worker.Actions,
+		ProjectName:            project.Name,
+		ProjectRepo:            project.Repo,
+		DashboardURL:           project.DashboardURL,
+		Slot:                   worker.Slot,
+		IssueNumber:            worker.IssueNumber,
+		IssueTitle:             worker.IssueTitle,
+		IssueURL:               worker.IssueURL,
+		Status:                 worker.Status,
+		DisplayStatus:          worker.DisplayStatus,
+		StatusReason:           worker.StatusReason,
+		NextAction:             worker.NextAction,
+		NeedsAttention:         worker.NeedsAttention,
+		Live:                   worker.Live,
+		Backend:                worker.Backend,
+		PRNumber:               worker.PRNumber,
+		PRURL:                  worker.PRURL,
+		TokensUsedAttempt:      worker.TokensUsedAttempt,
+		TokensUsedTotal:        worker.TokensUsedTotal,
+		Runtime:                worker.Runtime,
+		RuntimeSeconds:         worker.RuntimeSeconds,
+		WorkerRuntime:          worker.WorkerRuntime,
+		WorkerRuntimeSeconds:   worker.WorkerRuntimeSeconds,
+		WorkflowRuntime:        worker.WorkflowRuntime,
+		WorkflowRuntimeSeconds: worker.WorkflowRuntimeSeconds,
+		PROpenRuntime:          worker.PROpenRuntime,
+		PROpenRuntimeSeconds:   worker.PROpenRuntimeSeconds,
+		StartedAt:              worker.StartedAt,
+		FinishedAt:             worker.FinishedAt,
+		WorkerEndedAt:          worker.WorkerEndedAt,
+		PROpenedAt:             worker.PROpenedAt,
+		NextRetryAt:            worker.NextRetryAt,
+		PID:                    worker.PID,
+		Alive:                  worker.Alive,
+		Worktree:               worker.Worktree,
+		Branch:                 worker.Branch,
+		TmuxSession:            worker.TmuxSession,
+		HasLog:                 worker.HasLog,
+		RetryCount:             worker.RetryCount,
+		LastNotification:       worker.LastNotification,
+		Attribution:            worker.Attribution,
+		Actions:                worker.Actions,
 	}
 }
 

--- a/internal/server/runtime_breakdown_test.go
+++ b/internal/server/runtime_breakdown_test.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// TestRuntimeBreakdownSeparatesWorkerFromWorkflow reproduces the scribe-service
+// #115 / #106 scenario captured in #426: a session that ran for ~3 minutes as a
+// coding agent, then waited for PR / CI / Greptile / merge for ~1h43m, and was
+// finally marked done. The original dashboard reported `runtime=1h46m3s` which
+// conflated agent execution with orchestration waiting.
+//
+// The expectation is that worker_runtime stays at the agent's wall-clock and
+// workflow_runtime is the total session elapsed — PR/CI waiting is exposed
+// separately so the operator can see the orchestration latency rather than
+// blame the coding backend.
+func TestRuntimeBreakdownSeparatesWorkerFromWorkflow(t *testing.T) {
+	startedAt := time.Date(2026, 5, 21, 14, 57, 24, 0, time.UTC)
+	workerEndedAt := startedAt.Add(3 * time.Minute)
+	finishedAt := time.Date(2026, 5, 21, 16, 43, 27, 0, time.UTC) // 1h46m3s after start
+	prOpenedAt := workerEndedAt
+
+	sess := &state.Session{
+		IssueNumber:   106,
+		IssueTitle:    "scribe-service: fix",
+		Status:        state.StatusDone,
+		Backend:       "claude",
+		PRNumber:      115,
+		Branch:        "feat/scr-46",
+		StartedAt:     startedAt,
+		WorkerEndedAt: &workerEndedAt,
+		PROpenedAt:    &prOpenedAt,
+		FinishedAt:    &finishedAt,
+	}
+
+	info := makeSessionInfo("test/repo", "scr-46", sess)
+
+	if info.WorkerRuntimeSeconds != 180 {
+		t.Errorf("worker_runtime_seconds = %d, want 180 (3m of actual agent wall-clock, not the 1h46m3s workflow elapsed)",
+			info.WorkerRuntimeSeconds)
+	}
+	if info.WorkflowRuntimeSeconds != int64(finishedAt.Sub(startedAt)/time.Second) {
+		t.Errorf("workflow_runtime_seconds = %d, want %d", info.WorkflowRuntimeSeconds, int64(finishedAt.Sub(startedAt)/time.Second))
+	}
+	// PR/CI waiting must equal workflow - worker.
+	wantPRWait := info.WorkflowRuntimeSeconds - info.WorkerRuntimeSeconds
+	if info.PROpenRuntimeSeconds != wantPRWait {
+		t.Errorf("pr_open_runtime_seconds = %d, want %d (workflow - agent)", info.PROpenRuntimeSeconds, wantPRWait)
+	}
+	if info.WorkerEndedAt == "" {
+		t.Errorf("worker_ended_at not exposed; operator can't explain the long elapsed time without a state transition timestamp")
+	}
+	if info.PROpenedAt == "" {
+		t.Errorf("pr_opened_at not exposed; operator can't see when PR/CI waiting started")
+	}
+	// Legacy Runtime field must keep equivalence to workflow elapsed so historical
+	// rows stay understandable and the API stays backwards-compatible.
+	if info.RuntimeSeconds != info.WorkflowRuntimeSeconds {
+		t.Errorf("legacy runtime_seconds=%d, workflow_runtime_seconds=%d — they should agree on total workflow elapsed",
+			info.RuntimeSeconds, info.WorkflowRuntimeSeconds)
+	}
+}
+
+// TestRuntimeBreakdownRunningSessionWorkerRuntimeIsLiveWallClock confirms that
+// an in-flight session whose worker has not yet ended still reports
+// worker_runtime as the agent's live wall-clock, not zero.
+func TestRuntimeBreakdownRunningSessionWorkerRuntimeIsLiveWallClock(t *testing.T) {
+	startedAt := time.Now().UTC().Add(-12 * time.Minute)
+	sess := &state.Session{
+		IssueNumber: 200,
+		IssueTitle:  "in flight",
+		Status:      state.StatusRunning,
+		Backend:     "claude",
+		Branch:      "feat/in-flight",
+		StartedAt:   startedAt,
+	}
+
+	info := makeSessionInfo("test/repo", "slot-x", sess)
+
+	if info.WorkerRuntimeSeconds < 600 || info.WorkerRuntimeSeconds > 900 {
+		t.Errorf("worker_runtime_seconds = %d, want ~720 (running session wall-clock)", info.WorkerRuntimeSeconds)
+	}
+	if info.WorkflowRuntimeSeconds < info.WorkerRuntimeSeconds {
+		t.Errorf("workflow=%d worker=%d — workflow should be >= worker", info.WorkflowRuntimeSeconds, info.WorkerRuntimeSeconds)
+	}
+	if info.PROpenRuntime != "" {
+		t.Errorf("pr_open_runtime should be empty before PR opens, got %q", info.PROpenRuntime)
+	}
+}
+
+// TestMarkWorkerEndedIsIdempotent guards against later status transitions
+// (pr_open -> code_landed -> done) sliding WorkerEndedAt forward and
+// undoing the agent-vs-workflow distinction.
+func TestMarkWorkerEndedIsIdempotent(t *testing.T) {
+	first := time.Date(2026, 5, 21, 15, 0, 24, 0, time.UTC)
+	second := time.Date(2026, 5, 21, 16, 43, 27, 0, time.UTC)
+	sess := &state.Session{IssueNumber: 1, Status: state.StatusRunning, StartedAt: first.Add(-time.Hour)}
+
+	state.MarkWorkerEnded(sess, first)
+	state.MarkWorkerEnded(sess, second) // simulates code_landed → done writing FinishedAt again
+
+	if sess.WorkerEndedAt == nil {
+		t.Fatal("WorkerEndedAt should be set after first call")
+	}
+	if !sess.WorkerEndedAt.Equal(first) {
+		t.Errorf("WorkerEndedAt = %v, want first call %v (idempotent)", *sess.WorkerEndedAt, first)
+	}
+}
+
+// TestMarkPROpenedIsIdempotent guards against pr_open -> running review-retry
+// loops resetting the PR-open timestamp.
+func TestMarkPROpenedIsIdempotent(t *testing.T) {
+	first := time.Date(2026, 5, 21, 15, 0, 24, 0, time.UTC)
+	second := first.Add(30 * time.Minute)
+	sess := &state.Session{IssueNumber: 1, Status: state.StatusPROpen}
+
+	state.MarkPROpened(sess, first)
+	state.MarkPROpened(sess, second)
+
+	if sess.PROpenedAt == nil {
+		t.Fatal("PROpenedAt should be set after first call")
+	}
+	if !sess.PROpenedAt.Equal(first) {
+		t.Errorf("PROpenedAt = %v, want %v (idempotent across review-retry oscillation)", *sess.PROpenedAt, first)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -248,35 +248,49 @@ type controlActionRequest struct {
 }
 
 type sessionInfo struct {
-	Slot              string                  `json:"slot"`
-	IssueNumber       int                     `json:"issue_number"`
-	IssueTitle        string                  `json:"issue_title"`
-	IssueURL          string                  `json:"issue_url,omitempty"`
-	Status            string                  `json:"status"`
-	DisplayStatus     string                  `json:"display_status,omitempty"`
-	StatusReason      string                  `json:"status_reason,omitempty"`
-	NextAction        string                  `json:"next_action,omitempty"`
-	NeedsAttention    bool                    `json:"needs_attention,omitempty"`
-	Live              bool                    `json:"live"`
-	Backend           string                  `json:"backend,omitempty"`
-	PRNumber          int                     `json:"pr_number,omitempty"`
-	PRURL             string                  `json:"pr_url,omitempty"`
-	TokensUsedAttempt int                     `json:"tokens_used_attempt"`
-	TokensUsedTotal   int                     `json:"tokens_used_total"`
-	Runtime           string                  `json:"runtime"`
-	RuntimeSeconds    int64                   `json:"runtime_seconds"`
-	StartedAt         string                  `json:"started_at"`
-	FinishedAt        string                  `json:"finished_at,omitempty"`
-	NextRetryAt       string                  `json:"next_retry_at,omitempty"`
-	PID               int                     `json:"pid,omitempty"`
-	Alive             *bool                   `json:"alive,omitempty"`
-	Worktree          string                  `json:"worktree,omitempty"`
-	Branch            string                  `json:"branch,omitempty"`
-	TmuxSession       string                  `json:"tmux_session,omitempty"`
-	HasLog            bool                    `json:"has_log"`
-	RetryCount        int                     `json:"retry_count,omitempty"`
-	LastNotification  string                  `json:"last_notification,omitempty"`
-	BackendSelection  *state.BackendSelection `json:"backend_selection,omitempty"`
+	Slot              string `json:"slot"`
+	IssueNumber       int    `json:"issue_number"`
+	IssueTitle        string `json:"issue_title"`
+	IssueURL          string `json:"issue_url,omitempty"`
+	Status            string `json:"status"`
+	DisplayStatus     string `json:"display_status,omitempty"`
+	StatusReason      string `json:"status_reason,omitempty"`
+	NextAction        string `json:"next_action,omitempty"`
+	NeedsAttention    bool   `json:"needs_attention,omitempty"`
+	Live              bool   `json:"live"`
+	Backend           string `json:"backend,omitempty"`
+	PRNumber          int    `json:"pr_number,omitempty"`
+	PRURL             string `json:"pr_url,omitempty"`
+	TokensUsedAttempt int    `json:"tokens_used_attempt"`
+	TokensUsedTotal   int    `json:"tokens_used_total"`
+	// Runtime / RuntimeSeconds (legacy fields, kept for backwards
+	// compatibility) reflect WORKFLOW elapsed time — StartedAt to
+	// FinishedAt — including PR-open / CI / Greptile / merge waiting.
+	// Prefer WorkerRuntimeSeconds for "how long the coding agent ran"
+	// and WorkflowRuntimeSeconds for "how long the whole session took";
+	// see #426.
+	Runtime                string                  `json:"runtime"`
+	RuntimeSeconds         int64                   `json:"runtime_seconds"`
+	WorkerRuntime          string                  `json:"worker_runtime"`
+	WorkerRuntimeSeconds   int64                   `json:"worker_runtime_seconds"`
+	WorkflowRuntime        string                  `json:"workflow_runtime"`
+	WorkflowRuntimeSeconds int64                   `json:"workflow_runtime_seconds"`
+	PROpenRuntime          string                  `json:"pr_open_runtime,omitempty"`
+	PROpenRuntimeSeconds   int64                   `json:"pr_open_runtime_seconds,omitempty"`
+	StartedAt              string                  `json:"started_at"`
+	FinishedAt             string                  `json:"finished_at,omitempty"`
+	WorkerEndedAt          string                  `json:"worker_ended_at,omitempty"`
+	PROpenedAt             string                  `json:"pr_opened_at,omitempty"`
+	NextRetryAt            string                  `json:"next_retry_at,omitempty"`
+	PID                    int                     `json:"pid,omitempty"`
+	Alive                  *bool                   `json:"alive,omitempty"`
+	Worktree               string                  `json:"worktree,omitempty"`
+	Branch                 string                  `json:"branch,omitempty"`
+	TmuxSession            string                  `json:"tmux_session,omitempty"`
+	HasLog                 bool                    `json:"has_log"`
+	RetryCount             int                     `json:"retry_count,omitempty"`
+	LastNotification       string                  `json:"last_notification,omitempty"`
+	BackendSelection       *state.BackendSelection `json:"backend_selection,omitempty"`
 	// Attribution is the per-segment provider/model/variant/effort timeline
 	// recorded across spawn / respawn / fallover (#513, PR #518). The SPA
 	// renders the active segment inline on the session card and the full
@@ -310,15 +324,51 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 		Live:              state.SessionLiveAt(sess, now),
 	}
 
-	// Calculate runtime
+	// Calculate runtime breakdown (#426). The workflow runtime is the
+	// total session wall-clock (StartedAt -> FinishedAt or now). The
+	// worker runtime is the time the coding agent was actually executing
+	// (StartedAt -> WorkerEndedAt). When WorkerEndedAt is not yet recorded
+	// (legacy sessions or transitions that did not flow through MarkWorkerEnded),
+	// fall back to FinishedAt and finally to now, so historical rows remain
+	// understandable.
 	end := now
 	if sess.FinishedAt != nil {
 		end = *sess.FinishedAt
 		info.FinishedAt = sess.FinishedAt.Format(time.RFC3339)
 	}
-	runtime := end.Sub(sess.StartedAt).Round(time.Second)
-	info.Runtime = runtime.String()
-	info.RuntimeSeconds = int64(runtime / time.Second)
+	workflowDur := end.Sub(sess.StartedAt).Round(time.Second)
+	info.Runtime = workflowDur.String()
+	info.RuntimeSeconds = int64(workflowDur / time.Second)
+	info.WorkflowRuntime = workflowDur.String()
+	info.WorkflowRuntimeSeconds = info.RuntimeSeconds
+
+	workerEnd := end
+	if sess.WorkerEndedAt != nil {
+		workerEnd = *sess.WorkerEndedAt
+		info.WorkerEndedAt = sess.WorkerEndedAt.Format(time.RFC3339)
+	} else if sess.Status == state.StatusRunning {
+		workerEnd = now
+	}
+	workerDur := workerEnd.Sub(sess.StartedAt).Round(time.Second)
+	if workerDur < 0 {
+		workerDur = 0
+	}
+	info.WorkerRuntime = workerDur.String()
+	info.WorkerRuntimeSeconds = int64(workerDur / time.Second)
+
+	if sess.PROpenedAt != nil {
+		info.PROpenedAt = sess.PROpenedAt.Format(time.RFC3339)
+		prEnd := end
+		if sess.Status == state.StatusPROpen {
+			prEnd = now
+		}
+		prDur := prEnd.Sub(*sess.PROpenedAt).Round(time.Second)
+		if prDur < 0 {
+			prDur = 0
+		}
+		info.PROpenRuntime = prDur.String()
+		info.PROpenRuntimeSeconds = int64(prDur / time.Second)
+	}
 
 	if sess.Status == state.StatusRunning {
 		info.PID = sess.PID

--- a/internal/server/web/static/dashboard.css
+++ b/internal/server/web/static/dashboard.css
@@ -119,7 +119,10 @@
   .status { width: 128px; }
   .backend { width: 102px; }
   .pr { width: 64px; }
-  .runtime { width: 88px; }
+  .runtime { width: 138px; white-space: nowrap; }
+  .runtime .runtime-agent { font-weight: 600; }
+  .runtime .runtime-sep { color: var(--muted); }
+  .runtime .runtime-total { color: var(--muted); }
   .tokens { width: 78px; text-align: right; }
   .pill {
     display: inline-flex;

--- a/internal/server/web/static/dashboard.js
+++ b/internal/server/web/static/dashboard.js
@@ -77,6 +77,30 @@ function issueSummaryText(worker) {
   return (issue + " " + (worker.issue_title || "")).trim();
 }
 
+// #426: render agent runtime separately from total workflow elapsed time,
+// so the dashboard doesn't conflate "agent ran for 1h46m" with "session
+// (including PR/CI/Greptile/merge waiting) elapsed 1h46m".
+function runtimeCellHTML(worker) {
+  const workerRt = worker.worker_runtime || "-";
+  const workflowRt = worker.workflow_runtime || worker.runtime || "-";
+  if (!workerRt || workerRt === workflowRt) {
+    return escapeText(workflowRt);
+  }
+  return '<span class="runtime-agent">' + escapeText(workerRt) + '</span>' +
+    '<span class="runtime-sep"> / </span>' +
+    '<span class="runtime-total">' + escapeText(workflowRt) + '</span>';
+}
+
+function runtimeTitleText(worker) {
+  const workerRt = worker.worker_runtime || "-";
+  const workflowRt = worker.workflow_runtime || worker.runtime || "-";
+  const parts = ["Agent runtime: " + workerRt, "Workflow elapsed: " + workflowRt];
+  if (worker.pr_open_runtime) {
+    parts.push("PR/CI waiting: " + worker.pr_open_runtime);
+  }
+  return parts.join("\n");
+}
+
 function actionLabel(action) {
   switch (String(action || "").trim()) {
   case "none": return "Skipped tick";
@@ -359,7 +383,7 @@ function renderWorkers() {
       '<td class="status"><span class="' + pillClass(worker) + '">' + escapeText(statusLabel(worker)) + '</span></td>' +
       '<td class="backend">' + escapeText(worker.backend || "-") + '</td>' +
       '<td class="pr">' + linkHTML(worker.pr_url, pr) + '</td>' +
-      '<td class="runtime">' + escapeText(worker.runtime || "-") + '</td>' +
+      '<td class="runtime" title="' + escapeText(runtimeTitleText(worker)) + '">' + runtimeCellHTML(worker) + '</td>' +
       '<td class="tokens">' + compactNumber(worker.tokens_used_total) + '</td>' +
     '</tr>';
   }).join("");

--- a/internal/server/web/static/fleet.css
+++ b/internal/server/web/static/fleet.css
@@ -1014,7 +1014,10 @@
   .status-col { width: 132px; }
   .backend-col { width: 108px; }
   .pr-col { width: 70px; }
-  .runtime-col { width: 90px; }
+  .runtime-col { width: 140px; white-space: nowrap; }
+  .runtime-col .runtime-agent { font-weight: 600; }
+  .runtime-col .runtime-sep,
+  .runtime-col .runtime-total { color: var(--muted); }
   .tokens-col { width: 82px; text-align: right; }
   .action-col { width: 180px; }
   .grid {

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -151,6 +151,31 @@ function issueSummaryText(worker) {
   return (issue + " " + (worker.issue_title || "")).trim();
 }
 
+// #426: render agent runtime separately from total workflow elapsed time.
+// The fleet table previously labelled "Runtime" but it was actually total
+// session wall-clock from start to finish, which conflated coding-agent
+// runtime with PR-open / CI / Greptile / merge waiting.
+function runtimeCellHTML(worker) {
+  const workerRt = worker.worker_runtime || "-";
+  const workflowRt = worker.workflow_runtime || worker.runtime || "-";
+  if (!workerRt || workerRt === workflowRt) {
+    return escapeText(workflowRt);
+  }
+  return '<span class="runtime-agent">' + escapeText(workerRt) + '</span>' +
+    '<span class="runtime-sep"> / </span>' +
+    '<span class="runtime-total">' + escapeText(workflowRt) + '</span>';
+}
+
+function runtimeTitleText(worker) {
+  const workerRt = worker.worker_runtime || "-";
+  const workflowRt = worker.workflow_runtime || worker.runtime || "-";
+  const parts = ["Agent runtime: " + workerRt, "Workflow elapsed: " + workflowRt];
+  if (worker.pr_open_runtime) {
+    parts.push("PR/CI waiting: " + worker.pr_open_runtime);
+  }
+  return parts.join("\n");
+}
+
 function actionLabel(action) {
   switch (String(action || "").trim()) {
   case "none": return "Skipped tick";
@@ -1876,7 +1901,7 @@ function renderFleetWorkers() {
       '<td class="status-col" title="' + escapeText(statusLabel(worker)) + '"><span class="' + statusClass(worker) + '">' + escapeText(statusLabel(worker)) + '</span></td>' +
       '<td class="backend-col" title="' + escapeText(worker.backend || "-") + '">' + escapeText(worker.backend || "-") + '</td>' +
       '<td class="pr-col" title="' + escapeText(pr) + '">' + linkHTML(worker.pr_url, pr) + '</td>' +
-      '<td class="runtime-col" title="' + escapeText(worker.runtime || "-") + '">' + escapeText(worker.runtime || "-") + '</td>' +
+      '<td class="runtime-col" title="' + escapeText(runtimeTitleText(worker)) + '">' + runtimeCellHTML(worker) + '</td>' +
       '<td class="tokens-col">' + compactNumber(worker.tokens_used_total) + '</td>' +
       '<td class="action-col">' + renderActions(worker.actions || [], { details: false }) + '</td>' +
     '</tr>';
@@ -2078,8 +2103,12 @@ function renderWorkerDetail(data) {
     detailField("Worktree", worker.worktree || "-"),
     detailField("Branch", worker.branch || "-"),
     detailField("Started", formatTimestamp(worker.started_at)),
+    detailField("Worker ended", formatTimestamp(worker.worker_ended_at)),
+    detailField("PR opened", formatTimestamp(worker.pr_opened_at)),
     detailField("Finished", formatTimestamp(worker.finished_at)),
-    detailField("Runtime", worker.runtime || "-"),
+    detailField("Agent runtime", worker.worker_runtime || "-"),
+    detailField("Workflow elapsed", worker.workflow_runtime || worker.runtime || "-"),
+    detailField("PR/CI waiting", worker.pr_open_runtime || "-"),
     detailField("Next retry", formatTimestamp(worker.next_retry_at)),
     detailField("Retry count", worker.retry_count ? String(worker.retry_count) : "0"),
     detailField("Log", worker.has_log ? "recorded" : "not recorded")

--- a/internal/server/web/templates/dashboard.html
+++ b/internal/server/web/templates/dashboard.html
@@ -44,7 +44,7 @@
             <th class="status">Status</th>
             <th class="backend">Backend</th>
             <th class="pr">PR</th>
-            <th class="runtime">Runtime</th>
+            <th class="runtime" title="Agent runtime / total elapsed (#426: total includes PR/CI wait)">Runtime (agent / total)</th>
             <th class="tokens">Tokens</th>
           </tr>
         </thead>

--- a/internal/server/web/templates/fleet.html
+++ b/internal/server/web/templates/fleet.html
@@ -181,7 +181,7 @@
               <th class="status-col">Status</th>
               <th class="backend-col">Backend</th>
               <th class="pr-col">PR</th>
-              <th class="runtime-col">Runtime</th>
+              <th class="runtime-col" title="Agent runtime / total elapsed (#426: total includes PR/CI wait)">Runtime (agent / total)</th>
               <th class="tokens-col">Tokens</th>
               <th class="action-col">Actions</th>
             </tr>

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -138,6 +138,18 @@ type Session struct {
 	CheckpointFile              string            `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
 	DeploymentFinishedAt        *time.Time        `json:"deployment_finished_at,omitempty"`         // set when the post-merge deploy hook succeeds
 
+	// #426: distinguish agent execution time from workflow elapsed time.
+	// WorkerEndedAt is stamped the FIRST time the worker process exits
+	// (running -> pr_open / dead / failed / etc.). It is never overwritten
+	// by later status transitions, so worker_runtime (StartedAt -> WorkerEndedAt)
+	// reflects only the coding agent's wall-clock time, not subsequent
+	// PR-open / CI / Greptile / merge waiting. PROpenedAt is stamped the
+	// first time the session enters pr_open and is preserved similarly,
+	// so pr_open_runtime (PROpenedAt -> FinishedAt) is attributable to
+	// orchestration latency instead of agent runtime.
+	WorkerEndedAt *time.Time `json:"worker_ended_at,omitempty"`
+	PROpenedAt    *time.Time `json:"pr_opened_at,omitempty"`
+
 	// #513: per-segment attribution timeline. Every spawn / respawn /
 	// fallover appends a new entry; the previous entry's EndedAt is
 	// closed at the same moment. Records who actually produced the
@@ -2203,6 +2215,38 @@ func sessionAttentionActionableAt(sess *Session, now time.Time, ttl time.Duratio
 		return true
 	}
 	return now.Sub(changedAt) <= ttl
+}
+
+// MarkWorkerEnded stamps WorkerEndedAt with `now` the FIRST time the worker
+// process is observed to have stopped. Subsequent calls are no-ops, so a
+// later status transition (pr_open -> code_landed -> done) cannot move the
+// recorded agent-exit time forward. Callers should invoke this before/at
+// any transition out of StatusRunning (running -> pr_open / dead / failed /
+// retry_exhausted / conflict_failed / code_landed / done).
+//
+// See #426: dashboard "Runtime" used to conflate agent execution with
+// PR-open / CI / Greptile / merge waiting because FinishedAt was rewritten
+// at every status change.
+func MarkWorkerEnded(sess *Session, now time.Time) {
+	if sess == nil || sess.WorkerEndedAt != nil {
+		return
+	}
+	t := normalizedTime(now)
+	sess.WorkerEndedAt = &t
+}
+
+// MarkPROpened stamps PROpenedAt with `now` the FIRST time the session
+// enters StatusPROpen. Subsequent calls are no-ops, so a session that
+// flips pr_open -> running -> pr_open during a review-retry loop keeps
+// the original PR-open timestamp. Used by the dashboard to attribute
+// pr_open_runtime (PROpenedAt -> FinishedAt) to orchestration latency
+// rather than agent execution.
+func MarkPROpened(sess *Session, now time.Time) {
+	if sess == nil || sess.PROpenedAt != nil {
+		return
+	}
+	t := normalizedTime(now)
+	sess.PROpenedAt = &t
 }
 
 // SessionChangedAt returns the newest persisted activity timestamp for a session.


### PR DESCRIPTION
Refs #426

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates the dashboard's "Runtime" column into distinct agent execution time (`worker_runtime`) and total workflow elapsed time (`workflow_runtime`), resolving the #426 confusion where a 3-minute coding run followed by a 1h43m PR/CI wait was displayed as a single "1h46m" runtime.

- **State layer**: Two new idempotent helpers (`MarkWorkerEnded`, `MarkPROpened`) stamp `WorkerEndedAt` and `PROpenedAt` on the first exit/PR-open event and are no-ops on all subsequent calls, so later status rewrites (pr_open → code_landed → done) cannot slide the timestamps forward.
- **Orchestrator coverage**: `MarkWorkerEnded` is added to every worker-exit path across `orchestrator.go` and `pipeline.go`; `MarkPROpened` is added at each transition into `StatusPROpen`.
- **API + UI**: `sessionInfo` / `fleetWorkerState` expose `worker_runtime`, `workflow_runtime`, and `pr_open_runtime`; the legacy `runtime` field is preserved as a workflow-elapsed alias for backwards compatibility. The dashboard and fleet tables now render "Xm / Yh46m" with a tooltip breaking down the three segments.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the primary single-run scenario; multi-retry sessions will show a slightly inflated pr_open_runtime but no data is lost.

The idempotent first-write-wins design works correctly for the targeted case (single coding run followed by a long PR/CI wait). For sessions that go through CI failure or review-feedback retries, PROpenedAt is never reset, so pr_open_runtime is measured from the first PR open all the way to session end, capturing the retry worker's execution time as PR/CI waiting. No timestamps are lost or corrupted; the decomposition is just imprecise for multi-retry sessions.

internal/server/server.go (pr_open_runtime calculation) and internal/orchestrator/orchestrator.go (handleCIFailureRetry / handleReviewFeedbackRetry paths that schedule retries without resetting PROpenedAt)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds WorkerEndedAt and PROpenedAt fields to Session, plus MarkWorkerEnded/MarkPROpened helpers that are idempotent (first-write-wins). Core data model for the runtime breakdown feature. |
| internal/orchestrator/orchestrator.go | Adds MarkWorkerEnded (and MarkPROpened where appropriate) at every transition point where a running worker exits. Coverage looks comprehensive across all exit paths; multi-retry sessions pin WorkerEndedAt to the first cycle only. |
| internal/server/server.go | Adds WorkerRuntime/WorkflowRuntime/PROpenRuntime breakdown to sessionInfo. Fallback for legacy sessions (no WorkerEndedAt) is sound; pr_open_runtime will overcount for CI/review retry cycles. |
| internal/server/fleet.go | Mirrors sessionInfo struct changes into fleetWorkerState and makeFleetWorkerState. Mechanical propagation, no logic issues. |
| internal/server/runtime_breakdown_test.go | Four tests covering single-run breakdown, live session wall-clock, and idempotency of both mark functions. Good coverage of the primary use case; multi-retry scenario not tested. |
| internal/orchestrator/runtime_breakdown_test.go | Tests the reconcile path (running → pr_open) and the idempotency of WorkerEndedAt across pr_open → done transitions. Correct and well-targeted. |
| internal/server/web/static/dashboard.js | Adds runtimeCellHTML/runtimeTitleText to show agent vs. workflow runtime. Contains a dead !workerRt branch that is always false (workerRt is pre-set to '-' and therefore always truthy). |
| internal/server/web/static/fleet.js | Same runtimeCellHTML/runtimeTitleText additions as dashboard.js with the same dead !workerRt branch. |
| internal/server/web/static/dashboard.css | Widens runtime column to 138px and adds styling for .runtime-agent/.runtime-sep/.runtime-total. Clean change. |
| internal/server/web/static/fleet.css | Matching runtime column widening for the fleet view. Clean change. |
| internal/server/web/templates/dashboard.html | Column header updated to 'Runtime (agent / total)' with tooltip. Trivial. |
| internal/server/web/templates/fleet.html | Same header change as dashboard.html. Trivial. |
| internal/orchestrator/pipeline.go | Adds MarkWorkerEnded to all pipeline failure exits (plan, implement, validate). Straightforward additions, no issues. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/server/web/static/dashboard.js`, line 906-908 ([link](https://github.com/befeast/maestro/blob/17e5d43c00e2489134ef03dc7528c7f82d32137d/internal/server/web/static/dashboard.js#L906-L908)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead `!workerRt` branch in `runtimeCellHTML`**

   `workerRt` is assigned via `worker.worker_runtime || "-"`, so it is always a non-empty string and can never be falsy. The `!workerRt` guard is therefore unreachable — the condition collapses to just `workerRt === workflowRt`. The same pattern appears in `fleet.js` at the corresponding location. No output is wrong today, but the dead branch could confuse a future reader into thinking there is a code path that falls through to a plain `workflowRt` display for a different reason than equality.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/web/static/dashboard.js
   Line: 906-908

   Comment:
   **Dead `!workerRt` branch in `runtimeCellHTML`**

   `workerRt` is assigned via `worker.worker_runtime || "-"`, so it is always a non-empty string and can never be falsy. The `!workerRt` guard is therefore unreachable — the condition collapses to just `workerRt === workflowRt`. The same pattern appears in `fleet.js` at the corresponding location. No output is wrong today, but the dead branch could confuse a future reader into thinking there is a code path that falls through to a plain `workflowRt` display for a different reason than equality.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/server.go:359-371
**`pr_open_runtime` overstates waiting time for CI/review retry sessions**

`PROpenedAt` is pinned to the first PR-open event and is never reset when a CI failure or review-feedback retry closes the PR and respawns a new worker. Because `prEnd` is taken from `FinishedAt` (or `now` for a live `pr_open` session), the computed `prDur = prEnd - PROpenedAt` spans the *entire* window from first PR open through the retry worker's execution and back to done. The retry worker's own coding time is therefore counted as "PR/CI waiting", potentially inflating `pr_open_runtime` by the full duration of subsequent retry runs.

For example: first worker runs 3m → PR opened → CI fails → second worker runs 5m → done. `pr_open_runtime` would be `FinishedAt - PROpenedAt` = 3m + CI-wait + 5m, even though 5m of that was active agent execution.

### Issue 2 of 2
internal/server/web/static/dashboard.js:906-908
**Dead `!workerRt` branch in `runtimeCellHTML`**

`workerRt` is assigned via `worker.worker_runtime || "-"`, so it is always a non-empty string and can never be falsy. The `!workerRt` guard is therefore unreachable — the condition collapses to just `workerRt === workflowRt`. The same pattern appears in `fleet.js` at the corresponding location. No output is wrong today, but the dead branch could confuse a future reader into thinking there is a code path that falls through to a plain `workflowRt` display for a different reason than equality.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(server,state,fleet): separate worke..."](https://github.com/befeast/maestro/commit/17e5d43c00e2489134ef03dc7528c7f82d32137d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35057707)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->