### PR TITLE
supervisor: lesson-capture loop — turn recurring failures into approval-gated proposed rules

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -815,6 +815,7 @@ func superviseApprovalCmd(action string, args []string, defaultConfigPath string
 		Cfg:       cfg,
 		Sessions:  approver.SessionLookupFunc(st.SessionAt),
 		Workers:   newWorkerController(cfg),
+		State:     st,
 	}
 	res := ex.Execute(approval)
 

--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -14,8 +14,11 @@ package approver
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
@@ -134,6 +137,10 @@ type Executor struct {
 	// (#567: restart_worker / stop_worker). nil disables both verbs —
 	// the executor returns execution_failed with a clear summary.
 	Workers WorkerController
+
+	// State is optional for most actions. apply_lesson_proposal uses it to
+	// fetch the proposed rule and mark it applied after the gated append.
+	State *state.State
 
 	// locks serializes Execute(approval) per approval.ID within the same
 	// process. The second concurrent caller for the same ID returns
@@ -280,6 +287,8 @@ func (e *Executor) dispatchAction(approval *state.Approval) Result {
 			Status:  state.ApprovalStatusExecutionSkipped,
 			Summary: "change_global_config requires a manual edit + systemctl restart (executor not implemented)",
 		}
+	case config.SupervisorActionApplyLessonProposal:
+		return e.executeApplyLessonProposal(approval)
 	case "spawn_worker":
 		// The approver runs in the supervisor cycle; it does not own the
 		// dispatch loop that actually spawns workers. Mark the approval
@@ -507,6 +516,115 @@ func formatIssueList(issues []int) string {
 		parts = append(parts, fmt.Sprintf("#%d", issue))
 	}
 	return strings.Join(parts, ", ")
+}
+
+func (e *Executor) executeApplyLessonProposal(approval *state.Approval) Result {
+	if e.State == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no state wired into executor")}
+	}
+	if e.Cfg == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no project config wired into executor")}
+	}
+	id := strings.TrimSpace(approval.LessonProposalID)
+	if id == "" {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: fmt.Errorf("%w: lesson proposal id missing", ErrMissingTarget)}
+	}
+	proposal, ok := e.State.FindLessonProposal(id)
+	if !ok {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: fmt.Errorf("lesson proposal %s not found", id)}
+	}
+	if proposal.Status == state.LessonProposalStatusApplied {
+		return Result{
+			Status:  state.ApprovalStatusExecutionSkipped,
+			Summary: fmt.Sprintf("lesson proposal %s was already applied", proposal.ID),
+		}
+	}
+	path, targetLabel, err := e.lessonProposalTargetPath(proposal)
+	if err != nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Summary: err.Error(), Err: err}
+	}
+	block := formatLessonProposalBlock(*proposal)
+	if err := appendLessonBlock(path, block); err != nil {
+		return Result{
+			Status:  state.ApprovalStatusExecutionFailed,
+			Summary: fmt.Sprintf("apply lesson proposal %s to %s: %v", proposal.ID, targetLabel, err),
+			Err:     err,
+		}
+	}
+	e.State.MarkLessonProposalApplied(proposal.ID, time.Now().UTC(), approvalApprovedActor(approval), fmt.Sprintf("appended to %s", targetLabel))
+	return Result{
+		Status:  state.ApprovalStatusExecuted,
+		Summary: fmt.Sprintf("applied lesson proposal %s to %s", proposal.ID, targetLabel),
+	}
+}
+
+func (e *Executor) lessonProposalTargetPath(proposal *state.LessonProposal) (string, string, error) {
+	switch strings.TrimSpace(proposal.Target) {
+	case state.LessonProposalTargetWorkerPrompt:
+		path := strings.TrimSpace(e.Cfg.WorkerPrompt)
+		if path == "" {
+			return "", "", errors.New("worker_prompt is not configured; cannot apply worker prompt lesson")
+		}
+		return path, "worker prompt", nil
+	case state.LessonProposalTargetAgentsMD, "":
+		root := strings.TrimSpace(e.Cfg.LocalPath)
+		if root == "" {
+			return "", "", errors.New("local_path is not configured; cannot apply AGENTS.md lesson")
+		}
+		return filepath.Join(root, "AGENTS.md"), "AGENTS.md", nil
+	default:
+		return "", "", fmt.Errorf("unknown lesson proposal target %q", proposal.Target)
+	}
+}
+
+func formatLessonProposalBlock(proposal state.LessonProposal) string {
+	rule := strings.TrimSpace(proposal.SuggestedRule)
+	repro := strings.TrimSpace(proposal.MinimalRepro)
+	var b strings.Builder
+	b.WriteString("\n\n<!-- maestro:lesson-proposal ")
+	b.WriteString(proposal.ID)
+	b.WriteString(" -->\n")
+	b.WriteString("## Maestro Lesson: ")
+	b.WriteString(proposal.FailureClass)
+	b.WriteString("\n\n")
+	if repro != "" {
+		b.WriteString("Context: ")
+		b.WriteString(repro)
+		b.WriteString("\n\n")
+	}
+	b.WriteString(rule)
+	b.WriteString("\n")
+	b.WriteString("<!-- /maestro:lesson-proposal -->\n")
+	return b.String()
+}
+
+func appendLessonBlock(path, block string) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("empty lesson target path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create lesson target dir: %w", err)
+	}
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read lesson target: %w", err)
+	}
+	if strings.Contains(string(existing), strings.TrimSpace(block)) {
+		return nil
+	}
+	return os.WriteFile(path, append(existing, []byte(block)...), 0644)
+}
+
+func approvalApprovedActor(approval *state.Approval) string {
+	if approval == nil {
+		return ""
+	}
+	for i := len(approval.Audit) - 1; i >= 0; i-- {
+		if approval.Audit[i].Event == state.ApprovalAuditApproved {
+			return approval.Audit[i].Actor
+		}
+	}
+	return ""
 }
 
 func (e *Executor) executeDeleteWorktree(approval *state.Approval) Result {

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -2,6 +2,8 @@ package approver
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -137,6 +139,49 @@ func TestExecute_OpenChildIssue_ReturnsAwaitingDispatchWithActionableSummary(t *
 	}
 	if !strings.Contains(strings.ToLower(res.Summary), "manually") {
 		t.Fatalf("summary = %q, want manual-create hint for v1", res.Summary)
+	}
+}
+
+func TestExecute_ApplyLessonProposal_AppendsWorkerPromptAndMarksApplied(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "worker-prompt.md")
+	if err := os.WriteFile(promptPath, []byte("base prompt\n"), 0644); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+	st := state.NewState()
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	proposal, approval, created := st.RecordLessonProposal(state.LessonProposal{
+		FailureClass:  "retry_exhausted",
+		Area:          "issue:640",
+		MinimalRepro:  "Session sup-155 status=retry_exhausted retry_count=3",
+		SuggestedRule: "Inspect failed attempts before retrying.",
+		Target:        state.LessonProposalTargetWorkerPrompt,
+	}, now, "owner/repo", "owner/repo")
+	if !created {
+		t.Fatal("proposal was not created")
+	}
+	approval.Status = state.ApprovalStatusApproved
+	approval.Audit = append(approval.Audit, state.ApprovalAudit{At: now.Add(time.Minute), Event: state.ApprovalAuditApproved, Actor: "operator"})
+
+	ex := &Executor{Cfg: &config.Config{Repo: "owner/repo", WorkerPrompt: promptPath}, State: st}
+	res := ex.Execute(approval)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("status = %q, want executed; res=%+v", res.Status, res)
+	}
+	data, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("read prompt: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, proposal.ID) || !strings.Contains(content, "Inspect failed attempts before retrying.") {
+		t.Fatalf("prompt content missing lesson block:\n%s", content)
+	}
+	stored, ok := st.FindLessonProposal(proposal.ID)
+	if !ok {
+		t.Fatalf("proposal %s missing", proposal.ID)
+	}
+	if stored.Status != state.LessonProposalStatusApplied || stored.AppliedAt == nil {
+		t.Fatalf("proposal = %+v, want applied", stored)
 	}
 }
 

--- a/internal/approver/registry.go
+++ b/internal/approver/registry.go
@@ -23,13 +23,14 @@ package approver
 // here, by enumerating the verbs and checking each one routes through
 // Execute() without falling into default).
 var KnownApprovalActions = map[string]struct{}{
-	"merge_pr":             {},
-	"close_issue":          {},
-	"close_issue_batch":    {},
-	"delete_worktree":      {},
-	"change_global_config": {}, // executor returns execution_skipped pending YAML pipeline
-	"spawn_worker":         {}, // executor returns awaiting_dispatch (#515)
-	"open_child_issue":     {}, // executor returns awaiting_dispatch (#515)
+	"merge_pr":              {},
+	"close_issue":           {},
+	"close_issue_batch":     {},
+	"delete_worktree":       {},
+	"change_global_config":  {}, // executor returns execution_skipped pending YAML pipeline
+	"apply_lesson_proposal": {},
+	"spawn_worker":          {}, // executor returns awaiting_dispatch (#515)
+	"open_child_issue":      {}, // executor returns awaiting_dispatch (#515)
 	// #565: auto review-repair respawn. Executor returns awaiting_dispatch
 	// — the orchestrator's dispatcher spawns a scoped opus repair worker
 	// keyed on (pr_number, head_sha) so the same head is never

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,16 +117,17 @@ type GitHubProjectsConfig struct {
 }
 
 const (
-	SupervisorActionAddReadyLabel      = "add_ready_label"
-	SupervisorActionRemoveReadyLabel   = "remove_ready_label"
-	SupervisorActionAddBlockedLabel    = "add_blocked_label"
-	SupervisorActionRemoveBlockedLabel = "remove_blocked_label"
-	SupervisorActionAddIssueComment    = "add_issue_comment"
-	SupervisorActionMergePR            = "merge_pr"
-	SupervisorActionCloseIssue         = "close_issue"
-	SupervisorActionCloseIssueBatch    = "close_issue_batch"
-	SupervisorActionDeleteWorktree     = "delete_worktree"
-	SupervisorActionChangeGlobalConfig = "change_global_config"
+	SupervisorActionAddReadyLabel       = "add_ready_label"
+	SupervisorActionRemoveReadyLabel    = "remove_ready_label"
+	SupervisorActionAddBlockedLabel     = "add_blocked_label"
+	SupervisorActionRemoveBlockedLabel  = "remove_blocked_label"
+	SupervisorActionAddIssueComment     = "add_issue_comment"
+	SupervisorActionMergePR             = "merge_pr"
+	SupervisorActionCloseIssue          = "close_issue"
+	SupervisorActionCloseIssueBatch     = "close_issue_batch"
+	SupervisorActionDeleteWorktree      = "delete_worktree"
+	SupervisorActionChangeGlobalConfig  = "change_global_config"
+	SupervisorActionApplyLessonProposal = "apply_lesson_proposal"
 	// SupervisorActionRestartWorker / SupervisorActionStopWorker are the
 	// per-session worker-control verbs surfaced by the fleet snapshot
 	// (#567). Both are approval-gated: the operator clicks Restart/Stop on
@@ -1370,19 +1371,20 @@ func mergeApprovalGatedVerbs(approvalRequired []string) []string {
 
 func knownSupervisorActions() map[string]bool {
 	return map[string]bool{
-		SupervisorActionAddReadyLabel:      true,
-		SupervisorActionRemoveReadyLabel:   true,
-		SupervisorActionAddBlockedLabel:    true,
-		SupervisorActionRemoveBlockedLabel: true,
-		SupervisorActionAddIssueComment:    true,
-		SupervisorActionMergePR:            true,
-		SupervisorActionCloseIssue:         true,
-		SupervisorActionCloseIssueBatch:    true,
-		SupervisorActionDeleteWorktree:     true,
-		SupervisorActionChangeGlobalConfig: true,
-		SupervisorActionSpawnReviewRepair:  true,
-		SupervisorActionRestartWorker:      true,
-		SupervisorActionStopWorker:         true,
+		SupervisorActionAddReadyLabel:       true,
+		SupervisorActionRemoveReadyLabel:    true,
+		SupervisorActionAddBlockedLabel:     true,
+		SupervisorActionRemoveBlockedLabel:  true,
+		SupervisorActionAddIssueComment:     true,
+		SupervisorActionMergePR:             true,
+		SupervisorActionCloseIssue:          true,
+		SupervisorActionCloseIssueBatch:     true,
+		SupervisorActionDeleteWorktree:      true,
+		SupervisorActionChangeGlobalConfig:  true,
+		SupervisorActionApplyLessonProposal: true,
+		SupervisorActionSpawnReviewRepair:   true,
+		SupervisorActionRestartWorker:       true,
+		SupervisorActionStopWorker:          true,
 	}
 }
 
@@ -1398,6 +1400,7 @@ func knownSupervisorActionNames() []string {
 		SupervisorActionCloseIssueBatch,
 		SupervisorActionDeleteWorktree,
 		SupervisorActionChangeGlobalConfig,
+		SupervisorActionApplyLessonProposal,
 		SupervisorActionSpawnReviewRepair,
 		SupervisorActionRestartWorker,
 		SupervisorActionStopWorker,

--- a/internal/state/lesson_proposal_test.go
+++ b/internal/state/lesson_proposal_test.go
@@ -1,0 +1,73 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRecordLessonProposal_DedupsPendingFingerprint(t *testing.T) {
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	input := LessonProposal{
+		FailureClass:  "retry_exhausted",
+		Area:          "issue:640",
+		MinimalRepro:  "Session sup-155 status=retry_exhausted retry_count=3",
+		SuggestedRule: "Inspect failed attempts before retrying.",
+		Target:        LessonProposalTargetAgentsMD,
+	}
+
+	first, approval, created := s.RecordLessonProposal(input, now, "owner/repo", "owner/repo")
+	if !created || first == nil || approval == nil {
+		t.Fatalf("first created=%v proposal=%+v approval=%+v", created, first, approval)
+	}
+	if approval.LessonProposalID != first.ID {
+		t.Fatalf("approval lesson id = %q, want %q", approval.LessonProposalID, first.ID)
+	}
+
+	second, secondApproval, created := s.RecordLessonProposal(input, now.Add(time.Minute), "owner/repo", "owner/repo")
+	if created {
+		t.Fatal("duplicate proposal was created for same fingerprint")
+	}
+	if second == nil || second.ID != first.ID {
+		t.Fatalf("second = %+v, want existing %s", second, first.ID)
+	}
+	if secondApproval == nil || secondApproval.ID != approval.ID {
+		t.Fatalf("second approval = %+v, want existing %s", secondApproval, approval.ID)
+	}
+	if len(s.LessonProposals) != 1 || len(s.Approvals) != 1 {
+		t.Fatalf("counts proposals=%d approvals=%d, want 1/1", len(s.LessonProposals), len(s.Approvals))
+	}
+}
+
+func TestRejectLessonProposalApprovalMarksDeclined(t *testing.T) {
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	proposal, approval, created := s.RecordLessonProposal(LessonProposal{
+		FailureClass:  "review_repair_exhausted",
+		Area:          "pr:640",
+		MinimalRepro:  "PR #640 still has P1 findings after repair budget.",
+		SuggestedRule: "Address unresolved review findings only.",
+		Target:        LessonProposalTargetAgentsMD,
+	}, now, "owner/repo", "owner/repo")
+	if !created {
+		t.Fatal("proposal was not created")
+	}
+
+	rejected, err := s.RejectApproval(approval.ID, now.Add(time.Minute), "operator", "not general enough")
+	if err != nil {
+		t.Fatalf("RejectApproval: %v", err)
+	}
+	if rejected.Status != ApprovalStatusRejected {
+		t.Fatalf("approval status = %q, want rejected", rejected.Status)
+	}
+	stored, ok := s.FindLessonProposal(proposal.ID)
+	if !ok {
+		t.Fatalf("proposal %s missing", proposal.ID)
+	}
+	if stored.Status != LessonProposalStatusDeclined || stored.DeclinedAt == nil {
+		t.Fatalf("proposal = %+v, want declined timestamp", stored)
+	}
+	if stored.ResolutionActor != "operator" || stored.ResolutionNote != "not general enough" {
+		t.Fatalf("resolution = actor %q note %q", stored.ResolutionActor, stored.ResolutionNote)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -525,7 +525,40 @@ const (
 	// PR is held for operator review with the unresolved comments
 	// surfaced as evidence. NEVER a silent dead-end (#565).
 	StuckReviewRepairExhausted = "review_repair_exhausted"
+	StuckSearchGuardrailTrip   = "search_guardrail_trip"
 )
+
+const (
+	LessonProposalStatusPending  = "pending"
+	LessonProposalStatusApplied  = "applied"
+	LessonProposalStatusDeclined = "declined"
+
+	LessonProposalTargetWorkerPrompt = "worker_prompt"
+	LessonProposalTargetAgentsMD     = "agents_md"
+)
+
+// LessonProposal is a durable, approval-gated candidate rule derived from a
+// recurring terminal failure. Maestro records it for operator review, but never
+// applies it until the linked approval is explicitly approved.
+type LessonProposal struct {
+	ID              string            `json:"id"`
+	CreatedAt       time.Time         `json:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at,omitempty"`
+	FailureClass    string            `json:"failure_class"`
+	Area            string            `json:"area"`
+	MinimalRepro    string            `json:"minimal_repro"`
+	SuggestedRule   string            `json:"suggested_rule"`
+	Target          string            `json:"target"`
+	Fingerprint     string            `json:"fingerprint"`
+	Status          string            `json:"status"`
+	ApprovalID      string            `json:"approval_id,omitempty"`
+	SourceDecision  string            `json:"source_decision,omitempty"`
+	SourceTarget    *SupervisorTarget `json:"source_target,omitempty"`
+	AppliedAt       *time.Time        `json:"applied_at,omitempty"`
+	DeclinedAt      *time.Time        `json:"declined_at,omitempty"`
+	ResolutionActor string            `json:"resolution_actor,omitempty"`
+	ResolutionNote  string            `json:"resolution_note,omitempty"`
+}
 
 // SupervisorIssueCandidate describes the issue selected by queue policy without
 // exposing issue body content in persisted supervisor state.
@@ -766,6 +799,10 @@ type Approval struct {
 	// Both omitempty for back-compat with approvals created before #489.
 	Repo    string `json:"repo,omitempty"`
 	Project string `json:"project,omitempty"`
+
+	// LessonProposalID links apply_lesson_proposal approvals to the durable
+	// proposed rule they gate. Rejection/apply transitions update that record.
+	LessonProposalID string `json:"lesson_proposal_id,omitempty"`
 }
 
 type ApprovalAudit struct {
@@ -782,6 +819,7 @@ type State struct {
 	Missions            map[int]*Mission           `json:"missions,omitempty"` // parent issue number → mission
 	SupervisorDecisions []SupervisorDecision       `json:"supervisor_decisions,omitempty"`
 	Approvals           []Approval                 `json:"approvals,omitempty"`
+	LessonProposals     []LessonProposal           `json:"lesson_proposals,omitempty"`
 	OutcomeHealth       *outcome.HealthCheckResult `json:"outcome_health,omitempty"`
 	BackendHealth       map[string]BackendHealth   `json:"backend_health,omitempty"`
 	ProjectStatusSync   map[int]ProjectStatusSync  `json:"project_status_sync,omitempty"`
@@ -1125,6 +1163,7 @@ func (s *State) copyFrom(src *State) {
 	s.Missions = src.Missions
 	s.SupervisorDecisions = src.SupervisorDecisions
 	s.Approvals = src.Approvals
+	s.LessonProposals = src.LessonProposals
 	s.OutcomeHealth = src.OutcomeHealth
 	s.ProjectStatusSync = src.ProjectStatusSync
 	s.BackendHealth = src.BackendHealth
@@ -1166,6 +1205,9 @@ func mergeStateSnapshots(base, current, ours *State) (*State, error) {
 		return nil, err
 	}
 	if err := mergeSupervisorDecisions(merged, base, current, ours); err != nil {
+		return nil, err
+	}
+	if err := mergeLessonProposals(merged, base, current, ours); err != nil {
 		return nil, err
 	}
 	merged.OutcomeHealth = mergeOutcomeHealth(base.OutcomeHealth, current.OutcomeHealth, ours.OutcomeHealth)
@@ -1339,6 +1381,26 @@ func mergeSupervisorDecisions(merged, base, current, ours *State) error {
 	}
 	if len(merged.SupervisorDecisions) > DefaultSupervisorDecisionLimit {
 		merged.SupervisorDecisions = append([]SupervisorDecision(nil), merged.SupervisorDecisions[len(merged.SupervisorDecisions)-DefaultSupervisorDecisionLimit:]...)
+	}
+	return nil
+}
+
+func mergeLessonProposals(merged, base, current, ours *State) error {
+	merged.LessonProposals = cloneState(current).LessonProposals
+	keys := unionStringSets(lessonProposalKeys(base.LessonProposals), lessonProposalKeys(current.LessonProposals), lessonProposalKeys(ours.LessonProposals))
+	for _, key := range keys {
+		baseValue, baseOK := lessonProposalByKey(base.LessonProposals, key)
+		currentValue, currentOK := lessonProposalByKey(current.LessonProposals, key)
+		oursValue, oursOK := lessonProposalByKey(ours.LessonProposals, key)
+		resolved, keep, err := resolveListValue("lesson proposal "+key, baseValue, baseOK, currentValue, currentOK, oursValue, oursOK)
+		if err != nil {
+			return err
+		}
+		if keep {
+			merged.LessonProposals = upsertLessonProposal(merged.LessonProposals, resolved.(LessonProposal))
+		} else {
+			merged.LessonProposals = deleteLessonProposal(merged.LessonProposals, key)
+		}
 	}
 	return nil
 }
@@ -1558,6 +1620,54 @@ func deleteDecision(decisions []SupervisorDecision, key string) []SupervisorDeci
 	return filtered
 }
 
+func lessonProposalKeys(proposals []LessonProposal) map[string]bool {
+	keys := make(map[string]bool)
+	for _, proposal := range proposals {
+		keys[lessonProposalKey(proposal)] = true
+	}
+	return keys
+}
+
+func lessonProposalByKey(proposals []LessonProposal, key string) (LessonProposal, bool) {
+	for _, proposal := range proposals {
+		if lessonProposalKey(proposal) == key {
+			return proposal, true
+		}
+	}
+	return LessonProposal{}, false
+}
+
+func lessonProposalKey(proposal LessonProposal) string {
+	if proposal.ID != "" {
+		return proposal.ID
+	}
+	if proposal.Fingerprint != "" {
+		return "fingerprint:" + proposal.Fingerprint
+	}
+	return stableHash(proposal)
+}
+
+func upsertLessonProposal(proposals []LessonProposal, proposal LessonProposal) []LessonProposal {
+	key := lessonProposalKey(proposal)
+	for i := range proposals {
+		if lessonProposalKey(proposals[i]) == key {
+			proposals[i] = proposal
+			return proposals
+		}
+	}
+	return append(proposals, proposal)
+}
+
+func deleteLessonProposal(proposals []LessonProposal, key string) []LessonProposal {
+	filtered := proposals[:0]
+	for _, proposal := range proposals {
+		if lessonProposalKey(proposal) != key {
+			filtered = append(filtered, proposal)
+		}
+	}
+	return filtered
+}
+
 // NextSlotName returns "{prefix}-N" for the next available slot
 func (s *State) NextSlotName(prefix string) string {
 	name := fmt.Sprintf("%s-%d", prefix, s.NextSlot)
@@ -1696,6 +1806,152 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 	return &s.Approvals[len(s.Approvals)-1]
 }
 
+// RecordLessonProposal records a recurring-failure lesson candidate and mints a
+// linked pending approval. If the same failure class and area already has a
+// non-declined proposal, it returns that proposal without creating noise.
+func (s *State) RecordLessonProposal(proposal LessonProposal, now time.Time, repo, project string) (*LessonProposal, *Approval, bool) {
+	if s == nil {
+		return nil, nil, false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	proposal.CreatedAt = normalizedTime(firstNonZeroTime(proposal.CreatedAt, now))
+	proposal.UpdatedAt = normalizedTime(now)
+	proposal.FailureClass = strings.TrimSpace(proposal.FailureClass)
+	proposal.Area = strings.TrimSpace(proposal.Area)
+	proposal.MinimalRepro = strings.TrimSpace(proposal.MinimalRepro)
+	proposal.SuggestedRule = strings.TrimSpace(proposal.SuggestedRule)
+	proposal.Target = strings.TrimSpace(proposal.Target)
+	if proposal.Target == "" {
+		proposal.Target = LessonProposalTargetAgentsMD
+	}
+	if proposal.Status == "" {
+		proposal.Status = LessonProposalStatusPending
+	}
+	if proposal.Fingerprint == "" {
+		proposal.Fingerprint = LessonProposalFingerprint(proposal.FailureClass, proposal.Area)
+	}
+	if proposal.ID == "" {
+		proposal.ID = lessonProposalID(proposal.Fingerprint)
+	}
+	if proposal.FailureClass == "" || proposal.Area == "" || proposal.SuggestedRule == "" {
+		return nil, nil, false
+	}
+	for i := range s.LessonProposals {
+		existing := &s.LessonProposals[i]
+		if existing.Fingerprint != proposal.Fingerprint {
+			continue
+		}
+		if existing.Status == LessonProposalStatusDeclined {
+			continue
+		}
+		return existing, s.findApprovalByLessonProposalID(existing.ID), false
+	}
+
+	s.LessonProposals = append(s.LessonProposals, proposal)
+	stored := &s.LessonProposals[len(s.LessonProposals)-1]
+	approval := Approval{
+		ID:               "approval-" + stored.ID,
+		CreatedAt:        stored.CreatedAt,
+		UpdatedAt:        stored.UpdatedAt,
+		Action:           "apply_lesson_proposal",
+		Summary:          fmt.Sprintf("Apply lesson proposal for %s in %s.", stored.FailureClass, stored.Area),
+		Risk:             "approval_gated",
+		Evidence:         []string{stored.MinimalRepro, stored.SuggestedRule},
+		Status:           ApprovalStatusPending,
+		Repo:             repo,
+		Project:          project,
+		LessonProposalID: stored.ID,
+	}
+	approval.PayloadHash = approval.ComputePayloadHash()
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:          stored.UpdatedAt,
+		Event:       ApprovalAuditCreated,
+		PayloadHash: approval.PayloadHash,
+	})
+	s.Approvals = append(s.Approvals, approval)
+	stored.ApprovalID = approval.ID
+	return stored, &s.Approvals[len(s.Approvals)-1], true
+}
+
+func firstNonZeroTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}
+
+func LessonProposalFingerprint(failureClass, area string) string {
+	return stableHash(struct {
+		FailureClass string `json:"failure_class"`
+		Area         string `json:"area"`
+	}{
+		FailureClass: strings.ToLower(strings.TrimSpace(failureClass)),
+		Area:         strings.ToLower(strings.TrimSpace(area)),
+	})
+}
+
+func lessonProposalID(fingerprint string) string {
+	fp := strings.TrimSpace(fingerprint)
+	if len(fp) > 12 {
+		fp = fp[:12]
+	}
+	if fp == "" {
+		fp = time.Now().UTC().Format("20060102T150405")
+	}
+	return "lesson-" + fp
+}
+
+func (s *State) findApprovalByLessonProposalID(id string) *Approval {
+	for i := range s.Approvals {
+		if s.Approvals[i].LessonProposalID == id {
+			return &s.Approvals[i]
+		}
+	}
+	return nil
+}
+
+func (s *State) FindLessonProposal(id string) (*LessonProposal, bool) {
+	for i := range s.LessonProposals {
+		proposal := &s.LessonProposals[i]
+		if proposal.ID == id || proposal.Fingerprint == id {
+			return proposal, true
+		}
+	}
+	return nil, false
+}
+
+func (s *State) MarkLessonProposalApplied(id string, now time.Time, actor, note string) bool {
+	proposal, ok := s.FindLessonProposal(id)
+	if !ok {
+		return false
+	}
+	at := normalizedTime(now)
+	proposal.Status = LessonProposalStatusApplied
+	proposal.UpdatedAt = at
+	proposal.AppliedAt = &at
+	proposal.ResolutionActor = actor
+	proposal.ResolutionNote = note
+	return true
+}
+
+func (s *State) MarkLessonProposalDeclined(id string, now time.Time, actor, note string) bool {
+	proposal, ok := s.FindLessonProposal(id)
+	if !ok {
+		return false
+	}
+	at := normalizedTime(now)
+	proposal.Status = LessonProposalStatusDeclined
+	proposal.UpdatedAt = at
+	proposal.DeclinedAt = &at
+	proposal.ResolutionActor = actor
+	proposal.ResolutionNote = note
+	return true
+}
+
 // approvalTargetsEqual returns true if two SupervisorTarget pointers refer
 // to the same target identity (issue/pr/head_sha/session). Used by the
 // at-mint dedup check in RecordPendingApprovalForDecision. HeadSHA is
@@ -1785,6 +2041,9 @@ func (s *State) RejectApproval(id string, now time.Time, actor, reason string) (
 		PayloadHash:     approval.PayloadHash,
 		TargetStateHash: approval.TargetStateHash,
 	})
+	if approval.LessonProposalID != "" {
+		s.MarkLessonProposalDeclined(approval.LessonProposalID, approval.UpdatedAt, actor, reason)
+	}
 	return approval, nil
 }
 
@@ -1989,12 +2248,13 @@ func spawnWorkerApprovalMatchesSession(approval *Approval, slot string, sess *Se
 
 func (a Approval) ComputePayloadHash() string {
 	return stableHash(approvalPayload{
-		DecisionID: a.DecisionID,
-		Action:     a.Action,
-		Target:     a.Target,
-		Summary:    a.Summary,
-		Risk:       a.Risk,
-		Evidence:   a.Evidence,
+		DecisionID:       a.DecisionID,
+		Action:           a.Action,
+		Target:           a.Target,
+		Summary:          a.Summary,
+		Risk:             a.Risk,
+		Evidence:         a.Evidence,
+		LessonProposalID: a.LessonProposalID,
 	})
 }
 
@@ -2029,12 +2289,13 @@ func (s *State) ApprovalTargetStateHash(target *SupervisorTarget) string {
 }
 
 type approvalPayload struct {
-	DecisionID string            `json:"decision_id,omitempty"`
-	Action     string            `json:"action"`
-	Target     *SupervisorTarget `json:"target,omitempty"`
-	Summary    string            `json:"summary"`
-	Risk       string            `json:"risk"`
-	Evidence   []string          `json:"evidence,omitempty"`
+	DecisionID       string            `json:"decision_id,omitempty"`
+	Action           string            `json:"action"`
+	Target           *SupervisorTarget `json:"target,omitempty"`
+	Summary          string            `json:"summary"`
+	Risk             string            `json:"risk"`
+	Evidence         []string          `json:"evidence,omitempty"`
+	LessonProposalID string            `json:"lesson_proposal_id,omitempty"`
 }
 
 type approvalTargetStateSnapshot struct {

--- a/internal/supervisor/lesson_proposal.go
+++ b/internal/supervisor/lesson_proposal.go
@@ -1,0 +1,154 @@
+package supervisor
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func recordLessonProposalForDecision(cfg *config.Config, st *state.State, decision state.SupervisorDecision) (*state.LessonProposal, bool) {
+	proposal, ok := lessonProposalFromDecision(cfg, st, decision)
+	if !ok {
+		return nil, false
+	}
+	stored, _, created := st.RecordLessonProposal(proposal, decision.CreatedAt, decision.Repo, decision.Project)
+	return stored, created
+}
+
+func lessonProposalFromDecision(cfg *config.Config, st *state.State, decision state.SupervisorDecision) (state.LessonProposal, bool) {
+	if cfg == nil || st == nil {
+		return state.LessonProposal{}, false
+	}
+	for _, stuck := range decision.StuckStates {
+		if proposal, ok := lessonProposalFromStuckState(cfg, decision, stuck); ok {
+			return proposal, true
+		}
+	}
+	for slot, sess := range st.Sessions {
+		if sess == nil {
+			continue
+		}
+		if sess.Status == state.StatusConflictFailed {
+			target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}
+			stuck := state.SupervisorStuckState{
+				Code:              "conflict_unresolvable",
+				Severity:          SeverityBlocked,
+				Summary:           fmt.Sprintf("Issue #%d reached conflict_failed in session %s.", sess.IssueNumber, slot),
+				RecommendedAction: "Resolve the rebase or merge conflict manually before retrying.",
+				Target:            target,
+				Evidence:          []string{fmt.Sprintf("Session %s status=conflict_failed", slot)},
+			}
+			return lessonProposalFromStuckState(cfg, decision, stuck)
+		}
+	}
+	return state.LessonProposal{}, false
+}
+
+func lessonProposalFromStuckState(cfg *config.Config, decision state.SupervisorDecision, stuck state.SupervisorStuckState) (state.LessonProposal, bool) {
+	failureClass := lessonFailureClass(stuck.Code)
+	if failureClass == "" {
+		return state.LessonProposal{}, false
+	}
+	area := lessonArea(decision.Target, stuck.Target)
+	minimalRepro := lessonMinimalRepro(stuck)
+	target := state.LessonProposalTargetAgentsMD
+	if strings.TrimSpace(cfg.WorkerPrompt) != "" {
+		target = state.LessonProposalTargetWorkerPrompt
+	}
+	proposal := state.LessonProposal{
+		CreatedAt:      decision.CreatedAt,
+		FailureClass:   failureClass,
+		Area:           area,
+		MinimalRepro:   minimalRepro,
+		SuggestedRule:  lessonSuggestedRule(failureClass, minimalRepro),
+		Target:         target,
+		Status:         state.LessonProposalStatusPending,
+		SourceDecision: decision.ID,
+		SourceTarget:   cloneLessonTarget(firstTarget(stuck.Target, decision.Target)),
+	}
+	if proposal.CreatedAt.IsZero() {
+		proposal.CreatedAt = time.Now().UTC()
+	}
+	return proposal, true
+}
+
+func lessonFailureClass(code string) string {
+	switch strings.TrimSpace(code) {
+	case "retry_exhausted", "retry_exhausted_open_pr":
+		return "retry_exhausted"
+	case state.StuckReviewRepairExhausted:
+		return "review_repair_exhausted"
+	case "conflict_unresolvable", "unmergeable_pr":
+		return "conflict_unresolvable"
+	case state.StuckSearchGuardrailTrip:
+		return "search_guardrail_trip"
+	default:
+		return ""
+	}
+}
+
+func lessonArea(targets ...*state.SupervisorTarget) string {
+	target := firstTarget(targets...)
+	if target == nil {
+		return "project"
+	}
+	switch {
+	case target.Issue > 0:
+		return fmt.Sprintf("issue:%d", target.Issue)
+	case target.PR > 0:
+		return fmt.Sprintf("pr:%d", target.PR)
+	case strings.TrimSpace(target.Session) != "":
+		return "session:" + strings.TrimSpace(target.Session)
+	default:
+		return "project"
+	}
+}
+
+func lessonMinimalRepro(stuck state.SupervisorStuckState) string {
+	parts := []string{strings.TrimSpace(stuck.Summary)}
+	for _, evidence := range stuck.Evidence {
+		if evidence = strings.TrimSpace(evidence); evidence != "" {
+			parts = append(parts, evidence)
+		}
+	}
+	if action := strings.TrimSpace(stuck.RecommendedAction); action != "" {
+		parts = append(parts, "recommended_action="+action)
+	}
+	return strings.Join(parts, " | ")
+}
+
+func lessonSuggestedRule(failureClass, minimalRepro string) string {
+	switch failureClass {
+	case "retry_exhausted":
+		return "When a previous Maestro attempt is marked retry_exhausted, inspect the saved failure context before changing code, identify the smallest failing step that exhausted retries, and change the implementation or validation plan to avoid repeating that step before opening or updating a PR."
+	case "review_repair_exhausted":
+		return "When review repair is exhausted, stop making broad edits and address only the unresolved high-severity review findings on the current PR head; summarize each finding and the exact file-level fix before pushing another update."
+	case "conflict_unresolvable":
+		return "When a branch has unresolved rebase or merge conflicts, resolve the conflict first with the smallest file-scoped change, run the affected tests, and do not continue feature work until the branch is clean against the base branch."
+	case "search_guardrail_trip":
+		return "When searching the repository, run rg, grep, or find from the assigned worktree and scope path arguments to that worktree; do not search broad filesystem roots unless the operator explicitly grants a one-command broad-search override."
+	default:
+		return "Before retrying a recurring Maestro failure, inspect the recorded stuck state, identify the repeated mistake, and add a narrow file- or workflow-level guard so the next attempt avoids the same failure mode."
+	}
+}
+
+func firstTarget(targets ...*state.SupervisorTarget) *state.SupervisorTarget {
+	for _, target := range targets {
+		if target != nil {
+			return target
+		}
+	}
+	return nil
+}
+
+func cloneLessonTarget(target *state.SupervisorTarget) *state.SupervisorTarget {
+	if target == nil {
+		return nil
+	}
+	clone := *target
+	clone.Issues = append([]state.SupervisorIssueTarget(nil), target.Issues...)
+	return &clone
+}

--- a/internal/supervisor/lesson_proposal_test.go
+++ b/internal/supervisor/lesson_proposal_test.go
@@ -1,0 +1,64 @@
+package supervisor
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestRecordLessonProposalForDecision_GeneratesOnceForRetryExhausted(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:         "owner/repo",
+		WorkerPrompt: filepath.Join(dir, "worker-prompt.md"),
+	}
+	st := state.NewState()
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	decision := state.SupervisorDecision{
+		ID:        "decision-lesson",
+		CreatedAt: now,
+		Repo:      "owner/repo",
+		Project:   "owner/repo",
+		Target:    &state.SupervisorTarget{Issue: 640, Session: "sup-155"},
+		StuckStates: []state.SupervisorStuckState{{
+			Code:              "retry_exhausted",
+			Severity:          SeverityBlocked,
+			Summary:           "Issue #640 exhausted its retry budget.",
+			Evidence:          []string{"Session sup-155 status=retry_exhausted retry_count=3"},
+			RecommendedAction: ActionReviewRetryExhausted,
+			Target:            &state.SupervisorTarget{Issue: 640, Session: "sup-155"},
+		}},
+	}
+
+	first, created := recordLessonProposalForDecision(cfg, st, decision)
+	if !created || first == nil {
+		t.Fatalf("created = %v proposal=%+v, want first proposal", created, first)
+	}
+	if first.FailureClass != "retry_exhausted" || first.Area != "issue:640" {
+		t.Fatalf("proposal = %+v, want retry_exhausted issue area", first)
+	}
+	if first.Target != state.LessonProposalTargetWorkerPrompt {
+		t.Fatalf("target = %q, want worker_prompt", first.Target)
+	}
+	if !strings.Contains(first.MinimalRepro, "retry_count=3") {
+		t.Fatalf("minimal repro = %q, want evidence", first.MinimalRepro)
+	}
+	if len(st.Approvals) != 1 || st.Approvals[0].Action != config.SupervisorActionApplyLessonProposal {
+		t.Fatalf("approvals = %+v, want one apply_lesson_proposal approval", st.Approvals)
+	}
+
+	second, created := recordLessonProposalForDecision(cfg, st, decision)
+	if created {
+		t.Fatal("duplicate retry_exhausted proposal created")
+	}
+	if second == nil || second.ID != first.ID {
+		t.Fatalf("duplicate proposal = %+v, want existing %s", second, first.ID)
+	}
+	if len(st.LessonProposals) != 1 || len(st.Approvals) != 1 {
+		t.Fatalf("counts proposals=%d approvals=%d, want 1/1", len(st.LessonProposals), len(st.Approvals))
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -293,6 +293,9 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 		// restart). Lives inside the dry-run guard so the resulting
 		// state transitions are persisted by the state.Save below.
 		executeApprovedApprovals(cfg, st, reader)
+		if proposal, created := recordLessonProposalForDecision(cfg, st, decision); created && proposal != nil {
+			log.Printf("[supervisor] proposed lesson %s for %s/%s; approval=%s", proposal.ID, proposal.FailureClass, proposal.Area, proposal.ApprovalID)
+		}
 		if decisionRequiresApproval(cfg, decision) {
 			// #505: gate the mint on the executor registry. A verb the
 			// executor cannot handle would otherwise pile up
@@ -3523,6 +3526,7 @@ func executeApprovedApprovals(cfg *config.Config, st *state.State, reader Reader
 		Cfg:       cfg,
 		Sessions:  approver.SessionLookupFunc(st.SessionAt),
 		Workers:   newWorkerController(cfg),
+		State:     st,
 	}
 	for _, a := range approvals {
 		res := ex.Execute(a)


### PR DESCRIPTION
Refs #640

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a \"lesson-capture loop\" in the supervisor: when a session hits a terminal failure (retry exhausted, review repair exhausted, unresolvable conflict, search guardrail trip), a `LessonProposal` is recorded in state and a linked `apply_lesson_proposal` approval is minted. An operator must explicitly approve before the suggested rule is appended to the worker prompt or `AGENTS.md`.

- **`internal/state/state.go`**: New `LessonProposal` type, `RecordLessonProposal` / `FindLessonProposal` / `MarkLessonProposalApplied` / `MarkLessonProposalDeclined` methods, merge helpers, and `RejectApproval` integration that marks the linked proposal declined.
- **`internal/approver/executor.go`**: New `executeApplyLessonProposal` handler formats a Markdown block and appends it to the configured target file (with file-level dedup), then marks the proposal applied in state.
- **`internal/supervisor/lesson_proposal.go`**: New file derives proposals from stuck states and from any lingering `conflict_failed` session in state, with dedup by failure-class+area fingerprint.

<h3>Confidence Score: 3/5</h3>

Two correctness issues in the core state-mutation path should be addressed before this ships to production.

The proposal ID is derived deterministically from the fingerprint, so once an operator declines a proposal and the same failure recurs, RecordLessonProposal appends a second record with the identical ID. FindLessonProposal returns the first (declined) match, causing MarkLessonProposalApplied to update the wrong record while the new pending proposal is silently orphaned. Separately, the conflict_failed session scan in lessonProposalFromDecision is not scoped to the current decision's sessions, so any lingering conflict-failed session can attach a lesson to an entirely unrelated decision.

internal/state/state.go (RecordLessonProposal / lessonProposalID) and internal/supervisor/lesson_proposal.go (lessonProposalFromDecision) need the most attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds LessonProposal type, state mutations, merge logic, and RecordLessonProposal; deterministic ID generation causes duplicate IDs when a declined proposal is re-created for the same fingerprint |
| internal/supervisor/lesson_proposal.go | New file: derives lesson proposals from stuck states and conflict-failed sessions; fallback session scan is unconstrained by the current decision, potentially attributing conflict lessons to unrelated decisions |
| internal/approver/executor.go | Adds executeApplyLessonProposal handler: reads proposal, formats and appends a Markdown block to the target file, marks proposal applied; file-level dedup and nil guards are correct |
| internal/supervisor/supervisor.go | Wires recordLessonProposalForDecision into the RunOnce loop and passes State into executeApprovedApprovals executor; straightforward integration |
| internal/state/lesson_proposal_test.go | Tests dedup for pending fingerprint and declined-proposal state transition; decline + re-creation path not tested |
| internal/approver/executor_test.go | Adds happy-path test for apply_lesson_proposal execution covering file write and state mutation; covers the normal flow but not the re-creation-after-decline scenario |
| internal/supervisor/lesson_proposal_test.go | Tests that retry_exhausted decisions generate exactly one proposal and dedup on the second call; looks correct for the paths tested |
| internal/config/config.go | Adds SupervisorActionApplyLessonProposal constant and registers it in all three action maps; alignment-only whitespace changes elsewhere |
| internal/approver/registry.go | Registers apply_lesson_proposal in KnownApprovalActions; straightforward addition |
| cmd/maestro/main.go | Passes State into the approval executor for the supervise-approval command path; minimal and correct |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/state/state.go:1835-1875
**Duplicate proposal/approval IDs after decline + re-creation**

`lessonProposalID` is a pure function of the fingerprint, so a declined proposal and any successor for the same failure class+area receive the exact same ID (e.g. `"lesson-abcdef012345"`). The dedup loop correctly skips the declined entry and appends a new proposal, but that new record shares its ID with the declined one. Downstream, `FindLessonProposal` iterates from index 0 and returns the first match — the already-declined record. When `executeApplyLessonProposal` runs, it therefore mutates the declined record (marking it `applied`) while the actual new pending proposal is left perpetually in `pending` state with an orphaned approval. The same collision affects the linked approval ID (`"approval-" + stored.ID`), producing two `Approval` entries with identical `.ID` values in the slice.

A concrete failure path: (1) `retry_exhausted` for `issue:640` → proposal + approval created; (2) operator rejects → both marked declined/rejected; (3) same issue exhausts retries again → `RecordLessonProposal` creates a second record with the identical ID; (4) operator approves → executor applies file content correctly but marks the wrong (declined) state record as `applied`.

### Issue 2 of 2
internal/supervisor/lesson_proposal.go:30-46
**Conflict-failed session scan is unconstrained by the current decision**

The fallback loop iterates `st.Sessions` and returns a lesson proposal for the *first* session anywhere in state that has `status == conflict_failed`, regardless of whether the session is related to the incoming `decision`. If a conflict-failed session is lingering from a previous cycle, every unrelated supervisor decision (e.g. a routine merge-PR decision for a different issue) will trigger this branch and attribute a `conflict_unresolvable` lesson proposal to that unrelated `decision.ID`. Dedup by fingerprint prevents creating more than one proposal for a given issue, but the first creation will carry a `SourceDecision` that points to whatever decision happened to fire first, not the one that actually put the session into `conflict_failed`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["supervisor: add approval-gated lesson pr..."](https://github.com/befeast/maestro/commit/92e2772ab55f8ba6d13e7249d8bc3019ac584d0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35336306)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->