### PR TITLE
Failover: classify backend quota/usage-limit deaths and retry on fallback_backends instead of exhausting issue retries

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -1368,6 +1368,46 @@ func buildProjectStatusJSON(cfg *config.Config, s *state.State) projectStatusJSO
 	}
 }
 
+// showBackendHealth prints the per-backend cooldown gates so the operator
+// sees "codex: cooling down until 12:30 (usage_limit)" at a glance (#805).
+// Entries whose cooldown has already elapsed are skipped — the selector
+// treats those backends as available again even before ReconcileBackendHealth
+// clears the row.
+func showBackendHealth(s *state.State) {
+	if len(s.BackendHealth) == 0 {
+		return
+	}
+	now := time.Now().UTC()
+	names := make([]string, 0, len(s.BackendHealth))
+	for name := range s.BackendHealth {
+		h := s.BackendHealth[name]
+		if h.State != state.BackendHealthCooldown {
+			continue
+		}
+		if h.RetryAfter != nil && !now.Before(*h.RetryAfter) {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return
+	}
+	sort.Strings(names)
+	fmt.Printf("Backend health:\n")
+	for _, name := range names {
+		h := s.BackendHealth[name]
+		when := "auto-recovery pending"
+		if h.RetryAfter != nil {
+			when = "until " + h.RetryAfter.UTC().Format("2006-01-02 15:04 MST")
+		}
+		detail := h.Reason
+		if h.Pattern != "" && h.Pattern != h.Reason {
+			detail += "; " + h.Pattern
+		}
+		fmt.Printf("  %-16s cooling down %s (%s)\n", name+":", when, detail)
+	}
+}
+
 // decorateBackendWithTier annotates the status BACKEND cell with the routing
 // tier a policy decision resolved to (#783), e.g. "claude (strong)", or the
 // would-pick tier in shadow mode, e.g. "codex (shadow:strong)". Non-policy
@@ -1412,6 +1452,7 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 	}
 	showOutcomeStatus(cfg, s)
 	showSupervisorPolicy(cfg)
+	showBackendHealth(s)
 	if len(cfg.MaxConcurrentByState) > 0 {
 		// Sort keys for stable output
 		stateNames := make([]string, 0, len(cfg.MaxConcurrentByState))

--- a/docs/subscription-quota.md
+++ b/docs/subscription-quota.md
@@ -102,3 +102,51 @@ Estimation caveats to keep in mind:
   auth-failure or provider-limit cooldown, and unlike those, PR
   evidence does not clear it (the backend keeps working while
   pressured; only the reset clock ends the episode).
+
+## Reactive usage-limit classification (#805)
+
+Calibration is predictive and can miss (mis-calibrated capacities,
+another consumer draining the same account). When the provider itself
+starts refusing work — the CLI prints a quota error and exits — maestro
+classifies the death reactively instead of burning
+`max_retries_per_issue` respawning onto a dead backend:
+
+1. **Parseable reset** — a dead (or live) worker whose log matches a
+   rate-limit signature *and* states a reset time is a high-confidence
+   provider limit (#663). Reset hints may be date-bearing ("try again
+   at May 30, 2026 8:13 PM") or **time-only** ("try again at 12:30 PM",
+   the live codex phrasing) — a time-only hint resolves to the next
+   occurrence of that wall-clock time. The backend is gated with reason
+   `provider_limit` and `RetryAfter` at the stated reset.
+2. **No parseable reset** — a worker that died within the early-death
+   window (~10 min of spawn) whose log **tail** matches an
+   account-quota exhaustion signature ("You've hit your usage limit",
+   the codex settings/usage URL, claude "usage limit reached") is gated
+   with reason `usage_limit` and a fixed 30-minute re-probe cooldown.
+   Generic signals (bare 429, "too many requests") stay excluded — they
+   are transient and acting on them is the #663 false-positive class.
+
+Either way the attempt respawns on the next healthy backend from
+`model.fallback_backends` in the same cycle, the session is excluded
+from `FailedAttemptsForIssue` (retry budget preserved), a
+`backend_usage_limit` supervisor finding is emitted (blocking when the
+default backend is gated), and `maestro status` prints the gate under
+"Backend health". Scheduled retries also consult `backend_health`
+before respawning: a retry whose backend is gated substitutes the first
+healthy fallback, or defers to the cooldown expiry when none exists.
+
+Backends with quota phrasings maestro does not know can extend the
+classifier per backend:
+
+```yaml
+model:
+  backends:
+    mycli:
+      cmd: mycli
+      usage_limit_patterns:
+        - "(?i)monthly spend cap reached"
+```
+
+Entries are regexes (validated at config parse) matched against the
+dead worker's log tail. Keep them high-precision: a pattern that
+matches ordinary work output causes false backend gating.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -88,6 +89,17 @@ type BackendDef struct {
 	// percentages on the fleet API / Mission Control, and steers fresh
 	// dispatch to fallback backends once usage crosses the threshold.
 	Quota BackendQuota `yaml:"quota,omitempty"`
+
+	// UsageLimitPatterns (#805) holds extra regexes that classify this
+	// backend's dead-worker log tail as an account-quota exhaustion, in
+	// addition to the built-in signatures (codex "You've hit your usage
+	// limit", the codex settings/usage URL, claude "usage limit reached").
+	// A quota death gates the backend in backend_health and fails the
+	// attempt over to the next fallback backend without consuming the
+	// per-issue retry budget. Keep entries high-precision: a pattern that
+	// matches ordinary work output (a prompt echo, test output) causes
+	// false backend gating. Validated to compile at config parse.
+	UsageLimitPatterns []string `yaml:"usage_limit_patterns,omitempty"`
 
 	// SubagentHint steers an orchestrating backend (e.g. Claude Code) to
 	// delegate grunt subtasks to cheaper sub-agent models instead of
@@ -1493,6 +1505,14 @@ func parse(data []byte) (*Config, error) {
 		}
 		if t := def.Quota.DispatchThreshold; t < 0 || t > 1 {
 			return nil, fmt.Errorf("config: model.backends.%s.quota.dispatch_threshold = %v; want a fraction in (0, 1], e.g. 0.85 for 85%%", name, t)
+		}
+		// #805: usage-limit classifier extras must compile — an invalid
+		// regex would otherwise be skipped silently at classification
+		// time and the operator would believe the signature is covered.
+		for _, p := range def.UsageLimitPatterns {
+			if _, err := regexp.Compile(p); err != nil {
+				return nil, fmt.Errorf("config: model.backends.%s.usage_limit_patterns entry %q does not compile: %v", name, p, err)
+			}
 		}
 	}
 

--- a/internal/config/usage_limit_patterns_test.go
+++ b/internal/config/usage_limit_patterns_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #805: usage_limit_patterns extends the built-in quota-death classifier per
+// backend; entries are plain regexes validated at parse.
+func TestParse_UsageLimitPatterns(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      usage_limit_patterns:
+        - "(?i)monthly spend cap reached"
+        - "org quota exhausted"
+    claude:
+      cmd: claude
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := cfg.Model.Backends["codex"].UsageLimitPatterns
+	if len(got) != 2 || got[0] != "(?i)monthly spend cap reached" || got[1] != "org quota exhausted" {
+		t.Fatalf("UsageLimitPatterns = %v, want the two configured entries in order", got)
+	}
+	if len(cfg.Model.Backends["claude"].UsageLimitPatterns) != 0 {
+		t.Fatal("claude has no usage_limit_patterns; want empty")
+	}
+}
+
+// #805: an entry that does not compile fails config parse, so the operator
+// learns immediately instead of the classifier silently skipping it.
+func TestParse_UsageLimitPatterns_InvalidRegexRejected(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      usage_limit_patterns:
+        - "(unclosed"
+`
+	_, err := parse([]byte(yaml))
+	if err == nil {
+		t.Fatal("parse should reject an invalid usage_limit_patterns regex")
+	}
+	if !strings.Contains(err.Error(), "usage_limit_patterns") || !strings.Contains(err.Error(), "(unclosed") {
+		t.Fatalf("error should name the field and the offending entry, got: %v", err)
+	}
+}

--- a/internal/orchestrator/backend_selector.go
+++ b/internal/orchestrator/backend_selector.go
@@ -337,6 +337,32 @@ func (o *Orchestrator) dispatchBackendCandidates() []string {
 	return ordered
 }
 
+// earliestCandidateRetry returns the earliest cooldown expiry recorded across
+// a selection's blocked candidates, or nil when none states one. Only
+// candidates whose sole block is the cooldown carry a RetryAfter (see
+// selectBackendFallback — disabled/unknown/current/already-tried short-circuit
+// before the cooldown check), so the returned instant is one at which a
+// candidate genuinely becomes selectable. An all-blocked retry defers to this
+// instant when it beats the session backend's own expiry: waiting on the
+// session backend alone parks the session for hours a sooner-freeing fallback
+// could cover (#805).
+func earliestCandidateRetry(selection state.BackendSelection) *time.Time {
+	var earliest *time.Time
+	for _, entry := range selection.CandidateScores {
+		if entry.Available || entry.RetryAfter == "" {
+			continue
+		}
+		expiry, err := time.Parse(time.RFC3339, entry.RetryAfter)
+		if err != nil {
+			continue
+		}
+		if earliest == nil || expiry.Before(*earliest) {
+			earliest = &expiry
+		}
+	}
+	return earliest
+}
+
 // retryAfterHint formats a cooldown expiry for dispatch log lines.
 func retryAfterHint(retryAfter *time.Time) string {
 	if retryAfter == nil {

--- a/internal/orchestrator/backend_selector.go
+++ b/internal/orchestrator/backend_selector.go
@@ -15,10 +15,16 @@ const (
 	selectionReasonProviderLimitFallback    = "fallback_after_provider_limit"
 	selectionReasonAuthFailureFallback      = "fallback_after_backend_auth_failure"
 	selectionReasonModelUnavailableFallback = "fallback_after_backend_model_unavailable"
+	selectionReasonUsageLimitFallback       = "fallback_after_backend_usage_limit"
 	// selectionReasonDispatchBlockedFallback marks a fresh dispatch whose
 	// routed backend was blocked (disabled or in BackendHealth cooldown), so
 	// the first healthy candidate was substituted before spawn (#695).
 	selectionReasonDispatchBlockedFallback = "dispatch_fallback_blocked_backend"
+	// selectionReasonRetryBlockedFallback marks a scheduled retry whose
+	// session backend was blocked at respawn time (in BackendHealth cooldown
+	// or disabled), so the first healthy fallback was substituted instead of
+	// re-burning the retry budget on a dead backend (#805).
+	selectionReasonRetryBlockedFallback = "retry_fallback_blocked_backend"
 )
 
 // backendFailureCopy holds the reason-dependent strings the dead-worker
@@ -36,13 +42,22 @@ type backendFailureCopy struct {
 }
 
 func backendFailureCopyFor(reason string) backendFailureCopy {
-	if reason == state.BackendBlockModelUnavailable {
+	switch reason {
+	case state.BackendBlockModelUnavailable:
 		return backendFailureCopy{
 			selectionReason: selectionReasonModelUnavailableFallback,
 			displayToken:    string(state.DisplayBackendModelUnavailable),
 			desc:            "could not load its configured model (unavailable or no access)",
 			noun:            "backend model unavailable",
 			remedy:          "swap the model id or restore model access",
+		}
+	case state.BackendBlockUsageLimit:
+		return backendFailureCopy{
+			selectionReason: selectionReasonUsageLimitFallback,
+			displayToken:    string(state.DisplayBackendUsageLimit),
+			desc:            "exhausted its account usage quota",
+			noun:            "backend usage limit",
+			remedy:          "wait for the provider quota window to reset or raise the plan limit",
 		}
 	}
 	return backendFailureCopy{
@@ -60,6 +75,25 @@ func backendFailureCopyFor(reason string) backendFailureCopy {
 // provider states no reset time, so a short fixed window re-probes the
 // backend a few times an hour instead of per-spawn (#693).
 const backendAuthFailureCooldown = 10 * time.Minute
+
+// backendUsageLimitCooldown is the gate window for a quota-exhausted backend
+// whose reset time could not be parsed (#805) — a quota death WITH a
+// parseable reset goes through the provider-limit path and carries the
+// provider's own RetryAfter instead. Quota windows reset on multi-hour
+// boundaries (5-hour session windows, weekly caps), so re-probing is slower
+// than the auth cooldown: fast enough to resume within half an hour of an
+// unknown reset, slow enough not to spawn-die churn against a window that
+// stays exhausted for hours.
+const backendUsageLimitCooldown = 30 * time.Minute
+
+// backendFailureCooldownFor picks the fixed re-probe window for a hard
+// backend failure by gating reason.
+func backendFailureCooldownFor(reason string) time.Duration {
+	if reason == state.BackendBlockUsageLimit {
+		return backendUsageLimitCooldown
+	}
+	return backendAuthFailureCooldown
+}
 
 // recordProviderLimit marks the session's backend as rate-limited and puts it
 // into cooldown. resetAt, when non-nil, is the provider-stated reset time
@@ -95,15 +129,16 @@ func (o *Orchestrator) recordProviderLimit(st *state.State, slotName string, ses
 }
 
 // recordBackendFailure marks the session's backend as failing for a hard,
-// non-work reason (auth/credential outage #693, or model unavailable #713)
-// and puts it into cooldown. Unlike a provider capacity limit there is no
-// provider-stated reset time, so RetryAfter is a fixed short window
-// (backendAuthFailureCooldown) after which the selector re-probes the backend
-// automatically. RateLimitHit is set because it is the shared "transient
-// backend block" marker: FailedAttemptsForIssue excludes such sessions, so
-// the outage does not burn the per-issue retry budget. reason is the gating
-// reason recorded on both the session and BackendHealth so the supervisor and
-// dashboard can tell an auth outage from a missing model.
+// non-work reason (auth/credential outage #693, model unavailable #713, or
+// account quota exhausted #805) and puts it into cooldown. Unlike a provider
+// capacity limit there is no provider-stated reset time, so RetryAfter is a
+// fixed window picked by gating reason (backendFailureCooldownFor) after
+// which the selector re-probes the backend automatically. RateLimitHit is
+// set because it is the shared "transient backend block" marker:
+// FailedAttemptsForIssue excludes such sessions, so the outage does not burn
+// the per-issue retry budget. reason is the gating reason recorded on both
+// the session and BackendHealth so the supervisor and dashboard can tell an
+// auth outage from a missing model from an exhausted quota.
 func (o *Orchestrator) recordBackendFailure(st *state.State, slotName string, sess *state.Session, reason, pattern string, now time.Time) {
 	if st == nil || sess == nil || sess.Backend == "" {
 		return
@@ -120,7 +155,7 @@ func (o *Orchestrator) recordBackendFailure(st *state.State, slotName string, se
 	sess.RateLimitHit = true
 	sess.ProviderLimitBackend = sess.Backend
 	sess.ProviderLimitReason = reason
-	retryAfter := now.UTC().Add(backendAuthFailureCooldown)
+	retryAfter := now.UTC().Add(backendFailureCooldownFor(reason))
 	st.BackendHealth[sess.Backend] = state.BackendHealth{
 		State:       state.BackendHealthCooldown,
 		Reason:      reason,

--- a/internal/orchestrator/backend_usage_limit_test.go
+++ b/internal/orchestrator/backend_usage_limit_test.go
@@ -393,10 +393,13 @@ func TestRespawnDueRetries_BackendInCooldown_SubstitutesHealthyFallback(t *testi
 	}
 }
 
-// #805: with every backend blocked, the due retry is deferred to the
-// cooldown expiry instead of respawning a doomed worker — and instead of
-// consuming the attempt.
-func TestRespawnDueRetries_AllBackendsBlocked_DefersRetryToCooldownExpiry(t *testing.T) {
+// #805: with every backend blocked, the due retry is deferred to the EARLIEST
+// cooldown expiry across the blocked candidate set instead of respawning a
+// doomed worker — and instead of consuming the attempt. Here the session
+// backend (codex) is gated for 25 minutes but the fallback (opencode) frees
+// after 8; deferring to the session backend's expiry alone would park the
+// session 17 minutes longer than the fallback requires.
+func TestRespawnDueRetries_AllBackendsBlocked_DefersRetryToEarliestCooldownExpiry(t *testing.T) {
 	cfg := usageLimitTestConfig()
 	cfg.MaxRetryBackoffMs = 300000
 	cfg.MaxRuntimeMinutes = 999
@@ -415,7 +418,10 @@ func TestRespawnDueRetries_AllBackendsBlocked_DefersRetryToCooldownExpiry(t *tes
 		},
 	}
 
-	now := time.Now().UTC()
+	// Whole-second expiries: the fallback candidate's RetryAfter round-trips
+	// through the RFC3339 audit string on BackendSelection, which drops
+	// sub-second precision.
+	now := time.Now().UTC().Truncate(time.Second)
 	pastTime := now.Add(-time.Second)
 	codexRetry := now.Add(25 * time.Minute)
 	opencodeRetry := now.Add(8 * time.Minute)
@@ -447,11 +453,68 @@ func TestRespawnDueRetries_AllBackendsBlocked_DefersRetryToCooldownExpiry(t *tes
 	if sess.NextRetryAt == nil {
 		t.Fatal("NextRetryAt should be re-armed so the retry fires after the cooldown")
 	}
-	if !sess.NextRetryAt.Equal(codexRetry) {
-		t.Fatalf("NextRetryAt = %v, want the blocked backend's cooldown expiry %v", sess.NextRetryAt, codexRetry)
+	if !sess.NextRetryAt.Equal(opencodeRetry) {
+		t.Fatalf("NextRetryAt = %v, want the EARLIEST blocked-candidate expiry %v (opencode), not the session backend's %v",
+			sess.NextRetryAt, opencodeRetry, codexRetry)
 	}
 	if sess.RetryCount != 1 {
 		t.Fatalf("RetryCount = %d, want unchanged 1 — a deferral must not consume the budget", sess.RetryCount)
+	}
+}
+
+// #805: when the session backend's own cooldown is the earliest, the
+// all-blocked deferral still uses it — the earliest-expiry rule is a min over
+// the whole candidate set, not a preference for fallbacks.
+func TestRespawnDueRetries_AllBackendsBlocked_SessionBackendEarliest_UsesItsExpiry(t *testing.T) {
+	cfg := usageLimitTestConfig()
+	cfg.MaxRetryBackoffMs = 300000
+	cfg.MaxRuntimeMinutes = 999
+
+	o := &Orchestrator{
+		cfg:             cfg,
+		notifier:        &notify.Notifier{},
+		promptBase:      "test prompt",
+		isIssueClosedFn: func(issueNumber int) (bool, error) { return false, nil },
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "folio conveyor"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			t.Fatal("respawnWorkerFn must not be called while every backend is blocked")
+			return nil
+		},
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	pastTime := now.Add(-time.Second)
+	codexRetry := now.Add(5 * time.Minute)
+	opencodeRetry := now.Add(30 * time.Minute)
+	s := state.NewState()
+	s.BackendHealth["codex"] = state.BackendHealth{
+		State: state.BackendHealthCooldown, Reason: state.BackendBlockUsageLimit,
+		Since: now.Add(-5 * time.Minute), RetryAfter: &codexRetry,
+	}
+	s.BackendHealth["opencode"] = state.BackendHealth{
+		State: state.BackendHealthCooldown, Reason: state.BackendBlockAuthFailure,
+		Since: now.Add(-5 * time.Minute), RetryAfter: &opencodeRetry,
+	}
+	s.Sessions["ok-20"] = &state.Session{
+		IssueNumber: 220,
+		IssueTitle:  "folio conveyor",
+		Status:      state.StatusDead,
+		Backend:     "codex",
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/ok-20-220-conveyor",
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	sess := s.Sessions["ok-20"]
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be re-armed so the retry fires after the cooldown")
+	}
+	if !sess.NextRetryAt.Equal(codexRetry) {
+		t.Fatalf("NextRetryAt = %v, want the session backend's expiry %v (the earliest)", sess.NextRetryAt, codexRetry)
 	}
 }
 
@@ -496,6 +559,37 @@ func TestRespawnDueRetries_HealthyBackend_RespawnsUnchanged(t *testing.T) {
 	}
 	if sel := s.Sessions["ok-19"].BackendSelection; sel != nil {
 		t.Fatalf("BackendSelection = %+v, want nil (no substitution happened)", sel)
+	}
+}
+
+// #805 review: a dead worker's time-only reset hint must resolve against the
+// worker's time (the log's last write), not the daemon's read time. The CLI
+// died at 11:00 with "try again at 12:30 PM"; when the daemon only reconciles
+// the death after 12:30 (restart, long poll gap), resolving against
+// time.Now() rolls the hint to 12:30 the NEXT day and gates the backend ~24h
+// past its actual quota reset. Resolved from the log mtime the hint stays
+// 12:30 on the day the worker died — an already-expired cooldown.
+func TestRateLimitResetFromLog_TimeOnlyHint_ResolvedFromLogWriteTime(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "ok-21.log")
+	logContent := "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/codex/settings/usage) or try again at 12:30 PM.\n"
+	if err := os.WriteFile(logFile, []byte(logContent), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	// The incident timeline: worker died (last log write) 2026-07-02 11:00 UTC.
+	diedAt := time.Date(2026, 7, 2, 11, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(logFile, diedAt, diedAt); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	o := &Orchestrator{}
+	reset := o.rateLimitResetFromLog(logFile)
+	if reset == nil {
+		t.Fatal("reset should parse from the time-only hint")
+	}
+	want := time.Date(2026, 7, 2, 12, 30, 0, 0, time.UTC)
+	if !reset.Equal(want) {
+		t.Fatalf("reset = %v, want %v — the hint must resolve from the log write time, not the reconcile time", reset, want)
 	}
 }
 

--- a/internal/orchestrator/backend_usage_limit_test.go
+++ b/internal/orchestrator/backend_usage_limit_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -669,5 +670,67 @@ func TestReconcileRunningSessions_CodexTimeOnlyUsageLimit_IncidentReplay(t *test
 	}
 	if failed := s.FailedAttemptsForIssue(217); failed != 0 {
 		t.Fatalf("FailedAttemptsForIssue(217) = %d, want 0", failed)
+	}
+}
+
+// #805 review regression, end to end through the real log classifiers: a
+// long-running worker echoed the live quota text early in its log (the issue
+// body it was working on quotes the provider message verbatim) and later died
+// for an unrelated reason. The whole-log scan used to read that echo as a
+// high-confidence provider limit — gating codex, preserving the retry budget,
+// and respawning on the fallback for a death that had nothing to do with
+// quota. Tail-bounded scanning must leave this death on the ordinary path.
+func TestReconcileRunningSessions_QuotaEchoAboveLogTail_NotClassified(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "ok-22.log")
+	var b strings.Builder
+	b.WriteString("## Issue body\n")
+	b.WriteString("You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/codex/settings/usage) or try again at 12:30 PM.\n")
+	for i := 0; i < 150; i++ {
+		b.WriteString("normal work output\n")
+	}
+	b.WriteString("worker crashed on an unrelated error\n")
+	if err := os.WriteFile(logFile, []byte(b.String()), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	s := state.NewState()
+	s.Sessions["ok-22"] = &state.Session{
+		IssueNumber: 220,
+		IssueTitle:  "folio conveyor",
+		Status:      state.StatusRunning,
+		PID:         515156,
+		TmuxSession: "maestro-ok-22",
+		Branch:      "feat/ok-22-220-conveyor",
+		Backend:     "codex",
+		StartedAt:   time.Now().UTC().Add(-2 * time.Hour),
+		LogFile:     logFile,
+	}
+
+	o := &Orchestrator{
+		cfg:                 usageLimitTestConfig(),
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			t.Fatal("respawnWorkerFn must not be called — the quota echo is above the tail, this is an ordinary death")
+			return nil
+		},
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["ok-22"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (ordinary dead path)", sess.Status, state.StatusDead)
+	}
+	if sess.RateLimitHit {
+		t.Fatal("RateLimitHit must stay false — the echo above the tail is not a provider limit")
+	}
+	if _, ok := s.BackendHealth["codex"]; ok {
+		t.Fatal("BackendHealth[codex] must not be gated by a quota echo above the log tail")
 	}
 }

--- a/internal/orchestrator/backend_usage_limit_test.go
+++ b/internal/orchestrator/backend_usage_limit_test.go
@@ -1,0 +1,579 @@
+package orchestrator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func usageLimitTestConfig() *config.Config {
+	return &config.Config{
+		Repo: "owner/repo",
+		Model: config.ModelConfig{
+			Default:          "codex",
+			FallbackBackends: []string{"opencode"},
+			Backends: map[string]config.BackendDef{
+				"codex":    {Cmd: "codex"},
+				"opencode": {Cmd: "opencode"},
+			},
+		},
+	}
+}
+
+// #805: a dead worker whose log tail carries a quota-exhaustion signature
+// (live: codex "You've hit your usage limit") within the early-death window
+// is a backend failure, not a work failure. The backend is gated in
+// BackendHealth with reason usage_limit and the attempt respawns on the next
+// fallback backend with the per-issue retry budget untouched.
+func TestReconcileRunningSessions_UsageLimitDeadWorker_FallsOverToNextBackend(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["ok-12"] = &state.Session{
+		IssueNumber: 217,
+		IssueTitle:  "folio conveyor",
+		Status:      state.StatusRunning,
+		PID:         515151,
+		TmuxSession: "maestro-ok-12",
+		Branch:      "feat/ok-12-217-conveyor",
+		Backend:     "codex",
+		StartedAt:   time.Now().Add(-90 * time.Second),
+		LogFile:     "/tmp/ok-12-usage.log",
+	}
+
+	respawnedBackends := []string{}
+	o := &Orchestrator{
+		cfg:                 usageLimitTestConfig(),
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:     func(logFile string) bool { return false },
+		authFailureFromLogFn: func(logFile string) (bool, string) {
+			return false, ""
+		},
+		modelUnavailableFromLogFn: func(logFile string) (bool, string) {
+			return false, ""
+		},
+		usageLimitFromLogFn: func(logFile string, extraPatterns []string) (bool, string) {
+			return true, "hit_limit"
+		},
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "folio conveyor"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedBackends = append(respawnedBackends, backendName)
+			sess.Status = state.StatusRunning
+			sess.PID = 9101
+			sess.Backend = backendName
+			sess.StartedAt = time.Now().UTC()
+			sess.FinishedAt = nil
+			return nil
+		},
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["ok-12"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (usage-limit fallover should respawn the worker)", sess.Status, state.StatusRunning)
+	}
+	if len(respawnedBackends) != 1 || respawnedBackends[0] != "opencode" {
+		t.Fatalf("respawned backends = %v, want [opencode]", respawnedBackends)
+	}
+	if len(sess.TriedBackends) != 1 || sess.TriedBackends[0] != "codex" {
+		t.Fatalf("TriedBackends = %v, want [codex] (the quota-dead backend)", sess.TriedBackends)
+	}
+	if sess.RetryCount != 0 {
+		t.Fatalf("RetryCount = %d, want 0 — a quota death must not consume the retry budget", sess.RetryCount)
+	}
+	if !sess.RateLimitHit {
+		t.Fatal("RateLimitHit should be true so FailedAttemptsForIssue excludes the session")
+	}
+	if sess.ProviderLimitReason != state.BackendBlockUsageLimit {
+		t.Fatalf("ProviderLimitReason = %q, want %q", sess.ProviderLimitReason, state.BackendBlockUsageLimit)
+	}
+	if sess.BackendSelection == nil || sess.BackendSelection.SelectedBackend != "opencode" || sess.BackendSelection.SelectionReason != selectionReasonUsageLimitFallback {
+		t.Fatalf("BackendSelection = %+v, want SelectedBackend=opencode SelectionReason=%s", sess.BackendSelection, selectionReasonUsageLimitFallback)
+	}
+	health, ok := s.BackendHealth["codex"]
+	if !ok {
+		t.Fatal("BackendHealth[codex] should be recorded for the quota death")
+	}
+	if health.State != state.BackendHealthCooldown || health.Reason != state.BackendBlockUsageLimit {
+		t.Fatalf("BackendHealth[codex] = %+v, want cooldown/usage_limit", health)
+	}
+	if health.Pattern != "hit_limit" {
+		t.Fatalf("BackendHealth[codex].Pattern = %q, want hit_limit", health.Pattern)
+	}
+	if health.RetryAfter == nil {
+		t.Fatal("BackendHealth[codex].RetryAfter should be set so the backend is re-probed after the cooldown")
+	}
+	remaining := time.Until(*health.RetryAfter)
+	if remaining <= backendAuthFailureCooldown || remaining > backendUsageLimitCooldown+time.Minute {
+		t.Fatalf("RetryAfter in %s, want ~%s from now (quota cooldown, longer than the auth cooldown)", remaining, backendUsageLimitCooldown)
+	}
+	if failed := s.FailedAttemptsForIssue(217); failed != 0 {
+		t.Fatalf("FailedAttemptsForIssue(217) = %d, want 0", failed)
+	}
+}
+
+// #805: with no fallback backend available, a quota-dead worker is marked
+// dead with the backend_usage_limit display token — and still must not count
+// against the per-issue retry budget.
+func TestReconcileRunningSessions_UsageLimitDeadWorker_NoFallback_DoesNotBurnRetryBudget(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["ok-13"] = &state.Session{
+		IssueNumber: 218,
+		IssueTitle:  "folio conveyor",
+		Status:      state.StatusRunning,
+		PID:         515152,
+		TmuxSession: "maestro-ok-13",
+		Branch:      "feat/ok-13-218-conveyor",
+		Backend:     "codex",
+		StartedAt:   time.Now().Add(-2 * time.Minute),
+		LogFile:     "/tmp/ok-13-usage.log",
+	}
+
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			Model: config.ModelConfig{
+				Default:  "codex",
+				Backends: map[string]config.BackendDef{"codex": {Cmd: "codex"}},
+			},
+		},
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:     func(logFile string) bool { return false },
+		authFailureFromLogFn: func(logFile string) (bool, string) {
+			return false, ""
+		},
+		modelUnavailableFromLogFn: func(logFile string) (bool, string) {
+			return false, ""
+		},
+		usageLimitFromLogFn: func(logFile string, extraPatterns []string) (bool, string) {
+			return true, "codex_usage_limit"
+		},
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["ok-13"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.LastNotifiedStatus != string(state.DisplayBackendUsageLimit) {
+		t.Fatalf("last_notified_status = %q, want %q", sess.LastNotifiedStatus, state.DisplayBackendUsageLimit)
+	}
+	if !sess.RateLimitHit {
+		t.Fatal("RateLimitHit should be true so retry budget is preserved")
+	}
+	if failed := s.FailedAttemptsForIssue(218); failed != 0 {
+		t.Fatalf("FailedAttemptsForIssue(218) = %d, want 0 — quota-dead session must not burn retry budget", failed)
+	}
+	if got := state.SessionDisplayStatusFor(sess, nil); got != string(state.DisplayBackendUsageLimit) {
+		t.Fatalf("display status = %q, want %q", got, state.DisplayBackendUsageLimit)
+	}
+}
+
+// #805 precision guard: a usage-limit signature in the log of a worker that
+// ran well past the early-death window is more likely incidental work content
+// (a prompt echo of a quota-related issue) than a backend outage. The session
+// must take the ordinary dead path: no backend gating, no fallover.
+func TestReconcileRunningSessions_UsageLimitLateDeath_NotClassified(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["ok-14"] = &state.Session{
+		IssueNumber: 219,
+		Status:      state.StatusRunning,
+		PID:         515153,
+		TmuxSession: "maestro-ok-14",
+		Branch:      "feat/ok-14-219-conveyor",
+		Backend:     "codex",
+		StartedAt:   time.Now().Add(-backendAuthFailureWindow - 25*time.Minute),
+		LogFile:     "/tmp/ok-14-usage.log",
+	}
+
+	o := &Orchestrator{
+		cfg:                 usageLimitTestConfig(),
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		isRateLimitedFn:     func(logFile string) bool { return false },
+		usageLimitFromLogFn: func(logFile string, extraPatterns []string) (bool, string) {
+			t.Fatal("usageLimitFromLogFn must not be consulted outside the early-death window")
+			return false, ""
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			t.Fatal("respawnWorkerFn must not be called for an ordinary dead worker")
+			return nil
+		},
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["ok-14"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusDead)
+	}
+	if sess.RateLimitHit {
+		t.Fatal("RateLimitHit must stay false on the ordinary dead path")
+	}
+	if _, ok := s.BackendHealth["codex"]; ok {
+		t.Fatal("BackendHealth[codex] must not be gated for a late death")
+	}
+}
+
+// #805: the main-loop dead-worker path (checkSessions) must classify the
+// quota death the same way reconcile does — fallback respawn, no retry budget
+// burn. This is the path that parked ok-folio #217/#218 in retry_exhausted
+// overnight.
+func TestCheckSessions_UsageLimitDeadWorker_FallsOverToNextBackend(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["ok-15"] = &state.Session{
+		IssueNumber: 217,
+		IssueTitle:  "folio conveyor",
+		Status:      state.StatusRunning,
+		PID:         515154,
+		TmuxSession: "maestro-ok-15",
+		Branch:      "feat/ok-15-217-conveyor",
+		Backend:     "codex",
+		StartedAt:   time.Now().UTC().Add(-90 * time.Second),
+		LogFile:     "/tmp/ok-15-usage.log",
+	}
+
+	respawnedBackends := []string{}
+	cfg := usageLimitTestConfig()
+	cfg.MaxRuntimeMinutes = 999
+	cfg.MaxRetriesPerIssue = 3
+	o, _ := newCheckSessionsOrchestrator(cfg, "")
+	o.pidAliveFn = func(pid int) bool { return false }
+	o.isRateLimitedFn = func(logFile string) bool { return false }
+	o.authFailureFromLogFn = func(logFile string) (bool, string) { return false, "" }
+	o.modelUnavailableFromLogFn = func(logFile string) (bool, string) { return false, "" }
+	o.usageLimitFromLogFn = func(logFile string, extraPatterns []string) (bool, string) {
+		return true, "hit_limit"
+	}
+	o.getIssueFn = func(number int) (github.Issue, error) {
+		return github.Issue{Number: number, Title: "folio conveyor"}, nil
+	}
+	o.respawnWorkerFn = func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+		respawnedBackends = append(respawnedBackends, backendName)
+		sess.Status = state.StatusRunning
+		sess.PID = 9102
+		sess.Backend = backendName
+		sess.StartedAt = time.Now().UTC()
+		sess.FinishedAt = nil
+		return nil
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["ok-15"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q (usage-limit fallover should respawn the worker)", sess.Status, state.StatusRunning)
+	}
+	if len(respawnedBackends) != 1 || respawnedBackends[0] != "opencode" {
+		t.Fatalf("respawned backends = %v, want [opencode]", respawnedBackends)
+	}
+	if sess.RetryCount != 0 {
+		t.Fatalf("RetryCount = %d, want 0 — a quota death must not consume max_retries_per_issue", sess.RetryCount)
+	}
+	if sess.ProviderLimitReason != state.BackendBlockUsageLimit {
+		t.Fatalf("ProviderLimitReason = %q, want %q", sess.ProviderLimitReason, state.BackendBlockUsageLimit)
+	}
+	if health, ok := s.BackendHealth["codex"]; !ok || health.Reason != state.BackendBlockUsageLimit {
+		t.Fatalf("BackendHealth[codex] = %+v, want cooldown with reason usage_limit", health)
+	}
+	if failed := s.FailedAttemptsForIssue(217); failed != 0 {
+		t.Fatalf("FailedAttemptsForIssue(217) = %d, want 0", failed)
+	}
+}
+
+// #805: the operator's per-backend usage_limit_patterns reach the classifier
+// for the session's backend.
+func TestBackendUsageLimitFromLog_ThreadsConfiguredExtraPatterns(t *testing.T) {
+	cfg := usageLimitTestConfig()
+	def := cfg.Model.Backends["codex"]
+	def.UsageLimitPatterns = []string{`(?i)monthly spend cap reached`}
+	cfg.Model.Backends["codex"] = def
+
+	var gotExtra []string
+	o := &Orchestrator{
+		cfg: cfg,
+		usageLimitFromLogFn: func(logFile string, extraPatterns []string) (bool, string) {
+			gotExtra = extraPatterns
+			return false, ""
+		},
+	}
+	sess := &state.Session{Backend: "codex", StartedAt: time.Now().UTC().Add(-time.Minute), LogFile: "/tmp/x.log"}
+	o.backendUsageLimitFromLog(sess, time.Now().UTC())
+	if len(gotExtra) != 1 || gotExtra[0] != `(?i)monthly spend cap reached` {
+		t.Fatalf("extra patterns = %v, want the configured codex entry", gotExtra)
+	}
+}
+
+// #805: a scheduled retry whose session backend is gated in BackendHealth
+// must respawn on the first healthy fallback instead of re-burning the retry
+// budget on the dead backend (the "reason=default" respawn loop from the
+// incident).
+func TestRespawnDueRetries_BackendInCooldown_SubstitutesHealthyFallback(t *testing.T) {
+	cfg := usageLimitTestConfig()
+	cfg.MaxRetryBackoffMs = 300000
+	cfg.MaxRuntimeMinutes = 999
+
+	respawnedBackends := []string{}
+	o := &Orchestrator{
+		cfg:             cfg,
+		notifier:        &notify.Notifier{},
+		promptBase:      "test prompt",
+		isIssueClosedFn: func(issueNumber int) (bool, error) { return false, nil },
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "folio conveyor"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawnedBackends = append(respawnedBackends, backend)
+			sess.Status = state.StatusRunning
+			sess.PID = 9104
+			return nil
+		},
+	}
+
+	now := time.Now().UTC()
+	pastTime := now.Add(-time.Second)
+	retryAfter := now.Add(20 * time.Minute)
+	s := state.NewState()
+	s.BackendHealth["codex"] = state.BackendHealth{
+		State:      state.BackendHealthCooldown,
+		Reason:     state.BackendBlockUsageLimit,
+		Since:      now.Add(-10 * time.Minute),
+		RetryAfter: &retryAfter,
+	}
+	s.Sessions["ok-17"] = &state.Session{
+		IssueNumber: 217,
+		IssueTitle:  "folio conveyor",
+		Status:      state.StatusDead,
+		Backend:     "codex",
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/ok-17-217-conveyor",
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	sess := s.Sessions["ok-17"]
+	if len(respawnedBackends) != 1 || respawnedBackends[0] != "opencode" {
+		t.Fatalf("respawned backends = %v, want [opencode] — the retry must not respawn on the gated backend", respawnedBackends)
+	}
+	if sess.Backend != "opencode" {
+		t.Fatalf("sess.Backend = %q, want opencode", sess.Backend)
+	}
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want running", sess.Status)
+	}
+	if sess.BackendSelection == nil || sess.BackendSelection.SelectedBackend != "opencode" ||
+		sess.BackendSelection.SelectionReason != selectionReasonRetryBlockedFallback {
+		t.Fatalf("BackendSelection = %+v, want opencode/%s", sess.BackendSelection, selectionReasonRetryBlockedFallback)
+	}
+	if sess.BackendSelection.PreviousBackend != "codex" {
+		t.Fatalf("PreviousBackend = %q, want codex (the blocked backend)", sess.BackendSelection.PreviousBackend)
+	}
+}
+
+// #805: with every backend blocked, the due retry is deferred to the
+// cooldown expiry instead of respawning a doomed worker — and instead of
+// consuming the attempt.
+func TestRespawnDueRetries_AllBackendsBlocked_DefersRetryToCooldownExpiry(t *testing.T) {
+	cfg := usageLimitTestConfig()
+	cfg.MaxRetryBackoffMs = 300000
+	cfg.MaxRuntimeMinutes = 999
+
+	o := &Orchestrator{
+		cfg:             cfg,
+		notifier:        &notify.Notifier{},
+		promptBase:      "test prompt",
+		isIssueClosedFn: func(issueNumber int) (bool, error) { return false, nil },
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "folio conveyor"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			t.Fatal("respawnWorkerFn must not be called while every backend is blocked")
+			return nil
+		},
+	}
+
+	now := time.Now().UTC()
+	pastTime := now.Add(-time.Second)
+	codexRetry := now.Add(25 * time.Minute)
+	opencodeRetry := now.Add(8 * time.Minute)
+	s := state.NewState()
+	s.BackendHealth["codex"] = state.BackendHealth{
+		State: state.BackendHealthCooldown, Reason: state.BackendBlockUsageLimit,
+		Since: now.Add(-5 * time.Minute), RetryAfter: &codexRetry,
+	}
+	s.BackendHealth["opencode"] = state.BackendHealth{
+		State: state.BackendHealthCooldown, Reason: state.BackendBlockAuthFailure,
+		Since: now.Add(-5 * time.Minute), RetryAfter: &opencodeRetry,
+	}
+	s.Sessions["ok-18"] = &state.Session{
+		IssueNumber: 218,
+		IssueTitle:  "folio conveyor",
+		Status:      state.StatusDead,
+		Backend:     "codex",
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/ok-18-218-conveyor",
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	sess := s.Sessions["ok-18"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want dead (retry stays queued)", sess.Status)
+	}
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be re-armed so the retry fires after the cooldown")
+	}
+	if !sess.NextRetryAt.Equal(codexRetry) {
+		t.Fatalf("NextRetryAt = %v, want the blocked backend's cooldown expiry %v", sess.NextRetryAt, codexRetry)
+	}
+	if sess.RetryCount != 1 {
+		t.Fatalf("RetryCount = %d, want unchanged 1 — a deferral must not consume the budget", sess.RetryCount)
+	}
+}
+
+// A retry on a healthy backend keeps the pre-#805 behavior: no substitution,
+// no deferral.
+func TestRespawnDueRetries_HealthyBackend_RespawnsUnchanged(t *testing.T) {
+	cfg := usageLimitTestConfig()
+	cfg.MaxRetryBackoffMs = 300000
+	cfg.MaxRuntimeMinutes = 999
+
+	respawnedBackends := []string{}
+	o := &Orchestrator{
+		cfg:             cfg,
+		notifier:        &notify.Notifier{},
+		promptBase:      "test prompt",
+		isIssueClosedFn: func(issueNumber int) (bool, error) { return false, nil },
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "folio conveyor"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawnedBackends = append(respawnedBackends, backend)
+			sess.Status = state.StatusRunning
+			return nil
+		},
+	}
+
+	pastTime := time.Now().UTC().Add(-time.Second)
+	s := state.NewState()
+	s.Sessions["ok-19"] = &state.Session{
+		IssueNumber: 219,
+		Status:      state.StatusDead,
+		Backend:     "codex",
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/ok-19-219-conveyor",
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if len(respawnedBackends) != 1 || respawnedBackends[0] != "codex" {
+		t.Fatalf("respawned backends = %v, want [codex] unchanged", respawnedBackends)
+	}
+	if sel := s.Sessions["ok-19"].BackendSelection; sel != nil {
+		t.Fatalf("BackendSelection = %+v, want nil (no substitution happened)", sel)
+	}
+}
+
+// #805 incident replay, end to end through the real log classifiers: a codex
+// worker dies with the exact live message ("You've hit your usage limit ...
+// try again at 12:30 PM."). The time-only reset now parses, so the death is a
+// HIGH-confidence provider limit: BackendHealth gates codex with the resolved
+// reset time and the attempt respawns on the fallback within the same cycle —
+// the journal on 2026-07-02 instead showed running->dead and reason=default
+// respawns until retry_exhausted.
+func TestReconcileRunningSessions_CodexTimeOnlyUsageLimit_IncidentReplay(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "ok-16.log")
+	logContent := "Starting codex worker for issue #217\n" +
+		"You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/codex/settings/usage) or try again at 12:30 PM.\n"
+	if err := os.WriteFile(logFile, []byte(logContent), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	s := state.NewState()
+	s.Sessions["ok-16"] = &state.Session{
+		IssueNumber: 217,
+		IssueTitle:  "folio conveyor",
+		Status:      state.StatusRunning,
+		PID:         515155,
+		TmuxSession: "maestro-ok-16",
+		Branch:      "feat/ok-16-217-conveyor",
+		Backend:     "codex",
+		StartedAt:   time.Now().UTC().Add(-90 * time.Second),
+		LogFile:     logFile,
+	}
+
+	respawnedBackends := []string{}
+	o := &Orchestrator{
+		cfg:                 usageLimitTestConfig(),
+		notifier:            &notify.Notifier{},
+		pidAliveFn:          func(pid int) bool { return false },
+		tmuxSessionExistsFn: func(name string) bool { return false },
+		listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Title: "folio conveyor"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedBackends = append(respawnedBackends, backendName)
+			sess.Status = state.StatusRunning
+			sess.PID = 9103
+			sess.Backend = backendName
+			sess.StartedAt = time.Now().UTC()
+			sess.FinishedAt = nil
+			return nil
+		},
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected reconciliation to report changes")
+	}
+
+	sess := s.Sessions["ok-16"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want running (failover respawn), got dead — the #805 regression", sess.Status)
+	}
+	if len(respawnedBackends) != 1 || respawnedBackends[0] != "opencode" {
+		t.Fatalf("respawned backends = %v, want [opencode]", respawnedBackends)
+	}
+	health, ok := s.BackendHealth["codex"]
+	if !ok {
+		t.Fatal("BackendHealth[codex] should be recorded — it stayed empty during the incident")
+	}
+	if health.Reason != state.BackendBlockProviderLimit {
+		t.Fatalf("BackendHealth[codex].Reason = %q, want %q (parseable reset → provider-limit path)", health.Reason, state.BackendBlockProviderLimit)
+	}
+	if health.RetryAfter == nil {
+		t.Fatal("RetryAfter should carry the resolved 12:30 PM reset")
+	}
+	if hh, mm := health.RetryAfter.Hour(), health.RetryAfter.Minute(); hh != 12 || mm != 30 {
+		t.Fatalf("RetryAfter = %v, want a 12:30 wall-clock resolution", health.RetryAfter)
+	}
+	if failed := s.FailedAttemptsForIssue(217); failed != 0 {
+		t.Fatalf("FailedAttemptsForIssue(217) = %d, want 0", failed)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -652,7 +652,19 @@ func (o *Orchestrator) rateLimitResetFromLog(logFile string) *time.Time {
 	if err != nil {
 		return nil
 	}
-	if reset, ok := worker.ParseRateLimitResetAt(string(data), time.Now().UTC()); ok {
+	// Resolve a time-only reset hint ("try again at 12:30 PM", #805) against
+	// the log's last write — the moment the CLI printed the hint — not the
+	// moment the daemon got around to reading it. A dead worker can sit
+	// unreconciled past the stated reset (daemon restart, long poll gap);
+	// resolved against time.Now() the already-elapsed hint rolls a full day
+	// forward and gates the backend ~24h after its quota window actually
+	// reset. Against the write time the stale hint resolves to the elapsed
+	// instant instead, so the recorded cooldown is already expired.
+	ref := time.Now().UTC()
+	if fi, statErr := os.Stat(logFile); statErr == nil {
+		ref = fi.ModTime().UTC()
+	}
+	if reset, ok := worker.ParseRateLimitResetAt(string(data), ref); ok {
 		return &reset
 	}
 	return nil
@@ -1651,9 +1663,20 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 			if blockedBy, blockedRetry := o.dispatchBackendBlock(s, respawnBackend, now); blockedBy != "" {
 				selection := o.selectBackendFallback(s, sess, now, selectionReasonRetryBlockedFallback)
 				if selection.SelectedBackend == "" {
+					// Defer to the EARLIEST cooldown expiry across the blocked
+					// candidate set — the session backend and every fallback —
+					// not the session backend's alone: with the default gated
+					// until 18:00 but a fallback freeing at 13:00, the next
+					// pass can resume on the fallback hours earlier. 5 minutes
+					// is the re-probe default when no blocked backend states
+					// an expiry.
 					retryAt := now.Add(5 * time.Minute)
-					if blockedRetry != nil && blockedRetry.After(now) {
-						retryAt = blockedRetry.UTC()
+					earliest := blockedRetry
+					if candidateRetry := earliestCandidateRetry(selection); candidateRetry != nil && (earliest == nil || candidateRetry.Before(*earliest)) {
+						earliest = candidateRetry
+					}
+					if earliest != nil && earliest.After(now) {
+						retryAt = earliest.UTC()
 					}
 					sess.NextRetryAt = &retryAt
 					log.Printf("[orch] worker %s retry deferred until %s: backend %s blocked (%s) and no healthy fallback is available",

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -631,9 +631,13 @@ func (o *Orchestrator) isRateLimited(logFile string) bool {
 	return worker.IsRateLimited(logFile)
 }
 
-// rateLimitResetFromLog reads a dead worker's log file and parses the
+// rateLimitResetFromLog reads a dead worker's log tail and parses the
 // provider-stated reset time ("try again at ...") if present. It returns nil
-// when the log is unreadable or carries no parseable reset hint.
+// when the log is unreadable or carries no parseable reset hint. Only the log
+// tail is scanned, and the last parseable hint in it wins: a long-running
+// worker can echo the live quota text as prompt or work content and later die
+// for an unrelated reason, and a whole-log first-match scan read that echo as
+// the terminal error (#805 review).
 //
 // Per issue #663, a nil result from this function is the orchestrator's signal
 // that the rate-limit detection is LOW-confidence: the classifier matched a
@@ -648,10 +652,6 @@ func (o *Orchestrator) rateLimitResetFromLog(logFile string) *time.Time {
 	if logFile == "" {
 		return nil
 	}
-	data, err := os.ReadFile(logFile)
-	if err != nil {
-		return nil
-	}
 	// Resolve a time-only reset hint ("try again at 12:30 PM", #805) against
 	// the log's last write — the moment the CLI printed the hint — not the
 	// moment the daemon got around to reading it. A dead worker can sit
@@ -664,7 +664,7 @@ func (o *Orchestrator) rateLimitResetFromLog(logFile string) *time.Time {
 	if fi, statErr := os.Stat(logFile); statErr == nil {
 		ref = fi.ModTime().UTC()
 	}
-	if reset, ok := worker.ParseRateLimitResetAt(string(data), ref); ok {
+	if reset, ok := worker.ParseRateLimitResetFromLog(logFile, ref); ok {
 		return &reset
 	}
 	return nil
@@ -678,6 +678,12 @@ func (o *Orchestrator) rateLimitResetFromLog(logFile string) *time.Time {
 // through to the ordinary worker-died handling instead of triggering a false
 // backend fallback. The non-nil resetAt is also returned so callers can
 // stamp BackendHealth.RetryAfter without re-reading the log.
+//
+// Both the classifier and the reset parse scan only the log TAIL (the CLI's
+// terminal output), like every other post-mortem backend-failure detector: a
+// long-running worker that echoed the live quota text mid-log — prompt
+// context, work output touching this very signature — and later died
+// normally must not be classified as a provider limit (#805 review).
 func (o *Orchestrator) providerRateLimitFromLog(logFile string) (hit bool, resetAt *time.Time) {
 	if !o.isRateLimited(logFile) {
 		return false, nil

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -68,6 +68,7 @@ type Orchestrator struct {
 	rateLimitResetFromLogFn   func(logFile string) *time.Time
 	authFailureFromLogFn      func(logFile string) (bool, string)
 	modelUnavailableFromLogFn func(logFile string) (bool, string)
+	usageLimitFromLogFn       func(logFile string, extraPatterns []string) (bool, string)
 	// workerRespawnFn / respawnWorkerFn: used by respawnWorker() for dead-worker fallback (tests set one or the other)
 	workerRespawnFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 	respawnWorkerFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
@@ -651,7 +652,7 @@ func (o *Orchestrator) rateLimitResetFromLog(logFile string) *time.Time {
 	if err != nil {
 		return nil
 	}
-	if reset, ok := worker.ParseRateLimitReset(string(data)); ok {
+	if reset, ok := worker.ParseRateLimitResetAt(string(data), time.Now().UTC()); ok {
 		return &reset
 	}
 	return nil
@@ -726,19 +727,59 @@ func (o *Orchestrator) backendModelUnavailableFromLog(sess *state.Session, now t
 	return worker.IsModelUnavailable(sess.LogFile)
 }
 
+// backendUsageLimitFromLog reports whether a dead worker died because its
+// backend's account usage quota is exhausted (#805; live: codex "You've hit
+// your usage limit ... try again at 12:30 PM" printed once and the CLI
+// exited). Like the auth-failure detector it is trusted only within the
+// early-death window: a quota-dead CLI dies on its first API call, while the
+// same signature in a longer-lived worker's log is more likely incidental
+// work content than a backend outage. A quota death whose reset time IS
+// parseable never reaches this classifier — providerRateLimitFromLog handles
+// it first (any worker age) with the provider-stated RetryAfter.
+func (o *Orchestrator) backendUsageLimitFromLog(sess *state.Session, now time.Time) (bool, string) {
+	if sess == nil {
+		return false, ""
+	}
+	if sess.StartedAt.IsZero() || now.Sub(sess.StartedAt) > backendAuthFailureWindow {
+		return false, ""
+	}
+	extra := o.backendUsageLimitPatterns(sess.Backend)
+	if o.usageLimitFromLogFn != nil {
+		return o.usageLimitFromLogFn(sess.LogFile, extra)
+	}
+	return worker.IsUsageLimit(sess.LogFile, extra)
+}
+
+// backendUsageLimitPatterns returns the operator-supplied extra quota-death
+// regexes for one backend (config: model.backends.<name>.usage_limit_patterns,
+// #805).
+func (o *Orchestrator) backendUsageLimitPatterns(backend string) []string {
+	if o == nil || o.cfg == nil || backend == "" {
+		return nil
+	}
+	def, ok := o.cfg.Model.Backends[backend]
+	if !ok {
+		return nil
+	}
+	return def.UsageLimitPatterns
+}
+
 // classifyBackendFailure inspects a dead worker's log for any hard backend
 // failure that must not burn the per-issue retry budget. It returns the gating
-// reason (state.BackendBlockAuthFailure or state.BackendBlockModelUnavailable)
-// and the matched signature label. Auth is checked first: a 401 and a model
-// 404 can co-occur in a noisy log, and a credential outage is the more common
-// recovery path (re-login / cred-sync) than a config change. hit=false leaves
-// the death to the ordinary retry path.
+// reason (state.BackendBlockAuthFailure, state.BackendBlockModelUnavailable,
+// or state.BackendBlockUsageLimit) and the matched signature label. Auth is
+// checked first: a 401 and a model 404 can co-occur in a noisy log, and a
+// credential outage is the more common recovery path (re-login / cred-sync)
+// than a config change. hit=false leaves the death to the ordinary retry path.
 func (o *Orchestrator) classifyBackendFailure(sess *state.Session, now time.Time) (hit bool, reason string, pattern string) {
 	if ok, label := o.backendAuthFailureFromLog(sess, now); ok {
 		return true, state.BackendBlockAuthFailure, label
 	}
 	if ok, label := o.backendModelUnavailableFromLog(sess, now); ok {
 		return true, state.BackendBlockModelUnavailable, label
+	}
+	if ok, label := o.backendUsageLimitFromLog(sess, now); ok {
+		return true, state.BackendBlockUsageLimit, label
 	}
 	return false, "", ""
 }
@@ -1595,6 +1636,40 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 			// Keep sess.Backend consistent with the dispatched backend for the
 			// in-place retry path (RespawnInPlace does not restamp it).
 			sess.Backend = dec.Backend
+		}
+
+		// #805: a scheduled retry must not respawn onto a backend that is
+		// blocked in BackendHealth (quota exhausted, auth-failed, provider
+		// limit) or disabled. During the live incident every backoff retry
+		// re-resolved to the quota-dead default backend and burned the whole
+		// per-issue budget against it. Substitute the first healthy fallback
+		// (recorded on BackendSelection), or push the retry to the cooldown
+		// expiry when no backend is healthy. Sessions without a stamped
+		// backend (legacy states, minimal configs) keep the old behavior.
+		if respawnBackend != "" && len(o.cfg.Model.Backends) > 0 {
+			now := time.Now().UTC()
+			if blockedBy, blockedRetry := o.dispatchBackendBlock(s, respawnBackend, now); blockedBy != "" {
+				selection := o.selectBackendFallback(s, sess, now, selectionReasonRetryBlockedFallback)
+				if selection.SelectedBackend == "" {
+					retryAt := now.Add(5 * time.Minute)
+					if blockedRetry != nil && blockedRetry.After(now) {
+						retryAt = blockedRetry.UTC()
+					}
+					sess.NextRetryAt = &retryAt
+					log.Printf("[orch] worker %s retry deferred until %s: backend %s blocked (%s) and no healthy fallback is available",
+						slotName, retryAt.Format(time.RFC3339), respawnBackend, blockedBy)
+					continue
+				}
+				log.Printf("[orch] worker %s retry: backend %s blocked (%s%s) — substituting %s",
+					slotName, respawnBackend, blockedBy, retryAfterHint(blockedRetry), selection.SelectedBackend)
+				selection.PreviousBackend = respawnBackend
+				sess.BackendSelection = &selection
+				respawnBackend = selection.SelectedBackend
+				sess.Backend = respawnBackend
+				// Any tier override targeted the blocked backend; respawn the
+				// substitute on the plain config.
+				respawnCfg = o.cfg
+			}
 		}
 
 		// If this is a CI failure retry, include CI output and review feedback
@@ -3077,7 +3152,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					// that is still progressing despite a low-confidence match is left
 					// alone so it can recover (the apertune case from #663).
 					if !sess.RateLimitHit && sess.LastNotifiedStatus != "rate_limit" {
-						classifyHit, pattern, confidence, resetTime := worker.ClassifyRateLimit(output)
+						classifyHit, pattern, confidence, resetTime := worker.ClassifyRateLimitAt(output, time.Now().UTC())
 						if classifyHit && confidence != "high" {
 							log.Printf("[orch] worker %s rate-limit pattern matched (pattern=%s) but reset window unparseable — treating as low-confidence and letting worker continue (per #663)",
 								slotName, pattern)

--- a/internal/state/backend_usage_limit_test.go
+++ b/internal/state/backend_usage_limit_test.go
@@ -1,0 +1,52 @@
+package state
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// #805: a session that died on an account-quota exhaustion with no fallback
+// must render as backend_usage_limit (not dead/retry_exhausted, and not the
+// generic rate-limit token) so operators see "quota exhausted, wait for the
+// window", not a code failure.
+func TestSessionDisplayStatus_BackendUsageLimit(t *testing.T) {
+	now := time.Now().UTC()
+	sess := &Session{
+		Status:               StatusDead,
+		Backend:              "codex",
+		RateLimitHit:         true,
+		ProviderLimitBackend: "codex",
+		ProviderLimitReason:  BackendBlockUsageLimit,
+	}
+	if got := SessionDisplayStatusForAt(sess, nil, now); got != string(DisplayBackendUsageLimit) {
+		t.Fatalf("display status = %q, want %q", got, DisplayBackendUsageLimit)
+	}
+
+	// A scheduled retry takes precedence over the backend-block token.
+	retryAt := now.Add(time.Minute)
+	sess.NextRetryAt = &retryAt
+	if got := SessionDisplayStatusForAt(sess, nil, now); got != string(StatusDead) {
+		t.Fatalf("display status = %q, want %q", got, StatusDead)
+	}
+}
+
+func TestSessionAttention_BackendUsageLimit(t *testing.T) {
+	sess := &Session{
+		Status:               StatusDead,
+		Backend:              "codex",
+		RateLimitHit:         true,
+		ProviderLimitBackend: "codex",
+		ProviderLimitReason:  BackendBlockUsageLimit,
+	}
+	attention := SessionAttentionFor(sess, nil)
+	if !attention.NeedsAttention {
+		t.Fatal("quota-dead session with no fallback must need attention")
+	}
+	if !strings.Contains(attention.Reason, "usage quota") {
+		t.Fatalf("attention reason = %q, want usage-quota wording", attention.Reason)
+	}
+	if !strings.Contains(attention.NextAction, "retry budget was not consumed") {
+		t.Fatalf("next action = %q, want retry-budget note", attention.NextAction)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -55,7 +55,14 @@ const (
 	// "the model is gone" (swap the model id) rather than "fix credentials".
 	// Like the other backend-block tokens it did not burn the retry budget.
 	DisplayBackendModelUnavailable SessionDisplayStatus = "backend_model_unavailable"
-	LiveSessionRecentWindow                             = 24 * time.Hour
+	// DisplayBackendUsageLimit marks a session whose worker exited because
+	// its backend's account usage quota is exhausted (#805; live: codex
+	// "You've hit your usage limit") with no fallback available. Distinct
+	// from DisplayBackendRateLimited so operators see "quota exhausted,
+	// wait for the window reset" rather than a generic capacity blip. Like
+	// the other backend-block tokens it did not burn the retry budget.
+	DisplayBackendUsageLimit SessionDisplayStatus = "backend_usage_limit"
+	LiveSessionRecentWindow                       = 24 * time.Hour
 )
 
 const RetryReasonReviewFeedback = "review_feedback"
@@ -78,10 +85,21 @@ const (
 	// auth_failure so the operator remediation differs (swap the model id vs
 	// fix credentials).
 	BackendBlockModelUnavailable = "model_unavailable"
-	BackendBlockDisabled         = "disabled"
-	BackendBlockAlreadyTried     = "already_tried"
-	BackendBlockCurrent          = "current_backend"
-	BackendBlockUnknown          = "unknown_backend"
+	// BackendBlockUsageLimit gates a backend whose CLI died because the
+	// account's usage quota is exhausted (#805; live: codex "You've hit
+	// your usage limit ... try again at 12:30 PM" killed every worker on
+	// the then-default backend and the retry policy burned the per-issue
+	// budget respawning onto it). Like auth_failure it is a hard backend
+	// failure, not a work failure, and must not consume the retry budget.
+	// Distinct from provider_limit (which carries a provider-stated reset)
+	// and quota_pressure (predictive, token-estimate based): usage_limit is
+	// the reactive classification of a quota death whose reset time could
+	// not be parsed, so the cooldown is a fixed re-probe window.
+	BackendBlockUsageLimit   = "usage_limit"
+	BackendBlockDisabled     = "disabled"
+	BackendBlockAlreadyTried = "already_tried"
+	BackendBlockCurrent      = "current_backend"
+	BackendBlockUnknown      = "unknown_backend"
 	// BackendBlockQuotaPressure gates a backend whose estimated
 	// subscription-window usage crossed the quota dispatch threshold
 	// (#704). Unlike auth_failure it is a soft, predictive gate: the
@@ -368,6 +386,13 @@ func SessionAttentionForAt(sess *Session, alive *bool, now time.Time) SessionAtt
 					NeedsAttention: true,
 				}
 			}
+			if sess.ProviderLimitReason == BackendBlockUsageLimit {
+				return SessionAttention{
+					Reason:         fmt.Sprintf("Backend %s has exhausted its account usage quota; no fallback backend is currently available or allowed.", backend),
+					NextAction:     "Wait for the provider quota window to reset (or raise the plan limit / enable another backend); the per-issue retry budget was not consumed.",
+					NeedsAttention: true,
+				}
+			}
 			return SessionAttention{
 				Reason:         fmt.Sprintf("Backend %s hit a provider capacity limit; no fallback backend is currently available or allowed.", backend),
 				NextAction:     "Wait for provider capacity to recover, enable another backend, or change routing policy before retrying.",
@@ -440,6 +465,8 @@ func SessionDisplayStatusForAt(sess *Session, alive *bool, now time.Time) string
 			return string(DisplayBackendAuthFailure)
 		case BackendBlockModelUnavailable:
 			return string(DisplayBackendModelUnavailable)
+		case BackendBlockUsageLimit:
+			return string(DisplayBackendUsageLimit)
 		}
 		return string(DisplayBackendRateLimited)
 	}

--- a/internal/supervisor/backend_usage_limit_test.go
+++ b/internal/supervisor/backend_usage_limit_test.go
@@ -1,0 +1,106 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #805: a backend gated by an account-quota exhaustion must surface as a
+// backend_usage_limit finding — "quota exhausted, failover covering" — so the
+// operator sees why dispatch moved instead of discovering wedged issues. The
+// default backend is blocking; others warn.
+func TestDetectBackendUsageLimitStuckStates(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Model.Default = "codex"
+	e := testEngine(cfg, &fakeReader{})
+	now := e.now()
+
+	retryAfter := now.Add(25 * time.Minute)
+	st := state.NewState()
+	st.BackendHealth["codex"] = state.BackendHealth{
+		State:       state.BackendHealthCooldown,
+		Reason:      state.BackendBlockUsageLimit,
+		Pattern:     "hit_limit",
+		Since:       now.Add(-3 * time.Minute),
+		RetryAfter:  &retryAfter,
+		LastSession: "ok-12",
+	}
+
+	findings := e.detectBackendUsageLimitStuckStates(st, now)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1: %+v", len(findings), findings)
+	}
+	finding := findings[0]
+	if finding.Code != "backend_usage_limit" {
+		t.Fatalf("code = %q, want backend_usage_limit", finding.Code)
+	}
+	if finding.Severity != SeverityBlocked {
+		t.Fatalf("severity = %q, want %q (default backend quota-dead blocks new spawns)", finding.Severity, SeverityBlocked)
+	}
+	if !strings.Contains(finding.Summary, "usage quota") {
+		t.Fatalf("summary %q should say the quota is exhausted", finding.Summary)
+	}
+	evidence := strings.Join(finding.Evidence, "\n")
+	for _, want := range []string{"backend=codex", "signature=hit_limit", "last_session=ok-12"} {
+		if !strings.Contains(evidence, want) {
+			t.Errorf("evidence %q missing %q", evidence, want)
+		}
+	}
+}
+
+func TestDetectBackendUsageLimitStuckStates_SkipsExpiredAndOtherReasons(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Model.Default = "codex"
+	e := testEngine(cfg, &fakeReader{})
+	now := e.now()
+
+	expired := now.Add(-time.Minute)
+	st := state.NewState()
+	// Cooldown elapsed: the selector will re-probe the backend, no finding.
+	st.BackendHealth["codex"] = state.BackendHealth{
+		State:      state.BackendHealthCooldown,
+		Reason:     state.BackendBlockUsageLimit,
+		RetryAfter: &expired,
+	}
+	// Auth failure and quota pressure have their own findings.
+	st.BackendHealth["claude"] = state.BackendHealth{
+		State:  state.BackendHealthCooldown,
+		Reason: state.BackendBlockAuthFailure,
+	}
+	st.BackendHealth["opencode"] = state.BackendHealth{
+		State:  state.BackendHealthCooldown,
+		Reason: state.BackendBlockQuotaPressure,
+	}
+
+	if findings := e.detectBackendUsageLimitStuckStates(st, now); len(findings) != 0 {
+		t.Fatalf("findings = %+v, want none", findings)
+	}
+}
+
+// A non-default backend hitting its quota degrades capacity but does not
+// block new spawns — it must surface as a warning, not a blocker.
+func TestDetectBackendUsageLimitStuckStates_NonDefaultBackendWarns(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Model.Default = "claude"
+	e := testEngine(cfg, &fakeReader{})
+	now := e.now()
+
+	retryAfter := now.Add(25 * time.Minute)
+	st := state.NewState()
+	st.BackendHealth["codex"] = state.BackendHealth{
+		State:      state.BackendHealthCooldown,
+		Reason:     state.BackendBlockUsageLimit,
+		RetryAfter: &retryAfter,
+	}
+
+	findings := e.detectBackendUsageLimitStuckStates(st, now)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != SeverityWarning {
+		t.Fatalf("severity = %q, want %q", findings[0].Severity, SeverityWarning)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1065,6 +1065,7 @@ func (e *Engine) detectStuckStates(st *state.State, now time.Time, prs []github.
 	findings = append(findings, e.detectEnvironmentStuckStates(st, eligible)...)
 	findings = append(findings, e.detectBackendAuthFailureStuckStates(st, now)...)
 	findings = append(findings, e.detectBackendModelUnavailableStuckStates(st, now)...)
+	findings = append(findings, e.detectBackendUsageLimitStuckStates(st, now)...)
 	findings = append(findings, e.detectBackendQuotaPressureStuckStates(st, now)...)
 	findings = append(findings, e.detectOutcomeStuckStates(st)...)
 	findings = append(findings, detectVisualEvidenceStuckStates(st)...)
@@ -1204,6 +1205,60 @@ func (e *Engine) detectBackendModelUnavailableStuckStates(st *state.State, now t
 		findings = append(findings, stuckState("backend_model_unavailable", severity,
 			fmt.Sprintf("Backend %s cannot load its configured model (unavailable, renamed, or no access); workers cannot use it.", name),
 			"Point the backend at an available model id (or restore model access for this account); fallback backends keep the queue moving meanwhile and the per-issue retry budget is preserved.", false, nil,
+			evidence...))
+	}
+	return findings
+}
+
+// detectBackendUsageLimitStuckStates surfaces backends gated because a dead
+// worker's log matched an account-quota exhaustion signature (#805; live:
+// codex "You've hit your usage limit"). Distinct from the predictive
+// quota_pressure gate (#704, token-estimate based) — this is the provider
+// itself refusing work — and from provider_limit (which carries a
+// provider-stated reset). The remediation is time, not credentials: the gate
+// self-clears at RetryAfter and fallback backends keep the queue moving
+// meanwhile, with the per-issue retry budget preserved. The default backend
+// going dark is blocking (every new spawn prefers it); a non-default backend
+// is a warning because routing can avoid it.
+func (e *Engine) detectBackendUsageLimitStuckStates(st *state.State, now time.Time) []state.SupervisorStuckState {
+	if st == nil || len(st.BackendHealth) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(st.BackendHealth))
+	for name := range st.BackendHealth {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var findings []state.SupervisorStuckState
+	for _, name := range names {
+		health := st.BackendHealth[name]
+		if health.State != state.BackendHealthCooldown || health.Reason != state.BackendBlockUsageLimit {
+			continue
+		}
+		if health.RetryAfter != nil && !now.Before(*health.RetryAfter) {
+			continue // cooldown elapsed; the selector will re-probe the backend
+		}
+		severity := SeverityWarning
+		if name == e.cfg.Model.Default {
+			severity = SeverityBlocked
+		}
+		evidence := []string{fmt.Sprintf("backend=%s", name)}
+		if health.Pattern != "" {
+			evidence = append(evidence, fmt.Sprintf("signature=%s", health.Pattern))
+		}
+		if !health.Since.IsZero() {
+			evidence = append(evidence, fmt.Sprintf("since=%s", health.Since.Format(time.RFC3339)))
+		}
+		if health.RetryAfter != nil {
+			evidence = append(evidence, fmt.Sprintf("retry_after=%s", health.RetryAfter.Format(time.RFC3339)))
+		}
+		if health.LastSession != "" {
+			evidence = append(evidence, fmt.Sprintf("last_session=%s", health.LastSession))
+		}
+		findings = append(findings, stuckState("backend_usage_limit", severity,
+			fmt.Sprintf("Backend %s has exhausted its account usage quota; workers cannot use it until the provider window resets.", name),
+			"No credential action needed — the gate self-clears when the quota window resets (retry_after); fallback backends keep the queue moving meanwhile and the per-issue retry budget is preserved. If this recurs every window, raise the plan limit or rebalance dispatch.", false, nil,
 			evidence...))
 	}
 	return findings

--- a/internal/worker/authfailure.go
+++ b/internal/worker/authfailure.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"os"
 	"regexp"
 	"strings"
 )
@@ -85,16 +84,9 @@ func DetectAuthFailure(output string) (bool, string) {
 // signature in a long-lived worker's log is more likely incidental work
 // content than a backend outage.
 func IsAuthFailure(logFile string) (bool, string) {
-	if logFile == "" {
+	tail, ok := logTail(logFile, authFailureTailLines)
+	if !ok {
 		return false, ""
 	}
-	data, err := os.ReadFile(logFile)
-	if err != nil {
-		return false, ""
-	}
-	lines := strings.Split(string(data), "\n")
-	if len(lines) > authFailureTailLines {
-		lines = lines[len(lines)-authFailureTailLines:]
-	}
-	return DetectAuthFailure(strings.Join(lines, "\n"))
+	return DetectAuthFailure(tail)
 }

--- a/internal/worker/backendfailure.go
+++ b/internal/worker/backendfailure.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"os"
 	"regexp"
 	"strings"
 )
@@ -82,16 +81,9 @@ func DetectModelUnavailable(output string) (bool, string) {
 // signature in a long-lived worker's log is more likely incidental work
 // content than a backend outage.
 func IsModelUnavailable(logFile string) (bool, string) {
-	if logFile == "" {
+	tail, ok := logTail(logFile, authFailureTailLines)
+	if !ok {
 		return false, ""
 	}
-	data, err := os.ReadFile(logFile)
-	if err != nil {
-		return false, ""
-	}
-	lines := strings.Split(string(data), "\n")
-	if len(lines) > authFailureTailLines {
-		lines = lines[len(lines)-authFailureTailLines:]
-	}
-	return DetectModelUnavailable(strings.Join(lines, "\n"))
+	return DetectModelUnavailable(tail)
 }

--- a/internal/worker/ratelimit.go
+++ b/internal/worker/ratelimit.go
@@ -116,18 +116,40 @@ func OutputContainsRateLimit(output string) bool {
 	return hit
 }
 
-// IsRateLimited checks if a log file contains rate-limit error messages.
-// It reads the entire file and looks for known rate-limit patterns.
-// Used to detect rate-limiting in dead workers for fallback logic.
-func IsRateLimited(logFile string) bool {
+// logTail reads a dead worker's log file and returns its last n lines. It is
+// the shared read for every post-mortem log classifier in this package: the
+// error that killed a CLI is its terminal output, while earlier log content
+// can echo the same strings as prompt or work content (a worker fixing a
+// quota classifier, a runbook quoting the provider message). ok=false means
+// the path is empty or the file is unreadable.
+func logTail(logFile string, n int) (string, bool) {
 	if logFile == "" {
-		return false
+		return "", false
 	}
 	data, err := os.ReadFile(logFile)
 	if err != nil {
+		return "", false
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n"), true
+}
+
+// IsRateLimited checks whether a dead worker's log file ends with a
+// rate-limit error message. Only the last authFailureTailLines lines are
+// scanned — a long-running worker can echo live quota text as prompt or work
+// output and later die for an unrelated reason; scanning the whole log let
+// that echo classify the death as a provider limit (#805 review). The
+// terminal error that actually killed the CLI is always within the tail.
+// Used to detect rate-limiting in dead workers for fallback logic.
+func IsRateLimited(logFile string) bool {
+	tail, ok := logTail(logFile, authFailureTailLines)
+	if !ok {
 		return false
 	}
-	return OutputContainsRateLimit(string(data))
+	return OutputContainsRateLimit(tail)
 }
 
 // ClassifyRateLimit inspects output for a rate-limit signal and reports both
@@ -182,15 +204,37 @@ func ParseRateLimitReset(output string) (time.Time, bool) {
 // wall-clock time strictly after now. Without this, the reset went unparsed,
 // the death stayed a low-confidence rate-limit signal (#663), and the
 // orchestrator burned the per-issue retry budget on a quota-dead backend.
+//
+// When the output carries several "try again at" hints, the LAST parseable
+// one wins: the hint the provider printed as the CLI died is the most recent
+// output, while an earlier occurrence can be an echo of prompt or work
+// content quoting the same message (#805 review).
 func ParseRateLimitResetAt(output string, now time.Time) (time.Time, bool) {
-	m := rateLimitResetRe.FindStringSubmatch(output)
-	if m == nil {
+	matches := rateLimitResetRe.FindAllStringSubmatch(output, -1)
+	for i := len(matches) - 1; i >= 0; i-- {
+		if ts, ok := parseResetTimestamp(matches[i][1]); ok {
+			return ts, true
+		}
+		if ts, ok := parseTimeOnlyReset(matches[i][1], now); ok {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// ParseRateLimitResetFromLog extracts the provider-stated reset hint from a
+// dead worker's log file, resolving time-only hints against the given
+// reference time. Like IsRateLimited it scans only the last
+// authFailureTailLines lines — a "try again at ..." echoed mid-log as prompt
+// or work content must not lend a later, unrelated death a high-confidence
+// reset window (#805 review). ok=false when the file is unreadable or the
+// tail carries no parseable hint.
+func ParseRateLimitResetFromLog(logFile string, now time.Time) (time.Time, bool) {
+	tail, ok := logTail(logFile, authFailureTailLines)
+	if !ok {
 		return time.Time{}, false
 	}
-	if ts, ok := parseResetTimestamp(m[1]); ok {
-		return ts, true
-	}
-	return parseTimeOnlyReset(m[1], now)
+	return ParseRateLimitResetAt(tail, now)
 }
 
 // parseTimeOnlyReset resolves a clock-only "<when>" capture ("12:30 PM",

--- a/internal/worker/ratelimit.go
+++ b/internal/worker/ratelimit.go
@@ -74,6 +74,20 @@ var resetLayouts = []string{
 // can drop the suffix before parsing ("May 30th" -> "May 30").
 var ordinalSuffixRe = regexp.MustCompile(`(?i)(\d{1,2})(st|nd|rd|th)`)
 
+// timeOnlyResetLayouts are the clock-only layouts tried when no date-bearing
+// layout in resetLayouts matches the "try again at <when>" capture. Codex
+// emits this shape when the quota resets later the same day — the live #805
+// signature was "You've hit your usage limit ... try again at 12:30 PM."
+// with no date at all, which the date-bearing layouts reject; the reset then
+// went unparsed, the rate-limit signal stayed low-confidence (#663), and no
+// failover fired. A clock-only hint is resolved against a reference time to
+// the NEXT occurrence of that wall-clock time (see parseTimeOnlyReset).
+var timeOnlyResetLayouts = []string{
+	"3:04 PM",
+	"3:04PM",
+	"15:04",
+}
+
 // DetectRateLimit scans multi-line output for known rate-limit / quota error
 // patterns. Returns true and the matching pattern label on the first match,
 // or false and "" if no rate-limit pattern is found.
@@ -130,11 +144,19 @@ func IsRateLimited(logFile string) bool {
 // can wedge the session in a respawn loop when no fallback is configured.
 // See issue #663.
 func ClassifyRateLimit(output string) (hit bool, label string, confidence string, resetAt time.Time) {
+	return ClassifyRateLimitAt(output, time.Now().UTC())
+}
+
+// ClassifyRateLimitAt is ClassifyRateLimit with an explicit reference time,
+// used to resolve time-only reset hints ("try again at 12:30 PM", #805) to an
+// absolute instant. Callers on the live path pass time.Now().UTC(); tests pass
+// a fixed clock.
+func ClassifyRateLimitAt(output string, now time.Time) (hit bool, label string, confidence string, resetAt time.Time) {
 	hit, label = DetectRateLimit(output)
 	if !hit {
 		return false, "", "", time.Time{}
 	}
-	if reset, ok := ParseRateLimitReset(output); ok {
+	if reset, ok := ParseRateLimitResetAt(output, now); ok {
 		return true, label, "high", reset
 	}
 	return true, label, "low", time.Time{}
@@ -150,11 +172,56 @@ func ClassifyRateLimit(output string) (hit bool, label string, confidence string
 // interpreted in UTC. Callers that need wall-clock precision should treat the
 // result as a best-effort lower bound for the cooldown, not an exact instant.
 func ParseRateLimitReset(output string) (time.Time, bool) {
+	return ParseRateLimitResetAt(output, time.Now().UTC())
+}
+
+// ParseRateLimitResetAt is ParseRateLimitReset with an explicit reference
+// time. Date-bearing hints parse as before; a time-only hint ("try again at
+// 12:30 PM" — the live codex phrasing from #805, emitted when the quota
+// resets later the same day) is resolved to the next occurrence of that
+// wall-clock time strictly after now. Without this, the reset went unparsed,
+// the death stayed a low-confidence rate-limit signal (#663), and the
+// orchestrator burned the per-issue retry budget on a quota-dead backend.
+func ParseRateLimitResetAt(output string, now time.Time) (time.Time, bool) {
 	m := rateLimitResetRe.FindStringSubmatch(output)
 	if m == nil {
 		return time.Time{}, false
 	}
-	return parseResetTimestamp(m[1])
+	if ts, ok := parseResetTimestamp(m[1]); ok {
+		return ts, true
+	}
+	return parseTimeOnlyReset(m[1], now)
+}
+
+// parseTimeOnlyReset resolves a clock-only "<when>" capture ("12:30 PM",
+// "12:30pm", "09:15") against the reference time: the result is today's
+// occurrence of that wall-clock time in UTC, rolled to tomorrow when it has
+// already passed. Like the date-bearing layouts the provider states no
+// timezone, so the result is a best-effort lower bound for the cooldown.
+func parseTimeOnlyReset(raw string, now time.Time) (time.Time, bool) {
+	if now.IsZero() {
+		return time.Time{}, false
+	}
+	cleaned := strings.TrimRight(strings.TrimSpace(raw), ". ")
+	if cleaned == "" {
+		return time.Time{}, false
+	}
+	// Collapse whitespace and uppercase so "12:30pm" / "8:13  pm" parse with
+	// Go's reference layouts (which only accept "PM").
+	cleaned = strings.ToUpper(strings.Join(strings.Fields(cleaned), " "))
+	now = now.UTC()
+	for _, layout := range timeOnlyResetLayouts {
+		clock, err := time.ParseInLocation(layout, cleaned, time.UTC)
+		if err != nil {
+			continue
+		}
+		candidate := time.Date(now.Year(), now.Month(), now.Day(), clock.Hour(), clock.Minute(), 0, 0, time.UTC)
+		if !candidate.After(now) {
+			candidate = candidate.Add(24 * time.Hour)
+		}
+		return candidate, true
+	}
+	return time.Time{}, false
 }
 
 // parseResetTimestamp normalizes and parses a single "<when>" capture extracted

--- a/internal/worker/ratelimit_test.go
+++ b/internal/worker/ratelimit_test.go
@@ -471,3 +471,104 @@ func TestParseRateLimitReset_Variants(t *testing.T) {
 		})
 	}
 }
+
+// codexTimeOnlySignature is the live #805 signature (BeFeast/ok-folio fleet,
+// 2026-07-02): codex states only a wall-clock reset with no date. The
+// date-bearing layouts reject it, so before #805 the reset went unparsed, the
+// death stayed low-confidence, and no failover fired.
+const codexTimeOnlySignature = "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/codex/settings/usage) or try again at 12:30 PM."
+
+// TestParseRateLimitResetAt_TimeOnly verifies clock-only reset hints resolve
+// against the reference time: same day when the clock time is still ahead,
+// next day when it has already passed (#805).
+func TestParseRateLimitResetAt_TimeOnly(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		now   time.Time
+		want  time.Time
+		ok    bool
+	}{
+		{
+			name:  "clock ahead of now resolves same day",
+			input: codexTimeOnlySignature,
+			now:   time.Date(2026, time.July, 2, 1, 17, 0, 0, time.UTC),
+			want:  time.Date(2026, time.July, 2, 12, 30, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "clock already passed rolls to next day",
+			input: codexTimeOnlySignature,
+			now:   time.Date(2026, time.July, 2, 22, 45, 0, 0, time.UTC),
+			want:  time.Date(2026, time.July, 3, 12, 30, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "clock equal to now rolls to next day",
+			input: codexTimeOnlySignature,
+			now:   time.Date(2026, time.July, 2, 12, 30, 0, 0, time.UTC),
+			want:  time.Date(2026, time.July, 3, 12, 30, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "lowercase meridiem",
+			input: "You've hit your usage limit. try again at 8:13pm.",
+			now:   time.Date(2026, time.July, 2, 10, 0, 0, 0, time.UTC),
+			want:  time.Date(2026, time.July, 2, 20, 13, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "24h clock",
+			input: "quota exceeded; try again at 09:15",
+			now:   time.Date(2026, time.July, 2, 10, 0, 0, 0, time.UTC),
+			want:  time.Date(2026, time.July, 3, 9, 15, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "date-bearing hint keeps absolute parse",
+			input: codexUsageLimitSignature,
+			now:   time.Date(2026, time.July, 2, 10, 0, 0, 0, time.UTC),
+			want:  time.Date(2026, time.May, 30, 20, 13, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "unparseable hint still fails",
+			input: "try again at some point soon.",
+			now:   time.Date(2026, time.July, 2, 10, 0, 0, 0, time.UTC),
+			ok:    false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseRateLimitResetAt(tc.input, tc.now)
+			if ok != tc.ok {
+				t.Fatalf("ParseRateLimitResetAt ok = %v, want %v (got %v)", ok, tc.ok, got)
+			}
+			if tc.ok && !got.Equal(tc.want) {
+				t.Errorf("ParseRateLimitResetAt = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyRateLimitAt_TimeOnlyIsHighConfidence: the #805 signature must
+// classify as a HIGH-confidence rate limit so the orchestrator's provider-limit
+// fallover fires instead of burning the per-issue retry budget on retries
+// against a quota-dead backend.
+func TestClassifyRateLimitAt_TimeOnlyIsHighConfidence(t *testing.T) {
+	now := time.Date(2026, time.July, 2, 1, 17, 0, 0, time.UTC)
+	hit, label, confidence, resetAt := ClassifyRateLimitAt(codexTimeOnlySignature, now)
+	if !hit {
+		t.Fatal("expected hit=true on the codex time-only usage-limit signature")
+	}
+	if label != "hit_limit" {
+		t.Errorf("label = %q, want hit_limit", label)
+	}
+	if confidence != "high" {
+		t.Errorf("confidence = %q, want high — a resolvable time-only reset is a positive signal (#805)", confidence)
+	}
+	want := time.Date(2026, time.July, 2, 12, 30, 0, 0, time.UTC)
+	if !resetAt.Equal(want) {
+		t.Errorf("resetAt = %v, want %v", resetAt, want)
+	}
+}

--- a/internal/worker/ratelimit_test.go
+++ b/internal/worker/ratelimit_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -570,5 +571,91 @@ func TestClassifyRateLimitAt_TimeOnlyIsHighConfidence(t *testing.T) {
 	want := time.Date(2026, time.July, 2, 12, 30, 0, 0, time.UTC)
 	if !resetAt.Equal(want) {
 		t.Errorf("resetAt = %v, want %v", resetAt, want)
+	}
+}
+
+// #805 review regression: a long-running worker can echo the live quota text
+// early in its log — a prompt quoting the provider message, work output
+// touching this very classifier — and later die for an unrelated reason.
+// Post-mortem detection must scan only the log tail, so an echo buried above
+// it neither classifies the death as rate-limited nor lends it a parseable
+// reset window.
+func TestIsRateLimited_QuotaEchoBeyondTail_NotDetected(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "worker.log")
+	var b strings.Builder
+	b.WriteString("## Issue body\n")
+	b.WriteString(codexTimeOnlySignature + "\n")
+	for i := 0; i < authFailureTailLines+20; i++ {
+		b.WriteString("normal work output\n")
+	}
+	b.WriteString("worker finished normally\n")
+	if err := os.WriteFile(logFile, []byte(b.String()), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	if IsRateLimited(logFile) {
+		t.Error("IsRateLimited must not match a quota echo above the log tail")
+	}
+	now := time.Date(2026, time.July, 2, 11, 0, 0, 0, time.UTC)
+	if reset, ok := ParseRateLimitResetFromLog(logFile, now); ok {
+		t.Errorf("ParseRateLimitResetFromLog = %v, want no parse — the hint is above the tail", reset)
+	}
+}
+
+// The terminal quota error that actually killed the CLI is always within the
+// tail, however long the log: tail-bounding must not lose the true positive.
+func TestIsRateLimited_TerminalQuotaErrorOnLongLog_StillDetected(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "worker.log")
+	var b strings.Builder
+	for i := 0; i < authFailureTailLines+200; i++ {
+		b.WriteString("normal work output\n")
+	}
+	b.WriteString(codexTimeOnlySignature + "\n")
+	if err := os.WriteFile(logFile, []byte(b.String()), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	if !IsRateLimited(logFile) {
+		t.Error("IsRateLimited must still match the terminal quota error on a long log")
+	}
+	now := time.Date(2026, time.July, 2, 11, 0, 0, 0, time.UTC)
+	reset, ok := ParseRateLimitResetFromLog(logFile, now)
+	if !ok {
+		t.Fatal("ParseRateLimitResetFromLog should parse the terminal time-only hint")
+	}
+	want := time.Date(2026, time.July, 2, 12, 30, 0, 0, time.UTC)
+	if !reset.Equal(want) {
+		t.Errorf("reset = %v, want %v", reset, want)
+	}
+}
+
+// #805 review: when several "try again at" hints survive into the scanned
+// output, the LAST parseable one wins — the terminal error beats an earlier
+// echo — and an unparseable trailing capture falls back to the previous
+// parseable hint instead of failing the whole parse.
+func TestParseRateLimitResetAt_LastParseableHintWins(t *testing.T) {
+	now := time.Date(2026, time.July, 2, 8, 0, 0, 0, time.UTC)
+
+	echoThenTerminal := "the issue body quotes the provider: try again at 9:00 AM.\n" +
+		codexTimeOnlySignature + "\n"
+	got, ok := ParseRateLimitResetAt(echoThenTerminal, now)
+	if !ok {
+		t.Fatal("expected the terminal hint to parse")
+	}
+	want := time.Date(2026, time.July, 2, 12, 30, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("reset = %v, want %v — the terminal hint must beat the earlier echo", got, want)
+	}
+
+	terminalThenGarbage := codexTimeOnlySignature + "\n" +
+		"and the docs say to try again at some point soon.\n"
+	got, ok = ParseRateLimitResetAt(terminalThenGarbage, now)
+	if !ok {
+		t.Fatal("an unparseable trailing capture must fall back to the earlier parseable hint")
+	}
+	if !got.Equal(want) {
+		t.Errorf("reset = %v, want %v", got, want)
 	}
 }

--- a/internal/worker/usagelimit.go
+++ b/internal/worker/usagelimit.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"os"
 	"regexp"
 	"strings"
 )
@@ -81,16 +80,9 @@ func DetectUsageLimit(output string, extraPatterns []string) (bool, string) {
 // earlier by the provider-limit path (any worker age) with the provider's own
 // RetryAfter.
 func IsUsageLimit(logFile string, extraPatterns []string) (bool, string) {
-	if logFile == "" {
+	tail, ok := logTail(logFile, authFailureTailLines)
+	if !ok {
 		return false, ""
 	}
-	data, err := os.ReadFile(logFile)
-	if err != nil {
-		return false, ""
-	}
-	lines := strings.Split(string(data), "\n")
-	if len(lines) > authFailureTailLines {
-		lines = lines[len(lines)-authFailureTailLines:]
-	}
-	return DetectUsageLimit(strings.Join(lines, "\n"), extraPatterns)
+	return DetectUsageLimit(tail, extraPatterns)
 }

--- a/internal/worker/usagelimit.go
+++ b/internal/worker/usagelimit.go
@@ -1,0 +1,96 @@
+package worker
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+// usageLimitPatterns holds compiled regexes for detecting that a backend CLI
+// died because the account's usage quota is exhausted (#805; live: codex
+// "You've hit your usage limit ... try again at 12:30 PM" killed every
+// dispatch on the then-default backend). This is deliberately a high-precision
+// SUBSET of rateLimitPatterns: an account-level quota exhaustion lasts until
+// the provider window resets, so a dead worker matching one of these is a
+// backend failure worth gating and falling over even when no reset time is
+// parseable. The generic capacity signals (HTTP 429, "too many requests",
+// "rate limit exceeded", "resource_exhausted") are intentionally EXCLUDED —
+// they are transient, and acting on them without a provider-stated reset is
+// the false-positive class from #663.
+//
+// Supported signatures (case-insensitive):
+//   - "You've hit your (usage )?limit" (Codex / Claude provider phrasing)
+//   - "chatgpt.com/codex/settings/usage" marker (Codex usage-limit URL)
+//   - "usage/5-hour/weekly limit reached" (claude CLI subscription-window
+//     phrasings, e.g. "Claude usage limit reached ...")
+var usageLimitPatterns = []struct {
+	label string
+	re    *regexp.Regexp
+}{
+	{"hit_limit", regexp.MustCompile(`(?i)you'?ve hit your (usage )?limit`)},
+	{"codex_usage_limit", regexp.MustCompile(`(?i)(chatgpt\.com/)?codex/settings/usage`)},
+	{"usage_limit_reached", regexp.MustCompile(`(?i)\b(?:usage|5-hour|weekly)[ _-]limit reached\b`)},
+}
+
+// DetectUsageLimit scans multi-line output for known account-quota exhaustion
+// signatures, plus any operator-supplied per-backend extra patterns
+// (config: model.backends.<name>.usage_limit_patterns; validated to compile
+// at config parse, so an entry failing to compile here is silently skipped).
+// Returns true and the matching pattern label on the first match — for an
+// extra pattern the label is its regex source. Returns false and "" when
+// nothing matches.
+func DetectUsageLimit(output string, extraPatterns []string) (bool, string) {
+	extras := make([]*regexp.Regexp, 0, len(extraPatterns))
+	for _, p := range extraPatterns {
+		if re, err := regexp.Compile(p); err == nil {
+			extras = append(extras, re)
+		}
+	}
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		for _, p := range usageLimitPatterns {
+			if p.re.MatchString(line) {
+				return true, p.label
+			}
+		}
+		for _, re := range extras {
+			if re.MatchString(line) {
+				return true, re.String()
+			}
+		}
+	}
+	return false, ""
+}
+
+// IsUsageLimit checks whether a dead worker's log file ends with an
+// account-quota exhaustion signature (e.g. the codex "You've hit your usage
+// limit" from #805). Only the last authFailureTailLines lines are scanned —
+// the quota error that killed the CLI is its terminal output, while earlier
+// log content can echo the worker prompt (which for a quota-related issue
+// legitimately quotes these exact strings). Returns the verdict and the
+// matched pattern label.
+//
+// Callers MUST combine this with an early-death window (the worker died
+// shortly after spawn) before classifying the death as a backend failure: a
+// quota-dead CLI dies on its first API call, while a usage-limit signature in
+// a long-lived worker's log is more likely incidental work content than a
+// backend outage. A quota death that also states a parseable reset is handled
+// earlier by the provider-limit path (any worker age) with the provider's own
+// RetryAfter.
+func IsUsageLimit(logFile string, extraPatterns []string) (bool, string) {
+	if logFile == "" {
+		return false, ""
+	}
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		return false, ""
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) > authFailureTailLines {
+		lines = lines[len(lines)-authFailureTailLines:]
+	}
+	return DetectUsageLimit(strings.Join(lines, "\n"), extraPatterns)
+}

--- a/internal/worker/usagelimit_test.go
+++ b/internal/worker/usagelimit_test.go
@@ -1,0 +1,113 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #805 live signature (BeFeast/ok-folio fleet, 2026-07-02): the codex CLI
+// printed this and exited; the daemon saw only "pid dead, tmux missing" and
+// burned the whole per-issue retry budget respawning on the same dead backend.
+const codexUsageLimitDeath = "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/codex/settings/usage) or try again at 12:30 PM."
+
+func TestDetectUsageLimit_KnownSignatures(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		label string
+	}{
+		{"codex hit usage limit", codexUsageLimitDeath, "hit_limit"},
+		{"claude hit limit", "You've hit your limit", "hit_limit"},
+		{"codex usage url only", "See chatgpt.com/codex/settings/usage for details", "codex_usage_limit"},
+		{"claude usage limit reached", "Claude usage limit reached. Your limit will reset at 3am", "usage_limit_reached"},
+		{"claude 5-hour window", "5-hour limit reached ∙ resets 3am", "usage_limit_reached"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hit, label := DetectUsageLimit(tc.input, nil)
+			if !hit {
+				t.Fatalf("DetectUsageLimit(%q) = false, want hit", tc.input)
+			}
+			if label != tc.label {
+				t.Errorf("label = %q, want %q", label, tc.label)
+			}
+		})
+	}
+}
+
+// The generic capacity signals stay excluded: they are transient (the #663
+// false-positive class), not an account-level quota exhaustion. They remain
+// covered by the provider-limit path, which requires a parseable reset.
+func TestDetectUsageLimit_GenericRateLimitSignalsNotClassified(t *testing.T) {
+	cases := []string{
+		"Error: rate limit exceeded.",
+		"HTTP 429 too many requests",
+		"status: 429",
+		"resource_exhausted",
+		"quota exceeded",
+		codexWriteStdinClosed,
+		"processed 14290 records",
+	}
+	for _, in := range cases {
+		if hit, label := DetectUsageLimit(in, nil); hit {
+			t.Errorf("DetectUsageLimit(%q) incorrectly hit (label=%q)", in, label)
+		}
+	}
+}
+
+// #805: operators can extend the classifier per backend via
+// model.backends.<name>.usage_limit_patterns; the matched label is the regex
+// source so BackendHealth.Pattern names which entry fired.
+func TestDetectUsageLimit_ExtraPatterns(t *testing.T) {
+	extra := []string{`(?i)monthly spend cap reached`}
+	hit, label := DetectUsageLimit("ERROR: Monthly spend cap reached for org acme", extra)
+	if !hit {
+		t.Fatal("DetectUsageLimit should match an operator-supplied extra pattern")
+	}
+	if label != extra[0] {
+		t.Errorf("label = %q, want the regex source %q", label, extra[0])
+	}
+	if hit, _ := DetectUsageLimit("ordinary worker output", extra); hit {
+		t.Error("extra pattern must not match ordinary output")
+	}
+	// An invalid extra (config parse rejects these, but stay safe) is skipped
+	// without breaking the built-in signatures.
+	if hit, _ := DetectUsageLimit(codexUsageLimitDeath, []string{"(unclosed"}); !hit {
+		t.Error("built-in signatures must keep matching when an extra pattern fails to compile")
+	}
+}
+
+// IsUsageLimit scans only the log tail: a prompt echo of quota phrasing at the
+// top of a long log (a worker legitimately WORKING ON a quota issue) must not
+// classify, while the same phrasing as terminal output must.
+func TestIsUsageLimit_TailOnly(t *testing.T) {
+	dir := t.TempDir()
+
+	tail := filepath.Join(dir, "tail.log")
+	if err := os.WriteFile(tail, []byte("Starting worker\nProcessing issue #217\n"+codexUsageLimitDeath+"\n"), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	if hit, label := IsUsageLimit(tail, nil); !hit || label != "hit_limit" {
+		t.Fatalf("IsUsageLimit(tail) = %v/%q, want true/hit_limit", hit, label)
+	}
+
+	promptEcho := filepath.Join(dir, "echo.log")
+	content := "Prompt: fix the handler for the provider message \"" + codexUsageLimitDeath + "\"\n" +
+		strings.Repeat("worker made progress on an ordinary line\n", authFailureTailLines+20) +
+		"worker exited normally\n"
+	if err := os.WriteFile(promptEcho, []byte(content), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	if hit, label := IsUsageLimit(promptEcho, nil); hit {
+		t.Fatalf("IsUsageLimit must not classify a prompt echo outside the tail (label=%q)", label)
+	}
+
+	if hit, _ := IsUsageLimit("", nil); hit {
+		t.Error("empty path must not classify")
+	}
+	if hit, _ := IsUsageLimit(filepath.Join(dir, "missing.log"), nil); hit {
+		t.Error("unreadable file must not classify")
+	}
+}


### PR DESCRIPTION
Implements #805

## Changes

- **Time-only reset hints parse** (`worker.ParseRateLimitResetAt` / `ClassifyRateLimitAt`): "try again at 12:30 PM" (the live codex phrasing, no date) resolves to the next wall-clock occurrence, so the quota death is a high-confidence provider limit — the existing failover path gates the backend in `backend_health` with the provider-stated `RetryAfter` and respawns the attempt on the next `fallback_backends` entry in the same cycle. The #663 low-confidence discipline is unchanged for signatures with no resolvable reset outside the cases below.
- **Usage-limit classification without a parseable reset** (`worker.IsUsageLimit` + orchestrator wiring): a worker that dies within the early-death window whose log tail matches an account-quota exhaustion signature ("You've hit your usage limit", codex settings/usage URL, claude "usage limit reached") gates the backend with reason `usage_limit` and a 30-minute re-probe cooldown, fails the attempt over, and is excluded from `FailedAttemptsForIssue` — pure quota deaths no longer consume `max_retries_per_issue`. Generic 429/too-many-requests signals stay excluded (the #663 false-positive class).
- **Pluggable per-backend signatures**: `model.backends.<name>.usage_limit_patterns` extends the classifier with operator regexes, validated at config parse.
- **Scheduled retries consult `backend_health`**: a due retry whose backend is gated substitutes the first healthy fallback (audit reason `retry_fallback_blocked_backend`) instead of respawning `reason=default` onto a dead backend, or defers to the cooldown expiry when every backend is blocked.
- **Surfacing**: `backend_usage_limit` supervisor finding (blocking when the default backend is gated), `backend_usage_limit` session display token + attention copy, and a "Backend health" section in `maestro status` ("codex: cooling down until <reset> (usage_limit)"). `backend_health` rows already reach the fleet API / Mission Control pills and expire via `ReconcileBackendHealth`.
- Docs: reactive-classification section in `docs/subscription-quota.md`.

## Testing

- `go test ./...` passes; `gofmt` clean on changed files; `go build ./cmd/maestro/` ok.
- New tests: time-only reset resolution (same-day / next-day rollover, lowercase meridiem, 24h clock), usage-limit signature precision (tail-only scan, prompt-echo and generic-429 guards, config extras), reconcile + checkSessions quota-death failover with budget preservation, late-death precision guard, retry substitution / all-blocked deferral, supervisor finding severities, display/attention tokens, config regex validation.
- Incident replay test drives the exact 2026-07-02 log line end-to-end through the real classifiers: dead codex worker → `backend_health[codex]` gated with a 12:30 reset → respawn on the fallback backend → zero failed attempts consumed.

Maestro-Backend: claude anthropic claude-fable-5 xhigh (0-end)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds reactive backend quota handling and failover for usage-limit deaths. The main changes are:

- Time-only provider reset hints now parse as the next wall-clock occurrence.
- Usage-limit log tails can gate a backend without consuming issue retry budget.
- Scheduled retries avoid gated backends and defer when all candidates are cooling down.
- Backend health now surfaces in status output and supervisor findings.
- Per-backend `usage_limit_patterns` can extend the classifier with validated regexes.
- Tests cover reset parsing, classifier precision, failover, retry deferral, state display, and supervisor output.

<h3>Confidence Score: 5/5</h3>

This PR appears safe to merge with low risk.

No correctness or security issues were identified in the changed classifier, orchestrator, state, supervisor, CLI, config, or test paths. The previously reported whole-log reset scanning issue is addressed by tail-only log parsing and regression coverage.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex updated the respawn logic to cover the time-only usage-limit case on claude with BackendHealth\[codex\] cooldown/provider\_limit and FailedAttemptsForIssue=0, and the no-reset usage-limit case with retryAfterIn=30m0s, while preserving the #663 guard for generic 429.
- T-Rex executed the trex retry-health evidence test and verified that the head respawned on claude with reason retry\_fallback\_blocked\_backend and deferred all-blocked NextRetryAt to the earliest fallback cooldown.
- T-Rex ran the surfacing validation workflow and confirmed the head passed Go contract tests, built the binary, and displayed Backend health with cooling down usage\_limit and codex\_usage\_limit, including docs lines for reactive classification/usage-limit quota behavior.

<a href="https://app.greptile.com/trex/runs/13164311/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Threads provider-limit and usage-limit classification through dead-worker reconciliation and scheduled retries. |
| internal/orchestrator/backend_selector.go | Adds usage-limit fallback copy, cooldown selection, retry fallback reason, and earliest cooldown deferral. |
| internal/worker/ratelimit.go | Adds time-only reset parsing, tail-only log reset classification, and last-hint precedence. |
| internal/worker/usagelimit.go | Adds high-precision account usage-limit classification with operator-supplied regex support. |
| internal/config/config.go | Adds `usage_limit_patterns` backend config and parse-time regex validation. |
| internal/state/state.go | Adds usage-limit backend block and display status handling. |
| internal/supervisor/supervisor.go | Surfaces active usage-limit backend cooldowns as supervisor stuck-state findings. |
| cmd/maestro/main.go | Adds backend health cooldown display to `maestro status`. |

<sub>Reviews (4): Last reviewed commit: ["fix: scan only the log tail for post-mor..."](https://github.com/befeast/maestro/commit/7ce01b3c5ebd56b310a0202618af2b0d1880b655) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41571447)</sub>

<!-- /greptile_comment -->