### PR TITLE
supervisor: duplicate apply_lesson_proposal approvals share one id — CLI reject/approve can't target the pending twin; resolved lessons regenerate

### DIFF
--- a/internal/state/lesson_proposal_test.go
+++ b/internal/state/lesson_proposal_test.go
@@ -71,3 +71,159 @@ func TestRejectLessonProposalApprovalMarksDeclined(t *testing.T) {
 		t.Fatalf("resolution = actor %q note %q", stored.ResolutionActor, stored.ResolutionNote)
 	}
 }
+
+func TestRecordLessonProposal_DoesNotReopenDeclinedFingerprint(t *testing.T) {
+	now := time.Date(2026, 6, 5, 10, 59, 0, 0, time.UTC)
+	s := NewState()
+	input := LessonProposal{
+		FailureClass:   "retry_exhausted",
+		Area:           "issue:672",
+		MinimalRepro:   "Session sup-1 status=retry_exhausted",
+		SuggestedRule:  "Inspect retry context before retrying.",
+		Target:         LessonProposalTargetAgentsMD,
+		SourceDecision: "sup-1",
+	}
+	proposal, approval, created := s.RecordLessonProposal(input, now, "owner/repo", "owner/repo")
+	if !created || proposal == nil || approval == nil {
+		t.Fatalf("created=%v proposal=%+v approval=%+v", created, proposal, approval)
+	}
+	if _, err := s.RejectApproval(approval.ID, now.Add(time.Minute), "operator", "covered"); err != nil {
+		t.Fatalf("RejectApproval: %v", err)
+	}
+
+	reemitted := input
+	reemitted.MinimalRepro = "Session sup-1 status=retry_exhausted | still stuck"
+	reemitted.SourceDecision = "sup-2"
+	got, gotApproval, created := s.RecordLessonProposal(reemitted, now.Add(9*time.Minute), "owner/repo", "owner/repo")
+	if created {
+		t.Fatal("declined fingerprint reopened as a fresh pending proposal")
+	}
+	if got == nil || got.ID != proposal.ID || got.Status != LessonProposalStatusDeclined {
+		t.Fatalf("proposal = %+v, want existing declined %s", got, proposal.ID)
+	}
+	if gotApproval == nil || gotApproval.ID != approval.ID || gotApproval.Status != ApprovalStatusRejected {
+		t.Fatalf("approval = %+v, want original rejected %s", gotApproval, approval.ID)
+	}
+	if len(s.LessonProposals) != 1 || len(s.Approvals) != 1 {
+		t.Fatalf("counts proposals=%d approvals=%d, want 1/1", len(s.LessonProposals), len(s.Approvals))
+	}
+}
+
+func TestRecordLessonProposal_DoesNotReopenAppliedFingerprint(t *testing.T) {
+	now := time.Date(2026, 6, 5, 11, 0, 0, 0, time.UTC)
+	s := NewState()
+	input := LessonProposal{
+		FailureClass:   "retry_exhausted",
+		Area:           "issue:672",
+		MinimalRepro:   "Session sup-1 status=retry_exhausted",
+		SuggestedRule:  "Inspect retry context before retrying.",
+		Target:         LessonProposalTargetAgentsMD,
+		SourceDecision: "sup-1",
+	}
+	proposal, _, created := s.RecordLessonProposal(input, now, "owner/repo", "owner/repo")
+	if !created || proposal == nil {
+		t.Fatalf("created=%v proposal=%+v", created, proposal)
+	}
+	if !s.MarkLessonProposalApplied(proposal.ID, now.Add(time.Minute), "operator", "added") {
+		t.Fatalf("MarkLessonProposalApplied(%s) failed", proposal.ID)
+	}
+
+	got, _, created := s.RecordLessonProposal(input, now.Add(2*time.Minute), "owner/repo", "owner/repo")
+	if created {
+		t.Fatal("applied fingerprint reopened as a fresh pending proposal")
+	}
+	if got == nil || got.ID != proposal.ID || got.Status != LessonProposalStatusApplied {
+		t.Fatalf("proposal = %+v, want existing applied %s", got, proposal.ID)
+	}
+	if len(s.LessonProposals) != 1 || len(s.Approvals) != 1 {
+		t.Fatalf("counts proposals=%d approvals=%d, want 1/1", len(s.LessonProposals), len(s.Approvals))
+	}
+}
+
+func TestApprovalResolutionPrefersPendingDuplicateID(t *testing.T) {
+	now := time.Date(2026, 6, 5, 11, 8, 0, 0, time.UTC)
+	s := NewState()
+	id := "approval-lesson-3b5238ee4626"
+	s.Approvals = []Approval{
+		{ID: id, CreatedAt: now.Add(-9 * time.Minute), UpdatedAt: now.Add(-9 * time.Minute), Action: "apply_lesson_proposal", Status: ApprovalStatusRejected},
+		{ID: id, CreatedAt: now, UpdatedAt: now, Action: "apply_lesson_proposal", Status: ApprovalStatusPending},
+	}
+
+	rejected, err := s.RejectApproval(id, now.Add(time.Minute), "cli", "duplicate regression")
+	if err != nil {
+		t.Fatalf("RejectApproval duplicate id: %v", err)
+	}
+	if rejected != &s.Approvals[1] {
+		t.Fatalf("RejectApproval returned first duplicate; statuses=%s/%s", s.Approvals[0].Status, s.Approvals[1].Status)
+	}
+	if s.Approvals[1].Status != ApprovalStatusRejected {
+		t.Fatalf("pending twin status = %q, want rejected", s.Approvals[1].Status)
+	}
+}
+
+func TestLessonProposalApprovalAddressableBySourceDecisionID(t *testing.T) {
+	now := time.Date(2026, 6, 5, 11, 10, 0, 0, time.UTC)
+	s := NewState()
+	proposal, _, created := s.RecordLessonProposal(LessonProposal{
+		FailureClass:   "retry_exhausted",
+		Area:           "issue:672",
+		MinimalRepro:   "Session sup-20260605T110844 status=retry_exhausted",
+		SuggestedRule:  "Inspect retry context before retrying.",
+		Target:         LessonProposalTargetAgentsMD,
+		SourceDecision: "sup-20260605T110844",
+	}, now, "owner/repo", "owner/repo")
+	if !created || proposal == nil {
+		t.Fatalf("created=%v proposal=%+v", created, proposal)
+	}
+
+	rejected, err := s.RejectApproval("sup-20260605T110844", now.Add(time.Minute), "cli", "source decision")
+	if err != nil {
+		t.Fatalf("RejectApproval by source decision: %v", err)
+	}
+	if rejected.ID != proposal.ApprovalID || rejected.Status != ApprovalStatusRejected {
+		t.Fatalf("rejected = %+v, want lesson approval %s rejected", rejected, proposal.ApprovalID)
+	}
+}
+
+func TestMigrateDuplicateApprovalIDsKeepsPendingCanonical(t *testing.T) {
+	now := time.Date(2026, 6, 5, 11, 8, 0, 0, time.UTC)
+	s := NewState()
+	id := "approval-lesson-3b5238ee4626"
+	s.LessonProposals = []LessonProposal{{
+		ID:             "lesson-3b5238ee4626",
+		CreatedAt:      now.Add(-10 * time.Minute),
+		UpdatedAt:      now,
+		FailureClass:   "retry_exhausted",
+		Area:           "issue:672",
+		MinimalRepro:   "Session sup-20260605T110844 status=retry_exhausted",
+		SuggestedRule:  "Inspect retry context before retrying.",
+		Target:         LessonProposalTargetAgentsMD,
+		Fingerprint:    "3b5238ee4626",
+		Status:         LessonProposalStatusPending,
+		ApprovalID:     id,
+		SourceDecision: "sup-20260605T110844",
+	}}
+	s.Approvals = []Approval{
+		{ID: id, CreatedAt: now.Add(-9 * time.Minute), UpdatedAt: now.Add(-9 * time.Minute), Action: "apply_lesson_proposal", Status: ApprovalStatusRejected, LessonProposalID: "lesson-3b5238ee4626"},
+		{ID: id, CreatedAt: now, UpdatedAt: now, Action: "apply_lesson_proposal", Status: ApprovalStatusPending, LessonProposalID: "lesson-3b5238ee4626"},
+	}
+
+	if migrated := s.MigrateDuplicateApprovalIDs(); migrated != 3 {
+		t.Fatalf("migrated = %d, want 3 id/link updates", migrated)
+	}
+	if s.Approvals[1].ID != id {
+		t.Fatalf("pending approval id = %q, want canonical %q", s.Approvals[1].ID, id)
+	}
+	if s.Approvals[0].ID == id || s.Approvals[0].ID == s.Approvals[1].ID {
+		t.Fatalf("historical duplicate was not split: %+v", s.Approvals)
+	}
+	if s.LessonProposals[0].ApprovalID != id {
+		t.Fatalf("proposal approval_id = %q, want pending canonical %q", s.LessonProposals[0].ApprovalID, id)
+	}
+	if s.Approvals[1].DecisionID != "sup-20260605T110844" {
+		t.Fatalf("pending decision_id = %q, want source decision", s.Approvals[1].DecisionID)
+	}
+	if _, err := s.RejectApproval(id, now.Add(time.Minute), "cli", "after migration"); err != nil {
+		t.Fatalf("RejectApproval canonical pending after migration: %v", err)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1841,8 +1841,9 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 }
 
 // RecordLessonProposal records a recurring-failure lesson candidate and mints a
-// linked pending approval. If the same failure class and area already has a
-// non-declined proposal, it returns that proposal without creating noise.
+// linked pending approval. If the same fingerprint already exists, it updates
+// the durable proposal metadata without re-opening resolved proposals or
+// appending another same-id approval.
 func (s *State) RecordLessonProposal(proposal LessonProposal, now time.Time, repo, project string) (*LessonProposal, *Approval, bool) {
 	if s == nil {
 		return nil, nil, false
@@ -1877,10 +1878,37 @@ func (s *State) RecordLessonProposal(proposal LessonProposal, now time.Time, rep
 		if existing.Fingerprint != proposal.Fingerprint {
 			continue
 		}
-		if existing.Status == LessonProposalStatusDeclined {
-			continue
+		existing.UpdatedAt = proposal.UpdatedAt
+		existing.MinimalRepro = proposal.MinimalRepro
+		existing.SuggestedRule = proposal.SuggestedRule
+		existing.Target = proposal.Target
+		existing.SourceDecision = proposal.SourceDecision
+		existing.SourceTarget = cloneSupervisorTarget(proposal.SourceTarget)
+		if existing.ID == "" {
+			existing.ID = proposal.ID
 		}
-		return existing, s.findApprovalByLessonProposalID(existing.ID), false
+		if existing.FailureClass == "" {
+			existing.FailureClass = proposal.FailureClass
+		}
+		if existing.Area == "" {
+			existing.Area = proposal.Area
+		}
+		approval := s.findApprovalByLessonProposalID(existing.ID)
+		if approval != nil {
+			existing.ApprovalID = approval.ID
+			if approval.DecisionID == "" {
+				approval.DecisionID = existing.SourceDecision
+				approval.PayloadHash = approval.ComputePayloadHash()
+			}
+			if existing.Status == LessonProposalStatusPending && approval.Status == ApprovalStatusPending {
+				approval.UpdatedAt = proposal.UpdatedAt
+				approval.Evidence = []string{existing.MinimalRepro, existing.SuggestedRule}
+				approval.Repo = repo
+				approval.Project = project
+				approval.PayloadHash = approval.ComputePayloadHash()
+			}
+		}
+		return existing, approval, false
 	}
 
 	s.LessonProposals = append(s.LessonProposals, proposal)
@@ -1890,6 +1918,7 @@ func (s *State) RecordLessonProposal(proposal LessonProposal, now time.Time, rep
 		CreatedAt:        stored.CreatedAt,
 		UpdatedAt:        stored.UpdatedAt,
 		Action:           "apply_lesson_proposal",
+		DecisionID:       stored.SourceDecision,
 		Summary:          fmt.Sprintf("Apply lesson proposal for %s in %s.", stored.FailureClass, stored.Area),
 		Risk:             "approval_gated",
 		Evidence:         []string{stored.MinimalRepro, stored.SuggestedRule},
@@ -1940,12 +1969,20 @@ func lessonProposalID(fingerprint string) string {
 }
 
 func (s *State) findApprovalByLessonProposalID(id string) *Approval {
+	var fallback *Approval
 	for i := range s.Approvals {
 		if s.Approvals[i].LessonProposalID == id {
-			return &s.Approvals[i]
+			approval := &s.Approvals[i]
+			switch approval.Status {
+			case ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch:
+				return approval
+			}
+			if fallback == nil {
+				fallback = approval
+			}
 		}
 	}
-	return nil
+	return fallback
 }
 
 func (s *State) FindLessonProposal(id string) (*LessonProposal, bool) {
@@ -2030,13 +2067,42 @@ func supervisorIssueTargetsEqual(a, b []SupervisorIssueTarget) bool {
 }
 
 func (s *State) FindApproval(id string) (*Approval, bool) {
+	if approval, ok := s.findApprovalByIDAndStatus(id, ApprovalStatusPending); ok {
+		return approval, true
+	}
+	if approval, ok := s.findApprovalByIDAndStatus(id, ApprovalStatusApproved); ok {
+		return approval, true
+	}
+	if approval, ok := s.findApprovalByIDAndStatus(id, ApprovalStatusAwaitingDispatch); ok {
+		return approval, true
+	}
 	for i := range s.Approvals {
 		approval := &s.Approvals[i]
-		if approval.ID == id || approval.DecisionID == id {
+		if approvalMatchesID(approval, id) {
 			return approval, true
 		}
 	}
 	return nil, false
+}
+
+func (s *State) findApprovalByIDAndStatus(id string, status ApprovalStatus) (*Approval, bool) {
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if approval.Status == status && approvalMatchesID(approval, id) {
+			return approval, true
+		}
+	}
+	return nil, false
+}
+
+func approvalMatchesID(approval *Approval, id string) bool {
+	if approval == nil {
+		return false
+	}
+	if approval.ID == id || approval.DecisionID == id {
+		return true
+	}
+	return false
 }
 
 func (s *State) ApproveApproval(id string, now time.Time, actor, reason string) (*Approval, error) {
@@ -3453,6 +3519,108 @@ func (s *State) MigrateApprovalsBindRepo(repo string) int {
 		migrated++
 	}
 	return migrated
+}
+
+// MigrateDuplicateApprovalIDs rewrites legacy duplicate approval IDs so the
+// actionable approval keeps the canonical operator-facing ID and historical
+// twins become individually addressable. It also back-fills lesson approval
+// DecisionID links from the durable lesson proposal when older state omitted
+// them.
+func (s *State) MigrateDuplicateApprovalIDs() int {
+	if s == nil || len(s.Approvals) == 0 {
+		return 0
+	}
+	migrated := 0
+	proposalsByID := make(map[string]*LessonProposal, len(s.LessonProposals))
+	for i := range s.LessonProposals {
+		proposal := &s.LessonProposals[i]
+		if proposal.ID != "" {
+			proposalsByID[proposal.ID] = proposal
+		}
+	}
+	used := make(map[string]int, len(s.Approvals))
+	byID := make(map[string][]int)
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if approval.LessonProposalID != "" && approval.DecisionID == "" {
+			if proposal := proposalsByID[approval.LessonProposalID]; proposal != nil && proposal.SourceDecision != "" {
+				approval.DecisionID = proposal.SourceDecision
+				approval.PayloadHash = approval.ComputePayloadHash()
+				migrated++
+			}
+		}
+		id := strings.TrimSpace(approval.ID)
+		if id == "" {
+			continue
+		}
+		used[id]++
+		byID[id] = append(byID[id], i)
+	}
+	for id, indexes := range byID {
+		if len(indexes) < 2 {
+			continue
+		}
+		canonical := canonicalApprovalIndex(s.Approvals, indexes)
+		for _, idx := range indexes {
+			if idx == canonical {
+				continue
+			}
+			approval := &s.Approvals[idx]
+			oldID := approval.ID
+			approval.ID = nextDuplicateApprovalID(id, used)
+			if proposal := proposalsByID[approval.LessonProposalID]; proposal != nil && proposal.ApprovalID == oldID {
+				proposal.ApprovalID = approval.ID
+			}
+			migrated++
+		}
+		for _, idx := range indexes {
+			approval := &s.Approvals[idx]
+			if proposal := proposalsByID[approval.LessonProposalID]; proposal != nil {
+				if proposal.ApprovalID == "" || idx == canonical || approval.Status == ApprovalStatusPending {
+					proposal.ApprovalID = approval.ID
+				}
+			}
+		}
+	}
+	return migrated
+}
+
+func canonicalApprovalIndex(approvals []Approval, indexes []int) int {
+	if len(indexes) == 0 {
+		return -1
+	}
+	for _, status := range []ApprovalStatus{
+		ApprovalStatusPending,
+		ApprovalStatusApproved,
+		ApprovalStatusAwaitingDispatch,
+	} {
+		best := -1
+		for _, idx := range indexes {
+			if approvals[idx].Status != status {
+				continue
+			}
+			if best == -1 || approvals[idx].CreatedAt.After(approvals[best].CreatedAt) {
+				best = idx
+			}
+		}
+		if best != -1 {
+			return best
+		}
+	}
+	return indexes[0]
+}
+
+func nextDuplicateApprovalID(base string, used map[string]int) string {
+	n := used[base]
+	for {
+		n++
+		candidate := fmt.Sprintf("%s-legacy-%d", base, n)
+		if used[candidate] == 0 {
+			used[base] = n
+			used[candidate] = 1
+			return candidate
+		}
+	}
 }
 
 // ValidateSlotID is the canonical slot-id validator used at EVERY

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -261,6 +261,9 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 	if err != nil {
 		return state.SupervisorDecision{}, fmt.Errorf("load state: %w", err)
 	}
+	if migrated := st.MigrateDuplicateApprovalIDs(); migrated > 0 {
+		fmt.Fprintf(os.Stderr, "[supervisor] migrated %d duplicate approval id/link(s) (#672)\n", migrated)
+	}
 	st.MarkStaleApprovals(time.Now().UTC())
 	// #489 migration: stamp Repo on any pre-#489 approval still in
 	// flight so the executor's cross-project guard can fence reliably.


### PR DESCRIPTION
Refs #672

Maestro-Backend: codex openai gpt-5.5 medium (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related bugs: duplicate `apply_lesson_proposal` approvals being emitted with the same ID (making one untargetable by the CLI), and lesson proposals for already-resolved fingerprints regenerating new pending approvals on re-emission.

- `FindApproval` now resolves pending → approved → awaiting_dispatch before falling back to any status match, so reject/approve operations always target the live approval when duplicate IDs exist.
- `RecordLessonProposal` updates metadata on all existing fingerprint matches without re-opening declined or applied proposals or appending a new same-ID approval.
- New `MigrateDuplicateApprovalIDs` migration splits historical duplicate IDs into individually-addressable legacy IDs and back-fills missing `DecisionID` links.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the approval-targeting fix is well-tested and the migration is idempotent.

The core state changes are correct and covered by five new tests. Two minor observations keep this short of a clean score: nextDuplicateApprovalID generates counter-intuitive suffix numbers, and SourceDecision/DecisionID can diverge on re-emission. Neither causes data loss or wrong approval targeting in practice.

internal/state/state.go — specifically the RecordLessonProposal re-emission path and nextDuplicateApprovalID naming.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Core logic changes: FindApproval now prioritises pending/approved/awaiting_dispatch before falling back to any status match, fixing the duplicate-ID targeting bug; RecordLessonProposal updates metadata on all existing fingerprint matches; new MigrateDuplicateApprovalIDs splits historical duplicate IDs and backfills missing DecisionID links. |
| internal/state/lesson_proposal_test.go | Five new tests cover: declined-fingerprint no-reopen, applied-fingerprint no-reopen, pending-twin targeting by shared ID, source-decision addressability, and full migration round-trip. |
| internal/supervisor/supervisor.go | Single call to MigrateDuplicateApprovalIDs inserted early in RunOnce, before MarkStaleApprovals, consistent with the existing MigrateApprovalsBindRepo pattern. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/state/state.go:3613-3624
**Legacy ID numbering skips low suffixes**

`nextDuplicateApprovalID` seeds `n` from `used[base]`, which equals the duplicate count (e.g. 2 for a pair). So the first generated suffix is `base-legacy-3`, not `base-legacy-1`. The collision guard (`used[candidate] == 0`) keeps correctness, so there is no functional problem, but the resulting names can be confusing when operators inspect state directly — an approval pair produces `approval-lesson-xxx` + `approval-lesson-xxx-legacy-3` with no `-legacy-1` or `-legacy-2`.

### Issue 2 of 2
internal/state/state.go:1881-1886
**SourceDecision always overwritten on re-emission, but DecisionID is only backfilled once**

`existing.SourceDecision` is unconditionally updated to the newest emission's value, but `approval.DecisionID` is only set when it was previously empty. After two emissions with different source IDs (`sup-1`, then `sup-2`): `proposal.SourceDecision` becomes `"sup-2"` while `approval.DecisionID` remains `"sup-1"`. `FindApproval("sup-2")` then returns nothing — the second source decision is silently unaddressable. Operators relying on the latest emitting decision's ID to target the approval from the CLI would hit `ErrApprovalNotFound`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["supervisor: dedupe lesson proposal appro..."](https://github.com/befeast/maestro/commit/7c4525517476785e83cfca7fc08cea9c3b571f01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35831344)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->