### PR TITLE
orchestrator: free-text dependency clause + parent epic mis-parsed as a hard blocker (permanent deadlock)

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1221,6 +1221,8 @@ var dependencyInlinePattern = regexp.MustCompile(`(?im)^\s*depends(?:\s+on)?\s*[
 // line or section. Reused for both inline and structured forms.
 var dependencyIssueNumber = regexp.MustCompile(`#(\d+)`)
 
+var dependencyNegatingQualifierPattern = regexp.MustCompile(`(?i)\b(independently\s+mergeable|independent\s+mergeable|but\s+is\s+independent|but\s+independent|not\s+blocked|not\s+a\s+blocker)\b`)
+
 // FindDependencies scans an issue body for dependency references in two
 // supported shapes (see issue #442):
 //
@@ -1472,17 +1474,22 @@ func FindBlockers(body string, patterns []string) []int {
 		if err != nil {
 			continue
 		}
-		for _, match := range re.FindAllStringSubmatch(body, -1) {
-			if len(match) < 2 {
+		for _, line := range strings.Split(body, "\n") {
+			if dependencyNegatingQualifierPattern.MatchString(line) {
 				continue
 			}
-			n, err := strconv.Atoi(match[1])
-			if err != nil || n <= 0 {
-				continue
-			}
-			if _, ok := seen[n]; !ok {
-				seen[n] = struct{}{}
-				blockers = append(blockers, n)
+			for _, match := range re.FindAllStringSubmatch(line, -1) {
+				if len(match) < 2 {
+					continue
+				}
+				n, err := strconv.Atoi(match[1])
+				if err != nil || n <= 0 {
+					continue
+				}
+				if _, ok := seen[n]; !ok {
+					seen[n] = struct{}{}
+					blockers = append(blockers, n)
+				}
 			}
 		}
 	}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -591,6 +591,18 @@ func TestFindChildIssues_NestedHeading(t *testing.T) {
 	}
 }
 
+func TestFindBlockers_IgnoresNegatedDependencyProse(t *testing.T) {
+	body := "Depends on #307 sibling work but is independently mergeable.\nBlocked by #42"
+	patterns := []string{
+		`blocked by.*?#(\d+)`,
+		`depends on.*?#(\d+)`,
+	}
+	got := FindBlockers(body, patterns)
+	if !reflect.DeepEqual(got, []int{42}) {
+		t.Errorf("FindBlockers() = %v, want [42]", got)
+	}
+}
+
 func TestFormatReviewFeedback_NonEmpty(t *testing.T) {
 	comments := []ReviewComment{
 		{Path: "bridge.rs", Line: 42, Body: "P2: enabled flag logic inverted", User: "greptile-apps[bot]"},

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3610,8 +3610,16 @@ func (o *Orchestrator) markUnresolvableConflict(slotName string, sess *state.Ses
 
 // findOpenBlockers returns the subset of blocker issue numbers that are still open.
 func (o *Orchestrator) findOpenBlockers(blockers []int) []int {
+	return o.findOpenBlockersExceptEpics(blockers, nil)
+}
+
+func (o *Orchestrator) findOpenBlockersExceptEpics(blockers []int, issues []github.Issue) []int {
+	epics := epicIssueNumbers(issues)
 	var open []int
 	for _, num := range blockers {
+		if _, ok := epics[num]; ok {
+			continue
+		}
 		closed, err := o.isIssueClosed(num)
 		if err != nil {
 			// If we can't determine the state, assume it's open (safe default)
@@ -3624,6 +3632,16 @@ func (o *Orchestrator) findOpenBlockers(blockers []int) []int {
 		}
 	}
 	return open
+}
+
+func epicIssueNumbers(issues []github.Issue) map[int]struct{} {
+	epics := make(map[int]struct{})
+	for _, issue := range issues {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(issue.Title)), "epic:") || github.HasLabel(issue, []string{"epic"}) {
+			epics[issue.Number] = struct{}{}
+		}
+	}
+	return epics
 }
 
 // resolveBackend determines which backend to use for the given issue.
@@ -3792,7 +3810,7 @@ func (o *Orchestrator) orderedQueueIssueNumberPauseReason(s *state.State, issueN
 	return ""
 }
 
-func (o *Orchestrator) orderedQueueIssuePauseReason(s *state.State, issue github.Issue) string {
+func (o *Orchestrator) orderedQueueIssuePauseReason(s *state.State, issue github.Issue, issues []github.Issue) string {
 	if s.IsMissionParent(issue.Number) {
 		return fmt.Sprintf("issue #%d is a mission parent", issue.Number)
 	}
@@ -3805,7 +3823,7 @@ func (o *Orchestrator) orderedQueueIssuePauseReason(s *state.State, issue github
 	if len(o.cfg.BlockerPatterns) > 0 {
 		blockers := github.FindBlockers(issue.Body, o.cfg.BlockerPatterns)
 		if len(blockers) > 0 {
-			openBlockers := o.findOpenBlockers(blockers)
+			openBlockers := o.findOpenBlockersExceptEpics(blockers, issues)
 			if len(openBlockers) > 0 {
 				return fmt.Sprintf("issue #%d is blocked by open issue(s) %v", issue.Number, openBlockers)
 			}
@@ -3847,7 +3865,7 @@ func (o *Orchestrator) applyOrderedQueueFilter(s *state.State, issues []github.I
 			return nil, true
 		}
 
-		if reason := o.orderedQueueIssuePauseReason(s, issue); reason != "" {
+		if reason := o.orderedQueueIssuePauseReason(s, issue, issues); reason != "" {
 			log.Printf("[orch] ordered queue paused: %s", reason)
 			return nil, true
 		}
@@ -4214,7 +4232,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if len(o.cfg.BlockerPatterns) > 0 {
 			blockers := github.FindBlockers(issue.Body, o.cfg.BlockerPatterns)
 			if len(blockers) > 0 {
-				openBlockers := o.findOpenBlockers(blockers)
+				openBlockers := o.findOpenBlockersExceptEpics(blockers, issues)
 				if len(openBlockers) > 0 {
 					log.Printf("[orch] skipping issue #%d: blocked by open issues %v", issue.Number, openBlockers)
 					continue

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -6623,6 +6623,24 @@ func TestFindOpenBlockers_SomeOpen(t *testing.T) {
 	}
 }
 
+func TestFindOpenBlockersExceptEpics_IgnoresOpenEpic(t *testing.T) {
+	o := &Orchestrator{
+		isIssueClosedFn: func(number int) (bool, error) {
+			return false, nil
+		},
+	}
+	issues := []github.Issue{
+		{Number: 307, Title: "Epic: parent work", Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "epic"}}},
+	}
+
+	got := o.findOpenBlockersExceptEpics([]int{307, 42}, issues)
+	if len(got) != 1 || got[0] != 42 {
+		t.Errorf("findOpenBlockersExceptEpics() = %v, want [42]", got)
+	}
+}
+
 func TestFindOpenBlockers_ErrorAssumesOpen(t *testing.T) {
 	o := &Orchestrator{
 		isIssueClosedFn: func(number int) (bool, error) {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1613,7 +1613,7 @@ func (e *Engine) dynamicWaveCandidateIssues(st *state.State, issues []github.Iss
 
 	candidates := make([]github.Issue, 0, len(issues))
 	for _, issue := range issues {
-		reason, category, err := e.dynamicWaveSkipReason(st, issue)
+		reason, category, err := e.dynamicWaveSkipReason(st, issue, issues)
 		if err != nil {
 			return policyCandidateResult{}, err
 		}
@@ -1650,7 +1650,7 @@ func (e *Engine) dynamicWaveCandidateIssues(st *state.State, issues []github.Iss
 	}, nil
 }
 
-func (e *Engine) dynamicWaveSkipReason(st *state.State, issue github.Issue) (string, dynamicSkipCategory, error) {
+func (e *Engine) dynamicWaveSkipReason(st *state.State, issue github.Issue, issues []github.Issue) (string, dynamicSkipCategory, error) {
 	if st.IssueInProgress(issue.Number) {
 		return "already in progress", dynamicSkipOther, nil
 	}
@@ -1686,7 +1686,7 @@ func (e *Engine) dynamicWaveSkipReason(st *state.State, issue github.Issue) (str
 	}
 	if len(e.cfg.BlockerPatterns) > 0 {
 		blockers := github.FindBlockers(issue.Body, e.cfg.BlockerPatterns)
-		openBlockers, err := e.openBlockers(blockers)
+		openBlockers, err := e.openBlockersExceptEpics(blockers, issues)
 		if err != nil {
 			return "", dynamicSkipOther, err
 		}
@@ -2059,6 +2059,32 @@ func (e *Engine) openBlockers(blockers []int) ([]int, error) {
 		}
 	}
 	return open, nil
+}
+
+func (e *Engine) openBlockersExceptEpics(blockers []int, issues []github.Issue) ([]int, error) {
+	epics := epicIssueNumbers(issues)
+	filtered := blockers[:0]
+	for _, blocker := range blockers {
+		if _, ok := epics[blocker]; ok {
+			continue
+		}
+		filtered = append(filtered, blocker)
+	}
+	return e.openBlockers(filtered)
+}
+
+func epicIssueNumbers(issues []github.Issue) map[int]struct{} {
+	epics := make(map[int]struct{})
+	for _, issue := range issues {
+		if titleLooksEpic(issue.Title) {
+			epics[issue.Number] = struct{}{}
+			continue
+		}
+		if github.HasLabel(issue, []string{"epic"}) {
+			epics[issue.Number] = struct{}{}
+		}
+	}
+	return epics
 }
 
 func sessionWithOpenPR(st *state.State, prs []github.PR) (string, *state.Session, github.PR, bool) {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1739,6 +1739,52 @@ func TestDecide_DynamicWaveClassifiesTitleEpicAsHeld(t *testing.T) {
 	}
 }
 
+func TestDecide_DynamicWaveDoesNotBlockChildOnNegatedDependencyProse(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.BlockerPatterns = []string{`depends on.*?#(\d+)`}
+	enableDynamicWave(cfg)
+	epic := testIssue(307, "Epic: parent work", "epic")
+	child := testIssue(310, "child work", "maestro-ready")
+	child.Body = "Depends on #307 sibling work but is independently mergeable."
+	reader := &fakeReader{issues: []github.Issue{epic, child}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 310 {
+		t.Fatalf("target = %#v, want child issue 310", decision.Target)
+	}
+	if decision.QueueAnalysis == nil || decision.QueueAnalysis.BlockedByDependencyIssues != 0 {
+		t.Fatalf("queue analysis = %#v, want no dependency-blocked issue", decision.QueueAnalysis)
+	}
+}
+
+func TestDecide_DynamicWaveDoesNotCountParentEpicAsBlocker(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.BlockerPatterns = []string{`blocked by.*?#(\d+)`}
+	enableDynamicWave(cfg)
+	epic := testIssue(307, "tracking parent", "epic")
+	child := testIssue(310, "child work", "maestro-ready")
+	child.Body = "Blocked by #307."
+	reader := &fakeReader{issues: []github.Issue{epic, child}}
+
+	decision, err := testEngine(cfg, reader).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.Target == nil || decision.Target.Issue != 310 {
+		t.Fatalf("target = %#v, want child issue 310", decision.Target)
+	}
+	if decision.QueueAnalysis == nil || decision.QueueAnalysis.BlockedByDependencyIssues != 0 {
+		t.Fatalf("queue analysis = %#v, want parent epic excluded from blockers", decision.QueueAnalysis)
+	}
+}
+
 func TestDecide_DynamicWaveClassifiesAllSkipCategories(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.BlockerPatterns = []string{`blocked by #(\d+)`}
@@ -2217,7 +2263,8 @@ func TestDynamicWaveDoneStateDoesNotSkipWhenOutcomeNotVerified(t *testing.T) {
 		Summary:   "live verifier failed",
 	}
 
-	reason, _, err := testEngine(cfg, &fakeReader{}).dynamicWaveSkipReason(st, testIssue(42, "done issue", "maestro-ready"))
+	issue := testIssue(42, "done issue", "maestro-ready")
+	reason, _, err := testEngine(cfg, &fakeReader{}).dynamicWaveSkipReason(st, issue, []github.Issue{issue})
 	if err != nil {
 		t.Fatalf("dynamicWaveSkipReason: %v", err)
 	}


### PR DESCRIPTION
Refs #667

Maestro-Backend: codex openai gpt-5.5 medium (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent deadlock/mis-parse bugs: free-text "independently mergeable" clauses in issue bodies now suppress blocker extraction for that line, and parent epic issues listed as blockers are filtered out before the open-blocker check in both the orchestrator and supervisor engines.

- `FindBlockers` now splits the body by line and skips lines that match a negating-qualifier regex, preventing phrased-as-dependency-but-not-a-real-blocker references from halting work permanently.
- `findOpenBlockersExceptEpics` / `openBlockersExceptEpics` are added in both engines; they resolve blocker issue numbers against a live epic set (detected by `"epic:"` title prefix or `"epic"` label) and strip those numbers before consulting the open/closed API.
- Six new tests cover the negated-prose path and the epic-exclusion path end-to-end.

<h3>Confidence Score: 3/5</h3>

The core epic-bypass logic is correct, but the line-level negation filter in FindBlockers can drop legitimate blockers that happen to share a line with a negating phrase.

The negation check in FindBlockers operates on whole lines: any issue reference that appears on the same line as a qualifying phrase like 'not a blocker' or 'independently mergeable' is silently dropped — even if it is a genuine blocker. This means an issue body like 'Depends on #307 (not a blocker) and also needs #42' would leave #42 untracked, letting a blocked issue proceed when it should not. The epic-exclusion changes in both engines look sound, and the aliased-slice issue in supervisor.go is latent rather than currently observable.

internal/github/github.go (FindBlockers negation logic) and internal/supervisor/supervisor.go (openBlockersExceptEpics slice aliasing).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds line-level negating-qualifier filter in FindBlockers; the whole-line skip can cause genuine blockers on the same line as a negating phrase to be silently dropped. |
| internal/supervisor/supervisor.go | Adds openBlockersExceptEpics and epicIssueNumbers; uses filtered := blockers[:0] alias that mutates the caller's backing array (latent footgun). |
| internal/orchestrator/orchestrator.go | Adds findOpenBlockersExceptEpics and epicIssueNumbers; duplicates epicIssueNumbers logic already present in supervisor.go with slightly different code structure but same logic. |
| internal/github/github_test.go | Adds TestFindBlockers_IgnoresNegatedDependencyProse; covers only the happy-path (negated reference on separate line), missing edge case where negating phrase and real blocker share a line. |
| internal/orchestrator/orchestrator_test.go | Adds TestFindOpenBlockersExceptEpics_IgnoresOpenEpic; covers the intended epic-bypass behavior correctly. |
| internal/supervisor/supervisor_test.go | Adds two new integration tests and fixes the existing dynamicWaveSkipReason call site; tests are well-scoped and correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/github/github.go:1477-1480
**Whole-line negation skips genuine same-line blockers**

The negating-qualifier check operates on the entire line. If a single line contains both a negating phrase and a real blocker — e.g. `"Depends on #307 (not a blocker) and must wait for #42"` — the whole line is skipped and `#42` is silently dropped as an open blocker, leaving the issue appearing unblocked when it actually is.

### Issue 2 of 3
internal/supervisor/supervisor.go:2066
**`filtered := blockers[:0]` aliases and mutates the input's backing array**

`blockers[:0]` returns a zero-length slice that shares the same underlying array as the argument slice. Appending to `filtered` overwrites the front of that array in-place. Current callers don't reuse `blockers` after this call so no observable bug exists today, but any future code that reads `blockers` after calling `openBlockersExceptEpics` will see corrupted values. Using `make([]int, 0, len(blockers))` instead allocates a fresh backing array and eliminates the aliasing.

### Issue 3 of 3
internal/orchestrator/orchestrator.go:3637-3645
**`epicIssueNumbers` is duplicated across packages**

An identical `epicIssueNumbers` function now exists in both `internal/orchestrator` (inline `strings.HasPrefix` logic) and `internal/supervisor` (delegating to `titleLooksEpic`). The two are logically equivalent today, but any future change to the epic-detection heuristic will need to be applied in both places. Moving this function to the shared `internal/github` package (or a common helper) would keep the definition canonical.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: ignore epic dependency blo..."](https://github.com/befeast/maestro/commit/d95c433a8fc47a9c07c280f49ce4dfa9362be894) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35821560)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->