### PR TITLE
orchestrator: auto-ready green draft PRs before merge (draft-PR wedge has no automation) (#697)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ issue #44 labels: enhancement               → runs with default (claude)
 
 Runs the orchestration loop. Every interval:
 1. Checks running sessions (kill dead, clean stale)
-2. Auto-merges PRs where CI is green (sequential by default, configurable via `merge_strategy`)
+2. Auto-merges PRs where CI is green (sequential by default, configurable via `merge_strategy`). A green draft PR is automatically marked ready for review first (`gh pr ready`), unless its title/body carries an explicit WIP/Partial marker (`[WIP]` / `[Partial]` in the title, or `maestro:partial` / `maestro:wip` in the body) — those drafts are deliberate and stay untouched.
 3. Rebases PRs with conflicts
 4. Picks new issues to work on (up to `max_parallel - active`)
 5. Starts new workers for picked issues

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1079,6 +1079,19 @@ func (c *Client) MergePR(prNumber int) error {
 	return nil
 }
 
+// MarkPRReady marks a draft pull request as ready for review (wraps
+// `gh pr ready`). `gh pr merge` on a draft fails with "still a draft", so
+// the orchestrator readies a green draft PR before merging it (#697).
+func (c *Client) MarkPRReady(prNumber int) error {
+	out, err := exec.Command("gh", "pr", "ready",
+		fmt.Sprint(prNumber),
+		"--repo", c.Repo).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh pr ready %d: %w\n%s", prNumber, err, out)
+	}
+	return nil
+}
+
 // UpdateBranch merges the base branch into the PR's head branch so a
 // green-but-BEHIND PR becomes up to date with main, satisfying the
 // "branches must be up to date before merging" branch-protection rule.

--- a/internal/orchestrator/draft_ready_test.go
+++ b/internal/orchestrator/draft_ready_test.go
@@ -1,0 +1,147 @@
+package orchestrator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+// #697: autoMergePRs must un-wedge green draft PRs by marking them ready for
+// review before merging, while leaving deliberately-marked WIP/Partial drafts
+// alone.
+
+func TestAutoMergePRs_GreenDraftReadiedThenMerged(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a", Title: "feat: add thing (#100)", IsDraft: true}}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel"}
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+
+	calls := []string{}
+	o.ghMarkPRReadyFn = func(prNumber int) error {
+		calls = append(calls, fmt.Sprintf("ready:%d", prNumber))
+		return nil
+	}
+	mergeFn := o.ghMergePRFn
+	o.ghMergePRFn = func(prNumber int) error {
+		calls = append(calls, fmt.Sprintf("merge:%d", prNumber))
+		return mergeFn(prNumber)
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 1 || (*merged)[0] != 10 {
+		t.Fatalf("merged = %v, want [10]", *merged)
+	}
+	if len(calls) != 2 || calls[0] != "ready:10" || calls[1] != "merge:10" {
+		t.Fatalf("calls = %v, want ready before merge in the same cycle", calls)
+	}
+}
+
+func TestAutoMergePRs_MarkedDraftSkipped(t *testing.T) {
+	cases := []struct {
+		name string
+		pr   github.PR
+	}{
+		{"partial title token", github.PR{Number: 10, HeadRefName: "feat/a", Title: "[Partial] feat: add thing (#100)", IsDraft: true}},
+		{"wip title token", github.PR{Number: 10, HeadRefName: "feat/a", Title: "[WIP] feat: add thing (#100)", IsDraft: true}},
+		{"wip title prefix", github.PR{Number: 10, HeadRefName: "feat/a", Title: "WIP: add thing (#100)", IsDraft: true}},
+		{"body marker", github.PR{Number: 10, HeadRefName: "feat/a", Title: "feat: add thing (#100)", Body: "Refs #100\n\n<!-- maestro:partial -->\nblocked on X", IsDraft: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prs := []github.PR{tc.pr}
+			cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel"}
+			o, merged := newMergeTestOrchestrator(cfg, prs)
+			o.ghMarkPRReadyFn = func(prNumber int) error {
+				t.Fatalf("markPRReady(%d) called for a deliberately marked draft", prNumber)
+				return nil
+			}
+			s := makeTestState(prs)
+
+			o.autoMergePRs(s)
+
+			if len(*merged) != 0 {
+				t.Fatalf("merged = %v, want no merge for a marked draft", *merged)
+			}
+		})
+	}
+}
+
+func TestAutoMergePRs_NonDraftNeverMarkedReady(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a", Title: "WIP: still merges when not a draft (#100)"}}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel"}
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghMarkPRReadyFn = func(prNumber int) error {
+		t.Fatalf("markPRReady(%d) called for a non-draft PR", prNumber)
+		return nil
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 1 || (*merged)[0] != 10 {
+		t.Fatalf("merged = %v, want [10] — non-draft PRs keep the normal merge flow", *merged)
+	}
+}
+
+func TestAutoMergePRs_MarkReadyFailureSkipsMerge(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a", Title: "feat: add thing (#100)", IsDraft: true}}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel"}
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghMarkPRReadyFn = func(prNumber int) error {
+		return fmt.Errorf("boom")
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 0 {
+		t.Fatalf("merged = %v, want no merge when gh pr ready fails", *merged)
+	}
+}
+
+func TestAutoMergePRs_SequentialMarkedDraftDoesNotStarveOthers(t *testing.T) {
+	prs := []github.PR{
+		{Number: 10, HeadRefName: "feat/a", Title: "[Partial] feat: blocked thing (#100)", IsDraft: true},
+		{Number: 20, HeadRefName: "feat/b", Title: "feat: ready thing (#101)"},
+	}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "sequential"}
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 1 || (*merged)[0] != 20 {
+		t.Fatalf("merged = %v, want [20] — the marked draft must not occupy the sequential merge slot", *merged)
+	}
+}
+
+func TestPRHasDeliberateDraftMarker(t *testing.T) {
+	cases := []struct {
+		name string
+		pr   github.PR
+		want bool
+	}{
+		{"plain title", github.PR{Title: "feat: add thing (#100)"}, false},
+		{"wip token", github.PR{Title: "[WIP] feat: add thing"}, true},
+		{"partial token", github.PR{Title: "feat: add thing [Partial]"}, true},
+		{"wip colon prefix", github.PR{Title: "WIP: add thing"}, true},
+		{"wip word prefix", github.PR{Title: "wip add thing"}, true},
+		{"bare wip", github.PR{Title: "WIP"}, true},
+		{"partial colon prefix", github.PR{Title: "Partial: add thing"}, true},
+		{"draft prefix", github.PR{Title: "Draft: add thing"}, true},
+		{"wip mid-title is not a marker", github.PR{Title: "fix: handle WIP label parsing"}, false},
+		{"body partial marker", github.PR{Title: "feat: x", Body: "<!-- maestro:partial -->"}, true},
+		{"body wip marker", github.PR{Title: "feat: x", Body: "marker: maestro:wip"}, true},
+		{"body without marker", github.PR{Title: "feat: x", Body: "Refs #100, partial progress described in prose"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := prHasDeliberateDraftMarker(tc.pr); got != tc.want {
+				t.Fatalf("prHasDeliberateDraftMarker(%q / %q) = %v, want %v", tc.pr.Title, tc.pr.Body, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -108,6 +108,7 @@ type Orchestrator struct {
 	ghPRReviewGateVerdictFn     func(prNumber int, streams []string) (github.ReviewGateVerdict, error)
 	ghPRHasCriticalReviewFn     func(prNumber int) (bool, error)
 	ghUpdateBranchFn            func(prNumber int) error
+	ghMarkPRReadyFn             func(prNumber int) error
 	ghMergePRFn                 func(prNumber int) error
 	ghClosePRFn                 func(prNumber int, comment string) error
 	ghPRChecksOutputFn          func(prNumber int) (string, error)
@@ -320,6 +321,16 @@ func (o *Orchestrator) updateBranch(prNumber int) error {
 		return fmt.Errorf("no github client configured for update-branch")
 	}
 	return o.gh.UpdateBranch(prNumber)
+}
+
+func (o *Orchestrator) markPRReady(prNumber int) error {
+	if o.ghMarkPRReadyFn != nil {
+		return o.ghMarkPRReadyFn(prNumber)
+	}
+	if o.gh == nil {
+		return fmt.Errorf("no github client configured for mark-pr-ready")
+	}
+	return o.gh.MarkPRReady(prNumber)
 }
 
 func (o *Orchestrator) mergePR(prNumber int) error {
@@ -2790,6 +2801,20 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		}
 	}
 
+	// #697: a green draft carrying an explicit WIP/Partial marker is a
+	// deliberate draft — never auto-ready or merge it. Filter here (not in
+	// mergeReadyPR) so a marked draft cannot occupy the single sequential-mode
+	// merge slot and starve other ready PRs.
+	kept := ready[:0]
+	for _, candidate := range ready {
+		if candidate.pr.IsDraft && prHasDeliberateDraftMarker(candidate.pr) {
+			log.Printf("[orch] PR #%d is a draft with an explicit WIP/Partial marker — skipping auto-ready/merge (#697)", candidate.pr.Number)
+			continue
+		}
+		kept = append(kept, candidate)
+	}
+	ready = kept
+
 	if len(ready) == 0 {
 		return
 	}
@@ -2926,6 +2951,34 @@ func isSettledRetryExhausted(sess *state.Session, prNumber int) bool {
 		return true
 	}
 	return false
+}
+
+// prHasDeliberateDraftMarker reports whether a draft PR carries an explicit
+// WIP/Partial marker, meaning the draft is deliberate and must NOT be
+// auto-readied for merge (#697). The recognised markers are:
+//
+//   - title: a `[WIP]` or `[Partial]` token, or a `WIP:` / `WIP ` /
+//     `Partial:` / `Draft:` prefix (case-insensitive)
+//   - body: a literal `maestro:partial` or `maestro:wip` token — the TDD
+//     worker prompt's Partial flow embeds `<!-- maestro:partial -->`
+//
+// Only consulted for PRs with IsDraft=true; a non-draft PR mentioning WIP
+// keeps its normal merge flow.
+func prHasDeliberateDraftMarker(pr github.PR) bool {
+	title := strings.ToLower(strings.TrimSpace(pr.Title))
+	if strings.Contains(title, "[wip]") || strings.Contains(title, "[partial]") {
+		return true
+	}
+	for _, prefix := range []string{"wip:", "wip ", "partial:", "draft:"} {
+		if strings.HasPrefix(title, prefix) {
+			return true
+		}
+	}
+	if title == "wip" || title == "partial" {
+		return true
+	}
+	body := strings.ToLower(pr.Body)
+	return strings.Contains(body, "maestro:partial") || strings.Contains(body, "maestro:wip")
 }
 
 func mergeFlowPRForSession(sess *state.Session, byBranch map[string]github.PR, byNumber map[int]github.PR) (github.PR, bool) {
@@ -3483,6 +3536,27 @@ func outcomeHealthChecks(s *state.State) []outcome.HealthCheckResult {
 }
 
 func (o *Orchestrator) mergeReadyPR(s *state.State, slotName string, sess *state.Session, pr github.PR) bool {
+	// #697: `gh pr merge` on a draft fails with "still a draft", wedging the
+	// pipeline until a human runs `gh pr ready`. A PR that reached this point
+	// is green (CI pass + review gate resolved), so an unmarked draft is an
+	// accident — ready it and merge in the same cycle. Deliberate WIP/Partial
+	// drafts are filtered out by autoMergePRs before they get here; the guard
+	// below is defense-in-depth for any other caller.
+	if pr.IsDraft {
+		if prHasDeliberateDraftMarker(pr) {
+			log.Printf("[orch] PR #%d is a draft with an explicit WIP/Partial marker — skipping auto-ready/merge (#697)", pr.Number)
+			return false
+		}
+		log.Printf("[orch] PR #%d is a green draft without a WIP/Partial marker — marking ready for review (#697)", pr.Number)
+		if err := o.markPRReady(pr.Number); err != nil {
+			log.Printf("[orch] mark PR #%d ready: %v", pr.Number, err)
+			return false
+		}
+		// One-time mention: after a successful ready the PR stops being a
+		// draft, so this path cannot fire again for the same PR.
+		o.notifier.Sendf("📣 maestro: PR #%d (%s) was a green draft — marked ready for review, proceeding to merge", pr.Number, sess.Branch)
+	}
+
 	log.Printf("[orch] merging PR #%d (branch %s)", pr.Number, sess.Branch)
 	if err := o.mergePR(pr.Number); err != nil {
 		log.Printf("[orch] merge PR #%d: %v", pr.Number, err)

--- a/worker-prompt-go.md
+++ b/worker-prompt-go.md
@@ -66,6 +66,8 @@ gh pr create \
   --head {{BRANCH}}
 ```
 
+Open the PR **ready for review** — NEVER pass `--draft`. Maestro auto-merges green PRs and a draft wedges the pipeline. The only legitimate draft is deliberately partial work: prefix the title with `[Partial]` (or `[WIP]`) and include the literal marker `<!-- maestro:partial -->` in the PR body so Maestro knows not to auto-ready it.
+
 ### 6. After PR is created — STOP
 Do not wait for CI. Do not merge. Just stop.
 

--- a/worker-prompt-tdd-section.md
+++ b/worker-prompt-tdd-section.md
@@ -41,3 +41,9 @@ When creating the PR, include validation evidence in the description:
 
 If a VALIDATION.md file exists in the worktree, read it first and use it as your
 validation checklist. Report which assertions passed in the PR body.
+
+Open the PR **ready for review** — never as a draft. If some assertions are
+genuinely blocked and you must hand off partial work, open a **draft** PR with
+`[Partial]` prefixed to the title AND the literal marker `<!-- maestro:partial -->`
+in the PR body; that marker tells Maestro the draft is deliberate so it will
+not auto-ready or auto-merge it.

--- a/worker-prompt-tdd.md
+++ b/worker-prompt-tdd.md
@@ -73,8 +73,8 @@ The following contract defines what "done" means for this issue. Every item must
 - [ ] `go build ./...` — builds successfully (or `cargo build` / `bun run build`)
 
 ### Done vs Partial
-- **Done**: All assertions in the validation contract pass, all quality gates green, PR opened
-- **Partial**: Some assertions pass but others are blocked — open a draft PR, document what works and what's blocked in the PR body
+- **Done**: All assertions in the validation contract pass, all quality gates green, PR opened **ready for review** (never a draft)
+- **Partial**: Some assertions pass but others are blocked — open a **draft** PR with `[Partial]` prefixed to the title AND the literal marker `<!-- maestro:partial -->` in the PR body, documenting what works and what's blocked. The marker tells Maestro the draft is deliberate so it will not auto-ready or auto-merge it.
 
 ---
 

--- a/worker-prompt-template.md
+++ b/worker-prompt-template.md
@@ -62,6 +62,8 @@ git push --force-with-lease origin {{BRANCH}}
 gh pr create --repo {{REPO}} --title "feat: {{ISSUE_TITLE}} (#{{ISSUE_NUMBER}})" --body "Refs #{{ISSUE_NUMBER}}"
 ```
 
+Open the PR **ready for review** — NEVER pass `--draft`. Maestro auto-merges green PRs and a draft wedges the pipeline; it will mark an unmarked green draft ready automatically. The only legitimate draft is the deliberate Partial flow: prefix the title with `[Partial]` (or `[WIP]`) and include the literal marker `<!-- maestro:partial -->` in the PR body so Maestro knows not to auto-ready it.
+
 ### 3. Code quality
 - `cargo fmt --all` before EVERY commit — unformatted code fails CI
 - `cargo check` before pushing — don't open PRs with compile errors


### PR DESCRIPTION
Refs #697

## Changes
- `internal/github`: new `MarkPRReady` helper wrapping `gh pr ready`.
- `mergeReadyPR`: a green draft (CI pass + review gate resolved) without a WIP/Partial marker is marked ready for review and merged in the same cycle, with a log line and a one-time notifier mention. Previously `gh pr merge` on a draft failed with "still a draft" and wedged the pipeline until a human ran `gh pr ready`.
- `autoMergePRs`: deliberate drafts are skipped with a log line. The explicit marker is `[WIP]`/`[Partial]` in the title, a `WIP:`/`Partial:`/`Draft:` title prefix, or a literal `maestro:partial`/`maestro:wip` token in the body. Marked drafts are filtered out of the merge candidates so they cannot occupy the sequential-mode merge slot.
- Worker prompt alignment: default templates now state PRs open ready for review (never `--draft`); the TDD Partial flow defines the explicit marker (`[Partial]` title prefix + `<!-- maestro:partial -->` body token).
- No behavior change for non-draft PRs (a non-draft PR mentioning WIP keeps its normal merge flow).

## Testing
- New unit tests in `internal/orchestrator/draft_ready_test.go`: green draft is readied then merged in the same cycle (call-order asserted); marked drafts (title token, title prefix, body marker) are skipped and never readied; non-draft PRs never trigger `gh pr ready`; a `gh pr ready` failure skips the merge; a marked draft does not starve other ready PRs in sequential merge mode; table test for the marker matcher.
- `go test ./...` green, `go build ./cmd/maestro/` succeeds, gofmt clean on changed files, `.maestro/verify.sh` passes all requirements.

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the "draft PR wedge" (#697) by teaching the orchestrator to automatically call `gh pr ready` on any green draft PR that lacks an explicit WIP/Partial marker, then immediately merge it in the same cycle. Deliberate drafts are identified by `[WIP]`/`[Partial]` title tokens, `WIP:`/`Partial:`/`Draft:` title prefixes, or `maestro:partial`/`maestro:wip` body tokens, and are filtered out of the merge queue before they can occupy the sequential-mode slot.

- `MarkPRReady` in `internal/github/github.go` wraps `gh pr ready` following the same pattern as `MergePR` and `UpdateBranch`.
- `autoMergePRs` filters deliberate drafts early (preventing starvation in sequential mode); `mergeReadyPR` contains a defense-in-depth guard with a one-time notifier mention.
- All four worker-prompt files are updated to tell workers to open PRs as ready-for-review, with the `[Partial]` + `<!-- maestro:partial -->` escape hatch clearly documented for partial work.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the draft-ready path has solid test coverage and fails gracefully on error. The one thing to be aware of is that the Telegram notification is sent before the merge result is confirmed.

The implementation is clean and well-tested. The only rough edge is in `mergeReadyPR`: the notifier fires "proceeding to merge" immediately after `markPRReady` succeeds, but `mergePR` hasn't been called yet and can still fail (e.g., the PR is now non-draft and branch-protection requirements reset). The user would receive a notification implying an imminent merge that may not occur in that cycle. The PR recovers correctly in the next cycle, so no data is lost, but the notification text is misleading under that failure scenario.

The notification placement in `mergeReadyPR` (around line 3557) is the only spot worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Core orchestration logic extended with draft-PR auto-ready flow; filter and mergeReadyPR guard look correct, but the Telegram notification fires before the merge result is known |
| internal/github/github.go | Thin `MarkPRReady` helper wrapping `gh pr ready`; mirrors the exact structure of `MergePR` and `UpdateBranch` |
| internal/orchestrator/draft_ready_test.go | New unit-test file covering all five branches of the draft-ready flow; call-order assertion, skip-on-failure, starvation protection, and marker table test all look solid |
| worker-prompt-go.md | Adds clear guidance to open PRs as ready-for-review, with the escape hatch for deliberate partial work documented inline |
| worker-prompt-tdd-section.md | TDD partial-flow escape hatch now explicitly prescribes the `[Partial]` + `<!-- maestro:partial -->` marker pair |
| worker-prompt-tdd.md | Done/Partial definition updated to require ready-for-review PR and prescribe the deliberate-draft marker |
| worker-prompt-template.md | Generic template updated with the same no-draft guidance and Partial-flow escape hatch |
| README.md | Step-2 description updated to document auto-ready behaviour and deliberate-draft markers accurately |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:3554-3558
**Notification may be sent before merge actually completes**

`o.notifier.Sendf("… proceeding to merge")` fires immediately after `markPRReady` returns nil, but the actual `mergePR` call comes afterward and can still fail — most likely because `gh pr ready` may reset "branches must be up to date" protection or trigger pending code-review requirements on the newly non-draft PR. When that happens the user receives "marked ready for review, proceeding to merge" but no merge occurs in that cycle. The PR eventually recovers in the next cycle, so this is a correctness issue only in the notification text. Consider moving the notification after a successful `mergePR`, or rewording it to "marked ready for review — will merge when checks pass".

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: auto-ready green draft PRs..."](https://github.com/befeast/maestro/commit/1a37fa80fd34a171f48d1233f343679613a862dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37260930)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->