### PR TITLE
chore: run Dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     groups:
       gomod-minor-patch:
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     groups:
       github-actions-minor-patch:


### PR DESCRIPTION
Switch Dependabot schedule weekly→daily across this repo's ecosystems. Patch/minor auto-merge; major stays manual. Refs #761

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes Dependabot run more often for the configured ecosystems.

- Go module update checks now run daily.
- GitHub Actions update checks now run daily.
- Existing grouping and pull request limits stay unchanged.

<h3>Confidence Score: 4/5</h3>

The change is limited to Dependabot scheduling and is generally safe to merge, with attention needed for update backlog behavior.

The modified configuration is small and easy to inspect, while the remaining concern is operational rather than application-runtime behavior.

.github/dependabot.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The reviewer examined the pre-run state and confirmed weekly schedules with minor/patch grouping for gomod-minor-patch and github-actions-minor-patch.
- The reviewer examined the post-run state and confirmed daily schedules with update-types: \[minor, patch\] retained for both configured ecosystems.
- The reviewer noted that major-update/open-pull-request-limit behavior was not validated or reported, per the stated scope instructions.

<a href="https://app.greptile.com/trex/runs/12386284/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/dependabot.yml:6
**Major Updates Can Block Patches**

When daily Go module checks find several ungrouped major updates, those manual PRs can fill the per-ecosystem limit of 5. Dependabot then stops opening new Go module PRs, so grouped patch or minor updates that would auto-merge can be delayed until someone clears the major-update backlog.

### Issue 2 of 2
.github/dependabot.yml:15
**Major Actions Can Block Patches**

When daily GitHub Actions checks find several ungrouped major updates, those manual PRs can fill the per-ecosystem limit of 5. Dependabot then stops opening new Actions PRs, so grouped patch or minor updates that would auto-merge can be delayed until someone clears the major-update backlog.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: run Dependabot daily instead of w..."](https://github.com/befeast/maestro/commit/3939bc8d0ff306bfdf59228d79ddc65956d6938a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40018957)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->