### PR TITLE
Webhook ingestion into the unified SQLite store (epic #811, phase B) (#824)

### DIFF
--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -14,6 +14,8 @@ import (
 	"github.com/befeast/maestro/internal/configstore"
 	"github.com/befeast/maestro/internal/daemon"
 	"github.com/befeast/maestro/internal/statestore"
+	"github.com/befeast/maestro/internal/webhook"
+	"github.com/befeast/maestro/internal/webhookstore"
 )
 
 // daemonCmd runs every project in the config store as one long-lived process:
@@ -35,6 +37,9 @@ func daemonCmd(args []string) {
 	approvalsDB := fs.String("approvals-db", approvalstore.DefaultDBPath(), "Shared SQLite approvals db path (used with --approvals-store=sqlite)")
 	stateStore := fs.String("state-store", "json", "State store backend for sessions/decisions/health/missions: json|sqlite (write-through mirror, #760)")
 	stateDB := fs.String("state-db", statestore.DefaultDBPath(), "Shared SQLite state db path (used with --state-store=sqlite)")
+	webhookSecretFile := fs.String("webhook-secret-file", "", "Path to a file holding the GitHub webhook secret; enables inbound webhook ingestion on the fleet port (#824)")
+	webhookPath := fs.String("webhook-path", webhook.DefaultPath, "HTTP path the webhook ingestion endpoint is served on (#824)")
+	webhookDB := fs.String("webhook-db", webhookstore.DefaultDBPath(), "Shared SQLite db path webhook deliveries land in (#824)")
 	drainTimeout := fs.Duration("drain-timeout", daemon.DefaultDrainTimeout, "Max time the SIGTERM in-process drain waits for in-flight workers to finish (#761)")
 	fs.Parse(args)
 
@@ -66,6 +71,9 @@ func daemonCmd(args []string) {
 		ApprovalsDBPath:    *approvalsDB,
 		StateStore:         *stateStore,
 		StateDBPath:        *stateDB,
+		WebhookSecretFile:  *webhookSecretFile,
+		WebhookPath:        *webhookPath,
+		WebhookDBPath:      *webhookDB,
 	})
 
 	go handleDaemonSignals(ctx, cancel, d, *drainTimeout)

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -293,6 +293,17 @@ systemctl --user restart maestro-fleet.service
 
 Avoid these during incident handling unless you are deliberately debugging credentials: `env`, raw config dumps, `gh auth token`, shell history dumps, and full worker log pastebacks.
 
+## Webhook Ingestion (#824)
+
+The single-service `maestro daemon` can also ingest inbound GitHub webhooks into
+the unified `~/.maestro/maestro.db` — a push-shaped alternative to polling for
+issue / PR / check / review / label state. It is default OFF and opt-in via
+`--webhook-secret-file`; the ingestion diagnostics surface on `/api/v1/fleet`
+under the `webhooks` block (last delivery time, per-event-type counts,
+signature-failure counter). See the dedicated
+[Webhook Ingestion Runbook](webhook-ingestion-runbook.md) for setup, tunnel
+configuration, and semantics.
+
 ## Recovery Playbook
 
 ### No eligible issues

--- a/docs/webhook-ingestion-runbook.md
+++ b/docs/webhook-ingestion-runbook.md
@@ -1,0 +1,138 @@
+# Webhook Ingestion Runbook (#824, epic #811 phase B)
+
+Inbound GitHub webhook ingestion into the unified SQLite store
+(`~/.maestro/maestro.db`). The fleet daemon exposes one HTTP endpoint that
+validates each delivery's signature, deduplicates on the delivery UUID, and
+lands the raw payload plus a parsed envelope durably. Default **OFF** — a daemon
+started without `--webhook-secret-file` behaves exactly as before and keeps
+learning GitHub state by polling.
+
+This is **ingestion only** (phase B). Nothing consumes the stored deliveries
+into the orchestration read path yet; that is phase C/D. The goal of phase B is
+to make the deliveries arrive and persist so a later phase can stop polling.
+
+## Why
+
+All GitHub state (issues, PRs, checks, reviews, labels) reaches maestro by
+polling. #798 made unchanged polls cheap (304s), but polling still churns CLI
+processes, risks burst-limit exposure during high-change windows, and runs
+thousands of exchanges per hour. Webhooks turn that push-shaped: GitHub sends
+each change once, signed.
+
+## What lands
+
+For every delivery with a valid `X-Hub-Signature-256`:
+
+- the **raw payload** verbatim (the signed bytes), and
+- a denormalised **envelope** — event type (`X-GitHub-Event`), `action`,
+  `repository.full_name`, `sender.login`, hook id, and receipt time.
+
+Captured event types (phase B scope): `issues`, `label`, `issue_comment`,
+`pull_request`, `pull_request_review`, `pull_request_review_comment`,
+`check_run`, `check_suite`, `status`, `projects_v2_item`, plus `ping` (the
+delivery GitHub sends when a webhook is first created). A valid-signature
+delivery of any other event type is still stored — the supported set gates only
+observability labels, never persistence, so no acknowledged event is dropped.
+
+## Enabling it
+
+1. **Mint a secret** and put it in a file the daemon user can read (never commit
+   it):
+
+   ```
+   openssl rand -hex 32 > ~/.maestro/webhook-secret
+   chmod 600 ~/.maestro/webhook-secret
+   ```
+
+2. **Start the daemon with the secret file.** Only the *path* is passed on the
+   command line; the secret is read from disk at startup, never logged, and
+   never written to the config store.
+
+   ```
+   maestro daemon \
+     --webhook-secret-file ~/.maestro/webhook-secret \
+     [--webhook-path /api/v1/webhooks/github] \
+     [--webhook-db ~/.maestro/maestro.db]
+   ```
+
+   | Flag | Default | Purpose |
+   |------|---------|---------|
+   | `--webhook-secret-file` | *(empty — ingestion disabled)* | Path to the file holding the GitHub webhook secret. |
+   | `--webhook-path` | `/api/v1/webhooks/github` | Endpoint path under the fleet port. |
+   | `--webhook-db` | `~/.maestro/maestro.db` | Shared SQLite db deliveries land in. |
+
+   On success the daemon logs
+   `webhook ingestion active — POST <path> validates X-Hub-Signature-256 …`.
+   A blank / unreadable / empty secret file disables ingestion with a loud
+   warning rather than aborting startup.
+
+3. **Point GitHub at the endpoint.** The endpoint listens on the fleet port
+   (default `:8786`), which is bound to `127.0.0.1` by default — GitHub cannot
+   reach it directly. Expose it with a tunnel or reverse proxy on the LAN host:
+
+   - **Repository / org webhook** (Settings → Webhooks → Add webhook) or the
+     **GitHub App** webhook config:
+     - Payload URL: `https://<your-tunnel-host>/api/v1/webhooks/github`
+     - Content type: `application/json`
+     - Secret: the value from step 1
+     - Events: issues, labels, issue comments, pull requests, PR reviews, PR
+       review comments, check runs, check suites, statuses, and (org/App only)
+       Projects v2 items.
+   - **Tunnel options:** `cloudflared tunnel`, `ngrok http 8786`, or a reverse
+     proxy (Caddy/nginx) that forwards `/api/v1/webhooks/github` to
+     `127.0.0.1:8786`. The signature check means the tunnel does not need its
+     own auth, but TLS on the public leg is still recommended.
+
+   > The webhook endpoint authenticates by signature, **not** by the fleet
+   > bearer token (`server.auth`). GitHub cannot attach an `Authorization`
+   > header, so even in the exposed-auth posture the ingestion path is routed
+   > *before* the fleet auth middleware. It still fails closed on any bad or
+   > missing signature.
+
+## Semantics
+
+- **Idempotent.** Storage is keyed on `X-GitHub-Delivery`. GitHub retries on any
+  non-2xx and an operator can replay from the webhook's *Recent Deliveries*; a
+  replay of an already-stored delivery is a no-op that returns `200` with
+  `{"status":"duplicate"}`. A newly stored delivery returns `202`.
+- **Invalid signature → `401`**, counted, payload **not** stored.
+- **Missing `X-GitHub-Delivery` → `400`.**
+- **Durable across restart.** The store uses SQLite WAL, so an acknowledged
+  delivery survives a daemon restart — GitHub's at-least-once retry plus the
+  idempotency key means nothing is lost or double-counted.
+
+## Diagnostics
+
+- **Journal:** each accepted delivery logs one line
+  (`[webhook] stored delivery event=… action=… repo=… delivery=…`); the payload
+  is never logged. Rejections log `invalid or missing X-Hub-Signature-256`.
+- **Fleet API:** `GET /api/v1/fleet` carries a `webhooks` block:
+
+  ```json
+  "webhooks": {
+    "enabled": true,
+    "path": "/api/v1/webhooks/github",
+    "last_delivery_at": "2026-07-06T12:00:00Z",
+    "last_event_type": "pull_request",
+    "total_deliveries": 128,
+    "by_event_type": { "issues": 40, "pull_request": 88 },
+    "duplicates": 3,
+    "signature_failures": 0,
+    "bad_requests": 0
+  }
+  ```
+
+  `total_deliveries` and `by_event_type` are seeded from the durable store on
+  startup, so they reflect the persisted total across restarts;
+  `signature_failures` / `duplicates` / `bad_requests` are the current process's
+  tally.
+
+## Inspecting the store
+
+```
+sqlite3 ~/.maestro/maestro.db \
+  'SELECT received_at, event_type, action, repo FROM webhook_deliveries ORDER BY received_at DESC LIMIT 20;'
+```
+
+The `webhook_deliveries` table is disjoint from the approvals / state tables
+that share the same `maestro.db`.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -30,6 +31,8 @@ import (
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/statestore"
 	"github.com/befeast/maestro/internal/supervisor"
+	"github.com/befeast/maestro/internal/webhook"
+	"github.com/befeast/maestro/internal/webhookstore"
 )
 
 // Default loop intervals, shared by the daemon command's flag defaults and the
@@ -132,6 +135,21 @@ type Options struct {
 	// StateDBPath is the shared SQLite state database used when StateStore is
 	// "sqlite" (defaults to the same maestro.db the approvals store uses).
 	StateDBPath string
+
+	// WebhookSecretFile is the path to a file holding the GitHub webhook secret
+	// (epic #811 phase B, #824). When set and readable, the daemon exposes the
+	// inbound webhook ingestion endpoint on the fleet port, validating
+	// X-Hub-Signature-256 against this secret. Only the PATH is configured here;
+	// the secret is read from disk at startup, never logged, and never stored in
+	// the config store. Empty disables ingestion.
+	WebhookSecretFile string
+	// WebhookPath is the endpoint path served under the fleet port (default
+	// webhook.DefaultPath). Configurable so operators can obscure it or align it
+	// with a reverse-proxy route.
+	WebhookPath string
+	// WebhookDBPath is the shared SQLite database webhook deliveries land in
+	// (defaults to the same maestro.db the state/approvals stores use).
+	WebhookDBPath string
 }
 
 // Daemon owns the running project flows and the shared FleetServer.
@@ -352,6 +370,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 			log.Printf("[daemon] state prune (drop removed-project rows) failed: %v", perr)
 		}
 	}
+	// #824: expose the inbound GitHub webhook ingestion endpoint on the fleet
+	// port when a webhook secret file is configured. Non-fatal on any error —
+	// the daemon logs it loudly and comes up without ingestion (the fleet keeps
+	// polling), rather than aborting startup over an unreadable secret.
+	configureWebhookIngestion(fleet, d.opts)
+
 	fleetAuth := server.FleetAuthFromProjects(projects)
 	fleet.SetAuth(fleetAuth)
 	// Capture the fleet's shared auth token env so the self-deploy health probe
@@ -529,6 +553,61 @@ func configureFleetGitHubAppAuth(projects []server.FleetProject) {
 		return
 	}
 	log.Printf("[daemon] github app auth not configured — using PAT/gh for GitHub calls")
+}
+
+// configureWebhookIngestion wires the inbound GitHub webhook ingestion endpoint
+// (#824) onto the fleet server when opts.WebhookSecretFile is set. It reads the
+// secret from disk (never logging it), opens the delivery store in the shared
+// maestro.db, and hands the fleet an ingestor plus the configured path.
+//
+// Every failure is non-fatal: a blank/unreadable/empty secret file, or a store
+// that will not open, disables ingestion with a loud warning instead of
+// blocking daemon startup — webhooks are an optimisation over polling, so their
+// absence degrades to today's polling behaviour.
+func configureWebhookIngestion(fleet *server.FleetServer, opts Options) {
+	secretPath := strings.TrimSpace(opts.WebhookSecretFile)
+	if secretPath == "" {
+		log.Printf("[daemon] webhook ingestion not configured (no --webhook-secret-file) — GitHub state continues to arrive by polling")
+		return
+	}
+	secret, err := readWebhookSecret(secretPath)
+	if err != nil {
+		log.Printf("[daemon] webhook ingestion disabled: %v", err)
+		return
+	}
+
+	dbPath := strings.TrimSpace(opts.WebhookDBPath)
+	if dbPath == "" {
+		dbPath = webhookstore.DefaultDBPath()
+	}
+	store, err := webhookstore.Open(dbPath)
+	if err != nil {
+		log.Printf("[daemon] webhook ingestion disabled: open delivery store %s: %v", dbPath, err)
+		return
+	}
+
+	ingestor := webhook.NewIngestor(store, secret)
+	path := strings.TrimSpace(opts.WebhookPath)
+	if path == "" {
+		path = webhook.DefaultPath
+	}
+	fleet.SetWebhookIngestor(ingestor, path)
+	log.Printf("[daemon] webhook ingestion active — POST %s validates X-Hub-Signature-256 and lands deliveries in %s", path, dbPath)
+}
+
+// readWebhookSecret reads and trims the webhook secret from disk. The secret's
+// bytes never enter a log line; only errors (which carry the path, not the
+// content) are surfaced. An empty file is an operator error worth reporting.
+func readWebhookSecret(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read webhook secret file %s: %w", path, err)
+	}
+	secret := strings.TrimSpace(string(data))
+	if secret == "" {
+		return "", fmt.Errorf("webhook secret file %s is empty", path)
+	}
+	return secret, nil
 }
 
 // Fleet returns the aggregating FleetServer once Run has built it, or nil

--- a/internal/daemon/webhook_test.go
+++ b/internal/daemon/webhook_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/server"
+	"github.com/befeast/maestro/internal/webhook"
+)
+
+func TestReadWebhookSecret(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+	if err := os.WriteFile(path, []byte("  top-secret\n"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	got, err := readWebhookSecret(path)
+	if err != nil {
+		t.Fatalf("read secret: %v", err)
+	}
+	if got != "top-secret" {
+		t.Fatalf("secret = %q, want trimmed %q", got, "top-secret")
+	}
+}
+
+func TestReadWebhookSecretEmptyAndMissing(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty")
+	if err := os.WriteFile(empty, []byte("   \n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := readWebhookSecret(empty); err == nil {
+		t.Fatal("expected error for empty secret file")
+	}
+	if _, err := readWebhookSecret(filepath.Join(dir, "does-not-exist")); err == nil {
+		t.Fatal("expected error for missing secret file")
+	}
+}
+
+// TestConfigureWebhookIngestionWiresEndpoint proves the daemon-level wiring:
+// given a secret file, configureWebhookIngestion opens a store and registers a
+// live ingestion endpoint on the fleet server that accepts a signed delivery.
+func TestConfigureWebhookIngestionWiresEndpoint(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "secret")
+	const secret = "wire-me"
+	if err := os.WriteFile(secretPath, []byte(secret), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	fleet := server.NewFleet(nil, "127.0.0.1", 0, false)
+	configureWebhookIngestion(fleet, Options{
+		WebhookSecretFile: secretPath,
+		WebhookDBPath:     filepath.Join(dir, "maestro.db"),
+		WebhookPath:       webhook.DefaultPath,
+	})
+
+	body := []byte(`{"action":"opened","repository":{"full_name":"BeFeast/maestro"}}`)
+	req := httptest.NewRequest(http.MethodPost, webhook.DefaultPath, strings.NewReader(string(body)))
+	req.Header.Set(webhook.HeaderEvent, "issues")
+	req.Header.Set(webhook.HeaderDelivery, "wire-1")
+	req.Header.Set(webhook.HeaderSignature, webhook.Sign(secret, body))
+	rec := httptest.NewRecorder()
+	fleet.HandlerForTest().ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("wired endpoint: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestConfigureWebhookIngestionDisabledWithoutSecret confirms no endpoint is
+// registered when no secret file is configured — the delivery path 404s / falls
+// through to the dashboard rather than accepting unsigned input.
+func TestConfigureWebhookIngestionDisabledWithoutSecret(t *testing.T) {
+	fleet := server.NewFleet(nil, "127.0.0.1", 0, false)
+	configureWebhookIngestion(fleet, Options{})
+
+	req := httptest.NewRequest(http.MethodPost, webhook.DefaultPath, strings.NewReader("{}"))
+	req.Header.Set(webhook.HeaderDelivery, "nope")
+	rec := httptest.NewRecorder()
+	fleet.HandlerForTest().ServeHTTP(rec, req)
+	if rec.Code == http.StatusAccepted {
+		t.Fatal("delivery accepted despite no configured webhook secret")
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -27,6 +27,7 @@ import (
 	"github.com/befeast/maestro/internal/server/web"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/statestore"
+	"github.com/befeast/maestro/internal/webhook"
 	"gopkg.in/yaml.v3"
 )
 
@@ -306,6 +307,17 @@ type FleetServer struct {
 	// construction while handlers read it concurrently.
 	projectStoreMu sync.RWMutex
 	projectStore   FleetProjectStore
+
+	// webhook is the inbound GitHub webhook ingestion endpoint (epic #811,
+	// phase B — #824). nil disables ingestion (no endpoint registered). When
+	// wired by the daemon (SetWebhookIngestor) it serves POST <webhookPath>
+	// under the fleet port, authenticated by X-Hub-Signature-256 rather than the
+	// fleet bearer token — so buildHandler routes it BEFORE the auth middleware.
+	// Guarded by webhookMu so the daemon can wire it after construction while the
+	// snapshot/read paths read it concurrently.
+	webhookMu   sync.RWMutex
+	webhook     *webhook.Ingestor
+	webhookPath string
 }
 
 // FleetProjectStore is the write side of the daemon's config store that the
@@ -624,6 +636,32 @@ func (s *FleetServer) liveProjectStore() FleetProjectStore {
 	return s.projectStore
 }
 
+// SetWebhookIngestor wires the inbound GitHub webhook ingestion endpoint (#824).
+// The daemon calls it with an ingestor over the shared maestro.db and the
+// configured path (default webhook.DefaultPath). A blank path falls back to the
+// default; a nil ingestor disables ingestion. Safe to call before Start.
+func (s *FleetServer) SetWebhookIngestor(in *webhook.Ingestor, path string) {
+	if s == nil {
+		return
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		path = webhook.DefaultPath
+	}
+	s.webhookMu.Lock()
+	s.webhook = in
+	s.webhookPath = path
+	s.webhookMu.Unlock()
+}
+
+// liveWebhook returns the current webhook ingestor and its path under the read
+// lock. The ingestor is nil when ingestion is not configured.
+func (s *FleetServer) liveWebhook() (*webhook.Ingestor, string) {
+	s.webhookMu.RLock()
+	defer s.webhookMu.RUnlock()
+	return s.webhook, s.webhookPath
+}
+
 // buildHandler returns the fleet mux wrapped with the auth middleware.
 // When auth.Required() is true (#616: exposed install posture), every
 // route — JSON read endpoints, the SPA HTML, static assets, mutating
@@ -647,6 +685,15 @@ func (s *FleetServer) buildHandler() http.Handler {
 	mux.Handle("/static/", web.StaticHandler())
 	mux.HandleFunc("/", s.handleFleetDashboard)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The webhook ingestion endpoint authenticates by X-Hub-Signature-256,
+		// not the fleet bearer token — GitHub cannot attach an Authorization
+		// header. Route it BEFORE the auth middleware so an exposed-posture
+		// deployment (auth enabled) does not 401 every legitimate delivery
+		// (#824). The ingestor still fails closed on a bad/missing signature.
+		if in, path := s.liveWebhook(); in != nil && r.URL.Path == path {
+			in.ServeHTTP(w, r)
+			return
+		}
 		authMiddleware(mux, s.liveAuth()).ServeHTTP(w, r)
 	})
 }
@@ -737,6 +784,52 @@ type fleetResponse struct {
 	// so the SPA can render both the hero ("today / 7d") and the
 	// per-project drill-down without recomputing pricing client-side.
 	CostObservability fleetGlobalCost `json:"cost_observability"`
+
+	// Webhooks is the inbound GitHub webhook ingestion diagnostic (#824):
+	// last delivery time, total + per-event-type counts, and the
+	// signature-failure counter. nil when ingestion is not configured.
+	Webhooks *fleetWebhookStats `json:"webhooks,omitempty"`
+}
+
+// fleetWebhookStats is the webhook ingestion observability block surfaced on the
+// fleet snapshot (#824 AC 5/10 — "diagnostics show last webhook delivery time
+// and counts"). Counts are cumulative; Accepted/ByEventType reflect the durable
+// store total (seeded across restarts), SignatureFailures/Duplicates are the
+// current process's tally.
+type fleetWebhookStats struct {
+	Enabled           bool             `json:"enabled"`
+	Path              string           `json:"path,omitempty"`
+	LastDeliveryAt    string           `json:"last_delivery_at,omitempty"`
+	LastEventType     string           `json:"last_event_type,omitempty"`
+	TotalDeliveries   int64            `json:"total_deliveries"`
+	ByEventType       map[string]int64 `json:"by_event_type,omitempty"`
+	Duplicates        int64            `json:"duplicates"`
+	SignatureFailures int64            `json:"signature_failures"`
+	BadRequests       int64            `json:"bad_requests"`
+}
+
+// webhookStatsSnapshot maps the ingestor's counters into the fleet response
+// block. Returns nil when ingestion is not configured so the field is omitted.
+func (s *FleetServer) webhookStatsSnapshot() *fleetWebhookStats {
+	in, path := s.liveWebhook()
+	if in == nil {
+		return nil
+	}
+	st := in.Stats()
+	out := &fleetWebhookStats{
+		Enabled:           true,
+		Path:              path,
+		LastEventType:     st.LastEventType,
+		TotalDeliveries:   st.Accepted,
+		ByEventType:       st.ByEventType,
+		Duplicates:        st.Duplicates,
+		SignatureFailures: st.SignatureFailures,
+		BadRequests:       st.BadRequests,
+	}
+	if !st.LastDeliveryAt.IsZero() {
+		out.LastDeliveryAt = formatFleetTime(st.LastDeliveryAt)
+	}
+	return out
 }
 
 // fleetNextAction names the single canonical operator action across the fleet.
@@ -1791,6 +1884,7 @@ func (s *FleetServer) snapshot() fleetResponse {
 	resp.NextAction = buildFleetNextAction(resp.Projects, resp.Approvals, now)
 	resp.Verdict = buildFleetVerdict(resp, now)
 	resp.CostObservability = rollupGlobalCost(resp.Projects)
+	resp.Webhooks = s.webhookStatsSnapshot()
 	return resp
 }
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -662,6 +662,21 @@ func (s *FleetServer) liveWebhook() (*webhook.Ingestor, string) {
 	return s.webhook, s.webhookPath
 }
 
+// webhookPathMatches reports whether an inbound request path should route to the
+// webhook ingestor. It tolerates a single trailing slash on either side: a proxy
+// (or a re-typed GitHub webhook URL) that forwards "<path>/" must still reach the
+// ingestor. Without this, the trailing-slash variant falls through to the fleet
+// mux's "/" catch-all and, in the default unauthenticated posture, GitHub gets a
+// 200 dashboard response and marks the delivery succeeded even though nothing was
+// stored (greptile P1). An empty configured path never matches.
+func webhookPathMatches(reqPath, cfgPath string) bool {
+	cfgPath = strings.TrimRight(cfgPath, "/")
+	if cfgPath == "" {
+		return false
+	}
+	return strings.TrimRight(reqPath, "/") == cfgPath
+}
+
 // buildHandler returns the fleet mux wrapped with the auth middleware.
 // When auth.Required() is true (#616: exposed install posture), every
 // route — JSON read endpoints, the SPA HTML, static assets, mutating
@@ -690,7 +705,7 @@ func (s *FleetServer) buildHandler() http.Handler {
 		// header. Route it BEFORE the auth middleware so an exposed-posture
 		// deployment (auth enabled) does not 401 every legitimate delivery
 		// (#824). The ingestor still fails closed on a bad/missing signature.
-		if in, path := s.liveWebhook(); in != nil && r.URL.Path == path {
+		if in, path := s.liveWebhook(); in != nil && webhookPathMatches(r.URL.Path, path) {
 			in.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/fleet_webhook_test.go
+++ b/internal/server/fleet_webhook_test.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/webhook"
+	"github.com/befeast/maestro/internal/webhookstore"
+)
+
+const fleetWebhookSecret = "fleet-webhook-secret"
+
+func newFleetWithWebhook(t *testing.T) (*FleetServer, *webhookstore.Store) {
+	t.Helper()
+	db := filepath.Join(t.TempDir(), "maestro.db")
+	store, err := webhookstore.Open(db)
+	if err != nil {
+		t.Fatalf("open webhook store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	fleet := NewFleet(nil, "127.0.0.1", 0, false)
+	fleet.SetWebhookIngestor(webhook.NewIngestor(store, fleetWebhookSecret), webhook.DefaultPath)
+	return fleet, store
+}
+
+// TestFleetWebhookBypassesAuth proves the webhook endpoint authenticates by
+// signature, not the fleet bearer token: with fleet auth ENABLED, a bearer-less
+// but correctly-signed delivery still lands (#824), while a normal read endpoint
+// is 401'd.
+func TestFleetWebhookBypassesAuth(t *testing.T) {
+	fleet, _ := newFleetWithWebhook(t)
+	fleet.SetAuthForTest("operator-token", "operator")
+	handler := fleet.HandlerForTest()
+
+	// A normal endpoint without the bearer token is rejected.
+	readRec := httptest.NewRecorder()
+	handler.ServeHTTP(readRec, httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil))
+	if readRec.Code != http.StatusUnauthorized {
+		t.Fatalf("read endpoint without token: status=%d want 401", readRec.Code)
+	}
+
+	// The webhook endpoint with a valid signature but NO bearer token succeeds.
+	body := []byte(`{"action":"opened","repository":{"full_name":"BeFeast/maestro"}}`)
+	req := httptest.NewRequest(http.MethodPost, webhook.DefaultPath, strings.NewReader(string(body)))
+	req.Header.Set(webhook.HeaderEvent, "issues")
+	req.Header.Set(webhook.HeaderDelivery, "fleet-del-1")
+	req.Header.Set(webhook.HeaderSignature, webhook.Sign(fleetWebhookSecret, body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("signed webhook delivery: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestFleetWebhookInvalidSignature401 confirms an unsigned/bad-signature
+// delivery is 401'd by the ingestor even though it bypassed the fleet auth
+// middleware.
+func TestFleetWebhookInvalidSignature401(t *testing.T) {
+	fleet, store := newFleetWithWebhook(t)
+	handler := fleet.HandlerForTest()
+
+	body := []byte(`{"action":"opened"}`)
+	req := httptest.NewRequest(http.MethodPost, webhook.DefaultPath, strings.NewReader(string(body)))
+	req.Header.Set(webhook.HeaderEvent, "issues")
+	req.Header.Set(webhook.HeaderDelivery, "fleet-bad")
+	req.Header.Set(webhook.HeaderSignature, webhook.Sign("nope", body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("bad signature via fleet: status=%d want 401", rec.Code)
+	}
+	if n, _ := store.Count(req.Context()); n != 0 {
+		t.Fatalf("payload stored despite bad signature: count=%d", n)
+	}
+}
+
+// TestFleetSnapshotWebhookStats proves the ingestion diagnostics surface on the
+// fleet snapshot (#824 AC 5/10).
+func TestFleetSnapshotWebhookStats(t *testing.T) {
+	fleet, _ := newFleetWithWebhook(t)
+	handler := fleet.HandlerForTest()
+
+	body := []byte(`{"action":"labeled","repository":{"full_name":"BeFeast/maestro"}}`)
+	req := httptest.NewRequest(http.MethodPost, webhook.DefaultPath, strings.NewReader(string(body)))
+	req.Header.Set(webhook.HeaderEvent, "issues")
+	req.Header.Set(webhook.HeaderDelivery, "stats-1")
+	req.Header.Set(webhook.HeaderSignature, webhook.Sign(fleetWebhookSecret, body))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	snap := fleet.snapshot()
+	if snap.Webhooks == nil {
+		t.Fatal("fleet snapshot missing webhooks block")
+	}
+	if !snap.Webhooks.Enabled {
+		t.Fatal("webhooks block should be enabled")
+	}
+	if snap.Webhooks.TotalDeliveries != 1 || snap.Webhooks.ByEventType["issues"] != 1 {
+		t.Fatalf("unexpected webhook stats: %+v", snap.Webhooks)
+	}
+	if snap.Webhooks.LastDeliveryAt == "" {
+		t.Fatal("webhook stats missing last delivery time")
+	}
+
+	// The block is also present in the JSON the fleet API serves.
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil))
+	var payload struct {
+		Webhooks *fleetWebhookStats `json:"webhooks"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode fleet json: %v", err)
+	}
+	if payload.Webhooks == nil || payload.Webhooks.TotalDeliveries != 1 {
+		t.Fatalf("fleet JSON missing webhook stats: %+v", payload.Webhooks)
+	}
+}
+
+// TestFleetNoWebhookOmitsStats confirms the block is omitted when ingestion is
+// not configured (nil ingestor).
+func TestFleetNoWebhookOmitsStats(t *testing.T) {
+	fleet := NewFleet(nil, "127.0.0.1", 0, false)
+	if snap := fleet.snapshot(); snap.Webhooks != nil {
+		t.Fatalf("webhooks block should be nil when ingestion is unconfigured: %+v", snap.Webhooks)
+	}
+}

--- a/internal/server/fleet_webhook_test.go
+++ b/internal/server/fleet_webhook_test.go
@@ -56,6 +56,29 @@ func TestFleetWebhookBypassesAuth(t *testing.T) {
 	}
 }
 
+// TestFleetWebhookTrailingSlashRoutes proves a delivery to "<path>/" (as a proxy
+// or re-typed webhook URL may forward it) still reaches the ingestor and lands,
+// instead of falling through to the "/" dashboard catch-all — which in the
+// default unauthenticated posture would 200 GitHub without storing anything.
+func TestFleetWebhookTrailingSlashRoutes(t *testing.T) {
+	fleet, store := newFleetWithWebhook(t)
+	handler := fleet.HandlerForTest()
+
+	body := []byte(`{"action":"opened","repository":{"full_name":"BeFeast/maestro"}}`)
+	req := httptest.NewRequest(http.MethodPost, webhook.DefaultPath+"/", strings.NewReader(string(body)))
+	req.Header.Set(webhook.HeaderEvent, "issues")
+	req.Header.Set(webhook.HeaderDelivery, "trailing-1")
+	req.Header.Set(webhook.HeaderSignature, webhook.Sign(fleetWebhookSecret, body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("trailing-slash webhook delivery: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if _, ok, err := store.Get(req.Context(), "trailing-1"); err != nil || !ok {
+		t.Fatalf("trailing-slash delivery not stored: ok=%v err=%v", ok, err)
+	}
+}
+
 // TestFleetWebhookInvalidSignature401 confirms an unsigned/bad-signature
 // delivery is 401'd by the ingestor even though it bypassed the fleet auth
 // middleware.

--- a/internal/webhook/ingest.go
+++ b/internal/webhook/ingest.go
@@ -16,9 +16,11 @@ import (
 )
 
 // maxBodyBytes caps the request body the ingestor reads. GitHub documents a
-// 25 MiB maximum webhook payload; anything larger is refused rather than read
-// into memory unbounded. The signature is computed over exactly the bytes read,
-// so a truncated oversize body fails signature validation and is rejected.
+// 25 MiB maximum webhook payload; anything larger is refused (413) rather than
+// read into memory unbounded. The request is rejected as OVERSIZE before the
+// signature is checked — otherwise a truncated body would fail signature
+// validation and surface a misleading "401 invalid signature" for what is really
+// a size problem, which GitHub would then retry indefinitely.
 const maxBodyBytes = 25 << 20
 
 // DefaultPath is the endpoint path the fleet daemon serves webhook ingestion on
@@ -35,7 +37,9 @@ type Store interface {
 	Insert(ctx context.Context, d webhookstore.Delivery) (bool, error)
 	Count(ctx context.Context) (int, error)
 	CountsByEventType(ctx context.Context) (map[string]int, error)
-	LastDeliveryAt(ctx context.Context) (time.Time, error)
+	// LastDelivery returns the time and event type of the most recent stored
+	// delivery so restart seeding can restore both diagnostics, not just the time.
+	LastDelivery(ctx context.Context) (time.Time, string, error)
 }
 
 // Ingestor is the HTTP handler that authenticates, deduplicates and persists
@@ -95,7 +99,7 @@ func (in *Ingestor) seed(ctx context.Context) {
 		log.Printf("[webhook] seed per-event counts failed: %v", err)
 		byType = nil
 	}
-	last, err := in.store.LastDeliveryAt(ctx)
+	last, lastEvent, err := in.store.LastDelivery(ctx)
 	if err != nil {
 		log.Printf("[webhook] seed last-delivery time failed: %v", err)
 	}
@@ -108,6 +112,9 @@ func (in *Ingestor) seed(ctx context.Context) {
 	}
 	if !last.IsZero() {
 		in.lastDeliveryAt = last.UTC()
+		// Restore the event type alongside the time so a restart does not report a
+		// last-delivery timestamp with an empty event type (#824 observability).
+		in.lastEventType = lastEvent
 	}
 }
 
@@ -129,10 +136,21 @@ func (in *Ingestor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	// Read one byte past the cap so an oversize body is DETECTED (not silently
+	// truncated). A truncated body would fail signature validation and be reported
+	// as a bogus 401; reject it up front as 413 so operators see the real cause and
+	// GitHub gets a distinct, non-retryable-as-signature-failure status.
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes+1))
 	if err != nil {
 		in.countBadRequest()
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("read body: %v", err)})
+		return
+	}
+	if int64(len(body)) > maxBodyBytes {
+		in.countBadRequest()
+		log.Printf("[webhook] rejected delivery: payload exceeds %d bytes (event=%q delivery=%q)",
+			maxBodyBytes, r.Header.Get(HeaderEvent), r.Header.Get(HeaderDelivery))
+		writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "payload too large"})
 		return
 	}
 

--- a/internal/webhook/ingest.go
+++ b/internal/webhook/ingest.go
@@ -1,0 +1,283 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/befeast/maestro/internal/webhookstore"
+)
+
+// maxBodyBytes caps the request body the ingestor reads. GitHub documents a
+// 25 MiB maximum webhook payload; anything larger is refused rather than read
+// into memory unbounded. The signature is computed over exactly the bytes read,
+// so a truncated oversize body fails signature validation and is rejected.
+const maxBodyBytes = 25 << 20
+
+// DefaultPath is the endpoint path the fleet daemon serves webhook ingestion on
+// when the operator does not override it. It lives under the existing /api/v1
+// namespace so it shares the fleet server's port (:8786) without a second
+// listener (#824 scope: "HTTP endpoint under the existing fleet daemon, path
+// configurable").
+const DefaultPath = "/api/v1/webhooks/github"
+
+// Store is the persistence surface the Ingestor needs. *webhookstore.Store
+// satisfies it; the interface keeps the handler testable with an in-memory fake
+// and documents exactly the store methods ingestion touches.
+type Store interface {
+	Insert(ctx context.Context, d webhookstore.Delivery) (bool, error)
+	Count(ctx context.Context) (int, error)
+	CountsByEventType(ctx context.Context) (map[string]int, error)
+	LastDeliveryAt(ctx context.Context) (time.Time, error)
+}
+
+// Ingestor is the HTTP handler that authenticates, deduplicates and persists
+// inbound GitHub webhook deliveries. It is safe for concurrent use: the store
+// serialises writes through a single SQLite connection, and the in-memory
+// observability counters are guarded by a mutex, so the endpoint keeps working
+// while the daemon is under normal fleet load (#824 acceptance).
+type Ingestor struct {
+	store  Store
+	secret string
+	now    func() time.Time
+
+	mu sync.Mutex
+	// Session counters. accepted/duplicates/byEventType are seeded from the
+	// durable store on construction so a daemon restart reports the persisted
+	// totals, not zero; signatureFailures and badRequests are transient
+	// per-process (an unstored, unauthenticated delivery has nothing durable to
+	// count). lastDeliveryAt tracks the most recent accepted or duplicate
+	// delivery for the "last webhook delivery time" diagnostic (#824 AC 5/10).
+	accepted          int64
+	duplicates        int64
+	signatureFailures int64
+	badRequests       int64
+	byEventType       map[string]int64
+	lastDeliveryAt    time.Time
+	lastEventType     string
+}
+
+// NewIngestor builds an Ingestor over store with the given webhook secret and
+// seeds its counters from the durable store so observability survives a restart.
+// A seed failure is non-fatal (counters simply start from zero) — the endpoint
+// must come up even if the initial reconcile query hiccups.
+func NewIngestor(store Store, secret string) *Ingestor {
+	in := &Ingestor{
+		store:       store,
+		secret:      strings.TrimSpace(secret),
+		now:         func() time.Time { return time.Now().UTC() },
+		byEventType: make(map[string]int64),
+	}
+	in.seed(context.Background())
+	return in
+}
+
+// seed loads durable totals from the store into the in-memory counters so a
+// restart does not reset the "total deliveries" and per-event-type diagnostics.
+func (in *Ingestor) seed(ctx context.Context) {
+	if in.store == nil {
+		return
+	}
+	total, err := in.store.Count(ctx)
+	if err != nil {
+		log.Printf("[webhook] seed delivery count failed (starting counters from zero): %v", err)
+		return
+	}
+	byType, err := in.store.CountsByEventType(ctx)
+	if err != nil {
+		log.Printf("[webhook] seed per-event counts failed: %v", err)
+		byType = nil
+	}
+	last, err := in.store.LastDeliveryAt(ctx)
+	if err != nil {
+		log.Printf("[webhook] seed last-delivery time failed: %v", err)
+	}
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	in.accepted = int64(total)
+	in.byEventType = make(map[string]int64, len(byType))
+	for k, v := range byType {
+		in.byEventType[k] = int64(v)
+	}
+	if !last.IsZero() {
+		in.lastDeliveryAt = last.UTC()
+	}
+}
+
+// SecretConfigured reports whether the ingestor has a webhook secret. Without
+// one every delivery fails signature validation (fail-closed), so the daemon
+// logs a loud warning rather than silently accepting nothing.
+func (in *Ingestor) SecretConfigured() bool {
+	return in != nil && in.secret != ""
+}
+
+// ServeHTTP handles POST <path>: validate signature, dedupe on
+// X-GitHub-Delivery, persist. The ordering is deliberate — signature validation
+// fires BEFORE the body is parsed or stored, so an invalid-signature delivery is
+// counted and rejected with 401 without ever touching the store (#824 AC:
+// "Invalid signature → 401, counted, payload not stored").
+func (in *Ingestor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	if err != nil {
+		in.countBadRequest()
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("read body: %v", err)})
+		return
+	}
+
+	// Signature first: an attacker on the LAN must not be able to enumerate
+	// delivery-id state or plant payloads. Fail closed on any mismatch.
+	sig := r.Header.Get(HeaderSignature)
+	if !VerifySignature(in.secret, body, sig) {
+		in.countSignatureFailure()
+		log.Printf("[webhook] rejected delivery: invalid or missing %s (event=%q delivery=%q)",
+			HeaderSignature, r.Header.Get(HeaderEvent), r.Header.Get(HeaderDelivery))
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid signature"})
+		return
+	}
+
+	deliveryID := strings.TrimSpace(r.Header.Get(HeaderDelivery))
+	if deliveryID == "" {
+		in.countBadRequest()
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": HeaderDelivery + " header is required"})
+		return
+	}
+	eventType := strings.TrimSpace(r.Header.Get(HeaderEvent))
+
+	env := ParseEnvelope(body)
+	delivery := webhookstore.Delivery{
+		DeliveryID: deliveryID,
+		EventType:  eventType,
+		Action:     env.Action,
+		Repo:       env.Repo,
+		Sender:     env.Sender,
+		HookID:     strings.TrimSpace(r.Header.Get(HeaderHookID)),
+		ReceivedAt: in.now(),
+		Payload:    body,
+	}
+
+	stored, err := in.store.Insert(r.Context(), delivery)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("store delivery: %v", err)})
+		return
+	}
+
+	if !stored {
+		// Redelivery of an already-stored X-GitHub-Delivery. Ack with 200 and no
+		// side effect so GitHub stops retrying (#824 AC: "replaying the same
+		// X-GitHub-Delivery does not duplicate").
+		in.countDuplicate(eventType, delivery.ReceivedAt)
+		writeJSON(w, http.StatusOK, map[string]string{
+			"status":      "duplicate",
+			"delivery_id": deliveryID,
+			"event":       eventType,
+		})
+		return
+	}
+
+	in.countAccepted(eventType, delivery.ReceivedAt)
+	// One journal line per accepted delivery gives the "last webhook delivery
+	// time and counts" diagnostic straight from journalctl (#824 AC 10). The
+	// payload itself is never logged.
+	log.Printf("[webhook] stored delivery event=%q action=%q repo=%q delivery=%s",
+		eventType, env.Action, env.Repo, deliveryID)
+	writeJSON(w, http.StatusAccepted, map[string]string{
+		"status":      "stored",
+		"delivery_id": deliveryID,
+		"event":       eventType,
+	})
+}
+
+func (in *Ingestor) countSignatureFailure() {
+	in.mu.Lock()
+	in.signatureFailures++
+	in.mu.Unlock()
+}
+
+func (in *Ingestor) countBadRequest() {
+	in.mu.Lock()
+	in.badRequests++
+	in.mu.Unlock()
+}
+
+func (in *Ingestor) countAccepted(eventType string, at time.Time) {
+	in.mu.Lock()
+	in.accepted++
+	if in.byEventType == nil {
+		in.byEventType = make(map[string]int64)
+	}
+	in.byEventType[eventType]++
+	in.lastDeliveryAt = at.UTC()
+	in.lastEventType = eventType
+	in.mu.Unlock()
+}
+
+func (in *Ingestor) countDuplicate(eventType string, at time.Time) {
+	in.mu.Lock()
+	in.duplicates++
+	in.lastDeliveryAt = at.UTC()
+	in.lastEventType = eventType
+	in.mu.Unlock()
+}
+
+// Stats is the observability snapshot surfaced to diagnostics (fleet API and
+// journal). All counts are cumulative for the process except Accepted /
+// ByEventType, which are seeded from the durable store so they reflect the
+// persisted total across restarts.
+type Stats struct {
+	LastDeliveryAt    time.Time
+	LastEventType     string
+	Accepted          int64
+	Duplicates        int64
+	SignatureFailures int64
+	BadRequests       int64
+	ByEventType       map[string]int64
+}
+
+// Stats returns a snapshot of the observability counters.
+func (in *Ingestor) Stats() Stats {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	byType := make(map[string]int64, len(in.byEventType))
+	for k, v := range in.byEventType {
+		byType[k] = v
+	}
+	return Stats{
+		LastDeliveryAt:    in.lastDeliveryAt,
+		LastEventType:     in.lastEventType,
+		Accepted:          in.accepted,
+		Duplicates:        in.duplicates,
+		SignatureFailures: in.signatureFailures,
+		BadRequests:       in.badRequests,
+		ByEventType:       byType,
+	}
+}
+
+// SortedEventTypes returns the event types in a deterministic order, for callers
+// that render the per-event-type counters.
+func (s Stats) SortedEventTypes() []string {
+	types := make([]string, 0, len(s.ByEventType))
+	for k := range s.ByEventType {
+		types = append(types, k)
+	}
+	sort.Strings(types)
+	return types
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	// Best-effort; a broken client connection is not actionable here.
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/webhook/ingest_test.go
+++ b/internal/webhook/ingest_test.go
@@ -1,0 +1,221 @@
+package webhook
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/webhookstore"
+)
+
+const testSecret = "webhook-shared-secret"
+
+func newTestIngestor(t *testing.T) (*Ingestor, *webhookstore.Store) {
+	t.Helper()
+	db := filepath.Join(t.TempDir(), "maestro.db")
+	store, err := webhookstore.Open(db)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return NewIngestor(store, testSecret), store
+}
+
+// signedRequest builds a POST with a valid (or, when sign=false, a bogus)
+// GitHub signature over body.
+func signedRequest(t *testing.T, path, event, delivery string, body []byte, sign bool) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set(HeaderEvent, event)
+	req.Header.Set(HeaderDelivery, delivery)
+	req.Header.Set(HeaderHookID, "42")
+	if sign {
+		req.Header.Set(HeaderSignature, Sign(testSecret, body))
+	} else {
+		req.Header.Set(HeaderSignature, Sign("wrong-secret", body))
+	}
+	return req
+}
+
+func TestIngestValidStoredOnce(t *testing.T) {
+	in, store := newTestIngestor(t)
+	body := readFixture(t, "issues_opened.json")
+
+	rec := httptest.NewRecorder()
+	in.ServeHTTP(rec, signedRequest(t, DefaultPath, "issues", "del-1", body, true))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("valid delivery: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, ok, err := store.Get(context.Background(), "del-1")
+	if err != nil || !ok {
+		t.Fatalf("delivery not stored: ok=%v err=%v", ok, err)
+	}
+	if got.EventType != "issues" || got.Action != "opened" || got.Repo != "BeFeast/maestro" {
+		t.Fatalf("envelope not denormalised: %+v", got)
+	}
+	if string(got.Payload) != string(body) {
+		t.Fatal("raw payload not stored verbatim")
+	}
+
+	stats := in.Stats()
+	if stats.Accepted != 1 || stats.ByEventType["issues"] != 1 {
+		t.Fatalf("counters after one delivery: %+v", stats)
+	}
+	if stats.LastDeliveryAt.IsZero() {
+		t.Fatal("last delivery time not recorded")
+	}
+}
+
+func TestIngestReplayIsNoOp(t *testing.T) {
+	in, store := newTestIngestor(t)
+	body := readFixture(t, "issues_opened.json")
+
+	first := httptest.NewRecorder()
+	in.ServeHTTP(first, signedRequest(t, DefaultPath, "issues", "dup-1", body, true))
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first delivery status=%d", first.Code)
+	}
+
+	// Replaying the same X-GitHub-Delivery must ack (200) without duplicating.
+	replay := httptest.NewRecorder()
+	in.ServeHTTP(replay, signedRequest(t, DefaultPath, "issues", "dup-1", body, true))
+	if replay.Code != http.StatusOK {
+		t.Fatalf("replay status=%d body=%s", replay.Code, replay.Body.String())
+	}
+	if !strings.Contains(replay.Body.String(), "duplicate") {
+		t.Fatalf("replay body should note duplicate: %s", replay.Body.String())
+	}
+
+	n, err := store.Count(context.Background())
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("replay duplicated a delivery: count=%d", n)
+	}
+	stats := in.Stats()
+	if stats.Accepted != 1 || stats.Duplicates != 1 {
+		t.Fatalf("want accepted=1 duplicates=1, got %+v", stats)
+	}
+}
+
+func TestIngestInvalidSignatureRejectedAndNotStored(t *testing.T) {
+	in, store := newTestIngestor(t)
+	body := readFixture(t, "issues_opened.json")
+
+	rec := httptest.NewRecorder()
+	in.ServeHTTP(rec, signedRequest(t, DefaultPath, "issues", "bad-sig", body, false))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("invalid signature: status=%d want 401", rec.Code)
+	}
+
+	if _, ok, _ := store.Get(context.Background(), "bad-sig"); ok {
+		t.Fatal("payload was stored despite invalid signature")
+	}
+	n, _ := store.Count(context.Background())
+	if n != 0 {
+		t.Fatalf("store should be empty after rejected delivery, count=%d", n)
+	}
+	if stats := in.Stats(); stats.SignatureFailures != 1 {
+		t.Fatalf("signature failure not counted: %+v", stats)
+	}
+}
+
+func TestIngestMissingDeliveryID(t *testing.T) {
+	in, _ := newTestIngestor(t)
+	body := readFixture(t, "issues_opened.json")
+	req := signedRequest(t, DefaultPath, "issues", "", body, true)
+	req.Header.Del(HeaderDelivery)
+	rec := httptest.NewRecorder()
+	in.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing delivery id: status=%d want 400", rec.Code)
+	}
+}
+
+func TestIngestMethodNotAllowed(t *testing.T) {
+	in, _ := newTestIngestor(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, DefaultPath, nil)
+	in.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET: status=%d want 405", rec.Code)
+	}
+}
+
+// TestIngestEventTypeRouting drives one delivery of each fixture event type and
+// asserts the per-event-type counters route correctly (#824 AC: event-type
+// routing; integration test with sample GitHub payload fixtures).
+func TestIngestEventTypeRouting(t *testing.T) {
+	in, store := newTestIngestor(t)
+	fixtures := []struct {
+		event   string
+		file    string
+		action  string
+		delivID string
+	}{
+		{"issues", "issues_opened.json", "opened", "r-1"},
+		{"pull_request", "pull_request_synchronize.json", "synchronize", "r-2"},
+		{"check_run", "check_run_completed.json", "completed", "r-3"},
+	}
+	for _, f := range fixtures {
+		body := readFixture(t, f.file)
+		rec := httptest.NewRecorder()
+		in.ServeHTTP(rec, signedRequest(t, DefaultPath, f.event, f.delivID, body, true))
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("%s: status=%d", f.event, rec.Code)
+		}
+		got, ok, err := store.Get(context.Background(), f.delivID)
+		if err != nil || !ok {
+			t.Fatalf("%s not stored: ok=%v err=%v", f.event, ok, err)
+		}
+		if got.Action != f.action {
+			t.Fatalf("%s action=%q want %q", f.event, got.Action, f.action)
+		}
+	}
+
+	stats := in.Stats()
+	for _, f := range fixtures {
+		if stats.ByEventType[f.event] != 1 {
+			t.Fatalf("event %q counter=%d want 1 (stats=%+v)", f.event, stats.ByEventType[f.event], stats)
+		}
+	}
+	if stats.Accepted != 3 {
+		t.Fatalf("accepted=%d want 3", stats.Accepted)
+	}
+}
+
+// TestSeedFromDurableStore proves a fresh ingestor over a store that already
+// holds deliveries reports the persisted totals — the "restart does not lose
+// acknowledged deliveries" observability (#824 AC).
+func TestSeedFromDurableStore(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "maestro.db")
+	store, err := webhookstore.Open(db)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+
+	// Land two deliveries directly, then build a new ingestor as if the daemon
+	// restarted.
+	for _, id := range []string{"seed-a", "seed-b"} {
+		if _, err := store.Insert(context.Background(), webhookstore.Delivery{
+			DeliveryID: id, EventType: "issues", Payload: []byte("{}"),
+		}); err != nil {
+			t.Fatalf("seed insert: %v", err)
+		}
+	}
+
+	in := NewIngestor(store, testSecret)
+	stats := in.Stats()
+	if stats.Accepted != 2 {
+		t.Fatalf("seeded accepted=%d want 2", stats.Accepted)
+	}
+	if stats.ByEventType["issues"] != 2 {
+		t.Fatalf("seeded per-event=%d want 2", stats.ByEventType["issues"])
+	}
+}

--- a/internal/webhook/ingest_test.go
+++ b/internal/webhook/ingest_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -137,6 +138,32 @@ func TestIngestMissingDeliveryID(t *testing.T) {
 	}
 }
 
+// TestIngestOversizePayloadRejected proves an oversize body is rejected as 413
+// (payload too large) BEFORE signature validation — not silently truncated and
+// then surfaced as a misleading 401 invalid signature. The signature here is
+// valid over the full body, so a 401 would mean the size check ran too late.
+func TestIngestOversizePayloadRejected(t *testing.T) {
+	in, store := newTestIngestor(t)
+	body := bytes.Repeat([]byte("a"), maxBodyBytes+1)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, DefaultPath, bytes.NewReader(body))
+	req.Header.Set(HeaderEvent, "issues")
+	req.Header.Set(HeaderDelivery, "too-big")
+	req.Header.Set(HeaderSignature, Sign(testSecret, body))
+	in.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize payload: status=%d want 413 body=%s", rec.Code, rec.Body.String())
+	}
+	if _, ok, _ := store.Get(context.Background(), "too-big"); ok {
+		t.Fatal("oversize payload should not be stored")
+	}
+	if stats := in.Stats(); stats.SignatureFailures != 0 {
+		t.Fatalf("oversize should not count as a signature failure: %+v", stats)
+	}
+}
+
 func TestIngestMethodNotAllowed(t *testing.T) {
 	in, _ := newTestIngestor(t)
 	rec := httptest.NewRecorder()
@@ -217,5 +244,13 @@ func TestSeedFromDurableStore(t *testing.T) {
 	}
 	if stats.ByEventType["issues"] != 2 {
 		t.Fatalf("seeded per-event=%d want 2", stats.ByEventType["issues"])
+	}
+	// A restart must restore BOTH the last-delivery time and its event type — a
+	// non-zero time with an empty event type is the bug this guards.
+	if stats.LastDeliveryAt.IsZero() {
+		t.Fatal("seeded last delivery time not restored")
+	}
+	if stats.LastEventType != "issues" {
+		t.Fatalf("seeded last event type=%q want issues", stats.LastEventType)
 	}
 }

--- a/internal/webhook/testdata/check_run_completed.json
+++ b/internal/webhook/testdata/check_run_completed.json
@@ -1,0 +1,17 @@
+{
+  "action": "completed",
+  "check_run": {
+    "id": 987654321,
+    "name": "go test ./...",
+    "status": "completed",
+    "conclusion": "success",
+    "head_sha": "0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e"
+  },
+  "repository": {
+    "full_name": "BeFeast/maestro",
+    "name": "maestro"
+  },
+  "sender": {
+    "login": "github-actions[bot]"
+  }
+}

--- a/internal/webhook/testdata/issues_opened.json
+++ b/internal/webhook/testdata/issues_opened.json
@@ -1,0 +1,19 @@
+{
+  "action": "opened",
+  "issue": {
+    "number": 824,
+    "title": "Webhook ingestion into the unified SQLite store",
+    "state": "open",
+    "labels": [
+      { "name": "maestro-ready" }
+    ]
+  },
+  "repository": {
+    "full_name": "BeFeast/maestro",
+    "name": "maestro",
+    "private": true
+  },
+  "sender": {
+    "login": "octocat"
+  }
+}

--- a/internal/webhook/testdata/pull_request_synchronize.json
+++ b/internal/webhook/testdata/pull_request_synchronize.json
@@ -1,0 +1,19 @@
+{
+  "action": "synchronize",
+  "number": 828,
+  "pull_request": {
+    "number": 828,
+    "state": "open",
+    "title": "GitHub App auth path with PAT fallback",
+    "merged": false,
+    "head": { "sha": "0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e" },
+    "base": { "ref": "main" }
+  },
+  "repository": {
+    "full_name": "BeFeast/maestro",
+    "name": "maestro"
+  },
+  "sender": {
+    "login": "octocat"
+  }
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,0 +1,140 @@
+// Package webhook implements the fleet daemon's inbound GitHub webhook
+// ingestion (epic #811, phase B — issue #824): HMAC-SHA256 signature
+// validation, envelope parsing, and an idempotent HTTP handler that lands every
+// valid delivery in the shared maestro.db via internal/webhookstore.
+//
+// This is ingestion only. Nothing here mutates orchestration state or joins the
+// stored deliveries into the read path — that is phase C/D. The handler's job
+// is to authenticate a delivery by signature, key it by X-GitHub-Delivery for
+// idempotency, and persist it durably so a later phase can consume it and the
+// fleet stops polling GitHub for the same state.
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+)
+
+// GitHub delivery header names. Canonicalised (net/http canonicalises header
+// keys), so callers read them via http.Header.Get with these exact strings.
+const (
+	HeaderEvent     = "X-GitHub-Event"
+	HeaderDelivery  = "X-GitHub-Delivery"
+	HeaderSignature = "X-Hub-Signature-256"
+	HeaderHookID    = "X-GitHub-Hook-ID"
+)
+
+// signaturePrefix is the algorithm tag GitHub prepends to the hex digest in the
+// X-Hub-Signature-256 header ("sha256=<hexdigest>"). The older X-Hub-Signature
+// (sha1) header is intentionally NOT accepted — GitHub recommends validating
+// the sha256 variant exclusively.
+const signaturePrefix = "sha256="
+
+// SupportedEvents is the set of GitHub event types this phase captures (#824
+// scope: issues, labels, issue comments, pull requests, PR reviews / review
+// comments, check runs / suites, statuses, and Projects v2 item events). "ping"
+// is included so the delivery GitHub sends when a webhook is first created is
+// acknowledged rather than 400'd. A valid-signature delivery of any OTHER event
+// type is still stored (Supported gates only observability/routing labels, never
+// whether a signed delivery is persisted) so no acknowledged event is lost.
+var SupportedEvents = map[string]bool{
+	"ping":                        true,
+	"issues":                      true,
+	"label":                       true,
+	"issue_comment":               true,
+	"pull_request":                true,
+	"pull_request_review":         true,
+	"pull_request_review_comment": true,
+	"check_run":                   true,
+	"check_suite":                 true,
+	"status":                      true,
+	"projects_v2_item":            true,
+}
+
+// Supported reports whether eventType is in the phase-B captured set. It labels
+// observability and routing; it does NOT gate persistence — the ingestor stores
+// every valid-signature delivery so a not-yet-modelled event type is never
+// dropped on the floor.
+func Supported(eventType string) bool {
+	return SupportedEvents[strings.TrimSpace(eventType)]
+}
+
+// VerifySignature reports whether sigHeader is a valid HMAC-SHA256 signature of
+// body under secret. sigHeader is the raw X-Hub-Signature-256 value
+// ("sha256=<hexdigest>"). The comparison is constant-time (hmac.Equal) so a
+// caller cannot time-probe the expected digest, and an empty secret or a
+// malformed / missing header always fails closed — an unsigned or
+// wrongly-signed delivery is never accepted.
+func VerifySignature(secret string, body []byte, sigHeader string) bool {
+	if secret == "" {
+		return false
+	}
+	sigHeader = strings.TrimSpace(sigHeader)
+	if !strings.HasPrefix(sigHeader, signaturePrefix) {
+		return false
+	}
+	presented := strings.TrimPrefix(sigHeader, signaturePrefix)
+	// Decode the presented hex first so hmac.Equal compares raw bytes, not the
+	// hex encodings (which differ in length for an invalid header and would let
+	// ConstantTimeCompare short-circuit on length).
+	presentedMAC, err := hex.DecodeString(presented)
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expectedMAC := mac.Sum(nil)
+	return hmac.Equal(presentedMAC, expectedMAC)
+}
+
+// Sign returns the X-Hub-Signature-256 header value GitHub would send for body
+// under secret. Used by tests (and any operator diagnostic) to produce a valid
+// signature; the ingestion path only ever verifies.
+func Sign(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return signaturePrefix + hex.EncodeToString(mac.Sum(nil))
+}
+
+// Envelope holds the common fields extracted from a webhook payload for
+// indexing and observability. Every GitHub event payload is a JSON object; the
+// fields below are present on most event types (repository/sender on all
+// repo-scoped events, action on the action-carrying ones). Missing fields
+// simply stay empty — parsing never fails the ingestion, since the raw payload
+// is stored verbatim regardless.
+type Envelope struct {
+	Action string
+	Repo   string
+	Sender string
+}
+
+// envelopeShape is the minimal subset of a GitHub webhook payload the ingestor
+// denormalises into indexed columns.
+type envelopeShape struct {
+	Action     string `json:"action"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	Sender struct {
+		Login string `json:"login"`
+	} `json:"sender"`
+}
+
+// ParseEnvelope extracts the indexed envelope fields from a raw payload. A body
+// that is not a JSON object (or is empty) yields a zero Envelope with no error:
+// the raw bytes are still stored, so a malformed or unusual payload degrades to
+// "stored, just not denormalised" rather than a rejected delivery.
+func ParseEnvelope(body []byte) Envelope {
+	var shape envelopeShape
+	if err := json.Unmarshal(body, &shape); err != nil {
+		return Envelope{}
+	}
+	return Envelope{
+		Action: strings.TrimSpace(shape.Action),
+		Repo:   strings.TrimSpace(shape.Repository.FullName),
+		Sender: strings.TrimSpace(shape.Sender.Login),
+	}
+}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -1,0 +1,80 @@
+package webhook
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVerifySignature(t *testing.T) {
+	secret := "s3cr3t"
+	body := []byte(`{"action":"opened"}`)
+	valid := Sign(secret, body)
+
+	cases := []struct {
+		name   string
+		secret string
+		body   []byte
+		sig    string
+		want   bool
+	}{
+		{"valid", secret, body, valid, true},
+		{"wrong secret", "other", body, valid, false},
+		{"tampered body", secret, []byte(`{"action":"closed"}`), valid, false},
+		{"missing prefix", secret, body, "abcdef", false},
+		{"empty header", secret, body, "", false},
+		{"empty secret fails closed", "", body, valid, false},
+		{"non-hex digest", secret, body, "sha256=zzzz", false},
+		{"sha1 header rejected", secret, body, "sha1=" + valid[len("sha256="):], false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := VerifySignature(tc.secret, tc.body, tc.sig); got != tc.want {
+				t.Fatalf("VerifySignature=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseEnvelope(t *testing.T) {
+	body := readFixture(t, "issues_opened.json")
+	env := ParseEnvelope(body)
+	if env.Action != "opened" {
+		t.Fatalf("action=%q", env.Action)
+	}
+	if env.Repo != "BeFeast/maestro" {
+		t.Fatalf("repo=%q", env.Repo)
+	}
+	if env.Sender != "octocat" {
+		t.Fatalf("sender=%q", env.Sender)
+	}
+}
+
+func TestParseEnvelopeMalformedIsEmptyNotError(t *testing.T) {
+	// A non-JSON body must not panic or block ingestion — the raw payload is
+	// stored regardless; only the denormalised envelope is empty.
+	env := ParseEnvelope([]byte("not json at all"))
+	if env != (Envelope{}) {
+		t.Fatalf("want zero envelope for malformed body, got %+v", env)
+	}
+}
+
+func TestSupported(t *testing.T) {
+	for _, ev := range []string{"issues", "label", "issue_comment", "pull_request", "pull_request_review", "pull_request_review_comment", "check_run", "check_suite", "status", "projects_v2_item", "ping"} {
+		if !Supported(ev) {
+			t.Errorf("event %q should be supported", ev)
+		}
+	}
+	if Supported("deployment") {
+		t.Error("deployment should not be in the phase-B supported set")
+	}
+}
+
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return data
+}

--- a/internal/webhookstore/store.go
+++ b/internal/webhookstore/store.go
@@ -1,0 +1,228 @@
+// Package webhookstore persists inbound GitHub webhook deliveries in the SAME
+// shared maestro.db that internal/approvalstore and internal/statestore already
+// use (epic #811, phase B — issue #824). It is the durable landing zone for the
+// fleet daemon's webhook ingestion endpoint: instead of polling GitHub for
+// issue / PR / check / review / label state, the daemon accepts signed webhook
+// deliveries and lands the raw payload plus a parsed envelope here, idempotently.
+//
+// Idempotency is keyed on the delivery's X-GitHub-Delivery UUID, which GitHub
+// guarantees is stable across redeliveries of the same event. The row is the
+// primary key, so a redelivery (GitHub retries on any non-2xx, and an operator
+// can replay from the repo's webhook settings) is a no-op INSERT rather than a
+// duplicate row — Insert reports stored=false for it so the caller can 200 the
+// redelivery without side effects.
+//
+// This is ingestion only (phase B). No read-path consumer joins these rows into
+// the orchestration state yet; that is phase C/D. The table therefore carries
+// the raw payload verbatim so a later phase can re-parse whatever it needs
+// without a schema migration, plus a small set of denormalised envelope columns
+// (event type, action, repo, sender) so observability and routing questions are
+// one indexed query.
+package webhookstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// Schema creates the webhook_deliveries table. IF NOT EXISTS so Init is
+// idempotent and safe to run against the same maestro.db approvalstore /
+// statestore initialise (each package owns disjoint tables in one file). The
+// delivery_id primary key is what makes a redelivery a no-op.
+const Schema = `
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+	delivery_id TEXT PRIMARY KEY,
+	event_type  TEXT NOT NULL DEFAULT '',
+	action      TEXT NOT NULL DEFAULT '',
+	repo        TEXT NOT NULL DEFAULT '',
+	sender      TEXT NOT NULL DEFAULT '',
+	hook_id     TEXT NOT NULL DEFAULT '',
+	received_at TEXT NOT NULL DEFAULT '',
+	payload     TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_event ON webhook_deliveries(event_type);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_received ON webhook_deliveries(received_at);
+`
+
+// Delivery is one ingested GitHub webhook delivery. Payload is the raw request
+// body verbatim (the signed bytes), so a later read-path phase can re-parse it
+// without depending on the denormalised columns.
+type Delivery struct {
+	DeliveryID string    // X-GitHub-Delivery UUID (idempotency key)
+	EventType  string    // X-GitHub-Event (issues, pull_request, check_run, …)
+	Action     string    // parsed envelope "action" (opened, labeled, completed, …)
+	Repo       string    // parsed repository.full_name
+	Sender     string    // parsed sender.login
+	HookID     string    // X-GitHub-Hook-ID (the webhook that delivered it)
+	ReceivedAt time.Time // when the daemon accepted it
+	Payload    []byte    // raw request body
+}
+
+// Store is a SQLite-backed store for inbound webhook deliveries.
+type Store struct {
+	db *sql.DB
+}
+
+// DefaultDBPath is the shared database (~/.maestro/maestro.db) — the same file
+// approvalstore and statestore use. A single file holds every project's state;
+// webhook deliveries live in their own table.
+func DefaultDBPath() string {
+	return filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.db")
+}
+
+// Open opens (creating the parent dir if needed) the database and ensures the
+// schema. The pragmas mirror internal/statestore: busy_timeout lets a
+// connection wait for a lock instead of erroring "database is locked", WAL lets
+// a reader and a writer proceed concurrently (and is what makes an acknowledged
+// delivery durable across a daemon restart — #824 acceptance), and
+// MaxOpenConns(1) removes the SQLITE_BUSY modernc/sqlite can report between two
+// pooled connections of the same process.
+func Open(path string) (*Store, error) {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("create webhook db dir %s: %w", dir, err)
+		}
+	}
+	dsn := path
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	dsn += sep + "_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	s := &Store{db: db}
+	if err := s.Init(context.Background()); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+// Close releases the underlying database handle.
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// Init creates the schema. Idempotent.
+func (s *Store) Init(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, Schema)
+	return err
+}
+
+// Insert stores a delivery idempotently and reports whether the row was newly
+// written. A delivery whose DeliveryID already exists is a no-op — INSERT OR
+// IGNORE leaves the original row untouched and returns stored=false, so the
+// caller can acknowledge a GitHub redelivery with 200 without any duplicate
+// side effect (#824 acceptance: "replaying the same X-GitHub-Delivery does not
+// duplicate").
+//
+// DeliveryID is required; GitHub always sets X-GitHub-Delivery, and a blank one
+// would collapse every unkeyed delivery onto one row.
+func (s *Store) Insert(ctx context.Context, d Delivery) (stored bool, err error) {
+	if strings.TrimSpace(d.DeliveryID) == "" {
+		return false, fmt.Errorf("delivery_id is required")
+	}
+	received := d.ReceivedAt
+	if received.IsZero() {
+		received = time.Now().UTC()
+	}
+	res, err := s.db.ExecContext(ctx, `
+INSERT OR IGNORE INTO webhook_deliveries(delivery_id, event_type, action, repo, sender, hook_id, received_at, payload)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?)`,
+		d.DeliveryID, d.EventType, d.Action, d.Repo, d.Sender, d.HookID,
+		received.UTC().Format(time.RFC3339Nano), string(d.Payload))
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// Count returns the total number of stored deliveries.
+func (s *Store) Count(ctx context.Context) (int, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM webhook_deliveries`).Scan(&n)
+	return n, err
+}
+
+// CountsByEventType returns the per-event-type delivery counts, keyed by
+// X-GitHub-Event. Empty map when nothing has been ingested.
+func (s *Store) CountsByEventType(ctx context.Context) (map[string]int, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT event_type, COUNT(*) FROM webhook_deliveries GROUP BY event_type`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]int)
+	for rows.Next() {
+		var event string
+		var n int
+		if err := rows.Scan(&event, &n); err != nil {
+			return nil, err
+		}
+		out[event] = n
+	}
+	return out, rows.Err()
+}
+
+// LastDeliveryAt returns the most recent received_at across all stored
+// deliveries, or the zero time when the store is empty.
+func (s *Store) LastDeliveryAt(ctx context.Context) (time.Time, error) {
+	var raw sql.NullString
+	if err := s.db.QueryRowContext(ctx, `SELECT MAX(received_at) FROM webhook_deliveries`).Scan(&raw); err != nil {
+		return time.Time{}, err
+	}
+	if !raw.Valid || strings.TrimSpace(raw.String) == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, raw.String)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse received_at %q: %w", raw.String, err)
+	}
+	return t, nil
+}
+
+// Get returns the stored delivery for id, or ok=false when none exists. Used by
+// tests to assert the raw payload and envelope landed intact.
+func (s *Store) Get(ctx context.Context, id string) (Delivery, bool, error) {
+	var (
+		d       Delivery
+		payload string
+		recv    string
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT delivery_id, event_type, action, repo, sender, hook_id, received_at, payload
+FROM webhook_deliveries WHERE delivery_id = ?`, id).
+		Scan(&d.DeliveryID, &d.EventType, &d.Action, &d.Repo, &d.Sender, &d.HookID, &recv, &payload)
+	if err == sql.ErrNoRows {
+		return Delivery{}, false, nil
+	}
+	if err != nil {
+		return Delivery{}, false, err
+	}
+	d.Payload = []byte(payload)
+	if strings.TrimSpace(recv) != "" {
+		if t, perr := time.Parse(time.RFC3339Nano, recv); perr == nil {
+			d.ReceivedAt = t
+		}
+	}
+	return d, true, nil
+}

--- a/internal/webhookstore/store.go
+++ b/internal/webhookstore/store.go
@@ -52,6 +52,15 @@ CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_event ON webhook_deliveries(ev
 CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_received ON webhook_deliveries(received_at);
 `
 
+// receivedAtLayout is a FIXED-WIDTH, UTC, nanosecond-precision timestamp layout.
+// received_at is stored as TEXT and read back with MAX()/ORDER BY, so its lexical
+// order must equal its chronological order. time.RFC3339Nano would trim trailing
+// zeros from the fractional seconds (".1234Z" vs ".123Z"), making shorter strings
+// sort AFTER longer ones and letting a webhook burst report an older delivery as
+// the latest. Padding to a constant nine fractional digits (and always emitting
+// "Z" for UTC) keeps the field a constant width, so byte-order == time-order.
+const receivedAtLayout = "2006-01-02T15:04:05.000000000Z07:00"
+
 // Delivery is one ingested GitHub webhook delivery. Payload is the raw request
 // body verbatim (the signed bytes), so a later read-path phase can re-parse it
 // without depending on the denormalised columns.
@@ -145,7 +154,7 @@ func (s *Store) Insert(ctx context.Context, d Delivery) (stored bool, err error)
 INSERT OR IGNORE INTO webhook_deliveries(delivery_id, event_type, action, repo, sender, hook_id, received_at, payload)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?)`,
 		d.DeliveryID, d.EventType, d.Action, d.Repo, d.Sender, d.HookID,
-		received.UTC().Format(time.RFC3339Nano), string(d.Payload))
+		received.UTC().Format(receivedAtLayout), string(d.Payload))
 	if err != nil {
 		return false, err
 	}
@@ -198,6 +207,36 @@ func (s *Store) LastDeliveryAt(ctx context.Context) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("parse received_at %q: %w", raw.String, err)
 	}
 	return t, nil
+}
+
+// LastDelivery returns the received_at time AND the event_type of the most recent
+// stored delivery, or (zero time, "") when the store is empty. Restart seeding
+// uses this so BOTH the "last delivery time" and "last event type" diagnostics
+// survive a daemon restart — LastDeliveryAt alone would leave the event type
+// blank until the next live webhook (#824 observability). Ordering by received_at
+// is safe because it is stored fixed-width (see receivedAtLayout).
+func (s *Store) LastDelivery(ctx context.Context) (time.Time, string, error) {
+	var (
+		raw   sql.NullString
+		event sql.NullString
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT received_at, event_type FROM webhook_deliveries
+ORDER BY received_at DESC LIMIT 1`).Scan(&raw, &event)
+	if err == sql.ErrNoRows {
+		return time.Time{}, "", nil
+	}
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	if !raw.Valid || strings.TrimSpace(raw.String) == "" {
+		return time.Time{}, event.String, nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, raw.String)
+	if err != nil {
+		return time.Time{}, "", fmt.Errorf("parse received_at %q: %w", raw.String, err)
+	}
+	return t, event.String, nil
 }
 
 // Get returns the stored delivery for id, or ok=false when none exists. Used by

--- a/internal/webhookstore/store_test.go
+++ b/internal/webhookstore/store_test.go
@@ -1,0 +1,156 @@
+package webhookstore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	db := filepath.Join(t.TempDir(), "maestro.db")
+	store, err := Open(db)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func sampleDelivery(id string) Delivery {
+	return Delivery{
+		DeliveryID: id,
+		EventType:  "issues",
+		Action:     "opened",
+		Repo:       "BeFeast/maestro",
+		Sender:     "octocat",
+		HookID:     "42",
+		ReceivedAt: time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC),
+		Payload:    []byte(`{"action":"opened"}`),
+	}
+}
+
+func TestInsertIdempotent(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	stored, err := store.Insert(ctx, sampleDelivery("d-1"))
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if !stored {
+		t.Fatal("first insert should report stored=true")
+	}
+
+	// A redelivery of the same X-GitHub-Delivery must be a no-op that does not
+	// duplicate — even if the payload/envelope differs, the original row wins.
+	dup := sampleDelivery("d-1")
+	dup.Action = "edited"
+	dup.Payload = []byte(`{"action":"edited"}`)
+	stored, err = store.Insert(ctx, dup)
+	if err != nil {
+		t.Fatalf("redelivery insert: %v", err)
+	}
+	if stored {
+		t.Fatal("redelivery should report stored=false")
+	}
+
+	n, err := store.Count(ctx)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("want 1 stored delivery after redelivery, got %d", n)
+	}
+
+	got, ok, err := store.Get(ctx, "d-1")
+	if err != nil || !ok {
+		t.Fatalf("get d-1: ok=%v err=%v", ok, err)
+	}
+	// The original (opened) payload must be preserved, not overwritten by the
+	// redelivery's (edited) body.
+	if got.Action != "opened" {
+		t.Fatalf("original row overwritten by redelivery: action=%q", got.Action)
+	}
+	if string(got.Payload) != `{"action":"opened"}` {
+		t.Fatalf("payload not preserved: %q", got.Payload)
+	}
+}
+
+func TestInsertRequiresDeliveryID(t *testing.T) {
+	store := openTestStore(t)
+	if _, err := store.Insert(context.Background(), sampleDelivery("")); err == nil {
+		t.Fatal("expected error for blank delivery_id")
+	}
+}
+
+func TestCountsByEventTypeAndLastDelivery(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	deliveries := []Delivery{
+		{DeliveryID: "a", EventType: "issues", ReceivedAt: time.Date(2026, 7, 6, 10, 0, 0, 0, time.UTC), Payload: []byte("{}")},
+		{DeliveryID: "b", EventType: "issues", ReceivedAt: time.Date(2026, 7, 6, 11, 0, 0, 0, time.UTC), Payload: []byte("{}")},
+		{DeliveryID: "c", EventType: "pull_request", ReceivedAt: time.Date(2026, 7, 6, 12, 30, 0, 0, time.UTC), Payload: []byte("{}")},
+	}
+	for _, d := range deliveries {
+		if _, err := store.Insert(ctx, d); err != nil {
+			t.Fatalf("insert %s: %v", d.DeliveryID, err)
+		}
+	}
+
+	counts, err := store.CountsByEventType(ctx)
+	if err != nil {
+		t.Fatalf("counts by type: %v", err)
+	}
+	if counts["issues"] != 2 || counts["pull_request"] != 1 {
+		t.Fatalf("unexpected per-event counts: %+v", counts)
+	}
+
+	last, err := store.LastDeliveryAt(ctx)
+	if err != nil {
+		t.Fatalf("last delivery: %v", err)
+	}
+	want := time.Date(2026, 7, 6, 12, 30, 0, 0, time.UTC)
+	if !last.Equal(want) {
+		t.Fatalf("last delivery = %s, want %s", last, want)
+	}
+}
+
+func TestLastDeliveryEmptyStore(t *testing.T) {
+	store := openTestStore(t)
+	last, err := store.LastDeliveryAt(context.Background())
+	if err != nil {
+		t.Fatalf("last delivery on empty store: %v", err)
+	}
+	if !last.IsZero() {
+		t.Fatalf("want zero time on empty store, got %s", last)
+	}
+}
+
+// TestDurabilityAcrossReopen proves an acknowledged delivery survives a store
+// close+reopen (the SQLite WAL durability the #824 restart criterion needs).
+func TestDurabilityAcrossReopen(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "maestro.db")
+	store, err := Open(db)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := store.Insert(context.Background(), sampleDelivery("survive-me")); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, err := Open(db)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+	_, ok, err := reopened.Get(context.Background(), "survive-me")
+	if err != nil || !ok {
+		t.Fatalf("acknowledged delivery lost across reopen: ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/webhookstore/store_test.go
+++ b/internal/webhookstore/store_test.go
@@ -127,6 +127,79 @@ func TestLastDeliveryEmptyStore(t *testing.T) {
 	if !last.IsZero() {
 		t.Fatalf("want zero time on empty store, got %s", last)
 	}
+	lastT, event, err := store.LastDelivery(context.Background())
+	if err != nil {
+		t.Fatalf("LastDelivery on empty store: %v", err)
+	}
+	if !lastT.IsZero() || event != "" {
+		t.Fatalf("want zero time and empty event on empty store, got %s %q", lastT, event)
+	}
+}
+
+// TestLastDeliveryReturnsEventType proves LastDelivery carries the event type of
+// the most recent delivery, which restart seeding needs so the last-event-type
+// diagnostic survives a daemon restart (not just the timestamp).
+func TestLastDeliveryReturnsEventType(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	for _, d := range []Delivery{
+		{DeliveryID: "old", EventType: "issues", ReceivedAt: time.Date(2026, 7, 6, 10, 0, 0, 0, time.UTC), Payload: []byte("{}")},
+		{DeliveryID: "new", EventType: "pull_request", ReceivedAt: time.Date(2026, 7, 6, 11, 0, 0, 0, time.UTC), Payload: []byte("{}")},
+	} {
+		if _, err := store.Insert(ctx, d); err != nil {
+			t.Fatalf("insert %s: %v", d.DeliveryID, err)
+		}
+	}
+	last, event, err := store.LastDelivery(ctx)
+	if err != nil {
+		t.Fatalf("LastDelivery: %v", err)
+	}
+	if event != "pull_request" {
+		t.Fatalf("last event type = %q, want pull_request", event)
+	}
+	if want := time.Date(2026, 7, 6, 11, 0, 0, 0, time.UTC); !last.Equal(want) {
+		t.Fatalf("last delivery time = %s, want %s", last, want)
+	}
+}
+
+// TestReceivedAtFixedWidthOrdering guards the fixed-width timestamp encoding.
+// received_at is TEXT read back with MAX()/ORDER BY, so its byte order must equal
+// its time order. With RFC3339Nano (trailing zeros trimmed) ".123Z" sorts AFTER
+// ".1234Z", so a burst would report an EARLIER delivery as the latest. The
+// deliveries below differ only in the fourth fractional digit within the same
+// second — exactly the case that misorders under trimming.
+func TestReceivedAtFixedWidthOrdering(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	// earlier: .123 (123ms) — trims to ".123Z", which sorts lexically HIGH.
+	// later:   .1234 (123.4ms) — trims to ".1234Z", which sorts lexically LOW.
+	earlier := Delivery{DeliveryID: "earlier", EventType: "issues",
+		ReceivedAt: time.Date(2026, 7, 6, 12, 0, 0, 123000000, time.UTC), Payload: []byte("{}")}
+	later := Delivery{DeliveryID: "later", EventType: "pull_request",
+		ReceivedAt: time.Date(2026, 7, 6, 12, 0, 0, 123400000, time.UTC), Payload: []byte("{}")}
+	// Insert the lexically-high (but chronologically earlier) one last to make sure
+	// insertion order does not paper over the bug.
+	for _, d := range []Delivery{later, earlier} {
+		if _, err := store.Insert(ctx, d); err != nil {
+			t.Fatalf("insert %s: %v", d.DeliveryID, err)
+		}
+	}
+
+	last, err := store.LastDeliveryAt(ctx)
+	if err != nil {
+		t.Fatalf("LastDeliveryAt: %v", err)
+	}
+	if !last.Equal(later.ReceivedAt) {
+		t.Fatalf("LastDeliveryAt = %s, want the chronologically later %s", last, later.ReceivedAt)
+	}
+	_, event, err := store.LastDelivery(ctx)
+	if err != nil {
+		t.Fatalf("LastDelivery: %v", err)
+	}
+	if event != "pull_request" {
+		t.Fatalf("LastDelivery event = %q, want the later delivery's pull_request", event)
+	}
 }
 
 // TestDurabilityAcrossReopen proves an acknowledged delivery survives a store


### PR DESCRIPTION
Implements #824 (epic #811, phase B — ingestion only; no read-path changes, that is phase C/D).

The fleet daemon can now accept inbound GitHub webhook deliveries and land them durably in the shared `~/.maestro/maestro.db`, an alternative to polling for issue / PR / check / review / label state. Default OFF and opt-in via `--webhook-secret-file`.

## Changes
- **`internal/webhookstore`** — SQLite `webhook_deliveries` table keyed by `X-GitHub-Delivery` for idempotent, WAL-durable storage of the raw payload plus a denormalised envelope (event type, action, repo, sender); observability queries (count, per-event-type, last delivery).
- **`internal/webhook`** — constant-time, fail-closed HMAC-SHA256 `X-Hub-Signature-256` validation; envelope parsing; an `Ingestor` HTTP handler: valid delivery stored once (202), replay of the same delivery is a no-op (200 duplicate), invalid signature → 401 and not stored. Counters seeded from the durable store so diagnostics survive a restart.
- **`internal/server` (FleetServer)** — `SetWebhookIngestor` serves the endpoint on the fleet port, routed BEFORE the auth middleware (GitHub authenticates by signature, not the fleet bearer token); a `webhooks` diagnostics block is added to `/api/v1/fleet`.
- **daemon + cmd** — `--webhook-secret-file` / `--webhook-path` / `--webhook-db` flags. The secret is read from disk at startup, never logged, never stored in the config store; any failure disables ingestion with a warning rather than aborting startup.
- **docs** — new webhook ingestion runbook (setup, tunnel config, semantics) + fleet MC runbook cross-link.

## Testing
- `go build ./cmd/maestro/`
- `go test ./...` (all pass)
- `go test -race ./internal/webhook/... ./internal/webhookstore/... ./internal/server/...`
- Unit tests: signature validation, idempotency/redelivery no-op, event-type routing, restart-durability, auth bypass for the signed endpoint, snapshot diagnostics; integration test drives sample GitHub payload fixtures (issues / pull_request / check_run) through the handler.

Refs #824

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opt-in GitHub webhook ingestion to the fleet daemon. The main changes are:

- A signed webhook HTTP endpoint on the fleet port.
- Durable SQLite storage for raw deliveries and parsed envelope fields.
- CLI and daemon wiring for secret file, path, and database options.
- Fleet diagnostics for webhook counts, failures, duplicates, and last delivery state.
- Runbook documentation for setup and operations.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The base harness could not compile initially due to missing internal/webhook packages.
- After changes, the test run produced full HTTP statuses and bodies and persisted store counts for valid, duplicate, and invalid-signature scenarios.
- The persistence scenario now includes the internal/webhookstore package and demonstrates duplicate handling, with dup-1 stored=true on first insert and stored=false on a duplicate, while per-event counts and overall totals remain consistent.
- The fleet webhook route was exercised with signed, unsigned, and authenticated requests, yielding 202 for valid signatures, 401 for invalid signatures, and 200 OK with fleet diagnostics for authenticated deliveries.
- The daemon opt-in workflow was exercised; the CLI help shows webhook-related options and the runtime tests demonstrate default-off 404, valid-secret 202 on a custom path, and missing-secret 404 with a webhook ingestion-disabled warning.

<a href="https://app.greptile.com/trex/runs/13399376/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Adds webhook routing before fleet auth and exposes webhook diagnostics in the fleet snapshot. |
| internal/webhook/ingest.go | Adds the webhook ingestion handler with body size handling, signature validation, storage, counters, and restart seeding. |
| internal/webhookstore/store.go | Adds the SQLite webhook delivery table, idempotent inserts, event counts, and latest-delivery lookup. |
| internal/daemon/daemon.go | Reads the webhook secret file and wires the ingestor into the fleet server when configured. |
| cmd/maestro/daemon.go | Adds daemon flags for webhook secret file, endpoint path, and database path. |

<sub>Reviews (2): Last reviewed commit: ["fix(webhook): address review — fixed-wid..."](https://github.com/befeast/maestro/commit/2f57aee000934ff93f38c0ed635104f25554a45e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42071072)</sub>

<!-- /greptile_comment -->