### PR TITLE
self-deploy: externally-merged PRs (approval-gate / gh / manual) don't trigger a deploy → running binary lags main

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -548,6 +548,7 @@ func runCmd(args []string) {
 	if len(cfgs) == 1 {
 		cfg := cfgs[0]
 		orch := orchestrator.New(cfg)
+		orch.SetBinaryVersion(resolveVersion())
 		if err := orch.LoadPromptBase(*promptPath); err != nil {
 			log.Printf("warn: load prompt: %v", err)
 		}
@@ -606,6 +607,7 @@ func runCmd(args []string) {
 		go func(c *config.Config) {
 			defer wg.Done()
 			orch := orchestrator.New(c)
+			orch.SetBinaryVersion(resolveVersion())
 			if err := orch.LoadPromptBase(*promptPath); err != nil {
 				log.Printf("[%s] warn: load prompt: %v", c.SessionPrefix, err)
 			}

--- a/docs/self-deploy-runbook.md
+++ b/docs/self-deploy-runbook.md
@@ -8,9 +8,26 @@ restarting units.
 
 ## How it works
 
-After the orchestrator merges a PR (and after the optional version bump),
-it launches `scripts/self-deploy.sh` through a **detached transient systemd
-unit** (`systemd-run --user --collect --unit maestro-self-deploy-pr<N>-<ts>`).
+A self-deploy fires on either of two triggers:
+
+- **Orchestrator merge** — after the orchestrator merges a PR (and after the
+  optional version bump).
+- **Observed main-advance (#751)** — when the orchestrator sees `origin/main`
+  point past the commit the running binary was built from, i.e. a PR merged
+  outside its own merge path (the GitHub UI, a manual `gh pr merge`, or the
+  approval-gate executor). Each cycle compares the running binary's stamped SHA
+  (`<version>+g<shortsha>`) against `origin/main`'s head; a difference is the
+  drift signal. This means a green PR merged by **any** path reaches the running
+  binary without manual intervention. It is the **same debounced trigger** as a
+  merge (see the debounce below), so an orchestrator merge that just launched a
+  deploy is not double-triggered, and a reconcile that sees many already-merged
+  *historical* PRs does not storm — once a deploy lands, the binary matches main
+  and the drift clears.
+
+Either trigger launches `scripts/self-deploy.sh` through a **detached transient
+systemd unit** (`systemd-run --user --collect --unit
+maestro-self-deploy-pr<N>-<ts>`; the observed-main-advance path uses `pr0`,
+since no specific PR was merged by the orchestrator).
 Detachment is the load-bearing part: the script restarts the very units that
 run the orchestrator, and must survive that restart.
 
@@ -95,7 +112,10 @@ this:
   dir (`self-deploy-last-trigger.json`) and skips re-triggering within
   `min_interval_minutes` (default: `timeout_minutes`). This survives the
   run-loop being restarted by its own deploy. Lower it for faster back-to-back
-  deploys on an idle fleet.
+  deploys on an idle fleet. The observed-main-advance trigger (#751) shares this
+  marker, so it never double-fires against an orchestrator merge — and its
+  drift check (running-binary SHA vs `origin/main`) self-clears once a deploy
+  lands, so historical merged PRs never storm it.
 
 It is still safe (and simplest) to keep the run-loop unit in `units`; these
 guards make that configuration converge. Re-enable `self_deploy` on the dogfood

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -635,6 +635,32 @@ func (c *Client) PRHeadSHA(prNumber int) (string, error) {
 	return c.pullHeadSHA(prNumber)
 }
 
+// BranchHeadSHA returns the current head commit SHA of the given branch. The
+// orchestrator uses it to detect when origin/main has advanced past the running
+// binary so a PR merged outside the orchestrator's own merge path still
+// triggers a self-deploy (#751).
+func (c *Client) BranchHeadSHA(branch string) (string, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return "", fmt.Errorf("empty branch")
+	}
+	out, err := ghAPI(fmt.Sprintf("repos/%s/commits/%s", c.Repo, url.PathEscape(branch)))
+	if err != nil {
+		return "", err
+	}
+	var commit struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.Unmarshal(out, &commit); err != nil {
+		return "", fmt.Errorf("parse commit for branch %s: %w", branch, err)
+	}
+	sha := strings.TrimSpace(commit.SHA)
+	if sha == "" {
+		return "", fmt.Errorf("empty head sha for branch %s", branch)
+	}
+	return sha, nil
+}
+
 func (c *Client) checkRunsForSHA(sha string) ([]greptileCheckRun, error) {
 	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/commits/%s/check-runs?per_page=100", c.Repo, sha), "--paginate")
 	if err != nil {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -42,6 +42,7 @@ type Orchestrator struct {
 	gh                    *github.Client
 	router                *router.Router
 	repo                  string
+	binaryVersion         string
 	promptBase            string
 	bugPromptBase         string
 	enhancementPromptBase string
@@ -123,6 +124,7 @@ type Orchestrator struct {
 	runVisualCaptureFn           func(v config.VerifyVisualConfig, worktreePath string) ([]string, error)
 	workerStopFn                 func(cfg *config.Config, slotName string, sess *state.Session) error
 	selfDeployStartFn            func(prNumber int) error
+	mainHeadSHAFn                func() (string, error)
 	rebaseWorktreeFn             func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error
 	outcomeCheckFn               func(context.Context, outcome.Brief) outcome.HealthCheckResult
 	syncProjectFn                func(issueNumber int, status github.ProjectStatus) bool
@@ -230,6 +232,26 @@ func (o *Orchestrator) isPRMerged(prNumber int) (bool, error) {
 		return o.isPRMergedFn(prNumber)
 	}
 	return o.gh.IsPRMerged(prNumber)
+}
+
+// SetBinaryVersion records the running binary's resolved version (e.g.
+// "1.4.2+gabc1234"), set once at startup by cmd/maestro from resolveVersion().
+// The observe-merge self-deploy (#751) compares its stamped SHA against
+// origin/main to decide whether the live binary lags. Left unset (e.g. in
+// tests), the drift-based trigger stays off.
+func (o *Orchestrator) SetBinaryVersion(v string) {
+	o.binaryVersion = strings.TrimSpace(v)
+}
+
+// mainHeadSHA returns origin/main's current head commit SHA.
+func (o *Orchestrator) mainHeadSHA() (string, error) {
+	if o.mainHeadSHAFn != nil {
+		return o.mainHeadSHAFn()
+	}
+	if o.gh == nil {
+		return "", fmt.Errorf("no github client configured for main head sha")
+	}
+	return o.gh.BranchHeadSHA("main")
 }
 
 func (o *Orchestrator) prCIStatus(prNumber int) (string, error) {
@@ -1549,6 +1571,16 @@ func (o *Orchestrator) RunOnce() error {
 	// covers sessions that reached code_landed before the verifier was available
 	// or where the verifier passed on a later cycle.
 	o.reconcileCodeLandedSessions(s)
+
+	// Step 3c: Observe-merge self-deploy (#751). A PR merged outside the
+	// orchestrator's own merge path (GitHub UI, manual `gh pr merge`, or the
+	// approval-gate executor) advances origin/main but never reaches
+	// maybeSelfDeployAfterMerge, so without this the fleet binary silently lags
+	// main. Runs after autoMergePRs so a same-cycle orchestrator merge has
+	// already recorded its trigger and debounces this drift-based path. No-op
+	// unless self_deploy is enabled and main is genuinely ahead of the running
+	// binary.
+	o.maybeSelfDeployOnMainAdvance(s)
 
 	// Step 4: Rebase conflicting PRs
 	o.rebaseConflicts(s)
@@ -4055,6 +4087,72 @@ func (o *Orchestrator) maybeSelfDeployAfterMerge(s *state.State, prNumber int) {
 	}
 	log.Printf("[orch] self-deploy started for PR #%d (detached transient unit)", prNumber)
 	o.notifier.Sendf("🚀 maestro: self-deploy started after PR #%d merge — units will restart after drain", prNumber)
+}
+
+// maybeSelfDeployOnMainAdvance triggers the opt-in self-deploy (#698) when the
+// orchestrator OBSERVES origin/main advancing past the running binary — i.e. a
+// PR merged outside the orchestrator's own merge path: via the GitHub UI, a
+// manual `gh pr merge`, or the approval-gate executor (#751). Without this, only
+// orchestrator-merged PRs deploy and the fleet binary silently lags main.
+//
+// It reuses the same debounced trigger as maybeSelfDeployAfterMerge, gated on a
+// real drift signal rather than a specific merge:
+//   - storm guard (#751 AC3): deploy ONLY when origin/main's head SHA differs
+//     from the SHA the running binary was built from, so a reconcile that sees
+//     many already-merged historical PRs does not re-fire — once a deploy lands,
+//     the binary matches main and the drift clears.
+//   - debounce (#722 / #751 AC2): honor the existing RecordTrigger window so a
+//     deploy the orchestrator just launched for its own merge (which advanced
+//     main too) does not double-trigger here.
+func (o *Orchestrator) maybeSelfDeployOnMainAdvance(s *state.State) {
+	if o == nil || o.cfg == nil || !o.cfg.SelfDeploy.Enabled {
+		return
+	}
+	// Without a resolvable build SHA (e.g. a bare "dev" binary) drift cannot be
+	// told apart from a fresh build, so do nothing rather than redeploy every
+	// cycle.
+	if selfdeploy.BuildSHA(o.binaryVersion) == "" {
+		return
+	}
+	now := time.Now().UTC()
+	// Cheap debounce check first: if a deploy already fired within the window
+	// (e.g. the orchestrator merged a PR this cycle and recorded it), skip
+	// before spending a GitHub round-trip on the head-SHA lookup.
+	if last, _, ok := selfdeploy.LastTrigger(o.cfg.StateDir); ok {
+		window := time.Duration(o.cfg.SelfDeploy.EffectiveMinIntervalMinutes()) * time.Minute
+		if since := now.Sub(last); since >= 0 && since < window {
+			return
+		}
+	}
+	head, err := o.mainHeadSHA()
+	if err != nil {
+		log.Printf("[orch] self-deploy main-advance check: could not resolve origin/main head: %v", err)
+		return
+	}
+	if !selfdeploy.MainAdvanced(o.binaryVersion, head) {
+		return // running binary already matches main — no externally-merged drift
+	}
+	log.Printf("[orch] self-deploy: origin/main (%s) advanced past running binary (%s) — deploying", shortHeadSHA(head), o.binaryVersion)
+	// PR 0: this deploy was triggered by observing main advance, not by a merge
+	// the orchestrator performed itself.
+	if err := o.triggerSelfDeploy(0); err != nil {
+		log.Printf("[orch] self-deploy (main-advance) trigger failed: %v", err)
+		o.notifier.Sendf("⚠️ maestro: self-deploy trigger failed after observing origin/main advance: %v — fleet still on the previous binary", err)
+		// Surface as a supervisor finding so a silently-undeployed external merge
+		// shows as fleet attention; no marker is recorded, so the next cycle
+		// retries (mirrors maybeSelfDeployAfterMerge).
+		if s != nil {
+			s.RecordSupervisorDecision(selfdeploy.TriggerFailedFinding(0, err, o.cfg.Repo, now), state.DefaultSupervisorDecisionLimit)
+		}
+		return
+	}
+	// Record the trigger so a run-loop restarted by this deploy — and the next
+	// few cycles within the window — do not re-fire for the same wave (#722).
+	if err := selfdeploy.RecordTrigger(o.cfg.StateDir, 0, now); err != nil {
+		log.Printf("[orch] self-deploy (main-advance) trigger marker write failed: %v", err)
+	}
+	log.Printf("[orch] self-deploy started after observing origin/main advance (detached transient unit)")
+	o.notifier.Sendf("🚀 maestro: self-deploy started — origin/main advanced past the running binary (externally-merged PR); units will restart after drain")
 }
 
 // triggerSelfDeploy starts the opt-in self-deploy (#698) for a merged PR.

--- a/internal/orchestrator/selfdeploy_test.go
+++ b/internal/orchestrator/selfdeploy_test.go
@@ -137,6 +137,173 @@ func TestMaybeSelfDeployAfterMerge_FiresAfterWindow(t *testing.T) {
 	}
 }
 
+// #751: a PR merged outside the orchestrator's own merge path advances
+// origin/main past the running binary; the next cycle observes the drift and
+// fires exactly one debounced self-deploy. A second cycle within the window
+// (e.g. reconcile still seeing the same already-merged PRs) does not re-fire.
+func TestMaybeSelfDeployOnMainAdvance_FiresOnceThenDebounces(t *testing.T) {
+	stateDir := t.TempDir()
+	calls := 0
+	gotPR := -1
+	headLookups := 0
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   stateDir,
+			SelfDeploy: config.SelfDeployConfig{Enabled: true, MinIntervalMinutes: 30},
+		},
+		notifier:      &notify.Notifier{},
+		binaryVersion: "1.4.2+gabc1234", // built from abc1234...
+		// origin/main moved to a different commit (externally-merged PR).
+		mainHeadSHAFn:     func() (string, error) { headLookups++; return "fed9876543210fed9876543210fed9876543210f", nil },
+		selfDeployStartFn: func(prNumber int) error { calls++; gotPR = prNumber; return nil },
+	}
+
+	o.maybeSelfDeployOnMainAdvance(nil)
+	if calls != 1 {
+		t.Fatalf("first cycle fired %d deploys, want 1", calls)
+	}
+	if gotPR != 0 {
+		t.Errorf("observe-merge deploy PR = %d, want 0 (not a specific orchestrator merge)", gotPR)
+	}
+	if _, _, ok := selfdeploy.LastTrigger(stateDir); !ok {
+		t.Error("trigger marker not recorded after firing")
+	}
+
+	// Second cycle within the debounce window: still drifted, but must not
+	// re-fire — and must not even spend the head-SHA lookup.
+	headLookups = 0
+	o.maybeSelfDeployOnMainAdvance(nil)
+	if calls != 1 {
+		t.Fatalf("second cycle fired %d deploys total, want exactly 1 (debounced)", calls)
+	}
+	if headLookups != 0 {
+		t.Errorf("debounced cycle still made %d head-SHA lookups, want 0", headLookups)
+	}
+}
+
+// #751 AC3 (storm guard): reconcile that sees already-merged historical PRs but
+// where origin/main matches the running binary must NOT deploy.
+func TestMaybeSelfDeployOnMainAdvance_NoDriftNoTrigger(t *testing.T) {
+	calls := 0
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   t.TempDir(),
+			SelfDeploy: config.SelfDeployConfig{Enabled: true, MinIntervalMinutes: 30},
+		},
+		notifier:      &notify.Notifier{},
+		binaryVersion: "1.4.2+gabc1234",
+		// main head is the same commit the running binary was built from.
+		mainHeadSHAFn:     func() (string, error) { return "abc1234567890abcdef1234567890abcdef123456", nil },
+		selfDeployStartFn: func(prNumber int) error { calls++; return nil },
+	}
+
+	o.maybeSelfDeployOnMainAdvance(nil)
+	if calls != 0 {
+		t.Fatalf("deploy fired %d times with no drift, want 0", calls)
+	}
+}
+
+// #751 AC2: a deploy the orchestrator just launched for its own merge (which
+// also advanced main) must not be double-triggered by the drift-based path.
+func TestMaybeSelfDeployOnMainAdvance_DebouncesOrchestratorOwnMerge(t *testing.T) {
+	stateDir := t.TempDir()
+	// The orchestrator merged PR 740 moments ago and recorded its trigger.
+	if err := selfdeploy.RecordTrigger(stateDir, 740, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   stateDir,
+			SelfDeploy: config.SelfDeployConfig{Enabled: true, MinIntervalMinutes: 30},
+		},
+		notifier:          &notify.Notifier{},
+		binaryVersion:     "1.4.2+gabc1234",
+		mainHeadSHAFn:     func() (string, error) { return "fed9876543210fed9876543210fed9876543210f", nil },
+		selfDeployStartFn: func(prNumber int) error { calls++; return nil },
+	}
+
+	o.maybeSelfDeployOnMainAdvance(nil)
+	if calls != 0 {
+		t.Fatalf("drift-based deploy fired %d times within the orchestrator's own debounce window, want 0", calls)
+	}
+}
+
+// Flag default OFF: no drift check, no GitHub round-trip.
+func TestMaybeSelfDeployOnMainAdvance_DefaultOff(t *testing.T) {
+	headLookups := 0
+	calls := 0
+	o := &Orchestrator{
+		cfg:               &config.Config{Repo: "owner/repo", StateDir: t.TempDir()},
+		notifier:          &notify.Notifier{},
+		binaryVersion:     "1.4.2+gabc1234",
+		mainHeadSHAFn:     func() (string, error) { headLookups++; return "fed9876543210fed9876543210fed9876543210f", nil },
+		selfDeployStartFn: func(prNumber int) error { calls++; return nil },
+	}
+
+	o.maybeSelfDeployOnMainAdvance(nil)
+	if calls != 0 || headLookups != 0 {
+		t.Fatalf("flag off: calls=%d headLookups=%d, want 0/0", calls, headLookups)
+	}
+}
+
+// An unstamped binary (bare "dev") cannot determine drift — never deploy, and
+// never spend the head-SHA lookup.
+func TestMaybeSelfDeployOnMainAdvance_UnstampedBinaryNoTrigger(t *testing.T) {
+	headLookups := 0
+	calls := 0
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   t.TempDir(),
+			SelfDeploy: config.SelfDeployConfig{Enabled: true, MinIntervalMinutes: 30},
+		},
+		notifier:          &notify.Notifier{},
+		binaryVersion:     "dev",
+		mainHeadSHAFn:     func() (string, error) { headLookups++; return "fed9876543210fed9876543210fed9876543210f", nil },
+		selfDeployStartFn: func(prNumber int) error { calls++; return nil },
+	}
+
+	o.maybeSelfDeployOnMainAdvance(nil)
+	if calls != 0 || headLookups != 0 {
+		t.Fatalf("unstamped binary: calls=%d headLookups=%d, want 0/0", calls, headLookups)
+	}
+}
+
+// A trigger failure on the drift-based path surfaces a supervisor finding and
+// records NO marker, so the next cycle retries.
+func TestMaybeSelfDeployOnMainAdvance_TriggerFailureSurfacesFinding(t *testing.T) {
+	stateDir := t.TempDir()
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   stateDir,
+			SelfDeploy: config.SelfDeployConfig{Enabled: true, MinIntervalMinutes: 30},
+		},
+		notifier:          &notify.Notifier{},
+		binaryVersion:     "1.4.2+gabc1234",
+		mainHeadSHAFn:     func() (string, error) { return "fed9876543210fed9876543210fed9876543210f", nil },
+		selfDeployStartFn: func(prNumber int) error { return errors.New("systemd-run: exit status 1") },
+	}
+	s := &state.State{}
+
+	o.maybeSelfDeployOnMainAdvance(s)
+
+	if len(s.SupervisorDecisions) != 1 {
+		t.Fatalf("decisions recorded = %d, want 1", len(s.SupervisorDecisions))
+	}
+	if s.SupervisorDecisions[0].Status != "failed" {
+		t.Errorf("Status = %q, want failed", s.SupervisorDecisions[0].Status)
+	}
+	// No marker on a pure trigger failure — the next cycle must retry.
+	if _, _, ok := selfdeploy.LastTrigger(stateDir); ok {
+		t.Error("trigger marker recorded despite trigger failure — next cycle would be debounced")
+	}
+}
+
 // #698 AC5: a finished deploy surfaces as a supervisor finding and the
 // result file is consumed exactly once.
 func TestConsumeSelfDeployResult_Deployed(t *testing.T) {

--- a/internal/selfdeploy/selfdeploy.go
+++ b/internal/selfdeploy/selfdeploy.go
@@ -146,6 +146,58 @@ func LastTrigger(stateDir string) (when time.Time, pr int, ok bool) {
 	return m.TriggeredAt, m.PR, true
 }
 
+// BuildSHA recovers the git commit SHA a maestro binary was built from out of
+// its version string, so the orchestrator can tell whether the running binary
+// still matches origin/main (#751). Two stamp formats are understood:
+//
+//   - release / self-deploy builds: "<semver>+g<shortsha>" — the
+//     "-X main.version=<VERSION>+g<shortsha>" stamp from #682
+//     (e.g. "1.4.2+gabc1234" -> "abc1234");
+//   - local checkout builds: "dev-<vcsrevision>[-dirty]" — the resolveVersion
+//     VCS fallback (e.g. "dev-abc123456789" -> "abc123456789").
+//
+// Returns "" when no SHA can be recovered (the bare "dev" sentinel, a Go
+// pseudo-version, or an empty string), in which case drift cannot be
+// determined and callers must not deploy on a guess.
+func BuildSHA(version string) string {
+	v := strings.TrimSpace(version)
+	if v == "" {
+		return ""
+	}
+	// "<semver>+g<shortsha>": take the segment after the last "+g".
+	if i := strings.LastIndex(v, "+g"); i >= 0 {
+		return strings.TrimSpace(v[i+2:])
+	}
+	// "dev-<rev>[-dirty]": strip the prefix and any "-dirty" suffix.
+	if rest, ok := strings.CutPrefix(v, "dev-"); ok {
+		rest = strings.TrimSuffix(rest, "-dirty")
+		return strings.TrimSpace(rest)
+	}
+	return ""
+}
+
+// MainAdvanced reports whether origin/main (mainHeadSHA, a full commit SHA)
+// points at a different commit than the one the running binary was built from
+// (recovered from runningVersion via BuildSHA). It is the storm guard for the
+// observe-merge self-deploy (#751 AC3): a reconcile that sees many
+// already-merged historical PRs must NOT redeploy unless main is genuinely
+// ahead of the live binary — once a deploy lands, the binary matches main and
+// the drift clears. The build stamp carries a short SHA while mainHeadSHA is a
+// full commit, so the match is a case-insensitive prefix check. Returns false
+// (no deploy) whenever either SHA is unknown, so an undeterminable version
+// never triggers a spurious deploy.
+func MainAdvanced(runningVersion, mainHeadSHA string) bool {
+	head := strings.ToLower(strings.TrimSpace(mainHeadSHA))
+	built := strings.ToLower(BuildSHA(runningVersion))
+	if head == "" || built == "" {
+		return false
+	}
+	if len(built) > len(head) {
+		return built != head
+	}
+	return !strings.HasPrefix(head, built)
+}
+
 // TriggerCommand builds the detached systemd-run invocation for a deploy
 // after the given merged PR. Split from Trigger so tests can assert the
 // argv without systemd.

--- a/internal/selfdeploy/selfdeploy_test.go
+++ b/internal/selfdeploy/selfdeploy_test.go
@@ -345,3 +345,49 @@ func TestFindingRolledBack(t *testing.T) {
 		t.Errorf("Summary = %q", d.Summary)
 	}
 }
+
+func TestBuildSHA(t *testing.T) {
+	cases := []struct {
+		version string
+		want    string
+	}{
+		{"1.4.2+gabc1234", "abc1234"},              // self-deploy / release stamp (#682)
+		{"v1.4.2+gdeadbee", "deadbee"},             // leading v tolerated
+		{"dev-abc123456789", "abc123456789"},       // local checkout VCS fallback
+		{"dev-abc123456789-dirty", "abc123456789"}, // dirty working tree suffix stripped
+		{"dev", ""},                       // bare sentinel — no SHA
+		{"", ""},                          // empty
+		{"1.4.2", ""},                     // plain semver, no stamp
+		{"  1.4.2+gabc1234  ", "abc1234"}, // surrounding whitespace
+	}
+	for _, tc := range cases {
+		if got := BuildSHA(tc.version); got != tc.want {
+			t.Errorf("BuildSHA(%q) = %q, want %q", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestMainAdvanced(t *testing.T) {
+	const head = "abc1234567890abcdef1234567890abcdef123456" // full 40-char origin/main SHA
+
+	// Running binary built from the same commit as origin/main — up to date.
+	if MainAdvanced("1.4.2+gabc1234", head) {
+		t.Error("MainAdvanced = true when the binary's short SHA prefixes main head (no drift)")
+	}
+	// Case-insensitive prefix match still counts as up to date.
+	if MainAdvanced("1.4.2+gABC1234", strings.ToUpper(head)) {
+		t.Error("MainAdvanced = true for a case-only difference (no drift)")
+	}
+	// origin/main moved to a different commit — the binary lags.
+	if !MainAdvanced("1.4.2+gabc1234", "fed9876543210fed9876543210fed9876543210f") {
+		t.Error("MainAdvanced = false when main head differs from the running binary")
+	}
+	// Undeterminable running version (bare dev): never deploy on a guess.
+	if MainAdvanced("dev", head) {
+		t.Error("MainAdvanced = true for an unstamped binary")
+	}
+	// Missing head SHA (lookup failed): never deploy on a guess.
+	if MainAdvanced("1.4.2+gabc1234", "") {
+		t.Error("MainAdvanced = true with an empty main head SHA")
+	}
+}


### PR DESCRIPTION
Implements #751

## Changes

Self-deploy previously fired only from the orchestrator's own merge path (`maybeSelfDeployAfterMerge`). A PR landed outside that path — approval-gate executor, GitHub UI, or manual `gh pr merge` — advanced `origin/main` but never triggered a deploy, so the running fleet binary silently lagged main.

This adds an **observe-merge** trigger driven by a drift signal:

- `selfdeploy.BuildSHA` recovers the build SHA from a version stamp (`<semver>+g<shortsha>` or `dev-<rev>`).
- `selfdeploy.MainAdvanced` is the storm guard — deploy only when `origin/main`'s head differs from the SHA the running binary was built from.
- `github.Client.BranchHeadSHA` resolves `origin/main`'s head commit.
- `orchestrator.maybeSelfDeployOnMainAdvance` runs each cycle after `autoMergePRs`, reusing the existing debounced trigger (`RecordTrigger` window) and surfacing trigger failures as supervisor findings.
- `cmd/maestro` plumbs the running binary version via `SetBinaryVersion`.

Behavior maps to the acceptance criteria:
- A PR merged by any path advances main → next cycle observes drift → one deploy.
- An orchestrator self-merge in the same cycle already recorded its trigger, so the drift path debounces (no double-trigger).
- A reconcile seeing many already-merged historical PRs does not storm: the drift check self-clears once a deploy lands (binary matches main), and the shared debounce window collapses a wave of merges into a single deploy.

Default OFF — projects without `self_deploy.enabled` see no behavior change (and pay no extra GitHub round-trip).

Runbook updated to document the second trigger and the shared debounce.

## Testing

- `go test ./...` (all packages green)
- New unit tests: `selfdeploy.BuildSHA` / `MainAdvanced`; orchestrator `maybeSelfDeployOnMainAdvance` (fires-once-then-debounces, no-drift storm guard, orchestrator-own-merge debounce, default-off, unstamped binary, trigger-failure finding).
- `gofmt`, `go vet`, `go build ./cmd/maestro/`

Note: full runtime verification (an externally-merged PR actually self-deploying on the fleet) requires an enabled `self_deploy` host and is not provable in CI.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the gap where PRs merged outside the orchestrator's own path (GitHub UI, approval-gate executor, or manual `gh pr merge`) advanced `origin/main` without triggering a self-deploy, leaving the running binary silently behind.

- Adds `selfdeploy.BuildSHA` / `MainAdvanced` to detect drift between the running binary's stamped SHA and `origin/main`'s head, with a prefix-match to handle short vs. full SHAs.
- Adds `maybeSelfDeployOnMainAdvance` to the orchestrator cycle — runs after `autoMergePRs` to share the existing debounce marker and avoid double-triggering orchestrator-own merges.
- Plumbs `SetBinaryVersion(resolveVersion())` into both single-config and multi-config startup paths; feature is default-off via `self_deploy.enabled`.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the common case; both edge cases found are bounded by the existing debounce and don't cause data loss or a deployment loop.

The storm guard and debounce logic are solid and well-tested. Two edge cases are worth noting: the branch 'main' is hardcoded in mainHeadSHA(), so a host using a different default branch would compare against the wrong ref; and BuildSHA returns non-hex strings for unusual dev- version formats without validation, which could cause spurious drift signals until the debounce window kicks in.

internal/selfdeploy/selfdeploy.go (BuildSHA dev- path), internal/orchestrator/orchestrator.go (mainHeadSHA branch hardcoding)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/selfdeploy/selfdeploy.go | Adds BuildSHA and MainAdvanced helpers for drift detection. Logic is sound; dev-<rev> format accepts non-hex strings without validation. |
| internal/orchestrator/orchestrator.go | Adds maybeSelfDeployOnMainAdvance and SetBinaryVersion. Storm guard and debounce logic are correct; branch "main" is hardcoded in mainHeadSHA(). |
| internal/github/github.go | Adds BranchHeadSHA using the /repos/{repo}/commits/{ref} endpoint; correct use of url.PathEscape and empty-branch validation. |
| cmd/maestro/main.go | Plumbs SetBinaryVersion(resolveVersion()) into both single-config and multi-config orchestrator startup paths. |
| internal/orchestrator/selfdeploy_test.go | Six new test cases cover fires-once-debounces, no-drift storm guard, orchestrator-own-merge debounce, default-off, unstamped binary, and trigger-failure finding. |
| internal/selfdeploy/selfdeploy_test.go | Unit tests for BuildSHA and MainAdvanced cover all documented version formats and edge cases. |
| docs/self-deploy-runbook.md | Runbook updated to document the new observe-merge trigger path, the shared debounce, and the pr0 unit name convention. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/orchestrator/orchestrator.go:247-254
**Branch name hardcoded to "main"**

`mainHeadSHA()` always resolves `origin/main`, so any self-deploy host whose orchestrator repo uses a different default branch (e.g. `master`) will have drift detection compare the running binary's SHA against the HEAD of a branch it was never built from. The result is that either drift is always detected (spurious deploys) or never detected (no deploys), depending on the branch relationship. The branch to track should come from config (`cfg.Repo`'s default branch, or an explicit `self_deploy.branch` field) rather than being hardcoded.

### Issue 2 of 2
internal/selfdeploy/selfdeploy.go:171-176
**`dev-<rev>` path returns arbitrary strings without SHA validation**

`BuildSHA` for the `dev-<rev>` format only strips the `"dev-"` prefix and a `"-dirty"` suffix — it does not validate that the remainder is a hex string. If `resolveVersion()` ever produces a version like `"dev-v1.2.3"` or `"dev-unknown"` (e.g. from a non-standard VCS setup or a build without embedded revision info), `BuildSHA` returns `"v1.2.3"` or `"unknown"`, which will never prefix-match any real git SHA. `MainAdvanced` would then permanently return `true`, causing a deploy every cycle until the trigger marker debounces it. The function should return `""` for non-hex-looking strings (e.g. a simple hex-character guard before returning).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["self-deploy: trigger on observed origin/..."](https://github.com/befeast/maestro/commit/6dc9b969a77c6fe329c04fbda28b1bdcf9914b0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38836798)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->