### PR TITLE
Fleet burns the full 5000/hr GitHub REST quota within the hour, twice in one evening (post-#794)

### DIFF
--- a/docs/github-rest-quota-runbook.md
+++ b/docs/github-rest-quota-runbook.md
@@ -21,7 +21,13 @@ incidents shaped the protections in `internal/github`:
   consume the hourly REST quota; the wrapper serves the cached body. This has
   no effect on merge-gating correctness — a 304 is GitHub's own guarantee
   that a 200 would have returned identical content, so every gate still sees
-  exactly what GitHub would have sent.
+  exactly what GitHub would have sent. For `--paginate` reads a 304 only
+  certifies the *first page*, so the wrapper caches a paginated response only
+  when an unchanged first page proves the whole collection unchanged: array
+  bodies with fewer items than `per_page`, or object bodies carrying
+  `total_count`. Full single pages and multi-page responses are always
+  refetched plain, so a collection growing onto page 2 can never be masked by
+  a stale cache.
 - **Usage counter.** Each gh exchange is counted (total, 304s served free,
   rate-limited responses) and a one-line digest is written to the journal
   every hour:

--- a/docs/github-rest-quota-runbook.md
+++ b/docs/github-rest-quota-runbook.md
@@ -1,0 +1,61 @@
+# GitHub REST quota runbook
+
+The fleet daemon polls GitHub on a single shared PAT: every flow reads issues,
+open PRs, per-PR state, check-runs, and combined status each cycle. Two
+incidents shaped the protections in `internal/github`:
+
+- **2026-06-28 (#794)** — synchronized bursts tripped GitHub's *secondary*
+  rate limit. Fix: per-flow start/tick jitter, bounded retry with
+  backoff + Retry-After in the gh wrapper, per-cycle `ListOpenPRs` dedup.
+- **2026-07-02 (#797)** — steady-state consumption approached the full
+  *primary* 5000/hr window twice in one evening, and a rate-limited window
+  during a drain stretched daemon stop past 20 minutes. Fix: conditional
+  (ETag) polling, a usage counter with an hourly journal digest, and a
+  shutdown fail-fast mode.
+
+## What the wrapper does (#797)
+
+- **Conditional requests.** Every polling GET through the wrapper remembers
+  the endpoint's last `ETag` + body and replays with `If-None-Match`. GitHub
+  answers an unchanged resource with `304 Not Modified`, which does **not**
+  consume the hourly REST quota; the wrapper serves the cached body. This has
+  no effect on merge-gating correctness — a 304 is GitHub's own guarantee
+  that a 200 would have returned identical content, so every gate still sees
+  exactly what GitHub would have sent.
+- **Usage counter.** Each gh exchange is counted (total, 304s served free,
+  rate-limited responses) and a one-line digest is written to the journal
+  every hour:
+
+      [github] REST usage last 1h0m0s: 412 requests, ~118 billed against core quota, 294 served free by 304, 0 rate-limited
+
+- **Shutdown fail-fast.** `github.BeginShutdown()` — called by the daemon at
+  the start of drain and teardown — disables rate-limit retries and cuts
+  short any backoff already sleeping, so a rate-limited window degrades to
+  failed cycles instead of blocking flow stop.
+
+## Measuring calls/hour (before/after)
+
+1. Pull the hourly digests for the window of interest:
+
+       journalctl -u maestro.service --since "2026-07-02 20:00" | grep "REST usage last"
+
+   `requests − served free by 304` is what was billed against the shared
+   core bucket that hour. The digest counts one per gh invocation, so a
+   multi-page `--paginate` call is a lower bound on raw quota use.
+
+2. Cross-check against GitHub's own accounting (the `core.used` field):
+
+       gh api rate_limit --jq '.resources.core'
+
+   `used` resets exactly at the hourly window boundary (`reset`, epoch
+   seconds); the target is steady-state `used` under 50% of `limit` so
+   operator/CI activity on the same token cannot tip the fleet over.
+
+3. Rate-limited lines, when they do occur, are logged with the real GitHub
+   error text: grep for `rate-limited` in the same journal.
+
+## If the fleet is rate-limited during shutdown
+
+Nothing to do: the drain path already fails gh reads fast. If a stop still
+hangs, a second SIGTERM aborts the drain wait immediately (`maestro daemon`
+two-phase shutdown, #761).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -24,6 +24,7 @@ import (
 	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/configwatch"
+	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/selfdeploy"
 	"github.com/befeast/maestro/internal/server"
 	"github.com/befeast/maestro/internal/state"
@@ -503,6 +504,13 @@ func (d *Daemon) Fleet() *server.FleetServer {
 // so an operator can force shutdown. Non-positive timeout clamps to
 // DefaultDrainTimeout.
 func (d *Daemon) Drain(ctx context.Context, timeout time.Duration) {
+	// Fail fast on GitHub rate limits from here on (#797): the flows keep
+	// polling while the drain waits for in-flight workers, and a rate-limited
+	// window at that moment must degrade to failed cycles — not minutes of
+	// backoff that stall flow stop past the drain deadline (observed
+	// 2026-07-02: a 0-worker drain stretched past 20 minutes).
+	github.BeginShutdown()
+
 	if timeout <= 0 {
 		timeout = DefaultDrainTimeout
 	}

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/configwatch"
+	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/orchestrator"
 	"github.com/befeast/maestro/internal/server"
 )
@@ -168,6 +169,10 @@ func (d *Daemon) stopFlow(key string) {
 // RunOnce is not ctx-cancellable mid-cycle, so the sum could be many minutes
 // (#764).
 func (d *Daemon) stopAll() {
+	// Covers the teardown paths where Drain never ran (e.g. a serve error):
+	// gh reads fail fast on rate limits instead of blocking flow stop (#797).
+	github.BeginShutdown()
+
 	d.mu.Lock()
 	flows := make([]*projectFlow, 0, len(d.flows))
 	for _, flow := range d.flows {

--- a/internal/github/conditional_test.go
+++ b/internal/github/conditional_test.go
@@ -1,0 +1,328 @@
+package github
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withGHRunner installs a runner that records every invocation's args and
+// answers via fn. It also neutralizes the sleeper and jitter, and restores
+// everything on cleanup.
+func withGHRunner(t *testing.T, fn func(args []string) ([]byte, error)) *[][]string {
+	t.Helper()
+	origRunner := ghAPIRunner
+	origSleep := ghAPISleep
+	origJitter := ghAPIJitterFrac
+	var calls [][]string
+	ghAPIRunner = func(args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		return fn(args)
+	}
+	ghAPISleep = func(time.Duration) {}
+	ghAPIJitterFrac = func() float64 { return 0 }
+	t.Cleanup(func() {
+		ghAPIRunner = origRunner
+		ghAPISleep = origSleep
+		ghAPIJitterFrac = origJitter
+	})
+	return &calls
+}
+
+func clearETagCache(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		etagMu.Lock()
+		etagCache = map[string]*etagEntry{}
+		etagMu.Unlock()
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+// includeResponse builds the combined output `gh api --include` produces: a
+// status line, headers, a blank line, then the body.
+func includeResponse(statusLine, etag, body string) []byte {
+	var b strings.Builder
+	b.WriteString("HTTP/2.0 " + statusLine + "\r\n")
+	b.WriteString("Content-Type: application/json; charset=utf-8\r\n")
+	if etag != "" {
+		b.WriteString("Etag: " + etag + "\r\n")
+	}
+	b.WriteString("X-Ratelimit-Remaining: 4000\r\n")
+	b.WriteString("\r\n")
+	b.WriteString(body)
+	return []byte(b.String())
+}
+
+func argWithPrefix(args []string, prefix string) string {
+	for _, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			return a
+		}
+	}
+	return ""
+}
+
+func hasArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGHAPI_ConditionalServes304FromCache(t *testing.T) {
+	clearETagCache(t)
+	endpoint := "repos/owner/repo/pulls?state=open&per_page=100"
+	etag := `W/"abc123"`
+	bodyJSON := `[{"number":839}]`
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		if argWithPrefix(args, "If-None-Match:") != "" {
+			// Conditional replay of unchanged content: bodyless 304 headers on
+			// stdout plus gh's non-2xx error text, exit status 1.
+			out := append(includeResponse("304 Not Modified", "", ""),
+				[]byte("gh: HTTP 304 (https://api.github.com/"+endpoint+")")...)
+			return out, errors.New("exit status 1")
+		}
+		return includeResponse("200 OK", etag, bodyJSON), nil
+	})
+
+	before := APIUsage()
+
+	out, err := ghAPIWithArgs(endpoint)
+	if err != nil {
+		t.Fatalf("first fetch error = %v", err)
+	}
+	if string(out) != bodyJSON {
+		t.Fatalf("first fetch body = %q, want %q", out, bodyJSON)
+	}
+	if !hasArg((*calls)[0], "--include") {
+		t.Fatalf("first call args = %v, want --include so the ETag is captured", (*calls)[0])
+	}
+	if argWithPrefix((*calls)[0], "If-None-Match:") != "" {
+		t.Fatalf("first call must not send If-None-Match (nothing cached yet); args = %v", (*calls)[0])
+	}
+
+	out2, err := ghAPIWithArgs(endpoint)
+	if err != nil {
+		t.Fatalf("conditional refetch error = %v, want the 304 served from cache", err)
+	}
+	if string(out2) != bodyJSON {
+		t.Fatalf("304 body = %q, want the cached copy %q", out2, bodyJSON)
+	}
+	if got := argWithPrefix((*calls)[1], "If-None-Match:"); got != "If-None-Match: "+etag {
+		t.Fatalf("second call conditional header = %q, want the cached ETag", got)
+	}
+
+	delta := APIUsage()
+	if delta.Requests-before.Requests != 2 {
+		t.Fatalf("requests delta = %d, want 2", delta.Requests-before.Requests)
+	}
+	if delta.NotModified-before.NotModified != 1 {
+		t.Fatalf("not-modified delta = %d, want 1 (the free 304)", delta.NotModified-before.NotModified)
+	}
+}
+
+func TestGHAPI_Conditional304ErrorTextWithoutHeadersServesCache(t *testing.T) {
+	clearETagCache(t)
+	endpoint := "repos/owner/repo/pulls/136"
+	cached := []byte(`{"number":136}`)
+	etagStore(endpoint, `W/"pr136"`, cached)
+	withGHRunner(t, func(args []string) ([]byte, error) {
+		// Defensive path: gh swallowed the header block, only its error text
+		// survives. The cached copy must still be served.
+		return []byte("gh: HTTP 304 (https://api.github.com/" + endpoint + ")"), errors.New("exit status 1")
+	})
+
+	out, err := ghAPIWithArgs(endpoint)
+	if err != nil {
+		t.Fatalf("error = %v, want cached body on a header-less 304", err)
+	}
+	if string(out) != string(cached) {
+		t.Fatalf("body = %q, want cached %q", out, cached)
+	}
+}
+
+func TestGHAPI_ConditionalRefreshesCacheOnChange(t *testing.T) {
+	clearETagCache(t)
+	endpoint := "repos/owner/repo/commits/main"
+	etagStore(endpoint, `W/"old"`, []byte(`{"sha":"old"}`))
+	newBody := `{"sha":"new"}`
+	withGHRunner(t, func(args []string) ([]byte, error) {
+		return includeResponse("200 OK", `W/"new"`, newBody), nil
+	})
+
+	out, err := ghAPIWithArgs(endpoint)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if string(out) != newBody {
+		t.Fatalf("body = %q, want the fresh %q", out, newBody)
+	}
+	gotETag, gotBody := etagLookup(endpoint)
+	if gotETag != `W/"new"` || string(gotBody) != newBody {
+		t.Fatalf("cache = (%q, %q), want the refreshed entry", gotETag, gotBody)
+	}
+}
+
+func TestGHAPI_PaginatedMultiPageConcatenatesAndSkipsCache(t *testing.T) {
+	clearETagCache(t)
+	endpoint := "repos/owner/repo/commits/abc/check-runs?per_page=100"
+	page1 := includeResponse("200 OK", `W/"p1"`, "{\"check_runs\":[\n")
+	page2 := includeResponse("200 OK", `W/"p2"`, "]}")
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return append(append([]byte{}, page1...), page2...), nil
+	})
+
+	out, err := ghAPIWithArgs(endpoint, "--paginate")
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if string(out) != "{\"check_runs\":[\n]}" {
+		t.Fatalf("body = %q, want the pages' bodies concatenated", out)
+	}
+	if e, b := etagLookup(endpoint); e != "" || b != nil {
+		t.Fatalf("cache = (%q, %q), want empty — a multi-page response must not be cached", e, b)
+	}
+	if _, err := ghAPIWithArgs(endpoint, "--paginate"); err != nil {
+		t.Fatalf("second fetch error = %v", err)
+	}
+	if got := argWithPrefix((*calls)[1], "If-None-Match:"); got != "" {
+		t.Fatalf("second call sent %q, want no conditional header after a multi-page response", got)
+	}
+}
+
+func TestGHAPI_ShutdownSkipsRateLimitRetries(t *testing.T) {
+	resetShutdownForTest()
+	t.Cleanup(resetShutdownForTest)
+	BeginShutdown()
+
+	limit := []byte("gh: API rate limit exceeded for user ID 51094. (HTTP 403)")
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return limit, errors.New("exit status 1")
+	})
+
+	_, err := ghAPIWithArgs("repos/owner/repo/pulls/839")
+	if err == nil {
+		t.Fatal("error = nil, want the rate-limit failure surfaced immediately")
+	}
+	if !strings.Contains(err.Error(), "rate limit") {
+		t.Fatalf("error = %q, want the real rate-limit text", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1 — no retries once shutdown has begun", len(*calls))
+	}
+}
+
+func TestGHAPI_ShutdownDuringBackoffStopsRetrying(t *testing.T) {
+	resetShutdownForTest()
+	t.Cleanup(resetShutdownForTest)
+
+	limit := []byte("gh: You have exceeded a secondary rate limit. (HTTP 403)")
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return limit, errors.New("exit status 1")
+	})
+	sleeps := 0
+	ghAPISleep = func(time.Duration) {
+		sleeps++
+		BeginShutdown() // shutdown begins while the backoff is sleeping
+	}
+
+	_, err := ghAPIWithArgs("repos/owner/repo/pulls/838")
+	if err == nil {
+		t.Fatal("error = nil, want failure once shutdown interrupts the backoff")
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1 — no further attempt after an interrupted backoff", len(*calls))
+	}
+	if sleeps != 1 {
+		t.Fatalf("sleeps = %d, want 1", sleeps)
+	}
+}
+
+func TestParseGHConditionalResponse(t *testing.T) {
+	if _, ok := parseGHConditionalResponse([]byte(`{"ok":true}`)); ok {
+		t.Fatal("plain JSON must not parse as a header block")
+	}
+	if _, ok := parseGHConditionalResponse([]byte("gh: HTTP 304 (https://api.github.com/x)")); ok {
+		t.Fatal("gh error text must not parse as a header block")
+	}
+
+	resp, ok := parseGHConditionalResponse(includeResponse("200 OK", `W/"x"`, `{"a":1}`))
+	if !ok {
+		t.Fatal("single 200 block did not parse")
+	}
+	if resp.status != 200 || resp.etag != `W/"x"` || string(resp.body) != `{"a":1}` || resp.blocks != 1 || !resp.allOK {
+		t.Fatalf("parsed = %+v body=%q, want status 200 / etag / body / 1 block / allOK", resp, resp.body)
+	}
+
+	resp304, ok := parseGHConditionalResponse(includeResponse("304 Not Modified", "", ""))
+	if !ok {
+		t.Fatal("304 block did not parse")
+	}
+	if resp304.status != 304 || resp304.allOK {
+		t.Fatalf("parsed 304 = %+v, want status 304 and not allOK", resp304)
+	}
+}
+
+func TestGHConditionalEligible(t *testing.T) {
+	cases := []struct {
+		endpoint string
+		args     []string
+		want     bool
+	}{
+		{"repos/o/r/pulls?state=open", nil, true},
+		{"repos/o/r/commits/sha/check-runs?per_page=100", []string{"--paginate"}, true},
+		{"rate_limit", nil, false},
+		{"repos/o/r/pulls", []string{"-X", "POST"}, false},
+	}
+	for _, tc := range cases {
+		if got := ghConditionalEligible(tc.endpoint, tc.args); got != tc.want {
+			t.Fatalf("ghConditionalEligible(%q, %v) = %v, want %v", tc.endpoint, tc.args, got, tc.want)
+		}
+	}
+}
+
+func TestAPIUsage_CountsAndRollsHourlyWindow(t *testing.T) {
+	base := time.Date(2026, 7, 2, 21, 0, 0, 0, time.UTC)
+	now := base
+	origNow := apiUsageNow
+	apiUsageNow = func() time.Time { return now }
+	t.Cleanup(func() { apiUsageNow = origNow })
+	apiStatsMu.Lock()
+	apiStatsWindow = APIStats{}
+	apiWindowStart = time.Time{}
+	apiStatsMu.Unlock()
+
+	before := APIUsage()
+	noteAPIRequest(false, false)
+	noteAPIRequest(true, false)
+	noteAPIRequest(false, true)
+	got := APIUsage()
+	if d := got.Requests - before.Requests; d != 3 {
+		t.Fatalf("requests delta = %d, want 3", d)
+	}
+	if d := got.NotModified - before.NotModified; d != 1 {
+		t.Fatalf("not-modified delta = %d, want 1", d)
+	}
+	if d := got.RateLimited - before.RateLimited; d != 1 {
+		t.Fatalf("rate-limited delta = %d, want 1", d)
+	}
+
+	// Crossing the window boundary emits the digest and resets the window.
+	now = base.Add(2 * time.Hour)
+	noteAPIRequest(false, false)
+	apiStatsMu.Lock()
+	windowReqs := apiStatsWindow.Requests
+	windowStart := apiWindowStart
+	apiStatsMu.Unlock()
+	if windowReqs != 0 {
+		t.Fatalf("window requests after rollover = %d, want 0", windowReqs)
+	}
+	if !windowStart.Equal(now) {
+		t.Fatalf("window start = %s, want reset to %s", windowStart, now)
+	}
+}

--- a/internal/github/conditional_test.go
+++ b/internal/github/conditional_test.go
@@ -195,6 +195,122 @@ func TestGHAPI_PaginatedMultiPageConcatenatesAndSkipsCache(t *testing.T) {
 	}
 }
 
+func TestGHAPI_PaginatedFullPageNotCached(t *testing.T) {
+	clearETagCache(t)
+	// Exactly per_page items: the collection can grow onto page 2 while page 1
+	// stays byte-identical, so a later 304 would hide the new items. The page
+	// must never enter the cache.
+	endpoint := "repos/owner/repo/issues/5/comments?per_page=2"
+	fullPage := `[{"id":1},{"id":2}]`
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return includeResponse("200 OK", `W/"full"`, fullPage), nil
+	})
+
+	out, err := ghAPIWithArgs(endpoint, "--paginate")
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if string(out) != fullPage {
+		t.Fatalf("body = %q, want %q", out, fullPage)
+	}
+	if e, b := etagLookup(endpoint); e != "" || b != nil {
+		t.Fatalf("cache = (%q, %q), want empty — a full page can overflow to page 2 without changing", e, b)
+	}
+	if _, err := ghAPIWithArgs(endpoint, "--paginate"); err != nil {
+		t.Fatalf("second fetch error = %v", err)
+	}
+	if got := argWithPrefix((*calls)[1], "If-None-Match:"); got != "" {
+		t.Fatalf("second call sent %q, want no conditional header for an uncacheable full page", got)
+	}
+}
+
+func TestGHAPI_PaginatedPartialPageServes304FromCache(t *testing.T) {
+	clearETagCache(t)
+	// Fewer items than per_page: any growth changes page 1's bytes, so a 304
+	// proves the whole collection unchanged and the cache is safe to serve.
+	endpoint := "repos/owner/repo/pulls/7/comments?per_page=100"
+	body := `[{"id":1}]`
+	etag := `W/"partial"`
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		if argWithPrefix(args, "If-None-Match:") != "" {
+			out := append(includeResponse("304 Not Modified", "", ""),
+				[]byte("gh: HTTP 304 (https://api.github.com/"+endpoint+")")...)
+			return out, errors.New("exit status 1")
+		}
+		return includeResponse("200 OK", etag, body), nil
+	})
+
+	if _, err := ghAPIWithArgs(endpoint, "--paginate"); err != nil {
+		t.Fatalf("first fetch error = %v", err)
+	}
+	out, err := ghAPIWithArgs(endpoint, "--paginate")
+	if err != nil {
+		t.Fatalf("conditional refetch error = %v", err)
+	}
+	if string(out) != body {
+		t.Fatalf("304 body = %q, want the cached copy %q", out, body)
+	}
+	if got := argWithPrefix((*calls)[1], "If-None-Match:"); got != "If-None-Match: "+etag {
+		t.Fatalf("second call conditional header = %q, want the cached ETag", got)
+	}
+}
+
+func TestGHAPI_PaginatedTotalCountBodyCached(t *testing.T) {
+	clearETagCache(t)
+	// check-runs shape: growth anywhere changes total_count on page 1, so even
+	// a full page is safe to cache.
+	endpoint := "repos/owner/repo/commits/abc/check-runs?per_page=100"
+	body := `{"total_count":1,"check_runs":[{"id":9}]}`
+	withGHRunner(t, func(args []string) ([]byte, error) {
+		return includeResponse("200 OK", `W/"cr"`, body), nil
+	})
+
+	if _, err := ghAPIWithArgs(endpoint, "--paginate"); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if e, b := etagLookup(endpoint); e != `W/"cr"` || string(b) != body {
+		t.Fatalf("cache = (%q, %q), want the total_count body cached", e, b)
+	}
+}
+
+func TestPaginatedCacheable(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		perPage int
+		want    bool
+	}{
+		{"array below page size", `[{"id":1}]`, 100, true},
+		{"array at page size", `[{"id":1},{"id":2}]`, 2, false},
+		{"empty array", `[]`, 100, true},
+		{"object with total_count", `{"total_count":3,"check_runs":[]}`, 100, true},
+		{"object without total_count", `{"check_runs":[]}`, 100, false},
+		{"invalid json", `[{"id":`, 100, false},
+		{"empty body", "", 100, false},
+	}
+	for _, tc := range cases {
+		if got := paginatedCacheable([]byte(tc.body), tc.perPage); got != tc.want {
+			t.Fatalf("%s: paginatedCacheable = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestEndpointPerPage(t *testing.T) {
+	cases := []struct {
+		endpoint string
+		want     int
+	}{
+		{"repos/o/r/issues/5/comments?per_page=100", 100},
+		{"repos/o/r/issues/5/comments?direction=asc&per_page=7", 7},
+		{"repos/o/r/issues/5/comments", 30},
+	}
+	for _, tc := range cases {
+		if got := endpointPerPage(tc.endpoint); got != tc.want {
+			t.Fatalf("endpointPerPage(%q) = %d, want %d", tc.endpoint, got, tc.want)
+		}
+	}
+}
+
 func TestGHAPI_ShutdownSkipsRateLimitRetries(t *testing.T) {
 	resetShutdownForTest()
 	t.Cleanup(resetShutdownForTest)
@@ -312,15 +428,16 @@ func TestAPIUsage_CountsAndRollsHourlyWindow(t *testing.T) {
 		t.Fatalf("rate-limited delta = %d, want 1", d)
 	}
 
-	// Crossing the window boundary emits the digest and resets the window.
+	// Crossing the window boundary emits the digest and resets the window; the
+	// request that crossed it opens the new window rather than vanishing.
 	now = base.Add(2 * time.Hour)
 	noteAPIRequest(false, false)
 	apiStatsMu.Lock()
 	windowReqs := apiStatsWindow.Requests
 	windowStart := apiWindowStart
 	apiStatsMu.Unlock()
-	if windowReqs != 0 {
-		t.Fatalf("window requests after rollover = %d, want 0", windowReqs)
+	if windowReqs != 1 {
+		t.Fatalf("window requests after rollover = %d, want 1 (the boundary-crossing request)", windowReqs)
 	}
 	if !windowStart.Equal(now) {
 		t.Fatalf("window start = %s, want reset to %s", windowStart, now)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -364,10 +364,11 @@ func evictOldestETagLocked() {
 }
 
 // ghConditionalEligible reports whether a gh api call can carry conditional
-// request headers. Plain GETs — no extra args, or --paginate only (whose
-// single-page response is by far the common case here; multi-page responses
-// are detected and simply not cached) — are eligible. rate_limit is excluded:
-// its body changes on every read, so a conditional fetch would never hit.
+// request headers. Plain GETs — no extra args, or --paginate only — are
+// eligible; whether a paginated response may actually be cached is decided per
+// response by paginatedCacheable, and multi-page responses are never cached.
+// rate_limit is excluded: its body changes on every read, so a conditional
+// fetch would never hit.
 func ghConditionalEligible(endpoint string, args []string) bool {
 	if endpoint == "rate_limit" {
 		return false
@@ -459,8 +460,10 @@ func headerValue(headers []byte, name string) string {
 // not yield a trustworthy body: with runErr != nil the caller falls through to
 // normal rate-limit/error handling; with runErr == nil (an inconsistent
 // conditional shape, e.g. a paginated response embedding a non-2xx page) the
-// caller must drop the cache entry and refetch plain.
-func resolveConditional(endpoint string, out []byte, runErr error, cachedBody []byte) (body []byte, served bool, resolved bool) {
+// caller must drop the cache entry and refetch plain. paginated marks a
+// --paginate call, whose responses are cached only when paginatedCacheable
+// proves a later 304 cannot hide pages beyond the cached one.
+func resolveConditional(endpoint string, out []byte, runErr error, cachedBody []byte, paginated bool) (body []byte, served bool, resolved bool) {
 	resp, ok := parseGHConditionalResponse(out)
 	if !ok {
 		// No header block. Trust a successful run's output as the plain body
@@ -478,16 +481,66 @@ func resolveConditional(endpoint string, out []byte, runErr error, cachedBody []
 		return cachedBody, true, true
 	}
 	if runErr == nil && resp.allOK {
-		if resp.blocks == 1 {
+		if resp.blocks == 1 && (!paginated || paginatedCacheable(resp.body, endpointPerPage(endpoint))) {
 			etagStore(endpoint, resp.etag, resp.body)
 		} else {
 			// A multi-page response cannot be cached: the first page's ETag
-			// does not validate the concatenated whole.
+			// does not validate the concatenated whole. A full single page is
+			// not cached either — see paginatedCacheable.
 			etagDrop(endpoint)
 		}
 		return resp.body, false, true
 	}
 	return nil, false, false
+}
+
+// paginatedCacheable reports whether a single-page --paginate body may be
+// cached for If-None-Match revalidation. A 304 only certifies that page ONE is
+// unchanged: if the collection has meanwhile grown past the page size, the new
+// items live on a page the bodyless 304 carries no Link header to discover,
+// and serving the cache would hide them (e.g. review comments appended past
+// item 100). Caching is therefore limited to shapes where an unchanged first
+// page proves the whole collection is unchanged:
+//
+//   - a JSON array with fewer than per_page items — any growth lands on this
+//     page and changes its bytes;
+//   - a JSON object carrying GitHub's total_count (check-runs et al.) — growth
+//     anywhere changes the count on page one.
+//
+// A full single page (exactly per_page array items) is the one shape that can
+// overflow invisibly, so it is never cached.
+func paginatedCacheable(body []byte, perPage int) bool {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return false
+	}
+	switch trimmed[0] {
+	case '[':
+		var items []json.RawMessage
+		if err := json.Unmarshal(trimmed, &items); err != nil {
+			return false
+		}
+		return len(items) < perPage
+	case '{':
+		var probe struct {
+			TotalCount *int64 `json:"total_count"`
+		}
+		return json.Unmarshal(trimmed, &probe) == nil && probe.TotalCount != nil
+	}
+	return false
+}
+
+var ghPerPageRE = regexp.MustCompile(`[?&]per_page=(\d+)`)
+
+// endpointPerPage returns the page size a paginated endpoint requested,
+// defaulting to GitHub's 30 when the query string does not say.
+func endpointPerPage(endpoint string) int {
+	if m := ghPerPageRE.FindStringSubmatch(endpoint); m != nil {
+		if n, err := strconv.Atoi(m[1]); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 30
 }
 
 // ghConditionalErrorDetail returns the body portion of a --include response so
@@ -502,6 +555,12 @@ func ghConditionalErrorDetail(out []byte) []byte {
 
 func ghAPIWithArgs(endpoint string, args ...string) ([]byte, error) {
 	conditional := ghConditionalEligible(endpoint, args)
+	paginated := false
+	for _, a := range args {
+		if a == "--paginate" {
+			paginated = true
+		}
+	}
 	cmdArgs := append([]string{"api", endpoint}, args...)
 	var cachedBody []byte
 	if conditional {
@@ -519,7 +578,7 @@ func ghAPIWithArgs(endpoint string, args ...string) ([]byte, error) {
 		anomaly = false
 		out, err = ghAPIRunner(cmdArgs...)
 		if conditional {
-			body, served, resolved := resolveConditional(endpoint, out, err, cachedBody)
+			body, served, resolved := resolveConditional(endpoint, out, err, cachedBody, paginated)
 			if resolved {
 				noteAPIRequest(served, false)
 				return body, nil
@@ -611,6 +670,14 @@ func noteAPIRequest(notModified, rateLimited bool) {
 	now := apiUsageNow()
 	if apiWindowStart.IsZero() {
 		apiWindowStart = now
+	} else if elapsed := now.Sub(apiWindowStart); elapsed >= apiUsageLogEvery {
+		// Roll the window before counting so the request that crossed the
+		// boundary opens the new window instead of vanishing with the digest.
+		w := apiStatsWindow
+		log.Printf("[github] REST usage last %s: %d requests, ~%d billed against core quota, %d served free by 304, %d rate-limited",
+			elapsed.Round(time.Minute), w.Requests, w.Requests-w.NotModified, w.NotModified, w.RateLimited)
+		apiStatsWindow = APIStats{}
+		apiWindowStart = now
 	}
 	for _, s := range []*APIStats{&apiStatsTotal, &apiStatsWindow} {
 		s.Requests++
@@ -620,13 +687,6 @@ func noteAPIRequest(notModified, rateLimited bool) {
 		if rateLimited {
 			s.RateLimited++
 		}
-	}
-	if elapsed := now.Sub(apiWindowStart); elapsed >= apiUsageLogEvery {
-		w := apiStatsWindow
-		log.Printf("[github] REST usage last %s: %d requests, ~%d billed against core quota, %d served free by 304, %d rate-limited",
-			elapsed.Round(time.Minute), w.Requests, w.Requests-w.NotModified, w.NotModified, w.RateLimited)
-		apiStatsWindow = APIStats{}
-		apiWindowStart = now
 	}
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -10,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -195,6 +197,12 @@ func ghAPI(endpoint string) ([]byte, error) {
 //     honoring an explicit Retry-After hint when gh surfaces one and otherwise
 //     backing off exponentially (with jitter, capped) — so a transient 403
 //     degrades to a brief stall + retry instead of a failed cycle.
+//
+// #797 layers three more protections on top: conditional (ETag/If-None-Match)
+// requests so unchanged polling reads answer 304 and consume no quota, a
+// per-process usage counter with an hourly journal digest, and a shutdown
+// fail-fast mode (BeginShutdown) that skips retries so a rate-limited window
+// cannot stall a drain.
 const (
 	ghAPIMaxAttempts = 4
 	ghAPIBaseBackoff = 2 * time.Second
@@ -209,7 +217,16 @@ var ghAPIRunner = func(args ...string) ([]byte, error) {
 }
 
 // ghAPISleep is the backoff sleeper, injectable so tests do not actually wait.
-var ghAPISleep = time.Sleep
+// The default waits on a timer but returns early once BeginShutdown fires, so
+// an in-flight backoff cannot hold up daemon stop (#797).
+var ghAPISleep = func(d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ghShutdownChan():
+	}
+}
 
 // ghAPIJitterFrac yields a random fraction in [0,1) used to spread retry
 // backoff so the fleet's flows do not re-burst in lockstep after a shared 403.
@@ -217,17 +234,324 @@ var ghAPIJitterFrac = rand.Float64
 
 var ghRetryAfterRe = regexp.MustCompile(`(?i)retry-after:\s*(\d+)`)
 
+// ---------------------------------------------------------------------------
+// Shutdown fail-fast (#797). During the 2026-07-02 incident a drain that had
+// ZERO in-flight workers took 20+ minutes to stop because the still-live flows
+// kept polling a rate-limited GitHub and every read sat in the #794 backoff
+// loop. Once shutdown begins, a rate-limited response must degrade to a failed
+// cycle (retried after restart / next tick), never to minutes of sleeping.
+// ---------------------------------------------------------------------------
+
+var (
+	ghShutdownMu    sync.Mutex
+	ghShutdownCh    = make(chan struct{})
+	ghShutdownBegun bool
+)
+
+// BeginShutdown switches the gh wrapper into fail-fast mode for the rest of
+// the process lifetime: rate-limited responses are no longer retried and a
+// backoff already sleeping is cut short. The daemon calls it when drain or
+// teardown starts so a rate-limited window cannot block flow stop (#797).
+// Idempotent.
+func BeginShutdown() {
+	ghShutdownMu.Lock()
+	defer ghShutdownMu.Unlock()
+	if !ghShutdownBegun {
+		ghShutdownBegun = true
+		close(ghShutdownCh)
+	}
+}
+
+// ShuttingDown reports whether BeginShutdown has been called.
+func ShuttingDown() bool {
+	select {
+	case <-ghShutdownChan():
+		return true
+	default:
+		return false
+	}
+}
+
+func ghShutdownChan() <-chan struct{} {
+	ghShutdownMu.Lock()
+	defer ghShutdownMu.Unlock()
+	return ghShutdownCh
+}
+
+// resetShutdownForTest re-arms the one-way shutdown flag so tests can exercise
+// the fail-fast path without poisoning the rest of the test binary.
+func resetShutdownForTest() {
+	ghShutdownMu.Lock()
+	defer ghShutdownMu.Unlock()
+	ghShutdownCh = make(chan struct{})
+	ghShutdownBegun = false
+}
+
+// ---------------------------------------------------------------------------
+// Conditional (ETag) request layer (#797). The fleet's steady-state REST
+// consumption is dominated by per-cycle polling reads (open-PR lists, per-PR
+// lookups, check-runs, combined status) whose responses rarely change between
+// cycles. GitHub answers a conditional GET whose ETag still matches with
+// 304 Not Modified WITHOUT consuming the hourly REST quota, so the wrapper
+// remembers each endpoint's last ETag + body and replays the request with
+// If-None-Match. A 304 is served from the local copy for free; anything else
+// refreshes the cache. Merge-gating correctness is unchanged: a 304 is
+// GitHub's own guarantee that a 200 would have returned identical content.
+// ---------------------------------------------------------------------------
+
+const (
+	// etagCacheMaxEntries bounds the endpoint cache. The steady-state working
+	// set is a few dozen endpoints per flow, so this covers a large fleet;
+	// eviction is a safety valve, not a tuning knob.
+	etagCacheMaxEntries = 1024
+	// etagCacheMaxBody skips caching pathologically large responses so a
+	// long-lived daemon's memory stays bounded.
+	etagCacheMaxBody = 1 << 20
+)
+
+type etagEntry struct {
+	etag     string
+	body     []byte
+	lastUsed time.Time
+}
+
+var (
+	etagMu    sync.Mutex
+	etagCache = map[string]*etagEntry{}
+)
+
+func etagLookup(key string) (etag string, body []byte) {
+	etagMu.Lock()
+	defer etagMu.Unlock()
+	e, ok := etagCache[key]
+	if !ok {
+		return "", nil
+	}
+	e.lastUsed = time.Now()
+	return e.etag, e.body
+}
+
+func etagStore(key, etag string, body []byte) {
+	if etag == "" || len(body) > etagCacheMaxBody {
+		etagDrop(key)
+		return
+	}
+	etagMu.Lock()
+	defer etagMu.Unlock()
+	if _, exists := etagCache[key]; !exists && len(etagCache) >= etagCacheMaxEntries {
+		evictOldestETagLocked()
+	}
+	etagCache[key] = &etagEntry{etag: etag, body: body, lastUsed: time.Now()}
+}
+
+func etagDrop(key string) {
+	etagMu.Lock()
+	defer etagMu.Unlock()
+	delete(etagCache, key)
+}
+
+func evictOldestETagLocked() {
+	var oldestKey string
+	var oldest time.Time
+	for k, e := range etagCache {
+		if oldestKey == "" || e.lastUsed.Before(oldest) {
+			oldestKey, oldest = k, e.lastUsed
+		}
+	}
+	if oldestKey != "" {
+		delete(etagCache, oldestKey)
+	}
+}
+
+// ghConditionalEligible reports whether a gh api call can carry conditional
+// request headers. Plain GETs — no extra args, or --paginate only (whose
+// single-page response is by far the common case here; multi-page responses
+// are detected and simply not cached) — are eligible. rate_limit is excluded:
+// its body changes on every read, so a conditional fetch would never hit.
+func ghConditionalEligible(endpoint string, args []string) bool {
+	if endpoint == "rate_limit" {
+		return false
+	}
+	for _, a := range args {
+		if a != "--paginate" {
+			return false
+		}
+	}
+	return true
+}
+
+// ghHTTPStatusLine matches the status line gh prints at the start of each
+// header block under --include, anchored at line start. It cannot collide with
+// response content: GitHub's JSON escapes control characters inside strings,
+// so a raw newline followed by "HTTP/" only ever comes from gh itself.
+var ghHTTPStatusLine = regexp.MustCompile(`(?m)^HTTP/[0-9.]+ (\d{3})`)
+
+// ghHTTPResponse is a parsed `gh api --include` exchange. With --paginate gh
+// prints one header block per page; body is every page's body concatenated
+// (the same shape a plain --paginate call yields) while status/etag describe
+// the FIRST block.
+type ghHTTPResponse struct {
+	status int
+	etag   string
+	body   []byte
+	blocks int
+	allOK  bool // every block's status was 2xx
+}
+
+// parseGHConditionalResponse splits combined --include output into status,
+// ETag, and body. ok=false when out does not start with a header block (e.g.
+// gh did not honor --include, or the output is only an error message); the
+// caller should then treat out as a plain body / error text.
+func parseGHConditionalResponse(out []byte) (ghHTTPResponse, bool) {
+	locs := ghHTTPStatusLine.FindAllSubmatchIndex(out, -1)
+	if len(locs) == 0 || locs[0][0] != 0 {
+		return ghHTTPResponse{}, false
+	}
+	resp := ghHTTPResponse{blocks: len(locs), allOK: true}
+	var body []byte
+	for i, loc := range locs {
+		status, convErr := strconv.Atoi(string(out[loc[2]:loc[3]]))
+		if convErr != nil {
+			return ghHTTPResponse{}, false
+		}
+		blockEnd := len(out)
+		if i+1 < len(locs) {
+			blockEnd = locs[i+1][0]
+		}
+		headers, blockBody := splitHeadersAndBody(out[loc[0]:blockEnd])
+		if i == 0 {
+			resp.status = status
+			resp.etag = headerValue(headers, "etag")
+		}
+		if status < 200 || status > 299 {
+			resp.allOK = false
+		}
+		body = append(body, blockBody...)
+	}
+	resp.body = body
+	return resp, true
+}
+
+// splitHeadersAndBody splits one header block from its body at the first blank
+// line. A block with no blank line (e.g. a bodyless 304) is all headers.
+func splitHeadersAndBody(block []byte) (headers, body []byte) {
+	for _, sep := range [][]byte{[]byte("\r\n\r\n"), []byte("\n\n")} {
+		if idx := bytes.Index(block, sep); idx >= 0 {
+			return block[:idx], block[idx+len(sep):]
+		}
+	}
+	return block, nil
+}
+
+func headerValue(headers []byte, name string) string {
+	for _, line := range strings.Split(string(headers), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if k, v, ok := strings.Cut(line, ":"); ok && strings.EqualFold(strings.TrimSpace(k), name) {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// resolveConditional interprets a --include exchange for a conditional GET.
+// served=true means GitHub answered 304 Not Modified and body is the cached
+// copy — the request consumed no quota. resolved=false means the exchange did
+// not yield a trustworthy body: with runErr != nil the caller falls through to
+// normal rate-limit/error handling; with runErr == nil (an inconsistent
+// conditional shape, e.g. a paginated response embedding a non-2xx page) the
+// caller must drop the cache entry and refetch plain.
+func resolveConditional(endpoint string, out []byte, runErr error, cachedBody []byte) (body []byte, served bool, resolved bool) {
+	resp, ok := parseGHConditionalResponse(out)
+	if !ok {
+		// No header block. Trust a successful run's output as the plain body
+		// (gh ignored --include); a 304 whose headers were swallowed still
+		// shows up in gh's error text and is safely served from cache.
+		if runErr == nil {
+			return out, false, true
+		}
+		if cachedBody != nil && strings.Contains(string(out), "HTTP 304") {
+			return cachedBody, true, true
+		}
+		return nil, false, false
+	}
+	if resp.status == 304 && cachedBody != nil {
+		return cachedBody, true, true
+	}
+	if runErr == nil && resp.allOK {
+		if resp.blocks == 1 {
+			etagStore(endpoint, resp.etag, resp.body)
+		} else {
+			// A multi-page response cannot be cached: the first page's ETag
+			// does not validate the concatenated whole.
+			etagDrop(endpoint)
+		}
+		return resp.body, false, true
+	}
+	return nil, false, false
+}
+
+// ghConditionalErrorDetail returns the body portion of a --include response so
+// error logs surface GitHub's message rather than a screenful of headers; out
+// is returned unchanged when it carries no header block.
+func ghConditionalErrorDetail(out []byte) []byte {
+	if resp, ok := parseGHConditionalResponse(out); ok {
+		return resp.body
+	}
+	return out
+}
+
 func ghAPIWithArgs(endpoint string, args ...string) ([]byte, error) {
+	conditional := ghConditionalEligible(endpoint, args)
 	cmdArgs := append([]string{"api", endpoint}, args...)
+	var cachedBody []byte
+	if conditional {
+		var cachedETag string
+		cachedETag, cachedBody = etagLookup(endpoint)
+		cmdArgs = append(cmdArgs, "--include")
+		if cachedETag != "" {
+			cmdArgs = append(cmdArgs, "-H", "If-None-Match: "+cachedETag)
+		}
+	}
 	var out []byte
 	var err error
+	anomaly := false
 	for attempt := 0; attempt < ghAPIMaxAttempts; attempt++ {
+		anomaly = false
 		out, err = ghAPIRunner(cmdArgs...)
-		if err == nil {
+		if conditional {
+			body, served, resolved := resolveConditional(endpoint, out, err, cachedBody)
+			if resolved {
+				noteAPIRequest(served, false)
+				return body, nil
+			}
+		} else if err == nil {
+			noteAPIRequest(false, false)
 			return out, nil
 		}
+		if err == nil {
+			// A conditional exchange in a shape we refuse to trust: drop the
+			// cache entry and refetch plain so behavior matches the
+			// unconditional path.
+			anomaly = true
+			noteAPIRequest(false, false)
+			etagDrop(endpoint)
+			conditional = false
+			cachedBody = nil
+			cmdArgs = append([]string{"api", endpoint}, args...)
+			continue
+		}
 		retryAfter, rateLimited := parseGHRateLimit(out)
+		noteAPIRequest(false, rateLimited)
 		if !rateLimited || attempt == ghAPIMaxAttempts-1 {
+			break
+		}
+		// #797: once shutdown has begun a rate-limited read fails fast — the
+		// backoff loop was observed stretching a 0-worker drain past 20
+		// minutes. The post-sleep check catches a shutdown that began while
+		// the (interruptible) backoff was already sleeping.
+		if ShuttingDown() {
+			log.Printf("[github] gh api %s: rate-limited during shutdown (%s); failing fast without retry",
+				endpoint, ghErrorDetail(ghConditionalErrorDetail(out)))
 			break
 		}
 		wait := retryAfter
@@ -235,16 +559,83 @@ func ghAPIWithArgs(endpoint string, args ...string) ([]byte, error) {
 			wait = ghBackoffDelay(attempt)
 		}
 		log.Printf("[github] gh api %s: rate-limited (%s); backing off %s before retry %d/%d",
-			endpoint, ghErrorDetail(out), wait.Round(time.Millisecond), attempt+1, ghAPIMaxAttempts-1)
+			endpoint, ghErrorDetail(ghConditionalErrorDetail(out)), wait.Round(time.Millisecond), attempt+1, ghAPIMaxAttempts-1)
 		ghAPISleep(wait)
+		if ShuttingDown() {
+			break
+		}
 	}
 	if err != nil {
-		if detail := ghErrorDetail(out); detail != "" {
+		if detail := ghErrorDetail(ghConditionalErrorDetail(out)); detail != "" {
 			return nil, fmt.Errorf("gh api %s: %w: %s", endpoint, err, detail)
 		}
 		return nil, fmt.Errorf("gh api %s: %w", endpoint, err)
 	}
+	if anomaly {
+		return nil, fmt.Errorf("gh api %s: inconsistent conditional response", endpoint)
+	}
 	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// REST usage accounting (#797). The acceptance criterion asks for measured
+// calls/hour before/after via a counter in the gh wrapper: every exchange is
+// counted here and a one-line digest lands in the journal every hour, so an
+// operator can read consumption straight from journalctl and cross-check it
+// against `gh api rate_limit`.
+// ---------------------------------------------------------------------------
+
+// APIStats counts gh REST exchanges. Requests-NotModified approximates what
+// was billed against the core quota (a 304 is free). A --paginate call counts
+// once even when gh fetched several pages, so the digest is a lower bound.
+type APIStats struct {
+	Requests    int64
+	NotModified int64
+	RateLimited int64
+}
+
+// apiUsageLogEvery is how often the wrapper writes the one-line usage digest.
+const apiUsageLogEvery = time.Hour
+
+var (
+	apiStatsMu     sync.Mutex
+	apiStatsTotal  APIStats
+	apiStatsWindow APIStats
+	apiWindowStart time.Time
+	apiUsageNow    = time.Now // injectable for tests
+)
+
+func noteAPIRequest(notModified, rateLimited bool) {
+	apiStatsMu.Lock()
+	defer apiStatsMu.Unlock()
+	now := apiUsageNow()
+	if apiWindowStart.IsZero() {
+		apiWindowStart = now
+	}
+	for _, s := range []*APIStats{&apiStatsTotal, &apiStatsWindow} {
+		s.Requests++
+		if notModified {
+			s.NotModified++
+		}
+		if rateLimited {
+			s.RateLimited++
+		}
+	}
+	if elapsed := now.Sub(apiWindowStart); elapsed >= apiUsageLogEvery {
+		w := apiStatsWindow
+		log.Printf("[github] REST usage last %s: %d requests, ~%d billed against core quota, %d served free by 304, %d rate-limited",
+			elapsed.Round(time.Minute), w.Requests, w.Requests-w.NotModified, w.NotModified, w.RateLimited)
+		apiStatsWindow = APIStats{}
+		apiWindowStart = now
+	}
+}
+
+// APIUsage returns the process-lifetime REST exchange counters, the same
+// numbers the hourly journal digest reports per window.
+func APIUsage() APIStats {
+	apiStatsMu.Lock()
+	defer apiStatsMu.Unlock()
+	return apiStatsTotal
 }
 
 // parseGHRateLimit reports whether gh's combined output looks like a primary or
@@ -1150,9 +1541,9 @@ func (c *Client) PRHighSeverityReviewOnHead(prNumber int) (sha string, findings 
 }
 
 func (c *Client) greptileReviewComments(prNumber int) ([]greptileReviewComment, error) {
-	out, err := exec.Command("gh", "api",
-		fmt.Sprintf("repos/%s/pulls/%d/comments", c.Repo, prNumber),
-		"--paginate").Output()
+	// Routed through the shared wrapper (#797) so this per-cycle read gets the
+	// rate-limit backoff, the conditional-request cache, and usage accounting.
+	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
 		return nil, err
 	}
@@ -1768,11 +2159,10 @@ var reviewLocationPattern = regexp.MustCompile(`(?mi)(^|\s)([A-Za-z0-9_./-]+\.[A
 
 // CollectReviewFeedback collects actionable inline review comments from Greptile and Codex on a PR.
 func (c *Client) CollectReviewFeedback(prNumber int) ([]ReviewComment, error) {
-	// Get HEAD SHA — only return comments on the latest commit
-	prOut, _ := exec.Command("gh", "api",
-		fmt.Sprintf("repos/%s/pulls/%d", c.Repo, prNumber),
-		"--jq", ".head.sha").Output()
-	headSHA := strings.TrimSpace(string(prOut))
+	// Get HEAD SHA — only return comments on the latest commit. Errors are
+	// tolerated (empty SHA matches all comments, as before); the shared
+	// wrapper (#797) gives the read backoff + conditional caching.
+	headSHA, _ := c.pullHeadSHA(prNumber)
 
 	comments, err := c.greptileReviewComments(prNumber)
 	if err != nil {
@@ -2210,10 +2600,9 @@ func (c *Client) CIFailureSummary(prNumber int) (string, error) {
 func (c *Client) CollectPRReviewFeedback(prNumber int) (string, error) {
 	var sections []string
 
-	// 1. Fetch issue-level comments (Greptile summary with confidence score)
-	issueCommentsOut, err := exec.Command("gh", "api",
-		fmt.Sprintf("repos/%s/issues/%d/comments", c.Repo, prNumber),
-		"--paginate").Output()
+	// 1. Fetch issue-level comments (Greptile summary with confidence score),
+	// via the shared wrapper (#797) for backoff + conditional caching.
+	issueCommentsOut, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
 	if err == nil {
 		var comments []struct {
 			Body string `json:"body"`


### PR DESCRIPTION
Implements #797 (code side; runtime measurement still needs operator verification — see below).

## Changes

- **Conditional (ETag/If-None-Match) polling** in the gh wrapper (`internal/github`): every eligible GET remembers the endpoint's last ETag + body and replays with `If-None-Match`. GitHub answers unchanged content `304 Not Modified` without consuming the hourly REST quota, and the wrapper serves the cached copy. A 304 is GitHub's own guarantee that a 200 would have returned identical content, so merge-gating correctness is unchanged. `--paginate` reads are conditional too; multi-page responses are detected and simply not cached.
- **REST usage counter + hourly journal digest** (`[github] REST usage last …: N requests, ~M billed against core quota, K served free by 304, R rate-limited`) plus an exported `APIUsage()` snapshot, so calls/hour can be read straight from journalctl and cross-checked against the rate_limit endpoint.
- **Shutdown fail-fast**: `github.BeginShutdown()` — called at the start of `Daemon.Drain` and `stopAll` — skips rate-limit retries and cuts short an in-flight backoff sleep, so a rate-limited window during drain degrades to failed cycles instead of blocking daemon stop.
- Routed the remaining raw `gh api` reads (PR review comments, issue-level comments, head-SHA lookup) through the shared wrapper so they get backoff, conditional caching, and accounting.
- Runbook: `docs/github-rest-quota-runbook.md` documents how to measure before/after consumption.

## Testing

- Unit tests: conditional 200→304 flow (header capture, cached serve, free-request accounting), header-less 304 fallback, cache refresh on change, multi-page `--paginate` concat + no-cache, shutdown fail-fast (no retries, interrupted backoff), usage-counter window rollover, response parsing.
- `gofmt`, `go test ./...` (all 23 packages pass), `go build ./cmd/maestro/`, and the pipeline verify script all green.
- Validated assumptions against the real gh CLI: `--include` prints `HTTP/2.0 <status>` + CRLF headers + blank line + body per page, and an `If-None-Match` replay of unchanged content exits 1 with a bodyless 304 header block.

## Still requires runtime verification (do not auto-close)

- Measured REST calls/hour for the 9-flow daemon before/after, via the new hourly journal digest and `gh api rate_limit` (`core.used` under 50% of the window at steady state).
- Observing that a drain during a rate-limited window now completes promptly.

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces GitHub REST quota pressure for the daemon. The main changes are:

- Adds ETag-based conditional GET handling in the shared GitHub wrapper.
- Serves cached response bodies for `304 Not Modified` responses and tracks REST usage counters.
- Makes GitHub rate-limit retries fail fast once daemon drain or teardown begins.
- Routes remaining PR review, issue comment, and head-SHA reads through the shared wrapper.
- Adds tests for conditional caching, pagination cache safety, shutdown behavior, usage rollover, and response parsing.
- Adds a runbook for measuring GitHub REST quota usage and shutdown behavior.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge with low risk.

The changed paths are well-scoped to the GitHub wrapper and daemon shutdown behavior. Tests cover the main ETag, pagination, accounting, and shutdown cases. No verified issues were found in the changed code.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Baseline gh api calls were observed without --include or If-None-Match across eligible scenarios.
- After the corresponding artifact, eligible GET/paginated-safe calls used --include and later calls used If-None-Match, with 304 responses returning cached bodies and 200 responses reflecting updated bodies; paginated and multi-page cases avoided additional conditional headers; rate\_limit and -X POST remained ineligible.
- APIUsage was undefined before rollover, and after rollover it reported APIUsage before: requests=6 notModified=1 rateLimited=4 and APIUsage after: requests=7 notModified=1 rateLimited=4, with the exact digest line resting in the artifact.
- The shutdown fail-fast test run was captured with a before artifact logging the base command, cwd, exit code, retry logs, attempts/sleeps/elapsed, and BeginShutdown grep result, and an after artifact recording the head test command, cwd, exit code, fail-fast/interrupted-sleep logs, attempts/sleeps/elapsed/shuttingDown flag, and daemon BeginShutdown hook grep result.
- The routed reads probe tests executed, showing base gh api calls and, after the change, wrapper calls to api repos/... with per\_page and include parameters, along with an APIUsage summary showing requests=6 notModified=0 rateLimited=0.
- Documentation and implementation contract checks were evaluated, with runbook\_exists absent on base and both checks passing on head; the script source artifact captures the exact checks and exit code.

<a href="https://app.greptile.com/trex/runs/13140004/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds ETag-based conditional GET handling, usage accounting, shutdown fail-fast retry behavior, and routes review/comment reads through the shared wrapper; no issues found. |
| internal/github/conditional_test.go | Adds focused tests for conditional caching, pagination cache safety, shutdown retry behavior, usage rollover, and response parsing; no issues found. |
| internal/daemon/daemon.go | Calls `github.BeginShutdown()` at the start of drain so rate-limit backoff fails fast during graceful shutdown; no issues found. |
| internal/daemon/flow.go | Calls `github.BeginShutdown()` during full teardown paths where drain did not run; no issues found. |
| docs/github-rest-quota-runbook.md | Adds operational guidance for measuring GitHub REST quota usage, interpreting wrapper counters, and handling shutdown during rate limits; no issues found. |

<sub>Reviews (2): Last reviewed commit: ["fix(github): address PR #798 review find..."](https://github.com/befeast/maestro/commit/72c2e770e8c245f11bc30791f065e40cd97a0407) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41528141)</sub>

<!-- /greptile_comment -->