### PR TITLE
worker: PreToolUse / post-edit lint hooks inside the worker session

### DIFF
--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -196,6 +196,18 @@ session_prefix: proj
 # Worker prompt template
 worker_prompt: /path/to/worker-prompt-template.md
 
+# Optional in-session worker tool hooks
+hooks:
+  timeout_ms: 60000
+  post_edit:
+    command: gofmt -w .
+    matcher: Edit|MultiEdit|Write
+    block_on_failure: true
+  pre_tool:
+    command: ./scripts/check-safe-tool.sh
+    matcher: Bash
+    block_on_failure: true
+
 # Outcome brief (read-only supervisor context)
 outcome:
   desired_outcome: Users can run the product end-to-end.
@@ -232,10 +244,14 @@ telegram:
 | `deploy_cmd` | Shell command maestro runs after merging a PR |
 | `session_prefix` | Prefix for tmux session names |
 | `worker_prompt` | Path to the worker prompt template file |
+| `hooks.post_edit` | Optional command run inside worker sessions after matching file edit tools |
+| `hooks.pre_tool` | Optional command run inside worker sessions before matching tool calls |
 
 Supervisor policy can also live in `.maestro/supervisor.yaml` next to the project config or repository checkout. If an ordered queue is configured, only the first unfinished issue in that queue is eligible for supervisor dispatch until the queue is exhausted. `dynamic_wave` is explicit opt-in and lets the supervisor select the next runnable open issue without listing issue numbers, using priority labels and conservative skip rules. Set `supervisor.dispatch_sla_seconds` to control when Fleet escalates a selected issue that has not started a worker.
 
 For Maestro dogfooding, add the `outcome` block to the `BeFeast/maestro` project config first. Point `runtime_target` and `healthcheck_url` at the local Mission Control dashboard, and keep deploy/runtime actions read-only until approval-backed controls exist.
+
+Worker tool hooks are default-off and opt in per project. `command` runs from the worker worktree and receives the backend hook JSON in `MAESTRO_HOOK_INPUT`, plus `MAESTRO_HOOK_EVENT`, `MAESTRO_HOOK_TOOL_NAME`, and `MAESTRO_HOOK_FILE_PATH` when available. For Claude workers, Maestro writes a local `.claude/settings.local.json` hook file in the worktree and excludes it from git; stdout/stderr is returned to the agent as hook context. Other backends receive the same hook contract in the worker prompt so the configured command remains visible, but automatic per-tool interception depends on backend support. Set `block_on_failure: true` when a non-zero hook result should stop the matching tool/event until the worker corrects it.
 
 ### Optional: versioning config
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -580,13 +580,23 @@ type MissionsConfig struct {
 	Labels      []string `yaml:"labels"`       // labels that identify mission issues (default: ["mission", "epic"])
 }
 
+// ToolHookConfig describes an agent tool hook that runs inside the worker
+// session. Command is executed from the worker worktree.
+type ToolHookConfig struct {
+	Command        string `yaml:"command" json:"command"`                   // shell command to run for the hook
+	Matcher        string `yaml:"matcher" json:"matcher"`                   // backend-specific tool matcher; defaults by event
+	BlockOnFailure bool   `yaml:"block_on_failure" json:"block_on_failure"` // when true, non-zero command results block the tool/event
+}
+
 // HooksConfig holds lifecycle hook scripts that run at key points.
 type HooksConfig struct {
-	AfterCreate  string `yaml:"after_create"`  // runs once when a new issue workspace is first created
-	BeforeRun    string `yaml:"before_run"`    // runs before each agent attempt (fatal on failure)
-	AfterRun     string `yaml:"after_run"`     // runs after each agent attempt (logged, not fatal)
-	BeforeRemove string `yaml:"before_remove"` // runs before workspace cleanup (logged, not fatal)
-	TimeoutMs    int    `yaml:"timeout_ms"`    // timeout for hook execution in milliseconds (default: 60000)
+	AfterCreate  string         `yaml:"after_create"`  // runs once when a new issue workspace is first created
+	BeforeRun    string         `yaml:"before_run"`    // runs before each agent attempt (fatal on failure)
+	AfterRun     string         `yaml:"after_run"`     // runs after each agent attempt (logged, not fatal)
+	BeforeRemove string         `yaml:"before_remove"` // runs before workspace cleanup (logged, not fatal)
+	PreTool      ToolHookConfig `yaml:"pre_tool"`      // runs inside the worker session before matching tool calls
+	PostEdit     ToolHookConfig `yaml:"post_edit"`     // runs inside the worker session after file edit tools
+	TimeoutMs    int            `yaml:"timeout_ms"`    // timeout for hook execution in milliseconds (default: 60000)
 }
 
 // StaleSessionReconcilerConfig configures filtering of stale supervisor

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1671,6 +1671,12 @@ func TestParse_HooksDefault(t *testing.T) {
 	if cfg.Hooks.BeforeRemove != "" {
 		t.Errorf("Hooks.BeforeRemove = %q, want empty", cfg.Hooks.BeforeRemove)
 	}
+	if cfg.Hooks.PreTool.Command != "" {
+		t.Errorf("Hooks.PreTool.Command = %q, want empty", cfg.Hooks.PreTool.Command)
+	}
+	if cfg.Hooks.PostEdit.Command != "" {
+		t.Errorf("Hooks.PostEdit.Command = %q, want empty", cfg.Hooks.PostEdit.Command)
+	}
 	if cfg.Hooks.TimeoutMs != 60000 {
 		t.Errorf("Hooks.TimeoutMs = %d, want 60000", cfg.Hooks.TimeoutMs)
 	}
@@ -1689,6 +1695,14 @@ hooks:
     echo "Agent finished for $ISSUE_ID"
   before_remove: |
     echo "Cleaning up"
+  pre_tool:
+    command: ./scripts/pre-tool-check.sh
+    matcher: Bash|Write
+    block_on_failure: true
+  post_edit:
+    command: gofmt -w .
+    matcher: Edit|MultiEdit|Write
+    block_on_failure: false
   timeout_ms: 30000
 `
 	cfg, err := parse([]byte(yaml))
@@ -1706,6 +1720,24 @@ hooks:
 	}
 	if cfg.Hooks.BeforeRemove == "" {
 		t.Error("Hooks.BeforeRemove should not be empty")
+	}
+	if cfg.Hooks.PreTool.Command != "./scripts/pre-tool-check.sh" {
+		t.Errorf("Hooks.PreTool.Command = %q, want pre-tool script", cfg.Hooks.PreTool.Command)
+	}
+	if cfg.Hooks.PreTool.Matcher != "Bash|Write" {
+		t.Errorf("Hooks.PreTool.Matcher = %q, want Bash|Write", cfg.Hooks.PreTool.Matcher)
+	}
+	if !cfg.Hooks.PreTool.BlockOnFailure {
+		t.Error("Hooks.PreTool.BlockOnFailure should be true")
+	}
+	if cfg.Hooks.PostEdit.Command != "gofmt -w ." {
+		t.Errorf("Hooks.PostEdit.Command = %q, want gofmt", cfg.Hooks.PostEdit.Command)
+	}
+	if cfg.Hooks.PostEdit.Matcher != "Edit|MultiEdit|Write" {
+		t.Errorf("Hooks.PostEdit.Matcher = %q, want edit matcher", cfg.Hooks.PostEdit.Matcher)
+	}
+	if cfg.Hooks.PostEdit.BlockOnFailure {
+		t.Error("Hooks.PostEdit.BlockOnFailure should be false")
 	}
 	if cfg.Hooks.TimeoutMs != 30000 {
 		t.Errorf("Hooks.TimeoutMs = %d, want 30000", cfg.Hooks.TimeoutMs)

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -108,15 +108,6 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 		}
 	}
 
-	// Assemble prompt with checkpoint
-	prompt := assemblePromptWithCheckpoint(promptBase, issue, sess.Worktree, sess.Branch, cfg, checkpointContext)
-
-	// Write prompt to file
-	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
-	if err := writePromptFile(promptFile, prompt); err != nil {
-		return fmt.Errorf("write prompt file: %w", err)
-	}
-
 	// Determine backend
 	if backendName == "" {
 		backendName = cfg.Model.Default
@@ -133,6 +124,21 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+	}
+
+	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, backendName, cfg.Hooks)
+	if err != nil {
+		return fmt.Errorf("setup worker tool hooks: %w", err)
+	}
+
+	// Assemble prompt with checkpoint
+	prompt := assemblePromptWithCheckpoint(promptBase, issue, sess.Worktree, sess.Branch, cfg, checkpointContext)
+	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
+
+	// Write prompt to file
+	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
+	if err := writePromptFile(promptFile, prompt); err != nil {
+		return fmt.Errorf("write prompt file: %w", err)
 	}
 
 	// Prepare log file

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -25,12 +25,6 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 	tmuxName := TmuxSessionName(slotName)
 	exec.Command("tmux", "kill-session", "-t", tmuxName).CombinedOutput()
 
-	// Write prompt to file
-	promptFile := fmt.Sprintf("%s/%s-prompt.md", cfg.StateDir, slotName)
-	if err := writePromptFile(promptFile, prompt); err != nil {
-		return fmt.Errorf("write prompt file: %w", err)
-	}
-
 	// Determine backend
 	if backendName == "" {
 		backendName = cfg.Model.Default
@@ -48,6 +42,18 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+	}
+
+	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, backendName, cfg.Hooks)
+	if err != nil {
+		return fmt.Errorf("setup worker tool hooks: %w", err)
+	}
+	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
+
+	// Write prompt to file
+	promptFile := fmt.Sprintf("%s/%s-prompt.md", cfg.StateDir, slotName)
+	if err := writePromptFile(promptFile, prompt); err != nil {
+		return fmt.Errorf("write prompt file: %w", err)
 	}
 
 	// Prepare log file

--- a/internal/worker/tool_hooks.go
+++ b/internal/worker/tool_hooks.go
@@ -1,0 +1,345 @@
+package worker
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+const (
+	defaultPreToolMatcher  = "*"
+	defaultPostEditMatcher = "Edit|MultiEdit|Write"
+)
+
+type workerToolHookSetup struct {
+	RunnerPath string
+	Claude     bool
+}
+
+func setupWorkerToolHooks(stateDir, worktree, backendName string, hooks config.HooksConfig) (workerToolHookSetup, error) {
+	if !toolHookConfigured(hooks.PreTool) && !toolHookConfigured(hooks.PostEdit) {
+		return workerToolHookSetup{}, nil
+	}
+	if strings.TrimSpace(stateDir) == "" {
+		return workerToolHookSetup{}, fmt.Errorf("empty state dir")
+	}
+	if strings.TrimSpace(worktree) == "" {
+		return workerToolHookSetup{}, fmt.Errorf("empty worktree")
+	}
+
+	runnerPath, err := writeWorkerToolHookRunner(stateDir, hooks)
+	if err != nil {
+		return workerToolHookSetup{}, err
+	}
+
+	setup := workerToolHookSetup{RunnerPath: runnerPath}
+	if backendName == "claude" {
+		if err := writeClaudeToolHookSettings(worktree, runnerPath, hooks); err != nil {
+			return setup, err
+		}
+		if err := excludeClaudeLocalSettings(worktree); err != nil {
+			return setup, err
+		}
+		setup.Claude = true
+	}
+	return setup, nil
+}
+
+func toolHookConfigured(hook config.ToolHookConfig) bool {
+	return strings.TrimSpace(hook.Command) != ""
+}
+
+func writeWorkerToolHookRunner(stateDir string, hooks config.HooksConfig) (string, error) {
+	hookDir := filepath.Join(stateDir, "worker-tool-hooks")
+	if err := os.MkdirAll(hookDir, 0755); err != nil {
+		return "", fmt.Errorf("create worker tool hook dir: %w", err)
+	}
+
+	payload, err := json.Marshal(struct {
+		PreTool  config.ToolHookConfig `json:"pre_tool"`
+		PostEdit config.ToolHookConfig `json:"post_edit"`
+		Timeout  int                   `json:"timeout_ms"`
+	}{
+		PreTool:  hooks.PreTool,
+		PostEdit: hooks.PostEdit,
+		Timeout:  hooks.TimeoutMs,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal worker tool hook config: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	runnerPath := filepath.Join(hookDir, "maestro-tool-hook-"+hex.EncodeToString(sum[:8])+".py")
+	if err := os.WriteFile(runnerPath, []byte(workerToolHookRunnerPython), 0755); err != nil {
+		return "", fmt.Errorf("write worker tool hook runner: %w", err)
+	}
+	configPath := runnerPath + ".json"
+	if err := os.WriteFile(configPath, payload, 0600); err != nil {
+		return "", fmt.Errorf("write worker tool hook config: %w", err)
+	}
+	return runnerPath, nil
+}
+
+func writeClaudeToolHookSettings(worktree, runnerPath string, hooks config.HooksConfig) error {
+	claudeDir := filepath.Join(worktree, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		return fmt.Errorf("create .claude dir: %w", err)
+	}
+
+	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	var settings map[string]any
+	if data, err := os.ReadFile(settingsPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return fmt.Errorf("parse %s: %w", settingsPath, err)
+		}
+	} else {
+		settings = make(map[string]any)
+	}
+
+	hookMap, _ := settings["hooks"].(map[string]any)
+	if hookMap == nil {
+		hookMap = make(map[string]any)
+	}
+	if toolHookConfigured(hooks.PreTool) {
+		matcher := strings.TrimSpace(hooks.PreTool.Matcher)
+		if matcher == "" {
+			matcher = defaultPreToolMatcher
+		}
+		hookMap["PreToolUse"] = appendClaudeHook(hookMap["PreToolUse"], matcher, runnerPath, "pre_tool")
+	}
+	if toolHookConfigured(hooks.PostEdit) {
+		matcher := strings.TrimSpace(hooks.PostEdit.Matcher)
+		if matcher == "" {
+			matcher = defaultPostEditMatcher
+		}
+		hookMap["PostToolUse"] = appendClaudeHook(hookMap["PostToolUse"], matcher, runnerPath, "post_edit")
+	}
+	settings["hooks"] = hookMap
+
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", settingsPath, err)
+	}
+	if err := os.WriteFile(settingsPath, append(data, '\n'), 0600); err != nil {
+		return fmt.Errorf("write %s: %w", settingsPath, err)
+	}
+	return nil
+}
+
+func appendClaudeHook(existing any, matcher, runnerPath, event string) []any {
+	items, _ := existing.([]any)
+	command := fmt.Sprintf("MAESTRO_WORKER_HOOK_EVENT=%s %s", shellQuote(event), shellQuote(runnerPath))
+	entry := map[string]any{
+		"matcher": matcher,
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": command,
+			},
+		},
+	}
+	for i, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok || m["matcher"] != matcher {
+			continue
+		}
+		hookItems, _ := m["hooks"].([]any)
+		for _, hookItem := range hookItems {
+			h, ok := hookItem.(map[string]any)
+			if ok && h["command"] == command {
+				return items
+			}
+		}
+		m["hooks"] = append(hookItems, entry["hooks"].([]any)...)
+		items[i] = m
+		return items
+	}
+	return append(items, entry)
+}
+
+func excludeClaudeLocalSettings(worktree string) error {
+	out, err := exec.Command("git", "-C", worktree, "rev-parse", "--git-path", "info/exclude").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("resolve git exclude path: %w\n%s", err, out)
+	}
+	excludePath := strings.TrimSpace(string(out))
+	if excludePath == "" {
+		return fmt.Errorf("empty git exclude path")
+	}
+	excludePath = filepath.Clean(excludePath)
+	if !filepath.IsAbs(excludePath) {
+		excludePath = filepath.Join(worktree, excludePath)
+	}
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0755); err != nil {
+		return fmt.Errorf("create git info dir: %w", err)
+	}
+	existing, _ := os.ReadFile(excludePath)
+	line := ".claude/settings.local.json"
+	if strings.Contains("\n"+string(existing)+"\n", "\n"+line+"\n") {
+		return nil
+	}
+	f, err := os.OpenFile(excludePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open git exclude: %w", err)
+	}
+	defer f.Close()
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		if _, err := f.WriteString("\n"); err != nil {
+			return fmt.Errorf("write git exclude newline: %w", err)
+		}
+	}
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		return fmt.Errorf("write git exclude entry: %w", err)
+	}
+	return nil
+}
+
+func workerToolHookPromptSection(hooks config.HooksConfig, backendName string, setup workerToolHookSetup) string {
+	if !toolHookConfigured(hooks.PreTool) && !toolHookConfigured(hooks.PostEdit) {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n\n---\n\n## Worker Tool Hooks\n\n")
+	if setup.Claude {
+		b.WriteString("- Maestro installed local Claude Code hooks for this worker session; hook results are fed back into the session automatically.\n")
+	} else {
+		b.WriteString("- Maestro tool hooks are configured for this project, but this backend does not expose a supported automatic hook installer. Run the matching hook command yourself at the required point and use its output before continuing.\n")
+	}
+	if toolHookConfigured(hooks.PreTool) {
+		b.WriteString(fmt.Sprintf("- Before matching tool calls (`%s`), run: `%s`.\n", effectiveHookMatcher(hooks.PreTool, defaultPreToolMatcher), strings.TrimSpace(hooks.PreTool.Command)))
+		if hooks.PreTool.BlockOnFailure {
+			b.WriteString("- A non-zero pre-tool hook result blocks the tool call; correct the reported problem before retrying.\n")
+		}
+	}
+	if toolHookConfigured(hooks.PostEdit) {
+		b.WriteString(fmt.Sprintf("- After file edit tools (`%s`), run: `%s`.\n", effectiveHookMatcher(hooks.PostEdit, defaultPostEditMatcher), strings.TrimSpace(hooks.PostEdit.Command)))
+		if hooks.PostEdit.BlockOnFailure {
+			b.WriteString("- A non-zero post-edit hook result must be corrected before making more changes.\n")
+		}
+	}
+	if setup.RunnerPath != "" {
+		b.WriteString(fmt.Sprintf("- Hook runner: `%s`.\n", setup.RunnerPath))
+	}
+	return b.String()
+}
+
+func effectiveHookMatcher(hook config.ToolHookConfig, fallback string) string {
+	if strings.TrimSpace(hook.Matcher) != "" {
+		return strings.TrimSpace(hook.Matcher)
+	}
+	return fallback
+}
+
+const workerToolHookRunnerPython = `#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+
+MAX_CONTEXT = 9000
+
+def load_config():
+    with open(sys.argv[0] + ".json", "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def trim(text):
+    if len(text) <= MAX_CONTEXT:
+        return text
+    return text[:MAX_CONTEXT] + "\n... [maestro hook output truncated]"
+
+def event_name():
+    return os.environ.get("MAESTRO_WORKER_HOOK_EVENT", "").strip()
+
+def hook_for(cfg, event):
+    if event == "pre_tool":
+        return cfg.get("pre_tool") or {}
+    if event == "post_edit":
+        return cfg.get("post_edit") or {}
+    return {}
+
+def claude_event(event):
+    if event == "pre_tool":
+        return "PreToolUse"
+    if event == "post_edit":
+        return "PostToolUse"
+    return "PostToolUse"
+
+def emit_context(event, message, block=False):
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": claude_event(event),
+            "additionalContext": trim(message),
+        }
+    }
+    if block:
+        if event == "pre_tool":
+            payload["hookSpecificOutput"]["permissionDecision"] = "deny"
+            payload["hookSpecificOutput"]["permissionDecisionReason"] = trim(message)
+        else:
+            payload["decision"] = "block"
+            payload["reason"] = trim(message)
+    print(json.dumps(payload))
+
+def main():
+    cfg = load_config()
+    event = event_name()
+    hook = hook_for(cfg, event)
+    command = (hook.get("command") or "").strip()
+    if not command:
+        return 0
+
+    timeout = int(cfg.get("timeout_ms") or 60000) / 1000
+    raw_input = sys.stdin.read()
+    env = os.environ.copy()
+    env["MAESTRO_HOOK_EVENT"] = event
+    env["MAESTRO_HOOK_INPUT"] = raw_input
+    try:
+        input_data = json.loads(raw_input or "{}")
+        env["MAESTRO_HOOK_TOOL_NAME"] = str(input_data.get("tool_name") or "")
+        tool_input = input_data.get("tool_input") or {}
+        if isinstance(tool_input, dict):
+            file_path = tool_input.get("file_path") or tool_input.get("path") or ""
+            if file_path:
+                env["MAESTRO_HOOK_FILE_PATH"] = str(file_path)
+    except Exception:
+        pass
+
+    try:
+        proc = subprocess.run(
+            ["bash", "-c", command],
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            env=env,
+        )
+        output = ""
+        if proc.stdout:
+            output += "stdout:\n" + proc.stdout.rstrip() + "\n"
+        if proc.stderr:
+            output += "stderr:\n" + proc.stderr.rstrip() + "\n"
+        if not output:
+            output = "(no stdout/stderr)"
+        status = "passed" if proc.returncode == 0 else "failed"
+        message = f"Maestro {event} hook {status} (exit {proc.returncode}): {command}\n\n{output}".rstrip()
+        emit_context(event, message, block=proc.returncode != 0 and bool(hook.get("block_on_failure")))
+        return 0
+    except subprocess.TimeoutExpired as exc:
+        output = ""
+        if exc.stdout:
+            output += "stdout:\n" + exc.stdout.rstrip() + "\n"
+        if exc.stderr:
+            output += "stderr:\n" + exc.stderr.rstrip() + "\n"
+        message = f"Maestro {event} hook timed out after {timeout:.0f}s: {command}\n\n{output}".rstrip()
+        emit_context(event, message, block=bool(hook.get("block_on_failure")))
+        return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+`

--- a/internal/worker/tool_hooks_test.go
+++ b/internal/worker/tool_hooks_test.go
@@ -1,0 +1,193 @@
+package worker
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+func TestSetupWorkerToolHooksDefaultOff(t *testing.T) {
+	setup, err := setupWorkerToolHooks(t.TempDir(), t.TempDir(), "claude", config.HooksConfig{TimeoutMs: 1000})
+	if err != nil {
+		t.Fatalf("setupWorkerToolHooks: %v", err)
+	}
+	if setup.RunnerPath != "" || setup.Claude {
+		t.Fatalf("setup = %+v, want empty/default off", setup)
+	}
+}
+
+func TestSetupWorkerToolHooksWritesClaudeSettingsAndExcludesLocalFile(t *testing.T) {
+	worktree := newGitRepo(t)
+	stateDir := t.TempDir()
+	hooks := config.HooksConfig{
+		TimeoutMs: 2000,
+		PreTool: config.ToolHookConfig{
+			Command:        "echo pre",
+			BlockOnFailure: true,
+		},
+		PostEdit: config.ToolHookConfig{
+			Command: "echo post",
+			Matcher: "Write|Edit",
+		},
+	}
+
+	setup, err := setupWorkerToolHooks(stateDir, worktree, "claude", hooks)
+	if err != nil {
+		t.Fatalf("setupWorkerToolHooks: %v", err)
+	}
+	if !setup.Claude {
+		t.Fatal("setup.Claude = false, want true")
+	}
+	if setup.RunnerPath == "" {
+		t.Fatal("RunnerPath should be set")
+	}
+	if _, err := os.Stat(setup.RunnerPath); err != nil {
+		t.Fatalf("runner missing: %v", err)
+	}
+
+	settingsData, err := os.ReadFile(filepath.Join(worktree, ".claude", "settings.local.json"))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(settingsData, &settings); err != nil {
+		t.Fatalf("settings JSON: %v\n%s", err, settingsData)
+	}
+	content := string(settingsData)
+	for _, want := range []string{
+		`"PreToolUse"`,
+		`"PostToolUse"`,
+		`"matcher": "*"`,
+		`"matcher": "Write|Edit"`,
+		"MAESTRO_WORKER_HOOK_EVENT",
+		setup.RunnerPath,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("settings missing %q\n%s", want, content)
+		}
+	}
+
+	excludePath := gitPath(t, worktree, "info/exclude")
+	excludeData, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read git exclude: %v", err)
+	}
+	if !strings.Contains(string(excludeData), ".claude/settings.local.json") {
+		t.Fatalf("git exclude missing local settings entry:\n%s", excludeData)
+	}
+}
+
+func TestSetupWorkerToolHooksNonClaudeWritesRunnerOnly(t *testing.T) {
+	stateDir := t.TempDir()
+	worktree := t.TempDir()
+	hooks := config.HooksConfig{PostEdit: config.ToolHookConfig{Command: "echo post"}}
+
+	setup, err := setupWorkerToolHooks(stateDir, worktree, "codex", hooks)
+	if err != nil {
+		t.Fatalf("setupWorkerToolHooks: %v", err)
+	}
+	if setup.Claude {
+		t.Fatal("setup.Claude = true, want false for codex")
+	}
+	if setup.RunnerPath == "" {
+		t.Fatal("RunnerPath should be set for prompt fallback")
+	}
+	if _, err := os.Stat(filepath.Join(worktree, ".claude", "settings.local.json")); !os.IsNotExist(err) {
+		t.Fatalf("codex setup should not write Claude settings, err=%v", err)
+	}
+}
+
+func TestWorkerToolHookPromptSection(t *testing.T) {
+	hooks := config.HooksConfig{
+		PreTool:  config.ToolHookConfig{Command: "./check-pre.sh", BlockOnFailure: true},
+		PostEdit: config.ToolHookConfig{Command: "gofmt -w ."},
+	}
+	section := workerToolHookPromptSection(hooks, "codex", workerToolHookSetup{RunnerPath: "/tmp/hook.py"})
+
+	for _, want := range []string{
+		"## Worker Tool Hooks",
+		"does not expose a supported automatic hook installer",
+		"./check-pre.sh",
+		"gofmt -w .",
+		"/tmp/hook.py",
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("section missing %q\n%s", want, section)
+		}
+	}
+}
+
+func TestWorkerToolHookRunnerFeedsFailureOutputAsContext(t *testing.T) {
+	stateDir := t.TempDir()
+	hooks := config.HooksConfig{
+		TimeoutMs: 5000,
+		PostEdit: config.ToolHookConfig{
+			Command:        `echo out; echo err >&2; exit 3`,
+			BlockOnFailure: true,
+		},
+	}
+	runnerPath, err := writeWorkerToolHookRunner(stateDir, hooks)
+	if err != nil {
+		t.Fatalf("writeWorkerToolHookRunner: %v", err)
+	}
+
+	cmd := exec.Command(runnerPath)
+	cmd.Env = append(os.Environ(), "MAESTRO_WORKER_HOOK_EVENT=post_edit")
+	cmd.Stdin = strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":"main.go"}}`)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("runner should return JSON with exit 0, got %v\n%s", err, out)
+	}
+	got := string(out)
+	for _, want := range []string{
+		`"decision": "block"`,
+		"Maestro post_edit hook failed (exit 3)",
+		"stdout:",
+		"out",
+		"stderr:",
+		"err",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("runner output missing %q\n%s", want, got)
+		}
+	}
+}
+
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("test\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	run("add", "README.md")
+	run("-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "init")
+	return dir
+}
+
+func gitPath(t *testing.T, worktree, path string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", worktree, "rev-parse", "--git-path", path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse --git-path %s: %v\n%s", path, err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	if filepath.IsAbs(got) {
+		return got
+	}
+	return filepath.Join(worktree, got)
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -90,15 +90,6 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		promptBase = promptBase + section
 	}
 
-	// Assemble worker prompt
-	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
-
-	// Write prompt to file
-	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
-	if err := writePromptFile(promptFile, prompt); err != nil {
-		return "", fmt.Errorf("write prompt file: %w", err)
-	}
-
 	// Determine backend
 	if backendName == "" {
 		backendName = cfg.Model.Default
@@ -116,6 +107,21 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+	}
+
+	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, backendName, cfg.Hooks)
+	if err != nil {
+		return "", fmt.Errorf("setup worker tool hooks: %w", err)
+	}
+
+	// Assemble worker prompt
+	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
+	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
+
+	// Write prompt to file
+	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
+	if err := writePromptFile(promptFile, prompt); err != nil {
+		return "", fmt.Errorf("write prompt file: %w", err)
 	}
 
 	// Prepare log file
@@ -231,15 +237,6 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 		promptBase = promptBase + section
 	}
 
-	// Assemble worker prompt
-	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
-
-	// Write prompt to file
-	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
-	if err := writePromptFile(promptFile, prompt); err != nil {
-		return fmt.Errorf("write prompt file: %w", err)
-	}
-
 	// Determine backend
 	if backendName == "" {
 		backendName = cfg.Model.Default
@@ -256,6 +253,21 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+	}
+
+	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, backendName, cfg.Hooks)
+	if err != nil {
+		return fmt.Errorf("setup worker tool hooks: %w", err)
+	}
+
+	// Assemble worker prompt
+	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
+	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
+
+	// Write prompt to file
+	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
+	if err := writePromptFile(promptFile, prompt); err != nil {
+		return fmt.Errorf("write prompt file: %w", err)
 	}
 
 	// Prepare log file


### PR DESCRIPTION
Refs #647

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces per-session PreToolUse and PostToolUse hook support for worker sessions, allowing operators to run lint or safety-check commands automatically inside a Claude Code worker without manual intervention.

- A new `tool_hooks.go` module handles writing the Python runner, injecting the hook registrations into `.claude/settings.local.json`, and adding a `.git/info/exclude` entry to keep the file untracked; all four spawn paths (Start, Respawn, RespawnInPlace, StartPhase) are wired up consistently.
- `HooksConfig` gains `PreTool` and `PostEdit` `ToolHookConfig` fields with a `timeout_ms` default of 60 000 ms; config parsing, tests, and the runbook are updated accordingly.

<h3>Confidence Score: 3/5</h3>

Safe to merge with the nil-map panic fixed; the affected code path is exercised on every Claude worker spawn when hooks are configured.

The hook injection logic in writeClaudeToolHookSettings will panic if .claude/settings.local.json already exists in the worktree and its content is the JSON value null. After json.Unmarshal, settings is nil, and the subsequent settings["hooks"] = hookMap assignment is a runtime panic. This crash would surface on every hook-enabled worker spawn in that state. The rest of the implementation — Python runner protocol, deduplication, git-exclude wiring, and prompt section generation — looks correct and well-tested.

internal/worker/tool_hooks.go — specifically the settings.local.json merge path around line 96-123

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/tool_hooks.go | New file implementing PreToolUse/PostToolUse hook setup for Claude worker sessions; contains a nil-map panic if settings.local.json is valid JSON null, and missing test coverage for pre_tool blocking. |
| internal/worker/tool_hooks_test.go | Good coverage of the happy path and post_edit failure/blocking; missing a pre_tool block scenario exercised end-to-end via the Python runner. |
| internal/config/config.go | Adds ToolHookConfig / HooksConfig fields and a default TimeoutMs of 60 000 ms in parse(); straightforward and consistent with existing config patterns. |
| internal/worker/worker.go | Integrates setupWorkerToolHooks and workerToolHookPromptSection into Start and Respawn; integration is symmetric and correct in both code paths. |
| internal/worker/checkpoint.go | RespawnInPlace now calls setupWorkerToolHooks and appends the hook prompt section before writing the prompt file; consistent with Start/Respawn. |
| internal/worker/phase.go | StartPhase now calls setupWorkerToolHooks and appends the hook prompt section; consistent with the other spawn paths. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/worker/tool_hooks.go:96-103
**Nil-map panic when settings.local.json contains JSON null**

`json.Unmarshal([]byte("null"), &settings)` succeeds but leaves `settings` as a nil `map[string]any`. Every key read from a nil map is safe in Go, but the assignment `settings["hooks"] = hookMap` on line 123 then panics because writing to a nil map is a runtime error.

This is triggered if `.claude/settings.local.json` already exists in the worktree (e.g. from a repo template or a corrupted previous write) and its content is the JSON value `null`. A simple nil-guard after the unmarshal call would close the gap:

```go
if settings == nil {
    settings = make(map[string]any)
}
```

### Issue 2 of 2
internal/worker/tool_hooks.go:240-270
**`pre_tool` blocking path is untested**

`TestWorkerToolHookRunnerFeedsFailureOutputAsContext` only exercises `post_edit` with `block_on_failure: true`. The `pre_tool` branch (which emits `hookSpecificOutput.permissionDecision = "deny"` rather than a top-level `decision: "block"`) has no corresponding test. A bug in that path — wrong JSON key, wrong nesting level — would be invisible until a real session tried to block a tool call.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: add in-session tool hooks"](https://github.com/befeast/maestro/commit/908458c733a3a385a579e282b0007be547db1268) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35358953)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->