### PR TITLE
Orchestrator: retry_exhausted sessions on closed PRs never reconcile (stuck 'waiting for reconciliation', hold issue slots) (#818)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1372,8 +1372,9 @@ func (o *Orchestrator) projectBoardSweepDue(now time.Time) bool {
 //     whether the outcome contract requires deploy)
 //   - done                  => Done
 //   - retry_exhausted /
-//     conflict_failed /
-//     failed                => Blocked
+//     conflict_failed       => Blocked
+//   - failed                => Blocked, unless ReleasedForRedispatch (#818),
+//     which maps to Todo so a released-for-fresh-dispatch issue stays runnable
 //   - dead with no retry    => Blocked
 //   - dead awaiting retry   => In Progress (work is still active)
 func projectStatusForSession(sess *state.Session, requiresDeploy bool) (github.ProjectStatus, bool) {
@@ -1389,7 +1390,19 @@ func projectStatusForSession(sess *state.Session, requiresDeploy bool) (github.P
 		return codeLandedProjectStatusForSession(sess, requiresDeploy), true
 	case state.StatusDone:
 		return github.ProjectStatusDone, true
-	case state.StatusRetryExhausted, state.StatusConflictFailed, state.StatusFailed:
+	case state.StatusRetryExhausted, state.StatusConflictFailed:
+		return github.ProjectStatusBlocked, true
+	case state.StatusFailed:
+		// #818: a closed-unmerged retry_exhausted session is settled failed to
+		// release its issue for fresh dispatch. Mirror that released session as
+		// runnable Todo, not Blocked — otherwise reconcileSessionsToProjectBoard
+		// would re-push Blocked over the Todo the reconcile set, and the dynamic
+		// wave (which treats Blocked as non-runnable) would re-strand the issue
+		// instead of re-dispatching it. Genuinely-failed sessions still map to
+		// Blocked.
+		if sess.ReleasedForRedispatch {
+			return github.ProjectStatusTodo, true
+		}
 		return github.ProjectStatusBlocked, true
 	case state.StatusDead:
 		if sess.NextRetryAt != nil {
@@ -4089,6 +4102,13 @@ func mergeFlowPRForSession(sess *state.Session, byBranch map[string]github.PR, b
 // or re-notify, and so the "waiting for reconciliation" log stops firing.
 const noPRReconciledStatus = "no_pr_reconciled"
 
+// closedPRCloseRetryStatus marks a merged-PR retry_exhausted session whose
+// auto-close hit a transient GitHub failure. The session stays retry_exhausted
+// so the next cycle retries the close instead of settling done with the issue
+// still open (#818 follow-up); the marker suppresses re-posting the close
+// comment and re-notifying on each retry.
+const closedPRCloseRetryStatus = "closed_pr_close_retry"
+
 // reconcileNoPRRetryExhausted handles the #577 deadlock: a worker exhausted
 // retries without opening a PR (often because the issue was already
 // implemented by a prior merge via `Refs #N`), so the merge flow has nothing
@@ -4182,13 +4202,18 @@ func (o *Orchestrator) reconcileNoPRRetryExhausted(slotName string, sess *state.
 //   - merged PR → StatusDone. The work landed, so the session settles done
 //     (SessionAttentionForAt no longer flags it, SessionLive → false) and the
 //     issue is auto-closed when close_issue is a safe action, otherwise
-//     surfaced as an operator close-candidate.
-//   - closed-unmerged PR → StatusFailed with the recorded PR cleared. This
-//     drops IssueRetryExhausted for the issue and makes the attempt count via
-//     FailedAttemptsForIssue, so the dispatch loop re-picks the issue for a
-//     fresh worker while it stays under max_retries_per_issue. No blocked
-//     label is applied: only the supervisor removes that label, so labelling
-//     blocked would re-create the exact supervisor-dependence #818 removes.
+//     surfaced as an operator close-candidate. A *transient* close failure is
+//     the exception: the session is left retry_exhausted so the next cycle
+//     retries the close, rather than settling done with the issue still open.
+//   - closed-unmerged PR → StatusFailed with the recorded PR cleared and
+//     ReleasedForRedispatch set. Clearing the PR drops IssueRetryExhausted for
+//     the issue and makes the attempt count via FailedAttemptsForIssue, so the
+//     dispatch loop re-picks the issue for a fresh worker while it stays under
+//     max_retries_per_issue. The marker keeps the released session mirrored as
+//     runnable Todo on the board (projectStatusForSession) instead of Blocked,
+//     so the reconcile does not re-strand it. No blocked label is applied:
+//     only the supervisor removes that label, so labelling blocked would
+//     re-create the exact supervisor-dependence #818 removes.
 func (o *Orchestrator) reconcileClosedPRRetryExhausted(slotName string, sess *state.Session) {
 	if sess == nil || sess.IssueNumber <= 0 || sess.PRNumber <= 0 {
 		return
@@ -4206,21 +4231,32 @@ func (o *Orchestrator) reconcileClosedPRRetryExhausted(slotName string, sess *st
 	now := time.Now().UTC()
 
 	if merged {
-		comment := fmt.Sprintf("Maestro: closing this issue because worker session %s exhausted retries, but its PR #%d was merged.", slotName, sess.PRNumber)
 		if o.supervisorActionAllowed(config.SupervisorActionCloseIssue) && !o.supervisorActionRequiresApproval(config.SupervisorActionCloseIssue) {
+			// Post the close comment only on the first attempt; a retry after a
+			// transient close failure passes an empty comment so it does not
+			// spam the issue with a duplicate close note (CloseIssue skips the
+			// comment when it is empty).
+			comment := ""
+			if sess.LastNotifiedStatus != closedPRCloseRetryStatus {
+				comment = fmt.Sprintf("Maestro: closing this issue because worker session %s exhausted retries, but its PR #%d was merged.", slotName, sess.PRNumber)
+			}
 			if cerr := o.closeIssue(sess.IssueNumber, comment); cerr != nil {
-				log.Printf("[orch] closed-PR retry_exhausted: auto-close failed for issue #%d (slot %s, PR #%d): %v", sess.IssueNumber, slotName, sess.PRNumber, cerr)
-				if o.notifier != nil {
-					o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted (PR #%d merged); auto-close failed: %v", sess.IssueNumber, sess.PRNumber, cerr)
+				// Transient close failure: do NOT settle the session done, or
+				// the issue can stay open permanently — the retry_exhausted
+				// session would leave the merge flow and the close would never
+				// be retried (#818 follow-up). Leave it retry_exhausted so the
+				// next cycle retries the close; mark it so the retry does not
+				// re-post the comment or re-notify.
+				log.Printf("[orch] closed-PR retry_exhausted: auto-close failed for issue #%d (slot %s, PR #%d): %v — leaving retry_exhausted to retry close next cycle", sess.IssueNumber, slotName, sess.PRNumber, cerr)
+				if o.notifier != nil && sess.LastNotifiedStatus != closedPRCloseRetryStatus {
+					o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted (PR #%d merged); auto-close failed: %v — will retry", sess.IssueNumber, sess.PRNumber, cerr)
 				}
-				// Best-effort: even if the close API hiccupped, the PR is
-				// merged, so settle the session done below rather than leave it
-				// live forever waiting on a comment call.
-			} else {
-				log.Printf("[orch] closed-PR retry_exhausted: auto-closed issue #%d (slot %s, PR #%d merged)", sess.IssueNumber, slotName, sess.PRNumber)
-				if o.notifier != nil {
-					o.notifier.Sendf("✅ maestro: closed issue #%d after retry_exhausted (PR #%d merged)", sess.IssueNumber, sess.PRNumber)
-				}
+				sess.LastNotifiedStatus = closedPRCloseRetryStatus
+				return
+			}
+			log.Printf("[orch] closed-PR retry_exhausted: auto-closed issue #%d (slot %s, PR #%d merged)", sess.IssueNumber, slotName, sess.PRNumber)
+			if o.notifier != nil {
+				o.notifier.Sendf("✅ maestro: closed issue #%d after retry_exhausted (PR #%d merged)", sess.IssueNumber, sess.PRNumber)
 			}
 		} else {
 			log.Printf("[orch] closed-PR retry_exhausted: issue #%d (slot %s) PR #%d was merged — surfaced as operator close-candidate", sess.IssueNumber, slotName, sess.PRNumber)
@@ -4248,6 +4284,14 @@ func (o *Orchestrator) reconcileClosedPRRetryExhausted(slotName string, sess *st
 	sess.LastClosedPRNumber = sess.PRNumber
 	sess.PRNumber = 0
 	sess.Status = state.StatusFailed
+	// #818: mark the session so projectStatusForSession mirrors it as runnable
+	// Todo rather than Blocked. Otherwise reconcileSessionsToProjectBoard maps
+	// this fresh StatusFailed session to Blocked and overwrites the Todo synced
+	// above — and because the fresh worker may not start in the same cycle (no
+	// slots, pause/drain/emergency halt, backend dispatch pause), the dynamic
+	// wave would then see Blocked (non-runnable) and re-strand the released
+	// issue instead of dispatching it.
+	sess.ReleasedForRedispatch = true
 	sess.FinishedAt = &now
 	state.MarkWorkerEnded(sess, now)
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4171,21 +4171,39 @@ func (o *Orchestrator) reconcileNoPRRetryExhausted(slotName string, sess *state.
 // reconcileClosedPRRetryExhausted handles retry_exhausted sessions whose PR
 // is no longer open (#818). The PR was either merged by another path or
 // closed without merge. Without this reconciliation the session sat in
-// retry_exhausted forever logging "waiting for reconciliation", which held
-// the issue slot and stalled the dynamic-wave queue at max_parallel=1.
+// retry_exhausted forever: reported live (SessionAttentionForAt marks
+// retry_exhausted+PRNumber>0 as needs_attention/actionable), holding the
+// issue slot (IssueRetryExhausted stays true), logging "waiting for
+// reconciliation" every cycle, and surviving daemon restarts.
+//
+// The fix transitions the *session status* out of retry_exhausted so it stops
+// being reported live and releases the issue slot without any supervisor:
+//
+//   - merged PR → StatusDone. The work landed, so the session settles done
+//     (SessionAttentionForAt no longer flags it, SessionLive → false) and the
+//     issue is auto-closed when close_issue is a safe action, otherwise
+//     surfaced as an operator close-candidate.
+//   - closed-unmerged PR → StatusFailed with the recorded PR cleared. This
+//     drops IssueRetryExhausted for the issue and makes the attempt count via
+//     FailedAttemptsForIssue, so the dispatch loop re-picks the issue for a
+//     fresh worker while it stays under max_retries_per_issue. No blocked
+//     label is applied: only the supervisor removes that label, so labelling
+//     blocked would re-create the exact supervisor-dependence #818 removes.
 func (o *Orchestrator) reconcileClosedPRRetryExhausted(slotName string, sess *state.Session) {
 	if sess == nil || sess.IssueNumber <= 0 || sess.PRNumber <= 0 {
-		return
-	}
-	if sess.LastNotifiedStatus == noPRReconciledStatus {
 		return
 	}
 
 	merged, err := o.isPRMerged(sess.PRNumber)
 	if err != nil {
+		// Outcome unknown on a transient GitHub failure — leave the session in
+		// retry_exhausted and try again next cycle rather than settling it
+		// on a guess.
 		log.Printf("[orch] closed-PR retry_exhausted: could not check if PR #%d was merged for issue #%d (slot %s): %v", sess.PRNumber, sess.IssueNumber, slotName, err)
 		return
 	}
+
+	now := time.Now().UTC()
 
 	if merged {
 		comment := fmt.Sprintf("Maestro: closing this issue because worker session %s exhausted retries, but its PR #%d was merged.", slotName, sess.PRNumber)
@@ -4195,39 +4213,43 @@ func (o *Orchestrator) reconcileClosedPRRetryExhausted(slotName string, sess *st
 				if o.notifier != nil {
 					o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted (PR #%d merged); auto-close failed: %v", sess.IssueNumber, sess.PRNumber, cerr)
 				}
-				return
+				// Best-effort: even if the close API hiccupped, the PR is
+				// merged, so settle the session done below rather than leave it
+				// live forever waiting on a comment call.
+			} else {
+				log.Printf("[orch] closed-PR retry_exhausted: auto-closed issue #%d (slot %s, PR #%d merged)", sess.IssueNumber, slotName, sess.PRNumber)
+				if o.notifier != nil {
+					o.notifier.Sendf("✅ maestro: closed issue #%d after retry_exhausted (PR #%d merged)", sess.IssueNumber, sess.PRNumber)
+				}
 			}
-			log.Printf("[orch] closed-PR retry_exhausted: auto-closed issue #%d (slot %s, PR #%d merged)", sess.IssueNumber, slotName, sess.PRNumber)
-			if o.notifier != nil {
-				o.notifier.Sendf("✅ maestro: closed issue #%d after retry_exhausted (PR #%d merged)", sess.IssueNumber, sess.PRNumber)
-			}
-			o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
 		} else {
 			log.Printf("[orch] closed-PR retry_exhausted: issue #%d (slot %s) PR #%d was merged — surfaced as operator close-candidate", sess.IssueNumber, slotName, sess.PRNumber)
 			if o.notifier != nil {
 				o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted; PR #%d was merged — operator close-candidate", sess.IssueNumber, sess.PRNumber)
 			}
 		}
-	} else {
-		if blockedLabel := strings.TrimSpace(o.cfg.Supervisor.BlockedLabel); blockedLabel != "" {
-			if lerr := o.addIssueLabel(sess.IssueNumber, blockedLabel); lerr != nil {
-				log.Printf("[orch] closed-PR retry_exhausted: could not add %q label to issue #%d (slot %s): %v", blockedLabel, sess.IssueNumber, slotName, lerr)
-				if o.notifier != nil {
-					o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted (PR #%d closed); could not apply %q label: %v", sess.IssueNumber, sess.PRNumber, blockedLabel, lerr)
-				}
-				return
-			}
-			log.Printf("[orch] closed-PR retry_exhausted: labelled issue #%d %q (slot %s, PR #%d closed without merge)", sess.IssueNumber, blockedLabel, slotName, sess.PRNumber)
-		} else {
-			log.Printf("[orch] closed-PR retry_exhausted: issue #%d (slot %s) PR #%d closed without merge — operator review required (no blocked_label configured)", sess.IssueNumber, slotName, sess.PRNumber)
-		}
-		if o.notifier != nil {
-			o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted (PR #%d closed without merge) — needs operator review", sess.IssueNumber, sess.PRNumber)
-		}
-		o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
+		o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
+		sess.Status = state.StatusDone
+		sess.FinishedAt = &now
+		state.MarkWorkerEnded(sess, now)
+		return
 	}
 
-	sess.LastNotifiedStatus = noPRReconciledStatus
+	// PR closed without merge: release the issue for fresh dispatch. Marking
+	// the session failed and clearing the recorded PR drops
+	// IssueRetryExhausted for the issue and makes FailedAttemptsForIssue count
+	// this attempt, so the dispatch loop re-picks the issue (subject to
+	// max_retries_per_issue) without any supervisor un-block step.
+	log.Printf("[orch] closed-PR retry_exhausted: PR #%d closed without merge for issue #%d (slot %s) — marking session failed and releasing issue for fresh dispatch (subject to max_retries_per_issue)", sess.PRNumber, sess.IssueNumber, slotName)
+	if o.notifier != nil {
+		o.notifier.Sendf("🔁 maestro: issue #%d retry_exhausted (PR #%d closed without merge) — released for fresh dispatch (subject to max_retries)", sess.IssueNumber, sess.PRNumber)
+	}
+	o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+	sess.LastClosedPRNumber = sess.PRNumber
+	sess.PRNumber = 0
+	sess.Status = state.StatusFailed
+	sess.FinishedAt = &now
+	state.MarkWorkerEnded(sess, now)
 }
 
 // handleReviewFeedbackRetry schedules a retry worker with review feedback in

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9809,9 +9809,12 @@ func TestAutoMergePRs_NoPRRetryExhaustedHasMergedPRErrorDefersReconcile(t *testi
 }
 
 // #818: a retry_exhausted session whose PR was closed without merge must be
-// labelled blocked so the dynamic-wave queue advances instead of logging
-// "waiting for reconciliation" forever.
-func TestAutoMergePRs_ClosedPRRetryExhaustedAppliesBlockedLabel(t *testing.T) {
+// released for fresh dispatch. The session goes terminal (failed) with its
+// recorded PR cleared, which drops the IssueRetryExhausted slot-hold and makes
+// the attempt count via FailedAttemptsForIssue (so re-dispatch stays subject to
+// max_retries_per_issue). No blocked label is applied: only the supervisor
+// removes that label, and #818 must clear without the supervisor.
+func TestAutoMergePRs_ClosedPRRetryExhaustedReleasesIssueForFreshDispatch(t *testing.T) {
 	cfg := &config.Config{
 		Repo: "owner/repo",
 		Supervisor: config.SupervisorConfig{
@@ -9842,25 +9845,50 @@ func TestAutoMergePRs_ClosedPRRetryExhaustedAppliesBlockedLabel(t *testing.T) {
 
 	o.autoMergePRs(s)
 
-	if got, want := addedLabels[500], "blocked"; got != want {
-		t.Fatalf("issue #500 label = %q, want %q (closed-PR retry_exhausted must mark blocked)", got, want)
+	if len(addedLabels) != 0 {
+		t.Fatalf("blocked label applied %v, want none (closed-PR retry_exhausted must release, not block)", addedLabels)
 	}
 	sess := s.Sessions["sup-20"]
-	if sess.LastNotifiedStatus != noPRReconciledStatus {
-		t.Fatalf("LastNotifiedStatus = %q, want %q (reconciler must mark idempotent)", sess.LastNotifiedStatus, noPRReconciledStatus)
+	if sess.Status != state.StatusFailed {
+		t.Fatalf("status = %q, want %q (closed-unmerged retry_exhausted must go failed)", sess.Status, state.StatusFailed)
+	}
+	if sess.PRNumber != 0 {
+		t.Fatalf("PRNumber = %d, want 0 (closed PR must be cleared so the attempt counts and the issue re-dispatches)", sess.PRNumber)
+	}
+	if sess.LastClosedPRNumber != 218 {
+		t.Fatalf("LastClosedPRNumber = %d, want 218", sess.LastClosedPRNumber)
+	}
+	if sess.FinishedAt == nil {
+		t.Fatalf("FinishedAt must be set on a reconciled terminal session")
+	}
+	if s.IssueRetryExhausted(500) {
+		t.Fatalf("issue #500 still retry-exhausted; slot not released")
+	}
+	if got := s.FailedAttemptsForIssue(500); got != 1 {
+		t.Fatalf("FailedAttemptsForIssue(500) = %d, want 1 (attempt must count toward max_retries_per_issue)", got)
+	}
+	// The released session ages out of the live window instead of staying live
+	// forever (#818 / no permanent "waiting for reconciliation" state).
+	aged := sess.FinishedAt.Add(state.LiveSessionRecentWindow + time.Hour)
+	if state.SessionLiveAt(sess, aged) {
+		t.Fatalf("failed session still live after the aging window; must not be a permanent live state")
 	}
 
-	// Second cycle must NOT re-apply.
+	// Second cycle is a structural no-op: a failed session is not merge-flow
+	// eligible, so the reconciler does not run again.
 	clear(addedLabels)
 	o.autoMergePRs(s)
 	if len(addedLabels) != 0 {
-		t.Fatalf("second cycle re-applied labels = %v, want none (idempotency)", addedLabels)
+		t.Fatalf("second cycle applied labels = %v, want none (idempotency)", addedLabels)
+	}
+	if s.Sessions["sup-20"].Status != state.StatusFailed {
+		t.Fatalf("second cycle changed status to %q, want failed (idempotency)", s.Sessions["sup-20"].Status)
 	}
 }
 
-// #818: a retry_exhausted session whose PR was merged must auto-close the
-// issue when close_issue is a safe action, or surface as close-candidate
-// when it requires approval.
+// #818: a retry_exhausted session whose PR was merged settles the session done
+// (so it stops being reported live/needs_attention and releases the slot) and
+// auto-closes the issue when close_issue is a safe action.
 func TestAutoMergePRs_ClosedPRRetryExhaustedAutoClosesWhenMerged(t *testing.T) {
 	cfg := &config.Config{
 		Repo: "owner/repo",
@@ -9902,15 +9930,32 @@ func TestAutoMergePRs_ClosedPRRetryExhaustedAutoClosesWhenMerged(t *testing.T) {
 		t.Fatalf("issue #501 not auto-closed; closed=%v (merged PR + close_issue safe action must close)", closed)
 	}
 	if labelled != 0 {
-		t.Fatalf("blocked label applied %d times, want 0 (auto-close branch must not label)", labelled)
+		t.Fatalf("blocked label applied %d times, want 0 (merged branch must not label)", labelled)
 	}
-	if sess := s.Sessions["sup-22"]; sess.LastNotifiedStatus != noPRReconciledStatus {
-		t.Fatalf("LastNotifiedStatus = %q, want %q", sess.LastNotifiedStatus, noPRReconciledStatus)
+	sess := s.Sessions["sup-22"]
+	if sess.Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q (merged retry_exhausted must settle done)", sess.Status, state.StatusDone)
+	}
+	if sess.FinishedAt == nil {
+		t.Fatalf("FinishedAt must be set on a settled-done session")
+	}
+	if s.IssueRetryExhausted(501) {
+		t.Fatalf("issue #501 still retry-exhausted after merge; slot not released")
+	}
+	// A done session no longer flags for attention and ages out of the live
+	// window — it is not a permanent live/needs_attention state (#818).
+	if state.SessionAttentionForAt(sess, nil, *sess.FinishedAt).NeedsAttention {
+		t.Fatalf("done session must not need attention")
+	}
+	aged := sess.FinishedAt.Add(state.LiveSessionRecentWindow + time.Hour)
+	if state.SessionLiveAt(sess, aged) {
+		t.Fatalf("done session still live after the aging window; must not be a permanent live state")
 	}
 }
 
-// #818: a transient GitHub failure when checking if the PR was merged must
-// NOT mark the session reconciled.
+// #818: a transient GitHub failure when checking if the PR was merged must NOT
+// transition the session — it stays retry_exhausted so reconcile retries next
+// cycle rather than settling the outcome on a guess.
 func TestAutoMergePRs_ClosedPRRetryExhaustedMergeCheckErrorDefersReconcile(t *testing.T) {
 	cfg := &config.Config{
 		Repo: "owner/repo",
@@ -9941,8 +9986,12 @@ func TestAutoMergePRs_ClosedPRRetryExhaustedMergeCheckErrorDefersReconcile(t *te
 
 	o.autoMergePRs(s)
 
-	if sess := s.Sessions["sup-24"]; sess.LastNotifiedStatus == noPRReconciledStatus {
-		t.Fatalf("transient probe failure must not mark reconciled; LastNotifiedStatus=%q", sess.LastNotifiedStatus)
+	sess := s.Sessions["sup-24"]
+	if sess.Status != state.StatusRetryExhausted {
+		t.Fatalf("status = %q, want %q (transient probe failure must not transition the session)", sess.Status, state.StatusRetryExhausted)
+	}
+	if sess.PRNumber != 221 {
+		t.Fatalf("PRNumber = %d, want 221 (must not be cleared on probe failure)", sess.PRNumber)
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -8126,6 +8126,7 @@ func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
 		{name: "retry_exhausted -> blocked", sess: &state.Session{IssueNumber: 6, Status: state.StatusRetryExhausted}, want: github.ProjectStatusBlocked, wantOK: true},
 		{name: "conflict_failed -> blocked", sess: &state.Session{IssueNumber: 7, Status: state.StatusConflictFailed}, want: github.ProjectStatusBlocked, wantOK: true},
 		{name: "failed -> blocked", sess: &state.Session{IssueNumber: 8, Status: state.StatusFailed}, want: github.ProjectStatusBlocked, wantOK: true},
+		{name: "failed+released -> todo", sess: &state.Session{IssueNumber: 8, Status: state.StatusFailed, ReleasedForRedispatch: true}, want: github.ProjectStatusTodo, wantOK: true},
 		{name: "dead awaiting retry stays in_progress", sess: &state.Session{IssueNumber: 9, Status: state.StatusDead, NextRetryAt: &soon}, want: github.ProjectStatusInProgress, wantOK: true},
 		{name: "dead without retry -> blocked", sess: &state.Session{IssueNumber: 10, Status: state.StatusDead}, want: github.ProjectStatusBlocked, wantOK: true},
 		{name: "unknown status returns no mapping", sess: &state.Session{IssueNumber: 11, Status: state.SessionStatus("weird")}, want: "", wantOK: false},
@@ -9858,6 +9859,16 @@ func TestAutoMergePRs_ClosedPRRetryExhaustedReleasesIssueForFreshDispatch(t *tes
 	if sess.LastClosedPRNumber != 218 {
 		t.Fatalf("LastClosedPRNumber = %d, want 218", sess.LastClosedPRNumber)
 	}
+	if !sess.ReleasedForRedispatch {
+		t.Fatalf("ReleasedForRedispatch = false, want true (released session must mirror as runnable Todo, not Blocked)")
+	}
+	// #818: the released StatusFailed session must map to a runnable board
+	// status. Otherwise reconcileSessionsToProjectBoard re-pushes Blocked over
+	// the Todo the reconcile set, and the dynamic wave (Blocked = non-runnable)
+	// re-strands the issue when a fresh worker does not start the same cycle.
+	if status, ok := projectStatusForSession(sess, false); !ok || status != github.ProjectStatusTodo {
+		t.Fatalf("projectStatusForSession(released) = (%q, %v), want (%q, true)", status, ok, github.ProjectStatusTodo)
+	}
 	if sess.FinishedAt == nil {
 		t.Fatalf("FinishedAt must be set on a reconciled terminal session")
 	}
@@ -9992,6 +10003,85 @@ func TestAutoMergePRs_ClosedPRRetryExhaustedMergeCheckErrorDefersReconcile(t *te
 	}
 	if sess.PRNumber != 221 {
 		t.Fatalf("PRNumber = %d, want 221 (must not be cleared on probe failure)", sess.PRNumber)
+	}
+}
+
+// #818 follow-up: a merged retry_exhausted session whose auto-close hits a
+// transient GitHub failure must NOT settle done — it stays retry_exhausted so
+// the next cycle retries the close (otherwise the issue can stay open forever
+// because the settled session leaves the merge flow). The retry must not
+// re-post the close comment, and once the close succeeds the session settles.
+func TestAutoMergePRs_ClosedPRRetryExhaustedTransientCloseFailureRetries(t *testing.T) {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Supervisor: config.SupervisorConfig{
+			BlockedLabel: "blocked",
+			SafeActions:  []string{config.SupervisorActionCloseIssue},
+		},
+	}
+	var closeComments []string
+	closeErr := fmt.Errorf("gh: transient API failure")
+	o := &Orchestrator{
+		cfg:           cfg,
+		notifier:      &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		isPRMergedFn: func(prNumber int) (bool, error) {
+			return prNumber == 223, nil
+		},
+		ghCloseIssueFn: func(number int, comment string) error {
+			closeComments = append(closeComments, comment)
+			return closeErr
+		},
+	}
+	s := state.NewState()
+	s.Sessions["sup-26"] = &state.Session{
+		IssueNumber: 503,
+		IssueTitle:  "merged PR, transient close failure",
+		Branch:      "feat/sup-26",
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    223,
+	}
+
+	// Cycle 1: close fails transiently — session must stay retry_exhausted.
+	o.autoMergePRs(s)
+
+	sess := s.Sessions["sup-26"]
+	if sess.Status != state.StatusRetryExhausted {
+		t.Fatalf("status = %q, want %q (transient close failure must not settle done)", sess.Status, state.StatusRetryExhausted)
+	}
+	if sess.PRNumber != 223 {
+		t.Fatalf("PRNumber = %d, want 223 (recorded PR must survive so reconcile retries the close)", sess.PRNumber)
+	}
+	if len(closeComments) != 1 {
+		t.Fatalf("close attempts = %d, want 1", len(closeComments))
+	}
+	if closeComments[0] == "" {
+		t.Fatalf("first close attempt posted an empty comment, want the close note")
+	}
+	if sess.LastNotifiedStatus != closedPRCloseRetryStatus {
+		t.Fatalf("LastNotifiedStatus = %q, want %q (marker gates comment/notify re-spam)", sess.LastNotifiedStatus, closedPRCloseRetryStatus)
+	}
+
+	// Cycle 2: still transient — retry must not re-post the close comment.
+	o.autoMergePRs(s)
+	if len(closeComments) != 2 {
+		t.Fatalf("close attempts after retry = %d, want 2 (close must be retried)", len(closeComments))
+	}
+	if closeComments[1] != "" {
+		t.Fatalf("retry close comment = %q, want empty (must not re-post the close note)", closeComments[1])
+	}
+	if s.Sessions["sup-26"].Status != state.StatusRetryExhausted {
+		t.Fatalf("status = %q, want %q while close keeps failing", s.Sessions["sup-26"].Status, state.StatusRetryExhausted)
+	}
+
+	// Cycle 3: close succeeds — session settles done and releases the slot.
+	closeErr = nil
+	o.autoMergePRs(s)
+	if s.Sessions["sup-26"].Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q after the close succeeds", s.Sessions["sup-26"].Status, state.StatusDone)
+	}
+	if s.IssueRetryExhausted(503) {
+		t.Fatalf("issue #503 still retry-exhausted after close succeeded; slot not released")
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -219,6 +219,7 @@ type Session struct {
 	PreviousAttemptFeedbackKind string            `json:"previous_attempt_feedback_kind,omitempty"` // review_feedback, rebase_conflict
 	RetryReason                 string            `json:"retry_reason,omitempty"`                   // current retry lifecycle reason, e.g. review_feedback
 	LastClosedPRNumber          int               `json:"last_closed_pr_number,omitempty"`          // PR the retry path closed before scheduling this retry (#800); if an operator reopens and merges it while the backoff runs, the pre-respawn staleness check sees the merge and cancels the retry
+	ReleasedForRedispatch       bool              `json:"released_for_redispatch,omitempty"`        // #818: a retry_exhausted session whose closed-unmerged PR was reconciled and the issue released for fresh dispatch. Marked failed so the attempt counts toward max_retries_per_issue, but the board must mirror it as runnable Todo (not Blocked) so the dynamic wave re-dispatches instead of re-stranding it
 	CheckpointFile              string            `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
 	DeploymentFinishedAt        *time.Time        `json:"deployment_finished_at,omitempty"`         // set when the post-merge deploy hook succeeds
 


### PR DESCRIPTION
Refs #818

## Problem
The prior #818 fix (`reconcileClosedPRRetryExhausted`) reconciled the **issue side** (auto-close on merge, label blocked on close) but never transitioned the session out of `retry_exhausted`. Because `SessionAttentionForAt` flags `retry_exhausted + PRNumber>0` as `needs_attention` and `SessionAttentionActionableAt` treats that shape as *always* actionable (never ages out), the session kept reporting `live: true` forever and `IssueRetryExhausted` kept the issue's slot held — across daemon restarts, and independent of the supervisor. Labelling the issue `blocked` also re-created a supervisor dependence (only the supervisor removes that label), which the acceptance criteria rule out.

## Changes
Reworks `reconcileClosedPRRetryExhausted` to transition the **session status** so it clears on its own in the orchestrator loop:

- **Merged PR → `done`.** The work landed, so the session settles `done` (ages out of the live window, `needs_attention` clears) and the issue is auto-closed when `close_issue` is a safe action, otherwise surfaced as an operator close-candidate.
- **Closed-unmerged PR → `failed`, recorded PR cleared.** This drops `IssueRetryExhausted` for the issue and makes the attempt count via `FailedAttemptsForIssue`, so the dispatch loop re-picks the issue for a fresh worker while it stays under `max_retries_per_issue`. No blocked label is applied.
- A transient merge-probe failure still defers (session left `retry_exhausted`, retried next cycle).

Reconciliation runs inside `autoMergePRs` (orchestrator loop) with no supervisor involvement, and the new terminal status persists across restarts.

**Behavior change note:** the closed-unmerged path no longer applies the `blocked` label (the previous approach). Labelling blocked contradicts AC2 ("releases the issue for fresh dispatch") and AC3 ("survives without the supervisor"), since only the supervisor un-blocks. The three prior #818 tests were updated to assert the session-status/slot-release behavior.

## Testing
- `go test ./internal/config/... ./internal/state/... ./internal/orchestrator/... ./internal/server/...`
- `go test ./...`
- `go build ./cmd/maestro/`
- `gofmt` clean on changed files.

## Runtime verification still required
The fix is proven by unit tests at the state/dispatch layer. Confirming the live-fleet outcome (the 7 zombie `retry_exhausted` sessions clearing and their issues returning to dispatch) is an operator/runtime check, so this PR intentionally does not auto-close the issue.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates closed-PR retry exhaustion handling in the orchestrator.

- Merged closed PR sessions now settle after the issue close succeeds.
- Transient issue-close failures keep the session retryable for the next cycle.
- Closed-unmerged PR sessions now release their issues for fresh dispatch.
- Released failed sessions map back to a runnable project-board state.
- Tests cover the new session transitions, slot release, retry counting, and close retry flow.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code. The close-failure path now keeps enough session state to retry later, and the closed-unmerged path clears the retry-exhausted slot while keeping the issue runnable.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the targeted ClosedPRRetryExhausted test suite and observed all four tests pass with exit code 0.
- Validated the broader internal packages test set, which ends with package PASS and exit code 0.
- Checked the Maestro build and Go fmt checks, both completing with exit code 0.

<a href="https://app.greptile.com/trex/runs/13952514/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Updates project-board mapping and closed-PR retry exhaustion reconciliation for merged, transient-failure, and closed-unmerged paths. |
| internal/orchestrator/orchestrator_test.go | Adds tests for released redispatch state, retry-exhausted close retries, terminal session aging, and idempotent reconciliation. |
| internal/state/state.go | Adds a persisted marker for failed sessions that should remain runnable for redispatch. |

<sub>Reviews (2): Last reviewed commit: ["orchestrator: keep released retry\_exhaus..."](https://github.com/befeast/maestro/commit/ba73d6ec41e1c58f8d363d8f4872af8e9bca82dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43235258)</sub>

<!-- /greptile_comment -->