### PR TITLE
self-deploy: break the self-triggering deploy cascade (#722)

### DIFF
--- a/docs/self-deploy-runbook.md
+++ b/docs/self-deploy-runbook.md
@@ -36,8 +36,14 @@ The script then:
 4. **Verifies health** — the installed CLI must report the stamped version
    (`maestro version` → `maestro v<VERSION>+g<shortsha>`), every unit must be
    `active`, and (when a health URL is configured) the **running process**
-   must report the stamped version via the `version` field on
-   `/api/v1/state` (or `/api/v1/fleet`) before the deadline.
+   must report a version **built from the deployed commit SHA** via the
+   `version` field on `/api/v1/state` (or `/api/v1/fleet`) before the deadline.
+   The health check matches the commit SHA (the `+g<shortsha>` build metadata),
+   **not** the full version string: a stamped build reports `1.4.2+gf4550ef`
+   while an unstamped one reports a Go pseudo-version
+   `1.4.3-0.<ts>-f4550ef38a42` — same commit, different string. Matching the SHA
+   is format-agnostic, so a stamp-vs-pseudo-version formatting difference cannot
+   cause a false verify miss (#722).
 5. **Rolls back on failure** — restores `<bin>.prev`, restarts the units
    again, and records the rollback reason. `.prev` is kept either way for
    manual rollback.
@@ -66,7 +72,35 @@ self_deploy:
   # health_token_env: MAESTRO_DASH_TOKEN            # default: server.auth.token_env
   # script: ./scripts/self-deploy.sh                # default: <local_path>/scripts/self-deploy.sh
   # timeout_minutes: 30                             # build+restart+verify budget (covers drain)
+  # min_interval_minutes: 30                        # #722: debounce window between triggers (default: timeout_minutes)
 ```
+
+### Avoiding the self-trigger cascade (#722)
+
+The deploy restarts the **run-loop's own unit** (it must, to pick up the new
+binary). If that unit is in `units`, a deploy restarts the very process that
+triggers deploys — and on a busy fleet a burst of merges (or a deploy that rolls
+back) can re-fire fresh deploys while a previous one is still in flight. Stacked
+deploys keep bouncing the fleet web process the verify step polls, so verify
+never converges and every attempt rolls back and re-fires. Three guards prevent
+this:
+
+- **SHA-based verify** — the health check matches the commit SHA, not the full
+  version string, so a stamped binary and a rolled-back pseudo-version of the
+  *same commit* both satisfy verify (step 4 above).
+- **Single-flight lock** — `scripts/self-deploy.sh` takes a non-blocking
+  `flock` on `<result-file>.lock`; a re-triggered deploy that lands while one is
+  in flight exits cleanly instead of restarting units mid-verify.
+- **Orchestrator debounce** — the orchestrator records each trigger in the state
+  dir (`self-deploy-last-trigger.json`) and skips re-triggering within
+  `min_interval_minutes` (default: `timeout_minutes`). This survives the
+  run-loop being restarted by its own deploy. Lower it for faster back-to-back
+  deploys on an idle fleet.
+
+It is still safe (and simplest) to keep the run-loop unit in `units`; these
+guards make that configuration converge. Re-enable `self_deploy` on the dogfood
+orchestrator only after validating a deploy → verify-pass → no-re-trigger cycle
+on an idle fleet.
 
 ### Scope: user vs system units (#716)
 
@@ -166,6 +200,8 @@ maestro version
 | Finding `self-deploy: failed … no .prev` | First deploy failed before any previous binary existed | Build + install manually once, re-merge |
 | Finding `rolled_back … health check timed out` | New binary started but never reported the stamped version | Check `journalctl --user -u maestro.service`; the regression is in the merged code |
 | No finding, no restart | Trigger failed (script missing, systemd-run unavailable) | Orchestrator log shows `self-deploy trigger failed …`; a ⚠️ notification is sent |
+| Log `self-deploy debounced for PR #… < … window` | A deploy was triggered within `min_interval_minutes` of the previous one — expected on a burst of merges (#722) | None; the in-flight/previous deploy covers the merged code. Lower `min_interval_minutes` for faster successive deploys |
+| Deploy log `another self-deploy holds … — skipping` | A deploy started while one was already in flight; the single-flight lock skipped it (#722) | None; the in-flight deploy owns the rollout |
 | Units inactive after rollback | Rollback restart also failed | `systemctl --user start maestro.service` by hand; binary on disk is the previous version |
 
 ## Interaction with `deploy_cmd`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,6 +215,15 @@ type SelfDeployConfig struct {
 	HealthURL      string   `yaml:"health_url"`       // running-process version probe (default: http://127.0.0.1:<server.port>/api/v1/state when server.port > 0)
 	HealthTokenEnv string   `yaml:"health_token_env"` // env var holding the bearer token for health_url (default: server.auth.token_env)
 	TimeoutMinutes int      `yaml:"timeout_minutes"`  // build+install+restart+verify budget; must cover unit drain (default: 30)
+
+	// #722: minimum interval between self-deploy triggers. The deploy restarts
+	// the run-loop's own unit, so a burst of merges — or a run-loop restarted by
+	// its own deploy — can re-fire a new deploy while a previous one is still in
+	// flight (build + drain + verify + rollback), producing a self-triggering
+	// cascade that bounces the fleet web process mid-verify so verify never
+	// converges. The orchestrator debounces re-triggers within this window.
+	// Default: timeout_minutes (at most one deploy per budget).
+	MinIntervalMinutes int `yaml:"min_interval_minutes"`
 }
 
 // SelfDeployScope* are the valid values for SelfDeployConfig.Scope.
@@ -292,6 +301,19 @@ func (c SelfDeployConfig) EffectiveTimeoutMinutes() int {
 		return c.TimeoutMinutes
 	}
 	return 30
+}
+
+// EffectiveMinIntervalMinutes returns the debounce window between self-deploy
+// triggers (#722). Because the deploy restarts the run-loop's own unit, a burst
+// of merges (or a run-loop restarted mid-deploy) must not re-fire a fresh
+// deploy while a previous one may still be in flight — that is the
+// self-triggering cascade. Defaults to the deploy timeout so at most one deploy
+// runs per budget; set explicitly to allow faster back-to-back deploys.
+func (c SelfDeployConfig) EffectiveMinIntervalMinutes() int {
+	if c.MinIntervalMinutes > 0 {
+		return c.MinIntervalMinutes
+	}
+	return c.EffectiveTimeoutMinutes()
 }
 
 const (

--- a/internal/config/selfdeploy_config_test.go
+++ b/internal/config/selfdeploy_config_test.go
@@ -105,6 +105,11 @@ func TestSelfDeployEffectiveDefaults(t *testing.T) {
 	if got := sd.EffectiveTimeoutMinutes(); got != 30 {
 		t.Errorf("EffectiveTimeoutMinutes() = %d, want 30", got)
 	}
+	// #722: the debounce window defaults to the deploy timeout so at most one
+	// deploy runs per budget.
+	if got := sd.EffectiveMinIntervalMinutes(); got != 30 {
+		t.Errorf("EffectiveMinIntervalMinutes() default = %d, want 30 (timeout)", got)
+	}
 
 	// No server port → no health URL (CLI + unit checks only).
 	if got := sd.EffectiveHealthURL(ServerConfig{}); got != "" {
@@ -116,5 +121,30 @@ func TestSelfDeployEffectiveDefaults(t *testing.T) {
 	}
 	if got := sd.EffectiveHealthTokenEnv(ServerConfig{Auth: ServerAuthConfig{TokenEnv: "MC_TOKEN"}}); got != "MC_TOKEN" {
 		t.Errorf("EffectiveHealthTokenEnv() = %q", got)
+	}
+}
+
+// #722: the debounce window defaults to the deploy timeout (so re-triggers
+// cannot stack while a deploy may still be in flight) and an explicit
+// min_interval_minutes overrides it for faster back-to-back deploys.
+func TestSelfDeployEffectiveMinInterval(t *testing.T) {
+	// Default: falls back to EffectiveTimeoutMinutes().
+	if got := (SelfDeployConfig{}).EffectiveMinIntervalMinutes(); got != 30 {
+		t.Errorf("default EffectiveMinIntervalMinutes() = %d, want 30", got)
+	}
+	if got := (SelfDeployConfig{TimeoutMinutes: 45}).EffectiveMinIntervalMinutes(); got != 45 {
+		t.Errorf("EffectiveMinIntervalMinutes() with timeout 45 = %d, want 45", got)
+	}
+	// Explicit override wins over the timeout default.
+	if got := (SelfDeployConfig{TimeoutMinutes: 45, MinIntervalMinutes: 5}).EffectiveMinIntervalMinutes(); got != 5 {
+		t.Errorf("EffectiveMinIntervalMinutes() override = %d, want 5", got)
+	}
+
+	cfg, err := Parse([]byte("repo: owner/repo\nself_deploy:\n  enabled: true\n  min_interval_minutes: 7\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.SelfDeploy.EffectiveMinIntervalMinutes(); got != 7 {
+		t.Errorf("parsed min_interval_minutes EffectiveMinIntervalMinutes() = %d, want 7", got)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3799,10 +3799,33 @@ func (o *Orchestrator) maybeSelfDeployAfterMerge(prNumber int) {
 	if !o.cfg.SelfDeploy.Enabled {
 		return
 	}
+	now := time.Now().UTC()
+	// #722: debounce re-triggers. The deploy restarts the run-loop's own unit,
+	// so a burst of merges — or a run-loop restarted by its own deploy — can
+	// re-fire a fresh deploy while a previous one is still in flight (build +
+	// drain + verify + rollback). That stacks deploys that bounce the fleet web
+	// process mid-verify, so verify never converges (the cascade in #722). Skip
+	// if we triggered a deploy within the min-interval window.
+	if last, lastPR, ok := selfdeploy.LastTrigger(o.cfg.StateDir); ok {
+		window := time.Duration(o.cfg.SelfDeploy.EffectiveMinIntervalMinutes()) * time.Minute
+		if since := now.Sub(last); since >= 0 && since < window {
+			log.Printf("[orch] self-deploy debounced for PR #%d: last trigger (PR #%d) was %s ago (< %s window)", prNumber, lastPR, since.Round(time.Second), window)
+			return
+		}
+	}
 	if err := o.triggerSelfDeploy(prNumber); err != nil {
 		log.Printf("[orch] self-deploy trigger failed for PR #%d: %v", prNumber, err)
 		o.notifier.Sendf("⚠️ maestro: self-deploy trigger failed after PR #%d merge: %v", prNumber, err)
 		return
+	}
+	// Record the trigger now that the deploy is launched. The detached script
+	// fetches+builds before it restarts any unit, so this marker lands well
+	// before the run-loop's own restart — a run-loop restarted by this deploy
+	// then sees it on its next cycle and does not re-fire for the same wave
+	// (#722). Recording only on success keeps a pure trigger failure (no deploy
+	// happened) from suppressing the next attempt.
+	if err := selfdeploy.RecordTrigger(o.cfg.StateDir, prNumber, now); err != nil {
+		log.Printf("[orch] self-deploy trigger marker write failed for PR #%d: %v", prNumber, err)
 	}
 	log.Printf("[orch] self-deploy started for PR #%d (detached transient unit)", prNumber)
 	o.notifier.Sendf("🚀 maestro: self-deploy started after PR #%d merge — units will restart after drain", prNumber)

--- a/internal/orchestrator/selfdeploy_test.go
+++ b/internal/orchestrator/selfdeploy_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/notify"
@@ -40,6 +41,63 @@ func TestMaybeSelfDeployAfterMerge_Enabled(t *testing.T) {
 	o.maybeSelfDeployAfterMerge(698)
 	if gotPR != 698 {
 		t.Fatalf("trigger called with PR %d, want 698", gotPR)
+	}
+}
+
+// #722: a deploy triggered within the debounce window is skipped, so a burst of
+// merges (or a run-loop restarted by its own deploy) cannot stack overlapping
+// deploys — the self-trigger cascade.
+func TestMaybeSelfDeployAfterMerge_DebouncesRecentTrigger(t *testing.T) {
+	stateDir := t.TempDir()
+	// A trigger fired moments ago for PR 698.
+	if err := selfdeploy.RecordTrigger(stateDir, 698, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   stateDir,
+			SelfDeploy: config.SelfDeployConfig{Enabled: true, MinIntervalMinutes: 30},
+		},
+		notifier:          &notify.Notifier{},
+		selfDeployStartFn: func(prNumber int) error { calls++; return nil },
+	}
+
+	o.maybeSelfDeployAfterMerge(699)
+	if calls != 0 {
+		t.Fatalf("trigger fired %d times within the debounce window, want 0", calls)
+	}
+}
+
+// Outside the debounce window the next merge deploys again and refreshes the
+// trigger marker.
+func TestMaybeSelfDeployAfterMerge_FiresAfterWindow(t *testing.T) {
+	stateDir := t.TempDir()
+	// Last trigger is well past the (1 minute) window.
+	if err := selfdeploy.RecordTrigger(stateDir, 698, time.Now().UTC().Add(-10*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	gotPR := 0
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   stateDir,
+			SelfDeploy: config.SelfDeployConfig{Enabled: true, MinIntervalMinutes: 1},
+		},
+		notifier:          &notify.Notifier{},
+		selfDeployStartFn: func(prNumber int) error { gotPR = prNumber; return nil },
+	}
+
+	o.maybeSelfDeployAfterMerge(720)
+	if gotPR != 720 {
+		t.Fatalf("trigger called with PR %d, want 720", gotPR)
+	}
+	// The marker advanced to the new trigger.
+	if _, pr, ok := selfdeploy.LastTrigger(stateDir); !ok || pr != 720 {
+		t.Fatalf("marker after fire = (pr %d, ok %v), want (720, true)", pr, ok)
 	}
 }
 

--- a/internal/selfdeploy/selfdeploy.go
+++ b/internal/selfdeploy/selfdeploy.go
@@ -41,6 +41,13 @@ const (
 // unit and the orchestrator agree on the location without extra plumbing.
 const resultFileName = "self-deploy-result.json"
 
+// triggerMarkerName records when the orchestrator last launched a deploy, so a
+// burst of merges — or a run-loop restarted by its own deploy — can debounce
+// re-triggers instead of stacking deploys that bounce the fleet mid-verify
+// (#722). It lives in the state dir alongside the result file so it survives the
+// orchestrator unit restarting.
+const triggerMarkerName = "self-deploy-last-trigger.json"
+
 // Result is the JSON contract between scripts/self-deploy.sh and the
 // orchestrator.
 type Result struct {
@@ -82,6 +89,57 @@ func ClearResult(stateDir string) error {
 		return err
 	}
 	return nil
+}
+
+// triggerMarker is the JSON persisted by RecordTrigger / read by LastTrigger.
+type triggerMarker struct {
+	TriggeredAt time.Time `json:"triggered_at"`
+	PR          int       `json:"pr,omitempty"`
+}
+
+// triggerMarkerPath returns the path of the last-trigger marker inside stateDir.
+func triggerMarkerPath(stateDir string) string {
+	return filepath.Join(stateDir, triggerMarkerName)
+}
+
+// RecordTrigger persists the time (and PR) of a self-deploy trigger so a
+// re-evaluating — or restarted — orchestrator can debounce the same wave of
+// merges (#722). A blank stateDir is a no-op so callers without a state dir
+// (e.g. tests) do not write into the working directory.
+func RecordTrigger(stateDir string, prNumber int, now time.Time) error {
+	if strings.TrimSpace(stateDir) == "" {
+		return nil
+	}
+	data, err := json.Marshal(triggerMarker{TriggeredAt: now.UTC(), PR: prNumber})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return err
+	}
+	tmp := triggerMarkerPath(stateDir) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, triggerMarkerPath(stateDir))
+}
+
+// LastTrigger reports when a self-deploy was last triggered from stateDir, the
+// PR that triggered it, and whether a usable marker existed. A missing or
+// malformed marker reports ok=false (no debounce — fail open toward deploying).
+func LastTrigger(stateDir string) (when time.Time, pr int, ok bool) {
+	if strings.TrimSpace(stateDir) == "" {
+		return time.Time{}, 0, false
+	}
+	data, err := os.ReadFile(triggerMarkerPath(stateDir))
+	if err != nil {
+		return time.Time{}, 0, false
+	}
+	var m triggerMarker
+	if err := json.Unmarshal(data, &m); err != nil || m.TriggeredAt.IsZero() {
+		return time.Time{}, 0, false
+	}
+	return m.TriggeredAt, m.PR, true
 }
 
 // TriggerCommand builds the detached systemd-run invocation for a deploy

--- a/internal/selfdeploy/selfdeploy_test.go
+++ b/internal/selfdeploy/selfdeploy_test.go
@@ -57,6 +57,55 @@ func TestReadResultMalformed(t *testing.T) {
 	}
 }
 
+// #722: the trigger marker round-trips through the state dir so a restarted
+// orchestrator can debounce re-triggers.
+func TestRecordAndReadLastTrigger(t *testing.T) {
+	dir := t.TempDir()
+
+	// No marker yet → not ok.
+	if _, _, ok := LastTrigger(dir); ok {
+		t.Fatal("LastTrigger ok=true with no marker")
+	}
+
+	when := time.Date(2026, 6, 16, 15, 1, 39, 0, time.UTC)
+	if err := RecordTrigger(dir, 722, when); err != nil {
+		t.Fatalf("RecordTrigger: %v", err)
+	}
+	got, pr, ok := LastTrigger(dir)
+	if !ok {
+		t.Fatal("LastTrigger ok=false after RecordTrigger")
+	}
+	if !got.Equal(when) {
+		t.Errorf("LastTrigger time = %s, want %s", got, when)
+	}
+	if pr != 722 {
+		t.Errorf("LastTrigger pr = %d, want 722", pr)
+	}
+}
+
+// A blank state dir is a no-op (no marker written, nothing read) so callers
+// without a state dir don't scribble in the working directory.
+func TestTriggerMarkerBlankStateDir(t *testing.T) {
+	if err := RecordTrigger("", 1, time.Now().UTC()); err != nil {
+		t.Fatalf("RecordTrigger(\"\"): %v", err)
+	}
+	if _, _, ok := LastTrigger(""); ok {
+		t.Fatal("LastTrigger(\"\") ok=true, want false")
+	}
+}
+
+// A malformed marker fails open (ok=false) so a corrupt file never wedges
+// deploys forever.
+func TestLastTriggerMalformed(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(triggerMarkerPath(dir), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok := LastTrigger(dir); ok {
+		t.Fatal("LastTrigger ok=true for malformed marker")
+	}
+}
+
 func triggerTestConfig(t *testing.T) *config.Config {
 	t.Helper()
 	local := t.TempDir()

--- a/scripts/self-deploy.sh
+++ b/scripts/self-deploy.sh
@@ -12,10 +12,16 @@
 #      existing drain semantics are honored,
 #   4. verify post-restart health: installed CLI reports the stamped version,
 #      units are active, and (when --health-url is given) the running process
-#      reports the stamped version within the timeout,
+#      reports a version built from the deployed commit SHA within the timeout
+#      (SHA match, not full-string match, so a stamp vs Go pseudo-version
+#      formatting difference can't cause a false miss — #722),
 #   5. on failure roll back to <bin>.prev, restart the units again,
 #   6. write a JSON result file the orchestrator surfaces as a supervisor
 #      finding on its next cycle.
+#
+# A non-blocking single-flight lock (flock on <result-file>.lock) guarantees one
+# deploy at a time: a re-triggered deploy that lands while one is in flight exits
+# cleanly instead of bouncing the units mid-verify (#722).
 #
 # --scope selects the systemd unit manager (#716):
 #   * user   (default, back-compat) — `systemctl --user restart/is-active`,
@@ -182,12 +188,22 @@ units_active() {
 }
 
 health_ok() {
-  # Running-process check: the API must answer and report the stamped version.
-  local curl_args=(-fsS --max-time 10)
+  # Running-process check: the API must answer and report a version built from
+  # the deployed commit. Match on the commit SHA (embedded in the stamp as
+  # "+g<shortsha>") rather than the full version string: a stamped build reports
+  # "1.4.2+gf4550ef" while an unstamped one reports a Go pseudo-version
+  # "1.4.3-0.<ts>-f4550ef38a42" — same commit, different string. Matching the
+  # SHA is format-agnostic, so an ldflags-stamp vs pseudo-version mismatch can't
+  # cause a false verify miss (#722). The short SHA is a prefix of the 12-char
+  # pseudo-version SHA, so it matches both.
+  local curl_args=(-fsS --max-time 10) body
   if [[ -n "$HEALTH_TOKEN_ENV" && -n "${!HEALTH_TOKEN_ENV:-}" ]]; then
     curl_args+=(-H "Authorization: Bearer ${!HEALTH_TOKEN_ENV}")
   fi
-  curl "${curl_args[@]}" "$HEALTH_URL" 2>/dev/null | grep -qF "\"version\": \"$STAMP\""
+  body=$(curl "${curl_args[@]}" "$HEALTH_URL" 2>/dev/null) || return 1
+  # Constrain the SHA match to the reported "version" field (handles both
+  # indented `"version": "..."` and compact `"version":"..."` JSON).
+  printf '%s' "$body" | grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -qF "$SHORT_SHA"
 }
 
 verify() {
@@ -278,6 +294,29 @@ if (( INSTALL_VIA_SUDO )); then
 fi
 if [[ "$SCOPE" == "system" ]]; then
   log "scope=system — unit restarts run via sudo -n systemctl"
+fi
+
+# --- single-flight: one deploy at a time (#722) -----------------------------
+# Overlapping deploys restart the same units (notably the fleet web process the
+# verify step polls), so a re-triggered deploy landing on top of an in-flight
+# one bounces those units mid-verify and verify never converges. Take a
+# non-blocking exclusive lock; if another deploy already holds it, exit cleanly
+# without touching the binary or any unit — the in-flight deploy owns this wave.
+# (The orchestrator also debounces re-triggers; this is the host-side backstop.)
+LOCK_FD=
+if command -v flock >/dev/null 2>&1; then
+  LOCK_FILE="$RESULT_FILE.lock"
+  mkdir -p "$(dirname "$LOCK_FILE")"
+  exec {LOCK_FD}>"$LOCK_FILE" || fail "could not open self-deploy lock $LOCK_FILE"
+  if ! flock -n "$LOCK_FD"; then
+    log "another self-deploy holds $LOCK_FILE — skipping (one deploy at a time)"
+    trap - ERR EXIT
+    cleanup_build
+    exit 0
+  fi
+  log "acquired self-deploy lock $LOCK_FILE"
+else
+  log "flock not found — proceeding without single-flight lock"
 fi
 
 # --- 1. build from merged origin/main, version-stamped (#682) ---------------


### PR DESCRIPTION
Implements #722 (code/script/docs portion).

## Problem

Enabling `self_deploy` (system scope) on the dogfood orchestrator produced a
self-triggering deploy cascade whose verify never converged: the deploy restarts
the run-loop's own unit, so a burst of merges (or a run-loop restarted by its
own deploy) re-fired fresh deploys on top of in-flight ones. Stacked deploys
kept bouncing the fleet web process the verify step polls, so the API version
flapped between the new stamp and the rolled-back pseudo-version, verify timed
out, and every attempt rolled back and re-fired.

## Changes

Three independent guards, any one of which breaks the loop, combined for defense
in depth:

- **Verify on the commit SHA**, not the full version string (`scripts/self-deploy.sh` `health_ok`). A stamped build (`1.4.2+gf4550ef`) and a rolled-back Go pseudo-version (`1.4.3-0.<ts>-f4550ef38a42`) of the *same commit* now both satisfy the health check, so a stamp-vs-pseudo-version formatting difference can't cause a false miss.
- **Single-flight lock** — `self-deploy.sh` takes a non-blocking `flock` on `<result-file>.lock`; a re-triggered deploy that lands while one is in flight exits cleanly instead of restarting units mid-verify.
- **Orchestrator debounce** — each trigger is recorded in the state dir (`self-deploy-last-trigger.json`, survives the run-loop restart) and re-triggers within `self_deploy.min_interval_minutes` (default: `timeout_minutes`) are skipped.

Plus a new `min_interval_minutes` config knob and runbook updates.

## Testing

- `go test ./...` (full suite green)
- `go build ./cmd/maestro/`
- `gofmt` clean on changed Go files; `bash -n` clean on the script
- New unit tests cover the debounce window (skip-within / fire-after), the
  trigger-marker round-trip, and the `min_interval_minutes` config default/override.

## Runtime verification still required

This does not auto-close #722. Re-enabling `self_deploy` on the Loki dogfood
orchestrator and validating an end-to-end deploy → verify-pass → no-re-trigger
cycle on an idle fleet is an operator step that remains pending.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three independent guards to break the self-triggering deploy cascade described in #722: SHA-based health verification (tolerates stamp vs. Go pseudo-version format differences), a single-flight `flock` in the deploy script, and an orchestrator-side debounce that records each trigger in a persistent marker file and skips re-triggers within `min_interval_minutes`.

- **Debounce marker** (`self-deploy-last-trigger.json`) is written atomically after a successful `systemd-run` dispatch and survives run-loop restarts; missing or malformed markers fail open toward deploying.
- **`min_interval_minutes` config knob** defaults to `timeout_minutes` so at most one deploy runs per budget window; all three guard layers are exercised by new unit tests covering skip-within / fire-after / round-trip / malformed-marker paths.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the three cascade guards are logically sound and well-tested. The main operational edge case is that a fast rollback leaves the debounce marker active for the rest of the window, potentially delaying a follow-up fix PR.

The debounce marker is written on trigger but is never cleared or advanced when consumeSelfDeployResult processes a rolled_back or failed result. A deploy that fails within a few minutes starts a 30-minute silence window for new merges, so a developer's follow-up fix PR could be silently skipped until the window expires. Everything else — atomic writes, fail-open on malformed markers, SHA-based verify, single-flight lock — is correctly implemented and tested.

internal/orchestrator/orchestrator.go — the interaction between consumeSelfDeployResult and the debounce marker deserves a second look

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds debounce guard in maybeSelfDeployAfterMerge: reads the last-trigger marker, skips within the window, and records a new marker on successful trigger. The marker is not reset on rollback/failure result consumption, which can suppress re-deploys after a fast failure. |
| internal/selfdeploy/selfdeploy.go | Adds RecordTrigger and LastTrigger: atomic write via temp+rename, blank-stateDir no-op, and fail-open on missing/malformed marker. Implementation is correct. |
| scripts/self-deploy.sh | Adds single-flight flock and SHA-based health check. SHORT_SHA is a global set in the build step and used in health_ok; uninitialized if the function were ever called before the build step. Minor robustness concern. |
| internal/config/config.go | Adds MinIntervalMinutes field and EffectiveMinIntervalMinutes(): defaults to EffectiveTimeoutMinutes() when unset or zero. Clean and correct. |
| internal/orchestrator/selfdeploy_test.go | Two new tests cover debounce-within-window (skip) and debounce-after-window (fire + marker advance). Good coverage of the happy paths. |
| internal/selfdeploy/selfdeploy_test.go | Tests cover the trigger-marker round-trip, blank stateDir no-op, and malformed marker fail-open. Comprehensive unit coverage. |
| internal/config/selfdeploy_config_test.go | Tests EffectiveMinIntervalMinutes for default, explicit timeout, override, and YAML parse. Correct. |
| docs/self-deploy-runbook.md | Updates runbook with SHA-based verify explanation, cascade guards section, min_interval_minutes config knob, and new troubleshooting table rows. Accurate and helpful. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:3821-3829
**Debounce marker not cleared after rollback**

The debounce marker is written when a deploy is triggered but is never cleared or advanced when the result file is consumed by `consumeSelfDeployResult`. If a deploy rolls back quickly (e.g., within 5 minutes of a 30-minute window), the remaining ~25 minutes will silently debounce any new PR merges — including a "fix" PR pushed in response to the rollback. An operator would see no deploy triggered, no notification, only the log line `self-deploy debounced for PR #…`, with no indication that the previous deploy has already completed.

Advancing the marker to `result.FinishedAt` (or `time.Now()`) inside `consumeSelfDeployResult` when the status is `rolled_back` or `failed` would allow the next genuine trigger to fire as soon as the failed deploy is finished, rather than waiting for the full `min_interval_minutes` window to expire from the original trigger time.

### Issue 2 of 2
scripts/self-deploy.sh:203-206
**`SHORT_SHA` is set after the lock but referenced by name before it's exported**

`SHORT_SHA` is assigned at line 326 (inside the build step) but the `health_ok` function uses it as a bare `$SHORT_SHA` reference. If anything were ever to invoke `health_ok` before the build step (e.g. a future refactor that moves a verify call earlier, or a `verify()` call from a maintenance path), `SHORT_SHA` would be unset and `set -u` would abort the script with an error rather than returning a clean failure. Initialising `SHORT_SHA=""` alongside the other top-level variables (`STAMP=""`, `SHA=""`, etc.) at the top of the script would make the dependency explicit and prevent an accidental `set -u` abort in any future call-order change.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["self-deploy: break the self-triggering d..."](https://github.com/befeast/maestro/commit/974019a05425ffc3f359a3a87f93a71cfd07eb10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37917843)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->