### PR TITLE
worker: fleet-wide work-discipline prompt section (plan-before-first-write, durable-before-done, conflict surfacing)

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -861,6 +861,29 @@ func visualEvidencePromptSection(cfg *config.Config) string {
 	return b.String()
 }
 
+// workDisciplinePromptSection appends a fleet-wide "work discipline" block to
+// every worker prompt. Maestro workers are single-shot headless runs with no
+// human in the loop, so prompt-encoded discipline is the only lever over how a
+// worker sequences its work.
+//
+// The three checkpoints below come from Anthropic's advisor-tool best-practices
+// guidance on prompting coding and agent tasks
+// (https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool):
+// an early plan checkpoint (after read-only orientation, before the first
+// state-changing write) and making the deliverable durable before a final
+// review pass each measured +7–10 pp on under-planning workloads. The same
+// source found that aggressive "always plan first" nudges helped Haiku-class
+// models but slightly hurt Opus-class executors, so the block is phrased as a
+// lightweight checkpoint ("a checkpoint, not an essay") rather than a hard
+// demand for elaborate planning.
+func workDisciplinePromptSection() string {
+	return "\n\n---\n\n## Work Discipline\n\n" +
+		"Sequence your work so an interrupted run still leaves something durable:\n\n" +
+		"- **Plan before your first change.** Do read-only orientation first (ls, cat, grep, go doc, gh issue view — no plan needed). Before your first state-changing action (a file write/edit or state-changing bash), jot a short plan: the approach, the files you expect to touch, and how you will verify. Keep it brief — a checkpoint, not an essay.\n" +
+		"- **Make it durable before you declare done.** Commit, push, and open/update the PR *before* any final review or summary pass. A durable partial result beats a perfect plan lost to a dead session.\n" +
+		"- **Surface conflicts, don't silently switch.** If evidence you gather (test output, file contents, CI logs) contradicts your plan or the issue description, state the conflict and your resolution in the PR body or an issue comment instead of quietly changing approach.\n"
+}
+
 // subagentHintPromptSection renders the per-backend sub-agent model policy
 // (#706). Orchestrating backends (e.g. Claude Code) spawn their own
 // sub-agents and, by default, run them on the same expensive orchestrator
@@ -918,7 +941,7 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 		}
 
 		r := strings.NewReplacer(replacements...)
-		result := r.Replace(base) + repoRulesPromptSection(worktreePath) + workerSearchSafetyPromptSection(worktreePath) + visualEvidencePromptSection(cfg)
+		result := r.Replace(base) + repoRulesPromptSection(worktreePath) + workerSearchSafetyPromptSection(worktreePath) + visualEvidencePromptSection(cfg) + workDisciplinePromptSection()
 		return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, contractInlined)
 	}
 
@@ -966,6 +989,7 @@ Always rebase on origin/main immediately before creating the PR.
 	result += repoRulesPromptSection(worktreePath)
 	result += workerSearchSafetyPromptSection(worktreePath)
 	result += visualEvidencePromptSection(cfg)
+	result += workDisciplinePromptSection()
 	return appendSectionsAndValidation(result, cfg.PromptSections, validationContract, false)
 }
 

--- a/internal/worker/worker_prompt_test.go
+++ b/internal/worker/worker_prompt_test.go
@@ -53,6 +53,40 @@ func TestAssemblePromptIncludesSearchSafetyGuardrails(t *testing.T) {
 	}
 }
 
+func TestAssemblePromptIncludesWorkDisciplineSection(t *testing.T) {
+	cfg := &config.Config{Repo: "BeFeast/maestro"}
+	issue := github.Issue{Number: 834, Title: "work discipline", Body: "Sequence the work."}
+
+	want := []string{
+		"## Work Discipline",
+		"Plan before your first change.",
+		"read-only orientation first",
+		"a checkpoint, not an essay",
+		"Make it durable before you declare done.",
+		"A durable partial result beats a perfect plan lost to a dead session.",
+		"Surface conflicts, don't silently switch.",
+	}
+
+	// Both assemblePrompt branches must carry the section: the template path
+	// (base contains {{ISSUE_NUMBER}}) and the legacy append path (it does not).
+	for _, tc := range []struct {
+		name string
+		base string
+	}{
+		{name: "template", base: "Task {{ISSUE_NUMBER}} in {{REPO}}"},
+		{name: "legacy", base: "base prompt"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prompt := assemblePrompt(tc.base, issue, "/tmp/worktree", "feat/discipline", cfg)
+			for _, w := range want {
+				if !strings.Contains(prompt, w) {
+					t.Fatalf("assemblePrompt() [%s] missing %q\nprompt:\n%s", tc.name, w, prompt)
+				}
+			}
+		})
+	}
+}
+
 func TestGoWorkerPromptUsesStampedMaestroBuild(t *testing.T) {
 	promptPath := filepath.Join("..", "..", "worker-prompt-go.md")
 	data, err := os.ReadFile(promptPath)


### PR DESCRIPTION
Implements #834

## Changes

- New `workDisciplinePromptSection()` in `internal/worker/worker.go`, appended in `assemblePrompt` on BOTH the template path and the legacy append path (same placement pattern as `workerSearchSafetyPromptSection`/`visualEvidencePromptSection`).
- The section is a concise "Work Discipline" block (well under 20 lines) with three checkpoints:
  - **Plan before your first change** — read-only orientation first; jot a short plan before the first state-changing write. Phrased as a lightweight checkpoint ("a checkpoint, not an essay"), not a hard demand for elaborate planning.
  - **Make it durable before you declare done** — commit/push/open the PR before any final review pass.
  - **Surface conflicts, don't silently switch** — state evidence conflicts and their resolution rather than quietly changing approach.
- Unit test asserting the section is present in assembled prompts on both the template and legacy paths.
- Source citation (Anthropic advisor-tool best practices) lives in the function godoc, since no dedicated worker-prompt doc exists under `docs/`.

No config-store or runtime topology changes; ships with the next self-deploy.

## Testing

- `go build ./cmd/maestro/`
- `go test ./...` (full suite passes)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Work Discipline section to worker prompts. The main changes are:

- Appends the section in both template-based and legacy prompt assembly paths.
- Adds guidance for planning before edits, making work durable before final review, and surfacing conflicts.
- Adds unit coverage that checks the section appears in both prompt assembly branches.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is localized to prompt text assembly and includes targeted coverage for both affected branches.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The test run for TestAssemblePromptIncludesWorkDisciplineSection/template and the legacy path completed with all tests passing and EXIT\_CODE: 0.
- Maestro was built with go build ./cmd/maestro/ and the build exited with EXIT\_CODE: 0.
- The repository-wide Go test suite was executed and finished with all packages passing and EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/13808011/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/worker.go | Adds a fleet-wide Work Discipline prompt section to both prompt assembly paths. |
| internal/worker/worker_prompt_test.go | Adds test coverage for the Work Discipline section in template and legacy prompt paths. |

<sub>Reviews (1): Last reviewed commit: ["worker: fleet-wide work-discipline promp..."](https://github.com/befeast/maestro/commit/fb0bc4bf46f331a9e65f65e73923c7d9854613d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42949566)</sub>

<!-- /greptile_comment -->