### PR TITLE
chore: issue-template registry (bug / runbook-docs / infra-ops / epic) with per-section guidance (#852)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,93 @@
+name: Bug
+description: Report a defect with repro and evidence so a Maestro worker can fix it hands-off
+title: "bug: <short description>"
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        File one bug per report. Fill every required section — a worker fixes this from the
+        issue alone, so vagueness turns into a wrong or partial PR.
+        Do **not** apply `maestro-ready` yourself; a reviewer applies it once the report is
+        complete and the supervisor picks it up from there.
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+      description: What actually happens. State it as a fact, not a guess.
+      placeholder: |
+        `maestro outcome check` reports `healthy` for a project whose runtime container has
+        been down for 20 minutes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen instead, and where that expectation comes from (doc, prior behavior, acceptance criterion).
+      placeholder: |
+        Outcome health should flip to `failing` within one supervisor cycle when the container
+        is not running, per docs/handoff-epic-format.md "runtime health is the ground truth".
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro / evidence
+      description: |
+        Minimal steps to reproduce, plus evidence a worker can trace: log excerpts, session IDs
+        (e.g. `sup-301`), PR/issue numbers, commit SHAs, `curl`/`jq` output. Redact secrets.
+      placeholder: |
+        1. Stop the runtime container: `docker stop maestro-<project>`
+        2. Wait one supervisor cycle (~2 min)
+        3. `curl -fsS http://127.0.0.1:8786/api/v1/fleet | jq '.outcome.health_state'` → still "healthy"
+
+        Session: sup-274 · Log: `journalctl -u maestro.service --since "10:00"` shows no health probe.
+    validations:
+      required: true
+
+  - type: textarea
+    id: surface
+    attributes:
+      label: Affected surface
+      description: Which package / service / host / UI is involved. Point at the code path if you know it.
+      placeholder: |
+        internal/supervisor/outcome.go — health probe; maestro.service on workshop.
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: How a reviewer confirms the fix — a concrete check, not "it works now".
+      placeholder: |
+        - Repeat the repro; health flips to `failing` within one cycle.
+        - `go test ./internal/supervisor/...` covers the down-container case.
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: Optional. Related things the fix must NOT touch, to keep the PR focused.
+      placeholder: |
+        - Do not change the fleet refresh interval.
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority hint
+      description: Reporter's desired priority; a reviewer applies the actual P-label.
+      options:
+        - P0 — critical, drop other work
+        - P1 — high, schedule next
+        - P2 — medium, queue normally
+        - P3 — low, opportunistic
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# Free-form (blank) issues are disabled so intake lands pre-structured by type.
+# Pick the template that matches the work: Spec (feature), Bug, Runbook / Docs,
+# Infra / Ops, or Handoff Epic. Structured issues rank higher for supervisor
+# pickup and digest "Promotable" ranking, so a template is never busywork.
+blank_issues_enabled: false
+contact_links:
+  - name: Which template should I use?
+    url: https://github.com/BeFeast/maestro/blob/main/docs/po-spec-workflow.md#which-template-for-what
+    about: Guide to picking a template and writing an issue that is ready for Maestro pickup.
+  - name: How handoff epics work
+    url: https://github.com/BeFeast/maestro/blob/main/docs/handoff-epic-format.md
+    about: The Epic title/label contract, Issue Wave slice list, and child-issue layout the supervisor planner reads.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -35,7 +35,9 @@ body:
       description: |
         Ordered list of concrete, runnable slices — one child issue each. The planner reads the first
         unchecked line as the next slice to schedule, so keep them small and in dependency order.
-      value: |
+        Replace the example below with your real slices — this field is intentionally left empty so an
+        unedited epic cannot ship placeholder slices as schedulable work.
+      placeholder: |
         - [ ] Slice 1: route shell + layout primitives
         - [ ] Slice 2: replace `/inbox` route with the redesigned shell
         - [ ] Slice 3: replace `/settings` route with the redesigned shell
@@ -48,7 +50,7 @@ body:
     attributes:
       label: Route Replacement Map
       description: Optional (useful for UI epics). Map old route → new route and which slice owns the migration.
-      value: |
+      placeholder: |
         | Old route  | New route      | Owning slice |
         |------------|----------------|--------------|
         | /inbox     | /v2/inbox      | Slice 2      |

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,90 @@
+name: Handoff Epic
+description: Multi-slice handoff epic the supervisor planner dispatches from, one slice at a time
+title: "Epic: <product-area> — <short description>"
+labels:
+  - epic
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use a handoff epic when a single PR cannot deliver the whole change and the work splits into
+        1-day-or-less slices you want the overnight supervisor to keep dispatching. See
+        [docs/handoff-epic-format.md](../../docs/handoff-epic-format.md) for the full contract.
+
+        This form applies the `epic` label and an `Epic:` title prefix — either identifies the issue
+        to `supervisor.handoff_planner`. The `epic` label is **pickup-excluded** on purpose: workers
+        never pick up the epic itself; the planner reads it and opens/schedules the child slices.
+        The section headings below are what the planner parses — keep them intact.
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: One paragraph — the runtime goal, the target user, and what "done" looks like for the whole epic (not for a single PR).
+      placeholder: |
+        Replace the legacy inspector-style fleet UI with the redesigned status-board shell across
+        every route, so operators read live truth at a glance. Done = every route migrated and the
+        live visual gate passes on staging.
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue_wave
+    attributes:
+      label: Issue Wave
+      description: |
+        Ordered list of concrete, runnable slices — one child issue each. The planner reads the first
+        unchecked line as the next slice to schedule, so keep them small and in dependency order.
+      value: |
+        - [ ] Slice 1: route shell + layout primitives
+        - [ ] Slice 2: replace `/inbox` route with the redesigned shell
+        - [ ] Slice 3: replace `/settings` route with the redesigned shell
+        - [ ] Slice 4: live visual gate + production preflight wiring
+    validations:
+      required: true
+
+  - type: textarea
+    id: route_map
+    attributes:
+      label: Route Replacement Map
+      description: Optional (useful for UI epics). Map old route → new route and which slice owns the migration.
+      value: |
+        | Old route  | New route      | Owning slice |
+        |------------|----------------|--------------|
+        | /inbox     | /v2/inbox      | Slice 2      |
+        | /settings  | /v2/settings   | Slice 3      |
+
+  - type: textarea
+    id: done_for_epic
+    attributes:
+      label: Done For The Epic
+      description: The conditions under which the whole epic — not a single slice — is Done. Runtime health is the ground truth, not the checklist.
+      value: |
+        The whole epic is Done only when:
+        1. every slice in `Issue Wave` is checked off;
+        2. the live visual verification on staging passes;
+        3. the runtime health gate is `healthy` for at least one full deploy cycle;
+        4. the operator confirms the sign-off comment on this epic.
+    validations:
+      required: true
+
+  - type: textarea
+    id: source_materials
+    attributes:
+      label: Source Materials
+      description: Assets a slice worker needs — design zip checksum/location, design-system spec or Figma link, the runtime URL to verify against.
+      placeholder: |
+        - design zip: `/mnt/storage/src/<project>.redesign.zip` (sha256: ...)
+        - design ref: `<design-system route or asset id>`
+        - runtime URL: `<staging URL the worker must verify against>`
+
+  - type: textarea
+    id: children
+    attributes:
+      label: Children
+      description: |
+        Optional. When you open the child issues up front, list their numbers here so the
+        epic-completion aggregate can track merged/open counts. Both `- [ ] #147` and `#147` are read.
+      placeholder: |
+        - [ ] #147 — Slice 1: route shell
+        - [ ] #148 — Slice 2: replace /inbox

--- a/.github/ISSUE_TEMPLATE/infra-ops.yml
+++ b/.github/ISSUE_TEMPLATE/infra-ops.yml
@@ -1,0 +1,81 @@
+name: Infra / Ops change
+description: Request an ops or config change with an explicit target, rollback, and verification
+title: "ops: <short description>"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for changes to running infrastructure and configuration — a systemd unit, a
+        config-store row, a host-level setting, a workflow file. Every ops change needs a rollback
+        and a verification command before anyone touches production.
+
+        This template deliberately applies **no** label: it must not carry `maestro-ready` (a
+        reviewer applies that) or any pickup-excluded label. Ops work is operator-driven; a worker
+        only proposes the diff.
+
+  - type: textarea
+    id: target
+    attributes:
+      label: Target
+      description: Exactly what changes — unit name, config-store key + scope, host, file path, or workflow.
+      placeholder: |
+        - Unit: maestro.service on workshop
+        - Config row: supervisor.spec_groom.enabled (scope: befeast-maestro)
+        - File: .github/workflows/ci.yml
+    validations:
+      required: true
+
+  - type: textarea
+    id: change
+    attributes:
+      label: Change
+      description: The new desired state and why. Include the exact command or diff if you know it.
+      placeholder: |
+        Set `supervisor.spec_groom.enabled=true` for the befeast-maestro project so spec-lint runs
+        on new issues. Command: `maestro settings set supervisor.spec_groom.enabled=true --project befeast-maestro`
+    validations:
+      required: true
+
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback plan
+      description: The exact steps to revert to the prior state if the change misbehaves.
+      placeholder: |
+        `maestro settings set supervisor.spec_groom.enabled=false --project befeast-maestro`
+        (config-store change only — no restart required).
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification commands
+      description: Commands the operator runs after applying the change to confirm it took effect and nothing regressed.
+      placeholder: |
+        - `maestro settings get supervisor.spec_groom.enabled --project befeast-maestro` → `true`
+        - `curl -fsS http://127.0.0.1:8786/api/v1/fleet | jq .verdict.sentence` still returns
+        - `journalctl -u maestro.service -n 50` shows no new errors after one cycle
+    validations:
+      required: true
+
+  - type: textarea
+    id: blast_radius
+    attributes:
+      label: Blast radius / risk
+      description: Optional. What else this could affect, and how urgent.
+      placeholder: |
+        Fleet-wide default vs per-project scope; enabling adds one LLM pass per open issue per cycle.
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority hint
+      description: Reporter's desired priority; a reviewer applies the actual P-label.
+      options:
+        - P0 — critical, drop other work
+        - P1 — high, schedule next
+        - P2 — medium, queue normally
+        - P3 — low, opportunistic
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/runbook-docs.yml
+++ b/.github/ISSUE_TEMPLATE/runbook-docs.yml
@@ -1,0 +1,52 @@
+name: Runbook / Docs change
+description: Fix or add documentation or runbook content so a worker can land the change hands-off
+title: "docs: <short description>"
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for documentation and runbook changes — prose, examples, missing steps, stale
+        commands. For a code defect use **Bug**; for a config/ops change use **Infra / Ops change**.
+        Do **not** apply `maestro-ready` yourself; a reviewer applies it once the request is complete.
+
+  - type: input
+    id: doc
+    attributes:
+      label: Which doc
+      description: Repo-relative path of the doc (or the doc to create).
+      placeholder: docs/agent-lint-runbook.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing
+      description: The specific gap or error — quote the offending lines or name the missing section.
+      placeholder: |
+        The "Self-test" section references `--self-check`, but the flag is `--self-test`
+        (see .github/workflows/agent-lint.yml). A reader copy-pasting the command gets an error.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed change
+      description: Optional. Sketch the new/edited text or an outline. Leave blank if you only know the gap.
+      placeholder: |
+        Replace `--self-check` with `--self-test` and add a one-line note that CI runs it on every PR.
+
+  - type: textarea
+    id: done
+    attributes:
+      label: Done criteria
+      description: How a reviewer confirms the doc is right — concrete, checkable statements.
+      value: |
+        - [ ] The doc reflects the current behavior / commands.
+        - [ ] Examples are copy-pasteable and run as written.
+        - [ ] Links and cross-references resolve.
+    validations:
+      required: true

--- a/docs/po-spec-workflow.md
+++ b/docs/po-spec-workflow.md
@@ -2,6 +2,32 @@
 
 Source of truth for spec **drafts** is the Obsidian vault at `Dev/Areas/maestro/specs/`. This document describes the GitHub-side execution contract that workers and reviewers rely on.
 
+## Which template for what
+
+`.github/ISSUE_TEMPLATE/` is a small registry of typed templates. Blank issues are
+disabled (`config.yml`), so every report lands pre-structured — this is what lets
+future automated grooming produce consistent output, and it keeps bugs/ops/docs from
+arriving free-form and ranking poorly for supervisor pickup or the digest "Promotable"
+list. Pick by the shape of the work:
+
+| Template | File | Use it for | Auto label |
+|----------|------|------------|------------|
+| **Spec** | `spec.yml` | A feature a worker implements hands-off. The default. | `enhancement` |
+| **Bug** | `bug.yml` | A defect: observed vs expected, repro/evidence, affected surface, verification. | `bug` |
+| **Runbook / Docs change** | `runbook-docs.yml` | A docs/runbook fix: which doc, what's wrong/missing, done-criteria. | `documentation` |
+| **Infra / Ops change** | `infra-ops.yml` | An ops/config change: target unit/row/host, rollback plan, verification commands. | *(none)* |
+| **Handoff Epic** | `epic.yml` | A multi-slice epic the supervisor planner dispatches slice-by-slice (see [`handoff-epic-format.md`](./handoff-epic-format.md)). | `epic` |
+
+Label notes that matter for the [pickup contract](#pickup-contract-do-not-break-by-accident):
+
+- None of these templates apply `maestro-ready` — a reviewer applies that once the
+  issue is complete (or moves it into the Project, and the supervisor labels it).
+- `bug.yml` / `runbook-docs.yml` / `infra-ops.yml` apply no pickup-excluded label, so
+  they enter the runnable queue normally once marked ready.
+- `epic.yml` applies `epic` on purpose — that label is pickup-excluded, so a worker
+  never picks up the epic itself; the handoff planner reads it and schedules the child
+  slices.
+
 ## Loop
 
 1. **Draft in Obsidian** — create a note in `Dev/Areas/maestro/specs/<kebab-case>.md` with frontmatter


### PR DESCRIPTION
Implements #852

## Changes

Adds a small registry of typed issue templates under `.github/ISSUE_TEMPLATE/`, each with per-section guidance/placeholder text, plus a `config.yml` that disables blank issues so intake lands pre-structured by type.

- `bug.yml` — observed vs expected, repro/evidence (logs, session IDs), affected surface, verification. Label: `bug`.
- `runbook-docs.yml` — which doc, what's wrong/missing, done-criteria. Label: `documentation`.
- `infra-ops.yml` — target unit/config-row/host, rollback plan, verification commands. No auto label.
- `epic.yml` — handoff epic matching `docs/handoff-epic-format.md`: `Epic:` title prefix, `epic` label, `Issue Wave` slice list, `Children` references. Section headings match what `supervisor.handoff_planner` / epic-completion parse (level-agnostic).
- `config.yml` — `blank_issues_enabled: false` with guidance contact links.
- `spec.yml` — unchanged, remains the default feature-spec template.
- `docs/po-spec-workflow.md` — new "Which template for what" section.

## Pickup-contract safety

- No template applies `maestro-ready` (a reviewer/supervisor applies it).
- `bug` / `runbook-docs` / `infra-ops` apply no pickup-excluded label, so they queue normally once marked ready.
- `epic.yml` applies `epic` on purpose — that label is pickup-excluded, so a worker never picks up the epic itself; the handoff planner reads it and schedules the child slices.

## Testing

- `go build ./cmd/maestro/` — OK.
- `go test ./...` — all packages pass.
- All templates validated as YAML; required issue-form keys present.
- Rendering in the GitHub "New issue" chooser is verified after merge by creating one throwaway issue per template (closed as `invalid`), per the issue's test plan.

Refs #852

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds structured GitHub issue intake for several work types. The main changes are:

- New issue forms for bugs, docs/runbooks, infra/ops, and handoff epics.
- Blank issues disabled with links to template guidance.
- Epic intake aligned with the handoff planner format.
- Documentation explaining which template to use.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Confirmed that the primary passing proof shows all issue-template and PO workflow assertions passed with exit code 0.
- Examined the validation script to confirm the exact assertions executed for issue templates and PO workflows.
- Verified the supplementary Go proof that maestro builds successfully with go build ./cmd/maestro/.
- Observed the supplementary Go proof showing partial go test ./... output before timeout.

<a href="https://app.greptile.com/trex/runs/13942862/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug.yml | Adds a bug report form with required fields for observed behavior, expected behavior, repro evidence, affected surface, and verification. |
| .github/ISSUE_TEMPLATE/config.yml | Disables blank issues and adds links to template-selection and handoff-epic guidance. |
| .github/ISSUE_TEMPLATE/epic.yml | Adds the handoff epic form with required outcome, issue wave, and done criteria sections. |
| .github/ISSUE_TEMPLATE/infra-ops.yml | Adds an infra and ops form with required target, change, rollback, verification, and priority fields. |
| .github/ISSUE_TEMPLATE/runbook-docs.yml | Adds a docs and runbook form with fields for the affected doc, the problem, proposed change, and done criteria. |
| docs/po-spec-workflow.md | Documents the issue-template registry and the label behavior for each template. |

<sub>Reviews (2): Last reviewed commit: ["epic template: use placeholder (not valu..."](https://github.com/befeast/maestro/commit/933680ecd474834cb3dd038a06e0cc5a6e3c0d51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43217091)</sub>

<!-- /greptile_comment -->