### PR TITLE
Dashboard write-path (1/3, backend): implement action endpoints (safe direct, approval-required via cautious gate) instead of 501

### DIFF
--- a/internal/server/actions_test.go
+++ b/internal/server/actions_test.go
@@ -253,6 +253,35 @@ func TestSafeAction_UnknownActionID_Rejected(t *testing.T) {
 	}
 }
 
+// TestHandleAction_Never501 pins the #475 contract: the action endpoints
+// are wired through dispatchSafeAction + dispatchApprovalAction, so no
+// payload (known verb, unknown verb, empty verb, malformed) may surface
+// the legacy "approval-backed action endpoints are not implemented yet"
+// 501 stub. Unknown verbs return 4xx, server-side bugs return 5xx, but
+// 501 is gone.
+func TestHandleAction_Never501(t *testing.T) {
+	gh := &fakeActionGH{}
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetActionDeps(gh, nil)
+
+	for _, payload := range []string{
+		``,
+		`{}`,
+		`{"action_id":""}`,
+		`{"action_id":"do_a_barrel_roll"}`,
+		`{"action_id":"do_a_barrel_roll","issue_number":1}`,
+		`{"action_id":"add_ready_label","issue_number":42}`,
+	} {
+		w := postAction(t, srv, payload)
+		if w.Code == http.StatusNotImplemented {
+			t.Errorf("payload %q: status = 501; the legacy 'not implemented' stub must be gone (#475)", payload)
+		}
+		if strings.Contains(w.Body.String(), "not implemented yet") {
+			t.Errorf("payload %q: body still surfaces legacy stub text: %s", payload, w.Body.String())
+		}
+	}
+}
+
 func TestSafeAction_ReadOnlyStillWins(t *testing.T) {
 	// Even with safe-action wiring in place, --read-only must keep returning
 	// 403 — no behavior change in the default deployment.

--- a/internal/server/audit_failclosed_test.go
+++ b/internal/server/audit_failclosed_test.go
@@ -114,4 +114,3 @@ func TestSafeAction_AuditNilStillExecutes(t *testing.T) {
 		t.Fatalf("gh not called with audit=nil: %v", gh.addLabelCalls)
 	}
 }
-

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -779,7 +779,16 @@ func (s *FleetServer) handleFleetAction(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	writeError(w, http.StatusNotImplemented, "approval-backed action endpoints are not implemented yet")
+	// #475 (1/3): the safe and approval-required action endpoints are now
+	// implemented; this fallback is reachable only when a verb is neither
+	// safe, approval-required, nor a known UI-translation alias — i.e. an
+	// unknown action_id. Return 400, not the legacy 501 stub.
+	id := strings.TrimSpace(req.ActionID)
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "action_id is required")
+		return
+	}
+	writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown action_id %q", id))
 }
 
 type fleetAuditLogRequest struct {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -3647,6 +3647,41 @@ func TestFleetActionProjectReadOnlyRejectsMutation(t *testing.T) {
 	}
 }
 
+// TestFleetAction_Never501 pins the #475 contract for the fleet handler:
+// the safe + approval dispatchers cover every verb that should ever land
+// here, so no payload may surface the legacy "approval-backed action
+// endpoints are not implemented yet" 501 stub.
+func TestFleetAction_Never501(t *testing.T) {
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("one", "/tmp/one.yaml", "", &config.Config{
+			Repo:   "owner/one",
+			Server: config.ServerConfig{ReadOnly: false},
+			Supervisor: config.SupervisorConfig{
+				ReadyLabel:   "maestro-ready",
+				BlockedLabel: "blocked",
+			},
+		}),
+	}, "127.0.0.1", 8786, false)
+
+	for _, payload := range []string{
+		``,
+		`{}`,
+		`{"project":"one","action_id":""}`,
+		`{"project":"one","action_id":"do_a_barrel_roll"}`,
+		`{"project":"one","action_id":"do_a_barrel_roll","issue_number":1}`,
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/actions", bytes.NewBufferString(payload))
+		w := httptest.NewRecorder()
+		srv.handleFleetAction(w, req)
+		if w.Code == http.StatusNotImplemented {
+			t.Errorf("payload %q: status = 501; the legacy 'not implemented' stub must be gone (#475)", payload)
+		}
+		if contains(w.Body.String(), "not implemented yet") {
+			t.Errorf("payload %q: body still surfaces legacy stub text: %s", payload, w.Body.String())
+		}
+	}
+}
+
 func findFleetWorker(t *testing.T, workers []fleetWorkerState, slot string) fleetWorkerState {
 	t.Helper()
 	for _, worker := range workers {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1222,7 +1222,16 @@ func handleControlAction(w http.ResponseWriter, r *http.Request, readOnly bool, 
 		return
 	}
 
-	writeError(w, http.StatusNotImplemented, "approval-backed action endpoints are not implemented yet")
+	// #475 (1/3): the safe and approval-required action endpoints are now
+	// implemented; this fallback is reachable only when a verb is neither
+	// safe, approval-required, nor a known UI-translation alias — i.e. an
+	// unknown action_id. Return 400, not the legacy 501 stub.
+	id := strings.TrimSpace(req.ActionID)
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "action_id is required")
+		return
+	}
+	writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown action_id %q", id))
 }
 
 var dashboardHTML = web.MustReadTemplate("dashboard.html")


### PR DESCRIPTION
Refs #475

## Summary

Issue #475's acceptance criteria were already satisfied on `main` by
the three earlier landings — #478 (safe verbs), #479 (cautious-gate
enqueue), #480 (approver execution) — but a dead `501 "approval-backed
action endpoints are not implemented yet"` fallback was left at the
bottom of both `handleControlAction` (single-project) and
`handleFleetAction` (fleet). The path became unreachable when
`isUIOnlyAffordance` was emptied in #567, but the misleading copy
matched the literal wording in the issue title.

## Changes

- `internal/server/server.go` / `internal/server/fleet.go`: replace
  the trailing 501 stub with the correct 400 — empty `action_id` is
  distinguished from an unknown one.
- `internal/server/actions_test.go`: add `TestHandleAction_Never501`
  exercising empty / malformed / unknown / known payloads.
- `internal/server/fleet_test.go`: add `TestFleetAction_Never501`
  mirroring the contract on the fleet handler.

## Testing

- `go build ./cmd/maestro/`
- `go test ./...`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the dead 501 \"not implemented\" stubs at the bottom of `handleControlAction` and `handleFleetAction`, replacing them with 400 responses that distinguish an empty `action_id` from an unrecognised one, and pins the contract with two new `Never501` test suites.

- `server.go` / `fleet.go`: the trailing 501 fallback is replaced with a two-branch 400 block (empty vs unknown `action_id`); however, `dispatchSafeAction` in `actions.go` already handles both empty and unknown action IDs with `handled: true` before this block is reached, so the new fallback is similarly unreachable — the in-code comment's description of when it fires is inaccurate.
- `actions_test.go` / `fleet_test.go`: new `Never501` tests cover empty, malformed, unknown, and known payloads; they correctly verify the behavioral contract (no 501 emitted) even though the assertions are satisfied by the upstream dispatchers rather than the new fallback code.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the 501 is correctly eliminated and all tests pass; the only concern is that the replacement fallback block is also unreachable, and its explanatory comment misstates when it fires.

The behavioral change is correct and well-tested: no payload can produce a 501 from either handler. The new fallback block in both server.go and fleet.go is dead code because dispatchSafeAction already intercepts empty and unknown action_id values with handled: true. The comment describing the fallback's reachability condition points to a case that the dispatcher resolves first, which could mislead a future contributor modifying this flow.

The fallback blocks in internal/server/server.go (lines 1225–1234) and internal/server/fleet.go (lines 782–791) warrant a second look; the accompanying comments are inaccurate about when these branches fire.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/server.go | Replaces the 501 stub with a 400 fallback that is also unreachable in practice; behavior is correct because dispatchSafeAction already handles both empty and unknown action IDs before the new block. |
| internal/server/fleet.go | Same 501→400 stub replacement as server.go; new fallback block is similarly unreachable for identical reasons. |
| internal/server/actions_test.go | Adds TestHandleAction_Never501 covering empty, malformed, unknown, and known payloads; tests the right behavioral contract (no 501 returned) even though the new fallback code itself is never exercised. |
| internal/server/fleet_test.go | Mirrors the Never501 contract for the fleet handler; notably omits a known-safe action (e.g. add_ready_label with issue_number) that the server-side test includes, but all tested payloads return correct non-501 codes. |
| internal/server/audit_failclosed_test.go | Trailing newline removed; no logic changes. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/server.go:1225-1234
**Fallback block is unreachable dead code**

`dispatchSafeAction` (in `actions.go` lines 68–84) already handles every case the comment attributes to this fallback. It returns `handled: true` with a 400 for an empty `action_id` (lines 69–71) and for any unknown verb that is neither safe, approval-required, nor a UI-translation alias (lines 83–85). The only path that falls through to here is when `isApprovalRequiredAction(id)` is true — but `dispatchApprovalAction` handles all approval-required verbs, so `res.handled` will also be true there.

The comment's claim that "this fallback is reachable only when a verb is … an unknown action_id" describes a case that `dispatchSafeAction` resolves before control ever reaches this block. Like the original 501 stub it replaces, this code remains dead. The tests confirm correct behavior, but they're exercising the dispatchers rather than this new fallback.

### Issue 2 of 2
internal/server/fleet.go:782-791
**Same unreachable fallback as in `server.go`**

The same analysis applies here: `dispatchSafeAction` intercepts both the empty `action_id` case and all unknown verbs with `handled: true` before this block is reached. The fleet handler's fallback is similarly dead code, and the comment describing its reachability condition is inaccurate for the same reasons.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(server): retire the dead 501 action..."](https://github.com/befeast/maestro/commit/0a3c7c66c7c2dd0abca43b57cc294282a8444ea0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35111303)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->