### PR TITLE
Phase 1: пакет internal/daemon + maestro daemon — N флоу (run+supervise) + один FleetServer

### DIFF
--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/befeast/maestro/internal/configstore"
+	"github.com/befeast/maestro/internal/daemon"
+)
+
+// daemonCmd runs every project in the config store as one long-lived process:
+// an orchestrator + supervisor loop per project flow, plus a single
+// FleetServer aggregating them all (#756, epic #754). It is strictly opt-in —
+// the legacy maestro@<project> units and `maestro serve` are unaffected.
+func daemonCmd(args []string) {
+	fs := flag.NewFlagSet("daemon", flag.ExitOnError)
+	storePath := fs.String("store", defaultConfigStorePath(), "Path to SQLite config store")
+	runInterval := fs.Duration("run-interval", 10*time.Minute, "Orchestrator loop interval")
+	superviseInterval := fs.Duration("supervise-interval", 5*time.Minute, "Supervisor loop interval")
+	host := fs.String("host", "127.0.0.1", "Host/interface to bind the fleet web server")
+	port := fs.Int("port", 8786, "Port to bind the fleet web server")
+	promptPath := fs.String("prompt", "", "Path to worker prompt base file")
+	readOnly := fs.Bool("read-only", false, "Disable mutating fleet HTTP endpoints")
+	fs.Parse(args)
+
+	ctx := signalContext()
+
+	store, err := configstore.Open(*storePath)
+	if err != nil {
+		log.Fatalf("daemon: open config store %s: %v", *storePath, err)
+	}
+	defer store.Close()
+
+	d := daemon.New(store, daemon.Options{
+		Host:              *host,
+		Port:              *port,
+		RunInterval:       *runInterval,
+		SuperviseInterval: *superviseInterval,
+		PromptPath:        *promptPath,
+		Version:           resolveVersion(),
+		ReadOnly:          *readOnly,
+	})
+
+	log.Printf("starting maestro daemon — store=%s addr=%s:%d", *storePath, *host, *port)
+	if err := d.Run(ctx); err != nil {
+		log.Fatalf("daemon: %v", err)
+	}
+}
+
+// signalContext returns a context cancelled on SIGINT/SIGTERM so the daemon
+// drains its flows and shuts the fleet server down gracefully.
+func signalContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		log.Printf("received signal, shutting down daemon...")
+		cancel()
+	}()
+	return ctx
+}
+
+// defaultConfigStorePath mirrors the config-store default used elsewhere
+// (~/.maestro/config.db).
+func defaultConfigStorePath() string {
+	return filepath.Join(os.Getenv("HOME"), ".maestro", "config.db")
+}

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -46,6 +46,7 @@ Commands:
   run           Run the orchestration loop
   supervise     Run supervisor decision loop with safe queue actions
   serve         Run Mission Control read-only web dashboard/API
+  daemon        Run all config-store projects as one long-lived process (run+supervise+web)
   status        Show current state
   logs          Show worker logs (tail -f)
   watch         Open tmux dashboard with live worker output
@@ -309,6 +310,8 @@ func main() {
 		nightStartCmd(args)
 	case "serve":
 		serveCmd(args)
+	case "daemon":
+		daemonCmd(args)
 	case "status":
 		statusCmd(args)
 	case "logs":
@@ -722,7 +725,7 @@ func superviseCmd(args []string) {
 	// been bumped in 3*interval. The warning persists into state
 	// (SupervisorStuck=true) so the Fleet API and dashboards can
 	// surface it without grepping the journal.
-	go superviseWatchdog(ctx, cfg.StateDir, *interval)
+	go supervisor.Watchdog(ctx, cfg.StateDir, *interval)
 
 	ticker := time.NewTicker(*interval)
 	defer ticker.Stop()
@@ -742,79 +745,6 @@ func superviseCmd(args []string) {
 				log.Printf("supervise: cycle failed (will retry in %s): %v", *interval, err)
 			}
 		}
-	}
-}
-
-// superviseWatchdog emits a loud log warning + persists SupervisorStuck=true
-// in state.json when the supervise loop has not stamped state.LastRunOnceAt
-// within 3*interval. It is a defense against silent wedges (#499).
-//
-// The ticker fires every interval (matching the supervise cadence so we
-// don't over-poll the state file). On startup we grant a 3*interval grace
-// before the first check, since LastRunOnceAt might be old after a daemon
-// restart.
-func superviseWatchdog(ctx context.Context, stateDir string, interval time.Duration) {
-	if interval <= 0 {
-		return
-	}
-	stuckThreshold := 3 * interval
-	startedAt := time.Now()
-
-	tick := time.NewTicker(interval)
-	defer tick.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-tick.C:
-		}
-
-		// Startup grace: don't warn before we've had time to see one
-		// full cycle complete.
-		if time.Since(startedAt) < stuckThreshold {
-			continue
-		}
-
-		st, err := state.Load(stateDir)
-		if err != nil {
-			log.Printf("[supervise/watchdog] could not read state: %v (will retry)", err)
-			continue
-		}
-		if st.LastRunOnceAt.IsZero() {
-			// Daemon never completed a cycle. Loud warning, but only
-			// after the startup grace.
-			log.Printf("[supervise/watchdog] WARNING: no RunOnce has stamped state.LastRunOnceAt since the daemon started %s ago; check whether RunOnce is wedged",
-				time.Since(startedAt).Round(time.Second))
-			persistSupervisorStuck(stateDir, "no RunOnce has completed since daemon start")
-			continue
-		}
-		gap := time.Since(st.LastRunOnceAt)
-		if gap > stuckThreshold {
-			reason := fmt.Sprintf("LastRunOnceAt=%s is %s old (threshold %s)",
-				st.LastRunOnceAt.Format(time.RFC3339), gap.Round(time.Second), stuckThreshold)
-			log.Printf("[supervise/watchdog] WARNING: supervise loop appears stuck — %s", reason)
-			persistSupervisorStuck(stateDir, reason)
-		}
-	}
-}
-
-// persistSupervisorStuck flips SupervisorStuck=true in state.json so the
-// Fleet API surfaces it. Best-effort: a save failure is logged but does
-// not stop the watchdog.
-func persistSupervisorStuck(stateDir, reason string) {
-	st, err := state.Load(stateDir)
-	if err != nil {
-		log.Printf("[supervise/watchdog] persist: load state: %v", err)
-		return
-	}
-	if st.SupervisorStuck && st.SupervisorStuckReason == reason {
-		return // already set with the same reason; avoid log/save churn
-	}
-	st.SupervisorStuck = true
-	st.SupervisorStuckReason = reason
-	if err := state.Save(stateDir, st); err != nil {
-		log.Printf("[supervise/watchdog] persist: save state: %v", err)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,0 +1,157 @@
+// Package daemon runs every config-store project as one long-lived process
+// (#756, epic #754 single-service redesign). Before this, each project was its
+// own systemd unit (maestro@<project>.service) plus a per-project supervise
+// loop and a per-project fleet web server. The daemon collapses that into a
+// single process: one orchestrator + one supervisor loop per project flow, and
+// a single FleetServer aggregating every project.
+//
+// The orchestrator was already multi-project in one process (runCmd spawns a
+// goroutine per config); the daemon extends that model to supervise and the
+// web layer. It is strictly opt-in — the legacy units and `maestro serve`
+// keep working unchanged.
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/server"
+)
+
+// ConfigLoader yields the set of project configs the daemon supervises. It is
+// satisfied by *configstore.Store; tests inject an in-memory fake so the
+// daemon's lifecycle can be exercised without a real SQLite store.
+type ConfigLoader interface {
+	LoadAll(ctx context.Context) ([]*config.Config, error)
+}
+
+// Options configures a Daemon.
+type Options struct {
+	// Host and Port bind the single aggregating FleetServer (#516: one web
+	// for the whole fleet, default :8786).
+	Host string
+	Port int
+
+	// RunInterval is the orchestrator poll interval; a project's
+	// poll_interval_seconds in config overrides it per flow.
+	RunInterval time.Duration
+	// SuperviseInterval is the supervisor decision-loop interval per flow.
+	SuperviseInterval time.Duration
+
+	// PromptPath is an optional worker prompt base file applied to every flow.
+	PromptPath string
+	// Version is the running binary version, surfaced on the fleet API for
+	// the self-deploy health probe (#698).
+	Version string
+	// ReadOnly disables the fleet's mutating HTTP endpoints.
+	ReadOnly bool
+}
+
+// Daemon owns the running project flows and the shared FleetServer.
+type Daemon struct {
+	store ConfigLoader
+	opts  Options
+
+	mu    sync.Mutex
+	fleet *server.FleetServer
+	flows map[string]*projectFlow
+
+	// runLoop and superviseLoop build the per-project loops. They default to
+	// the production orchestrator + supervisor wiring; tests override them to
+	// drive flows without reaching GitHub.
+	runLoop       func(ctx context.Context, cfg *config.Config, opts Options)
+	superviseLoop func(ctx context.Context, cfg *config.Config, opts Options)
+}
+
+// New constructs a Daemon that loads projects from store on Run.
+func New(store ConfigLoader, opts Options) *Daemon {
+	d := &Daemon{
+		store: store,
+		opts:  opts,
+		flows: make(map[string]*projectFlow),
+	}
+	d.runLoop = runOrchestrator
+	d.superviseLoop = func(ctx context.Context, cfg *config.Config, opts Options) {
+		runSupervise(ctx, cfg, opts.SuperviseInterval)
+	}
+	return d
+}
+
+// Run loads every project from the store, starts a flow (orchestrator +
+// supervisor) for each, and serves one FleetServer aggregating them all. It
+// blocks until ctx is cancelled, then drains every flow before returning.
+//
+// A project that cannot be turned into a flow (duplicate fleet name) is
+// logged and skipped — one bad project must never abort daemon startup or the
+// other flows (#756).
+func (d *Daemon) Run(ctx context.Context) error {
+	cfgs, err := d.store.LoadAll(ctx)
+	if err != nil {
+		return fmt.Errorf("load configs: %w", err)
+	}
+	if len(cfgs) == 0 {
+		return errors.New("config store has no projects")
+	}
+
+	seen := make(map[string]bool, len(cfgs))
+	projects := make([]server.FleetProject, 0, len(cfgs))
+	for _, cfg := range cfgs {
+		proj := newFleetProject(cfg)
+		if seen[proj.Name] {
+			log.Printf("[daemon] skip project %q (repo=%s): duplicate fleet name already started", proj.Name, cfg.Repo)
+			continue
+		}
+		seen[proj.Name] = true
+		flow := d.startFlow(ctx, proj)
+		projects = append(projects, proj)
+		log.Printf("[daemon] started flow %q (repo=%s)", flow.name, cfg.Repo)
+	}
+
+	// One FleetServer for the whole fleet — replaces the N per-project
+	// server.New instances the legacy run/serve paths spun up (#516).
+	fleet := server.NewFleet(projects, d.opts.Host, d.opts.Port, d.opts.ReadOnly)
+	fleet.SetAuth(fleetAuth(projects))
+	d.mu.Lock()
+	d.fleet = fleet
+	d.mu.Unlock()
+
+	log.Printf("[daemon] serving fleet — projects=%d addr=%s:%d read_only=%v", len(projects), d.opts.Host, d.opts.Port, d.opts.ReadOnly)
+	fleetErr := make(chan error, 1)
+	go func() { fleetErr <- fleet.Start(ctx) }()
+
+	// Block until shutdown is requested. We wait on ctx (not fleet.Start) so
+	// the daemon stays up even when the fleet is not bound (port 0).
+	<-ctx.Done()
+	d.stopAll()
+	return <-fleetErr
+}
+
+// Fleet returns the aggregating FleetServer once Run has built it, or nil
+// before then. Exposed for tests and embedders that want the handle.
+func (d *Daemon) Fleet() *server.FleetServer {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.fleet
+}
+
+// fleetAuth returns the first non-empty Server.Auth config across the fleet.
+// The fleet uses a single shared token (#487); per-project distinct tokens are
+// intentionally out of scope.
+func fleetAuth(projects []server.FleetProject) config.ServerAuthConfig {
+	for i := range projects {
+		cfg := projects[i].Cfg()
+		if cfg == nil {
+			continue
+		}
+		if strings.TrimSpace(cfg.Server.Auth.TokenEnv) != "" {
+			return cfg.Server.Auth
+		}
+	}
+	return config.ServerAuthConfig{}
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,0 +1,252 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/server"
+)
+
+// fakeLoader is an in-memory ConfigLoader so the daemon lifecycle can be
+// exercised without a real SQLite config store.
+type fakeLoader struct {
+	cfgs []*config.Config
+	err  error
+}
+
+func (f fakeLoader) LoadAll(ctx context.Context) ([]*config.Config, error) {
+	return f.cfgs, f.err
+}
+
+func testConfig(t *testing.T, repo string) *config.Config {
+	t.Helper()
+	return &config.Config{
+		Repo:        repo,
+		StateDir:    t.TempDir(),
+		MaxParallel: 1,
+	}
+}
+
+// loopTracker records per-loop start/stop so tests can assert flows ran and
+// drained without reaching GitHub.
+type loopTracker struct {
+	started int64
+	stopped int64
+}
+
+func (lt *loopTracker) loop(ctx context.Context, cfg *config.Config, opts Options) {
+	atomic.AddInt64(&lt.started, 1)
+	<-ctx.Done()
+	atomic.AddInt64(&lt.stopped, 1)
+}
+
+// newTestDaemon builds a daemon with stub loops (no GitHub) over the given
+// configs.
+func newTestDaemon(loader ConfigLoader, run, supervise func(context.Context, *config.Config, Options)) *Daemon {
+	d := New(loader, Options{Host: "127.0.0.1", Port: 0})
+	if run != nil {
+		d.runLoop = run
+	}
+	if supervise != nil {
+		d.superviseLoop = supervise
+	}
+	return d
+}
+
+func TestRunStartsFlowPerProjectAndAggregatesFleet(t *testing.T) {
+	cfgs := []*config.Config{
+		testConfig(t, "owner/alpha"),
+		testConfig(t, "owner/beta"),
+		testConfig(t, "owner/gamma"),
+	}
+	var runTracker, supTracker loopTracker
+	d := newTestDaemon(fakeLoader{cfgs: cfgs}, runTracker.loop, supTracker.loop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	// Wait for the fleet to be built.
+	fleet := waitForFleet(t, d)
+
+	// /api/v1/fleet must show every project (acceptance criterion).
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	rec := httptest.NewRecorder()
+	fleet.HandlerForTest().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/fleet = %d, want 200", rec.Code)
+	}
+	var resp struct {
+		Projects []json.RawMessage `json:"projects"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode fleet response: %v", err)
+	}
+	if len(resp.Projects) != 3 {
+		t.Fatalf("fleet projects = %d, want 3", len(resp.Projects))
+	}
+
+	// Each flow ran both loops.
+	if got := atomic.LoadInt64(&runTracker.started); got != 3 {
+		t.Fatalf("run loops started = %d, want 3", got)
+	}
+	if got := atomic.LoadInt64(&supTracker.started); got != 3 {
+		t.Fatalf("supervise loops started = %d, want 3", got)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancellation")
+	}
+
+	// Every loop drained on shutdown.
+	if got := atomic.LoadInt64(&runTracker.stopped); got != 3 {
+		t.Fatalf("run loops stopped = %d, want 3", got)
+	}
+	if got := atomic.LoadInt64(&supTracker.stopped); got != 3 {
+		t.Fatalf("supervise loops stopped = %d, want 3", got)
+	}
+}
+
+func TestRunSkipsDuplicateFleetName(t *testing.T) {
+	// Two configs deriving the same fleet name (same repo) — the second must
+	// be skipped, not silently overwrite the first.
+	cfgs := []*config.Config{
+		testConfig(t, "owner/dup"),
+		testConfig(t, "owner/dup"),
+	}
+	var run, sup loopTracker
+	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.loop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	waitForFleet(t, d)
+
+	d.mu.Lock()
+	flows := len(d.flows)
+	d.mu.Unlock()
+	if flows != 1 {
+		t.Fatalf("flows = %d, want 1 (duplicate name skipped)", flows)
+	}
+	if got := atomic.LoadInt64(&run.started); got != 1 {
+		t.Fatalf("run loops started = %d, want 1", got)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestRunEmptyStoreReturnsError(t *testing.T) {
+	d := New(fakeLoader{cfgs: nil}, Options{Port: 0})
+	if err := d.Run(context.Background()); err == nil {
+		t.Fatal("Run with empty store: want error, got nil")
+	}
+}
+
+func TestStartStopFlowDrains(t *testing.T) {
+	cfg := testConfig(t, "owner/solo")
+	var run, sup loopTracker
+	d := newTestDaemon(fakeLoader{cfgs: []*config.Config{cfg}}, run.loop, sup.loop)
+
+	proj := newFleetProject(cfg)
+	flow := d.startFlow(context.Background(), proj)
+
+	// Both loops should be running.
+	waitFor(t, func() bool { return atomic.LoadInt64(&run.started) == 1 && atomic.LoadInt64(&sup.started) == 1 })
+
+	d.stopFlow(flow.name)
+
+	select {
+	case <-flow.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("flow did not drain after stopFlow")
+	}
+	if atomic.LoadInt64(&run.stopped) != 1 || atomic.LoadInt64(&sup.stopped) != 1 {
+		t.Fatalf("loops did not drain: run.stopped=%d sup.stopped=%d", run.stopped, sup.stopped)
+	}
+
+	// Flow is deregistered.
+	d.mu.Lock()
+	_, ok := d.flows[flow.name]
+	d.mu.Unlock()
+	if ok {
+		t.Fatal("flow still registered after stopFlow")
+	}
+
+	// stopFlow on an unknown name is a no-op.
+	d.stopFlow("does-not-exist")
+}
+
+func TestFlowPanicContained(t *testing.T) {
+	// A panic in one loop must be contained: the daemon (and the other loop)
+	// survive. This is the "one bad project doesn't kill the daemon" guarantee
+	// at the goroutine level (#756).
+	cfg := testConfig(t, "owner/panicky")
+	var supStarted, supStopped int64
+	supervise := func(ctx context.Context, c *config.Config, o Options) {
+		atomic.AddInt64(&supStarted, 1)
+		<-ctx.Done()
+		atomic.AddInt64(&supStopped, 1)
+	}
+	run := func(ctx context.Context, c *config.Config, o Options) {
+		panic("boom")
+	}
+	d := newTestDaemon(fakeLoader{cfgs: []*config.Config{cfg}}, run, supervise)
+
+	proj := newFleetProject(cfg)
+	flow := d.startFlow(context.Background(), proj)
+
+	// The supervise loop keeps running despite the run loop's panic.
+	waitFor(t, func() bool { return atomic.LoadInt64(&supStarted) == 1 })
+
+	d.stopFlow(flow.name)
+	select {
+	case <-flow.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("flow did not drain after a contained panic")
+	}
+	if atomic.LoadInt64(&supStopped) != 1 {
+		t.Fatal("supervise loop did not drain after the run loop panicked")
+	}
+}
+
+func waitForFleet(t *testing.T, d *Daemon) *server.FleetServer {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if f := d.Fleet(); f != nil {
+			return f
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("fleet was not built within deadline")
+	return nil
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -1,0 +1,145 @@
+package daemon
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/configwatch"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/orchestrator"
+	"github.com/befeast/maestro/internal/server"
+)
+
+// projectFlow is one project running inside the daemon: an orchestrator loop
+// and a supervisor loop sharing a child context. Cancelling that context
+// (stopFlow) tears both loops down.
+type projectFlow struct {
+	name   string
+	cfg    *config.Config
+	cancel context.CancelFunc
+	done   chan struct{} // closed once both loops have exited
+}
+
+// newFleetProject wraps a config for in-process fleet serving, mirroring the
+// `maestro serve` wiring: a safe-action GitHub client, plus the GitHub Project
+// board client when github_projects is enabled. The project name is derived
+// from the repo (NewFleetProject's default) to match the serve path.
+func newFleetProject(cfg *config.Config) server.FleetProject {
+	proj := server.NewFleetProject("", cfg.ResolvePath(), "", cfg)
+	gh := github.New(cfg.Repo)
+	proj.SetActionGH(gh)
+	if cfg.GitHubProjects.Enabled && cfg.GitHubProjects.ProjectNumber > 0 {
+		proj.SetBoardClient(gh, cfg.GitHubProjects.ProjectNumber)
+	}
+	return proj
+}
+
+// startFlow launches the orchestrator + supervisor loops for proj under a
+// child of parent and registers the flow. Each loop runs in its own goroutine
+// with a panic recover so a single project's crash can never take the daemon
+// (or the other flows) down (#756).
+func (d *Daemon) startFlow(parent context.Context, proj server.FleetProject) *projectFlow {
+	cfg := proj.Cfg()
+	fctx, cancel := context.WithCancel(parent)
+	flow := &projectFlow{
+		name:   proj.Name,
+		cfg:    cfg,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defer recoverFlow(flow.name, "orchestrator")
+		d.runLoop(fctx, cfg, d.opts)
+	}()
+	go func() {
+		defer wg.Done()
+		defer recoverFlow(flow.name, "supervise")
+		d.superviseLoop(fctx, cfg, d.opts)
+	}()
+	go func() {
+		wg.Wait()
+		close(flow.done)
+	}()
+
+	d.mu.Lock()
+	d.flows[flow.name] = flow
+	d.mu.Unlock()
+	return flow
+}
+
+// stopFlow cancels a flow's context, waits for both loops to drain, and
+// deregisters it. Safe to call for an unknown name (no-op).
+func (d *Daemon) stopFlow(name string) {
+	d.mu.Lock()
+	flow, ok := d.flows[name]
+	if ok {
+		delete(d.flows, name)
+	}
+	d.mu.Unlock()
+	if !ok {
+		return
+	}
+	flow.cancel()
+	<-flow.done
+	log.Printf("[daemon] stopped flow %q", name)
+}
+
+// stopAll drains every running flow. Called on daemon shutdown.
+func (d *Daemon) stopAll() {
+	d.mu.Lock()
+	names := make([]string, 0, len(d.flows))
+	for name := range d.flows {
+		names = append(names, name)
+	}
+	d.mu.Unlock()
+	for _, name := range names {
+		d.stopFlow(name)
+	}
+}
+
+// recoverFlow swallows a panic in a flow loop so it stays contained to that
+// project. A panicking goroutine would otherwise crash the whole daemon.
+func recoverFlow(name, loop string) {
+	if r := recover(); r != nil {
+		log.Printf("[daemon] flow %q %s loop panicked (contained, flow stopped): %v", name, loop, r)
+	}
+}
+
+// runOrchestrator is the production run loop for one flow. It mirrors the
+// single-project branch of `maestro run` minus the per-project HTTP server
+// (the daemon serves one shared FleetServer instead) and minus the fatal exit
+// on run error — a failing orchestrator must log-and-continue, never take the
+// daemon down (#756). orchestrator.Run already log-and-continues on per-cycle
+// errors and returns nil on ctx cancellation.
+func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options) {
+	orch := orchestrator.New(cfg)
+	orch.SetBinaryVersion(opts.Version)
+	if err := orch.LoadPromptBase(opts.PromptPath); err != nil {
+		log.Printf("[%s] warn: load prompt: %v", cfg.SessionPrefix, err)
+	}
+
+	refreshCh := make(chan struct{}, 1)
+
+	// Config file watcher for hot-reload, matching `maestro run`.
+	if cfgPath := cfg.ResolvePath(); cfgPath != "" {
+		reloadCh := configwatch.Watch(ctx, cfgPath, 2*time.Second)
+		orch.SetConfigReloadCh(reloadCh)
+	}
+
+	runInterval := opts.RunInterval
+	if cfg.PollIntervalSeconds > 0 {
+		runInterval = time.Duration(cfg.PollIntervalSeconds) * time.Second
+	}
+
+	log.Printf("[%s] starting orchestrator — repo=%s interval=%s", cfg.SessionPrefix, cfg.Repo, runInterval)
+	if err := orch.Run(ctx, runInterval, false, refreshCh); err != nil {
+		log.Printf("[%s] orchestrator exited: %v", cfg.SessionPrefix, err)
+	}
+}

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -1,0 +1,57 @@
+package daemon
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/supervisor"
+)
+
+// runSupervise is the per-project supervisor loop, extracted from the
+// single-project `maestro supervise` command (cmd/maestro/main.go). The daemon
+// runs one per flow.
+//
+// Key difference from the CLI: the first cycle is log-and-continue, NOT
+// log.Fatalf. Under `systemctl start maestro@<project>`, a fatal first cycle
+// made a broken setup fail loudly — correct for one unit per project. In the
+// daemon a single broken project must not abort the process or the other
+// flows, so every cycle (including the first) is logged and retried. Persistent
+// failures still surface: the #499 watchdog flags SupervisorStuck when
+// LastRunOnceAt stops advancing.
+func runSupervise(ctx context.Context, cfg *config.Config, interval time.Duration) {
+	gh := github.New(cfg.Repo)
+	runOnce := func() error {
+		_, err := supervisor.RunOnce(cfg, gh)
+		return err
+	}
+
+	if err := runOnce(); err != nil {
+		log.Printf("[%s] supervise: first cycle failed (will retry): %v", cfg.SessionPrefix, err)
+	}
+
+	if interval <= 0 {
+		return
+	}
+
+	// Phase 1.2 (#499) liveness watchdog, one per flow.
+	go supervisor.Watchdog(ctx, cfg.StateDir, interval)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// #689: a failed cycle is logged and retried on the next tick,
+			// never fatal — a transient GitHub/decision-layer failure must
+			// not crash the daemon.
+			if err := runOnce(); err != nil {
+				log.Printf("[%s] supervise: cycle failed (will retry in %s): %v", cfg.SessionPrefix, interval, err)
+			}
+		}
+	}
+}

--- a/internal/supervisor/watchdog.go
+++ b/internal/supervisor/watchdog.go
@@ -1,0 +1,86 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// Watchdog emits a loud log warning + persists SupervisorStuck=true in
+// state.json when the supervise loop has not stamped state.LastRunOnceAt
+// within 3*interval. It is a defense against silent wedges (#499).
+//
+// The ticker fires every interval (matching the supervise cadence so we
+// don't over-poll the state file). On startup we grant a 3*interval grace
+// before the first check, since LastRunOnceAt might be old after a daemon
+// restart.
+//
+// One Watchdog runs per supervise loop: the single-project `maestro supervise`
+// CLI starts one, and `maestro daemon` starts one per project flow (#756).
+func Watchdog(ctx context.Context, stateDir string, interval time.Duration) {
+	if interval <= 0 {
+		return
+	}
+	stuckThreshold := 3 * interval
+	startedAt := time.Now()
+
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+		}
+
+		// Startup grace: don't warn before we've had time to see one
+		// full cycle complete.
+		if time.Since(startedAt) < stuckThreshold {
+			continue
+		}
+
+		st, err := state.Load(stateDir)
+		if err != nil {
+			log.Printf("[supervise/watchdog] could not read state: %v (will retry)", err)
+			continue
+		}
+		if st.LastRunOnceAt.IsZero() {
+			// Daemon never completed a cycle. Loud warning, but only
+			// after the startup grace.
+			log.Printf("[supervise/watchdog] WARNING: no RunOnce has stamped state.LastRunOnceAt since the daemon started %s ago; check whether RunOnce is wedged",
+				time.Since(startedAt).Round(time.Second))
+			persistSupervisorStuck(stateDir, "no RunOnce has completed since daemon start")
+			continue
+		}
+		gap := time.Since(st.LastRunOnceAt)
+		if gap > stuckThreshold {
+			reason := fmt.Sprintf("LastRunOnceAt=%s is %s old (threshold %s)",
+				st.LastRunOnceAt.Format(time.RFC3339), gap.Round(time.Second), stuckThreshold)
+			log.Printf("[supervise/watchdog] WARNING: supervise loop appears stuck — %s", reason)
+			persistSupervisorStuck(stateDir, reason)
+		}
+	}
+}
+
+// persistSupervisorStuck flips SupervisorStuck=true in state.json so the
+// Fleet API surfaces it. Best-effort: a save failure is logged but does
+// not stop the watchdog.
+func persistSupervisorStuck(stateDir, reason string) {
+	st, err := state.Load(stateDir)
+	if err != nil {
+		log.Printf("[supervise/watchdog] persist: load state: %v", err)
+		return
+	}
+	if st.SupervisorStuck && st.SupervisorStuckReason == reason {
+		return // already set with the same reason; avoid log/save churn
+	}
+	st.SupervisorStuck = true
+	st.SupervisorStuckReason = reason
+	if err := state.Save(stateDir, st); err != nil {
+		log.Printf("[supervise/watchdog] persist: save state: %v", err)
+	}
+}


### PR DESCRIPTION
Implements #756 (Phase 1 of epic #754, single-service redesign).

## Changes
- **`maestro daemon` subcommand** (`cmd/maestro/daemon.go`): one long-lived process that runs every config-store project as an internal flow. Flags: `--store`, `--run-interval`, `--supervise-interval`, `--host`, `--port`, `--prompt`, `--read-only`; plus `signalContext()` for graceful SIGINT/SIGTERM drain. Strictly opt-in — legacy `maestro@<project>` units and `serve` are untouched.
- **`internal/daemon`**: `Daemon.Run` loads all projects from the store, starts a flow per project, and serves a single `FleetServer` (replaces N per-project `server.New` instances). `flow.go` wires the per-project orchestrator loop (no per-project HTTP server) with panic containment; `supervise.go` extracts the per-project supervise loop with a **log-and-continue first cycle** (not `log.Fatalf`) so one broken project never aborts the daemon or the other flows.
- **`internal/supervisor/watchdog.go`**: hoisted `superviseWatchdog` + `persistSupervisorStuck` out of `cmd/maestro` so both the `supervise` CLI and the daemon reuse one watchdog per flow (#499).

## Testing
- `go build ./cmd/maestro/`, `gofmt`, and `go test ./...` all green.
- New `internal/daemon` unit tests: flow-per-project + fleet aggregation over `/api/v1/fleet`, duplicate-fleet-name skip, empty-store error, start/stop drain, and panic containment.
- Live smoke: `maestro daemon --store <db> --port 8799` brought up the seeded project, `curl :8799/api/v1/fleet` listed it, a project with unreachable GitHub logged-and-continued (daemon stayed up), and shutdown drained the flow cleanly.

Runtime/soak verification alongside the existing units is left for operator follow-up.

Refs #756

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `maestro daemon`, a new long-lived subcommand that collapses the previous N-per-project systemd units into a single process: one orchestrator loop + one supervisor loop per project flow, and a single `FleetServer` aggregating the whole fleet. It also hoists `superviseWatchdog`/`persistSupervisorStuck` from `cmd/maestro` into `internal/supervisor` so both the CLI and the daemon share one watchdog per flow.

- **`internal/daemon`**: `Daemon.Run` loads all projects from a `ConfigLoader`, starts a `projectFlow` per project (with panic recovery so one crashing project can't kill the others), then serves one `server.FleetServer`; `stopAll` drains every flow on ctx cancellation.
- **`internal/supervisor/watchdog.go`**: Watchdog and persistSupervisorStuck are hoisted verbatim into the supervisor package and the CLI call-site updated to `supervisor.Watchdog`.
- **`cmd/maestro/daemon.go`**: Thin entry-point; parses flags, opens the config store, builds a `Daemon`, and wires a signal-cancellable context for graceful drain.

<h3>Confidence Score: 3/5</h3>

The daemon's flow isolation and drain logic are well-structured, but a fleet startup failure (e.g. port already in use) is not detected until the operator sends a signal — all project flows keep running and polling GitHub with no HTTP endpoint reachable.

The core issue is in `daemon.go`'s `Run`: the goroutine running `fleet.Start` pushes its error into a buffered channel, but `Run` only reads that channel after `ctx.Done()` fires. A real-world port conflict would leave the daemon silently running all flows with no HTTP serving, and the operator would only discover it at shutdown. The Watchdog goroutine leak on flow teardown and the missing project identity in watchdog log messages are minor quality concerns but do not affect correctness.

internal/daemon/daemon.go — the Run function's fleet error handling path needs a select on fleetErr alongside ctx.Done().

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/daemon/daemon.go | Core daemon lifecycle — loads projects, starts flows, serves one FleetServer. Fleet startup failure is not selected on alongside ctx.Done(), so a bind error leaves all flows running with no HTTP endpoint until the next signal. |
| internal/daemon/flow.go | Per-project flow wiring with panic recovery via deferred recoverFlow; defer ordering (LIFO) is correct. stopFlow drains the WaitGroup but the Watchdog goroutine started inside runSupervise is not tracked. |
| internal/daemon/supervise.go | Extracts per-project supervise loop from CLI; first-cycle log-and-continue is intentional. Watchdog goroutine launched here is outside the flow's WaitGroup, so stopFlow can return before it exits. |
| internal/supervisor/watchdog.go | Direct hoist of superviseWatchdog + persistSupervisorStuck from cmd/maestro into the supervisor package; logic is unchanged and correct. Log prefix doesn't carry project identity, which matters now that N watchdogs run concurrently. |
| cmd/maestro/daemon.go | New daemon subcommand entry-point; flag parsing, signalContext, and configstore open are all straightforward and correct. |
| cmd/maestro/main.go | Adds daemon case to the command router and removes the now-hoisted superviseWatchdog/persistSupervisorStuck functions, replacing their call-site with supervisor.Watchdog. Mechanical change. |
| internal/daemon/daemon_test.go | Good coverage of the main scenarios: flow-per-project, fleet aggregation, duplicate name skip, empty store error, start/stop drain, and panic containment. All tests use Port: 0 which makes fleet.Start a no-op, avoiding any bind issues in CI. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/daemon/daemon.go:125-132
**Fleet startup failure silently ignored while flows keep running**

If `fleet.Start` fails early (e.g., address already in use), the error is pushed to `fleetErr` but `Run` only reads that channel *after* `<-ctx.Done()` fires. In the meantime every project flow runs, GitHub is polled, and workers are dispatched — all while no HTTP endpoint is reachable. The operator won't see the bind error until they send SIGINT. A `select` across both `ctx.Done()` and `fleetErr` is needed so a fleet startup failure tears down the flows immediately and surfaces the error to `log.Fatalf` in the caller.

### Issue 2 of 3
internal/daemon/supervise.go:40
**Watchdog goroutine not tracked by the flow's WaitGroup**

`supervisor.Watchdog` is started as a free goroutine inside `runSupervise`. The flow's WaitGroup in `startFlow` only accounts for the `runLoop` and `superviseLoop` goroutines; the Watchdog is a third goroutine outside that group. When `stopFlow` waits on `<-flow.done`, it returns once the two tracked goroutines exit — but the Watchdog goroutine may still be executing (blocked on its ticker `select`) until the ticker fires and the `ctx.Done()` case is taken. On a long `SuperviseInterval` this can be several minutes. Passing a child `context.WithCancel` to the Watchdog and waiting for it to exit, or adding it to the WaitGroup, would close the gap.

### Issue 3 of 3
internal/supervisor/watchdog.go:48-64
**Watchdog log prefix doesn't identify the project in a multi-project daemon**

All log lines hard-code `[supervise/watchdog]` regardless of which project's state directory is being watched. Under `maestro daemon` with N projects, N watchdogs emit warnings with identical prefixes; there is no way to tell from the logs which project's `LastRunOnceAt` is stale. Adding a `name string` parameter (the project's repo or fleet name) and including it in every `log.Printf` call would make stuck-project diagnosis straightforward.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["daemon: internal/daemon + maestro daemon..."](https://github.com/befeast/maestro/commit/10e7792f61cbf14eb2dbd6877da21724be33e103) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39349306)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->