### PR TITLE
worker: inject the target repo's AGENTS.md/conventions into every worker prompt

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -768,6 +768,46 @@ func readValidationContract(worktreePath string) string {
 	return sanitizePromptUTF8(string(data))
 }
 
+const repoRulesPromptMaxBytes = 32 * 1024
+
+var repoRulesPromptFiles = []string{"AGENTS.md", "CLAUDE.md", "CONTRIBUTING.md"}
+
+// repoRulesPromptSection reads the target repository's primary convention file
+// from the worktree root and formats it for worker prompt injection.
+func repoRulesPromptSection(worktreePath string) string {
+	for _, name := range repoRulesPromptFiles {
+		path := filepath.Join(worktreePath, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+
+		truncated := len(data) > repoRulesPromptMaxBytes
+		if truncated {
+			data = data[:repoRulesPromptMaxBytes]
+		}
+
+		content := strings.TrimSpace(sanitizePromptUTF8(string(data)))
+		if content == "" {
+			continue
+		}
+
+		var b strings.Builder
+		b.WriteString("\n\n---\n\n## Repository Rules / Conventions\n\n")
+		b.WriteString("Source: `")
+		b.WriteString(name)
+		b.WriteString("` in the target repo worktree.")
+		if truncated {
+			b.WriteString(fmt.Sprintf(" Showing the first %d bytes; read the file for the rest.", repoRulesPromptMaxBytes))
+		}
+		b.WriteString("\n\n")
+		b.WriteString(content)
+		b.WriteByte('\n')
+		return b.String()
+	}
+	return ""
+}
+
 // assemblePrompt builds the final worker prompt.
 // If the base template contains {{ISSUE_NUMBER}} placeholders, it performs
 // template substitution. Otherwise it falls back to appending a task block.
@@ -804,7 +844,7 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 		}
 
 		r := strings.NewReplacer(replacements...)
-		result := r.Replace(base) + workerSearchSafetyPromptSection(worktreePath)
+		result := r.Replace(base) + repoRulesPromptSection(worktreePath) + workerSearchSafetyPromptSection(worktreePath)
 		return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, contractInlined)
 	}
 
@@ -848,6 +888,7 @@ Always rebase on origin/main immediately before creating the PR.
 		issue.Title,
 		issue.Number,
 	)
+	result += repoRulesPromptSection(worktreePath)
 	result += workerSearchSafetyPromptSection(worktreePath)
 	return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, false)
 }

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -53,6 +53,140 @@ func TestAssemblePromptIncludesSearchSafetyGuardrails(t *testing.T) {
 	}
 }
 
+func TestAssemblePromptIncludesRepoRulesFromAgentsFile(t *testing.T) {
+	worktree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(worktree, "AGENTS.md"), []byte("## Rules\n- Run go test ./...\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{Repo: "owner/repo"}
+	issue := github.Issue{Number: 642, Title: "repo rules", Body: "body"}
+
+	prompt := assemblePrompt("base prompt", issue, worktree, "feat/rules", cfg)
+
+	for _, want := range []string{
+		"## Repository Rules / Conventions",
+		"Source: `AGENTS.md` in the target repo worktree.",
+		"Run go test ./...",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("assemblePrompt() missing %q\nprompt:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestAssemblePromptOmitsRepoRulesWhenNoConventionFileExists(t *testing.T) {
+	cfg := &config.Config{Repo: "owner/repo"}
+	issue := github.Issue{Number: 642, Title: "repo rules", Body: "body"}
+
+	prompt := assemblePrompt("base prompt", issue, t.TempDir(), "feat/rules", cfg)
+
+	if strings.Contains(prompt, "Repository Rules / Conventions") {
+		t.Fatalf("repo rules section should be omitted when no convention file exists\nprompt:\n%s", prompt)
+	}
+}
+
+func TestAssemblePromptRepoRulesPrecedence(t *testing.T) {
+	worktree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(worktree, "CONTRIBUTING.md"), []byte("contributing rules\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, "CLAUDE.md"), []byte("claude rules\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, "AGENTS.md"), []byte("agents rules\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{Repo: "owner/repo"}
+	issue := github.Issue{Number: 642, Title: "repo rules", Body: "body"}
+
+	prompt := assemblePrompt("base prompt", issue, worktree, "feat/rules", cfg)
+
+	if !strings.Contains(prompt, "Source: `AGENTS.md`") || !strings.Contains(prompt, "agents rules") {
+		t.Fatalf("expected AGENTS.md rules in prompt:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "claude rules") || strings.Contains(prompt, "contributing rules") {
+		t.Fatalf("expected only the primary repo rules file in prompt:\n%s", prompt)
+	}
+}
+
+func TestAssemblePromptRepoRulesFallbackToClaudeThenContributing(t *testing.T) {
+	cfg := &config.Config{Repo: "owner/repo"}
+	issue := github.Issue{Number: 642, Title: "repo rules", Body: "body"}
+
+	t.Run("claude before contributing", func(t *testing.T) {
+		worktree := t.TempDir()
+		if err := os.WriteFile(filepath.Join(worktree, "CLAUDE.md"), []byte("claude rules\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(worktree, "CONTRIBUTING.md"), []byte("contributing rules\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		prompt := assemblePrompt("base prompt", issue, worktree, "feat/rules", cfg)
+
+		if !strings.Contains(prompt, "Source: `CLAUDE.md`") || !strings.Contains(prompt, "claude rules") {
+			t.Fatalf("expected CLAUDE.md rules in prompt:\n%s", prompt)
+		}
+		if strings.Contains(prompt, "contributing rules") {
+			t.Fatalf("expected only CLAUDE.md rules in prompt:\n%s", prompt)
+		}
+	})
+
+	t.Run("contributing when primary files missing", func(t *testing.T) {
+		worktree := t.TempDir()
+		if err := os.WriteFile(filepath.Join(worktree, "CONTRIBUTING.md"), []byte("contributing rules\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		prompt := assemblePrompt("base prompt", issue, worktree, "feat/rules", cfg)
+
+		if !strings.Contains(prompt, "Source: `CONTRIBUTING.md`") || !strings.Contains(prompt, "contributing rules") {
+			t.Fatalf("expected CONTRIBUTING.md rules in prompt:\n%s", prompt)
+		}
+	})
+}
+
+func TestAssemblePromptRepoRulesTruncatesOversizedFile(t *testing.T) {
+	worktree := t.TempDir()
+	content := strings.Repeat("a", repoRulesPromptMaxBytes) + "tail"
+	if err := os.WriteFile(filepath.Join(worktree, "AGENTS.md"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{Repo: "owner/repo"}
+	issue := github.Issue{Number: 642, Title: "repo rules", Body: "body"}
+
+	prompt := assemblePrompt("base prompt", issue, worktree, "feat/rules", cfg)
+
+	if !strings.Contains(prompt, "Showing the first 32768 bytes; read the file for the rest.") {
+		t.Fatalf("expected truncation notice in prompt:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "tail") {
+		t.Fatalf("expected oversized content to be truncated")
+	}
+}
+
+func TestAssemblePromptRepoRulesSanitizesInvalidUTF8(t *testing.T) {
+	worktree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(worktree, "AGENTS.md"), []byte{'r', 'u', 'l', 'e', ':', ' ', 0xff}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{Repo: "owner/repo"}
+	issue := github.Issue{Number: 642, Title: "repo rules", Body: "body"}
+
+	prompt := assemblePrompt("base prompt", issue, worktree, "feat/rules", cfg)
+
+	if !utf8.ValidString(prompt) {
+		t.Fatalf("assembled prompt is not valid UTF-8: %q", prompt)
+	}
+	if !strings.Contains(prompt, "rule: \uFFFD") {
+		t.Fatalf("expected invalid byte to be replaced in repo rules section:\n%q", prompt)
+	}
+}
+
 // --- Tests from main: validation contract placeholder ---
 
 func TestAssemblePrompt_ValidationContractFromFile(t *testing.T) {


### PR DESCRIPTION
Refs #642

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR injects the target repository's convention file (`AGENTS.md`, `CLAUDE.md`, or `CONTRIBUTING.md`, in priority order) into every worker prompt so the AI agent respects repo-specific rules without manual configuration. The file is read from the worktree root, truncated to 32 KiB if needed, and UTF-8–sanitised before being appended to both the template and legacy prompt code paths.

- A new `repoRulesPromptSection` helper handles discovery, truncation, sanitisation, and formatting; it is a no-op when none of the candidate files exist.
- Tests cover file-priority order, the absent-file case, oversized-file truncation, and invalid UTF-8 handling.

<h3>Confidence Score: 3/5</h3>

The change is safe for trusted repos but introduces a meaningful risk if Maestro is ever pointed at third-party or untrusted repositories, as the raw convention-file content is placed verbatim into the worker prompt.

The worker now embeds arbitrary text from a file that any repo author controls. Beyond UTF-8 normalisation there is no guard against adversarial content — a crafted AGENTS.md could include instructions designed to override earlier prompt sections, shadow system headings, or undermine the safety guardrail that follows. Whether that succeeds depends on the model, but the attack surface is present and real.

internal/worker/worker.go — specifically the repoRulesPromptSection function and its call sites in assemblePrompt

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/worker.go | Adds repoRulesPromptSection that reads and injects AGENTS.md/CLAUDE.md/CONTRIBUTING.md into every worker prompt; the raw file content is not sanitised against prompt injection beyond UTF-8 normalisation |
| internal/worker/worker_prompt_test.go | Thorough tests covering file precedence, truncation, UTF-8 sanitisation, and the absent-file no-op case |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/worker/worker.go:777-808
**Prompt injection via unfiltered repo convention files**

The raw content of `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` is injected into the worker's prompt after only UTF-8 sanitization. A target repo whose convention file contains adversarial instructions (e.g. a heading that mimics a system-prompt section, or text like "Ignore all prior instructions…") can hijack the worker's behavior. Because `repoRulesPromptSection` is placed before `workerSearchSafetyPromptSection`, a crafted file could also attempt to neutralise the safety guardrails that follow. If Maestro ever processes repos from untrusted third parties, this is a direct attack surface for data exfiltration or committing malicious changes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: inject repo convention rules int..."](https://github.com/befeast/maestro/commit/a30f5b034c121b5a7d890ded8eac5ccc1749ed2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35342627)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->