### PR TITLE
GitHub mirror read model in the unified SQLite store (epic #811, phase C) (#825)

### DIFF
--- a/docs/github-mirror-read-model-runbook.md
+++ b/docs/github-mirror-read-model-runbook.md
@@ -1,0 +1,87 @@
+# GitHub Mirror Read Model Runbook (#825, epic #811 phase C)
+
+A normalised, queryable mirror of GitHub state in the unified SQLite store
+(`~/.maestro/maestro.db`). Phase B (#824) lands **raw** webhook deliveries; this
+phase projects them into typed tables — issues, pull requests, labels,
+comments, reviews, check/CI status, and Projects v2 items — so a later phase can
+read GitHub state locally instead of polling the API on every cycle.
+
+This phase **builds and populates** the mirror only. **No read path switches over
+to it yet** — that is phase D. Today's polling behaviour is unchanged; the mirror
+runs alongside it and is observable through diagnostics.
+
+## What lands
+
+For each accepted webhook delivery the ingestor projects the modelled events into
+`mirror_*` tables (`internal/mirrorstore`):
+
+| Table | Keyed on | Filled from |
+|---|---|---|
+| `mirror_issues` | repo, number | `issues` |
+| `mirror_pull_requests` | repo, number | `pull_request` |
+| `mirror_labels` | repo, subject, name | issue / PR label sets |
+| `mirror_comments` | repo, comment id | `issue_comment`, `pull_request_review_comment` |
+| `mirror_reviews` | repo, review id | `pull_request_review` |
+| `mirror_checks` | repo, head sha, name | `check_run`, `status` |
+| `mirror_project_items` | repo, item id | `projects_v2_item` |
+
+Every row carries `last_seen_at` (the source resource's own timestamp) and
+`source` (`webhook` or `api`).
+
+## Three guarantees
+
+- **Ordering-safe.** An upsert applies only when the incoming `last_seen_at` is
+  `>=` the stored one. An out-of-order or duplicate redelivery never regresses a
+  row; GitHub retries and operator replays are idempotent.
+- **Explicit staleness.** A reader classifies any row as **fresh / stale /
+  missing** against a configurable horizon (`mirrorstore.Classify`,
+  default `mirrorstore.DefaultStaleHorizon` = 24h). Diagnostics expose per-entity
+  stale counts.
+- **Hydration on miss.** A reader can fetch a missing entity via the existing
+  `internal/github` client, record it (`source = "api"`), and return — so the
+  mirror converges to coverage without a bulk backfill. The next read is local.
+
+## Enabling it
+
+The mirror rides the webhook ingestion path: start the daemon with
+`--webhook-secret-file` (see the [webhook ingestion
+runbook](webhook-ingestion-runbook.md)). When ingestion comes up, the daemon also
+opens the mirror in the same `maestro.db` and projects each accepted delivery
+into it. No separate flag or migration step — the schema is added idempotently on
+start, so an existing fleet upgrades with no manual action.
+
+If the mirror store cannot open, ingestion still lands raw deliveries (phase B
+behaviour); only the read model is skipped, with a warning in the journal.
+
+## Observing it
+
+The fleet snapshot (`GET /api/v1/fleet`) carries a `mirror` block when the mirror
+is configured:
+
+```jsonc
+"mirror": {
+  "enabled": true,
+  "stale_horizon": "24h0m0s",
+  "counts": { "issues": 12, "pull_requests": 4, "labels": 20, "comments": 8,
+              "reviews": 3, "checks": 15, "project_items": 4 },
+  "stale":  { "issues": 1, ... },
+  "total_rows": 66,
+  "total_stale": 1
+}
+```
+
+`total_stale > 0` means that many mirrored rows have not been refreshed within
+the horizon — usually a sign deliveries stopped arriving for a repo. The block is
+omitted entirely when the mirror is not configured.
+
+## Notes / limits (phase C)
+
+- Hydration is implemented for **issues** (`Hydrator.Issue`); other entity types
+  are populated by projection. PR/other hydration follows the identical
+  miss → fetch → store shape and is added as readers need it in phase D.
+- `projects_v2_item` status is best-effort: the webhook carries the new value
+  only on an `edited` delivery (`changes.field_value.to.name`); otherwise the row
+  records item presence and `updated_at` with an empty status.
+- `check_suite` roll-ups and the repo-level `label` **definition** event are not
+  projected (the raw deliveries still land in `webhook_deliveries`, so coverage
+  can widen later without re-ingesting).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/configwatch"
 	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/mirrorstore"
 	"github.com/befeast/maestro/internal/selfdeploy"
 	"github.com/befeast/maestro/internal/server"
 	"github.com/befeast/maestro/internal/state"
@@ -587,6 +588,21 @@ func configureWebhookIngestion(fleet *server.FleetServer, opts Options) {
 	}
 
 	ingestor := webhook.NewIngestor(store, secret)
+
+	// Wire the GitHub mirror read model (#825, phase C). It lives in the same
+	// maestro.db as the raw deliveries; the ingestor projects each accepted
+	// delivery into its normalised tables, and the fleet snapshot exposes its
+	// counts/staleness diagnostics. A mirror that will not open is non-fatal:
+	// ingestion still lands raw deliveries (phase B behaviour), the mirror just
+	// stays empty until the next start.
+	if mirror, err := mirrorstore.Open(dbPath); err != nil {
+		log.Printf("[daemon] github mirror disabled: open mirror store %s: %v (raw deliveries still land)", dbPath, err)
+	} else {
+		ingestor.SetProjector(mirror)
+		fleet.SetMirrorStore(mirror, mirrorstore.DefaultStaleHorizon)
+		log.Printf("[daemon] github mirror active — accepted deliveries project into the read model in %s", dbPath)
+	}
+
 	path := strings.TrimSpace(opts.WebhookPath)
 	if path == "" {
 		path = webhook.DefaultPath

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -67,6 +67,11 @@ type Issue struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`
 	Body   string `json:"body"`
+	// State is the issue's lifecycle state ("open"/"closed") as GitHub reports it.
+	// The REST issue payload always carries it; consumers that mirror issue state
+	// (e.g. internal/mirrorstore hydration) rely on it so an already-closed issue
+	// is not recorded as open. Empty when a payload omits it.
+	State  string `json:"state"`
 	Labels []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
@@ -114,6 +119,7 @@ type restIssue struct {
 	Number int     `json:"number"`
 	Title  string  `json:"title"`
 	Body   *string `json:"body"`
+	State  string  `json:"state"`
 	Labels []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
@@ -154,6 +160,7 @@ func (ri restIssue) issue() Issue {
 		Number: ri.Number,
 		Title:  ri.Title,
 		Body:   body,
+		State:  ri.State,
 		Labels: ri.Labels,
 	}
 }

--- a/internal/mirrorstore/hydrate.go
+++ b/internal/mirrorstore/hydrate.go
@@ -3,6 +3,7 @@ package mirrorstore
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/befeast/maestro/internal/github"
@@ -81,11 +82,8 @@ func (h *Hydrator) Issue(ctx context.Context, number int) (Issue, error) {
 		LastSeenAt: now,
 		Source:     SourceAPI,
 	}
-	if _, err := h.store.UpsertIssue(ctx, row); err != nil {
+	if _, err := h.store.UpsertIssueWithLabels(ctx, row, issueLabelNames(gh)); err != nil {
 		return Issue{}, fmt.Errorf("store hydrated issue %d: %w", number, err)
-	}
-	if err := h.store.ReplaceLabels(ctx, h.repo, SubjectIssue, gh.Number, issueLabelNames(gh), now, SourceAPI); err != nil {
-		return Issue{}, fmt.Errorf("store hydrated issue %d labels: %w", number, err)
 	}
 	// Re-read so the returned row reflects exactly what a subsequent local read
 	// would see (e.g. if a fresher webhook row was already present, the guarded
@@ -97,13 +95,22 @@ func (h *Hydrator) Issue(ctx context.Context, number int) (Issue, error) {
 	return stored, nil
 }
 
-// issueStateFromGitHub reports the issue state. github.Issue does not carry an
-// explicit state field (the REST fetch drops it), so a hydrated issue is recorded
-// as "open" — the mirror only hydrates issues a reader is actively working, which
-// are open by construction. A later close arrives as an "issues"/"closed" webhook
-// and updates the row.
-func issueStateFromGitHub(github.Issue) string {
-	return "open"
+// issueStateFromGitHub reports the mirror state for a hydrated issue, preserving
+// the REST payload's own state ("open"/"closed") so hydrating an already-closed
+// issue is not silently reopened. If it were forced to "open", a subsequent
+// "issues"/"closed" webhook whose issue.updated_at predates the hydration time
+// would be rejected as stale and the mirror could stay open indefinitely (P1).
+//
+// GitHub reports lowercase state; the webhook projection stores it verbatim, so
+// hydration lower-cases to match and the two write paths converge. An empty state
+// (a client that does not populate it) falls back to "open": the mirror only
+// hydrates issues a reader is actively working, which are open by construction.
+func issueStateFromGitHub(gh github.Issue) string {
+	state := strings.ToLower(strings.TrimSpace(gh.State))
+	if state == "" {
+		return "open"
+	}
+	return state
 }
 
 func issueLabelNames(gh github.Issue) []string {

--- a/internal/mirrorstore/hydrate.go
+++ b/internal/mirrorstore/hydrate.go
@@ -1,0 +1,115 @@
+package mirrorstore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+// GitHubClient is the narrow slice of *github.Client the hydrator needs to fill a
+// mirror miss. *github.Client satisfies it; tests supply a fake so hydration is
+// exercised without touching the network.
+//
+// Only the reads a mirror miss triggers are listed here — the interface exists to
+// keep hydration testable and to document exactly which API calls the mirror can
+// still make. It deliberately does not grow into a full GitHub surface: the point
+// of the mirror is to stop calling the API, not to wrap it.
+type GitHubClient interface {
+	GetIssue(number int) (github.Issue, error)
+}
+
+// Hydrator serves reads from the mirror, falling back to the GitHub API on a
+// miss and recording the result so the next read is local (#825 AC 3). It is the
+// bridge that lets the mirror converge to full coverage without a bulk backfill:
+// every entity a reader actually asks for is fetched once and then mirrored.
+//
+// Hydration stamps source = "api" and last_seen_at = the fetch time (now). Unlike
+// a webhook, an API fetch has no server-side resource timestamp on
+// github.Issue, so it uses wall-clock arrival as the ordering key. A genuinely
+// newer webhook that arrives afterwards still wins (its resource updated_at is
+// later); a webhook that predates the fetch is correctly rejected as stale.
+type Hydrator struct {
+	store  *Store
+	client GitHubClient
+	repo   string
+	now    func() time.Time
+}
+
+// NewHydrator builds a hydrator over store for repo, backed by client for
+// misses. repo is the "owner/name" the mirror rows are keyed on.
+func NewHydrator(store *Store, client GitHubClient, repo string) *Hydrator {
+	return &Hydrator{
+		store:  store,
+		client: client,
+		repo:   repo,
+		now:    func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Issue returns the issue for number: from the mirror when present, otherwise
+// fetched from the API, stored (source = "api"), and returned. After a hydrating
+// call the row is local, so the immediately following call is served from the
+// mirror with no API traffic — the "mirror miss → hydrate → served locally"
+// acceptance.
+//
+// A miss with no client wired is reported as an error rather than a silent empty
+// issue, so a caller does not mistake "not configured" for "does not exist".
+func (h *Hydrator) Issue(ctx context.Context, number int) (Issue, error) {
+	row, ok, err := h.store.GetIssue(ctx, h.repo, number)
+	if err != nil {
+		return Issue{}, err
+	}
+	if ok {
+		return row, nil
+	}
+	if h.client == nil {
+		return Issue{}, fmt.Errorf("mirror miss for issue %d and no GitHub client to hydrate from", number)
+	}
+	gh, err := h.client.GetIssue(number)
+	if err != nil {
+		return Issue{}, fmt.Errorf("hydrate issue %d: %w", number, err)
+	}
+	now := h.now()
+	row = Issue{
+		Repo:       h.repo,
+		Number:     gh.Number,
+		Title:      gh.Title,
+		State:      issueStateFromGitHub(gh),
+		Body:       gh.Body,
+		LastSeenAt: now,
+		Source:     SourceAPI,
+	}
+	if _, err := h.store.UpsertIssue(ctx, row); err != nil {
+		return Issue{}, fmt.Errorf("store hydrated issue %d: %w", number, err)
+	}
+	if err := h.store.ReplaceLabels(ctx, h.repo, SubjectIssue, gh.Number, issueLabelNames(gh), now, SourceAPI); err != nil {
+		return Issue{}, fmt.Errorf("store hydrated issue %d labels: %w", number, err)
+	}
+	// Re-read so the returned row reflects exactly what a subsequent local read
+	// would see (e.g. if a fresher webhook row was already present, the guarded
+	// upsert kept it and this read returns that, not the API snapshot).
+	stored, _, err := h.store.GetIssue(ctx, h.repo, number)
+	if err != nil {
+		return Issue{}, err
+	}
+	return stored, nil
+}
+
+// issueStateFromGitHub reports the issue state. github.Issue does not carry an
+// explicit state field (the REST fetch drops it), so a hydrated issue is recorded
+// as "open" — the mirror only hydrates issues a reader is actively working, which
+// are open by construction. A later close arrives as an "issues"/"closed" webhook
+// and updates the row.
+func issueStateFromGitHub(github.Issue) string {
+	return "open"
+}
+
+func issueLabelNames(gh github.Issue) []string {
+	out := make([]string, 0, len(gh.Labels))
+	for _, l := range gh.Labels {
+		out = append(out, l.Name)
+	}
+	return out
+}

--- a/internal/mirrorstore/hydrate_test.go
+++ b/internal/mirrorstore/hydrate_test.go
@@ -100,6 +100,50 @@ func TestHydrateDoesNotClobberFresherWebhook(t *testing.T) {
 	}
 }
 
+// TestHydratePreservesClosedState covers the P1 fix: hydrating an already-closed
+// issue must record its real state, not hard-code "open". Otherwise a later
+// "issues"/"closed" webhook whose issue.updated_at predates the hydration time
+// would be guard-rejected as stale and the mirror would stay open indefinitely.
+func TestHydratePreservesClosedState(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	fake := &fakeGitHub{issue: github.Issue{Number: 5, Title: "done", State: "closed"}}
+	h := NewHydrator(s, fake, "o/r")
+
+	row, err := h.Issue(ctx, 5)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if row.State != "closed" {
+		t.Fatalf("hydrated state = %q, want closed", row.State)
+	}
+
+	// A later close webhook that predates the hydration time is a no-op — but the
+	// mirror already shows closed, so it never regressed to open in the first place.
+	stored, ok, _ := s.GetIssue(ctx, "o/r", 5)
+	if !ok || stored.State != "closed" {
+		t.Fatalf("stored issue = %+v, want state closed", stored)
+	}
+}
+
+// TestHydrateEmptyStateDefaultsOpen confirms the safety fallback: a client that
+// does not populate state records the issue as open (the mirror only hydrates
+// issues a reader is actively working, which are open by construction).
+func TestHydrateEmptyStateDefaultsOpen(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	fake := &fakeGitHub{issue: github.Issue{Number: 6, Title: "no state"}}
+	h := NewHydrator(s, fake, "o/r")
+	row, err := h.Issue(ctx, 6)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if row.State != "open" {
+		t.Fatalf("hydrated state = %q, want open fallback", row.State)
+	}
+}
+
 func TestHydrateErrorPropagates(t *testing.T) {
 	s := openTestStore(t)
 	ctx := context.Background()

--- a/internal/mirrorstore/hydrate_test.go
+++ b/internal/mirrorstore/hydrate_test.go
@@ -1,0 +1,120 @@
+package mirrorstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+// fakeGitHub is a GitHubClient that serves a fixed issue and counts calls, so a
+// test can assert hydration happens exactly once and later reads are local.
+type fakeGitHub struct {
+	issue github.Issue
+	err   error
+	calls int
+}
+
+func (f *fakeGitHub) GetIssue(number int) (github.Issue, error) {
+	f.calls++
+	if f.err != nil {
+		return github.Issue{}, f.err
+	}
+	return f.issue, nil
+}
+
+// TestHydrateMissThenLocal covers AC 3: a mirror miss hydrates from the API and
+// records the row; the immediately following read is served locally with no
+// further API call.
+func TestHydrateMissThenLocal(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	fake := &fakeGitHub{issue: github.Issue{
+		Number: 100,
+		Title:  "hydrated",
+		Body:   "from api",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "needs-triage"}},
+	}}
+	h := NewHydrator(s, fake, "o/r")
+
+	// Miss → hydrate.
+	row, err := h.Issue(ctx, 100)
+	if err != nil {
+		t.Fatalf("first Issue: %v", err)
+	}
+	if row.Title != "hydrated" || row.Source != SourceAPI {
+		t.Fatalf("hydrated row = %+v", row)
+	}
+	if fake.calls != 1 {
+		t.Fatalf("expected 1 API call, got %d", fake.calls)
+	}
+
+	// The row and its labels are now local.
+	if _, ok, _ := s.GetIssue(ctx, "o/r", 100); !ok {
+		t.Fatalf("hydrated row not stored")
+	}
+	labels, _ := s.Labels(ctx, "o/r", SubjectIssue, 100)
+	if len(labels) != 1 || labels[0] != "needs-triage" {
+		t.Fatalf("hydrated labels = %v", labels)
+	}
+
+	// Second read is served from the mirror: no additional API call.
+	if _, err := h.Issue(ctx, 100); err != nil {
+		t.Fatalf("second Issue: %v", err)
+	}
+	if fake.calls != 1 {
+		t.Fatalf("second read hit the API: calls=%d", fake.calls)
+	}
+}
+
+// TestHydrateDoesNotClobberFresherWebhook confirms the guarded upsert keeps a
+// fresher webhook row even when a hydration fetch (stamped "now") races it.
+func TestHydrateDoesNotClobberFresherWebhook(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	// A webhook already mirrored the issue with a FUTURE resource timestamp.
+	future := time.Now().UTC().Add(24 * time.Hour)
+	if _, err := s.UpsertIssue(ctx, Issue{Repo: "o/r", Number: 1, Title: "webhook", State: "open", LastSeenAt: future, Source: SourceWebhook}); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeGitHub{issue: github.Issue{Number: 1, Title: "api"}}
+	h := NewHydrator(s, fake, "o/r")
+
+	// GetIssue hits (row present) so hydration never calls the API.
+	row, err := h.Issue(ctx, 1)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if fake.calls != 0 {
+		t.Fatalf("hydration should not call API on a hit: calls=%d", fake.calls)
+	}
+	if row.Title != "webhook" || row.Source != SourceWebhook {
+		t.Fatalf("hit returned wrong row: %+v", row)
+	}
+}
+
+func TestHydrateErrorPropagates(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	fake := &fakeGitHub{err: errors.New("boom")}
+	h := NewHydrator(s, fake, "o/r")
+	if _, err := h.Issue(ctx, 7); err == nil {
+		t.Fatalf("expected error from failing hydration")
+	}
+}
+
+func TestHydrateNoClientErrors(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	h := NewHydrator(s, nil, "o/r")
+	if _, err := h.Issue(ctx, 7); err == nil {
+		t.Fatalf("expected error when no client is wired and the row is missing")
+	}
+}

--- a/internal/mirrorstore/project.go
+++ b/internal/mirrorstore/project.go
@@ -1,0 +1,374 @@
+package mirrorstore
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// ProjectWebhook projects one ingested GitHub webhook delivery into the mirror
+// tables. eventType is the X-GitHub-Event value, payload is the raw request body
+// (exactly what internal/webhookstore persisted), and receivedAt is when the
+// daemon accepted the delivery — used as the ordering timestamp only when the
+// payload carries no resource timestamp of its own.
+//
+// It is safe to call repeatedly with the same delivery (idempotent) and safe to
+// call with deliveries out of order: each upsert is guarded by last_seen_at, so a
+// replay or an out-of-order redelivery never regresses a row (#825 AC 2). Event
+// types the mirror does not model (ping, the repo-level label definition event,
+// check_suite roll-ups) are a no-op — the raw delivery still lives in
+// webhookstore, so a later phase can widen coverage without re-ingesting.
+//
+// A malformed payload for a modelled event returns the JSON error; the caller
+// (the ingestor's projection hook) logs it and moves on, because the raw
+// delivery is already durably stored and the projection can be re-run.
+func (s *Store) ProjectWebhook(ctx context.Context, eventType string, payload []byte, receivedAt time.Time) error {
+	switch strings.TrimSpace(eventType) {
+	case "issues":
+		return s.projectIssue(ctx, payload, receivedAt)
+	case "pull_request":
+		return s.projectPullRequest(ctx, payload, receivedAt)
+	case "issue_comment":
+		return s.projectIssueComment(ctx, payload, receivedAt)
+	case "pull_request_review_comment":
+		return s.projectReviewComment(ctx, payload, receivedAt)
+	case "pull_request_review":
+		return s.projectReview(ctx, payload, receivedAt)
+	case "check_run":
+		return s.projectCheckRun(ctx, payload, receivedAt)
+	case "status":
+		return s.projectStatus(ctx, payload, receivedAt)
+	case "projects_v2_item":
+		return s.projectProjectItem(ctx, payload, receivedAt)
+	default:
+		// ping, label (definition), check_suite, and any not-yet-modelled event
+		// are intentionally not projected. The raw delivery is still stored.
+		return nil
+	}
+}
+
+// repoEnvelope is the repository name every repo-scoped event carries.
+type repoEnvelope struct {
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+type labeled struct {
+	Name string `json:"name"`
+}
+
+func labelNames(ls []labeled) []string {
+	out := make([]string, 0, len(ls))
+	for _, l := range ls {
+		if n := strings.TrimSpace(l.Name); n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func (s *Store) projectIssue(ctx context.Context, payload []byte, receivedAt time.Time) error {
+	var p struct {
+		repoEnvelope
+		Issue struct {
+			Number    int       `json:"number"`
+			Title     string    `json:"title"`
+			Body      string    `json:"body"`
+			State     string    `json:"state"`
+			UpdatedAt string    `json:"updated_at"`
+			CreatedAt string    `json:"created_at"`
+			Labels    []labeled `json:"labels"`
+		} `json:"issue"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+	repo := strings.TrimSpace(p.Repository.FullName)
+	ts := pickTime(receivedAt, p.Issue.UpdatedAt, p.Issue.CreatedAt)
+	applied, err := s.UpsertIssue(ctx, Issue{
+		Repo:       repo,
+		Number:     p.Issue.Number,
+		Title:      p.Issue.Title,
+		State:      p.Issue.State,
+		Body:       p.Issue.Body,
+		LastSeenAt: ts,
+		Source:     SourceWebhook,
+	})
+	if err != nil {
+		return err
+	}
+	// Only reconcile the label set when this event was not stale — otherwise a
+	// late-arriving old event would clobber a fresher label set.
+	if applied {
+		return s.ReplaceLabels(ctx, repo, SubjectIssue, p.Issue.Number, labelNames(p.Issue.Labels), ts, SourceWebhook)
+	}
+	return nil
+}
+
+func (s *Store) projectPullRequest(ctx context.Context, payload []byte, receivedAt time.Time) error {
+	var p struct {
+		repoEnvelope
+		PullRequest struct {
+			Number    int    `json:"number"`
+			Title     string `json:"title"`
+			State     string `json:"state"`
+			Draft     bool   `json:"draft"`
+			Merged    bool   `json:"merged"`
+			UpdatedAt string `json:"updated_at"`
+			CreatedAt string `json:"created_at"`
+			Head      struct {
+				SHA string `json:"sha"`
+			} `json:"head"`
+			Base struct {
+				Ref string `json:"ref"`
+			} `json:"base"`
+			Labels []labeled `json:"labels"`
+		} `json:"pull_request"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+	repo := strings.TrimSpace(p.Repository.FullName)
+	ts := pickTime(receivedAt, p.PullRequest.UpdatedAt, p.PullRequest.CreatedAt)
+	applied, err := s.UpsertPullRequest(ctx, PullRequest{
+		Repo:       repo,
+		Number:     p.PullRequest.Number,
+		Title:      p.PullRequest.Title,
+		State:      p.PullRequest.State,
+		Draft:      p.PullRequest.Draft,
+		Merged:     p.PullRequest.Merged,
+		HeadSHA:    strings.TrimSpace(p.PullRequest.Head.SHA),
+		BaseRef:    strings.TrimSpace(p.PullRequest.Base.Ref),
+		LastSeenAt: ts,
+		Source:     SourceWebhook,
+	})
+	if err != nil {
+		return err
+	}
+	if applied {
+		return s.ReplaceLabels(ctx, repo, SubjectPullRequest, p.PullRequest.Number, labelNames(p.PullRequest.Labels), ts, SourceWebhook)
+	}
+	return nil
+}
+
+func (s *Store) projectIssueComment(ctx context.Context, payload []byte, receivedAt time.Time) error {
+	var p struct {
+		repoEnvelope
+		Issue struct {
+			Number      int              `json:"number"`
+			PullRequest *json.RawMessage `json:"pull_request"`
+		} `json:"issue"`
+		Comment commentShape `json:"comment"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+	// GitHub delivers comments on a PR as issue_comment too; the issue object then
+	// carries a pull_request field. Record the correct subject type so a reader can
+	// tell an issue-thread comment from a PR-conversation comment.
+	subjectType := SubjectIssue
+	if p.Issue.PullRequest != nil {
+		subjectType = SubjectPullRequest
+	}
+	ts := pickTime(receivedAt, p.Comment.UpdatedAt, p.Comment.CreatedAt)
+	_, err := s.UpsertComment(ctx, Comment{
+		Repo:          strings.TrimSpace(p.Repository.FullName),
+		CommentID:     p.Comment.ID,
+		SubjectType:   subjectType,
+		SubjectNumber: p.Issue.Number,
+		Author:        strings.TrimSpace(p.Comment.User.Login),
+		Body:          p.Comment.Body,
+		LastSeenAt:    ts,
+		Source:        SourceWebhook,
+	})
+	return err
+}
+
+func (s *Store) projectReviewComment(ctx context.Context, payload []byte, receivedAt time.Time) error {
+	var p struct {
+		repoEnvelope
+		PullRequest struct {
+			Number int `json:"number"`
+		} `json:"pull_request"`
+		Comment commentShape `json:"comment"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+	ts := pickTime(receivedAt, p.Comment.UpdatedAt, p.Comment.CreatedAt)
+	_, err := s.UpsertComment(ctx, Comment{
+		Repo:          strings.TrimSpace(p.Repository.FullName),
+		CommentID:     p.Comment.ID,
+		SubjectType:   SubjectPullRequest,
+		SubjectNumber: p.PullRequest.Number,
+		Author:        strings.TrimSpace(p.Comment.User.Login),
+		Body:          p.Comment.Body,
+		LastSeenAt:    ts,
+		Source:        SourceWebhook,
+	})
+	return err
+}
+
+// commentShape is shared by issue_comment and pull_request_review_comment.
+type commentShape struct {
+	ID   int64  `json:"id"`
+	Body string `json:"body"`
+	User struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	UpdatedAt string `json:"updated_at"`
+	CreatedAt string `json:"created_at"`
+}
+
+func (s *Store) projectReview(ctx context.Context, payload []byte, receivedAt time.Time) error {
+	var p struct {
+		repoEnvelope
+		Review struct {
+			ID    int64  `json:"id"`
+			State string `json:"state"`
+			Body  string `json:"body"`
+			User  struct {
+				Login string `json:"login"`
+			} `json:"user"`
+			SubmittedAt string `json:"submitted_at"`
+		} `json:"review"`
+		PullRequest struct {
+			Number int `json:"number"`
+		} `json:"pull_request"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+	ts := pickTime(receivedAt, p.Review.SubmittedAt)
+	_, err := s.UpsertReview(ctx, Review{
+		Repo:       strings.TrimSpace(p.Repository.FullName),
+		ReviewID:   p.Review.ID,
+		PRNumber:   p.PullRequest.Number,
+		Author:     strings.TrimSpace(p.Review.User.Login),
+		State:      strings.TrimSpace(p.Review.State),
+		Body:       p.Review.Body,
+		LastSeenAt: ts,
+		Source:     SourceWebhook,
+	})
+	return err
+}
+
+func (s *Store) projectCheckRun(ctx context.Context, payload []byte, receivedAt time.Time) error {
+	var p struct {
+		repoEnvelope
+		CheckRun struct {
+			Name        string `json:"name"`
+			Status      string `json:"status"`
+			Conclusion  string `json:"conclusion"`
+			HeadSHA     string `json:"head_sha"`
+			StartedAt   string `json:"started_at"`
+			CompletedAt string `json:"completed_at"`
+		} `json:"check_run"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+	ts := pickTime(receivedAt, p.CheckRun.CompletedAt, p.CheckRun.StartedAt)
+	_, err := s.UpsertCheck(ctx, Check{
+		Repo:       strings.TrimSpace(p.Repository.FullName),
+		HeadSHA:    strings.TrimSpace(p.CheckRun.HeadSHA),
+		Name:       strings.TrimSpace(p.CheckRun.Name),
+		Kind:       CheckKindRun,
+		Status:     strings.TrimSpace(p.CheckRun.Status),
+		Conclusion: strings.TrimSpace(p.CheckRun.Conclusion),
+		LastSeenAt: ts,
+		Source:     SourceWebhook,
+	})
+	return err
+}
+
+func (s *Store) projectStatus(ctx context.Context, payload []byte, receivedAt time.Time) error {
+	var p struct {
+		repoEnvelope
+		SHA       string `json:"sha"`
+		Context   string `json:"context"`
+		State     string `json:"state"`
+		UpdatedAt string `json:"updated_at"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+	// A commit-status event has no separate status/conclusion split; its single
+	// state (success/failure/pending/error) is recorded as both so a reader can
+	// treat mirror_checks uniformly across check_run and status rows.
+	state := strings.TrimSpace(p.State)
+	ts := pickTime(receivedAt, p.UpdatedAt, p.CreatedAt)
+	_, err := s.UpsertCheck(ctx, Check{
+		Repo:       strings.TrimSpace(p.Repository.FullName),
+		HeadSHA:    strings.TrimSpace(p.SHA),
+		Name:       strings.TrimSpace(p.Context),
+		Kind:       CheckKindStatus,
+		Status:     state,
+		Conclusion: state,
+		LastSeenAt: ts,
+		Source:     SourceWebhook,
+	})
+	return err
+}
+
+func (s *Store) projectProjectItem(ctx context.Context, payload []byte, receivedAt time.Time) error {
+	var p struct {
+		repoEnvelope
+		ProjectsV2Item struct {
+			NodeID      string `json:"node_id"`
+			ContentType string `json:"content_type"`
+			UpdatedAt   string `json:"updated_at"`
+			CreatedAt   string `json:"created_at"`
+		} `json:"projects_v2_item"`
+		// The item's status is not on the item object; an "edited" delivery carries
+		// the new value under changes.field_value.to.name. Best-effort: record it
+		// when present, otherwise leave status empty (the row still marks presence).
+		Changes struct {
+			FieldValue struct {
+				To struct {
+					Name string `json:"name"`
+				} `json:"to"`
+			} `json:"field_value"`
+		} `json:"changes"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+	itemID := strings.TrimSpace(p.ProjectsV2Item.NodeID)
+	if itemID == "" {
+		// Without a stable item id there is nothing to key on; skip rather than
+		// collapse every unkeyed item onto one row.
+		return nil
+	}
+	ts := pickTime(receivedAt, p.ProjectsV2Item.UpdatedAt, p.ProjectsV2Item.CreatedAt)
+	_, err := s.UpsertProjectItem(ctx, ProjectItem{
+		Repo:        strings.TrimSpace(p.Repository.FullName),
+		ItemID:      itemID,
+		ContentType: strings.TrimSpace(p.ProjectsV2Item.ContentType),
+		Status:      strings.TrimSpace(p.Changes.FieldValue.To.Name),
+		LastSeenAt:  ts,
+		Source:      SourceWebhook,
+	})
+	return err
+}
+
+// pickTime returns the first parseable RFC3339 timestamp from candidates,
+// falling back to fallback (the delivery's received_at) when none parse. GitHub
+// resource timestamps (updated_at, submitted_at, completed_at, …) are the
+// authoritative ordering key — two deliveries reordered in flight still resolve
+// correctly because the newer resource state carries the later timestamp. Only
+// when a payload omits every candidate does ordering fall back to arrival time.
+func pickTime(fallback time.Time, candidates ...string) time.Time {
+	for _, c := range candidates {
+		if t, err := parseTS(c); err == nil && !t.IsZero() {
+			return t.UTC()
+		}
+	}
+	if fallback.IsZero() {
+		return time.Time{}.UTC()
+	}
+	return fallback.UTC()
+}

--- a/internal/mirrorstore/project.go
+++ b/internal/mirrorstore/project.go
@@ -59,6 +59,12 @@ type labeled struct {
 	Name string `json:"name"`
 }
 
+// isDeleteAction reports whether a webhook's action field marks a deletion, so
+// the projection removes the mirror row instead of upserting it.
+func isDeleteAction(action string) bool {
+	return strings.EqualFold(strings.TrimSpace(action), "deleted")
+}
+
 func labelNames(ls []labeled) []string {
 	out := make([]string, 0, len(ls))
 	for _, l := range ls {
@@ -87,7 +93,11 @@ func (s *Store) projectIssue(ctx context.Context, payload []byte, receivedAt tim
 	}
 	repo := strings.TrimSpace(p.Repository.FullName)
 	ts := pickTime(receivedAt, p.Issue.UpdatedAt, p.Issue.CreatedAt)
-	applied, err := s.UpsertIssue(ctx, Issue{
+	// The issue row and its label set are reconciled atomically: the labels are
+	// replaced only when the guarded upsert applied, and inside the same
+	// transaction, so a late-arriving old event can neither clobber a fresher label
+	// set nor race a concurrent newer delivery between the row and its labels.
+	_, err := s.UpsertIssueWithLabels(ctx, Issue{
 		Repo:       repo,
 		Number:     p.Issue.Number,
 		Title:      p.Issue.Title,
@@ -95,16 +105,8 @@ func (s *Store) projectIssue(ctx context.Context, payload []byte, receivedAt tim
 		Body:       p.Issue.Body,
 		LastSeenAt: ts,
 		Source:     SourceWebhook,
-	})
-	if err != nil {
-		return err
-	}
-	// Only reconcile the label set when this event was not stale — otherwise a
-	// late-arriving old event would clobber a fresher label set.
-	if applied {
-		return s.ReplaceLabels(ctx, repo, SubjectIssue, p.Issue.Number, labelNames(p.Issue.Labels), ts, SourceWebhook)
-	}
-	return nil
+	}, labelNames(p.Issue.Labels))
+	return err
 }
 
 func (s *Store) projectPullRequest(ctx context.Context, payload []byte, receivedAt time.Time) error {
@@ -132,7 +134,7 @@ func (s *Store) projectPullRequest(ctx context.Context, payload []byte, received
 	}
 	repo := strings.TrimSpace(p.Repository.FullName)
 	ts := pickTime(receivedAt, p.PullRequest.UpdatedAt, p.PullRequest.CreatedAt)
-	applied, err := s.UpsertPullRequest(ctx, PullRequest{
+	_, err := s.UpsertPullRequestWithLabels(ctx, PullRequest{
 		Repo:       repo,
 		Number:     p.PullRequest.Number,
 		Title:      p.PullRequest.Title,
@@ -143,20 +145,15 @@ func (s *Store) projectPullRequest(ctx context.Context, payload []byte, received
 		BaseRef:    strings.TrimSpace(p.PullRequest.Base.Ref),
 		LastSeenAt: ts,
 		Source:     SourceWebhook,
-	})
-	if err != nil {
-		return err
-	}
-	if applied {
-		return s.ReplaceLabels(ctx, repo, SubjectPullRequest, p.PullRequest.Number, labelNames(p.PullRequest.Labels), ts, SourceWebhook)
-	}
-	return nil
+	}, labelNames(p.PullRequest.Labels))
+	return err
 }
 
 func (s *Store) projectIssueComment(ctx context.Context, payload []byte, receivedAt time.Time) error {
 	var p struct {
 		repoEnvelope
-		Issue struct {
+		Action string `json:"action"`
+		Issue  struct {
 			Number      int              `json:"number"`
 			PullRequest *json.RawMessage `json:"pull_request"`
 		} `json:"issue"`
@@ -164,6 +161,13 @@ func (s *Store) projectIssueComment(ctx context.Context, payload []byte, receive
 	}
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return err
+	}
+	// A "deleted" delivery means the comment is gone from GitHub; remove the mirror
+	// row so a reader (and staleness diagnostics) does not keep seeing a comment
+	// that no longer exists. Upserting it here would leave the read model diverging
+	// from the direct API snapshot.
+	if isDeleteAction(p.Action) {
+		return s.DeleteComment(ctx, strings.TrimSpace(p.Repository.FullName), p.Comment.ID)
 	}
 	// GitHub delivers comments on a PR as issue_comment too; the issue object then
 	// carries a pull_request field. Record the correct subject type so a reader can
@@ -189,6 +193,7 @@ func (s *Store) projectIssueComment(ctx context.Context, payload []byte, receive
 func (s *Store) projectReviewComment(ctx context.Context, payload []byte, receivedAt time.Time) error {
 	var p struct {
 		repoEnvelope
+		Action      string `json:"action"`
 		PullRequest struct {
 			Number int `json:"number"`
 		} `json:"pull_request"`
@@ -196,6 +201,11 @@ func (s *Store) projectReviewComment(ctx context.Context, payload []byte, receiv
 	}
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return err
+	}
+	// A deleted review comment is removed from the mirror for the same reason as a
+	// deleted issue comment: the read model must match the direct API snapshot.
+	if isDeleteAction(p.Action) {
+		return s.DeleteComment(ctx, strings.TrimSpace(p.Repository.FullName), p.Comment.ID)
 	}
 	ts := pickTime(receivedAt, p.Comment.UpdatedAt, p.Comment.CreatedAt)
 	_, err := s.UpsertComment(ctx, Comment{

--- a/internal/mirrorstore/project_test.go
+++ b/internal/mirrorstore/project_test.go
@@ -200,6 +200,81 @@ func TestProjectReviewAndComments(t *testing.T) {
 	}
 }
 
+// TestProjectIssueCommentDelete covers the P2 fix: a "deleted" issue_comment
+// removes the mirror row instead of leaving a comment that no longer exists on
+// GitHub visible (and fresh for staleness diagnostics).
+func TestProjectIssueCommentDelete(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	created := []byte(`{
+		"action": "created",
+		"issue": {"number": 42},
+		"comment": {"id": 111, "body": "hi", "user": {"login": "u"},
+			"updated_at": "2026-07-02T11:00:00Z"},
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "issue_comment", created, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.GetComment(ctx, "o/r", 111); !ok {
+		t.Fatalf("comment not stored on create")
+	}
+
+	deleted := []byte(`{
+		"action": "deleted",
+		"issue": {"number": 42},
+		"comment": {"id": 111, "body": "hi", "user": {"login": "u"},
+			"updated_at": "2026-07-02T11:05:00Z"},
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "issue_comment", deleted, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.GetComment(ctx, "o/r", 111); ok {
+		t.Fatalf("deleted comment still present in mirror")
+	}
+	// Idempotent: a duplicate delete is a no-op, not an error.
+	if err := s.ProjectWebhook(ctx, "issue_comment", deleted, time.Time{}); err != nil {
+		t.Fatalf("duplicate delete errored: %v", err)
+	}
+}
+
+// TestProjectReviewCommentDelete confirms the same removal for a deleted PR review
+// comment.
+func TestProjectReviewCommentDelete(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	created := []byte(`{
+		"action": "created",
+		"pull_request": {"number": 828},
+		"comment": {"id": 222, "body": "nit", "user": {"login": "rev"},
+			"updated_at": "2026-07-02T11:00:00Z"},
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "pull_request_review_comment", created, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.GetComment(ctx, "o/r", 222); !ok {
+		t.Fatalf("review comment not stored on create")
+	}
+
+	deleted := []byte(`{
+		"action": "deleted",
+		"pull_request": {"number": 828},
+		"comment": {"id": 222, "body": "nit", "user": {"login": "rev"},
+			"updated_at": "2026-07-02T11:05:00Z"},
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "pull_request_review_comment", deleted, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.GetComment(ctx, "o/r", 222); ok {
+		t.Fatalf("deleted review comment still present in mirror")
+	}
+}
+
 func TestProjectProjectItem(t *testing.T) {
 	s := openTestStore(t)
 	ctx := context.Background()

--- a/internal/mirrorstore/project_test.go
+++ b/internal/mirrorstore/project_test.go
@@ -1,0 +1,256 @@
+package mirrorstore
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestProjectIssueAndLabels(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	recv := mustTime(t, "2026-07-01T13:00:00Z")
+
+	payload := []byte(`{
+		"action": "labeled",
+		"issue": {
+			"number": 42,
+			"title": "hello",
+			"body": "world",
+			"state": "open",
+			"updated_at": "2026-07-01T12:00:00Z",
+			"labels": [{"name": "bug"}, {"name": "p1"}]
+		},
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "issues", payload, recv); err != nil {
+		t.Fatalf("ProjectWebhook: %v", err)
+	}
+	row, ok, err := s.GetIssue(ctx, "o/r", 42)
+	if err != nil || !ok {
+		t.Fatalf("GetIssue ok=%v err=%v", ok, err)
+	}
+	if row.Title != "hello" || row.Body != "world" || row.State != "open" || row.Source != SourceWebhook {
+		t.Fatalf("issue row = %+v", row)
+	}
+	if !row.LastSeenAt.Equal(mustTime(t, "2026-07-01T12:00:00Z")) {
+		t.Fatalf("last_seen_at = %v, want issue.updated_at", row.LastSeenAt)
+	}
+	labels, _ := s.Labels(ctx, "o/r", SubjectIssue, 42)
+	if len(labels) != 2 || labels[0] != "bug" || labels[1] != "p1" {
+		t.Fatalf("labels = %v", labels)
+	}
+}
+
+// TestProjectOutOfOrderIssue covers AC 2 at the projection layer: a later-arriving
+// but older event neither regresses the issue row nor its label set.
+func TestProjectOutOfOrderIssue(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	newer := []byte(`{
+		"action": "edited",
+		"issue": {"number": 1, "title": "NEW", "state": "closed",
+			"updated_at": "2026-07-01T12:00:00Z",
+			"labels": [{"name": "keep"}]},
+		"repository": {"full_name": "o/r"}
+	}`)
+	older := []byte(`{
+		"action": "edited",
+		"issue": {"number": 1, "title": "OLD", "state": "open",
+			"updated_at": "2026-07-01T09:00:00Z",
+			"labels": [{"name": "stale-label"}]},
+		"repository": {"full_name": "o/r"}
+	}`)
+
+	// Apply the newer event first, then replay the older one out of order.
+	if err := s.ProjectWebhook(ctx, "issues", newer, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ProjectWebhook(ctx, "issues", older, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+
+	row, _, _ := s.GetIssue(ctx, "o/r", 1)
+	if row.Title != "NEW" || row.State != "closed" {
+		t.Fatalf("older event regressed issue: %+v", row)
+	}
+	labels, _ := s.Labels(ctx, "o/r", SubjectIssue, 1)
+	if len(labels) != 1 || labels[0] != "keep" {
+		t.Fatalf("older event regressed labels: %v", labels)
+	}
+
+	// Replaying the newer event again is idempotent.
+	if err := s.ProjectWebhook(ctx, "issues", newer, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	labels, _ = s.Labels(ctx, "o/r", SubjectIssue, 1)
+	if len(labels) != 1 || labels[0] != "keep" {
+		t.Fatalf("duplicate replay changed labels: %v", labels)
+	}
+}
+
+func TestProjectPullRequest(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	payload := []byte(`{
+		"action": "synchronize",
+		"number": 828,
+		"pull_request": {
+			"number": 828, "title": "feat", "state": "open",
+			"draft": true, "merged": false,
+			"updated_at": "2026-07-02T09:15:00Z",
+			"head": {"sha": "abc123"}, "base": {"ref": "main"},
+			"labels": [{"name": "maestro-ready"}]
+		},
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "pull_request", payload, time.Time{}); err != nil {
+		t.Fatalf("ProjectWebhook: %v", err)
+	}
+	pr, ok, err := s.GetPullRequest(ctx, "o/r", 828)
+	if err != nil || !ok {
+		t.Fatalf("GetPullRequest ok=%v err=%v", ok, err)
+	}
+	if pr.Title != "feat" || !pr.Draft || pr.Merged || pr.HeadSHA != "abc123" || pr.BaseRef != "main" {
+		t.Fatalf("pr row = %+v", pr)
+	}
+	labels, _ := s.Labels(ctx, "o/r", SubjectPullRequest, 828)
+	if len(labels) != 1 || labels[0] != "maestro-ready" {
+		t.Fatalf("pr labels = %v", labels)
+	}
+}
+
+func TestProjectCheckRunAndStatus(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	checkRun := []byte(`{
+		"check_run": {"name": "go test", "status": "completed", "conclusion": "success",
+			"head_sha": "sha1", "completed_at": "2026-07-02T09:20:00Z"},
+		"repository": {"full_name": "o/r"}
+	}`)
+	status := []byte(`{
+		"sha": "sha1", "context": "ci/lint", "state": "failure",
+		"updated_at": "2026-07-02T09:21:00Z",
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "check_run", checkRun, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ProjectWebhook(ctx, "status", status, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	checks, err := s.Checks(ctx, "o/r", "sha1")
+	if err != nil {
+		t.Fatalf("Checks: %v", err)
+	}
+	if len(checks) != 2 {
+		t.Fatalf("want 2 checks for sha1, got %d: %+v", len(checks), checks)
+	}
+	byName := map[string]Check{}
+	for _, c := range checks {
+		byName[c.Name] = c
+	}
+	if c := byName["go test"]; c.Kind != CheckKindRun || c.Conclusion != "success" {
+		t.Fatalf("check_run row = %+v", c)
+	}
+	if c := byName["ci/lint"]; c.Kind != CheckKindStatus || c.Status != "failure" || c.Conclusion != "failure" {
+		t.Fatalf("status row = %+v", c)
+	}
+}
+
+func TestProjectReviewAndComments(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	review := []byte(`{
+		"review": {"id": 555, "state": "approved", "body": "LGTM",
+			"user": {"login": "rev"}, "submitted_at": "2026-07-02T10:05:00Z"},
+		"pull_request": {"number": 828},
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "pull_request_review", review, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	rev, ok, err := s.GetReview(ctx, "o/r", 555)
+	if err != nil || !ok {
+		t.Fatalf("GetReview ok=%v err=%v", ok, err)
+	}
+	if rev.PRNumber != 828 || rev.State != "approved" || rev.Author != "rev" {
+		t.Fatalf("review row = %+v", rev)
+	}
+
+	// issue_comment on a PR (issue.pull_request present) is recorded as a PR subject.
+	prComment := []byte(`{
+		"issue": {"number": 828, "pull_request": {"url": "x"}},
+		"comment": {"id": 900, "body": "note", "user": {"login": "u"},
+			"updated_at": "2026-07-02T11:00:00Z"},
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "issue_comment", prComment, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	c, ok, err := s.GetComment(ctx, "o/r", 900)
+	if err != nil || !ok {
+		t.Fatalf("GetComment ok=%v err=%v", ok, err)
+	}
+	if c.SubjectType != SubjectPullRequest || c.SubjectNumber != 828 || c.Body != "note" {
+		t.Fatalf("comment row = %+v", c)
+	}
+}
+
+func TestProjectProjectItem(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	payload := []byte(`{
+		"action": "edited",
+		"projects_v2_item": {"node_id": "PVTI_x", "content_type": "Issue",
+			"updated_at": "2026-07-02T12:00:00Z"},
+		"changes": {"field_value": {"to": {"name": "In Progress"}}},
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "projects_v2_item", payload, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	it, ok, err := s.GetProjectItem(ctx, "o/r", "PVTI_x")
+	if err != nil || !ok {
+		t.Fatalf("GetProjectItem ok=%v err=%v", ok, err)
+	}
+	if it.ContentType != "Issue" || it.Status != "In Progress" {
+		t.Fatalf("project item row = %+v", it)
+	}
+}
+
+// TestProjectUnmodelledEventIsNoop confirms an event the mirror does not model is
+// silently skipped (and never errors), so widening coverage later needs no
+// re-ingestion.
+func TestProjectUnmodelledEventIsNoop(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	for _, ev := range []string{"ping", "label", "check_suite", "membership"} {
+		if err := s.ProjectWebhook(ctx, ev, []byte(`{"repository":{"full_name":"o/r"}}`), time.Time{}); err != nil {
+			t.Fatalf("ProjectWebhook(%s) = %v, want nil", ev, err)
+		}
+	}
+	counts, _ := s.Counts(ctx)
+	if counts.Total() != 0 {
+		t.Fatalf("unmodelled events wrote rows: %+v", counts)
+	}
+}
+
+// TestProjectFallsBackToReceivedAt confirms a payload with no resource timestamp
+// orders by the delivery's received_at.
+func TestProjectFallsBackToReceivedAt(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	recv := mustTime(t, "2026-07-05T08:00:00Z")
+	payload := []byte(`{"issue":{"number":3,"title":"t","state":"open"},"repository":{"full_name":"o/r"}}`)
+	if err := s.ProjectWebhook(ctx, "issues", payload, recv); err != nil {
+		t.Fatal(err)
+	}
+	row, _, _ := s.GetIssue(ctx, "o/r", 3)
+	if !row.LastSeenAt.Equal(recv) {
+		t.Fatalf("last_seen_at = %v, want received_at %v", row.LastSeenAt, recv)
+	}
+}

--- a/internal/mirrorstore/replay_test.go
+++ b/internal/mirrorstore/replay_test.go
@@ -162,6 +162,7 @@ func TestReplayIssueMatchesAPIHydration(t *testing.T) {
 		Number: 824,
 		Title:  "Webhook ingestion into the unified SQLite store",
 		Body:   "Land signed webhook deliveries durably.",
+		State:  "open",
 		Labels: []struct {
 			Name string `json:"name"`
 		}{{Name: "maestro-ready"}, {Name: "phase-b"}},

--- a/internal/mirrorstore/replay_test.go
+++ b/internal/mirrorstore/replay_test.go
@@ -1,0 +1,198 @@
+package mirrorstore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+// delivery is one recorded webhook from the stream fixture: its event type
+// (derived from the "NN.eventtype.json" filename) and its raw payload.
+type delivery struct {
+	name      string
+	eventType string
+	payload   []byte
+}
+
+// loadStream reads testdata/stream/*.json in filename order. The numeric prefix
+// gives the recorded delivery order; the middle dotted segment is the
+// X-GitHub-Event type (e.g. "03.pull_request.json" → "pull_request").
+func loadStream(t *testing.T) []delivery {
+	t.Helper()
+	dir := filepath.Join("testdata", "stream")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read stream dir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	out := make([]delivery, 0, len(names))
+	for _, name := range names {
+		parts := strings.Split(name, ".")
+		if len(parts) < 3 {
+			t.Fatalf("unexpected fixture name %q (want NN.eventtype.json)", name)
+		}
+		eventType := strings.Join(parts[1:len(parts)-1], ".")
+		payload, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		out = append(out, delivery{name: name, eventType: eventType, payload: payload})
+	}
+	return out
+}
+
+func replay(t *testing.T, s *Store, stream []delivery, recv time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	for _, d := range stream {
+		if err := s.ProjectWebhook(ctx, d.eventType, d.payload, recv); err != nil {
+			t.Fatalf("project %s: %v", d.name, err)
+		}
+	}
+}
+
+// assertSnapshot asserts the mirror holds exactly the normalised state the
+// recorded stream describes for BeFeast/maestro — the "direct API snapshot" the
+// stream is expected to reproduce (#825 AC 1).
+func assertSnapshot(t *testing.T, s *Store) {
+	t.Helper()
+	ctx := context.Background()
+	const repo = "BeFeast/maestro"
+
+	issue, ok, err := s.GetIssue(ctx, repo, 824)
+	if err != nil || !ok {
+		t.Fatalf("issue 824 ok=%v err=%v", ok, err)
+	}
+	if issue.Title != "Webhook ingestion into the unified SQLite store" || issue.State != "open" {
+		t.Fatalf("issue snapshot mismatch: %+v", issue)
+	}
+	if labels, _ := s.Labels(ctx, repo, SubjectIssue, 824); !equalStrings(labels, []string{"maestro-ready", "phase-b"}) {
+		t.Fatalf("issue labels snapshot mismatch: %v", labels)
+	}
+
+	pr, ok, err := s.GetPullRequest(ctx, repo, 828)
+	if err != nil || !ok {
+		t.Fatalf("pr 828 ok=%v err=%v", ok, err)
+	}
+	if pr.State != "open" || pr.Merged || pr.HeadSHA != "0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e" || pr.BaseRef != "main" {
+		t.Fatalf("pr snapshot mismatch: %+v", pr)
+	}
+
+	checks, err := s.Checks(ctx, repo, "0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e")
+	if err != nil {
+		t.Fatalf("checks: %v", err)
+	}
+	if len(checks) != 1 || checks[0].Name != "go test ./..." || checks[0].Conclusion != "success" {
+		t.Fatalf("checks snapshot mismatch: %+v", checks)
+	}
+
+	rev, ok, err := s.GetReview(ctx, repo, 555111222)
+	if err != nil || !ok {
+		t.Fatalf("review ok=%v err=%v", ok, err)
+	}
+	if rev.PRNumber != 828 || rev.State != "approved" {
+		t.Fatalf("review snapshot mismatch: %+v", rev)
+	}
+
+	c, ok, err := s.GetComment(ctx, repo, 700800900)
+	if err != nil || !ok {
+		t.Fatalf("comment ok=%v err=%v", ok, err)
+	}
+	if c.SubjectNumber != 824 || c.Author != "octocat" {
+		t.Fatalf("comment snapshot mismatch: %+v", c)
+	}
+}
+
+// TestReplayMatchesSnapshot covers AC 1: replaying a recorded webhook stream
+// produces the mirror an operator would get by reading the repo directly.
+func TestReplayMatchesSnapshot(t *testing.T) {
+	s := openTestStore(t)
+	stream := loadStream(t)
+	replay(t, s, stream, mustTime(t, "2026-07-02T12:00:00Z"))
+	assertSnapshot(t, s)
+}
+
+// TestReplayOutOfOrderConverges covers AC 2 at the stream level: replaying the
+// SAME deliveries in reverse (and then forward again) converges to the identical
+// snapshot, because every upsert is guarded by the resource timestamp.
+func TestReplayOutOfOrderConverges(t *testing.T) {
+	s := openTestStore(t)
+	stream := loadStream(t)
+
+	reversed := make([]delivery, len(stream))
+	for i, d := range stream {
+		reversed[len(stream)-1-i] = d
+	}
+	recv := mustTime(t, "2026-07-02T12:00:00Z")
+	replay(t, s, reversed, recv) // out of order
+	replay(t, s, stream, recv)   // duplicate, in order
+	replay(t, s, reversed, recv) // out of order again
+	assertSnapshot(t, s)
+}
+
+// TestReplayIssueMatchesAPIHydration is the concrete "mirror matches a direct API
+// snapshot" equivalence: the issue row + labels produced by replaying the webhook
+// stream equal those produced by hydrating the same issue straight from the API,
+// ignoring only the bookkeeping fields (source, last_seen_at).
+func TestReplayIssueMatchesAPIHydration(t *testing.T) {
+	ctx := context.Background()
+
+	// (a) webhook-projected mirror.
+	webhookMirror := openTestStore(t)
+	replay(t, webhookMirror, loadStream(t), mustTime(t, "2026-07-02T12:00:00Z"))
+	wIssue, _, _ := webhookMirror.GetIssue(ctx, "BeFeast/maestro", 824)
+	wLabels, _ := webhookMirror.Labels(ctx, "BeFeast/maestro", SubjectIssue, 824)
+
+	// (b) API-hydrated mirror: the fake client returns the same final issue state a
+	// direct GET would, and the hydrator records it on the miss.
+	apiMirror := openTestStore(t)
+	fake := &fakeGitHub{issue: github.Issue{
+		Number: 824,
+		Title:  "Webhook ingestion into the unified SQLite store",
+		Body:   "Land signed webhook deliveries durably.",
+		Labels: []struct {
+			Name string `json:"name"`
+		}{{Name: "maestro-ready"}, {Name: "phase-b"}},
+	}}
+	h := NewHydrator(apiMirror, fake, "BeFeast/maestro")
+	if _, err := h.Issue(ctx, 824); err != nil {
+		t.Fatalf("hydrate: %v", err)
+	}
+	aIssue, _, _ := apiMirror.GetIssue(ctx, "BeFeast/maestro", 824)
+	aLabels, _ := apiMirror.Labels(ctx, "BeFeast/maestro", SubjectIssue, 824)
+
+	if wIssue.Number != aIssue.Number || wIssue.Title != aIssue.Title || wIssue.Body != aIssue.Body || wIssue.State != aIssue.State {
+		t.Fatalf("webhook vs API issue mismatch:\n webhook=%+v\n api=%+v", wIssue, aIssue)
+	}
+	if !equalStrings(wLabels, aLabels) {
+		t.Fatalf("webhook vs API labels mismatch: webhook=%v api=%v", wLabels, aLabels)
+	}
+	// The bookkeeping differs, as it should: one was pushed, one was pulled.
+	if wIssue.Source != SourceWebhook || aIssue.Source != SourceAPI {
+		t.Fatalf("source bookkeeping wrong: webhook=%q api=%q", wIssue.Source, aIssue.Source)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mirrorstore/store.go
+++ b/internal/mirrorstore/store.go
@@ -313,10 +313,21 @@ type ProjectItem struct {
 // for an issue) gate that work on the returned applied flag so a stale parent
 // event does not clobber a fresher child set.
 
+// execer is the subset of *sql.DB / *sql.Tx the guarded upserts need, so the same
+// upsert body can run either standalone (against the pool) or inside a
+// transaction that also reconciles a dependent set (labels).
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
 // UpsertIssue writes or refreshes an issue row, guarded by last_seen_at. Returns
 // applied=false when a strictly-older event was rejected.
 func (s *Store) UpsertIssue(ctx context.Context, r Issue) (applied bool, err error) {
-	res, err := s.db.ExecContext(ctx, `
+	return upsertIssue(ctx, s.db, r)
+}
+
+func upsertIssue(ctx context.Context, ex execer, r Issue) (bool, error) {
+	res, err := ex.ExecContext(ctx, `
 INSERT INTO mirror_issues (repo, number, title, state, body, last_seen_at, source)
 VALUES (?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(repo, number) DO UPDATE SET
@@ -332,7 +343,11 @@ WHERE excluded.last_seen_at >= mirror_issues.last_seen_at`,
 
 // UpsertPullRequest writes or refreshes a PR row, guarded by last_seen_at.
 func (s *Store) UpsertPullRequest(ctx context.Context, r PullRequest) (applied bool, err error) {
-	res, err := s.db.ExecContext(ctx, `
+	return upsertPullRequest(ctx, s.db, r)
+}
+
+func upsertPullRequest(ctx context.Context, ex execer, r PullRequest) (bool, error) {
+	res, err := ex.ExecContext(ctx, `
 INSERT INTO mirror_pull_requests (repo, number, title, state, draft, merged, head_sha, base_ref, last_seen_at, source)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(repo, number) DO UPDATE SET
@@ -348,6 +363,49 @@ WHERE excluded.last_seen_at >= mirror_pull_requests.last_seen_at`,
 		r.Repo, r.Number, r.Title, r.State, boolToInt(r.Draft), boolToInt(r.Merged),
 		r.HeadSHA, r.BaseRef, formatTS(r.LastSeenAt), r.Source)
 	return rowsApplied(res, err)
+}
+
+// UpsertIssueWithLabels writes the issue row and, only when that write applied
+// (i.e. the event was not stale), reconciles the full label set — both inside ONE
+// transaction. The shared handle is single-connection, so the transaction holds it
+// for the whole logical update; a concurrent newer delivery cannot interleave its
+// own upsert+labels between this upsert and its label replace and then have this
+// (older) goroutine delete the fresher labels. The label set is thus reconciled
+// under the SAME timestamp guard as the parent row, closing the race a separate
+// UpsertIssue-then-ReplaceLabels sequence left open (#825 AC 2).
+func (s *Store) UpsertIssueWithLabels(ctx context.Context, r Issue, labels []string) (applied bool, err error) {
+	return s.upsertWithLabels(ctx, SubjectIssue, r.Repo, r.Number, r.LastSeenAt, r.Source, labels,
+		func(ex execer) (bool, error) { return upsertIssue(ctx, ex, r) })
+}
+
+// UpsertPullRequestWithLabels is UpsertIssueWithLabels for a pull request: the PR
+// row and its labels are reconciled atomically under one timestamp guard.
+func (s *Store) UpsertPullRequestWithLabels(ctx context.Context, r PullRequest, labels []string) (applied bool, err error) {
+	return s.upsertWithLabels(ctx, SubjectPullRequest, r.Repo, r.Number, r.LastSeenAt, r.Source, labels,
+		func(ex execer) (bool, error) { return upsertPullRequest(ctx, ex, r) })
+}
+
+// upsertWithLabels runs upsert inside a transaction and, when it applied, replaces
+// the subject's labels in the same transaction so both share one timestamp guard.
+func (s *Store) upsertWithLabels(ctx context.Context, subjectType, repo string, subjectNumber int, ts time.Time, source string, labels []string, upsert func(execer) (bool, error)) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+	applied, err := upsert(tx)
+	if err != nil {
+		return false, err
+	}
+	if applied {
+		if err := replaceLabelsTx(ctx, tx, repo, subjectType, subjectNumber, labels, ts, source); err != nil {
+			return false, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return applied, nil
 }
 
 // UpsertComment writes or refreshes a comment row, guarded by last_seen_at.
@@ -366,6 +424,18 @@ WHERE excluded.last_seen_at >= mirror_comments.last_seen_at`,
 		r.Repo, r.CommentID, r.SubjectType, r.SubjectNumber, r.Author, r.Body,
 		formatTS(r.LastSeenAt), r.Source)
 	return rowsApplied(res, err)
+}
+
+// DeleteComment removes the mirror comment row for (repo, commentID). It is called
+// when a deletion webhook arrives (issue_comment or pull_request_review_comment
+// with action "deleted") so the read model stops exposing — and stops staleness
+// diagnostics from tracking — a comment that no longer exists on GitHub. A comment
+// id is never reused, so a straight delete keeps the mirror matching the direct
+// API snapshot. Idempotent: deleting an absent row is a no-op.
+func (s *Store) DeleteComment(ctx context.Context, repo string, commentID int64) error {
+	_, err := s.db.ExecContext(ctx, `
+DELETE FROM mirror_comments WHERE repo = ? AND comment_id = ?`, repo, commentID)
+	return err
 }
 
 // UpsertReview writes or refreshes a review row, guarded by last_seen_at.
@@ -434,6 +504,16 @@ func (s *Store) ReplaceLabels(ctx context.Context, repo, subjectType string, sub
 		return err
 	}
 	defer tx.Rollback()
+	if err := replaceLabelsTx(ctx, tx, repo, subjectType, subjectNumber, names, ts, source); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// replaceLabelsTx is the transaction body of ReplaceLabels, factored out so the
+// same delete-then-insert can run inside a caller's transaction (upsertWithLabels)
+// and share that transaction's timestamp guard rather than racing it.
+func replaceLabelsTx(ctx context.Context, tx *sql.Tx, repo, subjectType string, subjectNumber int, names []string, ts time.Time, source string) error {
 	if _, err := tx.ExecContext(ctx, `
 DELETE FROM mirror_labels WHERE repo = ? AND subject_type = ? AND subject_number = ?`,
 		repo, subjectType, subjectNumber); err != nil {
@@ -451,7 +531,7 @@ VALUES (?, ?, ?, ?, ?, ?)`, repo, subjectType, subjectNumber, name, stamp, sourc
 			return err
 		}
 	}
-	return tx.Commit()
+	return nil
 }
 
 // ---- Reads -----------------------------------------------------------------

--- a/internal/mirrorstore/store.go
+++ b/internal/mirrorstore/store.go
@@ -1,0 +1,746 @@
+// Package mirrorstore is the GitHub read-model mirror in the SAME shared
+// maestro.db that internal/webhookstore, internal/approvalstore and
+// internal/statestore already use (epic #811, phase C — issue #825).
+//
+// Phase B (#824) lands raw webhook deliveries verbatim. This phase projects
+// those deliveries into normalised, queryable tables — issues, pull requests,
+// labels, comments, reviews, check/CI status and Projects v2 items — so the
+// supervisor/orchestrator can eventually read GitHub state locally instead of
+// polling the API on every cycle. It does NOT switch any read path over yet;
+// that is phase D. This phase only builds and populates the model.
+//
+// Three properties make the mirror trustworthy:
+//
+//   - Ordering-safety. Every row carries last_seen_at, the source resource's own
+//     timestamp (issue.updated_at, review.submitted_at, check_run.completed_at,
+//     …). An upsert applies only when the incoming last_seen_at is >= the stored
+//     one, so an out-of-order or duplicate redelivery never regresses a row to an
+//     older state. GitHub retries and operator replays are therefore idempotent.
+//
+//   - Explicit staleness. Rows do not expire, but a reader can classify any row
+//     as fresh / stale / missing against a configurable horizon (Classify), and
+//     diagnostics expose per-entity stale counts (StaleCounts) so an operator can
+//     see how much of the mirror is lagging.
+//
+//   - Hydration. On a mirror miss a reader can fetch the entity via the existing
+//     internal/github client, record it (source = "api"), and return — so the
+//     mirror converges to full coverage without a bulk backfill (see hydrate.go).
+//
+// Each package owns disjoint tables in the one maestro.db file; the schema here
+// only ever CREATE ... IF NOT EXISTS, so Init is idempotent and an existing
+// fleet upgrades with no manual migration step (#825 AC 5).
+package mirrorstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// Source records how a mirror row was last written: from an ingested webhook
+// delivery, or from an on-demand API hydration on a mirror miss. Readers can use
+// it to tell "pushed to us" from "we pulled it".
+const (
+	SourceWebhook = "webhook"
+	SourceAPI     = "api"
+)
+
+// Subject kinds for rows that hang off an issue or a pull request (labels,
+// comments). GitHub models a PR as an issue for comments, so a comment can carry
+// either subject type.
+const (
+	SubjectIssue       = "issue"
+	SubjectPullRequest = "pull_request"
+)
+
+// Check kinds distinguish a Checks-API check_run from a legacy commit-status
+// context; both land in mirror_checks keyed by (repo, head_sha, name).
+const (
+	CheckKindRun    = "check_run"
+	CheckKindStatus = "status"
+)
+
+// tsLayout is a FIXED-WIDTH, UTC, nanosecond-precision timestamp layout, the
+// same shape internal/webhookstore uses. last_seen_at is stored as TEXT and both
+// the ordering-safety guard (excluded.last_seen_at >= mirror.last_seen_at) and
+// the staleness query (last_seen_at < cutoff) compare it lexically, so its byte
+// order must equal its chronological order. Padding to a constant nine
+// fractional digits and always emitting "Z" keeps the field constant-width, so
+// byte-order == time-order regardless of a source timestamp's own precision.
+const tsLayout = "2006-01-02T15:04:05.000000000Z07:00"
+
+func formatTS(t time.Time) string { return t.UTC().Format(tsLayout) }
+
+func parseTS(s string) (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, strings.TrimSpace(s))
+}
+
+// Schema creates the mirror tables. IF NOT EXISTS so Init is idempotent and safe
+// to run against the same maestro.db the other stores initialise. Timestamps are
+// TEXT in tsLayout; booleans are INTEGER 0/1.
+const Schema = `
+CREATE TABLE IF NOT EXISTS mirror_issues (
+	repo         TEXT    NOT NULL,
+	number       INTEGER NOT NULL,
+	title        TEXT    NOT NULL DEFAULT '',
+	state        TEXT    NOT NULL DEFAULT '',
+	body         TEXT    NOT NULL DEFAULT '',
+	last_seen_at TEXT    NOT NULL DEFAULT '',
+	source       TEXT    NOT NULL DEFAULT '',
+	PRIMARY KEY (repo, number)
+);
+
+CREATE TABLE IF NOT EXISTS mirror_pull_requests (
+	repo         TEXT    NOT NULL,
+	number       INTEGER NOT NULL,
+	title        TEXT    NOT NULL DEFAULT '',
+	state        TEXT    NOT NULL DEFAULT '',
+	draft        INTEGER NOT NULL DEFAULT 0,
+	merged       INTEGER NOT NULL DEFAULT 0,
+	head_sha     TEXT    NOT NULL DEFAULT '',
+	base_ref     TEXT    NOT NULL DEFAULT '',
+	last_seen_at TEXT    NOT NULL DEFAULT '',
+	source       TEXT    NOT NULL DEFAULT '',
+	PRIMARY KEY (repo, number)
+);
+
+CREATE TABLE IF NOT EXISTS mirror_labels (
+	repo           TEXT    NOT NULL,
+	subject_type   TEXT    NOT NULL,
+	subject_number INTEGER NOT NULL,
+	name           TEXT    NOT NULL,
+	last_seen_at   TEXT    NOT NULL DEFAULT '',
+	source         TEXT    NOT NULL DEFAULT '',
+	PRIMARY KEY (repo, subject_type, subject_number, name)
+);
+
+CREATE TABLE IF NOT EXISTS mirror_comments (
+	repo           TEXT    NOT NULL,
+	comment_id     INTEGER NOT NULL,
+	subject_type   TEXT    NOT NULL DEFAULT '',
+	subject_number INTEGER NOT NULL DEFAULT 0,
+	author         TEXT    NOT NULL DEFAULT '',
+	body           TEXT    NOT NULL DEFAULT '',
+	last_seen_at   TEXT    NOT NULL DEFAULT '',
+	source         TEXT    NOT NULL DEFAULT '',
+	PRIMARY KEY (repo, comment_id)
+);
+
+CREATE TABLE IF NOT EXISTS mirror_reviews (
+	repo         TEXT    NOT NULL,
+	review_id    INTEGER NOT NULL,
+	pr_number    INTEGER NOT NULL DEFAULT 0,
+	author       TEXT    NOT NULL DEFAULT '',
+	state        TEXT    NOT NULL DEFAULT '',
+	body         TEXT    NOT NULL DEFAULT '',
+	last_seen_at TEXT    NOT NULL DEFAULT '',
+	source       TEXT    NOT NULL DEFAULT '',
+	PRIMARY KEY (repo, review_id)
+);
+
+CREATE TABLE IF NOT EXISTS mirror_checks (
+	repo         TEXT    NOT NULL,
+	head_sha     TEXT    NOT NULL,
+	name         TEXT    NOT NULL,
+	kind         TEXT    NOT NULL DEFAULT '',
+	status       TEXT    NOT NULL DEFAULT '',
+	conclusion   TEXT    NOT NULL DEFAULT '',
+	last_seen_at TEXT    NOT NULL DEFAULT '',
+	source       TEXT    NOT NULL DEFAULT '',
+	PRIMARY KEY (repo, head_sha, name)
+);
+
+CREATE TABLE IF NOT EXISTS mirror_project_items (
+	repo           TEXT    NOT NULL,
+	item_id        TEXT    NOT NULL,
+	content_type   TEXT    NOT NULL DEFAULT '',
+	content_number INTEGER NOT NULL DEFAULT 0,
+	status         TEXT    NOT NULL DEFAULT '',
+	last_seen_at   TEXT    NOT NULL DEFAULT '',
+	source         TEXT    NOT NULL DEFAULT '',
+	PRIMARY KEY (repo, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mirror_checks_sha ON mirror_checks(repo, head_sha);
+CREATE INDEX IF NOT EXISTS idx_mirror_labels_subject ON mirror_labels(repo, subject_type, subject_number);
+CREATE INDEX IF NOT EXISTS idx_mirror_comments_subject ON mirror_comments(repo, subject_type, subject_number);
+CREATE INDEX IF NOT EXISTS idx_mirror_reviews_pr ON mirror_reviews(repo, pr_number);
+`
+
+// Store is the SQLite-backed GitHub mirror read model.
+type Store struct {
+	db *sql.DB
+}
+
+// DefaultDBPath is the shared database (~/.maestro/maestro.db) — the same file
+// approvalstore, statestore and webhookstore use. The mirror lives in its own
+// tables within that one file.
+func DefaultDBPath() string {
+	return filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.db")
+}
+
+// Open opens (creating the parent dir if needed) the database and ensures the
+// schema. The pragmas mirror internal/webhookstore: busy_timeout waits for a
+// lock instead of erroring, WAL lets a reader and writer proceed concurrently,
+// and MaxOpenConns(1) avoids the SQLITE_BUSY modernc/sqlite can report between
+// two pooled connections of the same process.
+func Open(path string) (*Store, error) {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("create mirror db dir %s: %w", dir, err)
+		}
+	}
+	dsn := path
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	dsn += sep + "_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	s := &Store{db: db}
+	if err := s.Init(context.Background()); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+// Close releases the underlying database handle.
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// Init creates the schema. Idempotent — safe to call on every daemon start, and
+// safe to run against a maestro.db that already has the other stores' tables.
+func (s *Store) Init(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, Schema)
+	return err
+}
+
+// ---- Row types -------------------------------------------------------------
+
+// Issue is one mirrored GitHub issue.
+type Issue struct {
+	Repo       string
+	Number     int
+	Title      string
+	State      string
+	Body       string
+	LastSeenAt time.Time
+	Source     string
+}
+
+// PullRequest is one mirrored GitHub pull request.
+type PullRequest struct {
+	Repo       string
+	Number     int
+	Title      string
+	State      string
+	Draft      bool
+	Merged     bool
+	HeadSHA    string
+	BaseRef    string
+	LastSeenAt time.Time
+	Source     string
+}
+
+// Comment is one mirrored issue or review comment.
+type Comment struct {
+	Repo          string
+	CommentID     int64
+	SubjectType   string
+	SubjectNumber int
+	Author        string
+	Body          string
+	LastSeenAt    time.Time
+	Source        string
+}
+
+// Review is one mirrored pull request review.
+type Review struct {
+	Repo       string
+	ReviewID   int64
+	PRNumber   int
+	Author     string
+	State      string
+	Body       string
+	LastSeenAt time.Time
+	Source     string
+}
+
+// Check is one mirrored check_run or commit-status row for a head SHA.
+type Check struct {
+	Repo       string
+	HeadSHA    string
+	Name       string
+	Kind       string
+	Status     string
+	Conclusion string
+	LastSeenAt time.Time
+	Source     string
+}
+
+// ProjectItem is one mirrored Projects v2 item.
+type ProjectItem struct {
+	Repo          string
+	ItemID        string
+	ContentType   string
+	ContentNumber int
+	Status        string
+	LastSeenAt    time.Time
+	Source        string
+}
+
+// ---- Ordering-safe upserts -------------------------------------------------
+//
+// Every upsert applies only when the incoming last_seen_at is >= the stored one
+// (the WHERE on the DO UPDATE). RowsAffected then tells the caller whether the
+// write landed: 1 for a fresh insert or an applied update, 0 for a stale event
+// whose guard rejected it. Callers that must reconcile a dependent set (labels
+// for an issue) gate that work on the returned applied flag so a stale parent
+// event does not clobber a fresher child set.
+
+// UpsertIssue writes or refreshes an issue row, guarded by last_seen_at. Returns
+// applied=false when a strictly-older event was rejected.
+func (s *Store) UpsertIssue(ctx context.Context, r Issue) (applied bool, err error) {
+	res, err := s.db.ExecContext(ctx, `
+INSERT INTO mirror_issues (repo, number, title, state, body, last_seen_at, source)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(repo, number) DO UPDATE SET
+	title = excluded.title,
+	state = excluded.state,
+	body = excluded.body,
+	last_seen_at = excluded.last_seen_at,
+	source = excluded.source
+WHERE excluded.last_seen_at >= mirror_issues.last_seen_at`,
+		r.Repo, r.Number, r.Title, r.State, r.Body, formatTS(r.LastSeenAt), r.Source)
+	return rowsApplied(res, err)
+}
+
+// UpsertPullRequest writes or refreshes a PR row, guarded by last_seen_at.
+func (s *Store) UpsertPullRequest(ctx context.Context, r PullRequest) (applied bool, err error) {
+	res, err := s.db.ExecContext(ctx, `
+INSERT INTO mirror_pull_requests (repo, number, title, state, draft, merged, head_sha, base_ref, last_seen_at, source)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(repo, number) DO UPDATE SET
+	title = excluded.title,
+	state = excluded.state,
+	draft = excluded.draft,
+	merged = excluded.merged,
+	head_sha = excluded.head_sha,
+	base_ref = excluded.base_ref,
+	last_seen_at = excluded.last_seen_at,
+	source = excluded.source
+WHERE excluded.last_seen_at >= mirror_pull_requests.last_seen_at`,
+		r.Repo, r.Number, r.Title, r.State, boolToInt(r.Draft), boolToInt(r.Merged),
+		r.HeadSHA, r.BaseRef, formatTS(r.LastSeenAt), r.Source)
+	return rowsApplied(res, err)
+}
+
+// UpsertComment writes or refreshes a comment row, guarded by last_seen_at.
+func (s *Store) UpsertComment(ctx context.Context, r Comment) (applied bool, err error) {
+	res, err := s.db.ExecContext(ctx, `
+INSERT INTO mirror_comments (repo, comment_id, subject_type, subject_number, author, body, last_seen_at, source)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(repo, comment_id) DO UPDATE SET
+	subject_type = excluded.subject_type,
+	subject_number = excluded.subject_number,
+	author = excluded.author,
+	body = excluded.body,
+	last_seen_at = excluded.last_seen_at,
+	source = excluded.source
+WHERE excluded.last_seen_at >= mirror_comments.last_seen_at`,
+		r.Repo, r.CommentID, r.SubjectType, r.SubjectNumber, r.Author, r.Body,
+		formatTS(r.LastSeenAt), r.Source)
+	return rowsApplied(res, err)
+}
+
+// UpsertReview writes or refreshes a review row, guarded by last_seen_at.
+func (s *Store) UpsertReview(ctx context.Context, r Review) (applied bool, err error) {
+	res, err := s.db.ExecContext(ctx, `
+INSERT INTO mirror_reviews (repo, review_id, pr_number, author, state, body, last_seen_at, source)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(repo, review_id) DO UPDATE SET
+	pr_number = excluded.pr_number,
+	author = excluded.author,
+	state = excluded.state,
+	body = excluded.body,
+	last_seen_at = excluded.last_seen_at,
+	source = excluded.source
+WHERE excluded.last_seen_at >= mirror_reviews.last_seen_at`,
+		r.Repo, r.ReviewID, r.PRNumber, r.Author, r.State, r.Body,
+		formatTS(r.LastSeenAt), r.Source)
+	return rowsApplied(res, err)
+}
+
+// UpsertCheck writes or refreshes a check/status row, guarded by last_seen_at.
+func (s *Store) UpsertCheck(ctx context.Context, r Check) (applied bool, err error) {
+	res, err := s.db.ExecContext(ctx, `
+INSERT INTO mirror_checks (repo, head_sha, name, kind, status, conclusion, last_seen_at, source)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(repo, head_sha, name) DO UPDATE SET
+	kind = excluded.kind,
+	status = excluded.status,
+	conclusion = excluded.conclusion,
+	last_seen_at = excluded.last_seen_at,
+	source = excluded.source
+WHERE excluded.last_seen_at >= mirror_checks.last_seen_at`,
+		r.Repo, r.HeadSHA, r.Name, r.Kind, r.Status, r.Conclusion,
+		formatTS(r.LastSeenAt), r.Source)
+	return rowsApplied(res, err)
+}
+
+// UpsertProjectItem writes or refreshes a Projects v2 item row, guarded by
+// last_seen_at.
+func (s *Store) UpsertProjectItem(ctx context.Context, r ProjectItem) (applied bool, err error) {
+	res, err := s.db.ExecContext(ctx, `
+INSERT INTO mirror_project_items (repo, item_id, content_type, content_number, status, last_seen_at, source)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(repo, item_id) DO UPDATE SET
+	content_type = excluded.content_type,
+	content_number = excluded.content_number,
+	status = excluded.status,
+	last_seen_at = excluded.last_seen_at,
+	source = excluded.source
+WHERE excluded.last_seen_at >= mirror_project_items.last_seen_at`,
+		r.Repo, r.ItemID, r.ContentType, r.ContentNumber, r.Status,
+		formatTS(r.LastSeenAt), r.Source)
+	return rowsApplied(res, err)
+}
+
+// ReplaceLabels reconciles the FULL label set for a subject atomically: it clears
+// the subject's existing labels and inserts the given names, all stamped at ts.
+// GitHub webhook payloads carry the complete current label array on the issue /
+// PR object, so a whole-set replace is both simpler and more correct than
+// per-label add/remove — and ordering-safety is inherited from the caller, which
+// only replaces labels when the parent issue/PR upsert applied (i.e. this event
+// was not stale). An empty names slice clears the subject's labels.
+func (s *Store) ReplaceLabels(ctx context.Context, repo, subjectType string, subjectNumber int, names []string, ts time.Time, source string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `
+DELETE FROM mirror_labels WHERE repo = ? AND subject_type = ? AND subject_number = ?`,
+		repo, subjectType, subjectNumber); err != nil {
+		return err
+	}
+	stamp := formatTS(ts)
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT OR REPLACE INTO mirror_labels (repo, subject_type, subject_number, name, last_seen_at, source)
+VALUES (?, ?, ?, ?, ?, ?)`, repo, subjectType, subjectNumber, name, stamp, source); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// ---- Reads -----------------------------------------------------------------
+
+// GetIssue returns the mirror issue row for (repo, number), or ok=false on a
+// miss. A miss is the signal for a reader to hydrate (see Hydrator).
+func (s *Store) GetIssue(ctx context.Context, repo string, number int) (Issue, bool, error) {
+	var (
+		r    Issue
+		seen string
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT repo, number, title, state, body, last_seen_at, source
+FROM mirror_issues WHERE repo = ? AND number = ?`, repo, number).
+		Scan(&r.Repo, &r.Number, &r.Title, &r.State, &r.Body, &seen, &r.Source)
+	if err == sql.ErrNoRows {
+		return Issue{}, false, nil
+	}
+	if err != nil {
+		return Issue{}, false, err
+	}
+	r.LastSeenAt, _ = parseTS(seen)
+	return r, true, nil
+}
+
+// GetPullRequest returns the mirror PR row for (repo, number), or ok=false on a
+// miss.
+func (s *Store) GetPullRequest(ctx context.Context, repo string, number int) (PullRequest, bool, error) {
+	var (
+		r             PullRequest
+		draft, merged int
+		seen          string
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT repo, number, title, state, draft, merged, head_sha, base_ref, last_seen_at, source
+FROM mirror_pull_requests WHERE repo = ? AND number = ?`, repo, number).
+		Scan(&r.Repo, &r.Number, &r.Title, &r.State, &draft, &merged, &r.HeadSHA, &r.BaseRef, &seen, &r.Source)
+	if err == sql.ErrNoRows {
+		return PullRequest{}, false, nil
+	}
+	if err != nil {
+		return PullRequest{}, false, err
+	}
+	r.Draft = draft != 0
+	r.Merged = merged != 0
+	r.LastSeenAt, _ = parseTS(seen)
+	return r, true, nil
+}
+
+// Labels returns the mirrored label names for a subject, sorted, or an empty
+// slice when the subject has none.
+func (s *Store) Labels(ctx context.Context, repo, subjectType string, subjectNumber int) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT name FROM mirror_labels
+WHERE repo = ? AND subject_type = ? AND subject_number = ?
+ORDER BY name`, repo, subjectType, subjectNumber)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out = append(out, name)
+	}
+	return out, rows.Err()
+}
+
+// GetComment returns the mirror comment row for (repo, commentID), or ok=false.
+func (s *Store) GetComment(ctx context.Context, repo string, commentID int64) (Comment, bool, error) {
+	var (
+		r    Comment
+		seen string
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT repo, comment_id, subject_type, subject_number, author, body, last_seen_at, source
+FROM mirror_comments WHERE repo = ? AND comment_id = ?`, repo, commentID).
+		Scan(&r.Repo, &r.CommentID, &r.SubjectType, &r.SubjectNumber, &r.Author, &r.Body, &seen, &r.Source)
+	if err == sql.ErrNoRows {
+		return Comment{}, false, nil
+	}
+	if err != nil {
+		return Comment{}, false, err
+	}
+	r.LastSeenAt, _ = parseTS(seen)
+	return r, true, nil
+}
+
+// GetReview returns the mirror review row for (repo, reviewID), or ok=false.
+func (s *Store) GetReview(ctx context.Context, repo string, reviewID int64) (Review, bool, error) {
+	var (
+		r    Review
+		seen string
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT repo, review_id, pr_number, author, state, body, last_seen_at, source
+FROM mirror_reviews WHERE repo = ? AND review_id = ?`, repo, reviewID).
+		Scan(&r.Repo, &r.ReviewID, &r.PRNumber, &r.Author, &r.State, &r.Body, &seen, &r.Source)
+	if err == sql.ErrNoRows {
+		return Review{}, false, nil
+	}
+	if err != nil {
+		return Review{}, false, err
+	}
+	r.LastSeenAt, _ = parseTS(seen)
+	return r, true, nil
+}
+
+// Checks returns the mirrored check/status rows for a head SHA, sorted by name.
+func (s *Store) Checks(ctx context.Context, repo, headSHA string) ([]Check, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT repo, head_sha, name, kind, status, conclusion, last_seen_at, source
+FROM mirror_checks WHERE repo = ? AND head_sha = ?
+ORDER BY name`, repo, headSHA)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Check
+	for rows.Next() {
+		var (
+			r    Check
+			seen string
+		)
+		if err := rows.Scan(&r.Repo, &r.HeadSHA, &r.Name, &r.Kind, &r.Status, &r.Conclusion, &seen, &r.Source); err != nil {
+			return nil, err
+		}
+		r.LastSeenAt, _ = parseTS(seen)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// GetProjectItem returns the mirror Projects v2 item row for (repo, itemID), or
+// ok=false.
+func (s *Store) GetProjectItem(ctx context.Context, repo, itemID string) (ProjectItem, bool, error) {
+	var (
+		r    ProjectItem
+		seen string
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT repo, item_id, content_type, content_number, status, last_seen_at, source
+FROM mirror_project_items WHERE repo = ? AND item_id = ?`, repo, itemID).
+		Scan(&r.Repo, &r.ItemID, &r.ContentType, &r.ContentNumber, &r.Status, &seen, &r.Source)
+	if err == sql.ErrNoRows {
+		return ProjectItem{}, false, nil
+	}
+	if err != nil {
+		return ProjectItem{}, false, err
+	}
+	r.LastSeenAt, _ = parseTS(seen)
+	return r, true, nil
+}
+
+// ---- Staleness -------------------------------------------------------------
+
+// DefaultStaleHorizon is the fallback staleness horizon: a mirror row not
+// refreshed by a webhook or hydration within this window is reported stale in
+// diagnostics. Chosen conservatively — the mirror is refreshed by pushes, so a
+// row older than a day almost certainly means deliveries stopped arriving for
+// that repo, which is exactly what an operator wants surfaced. Callers pass their
+// own horizon to Classify / StaleCounts; this is only the wiring default.
+const DefaultStaleHorizon = 24 * time.Hour
+
+// Freshness classifies a mirror row against a staleness horizon. Missing is the
+// zero value so a caller that forgot to check "ok" first still reads a safe
+// "we don't have it" rather than a false "fresh".
+type Freshness int
+
+const (
+	// Missing: the mirror has no row for the entity (the caller's GetX returned
+	// ok=false). Hydrate to fill it.
+	Missing Freshness = iota
+	// Stale: the row exists but its last_seen_at is older than the horizon.
+	Stale
+	// Fresh: the row exists and is within the horizon.
+	Fresh
+)
+
+func (f Freshness) String() string {
+	switch f {
+	case Fresh:
+		return "fresh"
+	case Stale:
+		return "stale"
+	default:
+		return "missing"
+	}
+}
+
+// Classify reports whether a row last seen at lastSeen is Fresh or Stale at now
+// under horizon. A non-positive horizon means "never stale" (every present row
+// is Fresh). Callers pass Missing themselves when the row is absent; Classify
+// only ever returns Fresh or Stale.
+func Classify(lastSeen, now time.Time, horizon time.Duration) Freshness {
+	if horizon <= 0 {
+		return Fresh
+	}
+	if now.Sub(lastSeen) > horizon {
+		return Stale
+	}
+	return Fresh
+}
+
+// ---- Diagnostics -----------------------------------------------------------
+
+// Counts is the per-entity row tally exposed in diagnostics.
+type Counts struct {
+	Issues       int `json:"issues"`
+	PullRequests int `json:"pull_requests"`
+	Labels       int `json:"labels"`
+	Comments     int `json:"comments"`
+	Reviews      int `json:"reviews"`
+	Checks       int `json:"checks"`
+	ProjectItems int `json:"project_items"`
+}
+
+// Total is the sum across every entity type.
+func (c Counts) Total() int {
+	return c.Issues + c.PullRequests + c.Labels + c.Comments + c.Reviews + c.Checks + c.ProjectItems
+}
+
+// Counts returns the total mirrored row count per entity type.
+func (s *Store) Counts(ctx context.Context) (Counts, error) {
+	return s.countRows(ctx, "")
+}
+
+// StaleCounts returns the per-entity count of rows whose last_seen_at is older
+// than horizon at now — the queryable staleness diagnostic (#825 AC 4). A
+// non-positive horizon returns an all-zero Counts (nothing is ever stale).
+func (s *Store) StaleCounts(ctx context.Context, now time.Time, horizon time.Duration) (Counts, error) {
+	if horizon <= 0 {
+		return Counts{}, nil
+	}
+	cutoff := formatTS(now.Add(-horizon))
+	return s.countRows(ctx, cutoff)
+}
+
+// countRows tallies each mirror table. When cutoff is non-empty it counts only
+// rows with last_seen_at < cutoff (the stale set); otherwise it counts all rows.
+func (s *Store) countRows(ctx context.Context, cutoff string) (Counts, error) {
+	var c Counts
+	specs := []struct {
+		table string
+		dst   *int
+	}{
+		{"mirror_issues", &c.Issues},
+		{"mirror_pull_requests", &c.PullRequests},
+		{"mirror_labels", &c.Labels},
+		{"mirror_comments", &c.Comments},
+		{"mirror_reviews", &c.Reviews},
+		{"mirror_checks", &c.Checks},
+		{"mirror_project_items", &c.ProjectItems},
+	}
+	for _, spec := range specs {
+		query := "SELECT COUNT(*) FROM " + spec.table
+		var row *sql.Row
+		if cutoff != "" {
+			query += " WHERE last_seen_at < ?"
+			row = s.db.QueryRowContext(ctx, query, cutoff)
+		} else {
+			row = s.db.QueryRowContext(ctx, query)
+		}
+		if err := row.Scan(spec.dst); err != nil {
+			return Counts{}, fmt.Errorf("count %s: %w", spec.table, err)
+		}
+	}
+	return c, nil
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+func rowsApplied(res sql.Result, err error) (bool, error) {
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/mirrorstore/store_test.go
+++ b/internal/mirrorstore/store_test.go
@@ -1,0 +1,204 @@
+package mirrorstore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "maestro.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	tm, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", s, err)
+	}
+	return tm
+}
+
+// TestOpenIdempotent covers AC 5: the schema is added idempotently, so opening
+// the same maestro.db twice (an existing fleet upgrading) is a no-op that neither
+// errors nor drops data.
+func TestOpenIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "maestro.db")
+	ctx := context.Background()
+
+	s1, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if _, err := s1.UpsertIssue(ctx, Issue{Repo: "o/r", Number: 1, Title: "t", State: "open", LastSeenAt: mustTime(t, "2026-07-01T00:00:00Z"), Source: SourceWebhook}); err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+	if err := s1.Close(); err != nil {
+		t.Fatalf("close s1: %v", err)
+	}
+
+	// Re-open: Init runs again against the populated DB and must not error or wipe.
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open: %v", err)
+	}
+	defer s2.Close()
+	if err := s2.Init(ctx); err != nil {
+		t.Fatalf("re-Init: %v", err)
+	}
+	row, ok, err := s2.GetIssue(ctx, "o/r", 1)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if !ok || row.Title != "t" {
+		t.Fatalf("row not preserved across re-open: ok=%v row=%+v", ok, row)
+	}
+}
+
+// TestUpsertOrderingSafe covers AC 2: a newer event wins, a strictly-older event
+// is rejected, and a duplicate does not regress the row.
+func TestUpsertOrderingSafe(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	t1 := mustTime(t, "2026-07-01T10:00:00Z")
+	t2 := mustTime(t, "2026-07-01T12:00:00Z")
+
+	// First write.
+	applied, err := s.UpsertIssue(ctx, Issue{Repo: "o/r", Number: 5, Title: "v1", State: "open", LastSeenAt: t1, Source: SourceWebhook})
+	if err != nil || !applied {
+		t.Fatalf("first upsert applied=%v err=%v", applied, err)
+	}
+
+	// Newer event applies.
+	applied, err = s.UpsertIssue(ctx, Issue{Repo: "o/r", Number: 5, Title: "v2", State: "closed", LastSeenAt: t2, Source: SourceWebhook})
+	if err != nil || !applied {
+		t.Fatalf("newer upsert applied=%v err=%v", applied, err)
+	}
+
+	// Strictly-older event is rejected and does not regress the row.
+	applied, err = s.UpsertIssue(ctx, Issue{Repo: "o/r", Number: 5, Title: "STALE", State: "open", LastSeenAt: t1, Source: SourceWebhook})
+	if err != nil {
+		t.Fatalf("older upsert err=%v", err)
+	}
+	if applied {
+		t.Fatalf("older upsert must not apply")
+	}
+	row, _, err := s.GetIssue(ctx, "o/r", 5)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if row.Title != "v2" || row.State != "closed" {
+		t.Fatalf("row regressed by stale event: %+v", row)
+	}
+
+	// A duplicate of the current newest (equal timestamp) is idempotent: it re-
+	// applies the same values (applied=true) but the row content is unchanged.
+	applied, err = s.UpsertIssue(ctx, Issue{Repo: "o/r", Number: 5, Title: "v2", State: "closed", LastSeenAt: t2, Source: SourceWebhook})
+	if err != nil {
+		t.Fatalf("duplicate upsert err=%v", err)
+	}
+	if !applied {
+		t.Fatalf("equal-timestamp upsert should re-apply (>=)")
+	}
+	row, _, _ = s.GetIssue(ctx, "o/r", 5)
+	if row.Title != "v2" {
+		t.Fatalf("duplicate changed row: %+v", row)
+	}
+}
+
+func TestReplaceLabels(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	ts := mustTime(t, "2026-07-01T10:00:00Z")
+
+	if err := s.ReplaceLabels(ctx, "o/r", SubjectIssue, 7, []string{"b", "a"}, ts, SourceWebhook); err != nil {
+		t.Fatalf("ReplaceLabels: %v", err)
+	}
+	got, err := s.Labels(ctx, "o/r", SubjectIssue, 7)
+	if err != nil {
+		t.Fatalf("Labels: %v", err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("labels = %v, want sorted [a b]", got)
+	}
+
+	// A whole-set replace removes labels no longer present.
+	if err := s.ReplaceLabels(ctx, "o/r", SubjectIssue, 7, []string{"a"}, ts, SourceWebhook); err != nil {
+		t.Fatalf("ReplaceLabels 2: %v", err)
+	}
+	got, _ = s.Labels(ctx, "o/r", SubjectIssue, 7)
+	if len(got) != 1 || got[0] != "a" {
+		t.Fatalf("labels = %v, want [a]", got)
+	}
+
+	// An empty set clears all labels.
+	if err := s.ReplaceLabels(ctx, "o/r", SubjectIssue, 7, nil, ts, SourceWebhook); err != nil {
+		t.Fatalf("ReplaceLabels 3: %v", err)
+	}
+	got, _ = s.Labels(ctx, "o/r", SubjectIssue, 7)
+	if len(got) != 0 {
+		t.Fatalf("labels = %v, want empty", got)
+	}
+}
+
+// TestStaleCountsAndClassify covers AC 4: staleness is queryable and readers can
+// distinguish fresh/stale/missing.
+func TestStaleCountsAndClassify(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	now := mustTime(t, "2026-07-03T00:00:00Z")
+	horizon := 24 * time.Hour
+
+	fresh := now.Add(-1 * time.Hour)  // within horizon
+	stale := now.Add(-48 * time.Hour) // older than horizon
+	if _, err := s.UpsertIssue(ctx, Issue{Repo: "o/r", Number: 1, LastSeenAt: fresh, Source: SourceWebhook}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.UpsertIssue(ctx, Issue{Repo: "o/r", Number: 2, LastSeenAt: stale, Source: SourceWebhook}); err != nil {
+		t.Fatal(err)
+	}
+
+	counts, err := s.Counts(ctx)
+	if err != nil {
+		t.Fatalf("Counts: %v", err)
+	}
+	if counts.Issues != 2 {
+		t.Fatalf("Counts.Issues = %d, want 2", counts.Issues)
+	}
+
+	staleCounts, err := s.StaleCounts(ctx, now, horizon)
+	if err != nil {
+		t.Fatalf("StaleCounts: %v", err)
+	}
+	if staleCounts.Issues != 1 {
+		t.Fatalf("StaleCounts.Issues = %d, want 1", staleCounts.Issues)
+	}
+
+	// Classify: fresh row, stale row, and a missing row (caller supplies Missing).
+	if got := Classify(fresh, now, horizon); got != Fresh {
+		t.Fatalf("Classify(fresh) = %v, want fresh", got)
+	}
+	if got := Classify(stale, now, horizon); got != Stale {
+		t.Fatalf("Classify(stale) = %v, want stale", got)
+	}
+	if _, ok, _ := s.GetIssue(ctx, "o/r", 999); ok {
+		t.Fatalf("expected miss for absent issue")
+	}
+	// A non-positive horizon means never stale.
+	if got := Classify(stale, now, 0); got != Fresh {
+		t.Fatalf("Classify with zero horizon = %v, want fresh", got)
+	}
+	if sc, _ := s.StaleCounts(ctx, now, 0); sc.Total() != 0 {
+		t.Fatalf("StaleCounts with zero horizon = %+v, want all zero", sc)
+	}
+}

--- a/internal/mirrorstore/store_test.go
+++ b/internal/mirrorstore/store_test.go
@@ -202,3 +202,99 @@ func TestStaleCountsAndClassify(t *testing.T) {
 		t.Fatalf("StaleCounts with zero horizon = %+v, want all zero", sc)
 	}
 }
+
+// TestUpsertIssueWithLabelsStaleKeepsLabels covers the P2 fix: reconciling an
+// issue's row and its labels atomically under one timestamp guard. A strictly
+// older event must not replace (and so must not delete) a fresher label set, even
+// though a bare UpsertIssue would report applied=false only after the fact.
+func TestUpsertIssueWithLabelsStaleKeepsLabels(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	newer := mustTime(t, "2026-07-02T12:00:00Z")
+	older := mustTime(t, "2026-07-02T09:00:00Z")
+
+	// A fresh event set the row and labels.
+	applied, err := s.UpsertIssueWithLabels(ctx, Issue{
+		Repo: "o/r", Number: 1, Title: "NEW", State: "closed", LastSeenAt: newer, Source: SourceWebhook,
+	}, []string{"keep"})
+	if err != nil || !applied {
+		t.Fatalf("seed applied=%v err=%v", applied, err)
+	}
+
+	// A strictly older event arrives: its upsert is rejected and, crucially, it does
+	// NOT run the label replace — so "keep" survives.
+	applied, err = s.UpsertIssueWithLabels(ctx, Issue{
+		Repo: "o/r", Number: 1, Title: "OLD", State: "open", LastSeenAt: older, Source: SourceWebhook,
+	}, []string{"stale-label"})
+	if err != nil {
+		t.Fatalf("stale upsert err=%v", err)
+	}
+	if applied {
+		t.Fatalf("stale event reported applied=true")
+	}
+	row, _, _ := s.GetIssue(ctx, "o/r", 1)
+	if row.Title != "NEW" || row.State != "closed" {
+		t.Fatalf("stale event regressed row: %+v", row)
+	}
+	labels, _ := s.Labels(ctx, "o/r", SubjectIssue, 1)
+	if len(labels) != 1 || labels[0] != "keep" {
+		t.Fatalf("stale event regressed labels: %v", labels)
+	}
+}
+
+// TestUpsertIssueWithLabelsAppliedReplaces confirms that when the row DOES move
+// forward, its labels are reconciled to the new set in the same transaction.
+func TestUpsertIssueWithLabelsAppliedReplaces(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	t0 := mustTime(t, "2026-07-02T09:00:00Z")
+	t1 := mustTime(t, "2026-07-02T12:00:00Z")
+
+	if _, err := s.UpsertIssueWithLabels(ctx, Issue{
+		Repo: "o/r", Number: 1, Title: "v0", State: "open", LastSeenAt: t0, Source: SourceWebhook,
+	}, []string{"a"}); err != nil {
+		t.Fatal(err)
+	}
+	applied, err := s.UpsertIssueWithLabels(ctx, Issue{
+		Repo: "o/r", Number: 1, Title: "v1", State: "open", LastSeenAt: t1, Source: SourceWebhook,
+	}, []string{"b", "c"})
+	if err != nil || !applied {
+		t.Fatalf("newer applied=%v err=%v", applied, err)
+	}
+	labels, _ := s.Labels(ctx, "o/r", SubjectIssue, 1)
+	if !equalStrings(labels, []string{"b", "c"}) {
+		t.Fatalf("labels after applied upsert = %v, want [b c]", labels)
+	}
+}
+
+// TestUpsertPullRequestWithLabels confirms the PR variant reconciles row + labels
+// atomically the same way.
+func TestUpsertPullRequestWithLabels(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	t0 := mustTime(t, "2026-07-02T09:00:00Z")
+	t1 := mustTime(t, "2026-07-02T12:00:00Z")
+
+	if _, err := s.UpsertPullRequestWithLabels(ctx, PullRequest{
+		Repo: "o/r", Number: 5, Title: "pr", State: "open", LastSeenAt: t1, Source: SourceWebhook,
+	}, []string{"ready"}); err != nil {
+		t.Fatal(err)
+	}
+	// Older event: rejected, labels preserved.
+	applied, err := s.UpsertPullRequestWithLabels(ctx, PullRequest{
+		Repo: "o/r", Number: 5, Title: "pr-old", State: "closed", LastSeenAt: t0, Source: SourceWebhook,
+	}, []string{"stale"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied {
+		t.Fatalf("older PR event reported applied=true")
+	}
+	labels, _ := s.Labels(ctx, "o/r", SubjectPullRequest, 5)
+	if !equalStrings(labels, []string{"ready"}) {
+		t.Fatalf("older PR event regressed labels: %v", labels)
+	}
+}

--- a/internal/mirrorstore/testdata/stream/01.issues.json
+++ b/internal/mirrorstore/testdata/stream/01.issues.json
@@ -1,0 +1,19 @@
+{
+  "action": "opened",
+  "issue": {
+    "number": 824,
+    "title": "Webhook ingestion into the unified SQLite store",
+    "body": "Land signed webhook deliveries durably.",
+    "state": "open",
+    "created_at": "2026-07-01T10:00:00Z",
+    "updated_at": "2026-07-01T10:00:00Z",
+    "labels": [
+      { "name": "maestro-ready" }
+    ]
+  },
+  "repository": {
+    "full_name": "BeFeast/maestro",
+    "name": "maestro"
+  },
+  "sender": { "login": "octocat" }
+}

--- a/internal/mirrorstore/testdata/stream/02.issues.json
+++ b/internal/mirrorstore/testdata/stream/02.issues.json
@@ -1,0 +1,20 @@
+{
+  "action": "labeled",
+  "issue": {
+    "number": 824,
+    "title": "Webhook ingestion into the unified SQLite store",
+    "body": "Land signed webhook deliveries durably.",
+    "state": "open",
+    "created_at": "2026-07-01T10:00:00Z",
+    "updated_at": "2026-07-01T12:30:00Z",
+    "labels": [
+      { "name": "maestro-ready" },
+      { "name": "phase-b" }
+    ]
+  },
+  "repository": {
+    "full_name": "BeFeast/maestro",
+    "name": "maestro"
+  },
+  "sender": { "login": "octocat" }
+}

--- a/internal/mirrorstore/testdata/stream/03.pull_request.json
+++ b/internal/mirrorstore/testdata/stream/03.pull_request.json
@@ -1,0 +1,24 @@
+{
+  "action": "opened",
+  "number": 828,
+  "pull_request": {
+    "number": 828,
+    "title": "GitHub App auth path with PAT fallback",
+    "body": "Adds installation-token auth with PAT fallback.",
+    "state": "open",
+    "draft": false,
+    "merged": false,
+    "created_at": "2026-07-02T09:00:00Z",
+    "updated_at": "2026-07-02T09:15:00Z",
+    "head": { "sha": "0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e" },
+    "base": { "ref": "main" },
+    "labels": [
+      { "name": "maestro-ready" }
+    ]
+  },
+  "repository": {
+    "full_name": "BeFeast/maestro",
+    "name": "maestro"
+  },
+  "sender": { "login": "octocat" }
+}

--- a/internal/mirrorstore/testdata/stream/04.check_run.json
+++ b/internal/mirrorstore/testdata/stream/04.check_run.json
@@ -1,0 +1,17 @@
+{
+  "action": "completed",
+  "check_run": {
+    "id": 987654321,
+    "name": "go test ./...",
+    "status": "completed",
+    "conclusion": "success",
+    "head_sha": "0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e",
+    "started_at": "2026-07-02T09:16:00Z",
+    "completed_at": "2026-07-02T09:20:00Z"
+  },
+  "repository": {
+    "full_name": "BeFeast/maestro",
+    "name": "maestro"
+  },
+  "sender": { "login": "github-actions[bot]" }
+}

--- a/internal/mirrorstore/testdata/stream/05.pull_request_review.json
+++ b/internal/mirrorstore/testdata/stream/05.pull_request_review.json
@@ -1,0 +1,18 @@
+{
+  "action": "submitted",
+  "review": {
+    "id": 555111222,
+    "state": "approved",
+    "body": "LGTM, ship it.",
+    "user": { "login": "maintainer" },
+    "submitted_at": "2026-07-02T10:05:00Z"
+  },
+  "pull_request": {
+    "number": 828
+  },
+  "repository": {
+    "full_name": "BeFeast/maestro",
+    "name": "maestro"
+  },
+  "sender": { "login": "maintainer" }
+}

--- a/internal/mirrorstore/testdata/stream/06.issue_comment.json
+++ b/internal/mirrorstore/testdata/stream/06.issue_comment.json
@@ -1,0 +1,18 @@
+{
+  "action": "created",
+  "issue": {
+    "number": 824
+  },
+  "comment": {
+    "id": 700800900,
+    "body": "Landed in phase B.",
+    "user": { "login": "octocat" },
+    "created_at": "2026-07-02T11:00:00Z",
+    "updated_at": "2026-07-02T11:00:00Z"
+  },
+  "repository": {
+    "full_name": "BeFeast/maestro",
+    "name": "maestro"
+  },
+  "sender": { "login": "octocat" }
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -23,6 +23,7 @@ import (
 	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/configstore"
+	"github.com/befeast/maestro/internal/mirrorstore"
 	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/server/web"
 	"github.com/befeast/maestro/internal/state"
@@ -318,6 +319,16 @@ type FleetServer struct {
 	webhookMu   sync.RWMutex
 	webhook     *webhook.Ingestor
 	webhookPath string
+
+	// mirror is the GitHub read-model mirror store (epic #811, phase C — #825).
+	// nil disables the mirror diagnostics block. Wired by the daemon
+	// (SetMirrorStore) alongside webhook ingestion; the projection that fills it
+	// runs inside the ingestor. mirrorHorizon is the staleness horizon used for
+	// the queryable stale counts. Guarded by mirrorMu for the same reason as the
+	// webhook fields.
+	mirrorMu      sync.RWMutex
+	mirror        MirrorStatsSource
+	mirrorHorizon time.Duration
 }
 
 // FleetProjectStore is the write side of the daemon's config store that the
@@ -662,6 +673,41 @@ func (s *FleetServer) liveWebhook() (*webhook.Ingestor, string) {
 	return s.webhook, s.webhookPath
 }
 
+// MirrorStatsSource is the read-only diagnostics surface the fleet snapshot needs
+// from the GitHub mirror (#825). *mirrorstore.Store satisfies it; the interface
+// keeps the snapshot testable and avoids the server depending on the mirror's
+// write path.
+type MirrorStatsSource interface {
+	Counts(ctx context.Context) (mirrorstore.Counts, error)
+	StaleCounts(ctx context.Context, now time.Time, horizon time.Duration) (mirrorstore.Counts, error)
+}
+
+// SetMirrorStore wires the GitHub mirror read model for diagnostics (#825). The
+// daemon calls it with the mirror store and the staleness horizon used for the
+// stale counts. A nil store disables the mirror diagnostics block; a
+// non-positive horizon falls back to mirrorstore.DefaultStaleHorizon. Safe to
+// call before Start.
+func (s *FleetServer) SetMirrorStore(store MirrorStatsSource, horizon time.Duration) {
+	if s == nil {
+		return
+	}
+	if horizon <= 0 {
+		horizon = mirrorstore.DefaultStaleHorizon
+	}
+	s.mirrorMu.Lock()
+	s.mirror = store
+	s.mirrorHorizon = horizon
+	s.mirrorMu.Unlock()
+}
+
+// liveMirror returns the current mirror stats source and staleness horizon under
+// the read lock. The source is nil when the mirror is not configured.
+func (s *FleetServer) liveMirror() (MirrorStatsSource, time.Duration) {
+	s.mirrorMu.RLock()
+	defer s.mirrorMu.RUnlock()
+	return s.mirror, s.mirrorHorizon
+}
+
 // webhookPathMatches reports whether an inbound request path should route to the
 // webhook ingestor. It tolerates a single trailing slash on either side: a proxy
 // (or a re-typed GitHub webhook URL) that forwards "<path>/" must still reach the
@@ -804,6 +850,11 @@ type fleetResponse struct {
 	// last delivery time, total + per-event-type counts, and the
 	// signature-failure counter. nil when ingestion is not configured.
 	Webhooks *fleetWebhookStats `json:"webhooks,omitempty"`
+
+	// Mirror is the GitHub read-model mirror diagnostic (#825): per-entity row
+	// counts and how many are stale against the configured horizon. nil when the
+	// mirror is not configured.
+	Mirror *fleetMirrorStats `json:"mirror,omitempty"`
 }
 
 // fleetWebhookStats is the webhook ingestion observability block surfaced on the
@@ -845,6 +896,50 @@ func (s *FleetServer) webhookStatsSnapshot() *fleetWebhookStats {
 		out.LastDeliveryAt = formatFleetTime(st.LastDeliveryAt)
 	}
 	return out
+}
+
+// fleetMirrorStats is the GitHub mirror observability block surfaced on the fleet
+// snapshot (#825 AC 4 — "staleness marking works and is queryable; counts exposed
+// in diagnostics"). Counts is the total mirrored rows per entity; Stale is the
+// subset older than StaleHorizon. An operator reads Stale > 0 as "the mirror is
+// lagging for this much of its state" without querying SQLite directly.
+type fleetMirrorStats struct {
+	Enabled      bool               `json:"enabled"`
+	StaleHorizon string             `json:"stale_horizon,omitempty"`
+	Counts       mirrorstore.Counts `json:"counts"`
+	Stale        mirrorstore.Counts `json:"stale"`
+	TotalRows    int                `json:"total_rows"`
+	TotalStale   int                `json:"total_stale"`
+}
+
+// mirrorStatsSnapshot maps the mirror store's counts into the fleet response
+// block. Returns nil when the mirror is not configured so the field is omitted.
+// A query error degrades to nil rather than failing the whole fleet snapshot —
+// diagnostics must never take down the read path.
+func (s *FleetServer) mirrorStatsSnapshot() *fleetMirrorStats {
+	store, horizon := s.liveMirror()
+	if store == nil {
+		return nil
+	}
+	ctx := context.Background()
+	counts, err := store.Counts(ctx)
+	if err != nil {
+		log.Printf("[fleet] mirror counts query failed (omitting mirror diagnostics): %v", err)
+		return nil
+	}
+	stale, err := store.StaleCounts(ctx, time.Now().UTC(), horizon)
+	if err != nil {
+		log.Printf("[fleet] mirror stale-counts query failed (reporting counts only): %v", err)
+		stale = mirrorstore.Counts{}
+	}
+	return &fleetMirrorStats{
+		Enabled:      true,
+		StaleHorizon: horizon.String(),
+		Counts:       counts,
+		Stale:        stale,
+		TotalRows:    counts.Total(),
+		TotalStale:   stale.Total(),
+	}
 }
 
 // fleetNextAction names the single canonical operator action across the fleet.
@@ -1900,6 +1995,7 @@ func (s *FleetServer) snapshot() fleetResponse {
 	resp.Verdict = buildFleetVerdict(resp, now)
 	resp.CostObservability = rollupGlobalCost(resp.Projects)
 	resp.Webhooks = s.webhookStatsSnapshot()
+	resp.Mirror = s.mirrorStatsSnapshot()
 	return resp
 }
 

--- a/internal/server/fleet_mirror_test.go
+++ b/internal/server/fleet_mirror_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/mirrorstore"
+)
+
+func newMirrorStore(t *testing.T) *mirrorstore.Store {
+	t.Helper()
+	db := filepath.Join(t.TempDir(), "maestro.db")
+	store, err := mirrorstore.Open(db)
+	if err != nil {
+		t.Fatalf("open mirror store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+// TestFleetSnapshotMirrorStats proves the GitHub mirror diagnostics surface on
+// the fleet snapshot (#825 AC 4): per-entity counts and a stale subset against
+// the configured horizon.
+func TestFleetSnapshotMirrorStats(t *testing.T) {
+	store := newMirrorStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// One fresh issue and one issue last seen well beyond the horizon.
+	if _, err := store.UpsertIssue(ctx, mirrorstore.Issue{Repo: "o/r", Number: 1, LastSeenAt: now, Source: mirrorstore.SourceWebhook}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertIssue(ctx, mirrorstore.Issue{Repo: "o/r", Number: 2, LastSeenAt: now.Add(-72 * time.Hour), Source: mirrorstore.SourceWebhook}); err != nil {
+		t.Fatal(err)
+	}
+
+	fleet := NewFleet(nil, "127.0.0.1", 0, false)
+	fleet.SetMirrorStore(store, mirrorstore.DefaultStaleHorizon)
+
+	snap := fleet.snapshot()
+	if snap.Mirror == nil {
+		t.Fatal("fleet snapshot missing mirror block")
+	}
+	if !snap.Mirror.Enabled {
+		t.Fatal("mirror block should be enabled")
+	}
+	if snap.Mirror.Counts.Issues != 2 || snap.Mirror.TotalRows != 2 {
+		t.Fatalf("unexpected mirror counts: %+v", snap.Mirror)
+	}
+	if snap.Mirror.Stale.Issues != 1 || snap.Mirror.TotalStale != 1 {
+		t.Fatalf("unexpected mirror stale counts: %+v", snap.Mirror)
+	}
+	if snap.Mirror.StaleHorizon != mirrorstore.DefaultStaleHorizon.String() {
+		t.Fatalf("stale horizon = %q, want %q", snap.Mirror.StaleHorizon, mirrorstore.DefaultStaleHorizon.String())
+	}
+
+	// The block is also present in the JSON the fleet API serves.
+	handler := fleet.HandlerForTest()
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil))
+	var payload struct {
+		Mirror *fleetMirrorStats `json:"mirror"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode fleet json: %v", err)
+	}
+	if payload.Mirror == nil || payload.Mirror.TotalRows != 2 || payload.Mirror.TotalStale != 1 {
+		t.Fatalf("fleet JSON missing mirror stats: %+v", payload.Mirror)
+	}
+}
+
+// TestFleetNoMirrorOmitsStats confirms the block is omitted when the mirror is
+// not configured.
+func TestFleetNoMirrorOmitsStats(t *testing.T) {
+	fleet := NewFleet(nil, "127.0.0.1", 0, false)
+	if snap := fleet.snapshot(); snap.Mirror != nil {
+		t.Fatalf("mirror block should be nil when unconfigured: %+v", snap.Mirror)
+	}
+}
+
+// TestFleetMirrorHorizonFallback confirms a non-positive horizon falls back to
+// the default rather than making every row look fresh.
+func TestFleetMirrorHorizonFallback(t *testing.T) {
+	store := newMirrorStore(t)
+	fleet := NewFleet(nil, "127.0.0.1", 0, false)
+	fleet.SetMirrorStore(store, 0)
+	snap := fleet.snapshot()
+	if snap.Mirror == nil || snap.Mirror.StaleHorizon != mirrorstore.DefaultStaleHorizon.String() {
+		t.Fatalf("expected default horizon fallback, got %+v", snap.Mirror)
+	}
+}

--- a/internal/webhook/ingest.go
+++ b/internal/webhook/ingest.go
@@ -42,15 +42,27 @@ type Store interface {
 	LastDelivery(ctx context.Context) (time.Time, string, error)
 }
 
+// Projector projects a newly-accepted delivery into the GitHub mirror read model
+// (epic #811, phase C — issue #825). *mirrorstore.Store satisfies it. It is
+// optional: when no projector is wired the ingestor is pure phase-B ingestion,
+// landing raw deliveries only. When one is wired, each first-time delivery is
+// also normalised into the mirror tables so a later phase can read GitHub state
+// locally. Projection is best-effort — the raw delivery is already durably
+// stored, so a projection error is logged and the delivery is still acknowledged.
+type Projector interface {
+	ProjectWebhook(ctx context.Context, eventType string, payload []byte, receivedAt time.Time) error
+}
+
 // Ingestor is the HTTP handler that authenticates, deduplicates and persists
 // inbound GitHub webhook deliveries. It is safe for concurrent use: the store
 // serialises writes through a single SQLite connection, and the in-memory
 // observability counters are guarded by a mutex, so the endpoint keeps working
 // while the daemon is under normal fleet load (#824 acceptance).
 type Ingestor struct {
-	store  Store
-	secret string
-	now    func() time.Time
+	store     Store
+	secret    string
+	now       func() time.Time
+	projector Projector
 
 	mu sync.Mutex
 	// Session counters. accepted/duplicates/byEventType are seeded from the
@@ -81,6 +93,21 @@ func NewIngestor(store Store, secret string) *Ingestor {
 	}
 	in.seed(context.Background())
 	return in
+}
+
+// SetProjector wires the GitHub mirror projector (#825). Passing nil disables
+// projection (pure phase-B ingestion). Safe to call before Start; the projector
+// is read under the ingestor's mutex so a hot-add is race-free.
+func (in *Ingestor) SetProjector(p Projector) {
+	in.mu.Lock()
+	in.projector = p
+	in.mu.Unlock()
+}
+
+func (in *Ingestor) liveProjector() Projector {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	return in.projector
 }
 
 // seed loads durable totals from the store into the in-memory counters so a
@@ -205,6 +232,18 @@ func (in *Ingestor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	in.countAccepted(eventType, delivery.ReceivedAt)
+	// Project the newly-accepted delivery into the GitHub mirror (#825). Best
+	// effort: the raw delivery is already durably stored, so a projection failure
+	// is logged and the delivery is still acknowledged — the mirror can be
+	// reconciled later from the stored delivery rather than losing the ack and
+	// making GitHub retry. Done before responding so a synchronous test observes
+	// the mirror row, but off the store's critical section.
+	if p := in.liveProjector(); p != nil {
+		if err := p.ProjectWebhook(r.Context(), eventType, body, delivery.ReceivedAt); err != nil {
+			log.Printf("[webhook] mirror projection failed (delivery stored, mirror will lag) event=%q delivery=%s: %v",
+				eventType, deliveryID, err)
+		}
+	}
 	// One journal line per accepted delivery gives the "last webhook delivery
 	// time and counts" diagnostic straight from journalctl (#824 AC 10). The
 	// payload itself is never logged.

--- a/internal/webhook/projector_test.go
+++ b/internal/webhook/projector_test.go
@@ -1,0 +1,96 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingProjector captures every ProjectWebhook call so a test can assert the
+// ingestor projects accepted deliveries (and only those).
+type recordingProjector struct {
+	mu    sync.Mutex
+	calls []string // event types projected
+	err   error
+}
+
+func (p *recordingProjector) ProjectWebhook(_ context.Context, eventType string, _ []byte, _ time.Time) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, eventType)
+	return p.err
+}
+
+func (p *recordingProjector) events() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.calls))
+	copy(out, p.calls)
+	return out
+}
+
+// TestProjectorRunsOnAcceptedDeliveryOnce confirms an accepted delivery is
+// projected into the mirror exactly once, and a redelivery (already stored) is
+// NOT re-projected — the projection rides the first-time store, so GitHub retries
+// do not re-run it.
+func TestProjectorRunsOnAcceptedDeliveryOnce(t *testing.T) {
+	in, _ := newTestIngestor(t)
+	proj := &recordingProjector{}
+	in.SetProjector(proj)
+
+	body := readFixture(t, "issues_opened.json")
+
+	first := httptest.NewRecorder()
+	in.ServeHTTP(first, signedRequest(t, DefaultPath, "issues", "del-1", body, true))
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first delivery status=%d", first.Code)
+	}
+
+	// Redelivery of the same X-GitHub-Delivery: acknowledged but not re-projected.
+	replay := httptest.NewRecorder()
+	in.ServeHTTP(replay, signedRequest(t, DefaultPath, "issues", "del-1", body, true))
+	if replay.Code != http.StatusOK {
+		t.Fatalf("replay status=%d, want 200 duplicate", replay.Code)
+	}
+
+	if got := proj.events(); len(got) != 1 || got[0] != "issues" {
+		t.Fatalf("projector calls = %v, want exactly one [issues]", got)
+	}
+}
+
+// TestProjectorErrorIsNonFatal confirms a projection failure does not fail the
+// delivery: the raw payload is already durably stored, so the ingestor still
+// acknowledges with 202 and the mirror can be reconciled later.
+func TestProjectorErrorIsNonFatal(t *testing.T) {
+	in, store := newTestIngestor(t)
+	in.SetProjector(&recordingProjector{err: errors.New("projection boom")})
+
+	body := readFixture(t, "issues_opened.json")
+	rec := httptest.NewRecorder()
+	in.ServeHTTP(rec, signedRequest(t, DefaultPath, "issues", "del-err", body, true))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status=%d, want 202 despite projection error", rec.Code)
+	}
+	if _, ok, _ := store.Get(context.Background(), "del-err"); !ok {
+		t.Fatal("raw delivery must still be stored when projection fails")
+	}
+}
+
+// TestNoProjectorIsPurePhaseB confirms an ingestor without a projector still
+// accepts and stores deliveries — the mirror is optional.
+func TestNoProjectorIsPurePhaseB(t *testing.T) {
+	in, store := newTestIngestor(t)
+	body := readFixture(t, "issues_opened.json")
+	rec := httptest.NewRecorder()
+	in.ServeHTTP(rec, signedRequest(t, DefaultPath, "issues", "del-2", body, true))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	if _, ok, _ := store.Get(context.Background(), "del-2"); !ok {
+		t.Fatal("delivery not stored without a projector")
+	}
+}


### PR DESCRIPTION
Implements #825 — phase C of epic #811 (Fleet GitHub control-plane mirror). Depends on #824 (webhook ingestion, already merged).

## Changes

- **`internal/mirrorstore`** — a normalised, queryable GitHub read model in the shared `maestro.db`: tables for issues, pull requests, labels, comments, reviews, check/CI status, and Projects v2 items, each carrying `last_seen_at` and `source`.
  - **Ordering-safe upserts:** an event applies only when its `last_seen_at` is `>=` the stored one, so out-of-order or duplicate redeliveries never regress a row.
  - **Projection layer** (`ProjectWebhook`): parses ingested webhook payloads into mirror rows.
  - **Hydration** (`Hydrator`): on a mirror miss, fetch via the existing `internal/github` client, record it (`source=api`), and return; the next read is served locally.
  - **Staleness:** rows classify fresh / stale / missing against a configurable horizon.
- **Wiring:** the webhook ingestor gains an optional best-effort `Projector` hook that projects each first-time accepted delivery; the daemon opens the mirror alongside webhook ingestion (same DB) and registers it for diagnostics.
- **Diagnostics:** the fleet snapshot (`GET /api/v1/fleet`) gains a `mirror` block with per-entity counts and the stale subset.
- **Docs:** `docs/github-mirror-read-model-runbook.md`.

Schema is added idempotently (`CREATE ... IF NOT EXISTS`), so existing fleets upgrade with no manual step. **No read-path switchover** — that is phase D; this phase only builds and populates the model.

## Testing

- `go test ./...` (full suite green)
- `go build ./cmd/maestro/`
- New tests cover each acceptance criterion: replay-stream-matches-API-snapshot fixture test, out-of-order/duplicate no-regress, mirror-miss → hydrate → local read, queryable staleness counts in diagnostics, and idempotent re-open of the schema.

Refs #825

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GitHub mirror read model to the shared SQLite store. The main changes are:

- Normalized mirror tables for issues, pull requests, labels, comments, reviews, checks, and Projects v2 items.
- Webhook projection into the mirror after accepted deliveries.
- Issue hydration from the GitHub API on mirror misses.
- Fleet diagnostics for mirror row counts and stale rows.
- Runbook and tests for replay, ordering, hydration, and diagnostics.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The latest hydration changes preserve issue state and keep label replacement behind the guarded store update.
- The mirror diagnostics and webhook projection paths degrade without blocking raw delivery storage.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/mirrorstore/store.go | Adds the SQLite schema, guarded upserts, label reconciliation, reads, and stale-count queries for the mirror. |
| internal/mirrorstore/project.go | Projects supported GitHub webhook payloads into the mirror tables. |
| internal/mirrorstore/hydrate.go | Adds issue hydration from the GitHub API and persists the hydrated mirror row. |
| internal/github/github.go | Adds issue state to the REST issue model used by hydration. |
| internal/webhook/ingest.go | Adds an optional projector hook that runs after a webhook delivery is accepted. |
| internal/server/fleet.go | Adds mirror diagnostics to the fleet snapshot response. |

<sub>Reviews (2): Last reviewed commit: ["mirrorstore: preserve hydrated state, at..."](https://github.com/befeast/maestro/commit/ae623e773d26e071e475fefbae42fef915fdf4d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42086641)</sub>

<!-- /greptile_comment -->