### PR TITLE
supervisor: sticky retry_exhausted spawns duplicate lesson proposals from preflight-only failures

### DIFF
--- a/internal/state/lesson_proposal_test.go
+++ b/internal/state/lesson_proposal_test.go
@@ -39,6 +39,42 @@ func TestRecordLessonProposal_DedupsPendingFingerprint(t *testing.T) {
 	}
 }
 
+func TestRecordLessonProposal_DedupsBySourceSessionAndRuleNotArea(t *testing.T) {
+	now := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	input := LessonProposal{
+		FailureClass:  "retry_exhausted",
+		Area:          "issue:528",
+		MinimalRepro:  "Session scr-528 status=retry_exhausted retry_count=3",
+		SuggestedRule: "Inspect failed attempts before retrying.",
+		Target:        LessonProposalTargetWorkerPrompt,
+		SourceTarget:  &SupervisorTarget{Issue: 528, Session: "scr-528"},
+	}
+
+	first, _, created := s.RecordLessonProposal(input, now, "owner/repo", "owner/repo")
+	if !created || first == nil {
+		t.Fatalf("first created=%v proposal=%+v, want proposal", created, first)
+	}
+	s.MarkLessonProposalApplied(first.ID, now.Add(time.Minute), "operator", "appended to worker prompt")
+
+	rotated := input
+	rotated.Area = "issue:999"
+	rotated.SourceTarget = &SupervisorTarget{Issue: 528, Session: "scr-528"}
+	second, approval, created := s.RecordLessonProposal(rotated, now.Add(2*time.Minute), "owner/repo", "owner/repo")
+	if created {
+		t.Fatal("created duplicate proposal for same source session and suggested rule with different area")
+	}
+	if second == nil || second.ID != first.ID {
+		t.Fatalf("second = %+v, want existing %s", second, first.ID)
+	}
+	if approval == nil || approval.ID != first.ApprovalID {
+		t.Fatalf("approval = %+v, want original approval %q", approval, first.ApprovalID)
+	}
+	if len(s.LessonProposals) != 1 || len(s.Approvals) != 1 {
+		t.Fatalf("counts proposals=%d approvals=%d, want 1/1", len(s.LessonProposals), len(s.Approvals))
+	}
+}
+
 func TestRejectLessonProposalApprovalMarksDeclined(t *testing.T) {
 	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
 	s := NewState()

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1841,9 +1841,9 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 }
 
 // RecordLessonProposal records a recurring-failure lesson candidate and mints a
-// linked pending approval. If the same fingerprint already exists, it updates
-// the durable proposal metadata without re-opening resolved proposals or
-// appending another same-id approval.
+// linked pending approval. If the same failure class, source session, and
+// suggested rule already exists, it updates the durable proposal metadata
+// without re-opening resolved proposals or appending another same-id approval.
 func (s *State) RecordLessonProposal(proposal LessonProposal, now time.Time, repo, project string) (*LessonProposal, *Approval, bool) {
 	if s == nil {
 		return nil, nil, false
@@ -1865,7 +1865,7 @@ func (s *State) RecordLessonProposal(proposal LessonProposal, now time.Time, rep
 		proposal.Status = LessonProposalStatusPending
 	}
 	if proposal.Fingerprint == "" {
-		proposal.Fingerprint = LessonProposalFingerprint(proposal.FailureClass, proposal.Area)
+		proposal.Fingerprint = LessonProposalFingerprint(proposal.FailureClass, lessonProposalSourceSession(&proposal), proposal.SuggestedRule)
 	}
 	if proposal.ID == "" {
 		proposal.ID = lessonProposalID(proposal.Fingerprint)
@@ -1875,7 +1875,7 @@ func (s *State) RecordLessonProposal(proposal LessonProposal, now time.Time, rep
 	}
 	for i := range s.LessonProposals {
 		existing := &s.LessonProposals[i]
-		if existing.Fingerprint != proposal.Fingerprint {
+		if existing.Fingerprint != proposal.Fingerprint && !lessonProposalEquivalent(*existing, proposal) {
 			continue
 		}
 		existing.UpdatedAt = proposal.UpdatedAt
@@ -1947,14 +1947,29 @@ func firstNonZeroTime(values ...time.Time) time.Time {
 	return time.Time{}
 }
 
-func LessonProposalFingerprint(failureClass, area string) string {
+func LessonProposalFingerprint(failureClass, sourceSession, suggestedRule string) string {
 	return stableHash(struct {
-		FailureClass string `json:"failure_class"`
-		Area         string `json:"area"`
+		FailureClass  string `json:"failure_class"`
+		SourceSession string `json:"source_session"`
+		SuggestedRule string `json:"suggested_rule"`
 	}{
-		FailureClass: strings.ToLower(strings.TrimSpace(failureClass)),
-		Area:         strings.ToLower(strings.TrimSpace(area)),
+		FailureClass:  strings.ToLower(strings.TrimSpace(failureClass)),
+		SourceSession: strings.ToLower(strings.TrimSpace(sourceSession)),
+		SuggestedRule: strings.TrimSpace(suggestedRule),
 	})
+}
+
+func lessonProposalEquivalent(a, b LessonProposal) bool {
+	return strings.EqualFold(strings.TrimSpace(a.FailureClass), strings.TrimSpace(b.FailureClass)) &&
+		strings.EqualFold(lessonProposalSourceSession(&a), lessonProposalSourceSession(&b)) &&
+		strings.TrimSpace(a.SuggestedRule) == strings.TrimSpace(b.SuggestedRule)
+}
+
+func lessonProposalSourceSession(proposal *LessonProposal) string {
+	if proposal == nil || proposal.SourceTarget == nil {
+		return ""
+	}
+	return strings.TrimSpace(proposal.SourceTarget.Session)
 }
 
 func lessonProposalID(fingerprint string) string {

--- a/internal/supervisor/lesson_proposal.go
+++ b/internal/supervisor/lesson_proposal.go
@@ -23,6 +23,9 @@ func lessonProposalFromDecision(cfg *config.Config, st *state.State, decision st
 		return state.LessonProposal{}, false
 	}
 	for _, stuck := range decision.StuckStates {
+		if !lessonProposalEligibleForStuckState(st, stuck) {
+			continue
+		}
 		if proposal, ok := lessonProposalFromStuckState(cfg, decision, stuck); ok {
 			return proposal, true
 		}
@@ -41,6 +44,9 @@ func lessonProposalFromDecision(cfg *config.Config, st *state.State, decision st
 				Target:            target,
 				Evidence:          []string{fmt.Sprintf("Session %s status=conflict_failed", slot)},
 			}
+			if !lessonProposalEligibleForStuckState(st, stuck) {
+				continue
+			}
 			return lessonProposalFromStuckState(cfg, decision, stuck)
 		}
 	}
@@ -52,7 +58,7 @@ func lessonProposalFromStuckState(cfg *config.Config, decision state.SupervisorD
 	if failureClass == "" {
 		return state.LessonProposal{}, false
 	}
-	area := lessonArea(decision.Target, stuck.Target)
+	area := lessonArea(stuck.Target, decision.Target)
 	minimalRepro := lessonMinimalRepro(stuck)
 	target := state.LessonProposalTargetAgentsMD
 	if strings.TrimSpace(cfg.WorkerPrompt) != "" {
@@ -73,6 +79,58 @@ func lessonProposalFromStuckState(cfg *config.Config, decision state.SupervisorD
 		proposal.CreatedAt = time.Now().UTC()
 	}
 	return proposal, true
+}
+
+func lessonProposalEligibleForStuckState(st *state.State, stuck state.SupervisorStuckState) bool {
+	if lessonFailureClass(stuck.Code) != "retry_exhausted" {
+		return true
+	}
+	issue := 0
+	if stuck.Target != nil {
+		issue = stuck.Target.Issue
+	}
+	if issue <= 0 {
+		return true
+	}
+	return retryExhaustedIssueHasTaskRunEvidence(st, issue)
+}
+
+func retryExhaustedIssueHasTaskRunEvidence(st *state.State, issue int) bool {
+	if st == nil || issue <= 0 {
+		return true
+	}
+	seenFailedAttempt := false
+	for _, sess := range st.Sessions {
+		if sess == nil || sess.IssueNumber != issue || sess.RateLimitHit {
+			continue
+		}
+		switch sess.Status {
+		case state.StatusDead, state.StatusFailed, state.StatusRetryExhausted, state.StatusConflictFailed:
+			seenFailedAttempt = true
+		default:
+			continue
+		}
+		if sessionHasTaskRunEvidence(sess) {
+			return true
+		}
+	}
+	return !seenFailedAttempt
+}
+
+func sessionHasTaskRunEvidence(sess *state.Session) bool {
+	if sess == nil {
+		return false
+	}
+	if sess.PRNumber > 0 || sess.TokensUsedAttempt > 0 || sess.TokensUsedTotal > 0 {
+		return true
+	}
+	if !sess.LastOutputChangedAt.IsZero() {
+		return true
+	}
+	if strings.TrimSpace(sess.CIFailureOutput) != "" || strings.TrimSpace(sess.PreviousAttemptFeedback) != "" {
+		return true
+	}
+	return false
 }
 
 func lessonFailureClass(code string) string {

--- a/internal/supervisor/lesson_proposal_test.go
+++ b/internal/supervisor/lesson_proposal_test.go
@@ -18,6 +18,11 @@ func TestRecordLessonProposalForDecision_GeneratesOnceForRetryExhausted(t *testi
 	}
 	st := state.NewState()
 	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	st.Sessions["sup-155"] = &state.Session{
+		IssueNumber:         640,
+		Status:              state.StatusRetryExhausted,
+		LastOutputChangedAt: now.Add(-30 * time.Minute),
+	}
 	decision := state.SupervisorDecision{
 		ID:        "decision-lesson",
 		CreatedAt: now,
@@ -60,5 +65,84 @@ func TestRecordLessonProposalForDecision_GeneratesOnceForRetryExhausted(t *testi
 	}
 	if len(st.LessonProposals) != 1 || len(st.Approvals) != 1 {
 		t.Fatalf("counts proposals=%d approvals=%d, want 1/1", len(st.LessonProposals), len(st.Approvals))
+	}
+}
+
+func TestRecordLessonProposalForDecision_SkipsPreflightOnlyRetryExhausted(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:         "owner/repo",
+		WorkerPrompt: filepath.Join(dir, "worker-prompt.md"),
+	}
+	st := state.NewState()
+	now := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	st.Sessions["scr-525"] = &state.Session{IssueNumber: 528, Status: state.StatusDead, StartedAt: now.Add(-4 * time.Hour)}
+	st.Sessions["scr-526"] = &state.Session{IssueNumber: 528, Status: state.StatusDead, StartedAt: now.Add(-3 * time.Hour)}
+	st.Sessions["scr-527"] = &state.Session{IssueNumber: 528, Status: state.StatusDead, StartedAt: now.Add(-2 * time.Hour)}
+	st.Sessions["scr-528"] = &state.Session{IssueNumber: 528, Status: state.StatusRetryExhausted, StartedAt: now.Add(-time.Hour)}
+	decision := state.SupervisorDecision{
+		ID:        "decision-preflight-only",
+		CreatedAt: now,
+		Repo:      "owner/repo",
+		Project:   "owner/repo",
+		Target:    &state.SupervisorTarget{Issue: 999, Session: "scr-focus"},
+		StuckStates: []state.SupervisorStuckState{{
+			Code:              "retry_exhausted",
+			Severity:          SeverityBlocked,
+			Summary:           "Issue #528 exhausted its retry budget.",
+			Evidence:          []string{"Session scr-528 status=retry_exhausted retry_count=3"},
+			RecommendedAction: ActionReviewRetryExhausted,
+			Target:            &state.SupervisorTarget{Issue: 528, Session: "scr-528"},
+		}},
+	}
+
+	proposal, created := recordLessonProposalForDecision(cfg, st, decision)
+	if created || proposal != nil {
+		t.Fatalf("proposal created=%v proposal=%+v, want none for preflight-only attempts", created, proposal)
+	}
+	if len(st.LessonProposals) != 0 || len(st.Approvals) != 0 {
+		t.Fatalf("counts proposals=%d approvals=%d, want 0/0", len(st.LessonProposals), len(st.Approvals))
+	}
+}
+
+func TestRecordLessonProposalForDecision_AreaUsesFailingSourceTarget(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Repo:         "owner/repo",
+		WorkerPrompt: filepath.Join(dir, "worker-prompt.md"),
+	}
+	st := state.NewState()
+	now := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	st.Sessions["scr-528"] = &state.Session{
+		IssueNumber:         528,
+		Status:              state.StatusRetryExhausted,
+		StartedAt:           now.Add(-time.Hour),
+		LastOutputChangedAt: now.Add(-30 * time.Minute),
+	}
+	decision := state.SupervisorDecision{
+		ID:        "decision-area-source",
+		CreatedAt: now,
+		Repo:      "owner/repo",
+		Project:   "owner/repo",
+		Target:    &state.SupervisorTarget{Issue: 999, Session: "scr-focus"},
+		StuckStates: []state.SupervisorStuckState{{
+			Code:              "retry_exhausted",
+			Severity:          SeverityBlocked,
+			Summary:           "Issue #528 exhausted its retry budget.",
+			Evidence:          []string{"Session scr-528 status=retry_exhausted retry_count=3"},
+			RecommendedAction: ActionReviewRetryExhausted,
+			Target:            &state.SupervisorTarget{Issue: 528, Session: "scr-528"},
+		}},
+	}
+
+	proposal, created := recordLessonProposalForDecision(cfg, st, decision)
+	if !created || proposal == nil {
+		t.Fatalf("created=%v proposal=%+v, want proposal", created, proposal)
+	}
+	if proposal.Area != "issue:528" {
+		t.Fatalf("area = %q, want failing source issue", proposal.Area)
+	}
+	if proposal.SourceTarget == nil || proposal.SourceTarget.Issue != 528 || proposal.SourceTarget.Session != "scr-528" {
+		t.Fatalf("source target = %#v, want failing source", proposal.SourceTarget)
 	}
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1151,7 +1151,7 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time, cache *
 			}
 		}
 
-		if sess.Status == state.StatusRetryExhausted && sess.PRNumber == 0 && !e.retryExhaustedSessionResolvedOnGitHub(sess, cache) {
+		if sess.Status == state.StatusRetryExhausted && sess.PRNumber == 0 && !e.retryExhaustedSessionResolved(st, sess, cache) {
 			findings = append(findings, stuckState("retry_exhausted", SeverityBlocked,
 				fmt.Sprintf("Issue #%d exhausted its retry budget.", sess.IssueNumber),
 				"Review the failed attempts, adjust the issue or retry budget, then restart intentionally.", false, target,
@@ -1216,6 +1216,9 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *re
 			continue
 		}
 		if e.sessionResolvedOnGitHub(sess, cache) {
+			continue
+		}
+		if sess.Status == state.StatusRetryExhausted && e.retryExhaustedSessionSupersededByIssueProgress(st, sess) {
 			continue
 		}
 		pr, found := openPRForSession(sess, byNumber, byBranch)
@@ -2495,7 +2498,7 @@ func (e *Engine) retryExhaustedSession(st *state.State, cache *resolutionCache) 
 		if sess == nil || sess.Status != state.StatusRetryExhausted {
 			continue
 		}
-		if e.retryExhaustedSessionResolvedOnGitHub(sess, cache) {
+		if e.retryExhaustedSessionResolved(st, sess, cache) {
 			continue
 		}
 		return slot, sess, true
@@ -2516,7 +2519,7 @@ func (e *Engine) retryExhaustedRepairCandidate(st *state.State, issues []github.
 		if sess == nil || sess.Status != state.StatusRetryExhausted || sess.PRNumber > 0 {
 			continue
 		}
-		if e.hasLiveRunningSessionForIssue(st, sess.IssueNumber) || e.retryExhaustedSessionResolvedOnGitHub(sess, cache) {
+		if e.retryExhaustedSessionResolved(st, sess, cache) {
 			continue
 		}
 		issue, ok := issueByNumber[sess.IssueNumber]
@@ -2544,6 +2547,45 @@ func (e *Engine) retryExhaustedRepairCandidate(st *state.State, issues []github.
 // review or worker spawning for the already-resolved issue.
 func (e *Engine) retryExhaustedSessionResolvedOnGitHub(sess *state.Session, cache *resolutionCache) bool {
 	return e.sessionResolvedOnGitHub(sess, cache)
+}
+
+func (e *Engine) retryExhaustedSessionResolved(st *state.State, sess *state.Session, cache *resolutionCache) bool {
+	return e.retryExhaustedSessionResolvedOnGitHub(sess, cache) || e.retryExhaustedSessionSupersededByIssueProgress(st, sess)
+}
+
+func (e *Engine) retryExhaustedSessionSupersededByIssueProgress(st *state.State, exhausted *state.Session) bool {
+	if st == nil || exhausted == nil || exhausted.IssueNumber <= 0 {
+		return false
+	}
+	exhaustedAt := state.SessionChangedAt(exhausted)
+	for _, sess := range st.Sessions {
+		if sess == nil || sess == exhausted || sess.IssueNumber != exhausted.IssueNumber {
+			continue
+		}
+		if !sessionCanSupersedeRetryExhausted(sess) {
+			continue
+		}
+		if !exhaustedAt.IsZero() && !state.SessionChangedAt(sess).After(exhaustedAt) {
+			continue
+		}
+		if sess.Status == state.StatusRunning && sess.PID > 0 && !e.pidAlive(sess.PID) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func sessionCanSupersedeRetryExhausted(sess *state.Session) bool {
+	if sess == nil {
+		return false
+	}
+	switch sess.Status {
+	case state.StatusRunning, state.StatusQueued, state.StatusPROpen, state.StatusCodeLanded, state.StatusDone:
+		return true
+	default:
+		return false
+	}
 }
 
 func (e *Engine) sessionResolvedOnGitHub(sess *state.Session, cache *resolutionCache) bool {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -472,6 +472,45 @@ func TestDecide_RetryExhaustedSkippedWhenSessionPRIsMerged(t *testing.T) {
 	}
 }
 
+func TestDecide_RetryExhaustedSkippedWhenNewerSessionForIssueIsLive(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	finished := now.Add(-20 * time.Minute)
+	st := state.NewState()
+	st.Sessions["scr-528"] = &state.Session{
+		IssueNumber: 528,
+		IssueTitle:  "stale exhausted work",
+		Status:      state.StatusRetryExhausted,
+		StartedAt:   now.Add(-time.Hour),
+		FinishedAt:  &finished,
+	}
+	st.Sessions["scr-532"] = &state.Session{
+		IssueNumber: 528,
+		IssueTitle:  "fresh respawn",
+		Status:      state.StatusRunning,
+		PID:         12345,
+		StartedAt:   now.Add(-10 * time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if decision.RecommendedAction == ActionReviewRetryExhausted {
+		t.Fatalf("action = %q, must not review stale retry_exhausted once same issue has a newer live session", decision.RecommendedAction)
+	}
+	if decision.Target != nil && decision.Target.Session == "scr-528" {
+		t.Fatalf("target = %#v, must not target stale session scr-528", decision.Target)
+	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == "retry_exhausted" && stuck.Target != nil && stuck.Target.Session == "scr-528" {
+			t.Fatalf("stale retry_exhausted stuck state reported: %#v", stuck)
+		}
+	}
+}
+
 func TestDecide_RetryExhaustedResolutionCachedPerDecisionCycle(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{}


### PR DESCRIPTION
Refs #668

Maestro-Backend: codex openai gpt-5.5 medium (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related problems triggered by \"sticky\" `retry_exhausted` sessions: (1) duplicate lesson proposals spawned on every supervisor cycle when preflight-only session failures (no real tokens, output, or PR produced) falsely looked like actionable stuck states, and (2) stale `retry_exhausted` records continuing to surface after the same issue already has a newer live session.

- `lessonProposalEligibleForStuckState` / `retryExhaustedIssueHasTaskRunEvidence` gate lesson-proposal creation on at least one non-rate-limited failed session having concrete task-run evidence (`PRNumber`, tokens, `LastOutputChangedAt`, CI output, or feedback). When all sessions for the issue are preflight-only, the proposal is suppressed.
- `retryExhaustedSessionSupersededByIssueProgress` identifies when a newer session (Running/Queued/PROpen/CodeLanded/Done) has made progress beyond the exhausted one and suppresses related stuck states and repair-candidate selection; this replaces the narrower `hasLiveRunningSessionForIssue` check in `retryExhaustedRepairCandidate`.
- `LessonProposalFingerprint` is re-keyed on `(failureClass, sourceSession, suggestedRule)` instead of `(failureClass, area)`, with a `lessonProposalEquivalent` fallback ensuring proposals stored under the old scheme still dedup correctly on upgrade.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core lesson-proposal and stuck-state suppression paths are well-covered by new tests and the logic is sound.

The behavioral replacement of hasLiveRunningSessionForIssue with the timestamp-gated retryExhaustedSessionSupersededByIssueProgress in retryExhaustedRepairCandidate is a net reduction in the guard against spawning duplicate repair workers: a running session whose activity timestamps predate the exhaustion would no longer block repair candidate selection. The scenario requires an unusual ordering of session timestamps that is unlikely in practice, but it is a real coverage gap relative to the previous check.

internal/supervisor/supervisor.go around retryExhaustedRepairCandidate and retryExhaustedSessionSupersededByIssueProgress

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/lesson_proposal.go | Adds lessonProposalEligibleForStuckState gate: retry_exhausted proposals now require task-run evidence (PR, tokens, output, CI logs) on at least one non-rate-limited failed session; also fixes lessonArea argument order to use stuck.Target before decision.Target |
| internal/state/state.go | Fingerprint now keyed on (failureClass, sourceSession, suggestedRule) instead of (failureClass, area); adds lessonProposalEquivalent fallback so in-flight proposals with old-style fingerprints still dedup correctly |
| internal/supervisor/supervisor.go | Introduces retryExhaustedSessionSupersededByIssueProgress to suppress stale retry-exhausted sessions when a newer session (Running/Queued/PROpen/CodeLanded/Done) has since made progress; replaces hasLiveRunningSessionForIssue in retryExhaustedRepairCandidate |
| internal/supervisor/supervisor_test.go | Adds TestDecide_RetryExhaustedSkippedWhenNewerSessionForIssueIsLive covering the core supersession path |
| internal/supervisor/lesson_proposal_test.go | New tests cover preflight-only skipping, correct area attribution, and the existing once-per-exhausted regression; test fixture updated to supply task-run evidence so the new gate does not silently suppress the original test |
| internal/state/lesson_proposal_test.go | Adds TestRecordLessonProposal_DedupsBySourceSessionAndRuleNotArea verifying dedup survives a rotated Area when FailureClass+Session+SuggestedRule are identical |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/supervisor.go:2522-2524
**Alive running session no longer blocks repair when it predates the exhausted session**

`retryExhaustedRepairCandidate` previously called `hasLiveRunningSessionForIssue`, which blocked repair candidate selection whenever any alive-PID running session existed for the same issue regardless of timestamps. The replacement `retryExhaustedSessionResolved` → `retryExhaustedSessionSupersededByIssueProgress` adds the requirement that the superseding session's `SessionChangedAt` must be strictly *after* `exhaustedAt`. A running session whose `StartedAt` and `LastOutputChangedAt` both predate the exhaustion timestamp (e.g., a stale-but-live background process that never emitted new output after the retries started) would not count as a superseder, so the exhausted session could be selected as a repair candidate and a second worker spawned on top of the still-running one. This scenario is unlikely in normal operation but it is a net reduction in the guard that was previously there.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["supervisor: dedupe retry exhausted lesso..."](https://github.com/befeast/maestro/commit/eaeead5f88c3cc30c241989d57adaca0f6e9c8a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35835016)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->