### PR TITLE
Orchestrator can keep reporting CI=pending after GitHub checks are green

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -97,6 +97,7 @@ type Orchestrator struct {
 
 	// Testing hooks for autoMergePRs / mergeReadyPR
 	ghPRCIStatusFn              func(prNumber int) (string, error)
+	ghPRMergeStatusFn           func(prNumber int) (mergeable string, mergeStateStatus string, err error)
 	ghPRGreptileApprovedFn      func(prNumber int) (approved bool, pending bool, err error)
 	ghPRHasCriticalReviewFn     func(prNumber int) (bool, error)
 	ghUpdateBranchFn            func(prNumber int) error
@@ -210,6 +211,22 @@ func (o *Orchestrator) prCIStatus(prNumber int) (string, error) {
 		return o.ghPRCIStatusFn(prNumber)
 	}
 	return o.gh.PRCIStatus(prNumber)
+}
+
+// prMergeStatus returns GitHub's per-PR mergeable verdict together with the
+// raw mergeable_state ("clean" / "unstable" / "blocked" / "behind" / "dirty"
+// / "" / "unknown" / "draft" / "has_hooks"). It mirrors the supervisor's
+// prMergeStateReader and is consulted by autoMergePRs when the aggregate
+// PRCIStatus sticks at "pending" — GitHub's own required-checks verdict is
+// the authoritative override for legacy commit-status drift (#424).
+func (o *Orchestrator) prMergeStatus(prNumber int) (string, string, error) {
+	if o.ghPRMergeStatusFn != nil {
+		return o.ghPRMergeStatusFn(prNumber)
+	}
+	if o.gh == nil {
+		return "", "", fmt.Errorf("no github client configured for merge-status")
+	}
+	return o.gh.PRMergeStatus(prNumber)
 }
 
 func (o *Orchestrator) prGreptileApproved(prNumber int) (bool, bool, error) {
@@ -2189,6 +2206,22 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		if err != nil {
 			log.Printf("[orch] CI status for PR #%d: %v", pr.Number, err)
 			continue
+		}
+
+		// #424: the aggregate PRCIStatus can stick at "pending" long after
+		// every required check has gone green (a common cause is a legacy
+		// commit-status used by some review bots that never resolves).
+		// GitHub's own per-PR mergeable_state already encodes the
+		// required-check verdict, so "clean" or "unstable" overrides the
+		// stale aggregate and lets autoMergePRs converge instead of looping.
+		if ciStatus == "pending" {
+			if mergeable, mergeState, mErr := o.prMergeStatus(pr.Number); mErr == nil && mergeable == "MERGEABLE" {
+				switch mergeState {
+				case "clean", "unstable":
+					log.Printf("[orch] PR #%d (%s) aggregate CI=pending but mergeable_state=%s — treating as success (#424)", pr.Number, sess.Branch, mergeState)
+					ciStatus = "success"
+				}
+			}
 		}
 
 		log.Printf("[orch] PR #%d (%s) CI=%s", pr.Number, sess.Branch, ciStatus)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2252,6 +2252,125 @@ func TestCheckSessions_SettledRetryExhausted_NoFlipFlop(t *testing.T) {
 	}
 }
 
+// #424: when the aggregate PRCIStatus sticks at "pending" (e.g. a legacy
+// commit-status that never resolves) but GitHub's per-PR mergeable_state
+// is "clean" (every required check has gone green) the orchestrator must
+// trust mergeable_state and merge the PR instead of looping on CI=pending.
+func TestAutoMergePRs_CIAggregateStaleButMergeStateClean_Merges(t *testing.T) {
+	prs := []github.PR{{Number: 99, HeadRefName: "feat/auth"}}
+
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none"}
+	merged := make([]int, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "pending", nil
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "MERGEABLE", "clean", nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = append(merged, prNumber)
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(merged) != 1 || merged[0] != 99 {
+		t.Fatalf("merged = %v, want [99] (mergeable_state=clean must override stale aggregate CI=pending)", merged)
+	}
+}
+
+// mergeable_state="blocked" means a required check is still failing; the
+// orchestrator must NOT override CI=pending in that case.
+func TestAutoMergePRs_CIPendingAndMergeStateBlocked_DoesNotMerge(t *testing.T) {
+	prs := []github.PR{{Number: 101, HeadRefName: "feat/blocked"}}
+
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none"}
+	merged := make([]int, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "pending", nil
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "MERGEABLE", "blocked", nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = append(merged, prNumber)
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(merged) != 0 {
+		t.Fatalf("merged = %v, want [] (mergeable_state=blocked must keep CI=pending blocking)", merged)
+	}
+}
+
+// mergeable_state="unstable" — only non-required checks are failing, so
+// the PR is still safe to merge under the same #424 override.
+func TestAutoMergePRs_CIPendingMergeStateUnstable_Merges(t *testing.T) {
+	prs := []github.PR{{Number: 102, HeadRefName: "feat/unstable"}}
+
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none"}
+	merged := make([]int, 0)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "pending", nil
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "MERGEABLE", "unstable", nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = append(merged, prNumber)
+			return nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			return nil
+		},
+		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
+			return nil
+		},
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(merged) != 1 || merged[0] != 102 {
+		t.Fatalf("merged = %v, want [102] (mergeable_state=unstable should still allow merge)", merged)
+	}
+}
+
 func TestAutoMergePRs_CIFailureBlocksMerge(t *testing.T) {
 	prs := []github.PR{
 		{Number: 10, HeadRefName: "feat/a"},


### PR DESCRIPTION
Refs #424

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issue #424 where the orchestrator's aggregate `PRCIStatus` can permanently stick at `"pending"` due to legacy commit-status reporters (e.g. review bots) that never resolve, even after every required GitHub check has gone green. The fix consults GitHub's per-PR `mergeable_state` as an authoritative override when `ciStatus == "pending"`, promoting the status to `"success"` for `"clean"` or `"unstable"` states while leaving `"blocked"`, `"dirty"`, and others untouched.

- Adds a `prMergeStatus` method and `ghPRMergeStatusFn` test hook following the same pattern as `prCIStatus`.
- Override logic is gated on `mergeable == "MERGEABLE"` to avoid acting on conflicting or unknown PRs, with three new tests covering the clean, blocked, and unstable cases.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the override is conservative (only fires for MERGEABLE + clean/unstable) and degrades gracefully on error, keeping prior pending behavior.

Errors from the new `prMergeStatus` call are silently discarded — no log line is emitted — so if the API call fails consistently the #424 fix becomes a transparent no-op. An operator seeing repeated `CI=pending` log lines would have no indication the override was being attempted at all.

The error-handling branch in `orchestrator.go` around the new `prMergeStatus` call deserves a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds `prMergeStatus` helper and an override in `autoMergePRs` so that a stale aggregate CI=pending is bypassed when GitHub's `mergeable_state` is "clean" or "unstable"; errors from the new API call are silently swallowed with no log. |
| internal/orchestrator/orchestrator_test.go | Adds three focused tests covering the clean-merges, blocked-does-not-merge, and unstable-merges scenarios for the #424 override; coverage is thorough for the new branch. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:2217-2225
When `prMergeStatus` returns an error the condition short-circuits silently — no log is emitted and `ciStatus` stays `"pending"`. This makes the entire #424 fix invisible when the underlying API call fails: an operator looking at logs would only see repeated `CI=pending` lines with no hint that the override was attempted and failed. Adding a log at the error branch gives the same diagnostic footprint that every other fallible helper in this function already provides.

```suggestion
		if ciStatus == "pending" {
			if mergeable, mergeState, mErr := o.prMergeStatus(pr.Number); mErr != nil {
				log.Printf("[orch] PR #%d (%s) merge-status check failed, keeping CI=pending: %v", pr.Number, sess.Branch, mErr)
			} else if mergeable == "MERGEABLE" {
				switch mergeState {
				case "clean", "unstable":
					log.Printf("[orch] PR #%d (%s) aggregate CI=pending but mergeable_state=%s — treating as success (#424)", pr.Number, sess.Branch, mergeState)
					ciStatus = "success"
				}
			}
		}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): override stale CI=pen..."](https://github.com/befeast/maestro/commit/0caf09848a6ff8c73e3458a34dd3055bace2c773) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35088869)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->