### PR TITLE
Backend routing should expose selection reason and support command strings

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1129,7 +1129,57 @@ func (c *Config) Warnings() []string {
 	if msg := c.handsOffMergeApprovalWarning(); msg != "" {
 		warnings = append(warnings, msg)
 	}
+	if msg := c.manualRoutingLabelPinWarning(); msg != "" {
+		warnings = append(warnings, msg)
+	}
 	return warnings
+}
+
+// manualRoutingLabelPinWarning surfaces the #427 misconfiguration where the
+// project advertises multiple backends but uses no routing mechanism that
+// reacts to issue content. In that shape, every dispatched issue picks its
+// backend from a model:* label (or falls through to model.default) — which is
+// label-pinning, not task-based routing. Operators reading the docs may
+// believe Maestro is matching tasks to backends when it is not.
+//
+// The warning fires only when ALL three are true:
+//   - 2+ backends are configured (single-backend setups have nothing to route)
+//   - routing.mode is empty or "manual" (auto-routing would be the task lever)
+//   - no role-specific backends are set (planner/implementer/validator overrides
+//     would be a legitimate role-based shape even without auto)
+//
+// This keeps the warning silent for the common single-backend project, for
+// projects that opted into auto-routing, and for projects that purposefully
+// pin per-role backends. It fires loudly for the failure mode in #427.
+func (c *Config) manualRoutingLabelPinWarning() string {
+	if c == nil {
+		return ""
+	}
+	if len(c.Model.Backends) < 2 {
+		return ""
+	}
+	mode := strings.ToLower(strings.TrimSpace(c.Routing.Mode))
+	if mode == "auto" {
+		return ""
+	}
+	if strings.TrimSpace(c.Routing.PlannerBackend) != "" ||
+		strings.TrimSpace(c.Routing.ImplementationBackend) != "" ||
+		strings.TrimSpace(c.Routing.ValidatorBackend) != "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"config: %d backends are configured but routing.mode is %q and no planner/implementation/validator_backend is set — backend selection will be by model:<name> label or model.default only, not by task content. Set routing.mode: auto for task-based routing or per-role backends for role-based routing.",
+		len(c.Model.Backends),
+		coalesceRoutingMode(c.Routing.Mode),
+	)
+}
+
+func coalesceRoutingMode(mode string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(mode))
+	if trimmed == "" {
+		return "manual"
+	}
+	return trimmed
 }
 
 func (c *Config) handsOffMergeApprovalWarning() string {

--- a/internal/config/warnings_test.go
+++ b/internal/config/warnings_test.go
@@ -56,3 +56,115 @@ func TestConfig_Warnings_NilSafe(t *testing.T) {
 		t.Fatalf("Warnings() on nil cfg = %v, want nil", warnings)
 	}
 }
+
+// #427: when a project has multiple backends but routing.mode is manual (or
+// empty) and no per-role backend is set, backend selection is pinned by
+// model:* labels / default — not by task content. Warn at config load so
+// operators do not mistake "model:codex on every issue" for task-based routing.
+func TestConfig_Warnings_ManualRoutingWithLabelPinning(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "codex",
+			Backends: map[string]BackendDef{
+				"codex":  {Cmd: "codex"},
+				"claude": {Cmd: "claude"},
+			},
+		},
+		Routing: RoutingConfig{Mode: "manual"},
+	}
+	warnings := cfg.Warnings()
+	found := false
+	for _, msg := range warnings {
+		if strings.Contains(msg, "routing.mode") && strings.Contains(msg, "label") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Warnings() = %v, want a warning naming routing.mode and label pinning for the #427 misconfiguration", warnings)
+	}
+}
+
+// #427: an empty routing block (the actual scribe-service shape from the bug
+// report) must trigger the warning — manual is the implicit default.
+func TestConfig_Warnings_EmptyRoutingTreatedAsManual(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "codex",
+			Backends: map[string]BackendDef{
+				"codex":  {Cmd: "codex"},
+				"claude": {Cmd: "claude"},
+			},
+		},
+	}
+	warnings := cfg.Warnings()
+	found := false
+	for _, msg := range warnings {
+		if strings.Contains(msg, "routing.mode") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Warnings() = %v, want a warning when routing block is absent and multiple backends exist", warnings)
+	}
+}
+
+// Single-backend projects have nothing to route — warning must stay silent.
+func TestConfig_Warnings_SingleBackendNoWarning(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "codex",
+			Backends: map[string]BackendDef{
+				"codex": {Cmd: "codex"},
+			},
+		},
+		Routing: RoutingConfig{Mode: "manual"},
+	}
+	for _, msg := range cfg.Warnings() {
+		if strings.Contains(msg, "routing.mode") {
+			t.Fatalf("Warnings() = %v, single-backend setup should not warn about routing", cfg.Warnings())
+		}
+	}
+}
+
+// Auto-routing opts the operator into task-based selection — no warning.
+func TestConfig_Warnings_AutoRoutingNoWarning(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "codex",
+			Backends: map[string]BackendDef{
+				"codex":  {Cmd: "codex"},
+				"claude": {Cmd: "claude"},
+			},
+		},
+		Routing: RoutingConfig{Mode: "auto", RouterModel: "claude"},
+	}
+	for _, msg := range cfg.Warnings() {
+		if strings.Contains(msg, "routing.mode") {
+			t.Fatalf("Warnings() = %v, auto routing should not trigger the #427 warning", cfg.Warnings())
+		}
+	}
+}
+
+// Per-role backends are legitimate role-based routing — no warning.
+func TestConfig_Warnings_RoleBackendsNoWarning(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "codex",
+			Backends: map[string]BackendDef{
+				"codex":  {Cmd: "codex"},
+				"claude": {Cmd: "claude"},
+			},
+		},
+		Routing: RoutingConfig{
+			Mode:                  "manual",
+			ImplementationBackend: "claude",
+		},
+	}
+	for _, msg := range cfg.Warnings() {
+		if strings.Contains(msg, "routing.mode") {
+			t.Fatalf("Warnings() = %v, role backends should not trigger the #427 warning", cfg.Warnings())
+		}
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3226,6 +3226,14 @@ func (o *Orchestrator) resolveBackend(issue github.Issue) string {
 	return name
 }
 
+// resolveBackendWithReason is like resolveBackend but also returns the
+// selection reason (one of router.Reason*) so the orchestrator can stamp it
+// on the session for the dashboard. Introduced for #427 to make it visible
+// whether a backend came from a model: label, auto-routing, or default.
+func (o *Orchestrator) resolveBackendWithReason(issue github.Issue) (string, string) {
+	return o.router.ResolveBackend(issue)
+}
+
 // availableSlots calculates how many new workers can be started, considering
 // both the global max_parallel limit and per-state limits from max_concurrent_by_state.
 // New workers enter the "running" state, so the "running" per-state limit is applied.
@@ -3814,6 +3822,10 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		initialPhase := pipeline.InitialPhase(o.cfg)
 		var backendName string
 		var promptBase string
+		// backendReason tracks why this backend was chosen so the dashboard /
+		// session record can show provenance: label, role, auto, default,
+		// router_error, phase, review_repair. (#427)
+		var backendReason string
 
 		// #565: when the supervisor selected spawn_review_repair for this
 		// issue, override backend + prompt with the strong backend and
@@ -3830,6 +3842,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			}
 			promptBase = supervisor.FormatReviewRepairPromptFromPayload(issue.Number, repairTarget.PR, reviewRepair)
 			initialPhase = state.PhaseNone
+			backendReason = "review_repair"
 			log.Printf("[orch] starting auto review-repair worker for issue #%d (PR #%d, head %s, backend=%s, %d findings)",
 				issue.Number, repairTarget.PR, shortReviewRepairSHA(reviewRepair.HeadSHA), backendName, len(reviewRepair.Findings))
 		} else if initialPhase != state.PhaseNone && initialPhase != state.PhaseImplement {
@@ -3837,15 +3850,24 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			// (worker.Start → assemblePrompt will substitute {{WORKTREE}} etc.)
 			backendName = pipeline.BackendForPhase(o.cfg, initialPhase)
 			promptBase = pipeline.PromptTemplateForPhase(o.cfg, initialPhase)
+			backendReason = "phase"
 		} else {
 			// Normal mode or pipeline starting at implement — use standard resolution
-			backendName = o.resolveBackend(issue)
+			backendName, backendReason = o.resolveBackendWithReason(issue)
 			promptBase = o.selectPrompt(issue)
 			if initialPhase == state.PhaseImplement {
 				// Pipeline mode but no planner — add pipeline preamble
 				preamble := pipeline.ImplementerPreamble(&state.Session{})
 				promptBase = preamble + "\n" + promptBase
 			}
+		}
+
+		// #427: surface router_error as a visible warning so operators don't
+		// have to grep the daemon log to discover that auto-routing fell
+		// through to default silently.
+		if backendReason == router.ReasonRouterError {
+			o.notifier.Sendf("⚠️ maestro: auto-routing failed for issue #%d — falling back to default backend %s. Check router model configuration.",
+				issue.Number, backendName)
 		}
 
 		// Detect long-running label
@@ -3857,7 +3879,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			}
 		}
 
-		log.Printf("[orch] starting worker for issue #%d: %s (backend=%s, phase=%s, long_running=%v)", issue.Number, issue.Title, backendName, initialPhase, longRunning)
+		log.Printf("[orch] starting worker for issue #%d: %s (backend=%s, reason=%s, phase=%s, long_running=%v)", issue.Number, issue.Title, backendName, backendReason, initialPhase, longRunning)
 		slotName, err := o.startWorker(s, issue, promptBase, backendName)
 		if err != nil {
 			log.Printf("[orch] start worker for issue #%d: %v", issue.Number, err)
@@ -3871,6 +3893,15 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		}
 		if initialPhase != state.PhaseNone {
 			s.Sessions[slotName].Phase = initialPhase
+		}
+		// #427: stamp the backend selection reason on the session so the
+		// dashboard / fleet API can show why this backend was chosen
+		// (label / role / auto / default / router_error / phase / review_repair).
+		if sess := s.Sessions[slotName]; sess != nil {
+			sess.BackendSelection = &state.BackendSelection{
+				SelectedBackend: backendName,
+				SelectionReason: backendReason,
+			}
 		}
 		if o.syncProject(issue.Number, github.ProjectStatusInProgress) {
 			s.MarkProjectStatusSynced(issue.Number, string(github.ProjectStatusInProgress), time.Now().UTC())

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -954,6 +954,56 @@ func TestResolveBackend_MultipleLabelsFirstModelWins(t *testing.T) {
 	}
 }
 
+// #427: resolveBackendWithReason returns the canonical reason string the
+// dispatch loop stamps onto Session.BackendSelection so the dashboard can
+// distinguish label-pinned picks from real auto-routed picks from silent
+// router_error fallbacks.
+func TestResolveBackendWithReason_LabelReturnsReasonLabel(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
+	name, reason := o.resolveBackendWithReason(makeIssue(11, "Fix bug", "model:codex"))
+	if name != "codex" || reason != router.ReasonLabel {
+		t.Fatalf("resolveBackendWithReason() = (%q, %q), want (codex, label)", name, reason)
+	}
+}
+
+func TestResolveBackendWithReason_DefaultReturnsReasonDefault(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
+	name, reason := o.resolveBackendWithReason(makeIssue(12, "Fix bug"))
+	if name != "claude" || reason != router.ReasonDefault {
+		t.Fatalf("resolveBackendWithReason() = (%q, %q), want (claude, default)", name, reason)
+	}
+}
+
+func TestResolveBackendWithReason_AutoReturnsReasonAuto(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	cfg.Routing.Mode = "auto"
+	r := router.New(cfg)
+	r.RouteFn = func(issue github.Issue) (string, string, error) {
+		return "codex", "small bugfix", nil
+	}
+	o := &Orchestrator{cfg: cfg, router: r}
+	name, reason := o.resolveBackendWithReason(makeIssue(13, "Small bugfix"))
+	if name != "codex" || reason != router.ReasonAuto {
+		t.Fatalf("resolveBackendWithReason() = (%q, %q), want (codex, auto)", name, reason)
+	}
+}
+
+func TestResolveBackendWithReason_RouterFailureReturnsReasonRouterError(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	cfg.Routing.Mode = "auto"
+	r := router.New(cfg)
+	r.RouteFn = func(issue github.Issue) (string, string, error) {
+		return "", "", fmt.Errorf("network error")
+	}
+	o := &Orchestrator{cfg: cfg, router: r}
+	name, reason := o.resolveBackendWithReason(makeIssue(14, "Fix bug"))
+	if name != "claude" || reason != router.ReasonRouterError {
+		t.Fatalf("resolveBackendWithReason() = (%q, %q), want (claude, router_error)", name, reason)
+	}
+}
+
 // newMergeTestOrchestrator creates an Orchestrator wired with test fakes for
 // autoMergePRs / mergeReadyPR. It records which PR numbers were merged and
 // stubs CI + Greptile to always return "success" / approved.
@@ -3649,6 +3699,102 @@ func TestStartNewWorkers_RecordsProjectStatusSyncOnStart(t *testing.T) {
 	}
 	if !s.ProjectStatusSynced(347, string(github.ProjectStatusInProgress)) {
 		t.Fatal("startNewWorkers did not record project status sync")
+	}
+}
+
+// #427: when a new worker is dispatched, the orchestrator must stamp the
+// session's BackendSelection with a canonical reason so the dashboard /
+// fleet API can surface label vs default vs auto vs router_error.
+func TestStartNewWorkers_StampsBackendSelectionReason_Label(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	issues := []github.Issue{makeIssue(427, "Fix bug", "model:codex")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+
+	s := state.NewState()
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 1 {
+		t.Fatalf("started = %d, want 1", len(*started))
+	}
+	sess := s.Sessions["slot-1"]
+	if sess == nil || sess.BackendSelection == nil {
+		t.Fatalf("session.BackendSelection not stamped: %+v", sess)
+	}
+	if sess.BackendSelection.SelectionReason != router.ReasonLabel {
+		t.Errorf("BackendSelection.SelectionReason = %q, want %q", sess.BackendSelection.SelectionReason, router.ReasonLabel)
+	}
+	if sess.BackendSelection.SelectedBackend != "codex" {
+		t.Errorf("BackendSelection.SelectedBackend = %q, want %q", sess.BackendSelection.SelectedBackend, "codex")
+	}
+}
+
+func TestStartNewWorkers_StampsBackendSelectionReason_Default(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	issues := []github.Issue{makeIssue(428, "Fix bug")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+
+	s := state.NewState()
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 1 {
+		t.Fatalf("started = %d, want 1", len(*started))
+	}
+	sess := s.Sessions["slot-1"]
+	if sess == nil || sess.BackendSelection == nil {
+		t.Fatalf("session.BackendSelection not stamped: %+v", sess)
+	}
+	if sess.BackendSelection.SelectionReason != router.ReasonDefault {
+		t.Errorf("BackendSelection.SelectionReason = %q, want %q", sess.BackendSelection.SelectionReason, router.ReasonDefault)
+	}
+}
+
+func TestStartNewWorkers_StampsBackendSelectionReason_Auto(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	cfg.Routing.Mode = "auto"
+	issues := []github.Issue{makeIssue(429, "Refactor module")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.router = router.New(cfg)
+	o.router.RouteFn = func(issue github.Issue) (string, string, error) {
+		return "codex", "tight loop", nil
+	}
+
+	s := state.NewState()
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 1 {
+		t.Fatalf("started = %d, want 1", len(*started))
+	}
+	sess := s.Sessions["slot-1"]
+	if sess == nil || sess.BackendSelection == nil {
+		t.Fatalf("session.BackendSelection not stamped: %+v", sess)
+	}
+	if sess.BackendSelection.SelectionReason != router.ReasonAuto {
+		t.Errorf("BackendSelection.SelectionReason = %q, want %q", sess.BackendSelection.SelectionReason, router.ReasonAuto)
+	}
+}
+
+func TestStartNewWorkers_StampsBackendSelectionReason_RouterError(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	cfg.Routing.Mode = "auto"
+	issues := []github.Issue{makeIssue(430, "Routing fails")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.router = router.New(cfg)
+	o.router.RouteFn = func(issue github.Issue) (string, string, error) {
+		return "", "", fmt.Errorf("network error")
+	}
+
+	s := state.NewState()
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 1 {
+		t.Fatalf("started = %d, want 1", len(*started))
+	}
+	sess := s.Sessions["slot-1"]
+	if sess == nil || sess.BackendSelection == nil {
+		t.Fatalf("session.BackendSelection not stamped: %+v", sess)
+	}
+	if sess.BackendSelection.SelectionReason != router.ReasonRouterError {
+		t.Errorf("BackendSelection.SelectionReason = %q, want %q", sess.BackendSelection.SelectionReason, router.ReasonRouterError)
 	}
 }
 

--- a/internal/router/resolve.go
+++ b/internal/router/resolve.go
@@ -15,6 +15,17 @@ const (
 	RoleValidator   = "validator"
 )
 
+// Selection reason canonical values written to Session.BackendSelection.SelectionReason
+// when the orchestrator records why a backend was chosen for an issue.
+const (
+	ReasonLabel       = "label"
+	ReasonRole        = "role"
+	ReasonAuto        = "auto"
+	ReasonDefault     = "default"
+	ReasonRouterError = "router_error"
+	ReasonUnknownPin  = "unknown_label_backend"
+)
+
 // BackendFromLabels extracts a backend name from issue labels with the "model:" prefix.
 // Returns the backend name if found, empty string otherwise.
 // If multiple model: labels exist, the first one wins.
@@ -43,6 +54,11 @@ func ValidateBackend(name string, cfg *config.Config) (string, bool) {
 //  1. model:<backend> label on the issue (highest priority)
 //  2. Auto-routing via LLM (if routing.mode == "auto")
 //  3. Default backend from config
+//
+// The returned reason is one of the canonical Reason* constants. When auto-routing
+// is configured but its execution fails (network / parse / unknown backend), the
+// reason is ReasonRouterError instead of ReasonDefault so operators can tell
+// auto-routing failed silently rather than not being configured at all (#427).
 func (r *Router) ResolveBackend(issue github.Issue) (backendName, reason string) {
 	// 1. Check for model: label (highest priority)
 	if name := BackendFromLabels(issue); name != "" {
@@ -50,10 +66,10 @@ func (r *Router) ResolveBackend(issue github.Issue) (backendName, reason string)
 		if !ok {
 			log.Printf("[router] issue #%d: label specifies unknown backend %q, falling back to default %q",
 				issue.Number, name, r.cfg.Model.Default)
-			return validated, "unknown label backend"
+			return validated, ReasonUnknownPin
 		}
 		log.Printf("[router] issue #%d → %s (label override)", issue.Number, validated)
-		return validated, "label"
+		return validated, ReasonLabel
 	}
 
 	// 2. Auto-routing via LLM (if enabled)
@@ -64,16 +80,23 @@ func (r *Router) ResolveBackend(issue github.Issue) (backendName, reason string)
 		}
 		routedBackend, routeReason, err := routeFn(issue)
 		if err != nil {
-			log.Printf("[router] issue #%d: error %v — using default", issue.Number, err)
-		} else if routedBackend != "" {
-			log.Printf("[router] issue #%d → %s (%s)", issue.Number, routedBackend, routeReason)
-			return routedBackend, routeReason
+			log.Printf("[router] issue #%d: auto-routing failed (%v) — using default %q with reason=%s",
+				issue.Number, err, r.cfg.Model.Default, ReasonRouterError)
+			return r.cfg.Model.Default, ReasonRouterError
 		}
-		// Fall through to default on error or empty backend
+		if routedBackend != "" {
+			log.Printf("[router] issue #%d → %s (auto: %s)", issue.Number, routedBackend, routeReason)
+			return routedBackend, ReasonAuto
+		}
+		// Auto-routing returned empty without an error — treat as router_error too
+		// so the dashboard can distinguish silent fallback from manual mode.
+		log.Printf("[router] issue #%d: auto-routing returned empty backend — using default %q with reason=%s",
+			issue.Number, r.cfg.Model.Default, ReasonRouterError)
+		return r.cfg.Model.Default, ReasonRouterError
 	}
 
 	// 3. Default backend
-	return r.cfg.Model.Default, "default"
+	return r.cfg.Model.Default, ReasonDefault
 }
 
 // roleBackend returns the configured backend name for a given role, or empty string if not set.
@@ -102,10 +125,10 @@ func (r *Router) ResolveBackendForRole(issue github.Issue, role string) (backend
 		if !ok {
 			log.Printf("[router] issue #%d role=%s: label specifies unknown backend %q, falling back to default %q",
 				issue.Number, role, name, r.cfg.Model.Default)
-			return validated, "unknown label backend"
+			return validated, ReasonUnknownPin
 		}
 		log.Printf("[router] issue #%d role=%s → %s (label override)", issue.Number, role, validated)
-		return validated, "label"
+		return validated, ReasonLabel
 	}
 
 	// 2. Role-specific backend from config
@@ -116,7 +139,7 @@ func (r *Router) ResolveBackendForRole(issue github.Issue, role string) (backend
 				issue.Number, role, rb)
 		} else {
 			log.Printf("[router] issue #%d role=%s → %s (role config)", issue.Number, role, validated)
-			return validated, "role"
+			return validated, ReasonRole
 		}
 	}
 

--- a/internal/router/resolve_test.go
+++ b/internal/router/resolve_test.go
@@ -143,8 +143,8 @@ func TestResolveBackend_LabelOverride_UnknownBackend(t *testing.T) {
 	if name != "claude" {
 		t.Errorf("ResolveBackend() name = %q, want %q (should fall back to default)", name, "claude")
 	}
-	if reason != "unknown label backend" {
-		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "unknown label backend")
+	if reason != ReasonUnknownPin {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, ReasonUnknownPin)
 	}
 }
 
@@ -289,8 +289,8 @@ func TestResolveBackend_AutoRoutingViaRouteFn(t *testing.T) {
 	if name != "codex" {
 		t.Errorf("ResolveBackend() name = %q, want %q", name, "codex")
 	}
-	if reason != "simple fix" {
-		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "simple fix")
+	if reason != ReasonAuto {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, ReasonAuto)
 	}
 }
 
@@ -662,8 +662,8 @@ func TestResolveBackendForRole_WithAutoRouting(t *testing.T) {
 	if name != "codex" {
 		t.Errorf("ResolveBackendForRole(planner) name = %q, want %q (should fall through to auto-routing)", name, "codex")
 	}
-	if reason != "auto-routed" {
-		t.Errorf("ResolveBackendForRole(planner) reason = %q, want %q", reason, "auto-routed")
+	if reason != ReasonAuto {
+		t.Errorf("ResolveBackendForRole(planner) reason = %q, want %q", reason, ReasonAuto)
 	}
 }
 
@@ -702,7 +702,7 @@ func TestResolveBackendForRole_RoleBackendOverridesAutoRouting(t *testing.T) {
 	}
 }
 
-func TestResolveBackend_AutoRoutingErrorFallsToDefault(t *testing.T) {
+func TestResolveBackend_AutoRoutingErrorFallsToDefaultWithRouterErrorReason(t *testing.T) {
 	cfg := &config.Config{
 		Model: config.ModelConfig{
 			Default: "claude",
@@ -718,12 +718,78 @@ func TestResolveBackend_AutoRoutingErrorFallsToDefault(t *testing.T) {
 		return "", "", fmt.Errorf("network error")
 	}
 
+	// #427: when routing.mode=auto is configured but the router call fails,
+	// the fallback to the default backend must surface a router_error reason
+	// (not the bare "default" used in manual mode) so operators can see that
+	// auto-routing failed silently rather than being unconfigured.
 	issue := makeIssue(48, "Fix bug")
 	name, reason := r.ResolveBackend(issue)
 	if name != "claude" {
 		t.Errorf("ResolveBackend() name = %q, want %q (should fall back to default)", name, "claude")
 	}
-	if reason != "default" {
-		t.Errorf("ResolveBackend() reason = %q, want %q", reason, "default")
+	if reason != ReasonRouterError {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, ReasonRouterError)
+	}
+}
+
+// #427: command strings with arguments must reach the router CLI through
+// splitRouterCmd, and a router that picks an unknown backend must surface
+// router_error so the dashboard does not present the default as auto-routed.
+func TestRoute_UnknownBackendFromCommandReturnsRouterError(t *testing.T) {
+	dir := t.TempDir()
+	cliPath := filepath.Join(dir, "router-cli")
+	// The fake CLI accepts any --foo arg and prints a backend that isn't in config.
+	script := "#!/bin/sh\nprintf '{\"backend\":\"nonexistent\",\"reason\":\"pick\"}'\n"
+	if err := os.WriteFile(cliPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake router cli: %v", err)
+	}
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: cliPath + " --temperature 0"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+		Routing: config.RoutingConfig{
+			Mode:        "auto",
+			RouterModel: "claude",
+		},
+	}
+
+	r := New(cfg)
+	name, reason := r.ResolveBackend(github.Issue{Number: 99, Title: "Anything"})
+	if name != "claude" {
+		t.Fatalf("ResolveBackend() name = %q, want claude (default fallback)", name)
+	}
+	if reason != ReasonRouterError {
+		t.Fatalf("ResolveBackend() reason = %q, want %q (silent unknown-backend fallback must surface router_error)", reason, ReasonRouterError)
+	}
+}
+
+// #427: an auto-routed call that returns an empty backend without error is
+// still a silent fallback — operators need the router_error signal too.
+func TestResolveBackend_AutoRoutingEmptyBackendUsesRouterErrorReason(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+		Routing: config.RoutingConfig{Mode: "auto"},
+	}
+	r := New(cfg)
+	r.RouteFn = func(issue github.Issue) (string, string, error) {
+		return "", "", nil
+	}
+
+	name, reason := r.ResolveBackend(makeIssue(49, "Empty route"))
+	if name != "claude" {
+		t.Errorf("ResolveBackend() name = %q, want %q", name, "claude")
+	}
+	if reason != ReasonRouterError {
+		t.Errorf("ResolveBackend() reason = %q, want %q", reason, ReasonRouterError)
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -40,7 +40,9 @@ func New(cfg *config.Config) *Router {
 
 // Route calls the router model to decide which backend to use for the issue.
 // Returns the backend name and a short reason for the decision.
-// On any error or unknown backend, falls back to config's default backend.
+// On any error (model call, parse, unknown backend), returns the configured
+// default backend and a non-nil error so callers can distinguish a real
+// auto-routed pick from a silent fallback (#427).
 func (r *Router) Route(issue github.Issue) (backendName string, reason string, err error) {
 	prompt := r.buildPrompt(issue)
 
@@ -56,10 +58,12 @@ func (r *Router) Route(issue github.Issue) (backendName string, reason string, e
 		return r.cfg.Model.Default, "parse error", err
 	}
 
-	// Validate that the chosen backend exists in config
+	// Validate that the chosen backend exists in config. Return an error so
+	// ResolveBackend can attribute the fallback to router_error rather than
+	// silently presenting the default backend as if it was task-routed (#427).
 	if _, ok := r.cfg.Model.Backends[resp.Backend]; !ok {
 		log.Printf("[router] unknown backend %q — falling back to default", resp.Backend)
-		return r.cfg.Model.Default, fmt.Sprintf("unknown backend %q", resp.Backend), nil
+		return r.cfg.Model.Default, fmt.Sprintf("unknown backend %q", resp.Backend), fmt.Errorf("router picked unknown backend %q", resp.Backend)
 	}
 
 	return resp.Backend, resp.Reason, nil

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -521,24 +521,28 @@ type fleetApprovalState struct {
 }
 
 type fleetWorkerState struct {
-	ProjectName       string `json:"project_name"`
-	ProjectRepo       string `json:"project_repo,omitempty"`
-	DashboardURL      string `json:"dashboard_url,omitempty"`
-	Slot              string `json:"slot"`
-	IssueNumber       int    `json:"issue_number"`
-	IssueTitle        string `json:"issue_title"`
-	IssueURL          string `json:"issue_url,omitempty"`
-	Status            string `json:"status"`
-	DisplayStatus     string `json:"display_status,omitempty"`
-	StatusReason      string `json:"status_reason,omitempty"`
-	NextAction        string `json:"next_action,omitempty"`
-	NeedsAttention    bool   `json:"needs_attention,omitempty"`
-	Live              bool   `json:"live"`
-	Backend           string `json:"backend,omitempty"`
-	PRNumber          int    `json:"pr_number,omitempty"`
-	PRURL             string `json:"pr_url,omitempty"`
-	TokensUsedAttempt int    `json:"tokens_used_attempt"`
-	TokensUsedTotal   int    `json:"tokens_used_total"`
+	ProjectName    string `json:"project_name"`
+	ProjectRepo    string `json:"project_repo,omitempty"`
+	DashboardURL   string `json:"dashboard_url,omitempty"`
+	Slot           string `json:"slot"`
+	IssueNumber    int    `json:"issue_number"`
+	IssueTitle     string `json:"issue_title"`
+	IssueURL       string `json:"issue_url,omitempty"`
+	Status         string `json:"status"`
+	DisplayStatus  string `json:"display_status,omitempty"`
+	StatusReason   string `json:"status_reason,omitempty"`
+	NextAction     string `json:"next_action,omitempty"`
+	NeedsAttention bool   `json:"needs_attention,omitempty"`
+	Live           bool   `json:"live"`
+	Backend        string `json:"backend,omitempty"`
+	// BackendSelection records why this backend was chosen (label, role, auto,
+	// default, router_error, phase, review_repair). Surfaced on the fleet drawer
+	// so operators can tell task-based routing from label-pinned defaults. (#427)
+	BackendSelection  *state.BackendSelection `json:"backend_selection,omitempty"`
+	PRNumber          int                     `json:"pr_number,omitempty"`
+	PRURL             string                  `json:"pr_url,omitempty"`
+	TokensUsedAttempt int                     `json:"tokens_used_attempt"`
+	TokensUsedTotal   int                     `json:"tokens_used_total"`
 	// Runtime / RuntimeSeconds (legacy fields, kept for backwards
 	// compatibility) reflect workflow elapsed time and include PR-open /
 	// CI / Greptile / merge waiting. See #426 — WorkerRuntimeSeconds is
@@ -2687,6 +2691,7 @@ func makeFleetWorkerState(project fleetProjectState, worker sessionInfo) fleetWo
 		NeedsAttention:         worker.NeedsAttention,
 		Live:                   worker.Live,
 		Backend:                worker.Backend,
+		BackendSelection:       worker.BackendSelection,
 		PRNumber:               worker.PRNumber,
 		PRURL:                  worker.PRURL,
 		TokensUsedAttempt:      worker.TokensUsedAttempt,


### PR DESCRIPTION
Refs #427

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses issue #427 by making backend routing decisions visible: it stamps a canonical `SelectionReason` on every new session's `BackendSelection`, exposes that field through the fleet API, and adds a config-load warning when multiple backends are configured with no task-based routing mechanism.

- `router.Reason*` constants (`label`, `role`, `auto`, `default`, `router_error`, `unknown_label_backend`) replace free-form strings; `Route()` now returns a non-nil error for unknown-backend picks so callers can distinguish silent fallbacks from real auto-routed selections.
- `startNewWorkers` stamps `BackendSelection` on each dispatched session and sends an operator notification when auto-routing fails with `router_error`; the `\"phase\"` and `\"review_repair\"` paths write reason strings as bare literals rather than exported constants.
- `manualRoutingLabelPinWarning` fires at config load for multi-backend projects that are in manual mode with no per-role overrides, with five new tests covering all guard conditions.

<h3>Confidence Score: 3/5</h3>

Mostly safe, but a label-misconfiguration fallback silently reroutes to the default backend without any in-channel operator warning.

When an issue carries a model:nonexistent label, the orchestrator falls back to the default backend with reason unknown_label_backend and stamps the session record — but unlike the parallel router_error path, it never calls o.notifier.Sendf. The operator put an explicit label on the issue expecting a specific backend; they won't know it was ignored until they inspect the session drawer. The rest of the change — constant definitions, BackendSelection stamping, Route() error propagation, and the config warning — is solid and well-tested.

internal/orchestrator/orchestrator.go — the notification guard in startNewWorkers needs to cover router.ReasonUnknownPin alongside router.ReasonRouterError.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds resolveBackendWithReason, stamps BackendSelection on sessions, and notifies on ReasonRouterError — but the notification guard misses ReasonUnknownPin, leaving label-misconfiguration fallbacks silent; also uses bare string literals for phase and review_repair reasons instead of exported constants. |
| internal/router/resolve.go | Adds Reason* exported constants and updates ResolveBackend / ResolveBackendForRole to return canonical reason strings; auto-routing empty-backend path now correctly returns ReasonRouterError instead of silently falling through. |
| internal/router/router.go | Unknown-backend path in Route now returns a non-nil error so ResolveBackend can attribute the fallback to router_error rather than presenting it as a clean default pick; comment updated accordingly. |
| internal/config/config.go | Adds manualRoutingLabelPinWarning that fires when 2+ backends exist but routing is not task-based; fires correctly for empty/manual mode and suppresses for auto-routing and per-role configs. |
| internal/server/fleet.go | Adds BackendSelection field to fleetWorkerState and wires it through makeFleetWorkerState; JSON-serialised as backend_selection with omitempty. |
| internal/orchestrator/orchestrator_test.go | Comprehensive new tests for resolveBackendWithReason and startNewWorkers BackendSelection stamping across all four reason paths; does not add a test for the ReasonUnknownPin dispatch path. |
| internal/config/warnings_test.go | Five new tests covering all guard conditions of manualRoutingLabelPinWarning (multi-backend, single-backend, auto, empty-routing, per-role); all cases are well-targeted. |
| internal/router/resolve_test.go | Updates existing tests to use Reason* constants and adds new tests for auto-routing empty-backend and unknown-backend-via-CLI paths; coverage is thorough. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:3862-3865
**Missing notification for unknown-label backend fallback**

The notification only fires for `router.ReasonRouterError`, but `router.ReasonUnknownPin` (`"unknown_label_backend"`) represents an equally silent misconfiguration: an operator puts `model:nonexistent` on an issue expecting that backend to be used, but the orchestrator quietly reroutes to the default with no in-channel warning. Unlike the auto-routing error case, this label misconfiguration is invisible to the operator at dispatch time — they only discover it by inspecting the session's `BackendSelection` record after the fact. The notification guard should also cover `router.ReasonUnknownPin`.

### Issue 2 of 2
internal/orchestrator/orchestrator.go:3844-3851
**Hardcoded reason strings bypass the `router.Reason*` constant pattern**

`"review_repair"` and `"phase"` are written to `Session.BackendSelection.SelectionReason` as bare string literals while all other reasons use exported `router.Reason*` constants. These values are also surfaced in the fleet API (documented in `fleet.go`), so any future rename will need a coordinated update across the orchestrator, the fleet serializer, and any consumers of the API — with no compile-time check to catch a mismatch. Defining `ReasonPhase` and `ReasonReviewRepair` constants in `internal/router/resolve.go` alongside the existing set would close this gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(router,orchestrator,fleet,config): ..."](https://github.com/befeast/maestro/commit/ebccc18a9a26dccc667765e3d74f402c61970cee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35060791)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->