### PR TITLE
feat: issue-grooming agent (@maestro groom) + spec-lint quality gate (#851)

### DIFF
--- a/docs/po-spec-workflow.md
+++ b/docs/po-spec-workflow.md
@@ -61,6 +61,42 @@ audit trail.
 - Specs that require running things off-workshop (laptop, NFS) — violates the hard operating rules.
 - Specs that re-introduce dense, nested, inspector-style UI — see the UI direction in the handover.
 
+## Spec-lint + grooming agent (#851)
+
+The supervisor can enforce the "good spec" rules above automatically. It is
+**off by default**; enabling it is a config-store row change, no code or restart:
+
+```bash
+maestro settings set supervisor.spec_groom.enabled=true            # fleet default
+maestro settings set supervisor.spec_groom.enabled=true --project befeast-maestro
+```
+
+Once enabled, per supervisor cycle (polling only — no webhook):
+
+- **Spec-lint** — each open, not-yet-`maestro-ready` issue is scored against the
+  rules above in a single cheap LLM pass (same backend selection as the
+  supervisor, respecting `supervisor.allow_metered_backend`). A failing issue
+  gets **exactly one** checklist comment naming what is missing; a well-formed
+  issue gets none. Lint runs at most once per issue-body change (a body hash is
+  tracked in state), so there is zero comment churn on unchanged issues.
+- **Grooming** — comment `@maestro groom` on any issue to get a proposed rewrite
+  in the Spec template structure (Summary / Why / Scope / Acceptance / Test Plan
+  / Non-goals; nothing dropped, gaps marked `TBD`) posted as a comment. The
+  proposal changes nothing on its own: applying it is the approval-gated
+  `edit_issue_body` verb — **approve** to replace the issue body, **reject** to
+  leave it untouched. Both outcomes are visible in the approvals UI and audit.
+
+Optional strict gate:
+
+```bash
+maestro settings set supervisor.spec_groom.require_lint_pass=true --project befeast-maestro
+```
+
+With `require_lint_pass` set, the supervisor withholds the `maestro-ready` label
+from an issue until its current body has **passed** spec-lint (default is
+warn-only: a failing issue still gets its lint comment but keeps its normal
+labeling flow).
+
 ## Operator commands
 
 Inspect the queue:

--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -35,6 +35,12 @@ type GitHubClient interface {
 	// approves an approval-gated label_issue_ready decision (#736).
 	AddIssueLabel(issueNumber int, label string) error
 
+	// EditIssueBody replaces an issue's body. executeEditIssueBody uses it
+	// to apply a groomed spec rewrite when an operator approves an
+	// edit_issue_body approval (#851); the proposed body rides
+	// approval.Target.Body.
+	EditIssueBody(issueNumber int, body string) error
+
 	// PRMergeStatus returns the normalized mergeable verdict
 	// ("MERGEABLE"/"CONFLICTING"/"UNKNOWN") and the raw GitHub
 	// mergeable_state ("clean", "behind", "dirty", ...). executeMergePR
@@ -294,6 +300,8 @@ func (e *Executor) dispatchAction(approval *state.Approval) Result {
 		}
 	case config.SupervisorActionApplyLessonProposal:
 		return e.executeApplyLessonProposal(approval)
+	case config.SupervisorActionEditIssueBody:
+		return e.executeEditIssueBody(approval)
 	case "label_issue_ready":
 		return e.executeLabelIssueReady(approval)
 	case "spawn_worker":
@@ -484,6 +492,40 @@ func (e *Executor) executeCloseIssue(approval *state.Approval) Result {
 	return Result{
 		Status:  state.ApprovalStatusExecuted,
 		Summary: fmt.Sprintf("closed issue #%d", issue),
+	}
+}
+
+// executeEditIssueBody applies a groomed issue-body rewrite (#851). The
+// proposed body rides approval.Target.Body, set at mint time by the spec-groom
+// step (state.RecordEditIssueBodyApproval). Approving runs the edit; a reject
+// never reaches the executor, so the issue is left untouched. An empty body is
+// refused rather than silently blanking the issue.
+func (e *Executor) executeEditIssueBody(approval *state.Approval) Result {
+	if approval.Target == nil || approval.Target.Issue <= 0 {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: fmt.Errorf("%w: issue number missing", ErrMissingTarget)}
+	}
+	if e.GH == nil {
+		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no GitHub client wired into executor")}
+	}
+	issue := approval.Target.Issue
+	body := strings.TrimSpace(approval.Target.Body)
+	if body == "" {
+		return Result{
+			Status:  state.ApprovalStatusExecutionFailed,
+			Summary: fmt.Sprintf("edit_issue_body for issue #%d has an empty body — refusing to blank the issue", issue),
+			Err:     fmt.Errorf("%w: issue body is empty", ErrMissingTarget),
+		}
+	}
+	if err := e.GH.EditIssueBody(issue, body); err != nil {
+		return Result{
+			Status:  state.ApprovalStatusExecutionFailed,
+			Summary: fmt.Sprintf("edit issue #%d body: %v", issue, err),
+			Err:     fmt.Errorf("edit issue #%d body: %w", issue, err),
+		}
+	}
+	return Result{
+		Status:  state.ApprovalStatusExecuted,
+		Summary: fmt.Sprintf("applied groomed body to issue #%d", issue),
 	}
 }
 

--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/specgroom"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -40,6 +41,12 @@ type GitHubClient interface {
 	// edit_issue_body approval (#851); the proposed body rides
 	// approval.Target.Body.
 	EditIssueBody(issueNumber int, body string) error
+
+	// IssueBody returns an issue's current body. executeEditIssueBody reads
+	// it just before applying a groomed rewrite and refuses the edit if the
+	// body changed since the proposal was minted, so a manual edit made in
+	// the interim is never silently overwritten (#851 review).
+	IssueBody(issueNumber int) (string, error)
 
 	// PRMergeStatus returns the normalized mergeable verdict
 	// ("MERGEABLE"/"CONFLICTING"/"UNKNOWN") and the raw GitHub
@@ -514,6 +521,28 @@ func (e *Executor) executeEditIssueBody(approval *state.Approval) Result {
 			Status:  state.ApprovalStatusExecutionFailed,
 			Summary: fmt.Sprintf("edit_issue_body for issue #%d has an empty body — refusing to blank the issue", issue),
 			Err:     fmt.Errorf("%w: issue body is empty", ErrMissingTarget),
+		}
+	}
+	// Stale-edit guard (#851 review): the rewrite was groomed against a
+	// specific body snapshot (BaseBodyHash, stamped at mint). Re-read the live
+	// body and refuse the whole-body replace if it changed since — otherwise an
+	// edit a maintainer made between proposal and approval is silently dropped.
+	// A missing base hash (approvals minted before this guard) skips the check.
+	if base := strings.TrimSpace(approval.Target.BaseBodyHash); base != "" {
+		current, err := e.GH.IssueBody(issue)
+		if err != nil {
+			return Result{
+				Status:  state.ApprovalStatusExecutionFailed,
+				Summary: fmt.Sprintf("verify issue #%d body before edit: %v", issue, err),
+				Err:     fmt.Errorf("verify issue #%d body: %w", issue, err),
+			}
+		}
+		if specgroom.BodyHash(current) != base {
+			return Result{
+				Status:  state.ApprovalStatusExecutionFailed,
+				Summary: fmt.Sprintf("issue #%d body changed since this rewrite was proposed — refusing to overwrite the intervening edit; re-run @maestro groom to propose against the current body", issue),
+				Err:     fmt.Errorf("edit issue #%d body: base body is stale", issue),
+			}
 		}
 	}
 	if err := e.GH.EditIssueBody(issue, body); err != nil {

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/specgroom"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -29,6 +30,12 @@ type fakeGH struct {
 	closeErr      error
 	labelErr      error
 	editBodyErr   error
+
+	// issueBody is what IssueBody returns (the "current" live body used by
+	// executeEditIssueBody's stale-edit guard); issueBodyErr forces a fetch
+	// failure.
+	issueBody    string
+	issueBodyErr error
 
 	// #547 stubs for PRMergeStatus.
 	mergeable      string
@@ -81,6 +88,12 @@ func (f *fakeGH) EditIssueBody(issue int, body string) error {
 	}
 	f.editBodyCalls = append(f.editBodyCalls, editBodyCall{issue: issue, body: body})
 	return nil
+}
+func (f *fakeGH) IssueBody(issue int) (string, error) {
+	if f.issueBodyErr != nil {
+		return "", f.issueBodyErr
+	}
+	return f.issueBody, nil
 }
 
 type fakeWT struct {
@@ -477,6 +490,62 @@ func TestExecute_EditIssueBody_PropagatesGitHubError(t *testing.T) {
 	res := ex.Execute(a)
 	if res.Status != state.ApprovalStatusExecutionFailed || res.Err == nil {
 		t.Fatalf("expected execution_failed with err, got %+v", res)
+	}
+}
+
+// TestExecute_EditIssueBody_RefusesStaleBody pins the #851-review guard: if the
+// live issue body changed after the rewrite was proposed (BaseBodyHash no longer
+// matches), the executor must refuse rather than clobber the intervening edit.
+func TestExecute_EditIssueBody_RefusesStaleBody(t *testing.T) {
+	gh := &fakeGH{issueBody: "the CURRENT body after a manual edit"}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	base := specgroom.BodyHash("the body the rewrite was groomed against")
+	a := mkApproval(config.SupervisorActionEditIssueBody,
+		&state.SupervisorTarget{Issue: 12, Body: "## Summary\nGroomed", BaseBodyHash: base}, "apply", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("a body that changed since the proposal must fail, got %+v", res)
+	}
+	if len(gh.editBodyCalls) != 0 {
+		t.Fatalf("must not overwrite an intervening edit: %+v", gh.editBodyCalls)
+	}
+}
+
+// TestExecute_EditIssueBody_AppliesWhenBaseBodyMatches confirms the guard is not
+// over-eager: when the live body still matches what was groomed, the rewrite is
+// applied.
+func TestExecute_EditIssueBody_AppliesWhenBaseBodyMatches(t *testing.T) {
+	const current = "the exact body the rewrite was groomed against"
+	gh := &fakeGH{issueBody: current}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionEditIssueBody,
+		&state.SupervisorTarget{Issue: 12, Body: "## Summary\nGroomed", BaseBodyHash: specgroom.BodyHash(current)}, "apply", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("a matching base body should apply, got %+v", res)
+	}
+	if len(gh.editBodyCalls) != 1 || gh.editBodyCalls[0].body != "## Summary\nGroomed" {
+		t.Fatalf("expected the rewrite applied once: %+v", gh.editBodyCalls)
+	}
+}
+
+// TestExecute_EditIssueBody_StaleGuardFailsClosedOnFetchError verifies the guard
+// fails closed: if the live body cannot be re-read, the executor refuses rather
+// than apply a possibly-stale overwrite.
+func TestExecute_EditIssueBody_StaleGuardFailsClosedOnFetchError(t *testing.T) {
+	gh := &fakeGH{issueBodyErr: errors.New("gh down")}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionEditIssueBody,
+		&state.SupervisorTarget{Issue: 12, Body: "x", BaseBodyHash: "somehash"}, "apply", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed || res.Err == nil {
+		t.Fatalf("a failed body fetch must fail closed, got %+v", res)
+	}
+	if len(gh.editBodyCalls) != 0 {
+		t.Fatalf("must not edit when the guard cannot verify the live body: %+v", gh.editBodyCalls)
 	}
 }
 

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -20,13 +20,15 @@ import (
 // tests keep merging without any extra setup. Tests that exercise the
 // #547 paths set mergeable/mergeState explicitly.
 type fakeGH struct {
-	mergeCalls  []int
-	closeCalls  []closeCall
-	updateCalls []int
-	labelCalls  []labelCall
-	mergeErr    error
-	closeErr    error
-	labelErr    error
+	mergeCalls    []int
+	closeCalls    []closeCall
+	updateCalls   []int
+	labelCalls    []labelCall
+	editBodyCalls []editBodyCall
+	mergeErr      error
+	closeErr      error
+	labelErr      error
+	editBodyErr   error
 
 	// #547 stubs for PRMergeStatus.
 	mergeable      string
@@ -44,6 +46,11 @@ type closeCall struct {
 type labelCall struct {
 	issue int
 	label string
+}
+
+type editBodyCall struct {
+	issue int
+	body  string
 }
 
 func (f *fakeGH) MergePR(pr int) error {
@@ -66,6 +73,13 @@ func (f *fakeGH) AddIssueLabel(issue int, label string) error {
 		return f.labelErr
 	}
 	f.labelCalls = append(f.labelCalls, labelCall{issue: issue, label: label})
+	return nil
+}
+func (f *fakeGH) EditIssueBody(issue int, body string) error {
+	if f.editBodyErr != nil {
+		return f.editBodyErr
+	}
+	f.editBodyCalls = append(f.editBodyCalls, editBodyCall{issue: issue, body: body})
 	return nil
 }
 
@@ -417,6 +431,52 @@ func TestExecute_CloseIssue_RequiresTarget(t *testing.T) {
 	res := ex.Execute(a)
 	if !errors.Is(res.Err, ErrMissingTarget) {
 		t.Fatalf("res = %+v, want ErrMissingTarget", res)
+	}
+}
+
+func TestExecute_EditIssueBody_AppliesRewriteOnApprove(t *testing.T) {
+	gh := &fakeGH{}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionEditIssueBody, &state.SupervisorTarget{Issue: 12, Body: "## Summary\nGroomed body"}, "apply rewrite", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("res = %+v", res)
+	}
+	if len(gh.editBodyCalls) != 1 || gh.editBodyCalls[0].issue != 12 || gh.editBodyCalls[0].body != "## Summary\nGroomed body" {
+		t.Fatalf("editBodyCalls = %+v", gh.editBodyCalls)
+	}
+}
+
+func TestExecute_EditIssueBody_MissingIssueFails(t *testing.T) {
+	ex := &Executor{GH: &fakeGH{}, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionEditIssueBody, &state.SupervisorTarget{Body: "x"}, "s", "")
+	res := ex.Execute(a)
+	if !errors.Is(res.Err, ErrMissingTarget) {
+		t.Fatalf("res = %+v, want ErrMissingTarget", res)
+	}
+}
+
+func TestExecute_EditIssueBody_EmptyBodyRefused(t *testing.T) {
+	gh := &fakeGH{}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionEditIssueBody, &state.SupervisorTarget{Issue: 12, Body: "   "}, "s", "")
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("empty body must fail, got %+v", res)
+	}
+	if len(gh.editBodyCalls) != 0 {
+		t.Fatalf("must not call EditIssueBody with an empty body: %+v", gh.editBodyCalls)
+	}
+}
+
+func TestExecute_EditIssueBody_PropagatesGitHubError(t *testing.T) {
+	gh := &fakeGH{editBodyErr: errors.New("gh boom")}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionEditIssueBody, &state.SupervisorTarget{Issue: 12, Body: "body"}, "s", "")
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed || res.Err == nil {
+		t.Fatalf("expected execution_failed with err, got %+v", res)
 	}
 }
 

--- a/internal/approver/idempotent_test.go
+++ b/internal/approver/idempotent_test.go
@@ -57,6 +57,10 @@ func (b *blockingGH) AddIssueLabel(issue int, label string) error {
 	atomic.AddInt32(&b.calls, 1)
 	return nil
 }
+func (b *blockingGH) EditIssueBody(issue int, body string) error {
+	atomic.AddInt32(&b.calls, 1)
+	return nil
+}
 
 // --- #488: per-approval-ID lock (concurrent Execute) -----------------------
 

--- a/internal/approver/idempotent_test.go
+++ b/internal/approver/idempotent_test.go
@@ -61,6 +61,9 @@ func (b *blockingGH) EditIssueBody(issue int, body string) error {
 	atomic.AddInt32(&b.calls, 1)
 	return nil
 }
+func (b *blockingGH) IssueBody(issue int) (string, error) {
+	return "", nil
+}
 
 // --- #488: per-approval-ID lock (concurrent Execute) -----------------------
 

--- a/internal/approver/registry.go
+++ b/internal/approver/registry.go
@@ -54,6 +54,12 @@ var KnownApprovalActions = map[string]struct{}{
 	// next dispatcher respawn.
 	"restart_worker": {},
 	"stop_worker":    {},
+	// #851: apply a groomed issue-body rewrite. The spec-groom step posts
+	// the proposed rewrite as a comment and mints this approval carrying the
+	// new body on Target.Body; executeEditIssueBody calls gh.EditIssueBody on
+	// approve, and a reject leaves the issue untouched. add_issue_comment (the
+	// safe verb used to post the proposal itself) stays OUT of this registry.
+	"edit_issue_body": {},
 	// #736: ready-label handoff fallback. The common path applies the
 	// add_ready_label mutation directly as an operator-whitelisted safe
 	// action (safe_actions), so it never reaches this registry. But when

--- a/internal/approver/registry_test.go
+++ b/internal/approver/registry_test.go
@@ -54,6 +54,7 @@ func TestRegistry_IsKnownApprovalAction(t *testing.T) {
 		{"stop_worker", true},         // #567: per-session worker-control
 		{"spawn_repair_worker", true}, // #662: classic repair worker (awaiting_dispatch)
 		{"label_issue_ready", true},   // #736: ready-label approval fallback (executor applies the label)
+		{"edit_issue_body", true},     // #851: apply a groomed issue-body rewrite
 
 		// Negative cases — the live-found bugs.
 		{"spawn_repair_repair", false},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -576,6 +576,12 @@ const (
 	SupervisorActionDeleteWorktree      = "delete_worktree"
 	SupervisorActionChangeGlobalConfig  = "change_global_config"
 	SupervisorActionApplyLessonProposal = "apply_lesson_proposal"
+	// SupervisorActionEditIssueBody applies a groomed issue-body rewrite
+	// (#851). It is approval-gated: the spec-groom step posts the proposed
+	// rewrite as a comment and mints this approval carrying the new body on
+	// Target.Body; the approver executor calls gh.EditIssueBody on approve,
+	// and a reject leaves the issue untouched.
+	SupervisorActionEditIssueBody = "edit_issue_body"
 	// SupervisorActionRestartWorker / SupervisorActionStopWorker are the
 	// per-session worker-control verbs surfaced by the fleet snapshot
 	// (#567). Both are approval-gated: the operator clicks Restart/Stop on
@@ -641,7 +647,43 @@ type SupervisorConfig struct {
 	// per-token cost explicitly.
 	AllowMeteredBackend bool `yaml:"allow_metered_backend" json:"allow_metered_backend,omitempty"`
 
+	// SpecGroom configures the issue-grooming agent + spec-lint quality gate
+	// (#851). Off by default: the supervisor only lints ready-candidate issues
+	// and answers `@maestro groom` mentions when SpecGroom.Enabled is set. All
+	// side effects (a single lint checklist comment, a groom proposal comment)
+	// go through the existing safe/cautious surfaces, and applying a rewrite is
+	// the approval-gated edit_issue_body verb.
+	SpecGroom SupervisorSpecGroomConfig `yaml:"spec_groom" json:"spec_groom,omitempty"`
+
 	excludedLabelsSet bool
+}
+
+// SupervisorSpecGroomConfig gates the spec-lint + grooming capability (#851).
+// Both knobs default to false (plain bools), so an untouched config never lints,
+// grooms, or withholds a ready label — enabling is a config-store row change.
+type SupervisorSpecGroomConfig struct {
+	// Enabled turns the whole capability on for this project. While false the
+	// supervisor performs no lint pass, posts no comments, and mints no
+	// edit_issue_body approvals.
+	Enabled bool `yaml:"enabled" json:"enabled,omitempty"`
+
+	// RequireLintPass, when true, withholds the ready label from an issue whose
+	// current body has not passed spec-lint (default warn-only: a failing issue
+	// still gets its lint comment but keeps its normal labeling flow). Has no
+	// effect unless Enabled is also true.
+	RequireLintPass bool `yaml:"require_lint_pass" json:"require_lint_pass,omitempty"`
+}
+
+// SpecGroomOn reports whether the spec-lint + grooming capability is enabled
+// for this project. Default false (#851).
+func (c SupervisorConfig) SpecGroomOn() bool {
+	return c.SpecGroom.Enabled
+}
+
+// SpecGroomRequireLintPass reports whether the ready label must be withheld from
+// issues that have not passed spec-lint. Only meaningful when SpecGroomOn().
+func (c SupervisorConfig) SpecGroomRequireLintPass() bool {
+	return c.SpecGroom.Enabled && c.SpecGroom.RequireLintPass
 }
 
 // LessonProposalsOn reports whether the supervisor should generate lesson
@@ -2243,6 +2285,7 @@ func knownSupervisorActions() map[string]bool {
 		SupervisorActionSpawnReviewRepair:   true,
 		SupervisorActionRestartWorker:       true,
 		SupervisorActionStopWorker:          true,
+		SupervisorActionEditIssueBody:       true,
 	}
 }
 
@@ -2262,6 +2305,7 @@ func knownSupervisorActionNames() []string {
 		SupervisorActionSpawnReviewRepair,
 		SupervisorActionRestartWorker,
 		SupervisorActionStopWorker,
+		SupervisorActionEditIssueBody,
 	}
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -84,6 +84,18 @@ func FleetSettingSpecs() []FleetSettingSpec {
 			Value:    func(c *Config) string { return strconv.FormatBool(c.Supervisor.AlwaysConsultLLM) },
 		},
 		{
+			Key:      "supervisor.spec_groom.enabled",
+			YAMLPath: []string{"supervisor", "spec_groom", "enabled"},
+			Kind:     SettingKindBool,
+			Value:    func(c *Config) string { return strconv.FormatBool(c.Supervisor.SpecGroom.Enabled) },
+		},
+		{
+			Key:      "supervisor.spec_groom.require_lint_pass",
+			YAMLPath: []string{"supervisor", "spec_groom", "require_lint_pass"},
+			Kind:     SettingKindBool,
+			Value:    func(c *Config) string { return strconv.FormatBool(c.Supervisor.SpecGroom.RequireLintPass) },
+		},
+		{
 			Key:      "poll_interval_seconds",
 			YAMLPath: []string{"poll_interval_seconds"},
 			Kind:     SettingKindInt,

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1568,6 +1568,18 @@ func (c *Client) GetIssue(number int) (Issue, error) {
 	return issue, nil
 }
 
+// IssueBody returns just the current body of an issue. The approver executor
+// uses it to re-read the live body before applying a groomed edit_issue_body
+// rewrite, so an edit made after the proposal was minted is not clobbered
+// (#851 review).
+func (c *Client) IssueBody(number int) (string, error) {
+	issue, err := c.GetIssue(number)
+	if err != nil {
+		return "", err
+	}
+	return issue.Body, nil
+}
+
 // IsIssueClosed returns true if the issue is closed
 func (c *Client) IsIssueClosed(number int) (bool, error) {
 	out, err := ghAPI(fmt.Sprintf("repos/%s/issues/%d", c.Repo, number))

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -64,6 +64,18 @@ type issueComment struct {
 	} `json:"user"`
 }
 
+// IssueComment is the public view of a single issue comment. Unlike the
+// internal issueComment (used only for PR Greptile scanning) it carries the
+// comment ID and creation time so callers can track "have I already handled
+// this comment" idempotently — required by the spec-groom mention trigger
+// (#851), which reacts to `@maestro groom` at most once per comment.
+type IssueComment struct {
+	ID        int64  `json:"id"`
+	Body      string `json:"body"`
+	Author    string `json:"author"`
+	CreatedAt string `json:"created_at"`
+}
+
 type Issue struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`
@@ -2233,6 +2245,39 @@ func (c *Client) CommentIssue(issueNumber int, body string) error {
 		return fmt.Errorf("gh issue comment: %w\n%s", err, out)
 	}
 	return nil
+}
+
+// ListIssueComments returns the comments on an issue in chronological order,
+// carrying each comment's ID, author login, and creation time. Used by the
+// spec-groom mention trigger (#851) to poll for `@maestro groom` commands
+// without a webhook dependency. GitHub treats PRs as issues, so this also
+// works for PR numbers, but the supervisor only calls it for issues.
+func (c *Client) ListIssueComments(issueNumber int) ([]IssueComment, error) {
+	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, issueNumber), "--paginate")
+	if err != nil {
+		return nil, fmt.Errorf("list issue comments for #%d: %w", issueNumber, err)
+	}
+	var raw []struct {
+		ID        int64  `json:"id"`
+		Body      string `json:"body"`
+		CreatedAt string `json:"created_at"`
+		User      struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse issue #%d comments: %w", issueNumber, err)
+	}
+	comments := make([]IssueComment, 0, len(raw))
+	for _, r := range raw {
+		comments = append(comments, IssueComment{
+			ID:        r.ID,
+			Body:      r.Body,
+			Author:    r.User.Login,
+			CreatedAt: r.CreatedAt,
+		})
+	}
+	return comments, nil
 }
 
 // CommentPR leaves a comment on a pull request.

--- a/internal/specgroom/specgroom.go
+++ b/internal/specgroom/specgroom.go
@@ -1,0 +1,342 @@
+// Package specgroom holds the pure, dependency-free core of the issue-grooming
+// agent + spec-lint quality gate (#851):
+//
+//   - the "good spec" rubric derived from docs/po-spec-workflow.md,
+//   - assembly of the single per-issue LLM prompt,
+//   - strict-ish parsing of the structured verdict it returns,
+//   - `@maestro groom` mention detection,
+//   - body hashing for lint idempotency, and
+//   - rendering the lint-checklist and groom-proposal comments.
+//
+// It imports only the standard library so it is trivially unit-testable and
+// carries no coupling to the supervisor, GitHub, or config packages. The
+// supervisor wires it to a real LLM backend and GitHub surfaces.
+package specgroom
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// GroomTrigger is the comment mention that requests a grooming proposal.
+const GroomTrigger = "@maestro groom"
+
+// Comment markers let the supervisor (and humans) recognize maestro's own
+// spec-groom comments. They are stable, machine-greppable HTML comments.
+const (
+	LintCommentMarker  = "<!-- maestro:spec-lint -->"
+	GroomCommentMarker = "<!-- maestro:groom-proposal -->"
+)
+
+// Completer is the one-method LLM surface specgroom needs. supervisor's
+// LLMClient (Complete(prompt) (string, error)) satisfies it directly.
+type Completer interface {
+	Complete(prompt string) (string, error)
+}
+
+// Issue is the minimal issue view the lint pass reasons over.
+type Issue struct {
+	Number int
+	Title  string
+	Body   string
+	Labels []string
+}
+
+// Comment is the minimal issue-comment view used for mention detection.
+type Comment struct {
+	ID     int64
+	Body   string
+	Author string
+}
+
+// Rule is one canonical "good spec" criterion. Key is stable (used as the
+// checklist item id the model echoes back); Label is human-facing.
+type Rule struct {
+	Key   string
+	Label string
+}
+
+// Rules is the spec-lint rubric, lifted from docs/po-spec-workflow.md
+// ("What makes a good spec"). The order is the order rendered in the checklist.
+var Rules = []Rule{
+	{Key: "testable_acceptance", Label: "Acceptance criteria are testable without re-asking the PO"},
+	{Key: "explicit_scope", Label: "Scope and non-goals are explicit"},
+	{Key: "no_broad_refactor", Label: "No implied broad refactor (worker prompt forbids them)"},
+	{Key: "single_repo", Label: "No multi-repo coordination in one spec"},
+	{Key: "observable_verification", Label: "Verification is observable against live services, not just unit tests"},
+}
+
+// ChecklistItem is the model's verdict for one rubric rule.
+type ChecklistItem struct {
+	Rule string `json:"rule"`
+	OK   bool   `json:"ok"`
+	Note string `json:"note,omitempty"`
+}
+
+// Verdict is the structured output of the single LLM pass: the lint verdict
+// plus (when failing or when grooming was requested) a full Spec-template
+// rewrite of the issue body.
+type Verdict struct {
+	Pass          bool            `json:"pass"`
+	Summary       string          `json:"summary"`
+	Checklist     []ChecklistItem `json:"checklist,omitempty"`
+	RewrittenBody string          `json:"rewritten_body,omitempty"`
+}
+
+// FailingRules returns the rubric items the model marked not-OK, in rubric
+// order, resolving each to its human label.
+func (v Verdict) FailingRules() []ChecklistItem {
+	byKey := make(map[string]ChecklistItem, len(v.Checklist))
+	for _, item := range v.Checklist {
+		byKey[strings.TrimSpace(item.Rule)] = item
+	}
+	var failing []ChecklistItem
+	for _, rule := range Rules {
+		if item, ok := byKey[rule.Key]; ok && !item.OK {
+			failing = append(failing, item)
+		}
+	}
+	return failing
+}
+
+// BodyHash returns a stable digest of an issue body, used to lint at most once
+// per body change. Leading/trailing whitespace is normalized so a trivial edit
+// (a trailing newline) does not force a re-lint.
+func BodyHash(body string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(body)))
+	return hex.EncodeToString(sum[:])
+}
+
+// DetectGroomMention returns the most recent (highest-id) comment that contains
+// the `@maestro groom` trigger. Maestro's own spec-groom comments are skipped
+// via their markers — the lint comment itself names the trigger, so a naive
+// scan would otherwise self-fire grooming on every lint. Comments authored by
+// any login in selfLogins are also skipped. Match is case-insensitive.
+func DetectGroomMention(comments []Comment, selfLogins ...string) (Comment, bool) {
+	self := make(map[string]struct{}, len(selfLogins))
+	for _, login := range selfLogins {
+		if login = strings.TrimSpace(strings.ToLower(login)); login != "" {
+			self[login] = struct{}{}
+		}
+	}
+	var latest Comment
+	found := false
+	for _, c := range comments {
+		if strings.Contains(c.Body, LintCommentMarker) || strings.Contains(c.Body, GroomCommentMarker) {
+			continue
+		}
+		if _, isSelf := self[strings.ToLower(strings.TrimSpace(c.Author))]; isSelf {
+			continue
+		}
+		if !strings.Contains(strings.ToLower(c.Body), GroomTrigger) {
+			continue
+		}
+		if !found || c.ID > latest.ID {
+			latest = c
+			found = true
+		}
+	}
+	return latest, found
+}
+
+const promptTemplate = `You are the Maestro spec-lint and issue-grooming agent.
+
+Score ONE GitHub issue against Maestro's "good spec" rules and, when it falls
+short (or when grooming was explicitly requested), rewrite it in the Spec
+template structure. Do not invent product requirements: when the issue omits
+information, mark it TBD rather than guessing.
+
+Good-spec rules (each maps to a checklist item "rule" key):
+%s
+
+Rewrite structure (use these exact section headings, keep every existing
+detail, mark genuine gaps as "TBD"):
+## Summary
+## Why
+## Scope
+## Acceptance criteria
+## Test plan
+## Non-goals
+
+Return ONE JSON object and nothing else (no Markdown, no prose outside JSON):
+{
+  "pass": true,
+  "summary": "one sentence on the overall verdict",
+  "checklist": [{"rule": "testable_acceptance", "ok": true, "note": "short reason"}],
+  "rewritten_body": "%s"
+}
+
+Rules for the JSON:
+- Include exactly one checklist entry per rule key above.
+- "pass" is true only when every checklist item is ok.
+- %s
+- Never include secrets, tokens, host paths, or internal identifiers.
+
+Issue #%d: %s
+
+Labels: %s
+
+Issue body:
+%s
+`
+
+// BuildPrompt assembles the single per-issue LLM prompt. When groomRequested is
+// true the model is told to always return a rewrite; otherwise it returns a
+// rewrite only when the issue fails lint.
+func BuildPrompt(issue Issue, groomRequested bool) string {
+	var rules strings.Builder
+	for _, rule := range Rules {
+		fmt.Fprintf(&rules, "- %s: %s\n", rule.Key, rule.Label)
+	}
+	rewriteHint := "full rewritten body when pass is false, else empty string"
+	rewriteRule := "Set \"rewritten_body\" to a full Spec-template rewrite whenever pass is false; leave it empty when pass is true."
+	if groomRequested {
+		rewriteHint = "full rewritten body in the Spec template structure"
+		rewriteRule = "Grooming was explicitly requested: always set \"rewritten_body\" to a full Spec-template rewrite, even if pass is true."
+	}
+	labels := strings.Join(issue.Labels, ", ")
+	if strings.TrimSpace(labels) == "" {
+		labels = "(none)"
+	}
+	title := strings.TrimSpace(issue.Title)
+	if title == "" {
+		title = "(no title)"
+	}
+	body := strings.TrimSpace(issue.Body)
+	if body == "" {
+		body = "(empty)"
+	}
+	return fmt.Sprintf(promptTemplate,
+		strings.TrimRight(rules.String(), "\n"),
+		rewriteHint,
+		rewriteRule,
+		issue.Number, title,
+		labels,
+		body,
+	)
+}
+
+// ParseVerdict decodes the model's JSON verdict, tolerating leading/trailing
+// prose by extracting the first {...} block on a strict-decode failure. It is
+// deliberately lenient about unknown fields (models add them) but requires a
+// non-empty summary so a malformed empty object is rejected rather than posted.
+func ParseVerdict(output string) (Verdict, error) {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return Verdict{}, fmt.Errorf("specgroom: empty verdict output")
+	}
+	verdict, err := decodeVerdict(trimmed)
+	if err != nil {
+		if jsonText, ok := extractJSONObject(trimmed); ok && jsonText != trimmed {
+			verdict, err = decodeVerdict(jsonText)
+		}
+	}
+	if err != nil {
+		return Verdict{}, fmt.Errorf("specgroom: parse verdict: %w", err)
+	}
+	if strings.TrimSpace(verdict.Summary) == "" {
+		return Verdict{}, fmt.Errorf("specgroom: verdict is missing a summary")
+	}
+	return verdict, nil
+}
+
+func decodeVerdict(raw string) (Verdict, error) {
+	var verdict Verdict
+	decoder := json.NewDecoder(bytes.NewBufferString(raw))
+	if err := decoder.Decode(&verdict); err != nil {
+		return Verdict{}, err
+	}
+	// Reject trailing junk after the object so a concatenation of two objects
+	// does not silently decode only the first.
+	var extra struct{}
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return Verdict{}, fmt.Errorf("extra content after JSON object")
+	}
+	return verdict, nil
+}
+
+func extractJSONObject(output string) (string, bool) {
+	start := strings.Index(output, "{")
+	end := strings.LastIndex(output, "}")
+	if start < 0 || end <= start {
+		return "", false
+	}
+	return output[start : end+1], true
+}
+
+// Evaluate runs the single LLM pass for one issue and returns the parsed
+// verdict.
+func Evaluate(c Completer, issue Issue, groomRequested bool) (Verdict, error) {
+	if c == nil {
+		return Verdict{}, fmt.Errorf("specgroom: nil completer")
+	}
+	output, err := c.Complete(BuildPrompt(issue, groomRequested))
+	if err != nil {
+		return Verdict{}, fmt.Errorf("specgroom: llm pass for issue #%d: %w", issue.Number, err)
+	}
+	return ParseVerdict(output)
+}
+
+// RenderLintComment renders the single spec-lint checklist comment for a
+// failing issue. Every rubric rule is shown with a ✓/✗, and failing items carry
+// the model's note. The stable LintCommentMarker leads the comment.
+func RenderLintComment(v Verdict) string {
+	byKey := make(map[string]ChecklistItem, len(v.Checklist))
+	for _, item := range v.Checklist {
+		byKey[strings.TrimSpace(item.Rule)] = item
+	}
+	var b strings.Builder
+	b.WriteString(LintCommentMarker)
+	b.WriteString("\n### Maestro spec-lint\n\n")
+	if s := strings.TrimSpace(v.Summary); s != "" {
+		b.WriteString(s)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("This issue is not yet a complete spec. Checklist against the good-spec rules:\n\n")
+	for _, rule := range Rules {
+		item, ok := byKey[rule.Key]
+		passed := ok && item.OK
+		fmt.Fprintf(&b, "- [%s] %s", boxFor(passed), rule.Label)
+		if !passed && ok && strings.TrimSpace(item.Note) != "" {
+			fmt.Fprintf(&b, " — %s", strings.TrimSpace(item.Note))
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("\nComment `@maestro groom` to get a proposed rewrite in the Spec template structure.\n")
+	return b.String()
+}
+
+func boxFor(ok bool) string {
+	if ok {
+		return "x"
+	}
+	return " "
+}
+
+// RenderGroomComment renders the groom-proposal comment carrying the rewritten
+// body. It notes that applying the rewrite requires an approval — the comment
+// itself changes nothing. Returns "" when there is no rewrite to propose.
+func RenderGroomComment(v Verdict) string {
+	rewrite := strings.TrimSpace(v.RewrittenBody)
+	if rewrite == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(GroomCommentMarker)
+	b.WriteString("\n### Maestro grooming proposal\n\n")
+	if s := strings.TrimSpace(v.Summary); s != "" {
+		b.WriteString(s)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("Proposed rewrite in the Spec template structure. This comment changes nothing on its own — applying it to the issue body is gated behind an `edit_issue_body` approval (approve to apply, reject to leave the issue untouched).\n\n")
+	b.WriteString("<details><summary>Proposed issue body</summary>\n\n")
+	b.WriteString("````markdown\n")
+	b.WriteString(rewrite)
+	b.WriteString("\n````\n\n</details>\n")
+	return b.String()
+}

--- a/internal/specgroom/specgroom_test.go
+++ b/internal/specgroom/specgroom_test.go
@@ -1,0 +1,221 @@
+package specgroom
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBodyHash_WhitespaceInsensitiveButContentSensitive(t *testing.T) {
+	a := BodyHash("hello world")
+	b := BodyHash("  hello world\n")
+	if a != b {
+		t.Fatalf("expected leading/trailing whitespace to not change the hash: %s != %s", a, b)
+	}
+	if a == BodyHash("hello  world") {
+		t.Fatalf("expected an internal content change to change the hash")
+	}
+	if a == "" {
+		t.Fatalf("hash must be non-empty")
+	}
+}
+
+func TestBuildPrompt_IncludesRubricBodyAndGroomMode(t *testing.T) {
+	issue := Issue{Number: 42, Title: "Improve the dashboard", Body: "make it better", Labels: []string{"enhancement"}}
+
+	lintOnly := BuildPrompt(issue, false)
+	for _, want := range []string{"#42", "Improve the dashboard", "make it better", "enhancement", "testable_acceptance", "observable_verification"} {
+		if !strings.Contains(lintOnly, want) {
+			t.Fatalf("lint prompt missing %q\n%s", want, lintOnly)
+		}
+	}
+	if !strings.Contains(lintOnly, "leave it empty when pass is true") {
+		t.Fatalf("lint-only prompt should make the rewrite conditional on failure")
+	}
+
+	groom := BuildPrompt(issue, true)
+	if !strings.Contains(groom, "always set") {
+		t.Fatalf("groom prompt should force a rewrite regardless of pass")
+	}
+}
+
+func TestBuildPrompt_HandlesEmptyFields(t *testing.T) {
+	prompt := BuildPrompt(Issue{Number: 7}, false)
+	if !strings.Contains(prompt, "(empty)") || !strings.Contains(prompt, "(no title)") || !strings.Contains(prompt, "(none)") {
+		t.Fatalf("empty fields should render placeholders:\n%s", prompt)
+	}
+}
+
+func TestParseVerdict_Valid(t *testing.T) {
+	raw := `{"pass": false, "summary": "acceptance criteria are not testable",
+	  "checklist": [{"rule":"testable_acceptance","ok":false,"note":"no observable outcome"}],
+	  "rewritten_body": "## Summary\nTBD"}`
+	v, err := ParseVerdict(raw)
+	if err != nil {
+		t.Fatalf("ParseVerdict: %v", err)
+	}
+	if v.Pass {
+		t.Fatalf("expected pass=false")
+	}
+	if len(v.Checklist) != 1 || v.Checklist[0].Rule != "testable_acceptance" {
+		t.Fatalf("checklist not parsed: %+v", v.Checklist)
+	}
+	if !strings.Contains(v.RewrittenBody, "## Summary") {
+		t.Fatalf("rewrite not parsed: %q", v.RewrittenBody)
+	}
+}
+
+func TestParseVerdict_ExtractsFromSurroundingProse(t *testing.T) {
+	raw := "Sure! Here is the verdict:\n{\"pass\": true, \"summary\": \"looks good\"}\nHope that helps."
+	v, err := ParseVerdict(raw)
+	if err != nil {
+		t.Fatalf("ParseVerdict with prose: %v", err)
+	}
+	if !v.Pass || v.Summary != "looks good" {
+		t.Fatalf("unexpected verdict: %+v", v)
+	}
+}
+
+func TestParseVerdict_RejectsEmptyOrSummaryless(t *testing.T) {
+	for _, raw := range []string{"", "   ", "{}", `{"pass": true}`, "not json at all"} {
+		if _, err := ParseVerdict(raw); err == nil {
+			t.Fatalf("expected error for %q", raw)
+		}
+	}
+}
+
+func TestParseVerdict_RejectsTrailingSecondObject(t *testing.T) {
+	// A valid object followed by a second object is ambiguous — reject rather
+	// than silently taking the first. (Prose fallback needs a single {...}.)
+	if _, err := ParseVerdict(`{"pass":true,"summary":"a"}{"pass":false,"summary":"b"}`); err == nil {
+		t.Fatalf("expected error on two concatenated objects")
+	}
+}
+
+func TestFailingRules_OrderedByRubric(t *testing.T) {
+	v := Verdict{
+		Checklist: []ChecklistItem{
+			{Rule: "single_repo", OK: false, Note: "touches two repos"},
+			{Rule: "testable_acceptance", OK: false},
+			{Rule: "explicit_scope", OK: true},
+		},
+	}
+	failing := v.FailingRules()
+	if len(failing) != 2 {
+		t.Fatalf("expected 2 failing rules, got %d: %+v", len(failing), failing)
+	}
+	// Rubric order puts testable_acceptance before single_repo.
+	if failing[0].Rule != "testable_acceptance" || failing[1].Rule != "single_repo" {
+		t.Fatalf("failing rules not in rubric order: %+v", failing)
+	}
+}
+
+func TestDetectGroomMention_FindsLatestAndIgnoresOwnComments(t *testing.T) {
+	comments := []Comment{
+		{ID: 1, Body: "please @maestro groom this", Author: "po"},
+		{ID: 2, Body: LintCommentMarker + "\nComment `@maestro groom` to get a rewrite", Author: "maestro-bot"},
+		{ID: 3, Body: "@MAESTRO GROOM again", Author: "po"},
+		{ID: 4, Body: "unrelated chatter", Author: "po"},
+	}
+	m, ok := DetectGroomMention(comments)
+	if !ok {
+		t.Fatalf("expected a mention")
+	}
+	if m.ID != 3 {
+		t.Fatalf("expected the latest real mention (id 3), got id %d", m.ID)
+	}
+}
+
+func TestDetectGroomMention_None(t *testing.T) {
+	if _, ok := DetectGroomMention([]Comment{{ID: 1, Body: "no trigger here", Author: "po"}}); ok {
+		t.Fatalf("did not expect a mention")
+	}
+}
+
+func TestDetectGroomMention_SkipsSelfLogin(t *testing.T) {
+	comments := []Comment{{ID: 5, Body: "@maestro groom", Author: "maestro-bot"}}
+	if _, ok := DetectGroomMention(comments, "maestro-bot"); ok {
+		t.Fatalf("comment from a self login must be ignored")
+	}
+}
+
+func TestRenderLintComment_HasMarkerAndChecklist(t *testing.T) {
+	v := Verdict{
+		Pass:    false,
+		Summary: "not testable yet",
+		Checklist: []ChecklistItem{
+			{Rule: "testable_acceptance", OK: false, Note: "no observable outcome"},
+			{Rule: "explicit_scope", OK: true},
+			{Rule: "no_broad_refactor", OK: true},
+			{Rule: "single_repo", OK: true},
+			{Rule: "observable_verification", OK: false, Note: "unit tests only"},
+		},
+	}
+	out := RenderLintComment(v)
+	if !strings.HasPrefix(out, LintCommentMarker) {
+		t.Fatalf("comment must start with the lint marker:\n%s", out)
+	}
+	if !strings.Contains(out, "not testable yet") {
+		t.Fatalf("summary missing")
+	}
+	if !strings.Contains(out, "no observable outcome") || !strings.Contains(out, "unit tests only") {
+		t.Fatalf("failing-rule notes missing:\n%s", out)
+	}
+	if !strings.Contains(out, "- [ ] Acceptance criteria are testable") {
+		t.Fatalf("failing rule should render an unchecked box:\n%s", out)
+	}
+	if !strings.Contains(out, "- [x] Scope and non-goals are explicit") {
+		t.Fatalf("passing rule should render a checked box:\n%s", out)
+	}
+	if !strings.Contains(out, GroomTrigger) {
+		t.Fatalf("lint comment should tell the PO how to request a rewrite")
+	}
+}
+
+func TestRenderGroomComment_CarriesRewriteOrEmpty(t *testing.T) {
+	if got := RenderGroomComment(Verdict{Summary: "x"}); got != "" {
+		t.Fatalf("no rewrite → empty proposal, got %q", got)
+	}
+	out := RenderGroomComment(Verdict{Summary: "here is a rewrite", RewrittenBody: "## Summary\nDo the thing"})
+	if !strings.HasPrefix(out, GroomCommentMarker) {
+		t.Fatalf("proposal must start with the groom marker:\n%s", out)
+	}
+	if !strings.Contains(out, "## Summary") || !strings.Contains(out, "Do the thing") {
+		t.Fatalf("proposal must embed the rewrite:\n%s", out)
+	}
+	if !strings.Contains(out, "edit_issue_body") {
+		t.Fatalf("proposal must explain the approval gate:\n%s", out)
+	}
+}
+
+type fakeCompleter struct {
+	out    string
+	err    error
+	prompt string
+	calls  int
+}
+
+func (f *fakeCompleter) Complete(prompt string) (string, error) {
+	f.calls++
+	f.prompt = prompt
+	return f.out, f.err
+}
+
+func TestEvaluate_OnePassParsesVerdict(t *testing.T) {
+	fc := &fakeCompleter{out: `{"pass": true, "summary": "well formed"}`}
+	v, err := Evaluate(fc, Issue{Number: 1, Body: "body"}, false)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if fc.calls != 1 {
+		t.Fatalf("expected exactly one LLM pass, got %d", fc.calls)
+	}
+	if !v.Pass {
+		t.Fatalf("expected pass")
+	}
+}
+
+func TestEvaluate_NilCompleter(t *testing.T) {
+	if _, err := Evaluate(nil, Issue{Number: 1}, false); err == nil {
+		t.Fatalf("expected error for nil completer")
+	}
+}

--- a/internal/state/spec_lint.go
+++ b/internal/state/spec_lint.go
@@ -122,11 +122,14 @@ func (s *State) MarkGroomMentionHandled(issue int, commentID int64, now time.Tim
 
 // RecordEditIssueBodyApproval mints (or refreshes in place) a pending
 // edit_issue_body approval carrying the proposed rewrite on Target.Body (#851).
-// Dedup is keyed on (edit_issue_body, issue): a re-groom with a fresh rewrite
-// updates the live pending approval's body and payload hash under its stable
-// id rather than piling up a sibling. Approving executes the edit; rejecting
+// baseBodyHash is the digest of the issue body the rewrite was groomed against;
+// it rides Target.BaseBodyHash so the approver can refuse the edit if the live
+// body changed after this proposal was minted (#851 review). Dedup is keyed on
+// (edit_issue_body, issue): a re-groom with a fresh rewrite updates the live
+// pending approval's body, base hash, and payload hash under its stable id
+// rather than piling up a sibling. Approving executes the edit; rejecting
 // leaves the issue untouched. Returns the stored approval.
-func (s *State) RecordEditIssueBodyApproval(issue int, body, summary, repo, project string, evidence []string, now time.Time) *Approval {
+func (s *State) RecordEditIssueBodyApproval(issue int, body, baseBodyHash, summary, repo, project string, evidence []string, now time.Time) *Approval {
 	if s == nil || issue <= 0 {
 		return nil
 	}
@@ -134,7 +137,7 @@ func (s *State) RecordEditIssueBodyApproval(issue int, body, summary, repo, proj
 		now = time.Now().UTC()
 	}
 	now = normalizedTime(now)
-	target := &SupervisorTarget{Issue: issue, Body: body}
+	target := &SupervisorTarget{Issue: issue, Body: body, BaseBodyHash: baseBodyHash}
 
 	// Dedup against a still-effective approval for the same issue.
 	for i := range s.Approvals {

--- a/internal/state/spec_lint.go
+++ b/internal/state/spec_lint.go
@@ -1,0 +1,255 @@
+package state
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// actionEditIssueBody is the approval verb that applies a groomed issue-body
+// rewrite (#851). It mirrors config.SupervisorActionEditIssueBody; the state
+// package deliberately does not import internal/config (that would invert the
+// layering — see MigrateApprovalsBindRepo), so the literal lives here too.
+const actionEditIssueBody = "edit_issue_body"
+
+// riskApprovalGated mirrors supervisor.RiskApprovalGated; the state package
+// cannot import the supervisor package (and treats Risk as an opaque string on
+// the wire), so the literal lives here for the edit_issue_body mint.
+const riskApprovalGated = "approval_gated"
+
+// SpecLintTrack is the durable per-issue spec-lint / grooming record (#851).
+// It answers two idempotency questions the supervisor asks every cycle:
+//   - "have I already linted this exact body?" (BodyHash) — so a passing or
+//     unchanged issue never gets a second comment;
+//   - "have I already handled this `@maestro groom` mention?"
+//     (LastGroomCommentID) — so one mention fires grooming exactly once.
+//
+// UpdatedAt is the tie-break for the 3-way merge (mergeSpecLintTracks), so a
+// concurrent orchestrator Save cannot clobber a fresher lint mark.
+type SpecLintTrack struct {
+	Issue    int    `json:"issue"`
+	BodyHash string `json:"body_hash,omitempty"`
+	// Pass is the last lint verdict for BodyHash: true when the issue met the
+	// good-spec rules, false when the checklist comment was posted.
+	Pass               bool      `json:"pass"`
+	LintedAt           time.Time `json:"linted_at,omitempty"`
+	LastGroomCommentID int64     `json:"last_groom_comment_id,omitempty"`
+	LastGroomedAt      time.Time `json:"last_groomed_at,omitempty"`
+	UpdatedAt          time.Time `json:"updated_at,omitempty"`
+}
+
+// SpecLintTrackFor returns the lint record for an issue, if any.
+func (s *State) SpecLintTrackFor(issue int) (SpecLintTrack, bool) {
+	if s == nil || issue <= 0 {
+		return SpecLintTrack{}, false
+	}
+	track, ok := s.SpecLintTracks[issue]
+	return track, ok
+}
+
+// IssueLintedForBody reports whether the issue has already been linted at the
+// given body hash. The supervisor gates the (cost-bearing) lint LLM pass on
+// this so it lints at most once per body change.
+func (s *State) IssueLintedForBody(issue int, bodyHash string) bool {
+	if s == nil || issue <= 0 || strings.TrimSpace(bodyHash) == "" {
+		return false
+	}
+	track, ok := s.SpecLintTracks[issue]
+	return ok && track.BodyHash == bodyHash
+}
+
+// SpecLintPassedForBody reports whether the issue's current body has passed
+// spec-lint. Used by the require_lint_pass gate to decide whether the ready
+// label may be applied. A missing or stale-hash record returns false, so the
+// gate is default-closed until lint proves the current body passes.
+func (s *State) SpecLintPassedForBody(issue int, bodyHash string) bool {
+	if s == nil || issue <= 0 || strings.TrimSpace(bodyHash) == "" {
+		return false
+	}
+	track, ok := s.SpecLintTracks[issue]
+	return ok && track.Pass && track.BodyHash == bodyHash
+}
+
+// RecordSpecLint records the lint verdict for an issue's current body,
+// preserving any groom-mention bookkeeping. Idempotent: re-recording the same
+// (bodyHash, pass) only refreshes timestamps.
+func (s *State) RecordSpecLint(issue int, bodyHash string, pass bool, now time.Time) {
+	if s == nil || issue <= 0 {
+		return
+	}
+	if s.SpecLintTracks == nil {
+		s.SpecLintTracks = make(map[int]SpecLintTrack)
+	}
+	track := s.SpecLintTracks[issue]
+	track.Issue = issue
+	track.BodyHash = strings.TrimSpace(bodyHash)
+	track.Pass = pass
+	track.LintedAt = normalizedTime(now)
+	track.UpdatedAt = normalizedTime(now)
+	s.SpecLintTracks[issue] = track
+}
+
+// GroomMentionHandled reports whether a `@maestro groom` comment with the given
+// id (or an earlier one) has already been handled for this issue. GitHub
+// comment ids increase monotonically, so a stored id >= the observed id means
+// the mention is not new.
+func (s *State) GroomMentionHandled(issue int, commentID int64) bool {
+	if s == nil || issue <= 0 || commentID <= 0 {
+		return false
+	}
+	track, ok := s.SpecLintTracks[issue]
+	return ok && track.LastGroomCommentID >= commentID
+}
+
+// MarkGroomMentionHandled records that a `@maestro groom` mention up to
+// commentID has been handled for this issue, preserving the lint verdict.
+func (s *State) MarkGroomMentionHandled(issue int, commentID int64, now time.Time) {
+	if s == nil || issue <= 0 || commentID <= 0 {
+		return
+	}
+	if s.SpecLintTracks == nil {
+		s.SpecLintTracks = make(map[int]SpecLintTrack)
+	}
+	track := s.SpecLintTracks[issue]
+	track.Issue = issue
+	if commentID > track.LastGroomCommentID {
+		track.LastGroomCommentID = commentID
+	}
+	track.LastGroomedAt = normalizedTime(now)
+	track.UpdatedAt = normalizedTime(now)
+	s.SpecLintTracks[issue] = track
+}
+
+// RecordEditIssueBodyApproval mints (or refreshes in place) a pending
+// edit_issue_body approval carrying the proposed rewrite on Target.Body (#851).
+// Dedup is keyed on (edit_issue_body, issue): a re-groom with a fresh rewrite
+// updates the live pending approval's body and payload hash under its stable
+// id rather than piling up a sibling. Approving executes the edit; rejecting
+// leaves the issue untouched. Returns the stored approval.
+func (s *State) RecordEditIssueBodyApproval(issue int, body, summary, repo, project string, evidence []string, now time.Time) *Approval {
+	if s == nil || issue <= 0 {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = normalizedTime(now)
+	target := &SupervisorTarget{Issue: issue, Body: body}
+
+	// Dedup against a still-effective approval for the same issue.
+	for i := range s.Approvals {
+		candidate := &s.Approvals[i]
+		if candidate.Status != ApprovalStatusPending && candidate.Status != ApprovalStatusAwaitingDispatch {
+			continue
+		}
+		if candidate.Action != actionEditIssueBody {
+			continue
+		}
+		if candidate.Target == nil || candidate.Target.Issue != issue {
+			continue
+		}
+		candidate.Target = cloneSupervisorTarget(target)
+		candidate.Summary = summary
+		candidate.Risk = riskApprovalGated
+		candidate.Evidence = append([]string(nil), evidence...)
+		if strings.TrimSpace(repo) != "" {
+			candidate.Repo = repo
+		}
+		if strings.TrimSpace(project) != "" {
+			candidate.Project = project
+		}
+		candidate.UpdatedAt = now
+		candidate.PayloadHash = candidate.ComputePayloadHash()
+		return candidate
+	}
+
+	decision := SupervisorDecision{
+		RecommendedAction: actionEditIssueBody,
+		Target:            cloneSupervisorTarget(target),
+	}
+	id := approvalID(decision, now)
+	if s.approvalIDInUse(id) {
+		id = id + "-" + now.UTC().Format("20060102T150405.000000000Z")
+	}
+	approval := Approval{
+		ID:              id,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		Action:          actionEditIssueBody,
+		Target:          cloneSupervisorTarget(target),
+		Summary:         summary,
+		Risk:            riskApprovalGated,
+		Evidence:        append([]string(nil), evidence...),
+		Status:          ApprovalStatusPending,
+		TargetStateHash: s.ApprovalTargetStateHash(target),
+		Repo:            repo,
+		Project:         project,
+	}
+	approval.PayloadHash = approval.ComputePayloadHash()
+	approval.Audit = append(approval.Audit, ApprovalAudit{
+		At:              now,
+		Event:           ApprovalAuditCreated,
+		PayloadHash:     approval.PayloadHash,
+		TargetStateHash: approval.TargetStateHash,
+	})
+	s.Approvals = append(s.Approvals, approval)
+	return &s.Approvals[len(s.Approvals)-1]
+}
+
+// PendingEditIssueBodyApproval returns the live pending/awaiting-dispatch
+// edit_issue_body approval for an issue, if one exists. Used to avoid churning
+// a fresh proposal comment when an unresolved proposal is already queued.
+func (s *State) PendingEditIssueBodyApproval(issue int) (*Approval, bool) {
+	if s == nil || issue <= 0 {
+		return nil, false
+	}
+	for i := range s.Approvals {
+		candidate := &s.Approvals[i]
+		if candidate.Status != ApprovalStatusPending && candidate.Status != ApprovalStatusAwaitingDispatch {
+			continue
+		}
+		if candidate.Action != actionEditIssueBody {
+			continue
+		}
+		if candidate.Target != nil && candidate.Target.Issue == issue {
+			return candidate, true
+		}
+	}
+	return nil, false
+}
+
+func mergeSpecLintTracks(current, ours map[int]SpecLintTrack) map[int]SpecLintTrack {
+	merged := make(map[int]SpecLintTrack)
+	for _, key := range unionSpecLintTrackKeys(current, ours) {
+		currentValue, currentOK := current[key]
+		oursValue, oursOK := ours[key]
+		switch {
+		case currentOK && oursOK:
+			if oursValue.UpdatedAt.After(currentValue.UpdatedAt) {
+				merged[key] = oursValue
+			} else {
+				merged[key] = currentValue
+			}
+		case currentOK:
+			merged[key] = currentValue
+		case oursOK:
+			merged[key] = oursValue
+		}
+	}
+	return merged
+}
+
+func unionSpecLintTrackKeys(maps ...map[int]SpecLintTrack) []int {
+	seen := make(map[int]struct{})
+	for _, m := range maps {
+		for k := range m {
+			seen[k] = struct{}{}
+		}
+	}
+	keys := make([]int, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	return keys
+}

--- a/internal/state/spec_lint_test.go
+++ b/internal/state/spec_lint_test.go
@@ -74,7 +74,7 @@ func TestRecordEditIssueBodyApproval_MintAndRefreshInPlace(t *testing.T) {
 	s := NewState()
 	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 
-	a := s.RecordEditIssueBodyApproval(77, "## Summary\nv1", "Apply rewrite", "owner/repo", "owner/repo", []string{"reason"}, now)
+	a := s.RecordEditIssueBodyApproval(77, "## Summary\nv1", "basehash-v1", "Apply rewrite", "owner/repo", "owner/repo", []string{"reason"}, now)
 	if a == nil {
 		t.Fatalf("expected an approval")
 	}
@@ -83,6 +83,9 @@ func TestRecordEditIssueBodyApproval_MintAndRefreshInPlace(t *testing.T) {
 	}
 	if a.Target == nil || a.Target.Issue != 77 || a.Target.Body != "## Summary\nv1" {
 		t.Fatalf("target not carried: %+v", a.Target)
+	}
+	if a.Target.BaseBodyHash != "basehash-v1" {
+		t.Fatalf("base body hash not carried: %q", a.Target.BaseBodyHash)
 	}
 	if a.PayloadHash == "" || a.ComputePayloadHash() != a.PayloadHash {
 		t.Fatalf("payload hash must be set and self-consistent")
@@ -93,7 +96,7 @@ func TestRecordEditIssueBodyApproval_MintAndRefreshInPlace(t *testing.T) {
 	firstID := a.ID
 
 	// A re-groom with a fresh rewrite refreshes IN PLACE under the same id.
-	b := s.RecordEditIssueBodyApproval(77, "## Summary\nv2", "Apply rewrite", "owner/repo", "owner/repo", nil, now.Add(time.Minute))
+	b := s.RecordEditIssueBodyApproval(77, "## Summary\nv2", "basehash-v2", "Apply rewrite", "owner/repo", "owner/repo", nil, now.Add(time.Minute))
 	if len(s.Approvals) != 1 {
 		t.Fatalf("re-groom must not mint a duplicate; got %d approvals", len(s.Approvals))
 	}
@@ -103,6 +106,9 @@ func TestRecordEditIssueBodyApproval_MintAndRefreshInPlace(t *testing.T) {
 	if b.Target.Body != "## Summary\nv2" {
 		t.Fatalf("refreshed approval must carry the new body, got %q", b.Target.Body)
 	}
+	if b.Target.BaseBodyHash != "basehash-v2" {
+		t.Fatalf("refreshed approval must carry the new base body hash, got %q", b.Target.BaseBodyHash)
+	}
 	if b.ComputePayloadHash() != b.PayloadHash {
 		t.Fatalf("payload hash must be recomputed after body refresh")
 	}
@@ -111,8 +117,8 @@ func TestRecordEditIssueBodyApproval_MintAndRefreshInPlace(t *testing.T) {
 func TestRecordEditIssueBodyApproval_DistinctIssuesGetDistinctApprovals(t *testing.T) {
 	s := NewState()
 	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
-	s.RecordEditIssueBodyApproval(1, "a", "s", "owner/repo", "owner/repo", nil, now)
-	s.RecordEditIssueBodyApproval(2, "b", "s", "owner/repo", "owner/repo", nil, now)
+	s.RecordEditIssueBodyApproval(1, "a", "ha", "s", "owner/repo", "owner/repo", nil, now)
+	s.RecordEditIssueBodyApproval(2, "b", "hb", "s", "owner/repo", "owner/repo", nil, now)
 	if len(s.Approvals) != 2 {
 		t.Fatalf("expected 2 approvals for 2 issues, got %d", len(s.Approvals))
 	}

--- a/internal/state/spec_lint_test.go
+++ b/internal/state/spec_lint_test.go
@@ -1,0 +1,171 @@
+package state
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestRecordSpecLint_IdempotencyByBodyHash(t *testing.T) {
+	s := NewState()
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	if s.IssueLintedForBody(101, "hashA") {
+		t.Fatalf("fresh state should report not-linted")
+	}
+	s.RecordSpecLint(101, "hashA", false, now)
+	if !s.IssueLintedForBody(101, "hashA") {
+		t.Fatalf("issue should be linted for hashA")
+	}
+	// A different body hash means the body changed → re-lint required.
+	if s.IssueLintedForBody(101, "hashB") {
+		t.Fatalf("changed body hash must report not-linted so a re-lint runs")
+	}
+	// Distinct issues do not collide.
+	if s.IssueLintedForBody(202, "hashA") {
+		t.Fatalf("distinct issue must not share issue 101's lint mark")
+	}
+}
+
+func TestSpecLintPassedForBody_DefaultClosed(t *testing.T) {
+	s := NewState()
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	if s.SpecLintPassedForBody(1, "h") {
+		t.Fatalf("unlinted issue must not report passed")
+	}
+	s.RecordSpecLint(1, "h", false, now)
+	if s.SpecLintPassedForBody(1, "h") {
+		t.Fatalf("failing lint must not report passed")
+	}
+	s.RecordSpecLint(1, "h", true, now)
+	if !s.SpecLintPassedForBody(1, "h") {
+		t.Fatalf("passing lint should report passed for the same body hash")
+	}
+	if s.SpecLintPassedForBody(1, "other") {
+		t.Fatalf("pass is scoped to the exact body hash")
+	}
+}
+
+func TestGroomMention_HandledOnce(t *testing.T) {
+	s := NewState()
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	if s.GroomMentionHandled(5, 900) {
+		t.Fatalf("no mention handled yet")
+	}
+	s.MarkGroomMentionHandled(5, 900, now)
+	if !s.GroomMentionHandled(5, 900) {
+		t.Fatalf("mention 900 should be marked handled")
+	}
+	// A newer comment id is a new mention.
+	if s.GroomMentionHandled(5, 901) {
+		t.Fatalf("a newer comment id must be treated as an unhandled mention")
+	}
+	// Marking does not clobber the lint verdict.
+	s.RecordSpecLint(5, "h", false, now)
+	s.MarkGroomMentionHandled(5, 950, now)
+	if !s.IssueLintedForBody(5, "h") {
+		t.Fatalf("marking a mention handled must preserve the lint mark")
+	}
+}
+
+func TestRecordEditIssueBodyApproval_MintAndRefreshInPlace(t *testing.T) {
+	s := NewState()
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	a := s.RecordEditIssueBodyApproval(77, "## Summary\nv1", "Apply rewrite", "owner/repo", "owner/repo", []string{"reason"}, now)
+	if a == nil {
+		t.Fatalf("expected an approval")
+	}
+	if a.Action != "edit_issue_body" || a.Status != ApprovalStatusPending {
+		t.Fatalf("unexpected approval: action=%s status=%s", a.Action, a.Status)
+	}
+	if a.Target == nil || a.Target.Issue != 77 || a.Target.Body != "## Summary\nv1" {
+		t.Fatalf("target not carried: %+v", a.Target)
+	}
+	if a.PayloadHash == "" || a.ComputePayloadHash() != a.PayloadHash {
+		t.Fatalf("payload hash must be set and self-consistent")
+	}
+	if len(s.Approvals) != 1 {
+		t.Fatalf("expected exactly one approval, got %d", len(s.Approvals))
+	}
+	firstID := a.ID
+
+	// A re-groom with a fresh rewrite refreshes IN PLACE under the same id.
+	b := s.RecordEditIssueBodyApproval(77, "## Summary\nv2", "Apply rewrite", "owner/repo", "owner/repo", nil, now.Add(time.Minute))
+	if len(s.Approvals) != 1 {
+		t.Fatalf("re-groom must not mint a duplicate; got %d approvals", len(s.Approvals))
+	}
+	if b.ID != firstID {
+		t.Fatalf("refreshed approval id changed: %s != %s", b.ID, firstID)
+	}
+	if b.Target.Body != "## Summary\nv2" {
+		t.Fatalf("refreshed approval must carry the new body, got %q", b.Target.Body)
+	}
+	if b.ComputePayloadHash() != b.PayloadHash {
+		t.Fatalf("payload hash must be recomputed after body refresh")
+	}
+}
+
+func TestRecordEditIssueBodyApproval_DistinctIssuesGetDistinctApprovals(t *testing.T) {
+	s := NewState()
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	s.RecordEditIssueBodyApproval(1, "a", "s", "owner/repo", "owner/repo", nil, now)
+	s.RecordEditIssueBodyApproval(2, "b", "s", "owner/repo", "owner/repo", nil, now)
+	if len(s.Approvals) != 2 {
+		t.Fatalf("expected 2 approvals for 2 issues, got %d", len(s.Approvals))
+	}
+	if _, ok := s.PendingEditIssueBodyApproval(1); !ok {
+		t.Fatalf("expected a pending approval for issue 1")
+	}
+	if _, ok := s.PendingEditIssueBodyApproval(3); ok {
+		t.Fatalf("did not expect a pending approval for issue 3")
+	}
+}
+
+func TestSpecLintTracks_SurvivesJSONRoundTrip(t *testing.T) {
+	s := NewState()
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	s.RecordSpecLint(9, "hash9", true, now)
+	s.MarkGroomMentionHandled(9, 4242, now)
+
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var loaded State
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !loaded.SpecLintPassedForBody(9, "hash9") {
+		t.Fatalf("lint pass lost across round trip")
+	}
+	if !loaded.GroomMentionHandled(9, 4242) {
+		t.Fatalf("groom mention marker lost across round trip")
+	}
+}
+
+func TestMergeSpecLintTracks_LatestWriteWins(t *testing.T) {
+	older := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Hour)
+
+	current := map[int]SpecLintTrack{
+		1: {Issue: 1, BodyHash: "old", Pass: false, UpdatedAt: older},
+		2: {Issue: 2, BodyHash: "keep", Pass: true, UpdatedAt: newer},
+	}
+	ours := map[int]SpecLintTrack{
+		1: {Issue: 1, BodyHash: "new", Pass: true, UpdatedAt: newer},
+		3: {Issue: 3, BodyHash: "fresh", Pass: false, UpdatedAt: older},
+	}
+	merged := mergeSpecLintTracks(current, ours)
+	if merged[1].BodyHash != "new" || !merged[1].Pass {
+		t.Fatalf("issue 1 should take the newer write: %+v", merged[1])
+	}
+	if merged[2].BodyHash != "keep" {
+		t.Fatalf("issue 2 (only in current) should survive: %+v", merged[2])
+	}
+	if merged[3].BodyHash != "fresh" {
+		t.Fatalf("issue 3 (only in ours) should survive: %+v", merged[3])
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -629,6 +629,14 @@ type SupervisorTarget struct {
 	// include the target).
 	HeadSHA string `json:"head_sha,omitempty"`
 	Session string `json:"session,omitempty"`
+	// Body carries the proposed replacement issue body for an edit_issue_body
+	// approval (#851). It is set only on that verb's target; the approver
+	// executor reads it on approve and calls gh.EditIssueBody. It is part of
+	// the approval payload hash (ComputePayloadHash hashes the whole Target)
+	// but intentionally NOT part of approvalTargetsEqual, so a re-groom with a
+	// fresh rewrite refreshes the pending approval in place rather than piling
+	// up a duplicate.
+	Body string `json:"body,omitempty"`
 }
 
 type SupervisorIssueTarget struct {
@@ -1103,6 +1111,15 @@ type State struct {
 	// short SHA observed when the decision was recorded.
 	ReviewRepairTracks map[string]ReviewRepairTrack `json:"review_repair_tracks,omitempty"`
 
+	// SpecLintTracks records the last spec-lint result per issue (#851),
+	// keyed by issue number (project scope is the state.json file itself).
+	// The supervisor lints an issue at most once per body change by comparing
+	// the current body hash to the stored one, and records the last handled
+	// `@maestro groom` comment so a mention fires grooming only once. Wired
+	// through the 3-way merge (mergeSpecLintTracks) latest-write-wins so a
+	// concurrent orchestrator Save cannot clobber a fresh lint mark.
+	SpecLintTracks map[int]SpecLintTrack `json:"spec_lint_tracks,omitempty"`
+
 	loadedHash  string
 	loadedState *State
 }
@@ -1225,6 +1242,7 @@ func NewState() *State {
 		Missions:          make(map[int]*Mission),
 		ProjectStatusSync: make(map[int]ProjectStatusSync),
 		BackendHealth:     make(map[string]BackendHealth),
+		SpecLintTracks:    make(map[int]SpecLintTrack),
 		NextSlot:          1,
 	}
 }
@@ -1473,6 +1491,9 @@ func (s *State) normalize() {
 	if s.BackendHealth == nil {
 		s.BackendHealth = make(map[string]BackendHealth)
 	}
+	if s.SpecLintTracks == nil {
+		s.SpecLintTracks = make(map[int]SpecLintTrack)
+	}
 	if s.NextSlot == 0 {
 		s.NextSlot = 1
 	}
@@ -1488,6 +1509,7 @@ func (s *State) copyFrom(src *State) {
 	s.ProjectStatusSync = src.ProjectStatusSync
 	s.BackendHealth = src.BackendHealth
 	s.BackendQuotaUsage = src.BackendQuotaUsage
+	s.SpecLintTracks = src.SpecLintTracks
 	s.NextSlot = src.NextSlot
 	s.LastMergeAt = src.LastMergeAt
 	s.SpawnDrain = src.SpawnDrain
@@ -1535,6 +1557,7 @@ func mergeStateSnapshots(base, current, ours *State) (*State, error) {
 	}
 	merged.OutcomeHealth = mergeOutcomeHealth(base.OutcomeHealth, current.OutcomeHealth, ours.OutcomeHealth)
 	merged.ProjectStatusSync = mergeProjectStatusSync(current.ProjectStatusSync, ours.ProjectStatusSync)
+	merged.SpecLintTracks = mergeSpecLintTracks(current.SpecLintTracks, ours.SpecLintTracks)
 	merged.BackendHealth = mergeBackendHealth(current.BackendHealth, ours.BackendHealth)
 	merged.BackendQuotaUsage = mergeBackendQuotaUsage(current.BackendQuotaUsage, ours.BackendQuotaUsage)
 	merged.NextSlot = mergeMonotonicInt(base.NextSlot, current.NextSlot, ours.NextSlot)
@@ -2901,7 +2924,11 @@ type approvalDecisionIdentity struct {
 
 // normalizedTargetIdentity returns a copy of target with Session/HeadSHA
 // trimmed, so the content-addressed approval id is robust to incidental
-// whitespace and consistent with approvalTargetsEqual.
+// whitespace and consistent with approvalTargetsEqual. Body is cleared: for
+// edit_issue_body (#851) the identity is (action, issue), so a re-groom with a
+// fresh rewrite refreshes the pending approval in place rather than minting a
+// duplicate under a new content-addressed id — matching approvalTargetsEqual,
+// which also ignores Body.
 func normalizedTargetIdentity(target *SupervisorTarget) *SupervisorTarget {
 	if target == nil {
 		return nil
@@ -2909,6 +2936,7 @@ func normalizedTargetIdentity(target *SupervisorTarget) *SupervisorTarget {
 	clone := cloneSupervisorTarget(target)
 	clone.HeadSHA = strings.TrimSpace(clone.HeadSHA)
 	clone.Session = strings.TrimSpace(clone.Session)
+	clone.Body = ""
 	return clone
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -637,6 +637,14 @@ type SupervisorTarget struct {
 	// fresh rewrite refreshes the pending approval in place rather than piling
 	// up a duplicate.
 	Body string `json:"body,omitempty"`
+	// BaseBodyHash is the digest of the issue body the edit_issue_body rewrite
+	// was groomed against, stamped at mint time (#851 review). On approve the
+	// executor re-fetches the live body and refuses the edit if its hash no
+	// longer matches — so a manual edit made after the proposal was minted is
+	// never silently clobbered. Like Body, it is intentionally NOT part of
+	// approvalTargetsEqual so a fresh re-groom refreshes the pending approval
+	// in place.
+	BaseBodyHash string `json:"base_body_hash,omitempty"`
 }
 
 type SupervisorIssueTarget struct {
@@ -1120,6 +1128,17 @@ type State struct {
 	// concurrent orchestrator Save cannot clobber a fresh lint mark.
 	SpecLintTracks map[int]SpecLintTrack `json:"spec_lint_tracks,omitempty"`
 
+	// SpecGroomCursor is the issue number where the last spec-groom cycle
+	// stopped examining (#851 review). The per-cycle cap only lets a bounded
+	// window of open issues be examined (comment fetch + LLM pass); the cursor
+	// lets the next cycle resume just past that window and wrap around, so a
+	// repo with more open issues than the cap eventually drains every issue
+	// instead of forever re-examining the same first N and starving the tail.
+	// Best-effort: it only steers which window runs, never lint/groom
+	// idempotency (guaranteed by SpecLintTracks), so a merge that keeps the
+	// on-disk value simply re-examines a window and self-heals next cycle.
+	SpecGroomCursor int `json:"spec_groom_cursor,omitempty"`
+
 	loadedHash  string
 	loadedState *State
 }
@@ -1510,6 +1529,7 @@ func (s *State) copyFrom(src *State) {
 	s.BackendHealth = src.BackendHealth
 	s.BackendQuotaUsage = src.BackendQuotaUsage
 	s.SpecLintTracks = src.SpecLintTracks
+	s.SpecGroomCursor = src.SpecGroomCursor
 	s.NextSlot = src.NextSlot
 	s.LastMergeAt = src.LastMergeAt
 	s.SpawnDrain = src.SpawnDrain

--- a/internal/supervisor/specgroom.go
+++ b/internal/supervisor/specgroom.go
@@ -3,6 +3,7 @@ package supervisor
 import (
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -13,9 +14,10 @@ import (
 
 // maxSpecGroomIssuesPerCycle bounds how many issues one supervisor cycle will
 // examine for spec-lint/grooming (comment fetch + LLM pass). It caps both the
-// GitHub API calls and the backend spend per cycle; issues past the cap are
-// picked up on the next cycle. Lint is already once-per-body-change, so a
-// backlog drains within a few cycles and then stays quiet.
+// GitHub API calls and the backend spend per cycle. The examined window rotates
+// across cycles (State.SpecGroomCursor), so issues past the cap are picked up on
+// subsequent cycles rather than starved. Lint is already once-per-body-change,
+// so a backlog drains within a few cycles and then stays quiet.
 const maxSpecGroomIssuesPerCycle = 30
 
 // issueCommentLister is the optional reader capability the spec-groom step needs
@@ -39,6 +41,14 @@ type issueCommentLister interface {
 // persisted by the cycle's single state.Save.
 func (e *Engine) runSpecGroom(st *state.State, mutator Mutator) {
 	if e == nil || e.cfg == nil || st == nil || !e.cfg.Supervisor.SpecGroomOn() {
+		return
+	}
+	// Honor the fleet-wide EMERGENCY STOP LLM halt (#840). The grooming pass
+	// dispatches to the same supervisor backend as Decide, so an active halt
+	// must short-circuit it too — otherwise spec-groom keeps supervisor LLM
+	// calls (and spend) running straight through the emergency stop.
+	if e.emergencyLLMHalt {
+		log.Printf("[supervisor] spec-groom: skipped; emergency LLM halt is active")
 		return
 	}
 	// Respect the metered-backend refusal (#838): the lint pass dispatches to
@@ -67,20 +77,42 @@ func (e *Engine) runSpecGroom(st *state.State, mutator Mutator) {
 	excluded := e.excludeLabels()
 	now := e.now()
 
-	// examined bounds how many issues get a comment fetch + (maybe) an LLM pass
-	// this cycle, capping GitHub and backend cost. truncated counts the
-	// non-excluded issues deferred to the next cycle so the cap is never silent.
-	examined := 0
-	truncated := 0
+	// Candidate set: the non-excluded open issues, sorted by number so the
+	// rotating window (below) is deterministic and issue numbers — which are
+	// stable and monotonic — can key the resume cursor.
+	candidates := make([]github.Issue, 0, len(issues))
 	for _, issue := range issues {
 		if len(excluded) > 0 && github.HasLabel(issue, excluded) {
 			continue
 		}
-		if examined >= maxSpecGroomIssuesPerCycle {
-			truncated++
-			continue
+		candidates = append(candidates, issue)
+	}
+	if len(candidates) == 0 {
+		return
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Number < candidates[j].Number })
+
+	// Rotate the capped window so the backlog drains (#851 review). The cap
+	// bounds how many issues get a comment fetch + (maybe) an LLM pass per
+	// cycle. A fixed [0,cap) window let the first N non-excluded issues consume
+	// the cap on every cycle — so with more open issues than the cap, issue N+1
+	// was never examined (and under require_lint_pass its ready label could stay
+	// withheld forever). Resume just past the last-examined issue and wrap, so
+	// every issue is eventually reached over successive cycles.
+	start := 0
+	for i, issue := range candidates {
+		if issue.Number > st.SpecGroomCursor {
+			start = i
+			break
 		}
+	}
+
+	examined := 0
+	lastExamined := st.SpecGroomCursor
+	for k := 0; k < len(candidates) && examined < maxSpecGroomIssuesPerCycle; k++ {
+		issue := candidates[(start+k)%len(candidates)]
 		examined++
+		lastExamined = issue.Number
 
 		isReady := readyLabel != "" && github.HasLabel(issue, []string{readyLabel})
 
@@ -105,11 +137,14 @@ func (e *Engine) runSpecGroom(st *state.State, mutator Mutator) {
 			e.applyLintVerdict(st, mutator, issue.Number, bodyHash, verdict, now)
 		}
 		if haveMention {
-			e.applyGroomProposal(st, mutator, issue.Number, mention, verdict, now)
+			e.applyGroomProposal(st, mutator, issue.Number, bodyHash, mention, verdict, now)
 		}
 	}
-	if truncated > 0 {
-		log.Printf("[supervisor] spec-groom: examined the first %d issues this cycle; %d more will be examined next cycle", maxSpecGroomIssuesPerCycle, truncated)
+	// Advance the cursor so the next cycle resumes past this window. deferred is
+	// the count not reached this cycle — logged so the cap is never silent.
+	st.SpecGroomCursor = lastExamined
+	if deferred := len(candidates) - examined; deferred > 0 {
+		log.Printf("[supervisor] spec-groom: examined %d issue(s) this cycle (rotating window through issue #%d); %d more will be examined over the next cycles", examined, lastExamined, deferred)
 	}
 }
 
@@ -155,7 +190,7 @@ func (e *Engine) applyLintVerdict(st *state.State, mutator Mutator, issueNumber 
 // marked handled only after the proposal is posted, so a transient error
 // retries next cycle. When the model returned no rewrite the mention is marked
 // handled without a proposal (nothing to apply).
-func (e *Engine) applyGroomProposal(st *state.State, mutator Mutator, issueNumber int, mention specgroom.Comment, verdict specgroom.Verdict, now time.Time) {
+func (e *Engine) applyGroomProposal(st *state.State, mutator Mutator, issueNumber int, baseBodyHash string, mention specgroom.Comment, verdict specgroom.Verdict, now time.Time) {
 	proposal := specgroom.RenderGroomComment(verdict)
 	if proposal == "" {
 		st.MarkGroomMentionHandled(issueNumber, mention.ID, now)
@@ -170,7 +205,10 @@ func (e *Engine) applyGroomProposal(st *state.State, mutator Mutator, issueNumbe
 		"Proposed by the spec-groom agent in response to an @maestro groom mention.",
 		"Approve to replace the issue body with the proposed rewrite; reject to leave it untouched.",
 	}
-	st.RecordEditIssueBodyApproval(issueNumber, verdict.RewrittenBody, summary, e.cfg.Repo, e.cfg.Repo, evidence, now)
+	// baseBodyHash stamps the body the rewrite was groomed against so the
+	// approver can refuse a stale overwrite if the issue is edited before the
+	// operator approves (#851 review).
+	st.RecordEditIssueBodyApproval(issueNumber, verdict.RewrittenBody, baseBodyHash, summary, e.cfg.Repo, e.cfg.Repo, evidence, now)
 	st.MarkGroomMentionHandled(issueNumber, mention.ID, now)
 	log.Printf("[supervisor] spec-groom: posted groom proposal + minted edit_issue_body approval for issue #%d", issueNumber)
 }
@@ -195,6 +233,13 @@ func (e *Engine) specLintAllowsReady(st *state.State, issue github.Issue) bool {
 	return false
 }
 
+// toSpecgroomIssue projects a GitHub issue into the specgroom prompt input.
+// Title and Body are redacted first (#851 review): the spec-groom LLM pass is a
+// backend call, and an issue body carrying a credential shape (Authorization:,
+// sk-..., etc.) must be scrubbed before it reaches the model — the same way
+// every other supervisor prompt redacts issue text (packet.go). The un-redacted
+// body is still what the body hash and the approver's stale-edit guard compare
+// against; only the prompt-bound copy is scrubbed.
 func toSpecgroomIssue(issue github.Issue) specgroom.Issue {
 	labels := make([]string, 0, len(issue.Labels))
 	for _, l := range issue.Labels {
@@ -204,8 +249,8 @@ func toSpecgroomIssue(issue github.Issue) specgroom.Issue {
 	}
 	return specgroom.Issue{
 		Number: issue.Number,
-		Title:  issue.Title,
-		Body:   issue.Body,
+		Title:  RedactSensitive(issue.Title),
+		Body:   RedactSensitive(issue.Body),
 		Labels: labels,
 	}
 }

--- a/internal/supervisor/specgroom.go
+++ b/internal/supervisor/specgroom.go
@@ -1,0 +1,219 @@
+package supervisor
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/specgroom"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// maxSpecGroomIssuesPerCycle bounds how many issues one supervisor cycle will
+// examine for spec-lint/grooming (comment fetch + LLM pass). It caps both the
+// GitHub API calls and the backend spend per cycle; issues past the cap are
+// picked up on the next cycle. Lint is already once-per-body-change, so a
+// backlog drains within a few cycles and then stays quiet.
+const maxSpecGroomIssuesPerCycle = 30
+
+// issueCommentLister is the optional reader capability the spec-groom step needs
+// to poll `@maestro groom` mentions. *github.Client satisfies it; a reader that
+// does not implement it simply disables mention-triggered grooming (lint still
+// runs). Mirrors the prCIStatusReader / prMergeableReader optional-interface
+// pattern the engine already uses.
+type issueCommentLister interface {
+	ListIssueComments(issueNumber int) ([]github.IssueComment, error)
+}
+
+// runSpecGroom lints ready-candidate issues and answers `@maestro groom`
+// mentions (#851). It is a no-op unless supervisor.spec_groom.enabled is set.
+// One LLM pass per issue produces both the lint verdict and (when failing or
+// when grooming was requested) the rewrite proposal. All side effects go
+// through safe/cautious surfaces: a single lint checklist comment, a groom
+// proposal comment, and an approval-gated edit_issue_body mint. It records
+// per-issue body hashes so an unchanged/passing issue generates zero churn.
+//
+// Called from RunOnce inside the !DryRun guard, so its state mutations are
+// persisted by the cycle's single state.Save.
+func (e *Engine) runSpecGroom(st *state.State, mutator Mutator) {
+	if e == nil || e.cfg == nil || st == nil || !e.cfg.Supervisor.SpecGroomOn() {
+		return
+	}
+	// Respect the metered-backend refusal (#838): the lint pass dispatches to
+	// the same supervisor backend, so a per-token model without opt-in must not
+	// silently burn on grooming either.
+	if backend, refused := e.meteredBackendRefused(); refused {
+		log.Printf("[supervisor] spec-groom: skipped; supervisor backend %q is metered and allow_metered_backend is not set", backend)
+		return
+	}
+	if mutator == nil {
+		// No safe write surface — cannot post comments; nothing to do.
+		return
+	}
+	llm := e.llm
+	if llm == nil {
+		llm = NewBackendLLMClient(e.cfg)
+	}
+
+	issues, err := e.reader.ListOpenIssues(nil)
+	if err != nil {
+		log.Printf("[supervisor] spec-groom: list open issues: %v", err)
+		return
+	}
+	commentsReader, hasComments := e.reader.(issueCommentLister)
+	readyLabel := e.readyLabel()
+	excluded := e.excludeLabels()
+	now := e.now()
+
+	// examined bounds how many issues get a comment fetch + (maybe) an LLM pass
+	// this cycle, capping GitHub and backend cost. truncated counts the
+	// non-excluded issues deferred to the next cycle so the cap is never silent.
+	examined := 0
+	truncated := 0
+	for _, issue := range issues {
+		if len(excluded) > 0 && github.HasLabel(issue, excluded) {
+			continue
+		}
+		if examined >= maxSpecGroomIssuesPerCycle {
+			truncated++
+			continue
+		}
+		examined++
+
+		isReady := readyLabel != "" && github.HasLabel(issue, []string{readyLabel})
+
+		bodyHash := specgroom.BodyHash(issue.Body)
+		// Passive lint targets ready-candidate issues only (unlabeled), so a
+		// well-formed maestro-ready issue is never re-linted → zero churn.
+		needLint := !isReady && !st.IssueLintedForBody(issue.Number, bodyHash)
+
+		mention, haveMention := e.newGroomMention(st, issue, commentsReader, hasComments)
+
+		if !needLint && !haveMention {
+			continue
+		}
+
+		verdict, err := specgroom.Evaluate(llm, toSpecgroomIssue(issue), haveMention)
+		if err != nil {
+			log.Printf("[supervisor] spec-groom: evaluate issue #%d: %v", issue.Number, err)
+			continue
+		}
+
+		if needLint {
+			e.applyLintVerdict(st, mutator, issue.Number, bodyHash, verdict, now)
+		}
+		if haveMention {
+			e.applyGroomProposal(st, mutator, issue.Number, mention, verdict, now)
+		}
+	}
+	if truncated > 0 {
+		log.Printf("[supervisor] spec-groom: examined the first %d issues this cycle; %d more will be examined next cycle", maxSpecGroomIssuesPerCycle, truncated)
+	}
+}
+
+// newGroomMention returns the newest unhandled `@maestro groom` mention on an
+// issue, if any. Returns (_, false) when the reader cannot list comments, the
+// fetch fails, or the latest mention was already handled.
+func (e *Engine) newGroomMention(st *state.State, issue github.Issue, reader issueCommentLister, hasComments bool) (specgroom.Comment, bool) {
+	if !hasComments {
+		return specgroom.Comment{}, false
+	}
+	comments, err := reader.ListIssueComments(issue.Number)
+	if err != nil {
+		log.Printf("[supervisor] spec-groom: list comments for issue #%d: %v", issue.Number, err)
+		return specgroom.Comment{}, false
+	}
+	mention, ok := specgroom.DetectGroomMention(toSpecgroomComments(comments))
+	if !ok || st.GroomMentionHandled(issue.Number, mention.ID) {
+		return specgroom.Comment{}, false
+	}
+	return mention, true
+}
+
+// applyLintVerdict records the lint result and, on failure, posts the single
+// checklist comment. The lint mark is recorded only after a successful comment
+// post (on failure) so a transient GitHub error retries next cycle instead of
+// silently swallowing the checklist.
+func (e *Engine) applyLintVerdict(st *state.State, mutator Mutator, issueNumber int, bodyHash string, verdict specgroom.Verdict, now time.Time) {
+	if verdict.Pass {
+		st.RecordSpecLint(issueNumber, bodyHash, true, now)
+		return
+	}
+	comment := RedactSensitive(specgroom.RenderLintComment(verdict))
+	if err := mutator.CommentIssue(issueNumber, comment); err != nil {
+		log.Printf("[supervisor] spec-groom: post lint comment on issue #%d: %v", issueNumber, err)
+		return
+	}
+	st.RecordSpecLint(issueNumber, bodyHash, false, now)
+	log.Printf("[supervisor] spec-groom: posted spec-lint checklist on issue #%d", issueNumber)
+}
+
+// applyGroomProposal posts the rewrite proposal comment and mints the
+// approval-gated edit_issue_body verb carrying the rewrite. The mention is
+// marked handled only after the proposal is posted, so a transient error
+// retries next cycle. When the model returned no rewrite the mention is marked
+// handled without a proposal (nothing to apply).
+func (e *Engine) applyGroomProposal(st *state.State, mutator Mutator, issueNumber int, mention specgroom.Comment, verdict specgroom.Verdict, now time.Time) {
+	proposal := specgroom.RenderGroomComment(verdict)
+	if proposal == "" {
+		st.MarkGroomMentionHandled(issueNumber, mention.ID, now)
+		return
+	}
+	if err := mutator.CommentIssue(issueNumber, RedactSensitive(proposal)); err != nil {
+		log.Printf("[supervisor] spec-groom: post groom proposal on issue #%d: %v", issueNumber, err)
+		return
+	}
+	summary := fmt.Sprintf("Apply groomed spec rewrite to issue #%d", issueNumber)
+	evidence := []string{
+		"Proposed by the spec-groom agent in response to an @maestro groom mention.",
+		"Approve to replace the issue body with the proposed rewrite; reject to leave it untouched.",
+	}
+	st.RecordEditIssueBodyApproval(issueNumber, verdict.RewrittenBody, summary, e.cfg.Repo, e.cfg.Repo, evidence, now)
+	st.MarkGroomMentionHandled(issueNumber, mention.ID, now)
+	log.Printf("[supervisor] spec-groom: posted groom proposal + minted edit_issue_body approval for issue #%d", issueNumber)
+}
+
+// specLintAllowsReady reports whether the ready label may be applied to an
+// issue under the require_lint_pass gate (#851). Default (gate off) always
+// allows. When on, the label is withheld until spec-lint has PASSED for the
+// issue's current body — default-closed so a failing or not-yet-linted issue
+// cannot be promoted. Withholding is logged so an operator sees why.
+func (e *Engine) specLintAllowsReady(st *state.State, issue github.Issue) bool {
+	if e == nil || e.cfg == nil || !e.cfg.Supervisor.SpecGroomRequireLintPass() {
+		return true
+	}
+	if st == nil {
+		return false
+	}
+	bodyHash := specgroom.BodyHash(issue.Body)
+	if st.SpecLintPassedForBody(issue.Number, bodyHash) {
+		return true
+	}
+	log.Printf("[supervisor] spec-groom: withholding %s from issue #%d — require_lint_pass is set and spec-lint has not passed for the current body", MutationAddReadyLabel, issue.Number)
+	return false
+}
+
+func toSpecgroomIssue(issue github.Issue) specgroom.Issue {
+	labels := make([]string, 0, len(issue.Labels))
+	for _, l := range issue.Labels {
+		if name := strings.TrimSpace(l.Name); name != "" {
+			labels = append(labels, name)
+		}
+	}
+	return specgroom.Issue{
+		Number: issue.Number,
+		Title:  issue.Title,
+		Body:   issue.Body,
+		Labels: labels,
+	}
+}
+
+func toSpecgroomComments(comments []github.IssueComment) []specgroom.Comment {
+	out := make([]specgroom.Comment, 0, len(comments))
+	for _, c := range comments {
+		out = append(out, specgroom.Comment{ID: c.ID, Body: c.Body, Author: c.Author})
+	}
+	return out
+}

--- a/internal/supervisor/specgroom_test.go
+++ b/internal/supervisor/specgroom_test.go
@@ -18,6 +18,10 @@ type editBodyGH struct {
 	editIssue int
 	editBody  string
 	edits     int
+	// currentBody is what IssueBody reports as the live issue body — the
+	// stale-edit guard hashes it against the approval's BaseBodyHash before
+	// applying the rewrite.
+	currentBody string
 }
 
 func (g *editBodyGH) MergePR(int) error               { return nil }
@@ -33,6 +37,7 @@ func (g *editBodyGH) EditIssueBody(issue int, body string) error {
 	g.edits++
 	return nil
 }
+func (g *editBodyGH) IssueBody(int) (string, error) { return g.currentBody, nil }
 
 func issueWithBody(number int, title, body string, labels ...string) github.Issue {
 	issue := testIssue(number, title, labels...)
@@ -84,6 +89,88 @@ func TestRunSpecGroom_DisabledIsNoOp(t *testing.T) {
 	}
 	if len(reader.comments) != 0 {
 		t.Fatalf("disabled feature must post no comments: %v", reader.comments)
+	}
+}
+
+func TestRunSpecGroom_EmergencyHaltSkipsLLM(t *testing.T) {
+	reader := &fakeReader{issues: []github.Issue{issueWithBody(1, "vague", "do stuff")}}
+	llm := &fakeLLM{output: failVerdict}
+	cfg := testConfig(t)
+	cfg.Supervisor.SpecGroom.Enabled = true
+	eng := testEngine(cfg, reader)
+	eng.llm = llm
+	eng.SetEmergencyLLMHalt(true) // #840 fleet-wide EMERGENCY STOP LLM gate
+	st := state.NewState()
+
+	eng.runSpecGroom(st, reader)
+
+	if llm.calls != 0 {
+		t.Fatalf("emergency LLM halt must skip the grooming LLM pass (calls=%d)", llm.calls)
+	}
+	if len(reader.comments) != 0 {
+		t.Fatalf("emergency LLM halt must post no comments: %v", reader.comments)
+	}
+}
+
+func TestRunSpecGroom_RedactsIssueTextBeforePrompt(t *testing.T) {
+	// A credential-shaped token in the title AND body must be scrubbed before
+	// it reaches the LLM backend (#851 review), matching how every other
+	// supervisor prompt redacts issue text.
+	secret := "sk-abcdefghijklmnopqrstuvwxyz012345"
+	reader := &fakeReader{issues: []github.Issue{
+		issueWithBody(1, "leaky "+secret, "Deploy with Authorization: Bearer "+secret),
+	}}
+	llm := &fakeLLM{output: failVerdict}
+	cfg := testConfig(t)
+	cfg.Supervisor.SpecGroom.Enabled = true
+	eng := testEngine(cfg, reader)
+	eng.llm = llm
+	st := state.NewState()
+
+	eng.runSpecGroom(st, reader)
+
+	if llm.calls == 0 {
+		t.Fatalf("expected the grooming LLM pass to run")
+	}
+	if strings.Contains(llm.prompt, secret) {
+		t.Fatalf("issue text with a credential shape leaked into the prompt: %q", llm.prompt)
+	}
+	if !strings.Contains(llm.prompt, "[REDACTED") {
+		t.Fatalf("expected a redaction marker in the prompt, got: %q", llm.prompt)
+	}
+}
+
+func TestRunSpecGroom_RotatesWindowToDrainBacklog(t *testing.T) {
+	// More open issues than the per-cycle cap: the old fixed [0,cap) window
+	// examined the same first N every cycle and starved the tail. The rotating
+	// window (#851 review) must reach issue cap+1.. over successive cycles.
+	total := maxSpecGroomIssuesPerCycle + 5
+	var issues []github.Issue
+	for i := 1; i <= total; i++ {
+		issues = append(issues, issueWithBody(i, "vague", "needs work"))
+	}
+	reader := &fakeReader{issues: issues}
+	eng := specGroomEngine(t, reader, failVerdict)
+	st := state.NewState()
+
+	// Cycle 1 examines exactly the cap; the tail is untouched.
+	eng.runSpecGroom(st, reader)
+	if len(reader.comments) != maxSpecGroomIssuesPerCycle {
+		t.Fatalf("cycle 1 should lint exactly the cap (%d), got %d", maxSpecGroomIssuesPerCycle, len(reader.comments))
+	}
+	if _, ok := st.SpecLintTrackFor(total); ok {
+		t.Fatalf("issue #%d must not be examined in cycle 1 (past the cap)", total)
+	}
+
+	// Cycle 2 resumes past the window and reaches the tail.
+	eng.runSpecGroom(st, reader)
+	if _, ok := st.SpecLintTrackFor(total); !ok {
+		t.Fatalf("issue #%d must be examined by cycle 2 (rotating window)", total)
+	}
+	for i := 1; i <= total; i++ {
+		if _, ok := st.SpecLintTrackFor(i); !ok {
+			t.Fatalf("issue #%d never linted across two cycles — window did not drain", i)
+		}
 	}
 }
 
@@ -279,7 +366,9 @@ func TestSpecGroom_EndToEnd_MintApproveExecute(t *testing.T) {
 	if _, err := st.ApproveApproval(approval.ID, time.Now().UTC(), "operator", "looks good"); err != nil {
 		t.Fatalf("approve: %v", err)
 	}
-	gh := &editBodyGH{}
+	// The live body still matches what the rewrite was groomed against, so the
+	// stale-edit guard passes and the rewrite is applied.
+	gh := &editBodyGH{currentBody: "do the thing"}
 	ex := &approver.Executor{GH: gh, Cfg: &config.Config{Repo: "owner/repo"}}
 	res := ex.Execute(approval)
 	if res.Status != state.ApprovalStatusExecuted {
@@ -290,7 +379,7 @@ func TestSpecGroom_EndToEnd_MintApproveExecute(t *testing.T) {
 	}
 
 	// Reject path: a fresh proposal that is rejected fires no side effect.
-	rej := st.RecordEditIssueBodyApproval(99, "## Summary\nx", "apply", "owner/repo", "owner/repo", nil, time.Now().UTC())
+	rej := st.RecordEditIssueBodyApproval(99, "## Summary\nx", "basehash", "apply", "owner/repo", "owner/repo", nil, time.Now().UTC())
 	if _, err := st.RejectApproval(rej.ID, time.Now().UTC(), "operator", "no thanks"); err != nil {
 		t.Fatalf("reject: %v", err)
 	}

--- a/internal/supervisor/specgroom_test.go
+++ b/internal/supervisor/specgroom_test.go
@@ -1,0 +1,336 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/approver"
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/specgroom"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// editBodyGH is a minimal approver.GitHubClient that records EditIssueBody
+// calls, used by the end-to-end mint→approve→execute test.
+type editBodyGH struct {
+	editIssue int
+	editBody  string
+	edits     int
+}
+
+func (g *editBodyGH) MergePR(int) error               { return nil }
+func (g *editBodyGH) CloseIssue(int, string) error    { return nil }
+func (g *editBodyGH) AddIssueLabel(int, string) error { return nil }
+func (g *editBodyGH) PRMergeStatus(int) (string, string, error) {
+	return "", "", nil
+}
+func (g *editBodyGH) UpdateBranch(int) error { return nil }
+func (g *editBodyGH) EditIssueBody(issue int, body string) error {
+	g.editIssue = issue
+	g.editBody = body
+	g.edits++
+	return nil
+}
+
+func issueWithBody(number int, title, body string, labels ...string) github.Issue {
+	issue := testIssue(number, title, labels...)
+	issue.Body = body
+	return issue
+}
+
+func specGroomEngine(t *testing.T, reader *fakeReader, llmOut string) *Engine {
+	t.Helper()
+	cfg := testConfig(t)
+	cfg.Supervisor.SpecGroom.Enabled = true
+	eng := testEngine(cfg, reader)
+	eng.llm = &fakeLLM{output: llmOut}
+	return eng
+}
+
+const failVerdict = `{"pass": false, "summary": "acceptance criteria are not testable",
+  "checklist": [
+    {"rule":"testable_acceptance","ok":false,"note":"no observable outcome"},
+    {"rule":"explicit_scope","ok":true},
+    {"rule":"no_broad_refactor","ok":true},
+    {"rule":"single_repo","ok":true},
+    {"rule":"observable_verification","ok":false,"note":"unit tests only"}
+  ],
+  "rewritten_body": "## Summary\nGroomed rewrite\n## Acceptance criteria\n- observable thing"}`
+
+const passVerdict = `{"pass": true, "summary": "well-formed spec",
+  "checklist": [
+    {"rule":"testable_acceptance","ok":true},
+    {"rule":"explicit_scope","ok":true},
+    {"rule":"no_broad_refactor","ok":true},
+    {"rule":"single_repo","ok":true},
+    {"rule":"observable_verification","ok":true}
+  ]}`
+
+func TestRunSpecGroom_DisabledIsNoOp(t *testing.T) {
+	reader := &fakeReader{issues: []github.Issue{issueWithBody(1, "vague", "do stuff")}}
+	cfg := testConfig(t)
+	// SpecGroom.Enabled defaults false.
+	eng := testEngine(cfg, reader)
+	llm := &fakeLLM{output: failVerdict}
+	eng.llm = llm
+	st := state.NewState()
+
+	eng.runSpecGroom(st, reader)
+
+	if llm.calls != 0 {
+		t.Fatalf("disabled feature must not call the LLM (calls=%d)", llm.calls)
+	}
+	if len(reader.comments) != 0 {
+		t.Fatalf("disabled feature must post no comments: %v", reader.comments)
+	}
+}
+
+func TestRunSpecGroom_LintsFailingCandidateExactlyOnce(t *testing.T) {
+	reader := &fakeReader{issues: []github.Issue{issueWithBody(1, "vague", "do stuff")}}
+	eng := specGroomEngine(t, reader, failVerdict)
+	st := state.NewState()
+
+	eng.runSpecGroom(st, reader)
+	if len(reader.comments) != 1 {
+		t.Fatalf("expected exactly one lint comment, got %d: %v", len(reader.comments), reader.comments)
+	}
+	if !strings.Contains(reader.comments[0], specgroom.LintCommentMarker) {
+		t.Fatalf("comment missing lint marker: %q", reader.comments[0])
+	}
+	if track, ok := st.SpecLintTrackFor(1); !ok || track.Pass {
+		t.Fatalf("expected a recorded failing lint track, got %+v ok=%v", track, ok)
+	}
+
+	// Second cycle over the SAME body → zero new comments (idempotency).
+	eng.runSpecGroom(st, reader)
+	if len(reader.comments) != 1 {
+		t.Fatalf("unchanged body must not re-lint: %d comments", len(reader.comments))
+	}
+}
+
+func TestRunSpecGroom_WellFormedIssueGetsNoComment(t *testing.T) {
+	reader := &fakeReader{issues: []github.Issue{issueWithBody(1, "good spec", "## Summary...")}}
+	eng := specGroomEngine(t, reader, passVerdict)
+	st := state.NewState()
+
+	eng.runSpecGroom(st, reader)
+	if len(reader.comments) != 0 {
+		t.Fatalf("a passing issue must get no comment: %v", reader.comments)
+	}
+	if !st.SpecLintPassedForBody(1, specgroom.BodyHash("## Summary...")) {
+		t.Fatalf("passing lint should be recorded so require_lint_pass can allow the label")
+	}
+}
+
+func TestRunSpecGroom_ChangedBodyRelints(t *testing.T) {
+	reader := &fakeReader{issues: []github.Issue{issueWithBody(1, "vague", "v1")}}
+	eng := specGroomEngine(t, reader, failVerdict)
+	st := state.NewState()
+
+	eng.runSpecGroom(st, reader)
+	if len(reader.comments) != 1 {
+		t.Fatalf("expected one lint comment, got %d", len(reader.comments))
+	}
+	// Body changes → the lint must run again.
+	reader.issues[0].Body = "v2 different content"
+	eng.runSpecGroom(st, reader)
+	if len(reader.comments) != 2 {
+		t.Fatalf("changed body should re-lint: got %d comments", len(reader.comments))
+	}
+}
+
+func TestRunSpecGroom_ReadyIssueNotPassivelyLinted(t *testing.T) {
+	reader := &fakeReader{issues: []github.Issue{issueWithBody(1, "ready one", "body", "maestro-ready")}}
+	eng := specGroomEngine(t, reader, failVerdict)
+	eng.cfg.Supervisor.ReadyLabel = "maestro-ready"
+	st := state.NewState()
+
+	eng.runSpecGroom(st, reader)
+	if len(reader.comments) != 0 {
+		t.Fatalf("already-ready issues must not be passively re-linted: %v", reader.comments)
+	}
+}
+
+func TestRunSpecGroom_GroomMentionMintsProposalAndApproval(t *testing.T) {
+	reader := &fakeReader{
+		issues: []github.Issue{issueWithBody(1, "needs work", "vague body", "maestro-ready")},
+		issueComments: map[int][]github.IssueComment{
+			1: {{ID: 500, Body: "@maestro groom please", Author: "po"}},
+		},
+	}
+	eng := specGroomEngine(t, reader, failVerdict)
+	eng.cfg.Supervisor.ReadyLabel = "maestro-ready" // ready issue: no passive lint, but mention still grooms
+	st := state.NewState()
+
+	eng.runSpecGroom(st, reader)
+
+	if len(reader.comments) != 1 || !strings.Contains(reader.comments[0], specgroom.GroomCommentMarker) {
+		t.Fatalf("expected one groom proposal comment, got %v", reader.comments)
+	}
+	approval, ok := st.PendingEditIssueBodyApproval(1)
+	if !ok {
+		t.Fatalf("expected a pending edit_issue_body approval")
+	}
+	if approval.Target == nil || !strings.Contains(approval.Target.Body, "Groomed rewrite") {
+		t.Fatalf("approval must carry the rewrite body: %+v", approval.Target)
+	}
+
+	// Second cycle: the mention is already handled → no duplicate comment/approval.
+	eng.runSpecGroom(st, reader)
+	if len(reader.comments) != 1 {
+		t.Fatalf("handled mention must not re-post: %d comments", len(reader.comments))
+	}
+	if len(st.Approvals) != 1 {
+		t.Fatalf("handled mention must not mint a duplicate approval: %d", len(st.Approvals))
+	}
+}
+
+func TestRunSpecGroom_NewMentionAfterHandledOneReGrooms(t *testing.T) {
+	reader := &fakeReader{
+		issues: []github.Issue{issueWithBody(1, "needs work", "vague body")},
+		issueComments: map[int][]github.IssueComment{
+			1: {{ID: 500, Body: "@maestro groom", Author: "po"}},
+		},
+	}
+	eng := specGroomEngine(t, reader, failVerdict)
+	st := state.NewState()
+
+	eng.runSpecGroom(st, reader)
+	firstComments := len(reader.comments)
+
+	// A newer @maestro groom comment is a fresh request.
+	reader.issueComments[1] = append(reader.issueComments[1], github.IssueComment{ID: 600, Body: "@maestro groom again", Author: "po"})
+	eng.runSpecGroom(st, reader)
+	if len(reader.comments) <= firstComments {
+		t.Fatalf("a newer mention should re-groom (comments %d -> %d)", firstComments, len(reader.comments))
+	}
+}
+
+func TestSpecLintAllowsReady_RequireLintPassGate(t *testing.T) {
+	reader := &fakeReader{}
+	eng := specGroomEngine(t, reader, passVerdict)
+	eng.cfg.Supervisor.SpecGroom.RequireLintPass = true
+	st := state.NewState()
+	issue := issueWithBody(1, "candidate", "the body")
+
+	// Not yet linted → default-closed: label withheld.
+	if eng.specLintAllowsReady(st, issue) {
+		t.Fatalf("require_lint_pass must withhold the label for a not-yet-linted issue")
+	}
+	// Failing lint → withheld.
+	st.RecordSpecLint(1, specgroom.BodyHash("the body"), false, eng.now())
+	if eng.specLintAllowsReady(st, issue) {
+		t.Fatalf("require_lint_pass must withhold the label for a failing issue")
+	}
+	// Passing lint for the current body → allowed.
+	st.RecordSpecLint(1, specgroom.BodyHash("the body"), true, eng.now())
+	if !eng.specLintAllowsReady(st, issue) {
+		t.Fatalf("require_lint_pass must allow the label once lint passes")
+	}
+	// A body change invalidates the pass.
+	issue.Body = "changed"
+	if eng.specLintAllowsReady(st, issue) {
+		t.Fatalf("a passing verdict must not carry over to a changed body")
+	}
+}
+
+func TestSpecLintAllowsReady_DefaultOffAlwaysAllows(t *testing.T) {
+	reader := &fakeReader{}
+	cfg := testConfig(t) // SpecGroom disabled, RequireLintPass false
+	eng := testEngine(cfg, reader)
+	st := state.NewState()
+	if !eng.specLintAllowsReady(st, issueWithBody(1, "x", "y")) {
+		t.Fatalf("default config must never withhold the ready label")
+	}
+
+	// Enabled but require_lint_pass off → still always allows.
+	eng.cfg.Supervisor.SpecGroom.Enabled = true
+	if !eng.specLintAllowsReady(st, issueWithBody(1, "x", "y")) {
+		t.Fatalf("warn-only mode must not withhold the ready label")
+	}
+}
+
+// TestSpecGroom_EndToEnd_MintApproveExecute is the integration flow from the
+// spec (#851): a vague issue with an `@maestro groom` mention yields a proposal
+// comment + a pending edit_issue_body approval; approving it drives the approver
+// executor to apply the rewrite; rejecting a fresh one leaves the issue
+// untouched.
+func TestSpecGroom_EndToEnd_MintApproveExecute(t *testing.T) {
+	reader := &fakeReader{
+		issues: []github.Issue{issueWithBody(42, "vague", "do the thing")},
+		issueComments: map[int][]github.IssueComment{
+			42: {{ID: 900, Body: "@maestro groom", Author: "po"}},
+		},
+	}
+	eng := specGroomEngine(t, reader, failVerdict)
+	eng.cfg.Repo = "owner/repo"
+	st := state.NewState()
+
+	// 1. Mention → proposal comment + pending approval (no body change yet).
+	eng.runSpecGroom(st, reader)
+	approval, ok := st.PendingEditIssueBodyApproval(42)
+	if !ok {
+		t.Fatalf("expected a pending edit_issue_body approval")
+	}
+
+	// 2. Approve → 3. execute via the approver executor → issue body updated.
+	if _, err := st.ApproveApproval(approval.ID, time.Now().UTC(), "operator", "looks good"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	gh := &editBodyGH{}
+	ex := &approver.Executor{GH: gh, Cfg: &config.Config{Repo: "owner/repo"}}
+	res := ex.Execute(approval)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("execute edit_issue_body: %+v", res)
+	}
+	if gh.edits != 1 || gh.editIssue != 42 || !strings.Contains(gh.editBody, "Groomed rewrite") {
+		t.Fatalf("executor did not apply the rewrite: issue=%d edits=%d body=%q", gh.editIssue, gh.edits, gh.editBody)
+	}
+
+	// Reject path: a fresh proposal that is rejected fires no side effect.
+	rej := st.RecordEditIssueBodyApproval(99, "## Summary\nx", "apply", "owner/repo", "owner/repo", nil, time.Now().UTC())
+	if _, err := st.RejectApproval(rej.ID, time.Now().UTC(), "operator", "no thanks"); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+	gh2 := &editBodyGH{}
+	// A rejected approval never reaches the executor loop; assert it is not in
+	// the approved set.
+	for _, a := range st.ListApprovedApprovals() {
+		if a.ID == rej.ID {
+			t.Fatalf("rejected approval must not appear in the approved set")
+		}
+	}
+	if gh2.edits != 0 {
+		t.Fatalf("reject must not edit any issue body")
+	}
+}
+
+func TestFirstQueueActionCandidate_RequireLintPassWithholdsReadyLabel(t *testing.T) {
+	issue := issueWithBody(7, "promote me", "the body")
+	reader := &fakeReader{issues: []github.Issue{issue}}
+	eng := specGroomEngine(t, reader, passVerdict)
+	eng.cfg.Supervisor.ReadyLabel = "maestro-ready"
+	eng.cfg.Supervisor.SpecGroom.RequireLintPass = true
+	st := state.NewState()
+
+	// No passing lint recorded → the ready-label queue action is withheld.
+	cand, err := eng.firstQueueActionCandidate(st, []github.Issue{issue})
+	if err != nil {
+		t.Fatalf("firstQueueActionCandidate: %v", err)
+	}
+	if cand != nil && cand.addReady {
+		t.Fatalf("expected add_ready_label withheld under require_lint_pass, got candidate %+v", cand)
+	}
+
+	// Record a passing lint → the label is now permitted.
+	st.RecordSpecLint(7, specgroom.BodyHash("the body"), true, eng.now())
+	cand, err = eng.firstQueueActionCandidate(st, []github.Issue{issue})
+	if err != nil {
+		t.Fatalf("firstQueueActionCandidate: %v", err)
+	}
+	if cand == nil || !cand.addReady {
+		t.Fatalf("expected add_ready_label allowed after a passing lint, got %+v", cand)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -357,6 +357,12 @@ func RunOnce(cfg *config.Config, reader Reader, opts ...RunOption) (state.Superv
 		if proposal, created := recordLessonProposalForDecision(cfg, st, decision); created && proposal != nil {
 			log.Printf("[supervisor] proposed lesson %s for %s/%s; approval=%s", proposal.ID, proposal.FailureClass, proposal.Area, proposal.ApprovalID)
 		}
+		// #851: spec-lint + grooming. No-op unless supervisor.spec_groom.enabled
+		// is set; runs before the queue mutation applies so a require_lint_pass
+		// gate reads freshly-recorded lint marks on the next cycle.
+		if mutator, ok := reader.(Mutator); ok {
+			engine.runSpecGroom(st, mutator)
+		}
 		applyOrMintDecision(cfg, st, reader, &decision)
 		st.RecordSupervisorDecision(decision, state.DefaultSupervisorDecisionLimit)
 		// Phase 1.2 (#499): stamp the last-run heartbeat just before save
@@ -2268,6 +2274,11 @@ func (e *Engine) firstQueueActionCandidate(st *state.State, issues []github.Issu
 		hasReadyLabel := readyLabel == "" || github.HasLabel(issue, []string{readyLabel})
 		hasBlockedLabel := blockedLabel != "" && github.HasLabel(issue, []string{blockedLabel})
 		addReady := readyLabel != "" && !hasReadyLabel && !supervisorMutationSucceeded(st, issue.Number, MutationAddReadyLabel, readyLabel)
+		// #851: require_lint_pass withholds the ready label until spec-lint has
+		// passed for the current body. Default (gate off) never blocks.
+		if addReady && !e.specLintAllowsReady(st, issue) {
+			addReady = false
+		}
 		removeBlocked := hasBlockedLabel && !supervisorMutationSucceeded(st, issue.Number, MutationRemoveBlockedLabel, blockedLabel)
 		candidate := queueActionCandidate{
 			issue:         issue,
@@ -2299,10 +2310,15 @@ func (e *Engine) dynamicQueueActionCandidate(st *state.State, selected github.Is
 	}
 
 	hasReadyLabel := github.HasLabel(selected, []string{readyLabel})
+	addReady := !hasReadyLabel && !supervisorMutationSucceeded(st, selected.Number, MutationAddReadyLabel, readyLabel)
+	// #851: require_lint_pass withholds the ready label until spec-lint passes.
+	if addReady && !e.specLintAllowsReady(st, selected) {
+		addReady = false
+	}
 	candidate := queueActionCandidate{
 		issue:      selected,
 		readyLabel: readyLabel,
-		addReady:   !hasReadyLabel && !supervisorMutationSucceeded(st, selected.Number, MutationAddReadyLabel, readyLabel),
+		addReady:   addReady,
 	}
 
 	if e.cfg.Supervisor.DynamicWave.OwnsReadyLabel {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -44,6 +44,15 @@ type fakeReader struct {
 	addLabelErr          error
 	removeLabelErr       error
 	commentErr           error
+	issueComments        map[int][]github.IssueComment
+	listCommentsErr      error
+}
+
+func (f *fakeReader) ListIssueComments(issueNumber int) ([]github.IssueComment, error) {
+	if f.listCommentsErr != nil {
+		return nil, f.listCommentsErr
+	}
+	return f.issueComments[issueNumber], nil
 }
 
 type fakeLLM struct {


### PR DESCRIPTION
Refs #851

Adds two coupled, config-gated (default **off**) supervisor capabilities that share one LLM pass per issue.

## Changes
- **Spec-lint** — new `internal/specgroom` scores each open, not-yet-ready issue against the good-spec rules in `docs/po-spec-workflow.md` (testable acceptance, explicit scope/non-goals, no broad refactor, single-repo, observable verification). A failing issue gets **exactly one** checklist comment; a well-formed issue gets none. Lint runs at most once per body change — a per-issue body hash is tracked in `state` — so unchanged/passing issues generate zero comment churn.
- **Grooming** — an `@maestro groom` comment (polled, no webhook) yields a proposed Spec-template rewrite as a comment, plus a pending approval-gated `edit_issue_body` verb carrying the rewrite. Approving applies it via `gh.EditIssueBody`; rejecting leaves the issue untouched. Both surface in the approvals UI and audit trail.
- **`require_lint_pass`** (optional) withholds the ready label until an issue's current body has passed spec-lint; default is warn-only.
- New config knobs `supervisor.spec_groom.enabled` / `supervisor.spec_groom.require_lint_pass` registered in the fleet-settings layer — enabling is a config-store row change only. Respects `supervisor.allow_metered_backend`.
- New approval verb `edit_issue_body` end-to-end: registry + executor + state mint helper (dedup/refresh-in-place per issue).

## Testing
- `go build ./cmd/maestro/`
- `go test ./...` (all green), incl. new unit + integration tests: lint idempotency, changed-body re-lint, well-formed no-comment, mention detection, groom proposal + approval mint, `edit_issue_body` approve/reject/execute, and `require_lint_pass` gating.

## Not auto-closing
Live verification (enable on the dogfood project, one real round-trip, confirm zero churn on good ready issues over 24h) is operator runtime work, so this references rather than closes the issue.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a config-gated issue grooming and spec-lint flow. The main changes are:

- New spec-lint scoring and checklist comments for open issues.
- New `@maestro groom` proposal comments and approval-gated issue body edits.
- New `edit_issue_body` approval action, executor path, and stale-body guard.
- New config settings for enabling grooming and requiring lint before ready labels.
- State tracking for lint body hashes, groom mention handling, and rotating issue scans.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code. The approved issue-body edit path checks the current body before replacing it, and the grooming mint path carries the base body hash needed by that check.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Maestro build command was executed and completed with exit code 0.
- Focused tests for specgroom, state, supervisor, approver, cmd/maestro, and config were run and completed with exit code 0 and PASS/ok results.
- The full test suite (go test ./...) was run and all packages passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/13940579/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/approver/executor.go | Adds the approved issue-body edit executor path with a live body check before replacement. |
| internal/state/spec_lint.go | Adds durable spec-lint tracking and minting for pending groomed body approvals. |
| internal/supervisor/specgroom.go | Adds the supervisor-side lint, groom mention, proposal, and approval minting flow. |
| internal/github/github.go | Adds issue body reads and issue comment listing for the grooming workflow. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/state/spec_lint.go`, line 1161-1172 ([link](https://github.com/befeast/maestro/blob/163742374fce5ade16338c2a8a15c2efc4b0ae8e/internal/state/spec_lint.go#L1161-L1172)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Pending Rewrite Changes Silently**

   When a pending `edit_issue_body` approval already exists, this refresh path replaces `Target.Body` and recomputes the payload hash under the same approval. If an operator reviewed the earlier rewrite and a later groom request refreshes it before approval, approving that same pending approval can apply different issue text than the operator originally reviewed.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: generated Go test demonstrating pending approval body and hash mutation under a stable ID](https://app.greptile.com/trex/artifacts/92f14ed3-2e3a-4994-9b9c-b8ed26de0ee2)**

   - Contains supporting evidence from the run (text/x-go; charset=utf-8).

   **[Repro: verbose go test output showing stable pending approval ID with changed body and payload hash](https://app.greptile.com/trex/artifacts/5a671587-da26-4a81-a8c0-04c06e430f4b)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/13938749/artifacts?artifact=92f14ed3-2e3a-4994-9b9c-b8ed26de0ee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/state/spec_lint.go
   Line: 1161-1172

   Comment:
   **Pending Rewrite Changes Silently**

   When a pending `edit_issue_body` approval already exists, this refresh path replaces `Target.Body` and recomputes the payload hash under the same approval. If an operator reviewed the earlier rewrite and a later groom request refreshes it before approval, approving that same pending approval can apply different issue text than the operator originally reviewed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["supervisor/approver: harden spec-groom r..."](https://github.com/befeast/maestro/commit/7d9b3f2f85af8c70deeb5c22b789d0dc1bfdff00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43211276)</sub>

<!-- /greptile_comment -->