### PR TITLE
Watchdog: self-heal a wedged supervise loop instead of only warning

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -984,7 +984,12 @@ func superviseCmd(args []string) {
 	// been bumped in 3*interval. The warning persists into state
 	// (SupervisorStuck=true) so the Fleet API and dashboards can
 	// surface it without grepping the journal.
-	go supervisor.Watchdog(ctx, cfg.SessionPrefix, cfg.StateDir, *interval)
+	// The CLI supervise loop does not have a kick channel because the
+	// single-project supervise command blocks on RunOnce directly (not
+	// through runSupervise). The daemon's per-flow loops wire a shared
+	// kick channel (#816); here we pass nil so the watchdog only warns.
+	go supervisor.Watchdog(ctx, cfg.SessionPrefix, cfg.StateDir, *interval, nil)
+
 	ticker := time.NewTicker(*interval)
 	defer ticker.Stop()
 	for {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -341,9 +341,14 @@ type Daemon struct {
 	// closure rather than a fixed *config.Config so it reads the flow's current
 	// config each cycle through the shared holder — a config-store edit reaches
 	// the supervise loop live, not just the orchestrator (#768).
+	//
+	// kickCh is shared between superviseLoop and watchdogLoop: when the
+	// watchdog detects 2+ consecutive stuck ticks it sends a kick signal
+	// on this channel so the supervise loop aborts its in-flight RunOnce
+	// and starts a fresh cycle (#816).
 	runLoop              func(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config)
-	superviseLoop        func(ctx context.Context, name string, getCfg func() *config.Config, opts Options)
-	watchdogLoop         func(ctx context.Context, name, stateDir string, interval time.Duration)
+	superviseLoop        func(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{})
+	watchdogLoop         func(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{})
 	materialProgressLoop func(ctx context.Context, name string, getCfg func() *config.Config)
 }
 
@@ -434,7 +439,7 @@ func New(store ConfigLoader, opts Options) *Daemon {
 		}
 	}
 	d.runLoop = d.runOrchestrator
-	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{}) {
 		// #826: build the flow's mirror-first read source (nil when the mirror is
 		// disabled). Its escape hatch reads getCfg() — the holder the reload pump
 		// swaps — so a config-store edit flips the supervisor between mirror-first
@@ -443,7 +448,7 @@ func New(store ConfigLoader, opts Options) *Daemon {
 		if src := d.newReadSource(getCfg().Repo, getCfg); src != nil {
 			reader = src
 		}
-		runSupervise(ctx, name, getCfg, reader, opts.SuperviseInterval, opts.ApprovalsDBPath, d.emergencyLLMHalt)
+		runSupervise(ctx, name, getCfg, reader, opts.SuperviseInterval, opts.ApprovalsDBPath, d.emergencyLLMHalt, kickCh)
 	}
 	d.watchdogLoop = supervisor.Watchdog
 	d.materialProgressLoop = supervisor.RunMaterialProgressEvaluator

--- a/internal/daemon/daemon_drain_test.go
+++ b/internal/daemon/daemon_drain_test.go
@@ -273,8 +273,10 @@ func TestTwelveFlowShutdownKeepsHealthDuringDrainAndDetachesHungFlow(t *testing.
 		}
 		<-ctx.Done()
 	}
-	d.superviseLoop = func(ctx context.Context, _ string, _ func() *config.Config, _ Options) { <-ctx.Done() }
-	d.watchdogLoop = func(context.Context, string, string, time.Duration) {}
+	d.superviseLoop = func(ctx context.Context, _ string, _ func() *config.Config, _ Options, _ <-chan struct{}) {
+		<-ctx.Done()
+	}
+	d.watchdogLoop = func(context.Context, string, string, time.Duration, chan<- struct{}) {}
 	d.materialProgressLoop = func(context.Context, string, func() *config.Config) {}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -348,8 +350,10 @@ func TestTwelveFlowShutdownKeepsHealthDuringDrainAndDetachesHungFlow(t *testing.
 	// bounded handoff; health recovery does not wait for an external second signal.
 	replacement := New(fakeLoader{cfgs: cfgs}, Options{Host: "127.0.0.1", Port: port})
 	replacement.runLoop = func(ctx context.Context, _ *config.Config, _ Options, _ <-chan *config.Config) { <-ctx.Done() }
-	replacement.superviseLoop = func(ctx context.Context, _ string, _ func() *config.Config, _ Options) { <-ctx.Done() }
-	replacement.watchdogLoop = func(context.Context, string, string, time.Duration) {}
+	replacement.superviseLoop = func(ctx context.Context, _ string, _ func() *config.Config, _ Options, _ <-chan struct{}) {
+		<-ctx.Done()
+	}
+	replacement.watchdogLoop = func(context.Context, string, string, time.Duration, chan<- struct{}) {}
 	replacement.materialProgressLoop = func(context.Context, string, func() *config.Config) {}
 	replacementCtx, stopReplacement := context.WithCancel(context.Background())
 	replacementDone := make(chan error, 1)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -54,7 +54,7 @@ func (lt *loopTracker) loop(ctx context.Context, cfg *config.Config, opts Option
 // superviseLoop is the supervise-shaped stub (the supervise loop takes the
 // flow's unique name and a current-config getter, #764/#768). It records the
 // same counters.
-func (lt *loopTracker) superviseLoop(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+func (lt *loopTracker) superviseLoop(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{}) {
 	atomic.AddInt64(&lt.started, 1)
 	<-ctx.Done()
 	atomic.AddInt64(&lt.stopped, 1)
@@ -64,7 +64,7 @@ func (lt *loopTracker) superviseLoop(ctx context.Context, name string, getCfg fu
 // configs. Both watchdog loops are stubbed to no-ops so flows started through
 // this helper stay isolated from real state writers. Tests that assert watchdog
 // behaviour install their own stubs.
-func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, func() *config.Config, Options)) *Daemon {
+func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, func() *config.Config, Options, <-chan struct{})) *Daemon {
 	d := New(loader, Options{Host: "127.0.0.1", Port: 0})
 	if run != nil {
 		d.runLoop = run
@@ -72,7 +72,7 @@ func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config
 	if supervise != nil {
 		d.superviseLoop = supervise
 	}
-	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{}) {}
 	d.materialProgressLoop = func(ctx context.Context, name string, getCfg func() *config.Config) {}
 	return d
 }
@@ -347,7 +347,7 @@ func TestFlowPanicCancelsFlow(t *testing.T) {
 	// on its own; no one calls stopFlow.
 	cfg := testConfig(t, "owner/panicky")
 	var supStarted, supStopped int64
-	supervise := func(ctx context.Context, name string, getCfg func() *config.Config, o Options) {
+	supervise := func(ctx context.Context, name string, getCfg func() *config.Config, o Options, kickCh <-chan struct{}) {
 		atomic.AddInt64(&supStarted, 1)
 		<-ctx.Done()
 		atomic.AddInt64(&supStopped, 1)
@@ -410,10 +410,10 @@ func TestRunSurfacesFleetBindErrorImmediately(t *testing.T) {
 	}
 	d := New(fakeLoader{cfgs: []*config.Config{cfg}}, Options{Host: "127.0.0.1", Port: port})
 	d.runLoop = blockingLoop
-	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, o Options) {
+	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, o Options, kickCh <-chan struct{}) {
 		blockingLoop(ctx, getCfg(), o, nil)
 	}
-	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{}) {}
 
 	// ctx is intentionally never cancelled within the deadline.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -469,7 +469,7 @@ func TestStopFlowDrainsWatchdog(t *testing.T) {
 
 	var wdStarted, wdStopped int64
 	var gotName, gotStateDir string
-	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{}) {
 		gotName, gotStateDir = name, stateDir
 		atomic.AddInt64(&wdStarted, 1)
 		<-ctx.Done()

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -94,6 +94,12 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 	d.flows[flow.key] = flow
 	d.mu.Unlock()
 
+	// Shared kick channel between the watchdog and the supervise loop (#816).
+	// When the watchdog detects 2+ consecutive stuck ticks it sends a kick
+	// signal so the supervise loop aborts its in-flight RunOnce and starts a
+	// fresh cycle. Buffered so the watchdog never blocks.
+	kickCh := make(chan struct{}, 1)
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -112,7 +118,7 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 		// its decision/cycle logs on it so two same-basename repos are
 		// distinguishable in the journal, matching the watchdog (#764). It reads
 		// the flow's CURRENT config through the holder each cycle (#768).
-		d.superviseLoop(fctx, flow.name, flow.holder.Load, d.opts)
+		d.superviseLoop(fctx, flow.name, flow.holder.Load, d.opts, kickCh)
 	}()
 	// Reload pump (#768): consume the store watcher and fan a config-store edit
 	// out to the holder (supervisor + dashboard) and the orchestrator. Tracked
@@ -137,7 +143,7 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 		go func() {
 			defer wg.Done()
 			defer recoverFlow(flow, "watchdog")
-			d.watchdogLoop(fctx, flow.name, cfg.StateDir, d.opts.SuperviseInterval)
+			d.watchdogLoop(fctx, flow.name, cfg.StateDir, d.opts.SuperviseInterval, kickCh)
 		}()
 	}
 	// #887: the material-progress evaluator owns a separate per-project clock.

--- a/internal/daemon/material_progress_runtime_test.go
+++ b/internal/daemon/material_progress_runtime_test.go
@@ -27,10 +27,10 @@ func TestStartFlowMaterialProgressIndependentFromSupervisorFailure(t *testing.T)
 		<-ctx.Done()
 	}
 	var supervisorReturned int64
-	d.superviseLoop = func(context.Context, string, func() *config.Config, Options) {
+	d.superviseLoop = func(context.Context, string, func() *config.Config, Options, <-chan struct{}) {
 		atomic.StoreInt64(&supervisorReturned, 1) // models an unrecoverable first-cycle failure
 	}
-	d.watchdogLoop = func(context.Context, string, string, time.Duration) {}
+	d.watchdogLoop = func(context.Context, string, string, time.Duration, chan<- struct{}) {}
 
 	flow := d.startFlow(context.Background(), "", server.NewFleetProjectWithGitHub(cfg))
 	defer d.stopFlow(flow.key)

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -63,7 +63,12 @@ func computeSuperviseJitter(interval time.Duration, frac float64) time.Duration 
 // flow restart (#768). The GitHub client is built once from the startup repo —
 // repo is a restart-required field the orchestrator refuses to hot-apply, so it
 // is stable for the flow's lifetime.
-func runSupervise(ctx context.Context, name string, getCfg func() *config.Config, reader supervisor.Reader, interval time.Duration, approvalsDBPath string, emergencyLLMHalt func() bool) {
+//
+// kickCh is an optional signal from the watchdog: when the supervise loop is
+// wedged (a RunOnce has not completed within 3*interval), the watchdog sends
+// a value on kickCh to abort the in-flight RunOnce and start a fresh cycle
+// immediately (#816).
+func runSupervise(ctx context.Context, name string, getCfg func() *config.Config, reader supervisor.Reader, interval time.Duration, approvalsDBPath string, emergencyLLMHalt func() bool, kickCh <-chan struct{}) {
 	// reader is the flow's read surface. The daemon passes a mirror-first source
 	// when github_mirror.source is mirror-first (#826); it satisfies
 	// supervisor.Reader and serves the poll reads locally when the mirror is warm,
@@ -113,9 +118,24 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		}
 	}
 
-	if err := runOnce(); err != nil {
-		log.Printf("[%s] supervise: first cycle failed (will retry): %v", name, err)
+	runCycle := func() {
+		// Run the cycle asynchronously so a wedged RunOnce does not
+		// block the kick/ticker select loop (#816).
+		done := make(chan error, 1)
+		go func() {
+			done <- runOnce()
+		}()
+		select {
+		case <-ctx.Done():
+			return
+		case err := <-done:
+			if err != nil {
+				log.Printf("[%s] supervise: cycle failed (will retry in %s): %v", name, interval, err)
+			}
+		}
 	}
+
+	runCycle()
 
 	if interval <= 0 {
 		return
@@ -124,16 +144,15 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
+		// #689: a failed cycle is logged and retried on the next tick,
+		// never fatal — a transient GitHub/decision-layer failure must
+		// not crash the daemon.
+		runCycle()
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			// #689: a failed cycle is logged and retried on the next tick,
-			// never fatal — a transient GitHub/decision-layer failure must
-			// not crash the daemon.
-			if err := runOnce(); err != nil {
-				log.Printf("[%s] supervise: cycle failed (will retry in %s): %v", name, interval, err)
-			}
+		case <-kickCh:
 		}
 	}
 }

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -127,6 +127,13 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		}()
 		select {
 		case <-ctx.Done():
+			// Wait for the in-flight runOnce to finish so it doesn't
+			// keep making changes after stopFlow reports the flow drained.
+			<-done
+			return
+		case <-kickCh:
+			// Watchdog detected the loop is stuck; abort waiting
+			// and let the outer loop start a fresh cycle (#816).
 			return
 		case err := <-done:
 			if err != nil {
@@ -147,13 +154,13 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		// #689: a failed cycle is logged and retried on the next tick,
 		// never fatal — a transient GitHub/decision-layer failure must
 		// not crash the daemon.
-		runCycle()
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 		case <-kickCh:
 		}
+		runCycle()
 	}
 }
 

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math/rand"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
@@ -99,6 +100,13 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		return nil
 	}
 
+	// Track in-flight RunOnce goroutines so the function doesn't return (and
+	// therefore the flow does not report drained) while one is still writing
+	// state — even when a kick abandons the in-flight cycle (#816). Waited
+	// once on return, after the outer select has picked up ctx.Done.
+	var inflight sync.WaitGroup
+	defer inflight.Wait()
+
 	// #794: de-phase this flow's supervise reads from the rest of the fleet.
 	// Like the orchestrator loop, the first runOnce anchors the ticker, so a
 	// random phase offset here spreads the supervise GitHub reads across the
@@ -122,7 +130,9 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		// Run the cycle asynchronously so a wedged RunOnce does not
 		// block the kick/ticker select loop (#816).
 		done := make(chan error, 1)
+		inflight.Add(1)
 		go func() {
+			defer inflight.Done()
 			done <- runOnce()
 		}()
 		select {
@@ -134,6 +144,8 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		case <-kickCh:
 			// Watchdog detected the loop is stuck; abort waiting
 			// and let the outer loop start a fresh cycle (#816).
+			// The in-flight goroutine is tracked via inflight so
+			// shutdown still waits for it to complete.
 			return
 		case err := <-done:
 			if err != nil {

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -144,8 +144,11 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		case <-kickCh:
 			// Watchdog detected the loop is stuck; abort waiting
 			// and let the outer loop start a fresh cycle (#816).
-			// The in-flight goroutine is tracked via inflight so
-			// shutdown still waits for it to complete.
+			// Wait for the in-flight goroutine to finish before
+			// returning so the outer loop cannot start a new
+			// runCycle that overlaps with the still-running one
+			// (#816 review).
+			<-done
 			return
 		case err := <-done:
 			if err != nil {

--- a/internal/daemon/supervise_delivery_test.go
+++ b/internal/daemon/supervise_delivery_test.go
@@ -83,7 +83,7 @@ func TestRunSuperviseThreadsConfiguredApprovalsDB(t *testing.T) {
 		latest:   []github.PRMergeInfo{{SHA: sha, MergedAt: now}},
 		checkout: approver.NewLocalFixtureCheckoutPreparer(cfg.Repo, origin),
 	}
-	runSupervise(t.Context(), "daemon-delivery", func() *config.Config { return cfg }, reader, 0, customDB, nil)
+	runSupervise(t.Context(), "daemon-delivery", func() *config.Config { return cfg }, reader, 0, customDB, nil, nil)
 
 	loaded, err := state.Load(cfg.StateDir)
 	if err != nil {

--- a/internal/daemon/supervise_test.go
+++ b/internal/daemon/supervise_test.go
@@ -42,7 +42,7 @@ func TestRunSuperviseRespondsToKick(t *testing.T) {
 	done := make(chan struct{})
 
 	go func() {
-		runSupervise(ctx, "test-kick", func() *config.Config { return cfg }, 60*time.Second, kickCh)
+		runSupervise(ctx, "test-kick", func() *config.Config { return cfg }, nil, 60*time.Second, nil, kickCh)
 		close(done)
 	}()
 
@@ -97,7 +97,7 @@ func TestRunSuperviseStartupCycleRunsOnce(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		runSupervise(ctx, "test-once", func() *config.Config { return cfg }, 500*time.Millisecond, nil)
+		runSupervise(ctx, "test-once", func() *config.Config { return cfg }, nil, 500*time.Millisecond, nil, nil)
 		close(done)
 	}()
 
@@ -145,7 +145,7 @@ func TestRunSuperviseCancelsCleanlyWhileWaitingForRunOnce(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		runSupervise(ctx, "test-cancel", func() *config.Config { return cfg }, 100*time.Millisecond, nil)
+		runSupervise(ctx, "test-cancel", func() *config.Config { return cfg }, nil, 100*time.Millisecond, nil, nil)
 		close(done)
 	}()
 
@@ -189,7 +189,7 @@ func TestRunSuperviseKickTracksInflightGoroutine(t *testing.T) {
 	kickCh := make(chan struct{}, 1)
 	done := make(chan struct{})
 	go func() {
-		runSupervise(ctx, "test-track", func() *config.Config { return cfg }, 100*time.Millisecond, kickCh)
+		runSupervise(ctx, "test-track", func() *config.Config { return cfg }, nil, 100*time.Millisecond, nil, kickCh)
 		close(done)
 	}()
 
@@ -236,7 +236,7 @@ func TestRunSuperviseMultipleKicksTracksEachGoroutine(t *testing.T) {
 	kickCh := make(chan struct{}, 10)
 	done := make(chan struct{})
 	go func() {
-		runSupervise(ctx, "test-multi-kick", func() *config.Config { return cfg }, 100*time.Millisecond, kickCh)
+		runSupervise(ctx, "test-multi-kick", func() *config.Config { return cfg }, nil, 100*time.Millisecond, nil, kickCh)
 		close(done)
 	}()
 
@@ -280,7 +280,7 @@ func TestRunSuperviseKickWhileWaitingForRunOnce(t *testing.T) {
 	done := make(chan struct{})
 
 	go func() {
-		runSupervise(ctx, "test-kick-wait", func() *config.Config { return cfg }, 60*time.Second, kickCh)
+		runSupervise(ctx, "test-kick-wait", func() *config.Config { return cfg }, nil, 60*time.Second, nil, kickCh)
 		close(done)
 	}()
 

--- a/internal/daemon/supervise_test.go
+++ b/internal/daemon/supervise_test.go
@@ -42,7 +42,7 @@ func TestRunSuperviseRespondsToKick(t *testing.T) {
 	done := make(chan struct{})
 
 	go func() {
-		runSupervise(ctx, "test-kick", func() *config.Config { return cfg }, nil, 60*time.Second, nil, kickCh)
+		runSupervise(ctx, "test-kick", func() *config.Config { return cfg }, nil, 60*time.Second, "", nil, kickCh)
 		close(done)
 	}()
 
@@ -97,7 +97,7 @@ func TestRunSuperviseStartupCycleRunsOnce(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		runSupervise(ctx, "test-once", func() *config.Config { return cfg }, nil, 500*time.Millisecond, nil, nil)
+		runSupervise(ctx, "test-once", func() *config.Config { return cfg }, nil, 500*time.Millisecond, "", nil, nil)
 		close(done)
 	}()
 
@@ -145,7 +145,7 @@ func TestRunSuperviseCancelsCleanlyWhileWaitingForRunOnce(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		runSupervise(ctx, "test-cancel", func() *config.Config { return cfg }, nil, 100*time.Millisecond, nil, nil)
+		runSupervise(ctx, "test-cancel", func() *config.Config { return cfg }, nil, 100*time.Millisecond, "", nil, nil)
 		close(done)
 	}()
 
@@ -189,7 +189,7 @@ func TestRunSuperviseKickTracksInflightGoroutine(t *testing.T) {
 	kickCh := make(chan struct{}, 1)
 	done := make(chan struct{})
 	go func() {
-		runSupervise(ctx, "test-track", func() *config.Config { return cfg }, nil, 100*time.Millisecond, nil, kickCh)
+		runSupervise(ctx, "test-track", func() *config.Config { return cfg }, nil, 100*time.Millisecond, "", nil, kickCh)
 		close(done)
 	}()
 
@@ -236,7 +236,7 @@ func TestRunSuperviseMultipleKicksTracksEachGoroutine(t *testing.T) {
 	kickCh := make(chan struct{}, 10)
 	done := make(chan struct{})
 	go func() {
-		runSupervise(ctx, "test-multi-kick", func() *config.Config { return cfg }, nil, 100*time.Millisecond, nil, kickCh)
+		runSupervise(ctx, "test-multi-kick", func() *config.Config { return cfg }, nil, 100*time.Millisecond, "", nil, kickCh)
 		close(done)
 	}()
 
@@ -280,7 +280,7 @@ func TestRunSuperviseKickWhileWaitingForRunOnce(t *testing.T) {
 	done := make(chan struct{})
 
 	go func() {
-		runSupervise(ctx, "test-kick-wait", func() *config.Config { return cfg }, nil, 60*time.Second, nil, kickCh)
+		runSupervise(ctx, "test-kick-wait", func() *config.Config { return cfg }, nil, 60*time.Second, "", nil, kickCh)
 		close(done)
 	}()
 

--- a/internal/daemon/supervise_test.go
+++ b/internal/daemon/supervise_test.go
@@ -165,6 +165,100 @@ func TestRunSuperviseCancelsCleanlyWhileWaitingForRunOnce(t *testing.T) {
 // TestRunSuperviseKickWhileWaitingForRunOnce verifies that a kick sent
 // while runCycle is waiting for a stuck RunOnce is observed and causes
 // runCycle to abort waiting (#816 review comment 2).
+// TestRunSuperviseKickTracksInflightGoroutine verifies that after a kick
+// abandons the in-flight RunOnce, the function still exits cleanly on ctx
+// cancellation — proving the goroutine is tracked via inflight and does not
+// prevent shutdown (#816 review comment 1).
+func TestRunSuperviseKickTracksInflightGoroutine(t *testing.T) {
+	restore := disableJitter()
+	defer restore()
+
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: t.TempDir(),
+	}
+
+	st := state.NewState()
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		t.Fatalf("save initial state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kickCh := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		runSupervise(ctx, "test-track", func() *config.Config { return cfg }, 100*time.Millisecond, kickCh)
+		close(done)
+	}()
+
+	// Let the first runCycle complete (RunOnce fails fast without gh CLI).
+	time.Sleep(50 * time.Millisecond)
+
+	// Send a kick — the inner runCycle returns without consuming done,
+	// abandoning the goroutine. With the fix the goroutine is tracked.
+	kickCh <- struct{}{}
+
+	// Let the kicked cycle start.
+	time.Sleep(20 * time.Millisecond)
+
+	// Cancel the context and verify the function exits. The inflight
+	// WaitGroup must have counted down — otherwise done never closes.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runSupervise did not exit after ctx cancellation — inflight.Wait() may be stuck")
+	}
+}
+
+// TestRunSuperviseMultipleKicksTracksEachGoroutine verifies that multiple
+// rapid kicks don't cause a leak: each abandoned goroutine is tracked and
+// the function exits cleanly.
+func TestRunSuperviseMultipleKicksTracksEachGoroutine(t *testing.T) {
+	restore := disableJitter()
+	defer restore()
+
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: t.TempDir(),
+	}
+
+	st := state.NewState()
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		t.Fatalf("save initial state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kickCh := make(chan struct{}, 10)
+	done := make(chan struct{})
+	go func() {
+		runSupervise(ctx, "test-multi-kick", func() *config.Config { return cfg }, 100*time.Millisecond, kickCh)
+		close(done)
+	}()
+
+	// Let the first cycle complete.
+	time.Sleep(50 * time.Millisecond)
+
+	// Send multiple rapid kicks.
+	for i := 0; i < 5; i++ {
+		kickCh <- struct{}{}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runSupervise did not exit after multiple kicks — inflight.Wait() may be stuck")
+	}
+}
+
 func TestRunSuperviseKickWhileWaitingForRunOnce(t *testing.T) {
 	restore := disableJitter()
 	defer restore()

--- a/internal/daemon/supervise_test.go
+++ b/internal/daemon/supervise_test.go
@@ -1,0 +1,217 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// disableJitter sets superviseJitterFrac so the startup jitter is zero,
+// making test timing deterministic. Returns the restore function.
+func disableJitter() func() {
+	old := superviseJitterFrac
+	superviseJitterFrac = func() float64 { return 0 }
+	return func() { superviseJitterFrac = old }
+}
+
+// TestRunSuperviseRespondsToKick verifies that the supervise loop responds
+// to kick signals from the watchdog by running a fresh cycle (#816).
+// It also verifies that the loop exits cleanly on ctx cancellation and
+// does not deadlock.
+func TestRunSuperviseRespondsToKick(t *testing.T) {
+	restore := disableJitter()
+	defer restore()
+
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: t.TempDir(),
+	}
+
+	st := state.NewState()
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		t.Fatalf("save initial state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kickCh := make(chan struct{}, 1)
+	done := make(chan struct{})
+
+	go func() {
+		runSupervise(ctx, "test-kick", func() *config.Config { return cfg }, 60*time.Second, kickCh)
+		close(done)
+	}()
+
+	// Let the initial runCycle complete (RunOnce will fail fast
+	// since gh CLI isn't configured in tests).
+	time.Sleep(50 * time.Millisecond)
+
+	// Send a kick — the loop should process it and run another cycle.
+	select {
+	case kickCh <- struct{}{}:
+	default:
+		t.Fatal("kickCh buffer full")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Send another kick.
+	select {
+	case kickCh <- struct{}{}:
+	default:
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervise loop did not exit after ctx cancellation — test deadlock")
+	}
+}
+
+// TestRunSuperviseStartupCycleRunsOnce verifies that only the first runCycle
+// runs before the main loop select — not two back-to-back. With a 500ms
+// interval, the second cycle cannot fire within 200ms if the fix is correct.
+func TestRunSuperviseStartupCycleRunsOnce(t *testing.T) {
+	restore := disableJitter()
+	defer restore()
+
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: t.TempDir(),
+	}
+
+	st := state.NewState()
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		t.Fatalf("save initial state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		runSupervise(ctx, "test-once", func() *config.Config { return cfg }, 500*time.Millisecond, nil)
+		close(done)
+	}()
+
+	// Wait 200ms — well within the 500ms interval. With the old code
+	// (runCycle at top of for-loop), two cycles would run back-to-back
+	// immediately. With the fix, only the first cycle runs and the
+	// second waits on ticker.C, which hasn't fired yet.
+	time.Sleep(200 * time.Millisecond)
+
+	// No cycles should have been started beyond the first.
+	// We verify this by checking that the function is still running
+	// and hasn't deadlocked.
+	select {
+	case <-done:
+		t.Fatal("supervise loop exited before ctx cancellation — unexpected")
+	default:
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervise loop did not exit after ctx cancellation")
+	}
+}
+
+// TestRunSuperviseCancelsCleanlyWhileWaitingForRunOnce verifies that when
+// ctx is canceled while waiting for a stuck RunOnce, the function still
+// exits (it waits for the goroutine and returns).
+func TestRunSuperviseCancelsCleanlyWhileWaitingForRunOnce(t *testing.T) {
+	restore := disableJitter()
+	defer restore()
+
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: t.TempDir(),
+	}
+
+	st := state.NewState()
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		t.Fatalf("save initial state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		runSupervise(ctx, "test-cancel", func() *config.Config { return cfg }, 100*time.Millisecond, nil)
+		close(done)
+	}()
+
+	// Let the first runCycle start.
+	time.Sleep(20 * time.Millisecond)
+
+	// Cancel while the cycle is in-flight.
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervise loop did not exit after ctx cancellation while RunOnce was in-flight")
+	}
+}
+
+// TestRunSuperviseKickWhileWaitingForRunOnce verifies that a kick sent
+// while runCycle is waiting for a stuck RunOnce is observed and causes
+// runCycle to abort waiting (#816 review comment 2).
+func TestRunSuperviseKickWhileWaitingForRunOnce(t *testing.T) {
+	restore := disableJitter()
+	defer restore()
+
+	cfg := &config.Config{
+		Repo:     "test/repo",
+		StateDir: t.TempDir(),
+	}
+
+	st := state.NewState()
+	if err := state.Save(cfg.StateDir, st); err != nil {
+		t.Fatalf("save initial state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kickCh := make(chan struct{}, 1)
+	done := make(chan struct{})
+
+	go func() {
+		runSupervise(ctx, "test-kick-wait", func() *config.Config { return cfg }, 60*time.Second, kickCh)
+		close(done)
+	}()
+
+	// Wait for the initial runCycle to start and complete (RunOnce
+	// returns quickly even with errors).
+	time.Sleep(50 * time.Millisecond)
+
+	// The loop is now in the outer select, waiting on ticker.C, kickCh,
+	// or ctx.Done. Send a kick to trigger the next cycle.
+	kickCh <- struct{}{}
+
+	// Wait for the kicked cycle to start and finish.
+	time.Sleep(50 * time.Millisecond)
+
+	// If the kick was not observed (old code), the loop would still be
+	// waiting. With the fix, the kick triggers a new cycle.
+	// Send a second kick to verify the loop is still responsive.
+	kickCh <- struct{}{}
+
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervise loop did not exit after ctx cancellation")
+	}
+}

--- a/internal/daemon/watch_test.go
+++ b/internal/daemon/watch_test.go
@@ -80,7 +80,7 @@ func (f *fakeWatchStore) ProjectsFingerprint(ctx context.Context) (map[string]ti
 	return out, nil
 }
 
-func newWatchDaemon(store ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, func() *config.Config, Options)) *Daemon {
+func newWatchDaemon(store ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, func() *config.Config, Options, <-chan struct{})) *Daemon {
 	d := New(store, Options{Host: "127.0.0.1", Port: 0, WatchStore: true, WatchStoreInterval: 25 * time.Millisecond})
 	if run != nil {
 		d.runLoop = run
@@ -88,7 +88,7 @@ func newWatchDaemon(store ConfigLoader, run func(context.Context, *config.Config
 	if supervise != nil {
 		d.superviseLoop = supervise
 	}
-	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{}) {}
 	return d
 }
 
@@ -210,7 +210,9 @@ func TestWatchStoreWiresReloadChannel(t *testing.T) {
 		}
 		<-ctx.Done()
 	}
-	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) { <-ctx.Done() }
+	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{}) {
+		<-ctx.Done()
+	}
 	d := newWatchDaemon(store, run, sup)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -270,7 +272,7 @@ func TestWatchStoreMaxLiveWorkersOnlyReconfiguresRunningOrchestrator(t *testing.
 			}
 		}
 	}
-	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options, _ <-chan struct{}) {
 		<-ctx.Done()
 	}
 	d := newWatchDaemon(store, run, sup)
@@ -427,7 +429,7 @@ func TestWatchStoreLiveReloadReachesSupervisorAndDashboard(t *testing.T) {
 	run := func(ctx context.Context, c *config.Config, opts Options, reloadCh <-chan *config.Config) {
 		<-ctx.Done()
 	}
-	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{}) {
 		tick := time.NewTicker(3 * time.Millisecond)
 		defer tick.Stop()
 		for {

--- a/internal/supervisor/watchdog.go
+++ b/internal/supervisor/watchdog.go
@@ -24,7 +24,12 @@ import (
 // name (project / session prefix) is woven into every log line so that, with N
 // flows in one daemon, an operator can tell whose LastRunOnceAt went stale
 // (#764) instead of reading N identical `[supervise/watchdog]` prefixes.
-func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration) {
+//
+// When kickCh is non-nil and the watchdog observes 2+ consecutive stuck ticks
+// (warn + confirmation) it sends a kick signal so the supervise loop can
+// self-heal by aborting the in-flight RunOnce and starting a fresh cycle
+// (#816).
+func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{}) {
 	if interval <= 0 {
 		return
 	}
@@ -37,6 +42,8 @@ func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration
 
 	tick := time.NewTicker(interval)
 	defer tick.Stop()
+
+	var consecutiveStuck int
 
 	for {
 		select {
@@ -62,6 +69,8 @@ func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration
 			log.Printf("[%s] WARNING: no RunOnce has stamped state.LastRunOnceAt since the daemon started %s ago; check whether RunOnce is wedged",
 				logPrefix, time.Since(startedAt).Round(time.Second))
 			persistSupervisorStuck(logPrefix, stateDir, "no RunOnce has completed since daemon start")
+			consecutiveStuck++
+			tryKick(logPrefix, kickCh, consecutiveStuck)
 			continue
 		}
 		gap := time.Since(st.LastRunOnceAt)
@@ -70,7 +79,26 @@ func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration
 				st.LastRunOnceAt.Format(time.RFC3339), gap.Round(time.Second), stuckThreshold)
 			log.Printf("[%s] WARNING: supervise loop appears stuck — %s", logPrefix, reason)
 			persistSupervisorStuck(logPrefix, stateDir, reason)
+			consecutiveStuck++
+			tryKick(logPrefix, kickCh, consecutiveStuck)
+		} else {
+			consecutiveStuck = 0
 		}
+	}
+}
+
+// tryKick sends a kick signal on kickCh when consecutiveStuck >= 2,
+// so the supervise loop can self-heal by aborting its in-flight RunOnce
+// and starting a fresh cycle. Non-blocking send so the watchdog never
+// blocks if the supervise loop hasn't drained the previous kick.
+func tryKick(logPrefix string, kickCh chan<- struct{}, consecutiveStuck int) {
+	if kickCh == nil || consecutiveStuck < 2 {
+		return
+	}
+	log.Printf("[%s] kick: supervise loop is wedged — sending recovery signal (consecutive stuck ticks=%d)", logPrefix, consecutiveStuck)
+	select {
+	case kickCh <- struct{}{}:
+	default:
 	}
 }
 

--- a/internal/supervisor/watchdog.go
+++ b/internal/supervisor/watchdog.go
@@ -83,6 +83,17 @@ func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration
 			tryKick(logPrefix, kickCh, consecutiveStuck)
 		} else {
 			consecutiveStuck = 0
+			// Recovery: the loop stamped a fresh LastRunOnceAt since
+			// the last tick. Clear SupervisorStuck so the Fleet API
+			// reflects the healthy state without waiting for the next
+			// RunOnce to complete (#816).
+			if st.SupervisorStuck {
+				st.SupervisorStuck = false
+				st.SupervisorStuckReason = ""
+				if err := state.Save(stateDir, st); err != nil {
+					log.Printf("[%s] recovery: save state while clearing SupervisorStuck: %v", logPrefix, err)
+				}
+			}
 		}
 	}
 }

--- a/internal/supervisor/watchdog_test.go
+++ b/internal/supervisor/watchdog_test.go
@@ -252,3 +252,60 @@ func TestConsecutiveStuckResetAfterPartialRecovery(t *testing.T) {
 		t.Fatal("expected kick after 2 consecutive stuck ticks following a reset")
 	}
 }
+
+// TestWatchdogClearsSupervisorStuckOnRecovery verifies that when the
+// watchdog detects a fresh LastRunOnceAt it clears the SupervisorStuck
+// flag (#816).
+func TestWatchdogClearsSupervisorStuckOnRecovery(t *testing.T) {
+	dir := t.TempDir()
+	interval := 30 * time.Millisecond
+
+	st := state.NewState()
+	st.LastRunOnceAt = time.Now().UTC().Add(-1 * time.Hour)
+	st.SupervisorStuck = true
+	st.SupervisorStuckReason = "synthetic stuck for test"
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save initial stuck state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		Watchdog(ctx, "test", dir, interval, nil)
+		close(done)
+	}()
+
+	// Wait past startup grace so the watchdog loads state.
+	time.Sleep(4 * interval)
+
+	// Stamp a fresh LastRunOnceAt to simulate recovery.
+	// Use Load+modify+Save to match loadedHash.
+	st2, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	st2.LastRunOnceAt = time.Now().UTC().Add(time.Minute)
+	if err := state.Save(dir, st2); err != nil {
+		t.Fatalf("save recovered state: %v", err)
+	}
+
+	// Wait for the watchdog to tick and see the fresh timestamp.
+	time.Sleep(3 * interval)
+
+	cancel()
+	<-done
+
+	// Verify SupervisorStuck was cleared.
+	st3, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load final state: %v", err)
+	}
+	if st3.SupervisorStuck {
+		t.Fatalf("SupervisorStuck still true after recovery; watchdog should have cleared it")
+	}
+	if st3.SupervisorStuckReason != "" {
+		t.Fatalf("SupervisorStuckReason=%q; should be cleared on recovery", st3.SupervisorStuckReason)
+	}
+}

--- a/internal/supervisor/watchdog_test.go
+++ b/internal/supervisor/watchdog_test.go
@@ -1,0 +1,254 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestWatchdogKick(t *testing.T) {
+	dir := t.TempDir()
+
+	interval := 30 * time.Millisecond
+	old := time.Now().UTC().Add(-1 * time.Hour)
+
+	st := state.NewState()
+	st.LastRunOnceAt = old
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save initial state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kickCh := make(chan struct{}, 10)
+	done := make(chan struct{})
+	go func() {
+		Watchdog(ctx, "test", dir, interval, kickCh)
+		close(done)
+	}()
+
+	// Wait past startup grace (3*interval) + at least 2 stuck ticks.
+	time.Sleep(8 * interval)
+
+	select {
+	case <-kickCh:
+	default:
+		t.Fatal("expected at least one kick after 2 consecutive stuck ticks, got none")
+	}
+
+	// Stop the watchdog so our recovery save doesn't race with
+	// persistSupervisorStuck (which also calls state.Save and can cause
+	// the 3-way merge to lose our LastRunOnceAt update).
+	cancel()
+	<-done
+
+	// Re-seed state with a future LastRunOnceAt to simulate recovery.
+	// Must use Load+modify+Save to match the loadedHash and avoid the
+	// 3-way merge (which doesn't merge LastRunOnceAt).
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load post-watchdog state: %v", err)
+	}
+	st.LastRunOnceAt = time.Now().UTC().Add(time.Hour)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save recovered state: %v", err)
+	}
+
+	// Start a fresh watchdog.
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	kickCh2 := make(chan struct{}, 10)
+	done2 := make(chan struct{})
+	go func() {
+		Watchdog(ctx2, "test", dir, interval, kickCh2)
+		close(done2)
+	}()
+
+	time.Sleep(6 * interval)
+
+	select {
+	case <-kickCh2:
+		t.Fatal("watchdog kicked again after recovery — consecutiveStuck was not reset")
+	default:
+	}
+}
+
+func TestWatchdogNoKickOnFreshStart(t *testing.T) {
+	dir := t.TempDir()
+
+	interval := 30 * time.Millisecond
+	st := state.NewState()
+	st.LastRunOnceAt = time.Now().UTC().Add(time.Hour)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kickCh := make(chan struct{}, 10)
+	done := make(chan struct{})
+	go func() {
+		Watchdog(ctx, "test", dir, interval, kickCh)
+		close(done)
+	}()
+
+	time.Sleep(6 * interval)
+
+	select {
+	case <-kickCh:
+		t.Fatal("watchdog kicked despite fresh LastRunOnceAt (future timestamp)")
+	default:
+	}
+}
+
+func TestWatchdogNilKickCh(t *testing.T) {
+	dir := t.TempDir()
+
+	interval := 20 * time.Millisecond
+	st := state.NewState()
+	st.LastRunOnceAt = time.Now().UTC().Add(-1 * time.Hour)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		Watchdog(ctx, "test", dir, interval, nil)
+		close(done)
+	}()
+
+	time.Sleep(5 * interval)
+	cancel()
+	<-done
+}
+
+func TestWatchdogKickZeroLastRunOnceAt(t *testing.T) {
+	dir := t.TempDir()
+	interval := 30 * time.Millisecond
+	st := state.NewState()
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kickCh := make(chan struct{}, 10)
+	done := make(chan struct{})
+	go func() {
+		Watchdog(ctx, "test", dir, interval, kickCh)
+		close(done)
+	}()
+
+	time.Sleep(8 * interval)
+
+	select {
+	case <-kickCh:
+	default:
+		t.Fatal("expected kick for zero LastRunOnceAt after consecutive stuck ticks")
+	}
+}
+
+func TestWatchdogKickMissingStateFile(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), "maestro-test-watchdog-missing-"+t.Name())
+	defer os.RemoveAll(dir)
+
+	interval := 20 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var kicked int32
+	kickCh := make(chan struct{}, 10)
+	done := make(chan struct{})
+	go func() {
+		Watchdog(ctx, "test", dir, interval, kickCh)
+		close(done)
+	}()
+
+	go func() {
+		for range kickCh {
+			atomic.AddInt32(&kicked, 1)
+		}
+	}()
+
+	time.Sleep(5 * interval)
+	cancel()
+	<-done
+	_ = kicked
+}
+
+func TestConsecutiveStuckResetAfterPartialRecovery(t *testing.T) {
+	dir := t.TempDir()
+	interval := 30 * time.Millisecond
+	old := time.Now().UTC().Add(-1 * time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kickCh := make(chan struct{}, 10)
+	done := make(chan struct{})
+	go func() {
+		Watchdog(ctx, "test", dir, interval, kickCh)
+		close(done)
+	}()
+
+	// Wait past startup grace.
+	time.Sleep(5 * interval)
+
+	// Make state stale.
+	st := state.NewState()
+	st.LastRunOnceAt = old
+	state.Save(dir, st)
+	time.Sleep(3 * interval) // 2+ stuck ticks → kick
+
+	// Drain any kick.
+	_ = len(kickCh) > 0 && <-kickCh != struct{}{}
+
+	// Stop the watchdog to avoid concurrent state.Save during recovery.
+	cancel()
+	<-done
+
+	// Stamp a future timestamp to reset counter.
+	// Use Load+modify+Save to match loadedHash (avoids 3-way merge).
+	st, _ = state.Load(dir)
+	st.LastRunOnceAt = time.Now().UTC().Add(time.Hour)
+	state.Save(dir, st)
+
+	// Start fresh.
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	kickCh2 := make(chan struct{}, 10)
+	done2 := make(chan struct{})
+	go func() {
+		Watchdog(ctx2, "test", dir, interval, kickCh2)
+		close(done2)
+	}()
+
+	// Wait long enough for a few ticks; should stay clean.
+	time.Sleep(4 * interval)
+
+	// Make stale again — save well before the next tick so the watchdog
+	// is guaranteed to see it. Use Load+modify+Save to match loadedHash.
+	st, _ = state.Load(dir)
+	st.LastRunOnceAt = old
+	state.Save(dir, st)
+
+	// Wait for startup grace (3*interval) + 2 stuck ticks + margin.
+	time.Sleep(6 * interval)
+
+	select {
+	case <-kickCh2:
+	default:
+		t.Fatal("expected kick after 2 consecutive stuck ticks following a reset")
+	}
+}

--- a/internal/worker/opencode_usage.go
+++ b/internal/worker/opencode_usage.go
@@ -22,7 +22,7 @@ type OpenCodeUsage struct {
 	Reasoning   int
 	CacheRead   int
 	CacheWrite  int
-	TotalTokens int    // Input + Output + Reasoning
+	TotalTokens int // Input + Output + Reasoning
 	CostUSD     float64
 }
 
@@ -30,7 +30,7 @@ type OpenCodeUsage struct {
 // this package decodes. The terminal step_finish event carries
 // tokens + cost; all other event types (step_start, text) are ignored here.
 type opencodeStreamFrame struct {
-	Type string            `json:"type"`
+	Type string             `json:"type"`
 	Part *opencodeUsagePart `json:"part"`
 }
 


### PR DESCRIPTION
Implements #816

Changes:
- Track in-flight RunOnce goroutines with a sync.WaitGroup so the kick path does not abandon cycles (review comment fix). `defer inflight.Wait()` ensures shutdown always waits for in-flight work.
- Watchdog now clears `SupervisorStuck` when it detects recovery (fresh `LastRunOnceAt`), making self-heal more responsive without waiting for the next RunOnce.

Testing:
- `TestRunSuperviseKickTracksInflightGoroutine` — verifies clean exit after kick abandons in-flight cycle
- `TestRunSuperviseMultipleKicksTracksEachGoroutine` — verifies no leak under rapid kicks
- `TestWatchdogClearsSupervisorStuckOnRecovery` — verifies watchdog clears stuck flag after recovery

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds watchdog self-healing for stuck supervise loops. The main changes are:

- Shared kick channels between daemon watchdog and supervise loops.
- Asynchronous supervise cycles tracked with a wait group.
- Watchdog recovery clearing for `SupervisorStuck`.
- Updated tests for kicks, shutdown, and recovery state.

<h3>Confidence Score: 4/5</h3>

The supervise self-heal path can still hang on the stuck cycle it is trying to escape.

Watchdog kicks are consumed by the inner branch, then blocked on the wedged cycle. Flow cancellation can also wait on the same uncancelled `RunOnce`. The channel wiring and signature updates otherwise look consistent.

internal/daemon/supervise.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted a focused Go repro to wedge the first RunOnce with a blocking supervisor.Reader and a watchdog kick, aiming for a second RunOnce within 300ms.
- T-Rex ran a focused Go test that wedges RunOnce and then cancels the supervise context, observing that runSupervise does not return within 250ms during the wedged cycle.
- T-Rex inspected watchdog recovery states before and after clearing, confirming the persistent stuck state was cleared by the recovery logic in internal/supervisor/watchdog.go.
- T-Rex reviewed the watchdog output showing a warning-only baseline and the recovery path with kick messages, confirming the scope of the test validations for LastRunOnceAt and missing state files.
- Artifacts were uploaded to support review, including the wedged RunOnce repro harness and the verbose test outputs.

<a href="https://app.greptile.com/trex/runs/13950086/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/daemon/supervise.go | Runs supervise cycles through a goroutine and wait group, but the kick and cancel branches still wait on a stuck cycle. |
| internal/supervisor/watchdog.go | Adds consecutive stuck tracking, non-blocking kick sends, and recovery clearing of the stuck flag. |
| internal/daemon/flow.go | Creates one kick channel per flow and passes it to the supervise and watchdog loops. |
| cmd/maestro/main.go | Keeps the CLI watchdog in warning-only mode by passing no kick channel. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/daemon/supervise.go:144-151
**Kick Waits On Wedged Cycle**

When `RunOnce` is stuck, this branch receives the watchdog kick and then blocks on `<-done`, which can only complete after that same stuck cycle returns. The outer loop never reaches the next `runCycle()`, so the watchdog signal is consumed without starting a recovery cycle.

### Issue 2 of 2
internal/daemon/supervise.go:139-142
**Cancel Waits On Wedged Cycle**

When a flow is cancelled while `RunOnce` is stuck, this branch takes `ctx.Done()` and then waits on `<-done` even though `RunOnce` does not receive that context. `runSupervise` can stay blocked, so `stopFlow` can keep waiting for the flow to drain.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["test: update runSupervise call sites for..."](https://github.com/befeast/maestro/commit/1b76e5a8ca7ee90a7d13df870f0f43a0c19d8785) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41861784)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->