### PR TITLE
gh wrapper amplifies primary rate-limit: make backoff primary-vs-secondary aware (fail-fast + pause-until-reset)

### DIFF
--- a/internal/github/conditional_test.go
+++ b/internal/github/conditional_test.go
@@ -15,6 +15,9 @@ func withGHRunner(t *testing.T, fn func(args []string) ([]byte, error)) *[][]str
 	origRunner := ghAPIRunner
 	origSleep := ghAPISleep
 	origJitter := ghAPIJitterFrac
+	// The primary-limit pause gate (#812) is process-wide; clear it before and
+	// after so a gate armed by another test cannot short-circuit this runner.
+	resetPrimaryLimitForTest()
 	var calls [][]string
 	ghAPIRunner = func(args ...string) ([]byte, error) {
 		calls = append(calls, args)
@@ -26,6 +29,7 @@ func withGHRunner(t *testing.T, fn func(args []string) ([]byte, error)) *[][]str
 		ghAPIRunner = origRunner
 		ghAPISleep = origSleep
 		ghAPIJitterFrac = origJitter
+		resetPrimaryLimitForTest()
 	})
 	return &calls
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -234,6 +234,16 @@ var ghAPIJitterFrac = rand.Float64
 
 var ghRetryAfterRe = regexp.MustCompile(`(?i)retry-after:\s*(\d+)`)
 
+// X-RateLimit-* headers appear in a `gh api --include` exchange (the shape the
+// conditional/ETag layer already uses for polling reads). A primary (hourly)
+// exhaustion answers X-RateLimit-Remaining: 0 with X-RateLimit-Reset carrying
+// the epoch the bucket refills at — the two signals #812 uses to fail fast and
+// pause REST polling until reset instead of retrying a doomed call.
+var (
+	ghRateLimitRemainingRe = regexp.MustCompile(`(?im)^\s*x-ratelimit-remaining:\s*(\d+)`)
+	ghRateLimitResetRe     = regexp.MustCompile(`(?im)^\s*x-ratelimit-reset:\s*(\d+)`)
+)
+
 // ---------------------------------------------------------------------------
 // Shutdown fail-fast (#797). During the 2026-07-02 incident a drain that had
 // ZERO in-flight workers took 20+ minutes to stop because the still-live flows
@@ -554,6 +564,16 @@ func ghConditionalErrorDetail(out []byte) []byte {
 }
 
 func ghAPIWithArgs(endpoint string, args ...string) ([]byte, error) {
+	// #812: while the core REST bucket is known-exhausted, skip the call
+	// entirely — issuing it would only fail against an empty budget. rate_limit
+	// is exempt: it does not consume the core quota and is exactly the probe an
+	// operator/guard uses to confirm the bucket has refilled.
+	if endpoint != "rate_limit" {
+		if paused, resetAt := primaryRateLimitActive(); paused {
+			notePrimarySkip()
+			return nil, &PrimaryRateLimitError{Endpoint: endpoint, ResetAt: resetAt}
+		}
+	}
 	conditional := ghConditionalEligible(endpoint, args)
 	paginated := false
 	for _, a := range args {
@@ -599,9 +619,25 @@ func ghAPIWithArgs(endpoint string, args ...string) ([]byte, error) {
 			cmdArgs = append([]string{"api", endpoint}, args...)
 			continue
 		}
-		retryAfter, rateLimited := parseGHRateLimit(out)
+		rl := classifyGHRateLimit(out)
+		rateLimited := rl.kind != ghRateLimitNone
 		noteAPIRequest(false, rateLimited)
-		if !rateLimited || attempt == ghAPIMaxAttempts-1 {
+		if rl.kind == ghRateLimitPrimary {
+			// #812: a primary (hourly) exhaustion does not refill for up to an
+			// hour, so retrying is guaranteed to fail and burns more of an
+			// already-empty budget. Fail fast after this one request and arm the
+			// shared gate so sibling flows skip their REST cycle until reset —
+			// replacing the old 4×-per-call amplification across all flows.
+			notePrimaryRateLimit(rl.resetAt, rl.remaining)
+			resetLabel := "a short fallback window"
+			if paused, resetAt := primaryRateLimitActive(); paused {
+				resetLabel = resetAt.UTC().Format(time.RFC3339)
+			}
+			log.Printf("[github] gh api %s: PRIMARY rate limit exhausted (%s); failing fast without retry, pausing REST polling until %s",
+				endpoint, ghErrorDetail(ghConditionalErrorDetail(out)), resetLabel)
+			break
+		}
+		if rl.kind != ghRateLimitSecondary || attempt == ghAPIMaxAttempts-1 {
 			break
 		}
 		// #797: once shutdown has begun a rate-limited read fails fast — the
@@ -613,11 +649,11 @@ func ghAPIWithArgs(endpoint string, args ...string) ([]byte, error) {
 				endpoint, ghErrorDetail(ghConditionalErrorDetail(out)))
 			break
 		}
-		wait := retryAfter
+		wait := rl.retryAfter
 		if wait <= 0 {
 			wait = ghBackoffDelay(attempt)
 		}
-		log.Printf("[github] gh api %s: rate-limited (%s); backing off %s before retry %d/%d",
+		log.Printf("[github] gh api %s: secondary rate-limited (%s); backing off %s before retry %d/%d",
 			endpoint, ghErrorDetail(ghConditionalErrorDetail(out)), wait.Round(time.Millisecond), attempt+1, ghAPIMaxAttempts-1)
 		ghAPISleep(wait)
 		if ShuttingDown() {
@@ -674,8 +710,8 @@ func noteAPIRequest(notModified, rateLimited bool) {
 		// Roll the window before counting so the request that crossed the
 		// boundary opens the new window instead of vanishing with the digest.
 		w := apiStatsWindow
-		log.Printf("[github] REST usage last %s: %d requests, ~%d billed against core quota, %d served free by 304, %d rate-limited",
-			elapsed.Round(time.Minute), w.Requests, w.Requests-w.NotModified, w.NotModified, w.RateLimited)
+		log.Printf("[github] REST usage last %s: %d requests, ~%d billed against core quota, %d served free by 304, %d rate-limited%s",
+			elapsed.Round(time.Minute), w.Requests, w.Requests-w.NotModified, w.NotModified, w.RateLimited, primaryLimitDigest())
 		apiStatsWindow = APIStats{}
 		apiWindowStart = now
 	}
@@ -698,25 +734,248 @@ func APIUsage() APIStats {
 	return apiStatsTotal
 }
 
-// parseGHRateLimit reports whether gh's combined output looks like a primary or
-// secondary rate-limit (or 429) response and, when gh surfaced an explicit
-// Retry-After hint, how long to wait. retryAfter is 0 when no hint is present,
-// in which case the caller falls back to exponential backoff.
-func parseGHRateLimit(out []byte) (retryAfter time.Duration, rateLimited bool) {
+// ghRateLimitKind distinguishes the two GitHub rate limits, which need opposite
+// handling (#812). The secondary (abuse / burst-concurrency) limit is short and
+// clears in seconds, so #794's retry-with-backoff is correct. The primary
+// (hourly, 5000/hr) limit does not refill for up to an hour, so every retry is
+// guaranteed to fail and only burns more of an already-empty budget — it must
+// fail fast and pause polling until reset instead.
+type ghRateLimitKind int
+
+const (
+	ghRateLimitNone ghRateLimitKind = iota
+	ghRateLimitSecondary
+	ghRateLimitPrimary
+)
+
+// ghRateLimitInfo is the classified verdict for a failed gh exchange.
+type ghRateLimitInfo struct {
+	kind       ghRateLimitKind
+	retryAfter time.Duration // explicit Retry-After hint (secondary); 0 if none
+	resetAt    time.Time     // X-RateLimit-Reset (primary); zero if unknown
+	remaining  int           // last-seen X-RateLimit-Remaining; -1 if unknown
+}
+
+// classifyGHRateLimit inspects gh's combined output (and, on a conditional
+// --include exchange, its response headers) and reports whether the failure is
+// a primary or secondary rate limit, plus any reset/Retry-After timing.
+//
+// Signals, in priority order:
+//   - X-RateLimit-Remaining: 0 → the core bucket is empty: PRIMARY. Definitive
+//     even under a secondary-worded message, because a retry cannot succeed
+//     until the reset regardless of what tripped the response.
+//   - "secondary rate limit" / "abuse", or an explicit Retry-After (which the
+//     primary limit never sends) → SECONDARY: retry with backoff, unchanged.
+//   - "api rate limit exceeded" (the primary signature, e.g. "API rate limit
+//     exceeded for user ID <n>") → PRIMARY.
+//   - any other rate-limit-ish text (bare "rate limit", HTTP 429) with no
+//     primary evidence → SECONDARY, preserving pre-#812 retry behavior; only a
+//     clear primary signal short-circuits to fail-fast.
+func classifyGHRateLimit(out []byte) ghRateLimitInfo {
 	text := strings.ToLower(string(out))
-	rateLimited = strings.Contains(text, "rate limit") ||
-		strings.Contains(text, "secondary rate limit") ||
-		strings.Contains(text, "http 429") ||
-		(strings.Contains(text, "http 403") && strings.Contains(text, "abuse"))
-	if !rateLimited {
-		return 0, false
+	info := ghRateLimitInfo{remaining: -1}
+
+	if m := ghRateLimitRemainingRe.FindSubmatch(out); m != nil {
+		if n, convErr := strconv.Atoi(string(m[1])); convErr == nil {
+			info.remaining = n
+		}
+	}
+	if m := ghRateLimitResetRe.FindSubmatch(out); m != nil {
+		if secs, convErr := strconv.ParseInt(string(m[1]), 10, 64); convErr == nil && secs > 0 {
+			info.resetAt = time.Unix(secs, 0)
+		}
 	}
 	if m := ghRetryAfterRe.FindSubmatch(out); m != nil {
 		if secs, convErr := strconv.Atoi(string(m[1])); convErr == nil && secs > 0 {
-			return time.Duration(secs) * time.Second, true
+			info.retryAfter = time.Duration(secs) * time.Second
 		}
 	}
-	return 0, true
+
+	primaryByHeader := info.remaining == 0
+	primaryBySignature := strings.Contains(text, "api rate limit exceeded")
+	secondary := strings.Contains(text, "secondary rate limit") || strings.Contains(text, "abuse")
+	anyLimit := primaryByHeader || primaryBySignature || secondary || info.retryAfter > 0 ||
+		strings.Contains(text, "rate limit") || strings.Contains(text, "http 429")
+
+	switch {
+	case !anyLimit:
+		info.kind = ghRateLimitNone
+	case primaryByHeader:
+		info.kind = ghRateLimitPrimary
+	case secondary || info.retryAfter > 0:
+		info.kind = ghRateLimitSecondary
+	case primaryBySignature:
+		info.kind = ghRateLimitPrimary
+	default:
+		info.kind = ghRateLimitSecondary
+	}
+	return info
+}
+
+// parseGHRateLimit reports whether gh's combined output looks like a rate-limit
+// (or 429) response and, when gh surfaced an explicit Retry-After hint, how long
+// to wait. retryAfter is 0 when no hint is present, in which case the caller
+// falls back to exponential backoff. It intentionally does not distinguish
+// primary from secondary — callers that need that use classifyGHRateLimit.
+func parseGHRateLimit(out []byte) (retryAfter time.Duration, rateLimited bool) {
+	info := classifyGHRateLimit(out)
+	return info.retryAfter, info.kind != ghRateLimitNone
+}
+
+// ---------------------------------------------------------------------------
+// Primary (hourly) rate-limit fail-fast + shared pause gate (#812). During the
+// 2026-07-03 storm a primary exhaustion was misclassified as retryable, so
+// every doomed call fanned out to ghAPIMaxAttempts retries across all in-process
+// flows — a 4× amplifier against an already-empty budget. When the wrapper now
+// recognises a primary exhaustion it arms this process-wide gate with the
+// X-RateLimit-Reset instant; every subsequent core-REST call from any flow
+// short-circuits until the reset instead of issuing a call that cannot succeed.
+// This is the REST analogue of the orchestrator's GraphQL budget guard
+// (projectGraphQLBudgetAvailable).
+// ---------------------------------------------------------------------------
+
+// primaryLimitFallbackPause is how long the gate stays armed when a primary
+// exhaustion carried no parseable X-RateLimit-Reset (a non-conditional call has
+// no headers to read). Short by design: one doomed call per flow per window is a
+// negligible drip next to the 4×-per-call burst this replaces, and it bounds an
+// over-long stall if the true reset was never surfaced.
+const primaryLimitFallbackPause = 60 * time.Second
+
+var (
+	primaryLimitMu      sync.Mutex
+	primaryLimitReset   time.Time  // gate expiry; zero = never armed
+	primaryLimitSince   time.Time  // start of the current pause window
+	primaryLimitRemain  = -1       // last-seen X-RateLimit-Remaining (-1 unknown)
+	primaryLimitSkipped int64      // core-REST calls short-circuited by the gate
+	primaryLimitHits    int64      // primary exhaustions observed
+	primaryLimitNow     = time.Now // injectable for tests
+)
+
+// PrimaryLimitState is a diagnostic snapshot of the shared primary-rate-limit
+// pause gate (#812): whether REST polling is paused, until when, the pause's
+// start, the last-seen remaining budget, how many calls were skipped, and how
+// many primary exhaustions were observed.
+type PrimaryLimitState struct {
+	Paused    bool
+	ResetAt   time.Time
+	Since     time.Time
+	Remaining int
+	Skipped   int64
+	Hits      int64
+}
+
+// notePrimaryRateLimit arms (or refreshes) the gate after the wrapper observed a
+// primary exhaustion. resetAt is X-RateLimit-Reset when gh surfaced it; a
+// zero/past reset falls back to a short fixed pause. A refresh only ever extends
+// the window (keeps the furthest reset) so a stale header cannot shorten it.
+func notePrimaryRateLimit(resetAt time.Time, remaining int) {
+	primaryLimitMu.Lock()
+	defer primaryLimitMu.Unlock()
+	now := primaryLimitNow()
+	if resetAt.IsZero() || !resetAt.After(now) {
+		resetAt = now.Add(primaryLimitFallbackPause)
+	}
+	primaryLimitHits++
+	if remaining >= 0 {
+		primaryLimitRemain = remaining
+	}
+	alreadyPaused := primaryLimitReset.After(now)
+	if resetAt.After(primaryLimitReset) {
+		primaryLimitReset = resetAt
+	}
+	if !alreadyPaused {
+		primaryLimitSince = now
+	}
+}
+
+// notePrimarySkip records that a core-REST call was short-circuited by the gate.
+func notePrimarySkip() {
+	primaryLimitMu.Lock()
+	primaryLimitSkipped++
+	primaryLimitMu.Unlock()
+}
+
+// primaryRateLimitActive reports whether the gate is currently armed and, if so,
+// the reset instant to wait for.
+func primaryRateLimitActive() (paused bool, resetAt time.Time) {
+	primaryLimitMu.Lock()
+	defer primaryLimitMu.Unlock()
+	if !primaryLimitReset.IsZero() && primaryLimitNow().Before(primaryLimitReset) {
+		return true, primaryLimitReset
+	}
+	return false, time.Time{}
+}
+
+// PrimaryRateLimitPaused reports whether the shared core-REST bucket is
+// currently known-exhausted and, if so, the reset instant callers should wait
+// for before polling again (#812). Flows consult it to skip their REST poll
+// cycle instead of issuing doomed calls.
+func PrimaryRateLimitPaused() (paused bool, resetAt time.Time) {
+	return primaryRateLimitActive()
+}
+
+// PrimaryRateLimitState returns a diagnostic snapshot of the primary-limit pause
+// gate for status/diagnostic surfaces (#812).
+func PrimaryRateLimitState() PrimaryLimitState {
+	primaryLimitMu.Lock()
+	defer primaryLimitMu.Unlock()
+	paused := !primaryLimitReset.IsZero() && primaryLimitNow().Before(primaryLimitReset)
+	return PrimaryLimitState{
+		Paused:    paused,
+		ResetAt:   primaryLimitReset,
+		Since:     primaryLimitSince,
+		Remaining: primaryLimitRemain,
+		Skipped:   primaryLimitSkipped,
+		Hits:      primaryLimitHits,
+	}
+}
+
+// primaryLimitDigest renders the primary-limit pause state for the hourly REST
+// usage digest so an operator reading journalctl sees, alongside consumption,
+// whether a primary exhaustion paused polling — last-seen remaining, reset
+// time, and how many calls were skipped (#812). Empty when nothing to report.
+func primaryLimitDigest() string {
+	st := PrimaryRateLimitState()
+	if st.Hits == 0 && !st.Paused {
+		return ""
+	}
+	status := "clear"
+	if st.Paused {
+		status = "PAUSED until " + st.ResetAt.UTC().Format(time.RFC3339)
+	}
+	return fmt.Sprintf("; primary-limit %s (hits=%d, calls skipped=%d, last remaining=%d)",
+		status, st.Hits, st.Skipped, st.Remaining)
+}
+
+// resetPrimaryLimitForTest clears the shared gate so a test that arms it does
+// not leak state into the rest of the (serially-run) package tests.
+func resetPrimaryLimitForTest() {
+	primaryLimitMu.Lock()
+	defer primaryLimitMu.Unlock()
+	primaryLimitReset = time.Time{}
+	primaryLimitSince = time.Time{}
+	primaryLimitRemain = -1
+	primaryLimitSkipped = 0
+	primaryLimitHits = 0
+}
+
+// PrimaryRateLimitError is returned when a core-REST call is skipped because the
+// shared primary-limit gate is armed (#812): the call was never issued because
+// it could not succeed until ResetAt.
+type PrimaryRateLimitError struct {
+	Endpoint string
+	ResetAt  time.Time
+}
+
+func (e *PrimaryRateLimitError) Error() string {
+	if e == nil {
+		return "primary GitHub rate limit exhausted"
+	}
+	if e.ResetAt.IsZero() {
+		return fmt.Sprintf("gh api %s: skipped — primary GitHub rate limit exhausted", e.Endpoint)
+	}
+	return fmt.Sprintf("gh api %s: skipped — primary GitHub rate limit exhausted (resets %s)",
+		e.Endpoint, e.ResetAt.UTC().Format(time.RFC3339))
 }
 
 // ghBackoffDelay computes the exponential backoff for the given zero-based retry

--- a/internal/github/ratelimit_test.go
+++ b/internal/github/ratelimit_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -21,6 +22,11 @@ func stubGHRunner(t *testing.T, results []struct {
 	origSleep := ghAPISleep
 	origJitter := ghAPIJitterFrac
 
+	// The primary-limit pause gate (#812) is process-wide. Clear it before and
+	// after so a test that arms it cannot silently short-circuit the next test's
+	// runner calls, and so the etag cache and gate start from a known state.
+	resetPrimaryLimitForTest()
+
 	calls := 0
 	var sleeps []time.Duration
 	ghAPIRunner = func(args ...string) ([]byte, error) {
@@ -38,6 +44,7 @@ func stubGHRunner(t *testing.T, results []struct {
 		ghAPIRunner = origRunner
 		ghAPISleep = origSleep
 		ghAPIJitterFrac = origJitter
+		resetPrimaryLimitForTest()
 	}
 	return &calls, &sleeps, cleanup
 }
@@ -98,8 +105,11 @@ func TestGHAPI_HonorsRetryAfterHint(t *testing.T) {
 	}
 }
 
-func TestGHAPI_RateLimitExhaustsRetriesAndSurfacesRealError(t *testing.T) {
-	body := []byte("gh: API rate limit exceeded for user ID 123. (HTTP 403)")
+func TestGHAPI_SecondaryRateLimitExhaustsRetriesAndSurfacesRealError(t *testing.T) {
+	// A SECONDARY (abuse/burst) 403 is the retryable case: when it never clears,
+	// the wrapper exhausts its attempts and surfaces the real gh error. Acceptance
+	// #3 — secondary behavior is unchanged (#812).
+	body := []byte("gh: You have exceeded a secondary rate limit. (HTTP 403)")
 	results := []struct {
 		out []byte
 		err error
@@ -123,6 +133,93 @@ func TestGHAPI_RateLimitExhaustsRetriesAndSurfacesRealError(t *testing.T) {
 	}
 	if len(*sleeps) != ghAPIMaxAttempts-1 {
 		t.Fatalf("sleeps = %d, want %d backoffs between attempts", len(*sleeps), ghAPIMaxAttempts-1)
+	}
+}
+
+// TestGHAPI_PrimaryRateLimitFailsFast covers acceptance #1: a simulated primary
+// "API rate limit exceeded for user" 403 causes AT MOST ONE request (no 4×
+// retry amplification), fails fast, and arms the shared pause gate.
+func TestGHAPI_PrimaryRateLimitFailsFast(t *testing.T) {
+	reset := time.Now().Add(37 * time.Minute).Truncate(time.Second)
+	body := []byte("HTTP/2.0 403 Forbidden\n" +
+		"x-ratelimit-limit: 5000\n" +
+		"x-ratelimit-remaining: 0\n" +
+		"x-ratelimit-reset: " + strconv.FormatInt(reset.Unix(), 10) + "\n\n" +
+		`{"message":"API rate limit exceeded for user ID 123."}`)
+	results := []struct {
+		out []byte
+		err error
+	}{
+		{body, errors.New("exit status 1")},
+	}
+	calls, sleeps, cleanup := stubGHRunner(t, results)
+	defer cleanup()
+
+	_, err := ghAPIWithArgs("repos/owner/repo/pulls?state=open")
+	if err == nil {
+		t.Fatal("ghAPIWithArgs() error = nil, want a fail-fast error on primary exhaustion")
+	}
+	if *calls != 1 {
+		t.Fatalf("runner calls = %d, want 1 (fail fast, no retry amplification)", *calls)
+	}
+	if len(*sleeps) != 0 {
+		t.Fatalf("sleeps = %d, want 0 (a primary exhaustion is not retried)", len(*sleeps))
+	}
+	// The gate must be armed at the parsed X-RateLimit-Reset so sibling flows
+	// skip their REST cycle until then.
+	st := PrimaryRateLimitState()
+	if !st.Paused {
+		t.Fatal("PrimaryRateLimitState().Paused = false, want the pause gate armed")
+	}
+	if !st.ResetAt.Equal(reset) {
+		t.Fatalf("gate ResetAt = %s, want the parsed X-RateLimit-Reset %s", st.ResetAt, reset)
+	}
+	if st.Remaining != 0 {
+		t.Fatalf("gate Remaining = %d, want 0 (last-seen X-RateLimit-Remaining)", st.Remaining)
+	}
+	if st.Hits != 1 {
+		t.Fatalf("gate Hits = %d, want 1", st.Hits)
+	}
+}
+
+// TestGHAPI_SkipsCallsWhilePrimaryPauseArmed covers acceptance #2: while the
+// primary bucket is exhausted, core-REST calls are short-circuited (never
+// issued) until the reset — but rate_limit stays exempt so the budget can be
+// re-probed.
+func TestGHAPI_SkipsCallsWhilePrimaryPauseArmed(t *testing.T) {
+	calls, _, cleanup := stubGHRunner(t, []struct {
+		out []byte
+		err error
+	}{
+		{[]byte(`{"ok":true}`), nil},
+	})
+	defer cleanup()
+
+	reset := time.Now().Add(20 * time.Minute)
+	notePrimaryRateLimit(reset, 0)
+
+	_, err := ghAPIWithArgs("repos/owner/repo/pulls?state=open")
+	if err == nil {
+		t.Fatal("ghAPIWithArgs() error = nil, want a skip error while the gate is armed")
+	}
+	var primaryErr *PrimaryRateLimitError
+	if !errors.As(err, &primaryErr) {
+		t.Fatalf("error = %v, want a *PrimaryRateLimitError", err)
+	}
+	if *calls != 0 {
+		t.Fatalf("runner calls = %d, want 0 (the doomed call must never be issued)", *calls)
+	}
+
+	// rate_limit is exempt: it does not consume the core quota and is the probe
+	// used to confirm the bucket refilled.
+	if _, err := ghAPIWithArgs("rate_limit"); err != nil {
+		t.Fatalf("rate_limit while paused: err = %v, want it exempt from the gate", err)
+	}
+	if *calls != 1 {
+		t.Fatalf("runner calls after rate_limit = %d, want 1 (rate_limit issued)", *calls)
+	}
+	if skipped := PrimaryRateLimitState().Skipped; skipped != 1 {
+		t.Fatalf("gate Skipped = %d, want 1 (only the pulls call skipped)", skipped)
 	}
 }
 
@@ -229,5 +326,93 @@ func TestParseGHRateLimit_IncidentFixture(t *testing.T) {
 	fixture := "gh: You have exceeded a secondary rate limit. (HTTP 403)"
 	if _, limited := parseGHRateLimit([]byte(fixture)); !limited {
 		t.Fatal("the 2026-06-28 secondary 403 fixture must be retryable")
+	}
+}
+
+// TestClassifyGHRateLimit pins the primary-vs-secondary split (#812): only a
+// clear primary signal (X-RateLimit-Remaining: 0 or the "api rate limit
+// exceeded for user" signature) is non-retryable; every other rate-limit-ish
+// response stays secondary (retryable).
+func TestClassifyGHRateLimit(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want ghRateLimitKind
+	}{
+		{"primary-user-signature", "gh: API rate limit exceeded for user ID 123. (HTTP 403)", ghRateLimitPrimary},
+		{"primary-header-remaining-0", "HTTP/2.0 403 Forbidden\nx-ratelimit-remaining: 0\nx-ratelimit-reset: 1893456000\n\n{}", ghRateLimitPrimary},
+		{"primary-header-wins-over-text", "HTTP/2.0 403\nx-ratelimit-remaining: 0\n\nYou have exceeded a secondary rate limit", ghRateLimitPrimary},
+		{"secondary", "You have exceeded a secondary rate limit (HTTP 403)", ghRateLimitSecondary},
+		{"abuse", "gh: You have triggered an abuse detection mechanism (HTTP 403)", ghRateLimitSecondary},
+		{"retry-after-hint", "HTTP 429\nRetry-After: 12", ghRateLimitSecondary},
+		{"bare-429", "HTTP 429: too many requests", ghRateLimitSecondary},
+		{"remaining-positive-not-primary", "HTTP/2.0 403\nx-ratelimit-remaining: 42\n\nYou have exceeded a secondary rate limit", ghRateLimitSecondary},
+		{"plain-403", "gh: Forbidden (HTTP 403)", ghRateLimitNone},
+		{"404", "gh: Not Found (HTTP 404)", ghRateLimitNone},
+		{"success", `{"ok":true}`, ghRateLimitNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyGHRateLimit([]byte(tc.out)).kind; got != tc.want {
+				t.Fatalf("kind = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyGHRateLimit_ParsesResetAndRemaining(t *testing.T) {
+	out := []byte("HTTP/2.0 403 Forbidden\nx-ratelimit-remaining: 0\nx-ratelimit-reset: 1893456000\n\n{}")
+	info := classifyGHRateLimit(out)
+	if info.remaining != 0 {
+		t.Fatalf("remaining = %d, want 0", info.remaining)
+	}
+	if want := time.Unix(1893456000, 0); !info.resetAt.Equal(want) {
+		t.Fatalf("resetAt = %s, want %s", info.resetAt, want)
+	}
+}
+
+// TestPrimaryRateLimitGate exercises the shared pause gate directly: arming,
+// auto-expiry at reset, refresh-only-extends, and the fallback pause when no
+// reset was parsed. Injects primaryLimitNow so no wall-clock sleeping is needed.
+func TestPrimaryRateLimitGate(t *testing.T) {
+	resetPrimaryLimitForTest()
+	origNow := primaryLimitNow
+	defer func() { primaryLimitNow = origNow; resetPrimaryLimitForTest() }()
+
+	base := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	now := base
+	primaryLimitNow = func() time.Time { return now }
+
+	if paused, _ := primaryRateLimitActive(); paused {
+		t.Fatal("gate armed before any exhaustion")
+	}
+
+	reset := base.Add(40 * time.Minute)
+	notePrimaryRateLimit(reset, 0)
+	paused, gotReset := primaryRateLimitActive()
+	if !paused || !gotReset.Equal(reset) {
+		t.Fatalf("after arm: paused=%v reset=%s, want true %s", paused, gotReset, reset)
+	}
+
+	// A refresh carrying an EARLIER reset must not shorten the window.
+	notePrimaryRateLimit(base.Add(5*time.Minute), 0)
+	if _, gotReset = primaryRateLimitActive(); !gotReset.Equal(reset) {
+		t.Fatalf("after early refresh: reset=%s, want unchanged %s", gotReset, reset)
+	}
+
+	// Advancing past the reset auto-clears the gate (no explicit clear needed).
+	now = reset.Add(time.Second)
+	if paused, _ = primaryRateLimitActive(); paused {
+		t.Fatal("gate still armed after the reset instant passed")
+	}
+
+	// A zero reset (no header parsed) falls back to a bounded fixed pause.
+	notePrimaryRateLimit(time.Time{}, -1)
+	paused, gotReset = primaryRateLimitActive()
+	if !paused {
+		t.Fatal("fallback pause not armed for a zero reset")
+	}
+	if want := now.Add(primaryLimitFallbackPause); !gotReset.Equal(want) {
+		t.Fatalf("fallback reset = %s, want %s", gotReset, want)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -133,6 +133,7 @@ type Orchestrator struct {
 	syncProjectFn                func(issueNumber int, status github.ProjectStatus) bool
 	listNonDoneProjectItemsFn    func(pf *github.ProjectField) ([]github.ProjectItem, error)
 	rateLimitFn                  func() (github.RateLimitStatus, error)
+	primaryRESTPausedFn          func() (bool, time.Time)
 
 	// Per-cycle open-PR cache (#794). ListOpenPRs is the dominant forge REST
 	// read (~78% of the core-bucket calls at the 2026-06-28 secondary
@@ -249,11 +250,36 @@ func (o *Orchestrator) listOpenPRsForCycle() ([]github.PR, error) {
 	if o.cyclePRsValid {
 		return o.cyclePRs, o.cyclePRsErr
 	}
+	// #812: when the shared core-REST bucket is exhausted (a primary rate-limit
+	// pause armed by the gh wrapper), skip the fleet's dominant open-PR read
+	// until the reset instead of issuing a doomed call. Generalizes the GraphQL
+	// budget guard (projectGraphQLBudgetAvailable) to the core REST bucket: the
+	// cached error fans the skip out to the cycle's four open-PR consumers
+	// (reconcile / check / auto-merge / rebase), which each degrade to a no-op
+	// this cycle exactly as they already do for any open-PR read failure.
+	if paused, resetAt := o.primaryRESTPaused(); paused {
+		o.cyclePRs = nil
+		o.cyclePRsErr = &github.PrimaryRateLimitError{Endpoint: fmt.Sprintf("repos/%s/pulls", o.repo), ResetAt: resetAt}
+		o.cyclePRsValid = true
+		log.Printf("[orch] core REST bucket exhausted (primary rate limit, #812); skipping open-PR poll until %s", resetAt.UTC().Format(time.RFC3339))
+		return o.cyclePRs, o.cyclePRsErr
+	}
 	prs, err := o.listOpenPRs()
 	o.cyclePRs = prs
 	o.cyclePRsErr = err
 	o.cyclePRsValid = true
 	return prs, err
+}
+
+// primaryRESTPaused reports whether the shared core-REST bucket is paused on a
+// primary rate-limit exhaustion, and until when (#812). The gh wrapper arms the
+// gate; the orchestrator consults it to skip doomed REST polling. Injectable for
+// tests.
+func (o *Orchestrator) primaryRESTPaused() (bool, time.Time) {
+	if o.primaryRESTPausedFn != nil {
+		return o.primaryRESTPausedFn()
+	}
+	return github.PrimaryRateLimitPaused()
 }
 
 func (o *Orchestrator) remoteBranchExists(branch string) (bool, error) {

--- a/internal/orchestrator/ratelimit_dedup_test.go
+++ b/internal/orchestrator/ratelimit_dedup_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -222,6 +223,53 @@ func TestListOpenPRsForCycle_NoMemoizationOutsideCycle(t *testing.T) {
 		t.Fatalf("post-invalidate calls fetched %d times total, want 5 (one re-fetch then memoized)", calls)
 	}
 	o.endCycle()
+}
+
+// TestListOpenPRsForCycle_SkipsWhilePrimaryRateLimited proves requirement #2 /
+// acceptance #2 at the orchestrator layer: when the shared core-REST bucket is
+// paused on a primary rate-limit exhaustion (#812), a cycle skips its dominant
+// open-PR poll entirely — never issuing the doomed fetch — and surfaces the
+// pause instant so the four cycle steps degrade to a no-op until reset.
+func TestListOpenPRsForCycle_SkipsWhilePrimaryRateLimited(t *testing.T) {
+	reset := time.Now().Add(30 * time.Minute)
+	calls := 0
+	o := &Orchestrator{
+		repo: "owner/repo",
+		listOpenPRsFn: func() ([]github.PR, error) {
+			calls++
+			return nil, nil
+		},
+		primaryRESTPausedFn: func() (bool, time.Time) { return true, reset },
+	}
+	o.beginCycle()
+	defer o.endCycle()
+
+	prs, err := o.listOpenPRsForCycle()
+	if err == nil {
+		t.Fatal("listOpenPRsForCycle err = nil, want a primary-rate-limit skip error")
+	}
+	var primaryErr *github.PrimaryRateLimitError
+	if !errors.As(err, &primaryErr) {
+		t.Fatalf("err = %v, want a *github.PrimaryRateLimitError", err)
+	}
+	if !primaryErr.ResetAt.Equal(reset) {
+		t.Fatalf("skip error ResetAt = %s, want %s", primaryErr.ResetAt, reset)
+	}
+	if prs != nil {
+		t.Fatalf("prs = %v, want nil while paused", prs)
+	}
+	if calls != 0 {
+		t.Fatalf("ListOpenPRs fired %d times while paused, want 0 (the doomed call must be skipped)", calls)
+	}
+
+	// The skip verdict is cached for the cycle: a second consumer reuses it
+	// without a fetch (still zero calls).
+	if _, err := o.listOpenPRsForCycle(); err == nil {
+		t.Fatal("second consumer err = nil, want the cached skip error")
+	}
+	if calls != 0 {
+		t.Fatalf("ListOpenPRs fired %d times, want 0 (skip verdict cached per cycle)", calls)
+	}
 }
 
 func TestComputeStartupJitter(t *testing.T) {


### PR DESCRIPTION
Refs #812

## Changes
- `internal/github`: `classifyGHRateLimit` distinguishes **primary** (hourly) from **secondary** (abuse/burst) rate limits. A primary exhaustion (`X-RateLimit-Remaining: 0` or the `api rate limit exceeded` signature) fails fast after **one** request instead of retrying 4×, and arms a process-wide pause gate at `X-RateLimit-Reset`.
- Every subsequent core-REST call short-circuits until reset (`rate_limit` stays exempt so the bucket can be re-probed). Secondary/abuse retry + Retry-After behavior is unchanged.
- `internal/orchestrator`: `listOpenPRsForCycle` consults the shared gate to skip the fleet's dominant open-PR poll until reset — generalizing the GraphQL budget guard to the core REST bucket.
- Pause state (last-seen remaining, reset time, hits, calls skipped) exposed via `PrimaryRateLimitState` and the hourly REST usage digest.

## Testing
- `go test ./...` (all pass)
- `go build ./cmd/maestro/`
- New tests: primary fail-fast (1 request, gate armed), pause-gate skip (0 doomed calls, `rate_limit` exempt), primary-vs-secondary classification, gate arm/expiry/refresh, orchestrator poll-skip while paused; existing secondary retry + Retry-After tests retained.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes GitHub REST rate-limit handling to avoid retry amplification on primary quota exhaustion. The main changes are:

- Classifies GitHub rate limits as primary, secondary, or none.
- Fails fast and arms a shared pause gate when primary REST quota is exhausted.
- Skips core REST calls while the primary pause gate is active, with `rate_limit` exempt for probing.
- Adds orchestrator logic to skip the per-cycle open-PR poll while the shared REST gate is paused.
- Adds tests for classification, fail-fast behavior, pause-gate lifecycle, and orchestrator polling skips.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped, mutex-protected, preserves secondary retry behavior, exempts `rate_limit` probes, and includes focused tests for the new behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The base harness test for TestTrexBasePrimaryAndSecondaryRateLimitBehavior was executed and completed with exit code 0.
- The head harness test for TestTrexHeadPrimaryGateAndSecondaryRateLimitBehavior was executed and completed with exit code 0.
- Captured the orchestrator rest pause-skip before state, showing one listOpenPRsFn call and no pause gate.
- Captured the orchestrator rest pause-skip after state, showing the injected primary REST pause, a returned PrimaryRateLimitError, zero open-PR poll calls, and cached error reuse.
- Captured the primary digest before state, confirming that diagnostic API/digest helpers are not present on base.
- Captured the primary digest after state, showing the head harness output, exit code 0, and that primary exhaust state and REST usage digest primary-limit details were emitted (no contract mismatch observed).

<a href="https://app.greptile.com/trex/runs/13226698/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds primary-vs-secondary GitHub rate-limit classification, fail-fast behavior for primary exhaustion, a shared pause gate, skip errors, and diagnostic state output. |
| internal/orchestrator/orchestrator.go | Consults the shared primary REST pause gate before the per-cycle open-PR poll and memoizes a skip error while paused. |
| internal/github/ratelimit_test.go | Adds tests for primary fail-fast behavior, pause-gate skipping, classification, parsed reset and remaining values, and gate lifecycle. |
| internal/orchestrator/ratelimit_dedup_test.go | Adds orchestrator coverage showing open-PR polling is skipped and cached for the cycle while the primary REST gate is paused. |
| internal/github/conditional_test.go | Resets the process-wide primary rate-limit gate around conditional GitHub API runner tests to avoid cross-test leakage. |

<sub>Reviews (1): Last reviewed commit: ["fix(github): fail fast on primary rate l..."](https://github.com/befeast/maestro/commit/27e71619d1e57d1f14b92fedf34bded5403924b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41706028)</sub>

<!-- /greptile_comment -->