### PR TITLE
feat: stable project_id + structured Management Home metadata (#869)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -1539,15 +1540,25 @@ func validateManagementHome(m ManagementHomeConfig) error {
 // a leading-slash test rather than any host filesystem semantics — Maestro never
 // resolves the path against a real directory.
 func validateVaultRelPath(p string) error {
-	if strings.HasPrefix(p, "/") || filepath.IsAbs(p) {
+	if strings.Contains(p, `\`) {
+		return fmt.Errorf("config: management_home.vault_path %q must use normalized forward-slash form (backslashes are not allowed)", p)
+	}
+	if strings.HasPrefix(p, "/") || filepath.IsAbs(p) || pathpkg.IsAbs(p) || windowsDriveAbsPath(p) {
 		return fmt.Errorf("config: management_home.vault_path %q must be vault-relative, not absolute", p)
 	}
-	for _, seg := range strings.Split(filepath.ToSlash(p), "/") {
+	for _, seg := range strings.Split(p, "/") {
 		if seg == ".." {
 			return fmt.Errorf("config: management_home.vault_path %q must not contain a '..' path traversal segment", p)
 		}
 	}
+	if clean := pathpkg.Clean(p); clean == "." || clean != p {
+		return fmt.Errorf("config: management_home.vault_path %q must be normalized (no empty, '.' or trailing path segments)", p)
+	}
 	return nil
+}
+
+func windowsDriveAbsPath(p string) bool {
+	return len(p) >= 3 && ((p[0] >= 'a' && p[0] <= 'z') || (p[0] >= 'A' && p[0] <= 'Z')) && p[1] == ':' && p[2] == '/'
 }
 
 type Config struct {
@@ -1699,21 +1710,64 @@ func ParseStrict(data []byte) (*Config, error) {
 // to surface an unknown/misspelled key by name. It ignores every other decode
 // error (missing repo, type mismatches, etc.) — those are reported with better
 // context by parse(); this probe's only job is the unknown-key report. Types
-// with a custom UnmarshalYAML (e.g. SupervisorConfig) decode with their own
-// decoder, so strictness stops at those boundaries, which is sufficient to catch
-// the top-level and management_home typos this guard targets.
+// with a custom UnmarshalYAML decode with their own decoder, so the supervisor
+// subtree is checked separately below with a methodless alias.
 func strictUnknownKeyCheck(data []byte) error {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	var probe Config
 	err := dec.Decode(&probe)
-	if err == nil || errors.Is(err, io.EOF) {
-		return nil
-	}
-	if strings.Contains(err.Error(), "not found in type") {
+	if err != nil && !errors.Is(err, io.EOF) && strings.Contains(err.Error(), "not found in type") {
 		return fmt.Errorf("config: %w", err)
 	}
 	// Any other decode error is left for parse() to report with full context.
+	return strictSupervisorUnknownKeyCheck(data)
+}
+
+// strictSupervisorConfig is methodless so KnownFields can inspect the
+// supervisor subtree instead of SupervisorConfig.UnmarshalYAML handling it with
+// a tolerant Node.Decode. The normal Parse path remains tolerant for legacy
+// reads; only ParseStrict invokes this probe (#869).
+type strictSupervisorConfig SupervisorConfig
+
+func strictSupervisorUnknownKeyCheck(data []byte) error {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil // parse() reports syntax/type errors with normal context
+	}
+	supervisor := yamlMappingValue(&root, "supervisor")
+	if supervisor == nil {
+		return nil
+	}
+	encoded, err := yaml.Marshal(supervisor)
+	if err != nil {
+		return nil
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(encoded))
+	dec.KnownFields(true)
+	var probe strictSupervisorConfig
+	if err := dec.Decode(&probe); err != nil && strings.Contains(err.Error(), "not found in type") {
+		return fmt.Errorf("config: %w", err)
+	}
+	return nil
+}
+
+func yamlMappingValue(root *yaml.Node, key string) *yaml.Node {
+	if root == nil {
+		return nil
+	}
+	node := root
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"bytes"
 	"crypto/md5"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -1449,10 +1452,116 @@ func (c SessionRetentionConfig) EffectiveArchiveFile(stateDir string) string {
 	return filepath.Join(stateDir, "sessions-archive.jsonl")
 }
 
+// ManagementHomeKind enumerates the supported management-home backends (#869).
+// Only "obsidian" is recognised in this slice; parse() rejects any other value
+// so a typo cannot masquerade as a working control-room link.
+const ManagementHomeKindObsidian = "obsidian"
+
+// ManagementHomeConfig is the optional, descriptive link from a Maestro project
+// row back to its PM / control-room home (#869). It carries identity metadata
+// only — Maestro never reads, traverses, or writes the referenced home in this
+// slice; the block round-trips through config-store and is surfaced on the Fleet
+// API for external bootstrap adapters to correlate Area/repo/Maestro row.
+//
+//   - Kind:      management-home backend ("obsidian" is the only supported value).
+//   - Path:      execution-host absolute path of the home (validated non-empty).
+//   - Vault:     Obsidian vault display name (required for kind obsidian).
+//   - VaultPath: vault-RELATIVE path to the project's Area, e.g. Dev/Areas/<slug>.
+//     Must be relative (not absolute) and contain no ".." traversal (validated).
+type ManagementHomeConfig struct {
+	Kind      string `yaml:"kind,omitempty" json:"kind,omitempty"`
+	Path      string `yaml:"path,omitempty" json:"path,omitempty"`
+	Vault     string `yaml:"vault,omitempty" json:"vault,omitempty"`
+	VaultPath string `yaml:"vault_path,omitempty" json:"vault_path,omitempty"`
+}
+
+// Configured reports whether any management-home field is set, i.e. whether the
+// block is present at all. A config with no management_home leaves every field
+// empty and is skipped by validation, so legacy configs parse unchanged.
+func (m ManagementHomeConfig) Configured() bool {
+	return strings.TrimSpace(m.Kind) != "" ||
+		strings.TrimSpace(m.Path) != "" ||
+		strings.TrimSpace(m.Vault) != "" ||
+		strings.TrimSpace(m.VaultPath) != ""
+}
+
+// projectIDPattern matches a canonical 8-4-4-4-12 UUID (any case). A stable
+// project_id must be a real UUID so an external bootstrap adapter can prove that
+// Area, repo, and Maestro row refer to the same durable project (#869).
+var projectIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// validateProjectID rejects a present-but-malformed project_id. An empty id is
+// allowed (the field is optional and legacy rows have none).
+func validateProjectID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil
+	}
+	if !projectIDPattern.MatchString(id) {
+		return fmt.Errorf("config: project_id %q is not a valid UUID (want canonical 8-4-4-4-12, e.g. 3f2504e0-4f89-41d3-9a0c-0305e82c3301)", id)
+	}
+	return nil
+}
+
+// validateManagementHome enforces the management_home contract (#869): a
+// supported kind, a non-empty path, the obsidian-required vault/vault_path, and
+// a vault-relative vault_path free of absolute prefixes and ".." traversal. An
+// unconfigured block validates trivially so legacy configs are unaffected.
+func validateManagementHome(m ManagementHomeConfig) error {
+	if !m.Configured() {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(m.Kind)) {
+	case ManagementHomeKindObsidian:
+		// supported
+	case "":
+		return fmt.Errorf("config: management_home.kind is required (supported: %s)", ManagementHomeKindObsidian)
+	default:
+		return fmt.Errorf("config: management_home.kind = %q is not supported (supported: %s)", m.Kind, ManagementHomeKindObsidian)
+	}
+	if strings.TrimSpace(m.Path) == "" {
+		return fmt.Errorf("config: management_home.path is required and must be non-empty")
+	}
+	// Obsidian consistency: both the vault name and the vault-relative Area path
+	// are required — a home missing either cannot be resolved back to a project.
+	if strings.TrimSpace(m.Vault) == "" {
+		return fmt.Errorf("config: management_home.vault is required for kind %s", ManagementHomeKindObsidian)
+	}
+	if strings.TrimSpace(m.VaultPath) == "" {
+		return fmt.Errorf("config: management_home.vault_path is required for kind %s", ManagementHomeKindObsidian)
+	}
+	return validateVaultRelPath(strings.TrimSpace(m.VaultPath))
+}
+
+// validateVaultRelPath rejects a vault_path that is absolute or contains a ".."
+// traversal segment. Vault paths are logical, forward-slash, vault-relative
+// references (e.g. Dev/Areas/maestro), so the check is on '/'-split segments and
+// a leading-slash test rather than any host filesystem semantics — Maestro never
+// resolves the path against a real directory.
+func validateVaultRelPath(p string) error {
+	if strings.HasPrefix(p, "/") || filepath.IsAbs(p) {
+		return fmt.Errorf("config: management_home.vault_path %q must be vault-relative, not absolute", p)
+	}
+	for _, seg := range strings.Split(filepath.ToSlash(p), "/") {
+		if seg == ".." {
+			return fmt.Errorf("config: management_home.vault_path %q must not contain a '..' path traversal segment", p)
+		}
+	}
+	return nil
+}
+
 type Config struct {
-	Server                          ServerConfig                 `yaml:"server"`
-	Supervisor                      SupervisorConfig             `yaml:"supervisor"`
-	Repo                            string                       `yaml:"repo"`
+	Server     ServerConfig     `yaml:"server"`
+	Supervisor SupervisorConfig `yaml:"supervisor"`
+	Repo       string           `yaml:"repo"`
+	// ProjectID is the optional stable UUID identifying this project durably,
+	// independent of the mutable repo/state/store names (#869). Empty for legacy
+	// rows; validated as a canonical UUID when present and kept immutable across
+	// an in-place config-store upsert.
+	ProjectID string `yaml:"project_id,omitempty"`
+	// ManagementHome is the optional, descriptive link back to the project's PM /
+	// control-room home (#869). Metadata only — never read or traversed here.
+	ManagementHome                  ManagementHomeConfig         `yaml:"management_home,omitempty"`
 	Outcome                         outcome.Brief                `yaml:"outcome"`
 	LocalPath                       string                       `yaml:"local_path"`
 	WorktreeBase                    string                       `yaml:"worktree_base"`
@@ -1570,6 +1679,44 @@ func Parse(data []byte) (*Config, error) {
 	return parse(data)
 }
 
+// ParseStrict is Parse plus a strict unknown-key check for project create/edit
+// WRITE paths (#869): a misspelled field (e.g. a mistyped `management_home` key)
+// is rejected by exact name instead of being silently discarded. Read paths keep
+// using the tolerant Parse so legacy rows carrying a field this build does not
+// know still load and run unchanged.
+//
+// The strictness is applied by a separate KnownFields decode probe over the raw
+// document; the returned *Config is produced by the same parse() so defaults and
+// semantic validation are identical to the tolerant path.
+func ParseStrict(data []byte) (*Config, error) {
+	if err := strictUnknownKeyCheck(data); err != nil {
+		return nil, err
+	}
+	return parse(data)
+}
+
+// strictUnknownKeyCheck decodes the document with yaml KnownFields(true) purely
+// to surface an unknown/misspelled key by name. It ignores every other decode
+// error (missing repo, type mismatches, etc.) — those are reported with better
+// context by parse(); this probe's only job is the unknown-key report. Types
+// with a custom UnmarshalYAML (e.g. SupervisorConfig) decode with their own
+// decoder, so strictness stops at those boundaries, which is sufficient to catch
+// the top-level and management_home typos this guard targets.
+func strictUnknownKeyCheck(data []byte) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	var probe Config
+	err := dec.Decode(&probe)
+	if err == nil || errors.Is(err, io.EOF) {
+		return nil
+	}
+	if strings.Contains(err.Error(), "not found in type") {
+		return fmt.Errorf("config: %w", err)
+	}
+	// Any other decode error is left for parse() to report with full context.
+	return nil
+}
+
 func parse(data []byte) (*Config, error) {
 
 	cfg := &Config{
@@ -1594,6 +1741,16 @@ func parse(data []byte) (*Config, error) {
 
 	if cfg.Repo == "" {
 		return nil, fmt.Errorf("config: repo is required")
+	}
+
+	// #869: optional project identity metadata. A present project_id must be a
+	// UUID; a present management_home must satisfy its field contract. Both are
+	// absent in legacy configs, so these checks are no-ops there.
+	if err := validateProjectID(cfg.ProjectID); err != nil {
+		return nil, err
+	}
+	if err := validateManagementHome(cfg.ManagementHome); err != nil {
+		return nil, err
 	}
 
 	// A negative max_live_workers is meaningless; clamp to 0 (legacy: pr_open

--- a/internal/config/project_identity_test.go
+++ b/internal/config/project_identity_test.go
@@ -99,6 +99,21 @@ func TestParse_ManagementHomeValidation(t *testing.T) {
 			yaml:    "repo: o/r\nmanagement_home:\n  kind: obsidian\n  path: /x\n  vault: V\n  vault_path: Dev/../../etc\n",
 			wantSub: "traversal",
 		},
+		{
+			name:    "backslash traversal vault_path",
+			yaml:    "repo: o/r\nmanagement_home:\n  kind: obsidian\n  path: /x\n  vault: V\n  vault_path: 'Dev\\..\\secret'\n",
+			wantSub: "backslashes",
+		},
+		{
+			name:    "windows absolute vault_path",
+			yaml:    "repo: o/r\nmanagement_home:\n  kind: obsidian\n  path: /x\n  vault: V\n  vault_path: C:/Vault/Dev\n",
+			wantSub: "vault-relative",
+		},
+		{
+			name:    "non-normalized vault_path",
+			yaml:    "repo: o/r\nmanagement_home:\n  kind: obsidian\n  path: /x\n  vault: V\n  vault_path: Dev//Areas/./foo/\n",
+			wantSub: "normalized",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -135,6 +150,13 @@ func TestParseStrict_RejectsUnknownKeyByName(t *testing.T) {
 	_, err = ParseStrict([]byte("repo: o/r\nproject_idd: 3f2504e0-4f89-41d3-9a0c-0305e82c3301\n"))
 	if err == nil || !strings.Contains(err.Error(), "project_idd") {
 		t.Fatalf("strict decode should name the misspelled top-level key, got: %v", err)
+	}
+
+	// SupervisorConfig has a custom UnmarshalYAML for legacy-read bookkeeping;
+	// strict writes must still reject typos inside that subtree.
+	_, err = ParseStrict([]byte("repo: o/r\nsupervisor:\n  ready_labell: typo\n"))
+	if err == nil || !strings.Contains(err.Error(), "ready_labell") {
+		t.Fatalf("strict decode should name the misspelled supervisor key, got: %v", err)
 	}
 }
 

--- a/internal/config/project_identity_test.go
+++ b/internal/config/project_identity_test.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// exampleProjectIdentityYAML mirrors the issue's example config (#869): a valid
+// UUID plus a complete obsidian management_home block.
+const exampleProjectIdentityYAML = `
+repo: BeFeast/maestro
+project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
+management_home:
+  kind: obsidian
+  path: /home/god/Obsidian/Dev
+  vault: Obsidian Vault
+  vault_path: Dev/Areas/maestro
+`
+
+func TestParse_ProjectIdentityExampleRoundTrips(t *testing.T) {
+	cfg, err := Parse([]byte(exampleProjectIdentityYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.ProjectID != "3f2504e0-4f89-41d3-9a0c-0305e82c3301" {
+		t.Fatalf("project_id = %q, want the example UUID", cfg.ProjectID)
+	}
+	mh := cfg.ManagementHome
+	if mh.Kind != "obsidian" || mh.Path != "/home/god/Obsidian/Dev" ||
+		mh.Vault != "Obsidian Vault" || mh.VaultPath != "Dev/Areas/maestro" {
+		t.Fatalf("management_home not parsed verbatim: %+v", mh)
+	}
+	if !mh.Configured() {
+		t.Fatalf("Configured() should be true for a populated block")
+	}
+}
+
+func TestParse_LegacyConfigWithoutIdentityParses(t *testing.T) {
+	cfg, err := Parse([]byte("repo: owner/repo\n"))
+	if err != nil {
+		t.Fatalf("legacy config must still parse: %v", err)
+	}
+	if cfg.ProjectID != "" {
+		t.Fatalf("legacy project_id should be empty, got %q", cfg.ProjectID)
+	}
+	if cfg.ManagementHome.Configured() {
+		t.Fatalf("legacy management_home should be unconfigured, got %+v", cfg.ManagementHome)
+	}
+}
+
+func TestParse_ProjectIDMustBeUUID(t *testing.T) {
+	_, err := Parse([]byte("repo: owner/repo\nproject_id: not-a-uuid\n"))
+	if err == nil {
+		t.Fatalf("expected malformed project_id to be rejected")
+	}
+	if !strings.Contains(err.Error(), "project_id") || !strings.Contains(err.Error(), "UUID") {
+		t.Fatalf("error should name project_id/UUID, got: %v", err)
+	}
+}
+
+func TestParse_ManagementHomeValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantSub string
+	}{
+		{
+			name:    "unknown kind",
+			yaml:    "repo: o/r\nmanagement_home:\n  kind: notion\n  path: /x\n  vault: V\n  vault_path: a/b\n",
+			wantSub: "kind",
+		},
+		{
+			name:    "missing kind",
+			yaml:    "repo: o/r\nmanagement_home:\n  path: /x\n  vault: V\n  vault_path: a/b\n",
+			wantSub: "kind is required",
+		},
+		{
+			name:    "empty path",
+			yaml:    "repo: o/r\nmanagement_home:\n  kind: obsidian\n  vault: V\n  vault_path: a/b\n",
+			wantSub: "path is required",
+		},
+		{
+			name:    "missing vault",
+			yaml:    "repo: o/r\nmanagement_home:\n  kind: obsidian\n  path: /x\n  vault_path: a/b\n",
+			wantSub: "vault is required",
+		},
+		{
+			name:    "missing vault_path",
+			yaml:    "repo: o/r\nmanagement_home:\n  kind: obsidian\n  path: /x\n  vault: V\n",
+			wantSub: "vault_path is required",
+		},
+		{
+			name:    "absolute vault_path",
+			yaml:    "repo: o/r\nmanagement_home:\n  kind: obsidian\n  path: /x\n  vault: V\n  vault_path: /abs/path\n",
+			wantSub: "must be vault-relative",
+		},
+		{
+			name:    "traversal vault_path",
+			yaml:    "repo: o/r\nmanagement_home:\n  kind: obsidian\n  path: /x\n  vault: V\n  vault_path: Dev/../../etc\n",
+			wantSub: "traversal",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.yaml))
+			if err == nil {
+				t.Fatalf("expected validation error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q should contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestParse_ManagementHomeValidBlockAccepted(t *testing.T) {
+	valid := "repo: o/r\nmanagement_home:\n  kind: obsidian\n  path: /x\n  vault: V\n  vault_path: Dev/Areas/foo\n"
+	if _, err := Parse([]byte(valid)); err != nil {
+		t.Fatalf("valid management_home should parse: %v", err)
+	}
+}
+
+func TestParseStrict_RejectsUnknownKeyByName(t *testing.T) {
+	// A misspelled management_home child must be rejected with the exact name.
+	bad := "repo: o/r\nmanagement_home:\n  kind: obsidian\n  path: /x\n  vault: V\n  vault_path: a/b\n  vault_pathh: typo\n"
+	_, err := ParseStrict([]byte(bad))
+	if err == nil {
+		t.Fatalf("strict decode should reject the misspelled child key")
+	}
+	if !strings.Contains(err.Error(), "vault_pathh") {
+		t.Fatalf("error should name the offending key, got: %v", err)
+	}
+
+	// A misspelled top-level key is likewise rejected.
+	_, err = ParseStrict([]byte("repo: o/r\nproject_idd: 3f2504e0-4f89-41d3-9a0c-0305e82c3301\n"))
+	if err == nil || !strings.Contains(err.Error(), "project_idd") {
+		t.Fatalf("strict decode should name the misspelled top-level key, got: %v", err)
+	}
+}
+
+func TestParseStrict_AcceptsKnownKeysAndLegacy(t *testing.T) {
+	if _, err := ParseStrict([]byte(exampleProjectIdentityYAML)); err != nil {
+		t.Fatalf("strict decode of the example config should pass: %v", err)
+	}
+	// Legacy config with no identity fields must still pass strict decode.
+	if _, err := ParseStrict([]byte("repo: owner/repo\n")); err != nil {
+		t.Fatalf("strict decode of a legacy config should pass: %v", err)
+	}
+}
+
+func TestParse_TolerantReadKeepsLegacyUnknownKey(t *testing.T) {
+	// The tolerant read path must still accept an unknown key (legacy rows) so a
+	// stored config written before strict decode existed continues to load (#869).
+	if _, err := Parse([]byte("repo: owner/repo\nsome_future_key: 1\n")); err != nil {
+		t.Fatalf("tolerant Parse should ignore an unknown key, got: %v", err)
+	}
+	// While the strict write path rejects that same key by name.
+	if _, err := ParseStrict([]byte("repo: owner/repo\nsome_future_key: 1\n")); err == nil {
+		t.Fatalf("strict Parse should reject the unknown key")
+	}
+}

--- a/internal/configstore/project_identity_test.go
+++ b/internal/configstore/project_identity_test.go
@@ -82,11 +82,29 @@ func TestUpsertProjectImmutableProjectID(t *testing.T) {
 		t.Fatalf("re-upsert with same id should be allowed: %v", err)
 	}
 
+	// An ordinary edit from an older/id-unaware client must preserve the stored
+	// identity even when project_id is omitted or explicitly blank.
+	idlessEdit := "repo: BeFeast/maestro\nlocal_path: /srv/maestro\n"
+	if err := store.UpsertProject(ctx, "befeast-maestro", idlessEdit); err != nil {
+		t.Fatalf("id-less edit should preserve identity: %v", err)
+	}
+	blankIDEdit := "repo: BeFeast/maestro\nlocal_path: /srv/maestro-2\nproject_id: \"\"\n"
+	if err := store.UpsertProject(ctx, "befeast-maestro", blankIDEdit); err != nil {
+		t.Fatalf("blank-id edit should preserve identity: %v", err)
+	}
+	preserved, err := store.Load(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("Load after id-less edits: %v", err)
+	}
+	if preserved.ProjectID != "3f2504e0-4f89-41d3-9a0c-0305e82c3301" {
+		t.Fatalf("stored id was removed by an id-less edit: %q", preserved.ProjectID)
+	}
+
 	// Changing to a DIFFERENT non-empty id is rejected.
 	changed := strings.Replace(identityProjectYAML,
 		"3f2504e0-4f89-41d3-9a0c-0305e82c3301",
 		"11111111-2222-3333-4444-555555555555", 1)
-	err := store.UpsertProject(ctx, "befeast-maestro", changed)
+	err = store.UpsertProject(ctx, "befeast-maestro", changed)
 	if err == nil {
 		t.Fatalf("changing project_id should be rejected")
 	}

--- a/internal/configstore/project_identity_test.go
+++ b/internal/configstore/project_identity_test.go
@@ -1,0 +1,125 @@
+package configstore
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+const identityProjectYAML = `repo: BeFeast/maestro
+local_path: ~/src/maestro
+project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
+management_home:
+  kind: obsidian
+  path: /home/god/Obsidian/Dev
+  vault: Obsidian Vault
+  vault_path: Dev/Areas/maestro
+`
+
+// Config-store upsert -> reload -> export is lossless for project_id and the
+// management_home block (#869).
+func TestUpsertReloadExportLosslessForIdentity(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	if err := store.UpsertProject(ctx, "befeast-maestro", identityProjectYAML); err != nil {
+		t.Fatalf("UpsertProject: %v", err)
+	}
+
+	// Reload through Load: both fields survive parse.
+	cfg, err := store.Load(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ProjectID != "3f2504e0-4f89-41d3-9a0c-0305e82c3301" {
+		t.Fatalf("reloaded project_id = %q", cfg.ProjectID)
+	}
+	if cfg.ManagementHome.Kind != "obsidian" || cfg.ManagementHome.VaultPath != "Dev/Areas/maestro" ||
+		cfg.ManagementHome.Vault != "Obsidian Vault" || cfg.ManagementHome.Path != "/home/god/Obsidian/Dev" {
+		t.Fatalf("reloaded management_home lost fields: %+v", cfg.ManagementHome)
+	}
+
+	// Export round-trips the fields back into portable YAML.
+	exported, err := store.ExportProject(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("ExportProject: %v", err)
+	}
+	reparsed, err := config.Parse(exported)
+	if err != nil {
+		t.Fatalf("re-parse export: %v", err)
+	}
+	if reparsed.ProjectID != cfg.ProjectID || reparsed.ManagementHome != cfg.ManagementHome {
+		t.Fatalf("export not lossless: id=%q mh=%+v", reparsed.ProjectID, reparsed.ManagementHome)
+	}
+	if !strings.Contains(string(exported), "project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301") {
+		t.Fatalf("export missing project_id line:\n%s", exported)
+	}
+	if !strings.Contains(string(exported), "vault_path: Dev/Areas/maestro") {
+		t.Fatalf("export missing management_home vault_path:\n%s", exported)
+	}
+}
+
+// Adding an id to a legacy id-less row is allowed; changing a set id to a
+// different non-empty one is rejected as an identity mismatch (#869).
+func TestUpsertProjectImmutableProjectID(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	legacy := "repo: BeFeast/maestro\nlocal_path: ~/src/maestro\n"
+	if err := store.UpsertProject(ctx, "befeast-maestro", legacy); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	// Adding an id to the legacy id-less row is allowed.
+	if err := store.UpsertProject(ctx, "befeast-maestro", identityProjectYAML); err != nil {
+		t.Fatalf("adding id to legacy row should be allowed: %v", err)
+	}
+
+	// Re-upserting the SAME id is a no-op-identity change, allowed.
+	if err := store.UpsertProject(ctx, "befeast-maestro", identityProjectYAML); err != nil {
+		t.Fatalf("re-upsert with same id should be allowed: %v", err)
+	}
+
+	// Changing to a DIFFERENT non-empty id is rejected.
+	changed := strings.Replace(identityProjectYAML,
+		"3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+		"11111111-2222-3333-4444-555555555555", 1)
+	err := store.UpsertProject(ctx, "befeast-maestro", changed)
+	if err == nil {
+		t.Fatalf("changing project_id should be rejected")
+	}
+	if !strings.Contains(err.Error(), "immutable") {
+		t.Fatalf("mismatch error should mention immutability, got: %v", err)
+	}
+
+	// And the stored row must be unchanged (write-nothing on the rejected edit).
+	cfg, err := store.Load(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("Load after rejected edit: %v", err)
+	}
+	if cfg.ProjectID != "3f2504e0-4f89-41d3-9a0c-0305e82c3301" {
+		t.Fatalf("stored id changed after a rejected edit: %q", cfg.ProjectID)
+	}
+}
+
+// A strict-decode failure (unknown/misspelled key) on the write path must be
+// rejected and must not persist a row (#869).
+func TestUpsertProjectStrictDecodeWritesNothing(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	bad := identityProjectYAML + "  vault_pathh: typo\n"
+	err := store.UpsertProject(ctx, "befeast-maestro", bad)
+	if err == nil {
+		t.Fatalf("misspelled key should be rejected on write")
+	}
+	if !strings.Contains(err.Error(), "vault_pathh") {
+		t.Fatalf("error should name the misspelled key, got: %v", err)
+	}
+	// No row was written.
+	if _, err := store.Load(ctx, "befeast-maestro"); err == nil {
+		t.Fatalf("no project row should exist after a rejected strict-decode write")
+	}
+}

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -241,7 +241,9 @@ func (s *Store) ExportDir(ctx context.Context, dir string) error {
 }
 
 func importProject(ctx context.Context, tx *sql.Tx, sourcePath string, data []byte) error {
-	if _, err := config.Parse(data); err != nil {
+	// Import is a create/edit write path: strict-decode so a misspelled field in
+	// a migrated file is reported by name rather than silently dropped (#869).
+	if _, err := config.ParseStrict(data); err != nil {
 		return err
 	}
 	var root yaml.Node
@@ -251,6 +253,9 @@ func importProject(ctx context.Context, tx *sql.Tx, sourcePath string, data []by
 	projectName := projectNameFromPath(sourcePath)
 	if repo := scalarAt(&root, "repo"); repo != "" {
 		projectName = safeProjectName(repo)
+	}
+	if err := enforceImmutableProjectID(ctx, tx, projectName, &root); err != nil {
+		return err
 	}
 	backends := detachBackends(&root)
 	now := time.Now().UTC().Format(time.RFC3339Nano) // nano, not seconds: see ProjectsFingerprint (#757)
@@ -424,6 +429,13 @@ func deepMergeMaps(a, b map[string]any) map[string]any {
 // project write back too. source_path is left empty for write-API projects
 // (they have no originating file) and is preserved on conflict.
 func (s *Store) UpsertProject(ctx context.Context, name, configYAML string) error {
+	// Public create/edit write path: reject unknown/misspelled keys by name so a
+	// typo cannot be silently discarded (#869). The internal settings re-persist
+	// (SetProjectSetting -> upsertProjectTx) stays tolerant because it re-writes
+	// already-validated stored YAML, not fresh operator input.
+	if _, err := config.ParseStrict([]byte(configYAML)); err != nil {
+		return err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -452,6 +464,9 @@ func upsertProjectTx(ctx context.Context, tx *sql.Tx, name, configYAML string) e
 	if err := yaml.Unmarshal([]byte(configYAML), &root); err != nil {
 		return err
 	}
+	if err := enforceImmutableProjectID(ctx, tx, name, &root); err != nil {
+		return err
+	}
 	backends := detachBackends(&root)
 	now := time.Now().UTC().Format(time.RFC3339Nano) // nano, not seconds: see ProjectsFingerprint (#757)
 	if err := upsertSharedBackendsTx(ctx, tx, backends, now); err != nil {
@@ -467,6 +482,42 @@ VALUES(?, '', ?, 'global', ?)
 ON CONFLICT(name) DO UPDATE SET config_yaml = excluded.config_yaml, updated_at = excluded.updated_at
 `, name, string(projectYAML), now)
 	return err
+}
+
+// enforceImmutableProjectID rejects an in-place project write that would change
+// a stable project_id that is already recorded on the row (#869). A stored id is
+// the durable identity an external bootstrap adapter correlates against, so it
+// must not silently flip on an edit. The rules mirror the acceptance criteria:
+//
+//   - incoming id empty            -> allowed (the write does not touch identity);
+//   - stored id empty              -> allowed (adding an id to a legacy id-less row);
+//   - stored == incoming           -> allowed (no change);
+//   - stored != incoming, both set -> REJECTED as an identity mismatch.
+//
+// A genuinely different id is an explicit migration concern, not an ordinary
+// upsert, so the caller must create a new project or migrate deliberately.
+func enforceImmutableProjectID(ctx context.Context, tx *sql.Tx, name string, incomingRoot *yaml.Node) error {
+	incoming := scalarAt(incomingRoot, "project_id")
+	if incoming == "" {
+		return nil
+	}
+	var storedYAML string
+	err := tx.QueryRowContext(ctx, `SELECT config_yaml FROM project WHERE name = ?`, name).Scan(&storedYAML)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var storedRoot yaml.Node
+	if err := yaml.Unmarshal([]byte(storedYAML), &storedRoot); err != nil {
+		return err
+	}
+	stored := scalarAt(&storedRoot, "project_id")
+	if stored != "" && stored != incoming {
+		return fmt.Errorf("project %q: project_id is immutable (stored %q, refusing to overwrite with %q); create a new project or run an explicit migration to change it", name, stored, incoming)
+	}
+	return nil
 }
 
 // ProjectNameFor derives the canonical project name for a config document the

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -489,7 +489,8 @@ ON CONFLICT(name) DO UPDATE SET config_yaml = excluded.config_yaml, updated_at =
 // the durable identity an external bootstrap adapter correlates against, so it
 // must not silently flip on an edit. The rules mirror the acceptance criteria:
 //
-//   - incoming id empty            -> allowed (the write does not touch identity);
+//   - incoming id empty            -> preserve the stored id (ordinary edits do
+//     not implicitly clear identity);
 //   - stored id empty              -> allowed (adding an id to a legacy id-less row);
 //   - stored == incoming           -> allowed (no change);
 //   - stored != incoming, both set -> REJECTED as an identity mismatch.
@@ -498,9 +499,6 @@ ON CONFLICT(name) DO UPDATE SET config_yaml = excluded.config_yaml, updated_at =
 // upsert, so the caller must create a new project or migrate deliberately.
 func enforceImmutableProjectID(ctx context.Context, tx *sql.Tx, name string, incomingRoot *yaml.Node) error {
 	incoming := scalarAt(incomingRoot, "project_id")
-	if incoming == "" {
-		return nil
-	}
 	var storedYAML string
 	err := tx.QueryRowContext(ctx, `SELECT config_yaml FROM project WHERE name = ?`, name).Scan(&storedYAML)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -514,6 +512,13 @@ func enforceImmutableProjectID(ctx context.Context, tx *sql.Tx, name string, inc
 		return err
 	}
 	stored := scalarAt(&storedRoot, "project_id")
+	if stored != "" && incoming == "" {
+		// Upserts replace config_yaml wholesale. Preserve the durable id in the
+		// incoming node so an older client or an ordinary id-less edit cannot
+		// silently erase identity (#869).
+		setMappingChild(incomingRoot, "project_id", &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: stored})
+		return nil
+	}
 	if stored != "" && stored != incoming {
 		return fmt.Errorf("project %q: project_id is immutable (stored %q, refusing to overwrite with %q); create a new project or run an explicit migration to change it", name, stored, incoming)
 	}

--- a/internal/daemon/project_identity_reload_test.go
+++ b/internal/daemon/project_identity_reload_test.go
@@ -1,7 +1,13 @@
 package daemon
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 )
@@ -47,4 +53,92 @@ func TestIdentityChangedIgnoresProjectMetadata(t *testing.T) {
 	if !identityChanged(withMetadata, &restartNeeded) {
 		t.Fatalf("state_dir change must still be flagged as an identity change")
 	}
+}
+
+// A real store-watch metadata edit must reach the live Fleet API without
+// restarting the flow. This covers the full store -> watcher -> holder/dashboard
+// path, not only the identityChanged predicate.
+func TestWatchStoreProjectMetadataReloadUpdatesFleetWithoutRestart(t *testing.T) {
+	store := newFakeWatchStore()
+	cfg := testConfig(t, "owner/alpha")
+	cfg.ProjectID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+	cfg.ManagementHome = config.ManagementHomeConfig{
+		Kind: "obsidian", Path: "/vault/Dev", Vault: "Vault", VaultPath: "Dev/Areas/alpha",
+	}
+	store.Set("alpha", cfg)
+
+	var run, sup loopTracker
+	d := newWatchDaemon(store, run.loop, sup.superviseLoop)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	waitForNames(t, d, "alpha")
+	waitFor(t, func() bool {
+		id, vaultPath := fleetProjectIdentityMetadata(t, d, "alpha")
+		return id == cfg.ProjectID && vaultPath == "Dev/Areas/alpha"
+	})
+	waitFor(t, func() bool { return atomic.LoadInt64(&run.started) == 1 })
+
+	edited := *cfg
+	edited.ManagementHome = cfg.ManagementHome
+	edited.ManagementHome.VaultPath = "Dev/Areas/alpha-renamed"
+	store.Set("alpha", &edited)
+
+	waitFor(t, func() bool {
+		id, vaultPath := fleetProjectIdentityMetadata(t, d, "alpha")
+		return id == cfg.ProjectID && vaultPath == "Dev/Areas/alpha-renamed"
+	})
+	if got := atomic.LoadInt64(&run.started); got != 1 {
+		t.Fatalf("run loops started = %d, want 1 (metadata edit must not restart flow)", got)
+	}
+	if got := atomic.LoadInt64(&run.stopped); got != 0 {
+		t.Fatalf("run loops stopped = %d before shutdown, want 0", got)
+	}
+	d.mu.Lock()
+	flows := len(d.flows)
+	d.mu.Unlock()
+	if flows != 1 {
+		t.Fatalf("flows = %d, want 1 after metadata-only reload", flows)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancellation")
+	}
+}
+
+func fleetProjectIdentityMetadata(t *testing.T, d *Daemon, name string) (string, string) {
+	t.Helper()
+	fleet := waitForFleet(t, d)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil)
+	rec := httptest.NewRecorder()
+	fleet.HandlerForTest().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/fleet = %d, want 200", rec.Code)
+	}
+	var resp struct {
+		Projects []struct {
+			Name           string `json:"name"`
+			ProjectID      string `json:"project_id"`
+			ManagementHome struct {
+				VaultPath string `json:"vault_path"`
+			} `json:"management_home"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode fleet response: %v", err)
+	}
+	for _, project := range resp.Projects {
+		if project.Name == name {
+			return project.ProjectID, project.ManagementHome.VaultPath
+		}
+	}
+	return "", ""
 }

--- a/internal/daemon/project_identity_reload_test.go
+++ b/internal/daemon/project_identity_reload_test.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// A metadata-only edit — adding or changing project_id / management_home (#869)
+// — must NOT be flagged as an identity change, so the store-watch reload pump
+// applies it live (holder swap + Fleet API UpdateProjectConfig) instead of
+// forcing a flow restart. Identity fields (repo/state_dir/session_prefix) still
+// require a restart.
+func TestIdentityChangedIgnoresProjectMetadata(t *testing.T) {
+	base := &config.Config{
+		Repo:          "owner/svc",
+		StateDir:      "/state/svc",
+		SessionPrefix: "svc",
+	}
+	withMetadata := &config.Config{
+		Repo:          "owner/svc",
+		StateDir:      "/state/svc",
+		SessionPrefix: "svc",
+		ProjectID:     "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+		ManagementHome: config.ManagementHomeConfig{
+			Kind:      "obsidian",
+			Path:      "/home/god/Obsidian/Dev",
+			Vault:     "Obsidian Vault",
+			VaultPath: "Dev/Areas/maestro",
+		},
+	}
+
+	if identityChanged(base, withMetadata) {
+		t.Fatalf("adding project_id/management_home must be hot-reloadable, not an identity change")
+	}
+
+	// Changing only the management_home Area path is likewise metadata-only.
+	moved := *withMetadata
+	moved.ManagementHome.VaultPath = "Dev/Areas/renamed"
+	if identityChanged(withMetadata, &moved) {
+		t.Fatalf("changing management_home metadata must not require a restart")
+	}
+
+	// A real identity change (state_dir) still requires a restart.
+	restartNeeded := *withMetadata
+	restartNeeded.StateDir = "/state/other"
+	if !identityChanged(withMetadata, &restartNeeded) {
+		t.Fatalf("state_dir change must still be flagged as an identity change")
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1272,15 +1272,32 @@ type fleetQueueSnapshot struct {
 	SkippedCandidates []state.SupervisorSkippedCandidate `json:"skipped_candidates,omitempty"`
 }
 
+// fleetManagementHome is the JSON projection of config.ManagementHomeConfig
+// surfaced on the Fleet API (#869). It carries the descriptive fields verbatim;
+// no file content is read and the vault path is not resolved.
+type fleetManagementHome struct {
+	Kind      string `json:"kind,omitempty"`
+	Path      string `json:"path,omitempty"`
+	Vault     string `json:"vault,omitempty"`
+	VaultPath string `json:"vault_path,omitempty"`
+}
+
 type fleetProjectState struct {
-	Name               string `json:"name"`
-	Repo               string `json:"repo"`
-	ConfigPath         string `json:"config_path"`
-	DashboardURL       string `json:"dashboard_url,omitempty"`
-	StateDir           string `json:"state_dir,omitempty"`
-	MaxParallel        int    `json:"max_parallel"`
-	ReadOnly           bool   `json:"read_only"`
-	DispatchSLASeconds int    `json:"dispatch_sla_seconds,omitempty"`
+	Name string `json:"name"`
+	Repo string `json:"repo"`
+	// ProjectID is the project's stable UUID identity (#869), omitted for legacy
+	// rows that have none. Descriptive only — it never changes routing/display.
+	ProjectID string `json:"project_id,omitempty"`
+	// ManagementHome mirrors the config's descriptive control-room link (#869).
+	// nil when the project has no management_home block. Metadata only: the Fleet
+	// API surfaces the fields verbatim and never reads or traverses the home.
+	ManagementHome     *fleetManagementHome `json:"management_home,omitempty"`
+	ConfigPath         string               `json:"config_path"`
+	DashboardURL       string               `json:"dashboard_url,omitempty"`
+	StateDir           string               `json:"state_dir,omitempty"`
+	MaxParallel        int                  `json:"max_parallel"`
+	ReadOnly           bool                 `json:"read_only"`
+	DispatchSLASeconds int                  `json:"dispatch_sla_seconds,omitempty"`
 
 	// RestartRequired/RestartRequiredReason mirror the orchestrator's restart-required
 	// signal (set when model.default / routing.* changed but cannot be hot-applied).
@@ -2051,8 +2068,10 @@ func (s *FleetServer) handleFleetProjectUpsert(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// Reject a malformed paste with 400 before touching the store. UpsertProject
-	// re-validates, but parsing here also lets ProjectNameFor derive the name.
-	if _, err := config.Parse([]byte(yamlText)); err != nil {
+	// re-validates strictly, but parsing here also lets ProjectNameFor derive the
+	// name and returns the unknown-key error (#869) to the client as a 400 rather
+	// than a 500 from the store write.
+	if _, err := config.ParseStrict([]byte(yamlText)); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid project config: %v", err))
 		return
 	}
@@ -3610,6 +3629,21 @@ func fleetWorkerStartedAt(worker fleetWorkerState) time.Time {
 	return startedAt
 }
 
+// fleetManagementHomeFromConfig projects a config.ManagementHomeConfig onto the
+// Fleet API shape (#869), returning nil when the block is absent so the payload
+// omits it entirely for legacy projects.
+func fleetManagementHomeFromConfig(m config.ManagementHomeConfig) *fleetManagementHome {
+	if !m.Configured() {
+		return nil
+	}
+	return &fleetManagementHome{
+		Kind:      strings.TrimSpace(m.Kind),
+		Path:      strings.TrimSpace(m.Path),
+		Vault:     strings.TrimSpace(m.Vault),
+		VaultPath: strings.TrimSpace(m.VaultPath),
+	}
+}
+
 func buildFleetEffectiveConfig(cfg *config.Config) fleetEffectiveConfig {
 	if cfg == nil {
 		return fleetEffectiveConfig{}
@@ -3737,6 +3771,8 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 		return item, nil
 	}
 	item.Repo = cfg.Repo
+	item.ProjectID = strings.TrimSpace(cfg.ProjectID)
+	item.ManagementHome = fleetManagementHomeFromConfig(cfg.ManagementHome)
 	item.StateDir = cfg.StateDir
 	item.MaxParallel = cfg.MaxParallel
 	item.ReadOnly = cfg.Server.ReadOnly || s.readOnly

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1414,6 +1414,8 @@ type fleetProjectState struct {
 }
 
 type fleetEffectiveConfig struct {
+	ProjectID      string                `json:"project_id,omitempty"`
+	ManagementHome *fleetManagementHome  `json:"management_home,omitempty"`
 	ModelPolicy    fleetModelPolicy      `json:"model_policy"`
 	MaxParallel    int                   `json:"max_parallel"`
 	ReviewGate     string                `json:"review_gate"`
@@ -3676,6 +3678,8 @@ func buildFleetEffectiveConfig(cfg *config.Config) fleetEffectiveConfig {
 
 	retention := cfg.SessionRetention
 	return fleetEffectiveConfig{
+		ProjectID:      strings.TrimSpace(cfg.ProjectID),
+		ManagementHome: fleetManagementHomeFromConfig(cfg.ManagementHome),
 		ModelPolicy: fleetModelPolicy{
 			Default:          strings.TrimSpace(cfg.Model.Default),
 			FallbackBackends: append([]string(nil), cfg.Model.FallbackBackends...),

--- a/internal/server/fleet_project_identity_test.go
+++ b/internal/server/fleet_project_identity_test.go
@@ -38,6 +38,10 @@ func TestProjectSnapshotExposesProjectIdentity(t *testing.T) {
 		item.ManagementHome.Vault != "Obsidian Vault" || item.ManagementHome.Path != "/home/god/Obsidian/Dev" {
 		t.Fatalf("management_home fields not surfaced verbatim: %+v", item.ManagementHome)
 	}
+	if item.EffectiveConfig.ProjectID != item.ProjectID || item.EffectiveConfig.ManagementHome == nil ||
+		item.EffectiveConfig.ManagementHome.VaultPath != item.ManagementHome.VaultPath {
+		t.Fatalf("effective_config identity metadata disagrees with project payload: %+v", item.EffectiveConfig)
+	}
 
 	// The JSON projection carries the fields under stable snake_case keys.
 	blob, err := json.Marshal(item)
@@ -69,6 +73,9 @@ func TestProjectSnapshotOmitsIdentityForLegacyProject(t *testing.T) {
 	}
 	if item.ManagementHome != nil {
 		t.Fatalf("legacy management_home should be nil, got %+v", item.ManagementHome)
+	}
+	if item.EffectiveConfig.ProjectID != "" || item.EffectiveConfig.ManagementHome != nil {
+		t.Fatalf("legacy effective_config should omit identity metadata: %+v", item.EffectiveConfig)
 	}
 	blob, _ := json.Marshal(item)
 	if strings.Contains(string(blob), "management_home") {

--- a/internal/server/fleet_project_identity_test.go
+++ b/internal/server/fleet_project_identity_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// The Fleet API project payload surfaces the stable project_id and the
+// descriptive management_home block (#869) without leaking file contents.
+func TestProjectSnapshotExposesProjectIdentity(t *testing.T) {
+	cfg := &config.Config{
+		Repo:      "owner/svc",
+		StateDir:  t.TempDir(),
+		ProjectID: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+		ManagementHome: config.ManagementHomeConfig{
+			Kind:      "obsidian",
+			Path:      "/home/god/Obsidian/Dev",
+			Vault:     "Obsidian Vault",
+			VaultPath: "Dev/Areas/maestro",
+		},
+	}
+	proj := NewFleetProject("svc", filepath.Join(t.TempDir(), "svc.yaml"), "", cfg)
+	fleet := NewFleet([]FleetProject{proj}, "127.0.0.1", 0, false)
+
+	item, _ := fleet.projectSnapshot(proj, time.Now())
+	if item.ProjectID != "3f2504e0-4f89-41d3-9a0c-0305e82c3301" {
+		t.Fatalf("payload project_id = %q", item.ProjectID)
+	}
+	if item.ManagementHome == nil {
+		t.Fatalf("payload management_home should be present")
+	}
+	if item.ManagementHome.Kind != "obsidian" || item.ManagementHome.VaultPath != "Dev/Areas/maestro" ||
+		item.ManagementHome.Vault != "Obsidian Vault" || item.ManagementHome.Path != "/home/god/Obsidian/Dev" {
+		t.Fatalf("management_home fields not surfaced verbatim: %+v", item.ManagementHome)
+	}
+
+	// The JSON projection carries the fields under stable snake_case keys.
+	blob, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(blob)
+	for _, want := range []string{
+		`"project_id":"3f2504e0-4f89-41d3-9a0c-0305e82c3301"`,
+		`"management_home":`,
+		`"vault_path":"Dev/Areas/maestro"`,
+	} {
+		if !strings.Contains(js, want) {
+			t.Fatalf("payload JSON missing %s:\n%s", want, js)
+		}
+	}
+}
+
+// A legacy project without the identity fields omits both from the payload, so
+// existing SPA clients see no new noise (#869).
+func TestProjectSnapshotOmitsIdentityForLegacyProject(t *testing.T) {
+	cfg := &config.Config{Repo: "owner/legacy", StateDir: t.TempDir()}
+	proj := NewFleetProject("legacy", "", "", cfg)
+	fleet := NewFleet([]FleetProject{proj}, "127.0.0.1", 0, false)
+
+	item, _ := fleet.projectSnapshot(proj, time.Now())
+	if item.ProjectID != "" {
+		t.Fatalf("legacy project_id should be empty, got %q", item.ProjectID)
+	}
+	if item.ManagementHome != nil {
+		t.Fatalf("legacy management_home should be nil, got %+v", item.ManagementHome)
+	}
+	blob, _ := json.Marshal(item)
+	if strings.Contains(string(blob), "management_home") {
+		t.Fatalf("legacy payload should omit management_home:\n%s", blob)
+	}
+}


### PR DESCRIPTION
Implements #869

## Changes
- **config**: `config.Config` gains optional `project_id` (validated canonical UUID) and a typed `management_home` block (`kind` / `path` / `vault` / `vault_path`). Validation rejects a malformed UUID, an unknown `kind`, missing `path`/`vault`/`vault_path` for `obsidian`, and an absolute or `..`-traversing `vault_path`. Legacy configs without either field parse and run unchanged.
- **strict decode**: `config.ParseStrict` rejects unknown/misspelled keys by exact name. Project create/edit write paths (config-store `UpsertProject`, import, Fleet API upsert) use it; read paths stay tolerant so legacy rows still load.
- **immutable id**: `project_id` is immutable across an in-place config-store upsert — a different non-empty id is rejected as an identity mismatch, while adding an id to a legacy id-less row is allowed. A rejected write persists nothing.
- **Fleet API**: the project payload surfaces `project_id` and `management_home` verbatim (descriptive only — no file reads or vault traversal), omitted for legacy projects. A metadata-only edit is not an identity change, so store-watch reload applies it live without a flow restart.

Out of scope for this slice (per issue non-goals): no SQLite primary-key change, no repo/state/store rename migration, no Mission Control UI, no genesis wizard, no vault file reads.

## Testing
- `go build ./cmd/maestro/`
- `go test ./...` (all green)
- Added unit tests: config valid/invalid/legacy + strict-decode shapes; config-store upsert→reload→export round-trip, immutable-id, and no-write-on-strict-error; Fleet API payload exposure/omission; daemon metadata-only reload is not an identity change.

## Runtime verification still required
This issue is `runtime-live`. The live dogfood canary (add the Maestro project's stable id + vault-relative Management Home metadata through the supported config change path, then confirm config export and `/api/v1/fleet` agree) is an operator step against the running fleet and is not performed by this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds stable project identity and structured Management Home metadata. The main changes are:

- Validates optional project UUIDs and Management Home fields.
- Rejects unknown keys on project write paths while keeping legacy reads tolerant.
- Preserves an existing project ID during ID-less updates.
- Exposes identity metadata through the Fleet API.
- Applies metadata-only store updates without restarting project flows.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The updated write path preserves stored project IDs when incoming YAML omits or blanks the field. Strict decoding now checks the custom supervisor decoder as well as the rest of the configuration schema.

No blocking issues remain in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The T-Rex run completed a CLI export of the project identity with exit code 0 and preserved the tested values in the YAML export.
- Daemon runtime logs show a config-store project loaded and Fleet listening on localhost, establishing the test environment.
- The after-state log reports MATCH: input == export == API and EXIT\_CODE: 0, confirming parity after the operation.
- Independent verification through the Raw Fleet JSON confirms matching metadata between the project payload and effective\_config.
- Artifacts including before/after YAML, export scripts, logs, and the JSON payload were prepared and reviewed to support the validation.

<a href="https://app.greptile.com/trex/runs/14173233/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds identity metadata, validation, and strict decoding that covers the custom supervisor decoder. |
| internal/configstore/store.go | Enforces strict writes and preserves stored project IDs during ID-less updates. |
| internal/server/fleet.go | Adds project identity metadata to Fleet responses and validates Fleet upserts strictly. |
| internal/config/project_identity_test.go | Tests metadata validation, legacy parsing, and strict unknown-key rejection. |
| internal/configstore/project_identity_test.go | Tests identity round trips, immutable IDs, ID preservation, and rejected writes. |
| internal/daemon/project_identity_reload_test.go | Tests live metadata reloads without project flow restarts. |
| internal/server/fleet_project_identity_test.go | Tests Fleet metadata exposure and omission for legacy projects. |

<sub>Reviews (2): Last reviewed commit: ["feat: harden project identity write and ..."](https://github.com/befeast/maestro/commit/209262bf78765a1e6089d28fe10f7509ae68dabf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43684598)</sub>

<!-- /greptile_comment -->