### PR TITLE
fix: self-deploy builds with -buildvcs=false so merges reliably ship (#807)

### DIFF
--- a/docs/self-deploy-runbook.md
+++ b/docs/self-deploy-runbook.md
@@ -35,8 +35,16 @@ The script then:
 
 1. **Builds from merged main** — fetches `origin/main`, checks it out into a
    temporary git worktree, reads the `VERSION` file, and builds with
-   `-ldflags "-X main.version=<VERSION>+g<shortsha>"` (version stamping per
-   #682, extended with the commit SHA as semver build metadata).
+   `-buildvcs=false -trimpath -ldflags "-X main.version=<VERSION>+g<shortsha>"`
+   (version stamping per #682, extended with the commit SHA as semver build
+   metadata). `-buildvcs=false` is load-bearing (#807): the build runs inside a
+   **detached git worktree** owned by the deploy uid, where Go's default
+   `-buildvcs=auto` shells out to `git status`, trips git's dubious-ownership
+   guard (`safe.directory`), and exits 128 — aborting the build so the merge
+   silently never shipped. On 2026-07-03 this stranded two merged fixes (#806,
+   #798) on the running fleet for ~5h. The version is already stamped via
+   `-ldflags`, so VCS stamping adds nothing here; disabling it makes the build
+   independent of git VCS status in the transient unit.
 2. **Installs atomically** — stages the new binary next to the target
    (`<bin>.next`), preserves the current binary as `<bin>.prev`, and renames
    into place (same-filesystem rename; safe under a running process). When
@@ -64,13 +72,32 @@ The script then:
 5. **Rolls back on failure** — restores `<bin>.prev`, restarts the units
    again, and records the rollback reason. `.prev` is kept either way for
    manual rollback.
-6. **Writes a result file** — `<state_dir>/self-deploy-result.json`. The next
-   orchestrator cycle (running the new binary, on success) consumes it,
-   records a **supervisor finding** (deployed version / rollback reason)
-   visible in Mission Control, and sends a notification. A `failed` /
+6. **Writes a result file** — `<state_dir>/self-deploy-result.json`, on **every**
+   terminal path (deployed, rolled_back, failed, and the "already at this
+   version" no-op). The script's `set -e` ERR trap plus an EXIT trap guarantee a
+   result even when a step bails unexpectedly, so a merge never silently produces
+   no record. The next orchestrator cycle (running the new binary, on success)
+   consumes it, records a **supervisor finding** (deployed version / rollback
+   reason) visible in Mission Control, and sends a notification. A `failed` /
    `rolled_back` result surfaces as an **error-tone operator state**
    ("Self-deploy failed") in `/api/v1/fleet`, so an undeployed-but-merged host
    is loud rather than buried in journald (#711).
+
+### Stale-trigger watchdog (#807)
+
+The one case the result file cannot cover is the detached deploy unit dying
+**before it can write one** — SIGKILLed at the `RuntimeMaxSec` backstop, or a
+crash before the EXIT trap runs. That leaves a recorded trigger
+(`self-deploy-last-trigger.json`) with no result and no restart — exactly the
+silent no-op that stranded #806/#798. The orchestrator watches for it: each
+cycle, if a trigger is older than the `RuntimeMaxSec` backstop (2×
+`timeout_minutes`, past which systemd has definitively killed the unit) and no
+result landed, it records a **`self-deploy: no result … — the deploy unit died`**
+supervisor finding and notifies, then advances a resolved watermark
+(`self-deploy-last-resolved.json`) so the alert fires once, not every cycle. The
+watermark also distinguishes a genuinely-lost deploy from a completed one whose
+trigger marker legitimately outlives its consumed result. A later merge (or
+observed main-advance) re-triggers a fresh deploy automatically.
 
 ## Enabling it
 
@@ -242,6 +269,8 @@ maestro version
 | Finding `self-deploy: failed … no .prev` | First deploy failed before any previous binary existed | Build + install manually once, re-merge |
 | Finding `rolled_back … health check timed out` | New binary started but never reported the stamped version | Check `journalctl --user -u maestro.service`; the regression is in the merged code |
 | No finding, no restart | Trigger failed (script missing, systemd-run unavailable) | Orchestrator log shows `self-deploy trigger failed …`; a ⚠️ notification is sent |
+| Deploy log `error obtaining VCS status: exit status 128` | `go build` in the detached worktree tripped git's dubious-ownership guard | Fixed in #807 — the build now passes `-buildvcs=false`; if you see this, the deploy script is pre-#807 (update it) |
+| Finding `self-deploy: no result … — the deploy unit died` | Trigger recorded but the transient unit never wrote a result (SIGKILLed at `RuntimeMaxSec`, or crashed pre-EXIT-trap) (#807) | Inspect `journalctl -u 'maestro-self-deploy-*'`; verify `maestro version` + units by hand; a later merge retries automatically |
 | Log `self-deploy debounced for PR #… < … window` | A deploy was triggered within `min_interval_minutes` of the previous one — expected on a burst of merges (#722) | None; the in-flight/previous deploy covers the merged code. Lower `min_interval_minutes` for faster successive deploys |
 | Deploy log `another self-deploy holds … — skipping` | A deploy started while one was already in flight; the single-flight lock skipped it (#722) | None; the in-flight deploy owns the rollout |
 | Units inactive after rollback | Rollback restart also failed | `systemctl --user start maestro.service` by hand; binary on disk is the previous version |

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1869,7 +1869,14 @@ func (o *Orchestrator) RunOnce() error {
 	// Step 0: Surface a finished self-deploy (#698) as a supervisor finding.
 	// Persist immediately: the result file is already consumed, so the
 	// finding must not depend on the rest of the cycle succeeding.
-	if o.consumeSelfDeployResult(s) {
+	// The stale-trigger watchdog (#807) runs in the same step, right after — it
+	// makes the OPPOSITE outcome loud: a trigger that produced no result because
+	// the detached deploy unit died silently. Both persist together.
+	changed := o.consumeSelfDeployResult(s)
+	if o.maybeSurfaceStaleSelfDeploy(s) {
+		changed = true
+	}
+	if changed {
 		if err := state.Save(o.cfg.StateDir, s); err != nil {
 			return fmt.Errorf("save state after self-deploy result: %w", err)
 		}
@@ -4653,7 +4660,16 @@ func (o *Orchestrator) consumeSelfDeployResult(s *state.State) bool {
 		return false
 	}
 
-	finding := selfdeploy.Finding(res, o.cfg.Repo, time.Now().UTC())
+	now := time.Now().UTC()
+	// Advance the resolved watermark so the stale-trigger watchdog (#807) does not
+	// later flag this now-consumed deploy: its trigger marker legitimately outlives
+	// the result file we just cleared, and without this watermark that surviving
+	// marker would eventually look like a trigger that never produced a result.
+	if err := selfdeploy.RecordResolved(o.cfg.StateDir, now); err != nil {
+		log.Printf("[orch] self-deploy resolved-watermark write failed: %v", err)
+	}
+
+	finding := selfdeploy.Finding(res, o.cfg.Repo, now)
 	s.RecordSupervisorDecision(finding, state.DefaultSupervisorDecisionLimit)
 	log.Printf("[orch] %s", finding.Summary)
 
@@ -4665,6 +4681,54 @@ func (o *Orchestrator) consumeSelfDeployResult(s *state.State) bool {
 	default:
 		o.notifier.Sendf("❌ maestro: self-deploy FAILED after PR #%d: %s — manual intervention may be needed", res.PR, res.Reason)
 	}
+	return true
+}
+
+// selfDeployStaleTimeout is how long after a trigger a missing result file is
+// treated as a dead deploy (#807). The transient unit's RuntimeMaxSec hard
+// backstop is 2× the deploy budget (see selfdeploy.TriggerCommand), past which
+// systemd has definitively killed the unit — so a trigger older than that with
+// no result cannot be an in-flight deploy. Match that backstop so the watchdog
+// never false-flags a slow-but-live deploy.
+func (o *Orchestrator) selfDeployStaleTimeout() time.Duration {
+	return time.Duration(o.cfg.SelfDeploy.EffectiveTimeoutMinutes()) * 2 * time.Minute
+}
+
+// maybeSurfaceStaleSelfDeploy is the watchdog for the silent-no-op failure that
+// motivated #807: a merge triggered a self-deploy, but the detached transient
+// unit died without ever writing a result file (SIGKILLed at RuntimeMaxSec, or
+// crashed before its own EXIT trap could run), so the fleet keeps running the
+// previous binary with nothing but a lone journald line to show for it. The
+// normal consume path only surfaces deploys that DID write a result; this makes
+// the absence itself loud.
+//
+// It runs right after consumeSelfDeployResult (which clears any present result
+// and advances the resolved watermark), so a trigger seen here with no result
+// and older than the RuntimeMaxSec backstop is a genuine silent loss. On
+// detection it records a supervisor finding and advances the resolved watermark
+// past the dead trigger, so the finding surfaces once (not every cycle) and a
+// later merge/main-advance re-triggers a fresh deploy. Returns true when it
+// recorded a finding (state changed). No-op unless self_deploy is enabled.
+func (o *Orchestrator) maybeSurfaceStaleSelfDeploy(s *state.State) bool {
+	if o == nil || o.cfg == nil || !o.cfg.SelfDeploy.Enabled || s == nil {
+		return false
+	}
+	now := time.Now().UTC()
+	pr, age, stale := selfdeploy.StaleTrigger(o.cfg.StateDir, now, o.selfDeployStaleTimeout())
+	if !stale {
+		return false
+	}
+	// Advance the resolved watermark past this dead trigger BEFORE recording, so
+	// even if the save below fails the watchdog does not re-flag the same trigger
+	// every cycle. Losing a single finding is the lesser failure mode; a later
+	// merge re-triggers regardless.
+	if err := selfdeploy.RecordResolved(o.cfg.StateDir, now); err != nil {
+		log.Printf("[orch] self-deploy stale-trigger watermark write failed: %v", err)
+	}
+	finding := selfdeploy.StaleTriggerFinding(pr, age, o.cfg.Repo, now)
+	s.RecordSupervisorDecision(finding, state.DefaultSupervisorDecisionLimit)
+	log.Printf("[orch] %s", finding.Summary)
+	o.notifier.Sendf("❗ maestro: self-deploy produced no result %s after triggering (PR #%d) — the deploy unit died; fleet still on the previous binary", age.Round(time.Minute), pr)
 	return true
 }
 

--- a/internal/orchestrator/selfdeploy_test.go
+++ b/internal/orchestrator/selfdeploy_test.go
@@ -411,6 +411,123 @@ func TestConsumeSelfDeployResult_NoFile(t *testing.T) {
 	}
 }
 
+// #807: a trigger that never produced a result within the RuntimeMaxSec backstop
+// — the detached deploy unit died silently — surfaces as a supervisor finding
+// exactly once (the resolved watermark advances so it does not re-fire every
+// cycle), and a later merge re-triggers.
+func TestMaybeSurfaceStaleSelfDeploy_Fires(t *testing.T) {
+	stateDir := t.TempDir()
+	// A trigger fired 90 minutes ago (past the default 2×30m backstop) with no
+	// result file — the silent-loss case.
+	if err := selfdeploy.RecordTrigger(stateDir, 806, time.Now().UTC().Add(-90*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   stateDir,
+			SelfDeploy: config.SelfDeployConfig{Enabled: true},
+		},
+		notifier: &notify.Notifier{},
+	}
+	s := &state.State{}
+
+	if !o.maybeSurfaceStaleSelfDeploy(s) {
+		t.Fatal("maybeSurfaceStaleSelfDeploy = false, want true (stale trigger)")
+	}
+	if len(s.SupervisorDecisions) != 1 {
+		t.Fatalf("decisions recorded = %d, want 1", len(s.SupervisorDecisions))
+	}
+	d := s.SupervisorDecisions[0]
+	if d.Status != "failed" {
+		t.Errorf("Status = %q, want failed", d.Status)
+	}
+	if !strings.Contains(d.Summary, "no result") || !strings.Contains(d.Summary, "PR #806") {
+		t.Errorf("Summary = %q", d.Summary)
+	}
+
+	// Second cycle: the watermark advanced, so the same dead trigger must not
+	// re-fire (no finding storm).
+	if o.maybeSurfaceStaleSelfDeploy(s) {
+		t.Fatal("stale trigger re-fired on the next cycle — watermark did not advance")
+	}
+	if len(s.SupervisorDecisions) != 1 {
+		t.Errorf("decisions after second cycle = %d, want 1", len(s.SupervisorDecisions))
+	}
+}
+
+// Flag default OFF: the watchdog is inert even with an ancient trigger marker.
+func TestMaybeSurfaceStaleSelfDeploy_DefaultOff(t *testing.T) {
+	stateDir := t.TempDir()
+	if err := selfdeploy.RecordTrigger(stateDir, 806, time.Now().UTC().Add(-90*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", StateDir: stateDir},
+		notifier: &notify.Notifier{},
+	}
+	s := &state.State{}
+	if o.maybeSurfaceStaleSelfDeploy(s) || len(s.SupervisorDecisions) != 0 {
+		t.Fatalf("flag off: fired watchdog (decisions=%d)", len(s.SupervisorDecisions))
+	}
+}
+
+// A recent trigger (a deploy still legitimately in flight — build + drain +
+// verify can take the full budget) is never mistaken for a silent loss.
+func TestMaybeSurfaceStaleSelfDeploy_InFlightNotStale(t *testing.T) {
+	stateDir := t.TempDir()
+	if err := selfdeploy.RecordTrigger(stateDir, 806, time.Now().UTC().Add(-5*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   stateDir,
+			SelfDeploy: config.SelfDeployConfig{Enabled: true},
+		},
+		notifier: &notify.Notifier{},
+	}
+	s := &state.State{}
+	if o.maybeSurfaceStaleSelfDeploy(s) || len(s.SupervisorDecisions) != 0 {
+		t.Fatalf("in-flight deploy flagged as stale (decisions=%d)", len(s.SupervisorDecisions))
+	}
+}
+
+// A completed deploy consumed via consumeSelfDeployResult advances the resolved
+// watermark, so the watchdog does NOT then false-flag the surviving trigger
+// marker as a silent loss — even when the trigger is old. This mirrors the real
+// cycle order (consume first, then the watchdog).
+func TestConsumeThenStale_NoFalsePositive(t *testing.T) {
+	stateDir := t.TempDir()
+	// An old trigger, plus its (successful) result waiting to be consumed.
+	if err := selfdeploy.RecordTrigger(stateDir, 806, time.Now().UTC().Add(-90*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(selfdeploy.ResultPath(stateDir), []byte(`{"status":"deployed","version":"1.4.2+gabc1234","pr":806}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:       "owner/repo",
+			StateDir:   stateDir,
+			SelfDeploy: config.SelfDeployConfig{Enabled: true},
+		},
+		notifier: &notify.Notifier{},
+	}
+	s := &state.State{}
+
+	if !o.consumeSelfDeployResult(s) {
+		t.Fatal("consumeSelfDeployResult = false, want true")
+	}
+	// The watchdog must see the consume as a resolution, not a silent loss.
+	if o.maybeSurfaceStaleSelfDeploy(s) {
+		t.Fatal("watchdog flagged a just-consumed deploy as a stale trigger")
+	}
+	if len(s.SupervisorDecisions) != 1 {
+		t.Fatalf("decisions = %d, want 1 (only the deploy finding)", len(s.SupervisorDecisions))
+	}
+}
+
 // A malformed result file is cleared (not re-logged forever) and records nothing.
 func TestConsumeSelfDeployResult_Malformed(t *testing.T) {
 	stateDir := t.TempDir()

--- a/internal/selfdeploy/selfdeploy.go
+++ b/internal/selfdeploy/selfdeploy.go
@@ -62,6 +62,16 @@ const resultFileName = "self-deploy-result.json"
 // orchestrator unit restarting.
 const triggerMarkerName = "self-deploy-last-trigger.json"
 
+// resolvedMarkerName records when a self-deploy result was last consumed, so the
+// stale-trigger watchdog (#807) can tell a trigger that never produced a result
+// (the transient unit died — e.g. SIGKILL at the RuntimeMaxSec backstop, or a
+// crash before the script's own EXIT trap could write one) apart from a trigger
+// whose result was already surfaced and cleared. Without this watermark a
+// completed deploy — whose trigger marker legitimately outlives the consumed
+// result file — would look identical to a silently-lost deploy once the marker
+// aged past the timeout.
+const resolvedMarkerName = "self-deploy-last-resolved.json"
+
 // Result is the JSON contract between scripts/self-deploy.sh and the
 // orchestrator.
 type Result struct {
@@ -154,6 +164,95 @@ func LastTrigger(stateDir string) (when time.Time, pr int, ok bool) {
 		return time.Time{}, 0, false
 	}
 	return m.TriggeredAt, m.PR, true
+}
+
+// resolvedMarker is the JSON persisted by RecordResolved / read by LastResolved.
+type resolvedMarker struct {
+	ResolvedAt time.Time `json:"resolved_at"`
+}
+
+// resolvedMarkerPath returns the path of the last-resolved watermark inside
+// stateDir.
+func resolvedMarkerPath(stateDir string) string {
+	return filepath.Join(stateDir, resolvedMarkerName)
+}
+
+// RecordResolved advances the resolved watermark to `when` — the moment a deploy
+// outcome was accounted for, either because its result file was consumed or
+// because the stale-trigger watchdog surfaced its silent loss (#807). A trigger
+// whose timestamp is at or before this watermark has already been resolved, so
+// the watchdog will not (re-)flag it. A blank stateDir is a no-op, matching
+// RecordTrigger.
+func RecordResolved(stateDir string, when time.Time) error {
+	if strings.TrimSpace(stateDir) == "" {
+		return nil
+	}
+	data, err := json.Marshal(resolvedMarker{ResolvedAt: when.UTC()})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return err
+	}
+	tmp := resolvedMarkerPath(stateDir) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, resolvedMarkerPath(stateDir))
+}
+
+// LastResolved reports when a self-deploy outcome was last accounted for. A
+// missing or malformed watermark reports ok=false (treated as "nothing resolved
+// yet" — fail toward flagging so a genuinely-lost deploy is never hidden).
+func LastResolved(stateDir string) (when time.Time, ok bool) {
+	if strings.TrimSpace(stateDir) == "" {
+		return time.Time{}, false
+	}
+	data, err := os.ReadFile(resolvedMarkerPath(stateDir))
+	if err != nil {
+		return time.Time{}, false
+	}
+	var m resolvedMarker
+	if err := json.Unmarshal(data, &m); err != nil || m.ResolvedAt.IsZero() {
+		return time.Time{}, false
+	}
+	return m.ResolvedAt, true
+}
+
+// StaleTrigger reports a self-deploy trigger that fired but produced no result
+// within `timeout` (#807): the detached transient unit died without writing a
+// result file — the silent-no-op class this whole change targets (a merge that
+// never shipped and never surfaced). It returns the triggering PR, the trigger's
+// age, and stale=true only when ALL hold:
+//
+//   - a trigger marker exists in stateDir;
+//   - no result file is present (a present result is consumed on this same cycle,
+//     so it is not a silent loss);
+//   - the trigger is newer than the resolved watermark (its outcome has not
+//     already been accounted for — this is what keeps a completed-and-cleared
+//     deploy, whose marker outlives its consumed result, from false-flagging);
+//   - the trigger is older than `timeout`, so an in-flight deploy (build + drain
+//   - verify can legitimately take the full budget) is never mistaken for a
+//     lost one. Callers pass a timeout at/above the unit's RuntimeMaxSec hard
+//     backstop, past which systemd has definitively killed the unit.
+func StaleTrigger(stateDir string, now time.Time, timeout time.Duration) (pr int, age time.Duration, stale bool) {
+	when, pr, ok := LastTrigger(stateDir)
+	if !ok {
+		return 0, 0, false
+	}
+	// A result waiting to be consumed is not a silent loss.
+	if res, err := ReadResult(stateDir); err == nil && res != nil {
+		return 0, 0, false
+	}
+	// Already accounted for (result consumed, or previously flagged).
+	if resolved, ok := LastResolved(stateDir); ok && !when.After(resolved) {
+		return 0, 0, false
+	}
+	age = now.Sub(when)
+	if age < timeout {
+		return 0, 0, false
+	}
+	return pr, age, true
 }
 
 // BuildSHA recovers the git commit SHA a maestro binary was built from out of
@@ -370,6 +469,35 @@ func TriggerFailedFinding(prNumber int, triggerErr error, project string, now ti
 		RecommendedAction: "the detached deploy unit never launched: check `sudo -n systemd-run`/`systemd-run --user` from the orchestrator's service context, " +
 			"then redeploy by hand (a later merge retries automatically)",
 		Reasons: []string{"trigger error: " + reason},
+	}
+}
+
+// StaleTriggerFinding converts a self-deploy trigger that never produced a
+// result within the timeout — the detached deploy unit died silently — into a
+// supervisor finding (#807). This is the loud backstop for the failure that
+// motivated the issue: a merge triggered a deploy, the transient unit exited
+// (or was SIGKILLed at RuntimeMaxSec) without writing a result, and the fleet
+// kept running the previous binary with nothing but a lone journald line to show
+// for it. The next merge/main-advance re-triggers automatically once the
+// resolved watermark advances past this trigger.
+func StaleTriggerFinding(prNumber int, age time.Duration, project string, now time.Time) state.SupervisorDecision {
+	prSuffix := ""
+	if prNumber > 0 {
+		prSuffix = fmt.Sprintf(" after PR #%d", prNumber)
+	}
+	return state.SupervisorDecision{
+		ID:               "self-deploy-stale-trigger-" + now.Format("20060102T150405.000000000Z"),
+		CreatedAt:        now,
+		Project:          project,
+		Risk:             "safe",
+		Confidence:       1.0,
+		RequiresApproval: false,
+		Status:           "failed",
+		Summary: fmt.Sprintf("self-deploy: no result %s after trigger%s — the deploy unit died without deploying; fleet still on the previous binary",
+			age.Round(time.Minute), prSuffix),
+		RecommendedAction: "the detached deploy unit produced no result file (likely killed at RuntimeMaxSec or crashed before writing one): " +
+			"inspect journalctl -u 'maestro-self-deploy-*', verify `maestro version` and units by hand, then redeploy (a later merge retries automatically)",
+		Reasons: []string{fmt.Sprintf("trigger age at detection: %s", age.Round(time.Second))},
 	}
 }
 

--- a/internal/selfdeploy/selfdeploy_script_test.go
+++ b/internal/selfdeploy/selfdeploy_script_test.go
@@ -1,0 +1,135 @@
+package selfdeploy
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// selfDeployScriptPath returns the repo's scripts/self-deploy.sh relative to
+// this test package (internal/selfdeploy → repo root is two levels up).
+func selfDeployScriptPath(t *testing.T) string {
+	t.Helper()
+	p, err := filepath.Abs(filepath.Join("..", "..", "scripts", "self-deploy.sh"))
+	if err != nil {
+		t.Fatalf("resolve script path: %v", err)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("scripts/self-deploy.sh not found at %s: %v", p, err)
+	}
+	return p
+}
+
+// buildLineRE matches the `go build ... ./cmd/maestro/` invocation in the deploy
+// script. The build is the step that silently failed in #807.
+var buildLineRE = regexp.MustCompile(`(?m)^.*go build .*\./cmd/maestro/.*$`)
+
+// #807 regression guard: the deploy build MUST pass -buildvcs=false (otherwise
+// Go's default -buildvcs=auto shells out to git in the detached transient-unit
+// worktree, trips dubious-ownership, exits 128, and the build — hence the whole
+// deploy — silently fails). It must also keep -trimpath and the -X main.version
+// stamp, so the fix doesn't regress version stamping (#682).
+func TestSelfDeployScriptBuildFlags(t *testing.T) {
+	data, err := os.ReadFile(selfDeployScriptPath(t))
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	line := buildLineRE.Find(data)
+	if line == nil {
+		t.Fatal("could not find the `go build ... ./cmd/maestro/` line in self-deploy.sh")
+	}
+	build := string(line)
+	for _, want := range []string{
+		"-buildvcs=false",        // #807: build must not depend on git VCS status
+		"-trimpath",              // reproducible paths
+		"-X main.version=$STAMP", // #682: version stamping preserved
+	} {
+		if !strings.Contains(build, want) {
+			t.Errorf("build line missing %q:\n\t%s", want, build)
+		}
+	}
+}
+
+// TestSelfDeployBuildIsVCSIndependent proves the smoke check that would have
+// caught #807: with Go's default VCS stamping, a build in a worktree where
+// `git status` fails aborts with "error obtaining VCS status: exit status 128";
+// with -buildvcs=false (what the deploy script now uses) the same build
+// succeeds. Reproduced here by corrupting a throwaway repo's HEAD — a
+// uid-independent proxy for the transient unit's dubious-ownership failure.
+func TestSelfDeployBuildIsVCSIndependent(t *testing.T) {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain not in PATH")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module vcsSmoke\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(dir, "main.go"), "package main\n\nfunc main() {}\n")
+
+	// git identity + a clean HOME so no user-global config leaks into the repo.
+	gitEnv := append(os.Environ(),
+		"HOME="+dir,
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+	)
+	runIn(t, dir, gitEnv, "git", "init", "-q")
+	runIn(t, dir, gitEnv, "git", "add", "-A")
+	runIn(t, dir, gitEnv, "git", "commit", "-qm", "init")
+
+	// Corrupt HEAD so `git status` exits 128 — the failure class from #807.
+	writeFile(t, filepath.Join(dir, ".git", "HEAD"), "garbage\n")
+
+	// Neutralize any ambient -buildvcs override so the default really is auto.
+	buildEnv := append(os.Environ(), "GOFLAGS=")
+
+	// Default build: expected to fail on VCS status. If some environment can't
+	// reproduce the failure (e.g. git behaves differently), skip this half rather
+	// than flake — the -buildvcs=false success below is the load-bearing guard.
+	def := exec.Command(goBin, "build", "-o", filepath.Join(dir, "out-default"), ".")
+	def.Dir = dir
+	def.Env = buildEnv
+	if out, err := def.CombinedOutput(); err == nil {
+		t.Logf("default build unexpectedly succeeded in this environment; skipping the failure assertion")
+	} else if !strings.Contains(string(out), "VCS") && !strings.Contains(string(out), "buildvcs") {
+		t.Fatalf("default build failed but not on VCS status: %v\n%s", err, out)
+	}
+
+	// -buildvcs=false (the deploy script's build): must succeed regardless of git.
+	fixed := exec.Command(goBin, "build", "-buildvcs=false",
+		"-trimpath", "-ldflags", "-s -w -X main.version=1.0.0+gdeadbee",
+		"-o", filepath.Join(dir, "out-fixed"), ".")
+	fixed.Dir = dir
+	fixed.Env = buildEnv
+	if out, err := fixed.CombinedOutput(); err != nil {
+		t.Fatalf("-buildvcs=false build failed (the deploy build must be VCS-independent): %v\n%s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "out-fixed")); err != nil {
+		t.Fatalf("-buildvcs=false build produced no binary: %v", err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runIn(t *testing.T, dir string, env []string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+}

--- a/internal/selfdeploy/selfdeploy_stale_test.go
+++ b/internal/selfdeploy/selfdeploy_stale_test.go
@@ -1,0 +1,155 @@
+package selfdeploy
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #807: the resolved watermark round-trips through the state dir so the
+// stale-trigger watchdog survives the orchestrator unit restarting.
+func TestRecordAndReadLastResolved(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, ok := LastResolved(dir); ok {
+		t.Fatal("LastResolved ok=true with no marker")
+	}
+
+	when := time.Date(2026, 7, 3, 6, 55, 0, 0, time.UTC)
+	if err := RecordResolved(dir, when); err != nil {
+		t.Fatalf("RecordResolved: %v", err)
+	}
+	got, ok := LastResolved(dir)
+	if !ok {
+		t.Fatal("LastResolved ok=false after RecordResolved")
+	}
+	if !got.Equal(when) {
+		t.Errorf("LastResolved = %s, want %s", got, when)
+	}
+}
+
+// A blank state dir is a no-op, matching RecordTrigger.
+func TestRecordResolvedBlankStateDir(t *testing.T) {
+	if err := RecordResolved("", time.Now().UTC()); err != nil {
+		t.Fatalf("RecordResolved(\"\"): %v", err)
+	}
+	if _, ok := LastResolved(""); ok {
+		t.Fatal("LastResolved(\"\") ok=true, want false")
+	}
+}
+
+// A malformed watermark fails open (ok=false) so a corrupt file never hides a
+// genuinely-lost deploy.
+func TestLastResolvedMalformed(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(resolvedMarkerPath(dir), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := LastResolved(dir); ok {
+		t.Fatal("LastResolved ok=true for malformed marker")
+	}
+}
+
+func TestStaleTrigger(t *testing.T) {
+	const timeout = 60 * time.Minute
+	now := time.Date(2026, 7, 3, 8, 0, 0, 0, time.UTC)
+
+	t.Run("no marker → not stale", func(t *testing.T) {
+		if _, _, stale := StaleTrigger(t.TempDir(), now, timeout); stale {
+			t.Fatal("stale=true with no trigger marker")
+		}
+	})
+
+	t.Run("recent trigger within timeout → not stale (in-flight deploy)", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := RecordTrigger(dir, 806, now.Add(-10*time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, stale := StaleTrigger(dir, now, timeout); stale {
+			t.Fatal("stale=true for a trigger still inside the timeout window")
+		}
+	})
+
+	t.Run("old trigger, no result → stale", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := RecordTrigger(dir, 806, now.Add(-90*time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		pr, age, stale := StaleTrigger(dir, now, timeout)
+		if !stale {
+			t.Fatal("stale=false for an old trigger with no result — the silent-loss case")
+		}
+		if pr != 806 {
+			t.Errorf("pr = %d, want 806", pr)
+		}
+		if age != 90*time.Minute {
+			t.Errorf("age = %s, want 90m", age)
+		}
+	})
+
+	t.Run("old trigger but result present → not stale (consumed this cycle)", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := RecordTrigger(dir, 806, now.Add(-90*time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(ResultPath(dir), []byte(`{"status":"deployed","pr":806}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, stale := StaleTrigger(dir, now, timeout); stale {
+			t.Fatal("stale=true while a result file waits to be consumed")
+		}
+	})
+
+	t.Run("old trigger already resolved → not stale (completed deploy)", func(t *testing.T) {
+		dir := t.TempDir()
+		triggeredAt := now.Add(-90 * time.Minute)
+		if err := RecordTrigger(dir, 806, triggeredAt); err != nil {
+			t.Fatal(err)
+		}
+		// A result was consumed AFTER the trigger — the marker legitimately
+		// outlives the cleared result; this must not read as a silent loss.
+		if err := RecordResolved(dir, triggeredAt.Add(3*time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, stale := StaleTrigger(dir, now, timeout); stale {
+			t.Fatal("stale=true for a trigger whose result was already resolved")
+		}
+	})
+
+	t.Run("new trigger after an old resolution → stale again", func(t *testing.T) {
+		dir := t.TempDir()
+		// Previous deploy resolved long ago.
+		if err := RecordResolved(dir, now.Add(-5*time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+		// A fresh trigger fired after that resolution and never produced a result.
+		if err := RecordTrigger(dir, 900, now.Add(-90*time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, stale := StaleTrigger(dir, now, timeout); !stale {
+			t.Fatal("stale=false for a new trigger that fired after the last resolution")
+		}
+	})
+}
+
+func TestStaleTriggerFinding(t *testing.T) {
+	now := time.Date(2026, 7, 3, 8, 0, 0, 0, time.UTC)
+	d := StaleTriggerFinding(806, 92*time.Minute, "owner/repo", now)
+
+	if d.Status != "failed" {
+		t.Errorf("Status = %q, want failed", d.Status)
+	}
+	if d.RequiresApproval {
+		t.Error("watchdog finding must not require approval")
+	}
+	if !strings.Contains(d.Summary, "no result") || !strings.Contains(d.Summary, "PR #806") {
+		t.Errorf("Summary = %q", d.Summary)
+	}
+	if !strings.HasPrefix(d.ID, "self-deploy-stale-trigger-") {
+		t.Errorf("ID = %q, want self-deploy-stale-trigger- prefix", d.ID)
+	}
+	if d.Project != "owner/repo" {
+		t.Errorf("Project = %q", d.Project)
+	}
+}

--- a/scripts/self-deploy.sh
+++ b/scripts/self-deploy.sh
@@ -8,7 +8,12 @@
 # system scope. Steps:
 #
 #   1. build from merged origin/main, version-stamped per #682
-#      (-X main.version=<VERSION>+g<shortsha>),
+#      (-X main.version=<VERSION>+g<shortsha>). The build passes
+#      -buildvcs=false (#807): the transient unit builds from a detached git
+#      worktree under a different uid, where Go's default -buildvcs=auto runs
+#      `git status`, hits git's dubious-ownership guard, and exits 128 —
+#      failing the whole build (merges silently never shipped). The version is
+#      stamped via -ldflags, so VCS stamping is redundant here anyway,
 #   2. install atomically, keeping the previous binary as <bin>.prev,
 #   3. restart the maestro units — the units' normal stop path runs, so
 #      existing drain semantics are honored,
@@ -334,7 +339,13 @@ VERSION=$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$BUILD_
 STAMP="${VERSION}+g${SHORT_SHA}"
 
 log "building maestro v$STAMP from $SHA"
-(cd "$BUILD_DIR" && go build -trimpath -ldflags "-s -w -X main.version=$STAMP" -o "$BUILD_ROOT/maestro" ./cmd/maestro/)
+# -buildvcs=false (#807): this build runs inside a detached git worktree owned by
+# the deploy uid, where Go's default -buildvcs=auto shells out to `git status`,
+# trips git's dubious-ownership guard, and exits 128 — aborting the build so the
+# merge silently never ships. The version is already stamped via -ldflags below,
+# so VCS stamping adds nothing; disabling it makes the build independent of git
+# VCS status in the transient unit. Keep -trimpath and the -X main.version stamp.
+(cd "$BUILD_DIR" && go build -buildvcs=false -trimpath -ldflags "-s -w -X main.version=$STAMP" -o "$BUILD_ROOT/maestro" ./cmd/maestro/)
 
 BUILT_VERSION=$("$BUILD_ROOT/maestro" version)
 [[ "$BUILT_VERSION" == *"v$STAMP"* ]] || fail "built binary reports '$BUILT_VERSION', want 'maestro v$STAMP'"


### PR DESCRIPTION
Refs #807

## Problem

The post-merge self-deploy silently failed at `go build`. The detached transient
unit builds from a git worktree under the deploy uid, where Go's default
`-buildvcs=auto` runs `git status`, trips git's dubious-ownership guard, and
exits 128 — aborting the whole build. Merges to `main` never reached the running
fleet.

## Changes

- **`scripts/self-deploy.sh`**: build with `-buildvcs=false` (keeping `-trimpath`
  and the `-X main.version=$STAMP` stamp); the build no longer depends on git VCS
  status in the transient unit.
- **`internal/selfdeploy`**: stale-trigger watchdog — a resolved watermark plus
  `StaleTrigger` / `StaleTriggerFinding` surface a trigger that produced no
  result within the `RuntimeMaxSec` backstop (the unit died before writing one),
  turning the silent no-op into a loud supervisor finding + notification.
- **`internal/orchestrator`**: advance the resolved watermark on result consume,
  and run the watchdog in cycle Step 0 right after `consumeSelfDeployResult`
  (fires once, then a later merge/main-advance re-triggers).
- **Tests**: a regression guard on the script's build flags and a VCS-independence
  build smoke check (runs under `go test ./...` in CI) that reproduces the
  exit-128 failure and proves `-buildvcs=false` fixes it, plus stale-trigger and
  watermark coverage.
- **`docs/self-deploy-runbook.md`**: document `-buildvcs=false` and the
  stale-trigger watchdog.

## Testing

- `gofmt` clean; `go vet ./...`; `go build ./cmd/maestro/`; `go test ./...` all pass.
- New smoke test reproduces `error obtaining VCS status: exit status 128` on a
  default build and confirms the `-buildvcs=false` build succeeds.

## Runtime verification still required

The build fix is proven by the CI smoke check, but the end-to-end self-deploy
path (a real merge to `main` producing a `self-deploy-result.json` and restarting
the unit on the live fleet) can only be confirmed on the deployment host, so this
PR intentionally does not auto-close the issue.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the self-deploy path and adds reporting for silent deploy failures. The main changes are:

- Adds `-buildvcs=false` to the self-deploy `go build` command while keeping `-trimpath` and version stamping.
- Adds a resolved watermark and stale-trigger watchdog for deploys that never write a result file.
- Surfaces stale self-deploy triggers as supervisor findings and notifications.
- Adds tests for build flags, VCS-independent builds, stale-trigger detection, and watermark behavior.
- Updates the self-deploy runbook with the new build flag and watchdog behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are focused on the self-deploy path, preserve existing build stamping, and add targeted tests for the build fix and watchdog state transitions.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared baseline Go build without -buildvcs=false to the VCS-disabled build; the VCS-disabled build succeeded and embedded trex-before-stamp.
- Ran targeted tests for selfdeploy and orchestrator; the base run executed only trigger-related tests and had no stale watchdog tests, while the head run passed all TestStaleTrigger subtests and related tests.

<a href="https://app.greptile.com/trex/runs/13190319/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/self-deploy.sh | Updates the deploy build command to pass `-buildvcs=false` while preserving `-trimpath` and version stamping. |
| internal/selfdeploy/selfdeploy.go | Adds resolved watermark persistence, stale trigger classification, and stale-trigger supervisor findings. |
| internal/orchestrator/orchestrator.go | Consumes self-deploy results with a resolved watermark and adds a stale-trigger watchdog in cycle step 0. |
| internal/selfdeploy/selfdeploy_script_test.go | Adds tests for deploy build flags and VCS-independent Go builds using `-buildvcs=false`. |
| internal/selfdeploy/selfdeploy_stale_test.go | Adds unit coverage for resolved watermark handling, stale trigger cases, and stale finding contents. |
| internal/orchestrator/selfdeploy_test.go | Adds orchestrator coverage for stale trigger detection, default-off behavior, in-flight triggers, and consumed-result false positive prevention. |
| docs/self-deploy-runbook.md | Documents the self-deploy `-buildvcs=false` build behavior and stale-trigger watchdog failure mode. |

<sub>Reviews (1): Last reviewed commit: ["fix: self-deploy builds with -buildvcs=f..."](https://github.com/befeast/maestro/commit/95aad5e89f03fb55faedb3d1265a9e1c27ce59f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41630783)</sub>

<!-- /greptile_comment -->