### PR TITLE
supervisor: pending approvals churn (stale every cycle) → CLI/SPA approve always races; gate un-actionable for merge_pr/spawn_repair_worker (#750)

### DIFF
--- a/internal/approver/stable_approval_test.go
+++ b/internal/approver/stable_approval_test.go
@@ -1,0 +1,152 @@
+package approver
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// driveCycles re-emits an unchanged approval-gated decision over n supervise
+// cycles, churning the bound session's runtime snapshot between cycles the way
+// a retry-exhausted worker's NextRetryAt / RetryCount move in production. It
+// returns the (stable) approval id and fails the test if it ever churns.
+func driveCycles(t *testing.T, st *state.State, slot string, decision state.SupervisorDecision, now time.Time, n int) string {
+	t.Helper()
+	var id string
+	for cycle := 0; cycle < n; cycle++ {
+		at := now.Add(time.Duration(cycle) * time.Minute)
+		st.MarkStaleApprovals(at) // cycle top, before re-emit
+		d := decision
+		d.ID = fmt.Sprintf("sup-cycle-%d", cycle)
+		d.CreatedAt = at
+		a := st.RecordPendingApprovalForDecision(d, at)
+		if a == nil {
+			t.Fatalf("cycle %d: approval was nil", cycle)
+		}
+		if cycle == 0 {
+			id = a.ID
+		} else if a.ID != id {
+			t.Fatalf("cycle %d: approval id churned %q -> %q", cycle, id, a.ID)
+		}
+		if sess := st.Sessions[slot]; sess != nil {
+			next := at.Add(time.Hour)
+			sess.NextRetryAt = &next
+			sess.RetryCount = cycle + 1
+		}
+	}
+	if len(st.Approvals) != 1 {
+		t.Fatalf("len(approvals) = %d, want 1 (no churn siblings)", len(st.Approvals))
+	}
+	return id
+}
+
+// TestStableApproval_MergePR_AcrossCyclesExecutesOnce covers #750 criteria
+// 3/4/5 for the merge_pr verb: an unchanged decision keeps a stable, approvable
+// id across supervise cycles, and approving once executes the merge exactly
+// once.
+func TestStableApproval_MergePR_AcrossCyclesExecutesOnce(t *testing.T) {
+	now := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{IssueNumber: 700, PRNumber: 748, Status: state.StatusRetryExhausted}
+
+	decision := state.SupervisorDecision{
+		Project:           "owner/repo",
+		Repo:              "owner/repo",
+		Summary:           "Merge PR #748.",
+		RecommendedAction: config.SupervisorActionMergePR,
+		Target:            &state.SupervisorTarget{PR: 748, Issue: 700},
+		Risk:              "mutating",
+	}
+
+	id := driveCycles(t, st, "slot-1", decision, now, 3)
+
+	approved, err := st.ApproveApproval(id, now.Add(10*time.Minute), "cli", "land it")
+	if err != nil {
+		t.Fatalf("ApproveApproval(stable id) after cycles: %v", err)
+	}
+
+	gh := &fakeGH{}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	res := ex.Execute(approved)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("execute status = %q (err=%v), want executed", res.Status, res.Err)
+	}
+	if got := len(gh.mergeCalls); got != 1 {
+		t.Fatalf("MergePR called %d times, want exactly 1 (idempotent)", got)
+	}
+	if gh.mergeCalls[0] != 748 {
+		t.Fatalf("MergePR(%d), want 748", gh.mergeCalls[0])
+	}
+}
+
+// TestStableApproval_SpawnRepairWorker_AcrossCyclesApprovable covers #750
+// criterion 5 for the spawn_repair_worker verb (the dogfood case that had to be
+// hand-merged): an unchanged decision keeps a stable, approvable id across
+// cycles, and approving routes to awaiting_dispatch so the dispatcher loop owns
+// the respawn.
+func TestStableApproval_SpawnRepairWorker_AcrossCyclesApprovable(t *testing.T) {
+	now := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["slot-2"] = &state.Session{IssueNumber: 442, PRNumber: 564, Status: state.StatusRetryExhausted}
+
+	decision := state.SupervisorDecision{
+		Project:           "owner/repo",
+		Repo:              "owner/repo",
+		Summary:           "Spawn a repair worker for issue #442 (PR #564).",
+		RecommendedAction: "spawn_repair_worker",
+		Target:            &state.SupervisorTarget{Issue: 442, PR: 564},
+		Risk:              "mutating",
+	}
+
+	id := driveCycles(t, st, "slot-2", decision, now, 4)
+
+	approved, err := st.ApproveApproval(id, now.Add(10*time.Minute), "cli", "unblock hand-off")
+	if err != nil {
+		t.Fatalf("ApproveApproval(stable id) after cycles: %v", err)
+	}
+
+	ex := &Executor{Cfg: newCfg()}
+	res := ex.Execute(approved)
+	if res.Status != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("execute status = %q (err=%v), want awaiting_dispatch", res.Status, res.Err)
+	}
+}
+
+// TestStableApproval_DistinctDecisionsGetDistinctIDs pins criterion 4: a
+// genuinely different decision (different target) is content-addressed to a
+// different id and coexists with the first — superseding is reserved for real
+// changes, not the same-decision churn.
+func TestStableApproval_DistinctDecisionsGetDistinctIDs(t *testing.T) {
+	now := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	st := state.NewState()
+
+	mk := func(pr int) state.SupervisorDecision {
+		return state.SupervisorDecision{
+			ID:                fmt.Sprintf("sup-%d", pr),
+			CreatedAt:         now,
+			Project:           "owner/repo",
+			Repo:              "owner/repo",
+			Summary:           fmt.Sprintf("Merge PR #%d.", pr),
+			RecommendedAction: config.SupervisorActionMergePR,
+			Target:            &state.SupervisorTarget{PR: pr},
+			Risk:              "mutating",
+		}
+	}
+
+	a := st.RecordPendingApprovalForDecision(mk(748), now)
+	b := st.RecordPendingApprovalForDecision(mk(749), now)
+	if a.ID == b.ID {
+		t.Fatalf("distinct PR targets shared an id %q", a.ID)
+	}
+	if len(st.Approvals) != 2 {
+		t.Fatalf("len(approvals) = %d, want 2 (distinct decisions coexist)", len(st.Approvals))
+	}
+	for _, ap := range st.Approvals {
+		if ap.Status != state.ApprovalStatusPending {
+			t.Fatalf("approval %q status = %q, want pending (no supersede on distinct decisions)", ap.ID, ap.Status)
+		}
+	}
+}

--- a/internal/server/approvals_test.go
+++ b/internal/server/approvals_test.go
@@ -78,6 +78,58 @@ func TestHandleApproval_Approve_HappyPath(t *testing.T) {
 	}
 }
 
+// TestHandleApproval_ApproveAfterChurningCycle covers #750 criteria 1/3: the
+// SPA /approvals approve path must execute without a "stale" race when the
+// pending approval was read a supervise cycle earlier and the bound session's
+// runtime snapshot churned in between. The id stays the live, approvable
+// record across the cycle.
+func TestHandleApproval_ApproveAfterChurningCycle(t *testing.T) {
+	srv, dir := srvWithStateDir(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 748, Issue: 700})
+
+	// Simulate one supervise cycle landing between the operator reading the id
+	// and clicking approve: a bound session churns, MarkStaleApprovals runs at
+	// the cycle top, and the unchanged decision is re-emitted.
+	st, _ := state.Load(dir)
+	now := time.Now().UTC()
+	st.Sessions["slot-1"] = &state.Session{IssueNumber: 700, PRNumber: 748, Status: state.StatusRetryExhausted, RetryCount: 5}
+	st.MarkStaleApprovals(now)
+	reemit := state.SupervisorDecision{
+		ID:                "synthetic-merge_pr-cycle2",
+		CreatedAt:         now,
+		Project:           "owner/repo",
+		Summary:           "test enqueue",
+		RecommendedAction: "merge_pr",
+		Target:            &state.SupervisorTarget{PR: 748, Issue: 700},
+		Risk:              "high",
+		RequiresApproval:  true,
+	}
+	reemitted := st.RecordPendingApprovalForDecision(reemit, now)
+	if reemitted.ID != a.ID {
+		t.Fatalf("approval id churned across cycle: %q -> %q", a.ID, reemitted.ID)
+	}
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Approve the id read before the cycle — must succeed, not 409 stale.
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/approvals/"+a.ID+"/approve",
+		bytes.NewBufferString(`{"actor":"oleg","reason":"green"}`))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp approvalDecisionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || resp.Approval == nil || resp.Approval.Status != state.ApprovalStatusApproved {
+		t.Fatalf("response = %+v", resp)
+	}
+}
+
 func TestHandleApproval_Reject_HappyPath(t *testing.T) {
 	srv, dir := srvWithStateDir(t)
 	a := enqueuedApproval(t, dir, "close_issue", &state.SupervisorTarget{Issue: 7})

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -2023,8 +2023,11 @@ func TestFleetAPIIncludesApprovalInboxMetadata(t *testing.T) {
 		Target:            &state.SupervisorTarget{Issue: 43, Session: "slot-stale"},
 		Risk:              "approval_gated",
 	}, now.Add(-50*time.Minute))
-	st.Sessions["slot-stale"].PRNumber = 9
-	st.MarkStaleApprovals(now.Add(-10 * time.Minute))
+	// #750: target-state drift no longer stales a pending approval (that churn
+	// made the freshest id un-approvable a cycle later). Drive this fixture to
+	// the stale state directly so the snapshot still exercises stale rendering.
+	stale.Status = state.ApprovalStatusStale
+	stale.UpdatedAt = now.Add(-10 * time.Minute)
 	if err := state.Save(stateDir, st); err != nil {
 		t.Fatalf("save state: %v", err)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1978,19 +1978,41 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 	}
 
 	if existingMatch != nil {
-		if existingMatch.TargetStateHash == freshTargetStateHash {
-			// Same (action, target, target-state) — the storm case.
-			// Return the existing approval untouched.
-			return existingMatch
-		}
-		// Same (action, target) but state has moved on — supersede the
-		// stale record and fall through to create a fresh one.
-		s.markApprovalSuperseded(existingMatch, now,
-			"superseded by fresh re-emit: target state changed before approval")
+		// #750: same decision identity (action, target) → update the live
+		// approval IN PLACE and return it under its existing, stable id.
+		// Re-evaluation must NOT supersede + re-mint a sibling just because
+		// the volatile runtime snapshot (session status, retry count, PR
+		// head) moved between cycles — that churn staled the freshest id the
+		// operator just read, so `supervise approve <id>` and the SPA button
+		// raced a moving target every cycle (dogfood 2026-06-20: 170 stale +
+		// 81 superseded in history; merge_pr / spawn_repair_worker were
+		// un-actionable). The previous behaviour returned the existing record
+		// untouched only when the target-state snapshot was identical and
+		// otherwise superseded+re-minted; both branches now collapse to a
+		// single in-place refresh. Supersession is reserved for a genuinely
+		// different decision (different action/target), which hashes to a
+		// different id and falls through to the create path below, and for
+		// the dedicated reconcilers (worker started, issue auto-closed). The
+		// executor re-validates runtime preconditions at execute time
+		// (executeMergePR re-checks PRMergeStatus; the worktree/worker verbs
+		// re-check slot reuse), so keeping the approval live across churn does
+		// not widen the blast radius.
+		s.refreshPendingApproval(existingMatch, decision, freshTargetStateHash, now)
+		return existingMatch
+	}
+
+	id := approvalID(decision, createdAt)
+	if s.approvalIDInUse(id) {
+		// A terminal approval for the same decision identity already holds
+		// this content-addressed id (the previous instance completed and the
+		// same decision recurred). Disambiguate so ids stay unique; the LIVE
+		// pending record is refreshed in place above and never reaches here,
+		// so this never re-introduces per-cycle churn on an effective gate.
+		id = id + "-" + createdAt.UTC().Format("20060102T150405.000000000Z")
 	}
 
 	approval := Approval{
-		ID:              approvalID(decision, createdAt),
+		ID:              id,
 		DecisionID:      decision.ID,
 		CreatedAt:       createdAt,
 		UpdatedAt:       now,
@@ -2013,6 +2035,47 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 	})
 	s.Approvals = append(s.Approvals, approval)
 	return &s.Approvals[len(s.Approvals)-1]
+}
+
+// refreshPendingApproval updates a still-effective (pending or
+// awaiting_dispatch) approval in place from a fresh re-evaluation of the same
+// decision identity, preserving its id, creation time, status, and audit
+// trail so the record stays stable and approvable across supervise cycles
+// (#750). Only the re-derived decision content (summary, risk, evidence,
+// repo/project) and the informational target-state snapshot are refreshed;
+// the recomputed PayloadHash keeps ensureApprovalCurrent's internal-
+// consistency check satisfied. No audit entry is appended — a re-evaluation
+// that changed nothing material must not churn the audit log (that noise was
+// part of the #750 symptom).
+func (s *State) refreshPendingApproval(approval *Approval, decision SupervisorDecision, targetStateHash string, now time.Time) {
+	if approval == nil {
+		return
+	}
+	approval.Summary = decision.Summary
+	approval.Risk = decision.Risk
+	approval.Evidence = append([]string(nil), decision.Reasons...)
+	if strings.TrimSpace(decision.Repo) != "" {
+		approval.Repo = decision.Repo
+	}
+	if strings.TrimSpace(decision.Project) != "" {
+		approval.Project = decision.Project
+	}
+	approval.TargetStateHash = targetStateHash
+	approval.UpdatedAt = normalizedTime(now)
+	approval.PayloadHash = approval.ComputePayloadHash()
+}
+
+// approvalIDInUse reports whether any approval already carries id. Used by the
+// content-addressed mint path to disambiguate a fresh approval whose decision
+// identity collides with a terminal (executed/superseded/stale) record from a
+// previous instance of the same decision (#750).
+func (s *State) approvalIDInUse(id string) bool {
+	for i := range s.Approvals {
+		if s.Approvals[i].ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 // RecordLessonProposal records a recurring-failure lesson candidate and mints a
@@ -2337,7 +2400,15 @@ func (s *State) RejectApproval(id string, now time.Time, actor, reason string) (
 	return approval, nil
 }
 
-// MarkStaleApprovals marks pending approvals stale when their payload or target snapshot changes.
+// MarkStaleApprovals marks a pending approval stale only when its payload
+// drifts out of sync with its stored PayloadHash (an internal-consistency
+// guard). As of #750 it no longer stales on target-state-snapshot drift:
+// re-evaluating the same (action, target) decision refreshes the approval in
+// place, and the volatile runtime snapshot moving between cycles must not make
+// the freshest id un-approvable. Genuinely-moot approvals are retired by the
+// dedicated reconcilers (ReconcileSpawnWorkerApprovalsForStartedWorkers,
+// MarkCloseIssueApprovalsStaleForVerifiedIssue, ...) or by the executor's
+// execute-time re-validation.
 func (s *State) MarkStaleApprovals(now time.Time) int {
 	count := 0
 	for i := range s.Approvals {
@@ -2450,11 +2521,19 @@ func (s *State) ensureApprovalCurrent(approval *Approval, now time.Time) error {
 		s.markApprovalStale(approval, now, "approval payload changed")
 		return ErrApprovalPayloadMismatch
 	}
-	currentTargetStateHash := s.ApprovalTargetStateHash(approval.Target)
-	if approval.TargetStateHash != "" && currentTargetStateHash != approval.TargetStateHash {
-		s.markApprovalStale(approval, now, "approval target state changed")
-		return ErrApprovalStale
-	}
+	// #750: a pending approval is NOT staled merely because the volatile
+	// runtime snapshot (session status, retry count, PR head) drifted since it
+	// was minted. The approval authorizes a decision identified by (action,
+	// target); that identity is unchanged here (the payload hash matched), and
+	// RecordPendingApprovalForDecision refreshes the record in place each
+	// cycle instead of re-minting. Staling on target-state churn is exactly
+	// what made the freshest id un-approvable a cycle later — the CLI/SPA
+	// approve path raced a moving target every supervise cycle (dogfood
+	// 2026-06-20: two `supervise approve <freshest-id>` attempts both returned
+	// "approval is stale"). Runtime preconditions are re-validated by the
+	// executor at execute time (e.g. executeMergePR re-checks PRMergeStatus;
+	// the delete/stop/restart verbs re-check slot reuse), so dropping the
+	// approve-time target-state gate does not weaken the safety envelope.
 	return nil
 }
 
@@ -2605,10 +2684,72 @@ type approvalSessionSnapshot struct {
 }
 
 func approvalID(decision SupervisorDecision, createdAt time.Time) string {
+	// #750: content-address the approval id on the decision IDENTITY —
+	// (action, target) — NOT the per-cycle decision.ID or mint timestamp.
+	// Re-evaluating the same logical decision across supervise cycles then
+	// yields the SAME id, so the approval minted in cycle N stays the live,
+	// approvable record in cycle N+k. The old timestamp/decision-id keying
+	// minted a fresh sibling id every cycle (and staled the prior one), so
+	// `maestro supervise approve <id>` and the SPA button always raced a
+	// moving target — the gate was un-actionable for the very verbs that
+	// matter (merge_pr / spawn_repair_worker). Two decisions that share an
+	// identity intentionally collapse to one approval (the idempotency the
+	// gate needs); a genuinely different decision (different action/target)
+	// hashes to a different id. RecordPendingApprovalForDecision updates the
+	// matching approval in place rather than minting a sibling under a new id.
+	if key := approvalDecisionIdentityHash(decision.RecommendedAction, decision.Target); key != "" {
+		return "approval-" + key
+	}
+	// Defensive fallback: a decision with neither an action nor a target
+	// identity (never produced by a real gated mint) keeps the legacy keying
+	// so two such records cannot collide on an empty hash.
 	if decision.ID != "" {
 		return "approval-" + decision.ID
 	}
 	return "approval-" + createdAt.UTC().Format("20060102T150405.000000000Z")
+}
+
+// approvalDecisionIdentityHash returns a stable 16-hex digest of a decision's
+// identity: the (action, target) tuple that determines WHICH side effect an
+// approval authorizes. The volatile per-cycle runtime snapshot folded into
+// ApprovalTargetStateHash (session status, retry count, next-retry time) is
+// deliberately excluded so the digest is stable across supervise cycles
+// (#750). Target.HeadSHA IS part of the identity — a decision stamped against
+// a specific PR head (e.g. spawn_review_repair, #565) genuinely changes when
+// the head moves. Returns "" when there is nothing to address (no action and
+// no target). Whitespace in Session/HeadSHA is trimmed so the digest matches
+// approvalTargetsEqual's trimmed comparison.
+func approvalDecisionIdentityHash(action string, target *SupervisorTarget) string {
+	action = strings.TrimSpace(action)
+	if action == "" && target == nil {
+		return ""
+	}
+	full := stableHash(approvalDecisionIdentity{
+		Action: action,
+		Target: normalizedTargetIdentity(target),
+	})
+	if len(full) > 16 {
+		return full[:16]
+	}
+	return full
+}
+
+type approvalDecisionIdentity struct {
+	Action string            `json:"action"`
+	Target *SupervisorTarget `json:"target,omitempty"`
+}
+
+// normalizedTargetIdentity returns a copy of target with Session/HeadSHA
+// trimmed, so the content-addressed approval id is robust to incidental
+// whitespace and consistent with approvalTargetsEqual.
+func normalizedTargetIdentity(target *SupervisorTarget) *SupervisorTarget {
+	if target == nil {
+		return nil
+	}
+	clone := cloneSupervisorTarget(target)
+	clone.HeadSHA = strings.TrimSpace(clone.HeadSHA)
+	clone.Session = strings.TrimSpace(clone.Session)
+	return clone
 }
 
 func approvalTargetMatches(target *SupervisorTarget, slot string, sess *Session) bool {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1952,7 +1952,13 @@ func TestRecordPendingApprovalDedupsIdenticalReEmit(t *testing.T) {
 	}
 }
 
-func TestRecordPendingApprovalSupersedesOnTargetStateChange(t *testing.T) {
+// #750: re-evaluating the same (action, target) decision after the volatile
+// target-state snapshot moved must UPDATE THE LIVE APPROVAL IN PLACE under its
+// stable id — NOT supersede it and re-mint a sibling. The pre-#750 behaviour
+// (asserted by the old TestRecordPendingApprovalSupersedesOnTargetStateChange)
+// is exactly the churn that made the CLI/SPA approve path race a moving target
+// every supervise cycle.
+func TestRecordPendingApprovalUpdatesInPlaceOnTargetStateChange(t *testing.T) {
 	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
 	s := NewState()
 
@@ -1981,58 +1987,125 @@ func TestRecordPendingApprovalSupersedesOnTargetStateChange(t *testing.T) {
 	}
 
 	later := now.Add(2 * time.Minute)
-	// Use a fresh decision ID — supervisor mints decisions with unique
-	// per-cycle IDs in production; testApprovalDecision reuses the same
-	// ID literal, so we'd otherwise collide on approvalID() output.
+	// A fresh per-cycle decision id must NOT change the content-addressed
+	// approval id — the id keys on (action, target), not decision.ID.
 	freshDecision := testApprovalDecision(later)
 	freshDecision.ID = "sup-approval-2"
+	freshDecision.Summary = "Start a worker for issue #42: ready work (re-evaluated)"
 	second := s.RecordPendingApprovalForDecision(freshDecision, later)
 	if second == nil {
 		t.Fatal("second approval was nil")
 	}
-	if second.ID == firstID {
-		t.Fatalf("expected a fresh approval after target-state change; got the original ID %q", firstID)
+	if second.ID != firstID {
+		t.Fatalf("approval id churned after target-state change: got %q, want stable %q", second.ID, firstID)
 	}
 
-	// Old one must be superseded.
-	old, ok := s.FindApproval(firstID)
-	if !ok {
-		t.Fatalf("original approval %q missing", firstID)
+	// Still exactly one approval, still pending, no superseded sibling.
+	if got := len(s.Approvals); got != 1 {
+		t.Fatalf("len(approvals) = %d, want 1 (no churn sibling minted)", got)
 	}
-	if old.Status != ApprovalStatusSuperseded {
-		t.Fatalf("original status = %q, want superseded", old.Status)
-	}
-	gotSupersededAudit := false
-	for _, a := range old.Audit {
-		if a.Event == ApprovalAuditSuperseded {
-			gotSupersededAudit = true
-			break
-		}
-	}
-	if !gotSupersededAudit {
-		t.Fatalf("expected superseded audit entry on original; got %+v", old.Audit)
-	}
-
-	// New one must be pending and tied to the new target hash.
 	if second.Status != ApprovalStatusPending {
-		t.Fatalf("new approval status = %q, want pending", second.Status)
+		t.Fatalf("status = %q, want pending", second.Status)
 	}
-	if second.TargetStateHash == firstTargetHash {
-		t.Fatalf("new TargetStateHash equal to old; expected fresh hash")
-	}
-
-	// Exactly one pending, one superseded.
-	var pending, superseded int
-	for _, a := range s.Approvals {
-		switch a.Status {
-		case ApprovalStatusPending:
-			pending++
-		case ApprovalStatusSuperseded:
-			superseded++
+	for _, a := range second.Audit {
+		if a.Event == ApprovalAuditSuperseded {
+			t.Fatalf("approval must not be superseded on target-state churn; audit = %+v", second.Audit)
 		}
 	}
-	if pending != 1 || superseded != 1 {
-		t.Fatalf("counts = pending %d / superseded %d, want 1 / 1", pending, superseded)
+
+	// Updated in place: target-state snapshot and re-derived content refreshed,
+	// UpdatedAt bumped, CreatedAt preserved, PayloadHash self-consistent.
+	if second.TargetStateHash != freshHash {
+		t.Fatalf("TargetStateHash = %q, want refreshed %q", second.TargetStateHash, freshHash)
+	}
+	if !second.CreatedAt.Equal(first.CreatedAt) {
+		t.Fatalf("CreatedAt moved: got %s, want %s", second.CreatedAt, first.CreatedAt)
+	}
+	if !second.UpdatedAt.After(first.CreatedAt) {
+		t.Fatalf("UpdatedAt = %s, want bumped past CreatedAt %s", second.UpdatedAt, first.CreatedAt)
+	}
+	if second.Summary != freshDecision.Summary {
+		t.Fatalf("summary = %q, want refreshed %q", second.Summary, freshDecision.Summary)
+	}
+	if second.ComputePayloadHash() != second.PayloadHash {
+		t.Fatalf("PayloadHash not refreshed in place: stored %q, computed %q", second.PayloadHash, second.ComputePayloadHash())
+	}
+
+	// The id remains approvable after the in-place update.
+	if _, err := s.ApproveApproval(firstID, later.Add(time.Minute), "cli", "go"); err != nil {
+		t.Fatalf("ApproveApproval after in-place update: %v", err)
+	}
+}
+
+// TestRecordPendingApprovalStableAcrossSupervisorCycles drives several
+// supervise cycles over an unchanged merge_pr decision while the bound
+// session's volatile runtime snapshot (status, retry count, next-retry time)
+// churns every cycle, and asserts the approval id is stable and still
+// approvable on the last cycle (#750 acceptance criteria 1, 2, 5). Before
+// #750 each cycle re-minted a fresh id keyed on the per-cycle decision
+// id/timestamp and staled the prior one, so `supervise approve <id>` always
+// raced a moving target.
+func TestRecordPendingApprovalStableAcrossSupervisorCycles(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber: 700,
+		Status:      StatusRetryExhausted,
+		PRNumber:    748,
+		RetryCount:  3,
+	}
+	decisionFor := func(cycle int, at time.Time) SupervisorDecision {
+		return SupervisorDecision{
+			// Production mints a UNIQUE per-cycle decision id; the stable
+			// approval id must NOT depend on it.
+			ID:                fmt.Sprintf("sup-cycle-%d", cycle),
+			CreatedAt:         at,
+			Project:           "owner/repo",
+			Summary:           "Merge PR #748 (retry-exhausted hand-off).",
+			RecommendedAction: "merge_pr",
+			Target:            &SupervisorTarget{PR: 748, Issue: 700},
+			Risk:              "mutating",
+			Reasons:           []string{"PR #748 is green"},
+		}
+	}
+
+	var ids []string
+	for cycle := 0; cycle < 4; cycle++ {
+		at := now.Add(time.Duration(cycle) * time.Minute)
+		// Cycle top: the supervisor stales drifted approvals before re-emit.
+		s.MarkStaleApprovals(at)
+		approval := s.RecordPendingApprovalForDecision(decisionFor(cycle, at), at)
+		if approval == nil {
+			t.Fatalf("cycle %d: approval was nil", cycle)
+		}
+		if approval.Status != ApprovalStatusPending {
+			t.Fatalf("cycle %d: status = %q, want pending", cycle, approval.Status)
+		}
+		ids = append(ids, approval.ID)
+		// Churn the bound session's runtime snapshot, the way a retry-exhausted
+		// worker's NextRetryAt / RetryCount move every supervise cycle.
+		next := at.Add(30 * time.Minute)
+		s.Sessions["slot-1"].NextRetryAt = &next
+		s.Sessions["slot-1"].RetryCount = 3 + cycle
+	}
+
+	for i, id := range ids {
+		if id != ids[0] {
+			t.Fatalf("approval id churned: cycle %d id = %q, cycle 0 id = %q", i, id, ids[0])
+		}
+	}
+	// Exactly one approval ever existed — no stale/superseded siblings.
+	if len(s.Approvals) != 1 {
+		t.Fatalf("len(approvals) = %d, want 1 (no churn siblings)", len(s.Approvals))
+	}
+
+	// The id read a cycle earlier is still approvable on the last cycle.
+	approved, err := s.ApproveApproval(ids[0], now.Add(5*time.Minute), "cli", "land hand-off")
+	if err != nil {
+		t.Fatalf("ApproveApproval(stable id) after %d cycles: %v", len(ids), err)
+	}
+	if approved.Status != ApprovalStatusApproved {
+		t.Fatalf("approved status = %q, want approved", approved.Status)
 	}
 }
 
@@ -2293,35 +2366,40 @@ func TestApproveMissingApprovalFailsSafely(t *testing.T) {
 	}
 }
 
-func TestApproveStaleApprovalFailsSafely(t *testing.T) {
+// #750: target-state drift between mint and approve must NOT stale the
+// approval. The pre-#750 behaviour (asserted by the old
+// TestApproveStaleApprovalFailsSafely) returned ErrApprovalStale here, which
+// is precisely why `supervise approve <freshest-id>` raced a moving target on
+// the dogfood supervisor. The executor re-validates runtime preconditions at
+// execute time, so the approve gate keys only on the unchanged decision
+// identity. Genuine payload-identity changes still fail safely — see
+// TestApproveChangedApprovalPayloadFailsSafely.
+func TestApproveSucceedsAcrossTargetStateDrift(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
 	s := NewState()
 	s.Sessions["slot-1"] = &Session{IssueNumber: 77, Status: StatusRetryExhausted, PRNumber: 12}
 	decision := SupervisorDecision{
-		ID:                "sup-stale",
+		ID:                "sup-stable",
 		CreatedAt:         now,
 		Project:           "owner/repo",
 		Mode:              "read_only",
-		Summary:           "Review retry-exhausted issue #77.",
-		RecommendedAction: "review_retry_exhausted",
+		Summary:           "Merge PR #12 for issue #77.",
+		RecommendedAction: "merge_pr",
 		Target:            &SupervisorTarget{Issue: 77, PR: 12, Session: "slot-1"},
-		Risk:              "approval_gated",
+		Risk:              "mutating",
 		Confidence:        0.93,
-		Reasons:           []string{"retry budget exhausted"},
+		Reasons:           []string{"PR is green"},
 	}
 	approval := s.RecordPendingApprovalForDecision(decision, now)
+	// The bound session's runtime state moves before the operator approves.
 	s.Sessions["slot-1"].Status = StatusDone
 
-	_, err := s.ApproveApproval(approval.ID, now.Add(time.Minute), "cli", "")
-	if !errors.Is(err, ErrApprovalStale) {
-		t.Fatalf("ApproveApproval stale err = %v, want %v", err, ErrApprovalStale)
+	approved, err := s.ApproveApproval(approval.ID, now.Add(time.Minute), "cli", "land it")
+	if err != nil {
+		t.Fatalf("ApproveApproval across target-state drift: %v, want success", err)
 	}
-	if s.Approvals[0].Status != ApprovalStatusStale {
-		t.Fatalf("status = %q, want %q", s.Approvals[0].Status, ApprovalStatusStale)
-	}
-	last := s.Approvals[0].Audit[len(s.Approvals[0].Audit)-1]
-	if last.Event != ApprovalAuditStale {
-		t.Fatalf("last audit = %#v, want stale event", last)
+	if approved.Status != ApprovalStatusApproved {
+		t.Fatalf("status = %q, want approved", approved.Status)
 	}
 }
 


### PR DESCRIPTION
Implements #750 (Refs #750)

## Problem
Approval-gated verbs (`merge_pr`, `spawn_repair_worker`, `close_issue`, `delete_worktree`) could not be approved via the CLI or SPA: the pending approval was re-minted under a fresh id and the prior one staled/superseded on nearly every supervise cycle. The id was keyed on the per-cycle decision id/timestamp, and any drift in the volatile target-state snapshot (session status, retry count, next-retry time) both staled the live approval and forced a supersede + re-mint — so `maestro supervise approve <id>` and the `/approvals` button always raced a moving target.

## Changes (all in `internal/state`)
- **Content-addressed approval id**: `approvalID` now hashes the decision *identity* — `(action, target)` — instead of the per-cycle decision id/timestamp. Re-evaluating the same decision across cycles yields the same id.
- **Update-in-place re-emit**: `RecordPendingApprovalForDecision` refreshes the matching pending/awaiting approval in place (summary/risk/evidence/target-state + recomputed payload hash; id, created-at, status, and audit preserved) instead of superseding and minting a sibling. A rare content-id collision with a terminal record from a prior instance is disambiguated with a timestamp suffix.
- **No stale on churn**: `ensureApprovalCurrent` / `MarkStaleApprovals` no longer stale a pending approval when only the volatile runtime snapshot drifts. The executor re-validates runtime preconditions at execute time (`executeMergePR` re-checks `PRMergeStatus`; the worktree/worker verbs re-check slot reuse). The PayloadHash internal-consistency guard and the dedicated reconcilers (worker started, issue auto-closed) are unchanged, so supersession is reserved for genuine changes.

## Testing
- `internal/state`: 4-cycle `merge_pr` stability test (id stable + approvable on the last cycle under churning session state); in-place update on target-state change; approve succeeds across target-state drift.
- `internal/approver`: stable id over cycles for `merge_pr` (approving once executes the merge exactly once) and `spawn_repair_worker` (routes to awaiting_dispatch); distinct decisions get distinct ids and coexist.
- `internal/server`: SPA approve path succeeds after a churning supervise cycle.
- Existing tests that pinned the old churn contract were rewritten to the new update-in-place contract. `go test ./...`, `gofmt`, `go vet`, and `go build ./cmd/maestro/` all pass.

## Runtime verification still required
The acceptance criteria were observed live on the dogfood supervisor (170 stale + 81 superseded in history). This PR lands the code-level fix and unit coverage; confirming the dogfood gate is actionable end-to-end (`supervise approve` / SPA on a real pending `merge_pr` / `spawn_repair_worker`) requires operator verification after deploy. Not auto-closing for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a long-standing approval churn bug (#750) where `merge_pr`, `spawn_repair_worker`, and related gated verbs were un-approvable via CLI or SPA because a fresh approval ID was minted every supervisor cycle and the prior one was immediately staled.

- **Content-addressed IDs**: `approvalID` now hashes `(action, target)` instead of the per-cycle `decision.ID`/timestamp, so the same logical decision always maps to the same approval ID across cycles.
- **In-place refresh**: `RecordPendingApprovalForDecision` updates the live approval record in place (summary, risk, evidence, target-state snapshot, payload hash) instead of superseding and re-minting a sibling; supersession is now reserved for dedicated reconcilers and genuinely different decisions.
- **Approve-time gate narrowed**: `ensureApprovalCurrent` / `MarkStaleApprovals` no longer stale on volatile runtime-snapshot drift; executor-time re-validation (PRMergeStatus, slot reuse) preserves the safety envelope.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the narrowed approve-time gate is compensated by executor-time re-validation, and the content-addressed ID scheme is proven correct by the new cycle-stability and end-to-end tests.

The logic change is well-contained to the approval state machine, backed by multi-layer tests (unit, integration, and SPA-path), and the dropped target-state-snapshot gate has a documented safety net at execute time. No correctness gaps were found in the new in-place refresh path or the timestamp-suffix disambiguation for terminal-ID collisions.

No files require special attention; the stale godoc on RecordPendingApprovalForDecision (describing the old supersede contract) is the only outstanding note and was already flagged in the prior review round.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/state/state.go | Core approval state machine rewritten to use content-addressed IDs ((action, target) hash) and in-place refresh instead of supersede+re-mint; ensureApprovalCurrent drops the target-state-snapshot gate; well-guarded by executor-time re-validation. |
| internal/state/state_test.go | Rewrites two tests from the old churn contract to the new update-in-place contract; adds a 4-cycle stability test and an approve-across-drift test; thorough coverage of the new invariants. |
| internal/approver/stable_approval_test.go | New integration test file; exercises merge_pr and spawn_repair_worker id stability across cycles and confirms execute-once semantics; distinct-decision coexistence test pins the non-collision contract. |
| internal/server/approvals_test.go | Adds the SPA approve-after-churn test covering #750 criterion 1/3; correctly simulates a full cycle (MarkStaleApprovals + re-emit) before the approve request. |
| internal/server/fleet_test.go | Updates stale-rendering fixture to set status directly instead of relying on MarkStaleApprovals's now-removed target-state-drift branch; minimal and correct. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/state/state.go`, line 1912-1930 ([link](https://github.com/befeast/maestro/blob/f9948dae672f28d3c33d8d3f616ccf662845ca1f/internal/state/state.go#L1912-L1930)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The godoc comment for `RecordPendingApprovalForDecision` still describes the old pre-#750 behavior — it says the second bullet ("same action/target but TargetStateHash changed") results in a supersede + re-mint. That behavior was the root cause of #750 and is now removed. A reader relying on this comment to understand the dedup contract would have the opposite of the current truth.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/state/state.go
   Line: 1912-1930

   Comment:
   The godoc comment for `RecordPendingApprovalForDecision` still describes the old pre-#750 behavior — it says the second bullet ("same action/target but TargetStateHash changed") results in a supersede + re-mint. That behavior was the root cause of #750 and is now removed. A reader relying on this comment to understand the dedup contract would have the opposite of the current truth.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-227-75..."](https://github.com/befeast/maestro/commit/fa1c0b021e2b78b860da05709d39e8c566fb16e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38836957)</sub>

<!-- /greptile_comment -->