### PR TITLE
self-deploy: behavioral smoke gate before finalize (evaluator outside the self-editing loop) (#842)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -65,6 +65,7 @@ Commands:
   digest        Write the morning operator digest across all fleet projects
   cleanup       Remove worktrees for all completed/dead sessions
   version-bump  Bump project version based on merged PR labels
+  selfcheck     Run the bundled behavioral smoke gate (self-deploy pre-finalize check)
   version       Print version
 
 Global flags:
@@ -367,6 +368,8 @@ func main() {
 		cleanupCmd(args)
 	case "version-bump":
 		versionBumpCmd(args)
+	case "selfcheck":
+		selfcheckCmd(args)
 	case "stream-split":
 		streamSplitCmd(args)
 	case "_watch-updater":

--- a/cmd/maestro/selfcheck.go
+++ b/cmd/maestro/selfcheck.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/befeast/maestro/internal/selfcheck"
+)
+
+// selfcheckCmd runs the bundled behavioral smoke gate (#842) and exits 0 when
+// every invariant holds, non-zero otherwise. It is what scripts/self-deploy.sh
+// runs against the freshly-installed binary after the version health check and
+// before finalizing the deploy: a binary that boots and reports the right
+// version but has regressed config parsing, backend resolution, prompt
+// assembly, or state persistence fails here and is rolled back to `.prev`.
+//
+// The gate is deterministic and side-effect-free — it runs against an embedded
+// held-out fixture and a throwaway temp dir, makes no GitHub/config-store/
+// network calls, and touches no live fleet state — so it is safe to run
+// anywhere, including by hand for diagnosis.
+func selfcheckCmd(args []string) {
+	os.Exit(runSelfCheck(args, os.Stdout))
+}
+
+// runSelfCheck is the testable core of selfcheckCmd: it parses flags, runs the
+// gate, writes a report to out, and returns the process exit code (0 = all
+// checks passed, 1 = one or more failed, 2 = usage error).
+func runSelfCheck(args []string, out io.Writer) int {
+	fs := flag.NewFlagSet("selfcheck", flag.ContinueOnError)
+	fs.SetOutput(out)
+	jsonOut := fs.Bool("json", false, "Emit the report as a single JSON object")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	// The invariants exercise packages (e.g. the router) that log through the
+	// standard logger. Silence it for the duration so the gate's own report is
+	// the only output — clean for a human diagnosing a rollback and stable for
+	// the deploy script that parses stdout.
+	prevOut, prevFlags, prevPrefix := log.Writer(), log.Flags(), log.Prefix()
+	log.SetOutput(io.Discard)
+	rep := selfcheck.Run()
+	log.SetOutput(prevOut)
+	log.SetFlags(prevFlags)
+	log.SetPrefix(prevPrefix)
+
+	if *jsonOut {
+		fmt.Fprintln(out, rep.JSON())
+		if rep.OK {
+			return 0
+		}
+		return 1
+	}
+
+	for _, c := range rep.Checks {
+		status := "PASS"
+		if !c.OK {
+			status = "FAIL"
+		}
+		if c.Detail != "" {
+			fmt.Fprintf(out, "[selfcheck] %s %s: %s\n", status, c.Name, c.Detail)
+		} else {
+			fmt.Fprintf(out, "[selfcheck] %s %s\n", status, c.Name)
+		}
+	}
+	if rep.OK {
+		fmt.Fprintf(out, "[selfcheck] OK (%d checks passed)\n", len(rep.Checks))
+		return 0
+	}
+	// Final line names the failed checks so self-deploy can attribute a
+	// gate-triggered rollback to a specific invariant. Keep this line's format
+	// stable — scripts/self-deploy.sh greps for the "FAILED:" prefix.
+	fmt.Fprintf(out, "[selfcheck] FAILED: %s\n", strings.Join(rep.FailedNames(), ","))
+	return 1
+}

--- a/cmd/maestro/selfcheck_test.go
+++ b/cmd/maestro/selfcheck_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSelfCheckCLIPasses: the real binary's `maestro selfcheck` exits 0 against
+// the embedded fixture and prints a PASS line per check plus the OK summary.
+// This guards the gate the deploy script depends on: if it ever exits non-zero
+// on a healthy build, every self-deploy would roll back.
+func TestSelfCheckCLIPasses(t *testing.T) {
+	var out bytes.Buffer
+	code := runSelfCheck(nil, &out)
+	if code != 0 {
+		t.Fatalf("runSelfCheck exit = %d, want 0\n%s", code, out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "[selfcheck] OK") {
+		t.Errorf("missing OK summary line:\n%s", got)
+	}
+	for _, name := range []string{"config", "backend", "prompt", "state"} {
+		if !strings.Contains(got, "PASS "+name) {
+			t.Errorf("missing PASS line for %q:\n%s", name, got)
+		}
+	}
+	if strings.Contains(got, "FAILED:") {
+		t.Errorf("healthy gate must not print a FAILED line:\n%s", got)
+	}
+}
+
+// TestSelfCheckCLIJSON: --json emits a single parseable report object and exits
+// 0 when healthy.
+func TestSelfCheckCLIJSON(t *testing.T) {
+	var out bytes.Buffer
+	code := runSelfCheck([]string{"--json"}, &out)
+	if code != 0 {
+		t.Fatalf("runSelfCheck --json exit = %d, want 0\n%s", code, out.String())
+	}
+	var rep struct {
+		OK     bool `json:"ok"`
+		Checks []struct {
+			Name string `json:"name"`
+			OK   bool   `json:"ok"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &rep); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if !rep.OK || len(rep.Checks) != 4 {
+		t.Fatalf("unexpected report: ok=%v checks=%d\n%s", rep.OK, len(rep.Checks), out.String())
+	}
+}
+
+// TestSelfCheckCLIUsageError: an unknown flag is a usage error (exit 2), not a
+// gate failure (exit 1) — so the deploy script does not misattribute a bad
+// invocation to a behavioral regression.
+func TestSelfCheckCLIUsageError(t *testing.T) {
+	var out bytes.Buffer
+	if code := runSelfCheck([]string{"--nope"}, &out); code != 2 {
+		t.Fatalf("runSelfCheck with unknown flag exit = %d, want 2\n%s", code, out.String())
+	}
+}

--- a/docs/self-deploy-runbook.md
+++ b/docs/self-deploy-runbook.md
@@ -69,10 +69,28 @@ The script then:
    `1.4.3-0.<ts>-f4550ef38a42` — same commit, different string. Matching the SHA
    is format-agnostic, so a stamp-vs-pseudo-version formatting difference cannot
    cause a false verify miss (#722).
-5. **Rolls back on failure** — restores `<bin>.prev`, restarts the units
-   again, and records the rollback reason. `.prev` is kept either way for
+5. **Runs the behavioral smoke gate** (#842) — `maestro selfcheck` against the
+   freshly-installed binary, after the version/health check and **before the
+   deploy is finalized** (and before `<bin>.prev` is used for rollback). The
+   version check proves the binary *booted and reports the right version*; the
+   gate proves it *still behaves*. It is the evaluator that sits **outside the
+   self-editing loop** (Weng, harness engineering): CI ran pre-merge inside the
+   same loop that produced the change, so this is the first held-out functional
+   assertion between "new binary live" and "deploy successful". The gate exercises
+   core invariants — config-store load, backend resolution, prompt assembly, and
+   state round-trip — against a **held-out fixture embedded in the binary**, not
+   live fleet state, so it is deterministic and asserts behavior independent of
+   current production data. It is side-effect-free: no GitHub writes, no
+   config-store mutation, no network beyond localhost. A binary that boots and
+   reports the correct version but has regressed one of these invariants fails
+   the gate and is rolled back exactly like a version mismatch; the result names
+   the failing check.
+6. **Rolls back on failure** — on a failed version/health check **or a failed
+   smoke gate**, restores `<bin>.prev`, restarts the units again, and records the
+   rollback reason (for a gate failure, the reason names the failing check, e.g.
+   `behavioral smoke gate failed: prompt`). `.prev` is kept either way for
    manual rollback.
-6. **Writes a result file** — `<state_dir>/self-deploy-result.json`, on **every**
+7. **Writes a result file** — `<state_dir>/self-deploy-result.json`, on **every**
    terminal path (deployed, rolled_back, failed, and the "already at this
    version" no-op). The script's `set -e` ERR trap plus an EXIT trap guarantee a
    result even when a step bails unexpectedly, so a merge never silently produces
@@ -98,6 +116,63 @@ supervisor finding and notifies, then advances a resolved watermark
 watermark also distinguishes a genuinely-lost deploy from a completed one whose
 trigger marker legitimately outlives its consumed result. A later merge (or
 observed main-advance) re-triggers a fresh deploy automatically.
+
+### Behavioral smoke gate (#842)
+
+Self-deploy is Maestro's one true self-editing loop: the running daemon observes
+an `origin/main` advance, builds and installs the new binary, and restarts the
+fleet — the binary that orchestrates everything replaces itself. Before #842 the
+only post-restart gate was the version/health check in step 4, which a binary
+that boots and reports the right version but **behaves worse** passes cleanly.
+That is the one place the loop lacks an evaluator *outside* itself: CI ran
+pre-merge, inside the same loop that produced the change.
+
+The smoke gate (step 5 above) closes that gap. It runs `maestro selfcheck`
+against the freshly-installed binary and asserts a small set of core invariants:
+
+- **config** — the embedded fixture config parses with full validation,
+  including the routing-policy validator;
+- **backend** — the router resolves backends deterministically (a `model:` label
+  overrides everything; an unlabelled issue routes through the policy to its
+  default tier's backend);
+- **prompt** — the supervisor prompt (the highest-stakes text the fleet-
+  orchestrating binary produces) assembles, with the state packet substituted
+  into the template;
+- **state** — a `State` survives a JSON-store save→load round-trip in a
+  throwaway temp dir, and an empty dir cold-starts to a fresh `State`.
+
+Everything runs against a **fixture embedded in the binary** (never live fleet
+state) and a temp dir, so the gate is deterministic, asserts behavior
+independent of production data, and has **no external side effects** — no GitHub
+writes, no config-store mutation, no network beyond localhost. Run it by hand
+any time to reproduce the gate:
+
+```bash
+maestro selfcheck          # human output, one PASS/FAIL line per check
+maestro selfcheck --json   # machine-readable {"ok":…,"checks":[…]}
+echo $?                    # 0 = all invariants held, 1 = a check failed
+```
+
+**Diagnosing a gate-triggered rollback.** A gate failure looks exactly like a
+version-mismatch rollback — `<bin>.prev` restored, units restarted on the old
+binary, a `rolled_back` finding + notification — but the reason names the smoke
+gate and the failing check:
+
+```
+self-deploy: rolled back to previous binary after PR #… — behavioral smoke gate failed: prompt
+```
+
+The failing check name (`config` / `backend` / `prompt` / `state`) points at the
+regressed invariant. To reproduce and drill in:
+
+```bash
+journalctl --user -u 'maestro-self-deploy-*' --since -2h | grep 'gate:'  # the gate's own report, logged line-by-line
+maestro selfcheck                                                        # re-run the gate against the installed binary
+```
+
+Because the gate only *adds* a stage, the existing version check and the
+drain-honoring restart are unchanged; a healthy build passes the gate and
+finalizes as `deployed` exactly as before.
 
 ## Enabling it
 
@@ -229,6 +304,7 @@ After a merge, within `timeout_minutes`:
 
 ```bash
 maestro version                                  # maestro v<VERSION>+g<shortsha> of merged main
+maestro selfcheck                                # re-run the behavioral smoke gate the deploy ran (#842)
 curl -s http://127.0.0.1:8788/api/v1/state | grep '"version"'
 systemctl --user status maestro.service
 journalctl --user -u 'maestro-self-deploy-*' -n 200   # deploy log
@@ -239,12 +315,14 @@ The supervisor finding appears in the state API under
 
 ## When it rolls back
 
-A deliberately broken build or failed health check leaves:
+A deliberately broken build, a failed health check, or a **failed behavioral
+smoke gate** (#842) leaves:
 
 - the previous binary restored at `bin_path` (and still kept at
   `<bin_path>.prev`),
 - units restarted and active on the old version,
-- a `rolled_back` finding + notification carrying the reason.
+- a `rolled_back` finding + notification carrying the reason (a gate failure
+  names the failing check, e.g. `behavioral smoke gate failed: prompt`).
 
 Inspect the deploy log, fix the regression, merge again:
 
@@ -268,6 +346,7 @@ maestro version
 | Finding `self-deploy: failed … passwordless sudo is unavailable` | `install_via_sudo` is set but `sudo -n` does not work for the deploy user | Add a NOPASSWD sudoers grant for the install file ops (see Enabling it) |
 | Finding `self-deploy: failed … no .prev` | First deploy failed before any previous binary existed | Build + install manually once, re-merge |
 | Finding `rolled_back … health check timed out` | New binary started but never reported the stamped version | Check `journalctl --user -u maestro.service`; the regression is in the merged code |
+| Finding `rolled_back … behavioral smoke gate failed: <check>` | New binary booted and reported the right version but failed the `maestro selfcheck` invariant `<check>` (config/backend/prompt/state) (#842) | Run `maestro selfcheck` to reproduce; inspect `journalctl --user -u 'maestro-self-deploy-*' \| grep gate:`; the regression is behavioral, in the merged code |
 | No finding, no restart | Trigger failed (script missing, systemd-run unavailable) | Orchestrator log shows `self-deploy trigger failed …`; a ⚠️ notification is sent |
 | Deploy log `error obtaining VCS status: exit status 128` | `go build` in the detached worktree tripped git's dubious-ownership guard | Fixed in #807 — the build now passes `-buildvcs=false`; if you see this, the deploy script is pre-#807 (update it) |
 | Finding `self-deploy: no result … — the deploy unit died` | Trigger recorded but the transient unit never wrote a result (SIGKILLed at `RuntimeMaxSec`, or crashed pre-EXIT-trap) (#807) | Inspect `journalctl -u 'maestro-self-deploy-*'`; verify `maestro version` + units by hand; a later merge retries automatically |

--- a/internal/selfcheck/selfcheck.go
+++ b/internal/selfcheck/selfcheck.go
@@ -1,0 +1,329 @@
+// Package selfcheck implements `maestro selfcheck` (#842): a bundled, held-out
+// behavioral smoke gate that exercises the maestro binary's core invariants
+// with no external side effects.
+//
+// It is the evaluator that sits OUTSIDE the self-editing loop. Self-deploy
+// (internal/selfdeploy, scripts/self-deploy.sh) builds, installs, and restarts
+// a freshly-merged maestro binary; its only pre-#842 post-restart gate was a
+// version-string health check, which a binary that boots and reports the right
+// version but behaves worse can satisfy. selfcheck closes that gap: the deploy
+// script runs `<new-binary> selfcheck` after the version check and before the
+// deploy is finalized (before `.prev` is used for rollback), so a regression in
+// config parsing, backend resolution, prompt assembly, or state persistence
+// rolls the binary back instead of shipping.
+//
+// Every check runs against a FIXED fixture embedded in the binary (fixture.yaml)
+// or a throwaway temp dir — never live fleet state — so the gate asserts
+// behavior independent of current production data, is deterministic, and makes
+// no GitHub writes, config-store mutations, or network calls beyond localhost.
+package selfcheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/router"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/supervisor"
+)
+
+// fixtureConfig is the held-out fixture config the gate runs against: the input
+// the config-parse, backend-resolution, and prompt-assembly invariants use, so
+// the gate never depends on a live config store or production data. It ships
+// inside the binary as a Go constant — not a *.yaml file — because the repo's
+// .gitignore blocks *.yaml (to prevent committing real config with secrets),
+// and this fixture must always travel with the binary.
+//
+// It is NOT a runnable project config: `repo` is a placeholder and the backends
+// are never executed. Keep it self-contained and deterministic — no env
+// interpolation, no on-disk sidecar files, no metered/auto-routing paths (which
+// would make the gate depend on the network). model.default deliberately
+// differs from the policy default_tier's backend (codex) so the
+// backend-resolution invariant catches a router regression that bypasses the
+// routing policy and falls straight through to model.default.
+const fixtureConfig = `
+repo: maestro-selfcheck/fixture
+model:
+  default: gemini
+  backends:
+    gemini:
+      cmd: gemini
+    codex:
+      cmd: codex
+    claude:
+      cmd: claude
+routing:
+  mode: policy
+  tiers:
+    cheap:
+      backend: gemini
+      rank: 0
+    standard:
+      backend: codex
+      effort: medium
+      rank: 1
+    strong:
+      backend: claude
+      effort: high
+      rank: 2
+  policy:
+    default_tier: standard
+    rules:
+      - when: { labels: ["migration", "security"] }
+        tier: strong
+      - when: { size: small, dependency: leaf }
+        tier: cheap
+`
+
+// Check names. These are the stable identifiers self-deploy names in the
+// rollback reason and self-deploy-result.json when a check fails, so keep them
+// short and script-greppable.
+const (
+	CheckConfig  = "config"
+	CheckBackend = "backend"
+	CheckPrompt  = "prompt"
+	CheckState   = "state"
+)
+
+// Check is one invariant's outcome.
+type Check struct {
+	Name   string `json:"name"`
+	OK     bool   `json:"ok"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// Report is the full selfcheck outcome.
+type Report struct {
+	OK     bool    `json:"ok"`
+	Checks []Check `json:"checks"`
+}
+
+// FailedNames returns the names of the checks that failed, in check order.
+func (r Report) FailedNames() []string {
+	var names []string
+	for _, c := range r.Checks {
+		if !c.OK {
+			names = append(names, c.Name)
+		}
+	}
+	return names
+}
+
+// JSON renders the report as a single indented JSON object.
+func (r Report) JSON() string {
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		// A Report is all plain fields; marshal cannot realistically fail, but
+		// never panic inside the deploy gate.
+		return fmt.Sprintf(`{"ok":false,"checks":[{"name":"selfcheck","ok":false,"detail":%q}]}`, err.Error())
+	}
+	return string(data)
+}
+
+func pass(name, detail string) Check { return Check{Name: name, OK: true, Detail: detail} }
+func fail(name, detail string) Check { return Check{Name: name, OK: false, Detail: detail} }
+
+// Run executes every invariant against the embedded held-out fixture and
+// returns the aggregate report. It is deterministic and side-effect-free (state
+// round-trip uses a throwaway temp dir it removes before returning).
+func Run() Report {
+	return RunWithConfig([]byte(fixtureConfig))
+}
+
+// RunWithConfig runs the gate against a caller-supplied fixture config instead
+// of the embedded one. It exists so tests can prove the gate has teeth — that a
+// deliberately-broken fixture (unparseable config, or a config whose backend
+// resolution regressed) fails the corresponding check — without shipping a
+// second binary.
+func RunWithConfig(configYAML []byte) Report {
+	var checks []Check
+
+	cfg, cfgCheck := checkConfig(configYAML)
+	checks = append(checks, cfgCheck)
+
+	// Backend resolution and prompt assembly need a parsed config; when config
+	// parsing failed there is nothing to resolve against, so record dependent
+	// failures rather than dereferencing a nil config.
+	if cfg != nil {
+		checks = append(checks, checkBackend(cfg), checkPrompt(cfg))
+	} else {
+		checks = append(checks,
+			fail(CheckBackend, "skipped: fixture config did not parse"),
+			fail(CheckPrompt, "skipped: fixture config did not parse"),
+		)
+	}
+
+	// State persistence is independent of the fixture config.
+	checks = append(checks, checkState())
+
+	ok := true
+	for _, c := range checks {
+		if !c.OK {
+			ok = false
+		}
+	}
+	return Report{OK: ok, Checks: checks}
+}
+
+// checkConfig asserts the config parses (defaults + full validation, including
+// the routing-policy validator) and has the shape the other invariants rely on.
+func checkConfig(configYAML []byte) (*config.Config, Check) {
+	cfg, err := config.Parse(configYAML)
+	if err != nil {
+		return nil, fail(CheckConfig, "parse fixture config: "+err.Error())
+	}
+	if strings.TrimSpace(cfg.Repo) == "" {
+		return cfg, fail(CheckConfig, "parsed config has empty repo")
+	}
+	if len(cfg.Model.Backends) == 0 {
+		return cfg, fail(CheckConfig, "parsed config declares no backends")
+	}
+	if !cfg.Routing.IsPolicyMode() || cfg.Routing.Policy == nil {
+		return cfg, fail(CheckConfig, "fixture routing is not in validated policy mode")
+	}
+	return cfg, pass(CheckConfig, fmt.Sprintf("%d backends, %d routing tiers, policy mode",
+		len(cfg.Model.Backends), len(cfg.Routing.Tiers)))
+}
+
+// checkBackend asserts the router resolves backends deterministically from the
+// config: a model: label overrides everything, and an unlabelled issue routes
+// through the policy to its default tier's backend (NOT model.default — the
+// fixture makes those differ so a policy-bypass regression is caught).
+func checkBackend(cfg *config.Config) Check {
+	r := router.New(cfg)
+
+	// 1. Label override wins and is a real, validated backend.
+	labelBackend := pinnableBackend(cfg)
+	if labelBackend == "" {
+		return fail(CheckBackend, "fixture declares no backends to pin")
+	}
+	labelled := github.Issue{Number: 1, Title: "labelled", State: "open"}
+	labelled.Labels = append(labelled.Labels, struct {
+		Name string `json:"name"`
+	}{Name: "model:" + labelBackend})
+	if d := r.ResolveBackendDecision(labelled); d.Backend != labelBackend || d.Reason != router.ReasonLabel {
+		return fail(CheckBackend, fmt.Sprintf("model:%s label resolved to backend=%q reason=%q, want backend=%q reason=%q",
+			labelBackend, d.Backend, d.Reason, labelBackend, router.ReasonLabel))
+	}
+
+	// 2. Unlabelled issue routes via policy to the default tier's backend.
+	defaultTier := strings.TrimSpace(cfg.Routing.Policy.DefaultTier)
+	wantBackend := strings.TrimSpace(cfg.Routing.Tiers[defaultTier].Backend)
+	if wantBackend == "" {
+		return fail(CheckBackend, "policy default_tier has no backend")
+	}
+	unlabelled := github.Issue{Number: 2, Title: "unlabelled", State: "open"}
+	if d := r.ResolveBackendDecision(unlabelled); d.Backend != wantBackend || d.Tier != defaultTier {
+		return fail(CheckBackend, fmt.Sprintf("unlabelled issue resolved to backend=%q tier=%q, want backend=%q tier=%q (policy default_tier)",
+			d.Backend, d.Tier, wantBackend, defaultTier))
+	}
+
+	return pass(CheckBackend, fmt.Sprintf("label override → %s; unlabelled → %s (tier %s)", labelBackend, wantBackend, defaultTier))
+}
+
+// checkPrompt asserts the supervisor prompt — the highest-stakes text the
+// fleet-orchestrating binary produces — assembles deterministically from the
+// config, with the state packet substituted into the template.
+func checkPrompt(cfg *config.Config) Check {
+	prompt, err := supervisor.BuildSelfCheckPrompt(cfg)
+	if err != nil {
+		return fail(CheckPrompt, "assemble supervisor prompt: "+err.Error())
+	}
+	if strings.TrimSpace(prompt) == "" {
+		return fail(CheckPrompt, "assembled supervisor prompt is empty")
+	}
+	if strings.Contains(prompt, "{{STATE_PACKET}}") {
+		return fail(CheckPrompt, "assembled prompt still contains the {{STATE_PACKET}} placeholder (substitution failed)")
+	}
+	// The substituted packet must carry the project identity, proving the
+	// packet was rendered into the template rather than dropped.
+	if cfg.Repo != "" && !strings.Contains(prompt, cfg.Repo) {
+		return fail(CheckPrompt, "assembled prompt does not contain the project repo from the state packet")
+	}
+	return pass(CheckPrompt, fmt.Sprintf("%d-byte supervisor prompt with substituted state packet", len(prompt)))
+}
+
+// checkState round-trips a State through the JSON store in a throwaway temp dir:
+// an empty dir must cold-start to a fresh State, and a populated State must
+// survive Save→Load unchanged. This exercises the on-disk state contract the
+// whole fleet reads and writes, without touching any real state dir.
+func checkState() Check {
+	dir, err := os.MkdirTemp("", "maestro-selfcheck-state-")
+	if err != nil {
+		return fail(CheckState, "create temp state dir: "+err.Error())
+	}
+	defer os.RemoveAll(dir)
+
+	store := state.NewJSONStore(dir)
+
+	// Cold start: an empty state dir must load a fresh, initialized State and
+	// must NOT create a file (the fleet's first-run contract).
+	fresh, err := store.Load()
+	if err != nil {
+		return fail(CheckState, "cold-start load: "+err.Error())
+	}
+	if fresh == nil || fresh.Sessions == nil {
+		return fail(CheckState, "cold-start load did not return an initialized State")
+	}
+
+	want := state.NewState()
+	want.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 842,
+		Branch:      "feat/selfcheck",
+		Status:      state.StatusPROpen,
+		PRNumber:    842,
+	}
+	want.SupervisorDecisions = []state.SupervisorDecision{{
+		ID:      "selfcheck-fixture",
+		Status:  "succeeded",
+		Summary: "selfcheck state round-trip",
+	}}
+
+	if err := store.Save(want); err != nil {
+		return fail(CheckState, "save state: "+err.Error())
+	}
+	got, err := store.Load()
+	if err != nil {
+		return fail(CheckState, "load state: "+err.Error())
+	}
+
+	sess := got.Sessions["slot-1"]
+	if sess == nil || sess.IssueNumber != 842 || sess.PRNumber != 842 || sess.Status != state.StatusPROpen {
+		return fail(CheckState, "session did not survive a save/load round-trip")
+	}
+	if len(got.SupervisorDecisions) != 1 || got.SupervisorDecisions[0].ID != "selfcheck-fixture" {
+		return fail(CheckState, "supervisor decision did not survive a save/load round-trip")
+	}
+	return pass(CheckState, fmt.Sprintf("round-tripped %d session(s) and %d decision(s)",
+		len(got.Sessions), len(got.SupervisorDecisions)))
+}
+
+// pinnableBackend returns a declared backend name to pin via a model: label.
+// It prefers a backend that is NOT model.default so the label-override
+// invariant is falsifiable: a router regression that ignored the label and fell
+// through to model.default would resolve to a different backend and fail the
+// check. Falls back to the default (or lexically-first) backend when the config
+// declares only one.
+func pinnableBackend(cfg *config.Config) string {
+	def := strings.TrimSpace(cfg.Model.Default)
+	best := ""
+	for name := range cfg.Model.Backends {
+		if name == def {
+			continue
+		}
+		if best == "" || name < best {
+			best = name
+		}
+	}
+	if best != "" {
+		return best
+	}
+	if _, ok := cfg.Model.Backends[def]; ok {
+		return def
+	}
+	return ""
+}

--- a/internal/selfcheck/selfcheck_test.go
+++ b/internal/selfcheck/selfcheck_test.go
@@ -1,0 +1,144 @@
+package selfcheck
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestRunPassesAgainstEmbeddedFixture is the load-bearing guard on the gate
+// itself: the real binary's `maestro selfcheck` MUST pass against the embedded
+// held-out fixture, otherwise every self-deploy would roll back. If a future
+// change to the fixture or the invariants breaks this, the gate is broken.
+func TestRunPassesAgainstEmbeddedFixture(t *testing.T) {
+	rep := Run()
+	if !rep.OK {
+		t.Fatalf("Run() against the embedded fixture failed: %s", rep.JSON())
+	}
+	wantChecks := map[string]bool{CheckConfig: false, CheckBackend: false, CheckPrompt: false, CheckState: false}
+	for _, c := range rep.Checks {
+		if _, known := wantChecks[c.Name]; !known {
+			t.Errorf("unexpected check %q", c.Name)
+		}
+		wantChecks[c.Name] = true
+		if !c.OK {
+			t.Errorf("check %q failed: %s", c.Name, c.Detail)
+		}
+	}
+	for name, seen := range wantChecks {
+		if !seen {
+			t.Errorf("check %q was not run", name)
+		}
+	}
+	if names := rep.FailedNames(); len(names) != 0 {
+		t.Errorf("FailedNames = %v, want none", names)
+	}
+}
+
+// TestRunIsDeterministic: two back-to-back runs against the embedded fixture
+// must produce identical reports. The gate is only trustworthy if its verdict
+// does not depend on wall clock, map iteration order, or ambient state.
+func TestRunIsDeterministic(t *testing.T) {
+	a, b := Run().JSON(), Run().JSON()
+	if a != b {
+		t.Fatalf("Run() is not deterministic:\nfirst:\n%s\nsecond:\n%s", a, b)
+	}
+}
+
+// TestGateHasTeeth_BrokenConfig proves a deliberately-broken fixture — a routing
+// tier pointing at a backend that is not declared — fails the config invariant.
+// This is the AC9 proof at the evaluator layer: broken fixture behavior makes
+// the gate fail, and self-deploy wires a failing gate to rollback.
+func TestGateHasTeeth_BrokenConfig(t *testing.T) {
+	broken := []byte(`
+repo: broken/fixture
+model:
+  default: codex
+  backends:
+    codex:
+      cmd: codex
+routing:
+  mode: policy
+  tiers:
+    standard:
+      backend: does-not-exist
+  policy:
+    default_tier: standard
+`)
+	rep := RunWithConfig(broken)
+	if rep.OK {
+		t.Fatalf("gate passed a config whose tier references an undeclared backend: %s", rep.JSON())
+	}
+	if !failed(rep, CheckConfig) {
+		t.Errorf("expected the %q check to fail; report: %s", CheckConfig, rep.JSON())
+	}
+	// Backend/prompt depend on a parsed config, so they must be marked failed
+	// too (not silently skipped-as-passing) when config does not parse.
+	if !failed(rep, CheckBackend) || !failed(rep, CheckPrompt) {
+		t.Errorf("dependent checks should fail when config does not parse: %s", rep.JSON())
+	}
+}
+
+// TestGateHasTeeth_BrokenPrompt proves the prompt invariant is falsifiable
+// independent of config parsing: this fixture parses and validates cleanly, but
+// points the supervisor prompt at a path that does not exist, so prompt
+// assembly errors and the gate fails naming the prompt check — while config,
+// backend, and state still pass.
+func TestGateHasTeeth_BrokenPrompt(t *testing.T) {
+	broken := []byte(`
+repo: broken/fixture
+supervisor:
+  prompt: /nonexistent/maestro-selfcheck-prompt-does-not-exist.txt
+model:
+  default: gemini
+  backends:
+    gemini:
+      cmd: gemini
+    codex:
+      cmd: codex
+    claude:
+      cmd: claude
+routing:
+  mode: policy
+  tiers:
+    standard:
+      backend: codex
+      rank: 0
+  policy:
+    default_tier: standard
+`)
+	rep := RunWithConfig(broken)
+	if rep.OK {
+		t.Fatalf("gate passed with an unreadable supervisor prompt: %s", rep.JSON())
+	}
+	if !failed(rep, CheckPrompt) {
+		t.Fatalf("expected the %q check to fail; report: %s", CheckPrompt, rep.JSON())
+	}
+	// The prompt failure must be isolated: config parsed, and backend + state
+	// are independent of the prompt path, so they should still pass.
+	for _, name := range []string{CheckConfig, CheckBackend, CheckState} {
+		if failed(rep, name) {
+			t.Errorf("check %q unexpectedly failed alongside the prompt check: %s", name, rep.JSON())
+		}
+	}
+}
+
+// TestJSONShape confirms the machine-readable report parses and carries the
+// per-check outcomes self-deploy names on failure.
+func TestJSONShape(t *testing.T) {
+	var rep Report
+	if err := json.Unmarshal([]byte(Run().JSON()), &rep); err != nil {
+		t.Fatalf("selfcheck JSON does not round-trip: %v", err)
+	}
+	if len(rep.Checks) == 0 {
+		t.Fatal("report has no checks")
+	}
+}
+
+func failed(rep Report, name string) bool {
+	for _, n := range rep.FailedNames() {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/selfdeploy/selfdeploy_gate_test.go
+++ b/internal/selfdeploy/selfdeploy_gate_test.go
@@ -1,0 +1,262 @@
+package selfdeploy
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSelfDeployGateTriggersRollback is the AC9 end-to-end proof (#842): a
+// freshly-built binary that BOOTS and reports the expected version (so the
+// existing version/health check passes) but BEHAVES worse (its `selfcheck`
+// fails) must be rolled back to <bin>.prev, and the result file must record a
+// rolled_back outcome naming the failing check.
+//
+// It runs the real scripts/self-deploy.sh with git/go/systemctl stubbed on PATH
+// so no systemd, network, or toolchain is needed — only bash + coreutils. The
+// "new binary" the stubbed build installs reports v9.9.9+gdeadbee for `version`
+// but exits non-zero for `selfcheck`; the "old binary" preserved as .prev
+// reports the previous version and a passing selfcheck.
+func TestSelfDeployGateTriggersRollback(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+	script := selfDeployScriptPath(t)
+
+	root := t.TempDir()
+	stubDir := filepath.Join(root, "stubs")
+	repoDir := filepath.Join(root, "repo")
+	stateDir := filepath.Join(root, "state")
+	binDir := filepath.Join(root, "bin")
+	for _, d := range []string{stubDir, repoDir, stateDir, binDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bin := filepath.Join(binDir, "maestro")
+	resultFile := filepath.Join(stateDir, resultFileName)
+
+	// The currently-installed binary → preserved as <bin>.prev on install, and
+	// restored on rollback. Old version, passing selfcheck.
+	writeExec(t, bin, `#!/bin/bash
+case "$1" in
+  version) echo "maestro v1.0.0+gcafef00" ;;
+  selfcheck) echo "[selfcheck] OK (4 checks passed)"; exit 0 ;;
+  *) exit 0 ;;
+esac
+`)
+
+	// git stub: fetch is a no-op; rev-parse yields a fixed SHA whose short form
+	// is "deadbee"; worktree add materializes the build dir with a VERSION file;
+	// worktree remove tears it down.
+	writeExec(t, filepath.Join(stubDir, "git"), `#!/bin/bash
+if [[ "$1" == "-C" ]]; then shift 2; fi
+sub="$1"; shift
+case "$sub" in
+  fetch) exit 0 ;;
+  rev-parse) echo "deadbeefcafe00000000000000000000000000ab" ;;
+  worktree)
+    action="$1"; shift
+    if [[ "$action" == "add" ]]; then
+      dir=""
+      for a in "$@"; do
+        case "$a" in --*) continue ;; *) dir="$a"; break ;; esac
+      done
+      mkdir -p "$dir"
+      printf 'version = "9.9.9"\n' > "$dir/VERSION"
+    elif [[ "$action" == "remove" ]]; then
+      dir="${!#}"
+      rm -rf "$dir" 2>/dev/null || true
+    fi
+    ;;
+  *) exit 0 ;;
+esac
+`)
+
+	// go stub: `build -o OUT` writes the NEW binary — one that reports the
+	// stamped version (so verify passes) but whose selfcheck FAILS (the exact
+	// regression the gate exists to catch).
+	writeExec(t, filepath.Join(stubDir, "go"), `#!/bin/bash
+sub="$1"; shift
+case "$sub" in
+  build)
+    out=""; prev=""
+    for a in "$@"; do
+      if [[ "$prev" == "-o" ]]; then out="$a"; fi
+      prev="$a"
+    done
+    cat > "$out" <<'NEWBIN'
+#!/bin/bash
+case "$1" in
+  version) echo "maestro v9.9.9+gdeadbee" ;;
+  selfcheck)
+    echo "[selfcheck] PASS config: ok"
+    echo "[selfcheck] FAIL prompt: assemble supervisor prompt: boom"
+    echo "[selfcheck] FAILED: prompt"
+    exit 1 ;;
+  *) exit 0 ;;
+esac
+NEWBIN
+    chmod +x "$out"
+    ;;
+  version) echo "go version go1.25.0 stub" ;;
+  *) exit 0 ;;
+esac
+`)
+
+	// systemctl stub: restarts and liveness checks always succeed.
+	writeExec(t, filepath.Join(stubDir, "systemctl"), "#!/bin/bash\nexit 0\n")
+
+	cmd := exec.Command(bash, script,
+		"--repo-dir", repoDir,
+		"--bin", bin,
+		"--units", "maestro-test.service",
+		"--result-file", resultFile,
+		"--timeout-seconds", "60",
+		"--pr", "842",
+		"--scope", "user",
+	)
+	cmd.Env = append(os.Environ(), "PATH="+stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, runErr := cmd.CombinedOutput()
+
+	// The script exits non-zero on any rollback (fail() ends with exit 1); the
+	// authoritative signal is the result file, not the exit code.
+	if runErr == nil {
+		t.Fatalf("expected the deploy to fail (rollback) on a gate failure, but it exited 0\n%s", out)
+	}
+
+	res, err := ReadResult(stateDir)
+	if err != nil {
+		t.Fatalf("ReadResult: %v\nscript output:\n%s", err, out)
+	}
+	if res == nil {
+		t.Fatalf("no result file written by the deploy\nscript output:\n%s", out)
+	}
+	if res.Status != StatusRolledBack {
+		t.Fatalf("result status = %q, want %q\nreason: %s\nscript output:\n%s", res.Status, StatusRolledBack, res.Reason, out)
+	}
+	if !strings.Contains(res.Reason, "smoke gate") || !strings.Contains(res.Reason, "prompt") {
+		t.Errorf("rollback reason should name the smoke gate and the failing check; got %q", res.Reason)
+	}
+
+	// Rollback must have restored the previous binary in place.
+	restored, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatalf("read restored bin: %v", err)
+	}
+	if !strings.Contains(string(restored), "1.0.0+gcafef00") {
+		t.Errorf("expected <bin> restored to the previous binary after rollback; content did not match old binary")
+	}
+	if _, err := os.Stat(bin + ".prev"); err != nil {
+		t.Errorf("<bin>.prev should be kept after rollback for manual inspection: %v", err)
+	}
+}
+
+// TestSelfDeployGatePassAllowsDeploy is the counterpart: when the freshly-built
+// binary's selfcheck PASSES, the gate does not interfere and the deploy
+// finalizes as `deployed`. This guards against the gate rejecting healthy
+// builds (which would make every deploy roll back).
+func TestSelfDeployGatePassAllowsDeploy(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+	script := selfDeployScriptPath(t)
+
+	root := t.TempDir()
+	stubDir := filepath.Join(root, "stubs")
+	repoDir := filepath.Join(root, "repo")
+	stateDir := filepath.Join(root, "state")
+	binDir := filepath.Join(root, "bin")
+	for _, d := range []string{stubDir, repoDir, stateDir, binDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bin := filepath.Join(binDir, "maestro")
+	resultFile := filepath.Join(stateDir, resultFileName)
+
+	writeExec(t, bin, `#!/bin/bash
+case "$1" in
+  version) echo "maestro v1.0.0+gcafef00" ;;
+  *) exit 0 ;;
+esac
+`)
+	writeExec(t, filepath.Join(stubDir, "git"), `#!/bin/bash
+if [[ "$1" == "-C" ]]; then shift 2; fi
+sub="$1"; shift
+case "$sub" in
+  fetch) exit 0 ;;
+  rev-parse) echo "deadbeefcafe00000000000000000000000000ab" ;;
+  worktree)
+    action="$1"; shift
+    if [[ "$action" == "add" ]]; then
+      dir=""
+      for a in "$@"; do case "$a" in --*) continue ;; *) dir="$a"; break ;; esac; done
+      mkdir -p "$dir"; printf 'version = "9.9.9"\n' > "$dir/VERSION"
+    elif [[ "$action" == "remove" ]]; then
+      dir="${!#}"; rm -rf "$dir" 2>/dev/null || true
+    fi
+    ;;
+  *) exit 0 ;;
+esac
+`)
+	// The healthy new binary: correct version AND a passing selfcheck.
+	writeExec(t, filepath.Join(stubDir, "go"), `#!/bin/bash
+sub="$1"; shift
+case "$sub" in
+  build)
+    out=""; prev=""
+    for a in "$@"; do if [[ "$prev" == "-o" ]]; then out="$a"; fi; prev="$a"; done
+    cat > "$out" <<'NEWBIN'
+#!/bin/bash
+case "$1" in
+  version) echo "maestro v9.9.9+gdeadbee" ;;
+  selfcheck) echo "[selfcheck] OK (4 checks passed)"; exit 0 ;;
+  *) exit 0 ;;
+esac
+NEWBIN
+    chmod +x "$out"
+    ;;
+  version) echo "go version go1.25.0 stub" ;;
+  *) exit 0 ;;
+esac
+`)
+	writeExec(t, filepath.Join(stubDir, "systemctl"), "#!/bin/bash\nexit 0\n")
+
+	cmd := exec.Command(bash, script,
+		"--repo-dir", repoDir,
+		"--bin", bin,
+		"--units", "maestro-test.service",
+		"--result-file", resultFile,
+		"--timeout-seconds", "60",
+		"--pr", "842",
+		"--scope", "user",
+	)
+	cmd.Env = append(os.Environ(), "PATH="+stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("healthy deploy should exit 0, got %v\n%s", runErr, out)
+	}
+
+	res, err := ReadResult(stateDir)
+	if err != nil || res == nil {
+		t.Fatalf("ReadResult: res=%v err=%v\n%s", res, err, out)
+	}
+	if res.Status != StatusDeployed {
+		t.Fatalf("result status = %q, want %q\nscript output:\n%s", res.Status, StatusDeployed, out)
+	}
+}
+
+func writeExec(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/selfdeploy/selfdeploy_script_test.go
+++ b/internal/selfdeploy/selfdeploy_script_test.go
@@ -114,6 +114,47 @@ func TestSelfDeployBuildIsVCSIndependent(t *testing.T) {
 	}
 }
 
+// TestSelfDeployScriptSmokeGateWiring (#842) is the static guard that the
+// behavioral smoke gate is wired into the deploy path correctly: it runs the
+// freshly-installed binary's `selfcheck`, does so AFTER the version/health
+// verify and BEFORE the deploy is finalized (write_result deployed), and routes
+// a gate failure through fail() — the same function the version-mismatch path
+// uses to roll back to .prev. A refactor that reorders these, or drops the gate
+// past the finalize point, would let a merely-booting-but-worse binary through.
+func TestSelfDeployScriptSmokeGateWiring(t *testing.T) {
+	data, err := os.ReadFile(selfDeployScriptPath(t))
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	script := string(data)
+
+	// The gate must invoke selfcheck on the installed binary and route failure
+	// through fail() (which rolls back when INSTALLED).
+	for _, want := range []string{
+		`"$BIN" selfcheck`,   // the gate exercises the new binary's behavior
+		"smoke_gate || fail", // gate failure → fail() → rollback
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("self-deploy.sh missing smoke-gate wiring %q", want)
+		}
+	}
+
+	// Ordering: the gate call must sit AFTER the verify call and BEFORE the
+	// deploy is finalized, so a booting-but-broken binary is caught pre-finalize.
+	verifyIdx := strings.Index(script, "verify || fail")
+	gateIdx := strings.Index(script, "smoke_gate || fail")
+	// Anchor on the finalize-specific form `write_result deployed ""`; a bare
+	// `write_result deployed` also appears earlier in the "already at this
+	// version" no-op path, which precedes verify.
+	finalizeIdx := strings.Index(script, `write_result deployed ""`)
+	if verifyIdx < 0 || gateIdx < 0 || finalizeIdx < 0 {
+		t.Fatalf("missing anchor(s): verify=%d gate=%d finalize=%d", verifyIdx, gateIdx, finalizeIdx)
+	}
+	if !(verifyIdx < gateIdx && gateIdx < finalizeIdx) {
+		t.Errorf("smoke gate is misordered: want verify(%d) < gate(%d) < finalize(%d)", verifyIdx, gateIdx, finalizeIdx)
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/supervisor/selfcheck.go
+++ b/internal/supervisor/selfcheck.go
@@ -1,0 +1,40 @@
+package supervisor
+
+import "github.com/befeast/maestro/internal/config"
+
+// BuildSelfCheckPrompt assembles a supervisor prompt from a fixed, held-out
+// fixture state packet — exercising the real prompt-assembly path (template
+// selection, {{STATE_PACKET}} substitution, and secret redaction) with no
+// GitHub, network, or live-state input. It powers the prompt-assembly invariant
+// of `maestro selfcheck` (#842): the supervisor prompt is the highest-stakes
+// text the fleet-orchestrating binary produces, so a freshly-installed binary
+// that cannot assemble it must not be finalized by self-deploy.
+//
+// It is deterministic: the packet is a constant and buildSupervisorPrompt only
+// reads disk when cfg.Supervisor.Prompt names a custom template file, which the
+// selfcheck fixture never sets (so the embedded defaultSupervisorPrompt is
+// used).
+func BuildSelfCheckPrompt(cfg *config.Config) (string, error) {
+	return buildSupervisorPrompt(cfg, selfCheckStatePacket(cfg))
+}
+
+// selfCheckStatePacket returns a minimal, fully-deterministic state packet for
+// the selfcheck prompt-assembly invariant. It carries just enough shape (the
+// project repo and a no-op allowed-actions policy) that a correctly-assembled
+// prompt provably contains the substituted packet.
+func selfCheckStatePacket(cfg *config.Config) supervisorStatePacket {
+	repo := ""
+	if cfg != nil {
+		repo = cfg.Repo
+	}
+	return supervisorStatePacket{
+		ProjectConfig: supervisorProjectConfigPacket{
+			Repo:          repo,
+			MergeStrategy: "sequential",
+			ReviewGate:    "greptile",
+		},
+		Policy: supervisorPolicyPacket{
+			AllowedActions: []string{"none"},
+		},
+	}
+}

--- a/scripts/self-deploy.sh
+++ b/scripts/self-deploy.sh
@@ -22,9 +22,16 @@
 #      reports a version built from the deployed commit SHA within the timeout
 #      (SHA match, not full-string match, so a stamp vs Go pseudo-version
 #      formatting difference can't cause a false miss — #722),
-#   5. on failure roll back to <bin>.prev, restart the units again,
+#   4b. run the behavioral smoke gate `maestro selfcheck` against the freshly
+#      installed binary (#842): a held-out, side-effect-free self-test of core
+#      invariants (config-store load, backend resolution, prompt assembly, state
+#      round-trip). The version check proves the binary booted; this proves it
+#      still behaves. It is the evaluator OUTSIDE the self-editing loop — a
+#      binary that boots and reports the right version but regressed fails here,
+#   5. on failure (version OR gate) roll back to <bin>.prev, restart the units
+#      again,
 #   6. write a JSON result file the orchestrator surfaces as a supervisor
-#      finding on its next cycle.
+#      finding on its next cycle (a gate rollback names the failing check).
 #
 # A non-blocking single-flight lock (flock on <result-file>.lock) guarantees one
 # deploy at a time: a re-triggered deploy that lands while one is in flight exits
@@ -103,6 +110,7 @@ RESULT_WRITTEN=0
 SHA=""
 STAMP=""
 PREV_VERSION=""
+GATE_FAIL_DETAIL=""
 
 IFS=',' read -r -a UNIT_LIST <<<"$UNITS"
 
@@ -236,6 +244,34 @@ verify() {
     fi
     sleep 5
   done
+}
+
+# smoke_gate runs the behavioral smoke gate (#842) against the freshly-installed
+# binary: `maestro selfcheck` exercises core invariants (config-store load,
+# backend resolution, prompt assembly, state round-trip) against a held-out
+# fixture, with no external side effects. It is the evaluator that sits OUTSIDE
+# the self-editing loop — CI ran pre-merge inside the loop that produced the
+# change, so this is the first held-out functional assertion between "new binary
+# live" and "deploy finalized". A binary that boots and reports the right
+# version but behaves worse fails here and is rolled back exactly like a version
+# mismatch. Returns 0 on pass; on failure sets GATE_FAIL_DETAIL to the failing
+# check name(s) and returns 1. Deterministic and side-effect-free, so it is safe
+# to run against the live binary before finalizing.
+smoke_gate() {
+  local out rc failed
+  out=$("$BIN" selfcheck 2>&1) && rc=0 || rc=$?
+  # Log the gate's own report either way so a gate-triggered rollback is
+  # diagnosable straight from the transient unit's journal.
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && log "gate: $line"
+  done <<<"$out"
+  if (( rc == 0 )); then
+    return 0
+  fi
+  # The subcommand's final line is "[selfcheck] FAILED: <name>[,<name>...]".
+  failed=$(printf '%s\n' "$out" | sed -nE 's/^\[selfcheck\] FAILED: (.+)$/\1/p' | tail -n1)
+  GATE_FAIL_DETAIL="${failed:-selfcheck exited $rc}"
+  return 1
 }
 
 rollback() {
@@ -381,6 +417,14 @@ restart_units "$RESTART_BUDGET" || fail "unit restart failed or exceeded ${RESTA
 
 # --- 4. verify post-restart health ------------------------------------------
 verify || fail "post-restart verification failed (expected v$STAMP from sha $SHA)"
+
+# --- 4b. behavioral smoke gate (#842) ---------------------------------------
+# The version check above confirms the new binary booted and reports v$STAMP; it
+# does NOT confirm the binary still behaves correctly. Run the held-out smoke
+# gate against it before finalizing (and before .prev is used for rollback). On
+# failure, fail() rolls back to .prev exactly like a version mismatch, and the
+# result records which check failed.
+smoke_gate || fail "behavioral smoke gate failed: $GATE_FAIL_DETAIL"
 
 # --- 5. success ---------------------------------------------------------------
 write_result deployed ""


### PR DESCRIPTION
Implements #842

## Changes

Adds a behavioral smoke gate to the self-deploy path — an evaluator that sits **outside** the self-editing loop, run against the freshly-installed binary before the deploy is finalized.

- **`internal/selfcheck` + `maestro selfcheck`** — a bundled, deterministic, side-effect-free self-test of core invariants against a **fixture embedded in the binary** (never live fleet state, no GitHub/config-store/network beyond localhost):
  - `config` — the fixture config parses with full validation (routing-policy validator included);
  - `backend` — the router resolves backends deterministically (a `model:` label overrides; an unlabelled issue routes via policy to its default tier's backend — the fixture makes that differ from `model.default` so a policy-bypass regression is caught);
  - `prompt` — the supervisor prompt assembles with the state packet substituted in;
  - `state` — a `State` survives a JSON-store save→load round-trip, and an empty dir cold-starts to a fresh `State`.
- **`scripts/self-deploy.sh`** — runs `maestro selfcheck` after the version/health verify and before `write_result deployed` (before `.prev` is used for rollback). On gate failure, `fail()` rolls back to `.prev` exactly like a version mismatch; `self-deploy-result.json` records a `rolled_back` outcome whose reason names the failing check. The gate only **adds** a stage — the existing version check and drain-honoring restart are untouched.
- **`docs/self-deploy-runbook.md`** — documents the gate (as step 5), how to diagnose a gate-triggered rollback, and a failure-mode row.

## Testing

- `go build ./cmd/maestro/` and `go test ./...` pass.
- `internal/selfcheck`: the gate passes against the embedded fixture, is deterministic, and has teeth — a deliberately-broken fixture fails the corresponding check.
- `internal/selfdeploy`: an end-to-end run of the real script (git/go/systemctl stubbed on PATH) proves a binary that reports the right version but fails `selfcheck` is **rolled back** to `.prev` with a `rolled_back` result naming the failing check, while a healthy binary finalizes as `deployed`; plus a static wiring guard on gate ordering (after verify, before finalize) and rollback routing.

Note: the runtime behavior (the gate firing on a live self-deploy) is exercised on the next self-deploy of this change; the integration test above stands in for that in CI.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a behavioral selfcheck gate to the self-deploy flow. The main changes are:

- Adds `maestro selfcheck` with deterministic config, backend routing, prompt assembly, and state persistence checks.
- Runs the selfcheck after version and health verification, before deploy finalization.
- Rolls back through the existing self-deploy failure path when the gate fails.
- Adds package and script tests for healthy deploys, gate-triggered rollback, CLI output, and gate determinism.
- Updates the self-deploy runbook with gate behavior and diagnosis steps.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changed paths are well-scoped and covered by selfcheck package tests plus self-deploy script tests for rollback and finalization behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the narrow selfdeploy gate test command, captured verbose passing output, and verified exit code 0.
- Executed the fresh Maestro build command and confirmed exit code 0.
- Ran the selfcheck on the built Maestro binary and captured passing JSON output with exit code 0.

<a href="https://app.greptile.com/trex/runs/13870794/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/self-deploy.sh | Runs `maestro selfcheck` after version/health verification and before finalizing, routing failures through existing rollback. |
| internal/selfcheck/selfcheck.go | Implements deterministic config, backend, prompt, and state invariants against an embedded fixture and temp state store. |
| cmd/maestro/selfcheck.go | Adds CLI handling and reporting for the bundled selfcheck gate, including JSON output and stable failure naming. |
| internal/selfdeploy/selfdeploy_gate_test.go | Adds end-to-end script tests proving selfcheck failure rolls back and selfcheck success finalizes deploy. |
| internal/supervisor/selfcheck.go | Exposes deterministic supervisor prompt assembly for selfcheck using a fixed state packet. |
| docs/self-deploy-runbook.md | Documents the new behavioral smoke gate, diagnostics, and rollback failure mode. |

<sub>Reviews (1): Last reviewed commit: ["self-deploy: behavioral smoke gate befor..."](https://github.com/befeast/maestro/commit/1856992693d873dd88f89a4c6a78dec60042bced) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43075963)</sub>

<!-- /greptile_comment -->