### PR TITLE
versioning: naive string replace clobbers dependency pins matching the old version (karaoke v0.9.0 deploy failure) (#687)

### DIFF
--- a/internal/versioning/versioning.go
+++ b/internal/versioning/versioning.go
@@ -193,16 +193,34 @@ func ReadCurrentVersion(files []string) (string, error) {
 	return "", fmt.Errorf("no version found in any configured file")
 }
 
-// UpdateVersionInFile replaces oldVer with newVer in the file.
+// replaceVersionField replaces the first version field whose value equals
+// oldVer, using the same anchored patterns as ReadVersionFromFile. It must
+// not touch other occurrences of the version string (e.g. a dependency pin
+// like "yt-dlp-ejs==0.8.0" in pyproject.toml, or a nested "version" key in
+// a lockfile dependency that coincidentally matches the project version).
+func replaceVersionField(content, oldVer, newVer string) (string, bool) {
+	for _, pat := range versionPatterns {
+		for _, m := range pat.FindAllStringSubmatchIndex(content, -1) {
+			// m[4]:m[5] bound the version capture group.
+			if content[m[4]:m[5]] != oldVer {
+				continue
+			}
+			return content[:m[4]] + newVer + content[m[5]:], true
+		}
+	}
+	return content, false
+}
+
+// UpdateVersionInFile updates the project version field from oldVer to newVer
+// in the file, leaving any other occurrences of oldVer untouched.
 func UpdateVersionInFile(path, oldVer, newVer string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
-	content := string(data)
-	updated := strings.ReplaceAll(content, oldVer, newVer)
-	if updated == content {
-		return fmt.Errorf("version %s not found in %s", oldVer, path)
+	updated, replaced := replaceVersionField(string(data), oldVer, newVer)
+	if !replaced {
+		return fmt.Errorf("version field %s not found in %s", oldVer, path)
 	}
 	if err := os.WriteFile(path, []byte(updated), 0644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)

--- a/internal/versioning/versioning_test.go
+++ b/internal/versioning/versioning_test.go
@@ -208,6 +208,168 @@ edition = "2021"
 	}
 }
 
+func TestUpdateVersionInFile_PreservesDependencyPins(t *testing.T) {
+	// Regression test for the karaoke v0.9.0 incident: a dependency pinned at
+	// the same version as the project must not be rewritten by the bump.
+	dir := t.TempDir()
+
+	content := `[project]
+name = "karaoke"
+version = "0.8.0"
+dependencies = [
+    "yt-dlp-ejs==0.8.0",
+    "fastapi>=0.110",
+]
+`
+	path := filepath.Join(dir, "pyproject.toml")
+	os.WriteFile(path, []byte(content), 0644)
+
+	if err := UpdateVersionInFile(path, "0.8.0", "0.9.0"); err != nil {
+		t.Fatalf("UpdateVersionInFile: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	got := string(data)
+	want := `[project]
+name = "karaoke"
+version = "0.9.0"
+dependencies = [
+    "yt-dlp-ejs==0.8.0",
+    "fastapi>=0.110",
+]
+`
+	if got != want {
+		t.Errorf("file content mismatch:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestUpdateVersionInFile_PackageJSONDependencyPins(t *testing.T) {
+	dir := t.TempDir()
+
+	content := `{
+  "name": "myapp",
+  "version": "1.2.3",
+  "dependencies": {
+    "leftpad": "1.2.3"
+  }
+}
+`
+	path := filepath.Join(dir, "package.json")
+	os.WriteFile(path, []byte(content), 0644)
+
+	if err := UpdateVersionInFile(path, "1.2.3", "1.3.0"); err != nil {
+		t.Fatalf("UpdateVersionInFile: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	got := string(data)
+	want := `{
+  "name": "myapp",
+  "version": "1.3.0",
+  "dependencies": {
+    "leftpad": "1.2.3"
+  }
+}
+`
+	if got != want {
+		t.Errorf("file content mismatch:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestUpdateVersionInFile_OnlyFirstVersionField(t *testing.T) {
+	// Lockfile-style nested "version" keys matching the project version must
+	// not be rewritten: only the first version field (the one
+	// ReadVersionFromFile reads) is updated.
+	dir := t.TempDir()
+
+	content := `{
+  "version": "1.2.3",
+  "packages": {
+    "node_modules/dep": {
+      "version": "1.2.3"
+    }
+  }
+}
+`
+	path := filepath.Join(dir, "package.json")
+	os.WriteFile(path, []byte(content), 0644)
+
+	if err := UpdateVersionInFile(path, "1.2.3", "2.0.0"); err != nil {
+		t.Fatalf("UpdateVersionInFile: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	got := string(data)
+	want := `{
+  "version": "2.0.0",
+  "packages": {
+    "node_modules/dep": {
+      "version": "1.2.3"
+    }
+  }
+}
+`
+	if got != want {
+		t.Errorf("file content mismatch:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestUpdateVersionInFile_VersionOnlyInDependencyPin(t *testing.T) {
+	// If the old version appears only inside a dependency pin (no version
+	// field carries it), the update must fail instead of clobbering the pin.
+	dir := t.TempDir()
+
+	content := `[project]
+name = "myapp"
+version = "0.5.0"
+dependencies = [
+    "foo==0.8.0",
+]
+`
+	path := filepath.Join(dir, "pyproject.toml")
+	os.WriteFile(path, []byte(content), 0644)
+
+	if err := UpdateVersionInFile(path, "0.8.0", "0.9.0"); err == nil {
+		t.Error("expected error when version only appears in a dependency pin")
+	}
+
+	data, _ := os.ReadFile(path)
+	if string(data) != content {
+		t.Errorf("file must be unchanged, got: %q", string(data))
+	}
+}
+
+func TestUpdateVersionInFile_SkipsNonMatchingVersionField(t *testing.T) {
+	// A version field holding a different value (e.g. a Cargo dependency
+	// table) is skipped in favor of the field that matches oldVer.
+	dir := t.TempDir()
+
+	content := `[dependencies.serde]
+version = "1.0.0"
+
+[package]
+version = "0.5.0"
+`
+	path := filepath.Join(dir, "Cargo.toml")
+	os.WriteFile(path, []byte(content), 0644)
+
+	if err := UpdateVersionInFile(path, "0.5.0", "0.6.0"); err != nil {
+		t.Fatalf("UpdateVersionInFile: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	got := string(data)
+	want := `[dependencies.serde]
+version = "1.0.0"
+
+[package]
+version = "0.6.0"
+`
+	if got != want {
+		t.Errorf("file content mismatch:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
 func TestBumpTypeString(t *testing.T) {
 	tests := []struct {
 		bt   BumpType


### PR DESCRIPTION
Refs #687

## Changes
- `UpdateVersionInFile` no longer does a global `strings.ReplaceAll` of the old version string. It now reuses the same anchored `versionPatterns` as `ReadVersionFromFile` and replaces only the first version field whose value equals the old version.
- Dependency pins that happen to match the project version (e.g. `yt-dlp-ejs==0.8.0` at project v0.8.0) and lockfile-style nested `"version"` keys are left untouched.
- If the old version appears only outside a version field (e.g. only in a dependency pin), the update now fails for that file instead of rewriting unrelated strings.

## Testing
- New regression test reproducing the karaoke pyproject.toml incident (version field bumped, `yt-dlp-ejs==0.8.0` pin preserved).
- New tests for package.json dependency pins, nested version keys (only the first field updated), version-only-in-pin error path, and skipping non-matching version fields (Cargo dependency tables).
- `gofmt`, `go test ./...`, and `go build ./cmd/maestro/` all pass; branch rebased on origin/main.

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a version-bump regression where `strings.ReplaceAll` would clobber dependency pins that happened to share the same version string as the project (the karaoke `yt-dlp-ejs==0.8.0` incident). The fix replaces the global replace with a targeted `replaceVersionField` helper that reuses the same anchored `versionPatterns` as `ReadVersionFromFile`, updating only the first version field whose value equals `oldVer`.

- `replaceVersionField` iterates patterns in document order and replaces the first matching version capture group, leaving all other occurrences (dependency pins, nested lockfile keys) untouched.
- `UpdateVersionInFile` now returns an error if no version field matches, preventing silent rewrites of unrelated strings.
- Five new tests cover the reported incident (pyproject.toml with `yt-dlp-ejs==` pin), package.json dependency pins, nested JSON keys, version-only-in-pin error path, and skip-on-non-matching Cargo dependency.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the targeted use-case; the fix correctly resolves the karaoke pyproject.toml incident and leaves unrelated version strings untouched.

The core logic is sound and well-tested for all described scenarios. One untested path remains: a Cargo.toml where a [dependencies.X] table block using version = "..." appears before [package] with an identical version string — in that configuration the dependency field would be bumped instead of the project field. This is an unusual file layout, so practical risk is low.

internal/versioning/versioning.go — specifically the replaceVersionField first-match behavior for Cargo.toml files with unconventional section ordering.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/versioning/versioning.go | Replaces global `strings.ReplaceAll` with pattern-anchored `replaceVersionField`; fixes the karaoke bug cleanly. One edge case: if a Cargo.toml `[dependencies.X]` table using `version = "..."` appears before `[package]` with the same version string, the dependency field is updated instead of the project field. |
| internal/versioning/versioning_test.go | Five new regression and scenario tests covering the reported incident, package.json dependency pins, nested version keys, error path for version-only-in-pin, and non-matching skip. All test cases are well-scoped and verify file content directly. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/versioning/versioning.go:201-211
**First-match wins can update the wrong field in Cargo.toml when dependency and project share the same version**

`replaceVersionField` iterates `versionPatterns` in document order and returns on the first match where `content[m[4]:m[5]] == oldVer`. The Cargo.toml pattern `(?m)^(\s*version\s*=\s*")...` matches both `[dependencies.X]` table-form entries and `[package]` entries. If a dependency section appears before `[package]` and happens to carry the same version string (e.g. both at `"1.0.0"`), the dependency's field is bumped while `[package]` is left at the old version — the inverse of the intended fix. The test in `TestUpdateVersionInFile_SkipsNonMatchingVersionField` protects against a *different* version in the dependency, but not equal ones. The issue only arises for table-form Cargo dependencies placed before `[package]`, which is unconventional, so real-world impact is low.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["versioning: anchor version bump to the v..."](https://github.com/befeast/maestro/commit/db8bf5ea9724ad29a8960a758cfa1f28f39a4f55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37011051)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->