### PR TITLE
orchestrator: include failing check-run excerpts in review-feedback retries (lint blindness) (#857)

### DIFF
--- a/internal/github/failing_checks_test.go
+++ b/internal/github/failing_checks_test.go
@@ -69,6 +69,54 @@ func TestCheckRunOutputErrorLines(t *testing.T) {
 	}
 }
 
+// A GitHub Actions step that fails emits "Error: Process completed with exit
+// code 1" into its output body; checkErrorLineRe matches it (via the `error:`
+// prefix) and strips it to "Process completed with exit code 1". That excerpt
+// is non-empty but names no actionable error, so PRFailingChecks must recognize
+// it as generic and fall through to the failure annotations instead of skipping
+// them — otherwise the real agent-lint error never reaches the retry prompt
+// (#857 review: generic output hid annotations).
+func TestCheckRunOutputErrorLines_GenericBoilerplateStaysGeneric(t *testing.T) {
+	var ck greptileCheckRun
+	ck.Output.Text = "Error: Process completed with exit code 1"
+	got := checkRunOutputErrorLines(ck)
+	if got == "" {
+		t.Fatalf("expected non-empty excerpt for generic boilerplate, got empty")
+	}
+	if !isGenericCheckExcerpt(got) {
+		t.Fatalf("excerpt %q should be classified generic so annotations fallback runs", got)
+	}
+}
+
+func TestIsGenericCheckExcerpt(t *testing.T) {
+	generic := []string{
+		"Process completed with exit code 1",
+		"process completed with exit code 137",
+		"Process completed with exit code 1.",
+		"The process '/usr/bin/bash' failed with exit code 1",
+		"  Process completed with exit code 2  ",
+		"Process completed with exit code 1\n\nProcess completed with exit code 2",
+	}
+	for _, s := range generic {
+		if !isGenericCheckExcerpt(s) {
+			t.Errorf("isGenericCheckExcerpt(%q) = false, want true", s)
+		}
+	}
+	actionable := []string{
+		"",
+		"agent-lint: possible secret detected (github-token) in added diff lines.",
+		"agent-lint: 1 check(s) failed",
+		// A generic line mixed with a real error must NOT be treated as generic,
+		// so a genuine excerpt is never discarded in favor of annotations.
+		"Process completed with exit code 1\nagent-lint: possible secret detected",
+	}
+	for _, s := range actionable {
+		if isGenericCheckExcerpt(s) {
+			t.Errorf("isGenericCheckExcerpt(%q) = true, want false", s)
+		}
+	}
+}
+
 func TestFormatFailureAnnotations(t *testing.T) {
 	anns := []checkAnnotation{
 		{AnnotationLevel: "failure", Message: "possible secret detected (github-token) in added diff lines.", Path: ".github"},

--- a/internal/github/failing_checks_test.go
+++ b/internal/github/failing_checks_test.go
@@ -1,0 +1,138 @@
+package github
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsFailingConclusion(t *testing.T) {
+	failing := []string{"failure", "timed_out", "cancelled", "action_required", "startup_failure", "stale", "FAILURE", "  failure  "}
+	for _, c := range failing {
+		if !isFailingConclusion(c) {
+			t.Errorf("isFailingConclusion(%q) = false, want true", c)
+		}
+	}
+	notFailing := []string{"success", "neutral", "skipped", "", "pending"}
+	for _, c := range notFailing {
+		if isFailingConclusion(c) {
+			t.Errorf("isFailingConclusion(%q) = true, want false", c)
+		}
+	}
+}
+
+func TestCheckRunOutputErrorLines(t *testing.T) {
+	tests := []struct {
+		name string
+		ck   greptileCheckRun
+		want string
+	}{
+		{
+			name: "extracts workflow-command error lines and strips the prefix",
+			ck: func() greptileCheckRun {
+				var ck greptileCheckRun
+				ck.Output.Text = "Running agent-lint\n::error::agent-lint: possible secret detected (github-token) in added diff lines.\nsome noise\n##[error]agent-lint: 1 check(s) failed"
+				return ck
+			}(),
+			want: "agent-lint: possible secret detected (github-token) in added diff lines.\nagent-lint: 1 check(s) failed",
+		},
+		{
+			name: "strips ::error file=...:: annotation prefix",
+			ck: func() greptileCheckRun {
+				var ck greptileCheckRun
+				ck.Output.Text = "::error file=x.go,line=3::boom"
+				return ck
+			}(),
+			want: "boom",
+		},
+		{
+			name: "falls back to summary when no error line matches",
+			ck: func() greptileCheckRun {
+				var ck greptileCheckRun
+				ck.Output.Summary = "agent-lint failed"
+				ck.Output.Text = "just some log output with no annotations"
+				return ck
+			}(),
+			want: "agent-lint failed",
+		},
+		{
+			name: "empty output yields empty excerpt (degrade)",
+			ck:   greptileCheckRun{},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checkRunOutputErrorLines(tt.ck); got != tt.want {
+				t.Fatalf("checkRunOutputErrorLines() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatFailureAnnotations(t *testing.T) {
+	anns := []checkAnnotation{
+		{AnnotationLevel: "failure", Message: "possible secret detected (github-token) in added diff lines.", Path: ".github"},
+		{AnnotationLevel: "warning", Message: "draft without WIP marker", Path: ".github"},
+		{AnnotationLevel: "failure", Message: "forbidden artifact committed", Path: "internal/x.go", StartLine: 12},
+		{AnnotationLevel: "failure", Message: "", Title: "titled failure"},
+	}
+	got := formatFailureAnnotations(anns)
+	if strings.Contains(got, "draft without WIP marker") {
+		t.Error("warning-level annotation should be dropped")
+	}
+	if !strings.Contains(got, "possible secret detected (github-token)") {
+		t.Errorf("failure annotation message missing: %q", got)
+	}
+	if !strings.Contains(got, "internal/x.go:12: forbidden artifact committed") {
+		t.Errorf("path:line prefix missing: %q", got)
+	}
+	if !strings.Contains(got, "titled failure") {
+		t.Errorf("title fallback missing when message empty: %q", got)
+	}
+	// The ".github" path is generic action noise and should not be prefixed.
+	if strings.Contains(got, ".github:") {
+		t.Errorf("generic .github path should not be prefixed: %q", got)
+	}
+}
+
+// The annotations endpoint is a plain JSON array, so `gh api --paginate` emits
+// each page as its own back-to-back `[...]` document. A check-run with more than
+// 100 annotations therefore returns `[...][...]`, which a single json.Unmarshal
+// rejects. parseCheckAnnotations must merge the pages so the failing-log excerpt
+// still parses instead of silently degrading to name + conclusion (#857 review).
+func TestParseCheckAnnotations_MergesPaginatedArrays(t *testing.T) {
+	page1 := `[{"annotation_level":"failure","message":"boom one","path":"a.go","start_line":1}]`
+	page2 := `[{"annotation_level":"failure","message":"boom two","path":"b.go","start_line":2}]`
+
+	anns, err := parseCheckAnnotations([]byte(page1 + page2))
+	if err != nil {
+		t.Fatalf("parseCheckAnnotations over two pages: %v", err)
+	}
+	if len(anns) != 2 {
+		t.Fatalf("want 2 merged annotations across pages, got %d: %+v", len(anns), anns)
+	}
+	if anns[0].Message != "boom one" || anns[1].Message != "boom two" {
+		t.Fatalf("annotations not merged in order: %+v", anns)
+	}
+
+	// A single-page body is one `[...]` document and must still parse.
+	single, err := parseCheckAnnotations([]byte(page1))
+	if err != nil {
+		t.Fatalf("parseCheckAnnotations single page: %v", err)
+	}
+	if len(single) != 1 {
+		t.Fatalf("want 1 annotation for single page, got %d", len(single))
+	}
+}
+
+func TestFailingChecksFieldsRoundTrip(t *testing.T) {
+	// FailingCheck must carry name + conclusion even when no excerpt is
+	// available, so a caller can still name the check (graceful degradation).
+	fc := FailingCheck{Name: "agent-lint", Conclusion: "failure"}
+	if fc.Excerpt != "" {
+		t.Fatalf("expected empty excerpt, got %q", fc.Excerpt)
+	}
+	if fc.Name != "agent-lint" || fc.Conclusion != "failure" {
+		t.Fatalf("unexpected fields: %+v", fc)
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2154,6 +2154,187 @@ func (c *Client) PRChecksOutput(prNumber int) (string, error) {
 	return formatChecksOverview(checks, combined), nil
 }
 
+// FailingCheck is one non-passing check-run on a PR head, carrying the check's
+// name, its GitHub conclusion, and a best-effort excerpt of the failing log
+// (the annotation / `##[error]` lines). Excerpt is empty when no log detail is
+// fetchable, so a caller degrades gracefully to name + conclusion (#857).
+type FailingCheck struct {
+	Name       string
+	Conclusion string
+	Excerpt    string
+}
+
+// PRFailingChecks returns the check-runs on a PR's head SHA whose conclusion is
+// a failure, each enriched with a best-effort excerpt of its failing log. It
+// exists so a retry can surface a red lint check the worker's previous push
+// introduced, instead of only the review feedback (or bare checks overview)
+// that triggered the retry (#857). The excerpt is drawn from the check-run's
+// own output fields, falling back to its failure annotations; either fetch
+// failing leaves the excerpt empty rather than erroring, so the caller still
+// names the check. A nil slice means no check is failing.
+func (c *Client) PRFailingChecks(prNumber int) ([]FailingCheck, error) {
+	sha, err := c.pullHeadSHA(prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
+	}
+	checks, err := c.checkRunsForSHA(sha)
+	if err != nil {
+		return nil, fmt.Errorf("get check-runs for PR %d: %w", prNumber, err)
+	}
+	var failing []FailingCheck
+	for _, ck := range checks {
+		if !isFailingConclusion(ck.Conclusion) {
+			continue
+		}
+		excerpt := checkRunOutputErrorLines(ck)
+		if excerpt == "" {
+			// Plain GitHub Actions jobs rarely populate the check-run output
+			// body; the `::error::` lines they emit (e.g. agent-lint) land as
+			// failure annotations instead. Fetch them best-effort — an error
+			// here degrades to name + conclusion, never fails the whole call.
+			if anns, aerr := c.checkRunAnnotations(ck.ID); aerr != nil {
+				log.Printf("[github] warn: could not read annotations for check-run %q (id %d): %v", ck.Name, ck.ID, aerr)
+			} else {
+				excerpt = formatFailureAnnotations(anns)
+			}
+		}
+		failing = append(failing, FailingCheck{
+			Name:       ck.Name,
+			Conclusion: ck.Conclusion,
+			Excerpt:    excerpt,
+		})
+	}
+	return failing, nil
+}
+
+// checkAnnotation is one entry from a check-run's annotations endpoint. GitHub
+// records each `::error::` / `::warning::` workflow command a job emits as an
+// annotation carrying the level and message.
+type checkAnnotation struct {
+	Path            string `json:"path"`
+	StartLine       int    `json:"start_line"`
+	AnnotationLevel string `json:"annotation_level"`
+	Message         string `json:"message"`
+	Title           string `json:"title"`
+}
+
+func (c *Client) checkRunAnnotations(id int64) ([]checkAnnotation, error) {
+	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/check-runs/%d/annotations?per_page=100", c.Repo, id), "--paginate")
+	if err != nil {
+		return nil, err
+	}
+	anns, err := parseCheckAnnotations(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse annotations for check-run %d: %w", id, err)
+	}
+	return anns, nil
+}
+
+// parseCheckAnnotations decodes the body of the annotations `--paginate` call.
+// The annotations endpoint is a plain JSON array, so a check-run with more than
+// 100 annotations yields back-to-back `[...][...]` documents that a single
+// json.Unmarshal rejects; merge the pages first (same shape handled by
+// mergePaginatedJSONArrays for the reconcile lists) so >100 annotations still
+// parse and the failing-log excerpt survives (#857).
+func parseCheckAnnotations(out []byte) ([]checkAnnotation, error) {
+	merged, err := mergePaginatedJSONArrays(out)
+	if err != nil {
+		return nil, err
+	}
+	var anns []checkAnnotation
+	if err := json.Unmarshal(merged, &anns); err != nil {
+		return nil, err
+	}
+	return anns, nil
+}
+
+// failingConclusions are the check-run conclusions ciStatusFromREST treats as a
+// hard failure; PRFailingChecks selects the same set so the excerpt path and the
+// aggregate CI verdict never disagree on what "failing" means.
+var failingConclusions = map[string]struct{}{
+	"failure":         {},
+	"timed_out":       {},
+	"cancelled":       {},
+	"action_required": {},
+	"startup_failure": {},
+	"stale":           {},
+}
+
+func isFailingConclusion(conclusion string) bool {
+	_, ok := failingConclusions[strings.ToLower(strings.TrimSpace(conclusion))]
+	return ok
+}
+
+// checkErrorLineRe matches an annotation / error line as emitted into a job log:
+// a GitHub workflow command (`::error::…`, `::error file=…::…`), the Azure-style
+// `##[error]…`, or a generic `Error:` prefix.
+var checkErrorLineRe = regexp.MustCompile(`(?i)^(?:::error\b[^:]*::|##\[error\]|error:)`)
+
+// checkErrorPrefixRe strips the recognized annotation prefix from a matched line
+// so the surfaced text reads as the message alone.
+var checkErrorPrefixRe = regexp.MustCompile(`(?i)^(?:::error\b[^:]*::|##\[error\]|error:\s*)`)
+
+// checkRunOutputErrorLines distills the error lines from a check-run's own
+// output body (summary + text). It keeps only lines that look like an error
+// annotation; if none match it falls back to the concise output summary, and to
+// "" when the check reported no output at all (the graceful-degradation case).
+func checkRunOutputErrorLines(ck greptileCheckRun) string {
+	body := strings.TrimSpace(ck.Output.Text)
+	if body == "" {
+		body = strings.TrimSpace(ck.Output.Summary)
+	} else if s := strings.TrimSpace(ck.Output.Summary); s != "" {
+		body = s + "\n" + body
+	}
+	if body == "" {
+		return ""
+	}
+	var lines []string
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if checkErrorLineRe.MatchString(line) {
+			lines = append(lines, strings.TrimSpace(checkErrorPrefixRe.ReplaceAllString(line, "")))
+		}
+	}
+	if len(lines) == 0 {
+		// No annotation-shaped line — fall back to the human summary, which is
+		// short and safe to surface, over the (possibly large) full text.
+		return strings.TrimSpace(ck.Output.Summary)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// formatFailureAnnotations renders the failure-level annotations of a check-run
+// as one message per line, prefixing the file:line when GitHub attached one.
+// Non-failure levels (warning/notice) are dropped so only blocking detail
+// reaches the retry prompt.
+func formatFailureAnnotations(anns []checkAnnotation) string {
+	var lines []string
+	for _, a := range anns {
+		if !strings.EqualFold(strings.TrimSpace(a.AnnotationLevel), "failure") {
+			continue
+		}
+		msg := strings.TrimSpace(a.Message)
+		if msg == "" {
+			msg = strings.TrimSpace(a.Title)
+		}
+		if msg == "" {
+			continue
+		}
+		if p := strings.TrimSpace(a.Path); p != "" && p != ".github" {
+			if a.StartLine > 0 {
+				msg = fmt.Sprintf("%s:%d: %s", p, a.StartLine, msg)
+			} else {
+				msg = fmt.Sprintf("%s: %s", p, msg)
+			}
+		}
+		lines = append(lines, msg)
+	}
+	return strings.Join(lines, "\n")
+}
+
 // MergePR squash-merges a PR
 func (c *Client) MergePR(prNumber int) error {
 	out, err := ghCommand("pr", "merge",

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2187,15 +2187,19 @@ func (c *Client) PRFailingChecks(prNumber int) ([]FailingCheck, error) {
 			continue
 		}
 		excerpt := checkRunOutputErrorLines(ck)
-		if excerpt == "" {
-			// Plain GitHub Actions jobs rarely populate the check-run output
-			// body; the `::error::` lines they emit (e.g. agent-lint) land as
-			// failure annotations instead. Fetch them best-effort — an error
-			// here degrades to name + conclusion, never fails the whole call.
+		if excerpt == "" || isGenericCheckExcerpt(excerpt) {
+			// The output body was empty, or carried only generic runner
+			// boilerplate ("Process completed with exit code 1") that names no
+			// actionable error. Plain GitHub Actions jobs (e.g. agent-lint) emit
+			// their real `::error::` detail as failure annotations, so fetch
+			// those and prefer them. A fetch error, or no failure-level
+			// annotation, leaves whatever the output gave us — the generic line
+			// still names the failure and the call never fails (#857 review:
+			// a generic excerpt must not hide the annotations fallback).
 			if anns, aerr := c.checkRunAnnotations(ck.ID); aerr != nil {
 				log.Printf("[github] warn: could not read annotations for check-run %q (id %d): %v", ck.Name, ck.ID, aerr)
-			} else {
-				excerpt = formatFailureAnnotations(anns)
+			} else if formatted := formatFailureAnnotations(anns); formatted != "" {
+				excerpt = formatted
 			}
 		}
 		failing = append(failing, FailingCheck{
@@ -2273,6 +2277,34 @@ var checkErrorLineRe = regexp.MustCompile(`(?i)^(?:::error\b[^:]*::|##\[error\]|
 // checkErrorPrefixRe strips the recognized annotation prefix from a matched line
 // so the surfaced text reads as the message alone.
 var checkErrorPrefixRe = regexp.MustCompile(`(?i)^(?:::error\b[^:]*::|##\[error\]|error:\s*)`)
+
+// genericCheckFailureLineRe matches the runner boilerplate a failed GitHub
+// Actions step emits — "Error: Process completed with exit code 1" or "Error:
+// The process '/usr/bin/bash' failed with exit code 1" — after checkErrorLineRe
+// strips its `error:` prefix. Such a line names no actionable error.
+var genericCheckFailureLineRe = regexp.MustCompile(`(?i)^(?:the process\b.*failed|process completed) with exit code \d+\.?$`)
+
+// isGenericCheckExcerpt reports whether an output-derived excerpt consists only
+// of generic runner boilerplate ("Process completed with exit code 1") that
+// carries no actionable detail. Such an excerpt is non-empty yet useless to a
+// retrying worker, so PRFailingChecks treats it like an empty excerpt and falls
+// through to the check-run's failure annotations, where the real `::error::`
+// lines (e.g. agent-lint) actually live (#857 review). An excerpt with any
+// non-boilerplate line is kept as-is.
+func isGenericCheckExcerpt(excerpt string) bool {
+	var sawLine bool
+	for _, raw := range strings.Split(excerpt, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if !genericCheckFailureLineRe.MatchString(line) {
+			return false
+		}
+		sawLine = true
+	}
+	return sawLine
+}
 
 // checkRunOutputErrorLines distills the error lines from a check-run's own
 // output body (summary + text). It keeps only lines that look like an error

--- a/internal/orchestrator/failing_check_test.go
+++ b/internal/orchestrator/failing_check_test.go
@@ -1,0 +1,346 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestFormatFailingCheckContext_CombinesAndDegrades(t *testing.T) {
+	checks := []github.FailingCheck{
+		{Name: "agent-lint", Conclusion: "failure", Excerpt: "agent-lint: forbidden artifact committed\nagent-lint: 1 check(s) failed"},
+		{Name: "flaky-check", Conclusion: "timed_out"}, // no excerpt -> degrade
+	}
+	got := formatFailingCheckContext(checks, failingCheckExcerptCapBytes)
+
+	if !strings.Contains(got, "agent-lint failed (conclusion: failure):") {
+		t.Errorf("named failing check with excerpt missing header: %q", got)
+	}
+	if !strings.Contains(got, "forbidden artifact committed") {
+		t.Errorf("excerpt error line missing: %q", got)
+	}
+	if !strings.Contains(got, "flaky-check failed (conclusion: timed_out); no log excerpt available.") {
+		t.Errorf("graceful degradation line missing for check without excerpt: %q", got)
+	}
+}
+
+func TestFormatFailingCheckContext_EmptyWhenNoFailingChecks(t *testing.T) {
+	if got := formatFailingCheckContext(nil, failingCheckExcerptCapBytes); got != "" {
+		t.Errorf("no failing checks should yield empty context, got %q", got)
+	}
+	if got := formatFailingCheckContext([]github.FailingCheck{}, failingCheckExcerptCapBytes); got != "" {
+		t.Errorf("empty failing-check slice should yield empty context, got %q", got)
+	}
+}
+
+func TestFormatFailingCheckContext_RedactsSecrets(t *testing.T) {
+	// A raw secret that slipped into a check log must never reach the prompt.
+	// Build the github-token-shaped literal at RUNTIME so this source file never
+	// contains a contiguous secret pattern of its own — tripping the secret
+	// scanner with a fixture literal is the exact failure class #857 exists to
+	// stop (the PR #850 lint blindness).
+	secret := "ghp_" + strings.Repeat("A", 36)
+	checks := []github.FailingCheck{
+		{Name: "agent-lint", Conclusion: "failure", Excerpt: "leaked TOKEN=" + secret},
+	}
+	got := formatFailingCheckContext(checks, failingCheckExcerptCapBytes)
+	if strings.Contains(got, secret) {
+		t.Error("raw github token leaked into failing-check context")
+	}
+	if !strings.Contains(got, "REDACTED") {
+		t.Error("expected a redaction marker in the redacted excerpt")
+	}
+}
+
+func TestCapFailingCheckExcerpt_Enforced(t *testing.T) {
+	long := strings.Repeat("agent-lint error line that is fairly long\n", 500)
+	capped := capFailingCheckExcerpt(long, failingCheckExcerptCapBytes)
+	if len(capped) > failingCheckExcerptCapBytes {
+		t.Fatalf("capped excerpt = %d bytes, exceeds cap %d", len(capped), failingCheckExcerptCapBytes)
+	}
+	if !strings.Contains(capped, "truncated") {
+		t.Errorf("expected truncation marker, got tail %q", capped[max(0, len(capped)-80):])
+	}
+}
+
+func TestCapFailingCheckExcerpt_ShortInputUnchanged(t *testing.T) {
+	in := "agent-lint: 1 check failed"
+	if got := capFailingCheckExcerpt(in, failingCheckExcerptCapBytes); got != in {
+		t.Errorf("short input should pass through unchanged, got %q", got)
+	}
+}
+
+func TestFormatFailingCheckContext_CapEnforcedOnAssembled(t *testing.T) {
+	checks := []github.FailingCheck{
+		{Name: "agent-lint", Conclusion: "failure", Excerpt: strings.Repeat("error: boom\n", 1000)},
+	}
+	got := formatFailingCheckContext(checks, failingCheckExcerptCapBytes)
+	if len(got) > failingCheckExcerptCapBytes {
+		t.Fatalf("assembled context = %d bytes, exceeds cap %d", len(got), failingCheckExcerptCapBytes)
+	}
+}
+
+func TestAppendFailingCheckContext_AddsSection(t *testing.T) {
+	base := "You are a coding agent."
+	excerpt := "- agent-lint failed (conclusion: failure):\n    agent-lint: forbidden artifact committed"
+	result := appendFailingCheckContext(base, excerpt)
+
+	if !strings.Contains(result, "You are a coding agent.") {
+		t.Error("result should retain the original prompt base")
+	}
+	if !strings.Contains(result, "Failing Check on the Current PR Head") {
+		t.Error("result should contain the failing-check header")
+	}
+	if !strings.Contains(result, "agent-lint: forbidden artifact committed") {
+		t.Error("result should contain the excerpt")
+	}
+	if !strings.Contains(result, "hard constraint on the new diff") {
+		t.Error("result should frame the check as a constraint on the new diff")
+	}
+}
+
+// failingCheckOrchestrator builds an orchestrator whose respawn hooks record the
+// assembled prompt so an end-to-end respawn can be asserted against.
+func failingCheckOrchestrator(captured *string) *Orchestrator {
+	cfg := &config.Config{
+		Repo:               "owner/repo",
+		MaxRetriesPerIssue: 3,
+		MaxRetryBackoffMs:  300000,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}},
+		},
+	}
+	record := func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+		*captured = promptBase
+		sess.Status = state.StatusRunning
+		return nil
+	}
+	return &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "base prompt {{ISSUE_NUMBER}}",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: 42, Title: "test issue", Body: "fix this"}, nil
+		},
+		// Never treat the test PR/issue as merged/closed so the retry proceeds.
+		isPRMergedFn:     func(int) (bool, error) { return false, nil },
+		isIssueClosedFn:  func(int) (bool, error) { return false, nil },
+		respawnInPlaceFn: record,
+		respawnWorkerFn:  record,
+	}
+}
+
+// End-to-end through the respawn loop: a review-feedback retry whose head also
+// has a failing check carries BOTH the review-feedback section and a
+// failing-check section naming the check, and the excerpt is consumed.
+func TestRespawnDueRetries_ReviewFeedbackWithFailingCheck(t *testing.T) {
+	respawnedPrompt := ""
+	o := failingCheckOrchestrator(&respawnedPrompt)
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:                 42,
+		IssueTitle:                  "test issue",
+		Status:                      state.StatusDead,
+		RetryCount:                  1,
+		NextRetryAt:                 &retryAt,
+		Backend:                     "claude",
+		PRNumber:                    10,
+		Worktree:                    "/tmp/wt",
+		PreviousAttemptFeedback:     "Confidence 3/5\nP2: enabled flag inverted in bridge.rs",
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		FailingCheckContext:         "- agent-lint failed (conclusion: failure):\n    agent-lint: forbidden artifact committed",
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if respawnedPrompt == "" {
+		t.Fatal("respawnInPlaceFn should have been called")
+	}
+	if !strings.Contains(respawnedPrompt, "Code Review Findings") {
+		t.Error("prompt should contain the review feedback section")
+	}
+	if !strings.Contains(respawnedPrompt, "enabled flag inverted") {
+		t.Error("prompt should contain the review feedback content")
+	}
+	if !strings.Contains(respawnedPrompt, "Failing Check on the Current PR Head") {
+		t.Error("prompt should contain the failing-check section")
+	}
+	if !strings.Contains(respawnedPrompt, "agent-lint: forbidden artifact committed") {
+		t.Error("prompt should name the failing check and its excerpt")
+	}
+	// A review retry carries no CI-failure trigger section.
+	if strings.Contains(respawnedPrompt, "Previous CI Failure") {
+		t.Error("pure review retry should not include a CI-failure trigger section")
+	}
+
+	sess := s.Sessions["slot-1"]
+	if sess.FailingCheckContext != "" {
+		t.Errorf("FailingCheckContext should be consumed, got %q", sess.FailingCheckContext)
+	}
+}
+
+// No behavior change when the head has no failing check: the review retry omits
+// the failing-check section entirely.
+func TestRespawnDueRetries_ReviewFeedbackNoFailingCheck(t *testing.T) {
+	respawnedPrompt := ""
+	o := failingCheckOrchestrator(&respawnedPrompt)
+
+	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-1 * time.Minute)
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber:                 42,
+		IssueTitle:                  "test issue",
+		Status:                      state.StatusDead,
+		RetryCount:                  1,
+		NextRetryAt:                 &retryAt,
+		Backend:                     "claude",
+		PRNumber:                    10,
+		Worktree:                    "/tmp/wt",
+		PreviousAttemptFeedback:     "P2: rename helper",
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+		// FailingCheckContext intentionally empty.
+	}
+
+	o.respawnDueRetries(s, 10)
+
+	if respawnedPrompt == "" {
+		t.Fatal("respawnInPlaceFn should have been called")
+	}
+	if !strings.Contains(respawnedPrompt, "Code Review Findings") {
+		t.Error("prompt should still contain the review feedback section")
+	}
+	if strings.Contains(respawnedPrompt, "Failing Check on the Current PR Head") {
+		t.Error("no failing check present — the failing-check section must be omitted")
+	}
+}
+
+// handleReviewFeedbackRetry (the #424-unstable / non-required-check path)
+// captures a bounded failing-check excerpt when the PR head has one, and
+// captures nothing when all checks pass.
+func TestHandleReviewFeedbackRetry_CapturesFailingCheck(t *testing.T) {
+	newOrch := func(failing []github.FailingCheck) *Orchestrator {
+		return &Orchestrator{
+			cfg:      &config.Config{Repo: "owner/repo", MaxRetryBackoffMs: 300000},
+			notifier: &notify.Notifier{},
+			ghPRFailingChecksFn: func(prNumber int) ([]github.FailingCheck, error) {
+				return failing, nil
+			},
+		}
+	}
+
+	t.Run("failing check captured", func(t *testing.T) {
+		o := newOrch([]github.FailingCheck{
+			{Name: "agent-lint", Conclusion: "failure", Excerpt: "agent-lint: forbidden artifact committed"},
+		})
+		s := state.NewState()
+		sess := &state.Session{IssueNumber: 42, IssueTitle: "t", Worktree: "/tmp/wt"}
+		s.Sessions["slot-1"] = sess
+
+		o.handleReviewFeedbackRetry(s, "slot-1", sess, github.PR{Number: 10}, "P2: fix it")
+
+		if sess.PreviousAttemptFeedback != "P2: fix it" {
+			t.Errorf("review feedback not stored, got %q", sess.PreviousAttemptFeedback)
+		}
+		if !strings.Contains(sess.FailingCheckContext, "agent-lint failed (conclusion: failure)") {
+			t.Errorf("failing-check excerpt not captured, got %q", sess.FailingCheckContext)
+		}
+		if !strings.Contains(sess.FailingCheckContext, "forbidden artifact committed") {
+			t.Errorf("failing-check excerpt missing detail, got %q", sess.FailingCheckContext)
+		}
+	})
+
+	t.Run("all checks green captures nothing", func(t *testing.T) {
+		o := newOrch(nil)
+		s := state.NewState()
+		sess := &state.Session{IssueNumber: 42, IssueTitle: "t", Worktree: "/tmp/wt"}
+		s.Sessions["slot-1"] = sess
+
+		o.handleReviewFeedbackRetry(s, "slot-1", sess, github.PR{Number: 10}, "P2: fix it")
+
+		if sess.FailingCheckContext != "" {
+			t.Errorf("no failing check — FailingCheckContext must stay empty, got %q", sess.FailingCheckContext)
+		}
+	})
+
+	t.Run("fetch error degrades to no excerpt", func(t *testing.T) {
+		o := &Orchestrator{
+			cfg:      &config.Config{Repo: "owner/repo", MaxRetryBackoffMs: 300000},
+			notifier: &notify.Notifier{},
+			ghPRFailingChecksFn: func(prNumber int) ([]github.FailingCheck, error) {
+				return nil, errTestFetch
+			},
+		}
+		s := state.NewState()
+		sess := &state.Session{IssueNumber: 42, IssueTitle: "t", Worktree: "/tmp/wt"}
+		s.Sessions["slot-1"] = sess
+
+		o.handleReviewFeedbackRetry(s, "slot-1", sess, github.PR{Number: 10}, "P2: fix it")
+
+		if sess.FailingCheckContext != "" {
+			t.Errorf("fetch error should degrade to empty excerpt, got %q", sess.FailingCheckContext)
+		}
+		if sess.PreviousAttemptFeedback != "P2: fix it" {
+			t.Errorf("review retry should still proceed on fetch error, got %q", sess.PreviousAttemptFeedback)
+		}
+	})
+}
+
+// handleCIFailureRetry is the path a red REQUIRED check (e.g. agent-lint) really
+// takes — its failure conclusion makes the aggregate CI verdict "failure". This
+// is the case the PR #850 lint blindness hit, so the concrete failing-check
+// excerpt must be captured here too, not only in the review-feedback path
+// (#857, addressing the "success-only branch" review concern).
+func TestHandleCIFailureRetry_CapturesFailingCheck(t *testing.T) {
+	captureFor := func(failing []github.FailingCheck) *state.Session {
+		o := &Orchestrator{
+			cfg:                         &config.Config{Repo: "owner/repo", MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000},
+			notifier:                    &notify.Notifier{},
+			ghPRChecksOutputFn:          func(int) (string, error) { return "agent-lint\tfailure\nbuild\tsuccess\n", nil },
+			ghCollectPRReviewFeedbackFn: func(int) (string, error) { return "", nil },
+			ghPRFailingChecksFn:         func(int) ([]github.FailingCheck, error) { return failing, nil },
+			ghClosePRFn:                 func(int, string) error { return nil },
+			workerStopFn:                func(*config.Config, string, *state.Session) error { return nil },
+		}
+		s := state.NewState()
+		sess := &state.Session{IssueNumber: 42, IssueTitle: "t", Status: state.StatusPROpen, PRNumber: 10, Worktree: "/tmp/wt"}
+		s.Sessions["slot-1"] = sess
+		o.handleCIFailureRetry(s, "slot-1", sess, github.PR{Number: 10})
+		return sess
+	}
+
+	t.Run("red check excerpt captured alongside CI overview", func(t *testing.T) {
+		sess := captureFor([]github.FailingCheck{
+			{Name: "agent-lint", Conclusion: "failure", Excerpt: "agent-lint: forbidden artifact committed"},
+		})
+		if sess.CIFailureOutput == "" {
+			t.Error("existing CI-failure overview must still be captured (path unchanged)")
+		}
+		if !strings.Contains(sess.FailingCheckContext, "agent-lint failed (conclusion: failure)") {
+			t.Errorf("concrete failing-check excerpt not captured on CI-failure path, got %q", sess.FailingCheckContext)
+		}
+		if !strings.Contains(sess.FailingCheckContext, "forbidden artifact committed") {
+			t.Errorf("failing-check excerpt missing concrete detail, got %q", sess.FailingCheckContext)
+		}
+	})
+
+	t.Run("no failing check leaves excerpt empty", func(t *testing.T) {
+		sess := captureFor(nil)
+		if sess.FailingCheckContext != "" {
+			t.Errorf("no failing check — FailingCheckContext must stay empty, got %q", sess.FailingCheckContext)
+		}
+	})
+}
+
+var errTestFetch = errTest("boom")
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -131,6 +131,7 @@ type Orchestrator struct {
 	ghMergePRFn                  func(prNumber int) error
 	ghClosePRFn                  func(prNumber int, comment string) error
 	ghPRChecksOutputFn           func(prNumber int) (string, error)
+	ghPRFailingChecksFn          func(prNumber int) ([]github.FailingCheck, error)
 	ghCollectPRReviewFeedbackFn  func(prNumber int) (string, error)
 	ghCloseIssueFn               func(number int, comment string) error
 	ghPRHeadSHAFn                func(prNumber int) (string, error)
@@ -585,6 +586,30 @@ func (o *Orchestrator) collectPRReviewFeedback(prNumber int) (string, error) {
 		return o.ghCollectPRReviewFeedbackFn(prNumber)
 	}
 	return o.gh.CollectPRReviewFeedback(prNumber)
+}
+
+func (o *Orchestrator) prFailingChecks(prNumber int) ([]github.FailingCheck, error) {
+	if o.ghPRFailingChecksFn != nil {
+		return o.ghPRFailingChecksFn(prNumber)
+	}
+	if o.gh == nil {
+		return nil, fmt.Errorf("no github client configured for failing-checks")
+	}
+	return o.gh.PRFailingChecks(prNumber)
+}
+
+// collectFailingCheckContext fetches the check-runs still failing on a PR head
+// and renders a bounded, redacted excerpt for the retry prompt (#857).
+// Best-effort: a fetch error yields "" (no section) rather than blocking the
+// retry, and an all-green head yields "" so a retry with no red check is
+// unchanged.
+func (o *Orchestrator) collectFailingCheckContext(prNumber int) string {
+	checks, err := o.prFailingChecks(prNumber)
+	if err != nil {
+		log.Printf("[orch] warn: could not collect failing-check context for PR #%d: %v", prNumber, err)
+		return ""
+	}
+	return formatFailingCheckContext(checks, failingCheckExcerptCapBytes)
 }
 
 func (o *Orchestrator) closeIssue(number int, comment string) error {
@@ -1639,6 +1664,82 @@ Do NOT repeat the same mistakes.
 `, promptBase, feedback)
 }
 
+// failingCheckExcerptCapBytes hard-caps the failing-check excerpt placed in a
+// retry prompt, mirroring the post-mortem cap discipline from #835 so a verbose
+// lint log cannot crowd out the rest of the prompt.
+const failingCheckExcerptCapBytes = 2048
+
+const failingCheckTruncationMarker = "\n… (failing-check excerpt truncated for the prompt)"
+
+// formatFailingCheckContext assembles a bounded, secret-redacted excerpt naming
+// each check-run still failing on the PR head. Each check contributes its
+// distilled error lines; a check with no fetchable log degrades to its name and
+// conclusion only. The whole excerpt is redacted and then hard-capped. It
+// returns "" when nothing is failing, so the caller adds no section (#857).
+func formatFailingCheckContext(checks []github.FailingCheck, capBytes int) string {
+	var b strings.Builder
+	for _, ck := range checks {
+		name := strings.TrimSpace(ck.Name)
+		if name == "" {
+			name = "check"
+		}
+		conclusion := strings.TrimSpace(ck.Conclusion)
+		if conclusion == "" {
+			conclusion = "failure"
+		}
+		excerpt := strings.TrimSpace(ck.Excerpt)
+		if excerpt == "" {
+			fmt.Fprintf(&b, "- %s failed (conclusion: %s); no log excerpt available.\n", name, conclusion)
+			continue
+		}
+		fmt.Fprintf(&b, "- %s failed (conclusion: %s):\n", name, conclusion)
+		for _, line := range strings.Split(excerpt, "\n") {
+			line = strings.TrimRight(line, " \t\r")
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			fmt.Fprintf(&b, "    %s\n", line)
+		}
+	}
+	assembled := strings.TrimRight(b.String(), "\n")
+	if assembled == "" {
+		return ""
+	}
+	assembled = supervisor.RedactSensitive(assembled)
+	return capFailingCheckExcerpt(assembled, capBytes)
+}
+
+// capFailingCheckExcerpt bounds s to capBytes with a check-specific truncation
+// marker, delegating to the shared worker cap so it honors the same UTF-8 /
+// line-boundary discipline as the #835 post-mortem cap. capBytes <= 0 disables
+// the cap.
+func capFailingCheckExcerpt(s string, capBytes int) string {
+	return worker.CapWithMarker(s, capBytes, failingCheckTruncationMarker)
+}
+
+// appendFailingCheckContext appends a section naming the check-run(s) still
+// failing on the PR head, so a retry treats a red lint check as a hard
+// constraint on the new diff instead of only the review comments / bare checks
+// overview that triggered the retry (#857). excerpt is already bounded/redacted
+// by formatFailingCheckContext.
+func appendFailingCheckContext(promptBase, excerpt string) string {
+	return fmt.Sprintf(`%s
+
+---
+
+## IMPORTANT: Failing Check on the Current PR Head
+
+Besides any review or CI-failure context above, the following CI check(s) are
+FAILING on your PR's current head commit — your previous push did not make them
+pass. Treat this as a hard constraint on the new diff and do NOT reintroduce the
+same failure:
+
+%s
+
+Make the failing check(s) pass AND address any other feedback before you push again.
+`, promptBase, excerpt)
+}
+
 // appendPriorAttemptPostmortem appends a bounded, automatically-extracted
 // summary of the previous failed attempt's own worker-log trajectory (#835).
 // It sits alongside — not in place of — the CI/review/conflict context, so the
@@ -1907,6 +2008,16 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 			}
 			sess.PreviousAttemptFeedback = "" // consumed — don't persist stale feedback
 			sess.PreviousAttemptFeedbackKind = ""
+		}
+		// #857: a retry whose PR head also has a red check (e.g. agent-lint)
+		// carries a bounded excerpt of that check alongside — not in place of —
+		// the CI/review context above, so the worker fixes the lint failure its
+		// previous push introduced instead of only the review P1s / bare
+		// checks-overview. Populated by both the CI-failure and review-feedback
+		// retry handlers; consumed here regardless of which path scheduled it.
+		if sess.FailingCheckContext != "" {
+			promptBase = appendFailingCheckContext(promptBase, sess.FailingCheckContext)
+			sess.FailingCheckContext = "" // consumed — don't persist stale excerpt
 		}
 
 		// #835: append a bounded post-mortem distilled from the previous
@@ -4171,6 +4282,13 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 	sess.PreviousAttemptFeedback = reviewFeedback
 	sess.PreviousAttemptFeedbackKind = state.RetryReasonReviewFeedback
 	sess.RetryReason = state.RetryReasonReviewFeedback
+	// #857: a review-feedback retry is scheduled off a green aggregate CI, but
+	// an individual non-required check (e.g. agent-lint) can still be red on the
+	// PR head — the #424 mergeable_state=unstable override treats that as
+	// "success" and routes here. Capture a bounded excerpt so the respawned
+	// worker also sees the failing check its previous push introduced, not just
+	// the review comments.
+	sess.FailingCheckContext = o.collectFailingCheckContext(pr.Number)
 
 	sess.MaintenanceRetryCount++
 	backoffMs := retryBackoffMs(sess.MaintenanceRetryCount, o.cfg.MaxRetryBackoffMs)
@@ -4226,6 +4344,15 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 		log.Printf("[orch] warn: could not collect review feedback for PR #%d: %v", pr.Number, err)
 	}
 
+	// #857: this is the path a red required check (e.g. agent-lint) actually
+	// takes — its failure conclusion makes the aggregate CI verdict "failure".
+	// CIFailureOutput above is only the bare checks overview (name + state); the
+	// concrete `##[error]` annotation lines that say WHY the check failed live
+	// here. Capture them before closing the PR so the retry worker sees the
+	// exact lint constraint its previous push broke, not just "agent-lint
+	// failed" — this was the observed PR #850 blindness.
+	failingCheckContext := o.collectFailingCheckContext(pr.Number)
+
 	// Close the failed PR with an explanation
 	closeComment := fmt.Sprintf("CI failed — maestro is closing this PR and respawning a new worker to retry (attempt %d).\n\nCI output:\n```\n%s\n```",
 		sess.RetryCount+1, ciOutput)
@@ -4241,6 +4368,7 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 
 	// Store CI failure output and review feedback for the next worker
 	sess.CIFailureOutput = ciOutput
+	sess.FailingCheckContext = failingCheckContext // #857: concrete failing-check error lines, alongside the overview
 	sess.PreviousAttemptFeedback = reviewFeedback
 	if strings.TrimSpace(reviewFeedback) != "" {
 		sess.PreviousAttemptFeedbackKind = "review_feedback"
@@ -5246,6 +5374,7 @@ func (o *Orchestrator) handleRebaseConflictRetry(s *state.State, slotName string
 	}
 
 	sess.CIFailureOutput = ""
+	sess.FailingCheckContext = "" // #857: rebase-conflict retry carries no failing-check excerpt
 	sess.PreviousAttemptFeedback = rebaseConflictFeedback(prNumber, cause)
 	sess.PreviousAttemptFeedbackKind = "rebase_conflict"
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -214,6 +214,7 @@ type Session struct {
 	ValidationFails             int               `json:"validation_fails,omitempty"`               // number of failed validation attempts
 	ValidationFeedback          string            `json:"validation_feedback,omitempty"`            // feedback from last failed validation
 	CIFailureOutput             string            `json:"ci_failure_output,omitempty"`              // CI failure output captured before retry (passed to next worker as context)
+	FailingCheckContext         string            `json:"failing_check_context,omitempty"`          // #857: bounded excerpt of a check-run still failing on the PR head, carried into a retry so the worker sees the red check its previous push introduced (consumed on respawn)
 	PreviousAttemptFeedback     string            `json:"previous_attempt_feedback,omitempty"`      // feedback from previous failed PR attempt
 	PreviousAttemptFeedbackKind string            `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
 	RetryReason                 string            `json:"retry_reason,omitempty"`                   // current retry lifecycle reason, e.g. review_feedback

--- a/internal/worker/postmortem.go
+++ b/internal/worker/postmortem.go
@@ -620,6 +620,16 @@ const postmortemTruncationMarker = "\n\n… (post-mortem truncated for the promp
 // lands on a line boundary where possible and always yields valid UTF-8.
 // capBytes <= 0 disables the cap.
 func CapPostmortem(s string, capBytes int) string {
+	return CapWithMarker(s, capBytes, postmortemTruncationMarker)
+}
+
+// CapWithMarker hard-caps s to capBytes, appending marker (whose byte length is
+// reserved out of the budget, so content+marker never exceeds capBytes) when it
+// has to cut. Truncation lands on a line boundary where possible and always
+// yields valid UTF-8. capBytes <= 0 disables the cap. Shared by CapPostmortem
+// (#835) and the orchestrator's failing-check excerpt cap (#857) so both honor
+// the same truncation discipline with their own marker text.
+func CapWithMarker(s string, capBytes int, marker string) string {
 	if capBytes <= 0 || len(s) <= capBytes {
 		return s
 	}
@@ -633,7 +643,7 @@ func CapPostmortem(s string, capBytes int) string {
 	// Reserve room for the marker so content+marker stays within capBytes. When
 	// the cap is too small to fit the marker at all, fall back to a marker-free
 	// excerpt bounded to a rune boundary (never grows past capBytes).
-	budget := capBytes - len(postmortemTruncationMarker)
+	budget := capBytes - len(marker)
 	if budget <= 0 {
 		return truncateToRuneBoundary(s, capBytes)
 	}
@@ -641,7 +651,7 @@ func CapPostmortem(s string, capBytes int) string {
 	if idx := strings.LastIndexByte(truncated, '\n'); idx > 0 {
 		truncated = truncated[:idx]
 	}
-	return strings.TrimRight(truncated, "\n") + postmortemTruncationMarker
+	return strings.TrimRight(truncated, "\n") + marker
 }
 
 // truncateToRuneBoundary returns the longest prefix of s that is at most


### PR DESCRIPTION
Implements #857

## Problem
When a PR head has both review feedback and a failing check (e.g. agent-lint), the retry prompt carried only the triggering signal — the failing check's concrete error lines never reached the worker, so retries fixed review P1s and reintroduced the same secret-scanner lint failure blind (observed twice on PR #850).

## Changes
- `github.PRFailingChecks`: returns each red check-run on the PR head with a best-effort excerpt (output `::error::` lines, falling back to failure annotations); an unfetchable log degrades to name + conclusion only.
- `github`: the annotations endpoint is a plain JSON array, so it is parsed through `mergePaginatedJSONArrays` — a check-run with more than one page of annotations no longer fails to parse and silently drop the excerpt.
- `orchestrator`: capture the bounded, secret-redacted excerpt in **both** retry handlers and consume it path-agnostically in `respawnDueRetries`, alongside (not in place of) the existing review/CI context. Rebase-conflict retries carry none.
- `worker`: the #835 post-mortem cap is extracted into a shared `CapWithMarker`, so the excerpt honors the same UTF-8 / line-boundary truncation discipline.

## Note on retry routing (addresses prior review)
A red **required** check makes the aggregate CI verdict `failure`, which routes through `handleCIFailureRetry` — so the excerpt is captured there (the real lint-blindness case), not only on the review-feedback path. A non-required red check reaching the review-feedback path via the existing `mergeable_state=unstable` override (#424) is captured too. This is why capture lives in both handlers.

## Testing
- `go build ./cmd/maestro/`
- `go test ./...` (all packages pass)
- New unit tests: combined review+lint assembly, cap enforcement, graceful degradation, paginated-annotation merge, and excerpt capture on both the CI-failure and review-feedback retry paths.

Note: this changes orchestrator respawn-prompt assembly; the end-to-end retry behavior is exercised by unit tests but benefits from live confirmation on a real red-check PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds failing check details to retry prompts. The main changes are:

- Collect failing check-runs from the PR head with best-effort excerpts.
- Fall back from generic runner output to failure annotations.
- Carry bounded, redacted check context through CI and review retry paths.
- Reuse the worker truncation helper for failing-check excerpts.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The build proof shows that the command go build ./cmd/maestro/ ran in the expected directory and returned EXIT\_CODE: 0.
- The test proof shows that the command go test ./... ran in the expected directory and returned EXIT\_CODE: 0, indicating all packages passed.

<a href="https://app.greptile.com/trex/runs/13949607/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds failing check collection, annotation fallback, pagination parsing, and generic runner-output detection. |
| internal/orchestrator/orchestrator.go | Captures failing-check context in retry handlers and appends it to respawn prompts. |
| internal/state/state.go | Persists failing-check context on sessions until the retry prompt consumes it. |
| internal/worker/postmortem.go | Extracts the prompt cap helper so failing-check excerpts share the existing truncation behavior. |

<sub>Reviews (2): Last reviewed commit: ["github: fall through to annotations when..."](https://github.com/befeast/maestro/commit/2e7baff52aee2aeaca0646540af9506baa5461c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43230209)</sub>

<!-- /greptile_comment -->