### PR TITLE
feat(worker): first-class opencode backend + fix CLIProxy auth classification

### DIFF
--- a/internal/config/backend_kind.go
+++ b/internal/config/backend_kind.go
@@ -13,12 +13,13 @@ import (
 // CLI-specific behaviour: permission-bypass flags and stdin prompt
 // delivery. #684.
 const (
-	BackendKindClaude  = "claude"
-	BackendKindCodex   = "codex"
-	BackendKindGemini  = "gemini"
-	BackendKindCline   = "cline"
-	BackendKindPi      = "pi"
-	BackendKindGeneric = "generic"
+	BackendKindClaude   = "claude"
+	BackendKindCodex    = "codex"
+	BackendKindGemini   = "gemini"
+	BackendKindCline    = "cline"
+	BackendKindPi       = "pi"
+	BackendKindOpencode = "opencode"
+	BackendKindGeneric  = "generic"
 )
 
 // providerBackendKinds maps the per-backend provider attribution field
@@ -35,6 +36,7 @@ var providerBackendKinds = map[string]string{
 	"cline":     BackendKindCline,
 	"pi":        BackendKindPi,
 	"ollama":    BackendKindPi,
+	"opencode":  BackendKindOpencode,
 }
 
 // ResolveBackendKind decides which CLI-specific exec path a backend uses.
@@ -51,7 +53,7 @@ var providerBackendKinds = map[string]string{
 // mutating tool call was denied by the CLI's permission layer (sup-175).
 func ResolveBackendKind(name, provider, cmd string) string {
 	switch name {
-	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindPi:
+	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindPi, BackendKindOpencode:
 		return name
 	}
 	if kind, ok := providerBackendKinds[strings.ToLower(strings.TrimSpace(provider))]; ok {
@@ -71,7 +73,7 @@ func backendKindFromCmd(cmd string) string {
 		return ""
 	}
 	switch base := filepath.Base(fields[0]); base {
-	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindPi:
+	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindPi, BackendKindOpencode:
 		return base
 	}
 	return ""

--- a/internal/orchestrator/backend_auth_failure_test.go
+++ b/internal/orchestrator/backend_auth_failure_test.go
@@ -2,6 +2,8 @@ package orchestrator
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -630,5 +632,42 @@ func TestStartNewWorkers_AllBackendsCoolingDown_NoSpawn(t *testing.T) {
 	}
 	if len(s.Sessions) != 0 {
 		t.Fatalf("sessions = %d, want 0 — dispatch must pause, not spawn doomed workers", len(s.Sessions))
+	}
+}
+
+// Codex with --profile proxy prints a "Model metadata for `fw-kimi-k2.7-code`
+// not found" warning followed by "Missing environment variable: `CLIPROXY_API_KEY`"
+// when the proxy key is absent. Without an auth-failure pattern for the missing
+// env var, the model-unavailable classifier would fire on the metadata warning
+// and gate codex with the wrong reason. The death must be classified as an auth
+// (credential/config) failure so the attempt falls back instead of being
+// mislabelled model-unavailable.
+func TestClassifyBackendFailure_CodexCLIProxyMissingEnvVar_IsAuthFailure(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "codex-cliproxy.log")
+	content := "OpenAI Codex v0.142.5\n" +
+		"model: fw-kimi-k2p7-code\n" +
+		"provider: cliproxy\n" +
+		"warning: Model metadata for `fw-kimi-k2p7-code` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.\n" +
+		"ERROR: Missing environment variable: `CLIPROXY_API_KEY`.\n"
+	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	o := &Orchestrator{cfg: claudeChainTestConfig()}
+	sess := &state.Session{
+		Backend:   "codex",
+		StartedAt: time.Now().UTC().Add(-90 * time.Second),
+		LogFile:   logFile,
+	}
+	hit, reason, pattern := o.classifyBackendFailure(sess, time.Now().UTC())
+	if !hit {
+		t.Fatal("classifyBackendFailure = false, want true")
+	}
+	if reason != state.BackendBlockAuthFailure {
+		t.Fatalf("reason = %q, want %q", reason, state.BackendBlockAuthFailure)
+	}
+	if pattern != "missing_api_key_env_var" {
+		t.Fatalf("pattern = %q, want missing_api_key_env_var", pattern)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -869,6 +869,9 @@ func (o *Orchestrator) updateTokensUsedFromOutput(slotName string, sess *state.S
 	if kind == config.BackendKindCodex && o.sessionUsageStream(sess) {
 		return o.updateCodexUsageFromJSONL(slotName, sess)
 	}
+	if kind == config.BackendKindOpencode && o.sessionUsageStream(sess) {
+		return o.updateOpenCodeUsageFromJSONL(slotName, sess)
+	}
 	tokens := worker.ParseTokensFromOutput(output)
 	if tokens <= sess.TokensUsedAttempt {
 		return false
@@ -1036,6 +1039,55 @@ func (o *Orchestrator) updateCodexUsageFromJSONL(slotName string, sess *state.Se
 	log.Printf("[orch] %s codex usage: input=%d output=%d cache_read=%d tokens=%d (total=%d)",
 		slotName, usage.Input, usage.Output, usage.CacheRead, usage.TotalTokens, sess.TokensUsedTotal)
 	return true
+}
+
+// updateOpenCodeUsageFromJSONL parses the opencode --format json side-channel
+// (slot.jsonl) and stamps tokens/cost onto the session. opencode emits one
+// terminal step_finish event per `opencode run` invocation; the stream-splitter
+// appends each attempt's frames to the same slot.jsonl, so
+// ParseOpenCodeUsage sums them to the cumulative run total. The monotonic
+// UsageTokensWatermark persists across respawns so a forced retry never
+// double-counts (mirrors the claude/codex/Pi paths). opencode carries no model
+// name in the event stream, so sess.Model is left as configured. Returns true
+// when anything changed; false (tokens stay 0) when the jsonl is absent — the
+// documented degradation when the stream-splitter was unavailable.
+func (o *Orchestrator) updateOpenCodeUsageFromJSONL(slotName string, sess *state.Session) bool {
+	jsonlPath := o.workerJSONLFile(slotName, sess)
+	if jsonlPath == "" {
+		return false
+	}
+	data, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		return false
+	}
+	usage, ok := worker.ParseOpenCodeUsage(string(data))
+	if !ok {
+		return false
+	}
+	changed := false
+	if usage.TotalTokens > sess.UsageTokensWatermark {
+		delta := usage.TotalTokens - sess.UsageTokensWatermark
+		sess.UsageTokensWatermark = usage.TotalTokens
+		sess.TokensUsedAttempt += delta
+		sess.TokensUsedTotal += delta
+		// Reasoning tokens are a separate thinking-tokens bucket in opencode
+		// (not a subset of output). Assign output+reasoning to TokensOutput
+		// since there is no dedicated reasoning field on the session.
+		sess.TokensInput = usage.Input
+		sess.TokensOutput = usage.Output + usage.Reasoning
+		sess.TokensCacheRead = usage.CacheRead
+		sess.TokensCacheWrite = usage.CacheWrite
+		changed = true
+	}
+	if usage.CostUSD > sess.CostUSDBackend {
+		sess.CostUSDBackend = usage.CostUSD
+		changed = true
+	}
+	if changed {
+		log.Printf("[orch] %s opencode usage: input=%d output=%d reasoning=%d cache_read=%d cache_write=%d tokens=%d cost=$%.4f (total=%d)",
+			slotName, usage.Input, usage.Output, usage.Reasoning, usage.CacheRead, usage.CacheWrite, usage.TotalTokens, usage.CostUSD, sess.TokensUsedTotal)
+	}
+	return changed
 }
 
 // sessionUsageStream reports whether the session's backend opted into

--- a/internal/worker/authfailure.go
+++ b/internal/worker/authfailure.go
@@ -45,6 +45,12 @@ var authFailurePatterns = []struct {
 	{"oauth_token_expired", regexp.MustCompile(`(?i)oauth token (?:has )?(?:expired|been revoked)`)},
 	{"login_required", regexp.MustCompile(`(?i)please run /login`)},
 	{"invalid_api_key", regexp.MustCompile(`(?i)(?:invalid|incorrect|expired|revoked)[ _-]?api[ _-]?key|api key (?:is )?(?:not valid|invalid|expired|revoked)`)},
+	// Codex's CLIProxy/fireworks profile dies with "Missing environment variable:
+	// `CLIPROXY_API_KEY`" when the proxy API key is not wired into the worker
+	// environment. This is a credential/config failure, not a model-unavailable
+	// death, so classify it as an auth failure and fall over to the next
+	// fallback backend instead of mis-gating codex as model-unavailable.
+	{"missing_api_key_env_var", regexp.MustCompile(`(?i)missing environment variable[:\s].*\b[a-z0-9_]*api[_-]?key[a-z0-9_]*\b`)},
 }
 
 // authFailureTailLines bounds post-mortem auth detection to the end of a

--- a/internal/worker/authfailure_test.go
+++ b/internal/worker/authfailure_test.go
@@ -58,6 +58,11 @@ func TestDetectAuthFailure_KnownSignatures(t *testing.T) {
 			output:    "API key not valid. Please pass a valid API key.",
 			wantLabel: "invalid_api_key",
 		},
+		{
+			name:      "codex cliproxy missing env var",
+			output:    "ERROR: Missing environment variable: `CLIPROXY_API_KEY`.",
+			wantLabel: "missing_api_key_env_var",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -75,11 +75,12 @@ type Backend interface {
 
 // knownBackends maps backend names to their implementations.
 var knownBackends = map[string]Backend{
-	"claude": claudeBackend{},
-	"cline":  clineBackend{},
-	"codex":  codexBackend{},
-	"gemini": geminiBackend{},
-	"pi":     piBackend{},
+	"claude":   claudeBackend{},
+	"cline":    clineBackend{},
+	"codex":    codexBackend{},
+	"gemini":   geminiBackend{},
+	"opencode": opencodeBackend{},
+	"pi":       piBackend{},
 }
 
 // --- Claude Backend ---
@@ -232,6 +233,46 @@ func (piBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec
 	return cmd, promptFile, nil
 }
 
+// --- OpenCode Backend ---
+
+// opencodeBackend runs the OpenCode coding agent headless in JSON event-stream
+// mode so Maestro can capture provider usage (model/tokens/cost) the way it
+// does for the first-class claude/codex backends.
+//
+// OpenCode is invoked as: opencode run --auto --format json
+// [--model <model>] [extra_args...]
+//
+// --auto auto-approves permissions that are not explicitly denied, rounding up to
+// the equivalent of claude --dangerously-skip-permissions. run reads the prompt
+// from stdin when no positional message is given; the runner script wires
+// promptFile to stdin, keeping large worker prompts under the Linux
+// MAX_ARG_STRLEN single-argument limit.
+//
+// --format json emits an NDJSON event stream (step_start / text / step_finish)
+// to the worker log. The stream-splitter forwards raw JSON frames to the
+// slot.jsonl side-channel and renders human-readable text to slot.log, and the
+// orchestrator's opencode usage parser aggregates model/tokens/cost from the
+// final step_finish event in the JSONL.
+type opencodeBackend struct{}
+
+func (opencodeBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
+	opencodeCmd := cfg.Cmd
+	if opencodeCmd == "" {
+		opencodeCmd = "opencode"
+	}
+	binary, cmdArgs := splitCmd(opencodeCmd)
+	args := append(cmdArgs, "run", "--auto", "--format", "json")
+	if m := strings.TrimSpace(cfg.Model); m != "" {
+		args = append(args, "--model", m)
+	}
+	args = appendTierModelEffort(args, pinnedArgs(cmdArgs, cfg), config.BackendKindOpencode, cfg)
+	args = append(args, cfg.ExtraArgs...)
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = worktree
+	// Stdin redirection is handled by the runner script — no file opened here.
+	return cmd, promptFile, nil
+}
+
 // --- Cline Backend ---
 
 type clineBackend struct{}
@@ -343,6 +384,10 @@ func appendTierModelEffort(args, pinned []string, kind string, cfg BackendConfig
 	case config.BackendKindClaude:
 		if !argsHaveFlag(pinned, "--effort") {
 			args = append(args, "--effort", effort)
+		}
+	case config.BackendKindOpencode:
+		if !argsHaveFlag(pinned, "--variant") {
+			args = append(args, "--variant", effort)
 		}
 	default:
 		// gemini and any other agentic backend routed here have no reasoning-effort
@@ -565,7 +610,7 @@ func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string
 		return nil
 	}
 	kind := resolveBackendKind(backendName, cfg)
-	if kind != config.BackendKindClaude && kind != config.BackendKindCodex {
+	if kind != config.BackendKindClaude && kind != config.BackendKindCodex && kind != config.BackendKindOpencode {
 		return nil
 	}
 	bin, ok := maestroExecutablePath()
@@ -692,6 +737,24 @@ func BuildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, workt
 			args = append(args, "--model", m)
 		}
 		args = append(args, "-p")
+		cmd := exec.Command(binary, args...)
+		cmd.Dir = worktree
+		return cmd, promptFile, nil
+	case "opencode":
+		opencodeCmd := cfg.Cmd
+		if opencodeCmd == "" {
+			opencodeCmd = "opencode"
+		}
+		binary, cmdArgs := splitCmd(opencodeCmd)
+		// Supervisor prompts are read-only decisions; no --auto bypass needed.
+		// run reads the prompt from stdin when no positional message is given,
+		// mirroring claude -p / codex - and keeping large supervisor prompts
+		// under the Linux MAX_ARG_STRLEN single-argument limit.
+		args := append(cmdArgs, "run", "--format", "json")
+		if m := strings.TrimSpace(cfg.Model); m != "" {
+			args = append(args, "--model", m)
+		}
+		args = append(args, cfg.ExtraArgs...)
 		cmd := exec.Command(binary, args...)
 		cmd.Dir = worktree
 		return cmd, promptFile, nil

--- a/internal/worker/opencode_usage.go
+++ b/internal/worker/opencode_usage.go
@@ -1,0 +1,95 @@
+package worker
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// OpenCodeUsage is the aggregated provider usage parsed from an opencode
+// --format json NDJSON stream. Each `opencode run` invocation emits one
+// terminal `step_finish` event carrying that invocation's cumulative token
+// usage and cost. The stream-splitter appends every attempt's frames to the
+// same slot.jsonl, so summing across step_finish events yields the cumulative
+// run total across attempts — monotonic as the log grows, which is what the
+// orchestrator's respawn-safe token watermark expects.
+//
+// opencode total = input + output + reasoning (reasoning is a separate
+// thinking-tokens bucket, not a subset of output). Cache read/write are also
+// separate counts. Cost is self-reported USD.
+type OpenCodeUsage struct {
+	Input       int
+	Output      int
+	Reasoning   int
+	CacheRead   int
+	CacheWrite  int
+	TotalTokens int    // Input + Output + Reasoning
+	CostUSD     float64
+}
+
+// opencodeStreamFrame is the subset of an opencode --format json event line
+// this package decodes. The terminal step_finish event carries
+// tokens + cost; all other event types (step_start, text) are ignored here.
+type opencodeStreamFrame struct {
+	Type string            `json:"type"`
+	Part *opencodeUsagePart `json:"part"`
+}
+
+type opencodeUsagePart struct {
+	Type   string              `json:"type"`
+	Tokens *opencodeUsageBlock `json:"tokens"`
+	Cost   float64             `json:"cost"`
+}
+
+// opencodeUsageBlock mirrors the usage object opencode emits on step_finish.
+// total = input + output + reasoning. cache.read / cache.write are separate
+// cumulative counts.
+type opencodeUsageBlock struct {
+	Total     int                `json:"total"`
+	Input     int                `json:"input"`
+	Output    int                `json:"output"`
+	Reasoning int                `json:"reasoning"`
+	Cache     *opencodeCacheInfo `json:"cache"`
+}
+
+type opencodeCacheInfo struct {
+	Write int `json:"write"`
+	Read  int `json:"read"`
+}
+
+// ParseOpenCodeUsage scans an opencode --format json NDJSON stream (the
+// appended slot.jsonl) and aggregates usage across every terminal step_finish
+// event. It returns ok=false when no usage-bearing event is found, so callers
+// can leave tokens at 0 (the documented degradation when the stream-splitter
+// was unavailable or no event has landed yet) and fall back to the legacy text
+// parser.
+func ParseOpenCodeUsage(text string) (OpenCodeUsage, bool) {
+	var out OpenCodeUsage
+	seen := false
+
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || line[0] != '{' {
+			continue
+		}
+		var fr opencodeStreamFrame
+		if err := json.Unmarshal([]byte(line), &fr); err != nil {
+			continue
+		}
+		if fr.Type != "step_finish" || fr.Part == nil || fr.Part.Tokens == nil {
+			continue
+		}
+		tk := fr.Part.Tokens
+		out.Input += tk.Input
+		out.Output += tk.Output
+		out.Reasoning += tk.Reasoning
+		out.CostUSD += fr.Part.Cost
+		if tk.Cache != nil {
+			out.CacheRead += tk.Cache.Read
+			out.CacheWrite += tk.Cache.Write
+		}
+		seen = true
+	}
+
+	out.TotalTokens = out.Input + out.Output + out.Reasoning
+	return out, seen
+}

--- a/internal/worker/stream_split.go
+++ b/internal/worker/stream_split.go
@@ -88,6 +88,8 @@ func renderStreamLine(backend, line string) string {
 		return renderClaudeStreamLine(line)
 	case "codex":
 		return renderCodexStreamLine(line)
+	case "opencode":
+		return renderOpenCodeStreamLine(line)
 	default:
 		return line
 	}
@@ -330,5 +332,66 @@ func renderCodexItem(item *codexRenderItem, completed bool) string {
 			}
 		}
 		return ""
+	}
+}
+
+// --- OpenCode stream renderer ---
+
+// opencodeRenderFrame is the subset of an opencode --format json event line the
+// renderer decodes. step_finish carries the usage block with tokens/cost.
+type opencodeRenderFrame struct {
+	Type      string               `json:"type"`
+	Timestamp int64                `json:"timestamp"`
+	Part      *opencodeRenderPart  `json:"part"`
+}
+
+type opencodeRenderPart struct {
+	Type   string              `json:"type"`
+	Text   string              `json:"text"`
+	Reason string              `json:"reason"`
+	Tokens *opencodeUsageBlock `json:"tokens"`
+	Cost   float64             `json:"cost"`
+}
+
+// renderOpenCodeStreamLine renders one opencode --format json event into
+// human-readable text for slot.log. A line that is not a JSON object, or
+// fails to decode, is returned verbatim so nothing is lost from the worker
+// log (and any plain stderr error text — rate-limit / auth-failure — still
+// reaches the text parsers). Unknown top-level event types are likewise
+// preserved verbatim so error signatures survive.
+func renderOpenCodeStreamLine(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || trimmed[0] != '{' {
+		return line
+	}
+	var fr opencodeRenderFrame
+	if err := json.Unmarshal([]byte(trimmed), &fr); err != nil {
+		return line
+	}
+	switch fr.Type {
+	case "step_start":
+		return ""
+	case "text":
+		if fr.Part != nil && fr.Part.Text != "" {
+			return fr.Part.Text
+		}
+		return ""
+	case "step_finish":
+		if fr.Part == nil || fr.Part.Tokens == nil {
+			return ""
+		}
+		var b strings.Builder
+		tk := fr.Part.Tokens
+		fmt.Fprintf(&b, "[opencode] usage: input=%d output=%d total=%d", tk.Input, tk.Output, tk.Total)
+		if tk.Reasoning > 0 {
+			fmt.Fprintf(&b, " reasoning=%d", tk.Reasoning)
+		}
+		if tk.Cache != nil && (tk.Cache.Read > 0 || tk.Cache.Write > 0) {
+			fmt.Fprintf(&b, " cache_read=%d cache_write=%d", tk.Cache.Read, tk.Cache.Write)
+		}
+		fmt.Fprintf(&b, " cost=$%.4f", fr.Part.Cost)
+		return b.String()
+	default:
+		return line
 	}
 }


### PR DESCRIPTION
Refs fallback/CLIProxy reliability work.

Changes:
- Add first-class `opencode` backend with stdin prompt delivery, `--auto` permission bypass, `--format json` structured stream, slot.jsonl usage capture, and supervisor support.
- Recognize `Missing environment variable: `CLIPROXY_API_KEY`` as a backend auth/config failure so codex CLIProxy deaths are classified correctly instead of mislabelled `model_unavailable`.

Testing:
- `go test ./...` passes.
- Added regression tests for the CLIProxy missing-env-var death signature in `internal/worker` and `internal/orchestrator`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opencode as a first-class worker backend and adjusts CLIProxy failure classification.

- Adds opencode backend-kind resolution and worker registration.
- Builds opencode worker and supervisor commands with JSON stream output.
- Adds opencode JSONL stream rendering and usage parsing.
- Updates orchestrator token and cost accounting for opencode streams.
- Classifies missing CLIProxy API key environment errors as auth/config failures.

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after tightening one diagnostic classifier.

Opencode command wiring follows the existing stdin and stream-split patterns, and usage accounting uses the same watermark shape as the other structured backends.

internal/worker/authfailure.go needs attention because the new auth regex can misread ordinary worker output as a backend credential failure during early-death classification.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the opencode contract test suite on the base branch with go test -v ./internal/config ./internal/worker ./internal/orchestrator -run 'TestTrexOpenCode'; it exited with code 1, signaling the expected unsupported/absent behavior.
- Re-ran the same test command on the head branch and it completed with exit code 0, with all focused opencode contract tests passing; orchestrator logs show tokens updated from 15 to 21 and cost increased from $0.1000 to $0.6000.

<a href="https://app.greptile.com/trex/runs/13313179/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/backend_kind.go | Adds opencode to backend kind constants, provider resolution, and command-name inference. |
| internal/worker/backend.go | Registers the opencode backend, builds worker and supervisor commands, maps tier effort to opencode flags, and enables stream splitting. |
| internal/worker/opencode_usage.go | Adds an opencode NDJSON usage parser that aggregates step-finish token and cost events. |
| internal/worker/stream_split.go | Adds opencode stream rendering while preserving raw JSONL frames for usage capture. |
| internal/orchestrator/orchestrator.go | Routes opencode usage-stream sessions through the new JSONL usage parser and existing watermark accounting. |
| internal/worker/authfailure.go | Adds a CLIProxy missing API-key environment-variable auth failure pattern, with a false-positive risk on ordinary worker output. |
| internal/worker/authfailure_test.go | Adds a worker-level regression case for the CLIProxy missing API-key environment error. |
| internal/orchestrator/backend_auth_failure_test.go | Adds an orchestrator-level regression for classifying CLIProxy missing-env-var logs as auth failures. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/worker/authfailure.go:51
**Worker Output Trips Auth Cooldown**

When a worker dies early after producing normal text like `Missing environment variable MY_SERVICE_API_KEY`, this unanchored pattern can match generated stdout instead of a backend error. Since auth classification runs first, the backend is put on auth cooldown and the attempt is treated as a credential failure even though the death may be unrelated.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): classify missing API-key en..."](https://github.com/befeast/maestro/commit/aa138f29559d279099f3b3e24b7372dc6000b162) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41894014)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->