### PR TITLE
Optional HTTP auth for Maestro dashboards on exposed / non-LAN installs (off by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,14 @@ maestro serve --config ./maestro.yaml --host 127.0.0.1 --port 8787 --read-only
 
 For multi-project Fleet Mission Control operations, see [`docs/fleet-mission-control-runbook.md`](docs/fleet-mission-control-runbook.md).
 
-When the dashboard runs anywhere other than `127.0.0.1`, configure HTTP auth on every mutating endpoint (#487). The token is loaded at runtime from an environment variable populated by your secret manager (Infisical, 1Password CLI, etc.) — never hardcoded in YAML:
+### Dashboard auth posture: trusted LAN vs. exposed
+
+Maestro's dashboard auth is opt-in and disabled by default. The right posture depends on where the port is reachable from:
+
+- **Trusted LAN (default).** When the dashboard is bound to `127.0.0.1` or a network only operators can reach, leave `server.auth` empty. The cautious approval gate still protects `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config` — flipping `--read-only=false` on a trusted LAN does not expose the four destructive verbs.
+- **Exposed / shared network.** When the dashboard is reachable from anywhere outside the trusted LAN — `--host 0.0.0.0`, behind a reverse proxy, on a multi-tenant host — set `server.auth.token_env`. With auth enabled, **every** endpoint (read GETs, write POSTs, and the SPA HTML) rejects unauthenticated requests with `401`; the cautious approval gate still fires for authenticated callers as defense in depth.
+
+The token is loaded at runtime from an environment variable populated by your secret manager (Infisical, 1Password CLI, etc.) — never hardcoded in YAML:
 
 ```yaml
 server:
@@ -156,7 +163,12 @@ server:
     actor_name: dashboard-operator       # optional; audit actor recorded for authed requests
 ```
 
-When `auth.token_env` resolves to a non-empty value, every `POST /api/v1/...` (`/actions`, `/approvals/{id}/{approve|reject}`, `/audit/log`, `/refresh`) requires `Authorization: Bearer <token>` and returns `401` otherwise. The authenticated identity replaces any `actor` field in the request body. Read-only GETs stay open.
+When `auth.token_env` resolves to a non-empty value, every request — `GET /api/v1/...`, `POST /api/v1/...` (`/actions`, `/approvals/{id}/{approve|reject}`, `/audit/log`, `/refresh`), and the dashboard HTML / static assets — requires a credential and returns `401` otherwise. Two authentication schemes are accepted (the server advertises both in the `WWW-Authenticate` challenge):
+
+- **HTTP Basic** — any username, password equal to the token. Browsers prompt natively, then cache the credential for the realm so subsequent SPA fetches authenticate automatically.
+- **Bearer token** — `Authorization: Bearer <token>`. Use this for `curl`, scripts, and clients driven directly by a secret manager.
+
+The authenticated identity replaces any `actor` field in the request body — operators cannot impersonate one another even if they share the token.
 
 To watch workers live in a tmux dashboard:
 ```bash

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -18,7 +18,14 @@ Reserve these services and ports on the workshop host:
 
 > Per-project Mission Control ports (`8788+`) were retired in #516. Every project is now reachable through the fleet aggregator at `/project/<name>`. Old `maestro-<project>-web.service` user units can be stopped and disabled; their `server.port` settings in project YAMLs are honored only when a project runs its own single-tenant `maestro serve --config ...` outside the fleet.
 
-Mutating endpoints require app-level HTTP auth (#487). Configure `server.auth.token_env` in each project config (the fleet picks up the first project that sets it) and populate the named environment variable from your secret manager (Infisical, 1Password CLI, etc.) — never inline the token in YAML. When auth is configured, every `POST /api/v1/...` (`/actions`, `/approvals/.../{approve|reject}`, `/audit/log`, `/fleet/actions`) requires `Authorization: Bearer <token>` and returns `401` without it. Read-only GETs stay open. The LAN is no longer treated as trusted: do not skip the token, even on `127.0.0.1`, when other devices share the network.
+### Dashboard auth posture: trusted LAN vs. exposed install
+
+The dashboard auth layer is opt-in. Choose the posture that matches the network the port is reachable from:
+
+- **Trusted LAN (default, no auth configured).** The dashboard binds to `127.0.0.1` or a private network only operators reach. The cautious approval gate still protects `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config` so flipping `--read-only=false` on a trusted LAN does not expose the four destructive verbs. Per the operator decision recorded against #477 (2026-06-02): the LAN is closed, alien access is not part of the threat model, and `server.auth` may be left empty.
+- **Exposed / shared-network install (auth required, #616).** The dashboard is reachable from anywhere outside the trusted LAN — `--host 0.0.0.0`, behind a reverse proxy, on a multi-tenant host, or on a workshop network shared with untrusted devices. Configure `server.auth.token_env` in each project config (the fleet picks up the first project that sets it) and populate the named environment variable from your secret manager (Infisical, 1Password CLI, etc.) — never inline the token in YAML. With auth enabled, every endpoint — **read** `GET /api/v1/...`, **write** `POST /api/v1/...` (`/actions`, `/approvals/.../{approve|reject}`, `/audit/log`, `/fleet/actions`, `/refresh`), and the SPA HTML / static assets — requires a credential and returns `401` otherwise. The cautious approval gate still fires for authenticated callers as defense in depth.
+
+The server advertises both **HTTP Basic** (any username, password equal to the token — so browsers prompt natively and cache the credential for the realm) and **Bearer** (`Authorization: Bearer <token>` — for `curl`, scripts, and secret-manager-driven clients) in the `WWW-Authenticate` challenge. The authenticated identity replaces any `actor` field in the request body so operators sharing a token cannot impersonate one another in the audit log.
 
 ## Config Boundaries
 

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -119,14 +119,43 @@ func constantTimeEqual(a, b string) bool {
 // on failure and returns ok=false; the caller MUST return immediately.
 // When auth is disabled, returns ("", true) and the caller proceeds with
 // its existing actor-fallback logic.
+//
+// The WWW-Authenticate challenge advertises Basic first so browsers prompt
+// natively (the SPA inherits credentials via the cached realm) and Bearer
+// second so curl / scripts / secret-manager-driven clients can attach a
+// header directly. Both schemes accept the configured token (Basic
+// password field for browser UX; Bearer for programmatic access).
 func requireAuth(w http.ResponseWriter, r *http.Request, a authChecker) (actor string, ok bool) {
 	actor, ok = a.Check(r)
 	if !ok {
-		w.Header().Set("WWW-Authenticate", `Bearer realm="maestro-dashboard"`)
-		writeError(w, http.StatusUnauthorized, "authentication required for mutating endpoints; provide Authorization: Bearer <token> loaded from your secret manager")
+		w.Header().Set("WWW-Authenticate", `Basic realm="maestro-dashboard", Bearer realm="maestro-dashboard"`)
+		writeError(w, http.StatusUnauthorized, "authentication required; provide HTTP Basic credentials (any user, password = token) or Authorization: Bearer <token> loaded from your secret manager")
 		return "", false
 	}
 	return actor, true
+}
+
+// authMiddleware wraps a handler so every request — read AND write —
+// passes the auth check before any inner handler runs. This is the
+// "exposed install" posture (#616): when auth.Required() is true, the
+// dashboard, the JSON read endpoints, and the mutating endpoints all
+// reject unauthenticated callers with 401 so an attacker on a public
+// network cannot enumerate state, harvest issue / PR / actor data, or
+// trigger any side effect.
+//
+// When auth.Required() is false (default, trusted-LAN posture), the
+// middleware is a pass-through — behaviour is byte-identical to a build
+// without this middleware so existing LAN installs see no regression.
+func authMiddleware(next http.Handler, a authChecker) http.Handler {
+	if !a.Required() {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := requireAuth(w, r, a); !ok {
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // resolveActor returns the final actor recorded in audit. authenticatedActor

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -437,3 +437,135 @@ func TestFleetApproval_NoCredentialReturns401_BeforeProjectLookup(t *testing.T) 
 		t.Fatalf("status = %d, want 401 (auth must fire before project lookup)", w.Code)
 	}
 }
+
+// --- #616 exposed-install posture: read endpoints also gated when auth is on
+
+// Pin the WWW-Authenticate challenge advertises Basic so browsers prompt
+// natively when an exposed install gates the SPA. Bearer is kept so curl /
+// secret-manager-driven clients can attach a token directly.
+func TestAuthChallenge_AdvertisesBasicAndBearer(t *testing.T) {
+	srv := New(newSafeActionTestCfg(), nil)
+	srv.SetAuthForTest("good-token", "alice")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.HandlerForTest().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	challenge := w.Header().Get("WWW-Authenticate")
+	if !strings.Contains(challenge, "Basic") {
+		t.Fatalf("WWW-Authenticate = %q, want Basic (browser prompt UX)", challenge)
+	}
+	if !strings.Contains(challenge, "Bearer") {
+		t.Fatalf("WWW-Authenticate = %q, want Bearer (curl/secret-manager UX)", challenge)
+	}
+}
+
+// Read endpoints (GETs) must reject unauthenticated callers when auth is
+// enabled. #616 acceptance: "every endpoint (read and write) rejects
+// unauthenticated requests".
+func TestRead_NoCredentialReturns401_WhenAuthEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"state", "/api/v1/state"},
+		{"workers", "/api/v1/workers"},
+		{"issue", "/api/v1/42"},
+		{"log", "/api/v1/logs/slot-1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := setupTestServer(t)
+			srv.SetAuthForTest("good-token", "alice")
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+			srv.HandlerForTest().ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401 (read endpoints must be gated when auth is enabled)", w.Code)
+			}
+		})
+	}
+}
+
+// The SPA HTML itself is gated when auth is enabled — otherwise an
+// unauthenticated visitor could harvest the embedded repo / initial-state
+// payload that the dashboard renders inline.
+func TestDashboardHTML_NoCredentialReturns401_WhenAuthEnabled(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.SetAuthForTest("good-token", "alice")
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.HandlerForTest().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (SPA HTML must be gated when auth is enabled)", w.Code)
+	}
+}
+
+// Authenticated reads succeed. Pin that a valid Bearer token unlocks the
+// read endpoints — proves the middleware is not a hard block.
+func TestRead_ValidBearerReturns200_WhenAuthEnabled(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.SetAuthForTest("good-token", "alice")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	req.Header.Set("Authorization", "Bearer good-token")
+	w := httptest.NewRecorder()
+	srv.HandlerForTest().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (valid token must unlock reads)", w.Code)
+	}
+}
+
+// Backward-compat: with auth disabled (default), read endpoints stay open
+// — this is the trusted-LAN posture from #477 and the no-regression
+// guarantee for existing installs.
+func TestRead_AuthDisabled_OpenAccess(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	// no SetAuthForTest → auth disabled (default)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	srv.HandlerForTest().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (auth disabled = LAN posture preserved)", w.Code)
+	}
+}
+
+// Fleet equivalent: GET /api/v1/fleet is gated when auth is enabled so an
+// unauthenticated probe cannot enumerate the fleet topology.
+func TestFleetRead_NoCredentialReturns401_WhenAuthEnabled(t *testing.T) {
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetAuthForTest("good-token", "alice")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.HandlerForTest().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (fleet read endpoints must be gated when auth is enabled)", w.Code)
+	}
+}
+
+// Fleet read endpoints stay open in the default LAN posture so existing
+// installs see no regression.
+func TestFleetRead_AuthDisabled_OpenAccess(t *testing.T) {
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	// no SetAuthForTest → auth disabled
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.HandlerForTest().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (auth disabled fleet should stay open)", w.Code)
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -233,12 +233,13 @@ func (s *FleetServer) SetAuthForTest(token, actorName string) {
 	s.auth = newAuthCheckerForTest(token, actorName)
 }
 
-// Start begins serving the fleet dashboard. It blocks until shutdown.
-func (s *FleetServer) Start(ctx context.Context) error {
-	if s.port == 0 {
-		return nil
-	}
-
+// buildHandler returns the fleet mux wrapped with the auth middleware.
+// When auth.Required() is true (#616: exposed install posture), every
+// route — JSON read endpoints, the SPA HTML, static assets, mutating
+// POSTs — rejects unauthenticated requests with 401 before the inner
+// handler runs. When auth is disabled (default LAN posture), the
+// middleware is a pass-through.
+func (s *FleetServer) buildHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/fleet/worker", s.handleFleetWorker)
 	mux.HandleFunc("/api/v1/fleet", s.handleFleet)
@@ -248,6 +249,18 @@ func (s *FleetServer) Start(ctx context.Context) error {
 	mux.HandleFunc("/approvals/audit", s.handleFleetApprovalAudit)
 	mux.Handle("/static/", web.StaticHandler())
 	mux.HandleFunc("/", s.handleFleetDashboard)
+	return authMiddleware(mux, s.auth)
+}
+
+// HandlerForTest exposes the wrapped handler so tests can exercise the
+// auth middleware without spinning up an httptest server.
+func (s *FleetServer) HandlerForTest() http.Handler { return s.buildHandler() }
+
+// Start begins serving the fleet dashboard. It blocks until shutdown.
+func (s *FleetServer) Start(ctx context.Context) error {
+	if s.port == 0 {
+		return nil
+	}
 
 	host := strings.TrimSpace(s.host)
 	if host == "" {
@@ -256,7 +269,7 @@ func (s *FleetServer) Start(ctx context.Context) error {
 	addr := net.JoinHostPort(host, strconv.Itoa(s.port))
 	s.srv = &http.Server{
 		Addr:         addr,
-		Handler:      mux,
+		Handler:      s.buildHandler(),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -69,13 +69,12 @@ func (s *Server) SetAuthForTest(token, actorName string) {
 	s.auth = newAuthCheckerForTest(token, actorName)
 }
 
-// Start begins serving HTTP on the configured port. It blocks until the server
-// is shut down. Returns nil if port is 0 (disabled).
-func (s *Server) Start(ctx context.Context) error {
-	if s.cfg.Server.Port == 0 {
-		return nil
-	}
-
+// buildHandler returns the dashboard mux wrapped with auth middleware.
+// Exported only for the test that exercises read-endpoint gating end-to-end
+// through the same handler that production serves (#616 acceptance: every
+// endpoint, read and write, rejects unauthenticated requests when auth
+// is enabled). When auth is disabled, the middleware is a pass-through.
+func (s *Server) buildHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/state", s.handleState)
 	mux.HandleFunc("/api/v1/workers", s.handleWorkers)
@@ -86,6 +85,20 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/v1/", s.handleIssue)
 	mux.Handle("/static/", web.StaticHandler())
 	mux.HandleFunc("/", s.handleDashboard)
+	return authMiddleware(mux, s.auth)
+}
+
+// HandlerForTest exposes the wrapped handler so tests can exercise the
+// auth middleware without spinning up an httptest server. Production code
+// goes through Start().
+func (s *Server) HandlerForTest() http.Handler { return s.buildHandler() }
+
+// Start begins serving HTTP on the configured port. It blocks until the server
+// is shut down. Returns nil if port is 0 (disabled).
+func (s *Server) Start(ctx context.Context) error {
+	if s.cfg.Server.Port == 0 {
+		return nil
+	}
 
 	host := strings.TrimSpace(s.cfg.Server.Host)
 	if host == "" {
@@ -94,7 +107,7 @@ func (s *Server) Start(ctx context.Context) error {
 	addr := net.JoinHostPort(host, strconv.Itoa(s.cfg.Server.Port))
 	s.srv = &http.Server{
 		Addr:         addr,
-		Handler:      mux,
+		Handler:      s.buildHandler(),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}


### PR DESCRIPTION
Refs #616

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces opt-in HTTP authentication for exposed Maestro dashboard installs (#616). When `server.auth.token_env` is set, a new `authMiddleware` wraps the entire mux — covering read GETs, the SPA HTML, static assets, and mutating POSTs — with a 401 gate that advertises both HTTP Basic (for browser native prompts) and Bearer (for `curl`/scripts). When auth is not configured (the default), the middleware is a compile-time pass-through, preserving byte-identical behaviour for existing trusted-LAN installs.

- `buildHandler()` is extracted from `Start()` on both `Server` and `FleetServer`, and the `authMiddleware` wrapper is applied there; `HandlerForTest()` exposes the same wrapped handler to tests so acceptance criteria are exercised end-to-end without spinning up a real HTTP server.
- `requireAuth` and the `WWW-Authenticate` challenge are updated to advertise `Basic` first (browser UX) then `Bearer` (programmatic access); the Basic credential decoder uses `SplitN(..., 2)` so tokens containing `:` survive round-trips through the browser prompt.
- Tests cover 401-gating of GETs and the SPA HTML, 200 pass-through with a valid Bearer token, backward-compat open-access when auth is disabled, and fleet equivalents of each case.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the middleware is a genuine pass-through for the default LAN posture and the exposed-install gating is correctly applied to all routes including reads and static assets.

The auth middleware and the inner handler requireAuth calls both succeed or fail together on any given request, so there is no auth bypass. The one structural observation is that mutating handlers will perform two authChecker.Check calls per request once the middleware is active — the middleware discards the returned actor while the inner handler uses it for audit — meaning actor resolution is tied to an internal convention that is easy to break silently in a future refactor.

internal/server/auth.go — the interaction between authMiddleware and the inner requireAuth calls in mutating handlers is the one area worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/auth.go | Adds authMiddleware (pass-through when disabled, 401-gating wrapper when enabled) and updates WWW-Authenticate to advertise both Basic and Bearer; double auth-check for mutating POSTs is a minor redundancy |
| internal/server/server.go | Extracts buildHandler() that wraps the full mux with authMiddleware; adds HandlerForTest(); Start() updated to use buildHandler() |
| internal/server/fleet.go | Same buildHandler()/HandlerForTest() refactor as server.go; fleet auth still requires explicit SetAuth() call before Start(), which is intentional |
| internal/server/auth_test.go | Adds tests for Basic+Bearer challenge header, GET 401-gating when auth enabled, dashboard HTML gating, backward-compat open-access, and fleet equivalents |
| README.md | Documentation updated to describe trusted-LAN vs. exposed postures, both auth schemes, and the opt-in nature of auth |
| docs/fleet-mission-control-runbook.md | Fleet runbook updated in parallel with README to reflect the two auth postures |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/server/auth.go:149-159
**Redundant auth check for mutating endpoints in exposed mode**

When `authMiddleware` is active, every POST to `/api/v1/actions`, `/api/v1/approvals/…`, and `/api/v1/refresh` ends up calling `a.Check(r)` twice — once here in the middleware (actor discarded) and again inside each handler via `requireAuth` (actor kept for audit). The inner calls were always the primary defense and remain so; the middleware layer makes them redundant for writes while being the sole guard for reads. This isn't wrong — both checks agree because they hit the same `authChecker` and the same request — but it means any future refactor that pulls the inner `requireAuth` calls out (e.g., to deduplicate) would silently drop actor resolution from audit records, since the middleware discards the actor today.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(server): gate read endpoints behind..."](https://github.com/befeast/maestro/commit/1e02568824969082342cf4d01316d20d73269473) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35219950)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->