### PR TITLE
orchestrator: include failing check-run excerpts in review-feedback retries (lint blindness) (#857)

### DIFF
--- a/internal/github/failing_checks_test.go
+++ b/internal/github/failing_checks_test.go
@@ -1,0 +1,108 @@
+package github
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsFailingConclusion(t *testing.T) {
+	failing := []string{"failure", "timed_out", "cancelled", "action_required", "startup_failure", "stale", "FAILURE", "  failure  "}
+	for _, c := range failing {
+		if !isFailingConclusion(c) {
+			t.Errorf("isFailingConclusion(%q) = false, want true", c)
+		}
+	}
+	notFailing := []string{"success", "neutral", "skipped", "", "pending"}
+	for _, c := range notFailing {
+		if isFailingConclusion(c) {
+			t.Errorf("isFailingConclusion(%q) = true, want false", c)
+		}
+	}
+}
+
+func TestCheckRunOutputErrorLines(t *testing.T) {
+	tests := []struct {
+		name string
+		ck   greptileCheckRun
+		want string
+	}{
+		{
+			name: "extracts workflow-command error lines and strips the prefix",
+			ck: func() greptileCheckRun {
+				var ck greptileCheckRun
+				ck.Output.Text = "Running agent-lint\n::error::agent-lint: possible secret detected (ghp) in added diff lines.\nsome noise\n##[error]agent-lint: 1 check(s) failed"
+				return ck
+			}(),
+			want: "agent-lint: possible secret detected (ghp) in added diff lines.\nagent-lint: 1 check(s) failed",
+		},
+		{
+			name: "strips ::error file=...:: annotation prefix",
+			ck: func() greptileCheckRun {
+				var ck greptileCheckRun
+				ck.Output.Text = "::error file=x.go,line=3::boom"
+				return ck
+			}(),
+			want: "boom",
+		},
+		{
+			name: "falls back to summary when no error line matches",
+			ck: func() greptileCheckRun {
+				var ck greptileCheckRun
+				ck.Output.Summary = "agent-lint failed"
+				ck.Output.Text = "just some log output with no annotations"
+				return ck
+			}(),
+			want: "agent-lint failed",
+		},
+		{
+			name: "empty output yields empty excerpt (degrade)",
+			ck:   greptileCheckRun{},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checkRunOutputErrorLines(tt.ck); got != tt.want {
+				t.Fatalf("checkRunOutputErrorLines() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatFailureAnnotations(t *testing.T) {
+	anns := []checkAnnotation{
+		{AnnotationLevel: "failure", Message: "possible secret detected (ghp) in added diff lines.", Path: ".github"},
+		{AnnotationLevel: "warning", Message: "draft without WIP marker", Path: ".github"},
+		{AnnotationLevel: "failure", Message: "forbidden artifact committed", Path: "internal/x.go", StartLine: 12},
+		{AnnotationLevel: "failure", Message: "", Title: "titled failure"},
+	}
+	got := formatFailureAnnotations(anns)
+	if strings.Contains(got, "draft without WIP marker") {
+		t.Error("warning-level annotation should be dropped")
+	}
+	if !strings.Contains(got, "possible secret detected (ghp)") {
+		t.Errorf("failure annotation message missing: %q", got)
+	}
+	if !strings.Contains(got, "internal/x.go:12: forbidden artifact committed") {
+		t.Errorf("path:line prefix missing: %q", got)
+	}
+	if !strings.Contains(got, "titled failure") {
+		t.Errorf("title fallback missing when message empty: %q", got)
+	}
+	// The ".github" path is generic action noise and should not be prefixed.
+	if strings.Contains(got, ".github:") {
+		t.Errorf("generic .github path should not be prefixed: %q", got)
+	}
+}
+
+func TestFailingChecksFieldsRoundTrip(t *testing.T) {
+	// FailingCheck must carry name + conclusion even when no excerpt is
+	// available, so a caller can still name the check (graceful degradation).
+	fc := FailingCheck{Name: "agent-lint", Conclusion: "failure"}
+	if fc.Excerpt != "" {
+		t.Fatalf("expected empty excerpt, got %q", fc.Excerpt)
+	}
+	if fc.Name != "agent-lint" || fc.Conclusion != "failure" {
+		t.Fatalf("unexpected fields: %+v", fc)
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2154,6 +2154,169 @@ func (c *Client) PRChecksOutput(prNumber int) (string, error) {
 	return formatChecksOverview(checks, combined), nil
 }
 
+// FailingCheck is one non-passing check-run on a PR head, carrying the check's
+// name, its GitHub conclusion, and a best-effort excerpt of the failing log
+// (the annotation / `##[error]` lines). Excerpt is empty when no log detail is
+// fetchable, so a caller degrades gracefully to name + conclusion (#857).
+type FailingCheck struct {
+	Name       string
+	Conclusion string
+	Excerpt    string
+}
+
+// PRFailingChecks returns the check-runs on a PR's head SHA whose conclusion is
+// a failure, each enriched with a best-effort excerpt of its failing log. It
+// exists so a review-feedback retry can also surface a red lint check the
+// worker's previous push introduced, instead of only the review feedback that
+// triggered the retry (#857). The excerpt is drawn from the check-run's own
+// output fields, falling back to its failure annotations; either fetch failing
+// leaves the excerpt empty rather than erroring, so the caller still names the
+// check. A nil slice means no check is failing.
+func (c *Client) PRFailingChecks(prNumber int) ([]FailingCheck, error) {
+	sha, err := c.pullHeadSHA(prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
+	}
+	checks, err := c.checkRunsForSHA(sha)
+	if err != nil {
+		return nil, fmt.Errorf("get check-runs for PR %d: %w", prNumber, err)
+	}
+	var failing []FailingCheck
+	for _, ck := range checks {
+		if !isFailingConclusion(ck.Conclusion) {
+			continue
+		}
+		excerpt := checkRunOutputErrorLines(ck)
+		if excerpt == "" {
+			// Plain GitHub Actions jobs rarely populate the check-run output
+			// body; the `::error::` lines they emit land as failure annotations
+			// instead. Fetch them best-effort — an error here degrades to
+			// name + conclusion, never fails the whole call.
+			if anns, aerr := c.checkRunAnnotations(ck.ID); aerr != nil {
+				log.Printf("[github] warn: could not read annotations for check-run %q (id %d): %v", ck.Name, ck.ID, aerr)
+			} else {
+				excerpt = formatFailureAnnotations(anns)
+			}
+		}
+		failing = append(failing, FailingCheck{
+			Name:       ck.Name,
+			Conclusion: ck.Conclusion,
+			Excerpt:    excerpt,
+		})
+	}
+	return failing, nil
+}
+
+// checkAnnotation is one entry from a check-run's annotations endpoint. GitHub
+// records each `::error::` / `::warning::` workflow command a job emits as an
+// annotation carrying the level and message.
+type checkAnnotation struct {
+	Path            string `json:"path"`
+	StartLine       int    `json:"start_line"`
+	AnnotationLevel string `json:"annotation_level"`
+	Message         string `json:"message"`
+	Title           string `json:"title"`
+}
+
+func (c *Client) checkRunAnnotations(id int64) ([]checkAnnotation, error) {
+	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/check-runs/%d/annotations?per_page=100", c.Repo, id), "--paginate")
+	if err != nil {
+		return nil, err
+	}
+	var anns []checkAnnotation
+	if err := json.Unmarshal(out, &anns); err != nil {
+		return nil, fmt.Errorf("parse annotations for check-run %d: %w", id, err)
+	}
+	return anns, nil
+}
+
+// failingConclusions are the check-run conclusions ciStatusFromREST treats as a
+// hard failure; PRFailingChecks selects the same set so the excerpt path and the
+// aggregate CI verdict never disagree on what "failing" means.
+var failingConclusions = map[string]struct{}{
+	"failure":         {},
+	"timed_out":       {},
+	"cancelled":       {},
+	"action_required": {},
+	"startup_failure": {},
+	"stale":           {},
+}
+
+func isFailingConclusion(conclusion string) bool {
+	_, ok := failingConclusions[strings.ToLower(strings.TrimSpace(conclusion))]
+	return ok
+}
+
+// checkErrorLineRe matches an annotation / error line as emitted into a job log:
+// a GitHub workflow command (`::error::…`, `::error file=…::…`), the Azure-style
+// `##[error]…`, or a generic `Error:` prefix.
+var checkErrorLineRe = regexp.MustCompile(`(?i)^(?:::error\b[^:]*::|##\[error\]|error:)`)
+
+// checkErrorPrefixRe strips the recognized annotation prefix from a matched line
+// so the surfaced text reads as the message alone.
+var checkErrorPrefixRe = regexp.MustCompile(`(?i)^(?:::error\b[^:]*::|##\[error\]|error:\s*)`)
+
+// checkRunOutputErrorLines distills the error lines from a check-run's own
+// output body (summary + text). It keeps only lines that look like an error
+// annotation; if none match it falls back to the concise output summary, and to
+// "" when the check reported no output at all (the graceful-degradation case).
+func checkRunOutputErrorLines(ck greptileCheckRun) string {
+	body := strings.TrimSpace(ck.Output.Text)
+	if body == "" {
+		body = strings.TrimSpace(ck.Output.Summary)
+	} else if s := strings.TrimSpace(ck.Output.Summary); s != "" {
+		body = s + "\n" + body
+	}
+	if body == "" {
+		return ""
+	}
+	var lines []string
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if checkErrorLineRe.MatchString(line) {
+			lines = append(lines, strings.TrimSpace(checkErrorPrefixRe.ReplaceAllString(line, "")))
+		}
+	}
+	if len(lines) == 0 {
+		// No annotation-shaped line — fall back to the human summary, which is
+		// short and safe to surface, over the (possibly large) full text.
+		return strings.TrimSpace(ck.Output.Summary)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// formatFailureAnnotations renders the failure-level annotations of a check-run
+// as one message per line, prefixing the file:line when GitHub attached one.
+// Non-failure levels (warning/notice) are dropped so only blocking detail
+// reaches the retry prompt.
+func formatFailureAnnotations(anns []checkAnnotation) string {
+	var lines []string
+	for _, a := range anns {
+		if !strings.EqualFold(strings.TrimSpace(a.AnnotationLevel), "failure") {
+			continue
+		}
+		msg := strings.TrimSpace(a.Message)
+		if msg == "" {
+			msg = strings.TrimSpace(a.Title)
+		}
+		if msg == "" {
+			continue
+		}
+		if p := strings.TrimSpace(a.Path); p != "" && p != ".github" {
+			if a.StartLine > 0 {
+				msg = fmt.Sprintf("%s:%d: %s", p, a.StartLine, msg)
+			} else {
+				msg = fmt.Sprintf("%s: %s", p, msg)
+			}
+		}
+		lines = append(lines, msg)
+	}
+	return strings.Join(lines, "\n")
+}
+
 // MergePR squash-merges a PR
 func (c *Client) MergePR(prNumber int) error {
 	out, err := ghCommand("pr", "merge",

--- a/internal/orchestrator/failing_check_test.go
+++ b/internal/orchestrator/failing_check_test.go
@@ -1,0 +1,304 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestFormatFailingCheckContext_CombinesAndDegrades(t *testing.T) {
+	checks := []github.FailingCheck{
+		{Name: "agent-lint", Conclusion: "failure", Excerpt: "agent-lint: possible secret detected (ghp) in added diff lines.\nagent-lint: 1 check(s) failed"},
+		{Name: "flaky-check", Conclusion: "timed_out"}, // no excerpt -> degrade
+	}
+	got := formatFailingCheckContext(checks, failingCheckExcerptCapBytes)
+
+	if !strings.Contains(got, "agent-lint failed (conclusion: failure):") {
+		t.Errorf("named failing check with excerpt missing header: %q", got)
+	}
+	if !strings.Contains(got, "possible secret detected (ghp)") {
+		t.Errorf("excerpt error line missing: %q", got)
+	}
+	if !strings.Contains(got, "flaky-check failed (conclusion: timed_out); no log excerpt available.") {
+		t.Errorf("graceful degradation line missing for check without excerpt: %q", got)
+	}
+}
+
+func TestFormatFailingCheckContext_EmptyWhenNoFailingChecks(t *testing.T) {
+	if got := formatFailingCheckContext(nil, failingCheckExcerptCapBytes); got != "" {
+		t.Errorf("no failing checks should yield empty context, got %q", got)
+	}
+	if got := formatFailingCheckContext([]github.FailingCheck{}, failingCheckExcerptCapBytes); got != "" {
+		t.Errorf("empty failing-check slice should yield empty context, got %q", got)
+	}
+}
+
+func TestFormatFailingCheckContext_RedactsSecrets(t *testing.T) {
+	// A raw secret that slipped into a check log must never reach the prompt.
+	checks := []github.FailingCheck{
+		{Name: "agent-lint", Conclusion: "failure", Excerpt: "leaked TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789"},
+	}
+	got := formatFailingCheckContext(checks, failingCheckExcerptCapBytes)
+	if strings.Contains(got, "ghp_abcdefghijklmnopqrstuvwxyz0123456789") {
+		t.Errorf("raw github token leaked into failing-check context: %q", got)
+	}
+	if !strings.Contains(got, "REDACTED") {
+		t.Errorf("expected a redaction marker, got %q", got)
+	}
+}
+
+func TestCapFailingCheckExcerpt_Enforced(t *testing.T) {
+	long := strings.Repeat("agent-lint error line that is fairly long\n", 500)
+	capped := capFailingCheckExcerpt(long, failingCheckExcerptCapBytes)
+	if len(capped) > failingCheckExcerptCapBytes {
+		t.Fatalf("capped excerpt = %d bytes, exceeds cap %d", len(capped), failingCheckExcerptCapBytes)
+	}
+	if !strings.Contains(capped, "truncated") {
+		t.Errorf("expected truncation marker, got tail %q", capped[max(0, len(capped)-80):])
+	}
+}
+
+func TestCapFailingCheckExcerpt_ShortInputUnchanged(t *testing.T) {
+	in := "agent-lint: 1 check failed"
+	if got := capFailingCheckExcerpt(in, failingCheckExcerptCapBytes); got != in {
+		t.Errorf("short input should pass through unchanged, got %q", got)
+	}
+}
+
+func TestFormatFailingCheckContext_CapEnforcedOnAssembled(t *testing.T) {
+	checks := []github.FailingCheck{
+		{Name: "agent-lint", Conclusion: "failure", Excerpt: strings.Repeat("error: boom\n", 1000)},
+	}
+	got := formatFailingCheckContext(checks, failingCheckExcerptCapBytes)
+	if len(got) > failingCheckExcerptCapBytes {
+		t.Fatalf("assembled context = %d bytes, exceeds cap %d", len(got), failingCheckExcerptCapBytes)
+	}
+}
+
+func TestAppendFailingCheckContext_AddsSection(t *testing.T) {
+	base := "You are a coding agent."
+	excerpt := "- agent-lint failed (conclusion: failure):\n    agent-lint: possible secret detected (pem)"
+	result := appendFailingCheckContext(base, excerpt)
+
+	if !strings.Contains(result, "You are a coding agent.") {
+		t.Error("result should retain the original prompt base")
+	}
+	if !strings.Contains(result, "Failing Check on the Current PR Head") {
+		t.Error("result should contain the failing-check header")
+	}
+	if !strings.Contains(result, "agent-lint: possible secret detected (pem)") {
+		t.Error("result should contain the excerpt")
+	}
+	if !strings.Contains(result, "hard constraint on the new diff") {
+		t.Error("result should frame the check as a constraint on the new diff")
+	}
+}
+
+// End-to-end through the respawn loop: a review-feedback retry whose head also
+// has a failing check carries BOTH the review-feedback section and a
+// failing-check section naming the check, and the excerpt is consumed.
+func TestRespawnDueRetries_ReviewFeedbackWithFailingCheck(t *testing.T) {
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRetriesPerIssue: 3,
+		MaxRetryBackoffMs:  300000,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	respawnedPrompt := ""
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "base prompt {{ISSUE_NUMBER}}",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: 42, Title: "test issue", Body: "fix this"}, nil
+		},
+		respawnInPlaceFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedPrompt = promptBase
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:                 42,
+		IssueTitle:                  "test issue",
+		Status:                      state.StatusDead,
+		RetryCount:                  1,
+		NextRetryAt:                 &retryAt,
+		Backend:                     "claude",
+		PRNumber:                    10,
+		Worktree:                    "/tmp/wt",
+		PreviousAttemptFeedback:     "Confidence 3/5\nP2: enabled flag inverted in bridge.rs",
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		FailingCheckContext:         "- agent-lint failed (conclusion: failure):\n    agent-lint: possible secret detected (ghp) in added diff lines.",
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if respawnedPrompt == "" {
+		t.Fatal("respawnInPlaceFn should have been called")
+	}
+	if !strings.Contains(respawnedPrompt, "Code Review Findings") {
+		t.Error("prompt should contain the review feedback section")
+	}
+	if !strings.Contains(respawnedPrompt, "enabled flag inverted") {
+		t.Error("prompt should contain the review feedback content")
+	}
+	if !strings.Contains(respawnedPrompt, "Failing Check on the Current PR Head") {
+		t.Error("prompt should contain the failing-check section")
+	}
+	if !strings.Contains(respawnedPrompt, "agent-lint: possible secret detected (ghp)") {
+		t.Error("prompt should name the failing check and its excerpt")
+	}
+	// A review retry carries no CI-failure trigger section.
+	if strings.Contains(respawnedPrompt, "Previous CI Failure") {
+		t.Error("pure review retry should not include a CI-failure trigger section")
+	}
+
+	sess := s.Sessions["slot-1"]
+	if sess.FailingCheckContext != "" {
+		t.Errorf("FailingCheckContext should be consumed, got %q", sess.FailingCheckContext)
+	}
+}
+
+// No behavior change when the head has no failing check: the review retry omits
+// the failing-check section entirely.
+func TestRespawnDueRetries_ReviewFeedbackNoFailingCheck(t *testing.T) {
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRetriesPerIssue: 3,
+		MaxRetryBackoffMs:  300000,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+
+	respawnedPrompt := ""
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "base prompt {{ISSUE_NUMBER}}",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: 42, Title: "test issue", Body: "fix this"}, nil
+		},
+		respawnInPlaceFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+			respawnedPrompt = promptBase
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:                 42,
+		IssueTitle:                  "test issue",
+		Status:                      state.StatusDead,
+		RetryCount:                  1,
+		NextRetryAt:                 &retryAt,
+		Backend:                     "claude",
+		PRNumber:                    10,
+		Worktree:                    "/tmp/wt",
+		PreviousAttemptFeedback:     "P2: rename helper",
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		// FailingCheckContext intentionally empty.
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if respawnedPrompt == "" {
+		t.Fatal("respawnInPlaceFn should have been called")
+	}
+	if !strings.Contains(respawnedPrompt, "Code Review Findings") {
+		t.Error("prompt should still contain the review feedback section")
+	}
+	if strings.Contains(respawnedPrompt, "Failing Check on the Current PR Head") {
+		t.Error("no failing check present — the failing-check section must be omitted")
+	}
+}
+
+// handleReviewFeedbackRetry captures a bounded failing-check excerpt naming the
+// red check when the PR head has one, and captures nothing when all checks pass.
+func TestHandleReviewFeedbackRetry_CapturesFailingCheck(t *testing.T) {
+	newOrch := func(failing []github.FailingCheck) *Orchestrator {
+		return &Orchestrator{
+			cfg:      &config.Config{Repo: "owner/repo", MaxRetryBackoffMs: 300000},
+			notifier: &notify.Notifier{},
+			ghPRFailingChecksFn: func(prNumber int) ([]github.FailingCheck, error) {
+				return failing, nil
+			},
+		}
+	}
+
+	t.Run("failing check captured", func(t *testing.T) {
+		o := newOrch([]github.FailingCheck{
+			{Name: "agent-lint", Conclusion: "failure", Excerpt: "agent-lint: forbidden artifact committed"},
+		})
+		s := state.NewState()
+		sess := &state.Session{IssueNumber: 42, IssueTitle: "t", Worktree: "/tmp/wt"}
+		s.Sessions["slot-1"] = sess
+
+		o.handleReviewFeedbackRetry(s, "slot-1", sess, github.PR{Number: 10}, "P2: fix it")
+
+		if sess.PreviousAttemptFeedback != "P2: fix it" {
+			t.Errorf("review feedback not stored, got %q", sess.PreviousAttemptFeedback)
+		}
+		if !strings.Contains(sess.FailingCheckContext, "agent-lint failed (conclusion: failure)") {
+			t.Errorf("failing-check excerpt not captured, got %q", sess.FailingCheckContext)
+		}
+		if !strings.Contains(sess.FailingCheckContext, "forbidden artifact committed") {
+			t.Errorf("failing-check excerpt missing detail, got %q", sess.FailingCheckContext)
+		}
+	})
+
+	t.Run("all checks green captures nothing", func(t *testing.T) {
+		o := newOrch(nil)
+		s := state.NewState()
+		sess := &state.Session{IssueNumber: 42, IssueTitle: "t", Worktree: "/tmp/wt"}
+		s.Sessions["slot-1"] = sess
+
+		o.handleReviewFeedbackRetry(s, "slot-1", sess, github.PR{Number: 10}, "P2: fix it")
+
+		if sess.FailingCheckContext != "" {
+			t.Errorf("no failing check — FailingCheckContext must stay empty, got %q", sess.FailingCheckContext)
+		}
+	})
+
+	t.Run("fetch error degrades to no excerpt", func(t *testing.T) {
+		o := &Orchestrator{
+			cfg:      &config.Config{Repo: "owner/repo", MaxRetryBackoffMs: 300000},
+			notifier: &notify.Notifier{},
+			ghPRFailingChecksFn: func(prNumber int) ([]github.FailingCheck, error) {
+				return nil, errTestFetch
+			},
+		}
+		s := state.NewState()
+		sess := &state.Session{IssueNumber: 42, IssueTitle: "t", Worktree: "/tmp/wt"}
+		s.Sessions["slot-1"] = sess
+
+		o.handleReviewFeedbackRetry(s, "slot-1", sess, github.PR{Number: 10}, "P2: fix it")
+
+		if sess.FailingCheckContext != "" {
+			t.Errorf("fetch error should degrade to empty excerpt, got %q", sess.FailingCheckContext)
+		}
+		if sess.PreviousAttemptFeedback != "P2: fix it" {
+			t.Errorf("review retry should still proceed on fetch error, got %q", sess.PreviousAttemptFeedback)
+		}
+	})
+}
+
+var errTestFetch = errTest("boom")
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
@@ -131,6 +132,7 @@ type Orchestrator struct {
 	ghMergePRFn                  func(prNumber int) error
 	ghClosePRFn                  func(prNumber int, comment string) error
 	ghPRChecksOutputFn           func(prNumber int) (string, error)
+	ghPRFailingChecksFn          func(prNumber int) ([]github.FailingCheck, error)
 	ghCollectPRReviewFeedbackFn  func(prNumber int) (string, error)
 	ghCloseIssueFn               func(number int, comment string) error
 	ghPRHeadSHAFn                func(prNumber int) (string, error)
@@ -585,6 +587,29 @@ func (o *Orchestrator) collectPRReviewFeedback(prNumber int) (string, error) {
 		return o.ghCollectPRReviewFeedbackFn(prNumber)
 	}
 	return o.gh.CollectPRReviewFeedback(prNumber)
+}
+
+func (o *Orchestrator) prFailingChecks(prNumber int) ([]github.FailingCheck, error) {
+	if o.ghPRFailingChecksFn != nil {
+		return o.ghPRFailingChecksFn(prNumber)
+	}
+	if o.gh == nil {
+		return nil, fmt.Errorf("no github client configured for failing-checks")
+	}
+	return o.gh.PRFailingChecks(prNumber)
+}
+
+// collectFailingCheckContext fetches the check-runs still failing on a PR head
+// and renders a bounded, redacted excerpt for the retry prompt (#857).
+// Best-effort: a fetch error yields "" (no section) rather than blocking the
+// retry, and an all-green head yields "" so a pure review retry is unchanged.
+func (o *Orchestrator) collectFailingCheckContext(prNumber int) string {
+	checks, err := o.prFailingChecks(prNumber)
+	if err != nil {
+		log.Printf("[orch] warn: could not collect failing-check context for PR #%d: %v", prNumber, err)
+		return ""
+	}
+	return formatFailingCheckContext(checks, failingCheckExcerptCapBytes)
 }
 
 func (o *Orchestrator) closeIssue(number int, comment string) error {
@@ -1639,6 +1664,113 @@ Do NOT repeat the same mistakes.
 `, promptBase, feedback)
 }
 
+// failingCheckExcerptCapBytes hard-caps the failing-check excerpt placed in a
+// review-feedback retry prompt, mirroring the post-mortem cap discipline from
+// #835 so a verbose lint log cannot crowd out the rest of the prompt.
+const failingCheckExcerptCapBytes = 2048
+
+const failingCheckTruncationMarker = "\n… (failing-check excerpt truncated for the prompt)"
+
+// formatFailingCheckContext assembles a bounded, secret-redacted excerpt naming
+// each check-run still failing on the PR head. Each check contributes its
+// distilled error lines; a check with no fetchable log degrades to its name and
+// conclusion only. The whole excerpt is redacted and then hard-capped. It
+// returns "" when nothing is failing, so the caller adds no section (#857).
+func formatFailingCheckContext(checks []github.FailingCheck, capBytes int) string {
+	var b strings.Builder
+	for _, ck := range checks {
+		name := strings.TrimSpace(ck.Name)
+		if name == "" {
+			name = "check"
+		}
+		conclusion := strings.TrimSpace(ck.Conclusion)
+		if conclusion == "" {
+			conclusion = "failure"
+		}
+		excerpt := strings.TrimSpace(ck.Excerpt)
+		if excerpt == "" {
+			fmt.Fprintf(&b, "- %s failed (conclusion: %s); no log excerpt available.\n", name, conclusion)
+			continue
+		}
+		fmt.Fprintf(&b, "- %s failed (conclusion: %s):\n", name, conclusion)
+		for _, line := range strings.Split(excerpt, "\n") {
+			line = strings.TrimRight(line, " \t\r")
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			fmt.Fprintf(&b, "    %s\n", line)
+		}
+	}
+	assembled := strings.TrimRight(b.String(), "\n")
+	if assembled == "" {
+		return ""
+	}
+	assembled = supervisor.RedactSensitive(assembled)
+	return capFailingCheckExcerpt(assembled, capBytes)
+}
+
+// capFailingCheckExcerpt bounds s to capBytes, appending a truncation marker
+// that is counted against the budget, on a line boundary where possible, always
+// yielding valid UTF-8. capBytes <= 0 disables the cap. Same discipline as
+// worker.CapPostmortem (#835), with a check-specific marker.
+func capFailingCheckExcerpt(s string, capBytes int) string {
+	if capBytes <= 0 || len(s) <= capBytes {
+		return s
+	}
+	budget := capBytes - len(failingCheckTruncationMarker)
+	if budget <= 0 {
+		return truncateExcerptToRune(s, capBytes)
+	}
+	truncated := truncateExcerptToRune(s, budget)
+	if idx := strings.LastIndexByte(truncated, '\n'); idx > 0 {
+		truncated = truncated[:idx]
+	}
+	return strings.TrimRight(truncated, "\n") + failingCheckTruncationMarker
+}
+
+// truncateExcerptToRune returns the longest prefix of s at most capBytes bytes
+// that does not split a UTF-8 rune (it only ever removes bytes, so the result
+// never exceeds capBytes).
+func truncateExcerptToRune(s string, capBytes int) string {
+	if capBytes <= 0 {
+		return ""
+	}
+	if len(s) <= capBytes {
+		return s
+	}
+	b := s[:capBytes]
+	for len(b) > 0 {
+		if r, size := utf8.DecodeLastRuneInString(b); r == utf8.RuneError && size <= 1 {
+			b = b[:len(b)-1]
+			continue
+		}
+		break
+	}
+	return b
+}
+
+// appendFailingCheckContext appends a section naming the check-run(s) still
+// failing on the PR head, so a review-feedback retry treats a red lint check as
+// a hard constraint on the new diff instead of only the review comments that
+// triggered the retry (#857). excerpt is already bounded/redacted by
+// formatFailingCheckContext.
+func appendFailingCheckContext(promptBase, excerpt string) string {
+	return fmt.Sprintf(`%s
+
+---
+
+## IMPORTANT: Failing Check on the Current PR Head
+
+Besides any review feedback above, the following CI check(s) are FAILING on your
+PR's current head commit — your previous push did not make them pass. Treat this
+as a hard constraint on the new diff and do NOT reintroduce the same failure:
+
+%s
+
+Make the failing check(s) pass AND address the review feedback before you push again.
+`, promptBase, excerpt)
+}
+
 // appendPriorAttemptPostmortem appends a bounded, automatically-extracted
 // summary of the previous failed attempt's own worker-log trajectory (#835).
 // It sits alongside — not in place of — the CI/review/conflict context, so the
@@ -1907,6 +2039,14 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 			}
 			sess.PreviousAttemptFeedback = "" // consumed — don't persist stale feedback
 			sess.PreviousAttemptFeedbackKind = ""
+		}
+		// #857: a review-feedback retry whose PR head also has a red check (e.g.
+		// agent-lint) carries a bounded excerpt of that check alongside — not in
+		// place of — the review feedback above, so the worker fixes the lint
+		// failure its previous push introduced instead of only the review P1s.
+		if sess.FailingCheckContext != "" {
+			promptBase = appendFailingCheckContext(promptBase, sess.FailingCheckContext)
+			sess.FailingCheckContext = "" // consumed — don't persist stale excerpt
 		}
 
 		// #835: append a bounded post-mortem distilled from the previous
@@ -4171,6 +4311,11 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 	sess.PreviousAttemptFeedback = reviewFeedback
 	sess.PreviousAttemptFeedbackKind = state.RetryReasonReviewFeedback
 	sess.RetryReason = state.RetryReasonReviewFeedback
+	// #857: a review-feedback retry is scheduled off a green aggregate CI, but
+	// an individual check (e.g. agent-lint) can still be red on the PR head.
+	// Capture a bounded excerpt so the respawned worker also sees the failing
+	// check its previous push introduced, not just the review comments.
+	sess.FailingCheckContext = o.collectFailingCheckContext(pr.Number)
 
 	sess.MaintenanceRetryCount++
 	backoffMs := retryBackoffMs(sess.MaintenanceRetryCount, o.cfg.MaxRetryBackoffMs)
@@ -4239,8 +4384,12 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 	o.stopWorker(slotName, sess)
 	sess.Worktree = ""
 
-	// Store CI failure output and review feedback for the next worker
+	// Store CI failure output and review feedback for the next worker. The CI
+	// failure trigger already carries the full checks overview via
+	// CIFailureOutput, so drop any stale review-path failing-check excerpt to
+	// keep this path's prompt unchanged (#857).
 	sess.CIFailureOutput = ciOutput
+	sess.FailingCheckContext = ""
 	sess.PreviousAttemptFeedback = reviewFeedback
 	if strings.TrimSpace(reviewFeedback) != "" {
 		sess.PreviousAttemptFeedbackKind = "review_feedback"
@@ -5246,6 +5395,7 @@ func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string
 	}
 
 	sess.CIFailureOutput = ""
+	sess.FailingCheckContext = "" // rebase-conflict retry carries no failing-check excerpt (#857)
 	sess.PreviousAttemptFeedback = rebaseConflictFeedback(prNumber, cause)
 	sess.PreviousAttemptFeedbackKind = "rebase_conflict"
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -214,6 +214,7 @@ type Session struct {
 	ValidationFails             int               `json:"validation_fails,omitempty"`               // number of failed validation attempts
 	ValidationFeedback          string            `json:"validation_feedback,omitempty"`            // feedback from last failed validation
 	CIFailureOutput             string            `json:"ci_failure_output,omitempty"`              // CI failure output captured before retry (passed to next worker as context)
+	FailingCheckContext         string            `json:"failing_check_context,omitempty"`          // #857: bounded excerpt of a check-run still failing on the PR head, carried into a review-feedback retry so the worker sees the red check its previous push introduced (consumed on respawn)
 	PreviousAttemptFeedback     string            `json:"previous_attempt_feedback,omitempty"`      // feedback from previous failed PR attempt
 	PreviousAttemptFeedbackKind string            `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
 	RetryReason                 string            `json:"retry_reason,omitempty"`                   // current retry lifecycle reason, e.g. review_feedback


### PR DESCRIPTION
Implements #857

## Changes
- `github.PRFailingChecks` returns each non-passing check-run on a PR head with a best-effort failing-log excerpt (output error lines, falling back to failure annotations); empty excerpt when nothing is fetchable.
- `handleReviewFeedbackRetry` captures a bounded, secret-redacted excerpt into a new `Session.FailingCheckContext`. The respawn loop appends a section naming the failing check **alongside** — not in place of — the review-feedback section, then consumes the field.
- Excerpt is hard-capped (same discipline as the #835 post-mortem cap); a missing/unfetchable log degrades to check name + conclusion only.
- No behavior change when all checks pass (no section) or when a CI failure is already the retry trigger (that path keeps its existing checks-overview context).

## Testing
- `internal/github`: unit tests for failing-conclusion classification, output error-line extraction, and failure-annotation formatting.
- `internal/orchestrator`: combined review+failing-check assembly, cap enforcement, secret redaction, graceful degradation, and end-to-end respawn assembly (both with and without a failing check).
- `go build ./cmd/maestro/`, `go test ./...` pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds failing-check context to review-feedback retries. The main changes are:

- New GitHub helpers for failing check-runs and log excerpts.
- Bounded and redacted failing-check prompt context in the orchestrator.
- Retry-state storage and consumption for the new context.
- Tests for formatting, redaction, capping, and retry assembly.

<h3>Confidence Score: 4/5</h3>

The changed annotation fallback needs a fix before merging.

- Paginated annotation responses can fail to unmarshal.
- That drops available failure excerpts from review-feedback retry prompts.
- The orchestrator state flow and prompt assembly look consistent in the changed paths.

internal/github/github.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds failing-check extraction, excerpt parsing, and annotation fallback; the annotation fallback needs paginated array handling. |
| internal/orchestrator/orchestrator.go | Adds failing-check collection, prompt formatting, redaction, capping, appending, and lifecycle clearing. |
| internal/state/state.go | Adds persisted retry context for failing-check excerpts. |
| internal/github/failing_checks_test.go | Adds unit tests for conclusion filtering, output extraction, annotation formatting, and empty excerpt behavior. |
| internal/orchestrator/failing_check_test.go | Adds orchestrator tests for failing-check prompt formatting, redaction, caps, capture, degradation, and respawn consumption. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/github/github.go:2222-2226
**Paginated Annotations Fail Parsing**

When a failing check-run has more than 100 annotations, this `--paginate` call can return multiple JSON arrays, but the new code unmarshals the raw output as one array. That makes the best-effort annotation fallback fail and the retry prompt loses the available failure excerpt, degrading to only the check name and conclusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: carry failing check-run ex..."](https://github.com/befeast/maestro/commit/979379f75c90ceda2f8a27cef5b82496c2b7a9fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43226627)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->