### PR TITLE
config: fleet-level settings layer + CLI/UI for cost-control knobs (supervisor.enabled, backends, budgets) (#839)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -60,6 +60,7 @@ Commands:
   kill          Kill a worker session by slot name
   import        Seed state from existing worktrees
   config-store  Manage the SQLite config store (migrate/export/add/rm/edit)
+  settings      Fleet-level cost-control knobs (list/get/set, fleet-wide or per-project)
   history       Show recently completed sessions
   digest        Write the morning operator digest across all fleet projects
   cleanup       Remove worktrees for all completed/dead sessions
@@ -356,6 +357,8 @@ func main() {
 		importCmd(args)
 	case "config-store":
 		configStoreCmd(args)
+	case "settings":
+		settingsCmd(args)
 	case "history":
 		historyCmd(args)
 	case "digest":

--- a/cmd/maestro/settings.go
+++ b/cmd/maestro/settings.go
@@ -1,0 +1,251 @@
+package main
+
+// `maestro settings` — the operator surface for fleet-level cost-control knobs
+// (#839). Before this, flipping e.g. `supervisor.enabled=false` fleet-wide meant
+// exporting, editing and re-importing every project row (the 2026-07-09 P0
+// mitigation did exactly that under incident pressure). `settings set` writes
+// the config store directly — fleet-wide by default, or per-project with
+// --project — so a `maestro daemon --watch-store` picks the change up on its
+// next poll without a restart, and every change is journaled (who/when/old→new).
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/befeast/maestro/internal/configstore"
+)
+
+func settingsCmd(args []string) {
+	if len(args) == 0 {
+		settingsUsage()
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "list", "ls":
+		settingsList(args[1:])
+	case "get":
+		settingsGet(args[1:])
+	case "set":
+		settingsSet(args[1:])
+	case "audit", "log":
+		settingsAudit(args[1:])
+	case "-h", "--help", "help":
+		settingsUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown settings command: %s\n\n", args[0])
+		settingsUsage()
+		os.Exit(1)
+	}
+}
+
+func settingsUsage() {
+	fmt.Fprintln(os.Stderr, "usage: maestro settings <list|get|set|audit> [flags]")
+	fmt.Fprintln(os.Stderr, "  list [--project <row>]           show effective values (per project) or fleet defaults")
+	fmt.Fprintln(os.Stderr, "  list --keys                      list supported keys and their meaning")
+	fmt.Fprintln(os.Stderr, "  get <key> [--project <row>]      print one key's value (resolved when --project)")
+	fmt.Fprintln(os.Stderr, "  set <key>=<value> [--project <row>] [--actor <who>]   set a fleet default or per-project override")
+	fmt.Fprintln(os.Stderr, "  set <key>= [--unset]             clear a fleet default (revert to built-in)")
+	fmt.Fprintln(os.Stderr, "  audit [--limit N]                show the settings change journal")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Precedence: per-project override > fleet default > built-in.")
+}
+
+// defaultSettingsActor derives the audit actor string when --actor is omitted:
+// the invoking user, falling back to "cli".
+func defaultSettingsActor() string {
+	if u := strings.TrimSpace(os.Getenv("USER")); u != "" {
+		return u + " (cli)"
+	}
+	return "cli"
+}
+
+func openSettingsStore(dbPath string) *configstore.Store {
+	store, err := configstore.Open(dbPath)
+	if err != nil {
+		log.Fatalf("settings: open db: %v", err)
+	}
+	return store
+}
+
+func settingsList(args []string) {
+	fs := flag.NewFlagSet("settings list", flag.ExitOnError)
+	dbPath := configStoreDBFlag(fs)
+	project := fs.String("project", "", "Project row to resolve (omit for fleet defaults)")
+	keys := fs.Bool("keys", false, "List supported keys and their meaning, then exit")
+	fs.Parse(args)
+
+	if *keys {
+		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "KEY\tTYPE\tDESCRIPTION")
+		for _, spec := range configstore.SettingSpecs() {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", spec.Name, spec.TypeName(), spec.Doc)
+		}
+		w.Flush()
+		return
+	}
+
+	store := openSettingsStore(*dbPath)
+	defer store.Close()
+	ctx := context.Background()
+
+	if strings.TrimSpace(*project) != "" {
+		resolved, err := store.ResolveProjectSettings(ctx, *project)
+		if err != nil {
+			log.Fatalf("settings list: %v", err)
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintf(w, "KEY\tVALUE\tSOURCE\n")
+		for _, r := range resolved {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", r.Key, r.Value, r.Source)
+		}
+		w.Flush()
+		return
+	}
+
+	// No project: show fleet-level defaults (unset keys render as "(unset)").
+	fleet, err := store.FleetSettings(ctx)
+	if err != nil {
+		log.Fatalf("settings list: %v", err)
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintf(w, "KEY\tFLEET DEFAULT\n")
+	for _, spec := range configstore.SettingSpecs() {
+		val, ok := fleet[spec.Name]
+		if !ok {
+			val = "(unset)"
+		}
+		fmt.Fprintf(w, "%s\t%s\n", spec.Name, val)
+	}
+	w.Flush()
+}
+
+func settingsGet(args []string) {
+	fs := flag.NewFlagSet("settings get", flag.ExitOnError)
+	dbPath := configStoreDBFlag(fs)
+	project := fs.String("project", "", "Project row to resolve (omit for the fleet default)")
+	fs.Parse(args)
+
+	rest := fs.Args()
+	if len(rest) != 1 || strings.TrimSpace(rest[0]) == "" {
+		log.Fatalf("settings get: exactly one key is required")
+	}
+	key := strings.TrimSpace(rest[0])
+	store := openSettingsStore(*dbPath)
+	defer store.Close()
+	ctx := context.Background()
+
+	if strings.TrimSpace(*project) != "" {
+		resolved, err := store.ResolveProjectSettings(ctx, *project)
+		if err != nil {
+			log.Fatalf("settings get: %v", err)
+		}
+		for _, r := range resolved {
+			if r.Key == key {
+				fmt.Printf("%s\t%s\n", r.Value, r.Source)
+				return
+			}
+		}
+		log.Fatalf("settings get: unknown key %q", key)
+	}
+
+	val, ok, err := store.FleetSetting(ctx, key)
+	if err != nil {
+		log.Fatalf("settings get: %v", err)
+	}
+	if !ok {
+		fmt.Println("(unset)")
+		return
+	}
+	fmt.Println(val)
+}
+
+func settingsSet(args []string) {
+	fs := flag.NewFlagSet("settings set", flag.ExitOnError)
+	dbPath := configStoreDBFlag(fs)
+	project := fs.String("project", "", "Project row to override (omit to set the fleet default)")
+	actor := fs.String("actor", "", "Actor recorded in the audit trail (default: $USER (cli))")
+	unset := fs.Bool("unset", false, "Clear the fleet default for the key (revert to built-in)")
+	fs.Parse(args)
+
+	rest := fs.Args()
+	if len(rest) != 1 || strings.TrimSpace(rest[0]) == "" {
+		log.Fatalf("settings set: exactly one key=value (or key= with --unset) is required")
+	}
+	key, value := parseSettingAssignment(rest[0])
+	who := strings.TrimSpace(*actor)
+	if who == "" {
+		who = defaultSettingsActor()
+	}
+	store := openSettingsStore(*dbPath)
+	defer store.Close()
+	ctx := context.Background()
+
+	if *unset {
+		if strings.TrimSpace(*project) != "" {
+			log.Fatalf("settings set: --unset applies to fleet defaults only (a project override lives in its row)")
+		}
+		if err := store.DeleteFleetSetting(ctx, key, who); err != nil {
+			log.Fatalf("settings set: %v", err)
+		}
+		fmt.Printf("Cleared fleet default %q (projects without an override revert to built-in).\n", key)
+		return
+	}
+
+	if strings.TrimSpace(*project) != "" {
+		if err := store.SetProjectSetting(ctx, *project, key, value, who); err != nil {
+			log.Fatalf("settings set: %v", err)
+		}
+		fmt.Printf("Set %s=%s on project %q (overrides the fleet default).\n", key, value, *project)
+		return
+	}
+	if err := store.SetFleetSetting(ctx, key, value, who); err != nil {
+		log.Fatalf("settings set: %v", err)
+	}
+	fmt.Printf("Set fleet default %s=%s (applies to every project without its own override; hot-reloads next cycle).\n", key, value)
+}
+
+// parseSettingAssignment splits a "key=value" argument. A bare "key" (no '=')
+// is treated as key with an empty value so `set --unset key` reads naturally.
+func parseSettingAssignment(arg string) (string, string) {
+	if i := strings.IndexByte(arg, '='); i >= 0 {
+		return strings.TrimSpace(arg[:i]), strings.TrimSpace(arg[i+1:])
+	}
+	return strings.TrimSpace(arg), ""
+}
+
+func settingsAudit(args []string) {
+	fs := flag.NewFlagSet("settings audit", flag.ExitOnError)
+	dbPath := configStoreDBFlag(fs)
+	limit := fs.Int("limit", 50, "Max number of journal rows to show (0 = all)")
+	fs.Parse(args)
+
+	store := openSettingsStore(*dbPath)
+	defer store.Close()
+	records, err := store.SettingsAudit(context.Background(), *limit)
+	if err != nil {
+		log.Fatalf("settings audit: %v", err)
+	}
+	if len(records) == 0 {
+		fmt.Println("No settings changes recorded.")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "WHEN\tSCOPE\tKEY\tOLD\tNEW\tACTOR")
+	for _, r := range records {
+		old := r.OldValue
+		if old == "" {
+			old = "-"
+		}
+		next := r.NewValue
+		if next == "" {
+			next = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", r.At, r.Scope, r.Key, old, next, r.Actor)
+	}
+	w.Flush()
+}

--- a/cmd/maestro/settings_test.go
+++ b/cmd/maestro/settings_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func TestParseSettingAssignment(t *testing.T) {
+	cases := []struct {
+		arg       string
+		wantKey   string
+		wantValue string
+	}{
+		{"supervisor.enabled=false", "supervisor.enabled", "false"},
+		{"worker_max_tokens=400000", "worker_max_tokens", "400000"},
+		{"  supervisor.backend = claude ", "supervisor.backend", "claude"},
+		{"supervisor.enabled=", "supervisor.enabled", ""}, // clear form
+		{"supervisor.enabled", "supervisor.enabled", ""},  // bare key (used with --unset)
+		{"key=a=b", "key", "a=b"},                         // only the first '=' splits
+	}
+	for _, c := range cases {
+		k, v := parseSettingAssignment(c.arg)
+		if k != c.wantKey || v != c.wantValue {
+			t.Errorf("parseSettingAssignment(%q) = (%q, %q), want (%q, %q)", c.arg, k, v, c.wantKey, c.wantValue)
+		}
+	}
+}
+
+func TestDefaultSettingsActor(t *testing.T) {
+	t.Setenv("USER", "alice")
+	if got := defaultSettingsActor(); got != "alice (cli)" {
+		t.Errorf("defaultSettingsActor() = %q, want \"alice (cli)\"", got)
+	}
+	t.Setenv("USER", "")
+	if got := defaultSettingsActor(); got != "cli" {
+		t.Errorf("defaultSettingsActor() with empty USER = %q, want \"cli\"", got)
+	}
+}

--- a/docs/fleet-settings-runbook.md
+++ b/docs/fleet-settings-runbook.md
@@ -113,8 +113,25 @@ files, so the builtin/fleet/project distinction survives a round-trip.
 ## Mission Control
 
 Mission Control surfaces `effective_config.cost_controls` per project, flagging
-each knob's source. Writing settings from the dashboard is a
-`change_global_config`-class action and is gated through the cautious approval
-flow — the same gate that guards other global-config changes — so a dashboard
-flip requires an approval, while the CLI (an operator on the host) writes
-directly.
+each knob's source (`builtin` / `fleet` / `project`).
+
+Writing settings from the dashboard goes through `POST /api/v1/fleet/settings`:
+
+```
+POST /api/v1/fleet/settings
+{ "key": "supervisor.enabled", "value": "false", "reason": "idle burn" }   # fleet default
+{ "key": "worker_max_tokens", "value": "400000", "project": "<row>" }       # per-project override
+{ "key": "supervisor.enabled", "unset": true }                             # clear a fleet default
+```
+
+The endpoint is gated like the other mutating config surfaces
+(`change_global_config`-class): auth fires first (401 when unauthenticated),
+the read-only posture rejects it (403), a bad key/value is a 400, and every
+accepted write is journaled in `settings_audit` with the authenticated actor.
+It requires the daemon config store (`maestro daemon --watch-store`); under
+`serve --fleet` it returns 501. The CLI (an operator on the host) writes the
+store directly.
+
+> The dashboard **SPA control** that drives this endpoint is a follow-up; today
+> the read side (per-project provenance) renders and the write endpoint is live
+> for API clients.

--- a/docs/fleet-settings-runbook.md
+++ b/docs/fleet-settings-runbook.md
@@ -1,0 +1,120 @@
+# Fleet Settings — cost-control knobs, fleet-wide or per-project
+
+**Turn the LLM supervisor off on idle projects with one command, without editing
+nine YAML rows.** The 2026-07-09 token-burn incident's P0 mitigation ("turn off
+the LLM supervisor on idle projects") took a scripted export → edit → re-import
+cycle across five project rows. `maestro settings` collapses that into a single
+write, applied fleet-wide or to one project, that hot-reloads on the next cycle
+and is journaled for attribution.
+
+This runbook is safe for shared docs: it uses placeholders for local paths and
+never requires printing tokens, environment variables, or raw config.
+
+## The knobs
+
+These cost/LLM controls used to live only as per-project fields in each config
+row. They are now *fleet-settable* — a fleet-level default the projects inherit:
+
+| Key | Type | Meaning |
+|---|---|---|
+| `supervisor.enabled` | bool | LLM supervisor on/off |
+| `supervisor.backend` | string | supervisor LLM backend name |
+| `supervisor.model` | string | supervisor LLM model |
+| `supervisor.effort` | string | supervisor LLM effort (low/medium/high/xhigh) |
+| `supervisor.allow_metered_backend` | bool | opt the supervisor LLM loop into a metered (per-token) backend (#838) |
+| `supervisor.always_consult_llm` | bool | always call the LLM even on safe deterministic decisions (pre-#837) |
+| `poll_interval_seconds` | int | supervisor/orchestrator poll interval override (0 = use CLI flag) |
+| `worker_max_tokens` | int | kill a worker over this token threshold (0 = unlimited) |
+
+`maestro settings list --keys` prints this table from the running binary.
+
+## Precedence
+
+A knob's effective value is resolved with a strict, three-layer precedence:
+
+```
+per-project value  >  fleet default  >  built-in (config default)
+```
+
+- A **per-project value** is a key set in that project's config row. It always
+  wins — a fleet default never overrides a project that spelled the key out.
+- A **fleet default** (the `settings` table in the config store) applies to
+  every project that does *not* set the key itself.
+- The **built-in** is the value `config.parse` uses when neither layer sets it.
+
+The fleet API's `effective_config.cost_controls` reports each knob's resolved
+value **and its source** (`builtin` / `fleet` / `project`), so Mission Control
+can highlight non-default overrides.
+
+## Flip a knob fleet-wide
+
+```
+# Turn the LLM supervisor OFF for every project that hasn't set it itself:
+maestro settings set supervisor.enabled=false
+
+# Bound worker token spend fleet-wide:
+maestro settings set worker_max_tokens=400000
+
+# Clear a fleet default (projects without an override revert to built-in):
+maestro settings set supervisor.enabled= --unset
+```
+
+The write lands in the config store (`~/.maestro/config.db` by default; pass
+`--db <path>` to target another). A running `maestro daemon --watch-store`
+picks it up **on its next poll, without a restart** — a fleet default change
+advances every store-backed project's fingerprint, so all flows reload.
+
+## Flip a knob for one project
+
+```
+# Override just this project (beats the fleet default going forward):
+maestro settings set --project <row> supervisor.enabled=true
+```
+
+A per-project override is written into that project's config row, so it survives
+export/import and shows as `source: project` in the effective config.
+
+## See what's effective
+
+```
+# Fleet-level defaults (unset keys show "(unset)"):
+maestro settings list
+
+# One project's effective values with provenance:
+maestro settings list --project <row>
+
+# A single key:
+maestro settings get supervisor.enabled --project <row>
+```
+
+## Attribution (audit trail)
+
+Every change — fleet or per-project — is journaled in the config store with the
+key, scope (`fleet` or the project name), old→new values, an actor string, and
+an RFC3339 timestamp. The 06:56 backend flip in the 2026-07-09 incident was only
+attributable via DB-backup diffing and journalctl archaeology; now it is one
+query:
+
+```
+maestro settings audit            # most-recent first
+maestro settings audit --limit 0  # the whole journal
+```
+
+Pass `--actor <who>` on a `set` to record who made the change; it defaults to
+`$USER (cli)`.
+
+## Round-trip / backup
+
+`maestro config-store export` writes the fleet-settings layer to a standalone
+`_fleet-settings.yaml` alongside the per-project rows, and `config-store
+migrate` (import) restores it. The layer is *not* baked into the per-project
+files, so the builtin/fleet/project distinction survives a round-trip.
+
+## Mission Control
+
+Mission Control surfaces `effective_config.cost_controls` per project, flagging
+each knob's source. Writing settings from the dashboard is a
+`change_global_config`-class action and is gated through the cautious approval
+flow — the same gate that guards other global-config changes — so a dashboard
+flip requires an approval, while the CLI (an operator on the host) writes
+directly.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1451,6 +1451,14 @@ type Config struct {
 	StaleSessionReconciler          StaleSessionReconcilerConfig `yaml:"stale_session_reconciler"` // filter stale supervisor sessions from operator attention
 	SessionRetention                SessionRetentionConfig       `yaml:"session_retention"`        // #497: bound state.Sessions growth via terminal-session compaction
 	SourcePath                      string                       `yaml:"-"`                        // path the config was loaded from (not serialized)
+
+	// SettingSources records, for each fleet-settable cost-control knob
+	// (#839), where its effective value came from: "project" (row YAML),
+	// "fleet" (fleet-level default overlaid at load), or "builtin" (neither
+	// set; config.parse default). Populated only by the config store's Load;
+	// nil for file-loaded configs (which have no fleet layer). Surfaced on
+	// effective_config so Mission Control can flag non-default overrides.
+	SettingSources map[string]string `yaml:"-" json:"-"`
 }
 
 // LoadFrom loads config from a specific path.

--- a/internal/configstore/settings.go
+++ b/internal/configstore/settings.go
@@ -125,6 +125,27 @@ func lookupSpec(name string) (SettingSpec, bool) {
 	return SettingSpec{}, false
 }
 
+// SettingKeyValid reports whether key names a known fleet setting (its value is
+// not checked). Lets an API layer reject an unknown key with 400 before a store
+// write.
+func SettingKeyValid(key string) bool {
+	_, ok := lookupSpec(key)
+	return ok
+}
+
+// ValidateSetting reports whether key is known and rawValue is acceptable for
+// its type, WITHOUT writing anything — the read-only pre-check an HTTP handler
+// runs so a bad key/value returns 400 (client error) while a later store write
+// failure is treated as 500 (infrastructure), mirroring the project-CRUD path.
+func ValidateSetting(key, rawValue string) error {
+	spec, ok := lookupSpec(key)
+	if !ok {
+		return fmt.Errorf("unknown setting %q", key)
+	}
+	_, err := canonicalizeSettingValue(spec, rawValue)
+	return err
+}
+
 // canonicalizeSettingValue validates raw against the key's type and returns the
 // canonical stored form ("true"/"false", a base-10 int, or the trimmed string).
 // A per-type parse keeps a `settings set poll_interval_seconds=banana` from

--- a/internal/configstore/settings.go
+++ b/internal/configstore/settings.go
@@ -1,0 +1,594 @@
+package configstore
+
+// Fleet-level settings layer (#839).
+//
+// Cost-control knobs (supervisor.enabled, supervisor.backend/model/effort,
+// poll_interval_seconds, worker_max_tokens, …) live per-project in each row's
+// config YAML. Before this layer, flipping one fleet-wide meant exporting,
+// editing and re-importing every project row (the 2026-07-09 P0 mitigation did
+// exactly that for 5 rows). This file adds a fleet-level DEFAULT layer plus an
+// audit trail, resolved with a strict precedence:
+//
+//	per-project value  >  fleet default  >  built-in (config.parse default)
+//
+// A fleet default is stored in the `settings` table and OVERLAID onto a
+// project's YAML at Load time only for keys the project does not set itself, so
+// a project override always wins. Every change (fleet or per-project) is
+// journaled in `settings_audit` with actor + RFC3339 timestamp and old→new
+// values, so a backend flip is attributable without DB-backup archaeology.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// SettingsSchema creates the fleet-settings tables. Kept separate from the
+// core Schema string only for readability; Init runs both so a store opened
+// against an older config.db migrates forward automatically (IF NOT EXISTS).
+const SettingsSchema = `
+CREATE TABLE IF NOT EXISTS settings (
+	key        TEXT PRIMARY KEY,
+	value      TEXT NOT NULL,
+	updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS settings_audit (
+	id         INTEGER PRIMARY KEY AUTOINCREMENT,
+	key        TEXT NOT NULL,
+	scope      TEXT NOT NULL,
+	old_value  TEXT NOT NULL,
+	new_value  TEXT NOT NULL,
+	actor      TEXT NOT NULL,
+	at         TEXT NOT NULL
+);
+`
+
+// FleetScope is the audit scope recorded for a fleet-wide default change. A
+// per-project override records the project name as its scope.
+const FleetScope = "fleet"
+
+// Setting sources reported in effective_config (#839 acceptance criterion 2).
+const (
+	SourceBuiltin = "builtin"
+	SourceFleet   = "fleet"
+	SourceProject = "project"
+)
+
+type settingType int
+
+const (
+	settingBool settingType = iota
+	settingInt
+	settingString
+)
+
+// SettingSpec is one supported cost-control knob: its dotted CLI name, the YAML
+// path it maps to in a project config, and its value type (used to validate a
+// `settings set` and to build the overlay scalar node with the right tag).
+type SettingSpec struct {
+	Name string
+	Path []string
+	Type settingType
+	Doc  string
+}
+
+// settingSpecs is the canonical registry of fleet-settable cost-control knobs.
+// Keep this in sync with the config fields the paths reference; a path that no
+// longer exists in config.Config would silently overlay a dead key.
+var settingSpecs = []SettingSpec{
+	{"supervisor.enabled", []string{"supervisor", "enabled"}, settingBool, "LLM supervisor on/off"},
+	{"supervisor.backend", []string{"supervisor", "backend"}, settingString, "supervisor LLM backend name"},
+	{"supervisor.model", []string{"supervisor", "model"}, settingString, "supervisor LLM model"},
+	{"supervisor.effort", []string{"supervisor", "effort"}, settingString, "supervisor LLM effort (low|medium|high|xhigh)"},
+	{"supervisor.allow_metered_backend", []string{"supervisor", "allow_metered_backend"}, settingBool, "opt the supervisor LLM loop into a metered (per-token) backend (#838)"},
+	{"supervisor.always_consult_llm", []string{"supervisor", "always_consult_llm"}, settingBool, "always call the LLM even on safe deterministic decisions (pre-#837)"},
+	{"poll_interval_seconds", []string{"poll_interval_seconds"}, settingInt, "supervisor/orchestrator poll interval override (0 = use CLI flag)"},
+	{"worker_max_tokens", []string{"worker_max_tokens"}, settingInt, "kill a worker over this token threshold (0 = unlimited)"},
+}
+
+// SettingSpecs returns the supported-key registry (name + doc), sorted by name.
+// Exposed so the CLI can print an accurate usage/list of valid keys.
+func SettingSpecs() []SettingSpec {
+	out := append([]SettingSpec(nil), settingSpecs...)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// TypeName returns a human-readable type label for the key ("bool"/"int"/
+// "string"), used by `maestro settings list --keys`.
+func (spec SettingSpec) TypeName() string {
+	switch spec.Type {
+	case settingBool:
+		return "bool"
+	case settingInt:
+		return "int"
+	default:
+		return "string"
+	}
+}
+
+func lookupSpec(name string) (SettingSpec, bool) {
+	for _, spec := range settingSpecs {
+		if spec.Name == name {
+			return spec, true
+		}
+	}
+	return SettingSpec{}, false
+}
+
+// canonicalizeSettingValue validates raw against the key's type and returns the
+// canonical stored form ("true"/"false", a base-10 int, or the trimmed string).
+// A per-type parse keeps a `settings set poll_interval_seconds=banana` from
+// landing an un-parseable value that would later break config.parse for every
+// project.
+func canonicalizeSettingValue(spec SettingSpec, raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	switch spec.Type {
+	case settingBool:
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return "", fmt.Errorf("setting %q wants a boolean (true|false), got %q", spec.Name, raw)
+		}
+		return strconv.FormatBool(b), nil
+	case settingInt:
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return "", fmt.Errorf("setting %q wants an integer, got %q", spec.Name, raw)
+		}
+		return strconv.Itoa(n), nil
+	default:
+		if raw == "" {
+			return "", fmt.Errorf("setting %q wants a non-empty string value", spec.Name)
+		}
+		return raw, nil
+	}
+}
+
+// scalarNode builds the YAML scalar for a canonical value with the tag matching
+// the key type, so an overlaid `worker_max_tokens: 400000` re-encodes as an int
+// (not a quoted string) and parses back cleanly.
+func (spec SettingSpec) scalarNode(value string) *yaml.Node {
+	tag := "!!str"
+	switch spec.Type {
+	case settingBool:
+		tag = "!!bool"
+	case settingInt:
+		tag = "!!int"
+	}
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: tag, Value: value}
+}
+
+// SetFleetSetting writes (or clears, when value is empty and the key already
+// exists) a fleet-level default and journals the change. actor is recorded
+// verbatim. The write advances the settings fingerprint so every store-backed
+// flow hot-reloads on its next poll without a restart (#839 AC1).
+func (s *Store) SetFleetSetting(ctx context.Context, key, rawValue, actor string) error {
+	spec, ok := lookupSpec(key)
+	if !ok {
+		return fmt.Errorf("unknown setting %q (see `maestro settings list --keys`)", key)
+	}
+	canon, err := canonicalizeSettingValue(spec, rawValue)
+	if err != nil {
+		return err
+	}
+	old, _, err := s.FleetSetting(ctx, key)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339Nano) // nano: see ProjectsFingerprint (#757)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO settings(key, value, updated_at)
+VALUES(?, ?, ?)
+ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+`, key, canon, nowStr); err != nil {
+		return err
+	}
+	if err := insertAuditTx(ctx, tx, key, FleetScope, old, canon, actor, now); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// DeleteFleetSetting removes a fleet-level default (reverting affected projects
+// to the built-in value) and journals the removal.
+func (s *Store) DeleteFleetSetting(ctx context.Context, key, actor string) error {
+	if _, ok := lookupSpec(key); !ok {
+		return fmt.Errorf("unknown setting %q", key)
+	}
+	old, present, err := s.FleetSetting(ctx, key)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return nil // idempotent: nothing to delete
+	}
+	now := time.Now().UTC()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM settings WHERE key = ?`, key); err != nil {
+		return err
+	}
+	if err := insertAuditTx(ctx, tx, key, FleetScope, old, "", actor, now); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// SetProjectSetting writes a per-project override into the project's config YAML
+// (the value that beats the fleet default) and journals it under the project's
+// scope. Advancing the project row's updated_at hot-reloads that flow.
+func (s *Store) SetProjectSetting(ctx context.Context, project, key, rawValue, actor string) error {
+	spec, ok := lookupSpec(key)
+	if !ok {
+		return fmt.Errorf("unknown setting %q (see `maestro settings list --keys`)", key)
+	}
+	canon, err := canonicalizeSettingValue(spec, rawValue)
+	if err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var projectYAML string
+	err = tx.QueryRowContext(ctx, `SELECT config_yaml FROM project WHERE name = ?`, project).Scan(&projectYAML)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("project %q not found in config store", project)
+	}
+	if err != nil {
+		return err
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(projectYAML), &root); err != nil {
+		return err
+	}
+	old := scalarAtPath(&root, spec.Path)
+	setSettingPath(&root, spec.Path, spec.scalarNode(canon))
+	updated, err := marshalNode(&root)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339Nano)
+	if _, err := tx.ExecContext(ctx, `UPDATE project SET config_yaml = ?, updated_at = ? WHERE name = ?`, string(updated), nowStr, project); err != nil {
+		return err
+	}
+	if err := insertAuditTx(ctx, tx, key, project, old, canon, actor, now); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func insertAuditTx(ctx context.Context, tx *sql.Tx, key, scope, old, next, actor string, at time.Time) error {
+	_, err := tx.ExecContext(ctx, `
+INSERT INTO settings_audit(key, scope, old_value, new_value, actor, at)
+VALUES(?, ?, ?, ?, ?, ?)
+`, key, scope, old, next, strings.TrimSpace(actor), at.Format(time.RFC3339))
+	return err
+}
+
+// FleetSetting returns the fleet-level value for key and whether it is set.
+func (s *Store) FleetSetting(ctx context.Context, key string) (string, bool, error) {
+	var value string
+	err := s.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return value, true, nil
+}
+
+// FleetSettings returns every fleet-level default (key → canonical value).
+func (s *Store) FleetSettings(ctx context.Context) (map[string]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT key, value FROM settings`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, err
+		}
+		out[key] = value
+	}
+	return out, rows.Err()
+}
+
+// settingsFingerprint returns the newest updated_at across the settings table,
+// or the zero time when no fleet default is set. ProjectsFingerprint folds this
+// into every project's timestamp so a fleet default change advances all
+// store-backed flows' watchers, hot-reloading them without a restart (#839).
+func (s *Store) settingsFingerprint(ctx context.Context) (time.Time, error) {
+	var updatedAt sql.NullString
+	err := s.db.QueryRowContext(ctx, `SELECT MAX(updated_at) FROM settings`).Scan(&updatedAt)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !updatedAt.Valid || updatedAt.String == "" {
+		return time.Time{}, nil
+	}
+	ts, err := time.Parse(time.RFC3339Nano, updatedAt.String)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse settings updated_at: %w", err)
+	}
+	return ts, nil
+}
+
+// AuditRecord is one journaled settings change (#839 AC4).
+type AuditRecord struct {
+	Key      string
+	Scope    string
+	OldValue string
+	NewValue string
+	Actor    string
+	At       string // RFC3339
+}
+
+// SettingsAudit returns the change journal, most recent first. limit <= 0
+// returns the whole journal.
+func (s *Store) SettingsAudit(ctx context.Context, limit int) ([]AuditRecord, error) {
+	query := `SELECT key, scope, old_value, new_value, actor, at FROM settings_audit ORDER BY id DESC`
+	args := []any{}
+	if limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AuditRecord
+	for rows.Next() {
+		var r AuditRecord
+		if err := rows.Scan(&r.Key, &r.Scope, &r.OldValue, &r.NewValue, &r.Actor, &r.At); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ResolvedSetting is a key's effective value in a project plus where it came
+// from (project override / fleet default / built-in).
+type ResolvedSetting struct {
+	Key    string
+	Value  string
+	Source string
+}
+
+// ResolveProjectSettings returns every cost-control knob's effective value and
+// source for one project, applying the project > fleet > builtin precedence.
+func (s *Store) ResolveProjectSettings(ctx context.Context, project string) ([]ResolvedSetting, error) {
+	cfg, err := s.Load(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	var projectYAML string
+	err = s.db.QueryRowContext(ctx, `SELECT config_yaml FROM project WHERE name = ?`, project).Scan(&projectYAML)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("project %q not found in config store", project)
+	}
+	if err != nil {
+		return nil, err
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(projectYAML), &root); err != nil {
+		return nil, err
+	}
+	fleet, err := s.FleetSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ResolvedSetting, 0, len(settingSpecs))
+	for _, spec := range SettingSpecs() {
+		source := SourceBuiltin
+		if settingPresent(&root, spec.Path) {
+			source = SourceProject
+		} else if _, ok := fleet[spec.Name]; ok {
+			source = SourceFleet
+		}
+		out = append(out, ResolvedSetting{
+			Key:    spec.Name,
+			Value:  settingValueFromConfig(cfg, spec.Name),
+			Source: source,
+		})
+	}
+	return out, nil
+}
+
+// CostControlValues returns each fleet-settable knob's effective (post-overlay)
+// value read off a resolved config, keyed by setting name. Paired with
+// config.Config.SettingSources, it lets the fleet API render effective_config's
+// cost-control block with both value and provenance (#839 AC2).
+func CostControlValues(cfg *config.Config) map[string]string {
+	if cfg == nil {
+		return nil
+	}
+	out := make(map[string]string, len(settingSpecs))
+	for _, spec := range settingSpecs {
+		out[spec.Name] = settingValueFromConfig(cfg, spec.Name)
+	}
+	return out
+}
+
+// settingValueFromConfig reads a knob's effective (post-overlay) value off a
+// resolved config. Switch is exhaustive over settingSpecs — a new spec needs a
+// case here so the CLI/API report its value.
+func settingValueFromConfig(cfg *config.Config, key string) string {
+	switch key {
+	case "supervisor.enabled":
+		return strconv.FormatBool(cfg.Supervisor.Enabled)
+	case "supervisor.backend":
+		return strings.TrimSpace(cfg.Supervisor.Backend)
+	case "supervisor.model":
+		return strings.TrimSpace(cfg.Supervisor.Model)
+	case "supervisor.effort":
+		return strings.TrimSpace(cfg.Supervisor.Effort)
+	case "supervisor.allow_metered_backend":
+		return strconv.FormatBool(cfg.Supervisor.AllowMeteredBackend)
+	case "supervisor.always_consult_llm":
+		return strconv.FormatBool(cfg.Supervisor.AlwaysConsultLLM)
+	case "poll_interval_seconds":
+		return strconv.Itoa(cfg.PollIntervalSeconds)
+	case "worker_max_tokens":
+		return strconv.Itoa(cfg.WorkerMaxTokens)
+	default:
+		return ""
+	}
+}
+
+// applyFleetSettings overlays each fleet default onto root at its YAML path,
+// but ONLY where the project has not already set that path — a per-project
+// value always wins (#839 precedence). Mutates root in place.
+func applyFleetSettings(root *yaml.Node, fleet map[string]string) {
+	if len(fleet) == 0 {
+		return
+	}
+	for _, spec := range settingSpecs {
+		val, ok := fleet[spec.Name]
+		if !ok {
+			continue
+		}
+		if settingPresent(root, spec.Path) {
+			continue // project override wins
+		}
+		setSettingPath(root, spec.Path, spec.scalarNode(val))
+	}
+}
+
+// settingSources reports each knob's source (project/fleet/builtin) for a
+// project whose raw YAML is root and whose fleet defaults are fleet. Used to
+// annotate a resolved config so effective_config can show provenance (#839 AC2).
+func settingSources(root *yaml.Node, fleet map[string]string) map[string]string {
+	out := make(map[string]string, len(settingSpecs))
+	for _, spec := range settingSpecs {
+		switch {
+		case settingPresent(root, spec.Path):
+			out[spec.Name] = SourceProject
+		case fleet != nil && fleetHas(fleet, spec.Name):
+			out[spec.Name] = SourceFleet
+		default:
+			out[spec.Name] = SourceBuiltin
+		}
+	}
+	return out
+}
+
+func fleetHas(fleet map[string]string, key string) bool {
+	_, ok := fleet[key]
+	return ok
+}
+
+// settingPresent reports whether root explicitly contains a value at path.
+func settingPresent(root *yaml.Node, path []string) bool {
+	node := documentValue(root)
+	for i, key := range path {
+		if node == nil || node.Kind != yaml.MappingNode {
+			return false
+		}
+		idx := mappingKeyIndex(node, key)
+		if idx < 0 {
+			return false
+		}
+		if i == len(path)-1 {
+			return true
+		}
+		node = node.Content[idx+1]
+	}
+	return true
+}
+
+// scalarAtPath returns the scalar value at path, or "" when absent / not a
+// scalar. Used to capture the old value for the audit trail.
+func scalarAtPath(root *yaml.Node, path []string) string {
+	node := documentValue(root)
+	for i, key := range path {
+		if node == nil || node.Kind != yaml.MappingNode {
+			return ""
+		}
+		idx := mappingKeyIndex(node, key)
+		if idx < 0 {
+			return ""
+		}
+		child := node.Content[idx+1]
+		if i == len(path)-1 {
+			if child.Kind == yaml.ScalarNode {
+				return strings.TrimSpace(child.Value)
+			}
+			return ""
+		}
+		node = child
+	}
+	return ""
+}
+
+// setSettingPath sets root's value at path to value, creating intermediate
+// mappings (e.g. the `supervisor` block for supervisor.enabled) as needed.
+func setSettingPath(root *yaml.Node, path []string, value *yaml.Node) {
+	node := documentValue(root)
+	if node == nil {
+		root.Kind = yaml.DocumentNode
+		root.Content = []*yaml.Node{{Kind: yaml.MappingNode}}
+		node = root.Content[0]
+	}
+	for i, key := range path {
+		if i == len(path)-1 {
+			setKeyOnMapping(node, key, value)
+			return
+		}
+		node = childMapping(node, key)
+	}
+}
+
+// setKeyOnMapping upserts key→value on a mapping node.
+func setKeyOnMapping(node *yaml.Node, key string, value *yaml.Node) {
+	idx := mappingKeyIndex(node, key)
+	if idx >= 0 {
+		node.Content[idx+1] = value
+		return
+	}
+	node.Content = append(node.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, value)
+}
+
+// childMapping returns node's child mapping for key, creating an empty one when
+// absent (or when the existing child is not a mapping).
+func childMapping(node *yaml.Node, key string) *yaml.Node {
+	idx := mappingKeyIndex(node, key)
+	if idx >= 0 {
+		if child := node.Content[idx+1]; child.Kind == yaml.MappingNode {
+			return child
+		}
+		child := &yaml.Node{Kind: yaml.MappingNode}
+		node.Content[idx+1] = child
+		return child
+	}
+	child := &yaml.Node{Kind: yaml.MappingNode}
+	setKeyOnMapping(node, key, child)
+	return child
+}

--- a/internal/configstore/settings_test.go
+++ b/internal/configstore/settings_test.go
@@ -1,0 +1,330 @@
+package configstore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const settingsTestYAML = `repo: BeFeast/maestro
+local_path: ~/src/maestro
+max_parallel: 2
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+      prompt_mode: stdin
+supervisor:
+  enabled: true
+  backend: claude
+`
+
+func seedSettingsProject(t *testing.T, store *Store, name string) {
+	t.Helper()
+	if err := store.UpsertProject(context.Background(), name, settingsTestYAML); err != nil {
+		t.Fatalf("seed project %q: %v", name, err)
+	}
+}
+
+// A fleet default applies to a project that does not set the key itself.
+func TestFleetSettingOverlaysBuiltin(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	seedSettingsProject(t, store, "maestro")
+
+	// worker_max_tokens is not set in the project YAML → built-in 0.
+	cfg, err := store.Load(ctx, "maestro")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.WorkerMaxTokens != 0 {
+		t.Fatalf("WorkerMaxTokens = %d, want 0 (built-in) before fleet default", cfg.WorkerMaxTokens)
+	}
+	if got := cfg.SettingSources["worker_max_tokens"]; got != SourceBuiltin {
+		t.Fatalf("source = %q, want %q", got, SourceBuiltin)
+	}
+
+	if err := store.SetFleetSetting(ctx, "worker_max_tokens", "400000", "op"); err != nil {
+		t.Fatalf("SetFleetSetting: %v", err)
+	}
+	cfg, err = store.Load(ctx, "maestro")
+	if err != nil {
+		t.Fatalf("Load after fleet set: %v", err)
+	}
+	if cfg.WorkerMaxTokens != 400000 {
+		t.Fatalf("WorkerMaxTokens = %d, want 400000 from fleet default", cfg.WorkerMaxTokens)
+	}
+	if got := cfg.SettingSources["worker_max_tokens"]; got != SourceFleet {
+		t.Fatalf("source = %q, want %q", got, SourceFleet)
+	}
+}
+
+// The fleet-wide supervisor.enabled=false flip lands on a project whose YAML
+// sets supervisor.enabled=true — WAIT, no: the project explicitly sets it, so it
+// must WIN. This is the core precedence guarantee (#839 AC2).
+func TestProjectOverrideWinsOverFleetDefault(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	seedSettingsProject(t, store, "maestro")
+
+	// Fleet says supervisor OFF...
+	if err := store.SetFleetSetting(ctx, "supervisor.enabled", "false", "op"); err != nil {
+		t.Fatalf("SetFleetSetting: %v", err)
+	}
+	// ...but the project row explicitly sets enabled: true, so it wins.
+	cfg, err := store.Load(ctx, "maestro")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Supervisor.Enabled {
+		t.Fatal("Supervisor.Enabled = false, want true (project override must beat fleet default)")
+	}
+	if got := cfg.SettingSources["supervisor.enabled"]; got != SourceProject {
+		t.Fatalf("source = %q, want %q", got, SourceProject)
+	}
+}
+
+// Fleet supervisor.enabled=false takes effect on a project WITHOUT its own
+// override (#839 AC1).
+func TestFleetDisableSupervisorForUnoverriddenProject(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	// A project that does NOT set supervisor.enabled.
+	yaml := "repo: owner/idle\nmodel:\n  default: codex\n  backends:\n    codex:\n      cmd: codex\n      prompt_mode: stdin\n"
+	if err := store.UpsertProject(ctx, "idle", yaml); err != nil {
+		t.Fatalf("UpsertProject: %v", err)
+	}
+
+	if err := store.SetFleetSetting(ctx, "supervisor.enabled", "false", "op"); err != nil {
+		t.Fatalf("SetFleetSetting: %v", err)
+	}
+	cfg, err := store.Load(ctx, "idle")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Supervisor.Enabled {
+		t.Fatal("Supervisor.Enabled = true, want false from fleet default")
+	}
+	if got := cfg.SettingSources["supervisor.enabled"]; got != SourceFleet {
+		t.Fatalf("source = %q, want %q", got, SourceFleet)
+	}
+}
+
+// A per-project override is written into the row YAML and beats the fleet
+// default going forward.
+func TestSetProjectSettingWritesOverride(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	yaml := "repo: owner/idle\nmodel:\n  default: codex\n  backends:\n    codex:\n      cmd: codex\n      prompt_mode: stdin\n"
+	if err := store.UpsertProject(ctx, "idle", yaml); err != nil {
+		t.Fatalf("UpsertProject: %v", err)
+	}
+	if err := store.SetFleetSetting(ctx, "poll_interval_seconds", "600", "op"); err != nil {
+		t.Fatalf("SetFleetSetting: %v", err)
+	}
+	if err := store.SetProjectSetting(ctx, "idle", "poll_interval_seconds", "30", "op"); err != nil {
+		t.Fatalf("SetProjectSetting: %v", err)
+	}
+	cfg, err := store.Load(ctx, "idle")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.PollIntervalSeconds != 30 {
+		t.Fatalf("PollIntervalSeconds = %d, want 30 (project override)", cfg.PollIntervalSeconds)
+	}
+	if got := cfg.SettingSources["poll_interval_seconds"]; got != SourceProject {
+		t.Fatalf("source = %q, want %q", got, SourceProject)
+	}
+}
+
+// Every change is journaled with old→new, actor, and an RFC3339 timestamp
+// (#839 AC4).
+func TestSettingsAuditTrail(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	seedSettingsProject(t, store, "maestro")
+
+	if err := store.SetFleetSetting(ctx, "supervisor.backend", "claude", "alice"); err != nil {
+		t.Fatalf("set 1: %v", err)
+	}
+	if err := store.SetFleetSetting(ctx, "supervisor.backend", "gemini", "bob"); err != nil {
+		t.Fatalf("set 2: %v", err)
+	}
+	records, err := store.SettingsAudit(ctx, 0)
+	if err != nil {
+		t.Fatalf("SettingsAudit: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("audit records = %d, want 2", len(records))
+	}
+	// Most recent first.
+	latest := records[0]
+	if latest.Key != "supervisor.backend" || latest.Scope != FleetScope {
+		t.Fatalf("latest key/scope = %q/%q", latest.Key, latest.Scope)
+	}
+	if latest.OldValue != "claude" || latest.NewValue != "gemini" {
+		t.Fatalf("latest old→new = %q→%q, want claude→gemini", latest.OldValue, latest.NewValue)
+	}
+	if latest.Actor != "bob" {
+		t.Fatalf("actor = %q, want bob", latest.Actor)
+	}
+	if _, err := time.Parse(time.RFC3339, latest.At); err != nil {
+		t.Fatalf("timestamp %q not RFC3339: %v", latest.At, err)
+	}
+	// The first change recorded an empty old value (backend was unset).
+	if records[1].OldValue != "" || records[1].NewValue != "claude" {
+		t.Fatalf("first old→new = %q→%q, want (empty)→claude", records[1].OldValue, records[1].NewValue)
+	}
+}
+
+// A fleet setting change advances every project's fingerprint so store-backed
+// watchers hot-reload without a restart (#839 AC1).
+func TestFleetSettingAdvancesFingerprint(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	seedSettingsProject(t, store, "maestro")
+
+	before, err := store.ProjectsFingerprint(ctx)
+	if err != nil {
+		t.Fatalf("fingerprint before: %v", err)
+	}
+	if err := store.SetFleetSetting(ctx, "supervisor.enabled", "false", "op"); err != nil {
+		t.Fatalf("SetFleetSetting: %v", err)
+	}
+	after, err := store.ProjectsFingerprint(ctx)
+	if err != nil {
+		t.Fatalf("fingerprint after: %v", err)
+	}
+	if !after["maestro"].After(before["maestro"]) {
+		t.Fatalf("fingerprint did not advance: before=%v after=%v", before["maestro"], after["maestro"])
+	}
+}
+
+// An invalid value for a typed key is rejected before it can land.
+func TestSetFleetSettingRejectsBadValue(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.SetFleetSetting(ctx, "worker_max_tokens", "banana", "op"); err == nil {
+		t.Fatal("SetFleetSetting with non-int value: want error, got nil")
+	}
+	if err := store.SetFleetSetting(ctx, "supervisor.enabled", "maybe", "op"); err == nil {
+		t.Fatal("SetFleetSetting with non-bool value: want error, got nil")
+	}
+	if err := store.SetFleetSetting(ctx, "not.a.key", "1", "op"); err == nil {
+		t.Fatal("SetFleetSetting with unknown key: want error, got nil")
+	}
+}
+
+// DeleteFleetSetting reverts affected projects to built-in and journals it.
+func TestDeleteFleetSetting(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	yaml := "repo: owner/idle\nmodel:\n  default: codex\n  backends:\n    codex:\n      cmd: codex\n      prompt_mode: stdin\n"
+	if err := store.UpsertProject(ctx, "idle", yaml); err != nil {
+		t.Fatalf("UpsertProject: %v", err)
+	}
+	if err := store.SetFleetSetting(ctx, "worker_max_tokens", "5000", "op"); err != nil {
+		t.Fatalf("SetFleetSetting: %v", err)
+	}
+	if err := store.DeleteFleetSetting(ctx, "worker_max_tokens", "op"); err != nil {
+		t.Fatalf("DeleteFleetSetting: %v", err)
+	}
+	cfg, err := store.Load(ctx, "idle")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.WorkerMaxTokens != 0 {
+		t.Fatalf("WorkerMaxTokens = %d, want 0 after delete", cfg.WorkerMaxTokens)
+	}
+	if got := cfg.SettingSources["worker_max_tokens"]; got != SourceBuiltin {
+		t.Fatalf("source = %q, want %q after delete", got, SourceBuiltin)
+	}
+}
+
+// The fleet-settings layer round-trips through export → import (#839 AC5).
+func TestSettingsExportImportRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	// Name the row after its repo derivation so export→import keeps a stable
+	// name (ImportDir re-derives the project name from the `repo` field).
+	const projName = "befeast-maestro"
+	seedSettingsProject(t, store, projName)
+	if err := store.SetFleetSetting(ctx, "supervisor.enabled", "false", "op"); err != nil {
+		t.Fatalf("SetFleetSetting: %v", err)
+	}
+	if err := store.SetFleetSetting(ctx, "worker_max_tokens", "250000", "op"); err != nil {
+		t.Fatalf("SetFleetSetting: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := store.ExportDir(ctx, dir); err != nil {
+		t.Fatalf("ExportDir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, fleetSettingsFileName)); err != nil {
+		t.Fatalf("expected %s in export dir: %v", fleetSettingsFileName, err)
+	}
+	// The per-project row must NOT have the fleet default baked in (the layer is
+	// exported separately so the distinction survives).
+	projData, err := os.ReadFile(filepath.Join(dir, projName+".yaml"))
+	if err != nil {
+		t.Fatalf("read exported project: %v", err)
+	}
+	if strings.Contains(string(projData), "worker_max_tokens") {
+		t.Fatal("exported project row should not carry the fleet-level worker_max_tokens default")
+	}
+
+	// Re-import into a fresh store and confirm the fleet layer is restored.
+	fresh, err := Open(filepath.Join(t.TempDir(), "config.db"))
+	if err != nil {
+		t.Fatalf("Open fresh: %v", err)
+	}
+	defer fresh.Close()
+	if err := fresh.ImportDir(ctx, dir); err != nil {
+		t.Fatalf("ImportDir: %v", err)
+	}
+	fleet, err := fresh.FleetSettings(ctx)
+	if err != nil {
+		t.Fatalf("FleetSettings: %v", err)
+	}
+	if fleet["supervisor.enabled"] != "false" || fleet["worker_max_tokens"] != "250000" {
+		t.Fatalf("round-tripped fleet settings = %v", fleet)
+	}
+	cfg, err := fresh.Load(ctx, projName)
+	if err != nil {
+		t.Fatalf("Load from fresh: %v", err)
+	}
+	if cfg.WorkerMaxTokens != 250000 {
+		t.Fatalf("WorkerMaxTokens = %d, want 250000 after round-trip", cfg.WorkerMaxTokens)
+	}
+}
+
+// ResolveProjectSettings reports value+source for every knob.
+func TestResolveProjectSettings(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	seedSettingsProject(t, store, "maestro")
+	if err := store.SetFleetSetting(ctx, "worker_max_tokens", "123", "op"); err != nil {
+		t.Fatalf("SetFleetSetting: %v", err)
+	}
+	resolved, err := store.ResolveProjectSettings(ctx, "maestro")
+	if err != nil {
+		t.Fatalf("ResolveProjectSettings: %v", err)
+	}
+	got := map[string]ResolvedSetting{}
+	for _, r := range resolved {
+		got[r.Key] = r
+	}
+	if r := got["supervisor.enabled"]; r.Value != "true" || r.Source != SourceProject {
+		t.Fatalf("supervisor.enabled resolved = %+v, want value=true source=project", r)
+	}
+	if r := got["worker_max_tokens"]; r.Value != "123" || r.Source != SourceFleet {
+		t.Fatalf("worker_max_tokens resolved = %+v, want value=123 source=fleet", r)
+	}
+	if r := got["poll_interval_seconds"]; r.Value != "0" || r.Source != SourceBuiltin {
+		t.Fatalf("poll_interval_seconds resolved = %+v, want value=0 source=builtin", r)
+	}
+}

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -82,7 +82,13 @@ func (s *Store) Close() error {
 }
 
 func (s *Store) Init(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, Schema)
+	if _, err := s.db.ExecContext(ctx, Schema); err != nil {
+		return err
+	}
+	// SettingsSchema adds the fleet-settings layer tables (#839). Run in the
+	// same Init so a store opened against an older config.db migrates forward
+	// (both use IF NOT EXISTS, so re-running is a no-op).
+	_, err := s.db.ExecContext(ctx, SettingsSchema)
 	return err
 }
 
@@ -97,6 +103,7 @@ func (s *Store) ImportDir(ctx context.Context, dir string) error {
 	}
 	defer tx.Rollback()
 
+	var fleetSettingsData []byte // #839: routed to the settings table post-commit
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -110,6 +117,10 @@ func (s *Store) ImportDir(ctx context.Context, dir string) error {
 		if err != nil {
 			return fmt.Errorf("read %s: %w", path, err)
 		}
+		if name == fleetSettingsFileName {
+			fleetSettingsData = data // not a project — import after the project tx
+			continue
+		}
 		if err := importProject(ctx, tx, path, data); err != nil {
 			return fmt.Errorf("import %s: %w", path, err)
 		}
@@ -121,7 +132,17 @@ func (s *Store) ImportDir(ctx context.Context, dir string) error {
 	if count == 0 {
 		return fmt.Errorf("no config files found in %s", dir)
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	// SetFleetSetting opens its own transaction, so it must run after the
+	// project tx commits (the store serializes on a single connection).
+	if len(fleetSettingsData) > 0 {
+		if err := s.importFleetSettings(ctx, fleetSettingsData); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SourcePathPrefix marks a config's SourcePath as a config-store row
@@ -137,10 +158,32 @@ func (s *Store) Load(ctx context.Context, name string) (*config.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Overlay fleet-level defaults (#839): parse the row's raw YAML, inject each
+	// fleet default the project does not set itself, then parse the merged
+	// document. Sources are computed off the RAW node (before overlay) so a
+	// project value reads as "project", an injected default as "fleet", and an
+	// untouched knob as "builtin".
+	fleet, err := s.FleetSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var rawRoot yaml.Node
+	if err := yaml.Unmarshal(data, &rawRoot); err != nil {
+		return nil, err
+	}
+	sources := settingSources(&rawRoot, fleet)
+	if len(fleet) > 0 {
+		applyFleetSettings(&rawRoot, fleet)
+		data, err = marshalNode(&rawRoot)
+		if err != nil {
+			return nil, err
+		}
+	}
 	cfg, err := config.Parse(data)
 	if err != nil {
 		return nil, err
 	}
+	cfg.SettingSources = sources
 	if strings.TrimSpace(sourcePath) == "" {
 		// No originating file (write-API row): report the store row itself so
 		// path consumers surface "store:<name>" instead of inventing a
@@ -185,6 +228,59 @@ func (s *Store) ExportDir(ctx context.Context, dir string) error {
 		}
 		if err := os.WriteFile(filepath.Join(dir, name+".yaml"), data, 0644); err != nil {
 			return fmt.Errorf("write export %s: %w", name, err)
+		}
+	}
+	// Round-trip the fleet-settings layer as a standalone file (#839 AC5) so a
+	// re-import restores the fleet defaults, not just the per-project rows. The
+	// leading underscore keeps it out of the project-import glob and sorts it
+	// first for an operator eyeballing the export dir.
+	if err := s.exportFleetSettings(ctx, dir); err != nil {
+		return err
+	}
+	return nil
+}
+
+// fleetSettingsFileName is the export/import filename for the fleet-settings
+// layer. It is NOT a project config — ImportDir routes it to the settings table
+// and the project glob skips it.
+const fleetSettingsFileName = "_fleet-settings.yaml"
+
+// fleetSettingsDoc is the on-disk shape of the exported fleet-settings layer.
+type fleetSettingsDoc struct {
+	Settings map[string]string `yaml:"settings"`
+}
+
+func (s *Store) exportFleetSettings(ctx context.Context, dir string) error {
+	fleet, err := s.FleetSettings(ctx)
+	if err != nil {
+		return err
+	}
+	if len(fleet) == 0 {
+		return nil // nothing to round-trip
+	}
+	data, err := yaml.Marshal(fleetSettingsDoc{Settings: fleet})
+	if err != nil {
+		return fmt.Errorf("marshal fleet settings: %w", err)
+	}
+	header := []byte("# maestro fleet-level settings layer (#839): defaults applied\n" +
+		"# to any project that does not set the key itself.\n")
+	if err := os.WriteFile(filepath.Join(dir, fleetSettingsFileName), append(header, data...), 0644); err != nil {
+		return fmt.Errorf("write fleet settings: %w", err)
+	}
+	return nil
+}
+
+// importFleetSettings loads a previously exported fleet-settings file into the
+// settings table. Unknown keys are rejected so a typo in a hand-edited export
+// is caught at import rather than silently overlaying a dead key.
+func (s *Store) importFleetSettings(ctx context.Context, data []byte) error {
+	var doc fleetSettingsDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parse %s: %w", fleetSettingsFileName, err)
+	}
+	for key, value := range doc.Settings {
+		if err := s.SetFleetSetting(ctx, key, value, "config-store import"); err != nil {
+			return fmt.Errorf("%s: %w", fleetSettingsFileName, err)
 		}
 	}
 	return nil
@@ -515,7 +611,25 @@ func (s *Store) ProjectsFingerprint(ctx context.Context) (map[string]time.Time, 
 		}
 		out[name] = ts
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Fold the fleet-settings fingerprint into every project's timestamp so a
+	// fleet-level `settings set` advances all store-backed watchers and each
+	// project hot-reloads on its next poll without a restart (#839 AC1). A
+	// per-project override already advances that row's own updated_at above.
+	settingsTS, err := s.settingsFingerprint(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !settingsTS.IsZero() {
+		for name, ts := range out {
+			if settingsTS.After(ts) {
+				out[name] = settingsTS
+			}
+		}
+	}
+	return out, nil
 }
 
 func (s *Store) exportProjectYAML(ctx context.Context, name string) ([]byte, string, error) {

--- a/internal/configstore/store_test.go
+++ b/internal/configstore/store_test.go
@@ -67,6 +67,7 @@ supervisor:
 	}
 	fromYAML.SourcePath = ""
 	fromStore.SourcePath = ""
+	fromStore.SettingSources = nil // load-time provenance annotation (#839), not from Parse
 	if !reflect.DeepEqual(fromStore, fromYAML) {
 		t.Fatalf("store config differs from yaml\nstore=%#v\nyaml=%#v", fromStore.Model, fromYAML.Model)
 	}

--- a/internal/configstore/store_write_test.go
+++ b/internal/configstore/store_write_test.go
@@ -56,6 +56,7 @@ func TestUpsertProjectLoadAllRoundTrip(t *testing.T) {
 	}
 	want.SourcePath = ""
 	got.SourcePath = ""
+	got.SettingSources = nil // load-time provenance annotation (#839), not from Parse
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("round-trip config differs\n got=%#v\nwant=%#v", got.Model, want.Model)
 	}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1405,6 +1405,44 @@ type fleetEffectiveConfig struct {
 	CostCaps       fleetConfigCostCaps   `json:"cost_caps"`
 	SupervisorGate fleetConfigSupervisor `json:"supervisor_gate"`
 	ApprovalAction string                `json:"approval_action"`
+
+	// CostControls is the #839 fleet-settings layer surfaced per project: each
+	// cost-control knob with its effective value and source (builtin/fleet/
+	// project), so Mission Control can render a Settings panel that highlights
+	// non-default overrides. Populated only when the config came from the store
+	// (SettingSources is non-nil); empty for file-loaded configs.
+	CostControls []fleetCostControl `json:"cost_controls"`
+}
+
+// fleetCostControl is one fleet-settable knob's effective value and provenance.
+type fleetCostControl struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Source string `json:"source"` // builtin | fleet | project
+}
+
+// buildFleetCostControls renders the #839 cost-control knobs from a resolved
+// config and its SettingSources annotation. A nil SettingSources (file-loaded
+// config, no fleet layer) yields an empty slice, so the panel simply shows no
+// provenance for non-store deployments.
+func buildFleetCostControls(cfg *config.Config) []fleetCostControl {
+	if cfg == nil || cfg.SettingSources == nil {
+		return nil
+	}
+	values := configstore.CostControlValues(cfg)
+	out := make([]fleetCostControl, 0, len(configstore.SettingSpecs()))
+	for _, spec := range configstore.SettingSpecs() {
+		source := cfg.SettingSources[spec.Name]
+		if source == "" {
+			source = configstore.SourceBuiltin
+		}
+		out = append(out, fleetCostControl{
+			Key:    spec.Name,
+			Value:  values[spec.Name],
+			Source: source,
+		})
+	}
+	return out
 }
 
 type fleetModelPolicy struct {
@@ -3684,6 +3722,7 @@ func buildFleetEffectiveConfig(cfg *config.Config) fleetEffectiveConfig {
 			MeteredBackendRefused:   meteredRefused,
 		},
 		ApprovalAction: config.SupervisorActionChangeGlobalConfig,
+		CostControls:   buildFleetCostControls(cfg),
 	}
 }
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -369,6 +369,17 @@ type FleetProjectStore interface {
 	DeleteProject(ctx context.Context, name string) error
 }
 
+// FleetSettingsStore is the write side of the fleet-level settings layer (#839)
+// the dashboard Settings panel needs: set a fleet default, set a per-project
+// override, or clear a fleet default. *configstore.Store satisfies it; the fleet
+// server reaches it by type-asserting the wired project store, so a deployment
+// without the daemon config store (serve --fleet) simply lacks the surface.
+type FleetSettingsStore interface {
+	SetFleetSetting(ctx context.Context, key, rawValue, actor string) error
+	SetProjectSetting(ctx context.Context, project, key, rawValue, actor string) error
+	DeleteFleetSetting(ctx context.Context, key, actor string) error
+}
+
 // SetEmergencySource wires the read side of the fleet-wide EMERGENCY STOP switch
 // (#840): the daemon passes a closure over its cached switch state so the fleet
 // snapshot reports the current level and the SPA renders the banner. Passing nil
@@ -845,6 +856,7 @@ func (s *FleetServer) buildHandler() http.Handler {
 	mux.HandleFunc("/api/v1/fleet/worker", s.handleFleetWorker)
 	mux.HandleFunc("/api/v1/fleet", s.handleFleet)
 	mux.HandleFunc("/api/v1/fleet/projects", s.handleFleetProjects)
+	mux.HandleFunc("/api/v1/fleet/settings", s.handleFleetSettings)
 	mux.HandleFunc("/api/v1/fleet/actions", s.handleFleetAction)
 	mux.HandleFunc("/api/v1/fleet/emergency", s.handleFleetEmergency)
 	mux.HandleFunc("/api/v1/fleet/approvals/", s.handleFleetApproval)
@@ -2129,6 +2141,115 @@ func (s *FleetServer) handleFleetProjectDelete(w http.ResponseWriter, r *http.Re
 		"project": name,
 		"action":  "delete_project",
 		"note":    "config store row removed; the daemon drains the flow on its next store-watch tick (requires --watch-store)",
+	})
+}
+
+type fleetSettingsRequest struct {
+	Key     string `json:"key"`
+	Value   string `json:"value"`
+	Project string `json:"project,omitempty"` // per-project override; empty = fleet default
+	Actor   string `json:"actor,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+	Unset   bool   `json:"unset,omitempty"` // clear a fleet default (revert to built-in)
+}
+
+// handleFleetSettings is the dashboard Settings-panel write endpoint for the
+// fleet-level cost-control knobs (#839). It writes the daemon's config store —
+// a fleet default (settings table), a per-project override (row YAML), or a
+// clear — and the change hot-reloads via the store-watch loop within one poll
+// interval. Every write is journaled in the store's settings_audit with the
+// authenticated actor and old→new values.
+//
+// Gating mirrors handleFleetProjects (change_global_config-class): auth fires
+// FIRST so an unauthenticated request always sees 401, read-only rejects with
+// 403, and a missing config store yields 501. A bad key/value is pre-validated
+// to 400 so a store write error is unambiguously infrastructure (500).
+func (s *FleetServer) handleFleetSettings(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost, http.MethodPut:
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	authenticatedActor, ok := requireAuth(w, r, s.liveAuth())
+	if !ok {
+		return
+	}
+	if s.readOnly {
+		writeError(w, http.StatusForbidden, "fleet server is read-only; settings changes require write-enabled controls")
+		return
+	}
+	settingsStore, ok := s.liveProjectStore().(FleetSettingsStore)
+	if !ok || settingsStore == nil {
+		writeError(w, http.StatusNotImplemented, "settings changes require the daemon config store (run `maestro daemon`); not available under `serve --fleet`")
+		return
+	}
+
+	var req fleetSettingsRequest
+	if r.Body != nil {
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("decode settings request: %v", err))
+			return
+		}
+	}
+	key := strings.TrimSpace(req.Key)
+	if key == "" {
+		writeError(w, http.StatusBadRequest, "key is required")
+		return
+	}
+	actor := resolveActor(authenticatedActor, req.Actor, "dashboard")
+	project := strings.TrimSpace(req.Project)
+
+	if req.Unset {
+		if project != "" {
+			writeError(w, http.StatusBadRequest, "--unset clears a fleet default only; a per-project override lives in its config row")
+			return
+		}
+		if !configstore.SettingKeyValid(key) {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown setting %q", key))
+			return
+		}
+		if err := settingsStore.DeleteFleetSetting(r.Context(), key, actor); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("clear fleet setting %q: %v", key, err))
+			return
+		}
+		s.writeFleetSettingsAccepted(w, key, "", project, actor, req.Reason, "unset_setting")
+		return
+	}
+
+	// Pre-validate key + value so a bad request is 400, not a store 500.
+	if err := configstore.ValidateSetting(key, req.Value); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	var err error
+	action := "set_fleet_setting"
+	if project != "" {
+		action = "set_project_setting"
+		err = settingsStore.SetProjectSetting(r.Context(), project, key, req.Value, actor)
+	} else {
+		err = settingsStore.SetFleetSetting(r.Context(), key, req.Value, actor)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("set setting %q: %v", key, err))
+		return
+	}
+	s.writeFleetSettingsAccepted(w, key, req.Value, project, actor, req.Reason, action)
+}
+
+func (s *FleetServer) writeFleetSettingsAccepted(w http.ResponseWriter, key, value, project, actor, reason, action string) {
+	scope := configstore.FleetScope
+	if project != "" {
+		scope = project
+	}
+	log.Printf("[fleet] settings %s %s=%q scope=%s by %s (reason=%q) — config store written; hot-reloads on the next store-watch tick", action, key, value, scope, actor, strings.TrimSpace(reason))
+	writeJSON(w, http.StatusAccepted, map[string]interface{}{
+		"ok":     true,
+		"key":    key,
+		"scope":  scope,
+		"action": action,
+		"note":   "config store updated; effective on the next store-watch tick without a restart (requires --watch-store)",
 	})
 }
 

--- a/internal/server/fleet_cost_controls_test.go
+++ b/internal/server/fleet_cost_controls_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/configstore"
+)
+
+// The #839 cost-control block surfaces each knob's effective value and source
+// (builtin/fleet/project) on effective_config, so Mission Control can flag
+// non-default overrides.
+func TestBuildFleetCostControls_ReportsSources(t *testing.T) {
+	cfg := &config.Config{
+		Supervisor:      config.SupervisorConfig{Enabled: true},
+		WorkerMaxTokens: 400000,
+		SettingSources: map[string]string{
+			"supervisor.enabled": configstore.SourceProject,
+			"worker_max_tokens":  configstore.SourceFleet,
+		},
+	}
+	eff := buildFleetEffectiveConfig(cfg)
+	got := map[string]fleetCostControl{}
+	for _, cc := range eff.CostControls {
+		got[cc.Key] = cc
+	}
+	if len(got) == 0 {
+		t.Fatal("cost_controls empty; want one entry per knob")
+	}
+	if cc := got["supervisor.enabled"]; cc.Value != "true" || cc.Source != configstore.SourceProject {
+		t.Errorf("supervisor.enabled = %+v, want value=true source=project", cc)
+	}
+	if cc := got["worker_max_tokens"]; cc.Value != "400000" || cc.Source != configstore.SourceFleet {
+		t.Errorf("worker_max_tokens = %+v, want value=400000 source=fleet", cc)
+	}
+	// A knob with no recorded source falls back to builtin.
+	if cc := got["poll_interval_seconds"]; cc.Source != configstore.SourceBuiltin {
+		t.Errorf("poll_interval_seconds source = %q, want builtin", cc.Source)
+	}
+}
+
+// A file-loaded config (no fleet layer, SettingSources nil) yields no
+// cost-control provenance rather than a misleading all-builtin block.
+func TestBuildFleetCostControls_NilForFileConfig(t *testing.T) {
+	cfg := &config.Config{Supervisor: config.SupervisorConfig{Enabled: true}}
+	eff := buildFleetEffectiveConfig(cfg)
+	if len(eff.CostControls) != 0 {
+		t.Fatalf("cost_controls = %d entries, want 0 for a config with nil SettingSources", len(eff.CostControls))
+	}
+}

--- a/internal/server/fleet_settings_test.go
+++ b/internal/server/fleet_settings_test.go
@@ -1,0 +1,227 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/befeast/maestro/internal/configstore"
+)
+
+// The real config store must satisfy the fleet's settings write API (#839).
+var _ FleetSettingsStore = (*configstore.Store)(nil)
+
+// fakeSettingsStore implements BOTH the project-CRUD and settings write APIs, so
+// the settings endpoint (which reaches the store by type-asserting the wired
+// project store) can be exercised without a real SQLite store.
+type fakeSettingsStore struct {
+	fakeProjectStore
+	mu       sync.Mutex
+	fleetSet map[string]string
+	projSet  map[string]string // "project/key" -> value
+	deleted  []string
+}
+
+func (f *fakeSettingsStore) SetFleetSetting(_ context.Context, key, value, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.fleetSet == nil {
+		f.fleetSet = map[string]string{}
+	}
+	f.fleetSet[key] = value
+	return nil
+}
+
+func (f *fakeSettingsStore) SetProjectSetting(_ context.Context, project, key, value, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.projSet == nil {
+		f.projSet = map[string]string{}
+	}
+	f.projSet[project+"/"+key] = value
+	return nil
+}
+
+func (f *fakeSettingsStore) DeleteFleetSetting(_ context.Context, key, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = append(f.deleted, key)
+	return nil
+}
+
+func postSettings(t *testing.T, srv *FleetServer, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/settings", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleFleetSettings(w, req)
+	return w
+}
+
+func TestFleetSettingsSetFleetDefault(t *testing.T) {
+	store := &fakeSettingsStore{}
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetProjectStore(store)
+
+	w := postSettings(t, srv, `{"key":"supervisor.enabled","value":"false","reason":"idle burn"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if store.fleetSet["supervisor.enabled"] != "false" {
+		t.Fatalf("fleetSet = %v, want supervisor.enabled=false", store.fleetSet)
+	}
+}
+
+func TestFleetSettingsSetProjectOverride(t *testing.T) {
+	store := &fakeSettingsStore{}
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetProjectStore(store)
+
+	w := postSettings(t, srv, `{"key":"worker_max_tokens","value":"400000","project":"svc"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if store.projSet["svc/worker_max_tokens"] != "400000" {
+		t.Fatalf("projSet = %v, want svc/worker_max_tokens=400000", store.projSet)
+	}
+	if len(store.fleetSet) != 0 {
+		t.Fatal("a per-project override must not touch the fleet defaults")
+	}
+}
+
+func TestFleetSettingsUnsetFleetDefault(t *testing.T) {
+	store := &fakeSettingsStore{}
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetProjectStore(store)
+
+	w := postSettings(t, srv, `{"key":"supervisor.enabled","unset":true}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if len(store.deleted) != 1 || store.deleted[0] != "supervisor.enabled" {
+		t.Fatalf("deleted = %v, want [supervisor.enabled]", store.deleted)
+	}
+}
+
+func TestFleetSettingsUnsetProjectRejected(t *testing.T) {
+	store := &fakeSettingsStore{}
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetProjectStore(store)
+
+	w := postSettings(t, srv, `{"key":"supervisor.enabled","project":"svc","unset":true}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (unset is fleet-only); body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestFleetSettingsRejectsBadValue(t *testing.T) {
+	store := &fakeSettingsStore{}
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetProjectStore(store)
+
+	w := postSettings(t, srv, `{"key":"worker_max_tokens","value":"banana"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 on bad value; body=%s", w.Code, w.Body.String())
+	}
+	if len(store.fleetSet) != 0 {
+		t.Fatal("a rejected value must not be written")
+	}
+}
+
+func TestFleetSettingsRejectsUnknownKey(t *testing.T) {
+	store := &fakeSettingsStore{}
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetProjectStore(store)
+
+	w := postSettings(t, srv, `{"key":"not.a.key","value":"1"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 on unknown key; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestFleetSettingsRequiresKey(t *testing.T) {
+	store := &fakeSettingsStore{}
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetProjectStore(store)
+
+	w := postSettings(t, srv, `{"value":"false"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 when key missing; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestFleetSettingsReadOnlyForbidden(t *testing.T) {
+	store := &fakeSettingsStore{}
+	srv := NewFleet(nil, "127.0.0.1", 8786, true) // read-only
+	srv.SetProjectStore(store)
+
+	w := postSettings(t, srv, `{"key":"supervisor.enabled","value":"false"}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+	if len(store.fleetSet) != 0 {
+		t.Fatal("read-only fleet must not write the store")
+	}
+}
+
+func TestFleetSettingsWithoutStoreReturns501(t *testing.T) {
+	srv := NewFleet(nil, "127.0.0.1", 8786, false) // no SetProjectStore
+
+	w := postSettings(t, srv, `{"key":"supervisor.enabled","value":"false"}`)
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// A project store that only does CRUD (no settings) must not accidentally accept
+// settings writes.
+func TestFleetSettingsProjectOnlyStoreReturns501(t *testing.T) {
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetProjectStore(&fakeProjectStore{}) // no settings methods
+
+	w := postSettings(t, srv, `{"key":"supervisor.enabled","value":"false"}`)
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501 for a CRUD-only store; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestFleetSettingsRequiresAuth(t *testing.T) {
+	store := &fakeSettingsStore{}
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetProjectStore(store)
+	srv.SetAuthForTest("s3cr3t", "ci")
+
+	// No credential → 401, store untouched.
+	w := postSettings(t, srv, `{"key":"supervisor.enabled","value":"false"}`)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want 401; body=%s", w.Code, w.Body.String())
+	}
+	if len(store.fleetSet) != 0 {
+		t.Fatal("unauthenticated request must not write the store")
+	}
+
+	// Bearer token → accepted.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/fleet/settings", bytes.NewBufferString(`{"key":"supervisor.enabled","value":"false"}`))
+	req.Header.Set("Authorization", "Bearer s3cr3t")
+	wa := httptest.NewRecorder()
+	srv.handleFleetSettings(wa, req)
+	if wa.Code != http.StatusAccepted {
+		t.Fatalf("authenticated status = %d, want 202; body=%s", wa.Code, wa.Body.String())
+	}
+}
+
+func TestFleetSettingsMethodNotAllowed(t *testing.T) {
+	store := &fakeSettingsStore{}
+	srv := NewFleet(nil, "127.0.0.1", 8786, false)
+	srv.SetProjectStore(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet/settings", nil)
+	w := httptest.NewRecorder()
+	srv.handleFleetSettings(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405; body=%s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
Implements #839 (fleet-level settings layer + CLI/API for cost-control knobs).

## Changes
- **Fleet settings layer** in the config store: new `settings` + `settings_audit`
  tables (schema migrates forward on `Init`). Cost/LLM knobs — `supervisor.enabled`,
  `supervisor.backend/model/effort/allow_metered_backend/always_consult_llm`,
  `poll_interval_seconds`, `worker_max_tokens` — become fleet-settable defaults.
- **Layered resolution** at load: a fleet default is overlaid onto a project only
  where the project does not set the key itself. Precedence is strictly
  `per-project > fleet > built-in`. Each knob's source is annotated on the
  resolved config.
- **Hot-reload**: a fleet default change advances every store-backed project's
  fingerprint, so `maestro daemon --watch-store` picks it up on its next poll
  without a restart, on all projects lacking a per-project override.
- **CLI** `maestro settings list|get|set|audit [--project <row>] [--actor <who>]`
  writes the store directly and journals who/when/old->new (RFC3339).
- **effective_config** in the fleet API carries a `cost_controls` block reporting
  each knob's effective value and `source` (builtin/fleet/project).
- **Write endpoint** `POST /api/v1/fleet/settings` sets a fleet default, a
  per-project override, or clears a fleet default. Gated like the other mutating
  config surfaces (`change_global_config`-class): auth-first 401, read-only 403,
  missing store 501, bad key/value 400; every write journaled with the
  authenticated actor.
- **Round-trip**: `config-store export`/import preserve the fleet layer via a
  standalone `_fleet-settings.yaml` (not baked into per-project rows).
- **Docs**: `docs/fleet-settings-runbook.md`.

## Testing
- `go test ./...` (new coverage in `internal/configstore`, `internal/server`,
  `cmd/maestro`).
- `go build ./cmd/maestro/`.
- CLI exercised end-to-end against a throwaway temp config store (set fleet
  default, per-project override wins, audit journal).

## Not in this PR (follow-up)
The Mission Control **SPA control** that drives the write endpoint is a
follow-up; today the dashboard renders the read side
(`effective_config.cost_controls` with source) and the write endpoint is live
for API/CLI clients.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds fleet-level settings for cost-control knobs. The main changes are:

- New config-store `settings` and `settings_audit` tables.
- Fleet, project, and built-in precedence for supported cost-control keys.
- `maestro settings` CLI commands for list, get, set, and audit.
- Config-store export/import support through `_fleet-settings.yaml`.
- Fleet API `effective_config.cost_controls` values with source metadata.

<h3>Confidence Score: 4/5</h3>

Mostly safe, with one contained hot-reload bug in the settings delete path.

Set, overlay, read, audit, and API paths are covered and consistent. Clearing a fleet default can leave store-watch daemons using stale effective config until another fingerprint-changing write happens.

`internal/configstore/settings.go`; `internal/configstore/store.go`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a focused Go test against internal/configstore to exercise ProjectsFingerprint behavior around SetFleetSetting and DeleteFleetSetting.
- The test showed that setting a fleet default advanced the fingerprint and increased worker\_max\_tokens to 5000, while deleting the fleet default reverted worker\_max\_tokens to 0 and did not advance the fingerprint, returning to the initial project timestamp.
- I reviewed artifacts from the first proof, including a focused Go test repro and verbose test output that demonstrate the stale fingerprint after deleting the last fleet default.
- I validated the build proof and observed a clear before/after sequence: Maestro built successfully with fleet value 400000, project inheritance 'fleet', and override to 12345, with audit rows showing actions by trex-fleet-actor and trex-project-actor.

<a href="https://app.greptile.com/trex/runs/13858262/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/maestro/settings.go | Adds CLI list/get/set/audit operations backed by the config store. |
| internal/configstore/settings.go | Implements setting registry, validation, overlays, audit, and writes; clearing a fleet setting can fail to advance hot-reload fingerprints. |
| internal/configstore/settings_test.go | Adds coverage for overlays, precedence, audit, validation, delete, round-trip, and resolve behavior. |
| internal/configstore/store.go | Integrates settings schema, load overlays, export/import, and fingerprint folding. |
| internal/server/fleet.go | Surfaces effective cost controls and adds the authenticated settings write endpoint. |
| internal/server/fleet_settings_test.go | Tests settings endpoint auth, read-only handling, validation, fleet/project writes, and unset behavior. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/configstore/settings.go:221
**Deleted defaults do not reload**
`DeleteFleetSetting` only removes the row from `settings`, but `ProjectsFingerprint` folds in `MAX(settings.updated_at)` from the remaining settings rows. When the last fleet default is cleared, or when the deleted key was the newest setting, every project timestamp stays unchanged or moves back to an older row, so `daemon --watch-store` does not reload projects that should revert to the built-in value. Record a monotonic settings change timestamp, for example from `settings_audit`, and fold that into the fingerprint.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["server: approval-gated fleet settings wr..."](https://github.com/befeast/maestro/commit/f17e87342ebe5115175d106e78dccbed1c111ced) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43051359)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->