### PR TITLE
Conflicting (real merge-conflict) retry_exhausted PR loops in convergence-merge and halts the queue

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2962,6 +2962,16 @@ func (o *Orchestrator) mergeReadyPR(s *state.State, slotName string, sess *state
 			return false
 		}
 
+		// Real-conflict path (#602): a merge failure that is NOT "not up to
+		// date" can still be a real merge conflict (GitHub returns variants
+		// like "merge commit cannot be cleanly created"). Confirm with the
+		// authoritative mergeable verdict and route to the conflict-resolution
+		// path so retry_exhausted convergence candidates can't loop forever and
+		// halt the queue.
+		if o.routeConflictingMergeFailure(s, slotName, sess, pr, err) {
+			return false
+		}
+
 		// Only notify merge failure once per PR
 		if sess.LastNotifiedStatus != "merge_failed" {
 			o.notifier.Sendf("❌ maestro: failed to merge PR #%d (%s): %v", pr.Number, sess.Branch, err)
@@ -3075,6 +3085,64 @@ func (o *Orchestrator) runDeployCmd(prNumber int) error {
 	return nil
 }
 
+// routeConflictingMergeFailure reconciles a merge failure that GitHub reports
+// as CONFLICTING — the real-merge-conflict sibling of the behind-base path
+// (#602). Returns true when the failure was handled (session advanced to a
+// terminal/self-healing state) and the caller should stop further fallthrough.
+//
+// For StatusPROpen sessions this mirrors the existing CONFLICTING loop in
+// rebaseConflicts (rebase worktree → handleRebaseConflictRetry on failure /
+// markUnresolvableConflict when rebase is impossible). For sessions that are
+// already retry_exhausted (convergence-merge candidates after #565/#574) we
+// must NOT respawn another worker via handleRebaseConflictRetry — the worker
+// has already exhausted its budget — so on rebase failure we go straight to
+// markUnresolvableConflict, which labels the issue blocked and frees the slot.
+func (o *Orchestrator) routeConflictingMergeFailure(s *state.State, slotName string, sess *state.Session, pr github.PR, mergeErr error) bool {
+	mergeable, _, mErr := o.prMergeStatus(pr.Number)
+	if mErr != nil {
+		log.Printf("[orch] PR #%d merge-status lookup after failed merge: %v", pr.Number, mErr)
+		return false
+	}
+	if mergeable != "CONFLICTING" {
+		return false
+	}
+
+	log.Printf("[orch] PR #%d merge failed and GitHub reports CONFLICTING — routing to conflict resolution (#602): %v", pr.Number, mergeErr)
+
+	retryExhausted := sess.Status == state.StatusRetryExhausted
+
+	if !o.cfg.AutoRebase {
+		o.markUnresolvableConflict(slotName, sess, pr.Number, fmt.Errorf("auto_rebase disabled"))
+		return true
+	}
+
+	if strings.TrimSpace(sess.Worktree) == "" {
+		// No worktree to rebase. For an in-flight (pr_open) session let the
+		// retry path handle worker respawn; for a settled retry_exhausted
+		// session the worker is already gone — mark unresolvable so the slot
+		// advances instead of looping on the same merge failure forever.
+		if retryExhausted {
+			o.markUnresolvableConflict(slotName, sess, pr.Number, mergeErr)
+			return true
+		}
+		o.handleRebaseConflictRetry(s, slotName, sess, pr.Number, mergeErr)
+		return true
+	}
+
+	if rerr := o.rebaseWorktree(sess.Worktree, sess.Branch); rerr != nil {
+		log.Printf("[orch] auto-rebase failed for %s: %v", slotName, rerr)
+		if retryExhausted {
+			o.markUnresolvableConflict(slotName, sess, pr.Number, rerr)
+			return true
+		}
+		o.handleRebaseConflictRetry(s, slotName, sess, pr.Number, rerr)
+		return true
+	}
+
+	o.markRebaseQueued(slotName, sess, pr.Number)
+	return true
+}
+
 // rebaseConflicts handles branch conflicts in two phases:
 //  1. Auto-rebase (if enabled)
 //  2. Label issue as blocked + keep session in conflict_failed permanently
@@ -3137,6 +3205,35 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 				continue
 			}
 			o.markRebaseQueued(slotName, sess, pr.Number)
+
+		case state.StatusRetryExhausted:
+			// #602: a retry_exhausted convergence candidate whose PR is
+			// CONFLICTING must reach a terminal advanced state — the worker
+			// has already exhausted retries, so we never respawn from this
+			// branch. Acts as a safety net for mergeReadyPR's primary route.
+			if !hasPR || sess.RebaseAttempted {
+				continue
+			}
+			mergeable, _, mErr := o.prMergeStatus(pr.Number)
+			if mErr != nil {
+				log.Printf("[orch] mergeable PR #%d: %v", pr.Number, mErr)
+				continue
+			}
+			if mergeable != "CONFLICTING" {
+				continue
+			}
+			if o.cfg.AutoRebase && strings.TrimSpace(sess.Worktree) != "" {
+				log.Printf("[orch] retry_exhausted PR #%d is CONFLICTING, attempting one-shot rebase for %s (#602)", pr.Number, slotName)
+				if err := o.rebaseWorktree(sess.Worktree, sess.Branch); err != nil {
+					log.Printf("[orch] rebase for retry_exhausted %s failed: %v — marking unresolvable", slotName, err)
+					o.markUnresolvableConflict(slotName, sess, pr.Number, err)
+					continue
+				}
+				o.markRebaseQueued(slotName, sess, pr.Number)
+				continue
+			}
+			log.Printf("[orch] retry_exhausted PR #%d is CONFLICTING and cannot self-heal (auto_rebase=%v, worktree=%q) — marking unresolvable for %s (#602)", pr.Number, o.cfg.AutoRebase, sess.Worktree, slotName)
+			o.markUnresolvableConflict(slotName, sess, pr.Number, fmt.Errorf("retry_exhausted PR is CONFLICTING"))
 		}
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3192,6 +3192,373 @@ func TestMergeReadyPR_OtherMergeErrorNoRebase(t *testing.T) {
 	}
 }
 
+// #602 — A real merge conflict on a StatusPROpen session must route through
+// the conflict-resolution path (rebase worktree → markRebaseQueued on success)
+// instead of looping with merge_failed forever.
+func TestMergeReadyPR_RealConflictRoutesToRebaseForPROpen(t *testing.T) {
+	rebased := false
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return fmt.Errorf("gh pr merge 10: merge commit cannot be cleanly created")
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "CONFLICTING", "dirty", nil
+		},
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
+			rebased = true
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
+
+	if result {
+		t.Fatal("mergeReadyPR should return false for a CONFLICTING merge failure")
+	}
+	if !rebased {
+		t.Fatal("rebase should be triggered when GitHub reports CONFLICTING")
+	}
+	if sess.Status != state.StatusQueued {
+		t.Errorf("session status = %q, want %q after successful rebase", sess.Status, state.StatusQueued)
+	}
+	if !sess.RebaseAttempted {
+		t.Error("RebaseAttempted should be true after rebase")
+	}
+	if sess.LastNotifiedStatus == "merge_failed" {
+		t.Error("LastNotifiedStatus must not be merge_failed — the conflict was routed, not surfaced as a generic failure")
+	}
+}
+
+// #602 — When the merge fails on a retry_exhausted convergence candidate and
+// GitHub reports CONFLICTING, the session must reach a terminal advanced state
+// (conflict_failed + blocked label) so the slot frees and the dynamic-wave
+// queue advances on the next cycle. No worker respawn.
+func TestMergeReadyPR_RealConflictMarksRetryExhaustedUnresolvable(t *testing.T) {
+	labels := make([]string, 0)
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return fmt.Errorf("gh pr merge 10: merge commit cannot be cleanly created")
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "CONFLICTING", "dirty", nil
+		},
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
+			return fmt.Errorf("CONFLICT (content): main.go")
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labels = append(labels, label)
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber:        100,
+		IssueTitle:         "test issue",
+		Branch:             "feat/a",
+		Worktree:           "/tmp/wt",
+		Status:             state.StatusRetryExhausted,
+		PRNumber:           10,
+		LastNotifiedStatus: "review_retry_exhausted",
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
+
+	if result {
+		t.Fatal("mergeReadyPR should return false on real conflict")
+	}
+	if sess.Status != state.StatusConflictFailed {
+		t.Errorf("session status = %q, want %q (slot must free)", sess.Status, state.StatusConflictFailed)
+	}
+	if sess.FinishedAt == nil {
+		t.Error("FinishedAt should be set so the slot is no longer active")
+	}
+	if !sess.RebaseAttempted {
+		t.Error("RebaseAttempted should be true")
+	}
+	if len(labels) == 0 || labels[0] != "blocked" {
+		t.Errorf("issue must be labelled blocked, got %v", labels)
+	}
+	if sess.LastNotifiedStatus == "merge_failed" {
+		t.Error("LastNotifiedStatus must not stay merge_failed — conflict was reconciled, not silently logged")
+	}
+}
+
+// #602 — A retry_exhausted convergence candidate with no remaining worktree
+// (worker already cleaned up after retry exhaustion) must still reach
+// conflict_failed without trying to respawn a worker via handleRebaseConflictRetry.
+func TestMergeReadyPR_RealConflictRetryExhaustedNoWorktree(t *testing.T) {
+	labels := make([]string, 0)
+	rebaseCalled := false
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return fmt.Errorf("gh pr merge 10: merge commit cannot be cleanly created")
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "CONFLICTING", "dirty", nil
+		},
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
+			rebaseCalled = true
+			return nil
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labels = append(labels, label)
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber:        100,
+		IssueTitle:         "test issue",
+		Branch:             "feat/a",
+		Worktree:           "",
+		Status:             state.StatusRetryExhausted,
+		PRNumber:           10,
+		LastNotifiedStatus: "review_retry_exhausted",
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
+
+	if result {
+		t.Fatal("mergeReadyPR should return false on real conflict")
+	}
+	if rebaseCalled {
+		t.Error("rebase must NOT be called when there is no worktree")
+	}
+	if sess.Status != state.StatusConflictFailed {
+		t.Errorf("session status = %q, want %q (slot must free)", sess.Status, state.StatusConflictFailed)
+	}
+	if len(labels) == 0 || labels[0] != "blocked" {
+		t.Errorf("issue must be labelled blocked, got %v", labels)
+	}
+}
+
+// #602 — AutoRebase disabled: a real conflict still drives to a terminal state
+// instead of looping silently.
+func TestMergeReadyPR_RealConflictAutoRebaseDisabledMarksUnresolvable(t *testing.T) {
+	labels := make([]string, 0)
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: false},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return fmt.Errorf("gh pr merge 10: merge commit cannot be cleanly created")
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "CONFLICTING", "dirty", nil
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labels = append(labels, label)
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	if o.mergeReadyPR(state.NewState(), "slot-0", sess, pr) {
+		t.Fatal("mergeReadyPR should return false on real conflict")
+	}
+	if sess.Status != state.StatusConflictFailed {
+		t.Errorf("session status = %q, want %q", sess.Status, state.StatusConflictFailed)
+	}
+	if len(labels) == 0 || labels[0] != "blocked" {
+		t.Errorf("issue must be labelled blocked, got %v", labels)
+	}
+}
+
+// #602 — End-to-end: a retry_exhausted convergence candidate whose PR is
+// CONFLICTING must NOT be re-selected on the next autoMergePRs cycle. After
+// one cycle it should be in conflict_failed (slot freed) and on the second
+// cycle mergePR must not be called again.
+func TestAutoMergePRs_RetryExhaustedConflictDoesNotLoopHaltQueue(t *testing.T) {
+	mergeAttempts := 0
+	labels := make([]string, 0)
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:                            "owner/repo",
+			MergeStrategy:                   "parallel",
+			AutoRebase:                      true,
+			AutoRetryReviewFeedback:         true,
+			MergeExhaustedNonCriticalReview: boolPtr(true),
+		},
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "P3 nit: rename foo", nil
+		},
+		ghPRHasCriticalReviewFn: func(prNumber int) (bool, error) {
+			return false, nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			mergeAttempts++
+			return fmt.Errorf("gh pr merge %d: merge commit cannot be cleanly created", prNumber)
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "CONFLICTING", "dirty", nil
+		},
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
+			return fmt.Errorf("CONFLICT (content): conflicted.go")
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labels = append(labels, label)
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber:        100,
+		IssueTitle:         "test issue",
+		Branch:             "feat/a",
+		Worktree:           "/tmp/wt",
+		Status:             state.StatusRetryExhausted,
+		PRNumber:           10,
+		LastNotifiedStatus: "review_retry_exhausted",
+	}
+
+	// First cycle: convergence picks the retry_exhausted PR, merge fails on
+	// real conflict, mergeReadyPR drives the session to conflict_failed.
+	o.autoMergePRs(s)
+	if mergeAttempts != 1 {
+		t.Fatalf("first cycle: mergeAttempts = %d, want 1", mergeAttempts)
+	}
+	sess := s.Sessions["slot-0"]
+	if sess.Status != state.StatusConflictFailed {
+		t.Fatalf("after first cycle status = %q, want %q", sess.Status, state.StatusConflictFailed)
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("FinishedAt must be set so the supervisor stops treating the slot as active")
+	}
+	if len(labels) == 0 || labels[0] != "blocked" {
+		t.Errorf("issue must be labelled blocked, got %v", labels)
+	}
+
+	// Second cycle: the session is no longer retry_exhausted, so convergence
+	// must not select it again. mergePR must NOT be called a second time.
+	o.autoMergePRs(s)
+	if mergeAttempts != 1 {
+		t.Fatalf("second cycle: mergeAttempts = %d, want 1 (queue must not loop)", mergeAttempts)
+	}
+}
+
+// #602 — rebaseConflicts loop safety net: if a retry_exhausted session has a
+// CONFLICTING open PR (e.g., entered this state via another path), the loop
+// must drive it to conflict_failed without respawning a worker.
+func TestRebaseConflicts_RetryExhaustedConflictingMarksUnresolvable(t *testing.T) {
+	labels := make([]string, 0)
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "CONFLICTING", "dirty", nil
+		},
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
+			return fmt.Errorf("CONFLICT (content): main.go")
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labels = append(labels, label)
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber:        100,
+		IssueTitle:         "test issue",
+		Branch:             "feat/a",
+		Worktree:           "/tmp/wt",
+		Status:             state.StatusRetryExhausted,
+		PRNumber:           10,
+		LastNotifiedStatus: "review_retry_exhausted",
+	}
+
+	o.rebaseConflicts(s)
+
+	sess := s.Sessions["slot-0"]
+	if sess.Status != state.StatusConflictFailed {
+		t.Errorf("session status = %q, want %q", sess.Status, state.StatusConflictFailed)
+	}
+	if !sess.RebaseAttempted {
+		t.Error("RebaseAttempted should be true after the safety-net rebase attempt")
+	}
+	if sess.FinishedAt == nil {
+		t.Error("FinishedAt must be set")
+	}
+	if len(labels) == 0 || labels[0] != "blocked" {
+		t.Errorf("issue must be labelled blocked, got %v", labels)
+	}
+}
+
+// #602 — When the merge fails with a non-"not up to date" error AND GitHub
+// reports MERGEABLE (so it's not actually a conflict), fall through to the
+// existing single-notification merge_failed path instead of mis-routing.
+func TestMergeReadyPR_NonConflictingMergeErrorFallsThroughToMergeFailed(t *testing.T) {
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return fmt.Errorf("gh pr merge 10: branch protection rule blocked the merge")
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "MERGEABLE", "blocked", nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	if o.mergeReadyPR(state.NewState(), "slot-0", sess, pr) {
+		t.Fatal("mergeReadyPR should return false")
+	}
+	if sess.Status != state.StatusPROpen {
+		t.Errorf("session status = %q, want %q (unchanged)", sess.Status, state.StatusPROpen)
+	}
+	if sess.LastNotifiedStatus != "merge_failed" {
+		t.Errorf("LastNotifiedStatus = %q, want %q", sess.LastNotifiedStatus, "merge_failed")
+	}
+}
+
 // --- silent timeout tests ---
 
 // newSilentTimeoutOrchestrator creates an Orchestrator wired for checkSessions


### PR DESCRIPTION
Refs #602

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real-merge-conflict loop (#602) where `retry_exhausted` convergence-merge candidates whose PRs were `CONFLICTING` could re-enter `mergeReadyPR` indefinitely, stalling the queue. The fix adds a two-layer defence: a primary `routeConflictingMergeFailure` hook inside `mergeReadyPR` that calls GitHub's merge-status API to confirm a true conflict and dispatches to either rebase-or-retry (for `StatusPROpen`) or straight to `markUnresolvableConflict` (for `StatusRetryExhausted`), and a safety-net `StatusRetryExhausted` branch inside `rebaseConflicts` that handles sessions which reach that state without going through the merge path.

- Seven new tests cover the main scenarios: `StatusPROpen` routing to rebase, `StatusRetryExhausted` routing to `conflict_failed` (with and without worktree), `AutoRebase=false`, the end-to-end non-looping `autoMergePRs` cycle, the `rebaseConflicts` safety net, and the non-CONFLICTING fallthrough to `merge_failed`.
- Both paths correctly guard `retry_exhausted` sessions from worker respawn on rebase failure; the `AutoRebase=false` case is consistently handled in both `routeConflictingMergeFailure` and the `rebaseConflicts` safety net.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is well-scoped, correctly handles all documented edge cases, and all new code paths are covered by tests.

The two-layer defence (primary hook + safety net) is logically sound and the test suite validates the critical rebase-fail, no-worktree, and non-looping scenarios. Minor gaps: the rebaseConflicts StatusRetryExhausted branch uses prMergeStatus while the adjacent StatusPROpen branch calls o.gh.PRMergeable directly, creating a subtle test-injection asymmetry; and there is no test for the rebase-success happy path of the rebaseConflicts safety net. Neither affects correctness in production, but they reduce confidence in long-term maintainability.

The new StatusRetryExhausted case in rebaseConflicts and the routeConflictingMergeFailure function in orchestrator.go are the places worth a second read.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds routeConflictingMergeFailure as the primary conflict-routing hook inside mergeReadyPR, and a StatusRetryExhausted branch inside rebaseConflicts as a safety net; logic is mostly correct but has a minor API inconsistency between the new StatusRetryExhausted branch and the existing StatusPROpen branch |
| internal/orchestrator/orchestrator_test.go | Seven new tests covering the main conflict-routing scenarios (#602); comprehensively covers rebase-fail paths and the no-worktree case, but is missing a test for the rebase-success path on a retry_exhausted session in rebaseConflicts |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:3217
**API inconsistency with the `StatusPROpen` branch above**

The new `StatusRetryExhausted` case calls `o.prMergeStatus(pr.Number)` (which routes through the injectable `ghPRMergeStatusFn` in tests and falls back to `o.gh.PRMergeStatus`), while the `StatusPROpen` case immediately above calls `o.gh.PRMergeable` directly (bypassing `ghPRMergeStatusFn`). Both end up querying the same REST endpoint via `mergeableFromRESTPull`, so the runtime result is identical, but the pattern is inconsistent and means the `StatusPROpen` path cannot be exercised with the standard test-injection mechanism. Consider wrapping the `StatusPROpen` merge-status call in a helper that mirrors `prMergeStatus` to keep the two branches symmetrical.

### Issue 2 of 2
internal/orchestrator/orchestrator_test.go:3563
**No test for the rebase-success path of a `retry_exhausted` session in `rebaseConflicts`**

`TestRebaseConflicts_RetryExhaustedConflictingMarksUnresolvable` only covers the rebase-failure path (the mock returns an error). There is no counterpart test where `rebaseWorktreeFn` succeeds, which would verify that `markRebaseQueued` is called correctly (status → `StatusQueued`, `RebaseAttempted = true`, `FinishedAt = nil`). This gap leaves the happy-path behaviour of the safety-net branch untested.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): drive real-conflict r..."](https://github.com/befeast/maestro/commit/50f574d1197d3a2d1c9edcbdad5d8176955ef9c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35104694)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->