### PR TITLE
maestro.service: bind fleet web on 0.0.0.0 so the LAN dashboard works

### DIFF
--- a/maestro.service
+++ b/maestro.service
@@ -14,7 +14,14 @@ Environment=PATH=%h/.local/bin:%h/.bun/bin:%h/.npm-global/bin:/usr/local/bin:/us
 # state; --approvals-db / --state-db default to that same file. --watch-store lets
 # the daemon hot add/remove/reload projects from the store (and powers dashboard
 # project CRUD: POST/DELETE /api/v1/fleet/projects) without a restart.
+# --host 0.0.0.0 binds the fleet web server on all interfaces so the Mission
+# Control dashboard is reachable on the LAN (http://<host>:8786/), matching the
+# retired per-project maestro-fleet-web unit (which ran `serve --host 0.0.0.0`).
+# Without it the daemon's default 127.0.0.1 bind makes the dashboard reachable
+# only from the host itself. The cautious approval gate — not the network bind —
+# is the write-path safety boundary.
 ExecStart=/usr/local/bin/maestro daemon \
+    --host 0.0.0.0 \
     --store %h/.maestro/maestro.db \
     --port 8786 \
     --watch-store \


### PR DESCRIPTION
Post-cutover regression: the Phase-6 `maestro.service` omitted `--host`, so the daemon bound `127.0.0.1` and the Mission Control dashboard at `http://<host>:8786/` became unreachable on the LAN (connection refused). The retired `maestro-fleet-web` unit ran `serve --host 0.0.0.0`; the daemon must match.

Add `--host 0.0.0.0` to the unit ExecStart. No proxy/socat was ever involved — verified the host has no forwarder and 10.10.0.23 is its own eth0; the localhost bind was the whole cause. Live unit already hot-patched to restore access; this fixes the committed template so a future `migrate-to-daemon.sh` render keeps it.

Refs #761

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the fleet web daemon bind address for Mission Control. The main changes are:

- Adds `--host 0.0.0.0` to `maestro.service`.
- Documents that the dashboard should be reachable from the LAN.
- Keeps the existing store, port, watch-store, approvals-store, and state-store arguments.

<h3>Confidence Score: 4/5</h3>

The service now exposes the fleet web/API listener on all interfaces while retaining write-capable unauthenticated endpoints.

- The changed service command delivers the intended bind-address behavior for LAN dashboard access.
- The same change expands network reachability for write-capable fleet API routes without adding authentication or access controls.
- The review scope is small and centered on a single service unit, so the affected runtime path is clear.

maestro.service

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the base ExecStart configuration with the updated one and observed that the --host flag was added, changing the effective bind from 127.0.0.1:8786 to 0.0.0.0:8786.

<a href="https://app.greptile.com/trex/runs/12354797/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
maestro.service:24
**LAN Bind Exposes Writes**

When this unit binds the daemon to `0.0.0.0`, any LAN host can reach the fleet API on port `8786`. With the service's default write-enabled mode and no required auth token, requests such as `POST /api/v1/fleet/projects` can update the project store and `POST /api/v1/fleet/approvals/<id>/approve` can approve pending actions without credentials.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["maestro.service: bind the fleet web on 0..."](https://github.com/befeast/maestro/commit/257f6403b098d85ebb139f76f963b800df807376) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39955223)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->