### PR TITLE
orchestrator: fix in-place respawn race (checkSessions flips Dead→pr_open before respawnDueRetries)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2439,6 +2439,21 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						// log, no project sync, no FinishedAt churn.
 						continue
 					}
+					// A Dead session with a pending NextRetryAt is QUEUED for an
+					// in-place respawn (review-feedback / CI-failure / rebase
+					// retry — handleReviewFeedbackRetry et al. set Status=Dead +
+					// NextRetryAt). Do NOT flip it to pr_open here: this reconcile
+					// runs at Step 1, BEFORE respawnDueRetries at Step 2b, which
+					// only relaunches sessions still in StatusDead. Flipping to
+					// pr_open clears the Dead status, so respawnDueRetries never
+					// sees the session and the worker never relaunches — every
+					// cycle re-detects the same review feedback and burns one
+					// maintenance retry until the budget exhausts and the PR holds,
+					// with not a single real fix attempt. Leave it Dead; the retry
+					// queue owns the relaunch (#758 in-place-respawn race).
+					if sess.Status == state.StatusDead && sess.NextRetryAt != nil {
+						continue
+					}
 					o.ensureAttributionTrailerOnPR(slotName, sess, pr)
 					o.ensureAttributionTrailerOnBranch(slotName, sess)
 					log.Printf("[orch] session %s %s->pr_open (PR #%d now open for branch %q)", slotName, sess.Status, pr.Number, sess.Branch)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -217,6 +217,45 @@ func TestReconcileRunningSessions_DeadWorkerWithOpenPR_TransitionsToPROpen(t *te
 	}
 }
 
+// A Dead session QUEUED for an in-place respawn (NextRetryAt set — the
+// review-feedback / CI-failure / rebase retry path) must NOT be flipped to
+// pr_open by the Step-1 reconcile. Flipping clears the Dead status before the
+// Step-2b respawnDueRetries — which only relaunches StatusDead sessions — so the
+// worker never respawns and the maintenance-retry budget burns to a held PR
+// without a single real fix attempt (#758 in-place-respawn race).
+func TestReconcileRunningSessions_DeadWithPendingRetry_NotFlippedToPROpen(t *testing.T) {
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(10 * time.Second)
+	s.Sessions["sup-9"] = &state.Session{
+		IssueNumber: 200,
+		IssueTitle:  "review-repair retry",
+		Status:      state.StatusDead,
+		NextRetryAt: &retryAt,
+		RetryCount:  1,
+		Branch:      "feat/sup-9-200-fix",
+		PRNumber:    300,
+	}
+	openPRs := []github.PR{{Number: 300, HeadRefName: "feat/sup-9-200-fix", Title: "fix"}}
+	o := &Orchestrator{
+		cfg:                 &config.Config{StateDir: t.TempDir()},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return openPRs, nil },
+	}
+
+	// checkSessions (Step 2) is the reconcile that flips terminal sessions with
+	// an open PR to pr_open — and where the in-place-respawn race lives.
+	o.checkSessions(s)
+
+	sess := s.Sessions["sup-9"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q — a retry-queued Dead session must stay Dead so respawnDueRetries relaunches it", sess.Status, state.StatusDead)
+	}
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt must be preserved — the in-place respawn depends on it")
+	}
+}
+
 func TestReconcileRunningSessions_DeadWorkerWithOpenPR_CapturesTokensFromPersistedLog(t *testing.T) {
 	stateDir := t.TempDir()
 	logDir := state.LogDir(stateDir)


### PR DESCRIPTION
Fixes the root cause behind every hand-fixed held PR in the daemon redesign. See #771 for the full root-cause writeup.

**Bug:** checkSessions (Step 2) flips a retry-queued `Dead` session to `pr_open` before respawnDueRetries (Step 2b) can relaunch it, so the in-place respawn never fires and the maintenance-retry budget burns to a held PR (observed #764/#770: 1/3→3/3 in ~6 min, PR head unchanged).

**Fix:** in checkSessions, don't flip a `Dead` session that has a pending `NextRetryAt` — the retry queue owns its relaunch. Crashed-worker re-attach (Dead, no NextRetryAt) unaffected.

**Test:** regression test (fails without the guard); `go test -race ./internal/orchestrator/` green.

Refs #771

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an orchestrator retry race for in-place PR repair sessions. The main changes are:

- Keeps retry-queued `Dead` sessions from being flipped to `pr_open` before respawn.
- Preserves `NextRetryAt` ownership for the retry queue.
- Adds a regression test for a `Dead` session with a pending retry and open PR.

<h3>Confidence Score: 4/5</h3>

The retry ownership fix is narrowly scoped, but the early return can bypass existing closed-issue cleanup for retry-queued sessions.

The changed control flow is localized and covered by a new regression test for the original race, while the remaining concern is a concrete cleanup path affected by the same guard.

internal/orchestrator/orchestrator.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex added a focused Go regression test that creates a Dead session with a due NextRetryAt, an open PR on the same branch, and a mocked closed GitHub issue, then exercises checkSessions and respawnDueRetries.
- T-Rex attempted to run the test command but the environment could not execute it because the Go toolchain was not installed.
- T-Rex captured the respawn race before-state artifact, documenting the pre-state conditions with the base command, cwd, commit, verbose test output, and the retry-queued transition to pr\_open (exit code 1).
- T-Rex captured the respawn race after-state artifact, showing the post-state where the retry-queued status is preserved and the reattach transition remains unaffected (exit code 0).

<a href="https://app.greptile.com/trex/runs/12216922/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:2454-2455
**Preserve zombie cleanup**

This `continue` skips more than the `Dead`→`pr_open` transition. When an in-place review or rebase retry keeps the PR open and the linked issue is closed during the retry backoff, this branch returns before the existing issue-closed cleanup below can mark the session done. Once `NextRetryAt` becomes due, `respawnDueRetries` can relaunch work for an issue that is already closed. Please skip only the `pr_open` flip here while still allowing the terminal cleanup checks below to run.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: don&#39;t flip a retry-queued ..."](https://github.com/befeast/maestro/commit/5501932fde0365fd30b036248f999f1cba94d929) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39682593)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->