### PR TITLE
Fix task-aware routing defects found in post-merge review (#791): backward-compat leak + policy-mode bugs

### DIFF
--- a/docs/model-routing-rfc.md
+++ b/docs/model-routing-rfc.md
@@ -453,9 +453,16 @@ Make the decision self-explaining (closing the §1.6 gap):
   `Signals` breakdown field to `BackendSelection`
   (`internal/state/state.go:115-123`).
 - Surface it where the reason already renders: the `maestro status` `BACKEND`
-  column (`cmd/maestro/main.go:1461`), the fleet drawer
+  column (`cmd/maestro/main.go:1461`), the fleet API
   (`internal/server/fleet.go:1152-1155`), and the dispatch log line
   (`orchestrator.go:5312`).
+  - **Implementation status (#792):** the `maestro status` column, the fleet API
+    JSON (`backend_selection` carries `tier`/`effort`/`model`/`shadow_tier` and
+    the tier-derived candidate scores), and the dispatch log line are wired. The
+    Mission Control **SPA drawer** does not yet render these new fields
+    (`internal/server/web/mc/src/` never reads `backend_selection`); rendering
+    them in the drawer is a tracked frontend follow-up, not part of #791/#792.
+    The data is already exposed on the API for whoever wires the view.
 - Keep the durable `Maestro-Backend:` trailer
   (`internal/state/attribution.go:9-20`) as the canonical backend timeline —
   escalation simply appends a new segment with its `EndReason`, which the trailer

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,15 @@ type BackendDef struct {
 	Variant  string `yaml:"variant,omitempty"`  // e.g. "opus[1m]", "fast", "sonnet"
 	Effort   string `yaml:"effort,omitempty"`   // e.g. "xhigh", "medium", "low"
 
+	// #783/#792 (P1-A): a routing tier's per-tier model/effort override, carried
+	// DISTINCTLY from the #513 attribution Model/Effort above. These are never
+	// parsed from YAML — the orchestrator injects them onto a config clone via
+	// applyTierOverride only for a real policy-resolved tier override. Only these
+	// reach the worker argv (see worker.appendTierModelEffort); the #513
+	// attribution Model/Effort must NOT leak into argv for a non-policy config.
+	TierModel  string `yaml:"-" json:"-"`
+	TierEffort string `yaml:"-" json:"-"`
+
 	// #737: opt-in structured usage capture. When true, a claude-kind backend
 	// runs in `--output-format stream-json --verbose` mode and the worker
 	// runner pipes its NDJSON through `maestro stream-split`, which writes the

--- a/internal/config/routing_policy.go
+++ b/internal/config/routing_policy.go
@@ -94,11 +94,30 @@ func validateRoutingPolicy(cfg *Config) error {
 		if _, ok := r.Tiers[mt]; !ok {
 			return fmt.Errorf("config: routing.policy.escalation.max_tier = %q is not declared in routing.tiers", mt)
 		}
+		// #792 P3: max_tier must rank at or above default_tier. The escalation
+		// climb is capped at max_tier's rank, so a max_tier ranked below the start
+		// tier silently clamps every climb back to the start — escalation becomes a
+		// no-op. Reject it instead of shipping a config that can never escalate.
+		order := r.OrderedTierNames()
+		if mtIdx, dtIdx := tierRankIndex(order, mt), tierRankIndex(order, dt); mtIdx >= 0 && dtIdx >= 0 && mtIdx < dtIdx {
+			return fmt.Errorf("config: routing.policy.escalation.max_tier = %q ranks below default_tier = %q, so the escalation ladder could never climb above the start tier; raise max_tier or lower default_tier", mt, dt)
+		}
 	}
 	if pol.Budget.MaxStrongPerWave < 0 {
 		return fmt.Errorf("config: routing.policy.budget.max_strong_per_wave must be >= 0")
 	}
 	return nil
+}
+
+// tierRankIndex returns the position of name in the rank-ordered tier list (the
+// same order the escalation ladder climbs), or -1 when absent.
+func tierRankIndex(order []string, name string) int {
+	for i, n := range order {
+		if n == name {
+			return i
+		}
+	}
+	return -1
 }
 
 // isEmpty reports whether the predicate sets no signal, which would make a rule

--- a/internal/config/routing_policy.go
+++ b/internal/config/routing_policy.go
@@ -94,13 +94,18 @@ func validateRoutingPolicy(cfg *Config) error {
 		if _, ok := r.Tiers[mt]; !ok {
 			return fmt.Errorf("config: routing.policy.escalation.max_tier = %q is not declared in routing.tiers", mt)
 		}
-		// #792 P3: max_tier must rank at or above default_tier. The escalation
-		// climb is capped at max_tier's rank, so a max_tier ranked below the start
-		// tier silently clamps every climb back to the start — escalation becomes a
-		// no-op. Reject it instead of shipping a config that can never escalate.
+		// #792 P3: max_tier caps the escalation climb at its rank, so a climb is a
+		// silent no-op only when NO possible starting tier ranks below max_tier. The
+		// starting tiers are default_tier (unmatched issues) and each rule's tier
+		// (matched issues). A high default_tier is fine as long as some lower-tier
+		// rule can still climb up to max_tier — e.g. default_tier: strong, a
+		// small/leaf -> cheap rule, and max_tier: standard lets cheap tasks climb to
+		// standard while unmatched tasks start strong. Reject only when default_tier
+		// sits above max_tier AND no rule selects a lower tier to climb from.
 		order := r.OrderedTierNames()
-		if mtIdx, dtIdx := tierRankIndex(order, mt), tierRankIndex(order, dt); mtIdx >= 0 && dtIdx >= 0 && mtIdx < dtIdx {
-			return fmt.Errorf("config: routing.policy.escalation.max_tier = %q ranks below default_tier = %q, so the escalation ladder could never climb above the start tier; raise max_tier or lower default_tier", mt, dt)
+		mtIdx, dtIdx := tierRankIndex(order, mt), tierRankIndex(order, dt)
+		if mtIdx >= 0 && dtIdx >= 0 && mtIdx < dtIdx && !anyRuleTierBelow(order, mtIdx, pol.Rules) {
+			return fmt.Errorf("config: routing.policy.escalation.max_tier = %q ranks below default_tier = %q and no rule selects a lower-rank tier, so the escalation ladder could never climb above the start tier; raise max_tier, lower default_tier, or add a lower-tier rule", mt, dt)
 		}
 	}
 	if pol.Budget.MaxStrongPerWave < 0 {
@@ -118,6 +123,23 @@ func tierRankIndex(order []string, name string) int {
 		}
 	}
 	return -1
+}
+
+// anyRuleTierBelow reports whether some non-passthrough policy rule selects a
+// starting tier ranked strictly below rank. Such a rule gives the escalation
+// ladder a tier to climb up from even when default_tier sits at/above max_tier,
+// so max_tier ranked below default_tier is not necessarily a no-op (#792 P3).
+func anyRuleTierBelow(order []string, rank int, rules []RoutingPolicyRule) bool {
+	for _, rule := range rules {
+		t := strings.TrimSpace(rule.Tier)
+		if t == "" || t == PolicyPassthroughTier {
+			continue
+		}
+		if idx := tierRankIndex(order, t); idx >= 0 && idx < rank {
+			return true
+		}
+	}
+	return false
 }
 
 // isEmpty reports whether the predicate sets no signal, which would make a rule

--- a/internal/config/routing_policy_test.go
+++ b/internal/config/routing_policy_test.go
@@ -263,6 +263,39 @@ routing:
 	}
 }
 
+func TestRoutingPolicy_CappedEscalationBelowStrongDefault(t *testing.T) {
+	// #792 review: a high default_tier with a lower-tier rule and a max_tier
+	// ranked below default_tier is valid — rule-selected cheap tasks still climb
+	// up to max_tier while unmatched tasks start strong. Must NOT be rejected as a
+	// no-op ladder.
+	yaml := policyBackendsYAML + `
+routing:
+  mode: policy
+  tiers:
+    cheap:
+      backend: gemini
+      rank: 0
+    standard:
+      backend: codex
+      rank: 1
+    strong:
+      backend: claude
+      rank: 2
+  policy:
+    default_tier: strong
+    rules:
+      - when: { size: small, dependency: leaf }
+        tier: cheap
+    escalation:
+      enabled: true
+      on: [retry]
+      max_tier: standard
+`
+	if _, err := parse([]byte(yaml)); err != nil {
+		t.Fatalf("parse: capped escalation below a strong default must be accepted, got %v", err)
+	}
+}
+
 func TestRoutingPolicy_NonAgenticTierRejected(t *testing.T) {
 	yaml := `
 repo: owner/repo

--- a/internal/config/routing_policy_test.go
+++ b/internal/config/routing_policy_test.go
@@ -228,6 +228,27 @@ routing:
 `,
 			wantSnip: "max_tier = \"titan\"",
 		},
+		{
+			name: "max_tier below default_tier",
+			routing: `
+routing:
+  mode: policy
+  tiers:
+    cheap:
+      backend: gemini
+      rank: 0
+    strong:
+      backend: claude
+      rank: 2
+  policy:
+    default_tier: strong
+    escalation:
+      enabled: true
+      on: [retry]
+      max_tier: cheap
+`,
+			wantSnip: "ranks below default_tier",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -468,13 +468,10 @@ func (o *Orchestrator) rateLimit() (github.RateLimitStatus, error) {
 	return o.gh.RateLimit()
 }
 
-func (o *Orchestrator) respawnInPlace(slotName string, sess *state.Session, issue github.Issue, promptBase string, backendName string) error {
-	return o.respawnInPlaceWithConfig(o.cfg, slotName, sess, issue, promptBase, backendName)
-}
-
 // respawnInPlaceWithConfig respawns a worker in place using the given config so
-// the escalation ladder can carry a tier's per-tier effort/model override
-// (#783). It defaults to o.cfg via respawnInPlace.
+// the escalation ladder (and the soft-token checkpoint path) can carry a tier's
+// per-tier effort/model override (#783/#792). Callers that have no override pass
+// o.cfg.
 func (o *Orchestrator) respawnInPlaceWithConfig(cfg *config.Config, slotName string, sess *state.Session, issue github.Issue, promptBase string, backendName string) error {
 	if o.respawnInPlaceFn != nil {
 		return o.respawnInPlaceFn(cfg, slotName, sess, o.repo, issue, promptBase, backendName)
@@ -2900,7 +2897,12 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 									log.Printf("[orch] fetch issue #%d for checkpoint respawn: %v — will hit hard limit", sess.IssueNumber, fetchErr)
 								} else {
 									promptBase := o.selectPrompt(issue)
-									if respawnErr := o.respawnInPlace(slotName, sess, issue, promptBase, sess.Backend); respawnErr != nil {
+									// #792: re-apply this policy session's tier effort/model
+									// override so the checkpoint respawn resumes on the
+									// selected tier instead of the base backend def (no-op
+									// for non-policy/shadow sessions — base o.cfg unchanged).
+									respawnCfg := o.tierOverrideConfigForSession(sess)
+									if respawnErr := o.respawnInPlaceWithConfig(respawnCfg, slotName, sess, issue, promptBase, sess.Backend); respawnErr != nil {
 										log.Printf("[orch] checkpoint respawn %s failed: %v — will hit hard limit", slotName, respawnErr)
 									} else {
 										log.Printf("[orch] checkpoint respawn complete for %s", slotName)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -8598,6 +8598,79 @@ func TestCheckSessions_SoftThreshold_CheckpointAndRespawn(t *testing.T) {
 	}
 }
 
+// TestCheckSessions_SoftThreshold_CheckpointRespawnKeepsTierOverride is the #792
+// greptile checkpoint regression guard: a policy-routed session that hits the
+// soft-token checkpoint must respawn with its tier effort/model re-applied. Before
+// the fix the checkpoint path passed the base o.cfg, so RespawnInPlace saw empty
+// tier fields and the resumed worker ran the rest of the session off-tier.
+func TestCheckSessions_SoftThreshold_CheckpointRespawnKeepsTierOverride(t *testing.T) {
+	softThreshold := 0.8
+	cfg := &config.Config{
+		Repo:                     "owner/repo",
+		WorkerMaxTokens:          100000,
+		WorkerSoftTokenThreshold: &softThreshold,
+		MaxRuntimeMinutes:        999,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	var respawnCfg *config.Config
+	respawned := 0
+	o := &Orchestrator{
+		cfg:             cfg,
+		notifier:        &notify.Notifier{},
+		listOpenPRsFn:   func() ([]github.PR, error) { return []github.PR{}, nil },
+		isIssueClosedFn: func(int) (bool, error) { return false, nil },
+		pidAliveFn:      func(int) bool { return true },
+		captureTmuxFn:   func(string) (string, error) { return "tokens 85000 (in 25000 / out 60000)", nil },
+		workerStopFn:    func(*config.Config, string, *state.Session) error { return nil },
+		saveCheckpointFn: func(sess *state.Session) (string, error) {
+			return "/tmp/CHECKPOINT.md", nil
+		},
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "test issue"}, nil
+		},
+		respawnInPlaceFn: func(c *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnCfg = c
+			respawned++
+			sess.Status = state.StatusRunning
+			sess.TokensUsedAttempt = 0
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber: 42,
+		Status:      state.StatusRunning,
+		PID:         1234,
+		TmuxSession: "maestro-mae-1",
+		Branch:      "feat/mae-1-42-test",
+		StartedAt:   time.Now().Add(-30 * time.Minute),
+		Backend:     "claude",
+		// Policy tier override recorded on the durable audit record.
+		BackendSelection: &state.BackendSelection{Tier: "strong", Effort: "high", Model: "opus-4.8"},
+	}
+
+	o.checkSessions(s)
+
+	if respawned != 1 || respawnCfg == nil {
+		t.Fatalf("respawned = %d (cfg nil = %v), want 1 with a config", respawned, respawnCfg == nil)
+	}
+	if got := respawnCfg.Model.Backends["claude"].TierEffort; got != "high" {
+		t.Fatalf("checkpoint respawn TierEffort = %q, want high (override dropped)", got)
+	}
+	if got := respawnCfg.Model.Backends["claude"].TierModel; got != "opus-4.8" {
+		t.Fatalf("checkpoint respawn TierModel = %q, want opus-4.8 (override dropped)", got)
+	}
+	// Base config must be untouched — the override lives on the respawn clone only.
+	if got := cfg.Model.Backends["claude"].TierEffort; got != "" {
+		t.Fatalf("base config mutated: claude TierEffort = %q, want empty", got)
+	}
+}
+
 func TestCheckSessions_SoftThreshold_AlreadyCheckpointed_NoRepeat(t *testing.T) {
 	softThreshold := 0.8
 	cfg := &config.Config{

--- a/internal/orchestrator/routing_policy.go
+++ b/internal/orchestrator/routing_policy.go
@@ -237,7 +237,15 @@ func (o *Orchestrator) escalateRetryBackend(s *state.State, sess *state.Session,
 	// retry path must not move sess.Backend at all — so log the would-escalate and
 	// return ok=false, leaving the retry on its current backend (the fresh-dispatch
 	// path is honored the same way: selection is unchanged in shadow mode).
-	if o.cfg.Routing.Policy.Shadow {
+	//
+	// Shadow shadows only the *policy*. A model:<backend> label override is
+	// resolved by ResolveBackendDecisionForAttempt BEFORE policy evaluation
+	// (resolve.go precedence 1, reason=label) and is a deliberate operator move,
+	// not a policy pick — so an operator who relabels a stuck session to move it
+	// must still be honored on retry, exactly as fresh dispatch honors the label
+	// in shadow mode. Suppress only non-label (policy) decisions; a label override
+	// falls through to the health gate below and dispatches as resolved.
+	if o.cfg.Routing.Policy.Shadow && decision.Reason != router.ReasonLabel {
 		if decision.ShadowTier != "" {
 			log.Printf("[orch] issue #%d retry: policy SHADOW would escalate to tier %q (%s) — keeping backend %s unchanged",
 				sess.IssueNumber, decision.ShadowTier, decision.ShadowReason, sess.Backend)

--- a/internal/orchestrator/routing_policy.go
+++ b/internal/orchestrator/routing_policy.go
@@ -33,11 +33,21 @@ func applyTierOverride(cfg *config.Config, backendName string, decision router.B
 	for k, v := range cfg.Model.Backends {
 		backends[k] = v
 	}
+	// Set BOTH the #513 attribution Model/Effort (so the dashboard + the durable
+	// Maestro-Backend: trailer reflect the model the tier actually ran, and the
+	// pi backend, which reads cfg.Model directly, still receives the override) AND
+	// the distinct TierModel/TierEffort carriers that thread into the worker argv
+	// for claude/codex/gemini. The distinct carriers are what keep a non-policy
+	// config's #513 attribution from leaking into argv (#792 P1-A): this function
+	// early-returns above when there is no real tier override, so for a non-policy
+	// dispatch TierModel/TierEffort stay empty and argv is byte-for-byte unchanged.
 	if effort != "" {
 		def.Effort = effort
+		def.TierEffort = effort
 	}
 	if model != "" {
 		def.Model = model
+		def.TierModel = model
 	}
 	backends[backendName] = def
 	clone.Model.Backends = backends
@@ -132,10 +142,24 @@ func (o *Orchestrator) applyPolicyBudget(s *state.State, decision router.Backend
 	}
 	reason := fmt.Sprintf("policy:%s (budget downgrade from %s, max_strong_per_wave=%d)",
 		target, top, pol.Budget.MaxStrongPerWave)
-	if downgraded, ok := o.router.DecisionForTier(target, reason); ok {
-		return downgraded
+	downgraded, ok := o.router.DecisionForTier(target, reason)
+	if !ok {
+		return decision
 	}
-	return decision
+	// #792 P1-B: honor BackendHealth on the budget path. DecisionForTier only
+	// checks config existence, so without this a downgrade could land on a
+	// backend that is disabled or cooling down after an auth failure / provider
+	// limit — re-introducing the #695 doomed-worker (the fresh-dispatch gate in
+	// resolveDispatchBackend runs BEFORE this and never sees the downgrade). The
+	// original (top-tier) decision was already health-gated, so when the downgrade
+	// target is blocked, keep the healthy strong dispatch this wave rather than
+	// spawn a doomed worker; the cap re-applies next cycle.
+	if blockedBy, _ := o.dispatchBackendBlock(s, downgraded.Backend, time.Now().UTC()); blockedBy != "" {
+		log.Printf("[orch] policy budget: downgrade target %s blocked (%s) — keeping %s (%s) dispatch this wave",
+			downgraded.Backend, blockedBy, decision.Backend, decision.Tier)
+		return decision
+	}
+	return downgraded
 }
 
 // policyBudgetDowngradeTier resolves the tier an over-budget top-tier dispatch
@@ -187,6 +211,13 @@ func (o *Orchestrator) countActiveTierSessions(s *state.State, tier string) int 
 //
 // Must be called before the retry consumes sess.CIFailureOutput /
 // PreviousAttemptFeedback, since the trigger is derived from them.
+//
+// The per-wave strong-tier budget cap (applyPolicyBudget) is intentionally NOT
+// applied here (#792 P3): the cap throttles fresh dispatch of a burst of large
+// tasks, whereas escalation is the failure-driven recovery of one already-active,
+// already-counted issue. Subjecting it to the cap would strand a stuck issue at a
+// tier that demonstrably failed it; the per-issue retry budget + max_tier already
+// bound the climb so it cannot loop.
 func (o *Orchestrator) escalateRetryBackend(s *state.State, sess *state.Session, issue github.Issue) (router.BackendDecision, bool) {
 	if !o.cfg.Routing.IsPolicyMode() || o.cfg.Routing.Policy == nil {
 		return router.BackendDecision{}, false
@@ -200,6 +231,19 @@ func (o *Orchestrator) escalateRetryBackend(s *state.State, sess *state.Session,
 	}
 	steps := escalationSteps(o.cfg.Routing.Policy, sess)
 	decision := o.router.ResolveBackendDecisionForAttempt(issue, steps)
+	// #792 P2-E: shadow mode promises "log the would-pick WITHOUT changing the
+	// dispatched backend" (RFC §2.8). resolvePolicyDecision already returns
+	// model.default with the would-escalate tier recorded as ShadowTier, but the
+	// retry path must not move sess.Backend at all — so log the would-escalate and
+	// return ok=false, leaving the retry on its current backend (the fresh-dispatch
+	// path is honored the same way: selection is unchanged in shadow mode).
+	if o.cfg.Routing.Policy.Shadow {
+		if decision.ShadowTier != "" {
+			log.Printf("[orch] issue #%d retry: policy SHADOW would escalate to tier %q (%s) — keeping backend %s unchanged",
+				sess.IssueNumber, decision.ShadowTier, decision.ShadowReason, sess.Backend)
+		}
+		return router.BackendDecision{}, false
+	}
 	if decision.Backend == "" {
 		return router.BackendDecision{}, false
 	}
@@ -227,10 +271,20 @@ func escalationSteps(pol *config.RoutingPolicy, sess *state.Session) int {
 	if pol == nil || !pol.Escalation.Enabled {
 		return 0
 	}
-	if !escalationTriggerEnabled(pol.Escalation.On, retryTrigger(sess)) {
+	trigger := retryTrigger(sess)
+	if !escalationTriggerEnabled(pol.Escalation.On, trigger) {
 		return 0
 	}
 	steps := sess.RetryCount
+	// #792 P1-C: the review-feedback maintenance-retry path
+	// (handleReviewFeedbackRetry) bumps sess.MaintenanceRetryCount, NOT
+	// sess.RetryCount. So for the review_rejection trigger the climb must count
+	// the maintenance retries, or a PR's blocking findings would never escalate
+	// the tier. Take the larger of the two so the climb tracks whichever counter
+	// actually advanced for this session.
+	if trigger == config.EscalationOnReviewRejection && sess.MaintenanceRetryCount > steps {
+		steps = sess.MaintenanceRetryCount
+	}
 	if steps < 1 {
 		steps = 1
 	}

--- a/internal/orchestrator/routing_policy.go
+++ b/internal/orchestrator/routing_policy.go
@@ -54,6 +54,29 @@ func applyTierOverride(cfg *config.Config, backendName string, decision router.B
 	return &clone
 }
 
+// tierOverrideConfigForSession re-applies a policy session's persisted per-tier
+// effort/model override (#783) onto the base config for an in-place / soft-token
+// checkpoint respawn (#792). RespawnInPlace reads the override off the backend
+// def, but the checkpoint path calls it with the base o.cfg — where the override
+// lives only on the cloned config from applyTierOverride — so without this the
+// resumed worker silently drops the tier model/effort and runs the rest of the
+// session on the base def.
+//
+// The override is read back from the durable BackendSelection audit record
+// (Effort/Model), which is set ONLY for a real policy tier decision; a non-policy
+// or shadow-mode session records no Effort/Model, so this returns o.cfg unchanged
+// and the byte-for-byte non-policy dispatch guarantee (#792 P1-A) holds.
+func (o *Orchestrator) tierOverrideConfigForSession(sess *state.Session) *config.Config {
+	sel := sess.BackendSelection
+	if sel == nil || (strings.TrimSpace(sel.Effort) == "" && strings.TrimSpace(sel.Model) == "") {
+		return o.cfg
+	}
+	return applyTierOverride(o.cfg, sess.Backend, router.BackendDecision{
+		Effort: sel.Effort,
+		Model:  sel.Model,
+	})
+}
+
 // policyBackendSelection builds the audit record for a policy decision (RFC
 // §2.7): the deciding signal+tier reason, the tier and its overrides, and
 // real, tier-rank-derived candidate scores (replacing the constant

--- a/internal/orchestrator/routing_policy_test.go
+++ b/internal/orchestrator/routing_policy_test.go
@@ -217,6 +217,29 @@ func TestEscalateRetryBackend_ShadowKeepsBackend(t *testing.T) {
 	}
 }
 
+// TestEscalateRetryBackend_ShadowHonorsLabelOverride is the #792 review
+// regression guard: shadow mode shadows only the *policy*. A model:<backend>
+// label override is resolved before policy evaluation (resolve.go precedence 1)
+// and is a deliberate operator move to relocate a stuck session, so the retry
+// must still honor it even in shadow mode (pre-fix the unconditional shadow
+// branch returned ok=false and the retry silently reused sess.Backend).
+func TestEscalateRetryBackend_ShadowHonorsLabelOverride(t *testing.T) {
+	cfg := policyCfg()
+	cfg.Routing.Policy.Shadow = true
+	o := policyOrch(cfg)
+	s := state.NewState()
+	sess := &state.Session{IssueNumber: 1, RetryCount: 1, Backend: "codex"}
+	// Operator relabels the stuck session model:claude to move it off codex.
+	issue := issueWithLabels(1, "Stuck", "model:claude")
+	dec, ok := o.escalateRetryBackend(s, sess, issue)
+	if !ok {
+		t.Fatalf("shadow mode: label override dropped (ok=false); want the label honored")
+	}
+	if dec.Backend != "claude" || dec.Reason != router.ReasonLabel {
+		t.Fatalf("shadow retry decision = %+v, want claude/%s (label override)", dec, router.ReasonLabel)
+	}
+}
+
 func TestEscalateRetryBackend_InertWhenManual(t *testing.T) {
 	cfg := policyCfg()
 	cfg.Routing.Mode = "manual"

--- a/internal/orchestrator/routing_policy_test.go
+++ b/internal/orchestrator/routing_policy_test.go
@@ -65,10 +65,22 @@ func TestApplyTierOverride_AppliesToClone(t *testing.T) {
 	if got := out.Model.Backends["codex"].Model; got != "gpt-5.5" {
 		t.Fatalf("override model = %q, want gpt-5.5", got)
 	}
+	// #792 P1-A: the override is ALSO mirrored onto the distinct TierModel/
+	// TierEffort carriers — the only fields threaded into the worker argv — so the
+	// #513 attribution Model/Effort never leak for a non-policy dispatch.
+	if got := out.Model.Backends["codex"].TierEffort; got != "high" {
+		t.Fatalf("override TierEffort = %q, want high", got)
+	}
+	if got := out.Model.Backends["codex"].TierModel; got != "gpt-5.5" {
+		t.Fatalf("override TierModel = %q, want gpt-5.5", got)
+	}
 	// Base config must be untouched — the codex backend def carries no effort
 	// of its own (the override lived on the tier).
 	if got := cfg.Model.Backends["codex"].Effort; got != "" {
 		t.Fatalf("base config mutated: codex effort = %q, want empty", got)
+	}
+	if got := cfg.Model.Backends["codex"].TierEffort; got != "" {
+		t.Fatalf("base config mutated: codex TierEffort = %q, want empty", got)
 	}
 }
 
@@ -143,6 +155,65 @@ func TestEscalateRetryBackend_ClimbsTier(t *testing.T) {
 	}
 	if dec.Backend != "claude" || dec.Tier != "strong" {
 		t.Fatalf("escalated decision = %+v, want claude/strong", dec)
+	}
+}
+
+// TestEscalationSteps_ReviewRejectionCountsMaintenance is the #792 P1-C
+// regression guard: the review-feedback maintenance-retry path bumps
+// MaintenanceRetryCount (not RetryCount), so a review_rejection escalation must
+// count it or the climb is stuck at the floor (1) and never tracks the number of
+// review retries.
+func TestEscalationSteps_ReviewRejectionCountsMaintenance(t *testing.T) {
+	cfg := policyCfg()
+	cfg.Routing.Policy.Escalation.On = []string{"review_rejection"}
+	pol := cfg.Routing.Policy
+	sess := &state.Session{
+		IssueNumber: 1, RetryCount: 0, MaintenanceRetryCount: 2,
+		RetryReason: state.RetryReasonReviewFeedback,
+	}
+	if got := escalationSteps(pol, sess); got != 2 {
+		t.Fatalf("escalationSteps (review_rejection) = %d, want 2 (maintenance retries)", got)
+	}
+}
+
+// TestEscalateRetryBackend_ReviewRejectionClimbsViaMaintenance proves the P1-C
+// fix end-to-end: a 2nd review-feedback retry of an issue that started at cheap
+// climbs two tiers to strong. The pre-fix climb counted RetryCount(0)→floor 1
+// and stranded the retry at standard.
+func TestEscalateRetryBackend_ReviewRejectionClimbsViaMaintenance(t *testing.T) {
+	cfg := policyCfg()
+	cfg.Routing.Policy.Escalation.On = []string{"review_rejection"}
+	cfg.Routing.Policy.Rules = append(cfg.Routing.Policy.Rules,
+		config.RoutingPolicyRule{When: config.RoutingSignalMatch{Size: "small", Dependency: "leaf"}, Tier: "cheap"})
+	o := policyOrch(cfg)
+	s := state.NewState()
+	sess := &state.Session{
+		IssueNumber: 1, Backend: "gemini",
+		RetryReason: state.RetryReasonReviewFeedback, MaintenanceRetryCount: 2,
+	}
+	issue := issueWithLabels(1, "Tiny", "size:small", "dependency:leaf") // starts cheap (rank 0)
+	dec, ok := o.escalateRetryBackend(s, sess, issue)
+	if !ok {
+		t.Fatalf("escalateRetryBackend ok = false, want true")
+	}
+	if dec.Tier != "strong" || dec.Backend != "claude" {
+		t.Fatalf("review escalation decision = %+v, want strong/claude (climbed 2 from cheap)", dec)
+	}
+}
+
+// TestEscalateRetryBackend_ShadowKeepsBackend is the #792 P2-E regression guard:
+// in shadow mode the retry/escalation path must log the would-pick WITHOUT
+// changing the dispatched backend, so escalateRetryBackend returns ok=false and
+// the retry reuses sess.Backend (pre-fix it returned model.default with ok=true,
+// silently moving a strong-tier session to the default backend).
+func TestEscalateRetryBackend_ShadowKeepsBackend(t *testing.T) {
+	cfg := policyCfg()
+	cfg.Routing.Policy.Shadow = true
+	o := policyOrch(cfg)
+	s := state.NewState()
+	sess := &state.Session{IssueNumber: 1, RetryCount: 1, Backend: "claude"}
+	if _, ok := o.escalateRetryBackend(s, sess, issueWithLabels(1, "Ordinary")); ok {
+		t.Fatalf("shadow mode: escalateRetryBackend ok = true, want false (dispatch unchanged)")
 	}
 }
 
@@ -254,6 +325,57 @@ func TestApplyPolicyBudget_SingleTierUnenforceable(t *testing.T) {
 	out := o.applyPolicyBudget(s, dec)
 	if out.Tier != "only" || out.Backend != "claude" {
 		t.Fatalf("single-tier budget = %+v, want unchanged only/claude", out)
+	}
+}
+
+// TestApplyPolicyBudget_SkipsDowngradeOntoCoolingDownBackend is the #792 P1-B
+// regression guard: resolveDispatchBackend health-gates the original (strong)
+// decision, but applyPolicyBudget runs AFTER and could swap to a downgrade tier
+// via DecisionForTier, which only checks config existence — never BackendHealth.
+// A downgrade onto a cooling-down standard backend would spawn the exact #695
+// doomed worker the gate prevents. So when the downgrade target is blocked, the
+// budget path must keep the already-gated strong dispatch instead.
+func TestApplyPolicyBudget_SkipsDowngradeOntoCoolingDownBackend(t *testing.T) {
+	cfg := policyCfg()
+	cfg.Routing.Policy.Budget.MaxStrongPerWave = 1
+	o := policyOrch(cfg)
+	s := state.NewState()
+	// One active strong session → the next strong dispatch is over the cap and
+	// would normally downgrade to standard (codex).
+	s.Sessions["slot-a"] = &state.Session{
+		IssueNumber: 9, Status: state.StatusRunning,
+		BackendSelection: &state.BackendSelection{Tier: "strong"},
+	}
+	// But codex (the downgrade target) is cooling down after a provider limit.
+	s.BackendHealth = map[string]state.BackendHealth{
+		"codex": {State: state.BackendHealthCooldown, Reason: "provider_limit"},
+	}
+	strongDecision := router.BackendDecision{Backend: "claude", Tier: "strong", Reason: "policy:strong"}
+	out := o.applyPolicyBudget(s, strongDecision)
+	if out.Backend != "claude" || out.Tier != "strong" {
+		t.Fatalf("must not downgrade onto cooling-down codex; got %+v", out)
+	}
+}
+
+// TestApplyPolicyBudget_DowngradesWhenTargetHealthy confirms the P1-B gate does
+// not over-fire: a healthy downgrade target still downgrades as before.
+func TestApplyPolicyBudget_DowngradesWhenTargetHealthy(t *testing.T) {
+	cfg := policyCfg()
+	cfg.Routing.Policy.Budget.MaxStrongPerWave = 1
+	o := policyOrch(cfg)
+	s := state.NewState()
+	s.Sessions["slot-a"] = &state.Session{
+		IssueNumber: 9, Status: state.StatusRunning,
+		BackendSelection: &state.BackendSelection{Tier: "strong"},
+	}
+	// A cooldown on an unrelated backend must not block the codex downgrade.
+	s.BackendHealth = map[string]state.BackendHealth{
+		"gemini": {State: state.BackendHealthCooldown, Reason: "provider_limit"},
+	}
+	strongDecision := router.BackendDecision{Backend: "claude", Tier: "strong", Reason: "policy:strong"}
+	out := o.applyPolicyBudget(s, strongDecision)
+	if out.Backend != "codex" || out.Tier != "standard" {
+		t.Fatalf("healthy downgrade target = %+v, want standard/codex", out)
 	}
 }
 

--- a/internal/orchestrator/routing_policy_test.go
+++ b/internal/orchestrator/routing_policy_test.go
@@ -92,6 +92,52 @@ func TestApplyTierOverride_NoOverrideReturnsSame(t *testing.T) {
 	}
 }
 
+// TestTierOverrideConfigForSession_ReappliesPolicyOverride is the #792 checkpoint
+// regression guard: a policy-routed session that hits the soft-token checkpoint
+// respawns through RespawnInPlace, which reads the override off the backend def.
+// The checkpoint path passes the base o.cfg (no override), so the override must
+// be reconstructed from the session's durable BackendSelection audit record or
+// the resumed worker silently drops the tier model/effort for the rest of the run.
+func TestTierOverrideConfigForSession_ReappliesPolicyOverride(t *testing.T) {
+	o := policyOrch(policyCfg())
+	sess := &state.Session{
+		IssueNumber: 1, Backend: "claude",
+		BackendSelection: &state.BackendSelection{Tier: "strong", Effort: "high", Model: "opus-4.8"},
+	}
+	out := o.tierOverrideConfigForSession(sess)
+	if out == o.cfg {
+		t.Fatalf("expected a cloned config carrying the tier override")
+	}
+	// The argv-threaded carriers must be set so the respawned worker dispatches
+	// on the selected tier (see worker.appendTierModelEffort).
+	if got := out.Model.Backends["claude"].TierEffort; got != "high" {
+		t.Fatalf("respawn TierEffort = %q, want high", got)
+	}
+	if got := out.Model.Backends["claude"].TierModel; got != "opus-4.8" {
+		t.Fatalf("respawn TierModel = %q, want opus-4.8", got)
+	}
+	// Base config must be untouched (override lives on the clone only).
+	if got := o.cfg.Model.Backends["claude"].TierEffort; got != "" {
+		t.Fatalf("base config mutated: claude TierEffort = %q, want empty", got)
+	}
+}
+
+// TestTierOverrideConfigForSession_NonPolicyUnchanged guards the #792 P1-A
+// inertness on the checkpoint path: a session with no recorded tier override
+// (non-policy, or shadow mode where Effort/Model stay empty and only ShadowTier
+// is set) must respawn on the base config so a non-policy checkpoint dispatch is
+// byte-for-byte unchanged.
+func TestTierOverrideConfigForSession_NonPolicyUnchanged(t *testing.T) {
+	o := policyOrch(policyCfg())
+	if out := o.tierOverrideConfigForSession(&state.Session{Backend: "claude"}); out != o.cfg {
+		t.Fatalf("nil BackendSelection: expected base config, got clone")
+	}
+	shadow := &state.Session{Backend: "codex", BackendSelection: &state.BackendSelection{ShadowTier: "strong"}}
+	if out := o.tierOverrideConfigForSession(shadow); out != o.cfg {
+		t.Fatalf("shadow selection (no effort/model): expected base config, got clone")
+	}
+}
+
 func TestRetryTrigger(t *testing.T) {
 	if got := retryTrigger(&state.Session{CIFailureOutput: "boom"}); got != config.EscalationOnCIFailure {
 		t.Fatalf("ci trigger = %q", got)

--- a/internal/router/policy.go
+++ b/internal/router/policy.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
@@ -209,11 +211,51 @@ func matchAnyKeyword(issue github.Issue, keywords []string) (matched string, ok 
 	hay := strings.ToLower(issue.Title + "\n" + issue.Body)
 	for _, kw := range keywords {
 		k := strings.ToLower(strings.TrimSpace(kw))
-		if k != "" && strings.Contains(hay, k) {
+		if k != "" && containsWord(hay, k) {
 			return k, true
 		}
 	}
 	return "", false
+}
+
+// containsWord reports whether word occurs in hay delimited by non-word
+// boundaries on both sides, so a risk keyword matches whole words only. Plain
+// strings.Contains over title+body false-routed to the expensive tier:
+// "auth" matched "author"/"oauth" and "infra" matched "infrastructure" (#792
+// P3). A word character is a Unicode letter/number or underscore; any other rune
+// (space, punctuation, slash, hyphen) is a boundary, so multi-token or
+// punctuated keywords ("ci/cd", "data migration") still match as written.
+func containsWord(hay, word string) bool {
+	if word == "" {
+		return false
+	}
+	for start := 0; start <= len(hay)-len(word); {
+		i := strings.Index(hay[start:], word)
+		if i < 0 {
+			return false
+		}
+		i += start
+		boundaryBefore := i == 0
+		if !boundaryBefore {
+			r, _ := utf8.DecodeLastRuneInString(hay[:i])
+			boundaryBefore = !isWordRune(r)
+		}
+		end := i + len(word)
+		boundaryAfter := end == len(hay)
+		if !boundaryAfter {
+			r, _ := utf8.DecodeRuneInString(hay[end:])
+			boundaryAfter = !isWordRune(r)
+		}
+		if boundaryBefore && boundaryAfter {
+			return true
+		}
+		start = i + 1
+	}
+	return false
+}
+
+func isWordRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsNumber(r)
 }
 
 // issueSize derives the size signal from a size:<v> (or size/<v>) issue label.

--- a/internal/router/policy_test.go
+++ b/internal/router/policy_test.go
@@ -62,6 +62,25 @@ func TestPolicy_RiskKeywordMatch(t *testing.T) {
 	}
 }
 
+// TestPolicy_RiskKeywordWordBoundary is the #792 P3 regression guard: risk
+// keywords must match whole words only. The old strings.Contains over title+body
+// false-routed to the expensive tier — "auth" matched "author"/"oauth", "infra"
+// matched "infrastructure".
+func TestPolicy_RiskKeywordWordBoundary(t *testing.T) {
+	r := New(policyConfig())
+	// Standalone keyword still routes to strong.
+	if d := r.ResolveBackendDecision(makeIssue(20, "Rework the auth flow")); d.Tier != "strong" {
+		t.Fatalf("standalone 'auth' tier = %q, want strong", d.Tier)
+	}
+	// Substrings must NOT match.
+	if d := r.ResolveBackendDecision(makeIssue(21, "Credit the author in README")); d.Tier != "standard" {
+		t.Fatalf("'author' falsely matched 'auth': tier = %q, want standard", d.Tier)
+	}
+	if d := r.ResolveBackendDecision(makeIssue(22, "Add oauth login button")); d.Tier != "standard" {
+		t.Fatalf("'oauth' falsely matched 'auth': tier = %q, want standard", d.Tier)
+	}
+}
+
 func TestPolicy_SizeDependencyMatch(t *testing.T) {
 	r := New(policyConfig())
 	d := r.ResolveBackendDecision(makeIssue(3, "Tiny fix", "size:small", "dependency:leaf"))

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -49,8 +49,14 @@ type BackendConfig struct {
 	ExtraArgs  []string // additional args from config
 	PromptMode string   // how to deliver prompt: "arg", "stdin", "file"
 	Provider   string   // per-backend provider field; resolves the exec path for custom-named backends (#684)
-	Model      string   // optional model name for role-specific backend calls
-	Effort     string   // optional reasoning effort for role-specific backend calls
+	Model      string   // optional model name for role-specific backend calls (#513 attribution metadata)
+	Effort     string   // optional reasoning effort for role-specific backend calls (#513 attribution metadata)
+	// TierModel/TierEffort carry a routing tier's per-tier override (#783/#792
+	// P1-A), DISTINCT from the #513 attribution Model/Effort above. Only these
+	// are threaded into the worker argv by appendTierModelEffort, so the #513
+	// attribution fields never leak into a non-policy config's dispatch.
+	TierModel  string
+	TierEffort string
 	// UsageStream opts a structured-stream worker into emitting NDJSON usage
 	// frames on a side-channel slot.jsonl: claude `--output-format stream-json
 	// --verbose` (#737) and codex `exec --json` (#738). Off by default;
@@ -307,29 +313,62 @@ func argsHaveCodexEffort(args []string) bool {
 
 // appendTierModelEffort threads a routing tier's optional per-tier model/effort
 // override (#783, RFC §2.4 step 5) into a first-class agentic backend's worker
-// argv. Until #783 these builders ignored cfg.Model/cfg.Effort for
-// claude/codex/gemini (only Pi read cfg.Model), so a tier could not steer the
-// model/effort without a distinct backend entry. The flag spelling is
-// backend-specific: codex takes the reasoning effort as `-c
-// model_reasoning_effort=<e>`, while claude/gemini take `--effort <e>`; all
-// three take `--model <m>`. An operator who already pinned the model/effort in
-// cmd or extra_args wins — the override is skipped to avoid a duplicate or
-// conflicting flag. pinned is the union of the backend's cmd-prefix args and
-// extra_args.
+// argv. It reads cfg.TierModel/cfg.TierEffort — the DISTINCT tier-override
+// carriers — NOT the #513 attribution cfg.Model/cfg.Effort, so a non-policy
+// config (which only sets the attribution fields) dispatches byte-for-byte as
+// before (#792 P1-A). The tier-override fields are only populated by the
+// orchestrator's applyTierOverride for a real policy-resolved tier.
+//
+// The flag spelling is backend-specific: codex takes the reasoning effort as
+// `-c model_reasoning_effort=<e>` and claude takes `--effort <e>`; all three
+// take `--model <m>`. gemini has no reasoning-effort flag (RFC §2.4 step 5 only
+// names codex/claude), so a tier effort is dropped for it rather than emitting
+// an unsupported `--effort` that would crash the worker (#792 P2-D). An operator
+// who already pinned the model/effort in cmd or extra_args wins — the override
+// is skipped to avoid a duplicate or conflicting flag. pinned is the union of
+// the backend's cmd-prefix args and extra_args.
 func appendTierModelEffort(args, pinned []string, kind string, cfg BackendConfig) []string {
-	if model := strings.TrimSpace(cfg.Model); model != "" && !argsHaveFlag(pinned, "--model") {
+	if model := strings.TrimSpace(cfg.TierModel); model != "" && !argsHaveFlag(pinned, "--model") {
 		args = append(args, "--model", model)
 	}
-	if effort := strings.TrimSpace(cfg.Effort); effort != "" {
-		if kind == config.BackendKindCodex {
-			if !argsHaveCodexEffort(pinned) {
-				args = append(args, "-c", "model_reasoning_effort="+effort)
-			}
-		} else if !argsHaveFlag(pinned, "--effort") {
+	effort := strings.TrimSpace(cfg.TierEffort)
+	if effort == "" {
+		return args
+	}
+	switch kind {
+	case config.BackendKindCodex:
+		if !argsHaveCodexEffort(pinned) {
+			args = append(args, "-c", "model_reasoning_effort="+effort)
+		}
+	case config.BackendKindClaude:
+		if !argsHaveFlag(pinned, "--effort") {
 			args = append(args, "--effort", effort)
 		}
+	default:
+		// gemini and any other agentic backend routed here have no reasoning-effort
+		// CLI flag — silently drop the tier effort (the tier model still applies).
 	}
 	return args
+}
+
+// workerBackendConfig builds the worker BackendConfig from a resolved backend
+// def. TierModel/TierEffort carry a routing tier's override DISTINCTLY from the
+// #513 attribution Model/Effort so only a real policy tier override reaches the
+// worker argv (see appendTierModelEffort) — the attribution metadata never
+// leaks into a non-policy config's dispatch (#792 P1-A).
+func workerBackendConfig(def config.BackendDef) BackendConfig {
+	return BackendConfig{
+		Cmd:         def.Cmd,
+		ExtraArgs:   def.ExtraArgs,
+		PromptMode:  def.PromptMode,
+		Provider:    def.Provider,
+		Model:       def.Model,
+		Effort:      def.Effort,
+		TierModel:   def.TierModel,
+		TierEffort:  def.TierEffort,
+		UsageStream: def.UsageStream,
+		MCP:         def.MCP,
+	}
 }
 
 // pinnedArgs returns the union of a backend's cmd-prefix args and extra_args as

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -120,16 +120,7 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 			return fmt.Errorf("backend %q (default) not found in config", backendName)
 		}
 	}
-	backendCfg := BackendConfig{
-		Cmd:         backendDef.Cmd,
-		ExtraArgs:   backendDef.ExtraArgs,
-		PromptMode:  backendDef.PromptMode,
-		Provider:    backendDef.Provider,
-		Model:       backendDef.Model,
-		Effort:      backendDef.Effort,
-		UsageStream: backendDef.UsageStream,
-		MCP:         backendDef.MCP,
-	}
+	backendCfg := workerBackendConfig(backendDef)
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
 	if err != nil {

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -38,16 +38,7 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 			return fmt.Errorf("backend %q (default) not found in config", backendName)
 		}
 	}
-	backendCfg := BackendConfig{
-		Cmd:         backendDef.Cmd,
-		ExtraArgs:   backendDef.ExtraArgs,
-		PromptMode:  backendDef.PromptMode,
-		Provider:    backendDef.Provider,
-		Model:       backendDef.Model,
-		Effort:      backendDef.Effort,
-		UsageStream: backendDef.UsageStream,
-		MCP:         backendDef.MCP,
-	}
+	backendCfg := workerBackendConfig(backendDef)
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
 	if err != nil {

--- a/internal/worker/tier_argv_test.go
+++ b/internal/worker/tier_argv_test.go
@@ -25,7 +25,7 @@ func buildArgs(t *testing.T, backend string, cfg BackendConfig) string {
 }
 
 func TestTierArgv_ClaudeModelEffort(t *testing.T) {
-	args := buildArgs(t, "claude", BackendConfig{Cmd: "claude", Model: "opus-4.8", Effort: "high"})
+	args := buildArgs(t, "claude", BackendConfig{Cmd: "claude", TierModel: "opus-4.8", TierEffort: "high"})
 	if !strings.Contains(args, "--model opus-4.8") {
 		t.Errorf("claude args missing tier model: %s", args)
 	}
@@ -35,7 +35,7 @@ func TestTierArgv_ClaudeModelEffort(t *testing.T) {
 }
 
 func TestTierArgv_CodexModelEffort(t *testing.T) {
-	args := buildArgs(t, "codex", BackendConfig{Cmd: "codex", Model: "gpt-5.5", Effort: "low"})
+	args := buildArgs(t, "codex", BackendConfig{Cmd: "codex", TierModel: "gpt-5.5", TierEffort: "low"})
 	if !strings.Contains(args, "--model gpt-5.5") {
 		t.Errorf("codex args missing tier model: %s", args)
 	}
@@ -49,12 +49,14 @@ func TestTierArgv_CodexModelEffort(t *testing.T) {
 }
 
 func TestTierArgv_GeminiModelEffort(t *testing.T) {
-	args := buildArgs(t, "gemini", BackendConfig{Cmd: "gemini", Model: "gemini-3-pro", Effort: "medium"})
+	// #792 P2-D: gemini takes --model but has NO --effort flag, so a tier effort
+	// must be dropped rather than emitting an unsupported flag that crashes it.
+	args := buildArgs(t, "gemini", BackendConfig{Cmd: "gemini", TierModel: "gemini-3-pro", TierEffort: "medium"})
 	if !strings.Contains(args, "--model gemini-3-pro") {
 		t.Errorf("gemini args missing tier model: %s", args)
 	}
-	if !strings.Contains(args, "--effort medium") {
-		t.Errorf("gemini args missing tier effort: %s", args)
+	if strings.Contains(args, "--effort") {
+		t.Errorf("gemini must not emit --effort (unsupported by the gemini CLI): %s", args)
 	}
 }
 
@@ -66,9 +68,29 @@ func TestTierArgv_NoOverrideWhenEmpty(t *testing.T) {
 	}
 }
 
+// TestTierArgv_AttributionMetadataDoesNotLeak is the #792 P1-A regression guard:
+// the #513 attribution fields (Provider/Model/Effort) must NEVER reach the worker
+// argv. Pre-#783 the claude/codex/gemini builders ignored them; #783 accidentally
+// threaded them on every dispatch (live fleets pin opus[1m] in cmd while the
+// attribution model is opus-4.8 → wrong/duplicate model). Only the distinct
+// TierModel/TierEffort carriers (set solely by a real policy tier override) may
+// thread, so a non-policy #513-metadata config dispatches byte-for-byte as before.
+func TestTierArgv_AttributionMetadataDoesNotLeak(t *testing.T) {
+	for _, backend := range []string{"claude", "codex", "gemini"} {
+		cfg := BackendConfig{Cmd: backend, Provider: "anthropic", Model: "opus-4.8", Effort: "xhigh"}
+		args := buildArgs(t, backend, cfg)
+		if strings.Contains(args, "--model") || strings.Contains(args, "opus-4.8") {
+			t.Errorf("%s: #513 attribution model leaked into argv: %s", backend, args)
+		}
+		if strings.Contains(args, "--effort") || strings.Contains(args, "model_reasoning_effort") {
+			t.Errorf("%s: #513 attribution effort leaked into argv: %s", backend, args)
+		}
+	}
+}
+
 func TestTierArgv_OperatorPinnedModelWins(t *testing.T) {
 	// An operator-pinned --model in cmd suppresses the tier override (no duplicate).
-	args := buildArgs(t, "claude", BackendConfig{Cmd: "claude --model pinned", Model: "opus-4.8"})
+	args := buildArgs(t, "claude", BackendConfig{Cmd: "claude --model pinned", TierModel: "opus-4.8"})
 	if strings.Count(args, "--model") != 1 {
 		t.Errorf("expected exactly one --model (operator pin wins): %s", args)
 	}
@@ -79,9 +101,9 @@ func TestTierArgv_OperatorPinnedModelWins(t *testing.T) {
 
 func TestTierArgv_OperatorPinnedCodexEffortWins(t *testing.T) {
 	args := buildArgs(t, "codex", BackendConfig{
-		Cmd:       "codex",
-		ExtraArgs: []string{"-c", "model_reasoning_effort=xhigh"},
-		Effort:    "low",
+		Cmd:        "codex",
+		ExtraArgs:  []string{"-c", "model_reasoning_effort=xhigh"},
+		TierEffort: "low",
 	})
 	if strings.Contains(args, "model_reasoning_effort=low") {
 		t.Errorf("tier effort must not override operator-pinned codex effort: %s", args)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -108,16 +108,7 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 			return "", fmt.Errorf("backend %q (default) not found in config", backendName)
 		}
 	}
-	backendCfg := BackendConfig{
-		Cmd:         backendDef.Cmd,
-		ExtraArgs:   backendDef.ExtraArgs,
-		PromptMode:  backendDef.PromptMode,
-		Provider:    backendDef.Provider,
-		Model:       backendDef.Model,
-		Effort:      backendDef.Effort,
-		UsageStream: backendDef.UsageStream,
-		MCP:         backendDef.MCP,
-	}
+	backendCfg := workerBackendConfig(backendDef)
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
 	if err != nil {
@@ -265,16 +256,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 			return fmt.Errorf("backend %q (default) not found in config", backendName)
 		}
 	}
-	backendCfg := BackendConfig{
-		Cmd:         backendDef.Cmd,
-		ExtraArgs:   backendDef.ExtraArgs,
-		PromptMode:  backendDef.PromptMode,
-		Provider:    backendDef.Provider,
-		Model:       backendDef.Model,
-		Effort:      backendDef.Effort,
-		UsageStream: backendDef.UsageStream,
-		MCP:         backendDef.MCP,
-	}
+	backendCfg := workerBackendConfig(backendDef)
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, worktreePath, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
 	if err != nil {


### PR DESCRIPTION
Refs #792

Follow-up to the post-merge review of #791 (task-aware model routing). Fixes the confirmed P1/P2 defects and addresses the P3 items. The verified-correct router precedence and the manual/auto inertness guarantees are preserved.

## Changes
- **P1-A (backward-compat leak):** the `#513` attribution `Model`/`Effort` no longer leak into the worker argv. A routing tier override is now carried on distinct `BackendDef.TierModel`/`TierEffort` fields (injected only by `applyTierOverride` for a real policy tier); `appendTierModelEffort` threads only those. A non-policy config dispatches byte-for-byte as before.
- **P1-B (#695 re-introduction):** `applyPolicyBudget` now honors `BackendHealth` — an over-budget strong dispatch is never downgraded onto a disabled/cooling-down backend; the already-gated strong dispatch is kept for that wave instead.
- **P1-C (escalation never climbs):** `escalationSteps` counts `MaintenanceRetryCount` for the `review_rejection` trigger so review-feedback retries climb the tier ladder.
- **P2-D (invalid gemini flag):** effort is threaded only for codex (`-c model_reasoning_effort=`) / claude (`--effort`); gemini no longer emits an unsupported `--effort`.
- **P2-E (shadow on retry):** the retry/escalation path honors shadow mode — the would-escalate tier is logged without changing the dispatched backend.
- **P3:** reject a `max_tier` ranked below `default_tier` (silent no-op escalation); word-boundary risk-keyword matching (`auth` no longer matches `author`/`oauth`); correct the fleet-drawer observability claim in the RFC (data is on the fleet API; the SPA drawer rendering is a tracked follow-up); document the intentional budget-cap exemption on the escalation path.

## Testing
- Added a regression test for each P1/P2 defect (each fails without its fix) plus P3 guards for the keyword boundary and the `max_tier` rank validation.
- `gofmt`, `go build ./cmd/maestro/`, and `go test -race ./...` all green.

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes task-aware model routing bugs found after the earlier routing change. The main changes are:

- Separate tier model and effort overrides from backend attribution metadata.
- Preserve policy tier overrides during checkpoint respawn.
- Keep budget downgrades away from blocked backends.
- Count review-feedback retries in escalation.
- Keep shadow-mode retries on the current backend.
- Tighten routing policy validation and keyword matching.

<h3>Confidence Score: 5/5</h3>

The routing changes appear merge-safe: the fixes are covered by focused regressions and preserve the intended manual/auto routing behavior.

No correctness issues were identified in the changed routing, worker argument construction, checkpoint respawn, policy validation, or documentation updates.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated attribution handling by running initial tests, confirming leaked attribution in worker argv and that head attribution dispatch aligns with provider-specific overrides.
- Verified policy-budget-health flow by comparing before and after states, showing downgrade to claude/strong in head and no contract mismatch observed.
- Observed changes in review\_rejection and shadow retry behavior, with after state escalated to strong/claude and tests exiting successfully.
- Reviewed fleet drawer and Mission Control frontend RFC updates, confirming API/status exposure changes and absence of budget cap lines in the after state.

<a href="https://app.greptile.com/trex/runs/12412653/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **RFC omits the claimed budget-cap exemption for escalation**

   - **Bug**
     - The PR contract says the RFC documents the intentional budget-cap exemption on the escalation path. The executed head documentation grep found only generic retry-budget and YAML `budget:` references, with no `budget cap`, `budget-cap`, or `exemption` wording. This leaves the documented contract incomplete even though the fleet API/SPA drawer wording was corrected.
   - **Cause**
     - `docs/model-routing-rfc.md` was updated for observability language but not updated to explain that escalation is intentionally exempt from the per-wave budget cap.
   - **Fix**
     - Add explicit RFC text in the escalation or budget interaction section documenting that the escalation path is intentionally exempt from the per-wave strong-tier budget cap, and why the retry budget/max_tier bounds it instead.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: keep policy tier override across so..."](https://github.com/befeast/maestro/commit/9d4dac16e1df14f403ae9477d7eb03c1e7bdb757) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40065972)</sub>

<!-- /greptile_comment -->