### PR TITLE
pipeline/research: hoist gopls regexes to package level + aggregate timeout budget (Greptile debt from #651)

### DIFF
--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
@@ -377,6 +378,53 @@ func TestRunResearchFallsBackWhenGoplsUnavailable(t *testing.T) {
 	}
 }
 
+func TestRunResearchFallsBackWithinGoplsAggregateBudget(t *testing.T) {
+	dir := t.TempDir()
+	writeStallingGopls(t, dir)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	oldGopls := goplsBinary
+	goplsBinary = "gopls"
+	oldBudget := goplsAggregateTimeout
+	goplsAggregateTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		goplsBinary = oldGopls
+		goplsAggregateTimeout = oldBudget
+	})
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/research\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "pipeline"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	researchGo := `package pipeline
+
+func runResearch() string {
+	return "context"
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "internal", "pipeline", "research.go"), []byte(researchGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	ctx, err := runResearch(dir, 657, "Add pipeline research", "Research phase for worker pipeline uses `runResearch`.")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("runResearch should keep filename-grep fallback working: %v", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("runResearch exceeded aggregate gopls budget by too much: %s", elapsed)
+	}
+	if !strings.Contains(ctx, "## Relevant Files") {
+		t.Fatalf("expected fallback relevant files context, got:\n%s", ctx)
+	}
+	if strings.Contains(ctx, "## Symbol Context (gopls)") {
+		t.Fatalf("did not expect symbol context after aggregate gopls timeout:\n%s", ctx)
+	}
+}
+
 func writeFakeGopls(t *testing.T, dir string) {
 	t.Helper()
 	script := `#!/bin/sh
@@ -403,6 +451,14 @@ esac
 `
 	path := filepath.Join(dir, "gopls")
 	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeStallingGopls(t *testing.T, dir string) {
+	t.Helper()
+	path := filepath.Join(dir, "gopls")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexec sleep 10\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/pipeline/research.go
+++ b/internal/pipeline/research.go
@@ -20,6 +20,19 @@ const researchDir = ".maestro/research"
 
 var goplsBinary = "gopls"
 
+var goplsAggregateTimeout = 20 * time.Second
+
+var (
+	markdownCodeBlockRe      = regexp.MustCompile("```[\\s\\S]*?```")
+	markdownInlineCodeRe     = regexp.MustCompile("`[^`]+`")
+	markdownURLRe            = regexp.MustCompile(`https?://\S+`)
+	markdownFormattingRe     = regexp.MustCompile(`[#*_\[\]()>~]`)
+	goCodeSpanSymbolRe       = regexp.MustCompile("`([A-Za-z_][A-Za-z0-9_]*)`")
+	goIdentifierRe           = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*\b`)
+	goSymbolCandidateShapeRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	goplsSpanRe              = regexp.MustCompile(`^(.+):([0-9]+):([0-9]+)`)
+)
+
 // runResearch performs the pre-coding research phase.
 // It scans the codebase for files relevant to the issue keywords and writes
 // a context file to .maestro/research/<issue-number>.md.
@@ -131,10 +144,10 @@ func extractKeywords(title, body string) []string {
 	text := title + " " + body
 
 	// Remove markdown formatting, URLs, code blocks
-	text = regexp.MustCompile("```[\\s\\S]*?```").ReplaceAllString(text, "")
-	text = regexp.MustCompile("`[^`]+`").ReplaceAllString(text, "")
-	text = regexp.MustCompile(`https?://\S+`).ReplaceAllString(text, "")
-	text = regexp.MustCompile(`[#*_\[\]()>~]`).ReplaceAllString(text, " ")
+	text = markdownCodeBlockRe.ReplaceAllString(text, "")
+	text = markdownInlineCodeRe.ReplaceAllString(text, "")
+	text = markdownURLRe.ReplaceAllString(text, "")
+	text = markdownFormattingRe.ReplaceAllString(text, " ")
 
 	words := strings.Fields(strings.ToLower(text))
 
@@ -252,8 +265,14 @@ func findSymbolContexts(worktreePath, issueTitle, issueBody string) ([]symbolCon
 		return nil, nil
 	}
 
+	queryCtx, cancel := context.WithTimeout(context.Background(), goplsAggregateTimeout)
+	defer cancel()
+
 	var contexts []symbolContext
 	for _, symbol := range candidates {
+		if queryCtx.Err() != nil {
+			return contexts, nil
+		}
 		path, line, char, ok := findSymbolTokenPosition(worktreePath, goFiles, symbol)
 		if !ok {
 			continue
@@ -265,18 +284,27 @@ func findSymbolContexts(worktreePath, issueTitle, issueBody string) ([]symbolCon
 			LookupCharacter: char,
 		}
 		var err error
-		ctx.Definitions, err = runGoplsLocationQuery(worktreePath, "definition", path, line, char)
+		ctx.Definitions, err = runGoplsLocationQuery(queryCtx, worktreePath, "definition", path, line, char)
 		if err != nil {
 			log.Printf("[pipeline] research: gopls definition failed for %s: %v", symbol, err)
+			if queryCtx.Err() != nil {
+				return contexts, nil
+			}
 			continue
 		}
-		ctx.References, err = runGoplsLocationQuery(worktreePath, "references", path, line, char)
+		ctx.References, err = runGoplsLocationQuery(queryCtx, worktreePath, "references", path, line, char)
 		if err != nil {
 			log.Printf("[pipeline] research: gopls references failed for %s: %v", symbol, err)
+			if queryCtx.Err() != nil {
+				return contexts, nil
+			}
 		}
-		ctx.Implementations, err = runGoplsLocationQuery(worktreePath, "implementation", path, line, char)
+		ctx.Implementations, err = runGoplsLocationQuery(queryCtx, worktreePath, "implementation", path, line, char)
 		if err != nil {
 			log.Printf("[pipeline] research: gopls implementation failed for %s: %v", symbol, err)
+			if queryCtx.Err() != nil {
+				return contexts, nil
+			}
 		}
 		if len(ctx.Definitions)+len(ctx.References)+len(ctx.Implementations) > 0 {
 			contexts = append(contexts, ctx)
@@ -347,13 +375,11 @@ func extractSymbolCandidates(title, body string) []string {
 		candidates = append(candidates, s)
 	}
 
-	codeSpanRe := regexp.MustCompile("`([A-Za-z_][A-Za-z0-9_]*)`")
-	for _, m := range codeSpanRe.FindAllStringSubmatch(title+" "+body, -1) {
+	for _, m := range goCodeSpanSymbolRe.FindAllStringSubmatch(title+" "+body, -1) {
 		add(m[1])
 	}
 
-	identRe := regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*\b`)
-	for _, m := range identRe.FindAllString(title+" "+body, -1) {
+	for _, m := range goIdentifierRe.FindAllString(title+" "+body, -1) {
 		if hasGoIdentifierShape(m) {
 			add(m)
 		}
@@ -380,7 +406,7 @@ func isUsefulGoSymbolCandidate(s string) bool {
 	if goKeywords[lower] {
 		return false
 	}
-	return regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(s)
+	return goSymbolCandidateShapeRe.MatchString(s)
 }
 
 func hasGoIdentifierShape(s string) bool {
@@ -426,23 +452,46 @@ func listGoSourceFiles(worktreePath string) []string {
 }
 
 func findSymbolTokenPosition(worktreePath string, files []string, symbol string) (string, int, int, bool) {
-	tokenRe := regexp.MustCompile(`\b` + regexp.QuoteMeta(symbol) + `\b`)
 	for _, rel := range files {
 		data, err := os.ReadFile(filepath.Join(worktreePath, rel))
 		if err != nil {
 			continue
 		}
 		for lineIndex, line := range strings.Split(string(data), "\n") {
-			if loc := tokenRe.FindStringIndex(line); loc != nil {
-				return rel, lineIndex + 1, loc[0] + 1, true
+			if loc := findIdentifierTokenIndex(line, symbol); loc >= 0 {
+				return rel, lineIndex + 1, loc + 1, true
 			}
 		}
 	}
 	return "", 0, 0, false
 }
 
-func runGoplsLocationQuery(worktreePath, verb, relPath string, line, char int) ([]symbolLocation, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+func findIdentifierTokenIndex(line, symbol string) int {
+	for offset := 0; offset < len(line); {
+		idx := strings.Index(line[offset:], symbol)
+		if idx < 0 {
+			return -1
+		}
+		idx += offset
+		end := idx + len(symbol)
+		if isIdentifierBoundary(line, idx-1) && isIdentifierBoundary(line, end) {
+			return idx
+		}
+		offset = end
+	}
+	return -1
+}
+
+func isIdentifierBoundary(s string, idx int) bool {
+	if idx < 0 || idx >= len(s) {
+		return true
+	}
+	c := s[idx]
+	return !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_')
+}
+
+func runGoplsLocationQuery(parentCtx context.Context, worktreePath, verb, relPath string, line, char int) ([]symbolLocation, error) {
+	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
 	defer cancel()
 
 	pos := fmt.Sprintf("%s:%d:%d", filepath.Join(worktreePath, relPath), line, char)
@@ -545,7 +594,7 @@ func uriToPath(uri string) string {
 }
 
 func parseGoplsSpan(worktreePath, span string) (symbolLocation, bool) {
-	match := regexp.MustCompile(`^(.+):([0-9]+):([0-9]+)`).FindStringSubmatch(span)
+	match := goplsSpanRe.FindStringSubmatch(span)
 	if match == nil {
 		return symbolLocation{}, false
 	}


### PR DESCRIPTION
Refs #657

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses Greptile debt from #651 by hoisting eight `regexp.MustCompile` calls from hot paths to package-level vars, and replacing the per-call `findSymbolTokenPosition` regex with a custom byte-scanning boundary checker. It also adds a `goplsAggregateTimeout` (20 s) threaded as a parent context through all `runGoplsLocationQuery` calls.

- **Regex hoisting & `findIdentifierTokenIndex`**: clean refactor with equivalent boundary logic to the replaced `\\b`-regex approach.
- **Aggregate timeout**: `findSymbolContexts` creates a shared context passed down to each query; each per-query call derives a 5-second child.
- **Early-return on timeout**: the checks inside the `references` and `implementations` error blocks return without appending the partially-built `ctx`, silently discarding definitions already collected for the current symbol.

<h3>Confidence Score: 3/5</h3>

Safe to merge if partial-context data loss on timeout is acceptable; the fallback to filename grep still works, but the research phase yields less information than it should when gopls is slow rather than completely stalled.

The aggregate timeout wiring is correct in the happy path and the stall-test covers it well. When the budget expires mid-symbol after a successful definitions query but during references or implementations, the accumulated data for that symbol is dropped before the return.

internal/pipeline/research.go — specifically the two return contexts, nil sites inside the references and implementations error blocks.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/pipeline/research.go | Hoists 8 compiled regexes to package level, adds a 20s aggregate gopls timeout context threaded through runGoplsLocationQuery, and replaces a per-call regex word-boundary search with a custom findIdentifierTokenIndex. The aggregate timeout early-return logic has a bug that discards partially-collected symbol data. |
| internal/pipeline/pipeline_test.go | Adds TestRunResearchFallsBackWithinGoplsAggregateBudget and a writeStallingGopls helper; the test correctly overrides goplsAggregateTimeout and validates the fallback path under a 100ms budget. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/pipeline/research.go:295-308
**Partial symbol context silently dropped on aggregate timeout**

Both early-return sites inside the `references` and `implementations` error blocks return `contexts` without first appending the current `ctx`. If the aggregate budget expires during the `references` query, `ctx.Definitions` (already successfully fetched) is discarded. If it expires during `implementations`, both `ctx.Definitions` and `ctx.References` are lost.

Concretely: a symbol where `definition` succeeds in ~4.9 s and then `references` hits the 20-second wall will never appear in the returned slice, even though useful definition data was collected. The fix at each of these two early-return points is to check and append `ctx` before returning.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["pipeline/research: bound gopls symbol lo..."](https://github.com/befeast/maestro/commit/ea63c513d4fad15bc98fa87aa1939319fcda4e20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35578052)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->