### PR TITLE
Supervisor: wire dependency-unblock so blocker-chained issues auto-advance (today they stall in Todo)

### DIFF
--- a/.github/ISSUE_TEMPLATE/spec.yml
+++ b/.github/ISSUE_TEMPLATE/spec.yml
@@ -59,6 +59,14 @@ body:
       required: true
 
   - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies / blockers
+      description: Optional. For chained work, use a parseable form such as `Blocked by #123` or `Blocked until #123 merged`.
+      placeholder: |
+        Blocked by #123
+
+  - type: textarea
     id: test_plan
     attributes:
       label: Test plan

--- a/docs/handoff-epic-format.md
+++ b/docs/handoff-epic-format.md
@@ -266,7 +266,7 @@ supervisor:
     owns_ready_label: false
     runnable_project_statuses: [Todo, To Do, Ready, Backlog, New]
     dependency_unblock:
-      enabled: true             # opt-in; default false
+      enabled: true             # default true when owns_ready_label=true with ready/blocked labels
       max_runnable: 5           # cap concurrent runnable wave members
       enroll_in_project: true   # default true when projects are configured
       announce_with_comment: true  # default true; comment lists dep evidence
@@ -317,5 +317,7 @@ to the supervisor:
 
 If your repo previously ran an external cron for this purpose, you can
 retire it once `supervisor.dynamic_wave.dependency_unblock.enabled` is
-true and `safe_actions` grants `remove_blocked_label`, `add_ready_label`,
-and `add_issue_comment`.
+true (or defaulted on through `owns_ready_label: true`) and
+`safe_actions` grants `remove_blocked_label`, `add_ready_label`, and
+`add_issue_comment`. Set `dependency_unblock.enabled: false` only when
+blocker chains are intentionally operator-managed.

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -140,6 +140,10 @@ exclude_labels:
   - blocked
   - duplicate
   - invalid
+blocker_patterns:
+  - "blocked by.*?#(\\d+)"
+  - "blocked until.*?#(\\d+).*merged"
+  - "depends on.*?#(\\d+)"
 
 # Supervisor policy (optional)
 supervisor:
@@ -164,6 +168,13 @@ supervisor:
       - Ready
       - Backlog
       - New
+    dependency_unblock:
+      # Defaults on when dynamic_wave owns ready/blocked labels; set false
+      # only when blocker chains are intentionally operator-managed.
+      enabled: true
+      max_runnable: 1
+      enroll_in_project: true
+      announce_with_comment: true
   safe_actions:
     - add_ready_label
     - remove_ready_label

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -384,7 +384,9 @@ func (w SupervisorDynamicWaveConfig) Active() bool {
 // blocked issues into the configured GitHub Project so wave members are
 // visible before they go runnable.
 //
-// Default is disabled. The Scribe redesign handoff used an external cron
+// Defaults on for dynamic waves that own the ready/blocked labels. Set
+// enabled: false when blocker chains are intentionally operator-managed.
+// The Scribe redesign handoff used an external cron
 // (`scribe-redesign-handoff-unblocker`) as a workaround; this config lets
 // supervisor own that handoff dev role directly. See issue #442.
 type SupervisorDependencyUnblockConfig struct {
@@ -394,8 +396,9 @@ type SupervisorDependencyUnblockConfig struct {
 	AnnounceWithComment *bool `yaml:"announce_with_comment" json:"announce_with_comment,omitempty"`
 }
 
-// Active reports whether the dependency-unblock controller should run. Disabled
-// by default so existing projects without the explicit opt-in stay unchanged.
+// Active reports whether the dependency-unblock controller should run. Parsed
+// configs default this on for owned dynamic waves with both ready and blocked
+// labels, unless the operator explicitly sets enabled: false.
 func (d SupervisorDependencyUnblockConfig) Active() bool {
 	return d.Enabled != nil && *d.Enabled
 }
@@ -1189,6 +1192,14 @@ func normalizeSupervisorPolicy(policy *SupervisorConfig) error {
 	policy.CompletionGates.LiveVisualCommand = strings.TrimSpace(policy.CompletionGates.LiveVisualCommand)
 	policy.CompletionGates.DeploymentStatusCmd = strings.TrimSpace(policy.CompletionGates.DeploymentStatusCmd)
 	policy.CompletionGates.VerificationLabel = strings.TrimSpace(policy.CompletionGates.VerificationLabel)
+	if policy.DynamicWave.DependencyUnblock.Enabled == nil &&
+		policy.DynamicWave.Active() &&
+		policy.DynamicWave.OwnsReadyLabel &&
+		policy.ReadyLabel != "" &&
+		policy.BlockedLabel != "" {
+		enabled := true
+		policy.DynamicWave.DependencyUnblock.Enabled = &enabled
+	}
 
 	if !policy.excludedLabelsSet && len(policy.ExcludedLabels) == 0 {
 		policy.ExcludedLabels = []string{"epic", "meta"}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -283,6 +283,49 @@ supervisor:
 	}
 }
 
+func TestParse_SupervisorDependencyUnblockDefaultsOnForOwnedDynamicWave(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  ready_label: maestro-ready
+  blocked_label: blocked
+  dynamic_wave:
+    enabled: true
+    owns_ready_label: true
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.Supervisor.DynamicWave.DependencyUnblock.Active() {
+		t.Fatal("DependencyUnblock should default on when dynamic_wave owns ready/blocked handoff labels")
+	}
+	if len(cfg.BlockerPatterns) == 0 {
+		t.Fatal("BlockerPatterns should default to machine-readable blocker forms")
+	}
+}
+
+func TestParse_SupervisorDependencyUnblockExplicitFalseWins(t *testing.T) {
+	yaml := `
+repo: owner/repo
+supervisor:
+  ready_label: maestro-ready
+  blocked_label: blocked
+  dynamic_wave:
+    enabled: true
+    owns_ready_label: true
+    dependency_unblock:
+      enabled: false
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Supervisor.DynamicWave.DependencyUnblock.Active() {
+		t.Fatal("DependencyUnblock should stay disabled when explicitly configured enabled=false")
+	}
+}
+
 func TestParse_OutcomeBrief(t *testing.T) {
 	yaml := `
 repo: owner/repo

--- a/internal/supervisor/dependency_unblock_test.go
+++ b/internal/supervisor/dependency_unblock_test.go
@@ -260,6 +260,47 @@ func TestRunOnceDependencyUnblockAppliesSafeLabelMutations(t *testing.T) {
 	}
 }
 
+func TestRunOnceOwnedDynamicWaveDefaultsDependencyUnblock(t *testing.T) {
+	cfg, err := config.Parse([]byte(`
+repo: owner/repo
+issue_labels:
+  - maestro-ready
+supervisor:
+  ready_label: maestro-ready
+  blocked_label: blocked
+  dynamic_wave:
+    enabled: true
+    owns_ready_label: true
+  safe_actions:
+    - add_ready_label
+    - remove_blocked_label
+`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg.StateDir = t.TempDir()
+	issue := testIssue(151, "blocked successor", "blocked")
+	issue.Body = "Blocked by #150"
+	reader := &fakeReader{
+		issues:       []github.Issue{issue},
+		closedIssues: map[int]bool{150: true},
+	}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if decision.RecommendedAction != ActionUnblockIssue {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionUnblockIssue)
+	}
+	if got, want := strings.Join(reader.removedLabels, ","), "#151:blocked"; got != want {
+		t.Fatalf("removed labels = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(reader.addedLabels, ","), "#151:maestro-ready"; got != want {
+		t.Fatalf("added labels = %q, want %q", got, want)
+	}
+}
+
 // Test: dep merged-PR also resolves the dependency --------------------------
 
 func TestEvaluate_UnblocksWhenDependencyPRMerged(t *testing.T) {


### PR DESCRIPTION
Refs #620

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `dependency_unblock` to auto-enable for dynamic waves that own the `ready_label` and `blocked_label` pair, so blocker-chained issues advance automatically without an explicit `enabled: true` in the config. The change is confined to a single guard block in `normalizeSupervisorPolicy` that only fires when `Enabled == nil` (no explicit operator setting), `DynamicWave.Active()`, `OwnsReadyLabel`, and both labels are non-empty — existing projects with `enabled: false` are unaffected.

- `internal/config/config.go`: normalization block defaults `DependencyUnblock.Enabled` to `&true` when all five conditions are satisfied; `Active()` itself is unchanged, so the contract is backward-compatible.
- `internal/config/config_test.go` + `internal/supervisor/dependency_unblock_test.go`: two unit tests cover the default-on path and the explicit-false-wins path; the integration test validates end-to-end label mutations under the new default.
- Docs and the issue template are updated consistently with the new behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrowly-scoped normalization that only fires for projects that already own the ready/blocked label pair, and explicit operator settings are fully respected.

The auto-enable guard correctly requires all five conditions before mutating the config, TrimSpace runs before the check, and explicit enabled: false is preserved because the nil-check short-circuits. Tests cover the two key branches and an end-to-end label-mutation path. No logic gaps found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds normalization logic to auto-enable dependency_unblock when dynamic_wave owns ready/blocked labels; Active() unchanged, defaulting is cleanly gated on five conditions with correct ordering after TrimSpace calls |
| internal/config/config_test.go | Two new tests added: one verifying auto-enable fires when all conditions met (with BlockerPatterns default check), one verifying explicit enabled=false overrides the default |
| internal/supervisor/dependency_unblock_test.go | Integration test validates end-to-end unblocking under the new default: label mutations (#151:blocked removed, #151:maestro-ready added) are correctly asserted; comment posting is already gated by safeActionAllowed so its omission from safe_actions is fine |
| .github/ISSUE_TEMPLATE/spec.yml | Adds optional 'Dependencies / blockers' textarea field with a parseable placeholder; correctly placed before test_plan and not marked required |
| docs/handoff-epic-format.md | Documentation updated to reflect the new default-on behavior and add operator guidance for opting out |
| docs/project-setup-runbook.md | Runbook updated with blocker_patterns examples and dependency_unblock config block; YAML regex escaping is correct for the double-backslash forms |

</details>

<sub>Reviews (1): Last reviewed commit: ["supervisor: default dependency unblock f..."](https://github.com/befeast/maestro/commit/ba2f0e7a675d4e5fbfbf8e1f591f442baf7461db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35285348)</sub>

<!-- /greptile_comment -->