### PR TITLE
worker: sanitize assembled prompt to valid UTF-8 before piping to backend (codex crashes on invalid bytes)

### DIFF
--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestBuildWorkerCmd_Claude(t *testing.T) {
@@ -141,6 +142,31 @@ func TestBuildWorkerCmd_Codex(t *testing.T) {
 	}
 	if cmd.Dir != worktree {
 		t.Errorf("expected Dir=%s, got %s", worktree, cmd.Dir)
+	}
+}
+
+func TestBuildWorkerCmd_CodexPromptFileIsValidUTF8(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	prompt := "assembled prompt with invalid byte: " + string([]byte{0xff}) + " end"
+	if err := writePromptFile(promptFile, prompt); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stdinFile, err := BuildWorkerCmd("codex", BackendConfig{Cmd: "codex"}, promptFile, "/tmp/codex-worktree")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(stdinFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !utf8.Valid(data) {
+		t.Fatalf("codex stdin prompt is not valid UTF-8: %q", data)
+	}
+	if !strings.Contains(string(data), "\uFFFD") {
+		t.Fatalf("expected invalid byte to be replaced with U+FFFD, got %q", string(data))
 	}
 }
 

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -104,7 +104,7 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 	checkpointContext := ""
 	if sess.CheckpointFile != "" {
 		if data, err := os.ReadFile(sess.CheckpointFile); err == nil {
-			checkpointContext = string(data)
+			checkpointContext = sanitizePromptUTF8(string(data))
 		}
 	}
 
@@ -113,7 +113,7 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 
 	// Write prompt to file
 	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
-	if err := os.WriteFile(promptFile, []byte(prompt), 0644); err != nil {
+	if err := writePromptFile(promptFile, prompt); err != nil {
 		return fmt.Errorf("write prompt file: %w", err)
 	}
 

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -27,7 +27,7 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 
 	// Write prompt to file
 	promptFile := fmt.Sprintf("%s/%s-prompt.md", cfg.StateDir, slotName)
-	if err := os.WriteFile(promptFile, []byte(prompt), 0644); err != nil {
+	if err := writePromptFile(promptFile, prompt); err != nil {
 		return fmt.Errorf("write prompt file: %w", err)
 	}
 

--- a/internal/worker/prompt_utf8.go
+++ b/internal/worker/prompt_utf8.go
@@ -1,0 +1,14 @@
+package worker
+
+import (
+	"os"
+	"strings"
+)
+
+func sanitizePromptUTF8(prompt string) string {
+	return strings.ToValidUTF8(prompt, "\uFFFD")
+}
+
+func writePromptFile(path, prompt string) error {
+	return os.WriteFile(path, []byte(sanitizePromptUTF8(prompt)), 0644)
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -95,7 +95,7 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 
 	// Write prompt to file
 	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
-	if err := os.WriteFile(promptFile, []byte(prompt), 0644); err != nil {
+	if err := writePromptFile(promptFile, prompt); err != nil {
 		return "", fmt.Errorf("write prompt file: %w", err)
 	}
 
@@ -236,7 +236,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 
 	// Write prompt to file
 	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
-	if err := os.WriteFile(promptFile, []byte(prompt), 0644); err != nil {
+	if err := writePromptFile(promptFile, prompt); err != nil {
 		return fmt.Errorf("write prompt file: %w", err)
 	}
 
@@ -765,7 +765,7 @@ func readValidationContract(worktreePath string) string {
 	if err != nil {
 		return ""
 	}
-	return string(data)
+	return sanitizePromptUTF8(string(data))
 }
 
 // assemblePrompt builds the final worker prompt.
@@ -866,7 +866,7 @@ func appendSectionsAndValidation(prompt string, sectionPaths []string, validatio
 			continue
 		}
 		b.WriteString("\n\n---\n\n")
-		b.WriteString(string(data))
+		b.WriteString(sanitizePromptUTF8(string(data)))
 	}
 
 	// Append validation contract if present and not already inlined

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
@@ -211,5 +212,27 @@ func TestAssemblePrompt_NoValidationFileIsOK(t *testing.T) {
 	// Should still produce a valid prompt
 	if !strings.Contains(prompt, "Base prompt with 1") {
 		t.Error("prompt should work without VALIDATION.md")
+	}
+}
+
+func TestAssemblePrompt_SanitizesInjectedFileContext(t *testing.T) {
+	dir := t.TempDir()
+	section := filepath.Join(dir, "section.md")
+	if err := os.WriteFile(section, []byte{'#', ' ', 'S', 'e', 'c', 't', 'i', 'o', 'n', '\n', 0xff}, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VALIDATION.md"), []byte{'V', 'a', 'l', 'i', 'd', 'a', 't', 'i', 'o', 'n', ':', ' ', 0xfe}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{Repo: "owner/repo", PromptSections: []string{section}}
+	issue := github.Issue{Number: 7, Title: "utf8", Body: "body"}
+	prompt := assemblePrompt("Base prompt with {{ISSUE_NUMBER}} and {{VALIDATION_CONTRACT}}", issue, dir, "feat/utf8", cfg)
+
+	if !utf8.ValidString(prompt) {
+		t.Fatalf("assembled prompt is not valid UTF-8: %q", prompt)
+	}
+	if got := strings.Count(prompt, "\uFFFD"); got != 2 {
+		t.Fatalf("replacement count = %d, want 2; prompt=%q", got, prompt)
 	}
 }


### PR DESCRIPTION
Refs #631

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR sanitizes assembled prompts to valid UTF-8 before writing them to disk, preventing the codex backend from crashing on invalid byte sequences. The fix is applied uniformly across all four prompt-write call sites (`Start`, `Respawn`, `RespawnInPlace`, `StartPhase`) and also at read-time for checkpoint files, section files, and `VALIDATION.md`.

- A new `prompt_utf8.go` module introduces `sanitizePromptUTF8` (backed by `strings.ToValidUTF8` with `\uFFFD` replacement) and `writePromptFile`, which all prompt-write sites now delegate to.
- Belt-and-suspenders sanitization is applied at both read time (checkpoint, section files, VALIDATION.md) and at final write time via `writePromptFile`, so invalid bytes from any source — including user-provided section files or checkpoint output — are cleaned up before reaching the backend.
- Two new tests cover the codex stdin path and the `assemblePrompt` file-injection path end-to-end, asserting U+FFFD replacement rather than just absence of errors.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to sanitizing prompt content before disk writes, with no behavioral changes to command construction or backend dispatch.

All four prompt-write paths are updated consistently, the sanitization primitive (strings.ToValidUTF8) is stdlib and well-understood, and both new tests verify the replacement-character behavior end-to-end rather than just checking for no-error. No logic was altered in the backend dispatch or session management code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/prompt_utf8.go | New file introducing sanitizePromptUTF8 (using strings.ToValidUTF8) and writePromptFile; clean and correct |
| internal/worker/worker.go | Replaces all four os.WriteFile prompt-write call sites with writePromptFile, and adds sanitizePromptUTF8 at two read-time sites (readValidationContract, appendSectionsAndValidation) |
| internal/worker/checkpoint.go | Sanitizes checkpoint file content at read time and uses writePromptFile for the prompt write; correct |
| internal/worker/phase.go | Single-line change replacing os.WriteFile with writePromptFile; correct |
| internal/worker/backend_test.go | Adds TestBuildWorkerCmd_CodexPromptFileIsValidUTF8 verifying that the stdinFile for the codex path contains valid UTF-8 with the replacement character after an invalid byte is written |
| internal/worker/worker_prompt_test.go | Adds TestAssemblePrompt_SanitizesInjectedFileContext covering invalid bytes in both section files and VALIDATION.md; correctly asserts exactly 2 replacement characters in the assembled result |

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: sanitize prompt utf8 before back..."](https://github.com/befeast/maestro/commit/384707c220bdb55190e3ef7a5e7a98b6a067f357) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35268057)</sub>

<!-- /greptile_comment -->