### PR TITLE
P2: state.Sessions has no retention — 177 sessions in dogfood state, grows without bound

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/befeast/maestro/internal/outcome"
 	"gopkg.in/yaml.v3"
@@ -594,6 +595,73 @@ func (c StaleSessionReconcilerConfig) MergedPRDismissesEnabled() bool {
 	return *c.MergedPRDismisses
 }
 
+// SessionRetentionConfig bounds the growth of state.Sessions by compacting
+// terminal sessions once both the count and age floors are exceeded (#497).
+// Defaults keep the 20 newest terminal sessions per project and any terminal
+// session younger than 7 days (whichever is larger), and append pruned
+// sessions to <state_dir>/sessions-archive.jsonl for forensics.
+type SessionRetentionConfig struct {
+	Enabled     *bool  `yaml:"enabled,omitempty"`      // default: true
+	KeepLast    int    `yaml:"keep_last,omitempty"`    // default: 20 (0 = default; negative = no count floor)
+	MinAgeDays  int    `yaml:"min_age_days,omitempty"` // default: 7  (0 = default; negative = no age floor)
+	Archive     *bool  `yaml:"archive,omitempty"`      // default: true
+	ArchiveFile string `yaml:"archive_file,omitempty"` // default: <state_dir>/sessions-archive.jsonl
+}
+
+// IsEnabled reports whether session retention runs. Default true.
+func (c SessionRetentionConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// EffectiveKeepLast returns the count floor. 0 means "use default (20)";
+// a negative value disables the count floor entirely.
+func (c SessionRetentionConfig) EffectiveKeepLast() int {
+	if c.KeepLast < 0 {
+		return 0
+	}
+	if c.KeepLast == 0 {
+		return 20
+	}
+	return c.KeepLast
+}
+
+// EffectiveMinAge returns the age floor. 0 means "use default (7d)";
+// a negative value disables the age floor entirely.
+func (c SessionRetentionConfig) EffectiveMinAge() time.Duration {
+	if c.MinAgeDays < 0 {
+		return 0
+	}
+	if c.MinAgeDays == 0 {
+		return 7 * 24 * time.Hour
+	}
+	return time.Duration(c.MinAgeDays) * 24 * time.Hour
+}
+
+// ArchiveEnabled reports whether pruned sessions are appended to a JSONL
+// archive before deletion. Default true.
+func (c SessionRetentionConfig) ArchiveEnabled() bool {
+	if c.Archive == nil {
+		return true
+	}
+	return *c.Archive
+}
+
+// EffectiveArchiveFile returns the absolute path to the archive file, or
+// empty when archiving is disabled. stateDir is the per-project state
+// directory and is used as the default location.
+func (c SessionRetentionConfig) EffectiveArchiveFile(stateDir string) string {
+	if !c.ArchiveEnabled() {
+		return ""
+	}
+	if strings.TrimSpace(c.ArchiveFile) != "" {
+		return expandHome(c.ArchiveFile)
+	}
+	return filepath.Join(stateDir, "sessions-archive.jsonl")
+}
+
 type Config struct {
 	Server                          ServerConfig                 `yaml:"server"`
 	Supervisor                      SupervisorConfig             `yaml:"supervisor"`
@@ -643,6 +711,7 @@ type Config struct {
 	BlockerPatterns                 []string                     `yaml:"blocker_patterns"`         // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
 	PollIntervalSeconds             int                          `yaml:"poll_interval_seconds"`    // override poll interval from config (0 = use CLI flag)
 	StaleSessionReconciler          StaleSessionReconcilerConfig `yaml:"stale_session_reconciler"` // filter stale supervisor sessions from operator attention
+	SessionRetention                SessionRetentionConfig       `yaml:"session_retention"`        // #497: bound state.Sessions growth via terminal-session compaction
 	SourcePath                      string                       `yaml:"-"`                        // path the config was loaded from (not serialized)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1937,3 +1937,78 @@ supervisor:
 		t.Fatalf("OrderedQueue.Issues = %v, want [262]", got)
 	}
 }
+
+func TestParse_SessionRetentionDefaults(t *testing.T) {
+	yaml := `
+repo: owner/repo
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.SessionRetention.IsEnabled() {
+		t.Fatalf("default session_retention must be enabled")
+	}
+	if got := cfg.SessionRetention.EffectiveKeepLast(); got != 20 {
+		t.Fatalf("default KeepLast = %d, want 20", got)
+	}
+	if got := cfg.SessionRetention.EffectiveMinAge(); got != 7*24*60*60*1e9 {
+		t.Fatalf("default MinAge = %v, want 168h", got)
+	}
+	if !cfg.SessionRetention.ArchiveEnabled() {
+		t.Fatalf("default archive must be enabled")
+	}
+	if got := cfg.SessionRetention.EffectiveArchiveFile("/tmp/state"); got != "/tmp/state/sessions-archive.jsonl" {
+		t.Fatalf("default archive file = %q, want /tmp/state/sessions-archive.jsonl", got)
+	}
+}
+
+func TestParse_SessionRetentionExplicitOverride(t *testing.T) {
+	yaml := `
+repo: owner/repo
+session_retention:
+  enabled: false
+  keep_last: 50
+  min_age_days: 14
+  archive: false
+  archive_file: /custom/sessions.jsonl
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.SessionRetention.IsEnabled() {
+		t.Fatalf("enabled=false must disable retention")
+	}
+	if got := cfg.SessionRetention.EffectiveKeepLast(); got != 50 {
+		t.Fatalf("KeepLast = %d, want 50", got)
+	}
+	if got := cfg.SessionRetention.EffectiveMinAge(); got != 14*24*60*60*1e9 {
+		t.Fatalf("MinAge = %v, want 336h", got)
+	}
+	if cfg.SessionRetention.ArchiveEnabled() {
+		t.Fatalf("archive=false must disable archiving")
+	}
+	if got := cfg.SessionRetention.EffectiveArchiveFile("/tmp/state"); got != "" {
+		t.Fatalf("archive_file with archive=false should resolve empty, got %q", got)
+	}
+}
+
+func TestParse_SessionRetentionNegativeDisablesFloor(t *testing.T) {
+	yaml := `
+repo: owner/repo
+session_retention:
+  keep_last: -1
+  min_age_days: -1
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.SessionRetention.EffectiveKeepLast(); got != 0 {
+		t.Fatalf("negative KeepLast must clamp to 0 (disables floor), got %d", got)
+	}
+	if got := cfg.SessionRetention.EffectiveMinAge(); got != 0 {
+		t.Fatalf("negative MinAgeDays must clamp to 0 (disables floor), got %v", got)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1177,6 +1177,12 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 		// daemon clears it — a `run --once` reconcile tick must not lift a
 		// drain that an operator is mid-way through.
 		o.clearSpawnDrainOnStartup()
+
+		// #497: bound state.Sessions growth — sweep terminal sessions
+		// older than the retention window at daemon startup, before the
+		// first poll cycle. Idempotent: a no-op when nothing is past the
+		// floors. Failures are logged inside the helper.
+		o.compactTerminalSessionsOnStartup()
 	}
 	if err := o.RunOnce(); err != nil {
 		log.Printf("[orch] run error: %v", err)
@@ -1230,6 +1236,43 @@ func (o *Orchestrator) clearSpawnDrainOnStartup() {
 		return
 	}
 	log.Printf("[orch] drain flag cleared on startup — resuming normal spawns")
+}
+
+// compactTerminalSessionsOnStartup applies cfg.SessionRetention to the
+// persisted state once at daemon startup so the long-running supervise loop
+// does not have to wait a full cycle before bounding state.Sessions (#497).
+// Idempotent: a no-op when retention is disabled or nothing falls outside
+// both retention floors. Failures are logged; the daemon still starts.
+func (o *Orchestrator) compactTerminalSessionsOnStartup() {
+	if o == nil || o.cfg == nil {
+		return
+	}
+	if !o.cfg.SessionRetention.IsEnabled() {
+		return
+	}
+	s, err := state.Load(o.cfg.StateDir)
+	if err != nil {
+		log.Printf("[orch] compact sessions: load state: %v", err)
+		return
+	}
+	policy := state.SessionRetentionPolicy{
+		KeepLast:    o.cfg.SessionRetention.EffectiveKeepLast(),
+		MinAge:      o.cfg.SessionRetention.EffectiveMinAge(),
+		ArchiveFile: o.cfg.SessionRetention.EffectiveArchiveFile(o.cfg.StateDir),
+	}
+	res, err := s.CompactSessions(policy, time.Now().UTC())
+	if err != nil {
+		log.Printf("[orch] compact sessions: %v", err)
+		return
+	}
+	if res.Removed == 0 {
+		return
+	}
+	if err := state.Save(o.cfg.StateDir, s); err != nil {
+		log.Printf("[orch] compact sessions: save: %v", err)
+		return
+	}
+	log.Printf("[orch] startup compaction removed %d terminal session(s) (archived=%d)", res.Removed, res.Archived)
 }
 
 // reloadConfig applies non-destructive config changes at runtime.

--- a/internal/state/compact_sessions_test.go
+++ b/internal/state/compact_sessions_test.go
@@ -1,0 +1,293 @@
+package state
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCompactSessions_KeepsNewest20OfFiftyDone(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	for i := 0; i < 50; i++ {
+		finished := now.Add(-time.Duration(i+30) * 24 * time.Hour) // all older than 7d
+		started := finished.Add(-time.Hour)
+		slot := fmt.Sprintf("done-%02d", i)
+		s.Sessions[slot] = &Session{
+			IssueNumber: i + 1,
+			Status:      StatusDone,
+			StartedAt:   started,
+			FinishedAt:  &finished,
+		}
+	}
+	s.Sessions["running"] = &Session{
+		IssueNumber: 999,
+		Status:      StatusRunning,
+		StartedAt:   now.Add(-time.Hour),
+	}
+
+	archive := filepath.Join(t.TempDir(), "sessions-archive.jsonl")
+	policy := SessionRetentionPolicy{KeepLast: 20, MinAge: 7 * 24 * time.Hour, ArchiveFile: archive}
+
+	res, err := s.CompactSessions(policy, now)
+	if err != nil {
+		t.Fatalf("CompactSessions: %v", err)
+	}
+	if res.Removed != 30 {
+		t.Errorf("Removed=%d, want 30", res.Removed)
+	}
+	if res.Archived != 30 {
+		t.Errorf("Archived=%d, want 30", res.Archived)
+	}
+	if _, ok := s.Sessions["running"]; !ok {
+		t.Error("running session must not be touched")
+	}
+	if len(s.Sessions) != 21 {
+		t.Errorf("remaining sessions=%d, want 21 (20 done + 1 running)", len(s.Sessions))
+	}
+	// The 20 kept slots are the newest by FinishedAt — done-00..done-19.
+	for i := 0; i < 20; i++ {
+		slot := fmt.Sprintf("done-%02d", i)
+		if _, ok := s.Sessions[slot]; !ok {
+			t.Errorf("expected %s kept", slot)
+		}
+	}
+	for i := 20; i < 50; i++ {
+		slot := fmt.Sprintf("done-%02d", i)
+		if _, ok := s.Sessions[slot]; ok {
+			t.Errorf("expected %s pruned", slot)
+		}
+	}
+
+	// Verify archive content is one JSON record per line.
+	f, err := os.Open(archive)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	lines := 0
+	for scanner.Scan() {
+		var rec archivedSessionRecord
+		if err := json.Unmarshal(scanner.Bytes(), &rec); err != nil {
+			t.Fatalf("decode archive line: %v", err)
+		}
+		if rec.Session == nil || rec.Slot == "" {
+			t.Errorf("archive record missing fields: %+v", rec)
+		}
+		lines++
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan archive: %v", err)
+	}
+	if lines != 30 {
+		t.Errorf("archive lines=%d, want 30", lines)
+	}
+}
+
+func TestCompactSessions_ActiveSessionsUntouched(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	veryOld := now.Add(-90 * 24 * time.Hour)
+	for _, status := range []SessionStatus{StatusRunning, StatusPROpen, StatusQueued} {
+		slot := "active-" + string(status)
+		s.Sessions[slot] = &Session{
+			IssueNumber: 1,
+			Status:      status,
+			StartedAt:   veryOld,
+		}
+	}
+
+	res, err := s.CompactSessions(SessionRetentionPolicy{KeepLast: 0, MinAge: 0}, now)
+	if err != nil {
+		t.Fatalf("CompactSessions: %v", err)
+	}
+	if res.Removed != 0 {
+		t.Errorf("Removed=%d, want 0", res.Removed)
+	}
+	if len(s.Sessions) != 3 {
+		t.Errorf("len(Sessions)=%d, want 3 (no active session pruned)", len(s.Sessions))
+	}
+}
+
+func TestCompactSessions_AgeFloorKeepsRecent(t *testing.T) {
+	// 30 done sessions all within the last 24h: nothing should be pruned
+	// because every one of them is younger than MinAge, even though the
+	// count window is 20.
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	for i := 0; i < 30; i++ {
+		finished := now.Add(-time.Duration(i) * time.Minute)
+		started := finished.Add(-time.Hour)
+		slot := fmt.Sprintf("done-%02d", i)
+		s.Sessions[slot] = &Session{
+			IssueNumber: i + 1,
+			Status:      StatusDone,
+			StartedAt:   started,
+			FinishedAt:  &finished,
+		}
+	}
+
+	res, err := s.CompactSessions(SessionRetentionPolicy{KeepLast: 20, MinAge: 7 * 24 * time.Hour}, now)
+	if err != nil {
+		t.Fatalf("CompactSessions: %v", err)
+	}
+	if res.Removed != 0 {
+		t.Errorf("Removed=%d, want 0 (age floor protects all)", res.Removed)
+	}
+	if len(s.Sessions) != 30 {
+		t.Errorf("len(Sessions)=%d, want 30", len(s.Sessions))
+	}
+}
+
+func TestCompactSessions_CountFloorKeepsSmallSet(t *testing.T) {
+	// Only 5 done sessions, all 30 days old. Count floor of 20 protects
+	// every session even though age floor would otherwise let them be
+	// pruned.
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	for i := 0; i < 5; i++ {
+		finished := now.Add(-30 * 24 * time.Hour).Add(-time.Duration(i) * time.Hour)
+		started := finished.Add(-time.Hour)
+		slot := fmt.Sprintf("done-%d", i)
+		s.Sessions[slot] = &Session{
+			IssueNumber: i + 1,
+			Status:      StatusDone,
+			StartedAt:   started,
+			FinishedAt:  &finished,
+		}
+	}
+
+	res, err := s.CompactSessions(SessionRetentionPolicy{KeepLast: 20, MinAge: 7 * 24 * time.Hour}, now)
+	if err != nil {
+		t.Fatalf("CompactSessions: %v", err)
+	}
+	if res.Removed != 0 {
+		t.Errorf("Removed=%d, want 0 (count floor protects all)", res.Removed)
+	}
+	if len(s.Sessions) != 5 {
+		t.Errorf("len(Sessions)=%d, want 5", len(s.Sessions))
+	}
+}
+
+func TestCompactSessions_Idempotent(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	for i := 0; i < 25; i++ {
+		finished := now.Add(-time.Duration(i+30) * 24 * time.Hour)
+		started := finished.Add(-time.Hour)
+		slot := fmt.Sprintf("done-%02d", i)
+		s.Sessions[slot] = &Session{
+			IssueNumber: i + 1,
+			Status:      StatusDone,
+			StartedAt:   started,
+			FinishedAt:  &finished,
+		}
+	}
+
+	archive := filepath.Join(t.TempDir(), "sessions-archive.jsonl")
+	policy := SessionRetentionPolicy{KeepLast: 20, MinAge: 7 * 24 * time.Hour, ArchiveFile: archive}
+
+	first, err := s.CompactSessions(policy, now)
+	if err != nil {
+		t.Fatalf("CompactSessions first: %v", err)
+	}
+	if first.Removed != 5 {
+		t.Errorf("first Removed=%d, want 5", first.Removed)
+	}
+
+	second, err := s.CompactSessions(policy, now)
+	if err != nil {
+		t.Fatalf("CompactSessions second: %v", err)
+	}
+	if second.Removed != 0 {
+		t.Errorf("second Removed=%d, want 0 (idempotent)", second.Removed)
+	}
+	if second.Archived != 0 {
+		t.Errorf("second Archived=%d, want 0", second.Archived)
+	}
+}
+
+func TestCompactSessions_AllTerminalStatusesEligible(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	veryOld := now.Add(-90 * 24 * time.Hour)
+	statuses := []SessionStatus{
+		StatusDone,
+		StatusFailed,
+		StatusConflictFailed,
+		StatusDead,
+		StatusRetryExhausted,
+		StatusCodeLanded,
+	}
+
+	s := NewState()
+	for i, status := range statuses {
+		finished := veryOld.Add(-time.Duration(i) * time.Hour)
+		slot := fmt.Sprintf("slot-%s", status)
+		s.Sessions[slot] = &Session{
+			IssueNumber: i + 1,
+			Status:      status,
+			StartedAt:   finished.Add(-time.Hour),
+			FinishedAt:  &finished,
+		}
+	}
+
+	// KeepLast=0 + MinAge=7d: every entry is older than 7d and beyond
+	// the count floor → every eligible status is pruned.
+	res, err := s.CompactSessions(SessionRetentionPolicy{KeepLast: 0, MinAge: 7 * 24 * time.Hour}, now)
+	if err != nil {
+		t.Fatalf("CompactSessions: %v", err)
+	}
+	if res.Removed != len(statuses) {
+		t.Errorf("Removed=%d, want %d (all retention-eligible statuses pruned)", res.Removed, len(statuses))
+	}
+	if len(s.Sessions) != 0 {
+		t.Errorf("len(Sessions)=%d, want 0", len(s.Sessions))
+	}
+}
+
+func TestCompactSessions_NoFinishedAtFallsBackToStartedAt(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	s.Sessions["dead-no-finish"] = &Session{
+		IssueNumber: 1,
+		Status:      StatusDead,
+		StartedAt:   now.Add(-30 * 24 * time.Hour),
+		FinishedAt:  nil,
+	}
+
+	res, err := s.CompactSessions(SessionRetentionPolicy{KeepLast: 0, MinAge: 7 * 24 * time.Hour}, now)
+	if err != nil {
+		t.Fatalf("CompactSessions: %v", err)
+	}
+	if res.Removed != 1 {
+		t.Errorf("Removed=%d, want 1", res.Removed)
+	}
+}
+
+func TestCompactSessions_ArchiveDisabled(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	finished := now.Add(-30 * 24 * time.Hour)
+	s.Sessions["done-1"] = &Session{
+		IssueNumber: 1,
+		Status:      StatusDone,
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+	}
+
+	res, err := s.CompactSessions(SessionRetentionPolicy{KeepLast: 0, MinAge: 7 * 24 * time.Hour}, now)
+	if err != nil {
+		t.Fatalf("CompactSessions: %v", err)
+	}
+	if res.Removed != 1 {
+		t.Errorf("Removed=%d, want 1", res.Removed)
+	}
+	if res.Archived != 0 {
+		t.Errorf("Archived=%d, want 0 (archive disabled)", res.Archived)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2573,6 +2573,141 @@ func (s *State) PruneOldSessions(maxAge time.Duration) int {
 	return pruned
 }
 
+// IsRetentionEligible reports whether a session in this status is eligible
+// for CompactSessions to consider it. Active states (running / pr_open /
+// queued and any non-listed state) are never touched. Matches the issue
+// #497 spec, which includes code_landed in the retention-eligible set even
+// though IsTerminal does not (code_landed is treated as terminal once the
+// session falls outside both retention floors).
+func IsRetentionEligible(status SessionStatus) bool {
+	switch status {
+	case StatusDone, StatusFailed, StatusConflictFailed, StatusDead, StatusRetryExhausted, StatusCodeLanded:
+		return true
+	}
+	return false
+}
+
+// SessionRetentionPolicy controls CompactSessions.
+//
+// A retention-eligible session is removed only when it is BOTH outside the
+// newest KeepLast window AND older than MinAge. This implements the #497
+// rule "keep last N or last D days, whichever is longer". Setting either
+// floor to 0 or negative disables that floor.
+type SessionRetentionPolicy struct {
+	KeepLast    int           // minimum newest-N eligible sessions to retain regardless of age
+	MinAge      time.Duration // retain any eligible session younger than this duration
+	ArchiveFile string        // if non-empty, append pruned sessions to this JSONL file before delete
+}
+
+// SessionCompactionResult is the count summary returned by CompactSessions.
+type SessionCompactionResult struct {
+	Removed  int // number of sessions deleted from state.Sessions
+	Archived int // number of sessions appended to the archive file
+}
+
+// archivedSessionRecord is the JSONL line format written to the archive
+// file. Each pruned session is serialized as one record per line so the
+// archive remains append-only and grep-friendly.
+type archivedSessionRecord struct {
+	Slot       string    `json:"slot"`
+	ArchivedAt time.Time `json:"archived_at"`
+	Session    *Session  `json:"session"`
+}
+
+// CompactSessions removes retention-eligible sessions from s.Sessions that
+// fall outside BOTH the policy's count window (KeepLast newest) AND the
+// policy's age window (MinAge). When policy.ArchiveFile is non-empty,
+// pruned sessions are first appended to that file as JSONL (one record per
+// line) for forensics, mirroring the audit-log pattern. The function is
+// idempotent — invoking it repeatedly with the same state and clock is a
+// no-op after the first call.
+//
+// Active sessions (running, pr_open, queued, and any non-listed state) are
+// never touched. now is the wall clock used for the age window so callers
+// can inject a deterministic clock in tests.
+func (s *State) CompactSessions(policy SessionRetentionPolicy, now time.Time) (SessionCompactionResult, error) {
+	var result SessionCompactionResult
+	if s == nil || len(s.Sessions) == 0 {
+		return result, nil
+	}
+
+	type candidate struct {
+		slot     string
+		sess     *Session
+		finished time.Time
+	}
+	eligible := make([]candidate, 0, len(s.Sessions))
+	for slot, sess := range s.Sessions {
+		if sess == nil || !IsRetentionEligible(sess.Status) {
+			continue
+		}
+		finished := sess.StartedAt
+		if sess.FinishedAt != nil {
+			finished = *sess.FinishedAt
+		}
+		eligible = append(eligible, candidate{slot: slot, sess: sess, finished: finished})
+	}
+	if len(eligible) == 0 {
+		return result, nil
+	}
+	sort.Slice(eligible, func(i, j int) bool {
+		if !eligible[i].finished.Equal(eligible[j].finished) {
+			return eligible[i].finished.After(eligible[j].finished)
+		}
+		// Stable tiebreak on slot name so the kept set is deterministic
+		// across runs even when several sessions share a FinishedAt.
+		return eligible[i].slot < eligible[j].slot
+	})
+
+	keepLast := policy.KeepLast
+	if keepLast < 0 {
+		keepLast = 0
+	}
+
+	pruneSlots := make([]candidate, 0)
+	for i, c := range eligible {
+		if i < keepLast {
+			continue
+		}
+		if policy.MinAge > 0 && now.Sub(c.finished) < policy.MinAge {
+			continue
+		}
+		pruneSlots = append(pruneSlots, c)
+	}
+	if len(pruneSlots) == 0 {
+		return result, nil
+	}
+
+	if policy.ArchiveFile != "" {
+		archivedAt := now.UTC()
+		if err := os.MkdirAll(filepath.Dir(policy.ArchiveFile), 0755); err != nil {
+			return result, fmt.Errorf("create archive dir: %w", err)
+		}
+		f, err := os.OpenFile(policy.ArchiveFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return result, fmt.Errorf("open archive: %w", err)
+		}
+		enc := json.NewEncoder(f)
+		for _, c := range pruneSlots {
+			rec := archivedSessionRecord{Slot: c.slot, ArchivedAt: archivedAt, Session: c.sess}
+			if err := enc.Encode(rec); err != nil {
+				_ = f.Close()
+				return result, fmt.Errorf("write archive record: %w", err)
+			}
+			result.Archived++
+		}
+		if err := f.Close(); err != nil {
+			return result, fmt.Errorf("close archive: %w", err)
+		}
+	}
+
+	for _, c := range pruneSlots {
+		delete(s.Sessions, c.slot)
+		result.Removed++
+	}
+	return result, nil
+}
+
 // StaleSessionPolicy controls reconciliation of sessions that have been idle
 // past their useful lifetime. The policy is intentionally conservative so a
 // live worker is never reclassified as stale.

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -328,8 +328,44 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 		if err := state.Save(cfg.StateDir, st); err != nil {
 			return state.SupervisorDecision{}, fmt.Errorf("save state: %w", err)
 		}
+		// #497: bound state.Sessions growth by compacting old terminal
+		// sessions every cycle. Runs after Save so a compaction failure
+		// can never lose a decision already persisted; we only re-Save
+		// when something was actually pruned.
+		compactTerminalSessions(cfg, st, "supervisor")
 	}
 	return decision, nil
+}
+
+// compactTerminalSessions applies cfg.SessionRetention to st and persists the
+// result when sessions were pruned. Failures are logged but never returned,
+// since retention is an idempotent best-effort sweep — the next cycle will
+// retry. caller is a tag used only in log lines.
+func compactTerminalSessions(cfg *config.Config, st *state.State, caller string) {
+	if cfg == nil || st == nil {
+		return
+	}
+	if !cfg.SessionRetention.IsEnabled() {
+		return
+	}
+	policy := state.SessionRetentionPolicy{
+		KeepLast:    cfg.SessionRetention.EffectiveKeepLast(),
+		MinAge:      cfg.SessionRetention.EffectiveMinAge(),
+		ArchiveFile: cfg.SessionRetention.EffectiveArchiveFile(cfg.StateDir),
+	}
+	res, err := st.CompactSessions(policy, time.Now().UTC())
+	if err != nil {
+		log.Printf("[%s] compact sessions: %v", caller, err)
+		return
+	}
+	if res.Removed == 0 {
+		return
+	}
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		log.Printf("[%s] compact sessions: save: %v", caller, err)
+		return
+	}
+	log.Printf("[%s] compacted %d terminal session(s) (archived=%d)", caller, res.Removed, res.Archived)
 }
 
 func recordOutcomeHealth(cfg *config.Config, st *state.State) {


### PR DESCRIPTION
Refs #497

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces bounded retention for `state.Sessions` by adding `CompactSessions` — a configurable, idempotent sweep that prunes terminal sessions falling outside both a newest-N count window and a minimum-age floor, with optional JSONL archiving before deletion. The orchestrator runs it once at startup; the supervisor runs it every cycle after the primary state save.

- **Config** (`SessionRetentionConfig`): zero/negative sentinels are cleanly handled via `Effective*` accessors; defaults (keep 20, 7-day floor, archive enabled) are tested.
- **Core logic** (`CompactSessions`): correctly implements "keep last N *or* last D days, whichever is larger" semantics; sort is deterministic via slot-name tiebreak; active sessions are never touched.
- **Partial archive write**: if `enc.Encode` fails mid-loop, already-encoded records are in the archive file but no sessions are deleted from state. On the next successful cycle all of those sessions are re-archived, producing duplicate JSONL entries for the failed batch.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is additive and isolated to session compaction, with no risk to active sessions or the primary state-save path.

The compaction logic, config accessors, and test coverage are solid. The one issue is in the archive write path: a mid-loop encode failure leaves already-written records in the JSONL file while keeping their sessions in state, so the next successful compaction re-archives those sessions and produces duplicate entries. This is a forensic-archive correctness concern rather than an operational one — sessions are never lost — but it is a real defect introduced by the new code.

internal/state/state.go — the archive write / session-delete sequencing in CompactSessions

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds CompactSessions, IsRetentionEligible, and supporting types; archive write path has a partial-write/retry issue that can produce duplicate JSONL records |
| internal/config/config.go | Adds SessionRetentionConfig with sensible defaults (20 sessions / 7 days), correct zero/negative sentinel handling via Effective* accessors |
| internal/supervisor/supervisor.go | Calls compactTerminalSessions after the primary state.Save so a compaction failure cannot lose a persisted decision; safe design |
| internal/orchestrator/orchestrator.go | Adds a one-shot startup compaction that loads/saves state independently; RunOnce always re-loads from disk so the compacted state is picked up correctly |
| internal/state/compact_sessions_test.go | New test file; covers active-session preservation, age floor, count floor, idempotency, all terminal statuses, nil-FinishedAt fallback, and archive-disabled paths |
| internal/config/config_test.go | Three new tests cover defaults, explicit overrides, and negative-disables-floor semantics for SessionRetentionConfig |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/state/state.go:2690-2707
If `enc.Encode` succeeds for the first _k_ sessions and then fails on session _k+1_, those _k_ records are already appended to the file but no sessions are deleted from state (the delete loop never runs). On the next compaction cycle, all sessions (including the already-archived _k_) are re-added to `pruneSlots` and written to the archive again, producing duplicate JSONL entries for those sessions. The same window exists when `f.Close()` fails after all encodes succeed. Tracking which sessions were successfully flushed before returning the error avoids the duplication.

```suggestion
		enc := json.NewEncoder(f)
		for _, c := range pruneSlots {
			rec := archivedSessionRecord{Slot: c.slot, ArchivedAt: archivedAt, Session: c.sess}
			if err := enc.Encode(rec); err != nil {
				_ = f.Close()
				return result, fmt.Errorf("write archive record: %w", err)
			}
			result.Archived++
		}
		if err := f.Close(); err != nil {
			return result, fmt.Errorf("close archive: %w", err)
		}
	}

	// Only delete sessions that were successfully archived (or didn't need
	// archiving). Pruning only the first result.Archived slots when archiving
	// is enabled prevents duplicate archive entries if the write partially
	// succeeded and the caller retries.
	toDelete := pruneSlots
	if policy.ArchiveFile != "" && result.Archived < len(pruneSlots) {
		toDelete = pruneSlots[:result.Archived]
	}
	for _, c := range toDelete {
		delete(s.Sessions, c.slot)
		result.Removed++
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(state): compact terminal sessions t..."](https://github.com/befeast/maestro/commit/d1b038a94c3ec24b87986ff4212b43f762e55c67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35127003)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->