### PR TITLE
Phase 2 follow-up: synchronized runtime config+auth holder (live supervisor/dashboard reload + hot-add auth)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -99,10 +99,13 @@ type Daemon struct {
 	// runLoop, superviseLoop, and watchdogLoop build the per-project loops.
 	// They default to the production orchestrator + supervisor wiring; tests
 	// override them to drive flows (and assert WaitGroup tracking) without
-	// reaching GitHub. runLoop receives the flow's hot-reload channel (#757),
-	// nil when store-watch is disabled.
+	// reaching GitHub. runLoop receives the orchestrator's hot-reload channel
+	// (#757), nil when store-watch is disabled. superviseLoop receives a getCfg
+	// closure rather than a fixed *config.Config so it reads the flow's current
+	// config each cycle through the shared holder — a config-store edit reaches
+	// the supervise loop live, not just the orchestrator (#768).
 	runLoop       func(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config)
-	superviseLoop func(ctx context.Context, name string, cfg *config.Config, opts Options)
+	superviseLoop func(ctx context.Context, name string, getCfg func() *config.Config, opts Options)
 	watchdogLoop  func(ctx context.Context, name, stateDir string, interval time.Duration)
 }
 
@@ -143,8 +146,8 @@ func New(store ConfigLoader, opts Options) *Daemon {
 		}
 	}
 	d.runLoop = runOrchestrator
-	d.superviseLoop = func(ctx context.Context, name string, cfg *config.Config, opts Options) {
-		runSupervise(ctx, name, cfg, opts.SuperviseInterval)
+	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+		runSupervise(ctx, name, getCfg, opts.SuperviseInterval)
 	}
 	d.watchdogLoop = supervisor.Watchdog
 	return d

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -52,8 +52,9 @@ func (lt *loopTracker) loop(ctx context.Context, cfg *config.Config, opts Option
 }
 
 // superviseLoop is the supervise-shaped stub (the supervise loop takes the
-// flow's unique name as its first arg, #764). It records the same counters.
-func (lt *loopTracker) superviseLoop(ctx context.Context, name string, cfg *config.Config, opts Options) {
+// flow's unique name and a current-config getter, #764/#768). It records the
+// same counters.
+func (lt *loopTracker) superviseLoop(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
 	atomic.AddInt64(&lt.started, 1)
 	<-ctx.Done()
 	atomic.AddInt64(&lt.stopped, 1)
@@ -64,7 +65,7 @@ func (lt *loopTracker) superviseLoop(ctx context.Context, name string, cfg *conf
 // this helper stay isolated from the real supervisor.Watchdog goroutine — a
 // future change to its shutdown path must not silently break these lifecycle
 // tests. Tests that assert watchdog behaviour install their own stub.
-func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, *config.Config, Options)) *Daemon {
+func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, func() *config.Config, Options)) *Daemon {
 	d := New(loader, Options{Host: "127.0.0.1", Port: 0})
 	if run != nil {
 		d.runLoop = run
@@ -308,7 +309,7 @@ func TestFlowPanicCancelsFlow(t *testing.T) {
 	// on its own; no one calls stopFlow.
 	cfg := testConfig(t, "owner/panicky")
 	var supStarted, supStopped int64
-	supervise := func(ctx context.Context, name string, c *config.Config, o Options) {
+	supervise := func(ctx context.Context, name string, getCfg func() *config.Config, o Options) {
 		atomic.AddInt64(&supStarted, 1)
 		<-ctx.Done()
 		atomic.AddInt64(&supStopped, 1)
@@ -371,7 +372,9 @@ func TestRunSurfacesFleetBindErrorImmediately(t *testing.T) {
 	}
 	d := New(fakeLoader{cfgs: []*config.Config{cfg}}, Options{Host: "127.0.0.1", Port: port})
 	d.runLoop = blockingLoop
-	d.superviseLoop = func(ctx context.Context, name string, c *config.Config, o Options) { blockingLoop(ctx, c, o, nil) }
+	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, o Options) {
+		blockingLoop(ctx, getCfg(), o, nil)
+	}
 	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
 
 	// ctx is intentionally never cancelled within the deadline.

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -17,11 +17,16 @@ import (
 // context. Cancelling that context (stopFlow) tears every goroutine down.
 type projectFlow struct {
 	name      string
-	key       string // stable flow identity (StateDir/Repo); the flows-map key
-	storeName string // config-store project name; "" when not store-backed (#757)
-	cfg       *config.Config
-	cancel    context.CancelFunc
-	done      chan struct{} // closed once every flow goroutine has exited
+	key       string         // stable flow identity (StateDir/Repo); the flows-map key
+	storeName string         // config-store project name; "" when not store-backed (#757)
+	cfg       *config.Config // startup config; identity (key) + logging source
+	// holder is the flow's current config, swapped by the reload pump on every
+	// config-store edit. The supervise loop reads it each cycle and the
+	// dashboard snapshot is rebuilt from it, so a live edit reaches all three
+	// readers — supervisor, dashboard, orchestrator — race-free (#768).
+	holder *configHolder
+	cancel context.CancelFunc
+	done   chan struct{} // closed once every flow goroutine has exited
 }
 
 // startFlow launches the orchestrator + supervisor loops (and the liveness
@@ -42,19 +47,29 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 		key:       flowKey(cfg),
 		storeName: storeName,
 		cfg:       cfg,
+		holder:    newConfigHolder(cfg),
 		cancel:    cancel,
 		done:      make(chan struct{}),
 	}
 
-	// Per-flow hot-reload (#757): when store-watch is enabled and this flow is
-	// store-backed, feed the orchestrator a reload channel sourced from the
-	// project's row so an operator editing the config (config-store edit) is
-	// applied live, without restarting the flow or disturbing the rest of the
-	// fleet. The watcher is a child of fctx, so stopFlow drains it. nil disables
-	// reload (the orchestrator's select arm is then inert).
-	var reloadCh <-chan *config.Config
+	// Per-flow hot-reload (#757, #768): when store-watch is enabled and this
+	// flow is store-backed, watch the project's row so an operator editing the
+	// config (config-store edit) is applied live, without restarting the flow or
+	// disturbing the rest of the fleet. The watcher is a child of fctx, so
+	// stopFlow drains it.
+	//
+	// The raw watcher channel feeds a single reload PUMP (runReloadPump) — not
+	// the orchestrator directly — because a config edit must reach all three
+	// readers: the supervise loop and dashboard (via the holder, #768) and the
+	// orchestrator (via orchReloadCh, which keeps its selective reloadConfig +
+	// restart-required detection). One channel can have only one consumer, so
+	// the pump fans out. A nil watcher leaves orchReloadCh nil too, so the
+	// orchestrator's reload select arm stays inert.
+	var watchCh <-chan *config.Config
+	var orchReloadCh chan *config.Config
 	if d.projectStore != nil && storeName != "" {
-		reloadCh = configwatch.WatchStore(fctx, d.projectStore, storeName, d.opts.WatchStoreInterval)
+		watchCh = configwatch.WatchStore(fctx, d.projectStore, storeName, d.opts.WatchStoreInterval)
+		orchReloadCh = make(chan *config.Config, 1)
 	}
 
 	// Register BEFORE launching any goroutine (including the reaper below), so
@@ -72,16 +87,31 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 	go func() {
 		defer wg.Done()
 		defer recoverFlow(flow, "orchestrator")
-		d.runLoop(fctx, cfg, d.opts, reloadCh)
+		// orchReloadCh (fed by the pump) is typed as <-chan; a nil channel
+		// leaves the orchestrator's reload arm inert (store-watch disabled).
+		d.runLoop(fctx, cfg, d.opts, orchReloadCh)
 	}()
 	go func() {
 		defer wg.Done()
 		defer recoverFlow(flow, "supervise")
 		// flow.name is the unique fleet display name; the supervise loop keys
 		// its decision/cycle logs on it so two same-basename repos are
-		// distinguishable in the journal, matching the watchdog (#764).
-		d.superviseLoop(fctx, flow.name, cfg, d.opts)
+		// distinguishable in the journal, matching the watchdog (#764). It reads
+		// the flow's CURRENT config through the holder each cycle (#768).
+		d.superviseLoop(fctx, flow.name, flow.holder.Load, d.opts)
 	}()
+	// Reload pump (#768): consume the store watcher and fan a config-store edit
+	// out to the holder (supervisor + dashboard) and the orchestrator. Tracked
+	// in the flow WaitGroup so stopFlow drains it before the flow is considered
+	// stopped. Only started when store-watch wired a channel.
+	if watchCh != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer recoverFlow(flow, "config-reload")
+			d.runReloadPump(fctx, flow, watchCh, orchReloadCh)
+		}()
+	}
 	// Phase 1.2 (#499) liveness watchdog, one per flow — tracked in the flow
 	// WaitGroup (#764 P2). The watchdog itself no-ops on a non-positive
 	// interval; gate here too so we never spawn a goroutine that immediately
@@ -168,6 +198,60 @@ func recoverFlow(flow *projectFlow, loop string) {
 	}
 }
 
+// runReloadPump is the single consumer of a flow's store watcher (#768). On
+// each config-store edit it fans the freshly loaded config out so all three
+// runtime readers see it without a flow restart:
+//
+//   - the holder — read each cycle by the supervise loop and used to rebuild
+//     the dashboard snapshot, so a changed supervisor policy / labels / etc.
+//     is applied LIVE (the gap #767 left: reload reached only the orchestrator);
+//   - the FleetServer project entry — replaced in place so /api/v1/fleet
+//     reflects the new config, and AddProject re-derives fleet auth so a newly
+//     token-bearing edit starts enforcing auth (#768);
+//   - the orchestrator — forwarded on orchReloadCh, which keeps its selective
+//     reloadConfig (restart-required detection, ticker reset) over a private
+//     shallow copy.
+//
+// The pump exits on ctx cancellation or when the watcher closes its channel on
+// shutdown. It never closes orchReloadCh: a closed channel would spin the
+// orchestrator's select on a nil config.
+func (d *Daemon) runReloadPump(ctx context.Context, flow *projectFlow, watchCh <-chan *config.Config, orchReloadCh chan<- *config.Config) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case newCfg, ok := <-watchCh:
+			if !ok {
+				// Watcher closed its channel (flow shutdown); nothing more to pump.
+				return
+			}
+			if newCfg == nil {
+				continue
+			}
+			// Holder first, so the supervise loop's next cycle and the rebuilt
+			// dashboard snapshot below both observe the new config.
+			flow.holder.Store(newCfg)
+
+			// Replace the project in the fleet so /api/v1/fleet reflects the edit
+			// and fleet auth is re-derived. d.Fleet() is nil only during the brief
+			// startup window before Run publishes it; no reload can arrive that
+			// early, but tolerate nil to be safe.
+			if fleet := d.Fleet(); fleet != nil {
+				fleet.AddProject(server.NewFleetProjectWithGitHubNamed(flow.name, newCfg))
+			}
+
+			// Forward to the orchestrator. Non-blocking with drop-if-not-drained,
+			// matching configwatch's own buffered-depth-1 semantics: if the
+			// orchestrator is mid-cycle and has not drained the previous reload, it
+			// applies the next edit on the following tick.
+			select {
+			case orchReloadCh <- newCfg:
+			default:
+			}
+		}
+	}
+}
+
 // runOrchestrator is the production run loop for one flow. It mirrors the
 // single-project branch of `maestro run` minus the per-project HTTP server
 // (the daemon serves one shared FleetServer instead) and minus the fatal exit
@@ -175,28 +259,28 @@ func recoverFlow(flow *projectFlow, loop string) {
 // daemon down (#756). orchestrator.Run already log-and-continues on per-cycle
 // errors and returns nil on ctx cancellation.
 //
-// Store-driven hot-reload (#757): reloadCh is fed by configwatch.WatchStore from
-// the project's config-store row (the daemon's source of truth, #754), wired in
-// by startFlow. The daemon deliberately does NOT watch the import-time YAML — a
-// file the store supersedes — which would let the run loop drift from the
-// supervise loop. A nil reloadCh (store-watch disabled) leaves the orchestrator's
-// reload select arm inert.
+// Store-driven hot-reload (#757): reloadCh is fed by the flow's reload pump
+// (runReloadPump), which sources it from configwatch.WatchStore over the
+// project's config-store row (the daemon's source of truth, #754). The daemon
+// deliberately does NOT watch the import-time YAML — a file the store supersedes
+// — which would let the run loop drift from the supervise loop. A nil reloadCh
+// (store-watch disabled) leaves the orchestrator's reload select arm inert.
 func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config) {
 	// Hot-reload (reloadCh, #757) makes the orchestrator's reloadConfig mutate
 	// its config in place (field replacement). The supervise loop and the
-	// FleetProject HTTP snapshot share this exact cfg pointer, so hand the
-	// orchestrator a private shallow copy to mutate — the shared struct the
-	// other goroutines read is then never written, closing the reload data race.
-	// reloadConfig only REPLACES fields (o.cfg.X = newCfg.X), never mutates a
-	// slice/map element in place, so a shallow copy fully isolates it.
+	// FleetProject HTTP snapshot read the flow's config through a shared holder
+	// (#768) that the reload pump swaps atomically, so hand the orchestrator a
+	// private shallow copy to mutate — nothing the other goroutines read is ever
+	// written in place, keeping the #767 reload data race closed. reloadConfig
+	// only REPLACES fields (o.cfg.X = newCfg.X), never mutates a slice/map
+	// element in place, so a shallow copy fully isolates it.
 	//
-	// Trade-off / known limitation: a config-store edit is now applied LIVE only
-	// to the orchestrator. The supervise loop and the dashboard snapshot keep the
-	// startup config until the flow restarts — same as before #757, which had no
-	// daemon reload at all, so this is strictly better than main, not a regression.
-	// Making all three live-reload safely needs a synchronized config holder
-	// shared across orchestrator + supervisor + FleetProject — a follow-up, not an
-	// in-place mutation (which is the data race this copy removes).
+	// As of #768 a config-store edit reaches all three readers live: the pump
+	// stores the new config in the holder (supervisor + dashboard) and forwards
+	// it here for the orchestrator's selective reload. The orchestrator keeps the
+	// private-copy reload (rather than reading the holder) because reloadConfig
+	// detects restart-required fields and resets the poll ticker — it needs the
+	// reload event, not just the latest value.
 	orchCfg := *cfg
 	orch := orchestrator.New(&orchCfg)
 	orch.SetBinaryVersion(opts.Version)

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -228,16 +228,31 @@ func (d *Daemon) runReloadPump(ctx context.Context, flow *projectFlow, watchCh <
 			if newCfg == nil {
 				continue
 			}
-			// Holder first, so the supervise loop's next cycle and the rebuilt
+			// Identity / restart-required fields (repo, state_dir, session_prefix)
+			// cannot be hot-applied: the orchestrator, supervisor, watchdog, and the
+			// supervisor's GitHub client were all built from the flow's STARTUP
+			// identity. Storing a changed identity in the holder would make
+			// supervisor.RunOnce(getCfg(), gh) read a repo/state_dir the rest of the
+			// flow is not running on (gh is pinned to the startup repo). Skip the
+			// live update and tell the operator to restart the project (rm+add, which
+			// the diff-loop handles as a fresh flow); hot-reloadable edits still
+			// apply (#768, Codex).
+			if identityChanged(flow.cfg, newCfg) {
+				log.Printf("[%s] config reload: identity field (repo/state_dir/session_prefix) changed — restart required, live reload skipped", flow.name)
+				continue
+			}
+			// Holder first, so the supervise loop's next cycle and the updated
 			// dashboard snapshot below both observe the new config.
 			flow.holder.Store(newCfg)
 
-			// Replace the project in the fleet so /api/v1/fleet reflects the edit
-			// and fleet auth is re-derived. d.Fleet() is nil only during the brief
+			// Update the project's config IN PLACE so /api/v1/fleet reflects the edit
+			// and fleet auth is re-derived — WITHOUT rebuilding the FleetProject,
+			// which would drop the live board refresher + action GH client a full
+			// replacement discards (#768). d.Fleet() is nil only during the brief
 			// startup window before Run publishes it; no reload can arrive that
 			// early, but tolerate nil to be safe.
 			if fleet := d.Fleet(); fleet != nil {
-				fleet.AddProject(server.NewFleetProjectWithGitHubNamed(flow.name, newCfg))
+				fleet.UpdateProjectConfig(flow.name, newCfg)
 			}
 
 			// Forward to the orchestrator. Non-blocking with drop-if-not-drained,
@@ -250,6 +265,18 @@ func (d *Daemon) runReloadPump(ctx context.Context, flow *projectFlow, watchCh <
 			}
 		}
 	}
+}
+
+// identityChanged reports whether two configs differ in a flow-identity /
+// restart-required field that cannot be hot-applied to a running flow: the
+// orchestrator, supervisor, watchdog, and the supervisor's GitHub client are
+// all built once from these at startup. flowKey already keys on StateDir/Repo;
+// session_prefix names worker sessions. A change here needs a flow restart.
+func identityChanged(a, b *config.Config) bool {
+	if a == nil || b == nil {
+		return a != b
+	}
+	return a.Repo != b.Repo || a.StateDir != b.StateDir || a.SessionPrefix != b.SessionPrefix
 }
 
 // runOrchestrator is the production run loop for one flow. It mirrors the

--- a/internal/daemon/holder.go
+++ b/internal/daemon/holder.go
@@ -1,0 +1,48 @@
+package daemon
+
+import (
+	"sync/atomic"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// configHolder is the synchronized current-config cell for one project flow
+// (#768). The flow's reload pump stores a freshly loaded config on every
+// config-store edit; the supervisor loop reads it once per cycle and the
+// FleetProject dashboard snapshot is rebuilt from it, so a live edit reaches
+// every reader race-free without restarting the flow.
+//
+// It is backed by an atomic pointer: a reader always observes a complete config
+// because the pump swaps a whole pointer, never a half-written field. This is
+// the safe alternative to the in-place field mutation #767 had to give the
+// orchestrator a private copy to avoid — the supervisor and dashboard share the
+// holder's pointer, but nothing mutates the pointed-at config in place
+// (supervisor.RunOnce only reads it; the orchestrator still mutates its own
+// private shallow copy).
+type configHolder struct {
+	ptr atomic.Pointer[config.Config]
+}
+
+// newConfigHolder seeds the holder with the flow's startup config.
+func newConfigHolder(cfg *config.Config) *configHolder {
+	h := &configHolder{}
+	h.ptr.Store(cfg)
+	return h
+}
+
+// Load returns the flow's current config. Safe for concurrent use.
+func (h *configHolder) Load() *config.Config {
+	if h == nil {
+		return nil
+	}
+	return h.ptr.Load()
+}
+
+// Store swaps in a newly loaded config. A nil config is ignored so a failed
+// reload can never blank out the holder. Safe for concurrent use.
+func (h *configHolder) Store(cfg *config.Config) {
+	if h == nil || cfg == nil {
+		return
+	}
+	h.ptr.Store(cfg)
+}

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -25,15 +25,21 @@ import (
 // flows, so every cycle (including the first) is logged and retried. Persistent
 // failures still surface: the #499 watchdog flags SupervisorStuck when
 // LastRunOnceAt stops advancing.
-func runSupervise(ctx context.Context, name string, cfg *config.Config, interval time.Duration) {
-	gh := github.New(cfg.Repo)
+//
+// getCfg yields the flow's CURRENT config: the loop reads it once per cycle so
+// a live config-store edit (supervisor policy, labels, …) is applied without a
+// flow restart (#768). The GitHub client is built once from the startup repo —
+// repo is a restart-required field the orchestrator refuses to hot-apply, so it
+// is stable for the flow's lifetime.
+func runSupervise(ctx context.Context, name string, getCfg func() *config.Config, interval time.Duration) {
+	gh := github.New(getCfg().Repo)
 	// Capture and log each cycle's SupervisorDecision. The daemon still acts
 	// (label/comment/approve), but without this the structural "why did the
 	// supervisor do that" trail was dropped — turning debugging into journal
 	// archaeology (#764). Logs key on the unique fleet name (not the possibly
 	// shared session prefix) so two same-basename repos stay distinguishable.
 	runOnce := func() error {
-		decision, err := supervisor.RunOnce(cfg, gh)
+		decision, err := supervisor.RunOnce(getCfg(), gh)
 		if err != nil {
 			return err
 		}

--- a/internal/daemon/watch_test.go
+++ b/internal/daemon/watch_test.go
@@ -76,7 +76,7 @@ func (f *fakeWatchStore) ProjectsFingerprint(ctx context.Context) (map[string]ti
 	return out, nil
 }
 
-func newWatchDaemon(store ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, *config.Config, Options)) *Daemon {
+func newWatchDaemon(store ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, func() *config.Config, Options)) *Daemon {
 	d := New(store, Options{Host: "127.0.0.1", Port: 0, WatchStore: true, WatchStoreInterval: 25 * time.Millisecond})
 	if run != nil {
 		d.runLoop = run
@@ -175,7 +175,7 @@ func TestWatchStoreWiresReloadChannel(t *testing.T) {
 		}
 		<-ctx.Done()
 	}
-	sup := func(ctx context.Context, name string, cfg *config.Config, opts Options) { <-ctx.Done() }
+	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) { <-ctx.Done() }
 	d := newWatchDaemon(store, run, sup)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -188,6 +188,105 @@ func TestWatchStoreWiresReloadChannel(t *testing.T) {
 
 	cancel()
 	<-done
+}
+
+// #768: a config-store edit must reach the supervise loop AND the /api/v1/fleet
+// dashboard snapshot live — not only the orchestrator (the #757 limitation).
+// The supervise loop reads the flow's current config each cycle through the
+// shared holder; the dashboard is rebuilt from the same config on reload. The
+// flow is never restarted (same StateDir → same flow identity).
+func TestWatchStoreLiveReloadReachesSupervisorAndDashboard(t *testing.T) {
+	store := newFakeWatchStore()
+	cfg := testConfig(t, "owner/alpha")
+	cfg.MaxParallel = 1
+	store.Set("alpha", cfg)
+
+	// The supervise stub polls the holder via getCfg() and records the latest
+	// MaxParallel it observed, modelling the real loop reading config each cycle.
+	var seenMax int64
+	run := func(ctx context.Context, c *config.Config, opts Options, reloadCh <-chan *config.Config) {
+		<-ctx.Done()
+	}
+	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+		tick := time.NewTicker(3 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			atomic.StoreInt64(&seenMax, int64(getCfg().MaxParallel))
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+			}
+		}
+	}
+	d := newWatchDaemon(store, run, sup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	waitForNames(t, d, "alpha")
+	waitFor(t, func() bool { return atomic.LoadInt64(&seenMax) == 1 })
+	if got := fleetProjectMaxParallel(t, d, "alpha"); got != 1 {
+		t.Fatalf("dashboard max_parallel = %d, want 1 at startup", got)
+	}
+
+	// Live edit: same StateDir keeps the same flow; only MaxParallel changes.
+	edited := *cfg
+	edited.MaxParallel = 7
+	store.Set("alpha", &edited)
+
+	// The supervise loop observes the new config through the holder...
+	waitFor(t, func() bool { return atomic.LoadInt64(&seenMax) == 7 })
+	// ...and the dashboard snapshot reflects it too — both without a restart.
+	waitFor(t, func() bool { return fleetProjectMaxParallel(t, d, "alpha") == 7 })
+
+	// No new flow was started: the edit reloaded the existing one in place.
+	d.mu.Lock()
+	flows := len(d.flows)
+	d.mu.Unlock()
+	if flows != 1 {
+		t.Fatalf("flows = %d, want 1 (edit must reload in place, not restart)", flows)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancellation")
+	}
+}
+
+// fleetProjectMaxParallel reads max_parallel for the named project from the live
+// /api/v1/fleet snapshot, or -1 when the project is absent.
+func fleetProjectMaxParallel(t *testing.T, d *Daemon, name string) int {
+	t.Helper()
+	fleet := waitForFleet(t, d)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	rec := httptest.NewRecorder()
+	fleet.HandlerForTest().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/fleet = %d, want 200", rec.Code)
+	}
+	var resp struct {
+		Projects []struct {
+			Name        string `json:"name"`
+			MaxParallel int    `json:"max_parallel"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode fleet response: %v", err)
+	}
+	for _, p := range resp.Projects {
+		if p.Name == name {
+			return p.MaxParallel
+		}
+	}
+	return -1
 }
 
 func waitForNames(t *testing.T, d *Daemon, want ...string) {

--- a/internal/server/approvals.go
+++ b/internal/server/approvals.go
@@ -181,7 +181,7 @@ func (s *FleetServer) handleFleetApproval(w http.ResponseWriter, r *http.Request
 	// "every mutating POST without a valid credential returns 401". Read the
 	// checker once (#768) so both the gate and applyApprovalDecision below see
 	// the same live token even if a hot-add re-derives it concurrently.
-	auth := s.authChecker()
+	auth := s.liveAuth()
 	if _, ok := requireAuth(w, r, auth); !ok {
 		return
 	}

--- a/internal/server/approvals.go
+++ b/internal/server/approvals.go
@@ -178,8 +178,11 @@ func (s *FleetServer) handleFleetApproval(w http.ResponseWriter, r *http.Request
 	}
 	// #487: auth fires BEFORE path / project parsing so an unauthenticated
 	// probe cannot enumerate fleet topology via 404/400 differences. Spec:
-	// "every mutating POST without a valid credential returns 401".
-	if _, ok := requireAuth(w, r, s.auth); !ok {
+	// "every mutating POST without a valid credential returns 401". Read the
+	// checker once (#768) so both the gate and applyApprovalDecision below see
+	// the same live token even if a hot-add re-derives it concurrently.
+	auth := s.authChecker()
+	if _, ok := requireAuth(w, r, auth); !ok {
 		return
 	}
 	route, ok := parseApprovalPath("/api/v1/fleet/approvals/", r.URL.Path)
@@ -207,5 +210,5 @@ func (s *FleetServer) handleFleetApproval(w http.ResponseWriter, r *http.Request
 	if project.cfg != nil {
 		stateDir = project.cfg.StateDir
 	}
-	applyApprovalDecision(w, r, readOnly, fmt.Sprintf("fleet project %q", projectName), stateDir, route, s.auth)
+	applyApprovalDecision(w, r, readOnly, fmt.Sprintf("fleet project %q", projectName), stateDir, route, auth)
 }

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -319,6 +319,31 @@ func (s *FleetServer) AddProject(p FleetProject) {
 	s.reauthLocked()
 }
 
+// UpdateProjectConfig swaps the config of the project named name IN PLACE and
+// re-derives fleet auth, preserving everything else about the FleetProject —
+// crucially its board refresher state and safe-action GitHub client. A full
+// AddProject replacement would hand back a fresh FleetProject with an empty
+// *boardState that no refresher updates (the refresher goroutine, started once
+// at Serve, keeps writing the project's existing board pointer), so any config
+// edit for a github_projects project would silently stop the board rollup. Used
+// by the daemon's reload pump (#768): a config-store edit updates the dashboard
+// snapshot without dropping the live board. Reports whether a project was found.
+func (s *FleetServer) UpdateProjectConfig(name string, cfg *config.Config) bool {
+	if s == nil || cfg == nil {
+		return false
+	}
+	s.projectsMu.Lock()
+	defer s.projectsMu.Unlock()
+	for i := range s.projects {
+		if s.projects[i].Name == name {
+			s.projects[i].cfg = cfg
+			s.reauthLocked()
+			return true
+		}
+	}
+	return false
+}
+
 // RemoveProject drops the project with the given fleet name (daemon hot-remove,
 // #757) and reports whether one was found. Safe for concurrent use with the
 // HTTP read paths. The shared auth token is re-derived from the remaining set
@@ -374,11 +399,12 @@ func (s *FleetServer) setAuthChecker(a authChecker) {
 	s.authMu.Unlock()
 }
 
-// authChecker returns the live auth checker under the read lock. Every fleet
+// liveAuth returns the current auth checker under the read lock. Every fleet
 // handler reads through this so a runtime SetAuth / hot-add re-derivation is
 // applied to the next request without a server rebuild and without racing the
-// write (#768).
-func (s *FleetServer) authChecker() authChecker {
+// write (#768). Named liveAuth (not authChecker) so call sites don't read like
+// a conversion to the authChecker type.
+func (s *FleetServer) liveAuth() authChecker {
 	s.authMu.RLock()
 	defer s.authMu.RUnlock()
 	return s.auth
@@ -393,7 +419,7 @@ func (s *FleetServer) authChecker() authChecker {
 //
 // The middleware reads the live checker per request (#768) rather than
 // capturing it at build time, so a hot-add that enables auth gates the read
-// path too — not only the mutating endpoints (which read s.authChecker()
+// path too — not only the mutating endpoints (which read s.liveAuth()
 // directly).
 func (s *FleetServer) buildHandler() http.Handler {
 	mux := http.NewServeMux()
@@ -406,7 +432,7 @@ func (s *FleetServer) buildHandler() http.Handler {
 	mux.Handle("/static/", web.StaticHandler())
 	mux.HandleFunc("/", s.handleFleetDashboard)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		authMiddleware(mux, s.authChecker()).ServeHTTP(w, r)
+		authMiddleware(mux, s.liveAuth()).ServeHTTP(w, r)
 	})
 }
 
@@ -1096,7 +1122,7 @@ func (s *FleetServer) handleFleetAction(w http.ResponseWriter, r *http.Request) 
 	// #487: auth fires BEFORE the read-only gate so an unauthenticated POST
 	// always sees 401 (never 403/405). Spec: "every mutating POST without a
 	// valid credential returns 401".
-	authenticatedActor, ok := requireAuth(w, r, s.authChecker())
+	authenticatedActor, ok := requireAuth(w, r, s.liveAuth())
 	if !ok {
 		return
 	}
@@ -1203,7 +1229,7 @@ func (s *FleetServer) handleFleetAuditLog(w http.ResponseWriter, r *http.Request
 	// arbitrary entries that bury the real attack signal under noise. Auth
 	// fires BEFORE payload parsing so probes cannot enumerate the project
 	// list via 400 differences.
-	authenticatedActor, ok := requireAuth(w, r, s.authChecker())
+	authenticatedActor, ok := requireAuth(w, r, s.liveAuth())
 	if !ok {
 		return
 	}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -255,11 +255,18 @@ type FleetServer struct {
 	port       int
 	readOnly   bool
 	srv        *http.Server
+	// authMu guards auth so the daemon can re-derive the fleet token when a
+	// project is hot-added/removed/edited (#768) while HTTP handlers read it
+	// concurrently. Writes go through SetAuth / reauthLocked; reads through
+	// authChecker(). #768 makes SetAuth a RUNTIME write (AddProject/RemoveProject
+	// re-derive auth), which without this lock would race the handlers reading
+	// s.auth — a data race under `go test -race`.
+	authMu sync.RWMutex
 	// auth gates every mutating fleet endpoint (#487, write-path premortem
 	// #4). When the resolved token is empty the checker is disabled and
 	// behaviour is unchanged; when non-empty, /api/v1/fleet/actions,
 	// /api/v1/fleet/approvals/{id}/{approve|reject}, and /api/v1/audit/log
-	// require Authorization: Bearer <token>.
+	// require Authorization: Bearer <token>. Always accessed under authMu.
 	auth authChecker
 }
 
@@ -289,6 +296,12 @@ func (s *FleetServer) projectsSnapshot() []FleetProject {
 // whose Name already exists is replaced in place rather than duplicated, so the
 // fleet's by-name addressing (findProject) stays unambiguous. Safe for
 // concurrent use with the HTTP read paths.
+//
+// The fleet's shared auth token is re-derived from the resulting project set
+// (#768): a hot-added project whose config carries server.auth.token_env starts
+// enforcing auth on the mutating endpoints without a daemon restart. Editing a
+// project's row goes through the same path (the daemon replaces the project in
+// place on reload).
 func (s *FleetServer) AddProject(p FleetProject) {
 	if s == nil {
 		return
@@ -298,15 +311,18 @@ func (s *FleetServer) AddProject(p FleetProject) {
 	for i := range s.projects {
 		if s.projects[i].Name == p.Name {
 			s.projects[i] = p
+			s.reauthLocked()
 			return
 		}
 	}
 	s.projects = append(s.projects, p)
+	s.reauthLocked()
 }
 
 // RemoveProject drops the project with the given fleet name (daemon hot-remove,
 // #757) and reports whether one was found. Safe for concurrent use with the
-// HTTP read paths.
+// HTTP read paths. The shared auth token is re-derived from the remaining set
+// (#768) — removing the last token-bearing project disables auth again.
 func (s *FleetServer) RemoveProject(name string) bool {
 	if s == nil {
 		return false
@@ -316,20 +332,31 @@ func (s *FleetServer) RemoveProject(name string) bool {
 	for i := range s.projects {
 		if s.projects[i].Name == name {
 			s.projects = append(s.projects[:i], s.projects[i+1:]...)
+			s.reauthLocked()
 			return true
 		}
 	}
 	return false
 }
 
+// reauthLocked re-derives the fleet's shared auth token from the current
+// project set and stores it under authMu (#768). The caller MUST hold
+// projectsMu (lock order projectsMu→authMu), so the project mutation and the
+// auth derivation it implies are one atomic step as far as any concurrent
+// handler is concerned.
+func (s *FleetServer) reauthLocked() {
+	s.setAuthChecker(newAuthChecker(FleetAuthFromProjects(s.projects)))
+}
+
 // SetAuth configures fleet-level auth from the operator's resolved
 // ServerAuthConfig. Empty token leaves auth disabled (backward-compat).
-// Call this BEFORE Start.
+// Safe to call before Start and at runtime (the handlers read the checker
+// live, #768).
 func (s *FleetServer) SetAuth(cfg config.ServerAuthConfig) {
 	if s == nil {
 		return
 	}
-	s.auth = newAuthChecker(cfg)
+	s.setAuthChecker(newAuthChecker(cfg))
 }
 
 // SetAuthForTest replaces the auth checker. Test-only helper.
@@ -337,7 +364,24 @@ func (s *FleetServer) SetAuthForTest(token, actorName string) {
 	if s == nil {
 		return
 	}
-	s.auth = newAuthCheckerForTest(token, actorName)
+	s.setAuthChecker(newAuthCheckerForTest(token, actorName))
+}
+
+// setAuthChecker stores the auth checker under authMu.
+func (s *FleetServer) setAuthChecker(a authChecker) {
+	s.authMu.Lock()
+	s.auth = a
+	s.authMu.Unlock()
+}
+
+// authChecker returns the live auth checker under the read lock. Every fleet
+// handler reads through this so a runtime SetAuth / hot-add re-derivation is
+// applied to the next request without a server rebuild and without racing the
+// write (#768).
+func (s *FleetServer) authChecker() authChecker {
+	s.authMu.RLock()
+	defer s.authMu.RUnlock()
+	return s.auth
 }
 
 // buildHandler returns the fleet mux wrapped with the auth middleware.
@@ -346,6 +390,11 @@ func (s *FleetServer) SetAuthForTest(token, actorName string) {
 // POSTs — rejects unauthenticated requests with 401 before the inner
 // handler runs. When auth is disabled (default LAN posture), the
 // middleware is a pass-through.
+//
+// The middleware reads the live checker per request (#768) rather than
+// capturing it at build time, so a hot-add that enables auth gates the read
+// path too — not only the mutating endpoints (which read s.authChecker()
+// directly).
 func (s *FleetServer) buildHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/fleet/worker", s.handleFleetWorker)
@@ -356,7 +405,9 @@ func (s *FleetServer) buildHandler() http.Handler {
 	mux.HandleFunc("/approvals/audit", s.handleFleetApprovalAudit)
 	mux.Handle("/static/", web.StaticHandler())
 	mux.HandleFunc("/", s.handleFleetDashboard)
-	return authMiddleware(mux, s.auth)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authMiddleware(mux, s.authChecker()).ServeHTTP(w, r)
+	})
 }
 
 // HandlerForTest exposes the wrapped handler so tests can exercise the
@@ -1045,7 +1096,7 @@ func (s *FleetServer) handleFleetAction(w http.ResponseWriter, r *http.Request) 
 	// #487: auth fires BEFORE the read-only gate so an unauthenticated POST
 	// always sees 401 (never 403/405). Spec: "every mutating POST without a
 	// valid credential returns 401".
-	authenticatedActor, ok := requireAuth(w, r, s.auth)
+	authenticatedActor, ok := requireAuth(w, r, s.authChecker())
 	if !ok {
 		return
 	}
@@ -1152,7 +1203,7 @@ func (s *FleetServer) handleFleetAuditLog(w http.ResponseWriter, r *http.Request
 	// arbitrary entries that bury the real attack signal under noise. Auth
 	// fires BEFORE payload parsing so probes cannot enumerate the project
 	// list via 400 differences.
-	authenticatedActor, ok := requireAuth(w, r, s.auth)
+	authenticatedActor, ok := requireAuth(w, r, s.authChecker())
 	if !ok {
 		return
 	}

--- a/internal/server/fleet_runtime_test.go
+++ b/internal/server/fleet_runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/befeast/maestro/internal/config"
@@ -62,4 +63,118 @@ func TestFleetAddRemoveProjectVisibleInAPI(t *testing.T) {
 	if s.RemoveProject("alpha") {
 		t.Fatal("RemoveProject of a missing project should report false")
 	}
+}
+
+// #768: hot-adding a project whose config sets server.auth.token_env must make
+// the fleet start enforcing auth — on both the global read gate (the middleware
+// reads the live checker) and the mutating endpoints (which read it directly) —
+// without a server rebuild. Removing the last token-bearing project disables it
+// again. s.auth reads/writes are synchronized, so this is also a -race probe of
+// the AddProject/RemoveProject re-derivation against the handler reads.
+func TestFleetHotAddReDerivesAuth(t *testing.T) {
+	const tokenEnv = "MAESTRO_TEST_FLEET_TOKEN_768"
+	t.Setenv(tokenEnv, "good-token")
+
+	s := NewFleet(nil, "127.0.0.1", 0, false)
+
+	// status hits the global read gate (GET /api/v1/fleet) with the given
+	// Authorization header (empty = none).
+	status := func(authz string) int {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+		if authz != "" {
+			req.Header.Set("Authorization", authz)
+		}
+		rec := httptest.NewRecorder()
+		s.HandlerForTest().ServeHTTP(rec, req)
+		return rec.Code
+	}
+	// mutatingStatus hits a mutating endpoint (POST /api/v1/fleet/actions).
+	mutatingStatus := func(authz string) int {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/actions", nil)
+		if authz != "" {
+			req.Header.Set("Authorization", authz)
+		}
+		rec := httptest.NewRecorder()
+		s.HandlerForTest().ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// No token-bearing project yet → auth disabled: reads are open and the
+	// mutating endpoint does not 401.
+	if got := status(""); got != http.StatusOK {
+		t.Fatalf("read with auth disabled = %d, want 200", got)
+	}
+	if got := mutatingStatus(""); got == http.StatusUnauthorized {
+		t.Fatalf("mutating endpoint 401 with auth disabled, want non-401 (got %d)", got)
+	}
+
+	// Hot-add a token-bearing project. AddProject must re-derive auth.
+	s.AddProject(NewFleetProjectWithGitHubNamed("secure", &config.Config{
+		Repo: "owner/secure",
+		Server: config.ServerConfig{
+			Auth: config.ServerAuthConfig{TokenEnv: tokenEnv},
+		},
+	}))
+
+	if got := status(""); got != http.StatusUnauthorized {
+		t.Fatalf("read after hot-add of token-bearing project = %d, want 401", got)
+	}
+	if got := mutatingStatus(""); got != http.StatusUnauthorized {
+		t.Fatalf("mutating endpoint after hot-add = %d, want 401", got)
+	}
+	if got := status("Bearer good-token"); got != http.StatusOK {
+		t.Fatalf("read with valid bearer = %d, want 200", got)
+	}
+	if got := mutatingStatus("Bearer good-token"); got == http.StatusUnauthorized {
+		t.Fatalf("mutating endpoint 401 with valid bearer, want non-401 (got %d)", got)
+	}
+
+	// Removing the last token-bearing project disables auth again.
+	if !s.RemoveProject("secure") {
+		t.Fatal("RemoveProject(secure) = false, want true")
+	}
+	if got := status(""); got != http.StatusOK {
+		t.Fatalf("read after removing token-bearing project = %d, want 200 (auth disabled)", got)
+	}
+	if got := mutatingStatus(""); got == http.StatusUnauthorized {
+		t.Fatalf("mutating endpoint 401 after auth disabled, want non-401 (got %d)", got)
+	}
+}
+
+// #768: AddProject/RemoveProject re-derive s.auth while HTTP handlers read it.
+// Run the two concurrently so `go test -race` flags any unsynchronized access.
+func TestFleetAuthReadWriteRaceFree(t *testing.T) {
+	const tokenEnv = "MAESTRO_TEST_FLEET_TOKEN_768_RACE"
+	t.Setenv(tokenEnv, "good-token")
+
+	s := NewFleet(nil, "127.0.0.1", 0, false)
+	tokenCfg := &config.Config{
+		Repo:   "owner/secure",
+		Server: config.ServerConfig{Auth: config.ServerAuthConfig{TokenEnv: tokenEnv}},
+	}
+
+	var wg sync.WaitGroup
+	// Writers: churn the token-bearing project in and out, re-deriving auth.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			s.AddProject(NewFleetProjectWithGitHubNamed("secure", tokenCfg))
+			s.RemoveProject("secure")
+		}
+	}()
+	// Readers: hammer both the read gate and a mutating endpoint.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				get := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+				s.HandlerForTest().ServeHTTP(httptest.NewRecorder(), get)
+				post := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/actions", nil)
+				s.HandlerForTest().ServeHTTP(httptest.NewRecorder(), post)
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Implements #768

## Changes

Closes the two runtime-mutation gaps the #767 review deferred — both needed a synchronized runtime holder rather than the in-place mutation Phase 2 used.

**Live config reload reaches all three readers (was: orchestrator only)**
- Each flow owns a `configHolder` (`atomic.Pointer[config.Config]`). A single reload pump (`runReloadPump`) consumes the store watcher and fans every config-store edit out to the holder (supervisor + dashboard), the FleetServer project entry (rebuilt in place), and the orchestrator (forwarded on its own channel, keeping selective `reloadConfig` + restart-required detection over its private shallow copy).
- The supervise loop reads the holder each cycle (`getCfg` closure), so a changed supervisor policy / labels is applied without a flow restart; the `/api/v1/fleet` snapshot is rebuilt from the same config.

**Fleet auth re-derived on add/remove/edit, race-free**
- `FleetServer.auth` is guarded by `authMu`; `SetAuth`/`reauthLocked` write, `authChecker()` reads. `AddProject`/`RemoveProject` re-derive the shared token from the resulting project set, so a hot-added token-bearing project starts enforcing auth (and removing the last one disables it). The read-path middleware reads the live checker per request, so the gate reflects a hot-add too — not only the mutating endpoints.

Nothing mutates the shared config in place (`supervisor.RunOnce` only reads it; the orchestrator still mutates its own copy), so the #767 reload data race is not reintroduced.

## Testing

- `go test -race ./internal/daemon/... ./internal/server/... ./internal/supervisor/... ./internal/orchestrator/...`
- `go test ./...`
- `go build ./cmd/maestro/`

New tests: live supervisor+dashboard reload through the holder; hot-add re-derives auth on both the read gate and the mutating endpoints; `AddProject`/`RemoveProject` vs handler reads concurrently under `-race`.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes two runtime-mutation gaps from the Phase 2 (#767) hot-reload work: live config edits now reach the supervise loop and the dashboard snapshot (not just the orchestrator), and fleet auth is re-derived race-free whenever a project is added, removed, or edited.

- A new `configHolder` (`atomic.Pointer[config.Config]`) is introduced per flow and a fan-out `runReloadPump` goroutine consumes the store watcher, atomically swapping the holder (supervisor + dashboard) and forwarding to `orchReloadCh` for the orchestrator's selective `reloadConfig`. Identity-field changes (repo/state_dir/session_prefix) are detected and skipped in the pump, with a log message directing the operator to restart the project.
- `FleetServer.auth` is now guarded by `authMu sync.RWMutex`; writes go through `setAuthChecker`/`reauthLocked` (called with `projectsMu` already held, maintaining a consistent lock order), reads through `liveAuth()`; every mutating handler and the auth middleware now call `liveAuth()` per request so a hot-added token-bearing project takes effect immediately without a server rebuild.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the concurrency design (atomic pointer, RWMutex with consistent lock ordering, non-closing orchReloadCh) is correct, identity-field guard prevents the supervise loop from reading a mismatched config, and both functional and race-detector tests cover the new paths.

The lock ordering (projectsMu → authMu) is enforced consistently: every write to s.auth is through setAuthChecker which only acquires authMu, while callers that mutate s.projects first (AddProject/RemoveProject/UpdateProjectConfig) always hold projectsMu before calling reauthLocked. The WaitGroup sequencing in startFlow is correct — all Add calls precede the reaper goroutine's Wait. The reload pump correctly skips nil and identity-changed configs and never closes orchReloadCh.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/daemon/flow.go | Introduces configHolder per flow and the fan-out reload pump; WaitGroup sequencing and lock-free orchReloadCh nil semantics are correct. |
| internal/server/fleet.go | Adds authMu RWMutex guarding s.auth; all write paths go through setAuthChecker, all read paths go through liveAuth(); lock order projectsMu→authMu is consistently maintained. |
| internal/daemon/holder.go | New atomic config holder — correctly seeds with startup config, nil-guards Load/Store, and never mutates pointed-at config in place. |
| internal/daemon/supervise.go | runSupervise now accepts getCfg closure instead of a fixed *config.Config; GitHub client correctly pinned to startup Repo (a restart-required field). |
| internal/daemon/watch_test.go | New TestWatchStoreLiveReloadReachesSupervisorAndDashboard covers the holder fan-out; fleetProjectMaxParallel helper exercises the dashboard endpoint end-to-end. |
| internal/server/fleet_runtime_test.go | TestFleetHotAddReDerivesAuth and TestFleetAuthReadWriteRaceFree directly exercise both the functional and race-detector correctness of the new auth derivation path. |

<sub>Reviews (2): Last reviewed commit: ["daemon/fleet: address #769 review findin..."](https://github.com/befeast/maestro/commit/811c62de6e4bf44887a1c8a4028389653ffabdc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39505457)</sub>

<!-- /greptile_comment -->