### PR TITLE
Supervisor: wire dependency-unblock so blocker-chained issues auto-advance (today they stall in Todo)

### DIFF
--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -72,6 +72,11 @@ server:
   port: 8788
   # read_only defaults to false (#477 trusted-LAN posture); set true for exposed installs.
 
+blocker_patterns:
+  - "blocked by.*?#(\\d+)"
+  - "blocked until.*?#(\\d+).*merged"
+  - "depends on.*?#(\\d+)"
+
 supervisor:
   enabled: true
   mode: cautious
@@ -86,6 +91,11 @@ supervisor:
       - Ready
       - Backlog
       - New
+    dependency_unblock:
+      enabled: true
+      max_runnable: 1
+      enroll_in_project: true
+      announce_with_comment: true
   safe_actions:
     - add_ready_label
     - remove_ready_label

--- a/docs/handoff-epic-format.md
+++ b/docs/handoff-epic-format.md
@@ -219,6 +219,14 @@ Depends on: #147
 ```
 
 ```markdown
+Blocked by #147
+```
+
+```markdown
+Blocked until #147 merged
+```
+
+```markdown
 Depends on: #148, #149
 ```
 
@@ -229,13 +237,20 @@ Depends on: #148, #149
 - #148 — UX wave 1 issues filed
 ```
 
-All three are recognised by `github.FindDependencies`. The structured
-section variant is preferred for wave epics because it survives template
-edits cleanly.
+The `Depends on:` and structured section variants are recognised by the
+built-in dependency parser. `Blocked by` / `Blocked until` forms are recognised
+through `blocker_patterns`, which are also used to keep issues out of the
+runnable queue while a blocker remains open. The structured section variant is
+preferred for wave epics because it survives template edits cleanly.
 
 ### Config
 
 ```yaml
+blocker_patterns:
+  - "blocked by.*?#(\\d+)"
+  - "blocked until.*?#(\\d+).*merged"
+  - "depends on.*?#(\\d+)"
+
 supervisor:
   ready_label: maestro-ready
   blocked_label: blocked

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -747,7 +747,7 @@ type Config struct {
 	Pipeline                        PipelineConfig               `yaml:"pipeline"`
 	Hooks                           HooksConfig                  `yaml:"hooks"`
 	Missions                        MissionsConfig               `yaml:"missions"`
-	BlockerPatterns                 []string                     `yaml:"blocker_patterns"`         // regex patterns to detect blocker references in issue body (e.g. "blocked by #(\\d+)")
+	BlockerPatterns                 []string                     `yaml:"blocker_patterns"`         // regex patterns to detect blocker references in issue body for queue skips and dependency_unblock (e.g. "blocked by #(\\d+)"; first capture group must be issue number)
 	PollIntervalSeconds             int                          `yaml:"poll_interval_seconds"`    // override poll interval from config (0 = use CLI flag)
 	StaleSessionReconciler          StaleSessionReconcilerConfig `yaml:"stale_session_reconciler"` // filter stale supervisor sessions from operator attention
 	SessionRetention                SessionRetentionConfig       `yaml:"session_retention"`        // #497: bound state.Sessions growth via terminal-session compaction
@@ -1056,6 +1056,7 @@ func parse(data []byte) (*Config, error) {
 	if cfg.BlockerPatterns == nil {
 		cfg.BlockerPatterns = []string{
 			`blocked by.*?#(\d+)`,
+			`blocked until.*?#(\d+).*merged`,
 			`depends on.*?#(\d+)`,
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1199,6 +1199,7 @@ func TestParse_BlockerPatternsDefault(t *testing.T) {
 	}
 	want := []string{
 		`blocked by.*?#(\d+)`,
+		`blocked until.*?#(\d+).*merged`,
 		`depends on.*?#(\d+)`,
 	}
 	if len(cfg.BlockerPatterns) != len(want) {

--- a/internal/supervisor/dependency_unblock.go
+++ b/internal/supervisor/dependency_unblock.go
@@ -163,7 +163,7 @@ func (e *Engine) evaluateDependencyUnblock(st *state.State, issues []github.Issu
 	}
 
 	for _, issue := range candidates {
-		deps := github.FindDependencies(issue.Body)
+		deps := dependencyUnblockDependencies(issue.Body, cfg.BlockerPatterns)
 		if len(deps) == 0 {
 			// A blocked issue without parseable dependencies is operator-
 			// gated: we don't guess when it's safe to unblock. Skip silently
@@ -225,6 +225,28 @@ func (e *Engine) evaluateDependencyUnblock(st *state.State, issues []github.Issu
 	}
 
 	return nil
+}
+
+func dependencyUnblockDependencies(body string, blockerPatterns []string) []int {
+	return mergeIssueRefs(github.FindBlockers(body, blockerPatterns), github.FindDependencies(body))
+}
+
+func mergeIssueRefs(groups ...[]int) []int {
+	seen := make(map[int]struct{})
+	var refs []int
+	for _, group := range groups {
+		for _, n := range group {
+			if n <= 0 {
+				continue
+			}
+			if _, ok := seen[n]; ok {
+				continue
+			}
+			seen[n] = struct{}{}
+			refs = append(refs, n)
+		}
+	}
+	return refs
 }
 
 // resolveDependencies returns the dependency issues that are closed or whose

--- a/internal/supervisor/dependency_unblock_test.go
+++ b/internal/supervisor/dependency_unblock_test.go
@@ -198,6 +198,68 @@ func TestEvaluate_UnblocksWhenAllDependenciesClosed(t *testing.T) {
 	}
 }
 
+func TestEvaluate_UnblocksUsingConfiguredBlockerPatterns(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.BlockerPatterns = []string{`blocked until #(\d+) merged`}
+	enableDependencyUnblock(cfg)
+	issue := testIssue(150, "blocked until predecessor merges", "blocked")
+	issue.Body = "Blocked until #147 merged."
+	reader := &fakeReader{
+		issues:       []github.Issue{issue},
+		closedIssues: map[int]bool{147: true},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionUnblockIssue {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionUnblockIssue)
+	}
+	if decision.Target == nil || decision.Target.Issue != 150 {
+		t.Fatalf("target = %#v, want issue 150", decision.Target)
+	}
+	if !strings.Contains(strings.Join(decision.Reasons, "\n"), "#147 closed") {
+		t.Fatalf("reasons = %#v, want closed dependency evidence", decision.Reasons)
+	}
+}
+
+func TestRunOnceDependencyUnblockAppliesSafeLabelMutations(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.BlockerPatterns = []string{`blocked until #(\d+) merged`}
+	enableDependencyUnblock(cfg)
+	issue := testIssue(150, "blocked until predecessor merges", "blocked")
+	issue.Body = "Blocked until #147 merged."
+	reader := &fakeReader{
+		issues:       []github.Issue{issue},
+		closedIssues: map[int]bool{147: true},
+	}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if decision.RecommendedAction != ActionUnblockIssue {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionUnblockIssue)
+	}
+	if got, want := strings.Join(reader.removedLabels, ","), "#150:blocked"; got != want {
+		t.Fatalf("removed labels = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(reader.addedLabels, ","), "#150:maestro-ready"; got != want {
+		t.Fatalf("added labels = %q, want %q", got, want)
+	}
+	if len(reader.comments) != 1 || !strings.Contains(reader.comments[0], "#147 closed") {
+		t.Fatalf("comments = %#v, want dependency evidence comment", reader.comments)
+	}
+	for _, mutation := range decision.Mutations {
+		if mutation.Status != MutationStatusSucceeded {
+			t.Fatalf("mutation %#v status = %q, want succeeded", mutation, mutation.Status)
+		}
+	}
+}
+
 // Test: dep merged-PR also resolves the dependency --------------------------
 
 func TestEvaluate_UnblocksWhenDependencyPRMerged(t *testing.T) {


### PR DESCRIPTION
Refs #620

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the `dependency_unblock` supervisor controller to also recognise issue references written in "blocked by / blocked until" prose forms, not just the structured `Depends on:` format. It adds `blocked until.*?#(\d+).*merged` as a third default blocker pattern and replaces the bare `FindDependencies` call in `evaluateDependencyUnblock` with a merged union of `FindBlockers(cfg.BlockerPatterns)` and `FindDependencies`, so issues stalled in Todo because their body only contains a `Blocked by #N` line now auto-advance when that dependency closes.

- `dependencyUnblockDependencies` and `mergeIssueRefs` are introduced as package-private helpers that deduplicate the combined result, including a guard for non-positive issue numbers.
- Two new tests cover the new path: one via `Decide()` checking the recommended action and evidence, one via `RunOnce()` verifying that label mutations and the announce comment are actually applied.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is narrowly scoped to the dependency-resolution step and backed by integration tests that exercise both the decision engine and the full RunOnce mutation path.

The core logic — merging blocker-pattern refs with structured dependency refs — is correct and well-deduped. The two observations are a repeated regex-compile per candidate issue per supervisor cycle (minor at typical wave sizes) and an outdated godoc comment on the main evaluation function. Neither affects correctness or runtime safety.

internal/supervisor/dependency_unblock.go — the regex compilation cost inside FindBlockers and the stale godoc are both worth a second look before the call volume grows.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/supervisor/dependency_unblock.go | Core logic change: replaces the bare `FindDependencies` call with a merged union of `FindBlockers(blockerPatterns)` + `FindDependencies`; adds `dependencyUnblockDependencies` and `mergeIssueRefs` helpers — both correct and well-deduped. |
| internal/supervisor/dependency_unblock_test.go | Adds two new tests: one via `Decide()` and one via `RunOnce()`, covering the new blocker-pattern-driven unblock path including label mutations and comment posting. |
| internal/config/config.go | Adds `blocked until.*?#(\d+).*merged` as the second default blocker pattern; one-line change to the defaults slice. |
| internal/config/config_test.go | Extends `TestParse_BlockerPatternsDefault` to include the new `blocked until` pattern in the expected defaults list. |
| docs/fleet-mission-control-runbook.md | Documents the new `blocked until` blocker pattern and the `dependency_unblock` config block in the sample YAML. |
| docs/handoff-epic-format.md | Adds `Blocked by` and `Blocked until` format examples and clarifies the relationship between built-in dependency parsing and `blocker_patterns`. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/supervisor/dependency_unblock.go`, line 115-121 ([link](https://github.com/befeast/maestro/blob/912f1ed45462c3d6e9c022bc4a000df907aca80b/internal/supervisor/dependency_unblock.go#L115-L121)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Function doc comment not updated to mention blocker-pattern dependencies**

   The godoc for `evaluateDependencyUnblock` still says "parses their `Depends on: #N` / `## Dependencies` references" without mentioning the new blocker-pattern path. After this change the function also resolves issues referenced via `blocked by` / `blocked until` patterns. A reader of the comment alone would not know that `cfg.BlockerPatterns` feeds into dependency resolution here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/supervisor/dependency_unblock.go
   Line: 115-121

   Comment:
   **Function doc comment not updated to mention blocker-pattern dependencies**

   The godoc for `evaluateDependencyUnblock` still says "parses their `Depends on: #N` / `## Dependencies` references" without mentioning the new blocker-pattern path. After this change the function also resolves issues referenced via `blocked by` / `blocked until` patterns. A reader of the comment alone would not know that `cfg.BlockerPatterns` feeds into dependency resolution here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/supervisor/dependency_unblock.go:230-232
**Regex compiled on every candidate issue per supervisor cycle**

`github.FindBlockers` calls `regexp.Compile` inside its loop for each pattern on every invocation. `dependencyUnblockDependencies` is called once per blocked candidate per cycle, so with N candidates and M patterns this compiles N×M regexes per cycle. The compile cost is modest for small waves, but it grows with fleet size. Pre-compiling the patterns once (e.g. when the config is loaded, or cached with `sync.Once`) and passing compiled `*regexp.Regexp` values into `FindBlockers` would avoid the repeated allocation with no behaviour change.

### Issue 2 of 2
internal/supervisor/dependency_unblock.go:115-121
**Function doc comment not updated to mention blocker-pattern dependencies**

The godoc for `evaluateDependencyUnblock` still says "parses their `Depends on: #N` / `## Dependencies` references" without mentioning the new blocker-pattern path. After this change the function also resolves issues referenced via `blocked by` / `blocked until` patterns. A reader of the comment alone would not know that `cfg.BlockerPatterns` feeds into dependency resolution here.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["supervisor: wire dependency unblock patt..."](https://github.com/befeast/maestro/commit/912f1ed45462c3d6e9c022bc4a000df907aca80b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35244858)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->