### PR TITLE
supervisor: spawn_repair_worker decision not in executor registry — review-repair silently refused

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -336,6 +336,32 @@ func (e *Executor) dispatchAction(approval *state.Approval) Result {
 			Status:  state.ApprovalStatusAwaitingDispatch,
 			Summary: summary,
 		}
+	case "spawn_repair_worker":
+		// #662: classic repair worker. Same shape as spawn_worker —
+		// the orchestrator's dispatcher loop (supervisorSelectedRepairSpawn)
+		// owns the actual respawn for the open-PR-not-progressing and
+		// retry-exhausted-without-PR cases. Returning AwaitingDispatch
+		// keeps the approval effective so RecordPendingApprovalForDecision's
+		// at-mint dedup coalesces fresh recommendations until the
+		// dispatcher resolves it; before #662 this verb fell through
+		// to the unknown-action default and cautious projects refused
+		// to mint the approval every cycle (silent stall).
+		pr, issue := 0, 0
+		if approval.Target != nil {
+			pr = approval.Target.PR
+			issue = approval.Target.Issue
+		}
+		summary := "spawn_repair_worker approval recorded; next dispatcher loop will start the repair worker"
+		switch {
+		case pr > 0 && issue > 0:
+			summary = fmt.Sprintf("spawn_repair_worker for issue #%d (PR #%d) approved; next dispatcher loop will start the repair worker (no extra command required)", issue, pr)
+		case issue > 0:
+			summary = fmt.Sprintf("spawn_repair_worker for issue #%d approved; next dispatcher loop will start the repair worker (no extra command required)", issue)
+		}
+		return Result{
+			Status:  state.ApprovalStatusAwaitingDispatch,
+			Summary: summary,
+		}
 	case "open_child_issue":
 		// Same shape as spawn_worker: the v1 supervisor records the
 		// intent, but the safe-action executor for create_issue lands

--- a/internal/approver/registry.go
+++ b/internal/approver/registry.go
@@ -4,9 +4,11 @@ package approver
 // verbs the executor knows how to handle. The supervisor and any other
 // approval-mint surface MUST consult this registry before persisting a
 // pending approval; minting a verb the executor does not implement leads
-// to the silent execution_failed loop seen on dogfood 2026-05-30
-// (spawn_repair_worker piled up 4 execution_failed records before an
-// operator noticed).
+// to the silent execution_failed loop seen on dogfood 2026-05-30 (an
+// earlier shape of `spawn_repair_worker` piled up 4 execution_failed
+// records before an operator noticed; #662 then resurfaced the issue on
+// cautious projects where the verb was still emitted but the executor
+// had no case — fix lands `spawn_repair_worker` as awaiting_dispatch).
 //
 // Adding a new approval-required verb is a TWO-step deliberate change:
 //   1. Add a case in executor.go::Execute() switch.
@@ -34,9 +36,18 @@ var KnownApprovalActions = map[string]struct{}{
 	// #565: auto review-repair respawn. Executor returns awaiting_dispatch
 	// — the orchestrator's dispatcher spawns a scoped opus repair worker
 	// keyed on (pr_number, head_sha) so the same head is never
-	// re-attempted. Replaces the refused `spawn_repair_worker` verb for
-	// the green+retry_exhausted+P0/P1-on-head case.
+	// re-attempted. Covers the green+retry_exhausted+P0/P1-on-head case;
+	// orthogonal to `spawn_repair_worker` below, which covers the
+	// not-progressing / retry-exhausted-without-PR cases.
 	"spawn_review_repair": {},
+	// #662: classic repair worker. Executor returns awaiting_dispatch —
+	// the orchestrator's dispatcher loop owns the actual respawn (see
+	// supervisorSelectedRepairSpawn in internal/orchestrator). Before
+	// #662 the supervisor emitted this verb deterministically (open PR
+	// not progressing, retry-exhausted with no usable PR) but the
+	// executor had no case, so cautious projects refused to mint the
+	// approval every cycle and the issue stalled silently.
+	"spawn_repair_worker": {},
 	// #567: per-session worker-control verbs surfaced by the fleet
 	// Mission Control snapshot. Executor calls into the WorkerController
 	// to kill the tmux session + (for restart) flag the slot for the

--- a/internal/approver/registry_test.go
+++ b/internal/approver/registry_test.go
@@ -52,12 +52,12 @@ func TestRegistry_IsKnownApprovalAction(t *testing.T) {
 		{"spawn_review_repair", true}, // #565: auto review-repair respawn
 		{"restart_worker", true},      // #567: per-session worker-control
 		{"stop_worker", true},         // #567: per-session worker-control
+		{"spawn_repair_worker", true}, // #662: classic repair worker (awaiting_dispatch)
 
 		// Negative cases — the live-found bugs.
 		{"spawn_repair_repair", false},
-		{"spawn_repair_worker", false}, // dogfood 2026-05-30: minted by LLM, never implemented
-		{"approve_merge", false},       // UI verb — server translates to merge_pr before enqueue
-		{"add_ready_label", false},     // safe action, NOT in approval registry
+		{"approve_merge", false},   // UI verb — server translates to merge_pr before enqueue
+		{"add_ready_label", false}, // safe action, NOT in approval registry
 		{"", false},
 	}
 	for _, tc := range cases {

--- a/internal/approver/review_repair_test.go
+++ b/internal/approver/review_repair_test.go
@@ -33,17 +33,31 @@ func TestExecute_SpawnReviewRepair_ReturnsAwaitingDispatch(t *testing.T) {
 	}
 }
 
-// Negative: the refused legacy verb stays refused — the registry's job
-// is to surface the failure loudly at mint, not silently.
-func TestExecute_SpawnRepairWorker_StillUnknownAction(t *testing.T) {
+// #662: spawn_repair_worker is now a registry verb so cautious projects
+// can mint the approval and the orchestrator's dispatcher loop can
+// actually start the repair worker. Before #662 the supervisor emitted
+// this verb from the deterministic path (open PR not progressing,
+// retry-exhausted with no usable PR) but the executor had no case, so
+// the at-mint guard refused the approval every cycle and the issue
+// stalled silently. Same dispatcher shape as spawn_worker.
+func TestExecute_SpawnRepairWorker_ReturnsAwaitingDispatch(t *testing.T) {
 	ex := &Executor{Cfg: newCfg()}
-	a := mkApproval("spawn_repair_worker", &state.SupervisorTarget{Issue: 442, PR: 564}, "legacy verb", "")
+	a := mkApproval("spawn_repair_worker", &state.SupervisorTarget{Issue: 442, PR: 564}, "repair worker", "")
 
 	res := ex.Execute(a)
-	if res.Status != state.ApprovalStatusExecutionFailed {
-		t.Fatalf("status = %q, want execution_failed (legacy verb must not silently land)", res.Status)
+	if res.Status != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("status = %q, want %q (#662)", res.Status, state.ApprovalStatusAwaitingDispatch)
 	}
-	if res.Err == nil {
-		t.Fatal("err = nil, want unknown-action error")
+	if !strings.Contains(res.Summary, "#442") {
+		t.Fatalf("summary = %q, want issue #442 reference", res.Summary)
+	}
+	if !strings.Contains(res.Summary, "#564") {
+		t.Fatalf("summary = %q, want PR #564 reference", res.Summary)
+	}
+	if !strings.Contains(strings.ToLower(res.Summary), "dispatcher") {
+		t.Fatalf("summary = %q, want dispatcher mention so operator knows next step", res.Summary)
+	}
+	if res.Err != nil {
+		t.Fatalf("err = %v, want nil for awaiting-dispatch", res.Err)
 	}
 }

--- a/internal/supervisor/registry_drift_test.go
+++ b/internal/supervisor/registry_drift_test.go
@@ -1,0 +1,109 @@
+package supervisor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/approver"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #662: every mutating action constant the supervisor's decision layer can
+// emit MUST be in the executor registry (approver.KnownApprovalActions).
+// Otherwise the at-mint guard refuses the verb every cycle on a cautious
+// project and the issue stalls silently — the bug this PR fixes for
+// spawn_repair_worker.
+//
+// The list below is the explicit set of mutating/approval-gated action
+// constants exported from this package. Add to this list any new
+// ActionXxx constant that the decision layer routes to RiskMutating or
+// RiskApprovalGated; the test then fails until the executor learns the
+// verb (executor.go switch + registry.go KnownApprovalActions).
+func TestSupervisorMutatingActions_AreInExecutorRegistry(t *testing.T) {
+	mutatingActions := []string{
+		ActionSpawnWorker,
+		ActionSpawnRepairWorker,
+		ActionSpawnReviewRepair,
+		ActionMergePR,
+		ActionOpenChildIssue,
+	}
+	for _, action := range mutatingActions {
+		action := action
+		t.Run(action, func(t *testing.T) {
+			if !approver.IsKnownApprovalAction(action) {
+				t.Fatalf("supervisor emits %q but it is NOT in approver.KnownApprovalActions = %v — at-mint guard would refuse every cycle (#662)", action, approver.KnownApprovalActionList())
+			}
+		})
+	}
+}
+
+// #662 regression: a dead session with a draft + failing PR triggers the
+// deterministic spawn_repair_worker decision. The resulting action MUST
+// be registry-supported so the at-mint guard does not refuse the
+// approval on cautious projects. Without this pin we re-introduce the
+// silent stall (live evidence in #662: "refusing to mint approval:
+// action \"spawn_repair_worker\" is not in the executor registry").
+func TestDecide_SpawnRepairWorkerDecision_IsRegistrySupported(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{
+		prs: []github.PR{{
+			Number:      7,
+			HeadRefName: "feat/checks",
+			State:       "OPEN",
+			Mergeable:   "MERGEABLE",
+			IsDraft:     true,
+		}},
+		ciStatuses: map[int]string{7: "failure"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 1,
+		IssueTitle:  "spawn repair regression",
+		Status:      state.StatusDead,
+		PRNumber:    7,
+		Branch:      "feat/checks",
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnRepairWorker {
+		t.Fatalf("action = %q, want %q (deterministic open-PR-not-progressing path)", decision.RecommendedAction, ActionSpawnRepairWorker)
+	}
+	if !approver.IsKnownApprovalAction(decision.RecommendedAction) {
+		t.Fatalf("decision.RecommendedAction = %q is not in approver.KnownApprovalActions = %v — at-mint guard would refuse and the project would stall silently (#662)", decision.RecommendedAction, approver.KnownApprovalActionList())
+	}
+}
+
+// #662 regression: a retry-exhausted ready-labeled issue with no usable
+// PR triggers the other deterministic spawn_repair_worker emission
+// site. Same registry contract applies.
+func TestDecide_RetryExhaustedRepairCandidate_IsRegistrySupported(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
+	reader := &fakeReader{issues: []github.Issue{
+		withProjectStatus(testIssue(808, "registry drift regression", "maestro-ready"), "Blocked"),
+	}}
+	st := state.NewState()
+	st.Sessions["pan-72"] = &state.Session{
+		IssueNumber: 808,
+		IssueTitle:  "registry drift regression",
+		Status:      state.StatusRetryExhausted,
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnRepairWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnRepairWorker)
+	}
+	if !approver.IsKnownApprovalAction(decision.RecommendedAction) {
+		t.Fatalf("decision.RecommendedAction = %q is not in approver.KnownApprovalActions = %v — at-mint guard would refuse and the project would stall silently (#662)", decision.RecommendedAction, approver.KnownApprovalActionList())
+	}
+}


### PR DESCRIPTION
Refs #662

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent stall on cautious projects where the supervisor deterministically emitted `spawn_repair_worker` (for open-PR-not-progressing and retry-exhausted-without-PR sessions) but the executor had no matching case, causing the at-mint guard to refuse the approval every cycle.

- **`executor.go` + `registry.go`**: adds `spawn_repair_worker` as an `AwaitingDispatch` case in the executor switch and registers it in `KnownApprovalActions`, following the exact same pattern as `spawn_worker` and `spawn_review_repair`.
- **`review_repair_test.go` / `registry_test.go`**: flips `spawn_repair_worker` from negative to positive test cases and strengthens assertions to cover the issue/PR mention and dispatcher reference in the summary.
- **`registry_drift_test.go`** (new): adds an enum-style drift guard that fails the build if any mutating supervisor action constant is absent from the executor registry, plus two deterministic regression tests that exercise both `spawn_repair_worker` emission paths end-to-end.

<h3>Confidence Score: 4/5</h3>

The core fix is straightforward and well-tested; the only follow-up needed is a comment update in the unchanged supervisor.go guard before future maintainers misread the now-wrong rationale.

The executor and registry changes are minimal and pattern-consistent. The new drift guard test is a strong regression net. The only concern is a stale justification comment in supervisor.go (not touched by this PR) that now incorrectly explains the StatusRetryExhausted early-return — the guard itself remains correct, but the comment says the executor refuses the verb when the verb is now registered, which could mislead a future reader into removing the guard.

The unchanged supervisor.go openPRNeedsRepair function (around line 2142) has a comment whose rationale is now stale — worth a quick follow-up to update it.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/approver/executor.go | Adds the missing `spawn_repair_worker` case to the executor switch, returning `AwaitingDispatch` — mirrors the `spawn_worker` and `spawn_review_repair` pattern exactly. |
| internal/approver/registry.go | Registers `spawn_repair_worker` in `KnownApprovalActions`, updates the comment to explain the orthogonal relationship with `spawn_review_repair`, and fixes the header comment to reflect the root cause accurately. |
| internal/approver/registry_test.go | Moves `spawn_repair_worker` from the negative (expected-false) to the positive (expected-true) test cases and removes the now-stale dogfood annotation. |
| internal/approver/review_repair_test.go | Replaces the old negative test (expected `execution_failed`) with a positive test checking `awaiting_dispatch`, issue/PR mention, and dispatcher mention in the summary. |
| internal/supervisor/registry_drift_test.go | New integration-level drift guard: enumerates all mutating supervisor actions and asserts each is in the executor registry; also adds two regression tests that exercise the deterministic `spawn_repair_worker` emission paths end-to-end. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/registry_drift_test.go:17
**Stale guard comment in `supervisor.go` now misleads**

The `openPRNeedsRepair` function in `supervisor.go` (~line 2142) still contains:

> `// the executor refuses spawn_repair_worker because the verb is not in the action registry`

as the justification for short-circuiting on `StatusRetryExhausted`. That reason is now factually wrong after this PR lands the verb in the registry. The guard itself is correct (exhausted sessions shouldn't trigger another repair spawn), but a future reader could see the stale rationale, notice the verb is now registered, and remove the guard thinking it's a leftover artefact — silently re-introducing the spawn loop for retry-exhausted sessions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["supervisor: register spawn\_repair\_worker..."](https://github.com/befeast/maestro/commit/e9310e3185908961d0fe8fe4845a84f51b8e5aab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35707489)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->