### PR TITLE
Review-feedback/retry session state is not invalidated by merge or issue close (zombie respawns)

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1326,7 +1326,10 @@ func (c *Client) MergedPRNumberForBranch(branch string) (int, error) {
 		return 0, err
 	}
 	for _, pr := range prs {
-		if pr.MergedAt != "" && pr.HeadRefName == branch {
+		// listClosedPRs only returns closed PRs, but require the closed state
+		// on the parsed record too (as IsPRMerged does) so the merged verdict
+		// never depends on the list source.
+		if strings.EqualFold(pr.State, "closed") && pr.MergedAt != "" && pr.HeadRefName == branch {
 			return pr.Number, nil
 		}
 	}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1309,6 +1309,29 @@ func (c *Client) HasMergedPRForIssue(issueNumber int) (bool, error) {
 	return false, nil
 }
 
+// HasMergedPRForBranch returns true if a merged PR used the given branch as
+// its head. After a squash-merge the branch tip is not an ancestor of main,
+// so ancestry cannot prove the content landed — but a merged PR with this
+// head branch can. The reconcile auto-create path consults this so a branch
+// that outlived its squash-merged PR (e.g. an operator merge without branch
+// deletion) does not spawn a duplicate junk PR (#800).
+func (c *Client) HasMergedPRForBranch(branch string) (bool, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return false, nil
+	}
+	prs, err := c.listClosedPRs()
+	if err != nil {
+		return false, err
+	}
+	for _, pr := range prs {
+		if pr.MergedAt != "" && pr.HeadRefName == branch {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // PRCIStatus returns "success", "failure", "pending", or "unknown"
 func (c *Client) PRCIStatus(prNumber int) (string, error) {
 	sha, err := c.pullHeadSHA(prNumber)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1309,27 +1309,28 @@ func (c *Client) HasMergedPRForIssue(issueNumber int) (bool, error) {
 	return false, nil
 }
 
-// HasMergedPRForBranch returns true if a merged PR used the given branch as
-// its head. After a squash-merge the branch tip is not an ancestor of main,
-// so ancestry cannot prove the content landed — but a merged PR with this
-// head branch can. The reconcile auto-create path consults this so a branch
-// that outlived its squash-merged PR (e.g. an operator merge without branch
-// deletion) does not spawn a duplicate junk PR (#800).
-func (c *Client) HasMergedPRForBranch(branch string) (bool, error) {
+// MergedPRNumberForBranch returns the number of a merged PR that used the
+// given branch as its head, or 0 if none exists. After a squash-merge the
+// branch tip is not an ancestor of main, so ancestry cannot prove the content
+// landed — but a merged PR with this head branch can. The reconcile
+// pushed-branch path consults this so a branch that outlived its
+// squash-merged PR (e.g. an operator merge without branch deletion) settles
+// the session as code_landed instead of spawning a duplicate junk PR (#800).
+func (c *Client) MergedPRNumberForBranch(branch string) (int, error) {
 	branch = strings.TrimSpace(branch)
 	if branch == "" {
-		return false, nil
+		return 0, nil
 	}
 	prs, err := c.listClosedPRs()
 	if err != nil {
-		return false, err
+		return 0, err
 	}
 	for _, pr := range prs {
 		if pr.MergedAt != "" && pr.HeadRefName == branch {
-			return true, nil
+			return pr.Number, nil
 		}
 	}
-	return false, nil
+	return 0, nil
 }
 
 // PRCIStatus returns "success", "failure", "pending", or "unknown"

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -39,24 +39,25 @@ const (
 
 // Orchestrator coordinates all agent sessions
 type Orchestrator struct {
-	cfg                   *config.Config
-	notifier              *notify.Notifier
-	gh                    *github.Client
-	router                *router.Router
-	repo                  string
-	binaryVersion         string
-	promptBase            string
-	bugPromptBase         string
-	enhancementPromptBase string
-	pidAliveFn            func(pid int) bool
-	tmuxSessionExistsFn   func(name string) bool
-	listOpenPRsFn         func() ([]github.PR, error)
-	remoteBranchExistsFn  func(branch string) (bool, error)
-	createPRFn            func(title, body, base, head string) (int, error)
-	amendHeadFn           func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error
-	hasOpenPRForIssueFn   func(issueNumber int) (bool, error)
-	hasMergedPRForIssueFn func(issueNumber int) (bool, error)
-	isPRMergedFn          func(prNumber int) (bool, error)
+	cfg                    *config.Config
+	notifier               *notify.Notifier
+	gh                     *github.Client
+	router                 *router.Router
+	repo                   string
+	binaryVersion          string
+	promptBase             string
+	bugPromptBase          string
+	enhancementPromptBase  string
+	pidAliveFn             func(pid int) bool
+	tmuxSessionExistsFn    func(name string) bool
+	listOpenPRsFn          func() ([]github.PR, error)
+	remoteBranchExistsFn   func(branch string) (bool, error)
+	createPRFn             func(title, body, base, head string) (int, error)
+	amendHeadFn            func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error
+	hasOpenPRForIssueFn    func(issueNumber int) (bool, error)
+	hasMergedPRForIssueFn  func(issueNumber int) (bool, error)
+	isPRMergedFn           func(prNumber int) (bool, error)
+	hasMergedPRForBranchFn func(branch string) (bool, error)
 
 	// Testing hooks for checkSessions
 	captureTmuxFn             func(session string) (string, error)
@@ -302,6 +303,9 @@ func (o *Orchestrator) hasMergedPRForIssue(issueNumber int) (bool, error) {
 	if o.hasMergedPRForIssueFn != nil {
 		return o.hasMergedPRForIssueFn(issueNumber)
 	}
+	if o.gh == nil {
+		return false, fmt.Errorf("no github client configured for merged-pr check")
+	}
 	return o.gh.HasMergedPRForIssue(issueNumber)
 }
 
@@ -309,7 +313,20 @@ func (o *Orchestrator) isPRMerged(prNumber int) (bool, error) {
 	if o.isPRMergedFn != nil {
 		return o.isPRMergedFn(prNumber)
 	}
+	if o.gh == nil {
+		return false, fmt.Errorf("no github client configured for pr-merged check")
+	}
 	return o.gh.IsPRMerged(prNumber)
+}
+
+func (o *Orchestrator) hasMergedPRForBranch(branch string) (bool, error) {
+	if o.hasMergedPRForBranchFn != nil {
+		return o.hasMergedPRForBranchFn(branch)
+	}
+	if o.gh == nil {
+		return false, fmt.Errorf("no github client configured for merged-branch check")
+	}
+	return o.gh.HasMergedPRForBranch(branch)
 }
 
 // SetBinaryVersion records the running binary's resolved version (e.g.
@@ -1531,6 +1548,14 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 			continue
 		}
 
+		// #800: the saved retry state can outlive the work it was scheduled
+		// for — the PR may have merged or the issue closed while the backoff
+		// ran. Re-check GitHub before consuming a slot; a stale session
+		// settles instead of respawning a zombie worker.
+		if o.retireStaleRetry(slotName, sess) {
+			continue
+		}
+
 		// Backoff elapsed — respawn the worker
 		log.Printf("[orch] worker %s backoff elapsed, respawning (retry %d)", slotName, sess.RetryCount)
 		sess.NextRetryAt = nil
@@ -1612,6 +1637,60 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 			slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount)
 		respawned++
 	}
+}
+
+// retireStaleRetry re-checks issue and PR state on GitHub for a dead session
+// whose retry backoff has elapsed (#800). Merge of the session's PR — the one
+// still recorded on the session or the one the CI-retry path closed and an
+// operator later reopened and merged — or closing of its issue invalidates
+// the pending retry: the work is settled, and respawning would burn a worker
+// run on a closed issue and let reconcile auto-create a junk PR from the
+// already-squash-merged branch. Stale sessions transition to code_landed
+// (merged PR, so the normal post-merge reconcile converges them to done) or
+// done (issue closed) instead of respawning. Best-effort: a GitHub read
+// error fails open — the retry proceeds — so a transient API hiccup cannot
+// strand a legitimate retry.
+func (o *Orchestrator) retireStaleRetry(slotName string, sess *state.Session) bool {
+	for _, prNumber := range []int{sess.PRNumber, sess.LastClosedPRNumber} {
+		if prNumber <= 0 {
+			continue
+		}
+		merged, err := o.isPRMerged(prNumber)
+		if err != nil {
+			log.Printf("[orch] retry staleness check for %s could not read PR #%d: %v — proceeding with retry", slotName, prNumber, err)
+			continue
+		}
+		if !merged {
+			continue
+		}
+		log.Printf("[orch] worker %s retry invalidated: PR #%d for issue #%d is merged — marking code_landed instead of respawning", slotName, prNumber, sess.IssueNumber)
+		sess.NextRetryAt = nil
+		o.markCodeLanded(sess, prNumber)
+		if o.notifier != nil {
+			o.notifier.Sendf("🧟 maestro: cancelled scheduled retry for issue #%d (%s) — PR #%d already merged", sess.IssueNumber, sess.IssueTitle, prNumber)
+		}
+		return true
+	}
+
+	closed, err := o.isIssueClosed(sess.IssueNumber)
+	if err != nil {
+		log.Printf("[orch] retry staleness check for %s could not read issue #%d: %v — proceeding with retry", slotName, sess.IssueNumber, err)
+		return false
+	}
+	if !closed {
+		return false
+	}
+	log.Printf("[orch] worker %s retry invalidated: issue #%d is closed — marking done instead of respawning", slotName, sess.IssueNumber)
+	sess.NextRetryAt = nil
+	sess.Status = state.StatusDone
+	now := time.Now().UTC()
+	sess.FinishedAt = &now
+	state.MarkWorkerEnded(sess, now)
+	o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
+	if o.notifier != nil {
+		o.notifier.Sendf("🧟 maestro: cancelled scheduled retry for issue #%d (%s) — issue already closed", sess.IssueNumber, sess.IssueTitle)
+	}
+	return true
 }
 
 // LoadPromptBase reads the worker prompt template from config or a provided path.
@@ -2468,6 +2547,25 @@ func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.S
 		return 0, false
 	}
 	if !exists {
+		return 0, false
+	}
+
+	// #800: a branch can outlive its squash-merged PR (an operator merge
+	// without branch deletion leaves the tip un-ancestored but the content
+	// landed). Auto-creating a PR from it produces a junk PR that only exists
+	// to be closed. Skip when a merged PR already used this head branch or
+	// the issue is settled; a GitHub read error fails open so the rescue path
+	// keeps working through transient API hiccups.
+	if merged, mergeErr := o.hasMergedPRForBranch(branch); mergeErr != nil {
+		log.Printf("[orch] reconcile: could not check merged PRs for branch %q (%s): %v — proceeding with auto-create", branch, slotName, mergeErr)
+	} else if merged {
+		log.Printf("[orch] reconcile: not auto-creating PR for %s — branch %q already merged via an earlier PR", slotName, branch)
+		return 0, false
+	}
+	if closed, closedErr := o.isIssueClosed(sess.IssueNumber); closedErr != nil {
+		log.Printf("[orch] reconcile: could not check issue #%d state for %s: %v — proceeding with auto-create", sess.IssueNumber, slotName, closedErr)
+	} else if closed {
+		log.Printf("[orch] reconcile: not auto-creating PR for %s — issue #%d is closed", slotName, sess.IssueNumber)
 		return 0, false
 	}
 
@@ -3644,6 +3742,7 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 			return
 		}
 		log.Printf("[orch] closed PR #%d due to review feedback (worktree unavailable)", pr.Number)
+		sess.LastClosedPRNumber = pr.Number
 		sess.PRNumber = 0
 	} else {
 		log.Printf("[orch] keeping PR #%d open and respawning %s in place to address review feedback", pr.Number, slotName)
@@ -3731,12 +3830,15 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 		sess.PreviousAttemptFeedbackKind = ""
 	}
 
-	// Schedule retry with exponential backoff
+	// Schedule retry with exponential backoff. Remember which PR this retry
+	// closed (#800): if an operator reopens and merges it while the backoff
+	// runs, the pre-respawn staleness check cancels the retry.
 	sess.RetryCount++
 	backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
 	retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
 	sess.NextRetryAt = &retryAt
 	sess.Status = state.StatusDead
+	sess.LastClosedPRNumber = pr.Number
 	sess.PRNumber = 0
 	now := time.Now().UTC()
 	sess.FinishedAt = &now

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -39,25 +39,25 @@ const (
 
 // Orchestrator coordinates all agent sessions
 type Orchestrator struct {
-	cfg                    *config.Config
-	notifier               *notify.Notifier
-	gh                     *github.Client
-	router                 *router.Router
-	repo                   string
-	binaryVersion          string
-	promptBase             string
-	bugPromptBase          string
-	enhancementPromptBase  string
-	pidAliveFn             func(pid int) bool
-	tmuxSessionExistsFn    func(name string) bool
-	listOpenPRsFn          func() ([]github.PR, error)
-	remoteBranchExistsFn   func(branch string) (bool, error)
-	createPRFn             func(title, body, base, head string) (int, error)
-	amendHeadFn            func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error
-	hasOpenPRForIssueFn    func(issueNumber int) (bool, error)
-	hasMergedPRForIssueFn  func(issueNumber int) (bool, error)
-	isPRMergedFn           func(prNumber int) (bool, error)
-	hasMergedPRForBranchFn func(branch string) (bool, error)
+	cfg                   *config.Config
+	notifier              *notify.Notifier
+	gh                    *github.Client
+	router                *router.Router
+	repo                  string
+	binaryVersion         string
+	promptBase            string
+	bugPromptBase         string
+	enhancementPromptBase string
+	pidAliveFn            func(pid int) bool
+	tmuxSessionExistsFn   func(name string) bool
+	listOpenPRsFn         func() ([]github.PR, error)
+	remoteBranchExistsFn  func(branch string) (bool, error)
+	createPRFn            func(title, body, base, head string) (int, error)
+	amendHeadFn           func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error
+	hasOpenPRForIssueFn   func(issueNumber int) (bool, error)
+	hasMergedPRForIssueFn func(issueNumber int) (bool, error)
+	isPRMergedFn          func(prNumber int) (bool, error)
+	mergedPRForBranchFn   func(branch string) (int, error)
 
 	// Testing hooks for checkSessions
 	captureTmuxFn             func(session string) (string, error)
@@ -221,7 +221,7 @@ func (o *Orchestrator) endCycle() {
 // autoMergePRs merging or closing one — would otherwise leave a later step
 // looking at the pre-mutation snapshot. The concrete failure this guards
 // against (#794 review): reconcile auto-creates a PR via
-// tryCreatePRForPushedBranch and flips the session to pr_open, but autoMergePRs
+// reconcilePushedBranch and flips the session to pr_open, but autoMergePRs
 // reuses the cache populated before that PR existed, fails to find it, takes
 // the "no open PR — assuming merged/closed" branch and marks the session done —
 // orphaning a live PR in the same cycle. Invalidating after every open-PR-set
@@ -319,14 +319,14 @@ func (o *Orchestrator) isPRMerged(prNumber int) (bool, error) {
 	return o.gh.IsPRMerged(prNumber)
 }
 
-func (o *Orchestrator) hasMergedPRForBranch(branch string) (bool, error) {
-	if o.hasMergedPRForBranchFn != nil {
-		return o.hasMergedPRForBranchFn(branch)
+func (o *Orchestrator) mergedPRForBranch(branch string) (int, error) {
+	if o.mergedPRForBranchFn != nil {
+		return o.mergedPRForBranchFn(branch)
 	}
 	if o.gh == nil {
-		return false, fmt.Errorf("no github client configured for merged-branch check")
+		return 0, fmt.Errorf("no github client configured for merged-branch check")
 	}
-	return o.gh.HasMergedPRForBranch(branch)
+	return o.gh.MergedPRNumberForBranch(branch)
 }
 
 // SetBinaryVersion records the running binary's resolved version (e.g.
@@ -2344,9 +2344,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 			continue
 		}
 		if prErr == nil {
-			if prNumber, ok := o.tryCreatePRForPushedBranch(slotName, sess); ok {
-				log.Printf("[orch] reconcile: %s running->pr_open (auto-created PR #%d for pushed branch %q; %s)",
-					slotName, prNumber, sess.Branch, strings.Join(reasons, ", "))
+			if o.reconcilePushedBranch(slotName, sess, strings.Join(reasons, ", ")) {
 				reconciled = true
 				continue
 			}
@@ -2536,37 +2534,74 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 	return reconciled
 }
 
-func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.Session) (int, bool) {
+// reconcilePushedBranch handles a stale running session whose worker died
+// after pushing its branch. Outcomes, in order (#800):
+//
+//   - branch already merged via an earlier PR → settle the session as
+//     code_landed. Falling through to dead instead would strand it outside
+//     IssueInProgress: maestro PRs carry no auto-closing keywords, so the
+//     issue is still open and the HasMergedPRForIssue dispatch guard cannot
+//     see a branch-only merge — the next cycle would spawn a fresh worker
+//     for already-landed work.
+//   - issue closed → settle as done (same transition retireStaleRetry uses).
+//   - otherwise → auto-create a PR and flip the session to pr_open, rescuing
+//     the worker's pushed result.
+//
+// Returns true when the session was transitioned; false leaves the caller's
+// dead-marking fall-through in charge. GitHub read errors on the staleness
+// checks fail open — the auto-create rescue proceeds — so a transient API
+// hiccup cannot disable the rescue path.
+func (o *Orchestrator) reconcilePushedBranch(slotName string, sess *state.Session, reasons string) bool {
 	branch := strings.TrimSpace(sess.Branch)
 	if branch == "" {
-		return 0, false
+		return false
 	}
 	exists, err := o.remoteBranchExists(branch)
 	if err != nil {
 		log.Printf("[orch] reconcile: could not check remote branch %q for %s: %v", branch, slotName, err)
-		return 0, false
+		return false
 	}
 	if !exists {
-		return 0, false
+		return false
 	}
 
 	// #800: a branch can outlive its squash-merged PR (an operator merge
 	// without branch deletion leaves the tip un-ancestored but the content
 	// landed). Auto-creating a PR from it produces a junk PR that only exists
-	// to be closed. Skip when a merged PR already used this head branch or
-	// the issue is settled; a GitHub read error fails open so the rescue path
-	// keeps working through transient API hiccups.
-	if merged, mergeErr := o.hasMergedPRForBranch(branch); mergeErr != nil {
+	// to be closed.
+	if mergedPR, mergeErr := o.mergedPRForBranch(branch); mergeErr != nil {
 		log.Printf("[orch] reconcile: could not check merged PRs for branch %q (%s): %v — proceeding with auto-create", branch, slotName, mergeErr)
-	} else if merged {
-		log.Printf("[orch] reconcile: not auto-creating PR for %s — branch %q already merged via an earlier PR", slotName, branch)
-		return 0, false
+	} else if mergedPR > 0 {
+		o.updateTokensUsedFromWorkerLog(slotName, sess)
+		sess.PID = 0
+		sess.TmuxSession = ""
+		o.markCodeLanded(sess, mergedPR)
+		log.Printf("[orch] reconcile: %s running->code_landed (branch %q already merged via PR #%d; %s)",
+			slotName, branch, mergedPR, reasons)
+		if o.notifier != nil {
+			o.notifier.Sendf("🧟 maestro: worker %s (issue #%d: %s) exited, but branch %s already merged via PR #%d — settled as code_landed",
+				slotName, sess.IssueNumber, sess.IssueTitle, branch, mergedPR)
+		}
+		return true
 	}
 	if closed, closedErr := o.isIssueClosed(sess.IssueNumber); closedErr != nil {
 		log.Printf("[orch] reconcile: could not check issue #%d state for %s: %v — proceeding with auto-create", sess.IssueNumber, slotName, closedErr)
 	} else if closed {
-		log.Printf("[orch] reconcile: not auto-creating PR for %s — issue #%d is closed", slotName, sess.IssueNumber)
-		return 0, false
+		o.updateTokensUsedFromWorkerLog(slotName, sess)
+		sess.PID = 0
+		sess.TmuxSession = ""
+		sess.Status = state.StatusDone
+		now := time.Now().UTC()
+		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
+		o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
+		log.Printf("[orch] reconcile: %s running->done (issue #%d closed; not auto-creating a PR; %s)",
+			slotName, sess.IssueNumber, reasons)
+		if o.notifier != nil {
+			o.notifier.Sendf("🧟 maestro: worker %s (issue #%d: %s) exited with the issue already closed — settled as done",
+				slotName, sess.IssueNumber, sess.IssueTitle)
+		}
+		return true
 	}
 
 	title := autoCreatedPRTitle(sess)
@@ -2575,7 +2610,7 @@ func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.S
 	prNumber, err := o.createPR(title, body, "main", branch)
 	if err != nil {
 		log.Printf("[orch] reconcile: could not auto-create PR for %s branch %q: %v", slotName, branch, err)
-		return 0, false
+		return false
 	}
 
 	o.updateTokensUsedFromWorkerLog(slotName, sess)
@@ -2587,11 +2622,13 @@ func (o *Orchestrator) tryCreatePRForPushedBranch(slotName string, sess *state.S
 	sess.FinishedAt = &now
 	state.MarkWorkerEnded(sess, now)
 	state.MarkPROpened(sess, now)
+	log.Printf("[orch] reconcile: %s running->pr_open (auto-created PR #%d for pushed branch %q; %s)",
+		slotName, prNumber, branch, reasons)
 	if o.notifier != nil {
 		o.notifier.Sendf("🔀 maestro: worker %s pushed branch %s and exited before opening a PR; auto-created PR #%d for issue #%d (%s)",
 			slotName, branch, prNumber, sess.IssueNumber, sess.IssueTitle)
 	}
-	return prNumber, true
+	return true
 }
 
 func autoCreatedPRTitle(sess *state.Session) string {

--- a/internal/orchestrator/ratelimit_dedup_test.go
+++ b/internal/orchestrator/ratelimit_dedup_test.go
@@ -90,7 +90,7 @@ func TestRunOnce_AutoCreatedPRNotOrphaned(t *testing.T) {
 
 	// A running session whose worker process + tmux are gone but whose branch
 	// was already pushed, with no PR recorded. reconcileRunningSessions takes the
-	// recovery path and auto-creates the PR via tryCreatePRForPushedBranch.
+	// recovery path and auto-creates the PR via reconcilePushedBranch.
 	s := state.NewState()
 	s.Sessions["slot-0"] = &state.Session{
 		IssueNumber: 200,

--- a/internal/orchestrator/zombie_respawn_test.go
+++ b/internal/orchestrator/zombie_respawn_test.go
@@ -1,0 +1,314 @@
+package orchestrator
+
+// #800: a session's saved retry/review-feedback state must not outlive the
+// work it was scheduled for. Merge of the session's PR or closing of its
+// issue invalidates the pending retry — the pre-respawn staleness check
+// settles the session instead of respawning a zombie worker, and the
+// reconcile auto-create path skips branches whose content already landed.
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func zombieRetryOrchestrator(t *testing.T, respawned *bool) *Orchestrator {
+	t.Helper()
+	return &Orchestrator{
+		cfg: &config.Config{
+			Repo:              "owner/repo",
+			MaxRetryBackoffMs: 300000,
+			MaxRuntimeMinutes: 999,
+		},
+		notifier:   &notify.Notifier{},
+		promptBase: "test prompt",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return makeIssue(number, "test issue"), nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			*respawned = true
+			sess.Status = state.StatusRunning
+			sess.PID = 5555
+			return nil
+		},
+		respawnInPlaceFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			*respawned = true
+			sess.Status = state.StatusRunning
+			sess.PID = 5555
+			return nil
+		},
+	}
+}
+
+func TestRespawnDueRetries_IssueClosed_RetiresInsteadOfRespawning(t *testing.T) {
+	respawned := false
+	o := zombieRetryOrchestrator(t, &respawned)
+	o.isIssueClosedFn = func(issueNumber int) (bool, error) {
+		return issueNumber == 133, nil
+	}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	s := state.NewState()
+	s.Sessions["ok-player-1"] = &state.Session{
+		IssueNumber: 133,
+		IssueTitle:  "closed while backoff ran",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/ok-player-1-133-test",
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if respawned {
+		t.Fatal("worker must NOT respawn for a closed issue")
+	}
+	sess := s.Sessions["ok-player-1"]
+	if sess.Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt must be cleared when the retry is retired")
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("FinishedAt should be set when the retry is retired")
+	}
+}
+
+func TestRespawnDueRetries_SessionPRMerged_RetiresInsteadOfRespawning(t *testing.T) {
+	respawned := false
+	o := zombieRetryOrchestrator(t, &respawned)
+	o.isPRMergedFn = func(prNumber int) (bool, error) {
+		return prNumber == 135, nil
+	}
+	o.isIssueClosedFn = func(issueNumber int) (bool, error) {
+		return false, nil // issue still open — the merged PR alone must invalidate the retry
+	}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	s := state.NewState()
+	s.Sessions["ok-player-1"] = &state.Session{
+		IssueNumber: 133,
+		IssueTitle:  "review retry with merged PR",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/ok-player-1-133-test",
+		Worktree:    "/tmp/maestro-ok-player-1",
+		PRNumber:    135,
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if respawned {
+		t.Fatal("worker must NOT respawn when the session's PR is already merged")
+	}
+	sess := s.Sessions["ok-player-1"]
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusCodeLanded)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt must be cleared when the retry is retired")
+	}
+}
+
+// Regression for the BeFeast/ok-player 2026-07-02 incident (#800): CI fails on
+// the PR, the CI-retry path closes it and schedules a backoff retry; an
+// operator then pushes a fix, reopens the PR, and merges it. When the backoff
+// elapses the orchestrator must NOT respawn — the closed-then-merged PR is
+// tracked via LastClosedPRNumber and invalidates the retry even though the
+// issue itself is still open (maestro PRs carry no auto-closing keywords).
+func TestRespawnDueRetries_PRClosedByCIRetryThenReopenedAndMerged_NoRespawn(t *testing.T) {
+	respawned := false
+	o := zombieRetryOrchestrator(t, &respawned)
+	o.ghPRChecksOutputFn = func(prNumber int) (string, error) { return "build failed", nil }
+	o.ghCollectPRReviewFeedbackFn = func(prNumber int) (string, error) { return "", nil }
+	o.ghClosePRFn = func(prNumber int, comment string) error { return nil }
+	o.workerStopFn = func(cfg *config.Config, slotName string, sess *state.Session) error { return nil }
+
+	s := state.NewState()
+	sess := &state.Session{
+		IssueNumber: 133,
+		IssueTitle:  "zombie respawn incident",
+		Status:      state.StatusPROpen,
+		PRNumber:    135,
+		Branch:      "feat/ok-player-1-133-test",
+		Worktree:    "/tmp/maestro-ok-player-1",
+	}
+	s.Sessions["ok-player-1"] = sess
+
+	// Step 1: CI fails — maestro closes PR #135 and schedules a retry.
+	o.handleCIFailureRetry(s, "ok-player-1", sess, github.PR{Number: 135, HeadRefName: sess.Branch})
+
+	if sess.Status != state.StatusDead || sess.NextRetryAt == nil {
+		t.Fatalf("after CI-retry: status = %q nextRetryAt = %v, want dead with a scheduled retry", sess.Status, sess.NextRetryAt)
+	}
+	if sess.PRNumber != 0 {
+		t.Fatalf("after CI-retry: PRNumber = %d, want 0 (PR closed)", sess.PRNumber)
+	}
+	if sess.LastClosedPRNumber != 135 {
+		t.Fatalf("after CI-retry: LastClosedPRNumber = %d, want 135", sess.LastClosedPRNumber)
+	}
+
+	// Step 2: operator pushes a fix, reopens PR #135, and merges it. The
+	// issue stays open (no auto-closing keywords on maestro PRs).
+	o.isPRMergedFn = func(prNumber int) (bool, error) {
+		return prNumber == 135, nil
+	}
+	o.isIssueClosedFn = func(issueNumber int) (bool, error) {
+		return false, nil
+	}
+
+	// Step 3: backoff elapses.
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	sess.NextRetryAt = &pastTime
+
+	o.respawnDueRetries(s, 10)
+
+	if respawned {
+		t.Fatal("worker must NOT respawn after the CI-closed PR was reopened and merged")
+	}
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusCodeLanded)
+	}
+	if sess.PRNumber != 135 {
+		t.Fatalf("PRNumber = %d, want 135 (restored from the merged PR)", sess.PRNumber)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt must be cleared when the retry is retired")
+	}
+}
+
+func TestRespawnDueRetries_GitHubReadErrorFailsOpen(t *testing.T) {
+	respawned := false
+	o := zombieRetryOrchestrator(t, &respawned)
+	o.isPRMergedFn = func(prNumber int) (bool, error) {
+		return false, fmt.Errorf("transient API error")
+	}
+	o.isIssueClosedFn = func(issueNumber int) (bool, error) {
+		return false, fmt.Errorf("transient API error")
+	}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	s := state.NewState()
+	s.Sessions["mae-1"] = &state.Session{
+		IssueNumber:        200,
+		IssueTitle:         "retry survives GitHub hiccup",
+		Status:             state.StatusDead,
+		RetryCount:         1,
+		NextRetryAt:        &pastTime,
+		Branch:             "feat/mae-1-200-test",
+		LastClosedPRNumber: 42,
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if !respawned {
+		t.Fatal("a transient GitHub read error must not strand a legitimate retry")
+	}
+	if s.Sessions["mae-1"].Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q", s.Sessions["mae-1"].Status, state.StatusRunning)
+	}
+}
+
+func TestRespawnDueRetries_IssueOpenPRNotMerged_StillRespawns(t *testing.T) {
+	respawned := false
+	o := zombieRetryOrchestrator(t, &respawned)
+	o.isPRMergedFn = func(prNumber int) (bool, error) { return false, nil }
+	o.isIssueClosedFn = func(issueNumber int) (bool, error) { return false, nil }
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	s := state.NewState()
+	s.Sessions["mae-2"] = &state.Session{
+		IssueNumber:        201,
+		IssueTitle:         "legit retry",
+		Status:             state.StatusDead,
+		RetryCount:         1,
+		NextRetryAt:        &pastTime,
+		Branch:             "feat/mae-2-201-test",
+		LastClosedPRNumber: 43,
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if !respawned {
+		t.Fatal("a retry whose issue is open and whose PR is unmerged must respawn")
+	}
+}
+
+func TestTryCreatePRForPushedBranch_SkipsBranchAlreadyMerged(t *testing.T) {
+	created := false
+	o := &Orchestrator{
+		cfg:                  &config.Config{Repo: "owner/repo"},
+		pidAliveFn:           func(pid int) bool { return false },
+		tmuxSessionExistsFn:  func(name string) bool { return false },
+		listOpenPRsFn:        func() ([]github.PR, error) { return []github.PR{}, nil },
+		remoteBranchExistsFn: func(branch string) (bool, error) { return true, nil },
+		hasMergedPRForBranchFn: func(branch string) (bool, error) {
+			return branch == "feat/ok-player-1-133-test", nil
+		},
+		isIssueClosedFn: func(issueNumber int) (bool, error) { return false, nil },
+		createPRFn: func(title, body, base, head string) (int, error) {
+			created = true
+			return 137, nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["ok-player-1"] = &state.Session{
+		IssueNumber: 133,
+		IssueTitle:  "stale squash-merged branch",
+		Status:      state.StatusRunning,
+		PID:         4242,
+		TmuxSession: "maestro-ok-player-1",
+		Branch:      "feat/ok-player-1-133-test",
+	}
+
+	o.reconcileRunningSessions(s)
+
+	if created {
+		t.Fatal("reconcile must NOT auto-create a PR from a branch that already merged via an earlier PR")
+	}
+	sess := s.Sessions["ok-player-1"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (dead, not rescued into a junk PR)", sess.Status, state.StatusDead)
+	}
+}
+
+func TestTryCreatePRForPushedBranch_SkipsClosedIssue(t *testing.T) {
+	created := false
+	o := &Orchestrator{
+		cfg:                    &config.Config{Repo: "owner/repo"},
+		pidAliveFn:             func(pid int) bool { return false },
+		tmuxSessionExistsFn:    func(name string) bool { return false },
+		listOpenPRsFn:          func() ([]github.PR, error) { return []github.PR{}, nil },
+		remoteBranchExistsFn:   func(branch string) (bool, error) { return true, nil },
+		hasMergedPRForBranchFn: func(branch string) (bool, error) { return false, nil },
+		isIssueClosedFn:        func(issueNumber int) (bool, error) { return issueNumber == 133, nil },
+		createPRFn: func(title, body, base, head string) (int, error) {
+			created = true
+			return 137, nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["ok-player-1"] = &state.Session{
+		IssueNumber: 133,
+		IssueTitle:  "issue closed before rescue",
+		Status:      state.StatusRunning,
+		PID:         4242,
+		TmuxSession: "maestro-ok-player-1",
+		Branch:      "feat/ok-player-1-133-test",
+	}
+
+	o.reconcileRunningSessions(s)
+
+	if created {
+		t.Fatal("reconcile must NOT auto-create a PR for a closed issue")
+	}
+}

--- a/internal/orchestrator/zombie_respawn_test.go
+++ b/internal/orchestrator/zombie_respawn_test.go
@@ -241,7 +241,13 @@ func TestRespawnDueRetries_IssueOpenPRNotMerged_StillRespawns(t *testing.T) {
 	}
 }
 
-func TestTryCreatePRForPushedBranch_SkipsBranchAlreadyMerged(t *testing.T) {
+// A branch-only merge (operator merged the PR; maestro PRs carry no
+// auto-closing keywords, so the issue stays open) must settle the session as
+// code_landed, not dead: a dead session without NextRetryAt drops out of
+// IssueInProgress, and HasMergedPRForIssue cannot see a merge that closed no
+// issue — the next dispatch cycle would spawn a fresh worker for
+// already-landed work (#800 review).
+func TestReconcilePushedBranch_BranchAlreadyMerged_SettlesCodeLanded(t *testing.T) {
 	created := false
 	o := &Orchestrator{
 		cfg:                  &config.Config{Repo: "owner/repo"},
@@ -249,8 +255,11 @@ func TestTryCreatePRForPushedBranch_SkipsBranchAlreadyMerged(t *testing.T) {
 		tmuxSessionExistsFn:  func(name string) bool { return false },
 		listOpenPRsFn:        func() ([]github.PR, error) { return []github.PR{}, nil },
 		remoteBranchExistsFn: func(branch string) (bool, error) { return true, nil },
-		hasMergedPRForBranchFn: func(branch string) (bool, error) {
-			return branch == "feat/ok-player-1-133-test", nil
+		mergedPRForBranchFn: func(branch string) (int, error) {
+			if branch == "feat/ok-player-1-133-test" {
+				return 135, nil
+			}
+			return 0, nil
 		},
 		isIssueClosedFn: func(issueNumber int) (bool, error) { return false, nil },
 		createPRFn: func(title, body, base, head string) (int, error) {
@@ -275,21 +284,30 @@ func TestTryCreatePRForPushedBranch_SkipsBranchAlreadyMerged(t *testing.T) {
 		t.Fatal("reconcile must NOT auto-create a PR from a branch that already merged via an earlier PR")
 	}
 	sess := s.Sessions["ok-player-1"]
-	if sess.Status != state.StatusDead {
-		t.Fatalf("status = %q, want %q (dead, not rescued into a junk PR)", sess.Status, state.StatusDead)
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q (settled, not dead — dead would re-open the zombie-respawn window)", sess.Status, state.StatusCodeLanded)
+	}
+	if sess.PRNumber != 135 {
+		t.Fatalf("PRNumber = %d, want 135 (the merged PR for the branch)", sess.PRNumber)
+	}
+	if sess.PID != 0 || sess.TmuxSession != "" {
+		t.Fatalf("PID = %d TmuxSession = %q, want cleared", sess.PID, sess.TmuxSession)
+	}
+	if !s.IssueInProgress(133) {
+		t.Fatal("settled session must keep issue #133 in progress so dispatch cannot spawn a duplicate worker")
 	}
 }
 
-func TestTryCreatePRForPushedBranch_SkipsClosedIssue(t *testing.T) {
+func TestReconcilePushedBranch_IssueClosed_SettlesDone(t *testing.T) {
 	created := false
 	o := &Orchestrator{
-		cfg:                    &config.Config{Repo: "owner/repo"},
-		pidAliveFn:             func(pid int) bool { return false },
-		tmuxSessionExistsFn:    func(name string) bool { return false },
-		listOpenPRsFn:          func() ([]github.PR, error) { return []github.PR{}, nil },
-		remoteBranchExistsFn:   func(branch string) (bool, error) { return true, nil },
-		hasMergedPRForBranchFn: func(branch string) (bool, error) { return false, nil },
-		isIssueClosedFn:        func(issueNumber int) (bool, error) { return issueNumber == 133, nil },
+		cfg:                  &config.Config{Repo: "owner/repo"},
+		pidAliveFn:           func(pid int) bool { return false },
+		tmuxSessionExistsFn:  func(name string) bool { return false },
+		listOpenPRsFn:        func() ([]github.PR, error) { return []github.PR{}, nil },
+		remoteBranchExistsFn: func(branch string) (bool, error) { return true, nil },
+		mergedPRForBranchFn:  func(branch string) (int, error) { return 0, nil },
+		isIssueClosedFn:      func(issueNumber int) (bool, error) { return issueNumber == 133, nil },
 		createPRFn: func(title, body, base, head string) (int, error) {
 			created = true
 			return 137, nil
@@ -310,5 +328,49 @@ func TestTryCreatePRForPushedBranch_SkipsClosedIssue(t *testing.T) {
 
 	if created {
 		t.Fatal("reconcile must NOT auto-create a PR for a closed issue")
+	}
+	sess := s.Sessions["ok-player-1"]
+	if sess.Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDone)
+	}
+	if sess.FinishedAt == nil {
+		t.Fatal("FinishedAt should be set when the session is settled")
+	}
+}
+
+func TestReconcilePushedBranch_MergedCheckErrorFailsOpen(t *testing.T) {
+	created := false
+	o := &Orchestrator{
+		cfg:                  &config.Config{Repo: "owner/repo"},
+		pidAliveFn:           func(pid int) bool { return false },
+		tmuxSessionExistsFn:  func(name string) bool { return false },
+		listOpenPRsFn:        func() ([]github.PR, error) { return []github.PR{}, nil },
+		remoteBranchExistsFn: func(branch string) (bool, error) { return true, nil },
+		mergedPRForBranchFn:  func(branch string) (int, error) { return 0, fmt.Errorf("transient API error") },
+		isIssueClosedFn:      func(issueNumber int) (bool, error) { return false, nil },
+		createPRFn: func(title, body, base, head string) (int, error) {
+			created = true
+			return 137, nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["ok-player-1"] = &state.Session{
+		IssueNumber: 133,
+		IssueTitle:  "rescue survives GitHub hiccup",
+		Status:      state.StatusRunning,
+		PID:         4242,
+		TmuxSession: "maestro-ok-player-1",
+		Branch:      "feat/ok-player-1-133-test",
+	}
+
+	o.reconcileRunningSessions(s)
+
+	if !created {
+		t.Fatal("a transient GitHub read error on the merged-branch check must not disable the auto-create rescue")
+	}
+	sess := s.Sessions["ok-player-1"]
+	if sess.Status != state.StatusPROpen {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusPROpen)
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -199,6 +199,7 @@ type Session struct {
 	PreviousAttemptFeedback     string            `json:"previous_attempt_feedback,omitempty"`      // feedback from previous failed PR attempt
 	PreviousAttemptFeedbackKind string            `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
 	RetryReason                 string            `json:"retry_reason,omitempty"`                   // current retry lifecycle reason, e.g. review_feedback
+	LastClosedPRNumber          int               `json:"last_closed_pr_number,omitempty"`          // PR the retry path closed before scheduling this retry (#800); if an operator reopens and merges it while the backoff runs, the pre-respawn staleness check sees the merge and cancels the retry
 	CheckpointFile              string            `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
 	DeploymentFinishedAt        *time.Time        `json:"deployment_finished_at,omitempty"`         // set when the post-merge deploy hook succeeds
 


### PR DESCRIPTION
Refs #800

## Changes
- Pre-respawn staleness guard (`retireStaleRetry`): before a scheduled retry/review-feedback respawn, the orchestrator re-checks GitHub. A merged session PR — including a PR the CI-retry path closed that an operator later reopened and merged, tracked via the new `Session.LastClosedPRNumber` — retires the session to `code_landed` (the normal post-merge reconcile then converges it to done); a closed issue retires it to `done`. GitHub read errors fail open so a transient API hiccup cannot strand a legitimate retry.
- Reconcile pushed-branch settling (review feedback): `reconcilePushedBranch` (was `tryCreatePRForPushedBranch`) settles a stale session in place instead of letting it fall through to `dead` — a branch already merged via an earlier PR (new `github.MergedPRNumberForBranch`, which catches squash-merged tips that ancestry checks cannot) settles as `code_landed` with the merged PR number; a closed issue settles as `done`. A dead session without a pending retry drops out of `IssueInProgress`, and since maestro PRs carry no auto-closing keywords, `HasMergedPRForIssue` cannot see a branch-only merge — the next cycle would respawn a worker for already-landed work. Maestro's own `MergePR` already passes `--delete-branch`; the remaining hole was operator merges that keep the branch alive.

## Testing
- New `internal/orchestrator/zombie_respawn_test.go`, including the regression for the 2026-07-02 ok-player incident: PR closed by CI-retry → operator pushes fix, reopens and merges → backoff elapses → no respawn. Settle-instead-of-dead coverage for the reconcile pushed-branch path (merged branch → `code_landed` and issue stays in progress; closed issue → `done`; GitHub read error → auto-create rescue still runs).
- `gofmt` on changed files, `go test ./...`, `go build ./cmd/maestro/` — all green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents stale retry sessions from respawning after their work has already been settled. The main changes are:

- Adds a pre-respawn GitHub staleness check for merged PRs and closed issues.
- Tracks the last PR closed by retry handling so reopened-and-merged PRs can cancel the pending retry.
- Skips pushed-branch PR auto-creation when the branch already merged through an earlier PR or the issue is closed.
- Adds tests for zombie retry prevention, branch-merge reconciliation, closed issues, and fail-open GitHub read errors.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are narrowly scoped to retry and reconcile state transitions. The updated paths use existing helper patterns and include focused tests for the incident paths and fail-open behavior. No blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the retry-staleness tests and observed that before-state retries respawned the CI-closed PR and on GitHub read errors, while after-state marked the head as done and code\_landed without respawn, with respawns possible on transient GitHub read errors.
- Ran the auto-create-hardening tests and observed that before, a duplicate-rescue PR was auto-created with createPR=true and final session status pr\_open; after, the head skipped auto-create for merged branches and closed issues while preserving fail-open auto-create on transient errors, and the fake GitHub list shows only the merged PR for the branch.

<a href="https://app.greptile.com/trex/runs/13144319/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds branch-head merged PR lookup using the existing closed PR listing. |
| internal/orchestrator/orchestrator.go | Adds stale retry retirement and pushed-branch reconciliation guards for merged PRs and closed issues. |
| internal/orchestrator/zombie_respawn_test.go | Adds tests for retry staleness, closed issues, merged branches, and fail-open GitHub read errors. |
| internal/state/state.go | Persists the last PR closed by retry handling for later stale-retry checks. |
| internal/orchestrator/ratelimit_dedup_test.go | Updates a test comment for the renamed pushed-branch reconciliation path. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **HasMergedPRForBranch ignores PR closed state**

   - **Bug**
     - `github.HasMergedPRForBranch` returned true for a PR fixture with matching `HeadRefName` and non-empty `MergedAt` even though the PR state was `open`. The requested contract says it should return true only for closed PRs with `MergedAt` set and a matching head branch.
   - **Cause**
     - In `internal/github/github.go`, `HasMergedPRForBranch` checks `pr.MergedAt != "" && pr.HeadRefName == branch` but does not also require `pr.State` to be closed. Although the production list source is named `listClosedPRs`, the helper's own contract is stricter and should enforce the state on the parsed PR data.
   - **Fix**
     - Update `HasMergedPRForBranch` to require a closed state as well, e.g. `if strings.EqualFold(pr.State, "closed") && pr.MergedAt != "" && pr.HeadRefName == branch { return true, nil }`, and keep the empty-branch trim and error propagation behavior.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["github: require closed state in MergedPR..."](https://github.com/befeast/maestro/commit/758b3091f3f636b60cf93de030a15907caf10961) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41536694)</sub>

<!-- /greptile_comment -->

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-20m); claude anthropic claude-fable-5 xhigh (20m-end, in_place_respawn)
