### PR TITLE
orchestrator: attribution amend loses race with worker push (stale force-with-lease) — retry/defer (#858)

### DIFF
--- a/internal/orchestrator/attribution_amend_test.go
+++ b/internal/orchestrator/attribution_amend_test.go
@@ -1,0 +1,244 @@
+package orchestrator
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// These tests exercise the real git-level attribution amend against temp repos,
+// reproducing the "stale info" force-with-lease race the orchestrator hit in
+// production when a worker/operator push lands between our read and our push
+// (#858).
+
+func amendGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s (in %s): %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func amendWrite(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, rel), []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func amendConfig(t *testing.T, dir string) {
+	t.Helper()
+	amendGit(t, dir, "config", "user.email", "test@example.com")
+	amendGit(t, dir, "config", "user.name", "Test User")
+}
+
+// setupAmendRepo builds a bare origin holding a feature branch with one worker
+// commit, plus two clones:
+//   - wt:   the orchestrator's worker worktree, checked out on the branch,
+//     tracking origin/<branch> — the amend target.
+//   - seed: a separate clone on the branch used to push new commits to origin,
+//     simulating a concurrent worker/operator push.
+func setupAmendRepo(t *testing.T) (origin, wt, seed, branch string) {
+	t.Helper()
+	branch = "feat/sup-1-worker-feature"
+	root := t.TempDir()
+	origin = filepath.Join(root, "origin.git")
+	seed = filepath.Join(root, "seed")
+	wt = filepath.Join(root, "wt")
+
+	amendGit(t, root, "init", "--bare", origin)
+	amendGit(t, origin, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	amendGit(t, root, "clone", origin, seed)
+	amendConfig(t, seed)
+	amendWrite(t, seed, "README.md", "v1\n")
+	amendGit(t, seed, "add", "README.md")
+	amendGit(t, seed, "commit", "-m", "initial")
+	amendGit(t, seed, "push", "-u", "origin", "main")
+	amendGit(t, seed, "checkout", "-b", branch)
+	amendWrite(t, seed, "work.txt", "worker output v1\n")
+	amendGit(t, seed, "add", "work.txt")
+	amendGit(t, seed, "commit", "-m", "worker: implement feature")
+	amendGit(t, seed, "push", "-u", "origin", branch)
+
+	amendGit(t, root, "clone", origin, wt)
+	amendConfig(t, wt)
+	amendGit(t, wt, "checkout", branch)
+	return origin, wt, seed, branch
+}
+
+func testAttribution() []state.BackendAttribution {
+	return []state.BackendAttribution{{
+		Backend:   "claude",
+		Provider:  "anthropic",
+		Model:     "opus-4.8",
+		Effort:    "xhigh",
+		StartedAt: time.Date(2026, 7, 10, 4, 0, 0, 0, time.UTC),
+	}}
+}
+
+func trailerCount(msg string) int {
+	return strings.Count(msg, state.AttributionTrailerKey+":")
+}
+
+// On a stale-info rejection, the amend re-fetches, re-applies the trailer onto
+// the commit the worker actually pushed, and retries — landing the trailer
+// exactly once without discarding the worker's concurrent commit.
+func TestAmendHead_StaleInfoRefetchRetrySucceeds(t *testing.T) {
+	origin, wt, seed, branch := setupAmendRepo(t)
+
+	prevBackoff := amendRetryBackoff
+	amendRetryBackoff = 0
+	defer func() { amendRetryBackoff = prevBackoff }()
+
+	// The concurrent worker push lands exactly once, in the window between our
+	// read and our first force-with-lease push (requirement: simulate the race).
+	fired := false
+	amendPushRaceHook = func() {
+		if fired {
+			return
+		}
+		fired = true
+		amendWrite(t, seed, "work.txt", "worker output v2 (concurrent)\n")
+		amendGit(t, seed, "commit", "-am", "worker: follow-up commit")
+		amendGit(t, seed, "push", "origin", branch)
+	}
+	defer func() { amendPushRaceHook = nil }()
+
+	now := time.Date(2026, 7, 10, 4, 5, 0, 0, time.UTC)
+	if err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), now); err != nil {
+		t.Fatalf("amend should recover from stale-info race, got: %v", err)
+	}
+	if !fired {
+		t.Fatal("race hook never fired — test did not exercise the stale-info path")
+	}
+
+	headMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", branch)
+	if !strings.Contains(headMsg, state.AttributionTrailerKey+":") {
+		t.Fatalf("origin head missing attribution trailer:\n%s", headMsg)
+	}
+	if n := trailerCount(headMsg); n != 1 {
+		t.Fatalf("trailer appears %d times, want exactly 1:\n%s", n, headMsg)
+	}
+	// The worker's concurrent commit must survive — only its message is
+	// reworded to carry the trailer; its work (and log subject) is intact.
+	work := amendGit(t, origin, "show", branch+":work.txt")
+	if !strings.Contains(work, "concurrent") {
+		t.Fatalf("worker's concurrent work.txt was discarded: %q", work)
+	}
+	if !strings.Contains(headMsg, "worker: follow-up commit") {
+		t.Fatalf("head is not the worker's follow-up commit reworded:\n%s", headMsg)
+	}
+}
+
+// When the branch keeps advancing under a live worker, every push loses the
+// lease. The amend defers (errAmendDeferred) instead of erroring, and never
+// force-pushes over the worker's commits.
+func TestAmendHead_BranchKeepsMovingDefers(t *testing.T) {
+	origin, wt, seed, branch := setupAmendRepo(t)
+
+	prevBackoff := amendRetryBackoff
+	amendRetryBackoff = 0
+	defer func() { amendRetryBackoff = prevBackoff }()
+
+	pushes := 0
+	amendPushRaceHook = func() {
+		pushes++
+		amendWrite(t, seed, "work.txt", strings.Repeat("worker output live\n", pushes+1))
+		amendGit(t, seed, "commit", "-am", "worker: live push")
+		amendGit(t, seed, "push", "origin", branch)
+	}
+	defer func() { amendPushRaceHook = nil }()
+
+	before := amendGit(t, origin, "rev-parse", branch)
+	err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), time.Now().UTC())
+	if !errors.Is(err, errAmendDeferred) {
+		t.Fatalf("expected errAmendDeferred when branch keeps moving, got: %v", err)
+	}
+	if pushes < 2 {
+		t.Fatalf("expected multiple retry attempts, saw %d", pushes)
+	}
+
+	// The worker's latest commit is untouched: no force-push discarded it, and
+	// no trailer was rewritten onto it.
+	head := amendGit(t, origin, "rev-parse", branch)
+	if head == before {
+		t.Fatal("test setup error: origin branch never advanced")
+	}
+	headMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", branch)
+	if strings.Contains(headMsg, state.AttributionTrailerKey+":") {
+		t.Fatalf("deferred amend must not have rewritten the worker's head:\n%s", headMsg)
+	}
+	if last := amendGit(t, seed, "rev-parse", branch); head != last {
+		t.Fatalf("origin head %s != worker's last push %s — orchestrator clobbered a worker commit", head, last)
+	}
+}
+
+// A second amend on a head that already carries the trailer is a no-op: no push,
+// no duplicate trailer.
+func TestAmendHead_IdempotentNoDuplicateTrailer(t *testing.T) {
+	origin, wt, _, branch := setupAmendRepo(t)
+
+	now := time.Date(2026, 7, 10, 4, 5, 0, 0, time.UTC)
+	if err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), now); err != nil {
+		t.Fatalf("first amend: %v", err)
+	}
+	firstHead := amendGit(t, origin, "rev-parse", branch)
+
+	if err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), now); err != nil {
+		t.Fatalf("second amend (should be no-op): %v", err)
+	}
+	secondHead := amendGit(t, origin, "rev-parse", branch)
+	if firstHead != secondHead {
+		t.Fatalf("idempotent amend re-pushed: %s -> %s", firstHead, secondHead)
+	}
+	headMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", branch)
+	if n := trailerCount(headMsg); n != 1 {
+		t.Fatalf("trailer appears %d times after repeat amend, want 1:\n%s", n, headMsg)
+	}
+}
+
+// If the new remote head does NOT descend from the commit we were attributing
+// (a real divergence, e.g. an unpushed local commit), the amend must defer
+// rather than reset --hard and drop a commit that is not ours.
+func TestAmendHead_DivergedHeadDefersWithoutDiscard(t *testing.T) {
+	origin, wt, seed, branch := setupAmendRepo(t)
+
+	prevBackoff := amendRetryBackoff
+	amendRetryBackoff = 0
+	defer func() { amendRetryBackoff = prevBackoff }()
+
+	// The worktree has a local commit that was never pushed to origin.
+	amendWrite(t, wt, "local.txt", "unpushed worker work\n")
+	amendGit(t, wt, "add", "local.txt")
+	amendGit(t, wt, "commit", "-m", "worker: unpushed local commit")
+
+	// Meanwhile origin advances to a sibling commit (diverges from our head).
+	amendWrite(t, seed, "work.txt", "diverging remote push\n")
+	amendGit(t, seed, "commit", "-am", "operator: diverging push")
+	amendGit(t, seed, "push", "origin", branch)
+
+	remoteHeadBefore := amendGit(t, origin, "rev-parse", branch)
+
+	err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), time.Now().UTC())
+	if !errors.Is(err, errAmendDeferred) {
+		t.Fatalf("expected errAmendDeferred on divergence, got: %v", err)
+	}
+
+	// Origin is untouched, and our unpushed local work still exists locally.
+	if after := amendGit(t, origin, "rev-parse", branch); after != remoteHeadBefore {
+		t.Fatalf("origin head moved on a diverged defer: %s -> %s", remoteHeadBefore, after)
+	}
+	if got := amendGit(t, wt, "show", "HEAD:local.txt"); !strings.Contains(got, "unpushed") {
+		t.Fatalf("local unpushed commit was discarded: %q", got)
+	}
+}

--- a/internal/orchestrator/attribution_amend_test.go
+++ b/internal/orchestrator/attribution_amend_test.go
@@ -207,6 +207,67 @@ func TestAmendHead_IdempotentNoDuplicateTrailer(t *testing.T) {
 	}
 }
 
+// After a deferral (the branch kept moving on every attempt), the worktree must
+// NOT be left sitting on an un-pushed local amend that already carries the
+// trailer. If it were, the next cycle's AppendAttributionTrailer would see the
+// local trailer and no-op before any fetch/push, so the remote — which advanced
+// during the race — would permanently miss attribution despite the deferral
+// promising a retry. This drives the deferral, then a quiet second cycle, and
+// asserts the trailer actually lands on the remote (#858).
+func TestAmendHead_DeferDoesNotPoisonNextCycle(t *testing.T) {
+	origin, wt, seed, branch := setupAmendRepo(t)
+
+	prevBackoff := amendRetryBackoff
+	amendRetryBackoff = 0
+	defer func() { amendRetryBackoff = prevBackoff }()
+
+	// First cycle: the branch advances on every push attempt, forcing a defer.
+	pushes := 0
+	amendPushRaceHook = func() {
+		pushes++
+		amendWrite(t, seed, "work.txt", strings.Repeat("live churn\n", pushes+1))
+		amendGit(t, seed, "commit", "-am", "worker: live push")
+		amendGit(t, seed, "push", "origin", branch)
+	}
+
+	if err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), time.Now().UTC()); !errors.Is(err, errAmendDeferred) {
+		t.Fatalf("expected errAmendDeferred while branch keeps moving, got: %v", err)
+	}
+	if pushes < 2 {
+		t.Fatalf("expected multiple retry attempts, saw %d", pushes)
+	}
+
+	// The worktree must not be left carrying an un-pushed trailer: HEAD must be a
+	// commit whose message has no attribution trailer, or the next cycle no-ops.
+	localMsg := amendGit(t, wt, "log", "-1", "--pretty=%B")
+	if strings.Contains(localMsg, state.AttributionTrailerKey+":") {
+		t.Fatalf("deferred amend left an un-pushed local trailer (poisons next cycle):\n%s", localMsg)
+	}
+
+	// Second cycle: the branch is now quiet. The amend must land the trailer on
+	// the remote exactly once — proving the first deferral did not poison this.
+	amendPushRaceHook = nil
+	if err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), time.Now().UTC()); err != nil {
+		t.Fatalf("quiet second cycle should land the trailer, got: %v", err)
+	}
+
+	headMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", branch)
+	if !strings.Contains(headMsg, state.AttributionTrailerKey+":") {
+		t.Fatalf("remote head missing attribution trailer after quiet retry:\n%s", headMsg)
+	}
+	if n := trailerCount(headMsg); n != 1 {
+		t.Fatalf("trailer appears %d times, want exactly 1:\n%s", n, headMsg)
+	}
+	// The worker's latest concurrent commit is what got reworded — nothing lost.
+	if last := amendGit(t, seed, "rev-parse", branch); amendGit(t, origin, "rev-parse", branch) == last {
+		t.Fatal("expected the remote head to be the reworded worker commit, not the raw worker push")
+	}
+	work := amendGit(t, origin, "show", branch+":work.txt")
+	if !strings.Contains(work, "live churn") {
+		t.Fatalf("worker's concurrent work.txt was discarded: %q", work)
+	}
+}
+
 // If the new remote head does NOT descend from the commit we were attributing
 // (a real divergence, e.g. an unpushed local commit), the amend must defer
 // rather than reset --hard and drop a commit that is not ours.

--- a/internal/orchestrator/attribution_merge_guard_test.go
+++ b/internal/orchestrator/attribution_merge_guard_test.go
@@ -1,0 +1,159 @@
+package orchestrator
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// mergeGuardSession builds a merge-eligible session that carries attribution, so
+// autoMergePRs will attempt the pre-merge attribution amend before deciding
+// whether to merge.
+func mergeGuardSession(branch string, pr int) *state.Session {
+	return &state.Session{
+		IssueNumber: 858,
+		IssueTitle:  "attribution amend race",
+		Status:      state.StatusPROpen,
+		PRNumber:    pr,
+		Branch:      branch,
+		Worktree:    "/tmp/does-not-matter",
+		Attribution: []state.BackendAttribution{{
+			Backend:   "claude",
+			Provider:  "anthropic",
+			Model:     "opus-4.8",
+			Effort:    "xhigh",
+			StartedAt: time.Date(2026, 7, 10, 4, 0, 0, 0, time.UTC),
+		}},
+	}
+}
+
+// When the pre-merge attribution amend defers (the branch is still advancing
+// under a concurrent worker/operator push), autoMergePRs must NOT let the PR
+// reach the merge decision this cycle: merging now would land it permanently
+// without the required Maestro-Backend trailer while the deferral's promised
+// retry never runs. The guard must short-circuit before even querying CI, so a
+// later quiet cycle can stamp the trailer and then merge (#858).
+func TestAutoMergePRs_DeferredAttributionBlocksMerge(t *testing.T) {
+	branch := "feat/sup-858-amend-race"
+	s := state.NewState()
+	s.Sessions["sup-858"] = mergeGuardSession(branch, 864)
+
+	ciQueried := false
+	merged := false
+	o := &Orchestrator{
+		cfg: &config.Config{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{{Number: 864, HeadRefName: branch}}, nil
+		},
+		amendHeadFn: func(worktreePath, b string, attribution []state.BackendAttribution, now time.Time) error {
+			return errAmendDeferred
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			ciQueried = true
+			return "success", nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = true
+			return nil
+		},
+	}
+
+	o.autoMergePRs(s)
+
+	if merged {
+		t.Fatal("deferred attribution amend must block the merge — ghMergePRFn was called (#858)")
+	}
+	if ciQueried {
+		t.Fatal("deferred attribution amend must short-circuit before the merge flow continues (CI was queried)")
+	}
+	// The session stays merge-eligible so a later quiet cycle completes it.
+	if s.Sessions["sup-858"].Status != state.StatusPROpen {
+		t.Fatalf("session status = %q, want pr_open (still awaiting a quiet cycle)", s.Sessions["sup-858"].Status)
+	}
+}
+
+// The guard is specific to the deferral: when the attribution amend lands (or is
+// a no-op), autoMergePRs proceeds past the attribution step into the normal
+// merge flow (here it reaches the CI query). This proves the guard does not
+// over-block PRs whose trailer is already settled.
+func TestAutoMergePRs_SettledAttributionProceedsToMergeFlow(t *testing.T) {
+	branch := "feat/sup-858-amend-settled"
+	s := state.NewState()
+	s.Sessions["sup-858"] = mergeGuardSession(branch, 870)
+
+	ciQueried := false
+	o := &Orchestrator{
+		cfg: &config.Config{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{{Number: 870, HeadRefName: branch}}, nil
+		},
+		amendHeadFn: func(worktreePath, b string, attribution []state.BackendAttribution, now time.Time) error {
+			return nil // trailer landed / already present
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			ciQueried = true
+			// Return an error so the flow stops here without needing the full
+			// review-gate/merge machinery; reaching this hook is the assertion.
+			return "", errors.New("ci lookup stops the test here")
+		},
+	}
+
+	o.autoMergePRs(s)
+
+	if !ciQueried {
+		t.Fatal("a settled attribution amend must let the merge flow proceed past attribution to the CI query")
+	}
+}
+
+// amendGitCommand must pin LC_ALL=C on the git subprocess so git's "stale info"
+// force-with-lease rejection is emitted in English regardless of the host
+// locale. Without this the git child inherits the orchestrator's environment,
+// and under a non-English locale the rejection is translated — so
+// isStaleInfoLeaseRejection would miss the real race and take the hard-error
+// path instead of retrying/deferring (#858).
+func TestAmendGitCommand_ForcesCLocale(t *testing.T) {
+	// Simulate an orchestrator running under a translating locale.
+	t.Setenv("LC_ALL", "fr_FR.UTF-8")
+
+	cmd := amendGitCommand(t.TempDir(), "status", "--porcelain")
+
+	// os/exec keeps the last value for a duplicate key, so resolve LC_ALL the
+	// same way the child process will: last occurrence wins.
+	got := ""
+	for _, kv := range cmd.Env {
+		if strings.HasPrefix(kv, "LC_ALL=") {
+			got = strings.TrimPrefix(kv, "LC_ALL=")
+		}
+	}
+	if got != "C" {
+		t.Fatalf("amendGitCommand LC_ALL resolved to %q, want \"C\" (inherited locale would translate git's stale-info text)", got)
+	}
+}
+
+// isStaleInfoLeaseRejection recognizes git's English stale-info marker (which is
+// what git emits under the forced C locale) and is unfazed by casing/framing,
+// while not false-positiving on unrelated push failures.
+func TestIsStaleInfoLeaseRejection(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{"english stale info", " ! [rejected]        feat -> feat (stale info)", true},
+		{"uppercase framing", "! [REJECTED] (STALE INFO)", true},
+		{"non-fast-forward is not stale", " ! [rejected] feat -> feat (non-fast-forward)", false},
+		{"auth failure is not stale", "fatal: Authentication failed", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStaleInfoLeaseRejection(tc.out); got != tc.want {
+				t.Fatalf("isStaleInfoLeaseRejection(%q) = %v, want %v", tc.out, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3185,11 +3185,13 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		}
 
 		// Record the commit we are about to attribute so a later refetch can
-		// prove the remote only moved forward from it (never discarding work).
-		origHead, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").CombinedOutput()
+		// prove the remote only moved forward from it (never discarding work),
+		// and so we can undo an un-pushed amend by resetting back to it.
+		origHeadRaw, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("git rev-parse HEAD: %w\n%s", err, origHead)
+			return fmt.Errorf("git rev-parse HEAD: %w\n%s", err, origHeadRaw)
 		}
+		origHead := strings.TrimSpace(string(origHeadRaw))
 
 		out, err := exec.Command("git", "-C", worktreePath, "log", "-1", "--pretty=%B").CombinedOutput()
 		if err != nil {
@@ -3216,12 +3218,27 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		if pushErr == nil {
 			return nil // trailer landed exactly once
 		}
+
+		// The push did not land, so the local --amend is now an un-pushed commit
+		// carrying the trailer while the remote head does not. Undo it before we
+		// return or retry, restoring HEAD to the exact pre-amend commit. Otherwise
+		// a later cycle reads the local trailer, AppendAttributionTrailer no-ops
+		// before any fetch/push, and attribution is lost forever despite the
+		// deferral promising a retry (#858). Resetting to the captured pre-amend
+		// HEAD discards nothing but our own reword — the worker's real commits
+		// live on the remote, not in this un-pushed amend.
+		if out, err := exec.Command("git", "-C", worktreePath, "reset", "--hard", origHead).CombinedOutput(); err != nil {
+			return fmt.Errorf("git reset --hard %s (undo un-pushed amend): %w\n%s", origHead, err, out)
+		}
+
 		if !isStaleInfoLeaseRejection(string(pushOut)) {
 			return fmt.Errorf("git push --force-with-lease origin %s: %w\n%s", branch, pushErr, pushOut)
 		}
 
 		// Stale lease: the remote advanced under a concurrent push. Out of
-		// attempts → defer to a later cycle rather than erroring.
+		// attempts → defer to a later cycle rather than erroring. HEAD is back on
+		// the pre-amend commit, so the next cycle re-reads the untrailered message
+		// and genuinely retries instead of no-oping on a stale local trailer.
 		if attempt == amendMaxAttempts {
 			return errAmendDeferred
 		}
@@ -3237,7 +3254,7 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		// (e.g. an unpushed local commit), defer rather than risk dropping a
 		// commit that is not ours (lease semantics preserved, #858).
 		if err := exec.Command("git", "-C", worktreePath, "merge-base", "--is-ancestor",
-			strings.TrimSpace(string(origHead)), "origin/"+branch).Run(); err != nil {
+			origHead, "origin/"+branch).Run(); err != nil {
 			return errAmendDeferred
 		}
 		if out, err := exec.Command("git", "-C", worktreePath, "reset", "--hard", "origin/"+branch).CombinedOutput(); err != nil {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3101,6 +3101,15 @@ func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *s
 		return
 	}
 	if err := o.amendHeadWithAttributionTrailer(sess.Worktree, sess.Branch, sess.Attribution, time.Now().UTC()); err != nil {
+		if errors.Is(err, errAmendDeferred) {
+			// The branch is advancing under a live worker/operator push, so the
+			// force-with-lease could not land this cycle. This is not a failure:
+			// autoMergePRs re-invokes this on every cycle, so a later quiet cycle
+			// (or the pre-merge amend) completes the trailer. Log one concise
+			// line instead of spamming raw git rejection output (#858).
+			log.Printf("[orch] attribution: deferring amend for %s (branch %q advancing under concurrent push; will retry next cycle)", slotName, sess.Branch)
+			return
+		}
 		log.Printf("[orch] attribution: could not amend branch %q for %s: %v", sess.Branch, slotName, err)
 	}
 }
@@ -3112,6 +3121,44 @@ func (o *Orchestrator) amendHeadWithAttributionTrailer(worktreePath, branch stri
 	return amendHeadWithAttributionTrailer(worktreePath, branch, attribution, now)
 }
 
+// amendMaxAttempts bounds how many times amendHeadWithAttributionTrailer will
+// re-fetch and re-apply the trailer after a stale-info lease rejection before
+// deferring to a later cycle: one initial try plus up to two refetch-retries.
+const amendMaxAttempts = 3
+
+// amendRetryBackoff is the pause between stale-info retry attempts. It is a var
+// so tests can shorten it.
+var amendRetryBackoff = 400 * time.Millisecond
+
+// amendPushRaceHook, when non-nil, runs immediately before each force-with-lease
+// push inside amendHeadWithAttributionTrailer. Tests use it to advance the
+// remote and deterministically reproduce the stale-info race; it is nil in
+// production.
+var amendPushRaceHook func()
+
+// errAmendDeferred signals that the attribution amend could not land this cycle
+// because the branch kept advancing under a concurrent worker/operator push (or
+// the worktree is mid-write). It is not a failure: the caller re-runs the amend
+// on later cycles, so a quieter cycle or the pre-merge pass completes it (#858).
+var errAmendDeferred = errors.New("attribution amend deferred: branch advancing under concurrent push")
+
+// isStaleInfoLeaseRejection reports whether `git push --force-with-lease` output
+// is the "stale info" rejection that occurs when the remote branch advanced
+// between our fetch and our push — i.e. a worker or operator pushed first.
+func isStaleInfoLeaseRejection(out string) bool {
+	return strings.Contains(strings.ToLower(out), "stale info")
+}
+
+// amendHeadWithAttributionTrailer amends the branch head to carry the durable
+// Maestro-Backend attribution trailer and force-pushes it. It is race-tolerant:
+// when the worker (or an operator) pushes a new commit between our read and our
+// force-with-lease push, git rejects the lease with "stale info". Rather than
+// losing the trailer and spamming raw git errors, it re-fetches the branch,
+// re-applies the trailer onto the commit the worker actually pushed, and retries
+// with backoff. If the branch keeps moving, it defers (errAmendDeferred) so a
+// later cycle completes it. The force-with-lease is only ever retargeted at a
+// head that descends from the commit we were about to attribute, so no push ever
+// discards a commit that is not our own reworded head (#858).
 func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
 	worktreePath = strings.TrimSpace(worktreePath)
 	branch = strings.TrimSpace(branch)
@@ -3124,30 +3171,83 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		}
 		return err
 	}
-	status, err := exec.Command("git", "-C", worktreePath, "status", "--porcelain").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("git status: %w\n%s", err, status)
+
+	for attempt := 1; attempt <= amendMaxAttempts; attempt++ {
+		// Never amend over a dirty tree: a worker may still be writing, and a
+		// force-push here could clobber uncommitted work the lease cannot
+		// protect (it only guards committed history). Defer instead.
+		status, err := exec.Command("git", "-C", worktreePath, "status", "--porcelain").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git status: %w\n%s", err, status)
+		}
+		if strings.TrimSpace(string(status)) != "" {
+			return errAmendDeferred
+		}
+
+		// Record the commit we are about to attribute so a later refetch can
+		// prove the remote only moved forward from it (never discarding work).
+		origHead, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git rev-parse HEAD: %w\n%s", err, origHead)
+		}
+
+		out, err := exec.Command("git", "-C", worktreePath, "log", "-1", "--pretty=%B").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git log -1: %w\n%s", err, out)
+		}
+		msg := state.AppendAttributionTrailer(string(out), attribution, now)
+		if msg == string(out) {
+			// Trailer already present on this head (idempotent — e.g. a prior
+			// cycle landed it), so there is nothing to do and never a duplicate.
+			return nil
+		}
+
+		cmd := exec.Command("git", "-C", worktreePath, "commit", "--amend", "-F", "-")
+		cmd.Stdin = strings.NewReader(msg)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git commit --amend: %w\n%s", err, out)
+		}
+
+		if amendPushRaceHook != nil {
+			amendPushRaceHook()
+		}
+
+		pushOut, pushErr := exec.Command("git", "-C", worktreePath, "push", "--force-with-lease", "origin", branch).CombinedOutput()
+		if pushErr == nil {
+			return nil // trailer landed exactly once
+		}
+		if !isStaleInfoLeaseRejection(string(pushOut)) {
+			return fmt.Errorf("git push --force-with-lease origin %s: %w\n%s", branch, pushErr, pushOut)
+		}
+
+		// Stale lease: the remote advanced under a concurrent push. Out of
+		// attempts → defer to a later cycle rather than erroring.
+		if attempt == amendMaxAttempts {
+			return errAmendDeferred
+		}
+
+		// Re-fetch the branch so we can re-apply the trailer onto the head the
+		// worker actually pushed.
+		if out, err := exec.Command("git", "-C", worktreePath, "fetch", "origin", branch).CombinedOutput(); err != nil {
+			return fmt.Errorf("git fetch origin %s: %w\n%s", branch, err, out)
+		}
+		// Only re-target the amend when the new remote head descends from the
+		// commit we were attributing: then our work (and the worker's) is fully
+		// contained and resetting to it discards nothing. If the branch diverged
+		// (e.g. an unpushed local commit), defer rather than risk dropping a
+		// commit that is not ours (lease semantics preserved, #858).
+		if err := exec.Command("git", "-C", worktreePath, "merge-base", "--is-ancestor",
+			strings.TrimSpace(string(origHead)), "origin/"+branch).Run(); err != nil {
+			return errAmendDeferred
+		}
+		if out, err := exec.Command("git", "-C", worktreePath, "reset", "--hard", "origin/"+branch).CombinedOutput(); err != nil {
+			return fmt.Errorf("git reset --hard origin/%s: %w\n%s", branch, err, out)
+		}
+		if amendRetryBackoff > 0 {
+			time.Sleep(amendRetryBackoff)
+		}
 	}
-	if strings.TrimSpace(string(status)) != "" {
-		return fmt.Errorf("worktree has uncommitted changes; refusing attribution amend")
-	}
-	out, err := exec.Command("git", "-C", worktreePath, "log", "-1", "--pretty=%B").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("git log -1: %w\n%s", err, out)
-	}
-	msg := state.AppendAttributionTrailer(string(out), attribution, now)
-	if msg == string(out) {
-		return nil
-	}
-	cmd := exec.Command("git", "-C", worktreePath, "commit", "--amend", "-F", "-")
-	cmd.Stdin = strings.NewReader(msg)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git commit --amend: %w\n%s", err, out)
-	}
-	if out, err := exec.Command("git", "-C", worktreePath, "push", "--force-with-lease", "origin", branch).CombinedOutput(); err != nil {
-		return fmt.Errorf("git push --force-with-lease origin %s: %w\n%s", branch, err, out)
-	}
-	return nil
+	return errAmendDeferred
 }
 
 // checkSessions inspects all sessions and updates their status

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3096,9 +3096,19 @@ Maestro auto-created this pull request for pushed branch %s because no open pull
 `, sess.IssueNumber, branch)
 }
 
-func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *state.Session) {
+// ensureAttributionTrailerOnBranch stamps the durable Maestro-Backend trailer
+// onto the branch head. It returns deferred=true when the amend could not land
+// this cycle because the branch is advancing under a concurrent worker/operator
+// push (errAmendDeferred). The merge flow MUST NOT merge a PR whose amend
+// deferred: merging now would land the PR permanently without the required
+// attribution trailer while the "later retry" the deferral promises never gets
+// to run (#858). A later quiet cycle re-invokes this and completes the trailer
+// before the merge proceeds. Non-merge callers (reconcile, pr_open transitions)
+// can ignore the return: for them the trailer legitimately lands on a later
+// cycle and nothing irreversible happens in between.
+func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *state.Session) (deferred bool) {
 	if sess == nil || len(sess.Attribution) == 0 {
-		return
+		return false
 	}
 	if err := o.amendHeadWithAttributionTrailer(sess.Worktree, sess.Branch, sess.Attribution, time.Now().UTC()); err != nil {
 		if errors.Is(err, errAmendDeferred) {
@@ -3108,10 +3118,11 @@ func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *s
 			// (or the pre-merge amend) completes the trailer. Log one concise
 			// line instead of spamming raw git rejection output (#858).
 			log.Printf("[orch] attribution: deferring amend for %s (branch %q advancing under concurrent push; will retry next cycle)", slotName, sess.Branch)
-			return
+			return true
 		}
 		log.Printf("[orch] attribution: could not amend branch %q for %s: %v", sess.Branch, slotName, err)
 	}
+	return false
 }
 
 func (o *Orchestrator) amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
@@ -3142,9 +3153,27 @@ var amendPushRaceHook func()
 // on later cycles, so a quieter cycle or the pre-merge pass completes it (#858).
 var errAmendDeferred = errors.New("attribution amend deferred: branch advancing under concurrent push")
 
+// amendGitCommand builds a git subprocess for the attribution amend with a
+// forced C locale. Git localizes its porcelain and error text per
+// LC_ALL/LC_MESSAGES/LANG, which the git child would otherwise inherit from the
+// orchestrator's environment. Under a non-English locale git translates the
+// "stale info" force-with-lease rejection, so isStaleInfoLeaseRejection (which
+// matches that English marker) would miss the real race and take the hard-error
+// path instead of retrying/deferring. Pinning LC_ALL=C keeps git's messages
+// stable and English regardless of the host locale (#858). os/exec keeps the
+// last value for a duplicate key, so this overrides any inherited LC_ALL, and
+// LC_ALL outranks LC_MESSAGES/LANG in the locale precedence.
+func amendGitCommand(worktreePath string, args ...string) *exec.Cmd {
+	cmd := exec.Command("git", append([]string{"-C", worktreePath}, args...)...)
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
+	return cmd
+}
+
 // isStaleInfoLeaseRejection reports whether `git push --force-with-lease` output
 // is the "stale info" rejection that occurs when the remote branch advanced
-// between our fetch and our push — i.e. a worker or operator pushed first.
+// between our fetch and our push — i.e. a worker or operator pushed first. The
+// git subprocess is run under LC_ALL=C (see amendGitCommand), so this English
+// marker is locale-stable and cannot be missed under a translated locale.
 func isStaleInfoLeaseRejection(out string) bool {
 	return strings.Contains(strings.ToLower(out), "stale info")
 }
@@ -3176,7 +3205,7 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		// Never amend over a dirty tree: a worker may still be writing, and a
 		// force-push here could clobber uncommitted work the lease cannot
 		// protect (it only guards committed history). Defer instead.
-		status, err := exec.Command("git", "-C", worktreePath, "status", "--porcelain").CombinedOutput()
+		status, err := amendGitCommand(worktreePath, "status", "--porcelain").CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("git status: %w\n%s", err, status)
 		}
@@ -3187,13 +3216,13 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		// Record the commit we are about to attribute so a later refetch can
 		// prove the remote only moved forward from it (never discarding work),
 		// and so we can undo an un-pushed amend by resetting back to it.
-		origHeadRaw, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").CombinedOutput()
+		origHeadRaw, err := amendGitCommand(worktreePath, "rev-parse", "HEAD").CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("git rev-parse HEAD: %w\n%s", err, origHeadRaw)
 		}
 		origHead := strings.TrimSpace(string(origHeadRaw))
 
-		out, err := exec.Command("git", "-C", worktreePath, "log", "-1", "--pretty=%B").CombinedOutput()
+		out, err := amendGitCommand(worktreePath, "log", "-1", "--pretty=%B").CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("git log -1: %w\n%s", err, out)
 		}
@@ -3204,7 +3233,7 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 			return nil
 		}
 
-		cmd := exec.Command("git", "-C", worktreePath, "commit", "--amend", "-F", "-")
+		cmd := amendGitCommand(worktreePath, "commit", "--amend", "-F", "-")
 		cmd.Stdin = strings.NewReader(msg)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("git commit --amend: %w\n%s", err, out)
@@ -3214,7 +3243,7 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 			amendPushRaceHook()
 		}
 
-		pushOut, pushErr := exec.Command("git", "-C", worktreePath, "push", "--force-with-lease", "origin", branch).CombinedOutput()
+		pushOut, pushErr := amendGitCommand(worktreePath, "push", "--force-with-lease", "origin", branch).CombinedOutput()
 		if pushErr == nil {
 			return nil // trailer landed exactly once
 		}
@@ -3227,7 +3256,7 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		// deferral promising a retry (#858). Resetting to the captured pre-amend
 		// HEAD discards nothing but our own reword — the worker's real commits
 		// live on the remote, not in this un-pushed amend.
-		if out, err := exec.Command("git", "-C", worktreePath, "reset", "--hard", origHead).CombinedOutput(); err != nil {
+		if out, err := amendGitCommand(worktreePath, "reset", "--hard", origHead).CombinedOutput(); err != nil {
 			return fmt.Errorf("git reset --hard %s (undo un-pushed amend): %w\n%s", origHead, err, out)
 		}
 
@@ -3245,7 +3274,7 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 
 		// Re-fetch the branch so we can re-apply the trailer onto the head the
 		// worker actually pushed.
-		if out, err := exec.Command("git", "-C", worktreePath, "fetch", "origin", branch).CombinedOutput(); err != nil {
+		if out, err := amendGitCommand(worktreePath, "fetch", "origin", branch).CombinedOutput(); err != nil {
 			return fmt.Errorf("git fetch origin %s: %w\n%s", branch, err, out)
 		}
 		// Only re-target the amend when the new remote head descends from the
@@ -3253,11 +3282,11 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		// contained and resetting to it discards nothing. If the branch diverged
 		// (e.g. an unpushed local commit), defer rather than risk dropping a
 		// commit that is not ours (lease semantics preserved, #858).
-		if err := exec.Command("git", "-C", worktreePath, "merge-base", "--is-ancestor",
+		if err := amendGitCommand(worktreePath, "merge-base", "--is-ancestor",
 			origHead, "origin/"+branch).Run(); err != nil {
 			return errAmendDeferred
 		}
-		if out, err := exec.Command("git", "-C", worktreePath, "reset", "--hard", "origin/"+branch).CombinedOutput(); err != nil {
+		if out, err := amendGitCommand(worktreePath, "reset", "--hard", "origin/"+branch).CombinedOutput(); err != nil {
 			return fmt.Errorf("git reset --hard origin/%s: %w\n%s", branch, err, out)
 		}
 		if amendRetryBackoff > 0 {
@@ -3899,7 +3928,17 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		if sess.PRNumber == 0 {
 			sess.PRNumber = pr.Number
 		}
-		o.ensureAttributionTrailerOnBranch(slotName, sess)
+		if o.ensureAttributionTrailerOnBranch(slotName, sess) {
+			// The attribution amend deferred because the branch is still moving
+			// under a concurrent worker/operator push. Do NOT let this PR reach
+			// the merge decision this cycle: merging now would land it without
+			// the durable Maestro-Backend trailer, and the deferral's "retry next
+			// cycle" would then have nothing left to amend. Skip it; a later quiet
+			// cycle stamps the trailer and this PR becomes merge-eligible (#858).
+			// ensureAttributionTrailerOnBranch already logged the concise defer
+			// line, so no extra journal noise here.
+			continue
+		}
 
 		// #705: opt-in visual evidence for UI-affecting PRs. One-shot,
 		// advisory — posts a warning comment when evidence is missing but


### PR DESCRIPTION
Implements #858

## Changes
- `amendHeadWithAttributionTrailer` now retries on a `stale info` force-with-lease rejection: it re-fetches the branch and re-applies the `Maestro-Backend` trailer onto the commit the worker actually pushed, with backoff (up to 3 attempts).
- The force-with-lease is only re-targeted when the new remote head descends from the commit being attributed; otherwise the amend defers, so a push never discards a commit that isn't the orchestrator's own reworded head (lease semantics preserved).
- If the branch keeps moving under a live worker (or the tree is dirty mid-write), the amend defers via a sentinel instead of erroring. The pre-merge amend re-runs every cycle, so a quieter cycle completes it.
- Journal noise collapsed to one concise structured line per deferral instead of raw git output.
- Trailer append stays idempotent — success adds it exactly once, no duplicates.

## Testing
- New git-level tests against temp repos simulate the race (remote advancing between read and push): refetch+retry success with the trailer landing once and the worker's concurrent commit preserved; a branch that keeps moving defers without touching the worker head; a repeat amend is a no-op; a diverged head defers without discarding local work.
- `gofmt`, `go build ./cmd/maestro/`, `go test ./...` all pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the attribution trailer amend path tolerate branch-push races. The main changes are:

- Retry and defer handling for stale `--force-with-lease` pushes.
- A merge guard when attribution stamping defers.
- Locale-pinned git commands for stable stale-info detection.
- Git-level tests for retry, deferral, idempotency, divergence, and merge blocking.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused proof for github.com/befeast/maestro/internal/orchestrator ran and completed with EXIT CODE 0.
- The package-level proof for github.com/befeast/maestro/internal/orchestrator completed with EXIT CODE 0 after 5.985s.
- An artifact named orchestrator-attribution-tests.log was produced, containing the full captured output for both runs.

<a href="https://app.greptile.com/trex/runs/13957889/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds deferred attribution signaling, locale-pinned git execution, and retry-safe amend handling. |
| internal/orchestrator/attribution_amend_test.go | Adds git-level coverage for stale retry, repeated deferral, idempotency, cleanup after deferral, and divergence safety. |
| internal/orchestrator/attribution_merge_guard_test.go | Adds coverage for deferred merge blocking, settled-attribution flow, locale pinning, and stale-info matching. |

<sub>Reviews (3): Last reviewed commit: ["orchestrator: block merge on deferred at..."](https://github.com/befeast/maestro/commit/7275bbef5fc6622e9eecc3859645cea5ec94ba23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43243462)</sub>

<!-- /greptile_comment -->