### PR TITLE
orchestrator: feed prior-attempt post-mortem from worker log into respawn prompts (#835)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1639,6 +1639,66 @@ Do NOT repeat the same mistakes.
 `, promptBase, feedback)
 }
 
+// appendPriorAttemptPostmortem appends a bounded, automatically-extracted
+// summary of the previous failed attempt's own worker-log trajectory (#835).
+// It sits alongside — not in place of — the CI/review/conflict context, so the
+// retry worker sees what the last attempt actually tried locally and can avoid
+// repeating the same dead ends until retry_exhausted. The postmortem argument
+// is already secret-redacted and hard-capped by the caller.
+func appendPriorAttemptPostmortem(promptBase, postmortem string, attempt int) string {
+	return fmt.Sprintf(`%s
+
+---
+
+## Prior Attempt Post-Mortem (Attempt %d)
+
+A previous attempt on this issue failed. The following is an automatically
+extracted summary of what that attempt tried, distilled from its own worker log
+(not from GitHub CI or review):
+
+`+"```"+`
+%s
+`+"```"+`
+
+Do NOT repeat the same approach without addressing why it failed. If the summary
+shows a command, file, or hypothesis that led nowhere, change strategy rather
+than retrying it verbatim.
+`, promptBase, attempt, postmortem)
+}
+
+// maybeAppendPriorAttemptPostmortem distills the previous attempt's worker log
+// into a post-mortem, persists the full version to the state dir for operator
+// inspection, and appends a hard-capped excerpt to the retry prompt. It is
+// best-effort: a missing/empty/unreadable log yields no section and no error,
+// so respawn proceeds exactly as it does today.
+func (o *Orchestrator) maybeAppendPriorAttemptPostmortem(slotName string, sess *state.Session, promptBase string) string {
+	logFile := o.workerLogFile(slotName, sess)
+	postmortem := worker.ExtractPostmortem(logFile, worker.PostmortemTailLines)
+	if strings.TrimSpace(postmortem) == "" {
+		return promptBase
+	}
+	// Persist the full post-mortem for operators; only a capped excerpt goes
+	// into the prompt (token budget). All attempts accumulate on disk under a
+	// per-attempt filename.
+	o.persistPostmortem(slotName, sess.RetryCount, postmortem)
+	capped := worker.CapPostmortem(postmortem, worker.PostmortemPromptCapBytes)
+	return appendPriorAttemptPostmortem(promptBase, capped, sess.RetryCount)
+}
+
+// persistPostmortem writes the full post-mortem to
+// <state_dir>/<slot>-attempt<N>-postmortem.md. Best-effort: a write failure is
+// logged, never fatal, and never blocks the respawn.
+func (o *Orchestrator) persistPostmortem(slotName string, attempt int, body string) {
+	if o == nil || o.cfg == nil || strings.TrimSpace(o.cfg.StateDir) == "" {
+		return
+	}
+	name := fmt.Sprintf("%s-attempt%d-postmortem.md", slotName, attempt)
+	path := filepath.Join(o.cfg.StateDir, name)
+	if err := os.WriteFile(path, []byte(body+"\n"), 0o644); err != nil {
+		log.Printf("[orch] warn: could not persist post-mortem for %s: %v", slotName, err)
+	}
+}
+
 // appendRebaseConflictContext appends a section to the worker prompt with
 // auto-rebase failure details so the retry worker can update the same PR branch.
 func appendRebaseConflictContext(promptBase, feedback string) string {
@@ -1848,6 +1908,12 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 			sess.PreviousAttemptFeedback = "" // consumed — don't persist stale feedback
 			sess.PreviousAttemptFeedbackKind = ""
 		}
+
+		// #835: append a bounded post-mortem distilled from the previous
+		// attempt's own worker log, alongside (not replacing) the CI/review/
+		// conflict context above. Read before respawn — respawnWorker /
+		// RespawnInPlace repoint sess.LogFile to the new attempt's log.
+		promptBase = o.maybeAppendPriorAttemptPostmortem(slotName, sess, promptBase)
 
 		var respawnErr error
 		if sess.PRNumber != 0 && sess.Worktree != "" {

--- a/internal/orchestrator/postmortem_test.go
+++ b/internal/orchestrator/postmortem_test.go
@@ -1,0 +1,154 @@
+package orchestrator
+
+// #835: on respawn after a failed attempt, the new prompt carries a bounded
+// post-mortem distilled from the previous attempt's own worker log, alongside
+// (not replacing) the existing CI/review/conflict context. The full
+// post-mortem is persisted to the state dir; a missing log degrades gracefully.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestAppendPriorAttemptPostmortem_AddsSection(t *testing.T) {
+	base := "You are a coding agent."
+	pm := "### Errors / failed commands observed\n- exit status 1"
+	result := appendPriorAttemptPostmortem(base, pm, 2)
+
+	for _, want := range []string{
+		"You are a coding agent.",
+		"Prior Attempt Post-Mortem (Attempt 2)",
+		"exit status 1",
+		"Do NOT repeat the same approach",
+	} {
+		if !strings.Contains(result, want) {
+			t.Errorf("result missing %q:\n%s", want, result)
+		}
+	}
+}
+
+func postmortemRetryOrchestrator(t *testing.T, stateDir string, captured *string) *Orchestrator {
+	t.Helper()
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRetriesPerIssue: 3,
+		MaxRetryBackoffMs:  300000,
+		StateDir:           stateDir,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+	return &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "base prompt",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: 42, Title: "test issue", Body: "fix this"}, nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			*captured = promptBase
+			return nil
+		},
+	}
+}
+
+func TestRespawnDueRetries_PriorAttemptPostmortem_IncludedAndPersisted(t *testing.T) {
+	stateDir := t.TempDir()
+	logFile := filepath.Join(stateDir, "slot-1.log")
+	logContent := strings.Join([]string{
+		`{"type":"tool_use","name":"Edit","input":{"file_path":"internal/foo.go"}}`,
+		"go test ./...",
+		"--- FAIL: TestFoo (0.00s)",
+		"exit status 1",
+		"giving up",
+	}, "\n")
+	if err := os.WriteFile(logFile, []byte(logContent), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	captured := ""
+	o := postmortemRetryOrchestrator(t, stateDir, &captured)
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:     42,
+		IssueTitle:      "test issue",
+		Status:          state.StatusDead,
+		RetryCount:      1,
+		NextRetryAt:     &retryAt,
+		Backend:         "claude",
+		LogFile:         logFile,
+		CIFailureOutput: "tests failed: FAIL main_test.go:15",
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if captured == "" {
+		t.Fatal("respawnWorkerFn should have been called")
+	}
+	// Post-mortem section present…
+	for _, want := range []string{
+		"Prior Attempt Post-Mortem",
+		"--- FAIL: TestFoo",
+		"internal/foo.go",
+	} {
+		if !strings.Contains(captured, want) {
+			t.Errorf("prompt missing post-mortem content %q", want)
+		}
+	}
+	// …in addition to the existing CI context (not replacing it).
+	if !strings.Contains(captured, "Previous CI Failure") {
+		t.Error("prompt should still contain CI failure context alongside the post-mortem")
+	}
+
+	// Full post-mortem persisted to the state dir for operator inspection.
+	persisted := filepath.Join(stateDir, "slot-1-attempt1-postmortem.md")
+	data, err := os.ReadFile(persisted)
+	if err != nil {
+		t.Fatalf("expected persisted post-mortem at %s: %v", persisted, err)
+	}
+	if !strings.Contains(string(data), "--- FAIL: TestFoo") {
+		t.Errorf("persisted post-mortem missing failure content:\n%s", data)
+	}
+}
+
+func TestRespawnDueRetries_MissingLog_GracefulDegradation(t *testing.T) {
+	stateDir := t.TempDir()
+	captured := ""
+	o := postmortemRetryOrchestrator(t, stateDir, &captured)
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "test issue",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &retryAt,
+		Backend:     "claude",
+		LogFile:     filepath.Join(stateDir, "logs", "nonexistent.log"),
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if captured == "" {
+		t.Fatal("respawn should proceed even without a readable log")
+	}
+	if strings.Contains(captured, "Prior Attempt Post-Mortem") {
+		t.Error("missing log should not add a post-mortem section")
+	}
+	// No stray post-mortem file written.
+	if _, err := os.Stat(filepath.Join(stateDir, "slot-1-attempt1-postmortem.md")); err == nil {
+		t.Error("no post-mortem file should be persisted when the log is missing")
+	}
+}

--- a/internal/orchestrator/postmortem_test.go
+++ b/internal/orchestrator/postmortem_test.go
@@ -122,6 +122,68 @@ func TestRespawnDueRetries_PriorAttemptPostmortem_IncludedAndPersisted(t *testin
 	}
 }
 
+// TestRespawnDueRetries_PostmortemRedactsInlinePEMTailInBothSinks guards the
+// #835 review finding end-to-end: a tail-clipped private-key fragment embedded
+// in a command line (`$ echo <fragment>`) must not survive into EITHER sink the
+// respawn writes it to — the retry prompt or the persisted post-mortem file.
+// The worker-level unit test proves ExtractPostmortem redacts the short padded
+// tail; this asserts both orchestrator sinks carry the redacted form, since the
+// finding named them both ("written to the saved post-mortem and copied into the
+// retry prompt").
+func TestRespawnDueRetries_PostmortemRedactsInlinePEMTailInBothSinks(t *testing.T) {
+	const secretFragment = "Kj34GkxFhD90vcNLYLInFE=" // short '='-padded base64 tail
+	stateDir := t.TempDir()
+	logFile := filepath.Join(stateDir, "slot-1.log")
+	logContent := strings.Join([]string{
+		"running deploy",
+		"$ echo " + secretFragment,
+		"exit status 1",
+	}, "\n")
+	if err := os.WriteFile(logFile, []byte(logContent), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	captured := ""
+	o := postmortemRetryOrchestrator(t, stateDir, &captured)
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		IssueTitle:  "test issue",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &retryAt,
+		Backend:     "claude",
+		LogFile:     logFile,
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if captured == "" {
+		t.Fatal("respawnWorkerFn should have been called")
+	}
+	// Sink 1: the retry prompt must carry the redacted form, not the raw tail.
+	if strings.Contains(captured, secretFragment) {
+		t.Errorf("inline PEM tail leaked into the retry prompt:\n%s", captured)
+	}
+	if !strings.Contains(captured, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected redaction marker in the retry prompt:\n%s", captured)
+	}
+	// Sink 2: the persisted post-mortem file must likewise be redacted.
+	persisted := filepath.Join(stateDir, "slot-1-attempt1-postmortem.md")
+	data, err := os.ReadFile(persisted)
+	if err != nil {
+		t.Fatalf("expected persisted post-mortem at %s: %v", persisted, err)
+	}
+	if strings.Contains(string(data), secretFragment) {
+		t.Errorf("inline PEM tail leaked into the persisted post-mortem:\n%s", data)
+	}
+	if !strings.Contains(string(data), "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected redaction marker in the persisted post-mortem:\n%s", data)
+	}
+}
+
 func TestRespawnDueRetries_MissingLog_GracefulDegradation(t *testing.T) {
 	stateDir := t.TempDir()
 	captured := ""

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -118,17 +118,21 @@ var pemStrongBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{44,}={0,3}$`)
 // token (a git SHA, a digest). It is disambiguated by pemHexHashRe below.
 var pemWeakBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{8,}={0,3}$`)
 
-// pemHexHashRe matches a fragment that is plausibly a hex hash — a git SHA, a
-// checksum, a digest — being purely hex digits with no base64-only character
-// (uppercase, g-z, '+', '/') and no '=' padding. A short base64 body tail from a
-// clipped PEM dump virtually never satisfies this (its base64 alphabet spans far
-// beyond hex), so a short fragment that is NOT pure hex is treated as key
-// material and redacted even in isolation; a pure-hex fragment stays weak and is
-// only swept into a redaction run when adjacent to a marker or full-width body
-// line. This closes the short-PEM-tail leak (#835 review) — a lone short final
-// body line was previously classified weak and left unredacted — without
-// over-redacting a lone git SHA.
-var pemHexHashRe = regexp.MustCompile(`^[0-9a-fA-F]+$`)
+// pemHexHashRe matches a fragment that is plausibly a git SHA / digest and so may
+// be benign: purely LOWERCASE hex digits, with no uppercase A–F, no base64-only
+// character (g-z, '+', '/'), and no '=' padding. The lowercase restriction is
+// what separates a hash from key material: a PEM/DER base64 body line draws on the
+// full base64 alphabet, so it routinely carries uppercase letters, '+', '/', or
+// padding — none of which survive here — whereas git SHAs, checksums, and hex
+// digests are conventionally lowercase. A short fragment that is NOT lowercase hex
+// is therefore treated as clipped key material and redacted even in isolation.
+// This is where an uppercase-bearing hex fragment such as `DEADBEEF…` — a
+// plausible clipped PEM body tail — is caught: the earlier `[0-9a-fA-F]` form
+// accepted it as a hash and left it weak, leaking the short final body line of a
+// tail-clipped key (#835 review — short PEM tail leak). A lowercase-hex fragment
+// stays weak and is only swept into a redaction run when adjacent to a marker or
+// full-width body line, so a lone git SHA is still not over-redacted.
+var pemHexHashRe = regexp.MustCompile(`^[0-9a-f]+$`)
 
 // pemInlineBodyRe matches a full-width PEM/DER base64 body run (>=44 chars — the
 // same width pemStrongBodyRe treats as key material) wherever it appears, even
@@ -210,10 +214,12 @@ func redactClippedPEM(text string) string {
 			class[i] = strong
 		case pemWeakBodyRe.MatchString(content):
 			// A short base64 fragment. Anchor it as key material (a clipped PEM
-			// body tail) unless it is a plausible hex hash: a git SHA / digest is
-			// pure hex with no base64-only character or '=' padding and may be
-			// benign, so it stays weak and is only redacted when adjacent to a
-			// marker or full-width body line (#835 review — short PEM tail leak).
+			// body tail) unless it is a plausible git SHA / digest: only a
+			// LOWERCASE-hex fragment (no uppercase A–F, no base64-only character,
+			// no '=' padding — see pemHexHashRe) stays weak, since a real PEM body
+			// line almost always carries a character outside lowercase hex. Any
+			// other short fragment — uppercase hex included — is redacted even in
+			// isolation (#835 review — short PEM tail leak).
 			if pemHexHashRe.MatchString(content) {
 				class[i] = weak
 			} else {

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -117,6 +117,16 @@ var pemStrongBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{44,}={0,3}$`)
 // redacted when it sits directly against a strong body line or a PEM marker.
 var pemWeakBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{8,}={0,3}$`)
 
+// pemInlineBodyRe matches a full-width PEM/DER base64 body run (>=44 chars — the
+// same width pemStrongBodyRe treats as key material) wherever it appears, even
+// embedded inside a larger line such as command output (`$ echo MIIEv…`, `cat
+// id_rsa: MIIEv…`). redactClippedPEM only recognizes a body that is the whole
+// line (after any list bullet), so an inline clipped body carrying a command or
+// label prefix would otherwise survive into the prompt and persisted file (#835
+// review). The run is unanchored and bounded by non-base64 characters, so the
+// surrounding prose ("$ echo", "cat id_rsa:") is preserved.
+var pemInlineBodyRe = regexp.MustCompile(`[A-Za-z0-9+/]{44,}={0,3}`)
+
 // listBulletPrefixRe captures the leading whitespace and optional list bullet
 // ("- ", "* ", "+ ") of a post-mortem line so classification ignores the bullet
 // and a redacted run can be re-emitted with the same one.
@@ -131,10 +141,24 @@ func redactPostmortemSecrets(text string) string {
 		text = r.re.ReplaceAllString(text, r.repl)
 	}
 	text = redactClippedPEM(text)
+	text = redactInlinePEMBody(text)
 	for _, r := range postmortemRedactions {
 		text = r.re.ReplaceAllString(text, r.repl)
 	}
 	return text
+}
+
+// redactInlinePEMBody masks a full-width base64 body run embedded inside a
+// larger line — the inline complement to redactClippedPEM's whole-line scrubber.
+// It runs after redactClippedPEM (whole-line body runs are already collapsed to a
+// marker there, so this only catches genuinely embedded runs like `$ echo <body>`
+// or `cat id_rsa: <body>`) and masks just the base64 run, keeping the command or
+// label prefix so the post-mortem still records what the attempt tried (#835
+// review). A 44+ base64 run in benign output (a long hex hash, a signed-URL token)
+// is redacted too; that mirrors pemStrongBodyRe's existing whole-line behavior and
+// is the conservative choice for a secrets-hygiene pass.
+func redactInlinePEMBody(text string) string {
+	return pemInlineBodyRe.ReplaceAllString(text, pemRedactionMarker)
 }
 
 // redactClippedPEM masks PEM private-key material whose -----BEGIN----- banner

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -72,6 +72,10 @@ var postmortemRedactions = []struct {
 	{regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{20,}\b`), "[REDACTED_SLACK_TOKEN]"},
 }
 
+// pemRedactionMarker replaces a redacted PEM private-key block, whether the
+// complete-block regex or the tail-clipped scrubber (redactClippedPEM) caught it.
+const pemRedactionMarker = "[REDACTED_PRIVATE_KEY_BLOCK]"
+
 // postmortemMultilineRedactions collapse credential shapes whose body spans
 // several lines. The per-line postmortemRedactions above only mask the first
 // line of such a value — a `KEY="-----BEGIN … KEY-----` assignment redacts the
@@ -87,8 +91,10 @@ var postmortemMultilineRedactions = []struct {
 	// (?s) lets . span the base64 body/footer lines — including any per-line
 	// bullet prefixes the post-mortem adds — and the lazy .*? stops at the first
 	// matching END so adjacent blocks are not merged. Catches a bare PEM key
-	// dumped to the log as well as one embedded in a KEY="…" assignment.
-	{regexp.MustCompile(`(?is)-----BEGIN[ A-Z0-9]+-----.*?-----END[ A-Z0-9]+-----`), "[REDACTED_PRIVATE_KEY_BLOCK]"},
+	// dumped to the log as well as one embedded in a KEY="…" assignment. A block
+	// whose BEGIN banner fell outside the scanned tail is handled separately by
+	// redactClippedPEM.
+	{regexp.MustCompile(`(?is)-----BEGIN[ A-Z0-9]+-----.*?-----END[ A-Z0-9]+-----`), pemRedactionMarker},
 	// KEY="…" whose closing quote lands on a later line (any multiline secret
 	// value). The embedded \n forces a genuine multiline match; single-line
 	// assignments are left to the per-line patterns. [^"] spans newlines, so the
@@ -97,17 +103,123 @@ var postmortemMultilineRedactions = []struct {
 	{regexp.MustCompile(`(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|PRIVATE[_-]?KEY)[A-Z0-9_]*)\s*[:=]\s*"[^"]*\n[^"]*"`), "${1}=[REDACTED]"},
 }
 
+// pemMarkerRe matches a PEM banner line (-----BEGIN … KEY----- / -----END …
+// -----, also CERTIFICATE), after any list-bullet prefix the post-mortem adds.
+var pemMarkerRe = regexp.MustCompile(`^-{5}(?:BEGIN|END)[ A-Z0-9]+-{5}$`)
+
+// pemStrongBodyRe matches a full-width PEM/DER base64 body line: >=44 base64
+// characters with optional '=' padding. 44 is above a bare 40-char git SHA, so a
+// lone hash is never mistaken for key material; canonical PEM body lines are 64.
+var pemStrongBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{44,}={0,3}$`)
+
+// pemWeakBodyRe matches a short base64 fragment (>=8 chars) — a clipped final
+// body line. On its own it is too short to trust as key material, so it is only
+// redacted when it sits directly against a strong body line or a PEM marker.
+var pemWeakBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{8,}={0,3}$`)
+
+// listBulletPrefixRe captures the leading whitespace and optional list bullet
+// ("- ", "* ", "+ ") of a post-mortem line so classification ignores the bullet
+// and a redacted run can be re-emitted with the same one.
+var listBulletPrefixRe = regexp.MustCompile(`^\s*(?:[-*+]\s+)?`)
+
 // redactPostmortemSecrets masks common credential shapes in place. Multiline
 // patterns run first so a PEM key or other multiline secret value is collapsed
-// to a single redacted token before the per-line patterns run.
+// to a single redacted token; redactClippedPEM then catches key material whose
+// BEGIN banner fell outside the scanned tail; the per-line patterns run last.
 func redactPostmortemSecrets(text string) string {
 	for _, r := range postmortemMultilineRedactions {
 		text = r.re.ReplaceAllString(text, r.repl)
 	}
+	text = redactClippedPEM(text)
 	for _, r := range postmortemRedactions {
 		text = r.re.ReplaceAllString(text, r.repl)
 	}
 	return text
+}
+
+// redactClippedPEM masks PEM private-key material whose -----BEGIN----- banner
+// fell outside the scanned log tail, so the complete-block regex in
+// postmortemMultilineRedactions cannot see it (#835 review). When a 400-line
+// tail starts inside a key dump, the orphaned base64 body lines (and any END
+// footer) otherwise survive into the "last actions" section and reach the prompt
+// and persisted file.
+//
+// It is line-oriented over the assembled body: classify each line (after any
+// list bullet) as a PEM marker, a full-width base64 body line, or a short base64
+// fragment, then redact each maximal contiguous run of such lines that either
+// contains a marker or holds >=2 full-width body lines. A lone base64 line with
+// no PEM context is left alone — it may be a hash or blob, not key material.
+func redactClippedPEM(text string) string {
+	lines := strings.Split(text, "\n")
+	n := len(lines)
+	const (
+		other = iota
+		weak
+		strong
+		marker
+	)
+	class := make([]int, n)
+	for i, ln := range lines {
+		content := ln[len(listBulletPrefixRe.FindString(ln)):]
+		switch {
+		case pemMarkerRe.MatchString(content):
+			class[i] = marker
+		case pemStrongBodyRe.MatchString(content):
+			class[i] = strong
+		case pemWeakBodyRe.MatchString(content):
+			class[i] = weak
+		}
+	}
+	// A line joins a PEM run if it is a marker or full-width body line, or a weak
+	// fragment transitively adjacent to one (so a clipped final body line next to
+	// the block is swept in, but an isolated short token is not).
+	inRun := make([]bool, n)
+	for i, c := range class {
+		if c == marker || c == strong {
+			inRun[i] = true
+		}
+	}
+	for changed := true; changed; {
+		changed = false
+		for i := 0; i < n; i++ {
+			if inRun[i] || class[i] != weak {
+				continue
+			}
+			if (i > 0 && inRun[i-1]) || (i+1 < n && inRun[i+1]) {
+				inRun[i] = true
+				changed = true
+			}
+		}
+	}
+	// Walk maximal runs; redact those with a marker or >=2 full-width body lines,
+	// collapsing each to a single marker that keeps the run's first bullet.
+	var out []string
+	for i := 0; i < n; {
+		if !inRun[i] {
+			out = append(out, lines[i])
+			i++
+			continue
+		}
+		j := i
+		hasMarker, strongCount := false, 0
+		for j < n && inRun[j] {
+			switch class[j] {
+			case marker:
+				hasMarker = true
+			case strong:
+				strongCount++
+			}
+			j++
+		}
+		if hasMarker || strongCount >= 2 {
+			prefix := listBulletPrefixRe.FindString(lines[i])
+			out = append(out, prefix+pemRedactionMarker)
+		} else {
+			out = append(out, lines[i:j]...)
+		}
+		i = j
+	}
+	return strings.Join(out, "\n")
 }
 
 // failureSignatures identify lines that report a failed command, build error,

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -1,0 +1,274 @@
+package worker
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Prior-attempt post-mortem extraction (#835).
+//
+// When a worker attempt fails and the orchestrator respawns it, the new
+// attempt's prompt otherwise only carries GitHub-side feedback (CI output,
+// review comments, rebase conflicts). The failed attempt's own trajectory —
+// everything the CLI streamed into <state_dir>/logs/<slot>.log — is discarded,
+// so attempt N+1 has no idea what attempt N tried and repeats the same dead
+// ends. ExtractPostmortem distills a compact, secret-redacted summary from the
+// tail of that log so the retry prompt can carry it forward.
+//
+// This is a deterministic, backend-agnostic heuristic pass (no LLM call): it
+// scans the tail for failure/error signatures, files the attempt touched, and
+// the last actions before termination. Extraction is best-effort — a missing,
+// empty, or unreadable log yields an empty string (no section), never an error.
+
+const (
+	// PostmortemTailLines bounds how many trailing log lines the extractor
+	// scans. Worker logs can be enormous; the failure signal lives near the
+	// end, so scanning the tail keeps the pass cheap and focused.
+	PostmortemTailLines = 400
+
+	// PostmortemPromptCapBytes hard-caps the post-mortem excerpt placed in a
+	// retry prompt. Logs can be huge and prompt bloat is a real token cost;
+	// the full post-mortem is persisted to disk uncapped by the caller.
+	PostmortemPromptCapBytes = 2048
+
+	maxPostmortemFailureLines = 20
+	maxPostmortemEditedFiles  = 15
+	maxPostmortemLastActions  = 15
+	// maxPostmortemLineRunes trims individual selected lines so a single
+	// pathological line (a giant JSON blob, a base64 payload) cannot dominate
+	// the budget.
+	maxPostmortemLineRunes = 400
+)
+
+// postmortemRedactions mirrors internal/supervisor's sensitiveRedactions so
+// obvious credential shapes never reach the retry prompt or the persisted
+// post-mortem file. The worker package cannot import supervisor (supervisor
+// already imports worker), so the patterns are mirrored here rather than
+// shared; keep the two lists in sync.
+var postmortemRedactions = []struct {
+	re   *regexp.Regexp
+	repl string
+}{
+	{regexp.MustCompile(`(?i)\bAuthorization\s*:\s*[^\n\r]+`), "Authorization: [REDACTED]"},
+	{regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+`), "Bearer [REDACTED]"},
+	{regexp.MustCompile(`(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|PRIVATE[_-]?KEY)[A-Z0-9_]*)\s*[:=]\s*("[^"\n]*"|'[^'\n]*'|[^\s\n]+)`), "${1}=[REDACTED]"},
+	{regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9_]{20,}\b`), "[REDACTED_GITHUB_TOKEN]"},
+	{regexp.MustCompile(`\bsk-[A-Za-z0-9]{20,}\b`), "[REDACTED_API_KEY]"},
+	{regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{20,}\b`), "[REDACTED_SLACK_TOKEN]"},
+}
+
+// redactPostmortemSecrets masks common credential shapes in place.
+func redactPostmortemSecrets(text string) string {
+	for _, r := range postmortemRedactions {
+		text = r.re.ReplaceAllString(text, r.repl)
+	}
+	return text
+}
+
+// failureSignatures identify lines that report a failed command, build error,
+// or test failure across the CLIs a worker may drive (Go tooling, git, npm,
+// python, generic shells). The set is intentionally curated rather than
+// matching every mention of "error" — a cap plus dedup bound any noise.
+var failureSignatures = []*regexp.Regexp{
+	regexp.MustCompile(`^\s*(?:--- FAIL|=== FAIL|FAIL\b)`), // go test failures
+	regexp.MustCompile(`^\s*ok\s+\S+\s+\S+\s+\[build failed\]`),
+	regexp.MustCompile(`^\s*panic:`),     // go / runtime panic
+	regexp.MustCompile(`\.go:\d+:\d+:`),  // go compiler diagnostics
+	regexp.MustCompile(`^\s*#\s+\S`),     // go build package error header
+	regexp.MustCompile(`\bundefined:\s`), // go link/compile
+	regexp.MustCompile(`(?i)\bexit status [1-9]`),
+	regexp.MustCompile(`(?i)\bexit code [1-9]`),
+	regexp.MustCompile(`(?i)\bcommand (?:failed|not found)\b`),
+	regexp.MustCompile(`(?i)^\s*error[:\s]`),
+	regexp.MustCompile(`(?i)\berror:`),
+	regexp.MustCompile(`(?i)\bfatal:`),
+	regexp.MustCompile(`(?i)\bnpm ERR!`),
+	regexp.MustCompile(`(?i)\bTraceback \(most recent call last\)`),
+	regexp.MustCompile(`(?i)\bassertion failed\b`),
+	regexp.MustCompile(`(?i)\b(?:build|tests?)\s+failed\b`),
+}
+
+// editedFilePatterns capture the path a line reports as edited/written. They
+// cover claude stream-json tool inputs ("file_path": "…"), common human-style
+// verbs some CLIs print, and unified-diff headers.
+var editedFilePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`"file_path"\s*:\s*"([^"]+)"`),
+	regexp.MustCompile(`(?i)^\s*(?:Edited|Editing|Wrote|Writing|Created|Creating|Modified|Updated)\s+(?:file\s+)?(\S+)`),
+	regexp.MustCompile(`^\+\+\+ b/(\S+)`),
+	regexp.MustCompile(`^diff --git a/\S+ b/(\S+)`),
+}
+
+// ExtractPostmortem reads up to tailLines trailing lines of the worker log at
+// path and returns a compact, secret-redacted post-mortem of the failed
+// attempt (or "" when the log is missing, empty, or unreadable — callers treat
+// "" as "no section"). Pass tailLines <= 0 to use PostmortemTailLines.
+func ExtractPostmortem(path string, tailLines int) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	if tailLines <= 0 {
+		tailLines = PostmortemTailLines
+	}
+	tail, err := readLogTail(path, tailLines)
+	if err != nil {
+		return "" // missing / unreadable ⇒ graceful degradation
+	}
+	if strings.TrimSpace(tail) == "" {
+		return "" // empty log ⇒ no section
+	}
+	return extractPostmortemBody(tail)
+}
+
+// readLogTail returns the last limit lines of the file at path joined by
+// newlines. It mirrors the orchestrator's readLastLines reader.
+func readLogTail(path string, limit int) (string, error) {
+	if limit <= 0 {
+		return "", nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	lines := make([]string, 0, limit)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+		if len(lines) > limit {
+			lines = lines[1:]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+// extractPostmortemBody runs the heuristic pass over already-read log text and
+// returns the redacted markdown body (or "" when nothing useful was found).
+func extractPostmortemBody(logText string) string {
+	rawLines := strings.Split(logText, "\n")
+
+	var failures, files, actions []string
+	seenFailure := map[string]bool{}
+	seenFile := map[string]bool{}
+
+	for _, raw := range rawLines {
+		line := trimPostmortemLine(raw)
+		if line == "" {
+			continue
+		}
+		if len(failures) < maxPostmortemFailureLines && matchesAny(line, failureSignatures) && !seenFailure[line] {
+			seenFailure[line] = true
+			failures = append(failures, line)
+		}
+		if len(files) < maxPostmortemEditedFiles {
+			if path := extractEditedFile(raw); path != "" && !seenFile[path] {
+				seenFile[path] = true
+				files = append(files, path)
+			}
+		}
+	}
+
+	// Last actions: the final non-empty lines, in chronological order.
+	for i := len(rawLines) - 1; i >= 0 && len(actions) < maxPostmortemLastActions; i-- {
+		line := trimPostmortemLine(rawLines[i])
+		if line == "" {
+			continue
+		}
+		actions = append(actions, line)
+	}
+	reverse(actions)
+
+	if len(failures) == 0 && len(files) == 0 && len(actions) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	if len(failures) > 0 {
+		b.WriteString("### Errors / failed commands observed\n")
+		for _, f := range failures {
+			fmt.Fprintf(&b, "- %s\n", f)
+		}
+		b.WriteString("\n")
+	}
+	if len(files) > 0 {
+		b.WriteString("### Files the previous attempt touched\n")
+		for _, f := range files {
+			fmt.Fprintf(&b, "- %s\n", f)
+		}
+		b.WriteString("\n")
+	}
+	if len(actions) > 0 {
+		b.WriteString("### Last actions before the attempt ended\n")
+		for _, a := range actions {
+			fmt.Fprintf(&b, "- %s\n", a)
+		}
+	}
+
+	return redactPostmortemSecrets(strings.TrimRight(b.String(), "\n"))
+}
+
+// CapPostmortem hard-caps a post-mortem to at most capBytes of content and
+// appends a short truncation marker when it had to cut. Truncation lands on a
+// line boundary where possible and always yields valid UTF-8. capBytes <= 0
+// disables the cap.
+func CapPostmortem(s string, capBytes int) string {
+	if capBytes <= 0 || len(s) <= capBytes {
+		return s
+	}
+	truncated := s[:capBytes]
+	if idx := strings.LastIndexByte(truncated, '\n'); idx > 0 {
+		truncated = truncated[:idx]
+	}
+	truncated = sanitizePromptUTF8(truncated)
+	return strings.TrimRight(truncated, "\n") +
+		"\n\n… (post-mortem truncated for the prompt; full version saved to the state dir)"
+}
+
+func trimPostmortemLine(raw string) string {
+	line := strings.TrimRight(raw, " \t\r")
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return ""
+	}
+	runes := []rune(line)
+	if len(runes) > maxPostmortemLineRunes {
+		line = string(runes[:maxPostmortemLineRunes]) + " …"
+	}
+	return line
+}
+
+func matchesAny(line string, patterns []*regexp.Regexp) bool {
+	for _, re := range patterns {
+		if re.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+func extractEditedFile(raw string) string {
+	for _, re := range editedFilePatterns {
+		if m := re.FindStringSubmatch(raw); m != nil {
+			path := strings.TrimSpace(m[1])
+			path = strings.Trim(path, `"',`)
+			if path != "" {
+				return path
+			}
+		}
+	}
+	return ""
+}
+
+func reverse(s []string) {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+}

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -134,22 +134,31 @@ var pemWeakBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{8,}={0,3}$`)
 // full-width body line, so a lone git SHA is still not over-redacted.
 var pemHexHashRe = regexp.MustCompile(`^[0-9a-f]+$`)
 
-// pemInlineBodyRe finds a candidate PEM/DER base64 run — >=16 base64 characters
-// with optional '=' padding — embedded anywhere in a line, such as command output
-// (`$ echo MIIEv…`, `cat id_rsa: MIIEv…`). redactClippedPEM only recognizes a body
-// that is the whole line (after any list bullet), so an inline clipped body
-// carrying a command or label prefix would otherwise survive into the prompt and
-// persisted file (#835 review). The pattern is deliberately broad — every
-// >=16-char run is a candidate, padded or not — so a short UNPADDED tail reaches
-// the classifier (inlineRunIsKeyMaterial) instead of being skipped by the regex
-// itself; the earlier padded-only bar let `$ echo Kj34GkxFhD90vcNLYLInFE` (no '=')
-// slip through into both sinks (#835 review — unpadded inline PEM tail leak).
+// pemInlineBodyRe finds a candidate PEM/DER base64 run embedded anywhere in a
+// line, such as command output (`$ echo MIIEv…`, `cat id_rsa: MIIEv…`).
+// redactClippedPEM only recognizes a body that is the whole line (after any list
+// bullet), so an inline clipped body carrying a command or label prefix would
+// otherwise survive into the prompt and persisted file (#835 review). Two
+// alternatives feed the classifier (inlineRunIsKeyMaterial):
+//
+//   - a >=16-char run with optional '=' padding — deliberately broad so a short
+//     UNPADDED tail still reaches the classifier instead of being skipped by the
+//     regex itself; the earlier padded-only bar let `$ echo Kj34GkxFhD90vcNLYLInFE`
+//     (no '=') slip through into both sinks (#835 review — unpadded inline PEM
+//     tail leak).
+//   - a >=8-char run that CARRIES '=' padding — a short clipped final body line
+//     such as `$ echo AbCdEfGhIjK=`. The 16-char floor above skipped an 8–15-char
+//     padded fragment before the classifier could see it, leaking the raw key tail
+//     into both sinks (#835 review — short inline PEM tail leak). '=' padding never
+//     appears in a git SHA / hex digest, so lowering the floor only for padded runs
+//     closes the leak without garbling the shorter identifiers and paths a
+//     post-mortem legitimately records.
 //
 // The run is unanchored and bounded by non-base64 characters, so the surrounding
 // prose ("$ echo", "cat id_rsa:") is preserved. Greedy matching grabs the whole
 // run plus any trailing '=' padding, so a full-width padded body is masked whole
 // rather than split.
-var pemInlineBodyRe = regexp.MustCompile(`[A-Za-z0-9+/]{16,}={0,3}`)
+var pemInlineBodyRe = regexp.MustCompile(`[A-Za-z0-9+/]{16,}={0,3}|[A-Za-z0-9+/]{8,}={1,3}`)
 
 // listBulletPrefixRe captures the leading whitespace and optional list bullet
 // ("- ", "* ", "+ ") of a post-mortem line so classification ignores the bullet

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -134,15 +134,25 @@ var pemWeakBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{8,}={0,3}$`)
 // full-width body line, so a lone git SHA is still not over-redacted.
 var pemHexHashRe = regexp.MustCompile(`^[0-9a-f]+$`)
 
-// pemInlineBodyRe matches a full-width PEM/DER base64 body run (>=44 chars — the
-// same width pemStrongBodyRe treats as key material) wherever it appears, even
+// pemInlineBodyRe matches a PEM/DER base64 body run wherever it appears, even
 // embedded inside a larger line such as command output (`$ echo MIIEv…`, `cat
 // id_rsa: MIIEv…`). redactClippedPEM only recognizes a body that is the whole
 // line (after any list bullet), so an inline clipped body carrying a command or
 // label prefix would otherwise survive into the prompt and persisted file (#835
-// review). The run is unanchored and bounded by non-base64 characters, so the
-// surrounding prose ("$ echo", "cat id_rsa:") is preserved.
-var pemInlineBodyRe = regexp.MustCompile(`[A-Za-z0-9+/]{44,}={0,3}`)
+// review). Two shapes qualify as key material:
+//
+//   - a full-width run (>=44 chars, the same width pemStrongBodyRe treats as key
+//     material), with or without '=' padding; or
+//   - a shorter run (>=16 chars) that carries base64 '=' padding — the tail
+//     signature of an encoded binary blob such as a clipped final PEM body line
+//     (`$ echo Kj34…Ec=`). '=' padding never appears in a git SHA / hex digest,
+//     so this catches a short inline tail the >=44 branch alone missed (#835
+//     review — short inline PEM tail leak) without redacting a lone hash.
+//
+// The run is unanchored and bounded by non-base64 characters, so the surrounding
+// prose ("$ echo", "cat id_rsa:") is preserved. The full-width alternative is
+// tried first so a padded full-width run is masked whole rather than split.
+var pemInlineBodyRe = regexp.MustCompile(`[A-Za-z0-9+/]{44,}={0,3}|[A-Za-z0-9+/]{16,}={1,2}`)
 
 // listBulletPrefixRe captures the leading whitespace and optional list bullet
 // ("- ", "* ", "+ ") of a post-mortem line so classification ignores the bullet
@@ -165,15 +175,17 @@ func redactPostmortemSecrets(text string) string {
 	return text
 }
 
-// redactInlinePEMBody masks a full-width base64 body run embedded inside a
-// larger line — the inline complement to redactClippedPEM's whole-line scrubber.
-// It runs after redactClippedPEM (whole-line body runs are already collapsed to a
-// marker there, so this only catches genuinely embedded runs like `$ echo <body>`
-// or `cat id_rsa: <body>`) and masks just the base64 run, keeping the command or
-// label prefix so the post-mortem still records what the attempt tried (#835
-// review). A 44+ base64 run in benign output (a long hex hash, a signed-URL token)
-// is redacted too; that mirrors pemStrongBodyRe's existing whole-line behavior and
-// is the conservative choice for a secrets-hygiene pass.
+// redactInlinePEMBody masks a base64 body run embedded inside a larger line —
+// the inline complement to redactClippedPEM's whole-line scrubber. It runs after
+// redactClippedPEM (whole-line body runs are already collapsed to a marker there,
+// so this only catches genuinely embedded runs like `$ echo <body>` or `cat
+// id_rsa: <body>`) and masks just the base64 run, keeping the command or label
+// prefix so the post-mortem still records what the attempt tried (#835 review).
+// The two run shapes it treats as key material — a full-width run and a shorter
+// '='-padded tail — are described on pemInlineBodyRe. A benign 44+ base64 run (a
+// long hex hash, a signed-URL token) or a padded blob is redacted too; that
+// mirrors pemStrongBodyRe's existing whole-line behavior and is the conservative
+// choice for a secrets-hygiene pass.
 func redactInlinePEMBody(text string) string {
 	return pemInlineBodyRe.ReplaceAllString(text, pemRedactionMarker)
 }

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -138,27 +138,23 @@ var pemHexHashRe = regexp.MustCompile(`^[0-9a-f]+$`)
 // line, such as command output (`$ echo MIIEv…`, `cat id_rsa: MIIEv…`).
 // redactClippedPEM only recognizes a body that is the whole line (after any list
 // bullet), so an inline clipped body carrying a command or label prefix would
-// otherwise survive into the prompt and persisted file (#835 review). Two
-// alternatives feed the classifier (inlineRunIsKeyMaterial):
+// otherwise survive into the prompt and persisted file (#835 review).
 //
-//   - a >=16-char run with optional '=' padding — deliberately broad so a short
-//     UNPADDED tail still reaches the classifier instead of being skipped by the
-//     regex itself; the earlier padded-only bar let `$ echo Kj34GkxFhD90vcNLYLInFE`
-//     (no '=') slip through into both sinks (#835 review — unpadded inline PEM
-//     tail leak).
-//   - a >=8-char run that CARRIES '=' padding — a short clipped final body line
-//     such as `$ echo AbCdEfGhIjK=`. The 16-char floor above skipped an 8–15-char
-//     padded fragment before the classifier could see it, leaking the raw key tail
-//     into both sinks (#835 review — short inline PEM tail leak). '=' padding never
-//     appears in a git SHA / hex digest, so lowering the floor only for padded runs
-//     closes the leak without garbling the shorter identifiers and paths a
-//     post-mortem legitimately records.
+// It matches any base64 run of >=8 characters with optional '=' padding and
+// hands the accept/reject decision to inlineRunIsKeyMaterial. The floor is a
+// deliberately broad >=8 whether or not the run carries '=' padding: an earlier
+// >=16-only bar for UNPADDED runs skipped short fragments such as
+// `$ echo XyZ12aBc` before the classifier could see them, leaking the raw key
+// tail into both sinks (#835 review — unpadded inline PEM tail leak). 8 is the
+// shortest run the classifier can still tell apart from the identifiers and
+// paths a post-mortem records, so a lower floor would only feed it fragments it
+// must preserve anyway.
 //
 // The run is unanchored and bounded by non-base64 characters, so the surrounding
 // prose ("$ echo", "cat id_rsa:") is preserved. Greedy matching grabs the whole
 // run plus any trailing '=' padding, so a full-width padded body is masked whole
 // rather than split.
-var pemInlineBodyRe = regexp.MustCompile(`[A-Za-z0-9+/]{16,}={0,3}|[A-Za-z0-9+/]{8,}={1,3}`)
+var pemInlineBodyRe = regexp.MustCompile(`[A-Za-z0-9+/]{8,}={0,3}`)
 
 // listBulletPrefixRe captures the leading whitespace and optional list bullet
 // ("- ", "* ", "+ ") of a post-mortem line so classification ignores the bullet
@@ -197,8 +193,8 @@ func redactInlinePEMBody(text string) string {
 	})
 }
 
-// inlineRunIsKeyMaterial reports whether an embedded >=16-char base64 run
-// (pemInlineBodyRe) is (clipped) PEM/DER key material worth redacting. It mirrors
+// inlineRunIsKeyMaterial reports whether an embedded base64 run (>=8 chars,
+// pemInlineBodyRe) is (clipped) PEM/DER key material worth redacting. It mirrors
 // the whole-line classification in redactClippedPEM but is tuned to spare the
 // identifiers and file paths that legitimately fill a post-mortem:
 //
@@ -206,21 +202,25 @@ func redactInlinePEMBody(text string) string {
 //     material outright — the same shapes the padded whole-line tail and
 //     pemStrongBodyRe already redact ('=' padding never appears in a git SHA /
 //     hex digest, and 44 is above a bare 40-char SHA);
-//   - a shorter UNPADDED run is key material only when it is NOT a plausible hex
-//     hash (pemHexHashRe) AND carries BOTH an uppercase letter and a digit — the
-//     encoded-byte mix a clipped final PEM body line such as
-//     `$ echo Kj34GkxFhD90vcNLYLInFE` has and the two kinds of benign run that
-//     reach this matcher do not: a lowercase file path keeps its digits but has no
-//     uppercase (`internal/attempt2`, `stream/01`), and a camelCase identifier
-//     keeps its case but has no digit (`handleUserRequest`). Requiring both masks
-//     the finding's unpadded inline tail (#835 review — unpadded inline PEM tail
-//     leak) without gutting the post-mortem, and a lowercase-hex fragment (a git
-//     SHA / digest) stays intact, matching redactClippedPEM's carve-out.
+//   - a lowercase-hex fragment (pemHexHashRe) is a plausible git SHA / digest and
+//     stays intact, matching redactClippedPEM's carve-out;
+//   - a shorter UNPADDED run is key material when it carries BOTH an uppercase
+//     letter and a digit — the encoded-byte mix a clipped final PEM body line such
+//     as `$ echo XyZ12aBc` has and the benign runs reaching this matcher do not: a
+//     lowercase file path keeps its digits but has no uppercase
+//     (`internal/attempt2`, `stream/01`), and a camelCase identifier keeps its case
+//     but has no digit (`handleUserRequest`);
+//   - an ALL-UPPERCASE run of >=16 chars (no lowercase, no digit) is likewise key
+//     material: camelCase/PascalCase identifiers carry lowercase and all-caps
+//     constants use '_' separators that break the run below this width, so a long
+//     bare uppercase base64 blob such as `$ echo ABCDEFGHIJKLMNOPQRSTUVWXYZAB` is a
+//     clipped key body, not ordinary post-mortem prose (#835 review — unpadded
+//     inline PEM tail leak, all-caps case).
 //
-// A bare fragment carrying only one of the two signals is inherently
-// indistinguishable from a path or identifier — redacting it would garble those —
-// so the residual is left to the padded / full-width / whole-line-clipped and
-// complete-block branches, which cover the shapes real key dumps actually take.
+// A shorter run carrying only one of these signals is inherently indistinguishable
+// from a path or identifier — redacting it would garble those — so the residual is
+// left to the padded / full-width / whole-line-clipped and complete-block branches,
+// which cover the shapes real key dumps actually take.
 func inlineRunIsKeyMaterial(run string) bool {
 	body := strings.TrimRight(run, "=")
 	if len(body) < len(run) { // carried '=' padding — an encoded blob, not a hash
@@ -232,8 +232,14 @@ func inlineRunIsKeyMaterial(run string) bool {
 	if pemHexHashRe.MatchString(body) { // a lone lowercase git SHA / digest
 		return false
 	}
-	return strings.ContainsAny(body, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") &&
-		strings.ContainsAny(body, "0123456789")
+	hasUpper := strings.ContainsAny(body, "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	hasLower := strings.ContainsAny(body, "abcdefghijklmnopqrstuvwxyz")
+	hasDigit := strings.ContainsAny(body, "0123456789")
+	if hasUpper && hasDigit { // encoded-byte mix of a clipped key body tail
+		return true
+	}
+	// A long, all-uppercase base64 blob is not an ordinary identifier or path.
+	return hasUpper && !hasLower && len(body) >= 16
 }
 
 // redactClippedPEM masks PEM private-key material whose -----BEGIN----- banner

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
@@ -43,6 +44,16 @@ const (
 	maxPostmortemLineRunes = 400
 )
 
+// workerLogAttemptMarker is the banner buildWorkerRunnerScript writes to
+// slot.log at the start of every (re)spawn ("[maestro] worker worktree: …").
+// Respawns append to the same slot.log, so this line is the per-attempt
+// boundary: the tail can otherwise carry an older attempt's failures/files
+// whenever the just-failed attempt produced fewer than the scanned lines, and
+// the prompt would mislabel that stale content as the current attempt (#835
+// review). isolateCurrentAttempt slices the tail to the region after the last
+// marker before extraction.
+const workerLogAttemptMarker = "[maestro] worker worktree:"
+
 // postmortemRedactions mirrors internal/supervisor's sensitiveRedactions so
 // obvious credential shapes never reach the retry prompt or the persisted
 // post-mortem file. The worker package cannot import supervisor (supervisor
@@ -81,6 +92,7 @@ var failureSignatures = []*regexp.Regexp{
 	regexp.MustCompile(`\bundefined:\s`), // go link/compile
 	regexp.MustCompile(`(?i)\bexit status [1-9]`),
 	regexp.MustCompile(`(?i)\bexit code [1-9]`),
+	regexp.MustCompile(`^\s*\[codex\]\s+exit=[1-9]`), // codex stream-splitter's rendered non-zero exit
 	regexp.MustCompile(`(?i)\bcommand (?:failed|not found)\b`),
 	regexp.MustCompile(`(?i)^\s*error[:\s]`),
 	regexp.MustCompile(`(?i)\berror:`),
@@ -91,11 +103,20 @@ var failureSignatures = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)\b(?:build|tests?)\s+failed\b`),
 }
 
-// editedFilePatterns capture the path a line reports as edited/written. They
-// cover claude stream-json tool inputs ("file_path": "…"), common human-style
-// verbs some CLIs print, and unified-diff headers.
+// editedFilePatterns capture the path a line reports as edited/written from the
+// human-readable slot.log. They cover raw claude stream-json tool inputs
+// ("file_path": "…") on non-stream-split logs, the codex stream-splitter's
+// rendered file-change form ("[codex] <kind> <path>"), common human-style verbs
+// some CLIs print, and unified-diff headers. claude's stream-splitter renders
+// tool_use without its file_path input, so those edits are recovered from the
+// raw .jsonl side channel instead (see filesFromSideChannel).
 var editedFilePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`"file_path"\s*:\s*"([^"]+)"`),
+	// codex `exec --json` file_change rendered by the stream-splitter as
+	// "[codex] <kind> <path>" (renderCodexItem). The two whitespace-separated
+	// tokens after the tag distinguish it from "[codex] $ …", "[codex] exit=…",
+	// and "[codex] usage: …", none of which present as <word> <token>.
+	regexp.MustCompile(`^\s*\[codex\]\s+\w+\s+(\S+)`),
 	regexp.MustCompile(`(?i)^\s*(?:Edited|Editing|Wrote|Writing|Created|Creating|Modified|Updated)\s+(?:file\s+)?(\S+)`),
 	regexp.MustCompile(`^\+\+\+ b/(\S+)`),
 	regexp.MustCompile(`^diff --git a/\S+ b/(\S+)`),
@@ -116,10 +137,41 @@ func ExtractPostmortem(path string, tailLines int) string {
 	if err != nil {
 		return "" // missing / unreadable ⇒ graceful degradation
 	}
+	// Bound extraction to the just-failed attempt: respawns append to the same
+	// slot.log, so a short final attempt would otherwise inherit an older
+	// attempt's failures/files (#835 review).
+	tail = isolateCurrentAttempt(tail)
 	if strings.TrimSpace(tail) == "" {
 		return "" // empty log ⇒ no section
 	}
-	return extractPostmortemBody(tail)
+	// The claude stream-splitter renders tool_use without its file_path input,
+	// so the "files touched" section would be empty for stream-split logs.
+	// Recover those paths from the raw NDJSON side channel, likewise bounded to
+	// the current attempt. Best-effort: a missing/unreadable jsonl yields none.
+	sideChannelFiles := filesFromSideChannel(JSONLPathForLog(path), tailLines)
+	return extractPostmortemBody(tail, sideChannelFiles)
+}
+
+// isolateCurrentAttempt returns the slice of log text after the last line whose
+// trimmed form begins with workerLogAttemptMarker — the banner the worker
+// runner writes at the start of every (re)spawn. The final marker delimits the
+// most recent attempt, so everything after it is that attempt's own output. The
+// marker line itself is dropped (it carries a host worktree path). When no
+// marker is present — a non-stream-split/legacy log, or an attempt longer than
+// the scanned tail — the whole tail is already current-attempt output and is
+// returned unchanged.
+func isolateCurrentAttempt(text string) string {
+	lines := strings.Split(text, "\n")
+	last := -1
+	for i, l := range lines {
+		if strings.HasPrefix(strings.TrimSpace(l), workerLogAttemptMarker) {
+			last = i
+		}
+	}
+	if last < 0 {
+		return text
+	}
+	return strings.Join(lines[last+1:], "\n")
 }
 
 // readLogTail returns the last limit lines of the file at path joined by
@@ -152,12 +204,24 @@ func readLogTail(path string, limit int) (string, error) {
 
 // extractPostmortemBody runs the heuristic pass over already-read log text and
 // returns the redacted markdown body (or "" when nothing useful was found).
-func extractPostmortemBody(logText string) string {
+// sideChannelFiles are paths recovered from the raw .jsonl side channel (edits
+// the rendered slot.log dropped); they are merged after the in-log matches so
+// log order is preserved.
+func extractPostmortemBody(logText string, sideChannelFiles []string) string {
 	rawLines := strings.Split(logText, "\n")
 
 	var failures, files, actions []string
 	seenFailure := map[string]bool{}
 	seenFile := map[string]bool{}
+
+	addFile := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" || seenFile[path] || len(files) >= maxPostmortemEditedFiles {
+			return
+		}
+		seenFile[path] = true
+		files = append(files, path)
+	}
 
 	for _, raw := range rawLines {
 		line := trimPostmortemLine(raw)
@@ -168,12 +232,12 @@ func extractPostmortemBody(logText string) string {
 			seenFailure[line] = true
 			failures = append(failures, line)
 		}
-		if len(files) < maxPostmortemEditedFiles {
-			if path := extractEditedFile(raw); path != "" && !seenFile[path] {
-				seenFile[path] = true
-				files = append(files, path)
-			}
+		if path := extractEditedFile(raw); path != "" {
+			addFile(path)
 		}
+	}
+	for _, path := range sideChannelFiles {
+		addFile(path)
 	}
 
 	// Last actions: the final non-empty lines, in chronological order.
@@ -265,6 +329,158 @@ func extractEditedFile(raw string) string {
 		}
 	}
 	return ""
+}
+
+// filesFromSideChannel recovers the paths of files the attempt edited from the
+// raw NDJSON side channel (slot.jsonl) the stream-splitter appends alongside the
+// rendered slot.log. This is where claude tool_use edits keep their file_path
+// (the rendered log drops it) and where codex file_change items keep their
+// paths. Best-effort: an empty path, a missing/unreadable jsonl, or a log that
+// never used stream-split all yield no extra files. Like the log tail it is
+// bounded to the current attempt so a respawn's earlier edits are not attributed
+// to the just-failed one.
+func filesFromSideChannel(jsonlPath string, tailLines int) []string {
+	if strings.TrimSpace(jsonlPath) == "" {
+		return nil
+	}
+	if tailLines <= 0 {
+		tailLines = PostmortemTailLines
+	}
+	tail, err := readLogTail(jsonlPath, tailLines)
+	if err != nil || strings.TrimSpace(tail) == "" {
+		return nil
+	}
+	return filesFromRawFrames(isolateCurrentAttemptJSONL(tail))
+}
+
+// isolateCurrentAttemptJSONL slices raw NDJSON to the frames at and after the
+// last session-start frame. The side channel carries no worker-worktree banner
+// (that goes straight to slot.log, not through the splitter), so the backend's
+// own run-start frame — claude's system/init, codex's thread.started — is the
+// per-attempt boundary. When none is present the whole tail is returned.
+func isolateCurrentAttemptJSONL(text string) string {
+	lines := strings.Split(text, "\n")
+	last := -1
+	for i, l := range lines {
+		if isSessionStartFrame(l) {
+			last = i
+		}
+	}
+	if last < 0 {
+		return text
+	}
+	return strings.Join(lines[last:], "\n")
+}
+
+// isSessionStartFrame reports whether a raw NDJSON line is a backend's
+// session-start frame: claude emits {"type":"system","subtype":"init",…} and
+// codex emits {"type":"thread.started",…} at the start of each (re)spawn.
+func isSessionStartFrame(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || trimmed[0] != '{' {
+		return false
+	}
+	var f struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+	}
+	if json.Unmarshal([]byte(trimmed), &f) != nil {
+		return false
+	}
+	switch f.Type {
+	case "system":
+		return f.Subtype == "init"
+	case "thread.started":
+		return true
+	}
+	return false
+}
+
+// rawFileFrame is the subset of a raw NDJSON frame that carries an edited path:
+// a claude assistant/user message (tool_use blocks live in Content) or a codex
+// item envelope (file_change items carry Changes).
+type rawFileFrame struct {
+	Message *struct {
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+	Item *struct {
+		Changes []struct {
+			Path string `json:"path"`
+		} `json:"changes"`
+	} `json:"item"`
+}
+
+// rawToolBlock is the subset of a claude message content block needed to
+// recover an edit target: a tool_use block whose input names a file.
+type rawToolBlock struct {
+	Type  string `json:"type"`
+	Input struct {
+		FilePath     string `json:"file_path"`
+		NotebookPath string `json:"notebook_path"`
+	} `json:"input"`
+}
+
+// filesFromRawFrames extracts edited-file paths from raw NDJSON frames: claude
+// tool_use file_path/notebook_path inputs and codex file_change item paths.
+// Paths are de-duplicated and capped at maxPostmortemEditedFiles.
+func filesFromRawFrames(text string) []string {
+	var files []string
+	seen := map[string]bool{}
+	add := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" || seen[path] || len(files) >= maxPostmortemEditedFiles {
+			return
+		}
+		seen[path] = true
+		files = append(files, path)
+	}
+	for _, raw := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || trimmed[0] != '{' {
+			continue
+		}
+		var fr rawFileFrame
+		if json.Unmarshal([]byte(trimmed), &fr) != nil {
+			continue
+		}
+		if fr.Message != nil {
+			for _, p := range claudeEditPaths(fr.Message.Content) {
+				add(p)
+			}
+		}
+		if fr.Item != nil {
+			for _, c := range fr.Item.Changes {
+				add(c.Path)
+			}
+		}
+	}
+	return files
+}
+
+// claudeEditPaths returns the file paths of the tool_use blocks in a claude
+// message content field. Only blocks that actually carry a file_path or
+// notebook_path input contribute, so Read/Grep/Bash tool_use blocks add
+// nothing; content that is a plain string (some user messages) yields none.
+func claudeEditPaths(content json.RawMessage) []string {
+	if len(content) == 0 {
+		return nil
+	}
+	var blocks []rawToolBlock
+	if json.Unmarshal(content, &blocks) != nil {
+		return nil
+	}
+	var paths []string
+	for _, b := range blocks {
+		if b.Type != "tool_use" {
+			continue
+		}
+		if p := strings.TrimSpace(b.Input.FilePath); p != "" {
+			paths = append(paths, p)
+		} else if p := strings.TrimSpace(b.Input.NotebookPath); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
 }
 
 func reverse(s []string) {

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -134,25 +134,22 @@ var pemWeakBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{8,}={0,3}$`)
 // full-width body line, so a lone git SHA is still not over-redacted.
 var pemHexHashRe = regexp.MustCompile(`^[0-9a-f]+$`)
 
-// pemInlineBodyRe matches a PEM/DER base64 body run wherever it appears, even
-// embedded inside a larger line such as command output (`$ echo MIIEv…`, `cat
-// id_rsa: MIIEv…`). redactClippedPEM only recognizes a body that is the whole
-// line (after any list bullet), so an inline clipped body carrying a command or
-// label prefix would otherwise survive into the prompt and persisted file (#835
-// review). Two shapes qualify as key material:
-//
-//   - a full-width run (>=44 chars, the same width pemStrongBodyRe treats as key
-//     material), with or without '=' padding; or
-//   - a shorter run (>=16 chars) that carries base64 '=' padding — the tail
-//     signature of an encoded binary blob such as a clipped final PEM body line
-//     (`$ echo Kj34…Ec=`). '=' padding never appears in a git SHA / hex digest,
-//     so this catches a short inline tail the >=44 branch alone missed (#835
-//     review — short inline PEM tail leak) without redacting a lone hash.
+// pemInlineBodyRe finds a candidate PEM/DER base64 run — >=16 base64 characters
+// with optional '=' padding — embedded anywhere in a line, such as command output
+// (`$ echo MIIEv…`, `cat id_rsa: MIIEv…`). redactClippedPEM only recognizes a body
+// that is the whole line (after any list bullet), so an inline clipped body
+// carrying a command or label prefix would otherwise survive into the prompt and
+// persisted file (#835 review). The pattern is deliberately broad — every
+// >=16-char run is a candidate, padded or not — so a short UNPADDED tail reaches
+// the classifier (inlineRunIsKeyMaterial) instead of being skipped by the regex
+// itself; the earlier padded-only bar let `$ echo Kj34GkxFhD90vcNLYLInFE` (no '=')
+// slip through into both sinks (#835 review — unpadded inline PEM tail leak).
 //
 // The run is unanchored and bounded by non-base64 characters, so the surrounding
-// prose ("$ echo", "cat id_rsa:") is preserved. The full-width alternative is
-// tried first so a padded full-width run is masked whole rather than split.
-var pemInlineBodyRe = regexp.MustCompile(`[A-Za-z0-9+/]{44,}={0,3}|[A-Za-z0-9+/]{16,}={1,2}`)
+// prose ("$ echo", "cat id_rsa:") is preserved. Greedy matching grabs the whole
+// run plus any trailing '=' padding, so a full-width padded body is masked whole
+// rather than split.
+var pemInlineBodyRe = regexp.MustCompile(`[A-Za-z0-9+/]{16,}={0,3}`)
 
 // listBulletPrefixRe captures the leading whitespace and optional list bullet
 // ("- ", "* ", "+ ") of a post-mortem line so classification ignores the bullet
@@ -179,15 +176,55 @@ func redactPostmortemSecrets(text string) string {
 // the inline complement to redactClippedPEM's whole-line scrubber. It runs after
 // redactClippedPEM (whole-line body runs are already collapsed to a marker there,
 // so this only catches genuinely embedded runs like `$ echo <body>` or `cat
-// id_rsa: <body>`) and masks just the base64 run, keeping the command or label
-// prefix so the post-mortem still records what the attempt tried (#835 review).
-// The two run shapes it treats as key material — a full-width run and a shorter
-// '='-padded tail — are described on pemInlineBodyRe. A benign 44+ base64 run (a
-// long hex hash, a signed-URL token) or a padded blob is redacted too; that
-// mirrors pemStrongBodyRe's existing whole-line behavior and is the conservative
-// choice for a secrets-hygiene pass.
+// id_rsa: <body>`) and masks just the base64 run inlineRunIsKeyMaterial flags as
+// key material, keeping the command or label prefix so the post-mortem still
+// records what the attempt tried (#835 review).
 func redactInlinePEMBody(text string) string {
-	return pemInlineBodyRe.ReplaceAllString(text, pemRedactionMarker)
+	return pemInlineBodyRe.ReplaceAllStringFunc(text, func(run string) string {
+		if inlineRunIsKeyMaterial(run) {
+			return pemRedactionMarker
+		}
+		return run
+	})
+}
+
+// inlineRunIsKeyMaterial reports whether an embedded >=16-char base64 run
+// (pemInlineBodyRe) is (clipped) PEM/DER key material worth redacting. It mirrors
+// the whole-line classification in redactClippedPEM but is tuned to spare the
+// identifiers and file paths that legitimately fill a post-mortem:
+//
+//   - a '='-padded run, or a full-width run (>=44 non-padding chars), is key
+//     material outright — the same shapes the padded whole-line tail and
+//     pemStrongBodyRe already redact ('=' padding never appears in a git SHA /
+//     hex digest, and 44 is above a bare 40-char SHA);
+//   - a shorter UNPADDED run is key material only when it is NOT a plausible hex
+//     hash (pemHexHashRe) AND carries BOTH an uppercase letter and a digit — the
+//     encoded-byte mix a clipped final PEM body line such as
+//     `$ echo Kj34GkxFhD90vcNLYLInFE` has and the two kinds of benign run that
+//     reach this matcher do not: a lowercase file path keeps its digits but has no
+//     uppercase (`internal/attempt2`, `stream/01`), and a camelCase identifier
+//     keeps its case but has no digit (`handleUserRequest`). Requiring both masks
+//     the finding's unpadded inline tail (#835 review — unpadded inline PEM tail
+//     leak) without gutting the post-mortem, and a lowercase-hex fragment (a git
+//     SHA / digest) stays intact, matching redactClippedPEM's carve-out.
+//
+// A bare fragment carrying only one of the two signals is inherently
+// indistinguishable from a path or identifier — redacting it would garble those —
+// so the residual is left to the padded / full-width / whole-line-clipped and
+// complete-block branches, which cover the shapes real key dumps actually take.
+func inlineRunIsKeyMaterial(run string) bool {
+	body := strings.TrimRight(run, "=")
+	if len(body) < len(run) { // carried '=' padding — an encoded blob, not a hash
+		return true
+	}
+	if len(body) >= 44 { // full-width PEM/DER body line
+		return true
+	}
+	if pemHexHashRe.MatchString(body) { // a lone lowercase git SHA / digest
+		return false
+	}
+	return strings.ContainsAny(body, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") &&
+		strings.ContainsAny(body, "0123456789")
 }
 
 // redactClippedPEM masks PEM private-key material whose -----BEGIN----- banner

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -210,6 +210,10 @@ func redactInlinePEMBody(text string) string {
 //     lowercase file path keeps its digits but has no uppercase
 //     (`internal/attempt2`, `stream/01`), and a camelCase identifier keeps its case
 //     but has no digit (`handleUserRequest`);
+//   - a run carrying a '+' is key material: '+' is a base64-only character that
+//     never appears in a file path, a Go identifier, or a hex digest, so its
+//     presence marks an encoded blob (#835 review — mixed-case inline PEM tail leak,
+//     `$ echo abc+DefG`);
 //   - an ALL-UPPERCASE run (no lowercase, no digit) at or above the >=8 inline
 //     floor is likewise key material. The base64 alphabet spans all 26 uppercase
 //     letters, so a clipped DER body window can land entirely in A–Z with no other
@@ -220,10 +224,18 @@ func redactInlinePEMBody(text string) string {
 //     leak); a secrets-hygiene extractor resolves the ambiguity toward masking. The
 //     rare legitimate all-caps word of the same width (`HOSTNAME`, `PASSWORD`) is
 //     over-redacted, while shorter all-caps tokens (`SIGKILL`, HTTP verbs) fall
-//     below the >=8 floor and survive.
+//     below the >=8 floor and survive;
+//   - a MIXED-CASE, digit-free run of >=8 chars is key material when it holds no
+//     same-case letter run of >=4 — the "word" or "acronym" signal of a real
+//     identifier. A camelCase/PascalCase name the post-mortem records
+//     (`handleUserRequest`, `HTTPSConn`) always carries such a run, while a clipped
+//     base64 key tail (`$ echo AbCdEfGh`) alternates case almost every character
+//     with no readable word to lean on (#835 review — mixed-case inline PEM tail
+//     leak). The rare short-word identifier (`getUrlFor`) is over-redacted, the safe
+//     direction for a secrets-hygiene extractor.
 //
-// A run whose only signal is LOWERCASE — a file path or camelCase identifier
-// (`internal/attempt2`, `handleUserRequest`) — is indistinguishable from ordinary
+// A run whose only signal is LOWERCASE — a file path or lowercase word
+// (`internal/attempt2`, `something`) — is indistinguishable from ordinary
 // post-mortem prose and is left intact, so the extractor does not garble the
 // identifiers and paths it exists to record. The residual key shapes it declines
 // here are covered by the padded / full-width / whole-line-clipped and
@@ -239,15 +251,54 @@ func inlineRunIsKeyMaterial(run string) bool {
 	if pemHexHashRe.MatchString(body) { // a lone lowercase git SHA / digest
 		return false
 	}
+	if strings.Contains(body, "+") { // '+' is base64-only: never a path/identifier/hash
+		return true
+	}
 	hasUpper := strings.ContainsAny(body, "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	hasLower := strings.ContainsAny(body, "abcdefghijklmnopqrstuvwxyz")
 	hasDigit := strings.ContainsAny(body, "0123456789")
 	if hasUpper && hasDigit { // encoded-byte mix of a clipped key body tail
 		return true
 	}
-	// An all-uppercase base64 run has no lowercase or digit to lean on; mask it at
-	// the >=8 inline floor rather than leak a clipped 8–15 char key tail.
-	return hasUpper && !hasLower && len(body) >= 8
+	if hasUpper && !hasLower && len(body) >= 8 {
+		// An all-uppercase base64 run has no lowercase or digit to lean on; mask it at
+		// the >=8 inline floor rather than leak a clipped 8–15 char key tail.
+		return true
+	}
+	// A mixed-case, digit-free run: a camelCase identifier or PascalCase type carries
+	// a word/acronym run of >=4 same-case letters; a clipped base64 key tail
+	// (`AbCdEfGh`) alternates case densely with no such run. Mask the
+	// dense-alternation shape at the >=8 inline floor while the identifier survives.
+	return hasUpper && hasLower && len(body) >= 8 && longestSameCaseRun(body) < 4
+}
+
+// longestSameCaseRun returns the length of the longest maximal run of adjacent
+// same-case ASCII letters in s; digits and any other character break a run. A
+// readable identifier or type name carries a word or acronym of several letters in
+// one case (`handle`, `HTTPS`); a base64 key fragment alternates case almost every
+// character, so its longest same-case run is short.
+func longestSameCaseRun(s string) int {
+	best, cur := 0, 0
+	var prevUpper, have bool
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		upper := c >= 'A' && c <= 'Z'
+		lower := c >= 'a' && c <= 'z'
+		if !upper && !lower {
+			cur, have = 0, false
+			continue
+		}
+		if have && upper == prevUpper {
+			cur++
+		} else {
+			cur = 1
+		}
+		prevUpper, have = upper, true
+		if cur > best {
+			best = cur
+		}
+	}
+	return best
 }
 
 // redactClippedPEM masks PEM private-key material whose -----BEGIN----- banner

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -210,17 +210,24 @@ func redactInlinePEMBody(text string) string {
 //     lowercase file path keeps its digits but has no uppercase
 //     (`internal/attempt2`, `stream/01`), and a camelCase identifier keeps its case
 //     but has no digit (`handleUserRequest`);
-//   - an ALL-UPPERCASE run of >=16 chars (no lowercase, no digit) is likewise key
-//     material: camelCase/PascalCase identifiers carry lowercase and all-caps
-//     constants use '_' separators that break the run below this width, so a long
-//     bare uppercase base64 blob such as `$ echo ABCDEFGHIJKLMNOPQRSTUVWXYZAB` is a
-//     clipped key body, not ordinary post-mortem prose (#835 review — unpadded
-//     inline PEM tail leak, all-caps case).
+//   - an ALL-UPPERCASE run (no lowercase, no digit) at or above the >=8 inline
+//     floor is likewise key material. The base64 alphabet spans all 26 uppercase
+//     letters, so a clipped DER body window can land entirely in A–Z with no other
+//     signal, and an 8–15 char fragment such as `$ echo ABCDEFGH` is
+//     indistinguishable by shape from a bare-caps clipped key tail. A previous
+//     >=16-char floor left the 8–15 band weak and leaked the raw tail into the
+//     prompt and persisted file (#835 review — short all-caps inline PEM tail
+//     leak); a secrets-hygiene extractor resolves the ambiguity toward masking. The
+//     rare legitimate all-caps word of the same width (`HOSTNAME`, `PASSWORD`) is
+//     over-redacted, while shorter all-caps tokens (`SIGKILL`, HTTP verbs) fall
+//     below the >=8 floor and survive.
 //
-// A shorter run carrying only one of these signals is inherently indistinguishable
-// from a path or identifier — redacting it would garble those — so the residual is
-// left to the padded / full-width / whole-line-clipped and complete-block branches,
-// which cover the shapes real key dumps actually take.
+// A run whose only signal is LOWERCASE — a file path or camelCase identifier
+// (`internal/attempt2`, `handleUserRequest`) — is indistinguishable from ordinary
+// post-mortem prose and is left intact, so the extractor does not garble the
+// identifiers and paths it exists to record. The residual key shapes it declines
+// here are covered by the padded / full-width / whole-line-clipped and
+// complete-block branches.
 func inlineRunIsKeyMaterial(run string) bool {
 	body := strings.TrimRight(run, "=")
 	if len(body) < len(run) { // carried '=' padding — an encoded blob, not a hash
@@ -238,8 +245,9 @@ func inlineRunIsKeyMaterial(run string) bool {
 	if hasUpper && hasDigit { // encoded-byte mix of a clipped key body tail
 		return true
 	}
-	// A long, all-uppercase base64 blob is not an ordinary identifier or path.
-	return hasUpper && !hasLower && len(body) >= 16
+	// An all-uppercase base64 run has no lowercase or digit to lean on; mask it at
+	// the >=8 inline floor rather than leak a clipped 8–15 char key tail.
+	return hasUpper && !hasLower && len(body) >= 8
 }
 
 // redactClippedPEM masks PEM private-key material whose -----BEGIN----- banner

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 // Prior-attempt post-mortem extraction (#835).
@@ -71,8 +72,38 @@ var postmortemRedactions = []struct {
 	{regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{20,}\b`), "[REDACTED_SLACK_TOKEN]"},
 }
 
-// redactPostmortemSecrets masks common credential shapes in place.
+// postmortemMultilineRedactions collapse credential shapes whose body spans
+// several lines. The per-line postmortemRedactions above only mask the first
+// line of such a value — a `KEY="-----BEGIN … KEY-----` assignment redacts the
+// assignment line but leaves the PEM body and footer lines, which are still
+// collected as recent actions and reach the prompt / persisted file (#835
+// review). These run first, over the whole assembled text, so a multiline
+// secret is redacted in full before the single-line patterns run.
+var postmortemMultilineRedactions = []struct {
+	re   *regexp.Regexp
+	repl string
+}{
+	// PEM blocks: -----BEGIN … KEY----- … -----END … KEY----- (also CERTIFICATE).
+	// (?s) lets . span the base64 body/footer lines — including any per-line
+	// bullet prefixes the post-mortem adds — and the lazy .*? stops at the first
+	// matching END so adjacent blocks are not merged. Catches a bare PEM key
+	// dumped to the log as well as one embedded in a KEY="…" assignment.
+	{regexp.MustCompile(`(?is)-----BEGIN[ A-Z0-9]+-----.*?-----END[ A-Z0-9]+-----`), "[REDACTED_PRIVATE_KEY_BLOCK]"},
+	// KEY="…" whose closing quote lands on a later line (any multiline secret
+	// value). The embedded \n forces a genuine multiline match; single-line
+	// assignments are left to the per-line patterns. [^"] spans newlines, so the
+	// whole value through its closing quote — and the bullet-prefixed body lines
+	// inside it — is masked.
+	{regexp.MustCompile(`(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|PRIVATE[_-]?KEY)[A-Z0-9_]*)\s*[:=]\s*"[^"]*\n[^"]*"`), "${1}=[REDACTED]"},
+}
+
+// redactPostmortemSecrets masks common credential shapes in place. Multiline
+// patterns run first so a PEM key or other multiline secret value is collapsed
+// to a single redacted token before the per-line patterns run.
 func redactPostmortemSecrets(text string) string {
+	for _, r := range postmortemMultilineRedactions {
+		text = r.re.ReplaceAllString(text, r.repl)
+	}
 	for _, r := range postmortemRedactions {
 		text = r.re.ReplaceAllString(text, r.repl)
 	}
@@ -279,21 +310,62 @@ func extractPostmortemBody(logText string, sideChannelFiles []string) string {
 	return redactPostmortemSecrets(strings.TrimRight(b.String(), "\n"))
 }
 
-// CapPostmortem hard-caps a post-mortem to at most capBytes of content and
-// appends a short truncation marker when it had to cut. Truncation lands on a
-// line boundary where possible and always yields valid UTF-8. capBytes <= 0
-// disables the cap.
+// postmortemTruncationMarker is appended when CapPostmortem has to cut. Its
+// byte length is reserved out of the caller's budget so the returned excerpt —
+// content plus marker — never exceeds capBytes (#835 review).
+const postmortemTruncationMarker = "\n\n… (post-mortem truncated for the prompt; full version saved to the state dir)"
+
+// CapPostmortem hard-caps a post-mortem so the returned string is at most
+// capBytes and appends a short truncation marker when it had to cut. The marker
+// is counted against capBytes, so the total never exceeds the budget. Truncation
+// lands on a line boundary where possible and always yields valid UTF-8.
+// capBytes <= 0 disables the cap.
 func CapPostmortem(s string, capBytes int) string {
 	if capBytes <= 0 || len(s) <= capBytes {
 		return s
 	}
-	truncated := s[:capBytes]
+	// Make the text valid UTF-8 up front so the subsequent byte-slice can only
+	// ever remove bytes (sanitizing after the slice could expand a split rune to
+	// U+FFFD and push content+marker back over capBytes).
+	s = sanitizePromptUTF8(s)
+	if len(s) <= capBytes {
+		return s
+	}
+	// Reserve room for the marker so content+marker stays within capBytes. When
+	// the cap is too small to fit the marker at all, fall back to a marker-free
+	// excerpt bounded to a rune boundary (never grows past capBytes).
+	budget := capBytes - len(postmortemTruncationMarker)
+	if budget <= 0 {
+		return truncateToRuneBoundary(s, capBytes)
+	}
+	truncated := truncateToRuneBoundary(s, budget)
 	if idx := strings.LastIndexByte(truncated, '\n'); idx > 0 {
 		truncated = truncated[:idx]
 	}
-	truncated = sanitizePromptUTF8(truncated)
-	return strings.TrimRight(truncated, "\n") +
-		"\n\n… (post-mortem truncated for the prompt; full version saved to the state dir)"
+	return strings.TrimRight(truncated, "\n") + postmortemTruncationMarker
+}
+
+// truncateToRuneBoundary returns the longest prefix of s that is at most
+// capBytes bytes and does not split a UTF-8 rune. It only ever removes bytes,
+// so the result is guaranteed <= capBytes (unlike sanitizePromptUTF8, which can
+// grow a string by expanding invalid bytes to U+FFFD). s is assumed valid
+// UTF-8, so the only possible invalid tail is a rune the byte-slice split.
+func truncateToRuneBoundary(s string, capBytes int) string {
+	if capBytes <= 0 {
+		return ""
+	}
+	if len(s) <= capBytes {
+		return s
+	}
+	b := s[:capBytes]
+	for len(b) > 0 {
+		if r, size := utf8.DecodeLastRuneInString(b); r == utf8.RuneError && size <= 1 {
+			b = b[:len(b)-1] // drop the partial trailing byte left by the slice
+			continue
+		}
+		break
+	}
+	return b
 }
 
 func trimPostmortemLine(raw string) string {

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -147,8 +147,11 @@ func redactPostmortemSecrets(text string) string {
 // It is line-oriented over the assembled body: classify each line (after any
 // list bullet) as a PEM marker, a full-width base64 body line, or a short base64
 // fragment, then redact each maximal contiguous run of such lines that either
-// contains a marker or holds >=2 full-width body lines. A lone base64 line with
-// no PEM context is left alone — it may be a hash or blob, not key material.
+// contains a marker or holds at least one full-width body line. A single
+// full-width line is enough because a tail clipped so that both PEM banners fall
+// outside it can leave one genuine key body line alone (#835 review). A run of
+// only short base64 fragments (no full-width line, no marker) is left alone — a
+// lone short token may be a hash or blob, not key material.
 func redactClippedPEM(text string) string {
 	lines := strings.Split(text, "\n")
 	n := len(lines)
@@ -191,8 +194,13 @@ func redactClippedPEM(text string) string {
 			}
 		}
 	}
-	// Walk maximal runs; redact those with a marker or >=2 full-width body lines,
-	// collapsing each to a single marker that keeps the run's first bullet.
+	// Walk maximal runs; redact those with a marker or any full-width body line,
+	// collapsing each to a single marker that keeps the run's first bullet. One
+	// full-width line is enough: when a PEM dump is clipped so both banners fall
+	// outside the scanned tail, a genuine key body line can remain alone (#835
+	// review) — requiring >=2 leaked it. The guard is also a defensive floor: it
+	// never collapses a run that carries no key-material evidence, so a run of
+	// only short base64 fragments (a lone hash or blob) is left intact.
 	var out []string
 	for i := 0; i < n; {
 		if !inRun[i] {
@@ -211,7 +219,7 @@ func redactClippedPEM(text string) string {
 			}
 			j++
 		}
-		if hasMarker || strongCount >= 2 {
+		if hasMarker || strongCount >= 1 {
 			prefix := listBulletPrefixRe.FindString(lines[i])
 			out = append(out, prefix+pemRedactionMarker)
 		} else {

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -113,9 +113,22 @@ var pemMarkerRe = regexp.MustCompile(`^-{5}(?:BEGIN|END)[ A-Z0-9]+-{5}$`)
 var pemStrongBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{44,}={0,3}$`)
 
 // pemWeakBodyRe matches a short base64 fragment (>=8 chars) — a clipped final
-// body line. On its own it is too short to trust as key material, so it is only
-// redacted when it sits directly against a strong body line or a PEM marker.
+// body line. A short fragment is ambiguous: it may be a PEM body tail whose
+// banners and full-width lines were clipped out of the tail, or a benign lone
+// token (a git SHA, a digest). It is disambiguated by pemHexHashRe below.
 var pemWeakBodyRe = regexp.MustCompile(`^[A-Za-z0-9+/]{8,}={0,3}$`)
+
+// pemHexHashRe matches a fragment that is plausibly a hex hash — a git SHA, a
+// checksum, a digest — being purely hex digits with no base64-only character
+// (uppercase, g-z, '+', '/') and no '=' padding. A short base64 body tail from a
+// clipped PEM dump virtually never satisfies this (its base64 alphabet spans far
+// beyond hex), so a short fragment that is NOT pure hex is treated as key
+// material and redacted even in isolation; a pure-hex fragment stays weak and is
+// only swept into a redaction run when adjacent to a marker or full-width body
+// line. This closes the short-PEM-tail leak (#835 review) — a lone short final
+// body line was previously classified weak and left unredacted — without
+// over-redacting a lone git SHA.
+var pemHexHashRe = regexp.MustCompile(`^[0-9a-fA-F]+$`)
 
 // pemInlineBodyRe matches a full-width PEM/DER base64 body run (>=44 chars — the
 // same width pemStrongBodyRe treats as key material) wherever it appears, even
@@ -169,13 +182,15 @@ func redactInlinePEMBody(text string) string {
 // and persisted file.
 //
 // It is line-oriented over the assembled body: classify each line (after any
-// list bullet) as a PEM marker, a full-width base64 body line, or a short base64
-// fragment, then redact each maximal contiguous run of such lines that either
-// contains a marker or holds at least one full-width body line. A single
-// full-width line is enough because a tail clipped so that both PEM banners fall
-// outside it can leave one genuine key body line alone (#835 review). A run of
-// only short base64 fragments (no full-width line, no marker) is left alone — a
-// lone short token may be a hash or blob, not key material.
+// list bullet) as a PEM marker, a full-width base64 body line, a short base64
+// body tail (a short fragment that is not a plausible hex hash — see
+// pemHexHashRe), or a short hex fragment, then redact each maximal contiguous run
+// of such lines that either contains a marker or holds at least one full-width /
+// short-body-tail anchor line. A single anchor is enough because a tail clipped
+// so that both PEM banners fall outside it can leave one genuine key body line
+// alone — full-width or, when the clip lands on the final line, short (#835
+// review). A run of only short hex fragments (no anchor, no marker) is left alone
+// — a lone hex token may be a git SHA or digest, not key material.
 func redactClippedPEM(text string) string {
 	lines := strings.Split(text, "\n")
 	n := len(lines)
@@ -194,7 +209,16 @@ func redactClippedPEM(text string) string {
 		case pemStrongBodyRe.MatchString(content):
 			class[i] = strong
 		case pemWeakBodyRe.MatchString(content):
-			class[i] = weak
+			// A short base64 fragment. Anchor it as key material (a clipped PEM
+			// body tail) unless it is a plausible hex hash: a git SHA / digest is
+			// pure hex with no base64-only character or '=' padding and may be
+			// benign, so it stays weak and is only redacted when adjacent to a
+			// marker or full-width body line (#835 review — short PEM tail leak).
+			if pemHexHashRe.MatchString(content) {
+				class[i] = weak
+			} else {
+				class[i] = strong
+			}
 		}
 	}
 	// A line joins a PEM run if it is a marker or full-width body line, or a weak
@@ -218,13 +242,15 @@ func redactClippedPEM(text string) string {
 			}
 		}
 	}
-	// Walk maximal runs; redact those with a marker or any full-width body line,
-	// collapsing each to a single marker that keeps the run's first bullet. One
-	// full-width line is enough: when a PEM dump is clipped so both banners fall
-	// outside the scanned tail, a genuine key body line can remain alone (#835
-	// review) — requiring >=2 leaked it. The guard is also a defensive floor: it
-	// never collapses a run that carries no key-material evidence, so a run of
-	// only short base64 fragments (a lone hash or blob) is left intact.
+	// Walk maximal runs; redact those with a marker or any anchor body line
+	// (full-width, or a short non-hex body tail), collapsing each to a single
+	// marker that keeps the run's first bullet. One anchor is enough: when a PEM
+	// dump is clipped so both banners fall outside the scanned tail, a genuine key
+	// body line can remain alone (#835 review) — requiring >=2 leaked it, and a
+	// tail clipped on the final line leaves only a short body tail. The guard is
+	// also a defensive floor: it never collapses a run that carries no key-material
+	// evidence, so a run of only short hex fragments (a lone SHA or digest) is
+	// left intact.
 	var out []string
 	for i := 0; i < n; {
 		if !inRun[i] {

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -207,6 +207,34 @@ func TestExtractPostmortem_RedactsTailClippedPEM(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsSingleClippedPEMBodyLine covers the finding's
+// sharpest case: the tail starts inside a PEM dump and only ONE full-width base64
+// body line survives into the last-actions window, with both -----BEGIN----- and
+// -----END----- banners clipped away. strongCount is 1, so the old >=2 threshold
+// left the line unredacted and it leaked into the prompt and persisted file (#835
+// review comment 1).
+func TestExtractPostmortem_RedactsSingleClippedPEMBodyLine(t *testing.T) {
+	body := "MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Q"
+	log := strings.Join([]string{
+		"$ cat ~/.ssh/id_rsa",
+		body, // lone survivor: both PEM banners fell outside the scanned tail
+		"$ go build ./...",
+		"build failed",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	if strings.Contains(out, body) {
+		t.Errorf("single clipped PEM body line leaked into post-mortem:\n%s", out)
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected clipped-PEM redaction marker in output:\n%s", out)
+	}
+	if !strings.Contains(out, "build failed") {
+		t.Errorf("benign trailing line should be preserved:\n%s", out)
+	}
+}
+
 // TestRedactClippedPEM covers the scrubber directly against assembled-body
 // shapes: an orphaned END + body run, a marker-free multi-line body run, and a
 // lone base64 token that must NOT be redacted (it may be a hash, not a key).
@@ -234,12 +262,38 @@ func TestRedactClippedPEM(t *testing.T) {
 		t.Errorf("marker-free body run leaked:\n%s", got)
 	}
 
-	// A lone base64-looking token (e.g. a 40-char git SHA, or a single blob) with
-	// no PEM context must be left intact.
+	// A SINGLE full-width body line with both banners clipped and surrounded by
+	// non-base64 lines: the tail started inside a PEM dump and only one body line
+	// survived. One full-width line must be enough to redact (#835 review comment
+	// 1 — the old >=2 threshold leaked this line).
+	single := "- $ cat id_rsa\n- " + body1 + "\n- $ go build ./...\n- build failed"
+	got = redactClippedPEM(single)
+	if strings.Contains(got, body1) {
+		t.Errorf("single full-width body line leaked:\n%s", got)
+	}
+	if !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("single full-width body line not redacted:\n%s", got)
+	}
+	for _, benign := range []string{"$ cat id_rsa", "$ go build ./...", "build failed"} {
+		if !strings.Contains(got, benign) {
+			t.Errorf("benign line %q should survive:\n%s", benign, got)
+		}
+	}
+
+	// A lone base64-looking token (e.g. a 40-char git SHA, or a single short blob)
+	// with no PEM context must be left intact: too short to trust as key material.
 	sha := "0123456789abcdef0123456789abcdef01234567"
 	loneBlob := "- edited internal/foo.go\n- " + sha + "\n- build failed"
 	if got := redactClippedPEM(loneBlob); !strings.Contains(got, sha) {
 		t.Errorf("lone base64 token should not be redacted:\n%s", got)
+	}
+
+	// Two adjacent short fragments with no full-width line and no marker must also
+	// survive: without a key-material anchor they never enter a redaction run.
+	frag1, frag2 := "0123456789abcdef", "fedcba9876543210"
+	weakPair := "- " + frag1 + "\n- " + frag2
+	if got := redactClippedPEM(weakPair); !strings.Contains(got, frag1) || !strings.Contains(got, frag2) {
+		t.Errorf("marker-free short-fragment pair should not be redacted:\n%s", got)
 	}
 }
 

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestExtractPostmortem_FailedCommands(t *testing.T) {
@@ -113,6 +114,57 @@ func TestExtractPostmortem_RedactsSecrets(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsMultilineSecrets covers PEM/multiline secret
+// bodies: the per-line patterns only mask the assignment line, so the base64
+// body and footer lines of a `KEY="-----BEGIN … KEY-----` value survived into
+// the prompt and persisted file (#835 review).
+func TestExtractPostmortem_RedactsMultilineSecrets(t *testing.T) {
+	// Fabricated PEM body so secret scanners don't match it in the diff.
+	body1 := "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAAB"
+	body2 := "AAAAMwAAAAtzc2gtZWQyNTUxOQAAACDddeadbeefdeadbeefdeadbe"
+	log := strings.Join([]string{
+		"error: ssh auth failed",
+		`SSH_PRIVATE_KEY="-----BEGIN OPENSSH PRIVATE KEY-----`,
+		body1,
+		body2,
+		`-----END OPENSSH PRIVATE KEY-----"`,
+		"last line",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	for _, secret := range []string{body1, body2, "BEGIN OPENSSH PRIVATE KEY", "END OPENSSH PRIVATE KEY"} {
+		if strings.Contains(out, secret) {
+			t.Errorf("post-mortem leaked multiline secret content %q:\n%s", secret, out)
+		}
+	}
+	if !strings.Contains(out, "REDACTED") {
+		t.Errorf("expected a redaction marker in output:\n%s", out)
+	}
+}
+
+// TestExtractPostmortem_RedactsBarePEMBlock covers a private key dumped to the
+// log outside any KEY=… assignment (e.g. a `cat key.pem` echo).
+func TestExtractPostmortem_RedactsBarePEMBlock(t *testing.T) {
+	body := "MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Q"
+	log := strings.Join([]string{
+		"error: reading deploy key",
+		"-----BEGIN RSA PRIVATE KEY-----",
+		body,
+		"-----END RSA PRIVATE KEY-----",
+		"build failed",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	if strings.Contains(out, body) {
+		t.Errorf("post-mortem leaked bare PEM body %q:\n%s", body, out)
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected PEM block redaction marker in output:\n%s", out)
+	}
+}
+
 func TestCapPostmortem_Enforced(t *testing.T) {
 	// A body far larger than the cap.
 	var sb strings.Builder
@@ -125,9 +177,10 @@ func TestCapPostmortem_Enforced(t *testing.T) {
 	}
 
 	capped := CapPostmortem(big, PostmortemPromptCapBytes)
-	// Content is capped to capBytes; a short marker may be appended.
-	if len(capped) > PostmortemPromptCapBytes+160 {
-		t.Errorf("capped output too large: %d bytes", len(capped))
+	// The marker is reserved out of the budget: content plus marker must never
+	// exceed capBytes (#835 review: marker previously overshot the cap).
+	if len(capped) > PostmortemPromptCapBytes {
+		t.Errorf("capped output exceeds cap: %d > %d bytes", len(capped), PostmortemPromptCapBytes)
 	}
 	if !strings.Contains(capped, "truncated") {
 		t.Errorf("expected truncation marker in capped output")
@@ -141,6 +194,47 @@ func TestCapPostmortem_Enforced(t *testing.T) {
 	// capBytes <= 0 disables the cap.
 	if got := CapPostmortem(big, 0); got != big {
 		t.Errorf("capBytes<=0 should disable cap")
+	}
+}
+
+// TestCapPostmortem_MarkerWithinCap exercises a range of caps — including ones
+// smaller than the truncation marker itself — and asserts the result stays
+// within budget and remains valid UTF-8 (#835 review: marker overshoot).
+func TestCapPostmortem_MarkerWithinCap(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 500; i++ {
+		sb.WriteString("- a reasonably long line of post-mortem content ☃\n")
+	}
+	big := sb.String()
+
+	for _, capBytes := range []int{10, 40, len(postmortemTruncationMarker), 100, 512, PostmortemPromptCapBytes} {
+		got := CapPostmortem(big, capBytes)
+		if len(got) > capBytes {
+			t.Errorf("cap=%d: output %d bytes exceeds cap", capBytes, len(got))
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("cap=%d: output is not valid UTF-8: %q", capBytes, got)
+		}
+	}
+}
+
+// TestCapPostmortem_MultibyteBoundary ensures a cap landing mid-rune does not
+// split a multibyte character or overshoot the byte budget — across both the
+// marker-free small-cap branch and the main branch (cap larger than the marker,
+// no newline in the budget window, where an after-slice sanitize could
+// previously expand a split rune and push content+marker back over the cap).
+func TestCapPostmortem_MultibyteBoundary(t *testing.T) {
+	s := strings.Repeat("☃", 200) // 3 bytes each, no newlines
+	m := len(postmortemTruncationMarker)
+	caps := []int{1, 2, 3, 5, 20, m - 1, m, m + 1, m + 2, m + 5, m + 10, m + 100}
+	for _, capBytes := range caps {
+		got := CapPostmortem(s, capBytes)
+		if len(got) > capBytes {
+			t.Fatalf("cap=%d: output %d bytes exceeds cap", capBytes, len(got))
+		}
+		if !utf8.ValidString(got) {
+			t.Fatalf("cap=%d: output not valid UTF-8: %q", capBytes, got)
+		}
 	}
 }
 

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -342,6 +342,41 @@ func TestExtractPostmortem_RedactsShortAndAllCapsInlinePEMTail(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsShortAllCapsInlinePEMTail closes the last residual of
+// the finding (#835 review — "Short Uppercase PEM Fragment Leaks"). An 8–15 char
+// ALL-UPPERCASE fragment (`$ echo ABCDEFGH`) sits below the old >=16 all-caps floor,
+// so it carried no digit and no '=' padding to trip any earlier branch and reached
+// both sinks intact. It survives selection as a last action, so it must be scrubbed
+// out of the extracted post-mortem AND out of the capped prompt excerpt. The >=8
+// all-caps floor now redacts it while the surrounding command prose is preserved.
+func TestExtractPostmortem_RedactsShortAllCapsInlinePEMTail(t *testing.T) {
+	shortAllCaps := "ABCDEFGH" // 8 chars, all uppercase, no digit, no padding
+	log := strings.Join([]string{
+		"running deploy",
+		"$ echo " + shortAllCaps,
+		"exit status 1",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+	if strings.Contains(out, shortAllCaps) {
+		t.Errorf("short all-caps inline PEM tail %q leaked into post-mortem:\n%s", shortAllCaps, out)
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected PEM redaction marker in output:\n%s", out)
+	}
+	for _, keep := range []string{"$ echo", "exit status 1"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("benign content %q should survive inline redaction:\n%s", keep, out)
+		}
+	}
+
+	// The capped prompt excerpt is the second sink; the fragment must not survive a
+	// tight cap either (the marker replaces it before any truncation runs).
+	if capped := CapPostmortem(out, 2048); strings.Contains(capped, shortAllCaps) {
+		t.Errorf("short all-caps inline PEM tail %q leaked into capped prompt excerpt:\n%s", shortAllCaps, capped)
+	}
+}
+
 // TestExtractPostmortem_RedactsSingleClippedPEMBodyLine covers the finding's
 // sharpest case: the tail starts inside a PEM dump and only ONE full-width base64
 // body line survives into the last-actions window, with both -----BEGIN----- and
@@ -564,6 +599,26 @@ func TestRedactInlinePEMBody(t *testing.T) {
 		t.Errorf("all-uppercase inline blob not redacted:\n%s", got)
 	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
 		t.Errorf("expected command prose kept and marker present:\n%s", got)
+	}
+
+	// A SHORT (8–15 char) ALL-UPPERCASE run is the finding's remaining leak: the old
+	// >=16 all-caps floor left it weak, so a clipped bare-caps key tail such as
+	// `$ echo ABCDEFGH` slipped into both sinks intact (#835 review — short all-caps
+	// inline PEM tail leak). The floor now matches the >=8 inline floor and redacts
+	// it. Over-redacting a same-width all-caps word is the safe direction here.
+	shortAllCaps := "ABCDEFGH" // 8 chars, all uppercase, no digit
+	if got := redactInlinePEMBody("$ echo " + shortAllCaps); strings.Contains(got, shortAllCaps) {
+		t.Errorf("short all-uppercase inline tail not redacted:\n%s", got)
+	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("expected command prose kept and marker present:\n%s", got)
+	}
+
+	// A sub-floor all-caps token (7 chars) never reaches the classifier — the >=8
+	// pemInlineBodyRe floor does not match it — so short signal names and HTTP verbs
+	// survive intact and are not garbled.
+	subFloor := "SIGKILL" // 7 chars, below the >=8 inline floor
+	if got := redactInlinePEMBody("worker exited on " + subFloor); !strings.Contains(got, subFloor) {
+		t.Errorf("sub-floor all-caps token should survive inline redaction:\n%s", got)
 	}
 
 	// A mixed-case, digit-free identifier stays intact: it has lowercase (so the

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -207,6 +207,34 @@ func TestExtractPostmortem_RedactsTailClippedPEM(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsShortInlinePEMTail covers a tail-clipped private
+// key fragment embedded in a larger command line (`$ echo <fragment>`). The
+// whole-line clipped-PEM pass cannot match an embedded run, and the fragment is
+// under the 44-byte full-width width, so redactInlinePEMBody must catch it by its
+// base64 '=' padding — the tail signature the >=44-only branch missed (#835
+// review — short inline PEM tail leak).
+func TestExtractPostmortem_RedactsShortInlinePEMTail(t *testing.T) {
+	frag := "Kj34GkxFhD90vcNLYLInFE="
+	log := strings.Join([]string{
+		"running deploy",
+		"$ echo " + frag,
+		"exit status 1",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	if strings.Contains(out, frag) {
+		t.Errorf("short inline PEM tail leaked into post-mortem:\n%s", out)
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected PEM redaction marker in output:\n%s", out)
+	}
+	// The command prose around the fragment must survive.
+	if !strings.Contains(out, "$ echo") {
+		t.Errorf("command prefix should be preserved:\n%s", out)
+	}
+}
+
 // TestExtractPostmortem_RedactsSingleClippedPEMBodyLine covers the finding's
 // sharpest case: the tail starts inside a PEM dump and only ONE full-width base64
 // body line survives into the last-actions window, with both -----BEGIN----- and
@@ -356,11 +384,23 @@ func TestRedactInlinePEMBody(t *testing.T) {
 	}
 
 	// A short base64 fragment embedded in a line (below the 44-char strong width)
-	// is not key material and must be left alone.
+	// with no '=' padding is ambiguous (may be a hash) and must be left alone.
 	frag := "deadbeefdeadbeef"
 	benign := "commit " + frag + " touched foo.go"
 	if got := redactInlinePEMBody(benign); !strings.Contains(got, frag) {
 		t.Errorf("short embedded fragment should not be redacted:\n%s", got)
+	}
+
+	// A short base64 tail that DOES carry '=' padding (a clipped final PEM body
+	// line embedded in a command) is key material and must be redacted, even
+	// though it is under the full-width width (#835 review — short inline PEM tail
+	// leak). '=' padding never appears in a git SHA / hex digest, so this does not
+	// reclassify the padding-free fragment above.
+	tail := "Kj34GkxFhD90vcNLYLInFE="
+	if got := redactInlinePEMBody("$ echo " + tail); strings.Contains(got, tail) {
+		t.Errorf("padded short inline tail not redacted:\n%s", got)
+	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("expected command prose kept and marker present:\n%s", got)
 	}
 }
 

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -235,6 +235,65 @@ func TestExtractPostmortem_RedactsSingleClippedPEMBodyLine(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsInlinePEMBody covers the finding's inline case: a
+// clipped full-width base64 body appears inside a larger log line — command
+// output prefixed with `$ echo ` or a `cat id_rsa: ` label — so the anchored
+// whole-line classifier in redactClippedPEM never sees it as PEM material and it
+// would otherwise reach the prompt and persisted file with the key body intact
+// (#835 review).
+func TestExtractPostmortem_RedactsInlinePEMBody(t *testing.T) {
+	body := "MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Q"
+	log := strings.Join([]string{
+		"$ echo " + body,
+		"cat id_rsa: " + body,
+		"build failed",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	if strings.Contains(out, body) {
+		t.Errorf("inline PEM body leaked into post-mortem:\n%s", out)
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected clipped-PEM redaction marker in output:\n%s", out)
+	}
+	// The command / label prefix around the redacted body must survive so the
+	// post-mortem still records what the attempt tried.
+	for _, ctx := range []string{"$ echo", "cat id_rsa:", "build failed"} {
+		if !strings.Contains(out, ctx) {
+			t.Errorf("benign context %q should survive inline redaction:\n%s", ctx, out)
+		}
+	}
+}
+
+// TestRedactInlinePEMBody covers the inline scrubber directly: a full-width body
+// embedded in a command line is masked while the prefix is kept, and a short
+// base64 token (below the strong width) embedded in a line is left intact.
+func TestRedactInlinePEMBody(t *testing.T) {
+	body := "MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Q"
+	line := "- $ printf %s " + body + " > /tmp/k"
+	got := redactInlinePEMBody(line)
+	if strings.Contains(got, body) {
+		t.Errorf("inline body not redacted:\n%s", got)
+	}
+	if !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("expected redaction marker:\n%s", got)
+	}
+	for _, ctx := range []string{"- $ printf", "> /tmp/k"} {
+		if !strings.Contains(got, ctx) {
+			t.Errorf("context %q should survive:\n%s", ctx, got)
+		}
+	}
+
+	// A short base64 fragment embedded in a line (below the 44-char strong width)
+	// is not key material and must be left alone.
+	frag := "deadbeefdeadbeef"
+	benign := "commit " + frag + " touched foo.go"
+	if got := redactInlinePEMBody(benign); !strings.Contains(got, frag) {
+		t.Errorf("short embedded fragment should not be redacted:\n%s", got)
+	}
+}
+
 // TestRedactClippedPEM covers the scrubber directly against assembled-body
 // shapes: an orphaned END + body run, a marker-free multi-line body run, and a
 // lone base64 token that must NOT be redacted (it may be a hash, not a key).

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -235,6 +235,39 @@ func TestExtractPostmortem_RedactsSingleClippedPEMBodyLine(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsShortClippedPEMTail covers the finding's sharpest
+// remaining case (#835 review comment 1 — "Short PEM Tail Leaks"): the scanned
+// tail starts inside a PEM dump so the -----BEGIN----- banner, every full-width
+// body line, and the -----END----- footer are all clipped away, leaving ONLY the
+// short final base64 body line. That fragment is below the 44-char strong width,
+// so the old adjacency rule classified it weak and — with no adjacent marker or
+// full-width line — left it unredacted, leaking a key fragment into the prompt
+// and persisted file.
+func TestExtractPostmortem_RedactsShortClippedPEMTail(t *testing.T) {
+	// A short final PEM body line: below the strong width and carrying base64
+	// characters no hex hash can (uppercase, '=' padding), so it is the tail of a
+	// clipped key rather than a git SHA.
+	tail := "Kj34GkxFhD90vcNLYLInFE="
+	log := strings.Join([]string{
+		"$ cat ~/.ssh/id_rsa",
+		tail, // lone survivor: BEGIN, body, and END all fell outside the scanned tail
+		"$ go build ./...",
+		"build failed",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	if strings.Contains(out, tail) {
+		t.Errorf("short clipped PEM tail leaked into post-mortem:\n%s", out)
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected clipped-PEM redaction marker in output:\n%s", out)
+	}
+	if !strings.Contains(out, "build failed") {
+		t.Errorf("benign trailing line should be preserved:\n%s", out)
+	}
+}
+
 // TestExtractPostmortem_RedactsInlinePEMBody covers the finding's inline case: a
 // clipped full-width base64 body appears inside a larger log line — command
 // output prefixed with `$ echo ` or a `cat id_rsa: ` label — so the anchored
@@ -339,8 +372,32 @@ func TestRedactClippedPEM(t *testing.T) {
 		}
 	}
 
+	// A lone short base64 body tail (below the strong width) with both banners and
+	// full-width lines clipped away — a tail that landed on the PEM's final line.
+	// It carries base64-only characters no hex hash can, so it anchors on its own
+	// and is redacted even in isolation (#835 review comment 1 — short PEM tail).
+	for _, shortTail := range []string{
+		"Kj34GkxFhD90vcNLYLInFE=", // padded final line
+		"MIIBOgIBAAJBAKj3GkxF",    // unpadded, but uppercase ⇒ not a hex hash
+	} {
+		single := "- $ cat id_rsa\n- " + shortTail + "\n- $ go build ./...\n- build failed"
+		got := redactClippedPEM(single)
+		if strings.Contains(got, shortTail) {
+			t.Errorf("short clipped PEM body tail %q leaked:\n%s", shortTail, got)
+		}
+		if !strings.Contains(got, pemRedactionMarker) {
+			t.Errorf("short clipped PEM body tail %q not redacted:\n%s", shortTail, got)
+		}
+		for _, benign := range []string{"$ cat id_rsa", "$ go build ./...", "build failed"} {
+			if !strings.Contains(got, benign) {
+				t.Errorf("benign line %q should survive:\n%s", benign, got)
+			}
+		}
+	}
+
 	// A lone base64-looking token (e.g. a 40-char git SHA, or a single short blob)
-	// with no PEM context must be left intact: too short to trust as key material.
+	// with no PEM context must be left intact: a pure-hex token is a plausible
+	// hash/digest, not key material.
 	sha := "0123456789abcdef0123456789abcdef01234567"
 	loneBlob := "- edited internal/foo.go\n- " + sha + "\n- build failed"
 	if got := redactClippedPEM(loneBlob); !strings.Contains(got, sha) {

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -235,6 +235,36 @@ func TestExtractPostmortem_RedactsShortInlinePEMTail(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsShortPaddedInlinePEMTail covers the finding's
+// sharpest inline case (#835 review — short inline PEM tail leak): a tail-clipped
+// key fragment embedded in a larger command line whose remaining base64 run is
+// only 8–15 characters. The >=16-char inline floor skipped the run before
+// inlineRunIsKeyMaterial could classify it, so `$ echo AbCdEfGhIjK=` reached both
+// the persisted post-mortem and the retry prompt with the raw fragment intact. The
+// run carries '=' padding — the unambiguous key-material signal — so the short
+// padded alternative in pemInlineBodyRe now hands it to the classifier.
+func TestExtractPostmortem_RedactsShortPaddedInlinePEMTail(t *testing.T) {
+	frag := "AbCdEfGhIjK=" // 11 base64 chars + '=' padding: under the 16-char floor
+	log := strings.Join([]string{
+		"running deploy",
+		"$ echo " + frag,
+		"exit status 1",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	if strings.Contains(out, frag) {
+		t.Errorf("short padded inline PEM tail leaked into post-mortem:\n%s", out)
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected PEM redaction marker in output:\n%s", out)
+	}
+	// The command prose around the fragment must survive.
+	if !strings.Contains(out, "$ echo") {
+		t.Errorf("command prefix should be preserved:\n%s", out)
+	}
+}
+
 // TestExtractPostmortem_RedactsUnpaddedInlinePEMTail covers the residual of the
 // same finding (#835 review — "Unpadded Inline PEM Tail Leaks"): a tail-clipped
 // key fragment embedded in a command line WITHOUT '=' padding (`$ echo
@@ -434,6 +464,19 @@ func TestRedactInlinePEMBody(t *testing.T) {
 	tail := "Kj34GkxFhD90vcNLYLInFE="
 	if got := redactInlinePEMBody("$ echo " + tail); strings.Contains(got, tail) {
 		t.Errorf("padded short inline tail not redacted:\n%s", got)
+	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("expected command prose kept and marker present:\n%s", got)
+	}
+
+	// A padded tail whose base64 run is under the 16-char candidate floor
+	// (`AbCdEfGhIjK=`, 11 chars) is the finding's leak: the >=16 alternative
+	// skipped it before inlineRunIsKeyMaterial could classify it, so the raw
+	// fragment reached both sinks. The short padded alternative now hands it to the
+	// classifier, whose '=' padding signal redacts it (#835 review — short inline
+	// PEM tail leak).
+	shortTail := "AbCdEfGhIjK="
+	if got := redactInlinePEMBody("$ echo " + shortTail); strings.Contains(got, shortTail) {
+		t.Errorf("short (<16-char) padded inline tail not redacted:\n%s", got)
 	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
 		t.Errorf("expected command prose kept and marker present:\n%s", got)
 	}

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -268,6 +268,43 @@ func TestExtractPostmortem_RedactsShortClippedPEMTail(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsUppercaseHexShortPEMTail closes the residual of the
+// same finding (#835 review comment 1 — "Short PEM Tail Leaks"): after realistic
+// (base64) short tails were already anchored, a fragment that is PURE HEX but
+// carries uppercase A–F — which a PEM/DER base64 body routinely does — was still
+// accepted as a hex hash by the earlier `[0-9a-fA-F]` rule, classified weak, and
+// left unredacted. Only a conventional LOWERCASE git SHA keeps the carve-out now.
+func TestExtractPostmortem_RedactsUppercaseHexShortPEMTail(t *testing.T) {
+	// The lone survivor of a clipped key dump: below the strong width and pure hex,
+	// but uppercase — so a base64 body tail, not a lowercase git SHA.
+	tail := "DEADBEEFCAFE1234DEADBEEF"
+	// A benign lowercase git SHA on its own line must still survive (the carve-out).
+	sha := "0123456789abcdef0123456789abcdef01234567"
+	log := strings.Join([]string{
+		"$ cat ~/.ssh/id_rsa",
+		tail, // BEGIN, full-width body, and END all fell outside the scanned tail
+		"$ git rev-parse HEAD",
+		sha,
+		"$ go build ./...",
+		"build failed",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	if strings.Contains(out, tail) {
+		t.Errorf("uppercase-hex short PEM tail leaked into post-mortem:\n%s", out)
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected clipped-PEM redaction marker in output:\n%s", out)
+	}
+	if !strings.Contains(out, sha) {
+		t.Errorf("lone lowercase git SHA should be preserved (not over-redacted):\n%s", out)
+	}
+	if !strings.Contains(out, "build failed") {
+		t.Errorf("benign trailing line should be preserved:\n%s", out)
+	}
+}
+
 // TestExtractPostmortem_RedactsInlinePEMBody covers the finding's inline case: a
 // clipped full-width base64 body appears inside a larger log line — command
 // output prefixed with `$ echo ` or a `cat id_rsa: ` label — so the anchored
@@ -374,11 +411,15 @@ func TestRedactClippedPEM(t *testing.T) {
 
 	// A lone short base64 body tail (below the strong width) with both banners and
 	// full-width lines clipped away — a tail that landed on the PEM's final line.
-	// It carries base64-only characters no hex hash can, so it anchors on its own
-	// and is redacted even in isolation (#835 review comment 1 — short PEM tail).
+	// Each carries a character no LOWERCASE-hex git SHA can (base64-only letters,
+	// '=' padding, or uppercase A–F), so it anchors on its own and is redacted even
+	// in isolation (#835 review comment 1 — short PEM tail).
 	for _, shortTail := range []string{
-		"Kj34GkxFhD90vcNLYLInFE=", // padded final line
-		"MIIBOgIBAAJBAKj3GkxF",    // unpadded, but uppercase ⇒ not a hex hash
+		"Kj34GkxFhD90vcNLYLInFE=",  // padded final line
+		"MIIBOgIBAAJBAKj3GkxF",     // unpadded, but uppercase base64 ⇒ not a hex hash
+		"DEADBEEFCAFE1234DEADBEEF", // pure UPPERCASE hex ⇒ a base64 body tail, not a
+		//                            lowercase git SHA; the old [0-9a-fA-F] rule left
+		//                            it weak and leaked it.
 	} {
 		single := "- $ cat id_rsa\n- " + shortTail + "\n- $ go build ./...\n- build failed"
 		got := redactClippedPEM(single)
@@ -396,7 +437,7 @@ func TestRedactClippedPEM(t *testing.T) {
 	}
 
 	// A lone base64-looking token (e.g. a 40-char git SHA, or a single short blob)
-	// with no PEM context must be left intact: a pure-hex token is a plausible
+	// with no PEM context must be left intact: a LOWERCASE-hex token is a plausible
 	// hash/digest, not key material.
 	sha := "0123456789abcdef0123456789abcdef01234567"
 	loneBlob := "- edited internal/foo.go\n- " + sha + "\n- build failed"

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -85,10 +85,14 @@ func TestExtractPostmortem_EmptyLogNoSection(t *testing.T) {
 }
 
 func TestExtractPostmortem_RedactsSecrets(t *testing.T) {
+	// Fabricated credentials are assembled via concatenation so secret
+	// scanners (agent-lint) don't match them in the diff.
+	fakeBearer := "sk-" + "abcdefghijklmnopqrstuvwxyz012345"
+	fakeGHToken := "ghp_" + "abcdefghijklmnopqrstuvwxyz0123456789"
 	log := strings.Join([]string{
 		"error: request failed",
-		"Authorization: Bearer sk-abcdefghijklmnopqrstuvwxyz012345",
-		"exporting GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+		"Authorization: Bearer " + fakeBearer,
+		"exporting GITHUB_TOKEN=" + fakeGHToken,
 		"API_KEY=supersecretvalue123",
 		"last line",
 	}, "\n")
@@ -96,8 +100,8 @@ func TestExtractPostmortem_RedactsSecrets(t *testing.T) {
 	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
 
 	for _, secret := range []string{
-		"sk-abcdefghijklmnopqrstuvwxyz012345",
-		"ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+		fakeBearer,
+		fakeGHToken,
 		"supersecretvalue123",
 	} {
 		if strings.Contains(out, secret) {

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -300,6 +300,48 @@ func TestExtractPostmortem_RedactsUnpaddedInlinePEMTail(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsShortAndAllCapsInlinePEMTail closes the residual of
+// the same finding (#835 review — "Unpadded Inline PEM Tail Escapes"). Two inline
+// fragments still slipped through: a short UNPADDED run below the old >=16 candidate
+// floor (`$ echo XyZ12aBc`, never matched by the regex at all) and a 16–43 char
+// ALL-UPPERCASE run (`$ echo ABCDEFGHIJKLMNOPQRSTUVWXYZAB`, matched but left weak by
+// the classifier's digit requirement). Both reach both sinks as raw key tails. The
+// >=8 inline floor now hands the short run to the classifier (whose upper+digit mix
+// redacts it) and the all-uppercase branch redacts the long bare-caps blob, while a
+// digit-free camelCase identifier and a lowercase hash in the same window survive.
+func TestExtractPostmortem_RedactsShortAndAllCapsInlinePEMTail(t *testing.T) {
+	shortTail := "XyZ12aBc"                   // 8 chars, unpadded, upper+lower+digit
+	allCaps := "ABCDEFGHIJKLMNOPQRSTUVWXYZAB" // 28 chars, all uppercase, no digit
+	ident := "handleUserRequest"              // camelCase identifier: case, no digit
+	hash := "deadbeefdeadbeef"                // lowercase hex: a plausible digest
+	log := strings.Join([]string{
+		"running deploy",
+		"$ echo " + shortTail,
+		"$ echo " + allCaps,
+		"$ grep " + ident,
+		"$ git show " + hash,
+		"exit status 1",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	for _, leak := range []string{shortTail, allCaps} {
+		if strings.Contains(out, leak) {
+			t.Errorf("inline PEM tail %q leaked into post-mortem:\n%s", leak, out)
+		}
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected PEM redaction marker in output:\n%s", out)
+	}
+	// Ordinary post-mortem content must survive: a digit-free identifier and a
+	// lowercase hash are not over-redacted, and the command prose is kept.
+	for _, keep := range []string{ident, hash, "$ echo", "exit status 1"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("benign content %q should survive inline redaction:\n%s", keep, out)
+		}
+	}
+}
+
 // TestExtractPostmortem_RedactsSingleClippedPEMBodyLine covers the finding's
 // sharpest case: the tail starts inside a PEM dump and only ONE full-width base64
 // body line survives into the last-actions window, with both -----BEGIN----- and
@@ -494,12 +536,42 @@ func TestRedactInlinePEMBody(t *testing.T) {
 		t.Errorf("expected command prose kept and marker present:\n%s", got)
 	}
 
-	// A digit-free file path embedded in a command line reaches the same >=16-char
-	// candidate matcher but carries no digit, so it must survive intact — the
+	// A digit-free file path embedded in a command line reaches the same >=8-char
+	// candidate matcher but carries no uppercase, so it must survive intact — the
 	// unpadded-tail rule must not garble the paths a post-mortem records.
 	path := "internal/worker/postmortem"
 	if got := redactInlinePEMBody("$ vim " + path + ".go"); !strings.Contains(got, path) {
 		t.Errorf("digit-free path should survive inline redaction:\n%s", got)
+	}
+
+	// A short (<16-char) UNPADDED run carrying the encoded-byte mix (uppercase +
+	// digit) is a clipped key tail the old >=16 floor never matched at all, leaking
+	// it into both sinks (#835 review — unpadded inline PEM tail escapes). The >=8
+	// floor now hands it to the classifier, which redacts it.
+	shortUnpadded := "XyZ12aBc" // 8 chars, upper+lower+digit
+	if got := redactInlinePEMBody("$ echo " + shortUnpadded); strings.Contains(got, shortUnpadded) {
+		t.Errorf("short unpadded inline tail not redacted:\n%s", got)
+	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("expected command prose kept and marker present:\n%s", got)
+	}
+
+	// A 16–43 char ALL-UPPERCASE run (no lowercase, no digit) was matched but left
+	// weak by the classifier's digit requirement, so a bare-caps clipped key body
+	// reached both sinks (#835 review — unpadded inline PEM tail escapes, all-caps
+	// case). The all-uppercase branch now redacts it.
+	allCaps := "ABCDEFGHIJKLMNOPQRSTUVWXYZAB" // 28 chars, all uppercase
+	if got := redactInlinePEMBody("$ echo " + allCaps); strings.Contains(got, allCaps) {
+		t.Errorf("all-uppercase inline blob not redacted:\n%s", got)
+	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("expected command prose kept and marker present:\n%s", got)
+	}
+
+	// A mixed-case, digit-free identifier stays intact: it has lowercase (so the
+	// all-caps branch skips it) and no digit (so the upper+digit branch skips it) —
+	// the unpadded-tail rules must not garble the identifiers a post-mortem records.
+	ident := "handleUserRequest"
+	if got := redactInlinePEMBody("$ grep " + ident); !strings.Contains(got, ident) {
+		t.Errorf("mixed-case identifier should survive inline redaction:\n%s", got)
 	}
 }
 

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -171,6 +171,78 @@ func TestExtractPostmortem_RedactsBarePEMBlock(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsTailClippedPEM covers the case where the scanned
+// tail starts inside a PEM dump: the -----BEGIN----- banner is beyond the tail
+// window, so the complete-block regex cannot see it, but the base64 body and the
+// -----END----- footer remain in the last-actions section. The clipped-PEM
+// scrubber must still redact the orphaned key material (#835 review comment 1).
+func TestExtractPostmortem_RedactsTailClippedPEM(t *testing.T) {
+	// A private key so large its BEGIN banner falls outside the last-400-line
+	// tail; only later body lines and the END footer survive into the window.
+	body := "MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Q"
+	dashes := strings.Repeat("-", 5)
+	var lines []string
+	lines = append(lines, "some early setup output")
+	lines = append(lines, dashes+"BEGIN RSA PRIVATE "+"KEY"+dashes) // clipped out of the tail
+	for i := 0; i < PostmortemTailLines+50; i++ {
+		lines = append(lines, body)
+	}
+	lines = append(lines, dashes+"END RSA PRIVATE "+"KEY"+dashes)
+	lines = append(lines, "build failed")
+
+	out := ExtractPostmortem(writeTempLog(t, strings.Join(lines, "\n")), PostmortemTailLines)
+
+	if strings.Contains(out, body) {
+		t.Errorf("tail-clipped PEM body leaked into post-mortem:\n%s", out)
+	}
+	if strings.Contains(out, "END RSA PRIVATE "+"KEY") {
+		t.Errorf("orphaned PEM footer leaked into post-mortem:\n%s", out)
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected clipped-PEM redaction marker in output:\n%s", out)
+	}
+	// A benign non-key line near the end must survive.
+	if !strings.Contains(out, "build failed") {
+		t.Errorf("benign trailing line should be preserved:\n%s", out)
+	}
+}
+
+// TestRedactClippedPEM covers the scrubber directly against assembled-body
+// shapes: an orphaned END + body run, a marker-free multi-line body run, and a
+// lone base64 token that must NOT be redacted (it may be a hash, not a key).
+func TestRedactClippedPEM(t *testing.T) {
+	body1 := "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAAB"
+	body2 := "AAAAMwAAAAtzc2gtZWQyNTUxOQAAACDddeadbeefdeadbeefdeadbe"
+	dashes := strings.Repeat("-", 5)
+	end := dashes + "END OPENSSH PRIVATE " + "KEY" + dashes
+
+	// Orphaned END + body (BEGIN clipped): redact the whole run.
+	orphanEnd := "### Last actions before the attempt ended\n- " + body1 + "\n- " + body2 + "\n- " + end
+	got := redactClippedPEM(orphanEnd)
+	for _, secret := range []string{body1, body2, "END OPENSSH PRIVATE " + "KEY"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("orphaned-END run leaked %q:\n%s", secret, got)
+		}
+	}
+	if !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("orphaned-END run not redacted:\n%s", got)
+	}
+
+	// Marker-free body run (both banners clipped): >=2 full-width lines ⇒ redact.
+	bodyOnly := "- " + body1 + "\n- " + body2
+	if got := redactClippedPEM(bodyOnly); strings.Contains(got, body1) || strings.Contains(got, body2) {
+		t.Errorf("marker-free body run leaked:\n%s", got)
+	}
+
+	// A lone base64-looking token (e.g. a 40-char git SHA, or a single blob) with
+	// no PEM context must be left intact.
+	sha := "0123456789abcdef0123456789abcdef01234567"
+	loneBlob := "- edited internal/foo.go\n- " + sha + "\n- build failed"
+	if got := redactClippedPEM(loneBlob); !strings.Contains(got, sha) {
+		t.Errorf("lone base64 token should not be redacted:\n%s", got)
+	}
+}
+
 func TestCapPostmortem_Enforced(t *testing.T) {
 	// A body far larger than the cap.
 	var sb strings.Builder

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -119,21 +119,25 @@ func TestExtractPostmortem_RedactsSecrets(t *testing.T) {
 // body and footer lines of a `KEY="-----BEGIN … KEY-----` value survived into
 // the prompt and persisted file (#835 review).
 func TestExtractPostmortem_RedactsMultilineSecrets(t *testing.T) {
-	// Fabricated PEM body so secret scanners don't match it in the diff.
+	// Fabricated PEM body and headers assembled at runtime so secret
+	// scanners (agent-lint private-key rule) don't match them in the diff.
 	body1 := "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAAB"
 	body2 := "AAAAMwAAAAtzc2gtZWQyNTUxOQAAACDddeadbeefdeadbeefdeadbe"
+	dashes := strings.Repeat("-", 5)
+	beginOpenSSH := dashes + "BEGIN OPENSSH PRIVATE " + "KEY" + dashes
+	endOpenSSH := dashes + "END OPENSSH PRIVATE " + "KEY" + dashes
 	log := strings.Join([]string{
 		"error: ssh auth failed",
-		`SSH_PRIVATE_KEY="-----BEGIN OPENSSH PRIVATE KEY-----`,
+		`SSH_PRIVATE_KEY="` + beginOpenSSH,
 		body1,
 		body2,
-		`-----END OPENSSH PRIVATE KEY-----"`,
+		endOpenSSH + `"`,
 		"last line",
 	}, "\n")
 
 	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
 
-	for _, secret := range []string{body1, body2, "BEGIN OPENSSH PRIVATE KEY", "END OPENSSH PRIVATE KEY"} {
+	for _, secret := range []string{body1, body2, "BEGIN OPENSSH PRIVATE " + "KEY", "END OPENSSH PRIVATE " + "KEY"} {
 		if strings.Contains(out, secret) {
 			t.Errorf("post-mortem leaked multiline secret content %q:\n%s", secret, out)
 		}
@@ -146,12 +150,14 @@ func TestExtractPostmortem_RedactsMultilineSecrets(t *testing.T) {
 // TestExtractPostmortem_RedactsBarePEMBlock covers a private key dumped to the
 // log outside any KEY=… assignment (e.g. a `cat key.pem` echo).
 func TestExtractPostmortem_RedactsBarePEMBlock(t *testing.T) {
+	// Headers assembled at runtime to avoid secret-scanner diff matches.
 	body := "MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Q"
+	dashes := strings.Repeat("-", 5)
 	log := strings.Join([]string{
 		"error: reading deploy key",
-		"-----BEGIN RSA PRIVATE KEY-----",
+		dashes + "BEGIN RSA PRIVATE " + "KEY" + dashes,
 		body,
-		"-----END RSA PRIVATE KEY-----",
+		dashes + "END RSA PRIVATE " + "KEY" + dashes,
 		"build failed",
 	}, "\n")
 

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -235,6 +235,41 @@ func TestExtractPostmortem_RedactsShortInlinePEMTail(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsUnpaddedInlinePEMTail covers the residual of the
+// same finding (#835 review — "Unpadded Inline PEM Tail Leaks"): a tail-clipped
+// key fragment embedded in a command line WITHOUT '=' padding (`$ echo
+// Kj34GkxFhD90vcNLYLInFE`) fell under both the 44-byte full-width width and the
+// padded-tail branch, so the inline matcher skipped it and the whole-line PEM
+// scrubber could not classify it — leaking the fragment into the prompt and the
+// persisted post-mortem. A digit-free file path in the same window must still
+// survive so the fix does not over-redact ordinary post-mortem content.
+func TestExtractPostmortem_RedactsUnpaddedInlinePEMTail(t *testing.T) {
+	frag := "Kj34GkxFhD90vcNLYLInFE" // no '=' padding
+	path := "internal/worker/postmortem.go"
+	log := strings.Join([]string{
+		"running deploy",
+		"$ echo " + frag,
+		"$ vim " + path,
+		"exit status 1",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	if strings.Contains(out, frag) {
+		t.Errorf("unpadded inline PEM tail leaked into post-mortem:\n%s", out)
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected PEM redaction marker in output:\n%s", out)
+	}
+	// The command prose and a digit-free path must survive.
+	if !strings.Contains(out, "$ echo") {
+		t.Errorf("command prefix should be preserved:\n%s", out)
+	}
+	if !strings.Contains(out, path) {
+		t.Errorf("digit-free path should be preserved (not over-redacted):\n%s", out)
+	}
+}
+
 // TestExtractPostmortem_RedactsSingleClippedPEMBodyLine covers the finding's
 // sharpest case: the tail starts inside a PEM dump and only ONE full-width base64
 // body line survives into the last-actions window, with both -----BEGIN----- and
@@ -401,6 +436,27 @@ func TestRedactInlinePEMBody(t *testing.T) {
 		t.Errorf("padded short inline tail not redacted:\n%s", got)
 	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
 		t.Errorf("expected command prose kept and marker present:\n%s", got)
+	}
+
+	// The same short tail with the '=' padding CLIPPED OFF (`$ echo Kj34…InFE`,
+	// no '=') is the finding's leak: it is under the full-width width and has no
+	// padding, so the padded-only bar skipped it. It is disambiguated from a hash
+	// by its digits together with base64-only characters (uppercase, no '='), so it
+	// is redacted while the command prose survives (#835 review — unpadded inline
+	// PEM tail leak).
+	unpadded := "Kj34GkxFhD90vcNLYLInFE"
+	if got := redactInlinePEMBody("$ echo " + unpadded); strings.Contains(got, unpadded) {
+		t.Errorf("unpadded short inline tail not redacted:\n%s", got)
+	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("expected command prose kept and marker present:\n%s", got)
+	}
+
+	// A digit-free file path embedded in a command line reaches the same >=16-char
+	// candidate matcher but carries no digit, so it must survive intact — the
+	// unpadded-tail rule must not garble the paths a post-mortem records.
+	path := "internal/worker/postmortem"
+	if got := redactInlinePEMBody("$ vim " + path + ".go"); !strings.Contains(got, path) {
+		t.Errorf("digit-free path should survive inline redaction:\n%s", got)
 	}
 }
 

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -1,0 +1,168 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractPostmortem_FailedCommands(t *testing.T) {
+	log := strings.Join([]string{
+		"running go test ./...",
+		"--- FAIL: TestFoo (0.01s)",
+		"    foo_test.go:42: expected 3, got 4",
+		"FAIL\tgithub.com/befeast/maestro/internal/foo\t0.02s",
+		"internal/bar/bar.go:10:2: undefined: doStuff",
+		"exit status 1",
+		"some unrelated chatter that is fine",
+	}, "\n")
+
+	path := writeTempLog(t, log)
+	out := ExtractPostmortem(path, PostmortemTailLines)
+
+	if out == "" {
+		t.Fatal("expected a non-empty post-mortem")
+	}
+	for _, want := range []string{
+		"--- FAIL: TestFoo",
+		"undefined: doStuff",
+		"exit status 1",
+		"Errors / failed commands observed",
+		"Last actions before the attempt ended",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("post-mortem missing %q:\n%s", want, out)
+		}
+	}
+	// A benign line must not be pulled into the failures section, but it is the
+	// last line so it appears under "last actions".
+	if strings.Count(out, "unrelated chatter") != 1 {
+		t.Errorf("benign line should appear once (as a last action), got:\n%s", out)
+	}
+}
+
+func TestExtractPostmortem_EditedFiles(t *testing.T) {
+	log := strings.Join([]string{
+		`{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/internal/a.go"}}`,
+		`Wrote internal/b.go`,
+		`+++ b/internal/c.go`,
+		`diff --git a/internal/d.go b/internal/d.go`,
+		"done",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+	for _, want := range []string{
+		"Files the previous attempt touched",
+		"/repo/internal/a.go",
+		"internal/b.go",
+		"internal/c.go",
+		"internal/d.go",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("post-mortem missing edited file %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestExtractPostmortem_EmptyLogNoSection(t *testing.T) {
+	// Empty file.
+	if got := ExtractPostmortem(writeTempLog(t, ""), PostmortemTailLines); got != "" {
+		t.Errorf("empty log should yield no post-mortem, got %q", got)
+	}
+	// Whitespace-only file.
+	if got := ExtractPostmortem(writeTempLog(t, "   \n\t\n  "), PostmortemTailLines); got != "" {
+		t.Errorf("whitespace-only log should yield no post-mortem, got %q", got)
+	}
+	// Missing file.
+	if got := ExtractPostmortem(filepath.Join(t.TempDir(), "does-not-exist.log"), PostmortemTailLines); got != "" {
+		t.Errorf("missing log should yield no post-mortem, got %q", got)
+	}
+	// Empty path.
+	if got := ExtractPostmortem("", PostmortemTailLines); got != "" {
+		t.Errorf("empty path should yield no post-mortem, got %q", got)
+	}
+}
+
+func TestExtractPostmortem_RedactsSecrets(t *testing.T) {
+	log := strings.Join([]string{
+		"error: request failed",
+		"Authorization: Bearer sk-abcdefghijklmnopqrstuvwxyz012345",
+		"exporting GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+		"API_KEY=supersecretvalue123",
+		"last line",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	for _, secret := range []string{
+		"sk-abcdefghijklmnopqrstuvwxyz012345",
+		"ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+		"supersecretvalue123",
+	} {
+		if strings.Contains(out, secret) {
+			t.Errorf("post-mortem leaked secret %q:\n%s", secret, out)
+		}
+	}
+	if !strings.Contains(out, "[REDACTED") && !strings.Contains(out, "=[REDACTED]") {
+		t.Errorf("expected a redaction marker in output:\n%s", out)
+	}
+}
+
+func TestCapPostmortem_Enforced(t *testing.T) {
+	// A body far larger than the cap.
+	var sb strings.Builder
+	for i := 0; i < 500; i++ {
+		sb.WriteString("- this is a reasonably long line of post-mortem content\n")
+	}
+	big := sb.String()
+	if len(big) <= PostmortemPromptCapBytes {
+		t.Fatalf("test setup: body should exceed cap, got %d", len(big))
+	}
+
+	capped := CapPostmortem(big, PostmortemPromptCapBytes)
+	// Content is capped to capBytes; a short marker may be appended.
+	if len(capped) > PostmortemPromptCapBytes+160 {
+		t.Errorf("capped output too large: %d bytes", len(capped))
+	}
+	if !strings.Contains(capped, "truncated") {
+		t.Errorf("expected truncation marker in capped output")
+	}
+
+	// A small body is returned unchanged.
+	small := "- short\n- body"
+	if got := CapPostmortem(small, PostmortemPromptCapBytes); got != small {
+		t.Errorf("small body should be unchanged, got %q", got)
+	}
+	// capBytes <= 0 disables the cap.
+	if got := CapPostmortem(big, 0); got != big {
+		t.Errorf("capBytes<=0 should disable cap")
+	}
+}
+
+func TestExtractPostmortem_TailBounded(t *testing.T) {
+	// A failure line far above the tail window must be dropped; a recent one kept.
+	var lines []string
+	lines = append(lines, "FAIL\tancient/package\t0.01s") // line 0, way above the tail
+	for i := 0; i < PostmortemTailLines+50; i++ {
+		lines = append(lines, "noise line filler")
+	}
+	lines = append(lines, "error: recent failure near the end")
+
+	out := ExtractPostmortem(writeTempLog(t, strings.Join(lines, "\n")), PostmortemTailLines)
+	if strings.Contains(out, "ancient/package") {
+		t.Errorf("failure outside the tail window should be dropped:\n%s", out)
+	}
+	if !strings.Contains(out, "recent failure near the end") {
+		t.Errorf("recent failure should be captured:\n%s", out)
+	}
+}
+
+func writeTempLog(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "worker.log")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp log: %v", err)
+	}
+	return path
+}

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -377,6 +377,46 @@ func TestExtractPostmortem_RedactsShortAllCapsInlinePEMTail(t *testing.T) {
 	}
 }
 
+// TestExtractPostmortem_RedactsMixedCaseInlinePEMTail closes the successor of the
+// all-caps finding (#835 review — "Mixed-Case PEM Tail Leaks"). A digit-free
+// base64 tail that mixes case (`$ echo AbCdEfGh`) or carries a '+' (`$ echo
+// abc+DefG`) sat below every earlier branch — it has lowercase (so the all-caps
+// branch skips it) and no digit (so the upper+digit branch skips it) — and reached
+// both the persisted post-mortem and the capped retry prompt intact. The
+// same-case-run density branch (and the '+' signal) now redact the dense
+// alternation while a real identifier keeps its word run and survives.
+func TestExtractPostmortem_RedactsMixedCaseInlinePEMTail(t *testing.T) {
+	mixed := "AbCdEfGh" // alternating case, no digit, no word run
+	plus := "abc+DefG"  // '+' is base64-only
+	ident := "handleUserRequest"
+	log := strings.Join([]string{
+		"running deploy",
+		"$ echo " + mixed,
+		"$ echo " + plus,
+		"$ grep " + ident,
+		"exit status 1",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+	for _, leak := range []string{mixed, plus} {
+		if strings.Contains(out, leak) {
+			t.Errorf("mixed-case inline PEM tail %q leaked into post-mortem:\n%s", leak, out)
+		}
+		if capped := CapPostmortem(out, 2048); strings.Contains(capped, leak) {
+			t.Errorf("mixed-case inline PEM tail %q leaked into capped prompt excerpt:\n%s", leak, capped)
+		}
+	}
+	if !strings.Contains(out, "REDACTED_PRIVATE_KEY_BLOCK") {
+		t.Errorf("expected PEM redaction marker in output:\n%s", out)
+	}
+	// A digit-free identifier with a word run must not be over-redacted.
+	for _, keep := range []string{ident, "$ echo", "exit status 1"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("benign content %q should survive inline redaction:\n%s", keep, out)
+		}
+	}
+}
+
 // TestExtractPostmortem_RedactsSingleClippedPEMBodyLine covers the finding's
 // sharpest case: the tail starts inside a PEM dump and only ONE full-width base64
 // body line survives into the last-actions window, with both -----BEGIN----- and
@@ -622,11 +662,42 @@ func TestRedactInlinePEMBody(t *testing.T) {
 	}
 
 	// A mixed-case, digit-free identifier stays intact: it has lowercase (so the
-	// all-caps branch skips it) and no digit (so the upper+digit branch skips it) —
-	// the unpadded-tail rules must not garble the identifiers a post-mortem records.
+	// all-caps branch skips it) and no digit (so the upper+digit branch skips it) and
+	// carries a word run of >=4 same-case letters (so the mixed-case density branch
+	// skips it) — the unpadded-tail rules must not garble the identifiers a
+	// post-mortem records.
 	ident := "handleUserRequest"
 	if got := redactInlinePEMBody("$ grep " + ident); !strings.Contains(got, ident) {
 		t.Errorf("mixed-case identifier should survive inline redaction:\n%s", got)
+	}
+
+	// A PascalCase type carrying an uppercase acronym run (`HTTPSConn`, HTTPS is a
+	// 5-letter same-case run) is also ordinary post-mortem prose and must survive.
+	acronym := "HTTPSConn"
+	if got := redactInlinePEMBody("$ grep " + acronym); !strings.Contains(got, acronym) {
+		t.Errorf("acronym-bearing identifier should survive inline redaction:\n%s", got)
+	}
+
+	// A MIXED-CASE, digit-free run that alternates case densely with no word/acronym
+	// run (`$ echo AbCdEfGh`) is a clipped key tail that the earlier all-caps and
+	// upper+digit branches both skip (it has lowercase, and no digit). It leaked into
+	// both sinks intact (#835 review — mixed-case inline PEM tail leak). The
+	// same-case-run density branch now redacts it while the command prose survives.
+	mixed := "AbCdEfGh" // 8 chars, alternating case, no digit, longest same-case run 1
+	if got := redactInlinePEMBody("$ echo " + mixed); strings.Contains(got, mixed) {
+		t.Errorf("mixed-case inline PEM tail not redacted:\n%s", got)
+	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("expected command prose kept and marker present:\n%s", got)
+	}
+
+	// A run carrying a '+' (`$ echo abc+DefG`) is key material outright: '+' is a
+	// base64-only character that never appears in a path, identifier, or hex digest
+	// (#835 review — mixed-case inline PEM tail leak, '+' case).
+	plus := "abc+DefG"
+	if got := redactInlinePEMBody("$ echo " + plus); strings.Contains(got, plus) {
+		t.Errorf("'+'-bearing inline blob not redacted:\n%s", got)
+	} else if !strings.Contains(got, "$ echo") || !strings.Contains(got, pemRedactionMarker) {
+		t.Errorf("expected command prose kept and marker present:\n%s", got)
 	}
 }
 

--- a/internal/worker/postmortem_test.go
+++ b/internal/worker/postmortem_test.go
@@ -158,6 +158,143 @@ func TestExtractPostmortem_TailBounded(t *testing.T) {
 	}
 }
 
+// #835 review comment 1: respawns append to the same slot.log, so the tail can
+// carry an older attempt's output. The extractor isolates the region after the
+// last worker-worktree banner (the per-(re)spawn marker) so the prior attempt's
+// failures/files are not mislabeled as the current one — and the banner's host
+// path never leaks into the post-mortem.
+func TestExtractPostmortem_IsolatesCurrentAttempt(t *testing.T) {
+	log := strings.Join([]string{
+		"[maestro] worker worktree: /home/wt/slot-1",
+		"--- FAIL: TestOld (0.00s)",
+		"Wrote internal/old.go",
+		"exit status 1",
+		"[maestro] worker worktree: /home/wt/slot-1", // attempt 2 begins here
+		"running go test ./...",
+		"--- FAIL: TestNew (0.00s)",
+		"Wrote internal/new.go",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	for _, stale := range []string{"TestOld", "internal/old.go"} {
+		if strings.Contains(out, stale) {
+			t.Errorf("prior attempt content %q should be isolated out:\n%s", stale, out)
+		}
+	}
+	for _, want := range []string{"TestNew", "internal/new.go"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("current attempt content %q missing:\n%s", want, out)
+		}
+	}
+	// The worker-worktree banner is a host path and must not reach the prompt.
+	if strings.Contains(out, "worker worktree") {
+		t.Errorf("worktree banner should not appear in the post-mortem:\n%s", out)
+	}
+}
+
+// #835 review comment 2: the codex stream-splitter renders file changes as
+// "[codex] <kind> <path>", which the earlier patterns ignored, so the edited
+// files were dropped for stream-split codex logs. Command/exit lines under the
+// same tag must not be misread as files.
+func TestExtractPostmortem_CodexRenderedFileChange(t *testing.T) {
+	log := strings.Join([]string{
+		"[codex] $ /bin/bash -lc go test ./...",
+		"--- FAIL: TestFoo (0.00s)",
+		"[codex] exit=1",
+		"[codex] modified internal/codexedit.go",
+		"[codex] add newpkg/newfile.go",
+	}, "\n")
+
+	out := ExtractPostmortem(writeTempLog(t, log), PostmortemTailLines)
+
+	for _, want := range []string{"internal/codexedit.go", "newpkg/newfile.go"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("codex-rendered edit %q not captured:\n%s", want, out)
+		}
+	}
+	// "[codex] $ …" (a command, not a file change) must not leak into the files
+	// section — it legitimately appears under "last actions".
+	if files := postmortemSection(out, "Files the previous attempt touched"); strings.Contains(files, "/bin/bash") {
+		t.Errorf("codex command token misparsed as a file:\n%s", files)
+	}
+	// A rendered non-zero codex exit is a failure signal.
+	if !strings.Contains(out, "[codex] exit=1") {
+		t.Errorf("codex non-zero exit should be flagged as a failure:\n%s", out)
+	}
+}
+
+// #835 review comment 2: the claude stream-splitter renders tool_use without
+// its file_path input, so the edited files live only in the raw .jsonl side
+// channel. The extractor reads that side channel to recover them.
+func TestExtractPostmortem_ClaudeJSONLSideChannel(t *testing.T) {
+	// slot.log — the rendered stream — drops file_path from tool_use.
+	logContent := strings.Join([]string{
+		"[claude] model: claude-opus-4",
+		"Let me edit the file.",
+		"[tool_use: Edit]",
+		"--- FAIL: TestBar (0.00s)",
+		"[tool_use: Write]",
+	}, "\n")
+	// slot.jsonl — the raw NDJSON side channel — keeps file_path.
+	jsonlContent := strings.Join([]string{
+		`{"type":"system","subtype":"init","model":"claude-opus-4"}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"internal/edited.go"}}]}}`,
+		`{"type":"user","message":{"content":"tool result string, not an array"}}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"internal/written.go"}}]}}`,
+	}, "\n")
+
+	logPath := writeTempLogAndJSONL(t, logContent, jsonlContent)
+	out := ExtractPostmortem(logPath, PostmortemTailLines)
+
+	for _, want := range []string{"Files the previous attempt touched", "internal/edited.go", "internal/written.go"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("claude jsonl side-channel edit %q not captured:\n%s", want, out)
+		}
+	}
+}
+
+// The .jsonl side channel also accumulates across respawns; its per-attempt
+// boundary is the backend's session-start frame (claude system/init here), so a
+// prior attempt's edits must not surface for the just-failed attempt.
+func TestExtractPostmortem_JSONLIsolatesCurrentAttempt(t *testing.T) {
+	logContent := strings.Join([]string{
+		"[maestro] worker worktree: /home/wt/slot-1",
+		"[tool_use: Edit]",
+	}, "\n")
+	jsonlContent := strings.Join([]string{
+		`{"type":"system","subtype":"init","model":"m"}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"internal/attempt1.go"}}]}}`,
+		`{"type":"system","subtype":"init","model":"m"}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"internal/attempt2.go"}}]}}`,
+	}, "\n")
+
+	logPath := writeTempLogAndJSONL(t, logContent, jsonlContent)
+	out := ExtractPostmortem(logPath, PostmortemTailLines)
+
+	if strings.Contains(out, "internal/attempt1.go") {
+		t.Errorf("prior attempt's jsonl edit should be isolated out:\n%s", out)
+	}
+	if !strings.Contains(out, "internal/attempt2.go") {
+		t.Errorf("current attempt's jsonl edit missing:\n%s", out)
+	}
+}
+
+// postmortemSection returns the body of the "### <heading>" section of a
+// post-mortem, up to the next "### " heading or the end of the text.
+func postmortemSection(out, heading string) string {
+	marker := "### " + heading
+	idx := strings.Index(out, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := out[idx+len(marker):]
+	if next := strings.Index(rest, "\n### "); next >= 0 {
+		return rest[:next]
+	}
+	return rest
+}
+
 func writeTempLog(t *testing.T, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "worker.log")
@@ -165,4 +302,19 @@ func writeTempLog(t *testing.T, content string) string {
 		t.Fatalf("write temp log: %v", err)
 	}
 	return path
+}
+
+// writeTempLogAndJSONL writes slot.log and its paired slot.jsonl side channel
+// into the same directory so JSONLPathForLog resolves the pair.
+func writeTempLogAndJSONL(t *testing.T, logContent, jsonlContent string) string {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "slot.log")
+	if err := os.WriteFile(logPath, []byte(logContent), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	if err := os.WriteFile(JSONLPathForLog(logPath), []byte(jsonlContent), 0o644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	return logPath
 }


### PR DESCRIPTION
Implements #835

## Changes
- New `internal/worker/postmortem.go`: deterministic, backend-agnostic extractor that reads the bounded tail of a failed attempt's worker log and distills a compact, secret-redacted post-mortem (failed commands/errors, files touched, last actions before termination). Includes `ExtractPostmortem` and `CapPostmortem` (hard cap for the prompt); secrets are redacted by mirroring the supervisor's existing patterns.
- `internal/orchestrator/orchestrator.go`: new `appendPriorAttemptPostmortem` prompt section plus wiring in `respawnDueRetries`. On respawn the full post-mortem is persisted to `<state_dir>/<slot>-attempt<N>-postmortem.md` and a capped (<=2KB) excerpt is appended to the retry prompt, alongside (not replacing) existing CI/review/conflict context.
- Graceful degradation: missing/empty/unreadable log => no section, no error, respawn proceeds as before.
- No changes to retry counting, backoff, or routing escalation; no LLM call.

## Testing
- `go test ./...` (all pass)
- `go build ./cmd/maestro/`
- New unit tests: extractor (failed-command extraction, edited-file detection, cap enforcement, empty/missing-log cases, secret redaction, tail bounding) and orchestrator prompt assembly + persistence + graceful degradation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds prior-attempt post-mortems to retry prompts. The main changes are:

- Extracts a compact summary from the failed worker log.
- Redacts secret-like content before writing any post-mortem output.
- Persists the full post-mortem and adds a capped excerpt to the respawn prompt.
- Adds unit and orchestrator coverage for extraction, capping, redaction, and graceful missing-log behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The worker postmortem tests were run and all selected tests passed, and the worker package is OK.
- The orchestrator postmortem tests were run and all listed tests passed, including TestRespawnDueRetries\_PriorAttemptPostmortem\_IncludedAndPersisted and TestRespawnDueRetries\_PostmortemRedactsInlinePEMTailInBothSinks, with graceful degradation coverage.
- Maestro build was performed and go build ./cmd/maestro exited with code 0.
- The full Go test suite was executed and all packages passed under go test ./... -count=1.

<a href="https://app.greptile.com/trex/runs/13935804/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/postmortem.go | Adds post-mortem extraction, current-attempt isolation, secret redaction, side-channel file recovery, and prompt capping. |
| internal/orchestrator/orchestrator.go | Adds retry-prompt wiring and best-effort persistence for the extracted post-mortem. |
| internal/worker/postmortem_test.go | Adds coverage for extraction, redaction, current-attempt isolation, UTF-8 handling, and cap enforcement. |
| internal/orchestrator/postmortem_test.go | Adds end-to-end coverage for prompt inclusion, persistence, missing logs, and redaction in both sinks. |

<sub>Reviews (17): Last reviewed commit: ["postmortem: redact mixed-case digit-free..."](https://github.com/befeast/maestro/commit/7ac011d1ee5c30e131441098754d4f56f701c87a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43154113)</sub>

<!-- /greptile_comment -->