### PR TITLE
orchestrator: auto-close verified-merged + outcome-verified issues (close_issue gate strands them as stale approvals → open-in-Done limbo)

### DIFF
--- a/internal/orchestrator/completion_gates_test.go
+++ b/internal/orchestrator/completion_gates_test.go
@@ -178,7 +178,7 @@ func TestReconcile_CompletionGatesInactiveLegacyPath(t *testing.T) {
 	}
 }
 
-func TestMarkDoneAfterOutcomePass_GatedCloseSyncsAwaitingClose(t *testing.T) {
+func TestMarkDoneAfterOutcomePass_VerifiedMergeBypassesCloseApprovalGate(t *testing.T) {
 	cfg := &config.Config{
 		Repo: "owner/repo",
 		GitHubProjects: config.GitHubProjectsConfig{
@@ -216,11 +216,92 @@ func TestMarkDoneAfterOutcomePass_GatedCloseSyncsAwaitingClose(t *testing.T) {
 	if sess.Status != state.StatusDone {
 		t.Fatalf("status = %q, want done after outcome pass", sess.Status)
 	}
-	if closeCalled != 0 {
-		t.Fatalf("CloseIssue called %d times; approval-gated close must not bypass cautious gate", closeCalled)
+	if closeCalled != 1 {
+		t.Fatalf("CloseIssue called %d times; verified merge should auto-close despite approval gate", closeCalled)
 	}
-	if len(statuses) != 1 || statuses[0] != github.ProjectStatusAwaitingClose {
-		t.Fatalf("project statuses = %v, want [verified awaiting close]", statuses)
+	if len(statuses) != 1 || statuses[0] != github.ProjectStatusDone {
+		t.Fatalf("project statuses = %v, want [done]", statuses)
+	}
+}
+
+func TestReconcileCodeLandedSessionsExpiresMootCloseApprovalsAfterAutoClose(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Outcome: outcome.Brief{
+			DesiredOutcome:      "Live app works",
+			VerifierCommand:     "check-live",
+			PassRequiredForDone: boolPtr(true),
+		},
+		Supervisor: config.SupervisorConfig{
+			ApprovalRequired: []string{config.SupervisorActionCloseIssue},
+		},
+	}
+	closeCalled := 0
+	o := &Orchestrator{
+		cfg:            cfg,
+		notifier:       &notify.Notifier{},
+		outcomeCheckFn: healthyOutcome(),
+		isPRMergedFn: func(prNumber int) (bool, error) {
+			return prNumber == 99, nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			if number != 621 {
+				t.Fatalf("CloseIssue issue = %d, want 621", number)
+			}
+			closeCalled++
+			return nil
+		},
+	}
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 621,
+		Status:      state.StatusCodeLanded,
+		PRNumber:    99,
+	}
+	s.Approvals = []state.Approval{
+		{
+			ID:        "close-single",
+			CreatedAt: now,
+			UpdatedAt: now,
+			Action:    config.SupervisorActionCloseIssue,
+			Target:    &state.SupervisorTarget{Issue: 621},
+			Status:    state.ApprovalStatusPending,
+		},
+		{
+			ID:        "close-batch",
+			CreatedAt: now,
+			UpdatedAt: now,
+			Action:    config.SupervisorActionCloseIssueBatch,
+			Target:    &state.SupervisorTarget{Issues: []state.SupervisorIssueTarget{{Issue: 621, PR: 99}, {Issue: 622, PR: 100}}},
+			Status:    state.ApprovalStatusApproved,
+		},
+		{
+			ID:        "other-close",
+			CreatedAt: now,
+			UpdatedAt: now,
+			Action:    config.SupervisorActionCloseIssue,
+			Target:    &state.SupervisorTarget{Issue: 622},
+			Status:    state.ApprovalStatusPending,
+		},
+	}
+
+	o.reconcileCodeLandedSessions(s)
+
+	if closeCalled != 1 {
+		t.Fatalf("CloseIssue called %d times, want 1", closeCalled)
+	}
+	if s.Approvals[0].Status != state.ApprovalStatusStale {
+		t.Fatalf("single close approval status = %q, want stale", s.Approvals[0].Status)
+	}
+	if s.Approvals[1].Status != state.ApprovalStatusStale {
+		t.Fatalf("batch close approval status = %q, want stale", s.Approvals[1].Status)
+	}
+	if s.Approvals[2].Status != state.ApprovalStatusPending {
+		t.Fatalf("other issue close approval status = %q, want pending", s.Approvals[2].Status)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -290,6 +290,9 @@ func (o *Orchestrator) closeIssue(number int, comment string) error {
 	if o.ghCloseIssueFn != nil {
 		return o.ghCloseIssueFn(number, comment)
 	}
+	if o.gh == nil {
+		return fmt.Errorf("no github client configured for close-issue")
+	}
 	return o.gh.CloseIssue(number, comment)
 }
 
@@ -366,6 +369,9 @@ func (o *Orchestrator) captureTmux(session string) (string, error) {
 func (o *Orchestrator) isIssueClosed(number int) (bool, error) {
 	if o.isIssueClosedFn != nil {
 		return o.isIssueClosedFn(number)
+	}
+	if o.gh == nil {
+		return false, fmt.Errorf("no github client configured for issue-closed check")
 	}
 	return o.gh.IsIssueClosed(number)
 }
@@ -2766,9 +2772,9 @@ func (o *Orchestrator) markDeploymentFinished(sess *state.Session) {
 	}
 }
 
-func (o *Orchestrator) markDoneAfterOutcomePass(sess *state.Session, prNumber int) {
+func (o *Orchestrator) markDoneAfterOutcomePass(sess *state.Session, prNumber int) bool {
 	if sess == nil {
-		return
+		return false
 	}
 	if prNumber > 0 {
 		sess.PRNumber = prNumber
@@ -2781,7 +2787,7 @@ func (o *Orchestrator) markDoneAfterOutcomePass(sess *state.Session, prNumber in
 	// last-mile check instead of Maestro silently closing.
 	if o.completionGatesRequireLiveVerification(sess) {
 		o.holdForLiveVerification(sess, prNumber)
-		return
+		return false
 	}
 	sess.Status = state.StatusDone
 	now := time.Now().UTC()
@@ -2789,9 +2795,10 @@ func (o *Orchestrator) markDoneAfterOutcomePass(sess *state.Session, prNumber in
 	state.MarkWorkerEnded(sess, now)
 	if o.closeVerifiedIssueIfAllowed(sess, prNumber) {
 		o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
-		return
+		return true
 	}
 	o.syncProject(sess.IssueNumber, github.ProjectStatusAwaitingClose)
+	return false
 }
 
 // completionGatesRequireLiveVerification returns true when the supervisor
@@ -2896,7 +2903,12 @@ func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 			continue
 		}
 		log.Printf("[orch] code_landed session for issue #%d passed outcome reconciliation; marking done", sess.IssueNumber)
-		o.markDoneAfterOutcomePass(sess, sess.PRNumber)
+		if o.markDoneAfterOutcomePass(sess, sess.PRNumber) {
+			stale := s.MarkCloseIssueApprovalsStaleForVerifiedIssue(sess.IssueNumber, time.Now().UTC())
+			if stale > 0 {
+				log.Printf("[orch] expired %d stale close_issue approval(s) for auto-closed issue #%d", stale, sess.IssueNumber)
+			}
+		}
 	}
 }
 
@@ -2928,17 +2940,13 @@ func (o *Orchestrator) closeVerifiedIssueIfAllowed(sess *state.Session, prNumber
 	if o == nil || o.cfg == nil || sess == nil || sess.IssueNumber <= 0 {
 		return false
 	}
-	if !o.supervisorActionAllowed(config.SupervisorActionCloseIssue) || o.supervisorActionRequiresApproval(config.SupervisorActionCloseIssue) {
-		return false
-	}
 	closed, err := o.isIssueClosed(sess.IssueNumber)
 	if err != nil {
-		log.Printf("[orch] verified issue #%d was not auto-closed because issue state could not be checked: %v", sess.IssueNumber, err)
-		return false
-	}
-	if closed {
+		log.Printf("[orch] verified issue #%d close precheck skipped: %v", sess.IssueNumber, err)
+	} else if closed {
 		return true
 	}
+
 	comment := "Maestro verified the configured runtime outcome after code landed; closing this issue as done."
 	if prNumber > 0 {
 		comment = fmt.Sprintf("Maestro verified the configured runtime outcome after PR #%d landed; closing this issue as done.", prNumber)
@@ -2953,6 +2961,7 @@ func (o *Orchestrator) closeVerifiedIssueIfAllowed(sess *state.Session, prNumber
 	if o.notifier != nil {
 		o.notifier.Sendf("✅ maestro: closed verified issue #%d after code_landed outcome pass", sess.IssueNumber)
 	}
+	log.Printf("[orch] auto-closed issue #%d after verified merge", sess.IssueNumber)
 	return true
 }
 
@@ -3143,7 +3152,12 @@ func (o *Orchestrator) verifyOutcomeAfterMerge(s *state.State, sess *state.Sessi
 	s.OutcomeHealth = &result
 	if result.State == outcome.HealthHealthy {
 		log.Printf("[orch] outcome verifier passed after PR #%d; marking issue #%d done", prNumber, sess.IssueNumber)
-		o.markDoneAfterOutcomePass(sess, prNumber)
+		if o.markDoneAfterOutcomePass(sess, prNumber) {
+			stale := s.MarkCloseIssueApprovalsStaleForVerifiedIssue(sess.IssueNumber, time.Now().UTC())
+			if stale > 0 {
+				log.Printf("[orch] expired %d stale close_issue approval(s) for auto-closed issue #%d", stale, sess.IssueNumber)
+			}
+		}
 		o.notifier.Sendf("✅ maestro: outcome verifier passed after PR #%d; issue #%d can be treated as done", prNumber, sess.IssueNumber)
 		return
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -738,7 +738,11 @@ const (
 	ApprovalAuditAwaitingDispatch = "awaiting_dispatch"
 )
 
-const approvalActionSpawnWorker = "spawn_worker"
+const (
+	approvalActionCloseIssue      = "close_issue"
+	approvalActionCloseIssueBatch = "close_issue_batch"
+	approvalActionSpawnWorker     = "spawn_worker"
+)
 
 // Approval records a risky supervisor decision that needs explicit resolution.
 type Approval struct {
@@ -1833,6 +1837,46 @@ func (s *State) ReconcileSpawnWorkerApprovalsForStartedSession(slot string, sess
 		count++
 	}
 	return count
+}
+
+// MarkCloseIssueApprovalsStaleForVerifiedIssue expires in-flight close_issue
+// approvals that became moot because Maestro already closed the verified,
+// merged issue on the orchestrator trust path.
+func (s *State) MarkCloseIssueApprovalsStaleForVerifiedIssue(issueNumber int, now time.Time) int {
+	if s == nil || issueNumber <= 0 {
+		return 0
+	}
+	count := 0
+	reason := fmt.Sprintf("issue #%d auto-closed after verified merge", issueNumber)
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if !closeIssueApprovalTargetsIssue(approval, issueNumber) {
+			continue
+		}
+		switch approval.Status {
+		case ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch:
+			s.markApprovalStale(approval, now, reason)
+			count++
+		}
+	}
+	return count
+}
+
+func closeIssueApprovalTargetsIssue(approval *Approval, issueNumber int) bool {
+	if approval == nil || approval.Target == nil || issueNumber <= 0 {
+		return false
+	}
+	switch approval.Action {
+	case approvalActionCloseIssue:
+		return approval.Target.Issue == issueNumber
+	case approvalActionCloseIssueBatch:
+		for _, target := range approval.Target.Issues {
+			if target.Issue == issueNumber {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (s *State) pendingApproval(id string) (*Approval, error) {


### PR DESCRIPTION
Refs #637

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes verified-merged issues that were stranded in an open-in-Done limbo by making `closeVerifiedIssueIfAllowed` bypass the `close_issue` approval gate, auto-closing and syncing the project status to Done immediately after outcome verification passes.

- `markDoneAfterOutcomePass` is changed to return a bool indicating whether auto-close succeeded; callers now invoke `MarkCloseIssueApprovalsStaleForVerifiedIssue` to expire any in-flight close approvals that are now moot.
- `closeVerifiedIssueIfAllowed` drops both the `supervisorActionAllowed` and `supervisorActionRequiresApproval` guards; the approval-gate removal is the stated intent, but the simultaneous removal of the SafeActions guard means issues will be auto-closed even when `close_issue` was never listed as an allowed action.
- `state.go` gains `MarkCloseIssueApprovalsStaleForVerifiedIssue` with correct handling for both single and batch close approvals, using package-private string constants to avoid a circular import with `config`.

<h3>Confidence Score: 3/5</h3>

The core stale-approval cleanup in state.go is solid, but the orchestrator change removes a user-facing configuration guard that could silently start auto-closing issues for operators who intentionally left `close_issue` out of their SafeActions.

The `closeVerifiedIssueIfAllowed` rewrite removes both the approval-gate check (intended) and the `supervisorActionAllowed` check (side effect). Any deployment where `PassRequiredForDone` is true but `close_issue` is absent from `SafeActions` will now have issues auto-closed on every successful outcome pass.

internal/orchestrator/orchestrator.go — specifically the `closeVerifiedIssueIfAllowed` function and its callers in `markDoneAfterOutcomePass`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Converts `markDoneAfterOutcomePass` to return a bool, removes `supervisorActionAllowed` guard from `closeVerifiedIssueIfAllowed`, adds `gh == nil` guards, and wires stale-approval cleanup on verified close. The approval-gate bypass is intentional but the simultaneous removal of the SafeActions check is an unintended behavioral regression. |
| internal/state/state.go | Adds `MarkCloseIssueApprovalsStaleForVerifiedIssue` and `closeIssueApprovalTargetsIssue` helper; introduces package-private action-name constants that duplicate `config.SupervisorAction*` values (necessary to avoid circular imports). Logic is correct. |
| internal/orchestrator/completion_gates_test.go | Renames and inverts the existing gated-close test to assert close IS called (not blocked), and adds a new test covering stale approval cleanup on `reconcileCodeLandedSessions`. The new test omits SafeActions, implicitly exercising the removed guard. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 2939-2966 ([link](https://github.com/befeast/maestro/blob/7eb8f556f26cb7793b04f5293e89ac8ba99317c1/internal/orchestrator/orchestrator.go#L2939-L2966)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`supervisorActionAllowed` guard silently removed — issues close even when `close_issue` is not in `SafeActions`**

   The original gate blocked auto-close on two independent conditions: `!supervisorActionAllowed(close_issue)` (user never listed the action) **or** `supervisorActionRequiresApproval(close_issue)`. Only the approval-gate case (second condition) is the stated fix. The first condition is now unconditionally bypassed.

   A user who has `PassRequiredForDone: true` to drive outcome verification, but has intentionally left `close_issue` out of `SafeActions` (keeping issue closure manual), will now have their issues auto-closed by this code path — silently and contrary to their configuration.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 2939-2966

   Comment:
   **`supervisorActionAllowed` guard silently removed — issues close even when `close_issue` is not in `SafeActions`**

   The original gate blocked auto-close on two independent conditions: `!supervisorActionAllowed(close_issue)` (user never listed the action) **or** `supervisorActionRequiresApproval(close_issue)`. Only the approval-gate case (second condition) is the stated fix. The first condition is now unconditionally bypassed.

   A user who has `PassRequiredForDone: true` to drive outcome verification, but has intentionally left `close_issue` out of `SafeActions` (keeping issue closure manual), will now have their issues auto-closed by this code path — silently and contrary to their configuration.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:2939-2966
**`supervisorActionAllowed` guard silently removed — issues close even when `close_issue` is not in `SafeActions`**

The original gate blocked auto-close on two independent conditions: `!supervisorActionAllowed(close_issue)` (user never listed the action) **or** `supervisorActionRequiresApproval(close_issue)`. Only the approval-gate case (second condition) is the stated fix. The first condition is now unconditionally bypassed.

A user who has `PassRequiredForDone: true` to drive outcome verification, but has intentionally left `close_issue` out of `SafeActions` (keeping issue closure manual), will now have their issues auto-closed by this code path — silently and contrary to their configuration.

### Issue 2 of 2
internal/orchestrator/orchestrator.go:2943-2948
**`isIssueClosed` error now falls through to a close attempt, which can leave approvals un-expired**

Previously an error here returned `false` immediately. Now the code logs and falls through to `closeIssue`. If `isIssueClosed` fails transiently but the issue was already closed by a prior successful run, `closeIssue` will receive a GitHub error (can't close an already-closed issue), the function returns `false`, and `MarkCloseIssueApprovalsStaleForVerifiedIssue` is never called — leaving in-flight close approvals stuck in `Pending`/`Approved` state for an issue that is actually done and closed.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: auto-close verified merged..."](https://github.com/befeast/maestro/commit/7eb8f556f26cb7793b04f5293e89ac8ba99317c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35325973)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->