### PR TITLE
release/deploy: opt-in self-deploy of the maestro binary after merge (child of #674)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -272,6 +272,11 @@ func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmsgprefix)
 	log.SetPrefix("[maestro] ")
 
+	// Surface the running binary's version on the state/fleet APIs so the
+	// self-deploy health probe (#698) can confirm a restart picked up the
+	// freshly stamped build.
+	server.SetBinaryVersion(resolveVersion())
+
 	if len(os.Args) < 2 {
 		fmt.Print(usage)
 		os.Exit(1)

--- a/docs/self-deploy-runbook.md
+++ b/docs/self-deploy-runbook.md
@@ -1,0 +1,124 @@
+# Self-Deploy Runbook (#698)
+
+Opt-in, config-gated self-deploy of the maestro binary after a PR merges.
+Default **OFF** — projects without a `self_deploy:` block see no behavior
+change. Intended for the dogfood project, where merged maestro fixes should
+reach the runtime without an operator manually building, installing, and
+restarting units.
+
+## How it works
+
+After the orchestrator merges a PR (and after the optional version bump),
+it launches `scripts/self-deploy.sh` through a **detached transient systemd
+unit** (`systemd-run --user --collect --unit maestro-self-deploy-pr<N>-<ts>`).
+Detachment is the load-bearing part: the script restarts the very units that
+run the orchestrator, and must survive that restart.
+
+The script then:
+
+1. **Builds from merged main** — fetches `origin/main`, checks it out into a
+   temporary git worktree, reads the `VERSION` file, and builds with
+   `-ldflags "-X main.version=<VERSION>+g<shortsha>"` (version stamping per
+   #682, extended with the commit SHA as semver build metadata).
+2. **Installs atomically** — stages the new binary next to the target
+   (`<bin>.next`), preserves the current binary as `<bin>.prev`, and renames
+   into place (same-filesystem rename; safe under a running process).
+3. **Restarts the units** — `systemctl --user restart <unit>` for each
+   configured unit. The unit's normal stop path runs, so existing **drain
+   semantics are honored**: if your unit declares `ExecStop=... drain`,
+   in-flight workers finish before the stop completes. Budget for this in
+   `timeout_minutes`.
+4. **Verifies health** — the installed CLI must report the stamped version
+   (`maestro version` → `maestro v<VERSION>+g<shortsha>`), every unit must be
+   `active`, and (when a health URL is configured) the **running process**
+   must report the stamped version via the `version` field on
+   `/api/v1/state` (or `/api/v1/fleet`) before the deadline.
+5. **Rolls back on failure** — restores `<bin>.prev`, restarts the units
+   again, and records the rollback reason. `.prev` is kept either way for
+   manual rollback.
+6. **Writes a result file** — `<state_dir>/self-deploy-result.json`. The next
+   orchestrator cycle (running the new binary, on success) consumes it,
+   records a **supervisor finding** (deployed version / rollback reason)
+   visible in Mission Control, and sends a notification.
+
+## Enabling it
+
+```yaml
+# maestro.yaml of the dogfood project
+server:
+  port: 8788            # gives the deploy a health endpoint to probe
+
+self_deploy:
+  enabled: true
+  bin_path: /usr/local/bin/maestro   # default: path of the running binary
+  units: ["maestro.service"]         # systemd user units to restart
+  # health_url: http://127.0.0.1:8788/api/v1/state  # default: derived from server.port
+  # health_token_env: MAESTRO_DASH_TOKEN            # default: server.auth.token_env
+  # script: ./scripts/self-deploy.sh                # default: <local_path>/scripts/self-deploy.sh
+  # timeout_minutes: 30                             # build+restart+verify budget (covers drain)
+```
+
+Prerequisites on the host:
+
+- `systemd-run` / `systemctl --user` available (linger enabled for the user
+  if the deploy must run without an active login session:
+  `loginctl enable-linger $USER`).
+- Go toolchain reachable from the orchestrator's `PATH` (it is handed down
+  to the transient unit) or at `/usr/local/go/bin`.
+- The user can write `bin_path` and its directory (no sudo: install the
+  binary under the user's control, e.g. `~/.local/bin/maestro`, or make
+  `/usr/local/bin/maestro` user-writable).
+
+## Verifying a rollout
+
+After a merge, within `timeout_minutes`:
+
+```bash
+maestro version                                  # maestro v<VERSION>+g<shortsha> of merged main
+curl -s http://127.0.0.1:8788/api/v1/state | grep '"version"'
+systemctl --user status maestro.service
+journalctl --user -u 'maestro-self-deploy-*' -n 200   # deploy log
+```
+
+The supervisor finding appears in the state API under
+`supervisor_decisions` with a `self-deploy-…` ID and in Mission Control.
+
+## When it rolls back
+
+A deliberately broken build or failed health check leaves:
+
+- the previous binary restored at `bin_path` (and still kept at
+  `<bin_path>.prev`),
+- units restarted and active on the old version,
+- a `rolled_back` finding + notification carrying the reason.
+
+Inspect the deploy log, fix the regression, merge again:
+
+```bash
+journalctl --user -u 'maestro-self-deploy-*' --since -2h
+```
+
+## Manual rollback
+
+```bash
+cp -p /usr/local/bin/maestro.prev /usr/local/bin/maestro
+systemctl --user restart maestro.service
+maestro version
+```
+
+## Failure modes
+
+| Symptom | Meaning | Action |
+|---|---|---|
+| Finding `self-deploy: failed … no .prev` | First deploy failed before any previous binary existed | Build + install manually once, re-merge |
+| Finding `rolled_back … health check timed out` | New binary started but never reported the stamped version | Check `journalctl --user -u maestro.service`; the regression is in the merged code |
+| No finding, no restart | Trigger failed (script missing, systemd-run unavailable) | Orchestrator log shows `self-deploy trigger failed …`; a ⚠️ notification is sent |
+| Units inactive after rollback | Rollback restart also failed | `systemctl --user start maestro.service` by hand; binary on disk is the previous version |
+
+## Interaction with `deploy_cmd`
+
+`self_deploy` is independent of the generic `deploy_cmd` hook: `deploy_cmd`
+runs synchronously inside the orchestrator (fine for deploying *other*
+projects), while `self_deploy` is detached because maestro cannot wait on a
+deploy that restarts maestro. Both may be configured; the self-deploy is
+triggered first and proceeds in the background.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,8 +3,10 @@ package config
 import (
 	"crypto/md5"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -143,6 +145,87 @@ type VersioningConfig struct {
 type GitHubProjectsConfig struct {
 	Enabled       bool `yaml:"enabled"`
 	ProjectNumber int  `yaml:"project_number"` // GitHub Project number (auto-detect from repo)
+}
+
+// SelfDeployConfig gates the opt-in post-merge self-deploy of the maestro
+// binary itself (#698). Default OFF: projects without a `self_deploy:` block
+// (or with enabled: false) see no behavior change.
+//
+// When enabled, the orchestrator launches scripts/self-deploy.sh through a
+// detached transient systemd unit (systemd-run --user) after every PR merge.
+// Running detached is what lets the script restart maestro's own units and
+// survive that restart; restarting via `systemctl --user restart` keeps the
+// unit's ExecStop drain semantics intact.
+type SelfDeployConfig struct {
+	Enabled        bool     `yaml:"enabled"`          // default false (opt-in)
+	Script         string   `yaml:"script"`           // deploy script path (default: <local_path>/scripts/self-deploy.sh)
+	BinPath        string   `yaml:"bin_path"`         // install target (default: path of the running binary)
+	Units          []string `yaml:"units"`            // systemd user units to restart (default: ["maestro.service"])
+	HealthURL      string   `yaml:"health_url"`       // running-process version probe (default: http://127.0.0.1:<server.port>/api/v1/state when server.port > 0)
+	HealthTokenEnv string   `yaml:"health_token_env"` // env var holding the bearer token for health_url (default: server.auth.token_env)
+	TimeoutMinutes int      `yaml:"timeout_minutes"`  // build+install+restart+verify budget; must cover unit drain (default: 30)
+}
+
+// EffectiveScript returns the deploy script path, defaulting to
+// scripts/self-deploy.sh inside the project checkout.
+func (c SelfDeployConfig) EffectiveScript(localPath string) string {
+	if s := strings.TrimSpace(c.Script); s != "" {
+		return expandHome(s)
+	}
+	if strings.TrimSpace(localPath) == "" {
+		return ""
+	}
+	return filepath.Join(localPath, "scripts", "self-deploy.sh")
+}
+
+// EffectiveUnits returns the systemd user units to restart, defaulting to
+// the unit name `maestro init` installs.
+func (c SelfDeployConfig) EffectiveUnits() []string {
+	units := make([]string, 0, len(c.Units))
+	for _, u := range c.Units {
+		if u = strings.TrimSpace(u); u != "" {
+			units = append(units, u)
+		}
+	}
+	if len(units) == 0 {
+		return []string{"maestro.service"}
+	}
+	return units
+}
+
+// EffectiveHealthURL returns the URL polled to confirm the restarted process
+// reports the freshly stamped version. Empty means CLI + unit checks only.
+func (c SelfDeployConfig) EffectiveHealthURL(server ServerConfig) string {
+	if u := strings.TrimSpace(c.HealthURL); u != "" {
+		return u
+	}
+	if server.Port <= 0 {
+		return ""
+	}
+	host := strings.TrimSpace(server.Host)
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("http://%s/api/v1/state", net.JoinHostPort(host, strconv.Itoa(server.Port)))
+}
+
+// EffectiveHealthTokenEnv returns the env var name holding the bearer token
+// for the health probe, falling back to the dashboard auth token env.
+func (c SelfDeployConfig) EffectiveHealthTokenEnv(server ServerConfig) string {
+	if e := strings.TrimSpace(c.HealthTokenEnv); e != "" {
+		return e
+	}
+	return strings.TrimSpace(server.Auth.TokenEnv)
+}
+
+// EffectiveTimeoutMinutes returns the total deploy budget. The default is
+// deliberately larger than deploy_timeout_minutes because a unit restart
+// honors drain (in-flight workers finish before the stop completes).
+func (c SelfDeployConfig) EffectiveTimeoutMinutes() int {
+	if c.TimeoutMinutes > 0 {
+		return c.TimeoutMinutes
+	}
+	return 30
 }
 
 const (
@@ -841,6 +924,7 @@ type Config struct {
 	AutoRetryRebaseConflicts        bool                         `yaml:"auto_retry_rebase_conflicts"`        // retry PRs whose auto-rebase fails with conflicts
 	Telegram                        TelegramConfig               `yaml:"telegram"`
 	Versioning                      VersioningConfig             `yaml:"versioning"`
+	SelfDeploy                      SelfDeployConfig             `yaml:"self_deploy"` // #698: opt-in post-merge self-deploy of the maestro binary (default OFF)
 	GitHubProjects                  GitHubProjectsConfig         `yaml:"github_projects"`
 	MaxRetryBackoffMs               int                          `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
 	AutoResolveFiles                []string                     `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
@@ -982,6 +1066,8 @@ func parse(data []byte) (*Config, error) {
 		cfg.PromptSections[i] = expandHome(s)
 	}
 	cfg.StateDir = expandHome(cfg.StateDir)
+	cfg.SelfDeploy.Script = expandHome(cfg.SelfDeploy.Script)
+	cfg.SelfDeploy.BinPath = expandHome(cfg.SelfDeploy.BinPath)
 
 	// Default session_prefix: first 3 chars of repo name
 	if cfg.SessionPrefix == "" {

--- a/internal/config/selfdeploy_config_test.go
+++ b/internal/config/selfdeploy_config_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// #698 AC3: flag default OFF — a config without a self_deploy block must not
+// enable self-deploy or change any behavior.
+func TestSelfDeployDefaultOff(t *testing.T) {
+	cfg, err := Parse([]byte("repo: owner/repo\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.SelfDeploy.Enabled {
+		t.Fatal("self_deploy.enabled must default to false")
+	}
+}
+
+func TestSelfDeployParse(t *testing.T) {
+	yaml := `
+repo: owner/repo
+self_deploy:
+  enabled: true
+  bin_path: /usr/local/bin/maestro
+  units: ["maestro.service", " maestro-fleet.service "]
+  health_url: http://127.0.0.1:9999/api/v1/state
+  timeout_minutes: 45
+`
+	cfg, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	sd := cfg.SelfDeploy
+	if !sd.Enabled {
+		t.Fatal("enabled = false, want true")
+	}
+	if sd.BinPath != "/usr/local/bin/maestro" {
+		t.Errorf("bin_path = %q", sd.BinPath)
+	}
+	if got := sd.EffectiveUnits(); len(got) != 2 || got[0] != "maestro.service" || got[1] != "maestro-fleet.service" {
+		t.Errorf("EffectiveUnits() = %v", got)
+	}
+	if got := sd.EffectiveHealthURL(cfg.Server); got != "http://127.0.0.1:9999/api/v1/state" {
+		t.Errorf("EffectiveHealthURL() = %q", got)
+	}
+	if got := sd.EffectiveTimeoutMinutes(); got != 45 {
+		t.Errorf("EffectiveTimeoutMinutes() = %d", got)
+	}
+}
+
+func TestSelfDeployEffectiveDefaults(t *testing.T) {
+	var sd SelfDeployConfig
+
+	if got := sd.EffectiveScript("/srv/maestro"); got != filepath.Join("/srv/maestro", "scripts", "self-deploy.sh") {
+		t.Errorf("EffectiveScript() = %q", got)
+	}
+	if got := sd.EffectiveScript(""); got != "" {
+		t.Errorf("EffectiveScript(\"\") = %q, want empty", got)
+	}
+	if got := sd.EffectiveUnits(); len(got) != 1 || got[0] != "maestro.service" {
+		t.Errorf("EffectiveUnits() = %v", got)
+	}
+	if got := sd.EffectiveTimeoutMinutes(); got != 30 {
+		t.Errorf("EffectiveTimeoutMinutes() = %d, want 30", got)
+	}
+
+	// No server port → no health URL (CLI + unit checks only).
+	if got := sd.EffectiveHealthURL(ServerConfig{}); got != "" {
+		t.Errorf("EffectiveHealthURL(no port) = %q, want empty", got)
+	}
+	// Server port set → default to the project state endpoint.
+	if got := sd.EffectiveHealthURL(ServerConfig{Port: 8788}); got != "http://127.0.0.1:8788/api/v1/state" {
+		t.Errorf("EffectiveHealthURL(port) = %q", got)
+	}
+	if got := sd.EffectiveHealthTokenEnv(ServerConfig{Auth: ServerAuthConfig{TokenEnv: "MC_TOKEN"}}); got != "MC_TOKEN" {
+		t.Errorf("EffectiveHealthTokenEnv() = %q", got)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/pipeline"
 	"github.com/befeast/maestro/internal/router"
+	"github.com/befeast/maestro/internal/selfdeploy"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/supervisor"
 	"github.com/befeast/maestro/internal/versioning"
@@ -117,6 +118,7 @@ type Orchestrator struct {
 	ghPRHeadSHAFn               func(prNumber int) (string, error)
 	ghCommentPRFn               func(prNumber int, body string) error
 	workerStopFn                func(cfg *config.Config, slotName string, sess *state.Session) error
+	selfDeployStartFn           func(prNumber int) error
 	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
 	outcomeCheckFn              func(context.Context, outcome.Brief) outcome.HealthCheckResult
 	syncProjectFn               func(issueNumber int, status github.ProjectStatus) bool
@@ -1251,6 +1253,15 @@ func (o *Orchestrator) RunOnce() error {
 	}
 
 	log.Printf("[orch] === cycle start — %d sessions in state ===", len(s.Sessions))
+
+	// Step 0: Surface a finished self-deploy (#698) as a supervisor finding.
+	// Persist immediately: the result file is already consumed, so the
+	// finding must not depend on the rest of the cycle succeeding.
+	if o.consumeSelfDeployResult(s) {
+		if err := state.Save(o.cfg.StateDir, s); err != nil {
+			return fmt.Errorf("save state after self-deploy result: %w", err)
+		}
+	}
 
 	// Step 1: Reconcile stale running sessions before scheduling/slot calculation.
 	reconciled := o.reconcileRunningSessions(s)
@@ -3632,6 +3643,9 @@ func (o *Orchestrator) mergeReadyPR(s *state.State, slotName string, sess *state
 		}
 	}
 
+	// Self-deploy hook (#698)
+	o.maybeSelfDeployAfterMerge(pr.Number)
+
 	// Deploy hook
 	deploySucceeded := false
 	if o.cfg.DeployCmd != "" {
@@ -3714,6 +3728,74 @@ func (o *Orchestrator) runDeployCmd(prNumber int) error {
 		return fmt.Errorf("deploy command failed: %w\n%s", err, out)
 	}
 	return nil
+}
+
+// maybeSelfDeployAfterMerge launches the opt-in self-deploy (#698) for a
+// merged PR. Default OFF: without self_deploy.enabled this is a no-op. The
+// deploy script runs in a detached transient unit and restarts this very
+// process, so we must not wait on it here — the outcome lands as a
+// supervisor finding when the result file is consumed on a later cycle (see
+// consumeSelfDeployResult).
+func (o *Orchestrator) maybeSelfDeployAfterMerge(prNumber int) {
+	if !o.cfg.SelfDeploy.Enabled {
+		return
+	}
+	if err := o.triggerSelfDeploy(prNumber); err != nil {
+		log.Printf("[orch] self-deploy trigger failed for PR #%d: %v", prNumber, err)
+		o.notifier.Sendf("⚠️ maestro: self-deploy trigger failed after PR #%d merge: %v", prNumber, err)
+		return
+	}
+	log.Printf("[orch] self-deploy started for PR #%d (detached transient unit)", prNumber)
+	o.notifier.Sendf("🚀 maestro: self-deploy started after PR #%d merge — units will restart after drain", prNumber)
+}
+
+// triggerSelfDeploy starts the opt-in self-deploy (#698) for a merged PR.
+func (o *Orchestrator) triggerSelfDeploy(prNumber int) error {
+	if o.selfDeployStartFn != nil {
+		return o.selfDeployStartFn(prNumber)
+	}
+	return selfdeploy.Trigger(o.cfg, prNumber)
+}
+
+// consumeSelfDeployResult surfaces a finished self-deploy (#698) as a
+// supervisor finding. The deploy script runs detached from this process and
+// drops a JSON result file in the state dir; the first cycle that sees it —
+// typically the first cycle of the freshly deployed binary — records the
+// deployed version (or rollback reason) as a supervisor decision and
+// notifies the operator. Returns true when state changed.
+func (o *Orchestrator) consumeSelfDeployResult(s *state.State) bool {
+	res, err := selfdeploy.ReadResult(o.cfg.StateDir)
+	if err != nil {
+		log.Printf("[orch] self-deploy result unreadable: %v", err)
+		// Clear the malformed file so the error is not re-logged forever.
+		if rmErr := selfdeploy.ClearResult(o.cfg.StateDir); rmErr != nil {
+			log.Printf("[orch] self-deploy result cleanup: %v", rmErr)
+		}
+		return false
+	}
+	if res == nil {
+		return false
+	}
+	// Clear before recording so a save failure cannot double-record on the
+	// next cycle; losing the finding is the lesser failure mode.
+	if err := selfdeploy.ClearResult(o.cfg.StateDir); err != nil {
+		log.Printf("[orch] self-deploy result cleanup: %v", err)
+		return false
+	}
+
+	finding := selfdeploy.Finding(res, o.cfg.Repo, time.Now().UTC())
+	s.RecordSupervisorDecision(finding, state.DefaultSupervisorDecisionLimit)
+	log.Printf("[orch] %s", finding.Summary)
+
+	switch res.Status {
+	case selfdeploy.StatusDeployed:
+		o.notifier.Sendf("✅ maestro: self-deploy finished — running v%s (PR #%d)", res.Version, res.PR)
+	case selfdeploy.StatusRolledBack:
+		o.notifier.Sendf("⏪ maestro: self-deploy ROLLED BACK after PR #%d: %s", res.PR, res.Reason)
+	default:
+		o.notifier.Sendf("❌ maestro: self-deploy FAILED after PR #%d: %s — manual intervention may be needed", res.PR, res.Reason)
+	}
+	return true
 }
 
 // routeConflictingMergeFailure reconciles a merge failure that GitHub reports

--- a/internal/orchestrator/selfdeploy_test.go
+++ b/internal/orchestrator/selfdeploy_test.go
@@ -1,0 +1,143 @@
+package orchestrator
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/selfdeploy"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #698 AC3: flag default OFF — no trigger without self_deploy.enabled.
+func TestMaybeSelfDeployAfterMerge_DefaultOff(t *testing.T) {
+	called := false
+	o := &Orchestrator{
+		cfg:               &config.Config{Repo: "owner/repo"},
+		notifier:          &notify.Notifier{},
+		selfDeployStartFn: func(prNumber int) error { called = true; return nil },
+	}
+
+	o.maybeSelfDeployAfterMerge(698)
+	if called {
+		t.Fatal("self-deploy triggered with the flag off")
+	}
+}
+
+func TestMaybeSelfDeployAfterMerge_Enabled(t *testing.T) {
+	gotPR := 0
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			SelfDeploy: config.SelfDeployConfig{Enabled: true},
+		},
+		notifier:          &notify.Notifier{},
+		selfDeployStartFn: func(prNumber int) error { gotPR = prNumber; return nil },
+	}
+
+	o.maybeSelfDeployAfterMerge(698)
+	if gotPR != 698 {
+		t.Fatalf("trigger called with PR %d, want 698", gotPR)
+	}
+}
+
+// #698 AC5: a finished deploy surfaces as a supervisor finding and the
+// result file is consumed exactly once.
+func TestConsumeSelfDeployResult_Deployed(t *testing.T) {
+	stateDir := t.TempDir()
+	payload := `{"status":"deployed","version":"1.4.2+gabc1234","expected_sha":"abc1234","pr":698}`
+	if err := os.WriteFile(selfdeploy.ResultPath(stateDir), []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", StateDir: stateDir},
+		notifier: &notify.Notifier{},
+	}
+	s := &state.State{}
+
+	if !o.consumeSelfDeployResult(s) {
+		t.Fatal("consumeSelfDeployResult = false, want true")
+	}
+	if len(s.SupervisorDecisions) != 1 {
+		t.Fatalf("decisions recorded = %d, want 1", len(s.SupervisorDecisions))
+	}
+	d := s.SupervisorDecisions[0]
+	if !strings.Contains(d.Summary, "deployed maestro v1.4.2+gabc1234") {
+		t.Errorf("Summary = %q", d.Summary)
+	}
+	if d.Status != "succeeded" {
+		t.Errorf("Status = %q", d.Status)
+	}
+	if _, err := os.Stat(selfdeploy.ResultPath(stateDir)); !os.IsNotExist(err) {
+		t.Error("result file not cleared after consume")
+	}
+	// Second cycle: nothing left to consume.
+	if o.consumeSelfDeployResult(s) {
+		t.Error("second consume = true, want false")
+	}
+	if len(s.SupervisorDecisions) != 1 {
+		t.Errorf("decisions after second consume = %d, want 1", len(s.SupervisorDecisions))
+	}
+}
+
+// #698 AC2: a rollback emits a finding carrying the rollback reason.
+func TestConsumeSelfDeployResult_RolledBack(t *testing.T) {
+	stateDir := t.TempDir()
+	payload := `{"status":"rolled_back","prev_version":"1.4.1","pr":698,"reason":"health check timed out"}`
+	if err := os.WriteFile(selfdeploy.ResultPath(stateDir), []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", StateDir: stateDir},
+		notifier: &notify.Notifier{},
+	}
+	s := &state.State{}
+
+	if !o.consumeSelfDeployResult(s) {
+		t.Fatal("consumeSelfDeployResult = false, want true")
+	}
+	d := s.SupervisorDecisions[0]
+	if !strings.Contains(d.Summary, "rolled back") || !strings.Contains(d.Summary, "health check timed out") {
+		t.Errorf("Summary = %q", d.Summary)
+	}
+	if d.Status != "failed" {
+		t.Errorf("Status = %q", d.Status)
+	}
+}
+
+func TestConsumeSelfDeployResult_NoFile(t *testing.T) {
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", StateDir: t.TempDir()},
+		notifier: &notify.Notifier{},
+	}
+	s := &state.State{}
+	if o.consumeSelfDeployResult(s) {
+		t.Fatal("consumeSelfDeployResult = true with no result file")
+	}
+	if len(s.SupervisorDecisions) != 0 {
+		t.Fatalf("decisions = %d, want 0", len(s.SupervisorDecisions))
+	}
+}
+
+// A malformed result file is cleared (not re-logged forever) and records nothing.
+func TestConsumeSelfDeployResult_Malformed(t *testing.T) {
+	stateDir := t.TempDir()
+	if err := os.WriteFile(selfdeploy.ResultPath(stateDir), []byte("{broken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", StateDir: stateDir},
+		notifier: &notify.Notifier{},
+	}
+	if o.consumeSelfDeployResult(&state.State{}) {
+		t.Fatal("consumeSelfDeployResult = true for malformed file")
+	}
+	if _, err := os.Stat(selfdeploy.ResultPath(stateDir)); !os.IsNotExist(err) {
+		t.Error("malformed result file not cleared")
+	}
+}

--- a/internal/selfdeploy/selfdeploy.go
+++ b/internal/selfdeploy/selfdeploy.go
@@ -1,0 +1,215 @@
+// Package selfdeploy implements the opt-in post-merge self-deploy of the
+// maestro binary (#698).
+//
+// The orchestrator does not build/install/restart in-process: it would kill
+// itself halfway through. Instead Trigger launches scripts/self-deploy.sh in
+// a detached transient systemd unit (systemd-run --user), so the script
+// survives the maestro unit restarting. The script builds from merged main
+// (version-stamped per #682), installs the binary atomically keeping the
+// previous one as `.prev`, restarts the configured user units (which honors
+// the units' drain semantics via their normal stop path), verifies the
+// restarted process reports the expected version, rolls back to `.prev` on
+// failure, and writes a JSON result file into the state dir. The next
+// orchestrator cycle — running the freshly deployed binary on success —
+// consumes that file and surfaces the outcome as a supervisor finding.
+package selfdeploy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// Result statuses written by scripts/self-deploy.sh.
+const (
+	StatusDeployed   = "deployed"    // new binary live and verified
+	StatusRolledBack = "rolled_back" // verification failed; .prev restored and units restarted
+	StatusFailed     = "failed"      // deploy failed and rollback was impossible or also failed
+)
+
+// resultFileName lives in the project state dir so both the transient deploy
+// unit and the orchestrator agree on the location without extra plumbing.
+const resultFileName = "self-deploy-result.json"
+
+// Result is the JSON contract between scripts/self-deploy.sh and the
+// orchestrator.
+type Result struct {
+	Status      string `json:"status"`                 // deployed | rolled_back | failed
+	Version     string `json:"version,omitempty"`      // stamped version of the new binary (e.g. "1.4.2+gabc1234")
+	PrevVersion string `json:"prev_version,omitempty"` // version reported by the replaced binary
+	ExpectedSHA string `json:"expected_sha,omitempty"` // origin/main commit the build was taken from
+	PR          int    `json:"pr,omitempty"`           // merged PR that triggered the deploy
+	Reason      string `json:"reason,omitempty"`       // failure/rollback reason
+	FinishedAt  string `json:"finished_at,omitempty"`  // RFC3339
+}
+
+// ResultPath returns the path of the deploy result file inside stateDir.
+func ResultPath(stateDir string) string {
+	return filepath.Join(stateDir, resultFileName)
+}
+
+// ReadResult loads a finished deploy result. Returns (nil, nil) when no
+// result file exists — i.e. no deploy has finished since the last consume.
+func ReadResult(stateDir string) (*Result, error) {
+	data, err := os.ReadFile(ResultPath(stateDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read self-deploy result: %w", err)
+	}
+	var res Result
+	if err := json.Unmarshal(data, &res); err != nil {
+		return nil, fmt.Errorf("parse self-deploy result: %w", err)
+	}
+	return &res, nil
+}
+
+// ClearResult removes the result file so a result is consumed exactly once.
+func ClearResult(stateDir string) error {
+	err := os.Remove(ResultPath(stateDir))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// TriggerCommand builds the detached systemd-run invocation for a deploy
+// after the given merged PR. Split from Trigger so tests can assert the
+// argv without systemd.
+func TriggerCommand(cfg *config.Config, prNumber int, now time.Time) (string, []string, error) {
+	if cfg == nil {
+		return "", nil, fmt.Errorf("self-deploy: nil config")
+	}
+	localPath := strings.TrimSpace(cfg.LocalPath)
+	if localPath == "" {
+		return "", nil, fmt.Errorf("self-deploy: local_path is required")
+	}
+	script := cfg.SelfDeploy.EffectiveScript(localPath)
+	if script == "" {
+		return "", nil, fmt.Errorf("self-deploy: no deploy script configured")
+	}
+	if _, err := os.Stat(script); err != nil {
+		return "", nil, fmt.Errorf("self-deploy: script %s: %w", script, err)
+	}
+	bin := strings.TrimSpace(cfg.SelfDeploy.BinPath)
+	if bin == "" {
+		exe, err := os.Executable()
+		if err != nil || strings.TrimSpace(exe) == "" {
+			return "", nil, fmt.Errorf("self-deploy: bin_path not set and running binary not resolvable: %w", err)
+		}
+		bin = exe
+	}
+
+	// One unit per trigger: a stale failed unit from a previous deploy must
+	// not block the next one, and --collect garbage-collects it either way.
+	unitName := fmt.Sprintf("maestro-self-deploy-pr%d-%d", prNumber, now.Unix())
+	timeoutSec := cfg.SelfDeploy.EffectiveTimeoutMinutes() * 60
+
+	args := []string{
+		"--user",
+		"--collect",
+		"--unit=" + unitName,
+		"--property=WorkingDirectory=" + localPath,
+		// Hard backstop well past the script's own deadline so a wedged
+		// deploy cannot linger forever; the script handles its own
+		// timeouts (and rollback) inside timeoutSec.
+		"--property=RuntimeMaxSec=" + strconv.Itoa(timeoutSec*2),
+	}
+	// The transient unit gets the user manager's default environment, which
+	// usually lacks the Go toolchain dirs the orchestrator unit configures.
+	// Hand our PATH down so the build step finds the same tools.
+	if path := strings.TrimSpace(os.Getenv("PATH")); path != "" {
+		args = append(args, "--setenv=PATH="+path)
+	}
+	args = append(args,
+		"/bin/bash", script,
+		"--repo-dir", localPath,
+		"--bin", bin,
+		"--units", strings.Join(cfg.SelfDeploy.EffectiveUnits(), ","),
+		"--result-file", ResultPath(cfg.StateDir),
+		"--timeout-seconds", strconv.Itoa(timeoutSec),
+		"--pr", strconv.Itoa(prNumber),
+	)
+	if url := cfg.SelfDeploy.EffectiveHealthURL(cfg.Server); url != "" {
+		args = append(args, "--health-url", url)
+		if env := cfg.SelfDeploy.EffectiveHealthTokenEnv(cfg.Server); env != "" {
+			args = append(args, "--health-token-env", env)
+		}
+	}
+	return "systemd-run", args, nil
+}
+
+// Trigger starts the deploy script in a detached transient unit and returns
+// once systemd has accepted the job. It does NOT wait for the deploy: the
+// orchestrator is typically restarted by it.
+func Trigger(cfg *config.Config, prNumber int) error {
+	name, args, err := TriggerCommand(cfg, prNumber, time.Now().UTC())
+	if err != nil {
+		return err
+	}
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("self-deploy: systemd-run: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// Finding converts a deploy result into the supervisor finding the
+// orchestrator records in state (#698 — "surfaces the result as a supervisor
+// finding: deployed version / rollback reason").
+func Finding(res *Result, project string, now time.Time) state.SupervisorDecision {
+	d := state.SupervisorDecision{
+		ID:               "self-deploy-" + now.Format("20060102T150405.000000000Z"),
+		CreatedAt:        now,
+		Project:          project,
+		Risk:             "safe",
+		Confidence:       1.0,
+		RequiresApproval: false,
+	}
+	if res == nil {
+		d.Status = "failed"
+		d.Summary = "self-deploy: empty result"
+		d.RecommendedAction = "inspect the self-deploy transient unit logs (journalctl --user -u 'maestro-self-deploy-*')"
+		return d
+	}
+	prSuffix := ""
+	if res.PR > 0 {
+		prSuffix = fmt.Sprintf(" after PR #%d", res.PR)
+	}
+	switch res.Status {
+	case StatusDeployed:
+		d.Status = "succeeded"
+		d.Summary = fmt.Sprintf("self-deploy: deployed maestro v%s%s", res.Version, prSuffix)
+		d.RecommendedAction = "none"
+	case StatusRolledBack:
+		d.Status = "failed"
+		d.Summary = fmt.Sprintf("self-deploy: rolled back to previous binary%s — %s", prSuffix, res.Reason)
+		d.RecommendedAction = "inspect the failed deploy (journalctl --user -u 'maestro-self-deploy-*'), fix the regression, re-merge"
+	default:
+		d.Status = "failed"
+		d.Summary = fmt.Sprintf("self-deploy: failed%s — %s", prSuffix, res.Reason)
+		d.RecommendedAction = "verify the maestro units and binary by hand (systemctl --user status; maestro version), then redeploy manually"
+	}
+	if res.Version != "" {
+		d.Reasons = append(d.Reasons, "new version: "+res.Version)
+	}
+	if res.PrevVersion != "" {
+		d.Reasons = append(d.Reasons, "previous version: "+res.PrevVersion)
+	}
+	if res.ExpectedSHA != "" {
+		d.Reasons = append(d.Reasons, "built from origin/main @ "+res.ExpectedSHA)
+	}
+	if res.Reason != "" && res.Status != StatusDeployed {
+		d.Reasons = append(d.Reasons, "reason: "+res.Reason)
+	}
+	return d
+}

--- a/internal/selfdeploy/selfdeploy_test.go
+++ b/internal/selfdeploy/selfdeploy_test.go
@@ -1,0 +1,165 @@
+package selfdeploy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+func TestReadResultAbsent(t *testing.T) {
+	res, err := ReadResult(t.TempDir())
+	if err != nil {
+		t.Fatalf("ReadResult: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("ReadResult = %+v, want nil", res)
+	}
+}
+
+func TestReadAndClearResult(t *testing.T) {
+	dir := t.TempDir()
+	payload := `{"status":"deployed","version":"1.4.2+gabc1234","expected_sha":"abc1234","pr":698,"finished_at":"2026-06-12T10:00:00Z"}`
+	if err := os.WriteFile(ResultPath(dir), []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ReadResult(dir)
+	if err != nil {
+		t.Fatalf("ReadResult: %v", err)
+	}
+	if res == nil || res.Status != StatusDeployed || res.Version != "1.4.2+gabc1234" || res.PR != 698 {
+		t.Fatalf("ReadResult = %+v", res)
+	}
+
+	if err := ClearResult(dir); err != nil {
+		t.Fatalf("ClearResult: %v", err)
+	}
+	if res, err = ReadResult(dir); err != nil || res != nil {
+		t.Fatalf("after clear: res=%+v err=%v, want nil/nil", res, err)
+	}
+	// Clearing twice is fine (consume-once semantics, no error on absent).
+	if err := ClearResult(dir); err != nil {
+		t.Fatalf("ClearResult twice: %v", err)
+	}
+}
+
+func TestReadResultMalformed(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(ResultPath(dir), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadResult(dir); err == nil {
+		t.Fatal("ReadResult on malformed JSON: want error")
+	}
+}
+
+func triggerTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	local := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(local, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(local, "scripts", "self-deploy.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/bash\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return &config.Config{
+		Repo:      "owner/repo",
+		LocalPath: local,
+		StateDir:  t.TempDir(),
+		Server:    config.ServerConfig{Port: 8788},
+		SelfDeploy: config.SelfDeployConfig{
+			Enabled: true,
+			BinPath: "/usr/local/bin/maestro",
+		},
+	}
+}
+
+func TestTriggerCommand(t *testing.T) {
+	cfg := triggerTestConfig(t)
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+
+	name, args, err := TriggerCommand(cfg, 698, now)
+	if err != nil {
+		t.Fatalf("TriggerCommand: %v", err)
+	}
+	if name != "systemd-run" {
+		t.Errorf("name = %q", name)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"--user",
+		"--collect",
+		"--unit=maestro-self-deploy-pr698-",
+		"--property=WorkingDirectory=" + cfg.LocalPath,
+		"/bin/bash " + filepath.Join(cfg.LocalPath, "scripts", "self-deploy.sh"),
+		"--bin /usr/local/bin/maestro",
+		"--units maestro.service",
+		"--result-file " + ResultPath(cfg.StateDir),
+		"--timeout-seconds 1800",
+		"--pr 698",
+		"--health-url http://127.0.0.1:8788/api/v1/state",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
+func TestTriggerCommandNoHealthURLWithoutServerPort(t *testing.T) {
+	cfg := triggerTestConfig(t)
+	cfg.Server = config.ServerConfig{}
+
+	_, args, err := TriggerCommand(cfg, 1, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("TriggerCommand: %v", err)
+	}
+	if strings.Contains(strings.Join(args, " "), "--health-url") {
+		t.Error("expected no --health-url when server port is unset")
+	}
+}
+
+func TestTriggerCommandMissingScript(t *testing.T) {
+	cfg := triggerTestConfig(t)
+	cfg.SelfDeploy.Script = filepath.Join(cfg.LocalPath, "does-not-exist.sh")
+
+	if _, _, err := TriggerCommand(cfg, 1, time.Now().UTC()); err == nil {
+		t.Fatal("want error for missing script")
+	}
+}
+
+func TestFindingDeployed(t *testing.T) {
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	res := &Result{Status: StatusDeployed, Version: "1.4.2+gabc1234", ExpectedSHA: "abc1234def", PR: 698, PrevVersion: "1.4.1"}
+
+	d := Finding(res, "owner/repo", now)
+	if d.Status != "succeeded" {
+		t.Errorf("Status = %q", d.Status)
+	}
+	if !strings.Contains(d.Summary, "deployed maestro v1.4.2+gabc1234") || !strings.Contains(d.Summary, "PR #698") {
+		t.Errorf("Summary = %q", d.Summary)
+	}
+	if d.RequiresApproval {
+		t.Error("informational finding must not require approval")
+	}
+	joined := strings.Join(d.Reasons, "\n")
+	for _, want := range []string{"1.4.2+gabc1234", "1.4.1", "abc1234def"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("Reasons missing %q: %v", want, d.Reasons)
+		}
+	}
+}
+
+func TestFindingRolledBack(t *testing.T) {
+	d := Finding(&Result{Status: StatusRolledBack, PR: 698, Reason: "health check timed out"}, "owner/repo", time.Now().UTC())
+	if d.Status != "failed" {
+		t.Errorf("Status = %q", d.Status)
+	}
+	if !strings.Contains(d.Summary, "rolled back") || !strings.Contains(d.Summary, "health check timed out") {
+		t.Errorf("Summary = %q", d.Summary)
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -337,6 +337,7 @@ func (s *FleetServer) Start(ctx context.Context) error {
 
 type fleetResponse struct {
 	ReadOnly      bool                 `json:"read_only"`
+	Version       string               `json:"version,omitempty"` // running maestro binary version (#698)
 	RefreshedAt   string               `json:"refreshed_at"`
 	NextAction    *fleetNextAction     `json:"next_action"`
 	Verdict       fleetVerdict         `json:"verdict"`
@@ -1137,6 +1138,7 @@ func (s *FleetServer) snapshot() fleetResponse {
 	now := time.Now().UTC()
 	resp := fleetResponse{
 		ReadOnly:    s.readOnly,
+		Version:     binaryVersion,
 		RefreshedAt: formatFleetTime(now),
 		Projects:    make([]fleetProjectState, 0, len(s.projects)),
 		Workers:     make([]fleetWorkerState, 0),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -142,9 +142,22 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
 }
 
+// binaryVersion is the resolved version of the running maestro process, set
+// once at startup by cmd/maestro via SetBinaryVersion. Surfacing it on the
+// state and fleet endpoints lets the self-deploy health probe (#698) confirm
+// the restarted process actually runs the freshly stamped build.
+var binaryVersion string
+
+// SetBinaryVersion records the running binary's resolved version for the
+// state and fleet API responses.
+func SetBinaryVersion(v string) {
+	binaryVersion = strings.TrimSpace(v)
+}
+
 // stateResponse is the JSON shape for GET /api/v1/state.
 type stateResponse struct {
 	Repo                string                         `json:"repo"`
+	Version             string                         `json:"version,omitempty"` // running maestro binary version (#698)
 	MaxParallel         int                            `json:"max_parallel"`
 	ReadOnly            bool                           `json:"read_only"`
 	Outcome             outcome.Status                 `json:"outcome"`
@@ -928,6 +941,7 @@ func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 	latestDecision := st.LatestSupervisorDecision()
 	resp := stateResponse{
 		Repo:                cfg.Repo,
+		Version:             binaryVersion,
 		MaxParallel:         cfg.MaxParallel,
 		ReadOnly:            cfg.Server.ReadOnly,
 		Outcome:             outcomeStatusForState(cfg, st),

--- a/internal/server/version_test.go
+++ b/internal/server/version_test.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #698: the state response carries the running binary's version so the
+// self-deploy health probe can confirm a restart picked up the new build.
+func TestStateResponseIncludesBinaryVersion(t *testing.T) {
+	SetBinaryVersion("1.4.2+gabc1234")
+	t.Cleanup(func() { SetBinaryVersion("") })
+
+	cfg := &config.Config{Repo: "owner/repo"}
+	resp := buildStateResponse(cfg, &state.State{})
+	if resp.Version != "1.4.2+gabc1234" {
+		t.Fatalf("state response version = %q, want 1.4.2+gabc1234", resp.Version)
+	}
+}
+
+func TestFleetSnapshotIncludesBinaryVersion(t *testing.T) {
+	SetBinaryVersion("1.4.2+gabc1234")
+	t.Cleanup(func() { SetBinaryVersion("") })
+
+	s := NewFleet(nil, "127.0.0.1", 0, true)
+	resp := s.snapshot()
+	if resp.Version != "1.4.2+gabc1234" {
+		t.Fatalf("fleet snapshot version = %q, want 1.4.2+gabc1234", resp.Version)
+	}
+}

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -106,6 +106,23 @@ worker_prompt: /path/to/worker-prompt-template.md
 # deploy_cmd: "cd /path/to/repo && go build ./cmd/app/ && systemctl --user restart app"
 # deploy_timeout_minutes: 15         # timeout for deploy command in minutes (default: 15)
 
+# Opt-in self-deploy of the maestro binary itself after every merge (#698).
+# Default OFF. For the dogfood project only: builds merged origin/main
+# (version-stamped), installs atomically keeping the previous binary as
+# <bin_path>.prev, restarts the units via a detached transient unit so the
+# restart survives the orchestrator restarting itself (drain semantics are
+# honored via the units' stop path), verifies the restarted process reports
+# the new version, and rolls back to .prev on failure. See
+# docs/self-deploy-runbook.md.
+# self_deploy:
+#   enabled: true
+#   bin_path: /usr/local/bin/maestro   # default: path of the running binary
+#   units: ["maestro.service"]         # systemd user units to restart
+#   # health_url: http://127.0.0.1:8788/api/v1/state  # default: derived from server.port
+#   # health_token_env: MAESTRO_DASH_TOKEN            # default: server.auth.token_env
+#   # script: ./scripts/self-deploy.sh                # default: <local_path>/scripts/self-deploy.sh
+#   # timeout_minutes: 30                             # build+restart+verify budget (covers drain)
+
 # Stale supervisor sessions are filtered out of the Fleet API attention list
 # under two independent conditions: (a) idle past idle_after_minutes AND the
 # recorded worktree is missing on disk (when require_worktree_missing=true),

--- a/scripts/self-deploy.sh
+++ b/scripts/self-deploy.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# self-deploy.sh — opt-in post-merge self-deploy of the maestro binary (#698).
+#
+# Launched by the orchestrator through a detached transient systemd unit
+# (systemd-run --user) after a PR merges, so this script survives restarting
+# the very units that run the orchestrator. Steps:
+#
+#   1. build from merged origin/main, version-stamped per #682
+#      (-X main.version=<VERSION>+g<shortsha>),
+#   2. install atomically, keeping the previous binary as <bin>.prev,
+#   3. restart the maestro user units via systemctl --user restart — the
+#      units' normal stop path runs, so existing drain semantics are honored,
+#   4. verify post-restart health: installed CLI reports the stamped version,
+#      units are active, and (when --health-url is given) the running process
+#      reports the stamped version within the timeout,
+#   5. on failure roll back to <bin>.prev, restart the units again,
+#   6. write a JSON result file the orchestrator surfaces as a supervisor
+#      finding on its next cycle.
+#
+# Usage:
+#   self-deploy.sh --repo-dir DIR --bin PATH --units a.service[,b.service] \
+#     --result-file PATH --timeout-seconds N --pr N \
+#     [--health-url URL] [--health-token-env ENVVAR]
+
+set -euo pipefail
+
+REPO_DIR=""
+BIN=""
+UNITS=""
+RESULT_FILE=""
+TIMEOUT_SECONDS=1800
+PR=0
+HEALTH_URL=""
+HEALTH_TOKEN_ENV=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-dir) REPO_DIR="$2"; shift 2 ;;
+    --bin) BIN="$2"; shift 2 ;;
+    --units) UNITS="$2"; shift 2 ;;
+    --result-file) RESULT_FILE="$2"; shift 2 ;;
+    --timeout-seconds) TIMEOUT_SECONDS="$2"; shift 2 ;;
+    --pr) PR="$2"; shift 2 ;;
+    --health-url) HEALTH_URL="$2"; shift 2 ;;
+    --health-token-env) HEALTH_TOKEN_ENV="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$REPO_DIR" && -n "$BIN" && -n "$UNITS" && -n "$RESULT_FILE" ]] || {
+  echo "usage: --repo-dir, --bin, --units, --result-file are required" >&2
+  exit 2
+}
+
+START_TS=$(date +%s)
+DEADLINE=$((START_TS + TIMEOUT_SECONDS))
+# Rollback restarts get their own fixed budget: the whole point of rollback is
+# to recover even after the main deadline is spent.
+ROLLBACK_RESTART_TIMEOUT=600
+
+BUILD_ROOT=$(mktemp -d /tmp/maestro-self-deploy.XXXXXX)
+BUILD_DIR="$BUILD_ROOT/src"
+INSTALLED=0
+HAVE_PREV=0
+RESULT_WRITTEN=0
+SHA=""
+STAMP=""
+PREV_VERSION=""
+
+IFS=',' read -r -a UNIT_LIST <<<"$UNITS"
+
+log() { echo "[self-deploy] $*" >&2; }
+
+json_escape() {
+  # Minimal JSON string escaper: backslash, double quote, newlines/tabs.
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/ }
+  s=${s//$'\t'/ }
+  printf '%s' "$s"
+}
+
+write_result() {
+  local status=$1 reason=$2
+  mkdir -p "$(dirname "$RESULT_FILE")"
+  local tmp="$RESULT_FILE.tmp.$$"
+  cat >"$tmp" <<EOF
+{
+  "status": "$(json_escape "$status")",
+  "version": "$(json_escape "$STAMP")",
+  "prev_version": "$(json_escape "$PREV_VERSION")",
+  "expected_sha": "$(json_escape "$SHA")",
+  "pr": ${PR:-0},
+  "reason": "$(json_escape "$reason")",
+  "finished_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+  mv -f "$tmp" "$RESULT_FILE"
+  RESULT_WRITTEN=1
+  log "result: $status${reason:+ — $reason}"
+}
+
+cleanup_build() {
+  git -C "$REPO_DIR" worktree remove --force "$BUILD_DIR" >/dev/null 2>&1 || true
+  rm -rf "$BUILD_ROOT"
+}
+
+restart_units() {
+  local budget=$1 unit
+  for unit in "${UNIT_LIST[@]}"; do
+    log "restarting $unit (honors the unit's stop/drain path; budget ${budget}s)"
+    if ! timeout "$budget" systemctl --user restart "$unit"; then
+      log "restart of $unit failed or timed out"
+      return 1
+    fi
+  done
+}
+
+units_active() {
+  local unit
+  for unit in "${UNIT_LIST[@]}"; do
+    systemctl --user is-active --quiet "$unit" || return 1
+  done
+}
+
+health_ok() {
+  # Running-process check: the API must answer and report the stamped version.
+  local curl_args=(-fsS --max-time 10)
+  if [[ -n "$HEALTH_TOKEN_ENV" && -n "${!HEALTH_TOKEN_ENV:-}" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${!HEALTH_TOKEN_ENV}")
+  fi
+  curl "${curl_args[@]}" "$HEALTH_URL" 2>/dev/null | grep -qF "\"version\": \"$STAMP\""
+}
+
+verify() {
+  # CLI check: the installed binary must report the stamped version.
+  local cli
+  cli=$("$BIN" version 2>/dev/null || true)
+  if [[ "$cli" != *"v$STAMP"* ]]; then
+    log "CLI version mismatch: got '$cli', want 'maestro v$STAMP'"
+    return 1
+  fi
+  while :; do
+    if units_active; then
+      if [[ -z "$HEALTH_URL" ]]; then
+        return 0
+      fi
+      if health_ok; then
+        return 0
+      fi
+    fi
+    if (( $(date +%s) >= DEADLINE )); then
+      log "verification did not pass before the deadline"
+      return 1
+    fi
+    sleep 5
+  done
+}
+
+rollback() {
+  local reason=$1
+  if [[ ! -f "$BIN.prev" ]]; then
+    write_result failed "$reason; no $BIN.prev to roll back to"
+    return
+  fi
+  log "rolling back to $BIN.prev"
+  # Restore atomically: copy .prev to a temp name on the same filesystem and
+  # rename over the live binary, keeping .prev itself for inspection.
+  if cp -p "$BIN.prev" "$BIN.rollback.$$" && mv -f "$BIN.rollback.$$" "$BIN"; then
+    if restart_units "$ROLLBACK_RESTART_TIMEOUT" && units_active; then
+      write_result rolled_back "$reason"
+    else
+      write_result failed "$reason; rollback restored $BIN.prev but units did not come back active"
+    fi
+  else
+    rm -f "$BIN.rollback.$$"
+    write_result failed "$reason; rollback copy of $BIN.prev failed"
+  fi
+}
+
+fail() {
+  local reason=$1
+  log "FAILED: $reason"
+  if (( INSTALLED )); then
+    rollback "$reason"
+  else
+    write_result failed "$reason"
+  fi
+  cleanup_build
+  exit 1
+}
+
+on_exit() {
+  local rc=$?
+  if (( rc != 0 )) && (( ! RESULT_WRITTEN )); then
+    # set -e bailed somewhere unexpected (or systemd's RuntimeMaxSec backstop
+    # fired): still attempt rollback + leave a result behind.
+    trap - ERR EXIT
+    fail "unexpected exit (rc=$rc) at deploy step"
+  fi
+  cleanup_build
+}
+trap on_exit EXIT
+trap 'fail "command failed: ${BASH_COMMAND}"' ERR
+
+command -v go >/dev/null 2>&1 || export PATH="$PATH:/usr/local/go/bin"
+command -v go >/dev/null 2>&1 || fail "go toolchain not found in PATH"
+
+# --- 1. build from merged origin/main, version-stamped (#682) ---------------
+log "fetching origin/main in $REPO_DIR"
+git -C "$REPO_DIR" fetch --quiet origin main
+SHA=$(git -C "$REPO_DIR" rev-parse origin/main)
+SHORT_SHA=${SHA:0:7}
+
+git -C "$REPO_DIR" worktree add --force --detach "$BUILD_DIR" "$SHA" >/dev/null
+
+VERSION=$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$BUILD_DIR/VERSION")
+[[ -n "$VERSION" ]] || fail "could not read version from VERSION at $SHA"
+STAMP="${VERSION}+g${SHORT_SHA}"
+
+log "building maestro v$STAMP from $SHA"
+(cd "$BUILD_DIR" && go build -trimpath -ldflags "-s -w -X main.version=$STAMP" -o "$BUILD_ROOT/maestro" ./cmd/maestro/)
+
+BUILT_VERSION=$("$BUILD_ROOT/maestro" version)
+[[ "$BUILT_VERSION" == *"v$STAMP"* ]] || fail "built binary reports '$BUILT_VERSION', want 'maestro v$STAMP'"
+
+# --- 2. install atomically, keep previous as .prev --------------------------
+PREV_VERSION=$("$BIN" version 2>/dev/null | sed 's/^maestro v//' || true)
+if [[ -n "$PREV_VERSION" && "$PREV_VERSION" == "$STAMP" ]]; then
+  log "already at v$STAMP — nothing to deploy"
+  write_result deployed "already at v$STAMP"
+  cleanup_build
+  exit 0
+fi
+
+# Stage next to the target so the final rename is atomic (same filesystem).
+install -m 0755 "$BUILD_ROOT/maestro" "$BIN.next" || fail "staging $BIN.next failed"
+if [[ -f "$BIN" ]]; then
+  cp -p "$BIN" "$BIN.prev" || { rm -f "$BIN.next"; fail "preserving $BIN.prev failed"; }
+  HAVE_PREV=1
+fi
+mv -f "$BIN.next" "$BIN" || fail "installing $BIN failed"
+INSTALLED=1
+if (( HAVE_PREV )); then
+  log "installed $BIN (previous kept at $BIN.prev)"
+else
+  log "installed $BIN (first deploy — no previous binary to keep)"
+fi
+
+# --- 3. restart units (drain semantics via the units' own stop path) --------
+RESTART_BUDGET=$((DEADLINE - $(date +%s)))
+(( RESTART_BUDGET > 30 )) || RESTART_BUDGET=30
+restart_units "$RESTART_BUDGET" || fail "unit restart failed or exceeded ${RESTART_BUDGET}s"
+
+# --- 4. verify post-restart health ------------------------------------------
+verify || fail "post-restart verification failed (expected v$STAMP from sha $SHA)"
+
+# --- 5. success ---------------------------------------------------------------
+write_result deployed ""
+log "deployed maestro v$STAMP ($SHA)"
+cleanup_build
+trap - ERR EXIT
+exit 0


### PR DESCRIPTION
Implements #698 (child of epic #674). Refs #698.

## Changes

- **`self_deploy` config block** (default OFF — no behavior change without it): `enabled`, `bin_path`, `units`, `health_url`, `health_token_env`, `script`, `timeout_minutes`, with derived defaults (health URL from `server.port`, script from `<local_path>/scripts/self-deploy.sh`, units `[maestro.service]`).
- **`scripts/self-deploy.sh`**: builds merged `origin/main` in a temp git worktree, version-stamped per #682 (`-X main.version=<VERSION>+g<shortsha>`); installs atomically keeping the previous binary as `.prev`; restarts the user units via `systemctl --user restart` (drain semantics honored through the units' stop path); verifies post-restart health (CLI version, units active, running process reports the stamped version via the API); rolls back to `.prev` + restarts on failure; writes a JSON result file.
- **`internal/selfdeploy`**: launches the script through a detached transient unit (`systemd-run --user --collect`) so the deploy survives the orchestrator restarting itself; defines the result-file contract and builds the supervisor finding.
- **Orchestrator**: post-merge hook triggers the deploy (fire-and-forget); the next cycle consumes the result file, records a supervisor finding (deployed version / rollback reason), and notifies.
- **Server**: `/api/v1/state` and `/api/v1/fleet` responses now carry the running binary's `version` so the health probe can match the expected build.
- **Docs**: `docs/self-deploy-runbook.md` (operator runbook) + `maestro.yaml.example`.

## Testing

- Unit tests: config defaults/parsing, trigger argv construction, result read/clear-once, finding construction, orchestrator gate (off by default / fires when enabled), result consumption (deployed, rolled back, malformed), version on state/fleet responses.
- Script smoke-tested end to end with a stubbed `systemctl`: happy path deploys and stamps `<VERSION>+g<sha>`; a deliberately failing health check rolls back to `.prev`, restarts units, and emits a `rolled_back` result with the reason.
- `gofmt` clean on changed files; `go test ./...` green; `go build ./cmd/maestro/` OK; rebased on `origin/main`.

## Still requires runtime verification

Acceptance criteria 1–2 involve live systemd units and a real merge on the dogfood host (flag enabled on a test config; deploy lands within N minutes; rollback drill). This PR must not auto-close #698 — runtime verification remains for the operator.

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements opt-in post-merge self-deployment of the maestro binary, gated behind a `self_deploy:` config block that defaults to OFF. When enabled, the orchestrator fires a detached `systemd-run` transient unit after each merge; the unit builds from `origin/main`, installs atomically (preserving `.prev`), restarts the configured user units, verifies the stamped version via CLI and HTTP health probe, and rolls back on failure — with the outcome surfaced as a supervisor finding on the next orchestrator cycle.

- Adds `SelfDeployConfig` with derived-default helpers, `internal/selfdeploy` package (trigger, result contract, finding builder), and `scripts/self-deploy.sh` (build/install/restart/verify/rollback).
- Surfaces the running binary's version on `/api/v1/state` and `/api/v1/fleet` so the health probe can confirm the restarted process picked up the new build.
- Ships a full operator runbook and example config, with unit tests covering defaults, trigger argv, result consumption (deployed/rolled-back/malformed), and version fields on both API responses.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the flag disabled (the default); the new code path only activates when self_deploy.enabled is explicitly set to true.

The design is solid: detached transient unit survives orchestrator restarts, atomic binary install preserves a `.prev` for rollback, and the result-file handoff cleanly decouples the deploy process from the orchestrator cycle. The two items worth a second look before enabling in production are (1) the `ClearResult` failure path in `consumeSelfDeployResult` — if the file cannot be removed, the deploy outcome (including a potential rollback) is silently suppressed on every subsequent cycle with no operator notification, and (2) the double `expandHome` call on `SelfDeploy.Script`, which is harmless today but inconsistent with how `BinPath` is handled.

internal/orchestrator/orchestrator.go (consumeSelfDeployResult error path), internal/config/config.go (EffectiveScript double-expansion), scripts/self-deploy.sh (rollback copy integrity)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/self-deploy.sh | New 264-line shell script implementing the full self-deploy lifecycle (build, atomic install, unit restart, health verification, rollback). Logic is sound; the rollback copy path lacks post-copy integrity verification. |
| internal/selfdeploy/selfdeploy.go | New package wrapping TriggerCommand/Trigger (systemd-run invocation builder), ReadResult/ClearResult (JSON contract), and Finding (supervisor decision builder). Clean design with good test coverage. |
| internal/orchestrator/orchestrator.go | Adds Step 0 (consume result file on each cycle) and post-merge hook. Silent drop of the supervisor finding when ClearResult fails is a concern; no operator notification on that error path. |
| internal/config/config.go | Adds SelfDeployConfig with derived-default helpers. EffectiveScript double-expands the home directory because parse() already expanded it; harmless today but worth cleaning up. |
| internal/server/server.go | Adds package-level binaryVersion set once at startup; surfaced on /api/v1/state. Set before http.ListenAndServe so memory ordering is correct per Go memory model. |
| internal/server/fleet.go | Adds version field to fleetResponse and populates it from the package-level binaryVersion. Minimal, correct change. |
| cmd/maestro/main.go | Calls SetBinaryVersion(resolveVersion()) at startup before any HTTP server is started; correct placement. |
| docs/self-deploy-runbook.md | New operator runbook covering enablement, verification, rollback, failure modes, and interaction with deploy_cmd. Complete and accurate. |
| maestro.yaml.example | Adds commented-out self_deploy block with sensible defaults annotated inline. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/self-deploy.sh`, line 1311 ([link](https://github.com/befeast/maestro/blob/2a8af3a22c9392d467a20868bbc4ffad609d6206/scripts/self-deploy.sh#L1311)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`cp -p` for rollback can cross filesystem boundaries without atomicity**

   The rollback copies `$BIN.prev` to `$BIN.rollback.$$` (same directory, same filesystem) and then renames over `$BIN`. The rename is atomic only because both paths share the same directory. However, if `$BIN.prev` is very large and the copy is interrupted (OOM-killer, power loss), you end up with a partial `$BIN.rollback.$$` that then gets renamed over the live binary. Consider checking that `$BIN.rollback.$$` has the expected size after copy before renaming, or accept the existing risk given that rollback is a last-resort path.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/self-deploy.sh
   Line: 1311

   Comment:
   **`cp -p` for rollback can cross filesystem boundaries without atomicity**

   The rollback copies `$BIN.prev` to `$BIN.rollback.$$` (same directory, same filesystem) and then renames over `$BIN`. The rename is atomic only because both paths share the same directory. However, if `$BIN.prev` is very large and the copy is interrupted (OOM-killer, power loss), you end up with a partial `$BIN.rollback.$$` that then gets renamed over the live binary. Consider checking that `$BIN.rollback.$$` has the expected size after copy before renaming, or accept the existing risk given that rollback is a last-resort path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/config/config.go:188-194
**Double `expandHome` on `Script` field**

`parse()` already calls `cfg.SelfDeploy.Script = expandHome(cfg.SelfDeploy.Script)` (a few lines below in the diff), so `EffectiveScript` sees an already-expanded path and calls `expandHome` on it again. For a non-`~` path this is a no-op, but it is inconsistent with how `BinPath` is handled (expanded only in `parse()`, used bare everywhere else). If `expandHome`'s behavior ever changes, this double-expansion could produce unexpected results.

### Issue 2 of 3
internal/orchestrator/orchestrator.go:3779-3784
**Silent finding loss when `ClearResult` fails**

When the result file exists but `os.Remove` fails (e.g., a transient permission error), `consumeSelfDeployResult` returns `false` without recording the finding or notifying the operator. On every subsequent cycle the same sequence repeats — `ReadResult` succeeds (file is still present), `ClearResult` fails, loop breaks. The deploy outcome (including a rollback) is swallowed forever with only a log message to signal the problem. Even a single `notifier.Sendf` warning here would let the operator know they need to clear the result file manually.

```suggestion
	// Clear before recording so a save failure cannot double-record on the
	// next cycle; losing the finding is the lesser failure mode.
	if err := selfdeploy.ClearResult(o.cfg.StateDir); err != nil {
		log.Printf("[orch] self-deploy result cleanup: %v", err)
		o.notifier.Sendf("⚠️ maestro: self-deploy result file could not be cleared (%v) — delete %s manually to stop this warning",
			err, selfdeploy.ResultPath(o.cfg.StateDir))
		return false
	}
```

### Issue 3 of 3
scripts/self-deploy.sh:1311
**`cp -p` for rollback can cross filesystem boundaries without atomicity**

The rollback copies `$BIN.prev` to `$BIN.rollback.$$` (same directory, same filesystem) and then renames over `$BIN`. The rename is atomic only because both paths share the same directory. However, if `$BIN.prev` is very large and the copy is interrupted (OOM-killer, power loss), you end up with a partial `$BIN.rollback.$$` that then gets renamed over the live binary. Consider checking that `$BIN.rollback.$$` has the expected size after copy before renaming, or accept the existing risk given that rollback is a last-resort path.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release/deploy: opt-in self-deploy of th..."](https://github.com/befeast/maestro/commit/2a8af3a22c9392d467a20868bbc4ffad609d6206) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37270718)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->