### PR TITLE
Phase 5: остальное состояние (sessions/decisions/health/missions) → единая SQLite-БД

### DIFF
--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -12,6 +12,7 @@ import (
 	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/configstore"
 	"github.com/befeast/maestro/internal/daemon"
+	"github.com/befeast/maestro/internal/statestore"
 )
 
 // daemonCmd runs every project in the config store as one long-lived process:
@@ -31,6 +32,8 @@ func daemonCmd(args []string) {
 	watchStoreInterval := fs.Duration("watch-store-interval", daemon.DefaultWatchStoreInterval, "Config-store diff/reload poll interval (with --watch-store)")
 	approvalsStore := fs.String("approvals-store", "json", "Approvals store backend for the fleet approve/reject endpoint: json|sqlite (#759)")
 	approvalsDB := fs.String("approvals-db", approvalstore.DefaultDBPath(), "Shared SQLite approvals db path (used with --approvals-store=sqlite)")
+	stateStore := fs.String("state-store", "json", "State store backend for sessions/decisions/health/missions: json|sqlite (write-through mirror, #760)")
+	stateDB := fs.String("state-db", statestore.DefaultDBPath(), "Shared SQLite state db path (used with --state-store=sqlite)")
 	fs.Parse(args)
 
 	ctx := signalContext()
@@ -58,6 +61,8 @@ func daemonCmd(args []string) {
 		WatchStoreInterval: *watchStoreInterval,
 		ApprovalsStore:     *approvalsStore,
 		ApprovalsDBPath:    *approvalsDB,
+		StateStore:         *stateStore,
+		StateDBPath:        *stateDB,
 	})
 
 	log.Printf("starting maestro daemon — store=%s addr=%s:%d", *storePath, *host, *port)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -299,7 +299,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// import failure is non-fatal: JSON stays authoritative and the fleet read
 	// path re-mirrors on its next snapshot.
 	if store := fleet.StateStore(); store != nil {
+		// keep is the CURRENT fleet's state dirs, built from importCfgs regardless
+		// of per-project import success, so a transient load/import error below
+		// never prunes a live project's rows.
+		keep := make([]string, 0, len(importCfgs))
 		for _, cfg := range importCfgs {
+			keep = append(keep, cfg.StateDir)
 			st, lerr := state.Load(cfg.StateDir)
 			if lerr != nil {
 				log.Printf("[daemon] state import skip (repo=%s state_dir=%s): load failed: %v", cfg.Repo, cfg.StateDir, lerr)
@@ -311,6 +316,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 				continue
 			}
 			log.Printf("[daemon] imported state.json → maestro.db (repo=%s state_dir=%s, %d sessions)", cfg.Repo, cfg.StateDir, len(st.Sessions))
+		}
+		// Drop rows for projects no longer in the fleet (removed from the config
+		// store while the daemon was stopped). Without this, a cross-project query
+		// keeps returning sessions/health for a project that is not running (#760).
+		if perr := store.RetainStateDirs(ctx, keep); perr != nil {
+			log.Printf("[daemon] state prune (drop removed-project rows) failed: %v", perr)
 		}
 	}
 	fleetAuth := server.FleetAuthFromProjects(projects)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -26,6 +26,8 @@ import (
 	"github.com/befeast/maestro/internal/configwatch"
 	"github.com/befeast/maestro/internal/selfdeploy"
 	"github.com/befeast/maestro/internal/server"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/statestore"
 	"github.com/befeast/maestro/internal/supervisor"
 )
 
@@ -100,6 +102,16 @@ type Options struct {
 	// ApprovalsDBPath is the shared SQLite approvals database used when
 	// ApprovalsStore is "sqlite".
 	ApprovalsDBPath string
+
+	// StateStore selects the store backing the remaining orchestration state —
+	// sessions/decisions/backend-health/missions (#760): "json" (default) keeps
+	// per-project state.json as the only store; "sqlite" write-through-mirrors
+	// every project's state into the shared maestro.db on startup and after each
+	// Save so cross-project SQL queries are available. Empty is treated as json.
+	StateStore string
+	// StateDBPath is the shared SQLite state database used when StateStore is
+	// "sqlite" (defaults to the same maestro.db the approvals store uses).
+	StateDBPath string
 }
 
 // Daemon owns the running project flows and the shared FleetServer.
@@ -239,6 +251,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 	usedNames := make(map[string]bool, len(named))
 	projects := make([]server.FleetProject, 0, len(named))
 	storeNames := make([]string, 0, len(named))
+	// importCfgs mirrors the deduped project configs so the startup state import
+	// (#760) and the fleet wiring see exactly the projects that became flows.
+	importCfgs := make([]*config.Config, 0, len(named))
 	for _, nc := range named {
 		cfg := nc.cfg
 		if cfg == nil {
@@ -257,6 +272,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		name := server.UniqueFleetName(cfg.Repo, usedNames)
 		projects = append(projects, server.NewFleetProjectWithGitHubNamed(name, cfg))
 		storeNames = append(storeNames, nc.name)
+		importCfgs = append(importCfgs, cfg)
 	}
 
 	// One FleetServer for the whole fleet — replaces the N per-project
@@ -268,6 +284,34 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 	if err := fleet.SetApprovalStore(approvalsMode, d.opts.ApprovalsDBPath); err != nil {
 		return fmt.Errorf("open approvals store %s: %w", d.opts.ApprovalsDBPath, err)
+	}
+	stateMode, err := statestore.ParseMode(d.opts.StateStore)
+	if err != nil {
+		return err
+	}
+	if err := fleet.SetStateStore(stateMode, d.opts.StateDBPath); err != nil {
+		return fmt.Errorf("open state store %s: %w", d.opts.StateDBPath, err)
+	}
+	// One-shot startup import (#760): mirror each project's existing state.json
+	// into the shared maestro.db so a cross-project query is answered from
+	// SQLite from the first tick. Idempotent — ImportState replaces a project's
+	// rows wholesale, so a re-run (daemon restart) re-converges. A per-project
+	// import failure is non-fatal: JSON stays authoritative and the fleet read
+	// path re-mirrors on its next snapshot.
+	if store := fleet.StateStore(); store != nil {
+		for _, cfg := range importCfgs {
+			st, lerr := state.Load(cfg.StateDir)
+			if lerr != nil {
+				log.Printf("[daemon] state import skip (repo=%s state_dir=%s): load failed: %v", cfg.Repo, cfg.StateDir, lerr)
+				continue
+			}
+			rb := statestore.RowBinding{Project: cfg.Repo, Repo: cfg.Repo, StateDir: cfg.StateDir}
+			if ierr := store.ImportState(ctx, rb, st); ierr != nil {
+				log.Printf("[daemon] state import failed (repo=%s state_dir=%s): %v", cfg.Repo, cfg.StateDir, ierr)
+				continue
+			}
+			log.Printf("[daemon] imported state.json → maestro.db (repo=%s state_dir=%s, %d sessions)", cfg.Repo, cfg.StateDir, len(st.Sessions))
+		}
 	}
 	fleetAuth := server.FleetAuthFromProjects(projects)
 	fleet.SetAuth(fleetAuth)

--- a/internal/daemon/watch.go
+++ b/internal/daemon/watch.go
@@ -78,6 +78,14 @@ func (d *Daemon) reconcileStore(flowParent context.Context, fp map[string]time.T
 		log.Printf("[daemon] store watch: project %q removed — draining flow %q", name, flow.name)
 		if fleet != nil {
 			fleet.RemoveProject(flow.name)
+			// Drop the removed project's rows from the shared maestro.db so its
+			// sessions/health stop surfacing in cross-project queries the moment it
+			// leaves the fleet (#760). No-op in json mode (StateStore() is nil).
+			if store := fleet.StateStore(); store != nil && flow.cfg != nil {
+				if err := store.ClearStateDir(flowParent, flow.cfg.StateDir); err != nil {
+					log.Printf("[daemon] store watch: clear state rows for %q (state_dir=%s) failed: %v", flow.name, flow.cfg.StateDir, err)
+				}
+			}
 		}
 		d.stopFlow(flow.key)
 		// Free this flow's fleet display name AND its flow identity in the local

--- a/internal/daemon/watch.go
+++ b/internal/daemon/watch.go
@@ -78,16 +78,27 @@ func (d *Daemon) reconcileStore(flowParent context.Context, fp map[string]time.T
 		log.Printf("[daemon] store watch: project %q removed — draining flow %q", name, flow.name)
 		if fleet != nil {
 			fleet.RemoveProject(flow.name)
-			// Drop the removed project's rows from the shared maestro.db so its
-			// sessions/health stop surfacing in cross-project queries the moment it
-			// leaves the fleet (#760). No-op in json mode (StateStore() is nil).
-			if store := fleet.StateStore(); store != nil && flow.cfg != nil {
+		}
+		// Drain the flow BEFORE clearing its SQLite rows. stopFlow cancels the flow
+		// ctx and waits for the orchestrator, supervisor, and watchdog goroutines to
+		// exit — any of which may be mid-state.Save. Save fires the process-global
+		// write-through hook (mirrorSavedState), which re-imports the state_dir into
+		// maestro.db AFTER the save. If we cleared first, a save draining between
+		// ClearStateDir and goroutine exit would re-mirror the removed project's
+		// rows, leaving its sessions/health visible to cross-project queries until a
+		// later restart/prune (#760 review). Draining first guarantees no writer can
+		// touch this state_dir after we clear it.
+		d.stopFlow(flow.key)
+		// Now that every writer for this flow has exited, drop the removed project's
+		// rows from the shared maestro.db so its sessions/health stop surfacing in
+		// cross-project queries (#760). No-op in json mode (StateStore() is nil).
+		if fleet != nil && flow.cfg != nil {
+			if store := fleet.StateStore(); store != nil {
 				if err := store.ClearStateDir(flowParent, flow.cfg.StateDir); err != nil {
 					log.Printf("[daemon] store watch: clear state rows for %q (state_dir=%s) failed: %v", flow.name, flow.cfg.StateDir, err)
 				}
 			}
 		}
-		d.stopFlow(flow.key)
 		// Free this flow's fleet display name AND its flow identity in the local
 		// snapshot maps, so a same-tick re-add of the same repo/StateDir reclaims
 		// the base name (instead of getting a numeric-suffixed UniqueFleetName)

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -357,6 +357,17 @@ func (s *FleetServer) SetStateStore(mode statestore.Mode, dbPath string) error {
 			return err
 		}
 		s.stateHandle = store
+		// Install the process-global state.Save write-through hook so EVERY save
+		// in this daemon — orchestrator, supervisor, watchdog, server action —
+		// mirrors into the shared maestro.db, not only the projects the fleet read
+		// path has polled (#760). Without this the mirror is refreshed solely from
+		// projectSnapshot, so a cross-project query stays stuck at the startup
+		// import whenever the dashboard/API is idle.
+		state.SetSaveHook(s.mirrorSavedState)
+	} else {
+		// json mode: drop any hook a prior sqlite configuration installed so the
+		// JSON-only path is fully restored.
+		state.SetSaveHook(nil)
 	}
 	return nil
 }
@@ -384,10 +395,12 @@ func (s *FleetServer) stateBinding(cfg *config.Config) statestore.Binding {
 }
 
 // mirrorState write-through-mirrors one project's freshly-loaded state into the
-// SQLite store. It is a no-op in json mode, so the fleet's per-project state
-// reads transparently keep the shared maestro.db in sync during the transition
-// without changing the HTTP response. A mirror failure is non-fatal — JSON
-// remains authoritative — so it is logged and swallowed rather than surfaced.
+// SQLite store from the fleet READ path. With the state.Save hook installed
+// (mirrorSavedState) the in-process writers already mirror on every save, so this
+// is now a backstop: it re-syncs state written by ANOTHER process (a CLI verb
+// still writing JSON during the transition) on the next fleet snapshot. It is a
+// no-op in json mode. A mirror failure is non-fatal — JSON remains authoritative
+// — so it is logged and swallowed rather than surfaced.
 func (s *FleetServer) mirrorState(cfg *config.Config, st *state.State) {
 	if s == nil || s.stateMode != statestore.ModeSQLite || cfg == nil {
 		return
@@ -395,6 +408,49 @@ func (s *FleetServer) mirrorState(cfg *config.Config, st *state.State) {
 	if err := statestore.Mirror(s.stateBinding(cfg), st); err != nil {
 		log.Printf("[fleet] state mirror for %s failed (json remains authoritative): %v", cfg.Repo, err)
 	}
+}
+
+// mirrorSavedState is the process-global state.Save write-through hook installed
+// by SetStateStore in sqlite mode (#760). It fires after every state.Save in this
+// process and mirrors the persisted snapshot into the shared maestro.db so a
+// cross-project SQL query reflects every write — not only the projects the fleet
+// read path has polled. The originating project's repo/name are resolved from the
+// live project list so a hot-added project tags its rows; a state dir not (yet) in
+// the fleet still mirrors under its state_dir, which is the row scope. A mirror
+// failure is non-fatal: JSON remains the authoritative mint source.
+func (s *FleetServer) mirrorSavedState(stateDir string, st *state.State) {
+	if s == nil || s.stateMode != statestore.ModeSQLite {
+		return
+	}
+	b := statestore.Binding{
+		Mode:     s.stateMode,
+		DBPath:   s.stateDBPath,
+		Handle:   s.stateHandle,
+		StateDir: stateDir,
+	}
+	if cfg := s.cfgForStateDir(stateDir); cfg != nil {
+		b.Repo = cfg.Repo
+		b.Project = cfg.Repo
+	}
+	if err := statestore.Mirror(b, st); err != nil {
+		log.Printf("[fleet] state write-through mirror for %s failed (json remains authoritative): %v", stateDir, err)
+	}
+}
+
+// cfgForStateDir returns the resolved config of the live project whose state dir
+// matches, or nil. It lets the write-through hook tag rows with repo/project
+// without threading a binding through every state.Save call site.
+func (s *FleetServer) cfgForStateDir(stateDir string) *config.Config {
+	stateDir = strings.TrimSpace(stateDir)
+	if stateDir == "" {
+		return nil
+	}
+	for _, p := range s.projectsSnapshot() {
+		if p.cfg != nil && p.cfg.StateDir == stateDir {
+			return p.cfg
+		}
+	}
+	return nil
 }
 
 // projectsSnapshot returns a copy of the project slice under the read lock so

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -25,6 +25,7 @@ import (
 	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/server/web"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/statestore"
 	"gopkg.in/yaml.v3"
 )
 
@@ -280,6 +281,20 @@ type FleetServer struct {
 	approvalsMode   approvalstore.Mode
 	approvalsDBPath string
 	approvalsHandle *approvalstore.Store
+
+	// stateMode / stateDBPath select the store backing the remaining
+	// orchestration state — sessions/decisions/backend-health/missions (#760).
+	// The zero value (mode "") keeps per-project state.json as the only store;
+	// SetStateStore flips it to write-through-mirror every project's state into
+	// the shared maestro.db (rows tagged by project/repo/state_dir) so a
+	// cross-project query ("every running session across the fleet") is one SQL
+	// statement instead of N state.Load calls. stateHandle is the one shared
+	// store reused across requests (single pooled connection). JSON stays the
+	// authoritative mint source during the transition; the mirror is refreshed
+	// on the daemon's startup import and on every fleet state read.
+	stateMode   statestore.Mode
+	stateDBPath string
+	stateHandle *statestore.Store
 }
 
 // NewFleet creates a FleetServer.
@@ -322,6 +337,64 @@ func (s *FleetServer) approvalBinding(cfg *config.Config) approvalstore.Binding 
 		b.Project = cfg.Repo
 	}
 	return b
+}
+
+// SetStateStore selects the store backing the remaining orchestration state —
+// sessions/decisions/backend-health/missions (#760). mode is "json" (default)
+// or "sqlite"; dbPath is the shared maestro.db used in sqlite mode. In sqlite
+// mode the shared store is opened eagerly and reused for the server's lifetime,
+// so the daemon's startup import and every fleet state read share one pooled
+// connection.
+func (s *FleetServer) SetStateStore(mode statestore.Mode, dbPath string) error {
+	if s == nil {
+		return nil
+	}
+	s.stateMode = mode
+	s.stateDBPath = dbPath
+	if mode == statestore.ModeSQLite {
+		store, err := statestore.Open(dbPath)
+		if err != nil {
+			return err
+		}
+		s.stateHandle = store
+	}
+	return nil
+}
+
+// StateStore returns the shared SQLite state store handle when sqlite mode is
+// enabled, else nil. The daemon uses it to run the one-shot startup import;
+// cross-project callers use it for single-query fleet questions.
+func (s *FleetServer) StateStore() *statestore.Store {
+	if s == nil {
+		return nil
+	}
+	return s.stateHandle
+}
+
+// stateBinding builds the per-project state-store binding from the fleet's
+// configured mode and the target project's repo/state dir.
+func (s *FleetServer) stateBinding(cfg *config.Config) statestore.Binding {
+	b := statestore.Binding{Mode: s.stateMode, DBPath: s.stateDBPath, Handle: s.stateHandle}
+	if cfg != nil {
+		b.Repo = cfg.Repo
+		b.Project = cfg.Repo
+		b.StateDir = cfg.StateDir
+	}
+	return b
+}
+
+// mirrorState write-through-mirrors one project's freshly-loaded state into the
+// SQLite store. It is a no-op in json mode, so the fleet's per-project state
+// reads transparently keep the shared maestro.db in sync during the transition
+// without changing the HTTP response. A mirror failure is non-fatal — JSON
+// remains authoritative — so it is logged and swallowed rather than surfaced.
+func (s *FleetServer) mirrorState(cfg *config.Config, st *state.State) {
+	if s == nil || s.stateMode != statestore.ModeSQLite || cfg == nil {
+		return
+	}
+	if err := statestore.Mirror(s.stateBinding(cfg), st); err != nil {
+		log.Printf("[fleet] state mirror for %s failed (json remains authoritative): %v", cfg.Repo, err)
+	}
 }
 
 // projectsSnapshot returns a copy of the project slice under the read lock so
@@ -2839,6 +2912,10 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 		item.OperatorState = buildFleetProjectOperatorState(item)
 		return item, nil
 	}
+	// Write-through the freshly-loaded snapshot into the shared maestro.db
+	// (no-op unless sqlite mode is on) so the cross-project mirror stays in
+	// sync at the fleet's read cadence. JSON stays authoritative (#760).
+	s.mirrorState(cfg, st)
 	item.Freshness = fleetProjectFreshnessForState(cfg.StateDir, st, now)
 	item.RestartRequired = st.RestartRequired
 	item.RestartRequiredReason = st.RestartRequiredReason

--- a/internal/server/fleet_statestore_test.go
+++ b/internal/server/fleet_statestore_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/statestore"
+)
+
+// TestFleetStateStoreCrossProject proves the #760 wiring end to end at the
+// fleet layer: SetStateStore(sqlite) opens a shared maestro.db, mirrorState
+// write-through-mirrors each project's freshly-loaded state, and the resulting
+// mirror answers "every running session across the fleet" in ONE query instead
+// of N state.Load calls.
+func TestFleetStateStoreCrossProject(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "maestro.db")
+	fleet := NewFleet(nil, "127.0.0.1", 0, false)
+	if err := fleet.SetStateStore(statestore.ModeSQLite, db); err != nil {
+		t.Fatalf("set state store: %v", err)
+	}
+	store := fleet.StateStore()
+	if store == nil {
+		t.Fatal("expected a state store handle in sqlite mode")
+	}
+
+	// Two projects, each with one running and one pr_open session.
+	cfgA := &config.Config{Repo: "owner/a", StateDir: filepath.Join(t.TempDir(), "a")}
+	cfgB := &config.Config{Repo: "owner/b", StateDir: filepath.Join(t.TempDir(), "b")}
+	for _, p := range []struct {
+		cfg   *config.Config
+		issue int
+	}{{cfgA, 11}, {cfgB, 22}} {
+		st := state.NewState()
+		st.Sessions["1"] = &state.Session{IssueNumber: p.issue, Status: state.StatusRunning}
+		st.Sessions["2"] = &state.Session{IssueNumber: p.issue + 1, Status: state.StatusPROpen}
+		fleet.mirrorState(p.cfg, st)
+	}
+
+	running, err := store.RunningSessions(context.Background())
+	if err != nil {
+		t.Fatalf("running sessions: %v", err)
+	}
+	if len(running) != 2 {
+		t.Fatalf("want 2 running sessions across the fleet, got %d", len(running))
+	}
+	byProject := map[string]int{}
+	for _, ps := range running {
+		if ps.Session.Status != state.StatusRunning {
+			t.Fatalf("non-running session leaked: %+v", ps.Session)
+		}
+		byProject[ps.Project] = ps.Session.IssueNumber
+	}
+	if byProject["owner/a"] != 11 || byProject["owner/b"] != 22 {
+		t.Fatalf("cross-project running sessions mis-tagged: %+v", byProject)
+	}
+}
+
+// TestFleetStateStoreJSONModeNoop asserts the default (json) mode opens no
+// handle and mirrorState is inert — observable behavior is unchanged until the
+// sqlite mirror is explicitly enabled.
+func TestFleetStateStoreJSONModeNoop(t *testing.T) {
+	fleet := NewFleet(nil, "127.0.0.1", 0, false)
+	if err := fleet.SetStateStore(statestore.ModeJSON, ""); err != nil {
+		t.Fatalf("set state store: %v", err)
+	}
+	if fleet.StateStore() != nil {
+		t.Fatal("json mode must not open a state store handle")
+	}
+	// mirrorState must not panic or write when no handle exists.
+	st := state.NewState()
+	st.Sessions["1"] = &state.Session{IssueNumber: 1, Status: state.StatusRunning}
+	fleet.mirrorState(&config.Config{Repo: "owner/a", StateDir: "/sd/a"}, st)
+}

--- a/internal/server/fleet_statestore_test.go
+++ b/internal/server/fleet_statestore_test.go
@@ -21,6 +21,9 @@ func TestFleetStateStoreCrossProject(t *testing.T) {
 	if err := fleet.SetStateStore(statestore.ModeSQLite, db); err != nil {
 		t.Fatalf("set state store: %v", err)
 	}
+	// SetStateStore installs a process-global state.Save hook; clear it so it
+	// cannot fire into this closed store from a later test in the package.
+	t.Cleanup(func() { state.SetSaveHook(nil) })
 	store := fleet.StateStore()
 	if store == nil {
 		t.Fatal("expected a state store handle in sqlite mode")
@@ -55,6 +58,46 @@ func TestFleetStateStoreCrossProject(t *testing.T) {
 	}
 	if byProject["owner/a"] != 11 || byProject["owner/b"] != 22 {
 		t.Fatalf("cross-project running sessions mis-tagged: %+v", byProject)
+	}
+}
+
+// TestFleetStateStoreWriteThroughOnSave is the #760 P1 fix: with sqlite mode on,
+// a plain state.Save (the orchestrator/supervisor/watchdog/server write path)
+// mirrors into the shared maestro.db through the installed save hook — WITHOUT
+// the fleet read path ever polling the project. The cross-project query then
+// reflects the save immediately instead of being stuck at the startup snapshot.
+func TestFleetStateStoreWriteThroughOnSave(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "maestro.db")
+	cfg := &config.Config{Repo: "owner/a", StateDir: filepath.Join(t.TempDir(), "a")}
+	proj := NewFleetProject("a", "", "", cfg)
+	fleet := NewFleet([]FleetProject{proj}, "127.0.0.1", 0, false)
+	if err := fleet.SetStateStore(statestore.ModeSQLite, db); err != nil {
+		t.Fatalf("set state store: %v", err)
+	}
+	// SetStateStore installs a process-global hook; drop it so it cannot fire into
+	// this closed store from a later test in the package.
+	t.Cleanup(func() { state.SetSaveHook(nil) })
+	store := fleet.StateStore()
+	if store == nil {
+		t.Fatal("expected a state store handle in sqlite mode")
+	}
+
+	// A direct save — no fleet read path involved — must reach the mirror.
+	st := state.NewState()
+	st.Sessions["1"] = &state.Session{IssueNumber: 99, Status: state.StatusRunning}
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	running, err := store.RunningSessions(context.Background())
+	if err != nil {
+		t.Fatalf("running sessions: %v", err)
+	}
+	if len(running) != 1 {
+		t.Fatalf("write-through did not mirror the save: got %d running sessions, want 1", len(running))
+	}
+	if running[0].Project != "owner/a" || running[0].Session.IssueNumber != 99 {
+		t.Fatalf("write-through row mis-tagged: %+v", running[0])
 	}
 }
 

--- a/internal/state/save_hook_test.go
+++ b/internal/state/save_hook_test.go
@@ -1,0 +1,42 @@
+package state
+
+import (
+	"testing"
+)
+
+// TestSaveHookFiresOnSave proves Save invokes the registered write-through hook
+// with the persisted snapshot (#760): this is the single chokepoint that lets the
+// daemon mirror EVERY save — orchestrator/supervisor/watchdog/server — into the
+// shared maestro.db, not just the fleet read path.
+func TestSaveHookFiresOnSave(t *testing.T) {
+	dir := t.TempDir()
+	var gotDir string
+	var gotSessions int
+	SetSaveHook(func(stateDir string, s *State) {
+		gotDir = stateDir
+		gotSessions = len(s.Sessions)
+	})
+	t.Cleanup(func() { SetSaveHook(nil) })
+
+	st := NewState()
+	st.Sessions["1"] = &Session{IssueNumber: 7, Status: StatusRunning}
+	if err := Save(dir, st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if gotDir != dir {
+		t.Fatalf("hook got state dir %q, want %q", gotDir, dir)
+	}
+	if gotSessions != 1 {
+		t.Fatalf("hook saw %d sessions, want 1", gotSessions)
+	}
+}
+
+// TestSaveHookNilIsNoop asserts a cleared hook leaves Save on the JSON-only path.
+func TestSaveHookNilIsNoop(t *testing.T) {
+	SetSaveHook(nil)
+	dir := t.TempDir()
+	st := NewState()
+	if err := Save(dir, st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/befeast/maestro/internal/outcome"
@@ -1269,6 +1270,40 @@ func Load(stateDir string) (*State, error) {
 	return s, nil
 }
 
+// SaveHook is invoked after every successful Save, with the state dir that was
+// written and the just-persisted snapshot. It is the single write-through
+// chokepoint that lets a long-lived process (the daemon) mirror EVERY state.Save
+// — orchestrator, supervisor, watchdog, server action — into a secondary store
+// (the shared maestro.db, #760) without threading a store handle through every
+// call site. The hook runs synchronously while the per-state flock is STILL held,
+// so the mirror write is serialised with the JSON write: two concurrent Saves for
+// the same dir mirror in the order they wrote JSON, and the mirror can never
+// settle on a snapshot older than the JSON. A hook MUST NOT re-enter Save/Load
+// for stateDir (it already holds the flock) and should be fast. A nil hook (the
+// default) leaves the JSON-only path unchanged.
+type SaveHook func(stateDir string, s *State)
+
+var (
+	saveHookMu sync.RWMutex
+	saveHook   SaveHook
+)
+
+// SetSaveHook installs (or clears, with nil) the process-global write-through
+// hook invoked after every successful Save. It is process-global because Save is
+// a free function reached from many packages; the daemon sets it once when the
+// SQLite mirror is enabled and clears it otherwise.
+func SetSaveHook(h SaveHook) {
+	saveHookMu.Lock()
+	saveHook = h
+	saveHookMu.Unlock()
+}
+
+func currentSaveHook() SaveHook {
+	saveHookMu.RLock()
+	defer saveHookMu.RUnlock()
+	return saveHook
+}
+
 func Save(stateDir string, s *State) error {
 	if err := os.MkdirAll(stateDir, 0755); err != nil {
 		return fmt.Errorf("create state dir: %w", err)
@@ -1279,7 +1314,18 @@ func Save(stateDir string, s *State) error {
 	}
 	defer unlock()
 
-	return saveLocked(stateDir, s)
+	if err := saveLocked(stateDir, s); err != nil {
+		return err
+	}
+	// Write-through mirror (#760): replicate the just-persisted snapshot into the
+	// secondary store while STILL holding the flock, so the mirror is serialised
+	// with the JSON write and cannot regress to an older snapshot under concurrent
+	// Saves. Nil unless the daemon registered a mirror, so the JSON-only path is
+	// unchanged.
+	if hook := currentSaveHook(); hook != nil {
+		hook(stateDir, s)
+	}
+	return nil
 }
 
 func saveLocked(stateDir string, s *State) error {

--- a/internal/statestore/gate.go
+++ b/internal/statestore/gate.go
@@ -1,0 +1,94 @@
+package statestore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// Mode selects whether the non-approval state is mirrored into the shared
+// SQLite database. It mirrors approvalstore.Mode so the daemon plumbs both
+// stores with one --state-store / --approvals-store flag pair.
+type Mode string
+
+const (
+	// ModeJSON keeps per-project state.json as the only store (no SQLite
+	// mirror). This is the safe default until the SQLite read path is flipped
+	// on for the fleet.
+	ModeJSON Mode = "json"
+	// ModeSQLite write-through-mirrors every project's state into the shared
+	// maestro.db (JSON remains the authoritative mint source during the
+	// transition) so cross-project SQL queries are available.
+	ModeSQLite Mode = "sqlite"
+)
+
+// ParseMode normalises the --state-store flag value. Empty defaults to json.
+func ParseMode(s string) (Mode, error) {
+	switch strings.TrimSpace(strings.ToLower(s)) {
+	case "", string(ModeJSON):
+		return ModeJSON, nil
+	case string(ModeSQLite):
+		return ModeSQLite, nil
+	default:
+		return "", fmt.Errorf("unknown state store %q (want json|sqlite)", s)
+	}
+}
+
+// Binding is everything a write-through call-site needs to mirror one project's
+// state into SQLite. StateDir is the JSON state directory (the mint source and
+// the row scope); Handle is an optional already-open store shared by a
+// long-lived process (the fleet server / daemon) so every in-process write
+// serialises through its single pooled connection. When Handle is nil and
+// ModeSQLite is selected the store is opened per call from DBPath.
+type Binding struct {
+	Mode     Mode
+	DBPath   string
+	StateDir string
+	Repo     string
+	Project  string
+	Handle   *Store
+}
+
+// UseSQLite reports whether the SQLite mirror is selected.
+func (b Binding) UseSQLite() bool { return b.Mode == ModeSQLite }
+
+// RowBinding projects the per-project columns out of a Binding.
+func (b Binding) RowBinding() RowBinding {
+	return RowBinding{Project: b.Project, Repo: b.Repo, StateDir: b.StateDir}
+}
+
+// resolveStore returns the store to use plus a cleanup func. When Handle is set
+// it is reused (cleanup is a no-op); otherwise a fresh store is opened from
+// DBPath and the cleanup closes it.
+func (b Binding) resolveStore() (*Store, func(), error) {
+	if b.Handle != nil {
+		return b.Handle, func() {}, nil
+	}
+	store, err := Open(b.DBPath)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return store, func() { store.Close() }, nil
+}
+
+// Mirror write-through-mirrors st into the SQLite store for one project. It is a
+// no-op in ModeJSON, so a caller can unconditionally call it after state.Save
+// during the transition and only pay the SQLite write when the mirror is
+// enabled. The mirror is a full per-project snapshot replace (see
+// Store.ImportState), so it is idempotent and converges even after a no-op Save.
+func Mirror(b Binding, st *state.State) error {
+	if !b.UseSQLite() {
+		return nil
+	}
+	if strings.TrimSpace(b.StateDir) == "" {
+		return nil
+	}
+	store, cleanup, err := b.resolveStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	return store.ImportState(context.Background(), b.RowBinding(), st)
+}

--- a/internal/statestore/store.go
+++ b/internal/statestore/store.go
@@ -207,6 +207,51 @@ func (s *Store) ImportState(ctx context.Context, b RowBinding, st *state.State) 
 	return tx.Commit()
 }
 
+// ClearStateDir removes every row bound to stateDir (all four tables) — the
+// removal counterpart used when a project is dropped from the fleet at runtime
+// (#760), so its sessions/health stop surfacing in cross-project queries the
+// moment it leaves. It is ImportState(stateDir, nil) under a clearer name.
+func (s *Store) ClearStateDir(ctx context.Context, stateDir string) error {
+	return s.ImportState(ctx, RowBinding{StateDir: stateDir}, nil)
+}
+
+// RetainStateDirs deletes every row whose state_dir is NOT in keep, across all
+// four tables, in one transaction. It is the startup reconcile for projects that
+// vanished from the config store while the daemon was stopped (#760): the import
+// loop refreshes the rows of the CURRENT fleet, and this drops the stale rows of
+// any project no longer present, so a cross-project query never returns sessions
+// or health for a project that is not running. An empty keep set clears every row
+// (no projects → no state). Blank/duplicate dirs in keep are ignored.
+func (s *Store) RetainStateDirs(ctx context.Context, keep []string) error {
+	seen := make(map[string]bool, len(keep))
+	placeholders := make([]string, 0, len(keep))
+	args := make([]any, 0, len(keep))
+	for _, dir := range keep {
+		dir = strings.TrimSpace(dir)
+		if dir == "" || seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		placeholders = append(placeholders, "?")
+		args = append(args, dir)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, table := range []string{"sessions", "decisions", "backend_health", "missions"} {
+		q := `DELETE FROM ` + table
+		if len(placeholders) > 0 {
+			q += ` WHERE state_dir NOT IN (` + strings.Join(placeholders, ", ") + `)`
+		}
+		if _, err := tx.ExecContext(ctx, q, args...); err != nil {
+			return fmt.Errorf("prune %s: %w", table, err)
+		}
+	}
+	return tx.Commit()
+}
+
 // ProjectSession is one session row with its originating project binding,
 // returned by the cross-project queries so a fleet caller knows which project a
 // session belongs to without a second lookup.

--- a/internal/statestore/store.go
+++ b/internal/statestore/store.go
@@ -1,0 +1,450 @@
+// Package statestore persists the orchestration State slices that Phase 4 left
+// in per-project JSON — Sessions, SupervisorDecisions, BackendHealth and
+// Missions — in the SAME shared maestro.db that internal/approvalstore already
+// uses. The target model (epic #754) is "one DB per daemon": every project's
+// state lives in unified tables keyed by project/repo/state_dir, so a
+// cross-project question ("every running session across the fleet") is one SQL
+// query instead of N state.Load calls.
+//
+// During the transition JSON remains the authoritative mint source: the daemon
+// imports each project's state.json into these tables on startup (idempotent,
+// one-shot) and write-through-mirrors every subsequent Save. Because the JSON
+// path still owns the flock+3-way-merge write, the SQLite copy is a faithful
+// read-optimised mirror — ImportState replaces a project's rows wholesale, so
+// re-running it (startup re-import or a write-through after a no-op Save) always
+// converges to the current snapshot.
+//
+// Every row carries project / repo / state_dir columns so one shared maestro.db
+// holds every project's state without cross-project bleed. state_dir is the
+// per-project identity (1:1 with a project; repo can be shared by two configs,
+// the project name can be aliased, but the state dir is unique), mirroring the
+// scoping internal/approvalstore uses for its (state_dir, id) row key.
+package statestore
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+	_ "modernc.org/sqlite"
+)
+
+// Schema creates the sessions / decisions / backend_health / missions tables.
+// All are IF NOT EXISTS so Init is idempotent and safe to run against the same
+// maestro.db internal/approvalstore initialises (the two packages own disjoint
+// tables in one file). The denormalised project/repo/state_dir columns bind
+// every row to its originating project.
+const Schema = `
+CREATE TABLE IF NOT EXISTS sessions (
+	state_dir    TEXT NOT NULL,
+	project      TEXT NOT NULL DEFAULT '',
+	repo         TEXT NOT NULL DEFAULT '',
+	slot         TEXT NOT NULL,
+	issue_number INTEGER NOT NULL DEFAULT 0,
+	pr_number    INTEGER NOT NULL DEFAULT 0,
+	status       TEXT NOT NULL DEFAULT '',
+	backend      TEXT NOT NULL DEFAULT '',
+	started_at   TEXT NOT NULL DEFAULT '',
+	updated_at   TEXT NOT NULL DEFAULT '',
+	session_json TEXT NOT NULL,
+	PRIMARY KEY (state_dir, slot)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+
+CREATE TABLE IF NOT EXISTS decisions (
+	state_dir     TEXT NOT NULL,
+	project       TEXT NOT NULL DEFAULT '',
+	repo          TEXT NOT NULL DEFAULT '',
+	id            TEXT NOT NULL,
+	created_at    TEXT NOT NULL DEFAULT '',
+	decision_json TEXT NOT NULL,
+	PRIMARY KEY (state_dir, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_decisions_created ON decisions(state_dir, created_at);
+
+CREATE TABLE IF NOT EXISTS backend_health (
+	state_dir    TEXT NOT NULL,
+	project      TEXT NOT NULL DEFAULT '',
+	repo         TEXT NOT NULL DEFAULT '',
+	backend      TEXT NOT NULL,
+	health_state TEXT NOT NULL DEFAULT '',
+	updated_at   TEXT NOT NULL DEFAULT '',
+	health_json  TEXT NOT NULL,
+	PRIMARY KEY (state_dir, backend)
+);
+
+CREATE TABLE IF NOT EXISTS missions (
+	state_dir    TEXT NOT NULL,
+	project      TEXT NOT NULL DEFAULT '',
+	repo         TEXT NOT NULL DEFAULT '',
+	parent_issue INTEGER NOT NULL,
+	status       TEXT NOT NULL DEFAULT '',
+	mission_json TEXT NOT NULL,
+	PRIMARY KEY (state_dir, parent_issue)
+);
+`
+
+// RowBinding is the per-project context stamped onto every row so one shared
+// maestro.db can hold every project's state. It mirrors
+// approvalstore.RowBinding.
+type RowBinding struct {
+	Project  string
+	Repo     string
+	StateDir string
+}
+
+// Store is a SQLite-backed store for the non-approval orchestration state.
+type Store struct {
+	db *sql.DB
+}
+
+// DefaultDBPath is the shared state database (~/.maestro/maestro.db), the same
+// file internal/approvalstore uses. A single file holds every project's state;
+// rows are tagged by project/repo/state_dir.
+func DefaultDBPath() string {
+	return filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.db")
+}
+
+// Open opens (creating the parent dir if needed) the state database and ensures
+// the schema. The pragmas mirror internal/configstore and internal/approvalstore:
+// busy_timeout lets a connection wait for a lock instead of erroring "database
+// is locked" (CLI verbs may write from a separate process than the daemon), WAL
+// lets a reader and a writer proceed concurrently across processes, and
+// MaxOpenConns(1) removes the SQLITE_BUSY that modernc/sqlite can still report
+// between two pooled connections of the same process.
+func Open(path string) (*Store, error) {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("create state db dir %s: %w", dir, err)
+		}
+	}
+	dsn := path
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	dsn += sep + "_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	s := &Store{db: db}
+	if err := s.Init(context.Background()); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+// Close releases the underlying database handle.
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// Init creates the schema. Idempotent.
+func (s *Store) Init(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, Schema)
+	return err
+}
+
+// ImportState replaces every row bound to b.StateDir with the slices carried by
+// st, in one transaction. It is the one-shot startup import AND the
+// write-through mirror: both want the SQLite copy to equal the JSON snapshot for
+// one project, so a wholesale per-project delete+insert is the simplest faithful
+// (and idempotent) sync — a session, decision, health entry or mission removed
+// from JSON disappears from the mirror on the next import, and re-importing an
+// unchanged state is a no-op observable result.
+//
+// st==nil clears the project's rows (an empty snapshot), so a freshly-deleted
+// project does not strand stale rows in a cross-project query.
+func (s *Store) ImportState(ctx context.Context, b RowBinding, st *state.State) error {
+	if strings.TrimSpace(b.StateDir) == "" {
+		return errors.New("state_dir is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	for _, table := range []string{"sessions", "decisions", "backend_health", "missions"} {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM `+table+` WHERE state_dir = ?`, b.StateDir); err != nil {
+			return fmt.Errorf("clear %s for %s: %w", table, b.StateDir, err)
+		}
+	}
+	if st == nil {
+		return tx.Commit()
+	}
+
+	now := time.Now().UTC()
+	if err := insertSessionsTx(ctx, tx, b, st.Sessions, now); err != nil {
+		return err
+	}
+	if err := insertDecisionsTx(ctx, tx, b, st.SupervisorDecisions); err != nil {
+		return err
+	}
+	if err := insertBackendHealthTx(ctx, tx, b, st.BackendHealth, now); err != nil {
+		return err
+	}
+	if err := insertMissionsTx(ctx, tx, b, st.Missions); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// ProjectSession is one session row with its originating project binding,
+// returned by the cross-project queries so a fleet caller knows which project a
+// session belongs to without a second lookup.
+type ProjectSession struct {
+	RowBinding
+	Slot    string
+	Session *state.Session
+}
+
+// RunningSessions returns every session across all projects whose status is
+// StatusRunning, in one query — the canonical cross-project example from #760
+// (all running sessions across the fleet without N state.Load calls).
+func (s *Store) RunningSessions(ctx context.Context) ([]ProjectSession, error) {
+	return s.SessionsByStatus(ctx, string(state.StatusRunning))
+}
+
+// SessionsByStatus returns every session across all projects whose status is in
+// the given set, ordered by project then slot, in one query. An empty set
+// returns every session.
+func (s *Store) SessionsByStatus(ctx context.Context, statuses ...string) ([]ProjectSession, error) {
+	q := `SELECT project, repo, state_dir, slot, session_json FROM sessions`
+	args := make([]any, 0, len(statuses))
+	if len(statuses) > 0 {
+		placeholders := make([]string, len(statuses))
+		for i, st := range statuses {
+			placeholders[i] = "?"
+			args = append(args, st)
+		}
+		q += ` WHERE status IN (` + strings.Join(placeholders, ", ") + `)`
+	}
+	q += ` ORDER BY project, state_dir, slot`
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]ProjectSession, 0)
+	for rows.Next() {
+		var project, repo, stateDir, slot, blob string
+		if err := rows.Scan(&project, &repo, &stateDir, &slot, &blob); err != nil {
+			return nil, err
+		}
+		var sess state.Session
+		if err := json.Unmarshal([]byte(blob), &sess); err != nil {
+			return nil, fmt.Errorf("unmarshal session %s/%s: %w", stateDir, slot, err)
+		}
+		out = append(out, ProjectSession{
+			RowBinding: RowBinding{Project: project, Repo: repo, StateDir: stateDir},
+			Slot:       slot,
+			Session:    &sess,
+		})
+	}
+	return out, rows.Err()
+}
+
+// Sessions returns every session bound to stateDir, keyed by slot — the SQLite
+// equivalent of state.Load(stateDir).Sessions.
+func (s *Store) Sessions(ctx context.Context, stateDir string) (map[string]*state.Session, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT slot, session_json FROM sessions WHERE state_dir = ? ORDER BY slot`, stateDir)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]*state.Session)
+	for rows.Next() {
+		var slot, blob string
+		if err := rows.Scan(&slot, &blob); err != nil {
+			return nil, err
+		}
+		var sess state.Session
+		if err := json.Unmarshal([]byte(blob), &sess); err != nil {
+			return nil, fmt.Errorf("unmarshal session %s/%s: %w", stateDir, slot, err)
+		}
+		out[slot] = &sess
+	}
+	return out, rows.Err()
+}
+
+// Decisions returns every supervisor decision bound to stateDir, ordered by
+// created_at (oldest first), matching the JSON slice order.
+func (s *Store) Decisions(ctx context.Context, stateDir string) ([]state.SupervisorDecision, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT decision_json FROM decisions WHERE state_dir = ? ORDER BY created_at, id`, stateDir)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]state.SupervisorDecision, 0)
+	for rows.Next() {
+		var blob string
+		if err := rows.Scan(&blob); err != nil {
+			return nil, err
+		}
+		var d state.SupervisorDecision
+		if err := json.Unmarshal([]byte(blob), &d); err != nil {
+			return nil, fmt.Errorf("unmarshal decision: %w", err)
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// BackendHealth returns the backend-health map bound to stateDir, keyed by
+// backend name.
+func (s *Store) BackendHealth(ctx context.Context, stateDir string) (map[string]state.BackendHealth, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT backend, health_json FROM backend_health WHERE state_dir = ? ORDER BY backend`, stateDir)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]state.BackendHealth)
+	for rows.Next() {
+		var backend, blob string
+		if err := rows.Scan(&backend, &blob); err != nil {
+			return nil, err
+		}
+		var h state.BackendHealth
+		if err := json.Unmarshal([]byte(blob), &h); err != nil {
+			return nil, fmt.Errorf("unmarshal backend health %s/%s: %w", stateDir, backend, err)
+		}
+		out[backend] = h
+	}
+	return out, rows.Err()
+}
+
+// Missions returns the missions map bound to stateDir, keyed by parent issue.
+func (s *Store) Missions(ctx context.Context, stateDir string) (map[int]*state.Mission, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT parent_issue, mission_json FROM missions WHERE state_dir = ? ORDER BY parent_issue`, stateDir)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[int]*state.Mission)
+	for rows.Next() {
+		var parent int
+		var blob string
+		if err := rows.Scan(&parent, &blob); err != nil {
+			return nil, err
+		}
+		var m state.Mission
+		if err := json.Unmarshal([]byte(blob), &m); err != nil {
+			return nil, fmt.Errorf("unmarshal mission %s/%d: %w", stateDir, parent, err)
+		}
+		out[parent] = &m
+	}
+	return out, rows.Err()
+}
+
+// --- tx insert helpers ------------------------------------------------------
+
+func insertSessionsTx(ctx context.Context, tx *sql.Tx, b RowBinding, sessions map[string]*state.Session, now time.Time) error {
+	for slot, sess := range sessions {
+		if sess == nil {
+			continue
+		}
+		blob, err := json.Marshal(sess)
+		if err != nil {
+			return fmt.Errorf("marshal session %s: %w", slot, err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO sessions(state_dir, project, repo, slot, issue_number, pr_number, status, backend, started_at, updated_at, session_json)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			b.StateDir, b.Project, b.Repo, slot, sess.IssueNumber, sess.PRNumber, string(sess.Status), sess.Backend,
+			formatTime(sess.StartedAt), formatTime(now), string(blob)); err != nil {
+			return fmt.Errorf("insert session %s: %w", slot, err)
+		}
+	}
+	return nil
+}
+
+func insertDecisionsTx(ctx context.Context, tx *sql.Tx, b RowBinding, decisions []state.SupervisorDecision) error {
+	for i := range decisions {
+		d := decisions[i]
+		blob, err := json.Marshal(d)
+		if err != nil {
+			return fmt.Errorf("marshal decision: %w", err)
+		}
+		// A decision normally carries a stable ID; fall back to a content hash
+		// so an id-less legacy decision still gets a unique (state_dir, id) key
+		// and is not collapsed with a sibling by the primary key.
+		id := decisionRowID(d, blob)
+		if _, err := tx.ExecContext(ctx, `
+INSERT OR REPLACE INTO decisions(state_dir, project, repo, id, created_at, decision_json)
+VALUES(?, ?, ?, ?, ?, ?)`,
+			b.StateDir, b.Project, b.Repo, id, formatTime(d.CreatedAt), string(blob)); err != nil {
+			return fmt.Errorf("insert decision %s: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func insertBackendHealthTx(ctx context.Context, tx *sql.Tx, b RowBinding, health map[string]state.BackendHealth, now time.Time) error {
+	for backend, h := range health {
+		blob, err := json.Marshal(h)
+		if err != nil {
+			return fmt.Errorf("marshal backend health %s: %w", backend, err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO backend_health(state_dir, project, repo, backend, health_state, updated_at, health_json)
+VALUES(?, ?, ?, ?, ?, ?, ?)`,
+			b.StateDir, b.Project, b.Repo, backend, h.State, formatTime(now), string(blob)); err != nil {
+			return fmt.Errorf("insert backend health %s: %w", backend, err)
+		}
+	}
+	return nil
+}
+
+func insertMissionsTx(ctx context.Context, tx *sql.Tx, b RowBinding, missions map[int]*state.Mission) error {
+	for parent, m := range missions {
+		if m == nil {
+			continue
+		}
+		blob, err := json.Marshal(m)
+		if err != nil {
+			return fmt.Errorf("marshal mission %d: %w", parent, err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO missions(state_dir, project, repo, parent_issue, status, mission_json)
+VALUES(?, ?, ?, ?, ?, ?)`,
+			b.StateDir, b.Project, b.Repo, parent, m.Status, string(blob)); err != nil {
+			return fmt.Errorf("insert mission %d: %w", parent, err)
+		}
+	}
+	return nil
+}
+
+// decisionRowID mirrors state.decisionKey: the decision's own ID when set, else
+// a content hash of its JSON so an id-less decision still keys uniquely.
+func decisionRowID(d state.SupervisorDecision, blob []byte) string {
+	if strings.TrimSpace(d.ID) != "" {
+		return d.ID
+	}
+	sum := sha256.Sum256(blob)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -1,0 +1,305 @@
+package statestore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "maestro.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func bindingFor(stateDir, project, repo string) RowBinding {
+	return RowBinding{Project: project, Repo: repo, StateDir: stateDir}
+}
+
+// sampleState builds a non-trivial state.State with one running and one pr_open
+// session plus a decision, backend-health entry and mission.
+func sampleState() *state.State {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["1"] = &state.Session{
+		IssueNumber: 101,
+		IssueTitle:  "running issue",
+		Status:      state.StatusRunning,
+		Backend:     "claude",
+		StartedAt:   now,
+	}
+	st.Sessions["2"] = &state.Session{
+		IssueNumber: 102,
+		IssueTitle:  "pr open issue",
+		Status:      state.StatusPROpen,
+		PRNumber:    55,
+		Backend:     "codex",
+		StartedAt:   now,
+	}
+	st.SupervisorDecisions = []state.SupervisorDecision{{
+		ID:                "dec-1",
+		CreatedAt:         now,
+		Summary:           "looks good",
+		RecommendedAction: "merge",
+		Risk:              "low",
+	}}
+	st.BackendHealth["claude"] = state.BackendHealth{State: state.BackendHealthAvailable, Since: now}
+	st.BackendHealth["codex"] = state.BackendHealth{State: state.BackendHealthCooldown, Reason: "quota", Since: now}
+	st.Missions[200] = &state.Mission{ParentIssue: 200, ChildIssues: []int{201, 202}, Status: "active"}
+	return st
+}
+
+func TestImportStateRoundTrip(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	b := bindingFor("/sd/a", "owner/a", "owner/a")
+	if err := s.ImportState(ctx, b, sampleState()); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	sessions, err := s.Sessions(ctx, b.StateDir)
+	if err != nil {
+		t.Fatalf("sessions: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("want 2 sessions, got %d", len(sessions))
+	}
+	if sessions["1"].IssueNumber != 101 || sessions["1"].Status != state.StatusRunning {
+		t.Fatalf("session 1 round-trip mismatch: %+v", sessions["1"])
+	}
+	if sessions["2"].PRNumber != 55 {
+		t.Fatalf("session 2 pr round-trip mismatch: %+v", sessions["2"])
+	}
+
+	decisions, err := s.Decisions(ctx, b.StateDir)
+	if err != nil {
+		t.Fatalf("decisions: %v", err)
+	}
+	if len(decisions) != 1 || decisions[0].ID != "dec-1" {
+		t.Fatalf("decision round-trip mismatch: %+v", decisions)
+	}
+
+	health, err := s.BackendHealth(ctx, b.StateDir)
+	if err != nil {
+		t.Fatalf("backend health: %v", err)
+	}
+	if health["claude"].State != state.BackendHealthAvailable || health["codex"].Reason != "quota" {
+		t.Fatalf("backend health round-trip mismatch: %+v", health)
+	}
+
+	missions, err := s.Missions(ctx, b.StateDir)
+	if err != nil {
+		t.Fatalf("missions: %v", err)
+	}
+	if len(missions) != 1 || missions[200].Status != "active" || len(missions[200].ChildIssues) != 2 {
+		t.Fatalf("mission round-trip mismatch: %+v", missions)
+	}
+}
+
+// TestImportStateIdempotent asserts a re-import of the same snapshot does not
+// duplicate rows (one-shot startup import must be safe to repeat) and that a
+// removed entry disappears (full per-project snapshot replace).
+func TestImportStateIdempotent(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	b := bindingFor("/sd/a", "owner/a", "owner/a")
+	if err := s.ImportState(ctx, b, sampleState()); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if err := s.ImportState(ctx, b, sampleState()); err != nil {
+		t.Fatalf("re-import: %v", err)
+	}
+	sessions, err := s.Sessions(ctx, b.StateDir)
+	if err != nil {
+		t.Fatalf("sessions: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("re-import duplicated sessions: got %d, want 2", len(sessions))
+	}
+
+	// Drop a session and re-import: the mirror must shrink to match JSON.
+	shrunk := sampleState()
+	delete(shrunk.Sessions, "2")
+	if err := s.ImportState(ctx, b, shrunk); err != nil {
+		t.Fatalf("import shrunk: %v", err)
+	}
+	sessions, err = s.Sessions(ctx, b.StateDir)
+	if err != nil {
+		t.Fatalf("sessions after shrink: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("removed session still present: got %d, want 1", len(sessions))
+	}
+	if _, ok := sessions["2"]; ok {
+		t.Fatalf("session 2 should be gone after re-import without it")
+	}
+}
+
+// TestCrossProjectRunningSessions is the #760 acceptance example: every running
+// session across the whole fleet answered in one query, each tagged with its
+// originating project.
+func TestCrossProjectRunningSessions(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	a := bindingFor("/sd/a", "owner/a", "owner/a")
+	bb := bindingFor("/sd/b", "owner/b", "owner/b")
+	if err := s.ImportState(ctx, a, sampleState()); err != nil {
+		t.Fatalf("import a: %v", err)
+	}
+	if err := s.ImportState(ctx, bb, sampleState()); err != nil {
+		t.Fatalf("import b: %v", err)
+	}
+
+	running, err := s.RunningSessions(ctx)
+	if err != nil {
+		t.Fatalf("running sessions: %v", err)
+	}
+	// Each project contributes exactly one running session (session "1"); the
+	// pr_open session "2" must be excluded.
+	if len(running) != 2 {
+		t.Fatalf("want 2 running sessions across the fleet, got %d", len(running))
+	}
+	seen := map[string]bool{}
+	for _, ps := range running {
+		if ps.Session.Status != state.StatusRunning {
+			t.Fatalf("non-running session leaked into RunningSessions: %+v", ps.Session)
+		}
+		seen[ps.Project] = true
+	}
+	if !seen["owner/a"] || !seen["owner/b"] {
+		t.Fatalf("running sessions not tagged with both projects: %+v", running)
+	}
+}
+
+// TestStateDirScopingIsolation asserts the same slot under two state dirs does
+// not collide — the composite (state_dir, slot) key keeps projects disjoint.
+func TestStateDirScopingIsolation(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	a := bindingFor("/sd/a", "owner/a", "owner/a")
+	bb := bindingFor("/sd/b", "owner/b", "owner/b")
+
+	stA := state.NewState()
+	stA.Sessions["1"] = &state.Session{IssueNumber: 1, Status: state.StatusRunning}
+	stB := state.NewState()
+	stB.Sessions["1"] = &state.Session{IssueNumber: 999, Status: state.StatusRunning}
+
+	if err := s.ImportState(ctx, a, stA); err != nil {
+		t.Fatalf("import a: %v", err)
+	}
+	if err := s.ImportState(ctx, bb, stB); err != nil {
+		t.Fatalf("import b: %v", err)
+	}
+
+	gotA, err := s.Sessions(ctx, a.StateDir)
+	if err != nil {
+		t.Fatalf("sessions a: %v", err)
+	}
+	gotB, err := s.Sessions(ctx, bb.StateDir)
+	if err != nil {
+		t.Fatalf("sessions b: %v", err)
+	}
+	if gotA["1"].IssueNumber != 1 || gotB["1"].IssueNumber != 999 {
+		t.Fatalf("same-slot rows collided across projects: a=%+v b=%+v", gotA["1"], gotB["1"])
+	}
+	// Re-importing project a must not disturb project b's identically-slotted row.
+	if err := s.ImportState(ctx, a, stA); err != nil {
+		t.Fatalf("re-import a: %v", err)
+	}
+	gotB, err = s.Sessions(ctx, bb.StateDir)
+	if err != nil {
+		t.Fatalf("sessions b after re-import a: %v", err)
+	}
+	if gotB["1"].IssueNumber != 999 {
+		t.Fatalf("re-import of a mutated b's row: %+v", gotB["1"])
+	}
+}
+
+// TestImportNilClears asserts ImportState(nil) clears a project's rows (a
+// deleted project leaves no stale rows in a cross-project query).
+func TestImportNilClears(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	b := bindingFor("/sd/a", "owner/a", "owner/a")
+	if err := s.ImportState(ctx, b, sampleState()); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if err := s.ImportState(ctx, b, nil); err != nil {
+		t.Fatalf("import nil: %v", err)
+	}
+	sessions, err := s.Sessions(ctx, b.StateDir)
+	if err != nil {
+		t.Fatalf("sessions: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("nil import did not clear sessions: got %d", len(sessions))
+	}
+	running, err := s.RunningSessions(ctx)
+	if err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	if len(running) != 0 {
+		t.Fatalf("cleared project still surfaced in cross-project query: %d", len(running))
+	}
+}
+
+func TestMirrorModeJSONIsNoop(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	b := Binding{Mode: ModeJSON, Handle: s, StateDir: "/sd/a", Project: "owner/a", Repo: "owner/a"}
+	if err := Mirror(b, sampleState()); err != nil {
+		t.Fatalf("mirror json: %v", err)
+	}
+	sessions, err := s.Sessions(ctx, "/sd/a")
+	if err != nil {
+		t.Fatalf("sessions: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("ModeJSON Mirror wrote rows: got %d", len(sessions))
+	}
+}
+
+func TestMirrorModeSQLiteWritesThrough(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	b := Binding{Mode: ModeSQLite, Handle: s, StateDir: "/sd/a", Project: "owner/a", Repo: "owner/a"}
+	if err := Mirror(b, sampleState()); err != nil {
+		t.Fatalf("mirror sqlite: %v", err)
+	}
+	sessions, err := s.Sessions(ctx, "/sd/a")
+	if err != nil {
+		t.Fatalf("sessions: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("ModeSQLite Mirror did not write through: got %d, want 2", len(sessions))
+	}
+}
+
+func TestParseMode(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want Mode
+		ok   bool
+	}{
+		{"", ModeJSON, true},
+		{"json", ModeJSON, true},
+		{"SQLite", ModeSQLite, true},
+		{"sqlite", ModeSQLite, true},
+		{"nope", "", false},
+	} {
+		got, err := ParseMode(tc.in)
+		if tc.ok && (err != nil || got != tc.want) {
+			t.Fatalf("ParseMode(%q) = (%q, %v), want (%q, nil)", tc.in, got, err, tc.want)
+		}
+		if !tc.ok && err == nil {
+			t.Fatalf("ParseMode(%q) expected error", tc.in)
+		}
+	}
+}

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -250,6 +250,100 @@ func TestImportNilClears(t *testing.T) {
 	}
 }
 
+// TestRetainStateDirs proves the startup reconcile drops rows for projects no
+// longer in the fleet while preserving the rows of projects still present — the
+// #760 fix for stale cross-project rows after a project is removed.
+func TestRetainStateDirs(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	a := bindingFor("/sd/a", "owner/a", "owner/a")
+	b := bindingFor("/sd/b", "owner/b", "owner/b")
+	c := bindingFor("/sd/c", "owner/c", "owner/c")
+	for _, bind := range []RowBinding{a, b, c} {
+		if err := s.ImportState(ctx, bind, sampleState()); err != nil {
+			t.Fatalf("import %s: %v", bind.StateDir, err)
+		}
+	}
+
+	// Keep only a and c; b was removed from the config store while stopped.
+	if err := s.RetainStateDirs(ctx, []string{"/sd/a", "", "/sd/a", "/sd/c"}); err != nil {
+		t.Fatalf("retain: %v", err)
+	}
+
+	running, err := s.RunningSessions(ctx)
+	if err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, ps := range running {
+		seen[ps.Project] = true
+	}
+	if seen["owner/b"] {
+		t.Fatalf("removed project still surfaced in cross-project query: %+v", running)
+	}
+	if !seen["owner/a"] || !seen["owner/c"] {
+		t.Fatalf("retained projects missing after prune: %+v", running)
+	}
+	// b's rows must be gone from every table, not just sessions.
+	if h, _ := s.BackendHealth(ctx, "/sd/b"); len(h) != 0 {
+		t.Fatalf("removed project's backend_health rows not pruned: %d", len(h))
+	}
+	if m, _ := s.Missions(ctx, "/sd/b"); len(m) != 0 {
+		t.Fatalf("removed project's mission rows not pruned: %d", len(m))
+	}
+	if d, _ := s.Decisions(ctx, "/sd/b"); len(d) != 0 {
+		t.Fatalf("removed project's decision rows not pruned: %d", len(d))
+	}
+	// a's rows must be untouched.
+	if sess, _ := s.Sessions(ctx, "/sd/a"); len(sess) != 2 {
+		t.Fatalf("retained project's sessions disturbed: %d", len(sess))
+	}
+}
+
+// TestRetainStateDirsEmptyClearsAll asserts an empty keep set (no projects)
+// clears every row.
+func TestRetainStateDirsEmptyClearsAll(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	if err := s.ImportState(ctx, bindingFor("/sd/a", "owner/a", "owner/a"), sampleState()); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if err := s.RetainStateDirs(ctx, nil); err != nil {
+		t.Fatalf("retain empty: %v", err)
+	}
+	running, err := s.RunningSessions(ctx)
+	if err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	if len(running) != 0 {
+		t.Fatalf("empty keep set did not clear all rows: %d", len(running))
+	}
+}
+
+// TestClearStateDir asserts the runtime-removal counterpart drops one project's
+// rows without touching another's.
+func TestClearStateDir(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	a := bindingFor("/sd/a", "owner/a", "owner/a")
+	b := bindingFor("/sd/b", "owner/b", "owner/b")
+	if err := s.ImportState(ctx, a, sampleState()); err != nil {
+		t.Fatalf("import a: %v", err)
+	}
+	if err := s.ImportState(ctx, b, sampleState()); err != nil {
+		t.Fatalf("import b: %v", err)
+	}
+	if err := s.ClearStateDir(ctx, "/sd/a"); err != nil {
+		t.Fatalf("clear a: %v", err)
+	}
+	if sess, _ := s.Sessions(ctx, "/sd/a"); len(sess) != 0 {
+		t.Fatalf("cleared project still has sessions: %d", len(sess))
+	}
+	if sess, _ := s.Sessions(ctx, "/sd/b"); len(sess) != 2 {
+		t.Fatalf("clearing a disturbed b: %d", len(sess))
+	}
+}
+
 func TestMirrorModeJSONIsNoop(t *testing.T) {
 	s := openTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
Implements #760 (part of epic #754, single-service redesign).

After Phase 4 only approvals lived in `maestro.db`; the rest of `state.State`
(Sessions, SupervisorDecisions, BackendHealth, Missions) was still per-project
JSON. This adds `internal/statestore`, mirroring the proven Phase 4
`approvalstore` pattern, so that state can live in the **same** `maestro.db` —
the "one DB per daemon" model.

## Changes
- **`internal/statestore`** (new): SQLite store for sessions/decisions/backend_health/missions
  in the shared `maestro.db`. WAL + single-writer pragmas (same as configstore/approvalstore),
  idempotent schema, rows tagged `project`/`repo`/`state_dir` so one file holds every project.
  - `ImportState` — per-project wholesale snapshot replace → **idempotent** one-shot
    startup import and faithful write-through mirror in one primitive.
  - `RunningSessions` / `SessionsByStatus` — **cross-project** fleet query answered in
    **one SQL statement** instead of N `state.Load` calls.
  - `Mode`/`Binding`/`Mirror` — write-through gate, a no-op in `json` mode.
- **daemon**: `--state-store` / `--state-db` flags; on startup (sqlite mode) the daemon
  imports each project's existing `state.json` into the tables (idempotent, re-converges
  on restart).
- **fleet**: `SetStateStore` + shared `StateStore()` handle; `mirrorState` write-through
  at the per-project state-read cadence (no-op in `json`), keeping the mirror fresh.

## Transition / flock
JSON remains the authoritative mint source during the transition, so `flock`+3-way-merge
is intentionally **retained** — a JSON writer still exists on every path (the scope's
"keep flock while any JSON writer remains"). Default mode is `json`, so observable
front/CLI behavior is unchanged until the SQLite mirror is explicitly enabled.

## Testing
- `gofmt` on changed Go files
- `go test ./...` (incl. `./internal/state/...`, `./internal/statestore/...`) — green
- `go build ./cmd/maestro/` — green
- New tests: idempotent import, per-`state_dir` scoping isolation, snapshot shrink,
  nil-clear, and the cross-project single-query running-sessions example at both the
  store and fleet layers (`-race` clean).

> Note: full daemon read-side cutover and flock removal land once the mirror is
> flipped on for the fleet and the last JSON writer is retired — runtime verification
> on a live daemon is still required before this issue is fully closed.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the remaining daemon state into the shared SQLite mirror. The main changes are:

- Adds `internal/statestore` for sessions, decisions, backend health, and missions.
- Wires daemon flags for selecting JSON or SQLite state storage.
- Imports existing per-project `state.json` snapshots into `maestro.db` on startup.
- Mirrors state saves into SQLite through the fleet/state save hook.
- Updates store-watch removal cleanup to drain flows before clearing SQLite rows.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the reviewed state-store integration and test coverage.

The changes are cohesive, keep JSON as the default source of truth during transition, include idempotent import and mirror behavior, and add focused tests around scoping, shrinking snapshots, nil clearing, and cross-project queries.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the statestore import test to compare the base checkout state with the state after adding the temporary test source, capturing both the before and after outputs.
- Validated the daemon state mirror tests by running the targeted tests and confirming a successful exit and symbol evidence for SetSaveHook, SetStateStore, and mirrorSavedState.

<a href="https://app.greptile.com/trex/runs/12256459/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/server/fleet.go`, line 2918-2932 ([link](https://github.com/befeast/maestro/blob/57a44fdc61fdd9bc860c4764f395a9bf812a8fb0/internal/server/fleet.go#L2918-L2932)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mirror reconciled health**

   This mirrors the loaded JSON state before `ReconcileBackendHealth` removes expired cooldowns and cooldowns cleared by PR evidence. When a backend cooldown has already expired, the fleet response shows the backend as healthy, but the SQLite mirror keeps the stale cooldown row. Any SQL-backed health read can then report a backend as unavailable even though the fleet snapshot has already normalized it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/fleet.go
   Line: 2918-2932

   Comment:
   **Mirror reconciled health**

   This mirrors the loaded JSON state before `ReconcileBackendHealth` removes expired cooldowns and cooldowns cleared by PR evidence. When a backend cooldown has already expired, the fleet response shows the backend as healthy, but the SQLite mirror keeps the stale cooldown row. Any SQL-backed health read can then report a backend as unavailable even though the fleet snapshot has already normalized it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/server/fleet.go`, line 474-478 ([link](https://github.com/befeast/maestro/blob/57a44fdc61fdd9bc860c4764f395a9bf812a8fb0/internal/server/fleet.go#L474-L478)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Clear removed state**

   Removing a project from the fleet only drops the in-memory entry. The new state store supports `ImportState(nil)` to clear rows, but this removal path never calls it, so deleted projects leave their old `sessions`, `decisions`, `backend_health`, and `missions` rows in `maestro.db`. `RunningSessions` can keep returning sessions for a project that no longer exists in the config store.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/fleet.go
   Line: 474-478

   Comment:
   **Clear removed state**

   Removing a project from the fleet only drops the in-memory entry. The new state store supports `ImportState(nil)` to clear rows, but this removal path never calls it, so deleted projects leave their old `sessions`, `decisions`, `backend_health`, and `missions` rows in `maestro.db`. `RunningSessions` can keep returning sessions for a project that no longer exists in the config store.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Phase 5 review fix: drain flow before cl..."](https://github.com/befeast/maestro/commit/2b7d48547bbb6256bc45b7ed845bacf1ba884128) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39762601)</sub>

<!-- /greptile_comment -->