### PR TITLE
Mirror-first source abstraction for supervisor/orchestrator reads (epic #811, phase D)

### DIFF
--- a/docs/digest-runbook.md
+++ b/docs/digest-runbook.md
@@ -22,6 +22,8 @@ The header carries a **GitHub auth** line so an operator can confirm which rate-
 - `GitHub App installation <id> · bucket installation · token expires <ts>` — authenticated as a GitHub App installation, which has its own bucket independent of the operator PAT. Configure it with a `github_app:` block (`app_id`, `private_key_path`, `installation_id`) on any fleet project; the private key stays on disk and is never logged or stored in the config store.
 - `PAT/gh (App fallback active …)` — a `github_app:` block is present but token issuance failed, so the daemon fell back to the PAT. The reason is shown inline and a loud line is written to the daemon journal. The same auth mode is appended to the hourly `[github] REST usage …` journal digest.
 
+The header also carries a **GitHub reads** line summarizing the process-lifetime REST traffic (#826): total exchanges, how many were billed against the core quota vs served free by a 304, and — once `github_mirror.source: mirror-first` is enabled — how many reads the local mirror served vs how many fell back to the API. A high `served locally` with a low `fell back to API` is the mirror-first quota win. The same mirror hit/fallback counts are appended to the hourly `[github] REST usage …` journal digest. See [mirror-first-source-runbook.md](mirror-first-source-runbook.md).
+
 ## Running it
 
 One command covers the whole fleet using the same `fleet.yaml` that Mission Control uses:

--- a/docs/github-mirror-read-model-runbook.md
+++ b/docs/github-mirror-read-model-runbook.md
@@ -74,6 +74,15 @@ is configured:
 the horizon — usually a sign deliveries stopped arriving for a repo. The block is
 omitted entirely when the mirror is not configured.
 
+## Phase D — reads switch over
+
+Phase D (#826) puts the supervisor/orchestrator read paths behind a mirror-first
+source (`mirrorstore.Source`): the open-issue/open-PR lists and issue/PR state
+reads are served from a warm mirror and fall back to the API on a miss/stale.
+It is opt-in per project via `github_mirror.source: mirror-first`, with `source:
+api` as the fleet-wide escape hatch. See
+[mirror-first-source-runbook.md](mirror-first-source-runbook.md).
+
 ## Notes / limits (phase C)
 
 - Hydration is implemented for **issues** (`Hydrator.Issue`); other entity types

--- a/docs/mirror-first-source-runbook.md
+++ b/docs/mirror-first-source-runbook.md
@@ -1,0 +1,112 @@
+# Mirror-first Source Runbook (#826, epic #811 phase D)
+
+Phase C (#825) built and populated the GitHub read-model mirror in
+`~/.maestro/maestro.db`. Phase D puts the supervisor/orchestrator **read paths**
+behind a mirror-first source: the high-volume per-cycle reads are served from the
+local mirror when it is warm, and fall back to the GitHub API only on a miss, a
+stale row, a cold mirror, or the escape hatch. GitHub stays authoritative for
+every write and every merge-gating read.
+
+This is the quota win: instead of polling `ListOpenIssues` / `ListOpenPRs` and
+per-issue/PR state on every cycle across all projects, a warm mirror answers
+those reads with zero REST traffic.
+
+## What is served mirror-first
+
+`internal/mirrorstore.Source` embeds `*github.Client`, so it is a drop-in for the
+concrete client. It overrides only these reads:
+
+| Read | Source | Notes |
+|---|---|---|
+| `ListOpenIssues(labels)` | `mirror_issues` (+ `mirror_labels`) | loss-free — title/body/labels all mirrored |
+| `ListOpenPRs()` | `mirror_pull_requests` | needs `head_ref` + `body`, added to the schema in phase D |
+| `IsIssueClosed(n)` | `mirror_issues.state` | point read |
+| `IsPRMerged(n)` | `mirror_pull_requests.merged` | terminal, monotonic — a lagging mirror only ever re-polls, never fabricates a merge |
+| `GetIssue(n)` | mirror hit, else **hydrate** | miss → fetch → store → serve; the next read is local |
+
+Everything else passes straight through to the GitHub API:
+
+- **All writes** — labels, comments, merges, closes, branch updates.
+- **All merge-gating reads** — `PRCIStatus`, `PRMergeStatus`, `PRGreptileApproved`,
+  review-gate verdicts. These are deliberately **not** mirror-served: the mirror
+  cannot prove check completeness, and a stale "green" would be a merge-safety
+  regression. Keeping them on the authoritative API is the conservative choice
+  (no decision-quality regression).
+- Project board reads, rate-limit probes, and any read not in the table above.
+
+## Warmth and the empty-mirror fallback
+
+A point miss (`GetIssue #N`) is a clean "hydrate this one entity" signal. A **list**
+read has no per-row miss — an empty result could mean "nothing is open" or "the
+mirror never saw the webhooks". So list serving is gated on **warmth**: the newest
+mirrored row for that entity must be within the freshness horizon (webhooks are
+flowing). A cold or lagging mirror falls back to the API, so an unpopulated mirror
+degrades to today's API-direct correctness rather than silently under-reporting.
+
+## Enabling / the escape hatch
+
+Per project, in config (or the config store):
+
+```yaml
+github_mirror:
+  source: mirror-first   # "" or "api" = API-direct (today's behavior, default)
+  stale_seconds: 86400   # freshness horizon; 0 = default 24h
+```
+
+- Default (`""` / `api`): every read goes straight to the API — unchanged from
+  before this phase. The default stays API-direct until mirror-first has soaked.
+- `mirror-first`: serve the reads above from a warm mirror, fall back on miss/stale.
+- **Escape hatch:** set `source: api` to restore today's behavior fleet-wide. The
+  flag is read on every cycle, so a config-store edit takes effect **without a
+  redeploy** — both the supervisor (via the config holder) and the orchestrator
+  (via hot-reload of `github_mirror`) flip live.
+
+The source is only built when the daemon has an open mirror — i.e. when webhook
+ingestion is configured (`--webhook-secret-file`). Without inbound deliveries the
+mirror has nothing to serve, so flows stay API-direct regardless of this flag.
+
+## Observability
+
+The gh wrapper already logs an hourly REST-usage line; phase D appends the
+mirror hit/fallback counts to it:
+
+```
+[github] REST usage last 1h0m: 812 requests, ~120 billed against core quota,
+  692 served free by 304, 0 rate-limited; mirror reads: 5400 served locally,
+  240 fell back to API (96% hit)
+```
+
+The morning digest (`maestro digest`) carries the same counters on its
+`GitHub reads:` header line and in JSON (`github_usage`):
+
+```jsonc
+"github_usage": {
+  "requests": 812, "billed": 120, "not_modified": 692, "rate_limited": 0,
+  "mirror_hits": 5400, "api_fallbacks": 240
+}
+```
+
+A high `mirror_hits` with a low `api_fallbacks` is the phase-D win, made visible.
+`mirror-first reads: not enabled` on the digest line means no read went through
+the source (mirror-first off, or mirror empty).
+
+## Verifying the quota drop
+
+1. Confirm the mirror is warm: `GET /api/v1/fleet` → `mirror.total_rows` > 0 and
+   `mirror.total_stale` low (see the phase-C runbook).
+2. Set `github_mirror.source: mirror-first` for a project.
+3. Watch the hourly `[github] REST usage` journal line: `served locally` climbs,
+   `billed against core quota` drops.
+4. To roll back instantly, set `source: api` — no redeploy.
+
+## Notes / limits
+
+- **List completeness** depends on webhooks. A PR/issue that exists on GitHub but
+  never produced a delivery is not in the mirror; warmth catches a *lagging*
+  mirror (stale newest row) but not a *missed single delivery*. Mitigations: the
+  soak period, the escape hatch, and that maestro itself creates the PRs it gates.
+- **Merge-gating stays on the API** by design (see above), so a warm-mirror cycle
+  still issues the low-frequency CI/mergeable/review reads for PRs under active
+  gating. The dominant per-cycle list + state reads are what move to the mirror.
+- `head_ref` and `body` were added to `mirror_pull_requests` in phase D; an
+  existing mirror is migrated in place on daemon start (idempotent `ALTER TABLE`).

--- a/docs/mirror-first-source-runbook.md
+++ b/docs/mirror-first-source-runbook.md
@@ -43,6 +43,22 @@ mirrored row for that entity must be within the freshness horizon (webhooks are
 flowing). A cold or lagging mirror falls back to the API, so an unpopulated mirror
 degrades to today's API-direct correctness rather than silently under-reporting.
 
+Warmth of the *newest* row is necessary but not sufficient, so the source also
+inspects every row it is about to serve and falls back to the API for the **whole
+list** when any member is untrustworthy:
+
+- **An individually-stale open row.** The newest row can be fresh while another
+  open row is older than the horizon — e.g. its `closed`/`unlabeled` delivery was
+  missed. Serving it would leak a no-longer-open (or mis-labelled) issue/PR into a
+  decision, so the list falls back.
+- **A PR row missing its head branch.** An existing mirror upgraded in place gets
+  `head_ref` added with an empty default (the `ALTER TABLE` cannot backfill the
+  branch of a PR mirrored before the column existed). Those rows keep their old,
+  possibly-still-fresh `last_seen_at`, so the staleness check alone would not catch
+  them. Because the supervisor/orchestrator match sessions to open PRs **by head
+  branch**, an empty `head_ref` would mis-match or duplicate work — so `ListOpenPRs`
+  falls back until a webhook repopulates the branch.
+
 ## Enabling / the escape hatch
 
 Per project, in config (or the config store):
@@ -103,10 +119,17 @@ the source (mirror-first off, or mirror empty).
 
 - **List completeness** depends on webhooks. A PR/issue that exists on GitHub but
   never produced a delivery is not in the mirror; warmth catches a *lagging*
-  mirror (stale newest row) but not a *missed single delivery*. Mitigations: the
-  soak period, the escape hatch, and that maestro itself creates the PRs it gates.
+  mirror (stale newest row), and the per-row guard above catches a *missed close/
+  unlabel delivery* on a row that IS mirrored (it goes stale and forces a
+  fallback) — but neither catches a brand-new entity the mirror has never seen a
+  delivery for. Mitigations: the soak period, the escape hatch, and that maestro
+  itself creates the PRs it gates.
 - **Merge-gating stays on the API** by design (see above), so a warm-mirror cycle
   still issues the low-frequency CI/mergeable/review reads for PRs under active
   gating. The dominant per-cycle list + state reads are what move to the mirror.
 - `head_ref` and `body` were added to `mirror_pull_requests` in phase D; an
   existing mirror is migrated in place on daemon start (idempotent `ALTER TABLE`).
+  The migration adds the columns with an empty default and does not backfill the
+  head branch of already-open PRs, so `ListOpenPRs` falls back to the API for any
+  list containing such a row until a webhook repopulates its `head_ref` (see the
+  per-row guard above).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -338,6 +338,50 @@ func (c GitHubAppConfig) Configured() bool {
 	return c.AppID > 0 && c.InstallationID > 0 && strings.TrimSpace(c.PrivateKeyPath) != ""
 }
 
+// Mirror source modes for supervisor/orchestrator reads (#826, epic #811 phase
+// D). The GitHub read-model mirror lives in maestro.db (phase C); this selects
+// whether the read paths consult it.
+const (
+	// GitHubSourceAPI reads every supervisor/orchestrator GitHub state directly
+	// from the API — today's behavior, and the fleet-wide escape hatch.
+	GitHubSourceAPI = "api"
+	// GitHubSourceMirrorFirst serves the high-volume reads (open-issue/open-PR
+	// lists, issue/PR state) from a warm local mirror, falling back to the API on
+	// a miss or a stale row.
+	GitHubSourceMirrorFirst = "mirror-first"
+)
+
+// GitHubMirrorConfig selects how the supervisor/orchestrator read GitHub state
+// (#826). Empty defaults to "api" (today's behavior) until the mirror-first path
+// has soaked in production, after which the default flips to "mirror-first".
+//
+// Setting `source: api` is the fleet-wide escape hatch: the source is consulted
+// on every read, so a live config-store edit restores API-direct reads without a
+// redeploy (#826 AC 3/8). GitHub stays authoritative for all writes and
+// merge-gating reads regardless of this setting.
+type GitHubMirrorConfig struct {
+	Source       string `yaml:"source"`        // "" (=api) | "api" | "mirror-first"
+	StaleSeconds int    `yaml:"stale_seconds"` // freshness horizon override in seconds; 0 = default (24h)
+}
+
+// MirrorFirst reports whether reads should be served mirror-first. Any value
+// other than "mirror-first" (including the empty default and typos) is API — the
+// safe direction, since a mis-set flag can only fall back to the authoritative
+// API, never fabricate a stale mirror read.
+func (c GitHubMirrorConfig) MirrorFirst() bool {
+	return strings.EqualFold(strings.TrimSpace(c.Source), GitHubSourceMirrorFirst)
+}
+
+// StaleHorizon is the freshness window a mirror row must fall within to be
+// served locally. A non-positive stale_seconds falls back to 24h — the same
+// conservative horizon mirrorstore.DefaultStaleHorizon uses.
+func (c GitHubMirrorConfig) StaleHorizon() time.Duration {
+	if c.StaleSeconds <= 0 {
+		return 24 * time.Hour
+	}
+	return time.Duration(c.StaleSeconds) * time.Second
+}
+
 // SelfDeployConfig gates the opt-in post-merge self-deploy of the maestro
 // binary itself (#698). Default OFF: projects without a `self_deploy:` block
 // (or with enabled: false) see no behavior change.
@@ -1306,6 +1350,7 @@ type Config struct {
 	SelfDeploy                      SelfDeployConfig             `yaml:"self_deploy"` // #698: opt-in post-merge self-deploy of the maestro binary (default OFF)
 	GitHubProjects                  GitHubProjectsConfig         `yaml:"github_projects"`
 	GitHubApp                       GitHubAppConfig              `yaml:"github_app"`                 // #823: GitHub App auth (app_id + private_key_path + installation_id)
+	GitHubMirror                    GitHubMirrorConfig           `yaml:"github_mirror"`              // #826: mirror-first vs api-direct supervisor/orchestrator reads
 	MaxRetryBackoffMs               int                          `yaml:"max_retry_backoff_ms"`       // cap for exponential retry backoff in milliseconds (default: 300000 = 5 min)
 	AutoResolveFiles                []string                     `yaml:"auto_resolve_files"`         // files to auto-resolve conflicts by keeping both sides
 	AutoRestoreFiles                []string                     `yaml:"auto_restore_files"`         // dirty files that may be restored before auto-rebase
@@ -1660,6 +1705,16 @@ func parse(data []byte) (*Config, error) {
 		cfg.ReviewGate = "greptile"
 	}
 	cfg.ReviewGateStreams = normalizeReviewGateStreams(cfg.ReviewGate, cfg.ReviewGateStreams)
+
+	// GitHub read source (#826). Normalize to a known value; anything unrecognised
+	// — including the empty default and typos — resolves to API-direct, which is
+	// always the safe direction (it can only fall back to the authoritative API).
+	switch strings.ToLower(strings.TrimSpace(cfg.GitHubMirror.Source)) {
+	case GitHubSourceMirrorFirst:
+		cfg.GitHubMirror.Source = GitHubSourceMirrorFirst
+	default:
+		cfg.GitHubMirror.Source = GitHubSourceAPI
+	}
 
 	// Default hooks timeout
 	if cfg.Hooks.TimeoutMs <= 0 {

--- a/internal/config/github_mirror_test.go
+++ b/internal/config/github_mirror_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParse_GitHubMirror_DefaultIsAPIDirect(t *testing.T) {
+	cfg, err := parse([]byte("repo: owner/repo\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.GitHubMirror.Source != GitHubSourceAPI {
+		t.Fatalf("default source = %q, want %q", cfg.GitHubMirror.Source, GitHubSourceAPI)
+	}
+	if cfg.GitHubMirror.MirrorFirst() {
+		t.Fatal("MirrorFirst() must be false by default (today's behavior until soaked)")
+	}
+	if got := cfg.GitHubMirror.StaleHorizon(); got != 24*time.Hour {
+		t.Fatalf("default StaleHorizon = %s, want 24h", got)
+	}
+}
+
+func TestParse_GitHubMirror_MirrorFirst(t *testing.T) {
+	yaml := `
+repo: owner/repo
+github_mirror:
+  source: mirror-first
+  stale_seconds: 300
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.GitHubMirror.MirrorFirst() {
+		t.Fatal("MirrorFirst() should be true for source: mirror-first")
+	}
+	if got := cfg.GitHubMirror.StaleHorizon(); got != 5*time.Minute {
+		t.Fatalf("StaleHorizon = %s, want 5m", got)
+	}
+}
+
+func TestParse_GitHubMirror_UnknownDefaultsToAPI(t *testing.T) {
+	// A typo (or any unrecognised value) resolves to API-direct — the safe
+	// direction: a mis-set flag can only fall back to the authoritative API.
+	yaml := `
+repo: owner/repo
+github_mirror:
+  source: mirorr-frist
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.GitHubMirror.Source != GitHubSourceAPI {
+		t.Fatalf("unknown source normalized to %q, want %q", cfg.GitHubMirror.Source, GitHubSourceAPI)
+	}
+	if cfg.GitHubMirror.MirrorFirst() {
+		t.Fatal("a typo must not enable mirror-first")
+	}
+}
+
+func TestParse_GitHubMirror_ExplicitAPIEscapeHatch(t *testing.T) {
+	yaml := `
+repo: owner/repo
+github_mirror:
+  source: api
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.GitHubMirror.MirrorFirst() {
+		t.Fatal("source: api is the escape hatch — MirrorFirst() must be false")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -169,6 +169,15 @@ type Daemon struct {
 	fleet *server.FleetServer
 	flows map[string]*projectFlow
 
+	// mirror is the shared GitHub read-model mirror (#825/#826). Opened once in
+	// Run when webhook ingestion is configured — the ingestor projects accepted
+	// deliveries into it, and the per-flow mirror-first read sources serve the
+	// supervisor/orchestrator poll loops from it. nil when ingestion is disabled,
+	// in which case every flow reads GitHub directly (mirror-first has nothing to
+	// read from without inbound deliveries).
+	mirror        *mirrorstore.Store
+	mirrorHorizon time.Duration
+
 	// Centralized self-deploy (#758). RequestSelfDeploy serializes on
 	// selfDeployMu and debounces on a single marker — the in-memory
 	// selfDeployLast (deterministic within this process) plus the on-disk marker
@@ -241,7 +250,15 @@ func New(store ConfigLoader, opts Options) *Daemon {
 	}
 	d.runLoop = d.runOrchestrator
 	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
-		runSupervise(ctx, name, getCfg, opts.SuperviseInterval)
+		// #826: build the flow's mirror-first read source (nil when the mirror is
+		// disabled). Its escape hatch reads getCfg() — the holder the reload pump
+		// swaps — so a config-store edit flips the supervisor between mirror-first
+		// and API-direct live.
+		var reader supervisor.Reader
+		if src := d.newReadSource(getCfg().Repo, getCfg); src != nil {
+			reader = src
+		}
+		runSupervise(ctx, name, getCfg, reader, opts.SuperviseInterval)
 	}
 	d.watchdogLoop = supervisor.Watchdog
 	// Default to the real launcher; tests swap it for a counter (#758).
@@ -375,7 +392,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// port when a webhook secret file is configured. Non-fatal on any error —
 	// the daemon logs it loudly and comes up without ingestion (the fleet keeps
 	// polling), rather than aborting startup over an unreadable secret.
-	configureWebhookIngestion(fleet, d.opts)
+	d.configureWebhookIngestion(fleet)
 
 	fleetAuth := server.FleetAuthFromProjects(projects)
 	fleet.SetAuth(fleetAuth)
@@ -565,7 +582,8 @@ func configureFleetGitHubAppAuth(projects []server.FleetProject) {
 // that will not open, disables ingestion with a loud warning instead of
 // blocking daemon startup — webhooks are an optimisation over polling, so their
 // absence degrades to today's polling behaviour.
-func configureWebhookIngestion(fleet *server.FleetServer, opts Options) {
+func (d *Daemon) configureWebhookIngestion(fleet *server.FleetServer) {
+	opts := d.opts
 	secretPath := strings.TrimSpace(opts.WebhookSecretFile)
 	if secretPath == "" {
 		log.Printf("[daemon] webhook ingestion not configured (no --webhook-secret-file) — GitHub state continues to arrive by polling")
@@ -600,6 +618,13 @@ func configureWebhookIngestion(fleet *server.FleetServer, opts Options) {
 	} else {
 		ingestor.SetProjector(mirror)
 		fleet.SetMirrorStore(mirror, mirrorstore.DefaultStaleHorizon)
+		// Share the SAME handle with the per-flow mirror-first read sources (#826)
+		// so the reads a flow serves reflect the deliveries the ingestor just
+		// projected. The counters that flow through the source land in the gh
+		// wrapper's hourly REST-usage journal line via this hook.
+		d.mirror = mirror
+		d.mirrorHorizon = mirrorstore.DefaultStaleHorizon
+		github.SetMirrorReadDigest(mirrorReadDigestLine)
 		log.Printf("[daemon] github mirror active — accepted deliveries project into the read model in %s", dbPath)
 	}
 

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -331,6 +331,15 @@ func (d *Daemon) runOrchestrator(ctx context.Context, cfg *config.Config, opts O
 	orchCfg := *cfg
 	orch := orchestrator.New(&orchCfg)
 	orch.SetBinaryVersion(opts.Version)
+	// Mirror-first reads (#826): serve the orchestrator's high-volume poll reads
+	// from the shared mirror when github_mirror.source is mirror-first, falling
+	// back to the API on a miss/stale. The closure reads &orchCfg — the live,
+	// reload-mutated config (reloadConfig copies GitHubMirror), so the escape
+	// hatch flips this flow without a redeploy. nil source (no mirror) leaves the
+	// orchestrator reading GitHub directly, unchanged.
+	if src := d.newReadSource(orchCfg.Repo, func() *config.Config { return &orchCfg }); src != nil {
+		orch.SetReadSource(src)
+	}
 	// Route post-merge self-deploy through the daemon's centralized,
 	// cross-flow-debounced launcher (#758) instead of this flow firing its own
 	// selfdeploy.Trigger. The closure passes the orchestrator's OWN config

--- a/internal/daemon/mirror_source.go
+++ b/internal/daemon/mirror_source.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/mirrorstore"
+)
+
+// newReadSource builds a mirror-first read source for one flow (#826), or
+// returns nil when there is no mirror to read from (webhook ingestion disabled).
+// A nil return tells the caller to keep reading GitHub directly, exactly as
+// before this phase.
+//
+// The GitHub client is built from repo (a restart-required field, stable for the
+// flow's lifetime). The escape hatch is wired to getCfg so a live config-store
+// edit flips the whole flow back to API-direct without a redeploy: apiDirect is
+// re-evaluated on every read, and MirrorFirst() is false unless the flow's
+// CURRENT config sets github_mirror.source: mirror-first (#826 AC 3/8).
+func (d *Daemon) newReadSource(repo string, getCfg func() *config.Config) *mirrorstore.Source {
+	if d.mirror == nil {
+		return nil
+	}
+	horizon := d.mirrorHorizon
+	if cfg := getCfg(); cfg != nil {
+		horizon = cfg.GitHubMirror.StaleHorizon()
+	}
+	return mirrorstore.NewSource(github.New(repo), d.mirror, repo, mirrorstore.SourceOptions{
+		Horizon: horizon,
+		APIDirect: func() bool {
+			cfg := getCfg()
+			return cfg == nil || !cfg.GitHubMirror.MirrorFirst()
+		},
+	})
+}
+
+// mirrorReadDigestLine is the fragment SetMirrorReadDigest appends to the gh
+// wrapper's hourly REST-usage journal line so an operator reading journalctl
+// sees, alongside API consumption, how many supervisor/orchestrator reads the
+// mirror served versus how many fell back to the API (#826 AC 5). Empty until
+// the mirror has served or turned away a read, so the pre-#826 line is unchanged
+// on a fleet that has not enabled mirror-first.
+func mirrorReadDigestLine() string {
+	st := mirrorstore.ReadStatsSnapshot()
+	if st.Total() == 0 {
+		return ""
+	}
+	return fmt.Sprintf("; mirror reads: %d served locally, %d fell back to API (%.0f%% hit)",
+		st.MirrorHits, st.APIFallbacks, st.HitRate()*100)
+}

--- a/internal/daemon/mirror_source_test.go
+++ b/internal/daemon/mirror_source_test.go
@@ -1,0 +1,65 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/mirrorstore"
+)
+
+// TestNewReadSourceNilWithoutMirror: with no mirror opened, a flow gets no read
+// source and keeps reading GitHub directly (pre-#826 behavior).
+func TestNewReadSourceNilWithoutMirror(t *testing.T) {
+	d := &Daemon{}
+	getCfg := func() *config.Config { return &config.Config{Repo: "o/r"} }
+	if src := d.newReadSource("o/r", getCfg); src != nil {
+		t.Fatal("newReadSource should be nil when the daemon has no mirror")
+	}
+}
+
+// TestNewReadSourceServesWarmMirror wires the real daemon helper against a warm
+// mirror and a mirror-first config, and asserts the read is served locally and
+// shows up in the journal digest fragment — the end-to-end wiring for AC 3/6/5.
+func TestNewReadSourceServesWarmMirror(t *testing.T) {
+	mirror, err := mirrorstore.Open(filepath.Join(t.TempDir(), "maestro.db"))
+	if err != nil {
+		t.Fatalf("open mirror: %v", err)
+	}
+	defer mirror.Close()
+
+	now := time.Now().UTC()
+	if _, err := mirror.UpsertIssueWithLabels(context.Background(), mirrorstore.Issue{
+		Repo: "o/r", Number: 5, Title: "warm", State: "open",
+		LastSeenAt: now, Source: mirrorstore.SourceWebhook,
+	}, []string{"maestro-ready"}); err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+
+	d := &Daemon{mirror: mirror, mirrorHorizon: mirrorstore.DefaultStaleHorizon}
+	getCfg := func() *config.Config {
+		return &config.Config{Repo: "o/r", GitHubMirror: config.GitHubMirrorConfig{Source: config.GitHubSourceMirrorFirst}}
+	}
+	src := d.newReadSource("o/r", getCfg)
+	if src == nil {
+		t.Fatal("newReadSource returned nil with a mirror present")
+	}
+
+	// A warm mirror hit is served locally — no gh exec, so this is safe in a test
+	// environment without a real gh binary.
+	issues, err := src.ListOpenIssues(nil)
+	if err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 5 {
+		t.Fatalf("open issues = %+v; want just #5", issues)
+	}
+
+	line := mirrorReadDigestLine()
+	if !strings.Contains(line, "served locally") {
+		t.Fatalf("digest line missing local-serve count: %q", line)
+	}
+}

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -63,15 +63,22 @@ func computeSuperviseJitter(interval time.Duration, frac float64) time.Duration 
 // flow restart (#768). The GitHub client is built once from the startup repo —
 // repo is a restart-required field the orchestrator refuses to hot-apply, so it
 // is stable for the flow's lifetime.
-func runSupervise(ctx context.Context, name string, getCfg func() *config.Config, interval time.Duration) {
-	gh := github.New(getCfg().Repo)
+func runSupervise(ctx context.Context, name string, getCfg func() *config.Config, reader supervisor.Reader, interval time.Duration) {
+	// reader is the flow's read surface. The daemon passes a mirror-first source
+	// when github_mirror.source is mirror-first (#826); it satisfies
+	// supervisor.Reader and serves the poll reads locally when the mirror is warm,
+	// falling back to the API on a miss/stale. A nil reader (mirror disabled)
+	// falls back to a plain client, byte-identical to pre-#826 behavior.
+	if reader == nil {
+		reader = github.New(getCfg().Repo)
+	}
 	// Capture and log each cycle's SupervisorDecision. The daemon still acts
 	// (label/comment/approve), but without this the structural "why did the
 	// supervisor do that" trail was dropped — turning debugging into journal
 	// archaeology (#764). Logs key on the unique fleet name (not the possibly
 	// shared session prefix) so two same-basename repos stay distinguishable.
 	runOnce := func() error {
-		decision, err := supervisor.RunOnce(getCfg(), gh)
+		decision, err := supervisor.RunOnce(getCfg(), reader)
 		if err != nil {
 			return err
 		}

--- a/internal/daemon/webhook_test.go
+++ b/internal/daemon/webhook_test.go
@@ -53,11 +53,12 @@ func TestConfigureWebhookIngestionWiresEndpoint(t *testing.T) {
 	}
 
 	fleet := server.NewFleet(nil, "127.0.0.1", 0, false)
-	configureWebhookIngestion(fleet, Options{
+	d := &Daemon{opts: Options{
 		WebhookSecretFile: secretPath,
 		WebhookDBPath:     filepath.Join(dir, "maestro.db"),
 		WebhookPath:       webhook.DefaultPath,
-	})
+	}}
+	d.configureWebhookIngestion(fleet)
 
 	body := []byte(`{"action":"opened","repository":{"full_name":"BeFeast/maestro"}}`)
 	req := httptest.NewRequest(http.MethodPost, webhook.DefaultPath, strings.NewReader(string(body)))
@@ -76,7 +77,8 @@ func TestConfigureWebhookIngestionWiresEndpoint(t *testing.T) {
 // through to the dashboard rather than accepting unsigned input.
 func TestConfigureWebhookIngestionDisabledWithoutSecret(t *testing.T) {
 	fleet := server.NewFleet(nil, "127.0.0.1", 0, false)
-	configureWebhookIngestion(fleet, Options{})
+	d := &Daemon{opts: Options{}}
+	d.configureWebhookIngestion(fleet)
 
 	req := httptest.NewRequest(http.MethodPost, webhook.DefaultPath, strings.NewReader("{}"))
 	req.Header.Set(webhook.HeaderDelivery, "nope")

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/mirrorstore"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -177,10 +178,46 @@ func (a AuthSummary) Line() string {
 	return "PAT/`gh` · bucket `shared-pat`"
 }
 
+// GitHubUsage summarizes the process-lifetime GitHub read traffic so the digest
+// shows the quota picture at a glance (#826 AC 5/10): how many REST exchanges the
+// gh wrapper made, how many were billed against the core quota vs served free by
+// a 304, and — once mirror-first reads are enabled — how many reads the local
+// mirror served vs how many fell back to the API. A high MirrorHits with a low
+// APIFallbacks is the phase-D quota win, made visible.
+//
+// The counters are process-lifetime for whichever process built the report; in
+// the long-running daemon they accumulate the fleet's real traffic, and the gh
+// wrapper's hourly journal line reports the same numbers per window.
+type GitHubUsage struct {
+	Requests     int64 `json:"requests"`      // total gh REST exchanges
+	Billed       int64 `json:"billed"`        // exchanges billed against the core quota (requests - not_modified)
+	NotModified  int64 `json:"not_modified"`  // served free by a 304 conditional response
+	RateLimited  int64 `json:"rate_limited"`  // exchanges that hit a rate limit
+	MirrorHits   int64 `json:"mirror_hits"`   // reads served from the local mirror (zero API traffic)
+	APIFallbacks int64 `json:"api_fallbacks"` // reads that fell back to the GitHub API
+}
+
+// Line renders the usage summary as a single human line for the digest header.
+func (u GitHubUsage) Line() string {
+	base := fmt.Sprintf("%d REST exchange(s) (~%d billed against core quota, %d served free by 304, %d rate-limited)",
+		u.Requests, u.Billed, u.NotModified, u.RateLimited)
+	if u.MirrorHits == 0 && u.APIFallbacks == 0 {
+		return base + " · mirror-first reads: not enabled"
+	}
+	total := u.MirrorHits + u.APIFallbacks
+	pct := 0.0
+	if total > 0 {
+		pct = 100 * float64(u.MirrorHits) / float64(total)
+	}
+	return fmt.Sprintf("%s · mirror reads: %d served locally, %d fell back to API (%.0f%% hit)",
+		base, u.MirrorHits, u.APIFallbacks, pct)
+}
+
 // Report is the full fleet digest.
 type Report struct {
 	GeneratedAt time.Time       `json:"generated_at"`
 	Auth        AuthSummary     `json:"auth"`
+	GitHub      GitHubUsage     `json:"github_usage"`
 	Projects    []ProjectReport `json:"projects"`
 }
 
@@ -206,11 +243,26 @@ func (r *Report) PromotableCount() int {
 // Collect builds the fleet digest across all projects.
 func Collect(projects []Project, opts Options) *Report {
 	opts = opts.withDefaults()
-	rep := &Report{GeneratedAt: opts.Now, Auth: authSummary()}
+	rep := &Report{GeneratedAt: opts.Now, Auth: authSummary(), GitHub: githubUsage()}
 	for _, p := range projects {
 		rep.Projects = append(rep.Projects, CollectProject(p, opts))
 	}
 	return rep
+}
+
+// githubUsage snapshots the process-wide GitHub read counters (#826): the gh
+// wrapper's REST exchange tallies and the mirror-first read hit/fallback counts.
+func githubUsage() GitHubUsage {
+	api := github.APIUsage()
+	mirror := mirrorstore.ReadStatsSnapshot()
+	return GitHubUsage{
+		Requests:     api.Requests,
+		Billed:       api.Requests - api.NotModified,
+		NotModified:  api.NotModified,
+		RateLimited:  api.RateLimited,
+		MirrorHits:   mirror.MirrorHits,
+		APIFallbacks: mirror.APIFallbacks,
+	}
 }
 
 // authSummary snapshots the process-wide GitHub auth mode into a serializable

--- a/internal/digest/github_usage_test.go
+++ b/internal/digest/github_usage_test.go
@@ -1,0 +1,39 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGitHubUsageLine_MirrorNotEnabled(t *testing.T) {
+	u := GitHubUsage{Requests: 100, Billed: 60, NotModified: 40, RateLimited: 2}
+	line := u.Line()
+	if !strings.Contains(line, "100 REST exchange(s)") {
+		t.Fatalf("line missing request count: %q", line)
+	}
+	if !strings.Contains(line, "not enabled") {
+		t.Fatalf("line should say mirror-first not enabled when no mirror reads: %q", line)
+	}
+}
+
+func TestGitHubUsageLine_WithMirrorReads(t *testing.T) {
+	u := GitHubUsage{Requests: 20, Billed: 20, MirrorHits: 80, APIFallbacks: 20}
+	line := u.Line()
+	if !strings.Contains(line, "80 served locally") {
+		t.Fatalf("line missing mirror hits: %q", line)
+	}
+	if !strings.Contains(line, "20 fell back to API") {
+		t.Fatalf("line missing fallbacks: %q", line)
+	}
+	if !strings.Contains(line, "80% hit") {
+		t.Fatalf("line missing hit rate: %q", line)
+	}
+}
+
+func TestReportMarkdownIncludesGitHubReads(t *testing.T) {
+	r := &Report{GitHub: GitHubUsage{Requests: 5, Billed: 5}}
+	md := r.Markdown()
+	if !strings.Contains(md, "GitHub reads:") {
+		t.Fatalf("markdown missing GitHub reads line:\n%s", md)
+	}
+}

--- a/internal/digest/markdown.go
+++ b/internal/digest/markdown.go
@@ -14,6 +14,7 @@ func (r *Report) Markdown() string {
 	fmt.Fprintf(&b, "Generated %s · %d project(s) · **%d decision(s) needed** · %d promotable\n\n",
 		r.GeneratedAt.Format("2006-01-02 15:04 MST"), len(r.Projects), r.DecideTodayCount(), r.PromotableCount())
 	fmt.Fprintf(&b, "GitHub auth: %s\n\n", r.Auth.Line())
+	fmt.Fprintf(&b, "GitHub reads: %s\n\n", r.GitHub.Line())
 
 	fmt.Fprintf(&b, "## 1. Decide today (%d)\n\n", r.DecideTodayCount())
 	if r.DecideTodayCount() == 0 {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -754,8 +754,8 @@ func noteAPIRequest(notModified, rateLimited bool) {
 		// Roll the window before counting so the request that crossed the
 		// boundary opens the new window instead of vanishing with the digest.
 		w := apiStatsWindow
-		log.Printf("[github] REST usage last %s: %d requests, ~%d billed against core quota, %d served free by 304, %d rate-limited%s%s",
-			elapsed.Round(time.Minute), w.Requests, w.Requests-w.NotModified, w.NotModified, w.RateLimited, authModeDigest(), primaryLimitDigest())
+		log.Printf("[github] REST usage last %s: %d requests, ~%d billed against core quota, %d served free by 304, %d rate-limited%s%s%s",
+			elapsed.Round(time.Minute), w.Requests, w.Requests-w.NotModified, w.NotModified, w.RateLimited, authModeDigest(), primaryLimitDigest(), mirrorReadDigest())
 		apiStatsWindow = APIStats{}
 		apiWindowStart = now
 	}
@@ -776,6 +776,26 @@ func APIUsage() APIStats {
 	apiStatsMu.Lock()
 	defer apiStatsMu.Unlock()
 	return apiStatsTotal
+}
+
+// mirrorReadDigestFn, when set by the daemon, returns a fragment describing how
+// many supervisor/orchestrator reads the local mirror served vs how many fell
+// back to the API (#826). github cannot import internal/mirrorstore — that would
+// be an import cycle, since mirrorstore imports github — so the fragment is
+// injected as a hook. Unset appends nothing, so the pre-#826 line is unchanged.
+var mirrorReadDigestFn func() string
+
+// SetMirrorReadDigest installs the mirror-usage fragment appended to the hourly
+// REST usage journal line. The daemon wires it to the mirrorstore read counters
+// so the "API calls/hour" journal line also reports mirror hit/fallback counts
+// (#826 AC 5). Passing nil clears it.
+func SetMirrorReadDigest(fn func() string) { mirrorReadDigestFn = fn }
+
+func mirrorReadDigest() string {
+	if mirrorReadDigestFn == nil {
+		return ""
+	}
+	return mirrorReadDigestFn()
 }
 
 // ghRateLimitKind distinguishes the two GitHub rate limits, which need opposite

--- a/internal/mirrorstore/migrate_test.go
+++ b/internal/mirrorstore/migrate_test.go
@@ -1,0 +1,122 @@
+package mirrorstore
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestMigrateAddsPRColumns proves a mirror created before #826 — whose
+// mirror_pull_requests table has neither head_ref nor body — is upgraded in
+// place by Init, so ListOpenPRs can serve the head branch and body without a
+// manual migration step. CREATE TABLE IF NOT EXISTS alone never alters an
+// existing table, so this exercises the ALTER path in migrate().
+func TestMigrateAddsPRColumns(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "maestro.db")
+
+	// Seed a pre-#826 schema: the old column set, no head_ref / body.
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE mirror_pull_requests (
+		repo TEXT NOT NULL, number INTEGER NOT NULL, title TEXT, state TEXT,
+		draft INTEGER, merged INTEGER, head_sha TEXT, base_ref TEXT,
+		last_seen_at TEXT, source TEXT, PRIMARY KEY (repo, number))`); err != nil {
+		t.Fatalf("create old table: %v", err)
+	}
+	raw.Close()
+
+	// Open via mirrorstore: Init runs the schema then migrate(), adding the
+	// missing columns to the existing table.
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	seen := mustTime(t, "2026-07-06T12:00:00Z")
+	if _, err := s.UpsertPullRequest(ctx, PullRequest{
+		Repo: "o/r", Number: 1, Title: "feat", State: "open",
+		HeadSHA: "sha", HeadRef: "feat/x", BaseRef: "main", Body: "desc",
+		LastSeenAt: seen, Source: SourceWebhook,
+	}); err != nil {
+		t.Fatalf("upsert after migrate: %v", err)
+	}
+	pr, ok, err := s.GetPullRequest(ctx, "o/r", 1)
+	if err != nil || !ok {
+		t.Fatalf("GetPullRequest ok=%v err=%v", ok, err)
+	}
+	if pr.HeadRef != "feat/x" || pr.Body != "desc" {
+		t.Fatalf("migrated columns not persisted: head_ref=%q body=%q", pr.HeadRef, pr.Body)
+	}
+
+	// Re-opening an already-migrated DB is a no-op (idempotent).
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("re-Open after migrate: %v", err)
+	}
+	s2.Close()
+}
+
+// TestProjectPullRequestCapturesHeadRefAndBody proves the webhook projection now
+// records the head branch and PR body — the fields ListOpenPRs consumers rely on.
+func TestProjectPullRequestCapturesHeadRefAndBody(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	payload := []byte(`{
+		"action": "opened",
+		"number": 42,
+		"pull_request": {
+			"number": 42, "title": "feat", "state": "open",
+			"draft": false, "merged": false,
+			"body": "the description",
+			"updated_at": "2026-07-02T09:15:00Z",
+			"head": {"sha": "abc123", "ref": "feat/head-branch"},
+			"base": {"ref": "main"}
+		},
+		"repository": {"full_name": "o/r"}
+	}`)
+	if err := s.ProjectWebhook(ctx, "pull_request", payload, time.Time{}); err != nil {
+		t.Fatalf("ProjectWebhook: %v", err)
+	}
+	pr, ok, err := s.GetPullRequest(ctx, "o/r", 42)
+	if err != nil || !ok {
+		t.Fatalf("GetPullRequest ok=%v err=%v", ok, err)
+	}
+	if pr.HeadRef != "feat/head-branch" {
+		t.Fatalf("head_ref = %q, want feat/head-branch", pr.HeadRef)
+	}
+	if pr.Body != "the description" {
+		t.Fatalf("body = %q, want the description", pr.Body)
+	}
+}
+
+// TestListOpenPullRequestsFiltersState confirms the list query returns only
+// open PRs, in number order — a merged/closed PR is excluded.
+func TestListOpenPullRequestsFiltersState(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	seen := mustTime(t, "2026-07-06T12:00:00Z")
+	for _, pr := range []PullRequest{
+		{Repo: "o/r", Number: 3, State: "open", HeadRef: "c", LastSeenAt: seen, Source: SourceWebhook},
+		{Repo: "o/r", Number: 1, State: "open", HeadRef: "a", LastSeenAt: seen, Source: SourceWebhook},
+		{Repo: "o/r", Number: 2, State: "closed", Merged: true, HeadRef: "b", LastSeenAt: seen, Source: SourceWebhook},
+	} {
+		if _, err := s.UpsertPullRequest(ctx, pr); err != nil {
+			t.Fatalf("upsert %d: %v", pr.Number, err)
+		}
+	}
+	got, err := s.ListOpenPullRequests(ctx, "o/r")
+	if err != nil {
+		t.Fatalf("ListOpenPullRequests: %v", err)
+	}
+	if len(got) != 2 || got[0].Number != 1 || got[1].Number != 3 {
+		t.Fatalf("open PRs = %+v; want #1,#3 in order", got)
+	}
+}

--- a/internal/mirrorstore/project.go
+++ b/internal/mirrorstore/project.go
@@ -120,8 +120,10 @@ func (s *Store) projectPullRequest(ctx context.Context, payload []byte, received
 			Merged    bool   `json:"merged"`
 			UpdatedAt string `json:"updated_at"`
 			CreatedAt string `json:"created_at"`
+			Body      string `json:"body"`
 			Head      struct {
 				SHA string `json:"sha"`
+				Ref string `json:"ref"`
 			} `json:"head"`
 			Base struct {
 				Ref string `json:"ref"`
@@ -142,7 +144,9 @@ func (s *Store) projectPullRequest(ctx context.Context, payload []byte, received
 		Draft:      p.PullRequest.Draft,
 		Merged:     p.PullRequest.Merged,
 		HeadSHA:    strings.TrimSpace(p.PullRequest.Head.SHA),
+		HeadRef:    strings.TrimSpace(p.PullRequest.Head.Ref),
 		BaseRef:    strings.TrimSpace(p.PullRequest.Base.Ref),
+		Body:       p.PullRequest.Body,
 		LastSeenAt: ts,
 		Source:     SourceWebhook,
 	}, labelNames(p.PullRequest.Labels))

--- a/internal/mirrorstore/reads.go
+++ b/internal/mirrorstore/reads.go
@@ -3,6 +3,7 @@ package mirrorstore
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 )
 
@@ -156,7 +157,11 @@ func (s *Store) newestSeen(ctx context.Context, table, repo string) (time.Time, 
 // ---- label helpers ---------------------------------------------------------
 
 // labelFilter normalises the requested labels into a lookup set, returning nil
-// when no filter was requested (every open issue matches).
+// when no filter was requested (every open issue matches). Keys are lower-cased
+// so the match is case-insensitive: GitHub's own labels= query filter matches
+// case-insensitively, so a mirror asked for "maestro-ready" must still match a
+// mirrored "Maestro-Ready" label rather than filtering the issue out and
+// silently skipping label-gated work (see anyLabelMatches).
 func labelFilter(labels []string) map[string]struct{} {
 	if len(labels) == 0 {
 		return nil
@@ -164,7 +169,7 @@ func labelFilter(labels []string) map[string]struct{} {
 	want := make(map[string]struct{}, len(labels))
 	for _, l := range labels {
 		if l != "" {
-			want[l] = struct{}{}
+			want[strings.ToLower(l)] = struct{}{}
 		}
 	}
 	if len(want) == 0 {
@@ -173,9 +178,11 @@ func labelFilter(labels []string) map[string]struct{} {
 	return want
 }
 
+// anyLabelMatches reports whether any mirrored label name matches one of the
+// requested labels, case-insensitively (want holds already-lower-cased keys).
 func anyLabelMatches(have []string, want map[string]struct{}) bool {
 	for _, name := range have {
-		if _, ok := want[name]; ok {
+		if _, ok := want[strings.ToLower(name)]; ok {
 			return true
 		}
 	}

--- a/internal/mirrorstore/reads.go
+++ b/internal/mirrorstore/reads.go
@@ -19,6 +19,14 @@ import (
 // NewestPullRequestAt against a freshness horizon) and falls back to the API
 // when the mirror is cold, so an unpopulated mirror degrades to today's
 // API-direct behavior rather than silently under-reporting.
+//
+// Warmth is necessary but not sufficient: the newest row being fresh proves
+// webhooks are flowing for the repo, but an individual open row can still be
+// stale (its close/unlabel delivery was missed) or, for a PR mirrored before the
+// head_ref column existed, be missing its head branch. The source therefore also
+// inspects each returned row and falls back for the whole list when any member is
+// untrustworthy — the rows here carry last_seen_at (and PRs carry head_ref) so it
+// can. See Source.ListOpenIssues / Source.ListOpenPRs.
 
 // ListOpenIssues returns every mirrored issue for repo whose state is "open",
 // each with its mirrored label set attached, ordered by issue number. When

--- a/internal/mirrorstore/reads.go
+++ b/internal/mirrorstore/reads.go
@@ -1,0 +1,175 @@
+package mirrorstore
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// This file holds the LIST reads the mirror-first source (source.go) serves for
+// the supervisor/orchestrator poll loops — the reads that dominate the fleet's
+// per-cycle REST consumption. Point reads live in store.go (GetIssue,
+// GetPullRequest, …); these return whole open-issue / open-PR sets so a warm
+// mirror answers "what is open right now?" with zero GitHub traffic (#826).
+//
+// A list is fundamentally different from a point read: a point miss is a clean
+// "hydrate this one entity" signal, but a list has no per-row miss — an empty
+// or lagging result could mean "nothing is open" or "the mirror never saw the
+// webhooks". The source therefore gates list serving on warmth (NewestIssueAt /
+// NewestPullRequestAt against a freshness horizon) and falls back to the API
+// when the mirror is cold, so an unpopulated mirror degrades to today's
+// API-direct behavior rather than silently under-reporting.
+
+// ListOpenIssues returns every mirrored issue for repo whose state is "open",
+// each with its mirrored label set attached, ordered by issue number. When
+// labels is non-empty the result is filtered to issues carrying at least one of
+// them (OR semantics — the same filter github.Client.ListOpenIssues applies).
+//
+// The label set is read from mirror_labels so a caller gets the same
+// {Number,Title,Body,State,Labels} shape the REST list returns; body and title
+// are mirrored on the issue row, so the reconstruction is loss-free.
+func (s *Store) ListOpenIssues(ctx context.Context, repo string, labels []string) ([]Issue, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT repo, number, title, state, body, last_seen_at, source
+FROM mirror_issues
+WHERE repo = ? AND state = 'open'
+ORDER BY number`, repo)
+	if err != nil {
+		return nil, err
+	}
+	issues, err := scanIssues(rows)
+	if err != nil {
+		return nil, err
+	}
+	want := labelFilter(labels)
+	out := make([]Issue, 0, len(issues))
+	for _, iss := range issues {
+		names, err := s.Labels(ctx, repo, SubjectIssue, iss.Number)
+		if err != nil {
+			return nil, err
+		}
+		if want != nil && !anyLabelMatches(names, want) {
+			continue
+		}
+		iss.Labels = names
+		out = append(out, iss)
+	}
+	return out, nil
+}
+
+// ListOpenPullRequests returns every mirrored pull request for repo whose state
+// is "open", ordered by number. head_ref and body are mirrored on the row so the
+// source can reconstruct the fields ListOpenPRs consumers rely on (branch
+// matching, draft-marker detection) without an API call.
+func (s *Store) ListOpenPullRequests(ctx context.Context, repo string) ([]PullRequest, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT repo, number, title, state, draft, merged, head_sha, head_ref, base_ref, body, last_seen_at, source
+FROM mirror_pull_requests
+WHERE repo = ? AND state = 'open'
+ORDER BY number`, repo)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PullRequest
+	for rows.Next() {
+		var (
+			r             PullRequest
+			draft, merged int
+			seen          string
+		)
+		if err := rows.Scan(&r.Repo, &r.Number, &r.Title, &r.State, &draft, &merged,
+			&r.HeadSHA, &r.HeadRef, &r.BaseRef, &r.Body, &seen, &r.Source); err != nil {
+			return nil, err
+		}
+		r.Draft = draft != 0
+		r.Merged = merged != 0
+		r.LastSeenAt, _ = parseTS(seen)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func scanIssues(rows *sql.Rows) ([]Issue, error) {
+	defer rows.Close()
+	var out []Issue
+	for rows.Next() {
+		var (
+			r    Issue
+			seen string
+		)
+		if err := rows.Scan(&r.Repo, &r.Number, &r.Title, &r.State, &r.Body, &seen, &r.Source); err != nil {
+			return nil, err
+		}
+		r.LastSeenAt, _ = parseTS(seen)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ---- Warmth ----------------------------------------------------------------
+//
+// A list can only be trusted when the mirror is warm for that entity: the
+// newest row is within the freshness horizon, i.e. webhooks are flowing. The
+// source consults these before serving a list; a cold mirror (no rows, or the
+// newest row is stale) means "we cannot vouch for completeness" → API.
+
+// NewestIssueAt returns the most recent last_seen_at across mirrored issues for
+// repo and ok=false when the mirror holds no issue for repo.
+func (s *Store) NewestIssueAt(ctx context.Context, repo string) (time.Time, bool, error) {
+	return s.newestSeen(ctx, "mirror_issues", repo)
+}
+
+// NewestPullRequestAt returns the most recent last_seen_at across mirrored pull
+// requests for repo and ok=false when the mirror holds no PR for repo.
+func (s *Store) NewestPullRequestAt(ctx context.Context, repo string) (time.Time, bool, error) {
+	return s.newestSeen(ctx, "mirror_pull_requests", repo)
+}
+
+func (s *Store) newestSeen(ctx context.Context, table, repo string) (time.Time, bool, error) {
+	var newest sql.NullString
+	// MAX over a fixed-width, byte-order == time-order timestamp column yields the
+	// chronologically-latest row (see tsLayout).
+	err := s.db.QueryRowContext(ctx,
+		"SELECT MAX(last_seen_at) FROM "+table+" WHERE repo = ?", repo).Scan(&newest)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if !newest.Valid || newest.String == "" {
+		return time.Time{}, false, nil
+	}
+	t, err := parseTS(newest.String)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	return t, true, nil
+}
+
+// ---- label helpers ---------------------------------------------------------
+
+// labelFilter normalises the requested labels into a lookup set, returning nil
+// when no filter was requested (every open issue matches).
+func labelFilter(labels []string) map[string]struct{} {
+	if len(labels) == 0 {
+		return nil
+	}
+	want := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		if l != "" {
+			want[l] = struct{}{}
+		}
+	}
+	if len(want) == 0 {
+		return nil
+	}
+	return want
+}
+
+func anyLabelMatches(have []string, want map[string]struct{}) bool {
+	for _, name := range have {
+		if _, ok := want[name]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mirrorstore/source.go
+++ b/internal/mirrorstore/source.go
@@ -1,0 +1,351 @@
+package mirrorstore
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+// Source is the mirror-first read source the supervisor and orchestrator poll
+// loops read GitHub through (#826, epic #811 phase D). It serves the high-volume
+// per-cycle reads — the open-issue and open-PR lists and the issue/PR state
+// point reads — from the local SQLite mirror when the mirror is warm, and falls
+// back to the GitHub API only on a miss, a stale row, a cold mirror, or the
+// escape hatch. Every fallback is counted so the journal digest can show the
+// reduction (#826 AC 5).
+//
+// It EMBEDS *github.Client, so a Source is a drop-in wherever the concrete
+// client was used: every method the Source does not override — all writes
+// (labels, comments, merges), and the reads the mirror cannot faithfully serve
+// (mergeable state, review-gate verdicts, CI status, project board) — passes
+// straight through to GitHub, which stays authoritative. Only the reads listed
+// below are intercepted:
+//
+//   - ListOpenIssues  — mirror_issues (+ mirror_labels), loss-free
+//   - ListOpenPRs     — mirror_pull_requests (head_ref/body mirrored in phase D)
+//   - IsIssueClosed   — mirror_issues.state
+//   - IsPRMerged      — mirror_pull_requests.merged
+//   - GetIssue        — mirror hit, else hydrate (fetch → store → serve)
+//
+// Merge-gating reads (PRCIStatus, PRMergeStatus, PRGreptileApproved, review
+// verdicts) are deliberately NOT mirror-served: the mirror cannot prove check
+// completeness, and a stale "green" would be a merge-safety regression. They
+// stay on the authoritative API — the conservative choice AC 4 (no
+// decision-quality regression) demands.
+type Source struct {
+	*github.Client // pass-through: writes + reads the mirror does not serve
+
+	store *Store
+	repo  string
+	// api is the fallback read client for the overridden methods, injectable so
+	// tests can drive the fallback path without a real gh binary. In production it
+	// is the same *github.Client that is embedded.
+	api apiReader
+	// horizon is the freshness window: a mirror row (or list) older than this is
+	// stale and triggers an API fallback. <= 0 means "never stale" — every present
+	// row is served locally.
+	horizon time.Duration
+	// apiDirect is the escape hatch, consulted per read so a live config-store
+	// edit flips the whole fleet back to API-direct without a redeploy (#826 AC
+	// 3). nil means "always mirror-first".
+	apiDirect func() bool
+	now       func() time.Time
+}
+
+// apiReader is the slice of *github.Client the mirror-first reads fall back to.
+// *github.Client satisfies it; tests supply a fake.
+type apiReader interface {
+	ListOpenIssues(labels []string) ([]github.Issue, error)
+	ListOpenPRs() ([]github.PR, error)
+	IsIssueClosed(number int) (bool, error)
+	IsPRMerged(prNumber int) (bool, error)
+	GetIssue(number int) (github.Issue, error)
+}
+
+// SourceOptions tunes a Source. The zero value is valid: no staleness horizon
+// (every present row served), always mirror-first, wall-clock now.
+type SourceOptions struct {
+	// Horizon is the staleness window; <= 0 means never stale.
+	Horizon time.Duration
+	// APIDirect, when non-nil and returning true, forces every read to the API —
+	// the fleet-wide escape hatch. Evaluated per read for hot-reload.
+	APIDirect func() bool
+	// Now overrides the clock (tests). Defaults to time.Now().UTC().
+	Now func() time.Time
+}
+
+// NewSource builds a mirror-first Source over store for repo, backed by client
+// for API fallback and pass-through. A nil store or nil client yields a Source
+// that behaves API-direct (it can only pass through), so wiring is fail-safe.
+func NewSource(client *github.Client, store *Store, repo string, opts SourceOptions) *Source {
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Source{
+		Client:    client,
+		store:     store,
+		repo:      strings.TrimSpace(repo),
+		api:       client,
+		horizon:   opts.Horizon,
+		apiDirect: opts.APIDirect,
+		now:       now,
+	}
+}
+
+func (s *Source) ctx() context.Context { return context.Background() }
+
+// apiDirectNow reports whether the escape hatch is engaged, or the source has no
+// usable mirror to read from.
+func (s *Source) apiDirectNow() bool {
+	if s.store == nil {
+		return true
+	}
+	return s.apiDirect != nil && s.apiDirect()
+}
+
+// fresh reports whether a row last seen at lastSeen is within the horizon.
+func (s *Source) fresh(lastSeen time.Time) bool {
+	return Classify(lastSeen, s.now(), s.horizon) == Fresh
+}
+
+// ListOpenIssues serves the open-issue list from the mirror when it is warm,
+// falling back to the API otherwise. Warmth (the newest mirrored issue is within
+// the horizon) is what lets an empty/cold mirror degrade to today's API-direct
+// correctness instead of silently under-reporting an unpopulated list (AC 7).
+func (s *Source) ListOpenIssues(labels []string) ([]github.Issue, error) {
+	if s.apiDirectNow() {
+		return s.apiListOpenIssues(labels)
+	}
+	newest, ok, err := s.store.NewestIssueAt(s.ctx(), s.repo)
+	if err != nil || !ok || !s.fresh(newest) {
+		return s.apiListOpenIssues(labels)
+	}
+	rows, err := s.store.ListOpenIssues(s.ctx(), s.repo, labels)
+	if err != nil {
+		return s.apiListOpenIssues(labels)
+	}
+	noteMirrorHit()
+	out := make([]github.Issue, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, issueToGitHub(r))
+	}
+	return out, nil
+}
+
+// ListOpenPRs serves the open-PR list from the mirror when warm, else the API.
+func (s *Source) ListOpenPRs() ([]github.PR, error) {
+	if s.apiDirectNow() {
+		return s.apiListOpenPRs()
+	}
+	newest, ok, err := s.store.NewestPullRequestAt(s.ctx(), s.repo)
+	if err != nil || !ok || !s.fresh(newest) {
+		return s.apiListOpenPRs()
+	}
+	rows, err := s.store.ListOpenPullRequests(s.ctx(), s.repo)
+	if err != nil {
+		return s.apiListOpenPRs()
+	}
+	noteMirrorHit()
+	out := make([]github.PR, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, prToGitHub(r))
+	}
+	return out, nil
+}
+
+// IsIssueClosed answers from a fresh mirror issue row, else the API.
+func (s *Source) IsIssueClosed(number int) (bool, error) {
+	if s.apiDirectNow() {
+		return s.apiIsIssueClosed(number)
+	}
+	row, ok, err := s.store.GetIssue(s.ctx(), s.repo, number)
+	if err != nil || !ok || !s.fresh(row.LastSeenAt) {
+		return s.apiIsIssueClosed(number)
+	}
+	noteMirrorHit()
+	return strings.EqualFold(strings.TrimSpace(row.State), "closed"), nil
+}
+
+// IsPRMerged answers from a fresh mirror PR row, else the API. "merged" is a
+// terminal, monotonic state, so a lagging mirror can at worst report a
+// not-yet-merged PR (which re-polls) — it never fabricates a merge.
+func (s *Source) IsPRMerged(prNumber int) (bool, error) {
+	if s.apiDirectNow() {
+		return s.apiIsPRMerged(prNumber)
+	}
+	row, ok, err := s.store.GetPullRequest(s.ctx(), s.repo, prNumber)
+	if err != nil || !ok || !s.fresh(row.LastSeenAt) {
+		return s.apiIsPRMerged(prNumber)
+	}
+	noteMirrorHit()
+	return row.Merged, nil
+}
+
+// GetIssue serves a fresh mirror issue, otherwise HYDRATES: it fetches the issue
+// from the API, records it (source = "api"), and returns it — so the next read
+// is local. This is the miss-degrades-to-API-direct path (AC 7): an empty mirror
+// converges to full coverage one requested entity at a time, with no bulk
+// backfill.
+func (s *Source) GetIssue(number int) (github.Issue, error) {
+	if s.apiDirectNow() {
+		return s.apiGetIssue(number)
+	}
+	row, ok, err := s.store.GetIssue(s.ctx(), s.repo, number)
+	if err == nil && ok && s.fresh(row.LastSeenAt) {
+		labels, lerr := s.store.Labels(s.ctx(), s.repo, SubjectIssue, number)
+		if lerr == nil {
+			row.Labels = labels
+			noteMirrorHit()
+			return issueToGitHub(row), nil
+		}
+	}
+	// Miss / stale / mirror error → hydrate from the API and persist.
+	gh, err := s.apiGetIssue(number)
+	if err != nil {
+		return github.Issue{}, err
+	}
+	s.hydrateIssue(gh)
+	return gh, nil
+}
+
+// hydrateIssue stores an API-fetched issue into the mirror so the next GetIssue
+// is served locally. A store failure is swallowed: hydration is best-effort
+// convergence, and the correct answer was already returned to the caller.
+func (s *Source) hydrateIssue(gh github.Issue) {
+	if s.store == nil {
+		return
+	}
+	labels := make([]string, 0, len(gh.Labels))
+	for _, l := range gh.Labels {
+		labels = append(labels, l.Name)
+	}
+	state := strings.ToLower(strings.TrimSpace(gh.State))
+	if state == "" {
+		state = "open"
+	}
+	_, _ = s.store.UpsertIssueWithLabels(s.ctx(), Issue{
+		Repo:       s.repo,
+		Number:     gh.Number,
+		Title:      gh.Title,
+		State:      state,
+		Body:       gh.Body,
+		LastSeenAt: s.now(),
+		Source:     SourceAPI,
+	}, labels)
+}
+
+// ---- API fallbacks (each records the fallback) -----------------------------
+
+func (s *Source) apiListOpenIssues(labels []string) ([]github.Issue, error) {
+	noteAPIFallback()
+	return s.api.ListOpenIssues(labels)
+}
+
+func (s *Source) apiListOpenPRs() ([]github.PR, error) {
+	noteAPIFallback()
+	return s.api.ListOpenPRs()
+}
+
+func (s *Source) apiIsIssueClosed(number int) (bool, error) {
+	noteAPIFallback()
+	return s.api.IsIssueClosed(number)
+}
+
+func (s *Source) apiIsPRMerged(prNumber int) (bool, error) {
+	noteAPIFallback()
+	return s.api.IsPRMerged(prNumber)
+}
+
+func (s *Source) apiGetIssue(number int) (github.Issue, error) {
+	noteAPIFallback()
+	return s.api.GetIssue(number)
+}
+
+// ---- conversions -----------------------------------------------------------
+
+// ghLabel is the exact anonymous label type github.Issue.Labels holds, so a
+// reconstructed issue reports labels in the same shape a REST fetch would.
+type ghLabel = struct {
+	Name string `json:"name"`
+}
+
+func issueToGitHub(r Issue) github.Issue {
+	gh := github.Issue{
+		Number: r.Number,
+		Title:  r.Title,
+		Body:   r.Body,
+		State:  r.State,
+	}
+	for _, name := range r.Labels {
+		gh.Labels = append(gh.Labels, ghLabel{Name: name})
+	}
+	return gh
+}
+
+func prToGitHub(r PullRequest) github.PR {
+	// State is upper-cased to match github.Client's REST mapping (restPull.pr()).
+	// Mergeable and MergedAt are left empty on purpose: the REST list endpoint
+	// returns them empty for open PRs too (mergeable is only computed by the
+	// single-PR endpoint), so a mirror-served list matches in every field a
+	// ListOpenPRs consumer actually reads.
+	return github.PR{
+		Number:      r.Number,
+		HeadRefName: r.HeadRef,
+		State:       strings.ToUpper(strings.TrimSpace(r.State)),
+		Title:       r.Title,
+		Body:        r.Body,
+		IsDraft:     r.Draft,
+	}
+}
+
+// ---- process-global read metrics -------------------------------------------
+//
+// Counted process-wide (like github.APIUsage and the primary-limit gate) so the
+// journal digest can read them without threading a Source handle through every
+// call site. MirrorHits are reads served locally; APIFallbacks are reads that
+// reached the GitHub API through the source (miss, stale, cold mirror, or the
+// escape hatch). Together they quantify how much the mirror saved (#826 AC 5).
+
+var (
+	mirrorHitsTotal   atomic.Int64
+	apiFallbacksTotal atomic.Int64
+)
+
+func noteMirrorHit()   { mirrorHitsTotal.Add(1) }
+func noteAPIFallback() { apiFallbacksTotal.Add(1) }
+
+// ReadStats is a snapshot of the mirror-first read counters.
+type ReadStats struct {
+	MirrorHits   int64 `json:"mirror_hits"`
+	APIFallbacks int64 `json:"api_fallbacks"`
+}
+
+// Total is the number of source reads observed.
+func (r ReadStats) Total() int64 { return r.MirrorHits + r.APIFallbacks }
+
+// HitRate is the fraction of source reads served from the mirror (0 when none).
+func (r ReadStats) HitRate() float64 {
+	total := r.Total()
+	if total == 0 {
+		return 0
+	}
+	return float64(r.MirrorHits) / float64(total)
+}
+
+// ReadStats returns the process-lifetime mirror-first read counters.
+func ReadStatsSnapshot() ReadStats {
+	return ReadStats{
+		MirrorHits:   mirrorHitsTotal.Load(),
+		APIFallbacks: apiFallbacksTotal.Load(),
+	}
+}
+
+// resetReadStatsForTest zeroes the counters so a test starts from a known base.
+func resetReadStatsForTest() {
+	mirrorHitsTotal.Store(0)
+	apiFallbacksTotal.Store(0)
+}

--- a/internal/mirrorstore/source.go
+++ b/internal/mirrorstore/source.go
@@ -128,6 +128,17 @@ func (s *Source) ListOpenIssues(labels []string) ([]github.Issue, error) {
 	if err != nil {
 		return s.apiListOpenIssues(labels)
 	}
+	// The newest-row warmth check only proves webhooks are flowing for the repo as
+	// a whole; it does not vouch for every individual row. A single open row older
+	// than the horizon may have had its close/unlabel delivery missed, so it could
+	// be a no-longer-open (or mis-labelled) issue the mirror is still exposing —
+	// which would leak into supervisor/orchestrator decisions. Reject the whole
+	// list to the authoritative API if any returned row is itself stale (#826).
+	for i := range rows {
+		if !s.fresh(rows[i].LastSeenAt) {
+			return s.apiListOpenIssues(labels)
+		}
+	}
 	noteMirrorHit()
 	out := make([]github.Issue, 0, len(rows))
 	for _, r := range rows {
@@ -148,6 +159,20 @@ func (s *Source) ListOpenPRs() ([]github.PR, error) {
 	rows, err := s.store.ListOpenPullRequests(s.ctx(), s.repo)
 	if err != nil {
 		return s.apiListOpenPRs()
+	}
+	// As in ListOpenIssues, reject the list to the API if any returned open PR is
+	// itself stale (a missed close delivery could keep a merged/closed PR "open").
+	// ALSO reject it if any row is missing its head branch: a mirror upgraded before
+	// the head_ref column existed backfills head_ref = '' on every already-open PR
+	// (store.go migrate), and those rows keep their old — possibly still fresh —
+	// last_seen_at, so the staleness check alone would not catch them. The
+	// supervisor/orchestrator match running sessions to open PRs BY HEAD BRANCH, so
+	// serving a PR with an empty HeadRefName would mis-match or duplicate work; fall
+	// back to GitHub until a webhook repopulates the branch (#826).
+	for i := range rows {
+		if !s.fresh(rows[i].LastSeenAt) || strings.TrimSpace(rows[i].HeadRef) == "" {
+			return s.apiListOpenPRs()
+		}
 	}
 	noteMirrorHit()
 	out := make([]github.PR, 0, len(rows))

--- a/internal/mirrorstore/source_test.go
+++ b/internal/mirrorstore/source_test.go
@@ -187,6 +187,79 @@ func TestStaleRowFallsBackToAPI(t *testing.T) {
 	}
 }
 
+// TestWarmListWithStaleMemberFallsBack: a list whose NEWEST row is fresh (so the
+// mirror is warm) but which also contains an individually-stale open row must
+// fall back to the API for the whole list rather than serve the stale member. A
+// missed close/unlabel delivery would otherwise leak a no-longer-open issue/PR
+// into supervisor/orchestrator decisions (review comment 2).
+func TestWarmListWithStaleMemberFallsBack(t *testing.T) {
+	s := openTestStore(t)
+	now := mustTime(t, "2026-07-06T12:00:00Z")
+	stale := mustTime(t, "2026-07-01T00:00:00Z") // > 24h before now
+	// Newest row is fresh → warmth check passes; #11 is an individually-stale member.
+	seedIssue(t, s, 10, "fresh", "open", "body", now)
+	seedIssue(t, s, 11, "stale", "open", "body", stale)
+	seedPR(t, s, 20, "fresh pr", "open", false, false, "feat/a", "b", now)
+	seedPR(t, s, 21, "stale pr", "open", false, false, "feat/b", "b", stale)
+
+	api := &fakeAPI{
+		issues: []github.Issue{{Number: 99, Title: "from api"}},
+		prs:    []github.PR{{Number: 98, HeadRefName: "from-api"}},
+	}
+	src := newTestSource(t, s, api, now, 24*time.Hour, nil)
+
+	issues, err := src.ListOpenIssues(nil)
+	if err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 99 {
+		t.Fatalf("stale list member should force API fallback, got %+v", issues)
+	}
+	prs, err := src.ListOpenPRs()
+	if err != nil {
+		t.Fatalf("ListOpenPRs: %v", err)
+	}
+	if len(prs) != 1 || prs[0].Number != 98 {
+		t.Fatalf("stale PR list member should force API fallback, got %+v", prs)
+	}
+	if api.listIssuesCalls != 1 || api.listPRsCalls != 1 {
+		t.Fatalf("expected one API fallback each: %+v", api)
+	}
+	if got := ReadStatsSnapshot().MirrorHits; got != 0 {
+		t.Fatalf("MirrorHits = %d; want 0 (both lists fell back)", got)
+	}
+}
+
+// TestListOpenPRsMissingHeadRefFallsBack: after an in-place upgrade the migration
+// adds head_ref with an empty default on already-open PR rows, which keep their
+// (still fresh) last_seen_at. Serving such a row would hand the orchestrator an
+// empty HeadRefName and break branch matching, so the source must fall back to the
+// API for the list even though the row is fresh (review comment 1).
+func TestListOpenPRsMissingHeadRefFallsBack(t *testing.T) {
+	s := openTestStore(t)
+	now := mustTime(t, "2026-07-06T12:00:00Z")
+	// Fresh row, but empty head_ref — exactly the shape a pre-#826 row has after the
+	// ALTER TABLE adds the column with its empty default.
+	seedPR(t, s, 20, "migrated pr", "open", false, false, "", "body", now)
+
+	api := &fakeAPI{prs: []github.PR{{Number: 20, HeadRefName: "feat/real"}}}
+	src := newTestSource(t, s, api, now, 24*time.Hour, nil)
+
+	prs, err := src.ListOpenPRs()
+	if err != nil {
+		t.Fatalf("ListOpenPRs: %v", err)
+	}
+	if len(prs) != 1 || prs[0].HeadRefName != "feat/real" {
+		t.Fatalf("empty-head_ref row should force API fallback, got %+v", prs)
+	}
+	if api.listPRsCalls != 1 {
+		t.Fatalf("expected 1 API fallback, got %d", api.listPRsCalls)
+	}
+	if got := ReadStatsSnapshot().MirrorHits; got != 0 {
+		t.Fatalf("MirrorHits = %d; want 0 (missing head_ref fell back)", got)
+	}
+}
+
 // TestGetIssueHydrates covers the hydration path: a miss fetches from the API,
 // stores the row, and the NEXT GetIssue is served locally (zero further API).
 func TestGetIssueHydrates(t *testing.T) {

--- a/internal/mirrorstore/source_test.go
+++ b/internal/mirrorstore/source_test.go
@@ -1,0 +1,290 @@
+package mirrorstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+// fakeAPI is an apiReader that records every call, so a test can assert a warm
+// mirror performed ZERO API reads (AC 6) and a cold/stale mirror fell back.
+type fakeAPI struct {
+	issues    []github.Issue
+	prs       []github.PR
+	closed    map[int]bool
+	merged    map[int]bool
+	getIssues map[int]github.Issue
+
+	listIssuesCalls int
+	listPRsCalls    int
+	isClosedCalls   int
+	isMergedCalls   int
+	getIssueCalls   int
+}
+
+func (f *fakeAPI) ListOpenIssues(labels []string) ([]github.Issue, error) {
+	f.listIssuesCalls++
+	return f.issues, nil
+}
+func (f *fakeAPI) ListOpenPRs() ([]github.PR, error) {
+	f.listPRsCalls++
+	return f.prs, nil
+}
+func (f *fakeAPI) IsIssueClosed(number int) (bool, error) {
+	f.isClosedCalls++
+	return f.closed[number], nil
+}
+func (f *fakeAPI) IsPRMerged(prNumber int) (bool, error) {
+	f.isMergedCalls++
+	return f.merged[prNumber], nil
+}
+func (f *fakeAPI) GetIssue(number int) (github.Issue, error) {
+	f.getIssueCalls++
+	return f.getIssues[number], nil
+}
+
+func (f *fakeAPI) totalCalls() int {
+	return f.listIssuesCalls + f.listPRsCalls + f.isClosedCalls + f.isMergedCalls + f.getIssueCalls
+}
+
+// newTestSource wires a Source over a real mirror store and a fake API, with a
+// fixed clock so freshness is deterministic.
+func newTestSource(t *testing.T, s *Store, api *fakeAPI, now time.Time, horizon time.Duration, apiDirect func() bool) *Source {
+	t.Helper()
+	resetReadStatsForTest()
+	src := NewSource(nil, s, "o/r", SourceOptions{
+		Horizon:   horizon,
+		APIDirect: apiDirect,
+		Now:       func() time.Time { return now },
+	})
+	src.api = api
+	return src
+}
+
+func seedIssue(t *testing.T, s *Store, number int, title, state, body string, seen time.Time, labels ...string) {
+	t.Helper()
+	if _, err := s.UpsertIssueWithLabels(context.Background(), Issue{
+		Repo: "o/r", Number: number, Title: title, State: state, Body: body,
+		LastSeenAt: seen, Source: SourceWebhook,
+	}, labels); err != nil {
+		t.Fatalf("seed issue %d: %v", number, err)
+	}
+}
+
+func seedPR(t *testing.T, s *Store, number int, title, state string, draft, merged bool, headRef, body string, seen time.Time) {
+	t.Helper()
+	if _, err := s.UpsertPullRequest(context.Background(), PullRequest{
+		Repo: "o/r", Number: number, Title: title, State: state, Draft: draft, Merged: merged,
+		HeadSHA: "sha", HeadRef: headRef, BaseRef: "main", Body: body,
+		LastSeenAt: seen, Source: SourceWebhook,
+	}); err != nil {
+		t.Fatalf("seed pr %d: %v", number, err)
+	}
+}
+
+// TestWarmMirrorZeroAPIReads is AC 6: with a warm mirror, the list + point reads
+// covered by the mirror perform ZERO GitHub API reads.
+func TestWarmMirrorZeroAPIReads(t *testing.T) {
+	s := openTestStore(t)
+	now := mustTime(t, "2026-07-06T12:00:00Z")
+	seedIssue(t, s, 10, "issue ten", "open", "body", now, "maestro-ready")
+	seedIssue(t, s, 11, "issue eleven", "closed", "body", now)
+	seedPR(t, s, 20, "pr twenty", "open", false, false, "feat/x", "pr body", now)
+
+	api := &fakeAPI{}
+	src := newTestSource(t, s, api, now, time.Hour, nil)
+
+	issues, err := src.ListOpenIssues(nil)
+	if err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 10 {
+		t.Fatalf("open issues = %+v, want just #10", issues)
+	}
+	if len(issues[0].Labels) != 1 || issues[0].Labels[0].Name != "maestro-ready" {
+		t.Fatalf("issue #10 labels = %+v", issues[0].Labels)
+	}
+
+	prs, err := src.ListOpenPRs()
+	if err != nil {
+		t.Fatalf("ListOpenPRs: %v", err)
+	}
+	if len(prs) != 1 || prs[0].HeadRefName != "feat/x" || prs[0].Body != "pr body" || prs[0].State != "OPEN" {
+		t.Fatalf("open prs = %+v", prs)
+	}
+
+	closed, err := src.IsIssueClosed(11)
+	if err != nil || !closed {
+		t.Fatalf("IsIssueClosed(11) = %v, %v; want true", closed, err)
+	}
+	merged, err := src.IsPRMerged(20)
+	if err != nil || merged {
+		t.Fatalf("IsPRMerged(20) = %v, %v; want false", merged, err)
+	}
+	got, err := src.GetIssue(10)
+	if err != nil || got.Number != 10 {
+		t.Fatalf("GetIssue(10) = %+v, %v", got, err)
+	}
+
+	if api.totalCalls() != 0 {
+		t.Fatalf("warm mirror hit the API %d time(s); want 0 (%+v)", api.totalCalls(), api)
+	}
+	stats := ReadStatsSnapshot()
+	if stats.APIFallbacks != 0 {
+		t.Fatalf("APIFallbacks = %d; want 0", stats.APIFallbacks)
+	}
+	if stats.MirrorHits != 5 {
+		t.Fatalf("MirrorHits = %d; want 5", stats.MirrorHits)
+	}
+}
+
+// TestColdMirrorFallsBackToAPI is AC 7: an empty mirror degrades to API-direct.
+func TestColdMirrorFallsBackToAPI(t *testing.T) {
+	s := openTestStore(t)
+	now := mustTime(t, "2026-07-06T12:00:00Z")
+	api := &fakeAPI{
+		issues: []github.Issue{{Number: 1, Title: "from api"}},
+		prs:    []github.PR{{Number: 2}},
+	}
+	src := newTestSource(t, s, api, now, time.Hour, nil)
+
+	issues, err := src.ListOpenIssues(nil)
+	if err != nil || len(issues) != 1 || issues[0].Title != "from api" {
+		t.Fatalf("cold ListOpenIssues = %+v, %v", issues, err)
+	}
+	if _, err := src.ListOpenPRs(); err != nil {
+		t.Fatalf("cold ListOpenPRs: %v", err)
+	}
+	if api.listIssuesCalls != 1 || api.listPRsCalls != 1 {
+		t.Fatalf("cold mirror did not fall back: %+v", api)
+	}
+	if got := ReadStatsSnapshot().APIFallbacks; got != 2 {
+		t.Fatalf("APIFallbacks = %d; want 2", got)
+	}
+}
+
+// TestStaleRowFallsBackToAPI: a present-but-stale list triggers a fallback.
+func TestStaleRowFallsBackToAPI(t *testing.T) {
+	s := openTestStore(t)
+	seeded := mustTime(t, "2026-07-01T00:00:00Z")
+	now := mustTime(t, "2026-07-06T12:00:00Z") // > 24h later
+	seedIssue(t, s, 10, "old", "open", "body", seeded)
+
+	api := &fakeAPI{issues: []github.Issue{{Number: 99, Title: "fresh from api"}}}
+	src := newTestSource(t, s, api, now, 24*time.Hour, nil)
+
+	issues, err := src.ListOpenIssues(nil)
+	if err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 99 {
+		t.Fatalf("stale mirror should have fallen back to API: %+v", issues)
+	}
+	if api.listIssuesCalls != 1 {
+		t.Fatalf("expected 1 API fallback, got %d", api.listIssuesCalls)
+	}
+}
+
+// TestGetIssueHydrates covers the hydration path: a miss fetches from the API,
+// stores the row, and the NEXT GetIssue is served locally (zero further API).
+func TestGetIssueHydrates(t *testing.T) {
+	s := openTestStore(t)
+	now := mustTime(t, "2026-07-06T12:00:00Z")
+	api := &fakeAPI{getIssues: map[int]github.Issue{
+		7: {Number: 7, Title: "hydrated", State: "open", Body: "b"},
+	}}
+	src := newTestSource(t, s, api, now, time.Hour, nil)
+
+	got, err := src.GetIssue(7)
+	if err != nil || got.Title != "hydrated" {
+		t.Fatalf("first GetIssue = %+v, %v", got, err)
+	}
+	if api.getIssueCalls != 1 {
+		t.Fatalf("expected 1 hydration fetch, got %d", api.getIssueCalls)
+	}
+	// Row is now local — the next read hits the mirror, no further API.
+	got2, err := src.GetIssue(7)
+	if err != nil || got2.Number != 7 {
+		t.Fatalf("second GetIssue = %+v, %v", got2, err)
+	}
+	if api.getIssueCalls != 1 {
+		t.Fatalf("second GetIssue hit the API; hydration did not persist (%d calls)", api.getIssueCalls)
+	}
+	if got2.State != "open" {
+		t.Fatalf("hydrated issue state = %q, want open", got2.State)
+	}
+}
+
+// TestEscapeHatchForcesAPI is AC 3/8: with the escape hatch engaged, every read
+// goes to the API even when the mirror is warm.
+func TestEscapeHatchForcesAPI(t *testing.T) {
+	s := openTestStore(t)
+	now := mustTime(t, "2026-07-06T12:00:00Z")
+	seedIssue(t, s, 10, "issue", "open", "body", now)
+
+	apiDirect := true
+	api := &fakeAPI{issues: []github.Issue{{Number: 10, Title: "api"}}}
+	src := newTestSource(t, s, api, now, time.Hour, func() bool { return apiDirect })
+
+	if _, err := src.ListOpenIssues(nil); err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	if api.listIssuesCalls != 1 {
+		t.Fatalf("escape hatch did not force API: %d calls", api.listIssuesCalls)
+	}
+	// Flipping the hatch off restores mirror-first with no rebuild (hot-reload).
+	apiDirect = false
+	if _, err := src.ListOpenIssues(nil); err != nil {
+		t.Fatalf("ListOpenIssues after hatch off: %v", err)
+	}
+	if api.listIssuesCalls != 1 {
+		t.Fatalf("hatch-off should serve from mirror, but API was called again: %d", api.listIssuesCalls)
+	}
+	if ReadStatsSnapshot().MirrorHits != 1 {
+		t.Fatalf("MirrorHits = %d; want 1 after hatch off", ReadStatsSnapshot().MirrorHits)
+	}
+}
+
+// TestLabelFilter: ListOpenIssues honors the OR label filter against the mirror.
+func TestLabelFilter(t *testing.T) {
+	s := openTestStore(t)
+	now := mustTime(t, "2026-07-06T12:00:00Z")
+	seedIssue(t, s, 1, "ready", "open", "b", now, "maestro-ready")
+	seedIssue(t, s, 2, "blocked", "open", "b", now, "blocked")
+	seedIssue(t, s, 3, "both", "open", "b", now, "maestro-ready", "extra")
+
+	api := &fakeAPI{}
+	src := newTestSource(t, s, api, now, time.Hour, nil)
+
+	got, err := src.ListOpenIssues([]string{"maestro-ready"})
+	if err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	nums := map[int]bool{}
+	for _, iss := range got {
+		nums[iss.Number] = true
+	}
+	if len(got) != 2 || !nums[1] || !nums[3] {
+		t.Fatalf("label filter returned %+v; want #1 and #3", got)
+	}
+	if api.totalCalls() != 0 {
+		t.Fatalf("label-filtered mirror read hit the API %d time(s)", api.totalCalls())
+	}
+}
+
+// TestNilStoreIsAPIDirect: a Source with no mirror store is fail-safe API-direct.
+func TestNilStoreIsAPIDirect(t *testing.T) {
+	now := mustTime(t, "2026-07-06T12:00:00Z")
+	api := &fakeAPI{issues: []github.Issue{{Number: 1}}}
+	src := NewSource(nil, nil, "o/r", SourceOptions{Now: func() time.Time { return now }})
+	src.api = api
+	resetReadStatsForTest()
+	if _, err := src.ListOpenIssues(nil); err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	if api.listIssuesCalls != 1 {
+		t.Fatalf("nil-store source should be API-direct: %d calls", api.listIssuesCalls)
+	}
+}

--- a/internal/mirrorstore/source_test.go
+++ b/internal/mirrorstore/source_test.go
@@ -347,6 +347,30 @@ func TestLabelFilter(t *testing.T) {
 	}
 }
 
+// TestLabelFilterCaseInsensitive: a requested label matches a mirrored label
+// that differs only in case, mirroring GitHub's own case-insensitive labels=
+// filter, so label-gated work is not silently skipped over a case variant.
+func TestLabelFilterCaseInsensitive(t *testing.T) {
+	s := openTestStore(t)
+	now := mustTime(t, "2026-07-06T12:00:00Z")
+	// Mirrored label is capitalised; caller asks for the lower-case form.
+	seedIssue(t, s, 1, "ready", "open", "b", now, "Maestro-Ready")
+
+	api := &fakeAPI{}
+	src := newTestSource(t, s, api, now, time.Hour, nil)
+
+	got, err := src.ListOpenIssues([]string{"maestro-ready"})
+	if err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	if len(got) != 1 || got[0].Number != 1 {
+		t.Fatalf("case-variant label filter returned %+v; want #1", got)
+	}
+	if api.totalCalls() != 0 {
+		t.Fatalf("case-variant mirror read hit the API %d time(s)", api.totalCalls())
+	}
+}
+
 // TestNilStoreIsAPIDirect: a Source with no mirror store is fail-safe API-direct.
 func TestNilStoreIsAPIDirect(t *testing.T) {
 	now := mustTime(t, "2026-07-06T12:00:00Z")

--- a/internal/mirrorstore/store.go
+++ b/internal/mirrorstore/store.go
@@ -104,7 +104,9 @@ CREATE TABLE IF NOT EXISTS mirror_pull_requests (
 	draft        INTEGER NOT NULL DEFAULT 0,
 	merged       INTEGER NOT NULL DEFAULT 0,
 	head_sha     TEXT    NOT NULL DEFAULT '',
+	head_ref     TEXT    NOT NULL DEFAULT '',
 	base_ref     TEXT    NOT NULL DEFAULT '',
+	body         TEXT    NOT NULL DEFAULT '',
 	last_seen_at TEXT    NOT NULL DEFAULT '',
 	source       TEXT    NOT NULL DEFAULT '',
 	PRIMARY KEY (repo, number)
@@ -223,36 +225,117 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
-// Init creates the schema. Idempotent — safe to call on every daemon start, and
-// safe to run against a maestro.db that already has the other stores' tables.
+// Init creates the schema and applies post-schema column migrations. Idempotent
+// — safe to call on every daemon start, and safe to run against a maestro.db
+// that already has the other stores' tables.
 func (s *Store) Init(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, Schema)
-	return err
+	if _, err := s.db.ExecContext(ctx, Schema); err != nil {
+		return err
+	}
+	return s.migrate(ctx)
+}
+
+// migrate adds columns introduced after the original schema to a pre-existing
+// mirror. CREATE TABLE IF NOT EXISTS never alters an existing table, so a fleet
+// that initialised the mirror before #826 needs mirror_pull_requests.head_ref
+// and .body backfilled — the mirror-first source (source.go) serves ListOpenPRs
+// from these columns, so an un-migrated PR row would report an empty head branch
+// and body and break branch matching / draft-marker detection. Each add is
+// idempotent: it is skipped when the column already exists, so re-running Init
+// on an already-migrated database is a no-op.
+func (s *Store) migrate(ctx context.Context) error {
+	return s.addColumns(ctx, "mirror_pull_requests", []columnDef{
+		{name: "head_ref", decl: "TEXT NOT NULL DEFAULT ''"},
+		{name: "body", decl: "TEXT NOT NULL DEFAULT ''"},
+	})
+}
+
+// columnDef is one column to add during migration.
+type columnDef struct {
+	name string
+	decl string
+}
+
+// addColumns adds each missing column to table. Existing columns are left
+// untouched, so the whole call is idempotent.
+func (s *Store) addColumns(ctx context.Context, table string, cols []columnDef) error {
+	existing, err := s.tableColumns(ctx, table)
+	if err != nil {
+		return err
+	}
+	for _, c := range cols {
+		if existing[c.name] {
+			continue
+		}
+		stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, c.name, c.decl)
+		if _, err := s.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("add column %s.%s: %w", table, c.name, err)
+		}
+	}
+	return nil
+}
+
+// tableColumns returns the set of column names on table via PRAGMA table_info.
+func (s *Store) tableColumns(ctx context.Context, table string) (map[string]bool, error) {
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	cols := map[string]bool{}
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notNull   int
+			dfltValue any
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notNull, &dfltValue, &pk); err != nil {
+			return nil, err
+		}
+		cols[name] = true
+	}
+	return cols, rows.Err()
 }
 
 // ---- Row types -------------------------------------------------------------
 
 // Issue is one mirrored GitHub issue.
 type Issue struct {
-	Repo       string
-	Number     int
-	Title      string
-	State      string
-	Body       string
+	Repo   string
+	Number int
+	Title  string
+	State  string
+	Body   string
+	// Labels is the mirrored label set. It is NOT persisted on the issue row —
+	// labels live in mirror_labels — so it is only populated by reads that join
+	// them in (ListOpenIssues); a bare GetIssue leaves it nil. The mirror-first
+	// source fills it so a reconstructed github.Issue carries the same labels the
+	// REST list would (#826).
+	Labels     []string
 	LastSeenAt time.Time
 	Source     string
 }
 
 // PullRequest is one mirrored GitHub pull request.
 type PullRequest struct {
-	Repo       string
-	Number     int
-	Title      string
-	State      string
-	Draft      bool
-	Merged     bool
-	HeadSHA    string
-	BaseRef    string
+	Repo    string
+	Number  int
+	Title   string
+	State   string
+	Draft   bool
+	Merged  bool
+	HeadSHA string
+	// HeadRef is the head branch name. The mirror-first source needs it to
+	// reconstruct github.PR.HeadRefName for ListOpenPRs — the supervisor and
+	// orchestrator key running sessions to open PRs by head branch (#826).
+	HeadRef string
+	BaseRef string
+	// Body is the PR description, mirrored so a locally-served ListOpenPRs can
+	// reconstruct github.PR.Body (draft-marker detection reads it).
+	Body       string
 	LastSeenAt time.Time
 	Source     string
 }
@@ -348,20 +431,22 @@ func (s *Store) UpsertPullRequest(ctx context.Context, r PullRequest) (applied b
 
 func upsertPullRequest(ctx context.Context, ex execer, r PullRequest) (bool, error) {
 	res, err := ex.ExecContext(ctx, `
-INSERT INTO mirror_pull_requests (repo, number, title, state, draft, merged, head_sha, base_ref, last_seen_at, source)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO mirror_pull_requests (repo, number, title, state, draft, merged, head_sha, head_ref, base_ref, body, last_seen_at, source)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(repo, number) DO UPDATE SET
 	title = excluded.title,
 	state = excluded.state,
 	draft = excluded.draft,
 	merged = excluded.merged,
 	head_sha = excluded.head_sha,
+	head_ref = excluded.head_ref,
 	base_ref = excluded.base_ref,
+	body = excluded.body,
 	last_seen_at = excluded.last_seen_at,
 	source = excluded.source
 WHERE excluded.last_seen_at >= mirror_pull_requests.last_seen_at`,
 		r.Repo, r.Number, r.Title, r.State, boolToInt(r.Draft), boolToInt(r.Merged),
-		r.HeadSHA, r.BaseRef, formatTS(r.LastSeenAt), r.Source)
+		r.HeadSHA, r.HeadRef, r.BaseRef, r.Body, formatTS(r.LastSeenAt), r.Source)
 	return rowsApplied(res, err)
 }
 
@@ -566,9 +651,9 @@ func (s *Store) GetPullRequest(ctx context.Context, repo string, number int) (Pu
 		seen          string
 	)
 	err := s.db.QueryRowContext(ctx, `
-SELECT repo, number, title, state, draft, merged, head_sha, base_ref, last_seen_at, source
+SELECT repo, number, title, state, draft, merged, head_sha, head_ref, base_ref, body, last_seen_at, source
 FROM mirror_pull_requests WHERE repo = ? AND number = ?`, repo, number).
-		Scan(&r.Repo, &r.Number, &r.Title, &r.State, &draft, &merged, &r.HeadSHA, &r.BaseRef, &seen, &r.Source)
+		Scan(&r.Repo, &r.Number, &r.Title, &r.State, &draft, &merged, &r.HeadSHA, &r.HeadRef, &r.BaseRef, &r.Body, &seen, &r.Source)
 	if err == sql.ErrNoRows {
 		return PullRequest{}, false, nil
 	}

--- a/internal/mirrorstore/store.go
+++ b/internal/mirrorstore/store.go
@@ -238,11 +238,15 @@ func (s *Store) Init(ctx context.Context) error {
 // migrate adds columns introduced after the original schema to a pre-existing
 // mirror. CREATE TABLE IF NOT EXISTS never alters an existing table, so a fleet
 // that initialised the mirror before #826 needs mirror_pull_requests.head_ref
-// and .body backfilled — the mirror-first source (source.go) serves ListOpenPRs
-// from these columns, so an un-migrated PR row would report an empty head branch
-// and body and break branch matching / draft-marker detection. Each add is
-// idempotent: it is skipped when the column already exists, so re-running Init
-// on an already-migrated database is a no-op.
+// and .body added — the mirror-first source (source.go) serves ListOpenPRs from
+// these columns. The ALTER only adds the columns with an empty default; it does
+// NOT backfill the head branch of PRs already mirrored before the upgrade (that
+// value is not recoverable from the row). Those rows would report an empty head
+// branch and break branch matching, so Source.ListOpenPRs treats an open PR row
+// with an empty head_ref as untrustworthy and falls back to the API for the list
+// until a webhook repopulates the branch. Each add is idempotent: it is skipped
+// when the column already exists, so re-running Init on an already-migrated
+// database is a no-op.
 func (s *Store) migrate(ctx context.Context) error {
 	return s.addColumns(ctx, "mirror_pull_requests", []columnDef{
 		{name: "head_ref", decl: "TEXT NOT NULL DEFAULT ''"},

--- a/internal/orchestrator/mirror_read_source_test.go
+++ b/internal/orchestrator/mirror_read_source_test.go
@@ -1,0 +1,80 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+// fakeReadSource records which mirror-first read wrappers were routed to it.
+type fakeReadSource struct {
+	listIssues int
+	listPRs    int
+	getIssue   int
+	isClosed   int
+	isMerged   int
+}
+
+func (f *fakeReadSource) ListOpenIssues(labels []string) ([]github.Issue, error) {
+	f.listIssues++
+	return []github.Issue{{Number: 1}}, nil
+}
+func (f *fakeReadSource) ListOpenPRs() ([]github.PR, error) {
+	f.listPRs++
+	return []github.PR{{Number: 2}}, nil
+}
+func (f *fakeReadSource) GetIssue(number int) (github.Issue, error) {
+	f.getIssue++
+	return github.Issue{Number: number}, nil
+}
+func (f *fakeReadSource) IsIssueClosed(number int) (bool, error) {
+	f.isClosed++
+	return true, nil
+}
+func (f *fakeReadSource) IsPRMerged(prNumber int) (bool, error) {
+	f.isMerged++
+	return true, nil
+}
+
+// TestReadSourceRoutesReadWrappers proves SetReadSource routes the high-volume
+// read wrappers through the mirror-first source instead of the direct client
+// (#826). The orchestrator's gh client is left nil: if any wrapper fell through
+// to gh instead of the source, it would panic or error — so a clean pass is the
+// assertion that all five went to the source.
+func TestReadSourceRoutesReadWrappers(t *testing.T) {
+	src := &fakeReadSource{}
+	o := &Orchestrator{}
+	o.SetReadSource(src)
+
+	if _, err := o.listOpenIssues(nil); err != nil {
+		t.Fatalf("listOpenIssues: %v", err)
+	}
+	if _, err := o.listOpenPRs(); err != nil {
+		t.Fatalf("listOpenPRs: %v", err)
+	}
+	if _, err := o.getIssue(9); err != nil {
+		t.Fatalf("getIssue: %v", err)
+	}
+	if _, err := o.isIssueClosed(9); err != nil {
+		t.Fatalf("isIssueClosed: %v", err)
+	}
+	if _, err := o.isPRMerged(2); err != nil {
+		t.Fatalf("isPRMerged: %v", err)
+	}
+
+	if src.listIssues != 1 || src.listPRs != 1 || src.getIssue != 1 || src.isClosed != 1 || src.isMerged != 1 {
+		t.Fatalf("not all read wrappers routed to the source: %+v", src)
+	}
+}
+
+// TestReadSourceUnsetUsesClient confirms that without a read source the wrappers
+// still consult the direct client (nil here → the pre-#826 nil-client errors),
+// so wiring is purely additive.
+func TestReadSourceUnsetUsesClient(t *testing.T) {
+	o := &Orchestrator{}
+	// No SetReadSource, no gh client: isPRMerged reports the historical
+	// "no github client configured" error rather than silently succeeding.
+	if _, err := o.isPRMerged(1); err == nil {
+		t.Fatal("expected nil-client error when neither read source nor gh is set")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -39,9 +39,15 @@ const (
 
 // Orchestrator coordinates all agent sessions
 type Orchestrator struct {
-	cfg                   *config.Config
-	notifier              *notify.Notifier
-	gh                    *github.Client
+	cfg      *config.Config
+	notifier *notify.Notifier
+	gh       *github.Client
+	// readSource is the optional mirror-first read source (#826). When set
+	// (SetReadSource), the high-volume read wrappers consult it instead of the
+	// direct GitHub client — it serves fresh mirror rows locally and falls back
+	// to the API on a miss/stale. Writes and un-mirrored reads always stay on
+	// gh, so GitHub remains authoritative. nil = today's API-direct behavior.
+	readSource            githubReadSource
 	router                *router.Router
 	repo                  string
 	binaryVersion         string
@@ -173,6 +179,25 @@ func New(cfg *config.Config) *Orchestrator {
 	return o
 }
 
+// githubReadSource is the mirror-first read surface the orchestrator's poll-loop
+// wrappers consult when one is wired (#826). *mirrorstore.Source satisfies it.
+// It is a strict subset of *github.Client, so the orchestrator falls straight
+// back to gh for every read it does not list here and for all writes.
+type githubReadSource interface {
+	ListOpenIssues(labels []string) ([]github.Issue, error)
+	ListOpenPRs() ([]github.PR, error)
+	GetIssue(number int) (github.Issue, error)
+	IsIssueClosed(number int) (bool, error)
+	IsPRMerged(prNumber int) (bool, error)
+}
+
+// SetReadSource wires a mirror-first read source (#826). The daemon builds one
+// per flow when github_mirror.source is "mirror-first"; left unset, the
+// orchestrator reads GitHub directly exactly as before.
+func (o *Orchestrator) SetReadSource(src githubReadSource) {
+	o.readSource = src
+}
+
 func (o *Orchestrator) pidAlive(pid int) bool {
 	if o.pidAliveFn != nil {
 		return o.pidAliveFn(pid)
@@ -193,6 +218,9 @@ func (o *Orchestrator) tmuxSessionExists(name string) bool {
 func (o *Orchestrator) listOpenPRs() ([]github.PR, error) {
 	if o.listOpenPRsFn != nil {
 		return o.listOpenPRsFn()
+	}
+	if o.readSource != nil {
+		return o.readSource.ListOpenPRs()
 	}
 	return o.gh.ListOpenPRs()
 }
@@ -339,6 +367,9 @@ func (o *Orchestrator) hasMergedPRForIssue(issueNumber int) (bool, error) {
 func (o *Orchestrator) isPRMerged(prNumber int) (bool, error) {
 	if o.isPRMergedFn != nil {
 		return o.isPRMergedFn(prNumber)
+	}
+	if o.readSource != nil {
+		return o.readSource.IsPRMerged(prNumber)
 	}
 	if o.gh == nil {
 		return false, fmt.Errorf("no github client configured for pr-merged check")
@@ -563,6 +594,9 @@ func (o *Orchestrator) getIssue(number int) (github.Issue, error) {
 	if o.getIssueFn != nil {
 		return o.getIssueFn(number)
 	}
+	if o.readSource != nil {
+		return o.readSource.GetIssue(number)
+	}
 	return o.gh.GetIssue(number)
 }
 
@@ -636,6 +670,9 @@ func (o *Orchestrator) captureTmux(session string) (string, error) {
 func (o *Orchestrator) isIssueClosed(number int) (bool, error) {
 	if o.isIssueClosedFn != nil {
 		return o.isIssueClosedFn(number)
+	}
+	if o.readSource != nil {
+		return o.readSource.IsIssueClosed(number)
 	}
 	if o.gh == nil {
 		return false, fmt.Errorf("no github client configured for issue-closed check")
@@ -2311,6 +2348,13 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 	if !reflect.DeepEqual(newCfg.Supervisor, old.Supervisor) {
 		changed = append(changed, "supervisor policy")
 		o.cfg.Supervisor = newCfg.Supervisor
+	}
+	if newCfg.GitHubMirror != old.GitHubMirror {
+		// #826: the mirror-first read source's escape hatch reads o.cfg.GitHubMirror
+		// each cycle, so applying it here flips this flow between mirror-first and
+		// API-direct on a live config-store edit — no redeploy (AC 3/8).
+		changed = append(changed, fmt.Sprintf("github_mirror.source: %s→%s", old.GitHubMirror.Source, newCfg.GitHubMirror.Source))
+		o.cfg.GitHubMirror = newCfg.GitHubMirror
 	}
 	if newCfg.MergeStrategy != old.MergeStrategy {
 		changed = append(changed, fmt.Sprintf("merge_strategy: %s→%s", old.MergeStrategy, newCfg.MergeStrategy))
@@ -5253,6 +5297,9 @@ func availableSlots(cfg *config.Config, s *state.State, active int) int {
 func (o *Orchestrator) listOpenIssues(labels []string) ([]github.Issue, error) {
 	if o.listOpenIssuesFn != nil {
 		return o.listOpenIssuesFn(labels)
+	}
+	if o.readSource != nil {
+		return o.readSource.ListOpenIssues(labels)
 	}
 	return o.gh.ListOpenIssues(labels)
 }


### PR DESCRIPTION
Implements #826 (epic #811, phase D).

Puts the read-heavy supervisor/orchestrator poll paths behind a mirror-first source: the open-issue/open-PR lists and issue/PR state are served from a warm local mirror (phase C, #825) and fall back to the GitHub API only on a miss, a stale row, a cold mirror, or the escape hatch. GitHub stays authoritative for every write and every merge-gating read.

## Changes
- `mirrorstore.Source` embeds `*github.Client` and overrides `ListOpenIssues`, `ListOpenPRs`, `IsIssueClosed`, `IsPRMerged`, `GetIssue` (hydrating on miss). All writes and merge-gating reads (CI/mergeable/review verdicts) pass straight through — the conservative, no-regression choice.
- Extend `mirror_pull_requests` with `head_ref` + `body` (idempotent `ALTER TABLE` migration) so `ListOpenPRs` reconstructs the head branch and body faithfully; capture them in the webhook projection.
- Mirror list queries (`ListOpenIssues`, `ListOpenPullRequests`) + warmth checks; an empty/stale mirror degrades to today's API-direct correctness.
- Config escape hatch `github_mirror.source` (`api` | `mirror-first`), read per cycle and hot-reloadable — a config-store edit restores API-direct fleet-wide without a redeploy. Default stays `api` until soaked.
- Process-global mirror hit/fallback counters, surfaced in the hourly `[github] REST usage` journal line and the morning digest's `GitHub reads` line (+ `github_usage` JSON).
- Wire the source into the supervisor `Reader` and the orchestrator read wrappers via the daemon flows; runbook + digest-runbook updates.

## Testing
- `go test ./...` (full suite green)
- `go build ./cmd/maestro/`, `gofmt`, `go vet ./...`
- New tests: warm-mirror zero-API reads, cold/stale fallback, hydration path, escape hatch (incl. hot-reload), label filter, PR schema migration + projection, config parsing/defaults, digest usage line, daemon source wiring, orchestrator read-wrapper routing.

Merge-gating reads stay on the authoritative API by design, so a warm-mirror cycle still issues low-frequency CI/mergeable/review reads for PRs under active gating; the dominant per-cycle list + state reads move to the mirror.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a mirror-first read path for GitHub supervisor and orchestrator polling. The main changes are:

- Local mirror reads for open issues, open PRs, and issue or PR state.
- API fallback for cold, stale, missing, or disabled mirror reads.
- PR mirror schema fields for head branch and body.
- Case-insensitive mirror label filtering.
- Mirror read counters in digest and journal output.
- Daemon wiring for hot-reloadable `github_mirror.source` selection.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code, and the follow-up changes cover the stale list rows, migrated PR branch data, and label case handling paths.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the TestTrexMirrorFirstContract contract test and compared base versus head results; the base run failed with undefined mirror-first symbols, while the head run passed and showed warm mirror reads and merge-gating indicators.
- Ran the PR schema projection contraction test for schemas; the base run failed due to missing HeadRef/Body fields, while the head run passed, revealing new columns and actual head\_ref and body values.
- Validated hot-reload config and read-source routing tests; the base run showed no matching config tests and build failures, while the head run passed with defaults, mirror-first, typo fallback, explicit api, stale\_seconds, and related hot-escape hatch behavior.
- Inspected mirror read metrics and journal progression; the base artifact showed no mirror-report data, while the after artifact displayed counters (mirror\_hits and api\_fallbacks), a zero-to-nonzero journal progression, and digest lines reflecting local vs API reads (80% locally, 20% via API).

<a href="https://app.greptile.com/trex/runs/13417422/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/mirrorstore/source.go | Adds the mirror-first source with list warmth checks, per-row freshness checks, API fallback, and PR branch guards. |
| internal/mirrorstore/reads.go | Adds mirror-backed open issue and PR list queries with case-insensitive label matching. |
| internal/mirrorstore/store.go | Adds PR mirror columns for `head_ref` and `body`, plus an idempotent migration for existing stores. |
| internal/mirrorstore/project.go | Updates PR webhook projection to store the head branch and body in the mirror. |
| internal/daemon/mirror_source.go | Builds per-flow mirror-first read sources and exposes mirror read usage for GitHub usage logs. |
| internal/orchestrator/orchestrator.go | Routes selected orchestrator read wrappers through the optional mirror-first source. |

<sub>Reviews (3): Last reviewed commit: ["fix(mirror): match label filter case-ins..."](https://github.com/befeast/maestro/commit/69ad01a903b3f73425a8b6b1aa1671755f75b2d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42105911)</sub>

<!-- /greptile_comment -->