### PR TITLE
Dashboard write-path (3/3): flip --read-only on the 6 LAN-bound serves (LAN trusted; IP/auth hardening later)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ maestro run --once
 # 5. Check status
 maestro status
 
-# 6. Watch the read-only web dashboard
-maestro serve --port 8787 --read-only
+# 6. Watch the Mission Control dashboard (trusted-LAN default: write-enabled)
+#    Add --read-only=true (or set server.read_only: true in YAML) for installs
+#    exposed beyond a trusted LAN; #616 covers optional HTTP auth.
+maestro serve --port 8787
 
 # 7. When ready, run continuously
 maestro run
@@ -137,10 +139,12 @@ To manually spawn a worker for a specific issue:
 maestro spawn --issue 42
 ```
 
-To watch Maestro from a browser, use the read-only Mission Control dashboard:
+To watch Maestro from a browser, use the Mission Control dashboard:
 ```bash
-maestro serve --config ./maestro.yaml --host 127.0.0.1 --port 8787 --read-only
+maestro serve --config ./maestro.yaml --host 127.0.0.1 --port 8787
 ```
+
+The dashboard now boots **write-enabled by default** (trusted-LAN posture, #477). The cautious approval gate still guards the four mutating verbs — `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config` — so even a writable HTTP caller cannot bypass operator approval. For installs exposed beyond a trusted LAN, run with `--read-only=true` (or set `server.read_only: true` in YAML) and configure the optional HTTP auth layer (#616, off by default).
 
 For multi-project Fleet Mission Control operations, see [`docs/fleet-mission-control-runbook.md`](docs/fleet-mission-control-runbook.md).
 
@@ -199,7 +203,7 @@ claude_cmd: claude                 # deprecated: use model.backends.claude.cmd
 server:
   host: 127.0.0.1                  # bind address for `maestro serve`
   port: 8787                       # 0 = disabled for `maestro run`
-  read_only: true                  # dashboard mode: block mutating HTTP endpoints
+  read_only: false                 # default: trusted-LAN, writes enabled; flip true for exposed installs (#477)
 issue_labels:                      # preferred label filter (OR semantics)
   - enhancement
 exclude_labels:

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -79,7 +79,10 @@ Serve flags:
   --fleet string        Path to fleet YAML file for multi-project dashboard
   --host string         Host/interface to bind (default from config, then 127.0.0.1)
   --port int            Port to bind (overrides server.port)
-  --read-only           Disable mutating HTTP endpoints (default true)
+  --read-only           Disable mutating HTTP endpoints (default false; trusted-LAN posture).
+                        Set --read-only=true (or server.read_only: true in YAML) for installs
+                        exposed beyond a trusted LAN; non-LAN deployments should also configure
+                        the HTTP auth layer (#616, off by default).
 
 Spawn flags:
   --issue int           Issue number to work on
@@ -886,8 +889,20 @@ func serveCmd(args []string) {
 	fleetPath := fs.String("fleet", "", "Path to fleet YAML file")
 	host := fs.String("host", "", "Host/interface to bind")
 	port := fs.Int("port", 0, "Port to bind")
-	readOnly := fs.Bool("read-only", true, "Disable mutating HTTP endpoints")
+	// #477: trusted-LAN posture — the dashboard write path is enabled by
+	// default. The cautious approval gate still gates the four mutating
+	// verbs (merge_pr / close_issue / delete_worktree / change_global_config).
+	// Operators exposing the dashboard beyond a trusted LAN should set
+	// --read-only=true (or server.read_only: true in YAML) and configure
+	// the optional HTTP auth layer (#616, off by default).
+	readOnly := fs.Bool("read-only", false, "Disable mutating HTTP endpoints")
 	fs.Parse(args)
+	readOnlyExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "read-only" {
+			readOnlyExplicit = true
+		}
+	})
 
 	var cfgs []*config.Config
 	if strings.TrimSpace(*fleetPath) == "" {
@@ -958,7 +973,12 @@ func serveCmd(args []string) {
 	if *port > 0 {
 		cfg.Server.Port = *port
 	}
-	cfg.Server.ReadOnly = *readOnly
+	// #477: only override the YAML setting when --read-only was passed
+	// explicitly. Defaulting to false (trusted-LAN posture) must not
+	// silently flip a YAML that opts back into read-only mode.
+	if readOnlyExplicit {
+		cfg.Server.ReadOnly = *readOnly
+	}
 	if cfg.Server.Port <= 0 {
 		log.Fatalf("serve requires server.port in config or --port")
 	}

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -1,6 +1,6 @@
 # Fleet Mission Control Operating Runbook
 
-Use Fleet Mission Control as the primary operations surface for Maestro-managed repositories. The fleet dashboard shows one read-only view across project configs, runner state, supervisor decisions, approvals, stuck states, and active workers.
+Use Fleet Mission Control as the primary operations surface for Maestro-managed repositories. The fleet dashboard aggregates project configs, runner state, supervisor decisions, approvals, stuck states, and active workers in one view. On a trusted LAN the dashboard ships write-enabled by default (#477); the cautious approval gate still guards `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config`. Add `--read-only=true` (or `server.read_only: true` in YAML) for installs exposed beyond a trusted LAN, and configure the optional HTTP auth layer that #616 wires up.
 
 This runbook is intentionally safe for shared docs. It uses placeholders for local paths and never requires printing tokens, environment variables, raw config dumps, or full worker logs.
 
@@ -10,7 +10,7 @@ Reserve these services and ports on the workshop host:
 
 | Service | Default bind | Port | Purpose | Notes |
 |---|---:|---:|---|---|
-| Fleet Mission Control | `127.0.0.1` | `8787` | The single dashboard for the whole fleet, plus the `/api/v1/fleet` aggregate API and project-scoped routes (`/project/<name>`) | Start with `maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787 --read-only` |
+| Fleet Mission Control | `127.0.0.1` | `8787` | The single dashboard for the whole fleet, plus the `/api/v1/fleet` aggregate API and project-scoped routes (`/project/<name>`) | Start with `maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787` (writes enabled on trusted LAN; add `--read-only=true` for exposed installs) |
 | Project runner | none by default | none | Runs `maestro run --config ...` and owns workers, worktrees, PR handling, and merge/deploy loops | It only serves HTTP when that project config has `server.port` set |
 | Supervisor loop | none | none | Runs `maestro supervise --config ...` to record decisions, safe queue label mutations, and approval requests | Can be manual, timer-driven, or a user service |
 | Worker sessions | none | none | tmux sessions and log files created under each project's `state_dir` | Inspect through Mission Control, `maestro status`, or `maestro logs` |
@@ -70,7 +70,7 @@ outcome:
 server:
   host: 127.0.0.1
   port: 8788
-  read_only: true
+  # read_only defaults to false (#477 trusted-LAN posture); set true for exposed installs.
 
 supervisor:
   enabled: true
@@ -228,8 +228,8 @@ Supervisor approvals are stale-sensitive. A pending approval becomes stale if th
 Use explicit config paths for project commands. These commands are safe for local operation because they do not print token values or dump entire configs. Treat worker logs as potentially sensitive and avoid pasting full logs into PRs or issues.
 
 ```bash
-# Fleet dashboard and API
-maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787 --read-only
+# Fleet dashboard and API (writes enabled by default on trusted LAN; add --read-only=true for exposed installs)
+maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787
 curl -fsS http://127.0.0.1:8787/api/v1/fleet
 
 # Project status and queue analysis
@@ -366,7 +366,7 @@ Safe response:
 
 ## Operator Checklist
 
-- Fleet dashboard is reachable on `127.0.0.1:8787` and is read-only.
+- Fleet dashboard is reachable on `127.0.0.1:8787`; on a trusted LAN it is write-enabled by default (#477), with the cautious approval gate guarding `merge_pr` / `close_issue` / `delete_worktree` / `change_global_config`.
 - Every project in `~/.maestro/fleet.yaml` has a distinct `state_dir`, `session_prefix`, and optional project dashboard port.
 - Project commands use `--config ~/.maestro/maestro-<project>.yaml`.
 - Dynamic wave has known runnable statuses and clear ready/blocked label ownership.

--- a/docs/install-testing.md
+++ b/docs/install-testing.md
@@ -60,3 +60,17 @@ Fresh machine (not .14 or .22), testing the full install -> init -> run flow.
 - #103: install.sh — add checksum verification
 - #104: init — validate model backend and generate richer config
 - #105: init — set PATH in generated systemd unit for AI CLI discovery
+
+## Dashboard write-path posture (#477)
+
+A fresh `maestro serve` boots **write-enabled by default** (trusted-LAN
+posture). The cautious approval gate still guards `merge_pr`, `close_issue`,
+`delete_worktree`, and `change_global_config`, so the writable dashboard
+cannot bypass operator approval for those four verbs. The flag override
+semantics are: pass `--read-only=true` to force read-only, otherwise the
+flag falls back to `server.read_only` from the per-project YAML (zero
+value = writable).
+
+For installs that need to be reachable beyond a trusted LAN, flip
+`server.read_only: true` (or pass `--read-only=true`) and configure the
+optional HTTP auth layer wired up by #616 (off by default).

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -269,7 +269,7 @@ Use the fleet dashboard when one operator needs a read-only overview across mult
 
 For day-to-day operations, review gates, queue policy, approvals, and safe recovery steps, see the [Fleet Mission Control operating runbook](fleet-mission-control-runbook.md).
 
-Start read-only first, controls later: keep the fleet dashboard in `--read-only` mode while it is used for observation and dogfooding. Add mutating controls only after the auth, audit, and per-project safety model is explicit.
+Trusted-LAN default (#477): the fleet dashboard now boots write-enabled out of the box. The cautious approval gate still guards `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config`, so the writable HTTP surface cannot bypass operator approval for those four verbs. For installs exposed beyond a trusted LAN, pass `--read-only=true` (or set `server.read_only: true` in YAML) and configure the optional HTTP auth layer that #616 wires up (off by default). This supersedes the prior "never flip --read-only before auth" caveat.
 
 To add a project:
 
@@ -291,10 +291,10 @@ projects:
 
 `config` may be absolute, `~/...`, or relative to the fleet YAML file. `dashboard_url` is deprecated (#516); any value still present is silently overridden with the project-scoped MC route on load. For dogfooding, add Maestro's own project config to the same fleet file so the team can watch Maestro manage Maestro alongside application repos.
 
-Run the fleet dashboard manually:
+Run the fleet dashboard manually (writes enabled by default on the trusted LAN; add `--read-only=true` for exposed installs):
 
 ```bash
-maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787 --read-only
+maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787
 ```
 
 Verify the API:
@@ -322,7 +322,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/maestro serve --fleet %h/.maestro/fleet.yaml --host 127.0.0.1 --port 8787 --read-only
+ExecStart=/usr/local/bin/maestro serve --fleet %h/.maestro/fleet.yaml --host 127.0.0.1 --port 8787
 Restart=on-failure
 RestartSec=10
 
@@ -338,10 +338,10 @@ systemctl --user enable --now maestro-fleet.service
 systemctl --user status maestro-fleet.service
 ```
 
-Bind to the LAN only on a trusted network or behind a firewall/reverse proxy:
+Bind to the LAN only on a trusted network or behind a firewall/reverse proxy. For non-LAN exposure, force `--read-only=true` and configure the auth layer (#616):
 
 ```bash
-maestro serve --fleet ~/.maestro/fleet.yaml --host 0.0.0.0 --port 8787 --read-only
+maestro serve --fleet ~/.maestro/fleet.yaml --host 0.0.0.0 --port 8787 --read-only=true
 ```
 
 ---

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -2806,7 +2806,7 @@ func TestFleetDashboardReadOnlyProjectControlsRenderQuietNote(t *testing.T) {
 	body := legacyFleetJS(t)
 	readOnlyBranch := dashboardSnippet(t, body,
 		"if (project.read_only === true || fleetState.readOnly)",
-		"return '<div class=\"project-actions\"><div class=\"label\">Approval-gated controls</div>'")
+		"function projectFreshnessHTML")
 
 	if !contains(readOnlyBranch, "Write controls disabled in read-only mode.") {
 		t.Fatalf("read-only project controls should render disabled-write footer, got:\n%s", readOnlyBranch)
@@ -2821,18 +2821,26 @@ func TestFleetDashboardReadOnlyProjectControlsRenderQuietNote(t *testing.T) {
 	}
 }
 
-func TestFleetDashboardWritableProjectControlsKeepApprovalDiagnostics(t *testing.T) {
+// #477: when not read-only, the legacy fleet view used to render an
+// "Approval-gated controls" panel of unconditionally-disabled buttons.
+// That dead affordance has been retired — Mission Control owns the live
+// POSTs. The non-read-only branch now points operators at MC instead.
+func TestFleetDashboardWritableProjectControlsPointToMissionControl(t *testing.T) {
 	body := legacyFleetJS(t)
 	writableBranch := dashboardSnippet(t, body,
-		"return '<div class=\"project-actions\"><div class=\"label\">Approval-gated controls</div>'",
+		"if (project.read_only === true || fleetState.readOnly)",
 		"function projectFreshnessHTML")
 
-	for _, want := range []string{
+	if !contains(writableBranch, "Project controls live in Mission Control") {
+		t.Fatalf("writable project controls should point at Mission Control, got:\n%s", writableBranch)
+	}
+	for _, unwanted := range []string{
 		"Approval-gated controls",
-		"renderActions(project.actions || [], { details: false })",
+		"action-btn",
+		"<button",
 	} {
-		if !contains(writableBranch, want) {
-			t.Fatalf("writable project controls should preserve %q in:\n%s", want, writableBranch)
+		if contains(writableBranch, unwanted) {
+			t.Fatalf("writable project controls should no longer surface dead affordance %q in:\n%s", unwanted, writableBranch)
 		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -440,10 +440,12 @@ func buildSupervisorInfo(cfg *config.Config, st *state.State) supervisorInfo {
 	if latest != nil {
 		info.EmptyState = ""
 		info.Latest = makeSupervisorDecisionInfo(cfg, st, *latest)
-		if latest.Risk != "" && latest.Risk != "safe" && latest.RecommendedAction != "" {
-			info.ApprovalActions = append(info.ApprovalActions, makeSupervisorActionInfo(cfg, *latest, true,
-				"Supervisor controls are not implemented yet; this read-only panel only shows the required action."))
-		}
+		// #477: the "Supervisor controls are not implemented yet"
+		// affordance has been retired. The supervisor's recommended
+		// action is surfaced through info.Latest; mutating verbs flow
+		// through the per-worker / per-project controlAction buttons
+		// and the cautious approval gate (#475/#476). No standalone
+		// disabled supervisor button is rendered anymore.
 	}
 
 	if safe := latestSafeSupervisorDecision(st); safe != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -458,8 +458,12 @@ func TestHandleStateSupervisorRationale(t *testing.T) {
 	if resp.Supervisor.LastSafeAction.OperatorSentence != "Watching PR #12 until checks and review pass." {
 		t.Fatalf("last safe operator sentence = %q", resp.Supervisor.LastSafeAction.OperatorSentence)
 	}
-	if len(resp.Supervisor.ApprovalActions) != 1 || !resp.Supervisor.ApprovalActions[0].Disabled {
-		t.Fatalf("approval actions = %#v, want one disabled action", resp.Supervisor.ApprovalActions)
+	// #477: the supervisor "controls not implemented yet" disabled button
+	// was a dead affordance — mutating verbs now flow through the per-worker
+	// controlAction buttons and the cautious approval gate. The supervisor
+	// info no longer publishes a standalone approval-actions list.
+	if len(resp.Supervisor.ApprovalActions) != 0 {
+		t.Fatalf("approval actions = %#v, want none", resp.Supervisor.ApprovalActions)
 	}
 	if resp.SupervisorLatest == nil || resp.SupervisorLatest.ID != "sup-latest" {
 		t.Fatalf("legacy supervisor_latest = %#v, want sup-latest", resp.SupervisorLatest)
@@ -1185,17 +1189,24 @@ func TestHandleDashboard(t *testing.T) {
 	if !contains(body, "issueSummaryHTML") || !contains(body, "issue-main") || !contains(body, "issue-title") {
 		t.Error("dashboard should keep issue links visible while truncating long titles")
 	}
-	if !contains(body, "renderWorkerActions") || !contains(body, "actionDetailHTML") || !contains(body, "manual approval required") {
-		t.Error("dashboard should render disabled approval-gated action affordances")
+	// #477: the legacy single-project dashboard is no longer the canonical
+	// write surface. renderWorkerActions still gates on the read-only banner,
+	// but the dead "disabled in both modes" button row was retired —
+	// operators land on Mission Control for live POSTs instead.
+	if !contains(body, "renderWorkerActions") || !contains(body, "Write controls disabled in read-only mode.") {
+		t.Error("dashboard should still render the read-only banner from renderWorkerActions")
+	}
+	if !contains(body, "Worker controls live in Mission Control") {
+		t.Error("dashboard non-read-only branch should point operators at Mission Control")
+	}
+	for _, unwanted := range []string{"actionDetailHTML", "renderActionButtons", "actionDisabledReason", "actionTargetText", "actionPolicyText", "manual approval required"} {
+		if contains(body, unwanted) {
+			t.Errorf("dashboard should no longer ship the dead disabled-button helper %q", unwanted)
+		}
 	}
 	for _, want := range []string{"<html data-theme=\"light\">", "/static/tokens.css", "/static/components.css", "/static/status-icons.svg", "/static/maestro-mark.svg", "/static/favicon-32.png", "/static/apple-touch-icon-180.png", "/static/og-1200x630.png", "Inter Tight", "JetBrains Mono", "#059669", "#0891b2", "color-scheme: light"} {
 		if !contains(body, want) {
 			t.Fatalf("dashboard design tokens should contain %q", want)
-		}
-	}
-	for _, want := range []string{"Scope", "Target", "Approval", "Disabled", "replace(/^Would\\s+/i"} {
-		if !contains(body, want) {
-			t.Fatalf("dashboard action guardrails should contain %q", want)
 		}
 	}
 }

--- a/internal/server/web/static/dashboard.js
+++ b/internal/server/web/static/dashboard.js
@@ -101,28 +101,6 @@ function runtimeTitleText(worker) {
   return parts.join("\n");
 }
 
-function actionLabel(action) {
-  switch (String(action || "").trim()) {
-  case "none": return "Skipped tick";
-  case "monitor_open_pr": return "Watching PR";
-  case "merge_pr": return "Merging PR";
-  case "approve_merge": return "Ready to merge PR";
-  case "skip_wave": return "Skipped tick";
-  case "spawn_worker": return "Starting worker";
-  case "label_issue_ready": return "Mark issue ready";
-  case "review_retry_exhausted": return "Review retry-exhausted work";
-  case "check_outcome_health": return "Check runtime health";
-  case "wait_for_review": return "Waiting on review";
-  case "wait_for_ci": return "Waiting on CI";
-  case "wait_for_running_worker":
-  case "wait_for_worker": return "Waiting for worker";
-  case "wait_for_capacity": return "Waiting for free slot";
-  case "wait_for_ordered_queue": return "Waiting for queue order";
-  default:
-    return String(action || "-").replace(/_/g, " ");
-  }
-}
-
 function rawSupervisorAction(action) {
   const raw = String(action || "").trim();
   return raw || "none";
@@ -164,52 +142,16 @@ function supervisorOperatorSentence(item) {
   return "Supervisor chose " + raw + ". Inspect diagnostics for details.";
 }
 
-function actionDisabledReason(actions) {
-  const action = (actions || []).find(item => item.disabled_reason);
-  return action ? action.disabled_reason : "Write actions require approval-backed configuration.";
-}
-
-function actionTargetText(action) {
-  const parts = [];
-  if (action.target) parts.push(action.target);
-  if (action.issue_number) parts.push("issue #" + action.issue_number);
-  if (action.pr_number) parts.push("PR #" + action.pr_number);
-  return parts.length ? parts.join(" · ") : "project";
-}
-
-function actionPolicyText(action) {
-  if (action.approval_policy) return actionLabel(action.approval_policy);
-  return action.requires_approval ? "manual approval required" : "none";
-}
-
-function actionDetailHTML(action) {
-  const description = action.description ? '<div><strong>Would</strong> ' + escapeText(action.description.replace(/^Would\s+/i, "")) + '</div>' : "";
-  return '<div class="action-detail">' + description +
-    '<div><strong>Scope</strong> ' + escapeText(actionLabel(action.scope || "unknown")) + '</div>' +
-    '<div><strong>Target</strong> ' + escapeText(actionTargetText(action)) + '</div>' +
-    '<div><strong>Approval</strong> ' + escapeText(actionPolicyText(action)) + '</div>' +
-    '<div><strong>Disabled</strong> ' + escapeText(action.disabled_reason || "Write action unavailable") + '</div>' +
-    '</div>';
-}
-
-function renderActionButtons(actions, showDetails) {
-  const items = actions || [];
-  if (!items.length) return "";
-  return '<div class="action-list">' + items.map(action =>
-    '<div class="action-item"><button type="button" class="action-btn" disabled aria-disabled="true" title="' +
-    escapeText(action.disabled_reason || "Write action unavailable") + '">' +
-    escapeText(action.label || actionLabel(action.id)) + '</button>' +
-    (showDetails ? actionDetailHTML(action) : "") + '</div>'
-  ).join("") + '</div>';
-}
-
 function renderWorkerActions(actions) {
   if (state.readOnly) {
     return '<div class="project-actions-readonly">Write controls disabled in read-only mode.</div>';
   }
+  // #477: the legacy single-project dashboard is not the canonical operator
+  // surface — Mission Control owns the live write-path POSTs. Surfacing
+  // unconditionally-disabled buttons here was a dead affordance; replace it
+  // with a pointer so operators land on the working UI.
   if (!actions || !actions.length) return "";
-  return '<div class="worker-actions"><span>Actions</span>' + renderActionButtons(actions, false) + '</div>' +
-    '<div class="action-note">' + escapeText(actionDisabledReason(actions)) + '</div>';
+  return '<div class="worker-actions-note">Worker controls live in Mission Control. Use the per-worker drawer there to restart, stop, or approve a merge.</div>';
 }
 
 function formatTimestamp(value) {
@@ -318,14 +260,10 @@ function renderSupervisor(info) {
     '<span title="Raw action: ' + escapeText(lastSafeRaw) + '">Last safe action: ' + escapeText(supervisorOperatorSentence(info.last_safe_action)) + '</span>' +
     '<span>' + escapeText(formatTimestamp(info.last_safe_action.created_at)) + '</span>' +
     '</div>' : "";
-  const approvals = (info.approval_actions || []).length ? '<div class="supervisor-actions">' +
-    '<span>Requires approval:</span>' +
-    (info.approval_actions || []).map(action =>
-      '<button class="supervisor-approval" disabled title="Raw action: ' + escapeText(rawSupervisorAction(action.action)) + ' · ' + escapeText(action.disabled_reason || "Controls not available yet") + '">' +
-      escapeText(supervisorOperatorSentence(action)) +
-      '</button>'
-    ).join("") +
-    '</div>' : "";
+  // #477: the supervisor "Requires approval" disabled-button row was a
+  // dead affordance — the server no longer publishes approval_actions.
+  // Per-worker controls and the cautious approval gate own the write path.
+  const approvals = "";
 
   const rawAction = rawSupervisorAction(latest.recommended_action);
   const operatorSentence = supervisorOperatorSentence(latest);

--- a/internal/server/web/static/fleet.js
+++ b/internal/server/web/static/fleet.js
@@ -202,45 +202,18 @@ function cssToken(value) {
   return String(value || "unknown").toLowerCase().replace(/[^a-z0-9_-]+/g, "_");
 }
 
-function actionDisabledReason(actions) {
-  const action = (actions || []).find(item => item.disabled_reason);
-  return action ? action.disabled_reason : "Write actions require approval-backed configuration.";
-}
-
-function actionTargetText(action) {
-  const parts = [];
-  if (action.target) parts.push(action.target);
-  if (action.issue_number) parts.push("issue #" + action.issue_number);
-  if (action.pr_number) parts.push("PR #" + action.pr_number);
-  return parts.length ? parts.join(" · ") : "project";
-}
-
-function actionPolicyText(action) {
-  if (action.approval_policy) return actionLabel(action.approval_policy);
-  return action.requires_approval ? "manual approval required" : "none";
-}
-
-function actionDetailHTML(action) {
-  const description = action.description ? '<div><strong>Would</strong> ' + escapeText(action.description.replace(/^Would\s+/i, "")) + '</div>' : "";
-  return '<div class="action-detail">' + description +
-    '<div><strong>Scope</strong> ' + escapeText(actionLabel(action.scope || "unknown")) + '</div>' +
-    '<div><strong>Target</strong> ' + escapeText(actionTargetText(action)) + '</div>' +
-    '<div><strong>Approval</strong> ' + escapeText(actionPolicyText(action)) + '</div>' +
-    '<div><strong>Disabled</strong> ' + escapeText(action.disabled_reason || "Write action unavailable") + '</div>' +
-    '</div>';
-}
-
 function renderActions(actions, options) {
   const items = actions || [];
   if (!items.length) return '<span class="empty">No controls.</span>';
-  const showDetails = !options || options.details !== false;
-  return '<div class="actions">' + items.map(action =>
-    '<div class="action-item"><button type="button" class="action-btn" disabled aria-disabled="true" title="' +
-    escapeText(action.disabled_reason || "Write action unavailable") + '">' +
-    escapeText(action.label || actionLabel(action.id)) + '</button>' +
-    (showDetails ? actionDetailHTML(action) : "") + '</div>'
-  ).join("") + '</div>' +
-  '<div class="action-note">' + escapeText(actionDisabledReason(items)) + '</div>';
+  // #477: the legacy fleet view does not POST to the action endpoints.
+  // Render the action list as inert metadata only — disabled when read_only
+  // is on, otherwise as a Mission Control pointer. The dead "disabled in
+  // both modes" affordance is gone.
+  void options;
+  if (fleetState.readOnly) {
+    return '<div class="action-note">Write controls disabled in read-only mode.</div>';
+  }
+  return '<div class="action-note">Use Mission Control for write controls.</div>';
 }
 
 function approvalStatusRank(status) {
@@ -2121,9 +2094,13 @@ function renderWorkerDetail(data) {
     ? (log.truncated ? "tail, " : "") + (log.updated_at || "")
     : "unavailable";
 
+  // #477: the legacy fleet view is no longer the canonical write surface —
+  // Mission Control owns the live POST handlers. Surfacing the disabled
+  // affordance row here was a dead path; only the genuine read-only banner
+  // remains, with a pointer to MC otherwise.
   const workerActionsHTML = fleetState.readOnly
     ? '<div class="project-actions-readonly">Write controls disabled in read-only mode.</div>'
-    : '<div class="project-actions"><div class="label">Approval-gated controls</div>' + renderActions(worker.actions || [], { details: false }) + '</div>';
+    : '<div class="project-actions-note">Worker controls live in Mission Control. Use the per-worker drawer there to restart, stop, or approve a merge.</div>';
   workerDetailBodyEl.innerHTML = '<div class="detail-grid">' + fields + '</div>' +
     '<div class="' + noteClass + '"><strong>State</strong> ' + escapeText(reason) +
       (links.length ? '<div class="detail-links">' + links.join("") + '</div>' : "") +
@@ -2332,8 +2309,9 @@ function renderProjectActions(project) {
   if (project.read_only === true || fleetState.readOnly) {
     return '<div class="project-actions-readonly">Write controls disabled in read-only mode.</div>';
   }
-  return '<div class="project-actions"><div class="label">Approval-gated controls</div>' +
-    renderActions(project.actions || [], { details: false }) + '</div>';
+  // #477: project-level write controls are owned by Mission Control. The
+  // legacy fleet view no longer surfaces dead disabled buttons here.
+  return '<div class="project-actions-note">Project controls live in Mission Control.</div>';
 }
 
 function projectFreshnessHTML(project) {


### PR DESCRIPTION
Refs #477

## Summary
- Flip `--read-only` flag default from `true` to `false` in `cmd/maestro/main.go` so a fresh `maestro serve` matches the trusted-LAN posture (#477). The flag only overrides `server.read_only` from YAML when passed explicitly, so a deliberate `read_only: true` in a project config is not silently overridden by the new default.
- Retire the residual dead "Supervisor controls are not implemented yet" affordance in `internal/server/server.go`; the supervisor info no longer publishes a standalone disabled approval-action list.
- Clean up the legacy `dashboard.js` and `fleet.js` so the only disabled-control state surfaced anywhere is genuine `read_only=true`. The legacy single-project and legacy fleet views point operators at Mission Control for write actions instead of rendering dead disabled rows.
- Update `README.md`, `docs/install-testing.md`, `docs/fleet-mission-control-runbook.md`, and `docs/project-setup-runbook.md` to document the trusted-LAN-default + #616-for-exposed-installs posture (replaces the prior "never flip --read-only before auth" caveat).

The cautious approval gate still routes `merge_pr` / `close_issue` / `delete_worktree` / `change_global_config` through the approver pipeline; this PR does not change that wiring.

## Test plan
- [x] `go test ./...`
- [x] `go build ./cmd/maestro/`
- [x] `gofmt -l` clean on all changed Go files
- [x] `bash .maestro/verify.sh`
- [ ] Operator-side smoke: confirm `maestro serve` boots with `read_only=false` and `POST /api/v1/actions` for the cautious-gate verbs still enqueues (not executes) on a deployed unit. Runtime verification stays an operator step — this PR intentionally does not auto-close #477.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the write-path enablement (#477) by flipping `--read-only` to default `false` (trusted-LAN posture), removing the long-dead "Supervisor controls are not implemented yet" affordance from the server and both JS dashboards, and updating docs to recommend `--read-only=true` for non-LAN installs.

- `cmd/maestro/main.go`: uses `fs.Visit` to detect whether `--read-only` was passed explicitly, so a YAML `server.read_only: true` is preserved when the flag is omitted — closing a latent bug where the old `true` default silently overrode YAML config.
- `internal/server/server.go` + `dashboard.js` + `fleet.js`: the `approval_actions` disabled-button path is removed end-to-end (server no longer emits it, JS no longer renders it); writable branches now redirect operators to Mission Control instead of surfacing inert buttons.
- Tests in `server_test.go` and `fleet_test.go` are updated to assert zero `ApprovalActions` and the presence of the Mission Control pointer strings.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The default-flip is deliberate and the `fs.Visit` guard correctly preserves any YAML `read_only: true` that would otherwise be silently overridden.

All changed code paths are covered by updated tests. The `readOnlyExplicit` detection handles every combination of explicit flag vs. YAML config correctly. Dead JS affordances are removed cleanly without leaving dangling callers (`actionLabel` is correctly retained in `fleet.js` where it is still used by the approvals path). No logic paths were altered in the cautious approval gate or the action-dispatch pipeline.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/maestro/main.go | Changes `--read-only` default from `true` to `false` and adds `fs.Visit`-based `readOnlyExplicit` detection so a YAML `server.read_only: true` is not silently overridden by the new flag default; fleet path correctly uses `*readOnly` directly. |
| internal/server/server.go | Removes the dead "Supervisor controls are not implemented yet" affordance from `buildSupervisorInfo`; `ApprovalActions` will now always be empty, consistent with the updated test assertion. |
| internal/server/web/static/dashboard.js | Removes dead `actionLabel`, `actionDisabledReason`, `actionTargetText`, `actionPolicyText`, `actionDetailHTML`, and `renderActionButtons` helpers; `renderWorkerActions` and supervisor panel now point to Mission Control instead of rendering unconditionally-disabled buttons. |
| internal/server/web/static/fleet.js | Removes `actionDisabledReason`, `actionTargetText`, `actionPolicyText`, and `actionDetailHTML`; `actionLabel` is correctly retained (still used for approval rows); `renderActions`, `renderWorkerDetail`, and `renderProjectActions` now return read-only banners or Mission Control pointers instead of dead disabled-button rows. |
| internal/server/server_test.go | Tests updated to assert zero `ApprovalActions` and presence of Mission Control pointer strings instead of the retired disabled-button helpers. |
| internal/server/fleet_test.go | Fleet test renamed and updated to verify the writable branch now points to Mission Control and no longer contains dead `action-btn` or `<button` affordances. |
| README.md | Docs updated to reflect write-enabled default and recommend `--read-only=true` for non-LAN installs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(serve): flip --read-only default to..."](https://github.com/befeast/maestro/commit/a76f10c93b91eaca11b34410748023d8dd5869d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35221432)</sub>

<!-- /greptile_comment -->