### PR TITLE
fix: fleet snapshot config_path reports store row instead of vestigial maestro.yaml (#801)

### DIFF
--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -124,6 +124,14 @@ func (s *Store) ImportDir(ctx context.Context, dir string) error {
 	return tx.Commit()
 }
 
+// SourcePathPrefix marks a config's SourcePath as a config-store row
+// reference ("store:<name>") rather than a file path. Rows created through
+// the write API (UpsertProject) have no originating file, and an empty
+// SourcePath makes ResolvePath fall back to a literal "maestro.yaml" — which
+// the fleet snapshot then reports as a vestigial config_path for a file that
+// does not exist post-#761 (#801).
+const SourcePathPrefix = "store:"
+
 func (s *Store) Load(ctx context.Context, name string) (*config.Config, error) {
 	data, sourcePath, err := s.exportProjectYAML(ctx, name)
 	if err != nil {
@@ -132,6 +140,12 @@ func (s *Store) Load(ctx context.Context, name string) (*config.Config, error) {
 	cfg, err := config.Parse(data)
 	if err != nil {
 		return nil, err
+	}
+	if strings.TrimSpace(sourcePath) == "" {
+		// No originating file (write-API row): report the store row itself so
+		// path consumers surface "store:<name>" instead of inventing a
+		// maestro.yaml that does not exist (#801).
+		sourcePath = SourcePathPrefix + name
 	}
 	cfg.SourcePath = sourcePath
 	return cfg, nil

--- a/internal/configstore/store_test.go
+++ b/internal/configstore/store_test.go
@@ -72,6 +72,30 @@ supervisor:
 	}
 }
 
+// A row imported from a file keeps that file as its SourcePath; the
+// "store:<name>" pseudo path is only for rows with no originating file (#801).
+func TestLoadKeepsImportedSourcePath(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	yaml := "repo: BeFeast/maestro\n"
+	path := filepath.Join(dir, "befeast-maestro.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	store := openTestStore(t)
+	if err := store.ImportDir(ctx, dir); err != nil {
+		t.Fatalf("ImportDir: %v", err)
+	}
+	cfg, err := store.Load(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SourcePath != path {
+		t.Fatalf("SourcePath = %q, want %q", cfg.SourcePath, path)
+	}
+}
+
 func TestExportDirRoundTrips(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/configstore/store_write_test.go
+++ b/internal/configstore/store_write_test.go
@@ -69,6 +69,31 @@ func TestUpsertProjectLoadAllRoundTrip(t *testing.T) {
 	}
 }
 
+// A write-API row has no originating file (source_path = ”). Load must stamp
+// the store row reference on SourcePath — not leave it empty — otherwise
+// ResolvePath falls back to a literal "maestro.yaml" and the fleet snapshot
+// reports a vestigial config_path for a file that does not exist post-#761
+// (#801).
+func TestLoadStampsStoreRowSourcePath(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	if err := store.UpsertProject(ctx, "befeast-ok-player", writeTestYAML); err != nil {
+		t.Fatalf("UpsertProject: %v", err)
+	}
+	cfg, err := store.Load(ctx, "befeast-ok-player")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	const want = "store:befeast-ok-player"
+	if cfg.SourcePath != want {
+		t.Fatalf("SourcePath = %q, want %q", cfg.SourcePath, want)
+	}
+	if got := cfg.ResolvePath(); got != want {
+		t.Fatalf("ResolvePath() = %q, want %q", got, want)
+	}
+}
+
 func TestUpsertProjectOverwrites(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)

--- a/internal/server/fleet_build_test.go
+++ b/internal/server/fleet_build_test.go
@@ -30,6 +30,20 @@ func TestUniqueFleetName(t *testing.T) {
 	}
 }
 
+// A store-backed config carries a "store:<name>" SourcePath (configstore.Load,
+// #801); the fleet project must surface it verbatim as ConfigPath so the
+// snapshot's config_path reports the store row instead of a vestigial
+// maestro.yaml that does not exist post-#761.
+func TestNewFleetProjectWithGitHubNamedStoreSourcePath(t *testing.T) {
+	proj := NewFleetProjectWithGitHubNamed("ok-player", &config.Config{
+		Repo:       "BeFeast/ok-player",
+		SourcePath: "store:befeast-ok-player",
+	})
+	if want := "store:befeast-ok-player"; proj.ConfigPath != want {
+		t.Fatalf("ConfigPath = %q, want %q", proj.ConfigPath, want)
+	}
+}
+
 // FleetProjectsFromConfigs must produce one project per config, each with a
 // unique Name even when two configs share a repo basename.
 func TestFleetProjectsFromConfigsUniqueNames(t *testing.T) {


### PR DESCRIPTION
Implements #801

## Changes
- `configstore.Load` now stamps rows that have no originating file (write-API rows, `source_path = ''`) with a `store:<name>` pseudo source path. `ResolvePath()` previously fell back to the literal `maestro.yaml` for these configs, and the fleet snapshot surfaced that as `config_path` for a file that does not exist post-#761. The snapshot now reports the store row identity (e.g. `store:befeast-ok-player`).
- Rows imported from files keep their recorded source path (provenance unchanged).
- No fleet/server or web changes needed: `NewFleetProjectWithGitHubNamed` already passes the resolved path through, and both dashboards tolerate any `config_path` value.

## Testing
- New `internal/configstore` tests: write-API row loads with `SourcePath`/`ResolvePath()` = `store:<name>`; imported row keeps its file path.
- New `internal/server` test: a store-backed config's `store:<name>` path surfaces verbatim as the fleet project's `ConfigPath`.
- `gofmt`, `go test ./...`, `go build ./cmd/maestro/` all pass.

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates config-store source paths so store-backed fleet snapshots point at the store row. The main changes are:

- Add a `store:<name>` pseudo path when `configstore.Load` reads a row without file provenance.
- Preserve recorded file paths for configs imported from YAML files.
- Add tests for write-API rows, imported rows, and fleet project `ConfigPath` propagation.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to `configstore.Load`, keeps imported file provenance unchanged, and adds targeted tests for the affected store and fleet paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the change by comparing the before and after outputs: the base output showed a WRITE\_ROW line with an empty SourcePath and maestro.yaml as ResolvePath, while the imported row pointed to a temporary file; after the change, the head output shows WRITE\_ROW with SourcePath and ResolvePath set to store:befeast-ok-player, and the imported row still uses the real imported file path.
- Reviewed the fleet-config-path proof results, including the before and after path logs, the verbose head validation log, and the temporary test Go source used for the test harness.

<a href="https://app.greptile.com/trex/runs/13146608/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/configstore/store.go | Adds a `store:` pseudo-source path for config-store rows loaded without file provenance; no issues found. |
| internal/configstore/store_test.go | Adds coverage that imported file-backed configs retain their original source path; no issues found. |
| internal/configstore/store_write_test.go | Adds coverage that write-API configs load with `store:<name>` source and resolved paths; no issues found. |
| internal/server/fleet_build_test.go | Adds coverage that fleet project construction preserves store-backed config paths verbatim; no issues found. |

<sub>Reviews (1): Last reviewed commit: ["fix: report store row (store:&lt;name&gt;) ins..."](https://github.com/befeast/maestro/commit/6ada7b53c28180a93443be86cb2a3ca149c791ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41543698)</sub>

<!-- /greptile_comment -->