### PR TITLE
worker: first-class Pi backend with usage parsing (#730)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -2355,25 +2355,32 @@ func historyCmd(args []string) {
 
 	if *jsonOutput {
 		type jsonEntry struct {
-			Session    string `json:"session"`
-			Issue      int    `json:"issue"`
-			Title      string `json:"title"`
-			Status     string `json:"status"`
-			PRNumber   int    `json:"pr_number,omitempty"`
-			Duration   string `json:"duration"`
-			FinishedAt string `json:"finished_at,omitempty"`
-			Backend    string `json:"backend,omitempty"`
+			Session         string  `json:"session"`
+			Issue           int     `json:"issue"`
+			Title           string  `json:"title"`
+			Status          string  `json:"status"`
+			PRNumber        int     `json:"pr_number,omitempty"`
+			Duration        string  `json:"duration"`
+			FinishedAt      string  `json:"finished_at,omitempty"`
+			Backend         string  `json:"backend,omitempty"`
+			Model           string  `json:"model,omitempty"`
+			TokensUsedTotal int     `json:"tokens_used_total,omitempty"`
+			CostUSDEstimate float64 `json:"cost_usd_estimate,omitempty"`
 		}
 		entries := make([]jsonEntry, 0, len(completed))
 		for _, c := range completed {
+			sess := c.Session
 			entry := jsonEntry{
-				Session:  c.SlotName,
-				Issue:    c.IssueNumber,
-				Title:    c.IssueTitle,
-				Status:   string(c.Status),
-				PRNumber: c.PRNumber,
-				Duration: sessionDuration(c.Session),
-				Backend:  c.Backend,
+				Session:         c.SlotName,
+				Issue:           c.IssueNumber,
+				Title:           c.IssueTitle,
+				Status:          string(c.Status),
+				PRNumber:        c.PRNumber,
+				Duration:        sessionDuration(sess),
+				Backend:         c.Backend,
+				Model:           sess.Model,
+				TokensUsedTotal: sess.TokensUsedTotal,
+				CostUSDEstimate: server.SessionCostEstimate(cfg, c.Backend, sess.TokensUsedTotal, sess.CostUSDBackend),
 			}
 			if c.FinishedAt != nil {
 				entry.FinishedAt = c.FinishedAt.Format(time.RFC3339)

--- a/internal/config/backend_kind.go
+++ b/internal/config/backend_kind.go
@@ -17,6 +17,7 @@ const (
 	BackendKindCodex   = "codex"
 	BackendKindGemini  = "gemini"
 	BackendKindCline   = "cline"
+	BackendKindPi      = "pi"
 	BackendKindGeneric = "generic"
 )
 
@@ -32,6 +33,8 @@ var providerBackendKinds = map[string]string{
 	"google":    BackendKindGemini,
 	"gemini":    BackendKindGemini,
 	"cline":     BackendKindCline,
+	"pi":        BackendKindPi,
+	"ollama":    BackendKindPi,
 }
 
 // ResolveBackendKind decides which CLI-specific exec path a backend uses.
@@ -48,7 +51,7 @@ var providerBackendKinds = map[string]string{
 // mutating tool call was denied by the CLI's permission layer (sup-175).
 func ResolveBackendKind(name, provider, cmd string) string {
 	switch name {
-	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline:
+	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindPi:
 		return name
 	}
 	if kind, ok := providerBackendKinds[strings.ToLower(strings.TrimSpace(provider))]; ok {
@@ -68,7 +71,7 @@ func backendKindFromCmd(cmd string) string {
 		return ""
 	}
 	switch base := filepath.Base(fields[0]); base {
-	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline:
+	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindPi:
 		return base
 	}
 	return ""
@@ -100,7 +103,7 @@ func (c *Config) backendResolutionWarnings() []string {
 		kind := ResolveBackendKind(name, def.Provider, def.Cmd)
 		if kind == BackendKindGeneric {
 			warnings = append(warnings, fmt.Sprintf(
-				"config: backend %q resolves to the generic exec path (provider %q and cmd %q match no known CLI) — workers run without a permission-bypass flag (mutating tool calls may be denied) and the prompt is delivered per prompt_mode=%q (argv delivery risks E2BIG on large prompts). If this wraps a known CLI, set provider: anthropic|openai|google|cline or use a claude/codex/gemini/cline binary in cmd.",
+				"config: backend %q resolves to the generic exec path (provider %q and cmd %q match no known CLI) — workers run without a permission-bypass flag (mutating tool calls may be denied) and the prompt is delivered per prompt_mode=%q (argv delivery risks E2BIG on large prompts). If this wraps a known CLI, set provider: anthropic|openai|google|cline|pi|ollama or use a claude/codex/gemini/cline/pi binary in cmd.",
 				name, def.Provider, def.Cmd, coalescePromptMode(def.PromptMode)))
 			continue
 		}

--- a/internal/config/backend_kind_test.go
+++ b/internal/config/backend_kind_test.go
@@ -24,6 +24,9 @@ func TestResolveBackendKind(t *testing.T) {
 		{"fast", "openai", "codex --profile fast", BackendKindCodex},
 		{"flash", "google", "gemini", BackendKindGemini},
 		{"wrapped", "cline", "cline", BackendKindCline},
+		// #730: provider pi / ollama resolves to the first-class pi backend.
+		{"pi-ollama", "ollama", "pi", BackendKindPi},
+		{"picustom", "pi", "my-pi-shim", BackendKindPi},
 		// Provider matching is case/whitespace-insensitive.
 		{"fable", " Anthropic ", "", BackendKindClaude},
 		// Provider wins over a conflicting cmd binary.
@@ -32,6 +35,7 @@ func TestResolveBackendKind(t *testing.T) {
 		{"mymodel", "", "/usr/local/bin/claude --model opus", BackendKindClaude},
 		{"mymodel", "", "codex --flag", BackendKindCodex},
 		{"mymodel", "groq", "gemini", BackendKindGemini},
+		{"picli", "", "/usr/local/bin/pi", BackendKindPi},
 		// 4. Everything else is generic.
 		{"helper", "groq", "groq-cli", BackendKindGeneric},
 		{"custom", "", "my-cli --verbose", BackendKindGeneric},
@@ -85,6 +89,24 @@ func TestConfig_Warnings_CustomBackendProviderResolvedNoWarning(t *testing.T) {
 	for _, msg := range cfg.Warnings() {
 		if strings.Contains(msg, "generic exec path") {
 			t.Fatalf("Warnings() = %v, provider/basename-resolved backends should not trigger the generic path warning", cfg.Warnings())
+		}
+	}
+}
+
+// #730: a custom-named pi backend (provider: ollama) keeps the first-class
+// pi exec path — no generic-path warning.
+func TestConfig_Warnings_PiBackendNoGenericWarning(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "pi-ollama",
+			Backends: map[string]BackendDef{
+				"pi-ollama": {Provider: "ollama", Cmd: "pi", Model: "glm-5.2:cloud"},
+			},
+		},
+	}
+	for _, msg := range cfg.Warnings() {
+		if strings.Contains(msg, "generic exec path") {
+			t.Fatalf("Warnings() = %v, pi backend should not trigger the generic path warning", cfg.Warnings())
 		}
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -604,6 +604,13 @@ func (o *Orchestrator) updateTokensUsedFromOutput(slotName string, sess *state.S
 	if sess == nil {
 		return false
 	}
+	// #730: Pi-backed sessions stream a newline-delimited JSON event
+	// stream that carries provider/model + usage + cost. Parse it
+	// directly so model/tokens/cost_usd get attributed instead of the
+	// generic token regex (which sees none of the JSON shapes).
+	if o.backendKindForSession(sess) == config.BackendKindPi {
+		return o.updatePiUsageFromOutput(slotName, sess, output)
+	}
 	tokens := worker.ParseTokensFromOutput(output)
 	if tokens <= sess.TokensUsedAttempt {
 		return false
@@ -613,6 +620,55 @@ func (o *Orchestrator) updateTokensUsedFromOutput(slotName string, sess *state.S
 	sess.TokensUsedTotal += delta
 	log.Printf("[orch] %s tokens_used updated: attempt=%d total=%d", slotName, tokens, sess.TokensUsedTotal)
 	return true
+}
+
+// updatePiUsageFromOutput parses a Pi --mode json event stream from the
+// worker log and stamps model/tokens/cost_usd onto the session. Tokens use
+// the run-total (sum across turns); model is the provider-reported model;
+// cost is Pi's self-reported cost.total. Returns true when anything changed.
+func (o *Orchestrator) updatePiUsageFromOutput(slotName string, sess *state.Session, output string) bool {
+	usage, ok := worker.ParsePiUsage(output)
+	if !ok {
+		return false
+	}
+	changed := false
+	if usage.TotalTokens > sess.TokensUsedAttempt {
+		delta := usage.TotalTokens - sess.TokensUsedAttempt
+		sess.TokensUsedAttempt = usage.TotalTokens
+		sess.TokensUsedTotal += delta
+		changed = true
+	}
+	if strings.TrimSpace(usage.Model) != "" && strings.TrimSpace(sess.Model) == "" {
+		sess.Model = usage.Model
+		changed = true
+	}
+	if usage.CostUSD > 0 && sess.CostUSDBackend == 0 {
+		sess.CostUSDBackend = usage.CostUSD
+		changed = true
+	}
+	if changed {
+		log.Printf("[orch] %s pi usage: model=%s tokens=%d cost=$%.4f (total=%d)",
+			slotName, usage.Model, usage.TotalTokens, usage.CostUSD, sess.TokensUsedTotal)
+	}
+	return changed
+}
+
+// backendKindForSession resolves the CLI exec-path kind for a session's
+// backend from the configured backend def, so Pi (and other provider-mapped
+// backends) get their first-class usage parser instead of the generic one.
+func (o *Orchestrator) backendKindForSession(sess *state.Session) string {
+	if sess == nil {
+		return ""
+	}
+	name := strings.TrimSpace(sess.Backend)
+	var provider, cmd string
+	if o != nil && o.cfg != nil {
+		if def, ok := o.cfg.Model.Backends[name]; ok {
+			provider = def.Provider
+			cmd = def.Cmd
+		}
+	}
+	return config.ResolveBackendKind(name, provider, cmd)
 }
 
 func (o *Orchestrator) updateTokensUsedFromWorkerLog(slotName string, sess *state.Session) bool {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9529,3 +9529,71 @@ func TestAutoMergePRs_NoPRRetryExhaustedHasMergedPRErrorDefersReconcile(t *testi
 		t.Fatalf("transient probe failure must not mark reconciled; LastNotifiedStatus=%q", sess.LastNotifiedStatus)
 	}
 }
+
+// #730: a Pi-backed session's JSON event stream is parsed for usage, and the
+// orchestrator stamps model/tokens/cost_usd onto the session instead of the
+// generic token regex (which sees none of the JSON shapes).
+func TestUpdateTokensUsedFromOutput_PiBackendStampsModelTokensCost(t *testing.T) {
+	const piLog = `{"type":"session","version":3,"id":"abc"}
+{"type":"turn_end","message":{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":770,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":773,"cost":{"input":0.001078,"output":0.0000132,"total":0.0010912}}},"toolResults":[]}
+`
+	o := &Orchestrator{
+		cfg: &config.Config{
+			StateDir: t.TempDir(),
+			Model: config.ModelConfig{
+				Default: "pi-ollama",
+				Backends: map[string]config.BackendDef{
+					"pi-ollama": {Provider: "ollama", Cmd: "pi", Model: "glm-5.2:cloud"},
+				},
+			},
+		},
+	}
+	sess := &state.Session{Backend: "pi-ollama"}
+
+	changed := o.updateTokensUsedFromOutput("sup-730", sess, piLog)
+	if !changed {
+		t.Fatal("expected updateTokensUsedFromOutput to report a change for the Pi event stream")
+	}
+	if sess.TokensUsedAttempt != 773 {
+		t.Errorf("TokensUsedAttempt = %d, want 773", sess.TokensUsedAttempt)
+	}
+	if sess.TokensUsedTotal != 773 {
+		t.Errorf("TokensUsedTotal = %d, want 773", sess.TokensUsedTotal)
+	}
+	if sess.Model != "glm-5.2:cloud" {
+		t.Errorf("Model = %q, want glm-5.2:cloud", sess.Model)
+	}
+	if sess.CostUSDBackend < 0.0010911 || sess.CostUSDBackend > 0.0010913 {
+		t.Errorf("CostUSDBackend = %v, want ~0.0010912", sess.CostUSDBackend)
+	}
+}
+
+// #730: a non-Pi backend (claude/codex) keeps the generic token parser — the
+// Pi usage path must not engage just because the log happens to contain JSON.
+func TestUpdateTokensUsedFromOutput_ClaudeBackendKeepsGenericParser(t *testing.T) {
+	const claudeLog = "worker output\n\ntokens used\n100,965\nImplemented and opened PR\n"
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Model: config.ModelConfig{
+				Default: "claude",
+				Backends: map[string]config.BackendDef{
+					"claude": {Cmd: "claude"},
+				},
+			},
+		},
+	}
+	sess := &state.Session{Backend: "claude"}
+	changed := o.updateTokensUsedFromOutput("sup-150", sess, claudeLog)
+	if !changed {
+		t.Fatal("expected generic parser to capture tokens")
+	}
+	if sess.TokensUsedAttempt != 100965 {
+		t.Errorf("TokensUsedAttempt = %d, want 100965", sess.TokensUsedAttempt)
+	}
+	if sess.Model != "" {
+		t.Errorf("Model = %q, want empty (claude does not self-report a model here)", sess.Model)
+	}
+	if sess.CostUSDBackend != 0 {
+		t.Errorf("CostUSDBackend = %v, want 0", sess.CostUSDBackend)
+	}
+}

--- a/internal/server/cost_observability.go
+++ b/internal/server/cost_observability.go
@@ -388,3 +388,22 @@ func applySessionCostEstimate(backend string, tokens int, pricing map[string]con
 	}
 	return p.EstimateCostUSD(tokens)
 }
+
+// sessionCostEstimate returns the USD cost to surface for a session. It
+// prefers the backend's self-reported cost (Pi --mode json cost.total,
+// #730) and falls back to the per-backend pricing estimate (#619) when the
+// backend did not report a cost. Zero when neither is available.
+func sessionCostEstimate(backend string, tokens int, pricing map[string]config.BackendPricing, backendCost float64) float64 {
+	if backendCost > 0 {
+		return backendCost
+	}
+	return applySessionCostEstimate(backend, tokens, pricing)
+}
+
+// SessionCostEstimate is the exported form used by cmd/maestro (history
+// --json) so the CLI does not need to rebuild the pricing map logic. It
+// prefers the backend's self-reported cost and falls back to the configured
+// per-backend pricing estimate.
+func SessionCostEstimate(cfg *config.Config, backend string, tokens int, backendCost float64) float64 {
+	return sessionCostEstimate(backend, tokens, backendPricingMap(cfg), backendCost)
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -761,6 +761,9 @@ type fleetWorkerState struct {
 	NeedsAttention bool   `json:"needs_attention,omitempty"`
 	Live           bool   `json:"live"`
 	Backend        string `json:"backend,omitempty"`
+	// #730: model the backend self-reported for this run (Pi --mode json).
+	// Empty for backends that do not self-report a model.
+	Model string `json:"model,omitempty"`
 	// BackendSelection records why this backend was chosen (label, role, auto,
 	// default, router_error, phase, review_repair). Surfaced on the fleet drawer
 	// so operators can tell task-based routing from label-pinned defaults. (#427)
@@ -770,10 +773,15 @@ type fleetWorkerState struct {
 	TokensUsedAttempt int                     `json:"tokens_used_attempt"`
 	TokensUsedTotal   int                     `json:"tokens_used_total"`
 	// CostUSDEstimate is the $ estimate for TokensUsedTotal under the
-	// project's configured per-backend pricing (#619). 0 when no
-	// pricing is set for the backend; the SPA renders that as tokens
-	// only without computing pricing client-side.
+	// project's configured per-backend pricing (#619), OR the backend's
+	// self-reported cost when present (#730, Pi --mode json cost.total). 0
+	// when neither is set; the SPA renders that as tokens only without
+	// computing pricing client-side.
 	CostUSDEstimate float64 `json:"cost_usd_estimate,omitempty"`
+	// CostUSDBackend is the USD cost the backend self-reported (#730).
+	// Zero when not reported; surfaced separately from the pricing estimate
+	// so Mission Control can mark the value as backend-reported.
+	CostUSDBackend float64 `json:"cost_usd_backend,omitempty"`
 	// Runtime / RuntimeSeconds (legacy fields, kept for backwards
 	// compatibility) reflect workflow elapsed time and include PR-open /
 	// CI / Greptile / merge waiting. See #426 — WorkerRuntimeSeconds is
@@ -872,7 +880,7 @@ func (s *FleetServer) handleFleetWorker(w http.ResponseWriter, r *http.Request) 
 	infos := []sessionInfo{makeSessionInfo(project.cfg.Repo, slot, sess)}
 	applySupervisorAttention(infos, st.LatestSupervisorDecision())
 	pricing := backendPricingMap(project.cfg)
-	infos[0].CostUSDEstimate = applySessionCostEstimate(infos[0].Backend, infos[0].TokensUsedTotal, pricing)
+	infos[0].CostUSDEstimate = sessionCostEstimate(infos[0].Backend, infos[0].TokensUsedTotal, pricing, infos[0].CostUSDBackend)
 	infos[0].Actions = workerActionAffordances(projectState.ReadOnly, "/api/v1/fleet/actions", infos[0])
 	worker := makeFleetWorkerState(projectState, infos[0])
 	lines := parsePositiveInt(r.URL.Query().Get("lines"), 260)
@@ -3437,12 +3445,14 @@ func makeFleetWorkerState(project fleetProjectState, worker sessionInfo) fleetWo
 		NeedsAttention:         worker.NeedsAttention,
 		Live:                   worker.Live,
 		Backend:                worker.Backend,
+		Model:                  worker.Model,
 		BackendSelection:       worker.BackendSelection,
 		PRNumber:               worker.PRNumber,
 		PRURL:                  worker.PRURL,
 		TokensUsedAttempt:      worker.TokensUsedAttempt,
 		TokensUsedTotal:        worker.TokensUsedTotal,
 		CostUSDEstimate:        worker.CostUSDEstimate,
+		CostUSDBackend:         worker.CostUSDBackend,
 		Runtime:                worker.Runtime,
 		RuntimeSeconds:         worker.RuntimeSeconds,
 		WorkerRuntime:          worker.WorkerRuntime,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -276,27 +276,34 @@ type controlActionRequest struct {
 }
 
 type sessionInfo struct {
-	Slot              string `json:"slot"`
-	IssueNumber       int    `json:"issue_number"`
-	IssueTitle        string `json:"issue_title"`
-	IssueURL          string `json:"issue_url,omitempty"`
-	Status            string `json:"status"`
-	DisplayStatus     string `json:"display_status,omitempty"`
-	StatusReason      string `json:"status_reason,omitempty"`
-	NextAction        string `json:"next_action,omitempty"`
-	NeedsAttention    bool   `json:"needs_attention,omitempty"`
-	Live              bool   `json:"live"`
-	Backend           string `json:"backend,omitempty"`
+	Slot           string `json:"slot"`
+	IssueNumber    int    `json:"issue_number"`
+	IssueTitle     string `json:"issue_title"`
+	IssueURL       string `json:"issue_url,omitempty"`
+	Status         string `json:"status"`
+	DisplayStatus  string `json:"display_status,omitempty"`
+	StatusReason   string `json:"status_reason,omitempty"`
+	NextAction     string `json:"next_action,omitempty"`
+	NeedsAttention bool   `json:"needs_attention,omitempty"`
+	Live           bool   `json:"live"`
+	Backend        string `json:"backend,omitempty"`
+	// #730: model the backend self-reported for this run (Pi --mode json).
+	// Empty for backends that do not self-report a model.
+	Model             string `json:"model,omitempty"`
 	PRNumber          int    `json:"pr_number,omitempty"`
 	PRURL             string `json:"pr_url,omitempty"`
 	TokensUsedAttempt int    `json:"tokens_used_attempt"`
 	TokensUsedTotal   int    `json:"tokens_used_total"`
 	// CostUSDEstimate is the $ estimate for this session's
-	// TokensUsedTotal under the configured per-backend pricing (#619).
-	// Zero when no pricing is configured for the backend or when the
-	// token count is zero. The SPA reads this directly so it never
-	// computes pricing client-side.
+	// TokensUsedTotal under the configured per-backend pricing (#619),
+	// OR the backend's self-reported cost when present (#730, Pi
+	// --mode json cost.total). Zero when neither is available. The SPA
+	// reads this directly so it never computes pricing client-side.
 	CostUSDEstimate float64 `json:"cost_usd_estimate,omitempty"`
+	// CostUSDBackend is the USD cost the backend self-reported (#730).
+	// Surfaced separately so Mission Control can show "reported by
+	// backend" vs the pricing-block estimate. Zero when not reported.
+	CostUSDBackend float64 `json:"cost_usd_backend,omitempty"`
 	// Runtime / RuntimeSeconds (legacy fields, kept for backwards
 	// compatibility) reflect WORKFLOW elapsed time — StartedAt to
 	// FinishedAt — including PR-open / CI / Greptile / merge waiting.
@@ -342,10 +349,12 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 		IssueURL:          githubIssueURL(repo, sess.IssueNumber),
 		Status:            string(sess.Status),
 		Backend:           sess.Backend,
+		Model:             sess.Model,
 		PRNumber:          sess.PRNumber,
 		PRURL:             githubPRURL(repo, sess.PRNumber),
 		TokensUsedAttempt: sess.TokensUsedAttempt,
 		TokensUsedTotal:   sess.TokensUsedTotal,
+		CostUSDBackend:    sess.CostUSDBackend,
 		StartedAt:         sess.StartedAt.Format(time.RFC3339),
 		Worktree:          sess.Worktree,
 		Branch:            sess.Branch,
@@ -965,7 +974,7 @@ func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 	pricing := backendPricingMap(cfg)
 	var activeTokens, totalTokens int
 	for _, info := range sessionInfosWithActions(cfg.Repo, st, cfg.Server.ReadOnly, "/api/v1/actions") {
-		info.CostUSDEstimate = applySessionCostEstimate(info.Backend, info.TokensUsedTotal, pricing)
+		info.CostUSDEstimate = sessionCostEstimate(info.Backend, info.TokensUsedTotal, pricing, info.CostUSDBackend)
 		resp.All = append(resp.All, info)
 		summaryStatus := info.Status
 		if info.DisplayStatus != "" {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -132,18 +132,24 @@ const (
 )
 
 type Session struct {
-	IssueNumber                 int               `json:"issue_number"`
-	IssueTitle                  string            `json:"issue_title"`
-	Worktree                    string            `json:"worktree"`
-	Branch                      string            `json:"branch"`
-	PID                         int               `json:"pid"`
-	TmuxSession                 string            `json:"tmux_session,omitempty"`
-	LogFile                     string            `json:"log_file"`
-	StartedAt                   time.Time         `json:"started_at"`
-	FinishedAt                  *time.Time        `json:"finished_at,omitempty"`
-	Status                      SessionStatus     `json:"status"`
-	PRNumber                    int               `json:"pr_number,omitempty"`
-	Backend                     string            `json:"backend,omitempty"` // "claude", "codex", etc.
+	IssueNumber int           `json:"issue_number"`
+	IssueTitle  string        `json:"issue_title"`
+	Worktree    string        `json:"worktree"`
+	Branch      string        `json:"branch"`
+	PID         int           `json:"pid"`
+	TmuxSession string        `json:"tmux_session,omitempty"`
+	LogFile     string        `json:"log_file"`
+	StartedAt   time.Time     `json:"started_at"`
+	FinishedAt  *time.Time    `json:"finished_at,omitempty"`
+	Status      SessionStatus `json:"status"`
+	PRNumber    int           `json:"pr_number,omitempty"`
+	Backend     string        `json:"backend,omitempty"` // "claude", "codex", etc.
+	// #730: model + self-reported cost captured from the backend's own
+	// usage stream (Pi --mode json event stream). Empty/zero for backends
+	// that do not self-report; the fleet cost panel then falls back to the
+	// configured per-backend pricing estimate.
+	Model                       string            `json:"model,omitempty"`            // model the backend reported for this run (e.g. glm-5.2:cloud)
+	CostUSDBackend              float64           `json:"cost_usd_backend,omitempty"` // USD cost the backend self-reported (Pi cost.total)
 	LongRunning                 bool              `json:"long_running,omitempty"`
 	RebaseAttempted             bool              `json:"rebase_attempted,omitempty"`
 	NotifiedCIFail              bool              `json:"notified_ci_fail,omitempty"`           // deprecated: use LastNotifiedStatus

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -47,6 +47,7 @@ var knownBackends = map[string]Backend{
 	"cline":  clineBackend{},
 	"codex":  codexBackend{},
 	"gemini": geminiBackend{},
+	"pi":     piBackend{},
 }
 
 // --- Claude Backend ---
@@ -122,6 +123,56 @@ func (geminiBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = worktree
 	return cmd, "", nil
+}
+
+// --- Pi Backend ---
+
+// piWorkerTools is the default built-in tool allowlist for an autonomous
+// Pi worker run. read/bash/edit/write are on by default in Pi; grep/find/ls
+// are off by default — enable them so the worker can search the worktree.
+// Operators can override the allowlist per-backend via extra_args (a
+// trailing --tools wins) or narrow it there for locked-down runs. #730.
+const piWorkerTools = "read,bash,edit,write,grep,find,ls"
+
+// piBackend runs the Pi coding agent (badlogic/pi-mono) headless in JSON
+// event-stream mode so Maestro can capture provider usage (model/tokens/
+// cost) the way it does for the first-class claude/codex backends. #730.
+//
+// Pi is invoked as: pi --mode json --no-session --provider <provider>
+// --model <model> --tools <allowlist> [extra_args...] -p
+//
+// Print mode (-p) reads the prompt from stdin when no prompt argument is
+// given, mirroring claude -p / codex - and keeping large worker prompts
+// (retries append CI-failure + review context) under the Linux
+// MAX_ARG_STRLEN single-argument limit (128 KiB). The runner script wires
+// promptFile to stdin. The newline-delimited JSON event stream is written
+// to the worker log, where the orchestrator's Pi usage parser aggregates
+// model/tokens/cost from turn_end / agent_end events.
+type piBackend struct{}
+
+func (piBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
+	piCmd := cfg.Cmd
+	if piCmd == "" {
+		piCmd = "pi"
+	}
+	binary, cmdArgs := splitCmd(piCmd)
+	args := append([]string(nil), cmdArgs...)
+	args = append(args, "--mode", "json", "--no-session")
+	if p := strings.TrimSpace(cfg.Provider); p != "" {
+		args = append(args, "--provider", p)
+	}
+	if m := strings.TrimSpace(cfg.Model); m != "" {
+		args = append(args, "--model", m)
+	}
+	args = append(args, "--tools", piWorkerTools)
+	args = append(args, cfg.ExtraArgs...)
+	// -p with no prompt argument reads the prompt from stdin; keep it last
+	// so extra_args flags stay flags and never shadow the stdin prompt.
+	args = append(args, "-p")
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = worktree
+	// Stdin redirection is handled by the runner script — no file opened here.
+	return cmd, promptFile, nil
 }
 
 // --- Cline Backend ---
@@ -440,6 +491,33 @@ func BuildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, workt
 		cmd := exec.Command(binary, args...)
 		cmd.Dir = worktree
 		return cmd, "", nil
+	case "pi":
+		piCmd := cfg.Cmd
+		if piCmd == "" {
+			piCmd = "pi"
+		}
+		binary, cmdArgs := splitCmd(piCmd)
+		args := append([]string(nil), cmdArgs...)
+		args = append(args, "--mode", "json", "--no-session")
+		if p := strings.TrimSpace(cfg.Provider); p != "" {
+			args = append(args, "--provider", p)
+		}
+		// Supervisor prompts are read-only; run Pi with no mutating tools so a
+		// decision prompt cannot accidentally touch the worktree. -p reads
+		// the prompt from stdin (no prompt argument), keeping supervisor
+		// prompts that embed live PR/issue/review context under the Linux
+		// MAX_ARG_STRLEN single-argument limit. Pi uses --thinking (not
+		// --effort) for reasoning level, so cfg.Effort is intentionally not
+		// mapped here; operators can pass --thinking via extra_args.
+		args = append(args, "--no-tools")
+		args = append(args, cfg.ExtraArgs...)
+		if m := strings.TrimSpace(cfg.Model); m != "" {
+			args = append(args, "--model", m)
+		}
+		args = append(args, "-p")
+		cmd := exec.Command(binary, args...)
+		cmd.Dir = worktree
+		return cmd, promptFile, nil
 	default:
 		return buildGenericSupervisorCmd(cfg, promptFile, worktree)
 	}

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -896,7 +896,7 @@ func TestBuildSupervisorCmd_CustomNameProviderAnthropic(t *testing.T) {
 
 func TestKnownBackends(t *testing.T) {
 	backends := KnownBackends()
-	expected := map[string]bool{"claude": false, "codex": false, "gemini": false, "cline": false}
+	expected := map[string]bool{"claude": false, "codex": false, "gemini": false, "cline": false, "pi": false}
 	for _, name := range backends {
 		if _, ok := expected[name]; ok {
 			expected[name] = true
@@ -906,5 +906,127 @@ func TestKnownBackends(t *testing.T) {
 		if !found {
 			t.Errorf("expected %q in KnownBackends(), got: %v", name, backends)
 		}
+	}
+}
+
+// #730: the Pi backend runs headless in JSON event-stream mode with the
+// prompt delivered via stdin (-p with no prompt argument) so a large worker
+// prompt never hits the Linux MAX_ARG_STRLEN single-argument limit.
+func TestBuildWorkerCmd_Pi(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("implement the issue"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	worktree := "/tmp/pi-worktree"
+
+	cfg := BackendConfig{Cmd: "pi", Provider: "ollama", Model: "glm-5.2:cloud", ExtraArgs: []string{"--verbose"}}
+	cmd, stdinFile, err := BuildWorkerCmd("pi", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q (Pi -p reads prompt from stdin)", stdinFile, promptFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	for _, want := range []string{"--mode json", "--no-session", "--provider ollama", "--model glm-5.2:cloud", "--tools", "-p", "--verbose"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("expected %q in args, got: %s", want, args)
+		}
+	}
+	if strings.Contains(args, "implement the issue") {
+		t.Errorf("prompt content must not appear in argv (stdin delivery): %s", args)
+	}
+	// -p must be the last token so extra_args flags stay flags.
+	if cmd.Args[len(cmd.Args)-1] != "-p" {
+		t.Errorf("expected -p as last arg, got: %v", cmd.Args)
+	}
+	if cmd.Dir != worktree {
+		t.Errorf("expected Dir=%s, got %s", worktree, cmd.Dir)
+	}
+}
+
+// #730: a large Pi prompt is delivered via stdin, never as an argument.
+func TestBuildWorkerCmd_PiLargePromptViaStdin(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	largePrompt := strings.Repeat("PI_PROMPT_PAYLOAD\n", (1<<20)/16+16)
+	if err := os.WriteFile(promptFile, []byte(largePrompt), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := BackendConfig{Cmd: "pi", Provider: "ollama", Model: "glm-5.2:cloud"}
+	cmd, stdinFile, err := BuildWorkerCmd("pi", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, a := range cmd.Args {
+		if strings.Contains(a, "PI_PROMPT_PAYLOAD") {
+			t.Fatalf("prompt content leaked into argv at index %d (E2BIG risk): %s", i, a)
+		}
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+}
+
+// #730: a custom-named Pi backend resolves via provider: ollama to the pi
+// exec path, mirroring the claude/codex custom-name behaviour from #684.
+func TestBuildWorkerCmd_CustomNameProviderOllama(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("do the thing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := BackendConfig{Cmd: "pi", Provider: "ollama", Model: "glm-5.2:cloud"}
+	cmd, stdinFile, err := BuildWorkerCmd("pi-ollama", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--mode json") || !strings.Contains(args, "--provider ollama") {
+		t.Errorf("expected pi json+provider args, got: %s", args)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	direct, _, err := BuildWorkerCmd("pi", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error building pi-key cmd: %v", err)
+	}
+	if !reflect.DeepEqual(cmd.Args, direct.Args) {
+		t.Errorf("custom-name args = %v, want same as pi-key args %v", cmd.Args, direct.Args)
+	}
+}
+
+// #730: the Pi supervisor command runs read-only (--no-tools) and delivers
+// the prompt via stdin, never via argv, and never with worker bypass flags.
+func TestBuildSupervisorCmd_PiReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("decide safely"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := BackendConfig{Cmd: "pi", Provider: "ollama", Model: "glm-5.2:cloud"}
+	cmd, stdinFile, err := BuildSupervisorCmd("pi", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdinFile != promptFile {
+		t.Errorf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	for _, want := range []string{"--mode json", "--no-session", "--provider ollama", "--model glm-5.2:cloud", "--no-tools", "-p"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("expected %q in args, got: %s", want, args)
+		}
+	}
+	if strings.Contains(args, "decide safely") {
+		t.Errorf("prompt content must not appear in argv (stdin delivery): %s", args)
+	}
+	if strings.Contains(args, "dangerously") || strings.Contains(args, "bypass") {
+		t.Errorf("supervisor command should not include worker permission bypass flags: %s", args)
+	}
+	if cmd.Args[len(cmd.Args)-1] != "-p" {
+		t.Errorf("expected -p as last arg, got: %v", cmd.Args)
 	}
 }

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -125,6 +125,8 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
 		Provider:   backendDef.Provider,
+		Model:      backendDef.Model,
+		Effort:     backendDef.Effort,
 		MCP:        backendDef.MCP,
 	}
 

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -43,6 +43,8 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
 		Provider:   backendDef.Provider,
+		Model:      backendDef.Model,
+		Effort:     backendDef.Effort,
 		MCP:        backendDef.MCP,
 	}
 

--- a/internal/worker/pi_usage.go
+++ b/internal/worker/pi_usage.go
@@ -1,0 +1,155 @@
+package worker
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// PiUsage is the aggregated provider usage parsed from a Pi `--mode json`
+// event stream (#730). Pi emits a newline-delimited stream of events; the
+// turn_end / message_end / agent_end events carry the per-turn provider
+// usage block (input/output/cacheRead/cacheWrite tokens + a self-computed
+// cost) and the provider/model that produced them.
+type PiUsage struct {
+	Provider    string  // last provider seen on a usage-bearing event
+	Model       string  // last model seen on a usage-bearing event
+	Input       int     // sum of input tokens across turns
+	Output      int     // sum of output tokens across turns
+	CacheRead   int     // sum of cache-read tokens across turns
+	CacheWrite  int     // sum of cache-write tokens across turns
+	TotalTokens int     // Input + Output + CacheRead + CacheWrite
+	CostUSD     float64 // sum of Pi self-reported cost.total across turns
+}
+
+// piUsageEvent is the subset of a Pi AgentSessionEvent line that carries
+// usage. Only the `message` field is decoded for turn_end / message_end;
+// agent_end carries a `messages` array instead.
+type piUsageEvent struct {
+	Type     string           `json:"type"`
+	Message  *piUsageMessage  `json:"message"`
+	Messages []piUsageMessage `json:"messages"`
+}
+
+// piUsageMessage is the subset of a Pi message carrying provider usage.
+type piUsageMessage struct {
+	Role     string        `json:"role"`
+	Provider string        `json:"provider"`
+	Model    string        `json:"model"`
+	Usage    *piUsageBlock `json:"usage"`
+}
+
+// piUsageBlock is Pi's per-turn usage object. `cost.total` is the USD Pi
+// computed from the model's `cost` rates in ~/.pi/agent/models.json.
+type piUsageBlock struct {
+	Input       int    `json:"input"`
+	Output      int    `json:"output"`
+	CacheRead   int    `json:"cacheRead"`
+	CacheWrite  int    `json:"cacheWrite"`
+	TotalTokens int    `json:"totalTokens"`
+	Cost        piCost `json:"cost"`
+}
+
+type piCost struct {
+	Input  float64 `json:"input"`
+	Output float64 `json:"output"`
+	Total  float64 `json:"total"`
+}
+
+// ParsePiUsage scans a Pi `--mode json` event stream (the buffered worker
+// log) and aggregates provider usage across turns. It returns ok=false
+// when no usage-bearing event is found, so callers can fall back to the
+// generic token parser for non-Pi logs.
+//
+// Aggregation strategy (#730):
+//
+//   - turn_end fires once per turn with that turn's assistant message usage,
+//     so summing input/output/cacheRead/cacheWrite + cost.total across all
+//     turn_end events gives the run total without double-counting;
+//   - message_end fires for both the user message (usage 0) and the
+//     assistant message (usage = the turn's usage), so it is only used as a
+//     fallback when no turn_end event is present (e.g. a truncated log that
+//     captured the assistant message_end but not the trailing turn_end);
+//   - agent_end's messages array carries the final assistant message usage
+//     and is the last-resort fallback for a log that ended mid-turn;
+//   - model/provider are taken from the last event that carried them.
+func ParsePiUsage(text string) (PiUsage, bool) {
+	var out PiUsage
+	seen := false
+	var fallback *piUsageBlock
+	var fallbackCost float64
+
+	lines := strings.Split(text, "\n")
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" || line[0] != '{' {
+			continue
+		}
+		var ev piUsageEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		switch ev.Type {
+		case "turn_end":
+			if ev.Message == nil || ev.Message.Usage == nil {
+				continue
+			}
+			out.Provider = nonEmpty(out.Provider, ev.Message.Provider)
+			out.Model = nonEmpty(out.Model, ev.Message.Model)
+			out.Input += ev.Message.Usage.Input
+			out.Output += ev.Message.Usage.Output
+			out.CacheRead += ev.Message.Usage.CacheRead
+			out.CacheWrite += ev.Message.Usage.CacheWrite
+			out.CostUSD += ev.Message.Usage.Cost.Total
+			seen = true
+		case "message_end":
+			// Only assistant messages carry usage; user messages report 0.
+			if ev.Message == nil || ev.Message.Usage == nil || ev.Message.Role != "assistant" {
+				continue
+			}
+			out.Provider = nonEmpty(out.Provider, ev.Message.Provider)
+			out.Model = nonEmpty(out.Model, ev.Message.Model)
+			fallback = ev.Message.Usage
+			fallbackCost = ev.Message.Usage.Cost.Total
+		case "agent_end":
+			// Take the last assistant message in the array as the fallback.
+			for i := len(ev.Messages) - 1; i >= 0; i-- {
+				m := ev.Messages[i]
+				if m.Role != "assistant" || m.Usage == nil {
+					continue
+				}
+				out.Provider = nonEmpty(out.Provider, m.Provider)
+				out.Model = nonEmpty(out.Model, m.Model)
+				if fallback == nil {
+					fallback = &piUsageBlock{
+						Input:       m.Usage.Input,
+						Output:      m.Usage.Output,
+						CacheRead:   m.Usage.CacheRead,
+						CacheWrite:  m.Usage.CacheWrite,
+						TotalTokens: m.Usage.TotalTokens,
+						Cost:        m.Usage.Cost,
+					}
+					fallbackCost = m.Usage.Cost.Total
+				}
+				break
+			}
+		}
+	}
+
+	if !seen && fallback != nil {
+		out.Input = fallback.Input
+		out.Output = fallback.Output
+		out.CacheRead = fallback.CacheRead
+		out.CacheWrite = fallback.CacheWrite
+		out.CostUSD = fallbackCost
+		seen = true
+	}
+	out.TotalTokens = out.Input + out.Output + out.CacheRead + out.CacheWrite
+	return out, seen
+}
+
+func nonEmpty(preferred, candidate string) string {
+	if strings.TrimSpace(candidate) == "" {
+		return preferred
+	}
+	return candidate
+}

--- a/internal/worker/pi_usage_test.go
+++ b/internal/worker/pi_usage_test.go
@@ -1,0 +1,133 @@
+package worker
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// #730: ParsePiUsage aggregates provider usage from a Pi --mode json event
+// stream and reports model/tokens/cost for session attribution.
+func TestParsePiUsage_SingleTurn(t *testing.T) {
+	// Real stream shape captured from `pi --mode json -p` against the
+	// ollama/glm-5.2:cloud provider (reformatted one line per event).
+	const stream = `{"type":"session","version":3,"id":"abc","timestamp":"2026-06-19T21:10:12.069Z","cwd":"/tmp"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"message_start","message":{"role":"assistant","content":[],"provider":"ollama","model":"glm-5.2:cloud","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"total":0}}}}
+{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"OK"}],"provider":"ollama","model":"glm-5.2:cloud","usage":{"input":770,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":773,"cost":{"input":0.001078,"output":0.0000132,"total":0.0010912}}}}
+{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"OK"}],"provider":"ollama","model":"glm-5.2:cloud","usage":{"input":770,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":773,"cost":{"input":0.001078,"output":0.0000132,"total":0.0010912}}},"toolResults":[]}
+{"type":"agent_end","messages":[{"role":"user","content":[{"type":"text","text":"Reply"}]},{"role":"assistant","content":[{"type":"text","text":"OK"}],"provider":"ollama","model":"glm-5.2:cloud","usage":{"input":770,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":773,"cost":{"input":0.001078,"output":0.0000132,"total":0.0010912}}}]}
+`
+	usage, ok := ParsePiUsage(stream)
+	if !ok {
+		t.Fatal("expected ok=true, got false")
+	}
+	if usage.Provider != "ollama" {
+		t.Errorf("Provider = %q, want ollama", usage.Provider)
+	}
+	if usage.Model != "glm-5.2:cloud" {
+		t.Errorf("Model = %q, want glm-5.2:cloud", usage.Model)
+	}
+	if usage.Input != 770 || usage.Output != 3 {
+		t.Errorf("Input/Output = %d/%d, want 770/3", usage.Input, usage.Output)
+	}
+	if usage.TotalTokens != 773 {
+		t.Errorf("TotalTokens = %d, want 773", usage.TotalTokens)
+	}
+	if math.Abs(usage.CostUSD-0.0010912) > 1e-9 {
+		t.Errorf("CostUSD = %v, want 0.0010912", usage.CostUSD)
+	}
+}
+
+// #730: multiple turns must sum usage + cost across turn_end events without
+// double-counting the duplicate message_end usage block.
+func TestParsePiUsage_MultiTurnSums(t *testing.T) {
+	const stream = `{"type":"turn_end","message":{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":1000,"output":10,"cacheRead":200,"cacheWrite":50,"totalTokens":1260,"cost":{"input":0.0014,"output":0.000044,"total":0.001444}}}}
+{"type":"turn_end","message":{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":2200,"output":20,"cacheRead":0,"cacheWrite":0,"totalTokens":2220,"cost":{"input":0.00308,"output":0.000088,"total":0.003168}}}}
+`
+	usage, ok := ParsePiUsage(stream)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if usage.Input != 3200 || usage.Output != 30 || usage.CacheRead != 200 || usage.CacheWrite != 50 {
+		t.Errorf("usage fields = in=%d out=%d cr=%d cw=%d, want 3200/30/200/50", usage.Input, usage.Output, usage.CacheRead, usage.CacheWrite)
+	}
+	if usage.TotalTokens != 3480 {
+		t.Errorf("TotalTokens = %d, want 3480", usage.TotalTokens)
+	}
+	if math.Abs(usage.CostUSD-(0.001444+0.003168)) > 1e-9 {
+		t.Errorf("CostUSD = %v, want %v", usage.CostUSD, 0.001444+0.003168)
+	}
+}
+
+// #730: a truncated log that captured the assistant message_end but not the
+// trailing turn_end still falls back to the message_end usage so the run is
+// attributed instead of dropping to tokens=0.
+func TestParsePiUsage_FallsBackToMessageEnd(t *testing.T) {
+	const stream = `{"type":"message_end","message":{"role":"user","content":[],"usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"total":0}}}}
+{"type":"message_end","message":{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":500,"output":5,"cacheRead":0,"cacheWrite":0,"totalTokens":505,"cost":{"total":0.0007}}}}
+`
+	usage, ok := ParsePiUsage(stream)
+	if !ok {
+		t.Fatal("expected ok=true from message_end fallback")
+	}
+	if usage.TotalTokens != 505 {
+		t.Errorf("TotalTokens = %d, want 505", usage.TotalTokens)
+	}
+	if usage.Model != "glm-5.2:cloud" {
+		t.Errorf("Model = %q, want glm-5.2:cloud", usage.Model)
+	}
+	if math.Abs(usage.CostUSD-0.0007) > 1e-9 {
+		t.Errorf("CostUSD = %v, want 0.0007", usage.CostUSD)
+	}
+}
+
+// #730: agent_end is the last-resort fallback for a log that ended mid-turn
+// with no turn_end / message_end.
+func TestParsePiUsage_FallsBackToAgentEnd(t *testing.T) {
+	const stream = `{"type":"agent_end","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]},{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":42,"output":2,"cacheRead":0,"cacheWrite":0,"totalTokens":44,"cost":{"total":0.0001}}}]}
+`
+	usage, ok := ParsePiUsage(stream)
+	if !ok {
+		t.Fatal("expected ok=true from agent_end fallback")
+	}
+	if usage.TotalTokens != 44 {
+		t.Errorf("TotalTokens = %d, want 44", usage.TotalTokens)
+	}
+	if usage.Model != "glm-5.2:cloud" {
+		t.Errorf("Model = %q, want glm-5.2:cloud", usage.Model)
+	}
+}
+
+// #730: a buffer with no usage-bearing events (e.g. a claude log or a Pi
+// startup banner) must report ok=false so the caller keeps the generic path.
+func TestParsePiUsage_NoUsageReturnsFalse(t *testing.T) {
+	const stream = `{"type":"session","version":3,"id":"abc"}
+{"type":"agent_start"}
+some non-JSON log line
+Tokens: 1234 input, 5678 output
+`
+	_, ok := ParsePiUsage(stream)
+	if ok {
+		t.Fatal("expected ok=false for a stream with no Pi usage events")
+	}
+}
+
+// #730: malformed JSON lines are skipped without aborting the parse.
+func TestParsePiUsage_SkipsMalformedLines(t *testing.T) {
+	const stream = `garbage line
+{not json
+{"type":"turn_end","message":{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":10,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":11,"cost":{"total":0.0001}}}}
+`
+	usage, ok := ParsePiUsage(stream)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if usage.TotalTokens != 11 {
+		t.Errorf("TotalTokens = %d, want 11", usage.TotalTokens)
+	}
+	if !strings.Contains(stream, "glm-5.2:cloud") && usage.Model != "glm-5.2:cloud" {
+		t.Errorf("Model = %q", usage.Model)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -108,6 +108,8 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
 		Provider:   backendDef.Provider,
+		Model:      backendDef.Model,
+		Effort:     backendDef.Effort,
 		MCP:        backendDef.MCP,
 	}
 
@@ -256,6 +258,8 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 		ExtraArgs:  backendDef.ExtraArgs,
 		PromptMode: backendDef.PromptMode,
 		Provider:   backendDef.Provider,
+		Model:      backendDef.Model,
+		Effort:     backendDef.Effort,
 		MCP:        backendDef.MCP,
 	}
 


### PR DESCRIPTION
Refs #730

## Changes

Adds a first-class `piBackend` so a Pi-backed session records non-null `model`, `tokens`, and `cost_usd` like the first-class `claude`/`codex` backends, instead of going through the generic exec path with no usage attribution.

- `internal/config/backend_kind.go`: `BackendKindPi` + provider maps for `pi`/`ollama` and the cmd-basename heuristic. A backend named `pi` or carrying `provider: pi`/`ollama` resolves to the pi exec path and no longer trips the "resolves to the generic exec path" warning.
- `internal/worker/backend.go`: `piBackend` runs `pi --mode json --no-session --provider … --model … --tools … -p` with the prompt delivered via stdin (`-p` with no prompt argument) to avoid E2BIG; the read-only supervisor path uses `--no-tools`. Worker `BackendConfig` now carries the backend def `Model`/`Effort` so `--model` is wired for the worker run.
- `internal/worker/pi_usage.go`: `ParsePiUsage` aggregates provider usage (input/output/cache + `cost.total`) across `turn_end` events, with `message_end`/`agent_end` fallbacks for truncated logs. Unit tests cover single-turn, multi-turn sum, fallbacks and malformed lines.
- `internal/state/state.go`: `Session` gains `Model` + `CostUSDBackend`.
- `internal/orchestrator/orchestrator.go`: Pi-backed sessions route to a dedicated usage parser that stamps model/tokens/cost_usd onto the session; non-Pi backends keep the generic token parser unchanged.
- `internal/server`: `sessionInfo`/`fleetWorkerState` surface `model` + backend-reported cost; `sessionCostEstimate` prefers the backend's self-reported cost and falls back to the configured pricing-block estimate.
- `cmd/maestro`: `history --json` emits `model`/`tokens_used_total`/`cost_usd_estimate`.

## Testing

- `gofmt` applied to all changed Go files.
- `go build ./cmd/maestro/` and `go test ./...` pass.
- New unit tests: `internal/worker/pi_usage_test.go` (json-usage parser), Pi backend BuildCmd / supervisor / custom-name resolution in `internal/worker/backend_test.go`, config resolution + no-generic-warning in `internal/config/backend_kind_test.go`, and orchestrator Pi-usage stamping vs. claude generic-parser retention in `internal/orchestrator/orchestrator_test.go`.
- Existing `claude`/`codex`/`gemini`/`cline`/`generic` backends unchanged.

## Notes

Runtime/dogfood verification on a live `pi-ollama` backend (label `model:pi-ollama`) is out of scope for this code PR and still required to confirm `maestro history --json` and the Mission Control fleet dashboard show non-null model/tokens/cost_usd end-to-end against a real Ollama-served model.

Maestro-Backend: pi-ollama ollama glm-5.2:cloud (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a first-class `piBackend` so Pi-backed sessions record non-null `model`, `tokens`, and `cost_usd` instead of falling through the generic exec path. It wires `pi --mode json --no-session` with stdin prompt delivery (avoiding E2BIG), a JSON usage parser aggregating `turn_end`/`message_end`/`agent_end` events, and surfaces the parsed data through `sessionInfo`, `fleetWorkerState`, and `history --json`.

- `piBackend.BuildCmd` and its supervisor counterpart build the subprocess command; `BackendConfig` now carries `Model`/`Effort` so `--model` is wired end-to-end in worker, respawn, checkpoint, and phase paths.
- `ParsePiUsage` sums provider usage across all `turn_end` events in the buffered log, with `message_end`/`agent_end` fallbacks for truncated runs.
- `updatePiUsageFromOutput` stamps `model`/`tokens`/`CostUSDBackend` onto the session; the cost-update guard has a bug where it uses `== 0` instead of a watermark comparison, freezing the cost after the first parse while tokens accumulate correctly.

<h3>Confidence Score: 3/5</h3>

Mostly safe to merge, but multi-turn Pi sessions will report stale cost figures due to the update guard in updatePiUsageFromOutput.

The cost update condition (`sess.CostUSDBackend == 0`) means that once a Pi session's cost is recorded after the first turn, every subsequent call to updateTokensUsedFromWorkerLog — which reads the full log and is invoked many times during a run — will see a non-zero CostUSDBackend and skip the update. A three-turn session will permanently show the cost from turn one. Tokens use the correct watermark pattern and accumulate properly; cost silently does not. Everything else in the PR is correct.

internal/orchestrator/orchestrator.go — the cost update in updatePiUsageFromOutput needs the same watermark pattern used for token accumulation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | updatePiUsageFromOutput: CostUSDBackend frozen after first successful parse due to == 0 guard; tokens correctly use a watermark pattern but cost does not |
| internal/worker/pi_usage.go | New file: ParsePiUsage aggregates usage from Pi JSON event stream with turn_end primary + message_end/agent_end fallbacks; nonEmpty parameter naming is inverted |
| internal/worker/backend.go | piBackend BuildCmd and supervisor case added; --model flag order differs between worker (before extra_args) and supervisor (after extra_args) |
| internal/config/backend_kind.go | BackendKindPi constant + pi/ollama provider maps added; ResolveBackendKind and backendKindFromCmd updated correctly |
| internal/state/state.go | Session gains Model and CostUSDBackend fields with omitempty; backwards-compatible with existing persisted state |
| internal/server/cost_observability.go | sessionCostEstimate added: prefers backend-reported cost over pricing-block estimate; SessionCostEstimate exported for CLI use |
| internal/worker/checkpoint.go | RespawnInPlace now wires Model and Effort from backendDef into BackendConfig |
| internal/worker/phase.go | StartPhase wires Model and Effort from backendDef; mirrors checkpoint.go fix |
| internal/worker/worker.go | Start and Respawn now pass Model and Effort to BackendConfig |
| internal/server/fleet.go | fleetWorkerState surfaces Model and CostUSDBackend; sessionCostEstimate now used instead of applySessionCostEstimate |
| internal/server/server.go | sessionInfo and buildStateResponse updated to surface Model and CostUSDBackend; uses sessionCostEstimate consistently |
| cmd/maestro/main.go | history --json adds model, tokens_used_total, cost_usd_estimate fields using the new SessionCostEstimate helper |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/worker/backend.go`, line 572-598 ([link](https://github.com/befeast/maestro/blob/4782d57aa7cceaa8cdc4883443d392e571eb91c1/internal/worker/backend.go#L572-L598)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inconsistent `--model` placement vs. worker**

   In `BuildCmd` (worker), `--model` is inserted before `--tools` and `cfg.ExtraArgs`, so an operator can override it via `extra_args`. In the supervisor `case "pi"`, `--model` is appended after `cfg.ExtraArgs`, which means the configured model always wins over any `--model` in `extra_args` (last-value-wins if Pi honors that). This is the opposite of what operators would expect given worker behavior, and the comment only documents `--thinking` as overridable via `extra_args`, not `--model`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/worker/backend.go
   Line: 572-598

   Comment:
   **Inconsistent `--model` placement vs. worker**

   In `BuildCmd` (worker), `--model` is inserted before `--tools` and `cfg.ExtraArgs`, so an operator can override it via `extra_args`. In the supervisor `case "pi"`, `--model` is appended after `cfg.ExtraArgs`, which means the configured model always wins over any `--model` in `extra_args` (last-value-wins if Pi honors that). This is the opposite of what operators would expect given worker behavior, and the comment only documents `--thinking` as overridable via `extra_args`, not `--model`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/orchestrator/orchestrator.go:645-648
`CostUSDBackend` is frozen after the first successful parse. `updateTokensUsedFromWorkerLog` reads the full log on each call (called repeatedly during a session), so `usage.CostUSD` grows as turns accumulate — but the `== 0` guard prevents updating `CostUSDBackend` after the first non-zero value is stored. A three-turn session whose first-turn cost is $0.001 will permanently report $0.001 even if the final log yields $0.005. Tokens use the correct watermark pattern (`> sess.TokensUsedAttempt`); cost should mirror it.

```suggestion
	if usage.CostUSD > sess.CostUSDBackend {
		sess.CostUSDBackend = usage.CostUSD
		changed = true
	}
```

### Issue 2 of 3
internal/worker/pi_usage.go:150-155
The parameter named `preferred` is actually the fallback — when `candidate` is non-empty, `candidate` wins and `preferred` is discarded. The names are inverted relative to their semantics, which makes call-sites like `nonEmpty(out.Model, ev.Message.Model)` read as "prefer the existing value" when the function actually prefers the new value.

```suggestion
func nonEmpty(fallback, candidate string) string {
	if strings.TrimSpace(candidate) == "" {
		return fallback
	}
	return candidate
}
```

### Issue 3 of 3
internal/worker/backend.go:572-598
**Inconsistent `--model` placement vs. worker**

In `BuildCmd` (worker), `--model` is inserted before `--tools` and `cfg.ExtraArgs`, so an operator can override it via `extra_args`. In the supervisor `case "pi"`, `--model` is appended after `cfg.ExtraArgs`, which means the configured model always wins over any `--model` in `extra_args` (last-value-wins if Pi honors that). This is the opposite of what operators would expect given worker behavior, and the comment only documents `--thinking` as overridable via `extra_args`, not `--model`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: add first-class Pi backend with ..."](https://github.com/befeast/maestro/commit/4782d57aa7cceaa8cdc4883443d392e571eb91c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38735413)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->