### PR TITLE
review_gate(greptile): self-re-trigger after N minutes of pending with zero reviews (webhook-miss wedge, 4x in one evening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ auto_rebase: true                  # auto-rebase conflicting PR branches (defaul
 merge_strategy: sequential         # "sequential" (default) or "parallel"
 merge_interval_seconds: 30         # minimum seconds between merges in sequential mode
 review_gate: greptile              # "greptile" (default) or "none"
+review_retrigger:                  # self-heal greptile webhook misses (#691)
+  enabled: true                    # post "@greptile review" when the gate wedges at pending (default: true)
+  pending_minutes: 10              # re-trigger after this long pending on one head SHA (default: 10)
+  cooldown_minutes: 30             # minimum gap between re-trigger comments (default: 30)
 auto_retry_review_feedback: false  # retry PRs with actionable review comments
 auto_retry_rebase_conflicts: false # retry PRs whose auto-rebase fails with conflicts
 session_prefix: prj                # worker session name prefix (default: first 3 chars of repo name)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -690,6 +690,50 @@ func (c StaleSessionReconcilerConfig) MergedPRDismissesEnabled() bool {
 	return *c.MergedPRDismisses
 }
 
+// ReviewRetriggerConfig governs the orchestrator's self-healing re-trigger
+// for the greptile review gate (#691). Greptile occasionally misses its
+// review webhook: the PR sits CI=green with zero review signal on the
+// current head and the orchestrator loops "waiting for review gate
+// (greptile=pending)" forever. Server-side update-branch makes this worse —
+// the gate resets on the new head and the re-review webhook is missed again.
+// When the greptile stream has been pending on the same head SHA for more
+// than PendingMinutes, the orchestrator posts "@greptile review" on the PR
+// (bounded by CooldownMinutes to avoid comment churn) so the review re-runs
+// without operator intervention.
+type ReviewRetriggerConfig struct {
+	Enabled         *bool `yaml:"enabled"`          // default: true
+	PendingMinutes  int   `yaml:"pending_minutes"`  // re-trigger after this many minutes of greptile=pending on one head (default: 10)
+	CooldownMinutes int   `yaml:"cooldown_minutes"` // minimum minutes between re-trigger comments per session (default: 30)
+}
+
+// Active reports whether the stale-review re-trigger runs. Default true —
+// the orchestrator owns the review gate and should own its liveness.
+func (c ReviewRetriggerConfig) Active() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// EffectivePendingFor returns how long the greptile stream must stay pending
+// on the same head before a re-trigger fires. Default 10 minutes when unset
+// or non-positive.
+func (c ReviewRetriggerConfig) EffectivePendingFor() time.Duration {
+	if c.PendingMinutes <= 0 {
+		return 10 * time.Minute
+	}
+	return time.Duration(c.PendingMinutes) * time.Minute
+}
+
+// EffectiveCooldown returns the minimum gap between re-trigger comments for
+// one session. Default 30 minutes when unset or non-positive.
+func (c ReviewRetriggerConfig) EffectiveCooldown() time.Duration {
+	if c.CooldownMinutes <= 0 {
+		return 30 * time.Minute
+	}
+	return time.Duration(c.CooldownMinutes) * time.Minute
+}
+
 // SessionRetentionConfig bounds the growth of state.Sessions by compacting
 // terminal sessions once both the count and age floors are exceeded (#497).
 // Defaults keep the 20 newest terminal sessions per project and any terminal
@@ -791,6 +835,7 @@ type Config struct {
 	MergeIntervalSeconds            int                          `yaml:"merge_interval_seconds"`             // minimum seconds between merges in sequential mode
 	ReviewGate                      string                       `yaml:"review_gate"`                        // "greptile" (default) | "none"
 	ReviewGateStreams               []string                     `yaml:"review_gate_streams"`                // optional review dimensions; default ["greptile"], opt-in ["greptile","simplicity"]
+	ReviewRetrigger                 ReviewRetriggerConfig        `yaml:"review_retrigger"`                   // #691: re-post "@greptile review" when the gate wedges at pending with no review on head
 	AutoRetryReviewFeedback         bool                         `yaml:"auto_retry_review_feedback"`         // close PRs with review comments and respawn a fixer
 	MergeExhaustedNonCriticalReview *bool                        `yaml:"merge_exhausted_noncritical_review"` // #565: merge a green PR after review-feedback retries exhaust when only non-critical (P1/P2/P3) findings remain (no P0 on head). nil = default-on.
 	AutoRetryRebaseConflicts        bool                         `yaml:"auto_retry_rebase_conflicts"`        // retry PRs whose auto-rebase fails with conflicts

--- a/internal/config/review_retrigger_test.go
+++ b/internal/config/review_retrigger_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReviewRetriggerDefaults(t *testing.T) {
+	cfg, err := Parse([]byte("repo: owner/repo\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	rt := cfg.ReviewRetrigger
+	if !rt.Active() {
+		t.Errorf("Active() = false, want default on")
+	}
+	if got := rt.EffectivePendingFor(); got != 10*time.Minute {
+		t.Errorf("EffectivePendingFor() = %v, want 10m default", got)
+	}
+	if got := rt.EffectiveCooldown(); got != 30*time.Minute {
+		t.Errorf("EffectiveCooldown() = %v, want 30m default", got)
+	}
+}
+
+func TestReviewRetriggerParseOverrides(t *testing.T) {
+	cfg, err := Parse([]byte(`
+repo: owner/repo
+review_retrigger:
+  enabled: false
+  pending_minutes: 15
+  cooldown_minutes: 45
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	rt := cfg.ReviewRetrigger
+	if rt.Active() {
+		t.Errorf("Active() = true, want disabled via enabled: false")
+	}
+	if got := rt.EffectivePendingFor(); got != 15*time.Minute {
+		t.Errorf("EffectivePendingFor() = %v, want 15m", got)
+	}
+	if got := rt.EffectiveCooldown(); got != 45*time.Minute {
+		t.Errorf("EffectiveCooldown() = %v, want 45m", got)
+	}
+}
+
+func TestReviewRetriggerNonPositiveValuesFallBackToDefaults(t *testing.T) {
+	rt := ReviewRetriggerConfig{PendingMinutes: -5, CooldownMinutes: 0}
+	if got := rt.EffectivePendingFor(); got != 10*time.Minute {
+		t.Errorf("EffectivePendingFor() = %v, want 10m fallback", got)
+	}
+	if got := rt.EffectiveCooldown(); got != 30*time.Minute {
+		t.Errorf("EffectiveCooldown() = %v, want 30m fallback", got)
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -630,6 +630,11 @@ func (c *Client) pullHeadSHA(prNumber int) (string, error) {
 	return sha, nil
 }
 
+// PRHeadSHA returns the current head commit SHA of a PR.
+func (c *Client) PRHeadSHA(prNumber int) (string, error) {
+	return c.pullHeadSHA(prNumber)
+}
+
 func (c *Client) checkRunsForSHA(sha string) ([]greptileCheckRun, error) {
 	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/commits/%s/check-runs?per_page=100", c.Repo, sha), "--paginate")
 	if err != nil {
@@ -1149,6 +1154,19 @@ func (c *Client) CommentIssue(issueNumber int, body string) error {
 	).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("gh issue comment: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// CommentPR leaves a comment on a pull request.
+func (c *Client) CommentPR(prNumber int, body string) error {
+	out, err := exec.Command("gh", "pr", "comment",
+		strconv.Itoa(prNumber),
+		"--repo", c.Repo,
+		"--body", body,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh pr comment: %w\n%s", err, out)
 	}
 	return nil
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -112,6 +112,8 @@ type Orchestrator struct {
 	ghPRChecksOutputFn          func(prNumber int) (string, error)
 	ghCollectPRReviewFeedbackFn func(prNumber int) (string, error)
 	ghCloseIssueFn              func(number int, comment string) error
+	ghPRHeadSHAFn               func(prNumber int) (string, error)
+	ghCommentPRFn               func(prNumber int, body string) error
 	workerStopFn                func(cfg *config.Config, slotName string, sess *state.Session) error
 	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
 	outcomeCheckFn              func(context.Context, outcome.Brief) outcome.HealthCheckResult
@@ -276,6 +278,26 @@ func (o *Orchestrator) prReviewGateVerdict(prNumber int) (github.ReviewGateVerdi
 		return o.ghPRReviewGateVerdictFn(prNumber, streams)
 	}
 	return o.gh.PRReviewGateVerdict(prNumber, streams)
+}
+
+func (o *Orchestrator) prHeadSHA(prNumber int) (string, error) {
+	if o.ghPRHeadSHAFn != nil {
+		return o.ghPRHeadSHAFn(prNumber)
+	}
+	if o.gh == nil {
+		return "", fmt.Errorf("no github client configured for head SHA")
+	}
+	return o.gh.PRHeadSHA(prNumber)
+}
+
+func (o *Orchestrator) commentPR(prNumber int, body string) error {
+	if o.ghCommentPRFn != nil {
+		return o.ghCommentPRFn(prNumber, body)
+	}
+	if o.gh == nil {
+		return fmt.Errorf("no github client configured for PR comment")
+	}
+	return o.gh.CommentPR(prNumber, body)
 }
 
 func (o *Orchestrator) prHasCriticalReview(prNumber int) (bool, error) {
@@ -1486,6 +1508,10 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 		changed = append(changed, fmt.Sprintf("review_gate: %s→%s", old.ReviewGate, newCfg.ReviewGate))
 		o.cfg.ReviewGate = newCfg.ReviewGate
 	}
+	if !reflect.DeepEqual(newCfg.ReviewRetrigger, old.ReviewRetrigger) {
+		changed = append(changed, "review_retrigger")
+		o.cfg.ReviewRetrigger = newCfg.ReviewRetrigger
+	}
 	if newCfg.AutoRetryReviewFeedback != old.AutoRetryReviewFeedback {
 		changed = append(changed, fmt.Sprintf("auto_retry_review_feedback: %v→%v", old.AutoRetryReviewFeedback, newCfg.AutoRetryReviewFeedback))
 		o.cfg.AutoRetryReviewFeedback = newCfg.AutoRetryReviewFeedback
@@ -2572,8 +2598,10 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			}
 			if reviewVerdict.Pending {
 				log.Printf("[orch] PR #%d waiting for review gate (%s)", pr.Number, reviewVerdict.Summary())
+				o.maybeRetriggerStalePendingReview(sess, pr, reviewVerdict)
 				continue // not ready yet
 			}
+			clearReviewPendingTracking(sess)
 			if !reviewVerdict.Passed {
 				log.Printf("[orch] PR #%d blocked by review gate (%s)", pr.Number, reviewVerdict.Summary())
 				// auto-label blocked disabled
@@ -2628,6 +2656,80 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	if len(ready) > 1 {
 		log.Printf("[orch] sequential merge mode: deferring %d additional ready PR(s) to next cycle", len(ready)-1)
 	}
+}
+
+// greptileRetriggerComment is the PR comment that asks Greptile to (re)run
+// its review — the same comment an operator posts manually to un-wedge a PR.
+const greptileRetriggerComment = "@greptile review"
+
+// maybeRetriggerStalePendingReview self-heals the Greptile webhook-miss wedge
+// (#691): a PR sits CI=green with zero Greptile review signal on the current
+// head and the review gate loops greptile=pending forever. Server-side
+// update-branch re-arms the wedge by resetting the gate on the new head.
+// When the greptile stream has been pending on the same head SHA for longer
+// than review_retrigger.pending_minutes, post "@greptile review" on the PR —
+// at most once per review_retrigger.cooldown_minutes — so the review re-runs
+// without operator intervention. One info log line per re-trigger.
+func (o *Orchestrator) maybeRetriggerStalePendingReview(sess *state.Session, pr github.PR, verdict github.ReviewGateVerdict) {
+	if o.cfg == nil || !o.cfg.ReviewRetrigger.Active() {
+		return
+	}
+	if !greptileReviewStreamPending(verdict) {
+		return // a non-greptile stream is pending; "@greptile review" won't help
+	}
+	head, err := o.prHeadSHA(pr.Number)
+	if err != nil {
+		log.Printf("[orch] review re-trigger: head SHA for PR #%d: %v", pr.Number, err)
+		return
+	}
+	now := time.Now().UTC()
+	if sess.ReviewPendingSince == nil || sess.ReviewPendingHeadSHA != head {
+		// First pending observation on this head — start the clock. A new
+		// head (push or server-side update-branch) restarts it.
+		sess.ReviewPendingHeadSHA = head
+		sess.ReviewPendingSince = &now
+		return
+	}
+	pendingFor := now.Sub(*sess.ReviewPendingSince)
+	if pendingFor < o.cfg.ReviewRetrigger.EffectivePendingFor() {
+		return
+	}
+	if sess.ReviewRetriggerAt != nil && now.Sub(*sess.ReviewRetriggerAt) < o.cfg.ReviewRetrigger.EffectiveCooldown() {
+		return
+	}
+	if err := o.commentPR(pr.Number, greptileRetriggerComment); err != nil {
+		log.Printf("[orch] review re-trigger: comment on PR #%d: %v", pr.Number, err)
+		return
+	}
+	sess.ReviewRetriggerAt = &now
+	log.Printf("[orch] review re-trigger: PR #%d greptile=pending for %s on head %s with no review — posted %q (#691)",
+		pr.Number, pendingFor.Round(time.Second), shortHeadSHA(head), greptileRetriggerComment)
+}
+
+// greptileReviewStreamPending reports whether the greptile stream is the one
+// holding the review gate at pending.
+func greptileReviewStreamPending(verdict github.ReviewGateVerdict) bool {
+	for _, stream := range verdict.Streams {
+		if stream.Name == "greptile" {
+			return stream.Pending
+		}
+	}
+	return false
+}
+
+// clearReviewPendingTracking resets the #691 pending clock once the review
+// gate resolves (passed or blocked by findings) so a later pending phase on
+// the same head starts a fresh window.
+func clearReviewPendingTracking(sess *state.Session) {
+	sess.ReviewPendingHeadSHA = ""
+	sess.ReviewPendingSince = nil
+}
+
+func shortHeadSHA(sha string) string {
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
 }
 
 func mergeFlowEligibleStatus(sess *state.Session) bool {

--- a/internal/orchestrator/review_retrigger_test.go
+++ b/internal/orchestrator/review_retrigger_test.go
@@ -1,0 +1,245 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+// newRetriggerTestOrchestrator wires a merge-flow orchestrator whose greptile
+// stream reports pending (the #691 webhook-miss wedge: CI green, zero review
+// signal on head) and records every "@greptile review" comment posted.
+func newRetriggerTestOrchestrator(cfg *config.Config, prs []github.PR, headSHA string) (*Orchestrator, *[]string) {
+	o, _ := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRGreptileApprovedFn = func(prNumber int) (bool, bool, error) {
+		return false, true, nil // greptile=pending
+	}
+	o.ghPRHeadSHAFn = func(prNumber int) (string, error) {
+		return headSHA, nil
+	}
+	comments := make([]string, 0)
+	o.ghCommentPRFn = func(prNumber int, body string) error {
+		comments = append(comments, body)
+		return nil
+	}
+	return o, &comments
+}
+
+func retriggerTestConfig() *config.Config {
+	return &config.Config{Repo: "owner/repo", ReviewGate: "greptile"}
+}
+
+func backdated(d time.Duration) *time.Time {
+	t := time.Now().UTC().Add(-d)
+	return &t
+}
+
+func TestReviewRetrigger_FirstPendingObservationStartsClock(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(retriggerTestConfig(), prs, "abc123def456789")
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 0 {
+		t.Fatalf("comments = %v, want none on first pending observation", *comments)
+	}
+	sess := s.Sessions["slot-0"]
+	if sess.ReviewPendingHeadSHA != "abc123def456789" {
+		t.Errorf("ReviewPendingHeadSHA = %q, want head SHA recorded", sess.ReviewPendingHeadSHA)
+	}
+	if sess.ReviewPendingSince == nil {
+		t.Errorf("ReviewPendingSince = nil, want pending clock started")
+	}
+}
+
+func TestReviewRetrigger_PostsAfterPendingThreshold(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(retriggerTestConfig(), prs, "abc123def456789")
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(11 * time.Minute) // default threshold is 10m
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 1 || (*comments)[0] != "@greptile review" {
+		t.Fatalf("comments = %v, want one %q", *comments, "@greptile review")
+	}
+	if sess.ReviewRetriggerAt == nil {
+		t.Fatalf("ReviewRetriggerAt = nil, want cooldown anchor stamped")
+	}
+
+	// The very next cycle must not re-post: still pending, cooldown active.
+	o.autoMergePRs(s)
+	if len(*comments) != 1 {
+		t.Fatalf("comments = %v, want exactly one re-trigger within cooldown", *comments)
+	}
+}
+
+func TestReviewRetrigger_UnderThresholdDoesNotPost(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(retriggerTestConfig(), prs, "abc123def456789")
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(5 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 0 {
+		t.Fatalf("comments = %v, want none under the pending threshold", *comments)
+	}
+}
+
+func TestReviewRetrigger_CooldownElapsedRepostsOnce(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(retriggerTestConfig(), prs, "abc123def456789")
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(45 * time.Minute)
+	sess.ReviewRetriggerAt = backdated(31 * time.Minute) // default cooldown is 30m
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 1 {
+		t.Fatalf("comments = %v, want one re-post after cooldown elapsed", *comments)
+	}
+}
+
+func TestReviewRetrigger_CooldownActiveSuppressesRepost(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(retriggerTestConfig(), prs, "abc123def456789")
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(45 * time.Minute)
+	sess.ReviewRetriggerAt = backdated(5 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 0 {
+		t.Fatalf("comments = %v, want none while cooldown is active", *comments)
+	}
+}
+
+func TestReviewRetrigger_HeadChangeRestartsClock(t *testing.T) {
+	// After a push or server-side update-branch the head SHA changes and
+	// greptile gets a fresh chance to deliver its webhook — the pending
+	// clock must restart instead of firing on stale elapsed time.
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(retriggerTestConfig(), prs, "newhead9876543")
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "oldhead1234567"
+	sess.ReviewPendingSince = backdated(45 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 0 {
+		t.Fatalf("comments = %v, want none right after head change", *comments)
+	}
+	if sess.ReviewPendingHeadSHA != "newhead9876543" {
+		t.Errorf("ReviewPendingHeadSHA = %q, want new head recorded", sess.ReviewPendingHeadSHA)
+	}
+	if sess.ReviewPendingSince == nil || time.Since(*sess.ReviewPendingSince) > time.Minute {
+		t.Errorf("ReviewPendingSince = %v, want clock restarted", sess.ReviewPendingSince)
+	}
+}
+
+func TestReviewRetrigger_DisabledDoesNothing(t *testing.T) {
+	off := false
+	cfg := retriggerTestConfig()
+	cfg.ReviewRetrigger.Enabled = &off
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(cfg, prs, "abc123def456789")
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(45 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 0 {
+		t.Fatalf("comments = %v, want none when review_retrigger is disabled", *comments)
+	}
+}
+
+func TestReviewRetrigger_ConfigurableThresholdAndCooldown(t *testing.T) {
+	cfg := retriggerTestConfig()
+	cfg.ReviewRetrigger.PendingMinutes = 20
+	cfg.ReviewRetrigger.CooldownMinutes = 60
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(cfg, prs, "abc123def456789")
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(15 * time.Minute) // < 20m custom threshold
+
+	o.autoMergePRs(s)
+	if len(*comments) != 0 {
+		t.Fatalf("comments = %v, want none under custom 20m threshold", *comments)
+	}
+
+	sess.ReviewPendingSince = backdated(25 * time.Minute)
+	sess.ReviewRetriggerAt = backdated(45 * time.Minute) // < 60m custom cooldown
+	o.autoMergePRs(s)
+	if len(*comments) != 0 {
+		t.Fatalf("comments = %v, want none within custom 60m cooldown", *comments)
+	}
+
+	sess.ReviewRetriggerAt = backdated(61 * time.Minute)
+	o.autoMergePRs(s)
+	if len(*comments) != 1 {
+		t.Fatalf("comments = %v, want one re-trigger past custom threshold+cooldown", *comments)
+	}
+}
+
+func TestReviewRetrigger_NonGreptilePendingStreamIgnored(t *testing.T) {
+	cfg := retriggerTestConfig()
+	cfg.ReviewGateStreams = []string{"greptile", "simplicity"}
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(cfg, prs, "abc123def456789")
+	o.ghPRReviewGateVerdictFn = func(prNumber int, streams []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{
+			Passed:  false,
+			Pending: true,
+			Streams: []github.ReviewStreamVerdict{
+				{Name: "greptile", Passed: true},
+				{Name: "simplicity", Pending: true},
+			},
+		}, nil
+	}
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(45 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 0 {
+		t.Fatalf("comments = %v, want none when only a non-greptile stream is pending", *comments)
+	}
+}
+
+func TestReviewRetrigger_GateResolutionClearsTracking(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, _ := newRetriggerTestOrchestrator(retriggerTestConfig(), prs, "abc123def456789")
+	o.ghPRGreptileApprovedFn = func(prNumber int) (bool, bool, error) {
+		return false, false, nil // resolved: blocked by findings, not pending
+	}
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(45 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if sess.ReviewPendingHeadSHA != "" || sess.ReviewPendingSince != nil {
+		t.Fatalf("pending tracking = (%q, %v), want cleared once the gate resolves",
+			sess.ReviewPendingHeadSHA, sess.ReviewPendingSince)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -141,6 +141,15 @@ type Session struct {
 	CheckpointFile              string            `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
 	DeploymentFinishedAt        *time.Time        `json:"deployment_finished_at,omitempty"`         // set when the post-merge deploy hook succeeds
 
+	// #691: greptile webhook-miss self-heal. The orchestrator tracks how
+	// long the review gate has been greptile=pending on one head SHA; past
+	// the configured threshold it posts "@greptile review" on the PR
+	// (cooldown-bounded) to re-trigger the missed review. A new head SHA
+	// (push or server-side update-branch) restarts the pending clock.
+	ReviewPendingHeadSHA string     `json:"review_pending_head_sha,omitempty"` // head SHA the pending clock applies to
+	ReviewPendingSince   *time.Time `json:"review_pending_since,omitempty"`    // first observation of greptile=pending on that head
+	ReviewRetriggerAt    *time.Time `json:"review_retrigger_at,omitempty"`     // last "@greptile review" re-trigger (cooldown anchor)
+
 	// #426: distinguish agent execution time from workflow elapsed time.
 	// WorkerEndedAt is stamped the FIRST time the worker process exits
 	// (running -> pr_open / dead / failed / etc.). It is never overwritten

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -15,6 +15,10 @@ auto_rebase: true                  # auto-rebase conflicting PR branches (defaul
 merge_strategy: sequential         # "sequential" (default) or "parallel"
 merge_interval_seconds: 30         # minimum seconds between sequential merges (default: 30)
 review_gate: greptile              # "greptile" (default) or "none"
+review_retrigger:                  # self-heal greptile webhook misses (#691)
+  enabled: true                    # post "@greptile review" when the gate wedges at pending (default: true)
+  pending_minutes: 10              # re-trigger after this long pending on one head SHA (default: 10)
+  cooldown_minutes: 30             # minimum gap between re-trigger comments (default: 30)
 auto_retry_review_feedback: false  # retry PRs with actionable review comments
 auto_retry_rebase_conflicts: false # retry PRs whose auto-rebase fails with conflicts
 


### PR DESCRIPTION
Implements #691 (Refs #691)

## Changes

- **Orchestrator self-heal for the Greptile webhook-miss wedge**: when the review gate has been `greptile=pending` on the same head SHA for more than `review_retrigger.pending_minutes` (default 10), the orchestrator posts `@greptile review` on the PR — the same comment that un-wedges it manually — bounded by `review_retrigger.cooldown_minutes` (default 30) to avoid comment churn. One info log line per re-trigger.
- A new head SHA (push or server-side update-branch, the PR #137 case) restarts the pending clock, and the clock clears once the gate resolves, so re-triggers only fire for a genuinely stale pending state.
- Re-trigger only fires when the *greptile* stream is the pending one — a pending `simplicity` stream does not cause a Greptile ping.
- **Config**: new `review_retrigger` block (`enabled` default on, `pending_minutes`, `cooldown_minutes`), hot-reloadable; documented in README and `maestro.yaml.example`.
- **State**: per-session `review_pending_head_sha` / `review_pending_since` / `review_retrigger_at` fields persist the pending clock and cooldown anchor across cycles and restarts.
- **GitHub client**: exported `PRHeadSHA` and `CommentPR` helpers.

This replaces the `karaoke-shepherd.timer` workaround as the primary liveness mechanism — the orchestrator owns the review gate and now owns its liveness.

## Testing

- New `internal/orchestrator/review_retrigger_test.go`: first-observation starts the clock without commenting; posts once past the threshold; no re-post within cooldown; re-posts after cooldown; head-SHA change restarts the clock; disabled config and non-greptile pending streams do nothing; gate resolution clears tracking; custom threshold/cooldown values respected.
- New `internal/config/review_retrigger_test.go`: defaults (on, 10m/30m), YAML overrides, non-positive fallback.
- `go build ./cmd/maestro/`, `go test ./...`, and `.maestro/verify.sh` all pass; changed files gofmt-clean.

Runtime note: the webhook-miss wedge is timing-dependent, so the re-trigger behavior on live PRs still needs runtime observation after deploy before #691 is closed and the shepherd timer is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a self-healing mechanism for the Greptile webhook-miss wedge: when the `greptile` review stream has been `pending` on the same head SHA longer than `review_retrigger.pending_minutes` (default 10 min), the orchestrator posts `@greptile review` on the PR, rate-limited by `cooldown_minutes` (default 30 min).

- New `maybeRetriggerStalePendingReview` path in `autoMergePRs`; `clearReviewPendingTracking` is called whenever the gate resolves so the clock only accumulates on a genuinely stale pending state.
- Three new persisted `Session` fields (`ReviewPendingHeadSHA`, `ReviewPendingSince`, `ReviewRetriggerAt`) carry the pending clock and cooldown anchor across orchestrator restarts.
- Exports `PRHeadSHA` and `CommentPR` from the GitHub client; new `ReviewRetriggerConfig` in config with hot-reload support; test coverage in two new test files.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the retrigger logic is well-bounded, disabled config and non-greptile streams are explicitly guarded, and all stated tests pass.

The orchestrator change is non-destructive (worst case: a delayed or suppressed comment), the new state fields are additive and omitempty-safe, and the test suite is thorough. Two edge cases worth a follow-up: the cooldown anchor is not reset when the head SHA changes, and the prHeadSHA API call fires every cycle per pending PR before the threshold is checked.

internal/orchestrator/orchestrator.go — specifically the head-SHA reset path in maybeRetriggerStalePendingReview and the placement of the prHeadSHA call.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds maybeRetriggerStalePendingReview and clearReviewPendingTracking to the autoMergePRs loop; cooldown anchor (ReviewRetriggerAt) is not reset on head-SHA change, and prHeadSHA is called every cycle before the threshold check. |
| internal/config/config.go | Adds ReviewRetriggerConfig with Active/EffectivePendingFor/EffectiveCooldown helpers; non-positive fallbacks and default-on logic are correct. |
| internal/state/state.go | Adds three JSON-persisted fields (ReviewPendingHeadSHA, ReviewPendingSince, ReviewRetriggerAt) to Session; omitempty keeps the state file clean for existing sessions. |
| internal/github/github.go | Exports PRHeadSHA (thin wrapper over pullHeadSHA) and CommentPR (uses exec.Command with discrete args, no shell injection risk); both are minimal and correct. |
| internal/orchestrator/review_retrigger_test.go | Thorough test suite covering first observation, threshold, cooldown, head-change restart, disabled config, non-greptile pending streams, and gate resolution; covers the stated test matrix. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:2692-2698
**Cooldown anchor persists across head-SHA changes**

When a new head SHA is detected, `ReviewPendingSince` is restarted but `ReviewRetriggerAt` is not cleared. If a retrigger fired just before a push (e.g., at T+10 min on HEAD A), and a new HEAD B is pushed at T+12 min, the cooldown from the retrigger on HEAD A still applies. The new head's pending clock starts fresh, but the first eligible retrigger for HEAD B won't fire until T+40 min — up to 30 minutes after the push — even though no retrigger was ever sent for HEAD B. The "4x in one evening" scenario with rapid server-side update-branches could hit this repeatedly.

### Issue 2 of 2
internal/orchestrator/orchestrator.go:2683-2688
**`prHeadSHA` API call on every orchestrator cycle**

`prHeadSHA` is invoked unconditionally at the top of `maybeRetriggerStalePendingReview`, before the threshold is checked. This means every cycle where any PR is `greptile=pending` produces a `gh pr view` / REST call, even when `ReviewPendingSince` was just recorded seconds ago and the 10-minute threshold is nowhere near. On deployments with several long-pending PRs and a short tick interval this will add up quickly. The call could be deferred until after the early-return on `pendingFor < EffectivePendingFor()`, since head-change detection is only meaningful once the clock is already running and close to threshold.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: self-re-trigger greptile r..."](https://github.com/befeast/maestro/commit/6ec06dc694d2510203fa61851d5310cfbf8f0151) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37075676)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->