### PR TITLE
worker: claude stream-json usage capture + virtual cost (#737)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,21 @@ model:
 
 A backend that matches none of the above falls back to the generic exec path: `prompt_mode` applies, no permission-bypass flag is added, and Maestro logs a startup warning naming the backend. Use the generic path only for genuinely custom CLIs.
 
+### Claude usage capture (tokens + cost)
+
+Plain `claude -p` text mode prints no parseable token total, so a claude worker's `tokens_used_total` and USD cost stay `0`. Opt a claude backend into structured usage capture with `usage_stream: true`:
+
+```yaml
+model:
+  default: claude
+  backends:
+    claude:
+      cmd: claude
+      usage_stream: true   # run claude in --output-format stream-json; capture tokens + cost
+```
+
+When enabled, the worker runs `claude --output-format stream-json --verbose` and its NDJSON is piped through `maestro stream-split`, which writes the raw frames to a side-channel `<slot>.jsonl` (parsed for `input`/`output`/cache tokens + `total_cost_usd`) while keeping `<slot>.log` human-readable. The session then reports non-zero tokens + cost in `maestro history --json` and the `/api/v1/fleet` cost panel. Off by default; an operator-pinned `--output-format` in `extra_args` overrides it. (The `pi` backend captures usage natively and needs no opt-in.)
+
 ### Optional worker MCP tools
 
 Worker sessions receive no MCP tools by default. Attach project-specific MCP servers per backend with `model.backends.<name>.mcp`:

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -339,6 +339,8 @@ func main() {
 		cleanupCmd(args)
 	case "version-bump":
 		versionBumpCmd(args)
+	case "stream-split":
+		streamSplitCmd(args)
 	case "_watch-updater":
 		watchUpdaterCmd(args)
 	case "_watch-tail":

--- a/cmd/maestro/stream_split.go
+++ b/cmd/maestro/stream_split.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/befeast/maestro/internal/worker"
+)
+
+// streamSplitCmd implements `maestro stream-split`, the internal filter the
+// worker runner pipes a claude stream-json stream through (#737). It reads
+// NDJSON on stdin, appends every raw frame to --jsonl (the side-channel the
+// usage parser consumes), and renders human-readable text to stdout (tee'd
+// into slot.log). It never fails the pipeline on a per-line decode problem —
+// unrecognized lines pass through verbatim so the worker log is preserved.
+func streamSplitCmd(args []string) {
+	fs := flag.NewFlagSet("stream-split", flag.ExitOnError)
+	backend := fs.String("backend", "claude", "backend kind for rendering (claude)")
+	jsonl := fs.String("jsonl", "", "path to append raw NDJSON frames to (side channel)")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	if err := worker.RunStreamSplit(*backend, *jsonl, os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "[maestro] stream-split: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,16 @@ type BackendDef struct {
 	Variant  string `yaml:"variant,omitempty"`  // e.g. "opus[1m]", "fast", "sonnet"
 	Effort   string `yaml:"effort,omitempty"`   // e.g. "xhigh", "medium", "low"
 
+	// #737: opt-in structured usage capture. When true, a claude-kind backend
+	// runs in `--output-format stream-json --verbose` mode and the worker
+	// runner pipes its NDJSON through `maestro stream-split`, which writes the
+	// raw frames to a side-channel slot.jsonl (parsed for tokens/cost) while
+	// keeping slot.log human-readable. Off by default: plain `claude -p` text
+	// mode prints no parseable token total, so usage/cost stay 0 (the #737
+	// symptom) until an operator opts in. Overridable via extra_args (a
+	// trailing --output-format wins). Only the claude kind consumes this today.
+	UsageStream bool `yaml:"usage_stream,omitempty"`
+
 	// #507: NonAgentic marks a backend that is a TEXT-COMPLETION helper,
 	// not an agentic CLI capable of producing a real PR. Such a backend
 	// MUST NOT be used as model.default or in model.fallback_backends —

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -608,8 +608,17 @@ func (o *Orchestrator) updateTokensUsedFromOutput(slotName string, sess *state.S
 	// stream that carries provider/model + usage + cost. Parse it
 	// directly so model/tokens/cost_usd get attributed instead of the
 	// generic token regex (which sees none of the JSON shapes).
-	if o.backendKindForSession(sess) == config.BackendKindPi {
+	kind := o.backendKindForSession(sess)
+	if kind == config.BackendKindPi {
 		return o.updatePiUsageFromOutput(slotName, sess, output)
+	}
+	// #737: a claude session with usage_stream opted in carries its usage on a
+	// side-channel slot.jsonl (the human-readable slot.log has no parseable
+	// token total), so the passed `output` (tmux pane / slot.log) is ignored
+	// in favour of the raw NDJSON the stream-splitter appended. Without the
+	// opt-in, claude stays on the generic text parser (legacy behaviour).
+	if kind == config.BackendKindClaude && o.sessionUsageStream(sess) {
+		return o.updateClaudeUsageFromJSONL(slotName, sess)
 	}
 	tokens := worker.ParseTokensFromOutput(output)
 	if tokens <= sess.TokensUsedAttempt {
@@ -637,11 +646,11 @@ func (o *Orchestrator) updatePiUsageFromOutput(slotName string, sess *state.Sess
 	// On a respawn, the runner keeps appending to the same slot log while
 	// TokensUsedAttempt resets to 0 — comparing against TokensUsedAttempt
 	// would re-add the prior attempts' tokens. Use a separate monotonic
-	// watermark (PiTokensWatermark) that persists across respawns so only
+	// watermark (UsageTokensWatermark) that persists across respawns so only
 	// the new attempt's tokens are counted.
-	if usage.TotalTokens > sess.PiTokensWatermark {
-		delta := usage.TotalTokens - sess.PiTokensWatermark
-		sess.PiTokensWatermark = usage.TotalTokens
+	if usage.TotalTokens > sess.UsageTokensWatermark {
+		delta := usage.TotalTokens - sess.UsageTokensWatermark
+		sess.UsageTokensWatermark = usage.TotalTokens
 		sess.TokensUsedAttempt += delta
 		sess.TokensUsedTotal += delta
 		changed = true
@@ -662,6 +671,80 @@ func (o *Orchestrator) updatePiUsageFromOutput(slotName string, sess *state.Sess
 			slotName, usage.Model, usage.TotalTokens, usage.CostUSD, sess.TokensUsedTotal)
 	}
 	return changed
+}
+
+// workerJSONLFile returns the side-channel NDJSON path the claude
+// stream-splitter appends to (slot.jsonl), derived from the worker log path
+// (slot.log). Empty when no log path can be resolved.
+func (o *Orchestrator) workerJSONLFile(slotName string, sess *state.Session) string {
+	logFile := o.workerLogFile(slotName, sess)
+	if logFile == "" {
+		return ""
+	}
+	return worker.JSONLPathForLog(logFile)
+}
+
+// updateClaudeUsageFromJSONL parses the claude stream-json side-channel
+// (slot.jsonl) and stamps model/tokens/cost_usd onto the session (#737).
+// Like the Pi path it re-parses the full appended jsonl on each call, so
+// ParseClaudeUsage returns the cumulative run total across every attempt;
+// the monotonic UsageTokensWatermark persists across respawns so only the
+// new attempt's tokens are added (no double-count on retry/respawn). Cost
+// prefers the backend-reported total_cost_usd. Returns true when anything
+// changed; false (usage stays 0) when the jsonl is absent — the documented
+// degradation when the stream-splitter was unavailable.
+func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.Session) bool {
+	jsonlPath := o.workerJSONLFile(slotName, sess)
+	if jsonlPath == "" {
+		return false
+	}
+	data, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		// No side-channel stream (splitter disabled/unavailable, or the
+		// worker has not emitted a frame yet) — leave tokens at 0.
+		return false
+	}
+	usage, ok := worker.ParseClaudeUsage(string(data))
+	if !ok {
+		return false
+	}
+	changed := false
+	if usage.TotalTokens > sess.UsageTokensWatermark {
+		delta := usage.TotalTokens - sess.UsageTokensWatermark
+		sess.UsageTokensWatermark = usage.TotalTokens
+		sess.TokensUsedAttempt += delta
+		sess.TokensUsedTotal += delta
+		changed = true
+	}
+	if strings.TrimSpace(usage.Model) != "" && strings.TrimSpace(sess.Model) == "" {
+		sess.Model = usage.Model
+		changed = true
+	}
+	// total_cost_usd is the run-cumulative the full-jsonl parse sums across
+	// every result frame, so guard with `>` (mirrors the Pi cost fix in #732):
+	// a first-non-zero freeze would never update past the first attempt.
+	if usage.CostUSD > sess.CostUSDBackend {
+		sess.CostUSDBackend = usage.CostUSD
+		changed = true
+	}
+	if changed {
+		log.Printf("[orch] %s claude usage: model=%s tokens=%d cost=$%.4f (total=%d)",
+			slotName, usage.Model, usage.TotalTokens, usage.CostUSD, sess.TokensUsedTotal)
+	}
+	return changed
+}
+
+// sessionUsageStream reports whether the session's backend opted into #737
+// structured usage capture (usage_stream). Only then does the claude path read
+// the slot.jsonl side channel; otherwise it stays on the generic text parser.
+func (o *Orchestrator) sessionUsageStream(sess *state.Session) bool {
+	if sess == nil || o == nil || o.cfg == nil {
+		return false
+	}
+	if def, ok := o.cfg.Model.Backends[strings.TrimSpace(sess.Backend)]; ok {
+		return def.UsageStream
+	}
+	return false
 }
 
 // backendKindForSession resolves the CLI exec-path kind for a session's

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9638,8 +9638,8 @@ func TestUpdateTokensUsedFromOutput_PiBackendCostGrowsPastFirstTurn(t *testing.T
 	if sess.TokensUsedAttempt != 773 || sess.TokensUsedTotal != 773 {
 		t.Fatalf("after turn1: attempt=%d total=%d, want 773/773", sess.TokensUsedAttempt, sess.TokensUsedTotal)
 	}
-	if sess.PiTokensWatermark != 773 {
-		t.Errorf("PiTokensWatermark = %d, want 773", sess.PiTokensWatermark)
+	if sess.UsageTokensWatermark != 773 {
+		t.Errorf("UsageTokensWatermark = %d, want 773", sess.UsageTokensWatermark)
 	}
 	if !approxCostEq(sess.CostUSDBackend, 0.0010912) {
 		t.Errorf("after turn1: CostUSDBackend = %v, want 0.0010912", sess.CostUSDBackend)
@@ -9658,14 +9658,14 @@ func TestUpdateTokensUsedFromOutput_PiBackendCostGrowsPastFirstTurn(t *testing.T
 	if sess.TokensUsedAttempt != 2993 || sess.TokensUsedTotal != 2993 {
 		t.Errorf("after turn2: attempt=%d total=%d, want 2993/2993", sess.TokensUsedAttempt, sess.TokensUsedTotal)
 	}
-	if sess.PiTokensWatermark != 2993 {
-		t.Errorf("PiTokensWatermark = %d, want 2993", sess.PiTokensWatermark)
+	if sess.UsageTokensWatermark != 2993 {
+		t.Errorf("UsageTokensWatermark = %d, want 2993", sess.UsageTokensWatermark)
 	}
 }
 
 // #730/#732: on respawn/checkpoint resume the runner keeps appending to the
 // same slot log, so the full-log parse returns the all-attempt cumulative
-// token count. TokensUsedAttempt resets to 0 but the PiTokensWatermark
+// token count. TokensUsedAttempt resets to 0 but the UsageTokensWatermark
 // persists, so only the new attempt's delta is added — the prior attempts'
 // tokens are NOT re-counted into TokensUsedTotal.
 func TestUpdateTokensUsedFromOutput_PiBackendRetryNoDoubleCount(t *testing.T) {
@@ -9693,13 +9693,13 @@ func TestUpdateTokensUsedFromOutput_PiBackendRetryNoDoubleCount(t *testing.T) {
 	if !o.updateTokensUsedFromOutput("sup-732", sess, attempt1) {
 		t.Fatal("attempt1: expected a change")
 	}
-	if sess.TokensUsedTotal != 773 || sess.PiTokensWatermark != 773 || sess.TokensUsedAttempt != 773 {
+	if sess.TokensUsedTotal != 773 || sess.UsageTokensWatermark != 773 || sess.TokensUsedAttempt != 773 {
 		t.Fatalf("attempt1: total=%d wm=%d attempt=%d, want 773/773/773",
-			sess.TokensUsedTotal, sess.PiTokensWatermark, sess.TokensUsedAttempt)
+			sess.TokensUsedTotal, sess.UsageTokensWatermark, sess.TokensUsedAttempt)
 	}
 
 	// Simulate respawn: per-attempt counter resets to 0 (checkpoint/worker/phase
-	// reset it), but PiTokensWatermark persists across respawns.
+	// reset it), but UsageTokensWatermark persists across respawns.
 	sess.TokensUsedAttempt = 0
 
 	// Re-parse the SAME appended log (cumulative 773) before the new turn
@@ -9724,7 +9724,116 @@ func TestUpdateTokensUsedFromOutput_PiBackendRetryNoDoubleCount(t *testing.T) {
 	if sess.TokensUsedAttempt != 1000 {
 		t.Errorf("TokensUsedAttempt = %d, want 1000 (current attempt delta)", sess.TokensUsedAttempt)
 	}
-	if sess.PiTokensWatermark != 1773 {
-		t.Errorf("PiTokensWatermark = %d, want 1773", sess.PiTokensWatermark)
+	if sess.UsageTokensWatermark != 1773 {
+		t.Errorf("UsageTokensWatermark = %d, want 1773", sess.UsageTokensWatermark)
+	}
+}
+
+// claudeResultFrame builds one terminal claude stream-json `result` frame with
+// the given token totals + cost, as the stream-splitter would append it.
+func claudeResultFrame(in, out, cacheWrite, cacheRead int, cost float64, result string) string {
+	return fmt.Sprintf(`{"type":"result","subtype":"success","is_error":false,"num_turns":1,"result":%q,"total_cost_usd":%g,"usage":{"input_tokens":%d,"output_tokens":%d,"cache_creation_input_tokens":%d,"cache_read_input_tokens":%d}}`+"\n",
+		result, cost, in, out, cacheWrite, cacheRead)
+}
+
+// claudeTestOrchestrator wires a session to a claude backend whose slot.jsonl
+// lives at <dir>/<slot>.jsonl, returning the orchestrator, session, and jsonl
+// path. The session LogFile points at the sibling .log so the orchestrator
+// derives the .jsonl side channel (#737).
+func claudeTestOrchestrator(t *testing.T, slot string) (*Orchestrator, *state.Session, string) {
+	t.Helper()
+	dir := t.TempDir()
+	o := &Orchestrator{
+		cfg: &config.Config{
+			StateDir: dir,
+			Model: config.ModelConfig{
+				Default:  "claude",
+				Backends: map[string]config.BackendDef{"claude": {Cmd: "claude", UsageStream: true}},
+			},
+		},
+	}
+	logFile := dir + "/" + slot + ".log"
+	sess := &state.Session{Backend: "claude", LogFile: logFile}
+	return o, sess, dir + "/" + slot + ".jsonl"
+}
+
+// #737: a claude session reads usage from the slot.jsonl side channel (not the
+// human-readable slot.log) and stamps non-zero tokens + USD cost + model.
+func TestUpdateTokensUsedFromOutput_ClaudeBackendStampsUsage(t *testing.T) {
+	o, sess, jsonlPath := claudeTestOrchestrator(t, "sup-737")
+	frames := `{"type":"system","subtype":"init","model":"claude-opus-4-8[1m]"}` + "\n" +
+		claudeResultFrame(2487, 4, 1924, 15661, 0.0401785, "pong")
+	if err := os.WriteFile(jsonlPath, []byte(frames), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The passed output (slot.log/tmux) is intentionally ignored for claude.
+	if !o.updateTokensUsedFromOutput("sup-737", sess, "human readable log text, no token total") {
+		t.Fatal("expected a change from the claude jsonl side channel")
+	}
+	// 2487 + 4 + 1924 + 15661 = 20076
+	if sess.TokensUsedTotal != 20076 || sess.TokensUsedAttempt != 20076 {
+		t.Errorf("tokens total=%d attempt=%d, want 20076/20076", sess.TokensUsedTotal, sess.TokensUsedAttempt)
+	}
+	if sess.UsageTokensWatermark != 20076 {
+		t.Errorf("UsageTokensWatermark = %d, want 20076", sess.UsageTokensWatermark)
+	}
+	if !approxCostEq(sess.CostUSDBackend, 0.0401785) {
+		t.Errorf("CostUSDBackend = %v, want 0.0401785", sess.CostUSDBackend)
+	}
+	if sess.Model != "claude-opus-4-8[1m]" {
+		t.Errorf("Model = %q, want claude-opus-4-8[1m]", sess.Model)
+	}
+}
+
+// #737: a forced retry/respawn appends a second run's result frame to the same
+// slot.jsonl. The full-jsonl parse returns the cumulative total, but the
+// monotonic watermark ensures only the new run's delta is added — no
+// double-count of the prior attempt's tokens.
+func TestUpdateTokensUsedFromOutput_ClaudeBackendRetryNoDoubleCount(t *testing.T) {
+	o, sess, jsonlPath := claudeTestOrchestrator(t, "sup-737")
+
+	run1 := claudeResultFrame(770, 3, 0, 0, 0.001, "a") // total 773
+	if err := os.WriteFile(jsonlPath, []byte(run1), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateTokensUsedFromOutput("sup-737", sess, "") {
+		t.Fatal("run1: expected a change")
+	}
+	if sess.TokensUsedTotal != 773 || sess.UsageTokensWatermark != 773 || sess.TokensUsedAttempt != 773 {
+		t.Fatalf("run1: total=%d wm=%d attempt=%d, want 773/773/773",
+			sess.TokensUsedTotal, sess.UsageTokensWatermark, sess.TokensUsedAttempt)
+	}
+
+	// Respawn: per-attempt counter resets, watermark persists.
+	sess.TokensUsedAttempt = 0
+
+	// Re-parse the unchanged jsonl before the new run lands — must NOT re-add.
+	if o.updateTokensUsedFromOutput("sup-737", sess, "") {
+		t.Fatal("re-parse of unchanged jsonl must not report a change (would double-count)")
+	}
+	if sess.TokensUsedTotal != 773 {
+		t.Fatalf("after re-parse: TokensUsedTotal = %d, want 773 (no double-count)", sess.TokensUsedTotal)
+	}
+
+	// New run appends its result frame: cumulative 1773, delta only (1000).
+	run2 := claudeResultFrame(900, 100, 0, 0, 0.002, "b") // total 1000
+	if err := os.WriteFile(jsonlPath, []byte(run1+run2), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateTokensUsedFromOutput("sup-737", sess, "") {
+		t.Fatal("run2: expected a change")
+	}
+	if sess.TokensUsedTotal != 1773 {
+		t.Errorf("after run2: TokensUsedTotal = %d, want 1773 (delta only)", sess.TokensUsedTotal)
+	}
+	if sess.TokensUsedAttempt != 1000 {
+		t.Errorf("TokensUsedAttempt = %d, want 1000 (current attempt delta)", sess.TokensUsedAttempt)
+	}
+	if sess.UsageTokensWatermark != 1773 {
+		t.Errorf("UsageTokensWatermark = %d, want 1773", sess.UsageTokensWatermark)
+	}
+	if !approxCostEq(sess.CostUSDBackend, 0.003) {
+		t.Errorf("CostUSDBackend = %v, want 0.003 (cumulative)", sess.CostUSDBackend)
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -148,9 +148,9 @@ type Session struct {
 	// usage stream (Pi --mode json event stream). Empty/zero for backends
 	// that do not self-report; the fleet cost panel then falls back to the
 	// configured per-backend pricing estimate.
-	Model                       string            `json:"model,omitempty"`               // model the backend reported for this run (e.g. glm-5.2:cloud)
-	CostUSDBackend              float64           `json:"cost_usd_backend,omitempty"`    // USD cost the backend self-reported (Pi cost.total)
-	PiTokensWatermark           int               `json:"pi_tokens_watermark,omitempty"` // #730: high-water mark of the Pi full-log cumulative token count; persists across respawns so re-parsing the appended log does not double-count prior attempts
+	Model                       string            `json:"model,omitempty"`                  // model the backend reported for this run (e.g. glm-5.2:cloud, claude-opus-4-8)
+	CostUSDBackend              float64           `json:"cost_usd_backend,omitempty"`       // USD cost the backend self-reported (Pi cost.total / claude total_cost_usd)
+	UsageTokensWatermark        int               `json:"usage_tokens_watermark,omitempty"` // #730/#737: high-water mark of a backend usage stream's full-log cumulative token count (Pi --mode json, claude stream-json); persists across respawns so re-parsing the appended log/jsonl does not double-count prior attempts
 	LongRunning                 bool              `json:"long_running,omitempty"`
 	RebaseAttempted             bool              `json:"rebase_attempted,omitempty"`
 	NotifiedCIFail              bool              `json:"notified_ci_fail,omitempty"`           // deprecated: use LastNotifiedStatus

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -22,6 +22,19 @@ func splitCmd(cmd string) (binary string, prefixArgs []string) {
 	return parts[0], parts[1:]
 }
 
+// argsHaveOutputFormat reports whether the given args already pin an
+// --output-format flag (either `--output-format json` or `--output-format=json`).
+// Used so an operator-specified output format in cmd/extra_args overrides the
+// #737 stream-json default instead of producing a duplicate flag.
+func argsHaveOutputFormat(args []string) bool {
+	for _, a := range args {
+		if a == "--output-format" || strings.HasPrefix(a, "--output-format=") {
+			return true
+		}
+	}
+	return false
+}
+
 // BackendConfig holds the CLI command and any extra args from config.
 type BackendConfig struct {
 	Cmd        string   // binary name (e.g. "claude", "codex", "gemini")
@@ -30,7 +43,11 @@ type BackendConfig struct {
 	Provider   string   // per-backend provider field; resolves the exec path for custom-named backends (#684)
 	Model      string   // optional model name for role-specific backend calls
 	Effort     string   // optional reasoning effort for role-specific backend calls
-	MCP        config.MCPConfig
+	// UsageStream opts a claude-kind worker into `--output-format stream-json
+	// --verbose` so its NDJSON usage stream can be captured on a side-channel
+	// slot.jsonl (#737). Off by default; ignored by non-claude backends.
+	UsageStream bool
+	MCP         config.MCPConfig
 }
 
 // Backend builds the exec.Cmd for a specific model CLI.
@@ -68,6 +85,13 @@ func (claudeBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*
 	// argument is given; the runner script wires promptFile to stdin (mirrors
 	// the codex `-` path and the supervisor claude branch from #453).
 	args := append(cmdArgs, "--dangerously-skip-permissions", "-p")
+	// #737: opt-in structured streaming so usage (tokens/cost) can be parsed
+	// from the NDJSON side-channel. stream-json with -p requires --verbose.
+	// Skipped when the operator already pins an --output-format via cmd or
+	// extra_args, so their choice (and the matching runner wiring) wins.
+	if cfg.UsageStream && !argsHaveOutputFormat(cmdArgs) && !argsHaveOutputFormat(cfg.ExtraArgs) {
+		args = append(args, "--output-format", "stream-json", "--verbose")
+	}
 	var err error
 	args, err = appendClaudeMCPOptions(args, cfg.MCP)
 	if err != nil {
@@ -400,6 +424,41 @@ func resolveBackendKind(backendName string, cfg BackendConfig) string {
 		backendName = "claude"
 	}
 	return config.ResolveBackendKind(backendName, cfg.Provider, cfg.Cmd)
+}
+
+// maestroExecutablePath resolves the running maestro binary, which provides
+// the `stream-split` subcommand the worker runner pipes a claude stream-json
+// stream through (#737). Returns ok=false when the path cannot be resolved,
+// signalling the caller to degrade to a plain `tee` pipeline (log preserved,
+// usage capture disabled).
+func maestroExecutablePath() (string, bool) {
+	exe, err := os.Executable()
+	if err != nil || strings.TrimSpace(exe) == "" {
+		return "", false
+	}
+	return exe, true
+}
+
+// streamSplitForBackend returns the worker runner's stream-split configuration,
+// or nil when the plain `tee` pipeline should be used. Only a claude-kind
+// backend with usage_stream opted in streams NDJSON; when the maestro binary
+// cannot be resolved it degrades to nil (plain tee) per #737.
+func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string) *streamSplit {
+	if !cfg.UsageStream {
+		return nil
+	}
+	if resolveBackendKind(backendName, cfg) != config.BackendKindClaude {
+		return nil
+	}
+	bin, ok := maestroExecutablePath()
+	if !ok {
+		return nil
+	}
+	return &streamSplit{
+		MaestroBin: bin,
+		Backend:    config.BackendKindClaude,
+		JSONLPath:  JSONLPathForLog(logFile),
+	}
 }
 
 // BuildWorkerCmd creates the right exec.Cmd for a backend. The backend name,

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -49,6 +49,53 @@ func TestBuildWorkerCmd_Claude(t *testing.T) {
 	}
 }
 
+// TestBuildWorkerCmd_ClaudeUsageStream verifies the #737 opt-in: when
+// UsageStream is set the claude worker runs in stream-json mode, and an
+// operator-pinned --output-format in extra_args overrides it (no duplicate).
+func TestBuildWorkerCmd_ClaudeUsageStream(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("do the thing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("opt-in appends stream-json flags", func(t *testing.T) {
+		cfg := BackendConfig{Cmd: "claude", UsageStream: true}
+		cmd, _, err := BuildWorkerCmd("claude", cfg, promptFile, "/tmp/wt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		args := strings.Join(cmd.Args, " ")
+		for _, want := range []string{"--output-format stream-json", "--verbose"} {
+			if !strings.Contains(args, want) {
+				t.Errorf("expected %q in args, got: %s", want, args)
+			}
+		}
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		cfg := BackendConfig{Cmd: "claude"}
+		cmd, _, err := BuildWorkerCmd("claude", cfg, promptFile, "/tmp/wt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(strings.Join(cmd.Args, " "), "stream-json") {
+			t.Errorf("stream-json must not appear unless UsageStream is set: %v", cmd.Args)
+		}
+	})
+
+	t.Run("extra_args output-format overrides", func(t *testing.T) {
+		cfg := BackendConfig{Cmd: "claude", UsageStream: true, ExtraArgs: []string{"--output-format", "json"}}
+		cmd, _, err := BuildWorkerCmd("claude", cfg, promptFile, "/tmp/wt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(strings.Join(cmd.Args, " "), "stream-json") {
+			t.Errorf("operator --output-format must win over the stream-json default: %v", cmd.Args)
+		}
+	})
+}
+
 // TestBuildWorkerCmd_ClaudeLargePromptViaStdin guards against the latent E2BIG
 // regression from #454: a worker claude prompt larger than the Linux
 // MAX_ARG_STRLEN single-argument limit (128 KiB) must be delivered via stdin,

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -121,13 +121,14 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 		}
 	}
 	backendCfg := BackendConfig{
-		Cmd:        backendDef.Cmd,
-		ExtraArgs:  backendDef.ExtraArgs,
-		PromptMode: backendDef.PromptMode,
-		Provider:   backendDef.Provider,
-		Model:      backendDef.Model,
-		Effort:     backendDef.Effort,
-		MCP:        backendDef.MCP,
+		Cmd:         backendDef.Cmd,
+		ExtraArgs:   backendDef.ExtraArgs,
+		PromptMode:  backendDef.PromptMode,
+		Provider:    backendDef.Provider,
+		Model:       backendDef.Model,
+		Effort:      backendDef.Effort,
+		UsageStream: backendDef.UsageStream,
+		MCP:         backendDef.MCP,
 	}
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
@@ -160,7 +161,8 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 
 	// Write runner script
 	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
-	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, sess.Worktree); err != nil {
+	split := streamSplitForBackend(backendName, backendCfg, logFile)
+	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, sess.Worktree, split); err != nil {
 		return err
 	}
 

--- a/internal/worker/claude_usage.go
+++ b/internal/worker/claude_usage.go
@@ -1,0 +1,103 @@
+package worker
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ClaudeUsage is the aggregated provider usage parsed from a claude
+// `--output-format stream-json --verbose` NDJSON stream (#737). The terminal
+// `result` frame of each `claude -p` invocation carries that invocation's
+// cumulative `usage` (input/output/cache tokens) and `total_cost_usd`.
+// Because the stream-splitter appends every run's frames to the same
+// slot.jsonl, summing across all `result` frames yields the cumulative run
+// total across attempts — monotonic as the log grows, which is what the
+// orchestrator's respawn-safe token watermark expects.
+type ClaudeUsage struct {
+	Model       string  // session model (system/init), falling back to the assistant message model
+	Input       int     // sum of input_tokens across result frames
+	Output      int     // sum of output_tokens across result frames
+	CacheRead   int     // sum of cache_read_input_tokens across result frames
+	CacheWrite  int     // sum of cache_creation_input_tokens across result frames
+	TotalTokens int     // Input + Output + CacheRead + CacheWrite
+	CostUSD     float64 // sum of total_cost_usd across result frames
+}
+
+// claudeStreamFrame is the subset of a claude stream-json line this package
+// decodes. `model` is present on the system/init frame; `message` on
+// assistant/user frames; `usage` + `total_cost_usd` on the result frame.
+type claudeStreamFrame struct {
+	Type         string               `json:"type"`
+	Subtype      string               `json:"subtype"`
+	Model        string               `json:"model"`
+	Message      *claudeStreamMessage `json:"message"`
+	Usage        *claudeUsageBlock    `json:"usage"`
+	TotalCostUSD float64              `json:"total_cost_usd"`
+}
+
+// claudeStreamMessage is the subset of a claude assistant/user message that
+// carries the model name (and a per-turn usage block we do not aggregate —
+// the result frame's usage is the authoritative run total).
+type claudeStreamMessage struct {
+	Model string            `json:"model"`
+	Usage *claudeUsageBlock `json:"usage"`
+}
+
+// claudeUsageBlock mirrors the Anthropic usage object emitted on the result
+// frame. cache_creation_input_tokens are freshly written cache tokens
+// (CacheWrite); cache_read_input_tokens are reused cache tokens (CacheRead).
+type claudeUsageBlock struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+// ParseClaudeUsage scans a claude stream-json NDJSON stream (the appended
+// slot.jsonl) and aggregates usage across every terminal `result` frame.
+// It returns ok=false when no usage-bearing result frame is found, so callers
+// can leave tokens/cost at 0 (the documented degradation when the
+// stream-splitter was unavailable or no frame has landed yet).
+func ParseClaudeUsage(text string) (ClaudeUsage, bool) {
+	var out ClaudeUsage
+	seen := false
+	var systemModel, assistantModel string
+
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || line[0] != '{' {
+			continue
+		}
+		var fr claudeStreamFrame
+		if err := json.Unmarshal([]byte(line), &fr); err != nil {
+			continue
+		}
+		switch fr.Type {
+		case "system":
+			if strings.TrimSpace(fr.Model) != "" {
+				systemModel = fr.Model
+			}
+		case "assistant":
+			if fr.Message != nil && strings.TrimSpace(fr.Message.Model) != "" {
+				assistantModel = fr.Message.Model
+			}
+		case "result":
+			if fr.Usage == nil {
+				continue
+			}
+			out.Input += fr.Usage.InputTokens
+			out.Output += fr.Usage.OutputTokens
+			out.CacheRead += fr.Usage.CacheReadInputTokens
+			out.CacheWrite += fr.Usage.CacheCreationInputTokens
+			out.CostUSD += fr.TotalCostUSD
+			seen = true
+		}
+	}
+
+	// Prefer the session model from the system/init frame (the configured
+	// model, e.g. claude-opus-4-8[1m]); fall back to the assistant message
+	// model when init was not captured (truncated stream).
+	out.Model = nonEmpty(assistantModel, systemModel)
+	out.TotalTokens = out.Input + out.Output + out.CacheRead + out.CacheWrite
+	return out, seen
+}

--- a/internal/worker/claude_usage_test.go
+++ b/internal/worker/claude_usage_test.go
@@ -1,0 +1,76 @@
+package worker
+
+import "testing"
+
+// claudeSmokeStream is a real 1-turn claude `--output-format stream-json
+// --verbose` capture (claude 2.1.183, prompt "Reply with exactly the word:
+// pong"), with session_id/uuid values redacted. The token counts and
+// total_cost_usd are verbatim from the live run so the parser is exercised
+// against the actual frame shape, not a hand-written guess (#737).
+const claudeSmokeStream = `{"type":"system","subtype":"init","cwd":"/tmp","session_id":"REDACTED","model":"claude-opus-4-8[1m]","permissionMode":"bypassPermissions","tools":[],"uuid":"REDACTED"}
+{"type":"rate_limit_event","rate_limit_info":{"status":"allowed"},"session_id":"REDACTED","uuid":"REDACTED"}
+{"type":"assistant","message":{"id":"msg_REDACTED","type":"message","role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"pong"}],"stop_reason":"end_turn","usage":{"input_tokens":2487,"cache_creation_input_tokens":1924,"cache_read_input_tokens":15661,"output_tokens":1}},"session_id":"REDACTED","uuid":"REDACTED"}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":5000,"num_turns":1,"result":"pong","session_id":"REDACTED","total_cost_usd":0.0401785,"usage":{"input_tokens":2487,"cache_creation_input_tokens":1924,"cache_read_input_tokens":15661,"output_tokens":4,"server_tool_use":{"web_search_requests":0}},"uuid":"REDACTED"}
+`
+
+func TestParseClaudeUsage_RealSmokeCapture(t *testing.T) {
+	usage, ok := ParseClaudeUsage(claudeSmokeStream)
+	if !ok {
+		t.Fatal("ParseClaudeUsage returned ok=false on a real result frame")
+	}
+	if usage.Input != 2487 {
+		t.Errorf("Input = %d, want 2487", usage.Input)
+	}
+	if usage.Output != 4 {
+		t.Errorf("Output = %d, want 4", usage.Output)
+	}
+	if usage.CacheRead != 15661 {
+		t.Errorf("CacheRead = %d, want 15661", usage.CacheRead)
+	}
+	if usage.CacheWrite != 1924 {
+		t.Errorf("CacheWrite = %d, want 1924", usage.CacheWrite)
+	}
+	// 2487 + 4 + 15661 + 1924 = 20076
+	if usage.TotalTokens != 20076 {
+		t.Errorf("TotalTokens = %d, want 20076", usage.TotalTokens)
+	}
+	if usage.CostUSD != 0.0401785 {
+		t.Errorf("CostUSD = %v, want 0.0401785", usage.CostUSD)
+	}
+	// system/init model (the configured session model) is preferred.
+	if usage.Model != "claude-opus-4-8[1m]" {
+		t.Errorf("Model = %q, want claude-opus-4-8[1m]", usage.Model)
+	}
+}
+
+// A log with no result frame (truncated / non-claude) must report ok=false so
+// the orchestrator leaves tokens at 0 instead of stamping garbage.
+func TestParseClaudeUsage_NoResultFrame(t *testing.T) {
+	const noResult = `{"type":"system","subtype":"init","model":"claude-opus-4-8"}
+{"type":"assistant","message":{"role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"working"}]}}
+not json at all
+`
+	if usage, ok := ParseClaudeUsage(noResult); ok {
+		t.Fatalf("expected ok=false without a result frame, got %+v", usage)
+	}
+}
+
+// Multiple result frames (the slot.jsonl after a respawn appends a second
+// run's frames) must SUM to the cumulative run total — the property the
+// respawn-safe token watermark relies on.
+func TestParseClaudeUsage_SumsAcrossResultFrames(t *testing.T) {
+	const twoRuns = `{"type":"result","subtype":"success","is_error":false,"num_turns":1,"result":"a","total_cost_usd":0.01,"usage":{"input_tokens":700,"output_tokens":70,"cache_creation_input_tokens":0,"cache_read_input_tokens":3}}
+{"type":"result","subtype":"success","is_error":false,"num_turns":1,"result":"b","total_cost_usd":0.02,"usage":{"input_tokens":900,"output_tokens":100,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}
+`
+	usage, ok := ParseClaudeUsage(twoRuns)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	// (700+70+0+3) + (900+100+0+0) = 773 + 1000 = 1773
+	if usage.TotalTokens != 1773 {
+		t.Errorf("TotalTokens = %d, want 1773 (sum across result frames)", usage.TotalTokens)
+	}
+	if usage.CostUSD != 0.03 {
+		t.Errorf("CostUSD = %v, want 0.03 (sum across result frames)", usage.CostUSD)
+	}
+}

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -39,13 +39,14 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 		}
 	}
 	backendCfg := BackendConfig{
-		Cmd:        backendDef.Cmd,
-		ExtraArgs:  backendDef.ExtraArgs,
-		PromptMode: backendDef.PromptMode,
-		Provider:   backendDef.Provider,
-		Model:      backendDef.Model,
-		Effort:     backendDef.Effort,
-		MCP:        backendDef.MCP,
+		Cmd:         backendDef.Cmd,
+		ExtraArgs:   backendDef.ExtraArgs,
+		PromptMode:  backendDef.PromptMode,
+		Provider:    backendDef.Provider,
+		Model:       backendDef.Model,
+		Effort:      backendDef.Effort,
+		UsageStream: backendDef.UsageStream,
+		MCP:         backendDef.MCP,
 	}
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
@@ -75,7 +76,8 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 
 	// Write runner script
 	runnerPath := fmt.Sprintf("%s/%s-run.sh", cfg.StateDir, slotName)
-	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, sess.Worktree); err != nil {
+	split := streamSplitForBackend(backendName, backendCfg, logFile)
+	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, sess.Worktree, split); err != nil {
 		return err
 	}
 

--- a/internal/worker/search_guardrail.go
+++ b/internal/worker/search_guardrail.go
@@ -251,7 +251,34 @@ fi
 exec "$real_path" "$@"
 `
 
-func buildWorkerRunnerScript(args []string, stdinFile, logFile, worktree, guardDir string) string {
+// streamSplit configures the worker runner to route a backend's structured
+// NDJSON stream through `maestro stream-split` before tee: the raw frames are
+// appended to JSONLPath (parsed for usage) while the rendered human-readable
+// text flows to slot.log (#737). A nil *streamSplit keeps the plain `tee`
+// pipeline — also the degradation path when the maestro binary is unresolvable.
+type streamSplit struct {
+	MaestroBin string // path to the maestro binary providing the stream-split subcommand
+	Backend    string // backend kind for rendering (e.g. "claude")
+	JSONLPath  string // side-channel file for raw NDJSON frames (slot.jsonl)
+}
+
+// logPipeline builds the trailing `| ... | tee -a LOG` stage. When split is
+// set it inserts `| maestro stream-split --backend B --jsonl J` ahead of tee
+// so the raw stream lands in slot.jsonl and slot.log stays human-readable.
+func logPipeline(split *streamSplit, logFile string) string {
+	tee := "tee -a " + shellQuote(logFile)
+	if split == nil {
+		return "2>&1 | " + tee
+	}
+	splitter := shellJoin([]string{
+		split.MaestroBin, "stream-split",
+		"--backend", split.Backend,
+		"--jsonl", split.JSONLPath,
+	})
+	return "2>&1 | " + splitter + " | " + tee
+}
+
+func buildWorkerRunnerScript(args []string, stdinFile, logFile, worktree, guardDir string, split *streamSplit) string {
 	var b strings.Builder
 	b.WriteString("#!/bin/bash\n")
 	b.WriteString("export MAESTRO_WORKTREE=" + shellQuote(worktree) + "\n")
@@ -260,20 +287,21 @@ func buildWorkerRunnerScript(args []string, stdinFile, logFile, worktree, guardD
 	b.WriteString("export PATH=\"$MAESTRO_SEARCH_GUARDRAIL_DIR:$MAESTRO_ORIGINAL_PATH\"\n")
 	b.WriteString("cd \"$MAESTRO_WORKTREE\" || exit 1\n")
 	b.WriteString("printf '[maestro] worker worktree: %s\\n' \"$MAESTRO_WORKTREE\" | tee -a " + shellQuote(logFile) + "\n")
+	pipeline := logPipeline(split, logFile)
 	if stdinFile != "" {
-		b.WriteString(fmt.Sprintf("exec %s < %s 2>&1 | tee -a %s\n", shellJoin(args), shellQuote(stdinFile), shellQuote(logFile)))
+		b.WriteString(fmt.Sprintf("exec %s < %s %s\n", shellJoin(args), shellQuote(stdinFile), pipeline))
 	} else {
-		b.WriteString(fmt.Sprintf("exec %s 2>&1 | tee -a %s\n", shellJoin(args), shellQuote(logFile)))
+		b.WriteString(fmt.Sprintf("exec %s %s\n", shellJoin(args), pipeline))
 	}
 	return b.String()
 }
 
-func writeWorkerRunnerScript(stateDir, runnerPath string, args []string, stdinFile, logFile, worktree string) error {
+func writeWorkerRunnerScript(stateDir, runnerPath string, args []string, stdinFile, logFile, worktree string, split *streamSplit) error {
 	guardDir, err := ensureSearchGuardrailWrappers(stateDir)
 	if err != nil {
 		return err
 	}
-	runnerContent := buildWorkerRunnerScript(args, stdinFile, logFile, worktree, guardDir)
+	runnerContent := buildWorkerRunnerScript(args, stdinFile, logFile, worktree, guardDir, split)
 	if err := os.WriteFile(runnerPath, []byte(runnerContent), 0755); err != nil {
 		return fmt.Errorf("write runner script: %w", err)
 	}

--- a/internal/worker/search_guardrail_test.go
+++ b/internal/worker/search_guardrail_test.go
@@ -204,6 +204,7 @@ func TestBuildWorkerRunnerScriptIncludesSearchGuardrails(t *testing.T) {
 		"/tmp/worker.log",
 		"/tmp/worktree",
 		"/tmp/state/search-guardrails",
+		nil,
 	)
 
 	for _, want := range []string{
@@ -217,6 +218,25 @@ func TestBuildWorkerRunnerScriptIncludesSearchGuardrails(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Fatalf("runner script missing %q\nscript:\n%s", want, script)
 		}
+	}
+}
+
+// #737: with a stream-split config the worker command is piped through
+// `maestro stream-split` (raw NDJSON -> slot.jsonl) before tee, keeping
+// slot.log human-readable while capturing usage on the side channel.
+func TestBuildWorkerRunnerScriptStreamSplitPipeline(t *testing.T) {
+	script := buildWorkerRunnerScript(
+		[]string{"claude", "--dangerously-skip-permissions", "-p", "--output-format", "stream-json", "--verbose"},
+		"/tmp/prompt.md",
+		"/tmp/worker.log",
+		"/tmp/worktree",
+		"/tmp/state/search-guardrails",
+		&streamSplit{MaestroBin: "/usr/local/bin/maestro", Backend: "claude", JSONLPath: "/tmp/worker.jsonl"},
+	)
+
+	want := "2>&1 | /usr/local/bin/maestro stream-split --backend claude --jsonl /tmp/worker.jsonl | tee -a '/tmp/worker.log'"
+	if !strings.Contains(script, want) {
+		t.Fatalf("runner script missing stream-split pipeline %q\nscript:\n%s", want, script)
 	}
 }
 

--- a/internal/worker/stream_split.go
+++ b/internal/worker/stream_split.go
@@ -1,0 +1,210 @@
+package worker
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// JSONLPathForLog returns the side-channel NDJSON path paired with a worker
+// log path: slot.log -> slot.jsonl. The stream-splitter appends raw claude
+// stream-json frames here while slot.log keeps the rendered human-readable
+// text. A path without a .log suffix simply gets .jsonl appended.
+func JSONLPathForLog(logFile string) string {
+	if logFile == "" {
+		return ""
+	}
+	if strings.HasSuffix(logFile, ".log") {
+		return strings.TrimSuffix(logFile, ".log") + ".jsonl"
+	}
+	return logFile + ".jsonl"
+}
+
+// RunStreamSplit reads a backend's structured NDJSON stream from r, appends
+// every raw line verbatim to jsonlPath (the machine-readable side-channel the
+// usage parser consumes), and writes human-readable rendered text to w (the
+// worker log via tee). It is deliberately resilient: a line that cannot be
+// opened/decoded still passes through to w, and if jsonlPath cannot be opened
+// it degrades to pure pass-through so the worker log is never lost. Output is
+// flushed per line so the orchestrator's live log polling (rate-limit /
+// silent-timeout detection) sees output in real time.
+func RunStreamSplit(backend, jsonlPath string, r io.Reader, w io.Writer) error {
+	var jf *os.File
+	if strings.TrimSpace(jsonlPath) != "" {
+		f, err := os.OpenFile(jsonlPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[maestro] stream-split: cannot open %s: %v (passing stream through)\n", jsonlPath, err)
+		} else {
+			jf = f
+			defer jf.Close()
+		}
+	}
+
+	br := bufio.NewReader(r)
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+
+	for {
+		// ReadString tolerates arbitrarily long frames (tool results / large
+		// diffs) that would overflow a bufio.Scanner token.
+		chunk, readErr := br.ReadString('\n')
+		if len(chunk) > 0 {
+			if jf != nil {
+				// Append the raw frame verbatim (newline included) so the
+				// side-channel is a faithful NDJSON capture for the parser.
+				if _, err := jf.WriteString(chunk); err != nil {
+					fmt.Fprintf(os.Stderr, "[maestro] stream-split: write %s: %v\n", jsonlPath, err)
+				}
+			}
+			line := strings.TrimRight(chunk, "\r\n")
+			if rendered := renderStreamLine(backend, line); rendered != "" {
+				bw.WriteString(rendered)
+				if !strings.HasSuffix(rendered, "\n") {
+					bw.WriteByte('\n')
+				}
+				bw.Flush()
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return nil
+			}
+			return readErr
+		}
+	}
+}
+
+// renderStreamLine converts one structured stream line into human-readable
+// text for the worker log. Only the claude backend is rendered today; any
+// other backend (and any non-JSON or unrecognized line) passes through
+// verbatim, which preserves stderr error text so the rate-limit /
+// auth-failure text parsers keep matching (#737 acceptance).
+func renderStreamLine(backend, line string) string {
+	if strings.TrimSpace(backend) != "claude" {
+		return line
+	}
+	return renderClaudeStreamLine(line)
+}
+
+// RenderClaudeStreamLine is the exported entry point for rendering a single
+// claude stream-json line (used by tests verifying the renderer keeps
+// rate-limit / auth-failure text intact).
+func RenderClaudeStreamLine(line string) string {
+	return renderClaudeStreamLine(line)
+}
+
+type claudeRenderFrame struct {
+	Type          string               `json:"type"`
+	Subtype       string               `json:"subtype"`
+	Model         string               `json:"model"`
+	Message       *claudeRenderMessage `json:"message"`
+	Result        string               `json:"result"`
+	IsError       bool                 `json:"is_error"`
+	NumTurns      int                  `json:"num_turns"`
+	TotalCostUSD  float64              `json:"total_cost_usd"`
+	RateLimitInfo json.RawMessage      `json:"rate_limit_info"`
+}
+
+type claudeRenderMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+type claudeContentBlock struct {
+	Type    string          `json:"type"`
+	Text    string          `json:"text"`
+	Name    string          `json:"name"`
+	Content json.RawMessage `json:"content"`
+	IsError bool            `json:"is_error"`
+}
+
+// renderClaudeStreamLine renders one claude stream-json frame. A line that is
+// not a JSON object, or fails to decode, is returned verbatim so nothing is
+// lost from the worker log (and any plain stderr error text still reaches the
+// text parsers).
+func renderClaudeStreamLine(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || trimmed[0] != '{' {
+		return line
+	}
+	var fr claudeRenderFrame
+	if err := json.Unmarshal([]byte(trimmed), &fr); err != nil {
+		return line
+	}
+	switch fr.Type {
+	case "system":
+		if m := strings.TrimSpace(fr.Model); m != "" {
+			return "[claude] model: " + m
+		}
+		return ""
+	case "assistant", "user":
+		if fr.Message == nil {
+			return ""
+		}
+		return renderClaudeContent(fr.Message.Content)
+	case "result":
+		var b strings.Builder
+		if txt := strings.TrimSpace(fr.Result); txt != "" {
+			b.WriteString(fr.Result)
+			b.WriteByte('\n')
+		}
+		fmt.Fprintf(&b, "[claude] result: subtype=%s is_error=%t turns=%d cost=$%.4f",
+			fr.Subtype, fr.IsError, fr.NumTurns, fr.TotalCostUSD)
+		return b.String()
+	case "rate_limit_event":
+		if len(fr.RateLimitInfo) > 0 {
+			return "[claude] rate_limit: " + string(fr.RateLimitInfo)
+		}
+		return line
+	default:
+		// Unknown frame type — preserve it verbatim rather than drop it.
+		return line
+	}
+}
+
+// renderClaudeContent renders a message content field, which is either a JSON
+// string or an array of content blocks (text / tool_use / tool_result).
+func renderClaudeContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	// content may be a plain string (some user messages).
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var blocks []claudeContentBlock
+	if json.Unmarshal(raw, &blocks) != nil {
+		// Unexpected shape — surface the raw JSON rather than drop content.
+		return string(raw)
+	}
+	parts := make([]string, 0, len(blocks))
+	for _, blk := range blocks {
+		switch blk.Type {
+		case "text":
+			if t := blk.Text; t != "" {
+				parts = append(parts, t)
+			}
+		case "tool_use":
+			parts = append(parts, "[tool_use: "+strings.TrimSpace(blk.Name)+"]")
+		case "tool_result":
+			label := "[tool_result]"
+			if blk.IsError {
+				label = "[tool_result error]"
+			}
+			if inner := renderClaudeContent(blk.Content); inner != "" {
+				parts = append(parts, label+" "+inner)
+			} else {
+				parts = append(parts, label)
+			}
+		default:
+			if t := blk.Text; t != "" {
+				parts = append(parts, t)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/internal/worker/stream_split_test.go
+++ b/internal/worker/stream_split_test.go
@@ -1,0 +1,142 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestJSONLPathForLog(t *testing.T) {
+	cases := map[string]string{
+		"/logs/sup-1.log":           "/logs/sup-1.jsonl",
+		"/logs/sup-1-implement.log": "/logs/sup-1-implement.jsonl",
+		"/logs/sup-1":               "/logs/sup-1.jsonl",
+		"":                          "",
+	}
+	for in, want := range cases {
+		if got := JSONLPathForLog(in); got != want {
+			t.Errorf("JSONLPathForLog(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// RunStreamSplit must append the raw NDJSON frames verbatim to the jsonl side
+// channel (so ParseClaudeUsage can read them) while rendering human-readable
+// text to stdout (slot.log).
+func TestRunStreamSplit_SplitsRawAndRendered(t *testing.T) {
+	dir := t.TempDir()
+	jsonlPath := filepath.Join(dir, "sup-1.jsonl")
+
+	var out strings.Builder
+	if err := RunStreamSplit("claude", jsonlPath, strings.NewReader(claudeSmokeStream), &out); err != nil {
+		t.Fatalf("RunStreamSplit: %v", err)
+	}
+
+	// (a) the jsonl side channel is a faithful raw capture the parser accepts.
+	raw, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		t.Fatalf("read jsonl: %v", err)
+	}
+	if usage, ok := ParseClaudeUsage(string(raw)); !ok || usage.TotalTokens != 20076 {
+		t.Fatalf("jsonl side channel did not round-trip usage: ok=%v usage=%+v", ok, usage)
+	}
+
+	// (b) stdout (slot.log) is human-readable: the final answer is present and
+	// the raw frame envelope is not echoed verbatim.
+	rendered := out.String()
+	if !strings.Contains(rendered, "pong") {
+		t.Errorf("rendered output missing assistant text:\n%s", rendered)
+	}
+	if strings.Contains(rendered, `"cache_read_input_tokens"`) {
+		t.Errorf("rendered slot.log should not contain raw usage JSON:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "[claude] result:") {
+		t.Errorf("rendered output missing result summary:\n%s", rendered)
+	}
+}
+
+// If the jsonl path cannot be opened, RunStreamSplit must degrade to
+// pass-through so the worker log is never lost.
+func TestRunStreamSplit_DegradesWhenJSONLUnwritable(t *testing.T) {
+	// A path whose parent does not exist cannot be opened.
+	badPath := filepath.Join(t.TempDir(), "missing-dir", "sup-1.jsonl")
+	var out strings.Builder
+	if err := RunStreamSplit("claude", badPath, strings.NewReader(claudeSmokeStream), &out); err != nil {
+		t.Fatalf("RunStreamSplit should not fail the pipeline on jsonl open error: %v", err)
+	}
+	if !strings.Contains(out.String(), "pong") {
+		t.Errorf("stream should still pass through to stdout when jsonl is unwritable:\n%s", out.String())
+	}
+}
+
+// A non-claude backend passes every line through verbatim.
+func TestRunStreamSplit_NonClaudePassthrough(t *testing.T) {
+	var out strings.Builder
+	in := "plain line one\nplain line two\n"
+	if err := RunStreamSplit("codex", "", strings.NewReader(in), &out); err != nil {
+		t.Fatalf("RunStreamSplit: %v", err)
+	}
+	if out.String() != in {
+		t.Errorf("non-claude passthrough = %q, want %q", out.String(), in)
+	}
+}
+
+// #737 acceptance: routing the rate-limit / auth-failure fixtures through the
+// claude renderer must not break the text parsers. Plain stderr lines pass
+// through verbatim; the same signatures embedded in a stream-json result
+// frame surface via the rendered result text. Either way the detectors fire.
+func TestRenderClaudeStreamLine_PreservesDetectionSignatures(t *testing.T) {
+	signatures := []struct {
+		name string
+		text string
+		// detect reports whether the renderer output still trips the parser.
+		detect func(string) bool
+	}{
+		{"claude rate limit (stderr passthrough)", "Error: You've hit your limit for Claude. Please wait before trying again.", OutputContainsRateLimit},
+		{"http 429 (stderr passthrough)", "Request failed with status 429", OutputContainsRateLimit},
+		{"auth failure (stderr passthrough)", "Failed to authenticate. API Error: 401 Invalid authentication credentials", func(s string) bool { hit, _ := DetectAuthFailure(s); return hit }},
+	}
+
+	for _, sig := range signatures {
+		t.Run(sig.name+"/plain", func(t *testing.T) {
+			// Plain (non-JSON) stderr lines must pass through unchanged.
+			if got := RenderClaudeStreamLine(sig.text); got != sig.text {
+				t.Fatalf("plain line not passed through verbatim:\ngot  %q\nwant %q", got, sig.text)
+			}
+			if !sig.detect(RenderClaudeStreamLine(sig.text)) {
+				t.Errorf("detector regressed on rendered plain line: %q", sig.text)
+			}
+		})
+
+		t.Run(sig.name+"/in-result-frame", func(t *testing.T) {
+			frame := `{"type":"result","subtype":"error_during_execution","is_error":true,"num_turns":1,"result":` +
+				jsonQuote(sig.text) + `,"total_cost_usd":0,"usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}`
+			rendered := RenderClaudeStreamLine(frame)
+			if !sig.detect(rendered) {
+				t.Errorf("detector regressed on rendered result frame:\nframe:    %s\nrendered: %s", frame, rendered)
+			}
+		})
+	}
+}
+
+// jsonQuote returns a JSON string literal for s (small local helper to embed
+// detection signatures inside a result frame without pulling in encoding/json).
+func jsonQuote(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -109,13 +109,14 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 		}
 	}
 	backendCfg := BackendConfig{
-		Cmd:        backendDef.Cmd,
-		ExtraArgs:  backendDef.ExtraArgs,
-		PromptMode: backendDef.PromptMode,
-		Provider:   backendDef.Provider,
-		Model:      backendDef.Model,
-		Effort:     backendDef.Effort,
-		MCP:        backendDef.MCP,
+		Cmd:         backendDef.Cmd,
+		ExtraArgs:   backendDef.ExtraArgs,
+		PromptMode:  backendDef.PromptMode,
+		Provider:    backendDef.Provider,
+		Model:       backendDef.Model,
+		Effort:      backendDef.Effort,
+		UsageStream: backendDef.UsageStream,
+		MCP:         backendDef.MCP,
 	}
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
@@ -148,7 +149,8 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 
 	// Write runner script
 	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
-	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, worktreePath); err != nil {
+	split := streamSplitForBackend(backendName, backendCfg, logFile)
+	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, worktreePath, split); err != nil {
 		return "", err
 	}
 
@@ -263,13 +265,14 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 		}
 	}
 	backendCfg := BackendConfig{
-		Cmd:        backendDef.Cmd,
-		ExtraArgs:  backendDef.ExtraArgs,
-		PromptMode: backendDef.PromptMode,
-		Provider:   backendDef.Provider,
-		Model:      backendDef.Model,
-		Effort:     backendDef.Effort,
-		MCP:        backendDef.MCP,
+		Cmd:         backendDef.Cmd,
+		ExtraArgs:   backendDef.ExtraArgs,
+		PromptMode:  backendDef.PromptMode,
+		Provider:    backendDef.Provider,
+		Model:       backendDef.Model,
+		Effort:      backendDef.Effort,
+		UsageStream: backendDef.UsageStream,
+		MCP:         backendDef.MCP,
 	}
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
@@ -302,7 +305,8 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 
 	// Write runner script
 	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
-	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, worktreePath); err != nil {
+	split := streamSplitForBackend(backendName, backendCfg, logFile)
+	if err := writeWorkerRunnerScript(cfg.StateDir, runnerPath, workerCmd.Args, stdinFile, logFile, worktreePath, split); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Implements #737.

Plain `claude -p` text mode prints no parseable token total, so every claude worker session reported `tokens_used_total=0` and no USD cost. This captures usage by running claude in structured streaming mode and parsing a side-channel JSON stream, keeping `slot.log` human-readable so the rate-limit / auth-failure text parsers are untouched. Mirrors the Pi backend (#730).

## Changes
- **stream-split**: new internal `maestro stream-split` subcommand (`worker.RunStreamSplit`) reads NDJSON on stdin, appends raw frames to `slot.jsonl`, and renders human-readable text to stdout. Non-JSON / stderr lines pass through verbatim. The worker runner pipes claude through it before `tee`; degrades to plain `tee` (log preserved, usage 0) when the maestro binary can't be resolved.
- **Backend flags**: `claudeBackend.BuildCmd` appends `--output-format stream-json --verbose` behind a per-backend `usage_stream` opt-in (overridable via `extra_args`). Off by default — no behaviour change for backends that don't opt in.
- **Parser**: `internal/worker/claude_usage.go` — `ParseClaudeUsage` sums usage + `total_cost_usd` across the `result` frame(s); fixture built from a real 1-turn claude 2.1.183 capture.
- **Stamping**: `updateTokensUsedFromOutput` reads `slot.jsonl` for opted-in claude sessions. The Pi watermark generalises to a shared `UsageTokensWatermark` so the cumulative `result` total isn't double-counted on retry/respawn. Cost prefers `total_cost_usd` → `CostUSDBackend`.
- README: documents the `usage_stream` opt-in.

## Testing
- `go build ./cmd/maestro/` and `go test ./...` green (20 packages).
- Unit: parser against the real capture; stream-split raw/rendered split + degradation; rate-limit/auth-failure signatures survive the renderer (verbatim and inside a result frame); claude watermark no-double-count on forced retry.
- Live 1-turn smoke on host: `claude --output-format stream-json --verbose` piped through `maestro stream-split` produced a `slot.jsonl` `result` frame; parsed usage stamped non-zero tokens + USD cost; `slot.log` stayed human-readable.

## Runtime verification still pending
`usage_stream` is opt-in (default off). End-to-end confirmation that a deployed claude worker shows non-zero cost in the `/api/v1/fleet` panel requires an operator to set `usage_stream: true` in the live config and run a real session.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements opt-in structured usage capture for claude workers (#737): running claude in `--output-format stream-json --verbose` mode, piping its NDJSON output through a new `maestro stream-split` subprocess that writes raw frames to a side-channel `slot.jsonl` (for token/cost parsing) while keeping `slot.log` human-readable for the existing rate-limit and auth-failure text detectors.

- **`internal/worker/stream_split.go` + `claude_usage.go`**: new splitter and parser; `ParseClaudeUsage` sums tokens/cost across all `result` frames in the jsonl, giving a monotonically growing cumulative total compatible with the respawn watermark.
- **`internal/orchestrator/orchestrator.go`**: `updateClaudeUsageFromJSONL` mirrors the Pi usage path — full-jsonl re-parse guarded by `UsageTokensWatermark` (renamed from `PiTokensWatermark`) to prevent double-counting across retries.
- **`UsageStream` opt-in**: off by default; an operator `--output-format` in `extra_args` overrides it; the stream-split stage degrades to plain `tee` when the maestro binary cannot be resolved, preserving the worker log in all cases.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the feature is opt-in (off by default) so no behaviour change for existing deployments, and degradation paths preserve the worker log in all failure modes.

The implementation is solid end-to-end: the watermark anti-double-count logic mirrors the proven Pi path, shell quoting is handled via existing helpers, the splitter degrades gracefully when the jsonl file is unwritable or the maestro binary is unresolvable, and real-capture fixture tests cover the token/cost arithmetic. The one style issue is in claude_usage.go: nonEmpty(assistantModel, systemModel) correctly prefers the system model (because nonEmpty's second argument is the candidate), but the argument order reads as though assistant model is preferred — a future reader who doesn't check the function signature will infer the opposite priority.

internal/worker/claude_usage.go — the nonEmpty call at line 100.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/claude_usage.go | New NDJSON usage parser; sums tokens/cost across result frames correctly. nonEmpty(assistantModel, systemModel) is functionally correct but the argument order is counterintuitive given the function signature. |
| internal/worker/stream_split.go | New stream-splitter; appends raw NDJSON to slot.jsonl while rendering human-readable text to stdout. Resilient: degrades gracefully when jsonl is unwritable; ReadString handles arbitrarily long frames. |
| internal/orchestrator/orchestrator.go | Adds updateClaudeUsageFromJSONL; watermark/cost logic mirrors the Pi path and is correctly guarded against double-counting on respawn. |
| internal/worker/backend.go | Adds argsHaveOutputFormat, maestroExecutablePath, streamSplitForBackend. Flag deduplication and graceful binary-resolution fallback are correctly implemented. |
| internal/worker/search_guardrail.go | Adds streamSplit struct and logPipeline helper; buildWorkerRunnerScript now takes *streamSplit. Shell quoting is handled via shellJoin/shellQuote. |
| internal/state/state.go | Renames PiTokensWatermark to UsageTokensWatermark with a new JSON key; existing persisted state using the old key will silently read as 0 on upgrade, which is safe. |
| internal/config/config.go | Adds UsageStream bool field; opt-in, off by default. No behaviour change for existing configurations. |
| internal/worker/worker.go | Propagates UsageStream into BackendConfig and wires stream-split into the runner script in Start and Respawn paths. |
| internal/worker/phase.go | Propagates UsageStream into BackendConfig and wires stream-split into StartPhase runner script. |
| internal/worker/checkpoint.go | Propagates UsageStream into BackendConfig and wires stream-split into RespawnInPlace runner script. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/worker/claude_usage.go:100
**`nonEmpty` argument order is counterintuitive here**

`nonEmpty(fallback, candidate)` returns the *second* argument (candidate) when non-empty, making `nonEmpty(assistantModel, systemModel)` correctly prefer the system model — but it reads as "prefer assistantModel, fall back to systemModel." Any future reader who doesn't check the function signature would infer the opposite priority from the call site, and the comment directly above saying "prefer the system/init frame" only adds to the confusion. The Pi usages (e.g. `nonEmpty(out.Model, ev.Message.Model)`) avoid this because argument roles are symmetric; here they are not.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-219-73..."](https://github.com/befeast/maestro/commit/8fabd1303e8cd447ecc81a30bbd700d69bfae5df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38794382)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->