### PR TITLE
supervisor: cautious+LLM mode drops safe label_issue_ready handoff (ready label never applied → orchestrator starves)

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -30,6 +30,11 @@ type GitHubClient interface {
 	MergePR(prNumber int) error
 	CloseIssue(number int, comment string) error
 
+	// AddIssueLabel applies a label to an issue. executeLabelIssueReady
+	// uses it to apply the configured ready label when an operator
+	// approves an approval-gated label_issue_ready decision (#736).
+	AddIssueLabel(issueNumber int, label string) error
+
 	// PRMergeStatus returns the normalized mergeable verdict
 	// ("MERGEABLE"/"CONFLICTING"/"UNKNOWN") and the raw GitHub
 	// mergeable_state ("clean", "behind", "dirty", ...). executeMergePR
@@ -289,6 +294,8 @@ func (e *Executor) dispatchAction(approval *state.Approval) Result {
 		}
 	case config.SupervisorActionApplyLessonProposal:
 		return e.executeApplyLessonProposal(approval)
+	case "label_issue_ready":
+		return e.executeLabelIssueReady(approval)
 	case "spawn_worker":
 		// The approver runs in the supervisor cycle; it does not own the
 		// dispatch loop that actually spawns workers. Mark the approval
@@ -478,6 +485,64 @@ func (e *Executor) executeCloseIssue(approval *state.Approval) Result {
 		Status:  state.ApprovalStatusExecuted,
 		Summary: fmt.Sprintf("closed issue #%d", issue),
 	}
+}
+
+// executeLabelIssueReady applies the configured ready label to the target
+// issue. It is the approval-gated counterpart to the supervisor's safe
+// add_ready_label mutation (#736): when the operator lists the ready-label
+// verb in approval_required (instead of whitelisting add_ready_label as a
+// safe action), the supervisor mints a pending approval and this runs on
+// approve. The label name comes from cfg (supervisor.ready_label, falling
+// back to the first issue_labels entry) — the approval payload only carries
+// the target issue, mirroring how the safe mutation resolves the label.
+func (e *Executor) executeLabelIssueReady(approval *state.Approval) Result {
+	if approval.Target == nil || approval.Target.Issue <= 0 {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: fmt.Errorf("%w: issue number missing", ErrMissingTarget)}
+	}
+	if e.GH == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no GitHub client wired into executor")}
+	}
+	if e.Cfg == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no project config wired into executor")}
+	}
+	label := approverReadyLabel(e.Cfg)
+	if label == "" {
+		return Result{
+			Status:  state.ApprovalStatusExecutionFailed,
+			Summary: "no ready label configured (supervisor.ready_label / issue_labels) — cannot label issue ready",
+			Err:     errors.New("no ready label configured"),
+		}
+	}
+	issue := approval.Target.Issue
+	if err := e.GH.AddIssueLabel(issue, label); err != nil {
+		return Result{
+			Status:  state.ApprovalStatusExecutionFailed,
+			Summary: fmt.Sprintf("add ready label %q to issue #%d: %v", label, issue, err),
+			Err:     fmt.Errorf("add ready label to issue #%d: %w", issue, err),
+		}
+	}
+	return Result{
+		Status:  state.ApprovalStatusExecuted,
+		Summary: fmt.Sprintf("added ready label %q to issue #%d", label, issue),
+	}
+}
+
+// approverReadyLabel resolves the project ready label the same way the
+// supervisor's Engine.readyLabel does: prefer supervisor.ready_label, then
+// fall back to the first non-empty issue_labels entry.
+func approverReadyLabel(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if label := strings.TrimSpace(cfg.Supervisor.ReadyLabel); label != "" {
+		return label
+	}
+	for _, label := range cfg.IssueLabels {
+		if label = strings.TrimSpace(label); label != "" {
+			return label
+		}
+	}
+	return ""
 }
 
 func (e *Executor) executeCloseIssueBatch(approval *state.Approval) Result {

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -23,8 +23,10 @@ type fakeGH struct {
 	mergeCalls  []int
 	closeCalls  []closeCall
 	updateCalls []int
+	labelCalls  []labelCall
 	mergeErr    error
 	closeErr    error
+	labelErr    error
 
 	// #547 stubs for PRMergeStatus.
 	mergeable      string
@@ -37,6 +39,11 @@ type fakeGH struct {
 type closeCall struct {
 	issue   int
 	comment string
+}
+
+type labelCall struct {
+	issue int
+	label string
 }
 
 func (f *fakeGH) MergePR(pr int) error {
@@ -53,6 +60,13 @@ func (f *fakeGH) PRMergeStatus(pr int) (string, string, error) {
 func (f *fakeGH) UpdateBranch(pr int) error {
 	f.updateCalls = append(f.updateCalls, pr)
 	return f.updateErr
+}
+func (f *fakeGH) AddIssueLabel(issue int, label string) error {
+	if f.labelErr != nil {
+		return f.labelErr
+	}
+	f.labelCalls = append(f.labelCalls, labelCall{issue: issue, label: label})
+	return nil
 }
 
 type fakeWT struct {
@@ -700,5 +714,79 @@ func TestWorkerControllerFuncs_NilFunctionsReturnError(t *testing.T) {
 	}
 	if err := wc.RestartWorker("x", nil); err == nil {
 		t.Fatal("RestartWorker with nil Restart func should return an error, not panic")
+	}
+}
+
+// --- label_issue_ready (#736) ----------------------------------------------
+
+// TestExecute_LabelIssueReady_AppliesConfiguredReadyLabel verifies the
+// approval-gated ready-label handoff (#736): when the operator gates the
+// verb behind approval_required, approving the minted approval applies the
+// configured ready label to the target issue. The label name comes from
+// cfg (the approval payload only carries the target issue).
+func TestExecute_LabelIssueReady_AppliesConfiguredReadyLabel(t *testing.T) {
+	gh := &fakeGH{}
+	cfg := newCfg()
+	cfg.Supervisor.ReadyLabel = "maestro-ready"
+	ex := &Executor{GH: gh, Cfg: cfg}
+	a := mkApproval("label_issue_ready", &state.SupervisorTarget{Issue: 266}, "label ready", "operator ok")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("status = %q, want executed; res=%+v", res.Status, res)
+	}
+	if len(gh.labelCalls) != 1 || gh.labelCalls[0].issue != 266 || gh.labelCalls[0].label != "maestro-ready" {
+		t.Fatalf("label calls = %#v, want one #266:maestro-ready", gh.labelCalls)
+	}
+	if !strings.Contains(res.Summary, "#266") || !strings.Contains(res.Summary, "maestro-ready") {
+		t.Fatalf("summary = %q, want it to name the issue and label", res.Summary)
+	}
+}
+
+// Falls back to the first issue_labels entry when supervisor.ready_label
+// is unset — mirroring supervisor.Engine.readyLabel.
+func TestExecute_LabelIssueReady_FallsBackToIssueLabels(t *testing.T) {
+	gh := &fakeGH{}
+	cfg := newCfg()
+	cfg.IssueLabels = []string{"ready"}
+	ex := &Executor{GH: gh, Cfg: cfg}
+	a := mkApproval("label_issue_ready", &state.SupervisorTarget{Issue: 7}, "label ready", "ok")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("status = %q, want executed; res=%+v", res.Status, res)
+	}
+	if len(gh.labelCalls) != 1 || gh.labelCalls[0].label != "ready" {
+		t.Fatalf("label calls = %#v, want one #7:ready", gh.labelCalls)
+	}
+}
+
+func TestExecute_LabelIssueReady_MissingIssueFails(t *testing.T) {
+	gh := &fakeGH{}
+	cfg := newCfg()
+	cfg.Supervisor.ReadyLabel = "maestro-ready"
+	ex := &Executor{GH: gh, Cfg: cfg}
+	a := mkApproval("label_issue_ready", &state.SupervisorTarget{}, "label ready", "ok")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("status = %q, want execution_failed for missing issue", res.Status)
+	}
+	if len(gh.labelCalls) != 0 {
+		t.Fatalf("label calls = %#v, want none on failure", gh.labelCalls)
+	}
+}
+
+func TestExecute_LabelIssueReady_NoReadyLabelConfiguredFails(t *testing.T) {
+	gh := &fakeGH{}
+	ex := &Executor{GH: gh, Cfg: newCfg()} // no ready_label / issue_labels
+	a := mkApproval("label_issue_ready", &state.SupervisorTarget{Issue: 9}, "label ready", "ok")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("status = %q, want execution_failed when no ready label is configured", res.Status)
+	}
+	if len(gh.labelCalls) != 0 {
+		t.Fatalf("label calls = %#v, want none on failure", gh.labelCalls)
 	}
 }

--- a/internal/approver/idempotent_test.go
+++ b/internal/approver/idempotent_test.go
@@ -53,6 +53,10 @@ func (b *blockingGH) UpdateBranch(pr int) error {
 	atomic.AddInt32(&b.calls, 1)
 	return nil
 }
+func (b *blockingGH) AddIssueLabel(issue int, label string) error {
+	atomic.AddInt32(&b.calls, 1)
+	return nil
+}
 
 // --- #488: per-approval-ID lock (concurrent Execute) -----------------------
 

--- a/internal/approver/registry.go
+++ b/internal/approver/registry.go
@@ -54,6 +54,18 @@ var KnownApprovalActions = map[string]struct{}{
 	// next dispatcher respawn.
 	"restart_worker": {},
 	"stop_worker":    {},
+	// #736: ready-label handoff fallback. The common path applies the
+	// add_ready_label mutation directly as an operator-whitelisted safe
+	// action (safe_actions), so it never reaches this registry. But when
+	// the operator gates the verb behind approval_required instead, the
+	// supervisor mints this approval and the executor applies the
+	// configured ready label on approve (executeLabelIssueReady). Before
+	// #736 the verb was absent here, so the at-mint guard refused it every
+	// cycle and a cautious+LLM project's dynamic-wave handoff stalled
+	// silently — the ready label was never applied and the orchestrator
+	// starved. Note: the safe-action alias "add_ready_label" stays OUT of
+	// this registry (it is a safe action, never an approval mint).
+	"label_issue_ready": {},
 }
 
 // KnownSafeActions is the canonical set of safe (non-approval-gated)

--- a/internal/approver/registry_test.go
+++ b/internal/approver/registry_test.go
@@ -53,11 +53,12 @@ func TestRegistry_IsKnownApprovalAction(t *testing.T) {
 		{"restart_worker", true},      // #567: per-session worker-control
 		{"stop_worker", true},         // #567: per-session worker-control
 		{"spawn_repair_worker", true}, // #662: classic repair worker (awaiting_dispatch)
+		{"label_issue_ready", true},   // #736: ready-label approval fallback (executor applies the label)
 
 		// Negative cases — the live-found bugs.
 		{"spawn_repair_repair", false},
 		{"approve_merge", false},   // UI verb — server translates to merge_pr before enqueue
-		{"add_ready_label", false}, // safe action, NOT in approval registry
+		{"add_ready_label", false}, // safe action alias, NOT in approval registry (canonical verb label_issue_ready is)
 		{"", false},
 	}
 	for _, tc := range cases {

--- a/internal/supervisor/label_ready_handoff_test.go
+++ b/internal/supervisor/label_ready_handoff_test.go
@@ -1,0 +1,156 @@
+package supervisor
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/approver"
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #736 reproduction: in cautious+LLM mode the deterministic guardrail plans a
+// SAFE add_ready_label mutation (add_ready_label ∈ safe_actions) and computes
+// risk=safe, but the supervisor LLM is allowed to RAISE the headline risk to
+// approval_gated. Before the fix RunOnce keyed the safe-mutation apply on
+// decision.Risk == RiskSafe, so the inflated risk dropped the mutation, AND
+// the approval fallback refused to mint because label_issue_ready was not in
+// the executor registry — the ready label was never applied and the
+// orchestrator starved. The safe mutation must STILL be applied (recorded
+// succeeded, no approval minted).
+func TestRunOnce_SafeReadyLabelAppliedDespiteLLMRiskInflation(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
+	// Operator whitelisted the ready label as a safe action ...
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel}
+	// ... and did NOT gate it behind approval_required (only delete_worktree).
+	cfg.Supervisor.ApprovalRequired = []string{config.SupervisorActionDeleteWorktree}
+
+	reader := &fakeReader{issues: []github.Issue{testIssue(266, "auth handoff")}}
+
+	// LLM accepts the guardrail action/target but inflates the risk from
+	// safe -> approval_gated (and must mark requires_approval to satisfy the
+	// policy, since label_issue_ready is approval-required by default).
+	llm := &fakeLLM{output: `{
+  "summary": "Gate the ready label behind approval out of caution.",
+  "recommended_action": "label_issue_ready",
+  "target": {"issue": 266, "pr": 0, "session": ""},
+  "risk": "approval_gated",
+  "confidence": 0.7,
+  "reasons": ["being cautious about labeling"],
+  "requires_approval": true
+}`}
+
+	st := state.NewState()
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	// Sanity: this is the exact regression shape — label_issue_ready carrying
+	// the planned safe mutation, but with an LLM-inflated headline risk.
+	if decision.RecommendedAction != ActionLabelIssueReady {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionLabelIssueReady)
+	}
+	if decision.Risk != RiskApprovalGated {
+		t.Fatalf("risk = %q, want %q (LLM must have inflated the headline risk)", decision.Risk, RiskApprovalGated)
+	}
+	if len(decision.Mutations) != 1 || decision.Mutations[0].Type != MutationAddReadyLabel {
+		t.Fatalf("mutations = %#v, want one planned add_ready_label", decision.Mutations)
+	}
+
+	// RunOnce's side-effect stage must apply the safe mutation directly.
+	applyOrMintDecision(cfg, st, reader, &decision)
+
+	if decision.Status != DecisionStatusSucceeded {
+		t.Fatalf("status = %q, want %q (safe mutation must be applied, not refused)", decision.Status, DecisionStatusSucceeded)
+	}
+	if decision.Mode != ModeSafeActions {
+		t.Fatalf("mode = %q, want %q", decision.Mode, ModeSafeActions)
+	}
+	if got, want := joinLabels(reader.addedLabels), "#266:maestro-ready"; got != want {
+		t.Fatalf("added labels = %q, want %q — ready label never applied (orchestrator starves)", got, want)
+	}
+	if len(st.Approvals) != 0 {
+		t.Fatalf("approvals = %d, want 0 — the safe mutation must not ALSO mint/refuse an approval", len(st.Approvals))
+	}
+	if decision.ApprovalID != "" {
+		t.Fatalf("ApprovalID = %q, want empty (no approval for an applied safe mutation)", decision.ApprovalID)
+	}
+}
+
+// #736 acceptance criterion 3: when the operator DOES gate the ready-label
+// verb behind approval_required (and does not whitelist add_ready_label as a
+// safe action), the supervisor must NOT auto-apply — it mints a pending
+// approval, and the verb is now in the executor registry so the mint is not
+// refused ("not in the executor registry").
+func TestRunOnce_OperatorGatedReadyLabelMintsApproval(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	enableDynamicWave(cfg)
+	// add_ready_label is NOT a safe action; the operator gated it instead.
+	cfg.Supervisor.ApprovalRequired = []string{config.SupervisorActionAddReadyLabel}
+
+	reader := &fakeReader{issues: []github.Issue{testIssue(266, "auth handoff")}}
+
+	llm := &fakeLLM{output: `{
+  "summary": "Request approval to label issue #266 ready.",
+  "recommended_action": "label_issue_ready",
+  "target": {"issue": 266, "pr": 0, "session": ""},
+  "risk": "approval_gated",
+  "confidence": 0.7,
+  "reasons": ["operator gated the ready label"],
+  "requires_approval": true
+}`}
+
+	st := state.NewState()
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionLabelIssueReady {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionLabelIssueReady)
+	}
+	if len(decision.Mutations) != 0 {
+		t.Fatalf("mutations = %#v, want none (add_ready_label is not a safe action)", decision.Mutations)
+	}
+
+	applyOrMintDecision(cfg, st, reader, &decision)
+
+	if len(reader.addedLabels) != 0 {
+		t.Fatalf("added labels = %#v, want none (operator-gated verb must not auto-apply)", reader.addedLabels)
+	}
+	if len(st.Approvals) != 1 {
+		t.Fatalf("approvals = %d, want 1 pending approval (mint, not refuse)", len(st.Approvals))
+	}
+	a := st.Approvals[0]
+	if a.Action != ActionLabelIssueReady {
+		t.Fatalf("approval action = %q, want %q", a.Action, ActionLabelIssueReady)
+	}
+	if a.Status != state.ApprovalStatusPending {
+		t.Fatalf("approval status = %q, want %q", a.Status, state.ApprovalStatusPending)
+	}
+	if a.Target == nil || a.Target.Issue != 266 {
+		t.Fatalf("approval target = %#v, want issue 266", a.Target)
+	}
+	if decision.ApprovalID != a.ID {
+		t.Fatalf("decision.ApprovalID = %q, want %q", decision.ApprovalID, a.ID)
+	}
+	// The minted verb must be executable — the regression was the executor
+	// having no case for it. Pin the registry contract here too.
+	if !approver.IsKnownApprovalAction(a.Action) {
+		t.Fatalf("minted approval action %q is not in the executor registry %v — mint would be refused (#736)", a.Action, approver.KnownApprovalActionList())
+	}
+}
+
+func joinLabels(labels []string) string {
+	out := ""
+	for i, l := range labels {
+		if i > 0 {
+			out += ","
+		}
+		out += l
+	}
+	return out
+}

--- a/internal/supervisor/registry_drift_test.go
+++ b/internal/supervisor/registry_drift_test.go
@@ -5,9 +5,56 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/approver"
+	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/state"
 )
+
+// #736: every action the supervisor's decision layer can EMIT and drive to a
+// real side effect must be resolvable by RunOnce — EITHER applied directly as
+// an operator-whitelisted safe queue mutation OR mintable as an approval the
+// executor can run (approver.KnownApprovalActions). An action that is neither
+// rots silently: the at-mint guard refuses it every cycle and nothing applies
+// it. label_issue_ready regressed exactly here (cautious+LLM dynamic-wave
+// handoff: the safe mutation was dropped after the LLM raised the risk, and
+// the verb was missing from the registry so the mint was refused). This test
+// catches that drift class at CI time.
+//
+// Informational / operator-attention recommendations (none, the wait_*
+// family, monitor_open_pr, check_outcome_health, notify_red,
+// review_retry_exhausted, preflight_failed) are intentionally excluded: they
+// request human attention and are never executed by RunOnce.
+func TestSupervisorActions_ResolveToSafeMutationOrRegistry(t *testing.T) {
+	// Actions that drive a real side effect when emitted.
+	sideEffectActions := []string{
+		ActionSpawnWorker,
+		ActionSpawnRepairWorker,
+		ActionSpawnReviewRepair,
+		ActionMergePR,
+		ActionOpenChildIssue,
+		ActionLabelIssueReady,
+		ActionUnblockIssue,
+		config.SupervisorActionCloseIssue,
+		config.SupervisorActionCloseIssueBatch,
+	}
+	// Actions whose side effect is a safe queue mutation: RunOnce applies
+	// their planned label mutations directly (applyOrMintDecision) when the
+	// operator whitelists the corresponding safe action, so the "OR" arm is
+	// satisfied even when the verb is not in the approval registry.
+	appliedAsSafeMutation := map[string]bool{
+		ActionLabelIssueReady: true, // add_ready_label / remove_ready_label
+		ActionUnblockIssue:    true, // remove_blocked_label + add_ready_label
+	}
+	for _, action := range sideEffectActions {
+		action := action
+		t.Run(action, func(t *testing.T) {
+			if appliedAsSafeMutation[action] || approver.IsKnownApprovalAction(action) {
+				return
+			}
+			t.Fatalf("supervisor emits side-effecting %q but it is neither applied as a safe mutation nor in approver.KnownApprovalActions = %v — RunOnce can never resolve it; the at-mint guard would refuse it every cycle and the project would stall silently (#736)", action, approver.KnownApprovalActionList())
+		})
+	}
+}
 
 // #662: every mutating action constant the supervisor's decision layer can
 // emit MUST be in the executor registry (approver.KnownApprovalActions).
@@ -27,6 +74,13 @@ func TestSupervisorMutatingActions_AreInExecutorRegistry(t *testing.T) {
 		ActionSpawnReviewRepair,
 		ActionMergePR,
 		ActionOpenChildIssue,
+		// #736: label_issue_ready is normally applied directly as the
+		// operator-whitelisted add_ready_label safe mutation, but when the
+		// operator gates it behind approval_required the supervisor mints an
+		// approval instead — which the executor must be able to run. Missing
+		// here is exactly how the cautious+LLM dynamic-wave handoff stalled
+		// silently ("refusing to mint approval: action label_issue_ready").
+		ActionLabelIssueReady,
 	}
 	for _, action := range mutatingActions {
 		action := action

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -294,7 +294,15 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 	// requires_approval=false while the supervisor silently minted (or
 	// would mint) an approval. Recompute against the same predicate that
 	// drives the mint so the field never lies.
-	if decisionRequiresApproval(cfg, decision) {
+	//
+	// #736: a decision whose planned mutations are all operator-whitelisted
+	// safe actions is applied directly (no approval), so it must NOT report
+	// requires_approval — even when the LLM raised the headline decision.Risk
+	// for display. Otherwise fall back to the mint predicate so the field
+	// never under-reports a genuinely gated mutating verb.
+	if allQueueMutationsAllowed(cfg, decision.Mutations) {
+		decision.RequiresApproval = false
+	} else if decisionRequiresApproval(cfg, decision) {
 		decision.RequiresApproval = true
 	}
 	if !cfg.Supervisor.DryRun {
@@ -307,29 +315,7 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 		if proposal, created := recordLessonProposalForDecision(cfg, st, decision); created && proposal != nil {
 			log.Printf("[supervisor] proposed lesson %s for %s/%s; approval=%s", proposal.ID, proposal.FailureClass, proposal.Area, proposal.ApprovalID)
 		}
-		if decisionRequiresApproval(cfg, decision) {
-			// #505: gate the mint on the executor registry. A verb the
-			// executor cannot handle would otherwise pile up
-			// execution_failed records every cycle (live evidence:
-			// spawn_repair_worker on dogfood 2026-05-30, 4 stuck records
-			// before the operator noticed). Refuse at mint time so the
-			// failure surfaces loudly in the journal instead of silently
-			// in state.json.
-			if !approver.IsKnownApprovalAction(decision.RecommendedAction) {
-				log.Printf("[supervisor] refusing to mint approval: action %q is not in the executor registry; supported actions = %v", decision.RecommendedAction, approver.KnownApprovalActionList())
-			} else {
-				approval := st.RecordPendingApprovalForDecision(decision, decision.CreatedAt)
-				decision.ApprovalID = approval.ID
-			}
-		}
-		if len(decision.Mutations) > 0 && decision.Risk == RiskSafe {
-			mutator, ok := reader.(Mutator)
-			if !ok {
-				markUnsupportedQueueAction(&decision)
-			} else {
-				applyQueueAction(cfg, &decision, mutator)
-			}
-		}
+		applyOrMintDecision(cfg, st, reader, &decision)
 		st.RecordSupervisorDecision(decision, state.DefaultSupervisorDecisionLimit)
 		// Phase 1.2 (#499): stamp the last-run heartbeat just before save
 		// so the watchdog goroutine in cmd/maestro can see this cycle
@@ -349,6 +335,53 @@ func RunOnce(cfg *config.Config, reader Reader) (state.SupervisorDecision, error
 		compactTerminalSessions(cfg, st, "supervisor")
 	}
 	return decision, nil
+}
+
+// applyOrMintDecision is the post-decision side-effect stage of RunOnce,
+// extracted so the #736 apply-vs-mint choice is unit-testable without
+// shelling out to a real supervisor LLM backend.
+//
+// #736: a decision that carries only operator-whitelisted safe queue
+// mutations is applied DIRECTLY, regardless of the LLM-overridable headline
+// decision.Risk. The deterministic guardrail plans add_ready_label /
+// remove_*_label only when the operator put them in safe_actions
+// (queueMutationAllowed); the cautious+LLM merge may raise the headline risk
+// for display, but it must not nullify a safe mutation the operator already
+// whitelisted. Applying here — and minting only otherwise — also prevents
+// the double-handling the issue describes: before #736 label_issue_ready
+// could be both refused at mint (the #505 registry guard) AND dropped at
+// apply (the old `decision.Risk == RiskSafe` gate), so the ready label was
+// never applied and the orchestrator starved.
+//
+// Apply and mint are mutually exclusive: a decision whose mutations are all
+// safe-action-allowed is recorded as succeeded (applyQueueAction), never as
+// a refused/pending approval. Genuinely approval-gated verbs (empty or
+// non-whitelisted mutations) fall through to the existing mint path, still
+// gated on the executor registry (#505).
+func applyOrMintDecision(cfg *config.Config, st *state.State, reader Reader, decision *state.SupervisorDecision) {
+	if allQueueMutationsAllowed(cfg, decision.Mutations) {
+		mutator, ok := reader.(Mutator)
+		if !ok {
+			markUnsupportedQueueAction(decision)
+			return
+		}
+		applyQueueAction(cfg, decision, mutator)
+		return
+	}
+	if decisionRequiresApproval(cfg, *decision) {
+		// #505: gate the mint on the executor registry. A verb the executor
+		// cannot handle would otherwise pile up execution_failed records
+		// every cycle (live evidence: spawn_repair_worker on dogfood
+		// 2026-05-30, 4 stuck records before the operator noticed). Refuse
+		// at mint time so the failure surfaces loudly in the journal
+		// instead of silently in state.json.
+		if !approver.IsKnownApprovalAction(decision.RecommendedAction) {
+			log.Printf("[supervisor] refusing to mint approval: action %q is not in the executor registry; supported actions = %v", decision.RecommendedAction, approver.KnownApprovalActionList())
+			return
+		}
+		approval := st.RecordPendingApprovalForDecision(*decision, decision.CreatedAt)
+		decision.ApprovalID = approval.ID
+	}
 }
 
 // compactTerminalSessions applies cfg.SessionRetention to st and persists the
@@ -2080,6 +2113,31 @@ func safeActionAllowed(cfg *config.Config, action string) bool {
 		return false
 	}
 	return cfg.Supervisor.AllowsSafeAction(action)
+}
+
+// allQueueMutationsAllowed reports whether the decision carries ≥1 planned
+// mutation AND every one is an operator-whitelisted safe queue action
+// (queueMutationAllowed). RunOnce applies such mutations directly via
+// applyOrMintDecision, regardless of the LLM-overridable headline
+// decision.Risk (#736). An empty mutation list returns false — there is
+// nothing to apply, so the decision falls through to the approval mint path.
+//
+// This is the apply-gate counterpart of plannedMutations, which builds the
+// list using the same queueMutationAllowed predicate; if a mutation passed
+// the filter at planning time it passes here too. It deliberately uses
+// queueMutationAllowed (not the plain safeActionAllowed used by
+// allMutationsAllowed) so the owns_ready_label remove_ready_label carve-out
+// is honored at apply time as well.
+func allQueueMutationsAllowed(cfg *config.Config, mutations []state.SupervisorMutation) bool {
+	if len(mutations) == 0 {
+		return false
+	}
+	for _, m := range mutations {
+		if !queueMutationAllowed(cfg, m) {
+			return false
+		}
+	}
+	return true
 }
 
 func (e *Engine) firstQueueActionCandidate(st *state.State, issues []github.Issue) (*queueActionCandidate, error) {


### PR DESCRIPTION
Implements #736

## Problem
In cautious supervisor mode with an LLM backend, the deterministically-planned safe `add_ready_label` mutation that hands a dynamic-wave issue to the orchestrator was silently dropped every cycle: the LLM is allowed to raise the headline `decision.Risk` (safe → approval_gated), RunOnce keyed the safe-mutation apply on `decision.Risk == RiskSafe`, and the approval fallback refused to mint because `label_issue_ready` was missing from the executor registry. The ready label was never applied and the orchestrator starved (0 issues checked despite free slots).

## Changes
- **supervisor**: decouple safe queue-mutation application from the LLM-overridable headline risk. New `allQueueMutationsAllowed` gate applies planned mutations when every one is an operator-whitelisted safe action (`queueMutationAllowed`), regardless of `decision.Risk`. Apply and mint are now mutually exclusive (extracted `applyOrMintDecision`), so an applied safe mutation is recorded `succeeded` and never also refused/minted; `requires_approval` reporting is reconciled with the same gate.
- **approver** (defense-in-depth): add `label_issue_ready` to `KnownApprovalActions` and wire `executeLabelIssueReady`, which applies the configured ready label so the operator-gated path can actually execute on approve (`GitHubClient` gains `AddIssueLabel`). The `add_ready_label` safe-action alias stays out of the approval registry.
- **tests**: RunOnce LLM-risk-inflation reproduction (auto-applied, no approval) and operator-gated mint; executor `label_issue_ready` cases; registry + registry-drift coverage so this drift class is caught at CI.

## Testing
- `gofmt -l` on changed files (clean)
- `go build ./cmd/maestro/`
- `go test ./...` (all green), including `./internal/supervisor/... ./internal/approver/... ./internal/config/...`
- `.maestro/verify.sh` — all verifications passed

Refs #736

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the cautious+LLM supervisor mode bug (#736) where the `add_ready_label` safe mutation was silently dropped every cycle: the LLM could raise the headline `decision.Risk` to `approval_gated`, the old apply gate keyed on `decision.Risk == RiskSafe` and skipped the mutation, and the at-mint registry guard then refused to mint because `label_issue_ready` was absent from `KnownApprovalActions` — leaving the orchestrator starved.

- **`applyOrMintDecision`** replaces the two separate if-branches in `RunOnce`, making apply and mint mutually exclusive; the new `allQueueMutationsAllowed` gate triggers the apply path based on whether every planned mutation is operator-whitelisted, ignoring the LLM-overridable headline risk.
- **`label_issue_ready` added to `KnownApprovalActions`** and `executeLabelIssueReady` wired into the executor, so the operator-gated fallback path (approval_required instead of safe_actions) can actually be approved and executed.
- **New tests** reproduce the exact regression shape (safe mutation applied despite LLM risk inflation, no approval minted), the operator-gated mint path, and a registry-drift CI guard (`TestSupervisorActions_ResolveToSafeMutationOrRegistry`) that catches this class of omission going forward.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The new `allQueueMutationsAllowed` gate is a strict subset of the old safe-mutation path (checks the same `queueMutationAllowed` predicate used at planning time), apply and mint are mutually exclusive, and the existing `decisionRequiresApproval` guard is preserved for genuinely gated decisions.

The core logic change in `applyOrMintDecision` is small, well-commented, and directly exercised by two new end-to-end tests that reproduce the exact regression shape. The `approverReadyLabel` helper duplicates `Engine.readyLabel` but is functionally identical today. The registry drift test gives ongoing CI coverage of the failure class. No paths are left worse off than before.

`internal/approver/executor.go` — the `approverReadyLabel` helper duplicates supervisor label-resolution logic and could drift silently; worth consolidating in a follow-up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Extracts `applyOrMintDecision`, adds `allQueueMutationsAllowed` gate, and decouples safe-mutation application from LLM-overridable headline risk. Core logic of the fix is sound and mutually exclusive apply/mint is correctly enforced. |
| internal/approver/executor.go | Adds `AddIssueLabel` to `GitHubClient`, wires `executeLabelIssueReady` into `dispatchAction`, and introduces `approverReadyLabel` helper that mirrors `Engine.readyLabel()`. Implementation is correct; label resolution logic is consistent with the supervisor's own helper. |
| internal/approver/registry.go | Adds `label_issue_ready` to `KnownApprovalActions` with a clear comment explaining why the safe-action alias `add_ready_label` stays out. Correct and well-documented. |
| internal/supervisor/label_ready_handoff_test.go | New regression test covering both the LLM-risk-inflation path (mutations auto-applied, no approval) and the operator-gated path (approval minted and registerable). Good coverage of the exact bug shape described in the PR. |
| internal/supervisor/registry_drift_test.go | Adds `TestSupervisorActions_ResolveToSafeMutationOrRegistry` to catch the "action is neither safe-mutation nor in registry" drift class at CI time, and extends the existing `TestSupervisorMutatingActions_AreInExecutorRegistry` with `ActionLabelIssueReady`. |
| internal/approver/executor_test.go | Adds `fakeGH.AddIssueLabel` and four `executeLabelIssueReady` test cases: happy path, `issue_labels` fallback, missing issue, and unconfigured label. Good coverage. |
| internal/approver/registry_test.go | Adds `label_issue_ready` to the positive cases and refines the comment on `add_ready_label` in the negative cases. Consistent with the registry change. |
| internal/approver/idempotent_test.go | Adds `AddIssueLabel` to `blockingGH` stub to satisfy the updated `GitHubClient` interface. Minimal, correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/approver/executor.go:530-546
The `approverReadyLabel` function is a verbatim copy of `Engine.readyLabel()` in `supervisor.go`. The comment acknowledges this, but the duplication creates a silent drift risk: if the label-resolution fallback order is ever updated in one place, the approval-gated path will silently apply a different label than the safe-mutation path. Consider lifting the logic into a shared helper on `*config.Config` or in an internal config helper package that both callers can import without a cycle.

```suggestion
// approverReadyLabel resolves the project ready label the same way the
// supervisor's Engine.readyLabel does: prefer supervisor.ready_label, then
// fall back to the first non-empty issue_labels entry.
//
// TODO(#736-follow-up): lift into config or a shared helper so the two
// call-sites (Engine.readyLabel and here) cannot drift apart.
func approverReadyLabel(cfg *config.Config) string {
	if cfg == nil {
		return ""
	}
	if label := strings.TrimSpace(cfg.Supervisor.ReadyLabel); label != "" {
		return label
	}
	for _, label := range cfg.IssueLabels {
		if label = strings.TrimSpace(label); label != "" {
			return label
		}
	}
	return ""
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["supervisor: apply safe ready-label mutat..."](https://github.com/befeast/maestro/commit/7b81d82f6b04b6acd50f1e8531cb27988cb7cabe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38792726)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->