### PR TITLE
orchestrator: codex tool-exec error (write_stdin/stdin closed) misclassified as backend rate-limit → false fallback + loop

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -56,11 +56,12 @@ type Orchestrator struct {
 	isPRMergedFn          func(prNumber int) (bool, error)
 
 	// Testing hooks for checkSessions
-	captureTmuxFn   func(session string) (string, error)
-	tmuxCaptureFn   func(session string) (string, error)
-	isIssueClosedFn func(issueNumber int) (bool, error)
-	addIssueLabelFn func(number int, label string) error
-	isRateLimitedFn func(logFile string) bool
+	captureTmuxFn           func(session string) (string, error)
+	tmuxCaptureFn           func(session string) (string, error)
+	isIssueClosedFn         func(issueNumber int) (bool, error)
+	addIssueLabelFn         func(number int, label string) error
+	isRateLimitedFn         func(logFile string) bool
+	rateLimitResetFromLogFn func(logFile string) *time.Time
 	// workerRespawnFn / respawnWorkerFn: used by respawnWorker() for dead-worker fallback (tests set one or the other)
 	workerRespawnFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 	respawnWorkerFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
@@ -432,9 +433,18 @@ func (o *Orchestrator) isRateLimited(logFile string) bool {
 
 // rateLimitResetFromLog reads a dead worker's log file and parses the
 // provider-stated reset time ("try again at ...") if present. It returns nil
-// when the log is unreadable or carries no parseable reset hint, so callers can
-// fall back to a reasonable default cooldown.
+// when the log is unreadable or carries no parseable reset hint.
+//
+// Per issue #663, a nil result from this function is the orchestrator's signal
+// that the rate-limit detection is LOW-confidence: the classifier matched a
+// pattern but the provider did not state when the limit resets, so the match
+// may well be a stale prompt-context echo or a transient tool/exec error.
+// Callers that switch backends on rate-limit signals MUST treat nil as "do
+// not fall back" and let the ordinary worker-died path handle the session.
 func (o *Orchestrator) rateLimitResetFromLog(logFile string) *time.Time {
+	if o.rateLimitResetFromLogFn != nil {
+		return o.rateLimitResetFromLogFn(logFile)
+	}
 	if logFile == "" {
 		return nil
 	}
@@ -446,6 +456,25 @@ func (o *Orchestrator) rateLimitResetFromLog(logFile string) *time.Time {
 		return &reset
 	}
 	return nil
+}
+
+// providerRateLimitFromLog returns the high-confidence rate-limit verdict for
+// a dead worker's log. It reports hit=true only when the classifier matches
+// AND a provider-stated reset window is parseable — a positive rate-limit
+// signal in the sense of issue #663. A classifier match without a reset hint
+// is treated as low-confidence and reported as hit=false, so the caller falls
+// through to the ordinary worker-died handling instead of triggering a false
+// backend fallback. The non-nil resetAt is also returned so callers can
+// stamp BackendHealth.RetryAfter without re-reading the log.
+func (o *Orchestrator) providerRateLimitFromLog(logFile string) (hit bool, resetAt *time.Time) {
+	if !o.isRateLimited(logFile) {
+		return false, nil
+	}
+	reset := o.rateLimitResetFromLog(logFile)
+	if reset == nil {
+		return false, nil
+	}
+	return true, reset
 }
 
 func (o *Orchestrator) workerLogFile(slotName string, sess *state.Session) string {
@@ -1658,10 +1687,15 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		// (see :worker-died and :log-scanner paths) — select an available fallback
 		// backend and respawn the session there. Mark the session Dead only when no
 		// fallback is configured / available, or when the respawn itself fails (#506).
-		if o.isRateLimited(sess.LogFile) {
+		//
+		// Per #663, fallback is gated on a positive (parseable-reset) rate-limit
+		// signal. A pattern match without a reset hint is too easy to false-positive
+		// — a stale prompt-context echo, a codex tools-router error, or a transient
+		// stderr line containing "429" — and switching backends on it burns the
+		// more expensive fallback and can loop the session to the retry cap.
+		if hit, resetAt := o.providerRateLimitFromLog(sess.LogFile); hit {
 			now := time.Now().UTC()
 			o.updateTokensUsedFromWorkerLog(slotName, sess)
-			resetAt := o.rateLimitResetFromLog(sess.LogFile)
 			o.recordProviderLimit(s, slotName, sess, "log_rate_limit_reconcile", resetAt, now)
 			selection := o.selectProviderLimitFallback(s, sess, now)
 			sess.BackendSelection = &selection
@@ -2045,11 +2079,15 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					state.MarkPROpened(sess, now)
 					o.notifier.Sendf("🔀 maestro: worker %s completed, PR #%d open for issue #%d (%s)",
 						slotName, pr.Number, sess.IssueNumber, sess.IssueTitle)
-				} else if o.isRateLimited(sess.LogFile) {
+				} else if hit, resetAt := o.providerRateLimitFromLog(sess.LogFile); hit {
 					// Provider capacity limit detected — gate this backend and select a fallback.
+					// Per #663, only a high-confidence signal (parseable reset window)
+					// triggers backend fallback; a pattern match without a reset hint
+					// is too easy to false-positive (stale prompt echo, codex tool-exec
+					// errors, transient stderr containing "429") and is left to the
+					// ordinary retry/canRetryIssue path below.
 					now := time.Now().UTC()
 					o.updateTokensUsedFromWorkerLog(slotName, sess)
-					resetAt := o.rateLimitResetFromLog(sess.LogFile)
 					o.recordProviderLimit(s, slotName, sess, "log_rate_limit", resetAt, now)
 					selection := o.selectProviderLimitFallback(s, sess, now)
 					sess.BackendSelection = &selection
@@ -2161,18 +2199,30 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					o.updateTokensUsedFromOutput(slotName, sess, output)
 
 					// --- Rate-limit detection ---
+					// Per #663, the orchestrator only acts on a HIGH-confidence
+					// rate-limit signal: the classifier must match AND the provider
+					// must have stated a parseable reset window. A bare pattern match
+					// without a reset hint is too easy to false-positive — a stale
+					// prompt-context echo, a codex tools-router error, or a transient
+					// stderr line containing "429" — and killing the worker on it
+					// burns the more-expensive fallback for no reason. A live worker
+					// that is still progressing despite a low-confidence match is left
+					// alone so it can recover (the apertune case from #663).
 					if !sess.RateLimitHit && sess.LastNotifiedStatus != "rate_limit" {
-						if hit, pattern := worker.DetectRateLimit(output); hit {
-							log.Printf("[orch] worker %s hit rate limit (pattern=%s), stopping", slotName, pattern)
+						classifyHit, pattern, confidence, resetTime := worker.ClassifyRateLimit(output)
+						if classifyHit && confidence != "high" {
+							log.Printf("[orch] worker %s rate-limit pattern matched (pattern=%s) but reset window unparseable — treating as low-confidence and letting worker continue (per #663)",
+								slotName, pattern)
+						}
+						if classifyHit && confidence == "high" {
+							log.Printf("[orch] worker %s hit rate limit (pattern=%s, reset=%s), stopping",
+								slotName, pattern, resetTime.Format(time.RFC3339))
 							o.runAfterRunHook(sess)
 							if err := o.stopWorker(slotName, sess); err != nil {
 								log.Printf("[orch] warn: could not stop rate-limited worker %s: %v", slotName, err)
 							}
 							now := time.Now().UTC()
-							var resetAt *time.Time
-							if reset, ok := worker.ParseRateLimitReset(output); ok {
-								resetAt = &reset
-							}
+							resetAt := &resetTime
 							o.recordProviderLimit(s, slotName, sess, pattern, resetAt, now)
 							selection := o.selectProviderLimitFallback(s, sess, now)
 							sess.BackendSelection = &selection

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -543,6 +543,17 @@ func TestReconcileRunningSessions_DeadPIDGetsMarkedDead(t *testing.T) {
 	}
 }
 
+// mockRateLimitReset returns a fixed parseable reset time, used by reconcile
+// rate-limit tests to simulate a high-confidence provider rate-limit response.
+// Per #663, the orchestrator only triggers backend fallback when the
+// rate-limit signal is accompanied by a parseable reset window — tests that
+// want to exercise the fallback path mock this so providerRateLimitFromLog
+// reports hit=true.
+func mockRateLimitReset(string) *time.Time {
+	r := time.Date(2027, time.January, 1, 12, 0, 0, 0, time.UTC)
+	return &r
+}
+
 // TestReconcileRunningSessions_RateLimitedDeadWorker_DoesNotBurnRetryBudget
 // guards #466: when reconcile observes a dead worker whose log carries a
 // provider rate-limit signature, it must record the provider limit and skip
@@ -570,11 +581,12 @@ func TestReconcileRunningSessions_RateLimitedDeadWorker_DoesNotBurnRetryBudget(t
 				Backends: map[string]config.BackendDef{"codex": {Cmd: "codex"}},
 			},
 		},
-		notifier:            &notify.Notifier{},
-		pidAliveFn:          func(pid int) bool { return false },
-		tmuxSessionExistsFn: func(name string) bool { return false },
-		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
-		isRateLimitedFn:     func(logFile string) bool { return true },
+		notifier:                &notify.Notifier{},
+		pidAliveFn:              func(pid int) bool { return false },
+		tmuxSessionExistsFn:     func(name string) bool { return false },
+		listOpenPRsFn:           func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:         func(logFile string) bool { return true },
+		rateLimitResetFromLogFn: mockRateLimitReset,
 	}
 
 	changed := o.reconcileRunningSessions(s)
@@ -639,11 +651,12 @@ func TestReconcileRunningSessions_RateLimitedDeadWorker_FallsOverToNextBackend(t
 				},
 			},
 		},
-		notifier:            &notify.Notifier{},
-		pidAliveFn:          func(pid int) bool { return false },
-		tmuxSessionExistsFn: func(name string) bool { return false },
-		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
-		isRateLimitedFn:     func(logFile string) bool { return true },
+		notifier:                &notify.Notifier{},
+		pidAliveFn:              func(pid int) bool { return false },
+		tmuxSessionExistsFn:     func(name string) bool { return false },
+		listOpenPRsFn:           func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:         func(logFile string) bool { return true },
+		rateLimitResetFromLogFn: mockRateLimitReset,
 		getIssueFn: func(number int) (github.Issue, error) {
 			return github.Issue{Number: number, Title: "ciStatusFromREST returns pending forever"}, nil
 		},
@@ -722,11 +735,12 @@ func TestReconcileRunningSessions_RateLimitedDeadWorker_FallbackRespawnFails_Mar
 				},
 			},
 		},
-		notifier:            &notify.Notifier{},
-		pidAliveFn:          func(pid int) bool { return false },
-		tmuxSessionExistsFn: func(name string) bool { return false },
-		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
-		isRateLimitedFn:     func(logFile string) bool { return true },
+		notifier:                &notify.Notifier{},
+		pidAliveFn:              func(pid int) bool { return false },
+		tmuxSessionExistsFn:     func(name string) bool { return false },
+		listOpenPRsFn:           func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:         func(logFile string) bool { return true },
+		rateLimitResetFromLogFn: mockRateLimitReset,
 		getIssueFn: func(number int) (github.Issue, error) {
 			return github.Issue{Number: number, Title: "ci"}, nil
 		},
@@ -781,11 +795,12 @@ func TestReconcileRunningSessions_RateLimitedDeadWorker_FetchIssueFails_MarksDea
 				},
 			},
 		},
-		notifier:            &notify.Notifier{},
-		pidAliveFn:          func(pid int) bool { return false },
-		tmuxSessionExistsFn: func(name string) bool { return false },
-		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
-		isRateLimitedFn:     func(logFile string) bool { return true },
+		notifier:                &notify.Notifier{},
+		pidAliveFn:              func(pid int) bool { return false },
+		tmuxSessionExistsFn:     func(name string) bool { return false },
+		listOpenPRsFn:           func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:         func(logFile string) bool { return true },
+		rateLimitResetFromLogFn: mockRateLimitReset,
 		getIssueFn: func(number int) (github.Issue, error) {
 			return github.Issue{}, fmt.Errorf("gh transient: rate limit")
 		},
@@ -5572,9 +5587,17 @@ func newRateLimitOrchestrator(cfg *config.Config, tmuxOutput string) (*Orchestra
 
 // newFallbackTestOrchestrator creates an Orchestrator wired for testing
 // rate-limit fallback in checkSessions. It records respawned backends.
+//
+// When rateLimited is true the fixture also mocks rateLimitResetFromLogFn to
+// return a non-nil reset time, mirroring a real high-confidence provider
+// usage-limit response. Per #663, the orchestrator only triggers a backend
+// fallback on a high-confidence signal (parseable reset window); a tests that
+// wants to verify low-confidence behavior should leave rateLimitResetFromLogFn
+// nil (or override it) so providerRateLimitFromLog reports no positive signal.
 func newFallbackTestOrchestrator(cfg *config.Config, rateLimited bool) (*Orchestrator, *[]string) {
 	respawnedBackends := make([]string, 0)
-	return &Orchestrator{
+	fixedReset := time.Date(2027, time.January, 1, 12, 0, 0, 0, time.UTC)
+	o := &Orchestrator{
 		cfg:        cfg,
 		notifier:   &notify.Notifier{},
 		router:     router.New(cfg),
@@ -5603,7 +5626,14 @@ func newFallbackTestOrchestrator(cfg *config.Config, rateLimited bool) (*Orchest
 			sess.FinishedAt = nil
 			return nil
 		},
-	}, &respawnedBackends
+	}
+	if rateLimited {
+		o.rateLimitResetFromLogFn = func(string) *time.Time {
+			r := fixedReset
+			return &r
+		}
+	}
+	return o, &respawnedBackends
 }
 
 // ---- Running-worker rate-limit tests (tmux detection, worker alive) ----
@@ -5617,7 +5647,7 @@ func TestCheckSessions_RateLimitDetected_NoFallback_MarksDead(t *testing.T) {
 			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
 		},
 	}
-	o, stopped, _ := newRateLimitOrchestrator(cfg, "Error: You've hit your limit for today.")
+	o, stopped, _ := newRateLimitOrchestrator(cfg, "Error: You've hit your limit for today. Try again at January 1, 2027 12:00 PM.")
 
 	s := state.NewState()
 	s.Sessions["mae-1"] = &state.Session{
@@ -5664,7 +5694,7 @@ func TestCheckSessions_RateLimitDetected_WithFallback_Respawns(t *testing.T) {
 			},
 		},
 	}
-	o, stopped, respawned := newRateLimitOrchestrator(cfg, "rate limit exceeded â try again later")
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "rate limit exceeded. Try again at January 1, 2027 12:00 PM.")
 
 	s := state.NewState()
 	s.Sessions["mae-2"] = &state.Session{
@@ -5715,7 +5745,7 @@ func TestCheckSessions_RateLimitDetected_DefaultBackendFallback_Respawns(t *test
 			},
 		},
 	}
-	o, stopped, respawned := newRateLimitOrchestrator(cfg, "Error: You've hit your limit for today.")
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "Error: You've hit your limit for today. Try again at January 1, 2027 12:00 PM.")
 
 	s := state.NewState()
 	s.Sessions["mae-default"] = &state.Session{
@@ -5766,7 +5796,7 @@ func TestCheckSessions_RateLimitDetected_NoAvailableFallback_RecordsSelection(t 
 			},
 		},
 	}
-	o, stopped, respawned := newRateLimitOrchestrator(cfg, "Error: You've hit your limit for today.")
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "Error: You've hit your limit for today. Try again at January 1, 2027 12:00 PM.")
 
 	s := state.NewState()
 	s.Sessions["mae-none"] = &state.Session{
@@ -5814,7 +5844,7 @@ func TestCheckSessions_RateLimitDetected_AlreadyOnFallback_MarksDead(t *testing.
 			},
 		},
 	}
-	o, stopped, respawned := newRateLimitOrchestrator(cfg, "Error 429: too many requests")
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "Error 429: too many requests. Try again at January 1, 2027 12:00 PM.")
 
 	s := state.NewState()
 	s.Sessions["mae-3"] = &state.Session{
@@ -5938,7 +5968,7 @@ func TestCheckSessions_RateLimit429Pattern_Detected(t *testing.T) {
 			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
 		},
 	}
-	o, stopped, _ := newRateLimitOrchestrator(cfg, "API returned status 429")
+	o, stopped, _ := newRateLimitOrchestrator(cfg, "API returned status 429. Try again at January 1, 2027 12:00 PM.")
 
 	s := state.NewState()
 	s.Sessions["mae-6"] = &state.Session{
@@ -5963,6 +5993,196 @@ func TestCheckSessions_RateLimit429Pattern_Detected(t *testing.T) {
 	}
 	if len(*stopped) != 1 {
 		t.Fatalf("stopped = %v, want 1 entry", *stopped)
+	}
+}
+
+// TestCheckSessions_RateLimit_LowConfidenceNoFallback_LiveWorker is the
+// #663 regression guard for the live tmux path: when the classifier matches a
+// rate-limit pattern in worker output but no provider-stated reset window is
+// present, the orchestrator must NOT kill the worker and MUST NOT switch
+// backends. The apertune session apt-2 hit a codex tools-router
+// `write_stdin failed: stdin is closed` error and recovered to open a PR;
+// any classifier match without a reset hint is treated the same way — a
+// pass-through, low-confidence signal that the worker is left to resolve.
+func TestCheckSessions_RateLimit_LowConfidenceNoFallback_LiveWorker(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+		Model: config.ModelConfig{
+			Default:          "codex",
+			FallbackBackends: []string{"claude"},
+			Backends: map[string]config.BackendDef{
+				"codex":  {Cmd: "codex"},
+				"claude": {Cmd: "claude"},
+			},
+		},
+	}
+	// "rate limit exceeded" matches the classifier but carries no parseable
+	// reset — the orchestrator must treat this as low-confidence (per #663).
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, "transient: rate limit exceeded once, retrying")
+
+	s := state.NewState()
+	s.Sessions["mae-663-live"] = &state.Session{
+		IssueNumber: 663,
+		IssueTitle:  "issue under test",
+		Status:      state.StatusRunning,
+		PID:         42421,
+		TmuxSession: "maestro-mae-663-live",
+		Branch:      "feat/mae-663-live",
+		Backend:     "codex",
+		StartedAt:   time.Now().Add(-2 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-663-live"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q — low-confidence signal must not kill a live worker (#663)", sess.Status, state.StatusRunning)
+	}
+	if sess.RateLimitHit {
+		t.Fatal("rate_limit_hit must remain false on low-confidence signal (#663)")
+	}
+	if sess.Backend != "codex" {
+		t.Fatalf("backend = %q, want %q — must not switch backends on low-confidence signal", sess.Backend, "codex")
+	}
+	if len(*stopped) != 0 {
+		t.Fatalf("stopped = %v, want empty — must not stop the worker on low-confidence signal", *stopped)
+	}
+	if len(*respawned) != 0 {
+		t.Fatalf("respawned = %v, want empty — must not respawn on low-confidence signal", *respawned)
+	}
+}
+
+// TestCheckSessions_RateLimit_CodexWriteStdinError_NotClassified is the
+// direct #663 regression: a codex tools-router `write_stdin failed: stdin is
+// closed` error, in the exact shape that wedged apertune apt-2, MUST be
+// passed through as ordinary worker output — no kill, no provider-limit
+// record, no fallback selection.
+func TestCheckSessions_RateLimit_CodexWriteStdinError_NotClassified(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRuntimeMinutes: 999,
+		Model: config.ModelConfig{
+			Default:          "codex",
+			FallbackBackends: []string{"claude"},
+			Backends: map[string]config.BackendDef{
+				"codex":  {Cmd: "codex"},
+				"claude": {Cmd: "claude"},
+			},
+		},
+	}
+	tmuxOutput := "2026-06-04T19:41:32Z ERROR codex_core::tools::router: error=write_stdin failed: stdin is closed\nfor this session; rerun exec_command with tty=true to keep stdin open\nworker continued and opened PR.\n"
+	o, stopped, respawned := newRateLimitOrchestrator(cfg, tmuxOutput)
+
+	s := state.NewState()
+	s.Sessions["mae-663-wstdin"] = &state.Session{
+		IssueNumber: 663,
+		IssueTitle:  "apertune apt-2 repro",
+		Status:      state.StatusRunning,
+		PID:         42422,
+		TmuxSession: "maestro-mae-663-wstdin",
+		Branch:      "feat/mae-663-wstdin",
+		Backend:     "codex",
+		StartedAt:   time.Now().Add(-2 * time.Minute),
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["mae-663-wstdin"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q — codex write_stdin error must not be classified as rate-limit (#663)", sess.Status, state.StatusRunning)
+	}
+	if sess.RateLimitHit {
+		t.Fatal("rate_limit_hit must remain false for write_stdin error (#663)")
+	}
+	if sess.ProviderLimitBackend != "" {
+		t.Fatalf("provider_limit_backend = %q, want empty — must not record provider limit (#663)", sess.ProviderLimitBackend)
+	}
+	if sess.BackendSelection != nil {
+		t.Fatalf("backend_selection = %+v, want nil — must not run fallback selector (#663)", sess.BackendSelection)
+	}
+	if len(*stopped) != 0 {
+		t.Fatalf("stopped = %v, want empty (#663)", *stopped)
+	}
+	if len(*respawned) != 0 {
+		t.Fatalf("respawned = %v, want empty (#663)", *respawned)
+	}
+}
+
+// TestReconcileRunningSessions_RateLimit_LowConfidenceNoFallback is the #663
+// regression guard for the reconcile path: when the dead worker's log shows a
+// rate-limit pattern WITHOUT a parseable reset window, the orchestrator must
+// fall through to the ordinary running->dead handling instead of triggering a
+// backend fallback. The reconcile log line `rate-limited on backend=...
+// reset=unknown — respawned with backend=...` that wedged apertune MUST NOT
+// be emitted in this case.
+func TestReconcileRunningSessions_RateLimit_LowConfidenceNoFallback(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["sup-663"] = &state.Session{
+		IssueNumber: 663,
+		IssueTitle:  "apertune apt-2 repro",
+		Status:      state.StatusRunning,
+		PID:         42423,
+		TmuxSession: "maestro-sup-663",
+		Branch:      "feat/sup-663-663-apertune-repro",
+		Backend:     "codex",
+		StartedAt:   time.Now().Add(-2 * time.Minute),
+		LogFile:     "/tmp/sup-663-rl.log",
+	}
+
+	respawnAttempts := []string{}
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			Model: config.ModelConfig{
+				Default:          "codex",
+				FallbackBackends: []string{"claude"},
+				Backends: map[string]config.BackendDef{
+					"codex":  {Cmd: "codex"},
+					"claude": {Cmd: "claude"},
+				},
+			},
+		},
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		// Classifier reports a hit (e.g. stale prompt context echoed "rate limit")...
+		isRateLimitedFn: func(logFile string) bool { return true },
+		// ...but the log carries no parseable reset hint — low confidence.
+		rateLimitResetFromLogFn: func(string) *time.Time { return nil },
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "apertune apt-2 repro"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnAttempts = append(respawnAttempts, backendName)
+			return nil
+		},
+	}
+
+	changed := o.reconcileRunningSessions(s)
+	if !changed {
+		t.Fatal("expected reconciliation to mark dead worker dead")
+	}
+
+	sess := s.Sessions["sup-663"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (ordinary dead path)", sess.Status, state.StatusDead)
+	}
+	if sess.LastNotifiedStatus == "rate_limit" {
+		t.Fatal("last_notified_status must NOT be 'rate_limit' on low-confidence detection (#663)")
+	}
+	if sess.RateLimitHit {
+		t.Fatal("rate_limit_hit must remain false on low-confidence detection (#663)")
+	}
+	if sess.ProviderLimitBackend != "" {
+		t.Fatalf("provider_limit_backend = %q, want empty (#663)", sess.ProviderLimitBackend)
+	}
+	if len(respawnAttempts) != 0 {
+		t.Fatalf("respawnWorkerFn called %v, want no fallback respawn on low-confidence signal (#663)", respawnAttempts)
+	}
+	if _, recorded := s.BackendHealth["codex"]; recorded {
+		t.Fatal("BackendHealth[codex] must not be recorded on low-confidence signal (#663)")
 	}
 }
 

--- a/internal/worker/ratelimit.go
+++ b/internal/worker/ratelimit.go
@@ -11,14 +11,22 @@ import (
 // errors in AI CLI output. Each entry pairs a human-readable label with
 // its regex.
 //
+// Patterns are intentionally high-precision: they must NOT match transient
+// tool/exec errors (e.g. codex `write_stdin failed: stdin is closed`) or
+// stray digit sequences like "429" embedded in unrelated text — that
+// misclassification triggered a false backend fallback on apertune (issue
+// #663), where the orchestrator respawned a healthy codex worker on a more
+// expensive backend chasing a phantom quota block.
+//
 // Supported patterns (case-insensitive):
-//   - "You've hit your limit" (Claude web / API)
-//   - "You've hit your usage limit" (Codex / OpenAI) — the inserted "usage"
-//     word is matched by the optional "(usage )?" group, so both Claude and
-//     Codex signatures hit the same label
+//   - "You've hit your (usage )?limit" (Claude / Codex provider phrasing)
 //   - "chatgpt.com/codex/settings/usage" marker (Codex usage-limit URL)
-//   - HTTP 429 status codes
-//   - "rate limit exceeded" (generic)
+//   - HTTP 429 paired with a status/code/error context word — bare 429
+//     embedded in unrelated text is NOT matched
+//   - "<NNN> too many requests" (HTTP reason phrase)
+//   - "rate limit exceeded|reached|hit" / "rate_limit_error|exceeded" — the
+//     bare phrase "rate limit" alone is NOT matched (too noisy: appears in
+//     prompt context, runbook docs, etc.)
 //   - "quota exceeded" (Google / generic)
 //   - "too many requests" (HTTP 429 reason)
 //   - "resource_exhausted" (gRPC status)
@@ -28,28 +36,15 @@ var rateLimitPatterns = []struct {
 }{
 	{"hit_limit", regexp.MustCompile(`(?i)you'?ve hit your (usage )?limit`)},
 	{"codex_usage_limit", regexp.MustCompile(`(?i)(chatgpt\.com/)?codex/settings/usage`)},
-	{"http_429", regexp.MustCompile(`\b429\b`)},
-	{"rate_limit_exceeded", regexp.MustCompile(`(?i)rate.limit.exceeded`)},
-	{"quota_exceeded", regexp.MustCompile(`(?i)quota.exceeded`)},
-	{"too_many_requests", regexp.MustCompile(`(?i)too many requests`)},
+	// HTTP 429 with a rate-limit context word. Requires the literal 429 to
+	// appear next to an HTTP / status / code / error / response marker so
+	// "1.0.429" or "processed 14290 records" do not false-positive.
+	{"http_429", regexp.MustCompile(`(?i)\b(?:http|https|status|code|err(?:or)?|response|received)\b[ \t]*[:=]?[ \t]*429\b`)},
+	{"http_429_reason", regexp.MustCompile(`(?i)\b429\b[ \t:,-]*too[ \t]+many[ \t]+requests`)},
+	{"rate_limit_exceeded", regexp.MustCompile(`(?i)rate[ _.-]?limit[ _.-]?(?:exceeded|reached|hit|error)`)},
+	{"quota_exceeded", regexp.MustCompile(`(?i)quota[ _.-]?exceeded`)},
+	{"too_many_requests", regexp.MustCompile(`(?i)too\s+many\s+requests`)},
 	{"resource_exhausted", regexp.MustCompile(`(?i)resource[_.\s]?exhausted`)},
-}
-
-// rateLimitSubstrings is a flat list of case-insensitive substrings used for
-// quick log-file scanning (OutputContainsRateLimit / IsRateLimited).
-var rateLimitSubstrings = []string{
-	"you've hit your limit",
-	"you have hit your limit",
-	"you've hit your usage limit",
-	"you have hit your usage limit",
-	"chatgpt.com/codex/settings/usage",
-	"codex/settings/usage",
-	"rate limit",
-	"rate_limit",
-	"too many requests",
-	"quota exceeded",
-	"resource_exhausted",
-	"429",
 }
 
 // rateLimitResetRe extracts the human-readable reset hint emitted after a
@@ -98,17 +93,13 @@ func DetectRateLimit(output string) (bool, string) {
 	return false, ""
 }
 
-// OutputContainsRateLimit checks if the given output text contains
-// any known rate-limit error patterns (case-insensitive).
-// Used for post-mortem detection from log files (dead workers).
+// OutputContainsRateLimit checks if the given output text contains any known
+// rate-limit error patterns (case-insensitive). It uses the same regex set as
+// DetectRateLimit so live and post-mortem detection share one source of truth
+// and neither false-positives on transient tool/exec errors.
 func OutputContainsRateLimit(output string) bool {
-	lower := strings.ToLower(output)
-	for _, pattern := range rateLimitSubstrings {
-		if strings.Contains(lower, pattern) {
-			return true
-		}
-	}
-	return false
+	hit, _ := DetectRateLimit(output)
+	return hit
 }
 
 // IsRateLimited checks if a log file contains rate-limit error messages.
@@ -123,6 +114,30 @@ func IsRateLimited(logFile string) bool {
 		return false
 	}
 	return OutputContainsRateLimit(string(data))
+}
+
+// ClassifyRateLimit inspects output for a rate-limit signal and reports both
+// the match and its confidence. confidence is "high" when the output carries a
+// parseable provider-stated reset window (e.g. the codex "try again at
+// <when>" suffix), and "low" otherwise.
+//
+// Callers that switch backends on a rate-limit signal MUST require confidence
+// == "high". A low-confidence detection is too easy to false-positive — a
+// pattern match without a reset hint is often a stale prompt-context echo, a
+// transient tool/exec error, or a codex tools-router error that looks superficially
+// like a quota message — and switching backends on it burns the more-expensive
+// fallback for no reason, masks the real worker error in operator signal, and
+// can wedge the session in a respawn loop when no fallback is configured.
+// See issue #663.
+func ClassifyRateLimit(output string) (hit bool, label string, confidence string, resetAt time.Time) {
+	hit, label = DetectRateLimit(output)
+	if !hit {
+		return false, "", "", time.Time{}
+	}
+	if reset, ok := ParseRateLimitReset(output); ok {
+		return true, label, "high", reset
+	}
+	return true, label, "low", time.Time{}
 }
 
 // ParseRateLimitReset extracts the provider-stated reset time from output that

--- a/internal/worker/ratelimit_test.go
+++ b/internal/worker/ratelimit_test.go
@@ -294,6 +294,124 @@ func TestParseRateLimitReset_CodexSignature(t *testing.T) {
 	}
 }
 
+// codexWriteStdinClosed is the exact codex tools-router error from issue #663
+// (apertune session apt-2, 2026-06-04). Codex emits this when the worker's
+// stdin gets closed mid-session; the worker recovers and continues. It MUST
+// NOT be classified as a backend rate-limit, otherwise the orchestrator
+// triggers a false fallback to a more expensive backend and can loop the
+// session to the retry cap.
+const codexWriteStdinClosed = "2026-06-04T19:41:32Z ERROR codex_core::tools::router: error=write_stdin failed: stdin is closed\nfor this session; rerun exec_command with tty=true to keep stdin open"
+
+// TestRateLimit_CodexWriteStdinError_NotClassified is the #663 regression
+// guard. The codex tools-router `write_stdin failed: stdin is closed` line
+// is a transient tool error, not a provider rate-limit, so all three entry
+// points must report rate_limited=false.
+func TestRateLimit_CodexWriteStdinError_NotClassified(t *testing.T) {
+	if hit, label := DetectRateLimit(codexWriteStdinClosed); hit {
+		t.Errorf("DetectRateLimit incorrectly classified codex write_stdin error as rate-limit (label=%q)", label)
+	}
+	if OutputContainsRateLimit(codexWriteStdinClosed) {
+		t.Error("OutputContainsRateLimit incorrectly classified codex write_stdin error as rate-limit")
+	}
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "apt-2.log")
+	content := "Starting worker apt-2 on issue #471\nProcessing...\n" + codexWriteStdinClosed + "\nworker continued, opened PR.\n"
+	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write log file: %v", err)
+	}
+	if IsRateLimited(logFile) {
+		t.Error("IsRateLimited incorrectly classified codex write_stdin error log as rate-limit")
+	}
+}
+
+// TestRateLimit_BareDigitsNotClassified guards against the previous bare-429
+// substring match. Stray "429" sequences in IDs, version strings, or token
+// counts must not classify as HTTP 429 — only a 429 paired with an HTTP /
+// status / error context word counts.
+func TestRateLimit_BareDigitsNotClassified(t *testing.T) {
+	cases := []string{
+		"processed 14290 records",
+		"build artifact v0.4.29 ready",
+		"tokens 4290 (in 1000 / out 3290)",
+		"commit sha 429abcd",
+	}
+	for _, in := range cases {
+		if hit, label := DetectRateLimit(in); hit {
+			t.Errorf("DetectRateLimit(%q) incorrectly hit (label=%q) — bare 429 must not classify", in, label)
+		}
+		if OutputContainsRateLimit(in) {
+			t.Errorf("OutputContainsRateLimit(%q) incorrectly matched — bare 429 must not classify", in)
+		}
+	}
+}
+
+// TestRateLimit_BarePhrasesNotClassified guards against the previous bare
+// "rate limit" / "rate_limit" substring match. Generic mentions in prompt
+// context, runbook docs, or config field names must not classify — only a
+// concrete "rate limit exceeded/reached/hit/error" phrasing counts.
+func TestRateLimit_BarePhrasesNotClassified(t *testing.T) {
+	cases := []string{
+		"see the rate limit section in the runbook",
+		`{"config": {"rate_limit": 100}}`,
+		"the API has a rate limit of 60 req/min",
+	}
+	for _, in := range cases {
+		if hit, label := DetectRateLimit(in); hit {
+			t.Errorf("DetectRateLimit(%q) incorrectly hit (label=%q) — bare 'rate limit' must not classify", in, label)
+		}
+		if OutputContainsRateLimit(in) {
+			t.Errorf("OutputContainsRateLimit(%q) incorrectly matched — bare 'rate limit' must not classify", in)
+		}
+	}
+}
+
+// TestClassifyRateLimit_Confidence verifies that ClassifyRateLimit returns
+// "high" only when a parseable reset hint is present, and "low" otherwise.
+// Per #663, the orchestrator must use this confidence signal to gate backend
+// fallback — a low-confidence detection (reset=unknown) does NOT justify
+// switching to a more-expensive backend.
+func TestClassifyRateLimit_Confidence(t *testing.T) {
+	t.Run("high confidence with reset", func(t *testing.T) {
+		hit, label, confidence, resetAt := ClassifyRateLimit(codexUsageLimitSignature)
+		if !hit {
+			t.Fatal("expected hit=true on codex usage-limit signature")
+		}
+		if label != "hit_limit" {
+			t.Errorf("label = %q, want hit_limit", label)
+		}
+		if confidence != "high" {
+			t.Errorf("confidence = %q, want high (parseable reset hint)", confidence)
+		}
+		want := time.Date(2026, time.May, 30, 20, 13, 0, 0, time.UTC)
+		if !resetAt.Equal(want) {
+			t.Errorf("resetAt = %v, want %v", resetAt, want)
+		}
+	})
+
+	t.Run("low confidence without reset", func(t *testing.T) {
+		hit, _, confidence, resetAt := ClassifyRateLimit("Error: rate limit exceeded.")
+		if !hit {
+			t.Fatal("expected hit=true on 'rate limit exceeded'")
+		}
+		if confidence != "low" {
+			t.Errorf("confidence = %q, want low (no reset hint)", confidence)
+		}
+		if !resetAt.IsZero() {
+			t.Errorf("resetAt = %v, want zero on low confidence", resetAt)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		hit, label, confidence, _ := ClassifyRateLimit(codexWriteStdinClosed)
+		if hit {
+			t.Errorf("expected hit=false on write_stdin error, got label=%q confidence=%q", label, confidence)
+		}
+		if confidence != "" {
+			t.Errorf("confidence = %q, want empty when no hit", confidence)
+		}
+	})
+}
+
 func TestParseRateLimitReset_Variants(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
Refs #663

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a false backend-fallback loop (issue #663) where a Codex `write_stdin failed: stdin is closed` tool-exec error was being misclassified as a provider rate-limit, causing the orchestrator to respawn a healthy worker on a more expensive backend and potentially loop it to the retry cap.

- **`ratelimit.go`**: Regex patterns are tightened (bare `429` and bare `rate limit` no longer match); a new `ClassifyRateLimit` function returns high/low confidence based on whether a provider-stated `try again at <time>` reset window is parseable — only high-confidence signals trigger backend fallback.
- **`orchestrator.go`**: Both the live-worker (tmux) and dead-worker (log file) paths are updated to gate backend fallback on a high-confidence signal; a new `providerRateLimitFromLog` helper encapsulates the two-condition check for the dead-worker reconcile path.
- **Tests**: Regression guards are added for both paths covering the exact `write_stdin` repro, a low-confidence pattern match without a reset hint, bare-429 strings, and bare `rate limit` phrases.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change makes the fallback path strictly more conservative and is covered by targeted regression tests for both the live and dead-worker cases.

The core logic is sound and well-tested. The dead-worker providerRateLimitFromLog reads the same log file twice sequentially (once for pattern matching, once for reset parsing) while the live-worker path does the same work in a single ClassifyRateLimit call, leaving a minor structural asymmetry between the two paths.

internal/orchestrator/orchestrator.go — the double file-read in providerRateLimitFromLog is benign today but diverges from the single-pass live-worker approach.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/ratelimit.go | Tightened rate-limit regex patterns (bare "429" and "rate limit" no longer match); added ClassifyRateLimit returning high/low confidence based on whether a parseable reset window is present |
| internal/worker/ratelimit_test.go | Comprehensive regression tests for new patterns including write_stdin false-positive, bare-429, bare "rate limit" phrase, and ClassifyRateLimit confidence levels |
| internal/orchestrator/orchestrator.go | Added providerRateLimitFromLog gating fallback on both pattern-match + parseable reset; live-worker path now uses ClassifyRateLimit confidence check; dead-worker path reads log file twice sequentially |
| internal/orchestrator/orchestrator_test.go | New regression tests for low-confidence paths (both live and dead worker), write_stdin exact repro, and mockRateLimitReset fixture for high-confidence tests |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:469-478
The dead-worker path reads the log file twice in sequence: once via `isRateLimited` (which calls `os.ReadFile`) and again via `rateLimitResetFromLog` (another `os.ReadFile`). The live-worker path avoids this by calling `worker.ClassifyRateLimit(output)` in a single pass. Using the same function here would eliminate the double-read and keep both paths structurally identical, making the confidence semantics visible without chasing two separate functions.

```suggestion
func (o *Orchestrator) providerRateLimitFromLog(logFile string) (hit bool, resetAt *time.Time) {
	if o.isRateLimitedFn != nil || o.rateLimitResetFromLogFn != nil {
		// Test hooks: use the two-step path so each hook is exercised independently.
		if !o.isRateLimited(logFile) {
			return false, nil
		}
		reset := o.rateLimitResetFromLog(logFile)
		if reset == nil {
			return false, nil
		}
		return true, reset
	}
	// Production: single file read, mirrors the live-worker ClassifyRateLimit path.
	if logFile == "" {
		return false, nil
	}
	data, err := os.ReadFile(logFile)
	if err != nil {
		return false, nil
	}
	classifyHit, _, confidence, resetTime := worker.ClassifyRateLimit(string(data))
	if !classifyHit || confidence != "high" {
		return false, nil
	}
	return true, &resetTime
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: tighten rate-limit classif..."](https://github.com/befeast/maestro/commit/cde249fe6929254a12e45ad94a29f47023c57b71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35716771)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->