### PR TITLE
safety: refuse metered (per-token) backends for supervisor/router loops without explicit opt-in (#838)

### DIFF
--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -317,6 +317,65 @@ model:
       subagent_hint: "Use cheaper sub-agent models (e.g. opus/sonnet) for delegated grunt subtasks such as file sweeps, searches, and mechanical edits; reserve the main orchestrator model for planning and final review."
 ```
 
+### Pricing classes and the metered-backend guard (`pricing_class`, #838)
+
+Maestro's always-on internal loops — the supervisor cycle and the auto-router —
+call an LLM on a schedule regardless of whether there is work to do. Pointing one
+of those loops at a **per-token metered** model burns money making "do nothing"
+decisions: on 2026-07-09 the shared `codex` backend row was re-pointed at a
+per-token model and supervise cycles burned ~$4/hour across nine idle projects
+before anyone noticed. The `pricing_class` guard caps that blast radius.
+
+Declare how each backend bills with `pricing_class`:
+
+```yaml
+model:
+  default: claude
+  backends:
+    claude:
+      cmd: claude
+      pricing_class: subscription   # fixed monthly plan (Claude Max, etc.)
+    fireworks-kimi:
+      cmd: fw
+      provider: fireworks
+      pricing_class: metered        # per-token — gated from always-on loops
+```
+
+- `flat` / `subscription` — a fixed-cost plan. Always-on loops run normally.
+- `metered` — billed per token. The supervisor and router **refuse** to run
+  their LLM path on this backend unless the project opts in explicitly.
+- unset — treated as `flat` for backward compatibility. A backend that only sets
+  a `pricing:` table for cost observability (#619) is **not** gated; mark it
+  `metered` explicitly to activate the guard.
+
+When `supervisor.backend` (or the `model.default` fallback the supervisor uses)
+resolves to a `metered` backend and the project has not opted in, the supervisor
+drops to **deterministic-only** for that cycle — no supervisor backend call is
+made — and surfaces a red *"Metered backend"* attention badge on Mission Control
+until the operator re-points the backend or opts in. A config-store edit that
+re-points the backend at a per-token model therefore cannot silently start
+burning: the next supervise cycle runs deterministic-only and logs the refusal.
+The same guard applies to `routing.router_model` when `routing.mode: auto` — the
+router skips its per-issue LLM classification and falls back to `model.default`.
+
+Opt in per project when the per-token cost is acceptable:
+
+```yaml
+supervisor:
+  allow_metered_backend: true   # supervisor LLM may run on a metered backend
+routing:
+  allow_metered_backend: true   # auto-router LLM may run on a metered backend
+```
+
+The supervisor opt-in and the current refusal are visible on the fleet API under
+`effective_config.supervisor_gate` (`allow_metered_backend`,
+`metered_backend_refused`, `metered_backend`), and each backend's classification
+appears under `effective_config.model_policy.backends[].metered`.
+
+**Workers are not gated.** A worker is bounded by `worker_max_tokens` and produces
+a concrete PR, so a metered worker backend is a deliberate, bounded spend — this
+guard targets only the unbounded always-on loops.
+
 ### Optional: parallel review streams
 
 By default, `review_gate: greptile` waits for the single Greptile verdict before merge. Projects that also run the simplicity / over-engineering reviewer can opt in to the aggregate gate:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,6 +83,17 @@ type BackendDef struct {
 	// set the same value for both.
 	Pricing BackendPricing `yaml:"pricing,omitempty"`
 
+	// PricingClass declares how the backend bills so always-on internal
+	// loops (supervisor cycles, the auto-router) can refuse to run their
+	// LLM path on a per-token model without an explicit opt-in (#838). One
+	// of PricingClassFlat / PricingClassSubscription / PricingClassMetered;
+	// empty is treated as flat for backward compatibility. Only an explicit
+	// `metered` gates the loops — a backend that leaves this unset keeps
+	// running unchanged, even when it has a `pricing:` table set for cost
+	// observability (a subscription backend legitimately configures pricing
+	// for #619). parse() rejects any value outside the three classes.
+	PricingClass string `yaml:"pricing_class,omitempty"`
+
 	// Quota describes the backend's subscription window capacity (#704).
 	// When configured, maestro tracks estimated token usage against the
 	// provider's 5-hour session window and weekly cap, surfaces the
@@ -294,6 +305,35 @@ func (q BackendQuota) EffectiveDispatchThreshold() float64 {
 
 func (b BackendDef) IsEnabled() bool {
 	return b.Enabled == nil || *b.Enabled
+}
+
+// Backend pricing classes (#838). Only PricingClassMetered gates the always-on
+// supervisor/router LLM loops; flat, subscription, and unset run unchanged.
+const (
+	PricingClassFlat         = "flat"
+	PricingClassSubscription = "subscription"
+	PricingClassMetered      = "metered"
+)
+
+// IsMetered reports whether the backend bills per token in a way that must not
+// back an unbounded always-on loop without an explicit opt-in (#838). Only an
+// explicit `pricing_class: metered` qualifies; an unset class — even with a
+// `pricing:` table configured for cost observability (#619) — is treated as
+// flat so existing subscription backends keep running unchanged.
+func (b BackendDef) IsMetered() bool {
+	return strings.EqualFold(strings.TrimSpace(b.PricingClass), PricingClassMetered)
+}
+
+// validPricingClass reports whether a pricing_class string is one of the known
+// classes (or empty, which defaults to flat). parse() uses it to reject typos
+// that would otherwise silently disable the metered guard.
+func validPricingClass(class string) bool {
+	switch strings.ToLower(strings.TrimSpace(class)) {
+	case "", PricingClassFlat, PricingClassSubscription, PricingClassMetered:
+		return true
+	default:
+		return false
+	}
 }
 
 // ModelConfig holds multi-backend configuration.
@@ -590,6 +630,16 @@ type SupervisorConfig struct {
 	// cannot change it (see internal/supervisor/llm.go decideWithLLM). Set true to
 	// force a full-context second opinion on every cycle regardless of token cost.
 	AlwaysConsultLLM bool `yaml:"always_consult_llm" json:"always_consult_llm,omitempty"`
+
+	// AllowMeteredBackend opts this project's supervisor LLM loop into running on
+	// a metered (per-token) backend (#838). Default false: when supervisor.backend
+	// (or the model.default fallback the supervisor uses) resolves to a backend
+	// with pricing_class: metered, the supervisor refuses the LLM path and runs
+	// deterministic-only, emitting a red stuck state — so a config-store edit that
+	// re-points the backend at a per-token model cannot silently burn cost on
+	// always-on "do nothing" cycles (incident 2026-07-09). Set true to accept the
+	// per-token cost explicitly.
+	AllowMeteredBackend bool `yaml:"allow_metered_backend" json:"allow_metered_backend,omitempty"`
 
 	excludedLabelsSet bool
 }
@@ -904,6 +954,13 @@ type RoutingConfig struct {
 	RouterModelName  string            `yaml:"router_model_name"`  // specific model to use (default: "claude-sonnet-4-6")
 	RouterPrompt     string            `yaml:"router_prompt"`      // prompt template with {{BACKENDS}}, {{NUMBER}}, {{TITLE}}, {{BODY}}
 	TaskTypeBackends map[string]string `yaml:"task_type_backends"` // task_type -> backend override used only when routing.mode=auto
+
+	// AllowMeteredBackend opts the auto-router into running its per-issue LLM
+	// classification on a metered (per-token) backend (#838). Default false: when
+	// routing.router_model resolves to a pricing_class: metered backend the router
+	// refuses the LLM call and falls back to model.default — the same guard the
+	// supervisor applies to its own always-on loop.
+	AllowMeteredBackend bool `yaml:"allow_metered_backend,omitempty"`
 
 	// Task-aware model routing (#783, RFC docs/model-routing-rfc.md §2.5). Tiers
 	// are named strength bands (backend + optional effort/model override) and
@@ -1617,6 +1674,12 @@ func parse(data []byte) (*Config, error) {
 			if _, err := regexp.Compile(p); err != nil {
 				return nil, fmt.Errorf("config: model.backends.%s.usage_limit_patterns entry %q does not compile: %v", name, p, err)
 			}
+		}
+		// #838: a mistyped pricing_class (e.g. "meterd", "per_token") would
+		// silently leave the metered guard disabled, re-opening the exact
+		// always-on burn the field exists to prevent. Fail fast instead.
+		if !validPricingClass(def.PricingClass) {
+			return nil, fmt.Errorf("config: model.backends.%s.pricing_class = %q; want one of flat, subscription, metered (or empty)", name, def.PricingClass)
 		}
 	}
 

--- a/internal/config/metered_backend.go
+++ b/internal/config/metered_backend.go
@@ -1,0 +1,83 @@
+package config
+
+import "strings"
+
+// Metered-backend guard (#838).
+//
+// Nothing used to stop an operator (or a config-store edit) from pointing a
+// high-frequency internal loop — supervisor cycles, the auto-router — at a
+// per-token metered model. On 2026-07-09 the shared codex backend row was
+// re-pointed at a per-token Fireworks model in response to a 429-storm;
+// supervise cycles then burned ~$4/hour making "do nothing" decisions across
+// nine idle projects. The guard below lets the supervisor and router refuse a
+// backend declared `pricing_class: metered` unless the project opts in
+// explicitly, capping the blast radius of a re-point.
+//
+// These helpers are pure config reads so both the deterministic supervisor
+// decision and the router can share one source of truth, and so the whole
+// guard is unit-testable without a real backend.
+
+// ResolvedSupervisorBackend returns the backend name the supervisor LLM loop
+// dispatches to: supervisor.backend when set, otherwise model.default. parse()
+// already defaults supervisor.backend to model.default, but the fallback here
+// keeps the helper correct for configs built in-process (tests, hot-reload).
+func (c *Config) ResolvedSupervisorBackend() string {
+	if c == nil {
+		return ""
+	}
+	name := strings.TrimSpace(c.Supervisor.Backend)
+	if name == "" {
+		name = strings.TrimSpace(c.Model.Default)
+	}
+	return name
+}
+
+// ResolvedRouterBackend returns the backend name the auto-router dispatches to:
+// routing.router_model. parse() defaults it to "claude".
+func (c *Config) ResolvedRouterBackend() string {
+	if c == nil {
+		return ""
+	}
+	return strings.TrimSpace(c.Routing.RouterModel)
+}
+
+// backendIsMetered reports whether the named backend is declared metered
+// (pricing_class: metered). An unknown name is not metered — the caller's
+// existing "backend not found" error path handles that case.
+func (c *Config) backendIsMetered(name string) bool {
+	if c == nil {
+		return false
+	}
+	def, ok := c.Model.Backends[strings.TrimSpace(name)]
+	return ok && def.IsMetered()
+}
+
+// SupervisorMeteredRefusal reports whether the supervisor LLM path must be
+// refused because its resolved backend is metered and the project has not set
+// supervisor.allow_metered_backend (#838). The returned backend name feeds the
+// red stuck state / log line. refused=false means the LLM path may run — either
+// the backend is flat/subscription/unset, or the operator opted in.
+func (c *Config) SupervisorMeteredRefusal() (backend string, refused bool) {
+	if c == nil || c.Supervisor.AllowMeteredBackend {
+		return "", false
+	}
+	name := c.ResolvedSupervisorBackend()
+	if c.backendIsMetered(name) {
+		return name, true
+	}
+	return "", false
+}
+
+// RouterMeteredRefusal is the router analog of SupervisorMeteredRefusal: it
+// reports whether routing.router_model is metered and routing.allow_metered_backend
+// is not set (#838).
+func (c *Config) RouterMeteredRefusal() (backend string, refused bool) {
+	if c == nil || c.Routing.AllowMeteredBackend {
+		return "", false
+	}
+	name := c.ResolvedRouterBackend()
+	if c.backendIsMetered(name) {
+		return name, true
+	}
+	return "", false
+}

--- a/internal/config/metered_backend_test.go
+++ b/internal/config/metered_backend_test.go
@@ -1,0 +1,176 @@
+package config
+
+import "testing"
+
+// TestBackendDef_IsMetered pins the #838 classification: only an explicit
+// pricing_class: metered qualifies. A backend with a pricing: table but no
+// class stays flat so subscription backends configured for cost observability
+// (#619) are never gated.
+func TestBackendDef_IsMetered(t *testing.T) {
+	cases := []struct {
+		name string
+		def  BackendDef
+		want bool
+	}{
+		{"explicit metered", BackendDef{PricingClass: "metered"}, true},
+		{"metered case-insensitive", BackendDef{PricingClass: "Metered"}, true},
+		{"metered padded", BackendDef{PricingClass: " metered "}, true},
+		{"explicit flat", BackendDef{PricingClass: "flat"}, false},
+		{"explicit subscription", BackendDef{PricingClass: "subscription"}, false},
+		{"unset class", BackendDef{}, false},
+		// Backward compat: a priced backend with no class is NOT metered.
+		{"priced but no class", BackendDef{Pricing: BackendPricing{InputUSDPerMtok: 3, OutputUSDPerMtok: 9}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.def.IsMetered(); got != tc.want {
+				t.Errorf("IsMetered() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParse_PricingClass_RoundTripsAndValidates covers YAML parse of the field
+// and the parse-time rejection of a mistyped class (which would otherwise
+// silently disable the guard).
+func TestParse_PricingClass_RoundTripsAndValidates(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: claude
+  backends:
+    claude:
+      cmd: claude
+      pricing_class: subscription
+    fireworks:
+      cmd: fw
+      pricing_class: metered
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Model.Backends["claude"].IsMetered() {
+		t.Error("claude (subscription) must not be metered")
+	}
+	if !cfg.Model.Backends["fireworks"].IsMetered() {
+		t.Error("fireworks (metered) must be metered")
+	}
+
+	bad := `
+repo: owner/repo
+model:
+  default: claude
+  backends:
+    claude:
+      cmd: claude
+      pricing_class: per_token
+`
+	if _, err := parse([]byte(bad)); err == nil {
+		t.Fatal("parse must reject an unknown pricing_class")
+	}
+}
+
+// TestSupervisorMeteredRefusal covers the supervisor guard truth table (#838):
+// metered+no-opt-in refuses; metered+opt-in and flat/subscription/unset run.
+func TestSupervisorMeteredRefusal(t *testing.T) {
+	metered := func() *Config {
+		return &Config{
+			Model: ModelConfig{
+				Default: "claude",
+				Backends: map[string]BackendDef{
+					"claude":    {Cmd: "claude"},
+					"fireworks": {Cmd: "fw", PricingClass: PricingClassMetered},
+				},
+			},
+			Supervisor: SupervisorConfig{Backend: "fireworks"},
+		}
+	}
+
+	t.Run("metered + no opt-in refuses", func(t *testing.T) {
+		backend, refused := metered().SupervisorMeteredRefusal()
+		if !refused || backend != "fireworks" {
+			t.Fatalf("SupervisorMeteredRefusal() = (%q, %v), want (fireworks, true)", backend, refused)
+		}
+	})
+
+	t.Run("metered + opt-in runs", func(t *testing.T) {
+		cfg := metered()
+		cfg.Supervisor.AllowMeteredBackend = true
+		if _, refused := cfg.SupervisorMeteredRefusal(); refused {
+			t.Fatal("opt-in must clear the refusal")
+		}
+	})
+
+	t.Run("flat backend runs", func(t *testing.T) {
+		cfg := metered()
+		cfg.Supervisor.Backend = "claude"
+		if _, refused := cfg.SupervisorMeteredRefusal(); refused {
+			t.Fatal("flat/unset backend must not be refused")
+		}
+	})
+
+	t.Run("supervisor.backend unset falls back to model.default", func(t *testing.T) {
+		cfg := metered()
+		cfg.Supervisor.Backend = ""
+		cfg.Model.Default = "fireworks"
+		backend, refused := cfg.SupervisorMeteredRefusal()
+		if !refused || backend != "fireworks" {
+			t.Fatalf("fallback resolution = (%q, %v), want (fireworks, true)", backend, refused)
+		}
+	})
+}
+
+// TestRouterMeteredRefusal covers the router analog (#838): router_model metered
+// without routing.allow_metered_backend refuses; opt-in and flat run.
+func TestRouterMeteredRefusal(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			Model: ModelConfig{
+				Default: "claude",
+				Backends: map[string]BackendDef{
+					"claude":    {Cmd: "claude"},
+					"fireworks": {Cmd: "fw", PricingClass: PricingClassMetered},
+				},
+			},
+			Routing: RoutingConfig{RouterModel: "fireworks"},
+		}
+	}
+
+	backend, refused := base().RouterMeteredRefusal()
+	if !refused || backend != "fireworks" {
+		t.Fatalf("RouterMeteredRefusal() = (%q, %v), want (fireworks, true)", backend, refused)
+	}
+
+	optIn := base()
+	optIn.Routing.AllowMeteredBackend = true
+	if _, refused := optIn.RouterMeteredRefusal(); refused {
+		t.Fatal("routing.allow_metered_backend must clear the refusal")
+	}
+
+	flat := base()
+	flat.Routing.RouterModel = "claude"
+	if _, refused := flat.RouterMeteredRefusal(); refused {
+		t.Fatal("flat router_model must not be refused")
+	}
+}
+
+// TestMeteredRefusal_UnsetPricingZeroTableIsFlat is the backward-compat
+// acceptance: a backend with no pricing_class and a zero pricing table is
+// treated as flat, so nothing is gated for pre-#838 configs.
+func TestMeteredRefusal_UnsetPricingZeroTableIsFlat(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default:  "claude",
+			Backends: map[string]BackendDef{"claude": {Cmd: "claude"}},
+		},
+		Supervisor: SupervisorConfig{Backend: "claude"},
+		Routing:    RoutingConfig{RouterModel: "claude"},
+	}
+	if _, refused := cfg.SupervisorMeteredRefusal(); refused {
+		t.Error("unset pricing_class + zero pricing table must not refuse the supervisor")
+	}
+	if _, refused := cfg.RouterMeteredRefusal(); refused {
+		t.Error("unset pricing_class + zero pricing table must not refuse the router")
+	}
+}

--- a/internal/router/metered_backend_test.go
+++ b/internal/router/metered_backend_test.go
@@ -1,0 +1,76 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+// TestResolveBackend_AutoMode_MeteredRouterModel_Refused pins #838 for the
+// router: when routing.mode=auto and router_model is metered without
+// routing.allow_metered_backend, the router skips the LLM call and falls back
+// to model.default with ReasonMeteredRefused. The injected DecisionFn records
+// whether the model call was dispatched — it must not be.
+func TestResolveBackend_AutoMode_MeteredRouterModel_Refused(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude":    {Cmd: "claude"},
+				"fireworks": {Cmd: "fw", PricingClass: config.PricingClassMetered},
+			},
+		},
+		Routing: config.RoutingConfig{Mode: "auto", RouterModel: "fireworks"},
+	}
+	r := New(cfg)
+	called := false
+	r.DecisionFn = func(github.Issue) (Decision, error) {
+		called = true
+		return Decision{Backend: "codex"}, nil
+	}
+
+	name, reason := r.ResolveBackend(makeIssue(70, "route me", "enhancement"))
+	if called {
+		t.Fatal("router LLM (DecisionFn) must not be called for a metered router_model without opt-in")
+	}
+	if name != "claude" {
+		t.Errorf("backend = %q, want claude (deterministic fallback)", name)
+	}
+	if reason != ReasonMeteredRefused {
+		t.Errorf("reason = %q, want %q", reason, ReasonMeteredRefused)
+	}
+}
+
+// TestResolveBackend_AutoMode_MeteredRouterModel_OptIn confirms the opt-in
+// restores the auto path: routing.allow_metered_backend lets the router LLM run.
+func TestResolveBackend_AutoMode_MeteredRouterModel_OptIn(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude":    {Cmd: "claude"},
+				"codex":     {Cmd: "codex"},
+				"fireworks": {Cmd: "fw", PricingClass: config.PricingClassMetered},
+			},
+		},
+		Routing: config.RoutingConfig{Mode: "auto", RouterModel: "fireworks", AllowMeteredBackend: true},
+	}
+	r := New(cfg)
+	called := false
+	r.DecisionFn = func(github.Issue) (Decision, error) {
+		called = true
+		return Decision{Backend: "codex", Reason: "picked"}, nil
+	}
+
+	name, reason := r.ResolveBackend(makeIssue(71, "route me", "enhancement"))
+	if !called {
+		t.Fatal("opt-in must let the router LLM run")
+	}
+	if name != "codex" {
+		t.Errorf("backend = %q, want codex (router pick)", name)
+	}
+	if reason != ReasonAuto {
+		t.Errorf("reason = %q, want %q", reason, ReasonAuto)
+	}
+}

--- a/internal/router/resolve.go
+++ b/internal/router/resolve.go
@@ -40,6 +40,12 @@ const (
 	// usable tier backend (e.g. tier points at a now-missing backend) and fell
 	// back to model.default — the policy analogue of ReasonRouterError.
 	ReasonPolicyError = "policy_error"
+	// ReasonMeteredRefused marks an auto-routing decision that skipped the router
+	// LLM call because routing.router_model is metered (per-token) and
+	// routing.allow_metered_backend is not set (#838). Selection falls back to
+	// model.default deterministically — distinct from ReasonRouterError so the
+	// dashboard can tell a cost guard from a genuine router failure.
+	ReasonMeteredRefused = "metered_refused"
 )
 
 // BackendFromLabels extracts a backend name from issue labels with the "model:" prefix.
@@ -115,6 +121,16 @@ func (r *Router) ResolveBackendDecisionForAttempt(issue github.Issue, escalation
 
 	// 3. Auto-routing via LLM (if enabled)
 	if r.cfg.Routing.Mode == "auto" {
+		// #838: refuse the router LLM call when router_model is metered
+		// (per-token) and routing.allow_metered_backend is not set. A per-issue
+		// LLM classification on a per-token backend is the same unbounded burn
+		// class as the supervisor loop, so fall back to model.default
+		// deterministically instead of dispatching the call.
+		if backend, refused := r.cfg.RouterMeteredRefusal(); refused {
+			log.Printf("[router] issue #%d: router_model %q is metered (per-token) and routing.allow_metered_backend is not set — skipping router LLM, using default %q (#838)",
+				issue.Number, backend, r.cfg.Model.Default)
+			return BackendDecision{Backend: r.cfg.Model.Default, Reason: ReasonMeteredRefused}
+		}
 		routeDecisionFn := r.RouteDecision
 		if r.DecisionFn != nil {
 			routeDecisionFn = r.DecisionFn

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1197,8 +1197,12 @@ type fleetSummary struct {
 	OutcomeMissing   int `json:"outcome_missing"`
 	OutcomeDrift     int `json:"outcome_drift"`
 	StaleWorkers     int `json:"stale_workers"`
-	Running          int `json:"running"`
-	PROpen           int `json:"pr_open"`
+	// MeteredBackend counts projects whose supervisor LLM path is disabled
+	// because it resolves to a metered backend without opt-in (#838). It
+	// escalates the fleet verdict to attention like the other error-class states.
+	MeteredBackend int `json:"metered_backend"`
+	Running        int `json:"running"`
+	PROpen         int `json:"pr_open"`
 	// PRsOpen / WorkersRunning are truth-table mirrors expected by the
 	// SPA (#566). PRsOpen extends pr_open with retry_exhausted /
 	// failed / conflict_failed sessions whose PR is still open;
@@ -1422,12 +1426,19 @@ type fleetEffectiveBackendConfig struct {
 	PriceConfigured  bool    `json:"price_configured"`
 	InputUSDPerMtok  float64 `json:"input_usd_per_mtok,omitempty"`
 	OutputUSDPerMtok float64 `json:"output_usd_per_mtok,omitempty"`
+	// PricingClass / Metered surface the #838 pricing classification so an
+	// operator can see which backends the metered guard treats as per-token.
+	PricingClass string `json:"pricing_class,omitempty"`
+	Metered      bool   `json:"metered,omitempty"`
 }
 
 type fleetEffectiveRoutingConfig struct {
 	Mode            string `json:"mode,omitempty"`
 	RouterModel     string `json:"router_model,omitempty"`
 	RouterModelName string `json:"router_model_name,omitempty"`
+	// AllowMeteredBackend surfaces the router opt-in for a metered router_model
+	// (#838); false is the default guarded behavior.
+	AllowMeteredBackend bool `json:"allow_metered_backend,omitempty"`
 }
 
 type fleetConfigLabels struct {
@@ -1470,6 +1481,13 @@ type fleetConfigSupervisor struct {
 	ReviewRepairActive      bool     `json:"review_repair_active"`
 	ReviewRepairBackend     string   `json:"review_repair_backend,omitempty"`
 	ReviewRepairMaxRetries  int      `json:"review_repair_max_retries,omitempty"`
+	// AllowMeteredBackend surfaces the #838 supervisor opt-in: when false (the
+	// default) the supervisor refuses its LLM path if the resolved backend is
+	// metered. MeteredBackendRefused reports whether that refusal is currently
+	// active for this project's resolved supervisor backend.
+	AllowMeteredBackend   bool   `json:"allow_metered_backend"`
+	MeteredBackendRefused bool   `json:"metered_backend_refused,omitempty"`
+	MeteredBackend        string `json:"metered_backend,omitempty"`
 }
 
 type fleetCloseCandidate struct {
@@ -2434,7 +2452,7 @@ func fleetVerdictTone(summary fleetSummary, latest *supervisorDecisionInfo, now 
 	if actionableAttention < 0 {
 		actionableAttention = 0
 	}
-	if summary.Stale > 0 || summary.Errors > 0 || actionableAttention > 0 || fleetActionableApprovalCount(summary) > 0 || summary.DispatchFailures > 0 || summary.OutcomeDrift > 0 || summary.NoEligibleIssues > 0 {
+	if summary.Stale > 0 || summary.Errors > 0 || actionableAttention > 0 || fleetActionableApprovalCount(summary) > 0 || summary.DispatchFailures > 0 || summary.OutcomeDrift > 0 || summary.NoEligibleIssues > 0 || summary.MeteredBackend > 0 {
 		return "attention"
 	}
 	if summary.Running > 0 {
@@ -2534,7 +2552,7 @@ func fleetAttentionSentence(summary fleetSummary) string {
 		selfResolving = summary.NeedsAttention
 	}
 	actionable := summary.NeedsAttention - selfResolving
-	items := actionable + fleetActionableApprovalCount(summary) + summary.Errors + summary.Stale + summary.DispatchFailures + summary.OutcomeDrift + summary.NoEligibleIssues
+	items := actionable + fleetActionableApprovalCount(summary) + summary.Errors + summary.Stale + summary.DispatchFailures + summary.OutcomeDrift + summary.NoEligibleIssues + summary.MeteredBackend
 	var base string
 	switch items {
 	case 0:
@@ -2584,6 +2602,8 @@ func addFleetOperatorSummary(summary *fleetSummary, operator fleetOperatorState)
 		summary.OutcomeDrift++
 	case "stale_worker":
 		summary.StaleWorkers++
+	case "metered_backend":
+		summary.MeteredBackend++
 	}
 }
 
@@ -2717,7 +2737,7 @@ type fleetNextActionCandidate struct {
 // kinds (working, monitoring_pr, idle, ...) are excluded from the brief.
 func fleetNextActionPriorityForKind(kind string) (int, bool) {
 	switch strings.TrimSpace(kind) {
-	case "error", "dispatch_failure", "stale_worker":
+	case "error", "dispatch_failure", "metered_backend", "stale_worker":
 		return 0, true
 	case "attention":
 		return 1, true
@@ -2748,7 +2768,7 @@ func fleetProjectOperatorUpdatedAt(project fleetProjectState) time.Time {
 				return t
 			}
 		}
-	case "dispatch_failure", "outcome_drift", "queue_blocked", "no_eligible_issues":
+	case "dispatch_failure", "metered_backend", "outcome_drift", "queue_blocked", "no_eligible_issues":
 		if project.Supervisor.Latest != nil && !project.Supervisor.Latest.CreatedAt.IsZero() {
 			return project.Supervisor.Latest.CreatedAt.UTC()
 		}
@@ -2975,6 +2995,8 @@ func fleetNextActionCTAForProject(kind string, op fleetOperatorState) string {
 			return "Redeploy maestro binary" // #711
 		}
 		return "Resolve stuck dispatch"
+	case "metered_backend":
+		return "Fix metered supervisor backend" // #838
 	case "stale_worker":
 		if op.PRNumber > 0 {
 			return fmt.Sprintf("Open worker log for PR #%d", op.PRNumber)
@@ -3103,7 +3125,7 @@ func highestPriorityPendingFleetApproval(approvals []fleetApprovalState) *fleetA
 
 func fleetOperatorKindNeedsAction(kind string) bool {
 	switch strings.TrimSpace(kind) {
-	case "error", "dispatch_failure", "stale_worker", "attention", "stale", "outcome_drift", "no_eligible_issues", "queue_blocked":
+	case "error", "dispatch_failure", "metered_backend", "stale_worker", "attention", "stale", "outcome_drift", "no_eligible_issues", "queue_blocked":
 		return true
 	default:
 		return false
@@ -3162,6 +3184,10 @@ func fleetOperatorStatePriority(kind string) int {
 	case "error":
 		return 0
 	case "dispatch_failure":
+		return 1
+	case "metered_backend":
+		// #838: supervisor LLM disabled + per-token cost burn risk — an error-tone
+		// project outage that must sort near the top of the fleet list.
 		return 1
 	case "stale_worker":
 		return 2
@@ -3593,9 +3619,13 @@ func buildFleetEffectiveConfig(cfg *config.Config) fleetEffectiveConfig {
 			PriceConfigured:  def.Pricing.Configured(),
 			InputUSDPerMtok:  def.Pricing.InputUSDPerMtok,
 			OutputUSDPerMtok: def.Pricing.OutputUSDPerMtok,
+			PricingClass:     strings.TrimSpace(def.PricingClass),
+			Metered:          def.IsMetered(),
 		})
 	}
 	sort.Slice(backends, func(i, j int) bool { return backends[i].Name < backends[j].Name })
+
+	meteredBackend, meteredRefused := cfg.SupervisorMeteredRefusal()
 
 	retention := cfg.SessionRetention
 	return fleetEffectiveConfig{
@@ -3604,9 +3634,10 @@ func buildFleetEffectiveConfig(cfg *config.Config) fleetEffectiveConfig {
 			FallbackBackends: append([]string(nil), cfg.Model.FallbackBackends...),
 			Backends:         backends,
 			Routing: fleetEffectiveRoutingConfig{
-				Mode:            strings.TrimSpace(cfg.Routing.Mode),
-				RouterModel:     strings.TrimSpace(cfg.Routing.RouterModel),
-				RouterModelName: strings.TrimSpace(cfg.Routing.RouterModelName),
+				Mode:                strings.TrimSpace(cfg.Routing.Mode),
+				RouterModel:         strings.TrimSpace(cfg.Routing.RouterModel),
+				RouterModelName:     strings.TrimSpace(cfg.Routing.RouterModelName),
+				AllowMeteredBackend: cfg.Routing.AllowMeteredBackend,
 			},
 		},
 		MaxParallel: cfg.MaxParallel,
@@ -3648,6 +3679,9 @@ func buildFleetEffectiveConfig(cfg *config.Config) fleetEffectiveConfig {
 			ReviewRepairActive:      cfg.Supervisor.ReviewRepair.Active(),
 			ReviewRepairBackend:     cfg.Supervisor.ReviewRepair.EffectiveBackend(),
 			ReviewRepairMaxRetries:  cfg.Supervisor.ReviewRepair.EffectiveMaxRetries(),
+			AllowMeteredBackend:     cfg.Supervisor.AllowMeteredBackend,
+			MeteredBackend:          meteredBackend,
+			MeteredBackendRefused:   meteredRefused,
 		},
 		ApprovalAction: config.SupervisorActionChangeGlobalConfig,
 	}
@@ -4067,6 +4101,12 @@ func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorStat
 	if state, ok := fleetDispatchFailureOperatorState(project); ok {
 		return state
 	}
+	// #838: supervisor LLM path disabled because its backend is metered and the
+	// project has not opted in. Surface as a high-priority red badge — the loop is
+	// running degraded (deterministic-only) and only an operator can restore it.
+	if state, ok := fleetMeteredBackendOperatorState(project); ok {
+		return state
+	}
 	if project.NeedsAttention > 0 {
 		// #598: separate "self-resolving" sessions (retry_exhausted with an
 		// open PR and no failing-check evidence — convergence will auto-merge
@@ -4431,6 +4471,29 @@ func fleetOutcomeHealthState(project fleetProjectState, health string) fleetOper
 		Summary:    fmt.Sprintf("Runtime outcome health is %s for %s.", strings.ReplaceAll(firstNonEmpty(health, outcome.HealthUnknown), "_", " "), goal),
 		NextAction: firstNonEmpty(project.Outcome.NextAction, "Run the configured runtime/deploy healthcheck before dispatching more issue work."),
 	}
+}
+
+// fleetMeteredBackendOperatorState surfaces the #838 metered-backend refusal as
+// a red operator state. The supervisor attaches a StuckSupervisorMeteredBackend
+// stuck state to every deterministic-only cycle it runs while refusing a metered
+// backend, so the presence of that code on the latest decision is the signal.
+func fleetMeteredBackendOperatorState(project fleetProjectState) (fleetOperatorState, bool) {
+	latest := project.Supervisor.Latest
+	if latest == nil {
+		return fleetOperatorState{}, false
+	}
+	stuck, ok := findStuckState(latest.StuckStates, state.StuckSupervisorMeteredBackend)
+	if !ok {
+		return fleetOperatorState{}, false
+	}
+	operator := fleetOperatorState{
+		Kind:       "metered_backend",
+		Tone:       "error",
+		Label:      "Metered backend",
+		Summary:    firstNonEmpty(stuck.Summary, "Supervisor LLM disabled: metered backend without opt-in."),
+		NextAction: firstNonEmpty(stuck.RecommendedAction, "Point supervisor.backend at a flat/subscription backend, or set supervisor.allow_metered_backend: true to accept per-token cost."),
+	}
+	return applyFleetOperatorTarget(project, operator, stuck.Target), true
 }
 
 func fleetOperatorStateFromSupervisor(project fleetProjectState) (fleetOperatorState, bool) {

--- a/internal/server/metered_backend_test.go
+++ b/internal/server/metered_backend_test.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// TestFleetMeteredBackendOperatorState pins #838 AC: a supervisor decision
+// carrying the metered stuck state surfaces as an error-tone, top-priority
+// "Metered backend" operator state on Mission Control.
+func TestFleetMeteredBackendOperatorState(t *testing.T) {
+	now := time.Now().UTC()
+
+	op := buildFleetProjectOperatorState(fleetProjectState{
+		Name: "Dogfood",
+		Repo: "befeast/maestro",
+		Supervisor: supervisorInfo{Latest: &supervisorDecisionInfo{
+			CreatedAt:         now,
+			RecommendedAction: "none",
+			StuckStates: []state.SupervisorStuckState{{
+				Code:              state.StuckSupervisorMeteredBackend,
+				Severity:          "blocked",
+				Summary:           `Supervisor LLM disabled: backend "fireworks" is metered (per-token) and supervisor.allow_metered_backend is not set; running deterministic-only.`,
+				RecommendedAction: "Point supervisor.backend at a flat/subscription backend, or set supervisor.allow_metered_backend: true.",
+			}},
+		}},
+	})
+
+	if op.Kind != "metered_backend" {
+		t.Errorf("Kind = %q, want metered_backend", op.Kind)
+	}
+	if op.Tone != "error" {
+		t.Errorf("Tone = %q, want error", op.Tone)
+	}
+	if op.Label != "Metered backend" {
+		t.Errorf("Label = %q, want \"Metered backend\"", op.Label)
+	}
+	if op.Summary == "" || op.NextAction == "" {
+		t.Errorf("Summary/NextAction must be populated: %+v", op)
+	}
+	if !fleetOperatorKindNeedsAction(op.Kind) {
+		t.Error("metered_backend must be an operator-action kind")
+	}
+	if got := fleetNextActionCTAForProject(op.Kind, op); got != "Fix metered supervisor backend" {
+		t.Errorf("CTA = %q, want \"Fix metered supervisor backend\"", got)
+	}
+	// The kind must escalate the fleet verdict to attention.
+	var summary fleetSummary
+	addFleetOperatorSummary(&summary, op)
+	if summary.MeteredBackend != 1 {
+		t.Fatalf("summary.MeteredBackend = %d, want 1", summary.MeteredBackend)
+	}
+	if tone := fleetVerdictTone(summary, &supervisorDecisionInfo{CreatedAt: now}, now); tone != "attention" {
+		t.Errorf("verdict tone = %q, want attention", tone)
+	}
+}
+
+// TestBuildFleetEffectiveConfig_MeteredOptInVisible pins #838 AC: the supervisor
+// opt-in and the per-backend metered classification are visible in the fleet
+// effective_config surface.
+func TestBuildFleetEffectiveConfig_MeteredOptInVisible(t *testing.T) {
+	cfg := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"claude":    {Cmd: "claude"},
+				"fireworks": {Cmd: "fw", PricingClass: config.PricingClassMetered},
+			},
+		},
+		Supervisor: config.SupervisorConfig{Backend: "fireworks"},
+		Routing:    config.RoutingConfig{Mode: "auto", RouterModel: "claude"},
+	}
+
+	eff := buildFleetEffectiveConfig(cfg)
+	gate := eff.SupervisorGate
+	if gate.AllowMeteredBackend {
+		t.Error("AllowMeteredBackend should be false by default")
+	}
+	if !gate.MeteredBackendRefused || gate.MeteredBackend != "fireworks" {
+		t.Errorf("expected refusal for fireworks, got refused=%v backend=%q", gate.MeteredBackendRefused, gate.MeteredBackend)
+	}
+
+	var fireworks *fleetEffectiveBackendConfig
+	for i := range eff.ModelPolicy.Backends {
+		if eff.ModelPolicy.Backends[i].Name == "fireworks" {
+			fireworks = &eff.ModelPolicy.Backends[i]
+		}
+	}
+	if fireworks == nil || !fireworks.Metered || fireworks.PricingClass != "metered" {
+		t.Fatalf("fireworks backend must surface metered classification: %+v", fireworks)
+	}
+
+	// Opt-in clears the refusal in the surfaced config.
+	cfg.Supervisor.AllowMeteredBackend = true
+	eff = buildFleetEffectiveConfig(cfg)
+	if !eff.SupervisorGate.AllowMeteredBackend || eff.SupervisorGate.MeteredBackendRefused {
+		t.Errorf("opt-in must show allow=true, refused=false: %+v", eff.SupervisorGate)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -867,7 +867,7 @@ func stuckTargetsSession(stuck state.SupervisorStuckState, info sessionInfo) boo
 
 func supervisorStuckNeedsAttention(stuck state.SupervisorStuckState) bool {
 	switch stuck.Code {
-	case "retry_exhausted", "retry_exhausted_open_pr", "dead_running_pid", "stale_worker_logs", "worker_timeout", "failing_checks", "closed_pr_with_active_session", "unmergeable_pr", "stale_review_feedback", "greptile_not_approved", state.StuckPolicyBlocksMerge, state.StuckReviewRepairSpawned, state.StuckReviewRepairExhausted:
+	case "retry_exhausted", "retry_exhausted_open_pr", "dead_running_pid", "stale_worker_logs", "worker_timeout", "failing_checks", "closed_pr_with_active_session", "unmergeable_pr", "stale_review_feedback", "greptile_not_approved", state.StuckPolicyBlocksMerge, state.StuckReviewRepairSpawned, state.StuckReviewRepairExhausted, state.StuckSupervisorMeteredBackend:
 		return true
 	}
 	return stuck.Severity == "blocked"

--- a/internal/server/web/mc/src/fleetApi.js
+++ b/internal/server/web/mc/src/fleetApi.js
@@ -619,7 +619,12 @@ function mapEffectiveConfig(raw) {
       default: String(policy.default || ""),
       fallbackBackends: Array.isArray(policy.fallback_backends) ? policy.fallback_backends.map(String) : [],
       backends: Array.isArray(policy.backends) ? policy.backends.map(mapEffectiveBackend) : [],
-      routing: policy.routing || {},
+      routing: {
+        mode: String((policy.routing || {}).mode || ""),
+        routerModel: String((policy.routing || {}).router_model || ""),
+        routerModelName: String((policy.routing || {}).router_model_name || ""),
+        allowMeteredBackend: (policy.routing || {}).allow_metered_backend === true,
+      },
     },
     maxParallel: Number(raw.max_parallel || 0),
     reviewGate: String(raw.review_gate || ""),
@@ -659,6 +664,9 @@ function mapEffectiveConfig(raw) {
       reviewRepairActive: gate.review_repair_active === true,
       reviewRepairBackend: String(gate.review_repair_backend || ""),
       reviewRepairMaxRetries: Number(gate.review_repair_max_retries || 0),
+      allowMeteredBackend: gate.allow_metered_backend === true,
+      meteredBackendRefused: gate.metered_backend_refused === true,
+      meteredBackend: String(gate.metered_backend || ""),
     },
     approvalAction: String(raw.approval_action || "change_global_config"),
   };
@@ -677,6 +685,8 @@ function mapEffectiveBackend(raw) {
     priceConfigured: raw?.price_configured === true,
     inputUSDPerMtok: Number(raw?.input_usd_per_mtok || 0),
     outputUSDPerMtok: Number(raw?.output_usd_per_mtok || 0),
+    pricingClass: String(raw?.pricing_class || ""),
+    metered: raw?.metered === true,
   };
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -679,6 +679,14 @@ const (
 	// surfaced as evidence. NEVER a silent dead-end (#565).
 	StuckReviewRepairExhausted = "review_repair_exhausted"
 	StuckSearchGuardrailTrip   = "search_guardrail_trip"
+	// StuckSupervisorMeteredBackend is emitted when the supervisor LLM path is
+	// refused because supervisor.backend (or its model.default fallback) resolves
+	// to a metered (per-token) backend and supervisor.allow_metered_backend is not
+	// set (#838). The cycle runs deterministic-only so an always-on loop cannot
+	// silently burn per-token cost; the code surfaces the disabled LLM path as a
+	// red attention badge on Mission Control until the operator re-points the
+	// backend or opts in.
+	StuckSupervisorMeteredBackend = "supervisor_metered_backend"
 	// StuckGuardrailConflict is emitted when the supervisor LLM's
 	// recommendation disagrees with the deterministic guardrail (#689).
 	// The conflict is resolved to the safe side for the cycle (the

--- a/internal/supervisor/metered_backend.go
+++ b/internal/supervisor/metered_backend.go
@@ -1,0 +1,41 @@
+package supervisor
+
+import (
+	"fmt"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// meteredBackendRefused reports whether this engine must skip the supervisor
+// LLM path this cycle because its resolved backend is metered (per-token) and
+// the project has not set supervisor.allow_metered_backend (#838). It only
+// applies when the LLM path would otherwise run: the supervisor is enabled and
+// the fleet-wide emergency LLM stop is not already forcing deterministic-only.
+func (e *Engine) meteredBackendRefused() (backend string, refused bool) {
+	if e == nil || e.cfg == nil {
+		return "", false
+	}
+	if !e.cfg.Supervisor.Enabled || e.emergencyLLMHalt {
+		return "", false
+	}
+	return e.cfg.SupervisorMeteredRefusal()
+}
+
+// meteredBackendStuckState builds the red stuck state surfaced when the
+// supervisor LLM path is refused for a metered backend (#838). Severity=blocked
+// so Mission Control renders it as an attention/red badge, and the evidence
+// points the operator at both remediation paths.
+func meteredBackendStuckState(backend string) state.SupervisorStuckState {
+	return state.SupervisorStuckState{
+		Code:     state.StuckSupervisorMeteredBackend,
+		Severity: SeverityBlocked,
+		Summary:  fmt.Sprintf("Supervisor LLM disabled: backend %q is metered (per-token) and supervisor.allow_metered_backend is not set; running deterministic-only.", backend),
+		Evidence: []string{
+			fmt.Sprintf("Resolved supervisor backend %q is declared pricing_class: metered", backend),
+			"Always-on supervise cycles on a per-token backend burn cost making 'do nothing' decisions (incident 2026-07-09)",
+			"Set supervisor.allow_metered_backend: true to opt in, or point supervisor.backend at a flat/subscription backend",
+		},
+		RecommendedAction: "Point supervisor.backend at a flat/subscription backend, or set supervisor.allow_metered_backend: true to accept per-token cost.",
+		SupervisorCanAct:  false,
+	}
+}

--- a/internal/supervisor/metered_backend_test.go
+++ b/internal/supervisor/metered_backend_test.go
@@ -1,0 +1,97 @@
+package supervisor
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// meteredCfg builds a supervisor config whose resolved backend is metered
+// (per-token). The fakeLLM in testLLMEngine stands in for the backend call, so
+// a non-zero call count means the LLM path ran.
+func meteredCfg(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Model = config.ModelConfig{
+		Default: "claude",
+		Backends: map[string]config.BackendDef{
+			"claude":    {Cmd: "claude"},
+			"fireworks": {Cmd: "fw", PricingClass: config.PricingClassMetered},
+		},
+	}
+	cfg.Supervisor.Backend = "fireworks"
+	return cfg
+}
+
+// TestDecide_MeteredBackend_NoOptIn_SkipsLLM pins the #838 acceptance: a metered
+// supervisor backend without supervisor.allow_metered_backend takes the
+// deterministic-only path (the backend is never called) and the decision
+// carries the red metered stuck state.
+func TestDecide_MeteredBackend_NoOptIn_SkipsLLM(t *testing.T) {
+	cfg := meteredCfg(t)
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
+	llm := validSpawnLLM()
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if llm.calls != 0 {
+		t.Fatalf("LLM calls = %d, want 0 (metered backend without opt-in must skip the LLM path)", llm.calls)
+	}
+	if decision.RecommendedAction == "" {
+		t.Fatal("metered refusal produced no deterministic decision")
+	}
+	stuck := requireStuckState(t, decision, state.StuckSupervisorMeteredBackend)
+	if stuck.Severity != SeverityBlocked {
+		t.Fatalf("metered stuck severity = %q, want %q", stuck.Severity, SeverityBlocked)
+	}
+}
+
+// TestDecide_MeteredBackend_OptIn_RunsLLM proves the opt-in restores the LLM
+// path: with supervisor.allow_metered_backend the backend is called and no
+// metered stuck state is attached.
+func TestDecide_MeteredBackend_OptIn_RunsLLM(t *testing.T) {
+	cfg := meteredCfg(t)
+	cfg.Supervisor.AllowMeteredBackend = true
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
+	llm := validSpawnLLM()
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if llm.calls != 1 {
+		t.Fatalf("LLM calls = %d, want 1 (opt-in must restore the LLM path)", llm.calls)
+	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == state.StuckSupervisorMeteredBackend {
+			t.Fatal("opt-in must not attach the metered stuck state")
+		}
+	}
+}
+
+// TestDecide_FlatBackend_RunsLLM proves a flat/subscription backend is never
+// gated: the LLM path runs and no metered stuck state is attached.
+func TestDecide_FlatBackend_RunsLLM(t *testing.T) {
+	cfg := meteredCfg(t)
+	cfg.Supervisor.Backend = "claude" // flat / unset pricing class
+	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
+	llm := validSpawnLLM()
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if llm.calls != 1 {
+		t.Fatalf("LLM calls = %d, want 1 (flat backend must run the LLM path)", llm.calls)
+	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == state.StuckSupervisorMeteredBackend {
+			t.Fatal("flat backend must not attach the metered stuck state")
+		}
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -472,24 +472,40 @@ func recordOutcomeHealth(cfg *config.Config, st *state.State) {
 func (e *Engine) Decide(st *state.State) (state.SupervisorDecision, error) {
 	var decision state.SupervisorDecision
 	var err error
-	if st.PauseActive() && len(st.ActiveSessions()) == 0 {
+	// #838: refuse the LLM supervisor path when its resolved backend is metered
+	// (per-token) and the project has not opted in. The refusal drops this cycle
+	// to deterministic-only — decideWithLLM (and any supervisor backend call) is
+	// never reached — so a config-store edit re-pointing supervisor.backend at a
+	// per-token model cannot silently burn on always-on "do nothing" cycles.
+	meteredBackend, meteredRefused := e.meteredBackendRefused()
+	paused := st.PauseActive() && len(st.ActiveSessions()) == 0
+	if paused {
 		// Operator pause (#683) with no in-flight work: report the paused
 		// state instead of treating the idle project as a stall or
 		// recommending new work. While a worker is still finishing, normal
 		// decision flow continues so its PR keeps being monitored; the
 		// orchestrator's spawn gate prevents any new worker regardless.
 		decision = e.pausedDecision(st)
-	} else if e.cfg.Supervisor.Enabled && !e.emergencyLLMHalt {
+	} else if e.cfg.Supervisor.Enabled && !e.emergencyLLMHalt && !meteredRefused {
 		// EMERGENCY STOP (#840): when the fleet-wide LLM stop is active the
 		// supervisor drops to deterministic-only — decideWithLLM is never
 		// invoked, so no supervisor backend call is made — while every other
-		// read-only signal (state, GitHub reads, journal) keeps flowing.
+		// read-only signal (state, GitHub reads, journal) keeps flowing. The
+		// metered-backend guard (#838) drops to the same deterministic path.
 		decision, err = e.decideWithLLM(st)
 	} else {
 		decision, err = e.decideDeterministic(st)
 	}
 	if err != nil {
 		return state.SupervisorDecision{}, err
+	}
+	if meteredRefused && !paused {
+		// notify_red-grade: the supervisor is silently running degraded (no LLM
+		// second opinion) until an operator acts, so log it loudly every cycle and
+		// attach the red stuck state so Mission Control surfaces the disabled path.
+		// Suppressed while fully paused — nothing is spending, so it is not a red.
+		log.Printf("[supervisor] REFUSING LLM path: supervisor backend %q is metered (per-token) and supervisor.allow_metered_backend is not set; running deterministic-only this cycle (#838)", meteredBackend)
+		decision.StuckStates = appendStuck(decision.StuckStates, meteredBackendStuckState(meteredBackend))
 	}
 	outcomeStatus := e.outcomeStatus(st)
 	decision.Outcome = &outcomeStatus


### PR DESCRIPTION
Implements #838

## Changes
- **config**: `BackendDef.pricing_class` (`flat|subscription|metered`); unset is treated as `flat` for backward compatibility, so a subscription backend that only configures a `pricing:` table for cost observability (#619) is never gated. Adds `supervisor.allow_metered_backend` and `routing.allow_metered_backend` opt-ins, resolution/refusal helpers, and parse-time validation of the class.
- **supervisor**: refuses the LLM path when the resolved backend is metered and the project has not opted in — runs deterministic-only (no backend call), logs a `notify_red`-grade line, and attaches a red `supervisor_metered_backend` stuck state. Re-evaluated every cycle (the supervise loop reads the current config each `RunOnce`), so a config-store edit re-pointing `supervisor.backend` is caught on the next cycle without a restart. Suppressed while the project is fully paused.
- **router**: same guard on `routing.router_model` in `auto` mode — skips the per-issue LLM call and falls back to `model.default` (`metered_refused` reason).
- **fleet/server**: red "Metered backend" operator badge on Mission Control; exposes the opt-in and current refusal under `effective_config.supervisor_gate`, plus per-backend metered classification; `fleetApi.js` mapping.
- **docs**: pricing-classes and opt-in section in the project setup runbook.

Workers are intentionally NOT gated — they are bounded by `worker_max_tokens` and produce a concrete PR; this guard targets only unbounded always-on loops.

## Testing
- `go test ./...` (full suite green)
- `go build ./cmd/maestro/`
- New unit tests: config truth table + backward-compat + parse validation; supervisor metered+no-opt-in → deterministic / opt-in → LLM / flat → LLM; router refusal + opt-in; fleet operator badge + `effective_config` visibility.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a metered-backend guard for always-on LLM loops. The main changes are:

- Adds `pricing_class` to model backends with validation for `flat`, `subscription`, and `metered`.
- Adds supervisor and router opt-ins for running loop LLM calls on metered backends.
- Makes the supervisor run deterministic-only when its resolved backend is metered without opt-in.
- Makes auto-routing skip the router LLM call and fall back to `model.default` when `routing.router_model` is metered without opt-in.
- Surfaces metered backend state and opt-in status through Mission Control and the fleet API.
- Documents pricing classes, opt-in behavior, and worker exclusion from the guard.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The guard is centralized in config helpers, runs before supervisor/router LLM dispatch, and keeps unset `pricing_class` backward-compatible. The changed paths include focused tests for config parsing, supervisor behavior, router behavior, and fleet visibility.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification as part of general contract validation and noted that local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds `pricing_class` parsing and validation plus supervisor/router `allow_metered_backend` config fields. |
| internal/config/metered_backend.go | Adds shared helpers for resolving supervisor/router backends and detecting metered refusals. |
| internal/supervisor/supervisor.go | Wires metered refusal into `Decide` so non-paused cycles skip the LLM path and attach the stuck state. |
| internal/supervisor/metered_backend.go | Builds supervisor-specific metered refusal checks and the red stuck state. |
| internal/router/resolve.go | Adds `metered_refused` routing reason and deterministic fallback before router LLM dispatch. |
| internal/server/fleet.go | Surfaces metered backend state in fleet summaries, effective config, operator badges, priorities, and CTAs. |
| internal/server/web/mc/src/fleetApi.js | Maps new effective config fields for pricing class, metered flags, and supervisor/router opt-ins. |
| docs/project-setup-runbook.md | Documents pricing classes, opt-ins, refusal behavior, and why workers are excluded from the guard. |

<sub>Reviews (1): Last reviewed commit: ["safety: refuse metered (per-token) backe..."](https://github.com/befeast/maestro/commit/bf2deab7083829874ef004d2db6b91bec0d01917) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43044843)</sub>

<!-- /greptile_comment -->