### PR TITLE
supervise: fatal exit + systemd crash-loop on stable LLM-vs-guardrail disagreement (should be logged no-op, not rc=1)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -660,15 +660,21 @@ func superviseCmd(args []string) {
 		cfg.Supervisor.DryRun = true
 	}
 	gh := github.New(cfg.Repo)
-	runOnce := func() {
+	runOnce := func() error {
 		decision, err := supervisor.RunOnce(cfg, gh)
 		if err != nil {
-			log.Fatalf("supervise: %v", err)
+			return err
 		}
 		printSupervisorDecision(decision, *jsonOutput)
+		return nil
 	}
 
-	runOnce()
+	// The first cycle stays fatal so a broken setup (bad config, missing
+	// backend, auth) fails `systemctl start` loudly instead of leaving a
+	// daemon up that can never work.
+	if err := runOnce(); err != nil {
+		log.Fatalf("supervise: %v", err)
+	}
 	if *once {
 		return
 	}
@@ -701,7 +707,16 @@ func superviseCmd(args []string) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			runOnce()
+			// #689: a failed cycle inside the loop is logged and retried on
+			// the next tick, never rc=1 — exiting here converted stable
+			// decision-layer errors and transient GitHub failures into a
+			// systemd crash-loop (~40s CPU per restart, supervisor down for
+			// the whole window). Persistent failures still surface: the
+			// #499 watchdog flags SupervisorStuck when LastRunOnceAt stops
+			// advancing.
+			if err := runOnce(); err != nil {
+				log.Printf("supervise: cycle failed (will retry in %s): %v", *interval, err)
+			}
 		}
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -530,6 +530,14 @@ const (
 	// surfaced as evidence. NEVER a silent dead-end (#565).
 	StuckReviewRepairExhausted = "review_repair_exhausted"
 	StuckSearchGuardrailTrip   = "search_guardrail_trip"
+	// StuckGuardrailConflict is emitted when the supervisor LLM's
+	// recommendation disagrees with the deterministic guardrail (#689).
+	// The conflict is resolved to the safe side for the cycle (the
+	// deterministic decision when it is risk=safe, otherwise an explicit
+	// no-op) instead of exiting rc=1 — a stable disagreement used to put
+	// systemd in a restart loop. This code surfaces the standoff to the
+	// operator while the loop stays alive.
+	StuckGuardrailConflict = "guardrail_conflict"
 )
 
 const (

--- a/internal/supervisor/guardrail_conflict_test.go
+++ b/internal/supervisor/guardrail_conflict_test.go
@@ -1,0 +1,162 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #689 regression (karaoke 2026-06-11): a merge-ready PR with a
+// retry_exhausted worker makes the deterministic guardrail compute merge_pr
+// (risk=mutating), while the supervisor LLM keeps answering monitor_open_pr
+// or none because it sees pending review feedback. The disagreement is
+// stable, so treating it as a fatal error crash-looped systemd (13+
+// restarts in ~20 minutes). The cycle must instead succeed with an explicit
+// no-op: neither side executes, the conflict is recorded as a
+// guardrail_conflict stuck state, and the loop stays alive.
+func TestDecideWithLLM_GuardrailConflictOnMutatingAction_HoldsNoOp(t *testing.T) {
+	llmOutputs := map[string]string{
+		"monitor_open_pr": `{
+  "summary": "Keep monitoring PR #137 while review feedback is pending.",
+  "recommended_action": "monitor_open_pr",
+  "target": {"issue": 130, "pr": 137, "session": "karaoke-1"},
+  "risk": "safe",
+  "confidence": 0.8,
+  "reasons": ["unresolved review feedback on the PR"],
+  "requires_approval": false
+}`,
+		"none": `{
+  "summary": "No action while review feedback is pending.",
+  "recommended_action": "none",
+  "risk": "safe",
+  "confidence": 0.7,
+  "reasons": ["unresolved review feedback on the PR"],
+  "requires_approval": false
+}`,
+	}
+
+	for name, output := range llmOutputs {
+		t.Run(name, func(t *testing.T) {
+			cfg := testConfig(t)
+			cfg.ReviewGate = "none"
+			reader := &fakeReader{
+				prs:        []github.PR{{Number: 137, HeadRefName: "feat/standoff", Mergeable: "MERGEABLE"}},
+				ciStatuses: map[int]string{137: "success"},
+			}
+			st := state.NewState()
+			st.Sessions["karaoke-1"] = &state.Session{
+				IssueNumber: 130,
+				IssueTitle:  "standoff PR",
+				Status:      state.StatusRetryExhausted,
+				Branch:      "feat/standoff",
+				PRNumber:    137,
+				StartedAt:   time.Now().UTC().Add(-time.Hour),
+			}
+
+			decision, err := testLLMEngine(cfg, reader, &fakeLLM{output: output}).Decide(st)
+			if err != nil {
+				t.Fatalf("Decide: %v (stable disagreement must not fail the cycle — #689)", err)
+			}
+			if decision.RecommendedAction != ActionNone {
+				t.Fatalf("action = %q, want %q (mutating guardrail side must not execute without LLM agreement)", decision.RecommendedAction, ActionNone)
+			}
+			if decision.Risk != RiskSafe {
+				t.Fatalf("risk = %q, want safe", decision.Risk)
+			}
+			if decision.RequiresApproval {
+				t.Fatal("RequiresApproval = true, want false for the held no-op")
+			}
+			if len(decision.Mutations) != 0 {
+				t.Fatalf("mutations = %#v, want none for the held no-op", decision.Mutations)
+			}
+			stuck := requireStuckState(t, decision, state.StuckGuardrailConflict)
+			if stuck.Severity != SeverityWarning {
+				t.Errorf("severity = %q, want warning (operator must see the standoff)", stuck.Severity)
+			}
+			if !strings.Contains(stuck.Summary, "disagrees with deterministic guardrail") {
+				t.Errorf("summary = %q, want it to name the disagreement", stuck.Summary)
+			}
+			if stuck.Target == nil || stuck.Target.PR != 137 {
+				t.Errorf("stuck target = %#v, want PR=137 so the operator can find the standoff", stuck.Target)
+			}
+		})
+	}
+}
+
+// #689: a target-only disagreement is the same decision-layer class as an
+// action disagreement and must also resolve instead of failing the cycle.
+// The guardrail side (monitor_open_pr) is risk=safe, so the deterministic
+// decision wins the tie-break and keeps its own target.
+func TestDecideWithLLM_GuardrailTargetDisagreement_ResolvesToDeterministic(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 117, HeadRefName: "feat/pending", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{117: "pending"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 202,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/pending",
+		PRNumber:    117,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+	llm := &fakeLLM{output: `{
+  "summary": "Monitor a different PR.",
+  "recommended_action": "monitor_open_pr",
+  "target": {"pr": 999},
+  "risk": "safe",
+  "confidence": 0.8,
+  "reasons": ["LLM picked the wrong target"],
+  "requires_approval": false
+}`}
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v (target disagreement must not fail the cycle — #689)", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want deterministic %q", decision.RecommendedAction, ActionMonitorOpenPR)
+	}
+	if decision.Target == nil || decision.Target.PR != 117 {
+		t.Fatalf("target = %#v, want deterministic PR=117", decision.Target)
+	}
+	requireStuckState(t, decision, state.StuckGuardrailConflict)
+}
+
+// validateLLMDecision must keep returning the typed conflict error for the
+// guardrail comparisons and a plain error for policy violations — the
+// resolver only catches the former; a disallowed action stays a hard error.
+func TestValidateLLMDecision_ConflictErrorTyping(t *testing.T) {
+	policy := newSupervisorPolicy(testConfig(t))
+	deterministic := state.SupervisorDecision{
+		RecommendedAction: ActionMonitorOpenPR,
+		Risk:              RiskSafe,
+		Target:            &state.SupervisorTarget{PR: 117},
+	}
+	llm := LLMDecision{
+		Summary:           "monitor",
+		RecommendedAction: ActionNone,
+		Risk:              RiskSafe,
+		Confidence:        0.8,
+		Reasons:           []string{"r"},
+	}
+
+	_, err := validateLLMDecision(llm, deterministic, policy)
+	if _, ok := err.(*guardrailConflictError); !ok {
+		t.Fatalf("action disagreement error = %T (%v), want *guardrailConflictError", err, err)
+	}
+
+	llm.RecommendedAction = "delete_repo"
+	_, err = validateLLMDecision(llm, deterministic, policy)
+	if err == nil {
+		t.Fatal("disallowed action must stay an error")
+	}
+	if _, ok := err.(*guardrailConflictError); ok {
+		t.Fatalf("policy violation must NOT be a guardrail conflict: %v", err)
+	}
+}

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -3,8 +3,10 @@ package supervisor
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strings"
 
@@ -152,7 +154,15 @@ func (e *Engine) decideWithLLM(st *state.State) (state.SupervisorDecision, error
 	if err != nil {
 		return state.SupervisorDecision{}, err
 	}
-	return validateLLMDecision(llmDecision, deterministic, policy)
+	decision, err := validateLLMDecision(llmDecision, deterministic, policy)
+	var conflict *guardrailConflictError
+	if errors.As(err, &conflict) {
+		return resolveGuardrailConflict(llmDecision, deterministic, conflict), nil
+	}
+	if err != nil {
+		return state.SupervisorDecision{}, err
+	}
+	return decision, nil
 }
 
 func buildSupervisorPrompt(cfg *config.Config, packet supervisorStatePacket) (string, error) {
@@ -244,19 +254,30 @@ func validateLLMContractFields(decision LLMDecision) error {
 	return nil
 }
 
+// guardrailConflictError marks a decision-layer disagreement between the
+// supervisor LLM and the deterministic guardrail (action, target, or risk).
+// It is deliberately a distinct type: a conflict is not a process fault, so
+// decideWithLLM resolves it to a safe decision and keeps the loop alive
+// instead of failing the cycle (#689).
+type guardrailConflictError struct {
+	reason string
+}
+
+func (e *guardrailConflictError) Error() string { return e.reason }
+
 func validateLLMDecision(llm LLMDecision, deterministic state.SupervisorDecision, policy supervisorPolicy) (state.SupervisorDecision, error) {
 	action := canonicalAction(llm.RecommendedAction)
 	if action == "" || !policy.isAllowed(action) {
 		return state.SupervisorDecision{}, fmt.Errorf("supervisor LLM action %q is not allowed by policy", llm.RecommendedAction)
 	}
 	if action != deterministic.RecommendedAction {
-		return state.SupervisorDecision{}, fmt.Errorf("supervisor LLM action %q disagrees with deterministic guardrail %q", action, deterministic.RecommendedAction)
+		return state.SupervisorDecision{}, &guardrailConflictError{reason: fmt.Sprintf("supervisor LLM action %q disagrees with deterministic guardrail %q", action, deterministic.RecommendedAction)}
 	}
 	if !targetsAgree(llm.Target, deterministic.Target) {
-		return state.SupervisorDecision{}, fmt.Errorf("supervisor LLM target disagrees with deterministic guardrail")
+		return state.SupervisorDecision{}, &guardrailConflictError{reason: "supervisor LLM target disagrees with deterministic guardrail"}
 	}
 	if riskRank(llm.Risk) < riskRank(deterministic.Risk) {
-		return state.SupervisorDecision{}, fmt.Errorf("supervisor LLM risk %q is lower than deterministic guardrail %q", llm.Risk, deterministic.Risk)
+		return state.SupervisorDecision{}, &guardrailConflictError{reason: fmt.Sprintf("supervisor LLM risk %q is lower than deterministic guardrail %q", llm.Risk, deterministic.Risk)}
 	}
 	requiresApproval := policy.requiresApproval(action)
 	if requiresApproval && !llm.RequiresApproval {
@@ -272,6 +293,62 @@ func validateLLMDecision(llm LLMDecision, deterministic state.SupervisorDecision
 	decision.Reasons = compactReasons(append(outcomeGuardrailReasons(deterministic), redactReasons(llm.Reasons)...))
 	decision.RequiresApproval = llm.RequiresApproval || requiresApproval
 	return decision, nil
+}
+
+// resolveGuardrailConflict converts an LLM-vs-guardrail disagreement into a
+// non-fatal decision (#689). Failing the cycle here turned a stable
+// disagreement into a systemd crash-loop: the same project state reproduces
+// the same answers on every restart (karaoke 2026-06-11, 13+ restarts in ~20
+// minutes on PR #137), leaving the supervisor effectively down for the whole
+// window. The conflict is a decision-layer condition, not a process fault,
+// so it is logged, recorded as a guardrail_conflict stuck state, and
+// resolved to the safe side:
+//   - guardrail action is risk=safe (read-only, or operator-whitelisted
+//     safe_actions in cautious mode): deterministic tie-break — the
+//     guardrail decision wins and proceeds.
+//   - guardrail action is mutating/approval-gated: neither side proceeds
+//     unilaterally; hold an explicit no-op this cycle until LLM and
+//     guardrail agree or an operator intervenes.
+func resolveGuardrailConflict(llm LLMDecision, deterministic state.SupervisorDecision, conflict *guardrailConflictError) state.SupervisorDecision {
+	// The policy check in validateLLMDecision runs before the guardrail
+	// comparisons, so the LLM action is always canonical here.
+	llmAction := canonicalAction(llm.RecommendedAction)
+	log.Printf("[supervisor] guardrail conflict held as logged no-op, not a fatal exit (#689): %s", conflict.reason)
+
+	stuck := state.SupervisorStuckState{
+		Code:              state.StuckGuardrailConflict,
+		Severity:          SeverityWarning,
+		Summary:           fmt.Sprintf("Supervisor LLM and deterministic guardrail disagree: %s.", conflict.reason),
+		Evidence:          compactReasons(append([]string{fmt.Sprintf("LLM recommended %q; deterministic guardrail computed %q", llmAction, deterministic.RecommendedAction)}, redactReasons(llm.Reasons)...)),
+		RecommendedAction: "Inspect why the LLM and the deterministic guardrail disagree; the supervise loop stays alive and re-evaluates next cycle.",
+		SupervisorCanAct:  false,
+		Target:            copyTarget(deterministic.Target),
+	}
+
+	if deterministic.Risk == RiskSafe {
+		decision := deterministic
+		decision.Reasons = compactReasons(append([]string{
+			conflict.reason,
+			"Guardrail action is risk=safe, so the deterministic decision wins the tie-break",
+		}, deterministic.Reasons...))
+		decision.StuckStates = appendStuck(decision.StuckStates, stuck)
+		return decision
+	}
+
+	decision := deterministic
+	decision.RecommendedAction = ActionNone
+	decision.Risk = RiskSafe
+	decision.RequiresApproval = false
+	decision.Mutations = nil
+	decision.Target = nil
+	decision.Confidence = 0.5
+	decision.Summary = "Supervisor LLM and deterministic guardrail disagree on a mutating action; holding a no-op this cycle."
+	decision.Reasons = compactReasons(append([]string{
+		conflict.reason,
+		fmt.Sprintf("Guardrail action %q is not risk=safe, so neither side executes until the disagreement resolves", deterministic.RecommendedAction),
+	}, outcomeGuardrailReasons(deterministic)...))
+	decision.StuckStates = appendStuck(decision.StuckStates, stuck)
+	return decision
 }
 
 func outcomeGuardrailReasons(deterministic state.SupervisorDecision) []string {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -2634,7 +2634,12 @@ func TestDecideWithLLM_MalformedOutputRejected(t *testing.T) {
 	}
 }
 
-func TestDecideWithLLM_DetectorDisagreementRejected(t *testing.T) {
+// #689: an LLM-vs-guardrail disagreement is a decision-layer condition, not
+// a process fault. When the guardrail side is risk=safe, the deterministic
+// decision wins the tie-break and the cycle succeeds with a
+// guardrail_conflict stuck state instead of an error (which used to exit
+// rc=1 and put systemd in a crash-loop).
+func TestDecideWithLLM_DetectorDisagreementResolvesToDeterministicSafeSide(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work")}}
 	llm := &fakeLLM{output: `{
@@ -2654,9 +2659,22 @@ func TestDecideWithLLM_DetectorDisagreementRejected(t *testing.T) {
 		StartedAt:   time.Now().UTC(),
 	}
 
-	_, err := testLLMEngine(cfg, reader, llm).Decide(st)
-	if err == nil || !strings.Contains(err.Error(), "disagrees with deterministic guardrail") {
-		t.Fatalf("Decide error = %v, want detector disagreement", err)
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v (disagreement must resolve, not fail the cycle — #689)", err)
+	}
+	if decision.RecommendedAction != ActionWaitForRunningWorker {
+		t.Fatalf("action = %q, want deterministic %q (safe guardrail side wins the tie-break)", decision.RecommendedAction, ActionWaitForRunningWorker)
+	}
+	if decision.Risk != RiskSafe {
+		t.Fatalf("risk = %q, want safe", decision.Risk)
+	}
+	stuck := requireStuckState(t, decision, state.StuckGuardrailConflict)
+	if stuck.Severity != SeverityWarning {
+		t.Errorf("severity = %q, want warning", stuck.Severity)
+	}
+	if !strings.Contains(stuck.Summary, "disagrees with deterministic guardrail") {
+		t.Errorf("summary = %q, want it to name the disagreement", stuck.Summary)
 	}
 }
 


### PR DESCRIPTION
Implements #689 (Refs #689)

## Changes

- `internal/supervisor/llm.go`: the three guardrail comparisons in `validateLLMDecision` (action, target, risk vs the deterministic decision) now return a typed `guardrailConflictError` instead of a generic error. `decideWithLLM` resolves that conflict instead of failing the cycle:
  - guardrail side is `risk=safe` (read-only / operator-whitelisted safe_actions): deterministic tie-break — the guardrail decision wins and proceeds;
  - guardrail side is mutating/approval-gated (the karaoke `merge_pr` standoff): the cycle holds an explicit `none` no-op so neither side executes unilaterally.
  - Either way the standoff is logged and recorded as a `guardrail_conflict` stuck state (severity=warning, targeted at the contested PR) so the operator sees it. Policy violations (disallowed action, missing approval flag, malformed JSON) stay hard errors.
- `internal/state/state.go`: new `StuckGuardrailConflict` (`guardrail_conflict`) stuck-state code.
- `cmd/maestro/main.go`: in the supervise ticker loop, a failed cycle is logged and retried next tick instead of `log.Fatalf` — exiting rc=1 mid-flight converted stable decision-layer errors and transient GitHub failures into a systemd crash-loop. The first cycle stays fatal so a broken setup still fails `systemctl start` loudly; persistent failures surface via the #499 watchdog (`LastRunOnceAt` stops advancing → `SupervisorStuck`).

## Testing

- New `internal/supervisor/guardrail_conflict_test.go`: karaoke-shaped regression (green PR + retry_exhausted session → deterministic `merge_pr` vs LLM `monitor_open_pr`/`none` → held no-op with `guardrail_conflict` stuck state), target-only disagreement resolution, and conflict-vs-policy error typing.
- Updated `TestDecideWithLLM_DetectorDisagreement*`: a safe-side disagreement now resolves to the deterministic decision with the conflict surfaced.
- `go build ./cmd/maestro/`, `go test ./...`, and `.maestro/verify.sh` all pass after rebasing on origin/main.

Runtime verification on a live fleet host (disagreement no longer restart-loops systemd) is still pending; this PR should not auto-close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a systemd crash-loop caused by stable LLM-vs-guardrail disagreements by introducing typed `guardrailConflictError` handling in `decideWithLLM` and changing the `supervise` ticker loop to log-and-retry rather than `log.Fatalf` on cycle failures.

- **`internal/supervisor/llm.go`**: Guardrail comparison failures in `validateLLMDecision` now return a typed `*guardrailConflictError`; `decideWithLLM` intercepts it and calls `resolveGuardrailConflict`, which either lets the safe-side deterministic decision proceed or holds an explicit `none` no-op for mutating actions, recording a `guardrail_conflict` stuck state in both cases.
- **`cmd/maestro/main.go`**: The first supervise cycle remains fatal (preserving loud `systemctl start` failure for broken setups); subsequent ticker cycles log errors and retry, leaning on the existing `#499` watchdog (`LastRunOnceAt` stops advancing) to surface persistent failures.
- **`internal/state/state.go`** and tests: Adds the `StuckGuardrailConflict` constant and a dedicated regression test file covering the karaoke standoff, target-only disagreement, and conflict-vs-policy error-type distinction.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core conflict-resolution logic is correct and well-tested, with one misleading log line in the safe-side path that does not affect execution.

The guardrail conflict resolution branches are logically correct and covered by the new regression tests. The only finding is that the log message in resolveGuardrailConflict reads "no-op" for both branches, while the safe-side branch actually executes the deterministic decision — an operator tracing a conflict in the journal would see "no-op" but find that an action ran. Everything else — the typed error separation, the no-op path clearing mutations and target, the first-cycle fatal preservation in main.go, and the watchdog fallback — is sound.

internal/supervisor/llm.go — the resolveGuardrailConflict log message

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/llm.go | Adds guardrailConflictError type, rewires validateLLMDecision to emit typed errors for the three guardrail comparisons, and introduces resolveGuardrailConflict to handle safe/mutating branches; log message at the top of resolveGuardrailConflict says "no-op" unconditionally but the safe-side path executes the deterministic decision. |
| cmd/maestro/main.go | runOnce now returns error; first cycle stays fatal so systemctl start fails loudly on broken setup, subsequent ticker cycles log the error and retry next tick instead of exiting rc=1. |
| internal/state/state.go | Adds StuckGuardrailConflict ("guardrail_conflict") stuck-state constant with a clear doc comment referencing #689. |
| internal/supervisor/guardrail_conflict_test.go | New regression tests covering the karaoke crash-loop (mutating no-op), target-only safe disagreement, and conflict-vs-policy error type distinction; assertions are tight and match the intended resolution semantics. |
| internal/supervisor/supervisor_test.go | DetectorDisagreementRejected renamed and updated to assert the safe-side tie-break resolution rather than expecting an error. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/llm.go:316
The log message says "held as logged no-op" unconditionally, but the `deterministic.Risk == RiskSafe` branch returns the deterministic decision — an action that actually executes. An operator inspecting the journal after a safe-side conflict resolution would see "no-op" yet the deterministic action (e.g. `monitor_open_pr`, `wait_for_running_worker`) ran, making it harder to correlate log entries with side effects.

```suggestion
	if deterministic.Risk == RiskSafe {
		log.Printf("[supervisor] guardrail conflict resolved to deterministic decision (risk=safe tie-break, not fatal exit #689): %s", conflict.reason)
	} else {
		log.Printf("[supervisor] guardrail conflict held as explicit no-op (mutating action, not fatal exit #689): %s", conflict.reason)
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["supervise: resolve LLM-vs-guardrail disa..."](https://github.com/befeast/maestro/commit/33487649eec966cd6c9f0fc06dc1b31df67464f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37019718)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->