### PR TITLE
worker spawn: classify backend auth failures (401) as backend failure — use fallback_backends, do not burn the issue retry budget

### DIFF
--- a/internal/orchestrator/backend_auth_failure_test.go
+++ b/internal/orchestrator/backend_auth_failure_test.go
@@ -1,0 +1,336 @@
+package orchestrator
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #693: when reconcile observes a dead worker whose log tail carries a
+// backend auth-failure signature (live case: claude CLI "Failed to
+// authenticate. API Error: 401 Invalid authentication credentials"), the
+// death is a backend failure, not a work failure. The session must be
+// respawned on the next fallback backend with the per-issue retry budget
+// untouched, and the failed backend gated in BackendHealth.
+func TestReconcileRunningSessions_AuthFailureDeadWorker_FallsOverToNextBackend(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["kar-43"] = &state.Session{
+		IssueNumber: 169,
+		IssueTitle:  "karaoke conveyor",
+		Status:      state.StatusRunning,
+		PID:         424242,
+		TmuxSession: "maestro-kar-43",
+		Branch:      "feat/kar-43-169-conveyor",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-2 * time.Minute),
+		LogFile:     "/tmp/kar-43-auth.log",
+	}
+
+	respawnedBackends := []string{}
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			Model: config.ModelConfig{
+				Default:          "claude",
+				FallbackBackends: []string{"codex"},
+				Backends: map[string]config.BackendDef{
+					"claude": {Cmd: "claude"},
+					"codex":  {Cmd: "codex"},
+				},
+			},
+		},
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:     func(logFile string) bool { return false },
+		authFailureFromLogFn: func(logFile string) (bool, string) {
+			return true, "failed_to_authenticate"
+		},
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "karaoke conveyor"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedBackends = append(respawnedBackends, backendName)
+			sess.Status = state.StatusRunning
+			sess.PID = 9001
+			sess.Backend = backendName
+			sess.StartedAt = time.Now().UTC()
+			sess.FinishedAt = nil
+			return nil
+		},
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["kar-43"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (auth fallover should respawn the worker)", sess.Status, state.StatusRunning)
+	}
+	if len(respawnedBackends) != 1 || respawnedBackends[0] != "codex" {
+		t.Fatalf("respawned backends = %v, want [codex]", respawnedBackends)
+	}
+	if len(sess.TriedBackends) != 1 || sess.TriedBackends[0] != "claude" {
+		t.Fatalf("TriedBackends = %v, want [claude] (the auth-failed backend)", sess.TriedBackends)
+	}
+	if sess.RetryCount != 0 {
+		t.Fatalf("RetryCount = %d, want 0 — backend auth failure must not consume the retry budget", sess.RetryCount)
+	}
+	if !sess.RateLimitHit {
+		t.Fatal("RateLimitHit should be true so FailedAttemptsForIssue excludes the session")
+	}
+	if sess.ProviderLimitBackend != "claude" {
+		t.Fatalf("ProviderLimitBackend = %q, want claude", sess.ProviderLimitBackend)
+	}
+	if sess.ProviderLimitReason != state.BackendBlockAuthFailure {
+		t.Fatalf("ProviderLimitReason = %q, want %q", sess.ProviderLimitReason, state.BackendBlockAuthFailure)
+	}
+	if sess.BackendSelection == nil || sess.BackendSelection.SelectedBackend != "codex" || sess.BackendSelection.SelectionReason != selectionReasonAuthFailureFallback {
+		t.Fatalf("BackendSelection = %+v, want SelectedBackend=codex SelectionReason=%s", sess.BackendSelection, selectionReasonAuthFailureFallback)
+	}
+	health, ok := s.BackendHealth["claude"]
+	if !ok {
+		t.Fatal("BackendHealth[claude] should be recorded by recordBackendAuthFailure")
+	}
+	if health.State != state.BackendHealthCooldown || health.Reason != state.BackendBlockAuthFailure {
+		t.Fatalf("BackendHealth[claude] = %+v, want cooldown/auth_failure", health)
+	}
+	if health.Pattern != "failed_to_authenticate" {
+		t.Fatalf("BackendHealth[claude].Pattern = %q, want failed_to_authenticate", health.Pattern)
+	}
+	if health.RetryAfter == nil {
+		t.Fatal("BackendHealth[claude].RetryAfter should be set so the backend is re-probed after the cooldown")
+	}
+	if remaining := time.Until(*health.RetryAfter); remaining <= 0 || remaining > backendAuthFailureCooldown+time.Minute {
+		t.Fatalf("RetryAfter = %v (in %s), want ~%s from now", health.RetryAfter, remaining, backendAuthFailureCooldown)
+	}
+	if failed := s.FailedAttemptsForIssue(169); failed != 0 {
+		t.Fatalf("FailedAttemptsForIssue(169) = %d, want 0", failed)
+	}
+}
+
+// #693: with no fallback backend available, an auth-failed worker is marked
+// dead with the backend_auth_failure notification token — and still must not
+// count against the per-issue retry budget.
+func TestReconcileRunningSessions_AuthFailureDeadWorker_NoFallback_DoesNotBurnRetryBudget(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["kar-44"] = &state.Session{
+		IssueNumber: 169,
+		IssueTitle:  "karaoke conveyor",
+		Status:      state.StatusRunning,
+		PID:         424243,
+		TmuxSession: "maestro-kar-44",
+		Branch:      "feat/kar-44-169-conveyor",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-90 * time.Second),
+		LogFile:     "/tmp/kar-44-auth.log",
+	}
+
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			Model: config.ModelConfig{
+				Default:  "claude",
+				Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+			},
+		},
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:     func(logFile string) bool { return false },
+		authFailureFromLogFn: func(logFile string) (bool, string) {
+			return true, "invalid_auth_credentials"
+		},
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["kar-44"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.LastNotifiedStatus != "backend_auth_failure" {
+		t.Fatalf("last_notified_status = %q, want backend_auth_failure", sess.LastNotifiedStatus)
+	}
+	if !sess.RateLimitHit {
+		t.Fatal("RateLimitHit should be true so retry budget is preserved")
+	}
+	if failed := s.FailedAttemptsForIssue(169); failed != 0 {
+		t.Fatalf("FailedAttemptsForIssue(169) = %d, want 0 — auth-failed dead session must not burn retry budget", failed)
+	}
+	if got := state.SessionDisplayStatusFor(sess, nil); got != string(state.DisplayBackendAuthFailure) {
+		t.Fatalf("display status = %q, want %q", got, state.DisplayBackendAuthFailure)
+	}
+}
+
+// #693 precision guard: an auth signature in the log of a worker that ran
+// well past the early-death window is more likely incidental work content
+// (the worker reading/writing auth-related code) than a backend outage. The
+// session must take the ordinary dead path: no backend gating, no fallover.
+func TestReconcileRunningSessions_AuthFailureLateDeath_NotClassified(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["kar-45"] = &state.Session{
+		IssueNumber: 169,
+		Status:      state.StatusRunning,
+		PID:         424244,
+		TmuxSession: "maestro-kar-45",
+		Branch:      "feat/kar-45-169-conveyor",
+		Backend:     "claude",
+		StartedAt:   time.Now().Add(-backendAuthFailureWindow - 20*time.Minute),
+		LogFile:     "/tmp/kar-45-auth.log",
+	}
+
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			Model: config.ModelConfig{
+				Default:          "claude",
+				FallbackBackends: []string{"codex"},
+				Backends: map[string]config.BackendDef{
+					"claude": {Cmd: "claude"},
+					"codex":  {Cmd: "codex"},
+				},
+			},
+		},
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:     func(logFile string) bool { return false },
+		authFailureFromLogFn: func(logFile string) (bool, string) {
+			t.Fatal("authFailureFromLogFn must not be consulted outside the early-death window")
+			return false, ""
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			t.Fatal("respawnWorkerFn must not be called for an ordinary dead worker")
+			return nil
+		},
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["kar-45"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.RateLimitHit {
+		t.Fatal("RateLimitHit must stay false on the ordinary dead path")
+	}
+	if _, ok := s.BackendHealth["claude"]; ok {
+		t.Fatal("BackendHealth[claude] must not be gated for a late death")
+	}
+}
+
+// #693: the main-loop dead-worker path (checkSessions) must classify the
+// auth failure the same way reconcile does — fallback respawn, no retry
+// budget burn. This is the path that torched kar-43/44/45/46 live: each
+// death incremented RetryCount until the issue wedged on retry_exhausted.
+func TestCheckSessions_AuthFailureDeadWorker_FallsOverToNextBackend(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["kar-46"] = &state.Session{
+		IssueNumber: 169,
+		IssueTitle:  "karaoke conveyor",
+		Status:      state.StatusRunning,
+		PID:         424245,
+		TmuxSession: "maestro-kar-46",
+		Branch:      "feat/kar-46-169-conveyor",
+		Backend:     "claude",
+		StartedAt:   time.Now().UTC().Add(-2 * time.Minute),
+		LogFile:     "/tmp/kar-46-auth.log",
+	}
+
+	respawnedBackends := []string{}
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRuntimeMinutes:  999,
+		MaxRetriesPerIssue: 3,
+		Model: config.ModelConfig{
+			Default:          "claude",
+			FallbackBackends: []string{"codex"},
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+	}
+	o, _ := newCheckSessionsOrchestrator(cfg, "")
+	o.pidAliveFn = func(pid int) bool { return false }
+	o.isRateLimitedFn = func(logFile string) bool { return false }
+	o.authFailureFromLogFn = func(logFile string) (bool, string) {
+		return true, "failed_to_authenticate"
+	}
+	o.getIssueFn = func(number int) (github.Issue, error) {
+		return github.Issue{Number: number, Title: "karaoke conveyor"}, nil
+	}
+	o.respawnWorkerFn = func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+		respawnedBackends = append(respawnedBackends, backendName)
+		sess.Status = state.StatusRunning
+		sess.PID = 9002
+		sess.Backend = backendName
+		sess.StartedAt = time.Now().UTC()
+		sess.FinishedAt = nil
+		return nil
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["kar-46"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (auth fallover should respawn the worker)", sess.Status, state.StatusRunning)
+	}
+	if len(respawnedBackends) != 1 || respawnedBackends[0] != "codex" {
+		t.Fatalf("respawned backends = %v, want [codex]", respawnedBackends)
+	}
+	if sess.RetryCount != 0 {
+		t.Fatalf("RetryCount = %d, want 0 — backend auth failure must not consume max_retries_per_issue", sess.RetryCount)
+	}
+	if len(sess.TriedBackends) != 1 || sess.TriedBackends[0] != "claude" {
+		t.Fatalf("TriedBackends = %v, want [claude]", sess.TriedBackends)
+	}
+	if sess.ProviderLimitReason != state.BackendBlockAuthFailure {
+		t.Fatalf("ProviderLimitReason = %q, want %q", sess.ProviderLimitReason, state.BackendBlockAuthFailure)
+	}
+	if health, ok := s.BackendHealth["claude"]; !ok || health.Reason != state.BackendBlockAuthFailure {
+		t.Fatalf("BackendHealth[claude] = %+v, want cooldown with reason auth_failure", health)
+	}
+	if failed := s.FailedAttemptsForIssue(169); failed != 0 {
+		t.Fatalf("FailedAttemptsForIssue(169) = %d, want 0", failed)
+	}
+}
+
+// #693: repeated auth deaths across the fallback chain must never wedge the
+// issue via retry_exhausted. With both backends auth-failed (claude gated,
+// codex tried), canRetryIssue still sees zero consumed attempts.
+func TestCanRetryIssue_AuthFailedSessions_DoNotConsumeBudget(t *testing.T) {
+	s := state.NewState()
+	for i := 0; i < 4; i++ {
+		slot := fmt.Sprintf("kar-%d", 50+i)
+		s.Sessions[slot] = &state.Session{
+			IssueNumber:          169,
+			Status:               state.StatusDead,
+			Backend:              "claude",
+			RateLimitHit:         true,
+			ProviderLimitBackend: "claude",
+			ProviderLimitReason:  state.BackendBlockAuthFailure,
+		}
+	}
+	live := &state.Session{IssueNumber: 169, Status: state.StatusRunning, Backend: "codex"}
+	s.Sessions["kar-54"] = live
+
+	o := &Orchestrator{cfg: &config.Config{MaxRetriesPerIssue: 3}}
+	if !o.canRetryIssue(s, live) {
+		t.Fatal("canRetryIssue = false — four auth-failed sessions burned the retry budget (#693 regression)")
+	}
+}

--- a/internal/orchestrator/backend_selector.go
+++ b/internal/orchestrator/backend_selector.go
@@ -8,7 +8,17 @@ import (
 	"github.com/befeast/maestro/internal/state"
 )
 
-const selectionReasonProviderLimitFallback = "fallback_after_provider_limit"
+const (
+	selectionReasonProviderLimitFallback = "fallback_after_provider_limit"
+	selectionReasonAuthFailureFallback   = "fallback_after_backend_auth_failure"
+)
+
+// backendAuthFailureCooldown is how long an auth-failed backend stays gated
+// before the fallback selector may pick it again. Credential failures clear
+// when the operator (or the cred-sync agent) refreshes the token, and the
+// provider states no reset time, so a short fixed window re-probes the
+// backend a few times an hour instead of per-spawn (#693).
+const backendAuthFailureCooldown = 10 * time.Minute
 
 // recordProviderLimit marks the session's backend as rate-limited and puts it
 // into cooldown. resetAt, when non-nil, is the provider-stated reset time
@@ -43,9 +53,53 @@ func (o *Orchestrator) recordProviderLimit(st *state.State, slotName string, ses
 	st.BackendHealth[sess.Backend] = health
 }
 
+// recordBackendAuthFailure marks the session's backend as failing
+// authentication and puts it into cooldown (#693). Unlike a provider
+// capacity limit there is no provider-stated reset time, so RetryAfter is a
+// fixed short window (backendAuthFailureCooldown) after which the selector
+// re-probes the backend automatically. RateLimitHit is set because it is the
+// shared "transient backend block" marker: FailedAttemptsForIssue excludes
+// such sessions, so the auth outage does not burn the per-issue retry budget.
+func (o *Orchestrator) recordBackendAuthFailure(st *state.State, slotName string, sess *state.Session, pattern string, now time.Time) {
+	if st == nil || sess == nil || sess.Backend == "" {
+		return
+	}
+	if st.BackendHealth == nil {
+		st.BackendHealth = make(map[string]state.BackendHealth)
+	}
+	if pattern == "" {
+		pattern = state.BackendBlockAuthFailure
+	}
+	sess.RateLimitHit = true
+	sess.ProviderLimitBackend = sess.Backend
+	sess.ProviderLimitReason = state.BackendBlockAuthFailure
+	retryAfter := now.UTC().Add(backendAuthFailureCooldown)
+	st.BackendHealth[sess.Backend] = state.BackendHealth{
+		State:       state.BackendHealthCooldown,
+		Reason:      state.BackendBlockAuthFailure,
+		Pattern:     pattern,
+		Since:       now.UTC(),
+		RetryAfter:  &retryAfter,
+		LastSession: slotName,
+	}
+}
+
 func (o *Orchestrator) selectProviderLimitFallback(st *state.State, sess *state.Session, now time.Time) state.BackendSelection {
+	return o.selectBackendFallback(st, sess, now, selectionReasonProviderLimitFallback)
+}
+
+func (o *Orchestrator) selectAuthFailureFallback(st *state.State, sess *state.Session, now time.Time) state.BackendSelection {
+	return o.selectBackendFallback(st, sess, now, selectionReasonAuthFailureFallback)
+}
+
+// selectBackendFallback picks the next backend for a session whose current
+// backend is blocked (provider limit or auth failure), walking
+// backendFallbackCandidates and skipping disabled, already-tried, current,
+// and cooling-down backends. selectionReason records which failure class
+// triggered the fallover in the session's BackendSelection audit record.
+func (o *Orchestrator) selectBackendFallback(st *state.State, sess *state.Session, now time.Time, selectionReason string) state.BackendSelection {
 	selection := state.BackendSelection{
-		SelectionReason: selectionReasonProviderLimitFallback,
+		SelectionReason: selectionReason,
 		PreviousBackend: backendName(sess),
 	}
 	for _, candidate := range o.backendFallbackCandidates(sess) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -62,6 +62,7 @@ type Orchestrator struct {
 	addIssueLabelFn         func(number int, label string) error
 	isRateLimitedFn         func(logFile string) bool
 	rateLimitResetFromLogFn func(logFile string) *time.Time
+	authFailureFromLogFn    func(logFile string) (bool, string)
 	// workerRespawnFn / respawnWorkerFn: used by respawnWorker() for dead-worker fallback (tests set one or the other)
 	workerRespawnFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 	respawnWorkerFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
@@ -500,6 +501,35 @@ func (o *Orchestrator) providerRateLimitFromLog(logFile string) (hit bool, reset
 		return false, nil
 	}
 	return true, reset
+}
+
+// backendAuthFailureWindow bounds how long after spawn an auth-error log
+// signature is trusted as a backend credential failure (#693). An
+// unauthenticated CLI dies on its first API call — within a couple of
+// minutes of spawn (live case: claude 401 killed every worker ~2 minutes
+// in) — so an auth signature in a longer-lived worker's log is more likely
+// incidental work content (the worker reading or writing auth-related code)
+// than a backend outage, and is left to the ordinary retry path.
+const backendAuthFailureWindow = 10 * time.Minute
+
+// backendAuthFailureFromLog reports whether a dead worker died because its
+// backend could not authenticate (e.g. "Failed to authenticate. API Error:
+// 401 Invalid authentication credentials"). It returns hit=true only when
+// the worker died within backendAuthFailureWindow of its spawn AND the log
+// tail carries a known auth-failure signature. Such a death is a backend
+// failure, not a work failure: callers must gate the backend, preserve the
+// per-issue retry budget, and respawn the attempt on a fallback backend.
+func (o *Orchestrator) backendAuthFailureFromLog(sess *state.Session, now time.Time) (bool, string) {
+	if sess == nil {
+		return false, ""
+	}
+	if sess.StartedAt.IsZero() || now.Sub(sess.StartedAt) > backendAuthFailureWindow {
+		return false, ""
+	}
+	if o.authFailureFromLogFn != nil {
+		return o.authFailureFromLogFn(sess.LogFile)
+	}
+	return worker.IsAuthFailure(sess.LogFile)
 }
 
 func (o *Orchestrator) workerLogFile(slotName string, sess *state.Session) string {
@@ -1813,6 +1843,83 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 			continue
 		}
 
+		// Backend auth/credential failure (#693): the worker died early with
+		// an auth-error signature in its log tail (e.g. claude CLI "Failed to
+		// authenticate. API Error: 401 Invalid authentication credentials").
+		// This is a backend outage, not a work failure — respawning on the
+		// same backend dies the same way and burns the per-issue retry budget
+		// on an auth hiccup. Gate the backend (short cooldown; the credential
+		// usually recovers via re-login / cred-sync), keep the budget intact,
+		// and respawn the same attempt on the next fallback backend.
+		if hit, pattern := o.backendAuthFailureFromLog(sess, time.Now().UTC()); hit {
+			now := time.Now().UTC()
+			o.updateTokensUsedFromWorkerLog(slotName, sess)
+			o.recordBackendAuthFailure(s, slotName, sess, pattern, now)
+			selection := o.selectAuthFailureFallback(s, sess, now)
+			sess.BackendSelection = &selection
+			oldPID := sess.PID
+			oldTmux := tmuxName
+			previousBackend := sess.Backend
+			nextBackend := selection.SelectedBackend
+
+			if nextBackend == "" {
+				sess.PID = 0
+				sess.TmuxSession = ""
+				sess.FinishedAt = &now
+				state.MarkWorkerEnded(sess, now)
+				sess.LastNotifiedStatus = "backend_auth_failure"
+				sess.Status = state.StatusDead
+				reconciled = true
+				log.Printf("[orch] reconcile: %s running->dead via backend auth failure on backend=%s signature=%s (no fallback available; %s); pid=%d tmux=%q",
+					slotName, previousBackend, pattern, strings.Join(reasons, ", "), oldPID, oldTmux)
+				o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) backend %s failed authentication (%s); no fallback backend available — fix credentials",
+					slotName, sess.IssueNumber, sess.IssueTitle, previousBackend, pattern)
+				continue
+			}
+
+			issue, fetchErr := o.getIssue(sess.IssueNumber)
+			if fetchErr != nil {
+				sess.PID = 0
+				sess.TmuxSession = ""
+				sess.FinishedAt = &now
+				state.MarkWorkerEnded(sess, now)
+				sess.LastNotifiedStatus = "backend_auth_failure"
+				sess.Status = state.StatusDead
+				reconciled = true
+				log.Printf("[orch] reconcile: %s running->dead via backend auth failure on backend=%s signature=%s (fallback to %s aborted: could not fetch issue #%d: %v; %s); pid=%d tmux=%q",
+					slotName, previousBackend, pattern, nextBackend, sess.IssueNumber, fetchErr, strings.Join(reasons, ", "), oldPID, oldTmux)
+				o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) backend %s failed authentication; fallback to %s failed (could not fetch issue): %v",
+					slotName, sess.IssueNumber, sess.IssueTitle, previousBackend, nextBackend, fetchErr)
+				continue
+			}
+
+			if previousBackend != "" {
+				sess.TriedBackends = append(sess.TriedBackends, previousBackend)
+			}
+			promptBase := o.selectPrompt(issue)
+			if respawnErr := o.respawnWorker(slotName, sess, issue, promptBase, nextBackend); respawnErr != nil {
+				sess.PID = 0
+				sess.TmuxSession = ""
+				sess.FinishedAt = &now
+				state.MarkWorkerEnded(sess, now)
+				sess.LastNotifiedStatus = "backend_auth_failure"
+				sess.Status = state.StatusDead
+				reconciled = true
+				log.Printf("[orch] reconcile: %s running->dead via backend auth failure on backend=%s signature=%s (fallback respawn on %s failed: %v; %s); pid=%d tmux=%q",
+					slotName, previousBackend, pattern, nextBackend, respawnErr, strings.Join(reasons, ", "), oldPID, oldTmux)
+				o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) backend %s failed authentication; fallback to %s failed: %v",
+					slotName, sess.IssueNumber, sess.IssueTitle, previousBackend, nextBackend, respawnErr)
+				continue
+			}
+
+			reconciled = true
+			log.Printf("[orch] reconcile: %s backend auth failure on backend=%s signature=%s — respawned with backend=%s, retry budget preserved (%s); old pid=%d tmux=%q",
+				slotName, previousBackend, pattern, nextBackend, strings.Join(reasons, ", "), oldPID, oldTmux)
+			o.notifier.Sendf("🔄 maestro: worker %s (issue #%d: %s) backend %s failed authentication (%s) — respawned on %s, retry budget preserved",
+				slotName, sess.IssueNumber, sess.IssueTitle, previousBackend, pattern, nextBackend)
+			continue
+		}
+
 		oldPID := sess.PID
 		oldTmux := tmuxName
 		o.updateTokensUsedFromWorkerLog(slotName, sess)
@@ -2182,6 +2289,63 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 					o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) rate-limited on %s, switched to %s",
 						slotName, sess.IssueNumber, previousBackend, nextBackend)
+				} else if hit, pattern := o.backendAuthFailureFromLog(sess, time.Now().UTC()); hit {
+					// Backend auth/credential failure (e.g. claude CLI
+					// "Failed to authenticate. API Error: 401"). This is a
+					// backend outage, not a work failure (#693): every retry
+					// on the same backend dies the same way and silently burns
+					// max_retries_per_issue on an auth hiccup. Gate the
+					// backend, keep the retry budget intact, and respawn the
+					// same attempt on the next fallback backend.
+					now := time.Now().UTC()
+					o.updateTokensUsedFromWorkerLog(slotName, sess)
+					o.recordBackendAuthFailure(s, slotName, sess, pattern, now)
+					selection := o.selectAuthFailureFallback(s, sess, now)
+					sess.BackendSelection = &selection
+					nextBackend := selection.SelectedBackend
+					if nextBackend == "" {
+						log.Printf("[orch] worker %s (backend=%s) backend auth failure (%s); no fallback backend available", slotName, sess.Backend, pattern)
+						sess.Status = state.StatusDead
+						sess.LastNotifiedStatus = "backend_auth_failure"
+						sess.FinishedAt = &now
+						state.MarkWorkerEnded(sess, now)
+						o.notifier.Sendf("⚠️ maestro: worker %s (issue #%d: %s) backend %s failed authentication (%s); no fallback backend available — fix credentials",
+							slotName, sess.IssueNumber, sess.IssueTitle, sess.Backend, pattern)
+						continue
+					}
+					log.Printf("[orch] worker %s (backend=%s) failed authentication (%s), falling back to %s — retry budget preserved",
+						slotName, sess.Backend, pattern, nextBackend)
+
+					issue, err := o.getIssue(sess.IssueNumber)
+					if err != nil {
+						log.Printf("[orch] fetch issue #%d for auth-failure fallback: %v — marking as failed", sess.IssueNumber, err)
+						sess.Status = state.StatusFailed
+						now := time.Now().UTC()
+						sess.FinishedAt = &now
+						state.MarkWorkerEnded(sess, now)
+						o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) backend auth failure and fallback failed (could not fetch issue)",
+							slotName, sess.IssueNumber, sess.IssueTitle)
+						continue
+					}
+
+					previousBackend := sess.Backend
+					if previousBackend != "" {
+						sess.TriedBackends = append(sess.TriedBackends, previousBackend)
+					}
+					promptBase := o.selectPrompt(issue)
+					if err := o.respawnWorker(slotName, sess, issue, promptBase, nextBackend); err != nil {
+						log.Printf("[orch] auth-failure fallback respawn worker %s with %s: %v — marking as failed", slotName, nextBackend, err)
+						sess.Status = state.StatusFailed
+						now := time.Now().UTC()
+						sess.FinishedAt = &now
+						state.MarkWorkerEnded(sess, now)
+						o.notifier.Sendf("💀 maestro: worker %s (issue #%d: %s) backend auth failure and fallback to %s failed: %v",
+							slotName, sess.IssueNumber, sess.IssueTitle, nextBackend, err)
+						continue
+					}
+
+					o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) backend %s failed authentication (%s), switched to %s — retry budget preserved",
+						slotName, sess.IssueNumber, previousBackend, pattern, nextBackend)
 				} else if o.canRetryIssue(s, sess) {
 					// Schedule retry with exponential backoff (respects max_retries_per_issue)
 					o.updateTokensUsedFromWorkerLog(slotName, sess)

--- a/internal/state/backend_auth_failure_test.go
+++ b/internal/state/backend_auth_failure_test.go
@@ -1,0 +1,58 @@
+package state
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// #693: a session that died on a backend auth failure with no fallback must
+// render as backend_auth_failure (not dead/retry_exhausted, and not the
+// rate-limit token) so operators see a credential outage, not a code failure.
+func TestSessionDisplayStatus_BackendAuthFailure(t *testing.T) {
+	now := time.Now().UTC()
+	sess := &Session{
+		Status:               StatusDead,
+		Backend:              "claude",
+		RateLimitHit:         true,
+		ProviderLimitBackend: "claude",
+		ProviderLimitReason:  BackendBlockAuthFailure,
+	}
+	if got := SessionDisplayStatusForAt(sess, nil, now); got != string(DisplayBackendAuthFailure) {
+		t.Fatalf("display status = %q, want %q", got, DisplayBackendAuthFailure)
+	}
+
+	// A provider capacity limit keeps the existing token.
+	sess.ProviderLimitReason = BackendBlockProviderLimit
+	if got := SessionDisplayStatusForAt(sess, nil, now); got != string(DisplayBackendRateLimited) {
+		t.Fatalf("display status = %q, want %q", got, DisplayBackendRateLimited)
+	}
+
+	// A scheduled retry takes precedence over the backend-block token.
+	sess.ProviderLimitReason = BackendBlockAuthFailure
+	retryAt := now.Add(time.Minute)
+	sess.NextRetryAt = &retryAt
+	if got := SessionDisplayStatusForAt(sess, nil, now); got != string(StatusDead) {
+		t.Fatalf("display status = %q, want %q", got, StatusDead)
+	}
+}
+
+func TestSessionAttention_BackendAuthFailure(t *testing.T) {
+	sess := &Session{
+		Status:               StatusDead,
+		Backend:              "claude",
+		RateLimitHit:         true,
+		ProviderLimitBackend: "claude",
+		ProviderLimitReason:  BackendBlockAuthFailure,
+	}
+	attention := SessionAttentionFor(sess, nil)
+	if !attention.NeedsAttention {
+		t.Fatal("auth-failed session with no fallback must need attention")
+	}
+	if !strings.Contains(attention.Reason, "failed authentication") {
+		t.Fatalf("attention reason = %q, want authentication wording", attention.Reason)
+	}
+	if !strings.Contains(attention.NextAction, "retry budget was not consumed") {
+		t.Fatalf("next action = %q, want retry-budget note", attention.NextAction)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -42,6 +42,11 @@ const (
 	// distinct, non-failure display token so operators do not confuse a
 	// rate-limited backend with a genuine retry_exhausted code failure.
 	DisplayBackendRateLimited SessionDisplayStatus = "backend_rate_limited"
+	// DisplayBackendAuthFailure marks a session whose worker exited because its
+	// backend could not authenticate (e.g. claude CLI 401, #693) with no
+	// fallback available. Like DisplayBackendRateLimited it is a backend
+	// outage, not a work failure, and did not burn the per-issue retry budget.
+	DisplayBackendAuthFailure SessionDisplayStatus = "backend_auth_failure"
 	LiveSessionRecentWindow                        = 24 * time.Hour
 )
 
@@ -52,10 +57,15 @@ const (
 	BackendHealthCooldown  = "cooldown"
 
 	BackendBlockProviderLimit = "provider_limit"
-	BackendBlockDisabled      = "disabled"
-	BackendBlockAlreadyTried  = "already_tried"
-	BackendBlockCurrent       = "current_backend"
-	BackendBlockUnknown       = "unknown_backend"
+	// BackendBlockAuthFailure gates a backend whose CLI failed to
+	// authenticate (e.g. 401 invalid/expired credentials, #693). Worker
+	// deaths attributed to it are backend failures, not work failures: they
+	// must not consume the per-issue retry budget.
+	BackendBlockAuthFailure  = "auth_failure"
+	BackendBlockDisabled     = "disabled"
+	BackendBlockAlreadyTried = "already_tried"
+	BackendBlockCurrent      = "current_backend"
+	BackendBlockUnknown      = "unknown_backend"
 )
 
 // BackendHealth records cross-session availability for a configured backend.
@@ -124,10 +134,10 @@ type Session struct {
 	LastOutputChangedAt         time.Time         `json:"last_output_changed_at,omitempty"`
 	TokensUsedAttempt           int               `json:"tokens_used_attempt,omitempty"`            // tokens consumed in current attempt (reset on respawn)
 	TokensUsedTotal             int               `json:"tokens_used_total,omitempty"`              // cumulative tokens across the issue lifecycle
-	RateLimitHit                bool              `json:"rate_limit_hit,omitempty"`                 // true if worker was rate-limited (tmux detection, running worker)
-	TriedBackends               []string          `json:"tried_backends,omitempty"`                 // backends already attempted (for rate-limit fallback)
-	ProviderLimitBackend        string            `json:"provider_limit_backend,omitempty"`         // backend that hit a provider capacity limit
-	ProviderLimitReason         string            `json:"provider_limit_reason,omitempty"`          // provider limit signature or class
+	RateLimitHit                bool              `json:"rate_limit_hit,omitempty"`                 // true when the worker died on a transient backend block (provider limit or auth failure, #693); excludes the session from the per-issue retry budget
+	TriedBackends               []string          `json:"tried_backends,omitempty"`                 // backends already attempted (for backend-failure fallback)
+	ProviderLimitBackend        string            `json:"provider_limit_backend,omitempty"`         // backend that hit a provider capacity limit or auth failure
+	ProviderLimitReason         string            `json:"provider_limit_reason,omitempty"`          // backend block signature or class (e.g. BackendBlockAuthFailure)
 	ProviderLimitResetAt        *time.Time        `json:"provider_limit_reset_at,omitempty"`        // provider-stated reset time parsed from the limit message ("try again at ..."), UTC
 	BackendSelection            *BackendSelection `json:"backend_selection,omitempty"`              // latest backend selection audit record
 	Phase                       Phase             `json:"phase,omitempty"`                          // current pipeline phase (empty = legacy single-phase)
@@ -272,6 +282,13 @@ func SessionAttentionForAt(sess *Session, alive *bool, now time.Time) SessionAtt
 			if backend == "" {
 				backend = sess.Backend
 			}
+			if sess.ProviderLimitReason == BackendBlockAuthFailure {
+				return SessionAttention{
+					Reason:         fmt.Sprintf("Backend %s failed authentication (invalid or expired credentials); no fallback backend is currently available or allowed.", backend),
+					NextAction:     "Re-authenticate the backend CLI (or wait for credential sync), then retry; the per-issue retry budget was not consumed.",
+					NeedsAttention: true,
+				}
+			}
 			return SessionAttention{
 				Reason:         fmt.Sprintf("Backend %s hit a provider capacity limit; no fallback backend is currently available or allowed.", backend),
 				NextAction:     "Wait for provider capacity to recover, enable another backend, or change routing policy before retrying.",
@@ -339,16 +356,19 @@ func SessionDisplayStatusForAt(sess *Session, alive *bool, now time.Time) string
 		return string(display)
 	}
 	if backendRateLimitedDisplayStatus(sess) {
+		if sess.ProviderLimitReason == BackendBlockAuthFailure {
+			return string(DisplayBackendAuthFailure)
+		}
 		return string(DisplayBackendRateLimited)
 	}
 	return string(sess.Status)
 }
 
 // backendRateLimitedDisplayStatus reports whether a session represents a worker
-// that exited because its backend hit a provider usage limit with no fallback
-// available. Such a session is marked Dead but, unlike a real failure, did not
-// burn the per-issue retry budget; it must be shown distinctly so operators do
-// not mistake it for retry_exhausted.
+// that exited because of a backend block (provider usage limit or auth
+// failure, #693) with no fallback available. Such a session is marked Dead
+// but, unlike a real failure, did not burn the per-issue retry budget; it
+// must be shown distinctly so operators do not mistake it for retry_exhausted.
 func backendRateLimitedDisplayStatus(sess *Session) bool {
 	if sess == nil {
 		return false
@@ -2934,9 +2954,10 @@ func (s *State) IssueDone(issueNum int) bool {
 // FailedAttemptsForIssue counts sessions for the given issue that ended
 // without producing a PR (dead, failed, or retry_exhausted).
 //
-// Sessions marked as rate-limited (RateLimitHit) are NOT counted as failed
-// attempts: a transient backend block must not consume the per-issue retry
-// budget. See #432 / #458 / #466.
+// Sessions marked as backend-blocked (RateLimitHit — provider capacity limit
+// or backend auth failure) are NOT counted as failed attempts: a transient
+// backend block must not consume the per-issue retry budget.
+// See #432 / #458 / #466 / #693.
 func (s *State) FailedAttemptsForIssue(issueNum int) int {
 	count := 0
 	for _, sess := range s.Sessions {

--- a/internal/supervisor/backend_auth_failure_test.go
+++ b/internal/supervisor/backend_auth_failure_test.go
@@ -1,0 +1,100 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #693: a backend gated by an auth/credential failure must surface as a
+// backend_auth_failure finding so the operator sees the backend is down
+// (expired/invalidated OAuth token) instead of discovering it later as
+// wedged issues. The default backend is blocking; others warn.
+func TestDetectBackendAuthFailureStuckStates(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Model.Default = "claude"
+	e := testEngine(cfg, &fakeReader{})
+	now := e.now()
+
+	retryAfter := now.Add(8 * time.Minute)
+	st := state.NewState()
+	st.BackendHealth["claude"] = state.BackendHealth{
+		State:       state.BackendHealthCooldown,
+		Reason:      state.BackendBlockAuthFailure,
+		Pattern:     "failed_to_authenticate",
+		Since:       now.Add(-2 * time.Minute),
+		RetryAfter:  &retryAfter,
+		LastSession: "kar-43",
+	}
+
+	findings := e.detectBackendAuthFailureStuckStates(st, now)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1: %+v", len(findings), findings)
+	}
+	finding := findings[0]
+	if finding.Code != "backend_auth_failure" {
+		t.Fatalf("code = %q, want backend_auth_failure", finding.Code)
+	}
+	if finding.Severity != SeverityBlocked {
+		t.Fatalf("severity = %q, want %q (default backend down blocks new spawns)", finding.Severity, SeverityBlocked)
+	}
+	evidence := strings.Join(finding.Evidence, "\n")
+	for _, want := range []string{"backend=claude", "signature=failed_to_authenticate", "last_session=kar-43"} {
+		if !strings.Contains(evidence, want) {
+			t.Errorf("evidence %q missing %q", evidence, want)
+		}
+	}
+}
+
+func TestDetectBackendAuthFailureStuckStates_SkipsExpiredAndOtherReasons(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Model.Default = "claude"
+	e := testEngine(cfg, &fakeReader{})
+	now := e.now()
+
+	expired := now.Add(-time.Minute)
+	st := state.NewState()
+	// Cooldown elapsed: the selector will re-probe the backend, no finding.
+	st.BackendHealth["claude"] = state.BackendHealth{
+		State:      state.BackendHealthCooldown,
+		Reason:     state.BackendBlockAuthFailure,
+		RetryAfter: &expired,
+	}
+	// Provider rate limit is not an auth failure.
+	st.BackendHealth["codex"] = state.BackendHealth{
+		State:  state.BackendHealthCooldown,
+		Reason: state.BackendBlockProviderLimit,
+	}
+
+	if findings := e.detectBackendAuthFailureStuckStates(st, now); len(findings) != 0 {
+		t.Fatalf("findings = %+v, want none", findings)
+	}
+}
+
+// A non-default backend failing auth degrades capacity but does not block
+// new spawns — it must surface as a warning, not a blocker.
+func TestDetectBackendAuthFailureStuckStates_NonDefaultBackendWarns(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Model.Default = "claude"
+	e := testEngine(cfg, &fakeReader{})
+	now := e.now()
+
+	retryAfter := now.Add(8 * time.Minute)
+	st := state.NewState()
+	st.BackendHealth["codex"] = state.BackendHealth{
+		State:      state.BackendHealthCooldown,
+		Reason:     state.BackendBlockAuthFailure,
+		Pattern:    "http_401",
+		RetryAfter: &retryAfter,
+	}
+
+	findings := e.detectBackendAuthFailureStuckStates(st, now)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != SeverityWarning {
+		t.Fatalf("severity = %q, want %q", findings[0].Severity, SeverityWarning)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1023,8 +1023,60 @@ func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.
 		findings = append(findings, detectPolicyStuckStates(skipped)...)
 	}
 	findings = append(findings, e.detectEnvironmentStuckStates(st, eligible)...)
+	findings = append(findings, e.detectBackendAuthFailureStuckStates(st, now)...)
 	findings = append(findings, e.detectOutcomeStuckStates(st)...)
 	return compactStuckStates(findings)
+}
+
+// detectBackendAuthFailureStuckStates surfaces backends gated by an
+// auth/credential failure (#693) so the operator sees the backend is down
+// (e.g. an expired/invalidated OAuth token) instead of discovering it later
+// as wedged issues. The finding self-clears once the cooldown expires or
+// ReconcileBackendHealth removes the entry. The default backend going dark
+// is blocking (every new spawn prefers it); a non-default backend is a
+// warning because routing can avoid it.
+func (e *Engine) detectBackendAuthFailureStuckStates(st *state.State, now time.Time) []state.SupervisorStuckState {
+	if st == nil || len(st.BackendHealth) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(st.BackendHealth))
+	for name := range st.BackendHealth {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var findings []state.SupervisorStuckState
+	for _, name := range names {
+		health := st.BackendHealth[name]
+		if health.State != state.BackendHealthCooldown || health.Reason != state.BackendBlockAuthFailure {
+			continue
+		}
+		if health.RetryAfter != nil && !now.Before(*health.RetryAfter) {
+			continue // cooldown elapsed; the selector will re-probe the backend
+		}
+		severity := SeverityWarning
+		if name == e.cfg.Model.Default {
+			severity = SeverityBlocked
+		}
+		evidence := []string{fmt.Sprintf("backend=%s", name)}
+		if health.Pattern != "" {
+			evidence = append(evidence, fmt.Sprintf("signature=%s", health.Pattern))
+		}
+		if !health.Since.IsZero() {
+			evidence = append(evidence, fmt.Sprintf("since=%s", health.Since.Format(time.RFC3339)))
+		}
+		if health.RetryAfter != nil {
+			evidence = append(evidence, fmt.Sprintf("retry_after=%s", health.RetryAfter.Format(time.RFC3339)))
+		}
+		if health.LastSession != "" {
+			evidence = append(evidence, fmt.Sprintf("last_session=%s", health.LastSession))
+		}
+		findings = append(findings, stuckState("backend_auth_failure", severity,
+			fmt.Sprintf("Backend %s is failing authentication (invalid or expired credentials); workers cannot use it.", name),
+			"Re-authenticate the backend CLI or re-sync its credentials; fallback backends keep the queue moving meanwhile and the per-issue retry budget is preserved.", false, nil,
+			evidence...))
+	}
+	return findings
 }
 
 func (e *Engine) outcomeStatus(st *state.State) outcome.Status {

--- a/internal/worker/authfailure.go
+++ b/internal/worker/authfailure.go
@@ -1,0 +1,100 @@
+package worker
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+// authFailurePatterns holds compiled regexes for detecting backend
+// auth/credential failures in AI CLI output. Each entry pairs a
+// human-readable label with its regex.
+//
+// Like rateLimitPatterns above, these are intentionally high-precision:
+// a bare "401" or the word "unauthorized" embedded in unrelated text must
+// NOT match, because worker logs can legitimately contain such strings as
+// work content (a worker writing auth middleware, test output asserting
+// 401 responses, or a prompt echo of an auth-related issue body — the
+// false-positive class from #663).
+//
+// Supported signatures (case-insensitive):
+//   - "Failed to authenticate" (claude CLI, observed live in #693:
+//     "Failed to authenticate. API Error: 401 Invalid authentication
+//     credentials")
+//   - "Invalid authentication credentials"
+//   - "authentication_error" / "authentication error" (Anthropic API error
+//     type embedded in CLI error JSON)
+//   - HTTP 401 paired with a status/code/error context word — bare 401
+//     embedded in unrelated text is NOT matched
+//   - "401 Unauthorized" (HTTP reason phrase)
+//   - "OAuth token has expired/been revoked" and "Please run /login"
+//     (claude CLI logged-out states)
+//   - invalid / incorrect / expired / revoked API key (OpenAI & Gemini
+//     phrasings: "Incorrect API key provided", "API key not valid")
+var authFailurePatterns = []struct {
+	label string
+	re    *regexp.Regexp
+}{
+	{"failed_to_authenticate", regexp.MustCompile(`(?i)failed to authenticate`)},
+	{"invalid_auth_credentials", regexp.MustCompile(`(?i)invalid authentication credentials`)},
+	{"authentication_error", regexp.MustCompile(`(?i)\bauthentication[_ ]error\b`)},
+	// HTTP 401 with an auth context word. Requires the literal 401 to appear
+	// next to an HTTP / status / code / error / response marker so issue
+	// numbers ("#401") or counters ("4012 records") do not false-positive.
+	{"http_401", regexp.MustCompile(`(?i)\b(?:http|https|status|code|err(?:or)?|response|received)\b[ \t]*[:=]?[ \t]*401\b`)},
+	{"http_401_reason", regexp.MustCompile(`(?i)\b401\b[ \t:,-]*unauthorized`)},
+	{"oauth_token_expired", regexp.MustCompile(`(?i)oauth token (?:has )?(?:expired|been revoked)`)},
+	{"login_required", regexp.MustCompile(`(?i)please run /login`)},
+	{"invalid_api_key", regexp.MustCompile(`(?i)(?:invalid|incorrect|expired|revoked)[ _-]?api[ _-]?key|api key (?:is )?(?:not valid|invalid|expired|revoked)`)},
+}
+
+// authFailureTailLines bounds post-mortem auth detection to the end of a
+// dead worker's log. The auth error that killed the CLI is its terminal
+// output, while earlier log content can echo the worker prompt — which for
+// auth-related issues legitimately contains strings like "401" or "Failed
+// to authenticate". Scanning only the tail keeps a prompt echo at the top
+// of a long log from being misread as a backend outage.
+const authFailureTailLines = 100
+
+// DetectAuthFailure scans multi-line output for known backend
+// auth/credential failure signatures. Returns true and the matching pattern
+// label on the first match, or false and "" if none is found.
+func DetectAuthFailure(output string) (bool, string) {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		for _, p := range authFailurePatterns {
+			if p.re.MatchString(line) {
+				return true, p.label
+			}
+		}
+	}
+	return false, ""
+}
+
+// IsAuthFailure checks whether a dead worker's log file ends with a backend
+// auth/credential failure signature (e.g. the claude CLI 401 from #693).
+// Only the last authFailureTailLines lines are scanned — see the constant's
+// comment for why. Returns the verdict and the matched pattern label.
+//
+// Callers MUST combine this with an early-death window (the worker died
+// shortly after spawn) before classifying the death as a backend failure:
+// an unauthenticated CLI dies on its first API call, while an auth
+// signature in a long-lived worker's log is more likely incidental work
+// content than a backend outage.
+func IsAuthFailure(logFile string) (bool, string) {
+	if logFile == "" {
+		return false, ""
+	}
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		return false, ""
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) > authFailureTailLines {
+		lines = lines[len(lines)-authFailureTailLines:]
+	}
+	return DetectAuthFailure(strings.Join(lines, "\n"))
+}

--- a/internal/worker/authfailure_test.go
+++ b/internal/worker/authfailure_test.go
@@ -1,0 +1,138 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #693: the live failure signature from the claude CLI on workshop
+// ("Failed to authenticate. API Error: 401 Invalid authentication
+// credentials") and provider-equivalent phrasings must be detected so the
+// orchestrator can classify the death as a backend failure instead of
+// burning the per-issue retry budget.
+func TestDetectAuthFailure_KnownSignatures(t *testing.T) {
+	cases := []struct {
+		name      string
+		output    string
+		wantLabel string
+	}{
+		{
+			name:      "claude CLI live signature (#693)",
+			output:    "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+			wantLabel: "failed_to_authenticate",
+		},
+		{
+			name:      "anthropic API error JSON",
+			output:    `API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth token has expired."}}`,
+			wantLabel: "authentication_error",
+		},
+		{
+			name:      "http 401 with context word",
+			output:    "request failed with status: 401",
+			wantLabel: "http_401",
+		},
+		{
+			name:      "401 unauthorized reason phrase",
+			output:    "stream error: 401 Unauthorized",
+			wantLabel: "http_401",
+		},
+		{
+			name:      "oauth token expired",
+			output:    "OAuth token has expired. Please obtain a new token or refresh your existing token.",
+			wantLabel: "oauth_token_expired",
+		},
+		{
+			name:      "claude CLI logged out",
+			output:    "Invalid API key · Please run /login",
+			wantLabel: "login_required",
+		},
+		{
+			name:      "openai incorrect api key",
+			output:    "Incorrect API key provided: sk-xxxx. You can find your API key at platform.openai.com.",
+			wantLabel: "invalid_api_key",
+		},
+		{
+			name:      "gemini api key not valid",
+			output:    "API key not valid. Please pass a valid API key.",
+			wantLabel: "invalid_api_key",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hit, label := DetectAuthFailure(tc.output)
+			if !hit {
+				t.Fatalf("DetectAuthFailure(%q) = false, want true", tc.output)
+			}
+			if label != tc.wantLabel {
+				t.Fatalf("DetectAuthFailure(%q) label = %q, want %q", tc.output, label, tc.wantLabel)
+			}
+		})
+	}
+}
+
+// Bare digits, issue references, and rate-limit phrasings must not be
+// classified as auth failures — the patterns are precision-first, mirroring
+// the #663 rule for rate-limit detection.
+func TestDetectAuthFailure_NoFalsePositives(t *testing.T) {
+	cases := []string{
+		"",
+		"processed 4012 records in 401ms",
+		"see issue #401 for details",
+		"You've hit your usage limit. Try again at May 30th, 2026 8:13 PM.",
+		"HTTP 429 Too Many Requests",
+		"the authentication flow redirects to the login page",
+		"unauthorized users are shown a banner",
+		"all tests passed: 401 assertions",
+	}
+	for _, output := range cases {
+		if hit, label := DetectAuthFailure(output); hit {
+			t.Errorf("DetectAuthFailure(%q) = true (label=%q), want false", output, label)
+		}
+	}
+}
+
+func TestIsAuthFailure_ReadsLogTail(t *testing.T) {
+	dir := t.TempDir()
+
+	logFile := filepath.Join(dir, "worker.log")
+	content := "starting worker\nsome output\nFailed to authenticate. API Error: 401 Invalid authentication credentials\n"
+	if err := os.WriteFile(logFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hit, label := IsAuthFailure(logFile)
+	if !hit || label != "failed_to_authenticate" {
+		t.Fatalf("IsAuthFailure = (%v, %q), want (true, failed_to_authenticate)", hit, label)
+	}
+
+	if hit, _ := IsAuthFailure(filepath.Join(dir, "missing.log")); hit {
+		t.Fatal("IsAuthFailure on missing file = true, want false")
+	}
+	if hit, _ := IsAuthFailure(""); hit {
+		t.Fatal("IsAuthFailure on empty path = true, want false")
+	}
+}
+
+// A prompt echo at the top of a long log (e.g. a worker assigned an
+// auth-related issue whose body quotes the 401 error) must not classify the
+// session as a backend auth failure: only the log tail — where the CLI's
+// terminal error actually lands — is scanned.
+func TestIsAuthFailure_PromptEchoOutsideTailIgnored(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "worker.log")
+
+	var b strings.Builder
+	b.WriteString("Issue #693: worker spawn: classify backend auth failures (401)\n")
+	b.WriteString("Failed to authenticate. API Error: 401 Invalid authentication credentials\n")
+	for i := 0; i < authFailureTailLines+10; i++ {
+		b.WriteString("normal worker output line\n")
+	}
+	if err := os.WriteFile(logFile, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if hit, label := IsAuthFailure(logFile); hit {
+		t.Fatalf("IsAuthFailure = (true, %q), want false — auth signature outside the log tail is prompt echo, not a backend outage", label)
+	}
+}


### PR DESCRIPTION
Implements #693 (refs #693)

## Changes

- **worker**: new auth-failure detector (`internal/worker/authfailure.go`) with high-precision signatures (`Failed to authenticate`, contextual `401`, `Invalid authentication credentials`, `authentication_error`, OAuth-expired / `/login`, invalid-API-key phrasings), following the #663 precision rules. Post-mortem detection scans only the log tail so a prompt echo of an auth-related issue body cannot false-positive.
- **orchestrator**: a worker that dies within 10 minutes of spawn with an auth signature in its log tail is classified as a **backend failure, not a work failure**, in both dead-worker paths (`checkSessions` and `reconcileRunningSessions`):
  - the backend is gated in `BackendHealth` (`reason=auth_failure`) with a fixed 10-minute `RetryAfter`, so a dead backend is re-probed once per interval instead of per-spawn;
  - the same attempt respawns on the next backend from `model.fallback_backends` (selection reason `fallback_after_backend_auth_failure` in the audit record);
  - the per-issue retry budget is untouched (`RateLimitHit` exclusion in `FailedAttemptsForIssue`, same mechanism as provider limits) — covered by a regression test asserting four auth-dead sessions still leave `canRetryIssue` true;
  - with no fallback available, the session is marked dead with `last_notified_status=backend_auth_failure` and still does not consume the budget.
- **supervisor**: new `backend_auth_failure` stuck-state finding (blocked when the default backend is down, warning for a non-default backend) with backend / signature / since / retry_after / last_session evidence.
- **state**: `backend_auth_failure` display token + attention copy so operators see a credential outage rather than a code failure.

## Not included (follow-ups)

- The optional pre-spawn probe (`<backend cmd> -p "pong"`) from the issue: the 10-minute `BackendHealth` cooldown already achieves once-per-interval detection for the fallover path without spawning probe processes in the reconcile loop.
- MC dashboard pill mapping for the new display token (requires rebuilding the bundled web assets); the token degrades gracefully to the red `dead` pill, and the session attention text carries the auth-specific wording.

## Testing

- `go test ./...` green; `go build ./cmd/maestro/` clean; changed Go files gofmt-clean.
- New tests: worker signature detection (positives, false-positive guards, log-tail behavior), orchestrator fallover in both dead-worker paths, no-fallback budget preservation, late-death precision guard (auth signature outside the early-death window takes the ordinary retry path), supervisor finding emission/severity/expiry, display/attention rendering.
- Runtime verification of the live failure mode (claude 401 on a real host) has not been performed; this PR should not auto-close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds end-to-end handling for backend 401 / credential failures: a new `IsAuthFailure` detector in the worker package, orchestrator classification of early-death auth failures in both `checkSessions` and `reconcileRunningSessions`, fallback-backend respawn with the retry budget preserved, a `BackendHealth` cooldown for the failed backend, a new `backend_auth_failure` supervisor stuck-state finding, and a matching display/attention token in `state`.

- **Worker detector** (`authfailure.go`): high-precision regexes gated to the log tail only, with an early-death window (10 min) in the orchestrator to prevent incidental work content from being misclassified.
- **Orchestrator**: two dead-worker paths (`reconcileRunningSessions`, `checkSessions`) both gate the failed backend, preserve the per-issue retry budget via `RateLimitHit`, and respawn on the next fallback backend with an audit record.
- **Supervisor + state**: `detectBackendAuthFailureStuckStates` surfaces a `Blocked` finding for the default backend and `Warning` for non-default; `DisplayBackendAuthFailure` distinguishes the state from `retry_exhausted` on dashboards.

<h3>Confidence Score: 3/5</h3>

The core auth-failure classification and budget-preservation logic is sound, but two error paths in checkSessions leave sessions in StatusFailed rather than StatusDead, silently dropping the new backend_auth_failure display token for those edge cases.

The retry-budget preservation, backend gating, fallover, supervisor finding, and state display are all correctly wired and well-tested along the happy path. The inconsistency surfaces only when getIssue or respawnWorker fails during an auth-failure fallover in checkSessions: those sessions land as failed with no credential-outage context visible to operators, while the parallel paths in reconcileRunningSessions correctly emit StatusDead and LastNotifiedStatus=backend_auth_failure. The affected paths have no test coverage, so the gap went undetected.

internal/orchestrator/orchestrator.go — the two error sub-paths (getIssue failure and respawnWorker failure) inside the checkSessions auth-failure else-if branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/authfailure.go | New auth-failure detector with high-precision regexes; tail-only scanning correctly guards against prompt-echo false positives. |
| internal/orchestrator/backend_selector.go | Adds recordBackendAuthFailure and selectAuthFailureFallback by refactoring selectProviderLimitFallback into a shared selectBackendFallback; clean and correct. |
| internal/orchestrator/orchestrator.go | Auth-failure detection added to both reconcileRunningSessions and checkSessions; error paths in checkSessions use StatusFailed instead of StatusDead, dropping the backend_auth_failure display token for those edge cases. |
| internal/orchestrator/backend_auth_failure_test.go | Good coverage of the happy path and no-fallback cases, but error paths (getIssue/respawnWorker failure) in checkSessions are not tested, leaving the StatusFailed inconsistency undetected. |
| internal/state/state.go | Adds BackendBlockAuthFailure constant, DisplayBackendAuthFailure token, and wires both into SessionDisplayStatusForAt and SessionAttentionForAt correctly. |
| internal/supervisor/supervisor.go | detectBackendAuthFailureStuckStates correctly emits Blocked for the default backend and Warning for non-default; self-clears when RetryAfter has elapsed. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:2322-2328
**`StatusFailed` drops the `backend_auth_failure` display token in error paths**

`backendRateLimitedDisplayStatus` (in `state.go`) only activates when `sess.Status` is `StatusDead` or `StatusRetryExhausted`. By using `state.StatusFailed` here (and in the `respawnWorker` failure path a few lines below), these sessions display as `"failed"` instead of `"backend_auth_failure"`, and `SessionAttentionForAt` won't surface the credential-outage copy. The retry budget is still preserved correctly because `RateLimitHit=true` is already set by `recordBackendAuthFailure`, but operators will see an unexplained `failed` status with no indication of the root credential cause. The equivalent paths in `reconcileRunningSessions` both use `state.StatusDead` + `sess.LastNotifiedStatus = "backend_auth_failure"` — the same treatment should be applied here.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["worker spawn: classify backend auth fail..."](https://github.com/befeast/maestro/commit/dfcdb9311a9fc79adda7c4b6a6509e994d3b1c6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37207045)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->