### PR TITLE
Phase 2: DB-driven hot add/remove/reload проектов (WatchStore, diff-loop, config-store CRUD)

### DIFF
--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -26,6 +26,8 @@ func daemonCmd(args []string) {
 	port := fs.Int("port", 8786, "Port to bind the fleet web server")
 	promptPath := fs.String("prompt", "", "Path to worker prompt base file")
 	readOnly := fs.Bool("read-only", false, "Disable mutating fleet HTTP endpoints")
+	watchStore := fs.Bool("watch-store", false, "Hot add/remove/reload projects from the config store without a restart (#757)")
+	watchStoreInterval := fs.Duration("watch-store-interval", daemon.DefaultWatchStoreInterval, "Config-store diff/reload poll interval (with --watch-store)")
 	fs.Parse(args)
 
 	ctx := signalContext()
@@ -37,13 +39,15 @@ func daemonCmd(args []string) {
 	defer store.Close()
 
 	d := daemon.New(store, daemon.Options{
-		Host:              *host,
-		Port:              *port,
-		RunInterval:       *runInterval,
-		SuperviseInterval: *superviseInterval,
-		PromptPath:        *promptPath,
-		Version:           resolveVersion(),
-		ReadOnly:          *readOnly,
+		Host:               *host,
+		Port:               *port,
+		RunInterval:        *runInterval,
+		SuperviseInterval:  *superviseInterval,
+		PromptPath:         *promptPath,
+		Version:            resolveVersion(),
+		ReadOnly:           *readOnly,
+		WatchStore:         *watchStore,
+		WatchStoreInterval: *watchStoreInterval,
 	})
 
 	log.Printf("starting maestro daemon — store=%s addr=%s:%d", *storePath, *host, *port)

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -57,7 +57,7 @@ Commands:
   stop          Stop a worker session
   kill          Kill a worker session by slot name
   import        Seed state from existing worktrees
-  config-store  Migrate YAML runtime config to SQLite or export it back
+  config-store  Manage the SQLite config store (migrate/export/add/rm/edit)
   history       Show recently completed sessions
   digest        Write the morning operator digest across all fleet projects
   cleanup       Remove worktrees for all completed/dead sessions
@@ -498,10 +498,21 @@ func loadConfigsWithStore(paths []string, storePath, project string) []*config.C
 
 func configStoreCmd(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: maestro config-store migrate --db <path> --dir <maestro.d> | export --db <path> --dir <out>")
+		fmt.Fprintln(os.Stderr, "usage: maestro config-store <migrate|export|add|rm|edit> ...")
+		fmt.Fprintln(os.Stderr, "  migrate --db <path> --dir <maestro.d>   import a directory of YAML configs")
+		fmt.Fprintln(os.Stderr, "  export  --db <path> --dir <out>         export every project to YAML")
+		fmt.Fprintln(os.Stderr, "  add     --file <yaml> [--name <name>]   add/replace a single project")
+		fmt.Fprintln(os.Stderr, "  rm      <name>                          remove a project")
+		fmt.Fprintln(os.Stderr, "  edit    <name>                          export → $EDITOR → re-import")
 		os.Exit(1)
 	}
 	switch args[0] {
+	case "add":
+		configStoreAdd(args[1:])
+	case "rm":
+		configStoreRm(args[1:])
+	case "edit":
+		configStoreEdit(args[1:])
 	case "migrate":
 		fs := flag.NewFlagSet("config-store migrate", flag.ExitOnError)
 		dbPath := fs.String("db", filepath.Join(os.Getenv("HOME"), ".maestro", "config.db"), "SQLite config store path")
@@ -534,6 +545,166 @@ func configStoreCmd(args []string) {
 		fmt.Fprintf(os.Stderr, "unknown config-store command: %s\n", args[0])
 		os.Exit(1)
 	}
+}
+
+// configStoreDBFlag registers the shared --db flag (default ~/.maestro/config.db)
+// used by the per-project CRUD subcommands so they target the same store the
+// daemon reads.
+func configStoreDBFlag(fs *flag.FlagSet) *string {
+	return fs.String("db", filepath.Join(os.Getenv("HOME"), ".maestro", "config.db"), "SQLite config store path")
+}
+
+// configStoreAdd implements `config-store add --file <yaml> [--name <name>]`:
+// it adds (or replaces) a single project row from a YAML file. The config is
+// validated by UpsertProject (config.Parse), so a malformed file is rejected
+// before it lands. With `maestro daemon --watch-store` running, the new project
+// appears in the fleet without a unit restart (#757).
+func configStoreAdd(args []string) {
+	fs := flag.NewFlagSet("config-store add", flag.ExitOnError)
+	dbPath := configStoreDBFlag(fs)
+	file := fs.String("file", "", "Path to the project YAML to add")
+	name := fs.String("name", "", "Project name (default: derived from repo, else filename)")
+	fs.Parse(args)
+
+	if strings.TrimSpace(*file) == "" {
+		log.Fatalf("config-store add: --file is required")
+	}
+	data, err := os.ReadFile(*file)
+	if err != nil {
+		log.Fatalf("config-store add: read %s: %v", *file, err)
+	}
+	projectName := strings.TrimSpace(*name)
+	if projectName == "" {
+		projectName, err = configstore.ProjectNameFor(*file, data)
+		if err != nil {
+			log.Fatalf("config-store add: %v", err)
+		}
+	}
+	store, err := configstore.Open(*dbPath)
+	if err != nil {
+		log.Fatalf("config-store add: open db: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertProject(context.Background(), projectName, string(data)); err != nil {
+		log.Fatalf("config-store add: %v", err)
+	}
+	fmt.Printf("Added project %q to config store %s.\n", projectName, *dbPath)
+}
+
+// configStoreRm implements `config-store rm <name>`: it removes a project row.
+// Deletion is idempotent (removing a missing project is not an error). With
+// `maestro daemon --watch-store` running, the flow is drained and the project
+// leaves the fleet after its workers finish (#757).
+func configStoreRm(args []string) {
+	fs := flag.NewFlagSet("config-store rm", flag.ExitOnError)
+	dbPath := configStoreDBFlag(fs)
+	fs.Parse(args)
+
+	rest := fs.Args()
+	if len(rest) != 1 || strings.TrimSpace(rest[0]) == "" {
+		log.Fatalf("config-store rm: exactly one project name is required")
+	}
+	name := strings.TrimSpace(rest[0])
+	store, err := configstore.Open(*dbPath)
+	if err != nil {
+		log.Fatalf("config-store rm: open db: %v", err)
+	}
+	defer store.Close()
+	if err := store.DeleteProject(context.Background(), name); err != nil {
+		log.Fatalf("config-store rm: %v", err)
+	}
+	fmt.Printf("Removed project %q from config store %s.\n", name, *dbPath)
+}
+
+// configStoreEdit implements `config-store edit <name>`: export the project to a
+// temp file, open it in $EDITOR, and re-import the saved result with validation.
+// A parse failure on save aborts without touching the stored row, so a bad edit
+// can never break a running flow (#757).
+func configStoreEdit(args []string) {
+	fs := flag.NewFlagSet("config-store edit", flag.ExitOnError)
+	dbPath := configStoreDBFlag(fs)
+	fs.Parse(args)
+
+	rest := fs.Args()
+	if len(rest) != 1 || strings.TrimSpace(rest[0]) == "" {
+		log.Fatalf("config-store edit: exactly one project name is required")
+	}
+	name := strings.TrimSpace(rest[0])
+	store, err := configstore.Open(*dbPath)
+	if err != nil {
+		log.Fatalf("config-store edit: open db: %v", err)
+	}
+	defer store.Close()
+	if err := editStoreProject(store, name); err != nil {
+		log.Fatalf("config-store edit: %v", err)
+	}
+}
+
+// editStoreProject round-trips a project through the operator's $EDITOR. It is
+// split out so the export/launch/re-import flow is testable apart from the CLI's
+// flag wiring.
+func editStoreProject(store *configstore.Store, name string) error {
+	ctx := context.Background()
+	original, err := store.ExportProject(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp("", "maestro-edit-"+name+"-*.yaml")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(original); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if err := launchEditor(tmpPath); err != nil {
+		return err
+	}
+
+	edited, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return fmt.Errorf("read edited file: %w", err)
+	}
+	if string(edited) == string(original) {
+		fmt.Printf("No changes to project %q; left unchanged.\n", name)
+		return nil
+	}
+	// UpsertProject validates via config.Parse, so an invalid edit is rejected
+	// here and the stored row is untouched.
+	if err := store.UpsertProject(ctx, name, string(edited)); err != nil {
+		return err
+	}
+	fmt.Printf("Updated project %q.\n", name)
+	return nil
+}
+
+// launchEditor opens path in the operator's editor ($EDITOR, then $VISUAL,
+// defaulting to vi), wired to the terminal. The editor command may include
+// arguments (e.g. `code --wait`), so it is split on whitespace.
+func launchEditor(path string) error {
+	editor := strings.TrimSpace(os.Getenv("EDITOR"))
+	if editor == "" {
+		editor = strings.TrimSpace(os.Getenv("VISUAL"))
+	}
+	if editor == "" {
+		editor = "vi"
+	}
+	parts := strings.Fields(editor)
+	cmd := exec.Command(parts[0], append(parts[1:], path)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("editor %q exited with error: %w", editor, err)
+	}
+	return nil
 }
 
 func runCmd(args []string) {

--- a/cmd/maestro/main_config_store_test.go
+++ b/cmd/maestro/main_config_store_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/befeast/maestro/internal/configstore"
+)
+
+const editTestYAML = `repo: owner/svc
+max_parallel: 2
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      prompt_mode: stdin
+`
+
+// writeFakeEditor writes an executable shell script that mutates the file it is
+// given, and points $EDITOR at it, so editStoreProject can be exercised without
+// a real interactive editor.
+func writeFakeEditor(t *testing.T, script string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-editor.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatalf("write fake editor: %v", err)
+	}
+	t.Setenv("EDITOR", path)
+	t.Setenv("VISUAL", "")
+}
+
+func openEditTestStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store, err := configstore.Open(filepath.Join(t.TempDir(), "config.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.UpsertProject(context.Background(), "svc", editTestYAML); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return store
+}
+
+func TestEditStoreProjectAppliesEdit(t *testing.T) {
+	store := openEditTestStore(t)
+	writeFakeEditor(t, `sed -i 's/max_parallel: 2/max_parallel: 42/' "$1"`)
+
+	if err := editStoreProject(store, "svc"); err != nil {
+		t.Fatalf("editStoreProject: %v", err)
+	}
+	cfg, err := store.Load(context.Background(), "svc")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.MaxParallel != 42 {
+		t.Fatalf("MaxParallel = %d, want 42 after edit", cfg.MaxParallel)
+	}
+}
+
+func TestEditStoreProjectNoChangeKeepsConfig(t *testing.T) {
+	store := openEditTestStore(t)
+	writeFakeEditor(t, `true`) // touch nothing
+
+	if err := editStoreProject(store, "svc"); err != nil {
+		t.Fatalf("editStoreProject: %v", err)
+	}
+	cfg, err := store.Load(context.Background(), "svc")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.MaxParallel != 2 {
+		t.Fatalf("MaxParallel = %d, want 2 (unchanged)", cfg.MaxParallel)
+	}
+}
+
+func TestEditStoreProjectInvalidEditRejected(t *testing.T) {
+	store := openEditTestStore(t)
+	writeFakeEditor(t, `printf '%s' '::: not yaml :::' > "$1"`)
+
+	if err := editStoreProject(store, "svc"); err == nil {
+		t.Fatal("editStoreProject with invalid YAML: want error, got nil")
+	}
+	// The stored row must be untouched by a rejected edit.
+	cfg, err := store.Load(context.Background(), "svc")
+	if err != nil {
+		t.Fatalf("Load after rejected edit: %v", err)
+	}
+	if cfg.MaxParallel != 2 {
+		t.Fatalf("MaxParallel = %d, want 2 (edit must not land)", cfg.MaxParallel)
+	}
+}

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -259,6 +259,34 @@ ON CONFLICT(name) DO UPDATE SET config_yaml = excluded.config_yaml, updated_at =
 	return tx.Commit()
 }
 
+// ProjectNameFor derives the canonical project name for a config document the
+// same way ImportDir does: the sanitised `repo` field when present, else the
+// source file's basename. Exposed so `config-store add --file` names a single
+// file identically to a bulk `config-store migrate` (#757).
+func ProjectNameFor(sourcePath string, data []byte) (string, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return "", err
+	}
+	name := projectNameFromPath(sourcePath)
+	if repo := scalarAt(&root, "repo"); repo != "" {
+		name = safeProjectName(repo)
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", fmt.Errorf("cannot derive a project name from %q (set repo or pass --name)", sourcePath)
+	}
+	return name, nil
+}
+
+// ExportProject returns one project's portable YAML — the stored project
+// document with its shared backend definitions re-attached, identical to a
+// single file written by ExportDir. Exposed for `config-store edit`, which
+// round-trips a project through $EDITOR (#757).
+func (s *Store) ExportProject(ctx context.Context, name string) ([]byte, error) {
+	data, _, err := s.exportProjectYAML(ctx, name)
+	return data, err
+}
+
 // DeleteProject removes a project row. Deleting a missing project is a no-op
 // (no error), matching idempotent delete semantics. Shared backend rows are
 // left intact: they may still be referenced by other projects.

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -44,10 +44,27 @@ type Store struct {
 }
 
 func Open(path string) (*Store, error) {
-	db, err := sql.Open("sqlite", path)
+	// busy_timeout makes a connection wait (up to 5s) for a lock instead of
+	// erroring with "database is locked" immediately: the daemon's watch-loop
+	// reads config.db (ProjectsFingerprint every tick, Load on add) while
+	// `config-store add/rm/edit` writes it from a SEPARATE process (#757). WAL
+	// lets a reader and a writer proceed concurrently across processes. The
+	// pragmas go in the DSN so modernc applies them to every pooled connection.
+	dsn := path
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	dsn += sep + "_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}
+	// Serialize in-process access through a single connection — modernc/sqlite
+	// can still report SQLITE_BUSY between two pooled connections of the same
+	// process; one connection plus busy_timeout removes that contention while
+	// WAL handles the cross-process case.
+	db.SetMaxOpenConns(1)
 	s := &Store{db: db}
 	if err := s.Init(context.Background()); err != nil {
 		db.Close()
@@ -171,7 +188,7 @@ func importProject(ctx context.Context, tx *sql.Tx, sourcePath string, data []by
 		projectName = safeProjectName(repo)
 	}
 	backends := detachBackends(&root)
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339Nano) // nano, not seconds: see ProjectsFingerprint (#757)
 	if err := upsertSharedBackendsTx(ctx, tx, backends, now); err != nil {
 		return err
 	}
@@ -241,7 +258,7 @@ func (s *Store) UpsertProject(ctx context.Context, name, configYAML string) erro
 	defer tx.Rollback()
 
 	backends := detachBackends(&root)
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339Nano) // nano, not seconds: see ProjectsFingerprint (#757)
 	if err := upsertSharedBackendsTx(ctx, tx, backends, now); err != nil {
 		return err
 	}
@@ -311,7 +328,7 @@ func (s *Store) UpsertBackend(ctx context.Context, name, definitionYAML string) 
 	if err := yaml.Unmarshal([]byte(definitionYAML), &probe); err != nil {
 		return fmt.Errorf("parse backend %q: %w", name, err)
 	}
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339Nano) // nano, not seconds: see ProjectsFingerprint (#757)
 	_, err := s.db.ExecContext(ctx, `
 INSERT INTO backends(name, definition_yaml, updated_at)
 VALUES(?, ?, ?)
@@ -330,7 +347,7 @@ func (s *Store) SetGlobal(ctx context.Context, key, valueYAML string) error {
 	if err := yaml.Unmarshal([]byte(valueYAML), &probe); err != nil {
 		return fmt.Errorf("parse global %q: %w", key, err)
 	}
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339Nano) // nano, not seconds: see ProjectsFingerprint (#757)
 	_, err := s.db.ExecContext(ctx, `
 INSERT INTO global(key, value_yaml, updated_at)
 VALUES(?, ?, ?)
@@ -340,8 +357,13 @@ ON CONFLICT(key) DO UPDATE SET value_yaml = excluded.value_yaml, updated_at = ex
 }
 
 // ProjectsFingerprint returns each project's name mapped to its updated_at
-// timestamp. Callers use it to detect which projects changed since a prior
-// snapshot without loading every config.
+// timestamp. Callers (the daemon diff-loop and configwatch.WatchStore) use it
+// to detect which projects changed since a prior snapshot without loading every
+// config. updated_at is written at RFC3339Nano precision so two writes in the
+// same second do not compare equal — otherwise a config-store edit immediately
+// after add/migrate would never advance the fingerprint and a --watch-store
+// daemon would never hot-reload that project (#757). Parsing with RFC3339Nano
+// also accepts older seconds-precision rows.
 func (s *Store) ProjectsFingerprint(ctx context.Context) (map[string]time.Time, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT name, updated_at FROM project`)
 	if err != nil {
@@ -354,7 +376,7 @@ func (s *Store) ProjectsFingerprint(ctx context.Context) (map[string]time.Time, 
 		if err := rows.Scan(&name, &updatedAt); err != nil {
 			return nil, err
 		}
-		ts, err := time.Parse(time.RFC3339, updatedAt)
+		ts, err := time.Parse(time.RFC3339Nano, updatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("parse updated_at for project %q: %w", name, err)
 		}

--- a/internal/configstore/store_crud_test.go
+++ b/internal/configstore/store_crud_test.go
@@ -1,0 +1,76 @@
+package configstore
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestProjectNameFor(t *testing.T) {
+	// The repo field wins and is sanitised the way ImportDir names projects.
+	name, err := ProjectNameFor("/tmp/whatever.yaml", []byte("repo: BeFeast/maestro\n"))
+	if err != nil {
+		t.Fatalf("ProjectNameFor(repo): %v", err)
+	}
+	if name != "befeast-maestro" {
+		t.Fatalf("name = %q, want befeast-maestro", name)
+	}
+
+	// No repo: fall back to the file basename.
+	name, err = ProjectNameFor("/tmp/My_Project.yml", []byte("max_parallel: 2\n"))
+	if err != nil {
+		t.Fatalf("ProjectNameFor(basename): %v", err)
+	}
+	if name != "my-project" {
+		t.Fatalf("name = %q, want my-project", name)
+	}
+
+	if _, err := ProjectNameFor("x.yaml", []byte("::: not yaml :::\n")); err == nil {
+		t.Fatal("ProjectNameFor on invalid YAML: want error, got nil")
+	}
+}
+
+func TestExportProjectRoundTripThroughEdit(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	const yaml = `repo: owner/svc
+max_parallel: 2
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      prompt_mode: stdin
+`
+	if err := store.UpsertProject(ctx, "svc", yaml); err != nil {
+		t.Fatalf("UpsertProject: %v", err)
+	}
+
+	// ExportProject re-attaches the shared backend so an editor sees a complete,
+	// re-importable document.
+	out, err := store.ExportProject(ctx, "svc")
+	if err != nil {
+		t.Fatalf("ExportProject: %v", err)
+	}
+	if !strings.Contains(string(out), "backends:") || !strings.Contains(string(out), "codex") {
+		t.Fatalf("exported YAML missing re-attached backend:\n%s", out)
+	}
+
+	// Simulate an edit (bump max_parallel) and re-import — the change persists.
+	edited := strings.Replace(string(out), "max_parallel: 2", "max_parallel: 9", 1)
+	if err := store.UpsertProject(ctx, "svc", edited); err != nil {
+		t.Fatalf("re-import edited project: %v", err)
+	}
+	cfg, err := store.Load(ctx, "svc")
+	if err != nil {
+		t.Fatalf("Load after edit: %v", err)
+	}
+	if cfg.MaxParallel != 9 {
+		t.Fatalf("MaxParallel = %d, want 9 after edit round-trip", cfg.MaxParallel)
+	}
+
+	if _, err := store.ExportProject(ctx, "missing"); err == nil {
+		t.Fatal("ExportProject of a missing project: want error, got nil")
+	}
+}

--- a/internal/configstore/store_crud_test.go
+++ b/internal/configstore/store_crud_test.go
@@ -74,3 +74,42 @@ model:
 		t.Fatal("ExportProject of a missing project: want error, got nil")
 	}
 }
+
+// #757: two writes in the same wall-clock second must produce DIFFERENT
+// fingerprints — otherwise a config-store edit immediately after add/migrate
+// would never advance updated_at and a --watch-store daemon would never
+// hot-reload. Guards against a regression to seconds-precision (RFC3339).
+func TestUpsertProjectFingerprintAdvancesWithinSameSecond(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	const y1 = `repo: owner/svc
+max_parallel: 2
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      prompt_mode: stdin
+`
+	if err := store.UpsertProject(ctx, "svc", y1); err != nil {
+		t.Fatalf("UpsertProject 1: %v", err)
+	}
+	fp1, err := store.ProjectsFingerprint(ctx)
+	if err != nil {
+		t.Fatalf("fingerprint 1: %v", err)
+	}
+
+	y2 := strings.Replace(y1, "max_parallel: 2", "max_parallel: 3", 1)
+	if err := store.UpsertProject(ctx, "svc", y2); err != nil {
+		t.Fatalf("UpsertProject 2: %v", err)
+	}
+	fp2, err := store.ProjectsFingerprint(ctx)
+	if err != nil {
+		t.Fatalf("fingerprint 2: %v", err)
+	}
+
+	if !fp2["svc"].After(fp1["svc"]) {
+		t.Fatalf("fingerprint did not advance within the same second: %v not After %v — seconds-precision updated_at regression", fp2["svc"], fp1["svc"])
+	}
+}

--- a/internal/configwatch/watcher.go
+++ b/internal/configwatch/watcher.go
@@ -60,6 +60,86 @@ func Watch(ctx context.Context, path string, pollInterval time.Duration) <-chan 
 	return ch
 }
 
+// ProjectStore is the subset of *configstore.Store that WatchStore polls: a
+// single project's config and the fleet-wide fingerprint (name → updated_at)
+// used to detect when that project changed. It is declared here — not imported
+// from configstore — so configwatch stays free of a store dependency and the
+// daemon can reuse the same interface for its diff-loop (#757).
+type ProjectStore interface {
+	Load(ctx context.Context, name string) (*config.Config, error)
+	ProjectsFingerprint(ctx context.Context) (map[string]time.Time, error)
+}
+
+// WatchStore polls the config store for the project named name and sends a
+// newly loaded *config.Config on the returned channel whenever that project's
+// updated_at advances. It is the DB-backed sibling of Watch (#757): the daemon
+// wires it into each flow's orchestrator via SetConfigReloadCh, so an operator
+// editing a project row in the store hot-reloads the running flow without a
+// restart.
+//
+// Semantics mirror Watch: a load/fingerprint error is logged and skipped (the
+// caller keeps the last good config), and a project that has disappeared from
+// the store emits nothing — the daemon's diff-loop owns add/remove, so WatchStore
+// must not push a stale config or close on removal. The channel is buffered with
+// depth 1 and drops a new config if the consumer has not drained the previous
+// one, matching Watch. The goroutine exits and closes the channel on ctx.Done.
+func WatchStore(ctx context.Context, store ProjectStore, name string, pollInterval time.Duration) <-chan *config.Config {
+	ch := make(chan *config.Config, 1)
+	go func() {
+		defer close(ch)
+
+		// Seed last with the project's current timestamp so an unchanged project
+		// never triggers a spurious reload on the first tick. A project missing at
+		// seed time leaves last zero; once it appears its timestamp is After(zero)
+		// and the first real config is emitted.
+		last, _ := storeProjectUpdatedAt(ctx, store, name)
+
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+
+		log.Printf("[configwatch] watching store project %q (poll every %s)", name, pollInterval)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				ts, ok := storeProjectUpdatedAt(ctx, store, name)
+				if !ok || !ts.After(last) {
+					// Missing (the diff-loop will stop the flow), fingerprint
+					// errored, or unchanged — nothing to reload.
+					continue
+				}
+				cfg, err := store.Load(ctx, name)
+				if err != nil {
+					log.Printf("[configwatch] store reload of %q failed (keeping previous config): %v", name, err)
+					continue
+				}
+				last = ts
+				select {
+				case ch <- cfg:
+				default:
+					// Drop if consumer hasn't drained yet
+				}
+			}
+		}
+	}()
+	return ch
+}
+
+// storeProjectUpdatedAt returns project name's updated_at and whether it is
+// present in the store. A fingerprint error is logged and reported as absent so
+// the watcher treats it as "no change this tick" rather than reloading.
+func storeProjectUpdatedAt(ctx context.Context, store ProjectStore, name string) (time.Time, bool) {
+	fp, err := store.ProjectsFingerprint(ctx)
+	if err != nil {
+		log.Printf("[configwatch] fingerprint store for project %q failed: %v", name, err)
+		return time.Time{}, false
+	}
+	ts, ok := fp[name]
+	return ts, ok
+}
+
 func watchedConfigPaths(path string, cfg *config.Config) []string {
 	paths := []string{path}
 	paths = append(paths, config.SupervisorPolicyCandidatePaths(path, cfg)...)

--- a/internal/configwatch/watcher_store_test.go
+++ b/internal/configwatch/watcher_store_test.go
@@ -1,0 +1,199 @@
+package configwatch
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// fakeStore is an in-memory ProjectStore so WatchStore can be exercised without
+// a real SQLite config store. updated_at is bumped by Set, mirroring how the
+// real store advances a project's timestamp on UpsertProject.
+type fakeStore struct {
+	mu      sync.Mutex
+	cfgs    map[string]*config.Config
+	stamps  map[string]time.Time
+	loadErr error
+	fpErr   error
+	clock   time.Time
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		cfgs:   map[string]*config.Config{},
+		stamps: map[string]time.Time{},
+		clock:  time.Unix(1_700_000_000, 0).UTC(),
+	}
+}
+
+func (f *fakeStore) Set(name string, cfg *config.Config) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clock = f.clock.Add(time.Second)
+	f.cfgs[name] = cfg
+	f.stamps[name] = f.clock
+}
+
+func (f *fakeStore) Delete(name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.cfgs, name)
+	delete(f.stamps, name)
+}
+
+func (f *fakeStore) setLoadErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.loadErr = err
+}
+
+func (f *fakeStore) Load(ctx context.Context, name string) (*config.Config, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.loadErr != nil {
+		return nil, f.loadErr
+	}
+	cfg, ok := f.cfgs[name]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return cfg, nil
+}
+
+func (f *fakeStore) ProjectsFingerprint(ctx context.Context) (map[string]time.Time, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.fpErr != nil {
+		return nil, f.fpErr
+	}
+	out := make(map[string]time.Time, len(f.stamps))
+	for k, v := range f.stamps {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func TestWatchStore_DetectsConfigChange(t *testing.T) {
+	store := newFakeStore()
+	store.Set("alpha", &config.Config{Repo: "owner/alpha", MaxParallel: 3})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := WatchStore(ctx, store, "alpha", 50*time.Millisecond)
+
+	// Seeded with the current timestamp: no spurious reload before a change.
+	select {
+	case cfg := <-ch:
+		t.Fatalf("unexpected reload before any change: %+v", cfg)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Bump updated_at by writing a new config.
+	store.Set("alpha", &config.Config{Repo: "owner/alpha", MaxParallel: 10})
+
+	select {
+	case cfg := <-ch:
+		if cfg.MaxParallel != 10 {
+			t.Fatalf("MaxParallel = %d, want 10", cfg.MaxParallel)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for store reload")
+	}
+}
+
+func TestWatchStore_NoChangeNoEvent(t *testing.T) {
+	store := newFakeStore()
+	store.Set("alpha", &config.Config{Repo: "owner/alpha"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := WatchStore(ctx, store, "alpha", 50*time.Millisecond)
+
+	select {
+	case cfg := <-ch:
+		t.Fatalf("should not reload an unchanged project, got %+v", cfg)
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+func TestWatchStore_MissingProjectNoEvent(t *testing.T) {
+	// A project absent from the store must not emit — the daemon diff-loop owns
+	// removal; WatchStore staying quiet keeps the running flow on its last good
+	// config until the diff-loop drains it.
+	store := newFakeStore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := WatchStore(ctx, store, "ghost", 50*time.Millisecond)
+
+	select {
+	case cfg := <-ch:
+		t.Fatalf("should not reload a missing project, got %+v", cfg)
+	case <-time.After(400 * time.Millisecond):
+	}
+}
+
+func TestWatchStore_LoadErrorKeepsPrevious(t *testing.T) {
+	store := newFakeStore()
+	store.Set("alpha", &config.Config{Repo: "owner/alpha", MaxParallel: 1})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := WatchStore(ctx, store, "alpha", 50*time.Millisecond)
+
+	// A change lands, but Load fails — no config is emitted and last is NOT
+	// advanced, so a later successful change still reloads.
+	store.setLoadErr(errors.New("boom"))
+	store.Set("alpha", &config.Config{Repo: "owner/alpha", MaxParallel: 7})
+
+	select {
+	case cfg := <-ch:
+		t.Fatalf("should not emit while Load errors, got %+v", cfg)
+	case <-time.After(400 * time.Millisecond):
+	}
+
+	store.setLoadErr(nil)
+	store.Set("alpha", &config.Config{Repo: "owner/alpha", MaxParallel: 9})
+	select {
+	case cfg := <-ch:
+		if cfg.MaxParallel != 9 {
+			t.Fatalf("MaxParallel = %d, want 9", cfg.MaxParallel)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reload after Load recovered")
+	}
+}
+
+func TestWatchStore_ContextCancelClosesChannel(t *testing.T) {
+	store := newFakeStore()
+	store.Set("alpha", &config.Config{Repo: "owner/alpha"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := WatchStore(ctx, store, "alpha", 50*time.Millisecond)
+	cancel()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			// Drained a buffered value first; the next read must be the close.
+			select {
+			case _, ok := <-ch:
+				if ok {
+					t.Fatal("channel should be closed after context cancel")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("channel not closed after context cancel")
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("channel not closed after context cancel")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -16,11 +16,13 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/configwatch"
 	"github.com/befeast/maestro/internal/server"
 	"github.com/befeast/maestro/internal/supervisor"
 )
@@ -31,6 +33,11 @@ import (
 const (
 	DefaultRunInterval       = 10 * time.Minute
 	DefaultSuperviseInterval = 5 * time.Minute
+	// DefaultWatchStoreInterval is the cadence of the store diff-loop and each
+	// flow's reload watcher when --watch-store is enabled (#757). Short enough
+	// that operator CRUD (config-store add/rm/edit) is reflected quickly, long
+	// enough that polling SQLite is negligible.
+	DefaultWatchStoreInterval = 15 * time.Second
 )
 
 // ConfigLoader yields the set of project configs the daemon supervises. It is
@@ -60,12 +67,30 @@ type Options struct {
 	Version string
 	// ReadOnly disables the fleet's mutating HTTP endpoints.
 	ReadOnly bool
+
+	// WatchStore enables DB-driven hot add/remove/reload of projects (#757):
+	// a diff-loop over the store's ProjectsFingerprint starts a flow for a new
+	// project name and drains one for a removed name, and each flow's
+	// orchestrator hot-reloads when its project row's config changes. It
+	// requires the store to satisfy configwatch.ProjectStore (the real
+	// *configstore.Store does); a store that does not is a no-op with a warn.
+	WatchStore bool
+	// WatchStoreInterval is the diff-loop / reload poll cadence; clamped to
+	// DefaultWatchStoreInterval when non-positive.
+	WatchStoreInterval time.Duration
 }
 
 // Daemon owns the running project flows and the shared FleetServer.
 type Daemon struct {
 	store ConfigLoader
 	opts  Options
+
+	// projectStore is store viewed as a configwatch.ProjectStore — non-nil only
+	// when the store supports per-project Load + ProjectsFingerprint, which the
+	// store diff-loop and per-flow reload watchers need (#757). The in-memory
+	// test ConfigLoader does not satisfy it, so the watch path is simply inert
+	// for those tests.
+	projectStore configwatch.ProjectStore
 
 	mu    sync.Mutex
 	fleet *server.FleetServer
@@ -74,8 +99,9 @@ type Daemon struct {
 	// runLoop, superviseLoop, and watchdogLoop build the per-project loops.
 	// They default to the production orchestrator + supervisor wiring; tests
 	// override them to drive flows (and assert WaitGroup tracking) without
-	// reaching GitHub.
-	runLoop       func(ctx context.Context, cfg *config.Config, opts Options)
+	// reaching GitHub. runLoop receives the flow's hot-reload channel (#757),
+	// nil when store-watch is disabled.
+	runLoop       func(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config)
 	superviseLoop func(ctx context.Context, name string, cfg *config.Config, opts Options)
 	watchdogLoop  func(ctx context.Context, name, stateDir string, interval time.Duration)
 }
@@ -97,10 +123,24 @@ func New(store ConfigLoader, opts Options) *Daemon {
 		log.Printf("[daemon] supervise-interval %s is not positive; clamping to default %s", opts.SuperviseInterval, DefaultSuperviseInterval)
 		opts.SuperviseInterval = DefaultSuperviseInterval
 	}
+	if opts.WatchStore && opts.WatchStoreInterval <= 0 {
+		log.Printf("[daemon] watch-store-interval %s is not positive; clamping to default %s", opts.WatchStoreInterval, DefaultWatchStoreInterval)
+		opts.WatchStoreInterval = DefaultWatchStoreInterval
+	}
 	d := &Daemon{
 		store: store,
 		opts:  opts,
 		flows: make(map[string]*projectFlow),
+	}
+	if opts.WatchStore {
+		// Only the richer store (Load + ProjectsFingerprint) can drive hot
+		// add/remove/reload. Degrade loudly rather than silently if an embedder
+		// flips the flag on a loader that cannot support it.
+		if ps, ok := store.(configwatch.ProjectStore); ok {
+			d.projectStore = ps
+		} else {
+			log.Printf("[daemon] --watch-store requested but the config store does not support per-project reload; disabling hot add/remove/reload")
+		}
 	}
 	d.runLoop = runOrchestrator
 	d.superviseLoop = func(ctx context.Context, name string, cfg *config.Config, opts Options) {
@@ -118,11 +158,11 @@ func New(store ConfigLoader, opts Options) *Daemon {
 // is logged and skipped — one bad project must never abort daemon startup or
 // the other flows (#756).
 func (d *Daemon) Run(ctx context.Context) error {
-	cfgs, err := d.store.LoadAll(ctx)
+	named, err := d.loadNamedConfigs(ctx)
 	if err != nil {
-		return fmt.Errorf("load configs: %w", err)
+		return err
 	}
-	if len(cfgs) == 0 {
+	if len(named) == 0 {
 		return errors.New("config store has no projects")
 	}
 
@@ -147,10 +187,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// handed. Keeping the dedup here — over the shared per-cfg construction
 	// (UniqueFleetName + NewFleetProjectWithGitHubNamed) — documents that
 	// divergence instead of silently forking the shared builder (#764).
-	seen := make(map[string]bool, len(cfgs))
-	usedNames := make(map[string]bool, len(cfgs))
-	projects := make([]server.FleetProject, 0, len(cfgs))
-	for _, cfg := range cfgs {
+	seen := make(map[string]bool, len(named))
+	usedNames := make(map[string]bool, len(named))
+	projects := make([]server.FleetProject, 0, len(named))
+	storeNames := make([]string, 0, len(named))
+	for _, nc := range named {
+		cfg := nc.cfg
 		if cfg == nil {
 			// A nil entry from the loader must not panic Run: flowKey tolerates
 			// nil but the wiring below dereferences cfg. Skip it, mirroring
@@ -166,6 +208,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		seen[key] = true
 		name := server.UniqueFleetName(cfg.Repo, usedNames)
 		projects = append(projects, server.NewFleetProjectWithGitHubNamed(name, cfg))
+		storeNames = append(storeNames, nc.name)
 	}
 
 	// One FleetServer for the whole fleet — replaces the N per-project
@@ -186,7 +229,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 
 	for i := range projects {
-		flow := d.startFlow(ctx, projects[i])
+		flow := d.startFlow(ctx, storeNames[i], projects[i])
 		log.Printf("[daemon] started flow %q (repo=%s state_dir=%s)", flow.name, flow.cfg.Repo, flow.cfg.StateDir)
 	}
 
@@ -196,18 +239,45 @@ func (d *Daemon) Run(ctx context.Context) error {
 	d.fleet = fleet
 	d.mu.Unlock()
 
+	// Store diff-loop (#757): hot add/remove of project flows. It runs under its
+	// own context so it can be stopped on a serve error (where ctx is not yet
+	// cancelled) as well as on ctx.Done. New flows it starts are parented on the
+	// daemon ctx, not the loop's, so stopAll drains them; stopWatch always runs
+	// before stopAll, so the loop has exited and started no flow stopAll misses.
+	var stopWatch func()
+	if d.projectStore != nil {
+		wctx, watchCancel := context.WithCancel(ctx)
+		watchDone := make(chan struct{})
+		go func() {
+			defer close(watchDone)
+			d.watchStoreLoop(wctx, ctx, d.opts.WatchStoreInterval)
+		}()
+		log.Printf("[daemon] store watch enabled — diff-loop poll every %s", d.opts.WatchStoreInterval)
+		stopWatch = func() {
+			watchCancel()
+			<-watchDone
+		}
+	}
+	drainWatch := func() {
+		if stopWatch != nil {
+			stopWatch()
+		}
+	}
+
 	log.Printf("[daemon] serving fleet — projects=%d addr=%s:%d read_only=%v", len(projects), d.opts.Host, d.opts.Port, d.opts.ReadOnly)
 	fleetErr := make(chan error, 1)
 	go func() { fleetErr <- fleet.Serve(ctx, ln) }()
 
 	select {
 	case <-ctx.Done():
+		drainWatch()
 		d.stopAll()
 		return <-fleetErr
 	case err := <-fleetErr:
 		// Serve returned before shutdown — a runtime serve error after a
 		// successful bind (rare; the bind failure itself was already handled by
 		// Listen above). Flows are legitimately running, so drain them.
+		drainWatch()
 		d.stopAll()
 		if err != nil {
 			log.Printf("[daemon] fleet server failed on %s:%d: %v", d.opts.Host, d.opts.Port, err)
@@ -216,6 +286,52 @@ func (d *Daemon) Run(ctx context.Context) error {
 		<-ctx.Done()
 		return nil
 	}
+}
+
+// namedConfig pairs a config-store project name with its loaded config. The
+// name (the store's primary key) is what the diff-loop and per-flow reload
+// watcher key on; it is empty on the LoadAll fallback path, which disables
+// per-flow reload for that flow but leaves it otherwise fully functional.
+type namedConfig struct {
+	name string
+	cfg  *config.Config
+}
+
+// loadNamedConfigs resolves the projects to start. When the store supports
+// per-project reload (projectStore != nil), it loads via ProjectsFingerprint so
+// each config carries its store name for the diff-loop; otherwise it falls back
+// to LoadAll with empty names, preserving the Phase 1 behaviour for plain
+// ConfigLoaders and the in-memory test loader.
+func (d *Daemon) loadNamedConfigs(ctx context.Context) ([]namedConfig, error) {
+	if d.projectStore != nil {
+		fp, err := d.projectStore.ProjectsFingerprint(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("fingerprint config store: %w", err)
+		}
+		names := make([]string, 0, len(fp))
+		for name := range fp {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		out := make([]namedConfig, 0, len(names))
+		for _, name := range names {
+			cfg, err := d.projectStore.Load(ctx, name)
+			if err != nil {
+				return nil, fmt.Errorf("load project %s: %w", name, err)
+			}
+			out = append(out, namedConfig{name: name, cfg: cfg})
+		}
+		return out, nil
+	}
+	cfgs, err := d.store.LoadAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load configs: %w", err)
+	}
+	out := make([]namedConfig, 0, len(cfgs))
+	for _, cfg := range cfgs {
+		out = append(out, namedConfig{cfg: cfg})
+	}
+	return out, nil
 }
 
 // flowKey is a flow's stable identity for dedup and the flows registry. The

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -45,7 +45,7 @@ type loopTracker struct {
 	stopped int64
 }
 
-func (lt *loopTracker) loop(ctx context.Context, cfg *config.Config, opts Options) {
+func (lt *loopTracker) loop(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config) {
 	atomic.AddInt64(&lt.started, 1)
 	<-ctx.Done()
 	atomic.AddInt64(&lt.stopped, 1)
@@ -64,7 +64,7 @@ func (lt *loopTracker) superviseLoop(ctx context.Context, name string, cfg *conf
 // this helper stay isolated from the real supervisor.Watchdog goroutine — a
 // future change to its shutdown path must not silently break these lifecycle
 // tests. Tests that assert watchdog behaviour install their own stub.
-func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config, Options), supervise func(context.Context, string, *config.Config, Options)) *Daemon {
+func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, *config.Config, Options)) *Daemon {
 	d := New(loader, Options{Host: "127.0.0.1", Port: 0})
 	if run != nil {
 		d.runLoop = run
@@ -273,7 +273,7 @@ func TestStartStopFlowDrains(t *testing.T) {
 	d := newTestDaemon(fakeLoader{cfgs: []*config.Config{cfg}}, run.loop, sup.superviseLoop)
 
 	proj := server.NewFleetProjectWithGitHub(cfg)
-	flow := d.startFlow(context.Background(), proj)
+	flow := d.startFlow(context.Background(), "", proj)
 
 	// Both loops should be running.
 	waitFor(t, func() bool { return atomic.LoadInt64(&run.started) == 1 && atomic.LoadInt64(&sup.started) == 1 })
@@ -313,13 +313,13 @@ func TestFlowPanicCancelsFlow(t *testing.T) {
 		<-ctx.Done()
 		atomic.AddInt64(&supStopped, 1)
 	}
-	run := func(ctx context.Context, c *config.Config, o Options) {
+	run := func(ctx context.Context, c *config.Config, o Options, reloadCh <-chan *config.Config) {
 		panic("boom")
 	}
 	d := newTestDaemon(fakeLoader{cfgs: []*config.Config{cfg}}, run, supervise)
 
 	proj := server.NewFleetProjectWithGitHub(cfg)
-	flow := d.startFlow(context.Background(), proj)
+	flow := d.startFlow(context.Background(), "", proj)
 
 	// The panic cancels the flow, so the supervise loop drains and flow.done
 	// closes without anyone calling stopFlow.
@@ -365,13 +365,13 @@ func TestRunSurfacesFleetBindErrorImmediately(t *testing.T) {
 
 	cfg := testConfig(t, "owner/bind")
 	var started int64
-	blockingLoop := func(ctx context.Context, c *config.Config, o Options) {
+	blockingLoop := func(ctx context.Context, c *config.Config, o Options, reloadCh <-chan *config.Config) {
 		atomic.AddInt64(&started, 1)
 		select {} // never returns — models a flow stuck in a non-cancellable cycle
 	}
 	d := New(fakeLoader{cfgs: []*config.Config{cfg}}, Options{Host: "127.0.0.1", Port: port})
 	d.runLoop = blockingLoop
-	d.superviseLoop = func(ctx context.Context, name string, c *config.Config, o Options) { blockingLoop(ctx, c, o) }
+	d.superviseLoop = func(ctx context.Context, name string, c *config.Config, o Options) { blockingLoop(ctx, c, o, nil) }
 	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
 
 	// ctx is intentionally never cancelled within the deadline.
@@ -436,7 +436,7 @@ func TestStopFlowDrainsWatchdog(t *testing.T) {
 	}
 
 	proj := server.NewFleetProjectWithGitHub(cfg)
-	flow := d.startFlow(context.Background(), proj)
+	flow := d.startFlow(context.Background(), "", proj)
 	waitFor(t, func() bool { return atomic.LoadInt64(&wdStarted) == 1 })
 
 	d.stopFlow(flow.key)

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -182,7 +182,23 @@ func recoverFlow(flow *projectFlow, loop string) {
 // supervise loop. A nil reloadCh (store-watch disabled) leaves the orchestrator's
 // reload select arm inert.
 func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config) {
-	orch := orchestrator.New(cfg)
+	// Hot-reload (reloadCh, #757) makes the orchestrator's reloadConfig mutate
+	// its config in place (field replacement). The supervise loop and the
+	// FleetProject HTTP snapshot share this exact cfg pointer, so hand the
+	// orchestrator a private shallow copy to mutate — the shared struct the
+	// other goroutines read is then never written, closing the reload data race.
+	// reloadConfig only REPLACES fields (o.cfg.X = newCfg.X), never mutates a
+	// slice/map element in place, so a shallow copy fully isolates it.
+	//
+	// Trade-off / known limitation: a config-store edit is now applied LIVE only
+	// to the orchestrator. The supervise loop and the dashboard snapshot keep the
+	// startup config until the flow restarts — same as before #757, which had no
+	// daemon reload at all, so this is strictly better than main, not a regression.
+	// Making all three live-reload safely needs a synchronized config holder
+	// shared across orchestrator + supervisor + FleetProject — a follow-up, not an
+	// in-place mutation (which is the data race this copy removes).
+	orchCfg := *cfg
+	orch := orchestrator.New(&orchCfg)
 	orch.SetBinaryVersion(opts.Version)
 	if err := orch.LoadPromptBase(opts.PromptPath); err != nil {
 		log.Printf("[%s] warn: load prompt: %v", cfg.SessionPrefix, err)

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/configwatch"
 	"github.com/befeast/maestro/internal/orchestrator"
 	"github.com/befeast/maestro/internal/server"
 )
@@ -15,11 +16,12 @@ import (
 // supervisor loop, and (when supervising) a liveness watchdog sharing a child
 // context. Cancelling that context (stopFlow) tears every goroutine down.
 type projectFlow struct {
-	name   string
-	key    string // stable flow identity (StateDir/Repo); the flows-map key
-	cfg    *config.Config
-	cancel context.CancelFunc
-	done   chan struct{} // closed once every flow goroutine has exited
+	name      string
+	key       string // stable flow identity (StateDir/Repo); the flows-map key
+	storeName string // config-store project name; "" when not store-backed (#757)
+	cfg       *config.Config
+	cancel    context.CancelFunc
+	done      chan struct{} // closed once every flow goroutine has exited
 }
 
 // startFlow launches the orchestrator + supervisor loops (and the liveness
@@ -32,15 +34,27 @@ type projectFlow struct {
 // exited. An untracked watchdog could otherwise Load/Save StateDir after the
 // flow is considered stopped, racing a restarted flow for the same project
 // (#764 P2).
-func (d *Daemon) startFlow(parent context.Context, proj server.FleetProject) *projectFlow {
+func (d *Daemon) startFlow(parent context.Context, storeName string, proj server.FleetProject) *projectFlow {
 	cfg := proj.Cfg()
 	fctx, cancel := context.WithCancel(parent)
 	flow := &projectFlow{
-		name:   proj.Name,
-		key:    flowKey(cfg),
-		cfg:    cfg,
-		cancel: cancel,
-		done:   make(chan struct{}),
+		name:      proj.Name,
+		key:       flowKey(cfg),
+		storeName: storeName,
+		cfg:       cfg,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+	}
+
+	// Per-flow hot-reload (#757): when store-watch is enabled and this flow is
+	// store-backed, feed the orchestrator a reload channel sourced from the
+	// project's row so an operator editing the config (config-store edit) is
+	// applied live, without restarting the flow or disturbing the rest of the
+	// fleet. The watcher is a child of fctx, so stopFlow drains it. nil disables
+	// reload (the orchestrator's select arm is then inert).
+	var reloadCh <-chan *config.Config
+	if d.projectStore != nil && storeName != "" {
+		reloadCh = configwatch.WatchStore(fctx, d.projectStore, storeName, d.opts.WatchStoreInterval)
 	}
 
 	// Register BEFORE launching any goroutine (including the reaper below), so
@@ -58,7 +72,7 @@ func (d *Daemon) startFlow(parent context.Context, proj server.FleetProject) *pr
 	go func() {
 		defer wg.Done()
 		defer recoverFlow(flow, "orchestrator")
-		d.runLoop(fctx, cfg, d.opts)
+		d.runLoop(fctx, cfg, d.opts, reloadCh)
 	}()
 	go func() {
 		defer wg.Done()
@@ -161,17 +175,19 @@ func recoverFlow(flow *projectFlow, loop string) {
 // daemon down (#756). orchestrator.Run already log-and-continues on per-cycle
 // errors and returns nil on ctx cancellation.
 //
-// Hot-reload note (#764 P3): the daemon's source of truth is the config store
-// (#754), not the import-time YAML, so we deliberately do NOT wire a YAML file
-// watcher here — watching a file the store supersedes would let the run loop
-// drift from the supervise loop, which has no such watcher. Store-driven reload
-// is Phase 2 (#757).
-func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options) {
+// Store-driven hot-reload (#757): reloadCh is fed by configwatch.WatchStore from
+// the project's config-store row (the daemon's source of truth, #754), wired in
+// by startFlow. The daemon deliberately does NOT watch the import-time YAML — a
+// file the store supersedes — which would let the run loop drift from the
+// supervise loop. A nil reloadCh (store-watch disabled) leaves the orchestrator's
+// reload select arm inert.
+func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config) {
 	orch := orchestrator.New(cfg)
 	orch.SetBinaryVersion(opts.Version)
 	if err := orch.LoadPromptBase(opts.PromptPath); err != nil {
 		log.Printf("[%s] warn: load prompt: %v", cfg.SessionPrefix, err)
 	}
+	orch.SetConfigReloadCh(reloadCh)
 
 	runInterval := opts.RunInterval
 	if cfg.PollIntervalSeconds > 0 {
@@ -183,7 +199,7 @@ func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options) {
 	// FleetServer, which does not signal individual flows. Pass nil rather than
 	// a buffered channel nothing ever sends on, so orch.Run's `case <-refreshCh`
 	// arm is plainly inert instead of looking like a wired-but-dead feature
-	// (#764). Store-driven reload is Phase 2 (#757).
+	// (#764).
 	log.Printf("[%s] starting orchestrator — repo=%s interval=%s", cfg.SessionPrefix, cfg.Repo, runInterval)
 	if err := orch.Run(ctx, runInterval, false, nil); err != nil {
 		log.Printf("[%s] orchestrator exited: %v", cfg.SessionPrefix, err)

--- a/internal/daemon/watch.go
+++ b/internal/daemon/watch.go
@@ -80,6 +80,12 @@ func (d *Daemon) reconcileStore(flowParent context.Context, fp map[string]time.T
 			fleet.RemoveProject(flow.name)
 		}
 		d.stopFlow(flow.key)
+		// Free this flow's fleet display name AND its flow identity in the local
+		// snapshot maps, so a same-tick re-add of the same repo/StateDir reclaims
+		// the base name (instead of getting a numeric-suffixed UniqueFleetName)
+		// and is not wrongly skipped as a duplicate flow identity (#757).
+		delete(takenNames, flow.name)
+		delete(takenKeys, flow.key)
 	}
 
 	// Additions: a store project with no running flow.

--- a/internal/daemon/watch.go
+++ b/internal/daemon/watch.go
@@ -1,0 +1,116 @@
+package daemon
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/befeast/maestro/internal/server"
+)
+
+// watchStoreLoop is the daemon's DB diff-loop (#757). On each tick it diffs the
+// store's project set (ProjectsFingerprint) against the running store-backed
+// flows: a name present in the store but not running is started and registered
+// in the fleet, and a running flow whose name has vanished from the store is
+// drained and removed from the fleet. Per-project config CHANGES are handled
+// separately by each flow's configwatch.WatchStore reload channel (wired in
+// startFlow), so this loop reconciles membership only.
+//
+// loopCtx controls the loop's own lifetime; flowParent parents every flow it
+// starts (the daemon ctx) so daemon shutdown's stopAll drains them. Run always
+// stops this loop before stopAll, so the loop never starts a flow that stopAll
+// would miss.
+func (d *Daemon) watchStoreLoop(loopCtx, flowParent context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = DefaultWatchStoreInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Log a duplicate-identity skip at most once per offending name so a
+	// misconfigured store (two projects sharing one StateDir) does not spam the
+	// journal every tick.
+	loggedDupSkip := map[string]bool{}
+
+	for {
+		select {
+		case <-loopCtx.Done():
+			return
+		case <-ticker.C:
+			fp, err := d.projectStore.ProjectsFingerprint(loopCtx)
+			if err != nil {
+				// A transient store read must not kill the loop; retry next tick.
+				log.Printf("[daemon] store watch: fingerprint failed (will retry): %v", err)
+				continue
+			}
+			d.reconcileStore(flowParent, fp, loggedDupSkip)
+		}
+	}
+}
+
+// reconcileStore applies one diff between the store's project set (fp) and the
+// running store-backed flows: drain flows whose project row is gone, start
+// flows for project rows with no running flow. loggedDupSkip carries across
+// ticks so a duplicate-identity skip is logged once, not every cycle.
+func (d *Daemon) reconcileStore(flowParent context.Context, fp map[string]time.Time, loggedDupSkip map[string]bool) {
+	// Snapshot the running store-backed flows and the taken fleet identities
+	// under one lock so the add/remove decisions are internally consistent.
+	d.mu.Lock()
+	running := make(map[string]*projectFlow, len(d.flows)) // storeName -> flow
+	takenNames := make(map[string]bool, len(d.flows))      // fleet display names
+	takenKeys := make(map[string]bool, len(d.flows))       // flow identities (StateDir/Repo)
+	for _, flow := range d.flows {
+		takenNames[flow.name] = true
+		takenKeys[flow.key] = true
+		if flow.storeName != "" {
+			running[flow.storeName] = flow
+		}
+	}
+	d.mu.Unlock()
+
+	fleet := d.Fleet()
+
+	// Removals: a running store-backed flow whose name is gone from the store.
+	for name, flow := range running {
+		if _, ok := fp[name]; ok {
+			continue
+		}
+		log.Printf("[daemon] store watch: project %q removed — draining flow %q", name, flow.name)
+		if fleet != nil {
+			fleet.RemoveProject(flow.name)
+		}
+		d.stopFlow(flow.key)
+	}
+
+	// Additions: a store project with no running flow.
+	for name := range fp {
+		if _, ok := running[name]; ok {
+			continue
+		}
+		cfg, err := d.projectStore.Load(flowParent, name)
+		if err != nil {
+			log.Printf("[daemon] store watch: load new project %q failed (will retry): %v", name, err)
+			continue
+		}
+		if cfg == nil {
+			continue
+		}
+		key := flowKey(cfg)
+		if takenKeys[key] {
+			if !loggedDupSkip[name] {
+				log.Printf("[daemon] store watch: skip project %q (repo=%s state_dir=%s): duplicate flow identity already running", name, cfg.Repo, cfg.StateDir)
+				loggedDupSkip[name] = true
+			}
+			continue
+		}
+		fleetName := server.UniqueFleetName(cfg.Repo, takenNames)
+		proj := server.NewFleetProjectWithGitHubNamed(fleetName, cfg)
+		if fleet != nil {
+			fleet.AddProject(proj)
+		}
+		takenKeys[key] = true
+		flow := d.startFlow(flowParent, name, proj)
+		delete(loggedDupSkip, name) // recovered: it now has a running flow
+		log.Printf("[daemon] store watch: started flow %q for new project %q (repo=%s state_dir=%s)", flow.name, name, cfg.Repo, cfg.StateDir)
+	}
+}

--- a/internal/daemon/watch_test.go
+++ b/internal/daemon/watch_test.go
@@ -1,0 +1,218 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// fakeWatchStore is an in-memory store that satisfies both ConfigLoader (so it
+// can be handed to New) and configwatch.ProjectStore (so the daemon enables the
+// diff-loop). Each Set bumps the project's updated_at, mirroring UpsertProject.
+type fakeWatchStore struct {
+	mu     sync.Mutex
+	cfgs   map[string]*config.Config
+	stamps map[string]time.Time
+	clock  time.Time
+}
+
+func newFakeWatchStore() *fakeWatchStore {
+	return &fakeWatchStore{
+		cfgs:   map[string]*config.Config{},
+		stamps: map[string]time.Time{},
+		clock:  time.Unix(1_700_000_000, 0).UTC(),
+	}
+}
+
+func (f *fakeWatchStore) Set(name string, cfg *config.Config) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clock = f.clock.Add(time.Second)
+	f.cfgs[name] = cfg
+	f.stamps[name] = f.clock
+}
+
+func (f *fakeWatchStore) Delete(name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.cfgs, name)
+	delete(f.stamps, name)
+}
+
+func (f *fakeWatchStore) Load(ctx context.Context, name string) (*config.Config, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cfg, ok := f.cfgs[name]
+	if !ok {
+		return nil, context.Canceled
+	}
+	return cfg, nil
+}
+
+func (f *fakeWatchStore) LoadAll(ctx context.Context) ([]*config.Config, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*config.Config, 0, len(f.cfgs))
+	for _, cfg := range f.cfgs {
+		out = append(out, cfg)
+	}
+	return out, nil
+}
+
+func (f *fakeWatchStore) ProjectsFingerprint(ctx context.Context) (map[string]time.Time, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]time.Time, len(f.stamps))
+	for k, v := range f.stamps {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func newWatchDaemon(store ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, *config.Config, Options)) *Daemon {
+	d := New(store, Options{Host: "127.0.0.1", Port: 0, WatchStore: true, WatchStoreInterval: 25 * time.Millisecond})
+	if run != nil {
+		d.runLoop = run
+	}
+	if supervise != nil {
+		d.superviseLoop = supervise
+	}
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
+	return d
+}
+
+func fleetProjectNames(t *testing.T, d *Daemon) []string {
+	t.Helper()
+	fleet := waitForFleet(t, d)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	rec := httptest.NewRecorder()
+	fleet.HandlerForTest().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/fleet = %d, want 200", rec.Code)
+	}
+	var resp struct {
+		Projects []struct {
+			Name string `json:"name"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode fleet response: %v", err)
+	}
+	names := make([]string, 0, len(resp.Projects))
+	for _, p := range resp.Projects {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+// The diff-loop must add a flow for a project that appears in the store and
+// drain one for a project that disappears — both reflected in /api/v1/fleet
+// without a daemon restart (#757 acceptance).
+func TestWatchStoreLoopHotAddsAndRemoves(t *testing.T) {
+	store := newFakeWatchStore()
+	store.Set("alpha", testConfig(t, "owner/alpha"))
+
+	var run, sup loopTracker
+	d := newWatchDaemon(store, run.loop, sup.superviseLoop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	// Initial project is present.
+	waitForNames(t, d, "alpha")
+	if got := atomic.LoadInt64(&run.started); got != 1 {
+		t.Fatalf("run loops started = %d, want 1", got)
+	}
+
+	// Hot-add beta.
+	store.Set("beta", testConfig(t, "owner/beta"))
+	waitForNames(t, d, "alpha", "beta")
+	waitFor(t, func() bool { return atomic.LoadInt64(&run.started) == 2 })
+
+	// Hot-remove alpha; beta survives, other flows untouched.
+	store.Delete("alpha")
+	waitForNames(t, d, "beta")
+	waitFor(t, func() bool { return atomic.LoadInt64(&run.stopped) >= 1 })
+
+	d.mu.Lock()
+	flows := len(d.flows)
+	d.mu.Unlock()
+	if flows != 1 {
+		t.Fatalf("flows = %d, want 1 after hot-remove", flows)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancellation")
+	}
+}
+
+// A store-backed flow must receive a non-nil reload channel so an edited config
+// row hot-reloads its orchestrator (#757). A nil channel would silently disable
+// reload.
+func TestWatchStoreWiresReloadChannel(t *testing.T) {
+	store := newFakeWatchStore()
+	store.Set("alpha", testConfig(t, "owner/alpha"))
+
+	var gotReload int32 // 1 if the run loop saw a non-nil reload channel
+	run := func(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config) {
+		if reloadCh != nil {
+			atomic.StoreInt32(&gotReload, 1)
+		}
+		<-ctx.Done()
+	}
+	sup := func(ctx context.Context, name string, cfg *config.Config, opts Options) { <-ctx.Done() }
+	d := newWatchDaemon(store, run, sup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	waitForFleet(t, d)
+	waitFor(t, func() bool { return atomic.LoadInt32(&gotReload) == 1 })
+
+	cancel()
+	<-done
+}
+
+func waitForNames(t *testing.T, d *Daemon, want ...string) {
+	t.Helper()
+	wantSet := make(map[string]bool, len(want))
+	for _, w := range want {
+		wantSet[w] = true
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	var last []string
+	for time.Now().Before(deadline) {
+		last = fleetProjectNames(t, d)
+		if len(last) == len(wantSet) {
+			ok := true
+			for _, n := range last {
+				if !wantSet[n] {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("fleet names = %v, want %v", last, want)
+}

--- a/internal/daemon/watch_test.go
+++ b/internal/daemon/watch_test.go
@@ -216,3 +216,47 @@ func waitForNames(t *testing.T, d *Daemon, want ...string) {
 	}
 	t.Fatalf("fleet names = %v, want %v", last, want)
 }
+
+// #757: when one project is removed and a different project sharing its repo
+// basename is added in the SAME reconcile tick, the re-add must reclaim the
+// freed fleet name — not get a slug/numeric-suffixed one because the removed
+// flow's name lingered in the diff-loop's takenNames snapshot.
+func TestReconcileStoreSameTickRemoveAddReclaimsName(t *testing.T) {
+	store := newFakeWatchStore()
+	var run, sup loopTracker
+	d := newWatchDaemon(store, run.loop, sup.superviseLoop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Tick 1: project "old" (repo org-a/api) starts and takes fleet name "api".
+	store.Set("old", testConfig(t, "org-a/api"))
+	d.reconcileStore(ctx, map[string]time.Time{"old": time.Unix(1, 0)}, map[string]bool{})
+	if got := storeFlowName(d, "old"); got != "api" {
+		t.Fatalf("old fleet name = %q, want \"api\"", got)
+	}
+
+	// Tick 2 (one reconcile): "old" removed, "new" (same repo basename, distinct
+	// StateDir) added. The freed name "api" must be reclaimed.
+	store.Delete("old")
+	store.Set("new", testConfig(t, "org-a/api"))
+	d.reconcileStore(ctx, map[string]time.Time{"new": time.Unix(2, 0)}, map[string]bool{})
+
+	if got := storeFlowName(d, "new"); got != "api" {
+		t.Fatalf("re-added fleet name = %q, want reclaimed \"api\" (takenNames/takenKeys not freed on remove)", got)
+	}
+	cancel()
+}
+
+// storeFlowName returns the fleet display name of the running flow whose
+// config-store name is storeName, or "" if none.
+func storeFlowName(d *Daemon, storeName string) string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, flow := range d.flows {
+		if flow.storeName == storeName {
+			return flow.name
+		}
+	}
+	return ""
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -245,11 +245,16 @@ func defaultFleetProjectName(repo string) string {
 
 // FleetServer exposes a read-only dashboard/API across multiple Maestro configs.
 type FleetServer struct {
-	projects []FleetProject
-	host     string
-	port     int
-	readOnly bool
-	srv      *http.Server
+	// projectsMu guards projects so the daemon's diff-loop can add/remove
+	// flows at runtime (#757) while HTTP handlers read the slice concurrently.
+	// Reads go through projectsSnapshot; mutations through AddProject /
+	// RemoveProject.
+	projectsMu sync.RWMutex
+	projects   []FleetProject
+	host       string
+	port       int
+	readOnly   bool
+	srv        *http.Server
 	// auth gates every mutating fleet endpoint (#487, write-path premortem
 	// #4). When the resolved token is empty the checker is disabled and
 	// behaviour is unchanged; when non-empty, /api/v1/fleet/actions,
@@ -266,6 +271,55 @@ func NewFleet(projects []FleetProject, host string, port int, readOnly bool) *Fl
 		port:     port,
 		readOnly: readOnly,
 	}
+}
+
+// projectsSnapshot returns a copy of the project slice under the read lock so
+// callers can iterate without holding the lock across per-project work (state
+// loads, board calls). The backing array is fresh, so a concurrent AddProject /
+// RemoveProject can never mutate it mid-iteration.
+func (s *FleetServer) projectsSnapshot() []FleetProject {
+	s.projectsMu.RLock()
+	defer s.projectsMu.RUnlock()
+	out := make([]FleetProject, len(s.projects))
+	copy(out, s.projects)
+	return out
+}
+
+// AddProject registers a project at runtime (daemon hot-add, #757). A project
+// whose Name already exists is replaced in place rather than duplicated, so the
+// fleet's by-name addressing (findProject) stays unambiguous. Safe for
+// concurrent use with the HTTP read paths.
+func (s *FleetServer) AddProject(p FleetProject) {
+	if s == nil {
+		return
+	}
+	s.projectsMu.Lock()
+	defer s.projectsMu.Unlock()
+	for i := range s.projects {
+		if s.projects[i].Name == p.Name {
+			s.projects[i] = p
+			return
+		}
+	}
+	s.projects = append(s.projects, p)
+}
+
+// RemoveProject drops the project with the given fleet name (daemon hot-remove,
+// #757) and reports whether one was found. Safe for concurrent use with the
+// HTTP read paths.
+func (s *FleetServer) RemoveProject(name string) bool {
+	if s == nil {
+		return false
+	}
+	s.projectsMu.Lock()
+	defer s.projectsMu.Unlock()
+	for i := range s.projects {
+		if s.projects[i].Name == name {
+			s.projects = append(s.projects[:i], s.projects[i+1:]...)
+			return true
+		}
+	}
+	return false
 }
 
 // SetAuth configures fleet-level auth from the operator's resolved
@@ -933,7 +987,7 @@ func (s *FleetServer) handleFleetWorker(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *FleetServer) findProject(name string) (FleetProject, bool) {
-	for _, project := range s.projects {
+	for _, project := range s.projectsSnapshot() {
 		if project.Name == name {
 			return project, true
 		}
@@ -1153,7 +1207,7 @@ func (s *FleetServer) fleetAuditLogStateDir(projectName string) (string, error) 
 		}
 		return "", nil
 	}
-	for _, project := range s.projects {
+	for _, project := range s.projectsSnapshot() {
 		if project.cfg != nil && strings.TrimSpace(project.cfg.StateDir) != "" {
 			return project.cfg.StateDir, nil
 		}
@@ -1196,17 +1250,18 @@ func newFleetAuditID() string {
 
 func (s *FleetServer) snapshot() fleetResponse {
 	now := time.Now().UTC()
+	projects := s.projectsSnapshot()
 	resp := fleetResponse{
 		ReadOnly:    s.readOnly,
 		Version:     binaryVersion,
 		RefreshedAt: formatFleetTime(now),
-		Projects:    make([]fleetProjectState, 0, len(s.projects)),
+		Projects:    make([]fleetProjectState, 0, len(projects)),
 		Workers:     make([]fleetWorkerState, 0),
 		Attention:   make([]fleetWorkerState, 0),
 		Approvals:   make([]fleetApprovalState, 0),
 	}
 	throughputBuckets := newFleetThroughputBuckets(now, 7)
-	for _, project := range s.projects {
+	for _, project := range projects {
 		item, workers := s.projectSnapshot(project, now)
 		resp.Projects = append(resp.Projects, item)
 		resp.Workers = append(resp.Workers, workers...)

--- a/internal/server/fleet_runtime_test.go
+++ b/internal/server/fleet_runtime_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// The daemon hot-adds and hot-removes flows at runtime (#757); the fleet must
+// reflect that in /api/v1/fleet without a rebuild, and the by-name addressing
+// must stay unambiguous.
+func TestFleetAddRemoveProjectVisibleInAPI(t *testing.T) {
+	s := NewFleet(nil, "127.0.0.1", 0, false)
+
+	fleetNames := func() []string {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+		rec := httptest.NewRecorder()
+		s.HandlerForTest().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /api/v1/fleet = %d, want 200", rec.Code)
+		}
+		var resp struct {
+			Projects []struct {
+				Name string `json:"name"`
+			} `json:"projects"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode fleet response: %v", err)
+		}
+		names := make([]string, 0, len(resp.Projects))
+		for _, p := range resp.Projects {
+			names = append(names, p.Name)
+		}
+		return names
+	}
+
+	if got := fleetNames(); len(got) != 0 {
+		t.Fatalf("empty fleet should list 0 projects, got %v", got)
+	}
+
+	s.AddProject(NewFleetProjectWithGitHubNamed("alpha", &config.Config{Repo: "owner/alpha"}))
+	if got := fleetNames(); len(got) != 1 || got[0] != "alpha" {
+		t.Fatalf("after add, fleet = %v, want [alpha]", got)
+	}
+
+	// Re-adding the same name replaces in place rather than duplicating.
+	s.AddProject(NewFleetProjectWithGitHubNamed("alpha", &config.Config{Repo: "owner/alpha"}))
+	if got := fleetNames(); len(got) != 1 {
+		t.Fatalf("re-adding same name should not duplicate, fleet = %v", got)
+	}
+
+	if !s.RemoveProject("alpha") {
+		t.Fatal("RemoveProject(alpha) = false, want true")
+	}
+	if got := fleetNames(); len(got) != 0 {
+		t.Fatalf("after remove, fleet = %v, want []", got)
+	}
+
+	if s.RemoveProject("alpha") {
+		t.Fatal("RemoveProject of a missing project should report false")
+	}
+}


### PR DESCRIPTION
Implements #757

Part of epic #754 (single-service redesign). Builds on Phase 0 (ProjectsFingerprint + write API) and Phase 1 (daemon/flows). Projects become live rows the daemon reconciles without a unit restart.

## Changes
- `configwatch.WatchStore(ctx, store, name, interval) <-chan *config.Config` — DB-backed sibling of the file `Watch`; polls a project's `updated_at` and emits the reloaded config. The `orchestrator.SetConfigReloadCh` contract is unchanged.
- Daemon diff-loop over `ProjectsFingerprint`, opt-in behind `--watch-store`: a new name starts a flow and registers it in the fleet; a removed name drains the flow and unregisters it. Each flow's orchestrator is fed a per-flow `WatchStore` reload channel, so editing one project's config hot-reloads that flow alone — the rest of the fleet is untouched.
- `server.FleetServer` gains thread-safe `AddProject`/`RemoveProject` (+ a locked snapshot accessor) so `/api/v1/fleet` reflects hot add/remove at runtime.
- CLI: `config-store add --file <yaml>` / `rm <name>` / `edit <name>` (`edit` = export → $EDITOR → re-import with validation), plus `configstore.ProjectNameFor` / `ExportProject` helpers.

## Testing
- `gofmt` on changed Go files
- `go build ./cmd/maestro/`
- `go test ./...` (incl. `-race` on configwatch/daemon/server/configstore)
- New tests: WatchStore semantics, fleet runtime add/remove, daemon diff-loop hot add/remove + reload-channel wiring, config-store name derivation / export round-trip, and the $EDITOR edit flow.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements Phase 2 of the single-service redesign: DB-driven hot add/remove/reload of projects without a daemon restart. It adds `configwatch.WatchStore` (DB-backed sibling of the file `Watch`), a diff-loop (`watchStoreLoop`/`reconcileStore`) that reconciles running flows against the store's `ProjectsFingerprint`, thread-safe `AddProject`/`RemoveProject` on `FleetServer`, and `config-store add/rm/edit` CLI subcommands.

- `configstore.Store` gains WAL+busy_timeout pragmas and `SetMaxOpenConns(1)` to safely allow a running daemon and CLI tools to share the same SQLite file; timestamps are upgraded to RFC3339Nano so two writes within the same second advance the fingerprint.
- `reconcileStore` correctly frees `takenNames`/`takenKeys` for removed flows before processing additions in the same tick, so a same-tick rename reclaims the base fleet name rather than receiving a numeric suffix.
- `runOrchestrator` takes a shallow copy of `cfg` before handing it to the orchestrator, closing the reload data race that would otherwise arise from `reloadConfig` mutating a pointer shared with the supervisor loop.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge; the concurrency model (RWMutex on the project slice, per-flow child contexts, and snapshot-based iteration) is correct throughout.

All critical paths — fleet mutation under `projectsMu`, per-flow reload channel isolation via a shallow `cfg` copy, and the diff-loop's `takenNames`/`takenKeys` cleanup on removal — are implemented correctly and tested. The one inconsistency (startup fails hard on a load error while the runtime loop retries) is unlikely to matter in practice since the store validates on write.

internal/daemon/daemon.go — the startup load path in `loadNamedConfigs` differs in error handling from the runtime diff-loop.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/maestro/daemon.go | Adds `--watch-store` and `--watch-store-interval` CLI flags wired into `daemon.Options`; clean change. |
| cmd/maestro/main.go | Adds `config-store add/rm/edit` subcommands; `editStoreProject` correctly validates before writing, and `launchEditor` splits `$EDITOR` on whitespace for multi-arg editors like `code --wait`. |
| cmd/maestro/main_config_store_test.go | Tests for the edit flow cover apply, no-change, and invalid-YAML rejection paths using a fake shell-script editor. |
| internal/configstore/store.go | Adds WAL+busy_timeout DSN pragmas and `SetMaxOpenConns(1)` for cross-process safety; upgrades timestamps to RFC3339Nano; exposes `ProjectNameFor` and `ExportProject` helpers. |
| internal/configstore/store_crud_test.go | Covers `ProjectNameFor` derivation, `ExportProject` round-trip, and the same-second fingerprint advancement guarantee. |
| internal/configwatch/watcher.go | Adds `ProjectStore` interface and `WatchStore` goroutine; correctly seeds `last` to avoid spurious reloads, drops on full buffer, and exits cleanly on `ctx.Done`. |
| internal/configwatch/watcher_store_test.go | Comprehensive `WatchStore` tests (detect-change, no-change, missing-project, load-error, context-cancel) using a correct in-memory `fakeStore`. |
| internal/daemon/daemon.go | Introduces `loadNamedConfigs` (startup fail-fast if any project Load fails), `namedConfig`, and the watchStoreLoop wiring; runLoop signature gains `reloadCh`. |
| internal/daemon/daemon_test.go | Updated test helpers to match the new `runLoop` signature with `reloadCh`; existing tests pass correctly. |
| internal/daemon/flow.go | Adds `storeName` field to `projectFlow`, wires per-flow `WatchStore` channel in `startFlow`, and makes `runOrchestrator` take a shallow copy of `cfg` before handing it to the orchestrator to avoid shared-state races on reload. |
| internal/daemon/watch.go | Implements `watchStoreLoop` and `reconcileStore`; correctly frees `takenNames`/`takenKeys` for removed flows before processing additions in the same tick, preventing permanent name-suffix bugs. |
| internal/daemon/watch_test.go | Tests hot-add/remove/reload-channel wiring and same-tick remove+add name reclamation; `fakeWatchStore.Load` uses `context.Canceled` for not-found (semantically imprecise but doesn't affect test correctness). |
| internal/server/fleet.go | Adds `projectsMu sync.RWMutex` and `AddProject`/`RemoveProject`/`projectsSnapshot` methods; all existing `s.projects` read paths now go through `projectsSnapshot()` under `RLock`. |
| internal/server/fleet_runtime_test.go | Tests `AddProject`/`RemoveProject` visibility in `/api/v1/fleet`, including same-name replace-in-place and idempotent remove. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/daemon/watch_test.go`, line 1362-1370 ([link](https://github.com/befeast/maestro/blob/db3ea57d4083211932429a781ed06dbbf3834882/internal/daemon/watch_test.go#L1362-L1370)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`context.Canceled` used as "not found" error in test double**

   `fakeWatchStore.Load` returns `context.Canceled` when a key is absent. This is semantically incorrect — `context.Canceled` signals context cancellation, not a missing key. Code inspecting the error downstream (e.g., `errors.Is(err, context.Canceled)`) would misinterpret a legitimate "project not found" as a cancelled request. Using `errors.New("not found")` keeps the error category distinct.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/daemon/watch_test.go
   Line: 1362-1370

   Comment:
   **`context.Canceled` used as "not found" error in test double**

   `fakeWatchStore.Load` returns `context.Canceled` when a key is absent. This is semantically incorrect — `context.Canceled` signals context cancellation, not a missing key. Code inspecting the error downstream (e.g., `errors.Is(err, context.Canceled)`) would misinterpret a legitimate "project not found" as a cancelled request. Using `errors.New("not found")` keeps the error category distinct.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/configwatch/watcher.go`, line 537-548 ([link](https://github.com/befeast/maestro/blob/db3ea57d4083211932429a781ed06dbbf3834882/internal/configwatch/watcher.go#L537-L548)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **O(N) `ProjectsFingerprint` calls per tick, one per store-backed flow**

   Each running flow's `WatchStore` goroutine calls `storeProjectUpdatedAt` -> `store.ProjectsFingerprint` on every interval tick, fetching all project timestamps. With N store-backed flows that is N full-table reads per interval on top of the daemon's own diff-loop call. For a small fleet this is negligible, but worth noting as the design is extended.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/configwatch/watcher.go
   Line: 537-548

   Comment:
   **O(N) `ProjectsFingerprint` calls per tick, one per store-backed flow**

   Each running flow's `WatchStore` goroutine calls `storeProjectUpdatedAt` -> `store.ProjectsFingerprint` on every interval tick, fetching all project timestamps. With N store-backed flows that is N full-table reads per interval on top of the daemon's own diff-loop call. For a small fleet this is negligible, but worth noting as the design is extended.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["daemon/configstore: address #767 review ..."](https://github.com/befeast/maestro/commit/98bfcf12225150a8714eb4f4b2209334fd9ebc21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39493232)</sub>

<!-- /greptile_comment -->