### PR TITLE
pipeline: per-phase backend + effort for GSD (cheap implement, strong plan/validate) (#841)

### DIFF
--- a/docs/model-routing-rfc.md
+++ b/docs/model-routing-rfc.md
@@ -30,7 +30,7 @@ Every lever that influences which backend/model/effort a worker runs on lives in
 | `routing.router_prompt` | router prompt template | `internal/config/config.go:789` |
 | `routing.task_type_backends` | `task_type → backend`, used **only** when `mode: auto` | `internal/config/config.go:790` |
 | `routing.{planner,implementation,validator}_backend` | per-role backend overrides | `internal/config/config.go:794-796` |
-| `pipeline.{planner,validator}.backend` | the *other* per-role backend overrides | `internal/config/config.go:856-861` (`PipelineConfig`/`RoleConfig`) |
+| `pipeline.{planner,implementer,validator}.{backend,effort}` | the *other* per-role backend/effort overrides (implement phase + `effort:` added in #841) | `internal/config/config.go` (`PipelineConfig`/`RoleConfig`) |
 | `supervisor.review_repair.{backend,model,effort}` | backend used when a green PR is held on blocking review findings | `internal/config/config.go:543-548` |
 
 A subtle but load-bearing fact, with one backend-specific exception: for the
@@ -157,16 +157,41 @@ code:
   `roleBackend` at `:136-148`). **This function has no non-test callers** — it is
   exercised only by `internal/router/resolve_test.go`. It is dead code on the
   dispatch path.
-- `pipeline.{planner,validator}.backend` is consumed by
-  `pipeline.BackendForPhase` (`internal/pipeline/pipeline.go:111-123`), which
-  **is** wired into the dispatch loop for pipeline phases —
-  `internal/orchestrator/orchestrator.go:5261-5266`. The implementer phase has no
-  override and always uses `model.default` (`internal/pipeline/pipeline.go:122`).
+- `pipeline.{planner,implementer,validator}.backend` is consumed by
+  `pipeline.BackendForPhase` (`internal/pipeline/pipeline.go`), which **is** wired
+  into the dispatch loop for pipeline phases. Since #841 the implement phase
+  carries its own `pipeline.implementer.backend` (empty falls back to
+  `model.default`, the unchanged default), and every phase role also takes an
+  optional `effort:` threaded into the worker argv via
+  `worker.appendTierModelEffort` (claude `--effort`, codex `-c
+  model_reasoning_effort`; gemini drops it). This enables the "plan-big /
+  execute-small" economics — a strong backend + high effort on plan/validate and a
+  cheap backend + low effort on the token-heavy implement phase:
+
+  ```yaml
+  pipeline:
+    enabled: true
+    planner:
+      enabled: true
+      backend: fable      # strong model plans
+      effort: xhigh
+    implementer:
+      backend: codex      # cheap model executes the mechanical implement phase
+      effort: low
+    validator:
+      enabled: true
+      backend: fable      # strong model verifies
+      effort: high
+  ```
+
+  Operator-pinned flags (a `--model`/`--effort` in the backend `cmd`/`extra_args`)
+  still win — the per-phase effort is skipped when the flag is already present.
 
 So the "per-role backend" that actually runs is the `pipeline.*` one, and only
-for the planner/validator phases of the opt-in 3-phase pipeline
-(`pipeline.enabled` / `pipeline:full` label). The `routing.*_backend` fields
-parse and validate but never affect a worker.
+for the phases of the opt-in 3-phase pipeline (`pipeline.enabled` /
+`pipeline:full` label). The `routing.*_backend` fields parse and validate but
+never affect a worker. Per-phase config is orthogonal to `routing.mode` — it is
+phase config, not issue routing.
 
 ### 1.5 Failure, fallback, and escalation semantics
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1119,12 +1119,21 @@ func (a ServerAuthConfig) ResolvedActorName() string {
 	return name
 }
 
-// RoleConfig defines settings for a single pipeline role (planner, validator).
+// RoleConfig defines settings for a single pipeline role (planner,
+// implementer, validator).
 type RoleConfig struct {
 	Enabled           bool   `yaml:"enabled"`
 	Backend           string `yaml:"backend"`             // backend name from model.backends (empty = use default)
 	Prompt            string `yaml:"prompt"`              // path to prompt template (empty = built-in default)
 	MaxRuntimeMinutes int    `yaml:"max_runtime_minutes"` // override per-role max runtime (0 = use global)
+	// Effort is the per-phase reasoning-effort override (#841). When set it is
+	// threaded into the worker argv for the phase via
+	// worker.appendTierModelEffort — claude `--effort <e>`, codex `-c
+	// model_reasoning_effort=<e>`; gemini has no effort flag and drops it. Empty
+	// leaves the backend's effort unchanged (today's behavior). This enables the
+	// "plan-big / execute-small" economics: strong effort on plan/validate, a low
+	// effort on the token-heavy implement phase.
+	Effort string `yaml:"effort"`
 }
 
 // PipelineConfig controls the planner → implementer → validator phase pipeline
@@ -1134,7 +1143,12 @@ type PipelineConfig struct {
 	Enabled   bool       `yaml:"enabled"`   // enable 3-phase pipeline globally (default: false; issue label pipeline:full opts in per worker)
 	Planner   RoleConfig `yaml:"planner"`   // planner role settings
 	Validator RoleConfig `yaml:"validator"` // validator role settings
-	// Implementer uses the existing worker_prompt / bug_prompt / enhancement_prompt settings.
+	// Implementer carries the implement phase's own backend/effort override (#841)
+	// so the token-heavy implement phase can run on a cheap backend + low effort
+	// while plan/validate keep the strong model. Empty backend falls back to
+	// model.default (unchanged default); the prompt still comes from the existing
+	// worker_prompt / bug_prompt / enhancement_prompt settings.
+	Implementer RoleConfig `yaml:"implementer"`
 
 	// Deterministic pre-worker context preparation phases. These are heuristic
 	// local scans/checks, not separate agent sessions.
@@ -1586,6 +1600,7 @@ func parse(data []byte) (*Config, error) {
 	cfg.BugPrompt = expandHome(cfg.BugPrompt)
 	cfg.EnhancementPrompt = expandHome(cfg.EnhancementPrompt)
 	cfg.Pipeline.Planner.Prompt = expandHome(cfg.Pipeline.Planner.Prompt)
+	cfg.Pipeline.Implementer.Prompt = expandHome(cfg.Pipeline.Implementer.Prompt)
 	cfg.Pipeline.Validator.Prompt = expandHome(cfg.Pipeline.Validator.Prompt)
 	cfg.Supervisor.Prompt = expandHome(cfg.Supervisor.Prompt)
 	for i, s := range cfg.PromptSections {

--- a/internal/configstore/store_test.go
+++ b/internal/configstore/store_test.go
@@ -142,6 +142,110 @@ model:
 	}
 }
 
+// #841: the per-phase backend + effort fields (pipeline.{planner,implementer,
+// validator}.{backend,effort}) live in the project document, so the store must
+// round-trip them through import → export → parse without a schema change, and a
+// row that omits them must load with empty defaults.
+func TestExportDirRoundTripsPerPhaseBackendEffort(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	yaml := `
+repo: owner/gsd
+model:
+  default: fable
+  backends:
+    fable:
+      cmd: claude --model fable
+    codex:
+      cmd: codex
+pipeline:
+  enabled: true
+  planner:
+    enabled: true
+    backend: fable
+    effort: xhigh
+  implementer:
+    backend: codex
+    effort: low
+  validator:
+    enabled: true
+    backend: fable
+    effort: high
+`
+	if err := os.WriteFile(filepath.Join(dir, "gsd.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	store := openTestStore(t)
+	if err := store.ImportDir(ctx, dir); err != nil {
+		t.Fatalf("ImportDir: %v", err)
+	}
+	exportDir := t.TempDir()
+	if err := store.ExportDir(ctx, exportDir); err != nil {
+		t.Fatalf("ExportDir: %v", err)
+	}
+	exported, err := os.ReadFile(filepath.Join(exportDir, "owner-gsd.yaml"))
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+	roundTrip, err := config.Parse(exported)
+	if err != nil {
+		t.Fatalf("parse exported yaml: %v", err)
+	}
+	original, err := config.Parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse original yaml: %v", err)
+	}
+	if !reflect.DeepEqual(roundTrip.Pipeline, original.Pipeline) {
+		t.Fatalf("round-trip pipeline = %#v, want %#v", roundTrip.Pipeline, original.Pipeline)
+	}
+	if roundTrip.Pipeline.Implementer.Backend != "codex" || roundTrip.Pipeline.Implementer.Effort != "low" {
+		t.Fatalf("implementer backend/effort not preserved: %#v", roundTrip.Pipeline.Implementer)
+	}
+	if roundTrip.Pipeline.Planner.Effort != "xhigh" || roundTrip.Pipeline.Validator.Effort != "high" {
+		t.Fatalf("planner/validator effort not preserved: planner=%q validator=%q",
+			roundTrip.Pipeline.Planner.Effort, roundTrip.Pipeline.Validator.Effort)
+	}
+}
+
+// A project row that predates #841 (no pipeline effort/implementer fields) must
+// still load, with the new fields defaulting to empty.
+func TestLoadDefaultsPerPhaseFieldsWhenAbsent(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	yaml := `
+repo: owner/legacy
+model:
+  default: claude
+  backends:
+    claude:
+      cmd: claude
+pipeline:
+  enabled: true
+  planner:
+    enabled: true
+    backend: claude
+`
+	if err := os.WriteFile(filepath.Join(dir, "legacy.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	store := openTestStore(t)
+	if err := store.ImportDir(ctx, dir); err != nil {
+		t.Fatalf("ImportDir: %v", err)
+	}
+	cfg, err := store.Load(ctx, "owner-legacy")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Pipeline.Implementer.Backend != "" || cfg.Pipeline.Implementer.Effort != "" {
+		t.Fatalf("absent implementer should default empty: %#v", cfg.Pipeline.Implementer)
+	}
+	if cfg.Pipeline.Planner.Effort != "" || cfg.Pipeline.Validator.Effort != "" {
+		t.Fatalf("absent effort should default empty: planner=%q validator=%q",
+			cfg.Pipeline.Planner.Effort, cfg.Pipeline.Validator.Effort)
+	}
+}
+
 func TestImportDirRejectsDivergentSharedBackend(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6026,6 +6026,12 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		// dispatched worker's argv (no-op for non-policy decisions); surface the
 		// shadow would-pick on the dispatch line when policy shadow mode is on.
 		workerCfg = applyTierOverride(workerCfg, backendName, backendDecision)
+		// #841: thread the initial pipeline phase's role effort (plan, or implement
+		// when no planner) into the dispatched worker's argv. No-op for non-pipeline
+		// dispatch (PhaseNone) and when the phase role sets no effort, so today's
+		// dispatch is unchanged. Implement/validate phase transitions apply their own
+		// effort in worker.StartPhase.
+		workerCfg = pipeline.ApplyPhaseEffort(workerCfg, backendName, initialPhase)
 		if backendDecision.ShadowTier != "" {
 			log.Printf("[orch] issue #%d: policy SHADOW would pick %s — dispatching %s unchanged",
 				issue.Number, backendDecision.ShadowReason, backendName)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -106,33 +106,81 @@ func ValidationPassed(worktreePath string) (bool, string, error) {
 	return false, feedback, nil
 }
 
-// BackendForPhase returns the backend name to use for a given phase.
-// Falls back to the default backend if no role-specific backend is configured.
-func BackendForPhase(cfg *config.Config, phase state.Phase) string {
+// roleForPhase returns the RoleConfig governing a pipeline phase, and whether a
+// role is defined for it. The implement phase carries its own role (#841) so it
+// can run on a cheap backend + low effort while plan/validate keep the strong
+// model; PhaseNone / unknown phases have no role.
+func roleForPhase(cfg *config.Config, phase state.Phase) (config.RoleConfig, bool) {
 	switch phase {
 	case state.PhasePlan:
-		if cfg.Pipeline.Planner.Backend != "" {
-			return cfg.Pipeline.Planner.Backend
-		}
+		return cfg.Pipeline.Planner, true
+	case state.PhaseImplement:
+		return cfg.Pipeline.Implementer, true
 	case state.PhaseValidate:
-		if cfg.Pipeline.Validator.Backend != "" {
-			return cfg.Pipeline.Validator.Backend
+		return cfg.Pipeline.Validator, true
+	default:
+		return config.RoleConfig{}, false
+	}
+}
+
+// BackendForPhase returns the backend name to use for a given phase.
+// Falls back to the default backend if no role-specific backend is configured.
+// The implement phase honors pipeline.implementer.backend when set (#841); unset
+// keeps the historical default of model.default.
+func BackendForPhase(cfg *config.Config, phase state.Phase) string {
+	if role, ok := roleForPhase(cfg, phase); ok {
+		if b := strings.TrimSpace(role.Backend); b != "" {
+			return b
 		}
 	}
 	return cfg.Model.Default
 }
 
+// EffortForPhase returns the reasoning-effort override configured for a pipeline
+// phase's role (planner/implementer/validator), or "" when the role carries no
+// effort (#841). The empty default preserves today's behavior: no per-phase
+// --effort / -c model_reasoning_effort is emitted.
+func EffortForPhase(cfg *config.Config, phase state.Phase) string {
+	if role, ok := roleForPhase(cfg, phase); ok {
+		return strings.TrimSpace(role.Effort)
+	}
+	return ""
+}
+
+// ApplyPhaseEffort returns a config whose backendName def carries the phase
+// role's effort as a TierEffort override (#841), threaded into the worker argv by
+// worker.appendTierModelEffort (claude `--effort`, codex `-c
+// model_reasoning_effort`; gemini drops it as unsupported). When the phase has no
+// effort configured — or the backend is unknown — cfg is returned unchanged, so
+// today's dispatch is byte-for-byte preserved. The override is applied to a clone
+// (deep-copying the Backends map) so the shared base config is never mutated,
+// mirroring the routing-tier override path.
+func ApplyPhaseEffort(cfg *config.Config, backendName string, phase state.Phase) *config.Config {
+	effort := EffortForPhase(cfg, phase)
+	if effort == "" {
+		return cfg
+	}
+	def, ok := cfg.Model.Backends[backendName]
+	if !ok {
+		return cfg
+	}
+	clone := *cfg
+	backends := make(map[string]config.BackendDef, len(cfg.Model.Backends))
+	for k, v := range cfg.Model.Backends {
+		backends[k] = v
+	}
+	def.TierEffort = effort
+	backends[backendName] = def
+	clone.Model.Backends = backends
+	return &clone
+}
+
 // MaxRuntimeForPhase returns the max runtime in minutes for a given phase.
 // Falls back to the global max_runtime_minutes if no role-specific value is set.
 func MaxRuntimeForPhase(cfg *config.Config, phase state.Phase) int {
-	switch phase {
-	case state.PhasePlan:
-		if cfg.Pipeline.Planner.MaxRuntimeMinutes > 0 {
-			return cfg.Pipeline.Planner.MaxRuntimeMinutes
-		}
-	case state.PhaseValidate:
-		if cfg.Pipeline.Validator.MaxRuntimeMinutes > 0 {
-			return cfg.Pipeline.Validator.MaxRuntimeMinutes
+	if role, ok := roleForPhase(cfg, phase); ok {
+		if role.MaxRuntimeMinutes > 0 {
+			return role.MaxRuntimeMinutes
 		}
 	}
 	return cfg.MaxRuntimeMinutes

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -154,27 +154,98 @@ func TestBackendForPhase(t *testing.T) {
 	cfg := &config.Config{
 		Model: config.ModelConfig{Default: "claude"},
 		Pipeline: config.PipelineConfig{
-			Planner:   config.RoleConfig{Backend: "haiku"},
-			Validator: config.RoleConfig{Backend: "sonnet"},
+			Planner:     config.RoleConfig{Backend: "haiku"},
+			Implementer: config.RoleConfig{Backend: "codex"},
+			Validator:   config.RoleConfig{Backend: "sonnet"},
 		},
 	}
 
 	if got := BackendForPhase(cfg, state.PhasePlan); got != "haiku" {
 		t.Errorf("plan backend: got %q, want haiku", got)
 	}
-	if got := BackendForPhase(cfg, state.PhaseImplement); got != "claude" {
-		t.Errorf("implement backend: got %q, want claude", got)
+	// #841: the implement phase now honors pipeline.implementer.backend when set.
+	if got := BackendForPhase(cfg, state.PhaseImplement); got != "codex" {
+		t.Errorf("implement backend: got %q, want codex", got)
 	}
 	if got := BackendForPhase(cfg, state.PhaseValidate); got != "sonnet" {
 		t.Errorf("validate backend: got %q, want sonnet", got)
 	}
 
-	// Empty role backends → default
+	// Empty role backends → default (unchanged historical behavior).
 	cfg2 := &config.Config{
 		Model: config.ModelConfig{Default: "claude"},
 	}
 	if got := BackendForPhase(cfg2, state.PhasePlan); got != "claude" {
 		t.Errorf("empty plan backend: got %q, want claude", got)
+	}
+	// Implement phase with no implementer backend falls back to model.default.
+	if got := BackendForPhase(cfg2, state.PhaseImplement); got != "claude" {
+		t.Errorf("empty implement backend: got %q, want claude", got)
+	}
+}
+
+func TestEffortForPhase(t *testing.T) {
+	cfg := &config.Config{
+		Pipeline: config.PipelineConfig{
+			Planner:     config.RoleConfig{Effort: "xhigh"},
+			Implementer: config.RoleConfig{Effort: "low"},
+			Validator:   config.RoleConfig{Effort: "high"},
+		},
+	}
+
+	if got := EffortForPhase(cfg, state.PhasePlan); got != "xhigh" {
+		t.Errorf("plan effort: got %q, want xhigh", got)
+	}
+	if got := EffortForPhase(cfg, state.PhaseImplement); got != "low" {
+		t.Errorf("implement effort: got %q, want low", got)
+	}
+	if got := EffortForPhase(cfg, state.PhaseValidate); got != "high" {
+		t.Errorf("validate effort: got %q, want high", got)
+	}
+	// No role / unset effort → empty (no per-phase --effort emitted).
+	if got := EffortForPhase(cfg, state.PhaseNone); got != "" {
+		t.Errorf("none effort: got %q, want empty", got)
+	}
+	cfg2 := &config.Config{}
+	if got := EffortForPhase(cfg2, state.PhaseImplement); got != "" {
+		t.Errorf("unset implement effort: got %q, want empty", got)
+	}
+}
+
+func TestApplyPhaseEffort(t *testing.T) {
+	base := &config.Config{
+		Model: config.ModelConfig{
+			Default: "claude",
+			Backends: map[string]config.BackendDef{
+				"codex": {Cmd: "codex"},
+			},
+		},
+		Pipeline: config.PipelineConfig{
+			Implementer: config.RoleConfig{Backend: "codex", Effort: "low"},
+		},
+	}
+
+	// Effort set → clone carries the effort as a TierEffort override on the
+	// selected backend def, without mutating the base config.
+	got := ApplyPhaseEffort(base, "codex", state.PhaseImplement)
+	if got == base {
+		t.Fatal("expected a cloned config when effort is applied")
+	}
+	if te := got.Model.Backends["codex"].TierEffort; te != "low" {
+		t.Errorf("clone TierEffort: got %q, want low", te)
+	}
+	if te := base.Model.Backends["codex"].TierEffort; te != "" {
+		t.Errorf("base config was mutated: TierEffort=%q, want empty", te)
+	}
+
+	// No effort configured for the phase → same config returned unchanged.
+	if got := ApplyPhaseEffort(base, "codex", state.PhasePlan); got != base {
+		t.Error("expected unchanged config pointer when phase has no effort")
+	}
+
+	// Unknown backend → unchanged config pointer (defensive).
+	if got := ApplyPhaseEffort(base, "missing", state.PhaseImplement); got != base {
+		t.Error("expected unchanged config pointer for unknown backend")
 	}
 }
 
@@ -182,19 +253,26 @@ func TestMaxRuntimeForPhase(t *testing.T) {
 	cfg := &config.Config{
 		MaxRuntimeMinutes: 120,
 		Pipeline: config.PipelineConfig{
-			Planner:   config.RoleConfig{MaxRuntimeMinutes: 30},
-			Validator: config.RoleConfig{MaxRuntimeMinutes: 45},
+			Planner:     config.RoleConfig{MaxRuntimeMinutes: 30},
+			Implementer: config.RoleConfig{MaxRuntimeMinutes: 90},
+			Validator:   config.RoleConfig{MaxRuntimeMinutes: 45},
 		},
 	}
 
 	if got := MaxRuntimeForPhase(cfg, state.PhasePlan); got != 30 {
 		t.Errorf("plan runtime: got %d, want 30", got)
 	}
-	if got := MaxRuntimeForPhase(cfg, state.PhaseImplement); got != 120 {
-		t.Errorf("implement runtime: got %d, want 120", got)
+	if got := MaxRuntimeForPhase(cfg, state.PhaseImplement); got != 90 {
+		t.Errorf("implement runtime: got %d, want 90", got)
 	}
 	if got := MaxRuntimeForPhase(cfg, state.PhaseValidate); got != 45 {
 		t.Errorf("validate runtime: got %d, want 45", got)
+	}
+
+	// Unset implementer runtime falls back to the global default.
+	cfg2 := &config.Config{MaxRuntimeMinutes: 120}
+	if got := MaxRuntimeForPhase(cfg2, state.PhaseImplement); got != 120 {
+		t.Errorf("unset implement runtime: got %d, want 120", got)
 	}
 }
 

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/pipeline"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -39,6 +40,13 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 		}
 	}
 	backendCfg := workerBackendConfig(backendDef)
+	// #841: thread the phase role's effort override into the worker argv via the
+	// existing tier-effort path (claude --effort, codex -c model_reasoning_effort;
+	// gemini drops it). An operator-pinned effort still wins — appendTierModelEffort
+	// skips the override when the flag is already present in cmd/extra_args.
+	if effort := pipeline.EffortForPhase(cfg, sess.Phase); effort != "" {
+		backendCfg.TierEffort = effort
+	}
 
 	hookSetup, err := setupWorkerToolHooks(cfg.StateDir, sess.Worktree, resolveBackendKind(backendName, backendCfg), cfg.Hooks)
 	if err != nil {

--- a/internal/worker/tier_argv_test.go
+++ b/internal/worker/tier_argv_test.go
@@ -112,3 +112,34 @@ func TestTierArgv_OperatorPinnedCodexEffortWins(t *testing.T) {
 		t.Errorf("operator-pinned codex effort missing: %s", args)
 	}
 }
+
+// #841: a pipeline phase's per-role effort rides the SAME TierEffort carrier as a
+// routing tier's effort, so it emits per-backend exactly like the tier path —
+// claude --effort, codex -c model_reasoning_effort, gemini drops it. These guard
+// the per-phase effort argv emission end-to-end (pipeline.ApplyPhaseEffort /
+// StartPhase set TierEffort; the builders emit it).
+func TestPhaseEffort_ClaudeEmitsEffort(t *testing.T) {
+	args := buildArgs(t, "claude", BackendConfig{Cmd: "claude", TierEffort: "high"})
+	if !strings.Contains(args, "--effort high") {
+		t.Errorf("claude phase effort not emitted: %s", args)
+	}
+}
+
+func TestPhaseEffort_CodexEmitsReasoningEffort(t *testing.T) {
+	args := buildArgs(t, "codex", BackendConfig{Cmd: "codex", TierEffort: "low"})
+	if !strings.Contains(args, "model_reasoning_effort=low") {
+		t.Errorf("codex phase effort not emitted: %s", args)
+	}
+	if strings.Contains(args, "--effort") {
+		t.Errorf("codex must not use --effort: %s", args)
+	}
+}
+
+func TestPhaseEffort_GeminiDropsEffort(t *testing.T) {
+	// gemini has no reasoning-effort flag — a phase effort must be dropped, not
+	// emitted as an unsupported --effort that would crash the worker.
+	args := buildArgs(t, "gemini", BackendConfig{Cmd: "gemini", TierEffort: "medium"})
+	if strings.Contains(args, "--effort") {
+		t.Errorf("gemini must not emit --effort for a phase effort: %s", args)
+	}
+}


### PR DESCRIPTION
Implements #841

## Changes
- **config** (`internal/config/config.go`): `RoleConfig` gains an `Effort` field; `PipelineConfig` gains an `Implementer RoleConfig` so the implement phase carries its own backend/effort.
- **pipeline** (`internal/pipeline/pipeline.go`): `BackendForPhase` now returns `pipeline.implementer.backend` for the implement phase when set, else `model.default` (unchanged default). New `EffortForPhase` + `ApplyPhaseEffort` thread a phase's effort into the worker argv through the existing `appendTierModelEffort` path (claude `--effort`, codex `-c model_reasoning_effort`; gemini drops it as unsupported). `MaxRuntimeForPhase` now also honors an implementer runtime.
- **worker** (`internal/worker/phase.go`): `StartPhase` applies the phase role's effort for the implement/validate transitions.
- **orchestrator** (`internal/orchestrator/orchestrator.go`): initial-dispatch applies the initial phase's effort after the tier override.
- **docs** (`docs/model-routing-rfc.md`): note + plan-strong / implement-cheap / validate-strong example config.

Backward compatible: unset fields preserve today's behavior (implement uses `model.default`, no effort emitted). Operator-pinned `--model`/`--effort` in `cmd`/`extra_args` still win. Config-store round-trips the new fields with no schema break; a row without them loads with empty defaults.

## Testing
- `go build ./cmd/maestro/`
- `go test ./...` (all pass)
- New unit tests: implement-phase backend selection (set/unset), per-role effort resolution + argv emission (claude/codex/gemini-drop), `ApplyPhaseEffort` clone/no-mutation, config-store export/import round-trip of the new fields and default-on-absent.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-phase backend and effort settings for the pipeline roles. The main changes are:

- Adds `effort` to pipeline role config.
- Adds `pipeline.implementer` backend, effort, and runtime configuration.
- Threads per-phase effort into worker argv through the existing tier-effort path.
- Updates docs and tests for backend selection, effort emission, and config-store round trips.

<h3>Confidence Score: 4/5</h3>

One contained pipeline dispatch path can select the wrong backend.

The config, worker, and phase-transition changes are focused and covered by tests. The planner-disabled initial implement path still bypasses the new implementer backend selection.

`internal/orchestrator/orchestrator.go`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused orchestrator Go test to exercise the implement phase with planner disabled and backend set to implementer-backend.
- Observed that the startNewWorkers log showed phase=implement but backend=routed-default, explaining why the test failed due to using the wrong backend.
- Validated that the focused Go tests in the repository passed and the CLI build completed, with evidence that tests reported ok and the build finished successfully.
- Noted that the full Go test run failed due to the initial implement backend repro and packaging constraints, indicating the repro issue did not affect the focused validation.

<a href="https://app.greptile.com/trex/runs/13866388/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Applies phase effort to initial dispatch, but the planner-disabled implement path still resolves backend through normal routing instead of `pipeline.implementer.backend`. |
| internal/pipeline/pipeline.go | Centralizes phase role lookup and adds implementer backend, effort resolution, effort application, and implementer runtime support. |
| internal/worker/phase.go | Applies phase role effort during phase transitions before building worker argv. |
| internal/config/config.go | Adds `RoleConfig.Effort`, `PipelineConfig.Implementer`, and expands implementer prompt paths during config parse. |
| internal/pipeline/pipeline_test.go | Covers implementer backend fallback/override, per-phase effort resolution, non-mutating effort application, and implementer max runtime. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 5978-5983 ([link](https://github.com/befeast/maestro/blob/28ff49cff83f95f75130361284d5286b55c862b9/internal/orchestrator/orchestrator.go#L5978-L5983)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Implementer backend ignored**
   When pipeline mode starts directly in `PhaseImplement` with the planner disabled, this branch still calls `resolveDispatchBackend` instead of `pipeline.BackendForPhase`. A configured `pipeline.implementer.backend` is skipped on the initial implement worker, while later implement transitions use the new backend selection path.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused Go test source for initial implement backend selection](https://app.greptile.com/trex/artifacts/a89e62ef-f219-441a-b791-927ac080e233)**

   - Contains supporting evidence from the run (text/x-go; charset=utf-8).

   **[Repro: verbose go test output showing routed-default selected instead of implementer-backend](https://app.greptile.com/trex/artifacts/52669ba6-49a2-46af-92e2-2f80b2eaed22)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/13866388/artifacts?artifact=a89e62ef-f219-441a-b791-927ac080e233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 5978-5983

   Comment:
   **Implementer backend ignored**
   When pipeline mode starts directly in `PhaseImplement` with the planner disabled, this branch still calls `resolveDispatchBackend` instead of `pipeline.BackendForPhase`. A configured `pipeline.implementer.backend` is skipped on the initial implement worker, while later implement transitions use the new backend selection path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:5978-5983
**Implementer backend ignored**
When pipeline mode starts directly in `PhaseImplement` with the planner disabled, this branch still calls `resolveDispatchBackend` instead of `pipeline.BackendForPhase`. A configured `pipeline.implementer.backend` is skipped on the initial implement worker, while later implement transitions use the new backend selection path.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["pipeline: per-phase backend + effort for..."](https://github.com/befeast/maestro/commit/28ff49cff83f95f75130361284d5286b55c862b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43067885)</sub>

<!-- /greptile_comment -->