### PR TITLE
cost-obs: token capture never populates — ParseTokensFromOutput regexes don't match real codex/claude CLI output

### DIFF
--- a/internal/worker/tokens.go
+++ b/internal/worker/tokens.go
@@ -22,21 +22,110 @@ var tokenPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)\btotal[_ ]tokens[:\s]+(\d[\d,]*)`),
 }
 
+// codexTwoLineKeyword matches the codex "tokens used" header line that
+// precedes a number-only line (the modern codex CLI splits the total
+// across two lines, e.g. "tokens used\n89,655"). The keyword line is
+// allowed to carry a leading prefix (timestamps, log tags) but must end
+// with the phrase.
+var codexTwoLineKeyword = regexp.MustCompile(`(?i)(?:^|[\s\]])tokens used\s*$`)
+
+// numericLine matches a line that is just a (possibly comma-grouped)
+// integer, used as the value pairing for codexTwoLineKeyword.
+var numericLine = regexp.MustCompile(`^(\d[\d,]*)\s*$`)
+
+// jsonInputTokens / jsonOutputTokens extract the per-call usage totals
+// from claude --output-format json (and stream-json) result objects.
+// The result frame carries a single "usage" block with both fields; in
+// stream-json the trailing result frame still has them, so taking the
+// last match of each on the buffered output reflects the run total.
+var jsonInputTokens = regexp.MustCompile(`"input_tokens"\s*:\s*(\d+)`)
+var jsonOutputTokens = regexp.MustCompile(`"output_tokens"\s*:\s*(\d+)`)
+
 // ParseTokensFromOutput scans multi-line text for token-usage lines and
 // returns the maximum total count found (0 if none matched).
 // Commas in numbers are stripped before parsing.
+//
+// Three families of producers are recognised:
+//
+//  1. Single-line totals — see tokenPatterns above.
+//
+//  2. The codex "two-line" form, where the keyword and the count live on
+//     adjacent lines:
+//
+//     tokens used
+//     89,655
+//
+//  3. JSON "usage" objects (claude --output-format json / stream-json):
+//
+//     "usage": {"input_tokens": 123, "output_tokens": 456}
+//
+// claude's default text mode (`claude -p ...`) does NOT print a
+// parseable token total to stdout — token capture for claude requires
+// running with `--output-format json` (and `--verbose` for stream-json).
+// Workers that run claude in default mode degrade to tokens=0; the
+// cost-observability rollup already skips zero-token sessions and
+// reports "price not configured" rather than a misleading total.
 func ParseTokensFromOutput(text string) int {
-	max := 0
-	for _, line := range strings.Split(text, "\n") {
-		line = strings.TrimSpace(line)
+	maxTokens := 0
+	lines := strings.Split(text, "\n")
+
+	for i, raw := range lines {
+		line := strings.TrimSpace(raw)
 		if line == "" {
 			continue
 		}
-		if n := parseTokensFromLine(line); n > max {
-			max = n
+		if n := parseTokensFromLine(line); n > maxTokens {
+			maxTokens = n
+		}
+		if codexTwoLineKeyword.MatchString(line) {
+			if n := nextNumericValue(lines, i+1); n > maxTokens {
+				maxTokens = n
+			}
 		}
 	}
-	return max
+
+	if n := parseJSONUsage(text); n > maxTokens {
+		maxTokens = n
+	}
+
+	return maxTokens
+}
+
+// nextNumericValue returns the integer on the first non-empty line at or
+// after start that consists solely of a (comma-grouped) number, or 0 if
+// the next non-empty line is something else. Used to pair a codex
+// "tokens used" header with its count line.
+func nextNumericValue(lines []string, start int) int {
+	for j := start; j < len(lines); j++ {
+		next := strings.TrimSpace(lines[j])
+		if next == "" {
+			continue
+		}
+		if m := numericLine.FindStringSubmatch(next); m != nil {
+			return parseNum(m[1])
+		}
+		return 0
+	}
+	return 0
+}
+
+// parseJSONUsage extracts the run-total token count from a claude
+// `--output-format json` (or stream-json) buffer by summing the last
+// `"input_tokens"` and `"output_tokens"` values found. Returns 0 when
+// neither field appears.
+func parseJSONUsage(text string) int {
+	in := lastIntMatch(jsonInputTokens, text)
+	out := lastIntMatch(jsonOutputTokens, text)
+	return in + out
+}
+
+func lastIntMatch(re *regexp.Regexp, s string) int {
+	ms := re.FindAllStringSubmatch(s, -1)
+	if len(ms) == 0 {
+		return 0
+	}
+	n, _ := strconv.Atoi(ms[len(ms)-1][1])
+	return n
 }
 
 func parseTokensFromLine(line string) int {

--- a/internal/worker/tokens_test.go
+++ b/internal/worker/tokens_test.go
@@ -70,6 +70,66 @@ tokens 3000 (in 500 / out 2500)
 			input: "TOKENS 777 (IN 300 / OUT 477)",
 			want:  777,
 		},
+		{
+			name: "codex two-line tokens used (comma-grouped)",
+			input: `running step 5
+tokens used
+89,655
+done`,
+			want: 89655,
+		},
+		{
+			name: "codex two-line tokens used (small number, no commas)",
+			input: `tokens used
+512`,
+			want: 512,
+		},
+		{
+			name: "codex two-line with blank line between keyword and number",
+			input: `tokens used
+
+12,345`,
+			want: 12345,
+		},
+		{
+			name: "codex two-line is case insensitive",
+			input: `TOKENS USED
+2,048`,
+			want: 2048,
+		},
+		{
+			name: "codex two-line keyword with log prefix",
+			input: `[2026-06-02T10:00:00Z] tokens used
+1,000,000`,
+			want: 1000000,
+		},
+		{
+			name: "codex two-line ignored when next non-empty line is not a number",
+			input: `tokens used
+not a number
+99,999`,
+			want: 0,
+		},
+		{
+			name:  "claude json usage object",
+			input: `{"type":"result","usage":{"input_tokens":1200,"output_tokens":3400},"result":"done"}`,
+			want:  4600,
+		},
+		{
+			name: "claude stream-json — last result frame wins",
+			input: `{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":200}}}
+{"type":"assistant","message":{"usage":{"input_tokens":50,"output_tokens":75}}}
+{"type":"result","usage":{"input_tokens":150,"output_tokens":275}}`,
+			want: 425,
+		},
+		{
+			name: "multi-format log — parser returns the max",
+			input: `tokens 100 (in 10 / out 90)
+tokens used
+89,655
+{"type":"result","usage":{"input_tokens":10,"output_tokens":20}}`,
+			want: 89655,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Refs #626

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes token-count capture for the codex and claude CLIs by adding two new regex strategies to `ParseTokensFromOutput`: a two-line keyword/value pattern for modern codex output (`tokens used
89,655`) and a JSON field scanner for claude's `--output-format json` / `stream-json` modes.

- `codexTwoLineKeyword` + `nextNumericValue` scan adjacent lines for the codex header/count split, skipping blank lines and handling log-tag prefixes; the single-line `tokenPatterns` and the new JSON path both contribute to a unified max.
- `parseJSONUsage` sums the last `\"input_tokens\"` and `\"output_tokens\"` matches found anywhere in the buffered output, relying on the assumption that the trailing result frame always carries both fields together.
- Eleven new table-driven tests cover comma-grouped numbers, blank-line gaps, case insensitivity, log prefixes, mismatched next-line, and multi-format interplay.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are isolated to a single parsing utility with no side effects on other subsystems.

Both findings are latent risks rather than present breakage: the independent last-match for JSON fields works correctly for every Claude output format documented and tested, and the suffix-match false-positive for the two-line keyword is unlikely to trigger on real codex output. Neither path touches persistence, auth, or inter-service contracts.

internal/worker/tokens.go — the two-line keyword regex and the JSON field pairing logic are the subtle spots worth a second read.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/tokens.go | Adds two-line codex format parsing and JSON usage extraction; regex for two-line keyword can over-match suffix cases, and JSON field pairing is done independently which could mis-sum under format changes. |
| internal/worker/tokens_test.go | Adds 11 new test cases covering the two-line codex format, JSON usage parsing, blank-line skipping, and multi-format max selection; coverage is thorough for the happy paths. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/worker/tokens.go:116-120
**Independent last-match can silently pair fields from different JSON objects**

`lastIntMatch` is called independently for `"input_tokens"` and `"output_tokens"`, so the "last" occurrence of each is determined separately across the entire text. If a stream-json run ever produces a trailing frame that carries only one of the two fields — for example an intermediate usage summary appended after the result frame — the function will pair the final `input_tokens` value with a stale `output_tokens` from an earlier frame, or vice versa, and return a silently wrong total.

The currently tested output shapes (every frame that has either field has both) make this safe today, but the assumption is not enforced and would be easy to violate if Claude's streaming format changes.

### Issue 2 of 2
internal/worker/tokens.go:30
**`codexTwoLineKeyword` matches any line whose suffix is "tokens used"**

The regex `(?:^|[\s\]])tokens used\s*$` fires on any line that **ends with** the phrase "tokens used", not exclusively lines that consist only of it. A natural-language line like `"200 output tokens used"` or `"cache: 1,024 tokens used"` will match, and if the very next non-empty line happens to be a bare integer (an unrelated count, a step number, etc.), `nextNumericValue` will return it as the token total. Anchoring the keyword more strictly — e.g., requiring the match to start at `^` or immediately after a log-tag bracket — would eliminate the false-positive risk.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): parse codex two-line and cl..."](https://github.com/befeast/maestro/commit/e0edb3e76b6d85bd893f8c6682bb3d842f7a72d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35263964)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->