### PR TITLE
router: task-type classification (vision/design/refactor/bugfix/test) to drive backend selection

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -1928,10 +1928,21 @@ func spawnCmd(args []string) {
 
 	// Resolve backend via 3-tier priority: label → auto-routing → default
 	r := router.New(cfg)
-	backendName, _ := r.ResolveBackend(*targetIssue)
+	backendDecision := r.ResolveBackendDecision(*targetIssue)
+	backendName := backendDecision.Backend
 	slotName, err := worker.Start(cfg, s, cfg.Repo, *targetIssue, promptBase, backendName)
 	if err != nil {
 		log.Fatalf("start worker: %v", err)
+	}
+	if sess := s.Sessions[slotName]; sess != nil {
+		sess.BackendSelection = &state.BackendSelection{
+			SelectedBackend: backendName,
+			SelectionReason: backendDecision.Reason,
+			TaskType:        backendDecision.TaskType,
+		}
+		if backendDecision.TaskType != "" && len(sess.Attribution) > 0 {
+			sess.Attribution[len(sess.Attribution)-1].TaskType = backendDecision.TaskType
+		}
 	}
 
 	if err := state.Save(cfg.StateDir, s); err != nil {

--- a/docs/gemini-backend.md
+++ b/docs/gemini-backend.md
@@ -97,6 +97,23 @@ issue #42 labels: enhancement, model:gemini  -> runs with Gemini
 issue #43 labels: enhancement                -> runs with default
 ```
 
+When `routing.mode: auto` is enabled, the LLM router also returns a structured
+`task_type` classification: `refactor`, `bugfix`, `test`, `vision`, `design`,
+`docs`, or `infra`. You can map task types to preferred backends before the
+router's free-text backend pick is used:
+
+```yaml
+routing:
+  mode: auto
+  task_type_backends:
+    vision: claude
+    design: claude
+```
+
+Manual routing is unchanged: with `routing.mode: manual`, `task_type_backends`
+is inert and backend selection remains `model:<backend>` labels or
+`model.default`.
+
 ## Test coverage
 
 The Gemini backend has unit tests covering:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -503,10 +503,11 @@ func (s SupervisorConfig) AllowsSafeAction(action string) bool {
 
 // RoutingConfig controls automatic backend selection via LLM router.
 type RoutingConfig struct {
-	Mode            string `yaml:"mode"`              // "auto", "manual" (labels only)
-	RouterModel     string `yaml:"router_model"`      // backend name from model.backends (default: "claude")
-	RouterModelName string `yaml:"router_model_name"` // specific model to use (default: "claude-sonnet-4-6")
-	RouterPrompt    string `yaml:"router_prompt"`     // prompt template with {{BACKENDS}}, {{NUMBER}}, {{TITLE}}, {{BODY}}
+	Mode             string            `yaml:"mode"`               // "auto", "manual" (labels only)
+	RouterModel      string            `yaml:"router_model"`       // backend name from model.backends (default: "claude")
+	RouterModelName  string            `yaml:"router_model_name"`  // specific model to use (default: "claude-sonnet-4-6")
+	RouterPrompt     string            `yaml:"router_prompt"`      // prompt template with {{BACKENDS}}, {{NUMBER}}, {{TITLE}}, {{BODY}}
+	TaskTypeBackends map[string]string `yaml:"task_type_backends"` // task_type -> backend override used only when routing.mode=auto
 
 	// Role-specific backend overrides for the planner → implementer → validator pipeline.
 	// Each maps to a backend name from model.backends. If empty, falls back to issue-level routing.
@@ -1047,6 +1048,24 @@ func parse(data []byte) (*Config, error) {
 	if cfg.Routing.RouterModelName == "" {
 		cfg.Routing.RouterModelName = "claude-sonnet-4-6"
 	}
+	if len(cfg.Routing.TaskTypeBackends) > 0 {
+		normalized := make(map[string]string, len(cfg.Routing.TaskTypeBackends))
+		for taskType, backend := range cfg.Routing.TaskTypeBackends {
+			taskType = strings.ToLower(strings.TrimSpace(taskType))
+			backend = strings.TrimSpace(backend)
+			if !validRoutingTaskType(taskType) {
+				return nil, fmt.Errorf("config: routing.task_type_backends has unknown task type %q (valid: refactor, bugfix, test, vision, design, docs, infra)", taskType)
+			}
+			if backend == "" {
+				return nil, fmt.Errorf("config: routing.task_type_backends.%s is empty", taskType)
+			}
+			if _, ok := cfg.Model.Backends[backend]; !ok {
+				return nil, fmt.Errorf("config: routing.task_type_backends.%s = %q is not declared in model.backends", taskType, backend)
+			}
+			normalized[taskType] = backend
+		}
+		cfg.Routing.TaskTypeBackends = normalized
+	}
 
 	// Versioning defaults
 	if cfg.Versioning.DefaultBump == "" {
@@ -1158,6 +1177,15 @@ func (c *Config) EffectiveReviewGateStreams() []string {
 		return nil
 	}
 	return normalizeReviewGateStreams(c.ReviewGate, c.ReviewGateStreams)
+}
+
+func validRoutingTaskType(taskType string) bool {
+	switch taskType {
+	case "refactor", "bugfix", "test", "vision", "design", "docs", "infra":
+		return true
+	default:
+		return false
+	}
 }
 
 // SupervisorPolicyCandidatePaths returns structured policy files that may live

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -649,6 +649,58 @@ routing:
 	}
 }
 
+func TestParse_RoutingTaskTypeBackends(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+    claude:
+      cmd: claude
+routing:
+  mode: auto
+  task_type_backends:
+    Vision: claude
+    design: claude
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.Routing.TaskTypeBackends["vision"]; got != "claude" {
+		t.Fatalf("task_type_backends[vision] = %q, want claude", got)
+	}
+	if got := cfg.Routing.TaskTypeBackends["design"]; got != "claude" {
+		t.Fatalf("task_type_backends[design] = %q, want claude", got)
+	}
+}
+
+func TestParse_RoutingTaskTypeBackendsRejectsUnknownTaskType(t *testing.T) {
+	yaml := `
+repo: owner/repo
+routing:
+  task_type_backends:
+    feature: claude
+`
+	if _, err := parse([]byte(yaml)); err == nil {
+		t.Fatal("expected parse error for unknown task type")
+	}
+}
+
+func TestParse_RoutingTaskTypeBackendsRejectsUnknownBackend(t *testing.T) {
+	yaml := `
+repo: owner/repo
+routing:
+  task_type_backends:
+    vision: ghost
+`
+	if _, err := parse([]byte(yaml)); err == nil {
+		t.Fatal("expected parse error for unknown mapped backend")
+	}
+}
+
 func TestParse_MaxRuntimeMinutesDefault(t *testing.T) {
 	yaml := `repo: owner/repo`
 	cfg, err := parse([]byte(yaml))

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1384,7 +1384,7 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 		o.markRestartRequired(fmt.Sprintf("model.default changed (%s → %s)", old.Model.Default, newCfg.Model.Default))
 		log.Printf("[orch] config reload: model.default changed (%s → %s) — requires restart (not applied)", old.Model.Default, newCfg.Model.Default)
 	}
-	if newCfg.Routing != old.Routing {
+	if !reflect.DeepEqual(newCfg.Routing, old.Routing) {
 		o.markRestartRequired(fmt.Sprintf("routing.* changed (router_model %s → %s, mode %s → %s)",
 			old.Routing.RouterModel, newCfg.Routing.RouterModel, old.Routing.Mode, newCfg.Routing.Mode))
 		log.Printf("[orch] config reload: routing.* changed (router_model %s → %s, mode %s → %s) — requires restart (not applied)",
@@ -3582,8 +3582,8 @@ func (o *Orchestrator) findOpenBlockers(blockers []int) []int {
 //  2. Auto-routing via LLM (if routing.mode == "auto")
 //  3. Default backend from config
 func (o *Orchestrator) resolveBackend(issue github.Issue) string {
-	name, _ := o.router.ResolveBackend(issue)
-	return name
+	decision := o.router.ResolveBackendDecision(issue)
+	return decision.Backend
 }
 
 // resolveBackendWithReason is like resolveBackend but also returns the
@@ -3591,7 +3591,12 @@ func (o *Orchestrator) resolveBackend(issue github.Issue) string {
 // on the session for the dashboard. Introduced for #427 to make it visible
 // whether a backend came from a model: label, auto-routing, or default.
 func (o *Orchestrator) resolveBackendWithReason(issue github.Issue) (string, string) {
-	return o.router.ResolveBackend(issue)
+	decision := o.router.ResolveBackendDecision(issue)
+	return decision.Backend, decision.Reason
+}
+
+func (o *Orchestrator) resolveBackendDecision(issue github.Issue) router.BackendDecision {
+	return o.router.ResolveBackendDecision(issue)
 }
 
 // availableSlots calculates how many new workers can be started, considering
@@ -4211,6 +4216,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		// session record can show provenance: label, role, auto, default,
 		// router_error, phase, review_repair. (#427)
 		var backendReason string
+		var taskType string
 
 		// #565: when the supervisor selected spawn_review_repair for this
 		// issue, override backend + prompt with the strong backend and
@@ -4238,7 +4244,10 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			backendReason = "phase"
 		} else {
 			// Normal mode or pipeline starting at implement — use standard resolution
-			backendName, backendReason = o.resolveBackendWithReason(issue)
+			backendDecision := o.resolveBackendDecision(issue)
+			backendName = backendDecision.Backend
+			backendReason = backendDecision.Reason
+			taskType = backendDecision.TaskType
 			promptBase = o.selectPrompt(issue)
 			if initialPhase == state.PhaseImplement {
 				// Pipeline mode but no planner — add pipeline preamble
@@ -4289,6 +4298,10 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			sess.BackendSelection = &state.BackendSelection{
 				SelectedBackend: backendName,
 				SelectionReason: backendReason,
+				TaskType:        taskType,
+			}
+			if taskType != "" && len(sess.Attribution) > 0 {
+				sess.Attribution[len(sess.Attribution)-1].TaskType = taskType
 			}
 		}
 		if o.syncProject(issue.Number, github.ProjectStatusInProgress) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -4329,13 +4329,22 @@ func newStartWorkersOrchestrator(cfg *config.Config, issues []github.Issue) (*Or
 		workerStartFn: func(cfg *config.Config, s *state.State, repo string, issue github.Issue, promptBase, backend string) (string, error) {
 			slotCounter++
 			slotName := fmt.Sprintf("slot-%d", slotCounter)
+			startedAt := time.Now().UTC()
 			s.Sessions[slotName] = &state.Session{
 				IssueNumber: issue.Number,
 				IssueTitle:  issue.Title,
 				Status:      state.StatusRunning,
 				PID:         1000 + slotCounter,
 				Branch:      fmt.Sprintf("feat/%s", slotName),
-				StartedAt:   time.Now().UTC(),
+				StartedAt:   startedAt,
+				Backend:     backend,
+				Attribution: []state.BackendAttribution{
+					{
+						Backend:   backend,
+						StartedAt: startedAt,
+						Reason:    "initial_spawn",
+					},
+				},
 			}
 			started = append(started, issue.Number)
 			return slotName, nil
@@ -4450,8 +4459,8 @@ func TestStartNewWorkers_StampsBackendSelectionReason_Auto(t *testing.T) {
 	issues := []github.Issue{makeIssue(429, "Refactor module")}
 	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
 	o.router = router.New(cfg)
-	o.router.RouteFn = func(issue github.Issue) (string, string, error) {
-		return "codex", "tight loop", nil
+	o.router.DecisionFn = func(issue github.Issue) (router.Decision, error) {
+		return router.Decision{Backend: "codex", TaskType: router.TaskTypeRefactor, Reason: "tight loop"}, nil
 	}
 
 	s := state.NewState()
@@ -4466,6 +4475,12 @@ func TestStartNewWorkers_StampsBackendSelectionReason_Auto(t *testing.T) {
 	}
 	if sess.BackendSelection.SelectionReason != router.ReasonAuto {
 		t.Errorf("BackendSelection.SelectionReason = %q, want %q", sess.BackendSelection.SelectionReason, router.ReasonAuto)
+	}
+	if sess.BackendSelection.TaskType != router.TaskTypeRefactor {
+		t.Errorf("BackendSelection.TaskType = %q, want %q", sess.BackendSelection.TaskType, router.TaskTypeRefactor)
+	}
+	if len(sess.Attribution) != 1 || sess.Attribution[0].TaskType != router.TaskTypeRefactor {
+		t.Fatalf("Attribution = %+v, want task_type %q on first segment", sess.Attribution, router.TaskTypeRefactor)
 	}
 }
 

--- a/internal/router/resolve.go
+++ b/internal/router/resolve.go
@@ -15,6 +15,14 @@ const (
 	RoleValidator   = "validator"
 )
 
+// BackendDecision is the resolved backend plus visibility metadata that callers
+// persist on sessions.
+type BackendDecision struct {
+	Backend  string
+	Reason   string
+	TaskType string
+}
+
 // Selection reason canonical values written to Session.BackendSelection.SelectionReason
 // when the orchestrator records why a backend was chosen for an issue.
 const (
@@ -60,43 +68,69 @@ func ValidateBackend(name string, cfg *config.Config) (string, bool) {
 // reason is ReasonRouterError instead of ReasonDefault so operators can tell
 // auto-routing failed silently rather than not being configured at all (#427).
 func (r *Router) ResolveBackend(issue github.Issue) (backendName, reason string) {
+	decision := r.ResolveBackendDecision(issue)
+	return decision.Backend, decision.Reason
+}
+
+// ResolveBackendDecision determines the backend for an issue and includes the
+// structured task type when routing.mode=auto produced one.
+func (r *Router) ResolveBackendDecision(issue github.Issue) BackendDecision {
 	// 1. Check for model: label (highest priority)
 	if name := BackendFromLabels(issue); name != "" {
 		validated, ok := ValidateBackend(name, r.cfg)
 		if !ok {
 			log.Printf("[router] issue #%d: label specifies unknown backend %q, falling back to default %q",
 				issue.Number, name, r.cfg.Model.Default)
-			return validated, ReasonUnknownPin
+			return BackendDecision{Backend: validated, Reason: ReasonUnknownPin}
 		}
 		log.Printf("[router] issue #%d → %s (label override)", issue.Number, validated)
-		return validated, ReasonLabel
+		return BackendDecision{Backend: validated, Reason: ReasonLabel}
 	}
 
 	// 2. Auto-routing via LLM (if enabled)
 	if r.cfg.Routing.Mode == "auto" {
-		routeFn := r.Route
-		if r.RouteFn != nil {
-			routeFn = r.RouteFn
+		routeDecisionFn := r.RouteDecision
+		if r.DecisionFn != nil {
+			routeDecisionFn = r.DecisionFn
+		} else if r.RouteFn != nil {
+			routeDecisionFn = func(issue github.Issue) (Decision, error) {
+				backend, reason, err := r.RouteFn(issue)
+				return Decision{Backend: backend, Reason: reason}, err
+			}
 		}
-		routedBackend, routeReason, err := routeFn(issue)
+		routeDecision, err := routeDecisionFn(issue)
 		if err != nil {
 			log.Printf("[router] issue #%d: auto-routing failed (%v) — using default %q with reason=%s",
 				issue.Number, err, r.cfg.Model.Default, ReasonRouterError)
-			return r.cfg.Model.Default, ReasonRouterError
+			return BackendDecision{Backend: r.cfg.Model.Default, Reason: ReasonRouterError, TaskType: routeDecision.TaskType}
 		}
-		if routedBackend != "" {
-			log.Printf("[router] issue #%d → %s (auto: %s)", issue.Number, routedBackend, routeReason)
-			return routedBackend, ReasonAuto
+		taskType := normalizeTaskType(routeDecision.TaskType)
+		if taskType != "" {
+			if mappedBackend := strings.TrimSpace(r.cfg.Routing.TaskTypeBackends[taskType]); mappedBackend != "" {
+				validated, ok := ValidateBackend(mappedBackend, r.cfg)
+				if !ok {
+					log.Printf("[router] issue #%d: task_type=%s maps to unknown backend %q — using default %q with reason=%s",
+						issue.Number, taskType, mappedBackend, r.cfg.Model.Default, ReasonRouterError)
+					return BackendDecision{Backend: validated, Reason: ReasonRouterError, TaskType: taskType}
+				}
+				log.Printf("[router] issue #%d → %s (auto task_type=%s mapped from router backend=%s: %s)",
+					issue.Number, validated, taskType, routeDecision.Backend, routeDecision.Reason)
+				return BackendDecision{Backend: validated, Reason: ReasonAuto, TaskType: taskType}
+			}
+		}
+		if routeDecision.Backend != "" {
+			log.Printf("[router] issue #%d → %s (auto task_type=%s: %s)", issue.Number, routeDecision.Backend, taskType, routeDecision.Reason)
+			return BackendDecision{Backend: routeDecision.Backend, Reason: ReasonAuto, TaskType: taskType}
 		}
 		// Auto-routing returned empty without an error — treat as router_error too
 		// so the dashboard can distinguish silent fallback from manual mode.
 		log.Printf("[router] issue #%d: auto-routing returned empty backend — using default %q with reason=%s",
 			issue.Number, r.cfg.Model.Default, ReasonRouterError)
-		return r.cfg.Model.Default, ReasonRouterError
+		return BackendDecision{Backend: r.cfg.Model.Default, Reason: ReasonRouterError, TaskType: taskType}
 	}
 
 	// 3. Default backend
-	return r.cfg.Model.Default, ReasonDefault
+	return BackendDecision{Backend: r.cfg.Model.Default, Reason: ReasonDefault}
 }
 
 // roleBackend returns the configured backend name for a given role, or empty string if not set.

--- a/internal/router/resolve_test.go
+++ b/internal/router/resolve_test.go
@@ -294,6 +294,101 @@ func TestResolveBackend_AutoRoutingViaRouteFn(t *testing.T) {
 	}
 }
 
+func TestResolveBackend_AutoRoutingTaskTypeMappingWinsBeforeBackendPick(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "codex",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+				"gemini": {Cmd: "gemini"},
+			},
+		},
+		Routing: config.RoutingConfig{
+			Mode: "auto",
+			TaskTypeBackends: map[string]string{
+				TaskTypeVision: "claude",
+			},
+		},
+	}
+	r := New(cfg)
+	r.DecisionFn = func(issue github.Issue) (Decision, error) {
+		return Decision{Backend: "gemini", TaskType: TaskTypeVision, Reason: "image-heavy UI issue"}, nil
+	}
+
+	decision := r.ResolveBackendDecision(makeIssue(658, "Match screenshot"))
+	if decision.Backend != "claude" {
+		t.Fatalf("Backend = %q, want claude from vision task_type mapping", decision.Backend)
+	}
+	if decision.Reason != ReasonAuto {
+		t.Fatalf("Reason = %q, want %q", decision.Reason, ReasonAuto)
+	}
+	if decision.TaskType != TaskTypeVision {
+		t.Fatalf("TaskType = %q, want %q", decision.TaskType, TaskTypeVision)
+	}
+}
+
+func TestResolveBackend_AutoRoutingTaskTypeWithoutMappingUsesBackendPick(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "codex",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+				"gemini": {Cmd: "gemini"},
+			},
+		},
+		Routing: config.RoutingConfig{Mode: "auto"},
+	}
+	r := New(cfg)
+	r.DecisionFn = func(issue github.Issue) (Decision, error) {
+		return Decision{Backend: "gemini", TaskType: TaskTypeVision, Reason: "image-heavy UI issue"}, nil
+	}
+
+	decision := r.ResolveBackendDecision(makeIssue(659, "Inspect screenshot"))
+	if decision.Backend != "gemini" {
+		t.Fatalf("Backend = %q, want router backend pick gemini", decision.Backend)
+	}
+	if decision.TaskType != TaskTypeVision {
+		t.Fatalf("TaskType = %q, want %q", decision.TaskType, TaskTypeVision)
+	}
+}
+
+func TestResolveBackend_ManualModeIgnoresTaskTypeBackends(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "codex",
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+		Routing: config.RoutingConfig{
+			Mode: "manual",
+			TaskTypeBackends: map[string]string{
+				TaskTypeVision: "claude",
+			},
+		},
+	}
+	r := New(cfg)
+	routerCalled := false
+	r.DecisionFn = func(issue github.Issue) (Decision, error) {
+		routerCalled = true
+		return Decision{Backend: "claude", TaskType: TaskTypeVision, Reason: "vision"}, nil
+	}
+
+	decision := r.ResolveBackendDecision(makeIssue(660, "Screenshot task"))
+	if decision.Backend != "codex" || decision.Reason != ReasonDefault {
+		t.Fatalf("decision = %+v, want codex/default", decision)
+	}
+	if decision.TaskType != "" {
+		t.Fatalf("TaskType = %q, want empty in manual mode", decision.TaskType)
+	}
+	if routerCalled {
+		t.Fatal("manual mode must not call router even when task_type_backends is configured")
+	}
+}
+
 func TestRoute_UsesBackendCommandPrefixArgs(t *testing.T) {
 	dir := t.TempDir()
 	argsPath := filepath.Join(dir, "args.txt")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -11,18 +11,37 @@ import (
 	"github.com/befeast/maestro/internal/github"
 )
 
-const defaultRouterPrompt = `Given this GitHub issue, choose the best AI coding backend.
+const defaultRouterPrompt = `Given this GitHub issue, choose the best AI coding backend and classify the task type.
 Available backends: {{BACKENDS}}
+Task types: refactor, bugfix, test, vision, design, docs, infra
 
 Issue: #{{NUMBER}} — {{TITLE}}
 {{BODY}}
 
-Return JSON only: {"backend": "<name>", "reason": "<one sentence>"}`
+Return JSON only: {"backend": "<name>", "task_type": "<task type>", "reason": "<one sentence>"}`
+
+const (
+	TaskTypeRefactor = "refactor"
+	TaskTypeBugfix   = "bugfix"
+	TaskTypeTest     = "test"
+	TaskTypeVision   = "vision"
+	TaskTypeDesign   = "design"
+	TaskTypeDocs     = "docs"
+	TaskTypeInfra    = "infra"
+)
 
 // routerResponse is the expected JSON response from the router model.
 type routerResponse struct {
-	Backend string `json:"backend"`
-	Reason  string `json:"reason"`
+	Backend  string `json:"backend"`
+	TaskType string `json:"task_type"`
+	Reason   string `json:"reason"`
+}
+
+// Decision is the structured router result used by auto-routing.
+type Decision struct {
+	Backend  string
+	TaskType string
+	Reason   string
 }
 
 // Router selects the best backend for a given issue using an LLM call.
@@ -31,6 +50,10 @@ type Router struct {
 
 	// RouteFn overrides the default Route method (used in tests).
 	RouteFn func(issue github.Issue) (string, string, error)
+
+	// DecisionFn overrides the default RouteDecision method (used in tests
+	// that need task_type-aware routing).
+	DecisionFn func(issue github.Issue) (Decision, error)
 }
 
 // New creates a new Router.
@@ -44,18 +67,25 @@ func New(cfg *config.Config) *Router {
 // default backend and a non-nil error so callers can distinguish a real
 // auto-routed pick from a silent fallback (#427).
 func (r *Router) Route(issue github.Issue) (backendName string, reason string, err error) {
+	decision, err := r.RouteDecision(issue)
+	return decision.Backend, decision.Reason, err
+}
+
+// RouteDecision calls the router model and returns the structured backend
+// decision including the task taxonomy classification.
+func (r *Router) RouteDecision(issue github.Issue) (Decision, error) {
 	prompt := r.buildPrompt(issue)
 
 	output, err := r.callModel(prompt)
 	if err != nil {
 		log.Printf("[router] model call failed: %v — falling back to default", err)
-		return r.cfg.Model.Default, "router error", err
+		return Decision{Backend: r.cfg.Model.Default, Reason: "router error"}, err
 	}
 
 	resp, err := parseResponse(output)
 	if err != nil {
 		log.Printf("[router] parse response failed: %v — falling back to default", err)
-		return r.cfg.Model.Default, "parse error", err
+		return Decision{Backend: r.cfg.Model.Default, Reason: "parse error"}, err
 	}
 
 	// Validate that the chosen backend exists in config. Return an error so
@@ -63,10 +93,10 @@ func (r *Router) Route(issue github.Issue) (backendName string, reason string, e
 	// silently presenting the default backend as if it was task-routed (#427).
 	if _, ok := r.cfg.Model.Backends[resp.Backend]; !ok {
 		log.Printf("[router] unknown backend %q — falling back to default", resp.Backend)
-		return r.cfg.Model.Default, fmt.Sprintf("unknown backend %q", resp.Backend), fmt.Errorf("router picked unknown backend %q", resp.Backend)
+		return Decision{Backend: r.cfg.Model.Default, TaskType: resp.TaskType, Reason: fmt.Sprintf("unknown backend %q", resp.Backend)}, fmt.Errorf("router picked unknown backend %q", resp.Backend)
 	}
 
-	return resp.Backend, resp.Reason, nil
+	return Decision{Backend: resp.Backend, TaskType: resp.TaskType, Reason: resp.Reason}, nil
 }
 
 // buildPrompt constructs the router prompt from the template and issue data.
@@ -143,10 +173,8 @@ func hasModelArg(args []string) bool {
 // parseResponse extracts a JSON object from the model output.
 // The model may include extra text around the JSON, so we find and extract it.
 func parseResponse(output string) (routerResponse, error) {
-	var resp routerResponse
-
 	// Try direct unmarshal first
-	if err := json.Unmarshal([]byte(output), &resp); err == nil && resp.Backend != "" {
+	if resp, err := decodeRouterResponse(output); err == nil {
 		return resp, nil
 	}
 
@@ -155,12 +183,46 @@ func parseResponse(output string) (routerResponse, error) {
 	end := strings.LastIndex(output, "}")
 	if start >= 0 && end > start {
 		jsonStr := output[start : end+1]
-		if err := json.Unmarshal([]byte(jsonStr), &resp); err == nil && resp.Backend != "" {
+		if resp, err := decodeRouterResponse(jsonStr); err == nil {
 			return resp, nil
 		}
 	}
 
-	return resp, fmt.Errorf("no valid JSON with backend field in output: %s", truncate(output, 200))
+	return routerResponse{}, fmt.Errorf("no valid JSON with backend field in output: %s", truncate(output, 200))
+}
+
+func normalizeTaskType(taskType string) string {
+	taskType = strings.ToLower(strings.TrimSpace(taskType))
+	if IsTaskType(taskType) {
+		return taskType
+	}
+	return ""
+}
+
+func IsTaskType(taskType string) bool {
+	switch taskType {
+	case TaskTypeRefactor, TaskTypeBugfix, TaskTypeTest, TaskTypeVision, TaskTypeDesign, TaskTypeDocs, TaskTypeInfra:
+		return true
+	default:
+		return false
+	}
+}
+
+func decodeRouterResponse(output string) (routerResponse, error) {
+	var resp routerResponse
+	if err := json.Unmarshal([]byte(output), &resp); err != nil {
+		return resp, err
+	}
+	if strings.TrimSpace(resp.Backend) == "" {
+		return resp, fmt.Errorf("missing backend")
+	}
+	resp.Backend = strings.TrimSpace(resp.Backend)
+	rawTaskType := resp.TaskType
+	resp.TaskType = normalizeTaskType(resp.TaskType)
+	if strings.TrimSpace(rawTaskType) != "" && resp.TaskType == "" {
+		return resp, fmt.Errorf("invalid task_type %q", rawTaskType)
+	}
+	return resp, nil
 }
 
 func truncate(s string, max int) string {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestParseResponse_ValidJSON(t *testing.T) {
-	resp, err := parseResponse(`{"backend": "codex", "reason": "simple bug fix"}`)
+	resp, err := parseResponse(`{"backend": "codex", "task_type": "bugfix", "reason": "simple bug fix"}`)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -18,11 +18,14 @@ func TestParseResponse_ValidJSON(t *testing.T) {
 	if resp.Reason != "simple bug fix" {
 		t.Errorf("reason = %q, want %q", resp.Reason, "simple bug fix")
 	}
+	if resp.TaskType != TaskTypeBugfix {
+		t.Errorf("task_type = %q, want %q", resp.TaskType, TaskTypeBugfix)
+	}
 }
 
 func TestParseResponse_JSONWithSurroundingText(t *testing.T) {
 	input := `Here is my analysis:
-{"backend": "claude", "reason": "multi-file refactor"}
+{"backend": "claude", "task_type": "refactor", "reason": "multi-file refactor"}
 That's my recommendation.`
 	resp, err := parseResponse(input)
 	if err != nil {
@@ -30,6 +33,16 @@ That's my recommendation.`
 	}
 	if resp.Backend != "claude" {
 		t.Errorf("backend = %q, want %q", resp.Backend, "claude")
+	}
+	if resp.TaskType != TaskTypeRefactor {
+		t.Errorf("task_type = %q, want %q", resp.TaskType, TaskTypeRefactor)
+	}
+}
+
+func TestParseResponse_InvalidTaskType(t *testing.T) {
+	_, err := parseResponse(`{"backend": "codex", "task_type": "feature", "reason": "new feature"}`)
+	if err == nil {
+		t.Error("expected error for invalid task_type")
 	}
 }
 
@@ -82,6 +95,9 @@ func TestBuildPrompt_DefaultTemplate(t *testing.T) {
 	// Should contain both backend names (order may vary)
 	if !contains(prompt, "claude") || !contains(prompt, "codex") {
 		t.Error("prompt should contain backend names")
+	}
+	if !contains(prompt, "task_type") || !contains(prompt, "vision") || !contains(prompt, "design") {
+		t.Error("prompt should request task_type classification with enum values")
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -83,6 +83,7 @@ type BackendCandidate struct {
 type BackendSelection struct {
 	SelectedBackend string             `json:"selected_backend,omitempty"`
 	SelectionReason string             `json:"selection_reason"`
+	TaskType        string             `json:"task_type,omitempty"`
 	CandidateScores []BackendCandidate `json:"candidate_scores,omitempty"`
 	HardPin         bool               `json:"hard_pin,omitempty"`
 	PreviousBackend string             `json:"previous_backend,omitempty"`
@@ -170,6 +171,7 @@ type BackendAttribution struct {
 	Model     string     `json:"model,omitempty"`      // opus-4.8, gpt-5.5, llama-3.3-70b-versatile, …
 	Variant   string     `json:"variant,omitempty"`    // opus[1m], fast, sonnet, …
 	Effort    string     `json:"effort,omitempty"`     // xhigh, medium, low, …
+	TaskType  string     `json:"task_type,omitempty"`  // router classification: refactor, bugfix, test, vision, design, docs, infra
 	StartedAt time.Time  `json:"started_at"`           // when this segment became active
 	EndedAt   *time.Time `json:"ended_at,omitempty"`   // when the segment was closed; nil if still active
 	EndReason string     `json:"end_reason,omitempty"` // why the segment closed: "completed", "provider_limit", "fallover", "in_place_respawn", "killed"

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -60,6 +60,50 @@ func TestNotifiedCIFail_Persistence(t *testing.T) {
 	}
 }
 
+func TestBackendTaskTypePersistence(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber: 42,
+		Status:      StatusRunning,
+		StartedAt:   now,
+		Backend:     "claude",
+		BackendSelection: &BackendSelection{
+			SelectedBackend: "claude",
+			SelectionReason: "auto",
+			TaskType:        "vision",
+		},
+		Attribution: []BackendAttribution{
+			{
+				Backend:   "claude",
+				TaskType:  "vision",
+				StartedAt: now,
+				Reason:    "initial_spawn",
+			},
+		},
+	}
+
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	sess := loaded.Sessions["slot-1"]
+	if sess == nil {
+		t.Fatal("slot-1 not found after load")
+	}
+	if sess.BackendSelection == nil || sess.BackendSelection.TaskType != "vision" {
+		t.Fatalf("BackendSelection = %+v, want task_type vision", sess.BackendSelection)
+	}
+	if len(sess.Attribution) != 1 || sess.Attribution[0].TaskType != "vision" {
+		t.Fatalf("Attribution = %+v, want task_type vision", sess.Attribution)
+	}
+}
+
 func TestDonePRCount(t *testing.T) {
 	s := NewState()
 	s.Sessions["merged-1"] = &Session{IssueNumber: 1, Status: StatusDone, PRNumber: 10}


### PR DESCRIPTION
Refs #658

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads a `task_type` classification (`refactor`, `bugfix`, `test`, `vision`, `design`, `docs`, `infra`) from the LLM router all the way through to session state, and adds an optional `routing.task_type_backends` config map that can redirect specific task types to a preferred backend before the router's own backend pick is used.

- New `Decision` / `BackendDecision` structs replace the old two-value `(backend, reason)` returns throughout `router`, `orchestrator`, and `main.go`, with `TaskType` stamped on both `BackendSelection` and the first `BackendAttribution` segment.
- `task_type_backends` is validated at config-parse time (unknown task types and undeclared backends are rejected), only activated in `routing.mode: auto`, and the routing priority is: label → task-type map → router backend pick → default.
- The `RouteFn` shim maintains backward compat for existing tests that don't exercise task-type routing.

<h3>Confidence Score: 3/5</h3>

Core routing is correct when the LLM behaves perfectly, but a real failure mode exists when it returns a valid backend alongside an unrecognized task type — the entire response is rejected and the default backend is used instead of the one the LLM chose.

The decodeRouterResponse function returns an error for any non-empty, non-enumerated task_type value, which bubbles up as a parse error and silently replaces the LLM's backend pick with model.default. This affects every production deployment running routing.mode: auto whenever the router model returns a slightly different task classification than the hard-coded seven values, which LLMs do routinely. The task_type_backends override path and the state-stamping are otherwise well-implemented.

internal/router/router.go — specifically the decodeRouterResponse function

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/router/router.go | Adds task_type classification to router response; strict unknown-task_type validation in decodeRouterResponse silently falls back to default backend even when backend pick is valid |
| internal/router/resolve.go | Adds ResolveBackendDecision returning BackendDecision with TaskType; task_type_backends mapping logic and RouteFn compat shim look correct |
| internal/config/config.go | Adds TaskTypeBackends field with normalization and full validation at parse time; duplicates the valid-task-type set already defined in router.go as IsTaskType |
| internal/orchestrator/orchestrator.go | Switches to resolveBackendDecision and stamps TaskType on BackendSelection and Attribution; reflect.DeepEqual fix for RoutingConfig is correct |
| cmd/maestro/main.go | Switches spawnCmd to ResolveBackendDecision and stamps session metadata; nil check on sess is appropriate |
| internal/state/state.go | Adds TaskType string field to BackendSelection and BackendAttribution with json tags; straightforward schema addition |
| internal/router/resolve_test.go | Adds three new resolve tests covering task_type mapping, fallthrough, and manual mode isolation; good coverage |
| internal/router/router_test.go | Extends existing parse tests with task_type assertions and adds TestParseResponse_InvalidTaskType; covers validation path |
| internal/orchestrator/orchestrator_test.go | Updates mock to DecisionFn and adds Attribution/BackendSelection.TaskType assertions; solid test update |
| internal/config/config_test.go | Adds three parse tests for task_type_backends; covers normalization, unknown task type, and unknown backend rejections |
| internal/state/state_test.go | Adds persistence round-trip test for TaskType in BackendSelection and Attribution; straightforward |
| docs/gemini-backend.md | Documents task_type_backends YAML config with example; correctly notes the field is inert in manual mode |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/config/config.go`, line 1106-1113 ([link](https://github.com/befeast/maestro/blob/a4377f427ef674cbf46bccd30e6f3ecc379220f3/internal/config/config.go#L1106-L1113)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Duplicate task-type enumeration — `validRoutingTaskType` here and `IsTaskType` in `router.go` both hard-code the same seven values. If a new task type is added to the router constants in the future, this function also needs updating independently, with no compiler help to catch the omission. Since `config` cannot import `router`, one pragmatic fix is to expose the valid set as a slice from `router` and have the config test import it, or to factor both into a shared internal package.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/config/config.go
   Line: 1106-1113

   Comment:
   Duplicate task-type enumeration — `validRoutingTaskType` here and `IsTaskType` in `router.go` both hard-code the same seven values. If a new task type is added to the router constants in the future, this function also needs updating independently, with no compiler help to catch the omission. Since `config` cannot import `router`, one pragmatic fix is to expose the valid set as a slice from `router` and have the config test import it, or to factor both into a shared internal package.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/router/router.go:220-225
An unrecognized but non-empty `task_type` from the LLM causes `decodeRouterResponse` to return an error, which propagates through `parseResponse` → `RouteDecision` → `ResolveBackendDecision` as a "parse error", silently falling back to `model.default` with `ReasonRouterError`. This discards a perfectly valid `backend` pick. LLMs occasionally return values like `"feature"` or `"enhancement"` instead of the enumerated set, so this will silently override the intended backend in production. The invalid `task_type` should be logged and dropped rather than failing the whole parse.

```suggestion
	rawTaskType := resp.TaskType
	resp.TaskType = normalizeTaskType(resp.TaskType)
	if strings.TrimSpace(rawTaskType) != "" && resp.TaskType == "" {
		log.Printf("[router] unknown task_type %q — ignoring", rawTaskType)
	}
	return resp, nil
```

### Issue 2 of 2
internal/config/config.go:1106-1113
Duplicate task-type enumeration — `validRoutingTaskType` here and `IsTaskType` in `router.go` both hard-code the same seven values. If a new task type is added to the router constants in the future, this function also needs updating independently, with no compiler help to catch the omission. Since `config` cannot import `router`, one pragmatic fix is to expose the valid set as a slice from `router` and have the config test import it, or to factor both into a shared internal package.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["router: add task-type backend mapping"](https://github.com/befeast/maestro/commit/a4377f427ef674cbf46bccd30e6f3ecc379220f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35581504)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->