### PR TITLE
dependency-unblock: blocked issues re-enrolled into GitHub Project every cycle (no dedup -> wasted GraphQL budget)

### DIFF
--- a/internal/supervisor/dependency_unblock.go
+++ b/internal/supervisor/dependency_unblock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
@@ -30,6 +31,44 @@ type ProjectEnroller interface {
 	EnrollBlockedIssue(issueNumber int) error
 }
 
+// enrollmentTracker remembers which blocked issue numbers have already
+// been handed to ProjectEnroller this process so subsequent supervisor
+// cycles do not re-issue the same GraphQL enrollment call (#569). The
+// reset-on-restart cost is bounded: enrollment is idempotent, and a fresh
+// daemon process only pays the dedup miss once per blocked issue.
+type enrollmentTracker interface {
+	Seen(issueNumber int) bool
+	Mark(issueNumber int)
+}
+
+type inMemoryEnrollmentTracker struct {
+	mu   sync.Mutex
+	seen map[int]struct{}
+}
+
+func newInMemoryEnrollmentTracker() *inMemoryEnrollmentTracker {
+	return &inMemoryEnrollmentTracker{seen: make(map[int]struct{})}
+}
+
+func (t *inMemoryEnrollmentTracker) Seen(issueNumber int) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, ok := t.seen[issueNumber]
+	return ok
+}
+
+func (t *inMemoryEnrollmentTracker) Mark(issueNumber int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.seen[issueNumber] = struct{}{}
+}
+
+// defaultEnrollmentTracker is the process-wide tracker shared by every
+// Engine created via NewEngine. RunOnce constructs a fresh Engine per
+// cycle, so the dedup has to live above the Engine to survive cycle
+// boundaries.
+var defaultEnrollmentTracker = newInMemoryEnrollmentTracker()
+
 // enrollBlockedWaveMembers walks every blocked wave member and asks the
 // configured enroller to add it to the GitHub Project. Returns the issues
 // that were attempted (regardless of success) so the decision Reasons can
@@ -46,14 +85,27 @@ func (e *Engine) enrollBlockedWaveMembers(blocked []github.Issue) []int {
 	if e.enroller == nil {
 		return nil
 	}
+	tracker := e.enrollmentTracker
+	if tracker == nil {
+		tracker = defaultEnrollmentTracker
+	}
 	enrolled := make([]int, 0, len(blocked))
 	for _, issue := range blocked {
+		// Dedup against prior cycles in this process (#569). Enrollment
+		// is idempotent on the GraphQL side, but re-issuing the call
+		// every cycle burns rate-limit budget proportional to wave size
+		// × cycle count.
+		if tracker.Seen(issue.Number) {
+			continue
+		}
 		if err := e.enroller.EnrollBlockedIssue(issue.Number); err != nil {
 			// Best-effort: keep the supervisor cycle moving. The
 			// fake reader in tests can capture this through its own
 			// counter; production wiring logs via the gh client.
+			// Do NOT mark on failure — the next cycle should retry.
 			continue
 		}
+		tracker.Mark(issue.Number)
 		enrolled = append(enrolled, issue.Number)
 	}
 	sort.Ints(enrolled)

--- a/internal/supervisor/dependency_unblock_test.go
+++ b/internal/supervisor/dependency_unblock_test.go
@@ -26,6 +26,19 @@ func (f *fakeEnroller) EnrollBlockedIssue(issueNumber int) error {
 	return nil
 }
 
+// errorEnroller always fails the enrollment call and counts attempts so a
+// test can assert that a failure is retried on the next supervisor cycle
+// (the dedup tracker must not mark failed enrollments as seen). #569.
+type errorEnroller struct {
+	err   error
+	calls int
+}
+
+func (e *errorEnroller) EnrollBlockedIssue(int) error {
+	e.calls++
+	return e.err
+}
+
 // Helpers ---------------------------------------------------------------
 
 func enableDependencyUnblock(cfg *config.Config) {
@@ -372,6 +385,83 @@ func TestEvaluate_EnrollmentSkippedWhenDisabled(t *testing.T) {
 	}
 	if len(enroller.enrolled) != 0 {
 		t.Fatalf("enrolled = %v, want none (enroll_in_project=false)", enroller.enrolled)
+	}
+}
+
+// Test: dedup — a previously enrolled blocked issue is not re-enrolled (#569)
+
+func TestEvaluate_DoesNotReEnrollAlreadyEnrolledBlockedIssue(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	cfg.GitHubProjects.Enabled = true
+	cfg.GitHubProjects.ProjectNumber = 7
+
+	reader := &fakeReader{issues: []github.Issue{blockedIssue(148, []int{147})}}
+	enroller := &fakeEnroller{}
+	eng := testEngine(cfg, reader)
+	eng.SetProjectEnroller(enroller)
+
+	// First cycle: candidate is unseen → enroller is called once.
+	if _, err := eng.Decide(state.NewState()); err != nil {
+		t.Fatalf("Decide(1): %v", err)
+	}
+	if !equalInts(enroller.enrolled, []int{148}) {
+		t.Fatalf("after cycle 1: enrolled = %v, want [148]", enroller.enrolled)
+	}
+
+	// Second cycle: same blocked candidate, same reader. The dedup
+	// tracker must suppress the redundant GraphQL call. Acceptance #1.
+	if _, err := eng.Decide(state.NewState()); err != nil {
+		t.Fatalf("Decide(2): %v", err)
+	}
+	if !equalInts(enroller.enrolled, []int{148}) {
+		t.Fatalf("after cycle 2: enrolled = %v, want [148] (no re-enroll)", enroller.enrolled)
+	}
+
+	// Third cycle: a newly-blocked issue appears. Only the new one is
+	// enrolled — calls are O(new blocked members). Acceptance #2.
+	reader.issues = []github.Issue{
+		blockedIssue(148, []int{147}),
+		blockedIssue(149, []int{147}),
+	}
+	if _, err := eng.Decide(state.NewState()); err != nil {
+		t.Fatalf("Decide(3): %v", err)
+	}
+	if !equalInts(enroller.enrolled, []int{148, 149}) {
+		t.Fatalf("after cycle 3: enrolled = %v, want [148 149] (only the new one)", enroller.enrolled)
+	}
+}
+
+// Test: a failed enrollment is retried on the next cycle (failures don't mark
+// the issue as seen). #569.
+
+func TestEvaluate_FailedEnrollmentIsRetriedOnNextCycle(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDependencyUnblock(cfg)
+	cfg.GitHubProjects.Enabled = true
+	cfg.GitHubProjects.ProjectNumber = 7
+
+	reader := &fakeReader{issues: []github.Issue{blockedIssue(148, []int{147})}}
+	failing := &errorEnroller{err: errors.New("graphql rate limited")}
+	eng := testEngine(cfg, reader)
+	eng.SetProjectEnroller(failing)
+
+	if _, err := eng.Decide(state.NewState()); err != nil {
+		t.Fatalf("Decide(1): %v", err)
+	}
+	if failing.calls != 1 {
+		t.Fatalf("after cycle 1: enroller calls = %d, want 1", failing.calls)
+	}
+
+	// Cycle 2: the failure must not have marked the issue as enrolled,
+	// so the enroller is called again.
+	if _, err := eng.Decide(state.NewState()); err != nil {
+		t.Fatalf("Decide(2): %v", err)
+	}
+	if failing.calls != 2 {
+		t.Fatalf("after cycle 2: enroller calls = %d, want 2 (retry after failure)", failing.calls)
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -166,15 +166,16 @@ type PreflightRunner func(command string) PreflightResult
 // Engine makes deterministic supervisor decisions. It plans safe queue mutations
 // and emits structured stuck-state explanations.
 type Engine struct {
-	cfg       *config.Config
-	reader    Reader
-	llm       LLMClient
-	now       func() time.Time
-	pidAlive  func(pid int) bool
-	stat      func(name string) (os.FileInfo, error)
-	lookPath  func(file string) (string, error)
-	preflight PreflightRunner
-	enroller  ProjectEnroller
+	cfg               *config.Config
+	reader            Reader
+	llm               LLMClient
+	now               func() time.Time
+	pidAlive          func(pid int) bool
+	stat              func(name string) (os.FileInfo, error)
+	lookPath          func(file string) (string, error)
+	preflight         PreflightRunner
+	enroller          ProjectEnroller
+	enrollmentTracker enrollmentTracker
 }
 
 func NewEngine(cfg *config.Config, reader Reader) *Engine {
@@ -182,13 +183,14 @@ func NewEngine(cfg *config.Config, reader Reader) *Engine {
 		reader = github.New(cfg.Repo)
 	}
 	eng := &Engine{
-		cfg:       cfg,
-		reader:    reader,
-		now:       func() time.Time { return time.Now().UTC() },
-		pidAlive:  pidAlive,
-		stat:      os.Stat,
-		lookPath:  exec.LookPath,
-		preflight: defaultPreflightRunner,
+		cfg:               cfg,
+		reader:            reader,
+		now:               func() time.Time { return time.Now().UTC() },
+		pidAlive:          pidAlive,
+		stat:              os.Stat,
+		lookPath:          exec.LookPath,
+		preflight:         defaultPreflightRunner,
+		enrollmentTracker: defaultEnrollmentTracker,
 	}
 	if enroller, ok := reader.(ProjectEnroller); ok {
 		eng.enroller = enroller

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -191,6 +191,9 @@ func testEngine(cfg *config.Config, reader *fakeReader) *Engine {
 	eng.now = func() time.Time { return time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC) }
 	eng.pidAlive = func(pid int) bool { return true }
 	eng.lookPath = func(file string) (string, error) { return file, nil }
+	// Isolate the in-process enrollment dedup (#569) so each test starts
+	// with an empty set and does not bleed state into sibling tests.
+	eng.enrollmentTracker = newInMemoryEnrollmentTracker()
 	return eng
 }
 


### PR DESCRIPTION
Refs #569

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a GraphQL budget waste where blocked issues were re-enrolled into the GitHub Project board on every supervisor cycle instead of only once. A process-wide `inMemoryEnrollmentTracker` is introduced to deduplicate enrollment calls, and the tracker is wired into `Engine` via a new field so it survives cycle boundaries (since `RunOnce` creates a fresh `Engine` per cycle).

- Adds `enrollmentTracker` interface with `inMemoryEnrollmentTracker` implementation; a package-level `defaultEnrollmentTracker` is shared across all `Engine` instances created via `NewEngine` to persist dedup state across cycles.
- Failures are intentionally not marked as seen so the next cycle retries them; `testEngine` is updated to stamp a fresh tracker per test to prevent cross-test state bleed.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the dedup logic is correct, failure-retry behavior is properly preserved, and test isolation is handled.

The implementation is correct and well-tested. The only finding is a function comment that still says 'walks every blocked wave member' and 'regardless of success' after the dedup skip was added — a future caller reasoning from that doc about what the returned slice contains could draw a wrong conclusion.

dependency_unblock.go — specifically the enrollBlockedWaveMembers docstring, which no longer accurately describes which issues are walked or what the returned slice contains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/supervisor/dependency_unblock.go | Adds enrollmentTracker interface + inMemoryEnrollmentTracker to deduplicate GraphQL enrollment calls across supervisor cycles. Logic is correct; function docstring is slightly stale after the dedup skip was introduced. |
| internal/supervisor/dependency_unblock_test.go | Adds errorEnroller stub and two focused tests covering the dedup path (no re-enroll on second cycle, new issue enrolled in third cycle) and the failure-retry path. Coverage is thorough for the new behavior. |
| internal/supervisor/supervisor.go | Adds enrollmentTracker field to Engine struct and wires defaultEnrollmentTracker in NewEngine. Straightforward structural change with no logic concerns. |
| internal/supervisor/supervisor_test.go | testEngine now stamps a fresh inMemoryEnrollmentTracker on every engine, correctly isolating the dedup state so tests don't bleed enrollment state across cases. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/supervisor/dependency_unblock.go`, line 72-75 ([link](https://github.com/befeast/maestro/blob/039cae2984165d3579a54d6517c5db7e6a61bd9f/internal/supervisor/dependency_unblock.go#L72-L75)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `enrollBlockedWaveMembers` function comment is now inaccurate in two ways after this change. It says "walks every blocked wave member and asks the configured enroller to add it" — but already-seen issues are silently skipped via `continue` before the enroller is called. It also says "Returns the issues that were attempted (regardless of success)" — but dedup-skipped issues are not in the returned slice, and neither are failed attempts (that was already true before this PR). A future reader using the doc to understand what `enrolled` contains could incorrectly assume all attempted issues are present, leading to misuse in any downstream counting or audit logic.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/supervisor/dependency_unblock.go
   Line: 72-75

   Comment:
   The `enrollBlockedWaveMembers` function comment is now inaccurate in two ways after this change. It says "walks every blocked wave member and asks the configured enroller to add it" — but already-seen issues are silently skipped via `continue` before the enroller is called. It also says "Returns the issues that were attempted (regardless of success)" — but dedup-skipped issues are not in the returned slice, and neither are failed attempts (that was already true before this PR). A future reader using the doc to understand what `enrolled` contains could incorrectly assume all attempted issues are present, leading to misuse in any downstream counting or audit logic.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/dependency_unblock.go:72-75
The `enrollBlockedWaveMembers` function comment is now inaccurate in two ways after this change. It says "walks every blocked wave member and asks the configured enroller to add it" — but already-seen issues are silently skipped via `continue` before the enroller is called. It also says "Returns the issues that were attempted (regardless of success)" — but dedup-skipped issues are not in the returned slice, and neither are failed attempts (that was already true before this PR). A future reader using the doc to understand what `enrolled` contains could incorrectly assume all attempted issues are present, leading to misuse in any downstream counting or audit logic.

```suggestion
// enrollBlockedWaveMembers walks each blocked wave member that has not yet
// been enrolled in this process and calls the configured enroller. Returns
// the issue numbers that were newly and successfully enrolled this call;
// already-seen issues (deduped, #569) and failed attempts are excluded.
// Safe to call with a nil enroller; this is just a no-op then.
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(supervisor): dedup blocked-issue pro..."](https://github.com/befeast/maestro/commit/039cae2984165d3579a54d6517c5db7e6a61bd9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35083685)</sub>

<!-- /greptile_comment -->