### PR TITLE
P2: pin bun toolchain + document bundle-rebuild SOP (premortem #6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
       - name: Install MC deps
         working-directory: internal/server/web/mc
         run: bun install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -453,6 +453,35 @@ systemctl --user status maestro@panoptikon
 journalctl --user -u maestro@panoptikon -f
 ```
 
+## Mission Control bundle
+
+The Mission Control SPA lives in `internal/server/web/mc/` and ships as a pre-built bundle committed under `internal/server/web/static/mc/`. CI rebuilds the bundle on every PR and fails the `frontend-build` job if the committed output drifts from a fresh build.
+
+### Toolchain
+
+The frontend toolchain is pinned via the `packageManager` field in `internal/server/web/mc/package.json` and the matching `bun-version` in `.github/workflows/ci.yml`. Use the same bun version locally — Corepack will respect `packageManager` automatically, or install it explicitly:
+
+```bash
+bun --version   # must match the pinned version in package.json
+```
+
+When bumping bun, update both `packageManager` in `package.json` and `bun-version` in `.github/workflows/ci.yml` in the same PR so they cannot drift.
+
+### Bundle-rebuild SOP (staleness gate failures)
+
+When CI fails with `Committed MC bundle is stale`, the fix is always to rebuild and commit — never `gh pr merge --admin`. The canonical recipe:
+
+```bash
+cd internal/server/web/mc
+bun install --frozen-lockfile
+bun run build
+cd -
+git add internal/server/web/static/mc/
+git commit -m "chore: rebuild MC bundle"
+```
+
+If the diff still appears after a clean rebuild, your local bun/vite versions disagree with CI. Verify `bun --version` matches the pin in `package.json`. Bypassing the gate with `--admin` is the failure mode this guard exists to prevent — the bundle that ships from `static/mc/` is what users load, so a stale commit ships stale UI.
+
 ## Troubleshooting
 
 ### `gh auth status` fails or maestro can't access the repo

--- a/internal/server/web/mc/package.json
+++ b/internal/server/web/mc/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
+  "packageManager": "bun@1.3.14",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
Refs #493

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins the Bun toolchain to `1.3.14` in both CI (`bun-version`) and `package.json` (`packageManager`), replacing the previous `latest` resolution, and adds a README section documenting the bundle-rebuild SOP and the staleness gate that already exists in CI.

- **CI / `package.json`**: Version is pinned consistently in both places; the existing staleness gate (`git diff --quiet`) continues to enforce that committed static assets match a fresh build.
- **README**: The new SOP commands are accurate and match what CI runs, but the toolchain section incorrectly states that Corepack enforces the `packageManager` field for Bun — Corepack does not support Bun, so the local enforcement claim is misleading.

<h3>Confidence Score: 4/5</h3>

The CI and package.json changes are correct and safe to merge; the README has one inaccurate sentence about Corepack that should be corrected before or shortly after merging.

The version-pinning itself (CI + package.json) is correct and solves the stated problem. The only defect is in the new README documentation: the claim that Corepack enforces the `packageManager` field for Bun is wrong — Corepack has never shipped Bun support — so developers who follow that guidance for local enforcement will get no protection. This doesn't break CI or the runtime artifact, but it does undermine the local-toolchain-consistency goal the SOP is meant to achieve.

README.md — specifically the paragraph about Corepack respecting `packageManager` automatically.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Pins bun from `latest` to `1.3.14` in the `frontend-build` job; straightforward and correct. |
| README.md | Adds Mission Control bundle SOP and toolchain docs; contains an incorrect claim that Corepack enforces the Bun `packageManager` field — Corepack does not support Bun. |
| internal/server/web/mc/package.json | Adds `"packageManager": "bun@1.3.14"` to match the CI pin; consistent and correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
README.md:467
**Corepack does not support Bun**

The sentence "Corepack will respect `packageManager` automatically" is inaccurate — as of mid-2025 Corepack does not support Bun as a managed package manager (nodejs/corepack#295 is still open). `corepack enable` installs jumpers only for npm, yarn, and pnpm; it will not intercept `bun` invocations or enforce the version in this field. A developer who trusts this statement and relies on Corepack for local enforcement will silently use whatever Bun version is installed on their machine, which is exactly the drift this PR aims to prevent. Consider replacing this paragraph with a direct `bun upgrade --to 1.3.14` / `curl` install instruction or a reference to `.mise.toml`/`.tool-versions` for local version pinning.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): pin bun toolchain and documen..."](https://github.com/befeast/maestro/commit/b6d73e5676b96ce8fa650bd68867cf6d1126f15b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35118200)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->