### PR TITLE
orchestrator: attribution amend wedges when origin tracks only main (#873)

### DIFF
--- a/internal/orchestrator/attribution_amend_test.go
+++ b/internal/orchestrator/attribution_amend_test.go
@@ -291,8 +291,8 @@ func TestAmendHead_DivergedHeadDefersWithoutDiscard(t *testing.T) {
 	remoteHeadBefore := amendGit(t, origin, "rev-parse", branch)
 
 	err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), time.Now().UTC())
-	if !errors.Is(err, errAmendDeferred) {
-		t.Fatalf("expected errAmendDeferred on divergence, got: %v", err)
+	if !errors.Is(err, errAmendDiverged) {
+		t.Fatalf("expected errAmendDiverged on divergence, got: %v", err)
 	}
 
 	// Origin is untouched, and our unpushed local work still exists locally.
@@ -302,4 +302,173 @@ func TestAmendHead_DivergedHeadDefersWithoutDiscard(t *testing.T) {
 	if got := amendGit(t, wt, "show", "HEAD:local.txt"); !strings.Contains(got, "unpushed") {
 		t.Fatalf("local unpushed commit was discarded: %q", got)
 	}
+}
+
+// setupNarrowAmendRepo builds the same origin + seed as setupAmendRepo, but the
+// orchestrator worktree (wt) intentionally tracks ONLY main — the narrow fetch
+// refspec `+refs/heads/main:refs/remotes/origin/main`. It checks out the feature
+// branch from an explicit fetch (FETCH_HEAD), so there is NO
+// refs/remotes/origin/<branch> tracking ref. This is the exact production shape
+// (#873) where the old implicit `--force-with-lease` had no expected value and
+// git rejected every push as "stale info", wedging a quiet branch forever.
+func setupNarrowAmendRepo(t *testing.T) (origin, wt, seed, branch string) {
+	t.Helper()
+	branch = "feat/sup-873-narrow-refspec"
+	root := t.TempDir()
+	origin = filepath.Join(root, "origin.git")
+	seed = filepath.Join(root, "seed")
+	wt = filepath.Join(root, "wt")
+
+	amendGit(t, root, "init", "--bare", origin)
+	amendGit(t, origin, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	amendGit(t, root, "clone", origin, seed)
+	amendConfig(t, seed)
+	amendWrite(t, seed, "README.md", "v1\n")
+	amendGit(t, seed, "add", "README.md")
+	amendGit(t, seed, "commit", "-m", "initial")
+	amendGit(t, seed, "push", "-u", "origin", "main")
+	amendGit(t, seed, "checkout", "-b", branch)
+	amendWrite(t, seed, "work.txt", "worker output v1\n")
+	amendGit(t, seed, "add", "work.txt")
+	amendGit(t, seed, "commit", "-m", "worker: implement feature")
+	amendGit(t, seed, "push", "-u", "origin", branch)
+
+	// Clone tracking only main, then check out the feature branch from an
+	// explicit fetch so no origin/<branch> remote-tracking ref is ever created.
+	amendGit(t, root, "clone", "--single-branch", "--branch", "main", origin, wt)
+	amendConfig(t, wt)
+	amendGit(t, wt, "fetch", "origin", branch)
+	amendGit(t, wt, "checkout", "-b", branch, "FETCH_HEAD")
+	return origin, wt, seed, branch
+}
+
+// assertNoRemoteTrackingFeatureRef fails if refs/remotes/origin/<branch> exists
+// in wt — the precondition that makes the narrow-refspec wedge reproducible.
+func assertNoRemoteTrackingFeatureRef(t *testing.T, wt, branch string) {
+	t.Helper()
+	cmd := exec.Command("git", "-C", wt, "show-ref", "--verify", "--quiet", "refs/remotes/origin/"+branch)
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("precondition failed: refs/remotes/origin/%s exists — narrow-refspec wedge not reproduced", branch)
+	}
+}
+
+// A quiet feature branch (local == remote) under the narrow fetch refspec must
+// receive the attribution trailer exactly once, with NO deferral — the #873
+// wedge. The old implicit `--force-with-lease` had no expected value here and
+// git rejected the push as "stale info", deferring every cycle forever.
+func TestAmendHead_NarrowRefspec_QuietBranchConverges(t *testing.T) {
+	origin, wt, _, branch := setupNarrowAmendRepo(t)
+	assertNoRemoteTrackingFeatureRef(t, wt, branch)
+
+	now := time.Date(2026, 7, 12, 4, 5, 0, 0, time.UTC)
+	if err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), now); err != nil {
+		t.Fatalf("quiet narrow-refspec branch must converge without deferring, got: %v", err)
+	}
+
+	headMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", branch)
+	if !strings.Contains(headMsg, state.AttributionTrailerKey+":") {
+		t.Fatalf("origin head missing attribution trailer:\n%s", headMsg)
+	}
+	if n := trailerCount(headMsg); n != 1 {
+		t.Fatalf("trailer appears %d times, want exactly 1:\n%s", n, headMsg)
+	}
+	// The fix must not broaden the configured refspec as a side effect.
+	if got := amendGit(t, wt, "config", "--get-all", "remote.origin.fetch"); got != "+refs/heads/main:refs/remotes/origin/main" {
+		t.Fatalf("fetch refspec broadened by the amend: %q", got)
+	}
+	// And it must not have created an origin/<branch> tracking ref behind our back.
+	assertNoRemoteTrackingFeatureRef(t, wt, branch)
+}
+
+// Under the narrow refspec, a concurrent worker push that lands in the race
+// window must still be fetched (via FETCH_HEAD, not origin/<branch>),
+// ancestry-checked, retained, and attributed on retry — landing the trailer once
+// on the worker's real commit.
+func TestAmendHead_NarrowRefspec_ConcurrentDescendantAttributedOnRetry(t *testing.T) {
+	origin, wt, seed, branch := setupNarrowAmendRepo(t)
+	assertNoRemoteTrackingFeatureRef(t, wt, branch)
+
+	prevBackoff := amendRetryBackoff
+	amendRetryBackoff = 0
+	defer func() { amendRetryBackoff = prevBackoff }()
+
+	fired := false
+	amendPushRaceHook = func() {
+		if fired {
+			return
+		}
+		fired = true
+		amendWrite(t, seed, "work.txt", "worker output v2 (concurrent)\n")
+		amendGit(t, seed, "commit", "-am", "worker: follow-up commit")
+		amendGit(t, seed, "push", "origin", branch)
+	}
+	defer func() { amendPushRaceHook = nil }()
+
+	now := time.Date(2026, 7, 12, 4, 5, 0, 0, time.UTC)
+	if err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), now); err != nil {
+		t.Fatalf("amend should recover from the race under a narrow refspec, got: %v", err)
+	}
+	if !fired {
+		t.Fatal("race hook never fired — test did not exercise the stale-info path")
+	}
+
+	headMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", branch)
+	if n := trailerCount(headMsg); n != 1 {
+		t.Fatalf("trailer appears %d times, want exactly 1:\n%s", n, headMsg)
+	}
+	if !strings.Contains(headMsg, "worker: follow-up commit") {
+		t.Fatalf("head is not the worker's follow-up commit reworded:\n%s", headMsg)
+	}
+	work := amendGit(t, origin, "show", branch+":work.txt")
+	if !strings.Contains(work, "concurrent") {
+		t.Fatalf("worker's concurrent work.txt was discarded: %q", work)
+	}
+}
+
+// Under the narrow refspec, a divergent remote update (neither head descends from
+// the other) must never be overwritten: the amend defers (errAmendDiverged) and
+// leaves origin untouched.
+func TestAmendHead_NarrowRefspec_DivergenceNeverOverwritten(t *testing.T) {
+	origin, wt, seed, branch := setupNarrowAmendRepo(t)
+	assertNoRemoteTrackingFeatureRef(t, wt, branch)
+
+	// A local unpushed commit on wt...
+	amendWrite(t, wt, "local.txt", "unpushed worker work\n")
+	amendGit(t, wt, "add", "local.txt")
+	amendGit(t, wt, "commit", "-m", "worker: unpushed local commit")
+
+	// ...while origin advances to a diverging sibling commit.
+	amendWrite(t, seed, "work.txt", "diverging remote push\n")
+	amendGit(t, seed, "commit", "-am", "operator: diverging push")
+	amendGit(t, seed, "push", "origin", branch)
+
+	remoteHeadBefore := amendGit(t, origin, "rev-parse", branch)
+
+	err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), time.Now().UTC())
+	if !errors.Is(err, errAmendDiverged) {
+		t.Fatalf("expected errAmendDiverged on divergence, got: %v", err)
+	}
+	if after := amendGit(t, origin, "rev-parse", branch); after != remoteHeadBefore {
+		t.Fatalf("origin head moved on a diverged defer: %s -> %s", remoteHeadBefore, after)
+	}
+	if got := amendGit(t, wt, "show", "HEAD:local.txt"); !strings.Contains(got, "unpushed") {
+		t.Fatalf("local unpushed commit was discarded: %q", got)
+	}
+}
+
+// A missing remote branch must be reported distinctly (errAmendFetchFailed), NOT
+// as an advancing-race deferral: only proven movement says "advancing under
+// concurrent push" (#873).
+func TestAmendHead_NarrowRefspec_MissingBranchReportedDistinctly(t *testing.T) {
+	_, wt, _, branch := setupNarrowAmendRepo(t)
+
+	err := amendHeadWithAttributionTrailer(wt, "feat/sup-873-does-not-exist", testAttribution(), time.Now().UTC())
+	if !errors.Is(err, errAmendFetchFailed) {
+		t.Fatalf("expected errAmendFetchFailed for a missing remote branch, got: %v", err)
+	}
+	if errors.Is(err, errAmendDeferred) {
+		t.Fatal("a missing remote branch must not be reported as an advancing-race deferral")
+	}
+	_ = branch
 }

--- a/internal/orchestrator/attribution_amend_test.go
+++ b/internal/orchestrator/attribution_amend_test.go
@@ -472,3 +472,68 @@ func TestAmendHead_NarrowRefspec_MissingBranchReportedDistinctly(t *testing.T) {
 	}
 	_ = branch
 }
+
+// A same-named tag must never be mistaken for either the remote branch tip or
+// the local push source. Fully qualified fetch and HEAD:refs/heads/<branch> push
+// refspecs keep the entire amend anchored to the branch.
+func TestAmendHead_NarrowRefspec_SameNamedTagUsesBranch(t *testing.T) {
+	origin, wt, seed, branch := setupNarrowAmendRepo(t)
+
+	// Point the ambiguous tag at main so it is deliberately different from the
+	// feature branch head.
+	amendGit(t, seed, "tag", branch, "main")
+	amendGit(t, seed, "push", "origin", "refs/tags/"+branch)
+	branchOID := amendGit(t, origin, "rev-parse", "refs/heads/"+branch)
+	tagOID := amendGit(t, origin, "rev-parse", "refs/tags/"+branch)
+	if branchOID == tagOID {
+		t.Fatal("test precondition failed: same-named tag and branch point to the same object")
+	}
+
+	if err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), time.Now().UTC()); err != nil {
+		t.Fatalf("amend with same-named tag: %v", err)
+	}
+	branchMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", "refs/heads/"+branch)
+	if n := trailerCount(branchMsg); n != 1 {
+		t.Fatalf("branch trailer count = %d, want 1:\n%s", n, branchMsg)
+	}
+	if got := amendGit(t, origin, "rev-parse", "refs/tags/"+branch); got != tagOID {
+		t.Fatalf("same-named tag moved: got %s, want %s", got, tagOID)
+	}
+	tagMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", "refs/tags/"+branch)
+	if strings.Contains(tagMsg, state.AttributionTrailerKey+":") {
+		t.Fatalf("attribution landed on the tag target instead of only the branch:\n%s", tagMsg)
+	}
+}
+
+// If a previous process amended a local-ahead commit and stopped before its
+// push, the next cycle sees a local head that already carries the trailer while
+// the remote remains on its ancestor. That is not success yet: publish the
+// attributed local head under the explicit lease.
+func TestAmendHead_NarrowRefspec_LocalAheadAlreadyAttributedIsPushed(t *testing.T) {
+	origin, wt, _, branch := setupNarrowAmendRepo(t)
+	now := time.Date(2026, 7, 12, 4, 5, 0, 0, time.UTC)
+
+	amendWrite(t, wt, "local-ahead.txt", "work completed before daemon restart\n")
+	amendGit(t, wt, "add", "local-ahead.txt")
+	msg := "worker: local follow-up\n\n" + state.FormatAttributionTrailer(testAttribution(), now)
+	amendGit(t, wt, "commit", "-m", msg)
+	localHead := amendGit(t, wt, "rev-parse", "HEAD")
+	remoteBefore := amendGit(t, origin, "rev-parse", "refs/heads/"+branch)
+	if localHead == remoteBefore {
+		t.Fatal("test precondition failed: local head is not ahead of the remote")
+	}
+
+	if err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), now); err != nil {
+		t.Fatalf("publish already-attributed local-ahead head: %v", err)
+	}
+	if got := amendGit(t, origin, "rev-parse", "refs/heads/"+branch); got != localHead {
+		t.Fatalf("remote head = %s, want attributed local head %s", got, localHead)
+	}
+	remoteMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", "refs/heads/"+branch)
+	if n := trailerCount(remoteMsg); n != 1 {
+		t.Fatalf("remote trailer count = %d, want 1:\n%s", n, remoteMsg)
+	}
+	if got := amendGit(t, origin, "show", "refs/heads/"+branch+":local-ahead.txt"); !strings.Contains(got, "completed") {
+		t.Fatalf("local-ahead work was not published: %q", got)
+	}
+}

--- a/internal/orchestrator/attribution_merge_guard_test.go
+++ b/internal/orchestrator/attribution_merge_guard_test.go
@@ -77,6 +77,44 @@ func TestAutoMergePRs_DeferredAttributionBlocksMerge(t *testing.T) {
 	}
 }
 
+// An unexpected amend failure is just as unsafe as a known deferral: the
+// trailer is not known to be on the remote, so the merge path must fail closed
+// before querying CI or attempting the merge.
+func TestAutoMergePRs_UnexpectedAttributionFailureBlocksMerge(t *testing.T) {
+	branch := "feat/sup-873-amend-error"
+	s := state.NewState()
+	s.Sessions["sup-873"] = mergeGuardSession(branch, 875)
+
+	ciQueried := false
+	merged := false
+	o := &Orchestrator{
+		cfg: &config.Config{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{{Number: 875, HeadRefName: branch}}, nil
+		},
+		amendHeadFn: func(worktreePath, b string, attribution []state.BackendAttribution, now time.Time) error {
+			return errors.New("ordinary git failure")
+		},
+		ghPRCIStatusFn: func(prNumber int) (string, error) {
+			ciQueried = true
+			return "success", nil
+		},
+		ghMergePRFn: func(prNumber int) error {
+			merged = true
+			return nil
+		},
+	}
+
+	o.autoMergePRs(s)
+
+	if merged {
+		t.Fatal("unexpected attribution failure must block the merge")
+	}
+	if ciQueried {
+		t.Fatal("unexpected attribution failure must short-circuit before CI is queried")
+	}
+}
+
 // The guard is specific to the deferral: when the attribution amend lands (or is
 // a no-op), autoMergePRs proceeds past the attribution step into the normal
 // merge flow (here it reaches the CI query). This proves the guard does not

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3098,8 +3098,9 @@ Maestro auto-created this pull request for pushed branch %s because no open pull
 
 // ensureAttributionTrailerOnBranch stamps the durable Maestro-Backend trailer
 // onto the branch head. It returns deferred=true when the amend could not land
-// this cycle because the branch is advancing under a concurrent worker/operator
-// push (errAmendDeferred). The merge flow MUST NOT merge a PR whose amend
+// the trailer this cycle — the branch is advancing under a concurrent push, it
+// diverged from the attributed head, the worktree is mid-write, or the remote
+// tip could not be fetched. The merge flow MUST NOT merge a PR whose amend
 // deferred: merging now would land the PR permanently without the required
 // attribution trailer while the "later retry" the deferral promises never gets
 // to run (#858). A later quiet cycle re-invokes this and completes the trailer
@@ -3110,19 +3111,34 @@ func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *s
 	if sess == nil || len(sess.Attribution) == 0 {
 		return false
 	}
-	if err := o.amendHeadWithAttributionTrailer(sess.Worktree, sess.Branch, sess.Attribution, time.Now().UTC()); err != nil {
-		if errors.Is(err, errAmendDeferred) {
-			// The branch is advancing under a live worker/operator push, so the
-			// force-with-lease could not land this cycle. This is not a failure:
-			// autoMergePRs re-invokes this on every cycle, so a later quiet cycle
-			// (or the pre-merge amend) completes the trailer. Log one concise
-			// line instead of spamming raw git rejection output (#858).
-			log.Printf("[orch] attribution: deferring amend for %s (branch %q advancing under concurrent push; will retry next cycle)", slotName, sess.Branch)
-			return true
-		}
-		log.Printf("[orch] attribution: could not amend branch %q for %s: %v", sess.Branch, slotName, err)
+	err := o.amendHeadWithAttributionTrailer(sess.Worktree, sess.Branch, sess.Attribution, time.Now().UTC())
+	if err == nil {
+		return false
 	}
-	return false
+	// Every deferral means the trailer is not on the branch yet, so the merge flow
+	// must wait (autoMergePRs re-invokes this on every cycle, so a later quiet
+	// cycle or the pre-merge pass completes it). The reasons are logged distinctly
+	// so a quiet-branch convergence bug or a missing-branch / network failure is
+	// never masked as an "advancing under concurrent push" race (#858, #873).
+	switch {
+	case errors.Is(err, errAmendDeferred):
+		log.Printf("[orch] attribution: deferring amend for %s (branch %q advancing under concurrent push; will retry next cycle)", slotName, sess.Branch)
+		return true
+	case errors.Is(err, errAmendDiverged):
+		log.Printf("[orch] attribution: deferring amend for %s (branch %q diverged from the attributed head; not overwriting, will retry next cycle)", slotName, sess.Branch)
+		return true
+	case errors.Is(err, errAmendWorktreeBusy):
+		log.Printf("[orch] attribution: deferring amend for %s (branch %q worktree busy mid-write; will retry next cycle)", slotName, sess.Branch)
+		return true
+	case errors.Is(err, errAmendFetchFailed):
+		log.Printf("[orch] attribution: deferring amend for %s (could not fetch remote branch %q: %v; will retry next cycle)", slotName, sess.Branch, err)
+		return true
+	default:
+		// An unexpected git failure (not a known deferral). Log it; the merge flow
+		// continues as before, but never on a claim that the branch is advancing.
+		log.Printf("[orch] attribution: could not amend branch %q for %s: %v", sess.Branch, slotName, err)
+		return false
+	}
 }
 
 func (o *Orchestrator) amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
@@ -3147,11 +3163,29 @@ var amendRetryBackoff = 400 * time.Millisecond
 // production.
 var amendPushRaceHook func()
 
-// errAmendDeferred signals that the attribution amend could not land this cycle
-// because the branch kept advancing under a concurrent worker/operator push (or
-// the worktree is mid-write). It is not a failure: the caller re-runs the amend
-// on later cycles, so a quieter cycle or the pre-merge pass completes it (#858).
-var errAmendDeferred = errors.New("attribution amend deferred: branch advancing under concurrent push")
+// The attribution amend can decline to land the trailer this cycle for several
+// distinct reasons. Each is a "retry next cycle" deferral — never a merge without
+// the trailer — but they are kept separate so the orchestrator reports them
+// distinctly: only a proven lease race says "advancing under concurrent push".
+// Misreporting a quiet branch — or a missing-branch / network failure — as an
+// advancing race is exactly the wedge #873 fixes.
+var (
+	// errAmendDeferred: the remote branch genuinely advanced under a concurrent
+	// worker/operator push and the force-with-lease was lost on every attempt
+	// (proven movement). A later quieter cycle or the pre-merge pass completes it.
+	errAmendDeferred = errors.New("attribution amend deferred: branch advancing under concurrent push")
+	// errAmendDiverged: the remote head does not descend from the commit we were
+	// attributing (a real divergence, e.g. an unpushed local commit or an operator
+	// force-push). Never overwrite it; defer.
+	errAmendDiverged = errors.New("attribution amend deferred: remote branch diverged from the attributed head")
+	// errAmendWorktreeBusy: the worktree has uncommitted changes (a worker is
+	// mid-write). Amending would race the writer, so defer.
+	errAmendWorktreeBusy = errors.New("attribution amend deferred: worktree has uncommitted changes")
+	// errAmendFetchFailed: the remote branch tip could not be fetched — a missing
+	// remote branch, or an auth / network failure. This is not movement; defer with
+	// a distinct message rather than mislabeling it an advancing race (#873).
+	errAmendFetchFailed = errors.New("attribution amend deferred: could not fetch remote branch tip")
+)
 
 // amendGitCommand builds a git subprocess for the attribution amend with a
 // forced C locale. Git localizes its porcelain and error text per
@@ -3179,15 +3213,32 @@ func isStaleInfoLeaseRejection(out string) bool {
 }
 
 // amendHeadWithAttributionTrailer amends the branch head to carry the durable
-// Maestro-Backend attribution trailer and force-pushes it. It is race-tolerant:
-// when the worker (or an operator) pushes a new commit between our read and our
-// force-with-lease push, git rejects the lease with "stale info". Rather than
-// losing the trailer and spamming raw git errors, it re-fetches the branch,
-// re-applies the trailer onto the commit the worker actually pushed, and retries
-// with backoff. If the branch keeps moving, it defers (errAmendDeferred) so a
-// later cycle completes it. The force-with-lease is only ever retargeted at a
-// head that descends from the commit we were about to attribute, so no push ever
-// discards a commit that is not our own reworded head (#858).
+// Maestro-Backend attribution trailer and force-pushes it. It is race-tolerant
+// and — crucially — does not depend on a refs/remotes/origin/<branch>
+// remote-tracking ref, which a checkout tracking only main (narrow fetch refspec
+// `+refs/heads/main:refs/remotes/origin/main`) never has.
+//
+// Each attempt fetches the remote branch tip explicitly (FETCH_HEAD) and uses
+// that OID both as the ancestry reference and as an explicit
+// `--force-with-lease=refs/heads/<branch>:<oid>` expectation. The implicit
+// `--force-with-lease` form derives its expectation from the remote-tracking
+// ref; when that ref is absent git rejects every push as "stale info", so a
+// quiet branch (local == remote) was misread as an advancing race and wedged
+// forever (#873).
+//
+// The commit that gets attributed is chosen by ancestry, so no push ever
+// discards a commit that is not our own reworded head:
+//   - remote == local: quiet branch; attribute the shared head.
+//   - local is an ancestor of remote: a worker/operator pushed a descendant;
+//     reword that remote head so nothing is lost.
+//   - remote is an ancestor of local: local carries commits the remote lacks;
+//     attribute the local head (remote is fully contained).
+//   - otherwise: a genuine divergence — defer (errAmendDiverged), never
+//     overwrite.
+//
+// When the remote advances between our fetch and our push, git rejects the lease
+// with "stale info"; the amend re-fetches and retries with backoff, deferring
+// (errAmendDeferred) if the branch keeps moving (#858).
 func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
 	worktreePath = strings.TrimSpace(worktreePath)
 	branch = strings.TrimSpace(branch)
@@ -3210,17 +3261,49 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 			return fmt.Errorf("git status: %w\n%s", err, status)
 		}
 		if strings.TrimSpace(string(status)) != "" {
-			return errAmendDeferred
+			return errAmendWorktreeBusy
 		}
 
-		// Record the commit we are about to attribute so a later refetch can
-		// prove the remote only moved forward from it (never discarding work),
-		// and so we can undo an un-pushed amend by resetting back to it.
-		origHeadRaw, err := amendGitCommand(worktreePath, "rev-parse", "HEAD").CombinedOutput()
+		localHeadRaw, err := amendGitCommand(worktreePath, "rev-parse", "HEAD").CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("git rev-parse HEAD: %w\n%s", err, origHeadRaw)
+			return fmt.Errorf("git rev-parse HEAD: %w\n%s", err, localHeadRaw)
 		}
-		origHead := strings.TrimSpace(string(origHeadRaw))
+		localHead := strings.TrimSpace(string(localHeadRaw))
+
+		// Learn the remote branch tip explicitly. This OID is both the lease
+		// expectation and the ancestry reference; we never read
+		// refs/remotes/origin/<branch>, which a narrow-refspec checkout lacks. A
+		// fetch failure (missing branch / auth / network) is reported distinctly,
+		// not as an advancing race (#873).
+		remoteOID, err := fetchRemoteBranchOID(worktreePath, branch)
+		if err != nil {
+			return err
+		}
+
+		// Choose the commit to attribute by ancestry (see the doc comment). base
+		// is the commit we reword; on a push failure we restore HEAD to it so a
+		// deferral never leaves an un-pushed local trailer that would poison the
+		// next cycle (#858).
+		base := localHead
+		switch {
+		case remoteOID == localHead:
+			// Quiet branch: local and remote are identical; attribute the shared
+			// head. This is the common case the old implicit lease wedged (#873).
+		case isAncestorCommit(worktreePath, localHead, remoteOID):
+			// A worker/operator pushed a descendant of our head: reword that
+			// remote head so their concurrent work survives, attributed.
+			base = remoteOID
+			if out, err := amendGitCommand(worktreePath, "reset", "--hard", remoteOID).CombinedOutput(); err != nil {
+				return fmt.Errorf("git reset --hard %s: %w\n%s", remoteOID, err, out)
+			}
+		case isAncestorCommit(worktreePath, remoteOID, localHead):
+			// Local is ahead of the remote and fully contains it; attribute the
+			// local head. The lease still guards against a concurrent push.
+		default:
+			// Neither head descends from the other: a genuine divergence. Never
+			// overwrite it (lease semantics preserved, #858).
+			return errAmendDiverged
+		}
 
 		out, err := amendGitCommand(worktreePath, "log", "-1", "--pretty=%B").CombinedOutput()
 		if err != nil {
@@ -3228,8 +3311,9 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		}
 		msg := state.AppendAttributionTrailer(string(out), attribution, now)
 		if msg == string(out) {
-			// Trailer already present on this head (idempotent — e.g. a prior
-			// cycle landed it), so there is nothing to do and never a duplicate.
+			// Trailer already present on this head (idempotent — a prior cycle
+			// landed it, or we reset onto an already-attributed remote head), so
+			// there is nothing to push and never a duplicate.
 			return nil
 		}
 
@@ -3243,57 +3327,76 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 			amendPushRaceHook()
 		}
 
-		pushOut, pushErr := amendGitCommand(worktreePath, "push", "--force-with-lease", "origin", branch).CombinedOutput()
+		// Explicit lease: require the remote ref to still be at the OID we fetched,
+		// independent of any remote-tracking ref. The implicit form derives the
+		// expectation from refs/remotes/origin/<branch>, which a narrow-refspec
+		// checkout lacks — there git rejects every push as "stale info" and wedges
+		// a quiet branch forever (#873).
+		pushOut, pushErr := amendGitCommand(worktreePath, "push",
+			"--force-with-lease=refs/heads/"+branch+":"+remoteOID, "origin", branch).CombinedOutput()
 		if pushErr == nil {
 			return nil // trailer landed exactly once
 		}
 
-		// The push did not land, so the local --amend is now an un-pushed commit
-		// carrying the trailer while the remote head does not. Undo it before we
-		// return or retry, restoring HEAD to the exact pre-amend commit. Otherwise
-		// a later cycle reads the local trailer, AppendAttributionTrailer no-ops
-		// before any fetch/push, and attribution is lost forever despite the
-		// deferral promising a retry (#858). Resetting to the captured pre-amend
-		// HEAD discards nothing but our own reword — the worker's real commits
-		// live on the remote, not in this un-pushed amend.
-		if out, err := amendGitCommand(worktreePath, "reset", "--hard", origHead).CombinedOutput(); err != nil {
-			return fmt.Errorf("git reset --hard %s (undo un-pushed amend): %w\n%s", origHead, err, out)
+		// The push did not land, so the local --amend is an un-pushed commit
+		// carrying the trailer while the remote does not. Undo it before we return
+		// or retry, restoring HEAD to the pre-amend base. Otherwise a later cycle
+		// reads the local trailer, AppendAttributionTrailer no-ops before any
+		// fetch/push, and attribution is lost despite the deferral promising a
+		// retry (#858). Resetting to base discards nothing but our own reword — the
+		// remote's real commits live on the remote, not in this un-pushed amend.
+		if out, err := amendGitCommand(worktreePath, "reset", "--hard", base).CombinedOutput(); err != nil {
+			return fmt.Errorf("git reset --hard %s (undo un-pushed amend): %w\n%s", base, err, out)
 		}
 
 		if !isStaleInfoLeaseRejection(string(pushOut)) {
 			return fmt.Errorf("git push --force-with-lease origin %s: %w\n%s", branch, pushErr, pushOut)
 		}
 
-		// Stale lease: the remote advanced under a concurrent push. Out of
-		// attempts → defer to a later cycle rather than erroring. HEAD is back on
-		// the pre-amend commit, so the next cycle re-reads the untrailered message
-		// and genuinely retries instead of no-oping on a stale local trailer.
+		// Stale lease: the remote advanced under a concurrent push between our
+		// fetch and our push (proven movement). Out of attempts → defer to a later
+		// cycle rather than erroring. HEAD is back on an untrailered commit, so the
+		// next cycle re-reads the untrailered message and genuinely retries. The
+		// loop's next iteration re-fetches the head the worker actually pushed.
 		if attempt == amendMaxAttempts {
 			return errAmendDeferred
-		}
-
-		// Re-fetch the branch so we can re-apply the trailer onto the head the
-		// worker actually pushed.
-		if out, err := amendGitCommand(worktreePath, "fetch", "origin", branch).CombinedOutput(); err != nil {
-			return fmt.Errorf("git fetch origin %s: %w\n%s", branch, err, out)
-		}
-		// Only re-target the amend when the new remote head descends from the
-		// commit we were attributing: then our work (and the worker's) is fully
-		// contained and resetting to it discards nothing. If the branch diverged
-		// (e.g. an unpushed local commit), defer rather than risk dropping a
-		// commit that is not ours (lease semantics preserved, #858).
-		if err := amendGitCommand(worktreePath, "merge-base", "--is-ancestor",
-			origHead, "origin/"+branch).Run(); err != nil {
-			return errAmendDeferred
-		}
-		if out, err := amendGitCommand(worktreePath, "reset", "--hard", "origin/"+branch).CombinedOutput(); err != nil {
-			return fmt.Errorf("git reset --hard origin/%s: %w\n%s", branch, err, out)
 		}
 		if amendRetryBackoff > 0 {
 			time.Sleep(amendRetryBackoff)
 		}
 	}
 	return errAmendDeferred
+}
+
+// fetchRemoteBranchOID fetches the remote branch tip into FETCH_HEAD and returns
+// its OID. It deliberately does NOT rely on a refs/remotes/origin/<branch>
+// tracking ref: a checkout may intentionally track only main (narrow fetch
+// refspec `+refs/heads/main:refs/remotes/origin/main`), so that ref never exists.
+// `git fetch origin <branch>` updates FETCH_HEAD regardless of the configured
+// refspec and without broadening or rewriting it (#873). A fetch failure —
+// missing remote branch, auth, or network — is wrapped in errAmendFetchFailed so
+// the caller reports it distinctly rather than as an advancing race.
+func fetchRemoteBranchOID(worktreePath, branch string) (string, error) {
+	if out, err := amendGitCommand(worktreePath, "fetch", "origin", branch).CombinedOutput(); err != nil {
+		return "", fmt.Errorf("%w: git fetch origin %s: %v\n%s", errAmendFetchFailed, branch, err, out)
+	}
+	oidRaw, err := amendGitCommand(worktreePath, "rev-parse", "FETCH_HEAD").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%w: git rev-parse FETCH_HEAD: %v\n%s", errAmendFetchFailed, err, oidRaw)
+	}
+	oid := strings.TrimSpace(string(oidRaw))
+	if oid == "" {
+		return "", fmt.Errorf("%w: empty FETCH_HEAD after fetching %s", errAmendFetchFailed, branch)
+	}
+	return oid, nil
+}
+
+// isAncestorCommit reports whether ancestor is an ancestor of (or equal to)
+// descendant in worktreePath's object graph. A non-nil error from git
+// merge-base (unrelated histories, missing objects) reads as "not an ancestor",
+// which is the fail-safe: callers then defer rather than force-push.
+func isAncestorCommit(worktreePath, ancestor, descendant string) bool {
+	return amendGitCommand(worktreePath, "merge-base", "--is-ancestor", ancestor, descendant).Run() == nil
 }
 
 // checkSessions inspects all sessions and updates their status

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3134,10 +3134,10 @@ func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *s
 		log.Printf("[orch] attribution: deferring amend for %s (could not fetch remote branch %q: %v; will retry next cycle)", slotName, sess.Branch, err)
 		return true
 	default:
-		// An unexpected git failure (not a known deferral). Log it; the merge flow
-		// continues as before, but never on a claim that the branch is advancing.
-		log.Printf("[orch] attribution: could not amend branch %q for %s: %v", sess.Branch, slotName, err)
-		return false
+		// Any unexpected amend failure means the trailer is not known to be on
+		// the remote. Fail closed: block the merge and retry on a later cycle.
+		log.Printf("[orch] attribution: deferring amend for %s (could not amend branch %q: %v; will retry next cycle)", slotName, sess.Branch, err)
+		return true
 	}
 }
 
@@ -3310,17 +3310,19 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 			return fmt.Errorf("git log -1: %w\n%s", err, out)
 		}
 		msg := state.AppendAttributionTrailer(string(out), attribution, now)
-		if msg == string(out) {
+		if msg == string(out) && base == remoteOID {
 			// Trailer already present on this head (idempotent — a prior cycle
 			// landed it, or we reset onto an already-attributed remote head), so
 			// there is nothing to push and never a duplicate.
 			return nil
 		}
 
-		cmd := amendGitCommand(worktreePath, "commit", "--amend", "-F", "-")
-		cmd.Stdin = strings.NewReader(msg)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("git commit --amend: %w\n%s", err, out)
+		if msg != string(out) {
+			cmd := amendGitCommand(worktreePath, "commit", "--amend", "-F", "-")
+			cmd.Stdin = strings.NewReader(msg)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("git commit --amend: %w\n%s", err, out)
+			}
 		}
 
 		if amendPushRaceHook != nil {
@@ -3332,8 +3334,9 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		// expectation from refs/remotes/origin/<branch>, which a narrow-refspec
 		// checkout lacks — there git rejects every push as "stale info" and wedges
 		// a quiet branch forever (#873).
+		remoteRef := "refs/heads/" + branch
 		pushOut, pushErr := amendGitCommand(worktreePath, "push",
-			"--force-with-lease=refs/heads/"+branch+":"+remoteOID, "origin", branch).CombinedOutput()
+			"--force-with-lease="+remoteRef+":"+remoteOID, "origin", "HEAD:"+remoteRef).CombinedOutput()
 		if pushErr == nil {
 			return nil // trailer landed exactly once
 		}
@@ -3350,7 +3353,7 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		}
 
 		if !isStaleInfoLeaseRejection(string(pushOut)) {
-			return fmt.Errorf("git push --force-with-lease origin %s: %w\n%s", branch, pushErr, pushOut)
+			return fmt.Errorf("git push --force-with-lease origin HEAD:%s: %w\n%s", remoteRef, pushErr, pushOut)
 		}
 
 		// Stale lease: the remote advanced under a concurrent push between our
@@ -3372,13 +3375,16 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 // its OID. It deliberately does NOT rely on a refs/remotes/origin/<branch>
 // tracking ref: a checkout may intentionally track only main (narrow fetch
 // refspec `+refs/heads/main:refs/remotes/origin/main`), so that ref never exists.
-// `git fetch origin <branch>` updates FETCH_HEAD regardless of the configured
-// refspec and without broadening or rewriting it (#873). A fetch failure —
-// missing remote branch, auth, or network — is wrapped in errAmendFetchFailed so
-// the caller reports it distinctly rather than as an advancing race.
+// `git fetch origin refs/heads/<branch>` updates FETCH_HEAD regardless of the
+// configured refspec and without broadening or rewriting it. The fully qualified
+// source ref prevents a same-named tag from being selected instead of the branch
+// tip (#873). A fetch failure — missing remote branch, auth, or network — is
+// wrapped in errAmendFetchFailed so the caller reports it distinctly rather than
+// as an advancing race.
 func fetchRemoteBranchOID(worktreePath, branch string) (string, error) {
-	if out, err := amendGitCommand(worktreePath, "fetch", "origin", branch).CombinedOutput(); err != nil {
-		return "", fmt.Errorf("%w: git fetch origin %s: %v\n%s", errAmendFetchFailed, branch, err, out)
+	remoteRef := "refs/heads/" + branch
+	if out, err := amendGitCommand(worktreePath, "fetch", "origin", remoteRef).CombinedOutput(); err != nil {
+		return "", fmt.Errorf("%w: git fetch origin %s: %v\n%s", errAmendFetchFailed, remoteRef, err, out)
 	}
 	oidRaw, err := amendGitCommand(worktreePath, "rev-parse", "FETCH_HEAD").CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Implements #873

## Changes
- `amendHeadWithAttributionTrailer` no longer depends on a `refs/remotes/origin/<branch>` remote-tracking ref (absent when a checkout tracks only `main` via the narrow refspec `+refs/heads/main:refs/remotes/origin/main`).
- Each attempt fetches the remote branch tip explicitly (`FETCH_HEAD`) and uses that OID as both the ancestry reference and an explicit `--force-with-lease=refs/heads/<branch>:<oid>` expectation. A quiet branch (local == remote) now converges instead of being misread as an advancing race and wedged forever.
- The attributed commit is chosen by ancestry: quiet head, concurrent descendant (retained + attributed on retry), local-ahead (remote contained), or a genuine divergence that is never overwritten.
- Deferral reasons are reported distinctly (advancing race / divergence / worktree busy / fetch failure); only proven movement logs "advancing under concurrent push". A missing branch or network failure is no longer mislabeled a race. All deferrals still block the merge, preserving the attribution-before-merge guard.
- `git fetch origin <branch>` does not broaden or rewrite the configured fetch refspec.

## Testing
- New narrow-refspec regression tests: quiet convergence (trailer lands once, no defer, refspec unchanged, no `origin/<feature>` ref created), concurrent descendant attributed on retry, divergence never overwritten, missing branch reported distinctly.
- Updated the existing divergence test for the distinct `errAmendDiverged` sentinel.
- `go test ./...`, `go build ./cmd/maestro/`, `gofmt`, `go vet` all pass.

Runtime verification (live repair of #867 → Greptile retry → merge/self-deploy → freeing capacity for #869) remains an operator/runtime step and is not asserted by this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates attribution amendment for branches without remote-tracking refs. The main changes are:

- Fetches the remote branch tip explicitly through `FETCH_HEAD`.
- Selects the attributed commit using ancestry checks.
- Pushes with an explicit force-with-lease expectation.
- Separates race, divergence, busy-worktree, and fetch deferrals.
- Blocks merging on every attribution amendment error.
- Adds tests for narrow refspecs and related Git states.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

Unexpected amendment errors now block the merge path. Explicit fetch and lease handling cover branches without remote-tracking refs. No blocking issues were found in the changed code.

No files require additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran pre-change regression against HEAD^ (13f32d6) to establish baseline, and observed failures in both selected narrows-refspec cases.
- Executed the after-change narrow-refspec tests; the command completed with exit code 0 and all six tests reported PASS.
- Reviewed the attribution-merge-guard flow; the selection completed with exit code 0 and observable fail-closed deferral logs.

<a href="https://app.greptile.com/trex/runs/14171672/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds explicit branch fetching, ancestry-based amendment, leased pushes, distinct deferrals, and fail-closed merge handling. |
| internal/orchestrator/attribution_amend_test.go | Adds tests for narrow refspecs, concurrent updates, divergence, missing branches, same-named tags, and local-ahead commits. |
| internal/orchestrator/attribution_merge_guard_test.go | Verifies that unexpected attribution failures stop CI checks and merging. |

<sub>Reviews (2): Last reviewed commit: ["orchestrator: fail closed on attribution..."](https://github.com/befeast/maestro/commit/4ffd4a37c73be4059a2c001c2a6e609b3735b002) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43680413)</sub>

<!-- /greptile_comment -->