### PR TITLE
worker: classify CLIProxyAPI 'credentials cooling down' 429 as RateLimitHit (burns retry budget today)

### DIFF
--- a/internal/worker/ratelimit.go
+++ b/internal/worker/ratelimit.go
@@ -28,8 +28,16 @@ import (
 //     paired with a parseable "resets <t>" hint this is the high-confidence
 //     provider-limit signal the fallover selector acts on.
 //   - "chatgpt.com/codex/settings/usage" marker (Codex usage-limit URL)
-//   - HTTP 429 paired with a status/code/error context word — bare 429
-//     embedded in unrelated text is NOT matched
+//   - "credentials for model <m> are cooling down" — the CLIProxyAPI
+//     credential-pool exhaustion signature (#859). CLIProxyAPI returns quota
+//     exhaustion as "Request rejected (429) · All credentials for model
+//     claude-opus-4-8 are cooling down"; before #859 neither the 429 nor the
+//     cooling-down phrasing matched, so the death burned the per-issue retry
+//     budget.
+//   - HTTP 429 paired with a status/code/error/rejected context word — bare 429
+//     embedded in unrelated text is NOT matched. The "rejected (429)" shape
+//     (CLIProxyAPI, #859) is covered by the "rejected" marker plus an optional
+//     "(" separator.
 //   - "<NNN> too many requests" (HTTP reason phrase)
 //   - "rate limit exceeded|reached|hit" / "rate_limit_error|exceeded" — the
 //     bare phrase "rate limit" alone is NOT matched (too noisy: appears in
@@ -45,10 +53,17 @@ var rateLimitPatterns = []struct {
 	{"reached_limit", regexp.MustCompile(`(?i)you'?ve reached your\b[^.\n]{0,40}?\blimit\b`)},
 	{"out_of_usage", regexp.MustCompile(`(?i)you'?re out of (?:extra )?usage\b`)},
 	{"codex_usage_limit", regexp.MustCompile(`(?i)(chatgpt\.com/)?codex/settings/usage`)},
+	// CLIProxyAPI credential-pool exhaustion (#859): "All credentials for model
+	// <model> are cooling down". The bounded ".{0,40}" between "model" and the
+	// verb keeps the match tight to a model identifier so unrelated prose
+	// ("cooling down period in HVAC docs") does not false-positive.
+	{"proxy_cooling_down", regexp.MustCompile(`(?i)credentials? for model .{0,40}(?:are|is) cooling down`)},
 	// HTTP 429 with a rate-limit context word. Requires the literal 429 to
-	// appear next to an HTTP / status / code / error / response marker so
-	// "1.0.429" or "processed 14290 records" do not false-positive.
-	{"http_429", regexp.MustCompile(`(?i)\b(?:http|https|status|code|err(?:or)?|response|received)\b[ \t]*[:=]?[ \t]*429\b`)},
+	// appear next to an HTTP / status / code / error / response / rejected
+	// marker so "1.0.429" or "processed 14290 records" do not false-positive.
+	// The optional "(" separator admits the CLIProxyAPI "Request rejected (429)"
+	// shape (#859); the trailing "\b" still rejects "42900".
+	{"http_429", regexp.MustCompile(`(?i)\b(?:http|https|status|code|err(?:or)?|response|received|rejected)\b[ \t]*[:=(]?[ \t]*429\b`)},
 	{"http_429_reason", regexp.MustCompile(`(?i)\b429\b[ \t:,-]*too[ \t]+many[ \t]+requests`)},
 	{"rate_limit_exceeded", regexp.MustCompile(`(?i)rate[ _.-]?limit[ _.-]?(?:exceeded|reached|hit|error)`)},
 	{"quota_exceeded", regexp.MustCompile(`(?i)quota[ _.-]?exceeded`)},

--- a/internal/worker/ratelimit.go
+++ b/internal/worker/ratelimit.go
@@ -54,10 +54,16 @@ var rateLimitPatterns = []struct {
 	{"out_of_usage", regexp.MustCompile(`(?i)you'?re out of (?:extra )?usage\b`)},
 	{"codex_usage_limit", regexp.MustCompile(`(?i)(chatgpt\.com/)?codex/settings/usage`)},
 	// CLIProxyAPI credential-pool exhaustion (#859): "All credentials for model
-	// <model> are cooling down". The bounded ".{0,40}" between "model" and the
-	// verb keeps the match tight to a model identifier so unrelated prose
-	// ("cooling down period in HVAC docs") does not false-positive.
-	{"proxy_cooling_down", regexp.MustCompile(`(?i)credentials? for model .{0,40}(?:are|is) cooling down`)},
+	// <model> are cooling down". The model identifier is matched as a single
+	// "\S+" token (any length): a fixed ".{0,40}" bound silently missed model
+	// IDs longer than 40 chars (bedrock/vertex-qualified names such as
+	// "us.anthropic.claude-opus-4-8-20250805-canary-v1:0"), which then fell
+	// through to the bare "rejected (429)" and never reached a RateLimitHit
+	// path. "\S+" stays anchored to the token and cannot sprawl across
+	// whitespace into unrelated prose, and the required "credentials for model"
+	// prefix plus "cooling down" suffix keep stray "cooling down" text ("cooling
+	// down period in HVAC docs") from false-positiving.
+	{"proxy_cooling_down", regexp.MustCompile(`(?i)credentials? for model \S+ (?:are|is) cooling down`)},
 	// HTTP 429 with a rate-limit context word. Requires the literal 429 to
 	// appear next to an HTTP / status / code / error / response / rejected
 	// marker so "1.0.429" or "processed 14290 records" do not false-positive.

--- a/internal/worker/ratelimit_test.go
+++ b/internal/worker/ratelimit_test.go
@@ -14,6 +14,14 @@ import (
 // "(usage )?" group and/or the codex/settings/usage marker.
 const codexUsageLimitSignature = "ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to see your usage. You can try again at May 30th, 2026 8:13 PM."
 
+// proxyCoolingDownSignature is the exact CLIProxyAPI quota-exhaustion line that
+// killed sessions sup-275/276/277 (#859, root cause of #835's day-long stall,
+// 2026-07-09). The proxy returns quota exhaustion as a 429 whose "rejected
+// (429)" shape sat outside the old http_429 marker list, alongside an "All
+// credentials ... are cooling down" phrase no pattern matched — so the deaths
+// were recorded rate_limit_hit=false and burned the per-issue retry budget.
+const proxyCoolingDownSignature = "API Error: Request rejected (429) · All credentials for model claude-opus-4-8 are cooling down"
+
 func TestDetectRateLimit(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -107,6 +115,36 @@ func TestDetectRateLimit(t *testing.T) {
 			input:     "rpc error: code = ResourceExhausted desc = request limit",
 			wantHit:   true,
 			wantLabel: "resource_exhausted",
+		},
+		{
+			// #859: the exact CLIProxyAPI line. It matches both the
+			// proxy_cooling_down pattern and the widened http_429; the
+			// more-specific proxy_cooling_down is listed first, so it wins.
+			name:      "CLIProxyAPI credentials cooling down (#859)",
+			input:     proxyCoolingDownSignature,
+			wantHit:   true,
+			wantLabel: "proxy_cooling_down",
+		},
+		{
+			name:      "credentials cooling down bare phrasing (#859)",
+			input:     "All credentials for model claude-opus-4-8 are cooling down",
+			wantHit:   true,
+			wantLabel: "proxy_cooling_down",
+		},
+		{
+			// #859: "rejected (429)" now matches the widened http_429 even
+			// without the cooling-down phrase.
+			name:      "Request rejected (429) widened http_429 (#859)",
+			input:     "API Error: Request rejected (429)",
+			wantHit:   true,
+			wantLabel: "http_429",
+		},
+		{
+			// #859 negative: "cooling down" in unrelated prose (no "credentials
+			// for model" prefix) must not classify.
+			name:    "cooling down in unrelated prose no match (#859)",
+			input:   "the compressor needs a cooling down period in HVAC docs",
+			wantHit: false,
 		},
 		{
 			name:      "multiline with rate limit on later line",
@@ -302,6 +340,53 @@ func TestRateLimit_ClaudeStillMatches(t *testing.T) {
 	}
 	if !OutputContainsRateLimit(output) {
 		t.Error("OutputContainsRateLimit should still match the Claude phrasing")
+	}
+}
+
+// TestRateLimit_ProxyCoolingDownSignature is the #859 regression guard. The
+// exact CLIProxyAPI quota-exhaustion line that killed sup-275/276/277 must be
+// classified as a rate-limit across every entry point. Because it carries no
+// "try again at/resets" clause, the reset extractor must tolerate it — yield no
+// reset (ok=false), not a parse error — which leaves ClassifyRateLimit
+// low-confidence. The escalation to RateLimitHit=true then happens on the
+// usage-limit path (usagelimit.go), not the provider-limit path.
+func TestRateLimit_ProxyCoolingDownSignature(t *testing.T) {
+	if hit, label := DetectRateLimit(proxyCoolingDownSignature); !hit {
+		t.Fatal("DetectRateLimit should classify the CLIProxyAPI cooling-down signature")
+	} else if label != "proxy_cooling_down" {
+		t.Errorf("label = %q, want proxy_cooling_down", label)
+	}
+	if !OutputContainsRateLimit(proxyCoolingDownSignature) {
+		t.Error("OutputContainsRateLimit should classify the CLIProxyAPI cooling-down signature")
+	}
+
+	// No "try again at/resets" clause: the extractor must return ok=false
+	// (no reset time) rather than erroring or panicking (#859 requirement 2).
+	if reset, ok := ParseRateLimitReset(proxyCoolingDownSignature); ok {
+		t.Errorf("ParseRateLimitReset = %v, want no reset — the proxy signature states no reset window", reset)
+	}
+
+	// Classification is therefore low-confidence (no parseable reset).
+	hit, label, confidence, resetAt := ClassifyRateLimit(proxyCoolingDownSignature)
+	if !hit || label != "proxy_cooling_down" {
+		t.Errorf("ClassifyRateLimit hit/label = %v/%q, want true/proxy_cooling_down", hit, label)
+	}
+	if confidence != "low" {
+		t.Errorf("confidence = %q, want low (no reset hint)", confidence)
+	}
+	if !resetAt.IsZero() {
+		t.Errorf("resetAt = %v, want zero on low confidence", resetAt)
+	}
+
+	// The terminal error in a dead worker's log tail must still be recognised.
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "sup-277.log")
+	content := "Starting worker sup-277 on issue #835\nProcessing...\n" + proxyCoolingDownSignature + "\n"
+	if err := os.WriteFile(logFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write log file: %v", err)
+	}
+	if !IsRateLimited(logFile) {
+		t.Error("IsRateLimited should recognise the CLIProxyAPI cooling-down signature from a log file")
 	}
 }
 

--- a/internal/worker/ratelimit_test.go
+++ b/internal/worker/ratelimit_test.go
@@ -132,6 +132,15 @@ func TestDetectRateLimit(t *testing.T) {
 			wantLabel: "proxy_cooling_down",
 		},
 		{
+			// #859 review: a long, fully-qualified model ID (>40 chars) must
+			// still classify. A fixed ".{0,40}" bound missed these, dropping the
+			// death to the bare "rejected (429)" and burning the retry budget.
+			name:      "cooling down with long model id (#859 review)",
+			input:     "API Error: Request rejected (429) · All credentials for model us.anthropic.claude-opus-4-8-20250805-canary-v1:0 are cooling down",
+			wantHit:   true,
+			wantLabel: "proxy_cooling_down",
+		},
+		{
 			// #859: "rejected (429)" now matches the widened http_429 even
 			// without the cooling-down phrase.
 			name:      "Request rejected (429) widened http_429 (#859)",

--- a/internal/worker/usagelimit.go
+++ b/internal/worker/usagelimit.go
@@ -31,6 +31,14 @@ import (
 //   - "chatgpt.com/codex/settings/usage" marker (Codex usage-limit URL)
 //   - "usage/5-hour/weekly limit reached" (claude CLI subscription-window
 //     phrasings, e.g. "Claude usage limit reached ...")
+//   - "credentials for model <m> are cooling down" — the CLIProxyAPI
+//     credential-pool exhaustion signature (#859). This is a capacity
+//     exhaustion with no provider-stated reset, so the generic 429 the same
+//     message carries ("Request rejected (429)") never reaches a RateLimitHit
+//     path (the provider-limit path needs a parseable reset, and generic 429 is
+//     the #663 false-positive class). The cooling-down phrasing is specific
+//     enough to gate the backend and fall over without a reset, exactly like
+//     the other account-quota signatures here.
 var usageLimitPatterns = []struct {
 	label string
 	re    *regexp.Regexp
@@ -41,6 +49,7 @@ var usageLimitPatterns = []struct {
 	{"out_of_usage", regexp.MustCompile(`(?i)you'?re out of (?:extra )?usage\b`)},
 	{"codex_usage_limit", regexp.MustCompile(`(?i)(chatgpt\.com/)?codex/settings/usage`)},
 	{"usage_limit_reached", regexp.MustCompile(`(?i)\b(?:usage|5-hour|weekly)[ _-]limit reached\b`)},
+	{"proxy_cooling_down", regexp.MustCompile(`(?i)credentials? for model .{0,40}(?:are|is) cooling down`)},
 }
 
 // DetectUsageLimit scans multi-line output for known account-quota exhaustion

--- a/internal/worker/usagelimit.go
+++ b/internal/worker/usagelimit.go
@@ -49,7 +49,11 @@ var usageLimitPatterns = []struct {
 	{"out_of_usage", regexp.MustCompile(`(?i)you'?re out of (?:extra )?usage\b`)},
 	{"codex_usage_limit", regexp.MustCompile(`(?i)(chatgpt\.com/)?codex/settings/usage`)},
 	{"usage_limit_reached", regexp.MustCompile(`(?i)\b(?:usage|5-hour|weekly)[ _-]limit reached\b`)},
-	{"proxy_cooling_down", regexp.MustCompile(`(?i)credentials? for model .{0,40}(?:are|is) cooling down`)},
+	// The model identifier is matched as a single "\S+" token (any length) so a
+	// cooling-down death for a long, fully-qualified model ID (>40 chars) still
+	// classifies — a fixed ".{0,40}" bound missed those and let the death burn
+	// the retry budget (#859 review). Kept in sync with rateLimitPatterns.
+	{"proxy_cooling_down", regexp.MustCompile(`(?i)credentials? for model \S+ (?:are|is) cooling down`)},
 }
 
 // DetectUsageLimit scans multi-line output for known account-quota exhaustion

--- a/internal/worker/usagelimit_test.go
+++ b/internal/worker/usagelimit_test.go
@@ -89,6 +89,14 @@ func TestDetectUsageLimit_ProxyCoolingDown(t *testing.T) {
 	if label != "proxy_cooling_down" {
 		t.Errorf("label = %q, want proxy_cooling_down", label)
 	}
+	// #859 review: a long, fully-qualified model ID (>40 chars) must still take
+	// the usage-limit path. A fixed ".{0,40}" bound missed these, so the death
+	// fell through to the bare "rejected (429)" (excluded here) and burned the
+	// per-issue retry budget instead of being marked RateLimitHit.
+	const longModelDeath = "API Error: Request rejected (429) · All credentials for model us.anthropic.claude-opus-4-8-20250805-canary-v1:0 are cooling down"
+	if hit, label := DetectUsageLimit(longModelDeath, nil); !hit || label != "proxy_cooling_down" {
+		t.Errorf("DetectUsageLimit(long model cooling down) = %v/%q, want true/proxy_cooling_down", hit, label)
+	}
 	// The bare 429 without the cooling-down phrasing must NOT classify here:
 	// generic 429 stays out of the usage-limit set.
 	if hit, label := DetectUsageLimit("API Error: Request rejected (429)", nil); hit {

--- a/internal/worker/usagelimit_test.go
+++ b/internal/worker/usagelimit_test.go
@@ -73,6 +73,33 @@ func TestDetectUsageLimit_GenericRateLimitSignalsNotClassified(t *testing.T) {
 	}
 }
 
+// TestDetectUsageLimit_ProxyCoolingDown is the #859 escalation guard. The
+// CLIProxyAPI credential-pool exhaustion signature carries no parseable reset,
+// so the provider-limit path (which needs one) never fires; the usage-limit
+// path is what marks the death RateLimitHit=true (recordBackendFailure) and
+// keeps it off the per-issue retry budget. Only the "cooling down" phrasing
+// classifies here — the generic 429 the same message carries stays excluded
+// (the #663 false-positive class).
+func TestDetectUsageLimit_ProxyCoolingDown(t *testing.T) {
+	const proxyDeath = "API Error: Request rejected (429) · All credentials for model claude-opus-4-8 are cooling down"
+	hit, label := DetectUsageLimit(proxyDeath, nil)
+	if !hit {
+		t.Fatalf("DetectUsageLimit(%q) = false, want hit", proxyDeath)
+	}
+	if label != "proxy_cooling_down" {
+		t.Errorf("label = %q, want proxy_cooling_down", label)
+	}
+	// The bare 429 without the cooling-down phrasing must NOT classify here:
+	// generic 429 stays out of the usage-limit set.
+	if hit, label := DetectUsageLimit("API Error: Request rejected (429)", nil); hit {
+		t.Errorf("DetectUsageLimit(bare rejected 429) incorrectly hit (label=%q) — generic 429 stays excluded", label)
+	}
+	// Unrelated prose containing "cooling down" must not classify.
+	if hit, label := DetectUsageLimit("the compressor needs a cooling down period in HVAC docs", nil); hit {
+		t.Errorf("DetectUsageLimit(HVAC prose) incorrectly hit (label=%q)", label)
+	}
+}
+
 // #805: operators can extend the classifier per backend via
 // model.backends.<name>.usage_limit_patterns; the matched label is the regex
 // source so BackendHealth.Pattern names which entry fired.


### PR DESCRIPTION
Implements #859

## Changes

CLIProxyAPI returns quota exhaustion as `Request rejected (429) · All credentials for model <m> are cooling down`. Neither half matched the classifier: `http_429` required 429 next to an http/status/code/error marker (`rejected (429)` was not covered), and no pattern matched the cooling-down phrase. Quota deaths were recorded `rate_limit_hit=false` and burned the per-issue retry budget.

- **`internal/worker/ratelimit.go`**: add `proxy_cooling_down` pattern (`credentials? for model .{0,40}(?:are|is) cooling down`, bounded so unrelated prose does not false-positive); widen `http_429` to accept the `rejected (429)` shape via a `rejected` marker + optional `(` separator (the trailing `\b` still rejects `42900`).
- **`internal/worker/usagelimit.go`**: add `proxy_cooling_down` to `usageLimitPatterns`. This is the important half: the signature states **no** reset window, so the provider-limit path (which requires a parseable reset) never fires. The usage-limit path (`IsUsageLimit` → `recordBackendFailure`) is what actually sets `RateLimitHit=true` and excludes the death from `FailedAttemptsForIssue`. Generic 429 stays excluded from this set (the #663 false-positive class).
- Reset-extractor tolerance verified: a signature with no `try again at/resets` clause yields no reset (`ok=false`), not a parse error.

## Note on scope

The issue anticipated a `ratelimit.go`-only change. In tracing the death path I found that `DetectRateLimit` alone is insufficient for a no-reset signature: `RateLimitHit=true` is only set by `recordProviderLimit` (needs a parseable reset) or `recordBackendFailure` (via the separate `usageLimitPatterns` set). So the fix touches both pattern sets; no orchestrator changes were needed.

## Testing

- New fixtures in `ratelimit_test.go`: exact sup-277 line → `proxy_cooling_down`, bare `Request rejected (429)` → `http_429`, cooling-down-in-HVAC-prose negative case, and reset-extractor tolerance.
- New `usagelimit_test.go` test: proxy line classifies as a usage limit; bare 429 and HVAC prose do not.
- `go build ./cmd/maestro/` and `go test ./...` pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR classifies CLIProxyAPI credential cooling-down responses as retry-budget-safe rate limits. The main changes are:

- Added a `proxy_cooling_down` pattern to rate-limit detection.
- Added the same cooling-down pattern to usage-limit detection.
- Expanded `http_429` matching for `Request rejected (429)` responses.
- Added tests for exact proxy messages, long model IDs, generic 429s, unrelated prose, and reset parsing.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The worker classifier test list was retrieved before execution, as shown in the worker-classifier-list.log.
- The targeted worker classifier tests ran and all exited with code 0, including tests such as TestDetectRateLimit and TestParseRateLimitReset\_Variants, indicating passing results.
- The Maestro build completed successfully with exit code 0 when running go build ./cmd/maestro/.

<a href="https://app.greptile.com/trex/runs/13973699/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/ratelimit.go | Adds CLIProxyAPI cooling-down detection and broadens 429 matching for rejected proxy responses. |
| internal/worker/usagelimit.go | Adds the cooling-down usage-limit signature so no-reset proxy quota failures can mark backend rate-limit state. |
| internal/worker/ratelimit_test.go | Adds tests for proxy cooling-down rate-limit detection, long model IDs, rejected 429s, and reset parsing. |
| internal/worker/usagelimit_test.go | Adds tests for proxy cooling-down usage-limit detection while keeping bare 429s excluded. |

<sub>Reviews (3): Last reviewed commit: ["worker: match cooling-down model id as \\..."](https://github.com/befeast/maestro/commit/14018d32a6761840e04d198eb42d90ae92d3f07c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43251317)</sub>

<!-- /greptile_comment -->