### PR TITLE
supervisor: short-circuit LLM call when deterministic decision is safe and mutation-free (idle-project token burn) (#837)

### DIFF
--- a/docs/emergency-stop-runbook.md
+++ b/docs/emergency-stop-runbook.md
@@ -88,6 +88,42 @@ issue selection and the supervisor restores its LLM path on the next cycle. A
   per-project, gates only issue selection, and must be invoked once per
   project).
 
+## Supervisor LLM cost profile (baseline spend)
+
+The emergency stop is the brake for a runaway burn; the everyday floor of
+supervisor spend is set by how often the supervise loop actually calls its
+backend. That floor is deliberately low:
+
+- **Safe, mutation-free cycles do not call the LLM (#837).** When the
+  deterministic guardrail already decides `action=none`, a `wait_*` action, or
+  `monitor_open_pr` with `risk=safe` and no planned GitHub mutation, the
+  supervisor records that decision and skips the backend entirely. It builds no
+  state packet and makes no `Complete` call, so an idle project spends **zero**
+  supervisor tokens per cycle. The skip is safe because the LLM is only ever
+  allowed to *agree* with a `risk=safe` guardrail decision — any disagreement
+  resolves back to the deterministic side — so the full-context call could only
+  reword the summary, never change the outcome.
+- **The LLM still runs where it adds value.** Mutating / approval-gated
+  decisions (`spawn_worker`, `spawn_repair_worker`, `merge_pr`,
+  `review_retry_exhausted`, and `label_issue_ready` when it plans a real label
+  mutation) have `risk != safe` or carry planned mutations, so they take the
+  full LLM path exactly as before.
+- **Journal signal.** Each skipped cycle logs
+  `supervise: safe idle decision, LLM skipped (action=… risk=…)`, so the saving
+  is visible in `journalctl` and the proxy log shows no matching
+  `session=<backend>:*` supervise request.
+
+Why it matters: before #837 every enabled cycle sent a ~55K-token state packet,
+so nine idle fleet projects on a 180s poll interval issued ≈180 LLM calls/hour
+that almost all decided "do nothing" — the exact shape of the 2026-07-09 metered
+backend incident. The short-circuit removes that baseline; the emergency stop
+remains the fast brake for anything the baseline does not cover.
+
+**Escape hatch.** Set `supervisor.always_consult_llm: true` (default `false`) to
+restore the pre-#837 behavior and force a full-context LLM call on every enabled
+cycle — use it only when you specifically want a second opinion on idle
+decisions and accept the token cost.
+
 ## Relationship to `pause` / `drain`
 
 `maestro pause` and `maestro drain` remain per-project operator controls that

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -582,6 +582,14 @@ type SupervisorConfig struct {
 	ApprovalRequiredActions []string                        `yaml:"approval_required_actions" json:"approval_required_actions,omitempty"`
 	PolicyPath              string                          `yaml:"-" json:"policy_path,omitempty"`
 	LessonProposalsEnabled  *bool                           `yaml:"lesson_proposals_enabled" json:"lesson_proposals_enabled,omitempty"`
+	// AlwaysConsultLLM restores the pre-#837 behavior of calling the supervisor
+	// LLM on every enabled cycle, even when the deterministic guardrail already
+	// decided a safe, mutation-free action (action=none / wait_* / monitor_open_pr).
+	// Default false: those cycles short-circuit and skip the backend call, since
+	// the LLM can only agree with a risk=safe guardrail decision and therefore
+	// cannot change it (see internal/supervisor/llm.go decideWithLLM). Set true to
+	// force a full-context second opinion on every cycle regardless of token cost.
+	AlwaysConsultLLM bool `yaml:"always_consult_llm" json:"always_consult_llm,omitempty"`
 
 	excludedLabelsSet bool
 }

--- a/internal/supervisor/guardrail_conflict_test.go
+++ b/internal/supervisor/guardrail_conflict_test.go
@@ -90,9 +90,15 @@ func TestDecideWithLLM_GuardrailConflictOnMutatingAction_HoldsNoOp(t *testing.T)
 // action disagreement and must also resolve instead of failing the cycle.
 // The guardrail side (monitor_open_pr) is risk=safe, so the deterministic
 // decision wins the tie-break and keeps its own target.
+//
+// #837: a pure safe, mutation-free decision (monitor_open_pr) now
+// short-circuits the LLM entirely, so a disagreement can only arise when the
+// operator opts back into consulting the LLM. always_consult_llm=true restores
+// that path and, with it, this conflict-resolution behavior.
 func TestDecideWithLLM_GuardrailTargetDisagreement_ResolvesToDeterministic(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.ReviewGate = "none"
+	cfg.Supervisor.AlwaysConsultLLM = true
 	reader := &fakeReader{
 		prs:        []github.PR{{Number: 117, HeadRefName: "feat/pending", Mergeable: "MERGEABLE"}},
 		ciStatuses: map[int]string{117: "pending"},

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -132,6 +132,25 @@ func (e *Engine) decideWithLLM(st *state.State) (state.SupervisorDecision, error
 		return state.SupervisorDecision{}, err
 	}
 
+	// #837: short-circuit the LLM call on a safe, mutation-free deterministic
+	// decision (idle-project token burn). validateLLMDecision forces the LLM to
+	// agree with the guardrail on action/target/risk, and resolveGuardrailConflict
+	// resolves any disagreement in favor of the deterministic side whenever the
+	// guardrail decision is risk=safe — so on an idle project the LLM can only
+	// reword the summary, never change the decision. Building the ~55K-token state
+	// packet and calling the backend there buys nothing, so skip both.
+	//
+	// The LLM stays in the loop exactly where it adds value: every mutating /
+	// approval-gated decision (spawn_worker, spawn_repair_worker, merge_pr,
+	// review_retry_exhausted, ...) has Risk != safe, and a safe decision that
+	// still plans a GitHub mutation (label_issue_ready with add_ready_label) has
+	// len(Mutations) > 0 — both fall through to the LLM path below. The escape
+	// hatch supervisor.always_consult_llm=true restores the old always-call path.
+	if !e.cfg.Supervisor.AlwaysConsultLLM && deterministic.Risk == RiskSafe && len(deterministic.Mutations) == 0 {
+		log.Printf("[supervisor] supervise: safe idle decision, LLM skipped (action=%s risk=%s)", deterministic.RecommendedAction, deterministic.Risk)
+		return deterministic, nil
+	}
+
 	policy := newSupervisorPolicy(e.cfg)
 	packet, err := e.buildStatePacket(st, deterministic, policy)
 	if err != nil {

--- a/internal/supervisor/llm_short_circuit_test.go
+++ b/internal/supervisor/llm_short_circuit_test.go
@@ -1,0 +1,219 @@
+package supervisor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// idleLLM is an LLM decision that agrees with an idle (action=none) guardrail.
+// The short-circuit means it should never be consulted on a safe, mutation-free
+// cycle — the tests below assert calls==0 — but it is a valid response so the
+// always_consult_llm escape hatch has something to parse when it does call.
+func idleLLM() *fakeLLM {
+	return &fakeLLM{output: `{
+  "summary": "Nothing to do; the project is idle.",
+  "recommended_action": "none",
+  "target": {"issue": 0, "pr": 0, "session": ""},
+  "risk": "safe",
+  "confidence": 0.8,
+  "reasons": ["no eligible issue", "no worker running"],
+  "requires_approval": false
+}`}
+}
+
+// TestDecideWithLLM_SafeIdleDecision_SkipsLLM pins #837 AC: an idle project
+// (deterministic action=none, risk=safe, no planned mutations) completes the
+// supervise cycle without invoking the supervisor backend at all.
+func TestDecideWithLLM_SafeIdleDecision_SkipsLLM(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	// No open issues, no sessions → deterministic action=none / risk=safe / no mutations.
+	reader := &fakeReader{}
+	llm := idleLLM()
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if llm.calls != 0 {
+		t.Fatalf("LLM calls = %d, want 0 (safe idle decision must short-circuit the backend)", llm.calls)
+	}
+	if decision.RecommendedAction != ActionNone {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionNone)
+	}
+	if decision.Risk != RiskSafe {
+		t.Fatalf("risk = %q, want %q", decision.Risk, RiskSafe)
+	}
+	if len(decision.Mutations) != 0 {
+		t.Fatalf("mutations = %#v, want none", decision.Mutations)
+	}
+}
+
+// TestDecideWithLLM_MonitorOpenPR_SkipsLLM pins the monitor_open_pr arm of the
+// AC: a safe, mutation-free "watch this PR" decision does not spend an LLM call.
+func TestDecideWithLLM_MonitorOpenPR_SkipsLLM(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 100, HeadRefName: "feat/ci-pending", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{100: "pending"},
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 201,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/ci-pending",
+		PRNumber:    100,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+	llm := idleLLM()
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if llm.calls != 0 {
+		t.Fatalf("LLM calls = %d, want 0 (monitor_open_pr is safe + mutation-free)", llm.calls)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionMonitorOpenPR)
+	}
+}
+
+// TestDecideWithLLM_WaitForRunningWorker_SkipsLLM pins the wait_* arm of the AC:
+// waiting on an in-flight worker is a safe, mutation-free decision → no LLM call.
+func TestDecideWithLLM_WaitForRunningWorker_SkipsLLM(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{prs: []github.PR{{Number: 55, HeadRefName: "untracked-open-pr", State: "OPEN"}}}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "work in progress",
+		Status:      state.StatusRunning,
+		PID:         12345,
+		StartedAt:   time.Now().UTC(),
+	}
+	llm := idleLLM()
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if llm.calls != 0 {
+		t.Fatalf("LLM calls = %d, want 0 (wait_for_running_worker is safe + mutation-free)", llm.calls)
+	}
+	if decision.RecommendedAction != ActionWaitForRunningWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionWaitForRunningWorker)
+	}
+}
+
+// TestDecideWithLLM_SpawnCandidate_CallsLLM pins the counterpart AC: a mutating
+// spawn_worker candidate still goes through the LLM path exactly as before.
+func TestDecideWithLLM_SpawnCandidate_CallsLLM(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
+	llm := validSpawnLLM()
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if llm.calls != 1 {
+		t.Fatalf("LLM calls = %d, want 1 (spawn_worker is mutating; the LLM must be consulted)", llm.calls)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+}
+
+// TestDecideWithLLM_LabelIssueReadyWithMutations_CallsLLM pins the documented
+// choice for AC-3: a safe decision that still plans a GitHub mutation
+// (label_issue_ready with add_ready_label) keeps the LLM second opinion because
+// len(Mutations) > 0, even though its headline risk is safe.
+func TestDecideWithLLM_LabelIssueReadyWithMutations_CallsLLM(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel}
+	reader := &fakeReader{issues: []github.Issue{testIssue(308, "implement supervisor")}}
+	llm := &fakeLLM{output: `{
+  "summary": "Prepare issue #308 for the queue by adding the ready label.",
+  "recommended_action": "add_ready_label",
+  "target": {"issue": 308},
+  "risk": "safe",
+  "confidence": 0.82,
+  "reasons": ["issue #308 is next in queue"],
+  "requires_approval": true
+}`}
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if llm.calls != 1 {
+		t.Fatalf("LLM calls = %d, want 1 (safe decision with a planned GitHub mutation keeps the LLM)", llm.calls)
+	}
+	if decision.RecommendedAction != ActionLabelIssueReady {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionLabelIssueReady)
+	}
+	if len(decision.Mutations) == 0 {
+		t.Fatalf("mutations = %#v, want a planned add_ready_label mutation", decision.Mutations)
+	}
+}
+
+// TestDecideWithLLM_AlwaysConsultLLM_IdleStillCallsLLM pins the escape hatch:
+// supervisor.always_consult_llm=true restores the pre-#837 behavior of calling
+// the backend on every enabled cycle, even for a safe, mutation-free idle state.
+func TestDecideWithLLM_AlwaysConsultLLM_IdleStillCallsLLM(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.AlwaysConsultLLM = true
+	reader := &fakeReader{}
+	llm := idleLLM()
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if llm.calls != 1 {
+		t.Fatalf("LLM calls = %d, want 1 (always_consult_llm restores the old always-call path)", llm.calls)
+	}
+	if decision.RecommendedAction != ActionNone {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionNone)
+	}
+}
+
+// TestRunOnce_SafeIdleDecision_RecordedWithoutBackendCall proves the AC
+// end-to-end through the daemon seam: RunOnce builds its own real backend
+// client (Supervisor.Enabled, no injected LLM), so a real Complete would fail —
+// no backend is configured in the test config. A clean, recorded action=none
+// decision is therefore proof the LLM path was short-circuited.
+func TestRunOnce_SafeIdleDecision_RecordedWithoutBackendCall(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Supervisor.Enabled = true
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{}
+	if err := state.Save(cfg.StateDir, state.NewState()); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	decision, err := RunOnce(cfg, reader)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if decision.RecommendedAction != ActionNone {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionNone)
+	}
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if latest := st.LatestSupervisorDecision(); latest == nil || latest.RecommendedAction != ActionNone {
+		t.Fatalf("latest recorded decision = %#v, want an action=none decision", latest)
+	}
+}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -2702,8 +2702,13 @@ func TestDecideWithLLM_MalformedOutputRejected(t *testing.T) {
 // decision wins the tie-break and the cycle succeeds with a
 // guardrail_conflict stuck state instead of an error (which used to exit
 // rc=1 and put systemd in a crash-loop).
+//
+// #837: wait_for_running_worker is a pure safe, mutation-free decision, which
+// now short-circuits the LLM. always_consult_llm=true keeps the LLM in the loop
+// so this conflict-resolution path is still exercised.
 func TestDecideWithLLM_DetectorDisagreementResolvesToDeterministicSafeSide(t *testing.T) {
 	cfg := testConfig(t)
+	cfg.Supervisor.AlwaysConsultLLM = true
 	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work")}}
 	llm := &fakeLLM{output: `{
   "summary": "Start a new worker anyway.",


### PR DESCRIPTION
Implements #837

## Changes

- `internal/supervisor/llm.go` — `decideWithLLM` now returns the deterministic
  decision immediately when `Risk == safe` and `len(Mutations) == 0`, skipping
  the state packet build and the backend `Complete` call. A log line
  `supervise: safe idle decision, LLM skipped (action=… risk=…)` marks each
  skip in the journal.
- `internal/config/config.go` — new `supervisor.always_consult_llm` escape
  hatch (default `false`) that restores the old always-call behavior.
- Docs — supervisor LLM cost-profile section added to the emergency-stop
  runbook.

## Rationale (AC-3 choice)

Decisions with planned safe mutations (e.g. `label_issue_ready` with
`add_ready_label`) carry `len(Mutations) > 0`, so they **still go through the
LLM path** — they mutate GitHub state, so the second opinion is kept. Only
pure safe, mutation-free decisions (`action=none` / `wait_*` / `monitor_open_pr`)
short-circuit. This is safe because `validateLLMDecision` forces the LLM to
agree with a `risk=safe` guardrail and `resolveGuardrailConflict` resolves any
disagreement to the deterministic side anyway — the full-context call could
only reword the summary.

## Testing

- New `internal/supervisor/llm_short_circuit_test.go`: idle / monitor_open_pr /
  wait_for_running_worker skip the LLM (calls==0); spawn_worker and
  label_issue_ready-with-mutations still call it (calls==1); `always_consult_llm`
  keeps the LLM on an idle cycle; and a RunOnce end-to-end that records an
  action=none decision without any backend call.
- Two pre-existing guardrail-conflict tests exercised conflict resolution on a
  pure-safe decision, which is now short-circuited; updated to opt into
  `always_consult_llm` so they still cover that path.
- `go test ./...`, `go build ./cmd/maestro/`, and `gofmt` on changed Go files
  all pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces idle supervisor LLM usage while keeping the old behavior available through config. The main changes are:

- Short-circuits `risk=safe` supervisor decisions with no planned mutations before prompt building and backend calls.
- Adds `supervisor.always_consult_llm` to force the previous always-call path.
- Updates guardrail conflict tests to opt into LLM consultation where needed.
- Adds tests for idle, monitor, wait, mutating, escape-hatch, and `RunOnce` paths.
- Documents the supervisor LLM cost profile and escape hatch in the emergency-stop runbook.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The behavior is narrowly scoped to safe, mutation-free supervisor decisions and has an explicit config escape hatch. Tests cover the key skipped and non-skipped paths, including RunOnce recording and guardrail conflict behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The primary verbose test run completed with all requested tests passing and exit code 0, with skip logs recorded for safe idle decisions.
- Package-level supervisor tests completed successfully with exit code 0.
- Maestro build step completed successfully with go build ./cmd/maestro exiting 0.
- Go fmt completed with no rewrites and exit code 0.

<a href="https://app.greptile.com/trex/runs/13850181/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/llm.go | Short-circuits safe, mutation-free deterministic supervisor decisions before prompt construction and backend calls. |
| internal/supervisor/llm_short_circuit_test.go | Adds coverage for skipped idle/read-only decisions, retained mutating paths, the escape hatch, and `RunOnce` persistence. |
| internal/config/config.go | Adds the default-false `supervisor.always_consult_llm` config flag. |
| internal/supervisor/guardrail_conflict_test.go | Updates a guardrail conflict test to force LLM consultation under the new default short-circuit behavior. |
| internal/supervisor/supervisor_test.go | Updates the existing safe-side guardrail disagreement test to keep exercising conflict resolution. |
| docs/emergency-stop-runbook.md | Documents the supervisor LLM cost profile, skipped idle cycles, journal signal, and escape hatch. |

<sub>Reviews (1): Last reviewed commit: ["supervisor: short-circuit LLM call on sa..."](https://github.com/befeast/maestro/commit/edb38b516f4966156104867048af6034d9590b5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43037141)</sub>

<!-- /greptile_comment -->