### PR TITLE
self-deploy: outer systemd-run launcher is scope-aware (#742)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3770,7 +3770,7 @@ func (o *Orchestrator) mergeReadyPR(s *state.State, slotName string, sess *state
 	}
 
 	// Self-deploy hook (#698)
-	o.maybeSelfDeployAfterMerge(pr.Number)
+	o.maybeSelfDeployAfterMerge(s, pr.Number)
 
 	// Deploy hook
 	deploySucceeded := false
@@ -3862,7 +3862,7 @@ func (o *Orchestrator) runDeployCmd(prNumber int) error {
 // process, so we must not wait on it here — the outcome lands as a
 // supervisor finding when the result file is consumed on a later cycle (see
 // consumeSelfDeployResult).
-func (o *Orchestrator) maybeSelfDeployAfterMerge(prNumber int) {
+func (o *Orchestrator) maybeSelfDeployAfterMerge(s *state.State, prNumber int) {
 	if !o.cfg.SelfDeploy.Enabled {
 		return
 	}
@@ -3882,7 +3882,14 @@ func (o *Orchestrator) maybeSelfDeployAfterMerge(prNumber int) {
 	}
 	if err := o.triggerSelfDeploy(prNumber); err != nil {
 		log.Printf("[orch] self-deploy trigger failed for PR #%d: %v", prNumber, err)
-		o.notifier.Sendf("⚠️ maestro: self-deploy trigger failed after PR #%d merge: %v", prNumber, err)
+		o.notifier.Sendf("⚠️ maestro: self-deploy trigger failed after PR #%d merge: %v — fleet still on the previous binary", prNumber, err)
+		// #742: surface the failure as a supervisor finding so a merge that
+		// silently failed to deploy shows up as fleet attention rather than a
+		// lone log line; the next merge retries (the trigger marker is recorded
+		// only on success, below).
+		if s != nil {
+			s.RecordSupervisorDecision(selfdeploy.TriggerFailedFinding(prNumber, err, o.cfg.Repo, now), state.DefaultSupervisorDecisionLimit)
+		}
 		return
 	}
 	// Record the trigger now that the deploy is launched. The detached script

--- a/internal/orchestrator/selfdeploy_test.go
+++ b/internal/orchestrator/selfdeploy_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -21,7 +22,7 @@ func TestMaybeSelfDeployAfterMerge_DefaultOff(t *testing.T) {
 		selfDeployStartFn: func(prNumber int) error { called = true; return nil },
 	}
 
-	o.maybeSelfDeployAfterMerge(698)
+	o.maybeSelfDeployAfterMerge(nil, 698)
 	if called {
 		t.Fatal("self-deploy triggered with the flag off")
 	}
@@ -38,9 +39,44 @@ func TestMaybeSelfDeployAfterMerge_Enabled(t *testing.T) {
 		selfDeployStartFn: func(prNumber int) error { gotPR = prNumber; return nil },
 	}
 
-	o.maybeSelfDeployAfterMerge(698)
+	o.maybeSelfDeployAfterMerge(nil, 698)
 	if gotPR != 698 {
 		t.Fatalf("trigger called with PR %d, want 698", gotPR)
+	}
+}
+
+// #742: a trigger failure (the detached unit never launched) is surfaced as a
+// supervisor finding so a silently-undeployed merge shows as fleet attention
+// instead of just a log line — and does not record a trigger marker, so the
+// next merge retries.
+func TestMaybeSelfDeployAfterMerge_TriggerFailureSurfacesFinding(t *testing.T) {
+	stateDir := t.TempDir()
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   stateDir,
+			SelfDeploy: config.SelfDeployConfig{Enabled: true, MinIntervalMinutes: 30},
+		},
+		notifier:          &notify.Notifier{},
+		selfDeployStartFn: func(prNumber int) error { return errors.New("systemd-run: exit status 1") },
+	}
+	s := &state.State{}
+
+	o.maybeSelfDeployAfterMerge(s, 742)
+
+	if len(s.SupervisorDecisions) != 1 {
+		t.Fatalf("decisions recorded = %d, want 1", len(s.SupervisorDecisions))
+	}
+	d := s.SupervisorDecisions[0]
+	if d.Status != "failed" {
+		t.Errorf("Status = %q, want failed", d.Status)
+	}
+	if !strings.Contains(d.Summary, "trigger failed") || !strings.Contains(d.Summary, "PR #742") {
+		t.Errorf("Summary = %q", d.Summary)
+	}
+	// A pure trigger failure must not suppress the next attempt: no marker.
+	if _, _, ok := selfdeploy.LastTrigger(stateDir); ok {
+		t.Error("trigger marker recorded despite trigger failure — next merge would be debounced")
 	}
 }
 
@@ -65,7 +101,7 @@ func TestMaybeSelfDeployAfterMerge_DebouncesRecentTrigger(t *testing.T) {
 		selfDeployStartFn: func(prNumber int) error { calls++; return nil },
 	}
 
-	o.maybeSelfDeployAfterMerge(699)
+	o.maybeSelfDeployAfterMerge(nil, 699)
 	if calls != 0 {
 		t.Fatalf("trigger fired %d times within the debounce window, want 0", calls)
 	}
@@ -91,7 +127,7 @@ func TestMaybeSelfDeployAfterMerge_FiresAfterWindow(t *testing.T) {
 		selfDeployStartFn: func(prNumber int) error { gotPR = prNumber; return nil },
 	}
 
-	o.maybeSelfDeployAfterMerge(720)
+	o.maybeSelfDeployAfterMerge(nil, 720)
 	if gotPR != 720 {
 		t.Fatalf("trigger called with PR %d, want 720", gotPR)
 	}

--- a/internal/selfdeploy/selfdeploy.go
+++ b/internal/selfdeploy/selfdeploy.go
@@ -3,8 +3,11 @@
 //
 // The orchestrator does not build/install/restart in-process: it would kill
 // itself halfway through. Instead Trigger launches scripts/self-deploy.sh in
-// a detached transient systemd unit (systemd-run --user), so the script
-// survives the maestro unit restarting. The script builds from merged main
+// a detached transient systemd unit, so the script survives the maestro unit
+// restarting. The launcher scope matches the unit scope (#742): `systemd-run
+// --user` for user scope, or `sudo -n systemd-run --uid=<user>` in the system
+// manager for scope=system (whose orchestrator service env lacks the user bus).
+// The script builds from merged main
 // (version-stamped per #682), installs the binary atomically keeping the
 // previous one as `.prev`, restarts the configured units — user units via
 // `systemctl --user` or, with scope=system, system units via
@@ -21,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -174,17 +178,38 @@ func TriggerCommand(cfg *config.Config, prNumber int, now time.Time) (string, []
 	unitName := fmt.Sprintf("maestro-self-deploy-pr%d-%d", prNumber, now.Unix())
 	timeoutSec := cfg.SelfDeploy.EffectiveTimeoutMinutes() * 60
 
-	args := []string{
-		"--user",
+	scope := cfg.SelfDeploy.EffectiveScope()
+
+	// #742: the OUTER launcher scope must match the unit scope. #716 made only
+	// the inner unit restart scope-aware; the outer launcher stayed on
+	// `systemd-run --user`. On a system-scope host the orchestrator runs as a
+	// system service (e.g. User=god) whose process environment lacks
+	// XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS, so `systemd-run --user` cannot
+	// reach the user bus and exits 1 — silently dropping the deploy. For
+	// scope=system, launch the detached unit in the always-reachable system
+	// manager via `sudo -n systemd-run` (non-interactive, mirroring the script's
+	// privileged ops), running it as the invoking user via --uid so the build/git
+	// steps keep the same uid as the user-scope path (running as root would trip
+	// git's dubious-ownership guard on the user-owned checkout). Keep
+	// `systemd-run --user` for the legacy user scope.
+	launcher := "systemd-run"
+	var args []string
+	if scope == config.SelfDeployScopeSystem {
+		launcher = "sudo"
+		args = []string{"-n", "systemd-run", "--uid=" + deployRunAsUser()}
+	} else {
+		args = []string{"--user"}
+	}
+	args = append(args,
 		"--collect",
-		"--unit=" + unitName,
-		"--property=WorkingDirectory=" + localPath,
+		"--unit="+unitName,
+		"--property=WorkingDirectory="+localPath,
 		// Hard backstop well past the script's own deadline so a wedged
 		// deploy cannot linger forever; the script handles its own
 		// timeouts (and rollback) inside timeoutSec.
-		"--property=RuntimeMaxSec=" + strconv.Itoa(timeoutSec*2),
-	}
-	// The transient unit gets the user manager's default environment, which
+		"--property=RuntimeMaxSec="+strconv.Itoa(timeoutSec*2),
+	)
+	// The transient unit gets the systemd manager's default environment, which
 	// usually lacks the Go toolchain dirs the orchestrator unit configures.
 	// Hand our PATH down so the build step finds the same tools.
 	if path := strings.TrimSpace(os.Getenv("PATH")); path != "" {
@@ -198,11 +223,11 @@ func TriggerCommand(cfg *config.Config, prNumber int, now time.Time) (string, []
 		"--result-file", ResultPath(cfg.StateDir),
 		"--timeout-seconds", strconv.Itoa(timeoutSec),
 		"--pr", strconv.Itoa(prNumber),
-		// #716: select the systemd unit scope. Default "user" keeps the
-		// pre-migration behavior; "system" restarts system units via
+		// #716: select the systemd unit scope inside the script. Default "user"
+		// keeps the pre-migration behavior; "system" restarts system units via
 		// `sudo -n systemctl` (e.g. the Loki fleet, where maestro runs as
 		// User=god system units rather than per-user units).
-		"--scope", cfg.SelfDeploy.EffectiveScope(),
+		"--scope", scope,
 	)
 	// #711: when bin_path is root-owned, the unprivileged deploy user cannot
 	// stage/rename into it. install_via_sudo escalates the file ops with
@@ -216,7 +241,29 @@ func TriggerCommand(cfg *config.Config, prNumber int, now time.Time) (string, []
 			args = append(args, "--health-token-env", env)
 		}
 	}
-	return "systemd-run", args, nil
+	return launcher, args, nil
+}
+
+// deployRunAsUser returns the username the system-scope transient unit should
+// run as — the invoking user — so the build/git steps keep the same uid as the
+// user-scope path instead of running as root (which would trip git's
+// dubious-ownership guard on the user-owned checkout, and pollute root's build
+// cache). Falls back to the USER/LOGNAME env, then to the numeric uid.
+func deployRunAsUser() string {
+	if u, err := user.Current(); err == nil {
+		if name := strings.TrimSpace(u.Username); name != "" {
+			return name
+		}
+		if uid := strings.TrimSpace(u.Uid); uid != "" {
+			return uid
+		}
+	}
+	for _, k := range []string{"USER", "LOGNAME"} {
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v
+		}
+	}
+	return strconv.Itoa(os.Getuid())
 }
 
 // Trigger starts the deploy script in a detached transient unit and returns
@@ -229,9 +276,39 @@ func Trigger(cfg *config.Config, prNumber int) error {
 	}
 	out, err := exec.Command(name, args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("self-deploy: systemd-run: %w\n%s", err, out)
+		return fmt.Errorf("self-deploy: %s: %w\n%s", name, err, out)
 	}
 	return nil
+}
+
+// TriggerFailedFinding converts a failed self-deploy *trigger* — the detached
+// unit never launched (e.g. systemd-run/sudo rejected the request) — into a
+// supervisor finding so a merge that silently failed to deploy surfaces as
+// fleet attention instead of a lone log line (#742). Until acted on, the fleet
+// keeps running the previous binary, so this must not be invisible. The next
+// merge retries automatically (the trigger marker is only recorded on success).
+func TriggerFailedFinding(prNumber int, triggerErr error, project string, now time.Time) state.SupervisorDecision {
+	reason := "unknown error"
+	if triggerErr != nil {
+		reason = triggerErr.Error()
+	}
+	prSuffix := ""
+	if prNumber > 0 {
+		prSuffix = fmt.Sprintf(" after PR #%d", prNumber)
+	}
+	return state.SupervisorDecision{
+		ID:               "self-deploy-trigger-failed-" + now.Format("20060102T150405.000000000Z"),
+		CreatedAt:        now,
+		Project:          project,
+		Risk:             "safe",
+		Confidence:       1.0,
+		RequiresApproval: false,
+		Status:           "failed",
+		Summary:          fmt.Sprintf("self-deploy: trigger failed%s — merged change NOT deployed; fleet still on the previous binary", prSuffix),
+		RecommendedAction: "the detached deploy unit never launched: check `sudo -n systemd-run`/`systemd-run --user` from the orchestrator's service context, " +
+			"then redeploy by hand (a later merge retries automatically)",
+		Reasons: []string{"trigger error: " + reason},
+	}
 }
 
 // Finding converts a deploy result into the supervisor finding the

--- a/internal/selfdeploy/selfdeploy_test.go
+++ b/internal/selfdeploy/selfdeploy_test.go
@@ -185,6 +185,70 @@ func TestTriggerCommandScope(t *testing.T) {
 	}
 }
 
+// #742: the OUTER launcher must match the unit scope. User scope launches
+// `systemd-run --user`; system scope launches `sudo -n systemd-run --uid=<user>`
+// (no --user) so it works from a system-service context lacking the user bus.
+func TestTriggerCommandOuterLauncherScope(t *testing.T) {
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+
+	// --- user scope (default): systemd-run --user, no sudo ---
+	cfg := triggerTestConfig(t)
+	name, args, err := TriggerCommand(cfg, 742, now)
+	if err != nil {
+		t.Fatalf("TriggerCommand: %v", err)
+	}
+	if name != "systemd-run" {
+		t.Errorf("user-scope launcher = %q, want systemd-run", name)
+	}
+	if len(args) == 0 || args[0] != "--user" {
+		t.Errorf("user-scope first arg = %v, want --user first", args)
+	}
+	for _, banned := range []string{"-n", "sudo"} {
+		if contains(args, banned) {
+			t.Errorf("user-scope args must not contain %q: %v", banned, args)
+		}
+	}
+	if hasPrefix(args, "--uid=") {
+		t.Errorf("user-scope args must not set --uid: %v", args)
+	}
+
+	// --- system scope: sudo -n systemd-run --uid=<user>, no --user ---
+	cfg = triggerTestConfig(t)
+	cfg.SelfDeploy.Scope = "system"
+	name, args, err = TriggerCommand(cfg, 742, now)
+	if err != nil {
+		t.Fatalf("TriggerCommand: %v", err)
+	}
+	if name != "sudo" {
+		t.Errorf("system-scope launcher = %q, want sudo", name)
+	}
+	if len(args) < 3 || args[0] != "-n" || args[1] != "systemd-run" {
+		t.Errorf("system-scope args = %v, want [-n systemd-run ...] prefix", args)
+	}
+	if contains(args, "--user") {
+		t.Errorf("system-scope must NOT pass --user (root cause of #742): %v", args)
+	}
+	if !hasPrefix(args, "--uid=") {
+		t.Errorf("system-scope must run the unit as the invoking user via --uid: %v", args)
+	}
+	// The shared unit properties still flow through regardless of scope.
+	for _, want := range []string{"--collect", "/bin/bash"} {
+		if !contains(args, want) {
+			t.Errorf("system-scope args missing %q: %v", want, args)
+		}
+	}
+}
+
+// hasPrefix reports whether any arg starts with the given prefix.
+func hasPrefix(args []string, prefix string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // flagValue reports whether args contains "<flag> <value>" as adjacent items.
 func flagValue(args []string, flag, value string) bool {
 	for i := 0; i < len(args)-1; i++ {

--- a/scripts/self-deploy.sh
+++ b/scripts/self-deploy.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # self-deploy.sh — opt-in post-merge self-deploy of the maestro binary (#698).
 #
-# Launched by the orchestrator through a detached transient systemd unit
-# (systemd-run --user) after a PR merges, so this script survives restarting
-# the very units that run the orchestrator. Steps:
+# Launched by the orchestrator through a detached transient systemd unit after
+# a PR merges, so this script survives restarting the very units that run the
+# orchestrator. The launcher scope matches --scope (#742): `systemd-run --user`
+# for user scope, `sudo -n systemd-run --uid=<user>` (system manager) for
+# system scope. Steps:
 #
 #   1. build from merged origin/main, version-stamped per #682
 #      (-X main.version=<VERSION>+g<shortsha>),


### PR DESCRIPTION
Implements #742

## Problem
The self-deploy trigger hardcoded the outer launcher as `systemd-run --user`. #716 made only the *inner* unit restart scope-aware; the *outer* launcher stayed on `--user`. On a system-scope host the orchestrator runs as a system service (`User=god`) whose process environment lacks `XDG_RUNTIME_DIR`/`DBUS_SESSION_BUS_ADDRESS`, so `systemd-run --user` cannot reach the user bus → exit 1, and the merged PR silently does not deploy (the fleet keeps running the stale binary).

## Changes
- `internal/selfdeploy/selfdeploy.go` — `TriggerCommand` now picks the launcher by `EffectiveScope()`:
  - `scope: user` (default, unchanged): `systemd-run --user …`
  - `scope: system`: `sudo -n systemd-run --uid=<invoking-user> …` (no `--user`) — uses the always-reachable system manager and runs the unit as the invoking user so the build/git steps keep the same uid (running as root would trip git's dubious-ownership guard).
- A failed trigger is surfaced as a supervisor finding (`TriggerFailedFinding`) so a silently-undeployed merge shows up as fleet attention instead of a lone log line; it still retries on the next merge (the trigger marker is recorded only on success).
- `scripts/self-deploy.sh` — header doc updated to describe the scope-aware launcher.

## Testing
- `go test ./...` — all pass.
- New `TestTriggerCommandOuterLauncherScope` asserts the scope-correct outer argv for both `scope: user` (launcher `systemd-run`, `--user`, no `sudo`/`--uid`) and `scope: system` (launcher `sudo`, `-n systemd-run --uid=…`, no `--user`).
- New `TestMaybeSelfDeployAfterMerge_TriggerFailureSurfacesFinding` asserts a trigger failure records a `failed` supervisor finding and does not write a debounce marker.
- `gofmt`, `go vet`, `go build ./cmd/maestro/` clean.

## Runtime verification still required
Acceptance criterion "after a merge, the new version is live in `/api/v1/fleet` without manual intervention" depends on the system-scope host environment (passwordless `sudo -n`, system bus). It cannot be proven in CI and must be confirmed on the deployment host after this lands — hence this PR references rather than closes the issue.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent deploy failure on system-scope hosts: the outer `systemd-run --user` launcher could not reach the user bus from a system service environment, so merges on those hosts never deployed. `TriggerCommand` now selects the launcher by `EffectiveScope()`, and trigger failures are surfaced as supervisor findings rather than disappearing into a lone log line.

- **Scope-aware outer launcher**: user scope keeps `systemd-run --user`; system scope uses `sudo -n systemd-run --uid=<current-user>` so the transient unit runs in the always-reachable system manager as the correct uid (avoiding git's dubious-ownership guard).
- **`deployRunAsUser()` helper**: resolves the process user through `user.Current()`, env var fallbacks (`USER`/`LOGNAME`), and finally `os.Getuid()` — making the `--uid=` arg robust across CGO-disabled builds and minimal environments.
- **`TriggerFailedFinding`**: converts a failed trigger into a supervisor finding, keeping the debounce marker unwritten so the next merge automatically retries.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core launcher selection and user-resolution logic are sound and well-tested for both scopes.

The implementation is correct and the new tests cover both the scope-selection logic and the trigger-failure surfacing path. The only rough edge is that the pre-existing `Finding` function's `RecommendedAction` strings still hard-code `journalctl --user` and `systemctl --user`, which will give operators wrong debugging commands on a system-scope host now that the path is fully enabled.

`internal/selfdeploy/selfdeploy.go` — the pre-existing `Finding.RecommendedAction` strings warrant a follow-up fix for system-scope hosts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/selfdeploy/selfdeploy.go | Core change: `TriggerCommand` now selects the outer launcher by scope (`systemd-run --user` vs `sudo -n systemd-run --uid=<user>`). New `deployRunAsUser()` helper and `TriggerFailedFinding()` added. Logic is correct; `Finding.RecommendedAction` still hard-codes `--user` journalctl/systemctl commands that won't work on system-scope hosts. |
| internal/orchestrator/orchestrator.go | Adds `*state.State` parameter to `maybeSelfDeployAfterMerge` and records a `TriggerFailedFinding` on trigger failure. Nil guard for `s` is correct; `now` is in scope. Clean change. |
| internal/selfdeploy/selfdeploy_test.go | New `TestTriggerCommandOuterLauncherScope` tests both user and system scope launcher arguments thoroughly. `hasPrefix` helper is well-scoped. Existing tests updated for the new signature. |
| internal/orchestrator/selfdeploy_test.go | New `TestMaybeSelfDeployAfterMerge_TriggerFailureSurfacesFinding` correctly verifies that trigger failure records a supervisor finding with `status: failed` and does not write a debounce marker. Existing tests updated to pass `nil` state. |
| scripts/self-deploy.sh | Header comment updated to describe the scope-aware launcher. Documentation-only change, no logic affected. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/selfdeploy/selfdeploy.go`, line 329-348 ([link](https://github.com/befeast/maestro/blob/04e92628c8c72dcc0fe9b385bfd20b7c30823b62/internal/selfdeploy/selfdeploy.go#L329-L348)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Scope-blind `journalctl`/`systemctl` commands in `Finding.RecommendedAction`**

   Now that system scope is a fully-implemented path, three `RecommendedAction` strings that hard-code `--user` will actively mislead an operator debugging a system-scope failure. On a system-service host there is no user journal, so `journalctl --user -u 'maestro-self-deploy-*'` returns nothing, and `systemctl --user status` isn't the right command either. The new `TriggerFailedFinding` already avoids this by staying scope-agnostic — the same treatment would be appropriate here. The simplest fix without threading scope into `Finding` is to replace the scope-specific flags with scope-neutral language (`journalctl -u 'maestro-self-deploy-*'` works for both user and system units when run as root/with sudo, or the user-scope variant for unprivileged sessions).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/selfdeploy/selfdeploy.go
   Line: 329-348

   Comment:
   **Scope-blind `journalctl`/`systemctl` commands in `Finding.RecommendedAction`**

   Now that system scope is a fully-implemented path, three `RecommendedAction` strings that hard-code `--user` will actively mislead an operator debugging a system-scope failure. On a system-service host there is no user journal, so `journalctl --user -u 'maestro-self-deploy-*'` returns nothing, and `systemctl --user status` isn't the right command either. The new `TriggerFailedFinding` already avoids this by staying scope-agnostic — the same treatment would be appropriate here. The simplest fix without threading scope into `Finding` is to replace the scope-specific flags with scope-neutral language (`journalctl -u 'maestro-self-deploy-*'` works for both user and system units when run as root/with sudo, or the user-scope variant for unprivileged sessions).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/selfdeploy/selfdeploy.go:329-348
**Scope-blind `journalctl`/`systemctl` commands in `Finding.RecommendedAction`**

Now that system scope is a fully-implemented path, three `RecommendedAction` strings that hard-code `--user` will actively mislead an operator debugging a system-scope failure. On a system-service host there is no user journal, so `journalctl --user -u 'maestro-self-deploy-*'` returns nothing, and `systemctl --user status` isn't the right command either. The new `TriggerFailedFinding` already avoids this by staying scope-agnostic — the same treatment would be appropriate here. The simplest fix without threading scope into `Finding` is to replace the scope-specific flags with scope-neutral language (`journalctl -u 'maestro-self-deploy-*'` works for both user and system units when run as root/with sudo, or the user-scope variant for unprivileged sessions).


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["self-deploy: make outer systemd-run laun..."](https://github.com/befeast/maestro/commit/04e92628c8c72dcc0fe9b385bfd20b7c30823b62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38794079)</sub>

<!-- /greptile_comment -->