### PR TITLE
pipeline: enable the real plan/implement/validate phase pipeline behind a 'pipeline:full' opt-in label

### DIFF
--- a/docs/po-spec-workflow.md
+++ b/docs/po-spec-workflow.md
@@ -37,6 +37,11 @@ The supervisor selects issues that match **all** of:
 
 Source of truth: `~/.maestro/maestro.d/maestro-supervisor-dogfood.yaml`.
 
+For hard or architectural dogfood issues, add `pipeline:full` to that GitHub
+issue. The dogfood config should keep `pipeline.enabled` unset or `false` so
+routine `maestro-ready` issues continue to use the cheaper single implementer
+session by default.
+
 If a spec needs to wait, add `blocked` and explain in a comment. Do not delete the issue — supervisor needs the
 audit trail.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -541,18 +541,19 @@ type RoleConfig struct {
 	MaxRuntimeMinutes int    `yaml:"max_runtime_minutes"` // override per-role max runtime (0 = use global)
 }
 
-// PipelineConfig controls the planner → implementer → validator pipeline
-// and the GSD-inspired pre-worker context preparation phases.
+// PipelineConfig controls the planner → implementer → validator phase pipeline
+// and deterministic pre-worker context preparation phases.
 type PipelineConfig struct {
 	// Phase-based pipeline (planner → implementer → validator)
-	Enabled   bool       `yaml:"enabled"`   // enable 3-phase pipeline (default: false = legacy single-phase)
+	Enabled   bool       `yaml:"enabled"`   // enable 3-phase pipeline globally (default: false; issue label pipeline:full opts in per worker)
 	Planner   RoleConfig `yaml:"planner"`   // planner role settings
 	Validator RoleConfig `yaml:"validator"` // validator role settings
 	// Implementer uses the existing worker_prompt / bug_prompt / enhancement_prompt settings.
 
-	// GSD-inspired pre-worker context preparation phases
-	Research       bool  `yaml:"research"`        // spawn a research subagent before worker starts (default: false)
-	PlanValidation *bool `yaml:"plan_validation"` // validate a plan before coding starts (default: true)
+	// Deterministic pre-worker context preparation phases. These are heuristic
+	// local scans/checks, not separate agent sessions.
+	Research       bool  `yaml:"research"`        // scan repo context before worker starts (default: false)
+	PlanValidation *bool `yaml:"plan_validation"` // heuristic plan coverage check before coding starts (default: true)
 	TestMapping    *bool `yaml:"test_mapping"`    // map requirements to verify commands (default: true)
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -31,6 +31,7 @@ const (
 	minProjectGraphQLRemaining = 100
 	projectBoardSweepInterval  = 30 * time.Minute
 	projectBoardSweepRetry     = 10 * time.Minute
+	pipelineFullLabel          = "pipeline:full"
 )
 
 // Orchestrator coordinates all agent sessions
@@ -1913,7 +1914,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				// Pipeline phase transition: if this is a pipeline session,
 				// try to advance to the next phase before falling through
 				// to normal dead-worker handling.
-				if pipeline.IsEnabled(o.cfg) && o.advancePipeline(slotName, sess) {
+				if sess.Phase != state.PhaseNone && o.advancePipeline(slotName, sess) {
 					continue
 				}
 
@@ -3513,11 +3514,34 @@ func (o *Orchestrator) listOpenIssues(labels []string) ([]github.Issue, error) {
 	return o.gh.ListOpenIssues(labels)
 }
 
-func (o *Orchestrator) startWorker(s *state.State, issue github.Issue, promptBase, backend string) (string, error) {
-	if o.workerStartFn != nil {
-		return o.workerStartFn(o.cfg, s, o.repo, issue, promptBase, backend)
+func (o *Orchestrator) startWorker(cfg *config.Config, s *state.State, issue github.Issue, promptBase, backend string) (string, error) {
+	if cfg == nil {
+		cfg = o.cfg
 	}
-	return worker.Start(o.cfg, s, o.repo, issue, promptBase, backend)
+	if o.workerStartFn != nil {
+		return o.workerStartFn(cfg, s, o.repo, issue, promptBase, backend)
+	}
+	return worker.Start(cfg, s, o.repo, issue, promptBase, backend)
+}
+
+func issueHasLabel(issue github.Issue, label string) bool {
+	for _, issueLabel := range issue.Labels {
+		if strings.EqualFold(strings.TrimSpace(issueLabel.Name), label) {
+			return true
+		}
+	}
+	return false
+}
+
+func pipelineConfigForIssue(base *config.Config, issue github.Issue) (*config.Config, bool) {
+	if base == nil || !issueHasLabel(issue, pipelineFullLabel) {
+		return base, false
+	}
+	cfg := *base
+	cfg.Pipeline.Enabled = true
+	cfg.Pipeline.Planner.Enabled = true
+	cfg.Pipeline.Validator.Enabled = true
+	return &cfg, true
 }
 
 func (o *Orchestrator) orderedQueueIssueDone(s *state.State, issueNumber int) (bool, string, error) {
@@ -4062,8 +4086,10 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			log.Printf("[orch] allowing repair worker for issue #%d despite open PR because supervisor selected spawn_repair_worker", issue.Number)
 		}
 
-		// Determine initial phase and backend
-		initialPhase := pipeline.InitialPhase(o.cfg)
+		// Determine initial phase and backend. A pipeline:full issue label
+		// enables the phase pipeline only for this worker's copied config.
+		workerCfg, pipelineFull := pipelineConfigForIssue(o.cfg, issue)
+		initialPhase := pipeline.InitialPhase(workerCfg)
 		var backendName string
 		var promptBase string
 		// backendReason tracks why this backend was chosen so the dashboard /
@@ -4092,8 +4118,8 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		} else if initialPhase != state.PhaseNone && initialPhase != state.PhaseImplement {
 			// Pipeline mode with planner — use planner backend and raw template
 			// (worker.Start → assemblePrompt will substitute {{WORKTREE}} etc.)
-			backendName = pipeline.BackendForPhase(o.cfg, initialPhase)
-			promptBase = pipeline.PromptTemplateForPhase(o.cfg, initialPhase)
+			backendName = pipeline.BackendForPhase(workerCfg, initialPhase)
+			promptBase = pipeline.PromptTemplateForPhase(workerCfg, initialPhase)
 			backendReason = "phase"
 		} else {
 			// Normal mode or pipeline starting at implement — use standard resolution
@@ -4124,7 +4150,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		}
 
 		log.Printf("[orch] starting worker for issue #%d: %s (backend=%s, reason=%s, phase=%s, long_running=%v)", issue.Number, issue.Title, backendName, backendReason, initialPhase, longRunning)
-		slotName, err := o.startWorker(s, issue, promptBase, backendName)
+		slotName, err := o.startWorker(workerCfg, s, issue, promptBase, backendName)
 		if err != nil {
 			log.Printf("[orch] start worker for issue #%d: %v", issue.Number, err)
 			o.notifier.Sendf("❌ maestro: failed to start worker for issue #%d (%s): %v",
@@ -4137,6 +4163,9 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		}
 		if initialPhase != state.PhaseNone {
 			s.Sessions[slotName].Phase = initialPhase
+		}
+		if pipelineFull {
+			s.Sessions[slotName].PipelineFull = true
 		}
 		// #427: stamp the backend selection reason on the session so the
 		// dashboard / fleet API can show why this backend was chosen

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/outcome"
+	"github.com/befeast/maestro/internal/pipeline"
 	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/supervisor"
@@ -4339,6 +4340,103 @@ func TestStartNewWorkers_StampsBackendSelectionReason_RouterError(t *testing.T) 
 	}
 	if sess.BackendSelection.SelectionReason != router.ReasonRouterError {
 		t.Errorf("BackendSelection.SelectionReason = %q, want %q", sess.BackendSelection.SelectionReason, router.ReasonRouterError)
+	}
+}
+
+func TestStartNewWorkers_PipelineFullLabelSelectsPlannerPhase(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude", "planner")
+	cfg.Pipeline.Enabled = false
+	cfg.Pipeline.Planner.Backend = "planner"
+	issues := []github.Issue{makeIssue(641, "Use full pipeline", "pipeline:full")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+
+	var startCfg *config.Config
+	var promptBase string
+	o.workerStartFn = func(cfg *config.Config, s *state.State, repo string, issue github.Issue, prompt, backend string) (string, error) {
+		startCfg = cfg
+		promptBase = prompt
+		s.Sessions["slot-1"] = &state.Session{
+			IssueNumber: issue.Number,
+			IssueTitle:  issue.Title,
+			Status:      state.StatusRunning,
+			PID:         1001,
+			StartedAt:   time.Now().UTC(),
+		}
+		*started = append(*started, issue.Number)
+		return "slot-1", nil
+	}
+
+	s := state.NewState()
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 1 || (*started)[0] != 641 {
+		t.Fatalf("started = %v, want [641]", *started)
+	}
+	if cfg.Pipeline.Enabled {
+		t.Fatal("global config Pipeline.Enabled was mutated")
+	}
+	if startCfg == nil {
+		t.Fatal("worker config was not captured")
+	}
+	if !startCfg.Pipeline.Enabled || !startCfg.Pipeline.Planner.Enabled || !startCfg.Pipeline.Validator.Enabled {
+		t.Fatalf("worker config did not enable full pipeline: %+v", startCfg.Pipeline)
+	}
+	sess := s.Sessions["slot-1"]
+	if sess == nil {
+		t.Fatal("session not recorded")
+	}
+	if sess.Phase != state.PhasePlan {
+		t.Fatalf("session phase = %q, want %q", sess.Phase, state.PhasePlan)
+	}
+	if !sess.PipelineFull {
+		t.Fatal("session PipelineFull was not recorded")
+	}
+	if sess.BackendSelection == nil || sess.BackendSelection.SelectedBackend != "planner" || sess.BackendSelection.SelectionReason != "phase" {
+		t.Fatalf("backend selection = %+v, want planner phase", sess.BackendSelection)
+	}
+	if !strings.Contains(promptBase, pipeline.PlanFile) || !strings.Contains(promptBase, pipeline.ValidationFile) {
+		t.Fatalf("planner prompt does not mention handoff artifacts %s/%s", pipeline.PlanFile, pipeline.ValidationFile)
+	}
+}
+
+func TestStartNewWorkers_WithoutPipelineFullLabelKeepsSingleSession(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.Pipeline.Enabled = false
+	issues := []github.Issue{makeIssue(642, "Routine issue")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+
+	var startCfg *config.Config
+	o.workerStartFn = func(cfg *config.Config, s *state.State, repo string, issue github.Issue, prompt, backend string) (string, error) {
+		startCfg = cfg
+		s.Sessions["slot-1"] = &state.Session{
+			IssueNumber: issue.Number,
+			IssueTitle:  issue.Title,
+			Status:      state.StatusRunning,
+			PID:         1001,
+			StartedAt:   time.Now().UTC(),
+		}
+		*started = append(*started, issue.Number)
+		return "slot-1", nil
+	}
+
+	s := state.NewState()
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 1 || (*started)[0] != 642 {
+		t.Fatalf("started = %v, want [642]", *started)
+	}
+	if startCfg != cfg {
+		t.Fatal("unlabeled issue should use the original config")
+	}
+	sess := s.Sessions["slot-1"]
+	if sess == nil {
+		t.Fatal("session not recorded")
+	}
+	if sess.Phase != state.PhaseNone {
+		t.Fatalf("session phase = %q, want no pipeline phase", sess.Phase)
+	}
+	if sess.PipelineFull {
+		t.Fatal("unlabeled session should not record PipelineFull")
 	}
 }
 

--- a/internal/orchestrator/pipeline.go
+++ b/internal/orchestrator/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/pipeline"
 	"github.com/befeast/maestro/internal/state"
@@ -33,6 +34,7 @@ func (o *Orchestrator) advancePipeline(slotName string, sess *state.Session) boo
 
 // handlePlanComplete checks if the planner produced artifacts and advances to implement phase.
 func (o *Orchestrator) handlePlanComplete(slotName string, sess *state.Session) bool {
+	cfg := o.pipelineConfigForSession(sess)
 	o.runAfterRunHook(sess)
 
 	if !pipeline.PlanArtifactsExist(sess.Worktree) {
@@ -60,9 +62,9 @@ func (o *Orchestrator) handlePlanComplete(slotName string, sess *state.Session) 
 	}
 
 	promptContent := o.buildImplementerPrompt(sess, issue)
-	backendName := pipeline.BackendForPhase(o.cfg, state.PhaseImplement)
+	backendName := pipeline.BackendForPhase(cfg, state.PhaseImplement)
 
-	if err := o.startPhase(slotName, sess, promptContent, backendName); err != nil {
+	if err := o.startPhase(cfg, slotName, sess, promptContent, backendName); err != nil {
 		log.Printf("[pipeline] start implement phase for %s: %v — marking dead", slotName, err)
 		sess.Status = state.StatusDead
 		now := time.Now().UTC()
@@ -78,9 +80,10 @@ func (o *Orchestrator) handlePlanComplete(slotName string, sess *state.Session) 
 
 // handleImplementComplete advances to validate phase or proceeds to PR flow.
 func (o *Orchestrator) handleImplementComplete(slotName string, sess *state.Session) bool {
+	cfg := o.pipelineConfigForSession(sess)
 	o.runAfterRunHook(sess)
 
-	nextPhase := pipeline.NextPhase(o.cfg, state.PhaseImplement)
+	nextPhase := pipeline.NextPhase(cfg, state.PhaseImplement)
 	if nextPhase == state.PhaseNone {
 		// No validator — fall through to normal dead-worker handling (PR detection, retry, etc.)
 		log.Printf("[pipeline] implementer %s done, no validator configured — returning to normal flow", slotName)
@@ -101,10 +104,10 @@ func (o *Orchestrator) handleImplementComplete(slotName string, sess *state.Sess
 		return true
 	}
 
-	promptContent := pipeline.PromptForPhase(o.cfg, state.PhaseValidate, issue, sess.Worktree, sess.Branch)
-	backendName := pipeline.BackendForPhase(o.cfg, state.PhaseValidate)
+	promptContent := pipeline.PromptForPhase(cfg, state.PhaseValidate, issue, sess.Worktree, sess.Branch)
+	backendName := pipeline.BackendForPhase(cfg, state.PhaseValidate)
 
-	if err := o.startPhase(slotName, sess, promptContent, backendName); err != nil {
+	if err := o.startPhase(cfg, slotName, sess, promptContent, backendName); err != nil {
 		log.Printf("[pipeline] start validate phase for %s: %v — marking dead", slotName, err)
 		sess.Status = state.StatusDead
 		now := time.Now().UTC()
@@ -120,6 +123,7 @@ func (o *Orchestrator) handleImplementComplete(slotName string, sess *state.Sess
 
 // handleValidateComplete checks validation result and either proceeds to PR flow or retries implementer.
 func (o *Orchestrator) handleValidateComplete(slotName string, sess *state.Session) bool {
+	cfg := o.pipelineConfigForSession(sess)
 	o.runAfterRunHook(sess)
 
 	passed, feedback, err := pipeline.ValidationPassed(sess.Worktree)
@@ -166,9 +170,9 @@ func (o *Orchestrator) handleValidateComplete(slotName string, sess *state.Sessi
 	}
 
 	promptContent := o.buildImplementerPrompt(sess, issue)
-	backendName := pipeline.BackendForPhase(o.cfg, state.PhaseImplement)
+	backendName := pipeline.BackendForPhase(cfg, state.PhaseImplement)
 
-	if err := o.startPhase(slotName, sess, promptContent, backendName); err != nil {
+	if err := o.startPhase(cfg, slotName, sess, promptContent, backendName); err != nil {
 		log.Printf("[pipeline] start implement retry for %s: %v — marking dead", slotName, err)
 		sess.Status = state.StatusDead
 		now := time.Now().UTC()
@@ -180,6 +184,17 @@ func (o *Orchestrator) handleValidateComplete(slotName string, sess *state.Sessi
 	o.notifier.Sendf("✅→🔨 maestro: %s (issue #%d) validation failed, retrying implementer (attempt %d)",
 		slotName, sess.IssueNumber, sess.ValidationFails+1)
 	return true
+}
+
+func (o *Orchestrator) pipelineConfigForSession(sess *state.Session) *config.Config {
+	if o.cfg == nil || sess == nil || !sess.PipelineFull {
+		return o.cfg
+	}
+	cfg := *o.cfg
+	cfg.Pipeline.Enabled = true
+	cfg.Pipeline.Planner.Enabled = true
+	cfg.Pipeline.Validator.Enabled = true
+	return &cfg
 }
 
 // buildImplementerPrompt builds the implementer prompt with pipeline preamble.
@@ -208,11 +223,14 @@ func (o *Orchestrator) buildImplementerPrompt(sess *state.Session, issue github.
 }
 
 // startPhase is a wrapper around worker.StartPhase with test hook support.
-func (o *Orchestrator) startPhase(slotName string, sess *state.Session, prompt, backendName string) error {
-	if o.workerStartPhaseFn != nil {
-		return o.workerStartPhaseFn(o.cfg, sess, slotName, prompt, backendName)
+func (o *Orchestrator) startPhase(cfg *config.Config, slotName string, sess *state.Session, prompt, backendName string) error {
+	if cfg == nil {
+		cfg = o.cfg
 	}
-	return worker.StartPhase(o.cfg, sess, slotName, prompt, backendName)
+	if o.workerStartPhaseFn != nil {
+		return o.workerStartPhaseFn(cfg, sess, slotName, prompt, backendName)
+	}
+	return worker.StartPhase(cfg, sess, slotName, prompt, backendName)
 }
 
 func truncateFeedback(s string) string {

--- a/internal/orchestrator/pipeline_test.go
+++ b/internal/orchestrator/pipeline_test.go
@@ -145,6 +145,54 @@ func TestAdvancePipeline_ImplementComplete_ValidatorEnabled(t *testing.T) {
 	}
 }
 
+func TestAdvancePipeline_PipelineFullSessionUsesValidatorBackendWithGlobalPipelineDisabled(t *testing.T) {
+	cfg := pipelineConfig()
+	cfg.Pipeline.Enabled = false
+	cfg.Pipeline.Planner.Enabled = false
+	cfg.Pipeline.Validator.Enabled = false
+	cfg.Pipeline.Validator.Backend = "validator"
+	cfg.Model.Backends["validator"] = config.BackendDef{Cmd: "validator"}
+	o := pipelineOrchestrator(cfg)
+
+	worktreeDir := t.TempDir()
+	sess := &state.Session{
+		IssueNumber:  42,
+		IssueTitle:   "Test issue",
+		Phase:        state.PhaseImplement,
+		PipelineFull: true,
+		Worktree:     worktreeDir,
+		Branch:       "feat/test",
+		Status:       state.StatusRunning,
+	}
+
+	o.getIssueFn = func(number int) (github.Issue, error) {
+		return github.Issue{Number: number, Title: "Test issue"}, nil
+	}
+	var gotBackend string
+	var gotValidatorEnabled bool
+	o.workerStartPhaseFn = func(cfg *config.Config, s *state.Session, slotName, prompt, backendName string) error {
+		gotBackend = backendName
+		gotValidatorEnabled = cfg.Pipeline.Validator.Enabled
+		s.Status = state.StatusRunning
+		s.PID = 999
+		return nil
+	}
+
+	handled := o.advancePipeline("slot-1", sess)
+	if !handled {
+		t.Fatal("expected handled")
+	}
+	if sess.Phase != state.PhaseValidate {
+		t.Errorf("expected validate phase, got %s", sess.Phase)
+	}
+	if !gotValidatorEnabled {
+		t.Fatal("pipeline:full session did not enable validator for phase transition")
+	}
+	if gotBackend != "validator" {
+		t.Fatalf("validator backend = %q, want validator", gotBackend)
+	}
+}
+
 func TestAdvancePipeline_ImplementComplete_ValidatorDisabled(t *testing.T) {
 	cfg := pipelineConfig()
 	cfg.Pipeline.Validator.Enabled = false

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,19 +1,19 @@
 // Package pipeline implements the planner → implementer → validator phase pipeline
-// and the GSD-inspired pre-worker context preparation phases.
+// and the deterministic pre-worker context preparation phases.
 //
 // Phase pipeline (when pipeline.enabled is true):
 //  1. Plan   — creates MAESTRO_PLAN.md + VALIDATION.md in the worktree
 //  2. Implement — writes code based on the plan (current worker behavior)
 //  3. Validate — checks assertions from VALIDATION.md, gates PR creation
 //
-// GSD pre-worker phases (configurable independently):
+// Deterministic pre-worker context-prep phases (configurable independently):
 //   - Research: scans codebase for relevant patterns, writes context file
-//   - Plan Validation: extracts requirements, builds and validates a plan
+//   - Plan Validation: heuristically extracts requirements and checks plan coverage
 //   - Test Mapping: maps requirements to verification commands, generates verify.sh
 //
 // Each phase-pipeline phase runs as a separate worker session in the same worktree.
 // Failed validation retries the implementer with feedback, not a full re-plan.
-// GSD phases run before the worker starts and inject context into the prompt.
+// Context-prep phases run before the worker starts and inject context into the prompt.
 package pipeline
 
 import (
@@ -138,9 +138,9 @@ func MaxRuntimeForPhase(cfg *config.Config, phase state.Phase) int {
 	return cfg.MaxRuntimeMinutes
 }
 
-// ---- GSD-inspired pre-worker context preparation ----
+// ---- Deterministic pre-worker context preparation ----
 
-// GSDResult holds the output of the GSD pre-worker pipeline phases.
+// GSDResult holds the output of the deterministic pre-worker context-prep phases.
 // The context fields are appended to the worker prompt.
 type GSDResult struct {
 	// ResearchContext is the markdown context from the research phase.
@@ -182,7 +182,7 @@ func (r *GSDResult) PromptSection() string {
 	return "\n\n---\n\n# Pipeline Context\n\n" + strings.Join(sections, "\n\n---\n\n")
 }
 
-// RunGSD executes the GSD-inspired pre-worker pipeline phases before a worker starts.
+// RunGSD executes deterministic context-prep phases before a worker starts.
 // All phases are best-effort — a failure in one phase logs a warning
 // but does not prevent subsequent phases or worker startup.
 func RunGSD(cfg *config.Config, worktreePath string, issueNumber int, issueTitle, issueBody string) *GSDResult {
@@ -194,12 +194,12 @@ func RunGSD(cfg *config.Config, worktreePath string, issueNumber int, issueTitle
 		return result
 	}
 
-	log.Printf("[pipeline] running GSD pre-worker pipeline for issue #%d (research=%v, plan_validation=%v, test_mapping=%v)",
+	log.Printf("[pipeline] running deterministic context-prep for issue #%d (research=%v, heuristic_plan_validation=%v, test_mapping=%v)",
 		issueNumber, pipeline.Research, pipeline.PlanValidationEnabled(), pipeline.TestMappingEnabled())
 
 	// Phase 1: Research
 	if pipeline.Research {
-		log.Printf("[pipeline] GSD phase 1/3: research")
+		log.Printf("[pipeline] context-prep phase 1/3: research")
 		ctx, err := runResearch(worktreePath, issueNumber, issueTitle, issueBody)
 		if err != nil {
 			log.Printf("[pipeline] research phase error: %v (continuing)", err)
@@ -208,9 +208,9 @@ func RunGSD(cfg *config.Config, worktreePath string, issueNumber int, issueTitle
 		}
 	}
 
-	// Phase 2: Plan Validation
+	// Phase 2: heuristic plan validation
 	if pipeline.PlanValidationEnabled() {
-		log.Printf("[pipeline] GSD phase 2/3: plan validation")
+		log.Printf("[pipeline] context-prep phase 2/3: heuristic plan validation")
 		plan, err := validatePlan(issueNumber, issueTitle, issueBody, worktreePath, result.ResearchContext)
 		if err != nil {
 			log.Printf("[pipeline] plan validation error: %v (continuing)", err)
@@ -221,7 +221,7 @@ func RunGSD(cfg *config.Config, worktreePath string, issueNumber int, issueTitle
 
 	// Phase 3: Test Mapping
 	if pipeline.TestMappingEnabled() {
-		log.Printf("[pipeline] GSD phase 3/3: test mapping")
+		log.Printf("[pipeline] context-prep phase 3/3: test mapping")
 		verifyPath, summary, err := mapTests(issueNumber, issueTitle, issueBody, worktreePath, result.Plan)
 		if err != nil {
 			log.Printf("[pipeline] test mapping error: %v (continuing)", err)
@@ -231,6 +231,6 @@ func RunGSD(cfg *config.Config, worktreePath string, issueNumber int, issueTitle
 		}
 	}
 
-	log.Printf("[pipeline] GSD pre-worker pipeline complete for issue #%d", issueNumber)
+	log.Printf("[pipeline] deterministic context-prep complete for issue #%d", issueNumber)
 	return result
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -129,6 +129,7 @@ type Session struct {
 	ProviderLimitResetAt        *time.Time        `json:"provider_limit_reset_at,omitempty"`        // provider-stated reset time parsed from the limit message ("try again at ..."), UTC
 	BackendSelection            *BackendSelection `json:"backend_selection,omitempty"`              // latest backend selection audit record
 	Phase                       Phase             `json:"phase,omitempty"`                          // current pipeline phase (empty = legacy single-phase)
+	PipelineFull                bool              `json:"pipeline_full,omitempty"`                  // true when issue label opted this session into plan/implement/validate
 	ValidationFails             int               `json:"validation_fails,omitempty"`               // number of failed validation attempts
 	ValidationFeedback          string            `json:"validation_feedback,omitempty"`            // feedback from last failed validation
 	CIFailureOutput             string            `json:"ci_failure_output,omitempty"`              // CI failure output captured before retry (passed to next worker as context)


### PR DESCRIPTION
Refs #641

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables the full plan/implement/validate phase pipeline on a per-issue basis via a `pipeline:full` GitHub label, so operators can opt hard issues into the multi-session pipeline without changing the global config that governs routine issues.

- Adds `pipelineConfigForIssue` to build a per-worker config copy with pipeline phases enabled when the label is present, and threads that config through `startWorker` and all phase-transition handlers via a matching `pipelineConfigForSession` helper.
- Replaces the `checkSessions` guard `pipeline.IsEnabled(o.cfg)` with `sess.Phase != state.PhaseNone` so in-flight pipeline sessions advance correctly even when the global `pipeline.enabled` flag is false.
- Persists the opt-in as `PipelineFull bool` on the session so phase transitions survive orchestrator restarts.

<h3>Confidence Score: 4/5</h3>

The per-issue config copy is isolated and the global config is never mutated; the `checkSessions` guard change correctly handles both globally-enabled and label-opted sessions.

The core dispatch and phase-transition paths look correct. The two flagged issues — `PipelineFull` being stamped on `review_repair` sessions and the duplicated config-construction logic between `pipelineConfigForIssue` and `pipelineConfigForSession` — are both dormant under the current code flow, but one creates misleading persisted state and the other is a maintenance hazard if the two sites drift.

The `review_repair` branch inside `startNewWorkers` in `orchestrator.go` and the two parallel config-construction helpers (`pipelineConfigForIssue` / `pipelineConfigForSession`) deserve a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Introduces `pipelineConfigForIssue`, `issueHasLabel`, and `pipelineFullLabel`; changes `startWorker` to accept an explicit config; changes the `checkSessions` guard from `pipeline.IsEnabled(o.cfg)` to `sess.Phase != state.PhaseNone`. Minor logic issue: `PipelineFull` is stamped on review-repair sessions that bypass the pipeline. |
| internal/orchestrator/pipeline.go | Adds `pipelineConfigForSession` to reconstruct a full-pipeline config from `sess.PipelineFull` for each phase handler; threads the per-session config through `startPhase`. Logic is correct but duplicates the config-construction logic already present in `pipelineConfigForIssue` in orchestrator.go. |
| internal/state/state.go | Adds `PipelineFull bool` field to `Session`, JSON-serialised so the opt-in flag survives orchestrator restarts. |
| internal/orchestrator/orchestrator_test.go | Adds two tests covering the happy-path and isolation of the opt-in label. |
| internal/orchestrator/pipeline_test.go | Adds a test verifying a `PipelineFull` session uses the validator backend even when global `Pipeline.Enabled` is false. |
| internal/config/config.go | Comment-only changes clarifying that `pipeline.enabled` is a global default and `pipeline:full` is the per-issue opt-in. |
| internal/pipeline/pipeline.go | Terminology-only rename: "GSD-inspired" → "deterministic context-prep"; log messages updated consistently. |
| docs/po-spec-workflow.md | Documents the `pipeline:full` label and the recommended config split between dogfood and routine issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:4167-4169
**`PipelineFull` stamped on review-repair sessions**

When the supervisor picks `spawn_review_repair` for an issue that also carries the `pipeline:full` label, the code sets `initialPhase = state.PhaseNone` (line 4114) but `pipelineFull` remains `true`, so `sess.PipelineFull = true` gets written for a session that will never advance through a pipeline phase. Today this is dormant — `checkSessions` gates `advancePipeline` on `sess.Phase != state.PhaseNone`, so `pipelineConfigForSession` is never reached — but it leaves misleading state in the persisted session and is a latent risk if any future code path inspects `PipelineFull` without also checking `Phase`. The stamp should be skipped when the initial phase has been forced to `PhaseNone`.

### Issue 2 of 2
internal/orchestrator/pipeline.go:189-198
**Duplicated "full pipeline" config construction**

`pipelineConfigForSession` replicates the exact three field assignments that `pipelineConfigForIssue` makes in `orchestrator.go`. If the definition of "full pipeline" grows (e.g., a `Pipeline.Planner.MaxRuntimeMinutes` override), one site will likely be updated while the other is missed, causing the initial spawn and subsequent phase transitions to use different effective configs. Consider extracting a shared `applyFullPipeline(cfg *config.Config)` helper and calling it from both sites.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["pipeline: opt in full phase flow by labe..."](https://github.com/befeast/maestro/commit/accf89b32162ea6951fbb98cf9166f03c3628e4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35338798)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->