### PR TITLE
Phase 0: configstore write-API + интерфейс state.Store (фундамент, без изменения поведения)

### DIFF
--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -172,6 +172,26 @@ func importProject(ctx context.Context, tx *sql.Tx, sourcePath string, data []by
 	}
 	backends := detachBackends(&root)
 	now := time.Now().UTC().Format(time.RFC3339)
+	if err := upsertSharedBackendsTx(ctx, tx, backends, now); err != nil {
+		return err
+	}
+	projectYAML, err := marshalNode(&root)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
+INSERT INTO project(name, source_path, config_yaml, backend_ref, updated_at)
+VALUES(?, ?, ?, 'global', ?)
+ON CONFLICT(name) DO UPDATE SET source_path = excluded.source_path, config_yaml = excluded.config_yaml, updated_at = excluded.updated_at
+`, projectName, sourcePath, string(projectYAML), now)
+	return err
+}
+
+// upsertSharedBackendsTx inserts/updates the shared backend definitions
+// detached from a project's YAML. It mirrors importProject's behavior:
+// a backend whose definition differs from one already stored is rejected,
+// so two projects can share a backend only when their definitions agree.
+func upsertSharedBackendsTx(ctx context.Context, tx *sql.Tx, backends map[string]*yaml.Node, now string) error {
 	for name, def := range backends {
 		defYAML, err := marshalNode(def)
 		if err != nil {
@@ -193,16 +213,126 @@ ON CONFLICT(name) DO UPDATE SET definition_yaml = excluded.definition_yaml, upda
 			return err
 		}
 	}
+	return nil
+}
+
+// UpsertProject writes a single project's config under an explicit name,
+// mirroring importProject: the YAML is validated through config.Parse, any
+// model.backends block is detached into the shared backends table, and the
+// remaining project document is stored INSERT ... ON CONFLICT. The whole
+// write runs in one transaction so a divergent shared backend rolls the
+// project write back too. source_path is left empty for write-API projects
+// (they have no originating file) and is preserved on conflict.
+func (s *Store) UpsertProject(ctx context.Context, name, configYAML string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("project name is required")
+	}
+	if _, err := config.Parse([]byte(configYAML)); err != nil {
+		return err
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(configYAML), &root); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	backends := detachBackends(&root)
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := upsertSharedBackendsTx(ctx, tx, backends, now); err != nil {
+		return err
+	}
 	projectYAML, err := marshalNode(&root)
 	if err != nil {
 		return err
 	}
-	_, err = tx.ExecContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
 INSERT INTO project(name, source_path, config_yaml, backend_ref, updated_at)
-VALUES(?, ?, ?, 'global', ?)
-ON CONFLICT(name) DO UPDATE SET source_path = excluded.source_path, config_yaml = excluded.config_yaml, updated_at = excluded.updated_at
-`, projectName, sourcePath, string(projectYAML), now)
+VALUES(?, '', ?, 'global', ?)
+ON CONFLICT(name) DO UPDATE SET config_yaml = excluded.config_yaml, updated_at = excluded.updated_at
+`, name, string(projectYAML), now); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// DeleteProject removes a project row. Deleting a missing project is a no-op
+// (no error), matching idempotent delete semantics. Shared backend rows are
+// left intact: they may still be referenced by other projects.
+func (s *Store) DeleteProject(ctx context.Context, name string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("project name is required")
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM project WHERE name = ?`, name)
 	return err
+}
+
+// UpsertBackend writes a shared backend definition directly (write-API).
+// Unlike the import path it overwrites an existing definition rather than
+// rejecting divergence — the caller is making an explicit edit. definitionYAML
+// is validated only as well-formed YAML; backend-shape validation happens when
+// a project that references it is parsed.
+func (s *Store) UpsertBackend(ctx context.Context, name, definitionYAML string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("backend name is required")
+	}
+	var probe yaml.Node
+	if err := yaml.Unmarshal([]byte(definitionYAML), &probe); err != nil {
+		return fmt.Errorf("parse backend %q: %w", name, err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO backends(name, definition_yaml, updated_at)
+VALUES(?, ?, ?)
+ON CONFLICT(name) DO UPDATE SET definition_yaml = excluded.definition_yaml, updated_at = excluded.updated_at
+`, name, definitionYAML, now)
+	return err
+}
+
+// SetGlobal writes a global key/value (write-API). valueYAML is validated only
+// as well-formed YAML.
+func (s *Store) SetGlobal(ctx context.Context, key, valueYAML string) error {
+	if strings.TrimSpace(key) == "" {
+		return errors.New("global key is required")
+	}
+	var probe yaml.Node
+	if err := yaml.Unmarshal([]byte(valueYAML), &probe); err != nil {
+		return fmt.Errorf("parse global %q: %w", key, err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO global(key, value_yaml, updated_at)
+VALUES(?, ?, ?)
+ON CONFLICT(key) DO UPDATE SET value_yaml = excluded.value_yaml, updated_at = excluded.updated_at
+`, key, valueYAML, now)
+	return err
+}
+
+// ProjectsFingerprint returns each project's name mapped to its updated_at
+// timestamp. Callers use it to detect which projects changed since a prior
+// snapshot without loading every config.
+func (s *Store) ProjectsFingerprint(ctx context.Context) (map[string]time.Time, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT name, updated_at FROM project`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]time.Time)
+	for rows.Next() {
+		var name, updatedAt string
+		if err := rows.Scan(&name, &updatedAt); err != nil {
+			return nil, err
+		}
+		ts, err := time.Parse(time.RFC3339, updatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse updated_at for project %q: %w", name, err)
+		}
+		out[name] = ts
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) exportProjectYAML(ctx context.Context, name string) ([]byte, string, error) {

--- a/internal/configstore/store_write_test.go
+++ b/internal/configstore/store_write_test.go
@@ -1,0 +1,279 @@
+package configstore
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+const writeTestYAML = `
+repo: BeFeast/maestro
+local_path: ~/src/maestro
+model:
+  default: codex
+  fallback_backends: [claude]
+  backends:
+    codex:
+      cmd: codex
+      extra_args: ["--model", "gpt-5.4"]
+      prompt_mode: stdin
+    claude:
+      cmd: claude
+      prompt_mode: arg
+supervisor:
+  enabled: true
+  backend: claude
+`
+
+func TestUpsertProjectLoadAllRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	if err := store.UpsertProject(ctx, "befeast-maestro", writeTestYAML); err != nil {
+		t.Fatalf("UpsertProject: %v", err)
+	}
+
+	// Backends were detached into the shared table, not duplicated in the row.
+	var projectYAML string
+	if err := store.db.QueryRowContext(ctx, `SELECT config_yaml FROM project WHERE name = ?`, "befeast-maestro").Scan(&projectYAML); err != nil {
+		t.Fatalf("query project: %v", err)
+	}
+	if strings.Contains(projectYAML, "\n  backends:") {
+		t.Fatalf("project row should not duplicate backend definitions:\n%s", projectYAML)
+	}
+
+	want, err := config.Parse([]byte(writeTestYAML))
+	if err != nil {
+		t.Fatalf("parse yaml: %v", err)
+	}
+
+	got, err := store.Load(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want.SourcePath = ""
+	got.SourcePath = ""
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round-trip config differs\n got=%#v\nwant=%#v", got.Model, want.Model)
+	}
+
+	all, err := store.LoadAll(ctx)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("LoadAll len = %d, want 1", len(all))
+	}
+}
+
+func TestUpsertProjectOverwrites(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	first := `
+repo: owner/project
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      prompt_mode: stdin
+`
+	if err := store.UpsertProject(ctx, "p", first); err != nil {
+		t.Fatalf("UpsertProject first: %v", err)
+	}
+
+	second := `
+repo: owner/project
+issue_labels: [maestro-ready]
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      prompt_mode: stdin
+`
+	if err := store.UpsertProject(ctx, "p", second); err != nil {
+		t.Fatalf("UpsertProject second: %v", err)
+	}
+
+	got, err := store.Load(ctx, "p")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.IssueLabels) != 1 || got.IssueLabels[0] != "maestro-ready" {
+		t.Fatalf("overwrite did not take effect: issue_labels = %v", got.IssueLabels)
+	}
+
+	var count int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM project`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("project count = %d, want 1 (upsert, not insert)", count)
+	}
+}
+
+func TestUpsertProjectRejectsInvalidYAML(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.UpsertProject(ctx, "bad", "not: [valid"); err == nil {
+		t.Fatal("UpsertProject accepted invalid YAML, want error")
+	}
+	var count int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM project`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("rejected project should not be written: count = %d", count)
+	}
+}
+
+func TestDeleteProject(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	base := `
+repo: owner/%s
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      prompt_mode: stdin
+`
+	if err := store.UpsertProject(ctx, "keep", strings.Replace(base, "%s", "keep", 1)); err != nil {
+		t.Fatalf("UpsertProject keep: %v", err)
+	}
+	if err := store.UpsertProject(ctx, "drop", strings.Replace(base, "%s", "drop", 1)); err != nil {
+		t.Fatalf("UpsertProject drop: %v", err)
+	}
+
+	if err := store.DeleteProject(ctx, "drop"); err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+
+	all, err := store.LoadAll(ctx)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("LoadAll len = %d, want 1", len(all))
+	}
+	if _, err := store.Load(ctx, "drop"); err == nil {
+		t.Fatal("Load of deleted project should fail")
+	}
+
+	// Deleting a missing project is a no-op, not an error.
+	if err := store.DeleteProject(ctx, "drop"); err != nil {
+		t.Fatalf("DeleteProject (missing) should be a no-op: %v", err)
+	}
+}
+
+func TestProjectsFingerprint(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	base := `
+repo: owner/%s
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      prompt_mode: stdin
+`
+	if err := store.UpsertProject(ctx, "a", strings.Replace(base, "%s", "a", 1)); err != nil {
+		t.Fatalf("UpsertProject a: %v", err)
+	}
+	if err := store.UpsertProject(ctx, "b", strings.Replace(base, "%s", "b", 1)); err != nil {
+		t.Fatalf("UpsertProject b: %v", err)
+	}
+
+	fp, err := store.ProjectsFingerprint(ctx)
+	if err != nil {
+		t.Fatalf("ProjectsFingerprint: %v", err)
+	}
+	if len(fp) != 2 {
+		t.Fatalf("fingerprint len = %d, want 2", len(fp))
+	}
+	for _, name := range []string{"a", "b"} {
+		ts, ok := fp[name]
+		if !ok {
+			t.Fatalf("fingerprint missing project %q", name)
+		}
+		if ts.IsZero() {
+			t.Fatalf("fingerprint for %q has zero timestamp", name)
+		}
+	}
+
+	if err := store.DeleteProject(ctx, "a"); err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+	fp, err = store.ProjectsFingerprint(ctx)
+	if err != nil {
+		t.Fatalf("ProjectsFingerprint after delete: %v", err)
+	}
+	if len(fp) != 1 {
+		t.Fatalf("fingerprint len after delete = %d, want 1", len(fp))
+	}
+	if _, ok := fp["a"]; ok {
+		t.Fatal("deleted project still present in fingerprint")
+	}
+}
+
+func TestUpsertBackend(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	if err := store.UpsertBackend(ctx, "codex", "cmd: codex\nprompt_mode: stdin\n"); err != nil {
+		t.Fatalf("UpsertBackend: %v", err)
+	}
+	var def string
+	if err := store.db.QueryRowContext(ctx, `SELECT definition_yaml FROM backends WHERE name = ?`, "codex").Scan(&def); err != nil {
+		t.Fatalf("query backend: %v", err)
+	}
+	if !strings.Contains(def, "cmd: codex") {
+		t.Fatalf("backend def = %q", def)
+	}
+
+	// Direct UpsertBackend overwrites rather than rejecting divergence.
+	if err := store.UpsertBackend(ctx, "codex", "cmd: other-codex\nprompt_mode: stdin\n"); err != nil {
+		t.Fatalf("UpsertBackend overwrite: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT definition_yaml FROM backends WHERE name = ?`, "codex").Scan(&def); err != nil {
+		t.Fatalf("query backend: %v", err)
+	}
+	if !strings.Contains(def, "other-codex") {
+		t.Fatalf("overwrite did not take effect: %q", def)
+	}
+}
+
+func TestSetGlobal(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	if err := store.SetGlobal(ctx, "defaults", "model:\n  default: codex\n"); err != nil {
+		t.Fatalf("SetGlobal: %v", err)
+	}
+	var val string
+	if err := store.db.QueryRowContext(ctx, `SELECT value_yaml FROM global WHERE key = ?`, "defaults").Scan(&val); err != nil {
+		t.Fatalf("query global: %v", err)
+	}
+	if !strings.Contains(val, "default: codex") {
+		t.Fatalf("global value = %q", val)
+	}
+
+	if err := store.SetGlobal(ctx, "defaults", "model:\n  default: claude\n"); err != nil {
+		t.Fatalf("SetGlobal overwrite: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT value_yaml FROM global WHERE key = ?`, "defaults").Scan(&val); err != nil {
+		t.Fatalf("query global: %v", err)
+	}
+	if !strings.Contains(val, "default: claude") {
+		t.Fatalf("overwrite did not take effect: %q", val)
+	}
+}

--- a/internal/state/jsonstore_test.go
+++ b/internal/state/jsonstore_test.go
@@ -1,0 +1,74 @@
+package state
+
+import (
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// TestJSONStoreRoundTrip confirms NewJSONStore is a 1:1 wrapper over the
+// package-level Load/Save: a State saved through the Store loads back through
+// the Store with identical contents, and reads identically via the free
+// function on the same directory (same file, same format).
+func TestJSONStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewJSONStore(dir)
+
+	s := NewState()
+	s.Sessions["slot-1"] = &Session{
+		IssueNumber: 42,
+		Branch:      "feat/test",
+		Status:      StatusPROpen,
+		PRNumber:    10,
+		StartedAt:   time.Now().UTC().Truncate(time.Second),
+	}
+	if err := store.Save(s); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	sess := loaded.Sessions["slot-1"]
+	if sess == nil {
+		t.Fatal("slot-1 not found after Store round-trip")
+	}
+	if sess.IssueNumber != 42 || sess.PRNumber != 10 || sess.Status != StatusPROpen {
+		t.Fatalf("session mismatch after round-trip: %+v", sess)
+	}
+
+	// Same file, same format: the free function reads the same bytes the
+	// Store wrote, and produces an equivalent State.
+	viaFree, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !reflect.DeepEqual(loaded.Sessions, viaFree.Sessions) {
+		t.Fatalf("Store and free-function Load disagree:\n store=%#v\n free =%#v", loaded.Sessions, viaFree.Sessions)
+	}
+}
+
+// TestJSONStoreLoadEmpty confirms loading from a directory with no state file
+// returns a fresh State (no error), matching the free function's behavior.
+func TestJSONStoreLoadEmpty(t *testing.T) {
+	dir := t.TempDir()
+	store := NewJSONStore(dir)
+
+	s, err := store.Load()
+	if err != nil {
+		t.Fatalf("store.Load on empty dir: %v", err)
+	}
+	if s == nil || s.Sessions == nil {
+		t.Fatal("expected a fresh initialized State from empty dir")
+	}
+	if len(s.Sessions) != 0 {
+		t.Fatalf("expected no sessions, got %d", len(s.Sessions))
+	}
+
+	// No state file should have been created by a Load.
+	if _, statErr := os.Stat(StatePath(dir)); !os.IsNotExist(statErr) {
+		t.Fatalf("Load should not create the state file; stat err = %v", statErr)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1210,6 +1210,44 @@ func LogDir(stateDir string) string {
 	return filepath.Join(stateDir, "logs")
 }
 
+// Store abstracts persistence of orchestration State so call-sites need not
+// depend on the package-level Load/Save free functions directly. The default
+// jsonStore implementation (NewJSONStore) wraps the existing JSON-file path —
+// flock + 3-way merge on Save — so its behavior is identical to calling
+// Load/Save directly. A future database-backed implementation can satisfy the
+// same contract without touching call-sites. The typed accessors/mutators
+// (Sessions, Approvals, RecordSupervisorDecision, …) live on the *State value
+// that Load returns and Save persists.
+type Store interface {
+	// Load returns the current persisted State, or a fresh empty State when
+	// none has been written yet.
+	Load() (*State, error)
+	// Save persists s, merging independent concurrent writes exactly as the
+	// package-level Save does (flock + 3-way merge).
+	Save(s *State) error
+}
+
+// jsonStore is the default Store backed by <dir>/state.json. It is a thin
+// wrapper over the package-level Load/Save free functions, so its on-disk
+// format and concurrency semantics are unchanged.
+type jsonStore struct {
+	dir string
+}
+
+// NewJSONStore returns the default file-backed Store rooted at stateDir.
+func NewJSONStore(stateDir string) Store {
+	return &jsonStore{dir: stateDir}
+}
+
+// StateDir returns the directory this store persists to.
+func (j *jsonStore) StateDir() string { return j.dir }
+
+// Load implements Store by delegating to the package-level Load.
+func (j *jsonStore) Load() (*State, error) { return Load(j.dir) }
+
+// Save implements Store by delegating to the package-level Save.
+func (j *jsonStore) Save(s *State) error { return Save(j.dir, s) }
+
 func Load(stateDir string) (*State, error) {
 	path := StatePath(stateDir)
 	data, err := os.ReadFile(path)


### PR DESCRIPTION
Implements #755 (Phase 0 of epic #754). No behavior change — only new, currently unused methods plus an internal refactor.

## Changes
- **configstore write-API** (`internal/configstore/store.go`): `UpsertProject`, `DeleteProject`, `UpsertBackend`, `SetGlobal`, `ProjectsFingerprint`. Project upserts validate via `config.Parse`, detach `model.backends` into the shared table, and write `INSERT ... ON CONFLICT` in a single transaction. The shared-backend upsert (with divergence check) is extracted into a helper reused by `importProject`, so existing import behavior is unchanged.
- **state.Store interface** (`internal/state/state.go`): a `Store` interface (`Load`/`Save`) with the default file-backed `jsonStore` (`NewJSONStore`) that delegates 1:1 to the package-level `Load`/`Save` (flock + 3-way merge, same file, same format). Call-sites are left untouched; the abstraction is the foundation for later phases.
- Standard `database/sql` only (`?` placeholders + `ON CONFLICT`, consistent with existing code).

## Testing
- `go build ./cmd/maestro/` — green.
- `go test ./...` — green (includes new tests).
- New tests: configstore upsert→loadall round-trip, overwrite, invalid-YAML rejection, delete, fingerprint, UpsertBackend, SetGlobal; state jsonStore round-trip + empty-dir load.

Refs #755

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a write API to `configstore` (`UpsertProject`, `DeleteProject`, `UpsertBackend`, `SetGlobal`, `ProjectsFingerprint`) and introduces a `state.Store` interface backed by the existing JSON-file implementation, with no changes to existing call-sites.

- **configstore write API**: new methods run inside a transaction, re-use the extracted `upsertSharedBackendsTx` helper (shared with the unchanged import path), and validate project YAML via `config.Parse` before writing.
- **state.Store interface**: thin wrapper over the package-level `Load`/`Save` free functions; same flock + 3-way-merge semantics, intended as a seam for a future database-backed implementation.
- **Tests**: both new packages are covered by round-trip, overwrite, rejection, delete, and fingerprint scenarios.

<h3>Confidence Score: 3/5</h3>

Safe to merge for existing behavior (import path is unchanged), but the new UpsertBackend method has a format-consistency gap with the rest of the write API that should be resolved before these methods are wired up to any caller.

The refactor of importProject into upsertSharedBackendsTx is clean and the existing import path is demonstrably unchanged. The state.Store wrapper is a no-op shim. The concern is in UpsertBackend: it stores the raw caller-supplied YAML string, while every other write path normalizes through marshalNode first. A backend written by UpsertBackend and then referenced in a subsequent UpsertProject or ImportDir call will trigger the divergence check comparing two different string representations of the same logical definition, causing an unexpected rejection. Since these methods are currently unused (Phase 0 foundation), there is no runtime impact today, but the bug is baked in and will surface as soon as Phase 1 wires up callers.

internal/configstore/store.go — specifically the UpsertBackend implementation and the ProjectsFingerprint timestamp granularity.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/configstore/store.go | Adds write-API methods (UpsertProject, DeleteProject, UpsertBackend, SetGlobal, ProjectsFingerprint) and extracts upsertSharedBackendsTx helper; UpsertBackend stores raw YAML rather than the normalized form that the import path uses, which can cause false divergence errors on subsequent imports. |
| internal/configstore/store_write_test.go | New test file covering all write-API methods with round-trip, overwrite, invalid-YAML rejection, delete, fingerprint, and UpsertBackend scenarios; coverage is thorough for the happy paths. |
| internal/state/state.go | Adds Store interface and jsonStore wrapper delegating 1:1 to package-level Load/Save; exported StateDir() method on jsonStore is unreachable through the returned Store interface. |
| internal/state/jsonstore_test.go | New test file verifying Store round-trip and empty-dir load; correctly checks that Load does not create the state file. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/configstore/store.go:290-305
**`UpsertBackend` stores raw YAML; import path stores normalized YAML**

`UpsertBackend` writes the caller-supplied `definitionYAML` string verbatim, while `upsertSharedBackendsTx` (used by both `importProject` and `UpsertProject`) always normalizes through `marshalNode` before storing. When a subsequent call to `UpsertProject` or `ImportDir` encounters a backend that was last written by `UpsertBackend`, the divergence check compares `strings.TrimSpace(marshalNode(importedNode))` against the raw string, and any formatting difference (e.g. different indentation level within the source project's YAML, trailing newline variations, go-yaml quoting choices) will produce a false conflict error and roll back the project write. The fix is to run `marshalNode(&probe)` in `UpsertBackend` and store that normalized form instead of `definitionYAML`.

### Issue 2 of 3
internal/state/state.go:1243
**`StateDir()` is exported but unreachable through the `Store` interface**

`NewJSONStore` returns a `Store` interface value, so the exported `StateDir()` method on `*jsonStore` is inaccessible to any caller holding a `Store` — a type assertion to `*jsonStore` would be required. If callers need the directory, the method should be added to the `Store` interface; if it is purely internal, it should be unexported.

### Issue 3 of 3
internal/configstore/store.go:316-340
**`ProjectsFingerprint` has second-level granularity — same-second writes are invisible**

`updated_at` is formatted as `time.RFC3339` (one-second resolution). Two `UpsertProject` calls on the same row within the same UTC second produce identical timestamps, so a caller comparing `ProjectsFingerprint` snapshots taken before and after such a burst would see no change and incorrectly conclude nothing happened. Consider storing `time.RFC3339Nano` (or a monotonically increasing rowid / version counter) if the fingerprint is expected to catch every write.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["configstore+state: write-API + state.Sto..."](https://github.com/befeast/maestro/commit/ac7d47400aeb803d7fcbab0b65be9d785443164d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39343152)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->