### PR TITLE
cost-model: cache-aware split pricing (input/output/cache_read/cache_write) (#739)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -2382,7 +2382,7 @@ func historyCmd(args []string) {
 				Backend:         c.Backend,
 				Model:           sess.Model,
 				TokensUsedTotal: sess.TokensUsedTotal,
-				CostUSDEstimate: server.SessionCostEstimate(cfg, c.Backend, sess.TokensUsedTotal, sess.CostUSDBackend),
+				CostUSDEstimate: server.SessionCostEstimate(cfg, sess),
 			}
 			if c.FinishedAt != nil {
 				entry.FinishedAt = c.FinishedAt.Format(time.RFC3339)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,13 +127,32 @@ type MCPServerDef struct {
 }
 
 // BackendPricing is the per-backend cost table used by the fleet cost
-// observability rollup (#619). Rates are USD per million tokens. Both
+// observability rollup (#619). Rates are USD per million tokens. All
 // fields default to 0; a backend whose pricing is unset is reported
 // with tokens only ("price not configured") so it degrades gracefully.
 type BackendPricing struct {
 	InputUSDPerMtok  float64 `yaml:"input_usd_per_mtok,omitempty"`
 	OutputUSDPerMtok float64 `yaml:"output_usd_per_mtok,omitempty"`
+	// CacheReadUSDPerMtok prices reused (cache_read) input tokens — the bulk
+	// of an agentic run's tokens, since the full context is re-sent every
+	// turn and served from the prompt cache (#739). When unset (0) it
+	// defaults to DefaultCacheReadMultiplier × InputUSDPerMtok (Anthropic's
+	// cache-read rate). Set it to override for a non-Anthropic provider.
+	CacheReadUSDPerMtok float64 `yaml:"cache_read_usd_per_mtok,omitempty"`
+	// CacheWriteUSDPerMtok prices freshly written (cache_creation) input
+	// tokens. When unset (0) it defaults to DefaultCacheWriteMultiplier ×
+	// InputUSDPerMtok (Anthropic's 5-minute cache-write rate).
+	CacheWriteUSDPerMtok float64 `yaml:"cache_write_usd_per_mtok,omitempty"`
 }
+
+// Anthropic's published cache rates relative to the base input rate: a
+// cache read is ~10% of input, a 5-minute cache write ~125% of input.
+// These are the defaults applied when a backend leaves the cache rates
+// unset; operators on a different provider can override per-backend.
+const (
+	DefaultCacheReadMultiplier  = 0.1
+	DefaultCacheWriteMultiplier = 1.25
+)
 
 // Configured reports whether at least one rate is non-zero. Callers use
 // this to switch a backend's cost cell between a $ value and a
@@ -142,18 +161,71 @@ func (p BackendPricing) Configured() bool {
 	return p.InputUSDPerMtok > 0 || p.OutputUSDPerMtok > 0
 }
 
+// CacheReadRate returns the effective cache-read rate (USD/Mtok): the
+// configured rate when set, otherwise DefaultCacheReadMultiplier × input.
+func (p BackendPricing) CacheReadRate() float64 {
+	if p.CacheReadUSDPerMtok > 0 {
+		return p.CacheReadUSDPerMtok
+	}
+	return DefaultCacheReadMultiplier * p.InputUSDPerMtok
+}
+
+// CacheWriteRate returns the effective cache-write rate (USD/Mtok): the
+// configured rate when set, otherwise DefaultCacheWriteMultiplier × input.
+func (p BackendPricing) CacheWriteRate() float64 {
+	if p.CacheWriteUSDPerMtok > 0 {
+		return p.CacheWriteUSDPerMtok
+	}
+	return DefaultCacheWriteMultiplier * p.InputUSDPerMtok
+}
+
 // EstimateCostUSD returns the USD estimate for the given total token
 // count using a 50/50 input/output blend. Workers record a single
 // combined token counter so a finer split is not available; operators
 // who only price one side can leave the other at zero and the average
 // halves the cost as expected. Returns 0 when no rates are set or
 // tokens is non-positive.
+//
+// Prefer EstimateCostSplit when the backend stamps per-dimension tokens
+// (#739): the blend over-states an agentic run's cost by a large factor
+// because it prices cache_read tokens — most of an agentic run — at the
+// full input rate instead of the ~10% cache-read rate.
 func (p BackendPricing) EstimateCostUSD(tokens int) float64 {
 	if tokens <= 0 || !p.Configured() {
 		return 0
 	}
 	rate := (p.InputUSDPerMtok + p.OutputUSDPerMtok) / 2
 	return float64(tokens) * rate / 1_000_000.0
+}
+
+// EstimateCostSplit returns the USD estimate for a cache-aware token
+// breakdown (#739). Each dimension is priced with its own rate: input and
+// output at the configured rates, cache_read and cache_write at the
+// (defaulted) cache rates. Negative counts are treated as zero. Returns 0
+// when the backend has no pricing configured.
+//
+// This is the cache-aware replacement for the blended EstimateCostUSD: an
+// agentic run re-sends its full context every turn, so cache_read tokens
+// dominate and the ~10% cache-read rate makes the realistic cost a small
+// fraction of the naive blend.
+func (p BackendPricing) EstimateCostSplit(input, output, cacheRead, cacheWrite int) float64 {
+	if !p.Configured() {
+		return 0
+	}
+	cost := nonNegTokens(input)*p.InputUSDPerMtok +
+		nonNegTokens(output)*p.OutputUSDPerMtok +
+		nonNegTokens(cacheRead)*p.CacheReadRate() +
+		nonNegTokens(cacheWrite)*p.CacheWriteRate()
+	return cost / 1_000_000.0
+}
+
+// nonNegTokens clamps a token count to a non-negative float so a stray
+// negative counter cannot subtract from a cost estimate.
+func nonNegTokens(n int) float64 {
+	if n <= 0 {
+		return 0
+	}
+	return float64(n)
 }
 
 // BackendQuota calibrates a subscription-style backend against its

--- a/internal/config/pricing_test.go
+++ b/internal/config/pricing_test.go
@@ -48,8 +48,76 @@ func TestBackendPricing_EstimateCostUSD(t *testing.T) {
 	}
 }
 
+// TestBackendPricing_CacheRates covers the effective cache-read / cache-write
+// rates: the configured value when set, otherwise the Anthropic-default
+// multiple of the input rate (#739).
+func TestBackendPricing_CacheRates(t *testing.T) {
+	// Defaults derive from the input rate: read = 0.1×, write = 1.25×.
+	base := BackendPricing{InputUSDPerMtok: 15, OutputUSDPerMtok: 75}
+	if got := base.CacheReadRate(); math.Abs(got-1.5) > 1e-9 {
+		t.Errorf("default cache-read rate = %f, want 1.5 (0.1 × 15)", got)
+	}
+	if got := base.CacheWriteRate(); math.Abs(got-18.75) > 1e-9 {
+		t.Errorf("default cache-write rate = %f, want 18.75 (1.25 × 15)", got)
+	}
+
+	// Explicit overrides win over the input-derived default.
+	override := BackendPricing{InputUSDPerMtok: 15, CacheReadUSDPerMtok: 2, CacheWriteUSDPerMtok: 20}
+	if got := override.CacheReadRate(); got != 2 {
+		t.Errorf("override cache-read rate = %f, want 2", got)
+	}
+	if got := override.CacheWriteRate(); got != 20 {
+		t.Errorf("override cache-write rate = %f, want 20", got)
+	}
+}
+
+// TestBackendPricing_EstimateCostSplit covers the cache-aware per-dimension
+// cost (#739) and proves the cache-read discount makes a cache-heavy run's
+// split cost a small fraction of the naive blended figure (acceptance:
+// "blended vs split diverge as expected on a cache-heavy run").
+func TestBackendPricing_EstimateCostSplit(t *testing.T) {
+	price := BackendPricing{InputUSDPerMtok: 15, OutputUSDPerMtok: 75}
+
+	// Unpriced backend → 0 regardless of tokens.
+	if got := (BackendPricing{}).EstimateCostSplit(1000, 1000, 1000, 1000); got != 0 {
+		t.Errorf("unpriced split = %f, want 0", got)
+	}
+
+	// Cache-heavy agentic turn: the full context (1M tokens) is re-sent as
+	// cache_read, with a little fresh input/output/cache_write.
+	input, output, cacheRead, cacheWrite := 10_000, 5_000, 1_000_000, 50_000
+	// input 10k*15 + output 5k*75 + cacheRead 1M*1.5 + cacheWrite 50k*18.75
+	//   = (150_000 + 375_000 + 1_500_000 + 937_500) / 1e6 = 2.9625
+	wantSplit := 2.9625
+	gotSplit := price.EstimateCostSplit(input, output, cacheRead, cacheWrite)
+	if math.Abs(gotSplit-wantSplit) > 1e-6 {
+		t.Errorf("split cost = %f, want %f", gotSplit, wantSplit)
+	}
+
+	// The legacy blend prices the same tokens (1.065M total) at the 45/Mtok
+	// 50/50 blend → $47.925, ~16× the cache-aware figure.
+	total := input + output + cacheRead + cacheWrite
+	gotBlend := price.EstimateCostUSD(total)
+	if math.Abs(gotBlend-47.925) > 1e-6 {
+		t.Errorf("blended cost = %f, want 47.925", gotBlend)
+	}
+	if gotSplit >= gotBlend {
+		t.Errorf("split %f should be far below blended %f on a cache-heavy run", gotSplit, gotBlend)
+	}
+	if gotBlend/gotSplit < 5 {
+		t.Errorf("blended/split = %f, want a large divergence (>5×)", gotBlend/gotSplit)
+	}
+
+	// Negative counters are clamped to zero rather than subtracting cost.
+	if got := price.EstimateCostSplit(-100, -100, -100, -100); got != 0 {
+		t.Errorf("all-negative split = %f, want 0", got)
+	}
+}
+
 // TestParse_BackendPricingFromYAML confirms the pricing block parses
 // cleanly off the yaml config and is reachable through cfg.Model.Backends.
+// It also covers the #739 cache rates: round-tripped when set, defaulted
+// from the input rate when omitted.
 func TestParse_BackendPricingFromYAML(t *testing.T) {
 	yaml := `
 repo: owner/repo
@@ -61,8 +129,15 @@ model:
       pricing:
         input_usd_per_mtok: 15
         output_usd_per_mtok: 75
+        cache_read_usd_per_mtok: 2
+        cache_write_usd_per_mtok: 20
     codex:
       cmd: codex
+      pricing:
+        input_usd_per_mtok: 10
+        output_usd_per_mtok: 30
+    gemini:
+      cmd: gemini
 `
 	cfg, err := parse([]byte(yaml))
 	if err != nil {
@@ -78,8 +153,28 @@ model:
 	if claude.Pricing.OutputUSDPerMtok != 75 {
 		t.Errorf("claude output rate = %f, want 75", claude.Pricing.OutputUSDPerMtok)
 	}
+	// Explicit cache rates round-trip from YAML.
+	if claude.Pricing.CacheReadUSDPerMtok != 2 {
+		t.Errorf("claude cache-read rate = %f, want 2", claude.Pricing.CacheReadUSDPerMtok)
+	}
+	if claude.Pricing.CacheWriteUSDPerMtok != 20 {
+		t.Errorf("claude cache-write rate = %f, want 20", claude.Pricing.CacheWriteUSDPerMtok)
+	}
+
+	// codex omits cache rates → effective rates default off its input rate.
 	codex := cfg.Model.Backends["codex"]
-	if codex.Pricing.Configured() {
-		t.Errorf("codex pricing should not be configured")
+	if codex.Pricing.CacheReadUSDPerMtok != 0 {
+		t.Errorf("codex cache-read rate should be unset (0), got %f", codex.Pricing.CacheReadUSDPerMtok)
+	}
+	if got := codex.Pricing.CacheReadRate(); math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("codex effective cache-read rate = %f, want 1.0 (0.1 × 10)", got)
+	}
+	if got := codex.Pricing.CacheWriteRate(); math.Abs(got-12.5) > 1e-9 {
+		t.Errorf("codex effective cache-write rate = %f, want 12.5 (1.25 × 10)", got)
+	}
+
+	gemini := cfg.Model.Backends["gemini"]
+	if gemini.Pricing.Configured() {
+		t.Errorf("gemini pricing should not be configured")
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -661,6 +661,14 @@ func (o *Orchestrator) updatePiUsageFromOutput(slotName string, sess *state.Sess
 		sess.UsageTokensWatermark = usage.TotalTokens
 		sess.TokensUsedAttempt += delta
 		sess.TokensUsedTotal += delta
+		// #739: stamp the cache-aware split so the cost panel can price each
+		// dimension. The full-log parse is cumulative, so assigning (not
+		// accumulating) tracks the run total and is respawn-safe alongside the
+		// watermark guard above.
+		sess.TokensInput = usage.Input
+		sess.TokensOutput = usage.Output
+		sess.TokensCacheRead = usage.CacheRead
+		sess.TokensCacheWrite = usage.CacheWrite
 		changed = true
 	}
 	if strings.TrimSpace(usage.Model) != "" && strings.TrimSpace(sess.Model) == "" {
@@ -722,6 +730,14 @@ func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.S
 		sess.UsageTokensWatermark = usage.TotalTokens
 		sess.TokensUsedAttempt += delta
 		sess.TokensUsedTotal += delta
+		// #739: stamp the cache-aware split (input/output/cache_read/cache_write)
+		// so the cost panel can price the cache-read discount. The full-jsonl
+		// parse is cumulative, so assigning the run totals is respawn-safe
+		// alongside the watermark guard.
+		sess.TokensInput = usage.Input
+		sess.TokensOutput = usage.Output
+		sess.TokensCacheRead = usage.CacheRead
+		sess.TokensCacheWrite = usage.CacheWrite
 		changed = true
 	}
 	if strings.TrimSpace(usage.Model) != "" && strings.TrimSpace(sess.Model) == "" {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9628,6 +9628,49 @@ func TestUpdateTokensUsedFromOutput_PiBackendStampsModelTokensCost(t *testing.T)
 	}
 }
 
+// #739: a Pi-backed session's usage stream carries the cache-aware split
+// (input/output/cacheRead/cacheWrite); the orchestrator stamps each dimension
+// onto the session so the cost panel can apply the cache-read discount.
+func TestUpdateTokensUsedFromOutput_PiBackendStampsSplitTokens(t *testing.T) {
+	// Cache-heavy turn: the bulk of the tokens are reused cache_read.
+	const piLog = `{"type":"turn_end","message":{"role":"assistant","provider":"ollama","model":"glm-5.2:cloud","usage":{"input":1000,"output":500,"cacheRead":50000,"cacheWrite":2000,"totalTokens":53500,"cost":{"input":0,"output":0,"total":0}}}}
+`
+	o := &Orchestrator{
+		cfg: &config.Config{
+			StateDir: t.TempDir(),
+			Model: config.ModelConfig{
+				Default: "pi-ollama",
+				Backends: map[string]config.BackendDef{
+					"pi-ollama": {Provider: "ollama", Cmd: "pi", Model: "glm-5.2:cloud"},
+				},
+			},
+		},
+	}
+	sess := &state.Session{Backend: "pi-ollama"}
+
+	if !o.updateTokensUsedFromOutput("sup-739", sess, piLog) {
+		t.Fatal("expected a change for the Pi event stream")
+	}
+	if sess.TokensUsedTotal != 53500 {
+		t.Errorf("TokensUsedTotal = %d, want 53500 (combined total preserved)", sess.TokensUsedTotal)
+	}
+	if sess.TokensInput != 1000 {
+		t.Errorf("TokensInput = %d, want 1000", sess.TokensInput)
+	}
+	if sess.TokensOutput != 500 {
+		t.Errorf("TokensOutput = %d, want 500", sess.TokensOutput)
+	}
+	if sess.TokensCacheRead != 50000 {
+		t.Errorf("TokensCacheRead = %d, want 50000", sess.TokensCacheRead)
+	}
+	if sess.TokensCacheWrite != 2000 {
+		t.Errorf("TokensCacheWrite = %d, want 2000", sess.TokensCacheWrite)
+	}
+	if !sess.HasSplitTokens() {
+		t.Error("HasSplitTokens() = false, want true after stamping a split")
+	}
+}
+
 // #730: a non-Pi backend (claude/codex) keeps the generic token parser — the
 // Pi usage path must not engage just because the log happens to contain JSON.
 func TestUpdateTokensUsedFromOutput_ClaudeBackendKeepsGenericParser(t *testing.T) {
@@ -9843,6 +9886,18 @@ func TestUpdateTokensUsedFromOutput_ClaudeBackendStampsUsage(t *testing.T) {
 	}
 	if sess.Model != "claude-opus-4-8[1m]" {
 		t.Errorf("Model = %q, want claude-opus-4-8[1m]", sess.Model)
+	}
+	// #739: the cache-aware split is stamped per dimension so the cost panel
+	// can apply the cache-read discount (in=2487, out=4, cacheWrite=1924,
+	// cacheRead=15661 per the claudeResultFrame arg order).
+	if sess.TokensInput != 2487 || sess.TokensOutput != 4 {
+		t.Errorf("input/output = %d/%d, want 2487/4", sess.TokensInput, sess.TokensOutput)
+	}
+	if sess.TokensCacheRead != 15661 || sess.TokensCacheWrite != 1924 {
+		t.Errorf("cache read/write = %d/%d, want 15661/1924", sess.TokensCacheRead, sess.TokensCacheWrite)
+	}
+	if !sess.HasSplitTokens() {
+		t.Error("HasSplitTokens() = false, want true")
 	}
 }
 

--- a/internal/server/cost_observability.go
+++ b/internal/server/cost_observability.go
@@ -96,16 +96,6 @@ func buildFleetCostObservability(cfg *config.Config, st *state.State, now time.T
 		p, ok := pricing[backend]
 		return ok && p.Configured()
 	}
-	estimate := func(backend string, tokens int) float64 {
-		if tokens <= 0 {
-			return 0
-		}
-		p, ok := pricing[backend]
-		if !ok {
-			return 0
-		}
-		return p.EstimateCostUSD(tokens)
-	}
 
 	type backendRow struct {
 		today    fleetCostWindow
@@ -135,7 +125,7 @@ func buildFleetCostObservability(cfg *config.Config, st *state.State, now time.T
 		}
 		stamp := sessionCostTimestamp(sess)
 		backend := sess.Backend
-		usd := estimate(backend, tokens)
+		usd := sessionCostUSD(sess, pricing)
 		priced := priceConfigured(backend)
 
 		row, ok := backends[backend]
@@ -389,21 +379,48 @@ func applySessionCostEstimate(backend string, tokens int, pricing map[string]con
 	return p.EstimateCostUSD(tokens)
 }
 
-// sessionCostEstimate returns the USD cost to surface for a session. It
-// prefers the backend's self-reported cost (Pi --mode json cost.total,
-// #730) and falls back to the per-backend pricing estimate (#619) when the
-// backend did not report a cost. Zero when neither is available.
-func sessionCostEstimate(backend string, tokens int, pricing map[string]config.BackendPricing, backendCost float64) float64 {
+// sessionCostEstimate returns the USD cost to surface for a session under
+// the cache-aware precedence:
+//
+//  1. the backend's self-reported cost (Pi --mode json cost.total / claude
+//     total_cost_usd, #730) always wins;
+//  2. otherwise a cache-aware split estimate when the session carries split
+//     tokens (#739) — this prices the cache-read discount so an agentic run's
+//     cost reflects reality rather than the over-stated blend;
+//  3. otherwise the legacy blended estimate over the combined total (#619).
+//
+// Zero when the backend is unpriced/unknown and nothing was reported.
+func sessionCostEstimate(backend string, tokens, input, output, cacheRead, cacheWrite int, pricing map[string]config.BackendPricing, backendCost float64) float64 {
 	if backendCost > 0 {
 		return backendCost
+	}
+	if input > 0 || output > 0 || cacheRead > 0 || cacheWrite > 0 {
+		p, ok := pricing[backend]
+		if !ok {
+			return 0
+		}
+		return p.EstimateCostSplit(input, output, cacheRead, cacheWrite)
 	}
 	return applySessionCostEstimate(backend, tokens, pricing)
 }
 
+// sessionCostUSD applies sessionCostEstimate to a state.Session, sourcing the
+// split tokens / self-reported cost directly off the session record. Used by
+// the fleet rollup and the per-worker drawer so the cost panel reflects split
+// costing for claude/codex/Pi sessions that carry split tokens (#739).
+func sessionCostUSD(sess *state.Session, pricing map[string]config.BackendPricing) float64 {
+	if sess == nil {
+		return 0
+	}
+	return sessionCostEstimate(sess.Backend, sess.TokensUsedTotal,
+		sess.TokensInput, sess.TokensOutput, sess.TokensCacheRead, sess.TokensCacheWrite,
+		pricing, sess.CostUSDBackend)
+}
+
 // SessionCostEstimate is the exported form used by cmd/maestro (history
 // --json) so the CLI does not need to rebuild the pricing map logic. It
-// prefers the backend's self-reported cost and falls back to the configured
-// per-backend pricing estimate.
-func SessionCostEstimate(cfg *config.Config, backend string, tokens int, backendCost float64) float64 {
-	return sessionCostEstimate(backend, tokens, backendPricingMap(cfg), backendCost)
+// applies the same self-reported > split > blended precedence over the
+// session's persisted counters.
+func SessionCostEstimate(cfg *config.Config, sess *state.Session) float64 {
+	return sessionCostUSD(sess, backendPricingMap(cfg))
 }

--- a/internal/server/cost_observability_test.go
+++ b/internal/server/cost_observability_test.go
@@ -383,23 +383,151 @@ func TestApplySessionCostEstimate(t *testing.T) {
 // must come from the configured pricing block. With pricing the estimate is
 // non-zero; without it the session degrades to tokens-only ($0). A claude
 // session that DID self-report a cost still prefers that over the estimate.
+// Ported to the #739 split-token signature: codex carries no split tokens, so
+// the call falls through to the blended estimate (same result as pre-#739).
 func TestSessionCostEstimate_CodexVirtual(t *testing.T) {
 	pricing := map[string]config.BackendPricing{
 		"codex":  {InputUSDPerMtok: 1.25, OutputUSDPerMtok: 10},
 		"claude": {InputUSDPerMtok: 10, OutputUSDPerMtok: 30},
 	}
-	// codex: backendCost is always 0, so the (1.25+10)/2 = 5.625 $/Mtok blend
-	// applies → 1M tokens ≈ $5.625 (virtual, from pricing).
-	if got := sessionCostEstimate("codex", 1_000_000, pricing, 0); math.Abs(got-5.625) > 1e-6 {
+	// codex: backendCost is always 0 and no split tokens, so the
+	// (1.25+10)/2 = 5.625 $/Mtok blend applies → 1M tokens ≈ $5.625.
+	if got := sessionCostEstimate("codex", 1_000_000, 0, 0, 0, 0, pricing, 0); math.Abs(got-5.625) > 1e-6 {
 		t.Errorf("codex virtual cost = %f, want ~5.625", got)
 	}
 	// codex with no pricing → tokens-only ($0), never a self-reported cost.
-	if got := sessionCostEstimate("codex", 1_000_000, map[string]config.BackendPricing{"codex": {}}, 0); got != 0 {
+	if got := sessionCostEstimate("codex", 1_000_000, 0, 0, 0, 0, map[string]config.BackendPricing{"codex": {}}, 0); got != 0 {
 		t.Errorf("codex unpriced cost = %f, want 0", got)
 	}
 	// A self-reported cost (e.g. claude total_cost_usd) still wins over pricing.
-	if got := sessionCostEstimate("claude", 1_000_000, pricing, 0.04); math.Abs(got-0.04) > 1e-9 {
+	if got := sessionCostEstimate("claude", 1_000_000, 0, 0, 0, 0, pricing, 0.04); math.Abs(got-0.04) > 1e-9 {
 		t.Errorf("self-reported cost = %f, want 0.04 (prefer backend cost)", got)
+	}
+}
+
+// TestBuildFleetCostObservability_SplitCosting proves the rollup prices a
+// session carrying cache-aware split tokens (#739) with EstimateCostSplit —
+// the cache-read discount makes the panel's USD a small fraction of the naive
+// blended figure on a cache-heavy run.
+func TestBuildFleetCostObservability_SplitCosting(t *testing.T) {
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	dayStart := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Backends: map[string]config.BackendDef{
+				"claude": {Pricing: config.BackendPricing{InputUSDPerMtok: 15, OutputUSDPerMtok: 75}},
+			},
+		},
+	}
+	st := &state.State{Sessions: map[string]*state.Session{
+		// Cache-heavy split tokens, no self-reported cost → split estimate.
+		"split-1": {
+			IssueNumber:      1,
+			IssueTitle:       "cache-heavy run",
+			Backend:          "claude",
+			Status:           state.StatusDone,
+			StartedAt:        dayStart.Add(time.Hour),
+			FinishedAt:       timePtr(dayStart.Add(2 * time.Hour)),
+			TokensUsedTotal:  1_065_000,
+			TokensInput:      10_000,
+			TokensOutput:     5_000,
+			TokensCacheRead:  1_000_000,
+			TokensCacheWrite: 50_000,
+		},
+	}}
+
+	got := buildFleetCostObservability(cfg, st, now)
+
+	// Cache-aware split: $2.9625, NOT the blended $47.925.
+	if math.Abs(got.WindowToday.USD-2.9625) > 1e-6 {
+		t.Errorf("today USD = %f, want ~2.9625 (cache-aware split, not blended $47.925)", got.WindowToday.USD)
+	}
+	if math.Abs(got.Lifetime.USD-2.9625) > 1e-6 {
+		t.Errorf("lifetime USD = %f, want ~2.9625", got.Lifetime.USD)
+	}
+	// Tokens still report the full combined total for the panel.
+	if got.WindowToday.Tokens != 1_065_000 {
+		t.Errorf("today tokens = %d, want 1065000 (combined total preserved)", got.WindowToday.Tokens)
+	}
+	// The per-issue rollup carries the same split-priced figure.
+	if len(got.PerIssue) != 1 {
+		t.Fatalf("per_issue rows = %d, want 1", len(got.PerIssue))
+	}
+	if math.Abs(got.PerIssue[0].USD-2.9625) > 1e-6 {
+		t.Errorf("issue USD = %f, want ~2.9625", got.PerIssue[0].USD)
+	}
+}
+
+// TestBuildFleetCostObservability_SelfReportedCostWins proves the backend's
+// self-reported cost (#730) takes precedence over both the split and blended
+// estimates in the rollup (acceptance: "Self-reported cost still takes
+// precedence over the estimate").
+func TestBuildFleetCostObservability_SelfReportedCostWins(t *testing.T) {
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	dayStart := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Backends: map[string]config.BackendDef{
+				"claude": {Pricing: config.BackendPricing{InputUSDPerMtok: 15, OutputUSDPerMtok: 75}},
+			},
+		},
+	}
+	st := &state.State{Sessions: map[string]*state.Session{
+		"reported-1": {
+			IssueNumber:      1,
+			Backend:          "claude",
+			Status:           state.StatusDone,
+			StartedAt:        dayStart.Add(time.Hour),
+			FinishedAt:       timePtr(dayStart.Add(2 * time.Hour)),
+			TokensUsedTotal:  1_065_000,
+			TokensInput:      10_000,
+			TokensOutput:     5_000,
+			TokensCacheRead:  1_000_000,
+			TokensCacheWrite: 50_000,
+			CostUSDBackend:   1.23, // claude total_cost_usd
+		},
+	}}
+
+	got := buildFleetCostObservability(cfg, st, now)
+	if math.Abs(got.WindowToday.USD-1.23) > 1e-6 {
+		t.Errorf("today USD = %f, want 1.23 (self-reported wins over split/blended)", got.WindowToday.USD)
+	}
+}
+
+// TestSessionCostEstimate_Precedence covers the per-session cost helper's
+// self-reported > split > blended precedence (#739).
+func TestSessionCostEstimate_Precedence(t *testing.T) {
+	pricing := map[string]config.BackendPricing{
+		"claude": {InputUSDPerMtok: 15, OutputUSDPerMtok: 75},
+		"codex":  {},
+	}
+	const (
+		total      = 1_065_000
+		input      = 10_000
+		output     = 5_000
+		cacheRead  = 1_000_000
+		cacheWrite = 50_000
+	)
+
+	// Self-reported cost wins over everything else.
+	if got := sessionCostEstimate("claude", total, input, output, cacheRead, cacheWrite, pricing, 0.99); got != 0.99 {
+		t.Errorf("with self-reported cost = %f, want 0.99", got)
+	}
+	// Split tokens present, no self-reported cost → cache-aware split.
+	if got := sessionCostEstimate("claude", total, input, output, cacheRead, cacheWrite, pricing, 0); math.Abs(got-2.9625) > 1e-6 {
+		t.Errorf("split estimate = %f, want ~2.9625", got)
+	}
+	// No split tokens → legacy blended estimate over the combined total.
+	if got := sessionCostEstimate("claude", 1_000_000, 0, 0, 0, 0, pricing, 0); math.Abs(got-45.0) > 1e-6 {
+		t.Errorf("blended estimate = %f, want 45.00", got)
+	}
+	// Unpriced backend with split tokens → 0.
+	if got := sessionCostEstimate("codex", total, input, output, cacheRead, cacheWrite, pricing, 0); got != 0 {
+		t.Errorf("unpriced split = %f, want 0", got)
+	}
+	// Unknown backend with split tokens → 0.
+	if got := sessionCostEstimate("unknown", total, input, output, cacheRead, cacheWrite, pricing, 0); got != 0 {
+		t.Errorf("unknown backend split = %f, want 0", got)
 	}
 }
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -880,7 +880,7 @@ func (s *FleetServer) handleFleetWorker(w http.ResponseWriter, r *http.Request) 
 	infos := []sessionInfo{makeSessionInfo(project.cfg.Repo, slot, sess)}
 	applySupervisorAttention(infos, st.LatestSupervisorDecision())
 	pricing := backendPricingMap(project.cfg)
-	infos[0].CostUSDEstimate = sessionCostEstimate(infos[0].Backend, infos[0].TokensUsedTotal, pricing, infos[0].CostUSDBackend)
+	infos[0].CostUSDEstimate = sessionCostUSD(sess, pricing)
 	infos[0].Actions = workerActionAffordances(projectState.ReadOnly, "/api/v1/fleet/actions", infos[0])
 	worker := makeFleetWorkerState(projectState, infos[0])
 	lines := parsePositiveInt(r.URL.Query().Get("lines"), 260)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -294,6 +294,13 @@ type sessionInfo struct {
 	PRURL             string `json:"pr_url,omitempty"`
 	TokensUsedAttempt int    `json:"tokens_used_attempt"`
 	TokensUsedTotal   int    `json:"tokens_used_total"`
+	// #739: cache-aware split token breakdown when the backend stamped it
+	// (claude stream-json / Pi). Surfaced so the cost panel can show the
+	// cache-read discount; zero for backends that report only a combined total.
+	TokensInput      int `json:"tokens_input,omitempty"`
+	TokensOutput     int `json:"tokens_output,omitempty"`
+	TokensCacheRead  int `json:"tokens_cache_read,omitempty"`
+	TokensCacheWrite int `json:"tokens_cache_write,omitempty"`
 	// CostUSDEstimate is the $ estimate for this session's
 	// TokensUsedTotal under the configured per-backend pricing (#619),
 	// OR the backend's self-reported cost when present (#730, Pi
@@ -354,6 +361,10 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 		PRURL:             githubPRURL(repo, sess.PRNumber),
 		TokensUsedAttempt: sess.TokensUsedAttempt,
 		TokensUsedTotal:   sess.TokensUsedTotal,
+		TokensInput:       sess.TokensInput,
+		TokensOutput:      sess.TokensOutput,
+		TokensCacheRead:   sess.TokensCacheRead,
+		TokensCacheWrite:  sess.TokensCacheWrite,
 		CostUSDBackend:    sess.CostUSDBackend,
 		StartedAt:         sess.StartedAt.Format(time.RFC3339),
 		Worktree:          sess.Worktree,
@@ -974,7 +985,7 @@ func buildStateResponse(cfg *config.Config, st *state.State) stateResponse {
 	pricing := backendPricingMap(cfg)
 	var activeTokens, totalTokens int
 	for _, info := range sessionInfosWithActions(cfg.Repo, st, cfg.Server.ReadOnly, "/api/v1/actions") {
-		info.CostUSDEstimate = sessionCostEstimate(info.Backend, info.TokensUsedTotal, pricing, info.CostUSDBackend)
+		info.CostUSDEstimate = sessionCostEstimate(info.Backend, info.TokensUsedTotal, info.TokensInput, info.TokensOutput, info.TokensCacheRead, info.TokensCacheWrite, pricing, info.CostUSDBackend)
 		resp.All = append(resp.All, info)
 		summaryStatus := info.Status
 		if info.DisplayStatus != "" {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -148,21 +148,31 @@ type Session struct {
 	// usage stream (Pi --mode json event stream). Empty/zero for backends
 	// that do not self-report; the fleet cost panel then falls back to the
 	// configured per-backend pricing estimate.
-	Model                       string            `json:"model,omitempty"`                  // model the backend reported for this run (e.g. glm-5.2:cloud, claude-opus-4-8)
-	CostUSDBackend              float64           `json:"cost_usd_backend,omitempty"`       // USD cost the backend self-reported (Pi cost.total / claude total_cost_usd)
-	UsageTokensWatermark        int               `json:"usage_tokens_watermark,omitempty"` // #730/#737: high-water mark of a backend usage stream's full-log cumulative token count (Pi --mode json, claude stream-json); persists across respawns so re-parsing the appended log/jsonl does not double-count prior attempts
-	LongRunning                 bool              `json:"long_running,omitempty"`
-	RebaseAttempted             bool              `json:"rebase_attempted,omitempty"`
-	NotifiedCIFail              bool              `json:"notified_ci_fail,omitempty"`           // deprecated: use LastNotifiedStatus
-	LastNotifiedStatus          string            `json:"last_notified_status,omitempty"`       // dedup: last notification type sent
-	LiveVerificationNotified    bool              `json:"live_verification_notified,omitempty"` // #570 one-shot: hold-for-live-verification board sync + operator notification already fired
-	RetryCount                  int               `json:"retry_count,omitempty"`                // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
-	MaintenanceRetryCount       int               `json:"maintenance_retry_count,omitempty"`    // bounded post-PR maintenance attempts (review feedback / rebase conflict repair), separate from implementation retries
-	NextRetryAt                 *time.Time        `json:"next_retry_at,omitempty"`
-	LastOutputHash              string            `json:"last_output_hash,omitempty"`
-	LastOutputChangedAt         time.Time         `json:"last_output_changed_at,omitempty"`
-	TokensUsedAttempt           int               `json:"tokens_used_attempt,omitempty"`            // tokens consumed in current attempt (reset on respawn)
-	TokensUsedTotal             int               `json:"tokens_used_total,omitempty"`              // cumulative tokens across the issue lifecycle
+	Model                    string     `json:"model,omitempty"`                  // model the backend reported for this run (e.g. glm-5.2:cloud, claude-opus-4-8)
+	CostUSDBackend           float64    `json:"cost_usd_backend,omitempty"`       // USD cost the backend self-reported (Pi cost.total / claude total_cost_usd)
+	UsageTokensWatermark     int        `json:"usage_tokens_watermark,omitempty"` // #730/#737: high-water mark of a backend usage stream's full-log cumulative token count (Pi --mode json, claude stream-json); persists across respawns so re-parsing the appended log/jsonl does not double-count prior attempts
+	LongRunning              bool       `json:"long_running,omitempty"`
+	RebaseAttempted          bool       `json:"rebase_attempted,omitempty"`
+	NotifiedCIFail           bool       `json:"notified_ci_fail,omitempty"`           // deprecated: use LastNotifiedStatus
+	LastNotifiedStatus       string     `json:"last_notified_status,omitempty"`       // dedup: last notification type sent
+	LiveVerificationNotified bool       `json:"live_verification_notified,omitempty"` // #570 one-shot: hold-for-live-verification board sync + operator notification already fired
+	RetryCount               int        `json:"retry_count,omitempty"`                // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
+	MaintenanceRetryCount    int        `json:"maintenance_retry_count,omitempty"`    // bounded post-PR maintenance attempts (review feedback / rebase conflict repair), separate from implementation retries
+	NextRetryAt              *time.Time `json:"next_retry_at,omitempty"`
+	LastOutputHash           string     `json:"last_output_hash,omitempty"`
+	LastOutputChangedAt      time.Time  `json:"last_output_changed_at,omitempty"`
+	TokensUsedAttempt        int        `json:"tokens_used_attempt,omitempty"` // tokens consumed in current attempt (reset on respawn)
+	TokensUsedTotal          int        `json:"tokens_used_total,omitempty"`   // cumulative tokens across the issue lifecycle (sum of the split dimensions below; kept for back-compat)
+	// #739: cache-aware split token counters stamped from a backend usage
+	// stream (claude stream-json / Pi --mode json). Cumulative run totals so
+	// the cost panel can price each dimension separately — cache_read tokens
+	// dominate an agentic run and cost ~10% of input, so blending them into
+	// TokensUsedTotal over-states cost. Zero for backends that do not stamp a
+	// split; the cost rollup then falls back to the blended estimate.
+	TokensInput                 int               `json:"tokens_input,omitempty"`                   // cumulative non-cached input tokens
+	TokensOutput                int               `json:"tokens_output,omitempty"`                  // cumulative output (generated) tokens
+	TokensCacheRead             int               `json:"tokens_cache_read,omitempty"`              // cumulative cache-read (reused context) tokens, discounted
+	TokensCacheWrite            int               `json:"tokens_cache_write,omitempty"`             // cumulative cache-write (cache creation) tokens
 	QuotaTokensAccounted        int               `json:"quota_tokens_accounted,omitempty"`         // portion of TokensUsedTotal already accrued into BackendQuotaUsage windows (#704)
 	RateLimitHit                bool              `json:"rate_limit_hit,omitempty"`                 // true when the worker died on a transient backend block (provider limit or auth failure, #693); excludes the session from the per-issue retry budget
 	TriedBackends               []string          `json:"tried_backends,omitempty"`                 // backends already attempted (for backend-failure fallback)
@@ -535,6 +545,17 @@ func (s *Session) UnmarshalJSON(data []byte) error {
 		s.TokensUsedTotal = aux.LegacyTokensUsed
 	}
 	return nil
+}
+
+// HasSplitTokens reports whether the session carries the cache-aware split
+// token breakdown stamped from a backend usage stream (#739). When true the
+// cost rollup prices each dimension separately (EstimateCostSplit); when
+// false it falls back to the blended estimate over TokensUsedTotal.
+func (s *Session) HasSplitTokens() bool {
+	if s == nil {
+		return false
+	}
+	return s.TokensInput > 0 || s.TokensOutput > 0 || s.TokensCacheRead > 0 || s.TokensCacheWrite > 0
 }
 
 // Mission tracks a decomposed epic and its child issues.


### PR DESCRIPTION
Implements #739

## Changes
- **config** (`internal/config/config.go`): `BackendPricing` gains optional `cache_read_usd_per_mtok` / `cache_write_usd_per_mtok` (default `0.1×` / `1.25×` input — Anthropic rates, overridable) plus `CacheReadRate()`/`CacheWriteRate()` and a new `EstimateCostSplit(input, output, cacheRead, cacheWrite)`. The blended `EstimateCostUSD(total)` stays for backends without a split.
- **state** (`internal/state/state.go`): persist split tokens on `Session` (`tokens_input`/`tokens_output`/`tokens_cache_read`/`tokens_cache_write`). `TokensUsedTotal` remains the combined sum (back-compat). Adds `HasSplitTokens()`.
- **orchestrator** (`internal/orchestrator/orchestrator.go`): the claude (stream-json) and Pi (`--mode json`) usage stamping now records the per-dimension split alongside the existing total/cost.
- **cost panel** (`internal/server/cost_observability.go`, `server.go`, `fleet.go`): cost precedence is now self-reported cost → cache-aware split (when split tokens present) → legacy blended fallback. Applied across the fleet rollup, per-issue, per-backend and per-worker estimates; split tokens are surfaced on the worker/session API.

## Why
In agentic runs the full context is re-sent every turn and is overwhelmingly `cache_read` (≈10% of input). The blended model priced those at the full input rate, over-stating cost by a large factor; the split model reflects the cache discount.

## Testing
- `internal/config`: `EstimateCostSplit` blended-vs-split divergence on a cache-heavy run; cache-rate defaults/overrides; YAML round-trip of the new fields.
- `internal/server`: rollup uses split costing; self-reported cost still wins; per-session precedence helper.
- `internal/orchestrator`: claude + Pi stamping records the split per dimension.
- `go build ./cmd/maestro/` and `go test ./...` green; `.maestro/verify.sh` passes.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the blended 50/50 input/output cost estimate with a cache-aware split model that prices `cache_read`, `cache_write`, `input`, and `output` tokens at their own rates. In agentic runs where the full context is re-sent every turn as `cache_read` (≈10% of the base input rate), the old blended estimate overstated cost by up to ~16×.

- **Config layer** (`config.go`): `BackendPricing` gains optional `cache_read_usd_per_mtok` / `cache_write_usd_per_mtok` fields defaulting to Anthropic's 0.1×/1.25× multipliers; `EstimateCostSplit` prices each dimension independently, while `EstimateCostUSD` is kept for backends that only report a combined total.
- **State + orchestrator** (`state.go`, `orchestrator.go`): four new `TokensInput/Output/CacheRead/CacheWrite` fields are stamped from the backend's usage stream (cumulative assignment inside the watermark-guarded block) for both Claude JSONL and Pi `--mode json` paths.
- **Server / cost panel** (`cost_observability.go`, `fleet.go`, `server.go`, `main.go`): a three-tier precedence (self-reported cost → split estimate → blended fallback) is applied uniformly across the fleet rollup, per-session drawer, and `history --json` CLI; split token fields are surfaced on the session API for frontend use.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are additive and back-compatible; existing sessions without split tokens continue to use the blended estimate unchanged.

The change is well-scoped: new JSON fields are omitempty so persisted state is forward- and backward-compatible, the three-tier precedence degrades gracefully at every level, and the test suite directly validates the cache-heavy scenario that motivated the change (blended $47.92 vs split $2.96, >5× divergence asserted). No existing code paths are broken and the watermark-guarded assignment keeps split tokens consistent with the delta-accumulated total.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds CacheReadUSDPerMtok/CacheWriteUSDPerMtok fields, CacheReadRate()/CacheWriteRate() helpers with Anthropic-default multipliers (0.1×/1.25×), and EstimateCostSplit() with negative-token clamping; well-structured and back-compat |
| internal/config/pricing_test.go | Adds thorough tests for cache rate defaults/overrides, EstimateCostSplit correctness, and YAML round-trip of new fields; blended-vs-split divergence assertion (>5×) directly proves the motivating use case |
| internal/state/state.go | Adds four TokensInput/Output/CacheRead/CacheWrite fields with omitempty JSON tags (back-compat), and HasSplitTokens() nil-safe helper; comment accurately describes cumulative semantics |
| internal/orchestrator/orchestrator.go | Both Pi and Claude usage paths now assign the four split-token dimensions inside the watermark-guarded block, so the cumulative assignment is consistent with the delta-accumulation of TokensUsedTotal |
| internal/orchestrator/orchestrator_test.go | New Pi and Claude split-stamp tests verify all four dimensions and HasSplitTokens(); cache-heavy fixture with cacheRead dominating input validates the realistic scenario |
| internal/server/cost_observability.go | Replaces the local estimate closure with sessionCostUSD(); refactors sessionCostEstimate to the three-tier precedence (self-reported > split > blended); removes the now-redundant estimate closure cleanly |
| internal/server/cost_observability_test.go | Three new rollup tests cover split costing ($2.9625 vs $47.925 blended), self-reported-cost precedence, and the full five-case precedence chain |
| internal/server/fleet.go | Single-line change: per-worker drawer now uses sessionCostUSD(sess, pricing) instead of the old 4-arg sessionCostEstimate, consistently applying the three-tier precedence |
| internal/server/server.go | Adds four TokensInput/Output/CacheRead/CacheWrite fields to sessionInfo (omitempty), copies them in makeSessionInfo, and passes them to the updated sessionCostEstimate in buildStateResponse |
| cmd/maestro/main.go | historyCmd updated to pass the full session to the new SessionCostEstimate(cfg, sess) signature so the CLI benefits from the same three-tier costing as the fleet panel |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/server/cost_observability.go`, line 37-49 ([link](https://github.com/befeast/maestro/blob/eed3f70d8a1cbcad21905ad939ce21dd473c45a0/internal/server/cost_observability.go#L37-L49)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale struct comment after adding split pricing**

   The `fleetCostWindow` doc comment still says "USD is the estimate computed via `BackendPricing.EstimateCostUSD`", but after this PR the value can come from `EstimateCostSplit` (or the self-reported backend cost). A reader of the struct definition will have an incorrect mental model of where `USD` originates.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/cost_observability.go
   Line: 37-49

   Comment:
   **Stale struct comment after adding split pricing**

   The `fleetCostWindow` doc comment still says "USD is the estimate computed via `BackendPricing.EstimateCostUSD`", but after this PR the value can come from `EstimateCostSplit` (or the self-reported backend cost). A reader of the struct definition will have an incorrect mental model of where `USD` originates.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `internal/server/cost_observability.go`, line 51-63 ([link](https://github.com/befeast/maestro/blob/eed3f70d8a1cbcad21905ad939ce21dd473c45a0/internal/server/cost_observability.go#L51-L63)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cache rate fields not surfaced in the `fleetCostBackend` API response**

   `fleetCostBackend` exposes `input_usd_per_mtok` and `output_usd_per_mtok` for display in the cost panel, but the new `CacheReadUSDPerMtok` / `CacheWriteUSDPerMtok` are absent. Any frontend or operator tooling that wants to show "cache-read rate: $X/Mtok" for a backend currently has no way to retrieve the effective rates from the API. This may be intentional (the USD totals already reflect the correct pricing), but it means cache-rate overrides are opaque to consumers of this endpoint.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/cost_observability.go
   Line: 51-63

   Comment:
   **Cache rate fields not surfaced in the `fleetCostBackend` API response**

   `fleetCostBackend` exposes `input_usd_per_mtok` and `output_usd_per_mtok` for display in the cost panel, but the new `CacheReadUSDPerMtok` / `CacheWriteUSDPerMtok` are absent. Any frontend or operator tooling that wants to show "cache-read rate: $X/Mtok" for a backend currently has no way to retrieve the effective rates from the API. This may be intentional (the USD totals already reflect the correct pricing), but it means cache-rate overrides are opaque to consumers of this endpoint.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["cost-model: cache-aware split pricing (i..."](https://github.com/befeast/maestro/commit/2c9d21636157947a75fd6e99d17c79c9c48301ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38809124)</sub>

<!-- /greptile_comment -->