### PR TITLE
Fix OK Folio orchestration drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,8 +582,9 @@ plus one aggregating fleet dashboard on `:8786`. This replaces the old
 per-project `maestro@.service` template (and the separate supervise/serve units)
 — one unit instead of ~15.
 
-Projects live in a SQLite config store, not per-project YAML files. Seed it once
-from your existing `~/.maestro/maestro.d/*.yaml`:
+Projects live in a SQLite config store, not per-project runtime YAML files. Seed
+it once from existing `~/.maestro/maestro.d/*.yaml`; after that, treat those
+YAML files as import/export artifacts, not as the operator source of truth:
 
 ```bash
 maestro config-store migrate --db ~/.maestro/maestro.db --dir ~/.maestro/maestro.d
@@ -602,6 +603,14 @@ systemctl --user list-units 'maestro*'
 journalctl --user -u maestro.service -f
 ```
 
+Day-to-day project inspection should target the store row the daemon is running,
+not a seed YAML file:
+
+```bash
+maestro config-store list --db ~/.maestro/maestro.db
+maestro status --config-store ~/.maestro/maestro.db --config-store-project <project-name>
+```
+
 The whole cutover (seed store → stop legacy units → start the daemon → verify
 `:8786/api/v1/fleet`) is automated by `scripts/migrate-to-daemon.sh`:
 
@@ -616,7 +625,7 @@ supported because the legacy unit files stay on disk:
 
 ```bash
 systemctl --user disable --now maestro.service
-# regenerate per-project YAML from the store if you removed the originals:
+# regenerate portable YAML from the store only when you need a backup/export:
 maestro config-store export --db ~/.maestro/maestro.db --dir ~/.maestro/maestro.d
 systemctl --user enable --now maestro@panoptikon maestro@myapp   # re-enable old units
 ```

--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -107,7 +107,7 @@ func handleDaemonSignals(ctx context.Context, cancel context.CancelFunc, d *daem
 }
 
 // defaultConfigStorePath mirrors the config-store default used elsewhere
-// (~/.maestro/config.db).
+// (~/.maestro/maestro.db).
 func defaultConfigStorePath() string {
-	return filepath.Join(os.Getenv("HOME"), ".maestro", "config.db")
+	return filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.db")
 }

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -58,7 +58,7 @@ Commands:
   stop          Stop a worker session
   kill          Kill a worker session by slot name
   import        Seed state from existing worktrees
-  config-store  Manage the SQLite config store (migrate/export/add/rm/edit)
+  config-store  Manage the SQLite config store (migrate/export/list/add/rm/edit)
   history       Show recently completed sessions
   digest        Write the morning operator digest across all fleet projects
   cleanup       Remove worktrees for all completed/dead sessions
@@ -499,9 +499,10 @@ func loadConfigsWithStore(paths []string, storePath, project string) []*config.C
 
 func configStoreCmd(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: maestro config-store <migrate|export|add|rm|edit> ...")
+		fmt.Fprintln(os.Stderr, "usage: maestro config-store <migrate|export|list|add|rm|edit> ...")
 		fmt.Fprintln(os.Stderr, "  migrate --db <path> --dir <maestro.d>   import a directory of YAML configs")
 		fmt.Fprintln(os.Stderr, "  export  --db <path> --dir <out>         export every project to YAML")
+		fmt.Fprintln(os.Stderr, "  list    --db <path>                     list project names in the store")
 		fmt.Fprintln(os.Stderr, "  add     --file <yaml> [--name <name>]   add/replace a single project")
 		fmt.Fprintln(os.Stderr, "  rm      <name>                          remove a project")
 		fmt.Fprintln(os.Stderr, "  edit    <name>                          export → $EDITOR → re-import")
@@ -514,9 +515,11 @@ func configStoreCmd(args []string) {
 		configStoreRm(args[1:])
 	case "edit":
 		configStoreEdit(args[1:])
+	case "list":
+		configStoreList(args[1:])
 	case "migrate":
 		fs := flag.NewFlagSet("config-store migrate", flag.ExitOnError)
-		dbPath := fs.String("db", filepath.Join(os.Getenv("HOME"), ".maestro", "config.db"), "SQLite config store path")
+		dbPath := configStoreDBFlag(fs)
 		dir := fs.String("dir", filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.d"), "Directory containing project YAML files")
 		fs.Parse(args[1:])
 		store, err := configstore.Open(*dbPath)
@@ -530,7 +533,7 @@ func configStoreCmd(args []string) {
 		fmt.Printf("Migrated YAML configs from %s into SQLite store %s.\n", *dir, *dbPath)
 	case "export":
 		fs := flag.NewFlagSet("config-store export", flag.ExitOnError)
-		dbPath := fs.String("db", filepath.Join(os.Getenv("HOME"), ".maestro", "config.db"), "SQLite config store path")
+		dbPath := configStoreDBFlag(fs)
 		dir := fs.String("dir", filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.d.export"), "Directory to write portable YAML files")
 		fs.Parse(args[1:])
 		store, err := configstore.Open(*dbPath)
@@ -548,11 +551,29 @@ func configStoreCmd(args []string) {
 	}
 }
 
-// configStoreDBFlag registers the shared --db flag (default ~/.maestro/config.db)
+// configStoreDBFlag registers the shared --db flag (default ~/.maestro/maestro.db)
 // used by the per-project CRUD subcommands so they target the same store the
 // daemon reads.
 func configStoreDBFlag(fs *flag.FlagSet) *string {
-	return fs.String("db", filepath.Join(os.Getenv("HOME"), ".maestro", "config.db"), "SQLite config store path")
+	return fs.String("db", defaultConfigStorePath(), "SQLite config store path")
+}
+
+func configStoreList(args []string) {
+	fs := flag.NewFlagSet("config-store list", flag.ExitOnError)
+	dbPath := configStoreDBFlag(fs)
+	fs.Parse(args)
+	store, err := configstore.Open(*dbPath)
+	if err != nil {
+		log.Fatalf("config-store list: open db: %v", err)
+	}
+	defer store.Close()
+	names, err := store.ProjectNames(context.Background())
+	if err != nil {
+		log.Fatalf("config-store list: %v", err)
+	}
+	for _, name := range names {
+		fmt.Println(name)
+	}
 }
 
 // configStoreAdd implements `config-store add --file <yaml> [--name <name>]`:

--- a/cmd/maestro/main_config_store_test.go
+++ b/cmd/maestro/main_config_store_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,6 +44,19 @@ func openEditTestStore(t *testing.T) *configstore.Store {
 		t.Fatalf("seed project: %v", err)
 	}
 	return store
+}
+
+func TestConfigStoreDBFlagDefaultsToMaestroDB(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	got := configStoreDBFlag(fs)
+
+	want := filepath.Join(home, ".maestro", "maestro.db")
+	if *got != want {
+		t.Fatalf("config store db default = %q, want %q", *got, want)
+	}
 }
 
 func TestEditStoreProjectAppliesEdit(t *testing.T) {

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -4,19 +4,21 @@ Use Fleet Mission Control as the primary operations surface for Maestro-managed 
 
 This runbook is intentionally safe for shared docs. It uses placeholders for local paths and never requires printing tokens, environment variables, raw config dumps, or full worker logs.
 
-## Workshop Services
+## Runtime Services
 
-Reserve these services and ports on the workshop host:
+Reserve one Maestro service and one fleet port on the runtime host:
 
 | Service | Default bind | Port | Purpose | Notes |
 |---|---:|---:|---|---|
-| Fleet Mission Control | `127.0.0.1` | `8787` | The single dashboard for the whole fleet, plus the `/api/v1/fleet` aggregate API and project-scoped routes (`/project/<name>`) | Start with `maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787` (writes enabled on trusted LAN; add `--read-only=true` for exposed installs) |
-| Project runner | none by default | none | Runs `maestro run --config ...` and owns workers, worktrees, PR handling, and merge/deploy loops | It only serves HTTP when that project config has `server.port` set |
-| Supervisor loop | none | none | Runs `maestro supervise --config ...` to record decisions, safe queue label mutations, and approval requests | Can be manual, timer-driven, or a user service |
-| Worker sessions | none | none | tmux sessions and log files created under each project's `state_dir` | Inspect through Mission Control, `maestro status`, or `maestro logs` |
+| `maestro.service` | `0.0.0.0` or private bind | `8786` | Runs `maestro daemon`: every project flow, the supervisor loops, the watchdogs, approvals/state write-through, and Mission Control | Start from the SQLite store with `maestro daemon --store ~/.maestro/maestro.db --watch-store --approvals-store sqlite --state-store sqlite` |
+| Worker sessions | none | none | tmux sessions and log files created under each project's `state_dir` | Inspect through Mission Control, `maestro status --config-store ~/.maestro/maestro.db --config-store-project <name>`, or `maestro logs --config-store ...` |
 | OpenClaw relay | `127.0.0.1` | `18789` | Optional Telegram relay endpoint when `telegram.mode: openclaw` is used | Not required for Mission Control |
 
-> Per-project Mission Control ports (`8788+`) were retired in #516. Every project is now reachable through the fleet aggregator at `/project/<name>`. Old `maestro-<project>-web.service` user units can be stopped and disabled; their `server.port` settings in project YAMLs are honored only when a project runs its own single-tenant `maestro serve --config ...` outside the fleet.
+There are no per-project systemd units in the daemon model. Retire old
+`maestro-<project>`, `maestro-<project>-supervise`, `maestro@<project>`, and
+per-project web units after the cutover. Per-project Mission Control ports
+(`8788+`) were retired; every project is reachable through the one daemon API
+and SPA.
 
 ### Dashboard auth posture: trusted LAN vs. exposed install
 
@@ -29,17 +31,32 @@ The server advertises both **HTTP Basic** (any username, password equal to the t
 
 ## Config Boundaries
 
-Project config and fleet config have different jobs.
+The config store is the runtime source of truth. YAML files are still useful as
+seed/export artifacts, but operators should not use them as the primary status,
+debug, or launch surface once the daemon is running.
 
 | File | Loaded by | Owns | Does not own |
 |---|---|---|---|
-| `~/.maestro/maestro-<project>.yaml` | `maestro run`, `maestro supervise`, `maestro status`, `maestro logs`, single-project `maestro serve` | Repo, clone path, worktree path, state directory, session prefix, labels, supervisor policy, review gate, merge/deploy policy | Other projects |
-| `~/.maestro/fleet.yaml` | `maestro serve --fleet` | Project display names and project config paths | Queue policy, labels, state directories, review gates, merge behavior |
-| `.maestro/supervisor.yaml`, `.maestro/supervisor.yml`, or `.maestro/supervisor.md` | Loaded beside the project config or inside `local_path/.maestro` | Supervisor policy when the team wants policy beside the repo | Fleet membership |
+| `~/.maestro/maestro.db` | `maestro daemon`, Mission Control, store-backed CLI commands | Project rows, shared backend definitions, approvals, mirrored state | Product source code |
+| `~/.maestro/maestro.d/*.yaml` | `maestro config-store migrate/export`, explicit legacy `--config` commands | Portable seed/backup copies of project config | Runtime truth after cutover |
+| `.maestro/supervisor.yaml`, `.maestro/supervisor.yml`, or `.maestro/supervisor.md` | Loaded beside/imported with project config when intentionally used | Repo-local supervisor policy | Fleet membership, runtime state, backend credentials |
 
-Fleet config paths may be absolute, `~/...`, or relative to the fleet YAML file. A fleet file should not duplicate project settings. If a project needs a different label, review gate, state directory, or runner interval, change that project's config and restart that project's runner.
+Store-backed operator commands:
 
-`dashboard_url` was historically used to link from the fleet card to a per-project dashboard on its own port. Those ports are retired (#516); the aggregator routes operators to `/project/<name>` instead. Any `dashboard_url` value still present in a fleet.yaml file is ignored and logged as deprecated on load.
+```bash
+maestro config-store list --db ~/.maestro/maestro.db
+maestro config-store edit --db ~/.maestro/maestro.db <project>
+maestro status --config-store ~/.maestro/maestro.db --config-store-project <project>
+curl -fsS http://127.0.0.1:8786/api/v1/fleet
+```
+
+If a project needs a different label, review gate, state directory, runner
+interval, or backend policy, edit its store row. With `--watch-store`, the daemon
+hot-reloads config changes without creating or restarting a per-project unit.
+
+`fleet.yaml` and `dashboard_url` are legacy fleet-aggregator inputs. In the
+daemon model, fleet membership is the set of project rows in `maestro.db`, and
+the dashboard URL is derived from the single daemon port.
 
 Minimal project config shape:
 
@@ -62,15 +79,11 @@ outcome:
   runtime_target: https://app.example.com
   deployment_status_command: /path/to/repos/<project>/scripts/status.sh
   healthcheck_url: https://app.example.com/healthz
+  healthcheck_timeout_seconds: 60
   source_repo_path: /path/to/repos/<project>
   runtime_host: production host or platform
   non_goals:
     - Rewrite unrelated subsystems
-
-server:
-  host: 127.0.0.1
-  port: 8788
-  # read_only defaults to false (#477 trusted-LAN posture); set true for exposed installs.
 
 blocker_patterns:
   - "blocked by.*?#(\\d+)"
@@ -109,23 +122,25 @@ supervisor:
     - change_global_config
 ```
 
-Minimal fleet config shape:
-
-```yaml
-projects:
-  - name: project-a
-    config: maestro-project-a.yaml
-  - name: project-b
-    config: maestro-project-b.yaml
-```
-
-`dashboard_url:` is deprecated and silently ignored on load (#516). Every project is reachable at `/project/<name>` on the aggregator port.
+Import or edit that project shape through `maestro config-store`. Do not add a
+fleet YAML file for daemon membership; add or remove project rows in
+`maestro.db`.
 
 ## Operating Model
 
-Fleet Mission Control is an observation surface. It loads each project config, reads each project's state/log metadata, and returns one aggregate response from `/api/v1/fleet`. The header starts with one global operator brief across every configured project; project cards, supervisor details, queues, and worker logs are drilldown/debug data after that brief. One project load error is shown on that project card without hiding the rest of the fleet.
+Fleet Mission Control is an observation and safe-action surface. The daemon
+loads project rows from `maestro.db`, reads each project's state/log metadata,
+and returns one aggregate response from `/api/v1/fleet`. The header starts with
+one global operator brief across every configured project; project cards,
+supervisor details, queues, and worker logs are drilldown/debug data after that
+brief. One project load error is shown on that project card without hiding the
+rest of the fleet.
 
-The project runner remains the execution surface. It starts workers, reconciles dead sessions, opens and monitors PRs, waits for review gates, merges eligible PRs, deploys when configured, and updates local state.
+Each in-process project flow is the execution surface. It starts workers,
+reconciles dead sessions, opens and monitors PRs, waits for review gates, merges
+eligible PRs, deploys when configured, and updates local state. Do not start a
+second per-project runner for the same repo while the daemon owns that project
+row.
 
 When deploying Maestro itself from source on the fleet host, stamp the binary with the release version from `VERSION`; an unstamped source build leaves `maestro version` reporting build metadata instead of the release. Use the same stamped build shape as the release workflow, then verify the installed binary:
 
@@ -186,12 +201,12 @@ This algorithm is intentionally explicit and explainable. There is no ML priorit
 
 Use this order during normal operations:
 
-1. Open Fleet Mission Control at `http://127.0.0.1:8787/`.
+1. Open Fleet Mission Control at `http://127.0.0.1:8786/`.
 2. Read the global operator brief first; if it says no action is needed, treat the rest of the page as supporting detail.
 3. If the brief names an action, follow that project, issue/PR/session, and reason before scanning lower-priority cards.
 4. Open a project dashboard link only when the fleet card needs project-level detail.
-5. Use CLI commands with explicit `--config` paths when you need local state, logs, or a supervised decision.
-6. Restart services rather than editing state files by hand.
+5. Use CLI commands with explicit `--config-store ~/.maestro/maestro.db --config-store-project <project>` when you need local state, logs, or a supervised decision.
+6. Restart the daemon rather than editing state files by hand when the process itself needs a refresh.
 
 ## Queue Policy
 
@@ -265,30 +280,30 @@ Supervisor approvals are stale-sensitive. A pending approval becomes stale if th
 
 ## Safe Commands
 
-Use explicit config paths for project commands. These commands are safe for local operation because they do not print token values or dump entire configs. Treat worker logs as potentially sensitive and avoid pasting full logs into PRs or issues.
+Use explicit config-store project names for project commands. These commands are
+safe for local operation because they do not print token values or dump entire
+configs. Treat worker logs as potentially sensitive and avoid pasting full logs
+into PRs or issues.
 
 ```bash
-# Fleet dashboard and API (writes enabled by default on trusted LAN; add --read-only=true for exposed installs)
-maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787
-curl -fsS http://127.0.0.1:8787/api/v1/fleet
+# Fleet dashboard and API
+curl -fsS http://127.0.0.1:8786/api/v1/fleet
+maestro config-store list --db ~/.maestro/maestro.db
 
 # Project status and queue analysis
-maestro status --config ~/.maestro/maestro-<project>.yaml
-maestro status --config ~/.maestro/maestro-<project>.yaml --json
-maestro supervise --config ~/.maestro/maestro-<project>.yaml --once
-maestro supervise --config ~/.maestro/maestro-<project>.yaml --once --json
+maestro status --config-store ~/.maestro/maestro.db --config-store-project <project>
+maestro status --config-store ~/.maestro/maestro.db --config-store-project <project> --json
+maestro supervise --config-store ~/.maestro/maestro.db --config-store-project <project> --once
+maestro supervise --config-store ~/.maestro/maestro.db --config-store-project <project> --once --json
 
 # Worker logs through Maestro
-maestro logs --config ~/.maestro/maestro-<project>.yaml
-maestro logs --config ~/.maestro/maestro-<project>.yaml <session>
+maestro logs --config-store ~/.maestro/maestro.db --config-store-project <project>
+maestro logs --config-store ~/.maestro/maestro.db --config-store-project <project> <session>
 
-# Service status and restart
-systemctl --user status maestro@<project>.service --no-pager
-journalctl --user -u maestro@<project>.service --since "30 minutes ago" --no-pager
-systemctl --user restart maestro@<project>.service
-systemctl --user status maestro-fleet.service --no-pager
-journalctl --user -u maestro-fleet.service --since "30 minutes ago" --no-pager
-systemctl --user restart maestro-fleet.service
+# Single daemon service status and restart
+systemctl status maestro.service --no-pager
+journalctl -u maestro.service --since "30 minutes ago" --no-pager
+sudo systemctl restart maestro.service
 ```
 
 Avoid these during incident handling unless you are deliberately debugging credentials: `env`, raw config dumps, `gh auth token`, shell history dumps, and full worker log pastebacks.
@@ -301,14 +316,14 @@ Mission Control indicators: queue `eligible=0`, `no_eligible_issues`, `all_eligi
 
 Safe response:
 
-1. Run `maestro supervise --config ~/.maestro/maestro-<project>.yaml --once` and read the queue summary.
+1. Run `maestro supervise --config-store ~/.maestro/maestro.db --config-store-project <project> --once` and read the queue summary.
 2. If there are no open issues, add or wait for work.
 3. If issues are missing the ready label, add the configured `supervisor.ready_label` or let the supervisor add it when `add_ready_label` is allowed.
 4. If issues are excluded, remove the blocking/excluded label only after confirming the issue is actually runnable.
 5. If issues are held as parent/meta work, decompose or retitle/relabel only when the issue should become executable work.
 6. If issues are blocked by dependencies, close or resolve the blocker issue before expecting a worker to start.
-7. If dynamic wave reports non-runnable project status, move one issue to a configured runnable status or update `supervisor.dynamic_wave.runnable_project_statuses` in the project config.
-8. Restart the project runner only if config changed: `systemctl --user restart maestro@<project>.service`.
+7. If dynamic wave reports non-runnable project status, move one issue to a configured runnable status or update `supervisor.dynamic_wave.runnable_project_statuses` in the store row.
+8. Do not restart a per-project runner; the daemon hot-reloads store edits. Restart `maestro.service` only for daemon/env/binary changes.
 
 ### Running but dead PID
 
@@ -316,10 +331,10 @@ Mission Control indicators: status `running` with `alive=false`, CLI `ALIVE no`,
 
 Safe response:
 
-1. Run `maestro status --config ~/.maestro/maestro-<project>.yaml` to confirm the session and PID.
-2. Inspect the session with `maestro logs --config ~/.maestro/maestro-<project>.yaml <session>`.
-3. Restart the project runner with `systemctl --user restart maestro@<project>.service` so the next reconciliation cycle can mark the session dead and retry if eligible.
-4. If you intentionally need to reconcile immediately, run `maestro run --config ~/.maestro/maestro-<project>.yaml --once` knowing it can progress orchestration for that project.
+1. Run `maestro status --config-store ~/.maestro/maestro.db --config-store-project <project>` to confirm the session and PID.
+2. Inspect the session with `maestro logs --config-store ~/.maestro/maestro.db --config-store-project <project> <session>`.
+3. Let the daemon's next reconciliation cycle mark the session dead and retry if eligible.
+4. If the daemon process itself is stuck, restart `maestro.service`; do not start a second per-project runner for the same project.
 5. Do not edit `state.json` manually.
 
 ### PR open waiting Greptile
@@ -332,7 +347,7 @@ Safe response:
 2. Check the GitHub PR page if it remains pending unusually long.
 3. If Greptile is not approved, address the feedback or let the configured retry path handle review feedback.
 4. Do not spawn another worker for the same issue while the PR is open.
-5. Change `review_gate` only as an explicit project policy decision, then restart the project runner.
+5. Change `review_gate` only as an explicit project policy decision in the store row; the daemon hot-reloads the edit.
 
 ### Retry exhausted
 
@@ -340,10 +355,10 @@ Mission Control indicators: session status `retry_exhausted`, action `review_ret
 
 Safe response:
 
-1. Inspect the session status and logs with explicit `--config` commands.
+1. Inspect the session status and logs with explicit store-backed commands.
 2. If a PR is still open, keep it in normal merge flow when checks and review gates pass.
 3. If checks failed or no usable PR exists, review failed attempts, split or clarify the issue, and retry intentionally.
-4. If retrying is appropriate, update the issue/config first, then start a new worker with `maestro spawn --config ~/.maestro/maestro-<project>.yaml --issue <number>`.
+4. If retrying is appropriate, update the issue/config first, then start a new worker with `maestro spawn --config-store ~/.maestro/maestro.db --config-store-project <project> --issue <number>`.
 5. Do not increase retry budgets globally just to clear one incident unless that is the intended project policy change.
 
 ### Stale approval
@@ -353,13 +368,13 @@ Mission Control indicators: approval status `stale` or CLI error `approval is st
 Safe response:
 
 1. Do not approve the stale approval.
-2. Run `maestro supervise --config ~/.maestro/maestro-<project>.yaml --once` to record a fresh decision.
+2. Run `maestro supervise --config-store ~/.maestro/maestro.db --config-store-project <project> --once` to record a fresh decision.
 3. Review the new target, risk, reasons, and stuck states.
 4. Resolve the new approval ID if needed:
 
 ```bash
-maestro supervise approve --config ~/.maestro/maestro-<project>.yaml --actor <operator> --reason "approved after fresh status check" <approval-or-decision-id>
-maestro supervise reject --config ~/.maestro/maestro-<project>.yaml --actor <operator> --reason "state changed" <approval-or-decision-id>
+maestro supervise approve --config-store ~/.maestro/maestro.db --config-store-project <project> --actor <operator> --reason "approved after fresh status check" <approval-or-decision-id>
+maestro supervise reject --config-store ~/.maestro/maestro.db --config-store-project <project> --actor <operator> --reason "state changed" <approval-or-decision-id>
 ```
 
 ### Stale supervisor sessions
@@ -377,7 +392,7 @@ Safe response:
    - **Idle/worktree path:** the session is past `idle_after_minutes` AND, when `require_worktree_missing` is true, its recorded worktree path is missing on disk.
    - **Linked-PR-merged path:** the session's branch (head ref recorded as `branch` in the API, e.g. `feat/sup-44-346-…`) maps to a PR that the project state already classifies as merged. This path fires regardless of idle time, so a freshly retry-exhausted session whose PR has just merged stops haunting `attention` immediately.
 3. Reconciled sessions are recorded in `audit-log.jsonl` under the project's `state_dir` with action `stale_session_reconciled`. The audit `reason` field carries the trigger (`linked PR merged` for the new path, otherwise the legacy idle-window reason). Sessions remain searchable in `workers` for drilldown.
-4. To temporarily disable filtering for a project, set `stale_session_reconciler.enabled: false` and restart the project runner.
+4. To temporarily disable filtering for a project, set `stale_session_reconciler.enabled: false` in the store row; the daemon hot-reloads the edit.
 5. To keep only the legacy idle/worktree behaviour from PR #400, set `stale_session_reconciler.merged_pr_dismisses: false`.
 6. To tighten the idle path during dogfood/recovery, lower `idle_after_minutes` (for example `60` for one hour). Keep `require_worktree_missing: true` so a live worker is never reclaimed.
 7. The reconciler reads PR state from the existing project state snapshot (sessions already transitioned to `done`/`code_landed`); it does not issue ad-hoc `gh` calls in the snapshot path.
@@ -401,14 +416,14 @@ Safe response:
 2. Confirm the GitHub user or app has access to the repo and project board.
 3. Retry after GitHub rate limits or project API incidents clear.
 4. If dynamic wave depends on project status, keep work paused until project item data is reliable or make an explicit temporary policy change in the project config.
-5. Restart only the affected project runner after config or auth is fixed.
+5. After config changes, rely on store hot-reload. Restart `maestro.service` only when auth/env changes require a fresh daemon environment.
 6. Do not paste raw GraphQL output, tokens, or local config contents into issues or PRs.
 
 ## Operator Checklist
 
-- Fleet dashboard is reachable on `127.0.0.1:8787`; on a trusted LAN it is write-enabled by default (#477), with the cautious approval gate guarding `merge_pr` / `close_issue` / `delete_worktree` / `change_global_config`.
-- Every project in `~/.maestro/fleet.yaml` has a distinct `state_dir`, `session_prefix`, and optional project dashboard port.
-- Project commands use `--config ~/.maestro/maestro-<project>.yaml`.
+- Fleet dashboard is reachable on the daemon port, normally `127.0.0.1:8786`; on a trusted LAN it is write-enabled by default (#477), with the cautious approval gate guarding `merge_pr` / `close_issue` / `delete_worktree` / `change_global_config`.
+- Every live project is a row in `~/.maestro/maestro.db` with a distinct `state_dir` and `session_prefix`.
+- Project commands use `--config-store ~/.maestro/maestro.db --config-store-project <project>`.
 - Dynamic wave has known runnable statuses and clear ready/blocked label ownership.
 - Greptile gate policy is explicit per project.
 - Approvals are fresh before being approved or rejected.

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -121,6 +121,10 @@ Issues with any exclude label are skipped even if they also have a required labe
 
 ## 4. Maestro Config (`maestro-<project>.yaml`)
 
+For daemon fleets, use this YAML shape as a seed/import template and then add it
+to `~/.maestro/maestro.db`; do not keep project YAML as the runtime source of
+truth.
+
 Create the config file at `~/.maestro/maestro-<project>.yaml`. Example:
 
 ```yaml
@@ -232,6 +236,7 @@ outcome:
   runtime_target: https://app.example.com
   deployment_status_command: /path/to/repo/scripts/status.sh
   healthcheck_url: https://app.example.com/healthz
+  healthcheck_timeout_seconds: 60
   source_repo_path: /path/to/local/clone
   runtime_host: production host or platform
   non_goals:
@@ -368,6 +373,10 @@ config warning and stays inert.
 
 ### Running as a systemd service
 
+This section is for legacy single-project installs. Fleet hosts should run one
+`maestro.service` daemon from `~/.maestro/maestro.db`; see the runtime config
+store section below.
+
 ```bash
 # Single project
 maestro init  # creates ~/.config/systemd/user/maestro.service
@@ -386,9 +395,13 @@ For day-to-day operations, review gates, queue policy, approvals, and safe recov
 
 Trusted-LAN default (#477): the fleet dashboard now boots write-enabled out of the box. The cautious approval gate still guards `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config`, so the writable HTTP surface cannot bypass operator approval for those four verbs. For installs exposed beyond a trusted LAN, pass `--read-only=true` (or set `server.read_only: true` in YAML) and configure the optional HTTP auth layer that #616 wires up (off by default). This supersedes the prior "never flip --read-only before auth" caveat.
 
-### Runtime config store (phase 1)
+### Runtime config store
 
-Runtime project settings can be imported from `~/.maestro/maestro.d/*.yaml` into a small SQLite store. Phase 1 keeps the YAML files as the fallback read path; write-path changes, change history, and Mission Control settings UI edits are follow-up work.
+Current fleet runtime is store-first: one `maestro daemon` process reads project
+rows from `~/.maestro/maestro.db`, runs every project flow in-process, and serves
+Mission Control from one port. Per-project YAML files are seed/export artifacts
+for migration and backups; they are not the day-to-day runtime surface once the
+daemon is cut over.
 
 Proposed SQLite schema:
 
@@ -419,78 +432,61 @@ CREATE TABLE project (
 One-shot migration:
 
 ```sh
-maestro config-store migrate --db ~/.maestro/config.db --dir ~/.maestro/maestro.d
+maestro config-store migrate --db ~/.maestro/maestro.db --dir ~/.maestro/maestro.d
 ```
 
-Read from the store:
+Operate against the store:
 
 ```sh
-maestro run --config-store ~/.maestro/config.db
-maestro serve --config-store ~/.maestro/config.db --port 8787
+maestro config-store list --db ~/.maestro/maestro.db
+maestro config-store edit --db ~/.maestro/maestro.db <project>
+maestro status --config-store ~/.maestro/maestro.db --config-store-project <project>
 ```
 
-If `--config-store` is set and the store cannot be opened or read, Maestro falls back to the YAML paths passed with `--config`. Without YAML paths, store load failure remains fatal so operators do not accidentally run with an unintended default config.
+If `--config-store` is set and the store cannot be opened or read, Maestro falls
+back to YAML paths only when explicit `--config` paths were also supplied.
+Without YAML paths, store load failure remains fatal so operators do not
+accidentally run with an unintended default config.
 
 Export portable YAML backups:
 
 ```sh
-maestro config-store export --db ~/.maestro/config.db --dir ~/.maestro/maestro.d.export
+maestro config-store export --db ~/.maestro/maestro.db --dir ~/.maestro/maestro.d.export
 ```
 
 Exports restore the shared backend definitions into each YAML file so the result can be loaded by the legacy YAML loader or copied to another host.
 
 To add a project:
 
-1. Create or update `~/.maestro/maestro-<project>.yaml` using the config shape above.
+1. Create a temporary project YAML using the config shape above, outside the product repo unless the team intentionally wants a checked-in template.
 2. Use a distinct `state_dir` and `session_prefix` for each project so worker sessions and state files do not overlap.
-3. Add the project to `~/.maestro/fleet.yaml` with a human name and config path. Every project is reachable through the unified Mission Control aggregator at `/project/<name>` (#516); per-project dashboard ports are retired and no longer need a separate user unit.
-4. Restart the fleet dashboard service and verify `/api/v1/fleet`.
-
-Minimal two-project fleet file:
-
-```yaml
-# ~/.maestro/fleet.yaml
-projects:
-  - name: api
-    config: maestro-api.yaml
-  - name: web
-    config: maestro-web.yaml
-```
-
-`config` may be absolute, `~/...`, or relative to the fleet YAML file. `dashboard_url` is deprecated (#516); any value still present is silently overridden with the project-scoped MC route on load. For dogfooding, add Maestro's own project config to the same fleet file so the team can watch Maestro manage Maestro alongside application repos.
-
-Run the fleet dashboard manually (writes enabled by default on the trusted LAN; add `--read-only=true` for exposed installs):
+3. Add or replace the project row in the store:
 
 ```bash
-maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787
+maestro config-store add --db ~/.maestro/maestro.db --file ./maestro-<project>.yaml
 ```
 
-Verify the API:
+4. With `maestro daemon --watch-store` running, the project appears without creating a systemd unit or restarting the daemon. Verify the store row and fleet API:
 
 ```bash
-curl -fsS http://127.0.0.1:8787/api/v1/fleet
+maestro config-store list --db ~/.maestro/maestro.db
+maestro status --config-store ~/.maestro/maestro.db --config-store-project <project>
+curl -fsS http://127.0.0.1:8786/api/v1/fleet
 ```
 
 The fleet response includes `refreshed_at` plus per-project freshness metadata. Project cards show snapshot age and are marked stale when the latest state or log snapshot is older than 15 minutes; one project's load error is shown on that card without hiding the rest of the fleet. Queue snapshots split skipped work into `excluded`, `held/meta`, `blocked-deps`, and non-runnable project status counts so an idle project shows why no worker starts.
 
-`--fleet` versus repeated `--config`:
-
-| Mode | Use it when | Notes |
-|---|---|---|
-| `maestro serve --fleet ~/.maestro/fleet.yaml --port 8787` | You want a stable operating model for a shared dashboard or systemd service | Supports human project names and relative config paths; project-scoped routes (`/project/<name>`) are served from the same port |
-| `maestro serve --config a.yaml --config b.yaml --port 8787` | You want a quick local aggregate view without writing a fleet file | Project names are derived from `repo` |
-
-For a persistent user service, create a dedicated fleet dashboard unit:
+Persistent runtime uses the single daemon service, not a dedicated fleet
+dashboard unit and not one runner unit per project:
 
 ```ini
-# ~/.config/systemd/user/maestro-fleet.service
 [Unit]
-Description=Maestro fleet dashboard
+Description=Maestro agent orchestrator
 After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/maestro serve --fleet %h/.maestro/fleet.yaml --host 127.0.0.1 --port 8787
+ExecStart=/usr/local/bin/maestro daemon --host 0.0.0.0 --store %h/.maestro/maestro.db --port 8786 --watch-store --approvals-store sqlite --state-store sqlite
 Restart=on-failure
 RestartSec=10
 
@@ -502,15 +498,13 @@ Enable it:
 
 ```bash
 systemctl --user daemon-reload
-systemctl --user enable --now maestro-fleet.service
-systemctl --user status maestro-fleet.service
+systemctl --user enable --now maestro.service
+systemctl --user status maestro.service
 ```
 
-Bind to the LAN only on a trusted network or behind a firewall/reverse proxy. For non-LAN exposure, force `--read-only=true` and configure the auth layer (#616):
-
-```bash
-maestro serve --fleet ~/.maestro/fleet.yaml --host 0.0.0.0 --port 8787 --read-only=true
-```
+Bind to the LAN only on a trusted network or behind a firewall/reverse proxy.
+For non-LAN exposure, configure the auth layer (#616) and keep destructive
+actions behind the cautious approval gate.
 
 ---
 
@@ -696,10 +690,10 @@ Use this checklist when onboarding a new repo to maestro:
 - [ ] Branch protection on `main` requiring PR + status checks
 - [ ] Labels created: `bug`, `enhancement`, `documentation`
 - [ ] Exclude labels created: `wontfix`, `question`, `blocked`, `duplicate`, `invalid`
-- [ ] `maestro-<project>.yaml` config file created
+- [ ] Project config added to `~/.maestro/maestro.db`
 - [ ] `scripts/deploy.sh` written, tested manually, made executable
 - [ ] Worker prompt template written with test requirements
 - [ ] Post-deploy smoke test in deploy script
 - [ ] Version bump configured (CI workflow or maestro `versioning` block)
-- [ ] `maestro run --once` succeeds (picks an issue, spawns a worker)
+- [ ] `maestro status --config-store ~/.maestro/maestro.db --config-store-project <project>` succeeds
 - [ ] Telegram notifications working (if configured)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,53 @@ type BackendPricing struct {
 	CacheWriteUSDPerMtok float64 `yaml:"cache_write_usd_per_mtok,omitempty"`
 }
 
+type pricingNumber float64
+
+func (n *pricingNumber) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil || value.Tag == "!!null" {
+		*n = 0
+		return nil
+	}
+	if value.Kind == yaml.ScalarNode && value.Tag == "!!str" {
+		raw := strings.TrimSpace(value.Value)
+		if raw == "" {
+			*n = 0
+			return nil
+		}
+		parsed, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return fmt.Errorf("invalid pricing number %q: %w", value.Value, err)
+		}
+		*n = pricingNumber(parsed)
+		return nil
+	}
+	var parsed float64
+	if err := value.Decode(&parsed); err != nil {
+		return err
+	}
+	*n = pricingNumber(parsed)
+	return nil
+}
+
+func (p *BackendPricing) UnmarshalYAML(value *yaml.Node) error {
+	var raw struct {
+		InputUSDPerMtok      pricingNumber `yaml:"input_usd_per_mtok,omitempty"`
+		OutputUSDPerMtok     pricingNumber `yaml:"output_usd_per_mtok,omitempty"`
+		CacheReadUSDPerMtok  pricingNumber `yaml:"cache_read_usd_per_mtok,omitempty"`
+		CacheWriteUSDPerMtok pricingNumber `yaml:"cache_write_usd_per_mtok,omitempty"`
+	}
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*p = BackendPricing{
+		InputUSDPerMtok:      float64(raw.InputUSDPerMtok),
+		OutputUSDPerMtok:     float64(raw.OutputUSDPerMtok),
+		CacheReadUSDPerMtok:  float64(raw.CacheReadUSDPerMtok),
+		CacheWriteUSDPerMtok: float64(raw.CacheWriteUSDPerMtok),
+	}
+	return nil
+}
+
 // Anthropic's published cache rates relative to the base input rate: a
 // cache read is ~10% of input, a 5-minute cache write ~125% of input.
 // These are the defaults applied when a backend leaves the cache rates

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -337,6 +337,7 @@ outcome:
   runtime_target: https://repo.example.com
   deployment_status_command: systemctl --user status repo
   healthcheck_command: curl -fsS http://127.0.0.1:8080/healthz
+  healthcheck_timeout_seconds: 60
   healthcheck_url: https://repo.example.com/healthz
   source_repo_path: ~/src/repo-runtime
   runtime_host: fly.io/repo
@@ -354,6 +355,9 @@ outcome:
 	}
 	if cfg.Outcome.DesiredOutcome != "Users can run the hosted app end-to-end." {
 		t.Fatalf("DesiredOutcome = %q", cfg.Outcome.DesiredOutcome)
+	}
+	if cfg.Outcome.HealthcheckTimeoutSeconds != 60 {
+		t.Fatalf("HealthcheckTimeoutSeconds = %d, want 60", cfg.Outcome.HealthcheckTimeoutSeconds)
 	}
 	if cfg.Outcome.SourceRepoPath != filepath.Join(os.Getenv("HOME"), "src/repo-runtime") {
 		t.Fatalf("SourceRepoPath = %q", cfg.Outcome.SourceRepoPath)

--- a/internal/config/pricing_test.go
+++ b/internal/config/pricing_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -176,5 +177,51 @@ model:
 	gemini := cfg.Model.Backends["gemini"]
 	if gemini.Pricing.Configured() {
 		t.Errorf("gemini pricing should not be configured")
+	}
+}
+
+// TestParse_BackendPricingFromYAMLNumericStrings keeps exported/edited seed YAML
+// from taking down legacy --config commands when a pricing number was quoted.
+func TestParse_BackendPricingFromYAMLNumericStrings(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      pricing:
+        input_usd_per_mtok: "5"
+        output_usd_per_mtok: "30"
+        cache_read_usd_per_mtok: "0.5"
+        cache_write_usd_per_mtok: "6.25"
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := cfg.Model.Backends["codex"].Pricing
+	if got.InputUSDPerMtok != 5 || got.OutputUSDPerMtok != 30 || got.CacheReadUSDPerMtok != 0.5 || got.CacheWriteUSDPerMtok != 6.25 {
+		t.Fatalf("pricing = %+v, want input=5 output=30 cache_read=0.5 cache_write=6.25", got)
+	}
+}
+
+func TestParse_BackendPricingFromYAMLRejectsNonNumericStrings(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      pricing:
+        input_usd_per_mtok: cheap
+`
+	_, err := parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("parse succeeded, want invalid pricing number error")
+	}
+	if !strings.Contains(err.Error(), "invalid pricing number") {
+		t.Fatalf("parse error = %v, want invalid pricing number", err)
 	}
 }

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -47,7 +47,7 @@ type Store struct {
 func Open(path string) (*Store, error) {
 	// busy_timeout makes a connection wait (up to 5s) for a lock instead of
 	// erroring with "database is locked" immediately: the daemon's watch-loop
-	// reads config.db (ProjectsFingerprint every tick, Load on add) while
+	// reads maestro.db (ProjectsFingerprint every tick, Load on add) while
 	// `config-store add/rm/edit` writes it from a SEPARATE process (#757). WAL
 	// lets a reader and a writer proceed concurrently across processes. The
 	// pragmas go in the DSN so modernc applies them to every pooled connection.
@@ -435,6 +435,13 @@ func ProjectNameFor(sourcePath string, data []byte) (string, error) {
 func (s *Store) ExportProject(ctx context.Context, name string) ([]byte, error) {
 	data, _, err := s.exportProjectYAML(ctx, name)
 	return data, err
+}
+
+// ProjectNames returns the config-store project keys without loading or
+// validating each project document. Operators use it to discover the canonical
+// --config-store-project value even when a specific project config is broken.
+func (s *Store) ProjectNames(ctx context.Context) ([]string, error) {
+	return s.projectNames(ctx)
 }
 
 // DeleteProject removes a project row. Deleting a missing project is a no-op

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -65,6 +65,7 @@ func computeSuperviseJitter(interval time.Duration, frac float64) time.Duration 
 // is stable for the flow's lifetime.
 func runSupervise(ctx context.Context, name string, getCfg func() *config.Config, interval time.Duration) {
 	gh := github.New(getCfg().Repo)
+	clearSupervisorStuckOnStartup(name, getCfg().StateDir)
 	// Capture and log each cycle's SupervisorDecision. The daemon still acts
 	// (label/comment/approve), but without this the structural "why did the
 	// supervisor do that" trail was dropped — turning debugging into journal
@@ -121,6 +122,27 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 			}
 		}
 	}
+}
+
+func clearSupervisorStuckOnStartup(name, stateDir string) {
+	if strings.TrimSpace(stateDir) == "" {
+		return
+	}
+	st, err := state.Load(stateDir)
+	if err != nil {
+		log.Printf("[%s] supervise: load state to clear stale supervisor_stuck flag: %v", name, err)
+		return
+	}
+	if !st.SupervisorStuck && strings.TrimSpace(st.SupervisorStuckReason) == "" {
+		return
+	}
+	st.SupervisorStuck = false
+	st.SupervisorStuckReason = ""
+	if err := state.Save(stateDir, st); err != nil {
+		log.Printf("[%s] supervise: clear stale supervisor_stuck flag on startup: %v", name, err)
+		return
+	}
+	log.Printf("[%s] supervise: cleared stale supervisor_stuck flag on startup; watchdog will re-set it if this loop stalls", name)
 }
 
 // logSupervisorDecision emits a compact, single-line, per-cycle record of the

--- a/internal/daemon/supervise_stuck_test.go
+++ b/internal/daemon/supervise_stuck_test.go
@@ -1,0 +1,35 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestClearSupervisorStuckOnStartupClearsStaleFlag(t *testing.T) {
+	stateDir := t.TempDir()
+	st := state.NewState()
+	st.LastRunOnceAt = time.Now().UTC().Add(-time.Hour)
+	st.SupervisorStuck = true
+	st.SupervisorStuckReason = "old watchdog finding"
+	if err := state.Save(stateDir, st); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	clearSupervisorStuckOnStartup("project", stateDir)
+
+	reloaded, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatalf("reload state: %v", err)
+	}
+	if reloaded.SupervisorStuck {
+		t.Fatal("SupervisorStuck still true after startup clear")
+	}
+	if reloaded.SupervisorStuckReason != "" {
+		t.Fatalf("SupervisorStuckReason = %q, want empty", reloaded.SupervisorStuckReason)
+	}
+	if reloaded.LastRunOnceAt.IsZero() {
+		t.Fatal("LastRunOnceAt was cleared; startup clear should only reset the stale watchdog flag")
+	}
+}

--- a/internal/outcome/checker.go
+++ b/internal/outcome/checker.go
@@ -3,19 +3,26 @@ package outcome
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/gofrs/flock"
 )
 
 const (
-	defaultCheckTimeout = 15 * time.Second
-	maxCheckDetailBytes = 4000
+	defaultCheckTimeout     = 15 * time.Second
+	maxCheckDetailBytes     = 4000
+	outcomeLockPollInterval = 250 * time.Millisecond
 )
 
 // Checker executes configured read-only outcome signals and returns a compact
@@ -29,6 +36,9 @@ type Checker struct {
 
 func (c Checker) Check(ctx context.Context, brief Brief) HealthCheckResult {
 	brief = brief.Normalized()
+	if c.CommandTimeout <= 0 {
+		c.CommandTimeout = brief.HealthcheckTimeout()
+	}
 	start := c.now()
 	result := HealthCheckResult{
 		CheckedAt: start,
@@ -47,8 +57,18 @@ func (c Checker) Check(ctx context.Context, brief Brief) HealthCheckResult {
 	if strings.TrimSpace(brief.HealthcheckURL) != "" {
 		result = c.checkURL(ctx, brief.HealthcheckURL)
 	} else if strings.TrimSpace(brief.HealthcheckCommand) != "" {
+		unlock, lockResult := c.lockCommandCheck(ctx, brief.SourceRepoPath, brief.HealthcheckCommand, "healthcheck_command")
+		if lockResult != nil {
+			return *lockResult
+		}
+		defer unlock()
 		result = c.checkCommand(ctx, brief.HealthcheckCommand, brief.SourceRepoPath, "healthcheck_command")
 	} else {
+		unlock, lockResult := c.lockCommandCheck(ctx, brief.SourceRepoPath, brief.DeploymentStatusCommand, "deployment_status_command")
+		if lockResult != nil {
+			return *lockResult
+		}
+		defer unlock()
 		result = c.checkCommand(ctx, brief.DeploymentStatusCommand, brief.SourceRepoPath, "deployment_status_command")
 	}
 	if result.CheckedAt.IsZero() {
@@ -110,6 +130,41 @@ func (c Checker) checkCommand(ctx context.Context, command, dir, signal string) 
 		return c.result(start, signal, HealthFailing, summary, string(output), exitCode)
 	}
 	return c.result(start, signal, HealthHealthy, fmt.Sprintf("%s passed", signal), "", exitCode)
+}
+
+func (c Checker) lockCommandCheck(ctx context.Context, sourceRepoPath, command, signal string) (func(), *HealthCheckResult) {
+	start := c.now()
+	lockPath, err := outcomeLockPath(sourceRepoPath, command)
+	if err != nil {
+		result := c.result(start, signal, HealthFailing, fmt.Sprintf("%s lock unavailable: %v", signal, err), "", 0)
+		return nil, &result
+	}
+	lock := flock.New(lockPath)
+	ok, err := lock.TryLockContext(ctx, outcomeLockPollInterval)
+	if err != nil {
+		result := c.result(start, signal, HealthFailing, fmt.Sprintf("%s lock failed: %v", signal, err), "", 0)
+		return nil, &result
+	}
+	if !ok {
+		result := c.result(start, signal, HealthFailing, fmt.Sprintf("%s lock wait canceled", signal), "", 0)
+		return nil, &result
+	}
+	return func() {
+		_ = lock.Unlock()
+	}, nil
+}
+
+func outcomeLockPath(sourceRepoPath, command string) (string, error) {
+	root, err := os.UserCacheDir()
+	if err != nil || strings.TrimSpace(root) == "" {
+		root = os.TempDir()
+	}
+	dir := filepath.Join(root, "maestro", "outcome-locks")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(strings.TrimSpace(sourceRepoPath) + "\n" + strings.TrimSpace(command)))
+	return filepath.Join(dir, hex.EncodeToString(sum[:])+".lock"), nil
 }
 
 func (c Checker) runCommand(ctx context.Context, command, dir string) ([]byte, int, error) {

--- a/internal/outcome/outcome.go
+++ b/internal/outcome/outcome.go
@@ -16,50 +16,52 @@ const (
 // Brief is the project operating brief Maestro uses to judge progress by the
 // runtime outcome instead of by raw issue throughput.
 type Brief struct {
-	DesiredOutcome          string   `yaml:"desired_outcome" json:"desired_outcome,omitempty"`
-	RuntimeTarget           string   `yaml:"runtime_target" json:"runtime_target,omitempty"`
-	RuntimeURL              string   `yaml:"runtime_url" json:"runtime_url,omitempty"`
-	DeploymentStatusCommand string   `yaml:"deployment_status_command" json:"deployment_status_command,omitempty"`
-	DeployStatusCommand     string   `yaml:"deploy_status_command" json:"-"`
-	HealthcheckCommand      string   `yaml:"healthcheck_command" json:"healthcheck_command,omitempty"`
-	VerifierCommand         string   `yaml:"verifier_command" json:"verifier_command,omitempty"`
-	HealthcheckURL          string   `yaml:"healthcheck_url" json:"healthcheck_url,omitempty"`
-	SourceRepoPath          string   `yaml:"source_repo_path" json:"source_repo_path,omitempty"`
-	RuntimeHost             string   `yaml:"runtime_host" json:"runtime_host,omitempty"`
-	RequiredRoutes          []string `yaml:"required_routes" json:"required_routes,omitempty"`
-	RequiresDeploy          bool     `yaml:"requires_deploy" json:"requires_deploy,omitempty"`
-	PassRequiredForDone     *bool    `yaml:"pass_required_for_done" json:"-"`
-	FailRequiresVisibleWork *bool    `yaml:"fail_requires_visible_work" json:"-"`
-	NonGoals                []string `yaml:"non_goals" json:"non_goals,omitempty"`
+	DesiredOutcome            string   `yaml:"desired_outcome" json:"desired_outcome,omitempty"`
+	RuntimeTarget             string   `yaml:"runtime_target" json:"runtime_target,omitempty"`
+	RuntimeURL                string   `yaml:"runtime_url" json:"runtime_url,omitempty"`
+	DeploymentStatusCommand   string   `yaml:"deployment_status_command" json:"deployment_status_command,omitempty"`
+	DeployStatusCommand       string   `yaml:"deploy_status_command" json:"-"`
+	HealthcheckCommand        string   `yaml:"healthcheck_command" json:"healthcheck_command,omitempty"`
+	VerifierCommand           string   `yaml:"verifier_command" json:"verifier_command,omitempty"`
+	HealthcheckURL            string   `yaml:"healthcheck_url" json:"healthcheck_url,omitempty"`
+	HealthcheckTimeoutSeconds int      `yaml:"healthcheck_timeout_seconds" json:"healthcheck_timeout_seconds,omitempty"`
+	SourceRepoPath            string   `yaml:"source_repo_path" json:"source_repo_path,omitempty"`
+	RuntimeHost               string   `yaml:"runtime_host" json:"runtime_host,omitempty"`
+	RequiredRoutes            []string `yaml:"required_routes" json:"required_routes,omitempty"`
+	RequiresDeploy            bool     `yaml:"requires_deploy" json:"requires_deploy,omitempty"`
+	PassRequiredForDone       *bool    `yaml:"pass_required_for_done" json:"-"`
+	FailRequiresVisibleWork   *bool    `yaml:"fail_requires_visible_work" json:"-"`
+	NonGoals                  []string `yaml:"non_goals" json:"non_goals,omitempty"`
 }
 
 // Status is the concise outcome state exposed by CLI/API/dashboard surfaces.
 type Status struct {
-	Configured              bool     `json:"configured"`
-	Goal                    string   `json:"goal,omitempty"`
-	DesiredOutcome          string   `json:"desired_outcome,omitempty"`
-	RuntimeTarget           string   `json:"runtime_target,omitempty"`
-	RuntimeURL              string   `json:"runtime_url,omitempty"`
-	RuntimeHost             string   `json:"runtime_host,omitempty"`
-	HealthState             string   `json:"health_state"`
-	HealthCheckedAt         string   `json:"health_checked_at,omitempty"`
-	HealthSignal            string   `json:"health_signal,omitempty"`
-	HealthSummary           string   `json:"health_summary,omitempty"`
-	HealthDetail            string   `json:"health_detail,omitempty"`
-	NextAction              string   `json:"next_action,omitempty"`
-	SourceRepoPath          string   `json:"source_repo_path,omitempty"`
-	DeploymentStatusCommand string   `json:"deployment_status_command,omitempty"`
-	DeployStatusCommand     string   `json:"deploy_status_command,omitempty"`
-	HealthcheckCommand      string   `json:"healthcheck_command,omitempty"`
-	VerifierCommand         string   `json:"verifier_command,omitempty"`
-	HealthcheckURL          string   `json:"healthcheck_url,omitempty"`
-	RequiredRoutes          []string `json:"required_routes,omitempty"`
-	RequiresDeploy          bool     `json:"requires_deploy,omitempty"`
-	NonGoals                []string `json:"non_goals,omitempty"`
-	PassRequiredForDone     bool     `json:"pass_required_for_done,omitempty"`
-	FailRequiresVisibleWork bool     `json:"fail_requires_visible_work,omitempty"`
-	MergedPRs               int      `json:"merged_prs,omitempty"`
-	LastMergeAt             string   `json:"last_merge_at,omitempty"`
+	Configured                bool     `json:"configured"`
+	Goal                      string   `json:"goal,omitempty"`
+	DesiredOutcome            string   `json:"desired_outcome,omitempty"`
+	RuntimeTarget             string   `json:"runtime_target,omitempty"`
+	RuntimeURL                string   `json:"runtime_url,omitempty"`
+	RuntimeHost               string   `json:"runtime_host,omitempty"`
+	HealthState               string   `json:"health_state"`
+	HealthCheckedAt           string   `json:"health_checked_at,omitempty"`
+	HealthSignal              string   `json:"health_signal,omitempty"`
+	HealthSummary             string   `json:"health_summary,omitempty"`
+	HealthDetail              string   `json:"health_detail,omitempty"`
+	NextAction                string   `json:"next_action,omitempty"`
+	SourceRepoPath            string   `json:"source_repo_path,omitempty"`
+	DeploymentStatusCommand   string   `json:"deployment_status_command,omitempty"`
+	DeployStatusCommand       string   `json:"deploy_status_command,omitempty"`
+	HealthcheckCommand        string   `json:"healthcheck_command,omitempty"`
+	VerifierCommand           string   `json:"verifier_command,omitempty"`
+	HealthcheckURL            string   `json:"healthcheck_url,omitempty"`
+	HealthcheckTimeoutSeconds int      `json:"healthcheck_timeout_seconds,omitempty"`
+	RequiredRoutes            []string `json:"required_routes,omitempty"`
+	RequiresDeploy            bool     `json:"requires_deploy,omitempty"`
+	NonGoals                  []string `json:"non_goals,omitempty"`
+	PassRequiredForDone       bool     `json:"pass_required_for_done,omitempty"`
+	FailRequiresVisibleWork   bool     `json:"fail_requires_visible_work,omitempty"`
+	MergedPRs                 int      `json:"merged_prs,omitempty"`
+	LastMergeAt               string   `json:"last_merge_at,omitempty"`
 }
 
 // HealthCheckResult is the durable result of a read-only runtime/deploy health
@@ -98,6 +100,9 @@ func (b Brief) Normalized() Brief {
 		b.VerifierCommand = b.HealthcheckCommand
 	}
 	b.HealthcheckURL = strings.TrimSpace(b.HealthcheckURL)
+	if b.HealthcheckTimeoutSeconds < 0 {
+		b.HealthcheckTimeoutSeconds = 0
+	}
 	b.SourceRepoPath = strings.TrimSpace(b.SourceRepoPath)
 	b.RuntimeHost = strings.TrimSpace(b.RuntimeHost)
 	b.RequiredRoutes = compactStrings(b.RequiredRoutes)
@@ -135,6 +140,14 @@ func (b Brief) FailRequiresVisibleWorkEnabled() bool {
 	return b.Configured()
 }
 
+func (b Brief) HealthcheckTimeout() time.Duration {
+	b = b.Normalized()
+	if b.HealthcheckTimeoutSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(b.HealthcheckTimeoutSeconds) * time.Second
+}
+
 // StatusFor returns the current known outcome status. Callers may pass the
 // latest persisted health check result; StatusFor never executes checks itself.
 func StatusFor(brief Brief, mergedPRs int, lastMergeAt time.Time, checks ...HealthCheckResult) Status {
@@ -148,24 +161,25 @@ func StatusFor(brief Brief, mergedPRs int, lastMergeAt time.Time, checks ...Heal
 	}
 
 	status := Status{
-		Configured:              true,
-		Goal:                    brief.Goal(),
-		DesiredOutcome:          brief.Goal(),
-		RuntimeTarget:           brief.RuntimeTarget,
-		RuntimeURL:              brief.RuntimeURL,
-		RuntimeHost:             brief.RuntimeHost,
-		SourceRepoPath:          brief.SourceRepoPath,
-		DeploymentStatusCommand: brief.DeploymentStatusCommand,
-		DeployStatusCommand:     brief.DeploymentStatusCommand,
-		HealthcheckCommand:      brief.HealthcheckCommand,
-		VerifierCommand:         brief.VerifierCommand,
-		HealthcheckURL:          brief.HealthcheckURL,
-		RequiredRoutes:          append([]string(nil), brief.RequiredRoutes...),
-		RequiresDeploy:          brief.RequiresDeploy,
-		NonGoals:                append([]string(nil), brief.NonGoals...),
-		PassRequiredForDone:     brief.PassRequiredForDoneEnabled(),
-		FailRequiresVisibleWork: brief.FailRequiresVisibleWorkEnabled(),
-		MergedPRs:               mergedPRs,
+		Configured:                true,
+		Goal:                      brief.Goal(),
+		DesiredOutcome:            brief.Goal(),
+		RuntimeTarget:             brief.RuntimeTarget,
+		RuntimeURL:                brief.RuntimeURL,
+		RuntimeHost:               brief.RuntimeHost,
+		SourceRepoPath:            brief.SourceRepoPath,
+		DeploymentStatusCommand:   brief.DeploymentStatusCommand,
+		DeployStatusCommand:       brief.DeploymentStatusCommand,
+		HealthcheckCommand:        brief.HealthcheckCommand,
+		VerifierCommand:           brief.VerifierCommand,
+		HealthcheckURL:            brief.HealthcheckURL,
+		HealthcheckTimeoutSeconds: brief.HealthcheckTimeoutSeconds,
+		RequiredRoutes:            append([]string(nil), brief.RequiredRoutes...),
+		RequiresDeploy:            brief.RequiresDeploy,
+		NonGoals:                  append([]string(nil), brief.NonGoals...),
+		PassRequiredForDone:       brief.PassRequiredForDoneEnabled(),
+		FailRequiresVisibleWork:   brief.FailRequiresVisibleWorkEnabled(),
+		MergedPRs:                 mergedPRs,
 	}
 	if !lastMergeAt.IsZero() {
 		status.LastMergeAt = lastMergeAt.UTC().Format(time.RFC3339)

--- a/internal/outcome/outcome_test.go
+++ b/internal/outcome/outcome_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 )
@@ -164,5 +165,107 @@ func TestCheckerCommandFailure(t *testing.T) {
 	})
 	if result.State != HealthFailing || result.ExitCode != 7 || result.Detail != "not healthy" {
 		t.Fatalf("result = %+v, want failing command result", result)
+	}
+}
+
+func TestCheckerCommandUsesBriefTimeout(t *testing.T) {
+	var gotTimeout time.Duration
+	result := Checker{
+		RunCommand: func(ctx context.Context, command, dir string) ([]byte, int, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("command context has no deadline")
+			}
+			gotTimeout = time.Until(deadline)
+			return []byte("ok"), 0, nil
+		},
+	}.Check(context.Background(), Brief{
+		DesiredOutcome:            "App is live",
+		HealthcheckCommand:        "status.sh",
+		HealthcheckTimeoutSeconds: 42,
+	})
+	if result.State != HealthHealthy {
+		t.Fatalf("result = %+v, want healthy", result)
+	}
+	if gotTimeout < 41*time.Second || gotTimeout > 42*time.Second {
+		t.Fatalf("command deadline = %s, want about 42s", gotTimeout)
+	}
+}
+
+func TestCheckerCommandSerializesConcurrentChecks(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+	enteredFirst := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var first sync.Once
+
+	checker := Checker{
+		RunCommand: func(ctx context.Context, command, dir string) ([]byte, int, error) {
+			mu.Lock()
+			active++
+			if active > maxActive {
+				maxActive = active
+			}
+			mu.Unlock()
+
+			first.Do(func() {
+				close(enteredFirst)
+				select {
+				case <-releaseFirst:
+				case <-ctx.Done():
+				}
+			})
+
+			time.Sleep(10 * time.Millisecond)
+
+			mu.Lock()
+			active--
+			mu.Unlock()
+			return []byte("ok"), 0, nil
+		},
+	}
+	brief := Brief{
+		DesiredOutcome:            "App is live",
+		HealthcheckCommand:        "verify.sh",
+		HealthcheckTimeoutSeconds: 5,
+		SourceRepoPath:            t.TempDir(),
+	}
+
+	results := make(chan HealthCheckResult, 2)
+	go func() { results <- checker.Check(ctx, brief) }()
+
+	select {
+	case <-enteredFirst:
+	case <-ctx.Done():
+		t.Fatal("first check did not enter command")
+	}
+	go func() { results <- checker.Check(ctx, brief) }()
+
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	if maxActive != 1 || active != 1 {
+		t.Fatalf("concurrent command active=%d maxActive=%d, want one active command", active, maxActive)
+	}
+	mu.Unlock()
+	close(releaseFirst)
+
+	for range 2 {
+		select {
+		case result := <-results:
+			if result.State != HealthHealthy {
+				t.Fatalf("result = %+v, want healthy", result)
+			}
+		case <-ctx.Done():
+			t.Fatal("checks did not finish")
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if maxActive != 1 {
+		t.Fatalf("maxActive = %d, want serialized checks", maxActive)
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1073,9 +1073,12 @@ type State struct {
 	// workers but lets in-flight workers finish. It is set by `maestro
 	// drain` and cleared automatically when the orchestrator starts, so a
 	// drain never persists across a legitimate restart. SpawnDrainAt records
-	// when the drain was requested (UTC).
-	SpawnDrain   bool      `json:"spawn_drain,omitempty"`
-	SpawnDrainAt time.Time `json:"spawn_drain_at,omitempty"`
+	// when an active drain was requested (UTC); SpawnDrainClearAt records
+	// the clear transition for latest-write-wins merge semantics without
+	// making inactive state look drained.
+	SpawnDrain        bool      `json:"spawn_drain,omitempty"`
+	SpawnDrainAt      time.Time `json:"spawn_drain_at,omitempty,omitzero"`
+	SpawnDrainClearAt time.Time `json:"spawn_drain_clear_at,omitempty,omitzero"`
 
 	// Paused is the first-class operator pause (#683): while it is set, the
 	// orchestrator skips issue selection entirely and spawns no new workers,
@@ -1468,6 +1471,10 @@ func (s *State) normalize() {
 	if s.NextSlot == 0 {
 		s.NextSlot = 1
 	}
+	if !s.SpawnDrain && !s.SpawnDrainAt.IsZero() && s.SpawnDrainClearAt.IsZero() {
+		s.SpawnDrainClearAt = s.SpawnDrainAt
+		s.SpawnDrainAt = time.Time{}
+	}
 }
 
 func (s *State) copyFrom(src *State) {
@@ -1484,6 +1491,7 @@ func (s *State) copyFrom(src *State) {
 	s.LastMergeAt = src.LastMergeAt
 	s.SpawnDrain = src.SpawnDrain
 	s.SpawnDrainAt = src.SpawnDrainAt
+	s.SpawnDrainClearAt = src.SpawnDrainClearAt
 	s.Paused = src.Paused
 	s.PausedAt = src.PausedAt
 }
@@ -1536,19 +1544,39 @@ func mergeStateSnapshots(base, current, ours *State) (*State, error) {
 	return merged, nil
 }
 
-// mergeSpawnDrain resolves the drain flag (#541) latest-write-wins by
-// SpawnDrainAt. The drain CLI sets SpawnDrain=true and the orchestrator clears
-// it (SpawnDrain=false) — both stamp SpawnDrainAt — so picking the snapshot
-// with the newer timestamp keeps a concurrent orchestrator save from clobbering
-// a fresh drain request, and a fresh clear from being undone by a stale set.
+// mergeSpawnDrain resolves the drain flag (#541) latest-write-wins by the
+// newest set/clear transition. The drain CLI sets SpawnDrain=true and stamps
+// SpawnDrainAt; the orchestrator clears it and stamps SpawnDrainClearAt.
 func mergeSpawnDrain(merged, current, ours *State) {
-	if ours.SpawnDrainAt.After(current.SpawnDrainAt) {
-		merged.SpawnDrain = ours.SpawnDrain
-		merged.SpawnDrainAt = ours.SpawnDrainAt
+	if spawnDrainTransitionAt(ours).After(spawnDrainTransitionAt(current)) {
+		copySpawnDrainState(merged, ours)
 		return
 	}
-	merged.SpawnDrain = current.SpawnDrain
-	merged.SpawnDrainAt = current.SpawnDrainAt
+	copySpawnDrainState(merged, current)
+}
+
+func spawnDrainTransitionAt(s *State) time.Time {
+	if s == nil {
+		return time.Time{}
+	}
+	if s.SpawnDrain {
+		return s.SpawnDrainAt
+	}
+	if s.SpawnDrainClearAt.After(s.SpawnDrainAt) {
+		return s.SpawnDrainClearAt
+	}
+	return s.SpawnDrainAt
+}
+
+func copySpawnDrainState(dst, src *State) {
+	dst.SpawnDrain = src.SpawnDrain
+	if src.SpawnDrain {
+		dst.SpawnDrainAt = src.SpawnDrainAt
+		dst.SpawnDrainClearAt = time.Time{}
+		return
+	}
+	dst.SpawnDrainAt = time.Time{}
+	dst.SpawnDrainClearAt = spawnDrainTransitionAt(src)
 }
 
 // mergePaused resolves the pause flag (#683) latest-write-wins by PausedAt,
@@ -2994,6 +3022,7 @@ func (s *State) SetSpawnDrain(at time.Time) {
 	}
 	s.SpawnDrain = true
 	s.SpawnDrainAt = normalizedTime(at)
+	s.SpawnDrainClearAt = time.Time{}
 }
 
 // ClearSpawnDrain lifts a graceful drain. The orchestrator calls this on
@@ -3003,7 +3032,8 @@ func (s *State) ClearSpawnDrain(at time.Time) {
 		return
 	}
 	s.SpawnDrain = false
-	s.SpawnDrainAt = normalizedTime(at)
+	s.SpawnDrainAt = time.Time{}
+	s.SpawnDrainClearAt = normalizedTime(at)
 }
 
 // DrainActive reports whether a graceful drain is currently requested.

--- a/internal/state/state_drain_test.go
+++ b/internal/state/state_drain_test.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -35,14 +37,45 @@ func TestSetAndClearSpawnDrain(t *testing.T) {
 	if !s.SpawnDrainAt.Equal(at) {
 		t.Fatalf("SpawnDrainAt = %v, want %v", s.SpawnDrainAt, at)
 	}
+	if !s.SpawnDrainClearAt.IsZero() {
+		t.Fatalf("SpawnDrainClearAt = %v, want zero while drain is active", s.SpawnDrainClearAt)
+	}
 
 	later := at.Add(time.Minute)
 	s.ClearSpawnDrain(later)
 	if s.DrainActive() {
 		t.Fatal("DrainActive() true after ClearSpawnDrain")
 	}
-	if !s.SpawnDrainAt.Equal(later) {
-		t.Fatalf("SpawnDrainAt = %v, want %v after clear", s.SpawnDrainAt, later)
+	if !s.SpawnDrainAt.IsZero() {
+		t.Fatalf("SpawnDrainAt = %v, want zero after clear", s.SpawnDrainAt)
+	}
+	if !s.SpawnDrainClearAt.Equal(later) {
+		t.Fatalf("SpawnDrainClearAt = %v, want %v after clear", s.SpawnDrainClearAt, later)
+	}
+}
+
+func TestSpawnDrainJSONOmitsInactiveDrainAt(t *testing.T) {
+	s := NewState()
+	at := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	s.SetSpawnDrain(at)
+	active, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal active state: %v", err)
+	}
+	if !strings.Contains(string(active), `"spawn_drain_at"`) {
+		t.Fatalf("active state JSON = %s, want spawn_drain_at", active)
+	}
+
+	s.ClearSpawnDrain(at.Add(time.Minute))
+	cleared, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal cleared state: %v", err)
+	}
+	if strings.Contains(string(cleared), `"spawn_drain_at"`) {
+		t.Fatalf("cleared state JSON = %s, want no spawn_drain_at", cleared)
+	}
+	if !strings.Contains(string(cleared), `"spawn_drain_clear_at"`) {
+		t.Fatalf("cleared state JSON = %s, want spawn_drain_clear_at", cleared)
 	}
 }
 
@@ -102,5 +135,26 @@ func TestMergeSpawnDrain_LatestWriteWins(t *testing.T) {
 		if merged.DrainActive() {
 			t.Fatal("stale set undid a fresh clear")
 		}
+		if !merged.SpawnDrainAt.IsZero() {
+			t.Fatalf("SpawnDrainAt = %v, want zero after merged clear", merged.SpawnDrainAt)
+		}
+		if !merged.SpawnDrainClearAt.Equal(t0.Add(2 * time.Minute)) {
+			t.Fatalf("SpawnDrainClearAt = %v, want fresh clear timestamp", merged.SpawnDrainClearAt)
+		}
 	})
+}
+
+func TestNormalizeMigratesInactiveSpawnDrainAtToClearAt(t *testing.T) {
+	clearAt := time.Date(2026, 6, 1, 10, 30, 0, 0, time.UTC)
+	s := NewState()
+	s.SpawnDrain = false
+	s.SpawnDrainAt = clearAt
+	s.normalize()
+
+	if !s.SpawnDrainAt.IsZero() {
+		t.Fatalf("SpawnDrainAt = %v, want zero for inactive drain", s.SpawnDrainAt)
+	}
+	if !s.SpawnDrainClearAt.Equal(clearAt) {
+		t.Fatalf("SpawnDrainClearAt = %v, want migrated clear timestamp %v", s.SpawnDrainClearAt, clearAt)
+	}
 }


### PR DESCRIPTION
## Summary
- accept numeric-string backend pricing while preserving numeric YAML output
- add outcome healthcheck_timeout_seconds and serialize command healthchecks with a cross-process lock
- migrate cleared spawn_drain_at into spawn_drain_clear_at and clear stale supervisor_stuck on daemon startup
- update single-daemon/config-store docs and config-store CLI defaults/listing

## Live config/state changes
- updated /home/god/.maestro/maestro.d/ok-folio.yaml and the befeast-ok-folio config-store row with outcome.healthcheck_timeout_seconds: 60
- removed an accidental transient duplicate config-store row named ok-folio; the store is back to the expected 8 rows
- restarted maestro.service after installing the rebuilt binary

## Verification
- go test ./...
- go build ./cmd/maestro/
- maestro status --config /home/god/.maestro/maestro.d/ok-folio.yaml
- Fleet API on :8786 reports OK Folio healthy, not paused/drained/stuck, running=0
- systemctl list-units --all 'maestro*folio*' shows no per-project units

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the daemon and config-store flow for the OK Folio runtime model. The main changes are:

- Config-store defaults now point at `~/.maestro/maestro.db`.
- A `config-store list` command was added.
- Backend pricing accepts quoted numeric YAML values.
- Outcome healthchecks gained a configurable timeout and command lock.
- Drain and supervisor-stuck state handling was updated.
- Runtime docs now describe the single-daemon store-first setup.

<h3>Confidence Score: 4/5</h3>

The changed runtime paths need fixes before merging.

- Command healthchecks can wait forever on the new lock before the configured timeout starts.
- Startup supervisor-stuck clearing can be lost when another daemon startup save touches the same state file.
- The new list command can create an empty default store during inspection.

internal/outcome/checker.go, internal/daemon/supervise.go, cmd/maestro/main.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/outcome/checker.go | Adds command healthcheck locking and timeout selection; the lock wait can block before the timeout applies. |
| internal/outcome/outcome.go | Adds `healthcheck_timeout_seconds` to the outcome brief and status shape. |
| internal/daemon/supervise.go | Clears stale supervisor-stuck state on startup, but the save can lose the clear during concurrent startup writes. |
| internal/state/state.go | Adds `SpawnDrainClearAt` and updates drain latest-write-wins merge behavior. |
| cmd/maestro/main.go | Adds config-store listing and aligns config-store command defaults with the daemon store path. |
| cmd/maestro/daemon.go | Changes the daemon config-store default path to `~/.maestro/maestro.db`. |
| internal/config/config.go | Adds custom YAML parsing for backend pricing fields so quoted numeric values load as numbers. |
| internal/configstore/store.go | Exports `ProjectNames` for config-store project discovery. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/outcome/checker.go:143
**Lock Wait Has No Timeout**

When another daemon or CLI process holds this healthcheck lock, the wait uses the caller context before the command timeout is applied. The supervisor and post-merge outcome paths call this with `context.Background()`, so a stuck or long-running command in one process can block the next check forever instead of returning a timed-out health result.

### Issue 2 of 3
internal/daemon/supervise.go:141
**Startup Clear Can Vanish**

This `Save` can race with the orchestrator startup saves that run in parallel with the supervise loop. On a concurrent write, the state merge keeps `SupervisorStuck` and `SupervisorStuckReason` from the current on-disk snapshot rather than the cleared copy, so the log can say the stale flag was cleared while the persisted state still reports the project as stuck.

### Issue 3 of 3
cmd/maestro/main.go:564
**List Opens A New Store**

Running `maestro config-store list` without `--db` now opens the default `~/.maestro/maestro.db`, and `configstore.Open` initializes the SQLite schema. On a fresh host or a host whose real store is still at the old path, a read-only inspection command can create an empty default store that the daemon later treats as the fleet source of truth, leaving it with no projects.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix OK Folio orchestration drift"](https://github.com/befeast/maestro/commit/fe78b89f1e6740377e53c0d63fd4e64abf0a40dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41796499)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->