### PR TITLE
Close the loop: advance verified-merged issues out of the open-in-Done limbo

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -262,6 +262,8 @@ func (e *Executor) dispatchAction(approval *state.Approval) Result {
 		return e.executeMergePR(approval)
 	case config.SupervisorActionCloseIssue:
 		return e.executeCloseIssue(approval)
+	case config.SupervisorActionCloseIssueBatch:
+		return e.executeCloseIssueBatch(approval)
 	case config.SupervisorActionDeleteWorktree:
 		return e.executeDeleteWorktree(approval)
 	case config.SupervisorActionStopWorker:
@@ -443,6 +445,45 @@ func (e *Executor) executeCloseIssue(approval *state.Approval) Result {
 	}
 }
 
+func (e *Executor) executeCloseIssueBatch(approval *state.Approval) Result {
+	if approval.Target == nil || len(approval.Target.Issues) == 0 {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: fmt.Errorf("%w: issues missing", ErrMissingTarget)}
+	}
+	if e.GH == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no GitHub client wired into executor")}
+	}
+	comment := strings.TrimSpace(approvalCloseIssueComment(approval))
+	if comment == "" {
+		comment = "Maestro verified the configured runtime outcome after code landed; closing this issue as done."
+	}
+
+	closed := make([]int, 0, len(approval.Target.Issues))
+	for _, target := range approval.Target.Issues {
+		if target.Issue <= 0 {
+			continue
+		}
+		issueComment := comment
+		if target.PR > 0 && issueComment == "Maestro verified the configured runtime outcome after code landed; closing this issue as done." {
+			issueComment = fmt.Sprintf("Maestro verified the configured runtime outcome after PR #%d landed; closing this issue as done.", target.PR)
+		}
+		if err := e.GH.CloseIssue(target.Issue, issueComment); err != nil {
+			return Result{
+				Status:  state.ApprovalStatusExecutionFailed,
+				Summary: fmt.Sprintf("close issue batch after %d/%d issue(s): issue #%d: %v", len(closed), len(approval.Target.Issues), target.Issue, err),
+				Err:     fmt.Errorf("close issue batch: issue #%d: %w", target.Issue, err),
+			}
+		}
+		closed = append(closed, target.Issue)
+	}
+	if len(closed) == 0 {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: fmt.Errorf("%w: no valid issue numbers in batch", ErrMissingTarget)}
+	}
+	return Result{
+		Status:  state.ApprovalStatusExecuted,
+		Summary: fmt.Sprintf("closed %d verified issue(s): %s", len(closed), formatIssueList(closed)),
+	}
+}
+
 func approvalCloseIssueComment(approval *state.Approval) string {
 	// Prefer the operator's reason (it is the most recent audit entry's
 	// Reason for the Approve event). Fall back to the approval Summary.
@@ -455,6 +496,17 @@ func approvalCloseIssueComment(approval *state.Approval) string {
 		}
 	}
 	return strings.TrimSpace(approval.Summary)
+}
+
+func formatIssueList(issues []int) string {
+	if len(issues) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		parts = append(parts, fmt.Sprintf("#%d", issue))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func (e *Executor) executeDeleteWorktree(approval *state.Approval) Result {

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -361,6 +361,31 @@ func TestExecute_CloseIssue_RequiresTarget(t *testing.T) {
 	}
 }
 
+func TestExecute_CloseIssueBatch_ClosesAllTargetsAfterApproval(t *testing.T) {
+	gh := &fakeGH{}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionCloseIssueBatch, &state.SupervisorTarget{
+		Issues: []state.SupervisorIssueTarget{
+			{Issue: 7, PR: 70},
+			{Issue: 8, PR: 80},
+		},
+	}, "", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v, want executed", res)
+	}
+	if len(gh.closeCalls) != 2 {
+		t.Fatalf("closeCalls = %d, want 2: %+v", len(gh.closeCalls), gh.closeCalls)
+	}
+	if gh.closeCalls[0].issue != 7 || !strings.Contains(gh.closeCalls[0].comment, "PR #70") {
+		t.Fatalf("first close call = %+v, want issue #7 comment naming PR #70", gh.closeCalls[0])
+	}
+	if gh.closeCalls[1].issue != 8 || !strings.Contains(gh.closeCalls[1].comment, "PR #80") {
+		t.Fatalf("second close call = %+v, want issue #8 comment naming PR #80", gh.closeCalls[1])
+	}
+}
+
 // --- delete_worktree --------------------------------------------------------
 
 func TestExecute_DeleteWorktree_HappyPath_AnchoredUnderBase(t *testing.T) {

--- a/internal/approver/registry.go
+++ b/internal/approver/registry.go
@@ -25,6 +25,7 @@ package approver
 var KnownApprovalActions = map[string]struct{}{
 	"merge_pr":             {},
 	"close_issue":          {},
+	"close_issue_batch":    {},
 	"delete_worktree":      {},
 	"change_global_config": {}, // executor returns execution_skipped pending YAML pipeline
 	"spawn_worker":         {}, // executor returns awaiting_dispatch (#515)

--- a/internal/approver/registry_test.go
+++ b/internal/approver/registry_test.go
@@ -44,6 +44,7 @@ func TestRegistry_IsKnownApprovalAction(t *testing.T) {
 	}{
 		{"merge_pr", true},
 		{"close_issue", true},
+		{"close_issue_batch", true},
 		{"delete_worktree", true},
 		{"change_global_config", true},
 		{"spawn_worker", true},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,6 +124,7 @@ const (
 	SupervisorActionAddIssueComment    = "add_issue_comment"
 	SupervisorActionMergePR            = "merge_pr"
 	SupervisorActionCloseIssue         = "close_issue"
+	SupervisorActionCloseIssueBatch    = "close_issue_batch"
 	SupervisorActionDeleteWorktree     = "delete_worktree"
 	SupervisorActionChangeGlobalConfig = "change_global_config"
 	// SupervisorActionRestartWorker / SupervisorActionStopWorker are the
@@ -1355,6 +1356,7 @@ func knownSupervisorActions() map[string]bool {
 		SupervisorActionAddIssueComment:    true,
 		SupervisorActionMergePR:            true,
 		SupervisorActionCloseIssue:         true,
+		SupervisorActionCloseIssueBatch:    true,
 		SupervisorActionDeleteWorktree:     true,
 		SupervisorActionChangeGlobalConfig: true,
 		SupervisorActionSpawnReviewRepair:  true,
@@ -1372,6 +1374,7 @@ func knownSupervisorActionNames() []string {
 		SupervisorActionAddIssueComment,
 		SupervisorActionMergePR,
 		SupervisorActionCloseIssue,
+		SupervisorActionCloseIssueBatch,
 		SupervisorActionDeleteWorktree,
 		SupervisorActionChangeGlobalConfig,
 		SupervisorActionSpawnReviewRepair,

--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -19,13 +19,14 @@ const ghTimeout = 30 * time.Second
 type ProjectStatus string
 
 const (
-	ProjectStatusTodo       ProjectStatus = "todo"
-	ProjectStatusInProgress ProjectStatus = "in_progress"
-	ProjectStatusInReview   ProjectStatus = "in_review"
-	ProjectStatusBlocked    ProjectStatus = "blocked"
-	ProjectStatusDeploying  ProjectStatus = "deploying"
-	ProjectStatusLiveVerify ProjectStatus = "live_verification"
-	ProjectStatusDone       ProjectStatus = "done"
+	ProjectStatusTodo          ProjectStatus = "todo"
+	ProjectStatusInProgress    ProjectStatus = "in_progress"
+	ProjectStatusInReview      ProjectStatus = "in_review"
+	ProjectStatusBlocked       ProjectStatus = "blocked"
+	ProjectStatusDeploying     ProjectStatus = "deploying"
+	ProjectStatusLiveVerify    ProjectStatus = "live_verification"
+	ProjectStatusAwaitingClose ProjectStatus = "verified_awaiting_close"
+	ProjectStatusDone          ProjectStatus = "done"
 )
 
 // ProjectStatusCandidates returns the ordered list of column names to try when
@@ -49,6 +50,8 @@ func ProjectStatusCandidates(status ProjectStatus) []string {
 		return []string{"Deploying", "Deploy", "Deployment"}
 	case ProjectStatusLiveVerify:
 		return []string{"Live Verification", "Verification", "Verifying", "QA"}
+	case ProjectStatusAwaitingClose:
+		return []string{"Verified — awaiting close", "Verified - awaiting close", "Awaiting Close", "Ready to Close"}
 	case ProjectStatusDone:
 		return []string{"Done", "Completed", "Closed"}
 	default:

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -192,6 +192,7 @@ func TestProjectStatusCandidates(t *testing.T) {
 		{ProjectStatusBlocked, "Blocked"},
 		{ProjectStatusDeploying, "Deploying"},
 		{ProjectStatusLiveVerify, "Live Verification"},
+		{ProjectStatusAwaitingClose, "Verified — awaiting close"},
 		{ProjectStatusDone, "Done"},
 	}
 	for _, tc := range tests {

--- a/internal/orchestrator/completion_gates_test.go
+++ b/internal/orchestrator/completion_gates_test.go
@@ -178,6 +178,52 @@ func TestReconcile_CompletionGatesInactiveLegacyPath(t *testing.T) {
 	}
 }
 
+func TestMarkDoneAfterOutcomePass_GatedCloseSyncsAwaitingClose(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		GitHubProjects: config.GitHubProjectsConfig{
+			Enabled:       true,
+			ProjectNumber: 1,
+		},
+		Supervisor: config.SupervisorConfig{
+			SafeActions:      []string{config.SupervisorActionCloseIssue},
+			ApprovalRequired: []string{config.SupervisorActionCloseIssue},
+		},
+	}
+	now := time.Now().UTC()
+	closeCalled := 0
+	statuses := []github.ProjectStatus{}
+	o := &Orchestrator{
+		cfg:                  cfg,
+		projectRateAllowed:   true,
+		projectRateCheckedAt: now,
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			closeCalled++
+			return nil
+		},
+		syncProjectFn: func(issueNumber int, status github.ProjectStatus) bool {
+			statuses = append(statuses, status)
+			return true
+		},
+	}
+	sess := &state.Session{IssueNumber: 621, Status: state.StatusCodeLanded, PRNumber: 99}
+
+	o.markDoneAfterOutcomePass(sess, 99)
+
+	if sess.Status != state.StatusDone {
+		t.Fatalf("status = %q, want done after outcome pass", sess.Status)
+	}
+	if closeCalled != 0 {
+		t.Fatalf("CloseIssue called %d times; approval-gated close must not bypass cautious gate", closeCalled)
+	}
+	if len(statuses) != 1 || statuses[0] != github.ProjectStatusAwaitingClose {
+		t.Fatalf("project statuses = %v, want [verified awaiting close]", statuses)
+	}
+}
+
 // TestMarkDoneAfterOutcomePass_BodyMarkerHoldsClose covers the case where
 // the issue carries no special label but its body contains a configured
 // marker (e.g. "live visual command:").

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2742,8 +2742,11 @@ func (o *Orchestrator) markDoneAfterOutcomePass(sess *state.Session, prNumber in
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
 	state.MarkWorkerEnded(sess, now)
-	o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
-	o.closeVerifiedIssueIfAllowed(sess, prNumber)
+	if o.closeVerifiedIssueIfAllowed(sess, prNumber) {
+		o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
+		return
+	}
+	o.syncProject(sess.IssueNumber, github.ProjectStatusAwaitingClose)
 }
 
 // completionGatesRequireLiveVerification returns true when the supervisor
@@ -2876,20 +2879,20 @@ func (o *Orchestrator) codeLandedPRMerged(sess *state.Session) bool {
 	return merged
 }
 
-func (o *Orchestrator) closeVerifiedIssueIfAllowed(sess *state.Session, prNumber int) {
+func (o *Orchestrator) closeVerifiedIssueIfAllowed(sess *state.Session, prNumber int) bool {
 	if o == nil || o.cfg == nil || sess == nil || sess.IssueNumber <= 0 {
-		return
+		return false
 	}
 	if !o.supervisorActionAllowed(config.SupervisorActionCloseIssue) || o.supervisorActionRequiresApproval(config.SupervisorActionCloseIssue) {
-		return
+		return false
 	}
 	closed, err := o.isIssueClosed(sess.IssueNumber)
 	if err != nil {
 		log.Printf("[orch] verified issue #%d was not auto-closed because issue state could not be checked: %v", sess.IssueNumber, err)
-		return
+		return false
 	}
 	if closed {
-		return
+		return true
 	}
 	comment := "Maestro verified the configured runtime outcome after code landed; closing this issue as done."
 	if prNumber > 0 {
@@ -2900,11 +2903,12 @@ func (o *Orchestrator) closeVerifiedIssueIfAllowed(sess *state.Session, prNumber
 		if o.notifier != nil {
 			o.notifier.Sendf("⚠️ maestro: verified issue #%d is done but auto-close failed: %v", sess.IssueNumber, err)
 		}
-		return
+		return false
 	}
 	if o.notifier != nil {
 		o.notifier.Sendf("✅ maestro: closed verified issue #%d after code_landed outcome pass", sess.IssueNumber)
 	}
+	return true
 }
 
 func (o *Orchestrator) supervisorActionAllowed(action string) bool {

--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -182,6 +183,7 @@ func isApprovalRequiredAction(id string) bool {
 	switch id {
 	case config.SupervisorActionMergePR,
 		config.SupervisorActionCloseIssue,
+		config.SupervisorActionCloseIssueBatch,
 		config.SupervisorActionDeleteWorktree,
 		config.SupervisorActionChangeGlobalConfig,
 		// #565: review-repair respawn is approval-gated (RiskMutating);
@@ -395,6 +397,10 @@ func validateApprovalRequest(id string, req controlActionRequest) error {
 		if req.IssueNumber <= 0 {
 			return errors.New("issue_number is required for close_issue")
 		}
+	case config.SupervisorActionCloseIssueBatch:
+		if len(normalizeCloseIssueBatch(req.Issues)) == 0 {
+			return errors.New("issues is required for close_issue_batch")
+		}
 	case config.SupervisorActionDeleteWorktree:
 		if err := state.ValidateSlotID(req.Slot); err != nil {
 			return fmt.Errorf("delete_worktree: %w", err)
@@ -443,9 +449,10 @@ func buildApprovalDecision(id string, req controlActionRequest, cfg *config.Conf
 	target := &state.SupervisorTarget{
 		Issue:   req.IssueNumber,
 		PR:      req.PRNumber,
+		Issues:  normalizeCloseIssueBatch(req.Issues),
 		Session: strings.TrimSpace(req.Slot),
 	}
-	if target.Issue == 0 && target.PR == 0 && target.Session == "" {
+	if target.Issue == 0 && target.PR == 0 && len(target.Issues) == 0 && target.Session == "" {
 		target = nil
 	}
 
@@ -483,10 +490,42 @@ func approvalTargetSummary(target *state.SupervisorTarget) string {
 	if target.PR > 0 {
 		parts = append(parts, fmt.Sprintf("PR #%d", target.PR))
 	}
+	if len(target.Issues) > 0 {
+		parts = append(parts, fmt.Sprintf("%d issues", len(target.Issues)))
+	}
 	if target.Session != "" {
 		parts = append(parts, "session "+target.Session)
 	}
 	return strings.Join(parts, " ")
+}
+
+func normalizeCloseIssueBatch(in []state.SupervisorIssueTarget) []state.SupervisorIssueTarget {
+	if len(in) == 0 {
+		return nil
+	}
+	byIssue := make(map[int]state.SupervisorIssueTarget, len(in))
+	for _, item := range in {
+		if item.Issue <= 0 {
+			continue
+		}
+		existing := byIssue[item.Issue]
+		if existing.Issue == 0 || existing.PR <= 0 {
+			byIssue[item.Issue] = item
+		}
+	}
+	if len(byIssue) == 0 {
+		return nil
+	}
+	issues := make([]int, 0, len(byIssue))
+	for issue := range byIssue {
+		issues = append(issues, issue)
+	}
+	sort.Ints(issues)
+	out := make([]state.SupervisorIssueTarget, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, byIssue[issue])
+	}
+	return out
 }
 
 // randomDecisionSuffix returns a short random hex token used to

--- a/internal/server/approval_action_test.go
+++ b/internal/server/approval_action_test.go
@@ -123,6 +123,29 @@ func TestApprovalAction_CloseIssue_Enqueues202(t *testing.T) {
 	}
 }
 
+func TestApprovalAction_CloseIssueBatch_EnqueuesOneApproval(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	gh := &fakeActionGH{}
+	srv := New(cfg, nil)
+	srv.SetActionDeps(gh, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"close_issue_batch","issues":[{"issue":7,"pr":70},{"issue":8,"pr":80}],"reason":"verified backlog"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if len(gh.commentCalls)+len(gh.addLabelCalls)+len(gh.removeLabelCalls) != 0 {
+		t.Fatalf("safe-action GitHub client was touched during approval enqueue")
+	}
+	st := loadStateAt(t, dir)
+	if len(st.Approvals) != 1 {
+		t.Fatalf("approvals = %d, want 1", len(st.Approvals))
+	}
+	got := st.Approvals[0]
+	if got.Action != config.SupervisorActionCloseIssueBatch || got.Target == nil || len(got.Target.Issues) != 2 {
+		t.Fatalf("approval = %+v, want close_issue_batch with two targets", got)
+	}
+}
+
 func TestApprovalAction_DeleteWorktree_Enqueues202(t *testing.T) {
 	cfg, dir := approvalEnqueueCfg(t)
 	srv := New(cfg, nil)

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -482,6 +482,7 @@ type fleetProjectState struct {
 	Approvals       []fleetApprovalState  `json:"approvals,omitempty"`
 	ApprovalSummary map[string]int        `json:"approval_summary,omitempty"`
 	Actions         []controlAction       `json:"actions,omitempty"`
+	CloseCandidates []fleetCloseCandidate `json:"close_candidates,omitempty"`
 	Supervisor      supervisorInfo        `json:"supervisor"`
 	QueueSnapshot   *fleetQueueSnapshot   `json:"queue_snapshot,omitempty"`
 	Freshness       fleetProjectFreshness `json:"freshness"`
@@ -511,6 +512,15 @@ type fleetProjectState struct {
 	// USD windows per backend and per issue (#619). Backends without
 	// pricing configured render in the SPA as tokens only.
 	CostObservability fleetCostObservability `json:"cost_observability"`
+}
+
+type fleetCloseCandidate struct {
+	IssueNumber int    `json:"issue_number"`
+	IssueURL    string `json:"issue_url,omitempty"`
+	PRNumber    int    `json:"pr_number,omitempty"`
+	PRURL       string `json:"pr_url,omitempty"`
+	Session     string `json:"session,omitempty"`
+	FinishedAt  string `json:"finished_at,omitempty"`
 }
 
 // fleetSupervisorPulse describes the supervisor's liveness, cadence and
@@ -788,6 +798,11 @@ func (s *FleetServer) handleFleetAction(w http.ResponseWriter, r *http.Request) 
 		cfg = project.cfg
 		gh = project.actionGH
 		audit = s.fleetActionAudit(project)
+	}
+	if translateUIActionID(strings.TrimSpace(req.ActionID)) == config.SupervisorActionCloseIssueBatch && len(req.Issues) == 0 && cfg != nil {
+		if st, err := state.Load(cfg.StateDir); err == nil {
+			req.Issues = fleetCloseCandidateTargets(fleetCloseCandidates(fleetProjectState{Name: project.Name, Repo: cfg.Repo}, st))
+		}
 	}
 
 	if res := dispatchSafeAction(req, cfg, gh, audit, authenticatedActor); res.handled {
@@ -1639,6 +1654,8 @@ func fleetNextActionCTAForApproval(approval *fleetApprovalState) string {
 			return fmt.Sprintf("Close issue #%d", approval.IssueNumber)
 		}
 		return "Close issue"
+	case config.SupervisorActionCloseIssueBatch:
+		return "Close verified issues"
 	case "delete_worktree":
 		return "Delete worktree"
 	case "change_global_config":
@@ -2206,6 +2223,10 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	item.Freshness = fleetProjectFreshnessForState(cfg.StateDir, st, now)
 	item.RestartRequired = st.RestartRequired
 	item.RestartRequiredReason = st.RestartRequiredReason
+	item.CloseCandidates = fleetCloseCandidates(item, st)
+	if len(item.CloseCandidates) > 0 {
+		item.Actions = append(item.Actions, closeIssueBatchControlAction(item.ReadOnly, "/api/v1/fleet/actions", item.Name, item.CloseCandidates))
+	}
 	// #600: normalize stale cooldown entries for display so the BACKENDS
 	// panel matches reality between orchestrator cycles — RetryAfter in
 	// the past, max-cooldown TTL elapsed, or a successful PR-evidence
@@ -2270,6 +2291,79 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	}
 	item.OperatorState = buildFleetProjectOperatorState(item)
 	return item, workers
+}
+
+func fleetCloseCandidates(project fleetProjectState, st *state.State) []fleetCloseCandidate {
+	if st == nil {
+		return nil
+	}
+	alreadyClosed := fleetIssuesCoveredByExecutedCloseApproval(st)
+	candidates := make([]fleetCloseCandidate, 0)
+	for slot, sess := range st.Sessions {
+		if sess == nil || sess.IssueNumber <= 0 || sess.PRNumber <= 0 || sess.Status != state.StatusDone {
+			continue
+		}
+		if alreadyClosed[sess.IssueNumber] {
+			continue
+		}
+		candidates = append(candidates, fleetCloseCandidate{
+			IssueNumber: sess.IssueNumber,
+			IssueURL:    githubIssueURL(project.Repo, sess.IssueNumber),
+			PRNumber:    sess.PRNumber,
+			PRURL:       githubPRURL(project.Repo, sess.PRNumber),
+			Session:     slot,
+			FinishedAt:  formatOptionalFleetTime(sess.FinishedAt),
+		})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].IssueNumber != candidates[j].IssueNumber {
+			return candidates[i].IssueNumber < candidates[j].IssueNumber
+		}
+		return candidates[i].PRNumber < candidates[j].PRNumber
+	})
+	return candidates
+}
+
+func fleetCloseCandidateTargets(candidates []fleetCloseCandidate) []state.SupervisorIssueTarget {
+	if len(candidates) == 0 {
+		return nil
+	}
+	out := make([]state.SupervisorIssueTarget, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.IssueNumber <= 0 {
+			continue
+		}
+		out = append(out, state.SupervisorIssueTarget{Issue: candidate.IssueNumber, PR: candidate.PRNumber})
+	}
+	return out
+}
+
+func fleetIssuesCoveredByExecutedCloseApproval(st *state.State) map[int]bool {
+	covered := make(map[int]bool)
+	if st == nil {
+		return covered
+	}
+	for _, approval := range st.Approvals {
+		if approval.Status != state.ApprovalStatusExecuted {
+			continue
+		}
+		switch approval.Action {
+		case config.SupervisorActionCloseIssue:
+			if approval.Target != nil && approval.Target.Issue > 0 {
+				covered[approval.Target.Issue] = true
+			}
+		case config.SupervisorActionCloseIssueBatch:
+			if approval.Target == nil {
+				continue
+			}
+			for _, target := range approval.Target.Issues {
+				if target.Issue > 0 {
+					covered[target.Issue] = true
+				}
+			}
+		}
+	}
+	return covered
 }
 
 func reconcileStaleSessions(cfg *config.Config, st *state.State, now time.Time) []state.StaleSessionAudit {
@@ -3101,6 +3195,13 @@ func formatFleetTime(t time.Time) string {
 		return ""
 	}
 	return t.Format(time.RFC3339)
+}
+
+func formatOptionalFleetTime(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return formatFleetTime(*t)
 }
 
 // fleetSupervisorPulseRecentLimit caps the number of recommended_action

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -208,8 +208,8 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	for _, action := range worker.Actions {
 		assertFleetReadOnlyAction(t, action)
 	}
-	if len(resp.Projects[0].Actions) != 2 {
-		t.Fatalf("project actions = %d, want 2", len(resp.Projects[0].Actions))
+	if len(resp.Projects[0].Actions) != 3 {
+		t.Fatalf("project actions = %d, want 3", len(resp.Projects[0].Actions))
 	}
 	for _, action := range resp.Projects[0].Actions {
 		assertFleetReadOnlyAction(t, action)
@@ -3799,6 +3799,50 @@ func saveFleetTestState(t *testing.T, dir string, sessions map[string]*state.Ses
 // has its GitHub Project board client wired, the snapshot exposes a
 // project_board with the canonical URL and the per-column WIP counts the
 // MC SPA renders on the project drawer.
+func TestFleetAPIIncludesCloseCandidatesAndBatchAction(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:        "owner/repo",
+		StateDir:    dir,
+		MaxParallel: 2,
+	}
+	finished := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["sup-1"] = &state.Session{IssueNumber: 7, PRNumber: 70, Status: state.StatusDone, FinishedAt: &finished}
+	st.Sessions["sup-2"] = &state.Session{IssueNumber: 8, PRNumber: 80, Status: state.StatusDone, FinishedAt: &finished}
+	st.Approvals = append(st.Approvals, state.Approval{
+		Action: config.SupervisorActionCloseIssue,
+		Status: state.ApprovalStatusExecuted,
+		Target: &state.SupervisorTarget{Issue: 8},
+	})
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	fleet := NewFleet([]FleetProject{NewFleetProject("Project", "", "", cfg)}, "127.0.0.1", 0, false)
+	resp := fleet.snapshot()
+	if len(resp.Projects) != 1 {
+		t.Fatalf("projects = %d, want 1", len(resp.Projects))
+	}
+	project := resp.Projects[0]
+	if len(project.CloseCandidates) != 1 || project.CloseCandidates[0].IssueNumber != 7 || project.CloseCandidates[0].PRNumber != 70 {
+		t.Fatalf("close candidates = %+v, want only issue #7 / PR #70", project.CloseCandidates)
+	}
+	var batch *controlAction
+	for i := range project.Actions {
+		if project.Actions[i].ID == config.SupervisorActionCloseIssueBatch {
+			batch = &project.Actions[i]
+			break
+		}
+	}
+	if batch == nil {
+		t.Fatalf("project actions = %+v, want close_issue_batch action", project.Actions)
+	}
+	if !batch.RequiresApproval || len(batch.Issues) != 1 || batch.Issues[0].Issue != 7 {
+		t.Fatalf("batch action = %+v, want one approval-gated issue target", batch)
+	}
+}
+
 func TestFleetAPIIncludesProjectBoardSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "one")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -229,29 +229,31 @@ type tokenTotalsInfo struct {
 }
 
 type controlAction struct {
-	ID               string `json:"id"`
-	Label            string `json:"label"`
-	Description      string `json:"description,omitempty"`
-	Scope            string `json:"scope"`
-	Target           string `json:"target,omitempty"`
-	IssueNumber      int    `json:"issue_number,omitempty"`
-	PRNumber         int    `json:"pr_number,omitempty"`
-	Mutating         bool   `json:"mutating"`
-	RequiresApproval bool   `json:"requires_approval"`
-	ApprovalPolicy   string `json:"approval_policy,omitempty"`
-	Disabled         bool   `json:"disabled"`
-	DisabledReason   string `json:"disabled_reason,omitempty"`
-	Method           string `json:"method,omitempty"`
-	Endpoint         string `json:"endpoint,omitempty"`
+	ID               string                        `json:"id"`
+	Label            string                        `json:"label"`
+	Description      string                        `json:"description,omitempty"`
+	Scope            string                        `json:"scope"`
+	Target           string                        `json:"target,omitempty"`
+	IssueNumber      int                           `json:"issue_number,omitempty"`
+	PRNumber         int                           `json:"pr_number,omitempty"`
+	Issues           []state.SupervisorIssueTarget `json:"issues,omitempty"`
+	Mutating         bool                          `json:"mutating"`
+	RequiresApproval bool                          `json:"requires_approval"`
+	ApprovalPolicy   string                        `json:"approval_policy,omitempty"`
+	Disabled         bool                          `json:"disabled"`
+	DisabledReason   string                        `json:"disabled_reason,omitempty"`
+	Method           string                        `json:"method,omitempty"`
+	Endpoint         string                        `json:"endpoint,omitempty"`
 }
 
 type controlActionRequest struct {
-	ActionID    string `json:"action_id"`
-	Project     string `json:"project,omitempty"`
-	Slot        string `json:"slot,omitempty"`
-	IssueNumber int    `json:"issue_number,omitempty"`
-	PRNumber    int    `json:"pr_number,omitempty"`
-	ApprovalID  string `json:"approval_id,omitempty"`
+	ActionID    string                        `json:"action_id"`
+	Project     string                        `json:"project,omitempty"`
+	Slot        string                        `json:"slot,omitempty"`
+	IssueNumber int                           `json:"issue_number,omitempty"`
+	PRNumber    int                           `json:"pr_number,omitempty"`
+	Issues      []state.SupervisorIssueTarget `json:"issues,omitempty"`
+	ApprovalID  string                        `json:"approval_id,omitempty"`
 
 	// Body is the comment text for add_issue_comment safe actions.
 	Body string `json:"body,omitempty"`
@@ -816,6 +818,12 @@ func projectActionAffordances(readOnly bool, endpoint, target string) []controlA
 		newSafeControlAction("mark_issue_ready", "Mark ready", "Add the maestro-ready label so the supervisor picks the issue up.", "project", target, 0, 0, endpoint, readOnly),
 		newSafeControlAction("mark_issue_blocked", "Mark blocked", "Add the blocked label so the supervisor holds the issue.", "project", target, 0, 0, endpoint, readOnly),
 	}
+}
+
+func closeIssueBatchControlAction(readOnly bool, endpoint, target string, candidates []fleetCloseCandidate) controlAction {
+	a := newApprovalControlAction(config.SupervisorActionCloseIssueBatch, "Close batch", "Enqueue one cautious-gate approval to close all verified merged issues awaiting closure.", "project", target, 0, 0, endpoint, readOnly)
+	a.Issues = fleetCloseCandidateTargets(candidates)
+	return a
 }
 
 func workerActionAffordances(readOnly bool, endpoint string, worker sessionInfo) []controlAction {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -466,6 +466,9 @@ var (
 type SupervisorTarget struct {
 	Issue int `json:"issue,omitempty"`
 	PR    int `json:"pr,omitempty"`
+	// Issues carries a batch of verified merged issue candidates for one
+	// cautious-gate close approval. Single-issue verbs keep using Issue/PR.
+	Issues []SupervisorIssueTarget `json:"issues,omitempty"`
 	// HeadSHA stamps the PR head SHA at decision time. Used by the
 	// review-repair pipeline (#565) so a decision is keyed on the exact
 	// head it observed; a new push that moves head invalidates a pending
@@ -473,6 +476,11 @@ type SupervisorTarget struct {
 	// include the target).
 	HeadSHA string `json:"head_sha,omitempty"`
 	Session string `json:"session,omitempty"`
+}
+
+type SupervisorIssueTarget struct {
+	Issue int `json:"issue"`
+	PR    int `json:"pr,omitempty"`
 }
 
 // SupervisorProjectState captures the read-only state snapshot behind a decision.
@@ -1703,11 +1711,26 @@ func approvalTargetsEqual(a, b *SupervisorTarget) bool {
 	if a.PR != b.PR {
 		return false
 	}
+	if !supervisorIssueTargetsEqual(a.Issues, b.Issues) {
+		return false
+	}
 	if strings.TrimSpace(a.HeadSHA) != strings.TrimSpace(b.HeadSHA) {
 		return false
 	}
 	if strings.TrimSpace(a.Session) != strings.TrimSpace(b.Session) {
 		return false
+	}
+	return true
+}
+
+func supervisorIssueTargetsEqual(a, b []SupervisorIssueTarget) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Issue != b[i].Issue || a[i].PR != b[i].PR {
+			return false
+		}
 	}
 	return true
 }
@@ -2003,6 +2026,14 @@ func approvalTargetMatches(target *SupervisorTarget, slot string, sess *Session)
 	if target.PR > 0 && target.PR == sess.PRNumber {
 		return true
 	}
+	for _, issue := range target.Issues {
+		if issue.Issue > 0 && issue.Issue == sess.IssueNumber {
+			return true
+		}
+		if issue.PR > 0 && issue.PR == sess.PRNumber {
+			return true
+		}
+	}
 	return false
 }
 
@@ -2011,6 +2042,7 @@ func cloneSupervisorTarget(target *SupervisorTarget) *SupervisorTarget {
 		return nil
 	}
 	clone := *target
+	clone.Issues = append([]SupervisorIssueTarget(nil), target.Issues...)
 	return &clone
 }
 

--- a/internal/supervisor/approval_gate_test.go
+++ b/internal/supervisor/approval_gate_test.go
@@ -21,6 +21,7 @@ func cautiousApprovalCfg() *config.Config {
 	cfg.Supervisor.ApprovalRequired = []string{
 		config.SupervisorActionMergePR,
 		config.SupervisorActionCloseIssue,
+		config.SupervisorActionCloseIssueBatch,
 		config.SupervisorActionDeleteWorktree,
 		config.SupervisorActionChangeGlobalConfig,
 	}
@@ -31,6 +32,7 @@ func TestCanonicalAction_MutatingVerbsPassthrough(t *testing.T) {
 	verbs := []string{
 		config.SupervisorActionMergePR,
 		config.SupervisorActionCloseIssue,
+		config.SupervisorActionCloseIssueBatch,
 		config.SupervisorActionDeleteWorktree,
 		config.SupervisorActionChangeGlobalConfig,
 	}
@@ -50,6 +52,7 @@ func TestDecisionRequiresApproval_GatesMutatingVerbs(t *testing.T) {
 	verbs := []string{
 		config.SupervisorActionMergePR,
 		config.SupervisorActionCloseIssue,
+		config.SupervisorActionCloseIssueBatch,
 		config.SupervisorActionDeleteWorktree,
 		config.SupervisorActionChangeGlobalConfig,
 	}

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -403,6 +403,8 @@ func canonicalAction(action string) string {
 		return ActionMergePR
 	case config.SupervisorActionCloseIssue:
 		return config.SupervisorActionCloseIssue
+	case config.SupervisorActionCloseIssueBatch:
+		return config.SupervisorActionCloseIssueBatch
 	case config.SupervisorActionDeleteWorktree:
 		return config.SupervisorActionDeleteWorktree
 	case config.SupervisorActionChangeGlobalConfig:


### PR DESCRIPTION
Refs #621

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the \"open-in-Done\" limbo by wiring a new `close_issue_batch` action that lets operators approve a single cautious-gate to bulk-close all verified-merged issues, and by making `markDoneAfterOutcomePass` sync to a new `verified_awaiting_close` project-board column when the issue cannot be auto-closed.

- Adds `SupervisorActionCloseIssueBatch` end-to-end: config constant, executor handler, registry entry, fleet snapshot surfacing close candidates, server control action, and approval-gating — with matching tests across all layers.
- Changes `closeVerifiedIssueIfAllowed` to return `bool` so `markDoneAfterOutcomePass` can branch between syncing to `Done` (immediate auto-close) versus `AwaitingClose` (approval required).
- Deduplication of batch targets is sorted and normalised in `normalizeCloseIssueBatch`; `supervisorIssueTargetsEqual` provides positional equality for the existing approval-dedup path in `EnqueueApproval`.

<h3>Confidence Score: 3/5</h3>

Safe to review and iterate on; two functional gaps in the batch-close flow should be addressed before the feature is relied upon in production.

The orchestrator and state changes are clean. The two concerns are in the batch executor and the fleet snapshot. When executeCloseIssueBatch fails mid-batch, the approval is recorded as ExecutionFailed even though some issues were already closed on GitHub; those issues re-surface as candidates on the next snapshot and require another approval round — compounding the problem if GH.CloseIssue is not idempotent for already-closed issues. Additionally, pending, approved, and awaiting-dispatch batch approvals are invisible to the close-candidates filter, so the Close batch UI action remains active while an approval is already in flight; a new session completing in that window produces a different target, supersedes the in-flight approval, and silently resets the operator's review cycle.

internal/approver/executor.go (partial-failure handling in executeCloseIssueBatch) and internal/server/fleet.go (fleetIssuesCoveredByExecutedCloseApproval status filter)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/approver/executor.go | Adds executeCloseIssueBatch with fail-fast error handling; partial failures leave already-closed issues re-appearing as candidates and a brittle string-equality check gates PR-specific comments. |
| internal/server/fleet.go | Adds close-candidate discovery and batch-close control action; fleetIssuesCoveredByExecutedCloseApproval only filters executed approvals, leaving pending-approval issues visible in the UI action. |
| internal/orchestrator/orchestrator.go | closeVerifiedIssueIfAllowed now returns bool; markDoneAfterOutcomePass branches on this to sync either Done or AwaitingClose to the project board — logic is correct. |
| internal/state/state.go | SupervisorIssueTarget added; approvalTargetsEqual extended with supervisorIssueTargetsEqual; approvalTargetMatches extended for batch issues; cloneSupervisorTarget correctly deep-copies the Issues slice. |
| internal/server/actions.go | Adds normalizeCloseIssueBatch (dedup+sort by issue number), wires Issues into buildApprovalDecision, and adds close_issue_batch to the approval-required action list. |
| internal/github/github_projects.go | Adds ProjectStatusAwaitingClose constant and its column name candidates; straightforward and correct. |
| internal/config/config.go | Registers SupervisorActionCloseIssueBatch in knownSupervisorActions and knownSupervisorActionNames; consistent with other action additions. |
| internal/server/server.go | Adds Issues field to controlAction and controlActionRequest structs, and closeIssueBatchControlAction helper; no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/approver/executor.go:469-477
**Partial failure leaves already-closed issues as candidates on next refresh**

When `CloseIssue` succeeds for the first _k_ issues and then fails on issue _k+1_, the function returns `ApprovalStatusExecutionFailed`. Because `fleetIssuesCoveredByExecutedCloseApproval` only considers `ApprovalStatusExecuted` approvals when building the close-candidates set, all issues in the batch (including the ones that were already successfully closed at the GitHub layer) will reappear as candidates on the next snapshot. The operator must approve a second batch covering those already-closed issues. If `GH.CloseIssue` is not idempotent for already-closed issues, the re-submission will fail immediately, making recovery impossible without manual intervention. Consider using a partial-success status or tracking per-issue outcome so already-closed issues are excluded on the next pass.

### Issue 2 of 3
internal/server/fleet.go:2341-2367
**Pending batch approvals are invisible to the close-candidates filter**

`fleetIssuesCoveredByExecutedCloseApproval` skips every approval whose status isn't `ApprovalStatusExecuted`. This means issues already covered by a pending (`Pending` / `Approved` / `AwaitingDispatch`) batch approval still appear in `CloseCandidates` and the "Close batch" button remains visible. A user who clicks it again triggers `handleFleetAction`, which auto-populates the issues list and calls through to `EnqueueApproval`. Server-side dedup (`approvalTargetsEqual`) prevents a literal duplicate only when the candidate set is unchanged; if a new session completes in the interval, the target differs, the pending approval is superseded, and a fresh one is created — resetting the approval clock without the operator realising. At minimum, extend the filter to also skip `Pending`, `Approved`, and `AwaitingDispatch` statuses so the button disappears while an approval is in flight.

### Issue 3 of 3
internal/approver/executor.go:455-468
The condition comparing `issueComment` to a hardcoded string literal is fragile — any future edit to the default comment text silently breaks PR-specific message injection for all batch targets that have a PR. Introducing a sentinel boolean avoids the brittle equality check.

```suggestion
	const defaultComment = "Maestro verified the configured runtime outcome after code landed; closing this issue as done."
	comment := strings.TrimSpace(approvalCloseIssueComment(approval))
	useDefault := comment == ""
	if useDefault {
		comment = defaultComment
	}

	closed := make([]int, 0, len(approval.Target.Issues))
	for _, target := range approval.Target.Issues {
		if target.Issue <= 0 {
			continue
		}
		issueComment := comment
		if useDefault && target.PR > 0 {
			issueComment = fmt.Sprintf("Maestro verified the configured runtime outcome after PR #%d landed; closing this issue as done.", target.PR)
		}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add gated verified issue close batch"](https://github.com/befeast/maestro/commit/9fc190691cb60597bd9270f409689febb64e016f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35249559)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->