### PR TITLE
MC Workers: 'live · 44 in flight' shows 24-h activity, not running workers (only 2 actually running)

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -1372,6 +1372,73 @@ func TestFleetVerdictCoversHeaderStates(t *testing.T) {
 	}
 }
 
+// TestFleetSummaryRunningDistinguishesRunningFromRecent pins issue #496:
+// the "in flight" hero on the Workers screen must reflect only sessions
+// whose status is actually `running` — not every session that fell inside
+// the 24-h `Live` activity window. With one running session alongside five
+// terminal `done` sessions finished within the last hour, summary.Running
+// must read 1, the fleet verdict headline must say "1 worker in flight.",
+// and the historical 24-h reach (resp.Summary.Sessions) must still
+// account for the recent activity that the SPA renders under "Recent 24h".
+func TestFleetSummaryRunningDistinguishesRunningFromRecent(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "in-flight")
+
+	sessions := map[string]*state.Session{
+		"running-1": {
+			IssueNumber: 1,
+			IssueTitle:  "Actually running worker",
+			Status:      state.StatusRunning,
+			StartedAt:   now.Add(-3 * time.Minute),
+			PID:         os.Getpid(),
+		},
+	}
+	for i := 0; i < 5; i++ {
+		finished := now.Add(-time.Duration(i+1) * time.Hour)
+		started := finished.Add(-30 * time.Minute)
+		slot := "done-" + strconv.Itoa(i+1)
+		sessions[slot] = &state.Session{
+			IssueNumber: 100 + i,
+			IssueTitle:  "Recently completed worker",
+			Status:      state.StatusDone,
+			StartedAt:   started,
+			FinishedAt:  &finished,
+			PRNumber:    200 + i,
+		}
+	}
+	saveFleetTestSnapshot(t, stateDir, sessions, []state.SupervisorDecision{{
+		ID:                "sup-in-flight",
+		CreatedAt:         now,
+		Project:           "owner/in-flight",
+		Summary:           "Worker is already running.",
+		RecommendedAction: "wait_for_worker",
+		Risk:              "safe",
+	}})
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("InFlight", "/tmp/in-flight.yaml", "", &config.Config{
+			Repo:        "owner/in-flight",
+			StateDir:    stateDir,
+			MaxParallel: 2,
+		}),
+	}, "127.0.0.1", 8786, true)
+
+	resp := srv.snapshot()
+
+	if resp.Summary.Running != 1 {
+		t.Fatalf("summary.running = %d, want 1 (5 done sessions in last 24 h must not count as in-flight)", resp.Summary.Running)
+	}
+	if resp.Summary.Sessions != 6 {
+		t.Fatalf("summary.sessions = %d, want 6 (1 running + 5 done)", resp.Summary.Sessions)
+	}
+
+	headline := fleetVerdictHeadline(resp.Summary, resp.Projects[0].Supervisor.Latest, "busy", now)
+	if headline != "1 worker in flight." {
+		t.Fatalf("verdict headline = %q, want %q (must use summary.Running, not 24-h reach)", headline, "1 worker in flight.")
+	}
+}
+
 func TestFleetVerdictDoesNotTreatProjectFreshnessStaleAsHeartbeatStale(t *testing.T) {
 	now := time.Now().UTC()
 	latest := &supervisorDecisionInfo{CreatedAt: now}


### PR DESCRIPTION
Refs #496

## Summary
The SPA-side disambiguation for issue #496 already shipped in PR #498 (hero pill now uses `runningCount`, Live tab renamed to "Recent"). What was still missing from the acceptance checklist was a regression test that pins the contract on the server side, so the fix cannot silently regress when fleet aggregation changes.

## Changes
- `internal/server/fleet_test.go`: new `TestFleetSummaryRunningDistinguishesRunningFromRecent` seeds 1 `StatusRunning` + 5 `StatusDone` sessions finished within the last 24h and asserts
  - `summary.running == 1` (not 6 — the 24-h reach must not count as in-flight)
  - `summary.sessions == 6` (the 24-h activity window is still observable for the SPA's "Recent 24h" segment)
  - `fleetVerdictHeadline(..., "busy", ...) == "1 worker in flight."` — this is the string that drives the Workers screen hero copy.

## Testing
- `go test ./internal/server/ -run TestFleetSummaryRunningDistinguishesRunningFromRecent -v`
- `go test ./...`
- `go build ./cmd/maestro/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single regression test, `TestFleetSummaryRunningDistinguishesRunningFromRecent`, to `internal/server/fleet_test.go` that pins the server-side contract for issue #496: `summary.Running` must count only `StatusRunning` sessions, not every session that falls within the 24-h activity window.

- Seeds 1 `StatusRunning` + 5 `StatusDone` sessions and asserts `summary.Running == 1`, `summary.Sessions == 6`, and the fleet verdict headline equals `"1 worker in flight."`.
- The headline assertion calls `fleetVerdictHeadline` directly with a hardcoded `"busy"` tone rather than reading `resp.Verdict.Headline`, which is already populated by `snapshot()` and would also exercise the `fleetVerdictTone` selection path.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is test-only and adds no production logic.

The test correctly seeds state, calls `snapshot()`, and verifies the two most important counters (`Running` and `Sessions`). The headline check re-derives the verdict with a hardcoded tone instead of reading the value that `snapshot()` already computed, leaving the tone-selection branch untested. Fixing that one call would make the test a stronger end-to-end regression pin.

internal/server/fleet_test.go — headline assertion uses a hardcoded tone bypass.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet_test.go | Adds regression test for issue #496 pinning that summary.Running counts only StatusRunning sessions, not recent-24h StatusDone sessions; minor doc-comment inaccuracy and a gap in tone-selection coverage. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/server/fleet_test.go:1436-1439
The test calls `fleetVerdictHeadline` with a manually hardcoded `"busy"` tone instead of reading `resp.Verdict.Headline`, which is already populated by `snapshot()` via `buildFleetVerdict`. This means `fleetVerdictTone` — the function that determines whether the tone is `"busy"`, `"attention"`, or `"healthy"` — is never exercised. A regression that causes `fleetVerdictTone` to return the wrong value for a mix of running + done sessions would leave `resp.Verdict.Headline` wrong in production but this assertion would still pass.

```suggestion
	if resp.Verdict.Headline != "1 worker in flight." {
		t.Fatalf("verdict headline = %q, want %q (must use summary.Running, not 24-h reach)", resp.Verdict.Headline, "1 worker in flight.")
	}
```

### Issue 2 of 2
internal/server/fleet_test.go:1375-1379
The doc comment says "five terminal `done` sessions finished within the last hour" but the loop sets finish times at `-(i+1)` hours for `i` in 0–4, spanning 1 h to 5 h before `now`. The last session finished 5 hours ago, not within the last hour.

```suggestion
// TestFleetSummaryRunningDistinguishesRunningFromRecent pins issue #496:
// the "in flight" hero on the Workers screen must reflect only sessions
// whose status is actually `running` — not every session that fell inside
// the 24-h `Live` activity window. With one running session alongside five
// terminal `done` sessions finished within the last 5 hours, summary.Running
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(server): pin in-flight hero shows s..."](https://github.com/befeast/maestro/commit/d096b73f2212fb94466fc1fd147aa48b6c4709d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35122275)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->