### PR TITLE
Stale BackendHealth: cooldown/provider_limit never cleared after recovery — dashboard shows working backends as limited

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1090,6 +1090,14 @@ func (o *Orchestrator) RunOnce() error {
 		}
 	}
 
+	// Step 4c: Clear stale BackendHealth cooldown entries (#600) — backends
+	// that have since produced successful sessions, whose RetryAfter has
+	// elapsed, or whose cooldown is older than the max-cooldown TTL. The
+	// selector already ignores elapsed RetryAfter, but the MC BACKENDS
+	// panel reads the raw map; without this the panel reports working
+	// backends as "auto-recovery pending" indefinitely.
+	state.ReconcileBackendHealth(s, time.Now().UTC())
+
 	// Save after all checks/reconciliation
 	if err := state.Save(o.cfg.StateDir, s); err != nil {
 		return fmt.Errorf("save state: %w", err)

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2165,6 +2165,11 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	item.Freshness = fleetProjectFreshnessForState(cfg.StateDir, st, now)
 	item.RestartRequired = st.RestartRequired
 	item.RestartRequiredReason = st.RestartRequiredReason
+	// #600: normalize stale cooldown entries for display so the BACKENDS
+	// panel matches reality between orchestrator cycles — RetryAfter in
+	// the past, max-cooldown TTL elapsed, or a successful session
+	// recorded after the cooldown was set all render as healthy.
+	state.ReconcileBackendHealth(st, now)
 	item.BackendHealth = st.BackendHealth
 	projectState := buildStateResponse(cfg, st)
 	item.Summary = projectState.Summary

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -3972,3 +3972,71 @@ func TestFleetAPISurfacesBackendHealthAndAttribution(t *testing.T) {
 		t.Fatalf("second segment.Reason = %q, want fallover", worker.Attribution[1].Reason)
 	}
 }
+
+// #600: stale BackendHealth cooldown entries (RetryAfter in the past,
+// successful sessions recorded after the cooldown was set) must be
+// omitted from the fleet snapshot so the BACKENDS panel reflects
+// reality. Mirrors the operator-reported scenario where claude+codex
+// were producing merges while the panel reported them as "auto-recovery
+// pending".
+func TestFleetAPIClearsStaleBackendCooldown(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "one")
+	now := time.Now().UTC()
+
+	expiredRetry := now.Add(-48 * time.Hour)
+	staleSince := now.Add(-72 * time.Hour)
+	successStart := now.Add(-1 * time.Hour)
+
+	st := state.NewState()
+	st.Sessions["one-7"] = &state.Session{
+		IssueNumber: 600,
+		IssueTitle:  "Successful claude session post-cooldown",
+		Status:      state.StatusPROpen,
+		StartedAt:   successStart,
+		Backend:     "claude",
+		PRNumber:    597,
+	}
+	st.BackendHealth["claude"] = state.BackendHealth{
+		State:       state.BackendHealthCooldown,
+		Reason:      state.BackendBlockProviderLimit,
+		Since:       staleSince,
+		LastSession: "sup-83",
+	}
+	st.BackendHealth["codex"] = state.BackendHealth{
+		State:      state.BackendHealthCooldown,
+		Reason:     state.BackendBlockProviderLimit,
+		Since:      staleSince,
+		RetryAfter: &expiredRetry,
+	}
+	if err := state.Save(stateDir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("One", "/tmp/one.yaml", "", &config.Config{
+			Repo:        "owner/one",
+			StateDir:    stateDir,
+			MaxParallel: 1,
+		}),
+	}, "127.0.0.1", 8787, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleet(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp fleetResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	project := findFleetProject(t, resp.Projects, "One")
+	if got, ok := project.BackendHealth["claude"]; ok {
+		t.Fatalf("claude cooldown should be cleared after a successful PR session, got %+v", got)
+	}
+	if got, ok := project.BackendHealth["codex"]; ok {
+		t.Fatalf("codex cooldown should be cleared after RetryAfter elapses, got %+v", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -892,6 +892,10 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 
 func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 	latestDecision := st.LatestSupervisorDecision()
+	// #600: clear elapsed-RetryAfter / TTL-expired / proven-recovered
+	// cooldown entries so dashboard consumers see a truthful health map
+	// even between orchestrator cycles.
+	state.ReconcileBackendHealth(st, time.Now().UTC())
 	resp := stateResponse{
 		Repo:                cfg.Repo,
 		MaxParallel:         cfg.MaxParallel,

--- a/internal/server/web/mc/src/fleetApi.js
+++ b/internal/server/web/mc/src/fleetApi.js
@@ -106,24 +106,33 @@ export function mapFleetResponse(raw, now = Date.now()) {
 // available». When the same backend appears across projects, the worst
 // state wins (cooldown > available) and the earliest RetryAfter is kept
 // so the countdown reflects the soonest recovery.
-export function aggregateBackendHealth(rawProjects) {
+//
+// #600: a cooldown entry whose retry_after is already in the past is
+// coerced to "available" on the client too. The server normalizes the
+// map on every snapshot, but this guard protects against older
+// orchestrators / unrefreshed snapshots so the panel never reports a
+// working backend as limited.
+export function aggregateBackendHealth(rawProjects, now = Date.now()) {
   const out = new Map();
   for (const project of rawProjects || []) {
     const map = project?.backend_health || {};
     for (const [name, entry] of Object.entries(map)) {
       if (!entry || typeof entry !== "object") continue;
-      const state = String(entry.state || "");
+      let state = String(entry.state || "");
       const retry = entry.retry_after || null;
       const retryMs = retry ? parseTimestamp(retry) : null;
+      if (state === "cooldown" && retryMs != null && retryMs <= now) {
+        state = "available";
+      }
       const existing = out.get(name);
       if (!existing) {
         out.set(name, {
           backend: name,
           state,
-          reason: entry.reason || "",
-          pattern: entry.pattern || "",
-          retryAfter: retry,
-          retryAfterMs: retryMs,
+          reason: state === "available" ? "" : entry.reason || "",
+          pattern: state === "available" ? "" : entry.pattern || "",
+          retryAfter: state === "available" ? null : retry,
+          retryAfterMs: state === "available" ? null : retryMs,
           since: entry.since || "",
         });
         continue;
@@ -134,7 +143,7 @@ export function aggregateBackendHealth(rawProjects) {
         existing.reason = entry.reason || existing.reason;
         existing.pattern = entry.pattern || existing.pattern;
       }
-      if (retryMs != null && (existing.retryAfterMs == null || retryMs < existing.retryAfterMs)) {
+      if (state === "cooldown" && retryMs != null && (existing.retryAfterMs == null || retryMs < existing.retryAfterMs)) {
         existing.retryAfter = retry;
         existing.retryAfterMs = retryMs;
       }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2249,6 +2249,95 @@ func MarkPROpened(sess *Session, now time.Time) {
 	sess.PROpenedAt = &t
 }
 
+// MaxBackendCooldownTTL caps how long a BackendHealth cooldown entry stays
+// surfaced when no RetryAfter was parsed from the provider message. Without
+// this cap, a transient provider rate-limit would render as
+// "auto-recovery pending" indefinitely even though the backend is back in
+// active use (#600). 24h is the longest a Claude/Codex provider limit
+// realistically takes to reset.
+const MaxBackendCooldownTTL = 24 * time.Hour
+
+// MarkBackendHealthy clears any cooldown entry recorded for the named
+// backend. Called when the backend successfully completes a session,
+// opens a PR, or merges code — a successful use proves the backend is
+// no longer rate-limited regardless of the original RetryAfter (#600).
+func MarkBackendHealthy(s *State, backend string) {
+	if s == nil || backend == "" {
+		return
+	}
+	if _, ok := s.BackendHealth[backend]; !ok {
+		return
+	}
+	delete(s.BackendHealth, backend)
+}
+
+// ReconcileBackendHealth walks the BackendHealth map and clears stale
+// cooldown entries so the MC BACKENDS panel reflects reality (#600):
+//
+//   - RetryAfter is non-nil and in the past → cooldown has elapsed; the
+//     selector already treats this backend as available, so the panel
+//     should too.
+//   - RetryAfter is nil but Since is older than MaxBackendCooldownTTL →
+//     a stale provider-limit cooldown that was never cleared because no
+//     RetryAfter was parsed. Caps the "auto-recovery pending" indefinite
+//     state.
+//   - A session bound to this backend started after Since AND reached a
+//     successful status (pr_open / code_landed / done) → the backend is
+//     demonstrably back in service, regardless of the original RetryAfter.
+//
+// Returns true when at least one entry was cleared so the caller can
+// decide whether to persist the change.
+func ReconcileBackendHealth(s *State, now time.Time) bool {
+	if s == nil || len(s.BackendHealth) == 0 {
+		return false
+	}
+	changed := false
+	for name, health := range s.BackendHealth {
+		if health.State != BackendHealthCooldown {
+			continue
+		}
+		if health.RetryAfter != nil && !now.Before(*health.RetryAfter) {
+			delete(s.BackendHealth, name)
+			changed = true
+			continue
+		}
+		if health.RetryAfter == nil && !health.Since.IsZero() && now.Sub(health.Since) >= MaxBackendCooldownTTL {
+			delete(s.BackendHealth, name)
+			changed = true
+			continue
+		}
+		if backendHasSuccessAfter(s, name, health.Since) {
+			delete(s.BackendHealth, name)
+			changed = true
+			continue
+		}
+	}
+	return changed
+}
+
+func backendHasSuccessAfter(s *State, backend string, since time.Time) bool {
+	if s == nil || backend == "" {
+		return false
+	}
+	for _, sess := range s.Sessions {
+		if sess == nil || sess.Backend != backend {
+			continue
+		}
+		switch sess.Status {
+		case StatusPROpen, StatusCodeLanded, StatusDone:
+		default:
+			continue
+		}
+		if sess.StartedAt.IsZero() {
+			continue
+		}
+		if since.IsZero() || sess.StartedAt.After(since) {
+			return true
+		}
+	}
+	return false
+}
+
 // SessionChangedAt returns the newest persisted activity timestamp for a session.
 func SessionChangedAt(sess *Session) time.Time {
 	if sess == nil {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -123,6 +123,141 @@ func TestBackendHealthPersistence(t *testing.T) {
 	}
 }
 
+// #600: a backend that successfully produced a PR after the cooldown was
+// recorded must be cleared by ReconcileBackendHealth — the dashboard
+// should show it as healthy, not "auto-recovery pending".
+func TestReconcileBackendHealth_ClearsAfterSuccessfulSession(t *testing.T) {
+	s := NewState()
+	since := time.Date(2026, 5, 30, 18, 30, 0, 0, time.UTC)
+	s.BackendHealth["claude"] = BackendHealth{
+		State:       BackendHealthCooldown,
+		Reason:      BackendBlockProviderLimit,
+		Since:       since,
+		LastSession: "sup-83",
+	}
+	s.Sessions["sup-128"] = &Session{
+		IssueNumber: 600,
+		Backend:     "claude",
+		Status:      StatusPROpen,
+		StartedAt:   since.Add(48 * time.Hour),
+		PRNumber:    599,
+	}
+
+	now := since.Add(72 * time.Hour)
+	if !ReconcileBackendHealth(s, now) {
+		t.Fatal("ReconcileBackendHealth should report a change when a successful session post-dates the cooldown")
+	}
+	if _, ok := s.BackendHealth["claude"]; ok {
+		t.Fatalf("BackendHealth[claude] should be cleared, got %+v", s.BackendHealth["claude"])
+	}
+}
+
+// #600: an elapsed RetryAfter must clear the cooldown — the selector
+// already treats this backend as available, so the panel must too.
+func TestReconcileBackendHealth_ClearsAfterElapsedRetryAfter(t *testing.T) {
+	s := NewState()
+	since := time.Date(2026, 5, 29, 23, 0, 0, 0, time.UTC)
+	retryAfter := since.Add(2 * time.Hour)
+	s.BackendHealth["codex"] = BackendHealth{
+		State:      BackendHealthCooldown,
+		Reason:     BackendBlockProviderLimit,
+		Since:      since,
+		RetryAfter: &retryAfter,
+	}
+
+	now := retryAfter.Add(48 * time.Hour)
+	if !ReconcileBackendHealth(s, now) {
+		t.Fatal("ReconcileBackendHealth should clear cooldown when RetryAfter has elapsed")
+	}
+	if _, ok := s.BackendHealth["codex"]; ok {
+		t.Fatal("BackendHealth[codex] should be cleared after RetryAfter elapses")
+	}
+}
+
+// #600: a cooldown with no RetryAfter must be capped by MaxBackendCooldownTTL
+// so a transient provider limit cannot render as "auto-recovery pending"
+// forever.
+func TestReconcileBackendHealth_ClearsAfterMaxTTL(t *testing.T) {
+	s := NewState()
+	since := time.Now().UTC().Add(-MaxBackendCooldownTTL - time.Hour)
+	s.BackendHealth["claude"] = BackendHealth{
+		State:  BackendHealthCooldown,
+		Reason: BackendBlockProviderLimit,
+		Since:  since,
+	}
+
+	if !ReconcileBackendHealth(s, time.Now().UTC()) {
+		t.Fatal("ReconcileBackendHealth should clear cooldown after max TTL elapses")
+	}
+	if _, ok := s.BackendHealth["claude"]; ok {
+		t.Fatal("BackendHealth[claude] should be cleared after max-cooldown TTL")
+	}
+}
+
+// #600: an active cooldown whose RetryAfter is still in the future must
+// be preserved so the selector keeps blocking the backend.
+func TestReconcileBackendHealth_KeepsActiveCooldown(t *testing.T) {
+	s := NewState()
+	now := time.Now().UTC()
+	retryAfter := now.Add(30 * time.Minute)
+	s.BackendHealth["claude"] = BackendHealth{
+		State:      BackendHealthCooldown,
+		Reason:     BackendBlockProviderLimit,
+		Since:      now.Add(-5 * time.Minute),
+		RetryAfter: &retryAfter,
+	}
+
+	if ReconcileBackendHealth(s, now) {
+		t.Fatal("ReconcileBackendHealth should not clear an active cooldown")
+	}
+	if got, ok := s.BackendHealth["claude"]; !ok || got.State != BackendHealthCooldown {
+		t.Fatalf("BackendHealth[claude] = %+v, want active cooldown", got)
+	}
+}
+
+// #600: a successful session that pre-dates the cooldown must not clear
+// it — only later successes prove recovery.
+func TestReconcileBackendHealth_IgnoresOlderSuccess(t *testing.T) {
+	s := NewState()
+	since := time.Date(2026, 5, 30, 18, 0, 0, 0, time.UTC)
+	s.BackendHealth["claude"] = BackendHealth{
+		State:  BackendHealthCooldown,
+		Reason: BackendBlockProviderLimit,
+		Since:  since,
+	}
+	s.Sessions["sup-50"] = &Session{
+		Backend:   "claude",
+		Status:    StatusDone,
+		StartedAt: since.Add(-24 * time.Hour),
+		PRNumber:  500,
+	}
+
+	now := since.Add(1 * time.Hour)
+	if ReconcileBackendHealth(s, now) {
+		t.Fatal("ReconcileBackendHealth should not clear when only older successes exist")
+	}
+}
+
+// #600: MarkBackendHealthy removes a backend from the cooldown map
+// regardless of RetryAfter so a successful use immediately frees the
+// dashboard pill.
+func TestMarkBackendHealthy(t *testing.T) {
+	s := NewState()
+	retryAfter := time.Now().Add(2 * time.Hour)
+	s.BackendHealth["claude"] = BackendHealth{
+		State:      BackendHealthCooldown,
+		Reason:     BackendBlockProviderLimit,
+		RetryAfter: &retryAfter,
+	}
+	MarkBackendHealthy(s, "claude")
+	if _, ok := s.BackendHealth["claude"]; ok {
+		t.Fatal("MarkBackendHealthy should remove the cooldown entry")
+	}
+	// Idempotent on missing backend.
+	MarkBackendHealthy(s, "nonexistent")
+	MarkBackendHealthy(nil, "claude")
+}
+
 func TestBackendHealthMergeKeepsLatest(t *testing.T) {
 	base := NewState()
 	current := NewState()


### PR DESCRIPTION
Refs #600

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a stale-state display bug (#600) where backends that had recovered from provider rate-limits continued to show as \"auto-recovery pending\" in the MC BACKENDS panel indefinitely. It introduces `ReconcileBackendHealth`, which clears `BackendHealth` cooldown entries when their `RetryAfter` has elapsed, when `Since` is older than the new 24-hour `MaxBackendCooldownTTL`, or when a session for that backend has since reached a successful status (`pr_open` / `code_landed` / `done`).

- `ReconcileBackendHealth` is called in the orchestrator's `RunOnce` loop (persisting the change to disk) and in both server response builders (`buildStateResponse`, `projectSnapshot`) so the dashboard reflects reality even between orchestrator cycles.
- The JS `aggregateBackendHealth` function adds a client-side guard that coerces cooldown \u2192 available when `retry_after` is already in the past, protecting against stale snapshots from older orchestrators.
- A new exported `MarkBackendHealthy` helper is added and tested but has no production call sites; recovery is handled entirely through the periodic reconciliation scan.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the reconciliation logic is well-tested and the mutations are on short-lived in-memory copies in the server path; only the orchestrator persists the change.

The core fix is correct and covered by thorough unit and integration tests. The two concerns are both non-blocking: MarkBackendHealthy has no production callers despite its doc comment implying otherwise, and buildStateResponse carries a hidden mutation side effect that causes a redundant (but harmless) second reconciliation in fleet.go. Neither affects correctness of the bug fix itself.

internal/state/state.go and internal/server/server.go warrant a second look — the former for the uncalled MarkBackendHealthy export, the latter for the mutation side effect embedded inside a response-builder function.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds ReconcileBackendHealth (clears stale cooldowns by RetryAfter, TTL, or proven recovery) and MarkBackendHealthy (exported but never called in production — doc comment is misleading) |
| internal/state/state_test.go | Comprehensive unit tests for all three clearing conditions (elapsed RetryAfter, MaxTTL, post-cooldown success) and the preserve-active-cooldown / ignore-older-success negative cases |
| internal/orchestrator/orchestrator.go | Adds Step 4c calling ReconcileBackendHealth before Save so cleared entries are persisted at the end of each orchestrator cycle |
| internal/server/fleet.go | Calls ReconcileBackendHealth on the loaded state before capturing BackendHealth for the snapshot, but then calls buildStateResponse which reconciles the same state object a second time |
| internal/server/server.go | ReconcileBackendHealth added as an in-place mutation inside buildStateResponse, giving it a hidden side effect used by both server.go and (redundantly) fleet.go |
| internal/server/fleet_test.go | Integration test covering both clearing conditions (expired RetryAfter and post-cooldown success session) at the fleet API level |
| internal/server/web/mc/src/fleetApi.js | Client-side guard coerces cooldown→available when retry_after is already past, protecting against stale snapshots from older orchestrators; reason/pattern/retryAfter are correctly nulled out on coercion |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/state/state.go:2260-2272
**`MarkBackendHealthy` is exported but never called in production**

The doc comment says "Called when the backend successfully completes a session, opens a PR, or merges code" but there are zero call sites in the orchestrator or server code — only in `state_test.go`. The actual eager-clearing path described by the comment never executes; recovery is handled solely through the periodic `ReconcileBackendHealth` scan at end-of-cycle. The misleading doc comment will confuse future readers who expect the function to be wired into the session-completion path.

### Issue 2 of 2
internal/server/fleet.go:2172-2174
**Double-reconciliation on `st` from `buildStateResponse` side effect**

`ReconcileBackendHealth(st, now)` mutates `st.BackendHealth` in place here, then `buildStateResponse(cfg, st)` (line 2174) calls `state.ReconcileBackendHealth(st, time.Now().UTC())` again on the same pointer. The second call is functionally a no-op since all stale entries are already deleted, but `buildStateResponse` now carries a hidden mutation side effect that is easy to miss — the function name implies read-only response construction. Callers of `buildStateResponse` from other sites (e.g., `server.go:handleState`) rely on this implicit reconciliation; removing it from one site would silently break the other.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(state,server): clear stale BackendHe..."](https://github.com/befeast/maestro/commit/b7bea2757cf527a01909bee8bbac70ad49f3d211) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35098678)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->