### PR TITLE
worker: per-backend subagent_hint — steer orchestrating models to cheaper sub-agent models (#706)

### DIFF
--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -259,6 +259,7 @@ telegram:
 | `outcome` | Project operating brief used by the supervisor to judge runtime progress |
 | `supervisor` | Optional local policy for supervisor queue order, safe actions, dispatch SLA, and issue-type skips |
 | `model.backends.<name>.mcp` | Optional worker MCP attachment for that backend; omitted means no MCP tools |
+| `model.backends.<name>.subagent_hint` | Optional sub-agent model policy injected into the worker prompt for that backend; omitted means the prompt is unchanged |
 | `max_parallel` | Maximum concurrent worker sessions |
 | `deploy_cmd` | Shell command maestro runs after merging a PR |
 | `session_prefix` | Prefix for tmux session names |
@@ -301,6 +302,19 @@ model:
       cmd: claude
     codex:
       cmd: codex
+```
+
+### Optional: sub-agent model policy (`subagent_hint`)
+
+When a worker backend is an orchestrating CLI such as Claude Code, it spawns its own sub-agents and, by default, runs them on the same expensive model as the orchestrator. Bulk grunt subtasks (file sweeps, searches, mechanical edits) then burn the subscription window at orchestrator-model prices, multiplied across parallel sub-agents. Set `model.backends.<name>.subagent_hint` to steer those sub-agents to cheaper models; the worker prompt gains a "Sub-agent Model Policy" section carrying the text verbatim. The field is optional and field-driven — backends without it render an unchanged prompt, so non-orchestrating backends (codex, gemini, …) can leave it unset. A recommended default ships under the claude backend in `maestro.yaml.example`:
+
+```yaml
+model:
+  default: claude
+  backends:
+    claude:
+      cmd: claude
+      subagent_hint: "Use cheaper sub-agent models (e.g. opus/sonnet) for delegated grunt subtasks such as file sweeps, searches, and mechanical edits; reserve the main orchestrator model for planning and final review."
 ```
 
 ### Optional: parallel review streams

--- a/internal/config/backend_subagent_hint_test.go
+++ b/internal/config/backend_subagent_hint_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #706: model.backends.<name>.subagent_hint carries the per-backend sub-agent
+// model policy injected into the worker prompt. Backends without the field
+// leave it empty so the prompt is unchanged.
+func TestParse_BackendSubagentHint(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: claude
+  backends:
+    claude:
+      cmd: claude
+      subagent_hint: "Use cheaper sub-agent models for grunt work."
+    codex:
+      cmd: codex
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.Model.Backends["claude"].SubagentHint; got != "Use cheaper sub-agent models for grunt work." {
+		t.Fatalf("claude subagent_hint = %q, want the configured value", got)
+	}
+	if got := cfg.Model.Backends["codex"].SubagentHint; got != "" {
+		t.Fatalf("codex has no subagent_hint; want empty, got %q", got)
+	}
+}
+
+func TestDefaultSubagentHintIsActionable(t *testing.T) {
+	if strings.TrimSpace(DefaultSubagentHint) == "" {
+		t.Fatal("DefaultSubagentHint must be non-empty")
+	}
+	for _, want := range []string{"sub-agent", "cheaper"} {
+		if !strings.Contains(strings.ToLower(DefaultSubagentHint), want) {
+			t.Fatalf("DefaultSubagentHint should mention %q: %q", want, DefaultSubagentHint)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,7 +78,25 @@ type BackendDef struct {
 	// percentages on the fleet API / Mission Control, and steers fresh
 	// dispatch to fallback backends once usage crosses the threshold.
 	Quota BackendQuota `yaml:"quota,omitempty"`
+
+	// SubagentHint steers an orchestrating backend (e.g. Claude Code) to
+	// delegate grunt subtasks to cheaper sub-agent models instead of
+	// reusing the expensive orchestrator model for everything (#706). When
+	// set, the worker prompt gains a "Sub-agent Model Policy" section
+	// carrying this text. When empty, the prompt is unchanged — configs
+	// without the field behave exactly as before. DefaultSubagentHint is a
+	// ready-made value operators can paste under their claude backend.
+	SubagentHint string `yaml:"subagent_hint,omitempty"`
 }
+
+// DefaultSubagentHint is the recommended sub-agent model policy shipped for
+// the claude backend (#706). Orchestrating CLIs spawn their own sub-agents
+// and, by default, run them on the same expensive model — bulk grunt subtasks
+// (file sweeps, searches, mechanical edits) then burn the subscription window
+// at orchestrator-model prices, multiplied across parallel sub-agents. Set
+// model.backends.<name>.subagent_hint to this (or a tuned variant) to opt in;
+// leaving it unset keeps the prompt unchanged.
+const DefaultSubagentHint = "Use cheaper sub-agent models (e.g. opus/sonnet) for delegated grunt subtasks such as file sweeps, searches, and mechanical edits; reserve the main orchestrator model for planning and final review."
 
 // MCPConfig is an opt-in per-backend worker MCP attachment. When empty,
 // Maestro passes no MCP configuration to spawned workers.

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -138,6 +138,7 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 
 	// Assemble prompt with checkpoint
 	prompt := assemblePromptWithCheckpoint(promptBase, issue, sess.Worktree, sess.Branch, cfg, checkpointContext)
+	prompt += subagentHintPromptSection(backendDef.SubagentHint)
 	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
 
 	// Write prompt to file

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -126,6 +126,7 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 
 	// Assemble worker prompt
 	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
+	prompt += subagentHintPromptSection(backendDef.SubagentHint)
 	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
 
 	// Write prompt to file
@@ -282,6 +283,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 
 	// Assemble worker prompt
 	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
+	prompt += subagentHintPromptSection(backendDef.SubagentHint)
 	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
 
 	// Write prompt to file
@@ -874,6 +876,27 @@ func visualEvidencePromptSection(cfg *config.Config) string {
 	fmt.Fprintf(&b, "   ![home](https://raw.githubusercontent.com/%s/$sha/%s/home.png)\"\n", cfg.Repo, visual.ResolvedOutputDir())
 	b.WriteString("   ```\n")
 	b.WriteString("5. If the capture command fails or produces no screenshots, post a PR comment briefly explaining why visual evidence could not be captured, then continue — do NOT block the PR on it; Maestro records a finding for the operator.\n")
+	return b.String()
+}
+
+// subagentHintPromptSection renders the per-backend sub-agent model policy
+// (#706). Orchestrating backends (e.g. Claude Code) spawn their own
+// sub-agents and, by default, run them on the same expensive orchestrator
+// model; bulk grunt subtasks then burn the subscription window at
+// orchestrator prices, multiplied across parallel sub-agents. When the
+// backend has a `subagent_hint` configured, this section injects that policy
+// into the worker prompt. Returns "" when the hint is unset so configs
+// without the field render a byte-for-byte unchanged prompt.
+func subagentHintPromptSection(hint string) string {
+	hint = strings.TrimSpace(sanitizePromptUTF8(hint))
+	if hint == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\n---\n\n## Sub-agent Model Policy\n\n")
+	b.WriteString("This backend orchestrates its own sub-agents. Follow this delegation policy:\n\n")
+	b.WriteString(hint)
+	b.WriteByte('\n')
 	return b.String()
 }
 

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -262,6 +262,63 @@ func TestAssemblePromptOmitsVisualEvidenceSectionWhenInactive(t *testing.T) {
 	}
 }
 
+func TestSubagentHintPromptSectionRendersWhenSet(t *testing.T) {
+	hint := "Use cheaper sub-agent models (opus/sonnet) for delegated subtasks; reserve the main model for orchestration and final review."
+	section := subagentHintPromptSection(hint)
+	for _, want := range []string{
+		"## Sub-agent Model Policy",
+		hint,
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("subagentHintPromptSection() missing %q\nsection:\n%s", want, section)
+		}
+	}
+}
+
+func TestSubagentHintPromptSectionOmittedWhenUnset(t *testing.T) {
+	for name, hint := range map[string]string{
+		"empty":      "",
+		"whitespace": "   \n\t ",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := subagentHintPromptSection(hint); got != "" {
+				t.Fatalf("expected empty section for %s hint, got %q", name, got)
+			}
+		})
+	}
+}
+
+// TestWorkerPromptSubagentHintGolden is the acceptance golden check (#706):
+// with subagent_hint set the rendered worker prompt gains the policy section;
+// without it the prompt is byte-for-byte unchanged.
+func TestWorkerPromptSubagentHintGolden(t *testing.T) {
+	cfg := &config.Config{Repo: "owner/repo"}
+	issue := github.Issue{Number: 706, Title: "subagent hint", Body: "body"}
+	worktree := t.TempDir()
+
+	base := assemblePrompt("base prompt", issue, worktree, "feat/subagent-hint", cfg)
+
+	// Unset hint: the rendered prompt is identical to the base prompt.
+	if got := base + subagentHintPromptSection(""); got != base {
+		t.Fatalf("unset subagent_hint must not change the prompt; unexpected delta:\n%s", strings.TrimPrefix(got, base))
+	}
+
+	// Hint set: the prompt is the base with the policy section appended.
+	hint := config.DefaultSubagentHint
+	withHint := base + subagentHintPromptSection(hint)
+	if !strings.HasPrefix(withHint, base) {
+		t.Fatal("subagent_hint section must append to, not rewrite, the base prompt")
+	}
+	for _, want := range []string{"## Sub-agent Model Policy", hint} {
+		if !strings.Contains(withHint, want) {
+			t.Fatalf("rendered prompt with subagent_hint missing %q\nprompt:\n%s", want, withHint)
+		}
+	}
+	if strings.Contains(base, "Sub-agent Model Policy") {
+		t.Fatal("base prompt (no hint) must not contain the sub-agent policy section")
+	}
+}
+
 func TestWorkerPromptTemplateExplainsVisualEvidenceAttachment(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "worker-prompt-template.md"))
 	if err != nil {

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -60,6 +60,13 @@ model:
   backends:
     claude:
       cmd: claude
+      # Steer this orchestrating backend's own sub-agents to cheaper models
+      # (issue #706). Claude Code spawns sub-agents and, by default, runs them
+      # on the same expensive model — bulk grunt subtasks then burn the
+      # subscription window at orchestrator prices, multiplied across parallel
+      # sub-agents. When set, the worker prompt gains a "Sub-agent Model Policy"
+      # section. Omit the field to keep the prompt unchanged.
+      subagent_hint: "Use cheaper sub-agent models (e.g. opus/sonnet) for delegated grunt subtasks such as file sweeps, searches, and mechanical edits; reserve the main orchestrator model for planning and final review."
       # Optional per-backend pricing for the MC cost-observability panel
       # (issue #619). USD per million tokens. When unset, the SPA shows
       # tokens only ("price not configured") for this backend.

--- a/worker-prompt-template.md
+++ b/worker-prompt-template.md
@@ -46,6 +46,8 @@ If the build **passes** → proceed to implementation.
 
 ## Rules — read carefully, these are non-negotiable
 
+If Maestro appended a **Sub-agent Model Policy** section to this prompt (the backend sets `subagent_hint`), follow it when delegating work: route bulk grunt subtasks to the cheaper sub-agent model it names and reserve the main model for orchestration and final review.
+
 ### 1. Git hygiene
 - You are already in the worktree at `{{WORKTREE}}`
 - Your branch is `{{BRANCH}}` — it's already checked out


### PR DESCRIPTION
Implements #706

## Changes
- **config**: add optional `model.backends.<name>.subagent_hint` (`BackendDef.SubagentHint`) plus an exported `config.DefaultSubagentHint` constant with the recommended text.
- **worker**: `subagentHintPromptSection` injects a "Sub-agent Model Policy" section into the worker prompt when the backend sets the hint; appended in the Start, Respawn, and checkpoint-resume paths. Field-driven — backends without the field render a byte-for-byte unchanged prompt (no auto-default).
- **example config**: ship the recommended hint under the `claude` backend in `maestro.yaml.example`.
- **docs**: backend configuration reference paragraph + a field-table row in `docs/project-setup-runbook.md`; mirror note in `worker-prompt-template.md`.

## Testing
- `go test ./...` (full suite green)
- New: `TestWorkerPromptSubagentHintGolden`, `TestSubagentHintPromptSection*` (worker), `TestParse_BackendSubagentHint`, `TestDefaultSubagentHintIsActionable` (config)
- `go build ./cmd/maestro/`, `gofmt` clean on changed files

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional `subagent_hint` field to `BackendDef` that injects a "Sub-agent Model Policy" section into the worker prompt, steering orchestrating backends (e.g. Claude Code) to delegate bulk subtasks to cheaper sub-agent models. The feature is correctly gated — backends without the field produce a byte-for-byte unchanged prompt — and the hint is appended consistently across all three prompt-assembly paths (Start, Respawn, RespawnInPlace).

- `BackendDef.SubagentHint` + `DefaultSubagentHint` constant added in `config.go`; `subagentHintPromptSection` in `worker.go` sanitizes and renders the section.
- The exported `DefaultSubagentHint` and every shipped example name `opus/sonnet` as the "cheaper" models, but Opus is the most expensive Claude tier — operators copy-pasting the recommended value will steer sub-agents toward a more expensive model, not a cheaper one.

<h3>Confidence Score: 3/5</h3>

The prompt-injection plumbing is correct and backward-compatible, but the recommended hint text ships with a factually wrong model name that will cause operators to increase sub-agent costs instead of reducing them.

The core feature works correctly — field-driven, consistent across all prompt paths, well-tested. The problem is the `DefaultSubagentHint` constant and every copy of its example text (config.go, maestro.yaml.example, docs) lists `opus/sonnet` as the "cheaper" tier. Claude Opus is the most expensive model in the family; an operator who follows the shipped recommendation will steer sub-agents to Opus, doing the opposite of what the feature intends. Because the bad text is exported as a named constant and highlighted as the ready-made value to paste, it will propagate widely before anyone notices.

`internal/config/config.go` (the constant), `maestro.yaml.example`, and `docs/project-setup-runbook.md` all carry the inverted model names and need the same one-word fix (`opus` → `haiku`).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds `SubagentHint` field to `BackendDef` and exports `DefaultSubagentHint` constant — but the constant lists `opus/sonnet` as "cheaper" models when Opus is actually the most expensive Claude tier. |
| maestro.yaml.example | Adds `subagent_hint` under the `claude` backend with the same inverted `opus/sonnet` example text that will be copied by operators into production configs. |
| internal/worker/worker.go | Appends `subagentHintPromptSection` in both `Start` and `Respawn` paths, consistently after `assemblePrompt` and before `workerToolHookPromptSection`; implementation is clean and backward-compatible. |
| internal/worker/checkpoint.go | Correctly appends `subagentHintPromptSection` in the checkpoint-resume (`RespawnInPlace`) path, matching the ordering used in the other two prompt-assembly sites. |
| internal/config/backend_subagent_hint_test.go | New tests cover YAML parsing of `subagent_hint`, empty-field behaviour, and `DefaultSubagentHint` content checks; coverage is appropriate. |
| internal/worker/worker_prompt_test.go | Adds unit tests for `subagentHintPromptSection` (set, empty, whitespace) and a golden acceptance test for the full prompt with and without a hint; tests are thorough. |
| docs/project-setup-runbook.md | Documents `subagent_hint` with a field-table row and a configuration example, but carries the same `opus/sonnet` model-name inversion as the constant and example config. |
| worker-prompt-template.md | Adds a forward-reference note in the Rules section instructing workers to follow the Sub-agent Model Policy section when present; change is clean. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/config/config.go:99
The `DefaultSubagentHint` (and every copy of that text in the example config and docs) lists `opus/sonnet` as the *cheaper* sub-agent models, but Claude Opus is the **most expensive** tier — the opposite of what's intended. Operators who follow this hint verbatim will steer sub-agents toward Opus, which increases costs rather than reducing them. The cheaper Claude models are Haiku and Sonnet; Sonnet should be the ceiling, not Opus.

```suggestion
const DefaultSubagentHint = "Use cheaper sub-agent models (e.g. haiku/sonnet) for delegated grunt subtasks such as file sweeps, searches, and mechanical edits; reserve the main orchestrator model for planning and final review."
```

### Issue 2 of 3
maestro.yaml.example:69
Same model-name inversion as in `DefaultSubagentHint` — `opus/sonnet` is listed as the cheaper tier but Opus is the most expensive Claude model. This is the example operators will copy-paste, so the incorrect name will propagate into production configs.

```suggestion
      subagent_hint: "Use cheaper sub-agent models (e.g. haiku/sonnet) for delegated grunt subtasks such as file sweeps, searches, and mechanical edits; reserve the main orchestrator model for planning and final review."
```

### Issue 3 of 3
docs/project-setup-runbook.md:317
Same `opus/sonnet` inversion in the runbook example — should be `haiku/sonnet` to match the intended cheaper-tier recommendation.

```suggestion
      subagent_hint: "Use cheaper sub-agent models (e.g. haiku/sonnet) for delegated grunt subtasks such as file sweeps, searches, and mechanical edits; reserve the main orchestrator model for planning and final review."
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: per-backend subagent\_hint to ste..."](https://github.com/befeast/maestro/commit/2c5a9d7251de3ac3e075fd0023227e09eb5c0ffd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38797685)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->