### PR TITLE
fleet: morning operator digest — ranked decide-today / promotable / health report (MVP: vault file + notifier) (#703)

### DIFF
--- a/cmd/maestro/digest.go
+++ b/cmd/maestro/digest.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/digest"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/server"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// digestCmd implements `maestro digest`: a one-shot morning operator report
+// aggregated across every fleet project (#703). It writes a Markdown report
+// (Obsidian-vault friendly) and pings the notifier when decisions are pending.
+func digestCmd(args []string) {
+	fs := flag.NewFlagSet("digest", flag.ExitOnError)
+	fleetPath := fs.String("fleet", "", "Path to fleet YAML file covering every project")
+	var configs multiFlag
+	fs.Var(&configs, "config", "Path to config file (can be repeated)")
+	storePath, storeProject := configStoreFlags(fs)
+	outPath := fs.String("out", "", "Markdown report destination: a directory (file named maestro-digest-YYYY-MM-DD.md) or a .md file path; empty prints to stdout only")
+	doNotify := fs.Bool("notify", true, "Send a notifier summary when decide-today items > 0")
+	staleHours := fs.Int("stale-review-hours", 24, "Age threshold (hours) before unresolved review findings are surfaced")
+	jsonOut := fs.Bool("json", false, "Print the report as JSON to stdout instead of Markdown")
+	fs.Parse(args)
+
+	now := time.Now()
+	projects, notifierCfg := loadDigestProjects(*fleetPath, configs, *storePath, *storeProject)
+
+	report := digest.Collect(projects, digest.Options{
+		Now:            now,
+		StaleReviewAge: time.Duration(*staleHours) * time.Hour,
+	})
+
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			log.Fatalf("encode report: %v", err)
+		}
+	} else {
+		fmt.Print(report.Markdown())
+	}
+
+	writtenPath := ""
+	if strings.TrimSpace(*outPath) != "" {
+		path, err := writeDigestReport(*outPath, report.Markdown(), now)
+		if err != nil {
+			log.Fatalf("write report: %v", err)
+		}
+		writtenPath = path
+		log.Printf("digest report written to %s", path)
+	}
+
+	if *doNotify && report.DecideTodayCount() > 0 {
+		if notifierCfg == nil {
+			log.Printf("digest: %d decision(s) pending but no project has a notifier target configured", report.DecideTodayCount())
+		} else {
+			n := notify.NewWithToken(notifierCfg.Telegram.BotToken, notifierCfg.Telegram.Target, notifierCfg.Telegram.Mode, notifierCfg.Telegram.OpenclawURL)
+			if err := n.Send(report.NotifySummary(writtenPath)); err != nil {
+				log.Printf("digest: notifier send failed: %v", err)
+			}
+		}
+	}
+}
+
+// loadDigestProjects resolves the fleet membership (fleet.yaml, repeated
+// --config flags, maestro.d/, or default discovery) into digest inputs.
+// The returned notifier config is the first project with a notify target.
+func loadDigestProjects(fleetPath string, configs multiFlag, storePath, storeProject string) ([]digest.Project, *config.Config) {
+	var named []struct {
+		name string
+		cfg  *config.Config
+	}
+	if strings.TrimSpace(fleetPath) != "" {
+		fleet, err := server.LoadFleetProjects(fleetPath)
+		if err != nil {
+			log.Fatalf("load fleet: %v", err)
+		}
+		for i := range fleet {
+			named = append(named, struct {
+				name string
+				cfg  *config.Config
+			}{fleet[i].Name, fleet[i].Cfg()})
+		}
+	} else {
+		for _, cfg := range loadConfigsWithStore(configs, storePath, storeProject) {
+			named = append(named, struct {
+				name string
+				cfg  *config.Config
+			}{"", cfg})
+		}
+	}
+
+	var projects []digest.Project
+	var notifierCfg *config.Config
+	for _, entry := range named {
+		cfg := entry.cfg
+		if cfg == nil {
+			continue
+		}
+		st, err := state.Load(cfg.StateDir)
+		if err != nil {
+			log.Printf("warn: load state for %s: %v (sections from state will be empty)", cfg.Repo, err)
+			st = nil
+		}
+		p := digest.ProjectFromConfig(entry.name, cfg, st, github.New(cfg.Repo))
+		projects = append(projects, p)
+		if notifierCfg == nil && strings.TrimSpace(cfg.Telegram.Target) != "" {
+			notifierCfg = cfg
+		}
+	}
+	if len(projects) == 0 {
+		log.Fatalf("digest: no projects loaded")
+	}
+	return projects, notifierCfg
+}
+
+// writeDigestReport writes the Markdown report. out may be a directory (the
+// file is named maestro-digest-YYYY-MM-DD.md inside it) or a .md file path.
+func writeDigestReport(out, markdown string, now time.Time) (string, error) {
+	path := out
+	if !strings.HasSuffix(strings.ToLower(out), ".md") {
+		path = filepath.Join(out, fmt.Sprintf("maestro-digest-%s.md", now.Format("2006-01-02")))
+	}
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return "", err
+		}
+	}
+	if err := os.WriteFile(path, []byte(markdown), 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/cmd/maestro/digest_test.go
+++ b/cmd/maestro/digest_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWriteDigestReportToDirectory(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 12, 7, 0, 0, 0, time.UTC)
+
+	path, err := writeDigestReport(dir, "# report\n", now)
+	if err != nil {
+		t.Fatalf("writeDigestReport: %v", err)
+	}
+	want := filepath.Join(dir, "maestro-digest-2026-06-12.md")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if string(data) != "# report\n" {
+		t.Errorf("unexpected content: %q", data)
+	}
+}
+
+func TestWriteDigestReportToExplicitFile(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 12, 7, 0, 0, 0, time.UTC)
+	target := filepath.Join(dir, "nested", "digest.md")
+
+	path, err := writeDigestReport(target, "# report\n", now)
+	if err != nil {
+		t.Fatalf("writeDigestReport: %v", err)
+	}
+	if path != target {
+		t.Errorf("path = %q, want %q", path, target)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("report file not written: %v", err)
+	}
+}

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -58,6 +58,7 @@ Commands:
   import        Seed state from existing worktrees
   config-store  Migrate YAML runtime config to SQLite or export it back
   history       Show recently completed sessions
+  digest        Write the morning operator digest across all fleet projects
   cleanup       Remove worktrees for all completed/dead sessions
   version-bump  Bump project version based on merged PR labels
   version       Print version
@@ -132,6 +133,18 @@ History:
   maestro history --limit 50   Show last 50 completed sessions
   maestro history --json       Machine-readable JSON output
   maestro history --prune      Remove sessions older than retention period
+
+Digest flags:
+  --fleet string             Path to fleet YAML covering every project
+  --out string               Report destination: directory or .md file (default: stdout only)
+  --notify                   Send notifier summary when decisions are pending (default true)
+  --stale-review-hours int   Age threshold for unresolved review findings (default 24)
+  --json                     Print the report as JSON instead of Markdown
+
+  Ranked morning report across the fleet: pending approvals, retry-exhausted
+  sessions with open PRs, blocked issues whose blockers are resolved, PRs with
+  stale unresolved review findings, promotable issues, and a per-project
+  health line. See docs/digest-runbook.md for a systemd timer example.
 
 Watch:
   maestro watch             Open tmux dashboard attached to live worker sessions
@@ -320,6 +333,8 @@ func main() {
 		configStoreCmd(args)
 	case "history":
 		historyCmd(args)
+	case "digest":
+		digestCmd(args)
 	case "cleanup":
 		cleanupCmd(args)
 	case "version-bump":

--- a/docs/digest-runbook.md
+++ b/docs/digest-runbook.md
@@ -1,0 +1,77 @@
+# Morning Operator Digest Runbook
+
+`maestro digest` produces one ranked morning report across every configured fleet project, so the operator does not have to hunt across Mission Control, `maestro history`, and N GitHub repos for "what needs MY decision today" (#703).
+
+This runbook is intentionally safe for shared docs. It uses placeholders for local paths and never requires printing tokens, environment variables, or raw config dumps.
+
+## What the report contains
+
+1. **Decide today** — items that need an operator decision, ranked:
+   - pending supervisor approvals (danger risk first),
+   - retry-exhausted sessions that still have an open PR,
+   - issues carrying the blocked label whose blockers are all resolved (closed or PR merged),
+   - PRs whose review-repair budget is exhausted with unresolved findings older than `--stale-review-hours` (default 24h).
+2. **Promotable** — open issues without the ready label that look runnable (not epic/meta, not blocked, not already in progress), ranked by how mergeable/self-contained they appear (acceptance criteria, scoped description, non-exploratory title). Capped at 10 per project.
+3. **Fleet health (24h)** — one line per project: sessions run, merges, failures, backend distribution.
+
+Every item links to its GitHub issue or PR. GitHub API hiccups degrade gracefully: the affected check is skipped or over-reports, and a "Collection warnings" section flags the gap instead of silently dropping data.
+
+## Running it
+
+One command covers the whole fleet using the same `fleet.yaml` that Mission Control uses:
+
+```sh
+maestro digest --fleet ~/.maestro/fleet.yaml --out ~/vault/maestro
+```
+
+- `--out <dir>` writes `maestro-digest-YYYY-MM-DD.md` into the directory (create the directory inside your Obsidian vault sync root to pick it up automatically). Pass a `*.md` path instead to control the file name. Without `--out` the report goes to stdout only.
+- `--notify` (default true) sends a short summary via the existing notifier (Telegram, direct or OpenClaw relay) **only when at least one decide-today item exists**. The first fleet project with a configured `telegram.target` supplies the notifier credentials. Pass `--notify=false` to suppress.
+- `--stale-review-hours N` tunes the unresolved-review-findings age threshold (default 24).
+- `--json` emits the structured report instead of Markdown — the same data the future Mission Control digest panel will consume (the collection layer lives in `internal/digest` as a reusable API).
+
+Without `--fleet`, the command falls back to the usual config discovery: repeated `--config` flags, a `maestro.d/` directory, or the default single config.
+
+## Scheduling (systemd user timer)
+
+Create `~/.config/systemd/user/maestro-digest.service`:
+
+```ini
+[Unit]
+Description=Maestro morning operator digest
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/maestro digest --fleet %h/.maestro/fleet.yaml --out %h/vault/maestro
+```
+
+And `~/.config/systemd/user/maestro-digest.timer`:
+
+```ini
+[Unit]
+Description=Run the Maestro morning digest every day at 07:00
+
+[Timer]
+OnCalendar=*-*-* 07:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable it:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now maestro-digest.timer
+systemctl --user list-timers maestro-digest.timer
+```
+
+`Persistent=true` makes a missed run (machine asleep at 07:00) fire on the next boot. Use `journalctl --user -u maestro-digest.service` to inspect runs.
+
+## Reading the ranking
+
+Decide-today items carry a score used for ordering only (approvals 100+, retry-exhausted PRs 90, unblocked issues 80, stale review PRs 70+, with risk and age nudges). Promotable issues show their 0–100 self-containedness score inline so the operator can promote the top of the list with `maestro-ready` and skip the tail.
+
+## Out of scope (follow-up)
+
+Rendering the digest as a Mission Control dashboard panel is an explicit follow-up. The MVP keeps collection (`internal/digest.Collect`) separate from rendering (`Report.Markdown`, `Report.NotifySummary`) so the panel can reuse the same data without re-aggregating.

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -1,0 +1,625 @@
+// Package digest aggregates a morning operator report across all configured
+// fleet projects: what needs a decision today, which issues look promotable,
+// and a per-project fleet-health one-liner (#703).
+//
+// The collection layer is deliberately decoupled from the CLI so a Mission
+// Control panel can reuse Collect/CollectProject later: inputs are plain
+// state snapshots plus a narrow read-only GitHub interface, and the output is
+// a serializable Report.
+package digest
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// GitHubReader is the read-only slice of the GitHub client the digest needs.
+// *github.Client satisfies it; tests inject fakes.
+type GitHubReader interface {
+	ListOpenIssues(labels []string) ([]github.Issue, error)
+	ListOpenPRs() ([]github.PR, error)
+	IsIssueClosed(number int) (bool, error)
+	HasMergedPRForIssue(issueNumber int) (bool, error)
+}
+
+// Project is one fleet member's collection input.
+type Project struct {
+	Name  string
+	Repo  string
+	State *state.State
+	GH    GitHubReader
+
+	ReadyLabel      string
+	BlockedLabel    string
+	ExcludedLabels  []string // labels that are never promotable (e.g. epic, meta)
+	BlockerPatterns []string // regexes for "blocked by #N" references in issue bodies
+}
+
+// ProjectFromConfig builds a Project input from a loaded maestro config.
+func ProjectFromConfig(name string, cfg *config.Config, st *state.State, gh GitHubReader) Project {
+	if strings.TrimSpace(name) == "" && cfg != nil {
+		parts := strings.Split(strings.TrimSpace(cfg.Repo), "/")
+		name = parts[len(parts)-1]
+	}
+	p := Project{Name: strings.TrimSpace(name), State: st, GH: gh}
+	if cfg != nil {
+		p.Repo = cfg.Repo
+		p.ReadyLabel = cfg.Supervisor.ReadyLabel
+		p.BlockedLabel = cfg.Supervisor.BlockedLabel
+		p.ExcludedLabels = cfg.Supervisor.ExcludedLabels
+		p.BlockerPatterns = cfg.BlockerPatterns
+	}
+	return p
+}
+
+// Options tunes collection thresholds.
+type Options struct {
+	Now time.Time
+	// StaleReviewAge is the minimum age of unresolved review findings before
+	// the PR is surfaced as a decide-today item. Default 24h.
+	StaleReviewAge time.Duration
+	// HealthWindow is the look-back window for the fleet-health line. Default 24h.
+	HealthWindow time.Duration
+	// MaxPromotable caps the promotable list per project. Default 10.
+	MaxPromotable int
+}
+
+func (o Options) withDefaults() Options {
+	if o.Now.IsZero() {
+		o.Now = time.Now()
+	}
+	if o.StaleReviewAge <= 0 {
+		o.StaleReviewAge = 24 * time.Hour
+	}
+	if o.HealthWindow <= 0 {
+		o.HealthWindow = 24 * time.Hour
+	}
+	if o.MaxPromotable <= 0 {
+		o.MaxPromotable = 10
+	}
+	return o
+}
+
+// ItemKind classifies a digest item for ranking and counting.
+type ItemKind string
+
+const (
+	KindPendingApproval  ItemKind = "pending_approval"
+	KindRetryExhaustedPR ItemKind = "retry_exhausted_pr"
+	KindUnblockedIssue   ItemKind = "unblocked_issue"
+	KindStaleReviewPR    ItemKind = "stale_review_pr"
+	KindPromotable       ItemKind = "promotable"
+)
+
+// Item is one ranked entry in a report section.
+type Item struct {
+	Project string   `json:"project"`
+	Kind    ItemKind `json:"kind"`
+	Title   string   `json:"title"`
+	URL     string   `json:"url,omitempty"`
+	Detail  string   `json:"detail,omitempty"`
+	Score   float64  `json:"score"`
+	// AgeHours is how long the item has been waiting, when known.
+	AgeHours float64 `json:"age_hours,omitempty"`
+}
+
+// Health is the per-project fleet-health rollup over Options.HealthWindow.
+type Health struct {
+	Sessions int            `json:"sessions"`
+	Merged   int            `json:"merged"`
+	Failed   int            `json:"failed"`
+	Backends map[string]int `json:"backends,omitempty"`
+}
+
+// Line renders the health rollup as a single human line.
+func (h Health) Line() string {
+	parts := fmt.Sprintf("%d session(s), %d merged, %d failed", h.Sessions, h.Merged, h.Failed)
+	if len(h.Backends) == 0 {
+		return parts
+	}
+	names := make([]string, 0, len(h.Backends))
+	for name := range h.Backends {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	dist := make([]string, 0, len(names))
+	for _, name := range names {
+		dist = append(dist, fmt.Sprintf("%s ×%d", name, h.Backends[name]))
+	}
+	return parts + " · backends: " + strings.Join(dist, ", ")
+}
+
+// ProjectReport is one project's digest sections.
+type ProjectReport struct {
+	Name        string   `json:"name"`
+	Repo        string   `json:"repo"`
+	DecideToday []Item   `json:"decide_today,omitempty"`
+	Promotable  []Item   `json:"promotable,omitempty"`
+	Health      Health   `json:"health"`
+	Errors      []string `json:"errors,omitempty"`
+}
+
+// Report is the full fleet digest.
+type Report struct {
+	GeneratedAt time.Time       `json:"generated_at"`
+	Projects    []ProjectReport `json:"projects"`
+}
+
+// DecideTodayCount is the number of action items that need an operator
+// decision; the notifier fires when it is > 0.
+func (r *Report) DecideTodayCount() int {
+	n := 0
+	for _, p := range r.Projects {
+		n += len(p.DecideToday)
+	}
+	return n
+}
+
+// PromotableCount is the fleet-wide number of promotable issue candidates.
+func (r *Report) PromotableCount() int {
+	n := 0
+	for _, p := range r.Projects {
+		n += len(p.Promotable)
+	}
+	return n
+}
+
+// Collect builds the fleet digest across all projects.
+func Collect(projects []Project, opts Options) *Report {
+	opts = opts.withDefaults()
+	rep := &Report{GeneratedAt: opts.Now}
+	for _, p := range projects {
+		rep.Projects = append(rep.Projects, CollectProject(p, opts))
+	}
+	return rep
+}
+
+// CollectProject builds one project's digest sections. GitHub failures
+// degrade gracefully: the affected check is skipped or over-reports, and the
+// error is recorded on the project report.
+func CollectProject(p Project, opts Options) ProjectReport {
+	opts = opts.withDefaults()
+	rep := ProjectReport{Name: p.Name, Repo: p.Repo}
+	if p.State == nil {
+		p.State = state.NewState()
+	}
+
+	var issues []github.Issue
+	var openPRs map[int]bool // nil means "unknown" (fetch failed or no reader)
+	if p.GH != nil {
+		var err error
+		issues, err = p.GH.ListOpenIssues(nil)
+		if err != nil {
+			rep.Errors = append(rep.Errors, fmt.Sprintf("list open issues: %v", err))
+			issues = nil
+		}
+		prs, err := p.GH.ListOpenPRs()
+		if err != nil {
+			rep.Errors = append(rep.Errors, fmt.Sprintf("list open PRs: %v", err))
+		} else {
+			openPRs = make(map[int]bool, len(prs))
+			for _, pr := range prs {
+				openPRs[pr.Number] = true
+			}
+		}
+	}
+
+	res := newResolver(p.GH)
+	rep.DecideToday = collectDecideToday(p, issues, openPRs, res, opts)
+	rep.Promotable = collectPromotable(p, issues, res, opts)
+	rep.Health = collectHealth(p.State, opts)
+	rep.Errors = append(rep.Errors, res.errors()...)
+	return rep
+}
+
+// --- Decide today ---
+
+func collectDecideToday(p Project, issues []github.Issue, openPRs map[int]bool, res *resolver, opts Options) []Item {
+	var items []Item
+	items = append(items, pendingApprovalItems(p, opts)...)
+	items = append(items, retryExhaustedItems(p, openPRs, opts)...)
+	items = append(items, unblockedIssueItems(p, issues, res, opts)...)
+	items = append(items, staleReviewItems(p, openPRs, opts)...)
+	rankItems(items)
+	return items
+}
+
+func pendingApprovalItems(p Project, opts Options) []Item {
+	var items []Item
+	for _, a := range p.State.Approvals {
+		if a.Status != state.ApprovalStatusPending {
+			continue
+		}
+		age := opts.Now.Sub(a.CreatedAt)
+		score := 100.0
+		switch strings.ToLower(a.Risk) {
+		case "danger":
+			score += 15
+		case "caution":
+			score += 5
+		}
+		url := ""
+		detail := fmt.Sprintf("approval %s · risk: %s", a.ID, a.Risk)
+		if a.Target != nil {
+			switch {
+			case a.Target.PR > 0:
+				url = prURL(p.Repo, a.Target.PR)
+			case a.Target.Issue > 0:
+				url = issueURL(p.Repo, a.Target.Issue)
+			}
+		}
+		items = append(items, Item{
+			Project:  p.Name,
+			Kind:     KindPendingApproval,
+			Title:    "Approve or reject: " + a.Summary,
+			URL:      url,
+			Detail:   detail,
+			Score:    score,
+			AgeHours: hours(age),
+		})
+	}
+	return items
+}
+
+func retryExhaustedItems(p Project, openPRs map[int]bool, opts Options) []Item {
+	var items []Item
+	seenPR := make(map[int]bool)
+	for _, sess := range p.State.Sessions {
+		if sess == nil || sess.Status != state.StatusRetryExhausted || sess.PRNumber <= 0 {
+			continue
+		}
+		// When the open-PR list is unavailable, over-report rather than hide.
+		if openPRs != nil && !openPRs[sess.PRNumber] {
+			continue
+		}
+		if seenPR[sess.PRNumber] {
+			continue
+		}
+		seenPR[sess.PRNumber] = true
+		var age time.Duration
+		if sess.FinishedAt != nil {
+			age = opts.Now.Sub(*sess.FinishedAt)
+		}
+		items = append(items, Item{
+			Project:  p.Name,
+			Kind:     KindRetryExhaustedPR,
+			Title:    fmt.Sprintf("Retry-exhausted session with open PR #%d (issue #%d: %s)", sess.PRNumber, sess.IssueNumber, sess.IssueTitle),
+			URL:      prURL(p.Repo, sess.PRNumber),
+			Detail:   fmt.Sprintf("retries exhausted after %d attempt(s); decide: merge, repair, or close", sess.RetryCount+1),
+			Score:    90,
+			AgeHours: hours(age),
+		})
+	}
+	return items
+}
+
+func unblockedIssueItems(p Project, issues []github.Issue, res *resolver, opts Options) []Item {
+	if strings.TrimSpace(p.BlockedLabel) == "" {
+		return nil
+	}
+	var items []Item
+	for _, issue := range issues {
+		if !github.HasLabel(issue, []string{p.BlockedLabel}) {
+			continue
+		}
+		deps := mergeRefs(github.FindBlockers(issue.Body, p.BlockerPatterns), github.FindDependencies(issue.Body))
+		if len(deps) == 0 {
+			// No parseable dependencies: operator-gated, never auto-surfaced
+			// (same semantics as the supervisor dependency-unblock controller).
+			continue
+		}
+		resolved, allResolved := res.allResolved(deps)
+		if !allResolved {
+			continue
+		}
+		items = append(items, Item{
+			Project: p.Name,
+			Kind:    KindUnblockedIssue,
+			Title:   fmt.Sprintf("Issue #%d is still labeled `%s` but every blocker is resolved: %s", issue.Number, p.BlockedLabel, issue.Title),
+			URL:     issueURL(p.Repo, issue.Number),
+			Detail:  "resolved dependencies: " + refList(resolved),
+			Score:   80,
+		})
+	}
+	return items
+}
+
+func staleReviewItems(p Project, openPRs map[int]bool, opts Options) []Item {
+	var items []Item
+	seenPR := make(map[int]bool)
+	for _, track := range p.State.ReviewRepairTracks {
+		if !track.Exhausted || track.PRNumber <= 0 || seenPR[track.PRNumber] {
+			continue
+		}
+		since := track.ExhaustedAt
+		if since.IsZero() {
+			since = track.LastDecisionAt
+		}
+		age := opts.Now.Sub(since)
+		if !since.IsZero() && age < opts.StaleReviewAge {
+			continue
+		}
+		if openPRs != nil && !openPRs[track.PRNumber] {
+			continue
+		}
+		seenPR[track.PRNumber] = true
+		detail := fmt.Sprintf("repair budget exhausted after %d attempt(s)", track.Attempts)
+		if s := strings.TrimSpace(track.UnresolvedSummary); s != "" {
+			detail += " · " + s
+		}
+		items = append(items, Item{
+			Project:  p.Name,
+			Kind:     KindStaleReviewPR,
+			Title:    fmt.Sprintf("PR #%d has unresolved review findings older than %s", track.PRNumber, formatDuration(opts.StaleReviewAge)),
+			URL:      prURL(p.Repo, track.PRNumber),
+			Detail:   detail,
+			Score:    70 + min(hours(age)/24, 10),
+			AgeHours: hours(age),
+		})
+	}
+	return items
+}
+
+// --- Promotable ---
+
+func collectPromotable(p Project, issues []github.Issue, res *resolver, opts Options) []Item {
+	var items []Item
+	for _, issue := range issues {
+		if p.ReadyLabel != "" && github.HasLabel(issue, []string{p.ReadyLabel}) {
+			continue
+		}
+		if p.BlockedLabel != "" && github.HasLabel(issue, []string{p.BlockedLabel}) {
+			continue
+		}
+		if len(p.ExcludedLabels) > 0 && github.HasLabel(issue, p.ExcludedLabels) {
+			continue
+		}
+		if p.State.IssueInProgress(issue.Number) || p.State.IssueDone(issue.Number) {
+			continue
+		}
+		deps := mergeRefs(github.FindBlockers(issue.Body, p.BlockerPatterns), github.FindDependencies(issue.Body))
+		if len(deps) > 0 {
+			if _, allResolved := res.allResolved(deps); !allResolved {
+				continue
+			}
+		}
+		score, notes := promotableScore(issue)
+		items = append(items, Item{
+			Project: p.Name,
+			Kind:    KindPromotable,
+			Title:   fmt.Sprintf("#%d %s", issue.Number, issue.Title),
+			URL:     issueURL(p.Repo, issue.Number),
+			Detail:  strings.Join(notes, ", "),
+			Score:   score,
+		})
+	}
+	rankItems(items)
+	if len(items) > opts.MaxPromotable {
+		items = items[:opts.MaxPromotable]
+	}
+	return items
+}
+
+// promotableScore estimates how mergeable/self-contained an issue looks from
+// its title and body alone. Higher is better; the scale is 0–100.
+func promotableScore(issue github.Issue) (float64, []string) {
+	score := 50.0
+	var notes []string
+	body := strings.TrimSpace(issue.Body)
+	lower := strings.ToLower(issue.Title + "\n" + body)
+
+	switch n := len(body); {
+	case n == 0:
+		score -= 20
+		notes = append(notes, "no description")
+	case n < 200:
+		score -= 5
+		notes = append(notes, "thin description")
+	case n <= 4000:
+		score += 10
+		notes = append(notes, "well-scoped description")
+	default:
+		score -= 5
+		notes = append(notes, "very long description")
+	}
+
+	if strings.Contains(lower, "acceptance criteria") {
+		score += 20
+		notes = append(notes, "has acceptance criteria")
+	}
+	if strings.Contains(lower, "affected surfaces") {
+		score += 5
+		notes = append(notes, "names affected surfaces")
+	}
+	for _, kw := range []string{"investigate", "research", "spike", "rfc", "discussion"} {
+		if strings.Contains(strings.ToLower(issue.Title), kw) {
+			score -= 15
+			notes = append(notes, "exploratory ("+kw+")")
+			break
+		}
+	}
+	for _, kw := range []string{"epic", "umbrella", "tracking", "meta"} {
+		if strings.Contains(strings.ToLower(issue.Title), kw) {
+			score -= 25
+			notes = append(notes, "looks like an epic/tracking issue")
+			break
+		}
+	}
+
+	if score < 0 {
+		score = 0
+	}
+	if score > 100 {
+		score = 100
+	}
+	return score, notes
+}
+
+// --- Health ---
+
+func collectHealth(st *state.State, opts Options) Health {
+	h := Health{Backends: make(map[string]int)}
+	cutoff := opts.Now.Add(-opts.HealthWindow)
+	for _, sess := range st.Sessions {
+		if sess == nil {
+			continue
+		}
+		ran := sess.StartedAt.After(cutoff) || (sess.FinishedAt != nil && sess.FinishedAt.After(cutoff))
+		if !ran {
+			continue
+		}
+		h.Sessions++
+		backend := strings.TrimSpace(sess.Backend)
+		if backend == "" {
+			backend = "unknown"
+		}
+		h.Backends[backend]++
+		finishedInWindow := sess.FinishedAt != nil && sess.FinishedAt.After(cutoff)
+		switch sess.Status {
+		case state.StatusDone, state.StatusCodeLanded:
+			if finishedInWindow {
+				h.Merged++
+			}
+		case state.StatusFailed, state.StatusConflictFailed, state.StatusDead, state.StatusRetryExhausted:
+			if finishedInWindow || sess.FinishedAt == nil {
+				h.Failed++
+			}
+		}
+	}
+	if len(h.Backends) == 0 {
+		h.Backends = nil
+	}
+	return h
+}
+
+// --- ranking and helpers ---
+
+// rankItems sorts by score descending, then by age descending (older waits
+// rank higher), then by title for a deterministic order.
+func rankItems(items []Item) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].Score != items[j].Score {
+			return items[i].Score > items[j].Score
+		}
+		if items[i].AgeHours != items[j].AgeHours {
+			return items[i].AgeHours > items[j].AgeHours
+		}
+		return items[i].Title < items[j].Title
+	})
+}
+
+// resolver memoizes per-dependency GitHub lookups so a blocker shared by many
+// issues is fetched once per project. Lookup errors count as "not resolved".
+type resolver struct {
+	gh     GitHubReader
+	memo   map[int]bool
+	errs   []string
+	errSet map[string]bool
+}
+
+func newResolver(gh GitHubReader) *resolver {
+	return &resolver{gh: gh, memo: make(map[int]bool), errSet: make(map[string]bool)}
+}
+
+func (r *resolver) resolved(dep int) bool {
+	if done, ok := r.memo[dep]; ok {
+		return done
+	}
+	done := false
+	if r.gh != nil {
+		closed, err := r.gh.IsIssueClosed(dep)
+		if err != nil {
+			r.recordErr(fmt.Sprintf("check issue #%d closed: %v", dep, err))
+		} else if closed {
+			done = true
+		}
+		if !done {
+			merged, err := r.gh.HasMergedPRForIssue(dep)
+			if err != nil {
+				r.recordErr(fmt.Sprintf("check merged PR for #%d: %v", dep, err))
+			} else if merged {
+				done = true
+			}
+		}
+	}
+	r.memo[dep] = done
+	return done
+}
+
+func (r *resolver) allResolved(deps []int) (resolved []int, all bool) {
+	all = true
+	for _, dep := range deps {
+		if r.resolved(dep) {
+			resolved = append(resolved, dep)
+		} else {
+			all = false
+		}
+	}
+	return resolved, all
+}
+
+func (r *resolver) recordErr(msg string) {
+	if r.errSet[msg] {
+		return
+	}
+	r.errSet[msg] = true
+	r.errs = append(r.errs, msg)
+}
+
+func (r *resolver) errors() []string { return r.errs }
+
+func mergeRefs(groups ...[]int) []int {
+	seen := make(map[int]bool)
+	var refs []int
+	for _, group := range groups {
+		for _, n := range group {
+			if n > 0 && !seen[n] {
+				seen[n] = true
+				refs = append(refs, n)
+			}
+		}
+	}
+	return refs
+}
+
+func refList(refs []int) string {
+	parts := make([]string, len(refs))
+	for i, n := range refs {
+		parts[i] = fmt.Sprintf("#%d", n)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func issueURL(repo string, n int) string {
+	if repo == "" || n <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/%s/issues/%d", repo, n)
+}
+
+func prURL(repo string, n int) string {
+	if repo == "" || n <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/%s/pull/%d", repo, n)
+}
+
+func hours(d time.Duration) float64 {
+	if d <= 0 {
+		return 0
+	}
+	return d.Hours()
+}
+
+func formatDuration(d time.Duration) string {
+	if d%(24*time.Hour) == 0 {
+		return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
+	}
+	return fmt.Sprintf("%dh", int(d/time.Hour))
+}

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -1,0 +1,404 @@
+package digest
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+var now = time.Date(2026, 6, 12, 7, 0, 0, 0, time.UTC)
+
+// makeIssue creates a github.Issue with the given labels (works around json struct tags).
+func makeIssue(number int, title, body string, labelNames ...string) github.Issue {
+	issue := github.Issue{Number: number, Title: title, Body: body}
+	for _, name := range labelNames {
+		issue.Labels = append(issue.Labels, struct {
+			Name string `json:"name"`
+		}{Name: name})
+	}
+	return issue
+}
+
+type fakeGH struct {
+	issues    []github.Issue
+	issuesErr error
+	prs       []github.PR
+	prsErr    error
+	closed    map[int]bool
+	merged    map[int]bool
+	lookupErr error
+}
+
+func (f *fakeGH) ListOpenIssues(labels []string) ([]github.Issue, error) {
+	return f.issues, f.issuesErr
+}
+func (f *fakeGH) ListOpenPRs() ([]github.PR, error) { return f.prs, f.prsErr }
+func (f *fakeGH) IsIssueClosed(n int) (bool, error) {
+	if f.lookupErr != nil {
+		return false, f.lookupErr
+	}
+	return f.closed[n], nil
+}
+func (f *fakeGH) HasMergedPRForIssue(n int) (bool, error) {
+	if f.lookupErr != nil {
+		return false, f.lookupErr
+	}
+	return f.merged[n], nil
+}
+
+func testOptions() Options {
+	return Options{Now: now}
+}
+
+func baseProject(st *state.State, gh GitHubReader) Project {
+	return Project{
+		Name:            "demo",
+		Repo:            "acme/demo",
+		State:           st,
+		GH:              gh,
+		ReadyLabel:      "maestro-ready",
+		BlockedLabel:    "maestro-blocked",
+		ExcludedLabels:  []string{"epic", "meta"},
+		BlockerPatterns: []string{`blocked by.*?#(\d+)`, `depends on.*?#(\d+)`},
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func TestPendingApprovalsRankedByRisk(t *testing.T) {
+	st := state.NewState()
+	st.Approvals = []state.Approval{
+		{ID: "a-safe", Status: state.ApprovalStatusPending, Risk: "safe", Summary: "close issue #1", CreatedAt: now.Add(-time.Hour), Target: &state.SupervisorTarget{Issue: 1}},
+		{ID: "a-danger", Status: state.ApprovalStatusPending, Risk: "danger", Summary: "force merge PR #2", CreatedAt: now.Add(-time.Hour), Target: &state.SupervisorTarget{PR: 2}},
+		{ID: "a-done", Status: state.ApprovalStatusExecuted, Risk: "safe", Summary: "already executed", CreatedAt: now.Add(-time.Hour)},
+	}
+	rep := CollectProject(baseProject(st, &fakeGH{}), testOptions())
+
+	if len(rep.DecideToday) != 2 {
+		t.Fatalf("expected 2 decide-today items, got %d: %+v", len(rep.DecideToday), rep.DecideToday)
+	}
+	if rep.DecideToday[0].Title != "Approve or reject: force merge PR #2" {
+		t.Errorf("danger approval should rank first, got %q", rep.DecideToday[0].Title)
+	}
+	if got, want := rep.DecideToday[0].URL, "https://github.com/acme/demo/pull/2"; got != want {
+		t.Errorf("approval URL = %q, want %q", got, want)
+	}
+	if got, want := rep.DecideToday[1].URL, "https://github.com/acme/demo/issues/1"; got != want {
+		t.Errorf("approval URL = %q, want %q", got, want)
+	}
+}
+
+func TestRetryExhaustedRequiresOpenPR(t *testing.T) {
+	st := state.NewState()
+	st.Sessions = map[string]*state.Session{
+		"w1": {Status: state.StatusRetryExhausted, PRNumber: 10, IssueNumber: 100, IssueTitle: "open pr", FinishedAt: ptrTime(now.Add(-2 * time.Hour))},
+		"w2": {Status: state.StatusRetryExhausted, PRNumber: 11, IssueNumber: 101, IssueTitle: "closed pr", FinishedAt: ptrTime(now.Add(-2 * time.Hour))},
+		"w3": {Status: state.StatusRetryExhausted, PRNumber: 0, IssueNumber: 102, IssueTitle: "no pr"},
+		"w4": {Status: state.StatusFailed, PRNumber: 12, IssueNumber: 103, IssueTitle: "plain failure"},
+	}
+	gh := &fakeGH{prs: []github.PR{{Number: 10}}}
+	rep := CollectProject(baseProject(st, gh), testOptions())
+
+	if len(rep.DecideToday) != 1 {
+		t.Fatalf("expected 1 item, got %d: %+v", len(rep.DecideToday), rep.DecideToday)
+	}
+	item := rep.DecideToday[0]
+	if item.Kind != KindRetryExhaustedPR {
+		t.Errorf("kind = %s, want %s", item.Kind, KindRetryExhaustedPR)
+	}
+	if !strings.Contains(item.Title, "PR #10") || !strings.Contains(item.Title, "issue #100") {
+		t.Errorf("title should reference PR and issue: %q", item.Title)
+	}
+}
+
+func TestRetryExhaustedDedupedByPRAndOverReportsWhenPRListUnavailable(t *testing.T) {
+	st := state.NewState()
+	st.Sessions = map[string]*state.Session{
+		"w1": {Status: state.StatusRetryExhausted, PRNumber: 10, IssueNumber: 100},
+		"w2": {Status: state.StatusRetryExhausted, PRNumber: 10, IssueNumber: 100},
+	}
+	gh := &fakeGH{prsErr: errors.New("gh down")}
+	rep := CollectProject(baseProject(st, gh), testOptions())
+
+	count := 0
+	for _, item := range rep.DecideToday {
+		if item.Kind == KindRetryExhaustedPR {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 deduped retry-exhausted item despite PR list failure, got %d", count)
+	}
+	if len(rep.Errors) == 0 {
+		t.Errorf("expected a collection error recorded for the PR list failure")
+	}
+}
+
+func TestUnblockedIssueSurfacedOnlyWhenAllBlockersResolved(t *testing.T) {
+	st := state.NewState()
+	gh := &fakeGH{
+		issues: []github.Issue{
+			makeIssue(20, "ready to unblock", "Blocked by #5 and depends on #6", "maestro-blocked"),
+			makeIssue(21, "still blocked", "Blocked by #7", "maestro-blocked"),
+			makeIssue(22, "no parseable deps", "Some text", "maestro-blocked"),
+		},
+		closed: map[int]bool{5: true},
+		merged: map[int]bool{6: true},
+	}
+	rep := CollectProject(baseProject(st, gh), testOptions())
+
+	var unblocked []Item
+	for _, item := range rep.DecideToday {
+		if item.Kind == KindUnblockedIssue {
+			unblocked = append(unblocked, item)
+		}
+	}
+	if len(unblocked) != 1 {
+		t.Fatalf("expected exactly 1 unblocked item, got %d: %+v", len(unblocked), unblocked)
+	}
+	if !strings.Contains(unblocked[0].Title, "#20") {
+		t.Errorf("expected issue #20, got %q", unblocked[0].Title)
+	}
+	if !strings.Contains(unblocked[0].Detail, "#5") || !strings.Contains(unblocked[0].Detail, "#6") {
+		t.Errorf("detail should list resolved deps: %q", unblocked[0].Detail)
+	}
+}
+
+func TestStaleReviewFindingsRespectAgeThreshold(t *testing.T) {
+	st := state.NewState()
+	st.ReviewRepairTracks = map[string]state.ReviewRepairTrack{
+		"PR#30@abc": {PRNumber: 30, Attempts: 2, Exhausted: true, ExhaustedAt: now.Add(-30 * time.Hour), UnresolvedSummary: "2 P1 findings"},
+		"PR#31@def": {PRNumber: 31, Attempts: 1, Exhausted: true, ExhaustedAt: now.Add(-2 * time.Hour)},
+		"PR#32@ghi": {PRNumber: 32, Attempts: 1, Exhausted: false},
+	}
+	gh := &fakeGH{prs: []github.PR{{Number: 30}, {Number: 31}, {Number: 32}}}
+	rep := CollectProject(baseProject(st, gh), testOptions())
+
+	var stale []Item
+	for _, item := range rep.DecideToday {
+		if item.Kind == KindStaleReviewPR {
+			stale = append(stale, item)
+		}
+	}
+	if len(stale) != 1 {
+		t.Fatalf("expected 1 stale review item, got %d: %+v", len(stale), stale)
+	}
+	if !strings.Contains(stale[0].Title, "PR #30") {
+		t.Errorf("expected PR #30, got %q", stale[0].Title)
+	}
+	if !strings.Contains(stale[0].Detail, "2 P1 findings") {
+		t.Errorf("detail should carry the unresolved summary: %q", stale[0].Detail)
+	}
+}
+
+func TestDecideTodayKindOrdering(t *testing.T) {
+	st := state.NewState()
+	st.Approvals = []state.Approval{
+		{ID: "a1", Status: state.ApprovalStatusPending, Risk: "safe", Summary: "approve", CreatedAt: now.Add(-time.Hour)},
+	}
+	st.Sessions = map[string]*state.Session{
+		"w1": {Status: state.StatusRetryExhausted, PRNumber: 10, IssueNumber: 100, FinishedAt: ptrTime(now.Add(-time.Hour))},
+	}
+	st.ReviewRepairTracks = map[string]state.ReviewRepairTrack{
+		"PR#30@abc": {PRNumber: 30, Exhausted: true, ExhaustedAt: now.Add(-48 * time.Hour)},
+	}
+	gh := &fakeGH{
+		issues: []github.Issue{makeIssue(20, "unblock me", "Blocked by #5", "maestro-blocked")},
+		prs:    []github.PR{{Number: 10}, {Number: 30}},
+		closed: map[int]bool{5: true},
+	}
+	rep := CollectProject(baseProject(st, gh), testOptions())
+
+	wantOrder := []ItemKind{KindPendingApproval, KindRetryExhaustedPR, KindUnblockedIssue, KindStaleReviewPR}
+	if len(rep.DecideToday) != len(wantOrder) {
+		t.Fatalf("expected %d items, got %d: %+v", len(wantOrder), len(rep.DecideToday), rep.DecideToday)
+	}
+	for i, kind := range wantOrder {
+		if rep.DecideToday[i].Kind != kind {
+			t.Errorf("position %d: got %s, want %s", i, rep.DecideToday[i].Kind, kind)
+		}
+	}
+}
+
+func TestPromotableFiltersAndRanking(t *testing.T) {
+	st := state.NewState()
+	st.Sessions = map[string]*state.Session{
+		"w1": {Status: state.StatusRunning, IssueNumber: 45},
+	}
+	rich := strings.Repeat("Implement the parser for the config file. ", 10) +
+		"\n## Acceptance criteria\n1. parses\n## Affected surfaces\n- internal/config"
+	gh := &fakeGH{
+		issues: []github.Issue{
+			makeIssue(40, "already ready", "body", "maestro-ready"),
+			makeIssue(41, "an epic", "body", "epic"),
+			makeIssue(42, "blocked one", "body", "maestro-blocked"),
+			makeIssue(43, "well specified small fix", rich),
+			makeIssue(44, "vague idea", ""),
+			makeIssue(45, "in progress elsewhere", rich),
+			makeIssue(46, "investigate flaky CI", rich),
+			makeIssue(47, "has open dependency", "Depends on #99\n"+rich),
+		},
+	}
+	rep := CollectProject(baseProject(st, gh), testOptions())
+
+	if len(rep.Promotable) != 3 {
+		t.Fatalf("expected 3 promotable items, got %d: %+v", len(rep.Promotable), rep.Promotable)
+	}
+	if !strings.Contains(rep.Promotable[0].Title, "#43") {
+		t.Errorf("best-specified issue should rank first, got %q", rep.Promotable[0].Title)
+	}
+	if rep.Promotable[0].Score <= rep.Promotable[len(rep.Promotable)-1].Score {
+		t.Errorf("expected strictly ranked scores, got %+v", rep.Promotable)
+	}
+	for _, item := range rep.Promotable {
+		for _, excluded := range []string{"#40", "#41", "#42", "#45", "#47"} {
+			if strings.Contains(item.Title, excluded+" ") {
+				t.Errorf("issue %s should not be promotable: %+v", excluded, item)
+			}
+		}
+		if item.URL == "" {
+			t.Errorf("promotable item should link to the issue: %+v", item)
+		}
+	}
+}
+
+func TestPromotableCapped(t *testing.T) {
+	st := state.NewState()
+	var issues []github.Issue
+	for i := 1; i <= 15; i++ {
+		issues = append(issues, makeIssue(i, "task", "a reasonable description of the work to do"))
+	}
+	gh := &fakeGH{issues: issues}
+	opts := testOptions()
+	opts.MaxPromotable = 5
+	rep := CollectProject(baseProject(st, gh), opts)
+	if len(rep.Promotable) != 5 {
+		t.Fatalf("expected promotable capped at 5, got %d", len(rep.Promotable))
+	}
+}
+
+func TestHealthRollup(t *testing.T) {
+	st := state.NewState()
+	st.Sessions = map[string]*state.Session{
+		"w1": {Status: state.StatusDone, Backend: "claude", StartedAt: now.Add(-3 * time.Hour), FinishedAt: ptrTime(now.Add(-2 * time.Hour))},
+		"w2": {Status: state.StatusCodeLanded, Backend: "claude", StartedAt: now.Add(-5 * time.Hour), FinishedAt: ptrTime(now.Add(-4 * time.Hour))},
+		"w3": {Status: state.StatusFailed, Backend: "codex", StartedAt: now.Add(-6 * time.Hour), FinishedAt: ptrTime(now.Add(-5 * time.Hour))},
+		"w4": {Status: state.StatusRunning, Backend: "gemini", StartedAt: now.Add(-time.Hour)},
+		// Outside the 24h window entirely:
+		"w5": {Status: state.StatusDone, Backend: "claude", StartedAt: now.Add(-50 * time.Hour), FinishedAt: ptrTime(now.Add(-49 * time.Hour))},
+	}
+	rep := CollectProject(baseProject(st, &fakeGH{}), testOptions())
+
+	h := rep.Health
+	if h.Sessions != 4 {
+		t.Errorf("sessions = %d, want 4", h.Sessions)
+	}
+	if h.Merged != 2 {
+		t.Errorf("merged = %d, want 2", h.Merged)
+	}
+	if h.Failed != 1 {
+		t.Errorf("failed = %d, want 1", h.Failed)
+	}
+	if h.Backends["claude"] != 2 || h.Backends["codex"] != 1 || h.Backends["gemini"] != 1 {
+		t.Errorf("backend distribution wrong: %+v", h.Backends)
+	}
+	line := h.Line()
+	for _, want := range []string{"4 session(s)", "2 merged", "1 failed", "claude ×2", "codex ×1", "gemini ×1"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("health line missing %q: %q", want, line)
+		}
+	}
+}
+
+func TestMarkdownReportSectionsAndLinks(t *testing.T) {
+	st := state.NewState()
+	st.Approvals = []state.Approval{
+		{ID: "a1", Status: state.ApprovalStatusPending, Risk: "caution", Summary: "merge PR #9", CreatedAt: now.Add(-time.Hour), Target: &state.SupervisorTarget{PR: 9}},
+	}
+	gh := &fakeGH{
+		issues: []github.Issue{makeIssue(43, "small fix", "Body with acceptance criteria section.\n## Acceptance criteria\n1. works")},
+	}
+	rep := Collect([]Project{baseProject(st, gh)}, testOptions())
+	md := rep.Markdown()
+
+	for _, want := range []string{
+		"# Maestro morning digest — 2026-06-12",
+		"## 1. Decide today (1)",
+		"## 2. Promotable (1)",
+		"## 3. Fleet health (24h)",
+		"https://github.com/acme/demo/pull/9",
+		"https://github.com/acme/demo/issues/43",
+		"**[demo]**",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("markdown missing %q\n---\n%s", want, md)
+		}
+	}
+}
+
+func TestMarkdownEmptyReport(t *testing.T) {
+	rep := Collect([]Project{baseProject(state.NewState(), &fakeGH{})}, testOptions())
+	md := rep.Markdown()
+	if !strings.Contains(md, "Nothing needs an operator decision") {
+		t.Errorf("empty decide-today section should say so:\n%s", md)
+	}
+	if !strings.Contains(md, "No promotable candidates found") {
+		t.Errorf("empty promotable section should say so:\n%s", md)
+	}
+}
+
+func TestNotifySummaryCountsByKind(t *testing.T) {
+	st := state.NewState()
+	st.Approvals = []state.Approval{
+		{ID: "a1", Status: state.ApprovalStatusPending, Risk: "safe", Summary: "one", CreatedAt: now.Add(-time.Hour)},
+		{ID: "a2", Status: state.ApprovalStatusPending, Risk: "safe", Summary: "two", CreatedAt: now.Add(-time.Hour)},
+	}
+	st.Sessions = map[string]*state.Session{
+		"w1": {Status: state.StatusRetryExhausted, PRNumber: 10, IssueNumber: 100},
+	}
+	gh := &fakeGH{prs: []github.PR{{Number: 10}}}
+	rep := Collect([]Project{baseProject(st, gh)}, testOptions())
+
+	if got := rep.DecideTodayCount(); got != 3 {
+		t.Fatalf("DecideTodayCount = %d, want 3", got)
+	}
+	msg := rep.NotifySummary("/vault/digest.md")
+	for _, want := range []string{"3 decision(s)", "2 approval(s)", "1 retry-exhausted PR(s)", "/vault/digest.md", "2026-06-12"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("summary missing %q: %q", want, msg)
+		}
+	}
+}
+
+func TestCollectErrorsRecordedOnIssueListFailure(t *testing.T) {
+	gh := &fakeGH{issuesErr: errors.New("api rate limited")}
+	rep := CollectProject(baseProject(state.NewState(), gh), testOptions())
+	if len(rep.Errors) == 0 {
+		t.Fatalf("expected collection error recorded")
+	}
+	md := Collect([]Project{baseProject(state.NewState(), gh)}, testOptions()).Markdown()
+	if !strings.Contains(md, "Collection warnings") {
+		t.Errorf("markdown should surface collection warnings:\n%s", md)
+	}
+}
+
+func TestResolverLookupErrorMeansUnresolved(t *testing.T) {
+	st := state.NewState()
+	gh := &fakeGH{
+		issues:    []github.Issue{makeIssue(20, "blocked", "Blocked by #5", "maestro-blocked")},
+		lookupErr: errors.New("boom"),
+	}
+	rep := CollectProject(baseProject(st, gh), testOptions())
+	for _, item := range rep.DecideToday {
+		if item.Kind == KindUnblockedIssue {
+			t.Errorf("lookup failure must not surface an unblock item: %+v", item)
+		}
+	}
+	if len(rep.Errors) == 0 {
+		t.Errorf("expected resolver errors recorded")
+	}
+}

--- a/internal/digest/markdown.go
+++ b/internal/digest/markdown.go
@@ -1,0 +1,116 @@
+package digest
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Markdown renders the full report as a vault-friendly Markdown document.
+// Every item links to its GitHub issue/PR when a URL is known.
+func (r *Report) Markdown() string {
+	var b strings.Builder
+	day := r.GeneratedAt.Format("2006-01-02")
+	fmt.Fprintf(&b, "# Maestro morning digest — %s\n\n", day)
+	fmt.Fprintf(&b, "Generated %s · %d project(s) · **%d decision(s) needed** · %d promotable\n\n",
+		r.GeneratedAt.Format("2006-01-02 15:04 MST"), len(r.Projects), r.DecideTodayCount(), r.PromotableCount())
+
+	fmt.Fprintf(&b, "## 1. Decide today (%d)\n\n", r.DecideTodayCount())
+	if r.DecideTodayCount() == 0 {
+		b.WriteString("Nothing needs an operator decision. ✅\n\n")
+	} else {
+		i := 0
+		for _, p := range r.Projects {
+			for _, item := range p.DecideToday {
+				i++
+				writeItemLine(&b, i, item)
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	fmt.Fprintf(&b, "## 2. Promotable (%d)\n\n", r.PromotableCount())
+	if r.PromotableCount() == 0 {
+		b.WriteString("No promotable candidates found.\n\n")
+	} else {
+		b.WriteString("Open issues without the ready label that look runnable, ranked by how self-contained they appear:\n\n")
+		i := 0
+		for _, p := range r.Projects {
+			for _, item := range p.Promotable {
+				i++
+				writeItemLine(&b, i, item)
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("## 3. Fleet health (24h)\n\n")
+	for _, p := range r.Projects {
+		fmt.Fprintf(&b, "- **%s** — %s\n", p.Name, p.Health.Line())
+	}
+	b.WriteString("\n")
+
+	var errLines []string
+	for _, p := range r.Projects {
+		for _, e := range p.Errors {
+			errLines = append(errLines, fmt.Sprintf("- **%s**: %s", p.Name, e))
+		}
+	}
+	if len(errLines) > 0 {
+		b.WriteString("## Collection warnings\n\n")
+		b.WriteString("Some data sources were unavailable; the sections above may be incomplete.\n\n")
+		b.WriteString(strings.Join(errLines, "\n"))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func writeItemLine(b *strings.Builder, i int, item Item) {
+	title := item.Title
+	if item.URL != "" {
+		title = fmt.Sprintf("[%s](%s)", title, item.URL)
+	}
+	fmt.Fprintf(b, "%d. **[%s]** %s", i, item.Project, title)
+	if item.Detail != "" {
+		fmt.Fprintf(b, " — %s", item.Detail)
+	}
+	if item.Kind == KindPromotable {
+		fmt.Fprintf(b, " _(score %.0f)_", item.Score)
+	}
+	b.WriteString("\n")
+}
+
+// NotifySummary renders the short notifier (Telegram) message. reportPath is
+// appended when the Markdown report was written to disk; pass "" otherwise.
+func (r *Report) NotifySummary(reportPath string) string {
+	counts := map[ItemKind]int{}
+	for _, p := range r.Projects {
+		for _, item := range p.DecideToday {
+			counts[item.Kind]++
+		}
+	}
+	var parts []string
+	if n := counts[KindPendingApproval]; n > 0 {
+		parts = append(parts, fmt.Sprintf("%d approval(s)", n))
+	}
+	if n := counts[KindRetryExhaustedPR]; n > 0 {
+		parts = append(parts, fmt.Sprintf("%d retry-exhausted PR(s)", n))
+	}
+	if n := counts[KindUnblockedIssue]; n > 0 {
+		parts = append(parts, fmt.Sprintf("%d unblocked issue(s)", n))
+	}
+	if n := counts[KindStaleReviewPR]; n > 0 {
+		parts = append(parts, fmt.Sprintf("%d stale review PR(s)", n))
+	}
+
+	msg := fmt.Sprintf("🌅 maestro digest %s: %d decision(s) need you",
+		r.GeneratedAt.Format("2006-01-02"), r.DecideTodayCount())
+	if len(parts) > 0 {
+		msg += " (" + strings.Join(parts, ", ") + ")"
+	}
+	msg += fmt.Sprintf(" · %d promotable", r.PromotableCount())
+	if reportPath != "" {
+		msg += " · report: " + reportPath
+	}
+	return msg
+}


### PR DESCRIPTION
Implements #703 (Refs #703 — not auto-closing; operator runtime verification of the timer + notifier delivery is still pending).

## Changes

- New `maestro digest` command: one ranked Markdown report across every fleet project, loaded from `--fleet fleet.yaml`, repeated `--config` flags, `maestro.d/`, or default discovery.
- Report sections, all items linking to their GitHub issue/PR:
  1. **Decide today** — pending supervisor approvals (danger-risk first), retry-exhausted sessions with open PRs, blocked-labeled issues whose blockers are all resolved (closed or PR merged), and PRs whose review-repair budget is exhausted with findings older than `--stale-review-hours` (default 24h).
  2. **Promotable** — open issues without the ready label that look runnable (not epic/meta, not blocked, no unresolved dependencies, not already in progress), scored 0–100 by self-containedness and capped at 10 per project.
  3. **Fleet health (24h)** — per-project sessions run, merges, failures, backend distribution.
- Collection lives in a reusable `internal/digest` API (`Collect`/`CollectProject` + `Report.Markdown`/`NotifySummary`/`--json`) so the follow-up Mission Control panel can consume the same data without re-aggregating.
- Output path configurable via `--out` (directory → `maestro-digest-YYYY-MM-DD.md`, or explicit `.md` path); notifier summary (Telegram direct/OpenClaw) sent only when decide-today items > 0, suppressible with `--notify=false`.
- GitHub API failures degrade gracefully: affected checks skip or over-report and a "Collection warnings" section flags the gap.
- `docs/digest-runbook.md` documents the command, ranking, and a systemd user timer example.

## Testing

- `go test ./...` green (new unit tests cover decide-today ranking/kind ordering, retry-exhausted open-PR filtering + dedup, blocker resolution, stale-review age threshold, promotable filtering/scoring/cap, health rollup, Markdown sections/links, notifier summary counts, and degradation on GitHub errors).
- `go build ./cmd/maestro/`, gofmt clean on changed files.
- Manual smoke test against a temp fleet.yaml + state dir: ranked report rendered, vault file written, GH outage surfaced as collection warnings.

## Still requires runtime verification

- Operator enables the systemd user timer and confirms vault sync + Telegram delivery on the real fleet.

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `maestro digest` command that generates a ranked morning operator report across all fleet projects, writing a vault-friendly Markdown file and optionally sending a Telegram notification when action items exist. The collection logic lives in a new `internal/digest` package designed to be reusable by a future Mission Control panel.

- `internal/digest` implements `Collect`/`CollectProject` with four decide-today categories (pending approvals, retry-exhausted PRs, unblocked issues, stale review PRs) plus promotable-issue scoring and a per-project health rollup; GitHub API failures degrade gracefully with a warnings section.
- `cmd/maestro/digest.go` wires the flags (`--fleet`, `--out`, `--notify`, `--stale-review-hours`, `--json`) and handles file writing and notifier dispatch.
- The core ranking gap: `collectDecideToday` ranks items within each project, but `Markdown()` emits them per-project in insertion order rather than merging and sorting across the fleet; a danger approval in the second listed project will appear below a stale-review item from the first, contrary to the stated \"danger-risk first\" goal.

<h3>Confidence Score: 3/5</h3>

The feature is self-contained and additive; existing commands are unaffected, but the fleet-wide ranking the operator will rely on is not actually implemented in the Markdown output path.

The central value proposition of this command — showing the operator the highest-urgency item first, regardless of which project it belongs to — is not delivered. Markdown() outputs items project-by-project without a global merge-and-sort step, so a danger-level approval in the second project always appears below every item from the first project. For a single-project operator the command works correctly, but the fleet-level use case this MVP is built for will silently mis-rank items on every run.

internal/digest/markdown.go and internal/digest/digest.go need a global ranking pass; cmd/maestro/digest.go has the double-render and --json/--out inconsistency worth resolving before the systemd timer goes live.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/digest/digest.go | Core collection logic for the fleet digest; per-project ranking is correct but global cross-project ranking of DecideToday items is missing, which breaks the stated "danger-risk first across the fleet" promise. |
| internal/digest/markdown.go | Markdown renderer iterates projects in insertion order without a global merge-and-sort of DecideToday items, so cross-project ranking by score is not applied. |
| cmd/maestro/digest.go | CLI wiring for the digest command; calls report.Markdown() twice (minor inefficiency) and --json + --out produce inconsistent output formats between stdout and file. |
| internal/digest/digest_test.go | Comprehensive unit tests covering all four decide-today kinds, promotable filtering/ranking/cap, health rollup, Markdown rendering, and graceful degradation on GitHub errors. |
| cmd/maestro/digest_test.go | Tests for the writeDigestReport helper covering directory and explicit-file path modes; correct and complete. |
| cmd/maestro/main.go | Adds the digest subcommand to the router and usage string; straightforward and correct. |
| docs/digest-runbook.md | Clear runbook documenting flags, scheduling via systemd timer, and ranking semantics; the --json + --out interaction is not documented. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/digest/markdown.go`, line 1389-1401 ([link](https://github.com/befeast/maestro/blob/23749cfdc238ab5b147ee10b3ac118ee21e956ed/internal/digest/markdown.go#L1389-L1401)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Decide Today items are ranked per-project, not across the fleet**

   The PR's stated goal is "one ranked report across every fleet project, danger-risk first." `collectDecideToday` does rank within a project, but `Markdown()` emits items by iterating `r.Projects` in insertion order and then each project's `DecideToday` slice — no global merge-and-sort is applied. With two projects where Project A has a `KindStaleReviewPR` (score 70) and Project B has a `KindPendingApproval` danger (score 115), the danger approval appears second in the numbered list. The operator reading item #1 thinks it is the highest-priority action today, but it may not be.

   A fix is to flatten all `DecideToday` items across `r.Projects`, call `rankItems` on the combined slice, then emit that single sorted list.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/digest/markdown.go
   Line: 1389-1401

   Comment:
   **Decide Today items are ranked per-project, not across the fleet**

   The PR's stated goal is "one ranked report across every fleet project, danger-risk first." `collectDecideToday` does rank within a project, but `Markdown()` emits items by iterating `r.Projects` in insertion order and then each project's `DecideToday` slice — no global merge-and-sort is applied. With two projects where Project A has a `KindStaleReviewPR` (score 70) and Project B has a `KindPendingApproval` danger (score 115), the danger approval appears second in the numbered list. The operator reading item #1 thinks it is the highest-priority action today, but it may not be.

   A fix is to flatten all `DecideToday` items across `r.Projects`, call `rankItems` on the combined slice, then emit that single sorted list.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/digest/markdown.go:1389-1401
**Decide Today items are ranked per-project, not across the fleet**

The PR's stated goal is "one ranked report across every fleet project, danger-risk first." `collectDecideToday` does rank within a project, but `Markdown()` emits items by iterating `r.Projects` in insertion order and then each project's `DecideToday` slice — no global merge-and-sort is applied. With two projects where Project A has a `KindStaleReviewPR` (score 70) and Project B has a `KindPendingApproval` danger (score 115), the danger approval appears second in the numbered list. The operator reading item #1 thinks it is the highest-priority action today, but it may not be.

A fix is to flatten all `DecideToday` items across `r.Projects`, call `rankItems` on the combined slice, then emit that single sorted list.

### Issue 2 of 3
cmd/maestro/digest.go:50-65
`report.Markdown()` is called twice: once to print to stdout and once inside `writeDigestReport`. For a large fleet the Markdown render runs twice needlessly. Cache the result in a variable instead.

```suggestion
	mdReport := report.Markdown()
	if *jsonOut {
		enc := json.NewEncoder(os.Stdout)
		enc.SetIndent("", "  ")
		if err := enc.Encode(report); err != nil {
			log.Fatalf("encode report: %v", err)
		}
	} else {
		fmt.Print(mdReport)
	}

	writtenPath := ""
	if strings.TrimSpace(*outPath) != "" {
		path, err := writeDigestReport(*outPath, mdReport, now)
```

### Issue 3 of 3
cmd/maestro/digest.go:60-68
**`--json` flag does not affect the `--out` file format**

When both `--json` and `--out` are supplied, stdout receives the JSON-encoded report but `writeDigestReport` always writes `report.Markdown()` to the file. A user running `maestro digest --json --out /tmp/report.md` gets a JSON-on-stdout/Markdown-on-disk split with no indication this is intentional. The runbook doc and flag help text don't mention this combination either.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fleet: morning operator digest command —..."](https://github.com/befeast/maestro/commit/23749cfdc238ab5b147ee10b3ac118ee21e956ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37290330)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->