### PR TITLE
fix: auto-created PR bodies leak orchestration internals (Maestro-Backend, pid, tmux session) (#799)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,13 @@ from the repo root) working in the maestro repository.
   > document records the convention; an operator still has to set that flag for
   > the trailer to actually disappear.
 
-- **Do preserve the `Maestro-Backend:` trailer.** maestro stamps it on commits
-  and PR bodies (`internal/state/attribution.go`,
+- **Do preserve the `Maestro-Backend:` trailer on commits.** maestro stamps it
+  on commit messages (`internal/state/attribution.go`,
   `state.AttributionTrailerKey`) to record the backend timeline for a session.
   It is the canonical, queryable attribution for this repo — never strip,
-  rewrite, or duplicate it.
+  rewrite, or duplicate it. It goes on commits only: PR bodies must contain no
+  backend/model attribution, pids, tmux session names, or host-side paths,
+  because they land on target repos that may be public (#799).
 
 - **Do NOT use GitHub auto-closing keywords** (`Closes`, `Fixes`, `Resolves`,
   and their variants) followed by an issue reference in commit messages, PR

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -53,7 +53,6 @@ type Orchestrator struct {
 	listOpenPRsFn         func() ([]github.PR, error)
 	remoteBranchExistsFn  func(branch string) (bool, error)
 	createPRFn            func(title, body, base, head string) (int, error)
-	updatePRBodyFn        func(prNumber int, body string) error
 	amendHeadFn           func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error
 	hasOpenPRForIssueFn   func(issueNumber int) (bool, error)
 	hasMergedPRForIssueFn func(issueNumber int) (bool, error)
@@ -290,16 +289,6 @@ func (o *Orchestrator) createPR(title, body, base, head string) (int, error) {
 		o.invalidateCyclePRs()
 	}
 	return prNumber, err
-}
-
-func (o *Orchestrator) updatePRBody(prNumber int, body string) error {
-	if o.updatePRBodyFn != nil {
-		return o.updatePRBodyFn(prNumber, body)
-	}
-	if o.gh == nil {
-		return fmt.Errorf("no github client configured for PR body update")
-	}
-	return o.gh.UpdatePRBody(prNumber, body)
 }
 
 func (o *Orchestrator) hasOpenPRForIssue(issueNumber int) (bool, error) {
@@ -2261,7 +2250,6 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		// IssueInProgress to return false and startNewWorkers to spawn a duplicate.
 		if pr, found := branchToPR[sess.Branch]; found {
 			o.updateTokensUsedFromWorkerLog(slotName, sess)
-			o.ensureAttributionTrailerOnPR(slotName, sess, pr)
 			o.ensureAttributionTrailerOnBranch(slotName, sess)
 			log.Printf("[orch] reconcile: %s running->pr_open (PR #%d already open for branch %q; %s)",
 				slotName, pr.Number, sess.Branch, strings.Join(reasons, ", "))
@@ -2277,7 +2265,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 			continue
 		}
 		if prErr == nil {
-			if prNumber, ok := o.tryCreatePRForPushedBranch(slotName, sess, reasons); ok {
+			if prNumber, ok := o.tryCreatePRForPushedBranch(slotName, sess); ok {
 				log.Printf("[orch] reconcile: %s running->pr_open (auto-created PR #%d for pushed branch %q; %s)",
 					slotName, prNumber, sess.Branch, strings.Join(reasons, ", "))
 				reconciled = true
@@ -2469,7 +2457,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 	return reconciled
 }
 
-func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.Session, reasons []string) (int, bool) {
+func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.Session) (int, bool) {
 	branch := strings.TrimSpace(sess.Branch)
 	if branch == "" {
 		return 0, false
@@ -2485,7 +2473,7 @@ func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.S
 
 	title := autoCreatedPRTitle(sess)
 	o.ensureAttributionTrailerOnBranch(slotName, sess)
-	body := state.AppendAttributionTrailer(autoCreatedPRBody(sess, branch, reasons), sess.Attribution, time.Now().UTC())
+	body := autoCreatedPRBody(sess, branch)
 	prNumber, err := o.createPR(title, body, "main", branch)
 	if err != nil {
 		log.Printf("[orch] reconcile: could not auto-create PR for %s branch %q: %v", slotName, branch, err)
@@ -2523,30 +2511,16 @@ func autoCreatedPRTitle(sess *state.Session) string {
 	return title
 }
 
-func autoCreatedPRBody(sess *state.Session, branch string, reasons []string) string {
-	reasonText := strings.TrimSpace(strings.Join(reasons, ", "))
-	if reasonText == "" {
-		reasonText = "worker process exited before PR creation was observed"
-	}
+// autoCreatedPRBody renders the public PR body for the reconcile auto-create
+// path: issue ref, branch, and a neutral one-liner only. Backend attribution,
+// pids, tmux session names, and host paths must never appear here — the PR
+// body lands on the target repo, which may be public (#799). Observed-worker-
+// state diagnostics stay in the orchestrator log at the call site.
+func autoCreatedPRBody(sess *state.Session, branch string) string {
 	return fmt.Sprintf(`Refs #%d
 
-Maestro auto-created this PR because the worker pushed branch %s but exited before opening a pull request.
-
-Observed worker state: %s.
-`, sess.IssueNumber, branch, reasonText)
-}
-
-func (o *Orchestrator) ensureAttributionTrailerOnPR(slotName string, sess *state.Session, pr github.PR) {
-	if sess == nil || len(sess.Attribution) == 0 {
-		return
-	}
-	body := state.AppendAttributionTrailer(pr.Body, sess.Attribution, time.Now().UTC())
-	if body == pr.Body {
-		return
-	}
-	if err := o.updatePRBody(pr.Number, body); err != nil {
-		log.Printf("[orch] attribution: could not update PR #%d body for %s: %v", pr.Number, slotName, err)
-	}
+Maestro auto-created this pull request for pushed branch %s because no open pull request was found for it.
+`, sess.IssueNumber, branch)
 }
 
 func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *state.Session) {
@@ -2649,7 +2623,6 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					if sess.Status == state.StatusDead && sess.NextRetryAt != nil {
 						continue
 					}
-					o.ensureAttributionTrailerOnPR(slotName, sess, pr)
 					o.ensureAttributionTrailerOnBranch(slotName, sess)
 					log.Printf("[orch] session %s %s->pr_open (PR #%d now open for branch %q)", slotName, sess.Status, pr.Number, sess.Branch)
 					sess.Status = state.StatusPROpen
@@ -2770,7 +2743,6 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				// Check if there's an open PR for this branch BEFORE marking dead
 				if pr, found := branchToPR[sess.Branch]; found {
 					o.updateTokensUsedFromWorkerLog(slotName, sess)
-					o.ensureAttributionTrailerOnPR(slotName, sess, pr)
 					o.ensureAttributionTrailerOnBranch(slotName, sess)
 					log.Printf("[orch] worker %s exited but PR #%d is open — transitioning to pr_open", slotName, pr.Number)
 					sess.Status = state.StatusPROpen
@@ -3232,7 +3204,6 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		if sess.PRNumber == 0 {
 			sess.PRNumber = pr.Number
 		}
-		o.ensureAttributionTrailerOnPR(slotName, sess, pr)
 		o.ensureAttributionTrailerOnBranch(slotName, sess)
 
 		// #705: opt-in visual evidence for UI-affecting PRs. One-shot,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -401,10 +401,19 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 	if !strings.Contains(gotBody, "Refs #108") || strings.Contains(gotBody, "Closes #108") || !strings.Contains(gotBody, "auto-created") {
 		t.Fatalf("unexpected body %q", gotBody)
 	}
-	if !strings.Contains(gotBody, "Maestro-Backend: codex openai gpt-5.5 medium") ||
-		!strings.Contains(gotBody, "; claude anthropic opus-4.8 xhigh") ||
-		!strings.Contains(gotBody, "fallover") {
-		t.Fatalf("body missing attribution trailer: %q", gotBody)
+	if !strings.Contains(gotBody, "feat/mae-8-108-add-branch-rescue") {
+		t.Fatalf("body missing branch name: %q", gotBody)
+	}
+	// The PR body lands on the target repo, which may be public: no backend
+	// attribution, pids, tmux session names, or host-side paths (#799).
+	for _, leak := range []string{
+		"Maestro-Backend", "pid", "tmux", "state_dir",
+		"codex", "openai", "gpt-5.5", "claude", "anthropic", "opus-4.8",
+		"8080", "/tmp/mae-8",
+	} {
+		if strings.Contains(gotBody, leak) {
+			t.Fatalf("PR body leaks orchestration internals (%q): %q", leak, gotBody)
+		}
 	}
 	if amendedWorktree != "/tmp/mae-8" || amendedBranch != "feat/mae-8-108-add-branch-rescue" {
 		t.Fatalf("amend target = %q/%q", amendedWorktree, amendedBranch)
@@ -417,7 +426,9 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 	}
 }
 
-func TestReconcileRunningSessions_OpenPR_AppendsAttributionTrailer(t *testing.T) {
+// The Maestro-Backend attribution trailer stays on commits only; PR bodies on
+// the (possibly public) target repo must not be rewritten to carry it (#799).
+func TestReconcileRunningSessions_OpenPR_AmendsCommitOnly_LeavesPRBodyAlone(t *testing.T) {
 	s := state.NewState()
 	t0 := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
 	s.Sessions["mae-9"] = &state.Session{
@@ -437,8 +448,6 @@ func TestReconcileRunningSessions_OpenPR_AppendsAttributionTrailer(t *testing.T)
 		}},
 	}
 
-	var updatedPR int
-	var updatedBody string
 	var amended bool
 	o := &Orchestrator{
 		pidAliveFn:          func(pid int) bool { return false },
@@ -450,11 +459,6 @@ func TestReconcileRunningSessions_OpenPR_AppendsAttributionTrailer(t *testing.T)
 				Body:        "Refs #109\n",
 			}}, nil
 		},
-		updatePRBodyFn: func(prNumber int, body string) error {
-			updatedPR = prNumber
-			updatedBody = body
-			return nil
-		},
 		amendHeadFn: func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
 			amended = true
 			return nil
@@ -465,14 +469,37 @@ func TestReconcileRunningSessions_OpenPR_AppendsAttributionTrailer(t *testing.T)
 	if !changed {
 		t.Fatal("expected reconciliation to report changes")
 	}
-	if updatedPR != 145 {
-		t.Fatalf("updated PR = %d, want 145", updatedPR)
+	sess := s.Sessions["mae-9"]
+	if sess.Status != state.StatusPROpen {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusPROpen)
 	}
-	if !strings.Contains(updatedBody, "Maestro-Backend: codex openai gpt-5.5 medium") {
-		t.Fatalf("updated body missing attribution trailer: %q", updatedBody)
+	if sess.PRNumber != 145 {
+		t.Fatalf("pr_number = %d, want 145", sess.PRNumber)
 	}
 	if !amended {
 		t.Fatal("expected branch head amend hook")
+	}
+}
+
+func TestAutoCreatedPRBody_NoOrchestrationInternals(t *testing.T) {
+	sess := &state.Session{
+		IssueNumber: 799,
+		IssueTitle:  "sanitize auto-created PR bodies",
+		PID:         4242,
+		TmuxSession: "maestro-mae-1",
+		Worktree:    "/home/god/worktrees/example/mae-1",
+	}
+	body := autoCreatedPRBody(sess, "feat/mae-1-799-sanitize")
+	if !strings.Contains(body, "Refs #799") {
+		t.Fatalf("body missing issue ref: %q", body)
+	}
+	if !strings.Contains(body, "feat/mae-1-799-sanitize") {
+		t.Fatalf("body missing branch name: %q", body)
+	}
+	for _, leak := range []string{"Maestro-Backend", "pid", "tmux", "state_dir", "4242", "maestro-mae-1", "/home/god"} {
+		if strings.Contains(body, leak) {
+			t.Fatalf("PR body leaks orchestration internals (%q): %q", leak, body)
+		}
 	}
 }
 

--- a/internal/state/attribution.go
+++ b/internal/state/attribution.go
@@ -8,9 +8,11 @@ import (
 
 const AttributionTrailerKey = "Maestro-Backend"
 
-// FormatAttributionTrailer renders the durable git/PR trailer for a session's
-// backend timeline. It uses relative ranges from the first segment so the line
-// remains stable and queryable after the live state file is gone.
+// FormatAttributionTrailer renders the durable git commit trailer for a
+// session's backend timeline. It uses relative ranges from the first segment
+// so the line remains stable and queryable after the live state file is gone.
+// The trailer goes on commit messages only — never on PR bodies, which land on
+// the target repo and may be public (#799).
 func FormatAttributionTrailer(attribution []BackendAttribution, now time.Time) string {
 	timeline := FormatAttributionTimeline(attribution, now)
 	if timeline == "" {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -947,7 +947,7 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 4. Commit your changes with a clear message.
 5. Before committing or opening a PR, check for accidental secrets and generated artifacts. Do NOT commit or mention API keys, bearer tokens, oauth tokens, bot tokens, env values, raw config dumps, or diagnostic logs. Do NOT commit temp/debug artifacts such as tmp/, _tmp/, *.log, *.logs, *.test, or *.test.json unless the issue explicitly requires them.
 6. Keep the PR body minimal and safe. Use: gh pr create --repo %s --title "%s" --body "Refs #%d". Never use closing keywords such as Closes/Fixes/Resolves in PR bodies for Maestro-managed work. Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.
-7. Preserve any Maestro-Backend: attribution trailer that Maestro adds to commit messages or PR bodies.
+7. Preserve any Maestro-Backend: attribution trailer that Maestro adds to commit messages. Do NOT add backend/model attribution, pids, tmux session names, or host paths to PR bodies.
 8. After creating the PR, you are done. Do NOT merge it yourself.
 
 Important: Always run cargo fmt --all before committing if this is a Rust project.


### PR DESCRIPTION
Implements #799

## Changes
- `autoCreatedPRBody` (reconcile auto-create path) now renders the issue ref, branch, and a neutral one-liner only — observed-worker-state diagnostics (pid, tmux session) stay in the orchestrator log at the call site.
- The `Maestro-Backend` attribution trailer is no longer appended to any PR body: removed `ensureAttributionTrailerOnPR` (all four call sites) and the now-dead `updatePRBody` plumbing. Commit-message attribution via `ensureAttributionTrailerOnBranch` is unchanged, so the durable trailer still lands on commits.
- Worker prompt instruction, `FormatAttributionTrailer` doc comment, and CLAUDE.md updated to record the commits-only convention.

## Testing
- `TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR` now leak-greps the generated body for `Maestro-Backend`, pid, tmux, state_dir, backend/model names, and host paths, and still verifies the commit amend carries the attribution.
- New `TestAutoCreatedPRBody_NoOrchestrationInternals` unit test on the body renderer.
- `TestReconcileRunningSessions_OpenPR_AmendsCommitOnly_LeavesPRBodyAlone` replaces the old trailer-append test.
- `gofmt`, `go test ./...`, `go build ./cmd/maestro/` all pass.

Auto-create-on-pushed-branch behavior is otherwise unchanged (same trigger, title, base/head, status transitions).

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps orchestration details out of generated PR bodies. The main changes are:

- Removes `Maestro-Backend` attribution updates from PR body paths.
- Keeps backend attribution on commit messages through branch-head amendments.
- Simplifies auto-created PR bodies to issue ref, branch, and neutral context.
- Updates worker and repo guidance for the commits-only attribution convention.
- Adds tests that check PR bodies do not leak backend, process, tmux, or host-path details.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrow and preserve the commit attribution path while removing PR body leak paths. Tests cover sanitized auto-created PR bodies and existing-PR reconciliation behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the PR before and after head auto-creation, confirming the final PR had Refs #108 in the body, the correct base/main and head branch, an open status, and the Maestro-Backend trailer applied to commit attribution.
- Ran the open PR body preservation tests and observed that updatePRBody was invoked once during the base run, then no updatePRBody calls in the head run, with the final PR body remaining Refs #109.
- Executed the commits-only guidance checks by running the base-ref extraction and the head-ref extraction scripts, each against the requested base and head commits.

<a href="https://app.greptile.com/trex/runs/13142499/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Removes PR-body attribution update plumbing and sanitizes auto-created PR bodies while preserving commit attribution amendments. |
| internal/orchestrator/orchestrator_test.go | Updates reconciliation tests to assert PR bodies do not leak backend/process details and commit amendments still occur. |
| internal/worker/worker.go | Adjusts worker prompt instructions to keep `Maestro-Backend` attribution in commits and avoid internal details in PR bodies. |
| internal/state/attribution.go | Clarifies attribution trailer documentation to identify commit messages as the only intended destination. |
| CLAUDE.md | Updates repository guidance to clarify that `Maestro-Backend` attribution is commit-only and PR bodies must not expose orchestration internals. |

<sub>Reviews (1): Last reviewed commit: ["fix: keep orchestration internals out of..."](https://github.com/befeast/maestro/commit/32e121fe0dfd46a0e0c9c96312dc1a8fca862b41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41535583)</sub>

<!-- /greptile_comment -->