### PR TITLE
[pi-glm-experiment] Add edge-case coverage to TestSplitCmd (#724)

### DIFF
--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -643,6 +643,12 @@ func TestSplitCmd(t *testing.T) {
 		{"claude --model claude-opus-4-6", "claude", []string{"--model", "claude-opus-4-6"}},
 		{"/usr/local/bin/codex --flag", "/usr/local/bin/codex", []string{"--flag"}},
 		{"  gemini  --fast  ", "gemini", []string{"--fast"}},
+		// multiple consecutive spaces between tokens collapse per strings.Fields
+		{"claude   --model   opus", "claude", []string{"--model", "opus"}},
+		// leading and trailing whitespace around a multi-token command is stripped
+		{"  claude --model opus  ", "claude", []string{"--model", "opus"}},
+		// tabs are valid field separators, just like spaces
+		{"claude\t--model\topus", "claude", []string{"--model", "opus"}},
 		{"", "", nil},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Refs #724

Adds whitespace edge cases to the existing TestSplitCmd table in internal/worker/backend_test.go:
- multiple consecutive spaces between tokens ("claude   --model   opus")
- leading and trailing whitespace on a multi-token command ("  claude --model opus  ")
- tab as a field separator ("claude\t--model\topus")

Each case asserts the expected binary and args per strings.Fields semantics.

Changes:
- internal/worker/backend_test.go: extend TestSplitCmd table only.

Testing:
- gofmt -l clean
- go test ./internal/worker/ -run TestSplitCmd passes
- go build ./cmd/maestro/ succeeds
- go test ./... passes

Maestro-Backend: pi-glm-experiment

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the `TestSplitCmd` table in `internal/worker/backend_test.go` with three whitespace edge cases that exercise `strings.Fields` splitting behaviour: consecutive inner spaces, leading/trailing whitespace with single-space-separated tokens, and tab characters as field separators.

- All three new cases are test-only, touch no production code, and use correct expected values (`binary` and `args`) consistent with `strings.Fields` semantics.
- Note: the second new case (`"  claude --model opus  "`) overlaps partially with the pre-existing `"  gemini  --fast  "` entry, which already covers leading/trailing whitespace; the new case adds a two-arg variant with single inner spaces, so it is not fully redundant, but reviewers may want to decide if the incremental coverage is worth an extra row.

<h3>Confidence Score: 5/5</h3>

Test-only change with no production code touched; all assertions are correct for strings.Fields behaviour.

The change is confined to three new table-driven test rows. Expected values are accurate, the helper under test is unchanged, and nothing outside the test file is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/backend_test.go | Extends TestSplitCmd with three whitespace edge cases: consecutive inner spaces, leading/trailing with single spaces between tokens, and tab separators — all with correct expected values per strings.Fields semantics. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(worker): add whitespace edge cases ..."](https://github.com/befeast/maestro/commit/d736cf976e43f8e5efe407d3fe4ab672b1e93c49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38724019)</sub>

<!-- /greptile_comment -->