### PR TITLE
release: batched version-bump → tag on a cadence (link 2)

### DIFF
--- a/.github/maestro-release.yaml
+++ b/.github/maestro-release.yaml
@@ -1,0 +1,9 @@
+repo: BeFeast/maestro
+local_path: .
+
+versioning:
+  enabled: true
+  files:
+    - VERSION
+  default_bump: patch
+  tag_prefix: v

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,49 @@
+name: Version Bump
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: version-bump-main
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Bump and tag
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure version labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "version:major" --color "B60205" --description "Major version bump" --force
+          gh label create "version:minor" --color "0E8A16" --description "Minor version bump" --force
+          gh label create "version:patch" --color "1D76DB" --description "Patch version bump" --force
+
+      - name: Bump version since latest tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go run ./cmd/maestro/ version-bump --since-last-tag --config .github/maestro-release.yaml

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -2348,15 +2348,29 @@ func versionBumpCmd(args []string) {
 	fs := flag.NewFlagSet("version-bump", flag.ExitOnError)
 	configPath := fs.String("config", "", "Path to config file")
 	prNumber := fs.Int("pr", 0, "PR number to read labels/commits from")
+	sinceLastTag := fs.Bool("since-last-tag", false, "Bump once for commits since the latest version tag")
 	fs.Parse(args)
 
-	if *prNumber == 0 {
-		fmt.Fprintln(os.Stderr, "error: --pr is required")
+	if (*prNumber == 0 && !*sinceLastTag) || (*prNumber != 0 && *sinceLastTag) {
+		fmt.Fprintln(os.Stderr, "error: specify exactly one of --pr or --since-last-tag")
 		os.Exit(1)
 	}
 
 	cfg := loadConfig(*configPath)
 	gh := github.New(cfg.Repo)
+
+	if *sinceLastTag {
+		result, err := versioning.RunSinceLastTag(cfg, gh)
+		if err != nil {
+			log.Fatalf("version bump: %v", err)
+		}
+		if result.NoChanges {
+			fmt.Println("No version bump needed.")
+			return
+		}
+		fmt.Printf("Version bump complete: %s -> %s (%s).\n", result.OldVersion, result.NewVersion, result.BumpType)
+		return
+	}
 
 	if err := versioning.Run(cfg, gh, *prNumber); err != nil {
 		log.Fatalf("version bump: %v", err)

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -278,12 +278,18 @@ Worker tool hooks are default-off and opt in per project. `command` runs from th
 versioning:
   enabled: true
   files:
-    - "version.go"
-    - "package.json"
+    - "VERSION"
   default_bump: patch
   tag_prefix: v
   create_release: true
 ```
+
+For a batched release cadence, run `maestro version-bump --since-last-tag` from
+a scheduled GitHub Actions workflow with `workflow_dispatch`, full history
+checkout (`fetch-depth: 0`), and idempotent `version:major`,
+`version:minor`, and `version:patch` label creation. The workflow should use
+one repo-local config like `.github/maestro-release.yaml` with `files:
+[VERSION]`, `default_bump: patch`, and `tag_prefix: v`.
 
 ### Optional: model routing
 

--- a/docs/version-bump.md
+++ b/docs/version-bump.md
@@ -5,11 +5,16 @@ messages to determine the semver bump level (patch / minor / major), updates
 the version in configured files, commits the change, tags it, pushes, and
 optionally creates a GitHub release.
 
+`maestro version-bump --since-last-tag` performs the same update once for the
+whole batch of commits on `main` since the latest matching version tag. If the
+range is empty, it exits without committing or tagging.
+
 ## Usage
 
 ```bash
 maestro version-bump --pr 42
 maestro version-bump --pr 42 --config path/to/maestro.yaml
+maestro version-bump --since-last-tag --config path/to/maestro.yaml
 ```
 
 ## How It Works
@@ -26,7 +31,7 @@ contains a recognizable version pattern:
 
 ### 2. Detect bump type
 
-**Priority order — labels first, then commits, then default:**
+**For `--pr`, priority order is labels first, then commits, then default:**
 
 1. **PR labels** (highest priority): If the PR has a `version:` label, that
    determines the bump. When multiple version labels exist, the highest wins.
@@ -50,6 +55,14 @@ contains a recognizable version pattern:
 
 3. **Default bump**: If neither labels nor commits provide a signal, the
    `versioning.default_bump` config value is used (defaults to `patch`).
+
+For `--since-last-tag`, Maestro reads all commit messages since the latest
+`<tag_prefix>*` tag and extracts PR numbers from squash/merge commit messages
+such as `(#123)` and `Merge pull request #123`. It then computes one bump for
+the whole range from all discovered `version:*` PR labels plus conventional
+commit prefixes. The highest bump wins; if the range has commits but no signal,
+`versioning.default_bump` is used. If the range has no commits, no release is
+created.
 
 ### 3. Update files
 
@@ -76,8 +89,7 @@ Add a `versioning` block to your `maestro.yaml`:
 versioning:
   enabled: true
   files:
-    - Cargo.toml       # paths relative to local_path
-    - package.json
+    - VERSION          # paths relative to local_path
   default_bump: patch  # "patch", "minor", or "major"
   tag_prefix: v        # prepended to version in git tags
   create_release: true # create GitHub release on bump
@@ -85,23 +97,34 @@ versioning:
 
 ## Using in GitHub Actions
 
-`maestro version-bump` can run as a CI step triggered after PRs merge to
-`main`. This is how panoptikon's `.github/workflows/version-bump.yml` uses it:
+`maestro version-bump --since-last-tag` can run on a cadence and can also be
+replayed manually with `workflow_dispatch`. This produces at most one release
+per workflow run and produces none when there are no commits after the latest
+version tag:
 
 ```yaml
 name: Version Bump
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: version-bump-main
+  cancel-in-progress: false
 
 jobs:
   bump:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest  # or self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -110,24 +133,32 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Install maestro
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/BeFeast/maestro/main/install.sh | bash
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-      - name: Bump version
-        run: maestro version-bump --pr ${{ github.event.pull_request.number }}
+      - name: Ensure version labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "version:major" --color "B60205" --description "Major version bump" --force
+          gh label create "version:minor" --color "0E8A16" --description "Minor version bump" --force
+          gh label create "version:patch" --color "1D76DB" --description "Patch version bump" --force
+
+      - name: Bump version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go run ./cmd/maestro/ version-bump --since-last-tag --config .github/maestro-release.yaml
 ```
 
 ### GitHub Actions environment notes
 
 - `GH_TOKEN` must be set for `gh` CLI commands (PR label/commit reads, release
   creation). The default `GITHUB_TOKEN` works for most operations.
-- `fetch-depth: 0` is needed so git has full history for tagging.
+- `fetch-depth: 0` is needed so git has full history and tags.
 - Git user config is required for the commit step.
-- The workflow triggers on `pull_request.closed` with a merge check, so it only
-  runs for actually merged PRs.
+- The workflow checks the commit range itself, so scheduled runs with no merged
+  work after the latest tag are idempotent.
 
 ## Automatic mode (orchestrator)
 

--- a/internal/versioning/versioning.go
+++ b/internal/versioning/versioning.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -125,7 +126,7 @@ func DetectBumpFromLabels(labels []string, defaultBump string) (BumpType, bool) 
 
 // DetectBumpFromCommits parses conventional commit prefixes.
 // feat!: or BREAKING CHANGE → major, feat: → minor, fix: → patch.
-func DetectBumpFromCommits(messages []string, defaultBump string) BumpType {
+func DetectBumpSignalFromCommits(messages []string) (BumpType, bool) {
 	highest := BumpType(-1)
 	for _, msg := range messages {
 		lower := strings.ToLower(msg)
@@ -145,7 +146,16 @@ func DetectBumpFromCommits(messages []string, defaultBump string) BumpType {
 		}
 	}
 	if highest >= 0 {
-		return highest
+		return highest, true
+	}
+	return BumpPatch, false
+}
+
+// DetectBumpFromCommits parses conventional commit prefixes and returns the
+// configured default when no conventional-commit signal is present.
+func DetectBumpFromCommits(messages []string, defaultBump string) BumpType {
+	if bump, ok := DetectBumpSignalFromCommits(messages); ok {
+		return bump
 	}
 	return ParseBumpType(defaultBump)
 }
@@ -201,12 +211,12 @@ func UpdateVersionInFile(path, oldVer, newVer string) error {
 }
 
 // CommitAndTag creates a version bump commit and tag in the given repo.
-func CommitAndTag(repoPath, version, tagPrefix string) error {
+func CommitAndTag(repoPath, version, tagPrefix string, files []string) error {
 	tag := tagPrefix + version
 	commitMsg := fmt.Sprintf("chore: bump version to %s", version)
 
-	// Stage all changes
-	if out, err := runGit(repoPath, "add", "-A"); err != nil {
+	addArgs := append([]string{"add", "--"}, files...)
+	if out, err := runGit(repoPath, addArgs...); err != nil {
 		return fmt.Errorf("git add: %w\n%s", err, out)
 	}
 
@@ -255,6 +265,15 @@ type BumpResult struct {
 	BumpType   BumpType
 }
 
+// BatchBumpResult holds the result of a batched version bump.
+type BatchBumpResult struct {
+	BumpResult
+	LastTag     string
+	CommitCount int
+	PRNumbers   []int
+	NoChanges   bool
+}
+
 // DetectBump reads PR labels and commits to determine the bump type,
 // then computes the new version. It reads the current version from the
 // given files and uses labels-first with commit-message fallback.
@@ -289,6 +308,176 @@ func DetectBump(gh PRClient, prNumber int, files []string, defaultBump string) (
 
 	newVer := Bump(current, bumpType)
 	return BumpResult{OldVersion: current, NewVersion: newVer, BumpType: bumpType}, nil
+}
+
+var prNumberPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\(#(\d+)\)`),
+	regexp.MustCompile(`(?i)\bpull request #(\d+)\b`),
+}
+
+func extractPRNumbers(messages []string) []int {
+	seen := make(map[int]struct{})
+	for _, msg := range messages {
+		for _, pat := range prNumberPatterns {
+			for _, match := range pat.FindAllStringSubmatch(msg, -1) {
+				if len(match) < 2 {
+					continue
+				}
+				n, err := strconv.Atoi(match[1])
+				if err != nil || n <= 0 {
+					continue
+				}
+				seen[n] = struct{}{}
+			}
+		}
+	}
+	prs := make([]int, 0, len(seen))
+	for n := range seen {
+		prs = append(prs, n)
+	}
+	sort.Ints(prs)
+	return prs
+}
+
+func maxBump(a, b BumpType) BumpType {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// DetectBatchBump computes one bump for all commits and PR labels in a range.
+func DetectBatchBump(gh PRClient, files []string, defaultBump string, messages []string) (BumpResult, []int, error) {
+	currentStr, err := ReadCurrentVersion(files)
+	if err != nil {
+		return BumpResult{}, nil, fmt.Errorf("read current version: %w", err)
+	}
+	current, err := ParseVersion(currentStr)
+	if err != nil {
+		return BumpResult{}, nil, fmt.Errorf("parse current version: %w", err)
+	}
+
+	highest := BumpType(-1)
+	prNumbers := extractPRNumbers(messages)
+	for _, prNumber := range prNumbers {
+		labels, err := gh.PRLabels(prNumber)
+		if err != nil {
+			return BumpResult{}, nil, fmt.Errorf("get PR %d labels: %w", prNumber, err)
+		}
+		if bump, ok := DetectBumpFromLabels(labels, defaultBump); ok {
+			highest = maxBump(highest, bump)
+		}
+	}
+
+	if bump, ok := DetectBumpSignalFromCommits(messages); ok {
+		highest = maxBump(highest, bump)
+	}
+	if highest < 0 {
+		highest = ParseBumpType(defaultBump)
+	}
+
+	newVer := Bump(current, highest)
+	return BumpResult{OldVersion: current, NewVersion: newVer, BumpType: highest}, prNumbers, nil
+}
+
+func latestTag(repoPath, tagPrefix string) (string, error) {
+	match := tagPrefix + "*"
+	out, err := runGit(repoPath, "describe", "--tags", "--match", match, "--abbrev=0")
+	if err != nil {
+		return "", nil
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func commitMessagesSince(repoPath, tag string) ([]string, error) {
+	rangeArg := "HEAD"
+	if tag != "" {
+		rangeArg = tag + "..HEAD"
+	}
+	out, err := runGit(repoPath, "log", "--format=%B%x00", rangeArg)
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(out, "\x00")
+	messages := make([]string, 0, len(parts))
+	for _, part := range parts {
+		msg := strings.TrimSpace(part)
+		if msg == "" {
+			continue
+		}
+		messages = append(messages, msg)
+	}
+	return messages, nil
+}
+
+// RunSinceLastTag executes one batched version bump for commits since the
+// latest matching tag. If no commits exist in the range, it returns NoChanges.
+func RunSinceLastTag(cfg *config.Config, gh PRClient) (BatchBumpResult, error) {
+	if !cfg.Versioning.Enabled {
+		log.Printf("[versioning] disabled, skipping")
+		return BatchBumpResult{NoChanges: true}, nil
+	}
+
+	if len(cfg.Versioning.Files) == 0 {
+		return BatchBumpResult{}, fmt.Errorf("versioning enabled but no files configured")
+	}
+
+	if out, err := runGit(cfg.LocalPath, "checkout", "main"); err != nil {
+		return BatchBumpResult{}, fmt.Errorf("git checkout main: %w\n%s", err, out)
+	}
+	if out, err := runGit(cfg.LocalPath, "pull", "origin", "main"); err != nil {
+		return BatchBumpResult{}, fmt.Errorf("git pull: %w\n%s", err, out)
+	}
+
+	lastTag, err := latestTag(cfg.LocalPath, cfg.Versioning.TagPrefix)
+	if err != nil {
+		return BatchBumpResult{}, fmt.Errorf("find latest tag: %w", err)
+	}
+	messages, err := commitMessagesSince(cfg.LocalPath, lastTag)
+	if err != nil {
+		return BatchBumpResult{}, fmt.Errorf("list commits since %q: %w", lastTag, err)
+	}
+	if len(messages) == 0 {
+		log.Printf("[versioning] no commits since latest %s* tag, skipping", cfg.Versioning.TagPrefix)
+		return BatchBumpResult{LastTag: lastTag, NoChanges: true}, nil
+	}
+
+	files := ResolveFiles(cfg.LocalPath, cfg.Versioning.Files)
+	result, prs, err := DetectBatchBump(gh, files, cfg.Versioning.DefaultBump, messages)
+	if err != nil {
+		return BatchBumpResult{}, err
+	}
+	log.Printf("[versioning] bumping %s → %s (%s) from %d commit(s) since %s", result.OldVersion, result.NewVersion, result.BumpType, len(messages), lastTag)
+
+	oldStr := result.OldVersion.String()
+	newStr := result.NewVersion.String()
+	for _, f := range files {
+		if err := UpdateVersionInFile(f, oldStr, newStr); err != nil {
+			log.Printf("[versioning] warn: %v", err)
+			continue
+		}
+		log.Printf("[versioning] updated %s", f)
+	}
+
+	if err := CommitAndTag(cfg.LocalPath, newStr, cfg.Versioning.TagPrefix, files); err != nil {
+		return BatchBumpResult{}, fmt.Errorf("commit and tag: %w", err)
+	}
+	log.Printf("[versioning] committed and tagged %s%s", cfg.Versioning.TagPrefix, result.NewVersion)
+
+	if cfg.Versioning.CreateRelease {
+		tag := cfg.Versioning.TagPrefix + newStr
+		if err := gh.CreateRelease(tag, tag); err != nil {
+			return BatchBumpResult{}, fmt.Errorf("create release: %w", err)
+		}
+		log.Printf("[versioning] created release %s", tag)
+	}
+
+	return BatchBumpResult{
+		BumpResult:  result,
+		LastTag:     lastTag,
+		CommitCount: len(messages),
+		PRNumbers:   prs,
+	}, nil
 }
 
 // Run executes the full version bump flow for a merged PR.
@@ -331,7 +520,7 @@ func Run(cfg *config.Config, gh PRClient, prNumber int) error {
 	}
 
 	// Commit, tag, push
-	if err := CommitAndTag(cfg.LocalPath, newStr, cfg.Versioning.TagPrefix); err != nil {
+	if err := CommitAndTag(cfg.LocalPath, newStr, cfg.Versioning.TagPrefix, files); err != nil {
 		return fmt.Errorf("commit and tag: %w", err)
 	}
 	log.Printf("[versioning] committed and tagged %s%s", cfg.Versioning.TagPrefix, result.NewVersion)

--- a/internal/versioning/versioning_test.go
+++ b/internal/versioning/versioning_test.go
@@ -250,8 +250,9 @@ func TestResolveFiles(t *testing.T) {
 
 // mockPRClient implements PRClient for testing.
 type mockPRClient struct {
-	labels  []string
-	commits []string
+	labels     []string
+	commits    []string
+	labelsByPR map[int][]string
 
 	labelsErr  error
 	commitsErr error
@@ -261,6 +262,9 @@ type mockPRClient struct {
 }
 
 func (m *mockPRClient) PRLabels(prNumber int) ([]string, error) {
+	if m.labelsByPR != nil {
+		return m.labelsByPR[prNumber], m.labelsErr
+	}
 	return m.labels, m.labelsErr
 }
 
@@ -400,6 +404,91 @@ func TestDetectBump(t *testing.T) {
 			}
 			if result.NewVersion != tt.wantNew {
 				t.Errorf("NewVersion = %v, want %v", result.NewVersion, tt.wantNew)
+			}
+		})
+	}
+}
+
+func TestExtractPRNumbers(t *testing.T) {
+	got := extractPRNumbers([]string{
+		"feat: add batched release (#675)",
+		"Merge pull request #674 from BeFeast/release-cycle",
+		"docs: mention #999 without merge syntax",
+		"fix: duplicate (#675)",
+	})
+	want := []int{674, 675}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("extractPRNumbers() = %v, want %v", got, want)
+	}
+}
+
+func TestDetectBatchBump(t *testing.T) {
+	tests := []struct {
+		name        string
+		labelsByPR  map[int][]string
+		messages    []string
+		defaultBump string
+		wantBump    BumpType
+		wantNew     Version
+		wantPRs     []int
+	}{
+		{
+			name:        "minor label in batch wins",
+			labelsByPR:  map[int][]string{10: []string{"version:patch"}, 11: []string{"version:minor"}},
+			messages:    []string{"fix: typo (#10)", "chore: plumbing (#11)"},
+			defaultBump: "patch",
+			wantBump:    BumpMinor,
+			wantNew:     Version{1, 3, 0},
+			wantPRs:     []int{10, 11},
+		},
+		{
+			name:        "conventional commit fallback",
+			labelsByPR:  map[int][]string{12: []string{"bug"}},
+			messages:    []string{"feat: add API (#12)", "fix: typo"},
+			defaultBump: "patch",
+			wantBump:    BumpMinor,
+			wantNew:     Version{1, 3, 0},
+			wantPRs:     []int{12},
+		},
+		{
+			name:        "default patch without signals",
+			labelsByPR:  map[int][]string{13: []string{"maintenance"}},
+			messages:    []string{"chore: update docs (#13)"},
+			defaultBump: "patch",
+			wantBump:    BumpPatch,
+			wantNew:     Version{1, 2, 4},
+			wantPRs:     []int{13},
+		},
+		{
+			name:        "major commit beats minor label",
+			labelsByPR:  map[int][]string{14: []string{"version:minor"}},
+			messages:    []string{"feat!: replace API (#14)"},
+			defaultBump: "patch",
+			wantBump:    BumpMajor,
+			wantNew:     Version{2, 0, 0},
+			wantPRs:     []int{14},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			versionFile := filepath.Join(dir, "VERSION")
+			os.WriteFile(versionFile, []byte(`version = "1.2.3"`), 0644)
+
+			mock := &mockPRClient{labelsByPR: tt.labelsByPR}
+			result, prs, err := DetectBatchBump(mock, []string{versionFile}, tt.defaultBump, tt.messages)
+			if err != nil {
+				t.Fatalf("DetectBatchBump: %v", err)
+			}
+			if result.BumpType != tt.wantBump {
+				t.Fatalf("BumpType = %v, want %v", result.BumpType, tt.wantBump)
+			}
+			if result.NewVersion != tt.wantNew {
+				t.Fatalf("NewVersion = %v, want %v", result.NewVersion, tt.wantNew)
+			}
+			if fmt.Sprint(prs) != fmt.Sprint(tt.wantPRs) {
+				t.Fatalf("PRs = %v, want %v", prs, tt.wantPRs)
 			}
 		})
 	}


### PR DESCRIPTION
Refs #675

Maestro-Backend: codex openai gpt-5.5 medium (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a batched, cadenced release mode — `maestro version-bump --since-last-tag` — that processes all commits since the latest matching tag in one go, computes a single semver bump from PR labels and conventional-commit signals, and emits one release per scheduled run. It ships with a new daily GitHub Actions workflow, a repo-local config file, updated docs, and test coverage for the new batch logic.

- **`RunSinceLastTag` / `DetectBatchBump`** (`versioning.go`): new entry point that finds the latest tag via `git describe`, collects commit messages, extracts referenced PR numbers, aggregates label + commit signals, and calls the existing `CommitAndTag` path.
- **`CommitAndTag` signature change**: now takes an explicit `files []string` instead of staging everything with `git add -A`, making staged changes more precise; both the new and existing `Run` callers are updated.
- **Workflow** (`.github/workflows/version-bump.yml`): runs on cron (`17 6 * * *`) and `workflow_dispatch`, with a concurrency group to prevent overlapping runs and idempotent `version:*` label creation.

<h3>Confidence Score: 3/5</h3>

Two logic gaps in the core batch path should be addressed before this runs in production on a daily cadence.

The new `latestTag` helper silently converts any `git describe` failure into "no tag found", which causes the batch to fall back to scanning all commits in history — potentially triggering a major version bump from an unrelated past commit on any transient git error. Separately, `DetectBatchBump` returns a hard error if `gh.PRLabels` fails for any extracted PR number; because `(#N)` patterns in commit messages match issue references and other non-PR numbers, a single unresolvable reference permanently blocks every subsequent scheduled run until the tag is manually advanced.

internal/versioning/versioning.go — specifically `latestTag` (error handling) and the PR label fetch loop in `DetectBatchBump`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/versioning/versioning.go | Adds `RunSinceLastTag`, `DetectBatchBump`, `extractPRNumbers`, and refactors `CommitAndTag`/`DetectBumpFromCommits`. Two logic issues: `latestTag` swallows all git errors (treating real failures as "no tag"), and `DetectBatchBump` fails the whole batch when any PR label fetch errors. |
| .github/workflows/version-bump.yml | New scheduled + `workflow_dispatch` workflow; uses concurrency group to prevent races, `fetch-depth: 0` for full tag history, and idempotent label creation. Looks correct. |
| cmd/maestro/main.go | Adds `--since-last-tag` flag with a correct mutual-exclusion guard against `--pr`; routes to `RunSinceLastTag` and prints result. No issues. |
| internal/versioning/versioning_test.go | Adds `TestExtractPRNumbers` and `TestDetectBatchBump` covering label priority, conventional-commit fallback, default-patch, and major-beats-minor. Good coverage of the new batch path. |
| .github/maestro-release.yaml | New release config pointing at `VERSION` file with `patch` default and `v` prefix. Straightforward. |
| docs/version-bump.md | Documentation updated to describe the `--since-last-tag` mode, cadenced workflow, and idempotency. Accurate relative to the implementation. |
| docs/project-setup-runbook.md | Runbook updated to mention the batched cadence setup. No issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/versioning/versioning.go:383-390
`latestTag` swallows every non-zero exit from `git describe` and returns `("", nil)`. The intended case is "no matching tags yet" (bootstrap), but any real git failure — corrupted refs, a missing `--tags` fetch, or an unexpected error message — is also silently treated as "no tag found". `commitMessagesSince` then falls back to `rangeArg = "HEAD"`, which feeds every commit in the repository's history into `DetectBatchBump`. That can produce an unintended major version bump and a noisy batch of PR label lookups on the very first failure.

```suggestion
func latestTag(repoPath, tagPrefix string) (string, error) {
	match := tagPrefix + "*"
	out, err := runGit(repoPath, "describe", "--tags", "--match", match, "--abbrev=0")
	if err != nil {
		// "No names found" is the expected message when no matching tag exists yet.
		if strings.Contains(out, "No names found") || strings.Contains(out, "cannot describe") {
			return "", nil
		}
		return "", fmt.Errorf("git describe: %w\n%s", err, out)
	}
	return strings.TrimSpace(out), nil
}
```

### Issue 2 of 2
internal/versioning/versioning.go:362-369
**Batch fails permanently on inaccessible PR reference**

`extractPRNumbers` uses the broad pattern `(#\d+)` which matches any parenthesised hash-number in a commit message — including issue references, changelog notes, or manually written messages. If a matched number has no corresponding PR (e.g. it's a GitHub issue, a PR from a deleted fork, or a plain text reference like `(#0)`), `gh.PRLabels` will return a 404/error and the entire batch is aborted. Because the commit stays in the history after the tag, every subsequent scheduled run will hit the same error until someone manually advances the tag.

Consider logging a warning and continuing rather than returning a hard error, similar to how `Run` handles `PRCommits` failures.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release: add batched version bump workfl..."](https://github.com/befeast/maestro/commit/8d67b2d8934402d78f9a9bedf15f189b25958fb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35838700)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->