### PR TITLE
worker: optional MCP tool access for worker sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,34 @@ model:
 > Headless mode: `cline -y "task"` — auto-approves all actions and exits when done.
 > SAP AI Core example: set provider to `sapaicore`, model to `anthropic--claude-4.5-opus`.
 
+### Optional worker MCP tools
+
+Worker sessions receive no MCP tools by default. Attach project-specific MCP servers per backend with `model.backends.<name>.mcp`:
+
+```yaml
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      mcp:
+        servers:
+          docs:
+            command: npx
+            args: ["-y", "@example/docs-mcp"]
+          symbols:
+            url: https://mcp.example.com/mcp
+            bearer_token_env_var: SYMBOLS_MCP_TOKEN
+    claude:
+      cmd: claude
+      mcp:
+        strict: true
+        configs:
+          - /path/to/project-mcp.json
+```
+
+For Codex workers, Maestro passes configured servers as `-c mcp_servers...` overrides. For Claude workers, Maestro passes `--mcp-config` and `--strict-mcp-config` when requested. Keep tokens in environment variables and reference their names from config.
+
 ### Per-issue routing
 Label a GitHub issue with `model:codex`, `model:gemini`, or `model:cline` to override the default backend for that specific issue:
 ```
@@ -382,7 +410,7 @@ The exact command depends on the selected backend. Examples:
 
 ```bash
 # Claude
-cd /worktree/path && claude --dangerously-skip-permissions -p "<assembled prompt>"
+cd /worktree/path && claude --dangerously-skip-permissions -p < /path/to/prompt.txt
 
 # Codex
 cd /worktree/path && codex exec --dangerously-bypass-approvals-and-sandbox -C /worktree/path - < /path/to/prompt.txt

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -186,6 +186,24 @@ supervisor:
     - delete_worktree
     - change_global_config
 
+# Model backends. MCP is opt-in per backend; omit mcp to spawn workers
+# without external MCP tools.
+model:
+  default: claude
+  backends:
+    claude:
+      cmd: claude
+    codex:
+      cmd: codex
+      # mcp:
+      #   servers:
+      #     docs:
+      #       command: npx
+      #       args: ["-y", "@example/docs-mcp"]
+      #     symbols:
+      #       url: https://mcp.example.com/mcp
+      #       bearer_token_env_var: SYMBOLS_MCP_TOKEN
+
 # Concurrency
 max_parallel: 5
 max_runtime_minutes: 120
@@ -240,6 +258,7 @@ telegram:
 | `exclude_labels` | Skip issues with any of these labels |
 | `outcome` | Project operating brief used by the supervisor to judge runtime progress |
 | `supervisor` | Optional local policy for supervisor queue order, safe actions, dispatch SLA, and issue-type skips |
+| `model.backends.<name>.mcp` | Optional worker MCP attachment for that backend; omitted means no MCP tools |
 | `max_parallel` | Maximum concurrent worker sessions |
 | `deploy_cmd` | Shell command maestro runs after merging a PR |
 | `session_prefix` | Prefix for tmux session names |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,10 +22,11 @@ type TelegramConfig struct {
 
 // BackendDef defines a model backend CLI.
 type BackendDef struct {
-	Cmd        string   `yaml:"cmd"`
-	ExtraArgs  []string `yaml:"extra_args"`
-	PromptMode string   `yaml:"prompt_mode"` // how to deliver prompt: "arg" (last argument), "stdin" (via stdin), "file" (file path as argument)
-	Enabled    *bool    `yaml:"enabled"`     // nil means enabled for backward compatibility
+	Cmd        string    `yaml:"cmd"`
+	ExtraArgs  []string  `yaml:"extra_args"`
+	PromptMode string    `yaml:"prompt_mode"` // how to deliver prompt: "arg" (last argument), "stdin" (via stdin), "file" (file path as argument)
+	Enabled    *bool     `yaml:"enabled"`     // nil means enabled for backward compatibility
+	MCP        MCPConfig `yaml:"mcp,omitempty"`
 
 	// #513: optional per-backend attribution metadata. Lets the
 	// dashboard / commit trailer record which provider+model actually
@@ -58,6 +59,34 @@ type BackendDef struct {
 	// blends input/output 50/50; operators who care about precision can
 	// set the same value for both.
 	Pricing BackendPricing `yaml:"pricing,omitempty"`
+}
+
+// MCPConfig is an opt-in per-backend worker MCP attachment. When empty,
+// Maestro passes no MCP configuration to spawned workers.
+type MCPConfig struct {
+	// Configs are backend-native MCP config JSON strings or file paths. Claude
+	// receives them via --mcp-config. Codex cannot consume these directly; use
+	// Servers for Codex workers.
+	Configs []string `yaml:"configs,omitempty"`
+	// Strict is supported by Claude workers and makes --mcp-config the only
+	// MCP source for the session.
+	Strict  bool                    `yaml:"strict,omitempty"`
+	Servers map[string]MCPServerDef `yaml:"servers,omitempty"`
+}
+
+// MCPServerDef describes one MCP server exposed to a worker backend.
+// Configure either Command for stdio or URL for streamable HTTP.
+type MCPServerDef struct {
+	Command           string            `yaml:"command,omitempty"`
+	Args              []string          `yaml:"args,omitempty"`
+	Env               map[string]string `yaml:"env,omitempty"`
+	URL               string            `yaml:"url,omitempty"`
+	BearerTokenEnvVar string            `yaml:"bearer_token_env_var,omitempty"`
+	Headers           map[string]string `yaml:"headers,omitempty"`
+	AllowedTools      []string          `yaml:"allowed_tools,omitempty"`
+	StartupTimeoutMs  int               `yaml:"startup_timeout_ms,omitempty"`
+	ToolTimeoutMs     int               `yaml:"tool_timeout_ms,omitempty"`
+	Trust             string            `yaml:"trust,omitempty"`
 }
 
 // BackendPricing is the per-backend cost table used by the fleet cost

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -784,6 +784,71 @@ model:
 	}
 }
 
+func TestParse_ModelBackendMCPConfig(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      mcp:
+        servers:
+          docs:
+            command: npx
+            args: ["-y", "@example/docs-mcp"]
+            env:
+              DOCS_ENV: test
+            allowed_tools: ["search_docs"]
+            startup_timeout_ms: 15000
+          symbols:
+            url: https://mcp.example.invalid/mcp
+            bearer_token_env_var: SYMBOLS_MCP_TOKEN
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	mcp := cfg.Model.Backends["codex"].MCP
+	if len(mcp.Servers) != 2 {
+		t.Fatalf("expected 2 MCP servers, got %d", len(mcp.Servers))
+	}
+	docs := mcp.Servers["docs"]
+	if docs.Command != "npx" {
+		t.Errorf("docs.Command = %q, want npx", docs.Command)
+	}
+	if len(docs.Args) != 2 || docs.Args[1] != "@example/docs-mcp" {
+		t.Errorf("docs.Args = %v", docs.Args)
+	}
+	if docs.Env["DOCS_ENV"] != "test" {
+		t.Errorf("docs.Env = %v", docs.Env)
+	}
+	if len(docs.AllowedTools) != 1 || docs.AllowedTools[0] != "search_docs" {
+		t.Errorf("docs.AllowedTools = %v", docs.AllowedTools)
+	}
+	if docs.StartupTimeoutMs != 15000 {
+		t.Errorf("docs.StartupTimeoutMs = %d, want 15000", docs.StartupTimeoutMs)
+	}
+	symbols := mcp.Servers["symbols"]
+	if symbols.URL != "https://mcp.example.invalid/mcp" {
+		t.Errorf("symbols.URL = %q", symbols.URL)
+	}
+	if symbols.BearerTokenEnvVar != "SYMBOLS_MCP_TOKEN" {
+		t.Errorf("symbols.BearerTokenEnvVar = %q", symbols.BearerTokenEnvVar)
+	}
+}
+
+func TestParse_ModelBackendMCPDefaultEmpty(t *testing.T) {
+	cfg, err := parse([]byte(`repo: owner/repo`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	mcp := cfg.Model.Backends["claude"].MCP
+	if len(mcp.Configs) != 0 || len(mcp.Servers) != 0 || mcp.Strict {
+		t.Errorf("MCP default should be empty, got %+v", mcp)
+	}
+}
+
 func TestParse_GeminiDefaultBackend(t *testing.T) {
 	yaml := `
 repo: owner/repo

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -1,10 +1,15 @@
 package worker
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
+	"strconv"
 	"strings"
+
+	"github.com/befeast/maestro/internal/config"
 )
 
 // splitCmd splits a command string into binary and extra arguments.
@@ -24,6 +29,7 @@ type BackendConfig struct {
 	PromptMode string   // how to deliver prompt: "arg", "stdin", "file"
 	Model      string   // optional model name for role-specific backend calls
 	Effort     string   // optional reasoning effort for role-specific backend calls
+	MCP        config.MCPConfig
 }
 
 // Backend builds the exec.Cmd for a specific model CLI.
@@ -60,6 +66,11 @@ func (claudeBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*
 	// argument is given; the runner script wires promptFile to stdin (mirrors
 	// the codex `-` path and the supervisor claude branch from #453).
 	args := append(cmdArgs, "--dangerously-skip-permissions", "-p")
+	var err error
+	args, err = appendClaudeMCPOptions(args, cfg.MCP)
+	if err != nil {
+		return nil, "", err
+	}
 	args = append(args, cfg.ExtraArgs...)
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = worktree
@@ -77,8 +88,14 @@ func (codexBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*e
 		codexCmd = "codex"
 	}
 	binary, cmdArgs := splitCmd(codexCmd)
-	args := append(cmdArgs, "exec", "--dangerously-bypass-approvals-and-sandbox", "-C", worktree, "-")
+	args := append(cmdArgs, "exec", "--dangerously-bypass-approvals-and-sandbox", "-C", worktree)
+	var err error
+	args, err = appendCodexMCPOptions(args, cfg.MCP)
+	if err != nil {
+		return nil, "", err
+	}
 	args = append(args, cfg.ExtraArgs...)
+	args = append(args, "-")
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = worktree
 	// Stdin redirection is handled by the runner script — no file opened here
@@ -182,6 +199,142 @@ func appendModelOptions(args []string, cfg BackendConfig) []string {
 		args = append(args, "--effort", strings.TrimSpace(cfg.Effort))
 	}
 	return args
+}
+
+func appendClaudeMCPOptions(args []string, mcp config.MCPConfig) ([]string, error) {
+	configs := append([]string{}, mcp.Configs...)
+	if len(mcp.Servers) > 0 {
+		inline, err := claudeMCPConfigJSON(mcp.Servers)
+		if err != nil {
+			return nil, err
+		}
+		configs = append(configs, inline)
+	}
+	if len(configs) > 0 {
+		args = append(args, "--mcp-config")
+		args = append(args, configs...)
+		if mcp.Strict {
+			args = append(args, "--strict-mcp-config")
+		}
+	}
+	return args, nil
+}
+
+func claudeMCPConfigJSON(servers map[string]config.MCPServerDef) (string, error) {
+	out := map[string]map[string]map[string]interface{}{"mcpServers": {}}
+	for _, name := range sortedServerNames(servers) {
+		server := servers[name]
+		if strings.TrimSpace(server.Command) != "" && strings.TrimSpace(server.URL) != "" {
+			return "", fmt.Errorf("mcp server %q: configure command or url, not both", name)
+		}
+		entry := make(map[string]interface{})
+		if url := strings.TrimSpace(server.URL); url != "" {
+			entry["type"] = "http"
+			entry["url"] = url
+			if len(server.Headers) > 0 {
+				entry["headers"] = server.Headers
+			}
+		} else if command := strings.TrimSpace(server.Command); command != "" {
+			entry["command"] = command
+			if len(server.Args) > 0 {
+				entry["args"] = server.Args
+			}
+			if len(server.Env) > 0 {
+				entry["env"] = server.Env
+			}
+		} else {
+			return "", fmt.Errorf("mcp server %q: command or url is required", name)
+		}
+		out["mcpServers"][name] = entry
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		return "", fmt.Errorf("marshal claude mcp config: %w", err)
+	}
+	return string(data), nil
+}
+
+func appendCodexMCPOptions(args []string, mcp config.MCPConfig) ([]string, error) {
+	if len(mcp.Configs) > 0 {
+		return nil, fmt.Errorf("codex MCP config paths/JSON are not supported; configure model.backends.<name>.mcp.servers instead")
+	}
+	for _, name := range sortedServerNames(mcp.Servers) {
+		server := mcp.Servers[name]
+		if strings.TrimSpace(server.Command) != "" && strings.TrimSpace(server.URL) != "" {
+			return nil, fmt.Errorf("mcp server %q: configure command or url, not both", name)
+		}
+		prefix := "mcp_servers." + tomlKey(name) + "."
+		if command := strings.TrimSpace(server.Command); command != "" {
+			args = append(args, "-c", prefix+"command="+tomlString(command))
+			if len(server.Args) > 0 {
+				args = append(args, "-c", prefix+"args="+tomlStringArray(server.Args))
+			}
+			if len(server.Env) > 0 {
+				args = append(args, "-c", prefix+"env="+tomlStringMap(server.Env))
+			}
+		} else if url := strings.TrimSpace(server.URL); url != "" {
+			args = append(args, "-c", prefix+"url="+tomlString(url))
+			if bearer := strings.TrimSpace(server.BearerTokenEnvVar); bearer != "" {
+				args = append(args, "-c", prefix+"bearer_token_env_var="+tomlString(bearer))
+			}
+		} else {
+			return nil, fmt.Errorf("mcp server %q: command or url is required", name)
+		}
+		if len(server.AllowedTools) > 0 {
+			args = append(args, "-c", prefix+"allowed_tools="+tomlStringArray(server.AllowedTools))
+		}
+		if server.StartupTimeoutMs > 0 {
+			args = append(args, "-c", prefix+"startup_timeout_ms="+strconv.Itoa(server.StartupTimeoutMs))
+		}
+		if server.ToolTimeoutMs > 0 {
+			args = append(args, "-c", prefix+"tool_timeout_ms="+strconv.Itoa(server.ToolTimeoutMs))
+		}
+		if trust := strings.TrimSpace(server.Trust); trust != "" {
+			args = append(args, "-c", prefix+"trust="+tomlString(trust))
+		}
+	}
+	return args, nil
+}
+
+func sortedServerNames(servers map[string]config.MCPServerDef) []string {
+	names := make([]string, 0, len(servers))
+	for name := range servers {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func tomlKey(key string) string {
+	return strconv.Quote(strings.TrimSpace(key))
+}
+
+func tomlString(value string) string {
+	return strconv.Quote(value)
+}
+
+func tomlStringArray(values []string) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		parts = append(parts, tomlString(value))
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+func tomlStringMap(values map[string]string) string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, tomlKey(key)+"="+tomlString(values[key]))
+	}
+	return "{" + strings.Join(parts, ",") + "}"
 }
 
 // BuildWorkerCmd creates the right exec.Cmd based on backend name.

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/befeast/maestro/internal/config"
 )
 
 func TestBuildWorkerCmd_Claude(t *testing.T) {
@@ -167,6 +169,118 @@ func TestBuildWorkerCmd_CodexPromptFileIsValidUTF8(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "\uFFFD") {
 		t.Fatalf("expected invalid byte to be replaced with U+FFFD, got %q", string(data))
+	}
+}
+
+func TestBuildWorkerCmd_ClaudeWithMCPConfig(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("use docs"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BackendConfig{
+		Cmd: "claude",
+		MCP: config.MCPConfig{
+			Strict:  true,
+			Configs: []string{"/tmp/project-mcp.json"},
+			Servers: map[string]config.MCPServerDef{
+				"docs": {
+					Command: "npx",
+					Args:    []string{"-y", "@example/docs-mcp"},
+					Env:     map[string]string{"DOCS_ENV": "test"},
+				},
+			},
+		},
+	}
+	cmd, stdinFile, err := BuildWorkerCmd("claude", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	for _, want := range []string{
+		"--mcp-config",
+		"/tmp/project-mcp.json",
+		"--strict-mcp-config",
+		`"mcpServers"`,
+		`"docs"`,
+		`"command":"npx"`,
+		`"args":["-y","@example/docs-mcp"]`,
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("expected %q in args, got: %s", want, args)
+		}
+	}
+}
+
+func TestBuildWorkerCmd_CodexWithMCPServers(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("use docs"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BackendConfig{
+		Cmd: "codex",
+		MCP: config.MCPConfig{
+			Servers: map[string]config.MCPServerDef{
+				"docs": {
+					Command:          "npx",
+					Args:             []string{"-y", "@example/docs-mcp"},
+					AllowedTools:     []string{"search_docs"},
+					StartupTimeoutMs: 15000,
+				},
+				"symbols": {
+					URL:               "https://mcp.example.invalid/mcp",
+					BearerTokenEnvVar: "SYMBOLS_MCP_TOKEN",
+				},
+			},
+		},
+	}
+	cmd, stdinFile, err := BuildWorkerCmd("codex", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	for _, want := range []string{
+		`mcp_servers."docs".command="npx"`,
+		`mcp_servers."docs".args=["-y","@example/docs-mcp"]`,
+		`mcp_servers."docs".allowed_tools=["search_docs"]`,
+		`mcp_servers."docs".startup_timeout_ms=15000`,
+		`mcp_servers."symbols".url="https://mcp.example.invalid/mcp"`,
+		`mcp_servers."symbols".bearer_token_env_var="SYMBOLS_MCP_TOKEN"`,
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("expected %q in args, got: %s", want, args)
+		}
+	}
+	if cmd.Args[len(cmd.Args)-1] != "-" {
+		t.Errorf("codex stdin prompt marker should remain last, got args: %v", cmd.Args)
+	}
+}
+
+func TestBuildWorkerCmd_NoMCPByDefault(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("plain worker"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, backendName := range []string{"claude", "codex"} {
+		cmd, _, err := BuildWorkerCmd(backendName, BackendConfig{Cmd: backendName}, promptFile, "/tmp/wt")
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", backendName, err)
+		}
+		args := strings.Join(cmd.Args, " ")
+		if strings.Contains(args, "mcp") || strings.Contains(args, "MCP") {
+			t.Errorf("%s: expected no MCP args by default, got: %s", backendName, args)
+		}
 	}
 }
 

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -124,6 +124,7 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+		MCP:        backendDef.MCP,
 	}
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, backendName, cfg.Hooks)

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -42,6 +42,7 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+		MCP:        backendDef.MCP,
 	}
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, backendName, cfg.Hooks)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -107,6 +107,7 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+		MCP:        backendDef.MCP,
 	}
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, backendName, cfg.Hooks)
@@ -253,6 +254,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+		MCP:        backendDef.MCP,
 	}
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, backendName, cfg.Hooks)

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -64,6 +64,16 @@ model:
       #   output_usd_per_mtok: 75
     codex:
       cmd: codex
+      # Optional worker MCP tools. Omit this block for the safe default:
+      # workers receive no MCP servers unless explicitly configured.
+      # mcp:
+      #   servers:
+      #     docs:
+      #       command: npx
+      #       args: ["-y", "@example/docs-mcp"]
+      #     symbols:
+      #       url: https://mcp.example.com/mcp
+      #       bearer_token_env_var: SYMBOLS_MCP_TOKEN
     gemini:
       cmd: gemini
     cline:


### PR DESCRIPTION
Refs #648

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opt-in MCP tool access for worker sessions, letting users attach per-backend MCP servers via `model.backends.<name>.mcp` in `maestro.yaml`. Both Claude (via `--mcp-config` / inline JSON) and Codex (via `-c mcp_servers.*` overrides) are supported, and the MCP config is correctly threaded through all four worker entry points.

- New `MCPConfig` / `MCPServerDef` config structs with full YAML mapping and opt-in defaulting (omitting the block gives the previous no-MCP behaviour).
- `appendClaudeMCPOptions` and `appendCodexMCPOptions` translate the shared struct into backend-native CLI flags; helper functions cover TOML serialisation for Codex overrides.
- Two logic gaps in `backend.go`: `BearerTokenEnvVar` is silently dropped when generating Claude's `mcpServers` JSON, and when both `Configs` and `Servers` are set the code appends all values after a single `--mcp-config` token rather than repeating the flag, which will cause an argument-parse error at the Claude CLI level.

<h3>Confidence Score: 3/5</h3>

The plumbing that threads MCP config through worker start/respawn paths is correct, but two defects in the Claude argument-building logic would cause silent auth failures or a Claude CLI crash in specific but documented configurations.

The bearer-token field is accepted by the config and shown in the README example but is never written into the Claude mcpServers JSON, so any HTTP MCP server relying on it will launch without auth and fail at runtime. Separately, when a user combines explicit configs file paths with inline servers, appendClaudeMCPOptions emits a single --mcp-config followed by multiple positional values; standard flag parsers only consume one, leaving the inline JSON blob as an unrecognised argument that would cause Claude to exit with a parse error. Both paths are reachable with the config shapes the README explicitly documents.

internal/worker/backend.go — specifically the claudeMCPConfigJSON HTTP branch and the appendClaudeMCPOptions multi-config loop

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/backend.go | Core MCP integration logic; two issues: bearer token silently dropped for Claude HTTP servers, and multiple configs sharing a single --mcp-config flag may break CLI argument parsing |
| internal/config/config.go | Adds MCPConfig and MCPServerDef structs with correct YAML tags and omitempty defaults; struct design is clean |
| internal/worker/backend_test.go | Tests use strings.Contains which would not catch wrong argument order or the multi-value --mcp-config issue; functional correctness may not be caught by test failures |
| internal/worker/worker.go | MCP field correctly threaded into BackendConfig in Start and Respawn paths |
| README.md | Documentation added for optional MCP tool configuration; examples are clear but bearer_token_env_var is shown without noting it is only effective for Codex workers |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/worker/backend.go:231-235
**`BearerTokenEnvVar` silently dropped for Claude HTTP servers**

When `MCPServerDef.BearerTokenEnvVar` is set on an HTTP-type server and the backend is Claude, `claudeMCPConfigJSON` only writes `type`, `url`, and optional `headers` — the bearer token field is never included in the JSON output. The Codex path correctly passes `bearer_token_env_var` via `-c`, but there is no corresponding mapping here. A user following the README example (which shows `bearer_token_env_var: SYMBOLS_MCP_TOKEN` for an HTTP server without a Claude/Codex distinction) will have their Claude worker silently launch without auth, causing all calls to the HTTP MCP server to fail with 401s at runtime rather than a config-time error.

### Issue 2 of 2
internal/worker/backend.go:204-221
**Multiple values appended after a single `--mcp-config` flag**

When both `mcp.Configs` is non-empty and `mcp.Servers` is non-empty, `configs` ends up with two or more items (e.g. `["/path/to/mcp.json", "{\"mcpServers\":...}"]`). The code then appends a single `--mcp-config` token followed by all of them: `--mcp-config /path/to/mcp.json {"mcpServers":...}`. Standard CLI flag parsers (including cobra's `StringVar`) consume exactly one value per flag occurrence, so the inline JSON string would be left as an unrecognised positional argument and Claude would exit with an argument parse error.

If Claude's `--mcp-config` supports repeated flag invocations (i.e. `--mcp-config path1 --mcp-config json_blob`), each config should be prepended with its own `--mcp-config` token rather than sharing one.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: add optional MCP config for work..."](https://github.com/befeast/maestro/commit/c87e71255ace9bd717c154c234da437106ad3e53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35361740)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->