### PR TITLE
worker: backend dispatch keyed on name silently degrades custom-named backends (lost bypass flags + argv prompt) (#684)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,28 @@ model:
 > Headless mode: `cline -y "task"` — auto-approves all actions and exits when done.
 > SAP AI Core example: set provider to `sapaicore`, model to `anthropic--claude-4.5-opus`.
 
+### Custom-named backends
+
+Backends do not have to be named after the CLI they run. A custom key (e.g. a model nickname) keeps full CLI-specific behaviour — permission-bypass flags and stdin prompt delivery — as long as Maestro can tell which CLI it wraps. Resolution order:
+
+1. the backend name itself (`claude`, `codex`, `gemini`, `cline`),
+2. the `provider` field (`anthropic`/`claude` → Claude, `openai`/`codex` → Codex, `google`/`gemini` → Gemini, `cline` → Cline),
+3. the binary basename of `cmd` (`claude`, `codex`, `gemini`, `cline`).
+
+```yaml
+model:
+  default: fable
+  backends:
+    fable:
+      provider: anthropic    # → claude exec path (--dangerously-skip-permissions, -p, prompt via stdin)
+      cmd: claude --model claude-fable-5 --effort xhigh
+    fast:
+      provider: openai       # → codex exec path (exec, bypass flag, prompt via stdin)
+      cmd: codex --profile fast
+```
+
+A backend that matches none of the above falls back to the generic exec path: `prompt_mode` applies, no permission-bypass flag is added, and Maestro logs a startup warning naming the backend. Use the generic path only for genuinely custom CLIs.
+
 ### Optional worker MCP tools
 
 Worker sessions receive no MCP tools by default. Attach project-specific MCP servers per backend with `model.backends.<name>.mcp`:

--- a/internal/config/backend_kind.go
+++ b/internal/config/backend_kind.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Backend kinds name the CLI-specific exec path a backend resolves to.
+// Workers use the kind (not the raw backend name) to pick the command
+// builder, so a known CLI registered under a custom backend key keeps its
+// CLI-specific behaviour: permission-bypass flags and stdin prompt
+// delivery. #684.
+const (
+	BackendKindClaude  = "claude"
+	BackendKindCodex   = "codex"
+	BackendKindGemini  = "gemini"
+	BackendKindCline   = "cline"
+	BackendKindGeneric = "generic"
+)
+
+// providerBackendKinds maps the per-backend provider attribution field
+// (#513) to the CLI family it implies. Providers without a first-class
+// CLI integration (e.g. "groq") are intentionally absent and resolve via
+// the cmd-basename heuristic or the generic path.
+var providerBackendKinds = map[string]string{
+	"anthropic": BackendKindClaude,
+	"claude":    BackendKindClaude,
+	"openai":    BackendKindCodex,
+	"codex":     BackendKindCodex,
+	"google":    BackendKindGemini,
+	"gemini":    BackendKindGemini,
+	"cline":     BackendKindCline,
+}
+
+// ResolveBackendKind decides which CLI-specific exec path a backend uses.
+// Resolution order (#684):
+//  1. the backend name itself — claude/codex/gemini/cline keys keep their
+//     existing behaviour,
+//  2. the per-backend provider field (anthropic → claude, openai → codex, …),
+//  3. the binary basename of cmd's first token (claude/codex/gemini/cline),
+//  4. the generic fallback (prompt_mode applies, no permission-bypass flag).
+//
+// Before #684, dispatch was keyed on the name alone: the Anthropic CLI
+// registered as `fable:` silently fell through to the generic path, lost
+// --dangerously-skip-permissions and stdin prompt delivery, and every
+// mutating tool call was denied by the CLI's permission layer (sup-175).
+func ResolveBackendKind(name, provider, cmd string) string {
+	switch name {
+	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline:
+		return name
+	}
+	if kind, ok := providerBackendKinds[strings.ToLower(strings.TrimSpace(provider))]; ok {
+		return kind
+	}
+	if kind := backendKindFromCmd(cmd); kind != "" {
+		return kind
+	}
+	return BackendKindGeneric
+}
+
+// backendKindFromCmd matches the binary basename of cmd's first token
+// against the known CLIs. Returns "" when there is no match.
+func backendKindFromCmd(cmd string) string {
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return ""
+	}
+	switch base := filepath.Base(fields[0]); base {
+	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline:
+		return base
+	}
+	return ""
+}
+
+// backendResolutionWarnings surfaces backends whose exec path is unlikely
+// to be what the operator intended (#684):
+//
+//   - a backend that resolves to the generic path loses CLI permission
+//     bypass and (unless prompt_mode=stdin) argv prompt delivery risks
+//     E2BIG on large prompts — loud warning naming the backend;
+//   - a backend whose resolved kind disagrees with the cmd binary
+//     (e.g. provider: openai with a claude binary) will pass one CLI's
+//     flags to another CLI.
+//
+// Non-agentic backends are skipped: they are text-completion helpers that
+// never run as workers (config.parse rejects them from the worker chain),
+// so the generic path is their expected shape.
+func (c *Config) backendResolutionWarnings() []string {
+	var warnings []string
+	for _, name := range sortedBackendNames(c.Model.Backends) {
+		def := c.Model.Backends[name]
+		if def.Enabled != nil && !*def.Enabled {
+			continue
+		}
+		if def.NonAgentic {
+			continue
+		}
+		kind := ResolveBackendKind(name, def.Provider, def.Cmd)
+		if kind == BackendKindGeneric {
+			warnings = append(warnings, fmt.Sprintf(
+				"config: backend %q resolves to the generic exec path (provider %q and cmd %q match no known CLI) — workers run without a permission-bypass flag (mutating tool calls may be denied) and the prompt is delivered per prompt_mode=%q (argv delivery risks E2BIG on large prompts). If this wraps a known CLI, set provider: anthropic|openai|google|cline or use a claude/codex/gemini/cline binary in cmd.",
+				name, def.Provider, def.Cmd, coalescePromptMode(def.PromptMode)))
+			continue
+		}
+		if cmdKind := backendKindFromCmd(def.Cmd); cmdKind != "" && cmdKind != kind {
+			warnings = append(warnings, fmt.Sprintf(
+				"config: backend %q resolves to the %s exec path but cmd %q runs the %s binary — %s-specific flags will be passed to %s. Align the provider field with the cmd binary or rename the backend.",
+				name, kind, def.Cmd, cmdKind, kind, cmdKind))
+		}
+	}
+	return warnings
+}
+
+func sortedBackendNames(backends map[string]BackendDef) []string {
+	names := make([]string, 0, len(backends))
+	for name := range backends {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func coalescePromptMode(mode string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(mode))
+	if trimmed == "" {
+		return "arg"
+	}
+	return trimmed
+}

--- a/internal/config/backend_kind_test.go
+++ b/internal/config/backend_kind_test.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #684: exec-path resolution order — known name, then provider field, then
+// cmd binary basename, then generic.
+func TestResolveBackendKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		cmd      string
+		want     string
+	}{
+		// 1. Known backend names keep their behaviour regardless of other fields.
+		{"claude", "", "", BackendKindClaude},
+		{"codex", "", "", BackendKindCodex},
+		{"gemini", "", "gemini-cli", BackendKindGemini},
+		{"cline", "", "", BackendKindCline},
+		// 2. Provider field resolves custom names (sup-175 `fable:` shape).
+		{"fable", "anthropic", "claude --model claude-fable-5 --effort xhigh", BackendKindClaude},
+		{"fast", "openai", "codex --profile fast", BackendKindCodex},
+		{"flash", "google", "gemini", BackendKindGemini},
+		{"wrapped", "cline", "cline", BackendKindCline},
+		// Provider matching is case/whitespace-insensitive.
+		{"fable", " Anthropic ", "", BackendKindClaude},
+		// Provider wins over a conflicting cmd binary.
+		{"odd", "openai", "claude", BackendKindCodex},
+		// 3. cmd binary basename is the second heuristic.
+		{"mymodel", "", "/usr/local/bin/claude --model opus", BackendKindClaude},
+		{"mymodel", "", "codex --flag", BackendKindCodex},
+		{"mymodel", "groq", "gemini", BackendKindGemini},
+		// 4. Everything else is generic.
+		{"helper", "groq", "groq-cli", BackendKindGeneric},
+		{"custom", "", "my-cli --verbose", BackendKindGeneric},
+		{"empty", "", "", BackendKindGeneric},
+		// Basename matching is exact — gemini-cli under a custom name is not gemini.
+		{"custom-gemini", "", "gemini-cli", BackendKindGeneric},
+	}
+	for _, tt := range tests {
+		if got := ResolveBackendKind(tt.name, tt.provider, tt.cmd); got != tt.want {
+			t.Errorf("ResolveBackendKind(%q, %q, %q) = %q, want %q", tt.name, tt.provider, tt.cmd, got, tt.want)
+		}
+	}
+}
+
+// #684: a backend that resolves to the generic exec path must warn loudly at
+// startup, naming the backend and what it loses.
+func TestConfig_Warnings_GenericPathBackendWarns(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "mystery",
+			Backends: map[string]BackendDef{
+				"mystery": {Cmd: "my-cli --verbose"},
+			},
+		},
+	}
+	warnings := cfg.Warnings()
+	found := false
+	for _, msg := range warnings {
+		if strings.Contains(msg, `"mystery"`) && strings.Contains(msg, "generic exec path") && strings.Contains(msg, "permission-bypass") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Warnings() = %v, want a generic exec path warning naming the backend and the lost permission bypass", warnings)
+	}
+}
+
+// #684: a custom-named backend that resolves via provider (or cmd basename)
+// keeps the CLI-specific path — no generic-path warning.
+func TestConfig_Warnings_CustomBackendProviderResolvedNoWarning(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "fable",
+			Backends: map[string]BackendDef{
+				"fable":   {Provider: "anthropic", Cmd: "claude --model claude-fable-5 --effort xhigh"},
+				"mymodel": {Cmd: "/usr/local/bin/codex --profile fast"},
+			},
+		},
+	}
+	for _, msg := range cfg.Warnings() {
+		if strings.Contains(msg, "generic exec path") {
+			t.Fatalf("Warnings() = %v, provider/basename-resolved backends should not trigger the generic path warning", cfg.Warnings())
+		}
+	}
+}
+
+// Known backend names never trigger the generic-path warning.
+func TestConfig_Warnings_KnownBackendNamesNoGenericWarning(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "claude",
+			Backends: map[string]BackendDef{
+				"claude": {Cmd: "claude"},
+			},
+		},
+	}
+	for _, msg := range cfg.Warnings() {
+		if strings.Contains(msg, "generic exec path") {
+			t.Fatalf("Warnings() = %v, known backend names should not trigger the generic path warning", cfg.Warnings())
+		}
+	}
+}
+
+// Non-agentic text-completion helpers never run as workers — the generic
+// path is their expected shape, so they must stay silent.
+func TestConfig_Warnings_NonAgenticGenericNoWarning(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "claude",
+			Backends: map[string]BackendDef{
+				"claude": {Cmd: "claude"},
+				"helper": {Cmd: "groq-cli", Provider: "groq", NonAgentic: true},
+			},
+		},
+	}
+	for _, msg := range cfg.Warnings() {
+		if strings.Contains(msg, "generic exec path") {
+			t.Fatalf("Warnings() = %v, non-agentic backends should not trigger the generic path warning", cfg.Warnings())
+		}
+	}
+}
+
+// Disabled backends are not dispatched — no warning.
+func TestConfig_Warnings_DisabledGenericBackendNoWarning(t *testing.T) {
+	disabled := false
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "claude",
+			Backends: map[string]BackendDef{
+				"claude": {Cmd: "claude"},
+				"old":    {Cmd: "my-cli", Enabled: &disabled},
+			},
+		},
+	}
+	for _, msg := range cfg.Warnings() {
+		if strings.Contains(msg, "generic exec path") {
+			t.Fatalf("Warnings() = %v, disabled backends should not trigger the generic path warning", cfg.Warnings())
+		}
+	}
+}
+
+// #684: a resolved kind that disagrees with the cmd binary (provider: openai
+// driving a claude binary) gets one CLI's flags passed to another — warn.
+func TestConfig_Warnings_ProviderCmdMismatchWarns(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "odd",
+			Backends: map[string]BackendDef{
+				"odd": {Provider: "openai", Cmd: "claude --model opus"},
+			},
+		},
+	}
+	warnings := cfg.Warnings()
+	found := false
+	for _, msg := range warnings {
+		if strings.Contains(msg, `"odd"`) && strings.Contains(msg, "codex exec path") && strings.Contains(msg, "claude binary") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Warnings() = %v, want a provider/cmd mismatch warning", warnings)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1391,6 +1391,7 @@ func (c *Config) Warnings() []string {
 	if msg := c.manualRoutingLabelPinWarning(); msg != "" {
 		warnings = append(warnings, msg)
 	}
+	warnings = append(warnings, c.backendResolutionWarnings()...)
 	return warnings
 }
 

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -82,6 +82,7 @@ func (c *backendLLMClient) Complete(prompt string) (string, error) {
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+		Provider:   backendDef.Provider,
 		Model:      c.cfg.Supervisor.Model,
 		Effort:     c.cfg.Supervisor.Effort,
 	}

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -27,6 +27,7 @@ type BackendConfig struct {
 	Cmd        string   // binary name (e.g. "claude", "codex", "gemini")
 	ExtraArgs  []string // additional args from config
 	PromptMode string   // how to deliver prompt: "arg", "stdin", "file"
+	Provider   string   // per-backend provider field; resolves the exec path for custom-named backends (#684)
 	Model      string   // optional model name for role-specific backend calls
 	Effort     string   // optional reasoning effort for role-specific backend calls
 	MCP        config.MCPConfig
@@ -337,17 +338,27 @@ func tomlStringMap(values map[string]string) string {
 	return "{" + strings.Join(parts, ",") + "}"
 }
 
-// BuildWorkerCmd creates the right exec.Cmd based on backend name.
-// Known backends (claude, codex, gemini) use their specific command builders.
-// Unknown backends use the generic builder with prompt_mode from config.
-// Returns the command, an optional stdinFile path (for backends that read
-// the prompt via stdin, e.g. codex), and any error.
-func BuildWorkerCmd(backendName string, cfg BackendConfig, promptFile, worktree string) (cmd *exec.Cmd, stdinFile string, err error) {
+// resolveBackendKind maps a backend name + config to the CLI-specific exec
+// path (#684). Custom-named backends resolve by the per-backend provider
+// field, then by the binary basename of cmd, so a known CLI registered under
+// a custom key (e.g. `fable: {provider: anthropic, cmd: "claude --model …"}`)
+// keeps its CLI-specific behaviour — permission-bypass flags and stdin prompt
+// delivery — instead of silently degrading to the generic path.
+func resolveBackendKind(backendName string, cfg BackendConfig) string {
 	if backendName == "" {
 		backendName = "claude"
 	}
+	return config.ResolveBackendKind(backendName, cfg.Provider, cfg.Cmd)
+}
 
-	if b, ok := knownBackends[backendName]; ok {
+// BuildWorkerCmd creates the right exec.Cmd for a backend. The backend name,
+// provider field, and cmd binary resolve to a CLI-specific builder (claude,
+// codex, gemini, cline — see resolveBackendKind); anything else uses the
+// generic builder with prompt_mode from config.
+// Returns the command, an optional stdinFile path (for backends that read
+// the prompt via stdin, e.g. claude/codex), and any error.
+func BuildWorkerCmd(backendName string, cfg BackendConfig, promptFile, worktree string) (cmd *exec.Cmd, stdinFile string, err error) {
+	if b, ok := knownBackends[resolveBackendKind(backendName, cfg)]; ok {
 		return b.BuildCmd(cfg, promptFile, worktree)
 	}
 
@@ -357,13 +368,11 @@ func BuildWorkerCmd(backendName string, cfg BackendConfig, promptFile, worktree 
 
 // BuildSupervisorCmd creates a read-only model command for supervisor decisions.
 // It reuses backend prompt delivery semantics but intentionally avoids worker-only
-// permission bypass flags.
+// permission bypass flags. Like BuildWorkerCmd, the exec path is resolved from
+// the backend name, provider field, and cmd binary (#684) so custom-named
+// backends keep stdin prompt delivery.
 func BuildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, worktree string) (cmd *exec.Cmd, stdinFile string, err error) {
-	if backendName == "" {
-		backendName = "claude"
-	}
-
-	switch backendName {
+	switch resolveBackendKind(backendName, cfg) {
 	case "claude":
 		claudeCmd := cfg.Cmd
 		if claudeCmd == "" {

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -718,6 +719,172 @@ func TestBuildWorkerCmd_CmdWithArgs(t *testing.T) {
 	}
 	if !strings.Contains(args, "--debug") {
 		t.Errorf("expected --debug in args, got: %s", args)
+	}
+}
+
+// #684: the Anthropic CLI registered under a custom backend key (the sup-175
+// `fable:` shape) must build the exact same exec invocation as the `claude:`
+// key — skip-permissions flag, -p, prompt via stdin — resolved via the
+// per-backend provider field.
+func TestBuildWorkerCmd_CustomNameProviderAnthropic(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("implement the issue"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	worktree := "/tmp/fable-worktree"
+
+	cfg := BackendConfig{Cmd: "claude --model claude-fable-5 --effort xhigh", Provider: "anthropic"}
+	cmd, stdinFile, err := BuildWorkerCmd("fable", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--dangerously-skip-permissions") {
+		t.Errorf("expected --dangerously-skip-permissions in args, got: %s", args)
+	}
+	if !strings.Contains(args, "-p") {
+		t.Errorf("expected -p in args, got: %s", args)
+	}
+	if strings.Contains(args, "implement the issue") {
+		t.Errorf("prompt content must not appear in argv (stdin delivery): %s", args)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+
+	// Same invocation as the claude: key with the same cmd.
+	direct, directStdin, err := BuildWorkerCmd("claude", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error building claude-key cmd: %v", err)
+	}
+	if !reflect.DeepEqual(cmd.Args, direct.Args) {
+		t.Errorf("custom-name args = %v, want same as claude-key args %v", cmd.Args, direct.Args)
+	}
+	if stdinFile != directStdin {
+		t.Errorf("custom-name stdinFile = %q, want same as claude-key %q", stdinFile, directStdin)
+	}
+}
+
+// #684: provider: openai under a custom key must build the codex exec shape
+// (exec subcommand, bypass flag, -C worktree, stdin prompt via "-").
+func TestBuildWorkerCmd_CustomNameProviderOpenAI(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("implement the issue"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	worktree := "/tmp/fast-worktree"
+
+	cfg := BackendConfig{Cmd: "codex --profile fast", Provider: "openai"}
+	cmd, stdinFile, err := BuildWorkerCmd("fast", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "exec") {
+		t.Errorf("expected 'exec' subcommand in args, got: %s", args)
+	}
+	if !strings.Contains(args, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Errorf("expected --dangerously-bypass-approvals-and-sandbox in args, got: %s", args)
+	}
+	if !strings.Contains(args, "-C "+worktree) {
+		t.Errorf("expected -C %s in args, got: %s", worktree, args)
+	}
+	if cmd.Args[len(cmd.Args)-1] != "-" {
+		t.Errorf("expected stdin prompt marker '-' as last arg, got: %v", cmd.Args)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+
+	// Same invocation as the codex: key with the same cmd.
+	direct, _, err := BuildWorkerCmd("codex", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error building codex-key cmd: %v", err)
+	}
+	if !reflect.DeepEqual(cmd.Args, direct.Args) {
+		t.Errorf("custom-name args = %v, want same as codex-key args %v", cmd.Args, direct.Args)
+	}
+}
+
+// #684 second heuristic: no provider set, but the cmd binary basename is a
+// known CLI — must still resolve to the CLI-specific path.
+func TestBuildWorkerCmd_CustomNameCmdBasenameFallback(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("do the thing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BackendConfig{Cmd: "/usr/local/bin/claude --model opus"}
+	cmd, stdinFile, err := BuildWorkerCmd("mymodel", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--dangerously-skip-permissions") {
+		t.Errorf("expected --dangerously-skip-permissions in args, got: %s", args)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	if strings.Contains(args, "do the thing") {
+		t.Errorf("prompt content must not appear in argv (stdin delivery): %s", args)
+	}
+}
+
+// #684: a genuinely custom CLI (unknown provider, unknown binary) keeps the
+// generic path and its prompt_mode semantics.
+func TestBuildWorkerCmd_UnknownProviderStaysGeneric(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("stdin prompt"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BackendConfig{Cmd: "groq-cli --auto", Provider: "groq", PromptMode: "stdin"}
+	cmd, stdinFile, err := BuildWorkerCmd("helper", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if strings.Contains(args, "dangerously") {
+		t.Errorf("generic backend must not gain CLI permission-bypass flags: %s", args)
+	}
+}
+
+// #684: supervisor commands for custom-named claude backends keep stdin
+// prompt delivery and still avoid worker-only bypass flags.
+func TestBuildSupervisorCmd_CustomNameProviderAnthropic(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("decide safely"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BackendConfig{Cmd: "claude --model claude-fable-5", Provider: "anthropic"}
+	cmd, stdinFile, err := BuildSupervisorCmd("fable", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "-p") {
+		t.Errorf("expected -p in args, got: %s", args)
+	}
+	if strings.Contains(args, "dangerously") || strings.Contains(args, "bypass") {
+		t.Errorf("supervisor command should not include worker permission bypass flags: %s", args)
+	}
+	if strings.Contains(args, "decide safely") {
+		t.Errorf("prompt content must not appear in argv (stdin delivery): %s", args)
 	}
 }
 

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -124,10 +124,11 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+		Provider:   backendDef.Provider,
 		MCP:        backendDef.MCP,
 	}
 
-	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, backendName, cfg.Hooks)
+	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
 	if err != nil {
 		return fmt.Errorf("setup worker tool hooks: %w", err)
 	}

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -42,10 +42,11 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+		Provider:   backendDef.Provider,
 		MCP:        backendDef.MCP,
 	}
 
-	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, backendName, cfg.Hooks)
+	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
 	if err != nil {
 		return fmt.Errorf("setup worker tool hooks: %w", err)
 	}

--- a/internal/worker/tool_hooks.go
+++ b/internal/worker/tool_hooks.go
@@ -23,7 +23,10 @@ type workerToolHookSetup struct {
 	Claude     bool
 }
 
-func setupWorkerToolHooks(stateDir, worktree, backendName string, hooks config.HooksConfig) (workerToolHookSetup, error) {
+// setupWorkerToolHooks prepares the hook runner. backendKind is the resolved
+// exec-path kind from resolveBackendKind (not the raw config key), so a claude
+// CLI under a custom backend name still gets the automatic hook installer (#684).
+func setupWorkerToolHooks(stateDir, worktree, backendKind string, hooks config.HooksConfig) (workerToolHookSetup, error) {
 	if !toolHookConfigured(hooks.PreTool) && !toolHookConfigured(hooks.PostEdit) {
 		return workerToolHookSetup{}, nil
 	}
@@ -40,7 +43,7 @@ func setupWorkerToolHooks(stateDir, worktree, backendName string, hooks config.H
 	}
 
 	setup := workerToolHookSetup{RunnerPath: runnerPath}
-	if backendName == "claude" {
+	if backendKind == config.BackendKindClaude {
 		if err := writeClaudeToolHookSettings(worktree, runnerPath, hooks); err != nil {
 			return setup, err
 		}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -107,10 +107,11 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+		Provider:   backendDef.Provider,
 		MCP:        backendDef.MCP,
 	}
 
-	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, backendName, cfg.Hooks)
+	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
 	if err != nil {
 		return "", fmt.Errorf("setup worker tool hooks: %w", err)
 	}
@@ -254,10 +255,11 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 		Cmd:        backendDef.Cmd,
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
+		Provider:   backendDef.Provider,
 		MCP:        backendDef.MCP,
 	}
 
-	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, backendName, cfg.Hooks)
+	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
 	if err != nil {
 		return fmt.Errorf("setup worker tool hooks: %w", err)
 	}


### PR DESCRIPTION
Implements #684 (Refs #684)

## Changes

- **`internal/config/backend_kind.go` (new):** `ResolveBackendKind(name, provider, cmd)` resolves the CLI-specific exec path in order: backend name (`claude`/`codex`/`gemini`/`cline`), per-backend `provider` field (`anthropic`→claude, `openai`→codex, `google`→gemini, `cline`→cline), cmd binary basename, then generic fallback.
- **`internal/worker/backend.go`:** `BuildWorkerCmd` and `BuildSupervisorCmd` dispatch on the resolved kind instead of the raw backend name; `BackendConfig` gains the `Provider` field (populated at all call sites incl. supervisor LLM client). A claude CLI under a custom key (the sup-175 `fable:` shape) now builds the exact same invocation as the `claude:` key — `--dangerously-skip-permissions`, `-p`, prompt via stdin. Same for `provider: openai` → codex exec shape.
- **`internal/worker/tool_hooks.go`:** hook installer keys on the resolved kind, so custom-named claude backends still get automatic Claude Code hook installation.
- **Config warnings:** `Config.Warnings()` (logged at startup/hot-reload) now flags any agentic backend that resolves to the generic exec path — naming the backend and what it loses (permission bypass, stdin prompt delivery / E2BIG risk) — and warns on provider/cmd binary mismatches (e.g. `provider: openai` driving a `claude` binary). Non-agentic and disabled backends stay silent.
- **README:** documents custom-named backend resolution order with a `provider:` example.

## Testing

- New unit tests: provider-based resolution (anthropic→claude argv-equality with the `claude:` key, openai→codex exec shape), cmd-basename fallback, generic path preserved for unknown CLIs, supervisor stdin delivery for custom names, `ResolveBackendKind` table test, and warning-path tests (generic warns; provider-resolved/known/non-agentic/disabled don't; mismatch warns).
- `gofmt` clean, `go test ./...` green, `go build ./cmd/maestro/` OK, `.maestro/verify.sh` all requirements pass.

Note: runtime verification (a live worker spawn with a custom-named backend) still needs operator confirmation; this PR intentionally does not auto-close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent degradation bug (#684) where backends registered under a custom name (e.g. `fable:` for the Anthropic CLI) fell through to the generic exec path, losing `--dangerously-skip-permissions` and stdin prompt delivery. The fix introduces a `ResolveBackendKind` function in the `config` package that maps a backend to its CLI family via name, `provider` field, or cmd binary basename, and threads this resolution through every `BuildWorkerCmd`/`BuildSupervisorCmd`/hook-setup call site.

- `Provider` is now populated into `BackendConfig` at all five call sites (`worker.Start`, `Respawn`, `StartPhase`, `RespawnInPlace`, and supervisor `Complete`), ensuring no call site silently drops the field.
- `setupWorkerToolHooks` is updated to accept the resolved kind rather than the raw config key, so Claude Code hook installation fires correctly for custom-named claude backends.
- `Config.Warnings()` gains `backendResolutionWarnings()`, which warns at startup for any agentic backend that resolves to the generic path or has a provider/cmd mismatch.

<h3>Confidence Score: 4/5</h3>

The core dispatch fix is correct and well-tested. One incorrect clause in a startup warning message is the only issue found.

The generic-path warning unconditionally tells operators that argv delivery risks E2BIG regardless of their actual prompt_mode setting. An operator who has correctly set prompt_mode: stdin still sees "(argv delivery risks E2BIG on large prompts)" — factually wrong and could prompt unnecessary remediation. All other changes (resolution logic, call sites, hook setup) look correct.

internal/config/backend_kind.go — the warning message in backendResolutionWarnings needs the E2BIG clause made conditional on prompt_mode=arg.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/backend_kind.go | New file implementing the backend kind resolution logic. Resolution order (name → provider → cmd basename → generic) is correct; one issue: the generic-path warning message unconditionally includes an E2BIG argv clause regardless of prompt_mode. |
| internal/config/backend_kind_test.go | Good coverage of resolution order, mismatch warnings, and edge cases (case-insensitive provider, basename-only, non-agentic/disabled skipped). |
| internal/worker/backend.go | BuildWorkerCmd and BuildSupervisorCmd now dispatch on the resolved kind; resolveBackendKind wrapper correctly handles the empty-name default. Logic is clean. |
| internal/worker/backend_test.go | New tests cover the anthropic/openai provider paths, cmd-basename fallback, generic path preservation, and supervisor stdin delivery for custom names. |
| internal/worker/tool_hooks.go | setupWorkerToolHooks parameter renamed to backendKind and callers updated; hook installation now correctly fires for custom-named claude backends. |
| internal/worker/worker.go | Provider field added to BackendConfig construction at both call sites; resolveBackendKind used for hook setup. |
| internal/worker/phase.go | Provider field added to BackendConfig; hook setup now receives the resolved kind. Consistent with other Start/Respawn call sites. |
| internal/worker/checkpoint.go | Provider field added to BackendConfig; hook setup uses resolved kind. Consistent with other call sites. |
| internal/supervisor/llm.go | Provider field now flows into BackendConfig for supervisor commands; ensures custom-named backends get the right stdin delivery in supervisor context. |
| internal/config/config.go | Warnings() now includes backendResolutionWarnings(); minimal, correct addition. |
| README.md | Documents the resolution order and provider example accurately; fable/fast examples match the implementation. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/config/backend_kind.go:101-106
The E2BIG argv clause is unconditionally included in the warning regardless of the actual `prompt_mode`. For a backend with `prompt_mode: stdin` or `prompt_mode: file`, the prompt is never passed through argv, so there is no E2BIG risk — the warning produces factually incorrect guidance (e.g. `prompt_mode="stdin" (argv delivery risks E2BIG on large prompts)`). The E2BIG callout should be conditional on the resolved mode being `arg`.

```suggestion
		if kind == BackendKindGeneric {
			mode := coalescePromptMode(def.PromptMode)
			promptRisk := ""
			if mode == "arg" {
				promptRisk = " (argv delivery risks E2BIG on large prompts)"
			}
			warnings = append(warnings, fmt.Sprintf(
				"config: backend %q resolves to the generic exec path (provider %q and cmd %q match no known CLI) — workers run without a permission-bypass flag (mutating tool calls may be denied) and the prompt is delivered per prompt_mode=%q%s. If this wraps a known CLI, set provider: anthropic|openai|google|cline or use a claude/codex/gemini/cline binary in cmd.",
				name, def.Provider, def.Cmd, mode, promptRisk))
			continue
		}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: resolve backend exec path by pro..."](https://github.com/befeast/maestro/commit/67bf73cd234dc1072b3911acfd3088f068e1749d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36967108)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->