### PR TITLE
chore: add the missing Dependabot config for maestro (gomod + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      gomod-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.yml
 # But keep CI workflows and composite actions
 !.github/workflows/*.yml
+!.github/dependabot.yml
 !.github/ISSUE_TEMPLATE/*.yml
 !.github/actions/**/*.yml
 !.github/actions/**/*.yaml


### PR DESCRIPTION
Fleet-wide rollout PR #780 landed the auto-merge workflow but **not** `.github/dependabot.yml` — the repo's `.gitignore` `*.yml` rule swallowed it, so Dependabot never ran for maestro itself (every other fleet repo did). Add the config (force-tracked) + un-ignore it. Dependabot runs its initial check shortly after this merges. Refs #761

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Dependabot setup for the repository. The main changes are:

- Adds weekly Dependabot checks for root Go modules.
- Adds weekly Dependabot checks for GitHub Actions workflows.
- Un-ignores `.github/dependabot.yml` so the config stays tracked.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

The change is limited to Dependabot configuration and the matching ignore-rule exception, with no application runtime behavior changed.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the pre-change state showing .github/dependabot.yml was absent and ignored by .gitignore:14:\*.yml.
- Verified the post-change state showing .github/dependabot.yml exists, is tracked, is not ignored by git check-ignore, is explicitly unignored by .gitignore:17, and passes the Dependabot validation script with VALIDATION\_OK.

<a href="https://app.greptile.com/trex/runs/12385654/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: un-ignore .github/dependabot.yml ..."](https://github.com/befeast/maestro/commit/122497831f5e68db26c6702504b601a319b6374e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40017019)</sub>

<!-- /greptile_comment -->