### PR TITLE
codex backend: --json usage capture + virtual cost (replace regex scrape) (#738)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,9 @@ model:
 
 A backend that matches none of the above falls back to the generic exec path: `prompt_mode` applies, no permission-bypass flag is added, and Maestro logs a startup warning naming the backend. Use the generic path only for genuinely custom CLIs.
 
-### Claude usage capture (tokens + cost)
+### Claude / Codex usage capture (tokens + cost)
 
-Plain `claude -p` text mode prints no parseable token total, so a claude worker's `tokens_used_total` and USD cost stay `0`. Opt a claude backend into structured usage capture with `usage_stream: true`:
+Plain `claude -p` text mode prints no parseable token total, and `codex exec` text mode only prints a fuzzy single total — so a worker's `tokens_used_total` and USD cost are unreliable or `0`. Opt a `claude` or `codex` backend into structured usage capture with `usage_stream: true`:
 
 ```yaml
 model:
@@ -321,9 +321,15 @@ model:
     claude:
       cmd: claude
       usage_stream: true   # run claude in --output-format stream-json; capture tokens + cost
+    codex:
+      cmd: codex
+      usage_stream: true   # run codex exec --json; capture split tokens (cost = virtual)
+      pricing:
+        input_usd_per_mtok: 1.25
+        output_usd_per_mtok: 10
 ```
 
-When enabled, the worker runs `claude --output-format stream-json --verbose` and its NDJSON is piped through `maestro stream-split`, which writes the raw frames to a side-channel `<slot>.jsonl` (parsed for `input`/`output`/cache tokens + `total_cost_usd`) while keeping `<slot>.log` human-readable. The session then reports non-zero tokens + cost in `maestro history --json` and the `/api/v1/fleet` cost panel. Off by default; an operator-pinned `--output-format` in `extra_args` overrides it. (The `pi` backend captures usage natively and needs no opt-in.)
+When enabled, the worker runs the backend in structured-stream mode (`claude --output-format stream-json --verbose`, or `codex exec --json`) and its NDJSON is piped through `maestro stream-split`, which writes the raw frames to a side-channel `<slot>.jsonl` (parsed for `input`/`output`/cache tokens) while keeping `<slot>.log` human-readable. The session then reports non-zero split tokens in `maestro history --json` and the `/api/v1/fleet` cost panel. Off by default; an operator-pinned `--output-format` (claude) or `--json` (codex) in `extra_args` overrides it. Claude reports its own `total_cost_usd`; codex does not, so its cost is **virtual** — computed from the configured `pricing` block (tokens-only `$0` when no rates are set). (The `pi` backend captures usage natively and needs no opt-in.)
 
 ### Optional worker MCP tools
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -620,6 +620,14 @@ func (o *Orchestrator) updateTokensUsedFromOutput(slotName string, sess *state.S
 	if kind == config.BackendKindClaude && o.sessionUsageStream(sess) {
 		return o.updateClaudeUsageFromJSONL(slotName, sess)
 	}
+	// #738: a codex session with usage_stream opted in carries its usage on a
+	// side-channel slot.jsonl (`codex exec --json`); the human-readable slot.log
+	// has no parseable total, so the passed `output` is ignored in favour of the
+	// raw NDJSON. Without the opt-in, codex stays on the legacy text parser
+	// (the two-line "tokens used\n89,655" regex below).
+	if kind == config.BackendKindCodex && o.sessionUsageStream(sess) {
+		return o.updateCodexUsageFromJSONL(slotName, sess)
+	}
 	tokens := worker.ParseTokensFromOutput(output)
 	if tokens <= sess.TokensUsedAttempt {
 		return false
@@ -734,9 +742,49 @@ func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.S
 	return changed
 }
 
-// sessionUsageStream reports whether the session's backend opted into #737
-// structured usage capture (usage_stream). Only then does the claude path read
-// the slot.jsonl side channel; otherwise it stays on the generic text parser.
+// updateCodexUsageFromJSONL parses the codex `exec --json` side-channel
+// (slot.jsonl) and stamps tokens onto the session (#738). codex emits one
+// terminal turn.completed usage event per `codex exec` invocation; the
+// splitter appends each attempt's frames to the same slot.jsonl, so
+// ParseCodexUsage sums them to the cumulative run total. The monotonic
+// UsageTokensWatermark persists across respawns so a forced retry never
+// double-counts (mirrors the claude/Pi paths). codex reports no USD, so cost
+// stays virtual: CostUSDBackend is left at 0 and sessionCostEstimate supplies
+// the dollar figure from the configured pricing block. codex --json carries no
+// model name, so sess.Model is left as configured. Returns true when tokens
+// changed; false (tokens stay 0) when the jsonl is absent — the documented
+// degradation when the stream-splitter was unavailable.
+func (o *Orchestrator) updateCodexUsageFromJSONL(slotName string, sess *state.Session) bool {
+	jsonlPath := o.workerJSONLFile(slotName, sess)
+	if jsonlPath == "" {
+		return false
+	}
+	data, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		// No side-channel stream (splitter disabled/unavailable, or the
+		// worker has not emitted a turn.completed yet) — leave tokens at 0.
+		return false
+	}
+	usage, ok := worker.ParseCodexUsage(string(data))
+	if !ok {
+		return false
+	}
+	if usage.TotalTokens <= sess.UsageTokensWatermark {
+		return false
+	}
+	delta := usage.TotalTokens - sess.UsageTokensWatermark
+	sess.UsageTokensWatermark = usage.TotalTokens
+	sess.TokensUsedAttempt += delta
+	sess.TokensUsedTotal += delta
+	log.Printf("[orch] %s codex usage: input=%d output=%d cache_read=%d tokens=%d (total=%d)",
+		slotName, usage.Input, usage.Output, usage.CacheRead, usage.TotalTokens, sess.TokensUsedTotal)
+	return true
+}
+
+// sessionUsageStream reports whether the session's backend opted into
+// structured usage capture (usage_stream). Only then do the claude (#737) and
+// codex (#738) paths read the slot.jsonl side channel; otherwise they stay on
+// the generic text parser.
 func (o *Orchestrator) sessionUsageStream(sess *state.Session) bool {
 	if sess == nil || o == nil || o.cfg == nil {
 		return false

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9897,3 +9897,117 @@ func TestUpdateTokensUsedFromOutput_ClaudeBackendRetryNoDoubleCount(t *testing.T
 		t.Errorf("CostUSDBackend = %v, want 0.003 (cumulative)", sess.CostUSDBackend)
 	}
 }
+
+// codexTurnFrame builds one terminal codex `exec --json` turn.completed event
+// with the given token totals, as the stream-splitter would append it.
+// cached_input_tokens is a subset of input_tokens (OpenAI semantics).
+func codexTurnFrame(in, cached, out int) string {
+	return fmt.Sprintf(`{"type":"turn.completed","usage":{"input_tokens":%d,"cached_input_tokens":%d,"output_tokens":%d,"reasoning_output_tokens":0}}`+"\n",
+		in, cached, out)
+}
+
+// codexTestOrchestrator wires a session to a codex backend (usage_stream on,
+// with pricing so virtual cost is exercisable) whose slot.jsonl lives at
+// <dir>/<slot>.jsonl. Returns the orchestrator, session, and jsonl path.
+func codexTestOrchestrator(t *testing.T, slot string) (*Orchestrator, *state.Session, string) {
+	t.Helper()
+	dir := t.TempDir()
+	o := &Orchestrator{
+		cfg: &config.Config{
+			StateDir: dir,
+			Model: config.ModelConfig{
+				Default: "codex",
+				Backends: map[string]config.BackendDef{
+					"codex": {
+						Cmd:         "codex",
+						UsageStream: true,
+						Pricing:     config.BackendPricing{InputUSDPerMtok: 1.25, OutputUSDPerMtok: 10},
+					},
+				},
+			},
+		},
+	}
+	logFile := dir + "/" + slot + ".log"
+	sess := &state.Session{Backend: "codex", LogFile: logFile}
+	return o, sess, dir + "/" + slot + ".jsonl"
+}
+
+// #738: a codex session reads usage from the slot.jsonl side channel (not the
+// human-readable slot.log) and stamps non-zero tokens. codex reports no USD,
+// so CostUSDBackend stays 0 — the dollar figure is virtual (configured pricing
+// via SessionCostEstimate). cached_input_tokens is a subset of input_tokens,
+// so the stamped total is input+output only.
+func TestUpdateTokensUsedFromOutput_CodexBackendStampsUsage(t *testing.T) {
+	o, sess, jsonlPath := codexTestOrchestrator(t, "sup-738")
+	frames := `{"type":"thread.started","thread_id":"REDACTED"}` + "\n" +
+		`{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"pong"}}` + "\n" +
+		codexTurnFrame(12087, 4992, 5)
+	if err := os.WriteFile(jsonlPath, []byte(frames), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The passed output (slot.log/tmux) is intentionally ignored for codex.
+	if !o.updateTokensUsedFromOutput("sup-738", sess, "human readable log text, no token total") {
+		t.Fatal("expected a change from the codex jsonl side channel")
+	}
+	// input 12087 + output 5 = 12092 (cache is a subset of input, not added).
+	if sess.TokensUsedTotal != 12092 || sess.TokensUsedAttempt != 12092 {
+		t.Errorf("tokens total=%d attempt=%d, want 12092/12092", sess.TokensUsedTotal, sess.TokensUsedAttempt)
+	}
+	if sess.UsageTokensWatermark != 12092 {
+		t.Errorf("UsageTokensWatermark = %d, want 12092", sess.UsageTokensWatermark)
+	}
+	// codex never self-reports USD — cost stays virtual (CostUSDBackend == 0).
+	if sess.CostUSDBackend != 0 {
+		t.Errorf("CostUSDBackend = %v, want 0 (codex cost is virtual, never self-reported)", sess.CostUSDBackend)
+	}
+}
+
+// #738: a forced retry/respawn appends a second `codex exec` invocation's
+// turn.completed event to the same slot.jsonl. The full-jsonl parse returns
+// the cumulative total, but the monotonic watermark ensures only the new run's
+// delta is added — no double-count of the prior attempt's tokens.
+func TestUpdateTokensUsedFromOutput_CodexBackendRetryNoDoubleCount(t *testing.T) {
+	o, sess, jsonlPath := codexTestOrchestrator(t, "sup-738")
+
+	run1 := codexTurnFrame(770, 0, 3) // total 773
+	if err := os.WriteFile(jsonlPath, []byte(run1), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateTokensUsedFromOutput("sup-738", sess, "") {
+		t.Fatal("run1: expected a change")
+	}
+	if sess.TokensUsedTotal != 773 || sess.UsageTokensWatermark != 773 || sess.TokensUsedAttempt != 773 {
+		t.Fatalf("run1: total=%d wm=%d attempt=%d, want 773/773/773",
+			sess.TokensUsedTotal, sess.UsageTokensWatermark, sess.TokensUsedAttempt)
+	}
+
+	// Respawn: per-attempt counter resets, watermark persists.
+	sess.TokensUsedAttempt = 0
+
+	// Re-parse the unchanged jsonl before the new run lands — must NOT re-add.
+	if o.updateTokensUsedFromOutput("sup-738", sess, "") {
+		t.Fatal("re-parse of unchanged jsonl must not report a change (would double-count)")
+	}
+	if sess.TokensUsedTotal != 773 {
+		t.Fatalf("after re-parse: TokensUsedTotal = %d, want 773 (no double-count)", sess.TokensUsedTotal)
+	}
+
+	// New run appends its turn.completed: cumulative 1773, delta only (1000).
+	run2 := codexTurnFrame(900, 0, 100) // total 1000
+	if err := os.WriteFile(jsonlPath, []byte(run1+run2), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateTokensUsedFromOutput("sup-738", sess, "") {
+		t.Fatal("run2: expected a change")
+	}
+	if sess.TokensUsedTotal != 1773 {
+		t.Errorf("after run2: TokensUsedTotal = %d, want 1773 (delta only)", sess.TokensUsedTotal)
+	}
+	if sess.TokensUsedAttempt != 1000 {
+		t.Errorf("TokensUsedAttempt = %d, want 1000 (current attempt delta)", sess.TokensUsedAttempt)
+	}
+	if sess.UsageTokensWatermark != 1773 {
+		t.Errorf("UsageTokensWatermark = %d, want 1773", sess.UsageTokensWatermark)
+	}
+}

--- a/internal/server/cost_observability_test.go
+++ b/internal/server/cost_observability_test.go
@@ -378,4 +378,29 @@ func TestApplySessionCostEstimate(t *testing.T) {
 	}
 }
 
+// TestSessionCostEstimate_CodexVirtual covers the #738 virtual-cost contract:
+// codex never self-reports USD (backendCost is always 0), so the dollar figure
+// must come from the configured pricing block. With pricing the estimate is
+// non-zero; without it the session degrades to tokens-only ($0). A claude
+// session that DID self-report a cost still prefers that over the estimate.
+func TestSessionCostEstimate_CodexVirtual(t *testing.T) {
+	pricing := map[string]config.BackendPricing{
+		"codex":  {InputUSDPerMtok: 1.25, OutputUSDPerMtok: 10},
+		"claude": {InputUSDPerMtok: 10, OutputUSDPerMtok: 30},
+	}
+	// codex: backendCost is always 0, so the (1.25+10)/2 = 5.625 $/Mtok blend
+	// applies → 1M tokens ≈ $5.625 (virtual, from pricing).
+	if got := sessionCostEstimate("codex", 1_000_000, pricing, 0); math.Abs(got-5.625) > 1e-6 {
+		t.Errorf("codex virtual cost = %f, want ~5.625", got)
+	}
+	// codex with no pricing → tokens-only ($0), never a self-reported cost.
+	if got := sessionCostEstimate("codex", 1_000_000, map[string]config.BackendPricing{"codex": {}}, 0); got != 0 {
+		t.Errorf("codex unpriced cost = %f, want 0", got)
+	}
+	// A self-reported cost (e.g. claude total_cost_usd) still wins over pricing.
+	if got := sessionCostEstimate("claude", 1_000_000, pricing, 0.04); math.Abs(got-0.04) > 1e-9 {
+		t.Errorf("self-reported cost = %f, want 0.04 (prefer backend cost)", got)
+	}
+}
+
 func timePtr(t time.Time) *time.Time { return &t }

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -27,8 +27,16 @@ func splitCmd(cmd string) (binary string, prefixArgs []string) {
 // Used so an operator-specified output format in cmd/extra_args overrides the
 // #737 stream-json default instead of producing a duplicate flag.
 func argsHaveOutputFormat(args []string) bool {
+	return argsHaveFlag(args, "--output-format")
+}
+
+// argsHaveFlag reports whether args already contain the given flag, either as
+// a bare token (`--json`) or in the `--json=value` form. Used so an
+// operator-pinned flag in cmd/extra_args overrides a backend default instead
+// of producing a duplicate (e.g. the codex #738 `--json` opt-in).
+func argsHaveFlag(args []string, flag string) bool {
 	for _, a := range args {
-		if a == "--output-format" || strings.HasPrefix(a, "--output-format=") {
+		if a == flag || strings.HasPrefix(a, flag+"=") {
 			return true
 		}
 	}
@@ -43,9 +51,10 @@ type BackendConfig struct {
 	Provider   string   // per-backend provider field; resolves the exec path for custom-named backends (#684)
 	Model      string   // optional model name for role-specific backend calls
 	Effort     string   // optional reasoning effort for role-specific backend calls
-	// UsageStream opts a claude-kind worker into `--output-format stream-json
-	// --verbose` so its NDJSON usage stream can be captured on a side-channel
-	// slot.jsonl (#737). Off by default; ignored by non-claude backends.
+	// UsageStream opts a structured-stream worker into emitting NDJSON usage
+	// frames on a side-channel slot.jsonl: claude `--output-format stream-json
+	// --verbose` (#737) and codex `exec --json` (#738). Off by default;
+	// ignored by backends without a structured-stream mode.
 	UsageStream bool
 	MCP         config.MCPConfig
 }
@@ -115,6 +124,14 @@ func (codexBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*e
 	}
 	binary, cmdArgs := splitCmd(codexCmd)
 	args := append(cmdArgs, "exec", "--dangerously-bypass-approvals-and-sandbox", "-C", worktree)
+	// #738: opt-in structured streaming so usage (tokens) can be parsed from
+	// the NDJSON side-channel. `codex exec --json` emits JSONL events incl. a
+	// terminal turn.completed usage block {input, cached_input, output}.
+	// Skipped when the operator already pins --json via cmd or extra_args, so
+	// their choice (and the matching runner wiring) wins — no duplicate flag.
+	if cfg.UsageStream && !argsHaveFlag(cmdArgs, "--json") && !argsHaveFlag(cfg.ExtraArgs, "--json") {
+		args = append(args, "--json")
+	}
 	var err error
 	args, err = appendCodexMCPOptions(args, cfg.MCP)
 	if err != nil {
@@ -440,14 +457,17 @@ func maestroExecutablePath() (string, bool) {
 }
 
 // streamSplitForBackend returns the worker runner's stream-split configuration,
-// or nil when the plain `tee` pipeline should be used. Only a claude-kind
-// backend with usage_stream opted in streams NDJSON; when the maestro binary
-// cannot be resolved it degrades to nil (plain tee) per #737.
+// or nil when the plain `tee` pipeline should be used. Only a structured-stream
+// backend (claude #737, codex #738) with usage_stream opted in streams NDJSON;
+// when the maestro binary cannot be resolved it degrades to nil (plain tee).
+// The resolved backend kind is passed to the splitter so it renders the right
+// human-readable form into slot.log.
 func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string) *streamSplit {
 	if !cfg.UsageStream {
 		return nil
 	}
-	if resolveBackendKind(backendName, cfg) != config.BackendKindClaude {
+	kind := resolveBackendKind(backendName, cfg)
+	if kind != config.BackendKindClaude && kind != config.BackendKindCodex {
 		return nil
 	}
 	bin, ok := maestroExecutablePath()
@@ -456,7 +476,7 @@ func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string
 	}
 	return &streamSplit{
 		MaestroBin: bin,
-		Backend:    config.BackendKindClaude,
+		Backend:    kind,
 		JSONLPath:  JSONLPathForLog(logFile),
 	}
 }

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -100,6 +100,61 @@ func TestBuildWorkerCmd_ClaudeUsageStream(t *testing.T) {
 // regression from #454: a worker claude prompt larger than the Linux
 // MAX_ARG_STRLEN single-argument limit (128 KiB) must be delivered via stdin,
 // never as a CLI argument, so fork/exec never sees "argument list too long".
+// TestBuildWorkerCmd_CodexUsageStream verifies the #738 opt-in: when
+// UsageStream is set the codex worker runs `exec --json`, and an
+// operator-pinned --json in extra_args overrides it (no duplicate flag).
+func TestBuildWorkerCmd_CodexUsageStream(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("do the thing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("opt-in appends --json", func(t *testing.T) {
+		cfg := BackendConfig{Cmd: "codex", UsageStream: true}
+		cmd, _, err := BuildWorkerCmd("codex", cfg, promptFile, "/tmp/wt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		args := strings.Join(cmd.Args, " ")
+		if !strings.Contains(args, "--json") {
+			t.Errorf("expected --json in args, got: %s", args)
+		}
+		// The stdin prompt marker must remain the final argument.
+		if cmd.Args[len(cmd.Args)-1] != "-" {
+			t.Errorf("expected trailing '-' stdin marker, got: %v", cmd.Args)
+		}
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		cfg := BackendConfig{Cmd: "codex"}
+		cmd, _, err := BuildWorkerCmd("codex", cfg, promptFile, "/tmp/wt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(strings.Join(cmd.Args, " "), "--json") {
+			t.Errorf("--json must not appear unless UsageStream is set: %v", cmd.Args)
+		}
+	})
+
+	t.Run("extra_args --json is not duplicated", func(t *testing.T) {
+		cfg := BackendConfig{Cmd: "codex", UsageStream: true, ExtraArgs: []string{"--json"}}
+		cmd, _, err := BuildWorkerCmd("codex", cfg, promptFile, "/tmp/wt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		n := 0
+		for _, a := range cmd.Args {
+			if a == "--json" {
+				n++
+			}
+		}
+		if n != 1 {
+			t.Errorf("operator --json must not be duplicated, found %d in: %v", n, cmd.Args)
+		}
+	})
+}
+
 func TestBuildWorkerCmd_ClaudeLargePromptViaStdin(t *testing.T) {
 	dir := t.TempDir()
 	promptFile := filepath.Join(dir, "prompt.md")

--- a/internal/worker/codex_usage.go
+++ b/internal/worker/codex_usage.go
@@ -1,0 +1,79 @@
+package worker
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// CodexUsage is the aggregated provider usage parsed from a codex
+// `exec --json` JSONL stream (#738). Each `codex exec` invocation emits one
+// terminal `turn.completed` event carrying that invocation's cumulative token
+// usage. The stream-splitter appends every attempt's frames to the same
+// slot.jsonl, so summing across turn.completed events yields the cumulative
+// run total across attempts — monotonic as the log grows, which is what the
+// orchestrator's respawn-safe token watermark expects.
+//
+// codex follows OpenAI usage semantics: cached_input_tokens is a SUBSET of
+// input_tokens (the portion of the prompt served from cache), not a separate
+// bucket; reasoning_output_tokens is likewise a subset of output_tokens.
+// TotalTokens is therefore Input + Output only — adding CacheRead would
+// double-count the cached prompt tokens. CacheRead is retained for the
+// cache-aware split-cost model (#739). codex reports no USD, so cost stays
+// virtual (computed from the configured pricing block, no self-reported USD).
+type CodexUsage struct {
+	Input       int // sum of input_tokens across turn.completed events (includes the cached subset)
+	Output      int // sum of output_tokens across turn.completed events
+	CacheRead   int // sum of cached_input_tokens (a subset of Input; not added to TotalTokens)
+	TotalTokens int // Input + Output
+}
+
+// codexStreamFrame is the subset of a codex `exec --json` line this package
+// decodes. The terminal turn.completed event carries the usage block; all
+// other event types (thread.started, turn.started, item.*) are ignored here.
+type codexStreamFrame struct {
+	Type  string           `json:"type"`
+	Usage *codexUsageBlock `json:"usage"`
+}
+
+// codexUsageBlock mirrors the usage object codex emits on turn.completed.
+// cached_input_tokens and reasoning_output_tokens are subsets of
+// input_tokens / output_tokens respectively (OpenAI semantics); only
+// input/output feed the token total.
+type codexUsageBlock struct {
+	InputTokens           int `json:"input_tokens"`
+	CachedInputTokens     int `json:"cached_input_tokens"`
+	OutputTokens          int `json:"output_tokens"`
+	ReasoningOutputTokens int `json:"reasoning_output_tokens"`
+}
+
+// ParseCodexUsage scans a codex `exec --json` JSONL stream (the appended
+// slot.jsonl) and aggregates usage across every terminal turn.completed event.
+// It returns ok=false when no usage-bearing event is found, so callers can
+// leave tokens at 0 (the documented degradation when the stream-splitter was
+// unavailable or no event has landed yet) and fall back to the legacy text
+// parser.
+func ParseCodexUsage(text string) (CodexUsage, bool) {
+	var out CodexUsage
+	seen := false
+
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || line[0] != '{' {
+			continue
+		}
+		var fr codexStreamFrame
+		if err := json.Unmarshal([]byte(line), &fr); err != nil {
+			continue
+		}
+		if fr.Type != "turn.completed" || fr.Usage == nil {
+			continue
+		}
+		out.Input += fr.Usage.InputTokens
+		out.Output += fr.Usage.OutputTokens
+		out.CacheRead += fr.Usage.CachedInputTokens
+		seen = true
+	}
+
+	out.TotalTokens = out.Input + out.Output
+	return out, seen
+}

--- a/internal/worker/codex_usage_test.go
+++ b/internal/worker/codex_usage_test.go
@@ -1,0 +1,76 @@
+package worker
+
+import "testing"
+
+// codexSmokeStream is a real 1-turn codex `exec --json` capture
+// (codex-cli 0.139.0, prompt "Reply with exactly the word: pong"), with the
+// thread_id redacted. The token counts are verbatim from the live run so the
+// parser is exercised against the actual frame shape, not a hand-written
+// guess (#738). codex reports no USD — cost is virtual (configured pricing).
+const codexSmokeStream = `{"type":"thread.started","thread_id":"REDACTED"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"pong"}}
+{"type":"turn.completed","usage":{"input_tokens":12087,"cached_input_tokens":4992,"output_tokens":5,"reasoning_output_tokens":0}}
+`
+
+func TestParseCodexUsage_RealSmokeCapture(t *testing.T) {
+	usage, ok := ParseCodexUsage(codexSmokeStream)
+	if !ok {
+		t.Fatal("ParseCodexUsage returned ok=false on a real turn.completed event")
+	}
+	if usage.Input != 12087 {
+		t.Errorf("Input = %d, want 12087", usage.Input)
+	}
+	if usage.Output != 5 {
+		t.Errorf("Output = %d, want 5", usage.Output)
+	}
+	if usage.CacheRead != 4992 {
+		t.Errorf("CacheRead = %d, want 4992", usage.CacheRead)
+	}
+	// cached_input_tokens is a subset of input_tokens (OpenAI semantics), so
+	// the total is input + output only — NOT input + output + cache.
+	if usage.TotalTokens != 12092 {
+		t.Errorf("TotalTokens = %d, want 12092 (input+output, cache is a subset of input)", usage.TotalTokens)
+	}
+}
+
+// A stream with no turn.completed event (truncated / non-codex) must report
+// ok=false so the orchestrator leaves tokens at 0 and falls back to the
+// legacy text parser instead of stamping garbage.
+func TestParseCodexUsage_NoUsageEvent(t *testing.T) {
+	const noUsage = `{"type":"thread.started","thread_id":"REDACTED"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"working"}}
+not json at all
+`
+	if usage, ok := ParseCodexUsage(noUsage); ok {
+		t.Fatalf("expected ok=false without a turn.completed event, got %+v", usage)
+	}
+}
+
+// Multiple turn.completed events (the slot.jsonl after a respawn appends a
+// second `codex exec` invocation's frames) must SUM to the cumulative run
+// total — the property the respawn-safe token watermark relies on.
+func TestParseCodexUsage_SumsAcrossTurns(t *testing.T) {
+	const twoRuns = `{"type":"turn.completed","usage":{"input_tokens":700,"cached_input_tokens":100,"output_tokens":70,"reasoning_output_tokens":0}}
+{"type":"turn.completed","usage":{"input_tokens":900,"cached_input_tokens":0,"output_tokens":100,"reasoning_output_tokens":10}}
+`
+	usage, ok := ParseCodexUsage(twoRuns)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	// Input 700+900=1600, Output 70+100=170, CacheRead 100+0=100.
+	if usage.Input != 1600 {
+		t.Errorf("Input = %d, want 1600", usage.Input)
+	}
+	if usage.Output != 170 {
+		t.Errorf("Output = %d, want 170", usage.Output)
+	}
+	if usage.CacheRead != 100 {
+		t.Errorf("CacheRead = %d, want 100", usage.CacheRead)
+	}
+	// 1600 + 170 = 1770 (cache subset excluded from the total).
+	if usage.TotalTokens != 1770 {
+		t.Errorf("TotalTokens = %d, want 1770 (sum of input+output across turns)", usage.TotalTokens)
+	}
+}

--- a/internal/worker/stream_split.go
+++ b/internal/worker/stream_split.go
@@ -78,15 +78,19 @@ func RunStreamSplit(backend, jsonlPath string, r io.Reader, w io.Writer) error {
 }
 
 // renderStreamLine converts one structured stream line into human-readable
-// text for the worker log. Only the claude backend is rendered today; any
+// text for the worker log. claude (#737) and codex (#738) are rendered; any
 // other backend (and any non-JSON or unrecognized line) passes through
 // verbatim, which preserves stderr error text so the rate-limit /
-// auth-failure text parsers keep matching (#737 acceptance).
+// auth-failure text parsers keep matching (acceptance criterion).
 func renderStreamLine(backend, line string) string {
-	if strings.TrimSpace(backend) != "claude" {
+	switch strings.TrimSpace(backend) {
+	case "claude":
+		return renderClaudeStreamLine(line)
+	case "codex":
+		return renderCodexStreamLine(line)
+	default:
 		return line
 	}
-	return renderClaudeStreamLine(line)
 }
 
 // RenderClaudeStreamLine is the exported entry point for rendering a single
@@ -94,6 +98,13 @@ func renderStreamLine(backend, line string) string {
 // rate-limit / auth-failure text intact).
 func RenderClaudeStreamLine(line string) string {
 	return renderClaudeStreamLine(line)
+}
+
+// RenderCodexStreamLine is the exported entry point for rendering a single
+// codex `exec --json` line (used by tests verifying the renderer keeps
+// rate-limit / auth-failure text intact).
+func RenderCodexStreamLine(line string) string {
+	return renderCodexStreamLine(line)
 }
 
 type claudeRenderFrame struct {
@@ -207,4 +218,117 @@ func renderClaudeContent(raw json.RawMessage) string {
 		}
 	}
 	return strings.Join(parts, "\n")
+}
+
+// codexRenderFrame is the subset of a codex `exec --json` line the renderer
+// decodes. turn.completed carries the usage block (reused from codex_usage.go);
+// item.started / item.completed carry the work item being rendered.
+type codexRenderFrame struct {
+	Type  string           `json:"type"`
+	Item  *codexRenderItem `json:"item"`
+	Usage *codexUsageBlock `json:"usage"`
+}
+
+// codexRenderItem is the subset of a codex item.* envelope the renderer needs:
+// agent_message text, the executed command + its output/exit code, and file
+// changes.
+type codexRenderItem struct {
+	Type             string            `json:"type"`
+	Text             string            `json:"text"`
+	Command          string            `json:"command"`
+	AggregatedOutput string            `json:"aggregated_output"`
+	ExitCode         *int              `json:"exit_code"`
+	Changes          []codexFileChange `json:"changes"`
+}
+
+type codexFileChange struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
+}
+
+// renderCodexStreamLine renders one codex `exec --json` event into
+// human-readable text for slot.log (#738). A line that is not a JSON object,
+// or fails to decode, is returned verbatim so nothing is lost from the worker
+// log (and any plain stderr error text — rate-limit / auth-failure — still
+// reaches the text parsers). Unknown top-level event types (e.g. turn.failed)
+// are likewise preserved verbatim so error signatures survive.
+func renderCodexStreamLine(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || trimmed[0] != '{' {
+		return line
+	}
+	var fr codexRenderFrame
+	if err := json.Unmarshal([]byte(trimmed), &fr); err != nil {
+		return line
+	}
+	switch fr.Type {
+	case "thread.started", "turn.started":
+		// Structural envelopes with no human-facing content — drop.
+		return ""
+	case "item.started":
+		return renderCodexItem(fr.Item, false)
+	case "item.completed":
+		return renderCodexItem(fr.Item, true)
+	case "turn.completed":
+		if fr.Usage == nil {
+			return ""
+		}
+		return fmt.Sprintf("[codex] usage: input=%d cached=%d output=%d",
+			fr.Usage.InputTokens, fr.Usage.CachedInputTokens, fr.Usage.OutputTokens)
+	default:
+		// Unknown event type — preserve it verbatim rather than drop it, so
+		// error/rate-limit text carried in an unrecognized frame still matches.
+		return line
+	}
+}
+
+// renderCodexItem renders one codex work item. command_execution shows the
+// command on start and its output + exit code on completion; agent_message and
+// file_change render on completion. An unrecognized item type renders its text
+// (if any) or a compact marker so slot.log never carries raw item JSON.
+func renderCodexItem(item *codexRenderItem, completed bool) string {
+	if item == nil {
+		return ""
+	}
+	switch item.Type {
+	case "agent_message":
+		if completed {
+			return item.Text
+		}
+		return ""
+	case "command_execution":
+		if !completed {
+			return "[codex] $ " + strings.TrimSpace(item.Command)
+		}
+		var b strings.Builder
+		if out := strings.TrimRight(item.AggregatedOutput, "\n"); out != "" {
+			b.WriteString(out)
+			b.WriteByte('\n')
+		}
+		exit := 0
+		if item.ExitCode != nil {
+			exit = *item.ExitCode
+		}
+		fmt.Fprintf(&b, "[codex] exit=%d", exit)
+		return b.String()
+	case "file_change":
+		if !completed {
+			return ""
+		}
+		parts := make([]string, 0, len(item.Changes))
+		for _, c := range item.Changes {
+			parts = append(parts, fmt.Sprintf("[codex] %s %s", strings.TrimSpace(c.Kind), strings.TrimSpace(c.Path)))
+		}
+		return strings.Join(parts, "\n")
+	default:
+		if completed {
+			if t := strings.TrimSpace(item.Text); t != "" {
+				return item.Text
+			}
+			if it := strings.TrimSpace(item.Type); it != "" {
+				return "[codex] " + it
+			}
+		}
+		return ""
+	}
 }

--- a/internal/worker/stream_split_test.go
+++ b/internal/worker/stream_split_test.go
@@ -82,6 +82,116 @@ func TestRunStreamSplit_NonClaudePassthrough(t *testing.T) {
 	}
 }
 
+// RunStreamSplit with the codex backend must append the raw NDJSON frames
+// verbatim to the jsonl side channel (so ParseCodexUsage can read them) while
+// rendering human-readable text to stdout (slot.log) — no raw usage JSON.
+func TestRunStreamSplit_Codex(t *testing.T) {
+	dir := t.TempDir()
+	jsonlPath := filepath.Join(dir, "sup-1.jsonl")
+
+	var out strings.Builder
+	if err := RunStreamSplit("codex", jsonlPath, strings.NewReader(codexSmokeStream), &out); err != nil {
+		t.Fatalf("RunStreamSplit: %v", err)
+	}
+
+	// (a) the jsonl side channel round-trips usage through the parser.
+	raw, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		t.Fatalf("read jsonl: %v", err)
+	}
+	if usage, ok := ParseCodexUsage(string(raw)); !ok || usage.TotalTokens != 12092 {
+		t.Fatalf("jsonl side channel did not round-trip usage: ok=%v usage=%+v", ok, usage)
+	}
+
+	// (b) stdout (slot.log) is human-readable: the assistant text and a usage
+	// summary are present; the raw usage JSON envelope is not echoed verbatim.
+	rendered := out.String()
+	if !strings.Contains(rendered, "pong") {
+		t.Errorf("rendered output missing assistant text:\n%s", rendered)
+	}
+	if strings.Contains(rendered, `"cached_input_tokens"`) {
+		t.Errorf("rendered slot.log should not contain raw usage JSON:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "[codex] usage:") {
+		t.Errorf("rendered output missing usage summary:\n%s", rendered)
+	}
+}
+
+// The codex renderer must turn item events into readable text: a command and
+// its output/exit, a file change, and an agent message — never raw item JSON.
+func TestRenderCodexStreamLine_ItemsAreReadable(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			"command start",
+			`{"type":"item.started","item":{"id":"i1","type":"command_execution","command":"/bin/bash -lc ls","status":"in_progress"}}`,
+			[]string{"[codex] $ /bin/bash -lc ls"},
+		},
+		{
+			"command completed",
+			`{"type":"item.completed","item":{"id":"i1","type":"command_execution","command":"/bin/bash -lc ls","aggregated_output":"a.txt\nb.txt\n","exit_code":0,"status":"completed"}}`,
+			[]string{"a.txt", "b.txt", "[codex] exit=0"},
+		},
+		{
+			"file change",
+			`{"type":"item.completed","item":{"id":"i3","type":"file_change","changes":[{"path":"/wt/hello.txt","kind":"add"}],"status":"completed"}}`,
+			[]string{"[codex] add /wt/hello.txt"},
+		},
+		{
+			"agent message",
+			`{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"all done"}}`,
+			[]string{"all done"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RenderCodexStreamLine(tc.line)
+			if strings.Contains(got, "\"type\":") {
+				t.Errorf("rendered line leaked raw JSON: %q", got)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("rendered = %q, want substring %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+// #738 acceptance: routing rate-limit / auth-failure signatures through the
+// codex renderer must not break the text parsers. Plain stderr lines pass
+// through verbatim; an unrecognized JSON event is preserved verbatim too, so
+// either way the detectors fire.
+func TestRenderCodexStreamLine_PreservesDetectionSignatures(t *testing.T) {
+	signatures := []struct {
+		name   string
+		text   string
+		detect func(string) bool
+	}{
+		{"codex rate limit (stderr passthrough)", "Error: rate limit exceeded, please try again later", OutputContainsRateLimit},
+		{"http 429 (stderr passthrough)", "Request failed with status 429", OutputContainsRateLimit},
+		{"auth failure (stderr passthrough)", "API Error: 401 Invalid authentication credentials", func(s string) bool { hit, _ := DetectAuthFailure(s); return hit }},
+	}
+	for _, sig := range signatures {
+		t.Run(sig.name, func(t *testing.T) {
+			if got := RenderCodexStreamLine(sig.text); got != sig.text {
+				t.Fatalf("plain line not passed through verbatim:\ngot  %q\nwant %q", got, sig.text)
+			}
+			if !sig.detect(RenderCodexStreamLine(sig.text)) {
+				t.Errorf("detector regressed on rendered plain line: %q", sig.text)
+			}
+			// An unknown JSON event carrying the signature must survive too.
+			frame := `{"type":"error","message":` + jsonQuote(sig.text) + `}`
+			if !sig.detect(RenderCodexStreamLine(frame)) {
+				t.Errorf("detector regressed on rendered unknown event:\nframe: %s", frame)
+			}
+		})
+	}
+}
+
 // #737 acceptance: routing the rate-limit / auth-failure fixtures through the
 // claude renderer must not break the text parsers. Plain stderr lines pass
 // through verbatim; the same signatures embedded in a stream-json result


### PR DESCRIPTION
Implements #738

## Changes
Brings the `codex` (openai) backend up to the structured-stream usage standard already used by `claude` (#737) and `pi` (#730), replacing the fragile two-line `tokens used\n89,655` regex scrape.

- **`codexBackend.BuildCmd`** appends `--json` behind the `usage_stream` opt-in; an operator-pinned `--json` in `cmd`/`extra_args` overrides it (no duplicate flag).
- **Runner** routes codex through `maestro stream-split --backend codex --jsonl <slot>.jsonl` (`streamSplitForBackend` extended to codex). A new codex renderer keeps `slot.log` human-readable (assistant text, `$ command` + exit, file changes, a usage summary) while the raw JSONL frames land in the side-channel `slot.jsonl`. Unknown events and plain stderr pass through verbatim, so the ratelimit/authfailure detectors keep matching.
- **`internal/worker/codex_usage.go`** — `ParseCodexUsage` sums the `turn.completed` usage events. codex follows OpenAI semantics (`cached_input_tokens` is a subset of `input_tokens`), so the token total is `input + output` only; cache is retained for the future split-cost model (#739) but never double-counted.
- **`updateTokensUsedFromOutput`** branches `BackendKindCodex` to read `slot.jsonl` via the shared monotonic `UsageTokensWatermark` (no double-count on a forced retry/respawn). codex self-reports no USD, so cost stays **virtual** (configured `pricing`); the legacy regex remains the fallback when `usage_stream` is off.
- README usage-capture section + config doc updated for codex.

## Testing
- Parser/renderer/opt-in unit tests use fixtures captured from a **real** 1-turn codex-cli 0.139.0 smoke.
- Orchestrator watermark tests cover the no-double-count-on-retry path; a server test covers the codex virtual-cost contract.
- `go build ./cmd/maestro/` and `go test ./...` are green.
- Verified end-to-end on host: piped a live `codex exec --json` run through the built `maestro stream-split --backend codex` — `slot.jsonl` carried the `turn.completed` usage event and `slot.log` stayed human-readable.

Refs #738

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR brings the `codex` backend up to the structured-stream usage standard used by `claude` and `pi`, replacing a fragile regex scrape with JSONL-based token capture via `codex exec --json`.

- `codexBackend.BuildCmd` appends `--json` behind the `usage_stream` opt-in (with duplicate-flag guard); `streamSplitForBackend` is extended to codex so the runner pipes NDJSON through `maestro stream-split --backend codex`.
- `ParseCodexUsage` sums `turn.completed` usage events across respawns; `updateCodexUsageFromJSONL` applies the same monotonic watermark pattern as the claude/Pi paths to prevent double-counting on retry, leaving `CostUSDBackend` at 0 so cost remains virtual (from the configured pricing block).
- A new `renderCodexStreamLine` keeps `slot.log` human-readable while raw frames land in the side-channel `slot.jsonl`; unknown event types and plain stderr pass through verbatim so rate-limit/auth-failure detectors remain functional.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only gap is a stale doc string in the internal CLI help text.

The implementation is well-structured and follows the established claude/Pi patterns faithfully. The watermark logic, delta accounting, and virtual-cost wiring are all correct, and the test suite covers real smoke fixtures, multi-turn summing, respawn no-double-count, and detection-signature preservation. The one outstanding gap is that cmd/maestro/stream_split.go still describes --backend as accepting only claude in its flag help string and function comment, which doesn't reflect the new codex support.

cmd/maestro/stream_split.go — stale flag description and function comment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/maestro/stream_split.go | The CLI wiring routes codex streams correctly but the function comment and --backend flag description still mention only claude. |
| internal/worker/codex_usage.go | New file implementing ParseCodexUsage; correctly sums turn.completed events across attempts, and TotalTokens is input+output only (cached_input is a subset of input, not additive). |
| internal/worker/stream_split.go | renderCodexStreamLine added: correctly passes through non-JSON lines and unknown event types verbatim (rate-limit/auth-failure detection preserved), renders known events to human-readable text. |
| internal/worker/backend.go | argsHaveFlag refactored from argsHaveOutputFormat; codexBackend.BuildCmd appends --json when usage_stream is set and it isn't already present in cmdArgs or ExtraArgs; streamSplitForBackend extended to codex kind. |
| internal/orchestrator/orchestrator.go | updateCodexUsageFromJSONL added following the same monotonic-watermark pattern as claude and Pi paths; CostUSDBackend correctly left at 0 (cost is virtual via pricing block). |
| internal/orchestrator/orchestrator_test.go | Comprehensive codex watermark tests added: stamps usage from jsonl, no-double-count on respawn, CostUSDBackend stays 0. |
| internal/worker/codex_usage_test.go | Unit tests cover real smoke-capture fixture, no-usage-event fallback (ok=false), and multi-turn summing; correct TotalTokens = input+output only. |
| internal/worker/stream_split_test.go | Codex renderer tests added: full smoke stream round-trip, item rendering, and detection-signature preservation through plain-text and unknown-JSON-event paths. |
| internal/worker/backend_test.go | Tests verify --json opt-in, disabled-by-default, and no-duplicate-flag when operator pins --json in extra_args. |
| internal/server/cost_observability_test.go | Virtual-cost contract test: codex with pricing returns non-zero estimate, without pricing returns $0, and a self-reported claude cost still wins over the estimate. |

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: codex --json usage capture + vir..."](https://github.com/befeast/maestro/commit/d827ca3fc24e867261946e53ab1f371b50b5cd5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38809021)</sub>

<!-- /greptile_comment -->