### PR TITLE
chore(deps): bump actions/setup-go from 5 to 6 (supersedes #785)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true


### PR DESCRIPTION
Re-applies the setup-go v5→v6 bump on top of current main, since #785 conflicted with the checkout v7 bump (#787) in the same workflow files. Safe node24 runtime bump (reviewed). Supersedes #785. Refs #761

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the Go setup action in two workflows.

- `release.yml` now uses `actions/setup-go@v6`.
- `version-bump.yml` now uses `actions/setup-go@v6`.
- Both workflows keep `go-version-file: go.mod` and `cache: true`.

<h3>Confidence Score: 3/5</h3>

The change is small and isolated to workflow action versions, but merge safety depends on the custom runner supporting the JavaScript runtime required by the updated action.

The modified lines are straightforward, and the main risk is environmental compatibility on `blacksmith-4vcpu-ubuntu-2404` rather than application code behavior.

.github/workflows/release.yml and .github/workflows/version-bump.yml should be checked against the custom runner image before relying on these workflows.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The initial Build job ran with actions/setup-go@v5 and actions/checkout@v7, and the run completed with PASS.
- The Build job was re-run after upgrading actions/setup-go to v6 while keeping actions/checkout@v7, and the run completed with PASS.
- A test-capture showed the base state with exit code 0; the head state, after bumping setup-go to v6, also finished with exit code 0.

<a href="https://app.greptile.com/trex/runs/12395887/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/release.yml:41
**Custom Runner Node Runtime**

When this release job runs on `blacksmith-4vcpu-ubuntu-2404`, `actions/setup-go@v6` must start under the action runner's newer JavaScript runtime. If that custom runner image has not been updated for the v6 runtime, the setup step fails before any binaries are built, leaving the release flow unable to upload artifacts.

### Issue 2 of 2
.github/workflows/version-bump.yml:28
**Custom Runner Node Runtime**

This scheduled job also runs `actions/setup-go@v6` on `blacksmith-4vcpu-ubuntu-2404`. If that custom runner image does not provide the Node runtime required by the v6 action, the workflow stops at setup-go and the automated version bump never runs.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump actions/setup-go from ..."](https://github.com/befeast/maestro/commit/b3d9aa58197de2facba6d1aaebf2d729631dae51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40039376)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->