### PR TITLE
self-deploy: support system units (scope-aware), not just systemctl --user (#716)

### DIFF
--- a/docs/self-deploy-runbook.md
+++ b/docs/self-deploy-runbook.md
@@ -26,11 +26,13 @@ The script then:
    `install_via_sudo: true`, these file ops run through `sudo -n` so a
    root-owned `bin_path` (e.g. `/usr/local/bin/maestro`) can be updated by the
    unprivileged deploy user without losing atomic-rename semantics (#711).
-3. **Restarts the units** — `systemctl --user restart <unit>` for each
-   configured unit. The unit's normal stop path runs, so existing **drain
-   semantics are honored**: if your unit declares `ExecStop=... drain`,
-   in-flight workers finish before the stop completes. Budget for this in
-   `timeout_minutes`.
+3. **Restarts the units** — for each configured unit, scoped by `scope`
+   (#716): `systemctl --user restart <unit>` for `user` (default) or
+   `sudo -n systemctl restart <unit>` for `system` units (e.g. the Loki fleet,
+   where maestro runs as `User=god` system units). Either way the unit's normal
+   stop path runs, so existing **drain semantics are honored**: if your unit
+   declares `ExecStop=... drain`, in-flight workers finish before the stop
+   completes. Budget for this in `timeout_minutes`.
 4. **Verifies health** — the installed CLI must report the stamped version
    (`maestro version` → `maestro v<VERSION>+g<shortsha>`), every unit must be
    `active`, and (when a health URL is configured) the **running process**
@@ -58,12 +60,36 @@ self_deploy:
   enabled: true
   bin_path: /usr/local/bin/maestro   # default: path of the running binary
   install_via_sudo: true             # #711: stage/rename/rollback bin_path via `sudo -n` (root-owned target)
-  units: ["maestro.service"]         # systemd user units to restart
+  scope: user                        # #716: user (default, systemctl --user) | system (sudo -n systemctl, for system units)
+  units: ["maestro.service"]         # systemd units to restart
   # health_url: http://127.0.0.1:8788/api/v1/state  # default: derived from server.port
   # health_token_env: MAESTRO_DASH_TOKEN            # default: server.auth.token_env
   # script: ./scripts/self-deploy.sh                # default: <local_path>/scripts/self-deploy.sh
   # timeout_minutes: 30                             # build+restart+verify budget (covers drain)
 ```
+
+### Scope: user vs system units (#716)
+
+`scope` selects which systemd manager owns the units:
+
+- **`user`** (default, back-compat) — per-user units, restarted with
+  `systemctl --user restart` / `systemctl --user is-active`. This was the only
+  mode before #716 (the workshop@opti deployment).
+- **`system`** — system units (`User=god`, managed by the system manager),
+  restarted with `sudo -n systemctl restart` and checked with
+  `systemctl is-active` (no `--user`). This is the **Loki fleet** layout, where
+  maestro runs as `maestro-<project>{,-supervise,-web}.service` system units.
+  System scope needs **passwordless sudo** for `systemctl restart` (the
+  read-only `is-active` poll does not); the deploy preflights it and fails fast
+  with a recorded finding if it is missing. A minimal sudoers grant:
+
+  ```
+  # /etc/sudoers.d/maestro-self-deploy  (validate with: visudo -c -f <file>)
+  god ALL=(root) NOPASSWD: /usr/bin/systemctl restart maestro-*
+  ```
+
+  On Loki, combine with `install_via_sudo: true` (root-owned
+  `/usr/local/bin/maestro`) — the two are independent but both used there.
 
 Prerequisites on the host:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -210,10 +210,26 @@ type SelfDeployConfig struct {
 	Script         string   `yaml:"script"`           // deploy script path (default: <local_path>/scripts/self-deploy.sh)
 	BinPath        string   `yaml:"bin_path"`         // install target (default: path of the running binary)
 	InstallViaSudo bool     `yaml:"install_via_sudo"` // #711: stage/rename/rollback bin_path via `sudo -n` so a root-owned target (e.g. /usr/local/bin/maestro) can be updated by the unprivileged deploy user; requires passwordless sudo (default false)
-	Units          []string `yaml:"units"`            // systemd user units to restart (default: ["maestro.service"])
+	Scope          string   `yaml:"scope"`            // #716: systemd unit scope — "user" (systemctl --user, default for back-compat) or "system" (sudo -n systemctl restart, for system units like the Loki fleet)
+	Units          []string `yaml:"units"`            // systemd units to restart (default: ["maestro.service"])
 	HealthURL      string   `yaml:"health_url"`       // running-process version probe (default: http://127.0.0.1:<server.port>/api/v1/state when server.port > 0)
 	HealthTokenEnv string   `yaml:"health_token_env"` // env var holding the bearer token for health_url (default: server.auth.token_env)
 	TimeoutMinutes int      `yaml:"timeout_minutes"`  // build+install+restart+verify budget; must cover unit drain (default: 30)
+}
+
+// SelfDeployScope* are the valid values for SelfDeployConfig.Scope.
+const (
+	SelfDeployScopeUser   = "user"   // per-user systemd manager (systemctl --user)
+	SelfDeployScopeSystem = "system" // system systemd manager (sudo -n systemctl)
+)
+
+// EffectiveScope returns the systemd unit scope, defaulting to "user" for
+// back-compat (#716). Any value other than "system" maps to "user".
+func (c SelfDeployConfig) EffectiveScope() string {
+	if strings.EqualFold(strings.TrimSpace(c.Scope), SelfDeployScopeSystem) {
+		return SelfDeployScopeSystem
+	}
+	return SelfDeployScopeUser
 }
 
 // EffectiveScript returns the deploy script path, defaulting to

--- a/internal/config/selfdeploy_config_test.go
+++ b/internal/config/selfdeploy_config_test.go
@@ -18,6 +18,40 @@ func TestSelfDeployDefaultOff(t *testing.T) {
 	if cfg.SelfDeploy.InstallViaSudo {
 		t.Fatal("self_deploy.install_via_sudo must default to false")
 	}
+	// #716: scope defaults to "user" for back-compat.
+	if got := cfg.SelfDeploy.EffectiveScope(); got != SelfDeployScopeUser {
+		t.Fatalf("EffectiveScope() = %q, want %q", got, SelfDeployScopeUser)
+	}
+}
+
+// #716: scope is config-driven, defaults to "user", and only "system"
+// (case-insensitive) selects the system manager.
+func TestSelfDeployScope(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"", SelfDeployScopeUser},
+		{"   ", SelfDeployScopeUser},
+		{"user", SelfDeployScopeUser},
+		{"bogus", SelfDeployScopeUser},
+		{"system", SelfDeployScopeSystem},
+		{" System ", SelfDeployScopeSystem},
+	}
+	for _, tc := range cases {
+		sd := SelfDeployConfig{Scope: tc.raw}
+		if got := sd.EffectiveScope(); got != tc.want {
+			t.Errorf("EffectiveScope(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+
+	cfg, err := Parse([]byte("repo: owner/repo\nself_deploy:\n  enabled: true\n  scope: system\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.SelfDeploy.EffectiveScope(); got != SelfDeployScopeSystem {
+		t.Errorf("parsed scope EffectiveScope() = %q, want %q", got, SelfDeployScopeSystem)
+	}
 }
 
 func TestSelfDeployParse(t *testing.T) {

--- a/internal/selfdeploy/selfdeploy.go
+++ b/internal/selfdeploy/selfdeploy.go
@@ -6,8 +6,10 @@
 // a detached transient systemd unit (systemd-run --user), so the script
 // survives the maestro unit restarting. The script builds from merged main
 // (version-stamped per #682), installs the binary atomically keeping the
-// previous one as `.prev`, restarts the configured user units (which honors
-// the units' drain semantics via their normal stop path), verifies the
+// previous one as `.prev`, restarts the configured units — user units via
+// `systemctl --user` or, with scope=system, system units via
+// `sudo -n systemctl` (#716) — which honors the units' drain semantics via
+// their normal stop path, verifies the
 // restarted process reports the expected version, rolls back to `.prev` on
 // failure, and writes a JSON result file into the state dir. The next
 // orchestrator cycle — running the freshly deployed binary on success —
@@ -138,6 +140,11 @@ func TriggerCommand(cfg *config.Config, prNumber int, now time.Time) (string, []
 		"--result-file", ResultPath(cfg.StateDir),
 		"--timeout-seconds", strconv.Itoa(timeoutSec),
 		"--pr", strconv.Itoa(prNumber),
+		// #716: select the systemd unit scope. Default "user" keeps the
+		// pre-migration behavior; "system" restarts system units via
+		// `sudo -n systemctl` (e.g. the Loki fleet, where maestro runs as
+		// User=god system units rather than per-user units).
+		"--scope", cfg.SelfDeploy.EffectiveScope(),
 	)
 	// #711: when bin_path is root-owned, the unprivileged deploy user cannot
 	// stage/rename into it. install_via_sudo escalates the file ops with

--- a/internal/selfdeploy/selfdeploy_test.go
+++ b/internal/selfdeploy/selfdeploy_test.go
@@ -102,12 +102,48 @@ func TestTriggerCommand(t *testing.T) {
 		"--result-file " + ResultPath(cfg.StateDir),
 		"--timeout-seconds 1800",
 		"--pr 698",
+		"--scope user",
 		"--health-url http://127.0.0.1:8788/api/v1/state",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("args missing %q in:\n%s", want, joined)
 		}
 	}
+}
+
+// #716: scope flows from the self_deploy block to a --scope flag; default user.
+func TestTriggerCommandScope(t *testing.T) {
+	cfg := triggerTestConfig(t)
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+
+	// Default (no scope set) → --scope user.
+	_, args, err := TriggerCommand(cfg, 716, now)
+	if err != nil {
+		t.Fatalf("TriggerCommand: %v", err)
+	}
+	if !flagValue(args, "--scope", "user") {
+		t.Errorf("default scope: want --scope user, got %v", args)
+	}
+
+	// Opt-in system scope is forwarded verbatim.
+	cfg.SelfDeploy.Scope = "system"
+	_, args, err = TriggerCommand(cfg, 716, now)
+	if err != nil {
+		t.Fatalf("TriggerCommand: %v", err)
+	}
+	if !flagValue(args, "--scope", "system") {
+		t.Errorf("system scope: want --scope system, got %v", args)
+	}
+}
+
+// flagValue reports whether args contains "<flag> <value>" as adjacent items.
+func flagValue(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
 }
 
 func TestTriggerCommandInstallViaSudo(t *testing.T) {

--- a/scripts/self-deploy.sh
+++ b/scripts/self-deploy.sh
@@ -8,14 +8,22 @@
 #   1. build from merged origin/main, version-stamped per #682
 #      (-X main.version=<VERSION>+g<shortsha>),
 #   2. install atomically, keeping the previous binary as <bin>.prev,
-#   3. restart the maestro user units via systemctl --user restart — the
-#      units' normal stop path runs, so existing drain semantics are honored,
+#   3. restart the maestro units — the units' normal stop path runs, so
+#      existing drain semantics are honored,
 #   4. verify post-restart health: installed CLI reports the stamped version,
 #      units are active, and (when --health-url is given) the running process
 #      reports the stamped version within the timeout,
 #   5. on failure roll back to <bin>.prev, restart the units again,
 #   6. write a JSON result file the orchestrator surfaces as a supervisor
 #      finding on its next cycle.
+#
+# --scope selects the systemd unit manager (#716):
+#   * user   (default, back-compat) — `systemctl --user restart/is-active`,
+#     for per-user units (the pre-migration workshop@opti deployment).
+#   * system — `sudo -n systemctl restart` (non-interactive, mirroring
+#     --install-via-sudo) and `systemctl is-active` (no --user), for system
+#     units like the Loki fleet, where maestro runs as User=god system units.
+# The is-active poll and the rollback restart path are scope-aware too.
 #
 # When --install-via-sudo is passed (#711), the privileged file operations
 # (stage <bin>.next, preserve <bin>.prev, atomic rename into place, rollback)
@@ -26,7 +34,8 @@
 # Usage:
 #   self-deploy.sh --repo-dir DIR --bin PATH --units a.service[,b.service] \
 #     --result-file PATH --timeout-seconds N --pr N \
-#     [--health-url URL] [--health-token-env ENVVAR] [--install-via-sudo]
+#     [--health-url URL] [--health-token-env ENVVAR] [--install-via-sudo] \
+#     [--scope user|system]
 
 set -euo pipefail
 
@@ -39,6 +48,7 @@ PR=0
 HEALTH_URL=""
 HEALTH_TOKEN_ENV=""
 INSTALL_VIA_SUDO=0
+SCOPE="user"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -51,12 +61,18 @@ while [[ $# -gt 0 ]]; do
     --health-url) HEALTH_URL="$2"; shift 2 ;;
     --health-token-env) HEALTH_TOKEN_ENV="$2"; shift 2 ;;
     --install-via-sudo) INSTALL_VIA_SUDO=1; shift ;;
+    --scope) SCOPE="$2"; shift 2 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
 
 [[ -n "$REPO_DIR" && -n "$BIN" && -n "$UNITS" && -n "$RESULT_FILE" ]] || {
   echo "usage: --repo-dir, --bin, --units, --result-file are required" >&2
+  exit 2
+}
+
+[[ "$SCOPE" == "user" || "$SCOPE" == "system" ]] || {
+  echo "invalid --scope: $SCOPE (want user|system)" >&2
   exit 2
 }
 
@@ -127,21 +143,41 @@ cleanup_build() {
   rm -rf "$BUILD_ROOT"
 }
 
+# restart_units restarts each configured unit, scoped per --scope (#716).
+# user-scope uses the per-user manager (`systemctl --user restart`); system-scope
+# targets the system manager via `sudo -n systemctl restart` (non-interactive,
+# mirroring --install-via-sudo), since restarting a system unit needs privilege.
+# Either way the unit's normal stop path runs, so drain semantics are honored.
+# The user-scope command is byte-for-byte unchanged from before scope support.
 restart_units() {
   local budget=$1 unit
+  local -a restart_cmd
+  if [[ "$SCOPE" == "system" ]]; then
+    restart_cmd=(sudo -n systemctl restart)
+  else
+    restart_cmd=(systemctl --user restart)
+  fi
   for unit in "${UNIT_LIST[@]}"; do
-    log "restarting $unit (honors the unit's stop/drain path; budget ${budget}s)"
-    if ! timeout "$budget" systemctl --user restart "$unit"; then
+    log "restarting $unit (scope=$SCOPE; honors the unit's stop/drain path; budget ${budget}s)"
+    if ! timeout "$budget" "${restart_cmd[@]}" "$unit"; then
       log "restart of $unit failed or timed out"
       return 1
     fi
   done
 }
 
+# units_active is scope-aware too (#716). The read-only liveness query needs no
+# privilege even for system units, so system-scope simply drops --user (no sudo).
 units_active() {
   local unit
+  local -a active_cmd
+  if [[ "$SCOPE" == "system" ]]; then
+    active_cmd=(systemctl is-active --quiet)
+  else
+    active_cmd=(systemctl --user is-active --quiet)
+  fi
   for unit in "${UNIT_LIST[@]}"; do
-    systemctl --user is-active --quiet "$unit" || return 1
+    "${active_cmd[@]}" "$unit" || return 1
   done
 }
 
@@ -229,13 +265,19 @@ trap 'fail "command failed: ${BASH_COMMAND}"' ERR
 command -v go >/dev/null 2>&1 || export PATH="$PATH:/usr/local/go/bin"
 command -v go >/dev/null 2>&1 || fail "go toolchain not found in PATH"
 
-# Preflight passwordless sudo when install_via_sudo is requested, so a
-# misconfigured host fails loudly here (recorded as a finding) instead of at
-# the first privileged file op (#711).
+# Preflight passwordless sudo when any privileged operation is requested —
+# install_via_sudo file ops (#711) or system-scope unit restarts (#716) — so a
+# misconfigured host fails loudly here (recorded as a finding) instead of at the
+# first privileged operation.
+if (( INSTALL_VIA_SUDO )) || [[ "$SCOPE" == "system" ]]; then
+  command -v sudo >/dev/null 2>&1 || fail "privileged self-deploy requested but sudo not found in PATH"
+  sudo -n true >/dev/null 2>&1 || fail "privileged self-deploy requested but passwordless sudo is unavailable for $(id -un)"
+fi
 if (( INSTALL_VIA_SUDO )); then
-  command -v sudo >/dev/null 2>&1 || fail "install_via_sudo set but sudo not found in PATH"
-  sudo -n true >/dev/null 2>&1 || fail "install_via_sudo set but passwordless sudo is unavailable for $(id -un)"
   log "install_via_sudo enabled — privileged file ops on $BIN run via sudo -n"
+fi
+if [[ "$SCOPE" == "system" ]]; then
+  log "scope=system — unit restarts run via sudo -n systemctl"
 fi
 
 # --- 1. build from merged origin/main, version-stamped (#682) ---------------


### PR DESCRIPTION
Implements #716

## Changes
- `scripts/self-deploy.sh`: new `--scope user|system` flag (default `user`, back-compat).
  - `system` restarts via `sudo -n systemctl restart` (non-interactive, mirroring `--install-via-sudo`); `is-active` drops `--user` (no sudo for the read-only query). The verify poll and rollback restart path are scope-aware.
  - Preflight passwordless sudo for system scope (or `install_via_sudo`), failing loudly with a recorded finding.
  - `user` scope: systemctl invocations unchanged.
- `internal/config`: new `self_deploy.scope` key + `EffectiveScope()` (defaults to `user`).
- `internal/selfdeploy`: the Go caller forwards `--scope` from the `self_deploy:` block.
- `docs/self-deploy-runbook.md`: documents user-vs-system scope and the sudoers grant.

## Testing
- `go test ./...` (config + selfdeploy scope tests added)
- `go build ./cmd/maestro/`
- `gofmt -l` clean; `bash -n scripts/self-deploy.sh` clean

## Runtime verification still required
Per the issue's Done criteria, this needs to be proven on Loki: deploy the new binary, set `self_deploy { enabled: true, scope: system }`, and confirm one post-merge auto-deploy cycle (build → install → restart system units → health-verify via `/api/v1/fleet` → rollback-on-failure). Not auto-closing until that operator verification lands.

Refs #716

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `--scope user|system` flag to `self-deploy.sh` and the corresponding `self_deploy.scope` config key, enabling the orchestrator to restart system-manager units (via `sudo -n systemctl restart`) in addition to the existing per-user units (`systemctl --user restart`). The `is-active` poll and rollback restart path are made scope-aware, and a sudo preflight was extended to cover both `install_via_sudo` and `scope=system`.

- `internal/config`: new `Scope` field, `SelfDeployScope*` constants, and `EffectiveScope()` with case-insensitive defaulting; well-tested.
- `internal/selfdeploy`: `TriggerCommand` forwards `--scope` from config to the script; `Finding()` still hardcodes `systemctl --user status` in the failed-deploy `RecommendedAction`, which gives incorrect guidance for `scope=system`.
- `scripts/self-deploy.sh`: scope-aware `restart_units`/`units_active` helpers; the new sudo preflight uses `sudo -n true`, which is incompatible with the minimal `NOPASSWD: /usr/bin/systemctl restart maestro-*` grant documented in the runbook — that grant will cause the preflight to fail on every attempt.

<h3>Confidence Score: 3/5</h3>

The Go config and caller changes are clean; the shell script preflight will break every system-scope deploy on a host configured per the runbook.

The extended sudo -n true preflight is incompatible with the minimal sudoers grant the runbook documents for scope=system. A host configured exactly per the docs will fail at preflight on every deploy attempt, making the new system-scope feature unusable without deviating from the documented setup.

scripts/self-deploy.sh and docs/self-deploy-runbook.md need to be reconciled with each other.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/self-deploy.sh | Adds --scope flag, scope-aware restart_units/units_active, and a preflight for privileged operations; the sudo -n true preflight is incompatible with the minimal sudoers grant documented in this PR |
| internal/selfdeploy/selfdeploy.go | Forwards --scope from config to the shell script; Finding() RecommendedAction hardcodes --user guidance that is wrong for system scope |
| internal/config/config.go | Adds Scope field, SelfDeployScope constants, and EffectiveScope() with correct case-insensitive defaulting logic; no issues |
| internal/config/selfdeploy_config_test.go | Covers empty/whitespace/bogus/valid scope values and YAML round-trip; thorough |
| internal/selfdeploy/selfdeploy_test.go | Adds TestTriggerCommandScope verifying default and explicit system scope; flagValue helper is correct |
| docs/self-deploy-runbook.md | Documents user vs system scope, sudoers grant, and combined install_via_sudo usage; the documented minimal sudoers grant is incompatible with the preflight check |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/selfdeploy/selfdeploy.go`, line 213 ([link](https://github.com/befeast/maestro/blob/d3ef42e299fe1338203c4b3524427b6962ed120f/internal/selfdeploy/selfdeploy.go#L213)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Hardcoded `--user` guidance is wrong for `scope=system` deployments**

   `RecommendedAction` tells the operator to run `systemctl --user status`, but for `scope=system` the deployed units live in the system manager and won't appear in the user manager's status output. Since `Finding` doesn't receive scope information it can't branch here, so either the scope should be threaded through or the advice should be made scope-agnostic (e.g. suggest both commands or link to the runbook).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/selfdeploy/selfdeploy.go
   Line: 213

   Comment:
   **Hardcoded `--user` guidance is wrong for `scope=system` deployments**

   `RecommendedAction` tells the operator to run `systemctl --user status`, but for `scope=system` the deployed units live in the system manager and won't appear in the user manager's status output. Since `Finding` doesn't receive scope information it can't branch here, so either the scope should be threaded through or the advice should be made scope-agnostic (e.g. suggest both commands or link to the runbook).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/self-deploy.sh:272-274
**Preflight check incompatible with documented minimal sudoers grant**

`sudo -n true` tests whether *any* passwordless sudo is available, but the docs for `scope: system` recommend a narrowly-scoped rule (`NOPASSWD: /usr/bin/systemctl restart maestro-*`). Under that grant, `sudo -n true` fails because `/bin/true` is not in the allowlist, so the deploy dies at preflight with "passwordless sudo is unavailable" — even though the actual required command (`sudo -n systemctl restart`) would succeed. Any operator who follows the runbook to set up the Loki fleet will hit this on every deploy attempt.

### Issue 2 of 2
internal/selfdeploy/selfdeploy.go:213
**Hardcoded `--user` guidance is wrong for `scope=system` deployments**

`RecommendedAction` tells the operator to run `systemctl --user status`, but for `scope=system` the deployed units live in the system manager and won't appear in the user manager's status output. Since `Finding` doesn't receive scope information it can't branch here, so either the scope should be threaded through or the advice should be made scope-agnostic (e.g. suggest both commands or link to the runbook).


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["self-deploy: support system-scope units,..."](https://github.com/befeast/maestro/commit/d3ef42e299fe1338203c4b3524427b6962ed120f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37504974)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->