### PR TITLE
board reconcile: move ANY closed issue to Done, including NO-STATUS items (drift accumulates)

### DIFF
--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -211,11 +211,25 @@ type ProjectItem struct {
 	HasStatus   bool // false when the item has no Status field value (shows as "No Status")
 }
 
+// maxProjectItemPages caps how many 100-item pages ListNonDoneProjectItems will
+// walk before giving up. At 100 items per page this covers 10k board items —
+// far beyond any real coordination board — while bounding the worst case if
+// pagination ever fails to terminate.
+const maxProjectItemPages = 100
+
 // ListNonDoneProjectItems fetches all project items not in Done status
 // and returns their linked issue numbers along with whether they are closed.
 // "Done" is resolved against every candidate column name (Done/Completed/Closed)
 // so boards that label their terminal column differently still filter out
 // already-finished items instead of leaking them back into the reconciler.
+//
+// The board is walked across every page (100 items per request) rather than
+// just the first 100. A long-lived board accumulates items indefinitely —
+// Done items are never removed — so a single-page fetch eventually stops
+// observing the older non-done tail, leaving CLOSED items (especially ones
+// that never got a Status) stranded in NO STATUS forever instead of moving to
+// Done. Paginating ensures every non-done item is reconciled each cycle and
+// backfills existing drift (#741).
 func (c *Client) ListNonDoneProjectItems(pf *ProjectField) ([]ProjectItem, error) {
 	if pf == nil {
 		return nil, fmt.Errorf("nil ProjectField")
@@ -223,10 +237,41 @@ func (c *Client) ListNonDoneProjectItems(pf *ProjectField) ([]ProjectItem, error
 
 	_, doneOptionID, _ := resolveProjectStatusOption(pf, ProjectStatusCandidates(ProjectStatusDone))
 
+	var items []ProjectItem
+	cursor := ""
+	for page := 0; page < maxProjectItemPages; page++ {
+		out, err := c.fetchProjectItemsPage(pf.ProjectID, cursor)
+		if err != nil {
+			return nil, err
+		}
+		pageItems, hasNext, endCursor, err := parseNonDoneProjectItemsPage(out, doneOptionID)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, pageItems...)
+		if !hasNext || endCursor == "" {
+			return items, nil
+		}
+		cursor = endCursor
+	}
+	return items, nil
+}
+
+// fetchProjectItemsPage runs the project-items query for a single page. An empty
+// cursor fetches the first page; a non-empty cursor fetches the page after it.
+func (c *Client) fetchProjectItemsPage(projectID, cursor string) ([]byte, error) {
+	after := ""
+	if cursor != "" {
+		after = fmt.Sprintf(", after: %q", cursor)
+	}
 	query := fmt.Sprintf(`{
   node(id: %q) {
     ... on ProjectV2 {
-      items(first: 100) {
+      items(first: 100%s) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
         nodes {
           fieldValueByName(name: "Status") {
             ... on ProjectV2ItemFieldSingleSelectValue {
@@ -243,7 +288,7 @@ func (c *Client) ListNonDoneProjectItems(pf *ProjectField) ([]ProjectItem, error
       }
     }
   }
-}`, pf.ProjectID)
+}`, projectID, after)
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
@@ -254,14 +299,29 @@ func (c *Client) ListNonDoneProjectItems(pf *ProjectField) ([]ProjectItem, error
 		}
 		return nil, fmt.Errorf("graphql project items: %w", err)
 	}
-	return parseNonDoneProjectItemsResponse(out, doneOptionID)
+	return out, nil
 }
 
+// parseNonDoneProjectItemsResponse parses a single page of project items and
+// discards the pagination cursor. Retained for callers/tests that only need the
+// item slice from one response.
 func parseNonDoneProjectItemsResponse(out []byte, doneOptionID string) ([]ProjectItem, error) {
+	items, _, _, err := parseNonDoneProjectItemsPage(out, doneOptionID)
+	return items, err
+}
+
+// parseNonDoneProjectItemsPage parses one page of project items, returning the
+// non-done items plus the pagination state (hasNextPage and endCursor) needed
+// to fetch the following page.
+func parseNonDoneProjectItemsPage(out []byte, doneOptionID string) ([]ProjectItem, bool, string, error) {
 	var resp struct {
 		Data struct {
 			Node struct {
 				Items struct {
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
 					Nodes []struct {
 						FieldValueByName *struct {
 							OptionID string `json:"optionId"`
@@ -279,14 +339,14 @@ func parseNonDoneProjectItemsResponse(out []byte, doneOptionID string) ([]Projec
 		} `json:"errors"`
 	}
 	if err := json.Unmarshal(out, &resp); err != nil {
-		return nil, fmt.Errorf("parse project items response: %w", err)
+		return nil, false, "", fmt.Errorf("parse project items response: %w", err)
 	}
 	if len(resp.Errors) > 0 {
 		msgs := make([]string, len(resp.Errors))
 		for i, e := range resp.Errors {
 			msgs[i] = e.Message
 		}
-		return nil, fmt.Errorf("graphql errors: %s", strings.Join(msgs, "; "))
+		return nil, false, "", fmt.Errorf("graphql errors: %s", strings.Join(msgs, "; "))
 	}
 
 	var items []ProjectItem
@@ -304,7 +364,8 @@ func parseNonDoneProjectItemsResponse(out []byte, doneOptionID string) ([]Projec
 		})
 	}
 
-	return items, nil
+	pageInfo := resp.Data.Node.Items.PageInfo
+	return items, pageInfo.HasNextPage, pageInfo.EndCursor, nil
 }
 
 // ProjectBoardColumn captures one Status column on the board with its current

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -145,6 +145,64 @@ func TestParseNonDoneProjectItemsResponse_GraphQLErrors(t *testing.T) {
 	}
 }
 
+// parseNonDoneProjectItemsPage must surface the board's pagination cursor so
+// ListNonDoneProjectItems can walk every page. A board that has grown past one
+// 100-item page would otherwise strand its older non-done tail — including
+// CLOSED + NO STATUS drift — out of the reconciler's view (#741).
+func TestParseNonDoneProjectItemsPage_ReturnsPaginationCursor(t *testing.T) {
+	body := []byte(`{
+		"data": {
+			"node": {
+				"items": {
+					"pageInfo": {"hasNextPage": true, "endCursor": "CURSOR_2"},
+					"nodes": [
+						{"fieldValueByName": null, "content": {"number": 457, "state": "CLOSED"}}
+					]
+				}
+			}
+		}
+	}`)
+
+	items, hasNext, endCursor, err := parseNonDoneProjectItemsPage(body, "opt-done")
+	if err != nil {
+		t.Fatalf("parseNonDoneProjectItemsPage: %v", err)
+	}
+	if !hasNext || endCursor != "CURSOR_2" {
+		t.Fatalf("pagination = (hasNext=%v, endCursor=%q), want (true, CURSOR_2)", hasNext, endCursor)
+	}
+	if len(items) != 1 || items[0].IssueNumber != 457 || items[0].HasStatus || !items[0].IssueClosed {
+		t.Fatalf("items = %+v, want one closed no-status item #457", items)
+	}
+}
+
+// The final page reports hasNextPage=false; the walk in ListNonDoneProjectItems
+// stops there instead of looping forever.
+func TestParseNonDoneProjectItemsPage_LastPageStopsPagination(t *testing.T) {
+	body := []byte(`{
+		"data": {
+			"node": {
+				"items": {
+					"pageInfo": {"hasNextPage": false, "endCursor": "CURSOR_END"},
+					"nodes": [
+						{"fieldValueByName": {"optionId": "opt-progress"}, "content": {"number": 99, "state": "OPEN"}}
+					]
+				}
+			}
+		}
+	}`)
+
+	items, hasNext, _, err := parseNonDoneProjectItemsPage(body, "opt-done")
+	if err != nil {
+		t.Fatalf("parseNonDoneProjectItemsPage: %v", err)
+	}
+	if hasNext {
+		t.Fatal("hasNext = true on final page, want false")
+	}
+	if len(items) != 1 || items[0].IssueNumber != 99 {
+		t.Fatalf("items = %+v, want one item #99", items)
+	}
+}
+
 // ListNonDoneProjectItems must resolve the terminal-column option ID through
 // ProjectStatusCandidates so a board whose Done column is named "Completed"
 // or "Closed" still filters out finished items. The unit-test angle: ensure

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -973,8 +973,13 @@ func projectStatusForSession(sess *state.Session, requiresDeploy bool) (github.P
 //   - every active session (running/queued/pr_open/code_landed/blocked) has its
 //     status mirrored on the board so a live worker is always visible as
 //     active work (no manual "panoptikon-project-sync" timer needed);
-//   - items whose underlying issue is closed move to Done;
-//   - items with no Status fall back to Todo so they show up in the backlog.
+//   - ANY item whose underlying issue is closed moves to Done, regardless of
+//     its current board Status — including NO STATUS / unset items and
+//     externally-closed (merge-keyword or manual) issues the reconcile never
+//     transitioned itself. Closed wins over the no-status branch below, so
+//     stranded closed items are backfilled instead of bounced to Todo (#741);
+//   - items with no Status that are still open fall back to Todo so they show
+//     up in the backlog.
 //
 // "Done" is only set on the board when the underlying GitHub issue is closed —
 // merging a PR alone keeps the item in In Progress until runtime/deploy

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -7876,6 +7876,66 @@ func TestReconcileProjectBoard_ThrottlesNonDoneItemSweep(t *testing.T) {
 	}
 }
 
+// A CLOSED issue sitting in NO STATUS must move to Done on the next reconcile
+// sweep — not get bounced to Todo by the no-status branch — and must work for
+// externally-closed issues the reconcile never transitioned itself. This is the
+// core regression guard for #741.
+func TestReconcileProjectBoard_ClosedNoStatusItemMovesToDone(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		GitHubProjects: config.GitHubProjectsConfig{
+			Enabled:       true,
+			ProjectNumber: 5,
+		},
+	}
+
+	synced := make(map[int]github.ProjectStatus)
+	o := &Orchestrator{
+		cfg: cfg,
+		projectField: &github.ProjectField{
+			ProjectID: "PVT_test",
+			FieldID:   "FIELD_test",
+			Options:   map[string]string{"Todo": "opt-todo", "In Progress": "opt-progress", "Done": "opt-done"},
+		},
+		rateLimitFn: func() (github.RateLimitStatus, error) {
+			return github.RateLimitStatus{
+				GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000},
+			}, nil
+		},
+		syncProjectFn: func(issueNumber int, status github.ProjectStatus) bool {
+			synced[issueNumber] = status
+			return true
+		},
+		listNonDoneProjectItemsFn: func(pf *github.ProjectField) ([]github.ProjectItem, error) {
+			return []github.ProjectItem{
+				// Externally-closed issue that never had a board Status.
+				{IssueNumber: 457, IssueClosed: true, HasStatus: false},
+				// Closed issue parked in a non-terminal column.
+				{IssueNumber: 458, IssueClosed: true, HasStatus: true},
+				// Open no-status item still belongs in the backlog (Todo).
+				{IssueNumber: 459, IssueClosed: false, HasStatus: false},
+			}, nil
+		},
+	}
+
+	s := state.NewState()
+	if !o.reconcileProjectBoard(s) {
+		t.Fatal("reconcile should report changes for closed/no-status drift")
+	}
+	if synced[457] != github.ProjectStatusDone {
+		t.Fatalf("closed no-status issue #457 status = %q, want %q", synced[457], github.ProjectStatusDone)
+	}
+	if synced[458] != github.ProjectStatusDone {
+		t.Fatalf("closed in-progress issue #458 status = %q, want %q", synced[458], github.ProjectStatusDone)
+	}
+	if synced[459] != github.ProjectStatusTodo {
+		t.Fatalf("open no-status issue #459 status = %q, want %q", synced[459], github.ProjectStatusTodo)
+	}
+	if !s.ProjectStatusSynced(457, string(github.ProjectStatusDone)) {
+		t.Fatal("reconcile did not persist Done sync for closed no-status issue #457")
+	}
+}
+
 func TestDeferProjectBoardSweepDelaysOnlyBroadSweep(t *testing.T) {
 	o := &Orchestrator{}
 	now := time.Now().UTC()


### PR DESCRIPTION
Implements #741

## Changes
- Paginate `ListNonDoneProjectItems` so the board reconcile sweep walks **every** page of project items, not just the first 100. A long-lived board never removes Done items, so its non-done tail eventually scrolls past page 1 and stops being observed — which is how CLOSED issues (especially ones that never got a Status) accumulate and stay stranded in NO STATUS forever. Pagination backfills existing drift and keeps it from recurring.
- The reconcile sweep already moves a closed item to Done before the no-status→Todo branch, so **any** closed item moves to Done regardless of its board Status — including NO STATUS / unset and externally-closed (merge-keyword or manual) issues. Clarified that precedence in the doc comment.
- Items already in Done are filtered out of the sweep, so reconciling is idempotent with no churn.

## Testing
- `go test ./internal/github/... ./internal/orchestrator/...`
- `go test ./...`
- `go build ./cmd/maestro/`
- New unit tests: `TestReconcileProjectBoard_ClosedNoStatusItemMovesToDone` (feeds a CLOSED + NO STATUS item, plus a closed in-progress item and an open no-status item, through the reconcile), and pagination-cursor parse tests in the github package.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a board reconcile drift bug (#741) by paginating `ListNonDoneProjectItems` so every non-done item is observed regardless of board size, and clarifies that the reconciler already moves any closed issue (including NO STATUS ones) to Done before the no-status→Todo branch fires.

- **Pagination** (`github_projects.go`): `ListNonDoneProjectItems` now walks up to `maxProjectItemPages` (100) pages via a new `fetchProjectItemsPage`/`parseNonDoneProjectItemsPage` split; `parseNonDoneProjectItemsResponse` is retained as a thin wrapper for backward compatibility with existing callers and tests.
- **Reconcile logic** (`orchestrator.go`): Doc comment updated to make explicit that `IssueClosed` wins over `!HasStatus`, preventing stranded closed items from being bounced to Todo; the implementation was already correct.
- **Tests**: Two new pagination-contract unit tests in the github package, plus `TestReconcileProjectBoard_ClosedNoStatusItemMovesToDone` covering the closed+no-status, closed+status, and open+no-status cases with state-persistence verification.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the pagination logic is correct and well-tested, and the orchestrator change is documentation-only.

The pagination implementation is clean: the cursor is threaded correctly, the hasNext/endCursor early-exit guard is defensive, and the page cap prevents runaway loops. The only gaps are a missing log line when the cap is reached (silent partial sweep) and a stale comment in ListProjectItemStatusCounts that now incorrectly claims parity with the rest of the helpers. Neither affects correctness.

internal/github/github_projects.go — the page-cap exit path and the stale comment in ListProjectItemStatusCounts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/github/github_projects.go | Adds cursor-based pagination to ListNonDoneProjectItems via a new fetchProjectItemsPage/parseNonDoneProjectItemsPage split; logic is correct. Minor: no log emitted when maxProjectItemPages cap is hit, and a comment in ListProjectItemStatusCounts is now stale. |
| internal/github/github_projects_test.go | Adds two focused pagination tests (cursor returned on intermediate pages, hasNext=false stops the walk); both cover the core contract of parseNonDoneProjectItemsPage cleanly. |
| internal/orchestrator/orchestrator.go | Doc-comment-only change clarifying that the closed→Done branch already wins over the no-status→Todo branch, matching the actual pre-existing logic; no behavioural changes. |
| internal/orchestrator/orchestrator_test.go | Adds TestReconcileProjectBoard_ClosedNoStatusItemMovesToDone covering the three-item matrix (closed+no-status, closed+status, open+no-status) and verifies state persistence; solid regression guard for #741. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/github/github_projects.go` 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale comment in `ListProjectItemStatusCounts`**

   The comment says "that ceiling matches the rest of this package's ProjectV2 helpers" but `ListNonDoneProjectItems` now paginates. This claim is no longer accurate and should be updated to reflect the current state.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/github/github_projects.go
   Line: ?

   Comment:
   **Stale comment in `ListProjectItemStatusCounts`**

   The comment says "that ceiling matches the rest of this package's ProjectV2 helpers" but `ListNonDoneProjectItems` now paginates. This claim is no longer accurate and should be updated to reflect the current state.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/github/github_projects.go:242-257
**Silent truncation at page cap**

When the loop exhausts `maxProjectItemPages` without `hasNext` going false, the function returns whatever items were collected with no indication that the board was only partially walked. An operator debugging a board with more than 10,000 items would have no signal that the sweep terminated early. Adding a log line before the final `return` when the cap is hit would make this detectable without changing behaviour.

### Issue 2 of 2
internal/github/github_projects.go:?
**Stale comment in `ListProjectItemStatusCounts`**

The comment says "that ceiling matches the rest of this package's ProjectV2 helpers" but `ListNonDoneProjectItems` now paginates. This claim is no longer accurate and should be updated to reflect the current state.

```suggestion
// The query fetches up to 100 items in one page; that is more than enough for
// the maestro coordination board (#5). Larger boards would need pagination;
// left as a known follow-up since the rollup is operator-glance, not
// authoritative. (ListNonDoneProjectItems paginates fully; this helper does not.)
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: reconcile ANY closed board..."](https://github.com/befeast/maestro/commit/ce3ec1ab05f0723934a5475cd6bc01bd97921c8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38796608)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->