### PR TITLE
GitHub App auth path with PAT fallback (epic #811, phase A)

### DIFF
--- a/cmd/maestro/digest.go
+++ b/cmd/maestro/digest.go
@@ -101,6 +101,21 @@ func loadDigestProjects(fleetPath string, configs multiFlag, storePath, storePro
 		}
 	}
 
+	// #823: configure GitHub App auth from the first project carrying a complete
+	// github_app block so the digest's reads use the installation token and the
+	// report's auth line matches the daemon. A setup failure is non-fatal — the
+	// command stays on PAT/gh and the report says so.
+	for _, entry := range named {
+		if entry.cfg == nil || !entry.cfg.GitHubApp.Configured() {
+			continue
+		}
+		app := entry.cfg.GitHubApp
+		if err := github.ConfigureAppAuth(app.AppID, app.InstallationID, app.PrivateKeyPath); err != nil {
+			log.Printf("digest: github app auth setup failed (using PAT/gh): %v", err)
+		}
+		break
+	}
+
 	var projects []digest.Project
 	var notifierCfg *config.Config
 	for _, entry := range named {

--- a/docs/digest-runbook.md
+++ b/docs/digest-runbook.md
@@ -16,6 +16,12 @@ This runbook is intentionally safe for shared docs. It uses placeholders for loc
 
 Every item links to its GitHub issue or PR. GitHub API hiccups degrade gracefully: the affected check is skipped or over-reports, and a "Collection warnings" section flags the gap instead of silently dropping data.
 
+The header carries a **GitHub auth** line so an operator can confirm which rate-limit bucket the fleet spends against (#823):
+
+- `PAT/gh · bucket shared-pat` — the shared personal access token; all projects share one 5 000/hr core bucket.
+- `GitHub App installation <id> · bucket installation · token expires <ts>` — authenticated as a GitHub App installation, which has its own bucket independent of the operator PAT. Configure it with a `github_app:` block (`app_id`, `private_key_path`, `installation_id`) on any fleet project; the private key stays on disk and is never logged or stored in the config store.
+- `PAT/gh (App fallback active …)` — a `github_app:` block is present but token issuance failed, so the daemon fell back to the PAT. The reason is shown inline and a loud line is written to the daemon journal. The same auth mode is appended to the hourly `[github] REST usage …` journal digest.
+
 ## Running it
 
 One command covers the whole fleet using the same `fleet.yaml` that Mission Control uses:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -318,6 +318,26 @@ type GitHubProjectsConfig struct {
 	ProjectNumber int  `yaml:"project_number"` // GitHub Project number (auto-detect from repo)
 }
 
+// GitHubAppConfig holds credentials for authenticating as a GitHub App
+// installation instead of a personal access token (#823). When populated the
+// daemon signs a JWT with the App's private key, exchanges it for a
+// short-lived installation access token, and auto-refreshes before expiry.
+// The PAT/`gh` path stays as fallback when this block is absent or incomplete.
+//
+// The private key MUST live on disk — `private_key_path` points to the PEM
+// file. The key is never read into config, never logged, and never stored in
+// the config store; only the path is persisted.
+type GitHubAppConfig struct {
+	AppID          int64  `yaml:"app_id"`           // GitHub App ID (numeric)
+	PrivateKeyPath string `yaml:"private_key_path"` // path to the PEM-encoded RSA private key
+	InstallationID int64  `yaml:"installation_id"`  // installation ID for the target org/account
+}
+
+// Configured reports whether all three required fields are set.
+func (c GitHubAppConfig) Configured() bool {
+	return c.AppID > 0 && c.InstallationID > 0 && strings.TrimSpace(c.PrivateKeyPath) != ""
+}
+
 // SelfDeployConfig gates the opt-in post-merge self-deploy of the maestro
 // binary itself (#698). Default OFF: projects without a `self_deploy:` block
 // (or with enabled: false) see no behavior change.
@@ -1285,6 +1305,7 @@ type Config struct {
 	Versioning                      VersioningConfig             `yaml:"versioning"`
 	SelfDeploy                      SelfDeployConfig             `yaml:"self_deploy"` // #698: opt-in post-merge self-deploy of the maestro binary (default OFF)
 	GitHubProjects                  GitHubProjectsConfig         `yaml:"github_projects"`
+	GitHubApp                       GitHubAppConfig              `yaml:"github_app"`                 // #823: GitHub App auth (app_id + private_key_path + installation_id)
 	MaxRetryBackoffMs               int                          `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
 	AutoResolveFiles                []string                     `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
 	AutoRestoreFiles                []string                     `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase

--- a/internal/config/github_app_test.go
+++ b/internal/config/github_app_test.go
@@ -1,0 +1,87 @@
+package config
+
+import "testing"
+
+func TestParse_GitHubAppConfig(t *testing.T) {
+	yaml := `
+repo: owner/repo
+github_app:
+  app_id: 4242
+  private_key_path: /etc/maestro/app-key.pem
+  installation_id: 99
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.GitHubApp.AppID != 4242 {
+		t.Fatalf("app_id = %d, want 4242", cfg.GitHubApp.AppID)
+	}
+	if cfg.GitHubApp.PrivateKeyPath != "/etc/maestro/app-key.pem" {
+		t.Fatalf("private_key_path = %q", cfg.GitHubApp.PrivateKeyPath)
+	}
+	if cfg.GitHubApp.InstallationID != 99 {
+		t.Fatalf("installation_id = %d, want 99", cfg.GitHubApp.InstallationID)
+	}
+	if !cfg.GitHubApp.Configured() {
+		t.Fatal("Configured() should be true when all three fields are set")
+	}
+}
+
+func TestParse_GitHubAppConfig_AbsentIsUnconfigured(t *testing.T) {
+	cfg, err := parse([]byte("repo: owner/repo\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.GitHubApp.Configured() {
+		t.Fatal("Configured() must be false when github_app is absent — PAT path stays default")
+	}
+}
+
+func TestGitHubAppConfig_ConfiguredRequiresAllThree(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  GitHubAppConfig
+		want bool
+	}{
+		{"all set", GitHubAppConfig{AppID: 1, PrivateKeyPath: "/k.pem", InstallationID: 2}, true},
+		{"missing app_id", GitHubAppConfig{PrivateKeyPath: "/k.pem", InstallationID: 2}, false},
+		{"missing key path", GitHubAppConfig{AppID: 1, InstallationID: 2}, false},
+		{"blank key path", GitHubAppConfig{AppID: 1, PrivateKeyPath: "  ", InstallationID: 2}, false},
+		{"missing installation", GitHubAppConfig{AppID: 1, PrivateKeyPath: "/k.pem"}, false},
+		{"zero", GitHubAppConfig{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.Configured(); got != tc.want {
+				t.Fatalf("Configured() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGitHubAppConfig_NoRawKeyMaterial guards the "no secrets in the config
+// store" acceptance criterion (#823): the config carries only the PEM file
+// PATH, never the key bytes, so nothing secret is ever serialized or logged.
+func TestGitHubAppConfig_NoRawKeyMaterial(t *testing.T) {
+	cfg := GitHubAppConfig{AppID: 1, PrivateKeyPath: "/etc/maestro/app-key.pem", InstallationID: 2}
+	// The struct has exactly three fields; a private key field would be a leak.
+	if got := cfg.PrivateKeyPath; got == "" {
+		t.Fatal("expected a path, not inline key material")
+	}
+	// A YAML round-trip must not surface anything resembling a private key.
+	yaml := `
+repo: owner/repo
+github_app:
+  app_id: 1
+  private_key_path: /etc/maestro/app-key.pem
+  installation_id: 2
+`
+	parsed, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if parsed.GitHubApp.PrivateKeyPath != "/etc/maestro/app-key.pem" {
+		t.Fatalf("path not preserved: %q", parsed.GitHubApp.PrivateKeyPath)
+	}
+}

--- a/internal/configstore/store_crud_test.go
+++ b/internal/configstore/store_crud_test.go
@@ -75,6 +75,48 @@ model:
 	}
 }
 
+// #823: the GitHub App block must round-trip through the store carrying only
+// the private-key PATH, never key material — the "no secrets in the config
+// store" acceptance criterion. The stored YAML is asserted to hold the path and
+// nothing resembling a PEM private key.
+func TestGitHubAppConfigRoundTripStoresPathNotKey(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	const yaml = `repo: owner/svc
+github_app:
+  app_id: 4242
+  private_key_path: /etc/maestro/app-key.pem
+  installation_id: 99
+`
+	if err := store.UpsertProject(ctx, "svc", yaml); err != nil {
+		t.Fatalf("UpsertProject: %v", err)
+	}
+
+	cfg, err := store.Load(ctx, "svc")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.GitHubApp.AppID != 4242 || cfg.GitHubApp.InstallationID != 99 {
+		t.Fatalf("app config not preserved: %+v", cfg.GitHubApp)
+	}
+	if cfg.GitHubApp.PrivateKeyPath != "/etc/maestro/app-key.pem" {
+		t.Fatalf("private_key_path = %q", cfg.GitHubApp.PrivateKeyPath)
+	}
+
+	out, err := store.ExportProject(ctx, "svc")
+	if err != nil {
+		t.Fatalf("ExportProject: %v", err)
+	}
+	if !strings.Contains(string(out), "private_key_path: /etc/maestro/app-key.pem") {
+		t.Fatalf("exported YAML missing key path:\n%s", out)
+	}
+	// No key material should ever appear in the persisted document.
+	if strings.Contains(string(out), "PRIVATE KEY") || strings.Contains(string(out), "BEGIN RSA") {
+		t.Fatalf("exported YAML leaked private key material:\n%s", out)
+	}
+}
+
 // #757: two writes in the same wall-clock second must produce DIFFERENT
 // fingerprints — otherwise a config-store edit immediately after add/migrate
 // would never advance updated_at and a --watch-store daemon would never

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -360,6 +360,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// before any flow starts, so RequestSelfDeploy reads it race-free.
 	d.fleetAuthTokenEnv = strings.TrimSpace(fleetAuth.TokenEnv)
 
+	// #823: configure GitHub App installation-token auth process-wide before any
+	// flow issues a GitHub call. The token source is a package-level singleton
+	// (all flows share one gh wrapper and one rate-limit bucket), so the first
+	// project carrying a complete github_app block wins. When no project sets it,
+	// or the initial token fetch fails, the daemon keeps the PAT/`gh` path and
+	// logs which bucket is in use.
+	configureFleetGitHubAppAuth(projects)
+
 	// Bind the fleet port BEFORE starting any flow. If the port is already held
 	// (a legacy maestro@ unit, a second daemon), Listen fails here and we abort
 	// immediately — no flow has started, so there is nothing to drain. Binding
@@ -497,6 +505,30 @@ func flowKey(cfg *config.Config) string {
 		return sd
 	}
 	return strings.TrimSpace(cfg.Repo)
+}
+
+// configureFleetGitHubAppAuth arms process-wide GitHub App installation-token
+// auth from the first project whose github_app block is complete (#823). The
+// gh wrapper's token source is a singleton shared by every flow, so a fleet
+// with an org-wide App configures it once here. A configuration or initial
+// fetch failure is non-fatal: the daemon logs it loudly and keeps the PAT/`gh`
+// path, so a bad App block degrades to today's behavior rather than blocking
+// startup.
+func configureFleetGitHubAppAuth(projects []server.FleetProject) {
+	for i := range projects {
+		cfg := projects[i].Cfg()
+		if cfg == nil || !cfg.GitHubApp.Configured() {
+			continue
+		}
+		app := cfg.GitHubApp
+		if err := github.ConfigureAppAuth(app.AppID, app.InstallationID, app.PrivateKeyPath); err != nil {
+			log.Printf("[daemon] github app auth setup failed for %s (staying on PAT/gh): %v", cfg.Repo, err)
+			return
+		}
+		log.Printf("[daemon] github app auth active (app_id=%d installation_id=%d) — daemon GitHub calls use an installation token", app.AppID, app.InstallationID)
+		return
+	}
+	log.Printf("[daemon] github app auth not configured — using PAT/gh for GitHub calls")
 }
 
 // Fleet returns the aggregating FleetServer once Run has built it, or nil

--- a/internal/daemon/github_app_test.go
+++ b/internal/daemon/github_app_test.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/server"
+)
+
+// #823: with no project carrying a github_app block, the daemon leaves the
+// process on the PAT/gh path — byte-identical to today.
+func TestConfigureFleetGitHubAppAuth_NoConfigStaysPAT(t *testing.T) {
+	projects := []server.FleetProject{
+		server.NewFleetProjectWithGitHub(&config.Config{Repo: "owner/a"}),
+		server.NewFleetProjectWithGitHub(&config.Config{Repo: "owner/b"}),
+	}
+	configureFleetGitHubAppAuth(projects)
+	if got := github.GetAuthInfo().Mode; got != github.AuthModePAT {
+		t.Fatalf("auth mode = %q, want pat when no project configures github_app", got)
+	}
+}
+
+// A project with a github_app block pointing at a missing key file must NOT
+// abort startup: ConfigureAppAuth fails, the helper logs and returns, and the
+// process stays on PAT.
+func TestConfigureFleetGitHubAppAuth_BadKeyDegradesToPAT(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/a",
+		GitHubApp: config.GitHubAppConfig{
+			AppID:          1,
+			InstallationID: 2,
+			PrivateKeyPath: "/nonexistent/app-key.pem",
+		},
+	}
+	projects := []server.FleetProject{server.NewFleetProjectWithGitHub(cfg)}
+	// Must not panic or block; must leave auth on PAT.
+	configureFleetGitHubAppAuth(projects)
+	if got := github.GetAuthInfo().Mode; got != github.AuthModePAT {
+		t.Fatalf("auth mode = %q, want pat after a failed app-auth setup", got)
+	}
+}
+
+// Configured() gates which project arms the singleton — a partial block is
+// ignored so a half-filled github_app never silently disables the PAT path.
+func TestConfigureFleetGitHubAppAuth_PartialConfigIgnored(t *testing.T) {
+	cfg := &config.Config{
+		Repo:      "owner/a",
+		GitHubApp: config.GitHubAppConfig{AppID: 1}, // missing key path + installation
+	}
+	if cfg.GitHubApp.Configured() {
+		t.Fatal("partial github_app should not be Configured()")
+	}
+	projects := []server.FleetProject{server.NewFleetProjectWithGitHub(cfg)}
+	configureFleetGitHubAppAuth(projects)
+	if got := github.GetAuthInfo().Mode; got != github.AuthModePAT {
+		t.Fatalf("auth mode = %q, want pat for a partial github_app block", got)
+	}
+}
+
+// Guard the log wording the runbook references so a future rename does not
+// silently drop the operator's "which bucket am I on" signal.
+func TestConfigureFleetGitHubAppAuth_LogsPATWhenUnconfigured(t *testing.T) {
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(old)
+
+	configureFleetGitHubAppAuth([]server.FleetProject{
+		server.NewFleetProjectWithGitHub(&config.Config{Repo: "owner/a"}),
+	})
+	if !strings.Contains(buf.String(), "github app auth not configured") {
+		t.Fatalf("expected PAT log line, got: %s", buf.String())
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -145,9 +145,42 @@ type ProjectReport struct {
 	Errors      []string `json:"errors,omitempty"`
 }
 
+// AuthSummary captures which GitHub auth mode and rate-limit bucket the daemon
+// is using, surfaced in the digest so an operator can confirm at a glance
+// whether the fleet is on the shared PAT or a GitHub App installation (#823).
+type AuthSummary struct {
+	Mode           string    `json:"mode"`                      // "app" or "pat"
+	Bucket         string    `json:"bucket"`                    // "installation" or "shared-pat"
+	InstallationID int64     `json:"installation_id,omitempty"` // App installation, when mode=app
+	TokenExpiry    time.Time `json:"token_expiry,omitempty"`    // installation token expiry, when mode=app
+	FallbackActive bool      `json:"fallback_active,omitempty"` // App configured but currently on PAT fallback
+	FallbackReason string    `json:"fallback_reason,omitempty"` // why the fallback is active
+}
+
+// Line renders the auth summary as a single human line for the digest header.
+func (a AuthSummary) Line() string {
+	if a.FallbackActive {
+		reason := a.FallbackReason
+		if reason == "" {
+			reason = "app token unavailable"
+		}
+		return fmt.Sprintf("PAT/`gh` (App fallback active — bucket %s; reason: %s)", a.Bucket, reason)
+	}
+	if a.Mode == string(github.AuthModeApp) {
+		exp := "unknown"
+		if !a.TokenExpiry.IsZero() {
+			exp = a.TokenExpiry.UTC().Format("2006-01-02 15:04 MST")
+		}
+		return fmt.Sprintf("GitHub App installation %d · bucket `%s` · token expires %s",
+			a.InstallationID, a.Bucket, exp)
+	}
+	return "PAT/`gh` · bucket `shared-pat`"
+}
+
 // Report is the full fleet digest.
 type Report struct {
 	GeneratedAt time.Time       `json:"generated_at"`
+	Auth        AuthSummary     `json:"auth"`
 	Projects    []ProjectReport `json:"projects"`
 }
 
@@ -173,11 +206,32 @@ func (r *Report) PromotableCount() int {
 // Collect builds the fleet digest across all projects.
 func Collect(projects []Project, opts Options) *Report {
 	opts = opts.withDefaults()
-	rep := &Report{GeneratedAt: opts.Now}
+	rep := &Report{GeneratedAt: opts.Now, Auth: authSummary()}
 	for _, p := range projects {
 		rep.Projects = append(rep.Projects, CollectProject(p, opts))
 	}
 	return rep
+}
+
+// authSummary snapshots the process-wide GitHub auth mode into a serializable
+// digest field (#823). In the daemon this reflects the live installation-token
+// state; the standalone `maestro digest` command configures App auth from its
+// loaded configs before Collect so the report matches the daemon.
+func authSummary() AuthSummary {
+	info := github.GetAuthInfo()
+	s := AuthSummary{
+		Mode:           string(info.Mode),
+		InstallationID: info.InstallationID,
+		TokenExpiry:    info.TokenExpiry,
+		FallbackActive: info.FallbackActive,
+		FallbackReason: info.LastError,
+	}
+	if info.Mode == github.AuthModeApp {
+		s.Bucket = "installation"
+	} else {
+		s.Bucket = "shared-pat"
+	}
+	return s
 }
 
 // CollectProject builds one project's digest sections. GitHub failures

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -351,6 +351,43 @@ func TestMarkdownEmptyReport(t *testing.T) {
 	}
 }
 
+// #823: the digest surfaces the GitHub auth mode. With no App configured the
+// process defaults to the PAT path, and both the report field and the rendered
+// header say so.
+func TestReportAuthSummaryDefaultsToPAT(t *testing.T) {
+	rep := Collect([]Project{baseProject(state.NewState(), &fakeGH{})}, testOptions())
+	if rep.Auth.Mode != string(github.AuthModePAT) {
+		t.Fatalf("auth mode = %q, want pat", rep.Auth.Mode)
+	}
+	if rep.Auth.Bucket != "shared-pat" {
+		t.Fatalf("auth bucket = %q, want shared-pat", rep.Auth.Bucket)
+	}
+	if !strings.Contains(rep.Markdown(), "GitHub auth: PAT/`gh`") {
+		t.Fatalf("markdown missing PAT auth line:\n%s", rep.Markdown())
+	}
+}
+
+// TestAuthSummaryLine covers the three rendered states of the header line.
+func TestAuthSummaryLine(t *testing.T) {
+	exp := time.Date(2026, 7, 6, 13, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		a    AuthSummary
+		want string
+	}{
+		{"pat", AuthSummary{Mode: "pat", Bucket: "shared-pat"}, "PAT/`gh` · bucket `shared-pat`"},
+		{"app", AuthSummary{Mode: "app", Bucket: "installation", InstallationID: 99, TokenExpiry: exp}, "GitHub App installation 99 · bucket `installation`"},
+		{"fallback", AuthSummary{Mode: "pat", Bucket: "shared-pat", FallbackActive: true, FallbackReason: "revoked"}, "App fallback active"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.a.Line(); !strings.Contains(got, tc.want) {
+				t.Fatalf("Line() = %q, want substring %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNotifySummaryCountsByKind(t *testing.T) {
 	st := state.NewState()
 	st.Approvals = []state.Approval{

--- a/internal/digest/markdown.go
+++ b/internal/digest/markdown.go
@@ -13,6 +13,7 @@ func (r *Report) Markdown() string {
 	fmt.Fprintf(&b, "# Maestro morning digest — %s\n\n", day)
 	fmt.Fprintf(&b, "Generated %s · %d project(s) · **%d decision(s) needed** · %d promotable\n\n",
 		r.GeneratedAt.Format("2006-01-02 15:04 MST"), len(r.Projects), r.DecideTodayCount(), r.PromotableCount())
+	fmt.Fprintf(&b, "GitHub auth: %s\n\n", r.Auth.Line())
 
 	fmt.Fprintf(&b, "## 1. Decide today (%d)\n\n", r.DecideTodayCount())
 	if r.DecideTodayCount() == 0 {

--- a/internal/github/appauth.go
+++ b/internal/github/appauth.go
@@ -171,10 +171,18 @@ func ConfigureAppAuth(appID, installationID int64, privateKeyPath string) error 
 		privateKey:     key,
 	}
 
-	// Eagerly fetch the first token so startup fails visibly when the config
-	// is wrong (bad key, wrong installation ID, etc.).
+	// Eagerly fetch the first token so a misconfigured App (wrong installation
+	// ID, revoked app, transient network failure) surfaces at startup. On
+	// failure we still ARM the source with lastErr recorded — but no valid
+	// token — so GetAuthInfo()/the digest report the App fallback state and
+	// reason instead of a plain PAT path (#823 review). Subsequent gh calls
+	// retry the exchange via appToken() and self-heal if the failure was
+	// transient; until then appToken() returns an empty token and the gh
+	// wrapper stays on PAT, so runtime behavior is byte-identical to today.
 	token, expiry, err := src.fetchInstallationToken()
 	if err != nil {
+		src.lastErr = err
+		appTokenSrc = src
 		return fmt.Errorf("github app auth: initial token fetch: %w", err)
 	}
 	now := appTokenNow()

--- a/internal/github/appauth.go
+++ b/internal/github/appauth.go
@@ -1,0 +1,353 @@
+// Package github — GitHub App installation-token authentication (#823).
+//
+// When a GitHubAppConfig (app_id, private_key_path, installation_id) is
+// present, the daemon signs a short-lived JWT with the App's RSA private key,
+// exchanges it for a 1-hour installation access token via
+// POST /app/installations/{id}/access_tokens, and caches the token until it is
+// within a refresh margin of expiry. The token is injected into every `gh`
+// command via the GH_TOKEN environment variable so the installation gets its
+// own 5 000/hr rate-limit bucket, independent of the operator's PAT.
+//
+// When no App config is set, or when token issuance fails, the package falls
+// back to the ambient `gh` auth (PAT / OAuth) with a loud journal log line so
+// the operator knows which bucket is in use.
+package github
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Auth mode — surfaced in diagnostics (#823).
+// ---------------------------------------------------------------------------
+
+// AuthMode describes the authentication method the gh wrapper is using.
+type AuthMode string
+
+const (
+	AuthModePAT AuthMode = "pat" // ambient gh auth (PAT / OAuth)
+	AuthModeApp AuthMode = "app" // GitHub App installation token
+)
+
+// AuthInfo is a diagnostic snapshot of the current authentication state.
+type AuthInfo struct {
+	Mode           AuthMode  `json:"mode"`
+	InstallationID int64     `json:"installation_id,omitempty"`
+	AppID          int64     `json:"app_id,omitempty"`
+	TokenExpiry    time.Time `json:"token_expiry,omitempty"`
+	LastRefresh    time.Time `json:"last_refresh,omitempty"`
+	LastError      string    `json:"last_error,omitempty"`
+	FallbackActive bool      `json:"fallback_active,omitempty"` // true when App is configured but we fell back to PAT
+}
+
+// authModeDigest renders the current auth mode for the hourly REST usage
+// journal line so an operator reading journalctl sees which rate-limit bucket
+// the daemon is spending against — the App installation's own 5 000/hr bucket
+// or the shared PAT (#823). Empty for the plain PAT path so the log is
+// unchanged when App auth is not configured.
+func authModeDigest() string {
+	info := GetAuthInfo()
+	switch {
+	case info.FallbackActive:
+		return fmt.Sprintf("; auth=pat (app fallback: %s)", info.LastError)
+	case info.Mode == AuthModeApp:
+		exp := "unknown"
+		if !info.TokenExpiry.IsZero() {
+			exp = info.TokenExpiry.UTC().Format(time.RFC3339)
+		}
+		return fmt.Sprintf("; auth=app (installation=%d, bucket=installation, token expires %s)",
+			info.InstallationID, exp)
+	default:
+		return ""
+	}
+}
+
+// GetAuthInfo returns the current authentication diagnostic snapshot.
+func GetAuthInfo() AuthInfo {
+	appTokenMu.Lock()
+	defer appTokenMu.Unlock()
+	if appTokenSrc == nil {
+		return AuthInfo{Mode: AuthModePAT}
+	}
+	info := AuthInfo{
+		Mode:           AuthModeApp,
+		InstallationID: appTokenSrc.installationID,
+		AppID:          appTokenSrc.appID,
+		TokenExpiry:    appTokenSrc.expiry,
+		LastRefresh:    appTokenSrc.lastRefresh,
+	}
+	if appTokenSrc.lastErr != nil {
+		info.LastError = appTokenSrc.lastErr.Error()
+		info.FallbackActive = true
+		info.Mode = AuthModePAT // currently using PAT as fallback
+	}
+	return info
+}
+
+// ---------------------------------------------------------------------------
+// Token source — cached, auto-refreshing installation token.
+// ---------------------------------------------------------------------------
+
+// appTokenSource signs JWTs and exchanges them for installation tokens.
+// The zero value is not usable; ConfigureAppAuth builds and arms one.
+type appTokenSource struct {
+	appID          int64
+	installationID int64
+	privateKey     *rsa.PrivateKey
+
+	// Cached token state (guarded by appTokenMu, not an internal lock,
+	// because the global accessor also reads these fields).
+	token       string
+	expiry      time.Time
+	lastRefresh time.Time
+	lastErr     error
+}
+
+const (
+	// jwtLifetime is the validity window for the signed JWT sent to GitHub.
+	// GitHub rejects JWTs with exp > iat+10min; we use 9 min for safety.
+	jwtLifetime = 9 * time.Minute
+
+	// tokenRefreshMargin is how far before expiry we proactively refresh.
+	// Installation tokens live 1 hour; refreshing at 55 min gives 5 min of
+	// headroom so a slow exchange does not serve an expired token.
+	tokenRefreshMargin = 5 * time.Minute
+)
+
+// Process-wide singleton, guarded by appTokenMu.
+var (
+	appTokenMu  sync.Mutex
+	appTokenSrc *appTokenSource
+
+	// Indirection for tests.
+	appTokenNow      = time.Now
+	appTokenHTTPPost func(url, body string) ([]byte, error) // nil → real HTTP
+)
+
+// ConfigureAppAuth sets up (or tears down) GitHub App authentication for the
+// process. Call with a valid config to enable; call with a zero config (or one
+// where Configured() is false) to disable and revert to PAT. Safe to call
+// multiple times — the last call wins.
+//
+// On success the gh wrapper will inject GH_TOKEN=<installation-token> into
+// every exec.Command("gh", …) call. On failure the error is logged and the
+// PAT path remains active.
+func ConfigureAppAuth(appID, installationID int64, privateKeyPath string) error {
+	appTokenMu.Lock()
+	defer appTokenMu.Unlock()
+
+	if appID <= 0 || installationID <= 0 || strings.TrimSpace(privateKeyPath) == "" {
+		// Tear down: revert to PAT.
+		appTokenSrc = nil
+		return nil
+	}
+
+	keyData, err := os.ReadFile(privateKeyPath)
+	if err != nil {
+		return fmt.Errorf("github app auth: read private key %s: %w", privateKeyPath, err)
+	}
+	key, err := parseRSAPrivateKey(keyData)
+	if err != nil {
+		return fmt.Errorf("github app auth: parse private key %s: %w", privateKeyPath, err)
+	}
+
+	src := &appTokenSource{
+		appID:          appID,
+		installationID: installationID,
+		privateKey:     key,
+	}
+
+	// Eagerly fetch the first token so startup fails visibly when the config
+	// is wrong (bad key, wrong installation ID, etc.).
+	token, expiry, err := src.fetchInstallationToken()
+	if err != nil {
+		return fmt.Errorf("github app auth: initial token fetch: %w", err)
+	}
+	now := appTokenNow()
+	src.token = token
+	src.expiry = expiry
+	src.lastRefresh = now
+	appTokenSrc = src
+
+	log.Printf("[github] app auth configured: app_id=%d installation_id=%d token_expiry=%s",
+		appID, installationID, expiry.UTC().Format(time.RFC3339))
+	return nil
+}
+
+// appToken returns a valid installation token, refreshing if needed. Returns
+// ("", nil) when App auth is not configured (caller should use ambient gh auth).
+// Returns ("", err) when App auth IS configured but refresh failed — the caller
+// should fall back to PAT and log loudly.
+func appToken() (string, error) {
+	appTokenMu.Lock()
+	defer appTokenMu.Unlock()
+
+	if appTokenSrc == nil {
+		return "", nil
+	}
+
+	now := appTokenNow()
+	if appTokenSrc.token != "" && now.Before(appTokenSrc.expiry.Add(-tokenRefreshMargin)) {
+		return appTokenSrc.token, nil
+	}
+
+	// Token is expired or within the refresh margin — refresh.
+	token, expiry, err := appTokenSrc.fetchInstallationToken()
+	if err != nil {
+		appTokenSrc.lastErr = err
+		log.Printf("[github] app auth: token refresh FAILED (falling back to PAT): %v", err)
+		return "", err
+	}
+
+	appTokenSrc.token = token
+	appTokenSrc.expiry = expiry
+	appTokenSrc.lastRefresh = now
+	appTokenSrc.lastErr = nil
+	log.Printf("[github] app auth: token refreshed, new expiry %s", expiry.UTC().Format(time.RFC3339))
+	return token, nil
+}
+
+// ---------------------------------------------------------------------------
+// JWT signing (RS256) — minimal, dependency-free implementation.
+// ---------------------------------------------------------------------------
+
+// signJWT creates a signed JWT (RS256) with the standard GitHub App claims:
+//   - iss: the App ID
+//   - iat: now - 60s (clock skew buffer)
+//   - exp: iat + jwtLifetime
+func signJWT(appID int64, key *rsa.PrivateKey) (string, error) {
+	now := appTokenNow()
+	iat := now.Add(-60 * time.Second)
+	exp := iat.Add(jwtLifetime)
+
+	header := base64URLEncode([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64URLEncode([]byte(fmt.Sprintf(
+		`{"iss":"%d","iat":%d,"exp":%d}`,
+		appID, iat.Unix(), exp.Unix(),
+	)))
+
+	signingInput := header + "." + payload
+	h := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, h[:])
+	if err != nil {
+		return "", fmt.Errorf("sign JWT: %w", err)
+	}
+
+	return signingInput + "." + base64URLEncode(sig), nil
+}
+
+// base64URLEncode is the unpadded base64url encoding per RFC 7515.
+func base64URLEncode(data []byte) string {
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+// parseRSAPrivateKey decodes a PEM-encoded PKCS#1 or PKCS#8 RSA private key.
+func parseRSAPrivateKey(pemData []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+
+	// Try PKCS#1 first (RSA PRIVATE KEY), then PKCS#8 (PRIVATE KEY).
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("private key is not RSA (got %T)", parsed)
+	}
+	return key, nil
+}
+
+// ---------------------------------------------------------------------------
+// Installation token exchange — POST /app/installations/{id}/access_tokens.
+// ---------------------------------------------------------------------------
+
+type installationTokenResponse struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// fetchInstallationToken signs a JWT and exchanges it for an installation
+// access token via the GitHub API.
+func (s *appTokenSource) fetchInstallationToken() (token string, expiry time.Time, err error) {
+	jwt, err := signJWT(s.appID, s.privateKey)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	url := fmt.Sprintf("https://api.github.com/app/installations/%d/access_tokens", s.installationID)
+
+	var respBody []byte
+	if appTokenHTTPPost != nil {
+		respBody, err = appTokenHTTPPost(url, jwt)
+	} else {
+		respBody, err = doAppAuthHTTPPost(url, jwt)
+	}
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("POST %s: %w", url, err)
+	}
+
+	var resp installationTokenResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return "", time.Time{}, fmt.Errorf("decode installation token response: %w", err)
+	}
+	if resp.Token == "" {
+		return "", time.Time{}, fmt.Errorf("installation token response has empty token (body: %s)", truncate(string(respBody), 200))
+	}
+
+	return resp.Token, resp.ExpiresAt, nil
+}
+
+// doAppAuthHTTPPost is the real HTTP POST for installation token exchange.
+// Uses the gh CLI so this package keeps its exec-only dependency shape, but it
+// MUST bypass ghApplyAuth: the exchange authenticates with the App JWT bearer
+// header, and routing it through ghAPIRunner would (a) re-enter appToken() and
+// deadlock on appTokenMu, and (b) inject a stale GH_TOKEN that conflicts with
+// the bearer. It also clears GH_TOKEN/GITHUB_TOKEN from the child env so only
+// the JWT authenticates the call.
+func doAppAuthHTTPPost(url, jwt string) ([]byte, error) {
+	args := []string{
+		"api", url,
+		"--method", "POST",
+		"-H", "Authorization: Bearer " + jwt,
+		"-H", "Accept: application/vnd.github+json",
+		"--input", "/dev/null",
+	}
+	cmd := exec.Command("gh", args...)
+	env := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "GH_TOKEN=") || strings.HasPrefix(kv, "GITHUB_TOKEN=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	cmd.Env = env
+	return cmd.CombinedOutput()
+}
+
+// truncate shortens s to at most n bytes for safe error messages.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/github/appauth_test.go
+++ b/internal/github/appauth_test.go
@@ -322,7 +322,7 @@ func TestAppToken_FallbackOnRefreshFailure(t *testing.T) {
 	}
 }
 
-func TestConfigureAppAuth_InitialFetchFailureIsError(t *testing.T) {
+func TestConfigureAppAuth_InitialFetchFailureRecordsFallback(t *testing.T) {
 	cleanup := resetAppAuthForTest(t)
 	defer cleanup()
 
@@ -331,16 +331,39 @@ func TestConfigureAppAuth_InitialFetchFailureIsError(t *testing.T) {
 	appTokenHTTPPost = func(url, jwt string) ([]byte, error) {
 		return nil, fmt.Errorf("network down")
 	}
+	// Setup still returns an error so startup logs the failure loudly.
 	if err := ConfigureAppAuth(1, 2, keyPath); err == nil {
 		t.Fatal("expected error when initial token fetch fails")
 	}
-	// On failure the source is NOT armed — appToken stays on PAT (empty, nil).
-	tok, err := appToken()
-	if tok != "" || err != nil {
-		t.Fatalf("expected PAT fallback after failed setup, got tok=%q err=%v", tok, err)
+
+	// The configured source is armed with the failure recorded so diagnostics
+	// show the App fallback state and reason — not a plain PAT path (#823
+	// review): a bad installation ID or revoked app must not read as ordinary
+	// PAT auth in `maestro digest`.
+	info := GetAuthInfo()
+	if !info.FallbackActive {
+		t.Fatal("expected FallbackActive after failed setup")
 	}
-	if GetAuthInfo().Mode != AuthModePAT {
-		t.Fatal("expected PAT mode after failed setup")
+	if info.Mode != AuthModePAT {
+		t.Fatalf("mode = %q, want pat during fallback", info.Mode)
+	}
+	if info.AppID != 1 || info.InstallationID != 2 {
+		t.Fatalf("expected configured app/installation recorded, got %+v", info)
+	}
+	if !strings.Contains(info.LastError, "network down") {
+		t.Fatalf("LastError = %q, want network down", info.LastError)
+	}
+
+	// The hourly digest names the App fallback rather than staying silent.
+	if d := authModeDigest(); !strings.Contains(d, "app fallback") {
+		t.Fatalf("digest should surface app fallback, got %q", d)
+	}
+
+	// The gh wrapper still degrades to PAT: appToken yields an empty token so
+	// GH_TOKEN is never injected (ghApplyAuth ignores the error). Runtime
+	// behavior is byte-identical to the pre-#823 PAT path.
+	if tok, _ := appToken(); tok != "" {
+		t.Fatalf("expected empty token (PAT fallback) after failed setup, got %q", tok)
 	}
 }
 

--- a/internal/github/appauth_test.go
+++ b/internal/github/appauth_test.go
@@ -1,0 +1,491 @@
+package github
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testRSAKeyPEM generates a fresh RSA key and returns it PEM-encoded in the
+// requested form ("pkcs1" or "pkcs8") plus the key itself for verification.
+func testRSAKeyPEM(t *testing.T, form string) ([]byte, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	var block *pem.Block
+	switch form {
+	case "pkcs8":
+		der, err := x509.MarshalPKCS8PrivateKey(key)
+		if err != nil {
+			t.Fatalf("marshal pkcs8: %v", err)
+		}
+		block = &pem.Block{Type: "PRIVATE KEY", Bytes: der}
+	default:
+		block = &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+	}
+	return pem.EncodeToMemory(block), key
+}
+
+// writeKeyFile writes PEM bytes to a temp file and returns its path.
+func writeKeyFile(t *testing.T, pemBytes []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "app-key.pem")
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	return path
+}
+
+// resetAppAuthForTest clears the process-wide token source and injectables and
+// returns a cleanup restoring the defaults. The token source is a package-level
+// singleton, so tests must isolate it the way the rate-limit tests isolate the
+// primary-limit gate.
+func resetAppAuthForTest(t *testing.T) func() {
+	t.Helper()
+	appTokenMu.Lock()
+	origSrc := appTokenSrc
+	appTokenSrc = nil
+	appTokenMu.Unlock()
+	origNow := appTokenNow
+	origPost := appTokenHTTPPost
+	return func() {
+		appTokenMu.Lock()
+		appTokenSrc = origSrc
+		appTokenMu.Unlock()
+		appTokenNow = origNow
+		appTokenHTTPPost = origPost
+	}
+}
+
+// tokenResponse builds a JSON installation-token response body.
+func tokenResponse(token string, expiresAt time.Time) []byte {
+	b, _ := json.Marshal(installationTokenResponse{Token: token, ExpiresAt: expiresAt})
+	return b
+}
+
+func TestParseRSAPrivateKey_PKCS1AndPKCS8(t *testing.T) {
+	for _, form := range []string{"pkcs1", "pkcs8"} {
+		t.Run(form, func(t *testing.T) {
+			pemBytes, want := testRSAKeyPEM(t, form)
+			got, err := parseRSAPrivateKey(pemBytes)
+			if err != nil {
+				t.Fatalf("parse %s: %v", form, err)
+			}
+			if got.N.Cmp(want.N) != 0 {
+				t.Fatalf("parsed key modulus mismatch")
+			}
+		})
+	}
+}
+
+func TestParseRSAPrivateKey_Garbage(t *testing.T) {
+	if _, err := parseRSAPrivateKey([]byte("not a pem")); err == nil {
+		t.Fatal("expected error on non-PEM input")
+	}
+}
+
+func TestSignJWT_ValidSignatureAndClaims(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+
+	_, key := testRSAKeyPEM(t, "pkcs1")
+	fixed := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	appTokenNow = func() time.Time { return fixed }
+
+	jwt, err := signJWT(12345, key)
+	if err != nil {
+		t.Fatalf("signJWT: %v", err)
+	}
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT segments, got %d", len(parts))
+	}
+
+	// Verify the RS256 signature over header.payload.
+	signingInput := parts[0] + "." + parts[1]
+	h := sha256.Sum256([]byte(signingInput))
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
+	}
+	if err := rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, h[:], sig); err != nil {
+		t.Fatalf("signature verification failed: %v", err)
+	}
+
+	// Verify header + claims.
+	header, _ := base64.RawURLEncoding.DecodeString(parts[0])
+	if !strings.Contains(string(header), `"RS256"`) {
+		t.Fatalf("header missing RS256: %s", header)
+	}
+	payload, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	var claims struct {
+		Iss string `json:"iss"`
+		Iat int64  `json:"iat"`
+		Exp int64  `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("decode claims: %v", err)
+	}
+	if claims.Iss != "12345" {
+		t.Fatalf("iss = %q, want 12345", claims.Iss)
+	}
+	// iat is now-60s; exp is iat+jwtLifetime.
+	wantIat := fixed.Add(-60 * time.Second).Unix()
+	if claims.Iat != wantIat {
+		t.Fatalf("iat = %d, want %d", claims.Iat, wantIat)
+	}
+	if claims.Exp != wantIat+int64(jwtLifetime.Seconds()) {
+		t.Fatalf("exp = %d, want %d", claims.Exp, wantIat+int64(jwtLifetime.Seconds()))
+	}
+	// GitHub rejects JWTs whose exp exceeds iat+10min.
+	if claims.Exp-claims.Iat > 600 {
+		t.Fatalf("JWT lifetime %ds exceeds GitHub's 10min ceiling", claims.Exp-claims.Iat)
+	}
+}
+
+func TestConfigureAppAuth_FetchesAndCachesToken(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+
+	pemBytes, _ := testRSAKeyPEM(t, "pkcs1")
+	keyPath := writeKeyFile(t, pemBytes)
+	fixed := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	appTokenNow = func() time.Time { return fixed }
+
+	var posts int
+	appTokenHTTPPost = func(url, jwt string) ([]byte, error) {
+		posts++
+		if !strings.Contains(url, "/app/installations/99/access_tokens") {
+			t.Fatalf("unexpected url: %s", url)
+		}
+		return tokenResponse("ghs_installation_token", fixed.Add(time.Hour)), nil
+	}
+
+	if err := ConfigureAppAuth(4242, 99, keyPath); err != nil {
+		t.Fatalf("ConfigureAppAuth: %v", err)
+	}
+	if posts != 1 {
+		t.Fatalf("expected 1 initial fetch, got %d", posts)
+	}
+
+	// A second appToken() well before expiry serves the cache (no new POST).
+	tok, err := appToken()
+	if err != nil {
+		t.Fatalf("appToken: %v", err)
+	}
+	if tok != "ghs_installation_token" {
+		t.Fatalf("token = %q", tok)
+	}
+	if posts != 1 {
+		t.Fatalf("cache miss: expected 1 fetch total, got %d", posts)
+	}
+
+	info := GetAuthInfo()
+	if info.Mode != AuthModeApp {
+		t.Fatalf("mode = %q, want app", info.Mode)
+	}
+	if info.InstallationID != 99 || info.AppID != 4242 {
+		t.Fatalf("unexpected auth info: %+v", info)
+	}
+}
+
+func TestAppToken_RefreshBeforeExpiry(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+
+	pemBytes, _ := testRSAKeyPEM(t, "pkcs1")
+	keyPath := writeKeyFile(t, pemBytes)
+
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	appTokenNow = func() time.Time { return now }
+
+	var posts int
+	appTokenHTTPPost = func(url, jwt string) ([]byte, error) {
+		posts++
+		// Each fetch returns a token valid one hour from the current clock.
+		return tokenResponse(fmt.Sprintf("token-%d", posts), appTokenNow().Add(time.Hour)), nil
+	}
+	if err := ConfigureAppAuth(1, 2, keyPath); err != nil {
+		t.Fatalf("ConfigureAppAuth: %v", err)
+	}
+	if posts != 1 {
+		t.Fatalf("expected initial fetch, got %d", posts)
+	}
+
+	// Advance to within the refresh margin (token expires at +1h, margin 5m).
+	now = now.Add(56 * time.Minute)
+	tok, err := appToken()
+	if err != nil {
+		t.Fatalf("appToken: %v", err)
+	}
+	if posts != 2 {
+		t.Fatalf("expected refresh within margin, got %d fetches", posts)
+	}
+	if tok != "token-2" {
+		t.Fatalf("expected refreshed token, got %q", tok)
+	}
+
+	// The new token (expiry now+1h) is served from cache immediately after.
+	tok, err = appToken()
+	if err != nil {
+		t.Fatalf("appToken: %v", err)
+	}
+	if posts != 2 || tok != "token-2" {
+		t.Fatalf("expected cached refreshed token, got posts=%d tok=%q", posts, tok)
+	}
+}
+
+func TestAppToken_ForcedExpiryRefreshes(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+
+	pemBytes, _ := testRSAKeyPEM(t, "pkcs1")
+	keyPath := writeKeyFile(t, pemBytes)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	appTokenNow = func() time.Time { return now }
+
+	var posts int
+	appTokenHTTPPost = func(url, jwt string) ([]byte, error) {
+		posts++
+		return tokenResponse(fmt.Sprintf("tok-%d", posts), appTokenNow().Add(time.Hour)), nil
+	}
+	if err := ConfigureAppAuth(1, 2, keyPath); err != nil {
+		t.Fatalf("ConfigureAppAuth: %v", err)
+	}
+
+	// Force the clock past the cached token's hard expiry.
+	now = now.Add(2 * time.Hour)
+	tok, err := appToken()
+	if err != nil {
+		t.Fatalf("appToken after forced expiry: %v", err)
+	}
+	if posts != 2 || tok != "tok-2" {
+		t.Fatalf("forced-expiry did not refresh: posts=%d tok=%q", posts, tok)
+	}
+}
+
+func TestAppToken_FallbackOnRefreshFailure(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+
+	pemBytes, _ := testRSAKeyPEM(t, "pkcs1")
+	keyPath := writeKeyFile(t, pemBytes)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	appTokenNow = func() time.Time { return now }
+
+	var posts int
+	appTokenHTTPPost = func(url, jwt string) ([]byte, error) {
+		posts++
+		if posts == 1 {
+			return tokenResponse("first", now.Add(time.Hour)), nil
+		}
+		return nil, fmt.Errorf("boom: installation revoked")
+	}
+	if err := ConfigureAppAuth(1, 2, keyPath); err != nil {
+		t.Fatalf("ConfigureAppAuth: %v", err)
+	}
+
+	// Force expiry so the next appToken() must refresh — and fail.
+	now = now.Add(2 * time.Hour)
+	tok, err := appToken()
+	if err == nil {
+		t.Fatal("expected refresh error")
+	}
+	if tok != "" {
+		t.Fatalf("expected empty token on failure (PAT fallback), got %q", tok)
+	}
+
+	// GetAuthInfo reports the fallback with the reason, and mode degrades to PAT.
+	info := GetAuthInfo()
+	if !info.FallbackActive {
+		t.Fatal("expected FallbackActive")
+	}
+	if info.Mode != AuthModePAT {
+		t.Fatalf("mode = %q, want pat during fallback", info.Mode)
+	}
+	if !strings.Contains(info.LastError, "boom") {
+		t.Fatalf("LastError = %q, want boom", info.LastError)
+	}
+}
+
+func TestConfigureAppAuth_InitialFetchFailureIsError(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+
+	pemBytes, _ := testRSAKeyPEM(t, "pkcs1")
+	keyPath := writeKeyFile(t, pemBytes)
+	appTokenHTTPPost = func(url, jwt string) ([]byte, error) {
+		return nil, fmt.Errorf("network down")
+	}
+	if err := ConfigureAppAuth(1, 2, keyPath); err == nil {
+		t.Fatal("expected error when initial token fetch fails")
+	}
+	// On failure the source is NOT armed — appToken stays on PAT (empty, nil).
+	tok, err := appToken()
+	if tok != "" || err != nil {
+		t.Fatalf("expected PAT fallback after failed setup, got tok=%q err=%v", tok, err)
+	}
+	if GetAuthInfo().Mode != AuthModePAT {
+		t.Fatal("expected PAT mode after failed setup")
+	}
+}
+
+func TestConfigureAppAuth_DisableRevertsToPAT(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+
+	pemBytes, _ := testRSAKeyPEM(t, "pkcs1")
+	keyPath := writeKeyFile(t, pemBytes)
+	appTokenHTTPPost = func(url, jwt string) ([]byte, error) {
+		return tokenResponse("t", time.Now().Add(time.Hour)), nil
+	}
+	if err := ConfigureAppAuth(1, 2, keyPath); err != nil {
+		t.Fatalf("ConfigureAppAuth: %v", err)
+	}
+	// Tear down with an incomplete config.
+	if err := ConfigureAppAuth(0, 0, ""); err != nil {
+		t.Fatalf("teardown: %v", err)
+	}
+	tok, err := appToken()
+	if tok != "" || err != nil {
+		t.Fatalf("expected PAT after teardown, got tok=%q err=%v", tok, err)
+	}
+	if GetAuthInfo().Mode != AuthModePAT {
+		t.Fatal("expected PAT mode after teardown")
+	}
+}
+
+func TestConfigureAppAuth_MissingKeyFile(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+	if err := ConfigureAppAuth(1, 2, "/nonexistent/key.pem"); err == nil {
+		t.Fatal("expected error for missing key file")
+	}
+}
+
+// TestNoAppConfig_ByteIdenticalPATPath asserts that with no App configured,
+// appToken() yields the empty token that leaves gh's ambient auth untouched —
+// i.e. behavior is byte-identical to the pre-#823 PAT path.
+func TestNoAppConfig_ByteIdenticalPATPath(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+
+	tok, err := appToken()
+	if tok != "" || err != nil {
+		t.Fatalf("expected no token on the PAT path, got tok=%q err=%v", tok, err)
+	}
+	if info := GetAuthInfo(); info.Mode != AuthModePAT {
+		t.Fatalf("mode = %q, want pat", info.Mode)
+	}
+	if d := authModeDigest(); d != "" {
+		t.Fatalf("authModeDigest should be empty on the PAT path, got %q", d)
+	}
+}
+
+// TestGHApplyAuth_InjectsTokenOnlyWhenConfigured verifies the env-injection
+// wiring: GH_TOKEN appears on the gh command exactly when App auth is active.
+func TestGHApplyAuth_InjectsTokenOnlyWhenConfigured(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+
+	// PAT path: no GH_TOKEN override injected.
+	cmd := ghCommand("api", "rate_limit")
+	if hasGHTokenEnv(cmd.Env) {
+		t.Fatal("PAT path must not inject GH_TOKEN")
+	}
+
+	// App path: GH_TOKEN injected with the installation token.
+	pemBytes, _ := testRSAKeyPEM(t, "pkcs1")
+	keyPath := writeKeyFile(t, pemBytes)
+	appTokenHTTPPost = func(url, jwt string) ([]byte, error) {
+		return tokenResponse("ghs_app_tok", time.Now().Add(time.Hour)), nil
+	}
+	if err := ConfigureAppAuth(1, 2, keyPath); err != nil {
+		t.Fatalf("ConfigureAppAuth: %v", err)
+	}
+	cmd = ghCommand("api", "rate_limit")
+	if !envContains(cmd.Env, "GH_TOKEN=ghs_app_tok") {
+		t.Fatalf("App path must inject GH_TOKEN=<installation token>; env=%v", redactEnv(cmd.Env))
+	}
+}
+
+// TestAuthModeDigest_ShowsBucketWhenApp verifies the hourly journal digest
+// fragment names the installation bucket and expiry when App auth is active,
+// and the fallback reason when the App token could not be refreshed.
+func TestAuthModeDigest_ShowsBucketWhenApp(t *testing.T) {
+	cleanup := resetAppAuthForTest(t)
+	defer cleanup()
+
+	pemBytes, _ := testRSAKeyPEM(t, "pkcs1")
+	keyPath := writeKeyFile(t, pemBytes)
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	appTokenNow = func() time.Time { return now }
+	appTokenHTTPPost = func(url, jwt string) ([]byte, error) {
+		return tokenResponse("t", now.Add(time.Hour)), nil
+	}
+	if err := ConfigureAppAuth(1, 77, keyPath); err != nil {
+		t.Fatalf("ConfigureAppAuth: %v", err)
+	}
+	d := authModeDigest()
+	if !strings.Contains(d, "auth=app") || !strings.Contains(d, "installation=77") || !strings.Contains(d, "bucket=installation") {
+		t.Fatalf("digest missing app bucket details: %q", d)
+	}
+
+	// Force a failed refresh and confirm the digest flips to the PAT fallback.
+	appTokenHTTPPost = func(url, jwt string) ([]byte, error) {
+		return nil, fmt.Errorf("revoked")
+	}
+	now = now.Add(2 * time.Hour)
+	if _, err := appToken(); err == nil {
+		t.Fatal("expected refresh failure")
+	}
+	d = authModeDigest()
+	if !strings.Contains(d, "auth=pat") || !strings.Contains(d, "app fallback") {
+		t.Fatalf("digest missing fallback details: %q", d)
+	}
+}
+
+func hasGHTokenEnv(env []string) bool {
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GH_TOKEN=") {
+			return true
+		}
+	}
+	return false
+}
+
+func envContains(env []string, want string) bool {
+	for _, kv := range env {
+		if kv == want {
+			return true
+		}
+	}
+	return false
+}
+
+// redactEnv strips values so a test failure never prints a token.
+func redactEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GH_TOKEN=") || strings.HasPrefix(kv, "GITHUB_TOKEN=") {
+			out = append(out, strings.SplitN(kv, "=", 2)[0]+"=<redacted>")
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2,11 +2,13 @@ package github
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"math/rand"
 	"net/url"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -213,7 +215,42 @@ const (
 // process error. Indirection point so tests can drive the retry loop without a
 // real gh binary.
 var ghAPIRunner = func(args ...string) ([]byte, error) {
-	return exec.Command("gh", args...).CombinedOutput()
+	return ghCommand(args...).CombinedOutput()
+}
+
+// ghCommand builds an exec.Command for `gh <args...>` with GitHub App auth
+// injected when configured. All direct `gh` call sites in this package use it
+// instead of exec.Command so installation-token auth is uniform (#823).
+func ghCommand(args ...string) *exec.Cmd {
+	cmd := exec.Command("gh", args...)
+	ghApplyAuth(cmd)
+	return cmd
+}
+
+// ghCommandContext is the context-aware sibling of ghCommand, used by the
+// GraphQL Projects calls in github_projects.go so they authenticate with the
+// installation token when App auth is active (#823).
+func ghCommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	ghApplyAuth(cmd)
+	return cmd
+}
+
+// ghApplyAuth sets GH_TOKEN on cmd's environment when GitHub App installation
+// auth is active. When App auth is not configured, or a refresh failed, appToken
+// returns an empty token and cmd is left untouched — the process falls back to
+// the ambient gh auth (PAT path), so behavior is byte-identical to pre-#823. A
+// refresh failure was already logged loudly by appToken.
+func ghApplyAuth(cmd *exec.Cmd) {
+	token, _ := appToken()
+	if token == "" {
+		return
+	}
+	// Inherit the current environment and override GH_TOKEN.
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = append(cmd.Env, "GH_TOKEN="+token)
 }
 
 // ghAPISleep is the backoff sleeper, injectable so tests do not actually wait.
@@ -710,8 +747,8 @@ func noteAPIRequest(notModified, rateLimited bool) {
 		// Roll the window before counting so the request that crossed the
 		// boundary opens the new window instead of vanishing with the digest.
 		w := apiStatsWindow
-		log.Printf("[github] REST usage last %s: %d requests, ~%d billed against core quota, %d served free by 304, %d rate-limited%s",
-			elapsed.Round(time.Minute), w.Requests, w.Requests-w.NotModified, w.NotModified, w.RateLimited, primaryLimitDigest())
+		log.Printf("[github] REST usage last %s: %d requests, ~%d billed against core quota, %d served free by 304, %d rate-limited%s%s",
+			elapsed.Round(time.Minute), w.Requests, w.Requests-w.NotModified, w.NotModified, w.RateLimited, authModeDigest(), primaryLimitDigest())
 		apiStatsWindow = APIStats{}
 		apiWindowStart = now
 	}
@@ -1511,7 +1548,7 @@ func (c *Client) CreatePR(title, body, base, head string) (int, error) {
 		"--base", base,
 		"--head", head,
 	}
-	out, err := exec.Command("gh", args...).CombinedOutput()
+	out, err := ghCommand(args...).CombinedOutput()
 	if err != nil {
 		return 0, fmt.Errorf("gh pr create: %w\n%s", err, out)
 	}
@@ -1530,7 +1567,7 @@ func (c *Client) CreatePR(title, body, base, head string) (int, error) {
 
 // UpdatePRBody replaces a pull request body.
 func (c *Client) UpdatePRBody(prNumber int, body string) error {
-	out, err := exec.Command("gh",
+	out, err := ghCommand(
 		"pr", "edit", strconv.Itoa(prNumber),
 		"--repo", c.Repo,
 		"--body", body,
@@ -1903,7 +1940,7 @@ func (c *Client) greptileReviewComments(prNumber int) ([]greptileReviewComment, 
 // ClosePR closes a PR without merging and leaves a comment explaining why.
 func (c *Client) ClosePR(prNumber int, comment string) error {
 	if comment != "" {
-		out, err := exec.Command("gh", "pr", "comment",
+		out, err := ghCommand("pr", "comment",
 			fmt.Sprint(prNumber),
 			"--repo", c.Repo,
 			"--body", comment).CombinedOutput()
@@ -1911,7 +1948,7 @@ func (c *Client) ClosePR(prNumber int, comment string) error {
 			return fmt.Errorf("gh pr comment %d: %w\n%s", prNumber, err, out)
 		}
 	}
-	out, err := exec.Command("gh", "pr", "close",
+	out, err := ghCommand("pr", "close",
 		fmt.Sprint(prNumber),
 		"--repo", c.Repo).CombinedOutput()
 	if err != nil {
@@ -1937,7 +1974,7 @@ func (c *Client) PRChecksOutput(prNumber int) (string, error) {
 
 // MergePR squash-merges a PR
 func (c *Client) MergePR(prNumber int) error {
-	out, err := exec.Command("gh", "pr", "merge",
+	out, err := ghCommand("pr", "merge",
 		fmt.Sprint(prNumber),
 		"--repo", c.Repo,
 		"--squash",
@@ -1952,7 +1989,7 @@ func (c *Client) MergePR(prNumber int) error {
 // `gh pr ready`). `gh pr merge` on a draft fails with "still a draft", so
 // the orchestrator readies a green draft PR before merging it (#697).
 func (c *Client) MarkPRReady(prNumber int) error {
-	out, err := exec.Command("gh", "pr", "ready",
+	out, err := ghCommand("pr", "ready",
 		fmt.Sprint(prNumber),
 		"--repo", c.Repo).CombinedOutput()
 	if err != nil {
@@ -1972,7 +2009,7 @@ func (c *Client) MarkPRReady(prNumber int) error {
 // same pass; they should let the next supervisor cycle re-validate and
 // re-mint against the new state (#547).
 func (c *Client) UpdateBranch(prNumber int) error {
-	out, err := exec.Command("gh", "pr", "update-branch",
+	out, err := ghCommand("pr", "update-branch",
 		fmt.Sprint(prNumber),
 		"--repo", c.Repo).CombinedOutput()
 	if err != nil {
@@ -1984,7 +2021,7 @@ func (c *Client) UpdateBranch(prNumber int) error {
 // CloseIssue closes a GitHub issue and leaves a comment explaining why
 func (c *Client) CloseIssue(number int, comment string) error {
 	if comment != "" {
-		out, err := exec.Command("gh", "issue", "comment",
+		out, err := ghCommand("issue", "comment",
 			fmt.Sprint(number),
 			"--repo", c.Repo,
 			"--body", comment).CombinedOutput()
@@ -1992,7 +2029,7 @@ func (c *Client) CloseIssue(number int, comment string) error {
 			return fmt.Errorf("gh issue comment %d: %w\n%s", number, err, out)
 		}
 	}
-	out, err := exec.Command("gh", "issue", "close",
+	out, err := ghCommand("issue", "close",
 		fmt.Sprint(number),
 		"--repo", c.Repo).CombinedOutput()
 	if err != nil {
@@ -2003,7 +2040,7 @@ func (c *Client) CloseIssue(number int, comment string) error {
 
 // AddIssueLabel adds a label to an issue.
 func (c *Client) AddIssueLabel(issueNumber int, label string) error {
-	out, err := exec.Command("gh", "issue", "edit",
+	out, err := ghCommand("issue", "edit",
 		strconv.Itoa(issueNumber),
 		"--repo", c.Repo,
 		"--add-label", label,
@@ -2016,7 +2053,7 @@ func (c *Client) AddIssueLabel(issueNumber int, label string) error {
 
 // RemoveIssueLabel removes a label from an issue.
 func (c *Client) RemoveIssueLabel(issueNumber int, label string) error {
-	out, err := exec.Command("gh", "issue", "edit",
+	out, err := ghCommand("issue", "edit",
 		strconv.Itoa(issueNumber),
 		"--repo", c.Repo,
 		"--remove-label", label,
@@ -2029,7 +2066,7 @@ func (c *Client) RemoveIssueLabel(issueNumber int, label string) error {
 
 // CommentIssue leaves a comment on an issue.
 func (c *Client) CommentIssue(issueNumber int, body string) error {
-	out, err := exec.Command("gh", "issue", "comment",
+	out, err := ghCommand("issue", "comment",
 		strconv.Itoa(issueNumber),
 		"--repo", c.Repo,
 		"--body", body,
@@ -2042,7 +2079,7 @@ func (c *Client) CommentIssue(issueNumber int, body string) error {
 
 // CommentPR leaves a comment on a pull request.
 func (c *Client) CommentPR(prNumber int, body string) error {
-	out, err := exec.Command("gh", "pr", "comment",
+	out, err := ghCommand("pr", "comment",
 		strconv.Itoa(prNumber),
 		"--repo", c.Repo,
 		"--body", body,
@@ -2081,7 +2118,7 @@ func (c *Client) PRCommits(prNumber int) ([]string, error) {
 
 // CreateRelease creates a GitHub release for the given tag.
 func (c *Client) CreateRelease(tag, title string) error {
-	out, err := exec.Command("gh", "release", "create",
+	out, err := ghCommand("release", "create",
 		tag,
 		"--repo", c.Repo,
 		"--title", title,
@@ -2408,7 +2445,7 @@ func (c *Client) CreateIssue(title, body string, labels []string) (int, error) {
 		args = append(args, "--label", l)
 	}
 
-	out, err := exec.Command("gh", args...).CombinedOutput()
+	out, err := ghCommand(args...).CombinedOutput()
 	if err != nil {
 		return 0, fmt.Errorf("gh issue create: %w\n%s", err, out)
 	}
@@ -2428,7 +2465,7 @@ func (c *Client) CreateIssue(title, body string, labels []string) (int, error) {
 
 // EditIssueBody updates the body of a GitHub issue.
 func (c *Client) EditIssueBody(number int, body string) error {
-	out, err := exec.Command("gh", "issue", "edit",
+	out, err := ghCommand("issue", "edit",
 		strconv.Itoa(number),
 		"--repo", c.Repo,
 		"--body", body,

--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -89,7 +89,7 @@ func (c *Client) DiscoverProject(projectNumber int) (*ProjectField, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query).Output()
+	out, err := ghCommandContext(ctx, "api", "graphql", "-f", "query="+query).Output()
 	if err != nil {
 		return nil, fmt.Errorf("discover project %d: %w", projectNumber, err)
 	}
@@ -292,7 +292,7 @@ func (c *Client) fetchProjectItemsPage(projectID, cursor string) ([]byte, error)
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query).Output()
+	out, err := ghCommandContext(ctx, "api", "graphql", "-f", "query="+query).Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, fmt.Errorf("graphql project items: %w\nstderr: %s", err, exitErr.Stderr)
@@ -410,7 +410,7 @@ func (c *Client) ListProjectItemStatusCounts(pf *ProjectField) ([]ProjectBoardCo
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query).Output()
+	out, err := ghCommandContext(ctx, "api", "graphql", "-f", "query="+query).Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, 0, fmt.Errorf("graphql project status counts: %w\nstderr: %s", err, exitErr.Stderr)
@@ -538,7 +538,7 @@ func (c *Client) TrySyncIssueStatusOneOf(pf *ProjectField, issueNumber int, cand
 func (c *Client) getIssueNodeID(issueNumber int) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "gh", "api", fmt.Sprintf("repos/%s/issues/%d", c.Repo, issueNumber)).Output()
+	out, err := ghCommandContext(ctx, "api", fmt.Sprintf("repos/%s/issues/%d", c.Repo, issueNumber)).Output()
 	if err != nil {
 		return "", fmt.Errorf("gh api issue %d: %w", issueNumber, err)
 	}
@@ -572,7 +572,7 @@ func (c *Client) addToProject(projectID, contentID string) (string, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query).Output()
+	out, err := ghCommandContext(ctx, "api", "graphql", "-f", "query="+query).Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return "", fmt.Errorf("graphql addProjectV2ItemById: %w\nstderr: %s\nstdout: %s", err, exitErr.Stderr, out)
@@ -622,7 +622,7 @@ func (c *Client) setProjectItemStatus(projectID, itemID, fieldID, optionID strin
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query).Output()
+	out, err := ghCommandContext(ctx, "api", "graphql", "-f", "query="+query).Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return fmt.Errorf("graphql updateProjectV2ItemFieldValue: %w\nstderr: %s\nstdout: %s", err, exitErr.Stderr, out)


### PR DESCRIPTION
Implements #823 — Phase A of epic #811 (Fleet GitHub control-plane mirror).

## Problem
The daemon authenticates every GitHub API exchange with the shared user PAT via `gh`, so all projects share one 5,000/hr core bucket plus one secondary/burst budget. That budget trips even when core usage is low.

## Changes
- **`config.GitHubAppConfig`** (`app_id`, `private_key_path`, `installation_id`) at project level. `Configured()` gates activation. Only the key *path* is stored — key material is never read into config, logged, or persisted to the config store.
- **`internal/github/appauth.go`** — RS256 JWT signing (dependency-free), installation access-token exchange, per-installation token cache with refresh-before-expiry (5m margin), and a loud PAT fallback when issuance/refresh fails.
- **`gh` wrapper wiring** — `ghCommand`/`ghCommandContext` inject `GH_TOKEN=<installation token>` into every `gh` invocation when App auth is active. With no App config the ambient `gh`/PAT path is byte-identical to before.
- **Daemon + `maestro digest`** arm App auth process-wide from the first project with a complete `github_app` block; non-fatal on setup failure (stays on PAT).
- **Diagnostics** — auth mode / rate-limit bucket / token expiry surfaced in the hourly `[github] REST usage` journal digest and the morning digest report header.

## Testing
- `go test ./...` (all green)
- `go build ./cmd/maestro/`
- New unit tests: JWT sign+verify & claim bounds, token cache hit, refresh-within-margin, forced-expiry refresh, fallback-on-failure, env injection (token present only when configured), config parse + config-store round-trip (path only, no key material), and PAT-default byte-identical behavior.

## Runtime verification still required
This wires the code path but does not prove a live installation token against real GitHub — that needs an operator to provision a GitHub App, drop the PEM on the host, set the `github_app` block, and confirm the installation bucket via `gh api rate_limit` / diagnostics. Left non-closing for that reason.

Refs #823

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds GitHub App authentication with a PAT fallback for GitHub API calls. The main changes are:

- Project-level `github_app` config for App ID, key path, and installation ID.
- Installation-token signing, exchange, caching, refresh, and fallback diagnostics.
- `gh` command wiring that injects installation tokens when App auth is active.
- Daemon and digest setup that arm App auth from configured projects.
- Digest and journal output showing the active GitHub auth mode.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The initial App-auth contract tests were observed failing due to undefined App-auth symbols, establishing the baseline before changes.
- After applying fixes, the App-auth contract tests pass on head, with log evidence of configured app auth, token refresh, and PAT fallback.
- The GitHub App config baseline lacked github\_app fields/types and could not satisfy the new contract; after changes, TestParse\_GitHubAppConfig and related subcases pass.
- The daemon digest auth tests baseline showed partial coverage with no GitHub app auth diagnostics; head now passes digest PAT/shared-pat, App/fallback tests, daemon non-fatal fallback tests, and the generated daemon ordering test.

<a href="https://app.greptile.com/trex/runs/13394421/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/github/appauth.go | Adds GitHub App JWT signing, installation-token exchange, caching, refresh, and fallback diagnostics. |
| internal/github/github.go | Routes `gh` command creation through helpers that apply App installation tokens when available. |
| internal/daemon/daemon.go | Configures process-wide GitHub App auth during daemon startup from the configured fleet projects. |
| cmd/maestro/digest.go | Configures App auth before digest collection so report reads use the selected auth mode. |
| internal/digest/digest.go | Adds serializable auth-mode details for digest reports. |
| internal/digest/markdown.go | Renders the GitHub auth mode in the digest header. |
| internal/config/config.go | Adds GitHub App config fields and a completeness check. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/github/github.go`, line 1412-1414 ([link](https://github.com/befeast/maestro/blob/d14a2e8f0346733134a6bad0995bbe6764c94e12/internal/github/github.go#L1412-L1414)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Refresh Failure Runs As PAT**

   When an installation token is inside the refresh margin and the refresh request fails, `appToken()` returns an empty token and `ghApplyAuth` silently leaves the command on ambient `gh` auth. A merge, close, label, or comment issued during that transient failure can execute under the shared PAT even though the cached installation token may still be valid for several minutes.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/github/github.go
   Line: 1412-1414

   Comment:
   **Refresh Failure Runs As PAT**

   When an installation token is inside the refresh margin and the refresh request fails, `appToken()` returns an empty token and `ghApplyAuth` silently leaves the command on ambient `gh` auth. A merge, close, label, or comment issued during that transient failure can execute under the shared PAT even though the cached installation token may still be valid for several minutes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(github): record app-auth setup failu..."](https://github.com/befeast/maestro/commit/db60112b5d0f9084fdccde81b4e7cb145f23ded5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42061930)</sub>

<!-- /greptile_comment -->