### PR TITLE
orchestrator: auto-stale spawn_repair_worker approvals when their issue resolves

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3757,9 +3757,13 @@ func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 		}
 		log.Printf("[orch] code_landed session for issue #%d passed outcome reconciliation; marking done", sess.IssueNumber)
 		if o.markDoneAfterOutcomePass(sess, sess.PRNumber) {
-			stale := s.MarkCloseIssueApprovalsStaleForVerifiedIssue(sess.IssueNumber, time.Now().UTC())
+			now := time.Now().UTC()
+			stale := s.MarkCloseIssueApprovalsStaleForVerifiedIssue(sess.IssueNumber, now)
 			if stale > 0 {
 				log.Printf("[orch] expired %d stale close_issue approval(s) for auto-closed issue #%d", stale, sess.IssueNumber)
+			}
+			if rstale := s.MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue(sess.IssueNumber, now); rstale > 0 {
+				log.Printf("[orch] expired %d stale spawn_repair_worker approval(s) for auto-closed issue #%d", rstale, sess.IssueNumber)
 			}
 		}
 	}
@@ -4030,9 +4034,13 @@ func (o *Orchestrator) verifyOutcomeAfterMerge(s *state.State, sess *state.Sessi
 	if result.State == outcome.HealthHealthy {
 		log.Printf("[orch] outcome verifier passed after PR #%d; marking issue #%d done", prNumber, sess.IssueNumber)
 		if o.markDoneAfterOutcomePass(sess, prNumber) {
-			stale := s.MarkCloseIssueApprovalsStaleForVerifiedIssue(sess.IssueNumber, time.Now().UTC())
+			now := time.Now().UTC()
+			stale := s.MarkCloseIssueApprovalsStaleForVerifiedIssue(sess.IssueNumber, now)
 			if stale > 0 {
 				log.Printf("[orch] expired %d stale close_issue approval(s) for auto-closed issue #%d", stale, sess.IssueNumber)
+			}
+			if rstale := s.MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue(sess.IssueNumber, now); rstale > 0 {
+				log.Printf("[orch] expired %d stale spawn_repair_worker approval(s) for auto-closed issue #%d", rstale, sess.IssueNumber)
 			}
 		}
 		o.notifier.Sendf("✅ maestro: outcome verifier passed after PR #%d; issue #%d can be treated as done", prNumber, sess.IssueNumber)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -951,9 +951,10 @@ const (
 )
 
 const (
-	approvalActionCloseIssue      = "close_issue"
-	approvalActionCloseIssueBatch = "close_issue_batch"
-	approvalActionSpawnWorker     = "spawn_worker"
+	approvalActionCloseIssue        = "close_issue"
+	approvalActionCloseIssueBatch   = "close_issue_batch"
+	approvalActionSpawnWorker       = "spawn_worker"
+	approvalActionSpawnRepairWorker = "spawn_repair_worker"
 )
 
 // Approval records a risky supervisor decision that needs explicit resolution.
@@ -2581,6 +2582,35 @@ func closeIssueApprovalTargetsIssue(approval *Approval, issueNumber int) bool {
 		}
 	}
 	return false
+}
+
+// MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue expires in-flight
+// spawn_repair_worker approvals that became moot because the issue they were
+// going to repair is resolved — the orchestrator auto-closed it after a verified
+// merge, so there is nothing left to repair. Without this the pending approval
+// lingers indefinitely and surfaces as a Past-SLA red flag on the Approvals
+// dashboard (dogfood #773/#774/#775: repair approvals outlived their merged PRs;
+// the operator had to reject them by hand every wave). Mirrors
+// MarkCloseIssueApprovalsStaleForVerifiedIssue, co-located at the same
+// auto-close trust path.
+func (s *State) MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue(issueNumber int, now time.Time) int {
+	if s == nil || issueNumber <= 0 {
+		return 0
+	}
+	count := 0
+	reason := fmt.Sprintf("issue #%d resolved (verified merge) — repair worker moot", issueNumber)
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if approval.Action != approvalActionSpawnRepairWorker || approval.Target == nil || approval.Target.Issue != issueNumber {
+			continue
+		}
+		switch approval.Status {
+		case ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch:
+			s.markApprovalStale(approval, now, reason)
+			count++
+		}
+	}
+	return count
 }
 
 func (s *State) pendingApproval(id string) (*Approval, error) {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -2185,6 +2185,44 @@ func TestRecordPendingApprovalDedupsAgainstAwaitingDispatch(t *testing.T) {
 	}
 }
 
+// #771 follow-up: a pending spawn_repair_worker approval must auto-stale when
+// its issue is resolved (orchestrator auto-closed it after a verified merge),
+// so it stops lingering as a Past-SLA red flag on the dashboard
+// (dogfood #773/#774/#775). Only the repair approval for the resolved issue is
+// touched — a repair approval for a different issue, and a spawn_worker approval
+// for the same issue, are left pending.
+func TestMarkSpawnRepairWorkerApprovalsStaleForResolvedIssue(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	s := NewState()
+	s.Approvals = []Approval{
+		{ID: "ap-repair-759", Action: approvalActionSpawnRepairWorker, Target: &SupervisorTarget{Issue: 759, PR: 773}, Status: ApprovalStatusPending, CreatedAt: now},
+		{ID: "ap-repair-800", Action: approvalActionSpawnRepairWorker, Target: &SupervisorTarget{Issue: 800, PR: 801}, Status: ApprovalStatusPending, CreatedAt: now},
+		{ID: "ap-spawn-759", Action: approvalActionSpawnWorker, Target: &SupervisorTarget{Issue: 759}, Status: ApprovalStatusPending, CreatedAt: now},
+	}
+
+	count := s.MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue(759, now.Add(time.Minute))
+	if count != 1 {
+		t.Fatalf("staled count = %d, want 1", count)
+	}
+
+	statusOf := func(id string) ApprovalStatus {
+		a, ok := s.FindApproval(id)
+		if !ok {
+			t.Fatalf("approval %q vanished", id)
+		}
+		return a.Status
+	}
+	if got := statusOf("ap-repair-759"); got != ApprovalStatusStale {
+		t.Fatalf("repair approval for resolved issue = %q, want %q", got, ApprovalStatusStale)
+	}
+	if got := statusOf("ap-repair-800"); got != ApprovalStatusPending {
+		t.Fatalf("repair approval for a different issue = %q, want pending (untouched)", got)
+	}
+	if got := statusOf("ap-spawn-759"); got != ApprovalStatusPending {
+		t.Fatalf("spawn_worker approval = %q, want pending (only spawn_repair_worker is staled)", got)
+	}
+}
+
 // #515: ReconcileSpawnWorkerApprovalsForStartedSession must supersede
 // awaiting_dispatch records too, not just pending ones — once the
 // worker actually starts, the awaiting record has done its job.


### PR DESCRIPTION
Fixes the recurring Past-SLA red flags on the Approvals dashboard (the operator kept hand-rejecting stale repair approvals every wave: #762/#763/#767/#769/#770, then #773/#774/#775).

**Cause:** the verified-merge auto-close trust path staled `close_issue` approvals but had no equivalent for `spawn_repair_worker`. When the in-place respawn resolved a PR on its own and the issue auto-closed, the repair approval stayed pending forever.

**Fix:** `MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue` (mirrors the close_issue staler), called co-located at both verified-merge auto-close sites. Repair approval for the resolved issue → stale; repair approvals for other issues and `spawn_worker` approvals are untouched.

**Test:** regression test (fails without the staler); `go test -race ./internal/state/ ./internal/orchestrator/` green.

Refs #771 (where this gap was documented as a follow-up).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stales repair-worker approvals when their target issue is resolved by verified merge. The main changes are:

- Adds a `spawn_repair_worker` approval action constant.
- Adds `MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue` for matching in-flight repair approvals.
- Calls the new staler from both verified-merge auto-close paths.
- Adds a state test covering the matching repair approval and untouched unrelated approvals.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to staling matching repair-worker approvals after verified-merge issue resolution and leaves unrelated approval actions untouched.

Coverage includes the new state transition behavior and both orchestration call sites described by the change, with no unresolved review comments.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The team captured the initial stale-spawn-repair-approval scenario in its before state, where the temporary test code and base output showed MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue undefined and the process exited with code 1.
- The team reviewed the committed regression test source after the fix, noting call-site anchors at internal/orchestrator/orchestrator.go:3765 and 4042, and confirmed a focused test passes with exit code 0.
- The team ran the requested head race test for internal/state and internal/orchestrator, and confirmed it passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/12330096/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: auto-stale spawn\_repair\_wo..."](https://github.com/befeast/maestro/commit/e681479d6912ced5f642a5e46a970ce88710ec5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39913026)</sub>

<!-- /greptile_comment -->