### PR TITLE
attribution: emit provider/model/variant/effort trailer in commit + PR body (finish #513)

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -681,6 +681,19 @@ func (c *Client) CreatePR(title, body, base, head string) (int, error) {
 	return n, nil
 }
 
+// UpdatePRBody replaces a pull request body.
+func (c *Client) UpdatePRBody(prNumber int, body string) error {
+	out, err := exec.Command("gh",
+		"pr", "edit", strconv.Itoa(prNumber),
+		"--repo", c.Repo,
+		"--body", body,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh pr edit %d --body: %w\n%s", prNumber, err, out)
+	}
+	return nil
+}
+
 // IsPRMerged returns true if the PR has been merged.
 func (c *Client) IsPRMerged(prNumber int) (bool, error) {
 	pr, err := c.getRESTPull(prNumber)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -49,6 +49,8 @@ type Orchestrator struct {
 	listOpenPRsFn         func() ([]github.PR, error)
 	remoteBranchExistsFn  func(branch string) (bool, error)
 	createPRFn            func(title, body, base, head string) (int, error)
+	updatePRBodyFn        func(prNumber int, body string) error
+	amendHeadFn           func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error
 	hasOpenPRForIssueFn   func(issueNumber int) (bool, error)
 	hasMergedPRForIssueFn func(issueNumber int) (bool, error)
 	isPRMergedFn          func(prNumber int) (bool, error)
@@ -186,6 +188,16 @@ func (o *Orchestrator) createPR(title, body, base, head string) (int, error) {
 		return o.createPRFn(title, body, base, head)
 	}
 	return o.gh.CreatePR(title, body, base, head)
+}
+
+func (o *Orchestrator) updatePRBody(prNumber int, body string) error {
+	if o.updatePRBodyFn != nil {
+		return o.updatePRBodyFn(prNumber, body)
+	}
+	if o.gh == nil {
+		return fmt.Errorf("no github client configured for PR body update")
+	}
+	return o.gh.UpdatePRBody(prNumber, body)
 }
 
 func (o *Orchestrator) hasOpenPRForIssue(issueNumber int) (bool, error) {
@@ -1614,6 +1626,8 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		// IssueInProgress to return false and startNewWorkers to spawn a duplicate.
 		if pr, found := branchToPR[sess.Branch]; found {
 			o.updateTokensUsedFromWorkerLog(slotName, sess)
+			o.ensureAttributionTrailerOnPR(slotName, sess, pr)
+			o.ensureAttributionTrailerOnBranch(slotName, sess)
 			log.Printf("[orch] reconcile: %s running->pr_open (PR #%d already open for branch %q; %s)",
 				slotName, pr.Number, sess.Branch, strings.Join(reasons, ", "))
 			sess.Status = state.StatusPROpen
@@ -1750,7 +1764,8 @@ func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.S
 	}
 
 	title := autoCreatedPRTitle(sess)
-	body := autoCreatedPRBody(sess, branch, reasons)
+	o.ensureAttributionTrailerOnBranch(slotName, sess)
+	body := state.AppendAttributionTrailer(autoCreatedPRBody(sess, branch, reasons), sess.Attribution, time.Now().UTC())
 	prNumber, err := o.createPR(title, body, "main", branch)
 	if err != nil {
 		log.Printf("[orch] reconcile: could not auto-create PR for %s branch %q: %v", slotName, branch, err)
@@ -1801,6 +1816,73 @@ Observed worker state: %s.
 `, sess.IssueNumber, branch, reasonText)
 }
 
+func (o *Orchestrator) ensureAttributionTrailerOnPR(slotName string, sess *state.Session, pr github.PR) {
+	if sess == nil || len(sess.Attribution) == 0 {
+		return
+	}
+	body := state.AppendAttributionTrailer(pr.Body, sess.Attribution, time.Now().UTC())
+	if body == pr.Body {
+		return
+	}
+	if err := o.updatePRBody(pr.Number, body); err != nil {
+		log.Printf("[orch] attribution: could not update PR #%d body for %s: %v", pr.Number, slotName, err)
+	}
+}
+
+func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *state.Session) {
+	if sess == nil || len(sess.Attribution) == 0 {
+		return
+	}
+	if err := o.amendHeadWithAttributionTrailer(sess.Worktree, sess.Branch, sess.Attribution, time.Now().UTC()); err != nil {
+		log.Printf("[orch] attribution: could not amend branch %q for %s: %v", sess.Branch, slotName, err)
+	}
+}
+
+func (o *Orchestrator) amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
+	if o.amendHeadFn != nil {
+		return o.amendHeadFn(worktreePath, branch, attribution, now)
+	}
+	return amendHeadWithAttributionTrailer(worktreePath, branch, attribution, now)
+}
+
+func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
+	worktreePath = strings.TrimSpace(worktreePath)
+	branch = strings.TrimSpace(branch)
+	if worktreePath == "" || branch == "" || len(attribution) == 0 {
+		return nil
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	status, err := exec.Command("git", "-C", worktreePath, "status", "--porcelain").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git status: %w\n%s", err, status)
+	}
+	if strings.TrimSpace(string(status)) != "" {
+		return fmt.Errorf("worktree has uncommitted changes; refusing attribution amend")
+	}
+	out, err := exec.Command("git", "-C", worktreePath, "log", "-1", "--pretty=%B").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git log -1: %w\n%s", err, out)
+	}
+	msg := state.AppendAttributionTrailer(string(out), attribution, now)
+	if msg == string(out) {
+		return nil
+	}
+	cmd := exec.Command("git", "-C", worktreePath, "commit", "--amend", "-F", "-")
+	cmd.Stdin = strings.NewReader(msg)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git commit --amend: %w\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", worktreePath, "push", "--force-with-lease", "origin", branch).CombinedOutput(); err != nil {
+		return fmt.Errorf("git push --force-with-lease origin %s: %w\n%s", branch, err, out)
+	}
+	return nil
+}
+
 // checkSessions inspects all sessions and updates their status
 func (o *Orchestrator) checkSessions(s *state.State) {
 	// Fetch open PRs once for the whole check cycle
@@ -1832,6 +1914,8 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						// log, no project sync, no FinishedAt churn.
 						continue
 					}
+					o.ensureAttributionTrailerOnPR(slotName, sess, pr)
+					o.ensureAttributionTrailerOnBranch(slotName, sess)
 					log.Printf("[orch] session %s %s->pr_open (PR #%d now open for branch %q)", slotName, sess.Status, pr.Number, sess.Branch)
 					sess.Status = state.StatusPROpen
 					sess.PRNumber = pr.Number
@@ -1951,6 +2035,8 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				// Check if there's an open PR for this branch BEFORE marking dead
 				if pr, found := branchToPR[sess.Branch]; found {
 					o.updateTokensUsedFromWorkerLog(slotName, sess)
+					o.ensureAttributionTrailerOnPR(slotName, sess, pr)
+					o.ensureAttributionTrailerOnBranch(slotName, sess)
 					log.Printf("[orch] worker %s exited but PR #%d is open — transitioning to pr_open", slotName, pr.Number)
 					sess.Status = state.StatusPROpen
 					sess.PRNumber = pr.Number
@@ -2330,6 +2416,8 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		if sess.PRNumber == 0 {
 			sess.PRNumber = pr.Number
 		}
+		o.ensureAttributionTrailerOnPR(slotName, sess, pr)
+		o.ensureAttributionTrailerOnBranch(slotName, sess)
 
 		// Check CI
 		ciStatus, err := o.prCIStatus(pr.Number)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -277,6 +277,8 @@ func TestReconcileRunningSessions_DeadWorkerWithOpenPR_CapturesTokensFromPersist
 
 func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing.T) {
 	s := state.NewState()
+	t0 := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	t1 := t0.Add(12 * time.Minute)
 	s.Sessions["mae-8"] = &state.Session{
 		IssueNumber: 108,
 		IssueTitle:  "add branch rescue",
@@ -284,9 +286,30 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 		PID:         8080,
 		TmuxSession: "maestro-mae-8",
 		Branch:      "feat/mae-8-108-add-branch-rescue",
+		Worktree:    "/tmp/mae-8",
+		Attribution: []state.BackendAttribution{
+			{
+				Backend:   "codex",
+				Provider:  "openai",
+				Model:     "gpt-5.5",
+				Effort:    "medium",
+				StartedAt: t0,
+				EndedAt:   &t1,
+				EndReason: "fallover",
+			},
+			{
+				Backend:   "claude",
+				Provider:  "anthropic",
+				Model:     "opus-4.8",
+				Effort:    "xhigh",
+				StartedAt: t1,
+			},
+		},
 	}
 
 	var gotTitle, gotBody, gotBase, gotHead string
+	var amendedWorktree, amendedBranch string
+	var amendedAttribution []state.BackendAttribution
 	o := &Orchestrator{
 		pidAliveFn:          func(pid int) bool { return false },
 		tmuxSessionExistsFn: func(name string) bool { return false },
@@ -297,6 +320,12 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 		createPRFn: func(title, body, base, head string) (int, error) {
 			gotTitle, gotBody, gotBase, gotHead = title, body, base, head
 			return 144, nil
+		},
+		amendHeadFn: func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
+			amendedWorktree = worktreePath
+			amendedBranch = branch
+			amendedAttribution = append([]state.BackendAttribution(nil), attribution...)
+			return nil
 		},
 	}
 
@@ -333,8 +362,78 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 	if !strings.Contains(gotBody, "Refs #108") || strings.Contains(gotBody, "Closes #108") || !strings.Contains(gotBody, "auto-created") {
 		t.Fatalf("unexpected body %q", gotBody)
 	}
+	if !strings.Contains(gotBody, "Maestro-Backend: codex openai gpt-5.5 medium") ||
+		!strings.Contains(gotBody, "; claude anthropic opus-4.8 xhigh") ||
+		!strings.Contains(gotBody, "fallover") {
+		t.Fatalf("body missing attribution trailer: %q", gotBody)
+	}
+	if amendedWorktree != "/tmp/mae-8" || amendedBranch != "feat/mae-8-108-add-branch-rescue" {
+		t.Fatalf("amend target = %q/%q", amendedWorktree, amendedBranch)
+	}
+	if len(amendedAttribution) != 2 {
+		t.Fatalf("amended attribution len = %d, want 2", len(amendedAttribution))
+	}
 	if !s.IssueInProgress(108) {
 		t.Fatal("IssueInProgress(108) must remain true after auto-created PR")
+	}
+}
+
+func TestReconcileRunningSessions_OpenPR_AppendsAttributionTrailer(t *testing.T) {
+	s := state.NewState()
+	t0 := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	s.Sessions["mae-9"] = &state.Session{
+		IssueNumber: 109,
+		IssueTitle:  "existing pr",
+		Status:      state.StatusRunning,
+		PID:         9090,
+		TmuxSession: "maestro-mae-9",
+		Branch:      "feat/mae-9-109-existing-pr",
+		Worktree:    "/tmp/mae-9",
+		Attribution: []state.BackendAttribution{{
+			Backend:   "codex",
+			Provider:  "openai",
+			Model:     "gpt-5.5",
+			Effort:    "medium",
+			StartedAt: t0,
+		}},
+	}
+
+	var updatedPR int
+	var updatedBody string
+	var amended bool
+	o := &Orchestrator{
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{{
+				Number:      145,
+				HeadRefName: "feat/mae-9-109-existing-pr",
+				Body:        "Refs #109\n",
+			}}, nil
+		},
+		updatePRBodyFn: func(prNumber int, body string) error {
+			updatedPR = prNumber
+			updatedBody = body
+			return nil
+		},
+		amendHeadFn: func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
+			amended = true
+			return nil
+		},
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to report changes")
+	}
+	if updatedPR != 145 {
+		t.Fatalf("updated PR = %d, want 145", updatedPR)
+	}
+	if !strings.Contains(updatedBody, "Maestro-Backend: codex openai gpt-5.5 medium") {
+		t.Fatalf("updated body missing attribution trailer: %q", updatedBody)
+	}
+	if !amended {
+		t.Fatal("expected branch head amend hook")
 	}
 }
 

--- a/internal/state/attribution.go
+++ b/internal/state/attribution.go
@@ -1,0 +1,136 @@
+package state
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const AttributionTrailerKey = "Maestro-Backend"
+
+// FormatAttributionTrailer renders the durable git/PR trailer for a session's
+// backend timeline. It uses relative ranges from the first segment so the line
+// remains stable and queryable after the live state file is gone.
+func FormatAttributionTrailer(attribution []BackendAttribution, now time.Time) string {
+	timeline := FormatAttributionTimeline(attribution, now)
+	if timeline == "" {
+		return ""
+	}
+	return AttributionTrailerKey + ": " + timeline
+}
+
+// FormatAttributionTimeline renders BackendAttribution segments in order as a
+// compact, semicolon-separated audit line.
+func FormatAttributionTimeline(attribution []BackendAttribution, now time.Time) string {
+	if len(attribution) == 0 {
+		return ""
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	now = now.UTC()
+
+	var origin time.Time
+	for _, seg := range attribution {
+		if !seg.StartedAt.IsZero() {
+			origin = seg.StartedAt.UTC()
+			break
+		}
+	}
+	if origin.IsZero() {
+		origin = now
+	}
+
+	parts := make([]string, 0, len(attribution))
+	for i, seg := range attribution {
+		label := attributionSegmentLabel(seg)
+		if label == "" {
+			continue
+		}
+		rangeLabel := attributionSegmentRange(origin, seg, now)
+		reason := ""
+		if i > 0 {
+			reason = strings.TrimSpace(attribution[i-1].EndReason)
+		}
+		if rangeLabel != "" && reason != "" {
+			label += " (" + rangeLabel + ", " + reason + ")"
+		} else if rangeLabel != "" {
+			label += " (" + rangeLabel + ")"
+		} else if reason != "" {
+			label += " (" + reason + ")"
+		}
+		parts = append(parts, label)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func attributionSegmentLabel(seg BackendAttribution) string {
+	values := []string{seg.Backend, seg.Provider, seg.Model, seg.Variant, seg.Effort}
+	seen := make(map[string]struct{}, len(values))
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		parts = append(parts, value)
+	}
+	return strings.Join(parts, " ")
+}
+
+func attributionSegmentRange(origin time.Time, seg BackendAttribution, now time.Time) string {
+	if seg.StartedAt.IsZero() {
+		return ""
+	}
+	start := attributionElapsedLabel(seg.StartedAt.UTC().Sub(origin))
+	if seg.EndedAt == nil {
+		return start + "-end"
+	}
+	endAt := seg.EndedAt.UTC()
+	if endAt.Before(seg.StartedAt.UTC()) {
+		return start + "-end"
+	}
+	return start + "-" + attributionElapsedLabel(endAt.Sub(origin))
+}
+
+func attributionElapsedLabel(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	seconds := int(d.Round(time.Second).Seconds())
+	if seconds == 0 {
+		return "0"
+	}
+	if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	minutes := seconds / 60
+	if minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	hours := minutes / 60
+	rem := minutes % 60
+	if rem > 0 {
+		return fmt.Sprintf("%dh %dm", hours, rem)
+	}
+	return fmt.Sprintf("%dh", hours)
+}
+
+// AppendAttributionTrailer appends the attribution trailer to text unless the
+// trailer is empty or already present.
+func AppendAttributionTrailer(text string, attribution []BackendAttribution, now time.Time) string {
+	trailer := FormatAttributionTrailer(attribution, now)
+	if trailer == "" || strings.Contains(text, AttributionTrailerKey+":") {
+		return text
+	}
+	text = strings.TrimRight(text, " \t\r\n")
+	if text == "" {
+		return trailer + "\n"
+	}
+	return text + "\n\n" + trailer + "\n"
+}

--- a/internal/state/attribution_test.go
+++ b/internal/state/attribution_test.go
@@ -1,0 +1,69 @@
+package state
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatAttributionTrailerSingleSegment(t *testing.T) {
+	t0 := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	got := FormatAttributionTrailer([]BackendAttribution{{
+		Backend:   "codex",
+		Provider:  "openai",
+		Model:     "gpt-5.5",
+		Effort:    "medium",
+		StartedAt: t0,
+	}}, t0.Add(12*time.Minute))
+
+	want := "Maestro-Backend: codex openai gpt-5.5 medium (0-end)"
+	if got != want {
+		t.Fatalf("FormatAttributionTrailer() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatAttributionTrailerTwoSegmentsInOrder(t *testing.T) {
+	t0 := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	t1 := t0.Add(12 * time.Minute)
+	got := FormatAttributionTrailer([]BackendAttribution{
+		{
+			Backend:   "codex",
+			Provider:  "openai",
+			Model:     "gpt-5.5",
+			Effort:    "medium",
+			StartedAt: t0,
+			EndedAt:   &t1,
+			EndReason: "fallover",
+		},
+		{
+			Backend:   "claude",
+			Provider:  "anthropic",
+			Model:     "opus-4.8",
+			Effort:    "xhigh",
+			StartedAt: t1,
+		},
+	}, t1.Add(4*time.Minute))
+
+	want := "Maestro-Backend: codex openai gpt-5.5 medium (0-12m); claude anthropic opus-4.8 xhigh (12m-end, fallover)"
+	if got != want {
+		t.Fatalf("FormatAttributionTrailer() = %q, want %q", got, want)
+	}
+}
+
+func TestAppendAttributionTrailerDoesNotDuplicate(t *testing.T) {
+	t0 := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	attribution := []BackendAttribution{{
+		Backend:   "codex",
+		Model:     "gpt-5.5",
+		StartedAt: t0,
+	}}
+	once := AppendAttributionTrailer("Refs #656\n", attribution, t0.Add(time.Minute))
+	twice := AppendAttributionTrailer(once, attribution, t0.Add(2*time.Minute))
+
+	if twice != once {
+		t.Fatalf("trailer duplicated:\nonce=%q\ntwice=%q", once, twice)
+	}
+	if count := strings.Count(once, AttributionTrailerKey+":"); count != 1 {
+		t.Fatalf("trailer count = %d, want 1 in %q", count, once)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -887,7 +887,8 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 4. Commit your changes with a clear message.
 5. Before committing or opening a PR, check for accidental secrets and generated artifacts. Do NOT commit or mention API keys, bearer tokens, oauth tokens, bot tokens, env values, raw config dumps, or diagnostic logs. Do NOT commit temp/debug artifacts such as tmp/, _tmp/, *.log, *.logs, *.test, or *.test.json unless the issue explicitly requires them.
 6. Keep the PR body minimal and safe. Use: gh pr create --repo %s --title "%s" --body "Refs #%d". Never use closing keywords such as Closes/Fixes/Resolves in PR bodies for Maestro-managed work. Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.
-7. After creating the PR, you are done. Do NOT merge it yourself.
+7. Preserve any Maestro-Backend: attribution trailer that Maestro adds to commit messages or PR bodies.
+8. After creating the PR, you are done. Do NOT merge it yourself.
 
 Important: Always run cargo fmt --all before committing if this is a Rust project.
 Always rebase on origin/main immediately before creating the PR.

--- a/worker-prompt-template.md
+++ b/worker-prompt-template.md
@@ -91,6 +91,7 @@ When rebasing conflicts in these files: **keep BOTH sides**. Your additions + wh
 
 ### 7. Done means done
 Once you've opened a PR:
+- Preserve any `Maestro-Backend:` attribution trailer Maestro adds to commit messages or PR bodies.
 - Verify CI started with REST only:
   `sha=$(gh api repos/OWNER/REPO/pulls/PR_NUMBER --jq .head.sha) && gh api repos/OWNER/REPO/commits/$sha/check-runs --jq '.check_runs[] | {name,status,conclusion}'`
 - Write a brief summary of what you did


### PR DESCRIPTION
Refs #656

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires provider/model/variant/effort attribution into both commit messages (via `git commit --amend` + force-push) and PR bodies (via `gh pr edit`) at every `running→pr_open` transition and auto-merge path. A new `state.AppendAttributionTrailer` / `FormatAttributionTrailer` pair formats the `Maestro-Backend:` trailer line from `[]BackendAttribution`.

- **`internal/state/attribution.go`**: New file implementing compact semicolon-separated timeline formatting, elapsed-time labels, and the `AppendAttributionTrailer` helper that guards against duplicate writes.
- **`internal/orchestrator/orchestrator.go`**: `ensureAttributionTrailerOnPR` and `ensureAttributionTrailerOnBranch` are called at all session transition points; `amendHeadWithAttributionTrailer` does the actual amend+force-push.
- **`internal/github/github.go`** + prompt templates: `UpdatePRBody` added; worker instructions updated to preserve the trailer.

<h3>Confidence Score: 3/5</h3>

Core logic works for the common single-provider case, but multi-provider fallback sessions and transient push failures can silently produce incomplete or missing attribution records on both the remote branch and PR body.

The `AppendAttributionTrailer` guard uses a substring check that prevents any update once the key appears — even when the attribution slice grows after the first write. In a fallback session this leaves provider B's segment permanently absent from the PR body and commit message. Separately, a successful `git commit --amend` followed by a failed push leaves the local HEAD carrying the trailer while the remote does not; because `git log -1` then returns the locally-amended message, subsequent reconcile cycles see the key and skip the push entirely, so the failure is never recovered.

`internal/state/attribution.go` (trailer update logic) and `internal/orchestrator/orchestrator.go` (amend + push retry handling) need the most attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/attribution.go | New file implementing trailer formatting + append logic; frozen-on-first-write and too-broad key-presence check are issues |
| internal/orchestrator/orchestrator.go | Attribution trailer hooks wired into all running→pr_open and autoMergePRs paths; failed push after local amend leaves remote attribution permanently missing |
| internal/state/attribution_test.go | Unit tests for formatting and idempotency; no test for partial-update (stale trailer) or push-failure scenarios |
| internal/orchestrator/orchestrator_test.go | Two new integration tests cover PR-body append and amend-hook firing correctly; test coverage is good for the happy path |
| internal/github/github.go | Adds UpdatePRBody wrapping `gh pr edit --body`; straightforward and consistent with existing gh-CLI helpers |
| internal/worker/worker.go | Renumbers prompt step 7→8 and adds instruction to preserve the Maestro-Backend trailer; cosmetic, safe |
| worker-prompt-template.md | Adds matching prompt guidance to preserve the attribution trailer; no logic issues |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/state/attribution.go:126-136
**Attribution trailer frozen after first write**

`AppendAttributionTrailer` returns the original text unchanged whenever `"Maestro-Backend:"` is already present anywhere in the string. This means a PR body or commit message that received a one-segment trailer (e.g., after provider A's worker died) will never be updated when the session gains a second segment via rate-limit fallback. The `ensureAttributionTrailerOnPR` / `ensureAttributionTrailerOnBranch` call sites on every reconcile cycle cannot fix stale trailers — they'll hit the same early-return gate. Concretely: if provider A finishes with an open PR, reconcile writes `Maestro-Backend: A`; provider B then does all the real work, but its segment is silently dropped from the PR body and commit message.

The fix is to replace an existing trailer line rather than only guarding against duplication — e.g., find and replace the `AttributionTrailerKey + ":…"` line when the freshly-formatted trailer differs from the one already present.

### Issue 2 of 3
internal/orchestrator/orchestrator.go:1871-1884
**Failed push leaves remote branch without attribution — push never retried**

If `git commit --amend` succeeds but `git push --force-with-lease` fails (network blip, remote-lease mismatch, etc.), the error is logged and the function returns. On the next reconcile cycle, `git log -1 --pretty=%B` reads the **locally amended** HEAD, which already contains `"Maestro-Backend:"`. `AppendAttributionTrailer` returns the text unchanged, `msg == string(out)` is true, and the function returns nil — the push is never retried. Attribution silently stays local and the remote branch/PR never reflects it.

### Issue 3 of 3
internal/state/attribution.go:128
The presence check `strings.Contains(text, AttributionTrailerKey+":")` matches the key anywhere in the text — including mid-paragraph prose such as `"Maestro-Backend: see documentation"`. Use a line-anchored check so only an actual trailer line suppresses the append.

```suggestion
	if trailer == "" || containsTrailerLine(text, AttributionTrailerKey) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["attribution: emit backend trailer"](https://github.com/befeast/maestro/commit/4665f1a802f016cc2e8b65daeca34f1d2a5c02d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35575241)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->