### PR TITLE
Phase 3: централизованный self-deploy на уровне демона → рестарт ОДНОГО юнита

### DIFF
--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -39,13 +39,18 @@ func daemonCmd(args []string) {
 	defer store.Close()
 
 	d := daemon.New(store, daemon.Options{
-		Host:               *host,
-		Port:               *port,
-		RunInterval:        *runInterval,
-		SuperviseInterval:  *superviseInterval,
-		PromptPath:         *promptPath,
-		Version:            resolveVersion(),
-		ReadOnly:           *readOnly,
+		Host:              *host,
+		Port:              *port,
+		RunInterval:       *runInterval,
+		SuperviseInterval: *superviseInterval,
+		PromptPath:        *promptPath,
+		Version:           resolveVersion(),
+		ReadOnly:          *readOnly,
+		// Centralized self-deploy debounce marker (#758): one shared location next
+		// to the config store so every flow's RequestSelfDeploy debounces on the
+		// same marker, and it survives the daemon being restarted by its own
+		// deploy (#722).
+		SelfDeployStateDir: filepath.Join(filepath.Dir(*storePath), "self-deploy"),
 		WatchStore:         *watchStore,
 		WatchStoreInterval: *watchStoreInterval,
 	})

--- a/docs/self-deploy-runbook.md
+++ b/docs/self-deploy-runbook.md
@@ -122,6 +122,28 @@ guards make that configuration converge. Re-enable `self_deploy` on the dogfood
 orchestrator only after validating a deploy → verify-pass → no-re-trigger cycle
 on an idle fleet.
 
+### Centralized trigger under the daemon (#758)
+
+Under `maestro daemon` (epic #754, the single-service redesign), the fleet is N
+project flows in one process restarting one shared `maestro.service` unit — not
+N units. If each flow fired its own `selfdeploy.Trigger` on merge, a wave of
+merges across projects would restart that one unit N times: a thundering herd.
+
+So the daemon **centralizes the trigger**. Each flow's orchestrator signals
+`Daemon.RequestSelfDeploy(pr)` instead of deploying directly, and the daemon
+debounces every flow against a **single shared marker** (in-memory plus an
+on-disk `self-deploy-last-trigger.json` next to the config store, so it survives
+the daemon being restarted by its own deploy). The first merge in a wave
+launches exactly **one** deploy of **one** unit; the rest are debounced. The
+post-restart health probe is routed to the single fleet endpoint
+(`http://<host>:<port>/api/v1/fleet`, default `:8786`), whose snapshot carries
+the `version` field the script SHA-matches — so result and verify both go
+through one endpoint rather than a per-project server the daemon no longer runs.
+
+The default `units: ["maestro.service"]` (`config.EffectiveUnits`) keeps the
+restart to that one unit. The legacy per-project `maestro run`/`serve` paths are
+unchanged: there each orchestrator still debounces on its own state dir.
+
 ### Scope: user vs system units (#716)
 
 `scope` selects which systemd manager owns the units:

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -118,6 +118,15 @@ type Daemon struct {
 	selfDeployLast    time.Time
 	selfDeployLastPR  int
 	selfDeployTrigger func(cfg *config.Config, prNumber int) error
+	// selfDeployWindow is the longest debounce window any flow has requested, so
+	// the shared marker debounces on the max — a short-window flow cannot bypass
+	// a long-window flow's in-flight deploy (#758). Guarded by selfDeployMu.
+	selfDeployWindow time.Duration
+	// fleetAuthTokenEnv is the env var of the fleet's single shared auth token
+	// (server.FleetAuthFromProjects over the startup project set), used to
+	// authenticate the post-merge self-deploy health probe against /api/v1/fleet
+	// (#758). Set once in Run before flows start, then read-only.
+	fleetAuthTokenEnv string
 
 	// runLoop, superviseLoop, and watchdogLoop build the per-project loops.
 	// They default to the production orchestrator + supervisor wiring; tests
@@ -242,7 +251,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// One FleetServer for the whole fleet — replaces the N per-project
 	// server.New instances the legacy run/serve paths spun up (#516).
 	fleet := server.NewFleet(projects, d.opts.Host, d.opts.Port, d.opts.ReadOnly)
-	fleet.SetAuth(server.FleetAuthFromProjects(projects))
+	fleetAuth := server.FleetAuthFromProjects(projects)
+	fleet.SetAuth(fleetAuth)
+	// Capture the fleet's shared auth token env so the self-deploy health probe
+	// authenticates against /api/v1/fleet with the SAME token the server enforces
+	// — not the triggering flow's, which may differ or be empty (#758). Set here,
+	// before any flow starts, so RequestSelfDeploy reads it race-free.
+	d.fleetAuthTokenEnv = strings.TrimSpace(fleetAuth.TokenEnv)
 
 	// Bind the fleet port BEFORE starting any flow. If the port is already held
 	// (a legacy maestro@ unit, a second daemon), Listen fails here and we abort

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/configwatch"
+	"github.com/befeast/maestro/internal/selfdeploy"
 	"github.com/befeast/maestro/internal/server"
 	"github.com/befeast/maestro/internal/supervisor"
 )
@@ -68,6 +69,16 @@ type Options struct {
 	// ReadOnly disables the fleet's mutating HTTP endpoints.
 	ReadOnly bool
 
+	// SelfDeployStateDir is the shared directory the centralized self-deploy
+	// debounce marker lives in (#758). The orchestrator flows no longer each fire
+	// their own selfdeploy.Trigger; they signal Daemon.RequestSelfDeploy, which
+	// debounces on a SINGLE marker so N flows merging PRs near-simultaneously
+	// launch exactly ONE deploy of ONE unit. A per-flow StateDir cannot dedup
+	// across flows, so the daemon owns one shared marker dir that also survives
+	// the daemon being restarted by its own deploy (#722). Blank disables the
+	// on-disk marker; the in-process mutex still dedups within a single run.
+	SelfDeployStateDir string
+
 	// WatchStore enables DB-driven hot add/remove/reload of projects (#757):
 	// a diff-loop over the store's ProjectsFingerprint starts a flow for a new
 	// project name and drains one for a removed name, and each flow's
@@ -95,6 +106,18 @@ type Daemon struct {
 	mu    sync.Mutex
 	fleet *server.FleetServer
 	flows map[string]*projectFlow
+
+	// Centralized self-deploy (#758). RequestSelfDeploy serializes on
+	// selfDeployMu and debounces on a single marker — the in-memory
+	// selfDeployLast (deterministic within this process) plus the on-disk marker
+	// in opts.SelfDeployStateDir (survives the daemon restarting itself) — so a
+	// burst of merges across flows fires exactly ONE deploy. selfDeployTrigger is
+	// the launcher, defaulting to selfdeploy.Trigger; tests override it to count
+	// launches without touching systemd.
+	selfDeployMu      sync.Mutex
+	selfDeployLast    time.Time
+	selfDeployLastPR  int
+	selfDeployTrigger func(cfg *config.Config, prNumber int) error
 
 	// runLoop, superviseLoop, and watchdogLoop build the per-project loops.
 	// They default to the production orchestrator + supervisor wiring; tests
@@ -145,11 +168,13 @@ func New(store ConfigLoader, opts Options) *Daemon {
 			log.Printf("[daemon] --watch-store requested but the config store does not support per-project reload; disabling hot add/remove/reload")
 		}
 	}
-	d.runLoop = runOrchestrator
+	d.runLoop = d.runOrchestrator
 	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
 		runSupervise(ctx, name, getCfg, opts.SuperviseInterval)
 	}
 	d.watchdogLoop = supervisor.Watchdog
+	// Default to the real launcher; tests swap it for a counter (#758).
+	d.selfDeployTrigger = selfdeploy.Trigger
 	return d
 }
 

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -292,7 +292,12 @@ func identityChanged(a, b *config.Config) bool {
 // deliberately does NOT watch the import-time YAML — a file the store supersedes
 // — which would let the run loop drift from the supervise loop. A nil reloadCh
 // (store-watch disabled) leaves the orchestrator's reload select arm inert.
-func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config) {
+//
+// It is a method so the orchestrator's self-deploy launcher can be wired to the
+// daemon's centralized, cross-flow-debounced RequestSelfDeploy (#758): each
+// flow signals the daemon instead of firing its own selfdeploy.Trigger, so a
+// burst of merges across flows launches exactly ONE deploy of ONE unit.
+func (d *Daemon) runOrchestrator(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config) {
 	// Hot-reload (reloadCh, #757) makes the orchestrator's reloadConfig mutate
 	// its config in place (field replacement). The supervise loop and the
 	// FleetProject HTTP snapshot read the flow's config through a shared holder
@@ -311,6 +316,18 @@ func runOrchestrator(ctx context.Context, cfg *config.Config, opts Options, relo
 	orchCfg := *cfg
 	orch := orchestrator.New(&orchCfg)
 	orch.SetBinaryVersion(opts.Version)
+	// Route post-merge self-deploy through the daemon's centralized,
+	// cross-flow-debounced launcher (#758) instead of this flow firing its own
+	// selfdeploy.Trigger. The closure passes the orchestrator's OWN config
+	// pointer (&orchCfg, == o.cfg) — the live, reload-mutated config the prior
+	// per-flow selfdeploy.Trigger(o.cfg, …) used, supplying the build inputs
+	// (local_path/self_deploy/state_dir). It runs in the orchestrator goroutine
+	// (synchronous in triggerSelfDeploy), the same goroutine that mutates orchCfg
+	// on reload, so reading it here is race-free. The daemon overlays the
+	// single-endpoint health probe.
+	orch.SetSelfDeployStartFn(func(prNumber int) error {
+		return d.RequestSelfDeploy(&orchCfg, prNumber)
+	})
 	if err := orch.LoadPromptBase(opts.PromptPath); err != nil {
 		log.Printf("[%s] warn: load prompt: %v", cfg.SessionPrefix, err)
 	}

--- a/internal/daemon/selfdeploy.go
+++ b/internal/daemon/selfdeploy.go
@@ -1,0 +1,119 @@
+package daemon
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/selfdeploy"
+)
+
+// RequestSelfDeploy is the daemon's centralized post-merge self-deploy trigger
+// (#758). Before this, every orchestrator flow called selfdeploy.Trigger
+// directly and debounced on its OWN per-project StateDir marker — so N flows
+// merging PRs near-simultaneously each fired a deploy, a thundering herd that
+// restarts the maestro unit N times and bounces the fleet mid-verify (#722).
+//
+// The daemon collapses that to a single authority: each flow's orchestrator
+// signals here (wired through Orchestrator.SetSelfDeployStartFn), and this
+// method serializes on selfDeployMu and debounces on a SINGLE marker spanning
+// every flow. The first request in a merge wave launches exactly ONE deploy of
+// ONE unit; the rest return selfdeploy.ErrDebounced, which the orchestrator
+// treats as a benign skip rather than a failure.
+//
+// The debounce reads the most-recent trigger from two sources: an in-memory
+// timestamp (deterministic within this process, so two goroutines racing in
+// here can never both deploy) and the on-disk marker in
+// opts.SelfDeployStateDir (so a daemon restarted by its OWN deploy still
+// debounces the wave that triggered it). cfg is the requesting flow's config,
+// supplying the build inputs (local_path, self_deploy block, state_dir); the
+// post-restart health probe is routed through the single fleet endpoint so
+// verify hits one :port, not a per-project server the daemon no longer runs.
+func (d *Daemon) RequestSelfDeploy(cfg *config.Config, prNumber int) error {
+	if cfg == nil {
+		return fmt.Errorf("self-deploy: nil config")
+	}
+
+	d.selfDeployMu.Lock()
+	defer d.selfDeployMu.Unlock()
+
+	now := time.Now().UTC()
+	window := time.Duration(cfg.SelfDeploy.EffectiveMinIntervalMinutes()) * time.Minute
+
+	// Most-recent trigger across the in-memory marker (this process) and the
+	// shared on-disk marker. Either one inside the window debounces.
+	last, lastPR := d.selfDeployLast, d.selfDeployLastPR
+	if t, pr, ok := selfdeploy.LastTrigger(d.opts.SelfDeployStateDir); ok && t.After(last) {
+		last, lastPR = t, pr
+	}
+	if !last.IsZero() {
+		if since := now.Sub(last); since >= 0 && since < window {
+			log.Printf("[daemon] self-deploy debounced for PR #%d: last trigger (PR #%d) was %s ago (< %s window) — one deploy per merge wave", prNumber, lastPR, since.Round(time.Second), window)
+			return selfdeploy.ErrDebounced
+		}
+	}
+
+	if err := d.selfDeployTrigger(d.selfDeployConfig(cfg), prNumber); err != nil {
+		return err
+	}
+
+	// Record on BOTH markers only after a successful launch, so a pure launcher
+	// failure (systemd-run rejected the unit) does not suppress the next attempt.
+	d.selfDeployLast, d.selfDeployLastPR = now, prNumber
+	if err := selfdeploy.RecordTrigger(d.opts.SelfDeployStateDir, prNumber, now); err != nil {
+		log.Printf("[daemon] self-deploy shared trigger marker write failed for PR #%d: %v", prNumber, err)
+	}
+	log.Printf("[daemon] self-deploy launched for PR #%d — one unit, single deploy debounced across flows", prNumber)
+	return nil
+}
+
+// selfDeployConfig builds the config handed to the launcher from the requesting
+// flow's config, overriding only what the centralized single-service model
+// demands (#758):
+//
+//   - health probe routed to the SINGLE fleet endpoint (:port/api/v1/fleet,
+//     which carries the running binary's version field) so verify hits one
+//     endpoint. The daemon serves no per-project HTTP server, so the script's
+//     default <server.port>/api/v1/state target would be a dead URL — we both
+//     set the fleet URL and zero the requesting flow's Server.Port so the
+//     derive-from-server fallback cannot resurface it. An explicit
+//     self_deploy.health_url is respected; with no fleet port bound (port 0)
+//     the probe is left empty for CLI-only verify.
+//
+// Units are left to config.EffectiveUnits, which already defaults to the single
+// ["maestro.service"], so the restart touches exactly one unit. The shallow
+// copy keeps the flow's own config untouched.
+func (d *Daemon) selfDeployConfig(cfg *config.Config) *config.Config {
+	dc := *cfg
+	sd := cfg.SelfDeploy
+	if strings.TrimSpace(sd.HealthURL) == "" {
+		sd.HealthURL = d.fleetHealthURL() // "" when no fleet port is bound
+		dc.Server.Port = 0                // never derive a dead per-project URL
+		// Carry the auth token env so the probe authenticates against the single
+		// endpoint, defaulting to the flow's own server auth env.
+		if sd.HealthURL != "" && strings.TrimSpace(sd.HealthTokenEnv) == "" {
+			sd.HealthTokenEnv = strings.TrimSpace(cfg.Server.Auth.TokenEnv)
+		}
+	}
+	dc.SelfDeploy = sd
+	return &dc
+}
+
+// fleetHealthURL is the single endpoint the post-restart health probe targets:
+// the daemon's fleet snapshot, which surfaces the running binary's version
+// (#698) the script SHA-matches against the deployed commit. Empty when no web
+// endpoint is bound (port 0).
+func (d *Daemon) fleetHealthURL() string {
+	if d.opts.Port <= 0 {
+		return ""
+	}
+	host := strings.TrimSpace(d.opts.Host)
+	if host == "" || host == "0.0.0.0" {
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("http://%s/api/v1/fleet", net.JoinHostPort(host, strconv.Itoa(d.opts.Port)))
+}

--- a/internal/daemon/selfdeploy.go
+++ b/internal/daemon/selfdeploy.go
@@ -42,7 +42,15 @@ func (d *Daemon) RequestSelfDeploy(cfg *config.Config, prNumber int) error {
 	defer d.selfDeployMu.Unlock()
 
 	now := time.Now().UTC()
-	window := time.Duration(cfg.SelfDeploy.EffectiveMinIntervalMinutes()) * time.Minute
+	// Debounce on the LONGEST min_interval any flow has ever requested, not just
+	// the requesting flow's. The marker is shared across flows, so deriving the
+	// window per-caller would let a flow with a short min_interval fire a second
+	// deploy inside a flow with a longer one's window — while that flow's build
+	// may still be in flight, defeating the single-deploy guarantee (#758).
+	if w := time.Duration(cfg.SelfDeploy.EffectiveMinIntervalMinutes()) * time.Minute; w > d.selfDeployWindow {
+		d.selfDeployWindow = w
+	}
+	window := d.selfDeployWindow
 
 	// Most-recent trigger across the in-memory marker (this process) and the
 	// shared on-disk marker. Either one inside the window debounces.
@@ -92,11 +100,16 @@ func (d *Daemon) selfDeployConfig(cfg *config.Config) *config.Config {
 	sd := cfg.SelfDeploy
 	if strings.TrimSpace(sd.HealthURL) == "" {
 		sd.HealthURL = d.fleetHealthURL() // "" when no fleet port is bound
-		dc.Server.Port = 0                // never derive a dead per-project URL
-		// Carry the auth token env so the probe authenticates against the single
-		// endpoint, defaulting to the flow's own server auth env.
-		if sd.HealthURL != "" && strings.TrimSpace(sd.HealthTokenEnv) == "" {
-			sd.HealthTokenEnv = strings.TrimSpace(cfg.Server.Auth.TokenEnv)
+		if sd.HealthURL != "" {
+			dc.Server.Port = 0 // never derive a dead per-project URL
+			// Authenticate the probe against the single fleet endpoint. The fleet
+			// uses ONE shared token derived via server.FleetAuthFromProjects (the
+			// first token-bearing project), NOT necessarily the requesting flow's:
+			// using the triggering flow's env would send the wrong (or empty)
+			// token and the probe would 401, rolling back a healthy daemon (#758).
+			if strings.TrimSpace(sd.HealthTokenEnv) == "" {
+				sd.HealthTokenEnv = d.fleetAuthTokenEnv
+			}
 		}
 	}
 	dc.SelfDeploy = sd
@@ -112,8 +125,13 @@ func (d *Daemon) fleetHealthURL() string {
 		return ""
 	}
 	host := strings.TrimSpace(d.opts.Host)
-	if host == "" || host == "0.0.0.0" {
+	switch host {
+	case "", "0.0.0.0":
 		host = "127.0.0.1"
+	case "::":
+		// IPv6 all-interfaces: probe the loopback, not the any-address, matching
+		// the 0.0.0.0 → 127.0.0.1 treatment.
+		host = "::1"
 	}
 	return fmt.Sprintf("http://%s/api/v1/fleet", net.JoinHostPort(host, strconv.Itoa(d.opts.Port)))
 }

--- a/internal/daemon/selfdeploy_test.go
+++ b/internal/daemon/selfdeploy_test.go
@@ -1,0 +1,166 @@
+package daemon
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/selfdeploy"
+)
+
+func selfDeployCfg(t *testing.T, repo string) *config.Config {
+	t.Helper()
+	return &config.Config{
+		Repo:      repo,
+		LocalPath: t.TempDir(),
+		StateDir:  t.TempDir(),
+		SelfDeploy: config.SelfDeployConfig{
+			Enabled:            true,
+			MinIntervalMinutes: 30,
+		},
+	}
+}
+
+// #758 acceptance criterion: two near-simultaneous merges in DIFFERENT projects
+// must launch exactly ONE self-deploy (centralized debounce), not one per flow.
+func TestRequestSelfDeployDebouncesAcrossFlows(t *testing.T) {
+	var launches int64
+	d := New(fakeLoader{}, Options{Port: 0, SelfDeployStateDir: t.TempDir()})
+	d.selfDeployTrigger = func(cfg *config.Config, prNumber int) error {
+		atomic.AddInt64(&launches, 1)
+		return nil
+	}
+
+	cfgA := selfDeployCfg(t, "owner/alpha")
+	cfgB := selfDeployCfg(t, "owner/beta")
+
+	// Two flows merge PRs at the same instant.
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() { defer wg.Done(); errs[0] = d.RequestSelfDeploy(cfgA, 100) }()
+	go func() { defer wg.Done(); errs[1] = d.RequestSelfDeploy(cfgB, 200) }()
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&launches); got != 1 {
+		t.Fatalf("self-deploy launched %d times, want exactly 1 (cross-flow debounce)", got)
+	}
+	// Exactly one request deployed (nil); the other was debounced.
+	debounced, deployed := 0, 0
+	for _, e := range errs {
+		switch {
+		case e == nil:
+			deployed++
+		case errors.Is(e, selfdeploy.ErrDebounced):
+			debounced++
+		default:
+			t.Fatalf("unexpected RequestSelfDeploy error: %v", e)
+		}
+	}
+	if deployed != 1 || debounced != 1 {
+		t.Fatalf("deployed=%d debounced=%d, want 1 and 1", deployed, debounced)
+	}
+}
+
+// The centralized deploy restarts exactly ONE unit: with no units configured the
+// effective set defaults to the single maestro.service (#758).
+func TestRequestSelfDeployRestartsExactlyOneUnit(t *testing.T) {
+	var gotUnits []string
+	d := New(fakeLoader{}, Options{Port: 0, SelfDeployStateDir: t.TempDir()})
+	d.selfDeployTrigger = func(cfg *config.Config, prNumber int) error {
+		gotUnits = cfg.SelfDeploy.EffectiveUnits()
+		return nil
+	}
+
+	if err := d.RequestSelfDeploy(selfDeployCfg(t, "owner/alpha"), 100); err != nil {
+		t.Fatalf("RequestSelfDeploy: %v", err)
+	}
+	if len(gotUnits) != 1 || gotUnits[0] != "maestro.service" {
+		t.Fatalf("restarted units = %v, want exactly [maestro.service]", gotUnits)
+	}
+}
+
+// The post-restart health probe is routed through the single fleet endpoint so
+// verify hits one :port (the daemon serves no per-project HTTP server), and the
+// fleet snapshot carries the version field the script SHA-matches (#758/#698).
+func TestSelfDeployConfigRoutesHealthToFleetEndpoint(t *testing.T) {
+	d := New(fakeLoader{}, Options{Host: "127.0.0.1", Port: 8786})
+	dc := d.selfDeployConfig(&config.Config{
+		Repo:       "owner/alpha",
+		Server:     config.ServerConfig{Auth: config.ServerAuthConfig{TokenEnv: "MAESTRO_DASH_TOKEN"}},
+		SelfDeploy: config.SelfDeployConfig{Enabled: true},
+	})
+	wantURL := "http://127.0.0.1:8786/api/v1/fleet"
+	if got := dc.SelfDeploy.EffectiveHealthURL(dc.Server); got != wantURL {
+		t.Fatalf("health URL = %q, want %q (single fleet endpoint)", got, wantURL)
+	}
+	if got := dc.SelfDeploy.HealthTokenEnv; got != "MAESTRO_DASH_TOKEN" {
+		t.Fatalf("health token env = %q, want carried from server auth", got)
+	}
+}
+
+// An explicit self_deploy.health_url is respected — the daemon does not clobber
+// an operator-set probe target with the fleet endpoint.
+func TestSelfDeployConfigKeepsExplicitHealthURL(t *testing.T) {
+	d := New(fakeLoader{}, Options{Host: "127.0.0.1", Port: 8786})
+	dc := d.selfDeployConfig(&config.Config{
+		Repo:       "owner/alpha",
+		SelfDeploy: config.SelfDeployConfig{Enabled: true, HealthURL: "http://10.0.0.1:9000/custom"},
+	})
+	if got := dc.SelfDeploy.HealthURL; got != "http://10.0.0.1:9000/custom" {
+		t.Fatalf("health URL = %q, want the explicit value preserved", got)
+	}
+}
+
+// Outside the debounce window the next merge deploys again — the centralized
+// debounce gates a wave, it does not permanently suppress deploys.
+func TestRequestSelfDeployFiresAfterWindow(t *testing.T) {
+	var launches int64
+	d := New(fakeLoader{}, Options{Port: 0, SelfDeployStateDir: t.TempDir()})
+	d.selfDeployTrigger = func(cfg *config.Config, prNumber int) error {
+		atomic.AddInt64(&launches, 1)
+		return nil
+	}
+	cfg := selfDeployCfg(t, "owner/alpha")
+	cfg.SelfDeploy.MinIntervalMinutes = 1
+
+	if err := d.RequestSelfDeploy(cfg, 100); err != nil {
+		t.Fatalf("first RequestSelfDeploy: %v", err)
+	}
+	// Push the last-trigger past the 1-minute window (both markers).
+	past := time.Now().UTC().Add(-10 * time.Minute)
+	d.selfDeployLast = past
+	if err := selfdeploy.RecordTrigger(d.opts.SelfDeployStateDir, 100, past); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.RequestSelfDeploy(cfg, 200); err != nil {
+		t.Fatalf("second RequestSelfDeploy after window: %v", err)
+	}
+	if got := atomic.LoadInt64(&launches); got != 2 {
+		t.Fatalf("launches = %d, want 2 (a deploy fires again past the window)", got)
+	}
+}
+
+// A launcher failure (the detached unit never started) must NOT record the
+// debounce marker, so the next merge retries instead of being suppressed.
+func TestRequestSelfDeployLauncherFailureNotMarked(t *testing.T) {
+	d := New(fakeLoader{}, Options{Port: 0, SelfDeployStateDir: t.TempDir()})
+	d.selfDeployTrigger = func(cfg *config.Config, prNumber int) error {
+		return errors.New("systemd-run: exit status 1")
+	}
+
+	err := d.RequestSelfDeploy(selfDeployCfg(t, "owner/alpha"), 100)
+	if err == nil || errors.Is(err, selfdeploy.ErrDebounced) {
+		t.Fatalf("RequestSelfDeploy err = %v, want a launcher failure", err)
+	}
+	if !d.selfDeployLast.IsZero() {
+		t.Error("in-memory marker recorded despite launcher failure")
+	}
+	if _, _, ok := selfdeploy.LastTrigger(d.opts.SelfDeployStateDir); ok {
+		t.Error("on-disk marker recorded despite launcher failure — next merge would be debounced")
+	}
+}

--- a/internal/daemon/selfdeploy_test.go
+++ b/internal/daemon/selfdeploy_test.go
@@ -88,17 +88,23 @@ func TestRequestSelfDeployRestartsExactlyOneUnit(t *testing.T) {
 // fleet snapshot carries the version field the script SHA-matches (#758/#698).
 func TestSelfDeployConfigRoutesHealthToFleetEndpoint(t *testing.T) {
 	d := New(fakeLoader{}, Options{Host: "127.0.0.1", Port: 8786})
+	// The fleet's single shared token env, as Run captures it from
+	// server.FleetAuthFromProjects. The probe hits /api/v1/fleet, so it must
+	// authenticate with THIS — not the triggering flow's own env (#758).
+	d.fleetAuthTokenEnv = "FLEET_DASH_TOKEN"
 	dc := d.selfDeployConfig(&config.Config{
-		Repo:       "owner/alpha",
-		Server:     config.ServerConfig{Auth: config.ServerAuthConfig{TokenEnv: "MAESTRO_DASH_TOKEN"}},
+		Repo: "owner/alpha",
+		// A DIFFERENT per-flow token env: it must NOT be the one the probe uses,
+		// or a probe from a non-token-bearing flow would 401 (Codex on #770).
+		Server:     config.ServerConfig{Auth: config.ServerAuthConfig{TokenEnv: "FLOW_TOKEN"}},
 		SelfDeploy: config.SelfDeployConfig{Enabled: true},
 	})
 	wantURL := "http://127.0.0.1:8786/api/v1/fleet"
 	if got := dc.SelfDeploy.EffectiveHealthURL(dc.Server); got != wantURL {
 		t.Fatalf("health URL = %q, want %q (single fleet endpoint)", got, wantURL)
 	}
-	if got := dc.SelfDeploy.HealthTokenEnv; got != "MAESTRO_DASH_TOKEN" {
-		t.Fatalf("health token env = %q, want carried from server auth", got)
+	if got := dc.SelfDeploy.HealthTokenEnv; got != "FLEET_DASH_TOKEN" {
+		t.Fatalf("health token env = %q, want the FLEET shared token env, not the flow's", got)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -241,6 +242,18 @@ func (o *Orchestrator) isPRMerged(prNumber int) (bool, error) {
 // tests), the drift-based trigger stays off.
 func (o *Orchestrator) SetBinaryVersion(v string) {
 	o.binaryVersion = strings.TrimSpace(v)
+}
+
+// SetSelfDeployStartFn installs a custom self-deploy launcher, replacing the
+// default in-process selfdeploy.Trigger. The daemon (#758) wires this to its
+// centralized, cross-flow-debounced RequestSelfDeploy so N flows merging PRs
+// near-simultaneously launch exactly ONE deploy of ONE unit instead of each
+// flow firing its own — a thundering herd that bounces the fleet mid-verify
+// (#722). A launcher that returns selfdeploy.ErrDebounced signals the request
+// was dropped by the central debounce, which the trigger paths treat as a
+// benign skip rather than a failure.
+func (o *Orchestrator) SetSelfDeployStartFn(fn func(prNumber int) error) {
+	o.selfDeployStartFn = fn
 }
 
 // mainHeadSHA returns origin/main's current head commit SHA.
@@ -4065,6 +4078,14 @@ func (o *Orchestrator) maybeSelfDeployAfterMerge(s *state.State, prNumber int) {
 		}
 	}
 	if err := o.triggerSelfDeploy(prNumber); err != nil {
+		// #758: the central (daemon) launcher debounced this request — another
+		// flow's deploy already covers this merge wave. Not a failure: don't
+		// notify, don't record a finding, and don't write a per-flow marker
+		// (the central marker owns the debounce). A later merge re-checks.
+		if errors.Is(err, selfdeploy.ErrDebounced) {
+			log.Printf("[orch] self-deploy for PR #%d debounced centrally — another flow's deploy covers this wave", prNumber)
+			return
+		}
 		log.Printf("[orch] self-deploy trigger failed for PR #%d: %v", prNumber, err)
 		o.notifier.Sendf("⚠️ maestro: self-deploy trigger failed after PR #%d merge: %v — fleet still on the previous binary", prNumber, err)
 		// #742: surface the failure as a supervisor finding so a merge that
@@ -4136,6 +4157,12 @@ func (o *Orchestrator) maybeSelfDeployOnMainAdvance(s *state.State) {
 	// PR 0: this deploy was triggered by observing main advance, not by a merge
 	// the orchestrator performed itself.
 	if err := o.triggerSelfDeploy(0); err != nil {
+		// #758: debounced by the central (daemon) launcher — another flow already
+		// fired a deploy for the same main-advance wave. Benign skip.
+		if errors.Is(err, selfdeploy.ErrDebounced) {
+			log.Printf("[orch] self-deploy (main-advance) debounced centrally — another flow's deploy covers this wave")
+			return
+		}
 		log.Printf("[orch] self-deploy (main-advance) trigger failed: %v", err)
 		o.notifier.Sendf("⚠️ maestro: self-deploy trigger failed after observing origin/main advance: %v — fleet still on the previous binary", err)
 		// Surface as a supervisor finding so a silently-undeployed external merge

--- a/internal/orchestrator/selfdeploy_test.go
+++ b/internal/orchestrator/selfdeploy_test.go
@@ -137,6 +137,33 @@ func TestMaybeSelfDeployAfterMerge_FiresAfterWindow(t *testing.T) {
 	}
 }
 
+// #758: when the central (daemon) launcher debounces a request — another flow's
+// deploy already covers this merge wave — the orchestrator treats it as a benign
+// skip: no failure finding, no per-flow trigger marker, so a later merge
+// re-checks rather than being suppressed by a false-success marker.
+func TestMaybeSelfDeployAfterMerge_CentralDebounceIsBenignSkip(t *testing.T) {
+	stateDir := t.TempDir()
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   stateDir,
+			SelfDeploy: config.SelfDeployConfig{Enabled: true, MinIntervalMinutes: 30},
+		},
+		notifier:          &notify.Notifier{},
+		selfDeployStartFn: func(prNumber int) error { return selfdeploy.ErrDebounced },
+	}
+	s := &state.State{}
+
+	o.maybeSelfDeployAfterMerge(s, 758)
+
+	if len(s.SupervisorDecisions) != 0 {
+		t.Fatalf("decisions recorded = %d, want 0 (debounce is not a failure)", len(s.SupervisorDecisions))
+	}
+	if _, _, ok := selfdeploy.LastTrigger(stateDir); ok {
+		t.Error("per-flow trigger marker recorded on a central debounce — would suppress the next merge")
+	}
+}
+
 // #751: a PR merged outside the orchestrator's own merge path advances
 // origin/main past the running binary; the next cycle observes the drift and
 // fires exactly one debounced self-deploy. A second cycle within the window

--- a/internal/selfdeploy/selfdeploy.go
+++ b/internal/selfdeploy/selfdeploy.go
@@ -21,6 +21,7 @@ package selfdeploy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -33,6 +34,15 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
 )
+
+// ErrDebounced reports that a self-deploy request was dropped because another
+// deploy already fired within the debounce window — not that the trigger
+// failed. The daemon's centralized RequestSelfDeploy returns it so N flows
+// merging PRs near-simultaneously launch exactly ONE deploy of ONE unit (#758):
+// the first request in a wave deploys, the rest see ErrDebounced. Callers must
+// treat it as a benign skip (no failure finding, no "deploy started" notice),
+// distinct from a real launcher failure (systemd-run rejected the unit).
+var ErrDebounced = errors.New("self-deploy: debounced (recent trigger within window)")
 
 // Result statuses written by scripts/self-deploy.sh.
 const (

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -130,11 +130,17 @@ worker_prompt: /path/to/worker-prompt-template.md
 # honored via the units' stop path), verifies the restarted process reports
 # the new version, and rolls back to .prev on failure. See
 # docs/self-deploy-runbook.md.
+#
+# Under `maestro daemon` (#758) the trigger is centralized: N project flows
+# restart ONE shared maestro.service unit, so the daemon debounces every flow
+# against a single marker — a wave of merges launches exactly one deploy of one
+# unit — and routes the health probe to the single fleet endpoint
+# (http://<host>:<port>/api/v1/fleet, default :8786).
 # self_deploy:
 #   enabled: true
 #   bin_path: /usr/local/bin/maestro   # default: path of the running binary
-#   units: ["maestro.service"]         # systemd user units to restart
-#   # health_url: http://127.0.0.1:8788/api/v1/state  # default: derived from server.port
+#   units: ["maestro.service"]         # systemd unit(s) to restart (default: one — maestro.service)
+#   # health_url: http://127.0.0.1:8788/api/v1/state  # default: derived from server.port (daemon: the fleet endpoint)
 #   # health_token_env: MAESTRO_DASH_TOKEN            # default: server.auth.token_env
 #   # script: ./scripts/self-deploy.sh                # default: <local_path>/scripts/self-deploy.sh
 #   # timeout_minutes: 30                             # build+restart+verify budget (covers drain)


### PR DESCRIPTION
Refs #758 (part of epic #754, single-service redesign).

## Changes

Centralizes the post-merge self-deploy trigger at the daemon level so N project
flows in one process restart ONE shared unit instead of a thundering herd.

- **`Daemon.RequestSelfDeploy(cfg, pr)`** (`internal/daemon/selfdeploy.go`):
  single, mutex-serialized, debounced launcher. Debounce reads the most-recent
  trigger across an in-memory marker (deterministic within the process) and a
  shared on-disk marker (`SelfDeployStateDir`, next to the config store —
  survives the daemon being restarted by its own deploy, #722). The first merge
  in a wave launches exactly one deploy; the rest return `selfdeploy.ErrDebounced`.
- **`selfdeploy.ErrDebounced`** sentinel: lets callers tell a benign central
  debounce apart from a real launcher failure.
- **Orchestrator** wires its self-deploy launcher to the daemon via the new
  `SetSelfDeployStartFn`; `maybeSelfDeployAfterMerge` / `maybeSelfDeployOnMainAdvance`
  treat `ErrDebounced` as a skip (no finding, no notify, no per-flow marker).
  Legacy `maestro run`/`serve` keep the per-flow trigger unchanged.
- **Single endpoint**: the post-restart health probe is routed to the fleet
  endpoint (`:port/api/v1/fleet`, default `:8786`), whose snapshot carries the
  `version` field the script SHA-matches; the dead per-project `cfg.Server`
  derive-URL is neutralized. Default `units: ["maestro.service"]` keeps the
  restart to one unit.
- Docs (`docs/self-deploy-runbook.md`) + `maestro.yaml.example` updated.

## Testing

- `go build ./cmd/maestro/`, `go test ./...` — green.
- New daemon tests: two near-simultaneous merges in different projects → exactly
  one launch / one unit; fires again past the window; launcher failure leaves no
  marker; health routed to the fleet endpoint (explicit `health_url` respected).
- New orchestrator test: central debounce is a benign skip (no finding/marker).
- `go test -race` on the concurrent debounce path — clean.

## Not in this PR (runtime verification still required)

- Moving `self_deploy` into the `global` config-store table is deferred — this
  PR delivers the centralized trigger + one-unit + single-endpoint behavior (the
  fallback the issue allows). Per-flow config still supplies the build inputs.
- Verifying a real deploy → verify-pass → no-re-trigger cycle on the daemon host
  is operator runtime work, so this PR does not auto-close the issue.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Centralizes the self-deploy trigger at the daemon level so all N project flows share a single mutex-serialized, debounced launcher — one deploy, one unit, per merge wave — instead of each flow firing independently. The implementation introduces `Daemon.RequestSelfDeploy`, wires orchestrators to it via `SetSelfDeployStartFn`, routes the post-restart health probe to the single fleet endpoint, and adds `selfdeploy.ErrDebounced` so callers can distinguish a benign central debounce from a real launcher failure.

- `internal/daemon/selfdeploy.go` adds `RequestSelfDeploy` with a `sync.Mutex`-serialized debounce that reads both an in-memory timestamp and an on-disk marker (survives the daemon restart triggered by its own deploy); a growing `selfDeployWindow` ensures a short-interval flow cannot bypass a longer-interval flow's in-flight build.
- Orchestrators are wired to the daemon via a closure in `flow.go`; `maybeSelfDeployAfterMerge` and `maybeSelfDeployOnMainAdvance` both treat `ErrDebounced` as a skip with no finding, no notification, and no per-flow marker written.
- Legacy `maestro run`/`serve` paths are untouched; the daemon-level path adds IPv4/IPv6 loopback normalization for the fleet health URL and captures the shared fleet auth token once before flows start.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the window-persistence gap addressed; the core debounce logic is correct within a single process lifetime but can be bypassed after a daemon restart if flows have different min-interval configurations.

The selfDeployWindow field is in-memory only and resets to zero when the daemon restarts — which is exactly what the deploy script does. A flow with a shorter min_interval_minutes that was previously debounced (and therefore has no per-flow marker) can re-call RequestSelfDeploy on its first post-restart cycle. If its shorter window has already elapsed relative to the on-disk timestamp, the debounce check passes and a second deploy fires while the first deploy's detached script is still in its build/verify phase. Two concurrent scripts installing the binary and restarting the unit is the instability the debounce was designed to prevent.

internal/daemon/selfdeploy.go — the selfDeployWindow field and the on-disk marker (triggerMarker struct in internal/selfdeploy/selfdeploy.go) should be extended to persist and restore the effective window across restarts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/daemon/selfdeploy.go | New centralized self-deploy trigger with mutex+debounce logic; in-memory selfDeployWindow is not persisted to disk, so the max-window guarantee can be lost across daemon restarts triggered by the deploy itself |
| internal/daemon/selfdeploy_test.go | Good coverage of concurrent debounce, single-unit constraint, health routing, launcher failure, and fire-after-window; missing a test for the post-restart window-reset scenario |
| internal/daemon/flow.go | runOrchestrator promoted to a method; wires SetSelfDeployStartFn to RequestSelfDeploy via a closure that captures the live orchCfg pointer safely (same goroutine as hot-reload mutations) |
| internal/daemon/daemon.go | Adds selfDeployMu, selfDeployWindow, selfDeployTrigger fields and fleetAuthTokenEnv; fleetAuth token captured before flows start ensuring race-free reads in RequestSelfDeploy |
| internal/orchestrator/orchestrator.go | Adds selfDeployStartFn hook and SetSelfDeployStartFn; both maybeSelfDeployAfterMerge and maybeSelfDeployOnMainAdvance correctly treat ErrDebounced as a benign skip with no finding/marker/notification |
| internal/orchestrator/selfdeploy_test.go | New test correctly verifies central debounce is a benign skip: no SupervisorDecision recorded and no per-flow trigger marker written |
| internal/selfdeploy/selfdeploy.go | Adds ErrDebounced sentinel; existing RecordTrigger/LastTrigger functions are reused for both per-flow and centralized markers unchanged |
| cmd/maestro/daemon.go | Wires SelfDeployStateDir next to the config store; filepath.Dir(*storePath) is a reasonable shared location that survives the daemon restart |
| docs/self-deploy-runbook.md | Documents the centralized trigger design, single-unit restart, and fleet-endpoint health routing clearly |
| maestro.yaml.example | Comment updated to explain daemon mode behavior and fleet-endpoint health probe; accurate and consistent with implementation |

<sub>Reviews (2): Last reviewed commit: ["daemon/self-deploy: address #770 review ..."](https://github.com/befeast/maestro/commit/c5f1b0faf8f6d3dfb36b3a95ee76f38cd43c2176) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39527617)</sub>

<!-- /greptile_comment -->