### PR TITLE
config: validate model.fallback_backends references a defined backend (#727)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1263,7 +1263,7 @@ func parse(data []byte) (*Config, error) {
 	for _, fb := range cfg.Model.FallbackBackends {
 		def, ok := cfg.Model.Backends[fb]
 		if !ok {
-			continue // unknown backend names are caught elsewhere; we only gate non-agentic here.
+			return nil, fmt.Errorf("config: model.fallback_backends references %q which is not defined in model.backends; define it under model.backends or remove it from fallback_backends (the default backend is auto-defined, but fallback names must be declared explicitly)", fb)
 		}
 		if def.NonAgentic {
 			return nil, fmt.Errorf("config: model.fallback_backends includes %q which is marked non_agentic; the fallback chain is the worker chain — a non-agentic entry would produce fake-PR sessions when paid backends are exhausted. Remove %q from fallback_backends and use it only for supervisor sub-tasks", fb, fb)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1709,6 +1710,87 @@ model:
 	}
 	if cfg.Model.Default != "claude" {
 		t.Fatalf("Default = %q, want claude", cfg.Model.Default)
+	}
+}
+
+// #727: every entry in model.fallback_backends must resolve to a
+// backend declared under model.backends. The default backend is
+// auto-defined, but fallback names are not — a typo like "opencodee" used
+// to load cleanly and only blow up (quietly) at runtime when a fallback
+// was actually needed. Parse must fail fast and name the offender.
+func TestParse_FallbackBackendsMustReferenceDefinedBackend(t *testing.T) {
+	baseBackends := `
+    claude:
+      cmd: claude
+    codex:
+      cmd: codex
+    opencode:
+      cmd: opencode
+`
+	tests := []struct {
+		name        string
+		fallbacks   string
+		backends    string
+		wantErr     bool
+		wantSubstrs []string
+	}{
+		{
+			name:        "dangling fallback name rejected",
+			fallbacks:   "[codex, opencodee]",
+			backends:    baseBackends,
+			wantErr:     true,
+			wantSubstrs: []string{"opencodee", "fallback_backends", "backends"},
+		},
+		{
+			name:      "all fallback names defined load cleanly",
+			fallbacks: "[codex, opencode]",
+			backends:  baseBackends,
+			wantErr:   false,
+		},
+		{
+			name:      "default backend used as fallback is allowed (auto-defined)",
+			fallbacks: "[claude]",
+			backends:  baseBackends,
+			wantErr:   false,
+		},
+		{
+			name:        "empty fallback list is fine",
+			fallbacks:   "[]",
+			backends:    baseBackends,
+			wantErr:     false,
+			wantSubstrs: nil,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := []byte(fmt.Sprintf(`
+repo: owner/repo
+local_path: /tmp/repo
+worktree_base: /tmp/worktrees
+session_prefix: x
+model:
+  default: claude
+  fallback_backends: %s
+  backends:
+%s`, tc.fallbacks, tc.backends))
+			cfg, err := parse(yaml)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected parse to reject dangling fallback_backends entry, got nil error")
+				}
+				for _, s := range tc.wantSubstrs {
+					if !strings.Contains(err.Error(), s) {
+						t.Errorf("error = %q, want substring %q", err.Error(), s)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			_ = cfg
+		})
 	}
 }
 


### PR DESCRIPTION
Refs #727

## Changes
- `internal/config/config.go`: the fallback validation loop no longer `continue`s on an unknown backend name. It now returns an error naming the offending entry and pointing at `model.fallback_backends` / `model.backends`, so a typo (e.g. `opencodee`) is caught at config parse instead of silently degrading at runtime when a fallback is actually needed. The default backend is still auto-defined earlier in parse, so `model.default` used as a fallback keeps loading.
- `internal/config/config_test.go`: added table-driven `TestParse_FallbackBackendsMustReferenceDefinedBackend` covering a rejected dangling fallback (with error substrings for the offending name + `fallback_backends` + `backends`), an accepted valid fallback, the default-as-fallback case, and an empty list.

## Testing
- `gofmt` applied to changed files.
- `go build ./cmd/maestro/` succeeds.
- `go test ./internal/config/` passes (incl. the new test).
- `go test ./...` green across all packages.

Maestro-Backend: pi-ollama ollama glm-5.2:cloud (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent runtime degradation: a typo in `model.fallback_backends` (e.g. `opencodee`) previously loaded without error and only failed at the moment a fallback was actually needed. The fix replaces a `continue` with a descriptive `fmt.Errorf` so `parse` rejects unknown fallback names immediately.

- **`config.go`**: The unknown-backend branch in the fallback-validation loop now returns an error naming the offending entry and pointing to both `fallback_backends` and `backends`, making the failure fast and actionable.
- **`config_test.go`**: Four table-driven cases cover the rejected dangling name, a valid list, the empty list, and the default-as-fallback case — though that last case does not actually exercise the auto-define code path (see inline comment).

<h3>Confidence Score: 4/5</h3>

Safe to merge. The production logic change is a single-line, correct improvement that turns a silent degradation into a clear parse-time error.

The core fix in `config.go` is correct and well-scoped. The one test case that claims to cover the auto-defined-default-as-fallback path doesn't actually reach that code because `claude` is already present in `baseBackends`; the auto-define block (which runs before the fallback loop) is never exercised. The behavior is correct — the test just doesn't prove it for that specific path.

The "default backend used as fallback is allowed (auto-defined)" test case in `config_test.go` does not exercise the auto-define path it describes — it should omit `claude` from `backends` to do so.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | One-line change: replaces a silent `continue` on an unknown fallback backend with a descriptive error returned immediately, making typos in `model.fallback_backends` fail at config parse time instead of degrading silently at runtime. |
| internal/config/config_test.go | Adds a table-driven test covering the four main cases; the "auto-defined default as fallback" test case is mislabeled — it uses `baseBackends` which already includes `claude`, so the auto-define code path (lines 1250-1252) is never actually exercised. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/config/config_test.go:1750-1755
The test case named "default backend used as fallback is allowed (auto-defined)" uses `baseBackends`, which already declares `claude` explicitly. Because the auto-define logic (lines 1250–1252 of `config.go`) only runs when the default is absent from `backends`, this test never reaches that code path — it would pass even if the auto-define block were deleted. To actually exercise the path the comment describes, `backends` should omit `claude` so the auto-define runs before the fallback-lookup loop.

```suggestion
		{
			name:      "default backend used as fallback is allowed (auto-defined)",
			fallbacks: "[claude]",
			// Intentionally omit claude from backends so the auto-define
			// logic (cfg.Model.Backends[cfg.Model.Default] = ...) runs before
			// the fallback-lookup loop, which is the path this case exercises.
			backends: `
    codex:
      cmd: codex
    opencode:
      cmd: opencode
`,
			wantErr: false,
		},
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["config: validate model.fallback\_backends..."](https://github.com/befeast/maestro/commit/1dee9d5f5bb0cebaa0d2cd238bc7fc9ad3c3a6cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38732115)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->