### PR TITLE
feat: fleet GitHub rate-limit hardening — jitter + backoff + dedup ListOpenPRs (#794)

### DIFF
--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -12,6 +13,37 @@ import (
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/supervisor"
 )
+
+// superviseJitterCap bounds the random first-cycle phase offset so a freshly
+// (re)started daemon still runs its first supervise cycle promptly on long
+// poll intervals (#794).
+const superviseJitterCap = 60 * time.Second
+
+// superviseJitterFrac yields a random fraction in [0,1); a package var so tests
+// can make the offset deterministic.
+var superviseJitterFrac = rand.Float64
+
+// superviseStartupJitter returns a random phase offset in
+// [0, min(interval, cap)) used to de-synchronize this flow's supervise GitHub
+// reads from the rest of the fleet — and the ticker anchored to the first
+// cycle — so the flows do not burst on the shared PAT in one window (#794).
+// Returns 0 for a non-positive interval.
+func superviseStartupJitter(interval time.Duration) time.Duration {
+	return computeSuperviseJitter(interval, superviseJitterFrac())
+}
+
+// computeSuperviseJitter is the pure phase-offset calculation, split out so it
+// is unit testable without touching the rng.
+func computeSuperviseJitter(interval time.Duration, frac float64) time.Duration {
+	if interval <= 0 {
+		return 0
+	}
+	span := interval
+	if span > superviseJitterCap {
+		span = superviseJitterCap
+	}
+	return time.Duration(frac * float64(span))
+}
 
 // runSupervise is the per-project supervisor loop, extracted from the
 // single-project `maestro supervise` command (cmd/maestro/main.go). The daemon
@@ -45,6 +77,25 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		}
 		logSupervisorDecision(name, decision)
 		return nil
+	}
+
+	// #794: de-phase this flow's supervise reads from the rest of the fleet.
+	// Like the orchestrator loop, the first runOnce anchors the ticker, so a
+	// random phase offset here spreads the supervise GitHub reads across the
+	// poll interval instead of bursting in lockstep with the other flows on the
+	// shared PAT. Only the looping (interval > 0) path jitters — a one-shot
+	// cycle runs immediately. The wait honors ctx so shutdown is not delayed.
+	if interval > 0 {
+		if d := superviseStartupJitter(interval); d > 0 {
+			log.Printf("[%s] supervise: startup jitter — first cycle in %s", name, d.Round(time.Second))
+			t := time.NewTimer(d)
+			select {
+			case <-ctx.Done():
+				t.Stop()
+				return
+			case <-t.C:
+			}
+		}
 	}
 
 	if err := runOnce(); err != nil {

--- a/internal/daemon/supervise_jitter_test.go
+++ b/internal/daemon/supervise_jitter_test.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestComputeSuperviseJitter(t *testing.T) {
+	if d := computeSuperviseJitter(0, 0.5); d != 0 {
+		t.Fatalf("non-positive interval jitter = %s, want 0", d)
+	}
+	if d := computeSuperviseJitter(-time.Second, 0.5); d != 0 {
+		t.Fatalf("negative interval jitter = %s, want 0", d)
+	}
+	if d := computeSuperviseJitter(40*time.Second, 0); d != 0 {
+		t.Fatalf("frac 0 jitter = %s, want 0", d)
+	}
+	if d := computeSuperviseJitter(40*time.Second, 0.5); d != 20*time.Second {
+		t.Fatalf("frac 0.5 of 40s = %s, want 20s", d)
+	}
+	// A long supervise interval is clamped to the cap so a fresh daemon still
+	// runs its first cycle promptly. rand.Float64 yields [0,1), so the largest
+	// realizable offset stays strictly under the cap.
+	if d := computeSuperviseJitter(5*time.Minute, 0.999); d >= superviseJitterCap {
+		t.Fatalf("jitter %s, want < cap %s for a long interval", d, superviseJitterCap)
+	}
+	if d := computeSuperviseJitter(5*time.Minute, 0.5); d != superviseJitterCap/2 {
+		t.Fatalf("frac 0.5 above cap = %s, want %s", d, superviseJitterCap/2)
+	}
+}
+
+// TestSuperviseStartupJitter_Bounds checks the live (rng-backed) entry point
+// keeps every offset within [0, min(interval, cap)) across many draws.
+func TestSuperviseStartupJitter_Bounds(t *testing.T) {
+	interval := 90 * time.Second // > cap, so the bound is the cap
+	for i := 0; i < 1000; i++ {
+		d := superviseStartupJitter(interval)
+		if d < 0 || d >= superviseJitterCap {
+			t.Fatalf("draw %d = %s, want within [0, %s)", i, d, superviseJitterCap)
+		}
+	}
+	if superviseStartupJitter(0) != 0 {
+		t.Fatal("non-positive interval must yield 0 jitter")
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -3,11 +3,14 @@ package github
 import (
 	"encoding/json"
 	"fmt"
+	"log"
+	"math/rand"
 	"net/url"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type greptileCheckRun struct {
@@ -179,13 +182,116 @@ func ghAPI(endpoint string) ([]byte, error) {
 	return ghAPIWithArgs(endpoint)
 }
 
+// gh CLI rate-limit backoff (#794). The fleet runs 8 in-process flows polling
+// GitHub on a single shared PAT. A synchronized, redundant burst trips GitHub's
+// *secondary* (abuse / burst-concurrency) rate limit, which answers HTTP 403
+// even when the primary quota is healthy. Before this, ghAPIWithArgs was a
+// single-shot exec whose .Output() discarded stderr, so the real "403 rate
+// limit" message degraded to an opaque `exit status 1` and the first failed
+// read aborted the entire supervise / orchestrator cycle. We now:
+//   - use CombinedOutput so gh's real error text (HTTP status + the
+//     "rate limit" / "secondary rate limit" message) surfaces in logs, and
+//   - retry a bounded number of times on a detected rate-limit response,
+//     honoring an explicit Retry-After hint when gh surfaces one and otherwise
+//     backing off exponentially (with jitter, capped) — so a transient 403
+//     degrades to a brief stall + retry instead of a failed cycle.
+const (
+	ghAPIMaxAttempts = 4
+	ghAPIBaseBackoff = 2 * time.Second
+	ghAPIMaxBackoff  = 20 * time.Second
+)
+
+// ghAPIRunner runs `gh <args...>` and returns combined stdout+stderr plus the
+// process error. Indirection point so tests can drive the retry loop without a
+// real gh binary.
+var ghAPIRunner = func(args ...string) ([]byte, error) {
+	return exec.Command("gh", args...).CombinedOutput()
+}
+
+// ghAPISleep is the backoff sleeper, injectable so tests do not actually wait.
+var ghAPISleep = time.Sleep
+
+// ghAPIJitterFrac yields a random fraction in [0,1) used to spread retry
+// backoff so the fleet's flows do not re-burst in lockstep after a shared 403.
+var ghAPIJitterFrac = rand.Float64
+
+var ghRetryAfterRe = regexp.MustCompile(`(?i)retry-after:\s*(\d+)`)
+
 func ghAPIWithArgs(endpoint string, args ...string) ([]byte, error) {
 	cmdArgs := append([]string{"api", endpoint}, args...)
-	out, err := exec.Command("gh", cmdArgs...).Output()
+	var out []byte
+	var err error
+	for attempt := 0; attempt < ghAPIMaxAttempts; attempt++ {
+		out, err = ghAPIRunner(cmdArgs...)
+		if err == nil {
+			return out, nil
+		}
+		retryAfter, rateLimited := parseGHRateLimit(out)
+		if !rateLimited || attempt == ghAPIMaxAttempts-1 {
+			break
+		}
+		wait := retryAfter
+		if wait <= 0 {
+			wait = ghBackoffDelay(attempt)
+		}
+		log.Printf("[github] gh api %s: rate-limited (%s); backing off %s before retry %d/%d",
+			endpoint, ghErrorDetail(out), wait.Round(time.Millisecond), attempt+1, ghAPIMaxAttempts-1)
+		ghAPISleep(wait)
+	}
 	if err != nil {
+		if detail := ghErrorDetail(out); detail != "" {
+			return nil, fmt.Errorf("gh api %s: %w: %s", endpoint, err, detail)
+		}
 		return nil, fmt.Errorf("gh api %s: %w", endpoint, err)
 	}
 	return out, nil
+}
+
+// parseGHRateLimit reports whether gh's combined output looks like a primary or
+// secondary rate-limit (or 429) response and, when gh surfaced an explicit
+// Retry-After hint, how long to wait. retryAfter is 0 when no hint is present,
+// in which case the caller falls back to exponential backoff.
+func parseGHRateLimit(out []byte) (retryAfter time.Duration, rateLimited bool) {
+	text := strings.ToLower(string(out))
+	rateLimited = strings.Contains(text, "rate limit") ||
+		strings.Contains(text, "secondary rate limit") ||
+		strings.Contains(text, "http 429") ||
+		(strings.Contains(text, "http 403") && strings.Contains(text, "abuse"))
+	if !rateLimited {
+		return 0, false
+	}
+	if m := ghRetryAfterRe.FindSubmatch(out); m != nil {
+		if secs, convErr := strconv.Atoi(string(m[1])); convErr == nil && secs > 0 {
+			return time.Duration(secs) * time.Second, true
+		}
+	}
+	return 0, true
+}
+
+// ghBackoffDelay computes the exponential backoff for the given zero-based retry
+// attempt, capped at ghAPIMaxBackoff, with full jitter over the lower half so
+// concurrent flows do not retry in lockstep.
+func ghBackoffDelay(attempt int) time.Duration {
+	d := ghAPIBaseBackoff << attempt // base * 2^attempt
+	if d <= 0 || d > ghAPIMaxBackoff {
+		d = ghAPIMaxBackoff
+	}
+	return d/2 + time.Duration(ghAPIJitterFrac()*float64(d/2))
+}
+
+// ghErrorDetail renders gh's combined output as a single-line, length-bounded
+// diagnostic so the actual GitHub error reaches the logs without flooding them.
+func ghErrorDetail(out []byte) string {
+	detail := strings.TrimSpace(string(out))
+	if detail == "" {
+		return ""
+	}
+	detail = strings.Join(strings.Fields(detail), " ")
+	const max = 400
+	if len(detail) > max {
+		detail = detail[:max] + "…"
+	}
+	return detail
 }
 
 func parseRateLimitStatus(out []byte) (RateLimitStatus, error) {

--- a/internal/github/ratelimit_test.go
+++ b/internal/github/ratelimit_test.go
@@ -1,0 +1,233 @@
+package github
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubGHRunner installs a runner that returns the supplied (output, err) pairs
+// in order — one per call — and records every invocation. The final pair is
+// reused if the loop calls more times than provided. It also stubs the sleeper
+// (recording each backoff) and the jitter fraction (0, for determinism), and
+// returns a cleanup that restores the originals.
+func stubGHRunner(t *testing.T, results []struct {
+	out []byte
+	err error
+}) (*int, *[]time.Duration, func()) {
+	t.Helper()
+	origRunner := ghAPIRunner
+	origSleep := ghAPISleep
+	origJitter := ghAPIJitterFrac
+
+	calls := 0
+	var sleeps []time.Duration
+	ghAPIRunner = func(args ...string) ([]byte, error) {
+		i := calls
+		if i >= len(results) {
+			i = len(results) - 1
+		}
+		calls++
+		return results[i].out, results[i].err
+	}
+	ghAPISleep = func(d time.Duration) { sleeps = append(sleeps, d) }
+	ghAPIJitterFrac = func() float64 { return 0 }
+
+	cleanup := func() {
+		ghAPIRunner = origRunner
+		ghAPISleep = origSleep
+		ghAPIJitterFrac = origJitter
+	}
+	return &calls, &sleeps, cleanup
+}
+
+func TestGHAPI_RetriesOnSecondaryRateLimitThenSucceeds(t *testing.T) {
+	limit403 := []byte("gh: You have exceeded a secondary rate limit. Please wait a few minutes before you try again. (HTTP 403)")
+	results := []struct {
+		out []byte
+		err error
+	}{
+		{limit403, errors.New("exit status 1")},
+		{limit403, errors.New("exit status 1")},
+		{[]byte(`{"ok":true}`), nil},
+	}
+	calls, sleeps, cleanup := stubGHRunner(t, results)
+	defer cleanup()
+
+	out, err := ghAPIWithArgs("repos/owner/repo/pulls?state=open")
+	if err != nil {
+		t.Fatalf("ghAPIWithArgs() error = %v, want nil after retry recovery", err)
+	}
+	if string(out) != `{"ok":true}` {
+		t.Fatalf("out = %q, want the recovered body", out)
+	}
+	if *calls != 3 {
+		t.Fatalf("runner calls = %d, want 3 (2 rate-limited + 1 success)", *calls)
+	}
+	if len(*sleeps) != 2 {
+		t.Fatalf("backoff sleeps = %d, want 2", len(*sleeps))
+	}
+	for i, d := range *sleeps {
+		if d <= 0 {
+			t.Fatalf("sleep[%d] = %s, want a positive backoff", i, d)
+		}
+	}
+}
+
+func TestGHAPI_HonorsRetryAfterHint(t *testing.T) {
+	body := []byte("HTTP 429: API rate limit exceeded\nRetry-After: 7\n")
+	results := []struct {
+		out []byte
+		err error
+	}{
+		{body, errors.New("exit status 1")},
+		{[]byte("[]"), nil},
+	}
+	_, sleeps, cleanup := stubGHRunner(t, results)
+	defer cleanup()
+
+	if _, err := ghAPIWithArgs("repos/owner/repo/issues?state=open"); err != nil {
+		t.Fatalf("ghAPIWithArgs() error = %v", err)
+	}
+	if len(*sleeps) != 1 {
+		t.Fatalf("sleeps = %v, want exactly one", *sleeps)
+	}
+	if (*sleeps)[0] != 7*time.Second {
+		t.Fatalf("sleep = %s, want the honored Retry-After of 7s", (*sleeps)[0])
+	}
+}
+
+func TestGHAPI_RateLimitExhaustsRetriesAndSurfacesRealError(t *testing.T) {
+	body := []byte("gh: API rate limit exceeded for user ID 123. (HTTP 403)")
+	results := []struct {
+		out []byte
+		err error
+	}{
+		{body, errors.New("exit status 1")},
+	}
+	calls, sleeps, cleanup := stubGHRunner(t, results)
+	defer cleanup()
+
+	_, err := ghAPIWithArgs("repos/owner/repo/pulls?state=open")
+	if err == nil {
+		t.Fatal("ghAPIWithArgs() error = nil, want failure after exhausting retries")
+	}
+	// The real GitHub error text must reach the caller/log (acceptance #2): no
+	// more opaque "exit status 1" with the rate-limit message discarded.
+	if !strings.Contains(err.Error(), "rate limit") || !strings.Contains(err.Error(), "HTTP 403") {
+		t.Fatalf("error = %q, want it to surface the real gh rate-limit text", err)
+	}
+	if *calls != ghAPIMaxAttempts {
+		t.Fatalf("runner calls = %d, want %d (all attempts)", *calls, ghAPIMaxAttempts)
+	}
+	if len(*sleeps) != ghAPIMaxAttempts-1 {
+		t.Fatalf("sleeps = %d, want %d backoffs between attempts", len(*sleeps), ghAPIMaxAttempts-1)
+	}
+}
+
+func TestGHAPI_NonRateLimitErrorDoesNotRetry(t *testing.T) {
+	body := []byte("gh: Not Found (HTTP 404)")
+	results := []struct {
+		out []byte
+		err error
+	}{
+		{body, errors.New("exit status 1")},
+	}
+	calls, sleeps, cleanup := stubGHRunner(t, results)
+	defer cleanup()
+
+	_, err := ghAPIWithArgs("repos/owner/repo/pulls/999")
+	if err == nil {
+		t.Fatal("ghAPIWithArgs() error = nil, want the 404 surfaced")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Fatalf("error = %q, want the 404 detail surfaced", err)
+	}
+	if *calls != 1 {
+		t.Fatalf("runner calls = %d, want 1 (no retry on a non-rate-limit error)", *calls)
+	}
+	if len(*sleeps) != 0 {
+		t.Fatalf("sleeps = %d, want 0 (no backoff on a non-rate-limit error)", len(*sleeps))
+	}
+}
+
+func TestParseGHRateLimit(t *testing.T) {
+	cases := []struct {
+		name       string
+		out        string
+		wantLimit  bool
+		wantAfter  time.Duration
+		wantAfterY bool
+	}{
+		{"secondary", "You have exceeded a secondary rate limit (HTTP 403)", true, 0, false},
+		{"primary", "gh: API rate limit exceeded (HTTP 403)", true, 0, false},
+		{"http429", "HTTP 429: too many requests", true, 0, false},
+		{"abuse403", "gh: You have triggered an abuse detection mechanism (HTTP 403)", true, 0, false},
+		{"retry-after", "HTTP 429\nRetry-After: 12", true, 12 * time.Second, true},
+		{"plain-403", "gh: Forbidden (HTTP 403)", false, 0, false},
+		{"404", "gh: Not Found (HTTP 404)", false, 0, false},
+		{"success", `{"ok":true}`, false, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			after, limited := parseGHRateLimit([]byte(tc.out))
+			if limited != tc.wantLimit {
+				t.Fatalf("rateLimited = %v, want %v", limited, tc.wantLimit)
+			}
+			if tc.wantAfterY && after != tc.wantAfter {
+				t.Fatalf("retryAfter = %s, want %s", after, tc.wantAfter)
+			}
+			if !tc.wantAfterY && after != 0 {
+				t.Fatalf("retryAfter = %s, want 0 (no explicit hint)", after)
+			}
+		})
+	}
+}
+
+func TestGHBackoffDelay_IsBoundedAndGrows(t *testing.T) {
+	orig := ghAPIJitterFrac
+	ghAPIJitterFrac = func() float64 { return 0 }
+	defer func() { ghAPIJitterFrac = orig }()
+
+	prev := time.Duration(0)
+	for attempt := 0; attempt < 6; attempt++ {
+		d := ghBackoffDelay(attempt)
+		if d <= 0 {
+			t.Fatalf("attempt %d: delay = %s, want positive", attempt, d)
+		}
+		if d > ghAPIMaxBackoff {
+			t.Fatalf("attempt %d: delay = %s, want <= cap %s", attempt, d, ghAPIMaxBackoff)
+		}
+		if attempt > 0 && d < prev {
+			t.Fatalf("attempt %d: delay %s < previous %s, want monotonic until cap", attempt, d, prev)
+		}
+		prev = d
+	}
+}
+
+func TestGHErrorDetail_CollapsesAndBounds(t *testing.T) {
+	if got := ghErrorDetail([]byte("  \n\t ")); got != "" {
+		t.Fatalf("blank detail = %q, want empty", got)
+	}
+	multiline := ghErrorDetail([]byte("gh: error\n  on two lines"))
+	if strings.Contains(multiline, "\n") {
+		t.Fatalf("detail = %q, want newlines collapsed", multiline)
+	}
+	long := ghErrorDetail([]byte(strings.Repeat("x", 1000)))
+	if len([]rune(long)) > 401 {
+		t.Fatalf("detail rune length = %d, want bounded (~400 + ellipsis)", len([]rune(long)))
+	}
+	if !strings.HasSuffix(long, "…") {
+		t.Fatalf("long detail = %q, want truncation ellipsis", long[len(long)-10:])
+	}
+}
+
+// Guard: the secondary-rate-limit fixture the incident reproduced from is still
+// classified as retryable.
+func TestParseGHRateLimit_IncidentFixture(t *testing.T) {
+	fixture := "gh: You have exceeded a secondary rate limit. (HTTP 403)"
+	if _, limited := parseGHRateLimit([]byte(fixture)); !limited {
+		t.Fatal("the 2026-06-28 secondary 403 fixture must be retryable")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -213,6 +213,27 @@ func (o *Orchestrator) endCycle() {
 	o.cyclePRsErr = nil
 }
 
+// invalidateCyclePRs drops the memoized per-cycle open-PR snapshot so the next
+// listOpenPRsForCycle re-fetches fresh. The dedup cache (#794) is taken once at
+// the start of a cycle and shared across its four open-PR consumers
+// (reconcile, check, auto-merge, rebase), but a step that mutates the open-PR
+// set within the same RunOnce — reconcileRunningSessions auto-creating a PR,
+// autoMergePRs merging or closing one — would otherwise leave a later step
+// looking at the pre-mutation snapshot. The concrete failure this guards
+// against (#794 review): reconcile auto-creates a PR via
+// tryCreatePRForPushedBranch and flips the session to pr_open, but autoMergePRs
+// reuses the cache populated before that PR existed, fails to find it, takes
+// the "no open PR — assuming merged/closed" branch and marks the session done —
+// orphaning a live PR in the same cycle. Invalidating after every open-PR-set
+// mutation keeps the dedup win for the common, no-mutation cycle (still one
+// fetch) while guaranteeing correctness when the set does change (one extra
+// fetch). A no-op outside an active cycle.
+func (o *Orchestrator) invalidateCyclePRs() {
+	o.cyclePRsValid = false
+	o.cyclePRs = nil
+	o.cyclePRsErr = nil
+}
+
 // listOpenPRsForCycle returns the open-PR list, fetching it at most once per
 // orchestrator RunOnce. The four cycle steps that need open PRs share a single
 // fetch instead of issuing four identical core-bucket reads (#794). Outside an
@@ -253,10 +274,22 @@ func (o *Orchestrator) remoteBranchExists(branch string) (bool, error) {
 }
 
 func (o *Orchestrator) createPR(title, body, base, head string) (int, error) {
+	var (
+		prNumber int
+		err      error
+	)
 	if o.createPRFn != nil {
-		return o.createPRFn(title, body, base, head)
+		prNumber, err = o.createPRFn(title, body, base, head)
+	} else {
+		prNumber, err = o.gh.CreatePR(title, body, base, head)
 	}
-	return o.gh.CreatePR(title, body, base, head)
+	// A new PR mutates the open-PR set; drop any per-cycle cache so a later
+	// cycle step re-fetches and sees it instead of the pre-creation snapshot
+	// (#794 review).
+	if err == nil {
+		o.invalidateCyclePRs()
+	}
+	return prNumber, err
 }
 
 func (o *Orchestrator) updatePRBody(prNumber int, body string) error {
@@ -430,20 +463,36 @@ func (o *Orchestrator) markPRReady(prNumber int) error {
 }
 
 func (o *Orchestrator) mergePR(prNumber int) error {
+	var err error
 	if o.ghMergePRFn != nil {
-		return o.ghMergePRFn(prNumber)
+		err = o.ghMergePRFn(prNumber)
+	} else {
+		err = o.gh.MergePR(prNumber)
 	}
-	return o.gh.MergePR(prNumber)
+	// A merge removes the PR from the open-PR set; drop the per-cycle cache so
+	// a later step (rebaseConflicts) re-fetches a current view (#794 review).
+	if err == nil {
+		o.invalidateCyclePRs()
+	}
+	return err
 }
 
 func (o *Orchestrator) closePR(prNumber int, comment string) error {
-	if o.ghClosePRFn != nil {
-		return o.ghClosePRFn(prNumber, comment)
+	var err error
+	switch {
+	case o.ghClosePRFn != nil:
+		err = o.ghClosePRFn(prNumber, comment)
+	case o.gh == nil:
+		err = fmt.Errorf("no github client configured for close-pr")
+	default:
+		err = o.gh.ClosePR(prNumber, comment)
 	}
-	if o.gh == nil {
-		return fmt.Errorf("no github client configured for close-pr")
+	// A close removes the PR from the open-PR set; drop the per-cycle cache so
+	// a later step re-fetches a current view (#794 review).
+	if err == nil {
+		o.invalidateCyclePRs()
 	}
-	return o.gh.ClosePR(prNumber, comment)
+	return err
 }
 
 func (o *Orchestrator) prChecksOutput(prNumber int) (string, error) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -131,6 +132,21 @@ type Orchestrator struct {
 	syncProjectFn                func(issueNumber int, status github.ProjectStatus) bool
 	listNonDoneProjectItemsFn    func(pf *github.ProjectField) ([]github.ProjectItem, error)
 	rateLimitFn                  func() (github.RateLimitStatus, error)
+
+	// Per-cycle open-PR cache (#794). ListOpenPRs is the dominant forge REST
+	// read (~78% of the core-bucket calls at the 2026-06-28 secondary
+	// rate-limit incident) and was issued 4× per RunOnce —
+	// reconcileRunningSessions, checkSessions, autoMergePRs and rebaseConflicts
+	// each fetched the same open-PR list independently. While a cycle is active
+	// the first fetch is memoized and shared across those steps so a RunOnce
+	// issues exactly one ListOpenPRs read. Outside RunOnce the cache is inactive
+	// and every call fetches fresh, preserving the semantics of callers (and
+	// tests) that invoke those steps in isolation. RunOnce is serial per flow,
+	// so no locking is required.
+	cycleActive   bool
+	cyclePRsValid bool
+	cyclePRs      []github.PR
+	cyclePRsErr   error
 }
 
 // New creates a new Orchestrator
@@ -177,6 +193,45 @@ func (o *Orchestrator) listOpenPRs() ([]github.PR, error) {
 		return o.listOpenPRsFn()
 	}
 	return o.gh.ListOpenPRs()
+}
+
+// beginCycle resets the per-cycle GitHub-read cache and marks a RunOnce as
+// active so the cycle's steps share one ListOpenPRs fetch (#794).
+func (o *Orchestrator) beginCycle() {
+	o.cycleActive = true
+	o.cyclePRsValid = false
+	o.cyclePRs = nil
+	o.cyclePRsErr = nil
+}
+
+// endCycle clears the per-cycle cache and deactivates memoization so any
+// out-of-cycle caller fetches fresh.
+func (o *Orchestrator) endCycle() {
+	o.cycleActive = false
+	o.cyclePRsValid = false
+	o.cyclePRs = nil
+	o.cyclePRsErr = nil
+}
+
+// listOpenPRsForCycle returns the open-PR list, fetching it at most once per
+// orchestrator RunOnce. The four cycle steps that need open PRs share a single
+// fetch instead of issuing four identical core-bucket reads (#794). Outside an
+// active cycle it delegates straight to listOpenPRs (no memoization), so a
+// direct caller — or a test invoking a single step — sees the fresh,
+// per-call behavior. A fetch error is cached too: under a real 403 the cycle
+// makes one attempt, not four, which is the rate-limit relief this exists for.
+func (o *Orchestrator) listOpenPRsForCycle() ([]github.PR, error) {
+	if !o.cycleActive {
+		return o.listOpenPRs()
+	}
+	if o.cyclePRsValid {
+		return o.cyclePRs, o.cyclePRsErr
+	}
+	prs, err := o.listOpenPRs()
+	o.cyclePRs = prs
+	o.cyclePRsErr = err
+	o.cyclePRsValid = true
+	return prs, err
 }
 
 func (o *Orchestrator) remoteBranchExists(branch string) (bool, error) {
@@ -1577,6 +1632,12 @@ func (o *Orchestrator) selectPrompt(issue github.Issue) string {
 
 // RunOnce executes one orchestration cycle
 func (o *Orchestrator) RunOnce() error {
+	// Activate the per-cycle GitHub-read cache so the cycle's steps share one
+	// ListOpenPRs fetch (#794), and clear it on the way out so nothing leaks
+	// across cycles.
+	o.beginCycle()
+	defer o.endCycle()
+
 	s, err := state.Load(o.cfg.StateDir)
 	if err != nil {
 		return fmt.Errorf("load state: %w", err)
@@ -1704,6 +1765,36 @@ func (o *Orchestrator) SetConfigReloadCh(ch <-chan *config.Config) {
 	o.configReloadCh = ch
 }
 
+// startupJitterCap bounds the random first-cycle phase offset so a freshly
+// (re)started daemon still begins work promptly on long poll intervals (#794).
+const startupJitterCap = 60 * time.Second
+
+// startupJitterFrac yields a random fraction in [0,1); a package var so tests
+// can make the offset deterministic.
+var startupJitterFrac = rand.Float64
+
+// startupJitter returns a random phase offset in [0, min(interval, cap)) used
+// to de-synchronize the fleet's first GitHub read — and the poll ticker
+// anchored to it — so the flows do not burst on the shared PAT in one window
+// (#794). Returns 0 for a non-positive interval.
+func startupJitter(interval time.Duration) time.Duration {
+	return computeStartupJitter(interval, startupJitterFrac())
+}
+
+// computeStartupJitter is the pure phase-offset calculation: frac (in [0,1))
+// scaled across min(interval, startupJitterCap). Split out so it is unit
+// testable without touching the rng.
+func computeStartupJitter(interval time.Duration, frac float64) time.Duration {
+	if interval <= 0 {
+		return 0
+	}
+	span := interval
+	if span > startupJitterCap {
+		span = startupJitterCap
+	}
+	return time.Duration(frac * float64(span))
+}
+
 // Run loops with the given interval; if once=true, runs once and returns.
 // The context can be used to stop the loop (e.g. for multi-project shutdown).
 // An optional refreshCh triggers an immediate poll cycle when a value is received.
@@ -1741,6 +1832,26 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 		// first poll cycle. Idempotent: a no-op when nothing is past the
 		// floors. Failures are logged inside the helper.
 		o.compactTerminalSessionsOnStartup()
+
+		// #794: de-phase this flow from the rest of the fleet before the first
+		// cycle. The daemon starts all flows in a tight loop and each anchors
+		// its poll ticker to its first RunOnce, so without a phase offset the 8
+		// flows fire their GitHub reads in one 1–2s window every interval and
+		// trip GitHub's secondary (burst) rate limit on the shared PAT. A random
+		// offset before the first cycle spreads both the first burst AND the
+		// ticker (anchored right after) across the poll window. `run --once`
+		// skips this (a one-shot reconcile must run now); the wait honors ctx so
+		// shutdown is never delayed.
+		if d := startupJitter(interval); d > 0 {
+			log.Printf("[orch] startup jitter — first cycle in %s (%s)", d.Round(time.Second), o.repo)
+			t := time.NewTimer(d)
+			select {
+			case <-ctx.Done():
+				t.Stop()
+				return nil
+			case <-t.C:
+			}
+		}
 	}
 	if err := o.RunOnce(); err != nil {
 		log.Printf("[orch] run error: %v", err)
@@ -2058,7 +2169,8 @@ func strSliceEqual(a, b []string) bool {
 func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 	// Fetch open PRs once — used to rescue sessions where the worker exited
 	// after creating a PR (process/tmux gone, but PR is already open on GitHub).
-	prs, prErr := o.listOpenPRs()
+	// Shared across the cycle's four open-PR consumers (#794).
+	prs, prErr := o.listOpenPRsForCycle()
 	branchToPR := make(map[string]github.PR)
 	if prErr != nil {
 		log.Printf("[orch] reconcile: warn — could not list PRs: %v (will mark stale sessions dead)", prErr)
@@ -2444,8 +2556,8 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 
 // checkSessions inspects all sessions and updates their status
 func (o *Orchestrator) checkSessions(s *state.State) {
-	// Fetch open PRs once for the whole check cycle
-	prs, prErr := o.listOpenPRs()
+	// Fetch open PRs once for the whole check cycle (shared per-cycle, #794)
+	prs, prErr := o.listOpenPRsForCycle()
 	branchToPR := make(map[string]github.PR)
 	if prErr != nil {
 		log.Printf("[orch] list PRs (check): %v", prErr)
@@ -3008,7 +3120,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 // autoMergePRs checks open PRs and merges ones with green CI
 func (o *Orchestrator) autoMergePRs(s *state.State) {
-	prs, err := o.listOpenPRs()
+	prs, err := o.listOpenPRsForCycle()
 	if err != nil {
 		log.Printf("[orch] list PRs: %v", err)
 		return
@@ -4355,7 +4467,7 @@ func (o *Orchestrator) routeConflictingMergeFailure(s *state.State, slotName str
 //  1. Auto-rebase (if enabled)
 //  2. Label issue as blocked + keep session in conflict_failed permanently
 func (o *Orchestrator) rebaseConflicts(s *state.State) {
-	prs, err := o.listOpenPRs()
+	prs, err := o.listOpenPRsForCycle()
 	if err != nil {
 		log.Printf("[orch] list PRs (rebase): %v", err)
 		return

--- a/internal/orchestrator/ratelimit_dedup_test.go
+++ b/internal/orchestrator/ratelimit_dedup_test.go
@@ -1,0 +1,132 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// TestRunOnce_ListOpenPRsFiresOnce proves acceptance criterion #3 / requirement
+// #20: ListOpenPRs is the dominant (~78%) forge REST read and was issued 4× per
+// RunOnce; after the dedup it must fire at most once per cycle.
+func TestRunOnce_ListOpenPRsFiresOnce(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		StateDir:          t.TempDir(),
+		MaxParallel:       1,
+		MaxRuntimeMinutes: 60,
+	}
+
+	// A running session with a live process/tmux + an open PR on its branch
+	// exercises every cycle step that consumes the open-PR list (reconcile,
+	// check, auto-merge, rebase — each calls listOpenPRsForCycle at its top), so
+	// a regression that re-fetches in any of them is caught. Running (not
+	// pr_open) keeps the one slot occupied so startNewWorkers is skipped.
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "issue 100",
+		Status:      state.StatusRunning,
+		Branch:      "feat/a",
+		PRNumber:    10,
+		PID:         4321,
+		TmuxSession: "maestro-slot-0",
+		StartedAt:   time.Now().UTC(),
+	}
+	if err := state.Save(cfg.StateDir, s); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	listCalls := 0
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			listCalls++
+			return []github.PR{{Number: 10, HeadRefName: "feat/a", State: "OPEN"}}, nil
+		},
+		pidAliveFn:          func(pid int) bool { return true },
+		tmuxSessionExistsFn: func(name string) bool { return true },
+		isIssueClosedFn:     func(issueNumber int) (bool, error) { return false, nil },
+		captureTmuxFn:       func(session string) (string, error) { return "", nil },
+	}
+
+	if err := o.RunOnce(); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if listCalls != 1 {
+		t.Fatalf("ListOpenPRs fired %d times in one RunOnce, want exactly 1 (was 4× before #794)", listCalls)
+	}
+
+	// A second cycle must re-fetch — the cache is per-RunOnce, not persistent.
+	if err := o.RunOnce(); err != nil {
+		t.Fatalf("RunOnce second pass: %v", err)
+	}
+	if listCalls != 2 {
+		t.Fatalf("ListOpenPRs fired %d times across two cycles, want 2 (one per cycle)", listCalls)
+	}
+}
+
+// TestListOpenPRsForCycle_NoMemoizationOutsideCycle guards the behavior that
+// keeps single-step callers/tests correct: outside an active cycle each call
+// fetches fresh.
+func TestListOpenPRsForCycle_NoMemoizationOutsideCycle(t *testing.T) {
+	calls := 0
+	o := &Orchestrator{
+		listOpenPRsFn: func() ([]github.PR, error) {
+			calls++
+			return nil, nil
+		},
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := o.listOpenPRsForCycle(); err != nil {
+			t.Fatalf("listOpenPRsForCycle: %v", err)
+		}
+	}
+	if calls != 3 {
+		t.Fatalf("out-of-cycle calls fetched %d times, want 3 (no memoization)", calls)
+	}
+
+	// Inside a cycle the fetch is memoized.
+	o.beginCycle()
+	for i := 0; i < 3; i++ {
+		if _, err := o.listOpenPRsForCycle(); err != nil {
+			t.Fatalf("listOpenPRsForCycle (in cycle): %v", err)
+		}
+	}
+	if calls != 4 {
+		t.Fatalf("in-cycle calls fetched %d times total, want 4 (one shared fetch)", calls)
+	}
+	o.endCycle()
+}
+
+func TestComputeStartupJitter(t *testing.T) {
+	if d := computeStartupJitter(0, 0.5); d != 0 {
+		t.Fatalf("non-positive interval jitter = %s, want 0", d)
+	}
+	if d := computeStartupJitter(-time.Second, 0.5); d != 0 {
+		t.Fatalf("negative interval jitter = %s, want 0", d)
+	}
+	// Within the cap: full span available.
+	if d := computeStartupJitter(40*time.Second, 0); d != 0 {
+		t.Fatalf("frac 0 jitter = %s, want 0", d)
+	}
+	if d := computeStartupJitter(40*time.Second, 0.5); d != 20*time.Second {
+		t.Fatalf("frac 0.5 of 40s = %s, want 20s", d)
+	}
+	// Above the cap: span is clamped to startupJitterCap. rand.Float64 yields
+	// [0,1), so the largest realizable offset stays strictly under the cap.
+	if d := computeStartupJitter(10*time.Minute, 0.999); d >= startupJitterCap {
+		t.Fatalf("jitter %s, want < cap %s for a long interval", d, startupJitterCap)
+	}
+	if d := computeStartupJitter(10*time.Minute, 0.5); d != startupJitterCap/2 {
+		t.Fatalf("frac 0.5 above cap = %s, want %s", d, startupJitterCap/2)
+	}
+}

--- a/internal/orchestrator/ratelimit_dedup_test.go
+++ b/internal/orchestrator/ratelimit_dedup_test.go
@@ -73,6 +73,111 @@ func TestRunOnce_ListOpenPRsFiresOnce(t *testing.T) {
 	}
 }
 
+// TestRunOnce_AutoCreatedPRNotOrphaned is the regression guard for the #794
+// review finding: the per-cycle open-PR cache is populated before
+// reconcileRunningSessions auto-creates a PR, so a stale cache made autoMergePRs
+// miss the freshly created PR for the now-pr_open session, take the "no open
+// PR — assuming merged/closed" branch, and mark the session done — orphaning a
+// live PR in the same RunOnce. createPR must invalidate the cache so a later
+// cycle step re-fetches and finds the PR.
+func TestRunOnce_AutoCreatedPRNotOrphaned(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		StateDir:          t.TempDir(),
+		MaxParallel:       1,
+		MaxRuntimeMinutes: 60,
+	}
+
+	// A running session whose worker process + tmux are gone but whose branch
+	// was already pushed, with no PR recorded. reconcileRunningSessions takes the
+	// recovery path and auto-creates the PR via tryCreatePRForPushedBranch.
+	s := state.NewState()
+	s.Sessions["slot-0"] = &state.Session{
+		IssueNumber: 200,
+		IssueTitle:  "issue 200",
+		Status:      state.StatusRunning,
+		Branch:      "feat/b",
+		PRNumber:    0,
+		PID:         5555,
+		TmuxSession: "maestro-slot-0",
+		StartedAt:   time.Now().UTC(),
+	}
+	if err := state.Save(cfg.StateDir, s); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	const newPR = 42
+	prCreated := false
+	listCalls := 0
+	ciChecked := false
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: &notify.Notifier{},
+		// The open-PR list reflects the live world: empty until the PR is
+		// created, then containing it. Before the review fix the empty list was
+		// cached for the whole cycle, so autoMergePRs never saw PR #42.
+		listOpenPRsFn: func() ([]github.PR, error) {
+			listCalls++
+			if !prCreated {
+				return nil, nil
+			}
+			return []github.PR{{Number: newPR, HeadRefName: "feat/b", State: "OPEN"}}, nil
+		},
+		pidAliveFn:           func(pid int) bool { return false },
+		tmuxSessionExistsFn:  func(name string) bool { return false },
+		remoteBranchExistsFn: func(branch string) (bool, error) { return true, nil },
+		createPRFn: func(title, body, base, head string) (int, error) {
+			prCreated = true
+			return newPR, nil
+		},
+		// autoMergePRs must find PR #42 and inspect its CI. "pending" keeps the
+		// session in the merge flow without merging it, so it stays pr_open and
+		// the orphaning regression (status flipping to done) is observable.
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			ciChecked = true
+			if prNumber != newPR {
+				t.Errorf("CI checked for PR #%d, want #%d", prNumber, newPR)
+			}
+			return "pending", nil
+		},
+		// Non-MERGEABLE keeps the #424 pending→success override from firing and
+		// keeps rebaseConflicts a no-op, so nothing merges the PR.
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "UNKNOWN", "unknown", nil
+		},
+		isIssueClosedFn:  func(issueNumber int) (bool, error) { return false, nil },
+		captureTmuxFn:    func(session string) (string, error) { return "", nil },
+		listOpenIssuesFn: func(labels []string) ([]github.Issue, error) { return nil, nil },
+	}
+
+	if err := o.RunOnce(); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	final, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	sess := final.Sessions["slot-0"]
+	if sess == nil {
+		t.Fatal("session slot-0 vanished")
+	}
+	if sess.Status != state.StatusPROpen {
+		t.Fatalf("session status = %q, want pr_open — the auto-created PR #%d was orphaned", sess.Status, newPR)
+	}
+	if sess.PRNumber != newPR {
+		t.Fatalf("session PRNumber = %d, want %d", sess.PRNumber, newPR)
+	}
+	if !ciChecked {
+		t.Fatal("autoMergePRs never inspected the auto-created PR — it was not found in the (stale) cached list")
+	}
+	// One fetch before creation + one after the cache was invalidated.
+	if listCalls < 2 {
+		t.Fatalf("ListOpenPRs fired %d times; want ≥2 (a re-fetch after the PR was created)", listCalls)
+	}
+}
+
 // TestListOpenPRsForCycle_NoMemoizationOutsideCycle guards the behavior that
 // keeps single-step callers/tests correct: outside an active cycle each call
 // fetches fresh.
@@ -103,6 +208,18 @@ func TestListOpenPRsForCycle_NoMemoizationOutsideCycle(t *testing.T) {
 	}
 	if calls != 4 {
 		t.Fatalf("in-cycle calls fetched %d times total, want 4 (one shared fetch)", calls)
+	}
+
+	// Invalidating the cache mid-cycle (as a PR create/merge/close does) forces
+	// the next call to re-fetch, then re-memoize.
+	o.invalidateCyclePRs()
+	for i := 0; i < 3; i++ {
+		if _, err := o.listOpenPRsForCycle(); err != nil {
+			t.Fatalf("listOpenPRsForCycle (post-invalidate): %v", err)
+		}
+	}
+	if calls != 5 {
+		t.Fatalf("post-invalidate calls fetched %d times total, want 5 (one re-fetch then memoized)", calls)
 	}
 	o.endCycle()
 }


### PR DESCRIPTION
Implements #794 (Phase 1). **Does not auto-close:** acceptance criteria #6/#7 — a 30–60 min soak across the live 8-flow fleet on the shared PAT showing zero secondary-403s, plus the before/after burst-histogram benchmark — require runtime verification on the running fleet and cannot be proven from CI.

## Context
On 2026-06-28 the fleet hit GitHub HTTP 403 with a **healthy primary quota** → GitHub's **secondary** (burst-concurrency) limit, caused by synchronized, redundant, un-backed-off bursts on one shared PAT.

## Changes
- **Per-flow start/tick jitter** (orchestrator `Run` loop, `internal/daemon/supervise.go`): a random phase offset (capped 60s) before the first cycle de-synchronizes both the first GitHub read and the poll ticker anchored to it, so the flows stop firing in one 1–2s window. Honors ctx (no shutdown delay); skipped for `run --once`.
- **Backoff + `Retry-After` in `ghAPIWithArgs`** (`internal/github/github.go`): on a detected 403/429/secondary-limit, retry a bounded number of times (honor `Retry-After`, else capped exponential backoff with jitter) instead of aborting the cycle; `.Output()` → `CombinedOutput()` so the real GitHub error text reaches the logs instead of opaque `exit status 1`.
- **De-dup `ListOpenPRs` per `RunOnce`** (`internal/orchestrator/orchestrator.go`): reconcile / check / auto-merge / rebase share one per-cycle fetch (4×→1×) for the ~78% endpoint. The cache is active only inside `RunOnce`, so single-step callers/tests still fetch fresh, and decisions key on in-memory session status (no decision regression).

Out of scope (per the issue): GitHub Projects board migration (0% of the pressure, separate near-idle GraphQL bucket) and any forge migration. The board GraphQL path is untouched.

## Testing
- `go test ./...`, `go build ./cmd/maestro/`, `gofmt`, `go vet` — all clean; affected packages pass under `-race`.
- New unit tests: github retry/backoff + `Retry-After` honoring + real-error surfacing; orchestrator `RunOnce` asserting `ListOpenPRs` fires exactly once per cycle (and re-fetches the next cycle); jitter phase-offset bounds in orchestrator and daemon.

## Benchmark (runtime — pending fleet soak)
The before/after measurement (calls-per-cycle by category, per-second burst histogram, core-bucket req/hr, secondary-403 count over a soak window) must be captured on the running fleet. This PR lands the code path plus the deterministic dedup/backoff/jitter proof via unit tests; the `ListOpenPRs` 4×→1× reduction is statically verifiable and unit-tested.

Refs #794

Maestro-Backend: claude anthropic opus-4.8 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the fleet against GitHub secondary rate limits. The main changes are:

- Startup jitter for orchestrator and supervise polling loops.
- Bounded GitHub CLI retry/backoff with `Retry-After` support.
- Per-cycle `ListOpenPRs` reuse inside `RunOnce`.
- Cache invalidation after local PR create, merge, and close operations.
- Tests for jitter bounds, retry behavior, and same-cycle PR cache refresh.

<h3>Confidence Score: 5/5</h3>

The changes are merge-safe based on the provided test coverage and the absence of identified correctness or security issues.

The implementation is narrowly scoped to jitter, bounded retry behavior, and per-cycle GitHub request reuse, with targeted tests covering the new rate-limit handling paths and cache behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Recorded the base test command in the worktree with a missing Go tool, captured pre-run and post-run states showing EXIT\_CODE 127, and included the generated test files used for the attempted validation.
- Validated the HTTP rate-limit handling by simulating a 403 response and observing retries and final error progression, with runtime logs showing backoffs and 429 handling.
- Ran the dedup contract tests around open PRs and observed RunOnce counters change from 4 to 1, and confirmed PR cache invalidation behavior after the mutation test passes.

<a href="https://app.greptile.com/trex/runs/12554013/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: invalidate per-cycle PR cache after..."](https://github.com/befeast/maestro/commit/1b8849dcf352b6ee321982485344ecd9dd20510d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40358713)</sub>

<!-- /greptile_comment -->