### PR TITLE
self-deploy: install to root-owned /usr/local/bin fails (no sudo) — first live run #710 deployed nothing, silently

### DIFF
--- a/docs/self-deploy-runbook.md
+++ b/docs/self-deploy-runbook.md
@@ -22,7 +22,10 @@ The script then:
    #682, extended with the commit SHA as semver build metadata).
 2. **Installs atomically** — stages the new binary next to the target
    (`<bin>.next`), preserves the current binary as `<bin>.prev`, and renames
-   into place (same-filesystem rename; safe under a running process).
+   into place (same-filesystem rename; safe under a running process). When
+   `install_via_sudo: true`, these file ops run through `sudo -n` so a
+   root-owned `bin_path` (e.g. `/usr/local/bin/maestro`) can be updated by the
+   unprivileged deploy user without losing atomic-rename semantics (#711).
 3. **Restarts the units** — `systemctl --user restart <unit>` for each
    configured unit. The unit's normal stop path runs, so existing **drain
    semantics are honored**: if your unit declares `ExecStop=... drain`,
@@ -39,7 +42,10 @@ The script then:
 6. **Writes a result file** — `<state_dir>/self-deploy-result.json`. The next
    orchestrator cycle (running the new binary, on success) consumes it,
    records a **supervisor finding** (deployed version / rollback reason)
-   visible in Mission Control, and sends a notification.
+   visible in Mission Control, and sends a notification. A `failed` /
+   `rolled_back` result surfaces as an **error-tone operator state**
+   ("Self-deploy failed") in `/api/v1/fleet`, so an undeployed-but-merged host
+   is loud rather than buried in journald (#711).
 
 ## Enabling it
 
@@ -51,6 +57,7 @@ server:
 self_deploy:
   enabled: true
   bin_path: /usr/local/bin/maestro   # default: path of the running binary
+  install_via_sudo: true             # #711: stage/rename/rollback bin_path via `sudo -n` (root-owned target)
   units: ["maestro.service"]         # systemd user units to restart
   # health_url: http://127.0.0.1:8788/api/v1/state  # default: derived from server.port
   # health_token_env: MAESTRO_DASH_TOKEN            # default: server.auth.token_env
@@ -65,9 +72,27 @@ Prerequisites on the host:
   `loginctl enable-linger $USER`).
 - Go toolchain reachable from the orchestrator's `PATH` (it is handed down
   to the transient unit) or at `/usr/local/go/bin`.
-- The user can write `bin_path` and its directory (no sudo: install the
-  binary under the user's control, e.g. `~/.local/bin/maestro`, or make
-  `/usr/local/bin/maestro` user-writable).
+- **Write access to `bin_path`** — the deploy runs as the unprivileged user
+  that owns the maestro units. Pick one:
+  - **User-writable target** (simplest, no sudo): point `bin_path` at a
+    directory the user owns, e.g. `~/.local/bin/maestro`, and make the unit
+    `ExecStart` use that path. Leave `install_via_sudo` unset/false.
+  - **Root-owned target via sudo** (`install_via_sudo: true`): keep
+    `bin_path` at a root-owned path such as `/usr/local/bin/maestro` and grant
+    the deploy user **passwordless sudo**. The script then runs the privileged
+    file ops (`install`/`cp`/`mv`/`rm` of `<bin>`, `<bin>.next`, `<bin>.prev`)
+    through `sudo -n`, preserving the same-filesystem atomic-rename install and
+    rollback. The deploy fails fast with a recorded finding if passwordless
+    sudo is unavailable. A minimal sudoers grant:
+
+    ```
+    # /etc/sudoers.d/maestro-self-deploy  (validate with: visudo -c -f <file>)
+    god ALL=(root) NOPASSWD: /usr/bin/install, /bin/cp, /bin/mv, /bin/rm
+    ```
+
+> Without one of these, the install step fails (`staging
+> /usr/local/bin/maestro.next failed`) and the merge self-deploys nothing —
+> the symptom that motivated #711.
 
 ## Verifying a rollout
 
@@ -110,6 +135,8 @@ maestro version
 
 | Symptom | Meaning | Action |
 |---|---|---|
+| Finding `self-deploy: failed … staging <bin>.next failed` | The deploy user cannot write `bin_path` (root-owned target, no sudo) | Set `install_via_sudo: true` + grant passwordless sudo, or move `bin_path` to a user-writable path (#711) |
+| Finding `self-deploy: failed … passwordless sudo is unavailable` | `install_via_sudo` is set but `sudo -n` does not work for the deploy user | Add a NOPASSWD sudoers grant for the install file ops (see Enabling it) |
 | Finding `self-deploy: failed … no .prev` | First deploy failed before any previous binary existed | Build + install manually once, re-merge |
 | Finding `rolled_back … health check timed out` | New binary started but never reported the stamped version | Check `journalctl --user -u maestro.service`; the regression is in the merged code |
 | No finding, no restart | Trigger failed (script missing, systemd-run unavailable) | Orchestrator log shows `self-deploy trigger failed …`; a ⚠️ notification is sent |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,6 +209,7 @@ type SelfDeployConfig struct {
 	Enabled        bool     `yaml:"enabled"`          // default false (opt-in)
 	Script         string   `yaml:"script"`           // deploy script path (default: <local_path>/scripts/self-deploy.sh)
 	BinPath        string   `yaml:"bin_path"`         // install target (default: path of the running binary)
+	InstallViaSudo bool     `yaml:"install_via_sudo"` // #711: stage/rename/rollback bin_path via `sudo -n` so a root-owned target (e.g. /usr/local/bin/maestro) can be updated by the unprivileged deploy user; requires passwordless sudo (default false)
 	Units          []string `yaml:"units"`            // systemd user units to restart (default: ["maestro.service"])
 	HealthURL      string   `yaml:"health_url"`       // running-process version probe (default: http://127.0.0.1:<server.port>/api/v1/state when server.port > 0)
 	HealthTokenEnv string   `yaml:"health_token_env"` // env var holding the bearer token for health_url (default: server.auth.token_env)

--- a/internal/config/selfdeploy_config_test.go
+++ b/internal/config/selfdeploy_config_test.go
@@ -15,6 +15,9 @@ func TestSelfDeployDefaultOff(t *testing.T) {
 	if cfg.SelfDeploy.Enabled {
 		t.Fatal("self_deploy.enabled must default to false")
 	}
+	if cfg.SelfDeploy.InstallViaSudo {
+		t.Fatal("self_deploy.install_via_sudo must default to false")
+	}
 }
 
 func TestSelfDeployParse(t *testing.T) {
@@ -23,6 +26,7 @@ repo: owner/repo
 self_deploy:
   enabled: true
   bin_path: /usr/local/bin/maestro
+  install_via_sudo: true
   units: ["maestro.service", " maestro-fleet.service "]
   health_url: http://127.0.0.1:9999/api/v1/state
   timeout_minutes: 45
@@ -37,6 +41,9 @@ self_deploy:
 	}
 	if sd.BinPath != "/usr/local/bin/maestro" {
 		t.Errorf("bin_path = %q", sd.BinPath)
+	}
+	if !sd.InstallViaSudo {
+		t.Error("install_via_sudo = false, want true")
 	}
 	if got := sd.EffectiveUnits(); len(got) != 2 || got[0] != "maestro.service" || got[1] != "maestro-fleet.service" {
 		t.Errorf("EffectiveUnits() = %v", got)

--- a/internal/selfdeploy/selfdeploy.go
+++ b/internal/selfdeploy/selfdeploy.go
@@ -139,6 +139,12 @@ func TriggerCommand(cfg *config.Config, prNumber int, now time.Time) (string, []
 		"--timeout-seconds", strconv.Itoa(timeoutSec),
 		"--pr", strconv.Itoa(prNumber),
 	)
+	// #711: when bin_path is root-owned, the unprivileged deploy user cannot
+	// stage/rename into it. install_via_sudo escalates the file ops with
+	// passwordless `sudo -n` so atomic-rename install + rollback still work.
+	if cfg.SelfDeploy.InstallViaSudo {
+		args = append(args, "--install-via-sudo")
+	}
 	if url := cfg.SelfDeploy.EffectiveHealthURL(cfg.Server); url != "" {
 		args = append(args, "--health-url", url)
 		if env := cfg.SelfDeploy.EffectiveHealthTokenEnv(cfg.Server); env != "" {

--- a/internal/selfdeploy/selfdeploy_test.go
+++ b/internal/selfdeploy/selfdeploy_test.go
@@ -110,6 +110,39 @@ func TestTriggerCommand(t *testing.T) {
 	}
 }
 
+func TestTriggerCommandInstallViaSudo(t *testing.T) {
+	cfg := triggerTestConfig(t)
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+
+	// Default off: the flag must not be passed.
+	_, args, err := TriggerCommand(cfg, 711, now)
+	if err != nil {
+		t.Fatalf("TriggerCommand: %v", err)
+	}
+	if strings.Contains(strings.Join(args, " "), "--install-via-sudo") {
+		t.Error("--install-via-sudo passed with install_via_sudo off")
+	}
+
+	// Opt-in: the flag is forwarded to the deploy script.
+	cfg.SelfDeploy.InstallViaSudo = true
+	_, args, err = TriggerCommand(cfg, 711, now)
+	if err != nil {
+		t.Fatalf("TriggerCommand: %v", err)
+	}
+	if !contains(args, "--install-via-sudo") {
+		t.Errorf("--install-via-sudo missing when enabled: %v", args)
+	}
+}
+
+func contains(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestTriggerCommandNoHealthURLWithoutServerPort(t *testing.T) {
 	cfg := triggerTestConfig(t)
 	cfg.Server = config.ServerConfig{}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1897,6 +1897,9 @@ func fleetNextActionCTAForProject(kind string, op fleetOperatorState) string {
 	case "error":
 		return "Investigate project error"
 	case "dispatch_failure":
+		if op.Label == "Self-deploy failed" {
+			return "Redeploy maestro binary" // #711
+		}
 		return "Resolve stuck dispatch"
 	case "stale_worker":
 		if op.PRNumber > 0 {
@@ -3149,6 +3152,22 @@ func fleetDispatchFailureOperatorState(project fleetProjectState) (fleetOperator
 	}
 	if strings.TrimSpace(latest.Status) != "failed" && strings.TrimSpace(latest.ErrorClass) == "" {
 		return fleetOperatorState{}, false
+	}
+	// #711: a failed/rolled-back self-deploy lands as a supervisor finding with
+	// a `self-deploy-` decision ID. Surface it as an error-tone, high-priority
+	// operator state with deploy-specific copy so an undeployed-but-merged host
+	// is loud in Mission Control instead of silent (or mislabeled as a queue
+	// dispatch failure). It reuses the dispatch_failure kind so it inherits the
+	// existing error-tier priority/needs-action/next-action plumbing.
+	if strings.HasPrefix(strings.TrimSpace(latest.ID), "self-deploy-") {
+		operator := fleetOperatorState{
+			Kind:       "dispatch_failure",
+			Tone:       "error",
+			Label:      "Self-deploy failed",
+			Summary:    firstNonEmpty(latest.Summary, "Self-deploy of the maestro binary failed; the host may be running an undeployed version."),
+			NextAction: firstNonEmpty(latest.RecommendedAction, "Inspect journalctl --user -u 'maestro-self-deploy-*', then redeploy the merged binary by hand."),
+		}
+		return applyFleetOperatorTarget(project, operator, latest.Target), true
 	}
 	operator := fleetOperatorState{
 		Kind:       "dispatch_failure",

--- a/internal/server/fleet_self_deploy_test.go
+++ b/internal/server/fleet_self_deploy_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// #711: a failed/rolled-back self-deploy finding must surface loudly via
+// /api/v1/fleet — an error-tone, top-priority operator state with
+// deploy-specific copy — so an undeployed-but-merged host is not silent. The
+// finding is recognized by its `self-deploy-` decision ID and reuses the
+// dispatch_failure error tier rather than being mislabeled as a queue failure.
+func TestFleetSelfDeployFailureOperatorState(t *testing.T) {
+	now := time.Now().UTC()
+
+	op := buildFleetProjectOperatorState(fleetProjectState{
+		Name: "Dogfood",
+		Repo: "befeast/maestro",
+		Supervisor: supervisorInfo{Latest: &supervisorDecisionInfo{
+			ID:                "self-deploy-20260612T100000.000000000Z",
+			CreatedAt:         now,
+			Status:            "failed",
+			Summary:           "self-deploy: failed after PR #710 — staging /usr/local/bin/maestro.next failed",
+			RecommendedAction: "verify the maestro units and binary by hand, then redeploy manually",
+		}},
+	})
+
+	if op.Kind != "dispatch_failure" {
+		t.Errorf("Kind = %q, want dispatch_failure (error tier)", op.Kind)
+	}
+	if op.Tone != "error" {
+		t.Errorf("Tone = %q, want error", op.Tone)
+	}
+	if op.Label != "Self-deploy failed" {
+		t.Errorf("Label = %q, want \"Self-deploy failed\"", op.Label)
+	}
+	if op.Summary == "" || op.NextAction == "" {
+		t.Errorf("Summary/NextAction must be populated: %+v", op)
+	}
+	if !fleetOperatorKindNeedsAction(op.Kind) {
+		t.Error("self-deploy failure must be an operator-action kind")
+	}
+	if got := fleetNextActionCTAForProject(op.Kind, op); got != "Redeploy maestro binary" {
+		t.Errorf("CTA = %q, want \"Redeploy maestro binary\"", got)
+	}
+}
+
+// A rolled-back self-deploy (Status "failed", carrying the rollback reason)
+// is surfaced the same way — the binary is safe but the merge did not deploy.
+func TestFleetSelfDeployRolledBackOperatorState(t *testing.T) {
+	now := time.Now().UTC()
+
+	op := buildFleetProjectOperatorState(fleetProjectState{
+		Name: "Dogfood",
+		Repo: "befeast/maestro",
+		Supervisor: supervisorInfo{Latest: &supervisorDecisionInfo{
+			ID:                "self-deploy-20260612T110000.000000000Z",
+			CreatedAt:         now,
+			Status:            "failed",
+			Summary:           "self-deploy: rolled back to previous binary after PR #710 — health check timed out",
+			RecommendedAction: "inspect the failed deploy, fix the regression, re-merge",
+		}},
+	})
+
+	if op.Tone != "error" || op.Label != "Self-deploy failed" {
+		t.Fatalf("rolled-back self-deploy operator state = %+v, want error/\"Self-deploy failed\"", op)
+	}
+}
+
+// A normal (non self-deploy) failed supervisor decision keeps the generic
+// dispatch-failure copy — the #711 special-case is scoped to self-deploy IDs.
+func TestFleetDispatchFailureUnchangedForNonSelfDeploy(t *testing.T) {
+	now := time.Now().UTC()
+
+	op := buildFleetProjectOperatorState(fleetProjectState{
+		Name: "Other",
+		Repo: "owner/other",
+		Supervisor: supervisorInfo{Latest: &supervisorDecisionInfo{
+			ID:        "supervisor-20260612T120000.000000000Z",
+			CreatedAt: now,
+			Status:    "failed",
+			Summary:   "Supervisor queue action failed for issue #9.",
+		}},
+	})
+
+	if op.Label != "Dispatch failure" {
+		t.Errorf("Label = %q, want \"Dispatch failure\" for a non self-deploy finding", op.Label)
+	}
+}

--- a/scripts/self-deploy.sh
+++ b/scripts/self-deploy.sh
@@ -17,10 +17,16 @@
 #   6. write a JSON result file the orchestrator surfaces as a supervisor
 #      finding on its next cycle.
 #
+# When --install-via-sudo is passed (#711), the privileged file operations
+# (stage <bin>.next, preserve <bin>.prev, atomic rename into place, rollback)
+# run through `sudo -n` so a root-owned bin_path such as /usr/local/bin/maestro
+# can be updated by the unprivileged deploy user. Requires passwordless sudo;
+# atomic-rename semantics are preserved (sudo mv on the same filesystem).
+#
 # Usage:
 #   self-deploy.sh --repo-dir DIR --bin PATH --units a.service[,b.service] \
 #     --result-file PATH --timeout-seconds N --pr N \
-#     [--health-url URL] [--health-token-env ENVVAR]
+#     [--health-url URL] [--health-token-env ENVVAR] [--install-via-sudo]
 
 set -euo pipefail
 
@@ -32,6 +38,7 @@ TIMEOUT_SECONDS=1800
 PR=0
 HEALTH_URL=""
 HEALTH_TOKEN_ENV=""
+INSTALL_VIA_SUDO=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -43,6 +50,7 @@ while [[ $# -gt 0 ]]; do
     --pr) PR="$2"; shift 2 ;;
     --health-url) HEALTH_URL="$2"; shift 2 ;;
     --health-token-env) HEALTH_TOKEN_ENV="$2"; shift 2 ;;
+    --install-via-sudo) INSTALL_VIA_SUDO=1; shift ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -70,6 +78,19 @@ PREV_VERSION=""
 IFS=',' read -r -a UNIT_LIST <<<"$UNITS"
 
 log() { echo "[self-deploy] $*" >&2; }
+
+# priv runs a privileged file operation against bin_path. With
+# --install-via-sudo it prefixes `sudo -n` (non-interactive: fail fast rather
+# than block on a password prompt the detached unit has no tty to answer);
+# otherwise it runs the command directly, so the no-sudo path is byte-for-byte
+# unchanged (#711).
+priv() {
+  if (( INSTALL_VIA_SUDO )); then
+    sudo -n "$@"
+  else
+    "$@"
+  fi
+}
 
 json_escape() {
   # Minimal JSON string escaper: backslash, double quote, newlines/tabs.
@@ -166,15 +187,16 @@ rollback() {
   fi
   log "rolling back to $BIN.prev"
   # Restore atomically: copy .prev to a temp name on the same filesystem and
-  # rename over the live binary, keeping .prev itself for inspection.
-  if cp -p "$BIN.prev" "$BIN.rollback.$$" && mv -f "$BIN.rollback.$$" "$BIN"; then
+  # rename over the live binary, keeping .prev itself for inspection. priv
+  # escalates via sudo when bin_path is root-owned (#711).
+  if priv cp -p "$BIN.prev" "$BIN.rollback.$$" && priv mv -f "$BIN.rollback.$$" "$BIN"; then
     if restart_units "$ROLLBACK_RESTART_TIMEOUT" && units_active; then
       write_result rolled_back "$reason"
     else
       write_result failed "$reason; rollback restored $BIN.prev but units did not come back active"
     fi
   else
-    rm -f "$BIN.rollback.$$"
+    priv rm -f "$BIN.rollback.$$"
     write_result failed "$reason; rollback copy of $BIN.prev failed"
   fi
 }
@@ -207,6 +229,15 @@ trap 'fail "command failed: ${BASH_COMMAND}"' ERR
 command -v go >/dev/null 2>&1 || export PATH="$PATH:/usr/local/go/bin"
 command -v go >/dev/null 2>&1 || fail "go toolchain not found in PATH"
 
+# Preflight passwordless sudo when install_via_sudo is requested, so a
+# misconfigured host fails loudly here (recorded as a finding) instead of at
+# the first privileged file op (#711).
+if (( INSTALL_VIA_SUDO )); then
+  command -v sudo >/dev/null 2>&1 || fail "install_via_sudo set but sudo not found in PATH"
+  sudo -n true >/dev/null 2>&1 || fail "install_via_sudo set but passwordless sudo is unavailable for $(id -un)"
+  log "install_via_sudo enabled — privileged file ops on $BIN run via sudo -n"
+fi
+
 # --- 1. build from merged origin/main, version-stamped (#682) ---------------
 log "fetching origin/main in $REPO_DIR"
 git -C "$REPO_DIR" fetch --quiet origin main
@@ -235,12 +266,13 @@ if [[ -n "$PREV_VERSION" && "$PREV_VERSION" == "$STAMP" ]]; then
 fi
 
 # Stage next to the target so the final rename is atomic (same filesystem).
-install -m 0755 "$BUILD_ROOT/maestro" "$BIN.next" || fail "staging $BIN.next failed"
+# priv escalates these ops via sudo when bin_path is root-owned (#711).
+priv install -m 0755 "$BUILD_ROOT/maestro" "$BIN.next" || fail "staging $BIN.next failed"
 if [[ -f "$BIN" ]]; then
-  cp -p "$BIN" "$BIN.prev" || { rm -f "$BIN.next"; fail "preserving $BIN.prev failed"; }
+  priv cp -p "$BIN" "$BIN.prev" || { priv rm -f "$BIN.next"; fail "preserving $BIN.prev failed"; }
   HAVE_PREV=1
 fi
-mv -f "$BIN.next" "$BIN" || fail "installing $BIN failed"
+priv mv -f "$BIN.next" "$BIN" || fail "installing $BIN failed"
 INSTALLED=1
 if (( HAVE_PREV )); then
   log "installed $BIN (previous kept at $BIN.prev)"


### PR DESCRIPTION
Refs #711

## Summary
The first live self-deploy (#710) failed at the install step — the script runs as the unprivileged units user and cannot stage/rename into a root-owned `bin_path` (`/usr/local/bin/maestro`), so merges self-deployed nothing. Rollback worked (failed safe), but the failure was effectively silent. This adds a config-gated sudo install path and makes the failure loud in Mission Control.

## Changes
- **config**: add `self_deploy.install_via_sudo` (default `false`, opt-in).
- **selfdeploy**: `TriggerCommand` forwards `--install-via-sudo` to the deploy script when set.
- **scripts/self-deploy.sh**: with `--install-via-sudo`, the stage / preserve-`.prev` / atomic-rename / rollback file ops run through `sudo -n`, preserving same-filesystem atomic-rename install + rollback. Preflights passwordless sudo and fails loudly (recorded finding) when unavailable. The no-sudo path is byte-for-byte unchanged.
- **fleet**: a `failed` / `rolled_back` self-deploy finding now surfaces as an error-tone, top-priority `Self-deploy failed` operator state via `/api/v1/fleet`, instead of being mislabeled as a dispatch failure or buried.
- **docs**: self-deploy-runbook privilege requirement (user-writable path vs. `install_via_sudo` + passwordless sudoers example) and new failure-mode rows.

## Testing
- `go build ./cmd/maestro/`
- `go test ./...` (all packages green)
- New unit tests: config parse/default for `install_via_sudo`; `TriggerCommand` flag pass-through (on/off); fleet operator-state surfacing for failed/rolled-back self-deploy + non-self-deploy regression guard.
- `bash -n scripts/self-deploy.sh`

## Runtime verification still required
The host-side outcome (a merge actually updating root-owned `/usr/local/bin/maestro`, verified by the health check — AC1/AC3) depends on this host's passwordless sudo grant and a live post-merge run, so it cannot be proven in CI. Enable `install_via_sudo: true`, add the sudoers grant from the runbook, and confirm on the next merge.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent self-deploy failure caused by the unprivileged deploy user being unable to write to root-owned `bin_path` (e.g. `/usr/local/bin/maestro`), and makes any future self-deploy failure loud in Mission Control rather than buried.

- **`--install-via-sudo` flag**: adds a `priv()` wrapper in `self-deploy.sh` that prefixes file ops (`install`, `cp`, `mv`, `rm`) with `sudo -n` when opt-in config `install_via_sudo: true` is set; the no-sudo path is byte-for-byte unchanged.
- **Fleet surfacing**: `fleetDispatchFailureOperatorState` now detects `self-deploy-` decision IDs and emits a dedicated error-tone "Self-deploy failed" operator state instead of mislabeling the failure as a generic dispatch failure or dropping it entirely.
- **Config + tests**: `SelfDeployConfig.InstallViaSudo` added with default false, flag pass-through tested in `TriggerCommand`, and three new fleet operator-state tests cover failed, rolled-back, and non-self-deploy regression cases.

<h3>Confidence Score: 3/5</h3>

The Go changes are safe; the shell script has a preflight that will block every deploy on a host configured with the minimal sudoers grant from the docs.

The `priv()` wrapper, fleet surfacing, config field, and tests are all correct. However, the new preflight check (`sudo -n true`) tests a command not covered by the minimal sudoers grant documented in the runbook — `true` is not `install`, `cp`, `mv`, or `rm`. A host operator who follows the runbook exactly will see the preflight fail with "passwordless sudo is unavailable" on every deploy attempt, leaving #711 unfixed for that deployment path.

scripts/self-deploy.sh (sudo preflight line) and docs/self-deploy-runbook.md (sudoers example scope).

<details open><summary><h3>Security Review</h3></summary>

- **Broad sudoers grant** (`docs/self-deploy-runbook.md`): The "minimal" sudoers example grants passwordless root access to `/usr/bin/install`, `/bin/cp`, `/bin/mv`, and `/bin/rm` without any path constraints. This gives the deploy user unrestricted root read/write/execute across the entire filesystem. The runbook should note this is a broad capability grant, not a least-privilege one.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/self-deploy.sh | Adds `--install-via-sudo` flag and `priv()` wrapper; no-sudo path is unchanged. Preflight check uses `sudo -n true` which is incompatible with the minimal sudoers grant documented in the runbook, causing deploy abort even when required commands are properly granted. |
| internal/server/fleet.go | Adds self-deploy failure detection in `fleetDispatchFailureOperatorState` by matching the `self-deploy-` decision ID prefix; both rolled-back and failed results correctly map to `Status: "failed"` in `Finding()` so the early-return guard is never a problem. |
| internal/selfdeploy/selfdeploy.go | Cleanly appends `--install-via-sudo` to the systemd-run args when `cfg.SelfDeploy.InstallViaSudo` is set; no logic changes elsewhere. |
| internal/config/config.go | Adds `InstallViaSudo bool` field with `yaml:"install_via_sudo"` tag; default false is correct since zero-value bool is false. |
| docs/self-deploy-runbook.md | Correctly documents both install paths and new failure-mode rows; the "minimal" sudoers example grants unrestricted root filesystem access via cp/mv/rm/install without path constraints — worth noting explicitly. |
| internal/config/selfdeploy_config_test.go | Tests default-off and explicit opt-in for `install_via_sudo`; straightforward and correct. |
| internal/selfdeploy/selfdeploy_test.go | New `TestTriggerCommandInstallViaSudo` covers flag pass-through on/off; adds a package-private `contains` helper that is clean and correct. |
| internal/server/fleet_self_deploy_test.go | Three new tests cover failed, rolled-back, and non-self-deploy supervisor findings; the regression guard for generic dispatch failures is especially useful. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/self-deploy.sh:237
The preflight uses `sudo -n true` to validate passwordless sudo, but the minimal sudoers grant shown in the runbook (`NOPASSWD: /usr/bin/install, /bin/cp, /bin/mv, /bin/rm`) does not cover `/bin/true` or `/usr/bin/true`. On a host configured with exactly the minimal grant from the docs, this line fails and `fail` is called — the deploy aborts with "passwordless sudo is unavailable" even though every file op the script actually needs is properly granted. Testing against `install --version` (the first command in the required grant) validates the right capability and is self-documenting.

```suggestion
  sudo -n install --version >/dev/null 2>&1 || fail "install_via_sudo set but passwordless sudo is unavailable for $(id -un) (NOPASSWD required for install, cp, mv, rm)"
```

### Issue 2 of 2
docs/self-deploy-runbook.md:84-88
**Unrestricted root filesystem access via sudoers grant**

The "minimal" sudoers example grants `cp`, `mv`, `rm`, and `install` as root with no path restrictions. Without argument constraints, the deploy user can read from or write to any path on the filesystem as root (e.g. `sudo cp /etc/shadow /tmp/exfil`, `sudo install /tmp/malicious /usr/bin/sshd`). The runbook calls this a "minimal" grant but it is effectively unrestricted root filesystem access. Consider adding a note that this is a broad capability grant, and that operators who need a tighter posture should constrain the target paths in sudoers or restrict the allowed commands further via a wrapper script in a fixed path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["self-deploy: install to root-owned bin\_p..."](https://github.com/befeast/maestro/commit/728ea66f72878c00c12eb19bd267163ccae7a908) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37392514)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->