### PR TITLE
worker: symbol-aware (LSP/gopls) code search in the research phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,16 @@ maestro orchestrates multiple parallel AI coding agents (Claude, Codex, Gemini, 
 
 You only need one — whichever you have access to.
 
+### Optional for Go repositories
+- **`gopls`** — enables symbol-aware pre-worker research context for Go modules (`go install golang.org/x/tools/gopls@latest`)
+
 ### Verify prerequisites
 ```bash
 git --version        # any recent version
 gh --version         # 2.x+
 tmux -V              # any recent version
 claude --version     # or: codex --version / gemini --version / cline --version
+gopls version        # optional; used for Go symbol context when available
 ```
 
 ### Setup

--- a/cmd/maestro/init.go
+++ b/cmd/maestro/init.go
@@ -304,6 +304,10 @@ func checkInitPrerequisites(w io.Writer) {
 		allOK = false
 	}
 
+	if _, err := exec.LookPath("gopls"); err != nil {
+		fmt.Fprintln(w, "  NOTE: gopls not found — Go repo research will fall back to filename search")
+	}
+
 	if !allOK {
 		fmt.Fprintln(w)
 	}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -297,6 +297,116 @@ func TestRunResearch(t *testing.T) {
 	}
 }
 
+func TestRunResearchIncludesGoplsSymbolContext(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeGopls(t, dir)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	oldGopls := goplsBinary
+	goplsBinary = "gopls"
+	t.Cleanup(func() { goplsBinary = oldGopls })
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/research\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "pipeline"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	researchGo := `package pipeline
+
+func runResearch() string {
+	return "context"
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "internal", "pipeline", "research.go"), []byte(researchGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+	callGo := `package pipeline
+
+func callSite() {
+	_ = runResearch()
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "internal", "pipeline", "call.go"), []byte(callGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, err := runResearch(dir, 646, "worker: improve `runResearch`", "Use gopls references for `runResearch`.")
+	if err != nil {
+		t.Fatalf("runResearch: %v", err)
+	}
+
+	for _, want := range []string{
+		"## Symbol Context (gopls)",
+		"### `runResearch`",
+		"**Definitions**",
+		"`internal/pipeline/research.go:3:6`",
+		"**References**",
+		"`internal/pipeline/call.go:4:6`",
+	} {
+		if !strings.Contains(ctx, want) {
+			t.Fatalf("research context missing %q:\n%s", want, ctx)
+		}
+	}
+}
+
+func TestRunResearchFallsBackWhenGoplsUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	oldGopls := goplsBinary
+	goplsBinary = "definitely-not-gopls"
+	t.Cleanup(func() { goplsBinary = oldGopls })
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/research\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "pipeline"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "internal", "pipeline", "research.go"), []byte("package pipeline\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, err := runResearch(dir, 647, "Add pipeline research", "Research phase for worker pipeline")
+	if err != nil {
+		t.Fatalf("runResearch should keep filename-grep fallback working: %v", err)
+	}
+	if !strings.Contains(ctx, "## Relevant Files") {
+		t.Fatalf("expected fallback relevant files context, got:\n%s", ctx)
+	}
+	if strings.Contains(ctx, "## Symbol Context (gopls)") {
+		t.Fatalf("did not expect symbol context when gopls is unavailable:\n%s", ctx)
+	}
+}
+
+func writeFakeGopls(t *testing.T, dir string) {
+	t.Helper()
+	script := `#!/bin/sh
+verb="$1"
+case "$verb" in
+definition)
+cat <<JSON
+[{"span":"` + dir + `/internal/pipeline/research.go:3:6-17","description":"func runResearch() string"}]
+JSON
+;;
+references)
+cat <<JSON
+[{"span":"` + dir + `/internal/pipeline/research.go:3:6-17"},{"uri":"file://` + dir + `/internal/pipeline/call.go","range":{"start":{"line":3,"character":5},"end":{"line":3,"character":16}}}]
+JSON
+;;
+implementation)
+echo "[]"
+;;
+*)
+echo "unexpected gopls verb: $verb" >&2
+exit 1
+;;
+esac
+`
+	path := filepath.Join(dir, "gopls")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDiscoverPatterns_Go(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0644)

--- a/internal/pipeline/research.go
+++ b/internal/pipeline/research.go
@@ -1,16 +1,24 @@
 package pipeline
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 )
 
 // researchDir is the directory under the worktree where research files are written.
 const researchDir = ".maestro/research"
+
+var goplsBinary = "gopls"
 
 // runResearch performs the pre-coding research phase.
 // It scans the codebase for files relevant to the issue keywords and writes
@@ -62,6 +70,14 @@ func runResearch(worktreePath string, issueNumber int, issueTitle, issueBody str
 		}
 	}
 
+	symbols, err := findSymbolContexts(worktreePath, issueTitle, issueBody)
+	if err != nil {
+		log.Printf("[pipeline] research: symbol context unavailable: %v (falling back to filename search only)", err)
+	} else if len(symbols) > 0 {
+		log.Printf("[pipeline] research: found symbol context for %d symbols", len(symbols))
+		appendSymbolContexts(&sb, worktreePath, symbols)
+	}
+
 	// Discover project structure patterns
 	patterns := discoverPatterns(worktreePath)
 	if len(patterns) > 0 {
@@ -91,6 +107,22 @@ func runResearch(worktreePath string, issueNumber int, issueTitle, issueBody str
 type relevantFile struct {
 	Path            string
 	MatchedKeywords []string
+}
+
+type symbolContext struct {
+	Symbol          string
+	LookupPath      string
+	LookupLine      int
+	LookupCharacter int
+	Definitions     []symbolLocation
+	References      []symbolLocation
+	Implementations []symbolLocation
+}
+
+type symbolLocation struct {
+	Path      string
+	Line      int
+	Character int
 }
 
 // extractKeywords extracts meaningful keywords from issue title and body.
@@ -202,6 +234,373 @@ func findRelevantFiles(worktreePath string, keywords []string) []relevantFile {
 	return results
 }
 
+func findSymbolContexts(worktreePath, issueTitle, issueBody string) ([]symbolContext, error) {
+	if _, err := os.Stat(filepath.Join(worktreePath, "go.mod")); err != nil {
+		return nil, fmt.Errorf("not a Go module")
+	}
+	if _, err := exec.LookPath(goplsBinary); err != nil {
+		return nil, fmt.Errorf("%s not available: %w", goplsBinary, err)
+	}
+
+	candidates := extractSymbolCandidates(issueTitle, issueBody)
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	goFiles := listGoSourceFiles(worktreePath)
+	if len(goFiles) == 0 {
+		return nil, nil
+	}
+
+	var contexts []symbolContext
+	for _, symbol := range candidates {
+		path, line, char, ok := findSymbolTokenPosition(worktreePath, goFiles, symbol)
+		if !ok {
+			continue
+		}
+		ctx := symbolContext{
+			Symbol:          symbol,
+			LookupPath:      path,
+			LookupLine:      line,
+			LookupCharacter: char,
+		}
+		var err error
+		ctx.Definitions, err = runGoplsLocationQuery(worktreePath, "definition", path, line, char)
+		if err != nil {
+			log.Printf("[pipeline] research: gopls definition failed for %s: %v", symbol, err)
+			continue
+		}
+		ctx.References, err = runGoplsLocationQuery(worktreePath, "references", path, line, char)
+		if err != nil {
+			log.Printf("[pipeline] research: gopls references failed for %s: %v", symbol, err)
+		}
+		ctx.Implementations, err = runGoplsLocationQuery(worktreePath, "implementation", path, line, char)
+		if err != nil {
+			log.Printf("[pipeline] research: gopls implementation failed for %s: %v", symbol, err)
+		}
+		if len(ctx.Definitions)+len(ctx.References)+len(ctx.Implementations) > 0 {
+			contexts = append(contexts, ctx)
+		}
+		if len(contexts) >= 3 {
+			break
+		}
+	}
+
+	return contexts, nil
+}
+
+func appendSymbolContexts(sb *strings.Builder, worktreePath string, contexts []symbolContext) {
+	sb.WriteString("\n## Symbol Context (gopls)\n\n")
+	sb.WriteString("Language-server context for primary Go symbols named in the issue.\n\n")
+	for _, ctx := range contexts {
+		sb.WriteString(fmt.Sprintf("### `%s`\n\n", ctx.Symbol))
+		sb.WriteString(fmt.Sprintf("Lookup position: `%s:%d:%d`\n\n", ctx.LookupPath, ctx.LookupLine, ctx.LookupCharacter))
+		appendSymbolLocationList(sb, "Definitions", ctx.Definitions, 5)
+		appendSymbolLocationList(sb, "References", ctx.References, 10)
+		appendSymbolLocationList(sb, "Implementations", ctx.Implementations, 10)
+		appendSymbolSnippets(sb, worktreePath, ctx)
+	}
+}
+
+func appendSymbolLocationList(sb *strings.Builder, title string, locs []symbolLocation, limit int) {
+	if len(locs) == 0 {
+		return
+	}
+	sb.WriteString(fmt.Sprintf("**%s**\n", title))
+	for i, loc := range locs {
+		if i >= limit {
+			sb.WriteString(fmt.Sprintf("- ...and %d more.\n", len(locs)-limit))
+			break
+		}
+		sb.WriteString(fmt.Sprintf("- `%s:%d:%d`\n", loc.Path, loc.Line, loc.Character))
+	}
+	sb.WriteString("\n")
+}
+
+func appendSymbolSnippets(sb *strings.Builder, worktreePath string, ctx symbolContext) {
+	locs := dedupeSymbolLocations(append(append([]symbolLocation{}, ctx.Definitions...), ctx.References...))
+	if len(locs) == 0 {
+		return
+	}
+	sb.WriteString("**Snippets**\n\n")
+	limit := len(locs)
+	if limit > 3 {
+		limit = 3
+	}
+	for _, loc := range locs[:limit] {
+		snippet := readFileWindow(filepath.Join(worktreePath, loc.Path), loc.Line, 4)
+		if snippet == "" {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("`%s:%d`\n```go\n%s\n```\n\n", loc.Path, loc.Line, snippet))
+	}
+}
+
+func extractSymbolCandidates(title, body string) []string {
+	var candidates []string
+	seen := map[string]bool{}
+	add := func(s string) {
+		if !isUsefulGoSymbolCandidate(s) || seen[s] {
+			return
+		}
+		seen[s] = true
+		candidates = append(candidates, s)
+	}
+
+	codeSpanRe := regexp.MustCompile("`([A-Za-z_][A-Za-z0-9_]*)`")
+	for _, m := range codeSpanRe.FindAllStringSubmatch(title+" "+body, -1) {
+		add(m[1])
+	}
+
+	identRe := regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*\b`)
+	for _, m := range identRe.FindAllString(title+" "+body, -1) {
+		if hasGoIdentifierShape(m) {
+			add(m)
+		}
+	}
+
+	if len(candidates) > 8 {
+		candidates = candidates[:8]
+	}
+	return candidates
+}
+
+func isUsefulGoSymbolCandidate(s string) bool {
+	if len(s) < 3 {
+		return false
+	}
+	goKeywords := map[string]bool{
+		"break": true, "case": true, "chan": true, "const": true, "continue": true,
+		"default": true, "defer": true, "else": true, "fallthrough": true, "for": true,
+		"func": true, "go": true, "goto": true, "if": true, "import": true,
+		"interface": true, "map": true, "package": true, "range": true, "return": true,
+		"select": true, "struct": true, "switch": true, "type": true, "var": true,
+	}
+	lower := strings.ToLower(s)
+	if goKeywords[lower] {
+		return false
+	}
+	return regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(s)
+}
+
+func hasGoIdentifierShape(s string) bool {
+	if strings.Contains(s, "_") {
+		return true
+	}
+	if len(s) >= 5 && s[0] >= 'a' && s[0] <= 'z' {
+		for _, r := range s[1:] {
+			if r >= 'A' && r <= 'Z' {
+				return true
+			}
+		}
+	}
+	return len(s) >= 3 && s[0] >= 'A' && s[0] <= 'Z'
+}
+
+func listGoSourceFiles(worktreePath string) []string {
+	var files []string
+	skipDirs := map[string]bool{
+		".git": true, "node_modules": true, "vendor": true, ".maestro": true,
+		"target": true, "dist": true, "build": true, "__pycache__": true,
+	}
+	_ = filepath.Walk(worktreePath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			if skipDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(info.Name(), ".go") {
+			rel, err := filepath.Rel(worktreePath, path)
+			if err == nil {
+				files = append(files, rel)
+			}
+		}
+		return nil
+	})
+	sort.Strings(files)
+	return files
+}
+
+func findSymbolTokenPosition(worktreePath string, files []string, symbol string) (string, int, int, bool) {
+	tokenRe := regexp.MustCompile(`\b` + regexp.QuoteMeta(symbol) + `\b`)
+	for _, rel := range files {
+		data, err := os.ReadFile(filepath.Join(worktreePath, rel))
+		if err != nil {
+			continue
+		}
+		for lineIndex, line := range strings.Split(string(data), "\n") {
+			if loc := tokenRe.FindStringIndex(line); loc != nil {
+				return rel, lineIndex + 1, loc[0] + 1, true
+			}
+		}
+	}
+	return "", 0, 0, false
+}
+
+func runGoplsLocationQuery(worktreePath, verb, relPath string, line, char int) ([]symbolLocation, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pos := fmt.Sprintf("%s:%d:%d", filepath.Join(worktreePath, relPath), line, char)
+	cmd := exec.CommandContext(ctx, goplsBinary, verb, "-json", pos)
+	cmd.Dir = worktreePath
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return parseGoplsLocations(worktreePath, out), nil
+}
+
+func parseGoplsLocations(worktreePath string, data []byte) []symbolLocation {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	var locs []symbolLocation
+	walkGoplsJSON(worktreePath, raw, func(uri string, line, character int) {
+		path := uriToPath(uri)
+		if path == "" {
+			return
+		}
+		rel, err := filepath.Rel(worktreePath, path)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return
+		}
+		locs = append(locs, symbolLocation{
+			Path:      filepath.ToSlash(rel),
+			Line:      line + 1,
+			Character: character + 1,
+		})
+	})
+	return dedupeSymbolLocations(locs)
+}
+
+func walkGoplsJSON(worktreePath string, v any, emit func(uri string, line, character int)) {
+	switch x := v.(type) {
+	case []any:
+		for _, item := range x {
+			walkGoplsJSON(worktreePath, item, emit)
+		}
+	case map[string]any:
+		if span, ok := x["span"].(string); ok {
+			if loc, ok := parseGoplsSpan(worktreePath, span); ok {
+				emit("file://"+loc.Path, loc.Line-1, loc.Character-1)
+			}
+		}
+		uri, _ := x["uri"].(string)
+		if uri == "" {
+			if target, ok := x["targetUri"].(string); ok {
+				uri = target
+			}
+		}
+		if uri != "" {
+			if line, character, ok := jsonRangeStart(x); ok {
+				emit(uri, line, character)
+			}
+		}
+		for _, item := range x {
+			walkGoplsJSON(worktreePath, item, emit)
+		}
+	case string:
+		if loc, ok := parseGoplsSpan(worktreePath, x); ok {
+			emit("file://"+loc.Path, loc.Line-1, loc.Character-1)
+		}
+	}
+}
+
+func jsonRangeStart(m map[string]any) (int, int, bool) {
+	rangeValue := m["range"]
+	if rangeValue == nil {
+		rangeValue = m["targetRange"]
+	}
+	rangeMap, ok := rangeValue.(map[string]any)
+	if !ok {
+		return 0, 0, false
+	}
+	start, ok := rangeMap["start"].(map[string]any)
+	if !ok {
+		return 0, 0, false
+	}
+	line, lineOK := start["line"].(float64)
+	char, charOK := start["character"].(float64)
+	return int(line), int(char), lineOK && charOK
+}
+
+func uriToPath(uri string) string {
+	if !strings.HasPrefix(uri, "file://") {
+		return ""
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return ""
+	}
+	return u.Path
+}
+
+func parseGoplsSpan(worktreePath, span string) (symbolLocation, bool) {
+	match := regexp.MustCompile(`^(.+):([0-9]+):([0-9]+)`).FindStringSubmatch(span)
+	if match == nil {
+		return symbolLocation{}, false
+	}
+	line, err := parsePositiveInt(match[2])
+	if err != nil {
+		return symbolLocation{}, false
+	}
+	character, err := parsePositiveInt(match[3])
+	if err != nil {
+		return symbolLocation{}, false
+	}
+	path := match[1]
+	if worktreePath != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(worktreePath, path)
+	}
+	return symbolLocation{Path: path, Line: line, Character: character}, true
+}
+
+func parsePositiveInt(s string) (int, error) {
+	var n int
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("not a positive integer: %s", s)
+		}
+		n = n*10 + int(r-'0')
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("not a positive integer: %s", s)
+	}
+	return n, nil
+}
+
+func dedupeSymbolLocations(locs []symbolLocation) []symbolLocation {
+	seen := map[string]bool{}
+	var out []symbolLocation
+	for _, loc := range locs {
+		key := fmt.Sprintf("%s:%d:%d", loc.Path, loc.Line, loc.Character)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, loc)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		if out[i].Line != out[j].Line {
+			return out[i].Line < out[j].Line
+		}
+		return out[i].Character < out[j].Character
+	})
+	return out
+}
+
 // isSourceExt returns true for common source file extensions.
 func isSourceExt(ext string) bool {
 	switch ext {
@@ -225,6 +624,30 @@ func readFileHead(path string, lines int) string {
 		allLines = allLines[:lines]
 	}
 	return strings.Join(allLines, "\n")
+}
+
+func readFileWindow(path string, centerLine, radius int) string {
+	data, err := os.ReadFile(path)
+	if err != nil || centerLine <= 0 {
+		return ""
+	}
+	allLines := strings.Split(string(data), "\n")
+	start := centerLine - radius
+	if start < 1 {
+		start = 1
+	}
+	end := centerLine + radius
+	if end > len(allLines) {
+		end = len(allLines)
+	}
+	var b strings.Builder
+	for i := start; i <= end; i++ {
+		b.WriteString(fmt.Sprintf("%4d: %s", i, allLines[i-1]))
+		if i < end {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
 }
 
 // discoverPatterns identifies project structure patterns in the worktree.


### PR DESCRIPTION
Refs #646

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the pre-worker research phase with optional symbol-aware context for Go repositories by invoking `gopls` (definition, references, implementation) on identifier candidates extracted from the issue title and body, with a graceful fallback to the existing filename-grep path when `gopls` is absent or the repo is not a Go module.

- `research.go` gains ~370 lines: symbol candidate extraction (backtick spans prioritised, then camelCase/underscore heuristics), a file walker to locate a token's position, sequential `gopls` subprocess calls with per-call 5 s timeouts, a recursive JSON walker that handles both `span` strings and LSP `uri`+`range` objects, and a deduplication/sorting pass before rendering the markdown section.
- Two tests cover the full happy-path output via a fake `gopls` shell script and confirm the fallback still produces `## Relevant Files` with no `## Symbol Context` when `gopls` is unavailable.
- `cmd/maestro/init.go` emits a soft NOTE during the init check when `gopls` is missing, and `README.md` documents it as an optional dependency.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the gopls path is entirely opt-in and the fallback to filename search is well-tested, so non-Go repos and environments without gopls are unaffected.

The logic is correct and well-tested. The missing aggregate timeout is the most notable concern: 9 sequential cold-start gopls invocations could stall the research phase for ~45 s on a large Go codebase. The regex-per-call issues in the recursive JSON walker are minor but easy to fix.

internal/pipeline/research.go — the gopls subprocess loop and the recursive JSON walker.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/pipeline/research.go | Core implementation of LSP/gopls symbol lookup: adds ~370 lines of JSON parsing, symbol candidate extraction, and gopls subprocess invocation; regex compiled per-call in two hot paths, and no aggregate timeout caps the 9-query worst case. |
| internal/pipeline/pipeline_test.go | Adds two new tests covering gopls happy path and graceful fallback; fake gopls shell script correctly exercises both span and uri+range JSON formats. |
| cmd/maestro/init.go | Adds a non-blocking NOTE message when gopls is not found during prerequisite check; purely informational, no logic change. |
| README.md | Documents gopls as an optional dependency for Go repositories and adds it to the verification checklist. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
internal/pipeline/research.go:547-548
`regexp.MustCompile` is called on every invocation of `parseGoplsSpan`. This function is invoked from `walkGoplsJSON`'s `case string:` arm, which is reached for every string value encountered while recursively walking gopls JSON responses — potentially dozens of times per query. Compiling the same regex each time is needlessly expensive; it should be a package-level variable.

```suggestion
var goplsSpanRe = regexp.MustCompile(`^(.+):([0-9]+):([0-9]+)`)

func parseGoplsSpan(worktreePath, span string) (symbolLocation, bool) {
	match := goplsSpanRe.FindStringSubmatch(span)
```

### Issue 2 of 4
internal/pipeline/research.go:383
The same regex is compiled on every call to `isUsefulGoSymbolCandidate`. Since it describes a constant pattern, it should be a package-level variable like the similar patterns elsewhere.

```suggestion
	return goIdentifierRe.MatchString(s)
```

### Issue 3 of 4
internal/pipeline/research.go:485-515
**Double-emission for `span` fields in `walkGoplsJSON`**

When a JSON object contains a `"span"` key, the map case explicitly extracts and emits for it, but the generic `for _, item := range x` loop at the end of the same case then hands that same string value back to `walkGoplsJSON`, where the `case string:` arm parses and emits it a second time. `dedupeSymbolLocations` masks the duplicate, but `parseGoplsSpan` executes twice per span-bearing object. Guarding against re-processing the already-handled `"span"` string would make the intent explicit and avoid the redundant work.

### Issue 4 of 4
internal/pipeline/research.go:237-289
**No aggregate timeout across all gopls queries**

Each individual `runGoplsLocationQuery` call is bounded by a 5-second timeout, but `findSymbolContexts` can issue up to 3 symbols × 3 verbs = 9 sequential gopls calls. Since each invocation starts a fresh `gopls` process that must cold-load the module's type information, real-world startup latency can approach the per-call limit on large codebases. In the worst case the research phase stalls for ~45 seconds before returning any symbol context. Adding a single `context.WithTimeout` wrapping the entire symbol-search loop, threaded through to `runGoplsLocationQuery`, would put a firm ceiling on this path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: add symbol-aware research contex..."](https://github.com/befeast/maestro/commit/62af14d54d2b056a6608bd7fd946619f024f2552) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35356097)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->