### PR TITLE
worker: fast-forward local main before spawning workers (#734)

### DIFF
--- a/internal/worker/syncbase.go
+++ b/internal/worker/syncbase.go
@@ -1,0 +1,114 @@
+package worker
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// defaultBaseBranch is the branch worker worktrees are derived from. The
+// orchestrator creates PRs against this branch (see orchestrator.createPR) and
+// the whole pipeline assumes the local checkout tracks origin/<defaultBaseBranch>.
+const defaultBaseBranch = "main"
+
+// SyncBaseBranch fetches origin and fast-forwards the local base branch
+// (typically "main") inside localPath to origin/<branch>, so that newly created
+// worker worktrees branch from an up-to-date base.
+//
+// Maestro creates each worker worktree from the local checkout. When the local
+// base branch lags origin (e.g. PRs merged on GitHub but never pulled locally),
+// every worker branches from a stale base: it re-implements already-merged work,
+// its branch becomes a sibling rather than a descendant of origin/main, and the
+// attribution amend's `git push --force-with-lease` fails with stale
+// remote-tracking info. The fetch + fast-forward here prevents all of that
+// (#734).
+//
+// If the local base branch has diverged from origin (cannot fast-forward), or
+// the base branch is checked out with a dirty working tree, SyncBaseBranch
+// returns an explicit error instead of silently leaving a stale base in place.
+func SyncBaseBranch(localPath, branch string) error {
+	localPath = strings.TrimSpace(localPath)
+	if localPath == "" {
+		return fmt.Errorf("sync base branch: empty local path")
+	}
+	if strings.TrimSpace(branch) == "" {
+		branch = defaultBaseBranch
+	}
+	remoteRef := "origin/" + branch
+
+	// Refresh remote-tracking refs. This also repairs the stale remote-tracking
+	// info that otherwise breaks a later `git push --force-with-lease`.
+	if _, err := runGit(localPath, "fetch", "origin"); err != nil {
+		return fmt.Errorf("sync base branch %q: %w", branch, err)
+	}
+
+	// origin must actually have the branch.
+	if _, err := runGit(localPath, "rev-parse", "--verify", "--quiet", remoteRef); err != nil {
+		return fmt.Errorf("sync base branch %q: remote ref %s not found after fetch", branch, remoteRef)
+	}
+
+	// If the local branch doesn't exist yet, create it at origin/<branch>.
+	if _, err := runGit(localPath, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
+		if _, cErr := runGit(localPath, "branch", branch, remoteRef); cErr != nil {
+			return fmt.Errorf("sync base branch %q: create local branch: %w", branch, cErr)
+		}
+		return nil
+	}
+
+	localSHA, err := runGit(localPath, "rev-parse", branch)
+	if err != nil {
+		return fmt.Errorf("sync base branch %q: %w", branch, err)
+	}
+	remoteSHA, err := runGit(localPath, "rev-parse", remoteRef)
+	if err != nil {
+		return fmt.Errorf("sync base branch %q: %w", branch, err)
+	}
+	if strings.TrimSpace(localSHA) == strings.TrimSpace(remoteSHA) {
+		return nil // already up to date
+	}
+
+	// A fast-forward is only possible when the local branch is an ancestor of
+	// the remote. Otherwise the branch has diverged — fail loudly rather than
+	// branching workers from a base that conflicts with origin.
+	if _, err := runGit(localPath, "merge-base", "--is-ancestor", branch, remoteRef); err != nil {
+		return fmt.Errorf("local base branch %q has diverged from %s and cannot fast-forward; "+
+			"reconcile %s manually before spawning workers", branch, remoteRef, localPath)
+	}
+
+	head, _ := runGit(localPath, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if strings.TrimSpace(head) == branch {
+		// Base branch is checked out: refuse a dirty tree, then fast-forward merge.
+		if dirty, err := worktreeDirty(localPath); err != nil {
+			return fmt.Errorf("sync base branch %q: %w", branch, err)
+		} else if dirty != "" {
+			return fmt.Errorf("base branch %q checkout at %s is dirty; cannot fast-forward to %s:\n%s",
+				branch, localPath, remoteRef, dirty)
+		}
+		if _, err := runGit(localPath, "merge", "--ff-only", remoteRef); err != nil {
+			return fmt.Errorf("fast-forward base branch %q to %s: %w", branch, remoteRef, err)
+		}
+		return nil
+	}
+
+	// Base branch is not the checked-out branch: advance the ref directly. The
+	// ancestry check above guarantees this is a fast-forward.
+	if _, err := runGit(localPath, "branch", "-f", branch, remoteRef); err != nil {
+		return fmt.Errorf("fast-forward base branch %q to %s: %w", branch, remoteRef, err)
+	}
+	return nil
+}
+
+// addWorktreeFromBase creates worktreePath as a fresh checkout on branchName,
+// rooted directly at origin/<defaultBaseBranch>. Branching from the remote ref
+// (rather than the local checkout's HEAD) guarantees the worktree descends from
+// the remote base regardless of which branch localPath currently has checked
+// out, so the worktree's merge-base with origin/main is origin/main (#734).
+func addWorktreeFromBase(localPath, worktreePath, branchName string) error {
+	base := "origin/" + defaultBaseBranch
+	out, err := exec.Command("git", "-C", localPath,
+		"worktree", "add", "--no-track", "-b", branchName, worktreePath, base).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree add %s on %s from %s: %w\n%s", worktreePath, branchName, base, err, out)
+	}
+	return nil
+}

--- a/internal/worker/syncbase_test.go
+++ b/internal/worker/syncbase_test.go
@@ -1,0 +1,166 @@
+package worker
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupOriginAndClone builds a bare "origin" with a single commit on main and a
+// local clone of it (mirroring the orchestrator's local_path checkout). It
+// returns the origin path, the local clone path, and a separate seed clone used
+// to push new commits to origin (simulating PRs merged on GitHub).
+func setupOriginAndClone(t *testing.T) (origin, local, seed string) {
+	t.Helper()
+	root := t.TempDir()
+	origin = filepath.Join(root, "origin.git")
+	seed = filepath.Join(root, "seed")
+	local = filepath.Join(root, "local")
+
+	gitTest(t, root, "init", "--bare", origin)
+	gitTest(t, origin, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	gitTest(t, root, "clone", origin, seed)
+	gitTest(t, seed, "config", "user.email", "test@example.com")
+	gitTest(t, seed, "config", "user.name", "Test User")
+	gitTest(t, seed, "checkout", "-b", "main")
+	writeTestFile(t, seed, "README.md", "v1\n")
+	gitTest(t, seed, "add", "README.md")
+	gitTest(t, seed, "commit", "-m", "initial")
+	gitTest(t, seed, "push", "-u", "origin", "main")
+
+	gitTest(t, root, "clone", origin, local)
+	gitTest(t, local, "config", "user.email", "test@example.com")
+	gitTest(t, local, "config", "user.name", "Test User")
+	return origin, local, seed
+}
+
+// advanceOrigin pushes a new commit to origin/main via the seed clone, leaving
+// the local clone stale.
+func advanceOrigin(t *testing.T, seed, content string) {
+	t.Helper()
+	writeTestFile(t, seed, "README.md", content)
+	gitTest(t, seed, "commit", "-am", "advance")
+	gitTest(t, seed, "push", "origin", "main")
+}
+
+func revParse(t *testing.T, dir, ref string) string {
+	t.Helper()
+	out, err := runGit(dir, "rev-parse", ref)
+	if err != nil {
+		t.Fatalf("rev-parse %s in %s: %v", ref, dir, err)
+	}
+	return strings.TrimSpace(out)
+}
+
+func TestSyncBaseBranch_FastForwardsStaleLocalMain(t *testing.T) {
+	_, local, seed := setupOriginAndClone(t)
+	advanceOrigin(t, seed, "v2\n")
+
+	// Local main still points at v1 until we sync.
+	if err := SyncBaseBranch(local, "main"); err != nil {
+		t.Fatalf("SyncBaseBranch: %v", err)
+	}
+
+	got := revParse(t, local, "main")
+	want := revParse(t, local, "origin/main")
+	if got != want {
+		t.Fatalf("local main = %s, want origin/main %s after sync", got, want)
+	}
+}
+
+func TestSyncBaseBranch_NoopWhenUpToDate(t *testing.T) {
+	_, local, _ := setupOriginAndClone(t)
+	before := revParse(t, local, "main")
+	if err := SyncBaseBranch(local, "main"); err != nil {
+		t.Fatalf("SyncBaseBranch: %v", err)
+	}
+	if after := revParse(t, local, "main"); after != before {
+		t.Fatalf("main moved on no-op sync: %s -> %s", before, after)
+	}
+}
+
+func TestSyncBaseBranch_DivergedFailsLoudly(t *testing.T) {
+	_, local, seed := setupOriginAndClone(t)
+	advanceOrigin(t, seed, "v2-remote\n")
+
+	// Make local main diverge: commit a different change without pulling.
+	writeTestFile(t, local, "README.md", "v2-local\n")
+	gitTest(t, local, "commit", "-am", "local divergent")
+
+	err := SyncBaseBranch(local, "main")
+	if err == nil {
+		t.Fatal("expected error for diverged local main")
+	}
+	if !strings.Contains(err.Error(), "diverged") {
+		t.Fatalf("expected diverged error, got: %v", err)
+	}
+}
+
+func TestSyncBaseBranch_DirtyCheckoutFailsLoudly(t *testing.T) {
+	_, local, seed := setupOriginAndClone(t)
+	advanceOrigin(t, seed, "v2\n")
+
+	// Stale local main that also has a dirty working tree.
+	writeTestFile(t, local, "README.md", "dirty local edit\n")
+
+	err := SyncBaseBranch(local, "main")
+	if err == nil {
+		t.Fatal("expected error for dirty base checkout")
+	}
+	if !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("expected dirty error, got: %v", err)
+	}
+}
+
+func TestSyncBaseBranch_AdvancesUncheckedBaseBranch(t *testing.T) {
+	_, local, seed := setupOriginAndClone(t)
+	advanceOrigin(t, seed, "v2\n")
+
+	// Local checkout sits on a feature branch, not main.
+	gitTest(t, local, "checkout", "-b", "feature")
+
+	if err := SyncBaseBranch(local, "main"); err != nil {
+		t.Fatalf("SyncBaseBranch: %v", err)
+	}
+
+	if got, want := revParse(t, local, "main"), revParse(t, local, "origin/main"); got != want {
+		t.Fatalf("local main = %s, want origin/main %s", got, want)
+	}
+	head, err := runGit(local, "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		t.Fatalf("symbolic-ref HEAD: %v", err)
+	}
+	if strings.TrimSpace(head) != "feature" {
+		t.Fatalf("HEAD = %q, want to stay on feature branch", strings.TrimSpace(head))
+	}
+}
+
+// TestAddWorktreeFromBase_MergeBaseIsOriginMain is the core acceptance check:
+// after syncing, a worker worktree's merge-base with origin/main equals
+// origin/main, i.e. it descends from the real remote base rather than a stale
+// or sibling commit.
+func TestAddWorktreeFromBase_MergeBaseIsOriginMain(t *testing.T) {
+	root := t.TempDir()
+	_, local, seed := setupOriginAndClone(t)
+	advanceOrigin(t, seed, "v2\n")
+
+	if err := SyncBaseBranch(local, "main"); err != nil {
+		t.Fatalf("SyncBaseBranch: %v", err)
+	}
+
+	worktreePath := filepath.Join(root, "wt")
+	if err := addWorktreeFromBase(local, worktreePath, "feat/sup-1-thing"); err != nil {
+		t.Fatalf("addWorktreeFromBase: %v", err)
+	}
+
+	mergeBase, err := runGit(worktreePath, "merge-base", "HEAD", "origin/main")
+	if err != nil {
+		t.Fatalf("merge-base: %v", err)
+	}
+	originMain := revParse(t, worktreePath, "origin/main")
+	if strings.TrimSpace(mergeBase) != originMain {
+		t.Fatalf("worktree merge-base with origin/main = %s, want origin/main %s",
+			strings.TrimSpace(mergeBase), originMain)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -53,12 +53,17 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 	worktreePath := filepath.Join(cfg.WorktreeBase, slotName)
 	branchName := fmt.Sprintf("feat/%s-%d-%s", slotName, issue.Number, slugify(issue.Title))
 
+	// #734: sync the local base branch to origin so the worker branches from an
+	// up-to-date base, then root the worktree directly at origin/main. A stale
+	// or diverged base fails loudly here rather than silently branching from it.
+	if err := SyncBaseBranch(cfg.LocalPath, defaultBaseBranch); err != nil {
+		return "", fmt.Errorf("sync base branch before spawning worker: %w", err)
+	}
+
 	// Create worktree
 	log.Printf("[worker] creating worktree %s on branch %s", worktreePath, branchName)
-	out, err := exec.Command("git", "-C", cfg.LocalPath,
-		"worktree", "add", worktreePath, "-b", branchName).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("git worktree add: %w\n%s", err, out)
+	if err := addWorktreeFromBase(cfg.LocalPath, worktreePath, branchName); err != nil {
+		return "", err
 	}
 
 	// Run after_create hook
@@ -205,11 +210,15 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	worktreePath := filepath.Join(cfg.WorktreeBase, slotName)
 	branchName := fmt.Sprintf("feat/%s-%d-%s", slotName, issue.Number, slugify(issue.Title))
 
+	// #734: sync the local base branch to origin and root the worktree directly
+	// at origin/main so the respawned worker branches from an up-to-date base.
+	if err := SyncBaseBranch(cfg.LocalPath, defaultBaseBranch); err != nil {
+		return fmt.Errorf("sync base branch before respawning worker: %w", err)
+	}
+
 	log.Printf("[worker] respawn: creating worktree %s on branch %s", worktreePath, branchName)
-	out, err := exec.Command("git", "-C", cfg.LocalPath,
-		"worktree", "add", worktreePath, "-b", branchName).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("git worktree add: %w\n%s", err, out)
+	if err := addWorktreeFromBase(cfg.LocalPath, worktreePath, branchName); err != nil {
+		return err
 	}
 
 	// Run after_create hook


### PR DESCRIPTION
Implements #734

## Changes
- Add `SyncBaseBranch` (`internal/worker/syncbase.go`): before creating a worker worktree, run `git fetch origin` and fast-forward the local base branch (`main`) to `origin/main`. If local `main` has diverged (cannot fast-forward) or the base checkout is dirty, it returns an explicit error instead of silently branching from a stale base. The fetch also repairs stale remote-tracking info that breaks later `git push --force-with-lease`.
- Add `addWorktreeFromBase`: root the new worktree directly at `origin/main` so its merge-base with `origin/main` is `origin/main`, regardless of what `local_path` has checked out.
- Wire both into `worker.Start` and `worker.Respawn` ahead of the `git worktree add`.

## Testing
- `go build ./cmd/maestro/`
- `go test ./...`
- New `internal/worker/syncbase_test.go` covers: fast-forwarding a stale local main, no-op when up to date, loud failure on divergence, loud failure on a dirty checkout, advancing an unchecked-out base branch, and the acceptance check that a created worktree's merge-base with `origin/main` equals `origin/main`.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes stale-base branching (#734) by fetching `origin` and fast-forwarding the local `main` before each worker worktree is created, and rooting new worktrees directly at `origin/main` instead of the local checkout's HEAD.

- **`SyncBaseBranch`** (`syncbase.go`): fetches origin, verifies the remote ref exists, creates or fast-forwards the local base branch, and fails loudly if the branch has diverged or if the checkout is dirty — preventing silent branching from a stale or conflicting base.
- **`addWorktreeFromBase`** (`syncbase.go`): replaces the inline `git worktree add` in `Start`/`Respawn` with one that always starts from `origin/<defaultBaseBranch>` via `--no-track`, fixing both the stale-base and the stale-remote-tracking-ref issues that broke `push --force-with-lease`.
- **Tests** (`syncbase_test.go`): six scenarios cover the fast-forward, no-op, diverged, dirty-checkout, unchecked-base-branch, and merge-base acceptance cases using real git repos in temp directories.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge. The core git logic is correct and well-tested; the two observations are design notes rather than immediate breakage.

The fast-forward logic, ancestor check, dirty-tree guard, and worktree-from-remote-ref approach are all correct and covered by tests. One note: addWorktreeFromBase reads defaultBaseBranch from the package constant rather than receiving the branch as a parameter, so if the base branch ever becomes configurable the two functions could silently diverge. The other note is that SyncBaseBranch introduces new network- and state-dependent failure modes in Respawn after Stop has already torn down the old worker, which could leave session state stale more often than before — worth verifying how the orchestrator handles a failed Respawn.

internal/worker/worker.go — specifically the Respawn path where SyncBaseBranch is now called after Stop.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/syncbase.go | New file implementing SyncBaseBranch (fetch + fast-forward local base branch) and addWorktreeFromBase (create worktree rooted at origin/main). Logic is correct for the happy paths and diverged/dirty failure cases; minor coupling issue between the branch parameter of SyncBaseBranch and the hardcoded constant in addWorktreeFromBase. |
| internal/worker/syncbase_test.go | New test file with good coverage of the fast-forward, no-op, diverged, dirty-checkout, unchecked-base, and worktree-merge-base acceptance cases. Uses existing gitTest/writeTestFile helpers from rebase_test.go correctly. |
| internal/worker/worker.go | SyncBaseBranch and addWorktreeFromBase wired into Start and Respawn before worktree creation. New SyncBaseBranch failure modes after Stop in Respawn increase the risk of leaving a session in a zombie state, which was already possible before the PR but is now more likely. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/worker/syncbase.go:101-114
**`addWorktreeFromBase` hardcodes `defaultBaseBranch` independently of `SyncBaseBranch`'s `branch` parameter**

`SyncBaseBranch` accepts a configurable `branch` parameter and is called in `worker.go` with `defaultBaseBranch`, but `addWorktreeFromBase` reads `defaultBaseBranch` directly from the package constant rather than receiving the branch as a parameter. The two functions are implicitly coupled only through the constant. If the base branch ever becomes configurable via `cfg` (or a caller passes a different branch to `SyncBaseBranch`), `addWorktreeFromBase` will silently continue to root worktrees on `origin/main` while the sync targets a different branch.

### Issue 2 of 2
internal/worker/worker.go:213-217
**`SyncBaseBranch` introduces new failure modes after `Stop` tears down the old worker**

`Respawn` calls `Stop` (which kills the tmux session, kills the process, removes the worktree, and runs hooks) before calling `SyncBaseBranch`. If `SyncBaseBranch` fails — e.g., because the network is unreachable for `git fetch`, or because `local main` has diverged — the function returns an error while `sess` still holds stale data (the old branch and worktree path that no longer exist). This zombie state was theoretically possible before this PR (if `git worktree add` failed after `Stop`), but `SyncBaseBranch` adds new, more common failure modes that make this code path easier to hit in practice. The caller would need to detect and clear the stale session; it's worth verifying how the orchestrator handles a `Respawn` error in this scenario.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: fast-forward local base branch b..."](https://github.com/befeast/maestro/commit/ed5d512017c64fb5d87f262e645553acd0e3947d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38743386)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->