### PR TITLE
Phase 1 hardening: исправить находки ревью #763 (daemon) + commit-convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md
+
+Guidance for AI coding agents (and the worker harness that auto-loads this file
+from the repo root) working in the maestro repository.
+
+## Commit-message & PR convention
+
+- **Do NOT add `Co-authored-by: Claude …` or `🤖 Generated with Claude Code`
+  trailers** to commit messages or PR bodies. maestro attributes work via its
+  own durable trailer (below); the Claude/agent byline is noise in this repo's
+  history and is intentionally suppressed.
+
+  > Note: the `Co-authored-by` byline is emitted by the Claude Code *harness*,
+  > not by maestro code. The deterministic switch that stops it is
+  > `includeCoAuthoredBy: false` in the worker's `~/.claude/settings.json`. This
+  > document records the convention; an operator still has to set that flag for
+  > the trailer to actually disappear.
+
+- **Do preserve the `Maestro-Backend:` trailer.** maestro stamps it on commits
+  and PR bodies (`internal/state/attribution.go`,
+  `state.AttributionTrailerKey`) to record the backend timeline for a session.
+  It is the canonical, queryable attribution for this repo — never strip,
+  rewrite, or duplicate it.
+
+## Build & test before a PR
+
+- `gofmt` changed Go files.
+- `go test ./...`
+- `go build ./cmd/maestro/`

--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/befeast/maestro/internal/configstore"
 	"github.com/befeast/maestro/internal/daemon"
@@ -21,8 +20,8 @@ import (
 func daemonCmd(args []string) {
 	fs := flag.NewFlagSet("daemon", flag.ExitOnError)
 	storePath := fs.String("store", defaultConfigStorePath(), "Path to SQLite config store")
-	runInterval := fs.Duration("run-interval", 10*time.Minute, "Orchestrator loop interval")
-	superviseInterval := fs.Duration("supervise-interval", 5*time.Minute, "Supervisor loop interval")
+	runInterval := fs.Duration("run-interval", daemon.DefaultRunInterval, "Orchestrator loop interval")
+	superviseInterval := fs.Duration("supervise-interval", daemon.DefaultSuperviseInterval, "Supervisor loop interval")
 	host := fs.String("host", "127.0.0.1", "Host/interface to bind the fleet web server")
 	port := fs.Int("port", 8786, "Port to bind the fleet web server")
 	promptPath := fs.String("prompt", "", "Path to worker prompt base file")

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -725,7 +725,7 @@ func superviseCmd(args []string) {
 	// been bumped in 3*interval. The warning persists into state
 	// (SupervisorStuck=true) so the Fleet API and dashboards can
 	// surface it without grepping the journal.
-	go supervisor.Watchdog(ctx, cfg.StateDir, *interval)
+	go supervisor.Watchdog(ctx, cfg.SessionPrefix, cfg.StateDir, *interval)
 
 	ticker := time.NewTicker(*interval)
 	defer ticker.Stop()
@@ -1039,22 +1039,14 @@ func serveCmd(args []string) {
 			if err != nil {
 				log.Fatalf("load fleet: %v", err)
 			}
-			// LoadFleetProjects can't import github (cycle); wire the
-			// per-project safe-action GH client here at the boundary.
+			// LoadFleetProjects yields configs without their GitHub
+			// clients; wire the per-project safe-action + board client
+			// here via the shared helper (#529, #764).
 			for i := range projects {
-				if cfg := projects[i].Cfg(); cfg != nil {
-					gh := github.New(cfg.Repo)
-					projects[i].SetActionGH(gh)
-					// #529: surface the GitHub Project board (WIP
-					// rollup + URL) in the fleet snapshot when the
-					// project enables github_projects.
-					if cfg.GitHubProjects.Enabled && cfg.GitHubProjects.ProjectNumber > 0 {
-						projects[i].SetBoardClient(gh, cfg.GitHubProjects.ProjectNumber)
-					}
-				}
+				server.WireFleetProjectGitHub(&projects[i])
 			}
 		} else {
-			projects = fleetProjectsFromConfigs(cfgs)
+			projects = server.FleetProjectsFromConfigs(cfgs)
 		}
 		fleetHost := *host
 		if strings.TrimSpace(fleetHost) == "" {
@@ -1079,7 +1071,7 @@ func serveCmd(args []string) {
 		// #487: fleet auth uses the first project that configures a token
 		// env. A single shared token across the fleet is the deployment
 		// expectation; per-project tokens are out of scope.
-		fleetSrv.SetAuth(fleetAuthFromProjects(projects))
+		fleetSrv.SetAuth(server.FleetAuthFromProjects(projects))
 		if err := fleetSrv.Start(ctx); err != nil {
 			log.Fatalf("serve fleet: %v", err)
 		}
@@ -1123,45 +1115,6 @@ func serveCmd(args []string) {
 	if err := srv.Start(ctx); err != nil {
 		log.Fatalf("serve: %v", err)
 	}
-}
-
-func fleetProjectsFromConfigs(cfgs []*config.Config) []server.FleetProject {
-	projects := make([]server.FleetProject, 0, len(cfgs))
-	for _, cfg := range cfgs {
-		proj := server.NewFleetProject(defaultFleetProjectName(cfg.Repo), cfg.ResolvePath(), "", cfg)
-		gh := github.New(cfg.Repo)
-		proj.SetActionGH(gh)
-		if cfg.GitHubProjects.Enabled && cfg.GitHubProjects.ProjectNumber > 0 {
-			proj.SetBoardClient(gh, cfg.GitHubProjects.ProjectNumber)
-		}
-		projects = append(projects, proj)
-	}
-	return projects
-}
-
-// fleetAuthFromProjects returns the first non-empty Server.Auth config across
-// the fleet. The fleet uses a single shared token (#487); per-project
-// distinct tokens are intentionally out of scope.
-func fleetAuthFromProjects(projects []server.FleetProject) config.ServerAuthConfig {
-	for i := range projects {
-		cfg := projects[i].Cfg()
-		if cfg == nil {
-			continue
-		}
-		if strings.TrimSpace(cfg.Server.Auth.TokenEnv) != "" {
-			return cfg.Server.Auth
-		}
-	}
-	return config.ServerAuthConfig{}
-}
-
-func defaultFleetProjectName(repo string) string {
-	repo = strings.TrimSpace(repo)
-	if repo == "" {
-		return "project"
-	}
-	parts := strings.Split(repo, "/")
-	return parts[len(parts)-1]
 }
 
 func statusCmd(args []string) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -22,6 +22,15 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/server"
+	"github.com/befeast/maestro/internal/supervisor"
+)
+
+// Default loop intervals, shared by the daemon command's flag defaults and the
+// clamp in New so an explicit non-positive operator value falls back to a safe
+// cadence instead of disabling supervise or panicking time.NewTicker (#764).
+const (
+	DefaultRunInterval       = 10 * time.Minute
+	DefaultSuperviseInterval = 5 * time.Minute
 )
 
 // ConfigLoader yields the set of project configs the daemon supervises. It is
@@ -62,15 +71,32 @@ type Daemon struct {
 	fleet *server.FleetServer
 	flows map[string]*projectFlow
 
-	// runLoop and superviseLoop build the per-project loops. They default to
-	// the production orchestrator + supervisor wiring; tests override them to
-	// drive flows without reaching GitHub.
+	// runLoop, superviseLoop, and watchdogLoop build the per-project loops.
+	// They default to the production orchestrator + supervisor wiring; tests
+	// override them to drive flows (and assert WaitGroup tracking) without
+	// reaching GitHub.
 	runLoop       func(ctx context.Context, cfg *config.Config, opts Options)
 	superviseLoop func(ctx context.Context, cfg *config.Config, opts Options)
+	watchdogLoop  func(ctx context.Context, name, stateDir string, interval time.Duration)
 }
 
 // New constructs a Daemon that loads projects from store on Run.
+//
+// Non-positive intervals are clamped to the package defaults with a loud warn
+// rather than silently honored: a 0 run-interval would panic time.NewTicker
+// (caught by recoverFlow, killing the orchestrator silently) and a 0
+// supervise-interval would run a single cycle then leave the supervise loop and
+// its watchdog dead while the flow still reports healthy (#764). The 10m/5m
+// defaults are safe, so this only fires on an explicit non-positive value.
 func New(store ConfigLoader, opts Options) *Daemon {
+	if opts.RunInterval <= 0 {
+		log.Printf("[daemon] run-interval %s is not positive; clamping to default %s", opts.RunInterval, DefaultRunInterval)
+		opts.RunInterval = DefaultRunInterval
+	}
+	if opts.SuperviseInterval <= 0 {
+		log.Printf("[daemon] supervise-interval %s is not positive; clamping to default %s", opts.SuperviseInterval, DefaultSuperviseInterval)
+		opts.SuperviseInterval = DefaultSuperviseInterval
+	}
 	d := &Daemon{
 		store: store,
 		opts:  opts,
@@ -80,6 +106,7 @@ func New(store ConfigLoader, opts Options) *Daemon {
 	d.superviseLoop = func(ctx context.Context, cfg *config.Config, opts Options) {
 		runSupervise(ctx, cfg, opts.SuperviseInterval)
 	}
+	d.watchdogLoop = supervisor.Watchdog
 	return d
 }
 
@@ -87,9 +114,9 @@ func New(store ConfigLoader, opts Options) *Daemon {
 // supervisor) for each, and serves one FleetServer aggregating them all. It
 // blocks until ctx is cancelled, then drains every flow before returning.
 //
-// A project that cannot be turned into a flow (duplicate fleet name) is
-// logged and skipped — one bad project must never abort daemon startup or the
-// other flows (#756).
+// A project that duplicates an already-started flow identity (same StateDir)
+// is logged and skipped — one bad project must never abort daemon startup or
+// the other flows (#756).
 func (d *Daemon) Run(ctx context.Context) error {
 	cfgs, err := d.store.LoadAll(ctx)
 	if err != nil {
@@ -99,24 +126,32 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return errors.New("config store has no projects")
 	}
 
+	// Dedup on the flow's real identity (StateDir, falling back to Repo), not
+	// the fleet display name. The display name is the repo basename, so
+	// org-a/api and org-b/api collapsed to one "api" and the second project's
+	// orchestrator + supervisor never started; the legitimate one-repo /
+	// two-StateDir layout (which serve --fleet aggregates without dedup) was
+	// likewise dropped (#764). Only a literal re-load of the same StateDir is
+	// a true duplicate.
 	seen := make(map[string]bool, len(cfgs))
 	projects := make([]server.FleetProject, 0, len(cfgs))
 	for _, cfg := range cfgs {
-		proj := newFleetProject(cfg)
-		if seen[proj.Name] {
-			log.Printf("[daemon] skip project %q (repo=%s): duplicate fleet name already started", proj.Name, cfg.Repo)
+		proj := server.NewFleetProjectWithGitHub(cfg)
+		key := flowKey(cfg)
+		if seen[key] {
+			log.Printf("[daemon] skip project %q (repo=%s state_dir=%s): duplicate flow identity already started", proj.Name, cfg.Repo, cfg.StateDir)
 			continue
 		}
-		seen[proj.Name] = true
+		seen[key] = true
 		flow := d.startFlow(ctx, proj)
 		projects = append(projects, proj)
-		log.Printf("[daemon] started flow %q (repo=%s)", flow.name, cfg.Repo)
+		log.Printf("[daemon] started flow %q (repo=%s state_dir=%s)", flow.name, cfg.Repo, cfg.StateDir)
 	}
 
 	// One FleetServer for the whole fleet — replaces the N per-project
 	// server.New instances the legacy run/serve paths spun up (#516).
 	fleet := server.NewFleet(projects, d.opts.Host, d.opts.Port, d.opts.ReadOnly)
-	fleet.SetAuth(fleetAuth(projects))
+	fleet.SetAuth(server.FleetAuthFromProjects(projects))
 	d.mu.Lock()
 	d.fleet = fleet
 	d.mu.Unlock()
@@ -125,11 +160,42 @@ func (d *Daemon) Run(ctx context.Context) error {
 	fleetErr := make(chan error, 1)
 	go func() { fleetErr <- fleet.Start(ctx) }()
 
-	// Block until shutdown is requested. We wait on ctx (not fleet.Start) so
-	// the daemon stays up even when the fleet is not bound (port 0).
-	<-ctx.Done()
-	d.stopAll()
-	return <-fleetErr
+	// Surface a fleet bind failure immediately. If :8786 is already held (a
+	// legacy maestro@ unit, a second daemon), fleet.Start returns the bind
+	// error right away — racing it against ctx.Done() means we abort and
+	// report it now instead of buffering it and running every flow without a
+	// web endpoint / dashboard / health probe until SIGTERM (#764 P1).
+	//
+	// fleet.Start returns nil immediately when the port is 0 (no web endpoint
+	// requested); that is intentional, not a failure, so keep running the
+	// flows and fall through to wait on ctx.Done().
+	select {
+	case <-ctx.Done():
+		d.stopAll()
+		return <-fleetErr
+	case err := <-fleetErr:
+		if err != nil {
+			log.Printf("[daemon] fleet server failed on %s:%d: %v", d.opts.Host, d.opts.Port, err)
+			d.stopAll()
+			return err
+		}
+		<-ctx.Done()
+		d.stopAll()
+		return nil
+	}
+}
+
+// flowKey is a flow's stable identity for dedup and the flows registry. The
+// StateDir is the real per-flow identity (one repo can host several configs
+// with distinct StateDirs); Repo is the fallback when StateDir is unset.
+func flowKey(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if sd := strings.TrimSpace(cfg.StateDir); sd != "" {
+		return sd
+	}
+	return strings.TrimSpace(cfg.Repo)
 }
 
 // Fleet returns the aggregating FleetServer once Run has built it, or nil
@@ -138,20 +204,4 @@ func (d *Daemon) Fleet() *server.FleetServer {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.fleet
-}
-
-// fleetAuth returns the first non-empty Server.Auth config across the fleet.
-// The fleet uses a single shared token (#487); per-project distinct tokens are
-// intentionally out of scope.
-func fleetAuth(projects []server.FleetProject) config.ServerAuthConfig {
-	for i := range projects {
-		cfg := projects[i].Cfg()
-		if cfg == nil {
-			continue
-		}
-		if strings.TrimSpace(cfg.Server.Auth.TokenEnv) != "" {
-			return cfg.Server.Auth
-		}
-	}
-	return config.ServerAuthConfig{}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,16 +1,21 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/server"
+	"github.com/befeast/maestro/internal/state"
 )
 
 // fakeLoader is an in-memory ConfigLoader so the daemon lifecycle can be
@@ -121,13 +126,14 @@ func TestRunStartsFlowPerProjectAndAggregatesFleet(t *testing.T) {
 	}
 }
 
-func TestRunSkipsDuplicateFleetName(t *testing.T) {
-	// Two configs deriving the same fleet name (same repo) — the second must
-	// be skipped, not silently overwrite the first.
-	cfgs := []*config.Config{
-		testConfig(t, "owner/dup"),
-		testConfig(t, "owner/dup"),
-	}
+func TestRunSkipsDuplicateFlowIdentity(t *testing.T) {
+	// Two configs that resolve to the same flow identity (same StateDir) are a
+	// true duplicate — the second must be skipped, not silently overwrite the
+	// first in the flows registry.
+	shared := testConfig(t, "owner/dup")
+	dup := testConfig(t, "owner/dup")
+	dup.StateDir = shared.StateDir
+	cfgs := []*config.Config{shared, dup}
 	var run, sup loopTracker
 	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.loop)
 
@@ -142,10 +148,43 @@ func TestRunSkipsDuplicateFleetName(t *testing.T) {
 	flows := len(d.flows)
 	d.mu.Unlock()
 	if flows != 1 {
-		t.Fatalf("flows = %d, want 1 (duplicate name skipped)", flows)
+		t.Fatalf("flows = %d, want 1 (duplicate flow identity skipped)", flows)
 	}
 	if got := atomic.LoadInt64(&run.started); got != 1 {
 		t.Fatalf("run loops started = %d, want 1", got)
+	}
+
+	cancel()
+	<-done
+}
+
+// #764 P2: two distinct repos that share a basename ("api") must BOTH get a
+// flow. The old dedup keyed on the repo-basename fleet name, so org-b/api was
+// silently skipped — its orchestrator and supervisor never started.
+func TestRunSameBasenameDistinctReposBothStart(t *testing.T) {
+	cfgs := []*config.Config{
+		testConfig(t, "org-a/api"),
+		testConfig(t, "org-b/api"),
+	}
+	var run, sup loopTracker
+	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.loop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	waitForFleet(t, d)
+	waitFor(t, func() bool { return atomic.LoadInt64(&run.started) == 2 })
+
+	d.mu.Lock()
+	flows := len(d.flows)
+	d.mu.Unlock()
+	if flows != 2 {
+		t.Fatalf("flows = %d, want 2 (same-basename distinct repos both start)", flows)
+	}
+	if got := atomic.LoadInt64(&sup.started); got != 2 {
+		t.Fatalf("supervise loops started = %d, want 2", got)
 	}
 
 	cancel()
@@ -164,13 +203,13 @@ func TestStartStopFlowDrains(t *testing.T) {
 	var run, sup loopTracker
 	d := newTestDaemon(fakeLoader{cfgs: []*config.Config{cfg}}, run.loop, sup.loop)
 
-	proj := newFleetProject(cfg)
+	proj := server.NewFleetProjectWithGitHub(cfg)
 	flow := d.startFlow(context.Background(), proj)
 
 	// Both loops should be running.
 	waitFor(t, func() bool { return atomic.LoadInt64(&run.started) == 1 && atomic.LoadInt64(&sup.started) == 1 })
 
-	d.stopFlow(flow.name)
+	d.stopFlow(flow.key)
 
 	select {
 	case <-flow.done:
@@ -183,7 +222,7 @@ func TestStartStopFlowDrains(t *testing.T) {
 
 	// Flow is deregistered.
 	d.mu.Lock()
-	_, ok := d.flows[flow.name]
+	_, ok := d.flows[flow.key]
 	d.mu.Unlock()
 	if ok {
 		t.Fatal("flow still registered after stopFlow")
@@ -209,13 +248,13 @@ func TestFlowPanicContained(t *testing.T) {
 	}
 	d := newTestDaemon(fakeLoader{cfgs: []*config.Config{cfg}}, run, supervise)
 
-	proj := newFleetProject(cfg)
+	proj := server.NewFleetProjectWithGitHub(cfg)
 	flow := d.startFlow(context.Background(), proj)
 
 	// The supervise loop keeps running despite the run loop's panic.
 	waitFor(t, func() bool { return atomic.LoadInt64(&supStarted) == 1 })
 
-	d.stopFlow(flow.name)
+	d.stopFlow(flow.key)
 	select {
 	case <-flow.done:
 	case <-time.After(2 * time.Second):
@@ -223,6 +262,127 @@ func TestFlowPanicContained(t *testing.T) {
 	}
 	if atomic.LoadInt64(&supStopped) != 1 {
 		t.Fatal("supervise loop did not drain after the run loop panicked")
+	}
+}
+
+// #764 P1: a fleet bind failure (port already held) must surface immediately —
+// Run returns the error on its own, without waiting for ctx cancellation /
+// SIGTERM. Otherwise the daemon runs every flow with no web endpoint until the
+// operator kills it.
+func TestRunSurfacesFleetBindErrorImmediately(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	cfg := testConfig(t, "owner/bind")
+	var run, sup loopTracker
+	d := New(fakeLoader{cfgs: []*config.Config{cfg}}, Options{Host: "127.0.0.1", Port: port})
+	d.runLoop = run.loop
+	d.superviseLoop = sup.loop
+
+	// ctx is intentionally never cancelled within the deadline.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run returned nil; want the fleet bind error surfaced immediately")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return the bind error without ctx cancellation (#764 P1)")
+	}
+}
+
+// #764 P3: a non-positive interval must be clamped to the safe default with a
+// warn, never silently honored (a 0 run-interval panics time.NewTicker; a 0
+// supervise-interval kills the loop + watchdog while the flow reads healthy).
+func TestNewClampsNonPositiveIntervals(t *testing.T) {
+	d := New(fakeLoader{}, Options{RunInterval: 0, SuperviseInterval: -1})
+	if d.opts.RunInterval != DefaultRunInterval {
+		t.Fatalf("RunInterval = %s, want clamp to %s", d.opts.RunInterval, DefaultRunInterval)
+	}
+	if d.opts.SuperviseInterval != DefaultSuperviseInterval {
+		t.Fatalf("SuperviseInterval = %s, want clamp to %s", d.opts.SuperviseInterval, DefaultSuperviseInterval)
+	}
+
+	// A positive operator value is honored verbatim.
+	d2 := New(fakeLoader{}, Options{RunInterval: 3 * time.Minute, SuperviseInterval: 90 * time.Second})
+	if d2.opts.RunInterval != 3*time.Minute || d2.opts.SuperviseInterval != 90*time.Second {
+		t.Fatalf("positive intervals not honored: run=%s supervise=%s", d2.opts.RunInterval, d2.opts.SuperviseInterval)
+	}
+}
+
+// #764 P2: the watchdog goroutine must join the flow WaitGroup so stopFlow does
+// not return until it has exited. A stub watchdog records start/stop; after
+// stopFlow returns, stop must already be observed.
+func TestStopFlowDrainsWatchdog(t *testing.T) {
+	cfg := testConfig(t, "owner/wd")
+	var run, sup loopTracker
+	d := New(fakeLoader{cfgs: []*config.Config{cfg}}, Options{Port: 0, SuperviseInterval: time.Minute})
+	d.runLoop = run.loop
+	d.superviseLoop = sup.loop
+
+	var wdStarted, wdStopped int64
+	var gotName, gotStateDir string
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {
+		gotName, gotStateDir = name, stateDir
+		atomic.AddInt64(&wdStarted, 1)
+		<-ctx.Done()
+		atomic.AddInt64(&wdStopped, 1)
+	}
+
+	proj := server.NewFleetProjectWithGitHub(cfg)
+	flow := d.startFlow(context.Background(), proj)
+	waitFor(t, func() bool { return atomic.LoadInt64(&wdStarted) == 1 })
+
+	d.stopFlow(flow.key)
+
+	// stopFlow waits on flow.done, which only closes once the watchdog
+	// goroutine has also exited — so the stop must already be visible here,
+	// with no further wait.
+	if got := atomic.LoadInt64(&wdStopped); got != 1 {
+		t.Fatalf("watchdog not drained by stopFlow: wdStopped=%d, want 1", got)
+	}
+	// The watchdog is told which project it watches (#764 P2 log identity).
+	if gotName != flow.name {
+		t.Fatalf("watchdog name = %q, want %q", gotName, flow.name)
+	}
+	if gotStateDir != cfg.StateDir {
+		t.Fatalf("watchdog stateDir = %q, want %q", gotStateDir, cfg.StateDir)
+	}
+}
+
+// #764: the daemon supervise loop logs each cycle's SupervisorDecision so the
+// journal keeps the structural "why" trail the CLI printed.
+func TestLogSupervisorDecisionEmitsStructuredLine(t *testing.T) {
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(old)
+
+	cfg := &config.Config{SessionPrefix: "acme"}
+	logSupervisorDecision(cfg, state.SupervisorDecision{
+		RecommendedAction: "merge_pr",
+		Status:            "ready",
+		Risk:              "low",
+		Confidence:        0.92,
+		RequiresApproval:  true,
+		ApprovalID:        "appr-1",
+		Summary:           "PR #12 is green",
+	})
+
+	out := buf.String()
+	for _, want := range []string{"acme", "supervise decision", "action=merge_pr", "requires_approval=true", "approval=appr-1", "PR #12 is green"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("decision log %q missing %q", out, want)
+		}
 	}
 }
 

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -7,45 +7,37 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
-	"github.com/befeast/maestro/internal/configwatch"
-	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/orchestrator"
 	"github.com/befeast/maestro/internal/server"
 )
 
-// projectFlow is one project running inside the daemon: an orchestrator loop
-// and a supervisor loop sharing a child context. Cancelling that context
-// (stopFlow) tears both loops down.
+// projectFlow is one project running inside the daemon: an orchestrator loop, a
+// supervisor loop, and (when supervising) a liveness watchdog sharing a child
+// context. Cancelling that context (stopFlow) tears every goroutine down.
 type projectFlow struct {
 	name   string
+	key    string // stable flow identity (StateDir/Repo); the flows-map key
 	cfg    *config.Config
 	cancel context.CancelFunc
-	done   chan struct{} // closed once both loops have exited
+	done   chan struct{} // closed once every flow goroutine has exited
 }
 
-// newFleetProject wraps a config for in-process fleet serving, mirroring the
-// `maestro serve` wiring: a safe-action GitHub client, plus the GitHub Project
-// board client when github_projects is enabled. The project name is derived
-// from the repo (NewFleetProject's default) to match the serve path.
-func newFleetProject(cfg *config.Config) server.FleetProject {
-	proj := server.NewFleetProject("", cfg.ResolvePath(), "", cfg)
-	gh := github.New(cfg.Repo)
-	proj.SetActionGH(gh)
-	if cfg.GitHubProjects.Enabled && cfg.GitHubProjects.ProjectNumber > 0 {
-		proj.SetBoardClient(gh, cfg.GitHubProjects.ProjectNumber)
-	}
-	return proj
-}
-
-// startFlow launches the orchestrator + supervisor loops for proj under a
-// child of parent and registers the flow. Each loop runs in its own goroutine
-// with a panic recover so a single project's crash can never take the daemon
-// (or the other flows) down (#756).
+// startFlow launches the orchestrator + supervisor loops (and the liveness
+// watchdog) for proj under a child of parent and registers the flow. Each loop
+// runs in its own goroutine with a panic recover so a single project's crash
+// can never take the daemon (or the other flows) down (#756).
+//
+// Every goroutine the flow spawns is tracked in one WaitGroup, so close(done)
+// — and therefore stopFlow — does not return until the watchdog has also
+// exited. An untracked watchdog could otherwise Load/Save StateDir after the
+// flow is considered stopped, racing a restarted flow for the same project
+// (#764 P2).
 func (d *Daemon) startFlow(parent context.Context, proj server.FleetProject) *projectFlow {
 	cfg := proj.Cfg()
 	fctx, cancel := context.WithCancel(parent)
 	flow := &projectFlow{
 		name:   proj.Name,
+		key:    flowKey(cfg),
 		cfg:    cfg,
 		cancel: cancel,
 		done:   make(chan struct{}),
@@ -63,24 +55,37 @@ func (d *Daemon) startFlow(parent context.Context, proj server.FleetProject) *pr
 		defer recoverFlow(flow.name, "supervise")
 		d.superviseLoop(fctx, cfg, d.opts)
 	}()
+	// Phase 1.2 (#499) liveness watchdog, one per flow — tracked in the flow
+	// WaitGroup (#764 P2). The watchdog itself no-ops on a non-positive
+	// interval; gate here too so we never spawn a goroutine that immediately
+	// returns.
+	if d.opts.SuperviseInterval > 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer recoverFlow(flow.name, "watchdog")
+			d.watchdogLoop(fctx, flow.name, cfg.StateDir, d.opts.SuperviseInterval)
+		}()
+	}
 	go func() {
 		wg.Wait()
 		close(flow.done)
 	}()
 
 	d.mu.Lock()
-	d.flows[flow.name] = flow
+	d.flows[flow.key] = flow
 	d.mu.Unlock()
 	return flow
 }
 
-// stopFlow cancels a flow's context, waits for both loops to drain, and
-// deregisters it. Safe to call for an unknown name (no-op).
-func (d *Daemon) stopFlow(name string) {
+// stopFlow cancels a flow's context, waits for every flow goroutine to drain,
+// and deregisters it. Keyed on the flow identity (flowKey). Safe to call for an
+// unknown key (no-op).
+func (d *Daemon) stopFlow(key string) {
 	d.mu.Lock()
-	flow, ok := d.flows[name]
+	flow, ok := d.flows[key]
 	if ok {
-		delete(d.flows, name)
+		delete(d.flows, key)
 	}
 	d.mu.Unlock()
 	if !ok {
@@ -88,24 +93,24 @@ func (d *Daemon) stopFlow(name string) {
 	}
 	flow.cancel()
 	<-flow.done
-	log.Printf("[daemon] stopped flow %q", name)
+	log.Printf("[daemon] stopped flow %q", flow.name)
 }
 
 // stopAll drains every running flow. Called on daemon shutdown.
 func (d *Daemon) stopAll() {
 	d.mu.Lock()
-	names := make([]string, 0, len(d.flows))
-	for name := range d.flows {
-		names = append(names, name)
+	keys := make([]string, 0, len(d.flows))
+	for key := range d.flows {
+		keys = append(keys, key)
 	}
 	d.mu.Unlock()
-	for _, name := range names {
-		d.stopFlow(name)
+	for _, key := range keys {
+		d.stopFlow(key)
 	}
 }
 
-// recoverFlow swallows a panic in a flow loop so it stays contained to that
-// project. A panicking goroutine would otherwise crash the whole daemon.
+// recoverFlow swallows a panic in a flow goroutine so it stays contained to
+// that project. A panicking goroutine would otherwise crash the whole daemon.
 func recoverFlow(name, loop string) {
 	if r := recover(); r != nil {
 		log.Printf("[daemon] flow %q %s loop panicked (contained, flow stopped): %v", name, loop, r)
@@ -118,6 +123,12 @@ func recoverFlow(name, loop string) {
 // on run error — a failing orchestrator must log-and-continue, never take the
 // daemon down (#756). orchestrator.Run already log-and-continues on per-cycle
 // errors and returns nil on ctx cancellation.
+//
+// Hot-reload note (#764 P3): the daemon's source of truth is the config store
+// (#754), not the import-time YAML, so we deliberately do NOT wire a YAML file
+// watcher here — watching a file the store supersedes would let the run loop
+// drift from the supervise loop, which has no such watcher. Store-driven reload
+// is Phase 2 (#757).
 func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options) {
 	orch := orchestrator.New(cfg)
 	orch.SetBinaryVersion(opts.Version)
@@ -126,12 +137,6 @@ func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options) {
 	}
 
 	refreshCh := make(chan struct{}, 1)
-
-	// Config file watcher for hot-reload, matching `maestro run`.
-	if cfgPath := cfg.ResolvePath(); cfgPath != "" {
-		reloadCh := configwatch.Watch(ctx, cfgPath, 2*time.Second)
-		orch.SetConfigReloadCh(reloadCh)
-	}
 
 	runInterval := opts.RunInterval
 	if cfg.PollIntervalSeconds > 0 {

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -2,17 +2,21 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/supervisor"
 )
 
 // runSupervise is the per-project supervisor loop, extracted from the
 // single-project `maestro supervise` command (cmd/maestro/main.go). The daemon
-// runs one per flow.
+// runs one per flow; the liveness watchdog is owned by startFlow so it joins
+// the flow WaitGroup (#764 P2).
 //
 // Key difference from the CLI: the first cycle is log-and-continue, NOT
 // log.Fatalf. Under `systemctl start maestro@<project>`, a fatal first cycle
@@ -23,9 +27,17 @@ import (
 // LastRunOnceAt stops advancing.
 func runSupervise(ctx context.Context, cfg *config.Config, interval time.Duration) {
 	gh := github.New(cfg.Repo)
+	// Capture and log each cycle's SupervisorDecision the way `maestro
+	// supervise` prints it. The daemon still acts (label/comment/approve), but
+	// without this the structural "why did the supervisor do that" trail was
+	// dropped — turning debugging into journal archaeology (#764).
 	runOnce := func() error {
-		_, err := supervisor.RunOnce(cfg, gh)
-		return err
+		decision, err := supervisor.RunOnce(cfg, gh)
+		if err != nil {
+			return err
+		}
+		logSupervisorDecision(cfg, decision)
+		return nil
 	}
 
 	if err := runOnce(); err != nil {
@@ -35,9 +47,6 @@ func runSupervise(ctx context.Context, cfg *config.Config, interval time.Duratio
 	if interval <= 0 {
 		return
 	}
-
-	// Phase 1.2 (#499) liveness watchdog, one per flow.
-	go supervisor.Watchdog(ctx, cfg.StateDir, interval)
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -54,4 +63,28 @@ func runSupervise(ctx context.Context, cfg *config.Config, interval time.Duratio
 			}
 		}
 	}
+}
+
+// logSupervisorDecision emits a compact, per-cycle record of the supervisor's
+// decision so the daemon journal carries the same structural trail the CLI
+// `maestro supervise` printed (#764). One line, greppable by project prefix.
+func logSupervisorDecision(cfg *config.Config, decision state.SupervisorDecision) {
+	parts := []string{fmt.Sprintf("action=%s", decision.RecommendedAction)}
+	if decision.Status != "" {
+		parts = append(parts, fmt.Sprintf("status=%s", decision.Status))
+	}
+	if decision.Risk != "" {
+		parts = append(parts, fmt.Sprintf("risk=%s", decision.Risk))
+	}
+	parts = append(parts, fmt.Sprintf("confidence=%.2f", decision.Confidence))
+	if decision.RequiresApproval {
+		parts = append(parts, "requires_approval=true")
+	}
+	if decision.ApprovalID != "" {
+		parts = append(parts, fmt.Sprintf("approval=%s", decision.ApprovalID))
+	}
+	if summary := strings.TrimSpace(decision.Summary); summary != "" {
+		parts = append(parts, fmt.Sprintf("summary=%q", summary))
+	}
+	log.Printf("[%s] supervise decision: %s", cfg.SessionPrefix, strings.Join(parts, " "))
 }

--- a/internal/server/fleet_build.go
+++ b/internal/server/fleet_build.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+// WireFleetProjectGitHub attaches the per-project safe-action GitHub client and,
+// when github_projects is enabled, the board client (#529). It is the single
+// place the GitHub wiring lives, shared by every fleet entry point — `maestro
+// serve --fleet`, serve fleet-from-configs, and `maestro daemon` — so a fix to
+// token precedence (#487) or board wiring applies to all of them, not just one
+// copy (#764).
+func WireFleetProjectGitHub(proj *FleetProject) {
+	if proj == nil {
+		return
+	}
+	cfg := proj.Cfg()
+	if cfg == nil {
+		return
+	}
+	gh := github.New(cfg.Repo)
+	proj.SetActionGH(gh)
+	if cfg.GitHubProjects.Enabled && cfg.GitHubProjects.ProjectNumber > 0 {
+		proj.SetBoardClient(gh, cfg.GitHubProjects.ProjectNumber)
+	}
+}
+
+// NewFleetProjectWithGitHub builds a FleetProject for cfg (name derived from the
+// repo basename) with its safe-action GitHub client and board client wired in.
+// Shared by serve --fleet (one repo per config) and the daemon (one flow per
+// config) so the construction lives in one place (#764).
+func NewFleetProjectWithGitHub(cfg *config.Config) FleetProject {
+	proj := NewFleetProject("", cfg.ResolvePath(), "", cfg)
+	WireFleetProjectGitHub(&proj)
+	return proj
+}
+
+// FleetProjectsFromConfigs builds one wired FleetProject per config.
+func FleetProjectsFromConfigs(cfgs []*config.Config) []FleetProject {
+	projects := make([]FleetProject, 0, len(cfgs))
+	for _, cfg := range cfgs {
+		projects = append(projects, NewFleetProjectWithGitHub(cfg))
+	}
+	return projects
+}
+
+// FleetAuthFromProjects returns the first non-empty Server.Auth config across
+// the fleet. The fleet uses a single shared token (#487); per-project distinct
+// tokens are intentionally out of scope.
+func FleetAuthFromProjects(projects []FleetProject) config.ServerAuthConfig {
+	for i := range projects {
+		cfg := projects[i].Cfg()
+		if cfg == nil {
+			continue
+		}
+		if strings.TrimSpace(cfg.Server.Auth.TokenEnv) != "" {
+			return cfg.Server.Auth
+		}
+	}
+	return config.ServerAuthConfig{}
+}

--- a/internal/supervisor/watchdog.go
+++ b/internal/supervisor/watchdog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/befeast/maestro/internal/state"
@@ -19,10 +20,17 @@ import (
 // restart.
 //
 // One Watchdog runs per supervise loop: the single-project `maestro supervise`
-// CLI starts one, and `maestro daemon` starts one per project flow (#756).
-func Watchdog(ctx context.Context, stateDir string, interval time.Duration) {
+// CLI starts one, and `maestro daemon` starts one per project flow (#756). The
+// name (project / session prefix) is woven into every log line so that, with N
+// flows in one daemon, an operator can tell whose LastRunOnceAt went stale
+// (#764) instead of reading N identical `[supervise/watchdog]` prefixes.
+func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration) {
 	if interval <= 0 {
 		return
+	}
+	logPrefix := "supervise/watchdog"
+	if name = strings.TrimSpace(name); name != "" {
+		logPrefix = name + " supervise/watchdog"
 	}
 	stuckThreshold := 3 * interval
 	startedAt := time.Now()
@@ -45,23 +53,23 @@ func Watchdog(ctx context.Context, stateDir string, interval time.Duration) {
 
 		st, err := state.Load(stateDir)
 		if err != nil {
-			log.Printf("[supervise/watchdog] could not read state: %v (will retry)", err)
+			log.Printf("[%s] could not read state: %v (will retry)", logPrefix, err)
 			continue
 		}
 		if st.LastRunOnceAt.IsZero() {
 			// Daemon never completed a cycle. Loud warning, but only
 			// after the startup grace.
-			log.Printf("[supervise/watchdog] WARNING: no RunOnce has stamped state.LastRunOnceAt since the daemon started %s ago; check whether RunOnce is wedged",
-				time.Since(startedAt).Round(time.Second))
-			persistSupervisorStuck(stateDir, "no RunOnce has completed since daemon start")
+			log.Printf("[%s] WARNING: no RunOnce has stamped state.LastRunOnceAt since the daemon started %s ago; check whether RunOnce is wedged",
+				logPrefix, time.Since(startedAt).Round(time.Second))
+			persistSupervisorStuck(logPrefix, stateDir, "no RunOnce has completed since daemon start")
 			continue
 		}
 		gap := time.Since(st.LastRunOnceAt)
 		if gap > stuckThreshold {
 			reason := fmt.Sprintf("LastRunOnceAt=%s is %s old (threshold %s)",
 				st.LastRunOnceAt.Format(time.RFC3339), gap.Round(time.Second), stuckThreshold)
-			log.Printf("[supervise/watchdog] WARNING: supervise loop appears stuck — %s", reason)
-			persistSupervisorStuck(stateDir, reason)
+			log.Printf("[%s] WARNING: supervise loop appears stuck — %s", logPrefix, reason)
+			persistSupervisorStuck(logPrefix, stateDir, reason)
 		}
 	}
 }
@@ -69,10 +77,10 @@ func Watchdog(ctx context.Context, stateDir string, interval time.Duration) {
 // persistSupervisorStuck flips SupervisorStuck=true in state.json so the
 // Fleet API surfaces it. Best-effort: a save failure is logged but does
 // not stop the watchdog.
-func persistSupervisorStuck(stateDir, reason string) {
+func persistSupervisorStuck(logPrefix, stateDir, reason string) {
 	st, err := state.Load(stateDir)
 	if err != nil {
-		log.Printf("[supervise/watchdog] persist: load state: %v", err)
+		log.Printf("[%s] persist: load state: %v", logPrefix, err)
 		return
 	}
 	if st.SupervisorStuck && st.SupervisorStuckReason == reason {
@@ -81,6 +89,6 @@ func persistSupervisorStuck(stateDir, reason string) {
 	st.SupervisorStuck = true
 	st.SupervisorStuckReason = reason
 	if err := state.Save(stateDir, st); err != nil {
-		log.Printf("[supervise/watchdog] persist: save state: %v", err)
+		log.Printf("[%s] persist: save state: %v", logPrefix, err)
 	}
 }


### PR DESCRIPTION
Implements #764

Consolidates the Greptile/Codex review findings on the Phase 1 daemon (#763) plus the independent `/code-review` findings.

## Changes
- **P1 — fleet bind-error surfaced immediately**: `daemon.Run` races `ctx.Done()` against the fleet error channel, so a busy `:8786` aborts startup and reports the error instead of running every flow without a web endpoint/dashboard/health-probe until SIGTERM. The intentional `port 0` (no-bind) case still keeps the flows up.
- **P2 — dedup on real flow identity**: key dedup + the flows registry on `StateDir` (falling back to `Repo`), not the repo-basename fleet name. `org-a/api` and `org-b/api` now both get a flow; the legitimate one-repo/two-StateDir layout is no longer dropped.
- **P2 — watchdog joins the flow WaitGroup**: the liveness watchdog is started from `startFlow` and tracked, so `stopFlow` does not return until it has exited — no more watchdog `Load/Save` racing a restarted flow on the same `StateDir`.
- **P2 — watchdog log identifies the project**: `supervisor.Watchdog` takes a `name` woven into every log line.
- **SupervisorDecision logged per-cycle** in the daemon supervise loop, matching the CLI `supervise` path.
- **P3 — interval validation**: non-positive run/supervise intervals are clamped to the safe defaults with a warn (a `0` run-interval panicked `time.NewTicker`; a `0` supervise-interval silently disabled the loop + watchdog).
- **P3 — drop import-time YAML watcher** in the daemon: the config store is the source of truth (#754); store-driven reload is Phase 2 (#757).
- **Cleanup — shared fleet wiring**: lifted into `internal/server` (`WireFleetProjectGitHub`, `NewFleetProjectWithGitHub`, `FleetProjectsFromConfigs`, `FleetAuthFromProjects`) and called from both `serve` and `daemon`.
- **CLAUDE.md** at repo root documents the commit-message convention (no `Co-authored-by`/`Generated-with` trailers; preserve `Maestro-Backend`).

## Testing
- `go build ./cmd/maestro/`
- `go test ./...` (full suite green; daemon package also run with `-race`)
- New daemon tests cover: immediate bind-error, identity-based dedup (same-basename distinct repos both start; same-StateDir skipped), watchdog WaitGroup draining + name passthrough, interval clamping, and per-cycle decision logging.

Refs #764

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the Phase 1 daemon by addressing a batch of review findings from #763 and adds a `CLAUDE.md` commit-convention guide. The changes are well-scoped: each fix is small, directly motivated, and covered by a dedicated test.

- **Fleet bind-error surfacing**: `daemon.Run` now races `fleetErr` against `ctx.Done()` so a port-already-held error aborts startup immediately instead of letting flows run indefinitely with no web endpoint. The port-0 (no-bind) path is preserved correctly.
- **Identity-based dedup**: The flows registry is now keyed on `StateDir` (falling back to `Repo`) rather than the repo-basename fleet name, fixing the case where `org-a/api` and `org-b/api` collapsed to one flow; the shared `flowKey` helper keeps `daemon.Run` and `startFlow` consistent.
- **Watchdog WaitGroup tracking**: The liveness watchdog is added to the flow's `sync.WaitGroup` inside `startFlow`, so `stopFlow` does not return until the watchdog has exited — eliminating the race between a restarting flow and a lingering watchdog reading/writing the same `StateDir`. The watchdog also gains a `name` parameter for identifiable log lines in multi-flow daemons. GitHub-wiring logic is consolidated into `internal/server` (`WireFleetProjectGitHub`, `FleetProjectsFromConfigs`, `FleetAuthFromProjects`) and shared between `serve` and `daemon`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changed paths have direct test coverage and the daemon shutdown sequence is correct in both the bind-error and graceful-cancel cases.

The core logic changes (select-based bind-error detection, WaitGroup watchdog tracking, flowKey dedup) are all sound and exercised by new tests. The one thing worth noting is that `newTestDaemon` no longer stubs the watchdog, so existing tests like `TestStartStopFlowDrains` and `TestFlowPanicContained` now silently depend on the real `supervisor.Watchdog` exiting cleanly on context cancellation. This works today but creates an implicit coupling that could produce confusing failures if the watchdog's shutdown path ever acquires blocking work.

internal/daemon/daemon_test.go — the `newTestDaemon` helper now runs the real watchdog; worth stubbing it out to keep those tests isolated.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/daemon/daemon.go | Fleet bind-error now surfaces immediately via select race; dedup keyed on flowKey (StateDir→Repo); shared FleetAuthFromProjects wired in. Logic is correct. |
| internal/daemon/flow.go | Watchdog added to flow WaitGroup so stopFlow drains it; projectFlow gains a stable `key` field; configwatch YAML watcher removed deliberately. |
| internal/daemon/supervise.go | Watchdog ownership moved from runSupervise to startFlow; logSupervisorDecision added to emit per-cycle structured log line matching CLI supervise output. |
| internal/daemon/daemon_test.go | New tests for bind-error surfacing, same-basename dedup fix, watchdog WaitGroup drain, interval clamping, and decision logging. newTestDaemon inadvertently runs the real watchdog goroutine. |
| internal/supervisor/watchdog.go | Watchdog gains a `name` parameter woven into every log line; persistSupervisorStuck updated to use the same logPrefix. |
| internal/server/fleet_build.go | New file consolidates WireFleetProjectGitHub, NewFleetProjectWithGitHub, FleetProjectsFromConfigs, FleetAuthFromProjects — shared by serve and daemon paths. |
| cmd/maestro/main.go | superviseCmd updated to new Watchdog signature; fleetProjectsFromConfigs/fleetAuthFromProjects/defaultFleetProjectName deleted in favour of shared server helpers. |
| cmd/maestro/daemon.go | Flag defaults now reference daemon.DefaultRunInterval / daemon.DefaultSuperviseInterval; `time` import removed cleanly. |
| CLAUDE.md | New guidance file documenting commit-message convention (no Claude trailers) and build/test steps before PR. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/daemon/daemon_test.go`, line 56-65 ([link](https://github.com/befeast/maestro/blob/15d2d523552598a900b474065c174021053e5a3b/internal/daemon/daemon_test.go#L56-L65)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`newTestDaemon` silently runs the real watchdog**

   `newTestDaemon` calls `New(loader, Options{...})` which clamps `SuperviseInterval` to `DefaultSuperviseInterval` (5 min) and sets `d.watchdogLoop = supervisor.Watchdog`. Because `d.opts.SuperviseInterval > 0` in `startFlow`, every flow started through this helper now tracks the real `supervisor.Watchdog` goroutine in its WaitGroup. The tests `TestStartStopFlowDrains` and `TestFlowPanicContained` both use this helper and call `startFlow` directly — they now depend on `supervisor.Watchdog` exiting cleanly on context cancel to close `flow.done`. Adding a no-op stub (e.g., `d.watchdogLoop = func(context.Context, string, string, time.Duration) {}`) to `newTestDaemon` would keep those tests isolated and prevent a future change to `supervisor.Watchdog` shutdown behaviour from silently breaking unrelated tests.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/daemon/daemon_test.go
   Line: 56-65

   Comment:
   **`newTestDaemon` silently runs the real watchdog**

   `newTestDaemon` calls `New(loader, Options{...})` which clamps `SuperviseInterval` to `DefaultSuperviseInterval` (5 min) and sets `d.watchdogLoop = supervisor.Watchdog`. Because `d.opts.SuperviseInterval > 0` in `startFlow`, every flow started through this helper now tracks the real `supervisor.Watchdog` goroutine in its WaitGroup. The tests `TestStartStopFlowDrains` and `TestFlowPanicContained` both use this helper and call `startFlow` directly — they now depend on `supervisor.Watchdog` exiting cleanly on context cancel to close `flow.done`. Adding a no-op stub (e.g., `d.watchdogLoop = func(context.Context, string, string, time.Duration) {}`) to `newTestDaemon` would keep those tests isolated and prevent a future change to `supervisor.Watchdog` shutdown behaviour from silently breaking unrelated tests.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/daemon/daemon_test.go:56-65
**`newTestDaemon` silently runs the real watchdog**

`newTestDaemon` calls `New(loader, Options{...})` which clamps `SuperviseInterval` to `DefaultSuperviseInterval` (5 min) and sets `d.watchdogLoop = supervisor.Watchdog`. Because `d.opts.SuperviseInterval > 0` in `startFlow`, every flow started through this helper now tracks the real `supervisor.Watchdog` goroutine in its WaitGroup. The tests `TestStartStopFlowDrains` and `TestFlowPanicContained` both use this helper and call `startFlow` directly — they now depend on `supervisor.Watchdog` exiting cleanly on context cancel to close `flow.done`. Adding a no-op stub (e.g., `d.watchdogLoop = func(context.Context, string, string, time.Duration) {}`) to `newTestDaemon` would keep those tests isolated and prevent a future change to `supervisor.Watchdog` shutdown behaviour from silently breaking unrelated tests.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["daemon: Phase 1 hardening — fix #763 rev..."](https://github.com/befeast/maestro/commit/15d2d523552598a900b474065c174021053e5a3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39361272)</sub>

<!-- /greptile_comment -->