### PR TITLE
verify: opt-in visual-evidence step for UI-affecting PRs (screenshots attached before done)

### DIFF
--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -316,6 +316,42 @@ review_gate_streams:
 
 `review_gate: none` disables all review streams. A blocking simplicity finding is treated like a blocking Greptile finding for merge gating and review-repair.
 
+### Optional: visual evidence for UI-affecting PRs (`verify.visual`)
+
+Green tests are not proof a UI renders correctly. Projects with a screenshot
+harness can opt in to the visual-evidence step (#705):
+
+```yaml
+verify:
+  visual:
+    enabled: true
+    command: ./scripts/capture-screenshots.sh   # launches the app, writes screenshots
+    paths:                                      # globs that classify a PR as UI-affecting
+      - "web/**"
+      - "**/*.jsx"
+    # output_dir: .maestro/screenshots          # default; command also sees $MAESTRO_SCREENSHOT_DIR
+    # timeout_minutes: 10                       # capture command budget
+```
+
+How it behaves:
+
+- Workers get a **Visual Evidence** prompt section: when their diff touches a
+  configured glob, they run the capture command and attach the screenshots to
+  the PR (a comment with embedded images) before declaring done.
+- The orchestrator then checks each UI-affecting PR once. If no image is
+  attached it re-runs the capture command in the session worktree as a
+  diagnostic, posts a single advisory warning comment on the PR, and the
+  supervisor records a `visual_evidence_missing` finding (severity: warning).
+- Non-UI PRs are unaffected. The step never blocks or delays merge in v1 —
+  it makes the missing evidence loud instead of leaving it to the operator's
+  eyes after merge.
+
+The capture command runs from the worktree root with
+`MAESTRO_SCREENSHOT_DIR` set to the absolute output directory. Maestro counts
+`*.png`, `*.jpg`, `*.jpeg`, `*.gif`, and `*.webp` files (recursive) as
+screenshots. `verify.visual.enabled: true` without `command`/`paths` logs a
+config warning and stays inert.
+
 ### Running as a systemd service
 
 ```bash

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -744,6 +744,51 @@ func (p PipelineConfig) TestMappingEnabled() bool {
 	return *p.TestMapping
 }
 
+// VerifyConfig holds opt-in post-implementation verification steps.
+type VerifyConfig struct {
+	Visual VerifyVisualConfig `yaml:"visual"` // #705: visual evidence for UI-affecting PRs
+}
+
+// VerifyVisualConfig configures the opt-in visual-evidence step for
+// UI-affecting PRs (#705). When enabled, workers are instructed to run the
+// project's screenshot harness and attach the resulting images to the PR
+// before declaring done; the orchestrator checks UI-affecting PRs (changed
+// files matching Paths) for attached evidence and posts a warning comment
+// when it is missing. Advisory in v1 — never blocks merge.
+type VerifyVisualConfig struct {
+	Enabled        bool     `yaml:"enabled"`         // opt in per project (default: false)
+	Command        string   `yaml:"command"`         // project script that launches the app and writes screenshots to OutputDir; run from the worktree root
+	Paths          []string `yaml:"paths"`           // globs that classify a PR as UI-affecting (e.g. "**/*.jsx", "web/**"); `**` crosses directories
+	OutputDir      string   `yaml:"output_dir"`      // worktree-relative screenshot directory (default: .maestro/screenshots)
+	TimeoutMinutes int      `yaml:"timeout_minutes"` // capture command budget in minutes (default: 10)
+}
+
+// Active reports whether the visual-evidence step is fully configured:
+// enabled with a capture command and at least one UI path glob. The
+// misconfigured shapes (enabled without command/paths) surface via
+// Config.Warnings instead of half-running.
+func (v VerifyVisualConfig) Active() bool {
+	return v.Enabled && strings.TrimSpace(v.Command) != "" && len(v.Paths) > 0
+}
+
+// ResolvedOutputDir returns the worktree-relative directory the capture
+// command writes screenshots to. Default: .maestro/screenshots.
+func (v VerifyVisualConfig) ResolvedOutputDir() string {
+	dir := strings.TrimSpace(v.OutputDir)
+	if dir == "" {
+		return filepath.Join(".maestro", "screenshots")
+	}
+	return dir
+}
+
+// Timeout returns the capture command budget. Default: 10 minutes.
+func (v VerifyVisualConfig) Timeout() time.Duration {
+	if v.TimeoutMinutes <= 0 {
+		return 10 * time.Minute
+	}
+	return time.Duration(v.TimeoutMinutes) * time.Minute
+}
+
 // MissionsConfig controls mission mode for decomposing epics into child issues.
 type MissionsConfig struct {
 	Enabled     bool     `yaml:"enabled"`
@@ -980,6 +1025,7 @@ type Config struct {
 	AutoRestoreFiles                []string                     `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase
 	CleanupWorktreesOnMerge         *bool                        `yaml:"cleanup_worktrees_on_merge"` // remove worktrees immediately after PR merge (default: true)
 	Pipeline                        PipelineConfig               `yaml:"pipeline"`
+	Verify                          VerifyConfig                 `yaml:"verify"` // #705: opt-in post-implementation verify steps (visual evidence)
 	Hooks                           HooksConfig                  `yaml:"hooks"`
 	Missions                        MissionsConfig               `yaml:"missions"`
 	BlockerPatterns                 []string                     `yaml:"blocker_patterns"`         // regex patterns to detect blocker references in issue body for queue skips and dependency_unblock (e.g. "blocked by #(\\d+)"; first capture group must be issue number)
@@ -1585,7 +1631,31 @@ func (c *Config) Warnings() []string {
 		warnings = append(warnings, msg)
 	}
 	warnings = append(warnings, c.backendResolutionWarnings()...)
+	if msg := c.verifyVisualWarning(); msg != "" {
+		warnings = append(warnings, msg)
+	}
 	return warnings
+}
+
+// verifyVisualWarning surfaces a verify.visual block that is enabled but
+// cannot run (#705): without a capture command or UI path globs the step is
+// silently inert, which reads as "visual evidence is covered" when it is not.
+func (c *Config) verifyVisualWarning() string {
+	v := c.Verify.Visual
+	if !v.Enabled || v.Active() {
+		return ""
+	}
+	var missing []string
+	if strings.TrimSpace(v.Command) == "" {
+		missing = append(missing, "verify.visual.command")
+	}
+	if len(v.Paths) == 0 {
+		missing = append(missing, "verify.visual.paths")
+	}
+	return fmt.Sprintf(
+		"config: verify.visual.enabled is true but %s is not set — the visual-evidence step is inert. Set a capture command and UI path globs, or disable verify.visual.",
+		strings.Join(missing, " and "),
+	)
 }
 
 // manualRoutingLabelPinWarning surfaces the #427 misconfiguration where the

--- a/internal/config/verify_visual_test.go
+++ b/internal/config/verify_visual_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParse_VerifyVisualConfig(t *testing.T) {
+	yaml := `
+repo: owner/repo
+local_path: /tmp/repo
+verify:
+  visual:
+    enabled: true
+    command: ./scripts/capture-screenshots.sh
+    paths:
+      - "**/*.jsx"
+      - "web/**"
+    output_dir: artifacts/shots
+    timeout_minutes: 5
+`
+	cfg, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	v := cfg.Verify.Visual
+	if !v.Enabled {
+		t.Fatal("verify.visual.enabled should parse as true")
+	}
+	if v.Command != "./scripts/capture-screenshots.sh" {
+		t.Fatalf("command = %q", v.Command)
+	}
+	if len(v.Paths) != 2 || v.Paths[0] != "**/*.jsx" || v.Paths[1] != "web/**" {
+		t.Fatalf("paths = %v", v.Paths)
+	}
+	if !v.Active() {
+		t.Fatal("fully configured verify.visual should be Active")
+	}
+	if v.ResolvedOutputDir() != "artifacts/shots" {
+		t.Fatalf("ResolvedOutputDir = %q", v.ResolvedOutputDir())
+	}
+	if v.Timeout() != 5*time.Minute {
+		t.Fatalf("Timeout = %v", v.Timeout())
+	}
+}
+
+func TestParse_VerifyVisualDefaultsOff(t *testing.T) {
+	cfg, err := Parse([]byte("repo: owner/repo\nlocal_path: /tmp/repo\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	v := cfg.Verify.Visual
+	if v.Enabled || v.Active() {
+		t.Fatal("verify.visual must default to disabled")
+	}
+	if got, want := v.ResolvedOutputDir(), filepath.Join(".maestro", "screenshots"); got != want {
+		t.Fatalf("default output dir = %q, want %q", got, want)
+	}
+	if v.Timeout() != 10*time.Minute {
+		t.Fatalf("default timeout = %v, want 10m", v.Timeout())
+	}
+}
+
+func TestVerifyVisualActive(t *testing.T) {
+	cases := []struct {
+		name string
+		v    VerifyVisualConfig
+		want bool
+	}{
+		{"disabled", VerifyVisualConfig{Command: "x", Paths: []string{"web/**"}}, false},
+		{"no command", VerifyVisualConfig{Enabled: true, Paths: []string{"web/**"}}, false},
+		{"blank command", VerifyVisualConfig{Enabled: true, Command: "  ", Paths: []string{"web/**"}}, false},
+		{"no paths", VerifyVisualConfig{Enabled: true, Command: "x"}, false},
+		{"configured", VerifyVisualConfig{Enabled: true, Command: "x", Paths: []string{"web/**"}}, true},
+	}
+	for _, tc := range cases {
+		if got := tc.v.Active(); got != tc.want {
+			t.Errorf("%s: Active() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestWarnings_VerifyVisualMisconfigured(t *testing.T) {
+	t.Run("enabled without command and paths", func(t *testing.T) {
+		cfg := &Config{Verify: VerifyConfig{Visual: VerifyVisualConfig{Enabled: true}}}
+		warnings := cfg.Warnings()
+		found := false
+		for _, w := range warnings {
+			if strings.Contains(w, "verify.visual.command and verify.visual.paths") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected verify.visual warning, got %v", warnings)
+		}
+	})
+
+	t.Run("enabled without paths", func(t *testing.T) {
+		cfg := &Config{Verify: VerifyConfig{Visual: VerifyVisualConfig{Enabled: true, Command: "./capture.sh"}}}
+		warnings := cfg.Warnings()
+		found := false
+		for _, w := range warnings {
+			if strings.Contains(w, "verify.visual.paths") && !strings.Contains(w, "verify.visual.command") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected paths-only warning, got %v", warnings)
+		}
+	})
+
+	t.Run("fully configured is silent", func(t *testing.T) {
+		cfg := &Config{Verify: VerifyConfig{Visual: VerifyVisualConfig{
+			Enabled: true, Command: "./capture.sh", Paths: []string{"web/**"},
+		}}}
+		for _, w := range cfg.Warnings() {
+			if strings.Contains(w, "verify.visual") {
+				t.Fatalf("unexpected verify.visual warning: %s", w)
+			}
+		}
+	})
+
+	t.Run("disabled is silent", func(t *testing.T) {
+		cfg := &Config{}
+		for _, w := range cfg.Warnings() {
+			if strings.Contains(w, "verify.visual") {
+				t.Fatalf("unexpected verify.visual warning: %s", w)
+			}
+		}
+	})
+}

--- a/internal/github/visual_evidence.go
+++ b/internal/github/visual_evidence.go
@@ -1,0 +1,88 @@
+package github
+
+// Visual-evidence helpers for the opt-in verify.visual step (#705): list a
+// PR's changed files so the orchestrator can classify it as UI-affecting,
+// and detect whether screenshot evidence (an embedded image) is already
+// attached to the PR body or any comment.
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// PRChangedFiles returns the repo-relative paths changed by a PR.
+func (c *Client) PRChangedFiles(prNumber int) ([]string, error) {
+	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/files?per_page=100", c.Repo, prNumber), "--paginate")
+	if err != nil {
+		return nil, fmt.Errorf("list PR %d files: %w", prNumber, err)
+	}
+	files, err := parsePRChangedFiles(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse PR %d files: %w", prNumber, err)
+	}
+	return files, nil
+}
+
+func parsePRChangedFiles(out []byte) ([]string, error) {
+	var entries []struct {
+		Filename string `json:"filename"`
+	}
+	if err := json.Unmarshal(out, &entries); err != nil {
+		return nil, err
+	}
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if name := strings.TrimSpace(entry.Filename); name != "" {
+			files = append(files, name)
+		}
+	}
+	return files, nil
+}
+
+// PRVisualEvidenceAttached reports whether the PR body or any issue comment
+// embeds an image — markdown image syntax, an <img> tag, or a bare link to
+// an image file — which is how workers attach screenshot evidence.
+func (c *Client) PRVisualEvidenceAttached(prNumber int) (bool, error) {
+	pr, err := c.getRESTPull(prNumber)
+	if err != nil {
+		return false, fmt.Errorf("get PR %d: %w", prNumber, err)
+	}
+	if pr.Body != nil && ContainsEmbeddedImage(*pr.Body) {
+		return true, nil
+	}
+
+	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
+	if err != nil {
+		return false, fmt.Errorf("list PR %d comments: %w", prNumber, err)
+	}
+	comments, err := parseIssueComments(out)
+	if err != nil {
+		return false, fmt.Errorf("parse PR %d comments: %w", prNumber, err)
+	}
+	for _, comment := range comments {
+		if ContainsEmbeddedImage(comment.Body) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+var (
+	markdownImageRe = regexp.MustCompile(`!\[[^\]]*\]\([^)]+\)`)
+	imageURLRe      = regexp.MustCompile(`(?i)https?://\S+\.(png|jpe?g|gif|webp)(\?\S*)?\b`)
+	imgTagRe        = regexp.MustCompile(`(?i)<img\s[^>]*src\s*=`)
+)
+
+// ContainsEmbeddedImage reports whether markdown text embeds an image:
+// `![alt](url)`, an `<img src=...>` tag, or a link to a *.png/jpg/jpeg/
+// gif/webp URL (GitHub renders user-images attachment links inline).
+func ContainsEmbeddedImage(text string) bool {
+	if strings.TrimSpace(text) == "" {
+		return false
+	}
+	return markdownImageRe.MatchString(text) ||
+		imgTagRe.MatchString(text) ||
+		imageURLRe.MatchString(text)
+}

--- a/internal/github/visual_evidence_test.go
+++ b/internal/github/visual_evidence_test.go
@@ -1,0 +1,50 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePRChangedFiles(t *testing.T) {
+	out := []byte(`[
+		{"filename": "web/src/App.jsx", "status": "modified"},
+		{"filename": "internal/api/server.go", "status": "added"},
+		{"filename": "  "}
+	]`)
+	files, err := parsePRChangedFiles(out)
+	if err != nil {
+		t.Fatalf("parsePRChangedFiles: %v", err)
+	}
+	want := []string{"web/src/App.jsx", "internal/api/server.go"}
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files = %v, want %v", files, want)
+	}
+}
+
+func TestParsePRChangedFiles_Invalid(t *testing.T) {
+	if _, err := parsePRChangedFiles([]byte("not json")); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestContainsEmbeddedImage(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"markdown image", "### Visual evidence\n![home](https://raw.githubusercontent.com/o/r/abc/.maestro/screenshots/home.png)", true},
+		{"img tag", `before <img src="https://example.com/shot.png" width="400"> after`, true},
+		{"user-images link", "see https://user-images.githubusercontent.com/123/shot-1.PNG for evidence", true},
+		{"bare jpeg url", "uploaded to https://example.com/captures/page.jpeg?raw=true", true},
+		{"plain text", "no screenshots here, tests pass", false},
+		{"non-image link", "see https://example.com/report.html", false},
+		{"link text mentioning png", "the file home.png is in the repo", false},
+		{"empty", "  ", false},
+	}
+	for _, tc := range cases {
+		if got := ContainsEmbeddedImage(tc.text); got != tc.want {
+			t.Errorf("%s: ContainsEmbeddedImage = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -103,27 +103,30 @@ type Orchestrator struct {
 	restartRequiredReason string
 
 	// Testing hooks for autoMergePRs / mergeReadyPR
-	ghPRCIStatusFn              func(prNumber int) (string, error)
-	ghPRMergeStatusFn           func(prNumber int) (mergeable string, mergeStateStatus string, err error)
-	ghPRGreptileApprovedFn      func(prNumber int) (approved bool, pending bool, err error)
-	ghPRReviewGateVerdictFn     func(prNumber int, streams []string) (github.ReviewGateVerdict, error)
-	ghPRHasCriticalReviewFn     func(prNumber int) (bool, error)
-	ghUpdateBranchFn            func(prNumber int) error
-	ghMarkPRReadyFn             func(prNumber int) error
-	ghMergePRFn                 func(prNumber int) error
-	ghClosePRFn                 func(prNumber int, comment string) error
-	ghPRChecksOutputFn          func(prNumber int) (string, error)
-	ghCollectPRReviewFeedbackFn func(prNumber int) (string, error)
-	ghCloseIssueFn              func(number int, comment string) error
-	ghPRHeadSHAFn               func(prNumber int) (string, error)
-	ghCommentPRFn               func(prNumber int, body string) error
-	workerStopFn                func(cfg *config.Config, slotName string, sess *state.Session) error
-	selfDeployStartFn           func(prNumber int) error
-	rebaseWorktreeFn            func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
-	outcomeCheckFn              func(context.Context, outcome.Brief) outcome.HealthCheckResult
-	syncProjectFn               func(issueNumber int, status github.ProjectStatus) bool
-	listNonDoneProjectItemsFn   func(pf *github.ProjectField) ([]github.ProjectItem, error)
-	rateLimitFn                 func() (github.RateLimitStatus, error)
+	ghPRCIStatusFn               func(prNumber int) (string, error)
+	ghPRMergeStatusFn            func(prNumber int) (mergeable string, mergeStateStatus string, err error)
+	ghPRGreptileApprovedFn       func(prNumber int) (approved bool, pending bool, err error)
+	ghPRReviewGateVerdictFn      func(prNumber int, streams []string) (github.ReviewGateVerdict, error)
+	ghPRHasCriticalReviewFn      func(prNumber int) (bool, error)
+	ghUpdateBranchFn             func(prNumber int) error
+	ghMarkPRReadyFn              func(prNumber int) error
+	ghMergePRFn                  func(prNumber int) error
+	ghClosePRFn                  func(prNumber int, comment string) error
+	ghPRChecksOutputFn           func(prNumber int) (string, error)
+	ghCollectPRReviewFeedbackFn  func(prNumber int) (string, error)
+	ghCloseIssueFn               func(number int, comment string) error
+	ghPRHeadSHAFn                func(prNumber int) (string, error)
+	ghCommentPRFn                func(prNumber int, body string) error
+	ghPRChangedFilesFn           func(prNumber int) ([]string, error)
+	ghPRVisualEvidenceAttachedFn func(prNumber int) (bool, error)
+	runVisualCaptureFn           func(v config.VerifyVisualConfig, worktreePath string) ([]string, error)
+	workerStopFn                 func(cfg *config.Config, slotName string, sess *state.Session) error
+	selfDeployStartFn            func(prNumber int) error
+	rebaseWorktreeFn             func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
+	outcomeCheckFn               func(context.Context, outcome.Brief) outcome.HealthCheckResult
+	syncProjectFn                func(issueNumber int, status github.ProjectStatus) bool
+	listNonDoneProjectItemsFn    func(pf *github.ProjectField) ([]github.ProjectItem, error)
+	rateLimitFn                  func() (github.RateLimitStatus, error)
 }
 
 // New creates a new Orchestrator
@@ -2707,6 +2710,11 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		}
 		o.ensureAttributionTrailerOnPR(slotName, sess, pr)
 		o.ensureAttributionTrailerOnBranch(slotName, sess)
+
+		// #705: opt-in visual evidence for UI-affecting PRs. One-shot,
+		// advisory — posts a warning comment when evidence is missing but
+		// never blocks or delays the merge flow below.
+		o.ensureVisualEvidence(slotName, sess, pr)
 
 		// Check CI
 		ciStatus, err := o.prCIStatus(pr.Number)

--- a/internal/orchestrator/visual_evidence.go
+++ b/internal/orchestrator/visual_evidence.go
@@ -1,0 +1,147 @@
+package orchestrator
+
+// Opt-in visual-evidence verify for UI-affecting PRs (#705).
+//
+// When verify.visual is configured, workers are instructed (via the prompt)
+// to capture screenshots and attach them to the PR before declaring done.
+// The merge flow then runs a one-shot post-implementation check per session:
+// classify the PR by its changed files against the configured globs, and —
+// when it is UI-affecting but carries no attached image evidence — run the
+// capture command in the session worktree as a best-effort diagnostic, post
+// ONE warning comment on the PR, and stamp the session so the supervisor
+// records a visual_evidence_missing finding. The check is advisory in v1:
+// it never blocks or delays merge.
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/pipeline"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func (o *Orchestrator) prChangedFiles(prNumber int) ([]string, error) {
+	if o.ghPRChangedFilesFn != nil {
+		return o.ghPRChangedFilesFn(prNumber)
+	}
+	if o.gh == nil {
+		return nil, fmt.Errorf("no github client configured for changed files")
+	}
+	return o.gh.PRChangedFiles(prNumber)
+}
+
+func (o *Orchestrator) prVisualEvidenceAttached(prNumber int) (bool, error) {
+	if o.ghPRVisualEvidenceAttachedFn != nil {
+		return o.ghPRVisualEvidenceAttachedFn(prNumber)
+	}
+	if o.gh == nil {
+		return false, fmt.Errorf("no github client configured for visual evidence")
+	}
+	return o.gh.PRVisualEvidenceAttached(prNumber)
+}
+
+// ensureVisualEvidence runs the one-shot verify.visual check for a session's
+// open PR. Transient GitHub read errors leave the session unstamped so the
+// next cycle retries; every terminal outcome stamps sess.VisualEvidence so
+// the check (and its warning comment) never repeats for this session.
+func (o *Orchestrator) ensureVisualEvidence(slotName string, sess *state.Session, pr github.PR) {
+	if o == nil || o.cfg == nil || sess == nil {
+		return
+	}
+	visual := o.cfg.Verify.Visual
+	if !visual.Active() {
+		return
+	}
+	if sess.VisualEvidence != "" {
+		return // one-shot per session
+	}
+
+	files, err := o.prChangedFiles(pr.Number)
+	if err != nil {
+		log.Printf("[orch] verify.visual: changed-files lookup for PR #%d failed (will retry next cycle): %v", pr.Number, err)
+		return
+	}
+	matched := pipeline.MatchUIAffectingFiles(visual.Paths, files)
+	if len(matched) == 0 {
+		sess.VisualEvidence = state.VisualEvidenceNotRequired
+		return
+	}
+
+	attached, err := o.prVisualEvidenceAttached(pr.Number)
+	if err != nil {
+		log.Printf("[orch] verify.visual: evidence lookup for PR #%d failed (will retry next cycle): %v", pr.Number, err)
+		return
+	}
+	if attached {
+		sess.VisualEvidence = state.VisualEvidenceAttached
+		log.Printf("[orch] verify.visual: PR #%d (%s) is UI-affecting and has visual evidence attached", pr.Number, slotName)
+		return
+	}
+
+	// Post-implementation verify: the worker declared done without attaching
+	// evidence. Run the capture command in the session worktree so the warning
+	// can say whether the harness itself works.
+	detail := o.runVisualCaptureFallback(sess, visual)
+	sess.VisualEvidence = state.VisualEvidenceMissing
+	sess.VisualEvidenceDetail = detail
+	log.Printf("[orch] verify.visual: PR #%d (%s) is UI-affecting with no visual evidence — %s", pr.Number, slotName, detail)
+
+	if err := o.commentPR(pr.Number, visualEvidenceWarningComment(matched, detail)); err != nil {
+		log.Printf("[orch] verify.visual: warning comment on PR #%d failed: %v", pr.Number, err)
+	}
+	o.notifier.Sendf("⚠️ maestro: PR #%d (issue #%d: %s) touches UI paths but has no visual evidence attached — %s",
+		pr.Number, sess.IssueNumber, sess.IssueTitle, detail)
+}
+
+// runVisualCaptureFallback executes the configured capture command in the
+// session worktree and describes the outcome in one operator-facing sentence.
+// Best-effort: every failure mode degrades to a description, never an error.
+func (o *Orchestrator) runVisualCaptureFallback(sess *state.Session, visual config.VerifyVisualConfig) string {
+	runCapture := pipeline.RunVisualCapture
+	if o.runVisualCaptureFn != nil {
+		runCapture = o.runVisualCaptureFn
+	}
+
+	worktree := strings.TrimSpace(sess.Worktree)
+	if worktree == "" {
+		return "no worktree is recorded for the session, so the capture command could not be run"
+	}
+	if info, err := os.Stat(worktree); err != nil || !info.IsDir() {
+		return fmt.Sprintf("worktree %s is gone, so the capture command could not be run", worktree)
+	}
+
+	shots, err := runCapture(visual, worktree)
+	if err != nil {
+		return fmt.Sprintf("capture command failed: %v", err)
+	}
+	if len(shots) == 0 {
+		return fmt.Sprintf("capture command succeeded but produced no screenshots in %s", visual.ResolvedOutputDir())
+	}
+	return fmt.Sprintf("capture command produced %d screenshot(s) in %s on the worker worktree, but none are attached to the PR", len(shots), visual.ResolvedOutputDir())
+}
+
+// visualEvidenceWarningComment renders the single advisory comment posted on
+// a UI-affecting PR that lacks attached screenshots.
+func visualEvidenceWarningComment(matchedFiles []string, detail string) string {
+	const maxListed = 5
+	listed := matchedFiles
+	more := ""
+	if len(listed) > maxListed {
+		more = fmt.Sprintf("\n- … and %d more", len(listed)-maxListed)
+		listed = listed[:maxListed]
+	}
+	var b strings.Builder
+	b.WriteString("⚠️ **maestro verify.visual:** this PR changes UI paths but no visual evidence (screenshots) is attached.\n\n")
+	b.WriteString("UI-affecting files:\n")
+	for _, f := range listed {
+		fmt.Fprintf(&b, "- `%s`\n", f)
+	}
+	b.WriteString(more)
+	fmt.Fprintf(&b, "\nCapture status: %s.\n\n", detail)
+	b.WriteString("This does not block merge (v1) — please verify the rendered UI manually, or run the project's `verify.visual` capture command and attach the screenshots to this PR.")
+	return b.String()
+}

--- a/internal/orchestrator/visual_evidence_test.go
+++ b/internal/orchestrator/visual_evidence_test.go
@@ -1,0 +1,218 @@
+package orchestrator
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func visualTestConfig() *config.Config {
+	return &config.Config{
+		Repo: "owner/repo",
+		Verify: config.VerifyConfig{Visual: config.VerifyVisualConfig{
+			Enabled: true,
+			Command: "./capture.sh",
+			Paths:   []string{"web/**", "**/*.jsx"},
+		}},
+	}
+}
+
+func visualTestOrchestrator(cfg *config.Config) (*Orchestrator, *[]string) {
+	comments := &[]string{}
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		ghCommentPRFn: func(prNumber int, body string) error {
+			*comments = append(*comments, body)
+			return nil
+		},
+		runVisualCaptureFn: func(v config.VerifyVisualConfig, worktreePath string) ([]string, error) {
+			return nil, fmt.Errorf("capture command failed: exit 1")
+		},
+	}
+	return o, comments
+}
+
+func TestEnsureVisualEvidence_NonUIPRUnaffected(t *testing.T) {
+	o, comments := visualTestOrchestrator(visualTestConfig())
+	o.ghPRChangedFilesFn = func(prNumber int) ([]string, error) {
+		return []string{"internal/api/server.go", "docs/readme.md"}, nil
+	}
+	o.ghPRVisualEvidenceAttachedFn = func(prNumber int) (bool, error) {
+		t.Fatal("non-UI PR must not check for attached evidence")
+		return false, nil
+	}
+
+	sess := &state.Session{IssueNumber: 1, Status: state.StatusPROpen, Worktree: t.TempDir()}
+	o.ensureVisualEvidence("slot-0", sess, github.PR{Number: 12})
+
+	if sess.VisualEvidence != state.VisualEvidenceNotRequired {
+		t.Fatalf("VisualEvidence = %q, want %q", sess.VisualEvidence, state.VisualEvidenceNotRequired)
+	}
+	if len(*comments) != 0 {
+		t.Fatalf("non-UI PR must not get a warning comment, got %v", *comments)
+	}
+}
+
+func TestEnsureVisualEvidence_AttachedEvidencePasses(t *testing.T) {
+	o, comments := visualTestOrchestrator(visualTestConfig())
+	o.ghPRChangedFilesFn = func(prNumber int) ([]string, error) {
+		return []string{"web/src/app.css"}, nil
+	}
+	o.ghPRVisualEvidenceAttachedFn = func(prNumber int) (bool, error) {
+		return true, nil
+	}
+
+	sess := &state.Session{IssueNumber: 2, Status: state.StatusPROpen, Worktree: t.TempDir()}
+	o.ensureVisualEvidence("slot-0", sess, github.PR{Number: 13})
+
+	if sess.VisualEvidence != state.VisualEvidenceAttached {
+		t.Fatalf("VisualEvidence = %q, want %q", sess.VisualEvidence, state.VisualEvidenceAttached)
+	}
+	if len(*comments) != 0 {
+		t.Fatalf("attached evidence must not warn, got %v", *comments)
+	}
+}
+
+func TestEnsureVisualEvidence_MissingEvidenceWarnsOnce(t *testing.T) {
+	o, comments := visualTestOrchestrator(visualTestConfig())
+	o.ghPRChangedFilesFn = func(prNumber int) ([]string, error) {
+		return []string{"web/src/app.css", "src/Panel.jsx"}, nil
+	}
+	o.ghPRVisualEvidenceAttachedFn = func(prNumber int) (bool, error) {
+		return false, nil
+	}
+
+	sess := &state.Session{IssueNumber: 3, IssueTitle: "ui work", Status: state.StatusPROpen, Worktree: t.TempDir()}
+	pr := github.PR{Number: 14}
+	o.ensureVisualEvidence("slot-0", sess, pr)
+
+	if sess.VisualEvidence != state.VisualEvidenceMissing {
+		t.Fatalf("VisualEvidence = %q, want %q", sess.VisualEvidence, state.VisualEvidenceMissing)
+	}
+	if !strings.Contains(sess.VisualEvidenceDetail, "capture command failed") {
+		t.Fatalf("VisualEvidenceDetail = %q, want capture failure detail", sess.VisualEvidenceDetail)
+	}
+	if len(*comments) != 1 {
+		t.Fatalf("expected exactly one warning comment, got %d", len(*comments))
+	}
+	for _, want := range []string{
+		"verify.visual",
+		"`web/src/app.css`",
+		"`src/Panel.jsx`",
+		"capture command failed",
+		"does not block merge",
+	} {
+		if !strings.Contains((*comments)[0], want) {
+			t.Fatalf("warning comment missing %q:\n%s", want, (*comments)[0])
+		}
+	}
+
+	// Second cycle: one-shot guard suppresses a repeat comment.
+	o.ensureVisualEvidence("slot-0", sess, pr)
+	if len(*comments) != 1 {
+		t.Fatalf("warning comment must not repeat, got %d", len(*comments))
+	}
+}
+
+func TestEnsureVisualEvidence_CaptureProducesOutputButUnattachedStillWarns(t *testing.T) {
+	o, comments := visualTestOrchestrator(visualTestConfig())
+	o.ghPRChangedFilesFn = func(prNumber int) ([]string, error) {
+		return []string{"web/index.html"}, nil
+	}
+	o.ghPRVisualEvidenceAttachedFn = func(prNumber int) (bool, error) {
+		return false, nil
+	}
+	o.runVisualCaptureFn = func(v config.VerifyVisualConfig, worktreePath string) ([]string, error) {
+		return []string{".maestro/screenshots/home.png"}, nil
+	}
+
+	sess := &state.Session{IssueNumber: 4, Status: state.StatusPROpen, Worktree: t.TempDir()}
+	o.ensureVisualEvidence("slot-0", sess, github.PR{Number: 15})
+
+	if sess.VisualEvidence != state.VisualEvidenceMissing {
+		t.Fatalf("VisualEvidence = %q, want %q", sess.VisualEvidence, state.VisualEvidenceMissing)
+	}
+	if !strings.Contains(sess.VisualEvidenceDetail, "none are attached") {
+		t.Fatalf("VisualEvidenceDetail = %q", sess.VisualEvidenceDetail)
+	}
+	if len(*comments) != 1 {
+		t.Fatalf("expected one warning comment, got %d", len(*comments))
+	}
+}
+
+func TestEnsureVisualEvidence_TransientErrorRetriesNextCycle(t *testing.T) {
+	o, comments := visualTestOrchestrator(visualTestConfig())
+	o.ghPRChangedFilesFn = func(prNumber int) ([]string, error) {
+		return nil, fmt.Errorf("api rate limited")
+	}
+
+	sess := &state.Session{IssueNumber: 5, Status: state.StatusPROpen, Worktree: t.TempDir()}
+	o.ensureVisualEvidence("slot-0", sess, github.PR{Number: 16})
+
+	if sess.VisualEvidence != "" {
+		t.Fatalf("transient error must leave the session unstamped, got %q", sess.VisualEvidence)
+	}
+	if len(*comments) != 0 {
+		t.Fatalf("transient error must not comment, got %v", *comments)
+	}
+}
+
+func TestEnsureVisualEvidence_InactiveConfigDoesNothing(t *testing.T) {
+	cfg := &config.Config{Repo: "owner/repo"} // verify.visual not configured
+	o, comments := visualTestOrchestrator(cfg)
+	o.ghPRChangedFilesFn = func(prNumber int) ([]string, error) {
+		t.Fatal("inactive verify.visual must not list changed files")
+		return nil, nil
+	}
+
+	sess := &state.Session{IssueNumber: 6, Status: state.StatusPROpen}
+	o.ensureVisualEvidence("slot-0", sess, github.PR{Number: 17})
+
+	if sess.VisualEvidence != "" || len(*comments) != 0 {
+		t.Fatalf("inactive config must be a no-op, got status=%q comments=%v", sess.VisualEvidence, *comments)
+	}
+}
+
+func TestEnsureVisualEvidence_MissingWorktreeStillWarns(t *testing.T) {
+	o, comments := visualTestOrchestrator(visualTestConfig())
+	o.ghPRChangedFilesFn = func(prNumber int) ([]string, error) {
+		return []string{"web/app.jsx"}, nil
+	}
+	o.ghPRVisualEvidenceAttachedFn = func(prNumber int) (bool, error) {
+		return false, nil
+	}
+	o.runVisualCaptureFn = func(v config.VerifyVisualConfig, worktreePath string) ([]string, error) {
+		t.Fatal("capture must not run without a worktree")
+		return nil, nil
+	}
+
+	sess := &state.Session{IssueNumber: 7, Status: state.StatusPROpen, Worktree: "/no/such/worktree"}
+	o.ensureVisualEvidence("slot-0", sess, github.PR{Number: 18})
+
+	if sess.VisualEvidence != state.VisualEvidenceMissing {
+		t.Fatalf("VisualEvidence = %q, want %q", sess.VisualEvidence, state.VisualEvidenceMissing)
+	}
+	if !strings.Contains(sess.VisualEvidenceDetail, "could not be run") {
+		t.Fatalf("VisualEvidenceDetail = %q", sess.VisualEvidenceDetail)
+	}
+	if len(*comments) != 1 {
+		t.Fatalf("expected one warning comment, got %d", len(*comments))
+	}
+}
+
+func TestVisualEvidenceWarningCommentTruncatesFileList(t *testing.T) {
+	files := []string{"a.jsx", "b.jsx", "c.jsx", "d.jsx", "e.jsx", "f.jsx", "g.jsx"}
+	comment := visualEvidenceWarningComment(files, "capture command failed: exit 1")
+	if !strings.Contains(comment, "… and 2 more") {
+		t.Fatalf("expected truncation marker in comment:\n%s", comment)
+	}
+	if strings.Contains(comment, "`g.jsx`") {
+		t.Fatalf("files beyond the cap must not be listed:\n%s", comment)
+	}
+}

--- a/internal/pipeline/visual.go
+++ b/internal/pipeline/visual.go
@@ -1,0 +1,164 @@
+package pipeline
+
+// Visual-evidence verify step (#705). Opt-in per project via verify.visual:
+// a project-specific capture command produces screenshots for UI-affecting
+// changes, classified by glob patterns over the PR's changed files. The
+// helpers here are deterministic and side-effect free except for
+// RunVisualCapture, which executes the configured command.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// visualImageExtensions are the file extensions counted as screenshot output.
+var visualImageExtensions = map[string]bool{
+	".png":  true,
+	".jpg":  true,
+	".jpeg": true,
+	".gif":  true,
+	".webp": true,
+}
+
+// MatchesVisualPath reports whether a repo-relative file path matches one
+// doublestar-style glob pattern. A `**` segment matches any number of path
+// segments (including zero); other segments use path.Match semantics
+// (`*`, `?`, `[...]` within a single segment). A pattern with a trailing
+// slash is treated as a directory prefix (`web/` ≡ `web/**`).
+func MatchesVisualPath(pattern, file string) bool {
+	pattern = normalizeVisualPath(pattern)
+	file = normalizeVisualPath(file)
+	if pattern == "" || file == "" {
+		return false
+	}
+	if strings.HasSuffix(pattern, "/") {
+		pattern += "**"
+	}
+	return matchVisualSegments(strings.Split(pattern, "/"), strings.Split(file, "/"))
+}
+
+func normalizeVisualPath(p string) string {
+	p = strings.ReplaceAll(strings.TrimSpace(p), "\\", "/")
+	return strings.TrimPrefix(p, "./")
+}
+
+func matchVisualSegments(pattern, parts []string) bool {
+	if len(pattern) == 0 {
+		return len(parts) == 0
+	}
+	if pattern[0] == "**" {
+		for skip := 0; skip <= len(parts); skip++ {
+			if matchVisualSegments(pattern[1:], parts[skip:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(parts) == 0 {
+		return false
+	}
+	ok, err := path.Match(pattern[0], parts[0])
+	if err != nil || !ok {
+		return false
+	}
+	return matchVisualSegments(pattern[1:], parts[1:])
+}
+
+// MatchUIAffectingFiles returns the subset of changed files that match any
+// of the configured UI path globs, preserving input order. An empty result
+// means the change is not UI-affecting.
+func MatchUIAffectingFiles(patterns, changedFiles []string) []string {
+	if len(patterns) == 0 || len(changedFiles) == 0 {
+		return nil
+	}
+	var matched []string
+	for _, file := range changedFiles {
+		for _, pattern := range patterns {
+			if MatchesVisualPath(pattern, file) {
+				matched = append(matched, file)
+				break
+			}
+		}
+	}
+	return matched
+}
+
+// RunVisualCapture executes the configured capture command from the worktree
+// root and returns the worktree-relative paths of image files found in the
+// output directory afterwards, sorted lexically. The command sees the
+// absolute output directory as $MAESTRO_SCREENSHOT_DIR. A non-zero exit or
+// timeout returns an error together with whatever screenshots already exist —
+// callers treat both as advisory (warning + finding), never as a merge block.
+func RunVisualCapture(v config.VerifyVisualConfig, worktreePath string) ([]string, error) {
+	command := strings.TrimSpace(v.Command)
+	if command == "" {
+		return nil, fmt.Errorf("verify.visual: no capture command configured")
+	}
+
+	outputDir := filepath.Join(worktreePath, v.ResolvedOutputDir())
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("verify.visual: create output dir: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), v.Timeout())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd.Dir = worktreePath
+	cmd.Env = append(os.Environ(), "MAESTRO_SCREENSHOT_DIR="+outputDir)
+	out, err := cmd.CombinedOutput()
+
+	shots := ListScreenshots(worktreePath, v.ResolvedOutputDir())
+	if ctx.Err() == context.DeadlineExceeded {
+		return shots, fmt.Errorf("verify.visual: capture command timed out after %s", v.Timeout())
+	}
+	if err != nil {
+		return shots, fmt.Errorf("verify.visual: capture command failed: %v: %s", err, firstOutputLine(out))
+	}
+	return shots, nil
+}
+
+// ListScreenshots returns worktree-relative paths of image files under the
+// output directory (recursive), sorted lexically. A missing directory yields
+// an empty list.
+func ListScreenshots(worktreePath, outputDir string) []string {
+	root := filepath.Join(worktreePath, outputDir)
+	var shots []string
+	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil //nolint:nilerr // best-effort scan: skip unreadable entries
+		}
+		if !visualImageExtensions[strings.ToLower(filepath.Ext(p))] {
+			return nil
+		}
+		if rel, relErr := filepath.Rel(worktreePath, p); relErr == nil {
+			shots = append(shots, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	sort.Strings(shots)
+	return shots
+}
+
+func firstOutputLine(out []byte) string {
+	text := strings.TrimSpace(string(out))
+	if text == "" {
+		return "(no output)"
+	}
+	if idx := strings.IndexByte(text, '\n'); idx >= 0 {
+		text = text[:idx]
+	}
+	const maxLen = 200
+	if len(text) > maxLen {
+		text = text[:maxLen] + "…"
+	}
+	return text
+}

--- a/internal/pipeline/visual_test.go
+++ b/internal/pipeline/visual_test.go
@@ -1,0 +1,132 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+func TestMatchesVisualPath(t *testing.T) {
+	cases := []struct {
+		pattern string
+		file    string
+		want    bool
+	}{
+		{"**/*.jsx", "src/App.jsx", true},
+		{"**/*.jsx", "App.jsx", true}, // ** matches zero segments
+		{"**/*.jsx", "src/App.tsx", false},
+		{"web/**", "web/src/Button.tsx", true},
+		{"web/**", "web", true},
+		{"web/**", "server/main.go", false},
+		{"web/", "web/styles/app.css", true}, // trailing slash = directory prefix
+		{"web/src/*.css", "web/src/app.css", true},
+		{"web/src/*.css", "web/src/nested/app.css", false}, // single * does not cross /
+		{"*.css", "web/app.css", false},                    // root-level only without **
+		{"*.css", "app.css", true},
+		{"**/components/**/*.vue", "web/src/components/ui/Button.vue", true},
+		{"./web/**", "web/index.html", true}, // leading ./ normalized
+		{"", "web/app.css", false},
+		{"web/**", "", false},
+	}
+	for _, tc := range cases {
+		if got := MatchesVisualPath(tc.pattern, tc.file); got != tc.want {
+			t.Errorf("MatchesVisualPath(%q, %q) = %v, want %v", tc.pattern, tc.file, got, tc.want)
+		}
+	}
+}
+
+func TestMatchUIAffectingFiles(t *testing.T) {
+	patterns := []string{"**/*.jsx", "web/**"}
+	files := []string{"internal/api/server.go", "web/src/app.css", "src/Panel.jsx", "README.md"}
+
+	got := MatchUIAffectingFiles(patterns, files)
+	want := []string{"web/src/app.css", "src/Panel.jsx"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MatchUIAffectingFiles = %v, want %v", got, want)
+	}
+
+	if got := MatchUIAffectingFiles(patterns, []string{"cmd/main.go", "docs/x.md"}); len(got) != 0 {
+		t.Fatalf("non-UI files should not match, got %v", got)
+	}
+	if got := MatchUIAffectingFiles(nil, files); len(got) != 0 {
+		t.Fatalf("no patterns should match nothing, got %v", got)
+	}
+}
+
+func TestRunVisualCapture_Succeeds(t *testing.T) {
+	worktree := t.TempDir()
+	v := config.VerifyVisualConfig{
+		Enabled: true,
+		Command: `mkdir -p "$MAESTRO_SCREENSHOT_DIR" && touch "$MAESTRO_SCREENSHOT_DIR/home.png" "$MAESTRO_SCREENSHOT_DIR/notes.txt"`,
+		Paths:   []string{"web/**"},
+	}
+
+	shots, err := RunVisualCapture(v, worktree)
+	if err != nil {
+		t.Fatalf("RunVisualCapture: %v", err)
+	}
+	want := []string{".maestro/screenshots/home.png"}
+	if !reflect.DeepEqual(shots, want) {
+		t.Fatalf("screenshots = %v, want %v (non-image files must be ignored)", shots, want)
+	}
+}
+
+func TestRunVisualCapture_CommandFails(t *testing.T) {
+	worktree := t.TempDir()
+	v := config.VerifyVisualConfig{
+		Enabled: true,
+		Command: "echo capture exploded >&2; exit 3",
+		Paths:   []string{"web/**"},
+	}
+
+	shots, err := RunVisualCapture(v, worktree)
+	if err == nil {
+		t.Fatal("expected error from failing capture command")
+	}
+	if len(shots) != 0 {
+		t.Fatalf("expected no screenshots, got %v", shots)
+	}
+}
+
+func TestRunVisualCapture_NoOutput(t *testing.T) {
+	worktree := t.TempDir()
+	v := config.VerifyVisualConfig{
+		Enabled: true,
+		Command: "true",
+		Paths:   []string{"web/**"},
+	}
+
+	shots, err := RunVisualCapture(v, worktree)
+	if err != nil {
+		t.Fatalf("RunVisualCapture: %v", err)
+	}
+	if len(shots) != 0 {
+		t.Fatalf("expected zero screenshots for no-op command, got %v", shots)
+	}
+}
+
+func TestListScreenshots_MissingDirAndNesting(t *testing.T) {
+	worktree := t.TempDir()
+	if got := ListScreenshots(worktree, "no/such/dir"); len(got) != 0 {
+		t.Fatalf("missing dir should yield no screenshots, got %v", got)
+	}
+
+	nested := filepath.Join(worktree, "shots", "pages")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"b.PNG", "a.jpeg"} {
+		if err := os.WriteFile(filepath.Join(nested, name), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := ListScreenshots(worktree, "shots")
+	want := []string{"shots/pages/a.jpeg", "shots/pages/b.PNG"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListScreenshots = %v, want %v", got, want)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -159,6 +159,14 @@ type Session struct {
 	CheckpointFile              string            `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
 	DeploymentFinishedAt        *time.Time        `json:"deployment_finished_at,omitempty"`         // set when the post-merge deploy hook succeeds
 
+	// #705: opt-in verify.visual outcome for this session's PR. Set once by
+	// the orchestrator's merge flow: "not_required" (no UI paths touched),
+	// "attached" (evidence found on the PR), or "missing" (UI-affecting PR
+	// without attached evidence — warning comment posted, supervisor records
+	// a finding). Empty until checked. Advisory only; never blocks merge.
+	VisualEvidence       string `json:"visual_evidence,omitempty"`
+	VisualEvidenceDetail string `json:"visual_evidence_detail,omitempty"` // operator-facing detail for the "missing" case
+
 	// #691: greptile webhook-miss self-heal. The orchestrator tracks how
 	// long the review gate has been greptile=pending on one head SHA; past
 	// the configured threshold it posts "@greptile review" on the PR
@@ -188,6 +196,18 @@ type Session struct {
 	// then 4m on codex gpt-5.5 medium after rate-limit fallover".
 	Attribution []BackendAttribution `json:"attribution,omitempty"`
 }
+
+// Session.VisualEvidence outcomes for the opt-in verify.visual step (#705).
+const (
+	// VisualEvidenceNotRequired: the PR touches no configured UI paths.
+	VisualEvidenceNotRequired = "not_required"
+	// VisualEvidenceAttached: image evidence was found on the PR.
+	VisualEvidenceAttached = "attached"
+	// VisualEvidenceMissing: UI-affecting PR without attached evidence —
+	// the orchestrator posted a warning comment and the supervisor records
+	// a visual_evidence_missing finding. Advisory; never blocks merge.
+	VisualEvidenceMissing = "missing"
+)
 
 // BackendAttribution is one segment of a session's backend timeline.
 // A session has at least one (the initial spawn) and gains more if the

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1026,7 +1026,42 @@ func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.
 	findings = append(findings, e.detectBackendAuthFailureStuckStates(st, now)...)
 	findings = append(findings, e.detectBackendQuotaPressureStuckStates(st, now)...)
 	findings = append(findings, e.detectOutcomeStuckStates(st)...)
+	findings = append(findings, detectVisualEvidenceStuckStates(st)...)
 	return compactStuckStates(findings)
+}
+
+// detectVisualEvidenceStuckStates surfaces UI-affecting PRs that reached the
+// merge flow without attached screenshot evidence (#705). The orchestrator
+// stamps Session.VisualEvidence after its one-shot verify.visual check; this
+// finding keeps the gap visible to the operator while the PR is still in
+// flight. Advisory by design: SeverityWarning, never a merge block.
+func detectVisualEvidenceStuckStates(st *state.State) []state.SupervisorStuckState {
+	if st == nil {
+		return nil
+	}
+	var findings []state.SupervisorStuckState
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess == nil || sess.VisualEvidence != state.VisualEvidenceMissing || sess.PRNumber <= 0 {
+			continue
+		}
+		switch sess.Status {
+		case state.StatusPROpen, state.StatusQueued, state.StatusRetryExhausted:
+		default:
+			continue // PR no longer in flight — the finding self-clears
+		}
+		evidence := []string{fmt.Sprintf("Session %s status=%s pr=%d visual_evidence=missing", slot, sess.Status, sess.PRNumber)}
+		if detail := strings.TrimSpace(sess.VisualEvidenceDetail); detail != "" {
+			evidence = append(evidence, detail)
+		}
+		findings = append(findings, stuckState("visual_evidence_missing", SeverityWarning,
+			fmt.Sprintf("PR #%d (issue #%d) touches UI paths but has no visual evidence attached.", sess.PRNumber, sess.IssueNumber),
+			"Run the project's verify.visual capture command and attach the screenshots to the PR, or verify the rendered UI manually before merge. Does not block merge (v1).",
+			false,
+			&state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot},
+			evidence...))
+	}
+	return findings
 }
 
 // detectBackendAuthFailureStuckStates surfaces backends gated by an

--- a/internal/supervisor/visual_evidence_test.go
+++ b/internal/supervisor/visual_evidence_test.go
@@ -1,0 +1,84 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestDetectVisualEvidenceStuckStates(t *testing.T) {
+	st := state.NewState()
+	st.Sessions["sup-1"] = &state.Session{
+		IssueNumber:          705,
+		PRNumber:             710,
+		Status:               state.StatusPROpen,
+		VisualEvidence:       state.VisualEvidenceMissing,
+		VisualEvidenceDetail: "capture command failed: exit 1",
+	}
+	// Stamped but fine — no finding.
+	st.Sessions["sup-2"] = &state.Session{
+		IssueNumber:    1,
+		PRNumber:       2,
+		Status:         state.StatusPROpen,
+		VisualEvidence: state.VisualEvidenceAttached,
+	}
+	st.Sessions["sup-3"] = &state.Session{
+		IssueNumber:    3,
+		PRNumber:       4,
+		Status:         state.StatusPROpen,
+		VisualEvidence: state.VisualEvidenceNotRequired,
+	}
+	// Missing evidence but the session is terminal — self-clears.
+	st.Sessions["sup-4"] = &state.Session{
+		IssueNumber:    5,
+		PRNumber:       6,
+		Status:         state.StatusDone,
+		VisualEvidence: state.VisualEvidenceMissing,
+	}
+	// Not yet checked — no finding.
+	st.Sessions["sup-5"] = &state.Session{
+		IssueNumber: 7,
+		PRNumber:    8,
+		Status:      state.StatusPROpen,
+	}
+
+	findings := detectVisualEvidenceStuckStates(st)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one finding, got %d: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Code != "visual_evidence_missing" {
+		t.Fatalf("Code = %q", f.Code)
+	}
+	if f.Severity != SeverityWarning {
+		t.Fatalf("Severity = %q, want %q (advisory, never a merge block)", f.Severity, SeverityWarning)
+	}
+	if f.SupervisorCanAct {
+		t.Fatal("visual_evidence_missing must not be supervisor-actionable in v1")
+	}
+	if !strings.Contains(f.Summary, "PR #710") || !strings.Contains(f.Summary, "issue #705") {
+		t.Fatalf("Summary = %q", f.Summary)
+	}
+	if f.Target == nil || f.Target.PR != 710 || f.Target.Issue != 705 || f.Target.Session != "sup-1" {
+		t.Fatalf("Target = %+v", f.Target)
+	}
+	foundDetail := false
+	for _, e := range f.Evidence {
+		if strings.Contains(e, "capture command failed") {
+			foundDetail = true
+		}
+	}
+	if !foundDetail {
+		t.Fatalf("Evidence missing capture detail: %v", f.Evidence)
+	}
+}
+
+func TestDetectVisualEvidenceStuckStates_EmptyState(t *testing.T) {
+	if got := detectVisualEvidenceStuckStates(nil); len(got) != 0 {
+		t.Fatalf("nil state should yield no findings, got %v", got)
+	}
+	if got := detectVisualEvidenceStuckStates(state.NewState()); len(got) != 0 {
+		t.Fatalf("empty state should yield no findings, got %v", got)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -824,6 +824,42 @@ func repoRulesPromptSection(worktreePath string) string {
 	return ""
 }
 
+// visualEvidencePromptSection instructs the worker to attach screenshot
+// evidence to UI-affecting PRs before declaring done (#705). Returns the
+// empty string unless verify.visual is fully configured (enabled + command +
+// paths). The section is advisory for the worker but the orchestrator checks
+// the PR afterwards and posts a warning when the evidence is missing.
+func visualEvidencePromptSection(cfg *config.Config) string {
+	visual := cfg.Verify.Visual
+	if !visual.Active() {
+		return ""
+	}
+
+	globs := make([]string, 0, len(visual.Paths))
+	for _, p := range visual.Paths {
+		globs = append(globs, "`"+p+"`")
+	}
+
+	var b strings.Builder
+	b.WriteString("\n\n---\n\n## Visual Evidence (UI changes)\n\n")
+	b.WriteString("This project has Maestro's `verify.visual` step enabled: UI-affecting PRs must carry screenshot evidence (a PR comment with images) before you declare done. Maestro checks the PR afterwards and posts a warning if the evidence is missing.\n\n")
+	fmt.Fprintf(&b, "- UI path globs: %s\n", strings.Join(globs, ", "))
+	fmt.Fprintf(&b, "- Capture command (run from the worktree root): `%s`\n", visual.Command)
+	fmt.Fprintf(&b, "- Screenshot output directory: `%s`\n\n", visual.ResolvedOutputDir())
+	b.WriteString("After implementing and committing, before declaring done:\n\n")
+	b.WriteString("1. Run `git diff --name-only origin/main...HEAD`. If NO changed file matches the globs above, skip the rest of this section — non-UI PRs are unaffected.\n")
+	b.WriteString("2. Run the capture command from the worktree root. It launches the app and writes screenshots to the output directory.\n")
+	fmt.Fprintf(&b, "3. Confirm at least one image (png/jpg/jpeg/gif/webp) exists in `%s`.\n", visual.ResolvedOutputDir())
+	fmt.Fprintf(&b, "4. Attach the screenshots to the PR as a comment with embedded images. Unless the repository rules define another evidence channel, commit the screenshots on your branch inside `%s` (this evidence directory is the one exception to the no-artifacts rule), push, then post a PR comment embedding each image pinned to the commit SHA, e.g.:\n", visual.ResolvedOutputDir())
+	b.WriteString("   ```bash\n")
+	b.WriteString("   sha=$(git rev-parse HEAD)\n")
+	fmt.Fprintf(&b, "   gh pr comment <PR_NUMBER> --repo %s --body \"### 📸 Visual evidence\n", cfg.Repo)
+	fmt.Fprintf(&b, "   ![home](https://raw.githubusercontent.com/%s/$sha/%s/home.png)\"\n", cfg.Repo, visual.ResolvedOutputDir())
+	b.WriteString("   ```\n")
+	b.WriteString("5. If the capture command fails or produces no screenshots, post a PR comment briefly explaining why visual evidence could not be captured, then continue — do NOT block the PR on it; Maestro records a finding for the operator.\n")
+	return b.String()
+}
+
 // assemblePrompt builds the final worker prompt.
 // If the base template contains {{ISSUE_NUMBER}} placeholders, it performs
 // template substitution. Otherwise it falls back to appending a task block.
@@ -860,7 +896,7 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 		}
 
 		r := strings.NewReplacer(replacements...)
-		result := r.Replace(base) + repoRulesPromptSection(worktreePath) + workerSearchSafetyPromptSection(worktreePath)
+		result := r.Replace(base) + repoRulesPromptSection(worktreePath) + workerSearchSafetyPromptSection(worktreePath) + visualEvidencePromptSection(cfg)
 		return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, contractInlined)
 	}
 
@@ -907,6 +943,7 @@ Always rebase on origin/main immediately before creating the PR.
 	)
 	result += repoRulesPromptSection(worktreePath)
 	result += workerSearchSafetyPromptSection(worktreePath)
+	result += visualEvidencePromptSection(cfg)
 	return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, false)
 }
 

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -211,6 +211,73 @@ func TestAssemblePromptRepoRulesSanitizesInvalidUTF8(t *testing.T) {
 	}
 }
 
+func TestAssemblePromptIncludesVisualEvidenceSectionWhenActive(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "BeFeast/panoptikon",
+		Verify: config.VerifyConfig{Visual: config.VerifyVisualConfig{
+			Enabled: true,
+			Command: "./scripts/capture-screenshots.sh",
+			Paths:   []string{"**/*.jsx", "web/**"},
+		}},
+	}
+	issue := github.Issue{Number: 705, Title: "ui change", Body: "body"}
+
+	for name, base := range map[string]string{
+		"template": "base prompt {{ISSUE_NUMBER}}",
+		"legacy":   "base prompt",
+	} {
+		t.Run(name, func(t *testing.T) {
+			prompt := assemblePrompt(base, issue, t.TempDir(), "feat/ui", cfg)
+			for _, want := range []string{
+				"## Visual Evidence (UI changes)",
+				"`**/*.jsx`, `web/**`",
+				"`./scripts/capture-screenshots.sh`",
+				"`.maestro/screenshots`",
+				"git diff --name-only origin/main...HEAD",
+				"do NOT block the PR on it",
+			} {
+				if !strings.Contains(prompt, want) {
+					t.Fatalf("assemblePrompt() missing %q\nprompt:\n%s", want, prompt)
+				}
+			}
+		})
+	}
+}
+
+func TestAssemblePromptOmitsVisualEvidenceSectionWhenInactive(t *testing.T) {
+	for name, cfg := range map[string]*config.Config{
+		"disabled": {Repo: "owner/repo"},
+		"enabled but unconfigured": {
+			Repo:   "owner/repo",
+			Verify: config.VerifyConfig{Visual: config.VerifyVisualConfig{Enabled: true}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			issue := github.Issue{Number: 1, Title: "t", Body: "b"}
+			prompt := assemblePrompt("base prompt {{ISSUE_NUMBER}}", issue, t.TempDir(), "feat/x", cfg)
+			if strings.Contains(prompt, "Visual Evidence (UI changes)") {
+				t.Fatalf("visual evidence section should be omitted\nprompt:\n%s", prompt)
+			}
+		})
+	}
+}
+
+func TestWorkerPromptTemplateExplainsVisualEvidenceAttachment(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "worker-prompt-template.md"))
+	if err != nil {
+		t.Fatalf("read worker-prompt-template.md: %v", err)
+	}
+	prompt := string(data)
+	for _, want := range []string{
+		"Visual Evidence",
+		"verify.visual",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("worker-prompt-template.md missing %q", want)
+		}
+	}
+}
+
 // --- Tests from main: validation contract placeholder ---
 
 func TestAssemblePrompt_ValidationContractFromFile(t *testing.T) {

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -132,6 +132,23 @@ worker_prompt: /path/to/worker-prompt-template.md
 #   # script: ./scripts/self-deploy.sh                # default: <local_path>/scripts/self-deploy.sh
 #   # timeout_minutes: 30                             # build+restart+verify budget (covers drain)
 
+# Opt-in visual evidence for UI-affecting PRs (#705). When a PR's changed
+# files match any of the path globs, the worker is instructed to run the
+# capture command (a project-specific script that launches the app and writes
+# screenshots to output_dir) and attach the images to the PR before declaring
+# done. Missing/failed evidence produces a warning comment on the PR and a
+# supervisor finding — it never blocks merge in v1. The command runs from the
+# worktree root with $MAESTRO_SCREENSHOT_DIR set to the absolute output dir.
+# verify:
+#   visual:
+#     enabled: true
+#     command: ./scripts/capture-screenshots.sh
+#     paths:
+#       - "web/**"
+#       - "**/*.jsx"
+#     # output_dir: .maestro/screenshots   # default
+#     # timeout_minutes: 10                # default
+
 # Stale supervisor sessions are filtered out of the Fleet API attention list
 # under two independent conditions: (a) idle past idle_after_minutes AND the
 # recorded worktree is missing on disk (when require_worktree_missing=true),

--- a/worker-prompt-template.md
+++ b/worker-prompt-template.md
@@ -93,6 +93,7 @@ When rebasing conflicts in these files: **keep BOTH sides**. Your additions + wh
 
 ### 7. Done means done
 Once you've opened a PR:
+- If Maestro appended a **Visual Evidence** section to this prompt (the project has `verify.visual` enabled) and your diff touches the listed UI path globs: run the capture command, then attach the resulting screenshots to the PR as a comment with embedded images BEFORE declaring done. If the capture fails, post a PR comment saying so instead — do not block the PR on it.
 - Preserve any `Maestro-Backend:` attribution trailer Maestro adds to commit messages or PR bodies.
 - Verify CI started with REST only:
   `sha=$(gh api repos/OWNER/REPO/pulls/PR_NUMBER --jq .head.sha) && gh api repos/OWNER/REPO/commits/$sha/check-runs --jq '.check_runs[] | {name,status,conclusion}'`


### PR DESCRIPTION
Implements #705 (Refs #705 — not auto-closing: operator should verify the step end-to-end on a real UI project before closing).

## Changes

- **Config**: new opt-in `verify.visual` block — `{enabled, command, paths, output_dir, timeout_minutes}`. `command` is the project's screenshot harness (run from the worktree root, sees `$MAESTRO_SCREENSHOT_DIR`); `paths` are doublestar globs that classify a PR as UI-affecting. Enabled-but-incomplete config logs a startup warning and stays inert.
- **Pipeline** (`internal/pipeline/visual.go`): glob matcher (`**` crosses directories), UI-affecting classification of changed files, and a timeout-bounded capture runner that scans the output dir for images.
- **Worker prompt**: when active, `assemblePrompt` appends a *Visual Evidence* section instructing the worker to diff against the globs, run the capture command, and attach the screenshots to the PR (comment with embedded images) before declaring done. `worker-prompt-template.md` documents the attachment step.
- **Orchestrator**: one-shot post-implementation check per session in the merge flow. UI-affecting PRs without attached image evidence get a best-effort capture re-run in the session worktree (diagnostic), a single advisory warning comment, and a `visual_evidence` stamp on the session. Non-UI PRs are unaffected. Never blocks or delays merge (v1).
- **Supervisor**: records a `visual_evidence_missing` finding (severity: warning, not supervisor-actionable) while the PR is in flight; self-clears once the session leaves the merge flow.
- **GitHub client**: `PRChangedFiles` and `PRVisualEvidenceAttached` (markdown image / `<img>` / image-URL detection over PR body + comments).
- **Docs**: `docs/project-setup-runbook.md` section + `maestro.yaml.example` block.

## Testing

- Unit tests for: config parse/defaults/`Active()`/warnings, glob path-matching and UI classification, capture runner (success/failure/no-output), image-evidence detection, worker prompt gating (active/inactive, template+legacy paths), orchestrator gating (non-UI unaffected, attached passes, missing warns exactly once, transient errors retry, inactive no-op, missing worktree), supervisor finding.
- `go build ./cmd/maestro/`, `go test ./...` (all packages), and the generated `.maestro/verify.sh` all pass after rebasing on origin/main.

## Still requires runtime verification

End-to-end behavior on a real project with a screenshot harness (worker actually attaching images, warning comment on a live PR) has not been exercised — config is opt-in and default-off, so existing projects are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an opt-in `verify.visual` step that instructs workers to capture and attach screenshots for UI-affecting PRs, then performs a post-implementation check in the orchestrator's merge flow to warn when evidence is missing.

- **Config + pipeline**: `VerifyVisualConfig` with `Active()` guard and a hand-rolled doublestar glob matcher classify changed files against configured UI path patterns; `RunVisualCapture` executes the project's screenshot harness in a timeout-bounded subprocess.
- **Orchestrator**: `ensureVisualEvidence` runs once per session in the merge flow, posting a warning PR comment and recording a supervisor finding when a UI-affecting PR lacks attached images.
- **Worker prompt**: `visualEvidencePromptSection` appends step-by-step capture instructions (including a bash attachment example) only when `verify.visual` is fully configured; non-UI projects are unaffected.

<h3>Confidence Score: 3/5</h3>

Safe for existing projects (feature is default-off), but the on-PR warning comment — the primary signal for PR authors — can be silently and permanently dropped if commentPR encounters a transient error at the moment the session is stamped.

The orchestrator stamps sess.VisualEvidence = "missing" before calling commentPR. If the comment post fails, the one-shot guard prevents any retry, so the PR author gets no on-PR notification even though the supervisor and notifier do fire. The rest of the feature — config, glob matching, capture runner, supervisor finding, state fields — is well-implemented and fully tested.

internal/orchestrator/visual_evidence.go — the ordering of the session stamp and the commentPR call needs attention. internal/worker/worker.go — the hardcoded home.png example in the bash snippet.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/visual_evidence.go | Core visual-evidence check for the merge flow; one-shot guard and fallback capture are well-structured, but the session is stamped before the warning comment is posted, so a transient commentPR failure permanently suppresses the on-PR notification. |
| internal/pipeline/visual.go | Hand-rolled doublestar glob matcher, screenshot scanner, and capture runner; logic is correct and well-tested including edge cases like zero-segment ** and trailing-slash patterns. |
| internal/github/visual_evidence.go | Adds PRChangedFiles (with --paginate) and PRVisualEvidenceAttached; image-detection regexes cover markdown, img tags, and bare image URLs with case-insensitive matching. |
| internal/config/config.go | Clean VerifyVisualConfig addition with sensible defaults, Active() guard, and a startup warning for enabled-but-incomplete configs. |
| internal/worker/worker.go | visualEvidencePromptSection correctly gates on Active() and is appended to both template and legacy prompt paths; the bash example hardcodes home.png which could mislead workers into attaching only that one filename. |
| internal/supervisor/supervisor.go | detectVisualEvidenceStuckStates correctly self-clears for terminal session statuses and limits the finding to in-flight PRs. |
| internal/state/state.go | Adds VisualEvidence and VisualEvidenceDetail fields with named constants; clean and backward-compatible with omitempty JSON tags. |
| internal/orchestrator/orchestrator.go | Adds three injectable test-hook fields and calls ensureVisualEvidence once per merge-flow cycle; the placement before the CI check is correct for advisory-only behavior. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/visual_evidence.go:88-95
**PR warning comment permanently dropped on transient error**

The session is stamped `VisualEvidenceMissing` at line 89 before `commentPR` is attempted at line 93. If `commentPR` returns an error (e.g., a transient GitHub API failure), the error is only logged — and because the one-shot guard at line 59 (`if sess.VisualEvidence != ""`) now sees `"missing"`, the comment will never be retried on future cycles. The PR author ends up with no on-PR indicator that visual evidence is required, even though the supervisor finding and notifier message do reach the operator. Setting `sess.VisualEvidence` only after a successful comment (or moving the stamp after the comment attempt and skipping it on failure) would let the next merge-flow cycle retry.

### Issue 2 of 2
internal/worker/worker.go:856-858
**Hardcoded `home.png` in the bash example may mislead workers**

The example command embeds a single, hardcoded filename `home.png`. Workers (LLMs) following the example literally would attach only a file with that exact name instead of all captured screenshots. A loop over the actual output directory, or a placeholder filename like `<screenshot>.png`, would make the intent clearer.

```suggestion
	fmt.Fprintf(&b, "   body=\"### 📸 Visual evidence\"\n")
	fmt.Fprintf(&b, "   for f in %s/*.png %s/*.jpg %s/*.jpeg %s/*.gif %s/*.webp; do\n", visual.ResolvedOutputDir(), visual.ResolvedOutputDir(), visual.ResolvedOutputDir(), visual.ResolvedOutputDir(), visual.ResolvedOutputDir())
	fmt.Fprintf(&b, "     [ -f \"$f\" ] && body=\"$body\\n![$(basename $f)](https://raw.githubusercontent.com/%s/$sha/$f)\"\n", cfg.Repo)
	b.WriteString("   done\n")
	fmt.Fprintf(&b, "   gh pr comment <PR_NUMBER> --repo %s --body \"$body\"\n", cfg.Repo)
	b.WriteString("   ```\n")
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["verify: opt-in visual-evidence step for ..."](https://github.com/befeast/maestro/commit/e451a39250874bd54a88d01953af545efd4af2f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37306105)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->