### PR TITLE
epic-completion done-condition: aggregate epic done when children merged + outcome healthy

### DIFF
--- a/docs/handoff-epic-format.md
+++ b/docs/handoff-epic-format.md
@@ -157,6 +157,61 @@ maestro outcome check --project <name>
   `Issue Wave` list
 ```
 
+## Epic completion aggregate
+
+When an epic references its concrete child issues, the supervisor aggregates
+their merged / closed verdicts each cycle and surfaces the result on
+`fleet.epics[]` and the latest `SupervisorDecision.epics`. The aggregate
+is the basis for the approval-gated `close_epic` recommendation
+(`policy_rule: supervisor.epic_completion`): when **every** child is
+merged AND the configured outcome health gate is `healthy`, the
+supervisor mints a `close_issue` decision against the epic with
+`risk=approval_gated`. The cautious gate then queues an approval — no
+auto-close ever happens without operator confirmation.
+
+### Children reference shapes the supervisor understands
+
+```markdown
+Children: #147, #148, #149
+```
+
+```markdown
+## Children
+
+- #147 — slice A
+- [ ] #148 — slice B
+- [x] #149 — slice C
+```
+
+```markdown
+## Issue Wave
+
+- [ ] #147 — route shell
+- [ ] #148 — replace /inbox
+```
+
+Recognised section headings (case-insensitive): `Children`, `Child issues`,
+`Subtasks`, `Issue Wave`, `Slices`, `Wave`, `Epic checklist`. Both
+checked and unchecked task-list items are parsed; the closed-or-merged
+verdict comes from GitHub, not from the checkbox.
+
+### Aggregate semantics
+
+For each open epic with parseable children, the supervisor computes:
+
+- `total_children`, `merged_count`, `open_count`
+- `all_children_done = open_count == 0 && total_children > 0`
+- `outcome_healthy = outcome.health_state == "healthy"`
+- `complete = all_children_done && outcome_healthy`
+
+Only `complete=true` epics trigger the `close_epic` recommendation. An
+epic whose children are all merged but whose outcome health is
+`failing`/`unknown`/`unmonitored` stays in-progress: the
+`SupervisorDecision.summary` flags the unhealthy signal and the operator
+can choose to verify the runtime before approving the close. This matches
+the existing `pass_required_for_done` semantics — runtime health is the
+ground truth, not the checklist state.
+
 ## Completion gates
 
 Healthcheck passing is evidence, not the whole "Done" gate. When the

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1318,6 +1318,136 @@ func headingLevelAndText(line string) (int, string, bool) {
 	return level, text, true
 }
 
+// childInlinePattern matches `Children: #147, #148` (case-insensitive). Used
+// by FindChildIssues alongside a scan of structured child sections.
+var childInlinePattern = regexp.MustCompile(`(?im)^\s*child(?:ren)?(?:\s+issues?)?\s*[:\-]\s*([^\r\n]+)$`)
+
+// childSectionHeadings is the set of markdown headings that FindChildIssues
+// treats as a structured list of child issue references. The supervisor
+// epic-completion aggregate (sup-162) reads any `#N` token inside one of
+// these sections — including checked / unchecked task-list items — as a
+// child of the epic.
+var childSectionHeadings = []string{
+	"children",
+	"child issues",
+	"child issue",
+	"subtasks",
+	"sub-tasks",
+	"sub tasks",
+	"issue wave",
+	"wave",
+	"slices",
+	"epic checklist",
+}
+
+// FindChildIssues scans an issue body for child issue references used by
+// the epic-completion aggregate. It recognises two shapes:
+//
+//   - inline: `Children: #147, #148` (also `Child issues:` / `Child:`)
+//   - structured section: a markdown heading whose text matches one of
+//     childSectionHeadings (case-insensitive) followed by any lines that
+//     contain `#NNN` issue references. Task list items (`- [ ] #147`) and
+//     plain bullets are both recognised.
+//
+// Returns deduplicated issue numbers in the order they first appear. The
+// epic issue's own number is filtered out so a `Refs #<self>` line in
+// the body never inflates progress. Returns nil for the zero body.
+func FindChildIssues(body string) []int {
+	return findChildIssues(body, 0)
+}
+
+// FindChildIssuesExcluding behaves like FindChildIssues but skips the given
+// issue number even when it appears in the body. Callers use this to filter
+// out the epic's own number when it is known.
+func FindChildIssuesExcluding(body string, selfNumber int) []int {
+	return findChildIssues(body, selfNumber)
+}
+
+func findChildIssues(body string, selfNumber int) []int {
+	if strings.TrimSpace(body) == "" {
+		return nil
+	}
+	seen := make(map[int]struct{})
+	var children []int
+	add := func(n int) {
+		if n <= 0 || (selfNumber > 0 && n == selfNumber) {
+			return
+		}
+		if _, ok := seen[n]; ok {
+			return
+		}
+		seen[n] = struct{}{}
+		children = append(children, n)
+	}
+
+	for _, match := range childInlinePattern.FindAllStringSubmatch(body, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		for _, ref := range dependencyIssueNumber.FindAllStringSubmatch(match[1], -1) {
+			if len(ref) < 2 {
+				continue
+			}
+			n, err := strconv.Atoi(ref[1])
+			if err != nil {
+				continue
+			}
+			add(n)
+		}
+	}
+
+	for _, section := range extractChildSections(body) {
+		for _, ref := range dependencyIssueNumber.FindAllStringSubmatch(section, -1) {
+			if len(ref) < 2 {
+				continue
+			}
+			n, err := strconv.Atoi(ref[1])
+			if err != nil {
+				continue
+			}
+			add(n)
+		}
+	}
+
+	return children
+}
+
+// extractChildSections returns the markdown body of every section in the
+// given body whose heading text matches childSectionHeadings. A section
+// spans from its heading line until the next heading of equal-or-shallower
+// depth, or end of file.
+func extractChildSections(body string) []string {
+	lines := strings.Split(body, "\n")
+	var sections []string
+	for i := 0; i < len(lines); i++ {
+		level, heading, ok := headingLevelAndText(lines[i])
+		if !ok || !isChildSectionHeading(heading) {
+			continue
+		}
+		end := len(lines)
+		for j := i + 1; j < len(lines); j++ {
+			otherLevel, _, otherOK := headingLevelAndText(lines[j])
+			if otherOK && otherLevel <= level {
+				end = j
+				break
+			}
+		}
+		sections = append(sections, strings.Join(lines[i+1:end], "\n"))
+		i = end - 1
+	}
+	return sections
+}
+
+func isChildSectionHeading(heading string) bool {
+	heading = strings.ToLower(strings.TrimSpace(heading))
+	for _, name := range childSectionHeadings {
+		if heading == name {
+			return true
+		}
+	}
+	return false
+}
+
 // FindBlockers scans an issue body for blocker references matching the given
 // regex patterns. Each pattern must contain a capture group for the issue number.
 // Returns deduplicated issue numbers referenced as blockers.

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -519,6 +519,78 @@ func TestFindBlockers_DefaultPatternsMarkdown(t *testing.T) {
 	}
 }
 
+func TestFindChildIssues_InlineChildren(t *testing.T) {
+	body := "Children: #147, #148, #149\n"
+	got := FindChildIssues(body)
+	want := []int{147, 148, 149}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindChildIssues() = %v, want %v", got, want)
+	}
+}
+
+func TestFindChildIssues_ChildrenSectionTaskList(t *testing.T) {
+	body := `# Epic: Scribe redesign
+
+## Issue Wave
+
+- [ ] #147 — route shell
+- [x] #148 — replace /inbox
+- [ ] #149 — replace /settings
+
+## Notes
+no children referenced here
+`
+	got := FindChildIssues(body)
+	want := []int{147, 148, 149}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindChildIssues() = %v, want %v", got, want)
+	}
+}
+
+func TestFindChildIssues_DeduplicatesAndExcludesSelf(t *testing.T) {
+	body := `## Children
+- #200 — slice A
+- #200 — duplicate
+- #201 — slice B
+
+Children: #201, #202
+Refs #300 (self)
+`
+	got := FindChildIssuesExcluding(body, 300)
+	sort.Ints(got)
+	want := []int{200, 201, 202}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindChildIssuesExcluding() = %v, want %v", got, want)
+	}
+}
+
+func TestFindChildIssues_EmptyBody(t *testing.T) {
+	if got := FindChildIssues(""); len(got) != 0 {
+		t.Errorf("FindChildIssues(\"\") = %v, want empty", got)
+	}
+	if got := FindChildIssues("no children here"); len(got) != 0 {
+		t.Errorf("FindChildIssues(no children) = %v, want empty", got)
+	}
+}
+
+func TestFindChildIssues_NestedHeading(t *testing.T) {
+	body := `## Issue Wave
+- #1
+### Subnotes
+- #2
+## Other
+- #3
+`
+	got := FindChildIssues(body)
+	// Subnotes is nested under Issue Wave (deeper level), so #2 stays in the
+	// section. #3 lives under "Other" which is NOT a child section heading,
+	// so it must not be picked up.
+	want := []int{1, 2}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindChildIssues() = %v, want %v", got, want)
+	}
+}
+
 func TestFormatReviewFeedback_NonEmpty(t *testing.T) {
 	comments := []ReviewComment{
 		{Path: "bridge.rs", Line: 42, Body: "P2: enabled flag logic inverted", User: "greptile-apps[bot]"},

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -514,6 +514,18 @@ type fleetProjectState struct {
 	// pricing configured render in the SPA as tokens only.
 	CostObservability fleetCostObservability `json:"cost_observability"`
 
+	// Epics is the epic-completion aggregate the supervisor stamped on
+	// its latest decision (#650). The SPA renders per-epic progress
+	// (children merged / total) and the "epic complete" badge when all
+	// children are merged AND the configured outcome health gate is
+	// healthy. Empty when the project has no open epic with parseable
+	// children, or the supervisor has not run yet.
+	Epics []state.EpicProgress `json:"epics,omitempty"`
+	// EpicSummary is the operator-glance roll-up used by the project
+	// card to render an "N epic(s) tracked, 1 complete" pill without
+	// the SPA walking the Epics slice.
+	EpicSummary fleetEpicSummary `json:"epic_summary"`
+
 	// EffectiveConfig is the sanitized, parsed runtime config surfaced on
 	// MC Settings (#622). It deliberately excludes raw YAML, commands,
 	// auth, notification endpoints/tokens and local prompt paths.
@@ -607,6 +619,19 @@ type fleetCloseCandidate struct {
 	PRURL       string `json:"pr_url,omitempty"`
 	Session     string `json:"session,omitempty"`
 	FinishedAt  string `json:"finished_at,omitempty"`
+}
+
+// fleetEpicSummary is the operator-glance roll-up of the project's
+// epic-completion aggregate (#650). Zero values render as a calm
+// "no epics tracked" line in the SPA project card.
+type fleetEpicSummary struct {
+	Tracked          int `json:"tracked"`
+	Complete         int `json:"complete"`
+	InProgress       int `json:"in_progress"`
+	ChildrenTotal    int `json:"children_total"`
+	ChildrenMerged   int `json:"children_merged"`
+	ChildrenOpen     int `json:"children_open"`
+	AwaitingApproval int `json:"awaiting_approval"`
 }
 
 // fleetSupervisorPulse describes the supervisor's liveness, cadence and
@@ -2134,6 +2159,57 @@ func fleetProjectFreshnessForState(stateDir string, st *state.State, now time.Ti
 	return freshness
 }
 
+// fleetEpicProgressFromState returns the epic-completion aggregate the
+// supervisor stamped on its latest decision (#650), together with the
+// operator-glance roll-up the project card renders. Returns an empty
+// slice and zero-valued summary when no decision is recorded or the
+// recorded decision has no epic aggregate.
+func fleetEpicProgressFromState(st *state.State) ([]state.EpicProgress, fleetEpicSummary) {
+	if st == nil {
+		return nil, fleetEpicSummary{}
+	}
+	latest := st.LatestSupervisorDecision()
+	if latest == nil || len(latest.Epics) == 0 {
+		return nil, fleetEpicSummary{}
+	}
+	epics := append([]state.EpicProgress(nil), latest.Epics...)
+	summary := fleetEpicSummary{Tracked: len(epics)}
+	epicNumbers := make(map[int]bool, len(epics))
+	for _, epic := range epics {
+		summary.ChildrenTotal += epic.TotalChildren
+		summary.ChildrenMerged += epic.MergedCount
+		summary.ChildrenOpen += epic.OpenCount
+		if epic.Complete {
+			summary.Complete++
+		} else {
+			summary.InProgress++
+		}
+		if epic.Number > 0 {
+			epicNumbers[epic.Number] = true
+		}
+	}
+	// Cross-reference pending close_issue approvals against the epic
+	// list so the SPA can render an "awaiting approval" pill on the
+	// epic row. The executor verb stays `close_issue`; the epic-vs-
+	// child-close discriminator is whether the approval's target issue
+	// is one of the open epics surfaced by this snapshot.
+	for _, approval := range st.Approvals {
+		if approval.Status != state.ApprovalStatusPending {
+			continue
+		}
+		if approval.Action != config.SupervisorActionCloseIssue {
+			continue
+		}
+		if approval.Target == nil {
+			continue
+		}
+		if epicNumbers[approval.Target.Issue] {
+			summary.AwaitingApproval++
+		}
+	}
+	return epics, summary
+}
+
 func fleetQueueSnapshotFromSupervisor(info supervisorInfo) *fleetQueueSnapshot {
 	if info.Latest == nil || info.Latest.QueueAnalysis == nil {
 		return nil
@@ -2451,6 +2527,7 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	item.Supervisor = projectState.Supervisor
 	item.QueueSnapshot = fleetQueueSnapshotFromSupervisor(item.Supervisor)
 	item.SupervisorPulse = buildFleetSupervisorPulse(cfg, st, now)
+	item.Epics, item.EpicSummary = fleetEpicProgressFromState(st)
 	item.Approvals = makeFleetApprovalStates(item, st, now)
 	if len(item.Approvals) > 0 {
 		item.ApprovalSummary = make(map[string]int)

--- a/internal/server/fleet_epic_test.go
+++ b/internal/server/fleet_epic_test.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestFleetEpicProgressFromState_NoDecisionYieldsEmpty(t *testing.T) {
+	st := state.NewState()
+	epics, summary := fleetEpicProgressFromState(st)
+	if epics != nil {
+		t.Errorf("epics = %#v, want nil for empty state", epics)
+	}
+	if summary != (fleetEpicSummary{}) {
+		t.Errorf("summary = %#v, want zero-valued", summary)
+	}
+}
+
+func TestFleetEpicProgressFromState_DerivesSummaryFromLatestDecision(t *testing.T) {
+	st := state.NewState()
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	st.SupervisorDecisions = []state.SupervisorDecision{
+		{
+			ID:        "sup-1",
+			CreatedAt: now,
+			Epics: []state.EpicProgress{
+				{Number: 100, TotalChildren: 3, MergedCount: 3, OpenCount: 0, AllChildrenDone: true, OutcomeHealthy: true, Complete: true},
+				{Number: 101, TotalChildren: 4, MergedCount: 1, OpenCount: 3, Complete: false},
+			},
+		},
+	}
+
+	epics, summary := fleetEpicProgressFromState(st)
+	if len(epics) != 2 {
+		t.Fatalf("epics len = %d, want 2", len(epics))
+	}
+	if summary.Tracked != 2 {
+		t.Errorf("Tracked = %d, want 2", summary.Tracked)
+	}
+	if summary.Complete != 1 || summary.InProgress != 1 {
+		t.Errorf("Complete/InProgress = %d/%d, want 1/1", summary.Complete, summary.InProgress)
+	}
+	if summary.ChildrenTotal != 7 {
+		t.Errorf("ChildrenTotal = %d, want 7", summary.ChildrenTotal)
+	}
+	if summary.ChildrenMerged != 4 {
+		t.Errorf("ChildrenMerged = %d, want 4", summary.ChildrenMerged)
+	}
+	if summary.ChildrenOpen != 3 {
+		t.Errorf("ChildrenOpen = %d, want 3", summary.ChildrenOpen)
+	}
+}
+
+func TestFleetEpicProgressFromState_AwaitingApprovalCountsCloseIssueOnEpic(t *testing.T) {
+	st := state.NewState()
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	st.SupervisorDecisions = []state.SupervisorDecision{
+		{
+			ID:        "sup-1",
+			CreatedAt: now,
+			Epics: []state.EpicProgress{
+				{Number: 200, TotalChildren: 2, MergedCount: 2, Complete: true},
+				{Number: 300, TotalChildren: 1, MergedCount: 0, Complete: false},
+			},
+		},
+	}
+	// Pending close_issue against the complete epic counts as awaiting
+	// approval; the same verb against a non-epic does not.
+	st.Approvals = []state.Approval{
+		{
+			ID:     "close-epic",
+			Action: config.SupervisorActionCloseIssue,
+			Target: &state.SupervisorTarget{Issue: 200},
+			Status: state.ApprovalStatusPending,
+		},
+		{
+			ID:     "close-child",
+			Action: config.SupervisorActionCloseIssue,
+			Target: &state.SupervisorTarget{Issue: 999},
+			Status: state.ApprovalStatusPending,
+		},
+		{
+			ID:     "close-epic-but-executed",
+			Action: config.SupervisorActionCloseIssue,
+			Target: &state.SupervisorTarget{Issue: 200},
+			Status: state.ApprovalStatusExecuted,
+		},
+	}
+
+	_, summary := fleetEpicProgressFromState(st)
+	if summary.AwaitingApproval != 1 {
+		t.Fatalf("AwaitingApproval = %d, want 1", summary.AwaitingApproval)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -714,6 +714,36 @@ type SupervisorDecision struct {
 	// backend without re-fetching review comments from GitHub. nil for
 	// every non-review-repair decision.
 	ReviewRepair *SupervisorReviewRepairPayload `json:"review_repair,omitempty"`
+	// Epics is the epic-completion aggregate snapshot for the cycle that
+	// produced this decision (#650). Each entry summarises one open epic's
+	// children-merged ratio and the outcome health gate, so the fleet /
+	// status surfaces can render "epic in progress" / "epic complete"
+	// without re-listing issues. Empty when no candidate epic is open or
+	// no candidate epic has parseable children.
+	Epics []EpicProgress `json:"epics,omitempty"`
+}
+
+// EpicProgress is the per-epic aggregate the supervisor records alongside
+// a decision (#650). Counts and child slices are read by the fleet /
+// status surface; Complete=true means every child is merged or closed AND
+// the configured outcome health gate is healthy — the precondition for
+// the approval-gated epic close recommendation. Never used to auto-close
+// without a human approval.
+type EpicProgress struct {
+	Number          int      `json:"number"`
+	Title           string   `json:"title,omitempty"`
+	Children        []int    `json:"children,omitempty"`
+	MergedChildren  []int    `json:"merged_children,omitempty"`
+	OpenChildren    []int    `json:"open_children,omitempty"`
+	TotalChildren   int      `json:"total_children"`
+	MergedCount     int      `json:"merged_count"`
+	OpenCount       int      `json:"open_count"`
+	OutcomeHealth   string   `json:"outcome_health,omitempty"`
+	OutcomeHealthy  bool     `json:"outcome_healthy"`
+	AllChildrenDone bool     `json:"all_children_done"`
+	Complete        bool     `json:"complete"`
+	Summary         string   `json:"summary,omitempty"`
+	Evidence        []string `json:"evidence,omitempty"`
 }
 
 // SupervisorReviewRepairPayload carries the auto-review-repair payload

--- a/internal/supervisor/epic_completion.go
+++ b/internal/supervisor/epic_completion.go
@@ -1,0 +1,174 @@
+package supervisor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/outcome"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// ActionCloseEpic is the supervisor decision tag for the epic-completion
+// branch. The underlying executor verb is config.SupervisorActionCloseIssue;
+// ActionCloseEpic exists so the journal / dashboard can distinguish "epic
+// complete" from a routine done-issue close when filtering decisions.
+const ActionCloseEpic = "close_epic"
+
+// PolicyRuleEpicCompletion identifies decisions emitted by the epic-
+// completion aggregate in audit/state.
+const PolicyRuleEpicCompletion = "supervisor.epic_completion"
+
+// computeEpicProgress builds the aggregate for every open issue that
+// looks like a handoff/epic parent. childResolver receives a child issue
+// number and returns (merged, closed) verdicts; supervisor wires this to
+// the resolution cache so each underlying lookup happens at most once
+// per cycle. outcomeStatus controls the Complete=true gate.
+//
+// Returns a stable, number-sorted slice. Returns nil when no candidate
+// epics exist OR no candidate epic has any parseable children — a
+// label-only "epic" with an empty body should not surface as a fake
+// "0/0 complete" entry.
+func computeEpicProgress(epics []github.Issue, childResolver func(int) (merged, closed bool), outcomeStatus outcome.Status) []state.EpicProgress {
+	if len(epics) == 0 || childResolver == nil {
+		return nil
+	}
+	sorted := append([]github.Issue(nil), epics...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Number < sorted[j].Number })
+
+	out := make([]state.EpicProgress, 0, len(sorted))
+	for _, epic := range sorted {
+		children := github.FindChildIssuesExcluding(epic.Body, epic.Number)
+		if len(children) == 0 {
+			continue
+		}
+		progress := state.EpicProgress{
+			Number:        epic.Number,
+			Title:         strings.TrimSpace(epic.Title),
+			Children:      children,
+			TotalChildren: len(children),
+			OutcomeHealth: outcomeStatus.HealthState,
+		}
+		for _, child := range children {
+			merged, closed := childResolver(child)
+			if merged || closed {
+				progress.MergedChildren = append(progress.MergedChildren, child)
+				progress.MergedCount++
+			} else {
+				progress.OpenChildren = append(progress.OpenChildren, child)
+				progress.OpenCount++
+			}
+		}
+		progress.AllChildrenDone = progress.OpenCount == 0 && progress.TotalChildren > 0
+		progress.OutcomeHealthy = outcomeStatus.HealthState == outcome.HealthHealthy
+		progress.Complete = progress.AllChildrenDone && progress.OutcomeHealthy
+		progress.Summary = epicSummary(progress)
+		progress.Evidence = epicEvidence(progress)
+		out = append(out, progress)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func epicSummary(p state.EpicProgress) string {
+	switch {
+	case p.Complete:
+		return fmt.Sprintf("Epic #%d is complete: %d/%d children merged AND outcome health is healthy.", p.Number, p.MergedCount, p.TotalChildren)
+	case p.AllChildrenDone && !p.OutcomeHealthy:
+		return fmt.Sprintf("Epic #%d: all %d children merged, but outcome health is %s — verify runtime before close.", p.Number, p.TotalChildren, healthLabel(p.OutcomeHealth))
+	case p.MergedCount == 0:
+		return fmt.Sprintf("Epic #%d: 0/%d children merged.", p.Number, p.TotalChildren)
+	default:
+		return fmt.Sprintf("Epic #%d: %d/%d children merged, %d still open.", p.Number, p.MergedCount, p.TotalChildren, p.OpenCount)
+	}
+}
+
+func epicEvidence(p state.EpicProgress) []string {
+	if p.TotalChildren == 0 {
+		return nil
+	}
+	evidence := []string{
+		fmt.Sprintf("children_total=%d", p.TotalChildren),
+		fmt.Sprintf("children_merged=%d", p.MergedCount),
+		fmt.Sprintf("children_open=%d", p.OpenCount),
+		fmt.Sprintf("outcome_health=%s", healthLabel(p.OutcomeHealth)),
+	}
+	if len(p.MergedChildren) > 0 {
+		evidence = append(evidence, fmt.Sprintf("merged=%s", joinIssueNums(p.MergedChildren)))
+	}
+	if len(p.OpenChildren) > 0 {
+		evidence = append(evidence, fmt.Sprintf("open=%s", joinIssueNums(p.OpenChildren)))
+	}
+	return evidence
+}
+
+func joinIssueNums(nums []int) string {
+	parts := make([]string, 0, len(nums))
+	for _, n := range nums {
+		parts = append(parts, fmt.Sprintf("#%d", n))
+	}
+	return strings.Join(parts, ",")
+}
+
+func healthLabel(state string) string {
+	state = strings.TrimSpace(state)
+	if state == "" {
+		return "unknown"
+	}
+	return state
+}
+
+// openEpicCandidates returns the open issues that look like handoff/epic
+// parents under the configured handoff_planner labels OR an `epic:` title
+// prefix. Used by both the fleet snapshot and the close-epic decision
+// branch. Order is preserved from the caller-provided issue list; callers
+// that need stable ordering should sort themselves.
+func (e *Engine) openEpicCandidates(issues []github.Issue) []github.Issue {
+	if e == nil || e.cfg == nil {
+		return nil
+	}
+	labels := e.cfg.Supervisor.HandoffPlanner.EffectiveSourceLabels()
+	out := make([]github.Issue, 0)
+	for _, issue := range issues {
+		if isHandoffSource(issue, labels) {
+			out = append(out, issue)
+		}
+	}
+	return out
+}
+
+// epicProgressForIssues returns the EpicProgress aggregate for every open
+// epic in issues that has parseable children. Reads through the supplied
+// resolution cache so each child lookup happens at most once per cycle.
+func (e *Engine) epicProgressForIssues(issues []github.Issue, cache *resolutionCache, outcomeStatus outcome.Status) []state.EpicProgress {
+	epics := e.openEpicCandidates(issues)
+	if len(epics) == 0 {
+		return nil
+	}
+	if cache == nil {
+		cache = newResolutionCache(e.reader)
+	}
+	resolver := func(child int) (bool, bool) {
+		merged := cache.hasMergedPRForIssue(child)
+		closed := cache.isIssueClosed(child)
+		return merged, closed
+	}
+	return computeEpicProgress(epics, resolver, outcomeStatus)
+}
+
+// firstCompletedEpic returns the lowest-numbered epic in progresses whose
+// children are all merged AND the configured outcome health is healthy.
+// Used by the supervisor to mint a single approval-gated close_epic
+// recommendation per cycle. Returns nil when no epic is fully complete.
+func firstCompletedEpic(progresses []state.EpicProgress) *state.EpicProgress {
+	for i := range progresses {
+		p := progresses[i]
+		if p.Complete {
+			return &p
+		}
+	}
+	return nil
+}

--- a/internal/supervisor/epic_completion_test.go
+++ b/internal/supervisor/epic_completion_test.go
@@ -1,0 +1,340 @@
+package supervisor
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/outcome"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestComputeEpicProgress_PartialMergedInProgress(t *testing.T) {
+	epic := github.Issue{
+		Number: 500,
+		Title:  "Epic: Scribe redesign",
+		Body: `# Epic
+## Issue Wave
+- [ ] #501 — slice A
+- [ ] #502 — slice B
+- [ ] #503 — slice C
+`,
+	}
+	resolver := func(n int) (bool, bool) {
+		// only #501 is merged so far
+		return n == 501, false
+	}
+	status := outcome.Status{HealthState: outcome.HealthHealthy}
+
+	got := computeEpicProgress([]github.Issue{epic}, resolver, status)
+	if len(got) != 1 {
+		t.Fatalf("len(progress) = %d, want 1", len(got))
+	}
+	p := got[0]
+	if p.TotalChildren != 3 || p.MergedCount != 1 || p.OpenCount != 2 {
+		t.Fatalf("counts = total %d merged %d open %d, want 3/1/2", p.TotalChildren, p.MergedCount, p.OpenCount)
+	}
+	if p.AllChildrenDone || p.Complete {
+		t.Fatalf("AllChildrenDone=%v Complete=%v, want false", p.AllChildrenDone, p.Complete)
+	}
+	if !strings.Contains(p.Summary, "1/3") {
+		t.Fatalf("summary = %q, want it to mention 1/3", p.Summary)
+	}
+}
+
+func TestComputeEpicProgress_AllMergedAndHealthyIsComplete(t *testing.T) {
+	epic := github.Issue{
+		Number: 600,
+		Title:  "Epic: Migrate auth",
+		Body: `## Children
+- #601
+- #602
+`,
+	}
+	resolver := func(n int) (bool, bool) { return true, false } // all merged
+	status := outcome.Status{HealthState: outcome.HealthHealthy}
+
+	got := computeEpicProgress([]github.Issue{epic}, resolver, status)
+	if len(got) != 1 || !got[0].Complete {
+		t.Fatalf("progress = %#v, want one complete epic", got)
+	}
+	if got[0].MergedCount != 2 || got[0].OpenCount != 0 {
+		t.Fatalf("counts = merged %d open %d, want 2/0", got[0].MergedCount, got[0].OpenCount)
+	}
+	if !strings.Contains(got[0].Summary, "complete") {
+		t.Fatalf("summary = %q, want it to mention complete", got[0].Summary)
+	}
+}
+
+func TestComputeEpicProgress_AllMergedButOutcomeFailingHoldsCompletion(t *testing.T) {
+	epic := github.Issue{
+		Number: 700,
+		Title:  "Epic: ship",
+		Body:   "## Children\n- #701\n- #702\n",
+	}
+	resolver := func(n int) (bool, bool) { return true, false }
+	status := outcome.Status{HealthState: outcome.HealthFailing}
+
+	got := computeEpicProgress([]github.Issue{epic}, resolver, status)
+	if len(got) != 1 {
+		t.Fatalf("len(progress) = %d, want 1", len(got))
+	}
+	p := got[0]
+	if !p.AllChildrenDone {
+		t.Fatalf("AllChildrenDone = false, want true")
+	}
+	if p.Complete {
+		t.Fatalf("Complete = true, want false — outcome failing must hold completion")
+	}
+	if !strings.Contains(p.Summary, "outcome health is failing") {
+		t.Fatalf("summary = %q, want it to flag failing outcome", p.Summary)
+	}
+}
+
+func TestComputeEpicProgress_SkipsEpicsWithoutParseableChildren(t *testing.T) {
+	epic := github.Issue{Number: 800, Title: "Epic: empty", Body: "no children referenced here"}
+	got := computeEpicProgress([]github.Issue{epic},
+		func(int) (bool, bool) { return false, false },
+		outcome.Status{HealthState: outcome.HealthHealthy})
+	if got != nil {
+		t.Fatalf("progress = %#v, want nil for label-only epic with empty body", got)
+	}
+}
+
+func TestFirstCompletedEpic_PicksLowestNumber(t *testing.T) {
+	progresses := []state.EpicProgress{
+		{Number: 200, Complete: false},
+		{Number: 201, Complete: true},
+		{Number: 202, Complete: true},
+	}
+	got := firstCompletedEpic(progresses)
+	if got == nil || got.Number != 201 {
+		t.Fatalf("firstCompletedEpic = %#v, want 201", got)
+	}
+}
+
+func TestFirstCompletedEpic_NoneComplete(t *testing.T) {
+	progresses := []state.EpicProgress{
+		{Number: 200, Complete: false},
+		{Number: 201, Complete: false},
+	}
+	if got := firstCompletedEpic(progresses); got != nil {
+		t.Fatalf("firstCompletedEpic = %#v, want nil", got)
+	}
+}
+
+// TestDecide_EpicCompletionMintsApprovalGatedClose verifies the full path:
+// an open epic whose children are all merged AND a healthy outcome
+// signal produces an approval-gated close_issue recommendation tagged
+// PolicyRuleEpicCompletion. Never auto-closes (#650).
+func TestDecide_EpicCompletionMintsApprovalGatedClose(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableHandoffPlanner(cfg)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:      "Live app works",
+		HealthcheckCommand:  "check-live",
+		PassRequiredForDone: boolPtr(true),
+	}
+
+	epic := github.Issue{
+		Number: 900,
+		Title:  "Epic: Scribe redesign",
+		Body: `## Children
+- #901 — slice A
+- #902 — slice B
+`,
+	}
+	for _, label := range []string{"epic"} {
+		epic.Labels = append(epic.Labels, struct {
+			Name string `json:"name"`
+		}{Name: label})
+	}
+
+	reader := &fakeReader{
+		issues: []github.Issue{epic},
+		mergedPRIssues: map[int]bool{
+			901: true,
+			902: true,
+		},
+	}
+	st := state.NewState()
+	checkedAt := testEngineNow()
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: checkedAt,
+		State:     outcome.HealthHealthy,
+		Signal:    "healthcheck_command",
+		Summary:   "live verifier passed",
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction != config.SupervisorActionCloseIssue {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, config.SupervisorActionCloseIssue)
+	}
+	if decision.Risk != RiskApprovalGated {
+		t.Fatalf("risk = %q, want approval_gated", decision.Risk)
+	}
+	if !decision.RequiresApproval {
+		t.Fatalf("RequiresApproval = false, want true — epic close MUST be approval-gated")
+	}
+	if decision.Target == nil || decision.Target.Issue != epic.Number {
+		t.Fatalf("target = %#v, want epic #%d", decision.Target, epic.Number)
+	}
+	if decision.PolicyRule != PolicyRuleEpicCompletion {
+		t.Fatalf("policy_rule = %q, want %q", decision.PolicyRule, PolicyRuleEpicCompletion)
+	}
+	if len(decision.Epics) != 1 || !decision.Epics[0].Complete {
+		t.Fatalf("decision.Epics = %#v, want one complete epic", decision.Epics)
+	}
+}
+
+// TestDecide_EpicProgressStampedEvenWhenNotComplete verifies the snapshot
+// is recorded on every dynamic-wave decision so the fleet UI can render
+// "epic in progress" without re-listing issues.
+func TestDecide_EpicProgressStampedEvenWhenNotComplete(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableHandoffPlanner(cfg)
+
+	epic := github.Issue{
+		Number: 910,
+		Title:  "Epic: in flight",
+		Body:   "## Children\n- #911\n- #912\n",
+	}
+	epic.Labels = append(epic.Labels, struct {
+		Name string `json:"name"`
+	}{Name: "epic"})
+
+	reader := &fakeReader{
+		issues:         []github.Issue{epic},
+		mergedPRIssues: map[int]bool{911: true},
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if len(decision.Epics) != 1 {
+		t.Fatalf("decision.Epics = %#v, want one entry", decision.Epics)
+	}
+	got := decision.Epics[0]
+	if got.Number != 910 || got.MergedCount != 1 || got.OpenCount != 1 || got.Complete {
+		t.Fatalf("epic progress = %#v, want #910 1/2 not complete", got)
+	}
+	// The decision itself must NOT be a close_issue verb when children
+	// remain open — the close-epic branch only fires when Complete=true.
+	if decision.RecommendedAction == config.SupervisorActionCloseIssue {
+		t.Fatalf("action = %q, want NOT close_issue while children remain open", decision.RecommendedAction)
+	}
+}
+
+// TestDecide_EpicAllChildrenDoneButOutcomeFailingHoldsClose verifies the
+// safety gate: even when every child is merged, an unhealthy outcome
+// signal blocks the close-epic recommendation. The supervisor falls
+// through to the regular handoff-planner / none branch instead.
+func TestDecide_EpicAllChildrenDoneButOutcomeFailingHoldsClose(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableHandoffPlanner(cfg)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:      "Live app works",
+		HealthcheckCommand:  "check-live",
+		PassRequiredForDone: boolPtr(true),
+	}
+
+	epic := github.Issue{
+		Number: 920,
+		Title:  "Epic: ship",
+		Body:   "## Children\n- #921\n",
+	}
+	epic.Labels = append(epic.Labels, struct {
+		Name string `json:"name"`
+	}{Name: "epic"})
+
+	reader := &fakeReader{
+		issues:         []github.Issue{epic},
+		mergedPRIssues: map[int]bool{921: true},
+	}
+	st := state.NewState()
+	checkedAt := testEngineNow()
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: checkedAt,
+		State:     outcome.HealthFailing,
+		Signal:    "healthcheck_command",
+		Summary:   "runtime check failed",
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction == config.SupervisorActionCloseIssue {
+		t.Fatalf("action = %q, want NOT close_issue while outcome is failing", decision.RecommendedAction)
+	}
+	// The failing outcome can short-circuit decideDeterministic into the
+	// outcome-health branch BEFORE the dynamic wave stamps decision.Epics;
+	// that is fine. The behavior under test is that the cautious gate
+	// never lets close_issue fire while the runtime is unhealthy. The
+	// computed aggregate is verified directly here so the unit covers
+	// both the gate AND the Complete=false semantics.
+	eng := testEngine(cfg, reader)
+	progresses := eng.epicProgressForIssues([]github.Issue{epic},
+		newResolutionCache(reader),
+		eng.outcomeStatus(st))
+	if len(progresses) != 1 {
+		t.Fatalf("epicProgressForIssues = %#v, want one entry", progresses)
+	}
+	if !progresses[0].AllChildrenDone {
+		t.Fatalf("AllChildrenDone = false, want true")
+	}
+	if progresses[0].Complete {
+		t.Fatalf("Complete = true, want false — outcome failing must hold completion")
+	}
+}
+
+func testEngineNow() time.Time {
+	return time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+}
+
+func sortInts(in []int) []int {
+	out := append([]int(nil), in...)
+	sort.Ints(out)
+	return out
+}
+
+func TestEpicEvidence_ListsMergedAndOpen(t *testing.T) {
+	p := state.EpicProgress{
+		Number:         10,
+		TotalChildren:  3,
+		MergedCount:    1,
+		OpenCount:      2,
+		MergedChildren: []int{11},
+		OpenChildren:   []int{12, 13},
+		OutcomeHealth:  outcome.HealthHealthy,
+	}
+	ev := epicEvidence(p)
+	joined := strings.Join(ev, " ")
+	if !strings.Contains(joined, "children_total=3") {
+		t.Errorf("evidence missing total: %v", ev)
+	}
+	if !strings.Contains(joined, "children_merged=1") {
+		t.Errorf("evidence missing merged: %v", ev)
+	}
+	if !strings.Contains(joined, "outcome_health=healthy") {
+		t.Errorf("evidence missing outcome: %v", ev)
+	}
+	if !strings.Contains(joined, "merged=#11") {
+		t.Errorf("evidence missing merged list: %v", ev)
+	}
+	if !reflect.DeepEqual(sortInts(p.OpenChildren), []int{12, 13}) {
+		t.Errorf("open children = %v, want [12 13]", p.OpenChildren)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -771,9 +771,15 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 		}
 	}
 	stuckStates := e.detectStuckStates(st, now, prs, issues, candidates, result.skipped, true, cache)
+	// Epic-completion aggregate (#650): compute once per cycle so every
+	// decision returned by this path carries the latest children-merged /
+	// outcome-healthy snapshot. The fleet snapshot reads this off the
+	// latest decision to render "epic in progress" / "epic complete".
+	epicProgresses := e.epicProgressForIssues(issues, cache, outcomeStatus)
 	withAnalysis := func(decision state.SupervisorDecision) state.SupervisorDecision {
 		decision.QueueAnalysis = analysis
 		decision.StuckStates = stuckStates
+		decision.Epics = epicProgresses
 		return decision
 	}
 
@@ -794,6 +800,27 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 		)
 		for _, reason := range firstN(result.skipped, 3) {
 			reasons = append(reasons, reason)
+		}
+
+		// Epic-completion aggregate (#650): if any open epic has all
+		// children merged AND the configured outcome health gate is
+		// healthy, mint an approval-gated close_issue recommendation
+		// instead of silently idling on `none`. The cautious gate
+		// guarantees no unsupervised epic close — every close still
+		// requires explicit operator approval.
+		if completed := firstCompletedEpic(epicProgresses); completed != nil {
+			epicReasons := appendReasons(reasons,
+				completed.Summary,
+				fmt.Sprintf("Outcome health is %s; all %d child issue(s) are merged or closed", healthLabel(completed.OutcomeHealth), completed.TotalChildren),
+				"Epic close is approval-gated; the operator must confirm before Maestro closes the epic.",
+			)
+			for _, ev := range completed.Evidence {
+				epicReasons = append(epicReasons, ev)
+			}
+			decision := e.decision(st, now, projectState, config.SupervisorActionCloseIssue,
+				fmt.Sprintf("Epic #%d is complete (%d/%d children merged, outcome healthy); request approval to close it.", completed.Number, completed.MergedCount, completed.TotalChildren),
+				RiskApprovalGated, 0.9, &state.SupervisorTarget{Issue: completed.Number}, PolicyRuleEpicCompletion, epicReasons)
+			return withAnalysis(decision), nil
 		}
 
 		// Handoff planner v1: when an open handoff/epic remains but no


### PR DESCRIPTION
Implements #650

## Changes

- `internal/github`: new `FindChildIssues` / `FindChildIssuesExcluding` parse epic children from `Children:` inline lines and `## Children` / `## Issue Wave` / `## Subtasks` sections (task-list items and plain bullets both work). Self-references are filtered out.
- `internal/state`: add `EpicProgress` struct and `SupervisorDecision.Epics` so the per-cycle aggregate persists alongside the latest decision.
- `internal/supervisor` (`epic_completion.go`): `computeEpicProgress` rolls children/merged/open counts per open epic; `Complete = all_children_done && outcome_healthy`. Wired into `decideDynamicWave`: when a complete epic exists, mint an approval-gated `close_issue` decision with `policy_rule = supervisor.epic_completion`. Cautious gate enforces operator approval; no unsupervised epic close.
- `internal/server/fleet.go`: surface `Epics` and an `EpicSummary` roll-up (tracked, complete, in-progress, children totals, awaiting-approval) on the project snapshot.
- Docs: extend `handoff-epic-format.md` with the children reference shapes and aggregate semantics.

## Testing

- `go test ./...` — all suites pass.
- `go build ./cmd/maestro/` — clean.
- New unit tests cover: partial / full-merge aggregation, outcome-failing holds completion, label-only epics with empty body are skipped, supervisor mints approval-gated `close_issue` end-to-end, epic snapshot is stamped on in-progress decisions, fleet summary derives counts from the latest decision, and pending close approvals against epic issues drive `AwaitingApproval`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an epic-completion done-condition: the supervisor now parses child issue references from epic bodies each cycle, aggregates merged/open counts against the resolution cache, and \u2014 when every child is merged and the configured outcome health gate is healthy \u2014 mints a single approval-gated `close_issue` recommendation tagged `supervisor.epic_completion`. The fleet snapshot surfaces per-epic progress and a roll-up summary so the SPA can render \u201cepic in progress / complete\u201d pills without re-listing issues.

- `FindChildIssues` / `FindChildIssuesExcluding` handle both the `Children: #N` inline form and structured `## Children` / `## Issue Wave` / `## Subtasks` sections; self-references are filtered, duplicates are deduplicated.
- `computeEpicProgress` skips label-only epics with empty bodies and gates `Complete=true` on `AllChildrenDone && OutcomeHealthy`, so a merged-but-unhealthy epic stays in-progress.
- Every close recommendation requires explicit operator approval; the cautious gate prevents unsupervised epic closes.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the epic-completion path is well-guarded (approval-gated, outcome-health gated, empty-body skipped) and the existing dedup in RecordPendingApprovalForDecision prevents approval storms.

The implementation is solid and tests are thorough. The one notable behavioral gap is that epic progress is only stamped on dynamic-wave decisions — a project stuck on a failing-outcome deterministic cycle will temporarily show no epic data in the fleet UI until the dynamic wave runs again.

internal/supervisor/supervisor.go — the Epics stamp lives exclusively in the decideDynamicWave withAnalysis closure; worth a second look if deterministic-path stale-display is a concern. docs/handoff-epic-format.md — recognised heading list is missing three entries that the code accepts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/supervisor/epic_completion.go | New file implementing computeEpicProgress, openEpicCandidates, epicProgressForIssues, and firstCompletedEpic. Logic is correct — epics without parseable children are skipped, outcome health gates the Complete flag, and only one close_issue decision is minted per cycle. |
| internal/supervisor/supervisor.go | Wires epicProgressForIssues into decideDynamicWave via withAnalysis. Epic-completion check fires only when candidates==0 and before the handoff-planner fallback. Epics field is only stamped on dynamic-wave decisions; decideDeterministic decisions carry no Epics snapshot. |
| internal/github/github.go | Adds FindChildIssues / FindChildIssuesExcluding backed by childInlinePattern and extractChildSections. Self-filtering, deduplication, and the section-boundary walk are all correct. |
| internal/server/fleet.go | fleetEpicProgressFromState reads latest decision Epics, copies the slice defensively, computes the roll-up summary, and cross-references pending close_issue approvals against the epic number set for AwaitingApproval. |
| internal/state/state.go | Adds EpicProgress struct and SupervisorDecision.Epics field with omitempty. Clean; no serialisation regressions. |
| internal/supervisor/epic_completion_test.go | Comprehensive tests covering partial merge, full merge + healthy outcome, full merge + failing outcome, label-only epics, firstCompletedEpic ordering, and end-to-end approval-gated path. |
| internal/server/fleet_epic_test.go | Covers nil state, summary derivation from latest decision, and AwaitingApproval counting logic. |
| docs/handoff-epic-format.md | Adds Epic completion aggregate section. Documented heading list omits child issue (singular), sub-tasks, and sub tasks which are present in childSectionHeadings in code. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/handoff-epic-format.md`, line 42-43 ([link](https://github.com/befeast/maestro/blob/954982db66d285bcf4c285dcb48e9bd244a0a1b3/docs/handoff-epic-format.md#L42-L43)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Doc list is incomplete relative to code**

   `childSectionHeadings` in `github.go` also recognises `child issue` (singular), `sub-tasks`, and `sub tasks`, but these three are absent from the "Recognised section headings" line here. An operator writing a `## Child issue` or `## Sub-tasks` section would get matching behaviour but would have no doc reference for it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/handoff-epic-format.md
   Line: 42-43

   Comment:
   **Doc list is incomplete relative to code**

   `childSectionHeadings` in `github.go` also recognises `child issue` (singular), `sub-tasks`, and `sub tasks`, but these three are absent from the "Recognised section headings" line here. An operator writing a `## Child issue` or `## Sub-tasks` section would get matching behaviour but would have no doc reference for it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/supervisor/supervisor.go:778-783
**Epic progress hidden when deterministic path fires**

`epicProgresses` is only stamped via `withAnalysis`, which is exclusive to `decideDynamicWave`. Any cycle where `decideDeterministic` produces the final decision (outcome-health alarm, stuck-worker, review-repair, etc.) leaves `decision.Epics` nil. Because `fleetEpicProgressFromState` reads the *latest* decision, the fleet SPA will show "no epics tracked" for however long the deterministic path dominates — even though the epic is still in-flight and children may be partially merged. The stale display clears on the next dynamic-wave cycle, but in a project that’s stuck on a failing outcome for multiple cycles this could be misleading. Consider also stamping the aggregate on deterministic decisions, or separating the epic snapshot into its own state field so it survives across decision types.

### Issue 2 of 2
docs/handoff-epic-format.md:42-43
**Doc list is incomplete relative to code**

`childSectionHeadings` in `github.go` also recognises `child issue` (singular), `sub-tasks`, and `sub tasks`, but these three are absent from the "Recognised section headings" line here. An operator writing a `## Child issue` or `## Sub-tasks` section would get matching behaviour but would have no doc reference for it.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["supervisor: aggregate epic completion ac..."](https://github.com/befeast/maestro/commit/954982db66d285bcf4c285dcb48e9bd244a0a1b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35369912)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->