### PR TITLE
fix(supervisor): stop retry-exhausted board flip-flop

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -546,15 +546,20 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	if slot, sess, issue, ok, err := e.retryExhaustedRepairCandidate(st, issues, cache); err != nil {
 		return state.SupervisorDecision{}, err
 	} else if ok {
+		// #556: spawn_repair_worker is NOT in the executor's action registry
+		// (see approver/registry.go). The at-mint guard in RunOnce refuses the
+		// verb every cycle, logging "refusing to mint approval" — the dogfood
+		// loop the issue calls out. The supervisor must not recommend a verb
+		// the executor cannot handle. Fall through to review_retry_exhausted
+		// so the operator can triage the issue manually instead of re-recommending
+		// a refused spawn each poll.
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Session %s for issue #%d is retry_exhausted with no usable PR", slot, sess.IssueNumber),
-			"Ready-labeled issue is still open and has no dependency/blocking label reason",
-			"Retry exhaustion may have moved the project item to Blocked, but supervisor can start one intentional repair worker instead of dead-ending the queue",
-			"Starting a repair worker would mutate local worktrees, so supervisor records an explicit repair recommendation",
+			"Retry-exhausted work requires a human decision before more automation",
 		)
-		decision := e.decision(st, now, projectState, ActionSpawnRepairWorker,
-			fmt.Sprintf("Start a repair worker for retry-exhausted issue #%d: %s", issue.Number, issue.Title),
-			RiskMutating, 0.88, &state.SupervisorTarget{Issue: issue.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
+		decision := e.decision(st, now, projectState, ActionReviewRetryExhausted,
+			fmt.Sprintf("Issue #%d exhausted its retry budget and needs manual review.", issue.Number),
+			RiskApprovalGated, 0.93, &state.SupervisorTarget{Issue: issue.Number, PR: sess.PRNumber, Session: slot}, PolicyRuleRuntimeState, reasons)
 		decision.StuckStates = stuckStates
 		return decision, nil
 	}
@@ -1130,6 +1135,16 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time, cache *
 
 func (e *Engine) staleReviewFeedbackNeedsAttention(sess *state.Session) bool {
 	if sess == nil || sess.Status == state.StatusRunning || sess.Status == state.StatusDone {
+		return false
+	}
+	// #556: a retry-exhausted session with an open PR is handled by the
+	// deterministic path (bucket 1 – sessionWithOpenPR). Emitting a
+	// stale_review_feedback stuck state here creates a conflicting board
+	// signal: the stuck state says "blocked" while the decision may
+	// recommend merge_pr or monitor_open_pr for the same PR. The
+	// deterministic path already resolves the PR's fate; adding a
+	// redundant stuck state flip-flops the project board status.
+	if sess.Status == state.StatusRetryExhausted && sess.PRNumber > 0 {
 		return false
 	}
 	if sess.PRNumber > 0 {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -626,6 +626,11 @@ func TestDecide_RetryExhaustedUnaddressedFeedback_DoesNotRecommendSpawnRepairWor
 	if decision.RecommendedAction == ActionSpawnRepairWorker {
 		t.Fatalf("action = %q, must NOT recommend spawn_repair_worker for retry_exhausted (verb is refused at mint, leads to dogfood loop)", decision.RecommendedAction)
 	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == "stale_review_feedback" {
+			t.Fatalf("stuck states include stale_review_feedback for retry_exhausted open PR: %+v", decision.StuckStates)
+		}
+	}
 }
 
 // #512: CI is still pending → planner stays on monitor_open_pr with a
@@ -926,7 +931,14 @@ func TestDecide_DeadSessionWithDraftFailingPRRecommendsRepairWorker(t *testing.T
 	}
 }
 
-func TestDecide_RetryExhaustedReadyIssueSpawnsRepairWorkerEvenWhenProjectBlocked(t *testing.T) {
+// TestDecide_RetryExhaustedReadyIssueRecommendsManualReview verifies that
+// when dynamic-wave is active and a retry-exhausted session has no open PR,
+// the supervisor recommends ActionReviewRetryExhausted instead of
+// ActionSpawnRepairWorker (#556). spawn_repair_worker is NOT in the
+// executor's action registry and gets refused every cycle by the at-mint
+// guard; review_retry_exhausted replaces it so the operator sees a stable
+// signal instead of re-recommended refused spawn each poll.
+func TestDecide_RetryExhaustedReadyIssueRecommendsManualReview(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
 	enableDynamicWave(cfg)
@@ -946,18 +958,18 @@ func TestDecide_RetryExhaustedReadyIssueSpawnsRepairWorkerEvenWhenProjectBlocked
 		t.Fatalf("Decide: %v", err)
 	}
 
-	if decision.RecommendedAction != ActionSpawnRepairWorker {
-		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnRepairWorker)
+	if decision.RecommendedAction != ActionReviewRetryExhausted {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionReviewRetryExhausted)
 	}
-	if decision.RequiresApproval {
-		t.Fatalf("RequiresApproval = true, want false for policy-allowed repair spawn")
+	if !decision.RequiresApproval {
+		t.Fatalf("RequiresApproval = false, want true for review_retry_exhausted (RiskApprovalGated)")
 	}
 	if decision.Target == nil || decision.Target.Issue != 808 || decision.Target.Session != "pan-72" {
 		t.Fatalf("target = %#v, want issue 808 pan-72", decision.Target)
 	}
 	rationale := strings.Join(decision.Reasons, "\n")
-	if !strings.Contains(rationale, "retry_exhausted") || !strings.Contains(rationale, "Blocked") {
-		t.Fatalf("reasons = %q, want retry_exhausted and Blocked rationale", rationale)
+	if !strings.Contains(rationale, "retry_exhausted") {
+		t.Fatalf("reasons = %q, want retry_exhausted rationale", rationale)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the retry-exhausted repair-worker recommendation with `review_retry_exhausted`
- suppress `stale_review_feedback` stuck states for retry-exhausted sessions that already have an open PR
- add regression coverage so retry-exhausted open PRs no longer emit the board-flipping stale-review signal

## Why

`spawn_repair_worker` is not in the executor action registry, so recommending it can be refused every supervisor cycle. For retry-exhausted work, the supervisor should surface a stable manual-review signal instead of repeatedly recommending a verb the executor cannot run.

Retry-exhausted sessions with an open PR are already handled by the deterministic PR path, which can merge or monitor the PR. Emitting an additional `stale_review_feedback` stuck state for the same session creates a conflicting board signal.

## Testing

- `git diff --check`

Not run:

- `go test ./internal/supervisor` because `go` is not available in the current shell environment
