### PR TITLE
P2: Approvals page — group duplicates by target, allow bulk actions, drop title=summary duplication

### DIFF
--- a/internal/approver/title.go
+++ b/internal/approver/title.go
@@ -1,0 +1,121 @@
+package approver
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// ApprovalTitle returns the short, action-first card title for an approval
+// (issue #533, spec gap 12). The supervisor stores the full reasoning in
+// Approval.Summary — historically the dashboard used that string for BOTH
+// the card title and the body, producing a 1:1 duplication that read like
+// "Start a worker for issue #487: P0: ..." twice on the same card. The
+// title returned here is intentionally terse — "Start worker · #487",
+// "Merge PR · #123", "Close issue · #42" — so the long-form summary is
+// rendered exactly once, as the body.
+//
+// The function is total over an Approval; an unrecognised verb falls back
+// to a verb-prettified form ("foo bar · #N"), and a missing target collapses
+// the suffix.
+func ApprovalTitle(approval *state.Approval) string {
+	if approval == nil {
+		return ""
+	}
+	verb := actionVerbLabel(approval.Action)
+	suffix := approvalTargetSuffix(approval.Target)
+	if suffix == "" {
+		return verb
+	}
+	return verb + " · " + suffix
+}
+
+// ApprovalGroupKey returns the per-target dedup key the dashboard uses to
+// fold N re-emitted approvals that share the same (issue, pr) target into a
+// single card with a «regenerated N times» badge (issue #533, spec gap 1).
+//
+// The key is stable across the lifetime of a target so an approval on issue
+// #487 minted at t0 and the same approval minted at t1 (after the dedup
+// window expired or a fresh decision rolled in) share a key — the SPA can
+// then count and group without needing to interpret the verb.
+//
+// When the approval lacks a target, the approval ID is used as a singleton
+// key so the card still renders as its own group instead of all
+// target-less approvals collapsing onto one row.
+func ApprovalGroupKey(approval *state.Approval) string {
+	if approval == nil {
+		return ""
+	}
+	if approval.Target != nil {
+		t := approval.Target
+		switch {
+		case t.PR > 0:
+			return fmt.Sprintf("pr:%d", t.PR)
+		case t.Issue > 0:
+			return fmt.Sprintf("issue:%d", t.Issue)
+		case strings.TrimSpace(t.Session) != "":
+			return "session:" + strings.TrimSpace(t.Session)
+		}
+	}
+	if id := strings.TrimSpace(approval.ID); id != "" {
+		return "id:" + id
+	}
+	return "ungrouped"
+}
+
+// actionVerbLabel maps an Approval.Action to the short verb form the card
+// title uses. Kept in sync with the SPA's actionLabel() so server-rendered
+// and client-rendered titles agree.
+func actionVerbLabel(action string) string {
+	switch strings.TrimSpace(action) {
+	case config.SupervisorActionMergePR:
+		return "Merge PR"
+	case config.SupervisorActionCloseIssue:
+		return "Close issue"
+	case config.SupervisorActionDeleteWorktree:
+		return "Delete worktree"
+	case config.SupervisorActionChangeGlobalConfig:
+		return "Apply config change"
+	case "spawn_worker":
+		return "Start worker"
+	case "open_child_issue":
+		return "Open child issue"
+	case config.SupervisorActionSpawnReviewRepair:
+		return "Spawn review-repair"
+	case "":
+		return "Approval"
+	default:
+		return prettifyVerb(action)
+	}
+}
+
+// approvalTargetSuffix returns the "#N" / "slot foo" tail of an approval
+// title — empty when no target is set.
+func approvalTargetSuffix(target *state.SupervisorTarget) string {
+	if target == nil {
+		return ""
+	}
+	switch {
+	case target.PR > 0:
+		return fmt.Sprintf("#%d", target.PR)
+	case target.Issue > 0:
+		return fmt.Sprintf("#%d", target.Issue)
+	case strings.TrimSpace(target.Session) != "":
+		return "slot " + strings.TrimSpace(target.Session)
+	}
+	return ""
+}
+
+// prettifyVerb replaces underscores with spaces and uppercases the first
+// rune, so a future verb the registry knows but this file does not still
+// renders as a reasonable title ("do_something" -> "Do something").
+func prettifyVerb(verb string) string {
+	v := strings.TrimSpace(verb)
+	if v == "" {
+		return ""
+	}
+	v = strings.ReplaceAll(v, "_", " ")
+	return strings.ToUpper(v[:1]) + v[1:]
+}

--- a/internal/approver/title_test.go
+++ b/internal/approver/title_test.go
@@ -1,0 +1,161 @@
+package approver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// TestApprovalTitle_DropsSummaryDuplication pins issue #533 spec gap 12:
+// the card title MUST be the short `<verb> · #<target>` form, NOT the
+// full supervisor summary. A regression here means the dashboard shows
+// the summary text twice (once as title, once as body).
+func TestApprovalTitle_DropsSummaryDuplication(t *testing.T) {
+	cases := []struct {
+		name   string
+		action string
+		target *state.SupervisorTarget
+		want   string
+	}{
+		{
+			name:   "spawn_worker_uses_short_form_not_summary",
+			action: "spawn_worker",
+			target: &state.SupervisorTarget{Issue: 487},
+			want:   "Start worker · #487",
+		},
+		{
+			name:   "merge_pr_uses_pr_number",
+			action: config.SupervisorActionMergePR,
+			target: &state.SupervisorTarget{PR: 123, Issue: 100},
+			want:   "Merge PR · #123",
+		},
+		{
+			name:   "close_issue_uses_issue_number",
+			action: config.SupervisorActionCloseIssue,
+			target: &state.SupervisorTarget{Issue: 42},
+			want:   "Close issue · #42",
+		},
+		{
+			name:   "delete_worktree_uses_slot",
+			action: config.SupervisorActionDeleteWorktree,
+			target: &state.SupervisorTarget{Session: "sup-7"},
+			want:   "Delete worktree · slot sup-7",
+		},
+		{
+			name:   "spawn_review_repair_uses_pr_number",
+			action: config.SupervisorActionSpawnReviewRepair,
+			target: &state.SupervisorTarget{PR: 555, Issue: 540},
+			want:   "Spawn review-repair · #555",
+		},
+		{
+			name:   "open_child_issue_uses_parent_issue_number",
+			action: "open_child_issue",
+			target: &state.SupervisorTarget{Issue: 146},
+			want:   "Open child issue · #146",
+		},
+		{
+			name:   "change_global_config_no_target_collapses_suffix",
+			action: config.SupervisorActionChangeGlobalConfig,
+			target: nil,
+			want:   "Apply config change",
+		},
+		{
+			name:   "unknown_verb_prettified",
+			action: "do_something",
+			target: &state.SupervisorTarget{Issue: 1},
+			want:   "Do something · #1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			longSummary := "Start a worker for issue #487: P0: add HTTP auth on mutating dashboard endpoints (write-path premortem #4)"
+			a := &state.Approval{Action: tc.action, Target: tc.target, Summary: longSummary}
+			got := ApprovalTitle(a)
+			if got != tc.want {
+				t.Fatalf("ApprovalTitle = %q, want %q", got, tc.want)
+			}
+			// The whole point of the fix: the title must NOT contain the
+			// supervisor's long summary text.
+			if strings.Contains(got, longSummary) {
+				t.Fatalf("title %q contains supervisor summary %q — gap 12 regression", got, longSummary)
+			}
+		})
+	}
+}
+
+func TestApprovalTitle_NilApproval(t *testing.T) {
+	if got := ApprovalTitle(nil); got != "" {
+		t.Fatalf("ApprovalTitle(nil) = %q, want empty", got)
+	}
+}
+
+// TestApprovalGroupKey_GroupsByTarget pins issue #533 spec gap 1: two
+// approvals that share the same target — whether the verb is the same or
+// not — collapse onto a single group key so the SPA can render them as
+// «regenerated N times» on one card instead of N flat cards.
+func TestApprovalGroupKey_GroupsByTarget(t *testing.T) {
+	cases := []struct {
+		name string
+		a    *state.Approval
+		want string
+	}{
+		{
+			name: "pr_target_keyed_by_pr_number",
+			a:    &state.Approval{Action: config.SupervisorActionMergePR, Target: &state.SupervisorTarget{PR: 99, Issue: 50}},
+			want: "pr:99",
+		},
+		{
+			name: "issue_target_keyed_by_issue_number",
+			a:    &state.Approval{Action: "spawn_worker", Target: &state.SupervisorTarget{Issue: 487}},
+			want: "issue:487",
+		},
+		{
+			name: "session_target_keyed_by_slot",
+			a:    &state.Approval{Action: config.SupervisorActionDeleteWorktree, Target: &state.SupervisorTarget{Session: "sup-7"}},
+			want: "session:sup-7",
+		},
+		{
+			name: "pr_dominates_when_both_set",
+			a:    &state.Approval{Target: &state.SupervisorTarget{Issue: 500, PR: 600}},
+			want: "pr:600",
+		},
+		{
+			name: "no_target_falls_back_to_id_singleton",
+			a:    &state.Approval{ID: "approval-XYZ", Target: nil},
+			want: "id:approval-XYZ",
+		},
+		{
+			name: "no_target_no_id_collapses_to_ungrouped",
+			a:    &state.Approval{},
+			want: "ungrouped",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ApprovalGroupKey(tc.a); got != tc.want {
+				t.Fatalf("ApprovalGroupKey = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApprovalGroupKey_TwoApprovalsSameTargetShareKey is the directly
+// observable behaviour the dashboard relies on: minting a fresh approval
+// over an already-resolved one on the same issue produces the same group
+// key, so the SPA's «regenerated 2 times» badge can count them.
+func TestApprovalGroupKey_TwoApprovalsSameTargetShareKey(t *testing.T) {
+	a := &state.Approval{ID: "first", Action: "spawn_worker", Target: &state.SupervisorTarget{Issue: 487}}
+	b := &state.Approval{ID: "second", Action: "spawn_worker", Target: &state.SupervisorTarget{Issue: 487}}
+	if ApprovalGroupKey(a) != ApprovalGroupKey(b) {
+		t.Fatalf("same-target approvals must share a group key; got %q and %q",
+			ApprovalGroupKey(a), ApprovalGroupKey(b))
+	}
+}
+
+func TestApprovalGroupKey_NilApproval(t *testing.T) {
+	if got := ApprovalGroupKey(nil); got != "" {
+		t.Fatalf("ApprovalGroupKey(nil) = %q, want empty", got)
+	}
+}

--- a/internal/server/approval_title_group_test.go
+++ b/internal/server/approval_title_group_test.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// TestFleetApproval_TitleDropsSummaryDuplication pins issue #533 spec gap
+// 12 at the API layer: the JSON Title field is the short
+// "<verb> · #<target>" form, NOT the full supervisor summary that lives
+// in Summary. The SPA renders Title as the heading and Summary as the
+// body — when these collide (the pre-#533 bug) the card prints the same
+// long sentence twice.
+func TestFleetApproval_TitleDropsSummaryDuplication(t *testing.T) {
+	longSummary := "Start a worker for issue #487: P0: add HTTP auth on mutating dashboard endpoints (write-path premortem #4)"
+	st := &state.State{
+		Approvals: []state.Approval{{
+			ID:      "ap-1",
+			Action:  "spawn_worker",
+			Target:  &state.SupervisorTarget{Issue: 487},
+			Status:  state.ApprovalStatusPending,
+			Summary: longSummary,
+		}},
+	}
+	project := fleetProjectState{Name: "scribe", Repo: "owner/repo"}
+
+	items := makeFleetApprovalStates(project, st, time.Now().UTC())
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	got := items[0]
+
+	if got.Title != "Start worker · #487" {
+		t.Fatalf("Title = %q, want %q", got.Title, "Start worker · #487")
+	}
+	if got.Summary != longSummary {
+		t.Fatalf("Summary = %q, want supervisor reasoning preserved verbatim", got.Summary)
+	}
+	if strings.Contains(got.Title, longSummary) {
+		t.Fatalf("Title %q absorbs the supervisor summary — gap 12 regression", got.Title)
+	}
+	if got.Title == got.Summary {
+		t.Fatalf("Title and Summary collide (%q) — gap 12 regression", got.Title)
+	}
+}
+
+// TestFleetApproval_GroupKeyAndSize_RegeneratedCard pins gap 1: two LIVE
+// approvals on the same target collapse onto one group key with
+// GroupSize=2, so the SPA can render «regenerated 2 times» on a single
+// card instead of two flat rows.
+func TestFleetApproval_GroupKeyAndSize_RegeneratedCard(t *testing.T) {
+	st := &state.State{
+		Approvals: []state.Approval{
+			{
+				ID:     "first",
+				Action: "spawn_worker",
+				Target: &state.SupervisorTarget{Issue: 487},
+				Status: state.ApprovalStatusPending,
+			},
+			{
+				ID:     "second",
+				Action: "spawn_worker",
+				Target: &state.SupervisorTarget{Issue: 487},
+				Status: state.ApprovalStatusAwaitingDispatch,
+			},
+		},
+	}
+	items := makeFleetApprovalStates(fleetProjectState{Name: "scribe"}, st, time.Now().UTC())
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	for _, item := range items {
+		if item.GroupKey != "issue:487" {
+			t.Fatalf("approval %s GroupKey = %q, want issue:487", item.ID, item.GroupKey)
+		}
+		if item.GroupSize != 2 {
+			t.Fatalf("approval %s GroupSize = %d, want 2 (one card, regenerated once)", item.ID, item.GroupSize)
+		}
+	}
+}
+
+// TestFleetApproval_GroupSize_OnlyCountsLive verifies a terminal approval
+// (rejected / superseded / stale) is excluded from the regenerated count
+// — once the operator dismisses one of two duplicates, the remaining one
+// renders as a singleton, not as a 2-card stack.
+func TestFleetApproval_GroupSize_OnlyCountsLive(t *testing.T) {
+	st := &state.State{
+		Approvals: []state.Approval{
+			{
+				ID:     "live",
+				Action: "spawn_worker",
+				Target: &state.SupervisorTarget{Issue: 487},
+				Status: state.ApprovalStatusPending,
+			},
+			{
+				ID:     "dead-rejected",
+				Action: "spawn_worker",
+				Target: &state.SupervisorTarget{Issue: 487},
+				Status: state.ApprovalStatusRejected,
+			},
+			{
+				ID:     "dead-superseded",
+				Action: "spawn_worker",
+				Target: &state.SupervisorTarget{Issue: 487},
+				Status: state.ApprovalStatusSuperseded,
+			},
+		},
+	}
+	items := makeFleetApprovalStates(fleetProjectState{Name: "scribe"}, st, time.Now().UTC())
+	if len(items) != 3 {
+		t.Fatalf("items = %d, want 3", len(items))
+	}
+	for _, item := range items {
+		if item.GroupKey != "issue:487" {
+			t.Fatalf("approval %s GroupKey = %q, want issue:487", item.ID, item.GroupKey)
+		}
+		if item.GroupSize != 1 {
+			t.Fatalf("approval %s GroupSize = %d, want 1 (one live, two terminal)", item.ID, item.GroupSize)
+		}
+	}
+}
+
+// TestFleetApproval_GroupKey_PerTargetSeparation verifies that approvals on
+// different targets do NOT share a group — issue #487 and issue #488 each
+// render as singletons.
+func TestFleetApproval_GroupKey_PerTargetSeparation(t *testing.T) {
+	st := &state.State{
+		Approvals: []state.Approval{
+			{ID: "a", Action: "spawn_worker", Target: &state.SupervisorTarget{Issue: 487}, Status: state.ApprovalStatusPending},
+			{ID: "b", Action: "spawn_worker", Target: &state.SupervisorTarget{Issue: 488}, Status: state.ApprovalStatusPending},
+		},
+	}
+	items := makeFleetApprovalStates(fleetProjectState{Name: "scribe"}, st, time.Now().UTC())
+	for _, item := range items {
+		if item.GroupSize != 1 {
+			t.Fatalf("approval %s GroupSize = %d, want 1 (per-target separation)", item.ID, item.GroupSize)
+		}
+	}
+}

--- a/internal/server/approvals.go
+++ b/internal/server/approvals.go
@@ -27,6 +27,41 @@ type approvalDecisionResponse struct {
 	Approval *state.Approval `json:"approval"`
 }
 
+// approvalBulkRequest is the JSON body accepted by bulk reject/supersede
+// endpoints (#533 spec gap 7). IDs is the list of approval identifiers
+// the operator multi-selected on the dashboard; Verb is "reject" or
+// "supersede" — the server applies the same audit-recorded transition
+// to each id, atomically (single state.Save) so a partial failure does
+// not leave the queue in a half-applied state.
+type approvalBulkRequest struct {
+	IDs    []string `json:"ids"`
+	Verb   string   `json:"verb"`
+	Actor  string   `json:"actor,omitempty"`
+	Reason string   `json:"reason,omitempty"`
+}
+
+// approvalBulkItemResult describes the per-id outcome inside an
+// approvalBulkResponse. Status is "ok" for an applied transition,
+// "skipped" when the approval was already in a terminal state, or
+// "error" with Error populated for unrecoverable per-id failures.
+type approvalBulkItemResult struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+// approvalBulkResponse is the JSON body returned by bulk endpoints. OK
+// is true when at least one id was applied AND no id produced an error.
+// Counts let the dashboard render a "rejected 3, skipped 1" toast
+// without re-scanning Items.
+type approvalBulkResponse struct {
+	OK      bool                     `json:"ok"`
+	Applied int                      `json:"applied"`
+	Skipped int                      `json:"skipped"`
+	Errors  int                      `json:"errors"`
+	Items   []approvalBulkItemResult `json:"items"`
+}
+
 // approvalRoute is "approve" or "reject" parsed from the URL.
 type approvalRoute struct {
 	id   string
@@ -144,12 +179,147 @@ func applyApprovalDecision(w http.ResponseWriter, r *http.Request, readOnly bool
 	writeJSON(w, http.StatusOK, approvalDecisionResponse{OK: true, Approval: approval})
 }
 
+// applyApprovalBulk runs reject-or-supersede across a set of approval ids
+// in a single state Load/Save (#533 spec gap 7). Each id transitions
+// independently — an already-terminal approval is reported with
+// status="skipped" instead of failing the whole batch — but the final
+// state.Save is conditional on at least one transition succeeding, so a
+// "no ids matched" request does not churn the on-disk state.
+//
+// Identity rules mirror applyApprovalDecision: the authenticated actor
+// (when auth is configured) overrides any body field; the read-only
+// gate fires AFTER auth so an unauthenticated probe always sees 401.
+func applyApprovalBulk(w http.ResponseWriter, r *http.Request, readOnly bool, scope string, stateDir string, auth authChecker) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	authenticatedActor, ok := requireAuth(w, r, auth)
+	if !ok {
+		return
+	}
+	if readOnly {
+		writeError(w, http.StatusForbidden, scope+" is read-only; approval write actions require approval-backed controls to be enabled in configuration")
+		return
+	}
+	if strings.TrimSpace(stateDir) == "" {
+		writeError(w, http.StatusInternalServerError, "no state dir is available to update approvals")
+		return
+	}
+
+	var req approvalBulkRequest
+	if r.Body != nil {
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("decode bulk approval request: %v", err))
+			return
+		}
+	}
+	verb := strings.TrimSpace(req.Verb)
+	if verb != "reject" && verb != "supersede" {
+		writeError(w, http.StatusBadRequest, "verb must be \"reject\" or \"supersede\"")
+		return
+	}
+	if len(req.IDs) == 0 {
+		writeError(w, http.StatusBadRequest, "ids is required and must contain at least one approval id")
+		return
+	}
+
+	actor := resolveActor(authenticatedActor, req.Actor, "dashboard")
+	reason := strings.TrimSpace(req.Reason)
+
+	st, err := state.Load(stateDir)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load state: %v", err))
+		return
+	}
+
+	now := time.Now().UTC()
+	resp := approvalBulkResponse{Items: make([]approvalBulkItemResult, 0, len(req.IDs))}
+	seen := make(map[string]struct{}, len(req.IDs))
+	for _, raw := range req.IDs {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		var txErr error
+		switch verb {
+		case "reject":
+			_, txErr = st.RejectApproval(id, now, actor, reason)
+		case "supersede":
+			_, txErr = st.SupersedeApproval(id, now, actor, reason)
+		}
+		item := approvalBulkItemResult{ID: id}
+		switch {
+		case txErr == nil:
+			item.Status = "ok"
+			resp.Applied++
+		case errors.Is(txErr, state.ErrApprovalNotFound):
+			item.Status = "error"
+			item.Error = txErr.Error()
+			resp.Errors++
+		case errors.Is(txErr, state.ErrApprovalStale),
+			errors.Is(txErr, state.ErrApprovalSuperseded),
+			errors.Is(txErr, state.ErrApprovalNotPending),
+			errors.Is(txErr, state.ErrApprovalPayloadMismatch):
+			// Already-resolved approvals are not failures for bulk —
+			// the operator may have re-submitted after a partial apply
+			// or a stale snapshot. Report them as skipped so the SPA
+			// can render «3 rejected · 1 skipped» without raising an
+			// error banner.
+			item.Status = "skipped"
+			item.Error = txErr.Error()
+			resp.Skipped++
+		default:
+			item.Status = "error"
+			item.Error = txErr.Error()
+			resp.Errors++
+		}
+		resp.Items = append(resp.Items, item)
+	}
+
+	// Persist only when at least one transition actually mutated state.
+	// A "nothing applied" request leaves the on-disk store untouched.
+	if resp.Applied > 0 {
+		if err := state.Save(stateDir, st); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("save state: %v", err))
+			return
+		}
+	}
+	resp.OK = resp.Applied > 0 && resp.Errors == 0
+	status := http.StatusOK
+	if !resp.OK && resp.Applied == 0 && resp.Errors > 0 {
+		// All ids errored — surface 4xx so the dashboard treats the
+		// response as a failure, not a half-success.
+		status = http.StatusBadRequest
+	}
+	writeJSON(w, status, resp)
+}
+
 // --- single-project server hookup -------------------------------------------
 
 func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
+	// #533 spec gap 7: /api/v1/approvals/bulk handles multi-id
+	// reject/supersede. Route it here so the single-project server does
+	// not need a separate mux entry (the catch-all /api/v1/approvals/
+	// prefix already owns this segment).
+	if strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/api/v1/approvals/")) == "bulk" {
+		stateDir := ""
+		cfg := s.cfg
+		if cfg != nil {
+			stateDir = cfg.StateDir
+		}
+		applyApprovalBulk(w, r, cfgServerReadOnly(cfg), "server", stateDir, s.auth)
+		return
+	}
 	route, ok := parseApprovalPath("/api/v1/approvals/", r.URL.Path)
 	if !ok {
-		writeError(w, http.StatusNotFound, "expected /api/v1/approvals/{id}/{approve|reject}")
+		writeError(w, http.StatusNotFound, "expected /api/v1/approvals/{id}/{approve|reject} or /api/v1/approvals/bulk")
 		return
 	}
 	stateDir := ""
@@ -182,9 +352,33 @@ func (s *FleetServer) handleFleetApproval(w http.ResponseWriter, r *http.Request
 	if _, ok := requireAuth(w, r, s.auth); !ok {
 		return
 	}
+	// #533 spec gap 7: /api/v1/fleet/approvals/bulk handles multi-id
+	// reject/supersede across one project (selected via ?project=...).
+	if strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/api/v1/fleet/approvals/")) == "bulk" {
+		projectName := strings.TrimSpace(r.URL.Query().Get("project"))
+		if projectName == "" {
+			writeError(w, http.StatusBadRequest, "project query parameter is required")
+			return
+		}
+		project, ok := s.findProject(projectName)
+		if !ok {
+			writeError(w, http.StatusNotFound, fmt.Sprintf("unknown project %q", projectName))
+			return
+		}
+		readOnly := s.readOnly
+		if project.cfg != nil && project.cfg.Server.ReadOnly {
+			readOnly = true
+		}
+		stateDir := ""
+		if project.cfg != nil {
+			stateDir = project.cfg.StateDir
+		}
+		applyApprovalBulk(w, r, readOnly, fmt.Sprintf("fleet project %q", projectName), stateDir, s.auth)
+		return
+	}
 	route, ok := parseApprovalPath("/api/v1/fleet/approvals/", r.URL.Path)
 	if !ok {
-		writeError(w, http.StatusNotFound, "expected /api/v1/fleet/approvals/{id}/{approve|reject}?project=...")
+		writeError(w, http.StatusNotFound, "expected /api/v1/fleet/approvals/{id}/{approve|reject}?project=... or /api/v1/fleet/approvals/bulk?project=...")
 		return
 	}
 	projectName := strings.TrimSpace(r.URL.Query().Get("project"))

--- a/internal/server/approvals_bulk_test.go
+++ b/internal/server/approvals_bulk_test.go
@@ -1,0 +1,282 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// --- bulk reject ------------------------------------------------------------
+
+// TestBulkApproval_Reject_AppliesToMultiple verifies #533 spec gap 7: the
+// multi-id bulk endpoint rejects all named pending approvals in one
+// state.Save and reports each id under Items, with counts matching.
+func TestBulkApproval_Reject_AppliesToMultiple(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+	b := enqueuedApproval(t, dir, "close_issue", &state.SupervisorTarget{Issue: 2})
+	c := enqueuedApproval(t, dir, "spawn_worker", &state.SupervisorTarget{Issue: 3})
+
+	body := fmt.Sprintf(`{"ids":[%q,%q,%q],"verb":"reject","actor":"oleg","reason":"all junk"}`, a.ID, b.ID, c.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/bulk", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp approvalBulkResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if !resp.OK || resp.Applied != 3 || resp.Errors != 0 || resp.Skipped != 0 {
+		t.Fatalf("response counts = applied=%d skipped=%d errors=%d ok=%v",
+			resp.Applied, resp.Skipped, resp.Errors, resp.OK)
+	}
+	if len(resp.Items) != 3 {
+		t.Fatalf("items = %d, want 3", len(resp.Items))
+	}
+	for _, item := range resp.Items {
+		if item.Status != "ok" {
+			t.Fatalf("item %s status = %q, want ok", item.ID, item.Status)
+		}
+	}
+
+	st, _ := state.Load(dir)
+	for _, ap := range st.Approvals {
+		if ap.Status != state.ApprovalStatusRejected {
+			t.Fatalf("approval %s status = %q on disk, want rejected", ap.ID, ap.Status)
+		}
+		// Audit must record the operator action so the audit log can
+		// reconstruct who bulk-rejected.
+		var sawReject bool
+		for _, ev := range ap.Audit {
+			if ev.Event == state.ApprovalAuditRejected && ev.Actor == "oleg" && ev.Reason == "all junk" {
+				sawReject = true
+			}
+		}
+		if !sawReject {
+			t.Fatalf("approval %s audit lacks reject event with operator identity/reason: %+v",
+				ap.ID, ap.Audit)
+		}
+	}
+}
+
+// TestBulkApproval_Supersede_AppliesToMultiple is the parallel test for the
+// supersede verb: bulk-supersede dismisses N pending cards onto status
+// "superseded" without rejecting them.
+func TestBulkApproval_Supersede_AppliesToMultiple(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+	b := enqueuedApproval(t, dir, "close_issue", &state.SupervisorTarget{Issue: 2})
+
+	body := fmt.Sprintf(`{"ids":[%q,%q],"verb":"supersede","reason":"newer mint"}`, a.ID, b.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/bulk", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp approvalBulkResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if resp.Applied != 2 || resp.Errors != 0 {
+		t.Fatalf("counts = %+v", resp)
+	}
+	st, _ := state.Load(dir)
+	for _, ap := range st.Approvals {
+		if ap.Status != state.ApprovalStatusSuperseded {
+			t.Fatalf("approval %s status = %q, want superseded", ap.ID, ap.Status)
+		}
+	}
+}
+
+// TestBulkApproval_MixedTerminalAndPending_SkipsTerminalNotErrors verifies
+// the dashboard's "operator re-submits after partial apply" scenario:
+// already-rejected approvals come back as status="skipped", not as errors,
+// and pending ones still flip. The whole batch returns 200.
+func TestBulkApproval_MixedTerminalAndPending_SkipsTerminalNotErrors(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	stale := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+	fresh := enqueuedApproval(t, dir, "close_issue", &state.SupervisorTarget{Issue: 2})
+
+	// Pre-reject the first one — the bulk call must skip it gracefully.
+	st, _ := state.Load(dir)
+	if _, err := st.RejectApproval(stale.ID, time.Now().UTC(), "cli", "earlier"); err != nil {
+		t.Fatalf("pre-reject: %v", err)
+	}
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"ids":[%q,%q],"verb":"reject"}`, stale.ID, fresh.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/bulk", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp approvalBulkResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Applied != 1 || resp.Skipped != 1 || resp.Errors != 0 {
+		t.Fatalf("counts wrong: %+v", resp)
+	}
+	if !resp.OK {
+		t.Fatalf("ok = false despite a successful apply; resp = %+v", resp)
+	}
+}
+
+// TestBulkApproval_AllErrors_ReturnsBadRequest verifies an all-bogus-id
+// batch surfaces as 4xx so the dashboard renders an error banner instead
+// of a green toast.
+func TestBulkApproval_AllErrors_ReturnsBadRequest(t *testing.T) {
+	srv, _ := srvWithStateDir(t)
+	body := `{"ids":["nope-1","nope-2"],"verb":"reject"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/bulk", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (all-errors batch)", w.Code)
+	}
+}
+
+// TestBulkApproval_EmptyIDs_400 protects against a UI bug that submits an
+// empty list — easier to surface 400 than to silently no-op.
+func TestBulkApproval_EmptyIDs_400(t *testing.T) {
+	srv, _ := srvWithStateDir(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/bulk", bytes.NewBufferString(`{"ids":[],"verb":"reject"}`))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+// TestBulkApproval_UnknownVerb_400 protects against typos and gives the
+// caller a clear error so a fat-fingered curl does not silently succeed.
+func TestBulkApproval_UnknownVerb_400(t *testing.T) {
+	srv, _ := srvWithStateDir(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/bulk",
+		bytes.NewBufferString(`{"ids":["x"],"verb":"approve"}`))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (approve is not a bulk verb)", w.Code)
+	}
+}
+
+// TestBulkApproval_ReadOnly_403 verifies the read-only gate still wins:
+// even with valid ids and verb, a read-only deployment refuses the bulk
+// mutation.
+func TestBulkApproval_ReadOnly_403(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+	srv.cfg.Server.ReadOnly = true
+
+	body := fmt.Sprintf(`{"ids":[%q],"verb":"reject"}`, a.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/bulk", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	st, _ := state.Load(dir)
+	if st.Approvals[0].Status != state.ApprovalStatusPending {
+		t.Fatalf("status changed under read-only: %q", st.Approvals[0].Status)
+	}
+}
+
+// TestBulkApproval_GetIs405 verifies non-POST methods are rejected
+// upfront (the bulk endpoint is mutating).
+func TestBulkApproval_GetIs405(t *testing.T) {
+	srv, _ := srvWithStateDir(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/approvals/bulk", nil)
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Code)
+	}
+}
+
+// TestBulkApproval_DuplicateIDs_AppliedOnce checks that an operator
+// submitting the same id twice (slow UI, double-click) does not double-
+// audit or double-count.
+func TestBulkApproval_DuplicateIDs_AppliedOnce(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+
+	body := fmt.Sprintf(`{"ids":[%q,%q],"verb":"reject"}`, a.ID, a.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/bulk", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp approvalBulkResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Applied != 1 || len(resp.Items) != 1 {
+		t.Fatalf("expected exactly one apply on duplicate id; got resp = %+v", resp)
+	}
+}
+
+// --- fleet variant ----------------------------------------------------------
+
+// TestFleetBulkApproval_RoutesByProject verifies the fleet bulk endpoint
+// scopes the transition to the named project's state dir.
+func TestFleetBulkApproval_RoutesByProject(t *testing.T) {
+	srv, projectName, dir := newFleetForApprovalTest(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+	b := enqueuedApproval(t, dir, "close_issue", &state.SupervisorTarget{Issue: 2})
+
+	url := fmt.Sprintf("/api/v1/fleet/approvals/bulk?project=%s", projectName)
+	body := fmt.Sprintf(`{"ids":[%q,%q],"verb":"reject"}`, a.ID, b.ID)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	srv.handleFleetApproval(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	st, _ := state.Load(dir)
+	for _, ap := range st.Approvals {
+		if ap.Status != state.ApprovalStatusRejected {
+			t.Fatalf("approval %s status = %q", ap.ID, ap.Status)
+		}
+	}
+}
+
+func TestFleetBulkApproval_MissingProject_400(t *testing.T) {
+	srv, _, _ := newFleetForApprovalTest(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/approvals/bulk",
+		bytes.NewBufferString(`{"ids":["x"],"verb":"reject"}`))
+	w := httptest.NewRecorder()
+	srv.handleFleetApproval(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestFleetBulkApproval_UnknownProject_404(t *testing.T) {
+	srv, _, _ := newFleetForApprovalTest(t)
+	url := "/api/v1/fleet/approvals/bulk?project=ghost"
+	req := httptest.NewRequest(http.MethodPost, url,
+		bytes.NewBufferString(`{"ids":["x"],"verb":"reject"}`))
+	w := httptest.NewRecorder()
+	srv.handleFleetApproval(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/befeast/maestro/internal/approver"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/server/web"
@@ -514,7 +515,24 @@ type fleetApprovalState struct {
 	UpdatedAgeSeconds int64                   `json:"updated_age_seconds,omitempty"`
 	Risk              string                  `json:"risk,omitempty"`
 	Summary           string                  `json:"summary,omitempty"`
-	PastSLA           bool                    `json:"past_sla,omitempty"`
+	// Title is the short, action-first card title introduced for #533
+	// (spec gap 12). Format: "<verb> · #<target>" — e.g. "Start worker
+	// · #487", "Merge PR · #123". The SPA renders Title as the card
+	// heading and Summary as the body, eliminating the 1:1 duplication
+	// where both spots used to read the same supervisor reasoning.
+	Title string `json:"title,omitempty"`
+	// GroupKey collapses re-emitted approvals on the same target onto
+	// one card (spec gap 1). Two approvals on PR #99 share GroupKey
+	// "pr:99"; the SPA renders a single card with the «regenerated 2
+	// times» badge instead of two flat rows.
+	GroupKey string `json:"group_key,omitempty"`
+	// GroupSize is the count of LIVE approvals (pending +
+	// awaiting_dispatch + approved-but-not-executed) sharing this
+	// GroupKey on the same project. 1 for a singleton; ≥2 for a
+	// regenerated group. The SPA uses this for the «regenerated N
+	// times» badge.
+	GroupSize int  `json:"group_size,omitempty"`
+	PastSLA   bool `json:"past_sla,omitempty"`
 
 	createdAt time.Time
 	updatedAt time.Time
@@ -2730,8 +2748,46 @@ func makeFleetApprovalStates(project fleetProjectState, st *state.State, now tim
 	for _, approval := range st.Approvals {
 		items = append(items, makeFleetApprovalState(project, st, approval, now))
 	}
+	// #533 spec gap 1: count live approvals per (group_key) so the SPA can
+	// fold N re-emitted approvals on the same target onto one card with a
+	// «regenerated N times» badge. Counts only "live" statuses (pending,
+	// awaiting_dispatch, approved-not-yet-executed) — resolved approvals
+	// (rejected, stale, superseded, executed) have already exited the
+	// queue and should not inflate the regenerated count.
+	liveByGroup := make(map[string]int, len(items))
+	for _, item := range items {
+		if item.GroupKey == "" {
+			continue
+		}
+		if !isLiveFleetApprovalStatus(item.Status) {
+			continue
+		}
+		liveByGroup[item.GroupKey]++
+	}
+	for i := range items {
+		if items[i].GroupKey == "" {
+			continue
+		}
+		if n, ok := liveByGroup[items[i].GroupKey]; ok && n > 0 {
+			items[i].GroupSize = n
+		}
+	}
 	sortFleetApprovals(items)
 	return items
+}
+
+// isLiveFleetApprovalStatus reports whether the named approval status
+// represents an unresolved (still effective) record that contributes to
+// the per-target regenerated count. Used by makeFleetApprovalStates when
+// computing GroupSize (#533 spec gap 1).
+func isLiveFleetApprovalStatus(status string) bool {
+	switch state.ApprovalStatus(status) {
+	case state.ApprovalStatusPending,
+		state.ApprovalStatusAwaitingDispatch,
+		state.ApprovalStatusApproved:
+		return true
+	}
+	return false
 }
 
 func makeFleetApprovalState(project fleetProjectState, st *state.State, approval state.Approval, now time.Time) fleetApprovalState {
@@ -2758,6 +2814,8 @@ func makeFleetApprovalState(project fleetProjectState, st *state.State, approval
 		Status:            string(approval.Status),
 		Risk:              approval.Risk,
 		Summary:           approval.Summary,
+		Title:             approver.ApprovalTitle(&approval),
+		GroupKey:          approver.ApprovalGroupKey(&approval),
 		CreatedAt:         formatFleetTime(createdAt),
 		UpdatedAt:         formatFleetTime(updatedAt),
 		CreatedAge:        formatFleetAge(createdAt, now),

--- a/internal/server/web/mc/src/fleetApi.js
+++ b/internal/server/web/mc/src/fleetApi.js
@@ -675,18 +675,33 @@ function mapApproval(approval) {
     0,
     Math.floor(Number(approval.updated_age_seconds || approval.created_age_seconds || 0) / 60)
   );
+  // Issue #533 spec gap 12: prefer the server-rendered short Title
+  // ("Start worker · #487") over the long supervisor summary. Older fleet
+  // snapshots (pre-#533) lack the field — fall back to the action label
+  // plus target so the SPA never crashes and the card still reads as a
+  // verb+target, not as the full reasoning sentence.
+  const fallbackTitle = `${actionLabel(approval.action)}${
+    approval.pr_number ? ` · #${approval.pr_number}` :
+    approval.issue_number ? ` · #${approval.issue_number}` : ""
+  }`;
+  const title = approval.title || fallbackTitle;
   return {
     ...approval,
     project: approval.project_name || "",
     pr: approval.pr_number || 0,
-    title: approval.summary || actionLabel(approval.action),
+    title,
     author: approval.session || approval.decision_id || "supervisor",
     reviewer: approval.risk || "operator",
     ageMin,
     sla: 30,
     state: approvalTone(approval),
+    // body = supervisor's reasoning. Distinct from title (gap 12): the SPA
+    // renders body only when it differs from title, so the long sentence
+    // appears exactly once, as the body.
     body: approval.summary || "",
     stage: actionLabel(approval.action),
+    groupKey: approval.group_key || "",
+    groupSize: Number(approval.group_size || 0),
   };
 }
 
@@ -1013,6 +1028,56 @@ export async function postProjectApproval({ approvalId, verb, actor, reason }) {
     body: JSON.stringify({ actor: actor || "dashboard", reason: reason || "" }),
   });
   return parseApprovalResponse(res, verb);
+}
+
+// postFleetApprovalBulk / postProjectApprovalBulk drive the multi-id
+// reject/supersede endpoints introduced for #533 spec gap 7. The body
+// shape mirrors approvalBulkRequest on the server; the response is the
+// approvalBulkResponse (counts + per-id Items) so the SPA can render
+// "rejected 3, skipped 1" inline without re-fetching.
+export async function postFleetApprovalBulk({ approvalIds, project, verb, actor, reason }) {
+  if (!Array.isArray(approvalIds) || approvalIds.length === 0) {
+    throw new Error("approvalIds must be a non-empty array");
+  }
+  if (!project) throw new Error("project is required");
+  if (verb !== "reject" && verb !== "supersede") throw new Error("verb must be reject|supersede");
+  const url = `/api/v1/fleet/approvals/bulk?project=${encodeURIComponent(project)}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ids: approvalIds, verb, actor: actor || "dashboard", reason: reason || "" }),
+  });
+  return parseBulkApprovalResponse(res, verb);
+}
+
+export async function postProjectApprovalBulk({ approvalIds, verb, actor, reason }) {
+  if (!Array.isArray(approvalIds) || approvalIds.length === 0) {
+    throw new Error("approvalIds must be a non-empty array");
+  }
+  if (verb !== "reject" && verb !== "supersede") throw new Error("verb must be reject|supersede");
+  const res = await fetch("/api/v1/approvals/bulk", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ids: approvalIds, verb, actor: actor || "dashboard", reason: reason || "" }),
+  });
+  return parseBulkApprovalResponse(res, verb);
+}
+
+async function parseBulkApprovalResponse(res, verb) {
+  let payload = null;
+  try {
+    payload = await res.json();
+  } catch (_) {
+    /* non-JSON; fall through */
+  }
+  if (!res.ok) {
+    const msg = (payload && (payload.error || payload.message)) || `bulk ${verb} failed with status ${res.status}`;
+    const err = new Error(msg);
+    err.status = res.status;
+    err.payload = payload;
+    throw err;
+  }
+  return payload;
 }
 
 async function parseApprovalResponse(res, verb) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1761,6 +1761,47 @@ func (s *State) RejectApproval(id string, now time.Time, actor, reason string) (
 	return approval, nil
 }
 
+// SupersedeApproval marks a pending or awaiting_dispatch approval as
+// superseded by operator action (#533 spec gap 7: bulk supersede). The
+// supervisor uses markApprovalSuperseded for automatic dedup when fresh
+// state lands; this exported variant gives the dashboard the same lever
+// for operator-driven dismissal of stale or duplicate cards without
+// rejecting them — semantically "this card is no longer relevant", not
+// "the action is forbidden".
+//
+// Returns ErrApprovalNotFound when no approval matches id, or
+// ErrApprovalNotPending when the approval is in a terminal state
+// (rejected/stale/superseded/executed/execution_failed/execution_skipped).
+// Approved-but-not-yet-executed approvals are NOT supersedable here — the
+// operator already committed to executing them; the executor pipeline
+// owns the terminal transition.
+func (s *State) SupersedeApproval(id string, now time.Time, actor, reason string) (*Approval, error) {
+	approval, ok := s.FindApproval(id)
+	if !ok {
+		return nil, ErrApprovalNotFound
+	}
+	if approval.Status == ApprovalStatusStale {
+		return approval, ErrApprovalStale
+	}
+	if approval.Status == ApprovalStatusSuperseded {
+		return approval, ErrApprovalSuperseded
+	}
+	if approval.Status != ApprovalStatusPending && approval.Status != ApprovalStatusAwaitingDispatch {
+		return approval, ErrApprovalNotPending
+	}
+	approval.Status = ApprovalStatusSuperseded
+	approval.UpdatedAt = normalizedTime(now)
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              approval.UpdatedAt,
+		Event:           ApprovalAuditSuperseded,
+		Actor:           actor,
+		Reason:          reason,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: approval.TargetStateHash,
+	})
+	return approval, nil
+}
+
 // MarkStaleApprovals marks pending approvals stale when their payload or target snapshot changes.
 func (s *State) MarkStaleApprovals(now time.Time) int {
 	count := 0

--- a/internal/state/supersede_approval_test.go
+++ b/internal/state/supersede_approval_test.go
@@ -1,0 +1,143 @@
+package state
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestSupersedeApproval_PendingToSuperseded verifies the happy path for the
+// operator-driven bulk-supersede endpoint (#533 spec gap 7): a pending
+// approval transitions to "superseded" with an audit entry stamped by the
+// operator.
+func TestSupersedeApproval_PendingToSuperseded(t *testing.T) {
+	st := NewState()
+	now := time.Now().UTC()
+	dec := SupervisorDecision{
+		ID:                "dec-1",
+		CreatedAt:         now,
+		Project:           "p",
+		Mode:              "test",
+		Summary:           "x",
+		RecommendedAction: "merge_pr",
+		Target:            &SupervisorTarget{PR: 7},
+		Risk:              "high",
+		RequiresApproval:  true,
+	}
+	a := st.RecordPendingApprovalForDecision(dec, now)
+	if a == nil {
+		t.Fatal("RecordPendingApprovalForDecision returned nil")
+	}
+
+	got, err := st.SupersedeApproval(a.ID, now.Add(time.Second), "oleg", "newer mint landed")
+	if err != nil {
+		t.Fatalf("SupersedeApproval err = %v", err)
+	}
+	if got.Status != ApprovalStatusSuperseded {
+		t.Fatalf("status = %q, want superseded", got.Status)
+	}
+
+	var sawSupersede bool
+	for _, ev := range got.Audit {
+		if ev.Event == ApprovalAuditSuperseded && ev.Actor == "oleg" && ev.Reason == "newer mint landed" {
+			sawSupersede = true
+		}
+	}
+	if !sawSupersede {
+		t.Fatalf("audit lacks operator-stamped supersede event: %+v", got.Audit)
+	}
+}
+
+// TestSupersedeApproval_AwaitingDispatchAccepted verifies that approvals in
+// the awaiting_dispatch state (spawn_worker + open_child_issue, post-#515)
+// can also be operator-superseded — the dispatcher loop owns the actual
+// side effect, but the operator may dismiss a stale dispatch.
+func TestSupersedeApproval_AwaitingDispatchAccepted(t *testing.T) {
+	st := NewState()
+	now := time.Now().UTC()
+	dec := SupervisorDecision{
+		ID:                "dec-2",
+		CreatedAt:         now,
+		RecommendedAction: "spawn_worker",
+		Target:            &SupervisorTarget{Issue: 42},
+		Risk:              "medium",
+		RequiresApproval:  true,
+		Project:           "p",
+		Mode:              "test",
+	}
+	a := st.RecordPendingApprovalForDecision(dec, now)
+	if _, err := st.ApproveApproval(a.ID, now, "cli", ""); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if _, err := st.MarkApprovalAwaitingDispatch(a.ID, now, "cli", "spawn_worker awaiting"); err != nil {
+		t.Fatalf("mark awaiting: %v", err)
+	}
+
+	got, err := st.SupersedeApproval(a.ID, now.Add(time.Second), "oleg", "stale")
+	if err != nil {
+		t.Fatalf("SupersedeApproval err = %v", err)
+	}
+	if got.Status != ApprovalStatusSuperseded {
+		t.Fatalf("status = %q, want superseded", got.Status)
+	}
+}
+
+// TestSupersedeApproval_NotFound verifies a missing id surfaces
+// ErrApprovalNotFound so the bulk handler can report it under errors,
+// not skipped.
+func TestSupersedeApproval_NotFound(t *testing.T) {
+	st := NewState()
+	if _, err := st.SupersedeApproval("nope", time.Now().UTC(), "x", ""); !errors.Is(err, ErrApprovalNotFound) {
+		t.Fatalf("err = %v, want ErrApprovalNotFound", err)
+	}
+}
+
+// TestSupersedeApproval_AlreadyApprovedReturnsNotPending verifies that
+// committing-but-not-yet-executed approvals (status=approved) refuse
+// supersede — the executor pipeline owns their terminal transition.
+func TestSupersedeApproval_AlreadyApprovedReturnsNotPending(t *testing.T) {
+	st := NewState()
+	now := time.Now().UTC()
+	dec := SupervisorDecision{
+		ID:                "dec-3",
+		CreatedAt:         now,
+		RecommendedAction: "merge_pr",
+		Target:            &SupervisorTarget{PR: 1},
+		Risk:              "high",
+		RequiresApproval:  true,
+		Project:           "p",
+		Mode:              "test",
+	}
+	a := st.RecordPendingApprovalForDecision(dec, now)
+	if _, err := st.ApproveApproval(a.ID, now, "cli", ""); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if _, err := st.SupersedeApproval(a.ID, now.Add(time.Second), "oleg", "too late"); !errors.Is(err, ErrApprovalNotPending) {
+		t.Fatalf("err = %v, want ErrApprovalNotPending", err)
+	}
+}
+
+// TestSupersedeApproval_AlreadySuperseded is idempotent: a second call
+// returns ErrApprovalSuperseded so the bulk handler records "skipped"
+// instead of double-stamping audit.
+func TestSupersedeApproval_AlreadySuperseded(t *testing.T) {
+	st := NewState()
+	now := time.Now().UTC()
+	dec := SupervisorDecision{
+		ID:                "dec-4",
+		CreatedAt:         now,
+		RecommendedAction: "merge_pr",
+		Target:            &SupervisorTarget{PR: 9},
+		Risk:              "high",
+		RequiresApproval:  true,
+		Project:           "p",
+		Mode:              "test",
+	}
+	a := st.RecordPendingApprovalForDecision(dec, now)
+	if _, err := st.SupersedeApproval(a.ID, now, "oleg", ""); err != nil {
+		t.Fatalf("first supersede: %v", err)
+	}
+	if _, err := st.SupersedeApproval(a.ID, now.Add(time.Second), "oleg", ""); !errors.Is(err, ErrApprovalSuperseded) {
+		t.Fatalf("err = %v, want ErrApprovalSuperseded", err)
+	}
+}


### PR DESCRIPTION
Refs #533

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses three spec gaps from issue #533: it eliminates the title/summary duplication on approval cards by introducing a server-side `ApprovalTitle` helper that produces a concise `\"<Verb> · #<target>\"` string, adds `GroupKey`/`GroupSize` fields to fold re-emitted approvals on the same target into a single card with a \"regenerated N times\" badge, and exposes new `/approvals/bulk` endpoints (both single-project and fleet-scoped) that let the operator reject or supersede multiple approvals in one atomic `state.Save`.

- `internal/approver/title.go` centralises title/group-key logic; `fleet.go` and `fleetApi.js` consume it, and the JS falls back gracefully for pre-#533 snapshots.
- `state.SupersedeApproval` is a new exported method that accepts `Pending` and `AwaitingDispatch` statuses, mirroring `RejectApproval`; `applyApprovalBulk` orchestrates both verbs with per-id skip/error reporting and a single conditional `state.Save`.
- Test coverage is thorough across all three layers (unit, state, server/HTTP).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the bulk endpoint is well-guarded and the state mutation + save logic is correct.

The core state transitions (SupersedeApproval, RejectApproval) are correctly scoped and the conditional state.Save only fires when at least one approval was actually mutated. The three findings are edge-case gaps: "ungrouped" could falsely cluster unrelated approvals (unlikely with real approval IDs), the JS fallback title drops the slot label for session-targeted approvals on legacy snapshots, and the all-skipped HTTP 200 path is untested. None affect the happy path.

internal/approver/title.go (ungrouped sentinel), internal/server/web/mc/src/fleetApi.js (fallback title), internal/server/approvals.go (all-skipped response semantics)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/approver/title.go | New file: ApprovalTitle (short card title) and ApprovalGroupKey (per-target dedup key). One edge case: the final "ungrouped" fallback violates the stated singleton design. |
| internal/server/approvals.go | Adds bulk reject/supersede endpoint and routing for single-project and fleet servers. Logic is sound; all-skipped batch returns HTTP 200 with ok:false, which is undocumented and untested. |
| internal/server/fleet.go | Adds Title, GroupKey, GroupSize fields to fleetApprovalState; GroupSize counting logic is correct and well-tested. |
| internal/state/state.go | New SupersedeApproval method mirrors RejectApproval's pattern, accepts Pending and AwaitingDispatch statuses, and correctly guards against double-supersede. |
| internal/server/web/mc/src/fleetApi.js | Adds bulk API functions and updated mapApproval to prefer server-rendered title. Fallback title for legacy snapshots omits slot identifier for session-targeted approvals. |
| internal/approver/title_test.go | Thorough unit tests covering all known action verbs, nil input, and the key duplication regression for both ApprovalTitle and ApprovalGroupKey. |
| internal/server/approvals_bulk_test.go | Good coverage of the bulk endpoint: mixed terminal/pending batches, read-only gate, duplicate IDs, unknown verb, fleet routing. Missing a test for the all-skipped (no errors, no applied) path. |
| internal/state/supersede_approval_test.go | Comprehensive tests for SupersedeApproval covering all status transitions, idempotency, and audit entries. |
| internal/server/approval_title_group_test.go | Integration-level tests for Title/GroupKey/GroupSize at the API layer, including per-target separation and terminal-vs-live group counting. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/server/approvals.go`, line 605-612 ([link](https://github.com/befeast/maestro/blob/ec9563da8b5b88341c8e1dff98439d8804799cd0/internal/server/approvals.go#L605-L612)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **All-skipped batch: HTTP 200 with `ok: false` is untested and potentially surprising**

   When every ID in the batch is already terminal (all skipped, zero errors, zero applied), the handler returns HTTP 200 but `resp.OK = false`. The status-code branch only upgrades to 400 when `Applied == 0 && Errors > 0`, so a pure "all-already-done" request slips through as 200. `parseBulkApprovalResponse` in `fleetApi.js` only checks `!res.ok` (the HTTP status), so the caller receives a resolved promise with `payload.ok = false` — the SPA would need to explicitly inspect `payload.applied` to distinguish "nothing happened" from "succeeded." There is no test covering this path, so it is easy to regress silently.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/approvals.go
   Line: 605-612

   Comment:
   **All-skipped batch: HTTP 200 with `ok: false` is untested and potentially surprising**

   When every ID in the batch is already terminal (all skipped, zero errors, zero applied), the handler returns HTTP 200 but `resp.OK = false`. The status-code branch only upgrades to 400 when `Applied == 0 && Errors > 0`, so a pure "all-already-done" request slips through as 200. `parseBulkApprovalResponse` in `fleetApi.js` only checks `!res.ok` (the HTTP status), so the caller receives a resolved promise with `payload.ok = false` — the SPA would need to explicitly inspect `payload.applied` to distinguish "nothing happened" from "succeeded." There is no test covering this path, so it is easy to regress silently.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/approver/title.go:62-66
`ApprovalGroupKey` ends with `return "ungrouped"` — a shared literal key — but the doc comment directly above promises the opposite: "the approval ID is used as a singleton key so the card still renders as its own group instead of all target-less approvals collapsing onto one row." When `Target` is nil and `approval.ID` is also empty, every such approval returns `"ungrouped"`, which `makeFleetApprovalStates` counts as a single live group with `GroupSize = N`, causing the SPA to render unrelated approvals as "regenerated N times." Returning `""` instead lets the existing `if item.GroupKey == ""` guard in `makeFleetApprovalStates` skip them entirely, preserving the singleton behaviour stated in the comment.

```suggestion
	if id := strings.TrimSpace(approval.ID); id != "" {
		return "id:" + id
	}
	return ""
}
```

### Issue 2 of 3
internal/server/web/mc/src/fleetApi.js:683-686
The fallback title (used when a pre-#533 snapshot lacks the server-rendered `title` field) handles `pr_number` and `issue_number` but silently drops the `session` slot. A `delete_worktree` approval from an older snapshot would render as just `"Delete worktree"` with no slot identifier, making it indistinguishable from any other pending delete-worktree card. Adding the session arm keeps parity with `approvalTargetSuffix` on the server side.

```suggestion
  const fallbackTitle = `${actionLabel(approval.action)}${
    approval.pr_number ? ` · #${approval.pr_number}` :
    approval.issue_number ? ` · #${approval.issue_number}` :
    approval.session ? ` · slot ${approval.session}` : ""
  }`;
```

### Issue 3 of 3
internal/server/approvals.go:605-612
**All-skipped batch: HTTP 200 with `ok: false` is untested and potentially surprising**

When every ID in the batch is already terminal (all skipped, zero errors, zero applied), the handler returns HTTP 200 but `resp.OK = false`. The status-code branch only upgrades to 400 when `Applied == 0 && Errors > 0`, so a pure "all-already-done" request slips through as 200. `parseBulkApprovalResponse` in `fleetApi.js` only checks `!res.ok` (the HTTP status), so the caller receives a resolved promise with `payload.ok = false` — the SPA would need to explicitly inspect `payload.applied` to distinguish "nothing happened" from "succeeded." There is no test covering this path, so it is easy to regress silently.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(server,approver,state): approvals t..."](https://github.com/befeast/maestro/commit/ec9563da8b5b88341c8e1dff98439d8804799cd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35068760)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->