### PR TITLE
orchestrator: standing reconciliation of moot spawn_repair_worker approvals (#866)

### DIFF
--- a/internal/approvalstore/gate.go
+++ b/internal/approvalstore/gate.go
@@ -187,6 +187,30 @@ func FinalizeExecution(b Binding, id string, status state.ApprovalStatus, now ti
 	return err
 }
 
+// ReconcileMoot mirrors a moot-approval stale transition into the SQLite store
+// after the caller has already recorded it in JSON state (#866). It is a no-op
+// in ModeJSON. A missing row — the common case for an approval that was never
+// approved, so was never seeded into SQLite — is tolerated (there is nothing to
+// reconcile), as is a row already in a terminal status, so a repeated reconcile
+// across cycles, restarts, and concurrent saves never turns into a spurious
+// error. Only the JSON state is authoritative for the fleet read path; this
+// keeps the claim arbiter from diverging.
+func ReconcileMoot(b Binding, id string, now time.Time, reason string) error {
+	if !b.UseSQLite() {
+		return nil
+	}
+	store, cleanup, err := b.resolveStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	_, err = store.MarkStale(context.Background(), b.StateDir, id, now, reason)
+	if errors.Is(err, state.ErrApprovalNotFound) {
+		return nil
+	}
+	return err
+}
+
 func applyJSONTransition(st *state.State, verb, id string, now time.Time, actor, reason string) (*state.Approval, error) {
 	switch verb {
 	case "approve":

--- a/internal/approvalstore/store.go
+++ b/internal/approvalstore/store.go
@@ -547,6 +547,47 @@ func (s *Store) markTerminal(ctx context.Context, stateDir, id string, target st
 	return a, nil
 }
 
+// MarkStale idempotently reconciles a moot approval to the terminal `stale`
+// status in SQLite, mirroring state.markApprovalStale. It is the SQLite half of
+// the #866 fix: when the orchestrator stales a spawn_repair_worker approval in
+// JSON because its target issue reached a terminal state, the same transition
+// must reach the unified approval store so a later approve/reject claim cannot
+// act on a row the JSON state already retired. Only an active row (pending /
+// approved / awaiting_dispatch) is transitioned; a row already stale — or in any
+// other terminal status — is returned unchanged with a nil error, so repeated
+// reconciles, daemon restarts, and concurrent saves converge without churn or a
+// duplicate audit entry. A missing row returns state.ErrApprovalNotFound for the
+// caller (approvalstore.ReconcileMoot) to tolerate.
+func (s *Store) MarkStale(ctx context.Context, stateDir, id string, now time.Time, reason string) (*state.Approval, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	a, b, err := loadApprovalTx(ctx, tx, stateDir, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, state.ErrApprovalNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	switch a.Status {
+	case state.ApprovalStatusPending, state.ApprovalStatusApproved, state.ApprovalStatusAwaitingDispatch:
+		// Active — fall through and stale it.
+	default:
+		// Already stale / superseded / executed / rejected — idempotent no-op.
+		return a, nil
+	}
+	if err := markStaleTx(ctx, tx, a, b, now, reason); err != nil {
+		return a, err
+	}
+	if err := tx.Commit(); err != nil {
+		return a, err
+	}
+	return a, nil
+}
+
 // --- tx helpers -------------------------------------------------------------
 
 func putApprovalTx(ctx context.Context, tx *sql.Tx, a *state.Approval, b RowBinding) (bool, error) {

--- a/internal/approvalstore/store_test.go
+++ b/internal/approvalstore/store_test.go
@@ -290,6 +290,96 @@ func TestApprove_ConcurrentClaimOnce_SeparateConnections(t *testing.T) {
 	}
 }
 
+// #866: MarkStale reconciles a moot pending approval to stale, mirrors the
+// audit entry, and is idempotent — a second call neither errors nor appends a
+// duplicate audit row.
+func TestMarkStale_ReconcilesMootPendingApproval(t *testing.T) {
+	s := openTestStore(t)
+	seedPending(t, s, "rp1", "spawn_repair_worker", &state.SupervisorTarget{Issue: 858, PR: 864})
+
+	got, err := s.MarkStale(context.Background(), testStateDir, "rp1", time.Now().UTC(), "issue #858 resolved (verified merge) — repair worker moot")
+	if err != nil {
+		t.Fatalf("mark stale: %v", err)
+	}
+	if got.Status != state.ApprovalStatusStale {
+		t.Fatalf("status = %q, want stale", got.Status)
+	}
+	if n := auditCount(t, s, "rp1"); n != 2 {
+		t.Fatalf("audit rows = %d, want 2 (created + stale)", n)
+	}
+
+	// Idempotent: second reconcile is a no-op, no duplicate audit row.
+	again, err := s.MarkStale(context.Background(), testStateDir, "rp1", time.Now().UTC(), "again")
+	if err != nil {
+		t.Fatalf("second mark stale: %v", err)
+	}
+	if again.Status != state.ApprovalStatusStale {
+		t.Fatalf("second status = %q, want stale", again.Status)
+	}
+	if n := auditCount(t, s, "rp1"); n != 2 {
+		t.Fatalf("audit rows after re-reconcile = %d, want 2 (idempotent)", n)
+	}
+}
+
+// #866: an approved-but-awaiting_dispatch repair approval (its worker not yet
+// spawned) is reconciled to stale when the issue resolves under it, so the
+// SQLite claim arbiter agrees with the JSON state that dispatch is moot.
+func TestMarkStale_AwaitingDispatchTransitions(t *testing.T) {
+	s := openTestStore(t)
+	seedPending(t, s, "rp2", "spawn_repair_worker", &state.SupervisorTarget{Issue: 858})
+	if _, err := s.Approve(context.Background(), testStateDir, "rp2", time.Now().UTC(), "x", ""); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if _, err := s.MarkAwaitingDispatch(context.Background(), testStateDir, "rp2", time.Now().UTC(), "x", "queued"); err != nil {
+		t.Fatalf("mark awaiting dispatch: %v", err)
+	}
+	got, err := s.MarkStale(context.Background(), testStateDir, "rp2", time.Now().UTC(), "issue #858 closed — repair worker moot")
+	if err != nil {
+		t.Fatalf("mark stale: %v", err)
+	}
+	if got.Status != state.ApprovalStatusStale {
+		t.Fatalf("status = %q, want stale (awaiting_dispatch is active)", got.Status)
+	}
+}
+
+func TestMarkStale_NotFound(t *testing.T) {
+	s := openTestStore(t)
+	if _, err := s.MarkStale(context.Background(), testStateDir, "missing", time.Now().UTC(), "gone"); !errors.Is(err, state.ErrApprovalNotFound) {
+		t.Fatalf("err = %v, want ErrApprovalNotFound", err)
+	}
+}
+
+// #866: ReconcileMoot is the gate-level mirror. In json mode it is a pure
+// no-op; in sqlite mode it stales the row and tolerates a missing row (an
+// approval that was never approved has no SQLite row to reconcile).
+func TestReconcileMoot(t *testing.T) {
+	s := openTestStore(t)
+	seedPending(t, s, "gm1", "spawn_repair_worker", &state.SupervisorTarget{Issue: 858, PR: 864})
+	sqliteBind := Binding{Mode: ModeSQLite, StateDir: testStateDir, Handle: s}
+
+	// json mode: no-op even though the handle could reach the row.
+	jsonBind := Binding{Mode: ModeJSON, StateDir: testStateDir, Handle: s}
+	if err := ReconcileMoot(jsonBind, "gm1", time.Now().UTC(), "moot"); err != nil {
+		t.Fatalf("json ReconcileMoot: %v", err)
+	}
+	if got, _ := s.Get(context.Background(), testStateDir, "gm1"); got.Status != state.ApprovalStatusPending {
+		t.Fatalf("json mode changed status to %q, want pending (no-op)", got.Status)
+	}
+
+	// sqlite mode: reconciles the row to stale.
+	if err := ReconcileMoot(sqliteBind, "gm1", time.Now().UTC(), "issue #858 resolved — repair worker moot"); err != nil {
+		t.Fatalf("sqlite ReconcileMoot: %v", err)
+	}
+	if got, _ := s.Get(context.Background(), testStateDir, "gm1"); got.Status != state.ApprovalStatusStale {
+		t.Fatalf("sqlite mode status = %q, want stale", got.Status)
+	}
+
+	// Missing row (never approved → never seeded) is tolerated.
+	if err := ReconcileMoot(sqliteBind, "never-seeded", time.Now().UTC(), "moot"); err != nil {
+		t.Fatalf("ReconcileMoot on missing row = %v, want nil (tolerated)", err)
+	}
+}
+
 func TestMarkExecuted_Idempotent(t *testing.T) {
 	s := openTestStore(t)
 	seedPending(t, s, "m1", "merge_pr", &state.SupervisorTarget{PR: 3})

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -345,6 +345,11 @@ func (d *Daemon) runOrchestrator(ctx context.Context, cfg *config.Config, opts O
 	orchCfg := *cfg
 	orch := orchestrator.New(&orchCfg)
 	orch.SetBinaryVersion(opts.Version)
+	// #866: let the orchestrator's standing repair-approval reconciler mirror a
+	// moot-approval stale transition into the same SQLite approval store the
+	// fleet approve/reject endpoint uses, so JSON state and SQLite never diverge
+	// under --approvals-store sqlite. json mode makes the mirror a no-op.
+	orch.SetApprovalStore(opts.ApprovalsStore, opts.ApprovalsDBPath)
 	// Fleet-wide EMERGENCY STOP spawn gate (#840): the orchestrator consults this
 	// at the top of startNewWorkers each cycle, so an active stop halts new
 	// spawns (and the router LLM calls that only happen inside the spawn loop)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/mission"
@@ -101,6 +102,13 @@ type Orchestrator struct {
 
 	// Mission processor (nil when missions disabled)
 	missionProc *mission.Processor
+
+	// approvalsBinding, when SetApprovalStore is called, lets the standing
+	// repair-approval reconciler (#866) mirror a moot-approval stale transition
+	// into the same unified SQLite approval store the fleet approve/reject
+	// endpoint uses, so JSON state and SQLite never diverge under
+	// --approvals-store sqlite. Zero value (ModeJSON) makes the mirror a no-op.
+	approvalsBinding approvalstore.Binding
 
 	// Config hot-reload channel (nil = disabled, safe in select)
 	configReloadCh <-chan *config.Config
@@ -211,6 +219,25 @@ func (o *Orchestrator) SetReadSource(src githubReadSource) {
 // claims no new issues and spawns no new workers. Passing nil clears the gate.
 func (o *Orchestrator) SetEmergencyHalt(fn func() bool) {
 	o.emergencyHaltFn = fn
+}
+
+// SetApprovalStore configures which approval store the orchestrator's standing
+// repair-approval reconciler (#866) mirrors a moot-approval stale transition
+// into. mode/dbPath come from the daemon's --approvals-store/--approvals-db
+// flags (the same pair the fleet approve/reject endpoint uses); StateDir and
+// Repo are taken from the orchestrator config at reconcile time. An unparseable
+// mode falls back to json (mirror is a no-op) and is logged rather than fatal —
+// the JSON reconciliation, which the fleet dashboard reads, still happens.
+func (o *Orchestrator) SetApprovalStore(mode, dbPath string) {
+	if o == nil {
+		return
+	}
+	m, err := approvalstore.ParseMode(mode)
+	if err != nil {
+		log.Printf("[orch] invalid --approvals-store %q; repair-approval reconcile mirrors to JSON only: %v", mode, err)
+		m = approvalstore.ModeJSON
+	}
+	o.approvalsBinding = approvalstore.Binding{Mode: m, DBPath: dbPath}
 }
 
 func (o *Orchestrator) pidAlive(pid int) bool {
@@ -2226,6 +2253,15 @@ func (o *Orchestrator) RunOnce() error {
 	// covers sessions that reached code_landed before the verifier was available
 	// or where the verifier passed on a later cycle.
 	o.reconcileCodeLandedSessions(s)
+
+	// Step 3b2: Standing reconciliation of moot spawn_repair_worker approvals
+	// (#866). Independent of the exact done-transition cycle, this stales any
+	// repair approval whose target issue already reached a terminal state (a
+	// done session, or the issue closed on GitHub), so a transition lost to a
+	// conflicting concurrent state save self-heals here instead of aging past
+	// SLA as a false operator gate. Runs after checkSessions/reconcileCodeLanded
+	// so freshly-done sessions are already reflected in state.
+	o.reconcileResolvedRepairApprovals(s)
 
 	// Step 3c: Observe-merge self-deploy (#751). A PR merged outside the
 	// orchestrator's own merge path (GitHub UI, manual `gh pr merge`, or the
@@ -4760,6 +4796,115 @@ func (o *Orchestrator) holdForLiveVerification(sess *state.Session, prNumber int
 	sess.LiveVerificationNotified = true
 }
 
+// reconcileResolvedRepairApprovals is the standing, idempotent safety net for
+// #866. The edge-triggered stale calls in verifyOutcomeAfterMerge /
+// reconcileCodeLandedSessions fire only in the exact cycle a session transitions
+// to done; if that save is rolled back by a conflicting concurrent write (the
+// supervisor re-recording the same approval, a dashboard action, a merge landing
+// on disk between load and save), the session is already done next cycle and
+// neither edge re-fires — the spawn_repair_worker approval then ages past SLA as
+// a false operator gate, exactly the #858 dogfood incident. This pass runs every
+// cycle and re-derives the transition for any active repair approval whose target
+// issue has reached a terminal state (a done session, or the issue closed on
+// GitHub), so reconciliation converges regardless of which cycle first missed it
+// and survives a daemon restart. markApprovalStale is a no-op once stale, so it
+// is safe to run every cycle; unrelated approvals are never touched.
+func (o *Orchestrator) reconcileResolvedRepairApprovals(s *state.State) {
+	if o == nil || s == nil {
+		return
+	}
+	issues := s.ActiveSpawnRepairWorkerApprovalIssues()
+	if len(issues) == 0 {
+		return
+	}
+	now := time.Now().UTC()
+	for _, issue := range issues {
+		resolved, reason := o.repairApprovalIssueResolved(s, issue)
+		if !resolved {
+			continue
+		}
+		o.reconcileMootRepairApprovals(s, issue, now, reason)
+	}
+}
+
+// repairApprovalIssueResolved reports whether a spawn_repair_worker approval for
+// issue is moot: its target work reached a terminal state. A done session for
+// the issue is authoritative and needs no GitHub read (the merged/verified/
+// closed path). Otherwise, if no session is still actively working the issue,
+// the issue is checked on GitHub and treated as resolved when closed (the
+// externally-closed path). An issue still being actively worked — or a GitHub
+// read error — is reported unresolved so a legitimately-pending repair approval
+// is never staled out from under an operator.
+func (o *Orchestrator) repairApprovalIssueResolved(s *state.State, issue int) (bool, string) {
+	activeSession := false
+	for _, sess := range s.Sessions {
+		if sess == nil || sess.IssueNumber != issue {
+			continue
+		}
+		if sess.Status == state.StatusDone {
+			return true, fmt.Sprintf("issue #%d resolved (session done) — repair worker moot", issue)
+		}
+		if repairIssueSessionActive(sess.Status) {
+			activeSession = true
+		}
+	}
+	if activeSession {
+		return false, ""
+	}
+	closed, err := o.isIssueClosed(issue)
+	if err != nil {
+		log.Printf("[orch] repair-approval reconcile: issue #%d closed-state check failed; leaving approval pending: %v", issue, err)
+		return false, ""
+	}
+	if closed {
+		return true, fmt.Sprintf("issue #%d closed — repair worker moot", issue)
+	}
+	return false, ""
+}
+
+// repairIssueSessionActive reports whether a session status means the issue is
+// still being worked, so a repair approval is not yet moot. The terminal-failure
+// statuses (failed/dead/conflict_failed/retry_exhausted) are deliberately NOT
+// active: with those the repair approval may be legitimate, so resolution falls
+// through to the GitHub issue-closed check rather than assuming the issue open.
+func repairIssueSessionActive(status state.SessionStatus) bool {
+	switch status {
+	case state.StatusQueued, state.StatusRunning, state.StatusPROpen, state.StatusCodeLanded:
+		return true
+	default:
+		return false
+	}
+}
+
+// reconcileMootRepairApprovals stales every active spawn_repair_worker approval
+// targeting issue, emits a per-approval operator journal record (approval id +
+// issue/PR target + terminal-outcome reason), and mirrors the terminal
+// transition into the SQLite approval store when one is configured. It is the
+// single reconcile path shared by the edge-triggered post-merge/outcome callers
+// and the standing reconciler, so every path journals and persists identically
+// (#866). Returns the number staled.
+func (o *Orchestrator) reconcileMootRepairApprovals(s *state.State, issue int, now time.Time, reason string) int {
+	staled := s.StaleSpawnRepairWorkerApprovalsForResolvedIssue(issue, now, reason)
+	for i := range staled {
+		ap := staled[i]
+		pr := 0
+		if ap.Target != nil {
+			pr = ap.Target.PR
+		}
+		log.Printf("[orch] reconciled moot spawn_repair_worker approval %s (issue #%d, PR #%d): %s", ap.ID, issue, pr, reason)
+		if o.approvalsBinding.UseSQLite() {
+			b := o.approvalsBinding
+			b.StateDir = o.cfg.StateDir
+			b.Repo = o.repo
+			b.Project = o.repo
+			if err := approvalstore.ReconcileMoot(b, ap.ID, now, reason); err != nil {
+				log.Printf("[orch] approval %s stale mirror to SQLite failed (JSON already reconciled, retried next cycle): %v", ap.ID, err)
+			}
+		}
+	}
+	return len(staled)
+}
+
 func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 	if o == nil || o.cfg == nil || s == nil {
 		return
@@ -4803,9 +4948,8 @@ func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 			if stale > 0 {
 				log.Printf("[orch] expired %d stale close_issue approval(s) for auto-closed issue #%d", stale, sess.IssueNumber)
 			}
-			if rstale := s.MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue(sess.IssueNumber, now); rstale > 0 {
-				log.Printf("[orch] expired %d stale spawn_repair_worker approval(s) for auto-closed issue #%d", rstale, sess.IssueNumber)
-			}
+			o.reconcileMootRepairApprovals(s, sess.IssueNumber, now,
+				fmt.Sprintf("issue #%d resolved (verified merge) — repair worker moot", sess.IssueNumber))
 		}
 	}
 }
@@ -5080,9 +5224,8 @@ func (o *Orchestrator) verifyOutcomeAfterMerge(s *state.State, sess *state.Sessi
 			if stale > 0 {
 				log.Printf("[orch] expired %d stale close_issue approval(s) for auto-closed issue #%d", stale, sess.IssueNumber)
 			}
-			if rstale := s.MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue(sess.IssueNumber, now); rstale > 0 {
-				log.Printf("[orch] expired %d stale spawn_repair_worker approval(s) for auto-closed issue #%d", rstale, sess.IssueNumber)
-			}
+			o.reconcileMootRepairApprovals(s, sess.IssueNumber, now,
+				fmt.Sprintf("issue #%d resolved (verified merge) — repair worker moot", sess.IssueNumber))
 		}
 		o.notifier.Sendf("✅ maestro: outcome verifier passed after PR #%d; issue #%d can be treated as done", prNumber, sess.IssueNumber)
 		return

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4937,21 +4937,23 @@ func (o *Orchestrator) reconcileResolvedRepairApprovals(s *state.State) {
 }
 
 // repairApprovalIssueResolved reports whether a spawn_repair_worker approval for
-// issue is moot: its target work reached a terminal state. A done session for
-// the issue is authoritative and needs no GitHub read (the merged/verified/
-// closed path). Otherwise, if no session is still actively working the issue,
-// the issue is checked on GitHub and treated as resolved when closed (the
-// externally-closed path). An issue still being actively worked — or a GitHub
-// read error — is reported unresolved so a legitimately-pending repair approval
+// issue is moot: its target work reached a terminal state. An active session
+// always takes precedence over an older done session for the same issue, because
+// the active session may be the very repair the approval controls. When no
+// session is active, a done session is authoritative and needs no GitHub read
+// (the merged/verified/closed path). Otherwise the issue is checked on GitHub
+// and treated as resolved when closed (the externally-closed path). A GitHub
+// read error is reported unresolved so a legitimately-pending repair approval
 // is never staled out from under an operator.
 func (o *Orchestrator) repairApprovalIssueResolved(s *state.State, issue int) (bool, string) {
 	activeSession := false
+	doneSession := false
 	for _, sess := range s.Sessions {
 		if sess == nil || sess.IssueNumber != issue {
 			continue
 		}
 		if sess.Status == state.StatusDone {
-			return true, fmt.Sprintf("issue #%d resolved (session done) — repair worker moot", issue)
+			doneSession = true
 		}
 		if repairIssueSessionActive(sess.Status) {
 			activeSession = true
@@ -4959,6 +4961,9 @@ func (o *Orchestrator) repairApprovalIssueResolved(s *state.State, issue int) (b
 	}
 	if activeSession {
 		return false, ""
+	}
+	if doneSession {
+		return true, fmt.Sprintf("issue #%d resolved (session done) — repair worker moot", issue)
 	}
 	closed, err := o.isIssueClosed(issue)
 	if err != nil {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4941,19 +4941,26 @@ func (o *Orchestrator) reconcileResolvedRepairApprovals(s *state.State) {
 // always takes precedence over an older done session for the same issue, because
 // the active session may be the very repair the approval controls. When no
 // session is active, a done session is authoritative and needs no GitHub read
-// (the merged/verified/closed path). Otherwise the issue is checked on GitHub
-// and treated as resolved when closed (the externally-closed path). A GitHub
-// read error is reported unresolved so a legitimately-pending repair approval
-// is never staled out from under an operator.
+// only when no terminal-failure session also exists. A failed/dead/conflicted/
+// retry-exhausted session means the issue may have reopened or a newer repair
+// may still be needed, so it takes precedence over the done shortcut and falls
+// through to the GitHub issue check. Otherwise the issue is treated as resolved
+// when closed (the externally-closed path). A GitHub read error is reported
+// unresolved so a legitimately-pending repair approval is never staled out from
+// under an operator.
 func (o *Orchestrator) repairApprovalIssueResolved(s *state.State, issue int) (bool, string) {
 	activeSession := false
 	doneSession := false
+	failedSession := false
 	for _, sess := range s.Sessions {
 		if sess == nil || sess.IssueNumber != issue {
 			continue
 		}
 		if sess.Status == state.StatusDone {
 			doneSession = true
+		}
+		if state.IsTerminal(sess.Status) && sess.Status != state.StatusDone {
+			failedSession = true
 		}
 		if repairIssueSessionActive(sess.Status) {
 			activeSession = true
@@ -4962,7 +4969,7 @@ func (o *Orchestrator) repairApprovalIssueResolved(s *state.State, issue int) (b
 	if activeSession {
 		return false, ""
 	}
-	if doneSession {
+	if doneSession && !failedSession {
 		return true, fmt.Sprintf("issue #%d resolved (session done) — repair worker moot", issue)
 	}
 	closed, err := o.isIssueClosed(issue)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5019,6 +5019,19 @@ func (o *Orchestrator) reconcileMootRepairApprovals(s *state.State, issue int, n
 	return len(staled)
 }
 
+// reconcileMootRepairApprovalsAfterResolution is the edge-triggered counterpart
+// to the standing reconciler. A session may have just reached done while another
+// same-issue session is still active; in that case the repair approval is not
+// moot and must survive. Reuse the same full-session resolution check before
+// staling by issue number so edge and standing paths cannot disagree (#866).
+func (o *Orchestrator) reconcileMootRepairApprovalsAfterResolution(s *state.State, issue int, now time.Time, reason string) int {
+	resolved, _ := o.repairApprovalIssueResolved(s, issue)
+	if !resolved {
+		return 0
+	}
+	return o.reconcileMootRepairApprovals(s, issue, now, reason)
+}
+
 func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 	if o == nil || o.cfg == nil || s == nil {
 		return
@@ -5062,7 +5075,7 @@ func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 			if stale > 0 {
 				log.Printf("[orch] expired %d stale close_issue approval(s) for auto-closed issue #%d", stale, sess.IssueNumber)
 			}
-			o.reconcileMootRepairApprovals(s, sess.IssueNumber, now,
+			o.reconcileMootRepairApprovalsAfterResolution(s, sess.IssueNumber, now,
 				fmt.Sprintf("issue #%d resolved (verified merge) — repair worker moot", sess.IssueNumber))
 		}
 	}
@@ -5338,7 +5351,7 @@ func (o *Orchestrator) verifyOutcomeAfterMerge(s *state.State, sess *state.Sessi
 			if stale > 0 {
 				log.Printf("[orch] expired %d stale close_issue approval(s) for auto-closed issue #%d", stale, sess.IssueNumber)
 			}
-			o.reconcileMootRepairApprovals(s, sess.IssueNumber, now,
+			o.reconcileMootRepairApprovalsAfterResolution(s, sess.IssueNumber, now,
 				fmt.Sprintf("issue #%d resolved (verified merge) — repair worker moot", sess.IssueNumber))
 		}
 		o.notifier.Sendf("✅ maestro: outcome verifier passed after PR #%d; issue #%d can be treated as done", prNumber, sess.IssueNumber)

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -119,6 +119,51 @@ func TestReconcileResolvedRepairApprovals_ActiveSessionOutranksOlderDone(t *test
 	}
 }
 
+// A terminal-failure session must also outrank the done-session shortcut. The
+// GitHub issue is the authority in this ambiguous history: if it is open the
+// repair remains actionable; if it is closed the approval is safely staled.
+func TestReconcileResolvedRepairApprovals_FailedSessionOutranksOlderDone(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 47, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name        string
+		issueClosed bool
+		want        state.ApprovalStatus
+	}{
+		{name: "open issue keeps repair pending", issueClosed: false, want: state.ApprovalStatusPending},
+		{name: "closed issue stales repair", issueClosed: true, want: state.ApprovalStatusStale},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			checks := 0
+			o := &Orchestrator{
+				cfg:      &config.Config{Repo: "owner/repo"},
+				notifier: &notify.Notifier{},
+				isIssueClosedFn: func(issue int) (bool, error) {
+					checks++
+					return tc.issueClosed, nil
+				},
+			}
+
+			s := state.NewState()
+			s.Sessions = map[string]*state.Session{
+				"sup-old-done":   {IssueNumber: 858, Status: state.StatusDone, PRNumber: 864},
+				"sup-new-failed": {IssueNumber: 858, Status: state.StatusRetryExhausted, PRNumber: 867},
+			}
+			s.Approvals = []state.Approval{
+				repairApproval("ap-repair-858-after-failure", 858, 867, state.ApprovalStatusPending, now),
+			}
+
+			o.reconcileResolvedRepairApprovals(s)
+
+			if checks != 1 {
+				t.Fatalf("GitHub issue checks = %d, want 1", checks)
+			}
+			if got := approvalStatus(t, s, "ap-repair-858-after-failure"); got != tc.want {
+				t.Fatalf("repair approval = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestReconcileResolvedRepairApprovals_ExternallyClosedIssue covers the
 // externally-closed reconciliation path: an issue with no done session but
 // closed on GitHub is reconciled; an issue that is still open (a failed session

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -191,6 +192,78 @@ func TestVerifyOutcomeAfterMerge_ReconcilesRepairApproval(t *testing.T) {
 	}
 	if got := approvalStatus(t, s, "ap-repair-858"); got != state.ApprovalStatusStale {
 		t.Fatalf("repair approval after verified merge = %q, want stale", got)
+	}
+}
+
+func TestVerifyOutcomeAfterMerge_KeepsRepairApprovalForActiveSameIssue(t *testing.T) {
+	now := time.Date(2026, 7, 10, 8, 31, 0, 0, time.UTC)
+	closed := false
+	o := &Orchestrator{
+		cfg:            &config.Config{Repo: "owner/repo"},
+		notifier:       &notify.Notifier{},
+		outcomeCheckFn: healthyOutcome(),
+		isIssueClosedFn: func(int) (bool, error) {
+			return closed, nil
+		},
+		ghCloseIssueFn: func(int, string) error {
+			closed = true
+			return nil
+		},
+	}
+
+	landed := &state.Session{IssueNumber: 858, Status: state.StatusCodeLanded, PRNumber: 864}
+	active := &state.Session{IssueNumber: 858, Status: state.StatusRunning}
+	s := state.NewState()
+	s.Sessions = map[string]*state.Session{"sup-old": landed, "sup-active": active}
+	s.Approvals = []state.Approval{
+		repairApproval("ap-repair-858-active-edge", 858, 864, state.ApprovalStatusPending, now),
+	}
+
+	o.verifyOutcomeAfterMerge(s, landed, 864)
+
+	if landed.Status != state.StatusDone {
+		t.Fatalf("landed session status = %q, want done", landed.Status)
+	}
+	if got := approvalStatus(t, s, "ap-repair-858-active-edge"); got != state.ApprovalStatusPending {
+		t.Fatalf("repair approval with active same-issue session = %q, want pending", got)
+	}
+}
+
+func TestReconcileCodeLandedSessions_KeepsRepairApprovalForActiveSameIssue(t *testing.T) {
+	now := time.Date(2026, 7, 10, 8, 31, 0, 0, time.UTC)
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			Outcome: outcome.Brief{
+				DesiredOutcome:      "Live app works",
+				VerifierCommand:     "check-live",
+				PassRequiredForDone: boolPtr(true),
+			},
+		},
+		notifier:       &notify.Notifier{},
+		outcomeCheckFn: healthyOutcome(),
+		isPRMergedFn: func(pr int) (bool, error) {
+			return pr == 864, nil
+		},
+		isIssueClosedFn: func(int) (bool, error) { return false, nil },
+		ghCloseIssueFn:  func(int, string) error { return nil },
+	}
+
+	landed := &state.Session{IssueNumber: 858, Status: state.StatusCodeLanded, PRNumber: 864}
+	active := &state.Session{IssueNumber: 858, Status: state.StatusRunning}
+	s := state.NewState()
+	s.Sessions = map[string]*state.Session{"sup-old": landed, "sup-active": active}
+	s.Approvals = []state.Approval{
+		repairApproval("ap-repair-858-active-reconcile", 858, 864, state.ApprovalStatusPending, now),
+	}
+
+	o.reconcileCodeLandedSessions(s)
+
+	if landed.Status != state.StatusDone {
+		t.Fatalf("landed session status = %q, want done", landed.Status)
+	}
+	if got := approvalStatus(t, s, "ap-repair-858-active-reconcile"); got != state.ApprovalStatusPending {
+		t.Fatalf("repair approval with active same-issue session = %q, want pending", got)
 	}
 }
 

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -88,6 +88,36 @@ func TestReconcileResolvedRepairApprovals_DoneSessionSelfHeals(t *testing.T) {
 	}
 }
 
+// A newer active session for an issue must take precedence over an older done
+// session. Otherwise the standing reconciler can stale the approval controlling
+// the active repair and make legitimate work disappear.
+func TestReconcileResolvedRepairApprovals_ActiveSessionOutranksOlderDone(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 47, 0, 0, time.UTC)
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo"},
+		notifier: &notify.Notifier{},
+		isIssueClosedFn: func(issue int) (bool, error) {
+			t.Fatalf("active issue #%d must not fall through to a GitHub closed-state check", issue)
+			return false, nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions = map[string]*state.Session{
+		"sup-old": {IssueNumber: 858, Status: state.StatusDone, PRNumber: 864},
+		"sup-new": {IssueNumber: 858, Status: state.StatusRunning},
+	}
+	s.Approvals = []state.Approval{
+		repairApproval("ap-repair-858-active", 858, 864, state.ApprovalStatusPending, now),
+	}
+
+	o.reconcileResolvedRepairApprovals(s)
+
+	if got := approvalStatus(t, s, "ap-repair-858-active"); got != state.ApprovalStatusPending {
+		t.Fatalf("repair approval with active session = %q, want pending", got)
+	}
+}
+
 // TestReconcileResolvedRepairApprovals_ExternallyClosedIssue covers the
 // externally-closed reconciliation path: an issue with no done session but
 // closed on GitHub is reconciled; an issue that is still open (a failed session

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -1,0 +1,211 @@
+package orchestrator
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/approvalstore"
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+const actionSpawnRepairWorker = "spawn_repair_worker"
+
+func repairApproval(id string, issue, pr int, status state.ApprovalStatus, now time.Time) state.Approval {
+	return state.Approval{
+		ID:        id,
+		Action:    actionSpawnRepairWorker,
+		Target:    &state.SupervisorTarget{Issue: issue, PR: pr},
+		Status:    status,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Audit:     []state.ApprovalAudit{{At: now, Event: state.ApprovalAuditCreated}},
+	}
+}
+
+func approvalStatus(t *testing.T, s *state.State, id string) state.ApprovalStatus {
+	t.Helper()
+	a, ok := s.FindApproval(id)
+	if !ok {
+		t.Fatalf("approval %q vanished", id)
+	}
+	return a.Status
+}
+
+// TestReconcileResolvedRepairApprovals_DoneSessionSelfHeals is the #866
+// regression: even when the edge-triggered post-merge stale call was lost (the
+// live #858 incident left the approval pending with only its `created` audit
+// event), the standing reconciler stales the moot spawn_repair_worker approval
+// on the next cycle because the target issue's session is already done. Unrelated
+// approvals — a repair approval for an actively-worked issue and a spawn_worker
+// approval — are untouched, and the pass is idempotent.
+func TestReconcileResolvedRepairApprovals_DoneSessionSelfHeals(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 47, 0, 0, time.UTC)
+	o := &Orchestrator{cfg: &config.Config{Repo: "owner/repo"}, notifier: &notify.Notifier{}}
+
+	s := state.NewState()
+	s.Sessions = map[string]*state.Session{
+		"sup-305": {IssueNumber: 858, Status: state.StatusDone, PRNumber: 864},
+		"sup-400": {IssueNumber: 900, Status: state.StatusRunning},
+	}
+	s.Approvals = []state.Approval{
+		repairApproval("ap-repair-858", 858, 864, state.ApprovalStatusPending, now),
+		repairApproval("ap-repair-900", 900, 0, state.ApprovalStatusPending, now),
+		{ID: "ap-spawn-858", Action: "spawn_worker", Target: &state.SupervisorTarget{Issue: 858}, Status: state.ApprovalStatusPending, CreatedAt: now,
+			Audit: []state.ApprovalAudit{{At: now, Event: state.ApprovalAuditCreated}}},
+	}
+
+	o.reconcileResolvedRepairApprovals(s)
+
+	if got := approvalStatus(t, s, "ap-repair-858"); got != state.ApprovalStatusStale {
+		t.Fatalf("repair approval for done issue = %q, want stale", got)
+	}
+	moot, _ := s.FindApproval("ap-repair-858")
+	last := moot.Audit[len(moot.Audit)-1]
+	if last.Event != state.ApprovalAuditStale || !strings.Contains(last.Reason, "session done") {
+		t.Fatalf("stale audit = {%q,%q}, want stale reason mentioning session done", last.Event, last.Reason)
+	}
+	if got := approvalStatus(t, s, "ap-repair-900"); got != state.ApprovalStatusPending {
+		t.Fatalf("repair approval for actively-worked issue = %q, want pending (untouched)", got)
+	}
+	if got := approvalStatus(t, s, "ap-spawn-858"); got != state.ApprovalStatusPending {
+		t.Fatalf("spawn_worker approval = %q, want pending (only spawn_repair_worker reconciled)", got)
+	}
+
+	// Idempotent: a second cycle changes nothing and appends no new audit entry.
+	auditLen := len(moot.Audit)
+	o.reconcileResolvedRepairApprovals(s)
+	if got := approvalStatus(t, s, "ap-repair-858"); got != state.ApprovalStatusStale {
+		t.Fatalf("after re-run status = %q, want stale", got)
+	}
+	moot2, _ := s.FindApproval("ap-repair-858")
+	if len(moot2.Audit) != auditLen {
+		t.Fatalf("re-run appended audit entries (%d -> %d); reconcile must be idempotent", auditLen, len(moot2.Audit))
+	}
+}
+
+// TestReconcileResolvedRepairApprovals_ExternallyClosedIssue covers the
+// externally-closed reconciliation path: an issue with no done session but
+// closed on GitHub is reconciled; an issue that is still open (a failed session
+// awaiting a legitimate repair decision) is left pending.
+func TestReconcileResolvedRepairApprovals_ExternallyClosedIssue(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 47, 0, 0, time.UTC)
+	closedIssues := map[int]bool{858: true, 700: false}
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo"},
+		notifier: &notify.Notifier{},
+		isIssueClosedFn: func(issue int) (bool, error) {
+			return closedIssues[issue], nil
+		},
+	}
+
+	s := state.NewState()
+	// #700 has a failed session and is still open — repair approval is legitimate.
+	s.Sessions = map[string]*state.Session{
+		"sup-700": {IssueNumber: 700, Status: state.StatusRetryExhausted},
+	}
+	s.Approvals = []state.Approval{
+		repairApproval("ap-repair-858", 858, 0, state.ApprovalStatusPending, now), // no session, closed externally
+		repairApproval("ap-repair-700", 700, 0, state.ApprovalStatusPending, now), // failed session, still open
+	}
+
+	o.reconcileResolvedRepairApprovals(s)
+
+	if got := approvalStatus(t, s, "ap-repair-858"); got != state.ApprovalStatusStale {
+		t.Fatalf("repair approval for externally-closed issue = %q, want stale", got)
+	}
+	moot, _ := s.FindApproval("ap-repair-858")
+	if last := moot.Audit[len(moot.Audit)-1]; !strings.Contains(last.Reason, "closed") {
+		t.Fatalf("stale reason = %q, want it to mention the issue closed", last.Reason)
+	}
+	if got := approvalStatus(t, s, "ap-repair-700"); got != state.ApprovalStatusPending {
+		t.Fatalf("repair approval for still-open issue = %q, want pending (untouched)", got)
+	}
+}
+
+// TestVerifyOutcomeAfterMerge_ReconcilesRepairApproval reproduces the full #858
+// sequence through the edge path: pending spawn_repair_worker approval → PR
+// merges → outcome verifier passes → issue closes. The session moves to done and
+// the repair approval is reconciled to stale in the same cycle.
+func TestVerifyOutcomeAfterMerge_ReconcilesRepairApproval(t *testing.T) {
+	now := time.Date(2026, 7, 10, 8, 31, 0, 0, time.UTC)
+	closed := false
+	o := &Orchestrator{
+		cfg:            &config.Config{Repo: "owner/repo"},
+		notifier:       &notify.Notifier{},
+		outcomeCheckFn: healthyOutcome(),
+		isIssueClosedFn: func(int) (bool, error) {
+			return closed, nil
+		},
+		ghCloseIssueFn: func(int, string) error {
+			closed = true
+			return nil
+		},
+	}
+
+	sess := &state.Session{IssueNumber: 858, Status: state.StatusCodeLanded, PRNumber: 864}
+	s := state.NewState()
+	s.Sessions = map[string]*state.Session{"sup-305": sess}
+	s.Approvals = []state.Approval{
+		repairApproval("ap-repair-858", 858, 864, state.ApprovalStatusPending, now),
+	}
+
+	o.verifyOutcomeAfterMerge(s, sess, 864)
+
+	if sess.Status != state.StatusDone {
+		t.Fatalf("session status = %q, want done after verified merge", sess.Status)
+	}
+	if got := approvalStatus(t, s, "ap-repair-858"); got != state.ApprovalStatusStale {
+		t.Fatalf("repair approval after verified merge = %q, want stale", got)
+	}
+}
+
+// TestReconcileMootRepairApprovals_MirrorsToSQLite proves acceptance criterion
+// #10: when --approvals-store sqlite is active, the moot-approval stale
+// transition is persisted consistently in BOTH the JSON state and the SQLite
+// approval store, so a later approve/reject claim cannot act on a row the JSON
+// state already retired.
+func TestReconcileMootRepairApprovals_MirrorsToSQLite(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 47, 0, 0, time.UTC)
+	stateDir := t.TempDir()
+	store, err := approvalstore.Open(filepath.Join(t.TempDir(), "maestro.db"))
+	if err != nil {
+		t.Fatalf("open approvals store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	ap := repairApproval("ap-repair-858", 858, 864, state.ApprovalStatusPending, now)
+	ap.PayloadHash = ap.ComputePayloadHash()
+	rb := approvalstore.RowBinding{Project: "owner/repo", Repo: "owner/repo", StateDir: stateDir}
+	if _, err := store.Put(context.Background(), &ap, rb); err != nil {
+		t.Fatalf("seed approval into sqlite: %v", err)
+	}
+
+	o := &Orchestrator{
+		cfg:              &config.Config{Repo: "owner/repo", StateDir: stateDir},
+		repo:             "owner/repo",
+		notifier:         &notify.Notifier{},
+		approvalsBinding: approvalstore.Binding{Mode: approvalstore.ModeSQLite, Handle: store},
+	}
+	s := state.NewState()
+	s.Approvals = []state.Approval{ap}
+
+	n := o.reconcileMootRepairApprovals(s, 858, now, "issue #858 resolved (verified merge) — repair worker moot")
+	if n != 1 {
+		t.Fatalf("reconciled %d approvals, want 1", n)
+	}
+	if got := approvalStatus(t, s, "ap-repair-858"); got != state.ApprovalStatusStale {
+		t.Fatalf("JSON state status = %q, want stale", got)
+	}
+	sqliteRow, err := store.Get(context.Background(), stateDir, "ap-repair-858")
+	if err != nil {
+		t.Fatalf("get sqlite row: %v", err)
+	}
+	if sqliteRow.Status != state.ApprovalStatusStale {
+		t.Fatalf("SQLite status = %q, want stale (must agree with JSON state)", sqliteRow.Status)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2685,11 +2685,27 @@ func closeIssueApprovalTargetsIssue(approval *Approval, issueNumber int) bool {
 // MarkCloseIssueApprovalsStaleForVerifiedIssue, co-located at the same
 // auto-close trust path.
 func (s *State) MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue(issueNumber int, now time.Time) int {
-	if s == nil || issueNumber <= 0 {
-		return 0
-	}
-	count := 0
 	reason := fmt.Sprintf("issue #%d resolved (verified merge) — repair worker moot", issueNumber)
+	return len(s.StaleSpawnRepairWorkerApprovalsForResolvedIssue(issueNumber, now, reason))
+}
+
+// StaleSpawnRepairWorkerApprovalsForResolvedIssue is the reason-carrying core of
+// MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue. It expires every active
+// (pending/approved/awaiting_dispatch) spawn_repair_worker approval targeting
+// issueNumber and returns the staled approvals (post-transition copies) so the
+// caller can emit a per-approval operator journal record — approval id +
+// issue/PR target — and mirror the terminal transition into the SQLite approval
+// store (#866). The reason distinguishes the terminal outcome (verified merge vs
+// externally closed) in the audit trail. Idempotent: an approval already stale
+// is skipped by markApprovalStale, so re-running returns nothing new.
+func (s *State) StaleSpawnRepairWorkerApprovalsForResolvedIssue(issueNumber int, now time.Time, reason string) []Approval {
+	if s == nil || issueNumber <= 0 {
+		return nil
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = fmt.Sprintf("issue #%d resolved — repair worker moot", issueNumber)
+	}
+	var staled []Approval
 	for i := range s.Approvals {
 		approval := &s.Approvals[i]
 		if approval.Action != approvalActionSpawnRepairWorker || approval.Target == nil || approval.Target.Issue != issueNumber {
@@ -2698,10 +2714,41 @@ func (s *State) MarkSpawnRepairWorkerApprovalsStaleForResolvedIssue(issueNumber 
 		switch approval.Status {
 		case ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch:
 			s.markApprovalStale(approval, now, reason)
-			count++
+			staled = append(staled, *approval)
 		}
 	}
-	return count
+	return staled
+}
+
+// ActiveSpawnRepairWorkerApprovalIssues returns the sorted, distinct set of
+// issue numbers that still carry an active (pending/approved/awaiting_dispatch)
+// spawn_repair_worker approval. The orchestrator's standing reconciler (#866)
+// uses it to check only issues with a repair approval actually outstanding,
+// rather than scanning every session or every open issue each cycle.
+func (s *State) ActiveSpawnRepairWorkerApprovalIssues() []int {
+	if s == nil {
+		return nil
+	}
+	seen := make(map[int]struct{})
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if approval.Action != approvalActionSpawnRepairWorker || approval.Target == nil || approval.Target.Issue <= 0 {
+			continue
+		}
+		switch approval.Status {
+		case ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch:
+			seen[approval.Target.Issue] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	issues := make([]int, 0, len(seen))
+	for issue := range seen {
+		issues = append(issues, issue)
+	}
+	sort.Ints(issues)
+	return issues
 }
 
 func (s *State) pendingApproval(id string) (*Approval, error) {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -2223,6 +2223,69 @@ func TestMarkSpawnRepairWorkerApprovalsStaleForResolvedIssue(t *testing.T) {
 	}
 }
 
+// #866: the reason-carrying core stales approved/awaiting_dispatch repair
+// approvals too, records the supplied terminal-outcome reason in the audit
+// trail, returns the staled approvals for per-approval journaling, and is
+// idempotent (a second call finds nothing left to stale).
+func TestStaleSpawnRepairWorkerApprovalsForResolvedIssue(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 47, 0, 0, time.UTC)
+	s := NewState()
+	s.Approvals = []Approval{
+		{ID: "ap-repair-858", Action: approvalActionSpawnRepairWorker, Target: &SupervisorTarget{Issue: 858, PR: 864}, Status: ApprovalStatusPending, CreatedAt: now},
+		{ID: "ap-repair-858b", Action: approvalActionSpawnRepairWorker, Target: &SupervisorTarget{Issue: 858, PR: 864}, Status: ApprovalStatusAwaitingDispatch, CreatedAt: now},
+		{ID: "ap-repair-900", Action: approvalActionSpawnRepairWorker, Target: &SupervisorTarget{Issue: 900}, Status: ApprovalStatusPending, CreatedAt: now},
+	}
+
+	reason := "issue #858 resolved (verified merge) — repair worker moot"
+	staled := s.StaleSpawnRepairWorkerApprovalsForResolvedIssue(858, now.Add(time.Minute), reason)
+	if len(staled) != 2 {
+		t.Fatalf("staled = %d approvals, want 2 (pending + awaiting_dispatch for issue 858)", len(staled))
+	}
+	for _, ap := range staled {
+		if ap.Status != ApprovalStatusStale {
+			t.Fatalf("returned approval %s status = %q, want stale", ap.ID, ap.Status)
+		}
+		last := ap.Audit[len(ap.Audit)-1]
+		if last.Event != ApprovalAuditStale || last.Reason != reason {
+			t.Fatalf("approval %s last audit = {%q,%q}, want {stale,%q}", ap.ID, last.Event, last.Reason, reason)
+		}
+	}
+	if got, _ := s.FindApproval("ap-repair-900"); got.Status != ApprovalStatusPending {
+		t.Fatalf("unrelated issue approval = %q, want pending (untouched)", got.Status)
+	}
+
+	// Idempotent: nothing left active for issue 858.
+	if again := s.StaleSpawnRepairWorkerApprovalsForResolvedIssue(858, now.Add(2*time.Minute), reason); len(again) != 0 {
+		t.Fatalf("second reconcile staled %d approvals, want 0 (idempotent)", len(again))
+	}
+}
+
+// #866: ActiveSpawnRepairWorkerApprovalIssues enumerates only issues that still
+// carry an active repair approval, distinct and sorted, ignoring terminal
+// approvals and non-repair actions.
+func TestActiveSpawnRepairWorkerApprovalIssues(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 47, 0, 0, time.UTC)
+	s := NewState()
+	s.Approvals = []Approval{
+		{ID: "a1", Action: approvalActionSpawnRepairWorker, Target: &SupervisorTarget{Issue: 858}, Status: ApprovalStatusPending, CreatedAt: now},
+		{ID: "a2", Action: approvalActionSpawnRepairWorker, Target: &SupervisorTarget{Issue: 858}, Status: ApprovalStatusAwaitingDispatch, CreatedAt: now},
+		{ID: "a3", Action: approvalActionSpawnRepairWorker, Target: &SupervisorTarget{Issue: 700}, Status: ApprovalStatusApproved, CreatedAt: now},
+		{ID: "a4", Action: approvalActionSpawnRepairWorker, Target: &SupervisorTarget{Issue: 999}, Status: ApprovalStatusStale, CreatedAt: now},
+		{ID: "a5", Action: approvalActionSpawnWorker, Target: &SupervisorTarget{Issue: 500}, Status: ApprovalStatusPending, CreatedAt: now},
+	}
+
+	got := s.ActiveSpawnRepairWorkerApprovalIssues()
+	want := []int{700, 858}
+	if len(got) != len(want) {
+		t.Fatalf("active issues = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("active issues = %v, want %v", got, want)
+		}
+	}
+}
+
 // #515: ReconcileSpawnWorkerApprovalsForStartedSession must supersede
 // awaiting_dispatch records too, not just pending ones — once the
 // worker actually starts, the awaiting record has done its job.


### PR DESCRIPTION
Implements #866

## Problem
A `spawn_repair_worker` approval could stay `pending` past SLA after its target issue resolved (PR merged, outcome verified, issue closed), presenting a false operator gate for work Maestro already completed. The intended stale transition was only invoked on the done-transition *edge* (inside the `markDoneAfterOutcomePass`-gated blocks). If that cycle's `state.Save` rolled back on a conflicting concurrent write, the session was already `done` next cycle, so neither edge re-fired and the approval never reconciled (live #858 incident: pending with only its `created` audit event).

## Changes
- **Standing reconciler** (`reconcileResolvedRepairApprovals`, a new step in `RunOnce`): every cycle, stales any active repair approval whose target issue reached a terminal state — a done session (merged/verified/closed) or the issue closed on GitHub (externally closed). Independent of the done edge, so a lost transition self-heals and converges across daemon restart, repeated outcome checks, and concurrent saves. Idempotent; unrelated and actively-worked approvals are untouched.
- **Shared reconcile path** (`reconcileMootRepairApprovals`): journals each reconciled approval (approval id + issue/PR target + terminal-outcome reason) and mirrors the stale transition into the SQLite approval store. Both edge call sites now route through it.
- **state**: `StaleSpawnRepairWorkerApprovalsForResolvedIssue` (reason-carrying core, returns staled approvals) + `ActiveSpawnRepairWorkerApprovalIssues`; the existing int helper becomes a thin wrapper.
- **approvalstore**: idempotent `Store.MarkStale` + `ReconcileMoot` gate helper so JSON state and the SQLite claim arbiter stay consistent under `--approvals-store sqlite` (no-op in json mode; a never-approved approval with no row is tolerated).
- **daemon**: wire `orch.SetApprovalStore` from the flow.

## Testing
- `internal/state`: reason-carrying stale + active-issue enumerator, idempotency, unrelated untouched.
- `internal/approvalstore`: `MarkStale` (pending + awaiting_dispatch → stale, idempotent, not-found), `ReconcileMoot` (json no-op, sqlite stale, missing-row tolerated).
- `internal/orchestrator`: reproduces the #858 sequence (pending repair approval → PR merges → outcome verifier passes → issue closes) via `verifyOutcomeAfterMerge`; done-session self-heal; externally-closed issue; idempotency; JSON+SQLite consistency mirror.
- `gofmt`, `go vet`, `go test ./...`, `go build ./cmd/maestro/` all clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds standing reconciliation for moot repair-worker approvals. The main changes are:

- A recurring orchestrator pass for resolved repair targets.
- Shared stale-transition logic for edge and standing reconciliation paths.
- SQLite approval-store mirroring for stale repair approvals.
- Tests for done sessions, active same-issue work, externally closed issues, and idempotent stale transitions.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code, and the updated reconciliation path now checks active and failed same-issue sessions before staling repair approvals.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the targeted orchestrator run and confirmed reconciliation steps for issue #858, including spawn\_repair\_worker approval, external issue close, and merge/auto-close, as well as SQLite mirror reconciliation.
- Examined the verbose package-level proof showing state, approvalstore, orchestrator, and daemon all reported ok with final exit code 0.
- Validated the verifyOutcomeAfterMerge sequence, noting that the outcome verifier passed after PR #864, issue #858 was marked done and auto-closed, and stale repair approvals were reconciled.

<a href="https://app.greptile.com/trex/runs/14174372/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds the standing reconciliation path and reuses the same session-aware guard from the edge-triggered stale paths. |
| internal/state/state.go | Adds helpers to find active repair-approval issues and stale active repair approvals with a reason. |
| internal/approvalstore/store.go | Adds an idempotent SQLite stale transition for active approval rows. |
| internal/approvalstore/gate.go | Adds a gate-level helper that mirrors moot approval reconciliation into SQLite mode. |
| internal/daemon/flow.go | Wires the orchestrator to the configured approval store. |

<sub>Reviews (5): Last reviewed commit: ["orchestrator: preserve repair after newe..."](https://github.com/befeast/maestro/commit/11e747aad329db3a03d3b8d16e92642a79c1d2a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43284773)</sub>

<!-- /greptile_comment -->