### PR TITLE
Supervisor recommends retry-exhausted PR repair worker but does not execute spawn_worker

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -689,6 +689,17 @@ func superviseApprovalCmd(action string, args []string, defaultConfigPath string
 		if _, mErr := st.MarkApprovalExecutionSkipped(approval.ID, now, *actor, res.Summary); mErr != nil {
 			log.Fatalf("supervise approve: mark skipped: %v", mErr)
 		}
+	case state.ApprovalStatusAwaitingDispatch:
+		// #430: spawn_worker / spawn_review_repair / open_child_issue
+		// hand off to the orchestrator's dispatcher loop — the executor
+		// records the intent but the actual worker.Start (or issue
+		// creation) is owned by another loop. Mark the approval as
+		// awaiting_dispatch so the dashboard + dedup keep treating it as
+		// effective, and tell the operator explicitly what's pending
+		// instead of falling through to "execution failed".
+		if _, mErr := st.MarkApprovalAwaitingDispatch(approval.ID, now, *actor, res.Summary); mErr != nil {
+			log.Fatalf("supervise approve: mark awaiting_dispatch: %v", mErr)
+		}
 	default: // execution_failed
 		msg := res.Summary
 		if msg == "" && res.Err != nil {
@@ -708,6 +719,8 @@ func superviseApprovalCmd(action string, args []string, defaultConfigPath string
 		fmt.Printf("Approval %s executed: %s\n", approval.ID, res.Summary)
 	case state.ApprovalStatusExecutionSkipped:
 		fmt.Printf("Approval %s skipped: %s\n", approval.ID, res.Summary)
+	case state.ApprovalStatusAwaitingDispatch:
+		fmt.Printf("Approval %s awaiting dispatch: %s\n", approval.ID, res.Summary)
 	default:
 		if res.Err != nil {
 			log.Fatalf("Approval %s execution failed: %v", approval.ID, res.Err)
@@ -772,6 +785,13 @@ func printSupervisorDecision(decision state.SupervisorDecision, jsonOutput bool)
 	fmt.Printf("Confidence: %.2f\n", decision.Confidence)
 	if decision.ErrorClass != "" {
 		fmt.Printf("Error class: %s\n", decision.ErrorClass)
+	}
+	// #430: surface the requires_approval flag explicitly so an operator
+	// reading the CLI text output can tell at a glance that the supervisor
+	// only journaled a recommendation and the side effect is gated on an
+	// approval (or an autonomous-mode config flip).
+	if decision.RequiresApproval {
+		fmt.Println("Requires approval: yes (no side effect was executed; approve via `maestro supervise approve <id>` or unset supervisor.approval_required[_actions] to make it autonomous)")
 	}
 	if decision.ApprovalID != "" {
 		fmt.Printf("Approval: %s\n", decision.ApprovalID)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -274,6 +274,18 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 	if err != nil {
 		return state.SupervisorDecision{}, err
 	}
+	// #430: a mutating recommendation that the cautious gate will mint a
+	// pending approval for must report requires_approval=true in --once
+	// JSON / dashboard / journal. The Decide() shape only sets
+	// RequiresApproval when Risk==RiskApprovalGated; this misses the
+	// RiskMutating verbs the operator config gates (spawn_worker,
+	// merge_pr, close_issue, ...), so `--once --json` claimed
+	// requires_approval=false while the supervisor silently minted (or
+	// would mint) an approval. Recompute against the same predicate that
+	// drives the mint so the field never lies.
+	if decisionRequiresApproval(cfg, decision) {
+		decision.RequiresApproval = true
+	}
 	if !cfg.Supervisor.DryRun {
 		// Execute any approvals that were transitioned to status=approved
 		// outside this loop (CLI approve already executes inline; this

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -2574,3 +2574,96 @@ func TestDecideWithLLM_AddReadyLabelAliasAccepted(t *testing.T) {
 		t.Fatalf("action = %q, want canonical %q", decision.RecommendedAction, ActionLabelIssueReady)
 	}
 }
+
+// #430: a spawn_worker recommendation that the cautious gate will mint a
+// pending approval for must report decision.RequiresApproval=true in
+// `maestro supervise --once --json`. Before the fix the field was wired
+// to `risk == RiskApprovalGated` only, so a RiskMutating decision (the
+// common case for spawn_worker) reported requires_approval=false while
+// the supervisor silently minted a pending approval. The operator then
+// saw "Approval ... approved. No risky action was executed." with no
+// indication the verb needed approval at all. RunOnce must reconcile
+// the JSON flag with the actual mint predicate (decisionRequiresApproval).
+func TestRunOnce_SpawnWorker_RecommendedActionRequiresApprovalReflectsGate(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.ApprovalRequiredActions = []string{
+		ActionSpawnWorker,
+		ActionLabelIssueReady,
+	}
+	reader := &fakeReader{issues: []github.Issue{testIssue(119, "fix CI flake", "maestro-ready")}}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Status != DecisionStatusRecommended {
+		t.Fatalf("status = %q, want %q (action must not be reported as executed)", decision.Status, DecisionStatusRecommended)
+	}
+	if !decision.RequiresApproval {
+		t.Fatal("RequiresApproval = false, want true — JSON would otherwise claim no approval is needed while supervisor silently mints a pending approval (#430)")
+	}
+	if decision.ApprovalID == "" {
+		t.Fatal("ApprovalID is empty, want a minted approval id so the operator can address it")
+	}
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(st.Approvals) != 1 {
+		t.Fatalf("approvals = %d, want 1 pending approval", len(st.Approvals))
+	}
+	a := st.Approvals[0]
+	if a.Action != ActionSpawnWorker {
+		t.Fatalf("approval action = %q, want %q", a.Action, ActionSpawnWorker)
+	}
+	if a.Status != state.ApprovalStatusPending {
+		t.Fatalf("approval status = %q, want %q", a.Status, state.ApprovalStatusPending)
+	}
+	if a.Target == nil || a.Target.Issue != 119 {
+		t.Fatalf("approval target = %#v, want issue 119", a.Target)
+	}
+}
+
+// #430: when ApprovalRequiredActions explicitly excludes spawn_worker (the
+// operator opted into autonomous execution of spawn_worker), the supervisor
+// must NOT report requires_approval=true. The flag tracks reality: an
+// autonomous spawn_worker (still recommended-only inside the supervisor —
+// the orchestrator dispatcher owns the actual worker.Start) must surface
+// as a non-approval-gated action so the operator does not chase a phantom
+// approval.
+func TestRunOnce_SpawnWorker_AutonomousModeReportsNoApprovalRequired(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	// Empty-but-non-nil list: the operator has explicitly listed which
+	// actions require approval, and spawn_worker is intentionally absent.
+	cfg.Supervisor.ApprovalRequiredActions = []string{ActionMergePR}
+	reader := &fakeReader{issues: []github.Issue{testIssue(119, "fix CI flake", "maestro-ready")}}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.RequiresApproval {
+		t.Fatal("RequiresApproval = true, want false when spawn_worker is not in ApprovalRequiredActions")
+	}
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, a := range st.Approvals {
+		if a.Action == ActionSpawnWorker {
+			t.Fatalf("approval minted for spawn_worker = %#v, want none when not gated", a)
+		}
+	}
+}


### PR DESCRIPTION
Refs #430

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `requires_approval` field mis-reporting in `RunOnce`: previously only `RiskApprovalGated` decisions set the flag, leaving `RiskMutating` actions like `spawn_worker` — which the cautious gate does mint approvals for — reporting `requires_approval: false` in `--once --json` output. It also wires up the `awaiting_dispatch` executor result through the CLI approve path so the approval transitions correctly when the dispatcher loop owns the actual side effect.

- **`supervisor.go`**: Adds a post-`Decide()` correction that calls `decisionRequiresApproval` and forces `RequiresApproval = true` when the operator's config would gate the action; the predicate was already used to drive the mint decision and this re-use eliminates the mismatch.
- **`main.go`**: Adds `ApprovalStatusAwaitingDispatch` case to `superviseApprovalCmd` and surfaces `RequiresApproval` as a human-readable line in `printSupervisorDecision`, closing the gap for operators reading text (non-JSON) output.
- **`supervisor_test.go`**: Two new `RunOnce`-level tests cover the approval-gated path (expects `RequiresApproval = true` + a minted approval) and the autonomous path (expects `RequiresApproval = false` + no approval minted).

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are narrowly scoped to fixing a stale field in the supervisor's JSON/text output and adding the missing CLI case for the awaiting-dispatch executor result.

The core logic change is one-directional: the new correction block can only set `RequiresApproval` to `true`, never clear it. If `Decide()` has already set it to `true` for a `RiskApprovalGated` action that the operator has explicitly excluded from `ApprovalRequiredActions`, the field stays `true` while no approval is minted — producing a misleading `requires_approval: true` with an empty `approval_id`. The same correction also fires in dry-run mode, where the accompanying text message tells operators to approve an ID that doesn't exist yet.

The `decisionRequiresApproval` block in `supervisor.go` (lines 286–288) and the `printSupervisorDecision` message in `main.go` (line 794) are worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds a `RequiresApproval` correction pass in `RunOnce` before the dry-run block, using `decisionRequiresApproval` to reconcile the field with the actual mint predicate; minor concern that the patch is one-directional (can set true but not clear false) |
| cmd/maestro/main.go | Adds `ApprovalStatusAwaitingDispatch` handling in `superviseApprovalCmd` and surfaces `RequiresApproval` in the human-readable text output of `printSupervisorDecision`; changes are self-contained and correct |
| internal/supervisor/supervisor_test.go | Two new integration-style tests cover the approval-gated and autonomous-mode paths for `spawn_worker`; tests assert all observable state (decision fields + persisted approvals) |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/supervisor/supervisor.go:286-288
The patch is one-directional: it can flip `RequiresApproval` from `false` to `true`, but it cannot correct `true → false`. If `Decide()` sets `RequiresApproval = true` (because `Risk == RiskApprovalGated`) for an action the operator has explicitly excluded from `ApprovalRequiredActions`, `decisionRequiresApproval` will return `false` but the field stays `true`. The result is `requires_approval: true` in the JSON with an empty `approval_id`, which would mislead an operator chasing a phantom approval. Assigning directly rather than conditionally guards against this mismatch.

```suggestion
	decision.RequiresApproval = decisionRequiresApproval(cfg, decision)
```

### Issue 2 of 2
cmd/maestro/main.go:793-794
**Misleading message in dry-run mode**

When `cfg.Supervisor.DryRun` is `true`, `RunOnce` still sets `decision.RequiresApproval = true` (the correction block is placed before the dry-run guard), but no approval is minted, so `decision.ApprovalID` is empty. `printSupervisorDecision` then prints "approve via `maestro supervise approve <id>`" with no accompanying approval ID line. An operator running `--once --dry-run` on a `spawn_worker` recommendation would be told to approve an ID that doesn't exist yet. A conditional check (`RequiresApproval && ApprovalID != ""`) or a separate dry-run note would avoid the false instruction.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(supervisor,cli): require approval fl..."](https://github.com/befeast/maestro/commit/c307519782a6fcd1b946a144f47afcf8b0ca0f5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35108392)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->