### PR TITLE
release: fleet deploy stamps the real release version (link 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ Requires Go 1.22+.
 ```bash
 git clone https://github.com/BeFeast/maestro
 cd maestro
-go build ./cmd/maestro/
+VERSION="$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' VERSION)"
+test -n "$VERSION"
+go build -trimpath -ldflags "-X main.version=${VERSION}" ./cmd/maestro/
 sudo mv maestro /usr/local/bin/  # or add to PATH
 ```
 

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -127,6 +127,17 @@ Fleet Mission Control is an observation surface. It loads each project config, r
 
 The project runner remains the execution surface. It starts workers, reconciles dead sessions, opens and monitors PRs, waits for review gates, merges eligible PRs, deploys when configured, and updates local state.
 
+When deploying Maestro itself from source on the fleet host, stamp the binary with the release version from `VERSION`; an unstamped source build leaves `maestro version` reporting build metadata instead of the release. Use the same stamped build shape as the release workflow, then verify the installed binary:
+
+```bash
+cd /path/to/repos/maestro
+git pull --ff-only origin main
+VERSION="$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' VERSION)"
+test -n "$VERSION"
+go build -trimpath -ldflags "-X main.version=${VERSION}" -o maestro ./cmd/maestro/
+./maestro version
+```
+
 The supervisor is the explainability and policy surface. It records queue analysis, selected candidates, stuck states, outcome context, safe label mutations, and approval requests. Safe actions are limited to actions explicitly listed in `supervisor.safe_actions`. Risky recommendations are recorded for an operator; approving them with the CLI records the approval but does not execute the risky action by itself.
 
 Each project card shows an outcome status: goal, runtime target, health state, and next action. If no `outcome` brief is configured, Mission Control says so explicitly because merged PR throughput is not the same as a working runtime. If PRs keep merging while runtime health is unknown or failing, the supervisor records `no_outcome_progress` and recommends a read-only deploy/runtime check instead of mutating production.

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -53,6 +53,30 @@ func TestAssemblePromptIncludesSearchSafetyGuardrails(t *testing.T) {
 	}
 }
 
+func TestGoWorkerPromptUsesStampedMaestroBuild(t *testing.T) {
+	promptPath := filepath.Join("..", "..", "worker-prompt-go.md")
+	data, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", promptPath, err)
+	}
+	prompt := string(data)
+
+	required := []string{
+		`VERSION="$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' VERSION)"`,
+		`go build -trimpath -ldflags "-X main.version=${VERSION}" ./cmd/maestro/`,
+		`./maestro version`,
+	}
+	for _, want := range required {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("worker-prompt-go.md missing %q", want)
+		}
+	}
+	unstampedBuild := "\ngo build " + "./cmd/maestro/"
+	if strings.Contains(prompt, unstampedBuild) {
+		t.Fatalf("worker-prompt-go.md still contains an unstamped maestro build")
+	}
+}
+
 func TestAssemblePromptIncludesRepoRulesFromAgentsFile(t *testing.T) {
 	worktree := t.TempDir()
 	if err := os.WriteFile(filepath.Join(worktree, "AGENTS.md"), []byte("## Rules\n- Run go test ./...\n"), 0644); err != nil {

--- a/worker-prompt-go.md
+++ b/worker-prompt-go.md
@@ -27,9 +27,11 @@ git rebase origin/main
 go fmt ./...
 go vet ./...
 go test ./...
-go build ./cmd/maestro/
+VERSION="$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' VERSION)"
+test -n "$VERSION"
+go build -trimpath -ldflags "-X main.version=${VERSION}" ./cmd/maestro/
 ```
-All four must pass before creating a PR. If rebase has conflicts, resolve them.
+All commands must pass before creating a PR. If rebase has conflicts, resolve them.
 
 ### 3. Go conventions
 - Run `go fmt ./...` before every commit
@@ -41,7 +43,9 @@ All four must pass before creating a PR. If rebase has conflicts, resolve them.
 
 ### 4. Build verification
 ```bash
-go build ./cmd/maestro/
+VERSION="$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' VERSION)"
+test -n "$VERSION"
+go build -trimpath -ldflags "-X main.version=${VERSION}" ./cmd/maestro/
 ./maestro version
 ```
 Binary must build successfully before creating PR.


### PR DESCRIPTION
Refs #676

Maestro-Backend: codex openai gpt-5.5 medium (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ensures that every place where the Maestro binary is built from source — the worker prompt, the README install snippet, and the fleet runbook — uses a version-stamped build (`-ldflags \"-X main.version=${VERSION}\"`) instead of a plain `go build`, so `maestro version` reports the real release tag rather than build metadata.

- `worker-prompt-go.md` and `README.md` replace the bare `go build ./cmd/maestro/` with the `VERSION`-extraction + `test -n` guard + stamped build in both the pre-PR sequence and the build-verification section.
- `docs/fleet-mission-control-runbook.md` adds a new fleet-deploy snippet that mirrors the same stamped shape and includes `./maestro version` to verify the binary before installing.
- `internal/worker/worker_prompt_test.go` adds `TestGoWorkerPromptUsesStampedMaestroBuild` to lock in the required strings and reject the old unstamped pattern.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are documentation and test additions with no runtime logic affected.

The three documentation locations are updated consistently and the VERSION file format matches the sed command exactly. The new test correctly validates the worker prompt, but its required-strings list is missing the `test -n "$VERSION"` guard, which means that safety check could be dropped later without the test catching it. The unstamped-build negative check is also narrower than ideal. Neither issue blocks this change.

internal/worker/worker_prompt_test.go — the new test's assertion coverage has two minor gaps worth tightening.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| worker-prompt-go.md | Updated both the pre-PR mandatory sequence and the build-verification section to use a stamped build with version from VERSION file; the changes are self-consistent. |
| internal/worker/worker_prompt_test.go | Adds TestGoWorkerPromptUsesStampedMaestroBuild to assert the worker prompt contains the stamped build commands and lacks the old unstamped form; the test omits a check for the `test -n "$VERSION"` guard line, so that guard could be silently removed later without test failure. |
| README.md | Manual install snippet updated to use the stamped build; `test -n "$VERSION"` guard included, consistent with other locations. |
| docs/fleet-mission-control-runbook.md | Added a new runbook section describing how to stamp and install Maestro from source on the fleet host; uses `-o maestro` and follows with `./maestro version` for in-place verification before overwriting the running binary. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/worker/worker_prompt_test.go:64-68
The `required` slice checks for the version-extraction line and the stamped `go build` command, but omits `test -n "$VERSION"`. That guard is the safety net that causes the whole sequence to abort when the `VERSION` file is missing or the sed command produces an empty string. Without this assertion, the guard line could be removed from `worker-prompt-go.md` in a future edit and the test would not catch it.

```suggestion
	required := []string{
		`VERSION="$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' VERSION)"`,
		`test -n "$VERSION"`,
		`go build -trimpath -ldflags "-X main.version=${VERSION}" ./cmd/maestro/`,
		`./maestro version`,
	}
```

### Issue 2 of 2
internal/worker/worker_prompt_test.go:74-77
**Narrow unstamped-build detection pattern**

The negative check matches only the exact old form `\ngo build ./cmd/maestro/`. An alternative unstamped form — e.g. `go build -o maestro ./cmd/maestro/` or `go build -race ./cmd/maestro/` without the version ldflags — would not be caught. The guard protects against regression of the specific old pattern, but a future editor adding a new unstamped variant would pass the test undetected. Consider checking for the absence of `go build` commands that lack `-ldflags` instead, or at minimum document that the check is intentionally narrow.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release: stamp maestro deploy builds"](https://github.com/befeast/maestro/commit/27bc7c7d1886a51da7d3bdc48f16507c55abb0f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35841564)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->