### PR TITLE
configstore: merge shared-backend definitions that differ only in metadata

### DIFF
--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -205,32 +205,86 @@ ON CONFLICT(name) DO UPDATE SET source_path = excluded.source_path, config_yaml 
 }
 
 // upsertSharedBackendsTx inserts/updates the shared backend definitions
-// detached from a project's YAML. It mirrors importProject's behavior:
-// a backend whose definition differs from one already stored is rejected,
-// so two projects can share a backend only when their definitions agree.
+// detached from a project's YAML. Two projects may define the same backend
+// with an identical cmd but different optional metadata (provider / model /
+// pricing / effort) — that is not a real conflict, so the definitions are
+// merged (mergeBackendDefinitions, richest wins). Only a genuinely different
+// cmd is rejected, since the cmd is what dispatches the worker.
 func upsertSharedBackendsTx(ctx context.Context, tx *sql.Tx, backends map[string]*yaml.Node, now string) error {
 	for name, def := range backends {
 		defYAML, err := marshalNode(def)
 		if err != nil {
 			return err
 		}
+		toStore := string(defYAML)
 		var existing string
 		err = tx.QueryRowContext(ctx, `SELECT definition_yaml FROM backends WHERE name = ?`, name).Scan(&existing)
-		if err == nil && strings.TrimSpace(existing) != strings.TrimSpace(string(defYAML)) {
-			return fmt.Errorf("backend %q differs from an already imported definition", name)
-		}
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		switch {
+		case err == nil:
+			merged, mErr := mergeBackendDefinitions(name, existing, toStore)
+			if mErr != nil {
+				return mErr
+			}
+			toStore = merged
+		case errors.Is(err, sql.ErrNoRows):
+			// first definition for this backend name — store as-is
+		default:
 			return err
 		}
 		if _, err := tx.ExecContext(ctx, `
 INSERT INTO backends(name, definition_yaml, updated_at)
 VALUES(?, ?, ?)
 ON CONFLICT(name) DO UPDATE SET definition_yaml = excluded.definition_yaml, updated_at = excluded.updated_at
-`, name, string(defYAML), now); err != nil {
+`, name, toStore, now); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// mergeBackendDefinitions reconciles two definitions of the same shared backend.
+// The store keeps backends in one global table, but per-project configs often
+// annotate the same backend with different optional metadata
+// (provider/model/pricing/effort) while keeping an identical cmd — not a real
+// conflict, since the cmd is what dispatches the worker. So a differing cmd is a
+// hard error; otherwise the definitions are merged into their union, the richer
+// (more-complete) definition winning any overlapping field. The merge is
+// order-independent and idempotent, so a bulk `config-store migrate` converges
+// regardless of the order files are imported in.
+func mergeBackendDefinitions(name, existingYAML, incomingYAML string) (string, error) {
+	if strings.TrimSpace(existingYAML) == strings.TrimSpace(incomingYAML) {
+		return existingYAML, nil
+	}
+	var existing, incoming map[string]any
+	if err := yaml.Unmarshal([]byte(existingYAML), &existing); err != nil {
+		return "", fmt.Errorf("backend %q: parse stored definition: %w", name, err)
+	}
+	if err := yaml.Unmarshal([]byte(incomingYAML), &incoming); err != nil {
+		return "", fmt.Errorf("backend %q: parse incoming definition: %w", name, err)
+	}
+	existingCmd, _ := existing["cmd"].(string)
+	incomingCmd, _ := incoming["cmd"].(string)
+	if existingCmd != "" && incomingCmd != "" && strings.TrimSpace(existingCmd) != strings.TrimSpace(incomingCmd) {
+		return "", fmt.Errorf("backend %q has a conflicting cmd (%q vs %q) — projects cannot share a backend name with different commands", name, existingCmd, incomingCmd)
+	}
+	// Union of fields; the richer definition (more keys) wins on overlap so no
+	// metadata is lost and the result does not depend on import order.
+	richer, poorer := existing, incoming
+	if len(incoming) > len(existing) {
+		richer, poorer = incoming, existing
+	}
+	merged := make(map[string]any, len(richer)+len(poorer))
+	for k, v := range poorer {
+		merged[k] = v
+	}
+	for k, v := range richer {
+		merged[k] = v
+	}
+	out, err := yaml.Marshal(merged)
+	if err != nil {
+		return "", fmt.Errorf("backend %q: marshal merged definition: %w", name, err)
+	}
+	return string(out), nil
 }
 
 // UpsertProject writes a single project's config under an explicit name,

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -242,15 +243,58 @@ ON CONFLICT(name) DO UPDATE SET definition_yaml = excluded.definition_yaml, upda
 	return nil
 }
 
+// descriptiveBackendFields are the BackendDef fields that are attribution / cost
+// display metadata only (#513 provider/model/variant/effort, #619 pricing) — they
+// do not affect how the worker is dispatched, so two projects sharing a backend
+// name may carry different values and they get merged. EVERY other field (cmd,
+// extra_args, prompt_mode, enabled, mcp, usage_stream, non_agentic, quota,
+// subagent_hint) is execution-affecting: a difference there is a real conflict,
+// because the store keeps ONE global backend per name and re-attaches it to every
+// project, so a silent overlay would make one project run with another's runtime
+// settings.
+var descriptiveBackendFields = map[string]bool{
+	"provider": true,
+	"model":    true,
+	"variant":  true,
+	"effort":   true,
+	"pricing":  true,
+}
+
+// backendEffectiveCmd resolves the dispatch command: an empty cmd defaults to the
+// backend name for built-in backends (claude/codex/… BuildCmd), so `claude: {}`
+// and `claude: {cmd: claude}` are the same command, while `claude: {cmd: x}` is
+// not.
+func backendEffectiveCmd(def map[string]any, name string) string {
+	if c, _ := def["cmd"].(string); strings.TrimSpace(c) != "" {
+		return strings.TrimSpace(c)
+	}
+	return name
+}
+
+// behavioralCore returns the execution-affecting subset of a backend definition
+// (everything except descriptive metadata and cmd, which is compared separately
+// via its effective value).
+func behavioralCore(def map[string]any) map[string]any {
+	core := make(map[string]any, len(def))
+	for k, v := range def {
+		if k == "cmd" || descriptiveBackendFields[k] {
+			continue
+		}
+		core[k] = v
+	}
+	return core
+}
+
 // mergeBackendDefinitions reconciles two definitions of the same shared backend.
 // The store keeps backends in one global table, but per-project configs often
-// annotate the same backend with different optional metadata
-// (provider/model/pricing/effort) while keeping an identical cmd — not a real
-// conflict, since the cmd is what dispatches the worker. So a differing cmd is a
-// hard error; otherwise the definitions are merged into their union, the richer
-// (more-complete) definition winning any overlapping field. The merge is
+// annotate the same backend with different DESCRIPTIVE metadata (provider / model
+// / variant / effort / pricing) while keeping identical execution settings — not
+// a real conflict. So when the effective cmd and every other execution-affecting
+// field agree, the definitions are merged into their union (descriptive metadata
+// deep-merged, so e.g. complementary pricing fields converge to the superset).
+// A differing cmd, or any differing behavioral field, is rejected. The merge is
 // order-independent and idempotent, so a bulk `config-store migrate` converges
-// regardless of the order files are imported in.
+// regardless of file order.
 func mergeBackendDefinitions(name, existingYAML, incomingYAML string) (string, error) {
 	if strings.TrimSpace(existingYAML) == strings.TrimSpace(incomingYAML) {
 		return existingYAML, nil
@@ -262,29 +306,50 @@ func mergeBackendDefinitions(name, existingYAML, incomingYAML string) (string, e
 	if err := yaml.Unmarshal([]byte(incomingYAML), &incoming); err != nil {
 		return "", fmt.Errorf("backend %q: parse incoming definition: %w", name, err)
 	}
-	existingCmd, _ := existing["cmd"].(string)
-	incomingCmd, _ := incoming["cmd"].(string)
-	if existingCmd != "" && incomingCmd != "" && strings.TrimSpace(existingCmd) != strings.TrimSpace(incomingCmd) {
+	existingCmd := backendEffectiveCmd(existing, name)
+	incomingCmd := backendEffectiveCmd(incoming, name)
+	if existingCmd != incomingCmd {
 		return "", fmt.Errorf("backend %q has a conflicting cmd (%q vs %q) — projects cannot share a backend name with different commands", name, existingCmd, incomingCmd)
 	}
-	// Union of fields; the richer definition (more keys) wins on overlap so no
-	// metadata is lost and the result does not depend on import order.
-	richer, poorer := existing, incoming
-	if len(incoming) > len(existing) {
-		richer, poorer = incoming, existing
+	if !reflect.DeepEqual(behavioralCore(existing), behavioralCore(incoming)) {
+		return "", fmt.Errorf("backend %q has conflicting execution settings (extra_args/prompt_mode/enabled/mcp/usage_stream/non_agentic/quota/subagent_hint) — only descriptive metadata (provider/model/variant/effort/pricing) may differ between projects sharing a backend", name)
 	}
-	merged := make(map[string]any, len(richer)+len(poorer))
-	for k, v := range poorer {
-		merged[k] = v
-	}
-	for k, v := range richer {
-		merged[k] = v
+	merged := deepMergeMaps(existing, incoming)
+	// Keep an explicit cmd if either side had one (the effective values already
+	// match), so an omitted-cmd side never erases the spelled-out command.
+	if ec, _ := existing["cmd"].(string); strings.TrimSpace(ec) != "" {
+		merged["cmd"] = ec
+	} else if ic, _ := incoming["cmd"].(string); strings.TrimSpace(ic) != "" {
+		merged["cmd"] = ic
 	}
 	out, err := yaml.Marshal(merged)
 	if err != nil {
 		return "", fmt.Errorf("backend %q: marshal merged definition: %w", name, err)
 	}
 	return string(out), nil
+}
+
+// deepMergeMaps returns the recursive union of a and b. On a scalar-vs-scalar
+// overlap b wins; on a map-vs-map overlap the maps are merged recursively (so a
+// nested pricing map keeps both sides' fields instead of one overwriting the
+// other).
+func deepMergeMaps(a, b map[string]any) map[string]any {
+	out := make(map[string]any, len(a)+len(b))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		if existing, ok := out[k]; ok {
+			em, eok := existing.(map[string]any)
+			vm, vok := v.(map[string]any)
+			if eok && vok {
+				out[k] = deepMergeMaps(em, vm)
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // UpsertProject writes a single project's config under an explicit name,

--- a/internal/configstore/store_test.go
+++ b/internal/configstore/store_test.go
@@ -201,6 +201,85 @@ model:
 	}
 }
 
+// Same cmd but a DIFFERENT execution-affecting field (prompt_mode) is a real
+// conflict — the store keeps one global backend, so a silent overlay would make
+// one project deliver its prompt the other's way. Must reject, not merge.
+func TestImportDirRejectsDivergentBehavioralBackendField(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a := `
+repo: owner/a
+model:
+  backends:
+    claude:
+      cmd: claude
+      prompt_mode: stdin
+`
+	b := `
+repo: owner/b
+model:
+  backends:
+    claude:
+      cmd: claude
+      prompt_mode: arg
+`
+	if err := os.WriteFile(filepath.Join(dir, "a.yaml"), []byte(a), 0644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.yaml"), []byte(b), 0644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	store := openTestStore(t)
+	err := store.ImportDir(ctx, dir)
+	if err == nil || !strings.Contains(err.Error(), "conflicting execution settings") {
+		t.Fatalf("ImportDir err = %v, want conflicting-execution-settings error", err)
+	}
+}
+
+// Complementary nested pricing fields must converge to the superset, not have one
+// side's map overwrite the other's (a top-level overlay would drop fields).
+func TestImportDirDeepMergesNestedPricing(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a := `
+repo: owner/a
+model:
+  backends:
+    claude:
+      cmd: claude
+      pricing:
+        input_usd_per_mtok: 5
+`
+	b := `
+repo: owner/b
+model:
+  backends:
+    claude:
+      cmd: claude
+      pricing:
+        output_usd_per_mtok: 25
+`
+	if err := os.WriteFile(filepath.Join(dir, "a.yaml"), []byte(a), 0644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.yaml"), []byte(b), 0644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	store := openTestStore(t)
+	if err := store.ImportDir(ctx, dir); err != nil {
+		t.Fatalf("ImportDir err = %v, want success", err)
+	}
+	var def string
+	if err := store.db.QueryRowContext(ctx, `SELECT definition_yaml FROM backends WHERE name = ?`, "claude").Scan(&def); err != nil {
+		t.Fatalf("read merged backend: %v", err)
+	}
+	for _, want := range []string{"input_usd_per_mtok: 5", "output_usd_per_mtok: 25"} {
+		if !strings.Contains(def, want) {
+			t.Fatalf("merged pricing missing %q (deep-merge dropped a field)\n--- def ---\n%s", want, def)
+		}
+	}
+}
+
 func openTestStore(t *testing.T) *Store {
 	t.Helper()
 	store, err := Open(filepath.Join(t.TempDir(), "config.db"))

--- a/internal/configstore/store_test.go
+++ b/internal/configstore/store_test.go
@@ -142,8 +142,62 @@ model:
 	}
 	store := openTestStore(t)
 	err := store.ImportDir(ctx, dir)
-	if err == nil || !strings.Contains(err.Error(), "differs") {
-		t.Fatalf("ImportDir err = %v, want divergent backend error", err)
+	if err == nil || !strings.Contains(err.Error(), "conflicting cmd") {
+		t.Fatalf("ImportDir err = %v, want conflicting-cmd error", err)
+	}
+}
+
+// Two projects may annotate the same backend with different OPTIONAL metadata
+// (provider/model/pricing/effort) while keeping an identical cmd. That is not a
+// conflict — the cmd dispatches the worker — so ImportDir must merge them
+// (richest wins) rather than reject, which is what unblocks the single-daemon
+// config-store seed across the live fleet (per-project configs drifted in
+// metadata only). Reproduces the real maestro.d divergence in miniature.
+func TestImportDirMergesBackendMetadataWhenCmdMatches(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	// thin: cmd only
+	thin := `
+repo: owner/thin
+model:
+  backends:
+    claude:
+      cmd: claude --model opus[1m]
+`
+	// rich: same cmd, extra metadata
+	rich := `
+repo: owner/rich
+model:
+  backends:
+    claude:
+      cmd: claude --model opus[1m]
+      provider: anthropic
+      model: opus-4.8
+      pricing:
+        input_usd_per_mtok: 5
+        output_usd_per_mtok: 25
+`
+	if err := os.WriteFile(filepath.Join(dir, "a-thin.yaml"), []byte(thin), 0644); err != nil {
+		t.Fatalf("write thin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b-rich.yaml"), []byte(rich), 0644); err != nil {
+		t.Fatalf("write rich: %v", err)
+	}
+	store := openTestStore(t)
+	if err := store.ImportDir(ctx, dir); err != nil {
+		t.Fatalf("ImportDir err = %v, want merge success (cmd matches, metadata differs)", err)
+	}
+
+	// The stored shared backend must be the superset (richest wins) regardless
+	// of import order.
+	var def string
+	if err := store.db.QueryRowContext(ctx, `SELECT definition_yaml FROM backends WHERE name = ?`, "claude").Scan(&def); err != nil {
+		t.Fatalf("read merged backend: %v", err)
+	}
+	for _, want := range []string{"provider: anthropic", "model: opus-4.8", "input_usd_per_mtok: 5", "cmd: claude --model opus[1m]"} {
+		if !strings.Contains(def, want) {
+			t.Fatalf("merged backend missing %q\n--- def ---\n%s", want, def)
+		}
 	}
 }
 


### PR DESCRIPTION
Unblocks the single-daemon cutover seed (#761). `config-store migrate --dir ~/.maestro/maestro.d` failed on the live fleet — projects share an identical backend `cmd` but annotate it with different optional metadata (the dogfood config carries provider/model/pricing/effort; others carry only cmd), and the store rejected any non-byte-identical backend.

**Fix:** `upsertSharedBackendsTx` now merges definitions whose `cmd` matches (union of fields, richer wins — order-independent + idempotent) instead of erroring. Only a genuinely different `cmd` is still rejected.

**Verified:** real `config-store migrate` against maestro.d (9 projects, previously errored) now seeds all 9 and is idempotent; thin projects' claude backend resolves to the rich superset. Unit tests cover the merge + the still-rejected cmd conflict; `go test -race ./internal/configstore/ ./internal/config/` green.

Refs #761

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lets config-store share backend definitions that only differ in metadata. The main changes are:

- Merge shared backend YAML when the effective command matches.
- Reject shared backends that differ in execution settings.
- Deep-merge nested metadata such as pricing.
- Add tests for metadata merges and command or behavior conflicts.

<h3>Confidence Score: 0/5</h3>

No merge-safety assessment was supplied in the provided review context.

No supporting confidence rationale was supplied to carry through unchanged.

internal/configstore/store.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted go test ./internal/configstore -run TestSameCmdMetadataMergeContract -v and encountered an environment failure.
- T-Rex recorded the same focused command again and added an explicit blocker noting the Go environment is unavailable.
- T-Rex included a harness artifact that contains the executable test that would validate the contract if Go were installed.

<a href="https://app.greptile.com/trex/runs/12345615/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/configstore/store.go`, line 359 ([link](https://github.com/befeast/maestro/blob/94a654e433e4e49d48a588cf6e39841733ec4223/internal/configstore/store.go#L359)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Scalar Metadata Is Order-Dependent**

   When two projects use the same `cmd` but set the same metadata key to different scalar values, this merge accepts both definitions and lets the later import overwrite the earlier one. For example, conflicting `pricing.input_usd_per_mtok`, `model`, or `effort` values can make the stored shared backend depend on file order, so pricing or displayed backend metadata changes nondeterministically instead of being rejected or merged deterministically.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/configstore/store.go
   Line: 359

   Comment:
   **Scalar Metadata Is Order-Dependent**

   When two projects use the same `cmd` but set the same metadata key to different scalar values, this merge accepts both definitions and lets the later import overwrite the earlier one. For example, conflicting `pricing.input_usd_per_mtok`, `model`, or `effort` values can make the stored shared backend depend on file order, so pricing or displayed backend metadata changes nondeterministically instead of being rejected or merged deterministically.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/configstore/store.go:359
**Scalar Metadata Is Order-Dependent**

When two projects use the same `cmd` but set the same metadata key to different scalar values, this merge accepts both definitions and lets the later import overwrite the earlier one. For example, conflicting `pricing.input_usd_per_mtok`, `model`, or `effort` values can make the stored shared backend depend on file order, so pricing or displayed backend metadata changes nondeterministically instead of being rejected or merged deterministically.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["configstore: only merge descriptive back..."](https://github.com/befeast/maestro/commit/94a654e433e4e49d48a588cf6e39841733ec4223) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39936483)</sub>

<!-- /greptile_comment -->