### PR TITLE
Phase 4: approvals → SQLite (транзакционный claim-once, фикс double-execute race)

### DIFF
--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/configstore"
 	"github.com/befeast/maestro/internal/daemon"
 )
@@ -28,6 +29,8 @@ func daemonCmd(args []string) {
 	readOnly := fs.Bool("read-only", false, "Disable mutating fleet HTTP endpoints")
 	watchStore := fs.Bool("watch-store", false, "Hot add/remove/reload projects from the config store without a restart (#757)")
 	watchStoreInterval := fs.Duration("watch-store-interval", daemon.DefaultWatchStoreInterval, "Config-store diff/reload poll interval (with --watch-store)")
+	approvalsStore := fs.String("approvals-store", "json", "Approvals store backend for the fleet approve/reject endpoint: json|sqlite (#759)")
+	approvalsDB := fs.String("approvals-db", approvalstore.DefaultDBPath(), "Shared SQLite approvals db path (used with --approvals-store=sqlite)")
 	fs.Parse(args)
 
 	ctx := signalContext()
@@ -53,6 +56,8 @@ func daemonCmd(args []string) {
 		SelfDeployStateDir: filepath.Join(filepath.Dir(*storePath), "self-deploy"),
 		WatchStore:         *watchStore,
 		WatchStoreInterval: *watchStoreInterval,
+		ApprovalsStore:     *approvalsStore,
+		ApprovalsDBPath:    *approvalsDB,
 	})
 
 	log.Printf("starting maestro daemon — store=%s addr=%s:%d", *storePath, *host, *port)

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -19,6 +19,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/approver"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/configstore"
@@ -715,7 +716,14 @@ func runCmd(args []string) {
 	interval := fs.Duration("interval", 10*time.Minute, "Loop interval")
 	once := fs.Bool("once", false, "Run once and exit")
 	promptPath := fs.String("prompt", "", "Path to worker prompt base file")
+	approvalsStore := fs.String("approvals-store", "json", "Approvals store backend for the HTTP approve/reject endpoint: json|sqlite (#759)")
+	approvalsDB := fs.String("approvals-db", approvalstore.DefaultDBPath(), "SQLite approvals db path (used with --approvals-store=sqlite)")
 	fs.Parse(args)
+
+	approvalsMode, err := approvalstore.ParseMode(*approvalsStore)
+	if err != nil {
+		log.Fatalf("run: %v", err)
+	}
 
 	cfgs := loadConfigsWithStore(configs, *storePath, *storeProject)
 
@@ -733,6 +741,9 @@ func runCmd(args []string) {
 		if cfg.Server.Port > 0 {
 			srv := server.New(cfg, refreshCh)
 			srv.SetActionDeps(github.New(cfg.Repo), nil)
+			if err := srv.SetApprovalStore(approvalsMode, *approvalsDB); err != nil {
+				log.Fatalf("run: open approvals store: %v", err)
+			}
 			go func() {
 				if err := srv.Start(context.Background()); err != nil {
 					log.Printf("[server] error: %v", err)
@@ -792,6 +803,9 @@ func runCmd(args []string) {
 			if c.Server.Port > 0 {
 				srv := server.New(c, refreshCh)
 				srv.SetActionDeps(github.New(c.Repo), nil)
+				if err := srv.SetApprovalStore(approvalsMode, *approvalsDB); err != nil {
+					log.Fatalf("[%s] run: open approvals store: %v", c.SessionPrefix, err)
+				}
 				go func() {
 					if err := srv.Start(ctx); err != nil {
 						log.Printf("[%s][server] error: %v", c.SessionPrefix, err)
@@ -924,30 +938,35 @@ func superviseApprovalCmd(action string, args []string, defaultConfigPath string
 	configPath := fs.String("config", defaultConfigPath, "Path to config file")
 	actor := fs.String("actor", "cli", "Audit actor")
 	reason := fs.String("reason", "", "Audit reason")
+	approvalsStore := fs.String("approvals-store", "json", "Approvals store backend: json|sqlite (sqlite gives transactional claim-once)")
+	approvalsDB := fs.String("approvals-db", approvalstore.DefaultDBPath(), "SQLite approvals db path (used with --approvals-store=sqlite)")
 	fs.Parse(reorderArgs(fs, args))
 	if fs.NArg() != 1 {
 		log.Fatalf("supervise %s: expected approval or decision id", action)
 	}
 
 	cfg := loadConfig(*configPath)
-	st, err := state.Load(cfg.StateDir)
+	mode, err := approvalstore.ParseMode(*approvalsStore)
 	if err != nil {
-		log.Fatalf("supervise %s: load state: %v", action, err)
+		log.Fatalf("supervise %s: %v", action, err)
+	}
+	binding := approvalstore.Binding{
+		Mode:     mode,
+		DBPath:   *approvalsDB,
+		StateDir: cfg.StateDir,
+		Repo:     cfg.Repo,
+		Project:  cfg.Repo,
 	}
 
 	id := fs.Arg(0)
 	now := time.Now().UTC()
-	var approval *state.Approval
-	switch action {
-	case "approve":
-		approval, err = st.ApproveApproval(id, now, *actor, *reason)
-	case "reject":
-		approval, err = st.RejectApproval(id, now, *actor, *reason)
-	default:
-		log.Fatalf("supervise: unknown approval action %q", action)
-	}
+	// ApplyDecision performs the approve/reject transition. In sqlite mode the
+	// pending→approved claim is atomic (claim-once): a second concurrent
+	// approve loses the claim and is reported as "already processed", so the
+	// executor below fires exactly once (write-path premortem double-execute).
+	st, approval, err := approvalstore.ApplyDecision(binding, action, id, now, *actor, *reason)
 	if err != nil {
-		if errors.Is(err, state.ErrApprovalStale) || errors.Is(err, state.ErrApprovalPayloadMismatch) {
+		if st != nil && (errors.Is(err, state.ErrApprovalStale) || errors.Is(err, state.ErrApprovalPayloadMismatch)) {
 			if saveErr := state.Save(cfg.StateDir, st); saveErr != nil {
 				log.Fatalf("supervise %s: save stale approval: %v", action, saveErr)
 			}
@@ -1008,6 +1027,16 @@ func superviseApprovalCmd(action string, args []string, defaultConfigPath string
 
 	if err := state.Save(cfg.StateDir, st); err != nil {
 		log.Fatalf("supervise approve: save state after execution: %v", err)
+	}
+	// Mirror the terminal execution status into the SQLite store (no-op in
+	// json mode). JSON state stays authoritative for the executor loop, so a
+	// mirror failure is logged, not fatal.
+	mirrorMsg := res.Summary
+	if res.Status == state.ApprovalStatusExecutionFailed && mirrorMsg == "" && res.Err != nil {
+		mirrorMsg = res.Err.Error()
+	}
+	if mErr := approvalstore.FinalizeExecution(binding, approval.ID, res.Status, now, *actor, mirrorMsg); mErr != nil {
+		log.Printf("supervise approve: mirror execution to approvals store: %v", mErr)
 	}
 
 	switch res.Status {

--- a/internal/approvalstore/gate.go
+++ b/internal/approvalstore/gate.go
@@ -1,0 +1,193 @@
+package approvalstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// Mode selects which store arbitrates the approve/reject claim.
+type Mode string
+
+const (
+	// ModeJSON keeps the legacy per-project JSON read-merge-write path.
+	ModeJSON Mode = "json"
+	// ModeSQLite routes the claim through the transactional SQLite store
+	// (claim-once) while still write-through-mirroring into JSON state for
+	// compatibility during the transition.
+	ModeSQLite Mode = "sqlite"
+)
+
+// ParseMode normalizes the --approvals-store flag value. Empty defaults to
+// json (the safe default until the SQLite path is flipped on for a project).
+func ParseMode(s string) (Mode, error) {
+	switch strings.TrimSpace(strings.ToLower(s)) {
+	case "", string(ModeJSON):
+		return ModeJSON, nil
+	case string(ModeSQLite):
+		return ModeSQLite, nil
+	default:
+		return "", fmt.Errorf("unknown approvals store %q (want json|sqlite)", s)
+	}
+}
+
+// Binding is everything ApplyDecision/FinalizeExecution need to resolve the
+// approvals store for one project's approve/reject. StateDir is always the
+// JSON state directory (mint source and write-through target); DBPath is the
+// SQLite database used only in ModeSQLite.
+//
+// Handle is an optional already-open store. A long-lived server (the fleet /
+// single-project HTTP server) MUST set Handle to one shared *Store: with a
+// single pooled connection (MaxOpenConns(1)) every in-process claim serializes
+// through that connection, so concurrent dashboard approves never collide on
+// SQLITE_BUSY. When Handle is nil (the one-shot CLI path) the store is opened
+// per call from DBPath.
+type Binding struct {
+	Mode     Mode
+	DBPath   string
+	StateDir string
+	Repo     string
+	Project  string
+	Handle   *Store
+}
+
+// UseSQLite reports whether the SQLite claim path is selected.
+func (b Binding) UseSQLite() bool { return b.Mode == ModeSQLite }
+
+// resolveStore returns the store to use plus a cleanup func. When Handle is
+// set it is reused (cleanup is a no-op); otherwise a fresh store is opened from
+// DBPath and the cleanup closes it.
+func (b Binding) resolveStore() (*Store, func(), error) {
+	if b.Handle != nil {
+		return b.Handle, func() {}, nil
+	}
+	store, err := Open(b.DBPath)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return store, func() { store.Close() }, nil
+}
+
+// ApplyDecision performs verb ("approve"|"reject") on approval id and returns
+// the in-memory JSON *state.State to persist plus the updated *state.Approval.
+// The caller owns state.Save (and, for the CLI, executing the approved
+// side effect + FinalizeExecution).
+//
+// In ModeJSON this is exactly st.ApproveApproval / st.RejectApproval — the
+// returned state is mutated identically to the legacy path (including the
+// partial stale transition on a conflict), so the caller's existing save +
+// error-mapping logic is unchanged.
+//
+// In ModeSQLite the pending approval is seeded into SQLite (write-through),
+// claimed atomically there (claim-once across processes), and — on a winning
+// claim — mirrored back into JSON state so the executor loop, which reads
+// JSON via ListApprovedApprovals, still drives execution. A losing claim
+// returns state.ErrApprovalNotPending ("already processed") without touching
+// JSON, so exactly one caller proceeds to execute.
+func ApplyDecision(b Binding, verb, id string, now time.Time, actor, reason string) (*state.State, *state.Approval, error) {
+	verb = strings.TrimSpace(verb)
+	if verb != "approve" && verb != "reject" {
+		return nil, nil, fmt.Errorf("unknown approval verb %q", verb)
+	}
+	st, err := state.Load(b.StateDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !b.UseSQLite() {
+		approval, terr := applyJSONTransition(st, verb, id, now, actor, reason)
+		return st, approval, terr
+	}
+
+	// SQLite claim-once path.
+	a0, ok := st.FindApproval(id)
+	if !ok {
+		return st, nil, state.ErrApprovalNotFound
+	}
+	store, cleanup, err := b.resolveStore()
+	if err != nil {
+		return st, nil, err
+	}
+	defer cleanup()
+
+	ctx := context.Background()
+	rb := RowBinding{Project: b.Project, Repo: b.Repo, StateDir: b.StateDir}
+	if _, err := store.Put(ctx, a0, rb); err != nil {
+		return st, nil, err
+	}
+
+	var claimed *state.Approval
+	switch verb {
+	case "approve":
+		claimed, err = store.Approve(ctx, id, now, actor, reason)
+	case "reject":
+		claimed, err = store.Reject(ctx, id, now, actor, reason)
+	}
+	if err != nil {
+		// Mirror a stale / payload-mismatch transition into JSON so both
+		// stores agree and the caller's partial-persist path records it.
+		if errors.Is(err, state.ErrApprovalStale) || errors.Is(err, state.ErrApprovalPayloadMismatch) {
+			_, _ = applyJSONTransition(st, verb, id, now, actor, reason)
+		}
+		return st, claimed, err
+	}
+
+	// Won the claim — write through to JSON. In the normal same-load case the
+	// JSON record is still pending and the transition succeeds. If a rare
+	// cross-process drift left JSON already at the claimed status, accept it;
+	// otherwise the SQLite claim remains authoritative.
+	jApproval, jErr := applyJSONTransition(st, verb, id, now, actor, reason)
+	if jErr == nil {
+		return st, jApproval, nil
+	}
+	if cur, ok := st.FindApproval(id); ok && cur.Status == claimed.Status {
+		return st, cur, nil
+	}
+	return st, claimed, nil
+}
+
+// FinalizeExecution mirrors a post-execution terminal status into the SQLite
+// store after the caller has already recorded it in JSON state. It is a no-op
+// in ModeJSON. The idempotent not-approved / not-found cases are tolerated so
+// a concurrent finalize cannot turn into a spurious error.
+func FinalizeExecution(b Binding, id string, status state.ApprovalStatus, now time.Time, actor, summary string) error {
+	if !b.UseSQLite() {
+		return nil
+	}
+	store, cleanup, err := b.resolveStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	ctx := context.Background()
+	switch status {
+	case state.ApprovalStatusExecuted:
+		_, err = store.MarkExecuted(ctx, id, now, actor, summary)
+	case state.ApprovalStatusExecutionFailed:
+		_, err = store.MarkExecutionFailed(ctx, id, now, actor, summary)
+	case state.ApprovalStatusExecutionSkipped:
+		_, err = store.MarkExecutionSkipped(ctx, id, now, actor, summary)
+	case state.ApprovalStatusAwaitingDispatch:
+		_, err = store.MarkAwaitingDispatch(ctx, id, now, actor, summary)
+	default:
+		return fmt.Errorf("approvalstore: unsupported finalize status %q", status)
+	}
+	if errors.Is(err, state.ErrApprovalNotApproved) || errors.Is(err, state.ErrApprovalNotFound) {
+		return nil
+	}
+	return err
+}
+
+func applyJSONTransition(st *state.State, verb, id string, now time.Time, actor, reason string) (*state.Approval, error) {
+	switch verb {
+	case "approve":
+		return st.ApproveApproval(id, now, actor, reason)
+	case "reject":
+		return st.RejectApproval(id, now, actor, reason)
+	default:
+		return nil, fmt.Errorf("unknown approval verb %q", verb)
+	}
+}

--- a/internal/approvalstore/gate.go
+++ b/internal/approvalstore/gate.go
@@ -119,12 +119,18 @@ func ApplyDecision(b Binding, verb, id string, now time.Time, actor, reason stri
 		return st, nil, err
 	}
 
+	// Claim the RESOLVED approval id (a0.ID), not the user-supplied value:
+	// FindApproval accepts either Approval.ID or DecisionID, but the row is
+	// keyed under a0.ID, so claiming the original `id` (a decision-id alias)
+	// would miss the row and spuriously return ErrApprovalNotFound. Scope the
+	// claim to b.StateDir so a shared maestro.db never cross-claims another
+	// project's same-id approval.
 	var claimed *state.Approval
 	switch verb {
 	case "approve":
-		claimed, err = store.Approve(ctx, id, now, actor, reason)
+		claimed, err = store.Approve(ctx, b.StateDir, a0.ID, now, actor, reason)
 	case "reject":
-		claimed, err = store.Reject(ctx, id, now, actor, reason)
+		claimed, err = store.Reject(ctx, b.StateDir, a0.ID, now, actor, reason)
 	}
 	if err != nil {
 		// Mirror a stale / payload-mismatch transition into JSON so both
@@ -165,13 +171,13 @@ func FinalizeExecution(b Binding, id string, status state.ApprovalStatus, now ti
 	ctx := context.Background()
 	switch status {
 	case state.ApprovalStatusExecuted:
-		_, err = store.MarkExecuted(ctx, id, now, actor, summary)
+		_, err = store.MarkExecuted(ctx, b.StateDir, id, now, actor, summary)
 	case state.ApprovalStatusExecutionFailed:
-		_, err = store.MarkExecutionFailed(ctx, id, now, actor, summary)
+		_, err = store.MarkExecutionFailed(ctx, b.StateDir, id, now, actor, summary)
 	case state.ApprovalStatusExecutionSkipped:
-		_, err = store.MarkExecutionSkipped(ctx, id, now, actor, summary)
+		_, err = store.MarkExecutionSkipped(ctx, b.StateDir, id, now, actor, summary)
 	case state.ApprovalStatusAwaitingDispatch:
-		_, err = store.MarkAwaitingDispatch(ctx, id, now, actor, summary)
+		_, err = store.MarkAwaitingDispatch(ctx, b.StateDir, id, now, actor, summary)
 	default:
 		return fmt.Errorf("approvalstore: unsupported finalize status %q", status)
 	}

--- a/internal/approvalstore/store.go
+++ b/internal/approvalstore/store.go
@@ -18,7 +18,14 @@
 // Each row carries project / repo / state_dir columns so a single shared
 // maestro.db can hold every project's approvals without cross-project
 // mutation (premortem #2/#3 — the executor's repo guard re-checks the same
-// binding at execute time).
+// binding at execute time). Approval ids are content-addressed on
+// (action, target) only (state.approvalID), so two DIFFERENT projects that
+// gate the same action on the same target mint the SAME id. The row identity
+// and every claim predicate are therefore scoped by state_dir (the JSON state
+// directory, which is 1:1 with a project — repo can be shared by two configs,
+// the project name can be aliased, but the state dir is unique). Without that
+// scope the second project's INSERT OR IGNORE would be dropped and an
+// approve/reject would consume or block the first project's claim.
 package approvalstore
 
 import (
@@ -42,7 +49,7 @@ import (
 // row to its originating project context (premortem #2/#3).
 const Schema = `
 CREATE TABLE IF NOT EXISTS approvals (
-	id            TEXT PRIMARY KEY,
+	id            TEXT NOT NULL,
 	decision_id   TEXT NOT NULL DEFAULT '',
 	project       TEXT NOT NULL DEFAULT '',
 	repo          TEXT NOT NULL DEFAULT '',
@@ -52,7 +59,12 @@ CREATE TABLE IF NOT EXISTS approvals (
 	payload_hash  TEXT NOT NULL DEFAULT '',
 	created_at    TEXT NOT NULL,
 	updated_at    TEXT NOT NULL,
-	approval_json TEXT NOT NULL
+	approval_json TEXT NOT NULL,
+	-- Scope the row identity by state_dir: ids are content-addressed on
+	-- (action, target) only, so two projects can mint the same id. Without
+	-- (state_dir, id) the second project's INSERT OR IGNORE is dropped and a
+	-- claim consumes the wrong project's approval.
+	PRIMARY KEY (state_dir, id)
 );
 
 CREATE TABLE IF NOT EXISTS approval_audit (
@@ -185,10 +197,10 @@ func (s *Store) Put(ctx context.Context, a *state.Approval, b RowBinding) (inser
 	return ins, nil
 }
 
-// Get returns the full approval (audit included, via approval_json) for id,
-// or state.ErrApprovalNotFound.
-func (s *Store) Get(ctx context.Context, id string) (*state.Approval, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT approval_json FROM approvals WHERE id = ?`, id)
+// Get returns the full approval (audit included, via approval_json) for id
+// within the given state_dir scope, or state.ErrApprovalNotFound.
+func (s *Store) Get(ctx context.Context, stateDir, id string) (*state.Approval, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT approval_json FROM approvals WHERE state_dir = ? AND id = ?`, stateDir, id)
 	return scanApproval(row)
 }
 
@@ -231,28 +243,32 @@ func (s *Store) List(ctx context.Context, stateDir string) ([]*state.Approval, e
 //     processed" outcome)
 //   - state.ErrApprovalPayloadMismatch — payload drifted from its hash
 //
+// id must be the resolved Approval.ID (the row key) — callers that accept a
+// decision-id alias resolve it before claiming. stateDir scopes the claim to
+// one project so a shared maestro.db cannot cross-claim.
+//
 // Exactly one concurrent caller observes rows-affected==1 and returns nil;
 // every other caller returns ErrApprovalNotPending without mutating state.
-func (s *Store) Approve(ctx context.Context, id string, now time.Time, actor, reason string) (*state.Approval, error) {
-	return s.claim(ctx, id, state.ApprovalStatusApproved, state.ApprovalAuditApproved, now, actor, reason)
+func (s *Store) Approve(ctx context.Context, stateDir, id string, now time.Time, actor, reason string) (*state.Approval, error) {
+	return s.claim(ctx, stateDir, id, state.ApprovalStatusApproved, state.ApprovalAuditApproved, now, actor, reason)
 }
 
 // Reject atomically claims a pending approval (pending → rejected), with the
 // same claim-once semantics and error sentinels as Approve.
-func (s *Store) Reject(ctx context.Context, id string, now time.Time, actor, reason string) (*state.Approval, error) {
-	return s.claim(ctx, id, state.ApprovalStatusRejected, state.ApprovalAuditRejected, now, actor, reason)
+func (s *Store) Reject(ctx context.Context, stateDir, id string, now time.Time, actor, reason string) (*state.Approval, error) {
+	return s.claim(ctx, stateDir, id, state.ApprovalStatusRejected, state.ApprovalAuditRejected, now, actor, reason)
 }
 
 // claim implements the pending → {approved,rejected} transition with the
-// atomic UPDATE ... WHERE status='pending' guard.
-func (s *Store) claim(ctx context.Context, id string, target state.ApprovalStatus, event string, now time.Time, actor, reason string) (*state.Approval, error) {
+// atomic UPDATE ... WHERE status='pending' guard, scoped to one state_dir.
+func (s *Store) claim(ctx context.Context, stateDir, id string, target state.ApprovalStatus, event string, now time.Time, actor, reason string) (*state.Approval, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
-	a, b, err := loadApprovalTx(ctx, tx, id)
+	a, b, err := loadApprovalTx(ctx, tx, stateDir, id)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, state.ErrApprovalNotFound
 	}
@@ -286,8 +302,8 @@ func (s *Store) claim(ctx context.Context, id string, target state.ApprovalStatu
 
 	now = normalize(now)
 	res, err := tx.ExecContext(ctx,
-		`UPDATE approvals SET status = ?, updated_at = ? WHERE id = ? AND status = ?`,
-		string(target), formatTime(now), id, string(state.ApprovalStatusPending))
+		`UPDATE approvals SET status = ?, updated_at = ? WHERE state_dir = ? AND id = ? AND status = ?`,
+		string(target), formatTime(now), stateDir, id, string(state.ApprovalStatusPending))
 	if err != nil {
 		return a, err
 	}
@@ -299,7 +315,7 @@ func (s *Store) claim(ctx context.Context, id string, target state.ApprovalStatu
 		// Lost the claim to a concurrent writer between our read and UPDATE.
 		// Reload so the caller sees the winner's status, and report
 		// "already processed".
-		reloaded, _, lerr := loadApprovalTx(ctx, tx, id)
+		reloaded, _, lerr := loadApprovalTx(ctx, tx, stateDir, id)
 		if lerr == nil {
 			a = reloaded
 		}
@@ -317,7 +333,7 @@ func (s *Store) claim(ctx context.Context, id string, target state.ApprovalStatu
 		TargetStateHash: a.TargetStateHash,
 	}
 	a.Audit = append(a.Audit, audit)
-	if err := writeApprovalJSONTx(ctx, tx, a); err != nil {
+	if err := writeApprovalJSONTx(ctx, tx, b.StateDir, a); err != nil {
 		return a, err
 	}
 	if err := insertAuditTx(ctx, tx, id, b, audit); err != nil {
@@ -333,35 +349,35 @@ func (s *Store) claim(ctx context.Context, id string, target state.ApprovalStatu
 // state.MarkApprovalExecuted. Idempotent at the caller boundary: an approval
 // not in status=approved returns state.ErrApprovalNotApproved unchanged, so a
 // concurrent executor cannot double-record.
-func (s *Store) MarkExecuted(ctx context.Context, id string, now time.Time, actor, summary string) (*state.Approval, error) {
-	return s.markTerminal(ctx, id, state.ApprovalStatusExecuted, state.ApprovalAuditExecuted, now, actor, summary)
+func (s *Store) MarkExecuted(ctx context.Context, stateDir, id string, now time.Time, actor, summary string) (*state.Approval, error) {
+	return s.markTerminal(ctx, stateDir, id, state.ApprovalStatusExecuted, state.ApprovalAuditExecuted, now, actor, summary)
 }
 
 // MarkExecutionFailed transitions approved → execution_failed.
-func (s *Store) MarkExecutionFailed(ctx context.Context, id string, now time.Time, actor, errMsg string) (*state.Approval, error) {
-	return s.markTerminal(ctx, id, state.ApprovalStatusExecutionFailed, state.ApprovalAuditExecutionFailed, now, actor, errMsg)
+func (s *Store) MarkExecutionFailed(ctx context.Context, stateDir, id string, now time.Time, actor, errMsg string) (*state.Approval, error) {
+	return s.markTerminal(ctx, stateDir, id, state.ApprovalStatusExecutionFailed, state.ApprovalAuditExecutionFailed, now, actor, errMsg)
 }
 
 // MarkExecutionSkipped transitions approved → execution_skipped.
-func (s *Store) MarkExecutionSkipped(ctx context.Context, id string, now time.Time, actor, reason string) (*state.Approval, error) {
-	return s.markTerminal(ctx, id, state.ApprovalStatusExecutionSkipped, state.ApprovalAuditExecutionSkipped, now, actor, reason)
+func (s *Store) MarkExecutionSkipped(ctx context.Context, stateDir, id string, now time.Time, actor, reason string) (*state.Approval, error) {
+	return s.markTerminal(ctx, stateDir, id, state.ApprovalStatusExecutionSkipped, state.ApprovalAuditExecutionSkipped, now, actor, reason)
 }
 
 // MarkAwaitingDispatch transitions approved → awaiting_dispatch.
-func (s *Store) MarkAwaitingDispatch(ctx context.Context, id string, now time.Time, actor, reason string) (*state.Approval, error) {
-	return s.markTerminal(ctx, id, state.ApprovalStatusAwaitingDispatch, state.ApprovalAuditAwaitingDispatch, now, actor, reason)
+func (s *Store) MarkAwaitingDispatch(ctx context.Context, stateDir, id string, now time.Time, actor, reason string) (*state.Approval, error) {
+	return s.markTerminal(ctx, stateDir, id, state.ApprovalStatusAwaitingDispatch, state.ApprovalAuditAwaitingDispatch, now, actor, reason)
 }
 
 // markTerminal implements the approved → terminal transition with the atomic
-// UPDATE ... WHERE status='approved' idempotency guard.
-func (s *Store) markTerminal(ctx context.Context, id string, target state.ApprovalStatus, event string, now time.Time, actor, reason string) (*state.Approval, error) {
+// UPDATE ... WHERE status='approved' idempotency guard, scoped to one state_dir.
+func (s *Store) markTerminal(ctx context.Context, stateDir, id string, target state.ApprovalStatus, event string, now time.Time, actor, reason string) (*state.Approval, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
-	a, b, err := loadApprovalTx(ctx, tx, id)
+	a, b, err := loadApprovalTx(ctx, tx, stateDir, id)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, state.ErrApprovalNotFound
 	}
@@ -374,8 +390,8 @@ func (s *Store) markTerminal(ctx context.Context, id string, target state.Approv
 
 	now = normalize(now)
 	res, err := tx.ExecContext(ctx,
-		`UPDATE approvals SET status = ?, updated_at = ? WHERE id = ? AND status = ?`,
-		string(target), formatTime(now), id, string(state.ApprovalStatusApproved))
+		`UPDATE approvals SET status = ?, updated_at = ? WHERE state_dir = ? AND id = ? AND status = ?`,
+		string(target), formatTime(now), stateDir, id, string(state.ApprovalStatusApproved))
 	if err != nil {
 		return a, err
 	}
@@ -384,7 +400,7 @@ func (s *Store) markTerminal(ctx context.Context, id string, target state.Approv
 		return a, err
 	}
 	if n != 1 {
-		reloaded, _, lerr := loadApprovalTx(ctx, tx, id)
+		reloaded, _, lerr := loadApprovalTx(ctx, tx, stateDir, id)
 		if lerr == nil {
 			a = reloaded
 		}
@@ -402,7 +418,7 @@ func (s *Store) markTerminal(ctx context.Context, id string, target state.Approv
 		TargetStateHash: a.TargetStateHash,
 	}
 	a.Audit = append(a.Audit, audit)
-	if err := writeApprovalJSONTx(ctx, tx, a); err != nil {
+	if err := writeApprovalJSONTx(ctx, tx, b.StateDir, a); err != nil {
 		return a, err
 	}
 	if err := insertAuditTx(ctx, tx, id, b, audit); err != nil {
@@ -436,14 +452,14 @@ VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	return n == 1, nil
 }
 
-func writeApprovalJSONTx(ctx context.Context, tx *sql.Tx, a *state.Approval) error {
+func writeApprovalJSONTx(ctx context.Context, tx *sql.Tx, stateDir string, a *state.Approval) error {
 	blob, err := json.Marshal(a)
 	if err != nil {
 		return fmt.Errorf("marshal approval %s: %w", a.ID, err)
 	}
 	_, err = tx.ExecContext(ctx,
-		`UPDATE approvals SET payload_hash = ?, approval_json = ? WHERE id = ?`,
-		a.PayloadHash, string(blob), a.ID)
+		`UPDATE approvals SET payload_hash = ?, approval_json = ? WHERE state_dir = ? AND id = ?`,
+		a.PayloadHash, string(blob), stateDir, a.ID)
 	return err
 }
 
@@ -468,11 +484,11 @@ func markStaleTx(ctx context.Context, tx *sql.Tx, a *state.Approval, b RowBindin
 	}
 	a.Audit = append(a.Audit, audit)
 	if _, err := tx.ExecContext(ctx,
-		`UPDATE approvals SET status = ?, updated_at = ? WHERE id = ?`,
-		string(state.ApprovalStatusStale), formatTime(now), a.ID); err != nil {
+		`UPDATE approvals SET status = ?, updated_at = ? WHERE state_dir = ? AND id = ?`,
+		string(state.ApprovalStatusStale), formatTime(now), b.StateDir, a.ID); err != nil {
 		return err
 	}
-	if err := writeApprovalJSONTx(ctx, tx, a); err != nil {
+	if err := writeApprovalJSONTx(ctx, tx, b.StateDir, a); err != nil {
 		return err
 	}
 	return insertAuditTx(ctx, tx, a.ID, b, audit)
@@ -481,10 +497,10 @@ func markStaleTx(ctx context.Context, tx *sql.Tx, a *state.Approval, b RowBindin
 // loadApprovalTx returns the full approval plus its stored project/repo/
 // state_dir binding so audit rows written by a later transition carry the
 // same context that Put seeded.
-func loadApprovalTx(ctx context.Context, tx *sql.Tx, id string) (*state.Approval, RowBinding, error) {
+func loadApprovalTx(ctx context.Context, tx *sql.Tx, scopeDir, id string) (*state.Approval, RowBinding, error) {
 	var blob, project, repo, stateDir string
 	err := tx.QueryRowContext(ctx,
-		`SELECT approval_json, project, repo, state_dir FROM approvals WHERE id = ?`, id).
+		`SELECT approval_json, project, repo, state_dir FROM approvals WHERE state_dir = ? AND id = ?`, scopeDir, id).
 		Scan(&blob, &project, &repo, &stateDir)
 	if err != nil {
 		return nil, RowBinding{}, err

--- a/internal/approvalstore/store.go
+++ b/internal/approvalstore/store.go
@@ -1,0 +1,525 @@
+// Package approvalstore persists supervisor Approvals (and their audit
+// trail) in SQLite with a transactional claim-once primitive, replacing the
+// per-project JSON read-merge-write path for the approve/reject transition.
+//
+// The motivating bug (write-path premortem 2026-05-30, failure modes #2/#3):
+// two parallel `approve` of the same id read the same pending JSON snapshot,
+// each flips it to approved, and the 3-way merge keeps both — so the
+// downstream executor fires the side effect twice (double merge_pr, double
+// close_issue). The fix is an atomic claim:
+//
+//	UPDATE approvals SET status='approved' WHERE id=? AND status='pending'
+//
+// Exactly one writer observes rows-affected==1 and proceeds; every other
+// caller sees 0 and is told the approval was already processed. WAL + a
+// single pooled connection (mirroring internal/configstore) make the claim
+// safe both in-process and across the CLI/daemon process boundary.
+//
+// Each row carries project / repo / state_dir columns so a single shared
+// maestro.db can hold every project's approvals without cross-project
+// mutation (premortem #2/#3 — the executor's repo guard re-checks the same
+// binding at execute time).
+package approvalstore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+	_ "modernc.org/sqlite"
+)
+
+// Schema creates the approvals + approval_audit tables. Both are
+// IF NOT EXISTS so Init is idempotent and safe to run against an existing
+// maestro.db. The denormalized project/repo/state_dir columns bind every
+// row to its originating project context (premortem #2/#3).
+const Schema = `
+CREATE TABLE IF NOT EXISTS approvals (
+	id            TEXT PRIMARY KEY,
+	decision_id   TEXT NOT NULL DEFAULT '',
+	project       TEXT NOT NULL DEFAULT '',
+	repo          TEXT NOT NULL DEFAULT '',
+	state_dir     TEXT NOT NULL DEFAULT '',
+	action        TEXT NOT NULL DEFAULT '',
+	status        TEXT NOT NULL,
+	payload_hash  TEXT NOT NULL DEFAULT '',
+	created_at    TEXT NOT NULL,
+	updated_at    TEXT NOT NULL,
+	approval_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS approval_audit (
+	seq               INTEGER PRIMARY KEY AUTOINCREMENT,
+	approval_id       TEXT NOT NULL,
+	project           TEXT NOT NULL DEFAULT '',
+	repo              TEXT NOT NULL DEFAULT '',
+	state_dir         TEXT NOT NULL DEFAULT '',
+	at                TEXT NOT NULL,
+	event             TEXT NOT NULL,
+	actor             TEXT NOT NULL DEFAULT '',
+	reason            TEXT NOT NULL DEFAULT '',
+	payload_hash      TEXT NOT NULL DEFAULT '',
+	target_state_hash TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_approval_audit_approval_id ON approval_audit(approval_id);
+`
+
+// RowBinding is the per-project context stamped onto every approval and
+// audit row so one shared maestro.db can hold every project's approvals.
+type RowBinding struct {
+	Project  string
+	Repo     string
+	StateDir string
+}
+
+// Store is a SQLite-backed approvals store.
+type Store struct {
+	db *sql.DB
+}
+
+// DefaultDBPath is the shared approvals database (~/.maestro/maestro.db),
+// a sibling of the config store's config.db. A single file holds every
+// project's approvals; rows are tagged by project/repo/state_dir.
+func DefaultDBPath() string {
+	return filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.db")
+}
+
+// Open opens (creating the parent dir if needed) the approvals database and
+// ensures the schema. The pragmas mirror internal/configstore: busy_timeout
+// lets a connection wait for a lock instead of erroring "database is locked"
+// (the CLI `supervise approve` writes from a separate process than the
+// daemon), WAL lets a reader and a writer proceed concurrently across
+// processes, and MaxOpenConns(1) removes the SQLITE_BUSY that modernc/sqlite
+// can still report between two pooled connections of the same process.
+func Open(path string) (*Store, error) {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("create approvals db dir %s: %w", dir, err)
+		}
+	}
+	dsn := path
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	// _txlock=immediate is essential for the claim-once UPDATE: every
+	// transaction acquires the write lock at BEGIN rather than upgrading from
+	// a read lock mid-transaction. Two concurrent claims that both started a
+	// deferred (read) transaction and then tried to UPDATE would dead-lock on
+	// the write-lock upgrade and one would get SQLITE_BUSY *immediately*
+	// (busy_timeout does not cover an upgrade deadlock). With IMMEDIATE the
+	// second claimant simply waits up to busy_timeout for the first to commit,
+	// then observes status!='pending' and loses the claim cleanly. This is the
+	// cross-process (CLI vs daemon) safety that the WHERE status='pending'
+	// guard relies on.
+	dsn += sep + "_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	s := &Store{db: db}
+	if err := s.Init(context.Background()); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+// Close releases the underlying database handle.
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// Init creates the schema. Idempotent.
+func (s *Store) Init(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, Schema)
+	return err
+}
+
+// Put seeds an approval into the store WITHOUT overwriting an existing row
+// (INSERT OR IGNORE). Returning inserted=false means a row for this id was
+// already present — crucially, a concurrent claim that already advanced the
+// status MUST NOT be reset back to pending, so Put never updates an existing
+// row. When the row is newly inserted, the approval's existing audit entries
+// are mirrored into approval_audit so the table is a faithful trail.
+//
+// Put is the write-through seed used during the JSON→SQLite transition: the
+// JSON state remains the mint source; Put copies a pending approval into
+// SQLite just before the atomic claim.
+func (s *Store) Put(ctx context.Context, a *state.Approval, b RowBinding) (inserted bool, err error) {
+	if a == nil || strings.TrimSpace(a.ID) == "" {
+		return false, errors.New("approval id is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	ins, err := putApprovalTx(ctx, tx, a, b)
+	if err != nil {
+		return false, err
+	}
+	if ins {
+		for i := range a.Audit {
+			if err := insertAuditTx(ctx, tx, a.ID, b, a.Audit[i]); err != nil {
+				return false, err
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return ins, nil
+}
+
+// Get returns the full approval (audit included, via approval_json) for id,
+// or state.ErrApprovalNotFound.
+func (s *Store) Get(ctx context.Context, id string) (*state.Approval, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT approval_json FROM approvals WHERE id = ?`, id)
+	return scanApproval(row)
+}
+
+// List returns every approval bound to the given state_dir, ordered by
+// created_at. An empty stateDir returns all approvals.
+func (s *Store) List(ctx context.Context, stateDir string) ([]*state.Approval, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if strings.TrimSpace(stateDir) == "" {
+		rows, err = s.db.QueryContext(ctx, `SELECT approval_json FROM approvals ORDER BY created_at`)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `SELECT approval_json FROM approvals WHERE state_dir = ? ORDER BY created_at`, stateDir)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]*state.Approval, 0)
+	for rows.Next() {
+		a, err := scanApproval(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// Approve atomically claims a pending approval (pending → approved). It is
+// the transactional counterpart of state.ApproveApproval and returns the
+// same error sentinels:
+//
+//   - state.ErrApprovalNotFound       — no such id
+//   - state.ErrApprovalStale          — already stale
+//   - state.ErrApprovalSuperseded     — already superseded
+//   - state.ErrApprovalNotPending     — already approved/rejected/executed,
+//     OR lost the claim race to a concurrent caller (the "already
+//     processed" outcome)
+//   - state.ErrApprovalPayloadMismatch — payload drifted from its hash
+//
+// Exactly one concurrent caller observes rows-affected==1 and returns nil;
+// every other caller returns ErrApprovalNotPending without mutating state.
+func (s *Store) Approve(ctx context.Context, id string, now time.Time, actor, reason string) (*state.Approval, error) {
+	return s.claim(ctx, id, state.ApprovalStatusApproved, state.ApprovalAuditApproved, now, actor, reason)
+}
+
+// Reject atomically claims a pending approval (pending → rejected), with the
+// same claim-once semantics and error sentinels as Approve.
+func (s *Store) Reject(ctx context.Context, id string, now time.Time, actor, reason string) (*state.Approval, error) {
+	return s.claim(ctx, id, state.ApprovalStatusRejected, state.ApprovalAuditRejected, now, actor, reason)
+}
+
+// claim implements the pending → {approved,rejected} transition with the
+// atomic UPDATE ... WHERE status='pending' guard.
+func (s *Store) claim(ctx context.Context, id string, target state.ApprovalStatus, event string, now time.Time, actor, reason string) (*state.Approval, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	a, b, err := loadApprovalTx(ctx, tx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, state.ErrApprovalNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	switch a.Status {
+	case state.ApprovalStatusStale:
+		return a, state.ErrApprovalStale
+	case state.ApprovalStatusSuperseded:
+		return a, state.ErrApprovalSuperseded
+	case state.ApprovalStatusPending:
+		// claimable — fall through
+	default:
+		return a, state.ErrApprovalNotPending
+	}
+
+	// Internal-consistency guard, mirroring state.ensureApprovalCurrent: a
+	// pending approval whose payload drifted from its recorded hash is staled
+	// rather than approved.
+	if a.PayloadHash != "" && a.ComputePayloadHash() != a.PayloadHash {
+		if err := markStaleTx(ctx, tx, a, b, now, "approval payload changed"); err != nil {
+			return a, err
+		}
+		if err := tx.Commit(); err != nil {
+			return a, err
+		}
+		return a, state.ErrApprovalPayloadMismatch
+	}
+
+	now = normalize(now)
+	res, err := tx.ExecContext(ctx,
+		`UPDATE approvals SET status = ?, updated_at = ? WHERE id = ? AND status = ?`,
+		string(target), formatTime(now), id, string(state.ApprovalStatusPending))
+	if err != nil {
+		return a, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return a, err
+	}
+	if n != 1 {
+		// Lost the claim to a concurrent writer between our read and UPDATE.
+		// Reload so the caller sees the winner's status, and report
+		// "already processed".
+		reloaded, _, lerr := loadApprovalTx(ctx, tx, id)
+		if lerr == nil {
+			a = reloaded
+		}
+		return a, state.ErrApprovalNotPending
+	}
+
+	a.Status = target
+	a.UpdatedAt = now
+	audit := state.ApprovalAudit{
+		At:              now,
+		Event:           event,
+		Actor:           actor,
+		Reason:          reason,
+		PayloadHash:     a.PayloadHash,
+		TargetStateHash: a.TargetStateHash,
+	}
+	a.Audit = append(a.Audit, audit)
+	if err := writeApprovalJSONTx(ctx, tx, a); err != nil {
+		return a, err
+	}
+	if err := insertAuditTx(ctx, tx, id, b, audit); err != nil {
+		return a, err
+	}
+	if err := tx.Commit(); err != nil {
+		return a, err
+	}
+	return a, nil
+}
+
+// MarkExecuted transitions approved → executed, mirroring
+// state.MarkApprovalExecuted. Idempotent at the caller boundary: an approval
+// not in status=approved returns state.ErrApprovalNotApproved unchanged, so a
+// concurrent executor cannot double-record.
+func (s *Store) MarkExecuted(ctx context.Context, id string, now time.Time, actor, summary string) (*state.Approval, error) {
+	return s.markTerminal(ctx, id, state.ApprovalStatusExecuted, state.ApprovalAuditExecuted, now, actor, summary)
+}
+
+// MarkExecutionFailed transitions approved → execution_failed.
+func (s *Store) MarkExecutionFailed(ctx context.Context, id string, now time.Time, actor, errMsg string) (*state.Approval, error) {
+	return s.markTerminal(ctx, id, state.ApprovalStatusExecutionFailed, state.ApprovalAuditExecutionFailed, now, actor, errMsg)
+}
+
+// MarkExecutionSkipped transitions approved → execution_skipped.
+func (s *Store) MarkExecutionSkipped(ctx context.Context, id string, now time.Time, actor, reason string) (*state.Approval, error) {
+	return s.markTerminal(ctx, id, state.ApprovalStatusExecutionSkipped, state.ApprovalAuditExecutionSkipped, now, actor, reason)
+}
+
+// MarkAwaitingDispatch transitions approved → awaiting_dispatch.
+func (s *Store) MarkAwaitingDispatch(ctx context.Context, id string, now time.Time, actor, reason string) (*state.Approval, error) {
+	return s.markTerminal(ctx, id, state.ApprovalStatusAwaitingDispatch, state.ApprovalAuditAwaitingDispatch, now, actor, reason)
+}
+
+// markTerminal implements the approved → terminal transition with the atomic
+// UPDATE ... WHERE status='approved' idempotency guard.
+func (s *Store) markTerminal(ctx context.Context, id string, target state.ApprovalStatus, event string, now time.Time, actor, reason string) (*state.Approval, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	a, b, err := loadApprovalTx(ctx, tx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, state.ErrApprovalNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if a.Status != state.ApprovalStatusApproved {
+		return a, state.ErrApprovalNotApproved
+	}
+
+	now = normalize(now)
+	res, err := tx.ExecContext(ctx,
+		`UPDATE approvals SET status = ?, updated_at = ? WHERE id = ? AND status = ?`,
+		string(target), formatTime(now), id, string(state.ApprovalStatusApproved))
+	if err != nil {
+		return a, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return a, err
+	}
+	if n != 1 {
+		reloaded, _, lerr := loadApprovalTx(ctx, tx, id)
+		if lerr == nil {
+			a = reloaded
+		}
+		return a, state.ErrApprovalNotApproved
+	}
+
+	a.Status = target
+	a.UpdatedAt = now
+	audit := state.ApprovalAudit{
+		At:              now,
+		Event:           event,
+		Actor:           actor,
+		Reason:          reason,
+		PayloadHash:     a.PayloadHash,
+		TargetStateHash: a.TargetStateHash,
+	}
+	a.Audit = append(a.Audit, audit)
+	if err := writeApprovalJSONTx(ctx, tx, a); err != nil {
+		return a, err
+	}
+	if err := insertAuditTx(ctx, tx, id, b, audit); err != nil {
+		return a, err
+	}
+	if err := tx.Commit(); err != nil {
+		return a, err
+	}
+	return a, nil
+}
+
+// --- tx helpers -------------------------------------------------------------
+
+func putApprovalTx(ctx context.Context, tx *sql.Tx, a *state.Approval, b RowBinding) (bool, error) {
+	blob, err := json.Marshal(a)
+	if err != nil {
+		return false, fmt.Errorf("marshal approval %s: %w", a.ID, err)
+	}
+	res, err := tx.ExecContext(ctx, `
+INSERT OR IGNORE INTO approvals(id, decision_id, project, repo, state_dir, action, status, payload_hash, created_at, updated_at, approval_json)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		a.ID, a.DecisionID, b.Project, b.Repo, b.StateDir, a.Action, string(a.Status), a.PayloadHash,
+		formatTime(normalize(a.CreatedAt)), formatTime(normalize(a.UpdatedAt)), string(blob))
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n == 1, nil
+}
+
+func writeApprovalJSONTx(ctx context.Context, tx *sql.Tx, a *state.Approval) error {
+	blob, err := json.Marshal(a)
+	if err != nil {
+		return fmt.Errorf("marshal approval %s: %w", a.ID, err)
+	}
+	_, err = tx.ExecContext(ctx,
+		`UPDATE approvals SET payload_hash = ?, approval_json = ? WHERE id = ?`,
+		a.PayloadHash, string(blob), a.ID)
+	return err
+}
+
+func insertAuditTx(ctx context.Context, tx *sql.Tx, approvalID string, b RowBinding, e state.ApprovalAudit) error {
+	_, err := tx.ExecContext(ctx, `
+INSERT INTO approval_audit(approval_id, project, repo, state_dir, at, event, actor, reason, payload_hash, target_state_hash)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		approvalID, b.Project, b.Repo, b.StateDir, formatTime(normalize(e.At)), e.Event, e.Actor, e.Reason, e.PayloadHash, e.TargetStateHash)
+	return err
+}
+
+func markStaleTx(ctx context.Context, tx *sql.Tx, a *state.Approval, b RowBinding, now time.Time, reason string) error {
+	now = normalize(now)
+	a.Status = state.ApprovalStatusStale
+	a.UpdatedAt = now
+	audit := state.ApprovalAudit{
+		At:              now,
+		Event:           state.ApprovalAuditStale,
+		Reason:          reason,
+		PayloadHash:     a.PayloadHash,
+		TargetStateHash: a.TargetStateHash,
+	}
+	a.Audit = append(a.Audit, audit)
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE approvals SET status = ?, updated_at = ? WHERE id = ?`,
+		string(state.ApprovalStatusStale), formatTime(now), a.ID); err != nil {
+		return err
+	}
+	if err := writeApprovalJSONTx(ctx, tx, a); err != nil {
+		return err
+	}
+	return insertAuditTx(ctx, tx, a.ID, b, audit)
+}
+
+// loadApprovalTx returns the full approval plus its stored project/repo/
+// state_dir binding so audit rows written by a later transition carry the
+// same context that Put seeded.
+func loadApprovalTx(ctx context.Context, tx *sql.Tx, id string) (*state.Approval, RowBinding, error) {
+	var blob, project, repo, stateDir string
+	err := tx.QueryRowContext(ctx,
+		`SELECT approval_json, project, repo, state_dir FROM approvals WHERE id = ?`, id).
+		Scan(&blob, &project, &repo, &stateDir)
+	if err != nil {
+		return nil, RowBinding{}, err
+	}
+	var a state.Approval
+	if err := json.Unmarshal([]byte(blob), &a); err != nil {
+		return nil, RowBinding{}, fmt.Errorf("unmarshal approval %s: %w", id, err)
+	}
+	return &a, RowBinding{Project: project, Repo: repo, StateDir: stateDir}, nil
+}
+
+// rowScanner is satisfied by both *sql.Row and *sql.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanApproval(row rowScanner) (*state.Approval, error) {
+	var blob string
+	if err := row.Scan(&blob); err != nil {
+		return nil, err
+	}
+	var a state.Approval
+	if err := json.Unmarshal([]byte(blob), &a); err != nil {
+		return nil, fmt.Errorf("unmarshal approval: %w", err)
+	}
+	return &a, nil
+}
+
+func normalize(t time.Time) time.Time {
+	if t.IsZero() {
+		return time.Now().UTC()
+	}
+	return t.UTC()
+}
+
+func formatTime(t time.Time) string {
+	return t.Format(time.RFC3339Nano)
+}

--- a/internal/approvalstore/store.go
+++ b/internal/approvalstore/store.go
@@ -43,11 +43,10 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-// Schema creates the approvals + approval_audit tables. Both are
-// IF NOT EXISTS so Init is idempotent and safe to run against an existing
-// maestro.db. The denormalized project/repo/state_dir columns bind every
-// row to its originating project context (premortem #2/#3).
-const Schema = `
+// approvalsTableDDL is the approvals table on its own. It is reused as the
+// rebuild target for the legacy-schema migration (migrateApprovalsSchema),
+// which recreates the table under the composite (state_dir, id) primary key.
+const approvalsTableDDL = `
 CREATE TABLE IF NOT EXISTS approvals (
 	id            TEXT NOT NULL,
 	decision_id   TEXT NOT NULL DEFAULT '',
@@ -65,7 +64,22 @@ CREATE TABLE IF NOT EXISTS approvals (
 	-- (state_dir, id) the second project's INSERT OR IGNORE is dropped and a
 	-- claim consumes the wrong project's approval.
 	PRIMARY KEY (state_dir, id)
-);
+);`
+
+// approvalsColumns is the canonical column order of the approvals table. It is
+// the carry-over list when the legacy single-column-PK table is rebuilt under
+// the new schema (migrateApprovalsSchema copies the intersection of these with
+// whatever the legacy table actually has).
+var approvalsColumns = []string{
+	"id", "decision_id", "project", "repo", "state_dir", "action",
+	"status", "payload_hash", "created_at", "updated_at", "approval_json",
+}
+
+// Schema creates the approvals + approval_audit tables. Both are
+// IF NOT EXISTS so Init is idempotent and safe to run against an existing
+// maestro.db. The denormalized project/repo/state_dir columns bind every
+// row to its originating project context (premortem #2/#3).
+const Schema = approvalsTableDDL + `
 
 CREATE TABLE IF NOT EXISTS approval_audit (
 	seq               INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -154,10 +168,113 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
-// Init creates the schema. Idempotent.
+// Init creates the schema and upgrades any legacy single-column-PK approvals
+// table to the (state_dir, id) composite key. Idempotent.
 func (s *Store) Init(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, Schema)
-	return err
+	if _, err := s.db.ExecContext(ctx, Schema); err != nil {
+		return err
+	}
+	return s.migrateApprovalsSchema(ctx)
+}
+
+// migrateApprovalsSchema upgrades a maestro.db created before approval rows
+// were scoped by state_dir. The original table used `id TEXT PRIMARY KEY`, so
+// CREATE TABLE IF NOT EXISTS above is a no-op against it and the composite
+// PRIMARY KEY (state_dir, id) is never installed. In that unscoped table two
+// projects that mint the same content-addressed id collide: the second
+// project's INSERT OR IGNORE is dropped and a scoped claim cannot find — or is
+// blocked by — the wrong project's row. This detects the legacy primary key
+// and rebuilds the table in place (rename → recreate → copy → drop), so the
+// fix reaches already-created databases, not only fresh ones. No-op once the
+// table already carries the composite key.
+func (s *Store) migrateApprovalsSchema(ctx context.Context) error {
+	scoped, cols, err := approvalsPKScopedByStateDir(ctx, s.db)
+	if err != nil {
+		return err
+	}
+	// scoped==true: fresh DB or already migrated. len(cols)==0: the table does
+	// not exist (Schema would have created it, so this only guards a racing
+	// drop) — nothing to rebuild either way.
+	if scoped || len(cols) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// Carry over only columns present in BOTH the legacy table and the new
+	// schema, so a partial legacy layout still migrates without a missing-column
+	// error; any new-only column falls back to its schema default.
+	carry := intersectColumns(cols, approvalsColumns)
+	colList := strings.Join(carry, ", ")
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE approvals RENAME TO approvals_legacy`); err != nil {
+		return fmt.Errorf("rename legacy approvals table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, approvalsTableDDL); err != nil {
+		return fmt.Errorf("recreate approvals table: %w", err)
+	}
+	// Legacy `id` was globally unique, so (state_dir, id) pairs are unique too —
+	// a plain INSERT cannot conflict and surfaces any unexpected duplicate.
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+		`INSERT INTO approvals(%s) SELECT %s FROM approvals_legacy`, colList, colList)); err != nil {
+		return fmt.Errorf("copy legacy approvals rows: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DROP TABLE approvals_legacy`); err != nil {
+		return fmt.Errorf("drop legacy approvals table: %w", err)
+	}
+	return tx.Commit()
+}
+
+// approvalsPKScopedByStateDir reports whether the approvals table's primary key
+// includes state_dir (the new scoped schema) and returns the table's column
+// names. A table with no rows from PRAGMA table_info (the table does not exist)
+// returns scoped=false, cols=nil.
+func approvalsPKScopedByStateDir(ctx context.Context, db *sql.DB) (scoped bool, cols []string, err error) {
+	rows, err := db.QueryContext(ctx, `PRAGMA table_info(approvals)`)
+	if err != nil {
+		return false, nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			ctype   string
+			notnull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false, nil, err
+		}
+		cols = append(cols, name)
+		// pk is the 1-based position within the primary key (0 = not part of
+		// it). The new schema puts state_dir first; the legacy schema keys on
+		// id alone, leaving state_dir at pk=0.
+		if name == "state_dir" && pk > 0 {
+			scoped = true
+		}
+	}
+	return scoped, cols, rows.Err()
+}
+
+// intersectColumns returns the members of want present in have, preserving
+// want's order.
+func intersectColumns(have, want []string) []string {
+	set := make(map[string]bool, len(have))
+	for _, c := range have {
+		set[c] = true
+	}
+	out := make([]string, 0, len(want))
+	for _, c := range want {
+		if set[c] {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // Put seeds an approval into the store WITHOUT overwriting an existing row

--- a/internal/approvalstore/store_test.go
+++ b/internal/approvalstore/store_test.go
@@ -1,0 +1,291 @@
+package approvalstore
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "maestro.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+// seedPending records a pending approval (with a self-consistent payload
+// hash, so the currency guard does not stale it) and returns its id.
+func seedPending(t *testing.T, s *Store, id, action string, target *state.SupervisorTarget) *state.Approval {
+	t.Helper()
+	now := time.Now().UTC()
+	a := &state.Approval{
+		ID:        id,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Action:    action,
+		Target:    target,
+		Summary:   "test " + action,
+		Risk:      "high",
+		Status:    state.ApprovalStatusPending,
+		Repo:      "owner/repo",
+		Project:   "owner/repo",
+		Audit:     []state.ApprovalAudit{{At: now, Event: state.ApprovalAuditCreated}},
+	}
+	a.PayloadHash = a.ComputePayloadHash()
+	inserted, err := s.Put(context.Background(), a, RowBinding{Project: "owner/repo", Repo: "owner/repo", StateDir: "/tmp/sd"})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if !inserted {
+		t.Fatalf("expected fresh insert for %s", id)
+	}
+	return a
+}
+
+func TestApprove_HappyPath(t *testing.T) {
+	s := openTestStore(t)
+	seedPending(t, s, "a1", "merge_pr", &state.SupervisorTarget{PR: 7})
+
+	got, err := s.Approve(context.Background(), "a1", time.Now().UTC(), "oleg", "green")
+	if err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if got.Status != state.ApprovalStatusApproved {
+		t.Fatalf("status = %q, want approved", got.Status)
+	}
+	// Audit trail: created + approved mirrored into the table.
+	if n := auditCount(t, s, "a1"); n != 2 {
+		t.Fatalf("audit rows = %d, want 2", n)
+	}
+}
+
+func TestReject_HappyPath(t *testing.T) {
+	s := openTestStore(t)
+	seedPending(t, s, "r1", "close_issue", &state.SupervisorTarget{Issue: 9})
+
+	got, err := s.Reject(context.Background(), "r1", time.Now().UTC(), "oleg", "no")
+	if err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+	if got.Status != state.ApprovalStatusRejected {
+		t.Fatalf("status = %q, want rejected", got.Status)
+	}
+}
+
+func TestApprove_NotFound(t *testing.T) {
+	s := openTestStore(t)
+	if _, err := s.Approve(context.Background(), "missing", time.Now().UTC(), "x", ""); !errors.Is(err, state.ErrApprovalNotFound) {
+		t.Fatalf("err = %v, want ErrApprovalNotFound", err)
+	}
+}
+
+func TestApprove_SecondAttemptAlreadyProcessed(t *testing.T) {
+	s := openTestStore(t)
+	seedPending(t, s, "a2", "merge_pr", &state.SupervisorTarget{PR: 1})
+
+	if _, err := s.Approve(context.Background(), "a2", time.Now().UTC(), "x", ""); err != nil {
+		t.Fatalf("first approve: %v", err)
+	}
+	// Sequential second approve of an already-approved id → not pending.
+	if _, err := s.Approve(context.Background(), "a2", time.Now().UTC(), "y", ""); !errors.Is(err, state.ErrApprovalNotPending) {
+		t.Fatalf("second approve err = %v, want ErrApprovalNotPending", err)
+	}
+}
+
+func TestApprove_PayloadMismatchStales(t *testing.T) {
+	s := openTestStore(t)
+	a := seedPending(t, s, "a3", "merge_pr", &state.SupervisorTarget{PR: 5})
+	// Corrupt the stored payload hash so ComputePayloadHash() no longer matches.
+	a.PayloadHash = "stale-hash"
+	if err := s.forceWriteJSON(a); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got, err := s.Approve(context.Background(), "a3", time.Now().UTC(), "x", "")
+	if !errors.Is(err, state.ErrApprovalPayloadMismatch) {
+		t.Fatalf("err = %v, want ErrApprovalPayloadMismatch", err)
+	}
+	if got.Status != state.ApprovalStatusStale {
+		t.Fatalf("status = %q, want stale", got.Status)
+	}
+}
+
+// TestApprove_ConcurrentClaimOnce reproduces the write-path premortem
+// double-execute scenario: two parallel approves of the SAME id must result
+// in exactly ONE winning claim. Every loser is told the approval was already
+// processed (ErrApprovalNotPending), so a downstream executor fires once.
+func TestApprove_ConcurrentClaimOnce(t *testing.T) {
+	s := openTestStore(t)
+	seedPending(t, s, "race", "merge_pr", &state.SupervisorTarget{PR: 42})
+
+	const racers = 8
+	var (
+		wins      int32
+		notending int32
+		executed  int32 // proxy for the real side effect
+		start     = make(chan struct{})
+		wg        sync.WaitGroup
+	)
+	wg.Add(racers)
+	for i := 0; i < racers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := s.Approve(context.Background(), "race", time.Now().UTC(), "racer", "")
+			switch {
+			case err == nil:
+				atomic.AddInt32(&wins, 1)
+				atomic.AddInt32(&executed, 1) // only the winner "executes"
+			case errors.Is(err, state.ErrApprovalNotPending):
+				atomic.AddInt32(&notending, 1)
+			default:
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if wins != 1 {
+		t.Fatalf("wins = %d, want exactly 1 (claim-once violated)", wins)
+	}
+	if executed != 1 {
+		t.Fatalf("executed = %d, want exactly 1 side effect", executed)
+	}
+	if notending != racers-1 {
+		t.Fatalf("already-processed losers = %d, want %d", notending, racers-1)
+	}
+}
+
+// TestApprove_ConcurrentClaimOnce_SeparateConnections simulates the
+// cross-process CLI race: two `maestro supervise approve` invocations each
+// open their OWN store handle (separate connection) against the same db file.
+// The IMMEDIATE-locked claim plus busy_timeout must still yield exactly one
+// winner with no SQLITE_BUSY leaking out.
+func TestApprove_ConcurrentClaimOnce_SeparateConnections(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "maestro.db")
+	seeder, err := Open(path)
+	if err != nil {
+		t.Fatalf("open seeder: %v", err)
+	}
+	defer seeder.Close()
+	seedPending(t, seeder, "xproc", "merge_pr", &state.SupervisorTarget{PR: 99})
+
+	const procs = 6
+	var (
+		wins     int32
+		notpend  int32
+		start    = make(chan struct{})
+		wg       sync.WaitGroup
+		otherErr = make(chan error, procs)
+	)
+	wg.Add(procs)
+	for i := 0; i < procs; i++ {
+		go func() {
+			defer wg.Done()
+			s, err := Open(path) // its own connection, like a separate process
+			if err != nil {
+				otherErr <- err
+				return
+			}
+			defer s.Close()
+			<-start
+			_, err = s.Approve(context.Background(), "xproc", time.Now().UTC(), "racer", "")
+			switch {
+			case err == nil:
+				atomic.AddInt32(&wins, 1)
+			case errors.Is(err, state.ErrApprovalNotPending):
+				atomic.AddInt32(&notpend, 1)
+			default:
+				otherErr <- err
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(otherErr)
+	for e := range otherErr {
+		t.Errorf("unexpected error from cross-connection claim: %v", e)
+	}
+	if wins != 1 {
+		t.Fatalf("wins = %d, want exactly 1", wins)
+	}
+	if notpend != procs-1 {
+		t.Fatalf("already-processed = %d, want %d", notpend, procs-1)
+	}
+}
+
+func TestMarkExecuted_Idempotent(t *testing.T) {
+	s := openTestStore(t)
+	seedPending(t, s, "m1", "merge_pr", &state.SupervisorTarget{PR: 3})
+	if _, err := s.Approve(context.Background(), "m1", time.Now().UTC(), "x", ""); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	got, err := s.MarkExecuted(context.Background(), "m1", time.Now().UTC(), "x", "merged PR #3")
+	if err != nil {
+		t.Fatalf("mark executed: %v", err)
+	}
+	if got.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("status = %q, want executed", got.Status)
+	}
+	// Second finalize is a no-op error (not in status=approved).
+	if _, err := s.MarkExecuted(context.Background(), "m1", time.Now().UTC(), "x", "again"); !errors.Is(err, state.ErrApprovalNotApproved) {
+		t.Fatalf("second mark err = %v, want ErrApprovalNotApproved", err)
+	}
+}
+
+func TestPut_DoesNotResetStatus(t *testing.T) {
+	s := openTestStore(t)
+	a := seedPending(t, s, "p1", "merge_pr", &state.SupervisorTarget{PR: 8})
+	if _, err := s.Approve(context.Background(), "p1", time.Now().UTC(), "x", ""); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	// A second seed of the same (still pending in JSON) approval must NOT
+	// reset the SQLite row back to pending — that would re-open the claim.
+	a.Status = state.ApprovalStatusPending
+	inserted, err := s.Put(context.Background(), a, RowBinding{})
+	if err != nil {
+		t.Fatalf("re-put: %v", err)
+	}
+	if inserted {
+		t.Fatalf("re-put reported inserted; INSERT OR IGNORE must keep the existing row")
+	}
+	got, err := s.Get(context.Background(), "p1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != state.ApprovalStatusApproved {
+		t.Fatalf("status = %q after re-put, want approved (claim must survive)", got.Status)
+	}
+}
+
+func auditCount(t *testing.T, s *Store, id string) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM approval_audit WHERE approval_id = ?`, id).Scan(&n); err != nil {
+		t.Fatalf("count audit: %v", err)
+	}
+	return n
+}
+
+// forceWriteJSON rewrites the stored approval_json + payload_hash for tests
+// that need to simulate payload drift.
+func (s *Store) forceWriteJSON(a *state.Approval) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := writeApprovalJSONTx(context.Background(), tx, a); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/internal/approvalstore/store_test.go
+++ b/internal/approvalstore/store_test.go
@@ -2,6 +2,8 @@ package approvalstore
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"sync"
@@ -38,6 +40,20 @@ func seedPending(t *testing.T, s *Store, id, action string, target *state.Superv
 // the cross-project isolation test to seed the SAME id under two state dirs.
 func seedPendingScoped(t *testing.T, s *Store, b RowBinding, id, action string, target *state.SupervisorTarget) *state.Approval {
 	t.Helper()
+	a := makeApproval(id, action, target, b)
+	inserted, err := s.Put(context.Background(), a, b)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if !inserted {
+		t.Fatalf("expected fresh insert for %s under %s", id, b.StateDir)
+	}
+	return a
+}
+
+// makeApproval builds a self-consistent pending approval (payload hash matches
+// so the currency guard does not stale it) without writing it anywhere.
+func makeApproval(id, action string, target *state.SupervisorTarget, b RowBinding) *state.Approval {
 	now := time.Now().UTC()
 	a := &state.Approval{
 		ID:        id,
@@ -53,13 +69,6 @@ func seedPendingScoped(t *testing.T, s *Store, b RowBinding, id, action string, 
 		Audit:     []state.ApprovalAudit{{At: now, Event: state.ApprovalAuditCreated}},
 	}
 	a.PayloadHash = a.ComputePayloadHash()
-	inserted, err := s.Put(context.Background(), a, b)
-	if err != nil {
-		t.Fatalf("put: %v", err)
-	}
-	if !inserted {
-		t.Fatalf("expected fresh insert for %s under %s", id, b.StateDir)
-	}
 	return a
 }
 
@@ -322,6 +331,114 @@ func TestPut_DoesNotResetStatus(t *testing.T) {
 	}
 	if got.Status != state.ApprovalStatusApproved {
 		t.Fatalf("status = %q after re-put, want approved (claim must survive)", got.Status)
+	}
+}
+
+// legacyApprovalsDDL is the pre-scope approvals table: keyed on `id` alone, so
+// a shared maestro.db cannot hold two projects' same content-addressed id. It
+// reproduces a database an operator created before the (state_dir, id) key.
+const legacyApprovalsDDL = `
+CREATE TABLE approvals (
+	id            TEXT PRIMARY KEY,
+	decision_id   TEXT NOT NULL DEFAULT '',
+	project       TEXT NOT NULL DEFAULT '',
+	repo          TEXT NOT NULL DEFAULT '',
+	state_dir     TEXT NOT NULL DEFAULT '',
+	action        TEXT NOT NULL DEFAULT '',
+	status        TEXT NOT NULL,
+	payload_hash  TEXT NOT NULL DEFAULT '',
+	created_at    TEXT NOT NULL,
+	updated_at    TEXT NOT NULL,
+	approval_json TEXT NOT NULL
+);`
+
+// TestMigrate_LegacyIDPrimaryKey_Upgrades guards the review P1: an operator who
+// already created maestro.db with the legacy `approvals(id PRIMARY KEY)` table
+// would, with only CREATE TABLE IF NOT EXISTS, keep the unscoped key forever —
+// the second project's same-id approval is dropped by INSERT OR IGNORE. Opening
+// the store must rebuild the table under (state_dir, id), preserving existing
+// rows and unblocking per-project isolation.
+func TestMigrate_LegacyIDPrimaryKey_Upgrades(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "maestro.db")
+	bindA := RowBinding{Project: "owner/a", Repo: "owner/a", StateDir: "/tmp/a"}
+	legacy := makeApproval("legacy", "merge_pr", &state.SupervisorTarget{PR: 1}, bindA)
+	writeLegacyApprovalsDB(t, path, bindA, legacy)
+
+	// Open runs Init → migrateApprovalsSchema, which must detect and rebuild it.
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("open legacy store: %v", err)
+	}
+	defer s.Close()
+
+	if scoped, _, err := approvalsPKScopedByStateDir(context.Background(), s.db); err != nil {
+		t.Fatalf("inspect pk: %v", err)
+	} else if !scoped {
+		t.Fatalf("approvals PK still unscoped after migration")
+	}
+
+	// The legacy row survived the rebuild.
+	got, err := s.Get(context.Background(), bindA.StateDir, "legacy")
+	if err != nil {
+		t.Fatalf("get migrated row: %v", err)
+	}
+	if got.Status != state.ApprovalStatusPending || got.Project != "owner/a" {
+		t.Fatalf("migrated row = {status:%q project:%q}, want pending owner/a", got.Status, got.Project)
+	}
+
+	// The bug is fixed: a second project can now seed the SAME id under its own
+	// state_dir (previously dropped by INSERT OR IGNORE), and approving B's copy
+	// must leave A's untouched.
+	bindB := RowBinding{Project: "owner/b", Repo: "owner/b", StateDir: "/tmp/b"}
+	seedPendingScoped(t, s, bindB, "legacy", "merge_pr", &state.SupervisorTarget{PR: 1})
+	if _, err := s.Approve(context.Background(), bindB.StateDir, "legacy", time.Now().UTC(), "x", ""); err != nil {
+		t.Fatalf("approve B: %v", err)
+	}
+	a, err := s.Get(context.Background(), bindA.StateDir, "legacy")
+	if err != nil {
+		t.Fatalf("get A after B approve: %v", err)
+	}
+	if a.Status != state.ApprovalStatusPending {
+		t.Fatalf("A status = %q after B approve, want pending (legacy row cross-claimed)", a.Status)
+	}
+}
+
+// TestMigrate_NoOpOnFreshDB asserts the migration leaves an already-scoped
+// (freshly created) database untouched and does not error on repeated Init.
+func TestMigrate_NoOpOnFreshDB(t *testing.T) {
+	s := openTestStore(t)
+	seedPending(t, s, "fresh", "merge_pr", &state.SupervisorTarget{PR: 1})
+	// Re-running Init (idempotent) must not disturb the row or the schema.
+	if err := s.Init(context.Background()); err != nil {
+		t.Fatalf("re-init: %v", err)
+	}
+	if _, err := s.Get(context.Background(), testStateDir, "fresh"); err != nil {
+		t.Fatalf("get after re-init: %v", err)
+	}
+}
+
+// writeLegacyApprovalsDB creates a maestro.db with the legacy approvals schema
+// and one row, then closes it — the on-disk state an upgrade has to migrate.
+func writeLegacyApprovalsDB(t *testing.T, path string, b RowBinding, a *state.Approval) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(legacyApprovalsDDL); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	blob, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("marshal approval: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO approvals(id, decision_id, project, repo, state_dir, action, status, payload_hash, created_at, updated_at, approval_json)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		a.ID, a.DecisionID, b.Project, b.Repo, b.StateDir, a.Action, string(a.Status), a.PayloadHash,
+		a.CreatedAt.Format(time.RFC3339Nano), a.UpdatedAt.Format(time.RFC3339Nano), string(blob)); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
 	}
 }
 

--- a/internal/approvalstore/store_test.go
+++ b/internal/approvalstore/store_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/befeast/maestro/internal/state"
 )
 
+// testStateDir is the scope every seedPending row is bound to; tests pass it
+// as the claim scope so the (state_dir, id) row key resolves.
+const testStateDir = "/tmp/sd"
+
 func openTestStore(t *testing.T) *Store {
 	t.Helper()
 	s, err := Open(filepath.Join(t.TempDir(), "maestro.db"))
@@ -23,8 +27,16 @@ func openTestStore(t *testing.T) *Store {
 }
 
 // seedPending records a pending approval (with a self-consistent payload
-// hash, so the currency guard does not stale it) and returns its id.
+// hash, so the currency guard does not stale it) bound to testStateDir and
+// returns it.
 func seedPending(t *testing.T, s *Store, id, action string, target *state.SupervisorTarget) *state.Approval {
+	t.Helper()
+	return seedPendingScoped(t, s, RowBinding{Project: "owner/repo", Repo: "owner/repo", StateDir: testStateDir}, id, action, target)
+}
+
+// seedPendingScoped is seedPending with an explicit project binding, used by
+// the cross-project isolation test to seed the SAME id under two state dirs.
+func seedPendingScoped(t *testing.T, s *Store, b RowBinding, id, action string, target *state.SupervisorTarget) *state.Approval {
 	t.Helper()
 	now := time.Now().UTC()
 	a := &state.Approval{
@@ -36,17 +48,17 @@ func seedPending(t *testing.T, s *Store, id, action string, target *state.Superv
 		Summary:   "test " + action,
 		Risk:      "high",
 		Status:    state.ApprovalStatusPending,
-		Repo:      "owner/repo",
-		Project:   "owner/repo",
+		Repo:      b.Repo,
+		Project:   b.Project,
 		Audit:     []state.ApprovalAudit{{At: now, Event: state.ApprovalAuditCreated}},
 	}
 	a.PayloadHash = a.ComputePayloadHash()
-	inserted, err := s.Put(context.Background(), a, RowBinding{Project: "owner/repo", Repo: "owner/repo", StateDir: "/tmp/sd"})
+	inserted, err := s.Put(context.Background(), a, b)
 	if err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	if !inserted {
-		t.Fatalf("expected fresh insert for %s", id)
+		t.Fatalf("expected fresh insert for %s under %s", id, b.StateDir)
 	}
 	return a
 }
@@ -55,7 +67,7 @@ func TestApprove_HappyPath(t *testing.T) {
 	s := openTestStore(t)
 	seedPending(t, s, "a1", "merge_pr", &state.SupervisorTarget{PR: 7})
 
-	got, err := s.Approve(context.Background(), "a1", time.Now().UTC(), "oleg", "green")
+	got, err := s.Approve(context.Background(), testStateDir, "a1", time.Now().UTC(), "oleg", "green")
 	if err != nil {
 		t.Fatalf("approve: %v", err)
 	}
@@ -72,7 +84,7 @@ func TestReject_HappyPath(t *testing.T) {
 	s := openTestStore(t)
 	seedPending(t, s, "r1", "close_issue", &state.SupervisorTarget{Issue: 9})
 
-	got, err := s.Reject(context.Background(), "r1", time.Now().UTC(), "oleg", "no")
+	got, err := s.Reject(context.Background(), testStateDir, "r1", time.Now().UTC(), "oleg", "no")
 	if err != nil {
 		t.Fatalf("reject: %v", err)
 	}
@@ -83,7 +95,7 @@ func TestReject_HappyPath(t *testing.T) {
 
 func TestApprove_NotFound(t *testing.T) {
 	s := openTestStore(t)
-	if _, err := s.Approve(context.Background(), "missing", time.Now().UTC(), "x", ""); !errors.Is(err, state.ErrApprovalNotFound) {
+	if _, err := s.Approve(context.Background(), testStateDir, "missing", time.Now().UTC(), "x", ""); !errors.Is(err, state.ErrApprovalNotFound) {
 		t.Fatalf("err = %v, want ErrApprovalNotFound", err)
 	}
 }
@@ -92,12 +104,58 @@ func TestApprove_SecondAttemptAlreadyProcessed(t *testing.T) {
 	s := openTestStore(t)
 	seedPending(t, s, "a2", "merge_pr", &state.SupervisorTarget{PR: 1})
 
-	if _, err := s.Approve(context.Background(), "a2", time.Now().UTC(), "x", ""); err != nil {
+	if _, err := s.Approve(context.Background(), testStateDir, "a2", time.Now().UTC(), "x", ""); err != nil {
 		t.Fatalf("first approve: %v", err)
 	}
 	// Sequential second approve of an already-approved id → not pending.
-	if _, err := s.Approve(context.Background(), "a2", time.Now().UTC(), "y", ""); !errors.Is(err, state.ErrApprovalNotPending) {
+	if _, err := s.Approve(context.Background(), testStateDir, "a2", time.Now().UTC(), "y", ""); !errors.Is(err, state.ErrApprovalNotPending) {
 		t.Fatalf("second approve err = %v, want ErrApprovalNotPending", err)
+	}
+}
+
+// TestApprove_CrossProjectSameID_Isolated guards the P1 fix: approval ids are
+// content-addressed on (action, target) only, so two DIFFERENT projects that
+// both gate merge_pr on PR #1 mint the SAME id ("dup"). With a shared
+// maestro.db they must remain independent rows keyed by (state_dir, id):
+// approving project A's row must neither consume nor block project B's, and B
+// must still be able to approve (and reject) its own.
+func TestApprove_CrossProjectSameID_Isolated(t *testing.T) {
+	s := openTestStore(t)
+	const id = "dup"
+	bindA := RowBinding{Project: "owner/a", Repo: "owner/a", StateDir: "/tmp/a"}
+	bindB := RowBinding{Project: "owner/b", Repo: "owner/b", StateDir: "/tmp/b"}
+	seedPendingScoped(t, s, bindA, id, "merge_pr", &state.SupervisorTarget{PR: 1})
+	seedPendingScoped(t, s, bindB, id, "merge_pr", &state.SupervisorTarget{PR: 1})
+
+	// Approve A's copy — B's must stay untouched (still pending).
+	gotA, err := s.Approve(context.Background(), bindA.StateDir, id, time.Now().UTC(), "x", "")
+	if err != nil {
+		t.Fatalf("approve A: %v", err)
+	}
+	if gotA.Status != state.ApprovalStatusApproved {
+		t.Fatalf("A status = %q, want approved", gotA.Status)
+	}
+	gotB, err := s.Get(context.Background(), bindB.StateDir, id)
+	if err != nil {
+		t.Fatalf("get B: %v", err)
+	}
+	if gotB.Status != state.ApprovalStatusPending {
+		t.Fatalf("B status = %q after A approve, want pending (cross-project leak)", gotB.Status)
+	}
+	if gotB.Project != "owner/b" {
+		t.Fatalf("B project = %q, want owner/b (A's row leaked into B's scope)", gotB.Project)
+	}
+
+	// B reject its own copy independently — A stays approved.
+	if _, err := s.Reject(context.Background(), bindB.StateDir, id, time.Now().UTC(), "y", "no"); err != nil {
+		t.Fatalf("reject B: %v", err)
+	}
+	finalA, err := s.Get(context.Background(), bindA.StateDir, id)
+	if err != nil {
+		t.Fatalf("get A: %v", err)
+	}
+	if finalA.Status != state.ApprovalStatusApproved {
+		t.Fatalf("A status = %q after B reject, want still approved", finalA.Status)
 	}
 }
 
@@ -106,10 +164,10 @@ func TestApprove_PayloadMismatchStales(t *testing.T) {
 	a := seedPending(t, s, "a3", "merge_pr", &state.SupervisorTarget{PR: 5})
 	// Corrupt the stored payload hash so ComputePayloadHash() no longer matches.
 	a.PayloadHash = "stale-hash"
-	if err := s.forceWriteJSON(a); err != nil {
+	if err := s.forceWriteJSON(testStateDir, a); err != nil {
 		t.Fatalf("rewrite: %v", err)
 	}
-	got, err := s.Approve(context.Background(), "a3", time.Now().UTC(), "x", "")
+	got, err := s.Approve(context.Background(), testStateDir, "a3", time.Now().UTC(), "x", "")
 	if !errors.Is(err, state.ErrApprovalPayloadMismatch) {
 		t.Fatalf("err = %v, want ErrApprovalPayloadMismatch", err)
 	}
@@ -139,7 +197,7 @@ func TestApprove_ConcurrentClaimOnce(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			_, err := s.Approve(context.Background(), "race", time.Now().UTC(), "racer", "")
+			_, err := s.Approve(context.Background(), testStateDir, "race", time.Now().UTC(), "racer", "")
 			switch {
 			case err == nil:
 				atomic.AddInt32(&wins, 1)
@@ -198,7 +256,7 @@ func TestApprove_ConcurrentClaimOnce_SeparateConnections(t *testing.T) {
 			}
 			defer s.Close()
 			<-start
-			_, err = s.Approve(context.Background(), "xproc", time.Now().UTC(), "racer", "")
+			_, err = s.Approve(context.Background(), testStateDir, "xproc", time.Now().UTC(), "racer", "")
 			switch {
 			case err == nil:
 				atomic.AddInt32(&wins, 1)
@@ -226,10 +284,10 @@ func TestApprove_ConcurrentClaimOnce_SeparateConnections(t *testing.T) {
 func TestMarkExecuted_Idempotent(t *testing.T) {
 	s := openTestStore(t)
 	seedPending(t, s, "m1", "merge_pr", &state.SupervisorTarget{PR: 3})
-	if _, err := s.Approve(context.Background(), "m1", time.Now().UTC(), "x", ""); err != nil {
+	if _, err := s.Approve(context.Background(), testStateDir, "m1", time.Now().UTC(), "x", ""); err != nil {
 		t.Fatalf("approve: %v", err)
 	}
-	got, err := s.MarkExecuted(context.Background(), "m1", time.Now().UTC(), "x", "merged PR #3")
+	got, err := s.MarkExecuted(context.Background(), testStateDir, "m1", time.Now().UTC(), "x", "merged PR #3")
 	if err != nil {
 		t.Fatalf("mark executed: %v", err)
 	}
@@ -237,7 +295,7 @@ func TestMarkExecuted_Idempotent(t *testing.T) {
 		t.Fatalf("status = %q, want executed", got.Status)
 	}
 	// Second finalize is a no-op error (not in status=approved).
-	if _, err := s.MarkExecuted(context.Background(), "m1", time.Now().UTC(), "x", "again"); !errors.Is(err, state.ErrApprovalNotApproved) {
+	if _, err := s.MarkExecuted(context.Background(), testStateDir, "m1", time.Now().UTC(), "x", "again"); !errors.Is(err, state.ErrApprovalNotApproved) {
 		t.Fatalf("second mark err = %v, want ErrApprovalNotApproved", err)
 	}
 }
@@ -245,20 +303,20 @@ func TestMarkExecuted_Idempotent(t *testing.T) {
 func TestPut_DoesNotResetStatus(t *testing.T) {
 	s := openTestStore(t)
 	a := seedPending(t, s, "p1", "merge_pr", &state.SupervisorTarget{PR: 8})
-	if _, err := s.Approve(context.Background(), "p1", time.Now().UTC(), "x", ""); err != nil {
+	if _, err := s.Approve(context.Background(), testStateDir, "p1", time.Now().UTC(), "x", ""); err != nil {
 		t.Fatalf("approve: %v", err)
 	}
 	// A second seed of the same (still pending in JSON) approval must NOT
 	// reset the SQLite row back to pending — that would re-open the claim.
 	a.Status = state.ApprovalStatusPending
-	inserted, err := s.Put(context.Background(), a, RowBinding{})
+	inserted, err := s.Put(context.Background(), a, RowBinding{StateDir: testStateDir})
 	if err != nil {
 		t.Fatalf("re-put: %v", err)
 	}
 	if inserted {
 		t.Fatalf("re-put reported inserted; INSERT OR IGNORE must keep the existing row")
 	}
-	got, err := s.Get(context.Background(), "p1")
+	got, err := s.Get(context.Background(), testStateDir, "p1")
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
@@ -278,13 +336,13 @@ func auditCount(t *testing.T, s *Store, id string) int {
 
 // forceWriteJSON rewrites the stored approval_json + payload_hash for tests
 // that need to simulate payload drift.
-func (s *Store) forceWriteJSON(a *state.Approval) error {
+func (s *Store) forceWriteJSON(stateDir string, a *state.Approval) error {
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
-	if err := writeApprovalJSONTx(context.Background(), tx, a); err != nil {
+	if err := writeApprovalJSONTx(context.Background(), tx, stateDir, a); err != nil {
 		return err
 	}
 	return tx.Commit()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/configwatch"
 	"github.com/befeast/maestro/internal/selfdeploy"
@@ -89,6 +90,16 @@ type Options struct {
 	// WatchStoreInterval is the diff-loop / reload poll cadence; clamped to
 	// DefaultWatchStoreInterval when non-positive.
 	WatchStoreInterval time.Duration
+
+	// ApprovalsStore selects the store backing the fleet approve/reject
+	// endpoint (#759): "json" (default) keeps the legacy per-project JSON
+	// read-merge-write; "sqlite" routes the pending→approved/rejected claim
+	// through the transactional claim-once store at ApprovalsDBPath. Empty is
+	// treated as json.
+	ApprovalsStore string
+	// ApprovalsDBPath is the shared SQLite approvals database used when
+	// ApprovalsStore is "sqlite".
+	ApprovalsDBPath string
 }
 
 // Daemon owns the running project flows and the shared FleetServer.
@@ -251,6 +262,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// One FleetServer for the whole fleet — replaces the N per-project
 	// server.New instances the legacy run/serve paths spun up (#516).
 	fleet := server.NewFleet(projects, d.opts.Host, d.opts.Port, d.opts.ReadOnly)
+	approvalsMode, err := approvalstore.ParseMode(d.opts.ApprovalsStore)
+	if err != nil {
+		return err
+	}
+	if err := fleet.SetApprovalStore(approvalsMode, d.opts.ApprovalsDBPath); err != nil {
+		return fmt.Errorf("open approvals store %s: %w", d.opts.ApprovalsDBPath, err)
+	}
 	fleetAuth := server.FleetAuthFromProjects(projects)
 	fleet.SetAuth(fleetAuth)
 	// Capture the fleet's shared auth token env so the self-deploy health probe

--- a/internal/server/approvals.go
+++ b/internal/server/approvals.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
 )
@@ -65,7 +66,7 @@ func parseApprovalPath(prefix, urlPath string) (approvalRoute, bool) {
 // overrides any actor field in the request body — closing the bypass where
 // "approve IS the human-authorization step, and approve has no auth"
 // (write-path premortem failure mode #4).
-func applyApprovalDecision(w http.ResponseWriter, r *http.Request, readOnly bool, scope string, stateDir string, route approvalRoute, auth authChecker) {
+func applyApprovalDecision(w http.ResponseWriter, r *http.Request, readOnly bool, scope string, stateDir string, route approvalRoute, auth authChecker, store approvalstore.Binding) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -94,25 +95,20 @@ func applyApprovalDecision(w http.ResponseWriter, r *http.Request, readOnly bool
 	actor := resolveActor(authenticatedActor, req.Actor, "dashboard")
 	reason := strings.TrimSpace(req.Reason)
 
-	st, err := state.Load(stateDir)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("load state: %v", err))
-		return
-	}
-
+	// ApplyDecision performs the approve/reject transition against the
+	// configured store. In sqlite mode the pending→approved/rejected claim is
+	// atomic (claim-once across processes), so two parallel approves of the
+	// same id resolve to exactly one winner; the loser gets ErrApprovalNotPending
+	// (409). In json mode it is the legacy st.ApproveApproval/RejectApproval.
+	store.StateDir = stateDir
 	now := time.Now().UTC()
-	var approval *state.Approval
-	switch route.verb {
-	case "approve":
-		approval, err = st.ApproveApproval(route.id, now, actor, reason)
-	case "reject":
-		approval, err = st.RejectApproval(route.id, now, actor, reason)
-	default:
-		// parseApprovalPath already enforces this; defensive fall-back.
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown approval verb %q", route.verb))
-		return
-	}
+	st, approval, err := approvalstore.ApplyDecision(store, route.verb, route.id, now, actor, reason)
 	if err != nil {
+		if st == nil {
+			// state.Load (or store Open) failed before any transition.
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("load state: %v", err))
+			return
+		}
 		// Persist any partial state changes (stale/superseded transitions
 		// can mutate even when the verb fails) before returning.
 		if persistErr := state.Save(stateDir, st); persistErr != nil {
@@ -132,8 +128,12 @@ func applyApprovalDecision(w http.ResponseWriter, r *http.Request, readOnly bool
 			// uniformly with the other conflict cases instead of
 			// receiving a misleading 400 Bad Request.
 			writeError(w, http.StatusConflict, err.Error())
-		default:
+		case errors.Is(err, state.ErrApprovalNotApproved):
 			writeError(w, http.StatusBadRequest, err.Error())
+		default:
+			// Infrastructure errors (sqlite open/exec, write-through) — the
+			// approval state machine only emits the sentinels above.
+			writeError(w, http.StatusInternalServerError, err.Error())
 		}
 		return
 	}
@@ -157,7 +157,7 @@ func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
 	if cfg != nil {
 		stateDir = cfg.StateDir
 	}
-	applyApprovalDecision(w, r, cfgServerReadOnly(cfg), "server", stateDir, route, s.auth)
+	applyApprovalDecision(w, r, cfgServerReadOnly(cfg), "server", stateDir, route, s.auth, s.approvalBinding(cfg))
 }
 
 func cfgServerReadOnly(cfg *config.Config) bool {
@@ -210,5 +210,5 @@ func (s *FleetServer) handleFleetApproval(w http.ResponseWriter, r *http.Request
 	if project.cfg != nil {
 		stateDir = project.cfg.StateDir
 	}
-	applyApprovalDecision(w, r, readOnly, fmt.Sprintf("fleet project %q", projectName), stateDir, route, auth)
+	applyApprovalDecision(w, r, readOnly, fmt.Sprintf("fleet project %q", projectName), stateDir, route, auth, s.approvalBinding(project.cfg))
 }

--- a/internal/server/approvals_sqlite_test.go
+++ b/internal/server/approvals_sqlite_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/befeast/maestro/internal/approvalstore"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// sqliteSrv returns a single-project Server wired to the SQLite approvals
+// store at a fresh db path, sharing the JSON state dir for write-through.
+func sqliteSrv(t *testing.T) (*Server, string) {
+	t.Helper()
+	srv, dir := srvWithStateDir(t)
+	if err := srv.SetApprovalStore(approvalstore.ModeSQLite, filepath.Join(t.TempDir(), "maestro.db")); err != nil {
+		t.Fatalf("set approval store: %v", err)
+	}
+	return srv, dir
+}
+
+func postApprove(t *testing.T, srv *Server, id, verb string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/approvals/"+id+"/"+verb,
+		bytes.NewBufferString(`{"actor":"oleg","reason":"green"}`))
+	w := httptest.NewRecorder()
+	srv.handleApproval(w, req)
+	return w
+}
+
+// TestHandleApproval_SQLite_HappyPath is the sqlite-store parity for
+// TestHandleApproval_Approve_HappyPath: the endpoint behaves identically and
+// the write-through lands the approved status in JSON state.
+func TestHandleApproval_SQLite_HappyPath(t *testing.T) {
+	srv, dir := sqliteSrv(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 12})
+
+	w := postApprove(t, srv, a.ID, "approve")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp approvalDecisionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || resp.Approval == nil || resp.Approval.Status != state.ApprovalStatusApproved {
+		t.Fatalf("response = %+v", resp)
+	}
+	// Write-through: JSON state (executor loop's source) reflects approved.
+	st, _ := state.Load(dir)
+	if st.Approvals[0].Status != state.ApprovalStatusApproved {
+		t.Fatalf("json disk status = %q, want approved", st.Approvals[0].Status)
+	}
+}
+
+func TestHandleApproval_SQLite_Reject(t *testing.T) {
+	srv, dir := sqliteSrv(t)
+	a := enqueuedApproval(t, dir, "close_issue", &state.SupervisorTarget{Issue: 7})
+
+	w := postApprove(t, srv, a.ID, "reject")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	st, _ := state.Load(dir)
+	if st.Approvals[0].Status != state.ApprovalStatusRejected {
+		t.Fatalf("json disk status = %q, want rejected", st.Approvals[0].Status)
+	}
+}
+
+func TestHandleApproval_SQLite_NotFound_404(t *testing.T) {
+	srv, _ := sqliteSrv(t)
+	w := postApprove(t, srv, "does-not-exist", "approve")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleApproval_SQLite_SecondApprove_409(t *testing.T) {
+	srv, dir := sqliteSrv(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 1})
+
+	if w := postApprove(t, srv, a.ID, "approve"); w.Code != http.StatusOK {
+		t.Fatalf("first approve status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if w := postApprove(t, srv, a.ID, "approve"); w.Code != http.StatusConflict {
+		t.Fatalf("second approve status = %d, want 409 (already processed); body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleApproval_SQLite_ConcurrentClaimOnce reproduces the write-path
+// premortem double-execute race at the HTTP boundary: two parallel approve
+// POSTs for the SAME id (each opening its own store connection, as the CLI and
+// daemon do across processes) resolve to exactly ONE 200 winner; every other
+// request is told the approval was already processed (409). Exactly one caller
+// would proceed to fire the side effect.
+func TestHandleApproval_SQLite_ConcurrentClaimOnce(t *testing.T) {
+	srv, dir := sqliteSrv(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 42})
+
+	const racers = 6
+	var (
+		ok        int32
+		conflict  int32
+		start     = make(chan struct{})
+		wg        sync.WaitGroup
+		codeOther = make(chan string, racers)
+	)
+	wg.Add(racers)
+	for i := 0; i < racers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			w := postApprove(t, srv, a.ID, "approve")
+			switch w.Code {
+			case http.StatusOK:
+				atomic.AddInt32(&ok, 1)
+			case http.StatusConflict:
+				atomic.AddInt32(&conflict, 1)
+			default:
+				codeOther <- w.Body.String()
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(codeOther)
+	for c := range codeOther {
+		t.Errorf("unexpected response (want 200 or 409): %s", c)
+	}
+
+	if ok != 1 {
+		t.Fatalf("200 OK winners = %d, want exactly 1 (claim-once violated)", ok)
+	}
+	if conflict != racers-1 {
+		t.Fatalf("409 already-processed = %d, want %d", conflict, racers-1)
+	}
+	// Final JSON state is approved exactly once.
+	st, _ := state.Load(dir)
+	if st.Approvals[0].Status != state.ApprovalStatusApproved {
+		t.Fatalf("final json status = %q, want approved", st.Approvals[0].Status)
+	}
+}

--- a/internal/server/approvals_sqlite_test.go
+++ b/internal/server/approvals_sqlite_test.go
@@ -74,6 +74,35 @@ func TestHandleApproval_SQLite_Reject(t *testing.T) {
 	}
 }
 
+// TestHandleApproval_SQLite_ByDecisionID is the sqlite parity for the
+// CLI/JSON promise that `approve <approval-or-decision-id>` accepts either id.
+// The SQLite claim must target the RESOLVED Approval.ID (the row key), not the
+// user-supplied decision-id alias — claiming the raw alias would miss the row
+// and return 404 even though FindApproval resolves it.
+func TestHandleApproval_SQLite_ByDecisionID(t *testing.T) {
+	srv, dir := sqliteSrv(t)
+	a := enqueuedApproval(t, dir, "merge_pr", &state.SupervisorTarget{PR: 21})
+	if a.DecisionID == "" || a.DecisionID == a.ID {
+		t.Fatalf("test needs a distinct decision-id alias; got id=%q decision_id=%q", a.ID, a.DecisionID)
+	}
+
+	w := postApprove(t, srv, a.DecisionID, "approve")
+	if w.Code != http.StatusOK {
+		t.Fatalf("approve by decision-id status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp approvalDecisionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || resp.Approval == nil || resp.Approval.Status != state.ApprovalStatusApproved {
+		t.Fatalf("response = %+v", resp)
+	}
+	st, _ := state.Load(dir)
+	if st.Approvals[0].Status != state.ApprovalStatusApproved {
+		t.Fatalf("json disk status = %q, want approved", st.Approvals[0].Status)
+	}
+}
+
 func TestHandleApproval_SQLite_NotFound_404(t *testing.T) {
 	srv, _ := sqliteSrv(t)
 	w := postApprove(t, srv, "does-not-exist", "approve")

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/server/web"
@@ -268,6 +269,17 @@ type FleetServer struct {
 	// /api/v1/fleet/approvals/{id}/{approve|reject}, and /api/v1/audit/log
 	// require Authorization: Bearer <token>. Always accessed under authMu.
 	auth authChecker
+
+	// approvalsMode / approvalsDBPath select the approvals store backing the
+	// fleet approve/reject endpoint (#759). The zero value (mode "") is the
+	// legacy JSON path; SetApprovalStore flips it to the transactional SQLite
+	// claim-once store shared across every project (rows tagged by
+	// project/repo/state_dir). approvalsHandle is the one shared store reused
+	// across requests so every in-process claim serializes through a single
+	// connection (no SQLITE_BUSY between concurrent fleet approves).
+	approvalsMode   approvalstore.Mode
+	approvalsDBPath string
+	approvalsHandle *approvalstore.Store
 }
 
 // NewFleet creates a FleetServer.
@@ -278,6 +290,38 @@ func NewFleet(projects []FleetProject, host string, port int, readOnly bool) *Fl
 		port:     port,
 		readOnly: readOnly,
 	}
+}
+
+// SetApprovalStore selects the approvals store backend for the fleet
+// approve/reject endpoint. mode is "json" (default) or "sqlite"; dbPath is the
+// shared SQLite approvals database used in sqlite mode (#759). In sqlite mode
+// the shared store is opened eagerly and reused for the server's lifetime.
+func (s *FleetServer) SetApprovalStore(mode approvalstore.Mode, dbPath string) error {
+	if s == nil {
+		return nil
+	}
+	s.approvalsMode = mode
+	s.approvalsDBPath = dbPath
+	if mode == approvalstore.ModeSQLite {
+		store, err := approvalstore.Open(dbPath)
+		if err != nil {
+			return err
+		}
+		s.approvalsHandle = store
+	}
+	return nil
+}
+
+// approvalBinding builds the per-request approvals-store binding from the
+// fleet's configured mode and the target project's repo. StateDir is filled in
+// by applyApprovalDecision.
+func (s *FleetServer) approvalBinding(cfg *config.Config) approvalstore.Binding {
+	b := approvalstore.Binding{Mode: s.approvalsMode, DBPath: s.approvalsDBPath, Handle: s.approvalsHandle}
+	if cfg != nil {
+		b.Repo = cfg.Repo
+		b.Project = cfg.Repo
+	}
+	return b
 }
 
 // projectsSnapshot returns a copy of the project slice under the read lock so

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/server/web"
@@ -40,6 +41,45 @@ type Server struct {
 	// /actions, /approvals/.../{approve|reject}, and /refresh require
 	// Authorization: Bearer <token>.
 	auth authChecker
+
+	// approvalsMode / approvalsDBPath select the approvals store backing the
+	// approve/reject endpoint (#759). The zero value (mode "") is the legacy
+	// JSON path; SetApprovalStore flips it to the transactional SQLite
+	// claim-once store. approvalsHandle is the one shared store reused across
+	// requests so every in-process claim serializes through a single
+	// connection (no SQLITE_BUSY between concurrent dashboard approves).
+	approvalsMode   approvalstore.Mode
+	approvalsDBPath string
+	approvalsHandle *approvalstore.Store
+}
+
+// SetApprovalStore selects the approvals store backend for the approve/reject
+// endpoint. mode is "json" (default) or "sqlite"; dbPath is the SQLite
+// database used in sqlite mode (#759). In sqlite mode the shared store is
+// opened eagerly and reused for the server's lifetime.
+func (s *Server) SetApprovalStore(mode approvalstore.Mode, dbPath string) error {
+	s.approvalsMode = mode
+	s.approvalsDBPath = dbPath
+	if mode == approvalstore.ModeSQLite {
+		store, err := approvalstore.Open(dbPath)
+		if err != nil {
+			return err
+		}
+		s.approvalsHandle = store
+	}
+	return nil
+}
+
+// approvalBinding builds the per-request approvals-store binding from the
+// server's configured mode and the project's repo. StateDir is filled in by
+// applyApprovalDecision.
+func (s *Server) approvalBinding(cfg *config.Config) approvalstore.Binding {
+	b := approvalstore.Binding{Mode: s.approvalsMode, DBPath: s.approvalsDBPath, Handle: s.approvalsHandle}
+	if cfg != nil {
+		b.Repo = cfg.Repo
+		b.Project = cfg.Repo
+	}
+	return b
 }
 
 // SetActionDeps wires the GitHub client and (optional) audit recorder used


### PR DESCRIPTION
Implements #759 (Phase 4 of epic #754).

## Problem
Approvals were claimed via per-project JSON read-merge-write. Two parallel
`approve` of the same id could each flip pending→approved and the 3-way merge
kept both, firing the side effect twice (write-path premortem 2026-05-30,
failure modes #2/#3).

## Changes
- New `internal/approvalstore`: SQLite-backed `approvals` + `approval_audit`
  store (shared `maestro.db`, WAL; `project`/`repo`/`state_dir` columns for
  cross-project mutation defense).
- **Transactional claim-once**: `UPDATE ... WHERE id=? AND status='pending'` —
  exactly one caller wins; every other gets `ErrApprovalNotPending`
  ("already processed"). `_txlock=immediate` + `busy_timeout` make concurrent
  claimants serialize on the write lock instead of dead-locking on a
  read→write upgrade; the HTTP server reuses one connection so in-process
  claims serialize too.
- Flag `--approvals-store=json|sqlite` (default `json` during the transition)
  on `supervise`, `run`, and `daemon`. SQLite mode seeds the pending approval
  from JSON (write-through) and mirrors a winning claim back so the executor
  loop still drives execution.
- Applied at `superviseApprovalCmd` (CLI) and the server/fleet approve/reject
  endpoint (`applyApprovalDecision`); both behave identically on either store.

## Testing
- `go build ./cmd/maestro/`
- `go test ./internal/state/... ./internal/server/... ./internal/approver/... ./internal/approvalstore/... -race`
- Claim-once race tests at the store level (shared and separate connections —
  the cross-process CLI scenario) and at the HTTP boundary: exactly one
  winner, the rest 409 / already-processed. Reproduces the premortem
  double-execute scenario and passes on the sqlite store.

Default remains `json`, so production behavior is unchanged until an operator
flips `--approvals-store=sqlite`.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves approval claiming toward a SQLite-backed store and adds an upgrade path for existing approval databases. The main changes are:

- New SQLite approval store with scoped approval rows and audit records.
- Transactional approve/reject claims using pending-only updates.
- CLI, run, daemon, server, and fleet wiring for `json|sqlite` approval storage.
- Migration coverage for legacy `approvals(id PRIMARY KEY)` databases.

<h3>Confidence Score: 4/5</h3>

The SQLite approval path is reasonably safe to merge with the default still on the existing JSON behavior.

The change includes focused store and HTTP race coverage, migration handling, and keeps the new backend opt-in during transition.

No specific files require follow-up from this review.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the base run with default JSON concurrent approve, where one process succeeded and another failed during save state due to a write conflict.
- Reran with the head state using the SQLite approvals store; the loser hit a database lock error (SQLITE\_BUSY) rather than being already processed.
- The final SQLite row shows awaiting\_dispatch, indicating only one observable execution path occurred in this run and the losing claimant's CLI contract was not satisfied.
- The HTTP claim-once before path shows mixed responses and a summary with one 2xx win, six 409s, and final\_status=approved.
- The HTTP claim-once after path shows the remaining requests all returning 409 with body 'approval is not pending' and an updated summary that still ends in approved.
- The after command exited with code 0, demonstrating the HTTP path now serializes concurrent claimants as requested.
- The before log documents the cross-project base-side command blocker at '/bin/sh: 14: go: not found'.
- The after log shows the generated harness was present but the test did not run due to '/bin/sh: 84: go: not found', and no database or audit rows were produced.

<a href="https://app.greptile.com/trex/runs/12237921/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Concurrent SQLite CLI approve loser returns SQLITE_BUSY instead of already-processed**

   - **Bug**
     - Running two separate `maestro supervise approve <id>` processes concurrently against head with `--approvals-store=sqlite` yielded one successful approval/execution path and one process exiting with `database is locked (5) (SQLITE_BUSY)`. The PR contract requires the loser to serialize through SQLite and exit as already-processed / `ErrApprovalNotPending`, not leak a lock error to the operator.
   - **Cause**
     - The SQLite claim path still has a cross-process locking window where the second CLI process can receive `SQLITE_BUSY` during store initialization/claim setup rather than waiting and observing the first process's committed non-pending status. This bypasses the intended claim-once loser mapping.
   - **Fix**
     - Ensure every SQLite write in the CLI claim path, including schema/init, seed `Put`, claim transaction, and finalize interactions, consistently uses the busy timeout / immediate transaction behavior or retries `SQLITE_BUSY` around the claim boundary until it can re-read the row and return `state.ErrApprovalNotPending` when the first claimant has won.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(approvalstore): migrate legacy id-PK..."](https://github.com/befeast/maestro/commit/ff4a9c3d8c53f5db2354ec5db69eb7df58f4476b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39728477)</sub>

<!-- /greptile_comment -->