### PR TITLE
ci: reusable agent-lint workflow — enforce worker discipline rules in CI (closing keywords, artifacts, secrets, drafts) (#707)

### DIFF
--- a/.github/actions/agent-lint/action.yml
+++ b/.github/actions/agent-lint/action.yml
@@ -1,0 +1,40 @@
+name: agent-lint
+description: >-
+  Enforce the fleet's agent anti-pattern rules on a pull request: no
+  auto-closing keywords, no committed artifacts, no leaked secrets, and a
+  warning on drafts that lack an explicit WIP/Partial marker.
+
+inputs:
+  pr-number:
+    description: Pull request number to lint. Defaults to the triggering pull_request.
+    required: false
+    default: ${{ github.event.pull_request.number }}
+  repo:
+    description: owner/repo to read the PR from. Defaults to the current repository.
+    required: false
+    default: ${{ github.repository }}
+  artifact-allowlist:
+    description: Space- or newline-separated extra glob patterns exempt from the artifact check.
+    required: false
+    default: ""
+  override-label:
+    description: PR label that downgrades hard failures to warnings.
+    required: false
+    default: "agent-lint:override"
+  github-token:
+    description: Token used to read PR metadata and diff (needs contents:read + pull-requests:read).
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: agent-lint
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        AGENT_LINT_PR: ${{ inputs.pr-number }}
+        AGENT_LINT_REPO: ${{ inputs.repo }}
+        AGENT_LINT_ARTIFACT_ALLOWLIST: ${{ inputs.artifact-allowlist }}
+        AGENT_LINT_OVERRIDE_LABEL: ${{ inputs.override-label }}
+      run: bash "${GITHUB_ACTION_PATH}/agent-lint.sh"

--- a/.github/actions/agent-lint/agent-lint.sh
+++ b/.github/actions/agent-lint/agent-lint.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+#
+# agent-lint.sh — enforce the fleet's agent anti-pattern rules on a pull request.
+#
+# Worker-discipline rules live as prose in the worker prompt; rules enforced only
+# in prompts are not enforced at all. This script encodes them as CI checks:
+#
+#   1. closing keywords — fail if the PR title/body uses a GitHub auto-closing
+#      keyword (close/fix/resolve …) referencing an issue. Use `Refs #N` or
+#      `Implements #N` instead.
+#   2. diff hygiene     — fail if the diff adds forbidden artifacts
+#      (`.maestro/`, `tmp/`, `_tmp/`, `*.log`, `*.logs`, `*.test`, `*.test.json`).
+#   3. secret scan      — fail if added diff lines contain common secret shapes
+#      (sk-ant-…, ghp_…, AKIA…, BEGIN PRIVATE KEY, …).
+#   4. draft check      — WARN (never fail) if the PR is a draft without an
+#      explicit WIP/Partial marker (the deliberate-draft flow from #697).
+#
+# Escape hatch: a hard failure (checks 1–3) is downgraded to a warning when the
+# PR carries the override label (default `agent-lint:override`) or the body
+# marker `agent-lint:allow` / `agent-lint:ignore`. The draft check is warn-only.
+#
+# Modes:
+#   --self-test       run built-in fixtures; each forbidden pattern must trip its
+#                     check and a clean input must pass. Exit non-zero on any
+#                     unexpected result. No network/`gh` needed.
+#   (AGENT_LINT_PR set)   fetch the PR title/body/draft/labels/diff via `gh` and
+#                         lint it. Used by the composite action in CI.
+#   (otherwise)       offline dry-run: lint the values passed directly via
+#                     AGENT_LINT_TITLE / _BODY / _DRAFT / _LABELS / _FILES / _DIFF.
+#
+set -uo pipefail
+
+# ---- inputs / config --------------------------------------------------------
+REPO="${AGENT_LINT_REPO:-${GITHUB_REPOSITORY:-}}"
+PR="${AGENT_LINT_PR:-}"
+OVERRIDE_LABEL="${AGENT_LINT_OVERRIDE_LABEL:-agent-lint:override}"
+ALLOWLIST="${AGENT_LINT_ARTIFACT_ALLOWLIST:-}"
+
+# Lint subjects (populated by gh-fetch, offline env, or self-test fixtures).
+TITLE="" BODY="" DRAFT="false" LABELS="" FILES="" DIFF=""
+
+# ---- helpers ----------------------------------------------------------------
+
+# mask hides the bulk of a matched token so secrets are never echoed in full.
+mask() {
+	local s="$1" L=${#1}
+	if (( L <= 6 )); then printf '******'; else printf '%s…%s' "${s:0:4}" "${s: -2}"; fi
+}
+
+lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# is_artifact reports whether a committed path is a forbidden build/run artifact.
+is_artifact() {
+	case "$1" in
+		.maestro/*|*/.maestro/*) return 0 ;;
+		tmp/*|*/tmp/*|_tmp/*|*/_tmp/*) return 0 ;;
+		*.log|*.logs|*.test|*.test.json) return 0 ;;
+	esac
+	return 1
+}
+
+# is_allowlisted exempts a path that matches any configured allowlist glob.
+is_allowlisted() {
+	local f="$1" pat
+	[[ -z "${ALLOWLIST//[[:space:]]/}" ]] && return 1
+	for pat in $ALLOWLIST; do
+		# shellcheck disable=SC2053
+		[[ "$f" == $pat ]] && return 0
+	done
+	return 1
+}
+
+# has_partial_marker mirrors orchestrator.prHasDeliberateDraftMarker (#697).
+has_partial_marker() {
+	local t b
+	t="$(lc "$(printf '%s' "$TITLE" | sed 's/^[[:space:]]*//')")"
+	b="$(lc "$BODY")"
+	case "$t" in
+		*'[wip]'*|*'[partial]'*) return 0 ;;
+		wip:*|'wip '*|partial:*|draft:*) return 0 ;;
+		wip|partial) return 0 ;;
+	esac
+	case "$b" in
+		*maestro:partial*|*maestro:wip*) return 0 ;;
+	esac
+	return 1
+}
+
+# override_active reports the documented false-positive escape hatch.
+override_active() {
+	local lbl
+	while IFS= read -r lbl; do
+		[[ "$lbl" == "$OVERRIDE_LABEL" ]] && return 0
+	done <<<"$LABELS"
+	case "$(lc "$BODY")" in
+		*'agent-lint:allow'*|*'agent-lint:ignore'*) return 0 ;;
+	esac
+	return 1
+}
+
+# ---- checks (return 1 on a hard violation, 0 otherwise) ---------------------
+
+# 1. auto-closing keywords referencing an issue, in the PR title or body.
+check_closing() {
+	local blob hits rc=0
+	blob="$(printf '%s\n%s' "$TITLE" "$BODY")"
+	local re='\b(close[sd]?|fix|fixes|fixed|resolve[sd]?)\b[[:space:]]*:?[[:space:]]*(#[0-9]+|gh-[0-9]+|https?://github\.com/[^[:space:]]+/issues/[0-9]+)'
+	hits="$(printf '%s' "$blob" | grep -inE "$re" || true)"
+	if [[ -n "$hits" ]]; then
+		echo "::error::agent-lint: PR title/body uses a GitHub auto-closing keyword referencing an issue. Use 'Refs #N' or 'Implements #N' instead."
+		while IFS= read -r l; do [[ -n "$l" ]] && echo "  ↳ ${l}"; done <<<"$hits"
+		rc=1
+	fi
+	return $rc
+}
+
+# 2. forbidden artifacts committed in the diff.
+check_artifacts() {
+	local f rc=0
+	[[ -z "${FILES//[[:space:]]/}" ]] && return 0
+	while IFS= read -r f; do
+		[[ -z "$f" ]] && continue
+		is_allowlisted "$f" && continue
+		if is_artifact "$f"; then
+			echo "::error::agent-lint: forbidden artifact committed: ${f}"
+			rc=1
+		fi
+	done <<<"$FILES"
+	return $rc
+}
+
+# 3. common secret shapes in added diff lines.
+check_secrets() {
+	local added entry name pat hits h rc=0
+	added="$(printf '%s\n' "$DIFF" | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+	[[ -z "$added" ]] && return 0
+	for entry in \
+		"anthropic-key|sk-ant-[A-Za-z0-9_-]{8,}" \
+		"github-token|(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}" \
+		"github-pat|github_pat_[A-Za-z0-9_]{20,}" \
+		"aws-access-key|A(KIA|SIA)[0-9A-Z]{16}" \
+		"slack-token|xox[baprs]-[A-Za-z0-9-]{10,}" \
+		"google-api-key|AIza[0-9A-Za-z_-]{35}" \
+		"private-key|-----BEGIN [A-Z ]*PRIVATE KEY-----"; do
+		name="${entry%%|*}"
+		pat="${entry#*|}"
+		hits="$(printf '%s\n' "$added" | grep -oE -e "$pat" || true)"
+		if [[ -n "$hits" ]]; then
+			echo "::error::agent-lint: possible secret detected (${name}) in added diff lines."
+			while IFS= read -r h; do [[ -n "$h" ]] && echo "  ↳ $(mask "$h")"; done <<<"$hits"
+			rc=1
+		fi
+	done
+	return $rc
+}
+
+# 4. draft without a deliberate marker — warning only, never blocks.
+check_draft() {
+	[[ "$DRAFT" != "true" ]] && return 0
+	if has_partial_marker; then
+		echo "::notice::agent-lint: draft PR carries a deliberate WIP/Partial marker — OK."
+		return 0
+	fi
+	echo "::warning::agent-lint: PR is a draft without a WIP/Partial marker. If this is deliberate partial work, prefix the title with [Partial] and add '<!-- maestro:partial -->' to the body; otherwise mark it ready for review."
+	return 0
+}
+
+# ---- orchestration ----------------------------------------------------------
+
+run_lint() {
+	local errors=0
+	check_closing   || errors=$((errors + 1))
+	check_artifacts || errors=$((errors + 1))
+	check_secrets   || errors=$((errors + 1))
+	check_draft || true   # warn-only
+
+	if (( errors > 0 )); then
+		if override_active; then
+			echo "::notice::agent-lint: ${errors} hard check(s) failed but the override is active (label '${OVERRIDE_LABEL}' or body marker 'agent-lint:allow') — not blocking."
+			return 0
+		fi
+		echo "::error::agent-lint: ${errors} check(s) failed (see annotations above). To override (use sparingly), add the '${OVERRIDE_LABEL}' label or '<!-- agent-lint:allow -->' to the PR body."
+		return 1
+	fi
+	echo "agent-lint: all checks passed."
+	return 0
+}
+
+# fetch_pr loads the lint subjects from a real PR via the gh CLI.
+fetch_pr() {
+	if [[ -z "$REPO" || -z "$PR" ]]; then
+		echo "::notice::agent-lint: no pull_request context (AGENT_LINT_PR/REPO unset) — skipping."
+		exit 0
+	fi
+	local meta
+	if ! meta="$(gh pr view "$PR" --repo "$REPO" --json title,body,isDraft,labels 2>&1)"; then
+		echo "::error::agent-lint: unable to read PR #${PR} in ${REPO}: ${meta}"
+		exit 1
+	fi
+	TITLE="$(printf '%s' "$meta" | jq -r '.title // ""')"
+	BODY="$(printf '%s' "$meta" | jq -r '.body // ""')"
+	DRAFT="$(printf '%s' "$meta" | jq -r '.isDraft // false')"
+	LABELS="$(printf '%s' "$meta" | jq -r '.labels[].name')"
+	FILES="$(gh pr diff "$PR" --repo "$REPO" --name-only 2>/dev/null || true)"
+	DIFF="$(gh pr diff "$PR" --repo "$REPO" 2>/dev/null || true)"
+}
+
+# ---- self-test --------------------------------------------------------------
+
+self_test() {
+	local fails=0
+	_reset() { TITLE="" BODY="" DRAFT="false" LABELS="" FILES="" DIFF=""; ALLOWLIST=""; }
+	_expect() {
+		local desc="$1" want="$2" fn="$3" rc
+		"$fn" >/dev/null 2>&1
+		rc=$?
+		if [[ "$rc" == "$want" ]]; then
+			echo "ok   - $desc"
+		else
+			echo "FAIL - $desc (rc=$rc, want $want)"
+			fails=$((fails + 1))
+		fi
+	}
+
+	# 1. closing keywords
+	_reset; BODY="Some change. Fixes #123"; _expect "closing: 'Fixes #123' trips" 1 check_closing
+	_reset; BODY="Closes https://github.com/o/r/issues/9"; _expect "closing: issue URL trips" 1 check_closing
+	_reset; TITLE="feat: thing (#5)"; BODY="Refs #5"; _expect "closing: 'Refs #5' passes" 0 check_closing
+	_reset; BODY="Implements #5; this resolves the layout but closes nothing concrete"; _expect "closing: keyword without issue ref passes" 0 check_closing
+
+	# 2. diff hygiene
+	_reset; FILES=".maestro/verify.sh"; _expect "artifact: .maestro/ trips" 1 check_artifacts
+	_reset; FILES=$'internal/x.go\ndebug.log'; _expect "artifact: *.log trips" 1 check_artifacts
+	_reset; FILES="tmp/scratch.txt"; _expect "artifact: tmp/ trips" 1 check_artifacts
+	_reset; FILES=$'pkg/foo_test.go\ninternal/server.go'; _expect "artifact: clean files pass" 0 check_artifacts
+	_reset; FILES="docs/sample.test"; ALLOWLIST="docs/*.test"; _expect "artifact: allowlisted path passes" 0 check_artifacts; ALLOWLIST=""
+
+	# 3. secret scan — fixtures built by concatenation so the source file itself
+	#    carries no contiguous secret literal (and so cannot self-trip).
+	local sk="sk-""ant-abcdef12345678" akia="AKIA""IOSFODNN7EXAMPLE" pk="-----BEGIN ""PRIVATE KEY-----"
+	local ghp="ghp_$(printf 'A%.0s' {1..30})"
+	_reset; DIFF=$'+++ b/config.yaml\n+token: '"$sk"; _expect "secret: sk-ant- trips" 1 check_secrets
+	_reset; DIFF=$'+++ b/main.go\n+const t = "'"$ghp"'"'; _expect "secret: ghp_ trips" 1 check_secrets
+	_reset; DIFF=$'+++ b/aws.txt\n+id = '"$akia"; _expect "secret: AKIA trips" 1 check_secrets
+	_reset; DIFF=$'+++ b/id_rsa\n+'"$pk"; _expect "secret: private key trips" 1 check_secrets
+	_reset; DIFF=$'+++ b/main.go\n+const region = "us-east-1"\n-old removed line'; _expect "secret: clean diff passes" 0 check_secrets
+
+	# 4. draft check (warn-only → always rc 0)
+	_reset; DRAFT="true"; _expect "draft: no marker warns (rc 0)" 0 check_draft
+	_reset; DRAFT="true"; TITLE="[Partial] feat: x (#1)"; _expect "draft: with marker (rc 0)" 0 check_draft
+
+	# escape hatch
+	_reset; BODY="Fixes #1"; LABELS="$OVERRIDE_LABEL"; _expect "override: label downgrades failure" 0 run_lint
+	_reset; BODY=$'Fixes #1\n<!-- agent-lint:allow -->'; _expect "override: body marker downgrades failure" 0 run_lint
+	_reset; BODY="Fixes #1"; _expect "no override: failure blocks" 1 run_lint
+
+	echo "----"
+	if (( fails > 0 )); then
+		echo "agent-lint self-test: ${fails} failure(s)"
+		return 1
+	fi
+	echo "agent-lint self-test: all fixtures behaved as expected"
+	return 0
+}
+
+# ---- entrypoint -------------------------------------------------------------
+
+main() {
+	if [[ "${1:-}" == "--self-test" ]]; then
+		self_test
+		exit $?
+	fi
+
+	if [[ -n "$PR" ]]; then
+		fetch_pr
+	else
+		# offline dry-run: take subjects directly from the environment.
+		TITLE="${AGENT_LINT_TITLE:-}"
+		BODY="${AGENT_LINT_BODY:-}"
+		DRAFT="${AGENT_LINT_DRAFT:-false}"
+		LABELS="${AGENT_LINT_LABELS:-}"
+		FILES="${AGENT_LINT_FILES:-}"
+		DIFF="${AGENT_LINT_DIFF:-}"
+	fi
+
+	run_lint
+	exit $?
+}
+
+main "$@"

--- a/.github/workflows/agent-lint.yml
+++ b/.github/workflows/agent-lint.yml
@@ -1,0 +1,33 @@
+name: agent-lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # Lint the actual PR (closing keywords, artifacts, secrets, draft warning).
+  agent-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/agent-lint
+
+  # Continuously prove the fixtures still trip each check (acceptance criterion 1).
+  self-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fixture self-test
+        run: bash .github/actions/agent-lint/agent-lint.sh --self-test

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,11 @@
 # Config files with secrets
 *.yaml
 *.yml
-# But keep CI workflows
+# But keep CI workflows and composite actions
 !.github/workflows/*.yml
 !.github/ISSUE_TEMPLATE/*.yml
+!.github/actions/**/*.yml
+!.github/actions/**/*.yaml
 .claude/
 
 # Frontend build

--- a/docs/agent-lint-runbook.md
+++ b/docs/agent-lint-runbook.md
@@ -1,0 +1,103 @@
+# agent-lint Runbook (#707)
+
+`agent-lint` is a reusable CI check that encodes the fleet's **agent
+anti-pattern rules** so they are enforced, not just described in the worker
+prompt. Rules enforced only in prompts are not enforced at all — models
+occasionally violate them and today those violations are caught late, by review
+or by the operator.
+
+It ships as a **composite action** at `.github/actions/agent-lint`, backed by a
+single self-contained script (`agent-lint.sh`). The action is referenced by this
+repo's `agent-lint` workflow and is designed for one-file copy/reuse across the
+other fleet repos.
+
+## What it checks
+
+| # | Check | Result | Rule |
+|---|-------|--------|------|
+| 1 | **Closing keywords** | ❌ fail | PR title/body must not use a GitHub auto-closing keyword (`close`/`closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`) that references an issue (`#N`, `GH-N`, or an issue URL). Use `Refs #N` or `Implements #N` instead. |
+| 2 | **Diff hygiene** | ❌ fail | The diff must not add build/run artifacts: `.maestro/`, `tmp/`, `_tmp/`, `*.log`, `*.logs`, `*.test`, `*.test.json`. Exempt extra paths with `artifact-allowlist`. |
+| 3 | **Secret scan** | ❌ fail | Added diff lines must not contain common secret shapes: `sk-ant-…`, `ghp_…`/`gho_…`/`ghs_…`, `github_pat_…`, `AKIA…`/`ASIA…`, `xox…` (Slack), `AIza…` (Google), or a `BEGIN … PRIVATE KEY` block. Matches are reported masked, never echoed in full. |
+| 4 | **Draft check** | ⚠️ warn | A draft PR without an explicit WIP/Partial marker only **warns** (it never blocks). The recognised markers mirror the orchestrator's deliberate-draft detection (#697): `[WIP]`/`[Partial]` in the title, a `WIP:`/`Partial:`/`Draft:` prefix, or `maestro:partial`/`maestro:wip` in the body (the worker Partial flow embeds `<!-- maestro:partial -->`). |
+
+## Escape hatch (false positives)
+
+When a check fires incorrectly, downgrade the **hard** checks (1–3) to warnings
+so the job passes — pick either:
+
+- **Label:** add the `agent-lint:override` label to the PR, or
+- **Body marker:** add `<!-- agent-lint:allow -->` to the PR description.
+
+Use sparingly — the override is logged as a CI notice so it is visible in
+review. The draft check is warn-only and needs no override.
+
+> Operators: create the override label once per repo, e.g.
+> `gh label create "agent-lint:override" --color "FBCA04" --description "Bypass agent-lint hard checks"`.
+
+## One-file adoption for other fleet repos
+
+The lint logic travels with the composite action at its pinned ref, so a
+consuming repo only adds **one** workflow file — no scripts to copy:
+
+```yaml
+# .github/workflows/agent-lint.yml
+name: agent-lint
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review, converted_to_draft, labeled, unlabeled]
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  agent-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: BeFeast/maestro/.github/actions/agent-lint@main
+        # with:
+        #   artifact-allowlist: |
+        #     docs/**/*.log
+        #   override-label: agent-lint:override
+```
+
+Pin `@main` to a tag or commit SHA if you want the rules to change only on
+deliberate updates.
+
+## Local dry-run
+
+The same script runs locally — no `gh`, no network — by passing the PR fields
+directly as environment variables:
+
+```bash
+AGENT_LINT_TITLE="feat: thing (#42)" \
+AGENT_LINT_BODY="Fixes #42" \
+AGENT_LINT_FILES=$(git diff --name-only main) \
+AGENT_LINT_DIFF="$(git diff main)" \
+bash .github/actions/agent-lint/agent-lint.sh
+# → fails on the 'Fixes #42' closing keyword
+```
+
+To lint a real PR locally (requires an authenticated `gh`):
+
+```bash
+AGENT_LINT_PR=123 AGENT_LINT_REPO=BeFeast/maestro \
+  bash .github/actions/agent-lint/agent-lint.sh
+```
+
+## Fixtures / deliberate violations
+
+`agent-lint.sh --self-test` runs built-in fixtures that deliberately violate
+each rule and asserts that every check trips (and that clean input passes). The
+repo's `agent-lint` workflow runs this on every PR, so the checks cannot
+silently rot. To trip each check by hand:
+
+| Check | How to trip it |
+|-------|----------------|
+| Closing keyword | Put `Fixes #1` in the PR body or title. |
+| Diff hygiene | Commit a `debug.log` or any `.maestro/` file. |
+| Secret scan | Add a line containing a token shaped like `sk-ant-…` or `AKIA…`. |
+| Draft warning | Open a draft PR with no `[Partial]`/`[WIP]` marker. |
+
+```bash
+bash .github/actions/agent-lint/agent-lint.sh --self-test
+```


### PR DESCRIPTION
Implements #707

## Changes
Encode the fleet's agent anti-pattern rules as CI checks so they are enforced, not just described in the worker prompt. Ships as a reusable composite action at `.github/actions/agent-lint` (single self-contained `agent-lint.sh`), wired to this repo via `.github/workflows/agent-lint.yml`.

Checks:
- **Closing keywords** (fail): PR title/body must not use a GitHub auto-closing keyword referencing an issue — use `Refs #N` / `Implements #N`.
- **Diff hygiene** (fail): no committed `.maestro/`, `tmp/`, `_tmp/`, `*.log`, `*.logs`, `*.test`, `*.test.json` (configurable `artifact-allowlist`).
- **Secret scan** (fail): masked pattern check on added diff lines (sk-ant-, ghp_/gho_/ghs_, github_pat_, AKIA/ASIA, Slack, Google, BEGIN PRIVATE KEY).
- **Draft check** (warn only): drafts without a WIP/Partial marker, mirroring the orchestrator's deliberate-draft detection (#697).

Also:
- Escape hatch for false positives: `agent-lint:override` label or `<!-- agent-lint:allow -->` body marker.
- `docs/agent-lint-runbook.md`: one-file adoption for other fleet repos, escape hatch, local dry-run, fixtures.
- `.gitignore`: allow `.github/actions/**/*.yml` past the repo's secrets-oriented ignore.

## Testing
- `bash .github/actions/agent-lint/agent-lint.sh --self-test` — fixtures deliberately violate each rule and assert it trips; clean input passes (runs as a CI job on every PR).
- Offline dry-run of this PR's own diff + exact title/body: all checks pass (the script's pattern definitions do not self-trip the secret scan).
- `go build ./cmd/maestro/` and `go test ./...` green (no Go changes).

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a reusable `agent-lint` composite action and workflow that encodes the fleet's agent anti-pattern rules as enforced CI checks (no closing keywords, no committed artifacts, no leaked secrets, draft warning), wired up with a self-testing fixture suite and an escape-hatch mechanism.

- **Artifact check uses `--name-only` which includes deleted files** \u2014 a PR cleaning up committed artifacts will be falsely blocked; only added/modified paths should be checked (analogous to how `check_secrets` correctly limits itself to `+` diff lines).
- **Silent `gh pr diff` failure hides two hard checks** \u2014 both diff fetches use `2>/dev/null || true`; if either call fails, `check_artifacts` and `check_secrets` both return 0 silently, giving a false-green result with no indication the checks were skipped.
- The overall design (composite action, self-test fixtures running on every PR, override escape hatch, masking of matched secrets) is sound; the `.gitignore` negation rules are targeted and correct.

<h3>Confidence Score: 3/5</h3>

The workflow infrastructure and action wiring are safe to merge, but the artifact check has a behavioral inversion that will cause legitimate cleanup PRs to be blocked by the tool itself.

The artifact check populates FILES from gh pr diff --name-only, which includes deleted files. Any PR that removes a previously committed .maestro/ file or *.log will trip check_artifacts even though the intent is to clean up. Additionally, silently swallowing gh pr diff errors means two of the three hard checks can pass with empty data and no warning to the operator.

agent-lint.sh — specifically the fetch_pr function (lines 204–205) and the check_artifacts function (lines 118–130)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/actions/agent-lint/agent-lint.sh | Core lint script — artifact check incorrectly uses --name-only (includes deleted files), and diff fetch failures are silently swallowed, causing two hard checks to skip without any signal |
| .github/actions/agent-lint/action.yml | Composite action definition; inputs, defaults, and env wiring are correct; permissions documented appropriately |
| .github/workflows/agent-lint.yml | Workflow triggers on all relevant PR event types including converted_to_draft and label changes; minimal permissions scoped correctly; self-test job runs on every PR |
| .gitignore | Adds negation rules to unblock composite action YAML files past the broad *.yml ignore; correct and targeted |
| docs/agent-lint-runbook.md | Runbook covering adoption, escape hatch, local dry-run, and self-test fixtures; clear and accurate against the implementation |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.github/actions/agent-lint/agent-lint.sh:204
**`check_artifacts` fires on deleted artifact files**

`gh pr diff --name-only` lists every file touched in the PR — including deletions. A PR that removes a previously committed `.maestro/` file or `debug.log` will trip the check even though the change is *cleaning up*, not adding an artifact. The developer would have to reach for the override escape hatch just to merge a legitimate cleanup PR. The fix is to filter to only added/modified paths before populating `FILES`: `gh pr diff … --name-status | grep -E '^[AMR]\s' | awk '{print $NF}'` (or parse `+++ b/` lines from the full diff, already available in `DIFF`). Note that `check_secrets` gets this right — it only inspects `+` diff lines — so the asymmetry is especially jarring.

### Issue 2 of 3
.github/actions/agent-lint/agent-lint.sh:204-205
**Silent diff failure silently skips two hard checks**

Both `gh pr diff` calls use `2>/dev/null || true`, so any failure (token scope issue, API error, oversized diff) is completely swallowed. When `FILES` and `DIFF` are both empty, `check_artifacts` returns 0 immediately (`-z FILES`) and `check_secrets` returns 0 immediately (`-z added`) — the job shows green without having run either check. The metadata fetch above correctly fails hard on error; the same discipline should apply to the diff fetch, or at minimum emit a `::warning::` and set a flag so callers know the checks were skipped.

### Issue 3 of 3
.github/actions/agent-lint/agent-lint.sh:229
**Self-test fixture description doesn't match what it actually tests**

The label `"closing: keyword without issue ref passes"` implies the body contains a keyword with no `#N` reference, but the body is `"Implements #5; this resolves the layout but closes nothing concrete"` — it includes `#5`, and the real guard is that `resolves` / `closes` have no issue number after them. The test passes for the right reason, but if someone later reads this to understand coverage they may conclude the keyword-only case (no `#N` anywhere in the body) is tested, when it actually isn't. A separate fixture with `BODY="The code resolves the race condition"` would close that gap and avoid the misleading description.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: reusable agent-lint workflow — enfor..."](https://github.com/befeast/maestro/commit/b72cecd4a266f27b1bc65adf376f6216cd688d43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38822403)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->