### PR TITLE
orchestrator: open green PR has no maintenance budget for rebase/conflict/review-feedback after implementation retries exhausted

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -310,6 +310,9 @@ func (o *Orchestrator) closePR(prNumber int, comment string) error {
 	if o.ghClosePRFn != nil {
 		return o.ghClosePRFn(prNumber, comment)
 	}
+	if o.gh == nil {
+		return fmt.Errorf("no github client configured for close-pr")
+	}
 	return o.gh.ClosePR(prNumber, comment)
 }
 
@@ -996,6 +999,24 @@ func (o *Orchestrator) canRetryIssue(s *state.State, sess *state.Session) bool {
 	}
 	totalAttempts := s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount
 	return totalAttempts < maxRetries
+}
+
+func (o *Orchestrator) maintenanceRetryBudget() int {
+	if o == nil || o.cfg == nil {
+		return 1
+	}
+	max := o.cfg.Supervisor.ReviewRepair.EffectiveMaxRetries()
+	if max <= 0 {
+		return 1
+	}
+	return max
+}
+
+func (o *Orchestrator) canRetryPRMaintenance(sess *state.Session) bool {
+	if sess == nil {
+		return false
+	}
+	return sess.MaintenanceRetryCount < o.maintenanceRetryBudget()
 }
 
 func pendingRetryReservations(s *state.State) int {
@@ -2747,10 +2768,8 @@ func (o *Orchestrator) reconcileNoPRRetryExhausted(slotName string, sess *state.
 // its prompt. When the PR worktree is still available, keep the PR open and
 // respawn in place so the fixer pushes updates to the same PR.
 func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string, sess *state.Session, pr github.PR, reviewFeedback string) {
-	maxRetries := o.cfg.MaxRetriesPerIssue
-	totalAttempts := s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount
-
-	if maxRetries > 0 && totalAttempts >= maxRetries {
+	maxRetries := o.maintenanceRetryBudget()
+	if !o.canRetryPRMaintenance(sess) {
 		// #556: when the session is already settled retry-exhausted on
 		// this PR, short-circuit so the orchestrator does not re-emit
 		// the retry-limit log, re-sync the project board, or churn
@@ -2760,8 +2779,8 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 		if isSettledRetryExhausted(sess, pr.Number) {
 			return
 		}
-		log.Printf("[orch] review feedback on PR #%d — retry limit reached (%d/%d) for issue #%d",
-			pr.Number, totalAttempts, maxRetries, sess.IssueNumber)
+		log.Printf("[orch] review feedback on PR #%d — maintenance retry limit reached (%d/%d) for issue #%d",
+			pr.Number, sess.MaintenanceRetryCount, maxRetries, sess.IssueNumber)
 		alreadyNotified := sess.LastNotifiedStatus == "review_retry_exhausted"
 		s.MarkIssueRetryExhausted(sess.IssueNumber)
 		o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
@@ -2772,8 +2791,8 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 		sess.FinishedAt = &now
 		state.MarkWorkerEnded(sess, now)
 		if !alreadyNotified {
-			o.notifier.Sendf("💀 maestro: review feedback on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
-				pr.Number, sess.IssueNumber, sess.IssueTitle, totalAttempts)
+			o.notifier.Sendf("💀 maestro: review feedback on PR #%d (issue #%d: %s) — maintenance retry limit exhausted (%d attempts)",
+				pr.Number, sess.IssueNumber, sess.IssueTitle, sess.MaintenanceRetryCount)
 		}
 		return
 	}
@@ -2797,8 +2816,8 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 	sess.PreviousAttemptFeedbackKind = state.RetryReasonReviewFeedback
 	sess.RetryReason = state.RetryReasonReviewFeedback
 
-	sess.RetryCount++
-	backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
+	sess.MaintenanceRetryCount++
+	backoffMs := retryBackoffMs(sess.MaintenanceRetryCount, o.cfg.MaxRetryBackoffMs)
 	retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
 	sess.NextRetryAt = &retryAt
 	sess.Status = state.StatusDead
@@ -2806,10 +2825,10 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 	sess.FinishedAt = &now
 	state.MarkWorkerEnded(sess, now)
 
-	log.Printf("[orch] review feedback on PR #%d — scheduling retry %d in %dms for issue #%d",
-		pr.Number, sess.RetryCount, backoffMs, sess.IssueNumber)
-	o.notifier.Sendf("🔄 maestro: review feedback on PR #%d (issue #%d: %s), in-place retry %d scheduled in %ds",
-		pr.Number, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
+	log.Printf("[orch] review feedback on PR #%d — scheduling maintenance retry %d/%d in %dms for issue #%d",
+		pr.Number, sess.MaintenanceRetryCount, maxRetries, backoffMs, sess.IssueNumber)
+	o.notifier.Sendf("🔄 maestro: review feedback on PR #%d (issue #%d: %s), in-place maintenance retry %d/%d scheduled in %ds",
+		pr.Number, sess.IssueNumber, sess.IssueTitle, sess.MaintenanceRetryCount, maxRetries, backoffMs/1000)
 }
 
 // handleCIFailureRetry closes the failed PR, captures CI output, cleans up,
@@ -3438,9 +3457,26 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 			if !hasPR {
 				continue
 			}
-			mergeable, err := o.gh.PRMergeable(pr.Number)
+			mergeable, mergeState, err := o.prMergeStatus(pr.Number)
 			if err != nil {
 				log.Printf("[orch] mergeable PR #%d: %v", pr.Number, err)
+				continue
+			}
+			if mergeState == "behind" && mergeable != "CONFLICTING" {
+				if !o.cfg.AutoRebase {
+					log.Printf("[orch] PR #%d is behind main for %s, auto_rebase disabled", pr.Number, slotName)
+					continue
+				}
+				if sess.RebaseAttempted {
+					continue
+				}
+				log.Printf("[orch] PR #%d is behind main, updating %s", pr.Number, slotName)
+				if err := o.updateBehindPRBranch(slotName, sess, pr.Number); err != nil {
+					log.Printf("[orch] update behind PR #%d for %s failed: %v", pr.Number, slotName, err)
+					o.handleRebaseConflictRetry(s, slotName, sess, pr.Number, err)
+					continue
+				}
+				o.markRebaseQueued(slotName, sess, pr.Number)
 				continue
 			}
 			if mergeable != "CONFLICTING" {
@@ -3486,12 +3522,21 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 			if !hasPR || sess.RebaseAttempted {
 				continue
 			}
-			mergeable, _, mErr := o.prMergeStatus(pr.Number)
+			mergeable, mergeState, mErr := o.prMergeStatus(pr.Number)
 			if mErr != nil {
 				log.Printf("[orch] mergeable PR #%d: %v", pr.Number, mErr)
 				continue
 			}
 			if mergeable != "CONFLICTING" {
+				if mergeState == "behind" && o.cfg.AutoRebase && !sess.RebaseAttempted {
+					log.Printf("[orch] retry_exhausted PR #%d is behind main, attempting maintenance update for %s", pr.Number, slotName)
+					if err := o.updateBehindPRBranch(slotName, sess, pr.Number); err != nil {
+						log.Printf("[orch] update behind retry_exhausted PR #%d for %s failed: %v", pr.Number, slotName, err)
+						o.handleRebaseConflictRetry(s, slotName, sess, pr.Number, err)
+						continue
+					}
+					o.markRebaseQueued(slotName, sess, pr.Number)
+				}
 				continue
 			}
 			if o.cfg.AutoRebase && strings.TrimSpace(sess.Worktree) != "" {
@@ -3508,6 +3553,21 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 			o.markUnresolvableConflict(slotName, sess, pr.Number, fmt.Errorf("retry_exhausted PR is CONFLICTING"))
 		}
 	}
+}
+
+func (o *Orchestrator) updateBehindPRBranch(slotName string, sess *state.Session, prNumber int) error {
+	rebased := false
+	if strings.TrimSpace(sess.Worktree) != "" {
+		if err := o.rebaseWorktree(sess.Worktree, sess.Branch); err != nil {
+			log.Printf("[orch] auto-rebase failed for %s: %v — falling back to server-side update-branch", slotName, err)
+		} else {
+			rebased = true
+		}
+	}
+	if rebased {
+		return nil
+	}
+	return o.updateBranch(prNumber)
 }
 
 func (o *Orchestrator) markRebaseQueued(slotName string, sess *state.Session, prNumber int) {
@@ -3527,11 +3587,10 @@ func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string
 		return
 	}
 
-	maxRetries := o.cfg.MaxRetriesPerIssue
-	totalAttempts := s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount
-	if maxRetries > 0 && totalAttempts >= maxRetries {
-		log.Printf("[orch] rebase conflict on PR #%d — retry limit reached (%d/%d) for issue #%d",
-			prNumber, totalAttempts, maxRetries, sess.IssueNumber)
+	maxRetries := o.maintenanceRetryBudget()
+	if !o.canRetryPRMaintenance(sess) {
+		log.Printf("[orch] rebase conflict on PR #%d — maintenance retry limit reached (%d/%d) for issue #%d",
+			prNumber, sess.MaintenanceRetryCount, maxRetries, sess.IssueNumber)
 		s.MarkIssueRetryExhausted(sess.IssueNumber)
 		o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
 		sess.Status = state.StatusRetryExhausted
@@ -3540,8 +3599,8 @@ func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
 		state.MarkWorkerEnded(sess, now)
-		o.notifier.Sendf("💀 maestro: rebase conflict on PR #%d (issue #%d: %s) — retry limit exhausted (%d attempts)",
-			prNumber, sess.IssueNumber, sess.IssueTitle, totalAttempts)
+		o.notifier.Sendf("💀 maestro: rebase conflict on PR #%d (issue #%d: %s) — maintenance retry limit exhausted (%d attempts)",
+			prNumber, sess.IssueNumber, sess.IssueTitle, sess.MaintenanceRetryCount)
 		return
 	}
 
@@ -3564,8 +3623,8 @@ func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string
 	sess.PreviousAttemptFeedback = rebaseConflictFeedback(prNumber, cause)
 	sess.PreviousAttemptFeedbackKind = "rebase_conflict"
 
-	sess.RetryCount++
-	backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
+	sess.MaintenanceRetryCount++
+	backoffMs := retryBackoffMs(sess.MaintenanceRetryCount, o.cfg.MaxRetryBackoffMs)
 	retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
 	sess.NextRetryAt = &retryAt
 	sess.Status = state.StatusDead
@@ -3574,10 +3633,10 @@ func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string
 	sess.FinishedAt = &now
 	state.MarkWorkerEnded(sess, now)
 
-	log.Printf("[orch] rebase conflict on PR #%d — scheduling retry %d in %dms for issue #%d",
-		prNumber, sess.RetryCount, backoffMs, sess.IssueNumber)
-	o.notifier.Sendf("🔄 maestro: rebase conflict on PR #%d (issue #%d: %s), in-place retry %d scheduled in %ds",
-		prNumber, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
+	log.Printf("[orch] rebase conflict on PR #%d — scheduling maintenance retry %d/%d in %dms for issue #%d",
+		prNumber, sess.MaintenanceRetryCount, maxRetries, backoffMs, sess.IssueNumber)
+	o.notifier.Sendf("🔄 maestro: rebase conflict on PR #%d (issue #%d: %s), in-place maintenance retry %d/%d scheduled in %ds",
+		prNumber, sess.IssueNumber, sess.IssueTitle, sess.MaintenanceRetryCount, maxRetries, backoffMs/1000)
 }
 
 func rebaseConflictFeedback(prNumber int, cause error) string {
@@ -4203,8 +4262,12 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		}
 
 		if github.HasLabel(issue, o.cfg.ExcludeLabels) {
-			log.Printf("[orch] skipping issue #%d (excluded label)", issue.Number)
-			continue
+			if repairSpawn {
+				log.Printf("[orch] allowing repair worker for issue #%d despite excluded label because supervisor selected repair maintenance", issue.Number)
+			} else {
+				log.Printf("[orch] skipping issue #%d (excluded label)", issue.Number)
+				continue
+			}
 		}
 
 		// Check retry limit: skip issues that have exhausted their retry budget

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2149,7 +2149,7 @@ func TestAutoMergePRs_ReviewFeedbackFallsBackToCloseWhenWorktreeMissing(t *testi
 	}
 }
 
-func TestAutoMergePRs_ReviewFeedbackRetryLimitMarksTerminal(t *testing.T) {
+func TestAutoMergePRs_ReviewFeedbackImplementationRetryLimitStillSchedulesMaintenance(t *testing.T) {
 	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
 	cfg := &config.Config{
 		Repo:                    "owner/repo",
@@ -2181,11 +2181,61 @@ func TestAutoMergePRs_ReviewFeedbackRetryLimitMarksTerminal(t *testing.T) {
 
 	o.autoMergePRs(s)
 
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set for maintenance retry")
+	}
+	if sess.RetryCount != 3 {
+		t.Fatalf("RetryCount = %d, want 3 (implementation retry budget must not be consumed)", sess.RetryCount)
+	}
+	if sess.MaintenanceRetryCount != 1 {
+		t.Fatalf("MaintenanceRetryCount = %d, want 1", sess.MaintenanceRetryCount)
+	}
+	if sess.PreviousAttemptFeedbackKind != state.RetryReasonReviewFeedback {
+		t.Fatalf("PreviousAttemptFeedbackKind = %q, want review_feedback", sess.PreviousAttemptFeedbackKind)
+	}
+}
+
+func TestAutoMergePRs_ReviewFeedbackMaintenanceBudgetMarksTerminal(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "parallel",
+		ReviewGate:              "none",
+		AutoRetryReviewFeedback: true,
+		MaxRetriesPerIssue:      3,
+		MaxRetryBackoffMs:       300000,
+	}
+	notifier := notify.NewWithToken("", "123", "", "")
+	notifier.SetDigestMode(true)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: notifier,
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			return "success", nil
+		},
+		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
+		},
+	}
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.Worktree = "/tmp/maestro-slot-0"
+	sess.RetryCount = 3
+	sess.MaintenanceRetryCount = 1
+
+	o.autoMergePRs(s)
+
 	if sess.Status != state.StatusRetryExhausted {
 		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRetryExhausted)
 	}
 	if sess.NextRetryAt != nil {
-		t.Fatal("NextRetryAt should be nil after retry exhaustion")
+		t.Fatal("NextRetryAt should be nil after maintenance exhaustion")
 	}
 	if sess.LastNotifiedStatus != "review_retry_exhausted" {
 		t.Fatalf("LastNotifiedStatus = %q, want review_retry_exhausted", sess.LastNotifiedStatus)
@@ -2257,7 +2307,7 @@ func TestAutoMergePRs_RetryExhaustedGreenPRNoFeedbackMerges(t *testing.T) {
 	}
 }
 
-func TestAutoMergePRs_RetryExhaustedActionableFeedbackStillBlocks(t *testing.T) {
+func TestAutoMergePRs_RetryExhaustedActionableFeedbackGetsMaintenancePass(t *testing.T) {
 	prs := []github.PR{{Number: 10, HeadRefName: "feat/a", Mergeable: "MERGEABLE"}}
 	cfg := &config.Config{
 		Repo:                    "owner/repo",
@@ -2292,6 +2342,7 @@ func TestAutoMergePRs_RetryExhaustedActionableFeedbackStillBlocks(t *testing.T) 
 		IssueNumber: 100,
 		IssueTitle:  "green with current-head comments",
 		Branch:      "feat/a",
+		Worktree:    "/tmp/maestro-slot-0",
 		Status:      state.StatusRetryExhausted,
 		PRNumber:    10,
 		RetryCount:  3,
@@ -2303,11 +2354,17 @@ func TestAutoMergePRs_RetryExhaustedActionableFeedbackStillBlocks(t *testing.T) 
 		t.Fatalf("actionable review feedback should block merge, got merged=%v", merged)
 	}
 	sess := s.Sessions["slot-0"]
-	if sess.Status != state.StatusRetryExhausted {
-		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRetryExhausted)
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
 	}
-	if sess.LastNotifiedStatus != "review_retry_exhausted" {
-		t.Fatalf("LastNotifiedStatus = %q, want review_retry_exhausted", sess.LastNotifiedStatus)
+	if sess.RetryCount != 3 {
+		t.Fatalf("RetryCount = %d, want 3 (implementation retry budget must not be consumed)", sess.RetryCount)
+	}
+	if sess.MaintenanceRetryCount != 1 {
+		t.Fatalf("MaintenanceRetryCount = %d, want 1", sess.MaintenanceRetryCount)
+	}
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set for maintenance pass")
 	}
 	if notifier.Buffered() != 1 {
 		t.Fatalf("notifications buffered = %d, want 1", notifier.Buffered())
@@ -2365,12 +2422,13 @@ func TestAutoMergePRs_RetryExhaustedFeedback_NoReSyncAfterSettled(t *testing.T) 
 	}
 	s := state.NewState()
 	s.Sessions["sup-92"] = &state.Session{
-		IssueNumber: 535,
-		IssueTitle:  "review feedback PR",
-		Branch:      "feat/sup-92",
-		Status:      state.StatusRetryExhausted,
-		PRNumber:    555,
-		RetryCount:  2,
+		IssueNumber:           535,
+		IssueTitle:            "review feedback PR",
+		Branch:                "feat/sup-92",
+		Status:                state.StatusRetryExhausted,
+		PRNumber:              555,
+		RetryCount:            2,
+		MaintenanceRetryCount: 1,
 	}
 
 	// First cycle marks the session retry-exhausted (one project sync).
@@ -3276,6 +3334,7 @@ func TestHandleRebaseConflictRetry_SchedulesInPlaceRetry(t *testing.T) {
 		Status:      state.StatusPROpen,
 		PRNumber:    10,
 		Backend:     "claude",
+		RetryCount:  3,
 	}
 	s.Sessions["slot-0"] = sess
 
@@ -3287,8 +3346,11 @@ func TestHandleRebaseConflictRetry_SchedulesInPlaceRetry(t *testing.T) {
 	if sess.PRNumber != 10 {
 		t.Fatalf("PRNumber = %d, want 10", sess.PRNumber)
 	}
-	if sess.RetryCount != 1 {
-		t.Fatalf("RetryCount = %d, want 1", sess.RetryCount)
+	if sess.RetryCount != 3 {
+		t.Fatalf("RetryCount = %d, want 3 (implementation retry budget must not be consumed)", sess.RetryCount)
+	}
+	if sess.MaintenanceRetryCount != 1 {
+		t.Fatalf("MaintenanceRetryCount = %d, want 1", sess.MaintenanceRetryCount)
 	}
 	if sess.NextRetryAt == nil {
 		t.Fatal("NextRetryAt should be set")
@@ -3745,6 +3807,54 @@ func TestRebaseConflicts_RetryExhaustedConflictingMarksUnresolvable(t *testing.T
 	}
 	if len(labels) == 0 || labels[0] != "blocked" {
 		t.Errorf("issue must be labelled blocked, got %v", labels)
+	}
+}
+
+func TestRebaseConflicts_OpenPRBehindMainUpdatesUnderMaintenance(t *testing.T) {
+	updateCalled := 0
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "MERGEABLE", "behind", nil
+		},
+		ghUpdateBranchFn: func(prNumber int) error {
+			updateCalled++
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+		RetryCount:  3,
+	}
+
+	o.rebaseConflicts(s)
+
+	sess := s.Sessions["slot-0"]
+	if updateCalled != 1 {
+		t.Fatalf("updateBranch called %d times, want 1", updateCalled)
+	}
+	if sess.Status != state.StatusQueued {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusQueued)
+	}
+	if !sess.RebaseAttempted {
+		t.Fatal("RebaseAttempted should be true after behind update")
+	}
+	if sess.RetryCount != 3 {
+		t.Fatalf("RetryCount = %d, want 3 (behind maintenance must not consume implementation retries)", sess.RetryCount)
+	}
+	if sess.MaintenanceRetryCount != 0 {
+		t.Fatalf("MaintenanceRetryCount = %d, want 0 (clean branch update is not a worker retry)", sess.MaintenanceRetryCount)
 	}
 }
 
@@ -4387,6 +4497,45 @@ func TestStartNewWorkers_SkipsClosedIssueWithDoneSession(t *testing.T) {
 
 	if len(*started) != 0 {
 		t.Fatalf("started %d workers, want 0 for already closed issue", len(*started))
+	}
+}
+
+func TestStartNewWorkers_RepairSpawnBypassesExcludedLabel(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.ExcludeLabels = []string{"blocked"}
+	cfg.Supervisor.ReviewRepair.MaxRetries = 1
+	issues := []github.Issue{makeIssue(669, "repair open PR", "blocked")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	s := state.NewState()
+	s.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "repair-1",
+		CreatedAt:         time.Now().UTC(),
+		RecommendedAction: supervisor.ActionSpawnReviewRepair,
+		Risk:              supervisor.RiskMutating,
+		RequiresApproval:  false,
+		Target:            &state.SupervisorTarget{Issue: 669, PR: 1001, HeadSHA: "deadbeef"},
+		ReviewRepair: &state.SupervisorReviewRepairPayload{
+			HeadSHA:    "deadbeef",
+			MaxRetries: 1,
+			Backend:    "claude",
+			Findings: []state.SupervisorReviewFinding{{
+				Path:     "internal/foo.go",
+				Line:     10,
+				Body:     "P1: address this",
+				Severity: "P1",
+			}},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 1 || (*started)[0] != 669 {
+		t.Fatalf("started = %v, want [669] for supervisor-selected maintenance despite excluded label", *started)
+	}
+	track, ok := s.LookupReviewRepairTrack(1001, "deadbeef")
+	if !ok || track.Attempts != 1 {
+		t.Fatalf("review repair track = %+v, ok=%v; want one maintenance attempt", track, ok)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -118,6 +118,7 @@ type Session struct {
 	LastNotifiedStatus          string            `json:"last_notified_status,omitempty"`       // dedup: last notification type sent
 	LiveVerificationNotified    bool              `json:"live_verification_notified,omitempty"` // #570 one-shot: hold-for-live-verification board sync + operator notification already fired
 	RetryCount                  int               `json:"retry_count,omitempty"`                // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
+	MaintenanceRetryCount       int               `json:"maintenance_retry_count,omitempty"`    // bounded post-PR maintenance attempts (review feedback / rebase conflict repair), separate from implementation retries
 	NextRetryAt                 *time.Time        `json:"next_retry_at,omitempty"`
 	LastOutputHash              string            `json:"last_output_hash,omitempty"`
 	LastOutputChangedAt         time.Time         `json:"last_output_changed_at,omitempty"`


### PR DESCRIPTION
Refs #669

Maestro-Backend: codex openai gpt-5.5 medium (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a separate `MaintenanceRetryCount` budget for post-implementation maintenance tasks (review-feedback retries, rebase/conflict repair, and behind-main branch updates), decoupling them from the implementation `RetryCount` so exhausted PRs still get a bounded number of repair chances without re-consuming the implementation budget.

- Adds `MaintenanceRetryCount` to `Session`, new `maintenanceRetryBudget()` / `canRetryPRMaintenance()` helpers, and rewires `handleReviewFeedbackRetry` and `handleRebaseConflictRetry` to use the new counter; adds a `\"behind\"` update path in `rebaseConflicts` for both open and exhausted PRs.
- `startNewWorkers` now bypasses the excluded-label check when the supervisor selects a repair spawn, preventing the label from silently dropping supervised maintenance workers.

<h3>Confidence Score: 3/5</h3>

Two logic defects on newly introduced code paths should be addressed before merging.

The wrong counter in the close comment produces incorrect information visible to all PR reviewers on every no-worktree maintenance close. The markRebaseQueued path that revives an exhausted session leaves LastNotifiedStatus set to review_retry_exhausted, causing the alreadyNotified guard to suppress the maintenance-exhaustion notification so the operator never learns the maintenance pass also failed.

internal/orchestrator/orchestrator.go — the close-comment counter around line 2801 and the notification-suppression path inside markRebaseQueued.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Core orchestration logic: introduces MaintenanceRetryCount-based budget for review-feedback and rebase-conflict retries, adds behind-main update path in rebaseConflicts, and bypasses excluded-label check for repair spawns. Contains two logic defects: a stale counter in the PR close comment and a suppressed notification edge case. |
| internal/orchestrator/orchestrator_test.go | Test suite updated to reflect separated maintenance vs implementation retry budgets; renames and extends existing tests and adds new coverage for behind-main update and repair-spawn bypass. |
| internal/state/state.go | Adds MaintenanceRetryCount field to Session struct with JSON tag — minimal, correct change. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 2800-2802 ([link](https://github.com/befeast/maestro/blob/80b9f0e8e722c805b7a7fc4e81af5c997f111a28/internal/orchestrator/orchestrator.go#L2800-L2802)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The PR close comment still uses `sess.RetryCount+1` to label the attempt number, but `RetryCount` now tracks only implementation retries and is no longer incremented by `handleReviewFeedbackRetry`. For a session with `RetryCount = 3` (implementation budget exhausted) on its first maintenance retry (`MaintenanceRetryCount = 0`), the comment will say "attempt 4" when it should say "attempt 1". This produces incorrect information in the GitHub PR comment visible to all reviewers.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 2800-2802

   Comment:
   The PR close comment still uses `sess.RetryCount+1` to label the attempt number, but `RetryCount` now tracks only implementation retries and is no longer incremented by `handleReviewFeedbackRetry`. For a session with `RetryCount = 3` (implementation budget exhausted) on its first maintenance retry (`MaintenanceRetryCount = 0`), the comment will say "attempt 4" when it should say "attempt 1". This produces incorrect information in the GitHub PR comment visible to all reviewers.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/orchestrator/orchestrator.go`, line 3573-3580 ([link](https://github.com/befeast/maestro/blob/80b9f0e8e722c805b7a7fc4e81af5c997f111a28/internal/orchestrator/orchestrator.go#L3573-L3580)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale `LastNotifiedStatus` can suppress the maintenance-exhaustion notification**

   `markRebaseQueued` does not reset `sess.LastNotifiedStatus`. When a `StatusRetryExhausted` session with `LastNotifiedStatus == "review_retry_exhausted"` is revived via the new behind-main update path, transitions through `StatusQueued`, then exhausts its maintenance budget in `handleReviewFeedbackRetry`, the `alreadyNotified` guard at line 2784 evaluates to `true` because the field was set during the earlier implementation-retry exhaustion. The operator notification is silently dropped even though a brand-new maintenance failure just occurred. Adding `sess.LastNotifiedStatus = ""` inside `markRebaseQueued` would clear the stale marker before the session re-enters the merge flow.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 3573-3580

   Comment:
   **Stale `LastNotifiedStatus` can suppress the maintenance-exhaustion notification**

   `markRebaseQueued` does not reset `sess.LastNotifiedStatus`. When a `StatusRetryExhausted` session with `LastNotifiedStatus == "review_retry_exhausted"` is revived via the new behind-main update path, transitions through `StatusQueued`, then exhausts its maintenance budget in `handleReviewFeedbackRetry`, the `alreadyNotified` guard at line 2784 evaluates to `true` because the field was set during the earlier implementation-retry exhaustion. The operator notification is silently dropped even though a brand-new maintenance failure just occurred. Adding `sess.LastNotifiedStatus = ""` inside `markRebaseQueued` would clear the stale marker before the session re-enters the merge flow.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/orchestrator/orchestrator.go:2800-2802
The PR close comment still uses `sess.RetryCount+1` to label the attempt number, but `RetryCount` now tracks only implementation retries and is no longer incremented by `handleReviewFeedbackRetry`. For a session with `RetryCount = 3` (implementation budget exhausted) on its first maintenance retry (`MaintenanceRetryCount = 0`), the comment will say "attempt 4" when it should say "attempt 1". This produces incorrect information in the GitHub PR comment visible to all reviewers.

```suggestion
	if sess.Worktree == "" {
		closeComment := fmt.Sprintf("Code review feedback detected, but the PR worktree is unavailable — maestro is closing this PR and respawning a worker to address it (maintenance attempt %d).\n\nReview feedback:\n\n%s",
			sess.MaintenanceRetryCount+1, reviewFeedback)
```

### Issue 2 of 3
internal/orchestrator/orchestrator.go:3573-3580
**Stale `LastNotifiedStatus` can suppress the maintenance-exhaustion notification**

`markRebaseQueued` does not reset `sess.LastNotifiedStatus`. When a `StatusRetryExhausted` session with `LastNotifiedStatus == "review_retry_exhausted"` is revived via the new behind-main update path, transitions through `StatusQueued`, then exhausts its maintenance budget in `handleReviewFeedbackRetry`, the `alreadyNotified` guard at line 2784 evaluates to `true` because the field was set during the earlier implementation-retry exhaustion. The operator notification is silently dropped even though a brand-new maintenance failure just occurred. Adding `sess.LastNotifiedStatus = ""` inside `markRebaseQueued` would clear the stale marker before the session re-enters the merge flow.

### Issue 3 of 3
internal/orchestrator/orchestrator.go:3531
**Dead `!sess.RebaseAttempted` guard**

The outer check `if !hasPR || sess.RebaseAttempted { continue }` at line 3522 guarantees `sess.RebaseAttempted == false` whenever execution reaches this inner condition, so `&& !sess.RebaseAttempted` is always `true` and never filters anything. The dead clause could mislead future readers into believing there is an independent guard here when there isn't.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: separate open PR maintenan..."](https://github.com/befeast/maestro/commit/80b9f0e8e722c805b7a7fc4e81af5c997f111a28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35824584)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->