### PR TITLE
review: add a parallel simplicity / over-engineering reviewer stream

### DIFF
--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -297,6 +297,19 @@ model:
       cmd: codex
 ```
 
+### Optional: parallel review streams
+
+By default, `review_gate: greptile` waits for the single Greptile verdict before merge. Projects that also run the simplicity / over-engineering reviewer can opt in to the aggregate gate:
+
+```yaml
+review_gate: greptile
+review_gate_streams:
+  - greptile
+  - simplicity
+```
+
+`review_gate: none` disables all review streams. A blocking simplicity finding is treated like a blocking Greptile finding for merge gating and review-repair.
+
 ### Running as a systemd service
 
 ```bash

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -780,6 +780,7 @@ type Config struct {
 	MergeStrategy                   string                       `yaml:"merge_strategy"`                     // "sequential" | "parallel"
 	MergeIntervalSeconds            int                          `yaml:"merge_interval_seconds"`             // minimum seconds between merges in sequential mode
 	ReviewGate                      string                       `yaml:"review_gate"`                        // "greptile" (default) | "none"
+	ReviewGateStreams               []string                     `yaml:"review_gate_streams"`                // optional review dimensions; default ["greptile"], opt-in ["greptile","simplicity"]
 	AutoRetryReviewFeedback         bool                         `yaml:"auto_retry_review_feedback"`         // close PRs with review comments and respawn a fixer
 	MergeExhaustedNonCriticalReview *bool                        `yaml:"merge_exhausted_noncritical_review"` // #565: merge a green PR after review-feedback retries exhaust when only non-critical (P1/P2/P3) findings remain (no P0 on head). nil = default-on.
 	AutoRetryRebaseConflicts        bool                         `yaml:"auto_retry_rebase_conflicts"`        // retry PRs whose auto-rebase fails with conflicts
@@ -1083,6 +1084,7 @@ func parse(data []byte) (*Config, error) {
 	default:
 		cfg.ReviewGate = "greptile"
 	}
+	cfg.ReviewGateStreams = normalizeReviewGateStreams(cfg.ReviewGate, cfg.ReviewGateStreams)
 
 	// Default hooks timeout
 	if cfg.Hooks.TimeoutMs <= 0 {
@@ -1118,6 +1120,44 @@ func parse(data []byte) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func normalizeReviewGateStreams(reviewGate string, streams []string) []string {
+	if strings.EqualFold(strings.TrimSpace(reviewGate), "none") {
+		return nil
+	}
+	if len(streams) == 0 {
+		return []string{"greptile"}
+	}
+	out := make([]string, 0, len(streams))
+	seen := make(map[string]struct{}, len(streams))
+	for _, raw := range streams {
+		name := strings.ToLower(strings.TrimSpace(raw))
+		switch name {
+		case "", "off", "disabled", "none":
+			continue
+		case "greptile", "simplicity":
+			// supported as configured
+		default:
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	if len(out) == 0 {
+		return []string{"greptile"}
+	}
+	return out
+}
+
+func (c *Config) EffectiveReviewGateStreams() []string {
+	if c == nil {
+		return nil
+	}
+	return normalizeReviewGateStreams(c.ReviewGate, c.ReviewGateStreams)
 }
 
 // SupervisorPolicyCandidatePaths returns structured policy files that may live

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -1205,11 +1206,30 @@ func TestParse_ReviewGateDefaults(t *testing.T) {
 	if cfg.ReviewGate != "greptile" {
 		t.Errorf("ReviewGate = %q, want %q", cfg.ReviewGate, "greptile")
 	}
+	if got := cfg.EffectiveReviewGateStreams(); !reflect.DeepEqual(got, []string{"greptile"}) {
+		t.Errorf("EffectiveReviewGateStreams() = %#v, want [greptile]", got)
+	}
 	if cfg.AutoRetryReviewFeedback {
 		t.Error("AutoRetryReviewFeedback should default to false")
 	}
 	if cfg.AutoRetryRebaseConflicts {
 		t.Error("AutoRetryRebaseConflicts should default to false")
+	}
+}
+
+func TestParse_ReviewGateStreamsOptInSimplicity(t *testing.T) {
+	yaml := `
+repo: owner/repo
+review_gate_streams:
+  - greptile
+  - simplicity
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.EffectiveReviewGateStreams(); !reflect.DeepEqual(got, []string{"greptile", "simplicity"}) {
+		t.Fatalf("EffectiveReviewGateStreams() = %#v, want [greptile simplicity]", got)
 	}
 }
 
@@ -1226,6 +1246,9 @@ auto_retry_rebase_conflicts: true
 	}
 	if cfg.ReviewGate != "none" {
 		t.Errorf("ReviewGate = %q, want %q", cfg.ReviewGate, "none")
+	}
+	if got := cfg.EffectiveReviewGateStreams(); len(got) != 0 {
+		t.Errorf("EffectiveReviewGateStreams() = %#v, want empty when review_gate=none", got)
 	}
 	if !cfg.AutoRetryReviewFeedback {
 		t.Error("AutoRetryReviewFeedback should be true when configured")

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1412,6 +1412,45 @@ type ReviewComment struct {
 	User string `json:"user"`
 }
 
+type ReviewStreamVerdict struct {
+	Name     string          `json:"name"`
+	Passed   bool            `json:"passed"`
+	Pending  bool            `json:"pending"`
+	Findings []ReviewComment `json:"findings,omitempty"`
+}
+
+type ReviewGateVerdict struct {
+	Passed  bool                  `json:"passed"`
+	Pending bool                  `json:"pending"`
+	Streams []ReviewStreamVerdict `json:"streams"`
+}
+
+func (v ReviewGateVerdict) BlockingFindings() []ReviewComment {
+	var findings []ReviewComment
+	for _, stream := range v.Streams {
+		findings = append(findings, stream.Findings...)
+	}
+	return findings
+}
+
+func (v ReviewGateVerdict) Summary() string {
+	if len(v.Streams) == 0 {
+		return "review gate disabled"
+	}
+	var parts []string
+	for _, stream := range v.Streams {
+		status := "pass"
+		switch {
+		case stream.Pending:
+			status = "pending"
+		case !stream.Passed:
+			status = "findings"
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", stream.Name, status))
+	}
+	return strings.Join(parts, ", ")
+}
+
 var reviewLocationPattern = regexp.MustCompile(`(?mi)(^|\s)([A-Za-z0-9_./-]+\.[A-Za-z0-9]+:\d+|file:\s*\S+)`)
 
 // CollectReviewFeedback collects actionable inline review comments from Greptile and Codex on a PR.
@@ -1448,6 +1487,208 @@ func (c *Client) CollectReviewFeedback(prNumber int) ([]ReviewComment, error) {
 		result = append(result, comment)
 	}
 	return result, nil
+}
+
+func (c *Client) PRReviewGateVerdict(prNumber int, streams []string) (ReviewGateVerdict, error) {
+	normalized := normalizeReviewStreams(streams)
+	verdict := ReviewGateVerdict{Passed: true}
+	if len(normalized) == 0 {
+		return verdict, nil
+	}
+	for _, stream := range normalized {
+		var sv ReviewStreamVerdict
+		var err error
+		switch stream {
+		case "greptile":
+			sv, err = c.greptileReviewStreamVerdict(prNumber)
+		case "simplicity":
+			sv, err = c.namedReviewStreamVerdict(prNumber, reviewStreamSpec{
+				Name:          "simplicity",
+				CheckContains: []string{"simplicity", "over-engineering", "overengineering"},
+				UserContains:  []string{"simplicity", "maestro-simplicity", "over-engineering", "overengineering"},
+			})
+		default:
+			continue
+		}
+		if err != nil {
+			return ReviewGateVerdict{}, err
+		}
+		verdict.Streams = append(verdict.Streams, sv)
+		if sv.Pending {
+			verdict.Pending = true
+			verdict.Passed = false
+		}
+		if !sv.Passed {
+			verdict.Passed = false
+		}
+	}
+	return verdict, nil
+}
+
+func (c *Client) PRBlockingReviewFindingsOnHead(prNumber int, streams []string) (sha string, findings []ReviewComment, hasFindings bool, err error) {
+	sha, err = c.pullHeadSHA(prNumber)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
+	}
+	comments, err := c.greptileReviewComments(prNumber)
+	if err != nil {
+		return sha, nil, false, fmt.Errorf("review comments for PR %d: %w", prNumber, err)
+	}
+	for _, cm := range comments {
+		if !reviewCommentTargetsHead(cm, sha) {
+			continue
+		}
+		login := cm.User.Login
+		body := cm.Body
+		if streamEnabled(streams, "greptile") && isGreptileLogin(login) && isHighSeverity(body) {
+			findings = append(findings, ReviewComment{Path: cm.Path, Line: cm.Line, Body: body, User: login})
+			continue
+		}
+		if streamEnabled(streams, "simplicity") && isSimplicityReviewerLogin(login) && isActionableReviewComment(ReviewComment{Path: cm.Path, Line: cm.Line, Body: body, User: login}) {
+			findings = append(findings, ReviewComment{Path: cm.Path, Line: cm.Line, Body: body, User: login})
+		}
+	}
+	return sha, findings, len(findings) > 0, nil
+}
+
+type reviewStreamSpec struct {
+	Name          string
+	CheckContains []string
+	UserContains  []string
+}
+
+func (c *Client) greptileReviewStreamVerdict(prNumber int) (ReviewStreamVerdict, error) {
+	approved, pending, err := c.PRGreptileApproved(prNumber)
+	if err != nil {
+		return ReviewStreamVerdict{}, err
+	}
+	sv := ReviewStreamVerdict{Name: "greptile", Passed: approved, Pending: pending}
+	if !approved && !pending {
+		if _, findings, hasFindings, err := c.PRHighSeverityReviewOnHead(prNumber); err == nil && hasFindings {
+			sv.Findings = findings
+		}
+	}
+	return sv, nil
+}
+
+func (c *Client) namedReviewStreamVerdict(prNumber int, spec reviewStreamSpec) (ReviewStreamVerdict, error) {
+	sha, err := c.pullHeadSHA(prNumber)
+	if err != nil {
+		return ReviewStreamVerdict{}, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
+	}
+	checks, checkErr := c.checkRunsForSHA(sha)
+	var checkFound, checkPassed, checkPending bool
+	if checkErr == nil {
+		checkFound, checkPassed, checkPending = namedCheckDecision(checks, spec.CheckContains)
+	}
+	findings, commentsErr := c.reviewFindingsForStream(prNumber, sha, spec)
+	if commentsErr != nil && checkErr != nil {
+		return ReviewStreamVerdict{}, commentsErr
+	}
+	sv := ReviewStreamVerdict{Name: spec.Name, Passed: false, Pending: false, Findings: findings}
+	switch {
+	case checkPending:
+		sv.Pending = true
+	case len(findings) > 0:
+		// Any actionable inline finding from this reviewer blocks, even if
+		// the external check has already settled successfully.
+	case checkFound:
+		sv.Passed = checkPassed
+		if !checkPassed {
+			sv.Findings = []ReviewComment{{
+				Body: fmt.Sprintf("%s review check did not pass", spec.Name),
+				User: spec.Name,
+			}}
+		}
+	default:
+		sv.Pending = true
+	}
+	return sv, nil
+}
+
+func namedCheckDecision(checks []greptileCheckRun, needles []string) (found bool, passed bool, pending bool) {
+	for _, cr := range checks {
+		name := strings.ToLower(cr.Name)
+		if !containsAny(name, needles) {
+			continue
+		}
+		found = true
+		if cr.Conclusion == "success" || cr.Conclusion == "neutral" {
+			return true, true, false
+		}
+		if cr.Status == "in_progress" || cr.Status == "queued" || cr.Status == "waiting" || cr.Conclusion == "" {
+			return true, false, true
+		}
+		return true, false, false
+	}
+	return false, false, false
+}
+
+func (c *Client) reviewFindingsForStream(prNumber int, sha string, spec reviewStreamSpec) ([]ReviewComment, error) {
+	comments, err := c.greptileReviewComments(prNumber)
+	if err != nil {
+		return nil, err
+	}
+	var findings []ReviewComment
+	for _, cm := range comments {
+		if !reviewCommentTargetsHead(cm, sha) {
+			continue
+		}
+		if !containsAny(strings.ToLower(cm.User.Login), spec.UserContains) {
+			continue
+		}
+		comment := ReviewComment{Path: cm.Path, Line: cm.Line, Body: cm.Body, User: cm.User.Login}
+		if !isActionableReviewComment(comment) {
+			continue
+		}
+		findings = append(findings, comment)
+	}
+	return findings, nil
+}
+
+func normalizeReviewStreams(streams []string) []string {
+	if len(streams) == 0 {
+		return []string{"greptile"}
+	}
+	out := make([]string, 0, len(streams))
+	seen := map[string]struct{}{}
+	for _, raw := range streams {
+		name := strings.ToLower(strings.TrimSpace(raw))
+		switch name {
+		case "greptile", "simplicity":
+		default:
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+func streamEnabled(streams []string, name string) bool {
+	for _, stream := range normalizeReviewStreams(streams) {
+		if stream == name {
+			return true
+		}
+	}
+	return false
+}
+
+func isSimplicityReviewerLogin(login string) bool {
+	lower := strings.ToLower(strings.TrimSpace(login))
+	return containsAny(lower, []string{"simplicity", "maestro-simplicity", "over-engineering", "overengineering"})
+}
+
+func containsAny(s string, needles []string) bool {
+	for _, needle := range needles {
+		if needle = strings.ToLower(strings.TrimSpace(needle)); needle != "" && strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 func isActionableReviewComment(comment ReviewComment) bool {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -101,6 +101,7 @@ type Orchestrator struct {
 	ghPRCIStatusFn              func(prNumber int) (string, error)
 	ghPRMergeStatusFn           func(prNumber int) (mergeable string, mergeStateStatus string, err error)
 	ghPRGreptileApprovedFn      func(prNumber int) (approved bool, pending bool, err error)
+	ghPRReviewGateVerdictFn     func(prNumber int, streams []string) (github.ReviewGateVerdict, error)
 	ghPRHasCriticalReviewFn     func(prNumber int) (bool, error)
 	ghUpdateBranchFn            func(prNumber int) error
 	ghMergePRFn                 func(prNumber int) error
@@ -236,6 +237,32 @@ func (o *Orchestrator) prGreptileApproved(prNumber int) (bool, bool, error) {
 		return o.ghPRGreptileApprovedFn(prNumber)
 	}
 	return o.gh.PRGreptileApproved(prNumber)
+}
+
+func (o *Orchestrator) prReviewGateVerdict(prNumber int) (github.ReviewGateVerdict, error) {
+	streams := o.cfg.EffectiveReviewGateStreams()
+	if len(streams) == 0 {
+		return github.ReviewGateVerdict{Passed: true}, nil
+	}
+	if len(streams) == 1 && streams[0] == "greptile" {
+		approved, pending, err := o.prGreptileApproved(prNumber)
+		if err != nil {
+			return github.ReviewGateVerdict{}, err
+		}
+		return github.ReviewGateVerdict{
+			Passed:  approved && !pending,
+			Pending: pending,
+			Streams: []github.ReviewStreamVerdict{{
+				Name:    "greptile",
+				Passed:  approved,
+				Pending: pending,
+			}},
+		}, nil
+	}
+	if o.ghPRReviewGateVerdictFn != nil {
+		return o.ghPRReviewGateVerdictFn(prNumber, streams)
+	}
+	return o.gh.PRReviewGateVerdict(prNumber, streams)
 }
 
 func (o *Orchestrator) prHasCriticalReview(prNumber int) (bool, error) {
@@ -2379,17 +2406,17 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				continue
 			}
 
-			greptileOK, greptilePending, err := o.prGreptileApproved(pr.Number)
+			reviewVerdict, err := o.prReviewGateVerdict(pr.Number)
 			if err != nil {
-				log.Printf("[orch] greptile check PR #%d: %v", pr.Number, err)
+				log.Printf("[orch] review gate check PR #%d: %v", pr.Number, err)
 				continue // skip this cycle, try next
 			}
-			if greptilePending {
-				log.Printf("[orch] PR #%d waiting for Greptile review", pr.Number)
+			if reviewVerdict.Pending {
+				log.Printf("[orch] PR #%d waiting for review gate (%s)", pr.Number, reviewVerdict.Summary())
 				continue // not ready yet
 			}
-			if !greptileOK {
-				log.Printf("[orch] PR #%d not approved by Greptile", pr.Number)
+			if !reviewVerdict.Passed {
+				log.Printf("[orch] PR #%d blocked by review gate (%s)", pr.Number, reviewVerdict.Summary())
 				// auto-label blocked disabled
 				continue
 			}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1514,6 +1515,57 @@ func TestAutoMergePRs_ParallelMergesAllReady(t *testing.T) {
 		if (*merged)[i] != want {
 			t.Errorf("merged[%d] = %d, want %d", i, (*merged)[i], want)
 		}
+	}
+}
+
+func TestAutoMergePRs_AggregatesGreptileAndSimplicityStreams(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MergeStrategy:     "parallel",
+		ReviewGate:        "greptile",
+		ReviewGateStreams: []string{"greptile", "simplicity"},
+	}
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	calledStreams := []string{}
+	o.ghPRReviewGateVerdictFn = func(prNumber int, streams []string) (github.ReviewGateVerdict, error) {
+		calledStreams = append(calledStreams, streams...)
+		return github.ReviewGateVerdict{
+			Passed: false,
+			Streams: []github.ReviewStreamVerdict{
+				{Name: "greptile", Passed: true},
+				{Name: "simplicity", Passed: false, Findings: []github.ReviewComment{{
+					Path: "internal/foo.go",
+					Line: 7,
+					Body: "blocking: over-engineered for one caller",
+					User: "maestro-simplicity-reviewer",
+				}}},
+			},
+		}, nil
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 0 {
+		t.Fatalf("merged = %v, want no merge while simplicity stream has blocking findings", *merged)
+	}
+	if !reflect.DeepEqual(calledStreams, []string{"greptile", "simplicity"}) {
+		t.Fatalf("review streams = %#v, want [greptile simplicity]", calledStreams)
+	}
+
+	o.ghPRReviewGateVerdictFn = func(prNumber int, streams []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{
+			Passed: true,
+			Streams: []github.ReviewStreamVerdict{
+				{Name: "greptile", Passed: true},
+				{Name: "simplicity", Passed: true},
+			},
+		}, nil
+	}
+	o.autoMergePRs(s)
+	if len(*merged) != 1 || (*merged)[0] != 10 {
+		t.Fatalf("merged = %v, want PR #10 after both review streams pass", *merged)
 	}
 }
 

--- a/internal/supervisor/review_repair.go
+++ b/internal/supervisor/review_repair.go
@@ -37,10 +37,11 @@ type reviewRepairCandidate struct {
 //
 //   - SupervisorReviewRepairConfig.Active() (default on).
 //   - The session is settled retry_exhausted on review feedback.
-//   - The PR is not draft, mergeable, CI green, AND the Greptile gate
-//     is "not approved" only because of inline P0/P1 findings on head.
-//   - The Greptile reader exposes PRHighSeverityReviewOnHead and reports
-//     at least one P0/P1 inline finding on the current head SHA.
+//   - The PR is not draft, mergeable, CI green, AND the review gate is
+//     blocked by configured reviewer findings on head.
+//   - The reader exposes blocking review findings for the configured
+//     streams (or the legacy Greptile high-severity reader) and reports
+//     at least one blocking inline finding on the current head SHA.
 //
 // When the budget for the (pr,head_sha) pair is exhausted the candidate
 // is returned with Exhausted=true so the caller can choose a fall-
@@ -87,11 +88,7 @@ func (e *Engine) evaluateAutoReviewRepair(st *state.State, sess *state.Session, 
 		return nil
 	}
 
-	reader, ok := e.reader.(prHighSeverityReviewReader)
-	if !ok {
-		return nil
-	}
-	sha, findings, hasFindings, err := reader.PRHighSeverityReviewOnHead(pr.Number)
+	sha, findings, hasFindings, err := e.blockingReviewFindingsOnHead(pr.Number)
 	if err != nil {
 		return nil
 	}
@@ -115,6 +112,18 @@ func (e *Engine) evaluateAutoReviewRepair(st *state.State, sess *state.Session, 
 		return candidate
 	}
 	return candidate
+}
+
+func (e *Engine) blockingReviewFindingsOnHead(prNumber int) (string, []github.ReviewComment, bool, error) {
+	streams := e.cfg.EffectiveReviewGateStreams()
+	if reader, ok := e.reader.(prBlockingReviewFindingsReader); ok && !onlyGreptileReviewStream(streams) {
+		return reader.PRBlockingReviewFindingsOnHead(prNumber, streams)
+	}
+	reader, ok := e.reader.(prHighSeverityReviewReader)
+	if !ok {
+		return "", nil, false, nil
+	}
+	return reader.PRHighSeverityReviewOnHead(prNumber)
 }
 
 // reviewRepairSessionSettled reports whether the session has reached the
@@ -160,12 +169,12 @@ func (e *Engine) buildReviewRepairDecision(st *state.State, now time.Time, proje
 		Session: slot,
 	}
 	reasons := appendReasons(baseReasons,
-		fmt.Sprintf("PR #%d is green and mergeable but Greptile flags %d P0/P1 inline comment(s) on head %s", pr.Number, len(candidate.Findings), shortSHA(candidate.HeadSHA)),
+		fmt.Sprintf("PR #%d is green and mergeable but review gate flags %d blocking inline comment(s) on head %s", pr.Number, len(candidate.Findings), shortSHA(candidate.HeadSHA)),
 		fmt.Sprintf("Session %s is settled retry_exhausted on review feedback (#565: would otherwise dead-end)", slot),
 		fmt.Sprintf("Review-repair budget: attempt %d of %d for (PR #%d, head %s)", candidate.Track.Attempts+1, e.cfg.Supervisor.ReviewRepair.EffectiveMaxRetries(), pr.Number, shortSHA(candidate.HeadSHA)),
 	)
 	reasons = appendReasons(reasons, formatReviewRepairFindings(candidate.Findings)...)
-	summary := fmt.Sprintf("Spawn a scoped review-repair worker for PR #%d to address %d Greptile P0/P1 inline comment(s) on head %s", pr.Number, len(candidate.Findings), shortSHA(candidate.HeadSHA))
+	summary := fmt.Sprintf("Spawn a scoped review-repair worker for PR #%d to address %d blocking review finding(s) on head %s", pr.Number, len(candidate.Findings), shortSHA(candidate.HeadSHA))
 	decision := e.decision(st, now, projectState, ActionSpawnReviewRepair, summary,
 		RiskMutating, 0.9, target, PolicyRuleReviewRepair, reasons)
 	decision.StuckStates = append(decision.StuckStates, reviewRepairSpawnedStuckState(target, candidate))
@@ -214,7 +223,7 @@ func (e *Engine) buildReviewRepairExhaustedDecision(st *state.State, now time.Ti
 	}
 	reasons := appendReasons(baseReasons,
 		fmt.Sprintf("PR #%d retry-exhausted on review feedback; review-repair budget for (PR #%d, head %s) is also exhausted", pr.Number, pr.Number, shortSHA(candidate.HeadSHA)),
-		fmt.Sprintf("%d Greptile P0/P1 inline comment(s) remain unaddressed on head %s — operator decision required", len(candidate.Findings), shortSHA(candidate.HeadSHA)),
+		fmt.Sprintf("%d blocking review finding(s) remain unaddressed on head %s — operator decision required", len(candidate.Findings), shortSHA(candidate.HeadSHA)),
 	)
 	reasons = appendReasons(reasons, formatReviewRepairFindings(candidate.Findings)...)
 
@@ -234,7 +243,7 @@ func (e *Engine) buildReviewRepairExhaustedDecision(st *state.State, now time.Ti
 }
 
 func reviewRepairSpawnedStuckState(target *state.SupervisorTarget, candidate *reviewRepairCandidate) state.SupervisorStuckState {
-	summary := fmt.Sprintf("Auto review-repair worker queued for PR #%d (head %s): %d Greptile P0/P1 finding(s) on head", target.PR, shortSHA(candidate.HeadSHA), len(candidate.Findings))
+	summary := fmt.Sprintf("Auto review-repair worker queued for PR #%d (head %s): %d blocking review finding(s) on head", target.PR, shortSHA(candidate.HeadSHA), len(candidate.Findings))
 	return state.SupervisorStuckState{
 		Code:              state.StuckReviewRepairSpawned,
 		Severity:          SeverityWarning,
@@ -246,7 +255,7 @@ func reviewRepairSpawnedStuckState(target *state.SupervisorTarget, candidate *re
 }
 
 func reviewRepairExhaustedStuckState(target *state.SupervisorTarget, candidate *reviewRepairCandidate) state.SupervisorStuckState {
-	summary := fmt.Sprintf("Review-repair budget exhausted for PR #%d on head %s — %d Greptile P0/P1 finding(s) unresolved; operator decision required", target.PR, shortSHA(candidate.HeadSHA), len(candidate.Findings))
+	summary := fmt.Sprintf("Review-repair budget exhausted for PR #%d on head %s — %d blocking review finding(s) unresolved; operator decision required", target.PR, shortSHA(candidate.HeadSHA), len(candidate.Findings))
 	return state.SupervisorStuckState{
 		Code:              state.StuckReviewRepairExhausted,
 		Severity:          SeverityBlocked,
@@ -264,7 +273,7 @@ func reviewRepairExhaustedStuckState(target *state.SupervisorTarget, candidate *
 func formatReviewRepairFindings(findings []github.ReviewComment) []string {
 	out := make([]string, 0, len(findings))
 	for _, f := range findings {
-		out = append(out, "Greptile finding: "+formatReviewCommentLine(f))
+		out = append(out, "Review finding: "+formatReviewCommentLine(f))
 	}
 	return out
 }
@@ -293,7 +302,7 @@ func formatReviewCommentLine(f github.ReviewComment) string {
 	}
 }
 
-// severityLabel extracts P0/P1 from a Greptile comment body. Defaults to
+// severityLabel extracts P0/P1 from a review comment body. Defaults to
 // "P?" when no marker is found — the comment must already be a known
 // high-severity finding to reach this code path.
 func severityLabel(body string) string {
@@ -303,6 +312,8 @@ func severityLabel(body string) string {
 		return "P0"
 	case strings.Contains(lower, "alt=\"p1\""), strings.Contains(lower, "/p1"), strings.Contains(lower, "badge/p1"):
 		return "P1"
+	case strings.Contains(lower, "blocking"), strings.Contains(lower, "over-engineering"), strings.Contains(lower, "overengineering"):
+		return "blocking"
 	}
 	return "P?"
 }
@@ -352,22 +363,22 @@ func FormatReviewRepairPromptFromPayload(issueNumber, prNumber int, payload *sta
 }
 
 // FormatReviewRepairPrompt builds the worker prompt for a spawn_review_repair
-// dispatch. The prompt is scoped to the specific Greptile findings (path /
+// dispatch. The prompt is scoped to the specific review findings (path /
 // line / body) so the worker addresses only the comments — not a restatement
 // of the original issue. Used by the orchestrator when starting the scoped
 // repair worker.
 func FormatReviewRepairPrompt(issueNumber int, prNumber int, headSHA string, findings []github.ReviewComment) string {
 	var b strings.Builder
 	b.WriteString("# Auto review-repair worker\n\n")
-	b.WriteString(fmt.Sprintf("You are addressing Greptile review feedback on PR #%d (issue #%d) at head %s.\n\n", prNumber, issueNumber, shortSHA(headSHA)))
+	b.WriteString(fmt.Sprintf("You are addressing blocking review feedback on PR #%d (issue #%d) at head %s.\n\n", prNumber, issueNumber, shortSHA(headSHA)))
 	b.WriteString("The previous worker for this issue exhausted its review-feedback retry budget on this PR.\n")
-	b.WriteString("Your scope is NARROW: resolve EACH of the inline Greptile P0/P1 comments listed below.\n")
+	b.WriteString("Your scope is NARROW: resolve EACH of the inline blocking review comments listed below.\n")
 	b.WriteString("Do NOT re-implement the original issue. Do NOT refactor outside the touched files.\n\n")
 	b.WriteString("Per finding:\n")
 	b.WriteString("  1. Read the comment context (path, line, body).\n")
 	b.WriteString("  2. Make the minimal code change that resolves the comment.\n")
 	b.WriteString("  3. Push to the existing PR branch (do not open a new PR).\n\n")
-	b.WriteString("## Unresolved Greptile P0/P1 inline comments on head ")
+	b.WriteString("## Unresolved blocking review inline comments on head ")
 	b.WriteString(shortSHA(headSHA))
 	b.WriteString("\n\n")
 	for i, f := range findings {

--- a/internal/supervisor/review_repair_test.go
+++ b/internal/supervisor/review_repair_test.go
@@ -89,6 +89,67 @@ func TestDecide_RetryExhaustedGreenPR_WithGreptileP1OnHead_SpawnsReviewRepair(t 
 	}
 }
 
+func TestDecide_RetryExhaustedGreenPR_WithSimplicityFinding_SpawnsReviewRepair(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "greptile"
+	cfg.ReviewGateStreams = []string{"greptile", "simplicity"}
+	cfg.Supervisor.ReviewRepair.MaxRetries = 1
+
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 650, HeadRefName: "feat/sup-161", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{650: "success"},
+		reviewVerdicts: map[int]github.ReviewGateVerdict{
+			650: {
+				Passed: false,
+				Streams: []github.ReviewStreamVerdict{
+					{Name: "greptile", Passed: true},
+					{Name: "simplicity", Passed: false, Findings: []github.ReviewComment{{
+						Path: "internal/foo.go",
+						Line: 27,
+						Body: "blocking: this adds an unnecessary abstraction; inline the single caller",
+						User: "maestro-simplicity-reviewer",
+					}}},
+				},
+			},
+		},
+		highSeverityHeadSHA: map[int]string{650: "feedfacecafebeef"},
+		highSeverityFindings: map[int][]github.ReviewComment{
+			650: {{
+				Path: "internal/foo.go",
+				Line: 27,
+				Body: "blocking: this adds an unnecessary abstraction; inline the single caller",
+				User: "maestro-simplicity-reviewer",
+			}},
+		},
+	}
+	st := state.NewState()
+	st.Sessions["sup-161"] = &state.Session{
+		IssueNumber:                 649,
+		IssueTitle:                  "add simplicity reviewer",
+		Status:                      state.StatusRetryExhausted,
+		Branch:                      "feat/sup-161",
+		PRNumber:                    650,
+		LastNotifiedStatus:          "review_retry_exhausted",
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		StartedAt:                   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnReviewRepair {
+		t.Fatalf("action = %q, want %q for blocking simplicity finding", decision.RecommendedAction, ActionSpawnReviewRepair)
+	}
+	if decision.ReviewRepair == nil || len(decision.ReviewRepair.Findings) != 1 {
+		t.Fatalf("review repair payload = %#v, want one simplicity finding", decision.ReviewRepair)
+	}
+	got := decision.ReviewRepair.Findings[0]
+	if got.User != "maestro-simplicity-reviewer" || !strings.Contains(got.Body, "unnecessary abstraction") {
+		t.Fatalf("review repair finding = %#v, want simplicity finding", got)
+	}
+}
+
 // Negative: the review-repair branch must NOT fire on a green PR that
 // has no Greptile P0/P1 findings on head (convergence-merge handles
 // that case).

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -113,6 +113,10 @@ type prGreptileReader interface {
 	PRGreptileApproved(prNumber int) (approved bool, pending bool, err error)
 }
 
+type prReviewGateVerdictReader interface {
+	PRReviewGateVerdict(prNumber int, streams []string) (github.ReviewGateVerdict, error)
+}
+
 // prMergeableReader fetches the per-PR mergeable state via the
 // SINGLE-PR endpoint (`gh api repos/.../pulls/{N}`) which triggers
 // GitHub's mergeability computation. The LIST endpoint (used by
@@ -144,6 +148,10 @@ type prMergeStateReader interface {
 // PR moving.
 type prHighSeverityReviewReader interface {
 	PRHighSeverityReviewOnHead(prNumber int) (sha string, findings []github.ReviewComment, hasFindings bool, err error)
+}
+
+type prBlockingReviewFindingsReader interface {
+	PRBlockingReviewFindingsOnHead(prNumber int, streams []string) (sha string, findings []github.ReviewComment, hasFindings bool, err error)
 }
 
 // PreflightResult is the outcome of running a configured preflight command.
@@ -1254,7 +1262,24 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *re
 		}
 
 		if e.cfg.ReviewGate == "greptile" && (ciStatus == "" || ciStatus == "success") {
-			if greptileReader, ok := e.reader.(prGreptileReader); ok {
+			streams := e.cfg.EffectiveReviewGateStreams()
+			if reviewReader, ok := e.reader.(prReviewGateVerdictReader); ok && !onlyGreptileReviewStream(streams) {
+				verdict, err := reviewReader.PRReviewGateVerdict(pr.Number, streams)
+				if err == nil {
+					switch {
+					case verdict.Pending:
+						findings = append(findings, stuckState("review_gate_pending", SeverityInfo,
+							fmt.Sprintf("PR #%d is waiting for review gate streams.", pr.Number),
+							"Wait for all configured review streams to finish before merging.", true, target,
+							fmt.Sprintf("PR #%d review_gate=%s", pr.Number, verdict.Summary())))
+					case !verdict.Passed:
+						findings = append(findings, stuckState("review_gate_not_approved", SeverityBlocked,
+							fmt.Sprintf("PR #%d is blocked by review gate findings.", pr.Number),
+							"Address blocking review feedback or change this project's review gate policy.", e.cfg.AutoRetryReviewFeedback, target,
+							fmt.Sprintf("PR #%d review_gate=%s", pr.Number, verdict.Summary())))
+					}
+				}
+			} else if greptileReader, ok := e.reader.(prGreptileReader); ok {
 				approved, pending, err := greptileReader.PRGreptileApproved(pr.Number)
 				if err == nil {
 					switch {
@@ -1274,6 +1299,10 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *re
 		}
 	}
 	return findings
+}
+
+func onlyGreptileReviewStream(streams []string) bool {
+	return len(streams) == 1 && streams[0] == "greptile"
 }
 
 func (e *Engine) detectQueueStuckStates(st *state.State, prs []github.PR, issues, eligible []github.Issue, skipped []string) []state.SupervisorStuckState {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -27,6 +27,7 @@ type fakeReader struct {
 	ciStatuses           map[int]string
 	greptileOK           map[int]bool
 	greptilePend         map[int]bool
+	reviewVerdicts       map[int]github.ReviewGateVerdict
 	mergeStates          map[int]string
 	highSeverityHeadSHA  map[int]string
 	highSeverityFindings map[int][]github.ReviewComment
@@ -148,6 +149,23 @@ func (f *fakeReader) PRGreptileApproved(prNumber int) (bool, bool, error) {
 	return approved, false, nil
 }
 
+func (f *fakeReader) PRReviewGateVerdict(prNumber int, streams []string) (github.ReviewGateVerdict, error) {
+	if f.reviewVerdicts != nil {
+		if verdict, ok := f.reviewVerdicts[prNumber]; ok {
+			return verdict, nil
+		}
+	}
+	approved, pending, err := f.PRGreptileApproved(prNumber)
+	if err != nil {
+		return github.ReviewGateVerdict{}, err
+	}
+	return github.ReviewGateVerdict{
+		Passed:  approved && !pending,
+		Pending: pending,
+		Streams: []github.ReviewStreamVerdict{{Name: "greptile", Passed: approved, Pending: pending}},
+	}, nil
+}
+
 // PRHighSeverityReviewOnHead lets the supervisor #565 auto-review-repair
 // branch peek at fake P0/P1 inline findings. Returns the configured head
 // SHA + findings for prNumber; missing entries are no findings.
@@ -155,6 +173,10 @@ func (f *fakeReader) PRHighSeverityReviewOnHead(prNumber int) (string, []github.
 	sha := f.highSeverityHeadSHA[prNumber]
 	findings := f.highSeverityFindings[prNumber]
 	return sha, findings, len(findings) > 0, nil
+}
+
+func (f *fakeReader) PRBlockingReviewFindingsOnHead(prNumber int, streams []string) (string, []github.ReviewComment, bool, error) {
+	return f.PRHighSeverityReviewOnHead(prNumber)
 }
 
 func (f *fakeReader) RateLimit() (github.RateLimitStatus, error) {


### PR DESCRIPTION
Refs #649

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a parallel simplicity/over-engineering reviewer stream alongside the existing Greptile gate, controlled by a new `review_gate_streams` config field. The orchestrator, supervisor stuck-state detector, and review-repair engine are all wired to the new multi-stream verdict path.

- `normalizeReviewGateStreams` in config and `PRReviewGateVerdict`/`PRBlockingReviewFindingsOnHead` in the GitHub client implement the stream aggregation; the orchestrator's `prReviewGateVerdict` retains a fast-path for the greptile-only case to avoid a client round-trip.
- `namedReviewStreamVerdict` combines an external CI check and inline review comments into a per-stream verdict; the error guard (`commentsErr != nil && checkErr != nil`) is fail-open — a transient comment-fetch failure while the check has already passed causes the stream to return `Passed: true`.
- `fakeReader.PRBlockingReviewFindingsOnHead` ignores its `streams` argument in tests, leaving the stream-filtering path in `blockingReviewFindingsOnHead` unverified.

<h3>Confidence Score: 3/5</h3>

The multi-stream wiring is mostly correct, but namedReviewStreamVerdict can incorrectly clear a simplicity stream on a transient comment-fetch error, which could allow a blocked PR to merge.

The comment-fetching error in namedReviewStreamVerdict is silently discarded when the external check has already passed, flipping the stream verdict to Passed: true. This is a live failure path: any transient GitHub API error on reviewFindingsForStream while the simplicity CI check is green would let a PR with blocking inline findings pass the review gate and proceed to merge.

internal/github/github.go — specifically namedReviewStreamVerdict; the && guard on lines 1585-1586 should be reviewed before this ships.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds ReviewGateVerdict/ReviewStreamVerdict types, PRReviewGateVerdict, PRBlockingReviewFindingsOnHead, and supporting helpers; namedReviewStreamVerdict has a fail-open bug when comment fetching fails but the external check has passed. |
| internal/config/config.go | Adds ReviewGateStreams field and normalizeReviewGateStreams/EffectiveReviewGateStreams; normalization logic is correct and idempotent. |
| internal/orchestrator/orchestrator.go | Routes autoMergePRs through the new prReviewGateVerdict helper, with a fast-path for greptile-only and an injection point for tests; logic looks correct. |
| internal/supervisor/supervisor.go | Extends detectPRStuckStates to use PRReviewGateVerdict for multi-stream configs; when simplicity is configured but the reader only implements the old prGreptileReader, simplicity stuck-state detection silently falls back to greptile-only. |
| internal/supervisor/review_repair.go | Replaces Greptile-specific repair path with stream-aware blockingReviewFindingsOnHead; messaging updated throughout; logic is clean. |
| internal/supervisor/supervisor_test.go | Adds fakeReader support for PRReviewGateVerdict and PRBlockingReviewFindingsOnHead; the blocking-findings fake ignores its streams argument, leaving stream-filtering logic untested. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/supervisor/supervisor_test.go`, line 866-868 ([link](https://github.com/befeast/maestro/blob/585f127505f7aeb982ef27f091180ef7ea268793/internal/supervisor/supervisor_test.go#L866-L868)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`PRBlockingReviewFindingsOnHead` ignores `streams` in the fake**

   `fakeReader.PRBlockingReviewFindingsOnHead` unconditionally delegates to `PRHighSeverityReviewOnHead`, discarding the `streams` argument. `blockingReviewFindingsOnHead` in `review_repair.go` routes to this interface precisely when multiple streams are active, so the test does not exercise stream-filtering logic at all. A bug where stream filtering is accidentally skipped (e.g., always returning Greptile findings regardless of which stream is active) would pass every existing test.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/supervisor/supervisor_test.go
   Line: 866-868

   Comment:
   **`PRBlockingReviewFindingsOnHead` ignores `streams` in the fake**

   `fakeReader.PRBlockingReviewFindingsOnHead` unconditionally delegates to `PRHighSeverityReviewOnHead`, discarding the `streams` argument. `blockingReviewFindingsOnHead` in `review_repair.go` routes to this interface precisely when multiple streams are active, so the test does not exercise stream-filtering logic at all. A bug where stream filtering is accidentally skipped (e.g., always returning Greptile findings regardless of which stream is active) would pass every existing test.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/github/github.go:1585-1606
**Fail-open when comment fetch fails but check passes**

When `commentsErr != nil` but `checkErr == nil`, the error is silently dropped and `findings` is nil. If the external check has already passed (`checkFound && checkPassed`), the switch reaches `case checkFound: sv.Passed = checkPassed` and returns `Passed: true`. A transient GitHub API error on `reviewFindingsForStream` would therefore cause the simplicity stream to report a clean pass, potentially allowing a PR to merge despite outstanding blocking inline comments. The `&&` guard should be `||`, or at a minimum the function should return early with `sv.Pending = true` whenever `commentsErr != nil` to fail safely.

### Issue 2 of 2
internal/supervisor/supervisor_test.go:866-868
**`PRBlockingReviewFindingsOnHead` ignores `streams` in the fake**

`fakeReader.PRBlockingReviewFindingsOnHead` unconditionally delegates to `PRHighSeverityReviewOnHead`, discarding the `streams` argument. `blockingReviewFindingsOnHead` in `review_repair.go` routes to this interface precisely when multiple streams are active, so the test does not exercise stream-filtering logic at all. A bug where stream filtering is accidentally skipped (e.g., always returning Greptile findings regardless of which stream is active) would pass every existing test.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["review: add simplicity review stream"](https://github.com/befeast/maestro/commit/585f127505f7aeb982ef27f091180ef7ea268793) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35365214)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->