### PR TITLE
Phase 1 hardening: исправить находки ревью #763 (daemon) + commit-convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md
+
+Guidance for AI coding agents (and the worker harness that auto-loads this file
+from the repo root) working in the maestro repository.
+
+## Commit-message & PR convention
+
+- **Do NOT add `Co-authored-by: Claude …` or `🤖 Generated with Claude Code`
+  trailers** to commit messages or PR bodies. maestro attributes work via its
+  own durable trailer (below); the Claude/agent byline is noise in this repo's
+  history and is intentionally suppressed.
+
+  > Note: the `Co-authored-by` byline is emitted by the Claude Code *harness*,
+  > not by maestro code. The deterministic switch that stops it is
+  > `includeCoAuthoredBy: false` in the worker's `~/.claude/settings.json`. This
+  > document records the convention; an operator still has to set that flag for
+  > the trailer to actually disappear.
+
+- **Do preserve the `Maestro-Backend:` trailer.** maestro stamps it on commits
+  and PR bodies (`internal/state/attribution.go`,
+  `state.AttributionTrailerKey`) to record the backend timeline for a session.
+  It is the canonical, queryable attribution for this repo — never strip,
+  rewrite, or duplicate it.
+
+- **Do NOT use GitHub auto-closing keywords** (`Closes`, `Fixes`, `Resolves`,
+  and their variants) followed by an issue reference in commit messages, PR
+  titles, or PR bodies for maestro-managed work — `agent-lint` rejects them, and
+  a quoted commit subject can trip the check even when the PR body is clean. Use
+  `Refs #N` or `Implements #N` instead.
+
+## Build & test before a PR
+
+- `gofmt` changed Go files.
+- `go test ./...`
+- `go build ./cmd/maestro/`

--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/befeast/maestro/internal/configstore"
 	"github.com/befeast/maestro/internal/daemon"
@@ -21,8 +20,8 @@ import (
 func daemonCmd(args []string) {
 	fs := flag.NewFlagSet("daemon", flag.ExitOnError)
 	storePath := fs.String("store", defaultConfigStorePath(), "Path to SQLite config store")
-	runInterval := fs.Duration("run-interval", 10*time.Minute, "Orchestrator loop interval")
-	superviseInterval := fs.Duration("supervise-interval", 5*time.Minute, "Supervisor loop interval")
+	runInterval := fs.Duration("run-interval", daemon.DefaultRunInterval, "Orchestrator loop interval")
+	superviseInterval := fs.Duration("supervise-interval", daemon.DefaultSuperviseInterval, "Supervisor loop interval")
 	host := fs.String("host", "127.0.0.1", "Host/interface to bind the fleet web server")
 	port := fs.Int("port", 8786, "Port to bind the fleet web server")
 	promptPath := fs.String("prompt", "", "Path to worker prompt base file")

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -725,7 +725,7 @@ func superviseCmd(args []string) {
 	// been bumped in 3*interval. The warning persists into state
 	// (SupervisorStuck=true) so the Fleet API and dashboards can
 	// surface it without grepping the journal.
-	go supervisor.Watchdog(ctx, cfg.StateDir, *interval)
+	go supervisor.Watchdog(ctx, cfg.SessionPrefix, cfg.StateDir, *interval)
 
 	ticker := time.NewTicker(*interval)
 	defer ticker.Stop()
@@ -1039,22 +1039,14 @@ func serveCmd(args []string) {
 			if err != nil {
 				log.Fatalf("load fleet: %v", err)
 			}
-			// LoadFleetProjects can't import github (cycle); wire the
-			// per-project safe-action GH client here at the boundary.
+			// LoadFleetProjects yields configs without their GitHub
+			// clients; wire the per-project safe-action + board client
+			// here via the shared helper (#529, #764).
 			for i := range projects {
-				if cfg := projects[i].Cfg(); cfg != nil {
-					gh := github.New(cfg.Repo)
-					projects[i].SetActionGH(gh)
-					// #529: surface the GitHub Project board (WIP
-					// rollup + URL) in the fleet snapshot when the
-					// project enables github_projects.
-					if cfg.GitHubProjects.Enabled && cfg.GitHubProjects.ProjectNumber > 0 {
-						projects[i].SetBoardClient(gh, cfg.GitHubProjects.ProjectNumber)
-					}
-				}
+				server.WireFleetProjectGitHub(&projects[i])
 			}
 		} else {
-			projects = fleetProjectsFromConfigs(cfgs)
+			projects = server.FleetProjectsFromConfigs(cfgs)
 		}
 		fleetHost := *host
 		if strings.TrimSpace(fleetHost) == "" {
@@ -1079,7 +1071,7 @@ func serveCmd(args []string) {
 		// #487: fleet auth uses the first project that configures a token
 		// env. A single shared token across the fleet is the deployment
 		// expectation; per-project tokens are out of scope.
-		fleetSrv.SetAuth(fleetAuthFromProjects(projects))
+		fleetSrv.SetAuth(server.FleetAuthFromProjects(projects))
 		if err := fleetSrv.Start(ctx); err != nil {
 			log.Fatalf("serve fleet: %v", err)
 		}
@@ -1123,45 +1115,6 @@ func serveCmd(args []string) {
 	if err := srv.Start(ctx); err != nil {
 		log.Fatalf("serve: %v", err)
 	}
-}
-
-func fleetProjectsFromConfigs(cfgs []*config.Config) []server.FleetProject {
-	projects := make([]server.FleetProject, 0, len(cfgs))
-	for _, cfg := range cfgs {
-		proj := server.NewFleetProject(defaultFleetProjectName(cfg.Repo), cfg.ResolvePath(), "", cfg)
-		gh := github.New(cfg.Repo)
-		proj.SetActionGH(gh)
-		if cfg.GitHubProjects.Enabled && cfg.GitHubProjects.ProjectNumber > 0 {
-			proj.SetBoardClient(gh, cfg.GitHubProjects.ProjectNumber)
-		}
-		projects = append(projects, proj)
-	}
-	return projects
-}
-
-// fleetAuthFromProjects returns the first non-empty Server.Auth config across
-// the fleet. The fleet uses a single shared token (#487); per-project
-// distinct tokens are intentionally out of scope.
-func fleetAuthFromProjects(projects []server.FleetProject) config.ServerAuthConfig {
-	for i := range projects {
-		cfg := projects[i].Cfg()
-		if cfg == nil {
-			continue
-		}
-		if strings.TrimSpace(cfg.Server.Auth.TokenEnv) != "" {
-			return cfg.Server.Auth
-		}
-	}
-	return config.ServerAuthConfig{}
-}
-
-func defaultFleetProjectName(repo string) string {
-	repo = strings.TrimSpace(repo)
-	if repo == "" {
-		return "project"
-	}
-	parts := strings.Split(repo, "/")
-	return parts[len(parts)-1]
 }
 
 func statusCmd(args []string) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -76,7 +76,7 @@ type Daemon struct {
 	// override them to drive flows (and assert WaitGroup tracking) without
 	// reaching GitHub.
 	runLoop       func(ctx context.Context, cfg *config.Config, opts Options)
-	superviseLoop func(ctx context.Context, cfg *config.Config, opts Options)
+	superviseLoop func(ctx context.Context, name string, cfg *config.Config, opts Options)
 	watchdogLoop  func(ctx context.Context, name, stateDir string, interval time.Duration)
 }
 
@@ -103,8 +103,8 @@ func New(store ConfigLoader, opts Options) *Daemon {
 		flows: make(map[string]*projectFlow),
 	}
 	d.runLoop = runOrchestrator
-	d.superviseLoop = func(ctx context.Context, cfg *config.Config, opts Options) {
-		runSupervise(ctx, cfg, opts.SuperviseInterval)
+	d.superviseLoop = func(ctx context.Context, name string, cfg *config.Config, opts Options) {
+		runSupervise(ctx, name, cfg, opts.SuperviseInterval)
 	}
 	d.watchdogLoop = supervisor.Watchdog
 	return d
@@ -139,10 +139,25 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// on Project.Name, and two repos that share a basename ("api") would
 	// otherwise route the second repo's routes/actions/audit to the first
 	// (#764).
+	//
+	// This StateDir dedup is intentionally NOT folded into
+	// server.FleetProjectsFromConfigs (which `serve --fleet` uses): the daemon
+	// owns exactly one *flow* per identity, so a repeated StateDir is a true
+	// duplicate to skip, whereas serve merely aggregates the configs it is
+	// handed. Keeping the dedup here — over the shared per-cfg construction
+	// (UniqueFleetName + NewFleetProjectWithGitHubNamed) — documents that
+	// divergence instead of silently forking the shared builder (#764).
 	seen := make(map[string]bool, len(cfgs))
 	usedNames := make(map[string]bool, len(cfgs))
 	projects := make([]server.FleetProject, 0, len(cfgs))
 	for _, cfg := range cfgs {
+		if cfg == nil {
+			// A nil entry from the loader must not panic Run: flowKey tolerates
+			// nil but the wiring below dereferences cfg. Skip it, mirroring
+			// server.FleetProjectsFromConfigs' cfgRepo(nil) tolerance (#764).
+			log.Printf("[daemon] skip nil config from store")
+			continue
+		}
 		key := flowKey(cfg)
 		if seen[key] {
 			log.Printf("[daemon] skip project (repo=%s state_dir=%s): duplicate flow identity already started", cfg.Repo, cfg.StateDir)
@@ -150,45 +165,55 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 		seen[key] = true
 		name := server.UniqueFleetName(cfg.Repo, usedNames)
-		proj := server.NewFleetProjectWithGitHubNamed(name, cfg)
-		flow := d.startFlow(ctx, proj)
-		projects = append(projects, proj)
-		log.Printf("[daemon] started flow %q (repo=%s state_dir=%s)", flow.name, cfg.Repo, cfg.StateDir)
+		projects = append(projects, server.NewFleetProjectWithGitHubNamed(name, cfg))
 	}
 
 	// One FleetServer for the whole fleet — replaces the N per-project
 	// server.New instances the legacy run/serve paths spun up (#516).
 	fleet := server.NewFleet(projects, d.opts.Host, d.opts.Port, d.opts.ReadOnly)
 	fleet.SetAuth(server.FleetAuthFromProjects(projects))
+
+	// Bind the fleet port BEFORE starting any flow. If the port is already held
+	// (a legacy maestro@ unit, a second daemon), Listen fails here and we abort
+	// immediately — no flow has started, so there is nothing to drain. Binding
+	// AFTER starting flows would force the error path through stopAll, which
+	// blocks on a flow's in-flight, non-cancellable first RunOnce and hangs the
+	// startup-error return (#764 P2). Listen returns a nil listener for port 0
+	// (no web endpoint requested); Serve then no-ops on it.
+	ln, err := fleet.Listen()
+	if err != nil {
+		return err
+	}
+
+	for i := range projects {
+		flow := d.startFlow(ctx, projects[i])
+		log.Printf("[daemon] started flow %q (repo=%s state_dir=%s)", flow.name, flow.cfg.Repo, flow.cfg.StateDir)
+	}
+
+	// Expose the fleet only after the flows are started so callers that observe
+	// d.Fleet() can rely on the flows being live.
 	d.mu.Lock()
 	d.fleet = fleet
 	d.mu.Unlock()
 
 	log.Printf("[daemon] serving fleet — projects=%d addr=%s:%d read_only=%v", len(projects), d.opts.Host, d.opts.Port, d.opts.ReadOnly)
 	fleetErr := make(chan error, 1)
-	go func() { fleetErr <- fleet.Start(ctx) }()
+	go func() { fleetErr <- fleet.Serve(ctx, ln) }()
 
-	// Surface a fleet bind failure immediately. If the port is already held (a
-	// legacy maestro@ unit, a second daemon), fleet.Start returns the bind
-	// error right away — racing it against ctx.Done() means we abort and report
-	// it now instead of buffering it and running every flow with no web
-	// endpoint / dashboard / health probe until SIGTERM (#764 P1).
-	//
-	// fleet.Start returns nil immediately when the port is 0 (no web endpoint
-	// requested); that is intentional, not a failure, so keep running the flows
-	// and fall through to wait on ctx.Done().
 	select {
 	case <-ctx.Done():
 		d.stopAll()
 		return <-fleetErr
 	case err := <-fleetErr:
+		// Serve returned before shutdown — a runtime serve error after a
+		// successful bind (rare; the bind failure itself was already handled by
+		// Listen above). Flows are legitimately running, so drain them.
+		d.stopAll()
 		if err != nil {
 			log.Printf("[daemon] fleet server failed on %s:%d: %v", d.opts.Host, d.opts.Port, err)
-			d.stopAll()
 			return err
 		}
 		<-ctx.Done()
-		d.stopAll()
 		return nil
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -22,6 +22,15 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/server"
+	"github.com/befeast/maestro/internal/supervisor"
+)
+
+// Default loop intervals, shared by the daemon command's flag defaults and the
+// clamp in New so an explicit non-positive operator value falls back to a safe
+// cadence instead of disabling supervise or panicking time.NewTicker (#764).
+const (
+	DefaultRunInterval       = 10 * time.Minute
+	DefaultSuperviseInterval = 5 * time.Minute
 )
 
 // ConfigLoader yields the set of project configs the daemon supervises. It is
@@ -62,15 +71,32 @@ type Daemon struct {
 	fleet *server.FleetServer
 	flows map[string]*projectFlow
 
-	// runLoop and superviseLoop build the per-project loops. They default to
-	// the production orchestrator + supervisor wiring; tests override them to
-	// drive flows without reaching GitHub.
+	// runLoop, superviseLoop, and watchdogLoop build the per-project loops.
+	// They default to the production orchestrator + supervisor wiring; tests
+	// override them to drive flows (and assert WaitGroup tracking) without
+	// reaching GitHub.
 	runLoop       func(ctx context.Context, cfg *config.Config, opts Options)
 	superviseLoop func(ctx context.Context, cfg *config.Config, opts Options)
+	watchdogLoop  func(ctx context.Context, name, stateDir string, interval time.Duration)
 }
 
 // New constructs a Daemon that loads projects from store on Run.
+//
+// Non-positive intervals are clamped to the package defaults with a loud warn
+// rather than silently honored: a 0 run-interval would panic time.NewTicker
+// (caught by recoverFlow, killing the orchestrator silently) and a 0
+// supervise-interval would run a single cycle then leave the supervise loop and
+// its watchdog dead while the flow still reports healthy (#764). The 10m/5m
+// defaults are safe, so this only fires on an explicit non-positive value.
 func New(store ConfigLoader, opts Options) *Daemon {
+	if opts.RunInterval <= 0 {
+		log.Printf("[daemon] run-interval %s is not positive; clamping to default %s", opts.RunInterval, DefaultRunInterval)
+		opts.RunInterval = DefaultRunInterval
+	}
+	if opts.SuperviseInterval <= 0 {
+		log.Printf("[daemon] supervise-interval %s is not positive; clamping to default %s", opts.SuperviseInterval, DefaultSuperviseInterval)
+		opts.SuperviseInterval = DefaultSuperviseInterval
+	}
 	d := &Daemon{
 		store: store,
 		opts:  opts,
@@ -80,6 +106,7 @@ func New(store ConfigLoader, opts Options) *Daemon {
 	d.superviseLoop = func(ctx context.Context, cfg *config.Config, opts Options) {
 		runSupervise(ctx, cfg, opts.SuperviseInterval)
 	}
+	d.watchdogLoop = supervisor.Watchdog
 	return d
 }
 
@@ -87,9 +114,9 @@ func New(store ConfigLoader, opts Options) *Daemon {
 // supervisor) for each, and serves one FleetServer aggregating them all. It
 // blocks until ctx is cancelled, then drains every flow before returning.
 //
-// A project that cannot be turned into a flow (duplicate fleet name) is
-// logged and skipped — one bad project must never abort daemon startup or the
-// other flows (#756).
+// A project that duplicates an already-started flow identity (same StateDir)
+// is logged and skipped — one bad project must never abort daemon startup or
+// the other flows (#756).
 func (d *Daemon) Run(ctx context.Context) error {
 	cfgs, err := d.store.LoadAll(ctx)
 	if err != nil {
@@ -99,24 +126,40 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return errors.New("config store has no projects")
 	}
 
+	// Dedup on the flow's real identity (StateDir, falling back to Repo), not
+	// the fleet display name. The display name is the repo basename, so
+	// org-a/api and org-b/api collapsed to one "api" and the second project's
+	// orchestrator + supervisor never started; the legitimate one-repo /
+	// two-StateDir layout (which serve --fleet aggregates without dedup) was
+	// likewise dropped (#764). Only a literal re-load of the same StateDir is a
+	// true duplicate.
+	//
+	// usedNames keeps every started project's fleet display name distinct so
+	// the aggregating FleetServer can address each one — its findProject keys
+	// on Project.Name, and two repos that share a basename ("api") would
+	// otherwise route the second repo's routes/actions/audit to the first
+	// (#764).
 	seen := make(map[string]bool, len(cfgs))
+	usedNames := make(map[string]bool, len(cfgs))
 	projects := make([]server.FleetProject, 0, len(cfgs))
 	for _, cfg := range cfgs {
-		proj := newFleetProject(cfg)
-		if seen[proj.Name] {
-			log.Printf("[daemon] skip project %q (repo=%s): duplicate fleet name already started", proj.Name, cfg.Repo)
+		key := flowKey(cfg)
+		if seen[key] {
+			log.Printf("[daemon] skip project (repo=%s state_dir=%s): duplicate flow identity already started", cfg.Repo, cfg.StateDir)
 			continue
 		}
-		seen[proj.Name] = true
+		seen[key] = true
+		name := server.UniqueFleetName(cfg.Repo, usedNames)
+		proj := server.NewFleetProjectWithGitHubNamed(name, cfg)
 		flow := d.startFlow(ctx, proj)
 		projects = append(projects, proj)
-		log.Printf("[daemon] started flow %q (repo=%s)", flow.name, cfg.Repo)
+		log.Printf("[daemon] started flow %q (repo=%s state_dir=%s)", flow.name, cfg.Repo, cfg.StateDir)
 	}
 
 	// One FleetServer for the whole fleet — replaces the N per-project
 	// server.New instances the legacy run/serve paths spun up (#516).
 	fleet := server.NewFleet(projects, d.opts.Host, d.opts.Port, d.opts.ReadOnly)
-	fleet.SetAuth(fleetAuth(projects))
+	fleet.SetAuth(server.FleetAuthFromProjects(projects))
 	d.mu.Lock()
 	d.fleet = fleet
 	d.mu.Unlock()
@@ -125,11 +168,42 @@ func (d *Daemon) Run(ctx context.Context) error {
 	fleetErr := make(chan error, 1)
 	go func() { fleetErr <- fleet.Start(ctx) }()
 
-	// Block until shutdown is requested. We wait on ctx (not fleet.Start) so
-	// the daemon stays up even when the fleet is not bound (port 0).
-	<-ctx.Done()
-	d.stopAll()
-	return <-fleetErr
+	// Surface a fleet bind failure immediately. If the port is already held (a
+	// legacy maestro@ unit, a second daemon), fleet.Start returns the bind
+	// error right away — racing it against ctx.Done() means we abort and report
+	// it now instead of buffering it and running every flow with no web
+	// endpoint / dashboard / health probe until SIGTERM (#764 P1).
+	//
+	// fleet.Start returns nil immediately when the port is 0 (no web endpoint
+	// requested); that is intentional, not a failure, so keep running the flows
+	// and fall through to wait on ctx.Done().
+	select {
+	case <-ctx.Done():
+		d.stopAll()
+		return <-fleetErr
+	case err := <-fleetErr:
+		if err != nil {
+			log.Printf("[daemon] fleet server failed on %s:%d: %v", d.opts.Host, d.opts.Port, err)
+			d.stopAll()
+			return err
+		}
+		<-ctx.Done()
+		d.stopAll()
+		return nil
+	}
+}
+
+// flowKey is a flow's stable identity for dedup and the flows registry. The
+// StateDir is the real per-flow identity (one repo can host several configs
+// with distinct StateDirs); Repo is the fallback when StateDir is unset.
+func flowKey(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if sd := strings.TrimSpace(cfg.StateDir); sd != "" {
+		return sd
+	}
+	return strings.TrimSpace(cfg.Repo)
 }
 
 // Fleet returns the aggregating FleetServer once Run has built it, or nil
@@ -138,20 +212,4 @@ func (d *Daemon) Fleet() *server.FleetServer {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.fleet
-}
-
-// fleetAuth returns the first non-empty Server.Auth config across the fleet.
-// The fleet uses a single shared token (#487); per-project distinct tokens are
-// intentionally out of scope.
-func fleetAuth(projects []server.FleetProject) config.ServerAuthConfig {
-	for i := range projects {
-		cfg := projects[i].Cfg()
-		if cfg == nil {
-			continue
-		}
-		if strings.TrimSpace(cfg.Server.Auth.TokenEnv) != "" {
-			return cfg.Server.Auth
-		}
-	}
-	return config.ServerAuthConfig{}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -51,12 +51,20 @@ func (lt *loopTracker) loop(ctx context.Context, cfg *config.Config, opts Option
 	atomic.AddInt64(&lt.stopped, 1)
 }
 
+// superviseLoop is the supervise-shaped stub (the supervise loop takes the
+// flow's unique name as its first arg, #764). It records the same counters.
+func (lt *loopTracker) superviseLoop(ctx context.Context, name string, cfg *config.Config, opts Options) {
+	atomic.AddInt64(&lt.started, 1)
+	<-ctx.Done()
+	atomic.AddInt64(&lt.stopped, 1)
+}
+
 // newTestDaemon builds a daemon with stub loops (no GitHub) over the given
 // configs. The watchdog is also stubbed to a no-op so flows started through
 // this helper stay isolated from the real supervisor.Watchdog goroutine — a
 // future change to its shutdown path must not silently break these lifecycle
 // tests. Tests that assert watchdog behaviour install their own stub.
-func newTestDaemon(loader ConfigLoader, run, supervise func(context.Context, *config.Config, Options)) *Daemon {
+func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config, Options), supervise func(context.Context, string, *config.Config, Options)) *Daemon {
 	d := New(loader, Options{Host: "127.0.0.1", Port: 0})
 	if run != nil {
 		d.runLoop = run
@@ -75,7 +83,7 @@ func TestRunStartsFlowPerProjectAndAggregatesFleet(t *testing.T) {
 		testConfig(t, "owner/gamma"),
 	}
 	var runTracker, supTracker loopTracker
-	d := newTestDaemon(fakeLoader{cfgs: cfgs}, runTracker.loop, supTracker.loop)
+	d := newTestDaemon(fakeLoader{cfgs: cfgs}, runTracker.loop, supTracker.superviseLoop)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -139,7 +147,7 @@ func TestRunSkipsDuplicateFlowIdentity(t *testing.T) {
 	dup.StateDir = shared.StateDir
 	cfgs := []*config.Config{shared, dup}
 	var run, sup loopTracker
-	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.loop)
+	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.superviseLoop)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -171,7 +179,7 @@ func TestRunSameBasenameDistinctReposBothStart(t *testing.T) {
 		testConfig(t, "org-b/api"),
 	}
 	var run, sup loopTracker
-	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.loop)
+	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.superviseLoop)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -205,7 +213,7 @@ func TestRunSameBasenameDistinctReposGetUniqueFleetNames(t *testing.T) {
 		testConfig(t, "org-b/api"),
 	}
 	var run, sup loopTracker
-	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.loop)
+	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.superviseLoop)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -262,7 +270,7 @@ func TestRunEmptyStoreReturnsError(t *testing.T) {
 func TestStartStopFlowDrains(t *testing.T) {
 	cfg := testConfig(t, "owner/solo")
 	var run, sup loopTracker
-	d := newTestDaemon(fakeLoader{cfgs: []*config.Config{cfg}}, run.loop, sup.loop)
+	d := newTestDaemon(fakeLoader{cfgs: []*config.Config{cfg}}, run.loop, sup.superviseLoop)
 
 	proj := server.NewFleetProjectWithGitHub(cfg)
 	flow := d.startFlow(context.Background(), proj)
@@ -293,13 +301,14 @@ func TestStartStopFlowDrains(t *testing.T) {
 	d.stopFlow("does-not-exist")
 }
 
-func TestFlowPanicContained(t *testing.T) {
-	// A panic in one loop must be contained: the daemon (and the other loop)
-	// survive. This is the "one bad project doesn't kill the daemon" guarantee
-	// at the goroutine level (#756).
+func TestFlowPanicCancelsFlow(t *testing.T) {
+	// A panic in one loop must (a) be contained — the daemon survives — and
+	// (b) cancel the whole flow so the OTHER goroutines drain, rather than
+	// leaving the flow half-alive and still registered (#764). flow.done closes
+	// on its own; no one calls stopFlow.
 	cfg := testConfig(t, "owner/panicky")
 	var supStarted, supStopped int64
-	supervise := func(ctx context.Context, c *config.Config, o Options) {
+	supervise := func(ctx context.Context, name string, c *config.Config, o Options) {
 		atomic.AddInt64(&supStarted, 1)
 		<-ctx.Done()
 		atomic.AddInt64(&supStopped, 1)
@@ -312,24 +321,40 @@ func TestFlowPanicContained(t *testing.T) {
 	proj := server.NewFleetProjectWithGitHub(cfg)
 	flow := d.startFlow(context.Background(), proj)
 
-	// The supervise loop keeps running despite the run loop's panic.
-	waitFor(t, func() bool { return atomic.LoadInt64(&supStarted) == 1 })
-
-	d.stopFlow(flow.key)
+	// The panic cancels the flow, so the supervise loop drains and flow.done
+	// closes without anyone calling stopFlow.
 	select {
 	case <-flow.done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("flow did not drain after a contained panic")
+		t.Fatal("panic did not cancel the flow; flow.done never closed")
+	}
+	if atomic.LoadInt64(&supStarted) != 1 {
+		t.Fatalf("supervise loop never started: supStarted=%d", supStarted)
 	}
 	if atomic.LoadInt64(&supStopped) != 1 {
-		t.Fatal("supervise loop did not drain after the run loop panicked")
+		t.Fatalf("supervise loop did not drain after the run loop panicked: supStopped=%d", supStopped)
 	}
+
+	// The cancelled flow is deregistered, not left lingering in the registry.
+	waitFor(t, func() bool {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		_, ok := d.flows[flow.key]
+		return !ok
+	})
 }
 
-// #764 P1: a fleet bind failure (port already held) must surface immediately —
-// Run returns the error on its own, without waiting for ctx cancellation /
-// SIGTERM. Otherwise the daemon runs every flow with no web endpoint until the
-// operator kills it.
+// #764 P1/P2: a fleet bind failure (port already held) must surface immediately
+// — Run returns the error on its own, without waiting for ctx cancellation /
+// SIGTERM. The fix binds the port BEFORE starting any flow, so a bind failure
+// also means NO flow ever started: this both proves the immediate return and
+// guards against a regression where the error path drains a flow whose
+// non-cancellable first RunOnce hangs startup.
+//
+// The run/supervise stubs here intentionally BLOCK forever (they ignore ctx) so
+// that, if Run ever reverted to starting flows before binding and then draining
+// them on the bind error, this test would hang on the 3s deadline instead of
+// passing — i.e. the stub models the real non-ctx-cancellable RunOnce.
 func TestRunSurfacesFleetBindErrorImmediately(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -339,10 +364,14 @@ func TestRunSurfacesFleetBindErrorImmediately(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	cfg := testConfig(t, "owner/bind")
-	var run, sup loopTracker
+	var started int64
+	blockingLoop := func(ctx context.Context, c *config.Config, o Options) {
+		atomic.AddInt64(&started, 1)
+		select {} // never returns — models a flow stuck in a non-cancellable cycle
+	}
 	d := New(fakeLoader{cfgs: []*config.Config{cfg}}, Options{Host: "127.0.0.1", Port: port})
-	d.runLoop = run.loop
-	d.superviseLoop = sup.loop
+	d.runLoop = blockingLoop
+	d.superviseLoop = func(ctx context.Context, name string, c *config.Config, o Options) { blockingLoop(ctx, c, o) }
 	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
 
 	// ctx is intentionally never cancelled within the deadline.
@@ -358,7 +387,13 @@ func TestRunSurfacesFleetBindErrorImmediately(t *testing.T) {
 			t.Fatal("Run returned nil; want the fleet bind error surfaced immediately")
 		}
 	case <-time.After(3 * time.Second):
-		t.Fatal("Run did not return the bind error without ctx cancellation (#764 P1)")
+		t.Fatal("Run did not return the bind error without ctx cancellation (#764 P1/P2: bind must happen before flows start)")
+	}
+
+	// Bind happened before any flow started, so no goroutine is stuck in a
+	// blocking loop. (If flows had started first, Run would have hung above.)
+	if got := atomic.LoadInt64(&started); got != 0 {
+		t.Fatalf("flows started = %d, want 0 (bind must precede flow start)", got)
 	}
 }
 
@@ -389,7 +424,7 @@ func TestStopFlowDrainsWatchdog(t *testing.T) {
 	var run, sup loopTracker
 	d := New(fakeLoader{cfgs: []*config.Config{cfg}}, Options{Port: 0, SuperviseInterval: time.Minute})
 	d.runLoop = run.loop
-	d.superviseLoop = sup.loop
+	d.superviseLoop = sup.superviseLoop
 
 	var wdStarted, wdStopped int64
 	var gotName, gotStateDir string
@@ -429,19 +464,25 @@ func TestLogSupervisorDecisionEmitsStructuredLine(t *testing.T) {
 	log.SetOutput(&buf)
 	defer log.SetOutput(old)
 
-	cfg := &config.Config{SessionPrefix: "acme"}
-	logSupervisorDecision(cfg, state.SupervisorDecision{
+	logSupervisorDecision("org-b-api", state.SupervisorDecision{
 		RecommendedAction: "merge_pr",
 		Status:            "ready",
 		Risk:              "low",
 		Confidence:        0.92,
+		ErrorClass:        "none",
 		RequiresApproval:  true,
 		ApprovalID:        "appr-1",
+		Target:            &state.SupervisorTarget{Issue: 7, PR: 12},
+		Reasons:           []string{"ci green", "no P0"},
 		Summary:           "PR #12 is green",
 	})
 
 	out := buf.String()
-	for _, want := range []string{"acme", "supervise decision", "action=merge_pr", "requires_approval=true", "approval=appr-1", "PR #12 is green"} {
+	for _, want := range []string{
+		"org-b-api", "supervise decision", "action=merge_pr",
+		"error_class=none", "requires_approval=true", "approval=appr-1",
+		"target=issue#7/pr#12", "reasons=2", "PR #12 is green",
+	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("decision log %q missing %q", out, want)
 		}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,16 +1,21 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/server"
+	"github.com/befeast/maestro/internal/state"
 )
 
 // fakeLoader is an in-memory ConfigLoader so the daemon lifecycle can be
@@ -47,7 +52,10 @@ func (lt *loopTracker) loop(ctx context.Context, cfg *config.Config, opts Option
 }
 
 // newTestDaemon builds a daemon with stub loops (no GitHub) over the given
-// configs.
+// configs. The watchdog is also stubbed to a no-op so flows started through
+// this helper stay isolated from the real supervisor.Watchdog goroutine — a
+// future change to its shutdown path must not silently break these lifecycle
+// tests. Tests that assert watchdog behaviour install their own stub.
 func newTestDaemon(loader ConfigLoader, run, supervise func(context.Context, *config.Config, Options)) *Daemon {
 	d := New(loader, Options{Host: "127.0.0.1", Port: 0})
 	if run != nil {
@@ -56,6 +64,7 @@ func newTestDaemon(loader ConfigLoader, run, supervise func(context.Context, *co
 	if supervise != nil {
 		d.superviseLoop = supervise
 	}
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
 	return d
 }
 
@@ -121,13 +130,14 @@ func TestRunStartsFlowPerProjectAndAggregatesFleet(t *testing.T) {
 	}
 }
 
-func TestRunSkipsDuplicateFleetName(t *testing.T) {
-	// Two configs deriving the same fleet name (same repo) — the second must
-	// be skipped, not silently overwrite the first.
-	cfgs := []*config.Config{
-		testConfig(t, "owner/dup"),
-		testConfig(t, "owner/dup"),
-	}
+func TestRunSkipsDuplicateFlowIdentity(t *testing.T) {
+	// Two configs that resolve to the same flow identity (same StateDir) are a
+	// true duplicate — the second must be skipped, not silently overwrite the
+	// first in the flows registry.
+	shared := testConfig(t, "owner/dup")
+	dup := testConfig(t, "owner/dup")
+	dup.StateDir = shared.StateDir
+	cfgs := []*config.Config{shared, dup}
 	var run, sup loopTracker
 	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.loop)
 
@@ -142,10 +152,100 @@ func TestRunSkipsDuplicateFleetName(t *testing.T) {
 	flows := len(d.flows)
 	d.mu.Unlock()
 	if flows != 1 {
-		t.Fatalf("flows = %d, want 1 (duplicate name skipped)", flows)
+		t.Fatalf("flows = %d, want 1 (duplicate flow identity skipped)", flows)
 	}
 	if got := atomic.LoadInt64(&run.started); got != 1 {
 		t.Fatalf("run loops started = %d, want 1", got)
+	}
+
+	cancel()
+	<-done
+}
+
+// #764 P2: two distinct repos that share a basename ("api") must BOTH get a
+// flow. The old dedup keyed on the repo-basename fleet name, so org-b/api was
+// silently skipped — its orchestrator and supervisor never started.
+func TestRunSameBasenameDistinctReposBothStart(t *testing.T) {
+	cfgs := []*config.Config{
+		testConfig(t, "org-a/api"),
+		testConfig(t, "org-b/api"),
+	}
+	var run, sup loopTracker
+	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.loop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	waitForFleet(t, d)
+	waitFor(t, func() bool { return atomic.LoadInt64(&run.started) == 2 })
+
+	d.mu.Lock()
+	flows := len(d.flows)
+	d.mu.Unlock()
+	if flows != 2 {
+		t.Fatalf("flows = %d, want 2 (same-basename distinct repos both start)", flows)
+	}
+	if got := atomic.LoadInt64(&sup.started); got != 2 {
+		t.Fatalf("supervise loops started = %d, want 2", got)
+	}
+
+	cancel()
+	<-done
+}
+
+// #764 P2 (Codex follow-up): two distinct repos that share a basename must get
+// DISTINCT fleet display names. The fleet server addresses project-scoped
+// routes/actions by Project.Name (findProject returns the first exact match),
+// so two projects both named "api" would route org-b/api's traffic to org-a/api.
+func TestRunSameBasenameDistinctReposGetUniqueFleetNames(t *testing.T) {
+	cfgs := []*config.Config{
+		testConfig(t, "org-a/api"),
+		testConfig(t, "org-b/api"),
+	}
+	var run, sup loopTracker
+	d := newTestDaemon(fakeLoader{cfgs: cfgs}, run.loop, sup.loop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	fleet := waitForFleet(t, d)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	rec := httptest.NewRecorder()
+	fleet.HandlerForTest().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/fleet = %d, want 200", rec.Code)
+	}
+	var resp struct {
+		Projects []struct {
+			Name string `json:"name"`
+			Repo string `json:"repo"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode fleet response: %v", err)
+	}
+	if len(resp.Projects) != 2 {
+		t.Fatalf("fleet projects = %d, want 2", len(resp.Projects))
+	}
+	names := map[string]string{} // name -> repo
+	for _, p := range resp.Projects {
+		if prev, dup := names[p.Name]; dup {
+			t.Fatalf("duplicate fleet name %q used by repos %q and %q", p.Name, prev, p.Repo)
+		}
+		names[p.Name] = p.Repo
+	}
+	// First claimant keeps the basename; the collider is disambiguated by the
+	// owner-repo slug.
+	if _, ok := names["api"]; !ok {
+		t.Fatalf("expected one project to keep basename %q; got names %v", "api", names)
+	}
+	if _, ok := names["org-b-api"]; !ok {
+		t.Fatalf("expected colliding project to use slug %q; got names %v", "org-b-api", names)
 	}
 
 	cancel()
@@ -164,13 +264,13 @@ func TestStartStopFlowDrains(t *testing.T) {
 	var run, sup loopTracker
 	d := newTestDaemon(fakeLoader{cfgs: []*config.Config{cfg}}, run.loop, sup.loop)
 
-	proj := newFleetProject(cfg)
+	proj := server.NewFleetProjectWithGitHub(cfg)
 	flow := d.startFlow(context.Background(), proj)
 
 	// Both loops should be running.
 	waitFor(t, func() bool { return atomic.LoadInt64(&run.started) == 1 && atomic.LoadInt64(&sup.started) == 1 })
 
-	d.stopFlow(flow.name)
+	d.stopFlow(flow.key)
 
 	select {
 	case <-flow.done:
@@ -183,13 +283,13 @@ func TestStartStopFlowDrains(t *testing.T) {
 
 	// Flow is deregistered.
 	d.mu.Lock()
-	_, ok := d.flows[flow.name]
+	_, ok := d.flows[flow.key]
 	d.mu.Unlock()
 	if ok {
 		t.Fatal("flow still registered after stopFlow")
 	}
 
-	// stopFlow on an unknown name is a no-op.
+	// stopFlow on an unknown key is a no-op.
 	d.stopFlow("does-not-exist")
 }
 
@@ -209,13 +309,13 @@ func TestFlowPanicContained(t *testing.T) {
 	}
 	d := newTestDaemon(fakeLoader{cfgs: []*config.Config{cfg}}, run, supervise)
 
-	proj := newFleetProject(cfg)
+	proj := server.NewFleetProjectWithGitHub(cfg)
 	flow := d.startFlow(context.Background(), proj)
 
 	// The supervise loop keeps running despite the run loop's panic.
 	waitFor(t, func() bool { return atomic.LoadInt64(&supStarted) == 1 })
 
-	d.stopFlow(flow.name)
+	d.stopFlow(flow.key)
 	select {
 	case <-flow.done:
 	case <-time.After(2 * time.Second):
@@ -223,6 +323,128 @@ func TestFlowPanicContained(t *testing.T) {
 	}
 	if atomic.LoadInt64(&supStopped) != 1 {
 		t.Fatal("supervise loop did not drain after the run loop panicked")
+	}
+}
+
+// #764 P1: a fleet bind failure (port already held) must surface immediately —
+// Run returns the error on its own, without waiting for ctx cancellation /
+// SIGTERM. Otherwise the daemon runs every flow with no web endpoint until the
+// operator kills it.
+func TestRunSurfacesFleetBindErrorImmediately(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	cfg := testConfig(t, "owner/bind")
+	var run, sup loopTracker
+	d := New(fakeLoader{cfgs: []*config.Config{cfg}}, Options{Host: "127.0.0.1", Port: port})
+	d.runLoop = run.loop
+	d.superviseLoop = sup.loop
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
+
+	// ctx is intentionally never cancelled within the deadline.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run returned nil; want the fleet bind error surfaced immediately")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return the bind error without ctx cancellation (#764 P1)")
+	}
+}
+
+// #764 P3: a non-positive interval must be clamped to the safe default with a
+// warn, never silently honored (a 0 run-interval panics time.NewTicker; a 0
+// supervise-interval kills the loop + watchdog while the flow reads healthy).
+func TestNewClampsNonPositiveIntervals(t *testing.T) {
+	d := New(fakeLoader{}, Options{RunInterval: 0, SuperviseInterval: -1})
+	if d.opts.RunInterval != DefaultRunInterval {
+		t.Fatalf("RunInterval = %s, want clamp to %s", d.opts.RunInterval, DefaultRunInterval)
+	}
+	if d.opts.SuperviseInterval != DefaultSuperviseInterval {
+		t.Fatalf("SuperviseInterval = %s, want clamp to %s", d.opts.SuperviseInterval, DefaultSuperviseInterval)
+	}
+
+	// A positive operator value is honored verbatim.
+	d2 := New(fakeLoader{}, Options{RunInterval: 3 * time.Minute, SuperviseInterval: 90 * time.Second})
+	if d2.opts.RunInterval != 3*time.Minute || d2.opts.SuperviseInterval != 90*time.Second {
+		t.Fatalf("positive intervals not honored: run=%s supervise=%s", d2.opts.RunInterval, d2.opts.SuperviseInterval)
+	}
+}
+
+// #764 P2: the watchdog goroutine must join the flow WaitGroup so stopFlow does
+// not return until it has exited. A stub watchdog records start/stop; after
+// stopFlow returns, stop must already be observed.
+func TestStopFlowDrainsWatchdog(t *testing.T) {
+	cfg := testConfig(t, "owner/wd")
+	var run, sup loopTracker
+	d := New(fakeLoader{cfgs: []*config.Config{cfg}}, Options{Port: 0, SuperviseInterval: time.Minute})
+	d.runLoop = run.loop
+	d.superviseLoop = sup.loop
+
+	var wdStarted, wdStopped int64
+	var gotName, gotStateDir string
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {
+		gotName, gotStateDir = name, stateDir
+		atomic.AddInt64(&wdStarted, 1)
+		<-ctx.Done()
+		atomic.AddInt64(&wdStopped, 1)
+	}
+
+	proj := server.NewFleetProjectWithGitHub(cfg)
+	flow := d.startFlow(context.Background(), proj)
+	waitFor(t, func() bool { return atomic.LoadInt64(&wdStarted) == 1 })
+
+	d.stopFlow(flow.key)
+
+	// stopFlow waits on flow.done, which only closes once the watchdog
+	// goroutine has also exited — so the stop must already be visible here,
+	// with no further wait.
+	if got := atomic.LoadInt64(&wdStopped); got != 1 {
+		t.Fatalf("watchdog not drained by stopFlow: wdStopped=%d, want 1", got)
+	}
+	// The watchdog is told which project it watches (#764 P2 log identity).
+	if gotName != flow.name {
+		t.Fatalf("watchdog name = %q, want %q", gotName, flow.name)
+	}
+	if gotStateDir != cfg.StateDir {
+		t.Fatalf("watchdog stateDir = %q, want %q", gotStateDir, cfg.StateDir)
+	}
+}
+
+// #764: the daemon supervise loop logs each cycle's SupervisorDecision so the
+// journal keeps the structural "why" trail the CLI printed.
+func TestLogSupervisorDecisionEmitsStructuredLine(t *testing.T) {
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(old)
+
+	cfg := &config.Config{SessionPrefix: "acme"}
+	logSupervisorDecision(cfg, state.SupervisorDecision{
+		RecommendedAction: "merge_pr",
+		Status:            "ready",
+		Risk:              "low",
+		Confidence:        0.92,
+		RequiresApproval:  true,
+		ApprovalID:        "appr-1",
+		Summary:           "PR #12 is green",
+	})
+
+	out := buf.String()
+	for _, want := range []string{"acme", "supervise decision", "action=merge_pr", "requires_approval=true", "approval=appr-1", "PR #12 is green"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("decision log %q missing %q", out, want)
+		}
 	}
 }
 

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -7,45 +7,37 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
-	"github.com/befeast/maestro/internal/configwatch"
-	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/orchestrator"
 	"github.com/befeast/maestro/internal/server"
 )
 
-// projectFlow is one project running inside the daemon: an orchestrator loop
-// and a supervisor loop sharing a child context. Cancelling that context
-// (stopFlow) tears both loops down.
+// projectFlow is one project running inside the daemon: an orchestrator loop, a
+// supervisor loop, and (when supervising) a liveness watchdog sharing a child
+// context. Cancelling that context (stopFlow) tears every goroutine down.
 type projectFlow struct {
 	name   string
+	key    string // stable flow identity (StateDir/Repo); the flows-map key
 	cfg    *config.Config
 	cancel context.CancelFunc
-	done   chan struct{} // closed once both loops have exited
+	done   chan struct{} // closed once every flow goroutine has exited
 }
 
-// newFleetProject wraps a config for in-process fleet serving, mirroring the
-// `maestro serve` wiring: a safe-action GitHub client, plus the GitHub Project
-// board client when github_projects is enabled. The project name is derived
-// from the repo (NewFleetProject's default) to match the serve path.
-func newFleetProject(cfg *config.Config) server.FleetProject {
-	proj := server.NewFleetProject("", cfg.ResolvePath(), "", cfg)
-	gh := github.New(cfg.Repo)
-	proj.SetActionGH(gh)
-	if cfg.GitHubProjects.Enabled && cfg.GitHubProjects.ProjectNumber > 0 {
-		proj.SetBoardClient(gh, cfg.GitHubProjects.ProjectNumber)
-	}
-	return proj
-}
-
-// startFlow launches the orchestrator + supervisor loops for proj under a
-// child of parent and registers the flow. Each loop runs in its own goroutine
-// with a panic recover so a single project's crash can never take the daemon
-// (or the other flows) down (#756).
+// startFlow launches the orchestrator + supervisor loops (and the liveness
+// watchdog) for proj under a child of parent and registers the flow. Each loop
+// runs in its own goroutine with a panic recover so a single project's crash
+// can never take the daemon (or the other flows) down (#756).
+//
+// Every goroutine the flow spawns is tracked in one WaitGroup, so close(done)
+// — and therefore stopFlow — does not return until the watchdog has also
+// exited. An untracked watchdog could otherwise Load/Save StateDir after the
+// flow is considered stopped, racing a restarted flow for the same project
+// (#764 P2).
 func (d *Daemon) startFlow(parent context.Context, proj server.FleetProject) *projectFlow {
 	cfg := proj.Cfg()
 	fctx, cancel := context.WithCancel(parent)
 	flow := &projectFlow{
 		name:   proj.Name,
+		key:    flowKey(cfg),
 		cfg:    cfg,
 		cancel: cancel,
 		done:   make(chan struct{}),
@@ -63,24 +55,39 @@ func (d *Daemon) startFlow(parent context.Context, proj server.FleetProject) *pr
 		defer recoverFlow(flow.name, "supervise")
 		d.superviseLoop(fctx, cfg, d.opts)
 	}()
+	// Phase 1.2 (#499) liveness watchdog, one per flow — tracked in the flow
+	// WaitGroup (#764 P2). The watchdog itself no-ops on a non-positive
+	// interval; gate here too so we never spawn a goroutine that immediately
+	// returns. The flow's fleet display name (unique across the daemon, #764)
+	// is woven into the watchdog's log lines so an operator can tell whose
+	// LastRunOnceAt went stale.
+	if d.opts.SuperviseInterval > 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer recoverFlow(flow.name, "watchdog")
+			d.watchdogLoop(fctx, flow.name, cfg.StateDir, d.opts.SuperviseInterval)
+		}()
+	}
 	go func() {
 		wg.Wait()
 		close(flow.done)
 	}()
 
 	d.mu.Lock()
-	d.flows[flow.name] = flow
+	d.flows[flow.key] = flow
 	d.mu.Unlock()
 	return flow
 }
 
-// stopFlow cancels a flow's context, waits for both loops to drain, and
-// deregisters it. Safe to call for an unknown name (no-op).
-func (d *Daemon) stopFlow(name string) {
+// stopFlow cancels a flow's context, waits for every flow goroutine to drain,
+// and deregisters it. Keyed on the flow identity (flowKey). Safe to call for an
+// unknown key (no-op).
+func (d *Daemon) stopFlow(key string) {
 	d.mu.Lock()
-	flow, ok := d.flows[name]
+	flow, ok := d.flows[key]
 	if ok {
-		delete(d.flows, name)
+		delete(d.flows, key)
 	}
 	d.mu.Unlock()
 	if !ok {
@@ -88,24 +95,24 @@ func (d *Daemon) stopFlow(name string) {
 	}
 	flow.cancel()
 	<-flow.done
-	log.Printf("[daemon] stopped flow %q", name)
+	log.Printf("[daemon] stopped flow %q", flow.name)
 }
 
 // stopAll drains every running flow. Called on daemon shutdown.
 func (d *Daemon) stopAll() {
 	d.mu.Lock()
-	names := make([]string, 0, len(d.flows))
-	for name := range d.flows {
-		names = append(names, name)
+	keys := make([]string, 0, len(d.flows))
+	for key := range d.flows {
+		keys = append(keys, key)
 	}
 	d.mu.Unlock()
-	for _, name := range names {
-		d.stopFlow(name)
+	for _, key := range keys {
+		d.stopFlow(key)
 	}
 }
 
-// recoverFlow swallows a panic in a flow loop so it stays contained to that
-// project. A panicking goroutine would otherwise crash the whole daemon.
+// recoverFlow swallows a panic in a flow goroutine so it stays contained to
+// that project. A panicking goroutine would otherwise crash the whole daemon.
 func recoverFlow(name, loop string) {
 	if r := recover(); r != nil {
 		log.Printf("[daemon] flow %q %s loop panicked (contained, flow stopped): %v", name, loop, r)
@@ -118,6 +125,12 @@ func recoverFlow(name, loop string) {
 // on run error — a failing orchestrator must log-and-continue, never take the
 // daemon down (#756). orchestrator.Run already log-and-continues on per-cycle
 // errors and returns nil on ctx cancellation.
+//
+// Hot-reload note (#764 P3): the daemon's source of truth is the config store
+// (#754), not the import-time YAML, so we deliberately do NOT wire a YAML file
+// watcher here — watching a file the store supersedes would let the run loop
+// drift from the supervise loop, which has no such watcher. Store-driven reload
+// is Phase 2 (#757).
 func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options) {
 	orch := orchestrator.New(cfg)
 	orch.SetBinaryVersion(opts.Version)
@@ -126,12 +139,6 @@ func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options) {
 	}
 
 	refreshCh := make(chan struct{}, 1)
-
-	// Config file watcher for hot-reload, matching `maestro run`.
-	if cfgPath := cfg.ResolvePath(); cfgPath != "" {
-		reloadCh := configwatch.Watch(ctx, cfgPath, 2*time.Second)
-		orch.SetConfigReloadCh(reloadCh)
-	}
 
 	runInterval := opts.RunInterval
 	if cfg.PollIntervalSeconds > 0 {

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -43,17 +43,30 @@ func (d *Daemon) startFlow(parent context.Context, proj server.FleetProject) *pr
 		done:   make(chan struct{}),
 	}
 
+	// Register BEFORE launching any goroutine (including the reaper below), so
+	// the reaper's deregister can never run ahead of the insert. A fast-failing
+	// flow — a loop that panics or returns on its first cycle — could otherwise
+	// have its reaper acquire d.mu, find no entry (insert hadn't happened yet),
+	// skip the delete, and then the insert would re-add the now-dead flow
+	// permanently: exactly the lingering-flow leak this path exists to prevent.
+	d.mu.Lock()
+	d.flows[flow.key] = flow
+	d.mu.Unlock()
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		defer recoverFlow(flow.name, "orchestrator")
+		defer recoverFlow(flow, "orchestrator")
 		d.runLoop(fctx, cfg, d.opts)
 	}()
 	go func() {
 		defer wg.Done()
-		defer recoverFlow(flow.name, "supervise")
-		d.superviseLoop(fctx, cfg, d.opts)
+		defer recoverFlow(flow, "supervise")
+		// flow.name is the unique fleet display name; the supervise loop keys
+		// its decision/cycle logs on it so two same-basename repos are
+		// distinguishable in the journal, matching the watchdog (#764).
+		d.superviseLoop(fctx, flow.name, cfg, d.opts)
 	}()
 	// Phase 1.2 (#499) liveness watchdog, one per flow — tracked in the flow
 	// WaitGroup (#764 P2). The watchdog itself no-ops on a non-positive
@@ -65,18 +78,24 @@ func (d *Daemon) startFlow(parent context.Context, proj server.FleetProject) *pr
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			defer recoverFlow(flow.name, "watchdog")
+			defer recoverFlow(flow, "watchdog")
 			d.watchdogLoop(fctx, flow.name, cfg.StateDir, d.opts.SuperviseInterval)
 		}()
 	}
 	go func() {
 		wg.Wait()
 		close(flow.done)
+		// Deregister once every goroutine has exited, so a flow that stopped on
+		// its own — e.g. a panic that recoverFlow cancelled — does not linger in
+		// the registry reporting as live. Guarded against a restart that reused
+		// the same key (stopFlow may have already removed and replaced it).
+		d.mu.Lock()
+		if d.flows[flow.key] == flow {
+			delete(d.flows, flow.key)
+		}
+		d.mu.Unlock()
 	}()
 
-	d.mu.Lock()
-	d.flows[flow.key] = flow
-	d.mu.Unlock()
 	return flow
 }
 
@@ -98,24 +117,40 @@ func (d *Daemon) stopFlow(key string) {
 	log.Printf("[daemon] stopped flow %q", flow.name)
 }
 
-// stopAll drains every running flow. Called on daemon shutdown.
+// stopAll drains every running flow. Called on daemon shutdown. It cancels
+// every flow up front and only then waits, so the per-flow drains overlap and
+// total shutdown latency is the slowest single flow — not the sum across flows.
+// A serial cancel-then-wait would stack the drains, and each flow's first
+// RunOnce is not ctx-cancellable mid-cycle, so the sum could be many minutes
+// (#764).
 func (d *Daemon) stopAll() {
 	d.mu.Lock()
-	keys := make([]string, 0, len(d.flows))
-	for key := range d.flows {
-		keys = append(keys, key)
+	flows := make([]*projectFlow, 0, len(d.flows))
+	for _, flow := range d.flows {
+		flows = append(flows, flow)
 	}
+	d.flows = make(map[string]*projectFlow)
 	d.mu.Unlock()
-	for _, key := range keys {
-		d.stopFlow(key)
+
+	for _, flow := range flows {
+		flow.cancel()
+	}
+	for _, flow := range flows {
+		<-flow.done
+		log.Printf("[daemon] stopped flow %q", flow.name)
 	}
 }
 
 // recoverFlow swallows a panic in a flow goroutine so it stays contained to
-// that project. A panicking goroutine would otherwise crash the whole daemon.
-func recoverFlow(name, loop string) {
+// that project (a panicking goroutine would otherwise crash the whole daemon),
+// and cancels the flow so its OTHER goroutines drain too. Without the cancel a
+// panic in one loop would leave the flow half-alive — the surviving loops still
+// running and the flow still registered as healthy — while the log claimed it
+// stopped (#764).
+func recoverFlow(flow *projectFlow, loop string) {
 	if r := recover(); r != nil {
-		log.Printf("[daemon] flow %q %s loop panicked (contained, flow stopped): %v", name, loop, r)
+		log.Printf("[daemon] flow %q %s loop panicked (contained, cancelling flow): %v", flow.name, loop, r)
+		flow.cancel()
 	}
 }
 
@@ -138,15 +173,19 @@ func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options) {
 		log.Printf("[%s] warn: load prompt: %v", cfg.SessionPrefix, err)
 	}
 
-	refreshCh := make(chan struct{}, 1)
-
 	runInterval := opts.RunInterval
 	if cfg.PollIntervalSeconds > 0 {
 		runInterval = time.Duration(cfg.PollIntervalSeconds) * time.Second
 	}
 
+	// The daemon has no API-triggered refresh channel: the per-project HTTP
+	// server that drove one in `maestro run` is replaced by the shared
+	// FleetServer, which does not signal individual flows. Pass nil rather than
+	// a buffered channel nothing ever sends on, so orch.Run's `case <-refreshCh`
+	// arm is plainly inert instead of looking like a wired-but-dead feature
+	// (#764). Store-driven reload is Phase 2 (#757).
 	log.Printf("[%s] starting orchestrator — repo=%s interval=%s", cfg.SessionPrefix, cfg.Repo, runInterval)
-	if err := orch.Run(ctx, runInterval, false, refreshCh); err != nil {
+	if err := orch.Run(ctx, runInterval, false, nil); err != nil {
 		log.Printf("[%s] orchestrator exited: %v", cfg.SessionPrefix, err)
 	}
 }

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -2,17 +2,21 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/supervisor"
 )
 
 // runSupervise is the per-project supervisor loop, extracted from the
 // single-project `maestro supervise` command (cmd/maestro/main.go). The daemon
-// runs one per flow.
+// runs one per flow; the liveness watchdog is owned by startFlow so it joins
+// the flow WaitGroup (#764 P2).
 //
 // Key difference from the CLI: the first cycle is log-and-continue, NOT
 // log.Fatalf. Under `systemctl start maestro@<project>`, a fatal first cycle
@@ -23,9 +27,17 @@ import (
 // LastRunOnceAt stops advancing.
 func runSupervise(ctx context.Context, cfg *config.Config, interval time.Duration) {
 	gh := github.New(cfg.Repo)
+	// Capture and log each cycle's SupervisorDecision the way `maestro
+	// supervise` prints it. The daemon still acts (label/comment/approve), but
+	// without this the structural "why did the supervisor do that" trail was
+	// dropped — turning debugging into journal archaeology (#764).
 	runOnce := func() error {
-		_, err := supervisor.RunOnce(cfg, gh)
-		return err
+		decision, err := supervisor.RunOnce(cfg, gh)
+		if err != nil {
+			return err
+		}
+		logSupervisorDecision(cfg, decision)
+		return nil
 	}
 
 	if err := runOnce(); err != nil {
@@ -35,9 +47,6 @@ func runSupervise(ctx context.Context, cfg *config.Config, interval time.Duratio
 	if interval <= 0 {
 		return
 	}
-
-	// Phase 1.2 (#499) liveness watchdog, one per flow.
-	go supervisor.Watchdog(ctx, cfg.StateDir, interval)
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -54,4 +63,28 @@ func runSupervise(ctx context.Context, cfg *config.Config, interval time.Duratio
 			}
 		}
 	}
+}
+
+// logSupervisorDecision emits a compact, per-cycle record of the supervisor's
+// decision so the daemon journal carries the same structural trail the CLI
+// `maestro supervise` printed (#764). One line, greppable by project prefix.
+func logSupervisorDecision(cfg *config.Config, decision state.SupervisorDecision) {
+	parts := []string{fmt.Sprintf("action=%s", decision.RecommendedAction)}
+	if decision.Status != "" {
+		parts = append(parts, fmt.Sprintf("status=%s", decision.Status))
+	}
+	if decision.Risk != "" {
+		parts = append(parts, fmt.Sprintf("risk=%s", decision.Risk))
+	}
+	parts = append(parts, fmt.Sprintf("confidence=%.2f", decision.Confidence))
+	if decision.RequiresApproval {
+		parts = append(parts, "requires_approval=true")
+	}
+	if decision.ApprovalID != "" {
+		parts = append(parts, fmt.Sprintf("approval=%s", decision.ApprovalID))
+	}
+	if summary := strings.TrimSpace(decision.Summary); summary != "" {
+		parts = append(parts, fmt.Sprintf("summary=%q", summary))
+	}
+	log.Printf("[%s] supervise decision: %s", cfg.SessionPrefix, strings.Join(parts, " "))
 }

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -25,23 +25,24 @@ import (
 // flows, so every cycle (including the first) is logged and retried. Persistent
 // failures still surface: the #499 watchdog flags SupervisorStuck when
 // LastRunOnceAt stops advancing.
-func runSupervise(ctx context.Context, cfg *config.Config, interval time.Duration) {
+func runSupervise(ctx context.Context, name string, cfg *config.Config, interval time.Duration) {
 	gh := github.New(cfg.Repo)
-	// Capture and log each cycle's SupervisorDecision the way `maestro
-	// supervise` prints it. The daemon still acts (label/comment/approve), but
-	// without this the structural "why did the supervisor do that" trail was
-	// dropped — turning debugging into journal archaeology (#764).
+	// Capture and log each cycle's SupervisorDecision. The daemon still acts
+	// (label/comment/approve), but without this the structural "why did the
+	// supervisor do that" trail was dropped — turning debugging into journal
+	// archaeology (#764). Logs key on the unique fleet name (not the possibly
+	// shared session prefix) so two same-basename repos stay distinguishable.
 	runOnce := func() error {
 		decision, err := supervisor.RunOnce(cfg, gh)
 		if err != nil {
 			return err
 		}
-		logSupervisorDecision(cfg, decision)
+		logSupervisorDecision(name, decision)
 		return nil
 	}
 
 	if err := runOnce(); err != nil {
-		log.Printf("[%s] supervise: first cycle failed (will retry): %v", cfg.SessionPrefix, err)
+		log.Printf("[%s] supervise: first cycle failed (will retry): %v", name, err)
 	}
 
 	if interval <= 0 {
@@ -59,16 +60,21 @@ func runSupervise(ctx context.Context, cfg *config.Config, interval time.Duratio
 			// never fatal — a transient GitHub/decision-layer failure must
 			// not crash the daemon.
 			if err := runOnce(); err != nil {
-				log.Printf("[%s] supervise: cycle failed (will retry in %s): %v", cfg.SessionPrefix, interval, err)
+				log.Printf("[%s] supervise: cycle failed (will retry in %s): %v", name, interval, err)
 			}
 		}
 	}
 }
 
-// logSupervisorDecision emits a compact, per-cycle record of the supervisor's
-// decision so the daemon journal carries the same structural trail the CLI
-// `maestro supervise` printed (#764). One line, greppable by project prefix.
-func logSupervisorDecision(cfg *config.Config, decision state.SupervisorDecision) {
+// logSupervisorDecision emits a compact, single-line, per-cycle record of the
+// supervisor's decision so the daemon journal keeps the structural "why" trail
+// (#764). It is a one-line, greppable digest — action, status, risk,
+// confidence, error_class, approval, target, and a reasons count — not the
+// CLI's full multi-line dump (`printSupervisorDecision` also expands every
+// reason, the queue analysis, and each mutation); the count + summary point an
+// operator at the right cycle, and `maestro supervise --json` remains the
+// source for the full record. Keyed on the unique fleet name passed in.
+func logSupervisorDecision(name string, decision state.SupervisorDecision) {
 	parts := []string{fmt.Sprintf("action=%s", decision.RecommendedAction)}
 	if decision.Status != "" {
 		parts = append(parts, fmt.Sprintf("status=%s", decision.Status))
@@ -77,14 +83,42 @@ func logSupervisorDecision(cfg *config.Config, decision state.SupervisorDecision
 		parts = append(parts, fmt.Sprintf("risk=%s", decision.Risk))
 	}
 	parts = append(parts, fmt.Sprintf("confidence=%.2f", decision.Confidence))
+	if decision.ErrorClass != "" {
+		parts = append(parts, fmt.Sprintf("error_class=%s", decision.ErrorClass))
+	}
 	if decision.RequiresApproval {
 		parts = append(parts, "requires_approval=true")
 	}
 	if decision.ApprovalID != "" {
 		parts = append(parts, fmt.Sprintf("approval=%s", decision.ApprovalID))
 	}
+	if tgt := supervisorTargetLabel(decision.Target); tgt != "" {
+		parts = append(parts, fmt.Sprintf("target=%s", tgt))
+	}
+	if n := len(decision.Reasons); n > 0 {
+		parts = append(parts, fmt.Sprintf("reasons=%d", n))
+	}
 	if summary := strings.TrimSpace(decision.Summary); summary != "" {
 		parts = append(parts, fmt.Sprintf("summary=%q", summary))
 	}
-	log.Printf("[%s] supervise decision: %s", cfg.SessionPrefix, strings.Join(parts, " "))
+	log.Printf("[%s] supervise decision: %s", name, strings.Join(parts, " "))
+}
+
+// supervisorTargetLabel renders a decision target compactly (issue/PR/session)
+// for the one-line journal digest. Empty when there is no target.
+func supervisorTargetLabel(t *state.SupervisorTarget) string {
+	if t == nil {
+		return ""
+	}
+	var b []string
+	if t.Issue > 0 {
+		b = append(b, fmt.Sprintf("issue#%d", t.Issue))
+	}
+	if t.PR > 0 {
+		b = append(b, fmt.Sprintf("pr#%d", t.PR))
+	}
+	if s := strings.TrimSpace(t.Session); s != "" {
+		b = append(b, "session="+s)
+	}
+	return strings.Join(b, "/")
 }

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -173,7 +173,7 @@ func LoadFleetProjects(path string) ([]FleetProject, error) {
 	}
 
 	baseDir := filepath.Dir(path)
-	seen := make(map[string]struct{}, len(file.Projects))
+	taken := make(map[string]bool, len(file.Projects))
 	projects := make([]FleetProject, 0, len(file.Projects))
 	for i, project := range file.Projects {
 		configPath := expandFleetPath(project.ConfigPath)
@@ -189,20 +189,30 @@ func LoadFleetProjects(path string) ([]FleetProject, error) {
 			return nil, fmt.Errorf("fleet project %d config %s: %w", i+1, project.ConfigPath, err)
 		}
 		project.cfg = cfg
-		if strings.TrimSpace(project.Name) == "" {
-			project.Name = defaultFleetProjectName(cfg.Repo)
+		if explicit := strings.TrimSpace(project.Name); explicit == "" {
+			// Derived (basename) name: auto-disambiguate distinct repos that
+			// share a basename (org-a/api vs org-b/api) the same way `maestro
+			// daemon` does via UniqueFleetName, instead of hard-erroring on a
+			// legitimate two-repo layout (#764). UniqueFleetName records the
+			// chosen name into taken.
+			project.Name = UniqueFleetName(cfg.Repo, taken)
+		} else {
+			// Explicit name from the fleet file: a real duplicate is operator
+			// error, so still reject it. Case-sensitive to match
+			// UniqueFleetName and findProject, which address project-scoped
+			// routes/actions by exact Project.Name (#764) — "Api" and "api" are
+			// distinct routes, not a collision.
+			if taken[explicit] {
+				return nil, fmt.Errorf("duplicate fleet project name %q", explicit)
+			}
+			taken[explicit] = true
+			project.Name = explicit
 		}
-		project.Name = strings.TrimSpace(project.Name)
 		if legacy := strings.TrimSpace(project.DashboardURL); legacy != "" {
 			log.Printf("[fleet] project %q: dashboard_url %q in %s is deprecated and ignored — the project is reachable at the unified MC route %s (#516)",
 				project.Name, legacy, path, fleetProjectScopedPath(project.Name))
 		}
 		project.DashboardURL = fleetProjectScopedPath(project.Name)
-		key := strings.ToLower(project.Name)
-		if _, exists := seen[key]; exists {
-			return nil, fmt.Errorf("duplicate fleet project name %q", project.Name)
-		}
-		seen[key] = struct{}{}
 		projects = append(projects, project)
 	}
 	return projects, nil
@@ -301,17 +311,46 @@ func (s *FleetServer) HandlerForTest() http.Handler { return s.buildHandler() }
 
 // Start begins serving the fleet dashboard. It blocks until shutdown.
 func (s *FleetServer) Start(ctx context.Context) error {
-	if s.port == 0 {
-		return nil
+	ln, err := s.Listen()
+	if err != nil {
+		return err
 	}
+	return s.Serve(ctx, ln)
+}
 
+// Listen binds the fleet's TCP port without serving. Splitting bind from serve
+// lets the daemon detect an "address already in use" failure BEFORE it starts
+// any project flow, so a bind error aborts startup immediately instead of
+// blocking on stopAll's flow drain — which cannot interrupt a flow's in-flight,
+// non-cancellable first RunOnce, hanging the startup-error return (#764 P2).
+//
+// Returns (nil, nil) when port == 0 (no web endpoint requested); Serve then
+// no-ops on the nil listener. A non-nil error is a real bind failure.
+func (s *FleetServer) Listen() (net.Listener, error) {
+	if s.port == 0 {
+		return nil, nil
+	}
 	host := strings.TrimSpace(s.host)
 	if host == "" {
 		host = "127.0.0.1"
 	}
 	addr := net.JoinHostPort(host, strconv.Itoa(s.port))
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("fleet server bind %s: %w", addr, err)
+	}
+	return ln, nil
+}
+
+// Serve serves the fleet HTTP API on ln until ctx is cancelled, then gracefully
+// shuts down. A nil ln (port 0) blocks on ctx and returns nil, matching the
+// historical no-web behavior. Serve takes ownership of ln.
+func (s *FleetServer) Serve(ctx context.Context, ln net.Listener) error {
+	if ln == nil {
+		<-ctx.Done()
+		return nil
+	}
 	s.srv = &http.Server{
-		Addr:         addr,
 		Handler:      s.buildHandler(),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
@@ -328,8 +367,8 @@ func (s *FleetServer) Start(ctx context.Context) error {
 	// on ctx.Done(). No-op for projects without a configured board client.
 	s.startBoardRefreshers(ctx)
 
-	log.Printf("[fleet] listening on %s", addr)
-	if err := s.srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	log.Printf("[fleet] listening on %s", ln.Addr())
+	if err := s.srv.Serve(ln); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("fleet server: %w", err)
 	}
 	return nil

--- a/internal/server/fleet_build.go
+++ b/internal/server/fleet_build.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+// WireFleetProjectGitHub attaches the per-project safe-action GitHub client and,
+// when github_projects is enabled, the board client (#529). It is the single
+// place the GitHub wiring lives, shared by every fleet entry point — `maestro
+// serve --fleet`, serve fleet-from-configs, and `maestro daemon` — so a fix to
+// token precedence (#487) or board wiring applies to all of them, not just one
+// copy (#764).
+func WireFleetProjectGitHub(proj *FleetProject) {
+	if proj == nil {
+		return
+	}
+	cfg := proj.Cfg()
+	if cfg == nil {
+		return
+	}
+	gh := github.New(cfg.Repo)
+	proj.SetActionGH(gh)
+	if cfg.GitHubProjects.Enabled && cfg.GitHubProjects.ProjectNumber > 0 {
+		proj.SetBoardClient(gh, cfg.GitHubProjects.ProjectNumber)
+	}
+}
+
+// NewFleetProjectWithGitHub builds a FleetProject for cfg (name derived from the
+// repo basename) with its safe-action GitHub client and board client wired in.
+// Shared by serve --fleet (one repo per config) and the daemon (one flow per
+// config) so the construction lives in one place (#764).
+func NewFleetProjectWithGitHub(cfg *config.Config) FleetProject {
+	return NewFleetProjectWithGitHubNamed("", cfg)
+}
+
+// NewFleetProjectWithGitHubNamed is NewFleetProjectWithGitHub with an explicit
+// fleet display name. An empty name falls back to the repo basename (the
+// historical default). Callers that aggregate several configs pass a
+// disambiguated name (see UniqueFleetName) so distinct repos that share a
+// basename do not collide on Project.Name (#764).
+func NewFleetProjectWithGitHubNamed(name string, cfg *config.Config) FleetProject {
+	proj := NewFleetProject(name, cfg.ResolvePath(), "", cfg)
+	WireFleetProjectGitHub(&proj)
+	return proj
+}
+
+// FleetProjectsFromConfigs builds one wired FleetProject per config, assigning
+// every project a fleet display name that is unique across the slice (#764) so
+// the aggregating FleetServer — whose findProject keys on Project.Name — can
+// address each one unambiguously even when two repos share a basename.
+func FleetProjectsFromConfigs(cfgs []*config.Config) []FleetProject {
+	projects := make([]FleetProject, 0, len(cfgs))
+	taken := make(map[string]bool, len(cfgs))
+	for _, cfg := range cfgs {
+		name := UniqueFleetName(cfgRepo(cfg), taken)
+		projects = append(projects, NewFleetProjectWithGitHubNamed(name, cfg))
+	}
+	return projects
+}
+
+// UniqueFleetName returns a fleet display name for repo that does not collide
+// with any name already recorded in taken, and records the chosen name back
+// into taken. It starts from the repo basename (the default display name) and,
+// on a collision between distinct repos that share a basename (org-a/api vs
+// org-b/api), disambiguates with the full owner-repo slug and then a numeric
+// suffix.
+//
+// The fleet server addresses project-scoped routes (`/project/<name>`), worker
+// details, audit logging, and safe actions by Project.Name — findProject
+// returns the first exact match — so two projects sharing a Name would silently
+// route the second repo's traffic to the first. Every project in one fleet must
+// therefore carry a distinct Name (#764).
+func UniqueFleetName(repo string, taken map[string]bool) string {
+	base := defaultFleetProjectName(repo)
+	if !taken[base] {
+		taken[base] = true
+		return base
+	}
+	// First fallback: the full owner-repo slug, which stays human-recognizable
+	// in the dashboard ("org-b-api") instead of a bare counter.
+	if slug := repoSlug(repo); slug != "" && slug != base && !taken[slug] {
+		taken[slug] = true
+		return slug
+	}
+	// Last resort: a numeric suffix on the basename.
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if !taken[candidate] {
+			taken[candidate] = true
+			return candidate
+		}
+	}
+}
+
+// repoSlug renders owner/repo as a single path-safe token (owner-repo). Empty
+// when repo is blank.
+func repoSlug(repo string) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return ""
+	}
+	return strings.ReplaceAll(repo, "/", "-")
+}
+
+// cfgRepo safely reads cfg.Repo, tolerating a nil config.
+func cfgRepo(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Repo
+}
+
+// FleetAuthFromProjects returns the first non-empty Server.Auth config across
+// the fleet. The fleet uses a single shared token (#487); per-project distinct
+// tokens are intentionally out of scope.
+func FleetAuthFromProjects(projects []FleetProject) config.ServerAuthConfig {
+	for i := range projects {
+		cfg := projects[i].Cfg()
+		if cfg == nil {
+			continue
+		}
+		if strings.TrimSpace(cfg.Server.Auth.TokenEnv) != "" {
+			return cfg.Server.Auth
+		}
+	}
+	return config.ServerAuthConfig{}
+}

--- a/internal/server/fleet_build_test.go
+++ b/internal/server/fleet_build_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// UniqueFleetName must keep the basename for the first claimant and disambiguate
+// later collisions so the aggregating FleetServer can address every project by a
+// distinct Project.Name (#764).
+func TestUniqueFleetName(t *testing.T) {
+	taken := map[string]bool{}
+
+	if got := UniqueFleetName("org-a/api", taken); got != "api" {
+		t.Fatalf("first org-a/api = %q, want %q", got, "api")
+	}
+	// Distinct repo, same basename → owner-repo slug.
+	if got := UniqueFleetName("org-b/api", taken); got != "org-b-api" {
+		t.Fatalf("colliding org-b/api = %q, want %q", got, "org-b-api")
+	}
+	// A third collider whose slug is also taken falls back to a numeric suffix.
+	taken["org-c-api"] = true
+	if got := UniqueFleetName("org-c/api", taken); got != "api-2" {
+		t.Fatalf("third api collider = %q, want %q", got, "api-2")
+	}
+	// An unrelated basename is untouched.
+	if got := UniqueFleetName("org-a/worker", taken); got != "worker" {
+		t.Fatalf("org-a/worker = %q, want %q", got, "worker")
+	}
+}
+
+// FleetProjectsFromConfigs must produce one project per config, each with a
+// unique Name even when two configs share a repo basename.
+func TestFleetProjectsFromConfigsUniqueNames(t *testing.T) {
+	cfgs := []*config.Config{
+		{Repo: "org-a/api"},
+		{Repo: "org-b/api"},
+		{Repo: "org-a/worker"},
+	}
+	projects := FleetProjectsFromConfigs(cfgs)
+	if len(projects) != 3 {
+		t.Fatalf("projects = %d, want 3", len(projects))
+	}
+	seen := map[string]bool{}
+	for _, p := range projects {
+		if p.Name == "" {
+			t.Fatalf("project for repo %q has empty name", p.Cfg().Repo)
+		}
+		if seen[p.Name] {
+			t.Fatalf("duplicate fleet name %q", p.Name)
+		}
+		seen[p.Name] = true
+	}
+}

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -4590,3 +4590,51 @@ func TestFleetAPIClearsStaleBackendCooldown(t *testing.T) {
 		t.Fatalf("codex cooldown should be cleared after RetryAfter elapses, got %+v", got)
 	}
 }
+
+func TestLoadFleetProjectsAutoDisambiguatesSameBasename(t *testing.T) {
+	// #764: two distinct repos that share a basename and have NO explicit name
+	// must auto-disambiguate (api, org-b-api) instead of hard-erroring on a
+	// duplicate fleet project name — consistent with `maestro daemon`.
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.yaml")
+	bPath := filepath.Join(dir, "b.yaml")
+	if err := os.WriteFile(aPath, []byte("repo: org-a/api\nstate_dir: "+filepath.Join(dir, "a")+"\nsession_prefix: api\n"), 0o644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := os.WriteFile(bPath, []byte("repo: org-b/api\nstate_dir: "+filepath.Join(dir, "b")+"\nsession_prefix: api\n"), 0o644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	fleetPath := filepath.Join(dir, "fleet.yaml")
+	if err := os.WriteFile(fleetPath, []byte("projects:\n  - config: a.yaml\n  - config: b.yaml\n"), 0o644); err != nil {
+		t.Fatalf("write fleet: %v", err)
+	}
+
+	projects, err := LoadFleetProjects(fleetPath)
+	if err != nil {
+		t.Fatalf("LoadFleetProjects failed (want auto-disambiguation, not error): %v", err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("projects len = %d, want 2", len(projects))
+	}
+	names := map[string]bool{projects[0].Name: true, projects[1].Name: true}
+	if !names["api"] || !names["org-b-api"] {
+		t.Fatalf("names = %v, want {api, org-b-api}", names)
+	}
+}
+
+func TestLoadFleetProjectsRejectsExplicitDuplicateName(t *testing.T) {
+	// An explicit duplicate name in the fleet file is operator error and must
+	// still be rejected (only derived names auto-disambiguate, #764).
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "p.yaml")
+	if err := os.WriteFile(cfgPath, []byte("repo: owner/project\nstate_dir: "+filepath.Join(dir, "s")+"\nsession_prefix: prj\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	fleetPath := filepath.Join(dir, "fleet.yaml")
+	if err := os.WriteFile(fleetPath, []byte("projects:\n  - name: Dup\n    config: p.yaml\n  - name: Dup\n    config: p.yaml\n"), 0o644); err != nil {
+		t.Fatalf("write fleet: %v", err)
+	}
+	if _, err := LoadFleetProjects(fleetPath); err == nil {
+		t.Fatal("LoadFleetProjects: want error on explicit duplicate name, got nil")
+	}
+}

--- a/internal/supervisor/watchdog.go
+++ b/internal/supervisor/watchdog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/befeast/maestro/internal/state"
@@ -19,10 +20,17 @@ import (
 // restart.
 //
 // One Watchdog runs per supervise loop: the single-project `maestro supervise`
-// CLI starts one, and `maestro daemon` starts one per project flow (#756).
-func Watchdog(ctx context.Context, stateDir string, interval time.Duration) {
+// CLI starts one, and `maestro daemon` starts one per project flow (#756). The
+// name (project / session prefix) is woven into every log line so that, with N
+// flows in one daemon, an operator can tell whose LastRunOnceAt went stale
+// (#764) instead of reading N identical `[supervise/watchdog]` prefixes.
+func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration) {
 	if interval <= 0 {
 		return
+	}
+	logPrefix := "supervise/watchdog"
+	if name = strings.TrimSpace(name); name != "" {
+		logPrefix = name + " supervise/watchdog"
 	}
 	stuckThreshold := 3 * interval
 	startedAt := time.Now()
@@ -45,23 +53,23 @@ func Watchdog(ctx context.Context, stateDir string, interval time.Duration) {
 
 		st, err := state.Load(stateDir)
 		if err != nil {
-			log.Printf("[supervise/watchdog] could not read state: %v (will retry)", err)
+			log.Printf("[%s] could not read state: %v (will retry)", logPrefix, err)
 			continue
 		}
 		if st.LastRunOnceAt.IsZero() {
 			// Daemon never completed a cycle. Loud warning, but only
 			// after the startup grace.
-			log.Printf("[supervise/watchdog] WARNING: no RunOnce has stamped state.LastRunOnceAt since the daemon started %s ago; check whether RunOnce is wedged",
-				time.Since(startedAt).Round(time.Second))
-			persistSupervisorStuck(stateDir, "no RunOnce has completed since daemon start")
+			log.Printf("[%s] WARNING: no RunOnce has stamped state.LastRunOnceAt since the daemon started %s ago; check whether RunOnce is wedged",
+				logPrefix, time.Since(startedAt).Round(time.Second))
+			persistSupervisorStuck(logPrefix, stateDir, "no RunOnce has completed since daemon start")
 			continue
 		}
 		gap := time.Since(st.LastRunOnceAt)
 		if gap > stuckThreshold {
 			reason := fmt.Sprintf("LastRunOnceAt=%s is %s old (threshold %s)",
 				st.LastRunOnceAt.Format(time.RFC3339), gap.Round(time.Second), stuckThreshold)
-			log.Printf("[supervise/watchdog] WARNING: supervise loop appears stuck — %s", reason)
-			persistSupervisorStuck(stateDir, reason)
+			log.Printf("[%s] WARNING: supervise loop appears stuck — %s", logPrefix, reason)
+			persistSupervisorStuck(logPrefix, stateDir, reason)
 		}
 	}
 }
@@ -69,10 +77,10 @@ func Watchdog(ctx context.Context, stateDir string, interval time.Duration) {
 // persistSupervisorStuck flips SupervisorStuck=true in state.json so the
 // Fleet API surfaces it. Best-effort: a save failure is logged but does
 // not stop the watchdog.
-func persistSupervisorStuck(stateDir, reason string) {
+func persistSupervisorStuck(logPrefix, stateDir, reason string) {
 	st, err := state.Load(stateDir)
 	if err != nil {
-		log.Printf("[supervise/watchdog] persist: load state: %v", err)
+		log.Printf("[%s] persist: load state: %v", logPrefix, err)
 		return
 	}
 	if st.SupervisorStuck && st.SupervisorStuckReason == reason {
@@ -81,6 +89,6 @@ func persistSupervisorStuck(stateDir, reason string) {
 	st.SupervisorStuck = true
 	st.SupervisorStuckReason = reason
 	if err := state.Save(stateDir, st); err != nil {
-		log.Printf("[supervise/watchdog] persist: save state: %v", err)
+		log.Printf("[%s] persist: save state: %v", logPrefix, err)
 	}
 }


### PR DESCRIPTION
Implements #764

Hardens the Phase 1 daemon (#763) by resolving the Greptile/Codex review
findings plus the independent /code-review findings, and adds a repo-root
CLAUDE.md commit convention.

## Changes
- P1 — fleet bind error surfaces immediately: `daemon.Run` races `ctx.Done()`
  against the fleet error channel, so a busy `:8786` aborts startup and reports
  the error instead of running every flow with no web endpoint until SIGTERM.
  The intentional `port 0` (no-bind) path still keeps the flows up.
- P2 — dedup on real flow identity (`StateDir`, falling back to `Repo`), not the
  repo-basename fleet name; `org-a/api` and `org-b/api` now both get a flow.
- P2 (Codex follow-up) — unique fleet display names: a same-basename collision
  is disambiguated (`org-b-api`) so the FleetServer's `findProject` can address
  each project; no more routing the second repo's routes/actions/audit to the
  first.
- P2 — the liveness watchdog joins the flow WaitGroup, so `stopFlow` does not
  return until it has exited; the watchdog log line now carries the project name.
- SupervisorDecision logged per-cycle in the daemon supervise loop.
- P3 — non-positive run/supervise intervals are clamped to the safe defaults
  with a warn (a `0` run-interval panicked `time.NewTicker`; a `0` supervise
  interval silently disabled the loop + watchdog).
- P3 — drop the import-time YAML watcher in the daemon: the config store is the
  source of truth (#754); store-driven reload is Phase 2 (#757).
- Cleanup — shared fleet wiring lifted into `internal/server` and called from
  both `serve` and `daemon`.
- CLAUDE.md documents the commit-message convention (no `Co-authored-by` /
  generated-with trailers; preserve `Maestro-Backend`).

## Testing
- `gofmt` changed Go files
- `go build ./cmd/maestro/`
- `go test ./...` (full suite green; daemon/supervisor/server also run with -race)

Refs #764

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-27m); claude anthropic opus-4.8 xhigh (27m-end, fallover)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the Phase 1 daemon by addressing review findings from #763: it binds the fleet port before starting any flow (so a busy `:8786` aborts startup immediately), switches flow dedup from the fleet display name to the real `StateDir`/`Repo` identity (so `org-a/api` and `org-b/api` both get flows), assigns unique fleet display names to same-basename repos, and joins the liveness watchdog into the flow WaitGroup so `stopFlow` waits for it. It also adds interval clamping, parallel flow cancellation in `stopAll`, and consolidates all fleet-wiring helpers into `internal/server/fleet_build.go`.

- **Bind before flows**: `fleet.Listen()` is called before any `startFlow`, so a port-conflict error returns immediately with no flows to drain. The `Run` select correctly races `ctx.Done()` against a runtime `fleetErr` and drains flows in both branches.
- **Identity-based dedup + unique names**: `flowKey` uses `StateDir` (falling back to `Repo`), and `UniqueFleetName` disambiguates same-basename repos with the owner-slug then a numeric suffix, preventing silent misrouting in `findProject`.
- **Watchdog in WaitGroup + panic propagation**: `recoverFlow` now cancels the whole flow on panic (instead of leaving it half-alive), and the watchdog goroutine is tracked in `wg` so `close(flow.done)` is deferred until every goroutine has exited.

<h3>Confidence Score: 5/5</h3>

All changed paths are well-guarded, well-tested with race-detector coverage, and the concurrency invariants (register-before-goroutines, parallel cancel-then-wait, watchdog in WaitGroup) are correct.

The bind-before-start, dedup, WaitGroup, and panic-cancellation changes are all correctly implemented and each has a dedicated test that would catch a regression. The Run select handles both the ctx.Done() and runtime fleetErr branches without leaking goroutines. No correctness issues were found across the changed files.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/daemon/daemon.go | Core daemon refactor: dedup switched to StateDir/Repo identity, port is bound before flows start, parallel cancellation in stopAll, and the select-based fleet error races are correct. |
| internal/daemon/flow.go | Watchdog goroutine added to flow WaitGroup so stopAll/stopFlow waits for it; flows registered before goroutines to prevent reaper/insert race; recoverFlow now cancels the whole flow on panic. |
| internal/daemon/supervise.go | Watchdog goroutine removed from here (moved to startFlow); supervisor decision logging added per cycle; runSupervise now accepts a unique fleet name for identifiable log lines. |
| internal/server/fleet.go | Start() split into Listen() + Serve() so the bind happens before flows start; auto-disambiguation of same-basename derived names via UniqueFleetName; case-sensitive explicit-name duplicate check. |
| internal/server/fleet_build.go | New shared-wiring file: WireFleetProjectGitHub, NewFleetProjectWithGitHub(Named), FleetProjectsFromConfigs, UniqueFleetName, FleetAuthFromProjects — consolidates what was duplicated across main.go and daemon/flow.go. |
| internal/supervisor/watchdog.go | Watchdog gains a name parameter threaded into every log prefix so multi-flow daemon journals are distinguishable; logic otherwise unchanged. |
| internal/daemon/daemon_test.go | Comprehensive new tests: bind-before-start error surfacing, same-basename dedup correctness, unique fleet name assertion, watchdog WaitGroup drain, interval clamping, and decision logging. |

</details>

<sub>Reviews (2): Last reviewed commit: ["daemon: address #766 review findings (bi..."](https://github.com/befeast/maestro/commit/dc2b697f06c62069100f9aad2b2111f9005d6c59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39366455)</sub>

<!-- /greptile_comment -->