### PR TITLE
Fleet auto-fail-over on Claude/Fable usage-limit: built-in detection for real Claude signatures + build fable→opus→codex→glm→kimi chain (#808)

### DIFF
--- a/docs/subscription-quota.md
+++ b/docs/subscription-quota.md
@@ -114,17 +114,23 @@ classifies the death reactively instead of burning
 1. **Parseable reset** — a dead (or live) worker whose log matches a
    rate-limit signature *and* states a reset time is a high-confidence
    provider limit (#663). Reset hints may be date-bearing ("try again
-   at May 30, 2026 8:13 PM") or **time-only** ("try again at 12:30 PM",
-   the live codex phrasing) — a time-only hint resolves to the next
-   occurrence of that wall-clock time. The backend is gated with reason
-   `provider_limit` and `RetryAfter` at the stated reset.
+   at May 30, 2026 8:13 PM"), **time-only** ("try again at 12:30 PM",
+   the live codex phrasing), or the Claude subscription **"resets
+   `<clock>` (`<tz>`)"** shape ("You've hit your session limit · resets
+   9am (UTC)", "You're out of extra usage · resets 4:10pm (UTC)", #808)
+   — a clock-only hint resolves to the next occurrence of that
+   wall-clock time. The backend is gated with reason `provider_limit`
+   and `RetryAfter` at the stated reset.
 2. **No parseable reset** — a worker that died within the early-death
    window (~10 min of spawn) whose log **tail** matches an
-   account-quota exhaustion signature ("You've hit your usage limit",
-   the codex settings/usage URL, claude "usage limit reached") is gated
-   with reason `usage_limit` and a fixed 30-minute re-probe cooldown.
-   Generic signals (bare 429, "too many requests") stay excluded — they
-   are transient and acting on them is the #663 false-positive class.
+   account-quota exhaustion signature ("You've hit your `<usage|
+   session>` limit", "You've reached your `<plan>` limit" / the
+   `/usage-credits` marker (Claude/Fable, #808), "You're out of extra
+   usage", the codex settings/usage URL, claude "usage limit reached")
+   is gated with reason `usage_limit` and a fixed 30-minute re-probe
+   cooldown. Generic signals (bare 429, "too many requests") stay
+   excluded — they are transient and acting on them is the #663
+   false-positive class.
 
 Either way the attempt respawns on the next healthy backend from
 `model.fallback_backends` in the same cycle, the session is excluded

--- a/internal/orchestrator/backend_claude_usage_limit_test.go
+++ b/internal/orchestrator/backend_claude_usage_limit_test.go
@@ -1,0 +1,202 @@
+package orchestrator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #808 live Claude/Fable subscription signatures (BeFeast ok-player / ok-folio
+// fleet, 2026-07-03). Each was printed by the claude CLI as it exited on an
+// account-level quota; the daemon saw only "pid dead, tmux missing" and looped
+// respawns on the same exhausted backend until the issue was wrongly blocked.
+// The Codex-shaped built-in patterns from #806 matched none of them.
+const (
+	// ok-player-23.log — no reset stated.
+	claudeFableLimitDeath = "You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."
+	// ok-player-18.log — "resets 9am (UTC)".
+	claudeSessionLimitDeath = "You've hit your session limit · resets 9am (UTC)"
+	// bot-34.log — "resets 4:10pm (UTC)".
+	claudeExtraUsageDeath = "You're out of extra usage · resets 4:10pm (UTC)"
+)
+
+// claudeChainTestConfig models the desired failover chain fable → opus →
+// codex: the default backend (claude/fable) with an ordered fallback list. The
+// backend names are what the config store carries; the classifier itself is
+// backend-agnostic (it scans the worker log), so the in-memory defs only need
+// to exist and be enabled for the selector to pick them.
+func claudeChainTestConfig() *config.Config {
+	return &config.Config{
+		Repo: "owner/repo",
+		Model: config.ModelConfig{
+			Default:          "claude",
+			FallbackBackends: []string{"opus", "codex"},
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"opus":   {Cmd: "claude"},
+				"codex":  {Cmd: "codex"},
+			},
+		},
+	}
+}
+
+// TestClassifyBackendFailure_ClaudeSignatures replays the three live #808
+// strings through the real post-mortem log classifiers (detection +
+// classifyBackendFailure). Each must classify as a backend usage-limit — not
+// an ordinary work failure — so the attempt keeps its retry budget and fails
+// over. The matched signature label records which built-in pattern fired.
+func TestClassifyBackendFailure_ClaudeSignatures(t *testing.T) {
+	cases := []struct {
+		name    string
+		death   string
+		pattern string
+	}{
+		{"fable plan limit", claudeFableLimitDeath, "reached_limit"},
+		{"session limit", claudeSessionLimitDeath, "hit_limit"},
+		{"out of extra usage", claudeExtraUsageDeath, "out_of_usage"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			logFile := filepath.Join(dir, "worker.log")
+			content := "Starting claude worker for issue #151\n" + tc.death + "\n"
+			if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+				t.Fatalf("write log: %v", err)
+			}
+
+			o := &Orchestrator{cfg: claudeChainTestConfig()}
+			sess := &state.Session{
+				Backend:   "claude",
+				StartedAt: time.Now().UTC().Add(-90 * time.Second),
+				LogFile:   logFile,
+			}
+			hit, reason, pattern := o.classifyBackendFailure(sess, time.Now().UTC())
+			if !hit {
+				t.Fatalf("classifyBackendFailure(%q) = false, want a backend-failure classification", tc.death)
+			}
+			if reason != state.BackendBlockUsageLimit {
+				t.Fatalf("reason = %q, want %q", reason, state.BackendBlockUsageLimit)
+			}
+			if pattern != tc.pattern {
+				t.Errorf("pattern = %q, want %q", pattern, tc.pattern)
+			}
+		})
+	}
+}
+
+// TestReconcileRunningSessions_ClaudeUsageLimit_IncidentReplay is the #808
+// end-to-end regression: a claude/fable worker dies with each live signature
+// and the fleet must fail over to the next backend in the chain (opus) with the
+// per-issue retry budget preserved, instead of looping respawns on the
+// exhausted default until the issue is wrongly blocked.
+//
+// The two signatures that state a reset ("resets 9am (UTC)", "resets 4:10pm
+// (UTC)") take the provider-limit path and carry the provider-stated reset as
+// the backend cooldown; the Fable-limit signature states no reset and takes the
+// usage-limit path with the fixed re-probe window. Both preserve the budget.
+func TestReconcileRunningSessions_ClaudeUsageLimit_IncidentReplay(t *testing.T) {
+	cases := []struct {
+		name       string
+		death      string
+		wantReason string
+		wantReset  bool // provider-stated reset resolved onto RetryAfter
+		resetHour  int
+		resetMin   int
+	}{
+		{"fable plan limit no reset", claudeFableLimitDeath, state.BackendBlockUsageLimit, false, 0, 0},
+		{"session limit resets 9am", claudeSessionLimitDeath, state.BackendBlockProviderLimit, true, 9, 0},
+		{"out of extra usage resets 4:10pm", claudeExtraUsageDeath, state.BackendBlockProviderLimit, true, 16, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			logFile := filepath.Join(dir, "ok-player.log")
+			content := "Starting claude worker for issue #151\n" + tc.death + "\n"
+			if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+				t.Fatalf("write log: %v", err)
+			}
+
+			s := state.NewState()
+			s.Sessions["ok-player-1"] = &state.Session{
+				IssueNumber: 151,
+				IssueTitle:  "player pipeline",
+				Status:      state.StatusRunning,
+				PID:         515160,
+				TmuxSession: "maestro-ok-player-1",
+				Branch:      "feat/ok-player-1-151-pipeline",
+				Backend:     "claude",
+				StartedAt:   time.Now().UTC().Add(-90 * time.Second),
+				LogFile:     logFile,
+			}
+
+			respawnedBackends := []string{}
+			o := &Orchestrator{
+				cfg:                 claudeChainTestConfig(),
+				notifier:            &notify.Notifier{},
+				pidAliveFn:          func(pid int) bool { return false },
+				tmuxSessionExistsFn: func(name string) bool { return false },
+				listOpenPRsFn:       func() ([]github.PR, error) { return []github.PR{}, nil },
+				getIssueFn: func(number int) (github.Issue, error) {
+					return github.Issue{Number: number, Title: "player pipeline"}, nil
+				},
+				respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+					respawnedBackends = append(respawnedBackends, backendName)
+					sess.Status = state.StatusRunning
+					sess.PID = 9110
+					sess.Backend = backendName
+					sess.StartedAt = time.Now().UTC()
+					sess.FinishedAt = nil
+					return nil
+				},
+			}
+
+			if !o.reconcileRunningSessions(s) {
+				t.Fatal("expected reconciliation to report changes")
+			}
+
+			sess := s.Sessions["ok-player-1"]
+			if sess.Status != state.StatusRunning {
+				t.Fatalf("status = %q, want running (fail over to opus), got — the #808 regression is a blocked loop", sess.Status)
+			}
+			if len(respawnedBackends) != 1 || respawnedBackends[0] != "opus" {
+				t.Fatalf("respawned backends = %v, want [opus] (next in fable→opus→codex)", respawnedBackends)
+			}
+			if len(sess.TriedBackends) != 1 || sess.TriedBackends[0] != "claude" {
+				t.Fatalf("TriedBackends = %v, want [claude] (the exhausted default)", sess.TriedBackends)
+			}
+			if sess.RetryCount != 0 {
+				t.Fatalf("RetryCount = %d, want 0 — a quota death must not consume the retry budget", sess.RetryCount)
+			}
+			if !sess.RateLimitHit {
+				t.Fatal("RateLimitHit should be true so FailedAttemptsForIssue excludes the session")
+			}
+			if failed := s.FailedAttemptsForIssue(151); failed != 0 {
+				t.Fatalf("FailedAttemptsForIssue(151) = %d, want 0", failed)
+			}
+			health, ok := s.BackendHealth["claude"]
+			if !ok {
+				t.Fatal("BackendHealth[claude] should be gated — it stayed empty during the incident")
+			}
+			if health.State != state.BackendHealthCooldown {
+				t.Fatalf("BackendHealth[claude].State = %q, want cooldown", health.State)
+			}
+			if health.Reason != tc.wantReason {
+				t.Fatalf("BackendHealth[claude].Reason = %q, want %q", health.Reason, tc.wantReason)
+			}
+			if health.RetryAfter == nil {
+				t.Fatal("BackendHealth[claude].RetryAfter should be set so the backend is re-probed after the cooldown")
+			}
+			if tc.wantReset {
+				if hh, mm := health.RetryAfter.Hour(), health.RetryAfter.Minute(); hh != tc.resetHour || mm != tc.resetMin {
+					t.Fatalf("RetryAfter = %v, want a %02d:%02d wall-clock resolution from the provider-stated reset", health.RetryAfter, tc.resetHour, tc.resetMin)
+				}
+			}
+		})
+	}
+}

--- a/internal/worker/ratelimit.go
+++ b/internal/worker/ratelimit.go
@@ -19,7 +19,14 @@ import (
 // expensive backend chasing a phantom quota block.
 //
 // Supported patterns (case-insensitive):
-//   - "You've hit your (usage )?limit" (Claude / Codex provider phrasing)
+//   - "You've hit your <qualifier> limit" (Claude / Codex provider phrasing).
+//     The optional qualifier word matches "usage" (Codex) and "session"
+//     (Claude subscription: "You've hit your session limit · resets 9am
+//     (UTC)", #808) as well as the bare "You've hit your limit".
+//   - "You've reached your <plan> limit" (Claude/Fable subscription cap, #808)
+//   - "You're out of (extra )?usage" (Claude extra-usage exhaustion, #808) —
+//     paired with a parseable "resets <t>" hint this is the high-confidence
+//     provider-limit signal the fallover selector acts on.
 //   - "chatgpt.com/codex/settings/usage" marker (Codex usage-limit URL)
 //   - HTTP 429 paired with a status/code/error context word — bare 429
 //     embedded in unrelated text is NOT matched
@@ -34,7 +41,9 @@ var rateLimitPatterns = []struct {
 	label string
 	re    *regexp.Regexp
 }{
-	{"hit_limit", regexp.MustCompile(`(?i)you'?ve hit your (usage )?limit`)},
+	{"hit_limit", regexp.MustCompile(`(?i)you'?ve hit your (?:\w+ )?limit`)},
+	{"reached_limit", regexp.MustCompile(`(?i)you'?ve reached your\b[^.\n]{0,40}?\blimit\b`)},
+	{"out_of_usage", regexp.MustCompile(`(?i)you'?re out of (?:extra )?usage\b`)},
 	{"codex_usage_limit", regexp.MustCompile(`(?i)(chatgpt\.com/)?codex/settings/usage`)},
 	// HTTP 429 with a rate-limit context word. Requires the literal 429 to
 	// appear next to an HTTP / status / code / error / response marker so
@@ -50,11 +59,23 @@ var rateLimitPatterns = []struct {
 // rateLimitResetRe extracts the human-readable reset hint emitted after a
 // provider usage-limit error, e.g.
 //
-//	"... try again at May 30th, 2026 8:13 PM."
+//	"... try again at May 30th, 2026 8:13 PM."   (Codex / OpenAI)
+//	"You've hit your session limit · resets 9am (UTC)"   (Claude, #808)
+//	"You're out of extra usage · resets 4:10pm (UTC)"    (Claude, #808)
 //
-// The capture is greedy to the end of the line; parseResetTimestamp trims a
-// trailing sentence period and surrounding whitespace before parsing.
-var rateLimitResetRe = regexp.MustCompile(`(?i)try again (?:at|after)\s+([^\n]+)`)
+// The capture is greedy to the end of the line; parseResetTimestamp /
+// parseTimeOnlyReset trim a trailing sentence period, a trailing
+// parenthesised timezone ("(UTC)"), and surrounding whitespace before
+// parsing. The "resets" alternative is anchored on a word boundary so it does
+// not fire inside an unrelated token (e.g. "core-resets").
+var rateLimitResetRe = regexp.MustCompile(`(?i)(?:try again (?:at|after)|\bresets)\s+([^\n]+)`)
+
+// trailingTZParenRe strips a trailing parenthesised timezone marker from a
+// reset capture: "9am (UTC)" -> "9am", "4:10pm (UTC)" -> "4:10pm". The
+// timezone is dropped rather than honoured — parseTimeOnlyReset already
+// documents its result as a best-effort UTC lower bound, and every live
+// Claude signature states "(UTC)".
+var trailingTZParenRe = regexp.MustCompile(`\s*\([^)]*\)\s*$`)
 
 // resetLayouts are the timestamp layouts ParseRateLimitReset attempts, in
 // order, against the cleaned "try again at <when>" capture. The Codex signature
@@ -82,10 +103,15 @@ var ordinalSuffixRe = regexp.MustCompile(`(?i)(\d{1,2})(st|nd|rd|th)`)
 // went unparsed, the rate-limit signal stayed low-confidence (#663), and no
 // failover fired. A clock-only hint is resolved against a reference time to
 // the NEXT occurrence of that wall-clock time (see parseTimeOnlyReset).
+// The hour-only meridiem shapes ("3PM"/"3 PM") cover the Claude subscription
+// phrasing "resets 9am (UTC)" (#808), which states an hour with no minutes; the
+// date-bearing and minute-bearing layouts reject it.
 var timeOnlyResetLayouts = []string{
 	"3:04 PM",
 	"3:04PM",
 	"15:04",
+	"3PM",
+	"3 PM",
 }
 
 // DetectRateLimit scans multi-line output for known rate-limit / quota error
@@ -246,7 +272,11 @@ func parseTimeOnlyReset(raw string, now time.Time) (time.Time, bool) {
 	if now.IsZero() {
 		return time.Time{}, false
 	}
-	cleaned := strings.TrimRight(strings.TrimSpace(raw), ". ")
+	// Drop a trailing parenthesised timezone ("9am (UTC)" -> "9am") before the
+	// sentence-period trim so the "(UTC)" the Claude signature appends does not
+	// defeat the clock layouts (#808).
+	cleaned := trailingTZParenRe.ReplaceAllString(strings.TrimSpace(raw), "")
+	cleaned = strings.TrimRight(strings.TrimSpace(cleaned), ". ")
 	if cleaned == "" {
 		return time.Time{}, false
 	}
@@ -272,9 +302,10 @@ func parseTimeOnlyReset(raw string, now time.Time) (time.Time, bool) {
 // from a "try again at <when>" hint. Day ordinals are stripped and whitespace
 // is collapsed before trying each layout in resetLayouts.
 func parseResetTimestamp(raw string) (time.Time, bool) {
-	// Drop a trailing sentence period and surrounding whitespace ("... 8:13 PM."
-	// -> "... 8:13 PM").
-	cleaned := strings.TrimRight(strings.TrimSpace(raw), ". ")
+	// Drop a trailing parenthesised timezone, then a trailing sentence period
+	// and surrounding whitespace ("... 8:13 PM (UTC)." -> "... 8:13 PM").
+	cleaned := trailingTZParenRe.ReplaceAllString(strings.TrimSpace(raw), "")
+	cleaned = strings.TrimRight(strings.TrimSpace(cleaned), ". ")
 	if cleaned == "" {
 		return time.Time{}, false
 	}

--- a/internal/worker/ratelimit.go
+++ b/internal/worker/ratelimit.go
@@ -77,6 +77,20 @@ var rateLimitResetRe = regexp.MustCompile(`(?i)(?:try again (?:at|after)|\breset
 // Claude signature states "(UTC)".
 var trailingTZParenRe = regexp.MustCompile(`\s*\([^)]*\)\s*$`)
 
+// stripResetDecorations removes the sentence punctuation and parenthesised
+// timezone a provider may append to a "<when>" reset capture, in EITHER order:
+// "9am (UTC)", "9am (UTC).", "8:13 PM.", and "9am. (UTC)" all reduce to the
+// bare timestamp. The trailing period is trimmed FIRST so a "(UTC)." tail
+// (period after the closing paren, as a sentence-terminated Claude reset
+// emits) does not defeat trailingTZParenRe's "$" anchor and leave an
+// unparseable "9am (UTC)"; the strip and trim are then repeated so residual
+// punctuation exposed by removing the paren is dropped too (#808 review).
+func stripResetDecorations(raw string) string {
+	cleaned := strings.TrimRight(strings.TrimSpace(raw), ". ")
+	cleaned = trailingTZParenRe.ReplaceAllString(cleaned, "")
+	return strings.TrimRight(strings.TrimSpace(cleaned), ". ")
+}
+
 // resetLayouts are the timestamp layouts ParseRateLimitReset attempts, in
 // order, against the cleaned "try again at <when>" capture. The Codex signature
 // uses a "May 30th, 2026 8:13 PM" shape; ordinal suffixes (st/nd/rd/th) are
@@ -272,11 +286,10 @@ func parseTimeOnlyReset(raw string, now time.Time) (time.Time, bool) {
 	if now.IsZero() {
 		return time.Time{}, false
 	}
-	// Drop a trailing parenthesised timezone ("9am (UTC)" -> "9am") before the
-	// sentence-period trim so the "(UTC)" the Claude signature appends does not
-	// defeat the clock layouts (#808).
-	cleaned := trailingTZParenRe.ReplaceAllString(strings.TrimSpace(raw), "")
-	cleaned = strings.TrimRight(strings.TrimSpace(cleaned), ". ")
+	// Drop the trailing sentence period and parenthesised timezone
+	// ("9am (UTC)." -> "9am") so the "(UTC)" the Claude signature appends — and
+	// any period after it — does not defeat the clock layouts (#808).
+	cleaned := stripResetDecorations(raw)
 	if cleaned == "" {
 		return time.Time{}, false
 	}
@@ -302,10 +315,9 @@ func parseTimeOnlyReset(raw string, now time.Time) (time.Time, bool) {
 // from a "try again at <when>" hint. Day ordinals are stripped and whitespace
 // is collapsed before trying each layout in resetLayouts.
 func parseResetTimestamp(raw string) (time.Time, bool) {
-	// Drop a trailing parenthesised timezone, then a trailing sentence period
-	// and surrounding whitespace ("... 8:13 PM (UTC)." -> "... 8:13 PM").
-	cleaned := trailingTZParenRe.ReplaceAllString(strings.TrimSpace(raw), "")
-	cleaned = strings.TrimRight(strings.TrimSpace(cleaned), ". ")
+	// Drop the trailing sentence period and parenthesised timezone in either
+	// order ("... 8:13 PM (UTC)." -> "... 8:13 PM").
+	cleaned := stripResetDecorations(raw)
 	if cleaned == "" {
 		return time.Time{}, false
 	}

--- a/internal/worker/ratelimit_test.go
+++ b/internal/worker/ratelimit_test.go
@@ -46,6 +46,27 @@ func TestDetectRateLimit(t *testing.T) {
 			wantLabel: "hit_limit",
 		},
 		{
+			// #808: the Claude subscription "session limit" phrasing inserts
+			// "session" between "your" and "limit"; the qualifier group must
+			// admit it just as it admits "usage".
+			name:      "claude session limit (#808)",
+			input:     "You've hit your session limit · resets 9am (UTC)",
+			wantHit:   true,
+			wantLabel: "hit_limit",
+		},
+		{
+			name:      "claude fable plan limit (#808)",
+			input:     "You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.",
+			wantHit:   true,
+			wantLabel: "reached_limit",
+		},
+		{
+			name:      "claude out of extra usage (#808)",
+			input:     "You're out of extra usage · resets 4:10pm (UTC)",
+			wantHit:   true,
+			wantLabel: "out_of_usage",
+		},
+		{
 			name:      "HTTP 429 status code",
 			input:     "HTTP error 429: Too Many Requests",
 			wantHit:   true,
@@ -468,6 +489,95 @@ func TestParseRateLimitReset_Variants(t *testing.T) {
 			}
 			if tc.ok && !got.Equal(tc.want) {
 				t.Errorf("ParseRateLimitReset = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// #808 live Claude/Fable subscription signatures (BeFeast ok-player fleet,
+// 2026-07-03). Both state the reset as "resets <clock> (UTC)", a shape the
+// pre-#808 "try again at <when>" reset parser did not recognise, so the death
+// stayed low-confidence and no failover fired.
+const (
+	claudeSessionLimitSignature = "You've hit your session limit · resets 9am (UTC)"
+	claudeExtraUsageSignature   = "You're out of extra usage · resets 4:10pm (UTC)"
+)
+
+// TestParseRateLimitResetAt_ClaudeResetsTZ verifies the "resets <clock> (TZ)"
+// hint parses to the next occurrence of that wall-clock time in UTC, with the
+// hour-only ("9am") and minute-bearing ("4:10pm") shapes both handled and the
+// trailing "(UTC)" stripped (#808).
+func TestParseRateLimitResetAt_ClaudeResetsTZ(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		now   time.Time
+		want  time.Time
+		ok    bool
+	}{
+		{
+			name:  "hour-only am resolves same day",
+			input: claudeSessionLimitSignature,
+			now:   time.Date(2026, time.July, 3, 6, 0, 0, 0, time.UTC),
+			want:  time.Date(2026, time.July, 3, 9, 0, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "hour-only am already passed rolls next day",
+			input: claudeSessionLimitSignature,
+			now:   time.Date(2026, time.July, 3, 10, 0, 0, 0, time.UTC),
+			want:  time.Date(2026, time.July, 4, 9, 0, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "minute-bearing pm resolves same day",
+			input: claudeExtraUsageSignature,
+			now:   time.Date(2026, time.July, 3, 9, 0, 0, 0, time.UTC),
+			want:  time.Date(2026, time.July, 3, 16, 10, 0, 0, time.UTC),
+			ok:    true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseRateLimitResetAt(tc.input, tc.now)
+			if ok != tc.ok {
+				t.Fatalf("ParseRateLimitResetAt ok = %v, want %v (got %v)", ok, tc.ok, got)
+			}
+			if tc.ok && !got.Equal(tc.want) {
+				t.Errorf("ParseRateLimitResetAt = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyRateLimitAt_ClaudeResetsTZ_HighConfidence: the Claude signatures
+// must classify HIGH-confidence so the orchestrator's provider-limit fallover
+// fires with the provider-stated reset as the backend cooldown, rather than a
+// blind 30-minute re-probe (#808).
+func TestClassifyRateLimitAt_ClaudeResetsTZ_HighConfidence(t *testing.T) {
+	now := time.Date(2026, time.July, 3, 6, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name  string
+		input string
+		label string
+		want  time.Time
+	}{
+		{"session limit", claudeSessionLimitSignature, "hit_limit", time.Date(2026, time.July, 3, 9, 0, 0, 0, time.UTC)},
+		{"out of extra usage", claudeExtraUsageSignature, "out_of_usage", time.Date(2026, time.July, 3, 16, 10, 0, 0, time.UTC)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hit, label, confidence, resetAt := ClassifyRateLimitAt(tc.input, now)
+			if !hit {
+				t.Fatalf("expected hit=true on %q", tc.input)
+			}
+			if label != tc.label {
+				t.Errorf("label = %q, want %q", label, tc.label)
+			}
+			if confidence != "high" {
+				t.Errorf("confidence = %q, want high (parseable reset)", confidence)
+			}
+			if !resetAt.Equal(tc.want) {
+				t.Errorf("resetAt = %v, want %v", resetAt, tc.want)
 			}
 		})
 	}

--- a/internal/worker/ratelimit_test.go
+++ b/internal/worker/ratelimit_test.go
@@ -466,6 +466,16 @@ func TestParseRateLimitReset_Variants(t *testing.T) {
 			ok:    true,
 		},
 		{
+			// Parenthesised timezone followed by a sentence period: the
+			// period-after-")" tail must be trimmed before the "$"-anchored
+			// timezone strip runs, or the date-bearing layouts see a trailing
+			// "(UTC)" and reject the hint (#808 review).
+			name:  "parenthesised timezone with trailing period",
+			input: "try again at May 30th, 2026 8:13 PM (UTC).",
+			want:  time.Date(2026, time.May, 30, 20, 13, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
 			name:  "no reset hint",
 			input: "You've hit your usage limit.",
 			ok:    false,
@@ -532,6 +542,25 @@ func TestParseRateLimitResetAt_ClaudeResetsTZ(t *testing.T) {
 		{
 			name:  "minute-bearing pm resolves same day",
 			input: claudeExtraUsageSignature,
+			now:   time.Date(2026, time.July, 3, 9, 0, 0, 0, time.UTC),
+			want:  time.Date(2026, time.July, 3, 16, 10, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			// Sentence-terminated reset: the period lands AFTER the "(UTC)"
+			// paren, so the "$"-anchored timezone strip only fires once the
+			// period is trimmed first. Regression for the trim-order defect
+			// that left an unparseable "9am (UTC)" and downgraded an otherwise
+			// high-confidence reset to low (#808 review).
+			name:  "hour-only am with trailing sentence period",
+			input: "You've hit your session limit · resets 9am (UTC).",
+			now:   time.Date(2026, time.July, 3, 6, 0, 0, 0, time.UTC),
+			want:  time.Date(2026, time.July, 3, 9, 0, 0, 0, time.UTC),
+			ok:    true,
+		},
+		{
+			name:  "minute-bearing pm with trailing sentence period",
+			input: "You're out of extra usage · resets 4:10pm (UTC).",
 			now:   time.Date(2026, time.July, 3, 9, 0, 0, 0, time.UTC),
 			want:  time.Date(2026, time.July, 3, 16, 10, 0, 0, time.UTC),
 			ok:    true,

--- a/internal/worker/usagelimit.go
+++ b/internal/worker/usagelimit.go
@@ -18,7 +18,16 @@ import (
 // the false-positive class from #663.
 //
 // Supported signatures (case-insensitive):
-//   - "You've hit your (usage )?limit" (Codex / Claude provider phrasing)
+//   - "You've hit your <qualifier> limit" (Codex / Claude provider phrasing).
+//     The optional qualifier word covers "usage" (Codex) and "session"
+//     (Claude subscription: "You've hit your session limit · resets 9am
+//     (UTC)", #808) as well as the bare "You've hit your limit".
+//   - "You've reached your <plan> limit" — the Claude/Fable subscription cap
+//     ("You've reached your Fable 5 limit. Run /usage-credits ...", #808).
+//   - "/usage-credits" marker — the Claude slash-command the Fable-limit
+//     message points at, a high-precision quota signal on its own (#808).
+//   - "You're out of (extra )?usage" — the Claude extra-usage exhaustion
+//     ("You're out of extra usage · resets 4:10pm (UTC)", #808).
 //   - "chatgpt.com/codex/settings/usage" marker (Codex usage-limit URL)
 //   - "usage/5-hour/weekly limit reached" (claude CLI subscription-window
 //     phrasings, e.g. "Claude usage limit reached ...")
@@ -26,7 +35,10 @@ var usageLimitPatterns = []struct {
 	label string
 	re    *regexp.Regexp
 }{
-	{"hit_limit", regexp.MustCompile(`(?i)you'?ve hit your (usage )?limit`)},
+	{"hit_limit", regexp.MustCompile(`(?i)you'?ve hit your (?:\w+ )?limit`)},
+	{"reached_limit", regexp.MustCompile(`(?i)you'?ve reached your\b[^.\n]{0,40}?\blimit\b`)},
+	{"usage_credits", regexp.MustCompile(`(?i)/usage-credits\b`)},
+	{"out_of_usage", regexp.MustCompile(`(?i)you'?re out of (?:extra )?usage\b`)},
 	{"codex_usage_limit", regexp.MustCompile(`(?i)(chatgpt\.com/)?codex/settings/usage`)},
 	{"usage_limit_reached", regexp.MustCompile(`(?i)\b(?:usage|5-hour|weekly)[ _-]limit reached\b`)},
 }

--- a/internal/worker/usagelimit_test.go
+++ b/internal/worker/usagelimit_test.go
@@ -12,6 +12,17 @@ import (
 // burned the whole per-issue retry budget respawning on the same dead backend.
 const codexUsageLimitDeath = "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/codex/settings/usage) or try again at 12:30 PM."
 
+// #808 live Claude/Fable subscription signatures (BeFeast ok-player / ok-folio
+// fleet, 2026-07-03). Each was printed by the claude CLI as it exited on an
+// account-level quota; the daemon saw only "pid dead, tmux missing" and looped
+// respawns on the same exhausted backend until the issue was wrongly blocked.
+// The Codex-shaped built-in patterns matched none of them.
+const (
+	claudeFableLimitDeath   = "You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model." // ok-player-23.log
+	claudeSessionLimitDeath = "You've hit your session limit · resets 9am (UTC)"                                                // ok-player-18.log
+	claudeExtraUsageDeath   = "You're out of extra usage · resets 4:10pm (UTC)"                                                 // bot-34.log
+)
+
 func TestDetectUsageLimit_KnownSignatures(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -23,6 +34,11 @@ func TestDetectUsageLimit_KnownSignatures(t *testing.T) {
 		{"codex usage url only", "See chatgpt.com/codex/settings/usage for details", "codex_usage_limit"},
 		{"claude usage limit reached", "Claude usage limit reached. Your limit will reset at 3am", "usage_limit_reached"},
 		{"claude 5-hour window", "5-hour limit reached ∙ resets 3am", "usage_limit_reached"},
+		// #808 live Claude/Fable signatures.
+		{"claude fable limit", claudeFableLimitDeath, "reached_limit"},
+		{"claude usage-credits marker only", "Run /usage-credits to continue.", "usage_credits"},
+		{"claude session limit", claudeSessionLimitDeath, "hit_limit"},
+		{"claude out of extra usage", claudeExtraUsageDeath, "out_of_usage"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Refs #808

## Changes

The #806 built-in usage-limit classifier and reset parser were written for the
Codex phrasing; the live Claude/Fable subscription deaths matched none of them,
so a Fable account-exhaustion was treated as an ordinary failed attempt and the
fleet looped respawns on the exhausted backend until the issue was wrongly
blocked. This teaches the **built-in** classifier the real signatures
(fleet-wide, no per-project regex maintenance):

- `internal/worker/usagelimit.go` + `internal/worker/ratelimit.go`: match
  `You've hit your <session|usage> limit`, `You've reached your <plan> limit`,
  the `/usage-credits` marker, and `You're out of (extra) usage`. The hit-limit
  regex now admits any single qualifier word, so `session limit` matches
  alongside `usage limit`.
- `internal/worker/ratelimit.go` reset parser: recognise the Claude
  `resets <clock> (<tz>)` shape (e.g. `resets 9am (UTC)`, `resets 4:10pm
  (UTC)`) — strips the trailing parenthesised timezone and resolves an
  hour-only clock to the next occurrence, so `BackendHealth.RetryAfter` carries
  the provider-stated reset instead of a blind 30-minute re-probe.
- Regression tests replay all three live strings through detection and
  `classifyBackendFailure`: backend usage-limit classification, `RateLimitHit`,
  exclusion from `FailedAttemptsForIssue`, and fail-over to the next backend;
  plus the reset-parse and high-confidence cases.
- `docs/subscription-quota.md`: document the new built-in signatures.

The pi/ollama backend's `cfg.Model -> --model` argv path already exists in
`internal/worker/backend.go`; distinct glm/kimi model routing is a config-store
+ host-wrapper concern, not repo code.

## Testing

- `go test ./...` (green)
- `go build ./cmd/maestro/`

## Not in this PR (operator / runtime)

Detection is the code half of the chain. These acceptance items are
control-plane / host work that must be applied and verified out-of-band, so
this PR intentionally does not close the issue:

- Config-store backend rows (`opus`, `glm`, `kimi`) and per-project
  `fallback_backends: [opus, codex, glm, kimi]`.
- The pi/ollama host wrapper fix (per-model routing) and `ollama` sign-in / Pro
  / model pull.
- Reverting the Opus break-glass back to `default: claude` (fable) and
  confirming a live Fable-exhaustion auto-switches to Opus.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands built-in quota detection for Claude/Fable usage-limit failures. The main changes are:

- New rate-limit and usage-limit signatures for Claude/Fable subscription messages.
- Reset parsing for `resets <clock> (<tz>)` provider hints.
- Orchestrator tests for fallback to the next backend while preserving retry budget.
- Worker tests for detection, high-confidence reset parsing, and trailing timezone punctuation.
- Documentation updates for the new reactive quota classification behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped to classifier regexes, reset parsing, tests, and documentation. The prior trim-order issue is addressed by shared decoration stripping and covered by tests. No correctness or security issues were found in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Claude limit classification tests and captured the harness source used to drive them.
- Compared the before and after claude-limit-classification logs to verify the updated results, including the post-change head labels and parsed reset times with high-confidence classifications.
- Executed the Claude-fable failover tests and saved the harness sources for the failover scenarios.
- Reviewed the before/after fable failover logs to confirm the transition from dead to running with the Opus backend and RetryAfter evidence resolved to 09:00 UTC and 16:10 UTC.

<a href="https://app.greptile.com/trex/runs/13191551/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/ratelimit.go | Extends rate-limit detection and reset parsing for Claude/Fable subscription-limit messages, including timezone-decorated clock resets. |
| internal/worker/usagelimit.go | Extends account usage-limit detection to built-in Claude/Fable plan, usage-credit, session-limit, and extra-usage messages. |
| internal/orchestrator/backend_claude_usage_limit_test.go | Adds end-to-end tests covering Claude/Fable quota deaths, retry-budget preservation, backend gating, and fallback selection. |
| internal/worker/ratelimit_test.go | Adds tests for new Claude/Fable rate-limit signatures, high-confidence reset parsing, and the trailing-period timezone trim case. |
| internal/worker/usagelimit_test.go | Adds tests for the new Claude/Fable usage-limit classifier signatures while preserving generic-signal exclusions. |
| docs/subscription-quota.md | Documents the Claude/Fable reset and usage-limit signatures added to the built-in quota classifier. |

<sub>Reviews (2): Last reviewed commit: ["worker: trim sentence period before stri..."](https://github.com/befeast/maestro/commit/4201bf9905e4c00b18445405ce17db0a2f9b26aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41631377)</sub>

<!-- /greptile_comment -->