### PR TITLE
fix: each flow gets its own stopAll deadline, bounded fleet-shutdown wait (#817)

### DIFF
--- a/cmd/maestro/night.go
+++ b/cmd/maestro/night.go
@@ -21,18 +21,18 @@ import (
 // claude credits on a known-broken state.
 
 type nightPreflight struct {
-	StartedAt        time.Time         `json:"started_at"`
-	ConfigPath       string            `json:"config_path"`
-	BackendsChecked  map[string]string `json:"backends_checked"` // backend -> "ok" | "missing" | "exhausted" | "skipped: ..."
-	StatePath        string            `json:"state_path"`
-	StateRead        bool              `json:"state_read"`
-	StuckSupervisor  bool              `json:"stuck_supervisor"`
-	StalePending     int               `json:"stale_pending_approvals"`
-	MaxRuntimeMin    int               `json:"max_runtime_minutes"`
-	MaxRetriesIssue  int               `json:"max_retries_per_issue"`
-	WorkerChain      []string          `json:"worker_chain"`
-	OK               bool              `json:"ok"`
-	Reason           string            `json:"reason,omitempty"`
+	StartedAt       time.Time         `json:"started_at"`
+	ConfigPath      string            `json:"config_path"`
+	BackendsChecked map[string]string `json:"backends_checked"` // backend -> "ok" | "missing" | "exhausted" | "skipped: ..."
+	StatePath       string            `json:"state_path"`
+	StateRead       bool              `json:"state_read"`
+	StuckSupervisor bool              `json:"stuck_supervisor"`
+	StalePending    int               `json:"stale_pending_approvals"`
+	MaxRuntimeMin   int               `json:"max_runtime_minutes"`
+	MaxRetriesIssue int               `json:"max_retries_per_issue"`
+	WorkerChain     []string          `json:"worker_chain"`
+	OK              bool              `json:"ok"`
+	Reason          string            `json:"reason,omitempty"`
 }
 
 // nightStartCmd is the entry point bound to "maestro night-start <args>".

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -416,7 +416,15 @@ func (d *Daemon) Run(ctx context.Context) error {
 	case <-ctx.Done():
 		drainWatch()
 		d.stopAll()
-		return <-fleetErr
+		// Don't block indefinitely on fleet server shutdown: the server's
+		// Shutdown goroutine has a 5s timeout, but bound the read so a
+		// pathological case never keeps the process alive (#817).
+		select {
+		case err := <-fleetErr:
+			return err
+		case <-time.After(shutdownFlowTimeout):
+			return nil
+		}
 	case err := <-fleetErr:
 		// Serve returned before shutdown — a runtime serve error after a
 		// successful bind (rare; the bind failure itself was already handled by

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -46,14 +46,23 @@ const (
 	// DefaultDrainTimeout bounds the graceful in-process drain the daemon runs on
 	// SIGTERM (#761, single-service cutover): it sets SpawnDrain on every flow so
 	// no new workers are claimed, then waits for in-flight workers to finish. It
-	// is deliberately UNDER the unit's TimeoutStopSec=30min so the drain finishes
-	// before systemd escalates to SIGKILL.
-	DefaultDrainTimeout = 25 * time.Minute
+	// is deliberately UNDER the unit's TimeoutStopSec so the drain finishes
+	// before systemd escalates to SIGKILL. The 5m default covers the vast
+	// majority of in-flight workers; a long-running worker that exceeds it is
+	// an external tmux process the daemon should not wait for (#817).
+	DefaultDrainTimeout = 5 * time.Minute
 )
 
 // drainPollInterval is how often Drain re-reads each flow's state to see whether
 // the in-flight worker count has reached zero. A var so tests can shorten it.
 var drainPollInterval = 5 * time.Second
+
+// shutdownFlowTimeout is the maximum time stopAll waits for a single flow's
+// goroutines (orchestrator, supervisor, watchdog) to exit after context
+// cancellation. If a flow hangs beyond this deadline stopAll logs a warning
+// and moves on, so the daemon never blocks indefinitely on shutdown (#817).
+// A var so tests can shorten it.
+var shutdownFlowTimeout = 10 * time.Second
 
 // ConfigLoader yields the set of project configs the daemon supervises. It is
 // satisfied by *configstore.Store; tests inject an in-memory fake so the

--- a/internal/daemon/daemon_drain_test.go
+++ b/internal/daemon/daemon_drain_test.go
@@ -94,3 +94,71 @@ func TestDrainWaitsForWorkersThenAbortsOnCancel(t *testing.T) {
 		t.Fatal("Drain did not abort after ctx cancellation")
 	}
 }
+
+// TestStopAllTimesOutOnHangingFlow verifies that stopAll does not block
+// indefinitely when a flow's goroutines ignore context cancellation. It should
+// return within shutdownFlowTimeout and log a warning, not hang (#817).
+func TestStopAllTimesOutOnHangingFlow(t *testing.T) {
+	old := shutdownFlowTimeout
+	shutdownFlowTimeout = 50 * time.Millisecond
+	defer func() { shutdownFlowTimeout = old }()
+
+	d := New(fakeLoader{cfgs: nil}, Options{})
+
+	// A flow whose done channel never closes — the loop never exits.
+	neverDone := make(chan struct{})
+	_, cancel := context.WithCancel(context.Background())
+	flow := &projectFlow{
+		name:   "hanger",
+		key:    "hanger",
+		cfg:    testConfig(t, "owner/hanger"),
+		cancel: cancel,
+		done:   neverDone,
+	}
+	// Cancel so flow.cancel() works without panic; the done channel stays open.
+	cancel()
+	d.flows[flow.key] = flow
+
+	// stopAll must return within ~shutdownFlowTimeout, not hang.
+	done := make(chan struct{})
+	go func() {
+		d.stopAll()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stopAll did not return within shutdownFlowTimeout for a hanging flow")
+	}
+}
+
+// TestDrainReturnsAfterDefaultTimeoutWithStuckWorkers verifies that Drain
+// respects the bounded default timeout (DefaultDrainTimeout) when in-flight
+// workers never finish (#817).
+func TestDrainReturnsAfterDefaultTimeoutWithStuckWorkers(t *testing.T) {
+	old := drainPollInterval
+	drainPollInterval = 5 * time.Millisecond
+	defer func() { drainPollInterval = old }()
+
+	cfg := testConfig(t, "owner/stuck")
+	d := New(fakeLoader{cfgs: nil}, Options{})
+	d.flows[flowKey(cfg)] = &projectFlow{name: "stuck", key: flowKey(cfg), cfg: cfg}
+
+	// Seed an in-flight worker that never finishes.
+	seed := &state.State{Sessions: map[string]*state.Session{
+		"stuck-1": {Status: state.StatusRunning},
+	}}
+	if err := state.Save(cfg.StateDir, seed); err != nil {
+		t.Fatalf("seed running state: %v", err)
+	}
+
+	start := time.Now()
+	// Use a very short timeout so the test completes quickly.
+	d.Drain(context.Background(), 100*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("Drain took %v with a 100ms timeout, should have returned near the deadline", elapsed)
+	}
+}

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -184,16 +184,17 @@ func (d *Daemon) stopAll() {
 	for _, flow := range flows {
 		flow.cancel()
 	}
-	// Bound the per-flow wait so a stuck orchestrator cycle never blocks
-	// shutdown indefinitely. Each flow gets shutdownFlowTimeout to exit after
-	// context cancellation; after that we log a warning and move on (#817).
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownFlowTimeout)
-	defer cancel()
+	// Give each flow its own independent deadline so a stuck cycle in one
+	// flow never consumes the timeout for a later one (review #660). Each
+	// flow gets shutdownFlowTimeout to exit after context cancellation;
+	// after that we log a warning and move on (#817).
 	for _, flow := range flows {
+		t := time.NewTimer(shutdownFlowTimeout)
 		select {
 		case <-flow.done:
+			t.Stop()
 			log.Printf("[daemon] stopped flow %q", flow.name)
-		case <-shutdownCtx.Done():
+		case <-t.C:
 			log.Printf("[daemon] stopAll: timed out waiting for flow %q — proceeding with shutdown", flow.name)
 		}
 	}

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -184,9 +184,18 @@ func (d *Daemon) stopAll() {
 	for _, flow := range flows {
 		flow.cancel()
 	}
+	// Bound the per-flow wait so a stuck orchestrator cycle never blocks
+	// shutdown indefinitely. Each flow gets shutdownFlowTimeout to exit after
+	// context cancellation; after that we log a warning and move on (#817).
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownFlowTimeout)
+	defer cancel()
 	for _, flow := range flows {
-		<-flow.done
-		log.Printf("[daemon] stopped flow %q", flow.name)
+		select {
+		case <-flow.done:
+			log.Printf("[daemon] stopped flow %q", flow.name)
+		case <-shutdownCtx.Done():
+			log.Printf("[daemon] stopAll: timed out waiting for flow %q — proceeding with shutdown", flow.name)
+		}
 	}
 }
 

--- a/maestro.service
+++ b/maestro.service
@@ -30,8 +30,9 @@ ExecStart=/usr/local/bin/maestro daemon \
 # Graceful in-process drain on SIGTERM: the daemon sets SpawnDrain on every flow
 # (no new workers) and waits for in-flight workers to finish — there is no
 # per-unit ExecStop=maestro drain anymore. Give it room before SIGKILL; the
-# daemon's own --drain-timeout (default 25m) finishes inside this window.
-TimeoutStopSec=30min
+# daemon's own --drain-timeout (default 5m) finishes well inside this window
+# (#817).
+TimeoutStopSec=6min
 Restart=on-failure
 RestartSec=30
 


### PR DESCRIPTION
Refs #817

- `stopAll`: each flow gets its own `shutdownFlowTimeout` timer instead of a shared `context.WithTimeout`, so a stuck cycle in one flow never consumes the deadline for later flows (review feedback #660).
- `Run()`: on ctx cancellation, bound the `fleetErr` channel read by `shutdownFlowTimeout` so a pathological server shutdown never keeps the process alive.
- Existing changes from previous iteration: `DefaultDrainTimeout` 25m→5m, `shutdownFlowTimeout`=10s, `TimeoutStopSec` 30min→6min.
- Tests: `TestStopAllTimesOutOnHangingFlow`, `TestDrainReturnsAfterDefaultTimeoutWithStuckWorkers` (pre-existing).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes daemon shutdown bounded and faster. The main changes are:

- Shorter default drain timeout for stuck worker sessions.
- Independent per-flow shutdown waits in `stopAll`.
- Bounded fleet server shutdown wait.
- Updated systemd stop timeout.
- Tests for hanging flow shutdown and stuck-worker drain.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the daemon shutdown before-state artifact to the after-state artifact to confirm that the stopAll operation was initially blocked by a long default and a timeout in flow.go.
- Validated the after-state artifact shows a stopAll timeout warning, a 100ms drain timeout, a 5-minute default, and a passing test run.
- Compared the contract validation before-state and after-state artifacts to confirm the TimeoutStopSec reduced from 30 minutes to 6 minutes and DefaultDrainTimeout reduced from 25 minutes to 5 minutes, with service\_timeout\_gt\_default\_drain remaining true and no contract mismatch demonstrated.

<a href="https://app.greptile.com/trex/runs/13296510/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/daemon/flow.go | Changes `stopAll` to cancel all flows, then wait for each flow with its own timeout. |
| internal/daemon/daemon.go | Reduces the default drain window and bounds the fleet server shutdown wait. |
| internal/daemon/daemon_drain_test.go | Adds coverage for hanging flow shutdown and stuck-worker drain deadlines. |
| maestro.service | Lowers `TimeoutStopSec` to match the shorter daemon drain window. |
| cmd/maestro/night.go | Reformats the `nightPreflight` fields without behavior changes. |

<sub>Reviews (2): Last reviewed commit: ["fix: each flow gets its own stopAll dead..."](https://github.com/befeast/maestro/commit/01992a56f24e47a9784ef623df870dd2e4e50c2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41861593)</sub>

<!-- /greptile_comment -->