### PR TITLE
fix: Pi backend usage — frozen cost, retry token double-count, nonEmpty naming (#732)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -632,9 +632,17 @@ func (o *Orchestrator) updatePiUsageFromOutput(slotName string, sess *state.Sess
 		return false
 	}
 	changed := false
-	if usage.TotalTokens > sess.TokensUsedAttempt {
-		delta := usage.TotalTokens - sess.TokensUsedAttempt
-		sess.TokensUsedAttempt = usage.TotalTokens
+	// #730: Pi re-parses the full appended slot log on each call, so
+	// usage.TotalTokens is the cumulative run total across every attempt.
+	// On a respawn, the runner keeps appending to the same slot log while
+	// TokensUsedAttempt resets to 0 — comparing against TokensUsedAttempt
+	// would re-add the prior attempts' tokens. Use a separate monotonic
+	// watermark (PiTokensWatermark) that persists across respawns so only
+	// the new attempt's tokens are counted.
+	if usage.TotalTokens > sess.PiTokensWatermark {
+		delta := usage.TotalTokens - sess.PiTokensWatermark
+		sess.PiTokensWatermark = usage.TotalTokens
+		sess.TokensUsedAttempt += delta
 		sess.TokensUsedTotal += delta
 		changed = true
 	}
@@ -642,7 +650,10 @@ func (o *Orchestrator) updatePiUsageFromOutput(slotName string, sess *state.Sess
 		sess.Model = usage.Model
 		changed = true
 	}
-	if usage.CostUSD > 0 && sess.CostUSDBackend == 0 {
+	// #730: cost uses the same monotonic watermark as tokens — the full-log
+	// parse returns the cumulative run cost, so guard with `>` instead of a
+	// first-non-zero freeze (which would never update after the first turn).
+	if usage.CostUSD > sess.CostUSDBackend {
 		sess.CostUSDBackend = usage.CostUSD
 		changed = true
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9597,3 +9597,134 @@ func TestUpdateTokensUsedFromOutput_ClaudeBackendKeepsGenericParser(t *testing.T
 		t.Errorf("CostUSDBackend = %v, want 0", sess.CostUSDBackend)
 	}
 }
+
+// approxCostEq compares two USD floats with a 1e-9 tolerance (avoids pulling
+// in math just for cost assertions in the Pi usage tests).
+func approxCostEq(a, b float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d <= 1e-9
+}
+
+// #730/#732: Pi re-parses the full appended slot log on every call, so
+// usage.TotalTokens + CostUSD are cumulative run totals. Cost must keep
+// updating past the first non-zero turn (the old `== 0` freeze would
+// permanently report the first turn's cost) — guard with `>` like tokens.
+func TestUpdateTokensUsedFromOutput_PiBackendCostGrowsPastFirstTurn(t *testing.T) {
+	const turn1 = `{"type":"turn_end","message":{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":770,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":773,"cost":{"input":0.001078,"output":0.0000132,"total":0.0010912}}}}
+`
+	// Second parse simulates the appended log now containing two turns:
+	// turn 1 (773 tokens, $0.0010912) + turn 2 (2220 tokens, $0.003168).
+	const turn1And2 = turn1 + `{"type":"turn_end","message":{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":2200,"output":20,"cacheRead":0,"cacheWrite":0,"totalTokens":2220,"cost":{"input":0.00308,"output":0.000088,"total":0.003168}}}}
+`
+	o := &Orchestrator{
+		cfg: &config.Config{
+			StateDir: t.TempDir(),
+			Model: config.ModelConfig{
+				Default: "pi-ollama",
+				Backends: map[string]config.BackendDef{
+					"pi-ollama": {Provider: "ollama", Cmd: "pi", Model: "glm-5.2:cloud"},
+				},
+			},
+		},
+	}
+	sess := &state.Session{Backend: "pi-ollama"}
+
+	if !o.updateTokensUsedFromOutput("sup-732", sess, turn1) {
+		t.Fatal("first turn: expected a change")
+	}
+	if sess.TokensUsedAttempt != 773 || sess.TokensUsedTotal != 773 {
+		t.Fatalf("after turn1: attempt=%d total=%d, want 773/773", sess.TokensUsedAttempt, sess.TokensUsedTotal)
+	}
+	if sess.PiTokensWatermark != 773 {
+		t.Errorf("PiTokensWatermark = %d, want 773", sess.PiTokensWatermark)
+	}
+	if !approxCostEq(sess.CostUSDBackend, 0.0010912) {
+		t.Errorf("after turn1: CostUSDBackend = %v, want 0.0010912", sess.CostUSDBackend)
+	}
+
+	// Re-parsing the appended log (cumulative) must update cost past the
+	// first turn instead of freezing at $0.0010912.
+	if !o.updateTokensUsedFromOutput("sup-732", sess, turn1And2) {
+		t.Fatal("second turn: expected a change (cost/tokens must grow)")
+	}
+	wantCost := 0.0010912 + 0.003168
+	if !approxCostEq(sess.CostUSDBackend, wantCost) {
+		t.Errorf("after turn2: CostUSDBackend = %v, want %v (frozen-cost bug)", sess.CostUSDBackend, wantCost)
+	}
+	// Cumulative tokens = 773 + 2220 = 2993; only the delta (2220) is added.
+	if sess.TokensUsedAttempt != 2993 || sess.TokensUsedTotal != 2993 {
+		t.Errorf("after turn2: attempt=%d total=%d, want 2993/2993", sess.TokensUsedAttempt, sess.TokensUsedTotal)
+	}
+	if sess.PiTokensWatermark != 2993 {
+		t.Errorf("PiTokensWatermark = %d, want 2993", sess.PiTokensWatermark)
+	}
+}
+
+// #730/#732: on respawn/checkpoint resume the runner keeps appending to the
+// same slot log, so the full-log parse returns the all-attempt cumulative
+// token count. TokensUsedAttempt resets to 0 but the PiTokensWatermark
+// persists, so only the new attempt's delta is added — the prior attempts'
+// tokens are NOT re-counted into TokensUsedTotal.
+func TestUpdateTokensUsedFromOutput_PiBackendRetryNoDoubleCount(t *testing.T) {
+	// Attempt 1: single turn, 773 tokens. Watermark + total = 773.
+	const attempt1 = `{"type":"turn_end","message":{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":770,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":773,"cost":{"total":0.0010912}}}}
+`
+	// Attempt 2: the appended log now carries the original turn (773) plus a
+	// NEW turn (1000 tokens). The full-log parse yields cumulative 1773.
+	const attempt1And2 = attempt1 + `{"type":"turn_end","message":{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":900,"output":100,"cacheRead":0,"cacheWrite":0,"totalTokens":1000,"cost":{"total":0.002}}}}
+`
+
+	o := &Orchestrator{
+		cfg: &config.Config{
+			StateDir: t.TempDir(),
+			Model: config.ModelConfig{
+				Default: "pi-ollama",
+				Backends: map[string]config.BackendDef{
+					"pi-ollama": {Provider: "ollama", Cmd: "pi", Model: "glm-5.2:cloud"},
+				},
+			},
+		},
+	}
+	sess := &state.Session{Backend: "pi-ollama"}
+
+	if !o.updateTokensUsedFromOutput("sup-732", sess, attempt1) {
+		t.Fatal("attempt1: expected a change")
+	}
+	if sess.TokensUsedTotal != 773 || sess.PiTokensWatermark != 773 || sess.TokensUsedAttempt != 773 {
+		t.Fatalf("attempt1: total=%d wm=%d attempt=%d, want 773/773/773",
+			sess.TokensUsedTotal, sess.PiTokensWatermark, sess.TokensUsedAttempt)
+	}
+
+	// Simulate respawn: per-attempt counter resets to 0 (checkpoint/worker/phase
+	// reset it), but PiTokensWatermark persists across respawns.
+	sess.TokensUsedAttempt = 0
+
+	// Re-parse the SAME appended log (cumulative 773) before the new turn
+	// lands — must NOT re-add the prior attempt's tokens.
+	if o.updateTokensUsedFromOutput("sup-732", sess, attempt1) {
+		t.Fatal("re-parse of unchanged cumulative log must not report a change (would double-count)")
+	}
+	if sess.TokensUsedTotal != 773 {
+		t.Fatalf("after re-parse: TokensUsedTotal = %d, want 773 (no double-count)", sess.TokensUsedTotal)
+	}
+	if sess.TokensUsedAttempt != 0 {
+		t.Errorf("TokensUsedAttempt = %d, want 0 (no delta yet)", sess.TokensUsedAttempt)
+	}
+
+	// New turn lands: cumulative 1773. Only the delta (1000) is added.
+	if !o.updateTokensUsedFromOutput("sup-732", sess, attempt1And2) {
+		t.Fatal("new turn: expected a change")
+	}
+	if sess.TokensUsedTotal != 1773 {
+		t.Errorf("after new turn: TokensUsedTotal = %d, want 1773 (delta only)", sess.TokensUsedTotal)
+	}
+	if sess.TokensUsedAttempt != 1000 {
+		t.Errorf("TokensUsedAttempt = %d, want 1000 (current attempt delta)", sess.TokensUsedAttempt)
+	}
+	if sess.PiTokensWatermark != 1773 {
+		t.Errorf("PiTokensWatermark = %d, want 1773", sess.PiTokensWatermark)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -148,8 +148,9 @@ type Session struct {
 	// usage stream (Pi --mode json event stream). Empty/zero for backends
 	// that do not self-report; the fleet cost panel then falls back to the
 	// configured per-backend pricing estimate.
-	Model                       string            `json:"model,omitempty"`            // model the backend reported for this run (e.g. glm-5.2:cloud)
-	CostUSDBackend              float64           `json:"cost_usd_backend,omitempty"` // USD cost the backend self-reported (Pi cost.total)
+	Model                       string            `json:"model,omitempty"`               // model the backend reported for this run (e.g. glm-5.2:cloud)
+	CostUSDBackend              float64           `json:"cost_usd_backend,omitempty"`    // USD cost the backend self-reported (Pi cost.total)
+	PiTokensWatermark           int               `json:"pi_tokens_watermark,omitempty"` // #730: high-water mark of the Pi full-log cumulative token count; persists across respawns so re-parsing the appended log does not double-count prior attempts
 	LongRunning                 bool              `json:"long_running,omitempty"`
 	RebaseAttempted             bool              `json:"rebase_attempted,omitempty"`
 	NotifiedCIFail              bool              `json:"notified_ci_fail,omitempty"`           // deprecated: use LastNotifiedStatus

--- a/internal/worker/pi_usage.go
+++ b/internal/worker/pi_usage.go
@@ -147,9 +147,9 @@ func ParsePiUsage(text string) (PiUsage, bool) {
 	return out, seen
 }
 
-func nonEmpty(preferred, candidate string) string {
+func nonEmpty(fallback, candidate string) string {
 	if strings.TrimSpace(candidate) == "" {
-		return preferred
+		return fallback
 	}
 	return candidate
 }


### PR DESCRIPTION
Refs #732

Greptile follow-up to the first-class Pi backend (#731). The first-class Pi backend shipped with three review findings unaddressed in `main`; this PR fixes all three.

## Changes

1. **Frozen cost (P1)** - `internal/orchestrator/orchestrator.go`: `updatePiUsageFromOutput` re-parses the full Pi `--mode json` slot log on every call, so `usage.CostUSD` grows as `turn_end` events accumulate. The `== 0` guard froze `CostUSDBackend` at the first non-zero value, so a multi-turn session under-reported cost. Switched to the monotonic watermark pattern (`usage.CostUSD > sess.CostUSDBackend`) tokens use, so cost keeps updating past the first turn.

2. **Retry token double-count (P2)** - `internal/orchestrator/orchestrator.go` + `internal/state/state.go`: on respawn/checkpoint resume the runner keeps appending to the same slot log while `TokensUsedAttempt` resets to 0, so re-parsing the appended log treated the all-attempt cumulative total as the current attempt and re-added it to `TokensUsedTotal`. Added a persistent `state.Session.PiTokensWatermark` (high-water mark of the full-log cumulative count) that survives respawn (NOT reset in `checkpoint.go`/`worker.go`/`phase.go`) and only adds the delta to `TokensUsedAttempt`/`TokensUsedTotal`.

3. **`nonEmpty` naming (P2)** - `internal/worker/pi_usage.go`: `candidate` wins when non-empty, so `preferred` was really the fallback. Renamed parameter `preferred` -> `fallback` for honest semantics; positional call sites unchanged.

## Testing

- Added `TestUpdateTokensUsedFromOutput_PiBackendCostGrowsPastFirstTurn`: feeds a single-turn Pi log then re-parses with a second turn appended, asserting cost updates past the first turn (regression for the frozen-cost bug) and only the token delta is added.
- Added `TestUpdateTokensUsedFromOutput_PiBackendRetryNoDoubleCount`: simulates a respawn (`TokensUsedAttempt` reset to 0, `PiTokensWatermark` persists), re-parses the unchanged cumulative log (must NOT re-count prior attempts), then parses with a new turn (only the new delta is added).
- `gofmt` clean on changed files; `go build ./cmd/maestro/` passes; `go test ./...` passes; `.maestro/verify.sh` reports all verifications passed.

Maestro-Backend: sup-216

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three bugs introduced by the first-class Pi backend (#731): a frozen cost accumulator that stopped updating after the first turn, a retry token double-count caused by re-parsing the full appended slot log against a reset `TokensUsedAttempt`, and a misleading parameter name in `nonEmpty`.

- **Frozen cost**: replaces the `== 0` one-shot guard with a monotonic `>` comparison, matching the existing token watermark pattern so `CostUSDBackend` keeps tracking across multi-turn sessions.
- **Retry double-count**: adds `PiTokensWatermark` to `state.Session` as a persistent high-water mark (not reset alongside `TokensUsedAttempt` in worker/checkpoint/phase), so only the delta above the watermark is credited on each parse of the cumulative slot log.
- **`nonEmpty` rename**: `preferred` → `fallback` to reflect that the first argument is the fallback when the candidate is empty, not the preferred value.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all three fixes are well-scoped and covered by new regression tests. The only rough edge is a narrow transition window for Pi sessions that are live at deploy time.

The core logic changes are correct and each is directly validated by a new test. The one callout is that in-flight Pi sessions at deploy time will have PiTokensWatermark = 0 (absent from old serialized JSON), causing a one-time over-count on the first post-deploy call before the watermark kicks in. This is transient and narrow, but it can leave a permanent overage in TokensUsedTotal for affected sessions.

internal/orchestrator/orchestrator.go — the watermark-initialization behavior for sessions that pre-date this field deserves a second look if Pi backend usage is significant at deploy time.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Core bug fixes: cost guard changed from first-non-zero freeze to monotonic watermark, and token comparison pivoted from TokensUsedAttempt to the new PiTokensWatermark. Logic is correct for new sessions; existing in-flight Pi sessions will have PiTokensWatermark=0 on first deploy call, see migration note. |
| internal/state/state.go | Added PiTokensWatermark field with omitempty JSON tag; correctly omitted from all places that reset TokensUsedAttempt (worker.go, phase.go, checkpoint.go), ensuring the watermark survives respawns as intended. |
| internal/orchestrator/orchestrator_test.go | Two new regression tests cover the frozen-cost bug and the retry double-count bug; both correctly simulate multi-turn and respawn scenarios, and the approxCostEq helper correctly avoids pulling in math for float comparison. |
| internal/worker/pi_usage.go | Parameter rename preferred→fallback in nonEmpty: semantics are now honest (candidate wins, fallback if empty); call sites are positional-unchanged and correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:642-647
**One-time token over-count for in-flight Pi sessions at deploy time**

Any Pi session that is currently mid-attempt when this code is deployed will have `PiTokensWatermark = 0` (absent from the old JSON) while `TokensUsedAttempt` already holds the cumulative count written by the old code. On the first `updatePiUsageFromOutput` call under the new code, `usage.TotalTokens > 0` will be true, so the full cumulative token count gets added again via `TokensUsedAttempt += delta` — inflating both `TokensUsedAttempt` and `TokensUsedTotal` by the previous attempts' tokens. After that single call the watermark is set correctly and subsequent deltas are right, but the overage in `TokensUsedTotal` persists for the session's lifetime. This window is narrow (only Pi sessions alive at deploy time) and the old code was already broken for the respawn case, but it's worth being aware of for any observability or quota tooling that reads `TokensUsedTotal`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Pi backend usage — frozen cost, ret..."](https://github.com/befeast/maestro/commit/9d697ecb16eec1242dcaca47cebfc66459bb084c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38741303)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->