### PR TITLE
migrate-to-daemon: system scope + fix legacy-unit patterns for the live naming

### DIFF
--- a/scripts/migrate-to-daemon.sh
+++ b/scripts/migrate-to-daemon.sh
@@ -67,7 +67,8 @@ NO_START=0
 # what the Loki host actually runs; the `@` patterns cover the older
 # template-instance naming on other hosts. None of these match the new
 # single-service unit (`maestro.service` — no `@`, no `-` after `maestro`); the
-# new unit and the ephemeral self-deploy units are excluded in legacy_units too.
+# new unit, the self-deploy transient units, and the documented standalone
+# maestro-digest unit are excluded in legacy_units (exclude_non_legacy) too.
 LEGACY_PATTERNS=(
   'maestro@*'             # per-project run template instances (older naming)
   'maestro-supervise@*'   # per-project supervise template instances (older naming)
@@ -262,18 +263,24 @@ store_project_count() {
 # (`list-unit-files`). Bare template files (foo@.service) are dropped — only
 # instances/concrete units are stopped/disabled, and the templates stay on disk
 # for rollback.
-# exclude_self: drop units that must NEVER be stopped by the cutover — the new
-# single-service unit itself (defense-in-depth; `maestro-*` already can't match
-# it) and the ephemeral self-deploy transient units.
-exclude_self() {
-  grep -vxF 'maestro.service' | grep -vE '^maestro-self-deploy'
+# exclude_non_legacy: drop maestro-prefixed units that the broad `maestro-*`
+# glob matches but that are NOT part of the per-project fleet topology this
+# cutover replaces, so they are never stopped/disabled:
+#   * maestro.service          — the new single-service unit (defense-in-depth;
+#                                `maestro-*` already can't match it).
+#   * maestro-self-deploy*      — ephemeral self-deploy transient units.
+#   * maestro-digest{.service,} — the documented standalone digest unit/timer
+#                                (docs/digest-runbook.md); orthogonal to the
+#                                fleet, must survive the cutover.
+exclude_non_legacy() {
+  grep -vxF 'maestro.service' | grep -vE '^maestro-self-deploy' | grep -vE '^maestro-digest'
 }
 
 legacy_units() {
   {
     sc list-units --all --plain --no-legend "${LEGACY_PATTERNS[@]}" 2>/dev/null | awk '{print $1}'
     sc list-unit-files --no-legend "${LEGACY_PATTERNS[@]}" 2>/dev/null | awk '{print $1}'
-  } | grep -E '\.service$' | grep -vE '@\.service$' | exclude_self | sort -u || true
+  } | grep -E '\.service$' | grep -vE '@\.service$' | exclude_non_legacy | sort -u || true
 }
 
 # --- 1. seed the config store ----------------------------------------------
@@ -359,7 +366,7 @@ fi
 # daemon, or two drivers would run the same project.
 if [[ "${DRY_RUN}" != "1" ]]; then
   still_active="$(sc list-units --plain --no-legend "${LEGACY_PATTERNS[@]}" 2>/dev/null \
-    | awk '$3=="active"{print $1}' | grep -E '\.service$' | grep -vE '@\.service$' | exclude_self || true)"
+    | awk '$3=="active"{print $1}' | grep -E '\.service$' | grep -vE '@\.service$' | exclude_non_legacy || true)"
   if [[ -n "${still_active}" ]]; then
     die "legacy unit(s) still active after stop: ${still_active//$'\n'/ } — refusing to start maestro.service (it would double-drive those projects). Stop them and re-run."
   fi

--- a/scripts/migrate-to-daemon.sh
+++ b/scripts/migrate-to-daemon.sh
@@ -9,6 +9,18 @@
 # so no project ever has both a legacy unit and the daemon driving it — that
 # would double-spawn workers.
 #
+# Scope (#761): --scope selects the systemd manager, mirroring self-deploy.sh
+# (#742). Both the legacy units and the new maestro.service live in the same
+# manager.
+#   * user   (default, back-compat) — `systemctl --user ...`, unit installed
+#     into ~/.config/systemd/user, the committed `%h`/default.target template.
+#   * system — `sudo -n systemctl ...` for mutations (non-interactive; requires
+#     passwordless sudo), unit installed into /etc/systemd/system rendered with
+#     User=/WorkingDirectory= and `%h` expanded to the service user's home, so it
+#     matches the existing system units (e.g. maestro-supervisor-dogfood.service
+#     on the Loki host, which run as User=god). Reads (list-units / is-active)
+#     use plain `systemctl` (no sudo).
+#
 # Steps:
 #   1. Seed the SQLite config store from EVERY legacy config source:
 #      - the newer `~/.maestro/maestro.d/*.yaml` directory (`config-store migrate`)
@@ -16,10 +28,9 @@
 #        `~/.maestro/maestro-*.yaml` (`config-store add`, one per file).
 #      Then refuse to go any further if the store is still empty — we never stop
 #      the legacy units only to start an empty daemon.
-#   2. Render maestro.service with the requested --bin/--store/--port and install
-#      it into the systemd user unit dir (the committed template hard-codes the
-#      defaults; a custom binary/store/port must reach the unit, not just the
-#      verification).
+#   2. Render maestro.service with the requested --bin/--store/--port (and, for
+#      system scope, User=/WorkingDirectory=/absolute home) and install it into
+#      the scope's unit dir.
 #   3. Stop + disable the legacy units — discovered from BOTH `list-units`
 #      (loaded/running) AND `list-unit-files` (enabled-but-inactive on disk), so
 #      an enabled instance that is not currently loaded cannot re-appear on the
@@ -27,10 +38,10 @@
 #   4. enable --now maestro.service.
 #   5. Verify :PORT/api/v1/fleet responds and print the running version.
 #
-# Rollback (the legacy unit files stay on disk):
-#   systemctl --user disable --now maestro.service
+# Rollback (the legacy unit files stay on disk; SC = the scope's systemctl):
+#   <SC> disable --now maestro.service
 #   maestro config-store export --db <store> --dir ~/.maestro/maestro.d   # regen YAML if needed
-#   systemctl --user enable --now maestro@<project> ...                   # re-enable the old units
+#   <SC> enable --now maestro@<project> ...                               # re-enable the old units
 #
 # This script changes the operational topology of a running host and REQUIRES an
 # operator to approve it. It does not touch secrets and prints no credentials.
@@ -41,30 +52,41 @@ MAESTRO_DIR="${HOME}/.maestro"
 STORE="${MAESTRO_DIR}/maestro.db"
 CONFIG_DIR="${MAESTRO_DIR}/maestro.d"
 PORT=8786
-UNIT_DIR="${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user"
+SCOPE=user
+SVCUSER="$(id -un)"
+UNIT_DIR=""          # resolved from --scope after parsing unless --unit-dir given
 BIN=""
 DRY_RUN=0
 ASSUME_YES=0
 NO_START=0
 
-# Legacy unit name patterns to stop + disable. None of these match the new
-# single-service unit (`maestro.service` — no `@`, no `-` after `maestro`).
+# Legacy unit name patterns to stop + disable. `maestro-*` (dash form) is the
+# broad catch for the per-host dash naming — per-project worker
+# (maestro-<project>.service), supervise (maestro-<project>-supervise.service),
+# web (maestro-<project>-web.service), plus the dogfood/fleet units — which is
+# what the Loki host actually runs; the `@` patterns cover the older
+# template-instance naming on other hosts. None of these match the new
+# single-service unit (`maestro.service` — no `@`, no `-` after `maestro`); the
+# new unit and the ephemeral self-deploy units are excluded in legacy_units too.
 LEGACY_PATTERNS=(
-  'maestro@*'             # per-project run template instances
-  'maestro-supervise@*'   # per-project supervise template instances
-  'maestro-supervisor-*'  # per-project supervisor units (dash form)
-  'maestro-serve*'        # fleet serve unit(s)
-  'maestro-fleet*'        # documented legacy fleet dashboard unit(s)
+  'maestro@*'             # per-project run template instances (older naming)
+  'maestro-supervise@*'   # per-project supervise template instances (older naming)
+  'maestro-*'             # all dash-form units: per-project worker / -supervise /
+                          # -web, dogfood, fleet — the live Loki naming
 )
 
 usage() {
   cat >&2 <<EOF
 usage: migrate-to-daemon.sh [options]
 
+  --scope user|system honor the systemd --user manager (default) or the system
+                      manager via sudo -n (default: ${SCOPE})
+  --user NAME         service User= for --scope system (default: ${SVCUSER})
   --store PATH        SQLite store path (default: ${STORE})
   --config-dir DIR    YAML configs to seed the store from (default: ${CONFIG_DIR})
   --port N            Fleet web port — written into the unit AND verified (default: ${PORT})
-  --unit-dir DIR      systemd --user unit dir (default: ${UNIT_DIR})
+  --unit-dir DIR      systemd unit dir (default: scope-derived —
+                      ~/.config/systemd/user or /etc/systemd/system)
   --bin PATH          maestro binary — written into the unit's ExecStart
                       (default: resolved from PATH / /usr/local/bin/maestro)
   --dry-run           print the actions (incl. the rendered unit) without changing anything
@@ -90,6 +112,8 @@ run() {
 # --- parse args -------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --scope) SCOPE="$2"; shift 2 ;;
+    --user) SVCUSER="$2"; shift 2 ;;
     --store) STORE="$2"; shift 2 ;;
     --config-dir) CONFIG_DIR="$2"; shift 2 ;;
     --port) PORT="$2"; shift 2 ;;
@@ -103,8 +127,43 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+case "${SCOPE}" in user|system) ;; *) die "invalid --scope: ${SCOPE} (want user|system)" ;; esac
+
+# Service user's home: the unit's %h is expanded to this for system scope (system
+# units do not reliably resolve %h), and a system unit runs as User=${SVCUSER}.
+SVCHOME="$(getent passwd "${SVCUSER}" 2>/dev/null | cut -d: -f6)"
+[[ -n "${SVCHOME}" ]] || SVCHOME="${HOME}"
+
+# Default unit dir by scope unless the operator pinned one.
+if [[ -z "${UNIT_DIR}" ]]; then
+  if [[ "${SCOPE}" == "system" ]]; then
+    UNIT_DIR="/etc/systemd/system"
+  else
+    UNIT_DIR="${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user"
+  fi
+fi
+
 # Where the legacy per-instance files (maestro-*.yaml) live: next to maestro.d.
 LEGACY_CFG_DIR="$(dirname "${CONFIG_DIR}")"
+
+# --- scope-aware systemctl --------------------------------------------------
+# sc: read-only systemctl (list-units, is-active) — never needs sudo.
+sc() {
+  if [[ "${SCOPE}" == "system" ]]; then
+    systemctl "$@"
+  else
+    systemctl --user "$@"
+  fi
+}
+# sc_do: MUTATING systemctl (daemon-reload, stop, disable, enable) — routed
+# through run() for --dry-run, and via `sudo -n` for system scope.
+sc_do() {
+  if [[ "${SCOPE}" == "system" ]]; then
+    run sudo -n systemctl "$@"
+  else
+    run systemctl --user "$@"
+  fi
+}
 
 # --- resolve the binary -----------------------------------------------------
 if [[ -z "${BIN}" ]]; then
@@ -123,6 +182,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 UNIT_SRC="${SCRIPT_DIR}/../maestro.service"
 [[ -f "${UNIT_SRC}" ]] || die "maestro.service not found at ${UNIT_SRC}"
 
+log "scope:      ${SCOPE}$([[ "${SCOPE}" == system ]] && printf ' (User=%s, home %s, sudo -n)' "${SVCUSER}" "${SVCHOME}")"
 log "binary:     ${BIN} ($(${BIN} version 2>/dev/null || echo 'version unknown'))"
 log "store:      ${STORE}"
 log "config dir: ${CONFIG_DIR}"
@@ -147,17 +207,36 @@ sed_repl() { printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'; }
 # defaults (/usr/local/bin/maestro, %h/.maestro/maestro.db, 8786); rendering
 # keeps the installed unit consistent with the store this script seeds and the
 # endpoint it verifies. The rest of the unit (flag set, drain timeout, restart
-# policy) stays the template's — it remains the single source of truth.
+# policy) stays the template's.
+#
+# For --scope system the committed user-style template (%h, default.target, no
+# User=) is additionally transformed into a system unit: %h → the service user's
+# home, User=/WorkingDirectory= injected, and WantedBy → multi-user.target — so
+# it matches the existing system units on the host.
 render_unit() {
   local bin store port
   bin="$(sed_repl "${BIN}")"
   store="$(sed_repl "${STORE}")"
   port="$(sed_repl "${PORT}")"
-  sed \
-    -e "s|ExecStart=/usr/local/bin/maestro |ExecStart=${bin} |" \
-    -e "s|--store %h/.maestro/maestro.db|--store ${store}|" \
-    -e "s|--port 8786|--port ${port}|" \
-    "${UNIT_SRC}"
+  if [[ "${SCOPE}" == "system" ]]; then
+    local home user
+    home="$(sed_repl "${SVCHOME}")"
+    user="$(sed_repl "${SVCUSER}")"
+    sed \
+      -e "s|ExecStart=/usr/local/bin/maestro |ExecStart=${bin} |" \
+      -e "s|--store %h/.maestro/maestro.db|--store ${store}|" \
+      -e "s|--port 8786|--port ${port}|" \
+      -e "s|%h|${home}|g" \
+      -e "s|^\[Service\]\$|[Service]\nUser=${user}\nWorkingDirectory=${home}|" \
+      -e "s|^WantedBy=default.target\$|WantedBy=multi-user.target|" \
+      "${UNIT_SRC}"
+  else
+    sed \
+      -e "s|ExecStart=/usr/local/bin/maestro |ExecStart=${bin} |" \
+      -e "s|--store %h/.maestro/maestro.db|--store ${store}|" \
+      -e "s|--port 8786|--port ${port}|" \
+      "${UNIT_SRC}"
+  fi
 }
 
 # store_project_count prints how many projects the store currently holds, by
@@ -183,11 +262,18 @@ store_project_count() {
 # (`list-unit-files`). Bare template files (foo@.service) are dropped — only
 # instances/concrete units are stopped/disabled, and the templates stay on disk
 # for rollback.
+# exclude_self: drop units that must NEVER be stopped by the cutover — the new
+# single-service unit itself (defense-in-depth; `maestro-*` already can't match
+# it) and the ephemeral self-deploy transient units.
+exclude_self() {
+  grep -vxF 'maestro.service' | grep -vE '^maestro-self-deploy'
+}
+
 legacy_units() {
   {
-    systemctl --user list-units --all --plain --no-legend "${LEGACY_PATTERNS[@]}" 2>/dev/null | awk '{print $1}'
-    systemctl --user list-unit-files --no-legend "${LEGACY_PATTERNS[@]}" 2>/dev/null | awk '{print $1}'
-  } | grep -E '\.service$' | grep -vE '@\.service$' | sort -u || true
+    sc list-units --all --plain --no-legend "${LEGACY_PATTERNS[@]}" 2>/dev/null | awk '{print $1}'
+    sc list-unit-files --no-legend "${LEGACY_PATTERNS[@]}" 2>/dev/null | awk '{print $1}'
+  } | grep -E '\.service$' | grep -vE '@\.service$' | exclude_self | sort -u || true
 }
 
 # --- 1. seed the config store ----------------------------------------------
@@ -225,14 +311,21 @@ log "  ExecStart binary: ${BIN}"
 log "  --store:          ${STORE}"
 log "  --port:           ${PORT}"
 if [[ "${DRY_RUN}" == "1" ]]; then
-  printf '  + mkdir -p %s\n' "${UNIT_DIR}"
-  printf '  + render maestro.service (from %s) → %s/maestro.service:\n' "${UNIT_SRC}" "${UNIT_DIR}"
+  printf '  + install %s/maestro.service (rendered from %s):\n' "${UNIT_DIR}" "${UNIT_SRC}"
   render_unit | sed 's/^/        /'
-  printf '  + systemctl --user daemon-reload\n'
+  if [[ "${SCOPE}" == "system" ]]; then
+    printf '  + sudo -n systemctl daemon-reload\n'
+  else
+    printf '  + systemctl --user daemon-reload\n'
+  fi
 else
-  mkdir -p "${UNIT_DIR}"
-  render_unit > "${UNIT_DIR}/maestro.service"
-  systemctl --user daemon-reload
+  if [[ "${SCOPE}" == "system" ]]; then
+    render_unit | sudo -n tee "${UNIT_DIR}/maestro.service" >/dev/null
+  else
+    mkdir -p "${UNIT_DIR}"
+    render_unit > "${UNIT_DIR}/maestro.service"
+  fi
+  sc_do daemon-reload
 fi
 
 if [[ "${NO_START}" == "1" ]]; then
@@ -256,8 +349,8 @@ fi
 mapfile -t OLD < <(legacy_units)
 if [[ ${#OLD[@]} -gt 0 ]]; then
   log "stopping + disabling ${#OLD[@]} legacy unit(s): ${OLD[*]}"
-  run systemctl --user stop "${OLD[@]}" || warn "some legacy units did not stop cleanly"
-  run systemctl --user disable "${OLD[@]}" || warn "some legacy units did not disable cleanly"
+  sc_do stop "${OLD[@]}" || warn "some legacy units did not stop cleanly"
+  sc_do disable "${OLD[@]}" || warn "some legacy units did not disable cleanly"
 else
   warn "no legacy maestro units found (loaded or enabled) — proceeding to start the daemon"
 fi
@@ -265,8 +358,8 @@ fi
 # Non-concurrency guard: nothing legacy may still be active when we start the
 # daemon, or two drivers would run the same project.
 if [[ "${DRY_RUN}" != "1" ]]; then
-  still_active="$(systemctl --user list-units --plain --no-legend "${LEGACY_PATTERNS[@]}" 2>/dev/null \
-    | awk '$3=="active"{print $1}' | grep -E '\.service$' | grep -vE '@\.service$' || true)"
+  still_active="$(sc list-units --plain --no-legend "${LEGACY_PATTERNS[@]}" 2>/dev/null \
+    | awk '$3=="active"{print $1}' | grep -E '\.service$' | grep -vE '@\.service$' | exclude_self || true)"
   if [[ -n "${still_active}" ]]; then
     die "legacy unit(s) still active after stop: ${still_active//$'\n'/ } — refusing to start maestro.service (it would double-drive those projects). Stop them and re-run."
   fi
@@ -274,7 +367,7 @@ fi
 
 # --- 4. start the daemon ----------------------------------------------------
 log "enabling + starting maestro.service"
-run systemctl --user enable --now maestro.service
+sc_do enable --now maestro.service
 
 # --- 5. verify --------------------------------------------------------------
 if [[ "${DRY_RUN}" == "1" ]]; then
@@ -292,13 +385,21 @@ for _ in $(seq 1 15); do
 done
 if [[ "${ok}" != "1" ]]; then
   warn "fleet endpoint :${PORT}/api/v1/fleet did not respond yet"
-  warn "check: systemctl --user status maestro.service ; journalctl --user -u maestro.service -e"
+  if [[ "${SCOPE}" == "system" ]]; then
+    warn "check: systemctl status maestro.service ; journalctl -u maestro.service -e"
+  else
+    warn "check: systemctl --user status maestro.service ; journalctl --user -u maestro.service -e"
+  fi
   die "verification failed — investigate before assuming the cutover succeeded"
 fi
 
 log "active maestro units now:"
-systemctl --user list-units --no-legend 'maestro*' 2>/dev/null || true
+sc list-units --no-legend 'maestro*' 2>/dev/null || true
 log "running version: $(${BIN} version 2>/dev/null || echo unknown)"
-log "cutover complete. Rollback: systemctl --user disable --now maestro.service && re-enable the legacy units."
+if [[ "${SCOPE}" == "system" ]]; then
+  log "cutover complete. Rollback: sudo systemctl disable --now maestro.service && re-enable the legacy units."
+else
+  log "cutover complete. Rollback: systemctl --user disable --now maestro.service && re-enable the legacy units."
+fi
 log "(legacy unit files remain on disk, now disabled, so rollback re-enables them.)"
 exit 0


### PR DESCRIPTION
Makes the Phase 6 cutover script (#761) actually usable on the Loki host.

**Two real gaps caught via dry-run:**
1. Hardcoded `systemctl --user`, but the fleet runs as **system** units (User=god). Added `--scope user|system` (default user, back-compat) modeled on self-deploy.sh (#742): `sudo -n systemctl` for mutations, system unit-dir, and renders the user-style template into a system unit (User=/WorkingDirectory=, %h→home, multi-user.target).
2. Legacy patterns matched only the old template naming → found **2 of 19** units; a cutover would leave 13 running and **double-drive** those projects. Broadened to `maestro-*` (live dash naming) while excluding the new `maestro.service` + self-deploy units.

Verified `--dry-run --scope system`: renders a correct system unit, lists all 19 legacy units, `maestro.service` safely excluded.

Refs #761

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the Phase 6 cutover script to support `--scope system` (in addition to the existing `--user` default), and broadens legacy-unit discovery from a handful of specific template patterns to the `maestro-*` dash naming that the Loki host actually uses.

- `--scope system` wires `sudo -n systemctl` for mutations, resolves `SVCHOME` via `getent passwd`, expands `%h` to the service user's home, injects `User=`/`WorkingDirectory=` into the rendered unit, and switches `WantedBy` to `multi-user.target` — matching the existing system units on Loki.
- Adding `maestro-*` to `LEGACY_PATTERNS` and a new `exclude_non_legacy` filter (piped in both the stop list and the still-active guard) prevents `maestro-digest` and `maestro-self-deploy` units from being swept up while ensuring all 19 live units are discovered.

<h3>Confidence Score: 3/5</h3>

The scope-routing and broadened pattern discovery are correctly implemented, but the default STORE and CONFIG_DIR still derive from the invoking operator's ${HOME} rather than the resolved service user's home, so the primary Loki use case (--scope system --user god run by a different operator account) seeds from the wrong config directory and installs a unit whose --store points at the operator's database — the daemon would start with the wrong fleet data unless the caller explicitly overrides both flags.

STORE (line 52) and CONFIG_DIR (line 53) are expanded from ${HOME} at startup, before --scope/--user are parsed and before SVCHOME is resolved from getent passwd. For --scope system --user god, this means config-store seeding reads from /home/<operator>/.maestro/ and the rendered unit gets --store /home/<operator>/.maestro/maestro.db, while the unit runs as User=god. The daemon therefore accesses the operator's store rather than god's live fleet data. This was identified in the previous review and has not been addressed in this revision.

scripts/migrate-to-daemon.sh — lines 51-53 set STORE and CONFIG_DIR from ${HOME} before SVCHOME is available; for system scope with a distinct service user these need to be re-derived from SVCHOME after arg parsing and SVCHOME resolution.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/migrate-to-daemon.sh | Adds --scope user|system and broadens legacy-unit patterns; correctly wires sudo, SVCHOME, and unit rendering for system scope — but STORE/CONFIG_DIR defaults still derive from the operator's ${HOME} instead of the resolved service-user home, causing the primary Loki use case (--scope system --user god) to seed the wrong store and install a unit with the wrong --store path. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `scripts/migrate-to-daemon.sh`, line 51-57 ([link](https://github.com/befeast/maestro/blob/e5b8659f288a6154eacff1c4f4ab30c1ea733f62/scripts/migrate-to-daemon.sh#L51-L57)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Default paths target wrong home**
   For `--scope system --user god`, these defaults are expanded from the operator's `${HOME}` before `SVCHOME` is resolved, so the script seeds and renders `--store /home/<operator>/.maestro/maestro.db` while the unit runs as `User=god`. That makes the Loki cutover read the wrong config store unless every caller also overrides `--store` and `--config-dir`.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: dry-run harness with safe mocks for god home and system commands](https://app.greptile.com/trex/artifacts/5b7ef93b-39ba-462e-b410-c5e17e2b0f2f)**

   - Contains supporting evidence from the run (text/x-shellscript; charset=utf-8).

   **[Repro: verbose dry-run output showing operator-home defaults with User=god unit](https://app.greptile.com/trex/artifacts/5717ddd5-8f19-470c-8641-c0403fe7bd47)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12328071/artifacts?artifact=5b7ef93b-39ba-462e-b410-c5e17e2b0f2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/migrate-to-daemon.sh
   Line: 51-57

   Comment:
   **Default paths target wrong home**
   For `--scope system --user god`, these defaults are expanded from the operator's `${HOME}` before `SVCHOME` is resolved, so the script seeds and renders `--store /home/<operator>/.maestro/maestro.db` while the unit runs as `User=god`. That makes the Loki cutover read the wrong config store unless every caller also overrides `--store` and `--config-dir`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `scripts/migrate-to-daemon.sh`, line 51-56 ([link](https://github.com/befeast/maestro/blob/bb14b2675627ef6f68fffa011c65f1f41731a5fc/scripts/migrate-to-daemon.sh#L51-L56)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Retarget service defaults**
   `--user` changes the rendered `User=` and `%h`, but the default `STORE` and `CONFIG_DIR` were already derived from the invoking account's `HOME`. Running the system cutover as an operator with `--scope system --user god` seeds and verifies the operator's `~/.maestro/maestro.db`, then installs a system unit pointing at that same path instead of `god`'s live config store, so the daemon comes up with the wrong fleet data.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: dry-run harness with mocked system tools and separate operator and god homes](https://app.greptile.com/trex/artifacts/59c63a47-4c98-4f7f-bd2e-c07d4179aee0)**

   - Contains supporting evidence from the run (text/x-shellscript; charset=utf-8).

   **[Repro: dry-run output showing User=god with operator HOME store and config paths](https://app.greptile.com/trex/artifacts/73d8bc12-010d-42df-b64a-9a2031cf878c)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12331414/artifacts?artifact=59c63a47-4c98-4f7f-bd2e-c07d4179aee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/migrate-to-daemon.sh
   Line: 51-56

   Comment:
   **Retarget service defaults**
   `--user` changes the rendered `User=` and `%h`, but the default `STORE` and `CONFIG_DIR` were already derived from the invoking account's `HOME`. Running the system cutover as an operator with `--scope system --user god` seeds and verifies the operator's `~/.maestro/maestro.db`, then installs a system unit pointing at that same path instead of `god`'s live config store, so the daemon comes up with the wrong fleet data.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/migrate-sys..."](https://github.com/befeast/maestro/commit/8841f0b5ec7da24e7f210b55a755f31a2a27bebc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39909281)</sub>

<!-- /greptile_comment -->