### PR TITLE
[pi-glm-experiment] Validate model.fallback_backends references a defined backend (#727)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1263,7 +1263,11 @@ func parse(data []byte) (*Config, error) {
 	for _, fb := range cfg.Model.FallbackBackends {
 		def, ok := cfg.Model.Backends[fb]
 		if !ok {
-			continue // unknown backend names are caught elsewhere; we only gate non-agentic here.
+			// #727: fail fast at config parse. Previously a typo in
+			// fallback_backends was silently accepted and only surfaced at
+			// runtime (router/worker logged a warning and fell back to the
+			// default), which is exactly when you least want surprises.
+			return nil, fmt.Errorf("config: model.fallback_backends references %q which is not defined in model.backends; define the backend in model.backends or remove it from fallback_backends", fb)
 		}
 		if def.NonAgentic {
 			return nil, fmt.Errorf("config: model.fallback_backends includes %q which is marked non_agentic; the fallback chain is the worker chain — a non-agentic entry would produce fake-PR sessions when paid backends are exhausted. Remove %q from fallback_backends and use it only for supervisor sub-tasks", fb, fb)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1712,6 +1712,81 @@ model:
 	}
 }
 
+// #727: every entry in model.fallback_backends must reference a backend
+// declared in model.backends; a typo used to load cleanly and only
+// surface as a runtime warning in the router/worker. Fail fast at parse.
+func TestParse_FallbackBackendsMustBeDefined(t *testing.T) {
+	cases := []struct {
+		name     string
+		yaml     string
+		wantErr  bool
+		wantSubs []string // required substrings in the error message
+	}{
+		{
+			name: "dangling fallback rejected",
+			yaml: `
+repo: owner/repo
+model:
+  default: claude
+  fallback_backends: [codex, opencodee]
+  backends:
+    claude:
+      cmd: claude
+    codex:
+      cmd: codex
+`,
+			wantErr:  true,
+			wantSubs: []string{"fallback_backends", "opencodee", "model.backends"},
+		},
+		{
+			name: "valid fallback accepted",
+			yaml: `
+repo: owner/repo
+model:
+  default: claude
+  fallback_backends: [codex, opencode]
+  backends:
+    claude:
+      cmd: claude
+    codex:
+      cmd: codex
+    opencode:
+      cmd: opencode
+`,
+			wantErr: false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := parse([]byte(tc.yaml))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected parse error, got nil; cfg=%+v", cfg)
+				}
+				for _, want := range tc.wantSubs {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error = %q, want substring %q", err.Error(), want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			want := []string{"codex", "opencode"}
+			if len(cfg.Model.FallbackBackends) != len(want) {
+				t.Fatalf("FallbackBackends = %v, want %v", cfg.Model.FallbackBackends, want)
+			}
+			for i, fb := range cfg.Model.FallbackBackends {
+				if fb != want[i] {
+					t.Errorf("FallbackBackends[%d] = %q, want %q", i, fb, want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestParse_MaxConcurrentByStateDefault(t *testing.T) {
 	yaml := `repo: owner/repo`
 	cfg, err := parse([]byte(yaml))


### PR DESCRIPTION
Refs #727

## Changes
- `internal/config/config.go`: the `model.fallback_backends` validation loop no longer `continue`s on an unknown backend name. It returns a clear parse error naming the offending entry and pointing at `model.fallback_backends` / `model.backends`, so a typo (e.g. `fallback_backends: [opencodee]`) is caught at load time instead of silently degrading at runtime (router/worker warning + default-backend fallback).
- `internal/config/config_test.go`: added a table-driven `TestParse_FallbackBackendsMustBeDefined` covering a rejected dangling fallback (asserts the error mentions `fallback_backends`, the offending name, and `model.backends`) and an accepted valid fallback chain (no regression for the dogfood-style `[codex, opencode]` config).

## Testing
- `gofmt -w` on changed files.
- `go build ./cmd/maestro/` succeeds.
- `go test ./...` green (incl. `./internal/config/`, `./internal/configstore/`, `./internal/worker/`).

Maestro-Backend: pi-ollama

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tightens config validation by converting a silent `continue` for undefined `fallback_backends` entries into a hard parse error, so a typo like `opencodee` is caught at load time rather than degrading silently at runtime.

- `config.go`: the `!ok` branch now returns a descriptive `fmt.Errorf` naming the offending entry and pointing at both `model.fallback_backends` and `model.backends`, consistent with the existing non-agentic guard on the same loop.
- `config_test.go`: adds `TestParse_FallbackBackendsMustBeDefined` with two table cases — one asserting the error contains the right substrings for a dangling name, one asserting a fully-defined chain parses cleanly and preserves order.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, targeted tightening of an existing validation loop with no behavioural risk for correctly-configured deployments.

The one-line logic change is straightforward: an unknown fallback backend now produces an immediate, descriptive error instead of being silently ignored. The ordering relative to the default-backend auto-creation at line 1250 is correct. The new test covers both the rejection and the happy path, and the existing non-agentic guard on the same loop is unaffected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Converts a silent `continue` for unknown fallback backends into a hard parse error with a clear, descriptive message; the auto-creation of the default backend at line 1250 correctly happens before this loop, so the ordering is safe. |
| internal/config/config_test.go | Adds a well-structured table-driven test covering both the rejection of a dangling fallback and the acceptance of a fully-defined fallback chain; error substrings are verified explicitly. |

</details>

<sub>Reviews (1): Last reviewed commit: ["config: validate model.fallback\_backends..."](https://github.com/befeast/maestro/commit/ae2f8819a7ac926dc4fd662ae9363a6313200ae6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38732242)</sub>

<!-- /greptile_comment -->