### PR TITLE
orchestrator: fresh dispatch ignores BackendHealth cooldown — auth outage spawns a doomed worker per poll cycle (follow-up #693) (#695)

### DIFF
--- a/internal/orchestrator/backend_auth_failure_test.go
+++ b/internal/orchestrator/backend_auth_failure_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -332,5 +333,175 @@ func TestCanRetryIssue_AuthFailedSessions_DoNotConsumeBudget(t *testing.T) {
 	o := &Orchestrator{cfg: &config.Config{MaxRetriesPerIssue: 3}}
 	if !o.canRetryIssue(s, live) {
 		t.Fatal("canRetryIssue = false — four auth-failed sessions burned the retry budget (#693 regression)")
+	}
+}
+
+// --- #695: fresh dispatch consults BackendHealth ---
+
+func dispatchHealthConfig() *config.Config {
+	cfg := cfgWithBackends("claude", "claude", "codex")
+	cfg.Model.FallbackBackends = []string{"codex"}
+	return cfg
+}
+
+func stateWithBackendCooldowns(now time.Time, retryAfterByBackend map[string]time.Time) *state.State {
+	s := state.NewState()
+	s.BackendHealth = make(map[string]state.BackendHealth, len(retryAfterByBackend))
+	for backend, retryAfter := range retryAfterByBackend {
+		retryAfter := retryAfter
+		s.BackendHealth[backend] = state.BackendHealth{
+			State:      state.BackendHealthCooldown,
+			Reason:     state.BackendBlockAuthFailure,
+			Since:      now,
+			RetryAfter: &retryAfter,
+		}
+	}
+	return s
+}
+
+// #695 acceptance 1 (selection path): with the default backend inside its
+// auth-failure cooldown, a fresh dispatch resolves directly to the first
+// healthy fallback backend instead of spawning a doomed worker.
+func TestResolveDispatchBackend_DefaultInAuthCooldown_SubstitutesFirstHealthyFallback(t *testing.T) {
+	cfg := dispatchHealthConfig()
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
+	now := time.Now().UTC()
+	s := stateWithBackendCooldowns(now, map[string]time.Time{"claude": now.Add(8 * time.Minute)})
+
+	decision, ok, retryAt := o.resolveDispatchBackend(s, makeIssue(695, "conveyor churn"), now)
+
+	if !ok {
+		t.Fatal("ok = false, want dispatchable — codex is healthy")
+	}
+	if decision.Backend != "codex" {
+		t.Fatalf("Backend = %q, want codex (first healthy fallback)", decision.Backend)
+	}
+	if decision.Reason != selectionReasonDispatchBlockedFallback {
+		t.Fatalf("Reason = %q, want %q", decision.Reason, selectionReasonDispatchBlockedFallback)
+	}
+	if retryAt != nil {
+		t.Fatalf("retryAt = %v, want nil for a dispatchable decision", retryAt)
+	}
+}
+
+// #695: a healthy routed backend passes through unchanged — same backend,
+// same router-provided reason.
+func TestResolveDispatchBackend_HealthyDefault_DecisionUnchanged(t *testing.T) {
+	cfg := dispatchHealthConfig()
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
+	now := time.Now().UTC()
+
+	decision, ok, _ := o.resolveDispatchBackend(state.NewState(), makeIssue(695, "conveyor churn"), now)
+
+	if !ok || decision.Backend != "claude" || decision.Reason != router.ReasonDefault {
+		t.Fatalf("decision = %+v ok=%v, want claude/%s dispatchable", decision, ok, router.ReasonDefault)
+	}
+}
+
+// #695: an expired cooldown no longer blocks the routed backend, even before
+// ReconcileBackendHealth has cleared the stale entry.
+func TestResolveDispatchBackend_CooldownExpired_UsesRoutedBackend(t *testing.T) {
+	cfg := dispatchHealthConfig()
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
+	now := time.Now().UTC()
+	s := stateWithBackendCooldowns(now.Add(-20*time.Minute), map[string]time.Time{"claude": now.Add(-time.Minute)})
+
+	decision, ok, _ := o.resolveDispatchBackend(s, makeIssue(695, "conveyor churn"), now)
+
+	if !ok || decision.Backend != "claude" || decision.Reason != router.ReasonDefault {
+		t.Fatalf("decision = %+v ok=%v, want claude/%s after cooldown expiry", decision, ok, router.ReasonDefault)
+	}
+}
+
+// #695: the gate applies to label-pinned backends too — a pin onto a
+// cooling-down backend is substituted exactly like the fallback selector
+// would, instead of honoring the pin into a doomed spawn.
+func TestResolveDispatchBackend_LabelPinnedBackendCooling_SubstitutesHealthyDefault(t *testing.T) {
+	cfg := dispatchHealthConfig()
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
+	now := time.Now().UTC()
+	s := stateWithBackendCooldowns(now, map[string]time.Time{"codex": now.Add(8 * time.Minute)})
+
+	decision, ok, _ := o.resolveDispatchBackend(s, makeIssue(695, "conveyor churn", "model:codex"), now)
+
+	if !ok {
+		t.Fatal("ok = false, want dispatchable — claude is healthy")
+	}
+	if decision.Backend != "claude" || decision.Reason != selectionReasonDispatchBlockedFallback {
+		t.Fatalf("decision = %+v, want claude/%s", decision, selectionReasonDispatchBlockedFallback)
+	}
+}
+
+// #695 acceptance 2 (selection path): with every backend cooling down,
+// resolveDispatchBackend reports not-dispatchable and the earliest cooldown
+// expiry so dispatch can pause instead of spawn-die churning.
+func TestResolveDispatchBackend_AllBackendsCoolingDown_NotDispatchable(t *testing.T) {
+	cfg := dispatchHealthConfig()
+	o := &Orchestrator{cfg: cfg, router: router.New(cfg)}
+	now := time.Now().UTC()
+	codexRetry := now.Add(4 * time.Minute)
+	s := stateWithBackendCooldowns(now, map[string]time.Time{
+		"claude": now.Add(9 * time.Minute),
+		"codex":  codexRetry,
+	})
+
+	_, ok, retryAt := o.resolveDispatchBackend(s, makeIssue(695, "conveyor churn"), now)
+
+	if ok {
+		t.Fatal("ok = true, want not-dispatchable with all backends cooling down")
+	}
+	if retryAt == nil || !retryAt.Equal(codexRetry) {
+		t.Fatalf("retryAt = %v, want earliest cooldown expiry %v (codex)", retryAt, codexRetry)
+	}
+}
+
+// #695 acceptance 1 (dispatch loop): a newly dispatched issue whose default
+// backend is in auth cooldown spawns directly on the first healthy fallback,
+// with the substitution stamped on the session's BackendSelection.
+func TestStartNewWorkers_DefaultInCooldown_SpawnsOnFirstHealthyFallback(t *testing.T) {
+	cfg := dispatchHealthConfig()
+	issues := []github.Issue{makeIssue(695, "conveyor churn")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+
+	now := time.Now().UTC()
+	s := stateWithBackendCooldowns(now, map[string]time.Time{"claude": now.Add(8 * time.Minute)})
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 1 || (*started)[0] != 695 {
+		t.Fatalf("started = %v, want [695]", *started)
+	}
+	sess := s.Sessions["slot-1"]
+	if sess == nil || sess.Backend != "codex" {
+		t.Fatalf("session = %+v, want spawn on codex", sess)
+	}
+	if sess.BackendSelection == nil || sess.BackendSelection.SelectedBackend != "codex" ||
+		sess.BackendSelection.SelectionReason != selectionReasonDispatchBlockedFallback {
+		t.Fatalf("BackendSelection = %+v, want codex/%s", sess.BackendSelection, selectionReasonDispatchBlockedFallback)
+	}
+}
+
+// #695 acceptance 2 (dispatch loop): with all backends cooling down, no
+// worker is spawned — dispatch pauses until a cooldown expires instead of
+// churning one doomed spawn per poll cycle per issue.
+func TestStartNewWorkers_AllBackendsCoolingDown_NoSpawn(t *testing.T) {
+	cfg := dispatchHealthConfig()
+	issues := []github.Issue{
+		makeIssue(695, "conveyor churn"),
+		makeIssue(696, "second eligible issue"),
+	}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+
+	now := time.Now().UTC()
+	s := stateWithBackendCooldowns(now, map[string]time.Time{
+		"claude": now.Add(9 * time.Minute),
+		"codex":  now.Add(4 * time.Minute),
+	})
+	o.startNewWorkers(s, 5)
+
+	if len(*started) != 0 {
+		t.Fatalf("started = %v, want none while every backend is cooling down", *started)
+	}
+	if len(s.Sessions) != 0 {
+		t.Fatalf("sessions = %d, want 0 — dispatch must pause, not spawn doomed workers", len(s.Sessions))
 	}
 }

--- a/internal/orchestrator/backend_selector.go
+++ b/internal/orchestrator/backend_selector.go
@@ -1,16 +1,23 @@
 package orchestrator
 
 import (
+	"log"
 	"sort"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/state"
 )
 
 const (
 	selectionReasonProviderLimitFallback = "fallback_after_provider_limit"
 	selectionReasonAuthFailureFallback   = "fallback_after_backend_auth_failure"
+	// selectionReasonDispatchBlockedFallback marks a fresh dispatch whose
+	// routed backend was blocked (disabled or in BackendHealth cooldown), so
+	// the first healthy candidate was substituted before spawn (#695).
+	selectionReasonDispatchBlockedFallback = "dispatch_fallback_blocked_backend"
 )
 
 // backendAuthFailureCooldown is how long an auth-failed backend stays gated
@@ -154,6 +161,117 @@ func (o *Orchestrator) selectBackendFallback(st *state.State, sess *state.Sessio
 		}
 	}
 	return selection
+}
+
+// resolveDispatchBackend resolves the backend for a fresh dispatch and gates
+// the routed choice on BackendHealth (#695). Without this gate the router's
+// decision never saw cooldowns, so during a credential outage every new
+// dispatch spawned a doomed ~2-minute worker on the gated default backend
+// once per poll cycle. When the routed backend is blocked — disabled, or
+// cooling down after an auth failure / provider limit — the first healthy
+// candidate from dispatchBackendCandidates is substituted, with a log line
+// naming the substitution. ok=false means every candidate is blocked too;
+// retryAt then carries the earliest known cooldown expiry (nil when none of
+// the blocked backends states one) so the caller can pause fresh dispatch
+// until a cooldown lapses instead of spawn-die churning.
+func (o *Orchestrator) resolveDispatchBackend(st *state.State, issue github.Issue, now time.Time) (decision router.BackendDecision, ok bool, retryAt *time.Time) {
+	decision = o.resolveBackendDecision(issue)
+	blockedBy, blockedRetry := o.dispatchBackendBlock(st, decision.Backend, now)
+	if blockedBy == "" {
+		return decision, true, nil
+	}
+	earliest := blockedRetry
+	for _, candidate := range o.dispatchBackendCandidates() {
+		if candidate == decision.Backend {
+			continue
+		}
+		candidateBlock, candidateRetry := o.dispatchBackendBlock(st, candidate, now)
+		if candidateBlock != "" {
+			if candidateRetry != nil && (earliest == nil || candidateRetry.Before(*earliest)) {
+				earliest = candidateRetry
+			}
+			continue
+		}
+		log.Printf("[orch] issue #%d: backend %s blocked for fresh dispatch (%s%s) — substituting %s",
+			issue.Number, decision.Backend, blockedBy, retryAfterHint(blockedRetry), candidate)
+		return router.BackendDecision{
+			Backend:  candidate,
+			Reason:   selectionReasonDispatchBlockedFallback,
+			TaskType: decision.TaskType,
+		}, true, nil
+	}
+	return decision, false, earliest
+}
+
+// dispatchBackendBlock reports why a backend cannot receive a fresh dispatch,
+// or "" when it can. The skip rules mirror selectBackendFallback: unknown and
+// disabled backends are never dispatchable, and a backend in BackendHealth
+// cooldown stays blocked until its RetryAfter passes (or indefinitely while
+// RetryAfter is unset). retryAfter is the cooldown expiry when one exists.
+func (o *Orchestrator) dispatchBackendBlock(st *state.State, name string, now time.Time) (blockedBy string, retryAfter *time.Time) {
+	backendDef, ok := o.cfg.Model.Backends[name]
+	if !ok {
+		return state.BackendBlockUnknown, nil
+	}
+	if !backendDef.IsEnabled() {
+		return state.BackendBlockDisabled, nil
+	}
+	if st == nil {
+		return "", nil
+	}
+	if health, ok := st.BackendHealth[name]; ok && health.State == state.BackendHealthCooldown {
+		if health.RetryAfter == nil || now.Before(*health.RetryAfter) {
+			reason := health.Reason
+			if reason == "" {
+				reason = state.BackendHealthCooldown
+			}
+			return reason, health.RetryAfter
+		}
+	}
+	return "", nil
+}
+
+// dispatchBackendCandidates is the substitution order for a fresh dispatch
+// whose routed backend is blocked: the default backend first, then the
+// configured fallback chain — the same chain selectBackendFallback walks —
+// and, only when no explicit chain is configured, the remaining configured
+// backends sorted by name.
+func (o *Orchestrator) dispatchBackendCandidates() []string {
+	seen := make(map[string]bool)
+	ordered := make([]string, 0, len(o.cfg.Model.Backends)+1)
+	add := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		ordered = append(ordered, name)
+	}
+	add(o.cfg.Model.Default)
+	for _, name := range o.cfg.Model.FallbackBackends {
+		add(name)
+	}
+	if len(o.cfg.Model.FallbackBackends) > 0 {
+		return ordered
+	}
+	remaining := make([]string, 0, len(o.cfg.Model.Backends))
+	for name := range o.cfg.Model.Backends {
+		if !seen[name] {
+			remaining = append(remaining, name)
+		}
+	}
+	sort.Strings(remaining)
+	for _, name := range remaining {
+		add(name)
+	}
+	return ordered
+}
+
+// retryAfterHint formats a cooldown expiry for dispatch log lines.
+func retryAfterHint(retryAfter *time.Time) string {
+	if retryAfter == nil {
+		return ""
+	}
+	return ", retry after " + retryAfter.UTC().Format(time.RFC3339)
 }
 
 func (o *Orchestrator) backendFallbackCandidates(sess *state.Session) []string {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4489,6 +4489,9 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 	}
 
 	started := 0
+	// #695: when every backend is blocked or cooling down, fresh dispatch
+	// pauses for the cycle. Log the reason once, not once per eligible issue.
+	dispatchPauseLogged := false
 	for _, issue := range issues {
 		repairSpawn := o.supervisorSelectedRepairSpawn(s, issue.Number)
 		if s.IssueInProgress(issue.Number) {
@@ -4650,8 +4653,22 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			promptBase = pipeline.PromptTemplateForPhase(workerCfg, initialPhase)
 			backendReason = "phase"
 		} else {
-			// Normal mode or pipeline starting at implement — use standard resolution
-			backendDecision := o.resolveBackendDecision(issue)
+			// Normal mode or pipeline starting at implement — use standard
+			// resolution, gated on BackendHealth so a fresh dispatch never
+			// lands on a backend that is disabled or cooling down after an
+			// auth failure / provider limit (#695).
+			backendDecision, dispatchable, retryAt := o.resolveDispatchBackend(s, issue, time.Now().UTC())
+			if !dispatchable {
+				if !dispatchPauseLogged {
+					expiry := "no cooldown expiry recorded"
+					if retryAt != nil {
+						expiry = "earliest cooldown expires " + retryAt.UTC().Format(time.RFC3339)
+					}
+					log.Printf("[orch] dispatch paused: all backends blocked or cooling down (%s) — not spawning fresh workers this cycle", expiry)
+					dispatchPauseLogged = true
+				}
+				continue
+			}
 			backendName = backendDecision.Backend
 			backendReason = backendDecision.Reason
 			taskType = backendDecision.TaskType


### PR DESCRIPTION
Implements #695 (refs #693, #694).

## Changes
- `internal/orchestrator/backend_selector.go`: new `resolveDispatchBackend` gates the router's fresh-dispatch decision on `BackendHealth` with the same skip rules as the fallback selector (unknown, disabled, cooling down). A blocked routed backend is substituted with the first healthy candidate (default backend first, then the configured fallback chain), with a log line naming the substitution. When every candidate is blocked, it reports not-dispatchable plus the earliest known cooldown expiry.
- `internal/orchestrator/orchestrator.go` (`startNewWorkers`): the normal-resolution dispatch branch uses the gated resolution; when all backends are blocked/cooling down, fresh dispatch pauses for the cycle with a single log line (deduped across eligible issues) instead of spawning one doomed worker per poll cycle per issue.
- Selection reason `dispatch_fallback_blocked_backend` is stamped on the session's `BackendSelection` so the dashboard shows the substitution provenance.

Not included (deferred, optional item 3 of #695): the cheap pre-spawn `-p "pong"` probe. The cooldown gate alone removes the per-cycle churn; the probe remains available as follow-up hardening.

Existing #694 behavior (retry-budget preservation, fallback respawn for dead workers) is unchanged; its regression tests still pass.

## Testing
- Unit tests on the selection path: default backend in auth cooldown → first healthy fallback; healthy default unchanged; expired cooldown unblocks; label-pinned backend in cooldown substituted; all backends cooling → not dispatchable with earliest expiry.
- Dispatch-loop tests: spawn lands on the fallback with the substitution stamped on `BackendSelection`; with all backends cooling down no worker is spawned.
- `go test ./...` and `go build ./cmd/maestro/` green; `.maestro/verify.sh` passes.

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates fresh dispatch on `BackendHealth` so that when a backend is disabled or in auth-failure/provider-limit cooldown, the orchestrator either substitutes the first healthy fallback or pauses the cycle entirely instead of spawning a doomed worker per issue per poll cycle.

- `resolveDispatchBackend` wraps the router's decision with the same block rules (`unknown`, `disabled`, `cooldown`) already used by the mid-session fallback selector, returning the first healthy substitute or `ok=false` with the earliest expiry.
- `startNewWorkers` now calls `resolveDispatchBackend` for the normal-dispatch branch and skips spawning (with a single per-cycle log) when all backends are blocked.
- Seven new tests cover the selection path and dispatch-loop behavior for the main acceptance scenarios.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core fix correctly stops doomed spawns during a backend outage and the new tests verify the main acceptance cases.

The dispatch substitution logic is sound and well-tested. Two minor gaps worth a follow-up: the "dispatch paused" log fires once per poll cycle (not once per outage), and `BackendSelection.PreviousBackend` is left empty on substituted dispatches so the dashboard audit trail is incomplete. Neither affects runtime behavior.

The `startNewWorkers` changes in `orchestrator.go` are worth a second look for the logging interactions and the session stamping completeness.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/backend_selector.go | Adds `resolveDispatchBackend`, `dispatchBackendBlock`, `dispatchBackendCandidates`, and `retryAfterHint` — well-structured, mirrors existing `selectBackendFallback` skip rules, and correctly tracks earliest cooldown expiry across all blocked candidates. |
| internal/orchestrator/orchestrator.go | Replaces bare `resolveBackendDecision` in the normal-dispatch branch with the health-gated `resolveDispatchBackend`; dedup flag works within a cycle but logs repeat cross-cycle, and `BackendSelection.PreviousBackend` is not populated for substituted dispatches. |
| internal/orchestrator/backend_auth_failure_test.go | Five new unit tests and two dispatch-loop integration tests cover the main acceptance criteria: healthy pass-through, cooldown substitution, expiry unblocking, label-pin substitution, all-blocked pause, and no-spawn verification. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 4718-4730 ([link](https://github.com/befeast/maestro/blob/6594de99ad78ce4a1475e32bb00c5e5416d8ccad/internal/orchestrator/orchestrator.go#L4718-L4730)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`BackendSelection.PreviousBackend` not populated on dispatch substitution**

   When `resolveDispatchBackend` substitutes a fallback for a blocked routed backend, the log records the swap (e.g., "backend claude blocked … substituting codex"), but the session's `BackendSelection` only records the chosen substitute — `PreviousBackend` (the field used by mid-session fallback for the same purpose) is left empty. Dashboard or API consumers relying on `BackendSelection` to understand why a session landed on a non-default backend see only `dispatch_fallback_blocked_backend` without knowing which backend was originally blocked. Passing the original routed backend out of `resolveDispatchBackend` (or re-calling `resolveBackendDecision` in the substitution branch) and assigning it to `PreviousBackend` here would complete the audit trail.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 4718-4730

   Comment:
   **`BackendSelection.PreviousBackend` not populated on dispatch substitution**

   When `resolveDispatchBackend` substitutes a fallback for a blocked routed backend, the log records the swap (e.g., "backend claude blocked … substituting codex"), but the session's `BackendSelection` only records the chosen substitute — `PreviousBackend` (the field used by mid-session fallback for the same purpose) is left empty. Dashboard or API consumers relying on `BackendSelection` to understand why a session landed on a non-default backend see only `dispatch_fallback_blocked_backend` without knowing which backend was originally blocked. Passing the original routed backend out of `resolveDispatchBackend` (or re-calling `resolveBackendDecision` in the substitution branch) and assigning it to `PreviousBackend` here would complete the audit trail.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/orchestrator/orchestrator.go`, line 4738-4740 ([link](https://github.com/befeast/maestro/blob/6594de99ad78ce4a1475e32bb00c5e5416d8ccad/internal/orchestrator/orchestrator.go#L4738-L4740)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Misleading "no new workers started" log co-fires with the dispatch-pause log**

   When all backends are blocked and `dispatchPauseLogged` fires, `started` remains 0 and the pre-existing fallback log `[orch] no new workers started (N issues checked)` also fires on the same cycle. An operator reading the log sees two lines per cycle: the explicit pause message and a generic "nothing started" that implies an empty queue. Since the pause branch is now explicit and self-describing, suppressing the generic log when `dispatchPauseLogged` is true (or changing its wording to account for the paused case) would reduce ambiguity.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 4738-4740

   Comment:
   **Misleading "no new workers started" log co-fires with the dispatch-pause log**

   When all backends are blocked and `dispatchPauseLogged` fires, `started` remains 0 and the pre-existing fallback log `[orch] no new workers started (N issues checked)` also fires on the same cycle. An operator reading the log sees two lines per cycle: the explicit pause message and a generic "nothing started" that implies an empty queue. Since the pause branch is now explicit and self-describing, suppressing the generic log when `dispatchPauseLogged` is true (or changing its wording to account for the paused case) would reduce ambiguity.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/orchestrator/orchestrator.go:4492-4494
**Per-cycle log repetition not suppressed**

`dispatchPauseLogged` deduplicates within a single `startNewWorkers` invocation, eliminating the per-issue noise, but the log fires again on the next poll cycle. With a 10-minute auth-failure cooldown and a 30-second poll interval, operators will still see ~20 "dispatch paused" lines per outage. Cross-cycle suppression would require either a field on the `Orchestrator` struct (resetable when health clears) or rate-limiting via a `time.Time` tracking the last time this was logged.

### Issue 2 of 3
internal/orchestrator/orchestrator.go:4718-4730
**`BackendSelection.PreviousBackend` not populated on dispatch substitution**

When `resolveDispatchBackend` substitutes a fallback for a blocked routed backend, the log records the swap (e.g., "backend claude blocked … substituting codex"), but the session's `BackendSelection` only records the chosen substitute — `PreviousBackend` (the field used by mid-session fallback for the same purpose) is left empty. Dashboard or API consumers relying on `BackendSelection` to understand why a session landed on a non-default backend see only `dispatch_fallback_blocked_backend` without knowing which backend was originally blocked. Passing the original routed backend out of `resolveDispatchBackend` (or re-calling `resolveBackendDecision` in the substitution branch) and assigning it to `PreviousBackend` here would complete the audit trail.

### Issue 3 of 3
internal/orchestrator/orchestrator.go:4738-4740
**Misleading "no new workers started" log co-fires with the dispatch-pause log**

When all backends are blocked and `dispatchPauseLogged` fires, `started` remains 0 and the pre-existing fallback log `[orch] no new workers started (N issues checked)` also fires on the same cycle. An operator reading the log sees two lines per cycle: the explicit pause message and a generic "nothing started" that implies an empty queue. Since the pause branch is now explicit and self-describing, suppressing the generic log when `dispatchPauseLogged` is true (or changing its wording to account for the paused case) would reduce ambiguity.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: gate fresh dispatch on Bac..."](https://github.com/befeast/maestro/commit/6594de99ad78ce4a1475e32bb00c5e5416d8ccad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37252450)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->