### PR TITLE
cost-obs: capture token total from persisted worker log on completion (live tmux-capture misses the exit-time total)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -399,6 +400,47 @@ func (o *Orchestrator) rateLimitResetFromLog(logFile string) *time.Time {
 		return &reset
 	}
 	return nil
+}
+
+func (o *Orchestrator) workerLogFile(slotName string, sess *state.Session) string {
+	if sess == nil {
+		return ""
+	}
+	if logFile := strings.TrimSpace(sess.LogFile); logFile != "" {
+		return logFile
+	}
+	if o != nil && o.cfg != nil && strings.TrimSpace(o.cfg.StateDir) != "" {
+		return filepath.Join(state.LogDir(o.cfg.StateDir), slotName+".log")
+	}
+	return ""
+}
+
+func (o *Orchestrator) updateTokensUsedFromOutput(slotName string, sess *state.Session, output string) bool {
+	if sess == nil {
+		return false
+	}
+	tokens := worker.ParseTokensFromOutput(output)
+	if tokens <= sess.TokensUsedAttempt {
+		return false
+	}
+	delta := tokens - sess.TokensUsedAttempt
+	sess.TokensUsedAttempt = tokens
+	sess.TokensUsedTotal += delta
+	log.Printf("[orch] %s tokens_used updated: attempt=%d total=%d", slotName, tokens, sess.TokensUsedTotal)
+	return true
+}
+
+func (o *Orchestrator) updateTokensUsedFromWorkerLog(slotName string, sess *state.Session) bool {
+	logFile := o.workerLogFile(slotName, sess)
+	if logFile == "" {
+		return false
+	}
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		log.Printf("[orch] warn: could not read worker log for token capture %s (%s): %v", slotName, logFile, err)
+		return false
+	}
+	return o.updateTokensUsedFromOutput(slotName, sess, string(data))
 }
 
 // runAfterRunHook executes the after_run hook for a session (best-effort, never fatal).
@@ -1537,6 +1579,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		// Without this check, reconcile would mark the session dead, causing
 		// IssueInProgress to return false and startNewWorkers to spawn a duplicate.
 		if pr, found := branchToPR[sess.Branch]; found {
+			o.updateTokensUsedFromWorkerLog(slotName, sess)
 			log.Printf("[orch] reconcile: %s running->pr_open (PR #%d already open for branch %q; %s)",
 				slotName, pr.Number, sess.Branch, strings.Join(reasons, ", "))
 			sess.Status = state.StatusPROpen
@@ -1569,6 +1612,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		// fallback is configured / available, or when the respawn itself fails (#506).
 		if o.isRateLimited(sess.LogFile) {
 			now := time.Now().UTC()
+			o.updateTokensUsedFromWorkerLog(slotName, sess)
 			resetAt := o.rateLimitResetFromLog(sess.LogFile)
 			o.recordProviderLimit(s, slotName, sess, "log_rate_limit_reconcile", resetAt, now)
 			selection := o.selectProviderLimitFallback(s, sess, now)
@@ -1642,6 +1686,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 
 		oldPID := sess.PID
 		oldTmux := tmuxName
+		o.updateTokensUsedFromWorkerLog(slotName, sess)
 		sess.Status = state.StatusDead
 		sess.PID = 0
 		sess.TmuxSession = ""
@@ -1678,6 +1723,7 @@ func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.S
 		return 0, false
 	}
 
+	o.updateTokensUsedFromWorkerLog(slotName, sess)
 	sess.Status = state.StatusPROpen
 	sess.PRNumber = prNumber
 	sess.PID = 0
@@ -1870,6 +1916,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 				// Check if there's an open PR for this branch BEFORE marking dead
 				if pr, found := branchToPR[sess.Branch]; found {
+					o.updateTokensUsedFromWorkerLog(slotName, sess)
 					log.Printf("[orch] worker %s exited but PR #%d is open — transitioning to pr_open", slotName, pr.Number)
 					sess.Status = state.StatusPROpen
 					sess.PRNumber = pr.Number
@@ -1881,6 +1928,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				} else if o.isRateLimited(sess.LogFile) {
 					// Provider capacity limit detected — gate this backend and select a fallback.
 					now := time.Now().UTC()
+					o.updateTokensUsedFromWorkerLog(slotName, sess)
 					resetAt := o.rateLimitResetFromLog(sess.LogFile)
 					o.recordProviderLimit(s, slotName, sess, "log_rate_limit", resetAt, now)
 					selection := o.selectProviderLimitFallback(s, sess, now)
@@ -1931,6 +1979,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						slotName, sess.IssueNumber, previousBackend, nextBackend)
 				} else if o.canRetryIssue(s, sess) {
 					// Schedule retry with exponential backoff (respects max_retries_per_issue)
+					o.updateTokensUsedFromWorkerLog(slotName, sess)
 					sess.RetryCount++
 					backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
 					retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
@@ -1945,6 +1994,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
 				} else {
 					// Retry limit reached — mark as permanently failed
+					o.updateTokensUsedFromWorkerLog(slotName, sess)
 					log.Printf("[orch] worker %s (pid=%d) permanently failed after %d retries", slotName, sess.PID, sess.RetryCount)
 					// auto-label blocked disabled
 					o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
@@ -1988,12 +2038,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					log.Printf("[orch] warn: tmux capture-pane failed for %s (%s): %v", slotName, tmuxName, err)
 				} else {
 					// --- Token tracking ---
-					if tokens := worker.ParseTokensFromOutput(output); tokens > sess.TokensUsedAttempt {
-						delta := tokens - sess.TokensUsedAttempt
-						sess.TokensUsedAttempt = tokens
-						sess.TokensUsedTotal += delta
-						log.Printf("[orch] %s tokens_used updated: attempt=%d total=%d", slotName, tokens, sess.TokensUsedTotal)
-					}
+					o.updateTokensUsedFromOutput(slotName, sess, output)
 
 					// --- Rate-limit detection ---
 					if !sess.RateLimitHit && sess.LastNotifiedStatus != "rate_limit" {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -215,6 +215,64 @@ func TestReconcileRunningSessions_DeadWorkerWithOpenPR_TransitionsToPROpen(t *te
 	}
 }
 
+func TestReconcileRunningSessions_DeadWorkerWithOpenPR_CapturesTokensFromPersistedLog(t *testing.T) {
+	stateDir := t.TempDir()
+	logDir := state.LogDir(stateDir)
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		t.Fatalf("mkdir log dir: %v", err)
+	}
+	logPath := logDir + "/sup-150.log"
+	if err := os.WriteFile(logPath, []byte("worker output\n\ntokens used\n100,965\nImplemented and opened PR\n"), 0644); err != nil {
+		t.Fatalf("write worker log: %v", err)
+	}
+
+	s := state.NewState()
+	s.Sessions["sup-150"] = &state.Session{
+		IssueNumber:       633,
+		IssueTitle:        "capture token total",
+		Status:            state.StatusRunning,
+		PID:               9999,
+		TmuxSession:       "maestro-sup-150",
+		Branch:            "feat/sup-150-633-cost-obs",
+		TokensUsedAttempt: 2000,
+		TokensUsedTotal:   5000,
+	}
+
+	o := &Orchestrator{
+		cfg:                 &config.Config{StateDir: stateDir},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{{Number: 632, HeadRefName: "feat/sup-150-633-cost-obs", Title: "cost obs"}}, nil
+		},
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["sup-150"]
+	if sess.Status != state.StatusPROpen {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusPROpen)
+	}
+	if sess.PRNumber != 632 {
+		t.Fatalf("pr_number = %d, want 632", sess.PRNumber)
+	}
+	if sess.TokensUsedAttempt != 100965 {
+		t.Fatalf("tokens_used_attempt = %d, want 100965", sess.TokensUsedAttempt)
+	}
+	if sess.TokensUsedTotal != 103965 {
+		t.Fatalf("tokens_used_total = %d, want 103965", sess.TokensUsedTotal)
+	}
+	if sess.PID != 0 {
+		t.Fatalf("pid = %d, want 0", sess.PID)
+	}
+	if sess.TmuxSession != "" {
+		t.Fatalf("tmux_session = %q, want empty", sess.TmuxSession)
+	}
+}
+
 func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing.T) {
 	s := state.NewState()
 	s.Sessions["mae-8"] = &state.Session{


### PR DESCRIPTION
Refs #633

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes token-count under-reporting when a worker exits — `tmux capture-pane` cannot reliably read the final output once the session is gone, so the last token total was often missed. The fix reads the persisted worker log file at every dead-worker transition point in both `reconcileRunningSessions` and `checkSessions`.

- Three new helpers are introduced: `workerLogFile` (resolves log path from session or state dir), `updateTokensUsedFromOutput` (refactors the existing inline delta logic), and `updateTokensUsedFromWorkerLog` (reads the file and delegates). The new `updateTokensUsedFromWorkerLog` is called at eight transition sites covering PR-open, rate-limit, retry, and permanent-failure paths.
- The `updateTokensUsedFromOutput` guard (`tokens <= TokensUsedAttempt`) keeps updates idempotent, so both the live tmux capture and the exit-time log read can run without double-counting — the live tmux capture sets the watermark, and the log read only accumulates if it finds a higher value.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change reads log files at transition points that have already cleared the worker process, and the existing idempotency guard prevents any double-counting between live tmux captures and log reads.

All eight new call sites are in dead-worker branches that don't overlap with the live tmux-capture path; reconcileRunningSessions transitions the session away from StatusRunning before checkSessions runs, so both functions cannot fire updateTokensUsedFromWorkerLog for the same session in the same cycle. The test correctly validates the delta math with a pre-seeded attempt watermark. No correctness issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds three helpers (workerLogFile, updateTokensUsedFromOutput, updateTokensUsedFromWorkerLog) and inserts log-file token captures at all eight dead-worker transition points; existing tmux-based capture is refactored into the new helper with no behavior change. |
| internal/orchestrator/orchestrator_test.go | Adds an integration-style test covering the reconcile dead-worker→pr_open path; correctly seeds TokensUsedAttempt/TokensUsedTotal and asserts the expected delta accumulation after reading the persisted log. |

</details>

<sub>Reviews (1): Last reviewed commit: ["cost-obs: capture completion tokens from..."](https://github.com/befeast/maestro/commit/351ce0ef22d4ce7be70a2dd36f6a262181930dd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35272092)</sub>

<!-- /greptile_comment -->