### PR TITLE
MC: separate live worker capacity from PR-gate sessions in worker count and spawning (#814)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1250,6 +1250,7 @@ type Config struct {
 	LocalPath                       string                       `yaml:"local_path"`
 	WorktreeBase                    string                       `yaml:"worktree_base"`
 	MaxParallel                     int                          `yaml:"max_parallel"`
+	MaxLiveWorkers                  int                          `yaml:"max_live_workers"`              // #814: cap on live implementation workers (StatusRunning). When >0, pr_open PR-gate sessions no longer consume spawn capacity, so a gate-bound queue keeps dispatching live workers up to this limit. 0 = legacy (pr_open counts against max_parallel).
 	MaxConcurrentByState            map[string]int               `yaml:"max_concurrent_by_state"`       // per-state concurrency limits (e.g. "running": 5, "pr_open": 2)
 	MaxRuntimeMinutes               int                          `yaml:"max_runtime_minutes"`           // max worker runtime in minutes (default: 120)
 	WorkerSilentTimeoutMinutes      int                          `yaml:"worker_silent_timeout_minutes"` // kill running worker if tmux output hash doesn't change for N minutes (0 = disabled)
@@ -1378,6 +1379,13 @@ func parse(data []byte) (*Config, error) {
 
 	if cfg.Repo == "" {
 		return nil, fmt.Errorf("config: repo is required")
+	}
+
+	// A negative max_live_workers is meaningless; clamp to 0 (legacy: pr_open
+	// counts against max_parallel) so a typo can never silently disable
+	// dispatch entirely (#814).
+	if cfg.MaxLiveWorkers < 0 {
+		cfg.MaxLiveWorkers = 0
 	}
 
 	// Normalize max_concurrent_by_state keys: trim + lowercase

--- a/internal/config/max_live_workers_test.go
+++ b/internal/config/max_live_workers_test.go
@@ -1,0 +1,40 @@
+package config
+
+import "testing"
+
+// #814: max_live_workers separates live implementation-worker capacity from
+// pr_open PR-gate sessions. Default is 0 (legacy: pr_open counts against
+// max_parallel); a negative value is clamped to 0 so a typo cannot silently
+// disable dispatch.
+func TestParse_MaxLiveWorkersDefaultsToZero(t *testing.T) {
+	cfg, err := Parse([]byte("repo: owner/repo\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.MaxLiveWorkers != 0 {
+		t.Errorf("MaxLiveWorkers = %d, want 0 (legacy default)", cfg.MaxLiveWorkers)
+	}
+}
+
+func TestParse_MaxLiveWorkersExplicit(t *testing.T) {
+	cfg, err := Parse([]byte("repo: owner/repo\nmax_parallel: 4\nmax_live_workers: 2\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.MaxLiveWorkers != 2 {
+		t.Errorf("MaxLiveWorkers = %d, want 2", cfg.MaxLiveWorkers)
+	}
+	if cfg.MaxParallel != 4 {
+		t.Errorf("MaxParallel = %d, want 4 (unchanged)", cfg.MaxParallel)
+	}
+}
+
+func TestParse_MaxLiveWorkersNegativeClampsToZero(t *testing.T) {
+	cfg, err := Parse([]byte("repo: owner/repo\nmax_live_workers: -3\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.MaxLiveWorkers != 0 {
+		t.Errorf("MaxLiveWorkers = %d, want 0 (negative clamped)", cfg.MaxLiveWorkers)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1977,8 +1977,8 @@ func (o *Orchestrator) RunOnce() error {
 	}
 
 	// Step 5: Start new workers for available slots
-	active := len(s.ActiveSessions())
-	slots := availableSlots(o.cfg, s, active)
+	capNow := s.Capacity(capacityInput(o.cfg))
+	slots := capNow.AvailableSlots
 	if reserved := pendingRetryReservations(s); reserved > 0 && slots > 0 {
 		if reserved > slots {
 			reserved = slots
@@ -1986,7 +1986,8 @@ func (o *Orchestrator) RunOnce() error {
 		slots -= reserved
 		log.Printf("[orch] reserving %d worker slot(s) for scheduled retries", reserved)
 	}
-	log.Printf("[orch] active=%d max=%d available_slots=%d", active, o.cfg.MaxParallel, slots)
+	log.Printf("[orch] live_workers=%d pr_gates=%d limit=%d available_slots=%d (separated=%t blocked_by_gates=%d)",
+		capNow.LiveWorkers, capNow.PRGates, capNow.Limit, slots, capNow.Separated, capNow.BlockedByGates)
 
 	if slots > 0 {
 		o.startNewWorkers(s, slots)
@@ -5108,31 +5109,25 @@ func (o *Orchestrator) resolveBackendDecision(issue github.Issue) router.Backend
 	return o.router.ResolveBackendDecision(issue)
 }
 
-// availableSlots calculates how many new workers can be started, considering
-// both the global max_parallel limit and per-state limits from max_concurrent_by_state.
-// New workers enter the "running" state, so the "running" per-state limit is applied.
+// capacityInput builds the state.CapacityInput from a project config so the
+// spawn budget is computed by the single shared state.Capacity source of truth.
+func capacityInput(cfg *config.Config) state.CapacityInput {
+	return state.CapacityInput{
+		MaxParallel:          cfg.MaxParallel,
+		MaxLiveWorkers:       cfg.MaxLiveWorkers,
+		MaxConcurrentByState: cfg.MaxConcurrentByState,
+	}
+}
+
+// availableSlots calculates how many new workers can be started. It delegates to
+// state.Capacity, which separates live implementation workers from pr_open
+// PR-gate sessions: with max_live_workers>0, gate-bound sessions no longer
+// consume spawn capacity, so a long queue keeps dispatching implementation work
+// instead of stalling behind a handful of open PRs (#814). The active parameter
+// is retained for call-site clarity but Capacity recomputes from live state.
 func availableSlots(cfg *config.Config, s *state.State, active int) int {
-	slots := cfg.MaxParallel - active
-	if slots <= 0 {
-		return 0
-	}
-
-	// Apply per-state limit for "running" — new workers enter running state
-	if limit, ok := cfg.MaxConcurrentByState["running"]; ok && limit > 0 {
-		statusCounts := s.CountByStatus()
-		runningCount := statusCounts[state.StatusRunning]
-		runningSlots := limit - runningCount
-		if runningSlots < slots {
-			log.Printf("[orch] per-state limit: running=%d max_running=%d (capped from %d to %d slots)",
-				runningCount, limit, slots, runningSlots)
-			slots = runningSlots
-		}
-	}
-
-	if slots < 0 {
-		return 0
-	}
-	return slots
+	_ = active
+	return s.Capacity(capacityInput(cfg)).AvailableSlots
 }
 
 // startNewWorkers picks eligible issues and starts workers for them
@@ -5713,8 +5708,14 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			o.syncProject(issue.Number, github.ProjectStatusTodo)
 			continue
 		}
-		if liveActive := len(s.ActiveSessions()); o.cfg.MaxParallel > 0 && liveActive >= o.cfg.MaxParallel {
-			log.Printf("[orch] dispatch cap: %d active >= max_parallel %d — queueing issue #%d", liveActive, o.cfg.MaxParallel, issue.Number)
+		// Live backstop recomputed from current state each iteration (retry
+		// respawns earlier in the cycle already turned dead sessions running).
+		// Uses the same Capacity budget as availableSlots so pr_open PR-gate
+		// sessions do not count against live-worker capacity when
+		// max_live_workers is set (#814).
+		if capNow := s.Capacity(capacityInput(o.cfg)); capNow.Limit > 0 && capNow.AvailableSlots <= 0 {
+			log.Printf("[orch] dispatch cap: live=%d pr_gates=%d limit=%d (separated=%t) — queueing issue #%d",
+				capNow.LiveWorkers, capNow.PRGates, capNow.Limit, capNow.Separated, issue.Number)
 			o.syncProject(issue.Number, github.ProjectStatusTodo)
 			continue
 		}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -6794,6 +6794,38 @@ func TestAvailableSlots_NonRunningLimitIgnoredForDispatch(t *testing.T) {
 	}
 }
 
+// #814: with max_live_workers set, pr_open PR-gate sessions no longer consume
+// spawn capacity, so a gate-bound queue keeps dispatching live workers up to the
+// configured live-worker limit.
+func TestAvailableSlots_MaxLiveWorkersIgnoresPROpen(t *testing.T) {
+	cfg := &config.Config{MaxParallel: 4, MaxLiveWorkers: 4}
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{Status: state.StatusRunning}
+	s.Sessions["slot-2"] = &state.Session{Status: state.StatusRunning}
+	s.Sessions["slot-3"] = &state.Session{Status: state.StatusPROpen}
+	s.Sessions["slot-4"] = &state.Session{Status: state.StatusPROpen}
+
+	got := availableSlots(cfg, s, len(s.ActiveSessions()))
+	if got != 2 {
+		t.Errorf("availableSlots() = %d, want 2 (4 live limit - 2 running; pr_open ignored)", got)
+	}
+}
+
+// Acceptance: a project with N PR-open sessions can still spawn live workers up
+// to the live-worker limit — the case where legacy counting reported 0.
+func TestAvailableSlots_MaxLiveWorkersAllGatesStillDispatches(t *testing.T) {
+	cfg := &config.Config{MaxParallel: 2, MaxLiveWorkers: 3}
+	s := state.NewState()
+	for i := 1; i <= 4; i++ {
+		s.Sessions[fmt.Sprintf("gate-%d", i)] = &state.Session{Status: state.StatusPROpen}
+	}
+
+	// Legacy counting would give max_parallel(2) - active(4) => 0 slots.
+	if got := availableSlots(cfg, s, len(s.ActiveSessions())); got != 3 {
+		t.Errorf("availableSlots() = %d, want 3 (keep dispatching despite 4 open PRs)", got)
+	}
+}
+
 func TestPendingRetryReservations_CountsOnlyScheduledDeadRetries(t *testing.T) {
 	now := time.Now().UTC()
 	past := now.Add(-time.Second)

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -822,9 +822,17 @@ type fleetSummary struct {
 	// project card reads. Plain ints — never null.
 	PRsOpen        int `json:"prs_open"`
 	WorkersRunning int `json:"workers_running"`
-	Failed         int `json:"failed"`
-	Sessions       int `json:"sessions"`
-	NeedsAttention int `json:"needs_attention"`
+	// #814 capacity plane (fleet aggregate): LiveWorkers is the live
+	// implementation-worker count (StatusRunning) separated from PRGates
+	// (StatusPROpen, no live process, waiting on CI/review/merge gate).
+	// CapacityBlockedByGates sums the live-worker slots pr_open sessions are
+	// withholding across projects still on legacy counting.
+	LiveWorkers            int `json:"live_workers"`
+	PRGates                int `json:"pr_gates"`
+	CapacityBlockedByGates int `json:"capacity_blocked_by_gates"`
+	Failed                 int `json:"failed"`
+	Sessions               int `json:"sessions"`
+	NeedsAttention         int `json:"needs_attention"`
 	// SelfResolving counts attention items that are convergence-bound
 	// and need no operator action (e.g. retry_exhausted with a green PR
 	// — the orchestrator auto-merges once the merge gate clears). See
@@ -916,9 +924,24 @@ type fleetProjectState struct {
 	// by the SPA project card (#566). It is the count of sessions in
 	// StatusRunning. Always non-null.
 	WorkersRunning int `json:"workers_running"`
-	Failed         int `json:"failed"`
-	Sessions       int `json:"sessions"`
-	NeedsAttention int `json:"needs_attention"`
+	// #814 capacity plane: LiveWorkers separates live implementation workers
+	// (StatusRunning) from PRGates (StatusPROpen — PR open, no live process,
+	// waiting on CI/review/merge). CapacityUsed is the slots counted in-use
+	// for spawn accounting and CapacityBlockedByGates the live-worker slots
+	// pr_open sessions withhold on legacy counting (0 once max_live_workers
+	// separates gates out). LiveWorkerLimit is the effective spawn limit;
+	// Activity/ActivityReason explain why the project is or is not
+	// implementing (implementing / blocked_by_pr_gates / queue_empty / …).
+	LiveWorkers            int    `json:"live_workers"`
+	PRGates                int    `json:"pr_gates"`
+	CapacityUsed           int    `json:"capacity_used"`
+	CapacityBlockedByGates int    `json:"capacity_blocked_by_gates"`
+	LiveWorkerLimit        int    `json:"live_worker_limit,omitempty"`
+	Activity               string `json:"activity,omitempty"`
+	ActivityReason         string `json:"activity_reason,omitempty"`
+	Failed                 int    `json:"failed"`
+	Sessions               int    `json:"sessions"`
+	NeedsAttention         int    `json:"needs_attention"`
 	// SelfResolving is the count of attention sessions on this project
 	// that are convergence-bound (the orchestrator will resolve them
 	// without operator action — see fleetSessionIsConvergenceBound and
@@ -1703,6 +1726,9 @@ func (s *FleetServer) snapshot() fleetResponse {
 		resp.Summary.PROpen += item.PROpen
 		resp.Summary.PRsOpen += item.PRsOpen
 		resp.Summary.WorkersRunning += item.WorkersRunning
+		resp.Summary.LiveWorkers += item.LiveWorkers
+		resp.Summary.PRGates += item.PRGates
+		resp.Summary.CapacityBlockedByGates += item.CapacityBlockedByGates
 		resp.Summary.Failed += item.Failed
 		resp.Summary.Sessions += item.Sessions
 		resp.Summary.NeedsAttention += item.NeedsAttention
@@ -3167,6 +3193,18 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	item.Running = len(projectState.Running)
 	item.PROpen = len(projectState.PROpen)
 	item.WorkersRunning = item.Running
+	// #814: expose the live-worker vs PR-gate capacity split so Mission
+	// Control never renders "0 workers" for a gate-bound-but-busy project.
+	capacity := st.Capacity(state.CapacityInput{
+		MaxParallel:          cfg.MaxParallel,
+		MaxLiveWorkers:       cfg.MaxLiveWorkers,
+		MaxConcurrentByState: cfg.MaxConcurrentByState,
+	})
+	item.LiveWorkers = capacity.LiveWorkers
+	item.PRGates = capacity.PRGates
+	item.CapacityUsed = capacity.CapacityUsed
+	item.CapacityBlockedByGates = capacity.BlockedByGates
+	item.LiveWorkerLimit = cfg.MaxLiveWorkers
 	item.PRsOpen = fleetTruthfulOpenPRCount(projectState, st)
 	item.Failed = failedCount(projectState.Summary)
 	item.Sessions = len(projectState.All)
@@ -3181,6 +3219,24 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 			item.ApprovalSummary[approval.Status]++
 		}
 	}
+	// #814: classify why the project is (not) implementing so operators can tell
+	// an empty queue from a gate-bound-but-eligible pipeline. Signals are read
+	// from the same snapshot: eligible from the supervisor queue analysis,
+	// pending approvals from the approval summary, model limits from backend
+	// health.
+	eligibleIssues := 0
+	if item.QueueSnapshot != nil {
+		eligibleIssues = item.QueueSnapshot.Eligible
+	}
+	activity, activityReason := state.ClassifyActivity(state.ActivityInput{
+		Capacity:         capacity,
+		EligibleIssues:   eligibleIssues,
+		PendingApprovals: item.ApprovalSummary["pending"],
+		BackendsBlocked:  allBackendsBlocked(item.BackendHealth),
+		Paused:           item.Paused,
+	})
+	item.Activity = string(activity)
+	item.ActivityReason = activityReason
 	staleAudits := reconcileStaleSessions(cfg, st, now)
 	staleSlots := make(map[string]state.StaleSessionAudit, len(staleAudits))
 	for _, audit := range staleAudits {
@@ -3292,6 +3348,22 @@ func fleetIssuesCoveredByExecutedCloseApproval(st *state.State) map[int]bool {
 		}
 	}
 	return covered
+}
+
+// allBackendsBlocked reports whether every backend with a recorded health entry
+// is currently unavailable (e.g. cooldown / usage-limit). Used only as an
+// idle-reason signal (#814): with no health entries, backends are assumed
+// available so a fresh project never mislabels itself as model-limit-blocked.
+func allBackendsBlocked(health map[string]state.BackendHealth) bool {
+	if len(health) == 0 {
+		return false
+	}
+	for _, h := range health {
+		if h.State == "" || h.State == state.BackendHealthAvailable {
+			return false
+		}
+	}
+	return true
 }
 
 func reconcileStaleSessions(cfg *config.Config, st *state.State, now time.Time) []state.StaleSessionAudit {

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -3232,7 +3232,7 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 		Capacity:         capacity,
 		EligibleIssues:   eligibleIssues,
 		PendingApprovals: item.ApprovalSummary["pending"],
-		BackendsBlocked:  allBackendsBlocked(item.BackendHealth),
+		BackendsBlocked:  allBackendsBlocked(item.BackendHealth, configuredWorkerBackends(cfg)),
 		Paused:           item.Paused,
 	})
 	item.Activity = string(activity)
@@ -3350,11 +3350,69 @@ func fleetIssuesCoveredByExecutedCloseApproval(st *state.State) map[int]bool {
 	return covered
 }
 
-// allBackendsBlocked reports whether every backend with a recorded health entry
-// is currently unavailable (e.g. cooldown / usage-limit). Used only as an
-// idle-reason signal (#814): with no health entries, backends are assumed
-// available so a fresh project never mislabels itself as model-limit-blocked.
-func allBackendsBlocked(health map[string]state.BackendHealth) bool {
+// configuredWorkerBackends returns the set of backends a fresh dispatch could
+// route a worker to: the default backend plus every enabled backend declared
+// in model.backends. Disabled backends are omitted — they are never
+// dispatchable, so they cannot serve as an available escape hatch when
+// deciding whether the project is fully blocked by model limits (#814).
+func configuredWorkerBackends(cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var names []string
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	// The default backend is auto-defined and dispatchable unless it is
+	// explicitly present-and-disabled in model.backends.
+	if def, ok := cfg.Model.Backends[cfg.Model.Default]; !ok || def.IsEnabled() {
+		add(cfg.Model.Default)
+	}
+	for name, def := range cfg.Model.Backends {
+		if def.IsEnabled() {
+			add(name)
+		}
+	}
+	return names
+}
+
+// allBackendsBlocked reports whether every dispatchable backend is currently
+// unavailable (e.g. cooldown / usage-limit). Used only as an idle-reason
+// signal (#814).
+//
+// A backend counts as blocked only when it has a health entry whose state is
+// non-available. Any configured backend WITHOUT a health entry is assumed
+// available — dispatch may still try it — so a project is reported
+// blocked_by_model_limits only when no configured backend can be dispatched.
+// This prevents a partial health map (e.g. one backend in cooldown while other
+// configured backends have no entry yet) from mislabeling the project as fully
+// blocked while dispatch still has an available backend to try.
+//
+// When the configured set is unknown (empty), fall back to the health map
+// alone: blocked only when it is non-empty and every recorded entry is
+// unavailable.
+func allBackendsBlocked(health map[string]state.BackendHealth, configured []string) bool {
+	blocked := func(name string) bool {
+		h, ok := health[name]
+		if !ok {
+			return false // untracked backend is assumed available
+		}
+		return h.State != "" && h.State != state.BackendHealthAvailable
+	}
+	if len(configured) > 0 {
+		for _, name := range configured {
+			if !blocked(name) {
+				return false
+			}
+		}
+		return true
+	}
 	if len(health) == 0 {
 		return false
 	}

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -736,6 +736,102 @@ func TestFleetAPIIncludesQueueSnapshotMetadata(t *testing.T) {
 	}
 }
 
+// #814: the fleet snapshot must separate live implementation workers from
+// pr_open PR-gate sessions and explain a gate-bound-but-eligible project instead
+// of rendering it as idle with 0 workers.
+func TestFleetSnapshotSeparatesLiveWorkersFromPRGates(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+
+	// Legacy project: max_parallel filled entirely by pr_open PR-gate sessions
+	// while eligible work waits — the misleading "0 workers" case.
+	gateDir := filepath.Join(dir, "gatebound")
+	gateState := state.NewState()
+	gateState.Sessions["gate-1"] = &state.Session{Status: state.StatusPROpen, PRNumber: 101, IssueNumber: 11}
+	gateState.Sessions["gate-2"] = &state.Session{Status: state.StatusPROpen, PRNumber: 102, IssueNumber: 12}
+	gateState.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-gatebound",
+		CreatedAt:         now,
+		Project:           "owner/gatebound",
+		RecommendedAction: "spawn_worker",
+		Risk:              "mutating",
+		PolicyRule:        "supervisor.dynamic_wave",
+		QueueAnalysis: &state.SupervisorQueueAnalysis{
+			PolicyRule:         "supervisor.dynamic_wave",
+			OpenIssues:         5,
+			EligibleCandidates: 3,
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(gateDir, gateState); err != nil {
+		t.Fatalf("save gate state: %v", err)
+	}
+
+	// Separated project: max_live_workers>0 keeps a live worker running while
+	// several PRs are open — capacity is not blocked by the gates.
+	liveDir := filepath.Join(dir, "separated")
+	liveState := state.NewState()
+	liveState.Sessions["run-1"] = &state.Session{Status: state.StatusRunning, PID: 4242, IssueNumber: 20}
+	liveState.Sessions["gate-1"] = &state.Session{Status: state.StatusPROpen, PRNumber: 201, IssueNumber: 21}
+	liveState.Sessions["gate-2"] = &state.Session{Status: state.StatusPROpen, PRNumber: 202, IssueNumber: 22}
+	liveState.Sessions["gate-3"] = &state.Session{Status: state.StatusPROpen, PRNumber: 203, IssueNumber: 23}
+	if err := state.Save(liveDir, liveState); err != nil {
+		t.Fatalf("save live state: %v", err)
+	}
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("GateBound", "/tmp/gatebound.yaml", "", &config.Config{
+			Repo:        "owner/gatebound",
+			StateDir:    gateDir,
+			MaxParallel: 2,
+		}),
+		NewFleetProject("Separated", "/tmp/separated.yaml", "", &config.Config{
+			Repo:           "owner/separated",
+			StateDir:       liveDir,
+			MaxParallel:    2,
+			MaxLiveWorkers: 3,
+		}),
+	}, "127.0.0.1", 8786, true)
+	resp := srv.snapshot()
+
+	gate := findFleetProject(t, resp.Projects, "GateBound")
+	if gate.LiveWorkers != 0 || gate.WorkersRunning != 0 {
+		t.Fatalf("gate-bound live workers = %d/%d, want 0", gate.LiveWorkers, gate.WorkersRunning)
+	}
+	if gate.PRGates != 2 {
+		t.Errorf("gate-bound pr_gates = %d, want 2", gate.PRGates)
+	}
+	if gate.CapacityUsed != 2 || gate.CapacityBlockedByGates != 2 {
+		t.Errorf("gate-bound capacity_used=%d blocked_by_gates=%d, want 2/2", gate.CapacityUsed, gate.CapacityBlockedByGates)
+	}
+	if gate.Activity != string(state.ActivityBlockedByGates) {
+		t.Errorf("gate-bound activity = %q, want %q", gate.Activity, state.ActivityBlockedByGates)
+	}
+	if !contains(gate.ActivityReason, "Blocked by PR gates") {
+		t.Errorf("gate-bound activity reason = %q, want blocked-by-PR-gates explanation", gate.ActivityReason)
+	}
+
+	sep := findFleetProject(t, resp.Projects, "Separated")
+	if sep.LiveWorkers != 1 || sep.WorkersRunning != 1 {
+		t.Errorf("separated live workers = %d/%d, want 1", sep.LiveWorkers, sep.WorkersRunning)
+	}
+	if sep.PRGates != 3 {
+		t.Errorf("separated pr_gates = %d, want 3", sep.PRGates)
+	}
+	if sep.CapacityBlockedByGates != 0 {
+		t.Errorf("separated blocked_by_gates = %d, want 0 (gates separated out)", sep.CapacityBlockedByGates)
+	}
+	if sep.Activity != string(state.ActivityImplementing) {
+		t.Errorf("separated activity = %q, want %q", sep.Activity, state.ActivityImplementing)
+	}
+
+	if resp.Summary.LiveWorkers != 1 || resp.Summary.PRGates != 5 {
+		t.Errorf("summary live_workers=%d pr_gates=%d, want 1/5", resp.Summary.LiveWorkers, resp.Summary.PRGates)
+	}
+	if resp.Summary.CapacityBlockedByGates != 2 {
+		t.Errorf("summary capacity_blocked_by_gates = %d, want 2", resp.Summary.CapacityBlockedByGates)
+	}
+}
+
 func TestFleetQueueSnapshotFromSupervisorCarriesDecisionPlane(t *testing.T) {
 	info := supervisorInfo{
 		Latest: &supervisorDecisionInfo{

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -4734,3 +4734,78 @@ func TestLoadFleetProjectsRejectsExplicitDuplicateName(t *testing.T) {
 		t.Fatal("LoadFleetProjects: want error on explicit duplicate name, got nil")
 	}
 }
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestAllBackendsBlockedPartialHealthNotFullyBlocked guards the #814 review
+// finding: a health map holding only a cooldown entry for one backend must NOT
+// read as fully blocked while other configured backends have no health entry
+// yet and could still be dispatched.
+func TestAllBackendsBlockedPartialHealthNotFullyBlocked(t *testing.T) {
+	cfg := &config.Config{Model: config.ModelConfig{
+		Default: "claude",
+		Backends: map[string]config.BackendDef{
+			"claude": {},
+			"codex":  {},
+		},
+	}}
+	configured := configuredWorkerBackends(cfg)
+
+	// Only claude is in cooldown; codex has no entry -> dispatch can still try
+	// codex, so the project is not blocked_by_model_limits.
+	health := map[string]state.BackendHealth{
+		"claude": {State: state.BackendHealthCooldown},
+	}
+	if allBackendsBlocked(health, configured) {
+		t.Fatal("partial cooldown (codex still available) must not report all backends blocked")
+	}
+
+	// Both configured backends blocked -> genuinely blocked.
+	health["codex"] = state.BackendHealth{State: state.BackendHealthCooldown}
+	if !allBackendsBlocked(health, configured) {
+		t.Fatal("every configured backend in cooldown must report all backends blocked")
+	}
+
+	// An explicit available entry counts as an escape hatch.
+	health["codex"] = state.BackendHealth{State: state.BackendHealthAvailable}
+	if allBackendsBlocked(health, configured) {
+		t.Fatal("an available backend must not report all backends blocked")
+	}
+}
+
+// TestConfiguredWorkerBackendsOmitsDisabled confirms a disabled backend is not
+// counted as a dispatchable escape hatch, so its absence from the blocked set
+// cannot keep blocked_by_model_limits from firing when every enabled backend
+// is down.
+func TestConfiguredWorkerBackendsOmitsDisabled(t *testing.T) {
+	cfg := &config.Config{Model: config.ModelConfig{
+		Default: "claude",
+		Backends: map[string]config.BackendDef{
+			"claude": {},
+			"codex":  {Enabled: boolPtr(false)},
+		},
+	}}
+	configured := configuredWorkerBackends(cfg)
+	if len(configured) != 1 || configured[0] != "claude" {
+		t.Fatalf("configured = %v, want [claude] (codex disabled)", configured)
+	}
+	// claude down + codex disabled -> fully blocked (codex is not an escape).
+	health := map[string]state.BackendHealth{
+		"claude": {State: state.BackendBlockUsageLimit},
+	}
+	if !allBackendsBlocked(health, configured) {
+		t.Fatal("disabled codex must not prevent blocked_by_model_limits when claude is down")
+	}
+}
+
+// TestAllBackendsBlockedNoConfiguredFallsBackToHealthMap keeps the legacy
+// health-map-only behavior when the configured set is unknown.
+func TestAllBackendsBlockedNoConfiguredFallsBackToHealthMap(t *testing.T) {
+	if allBackendsBlocked(nil, nil) {
+		t.Fatal("empty health + no configured set must not report blocked")
+	}
+	blocked := map[string]state.BackendHealth{"claude": {State: state.BackendHealthCooldown}}
+	if !allBackendsBlocked(blocked, nil) {
+		t.Fatal("all recorded entries blocked + no configured set must report blocked")
+	}
+}

--- a/internal/state/capacity_test.go
+++ b/internal/state/capacity_test.go
@@ -1,0 +1,203 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func stateWith(statuses ...SessionStatus) *State {
+	s := NewState()
+	for i, st := range statuses {
+		s.Sessions[slotName(i)] = &Session{Status: st}
+	}
+	return s
+}
+
+func slotName(i int) string {
+	return "slot-" + string(rune('a'+i))
+}
+
+// #814: legacy accounting (max_live_workers unset) counts running + pr_open
+// against max_parallel, and reports the live-worker slots that pr_open sessions
+// withhold.
+func TestCapacity_LegacyCountsPROpenAgainstParallel(t *testing.T) {
+	s := stateWith(StatusRunning, StatusRunning, StatusPROpen, StatusPROpen)
+	c := s.Capacity(CapacityInput{MaxParallel: 4})
+
+	if c.LiveWorkers != 2 || c.PRGates != 2 {
+		t.Fatalf("LiveWorkers=%d PRGates=%d, want 2/2", c.LiveWorkers, c.PRGates)
+	}
+	if c.AvailableSlots != 0 {
+		t.Errorf("AvailableSlots = %d, want 0 (pr_open fills max_parallel)", c.AvailableSlots)
+	}
+	if c.CapacityUsed != 4 {
+		t.Errorf("CapacityUsed = %d, want 4", c.CapacityUsed)
+	}
+	if c.BlockedByGates != 2 {
+		t.Errorf("BlockedByGates = %d, want 2 (both gates withhold a live slot)", c.BlockedByGates)
+	}
+	if c.Separated {
+		t.Errorf("Separated = true, want false in legacy mode")
+	}
+}
+
+// The recurring misleading state: every slot is a PR gate, so a naive
+// "workers_running" reads 0 while the queue is not idle.
+func TestCapacity_LegacyGateBoundWhenAllPROpen(t *testing.T) {
+	s := stateWith(StatusPROpen, StatusPROpen, StatusPROpen, StatusPROpen)
+	c := s.Capacity(CapacityInput{MaxParallel: 4})
+
+	if c.AvailableSlots != 0 {
+		t.Errorf("AvailableSlots = %d, want 0", c.AvailableSlots)
+	}
+	if c.BlockedByGates != 4 {
+		t.Errorf("BlockedByGates = %d, want 4", c.BlockedByGates)
+	}
+	if !c.GateBound() {
+		t.Errorf("GateBound() = false, want true (0 live workers, gates hold all capacity)")
+	}
+}
+
+// The core fix: with max_live_workers>0, pr_open sessions no longer consume
+// live-worker capacity, so eligible work keeps dispatching.
+func TestCapacity_SeparatedIgnoresPROpen(t *testing.T) {
+	s := stateWith(StatusRunning, StatusPROpen, StatusPROpen, StatusPROpen, StatusPROpen)
+	c := s.Capacity(CapacityInput{MaxParallel: 4, MaxLiveWorkers: 3})
+
+	if !c.Separated {
+		t.Fatalf("Separated = false, want true")
+	}
+	if c.PRGates != 4 {
+		t.Fatalf("PRGates = %d, want 4", c.PRGates)
+	}
+	if c.AvailableSlots != 2 {
+		t.Errorf("AvailableSlots = %d, want 2 (3 live limit - 1 running, gates ignored)", c.AvailableSlots)
+	}
+	if c.CapacityUsed != 1 {
+		t.Errorf("CapacityUsed = %d, want 1 (live workers only)", c.CapacityUsed)
+	}
+	if c.BlockedByGates != 0 {
+		t.Errorf("BlockedByGates = %d, want 0 (gates separated out)", c.BlockedByGates)
+	}
+	if c.GateBound() {
+		t.Errorf("GateBound() = true, want false (slots available)")
+	}
+}
+
+func TestCapacity_SeparatedRespectsLiveLimit(t *testing.T) {
+	s := stateWith(StatusRunning, StatusRunning, StatusRunning, StatusPROpen)
+	c := s.Capacity(CapacityInput{MaxParallel: 10, MaxLiveWorkers: 3})
+	if c.AvailableSlots != 0 {
+		t.Errorf("AvailableSlots = %d, want 0 (at live limit)", c.AvailableSlots)
+	}
+}
+
+// The per-state "running" limit still caps live-worker spawning under
+// separated accounting — new workers always enter StatusRunning.
+func TestCapacity_SeparatedStillHonorsRunningPerStateLimit(t *testing.T) {
+	s := stateWith(StatusRunning, StatusPROpen)
+	c := s.Capacity(CapacityInput{
+		MaxParallel:          10,
+		MaxLiveWorkers:       5,
+		MaxConcurrentByState: map[string]int{"running": 2},
+	})
+	if c.AvailableSlots != 1 {
+		t.Errorf("AvailableSlots = %d, want 1 (running per-state limit 2 - 1 live)", c.AvailableSlots)
+	}
+}
+
+func TestCapacity_NilStateSafe(t *testing.T) {
+	var s *State
+	c := s.Capacity(CapacityInput{MaxParallel: 3})
+	if c.AvailableSlots != 3 {
+		t.Errorf("AvailableSlots = %d, want 3 on nil state", c.AvailableSlots)
+	}
+}
+
+func TestClassifyActivity(t *testing.T) {
+	tests := []struct {
+		name string
+		in   ActivityInput
+		want ProjectActivity
+	}{
+		{
+			name: "live workers implementing",
+			in:   ActivityInput{Capacity: Capacity{LiveWorkers: 2, PRGates: 1}, EligibleIssues: 3},
+			want: ActivityImplementing,
+		},
+		{
+			name: "paused wins over idle",
+			in:   ActivityInput{Capacity: Capacity{AvailableSlots: 2}, EligibleIssues: 3, Paused: true},
+			want: ActivityPaused,
+		},
+		{
+			name: "model limits block dispatch",
+			in:   ActivityInput{Capacity: Capacity{AvailableSlots: 2}, EligibleIssues: 3, BackendsBlocked: true},
+			want: ActivityBlockedByModelLimits,
+		},
+		{
+			name: "pending approvals block dispatch",
+			in:   ActivityInput{Capacity: Capacity{AvailableSlots: 2}, EligibleIssues: 3, PendingApprovals: 1},
+			want: ActivityBlockedByApprovals,
+		},
+		{
+			name: "gate-bound with eligible work is the intervention loop",
+			in:   ActivityInput{Capacity: Capacity{PRGates: 3, AvailableSlots: 0}, EligibleIssues: 5},
+			want: ActivityBlockedByGates,
+		},
+		{
+			name: "gate-bound with no eligible work is just waiting",
+			in:   ActivityInput{Capacity: Capacity{PRGates: 3, AvailableSlots: 0}, EligibleIssues: 0},
+			want: ActivityWaitingOnGates,
+		},
+		{
+			name: "empty queue",
+			in:   ActivityInput{Capacity: Capacity{AvailableSlots: 4}, EligibleIssues: 0},
+			want: ActivityQueueEmpty,
+		},
+		{
+			name: "idle with free capacity and eligible work",
+			in:   ActivityInput{Capacity: Capacity{AvailableSlots: 4}, EligibleIssues: 2},
+			want: ActivityIdle,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := ClassifyActivity(tc.in)
+			if got != tc.want {
+				t.Errorf("ClassifyActivity() = %q, want %q", got, tc.want)
+			}
+			if reason == "" {
+				t.Errorf("ClassifyActivity() reason is empty for %q", tc.want)
+			}
+		})
+	}
+}
+
+// #814 requirement 3/6: a pr_open PR-gate session must not produce stale-PID
+// attention — the worker process is intentionally gone after the PR opens.
+func TestPROpenSessionProducesNoStalePIDAttention(t *testing.T) {
+	// PID cleared at the running→pr_open transition; PR number recorded.
+	sess := &Session{Status: StatusPROpen, PRNumber: 42, PID: 0}
+
+	// Even if a caller passes a dead-liveness hint, pr_open never flags on PID.
+	dead := false
+	att := SessionAttentionFor(sess, &dead)
+	if att.NeedsAttention {
+		t.Errorf("pr_open session NeedsAttention = true, want false (reason: %q)", att.Reason)
+	}
+
+	// And stale reconciliation never reclassifies a pr_open session, even long
+	// idle with a missing worktree.
+	now := time.Now().UTC()
+	sess.StartedAt = now.Add(-72 * time.Hour)
+	sess.Worktree = "/tmp/does-not-exist-814"
+	policy := StaleSessionPolicy{
+		Enabled:                true,
+		IdleAfter:              time.Hour,
+		RequireWorktreeMissing: true,
+	}
+	if _, stale := SessionStale(sess, now, policy, func(string) bool { return false }); stale {
+		t.Errorf("SessionStale() = true for pr_open, want false")
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2984,6 +2984,164 @@ func (s *State) RunningSessionCount() int {
 	return len(s.RunningSessions())
 }
 
+// CapacityInput carries the concurrency knobs that govern how many live
+// implementation workers may be spawned. The caller populates it from config so
+// the state package stays free of a config import.
+//
+// #814: pr_open (PR-gate) sessions have no live worker process — their PID is
+// cleared when the PR is opened and Maestro only waits on CI / review / the
+// merge gate. Counting them against MaxParallel makes the pipeline look "full"
+// while it is merely gate-bound, so a long PRD-backed queue with a few open PRs
+// stops dispatching new implementation work and Mission Control shows 0 live
+// workers. When MaxLiveWorkers > 0, spawn capacity is computed from live
+// workers alone and pr_open sessions no longer consume a slot.
+type CapacityInput struct {
+	MaxParallel          int
+	MaxLiveWorkers       int
+	MaxConcurrentByState map[string]int
+}
+
+// Capacity is an operator-facing snapshot that separates live implementation
+// workers (StatusRunning) from PR-gate sessions (StatusPROpen) so Mission
+// Control can explain why a project is or is not spawning new work instead of
+// only reporting a single conflated "workers" number.
+type Capacity struct {
+	LiveWorkers    int  // StatusRunning — worker processes actively implementing
+	PRGates        int  // StatusPROpen — PR open, no live process, waiting on gates
+	Limit          int  // effective limit that governs live-worker spawning
+	CapacityUsed   int  // slots counted as in-use for spawn accounting
+	AvailableSlots int  // free slots available for new live workers
+	BlockedByGates int  // live-worker slots withheld purely because pr_open sessions count against capacity (0 once gates are separated out)
+	Separated      bool // true when MaxLiveWorkers>0, i.e. pr_open sessions do not consume live-worker capacity
+}
+
+// GateBound reports whether PR-gate sessions are the reason no live worker can
+// spawn: there are open PRs, no live worker is implementing, and no slot is
+// free. This is the misleading "0 workers but not idle" state from #814.
+func (c Capacity) GateBound() bool {
+	return c.LiveWorkers == 0 && c.PRGates > 0 && c.AvailableSlots == 0
+}
+
+// Capacity computes the live-worker spawn budget, separating live workers from
+// PR-gate sessions per the CapacityInput knobs. It is the single source of
+// truth for "how many new workers can start" shared by the orchestrator, the
+// supervisor, and Mission Control.
+func (s *State) Capacity(in CapacityInput) Capacity {
+	var counts map[SessionStatus]int
+	if s != nil {
+		counts = s.CountByStatus()
+	}
+	live := counts[StatusRunning]
+	gates := counts[StatusPROpen]
+
+	c := Capacity{LiveWorkers: live, PRGates: gates}
+
+	if in.MaxLiveWorkers > 0 {
+		// Separated accounting: pr_open sessions do not consume live-worker
+		// capacity. Spawning is governed by live workers alone.
+		c.Separated = true
+		c.Limit = in.MaxLiveWorkers
+		c.CapacityUsed = live
+		c.AvailableSlots = in.MaxLiveWorkers - live
+		c.BlockedByGates = 0
+	} else {
+		// Legacy accounting: running + pr_open both count against max_parallel.
+		c.Limit = in.MaxParallel
+		active := live + gates
+		c.CapacityUsed = active
+		c.AvailableSlots = in.MaxParallel - active
+		// How many additional live workers could run if gates were separated
+		// out of the budget — the slots pr_open sessions are withholding.
+		if headroom := in.MaxParallel - live; headroom > 0 && gates > 0 {
+			c.BlockedByGates = min(gates, headroom)
+		}
+	}
+	if c.AvailableSlots < 0 {
+		c.AvailableSlots = 0
+	}
+
+	// The per-state "running" limit caps live-worker spawning in either mode —
+	// new workers always enter StatusRunning. Non-"running" per-state limits
+	// (e.g. "pr_open") intentionally do not gate dispatch.
+	if limit, ok := in.MaxConcurrentByState["running"]; ok && limit > 0 {
+		runningSlots := limit - live
+		if runningSlots < 0 {
+			runningSlots = 0
+		}
+		if runningSlots < c.AvailableSlots {
+			c.AvailableSlots = runningSlots
+		}
+	}
+	return c
+}
+
+// ProjectActivity is a single operator-facing token that explains why a project
+// is or is not turning eligible issues into implementation work. It lets Mission
+// Control distinguish "idle because the queue is empty" from "idle because every
+// slot is a PR gate" at a glance (#814).
+type ProjectActivity string
+
+const (
+	ActivityImplementing         ProjectActivity = "implementing"            // at least one live worker is running
+	ActivityBlockedByGates       ProjectActivity = "blocked_by_pr_gates"     // no live worker; capacity is consumed by pr_open sessions while eligible work waits
+	ActivityWaitingOnGates       ProjectActivity = "waiting_on_pr_gates"     // no live worker, PRs open, and no eligible work left — just waiting for gates
+	ActivityBlockedByApprovals   ProjectActivity = "blocked_by_approvals"    // dispatch is held pending an operator approval decision
+	ActivityBlockedByModelLimits ProjectActivity = "blocked_by_model_limits" // every eligible backend is blocked by a model/usage limit
+	ActivityPaused               ProjectActivity = "paused"                  // operator paused the project
+	ActivityQueueEmpty           ProjectActivity = "queue_empty"             // no eligible ready issues remain
+	ActivityIdle                 ProjectActivity = "idle"                    // idle for none of the more specific reasons above
+)
+
+// ActivityInput carries the non-session signals ClassifyActivity needs beyond
+// the session-derived Capacity snapshot.
+type ActivityInput struct {
+	Capacity         Capacity
+	EligibleIssues   int  // ready issues that could be dispatched now
+	PendingApprovals int  // spawn/merge approvals awaiting an operator decision
+	BackendsBlocked  bool // every eligible backend is blocked by a model/usage limit
+	Paused           bool // operator paused the project
+}
+
+// ClassifyActivity returns the ProjectActivity token and a concise
+// operator-facing explanation for why a project is (not) implementing. The
+// ordering is deliberate: live work wins, then the specific block reasons, so an
+// operator always sees the most actionable cause rather than a generic "idle".
+func ClassifyActivity(in ActivityInput) (ProjectActivity, string) {
+	c := in.Capacity
+	if c.LiveWorkers > 0 {
+		return ActivityImplementing, fmt.Sprintf("Implementing: %d live worker(s) running%s.", c.LiveWorkers, prGateSuffix(c.PRGates))
+	}
+	if in.Paused {
+		return ActivityPaused, "Project is paused; dispatch is intentionally suspended."
+	}
+	if in.BackendsBlocked {
+		return ActivityBlockedByModelLimits, "Blocked by model limits: every eligible backend is rate/usage limited."
+	}
+	if in.PendingApprovals > 0 {
+		return ActivityBlockedByApprovals, fmt.Sprintf("Blocked by approvals: %d decision(s) awaiting an operator.", in.PendingApprovals)
+	}
+	// Gate-bound: no live worker and no free slot while PRs are open. Only a
+	// problem when eligible work is waiting — that is the recurring #814
+	// intervention loop. With eligible work drained it is simply "waiting".
+	if c.PRGates > 0 && c.AvailableSlots == 0 {
+		if in.EligibleIssues > 0 {
+			return ActivityBlockedByGates, fmt.Sprintf("Blocked by PR gates: %d PR gate(s) hold all capacity while %d ready issue(s) wait; raise max_live_workers or max_parallel to keep implementing.", c.PRGates, in.EligibleIssues)
+		}
+		return ActivityWaitingOnGates, fmt.Sprintf("Waiting on PR gates: %d PR(s) open, no eligible work left to dispatch.", c.PRGates)
+	}
+	if in.EligibleIssues <= 0 {
+		return ActivityQueueEmpty, "Queue empty: no eligible ready issues to dispatch."
+	}
+	return ActivityIdle, "Idle: eligible work exists and capacity is free; awaiting the next dispatch cycle."
+}
+
+func prGateSuffix(gates int) string {
+	if gates <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (%d PR gate(s) waiting on CI/review)", gates)
+}
+
 // SetSpawnDrain requests a graceful drain (#541): the run loop stops claiming
 // new issues and spawning new workers but lets in-flight workers finish. The
 // timestamp is stamped so concurrent state writers resolve drain on/off by

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -3027,20 +3027,16 @@ func sortedSessionNames(st *state.State) []string {
 	return names
 }
 
+// availableSlots delegates to state.Capacity so the supervisor and orchestrator
+// share one live-worker spawn budget. With max_live_workers>0, pr_open PR-gate
+// sessions no longer consume capacity, so the supervisor stops reporting
+// wait-for-capacity while a queue is merely gate-bound (#814).
 func availableSlots(cfg *config.Config, st *state.State) int {
-	maxParallel := cfg.MaxParallel
-	active := len(st.ActiveSessions())
-	slots := maxParallel - active
-	if limit, ok := cfg.MaxConcurrentByState["running"]; ok && limit > 0 {
-		runningSlots := limit - st.CountByStatus()[state.StatusRunning]
-		if runningSlots < slots {
-			slots = runningSlots
-		}
-	}
-	if slots < 0 {
-		return 0
-	}
-	return slots
+	return st.Capacity(state.CapacityInput{
+		MaxParallel:          cfg.MaxParallel,
+		MaxLiveWorkers:       cfg.MaxLiveWorkers,
+		MaxConcurrentByState: cfg.MaxConcurrentByState,
+	}).AvailableSlots
 }
 
 func countSessions(st *state.State, status state.SessionStatus) int {


### PR DESCRIPTION
Implements #814

## Problem
`pr_open` sessions have no live worker process (their PID is cleared when the PR opens), yet they consumed `max_parallel` capacity exactly like live workers. A long PRD-backed queue with a few open PRs stopped dispatching new implementation work, and Mission Control showed `0 workers` while the pipeline was only gate-bound — a recurring manual-intervention loop that raising `max_parallel` only worked around.

## Changes
- **`state.Capacity`** — one spawn-budget source of truth shared by the orchestrator, supervisor, and Mission Control. It separates live workers (`StatusRunning`) from PR-gate sessions (`StatusPROpen`) and reports `live_workers`, `pr_gates`, `capacity_used`, `capacity_blocked_by_gates`, `available_slots`.
- **`max_live_workers` config (new, default 0)** — when `>0`, `pr_open` sessions no longer consume live-worker capacity, so a project with N open PRs keeps spawning live implementation workers up to the configured limit. Default `0` preserves legacy accounting exactly (all existing capacity tests unchanged).
- **`state.ClassifyActivity`** — explains why a project is or is not implementing: `implementing` / `blocked_by_pr_gates` / `waiting_on_pr_gates` / `blocked_by_approvals` / `blocked_by_model_limits` / `paused` / `queue_empty` / `idle`.
- **Fleet/MC snapshot** — surfaces the capacity split plus `activity` + `activity_reason` per project and in the fleet summary, so MC never renders a gate-bound-but-busy project as idle.
- **Stale-PID attention** — added a regression test confirming `pr_open` slots never produce stale-PID attention (liveness is only checked for `StatusRunning`).

Existing sequential merge and Greptile gates are untouched.

## Testing
- `gofmt`, `go vet`, `go build ./cmd/maestro/`
- `go test ./...` (all pass), plus new tests in `internal/config`, `internal/state`, `internal/orchestrator`, `internal/server`
- `.maestro/verify.sh` — all requirement checks pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates live worker capacity from PR-gate sessions. The main changes are:

- Adds `max_live_workers` with legacy behavior preserved by default.
- Centralizes spawn capacity in `state.Capacity`.
- Updates orchestrator and supervisor slot checks to use the shared capacity model.
- Exposes live workers, PR gates, capacity usage, and activity in Fleet snapshots.
- Adjusts backend-limit activity detection to consider configured dispatchable backends.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the general contract after the first artifact set, confirming post-change values include max\_live\_workers and separated capacity while legacy accounting remains unchanged.
- Validated the HTTP contract after artifact, confirming head summary and GateBound/Separated reports show live\_workers, pr\_gates, and capacity\_blocked\_by\_gates.
- Observed stale PID contract behavior via before/after test runs, confirming exit code 0 and attention patterns for stale PID.
- Validated harness compilation and test output; initial compile errors were resolved and the after-state produced verbose subtest output with fleet snapshot evidence.

<a href="https://app.greptile.com/trex/runs/13267760/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds Fleet capacity fields, activity classification, and configured-backend handling for model-limit reporting. |
| internal/state/state.go | Adds the shared capacity model and project activity classifier. |
| internal/orchestrator/orchestrator.go | Moves orchestrator spawn-slot checks to the shared capacity calculation. |
| internal/supervisor/supervisor.go | Moves supervisor slot availability checks to the shared capacity calculation. |
| internal/config/config.go | Adds `max_live_workers` parsing and clamps negative values to the legacy default. |

<sub>Reviews (2): Last reviewed commit: ["fix(mc): treat untracked backends as ava..."](https://github.com/befeast/maestro/commit/692ed60ce90fc14c2aa08811dc2c9d901fa75653) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41803753)</sub>

<!-- /greptile_comment -->