### PR TITLE
Reconciliation loop + mirror observability + 60-min soak (epic #811, phase E)

### DIFF
--- a/docs/github-mirror-read-model-runbook.md
+++ b/docs/github-mirror-read-model-runbook.md
@@ -74,6 +74,12 @@ is configured:
 the horizon — usually a sign deliveries stopped arriving for a repo. The block is
 omitted entirely when the mirror is not configured.
 
+Phase E (#827) adds `drift_repairs`, a per-repo `reconcile` array (last
+run/success time and drift-repair counts), and a `reads` sub-block (mirror
+hits / API fallbacks) to this block — see the [mirror reconciliation &
+health runbook](mirror-reconciliation-runbook.md) for how to read them, force a
+full reconcile, and run the soak.
+
 ## Phase D — reads switch over
 
 Phase D (#826) puts the supervisor/orchestrator read paths behind a mirror-first

--- a/docs/mirror-first-source-runbook.md
+++ b/docs/mirror-first-source-runbook.md
@@ -115,15 +115,25 @@ the source (mirror-first off, or mirror empty).
    `billed against core quota` drops.
 4. To roll back instantly, set `source: api` — no redeploy.
 
+## Reconciliation closes the gap (phase E)
+
+Phase E (#827) adds a low-frequency reconciliation loop that snapshots GitHub and
+repairs mirror drift a missed webhook left behind — including the brand-new-entity
+and missed-close cases the warmth/per-row guards below can only *fall back* on,
+not repair. It runs whenever the mirror is open (even with reads still API-direct),
+so the mirror stays correct and warm. See the
+[mirror reconciliation & health runbook](mirror-reconciliation-runbook.md).
+
 ## Notes / limits
 
-- **List completeness** depends on webhooks. A PR/issue that exists on GitHub but
-  never produced a delivery is not in the mirror; warmth catches a *lagging*
-  mirror (stale newest row), and the per-row guard above catches a *missed close/
-  unlabel delivery* on a row that IS mirrored (it goes stale and forces a
-  fallback) — but neither catches a brand-new entity the mirror has never seen a
-  delivery for. Mitigations: the soak period, the escape hatch, and that maestro
-  itself creates the PRs it gates.
+- **List completeness** depends on webhooks *and* the reconciliation loop. A
+  PR/issue that exists on GitHub but never produced a delivery is not in the mirror
+  until either a webhook or the next reconcile pass records it; warmth catches a
+  *lagging* mirror (stale newest row), and the per-row guard above catches a
+  *missed close/unlabel delivery* on a row that IS mirrored (it goes stale and
+  forces a fallback). The reconciliation loop (#827) repairs all three within one
+  cadence. Additional mitigations: the soak period, the escape hatch, and that
+  maestro itself creates the PRs it gates.
 - **Merge-gating stays on the API** by design (see above), so a warm-mirror cycle
   still issues the low-frequency CI/mergeable/review reads for PRs under active
   gating. The dominant per-cycle list + state reads are what move to the mirror.

--- a/docs/mirror-reconciliation-runbook.md
+++ b/docs/mirror-reconciliation-runbook.md
@@ -1,0 +1,174 @@
+# Mirror Reconciliation & Health Runbook (#827, epic #811 phase E)
+
+Phases B–D landed inbound webhook ingestion (#824), the normalised read-model
+mirror (#825), and the mirror-first read source (#826). Phase E **closes the
+loop**: a low-frequency reconciliation loop detects and repairs mirror drift a
+missed webhook left behind, and the whole pipeline is observable end-to-end.
+
+Webhooks get missed — endpoint downtime, delivery failures, events GitHub does
+not emit. A mirror without reconciliation silently drifts from GitHub truth, and
+mirror-first reads would then act on wrong state. The reconciliation loop is the
+safety net that keeps the mirror honest **without operator action**.
+
+## What the loop does
+
+For each project, on a low cadence, the daemon takes an authoritative snapshot of
+the repo's open issues and open PRs and compares it to the mirror:
+
+- an issue/PR GitHub reports **open** that the mirror is **missing or has recorded
+  differently** (stale title/labels/head-branch) is refreshed;
+- an issue/PR the mirror still records **open** that GitHub **no longer lists** —
+  the missed `closed`/`merged` delivery — is marked closed (a dropped PR's
+  authoritative `merged` flag is fetched so a merge is never fabricated or lost);
+- rows that already match GitHub are **left untouched**, so an up-to-date mirror
+  does no writes and keeps its webhook-sourced `last_seen_at`.
+
+Every row the loop had to correct is counted as a **drift repair**. A nonzero
+repair count is the visible sign a webhook gap was healed.
+
+Repaired rows are written with `source = "reconcile"` (vs `webhook` / `api`), so a
+reader can tell pushed state from state a snapshot had to repair.
+
+### Cheap when nothing changed
+
+The snapshot reads (`ListOpenIssues`, `ListOpenPRs`) flow through the gh wrapper's
+conditional (ETag / `If-None-Match`) layer (#797). A repo whose lists have not
+changed since the last pass answers **304 Not Modified** and consumes **near-zero
+core quota**; the reconciler then writes nothing. The per-PR `IsPRMerged` call is
+made only for a PR that dropped out of the open set (a rare per-drift call, not a
+per-cycle one). The loop also skips a pass while the shared primary rate-limit
+gate is armed (#812), since the reads would only fail against an empty budget.
+
+## Enabling it & cadence
+
+The loop rides the same wiring as the mirror: it runs whenever the daemon has an
+open mirror — i.e. webhook ingestion is configured (`--webhook-secret-file`, see
+the [webhook ingestion runbook](webhook-ingestion-runbook.md)). It runs **even
+with mirror-first reads still off**, keeping the read model correct and warm for
+the moment an operator flips `github_mirror.source: mirror-first`.
+
+Cadence is per project, in config (or the config store):
+
+```yaml
+github_mirror:
+  source: mirror-first     # reconciliation runs regardless; this only gates reads
+  stale_seconds: 86400     # read freshness horizon
+  reconcile_seconds: 900   # reconciliation cadence; 0 = default 15m
+```
+
+The cadence is read **live** from the flow's config holder, so a config-store edit
+to `reconcile_seconds` retimes the loop without a restart.
+
+## Checking mirror health
+
+`GET /api/v1/fleet` carries a `mirror` block with the health picture:
+
+```jsonc
+"mirror": {
+  "enabled": true,
+  "stale_horizon": "24h0m0s",
+  "counts": { "issues": 12, "pull_requests": 4, ... },
+  "stale":  { "issues": 1, ... },
+  "total_rows": 66,
+  "total_stale": 1,
+  "drift_repairs": 3,                       // fleet-wide rows repaired since start
+  "reconcile": [
+    { "repo": "owner/repo", "last_run_at": "...", "last_success_at": "...",
+      "runs": 40, "failures": 0, "repairs": 3, "last_repairs": 0 }
+  ],
+  "reads": { "mirror_hits": 5400, "api_fallbacks": 240, "hit_rate": 0.957 }
+}
+```
+
+Read it as:
+
+- **`total_stale > 0`** — that many rows have not been refreshed within the
+  horizon; usually deliveries stopped arriving for a repo. The reconcile loop
+  should be repairing these — watch `drift_repairs` climb.
+- **`reconcile[].last_success_at`** — when the loop last completed a pass for that
+  repo. If it stops advancing, the loop is failing (see `last_error`) or the flow
+  is down.
+- **`reconcile[].repairs`** — cumulative drift healed for that repo; **`last_repairs`**
+  is the most recent pass. A steady stream of repairs means webhooks are being
+  missed and the loop is compensating; investigate the delivery path.
+- **`reads.api_fallbacks`** — reads that could not be served locally and fell back
+  to the GitHub API (the fallback-to-GitHub count).
+
+The same numbers land in the **journal** (see below), so an operator can check
+health straight from `journalctl` without the HTTP endpoint.
+
+### Journal
+
+The gh wrapper's hourly REST-usage line carries the mirror read + reconcile
+totals:
+
+```
+[github] REST usage last 1h0m: 812 requests, ~120 billed against core quota,
+  692 served free by 304, 0 rate-limited; mirror reads: 5400 served locally,
+  240 fell back to API (96% hit); mirror reconcile: 40 pass(es), 3 drift
+  repair(s), last 2026-07-06T09:14:03Z
+```
+
+Each pass that repairs drift also logs a line at the moment it happens:
+
+```
+[owner/repo] mirror reconcile repaired 2 row(s) (issues=1 prs=1) — drift healed
+  without operator action
+```
+
+The morning digest (`maestro digest`) carries a `Mirror reconcile:` header line
+and a `reconcile` block in its JSON (`repos`, `runs`, `failures`, `drift_repairs`,
+`last_reconcile`).
+
+## Forcing a full reconcile
+
+There is no separate manual-trigger endpoint — reconciliation is a background loop
+by design. To force a fresh pass:
+
+1. **Lower the cadence temporarily.** Set `github_mirror.reconcile_seconds` to a
+   small value (e.g. `60`) via the config store; the loop picks it up live on its
+   next tick and reconciles every minute. Restore the normal value afterwards.
+2. **Restart the flow.** `rm` + re-`add` the project in the config store (the
+   daemon's diff-loop treats it as a fresh flow) — the reconcile loop starts and
+   takes its first pass after one cadence interval.
+
+A pass is idempotent and safe to run as often as you like: it only writes on a
+divergence, and unchanged reads cost 304s.
+
+## Verifying convergence after a webhook outage (AC 1)
+
+1. Note `mirror.drift_repairs` and a target issue/PR's mirror state.
+2. Stop webhook delivery (disable the endpoint / point GitHub elsewhere) for a few
+   minutes and close/relabel the issue on GitHub so the delivery is missed.
+3. Restore delivery. Within one reconcile cadence, `drift_repairs` increments and
+   the mirror row converges to GitHub truth — with **no operator action** beyond
+   restoring the endpoint. The `[repo] mirror reconcile repaired …` journal line
+   records the healed row.
+
+## 60-minute runtime soak (epic #811 acceptance)
+
+Phase E's acceptance includes a **60-minute fleet soak on the runtime host**
+(webhooks live, mirror-first reads on, all projects) with API usage recorded
+before/after and posted to epic #811. That is an **operator task on the runtime
+host**, not something the code change performs. Procedure:
+
+1. Baseline: `gh api rate_limit` and the current `[github] REST usage` hourly line;
+   note requests/hr.
+2. Enable `github_mirror.source: mirror-first` fleet-wide and confirm the mirror is
+   warm (`mirror.total_rows` > 0, `total_stale` low).
+3. Let the fleet run 60 minutes under normal load.
+4. Record the after picture: requests/hr from the hourly line, `reads.hit_rate`,
+   `drift_repairs`. Post before/after to epic #811.
+
+A high `reads.hit_rate` with a low `api_fallbacks`, plus a low steady
+`drift_repairs`, is the phase-E success signal: the mirror carries the read load,
+and the reconciliation loop keeps it correct.
+
+## See also
+
+- [github-mirror-read-model-runbook.md](github-mirror-read-model-runbook.md) —
+  what the mirror stores and its staleness model.
+- [mirror-first-source-runbook.md](mirror-first-source-runbook.md) — which reads
+  are served mirror-first and the escape hatch.
+- [webhook-ingestion-runbook.md](webhook-ingestion-runbook.md) — the delivery path
+  the mirror rides on.

--- a/docs/webhook-ingestion-runbook.md
+++ b/docs/webhook-ingestion-runbook.md
@@ -127,6 +127,11 @@ observability labels, never persistence, so no acknowledged event is dropped.
   `signature_failures` / `duplicates` / `bad_requests` are the current process's
   tally.
 
+- **Missed deliveries self-heal.** A dropped or never-emitted delivery leaves the
+  mirror stale until the phase-E reconciliation loop repairs it — `last_delivery_at`
+  going quiet alongside a rising `mirror.drift_repairs` is that safety net working.
+  See the [mirror reconciliation & health runbook](mirror-reconciliation-runbook.md).
+
 ## Inspecting the store
 
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -362,7 +362,20 @@ const (
 type GitHubMirrorConfig struct {
 	Source       string `yaml:"source"`        // "" (=api) | "api" | "mirror-first"
 	StaleSeconds int    `yaml:"stale_seconds"` // freshness horizon override in seconds; 0 = default (24h)
+	// ReconcileSeconds is the cadence of the low-frequency reconciliation loop
+	// (#827, phase E) that snapshots GitHub and repairs mirror drift a missed
+	// webhook left behind. 0 = default (DefaultMirrorReconcileInterval). The loop
+	// only runs when the mirror is open (webhook ingestion configured); a caught-up
+	// mirror costs near-zero quota per pass because the snapshot reads answer 304.
+	ReconcileSeconds int `yaml:"reconcile_seconds"`
 }
+
+// DefaultMirrorReconcileInterval is the reconciliation cadence used when
+// github_mirror.reconcile_seconds is unset. Low by design: reconciliation is a
+// safety net over webhook ingestion, not the primary refresh path, and each pass
+// is cheap on an unchanged repo (conditional 304 reads), so a 15-minute sweep
+// keeps drift bounded without adding meaningful API load.
+const DefaultMirrorReconcileInterval = 15 * time.Minute
 
 // MirrorFirst reports whether reads should be served mirror-first. Any value
 // other than "mirror-first" (including the empty default and typos) is API — the
@@ -380,6 +393,15 @@ func (c GitHubMirrorConfig) StaleHorizon() time.Duration {
 		return 24 * time.Hour
 	}
 	return time.Duration(c.StaleSeconds) * time.Second
+}
+
+// ReconcileInterval is the cadence of the mirror reconciliation loop (#827). A
+// non-positive reconcile_seconds falls back to DefaultMirrorReconcileInterval.
+func (c GitHubMirrorConfig) ReconcileInterval() time.Duration {
+	if c.ReconcileSeconds <= 0 {
+		return DefaultMirrorReconcileInterval
+	}
+	return time.Duration(c.ReconcileSeconds) * time.Second
 }
 
 // SelfDeployConfig gates the opt-in post-merge self-deploy of the maestro

--- a/internal/config/github_mirror_test.go
+++ b/internal/config/github_mirror_test.go
@@ -19,6 +19,9 @@ func TestParse_GitHubMirror_DefaultIsAPIDirect(t *testing.T) {
 	if got := cfg.GitHubMirror.StaleHorizon(); got != 24*time.Hour {
 		t.Fatalf("default StaleHorizon = %s, want 24h", got)
 	}
+	if got := cfg.GitHubMirror.ReconcileInterval(); got != DefaultMirrorReconcileInterval {
+		t.Fatalf("default ReconcileInterval = %s, want %s", got, DefaultMirrorReconcileInterval)
+	}
 }
 
 func TestParse_GitHubMirror_MirrorFirst(t *testing.T) {
@@ -27,6 +30,7 @@ repo: owner/repo
 github_mirror:
   source: mirror-first
   stale_seconds: 300
+  reconcile_seconds: 600
 `
 	cfg, err := parse([]byte(yaml))
 	if err != nil {
@@ -37,6 +41,9 @@ github_mirror:
 	}
 	if got := cfg.GitHubMirror.StaleHorizon(); got != 5*time.Minute {
 		t.Fatalf("StaleHorizon = %s, want 5m", got)
+	}
+	if got := cfg.GitHubMirror.ReconcileInterval(); got != 10*time.Minute {
+		t.Fatalf("ReconcileInterval = %s, want 10m", got)
 	}
 }
 

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -127,6 +127,20 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 			d.watchdogLoop(fctx, flow.name, cfg.StateDir, d.opts.SuperviseInterval)
 		}()
 	}
+	// Mirror reconciliation loop (#827, phase E): a low-frequency GitHub snapshot
+	// that repairs mirror drift a missed webhook left behind, keeping the read
+	// model correct without operator action. Only started when the daemon has an
+	// open mirror (webhook ingestion configured) — without inbound deliveries there
+	// is nothing to reconcile. Tracked in the flow WaitGroup so stopFlow drains it,
+	// and reads its cadence live from the holder (a config-store edit retimes it).
+	if d.mirror != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer recoverFlow(flow, "mirror-reconcile")
+			d.runMirrorReconcile(fctx, flow.name, cfg.Repo, flow.holder.Load)
+		}()
+	}
 	go func() {
 		wg.Wait()
 		close(flow.done)

--- a/internal/daemon/mirror_source.go
+++ b/internal/daemon/mirror_source.go
@@ -1,7 +1,11 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
+	"log"
+	"strings"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
@@ -35,17 +39,84 @@ func (d *Daemon) newReadSource(repo string, getCfg func() *config.Config) *mirro
 	})
 }
 
+// runMirrorReconcile is the per-flow reconciliation loop (#827, epic #811 phase
+// E): a low-frequency snapshot of the repo's authoritative GitHub open-issue /
+// open-PR sets that repairs mirror drift a missed webhook left behind. It is a
+// SAFETY NET over webhook ingestion, so it runs whenever the daemon has an open
+// mirror — even with mirror-first reads still off — keeping the read model correct
+// and warm for the moment an operator flips the escape hatch.
+//
+// The cadence is read live from getCfg (the flow's config holder, swapped by the
+// reload pump), so a config-store edit to github_mirror.reconcile_seconds retimes
+// the loop without a restart. Each pass is cheap on an unchanged repo: the snapshot
+// reads flow through the gh wrapper's conditional (ETag) layer and answer 304, and
+// the reconciler writes only when it detects a divergence (#827 AC 2).
+//
+// The loop skips a pass while the shared primary rate-limit gate is armed — the
+// snapshot reads would only fail against an empty core budget, and a skipped pass
+// is harmless because the next one converges (#812).
+func (d *Daemon) runMirrorReconcile(ctx context.Context, name, repo string, getCfg func() *config.Config) {
+	if d.mirror == nil {
+		return
+	}
+	rec := mirrorstore.NewReconciler(d.mirror, github.New(repo), repo)
+	interval := reconcileInterval(getCfg)
+	log.Printf("[%s] mirror reconcile loop started — repo=%s cadence=%s", name, repo, interval)
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		if paused, _ := github.PrimaryRateLimitPaused(); paused {
+			timer.Reset(reconcileInterval(getCfg))
+			continue
+		}
+		res, err := rec.Reconcile(ctx)
+		if err != nil {
+			log.Printf("[%s] mirror reconcile failed: %v", name, err)
+		} else if res.Repaired() > 0 {
+			log.Printf("[%s] mirror reconcile repaired %d row(s) (issues=%d prs=%d) — drift healed without operator action",
+				name, res.Repaired(), res.IssuesRepaired, res.PRsRepaired)
+		}
+		timer.Reset(reconcileInterval(getCfg))
+	}
+}
+
+// reconcileInterval reads the flow's current reconciliation cadence, falling back
+// to the package default when the config is momentarily unavailable.
+func reconcileInterval(getCfg func() *config.Config) time.Duration {
+	if cfg := getCfg(); cfg != nil {
+		return cfg.GitHubMirror.ReconcileInterval()
+	}
+	return config.DefaultMirrorReconcileInterval
+}
+
 // mirrorReadDigestLine is the fragment SetMirrorReadDigest appends to the gh
 // wrapper's hourly REST-usage journal line so an operator reading journalctl
 // sees, alongside API consumption, how many supervisor/orchestrator reads the
-// mirror served versus how many fell back to the API (#826 AC 5). Empty until
-// the mirror has served or turned away a read, so the pre-#826 line is unchanged
-// on a fleet that has not enabled mirror-first.
+// mirror served versus how many fell back to the API (#826 AC 5), plus the
+// reconciliation loop's pass and drift-repair totals (#827). Empty until the
+// mirror has served/turned away a read or run a reconcile pass, so the pre-#826
+// line is unchanged on a fleet that has enabled neither.
 func mirrorReadDigestLine() string {
-	st := mirrorstore.ReadStatsSnapshot()
-	if st.Total() == 0 {
+	var parts []string
+	if st := mirrorstore.ReadStatsSnapshot(); st.Total() > 0 {
+		parts = append(parts, fmt.Sprintf("mirror reads: %d served locally, %d fell back to API (%.0f%% hit)",
+			st.MirrorHits, st.APIFallbacks, st.HitRate()*100))
+	}
+	if rt := mirrorstore.ReconcileTotalsSnapshot(); rt.Runs > 0 {
+		last := "never"
+		if !rt.LastSuccessAt.IsZero() {
+			last = rt.LastSuccessAt.UTC().Format(time.RFC3339)
+		}
+		parts = append(parts, fmt.Sprintf("mirror reconcile: %d pass(es), %d drift repair(s), last %s",
+			rt.Runs, rt.Repairs, last))
+	}
+	if len(parts) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("; mirror reads: %d served locally, %d fell back to API (%.0f%% hit)",
-		st.MirrorHits, st.APIFallbacks, st.HitRate()*100)
+	return "; " + strings.Join(parts, "; ")
 }

--- a/internal/daemon/mirror_source_test.go
+++ b/internal/daemon/mirror_source_test.go
@@ -63,3 +63,32 @@ func TestNewReadSourceServesWarmMirror(t *testing.T) {
 		t.Fatalf("digest line missing local-serve count: %q", line)
 	}
 }
+
+// TestReconcileIntervalReadsConfig: the reconcile cadence comes from the flow's
+// live config, defaulting when it is momentarily unavailable (#827).
+func TestReconcileIntervalReadsConfig(t *testing.T) {
+	if got := reconcileInterval(func() *config.Config { return nil }); got != config.DefaultMirrorReconcileInterval {
+		t.Fatalf("nil config cadence = %s, want default %s", got, config.DefaultMirrorReconcileInterval)
+	}
+	cfg := &config.Config{GitHubMirror: config.GitHubMirrorConfig{ReconcileSeconds: 120}}
+	if got := reconcileInterval(func() *config.Config { return cfg }); got != 2*time.Minute {
+		t.Fatalf("configured cadence = %s, want 2m", got)
+	}
+}
+
+// TestRunMirrorReconcileNoopWithoutMirror: the loop returns immediately when the
+// daemon has no open mirror, so a flow without webhook ingestion spawns no
+// reconcile work.
+func TestRunMirrorReconcileNoopWithoutMirror(t *testing.T) {
+	d := &Daemon{}
+	done := make(chan struct{})
+	go func() {
+		d.runMirrorReconcile(context.Background(), "flow", "o/r", func() *config.Config { return nil })
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runMirrorReconcile should return immediately without a mirror")
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -213,12 +213,40 @@ func (u GitHubUsage) Line() string {
 		base, u.MirrorHits, u.APIFallbacks, pct)
 }
 
+// ReconcileSummary is the fleet-wide rollup of the mirror reconciliation loop
+// (#827, phase E): how many repos the loop covers, how many passes ran, how many
+// failed, the cumulative drift-repair count, and the most recent successful
+// reconcile across repos. Surfacing drift repairs and the last-reconcile time in
+// the digest is one of phase E's observability requirements — a nonzero repair
+// count is the visible sign a missed webhook was healed without operator action.
+type ReconcileSummary struct {
+	Repos         int       `json:"repos"`
+	Runs          int64     `json:"runs"`
+	Failures      int64     `json:"failures"`
+	DriftRepairs  int64     `json:"drift_repairs"`
+	LastReconcile time.Time `json:"last_reconcile,omitempty"`
+}
+
+// Line renders the reconcile rollup as a single human line for the digest header.
+func (r ReconcileSummary) Line() string {
+	if r.Repos == 0 && r.Runs == 0 {
+		return "reconciliation loop not enabled"
+	}
+	last := "never"
+	if !r.LastReconcile.IsZero() {
+		last = r.LastReconcile.UTC().Format("2006-01-02 15:04 MST")
+	}
+	return fmt.Sprintf("%d repo(s), %d pass(es), %d failure(s), %d drift repair(s) · last reconcile %s",
+		r.Repos, r.Runs, r.Failures, r.DriftRepairs, last)
+}
+
 // Report is the full fleet digest.
 type Report struct {
-	GeneratedAt time.Time       `json:"generated_at"`
-	Auth        AuthSummary     `json:"auth"`
-	GitHub      GitHubUsage     `json:"github_usage"`
-	Projects    []ProjectReport `json:"projects"`
+	GeneratedAt time.Time        `json:"generated_at"`
+	Auth        AuthSummary      `json:"auth"`
+	GitHub      GitHubUsage      `json:"github_usage"`
+	Reconcile   ReconcileSummary `json:"reconcile"`
+	Projects    []ProjectReport  `json:"projects"`
 }
 
 // DecideTodayCount is the number of action items that need an operator
@@ -243,11 +271,26 @@ func (r *Report) PromotableCount() int {
 // Collect builds the fleet digest across all projects.
 func Collect(projects []Project, opts Options) *Report {
 	opts = opts.withDefaults()
-	rep := &Report{GeneratedAt: opts.Now, Auth: authSummary(), GitHub: githubUsage()}
+	rep := &Report{GeneratedAt: opts.Now, Auth: authSummary(), GitHub: githubUsage(), Reconcile: reconcileSummary()}
 	for _, p := range projects {
 		rep.Projects = append(rep.Projects, CollectProject(p, opts))
 	}
 	return rep
+}
+
+// reconcileSummary snapshots the process-wide mirror reconciliation counters
+// (#827) into the serializable digest field. In the long-running daemon these
+// accumulate the fleet's real reconcile activity; in the one-shot `maestro digest`
+// process no loop has run, so the summary reports "not enabled".
+func reconcileSummary() ReconcileSummary {
+	t := mirrorstore.ReconcileTotalsSnapshot()
+	return ReconcileSummary{
+		Repos:         t.Repos,
+		Runs:          t.Runs,
+		Failures:      t.Failures,
+		DriftRepairs:  t.Repairs,
+		LastReconcile: t.LastSuccessAt,
+	}
 }
 
 // githubUsage snapshots the process-wide GitHub read counters (#826): the gh

--- a/internal/digest/github_usage_test.go
+++ b/internal/digest/github_usage_test.go
@@ -37,3 +37,28 @@ func TestReportMarkdownIncludesGitHubReads(t *testing.T) {
 		t.Fatalf("markdown missing GitHub reads line:\n%s", md)
 	}
 }
+
+func TestReconcileSummaryLine(t *testing.T) {
+	if got := (ReconcileSummary{}).Line(); !strings.Contains(got, "not enabled") {
+		t.Fatalf("empty reconcile summary should say not enabled: %q", got)
+	}
+	s := ReconcileSummary{Repos: 2, Runs: 8, Failures: 1, DriftRepairs: 3}
+	got := s.Line()
+	if !strings.Contains(got, "3 drift repair(s)") {
+		t.Fatalf("line missing drift repairs: %q", got)
+	}
+	if !strings.Contains(got, "2 repo(s)") {
+		t.Fatalf("line missing repo count: %q", got)
+	}
+}
+
+func TestReportMarkdownIncludesReconcile(t *testing.T) {
+	r := &Report{Reconcile: ReconcileSummary{Repos: 1, Runs: 1, DriftRepairs: 2}}
+	md := r.Markdown()
+	if !strings.Contains(md, "Mirror reconcile:") {
+		t.Fatalf("markdown missing reconcile line:\n%s", md)
+	}
+	if !strings.Contains(md, "2 drift repair(s)") {
+		t.Fatalf("markdown missing drift-repair count:\n%s", md)
+	}
+}

--- a/internal/digest/markdown.go
+++ b/internal/digest/markdown.go
@@ -15,6 +15,7 @@ func (r *Report) Markdown() string {
 		r.GeneratedAt.Format("2006-01-02 15:04 MST"), len(r.Projects), r.DecideTodayCount(), r.PromotableCount())
 	fmt.Fprintf(&b, "GitHub auth: %s\n\n", r.Auth.Line())
 	fmt.Fprintf(&b, "GitHub reads: %s\n\n", r.GitHub.Line())
+	fmt.Fprintf(&b, "Mirror reconcile: %s\n\n", r.Reconcile.Line())
 
 	fmt.Fprintf(&b, "## 1. Decide today (%d)\n\n", r.DecideTodayCount())
 	if r.DecideTodayCount() == 0 {

--- a/internal/mirrorstore/reconcile.go
+++ b/internal/mirrorstore/reconcile.go
@@ -1,0 +1,473 @@
+package mirrorstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+// SourceReconcile marks a mirror row last written by the reconciliation loop's
+// authoritative GitHub snapshot (#827, epic #811 phase E), distinct from a pushed
+// webhook delivery (SourceWebhook) or an on-demand hydration on a read miss
+// (SourceAPI). A reader can tell state that arrived by push from drift a full
+// snapshot had to repair — the latter is the signal that a delivery was missed.
+const SourceReconcile = "reconcile"
+
+// ReconcileReader is the slice of *github.Client the reconciler needs to take an
+// authoritative snapshot of a repo's open issues and pull requests. *github.Client
+// satisfies it; tests supply a fake so the drift logic is exercised without a real
+// gh binary.
+//
+// Every read flows through the package's conditional (ETag / If-None-Match)
+// request layer (internal/github, #797): a repo whose open-issue / open-PR lists
+// have not changed since the last pass answers 304 Not Modified and the whole
+// reconcile costs near-zero core quota — the "cheap when nothing changed"
+// property (#827 AC 2). IsPRMerged is consulted only for a PR that has dropped out
+// of the open set, so it is a rare per-drift call, not a per-cycle one.
+type ReconcileReader interface {
+	ListOpenIssues(labels []string) ([]github.Issue, error)
+	ListOpenPRs() ([]github.PR, error)
+	IsPRMerged(prNumber int) (bool, error)
+}
+
+// Reconciler compares the authoritative GitHub open-issue / open-PR sets for one
+// repo against the local mirror and repairs any drift: an entity GitHub reports as
+// open that the mirror is missing or has recorded differently is refreshed, and an
+// entity the mirror still records as open that GitHub no longer lists is marked
+// closed (its close/merge delivery was missed). The number of rows actually
+// repaired is counted, so a webhook outage that the loop healed is visible in
+// diagnostics without operator action (#827 AC 1).
+//
+// The loop is a SAFETY NET over webhook ingestion, not a replacement for it: it
+// runs at a low cadence (config: github_mirror.reconcile_seconds) and only writes
+// when it detects a divergence, so a fully-caught-up mirror does no mirror writes
+// and — thanks to the ETag layer — issues no billed API calls.
+type Reconciler struct {
+	store *Store
+	api   ReconcileReader
+	repo  string
+	now   func() time.Time
+}
+
+// NewReconciler builds a reconciler over store for repo, taking its authoritative
+// GitHub snapshot through api. repo is the "owner/name" the mirror rows are keyed
+// on.
+func NewReconciler(store *Store, api ReconcileReader, repo string) *Reconciler {
+	return &Reconciler{
+		store: store,
+		api:   api,
+		repo:  strings.TrimSpace(repo),
+		now:   func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// ReconcileResult reports what one reconcile pass observed and repaired.
+type ReconcileResult struct {
+	Repo           string    `json:"repo"`
+	At             time.Time `json:"at"`
+	IssuesChecked  int       `json:"issues_checked"`
+	PRsChecked     int       `json:"prs_checked"`
+	IssuesRepaired int       `json:"issues_repaired"`
+	PRsRepaired    int       `json:"prs_repaired"`
+}
+
+// Repaired is the total number of mirror rows this pass had to correct — the
+// drift the loop healed.
+func (r ReconcileResult) Repaired() int { return r.IssuesRepaired + r.PRsRepaired }
+
+// Reconcile runs one full pass and records it in the process-global reconcile
+// stats (ReconcileStatsSnapshot). The pass is snapshot-consistent to a single
+// instant captured before the GitHub reads: repaired rows are stamped with that
+// instant so a genuinely-newer webhook that arrives concurrently (its resource
+// updated_at is later) still wins the ordering guard and is not clobbered by the
+// snapshot.
+func (r *Reconciler) Reconcile(ctx context.Context) (ReconcileResult, error) {
+	snap := r.now()
+	res := ReconcileResult{Repo: r.repo, At: snap}
+	if r.store == nil || r.api == nil {
+		err := errors.New("mirror reconciler not fully configured (nil store or client)")
+		noteReconcile(res, err)
+		return res, err
+	}
+
+	// ---- Issues -------------------------------------------------------------
+	ghIssues, err := r.api.ListOpenIssues(nil)
+	if err != nil {
+		err = fmt.Errorf("reconcile %s: list open issues: %w", r.repo, err)
+		noteReconcile(res, err)
+		return res, err
+	}
+	res.IssuesChecked = len(ghIssues)
+	ghOpenIssue := make(map[int]bool, len(ghIssues))
+	for _, iss := range ghIssues {
+		ghOpenIssue[iss.Number] = true
+		repaired, err := r.reconcileOpenIssue(ctx, iss, snap)
+		if err != nil {
+			err = fmt.Errorf("reconcile %s: issue #%d: %w", r.repo, iss.Number, err)
+			noteReconcile(res, err)
+			return res, err
+		}
+		if repaired {
+			res.IssuesRepaired++
+		}
+	}
+	closedIssues, err := r.closeMissedIssues(ctx, ghOpenIssue, snap)
+	if err != nil {
+		err = fmt.Errorf("reconcile %s: close missed issues: %w", r.repo, err)
+		noteReconcile(res, err)
+		return res, err
+	}
+	res.IssuesRepaired += closedIssues
+
+	// ---- Pull requests ------------------------------------------------------
+	ghPRs, err := r.api.ListOpenPRs()
+	if err != nil {
+		err = fmt.Errorf("reconcile %s: list open PRs: %w", r.repo, err)
+		noteReconcile(res, err)
+		return res, err
+	}
+	res.PRsChecked = len(ghPRs)
+	ghOpenPR := make(map[int]bool, len(ghPRs))
+	for _, pr := range ghPRs {
+		ghOpenPR[pr.Number] = true
+		repaired, err := r.reconcileOpenPR(ctx, pr, snap)
+		if err != nil {
+			err = fmt.Errorf("reconcile %s: PR #%d: %w", r.repo, pr.Number, err)
+			noteReconcile(res, err)
+			return res, err
+		}
+		if repaired {
+			res.PRsRepaired++
+		}
+	}
+	closedPRs, err := r.closeMissedPRs(ctx, ghOpenPR, snap)
+	if err != nil {
+		err = fmt.Errorf("reconcile %s: close missed PRs: %w", r.repo, err)
+		noteReconcile(res, err)
+		return res, err
+	}
+	res.PRsRepaired += closedPRs
+
+	noteReconcile(res, nil)
+	return res, nil
+}
+
+// reconcileOpenIssue refreshes the mirror for one GitHub-open issue when the
+// mirror is missing it or has recorded it differently. It writes nothing — and
+// returns repaired=false — when the mirror row already matches GitHub, so an
+// up-to-date mirror does no work and keeps its webhook-sourced last_seen_at (a
+// needless reconcile write would mask staleness). repaired=true means the guarded
+// upsert actually applied.
+func (r *Reconciler) reconcileOpenIssue(ctx context.Context, gh github.Issue, snap time.Time) (bool, error) {
+	row, ok, err := r.store.GetIssue(ctx, r.repo, gh.Number)
+	if err != nil {
+		return false, err
+	}
+	want := sortedIssueLabels(gh)
+	if ok {
+		have, err := r.store.Labels(ctx, r.repo, SubjectIssue, gh.Number)
+		if err != nil {
+			return false, err
+		}
+		if issueRowMatches(row, gh, have) {
+			return false, nil
+		}
+	}
+	return r.store.UpsertIssueWithLabels(ctx, Issue{
+		Repo:       r.repo,
+		Number:     gh.Number,
+		Title:      gh.Title,
+		State:      normalizeState(gh.State, "open"),
+		Body:       gh.Body,
+		LastSeenAt: snap,
+		Source:     SourceReconcile,
+	}, want)
+}
+
+// closeMissedIssues marks closed every mirror issue still recorded as open that
+// GitHub's authoritative open set no longer contains — the missed-close-delivery
+// case. GitHub was asked for state=open, so absence is unambiguous: the issue is
+// no longer open. Returns the number of rows the guarded upsert actually closed.
+func (r *Reconciler) closeMissedIssues(ctx context.Context, ghOpen map[int]bool, snap time.Time) (int, error) {
+	mirrorOpen, err := r.store.ListOpenIssues(ctx, r.repo, nil)
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, m := range mirrorOpen {
+		if ghOpen[m.Number] {
+			continue
+		}
+		applied, err := r.store.UpsertIssue(ctx, Issue{
+			Repo:       r.repo,
+			Number:     m.Number,
+			Title:      m.Title,
+			State:      "closed",
+			Body:       m.Body,
+			LastSeenAt: snap,
+			Source:     SourceReconcile,
+		})
+		if err != nil {
+			return n, err
+		}
+		if applied {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// reconcileOpenPR refreshes the mirror for one GitHub-open PR. As with issues it
+// writes only on a divergence. It preserves head_sha and base_ref from the
+// existing row — the open-PR list read does not carry them — so a reconcile that
+// repairs the title/head-branch does not blank a SHA a webhook recorded. This is
+// also where a PR mirrored before the head_ref column existed (empty head_ref,
+// possibly still "fresh") gets its branch backfilled, since the empty branch no
+// longer matches GitHub's headRefName.
+func (r *Reconciler) reconcileOpenPR(ctx context.Context, gh github.PR, snap time.Time) (bool, error) {
+	row, ok, err := r.store.GetPullRequest(ctx, r.repo, gh.Number)
+	if err != nil {
+		return false, err
+	}
+	if ok && prRowMatchesOpen(row, gh) {
+		return false, nil
+	}
+	headSHA, baseRef := "", ""
+	if ok {
+		headSHA, baseRef = row.HeadSHA, row.BaseRef
+	}
+	return r.store.UpsertPullRequest(ctx, PullRequest{
+		Repo:       r.repo,
+		Number:     gh.Number,
+		Title:      gh.Title,
+		State:      "open",
+		Draft:      gh.IsDraft,
+		Merged:     false,
+		HeadSHA:    headSHA,
+		HeadRef:    strings.TrimSpace(gh.HeadRefName),
+		BaseRef:    baseRef,
+		Body:       gh.Body,
+		LastSeenAt: snap,
+		Source:     SourceReconcile,
+	})
+}
+
+// closeMissedPRs marks closed every mirror PR still recorded as open that GitHub
+// no longer lists as open. Because IsPRMerged is a mirror-served read (a lagging
+// "not merged" only re-polls, but a fabricated "not merged" for a merged PR would
+// be a merge-detection regression), the authoritative merged flag is fetched for
+// each dropped PR and stored alongside state=closed. A PR whose merged state
+// cannot be determined this pass is left for the next one rather than closed with
+// a guessed flag.
+func (r *Reconciler) closeMissedPRs(ctx context.Context, ghOpen map[int]bool, snap time.Time) (int, error) {
+	mirrorOpen, err := r.store.ListOpenPullRequests(ctx, r.repo)
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, m := range mirrorOpen {
+		if ghOpen[m.Number] {
+			continue
+		}
+		merged, err := r.api.IsPRMerged(m.Number)
+		if err != nil {
+			// Cannot settle merged vs plain-closed right now; skip so the mirror
+			// keeps its last known (open) state and the next pass retries, rather
+			// than recording a guessed merged flag.
+			continue
+		}
+		applied, err := r.store.UpsertPullRequest(ctx, PullRequest{
+			Repo:       r.repo,
+			Number:     m.Number,
+			Title:      m.Title,
+			State:      "closed",
+			Draft:      m.Draft,
+			Merged:     merged,
+			HeadSHA:    m.HeadSHA,
+			HeadRef:    m.HeadRef,
+			BaseRef:    m.BaseRef,
+			Body:       m.Body,
+			LastSeenAt: snap,
+			Source:     SourceReconcile,
+		})
+		if err != nil {
+			return n, err
+		}
+		if applied {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// ---- comparison helpers ----------------------------------------------------
+
+// issueRowMatches reports whether the mirror issue row (with its label set) is
+// already in sync with GitHub's open snapshot, so reconcile can skip the write.
+func issueRowMatches(row Issue, gh github.Issue, haveLabels []string) bool {
+	if !strings.EqualFold(strings.TrimSpace(row.State), normalizeState(gh.State, "open")) {
+		return false
+	}
+	if row.Title != gh.Title || row.Body != gh.Body {
+		return false
+	}
+	return sameStrings(sortedStrings(haveLabels), sortedIssueLabels(gh))
+}
+
+// prRowMatchesOpen reports whether the mirror PR row already matches GitHub's
+// open snapshot. head_sha and base_ref are not compared: the open-PR list read
+// does not carry them, so they are preserved, not validated, here.
+func prRowMatchesOpen(row PullRequest, gh github.PR) bool {
+	return strings.EqualFold(strings.TrimSpace(row.State), "open") &&
+		!row.Merged &&
+		row.Title == gh.Title &&
+		row.Body == gh.Body &&
+		row.Draft == gh.IsDraft &&
+		strings.TrimSpace(row.HeadRef) == strings.TrimSpace(gh.HeadRefName)
+}
+
+// normalizeState lower-cases GitHub's state, falling back to fallback when empty
+// so the two write paths (webhook projection, reconcile) store the same value.
+func normalizeState(state, fallback string) string {
+	s := strings.ToLower(strings.TrimSpace(state))
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+func sortedIssueLabels(gh github.Issue) []string {
+	out := make([]string, 0, len(gh.Labels))
+	for _, l := range gh.Labels {
+		if n := strings.TrimSpace(l.Name); n != "" {
+			out = append(out, n)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedStrings(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ---- process-global reconcile metrics --------------------------------------
+//
+// Counted process-wide, like the mirror-first read counters (ReadStats) and the
+// gh wrapper's APIUsage, so the fleet diagnostics block and the journal digest can
+// read them without threading a Reconciler handle through the daemon. Keyed by
+// repo so "last successful reconcile per project" and the per-project drift-repair
+// count are both surfaced (#827 observability).
+
+// ReconcileStat is the observability snapshot for one repo's reconcile loop.
+type ReconcileStat struct {
+	Repo          string    `json:"repo"`
+	LastRunAt     time.Time `json:"last_run_at"`
+	LastSuccessAt time.Time `json:"last_success_at"`
+	Runs          int64     `json:"runs"`
+	Failures      int64     `json:"failures"`
+	Repairs       int64     `json:"repairs"`      // cumulative rows repaired across all passes
+	LastRepairs   int       `json:"last_repairs"` // rows repaired in the last successful pass
+	LastError     string    `json:"last_error,omitempty"`
+}
+
+var (
+	reconcileMu    sync.Mutex
+	reconcileStats = map[string]*ReconcileStat{}
+)
+
+// noteReconcile records one reconcile pass (success or failure) into the
+// process-global registry.
+func noteReconcile(res ReconcileResult, err error) {
+	reconcileMu.Lock()
+	defer reconcileMu.Unlock()
+	st := reconcileStats[res.Repo]
+	if st == nil {
+		st = &ReconcileStat{Repo: res.Repo}
+		reconcileStats[res.Repo] = st
+	}
+	st.Runs++
+	st.LastRunAt = res.At
+	if err != nil {
+		st.Failures++
+		st.LastError = err.Error()
+		return
+	}
+	st.LastError = ""
+	st.LastSuccessAt = res.At
+	st.LastRepairs = res.Repaired()
+	st.Repairs += int64(res.Repaired())
+}
+
+// ReconcileStatsSnapshot returns the per-repo reconcile counters, sorted by repo
+// for a stable diagnostics render.
+func ReconcileStatsSnapshot() []ReconcileStat {
+	reconcileMu.Lock()
+	defer reconcileMu.Unlock()
+	out := make([]ReconcileStat, 0, len(reconcileStats))
+	for _, st := range reconcileStats {
+		out = append(out, *st)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Repo < out[j].Repo })
+	return out
+}
+
+// ReconcileTotals is the fleet-wide reconcile rollup for the journal digest.
+type ReconcileTotals struct {
+	Repos         int       `json:"repos"`
+	Runs          int64     `json:"runs"`
+	Failures      int64     `json:"failures"`
+	Repairs       int64     `json:"repairs"`
+	LastSuccessAt time.Time `json:"last_success_at"`
+}
+
+// ReconcileTotalsSnapshot aggregates the per-repo reconcile counters into a
+// fleet-wide rollup, taking the most recent successful reconcile across repos.
+func ReconcileTotalsSnapshot() ReconcileTotals {
+	reconcileMu.Lock()
+	defer reconcileMu.Unlock()
+	var t ReconcileTotals
+	t.Repos = len(reconcileStats)
+	for _, st := range reconcileStats {
+		t.Runs += st.Runs
+		t.Failures += st.Failures
+		t.Repairs += st.Repairs
+		if st.LastSuccessAt.After(t.LastSuccessAt) {
+			t.LastSuccessAt = st.LastSuccessAt
+		}
+	}
+	return t
+}
+
+// resetReconcileStatsForTest clears the registry so a test starts from a known
+// base.
+func resetReconcileStatsForTest() {
+	reconcileMu.Lock()
+	defer reconcileMu.Unlock()
+	reconcileStats = map[string]*ReconcileStat{}
+}

--- a/internal/mirrorstore/reconcile_test.go
+++ b/internal/mirrorstore/reconcile_test.go
@@ -1,0 +1,314 @@
+package mirrorstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+// fakeReconcileReader is an in-memory ReconcileReader: it returns the configured
+// open-issue / open-PR snapshots and answers IsPRMerged from a lookup table,
+// counting the calls so a test can prove the merged read is only made for a
+// dropped PR (never per-cycle).
+type fakeReconcileReader struct {
+	issues     []github.Issue
+	prs        []github.PR
+	merged     map[int]bool
+	issuesErr  error
+	prsErr     error
+	mergedErr  error
+	mergedCall int
+}
+
+func (f *fakeReconcileReader) ListOpenIssues(labels []string) ([]github.Issue, error) {
+	return f.issues, f.issuesErr
+}
+func (f *fakeReconcileReader) ListOpenPRs() ([]github.PR, error) { return f.prs, f.prsErr }
+func (f *fakeReconcileReader) IsPRMerged(prNumber int) (bool, error) {
+	f.mergedCall++
+	if f.mergedErr != nil {
+		return false, f.mergedErr
+	}
+	return f.merged[prNumber], nil
+}
+
+func ghIssue(number int, title, body string, labels ...string) github.Issue {
+	iss := github.Issue{Number: number, Title: title, Body: body, State: "open"}
+	for _, l := range labels {
+		iss.Labels = append(iss.Labels, struct {
+			Name string `json:"name"`
+		}{Name: l})
+	}
+	return iss
+}
+
+// TestReconcileAddsMissingIssue: an issue GitHub reports open that the mirror
+// never saw is added by reconcile and counted as a repair.
+func TestReconcileAddsMissingIssue(t *testing.T) {
+	resetReconcileStatsForTest()
+	store := openTestStore(t)
+	ctx := context.Background()
+	api := &fakeReconcileReader{issues: []github.Issue{ghIssue(7, "hello", "body", "bug")}}
+
+	res, err := NewReconciler(store, api, "o/r").Reconcile(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.IssuesRepaired != 1 || res.Repaired() != 1 {
+		t.Fatalf("expected 1 issue repaired, got %+v", res)
+	}
+	row, ok, err := store.GetIssue(ctx, "o/r", 7)
+	if err != nil || !ok {
+		t.Fatalf("issue not mirrored: ok=%v err=%v", ok, err)
+	}
+	if row.Source != SourceReconcile || row.State != "open" || row.Title != "hello" {
+		t.Fatalf("unexpected mirrored issue: %+v", row)
+	}
+	labels, _ := store.Labels(ctx, "o/r", SubjectIssue, 7)
+	if len(labels) != 1 || labels[0] != "bug" {
+		t.Fatalf("labels not mirrored: %v", labels)
+	}
+}
+
+// TestReconcileSkipsInSyncIssue: when the mirror already matches GitHub, reconcile
+// writes nothing (no repair, and the webhook-sourced last_seen_at is preserved).
+func TestReconcileSkipsInSyncIssue(t *testing.T) {
+	resetReconcileStatsForTest()
+	store := openTestStore(t)
+	ctx := context.Background()
+	seen := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := store.UpsertIssueWithLabels(ctx, Issue{
+		Repo: "o/r", Number: 7, Title: "hello", State: "open", Body: "body",
+		LastSeenAt: seen, Source: SourceWebhook,
+	}, []string{"bug"}); err != nil {
+		t.Fatal(err)
+	}
+	api := &fakeReconcileReader{issues: []github.Issue{ghIssue(7, "hello", "body", "bug")}}
+
+	res, err := NewReconciler(store, api, "o/r").Reconcile(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.Repaired() != 0 {
+		t.Fatalf("expected no repair for in-sync issue, got %+v", res)
+	}
+	row, _, _ := store.GetIssue(ctx, "o/r", 7)
+	if row.Source != SourceWebhook || !row.LastSeenAt.Equal(seen) {
+		t.Fatalf("in-sync row should keep its webhook source/timestamp, got %+v", row)
+	}
+}
+
+// TestReconcileRepairsChangedIssue: a title/label edit the mirror missed is
+// repaired and re-stamped with the reconcile source.
+func TestReconcileRepairsChangedIssue(t *testing.T) {
+	resetReconcileStatsForTest()
+	store := openTestStore(t)
+	ctx := context.Background()
+	old := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := store.UpsertIssueWithLabels(ctx, Issue{
+		Repo: "o/r", Number: 7, Title: "old title", State: "open", Body: "body",
+		LastSeenAt: old, Source: SourceWebhook,
+	}, []string{"bug"}); err != nil {
+		t.Fatal(err)
+	}
+	api := &fakeReconcileReader{issues: []github.Issue{ghIssue(7, "new title", "body", "bug", "ready")}}
+
+	res, err := NewReconciler(store, api, "o/r").Reconcile(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.IssuesRepaired != 1 {
+		t.Fatalf("expected 1 repair, got %+v", res)
+	}
+	row, _, _ := store.GetIssue(ctx, "o/r", 7)
+	if row.Title != "new title" || row.Source != SourceReconcile {
+		t.Fatalf("issue not repaired: %+v", row)
+	}
+	labels, _ := store.Labels(ctx, "o/r", SubjectIssue, 7)
+	if len(labels) != 2 {
+		t.Fatalf("labels not repaired: %v", labels)
+	}
+}
+
+// TestReconcileClosesMissedIssue: an issue the mirror still records open that
+// GitHub no longer lists (a missed close delivery) is marked closed. This is the
+// convergence-after-a-webhook-outage acceptance (#827 AC 1).
+func TestReconcileClosesMissedIssue(t *testing.T) {
+	resetReconcileStatsForTest()
+	store := openTestStore(t)
+	ctx := context.Background()
+	if _, err := store.UpsertIssue(ctx, Issue{
+		Repo: "o/r", Number: 7, Title: "hello", State: "open", Body: "body",
+		LastSeenAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), Source: SourceWebhook,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// GitHub now reports NO open issues.
+	api := &fakeReconcileReader{}
+
+	res, err := NewReconciler(store, api, "o/r").Reconcile(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.IssuesRepaired != 1 {
+		t.Fatalf("expected the missed-close to be repaired, got %+v", res)
+	}
+	row, _, _ := store.GetIssue(ctx, "o/r", 7)
+	if row.State != "closed" || row.Source != SourceReconcile {
+		t.Fatalf("issue not closed by reconcile: %+v", row)
+	}
+}
+
+// TestReconcileBackfillsPRHeadRef: a PR mirrored before the head_ref column
+// existed (empty branch) is repaired to match GitHub's headRefName.
+func TestReconcileBackfillsPRHeadRef(t *testing.T) {
+	resetReconcileStatsForTest()
+	store := openTestStore(t)
+	ctx := context.Background()
+	if _, err := store.UpsertPullRequest(ctx, PullRequest{
+		Repo: "o/r", Number: 12, Title: "feat", State: "open", HeadRef: "", HeadSHA: "abc",
+		Body: "b", LastSeenAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), Source: SourceWebhook,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	api := &fakeReconcileReader{prs: []github.PR{{Number: 12, Title: "feat", HeadRefName: "feat/x", Body: "b", State: "OPEN"}}}
+
+	res, err := NewReconciler(store, api, "o/r").Reconcile(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.PRsRepaired != 1 {
+		t.Fatalf("expected PR head_ref backfill, got %+v", res)
+	}
+	row, _, _ := store.GetPullRequest(ctx, "o/r", 12)
+	if row.HeadRef != "feat/x" || row.HeadSHA != "abc" || row.Source != SourceReconcile {
+		t.Fatalf("PR not repaired (head_sha must be preserved): %+v", row)
+	}
+}
+
+// TestReconcileClosesMergedPR: a PR the mirror records open that GitHub no longer
+// lists is settled closed with the authoritative merged flag, and IsPRMerged is
+// consulted exactly once (only for the dropped PR).
+func TestReconcileClosesMergedPR(t *testing.T) {
+	resetReconcileStatsForTest()
+	store := openTestStore(t)
+	ctx := context.Background()
+	if _, err := store.UpsertPullRequest(ctx, PullRequest{
+		Repo: "o/r", Number: 12, Title: "feat", State: "open", HeadRef: "feat/x",
+		Body: "b", LastSeenAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), Source: SourceWebhook,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	api := &fakeReconcileReader{merged: map[int]bool{12: true}} // GitHub lists no open PRs
+
+	res, err := NewReconciler(store, api, "o/r").Reconcile(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.PRsRepaired != 1 {
+		t.Fatalf("expected the dropped PR to be repaired, got %+v", res)
+	}
+	if api.mergedCall != 1 {
+		t.Fatalf("IsPRMerged should be called once for the dropped PR, got %d", api.mergedCall)
+	}
+	row, _, _ := store.GetPullRequest(ctx, "o/r", 12)
+	if row.State != "closed" || !row.Merged {
+		t.Fatalf("PR not settled merged/closed: %+v", row)
+	}
+}
+
+// TestReconcileUnchangedRepoIsCheap: a fully caught-up mirror does zero repairs
+// and does not consult IsPRMerged — the "cheap when nothing changed" property.
+func TestReconcileUnchangedRepoIsCheap(t *testing.T) {
+	resetReconcileStatsForTest()
+	store := openTestStore(t)
+	ctx := context.Background()
+	seen := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := store.UpsertIssueWithLabels(ctx, Issue{
+		Repo: "o/r", Number: 7, Title: "hello", State: "open", Body: "body",
+		LastSeenAt: seen, Source: SourceWebhook,
+	}, []string{"bug"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertPullRequest(ctx, PullRequest{
+		Repo: "o/r", Number: 12, Title: "feat", State: "open", HeadRef: "feat/x",
+		Body: "b", LastSeenAt: seen, Source: SourceWebhook,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	api := &fakeReconcileReader{
+		issues: []github.Issue{ghIssue(7, "hello", "body", "bug")},
+		prs:    []github.PR{{Number: 12, Title: "feat", HeadRefName: "feat/x", Body: "b", State: "OPEN"}},
+	}
+
+	res, err := NewReconciler(store, api, "o/r").Reconcile(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.Repaired() != 0 {
+		t.Fatalf("expected zero repairs on an unchanged repo, got %+v", res)
+	}
+	if api.mergedCall != 0 {
+		t.Fatalf("IsPRMerged must not be called when nothing dropped, got %d", api.mergedCall)
+	}
+}
+
+// TestReconcileStatsRecorded: the process-global registry records runs, the last
+// success, and cumulative + last-pass repair counts.
+func TestReconcileStatsRecorded(t *testing.T) {
+	resetReconcileStatsForTest()
+	store := openTestStore(t)
+	ctx := context.Background()
+	api := &fakeReconcileReader{issues: []github.Issue{ghIssue(7, "hello", "body")}}
+	rec := NewReconciler(store, api, "o/r")
+
+	if _, err := rec.Reconcile(ctx); err != nil { // repairs 1 (adds)
+		t.Fatal(err)
+	}
+	if _, err := rec.Reconcile(ctx); err != nil { // repairs 0 (in sync)
+		t.Fatal(err)
+	}
+
+	stats := ReconcileStatsSnapshot()
+	if len(stats) != 1 || stats[0].Repo != "o/r" {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	st := stats[0]
+	if st.Runs != 2 || st.Failures != 0 {
+		t.Fatalf("runs/failures = %d/%d, want 2/0", st.Runs, st.Failures)
+	}
+	if st.Repairs != 1 || st.LastRepairs != 0 {
+		t.Fatalf("cumulative/last repairs = %d/%d, want 1/0", st.Repairs, st.LastRepairs)
+	}
+	if st.LastSuccessAt.IsZero() {
+		t.Fatal("last success time not recorded")
+	}
+
+	totals := ReconcileTotalsSnapshot()
+	if totals.Repos != 1 || totals.Runs != 2 || totals.Repairs != 1 {
+		t.Fatalf("unexpected totals: %+v", totals)
+	}
+}
+
+// TestReconcileRecordsFailure: a GitHub read error is recorded as a failed pass
+// and surfaced as LastError, not a silent no-op.
+func TestReconcileRecordsFailure(t *testing.T) {
+	resetReconcileStatsForTest()
+	store := openTestStore(t)
+	ctx := context.Background()
+	api := &fakeReconcileReader{issuesErr: errors.New("boom")}
+
+	if _, err := NewReconciler(store, api, "o/r").Reconcile(ctx); err == nil {
+		t.Fatal("expected reconcile to return the list error")
+	}
+	stats := ReconcileStatsSnapshot()
+	if len(stats) != 1 || stats[0].Failures != 1 || stats[0].LastError == "" {
+		t.Fatalf("failure not recorded: %+v", stats)
+	}
+	if !stats[0].LastSuccessAt.IsZero() {
+		t.Fatalf("a failed pass must not set last success time: %+v", stats[0])
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -910,6 +910,39 @@ type fleetMirrorStats struct {
 	Stale        mirrorstore.Counts `json:"stale"`
 	TotalRows    int                `json:"total_rows"`
 	TotalStale   int                `json:"total_stale"`
+
+	// Reconcile is the per-repo status of the low-frequency reconciliation loop
+	// (#827): when it last ran/succeeded, how many passes and failures, and the
+	// cumulative + last-pass drift-repair count. DriftRepairs sums Repairs across
+	// repos so an operator sees fleet-wide healed drift at a glance.
+	Reconcile    []fleetReconcileStat `json:"reconcile,omitempty"`
+	DriftRepairs int64                `json:"drift_repairs"`
+
+	// Reads is the mirror-first read outcome (#826/#827): reads served locally vs
+	// reads that fell back to the GitHub API, and the hit rate. The fallback count
+	// is one of the observability fields phase E surfaces in diagnostics.
+	Reads fleetMirrorReadStats `json:"reads"`
+}
+
+// fleetReconcileStat is one repo's reconciliation status in the mirror block.
+type fleetReconcileStat struct {
+	Repo          string `json:"repo"`
+	LastRunAt     string `json:"last_run_at,omitempty"`
+	LastSuccessAt string `json:"last_success_at,omitempty"`
+	Runs          int64  `json:"runs"`
+	Failures      int64  `json:"failures"`
+	Repairs       int64  `json:"repairs"`
+	LastRepairs   int    `json:"last_repairs"`
+	LastError     string `json:"last_error,omitempty"`
+}
+
+// fleetMirrorReadStats surfaces the mirror-first read hit/fallback counters on the
+// fleet snapshot so the fallback-to-GitHub count is visible in diagnostics, not
+// only in the journal digest.
+type fleetMirrorReadStats struct {
+	MirrorHits   int64   `json:"mirror_hits"`
+	APIFallbacks int64   `json:"api_fallbacks"`
+	HitRate      float64 `json:"hit_rate"`
 }
 
 // mirrorStatsSnapshot maps the mirror store's counts into the fleet response
@@ -932,7 +965,7 @@ func (s *FleetServer) mirrorStatsSnapshot() *fleetMirrorStats {
 		log.Printf("[fleet] mirror stale-counts query failed (reporting counts only): %v", err)
 		stale = mirrorstore.Counts{}
 	}
-	return &fleetMirrorStats{
+	out := &fleetMirrorStats{
 		Enabled:      true,
 		StaleHorizon: horizon.String(),
 		Counts:       counts,
@@ -940,6 +973,31 @@ func (s *FleetServer) mirrorStatsSnapshot() *fleetMirrorStats {
 		TotalRows:    counts.Total(),
 		TotalStale:   stale.Total(),
 	}
+	for _, st := range mirrorstore.ReconcileStatsSnapshot() {
+		out.DriftRepairs += st.Repairs
+		rs := fleetReconcileStat{
+			Repo:        st.Repo,
+			Runs:        st.Runs,
+			Failures:    st.Failures,
+			Repairs:     st.Repairs,
+			LastRepairs: st.LastRepairs,
+			LastError:   st.LastError,
+		}
+		if !st.LastRunAt.IsZero() {
+			rs.LastRunAt = formatFleetTime(st.LastRunAt)
+		}
+		if !st.LastSuccessAt.IsZero() {
+			rs.LastSuccessAt = formatFleetTime(st.LastSuccessAt)
+		}
+		out.Reconcile = append(out.Reconcile, rs)
+	}
+	reads := mirrorstore.ReadStatsSnapshot()
+	out.Reads = fleetMirrorReadStats{
+		MirrorHits:   reads.MirrorHits,
+		APIFallbacks: reads.APIFallbacks,
+		HitRate:      reads.HitRate(),
+	}
+	return out
 }
 
 // fleetNextAction names the single canonical operator action across the fleet.

--- a/internal/server/fleet_mirror_test.go
+++ b/internal/server/fleet_mirror_test.go
@@ -9,8 +9,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/mirrorstore"
 )
+
+// stubReconcileAPI is a minimal mirrorstore.ReconcileReader for driving a real
+// reconcile pass so the fleet diagnostics reconcile block can be asserted.
+type stubReconcileAPI struct {
+	issues []github.Issue
+	prs    []github.PR
+}
+
+func (s stubReconcileAPI) ListOpenIssues(labels []string) ([]github.Issue, error) {
+	return s.issues, nil
+}
+func (s stubReconcileAPI) ListOpenPRs() ([]github.PR, error)     { return s.prs, nil }
+func (s stubReconcileAPI) IsPRMerged(prNumber int) (bool, error) { return false, nil }
 
 func newMirrorStore(t *testing.T) *mirrorstore.Store {
 	t.Helper()
@@ -71,6 +85,44 @@ func TestFleetSnapshotMirrorStats(t *testing.T) {
 	}
 	if payload.Mirror == nil || payload.Mirror.TotalRows != 2 || payload.Mirror.TotalStale != 1 {
 		t.Fatalf("fleet JSON missing mirror stats: %+v", payload.Mirror)
+	}
+}
+
+// TestFleetSnapshotReconcileStats proves the reconciliation status surfaces on the
+// mirror diagnostics block (#827): a pass that repaired drift shows up per repo,
+// with a fleet-wide drift-repair total.
+func TestFleetSnapshotReconcileStats(t *testing.T) {
+	store := newMirrorStore(t)
+	ctx := context.Background()
+
+	// A reconcile that discovers a GitHub-open issue the mirror never saw repairs
+	// one row and records a successful pass for the repo.
+	api := stubReconcileAPI{issues: []github.Issue{{Number: 1, Title: "hi", State: "open"}}}
+	if _, err := mirrorstore.NewReconciler(store, api, "o/r").Reconcile(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	fleet := NewFleet(nil, "127.0.0.1", 0, false)
+	fleet.SetMirrorStore(store, mirrorstore.DefaultStaleHorizon)
+
+	snap := fleet.snapshot()
+	if snap.Mirror == nil {
+		t.Fatal("fleet snapshot missing mirror block")
+	}
+	if snap.Mirror.DriftRepairs != 1 {
+		t.Fatalf("drift repairs = %d, want 1", snap.Mirror.DriftRepairs)
+	}
+	var found bool
+	for _, rs := range snap.Mirror.Reconcile {
+		if rs.Repo == "o/r" {
+			found = true
+			if rs.Runs != 1 || rs.Repairs != 1 || rs.LastSuccessAt == "" {
+				t.Fatalf("unexpected reconcile stat: %+v", rs)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("reconcile block missing repo o/r: %+v", snap.Mirror.Reconcile)
 	}
 }
 


### PR DESCRIPTION
Implements #827 — phase E of epic #811 (Fleet GitHub control-plane mirror).

Closes the mirror loop: a low-frequency reconciliation loop detects and repairs
mirror drift a missed webhook left behind, and the whole read-model pipeline is
observable end-to-end.

## Changes

- **Reconciler** (`internal/mirrorstore/reconcile.go`): per repo, snapshots the
  authoritative GitHub open-issue/open-PR sets and repairs drift — missing rows
  added, changed rows (title/labels/head-branch) refreshed, and issues/PRs the
  mirror still shows open that GitHub no longer lists marked closed (a dropped
  PR's authoritative `merged` flag is fetched so a merge is never fabricated or
  lost). Reads flow through the gh wrapper's conditional (ETag) layer, so an
  unchanged repo answers 304 and the reconciler writes nothing — cheap when
  nothing changed. Repaired rows are stamped `source="reconcile"`.
- **Cadence config**: `github_mirror.reconcile_seconds` (default 15m).
- **Observability**:
  - Fleet diagnostics (`GET /api/v1/fleet` `mirror` block) gains per-repo
    reconcile status (last run/success, runs, failures, drift repairs),
    fleet-wide `drift_repairs`, and mirror read hit/fallback counts.
  - Journal digest (`maestro digest`) gains a `Mirror reconcile:` line + JSON
    `reconcile` block; the hourly gh REST-usage journal line is extended with
    reconcile pass/drift-repair totals.
- **Daemon**: per-flow reconcile loop, started when the mirror is open, cadence
  read live from the config holder.
- **Docs**: new `docs/mirror-reconciliation-runbook.md` (how to check mirror
  health, force a full reconcile, verify convergence after a webhook outage, and
  run the soak) with cross-links from the mirror/webhook runbooks.

## Testing

- `go test ./...` (all pass), `go build ./cmd/maestro/`, `gofmt` clean on changed
  files, `go vet` on changed packages.
- New unit tests cover reconcile add/refresh/close/backfill/merged-close paths,
  the "unchanged repo is cheap" property, the stats registry, the fleet
  diagnostics block, the digest summary, and the daemon cadence/no-op wiring.

## Runtime verification still required (not auto-closing)

Two acceptance criteria are operator tasks on the runtime host and are **not**
performed by this code change:

- the **60-minute fleet soak** (webhooks live, mirror-first on, all projects)
  with requests/hr before vs after posted to epic #811;
- the live **kill-webhook-delivery → mirror converges** check.

Both are documented step-by-step in the new runbook. This PR should not
auto-close #827 until that runtime verification is completed.

Refs #827

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds reconciliation and observability for the GitHub mirror. The main changes are:

- A per-repo reconcile pass that refreshes missing or changed mirror rows.
- Live `github_mirror.reconcile_seconds` cadence configuration.
- Fleet and digest fields for reconcile status, drift repairs, and mirror read counts.
- Runbook updates for mirror health checks, forced convergence, and the soak workflow.

<h3>Confidence Score: 4/5</h3>

The reconcile close path can write incorrect mirror state for large repos and can leave dropped PRs stale after merge-status lookup failures.

- The new loop is wired into the daemon lifecycle cleanly.
- The fleet and digest observability changes are additive.
- The reconcile pass treats a one-page GitHub list as complete before closing mirror rows.
- The dropped-PR path can skip convergence when the merge-status lookup keeps failing.

internal/mirrorstore/reconcile.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/mirrorstore/reconcile.go | Adds the reconcile engine and process-wide reconcile stats; the close logic needs attention around incomplete open snapshots and merge-status lookup failures. |
| internal/daemon/mirror_source.go | Adds the reconcile loop, live cadence lookup, rate-limit skip, and journal digest fragments. |
| internal/daemon/flow.go | Starts the reconcile goroutine when the daemon has an open mirror store. |
| internal/config/config.go | Adds `github_mirror.reconcile_seconds` and the default reconcile cadence. |
| internal/server/fleet.go | Extends the fleet mirror block with reconcile, drift repair, and read hit/fallback stats. |
| internal/digest/digest.go | Adds reconcile totals to the digest model. |
| internal/digest/markdown.go | Adds the mirror reconcile line to digest markdown. |
| docs/mirror-reconciliation-runbook.md | Adds the operator runbook for reconciliation health, convergence checks, and soak verification. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/mirrorstore/reconcile.go:100
**Open Snapshot Is Truncated**

When a repo has more than 100 open issues, `ListOpenIssues(nil)` returns only the first REST page but this pass treats that page as the complete GitHub open set. Any still-open mirror issue missing from that page then falls through `closeMissedIssues` and is stamped closed, so mirror-first readers can stop seeing live issues and diagnostics report a false drift repair. The same snapshot contract is used for PRs below, so the fix needs the authoritative open lists to paginate before absence is used as a close signal.

### Issue 2 of 2
internal/mirrorstore/reconcile.go:278-283
**Dropped PR Stays Open**

When a PR disappears from the open snapshot but `IsPRMerged` returns an error, this branch skips the row and records no failure for that PR. A persistent API error such as a 404 on the merge-status lookup leaves the mirror row open on every reconcile pass, so mirror diagnostics keep reporting stale open PR state instead of converging after the missed close or merge webhook.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Reconciliation loop + mirror observabili..."](https://github.com/befeast/maestro/commit/c433a3d86a082866e1fb46eab54831d41c3d9c5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42127251)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->