### PR TITLE
fix: PR-gate repair controls persist a dispatchable payload or reject (#874)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -1106,7 +1106,9 @@ func superviseApprovalCmd(action string, args []string, defaultConfigPath string
 //     and clear NextRetryAt so the orchestrator does NOT respawn.
 //   - restart_worker: terminate the worker, mark the session StatusDead,
 //     and set NextRetryAt = now so respawnDueRetries picks it up on the
-//     next dispatcher cycle.
+//     next dispatcher cycle. worker.Stop removed the worktree, so the stale
+//     worktree/PR pointers are cleared (#874) so respawnDueRetries does a
+//     fresh respawn instead of RespawnInPlace against the deleted directory.
 //
 // Both functions mutate sess in place; the caller of ex.Execute() is
 // responsible for state.Save (the supervisor and CLI approve paths do
@@ -1131,6 +1133,11 @@ func newWorkerController(cfg *config.Config) approver.WorkerControllerFuncs {
 			sess.Status = state.StatusDead
 			sess.FinishedAt = &now
 			sess.NextRetryAt = &now
+			// worker.Stop deleted the worktree; drop the stale pointers so
+			// respawnDueRetries fresh-respawns instead of RespawnInPlace
+			// against a directory that no longer exists (#874).
+			sess.Worktree = ""
+			sess.PRNumber = 0
 			return nil
 		},
 	}

--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -898,6 +898,25 @@ func (e *Executor) executeWorkerControl(approval *state.Approval, verb string, s
 		sess = live
 	}
 
+	// #874: a restart on a session that owns an open PR is the wrong control.
+	// restart_worker terminates the worker via worker.Stop, which removes the
+	// worktree; respawn would then either fail against the deleted directory
+	// or fresh-restart and discard the PR branch. Refuse it with a precise
+	// pointer to the supported in-place path (spawn_review_repair). stop_worker
+	// is unaffected — terminating a worker whose PR is open is legitimate and
+	// does not touch the PR on GitHub. This is defense-in-depth behind the
+	// fleet API/UI, which disables the restart affordance for the same state.
+	if !stop && sess != nil && sess.PRNumber > 0 {
+		return Result{
+			Status: state.ApprovalStatusExecutionFailed,
+			Summary: fmt.Sprintf(
+				"restart_worker refused: slot %s has open PR #%d — restarting deletes its worktree and would repair a stale or missing revision. Use spawn_review_repair to address review feedback in place, or stop_worker to terminate.",
+				slot, sess.PRNumber,
+			),
+			Err: fmt.Errorf("restart_worker on slot %s refused: open PR #%d present", slot, sess.PRNumber),
+		}
+	}
+
 	var err error
 	if stop {
 		err = e.Workers.StopWorker(slot, sess)

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -737,6 +737,45 @@ func TestExecute_RestartWorker_HappyPath(t *testing.T) {
 	}
 }
 
+// #874: restart_worker on a session that owns an open PR is refused before the
+// controller runs — restart deletes the worktree, which would strand or discard
+// the PR branch. The failure summary names the supported in-place alternative.
+func TestExecute_RestartWorker_RefusedForOpenPR(t *testing.T) {
+	wc := &fakeWorkers{}
+	// Finished pr_open gate: worker ended, only live state is the open PR.
+	sess := &state.Session{IssueNumber: 42, Status: state.StatusPROpen, PRNumber: 867, Worktree: "/wt/slot-1"}
+	ex := &Executor{Cfg: newCfg(), Workers: wc, Sessions: fakeSessions{"slot-1": sess}}
+	a := mkApproval(config.SupervisorActionRestartWorker, &state.SupervisorTarget{Session: "slot-1", Issue: 42}, "restart me", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("status = %q, want execution_failed (open PR); res=%+v", res.Status, res)
+	}
+	if len(wc.restartCalls) != 0 {
+		t.Fatalf("RestartWorker must NOT be called for an open-PR session; got %+v", wc.restartCalls)
+	}
+	if !strings.Contains(res.Summary, "PR #867") || !strings.Contains(res.Summary, "spawn_review_repair") {
+		t.Fatalf("summary = %q, want it to name the open PR and the review-repair alternative", res.Summary)
+	}
+}
+
+// #874: stop_worker is still allowed for an open-PR session — terminating a
+// worker whose PR is open is legitimate and does not touch the PR on GitHub.
+func TestExecute_StopWorker_AllowedForOpenPR(t *testing.T) {
+	wc := &fakeWorkers{}
+	sess := &state.Session{IssueNumber: 42, Status: state.StatusPROpen, PRNumber: 867}
+	ex := &Executor{Cfg: newCfg(), Workers: wc, Sessions: fakeSessions{"slot-1": sess}}
+	a := mkApproval(config.SupervisorActionStopWorker, &state.SupervisorTarget{Session: "slot-1", Issue: 42}, "stop me", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("status = %q, want executed (stop allowed with open PR); res=%+v", res.Status, res)
+	}
+	if len(wc.stopCalls) != 1 {
+		t.Fatalf("stopCalls = %+v, want exactly one", wc.stopCalls)
+	}
+}
+
 // TestExecute_StopWorker_SlotReuseFence pins the cautious-gate slot-reuse
 // fence (#488 pattern): if the slot now binds a different issue than the
 // approval targeted, refuse the stop without calling the controller.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5004,6 +5004,25 @@ func repairIssueSessionActive(status state.SessionStatus) bool {
 // single reconcile path shared by the edge-triggered post-merge/outcome callers
 // and the standing reconciler, so every path journals and persists identically
 // (#866). Returns the number staled.
+// mirrorReviewRepairApprovalTerminal mirrors a review-repair approval's
+// terminal transition (changed-head supersede / post-dispatch consume) into
+// the SQLite approval store when one is configured (#874), matching the
+// spawn_repair_worker reconcile mirror. The JSON state is already the source of
+// truth for dispatch; this keeps the queryable mirror from showing a lingering
+// active approval after the JSON record was superseded.
+func (o *Orchestrator) mirrorReviewRepairApprovalTerminal(id string, now time.Time, reason string) {
+	if o == nil || !o.approvalsBinding.UseSQLite() || strings.TrimSpace(id) == "" {
+		return
+	}
+	b := o.approvalsBinding
+	b.StateDir = o.cfg.StateDir
+	b.Repo = o.repo
+	b.Project = o.repo
+	if err := approvalstore.ReconcileMoot(b, id, now, reason); err != nil {
+		log.Printf("[orch] review-repair approval %s terminal mirror to SQLite failed (JSON already updated, retried next cycle): %v", id, err)
+	}
+}
+
 func (o *Orchestrator) reconcileMootRepairApprovals(s *state.State, issue int, now time.Time, reason string) int {
 	staled := s.StaleSpawnRepairWorkerApprovalsForResolvedIssue(issue, now, reason)
 	for i := range staled {
@@ -6282,6 +6301,78 @@ func (o *Orchestrator) supervisorSelectedReviewRepair(s *state.State, issueNumbe
 	return decision.ReviewRepair, decision.Target
 }
 
+// resolveReviewRepairDispatch resolves the review-repair payload the
+// dispatcher should act on for issueNumber. It prefers the latest supervisor
+// decision (the auto pipeline), then falls back to a still-effective
+// spawn_review_repair approval's DURABLE payload (#874). The fallback is what
+// makes a manually enqueued or decision-ring-evicted approval dispatchable: it
+// no longer requires the coincident LatestSupervisorDecision to still be a
+// spawn_review_repair. Returns the approval id when the payload came from the
+// durable approval path (so the caller can resolve it after dispatch); "" for
+// the decision path.
+func (o *Orchestrator) resolveReviewRepairDispatch(s *state.State, issueNumber int) (*state.SupervisorReviewRepairPayload, *state.SupervisorTarget, string) {
+	if payload, target := o.supervisorSelectedReviewRepair(s, issueNumber); payload != nil && target != nil {
+		return payload, target, ""
+	}
+	return o.approvalReviewRepairDispatch(s, issueNumber)
+}
+
+// approvalSelectedReviewRepair returns the durable payload + target + id of a
+// still-effective (approved / awaiting_dispatch) spawn_review_repair approval
+// for issueNumber, or nils when none applies. Pending (unapproved) approvals
+// are intentionally excluded — the cautious gate must clear first.
+func (o *Orchestrator) approvalSelectedReviewRepair(s *state.State, issueNumber int) (*state.SupervisorReviewRepairPayload, *state.SupervisorTarget, string) {
+	if s == nil || issueNumber <= 0 {
+		return nil, nil, ""
+	}
+	for i := range s.Approvals {
+		a := &s.Approvals[i]
+		if a.Action != supervisor.ActionSpawnReviewRepair || a.ReviewRepair == nil {
+			continue
+		}
+		switch a.Status {
+		case state.ApprovalStatusApproved, state.ApprovalStatusAwaitingDispatch:
+		default:
+			continue
+		}
+		if a.Target == nil || a.Target.Issue != issueNumber {
+			continue
+		}
+		return a.ReviewRepair, a.Target, a.ID
+	}
+	return nil, nil, ""
+}
+
+// approvalReviewRepairDispatch resolves a durable-approval review-repair
+// payload, enforcing the #874 changed-head guard: before spawning a worker it
+// reads the PR's current head and refuses to repair a stale revision. When the
+// head has moved past the approved payload, the approval is superseded (the
+// next supervisor cycle re-proves the current head) and (nil, nil, "") is
+// returned. A head-read error is treated conservatively — leave the approval
+// pending rather than repair a possibly-wrong revision.
+func (o *Orchestrator) approvalReviewRepairDispatch(s *state.State, issueNumber int) (*state.SupervisorReviewRepairPayload, *state.SupervisorTarget, string) {
+	payload, target, id := o.approvalSelectedReviewRepair(s, issueNumber)
+	if payload == nil || target == nil {
+		return nil, nil, ""
+	}
+	currentHead, err := o.prHeadSHA(target.PR)
+	if err != nil {
+		log.Printf("[orch] review-repair approval %s: PR #%d head read failed; leaving approval pending: %v", id, target.PR, err)
+		return nil, nil, ""
+	}
+	if strings.TrimSpace(currentHead) != strings.TrimSpace(payload.HeadSHA) {
+		now := time.Now().UTC()
+		reason := fmt.Sprintf("PR #%d head moved to %s (review-repair approved for %s) — superseded to avoid repairing a stale revision",
+			target.PR, shortReviewRepairSHA(currentHead), shortReviewRepairSHA(payload.HeadSHA))
+		for _, staled := range s.SupersedeReviewRepairApprovalsForStaleHead(target.PR, currentHead, now, reason) {
+			log.Printf("[orch] %s (approval %s)", reason, staled)
+			o.mirrorReviewRepairApprovalTerminal(staled, now, reason)
+		}
+		return nil, nil, ""
+	}
+	return payload, target, id
+}
+
 // hasEffectiveApprovalForDecision reports whether the supervisor decision
 // has a matching approval that is currently effective (approved or
 // awaiting_dispatch). Used to gate cautious-mode dispatch on the
@@ -6650,7 +6741,8 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		// the scoped Greptile-finding prompt. Skip the pipeline preamble
 		// — the review-repair worker is a focused, single-phase fixer
 		// (not a planner/implementer/validator pass).
-		if reviewRepair, repairTarget := o.supervisorSelectedReviewRepair(s, issue.Number); reviewRepair != nil && repairTarget != nil {
+		reviewRepair, repairTarget, reviewRepairApprovalID := o.resolveReviewRepairDispatch(s, issue.Number)
+		if reviewRepair != nil && repairTarget != nil {
 			if !o.tryClaimReviewRepairSlot(s, repairTarget, reviewRepair) {
 				continue
 			}
@@ -6661,8 +6753,12 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			promptBase = supervisor.FormatReviewRepairPromptFromPayload(issue.Number, repairTarget.PR, reviewRepair)
 			initialPhase = state.PhaseNone
 			backendReason = "review_repair"
-			log.Printf("[orch] starting auto review-repair worker for issue #%d (PR #%d, head %s, backend=%s, %d findings)",
-				issue.Number, repairTarget.PR, shortReviewRepairSHA(reviewRepair.HeadSHA), backendName, len(reviewRepair.Findings))
+			source := "auto"
+			if reviewRepairApprovalID != "" {
+				source = "approval " + reviewRepairApprovalID
+			}
+			log.Printf("[orch] starting review-repair worker for issue #%d (PR #%d, head %s, backend=%s, %d findings, source=%s)",
+				issue.Number, repairTarget.PR, shortReviewRepairSHA(reviewRepair.HeadSHA), backendName, len(reviewRepair.Findings), source)
 		} else if initialPhase != state.PhaseNone && initialPhase != state.PhaseImplement {
 			// Pipeline mode with planner — use planner backend and raw template
 			// (worker.Start → assemblePrompt will substitute {{WORKTREE}} etc.)
@@ -6769,6 +6865,19 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		}
 		if o.syncProject(issue.Number, github.ProjectStatusInProgress) {
 			s.MarkProjectStatusSynced(issue.Number, string(github.ProjectStatusInProgress), time.Now().UTC())
+		}
+		// #874: when this review-repair worker was dispatched from a durable
+		// approval (not the live decision path), supersede that approval now
+		// that its worker has really started — so the dispatcher does not
+		// re-resolve (and re-read the PR head) every cycle, and no active
+		// approval is left behind after the repair reaches a worker.
+		if reviewRepairApprovalID != "" {
+			resolveNow := time.Now().UTC()
+			reason := fmt.Sprintf("review-repair worker %s dispatched for PR #%d — approval consumed", slotName, repairTarget.PR)
+			if s.ResolveDispatchedReviewRepairApproval(reviewRepairApprovalID, resolveNow, reason) {
+				log.Printf("[orch] %s (approval %s)", reason, reviewRepairApprovalID)
+				o.mirrorReviewRepairApprovalTerminal(reviewRepairApprovalID, resolveNow, reason)
+			}
 		}
 		o.notifier.Sendf("🚀 maestro: started worker %s for issue #%d: %s", slotName, issue.Number, issue.Title)
 		started++

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6263,6 +6263,19 @@ func (o *Orchestrator) tryClaimReviewRepairSlot(s *state.State, target *state.Su
 	return true
 }
 
+// releaseReviewRepairSlot rolls back a (pr,head_sha) attempt claimed by
+// tryClaimReviewRepairSlot when the worker start that would have consumed it
+// failed (#874). Without this, a failed start spends an attempt from the
+// bounded budget while the approval stays active, so a run of start failures
+// exhausts the budget and the approved repair can never reach a worker.
+func (o *Orchestrator) releaseReviewRepairSlot(s *state.State, target *state.SupervisorTarget, payload *state.SupervisorReviewRepairPayload) {
+	if s == nil || target == nil || payload == nil {
+		return
+	}
+	s.ReleaseReviewRepairAttempt(target.PR, payload.HeadSHA, time.Now().UTC())
+	log.Printf("[orch] review-repair: released claimed attempt for PR #%d head %s after failed start", target.PR, shortReviewRepairSHA(payload.HeadSHA))
+}
+
 // shortReviewRepairSHA trims a SHA for log messages — keeps the path
 // dependency-free from internal/supervisor's shortSHA helper.
 func shortReviewRepairSHA(sha string) string {
@@ -6832,6 +6845,13 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			log.Printf("[orch] start worker for issue #%d: %v", issue.Number, err)
 			o.notifier.Sendf("❌ maestro: failed to start worker for issue #%d (%s): %v",
 				issue.Number, issue.Title, err)
+			// #874: a review-repair dispatch claimed a (pr,head) attempt via
+			// tryClaimReviewRepairSlot BEFORE this start; release it so a failed
+			// start does not burn a slot from the bounded repair budget and leave
+			// the still-active approval permanently un-dispatchable.
+			if reviewRepair != nil && repairTarget != nil {
+				o.releaseReviewRepairSlot(s, repairTarget, reviewRepair)
+			}
 			continue
 		}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -7557,6 +7557,62 @@ func TestRespawnDueRetries_WithOpenPRRespawnsInPlace(t *testing.T) {
 	}
 }
 
+// #874: restart_worker on a finished pr_open session tears down the worktree
+// and (via the restart controller) clears sess.Worktree/PRNumber. The dead
+// session that respawnDueRetries then picks up must take the FRESH respawn
+// path, never RespawnInPlace against the directory that was just removed.
+func TestRespawnDueRetries_ClearedWorktreeRespawnsFresh(t *testing.T) {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		MaxRetryBackoffMs: 300000,
+		MaxRuntimeMinutes: 999,
+	}
+	respawnedFresh := false
+	respawnedInPlace := false
+	o := &Orchestrator{
+		cfg:        cfg,
+		notifier:   &notify.Notifier{},
+		promptBase: "test prompt",
+		getIssueFn: func(number int) (github.Issue, error) {
+			return makeIssue(number, "test issue"), nil
+		},
+		respawnWorkerFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawnedFresh = true
+			sess.Status = state.StatusRunning
+			sess.PID = 4444
+			return nil
+		},
+		respawnInPlaceFn: func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+			respawnedInPlace = true
+			return nil
+		},
+	}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	s := state.NewState()
+	// The restart controller already ran worker.Stop (removed the worktree)
+	// and cleared the pointers: Worktree="" and PRNumber=0.
+	s.Sessions["mae-12"] = &state.Session{
+		IssueNumber: 112,
+		IssueTitle:  "restarted worker",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &pastTime,
+		Branch:      "feat/mae-12-112-test",
+		Worktree:    "",
+		PRNumber:    0,
+	}
+
+	o.respawnDueRetries(s, 1)
+
+	if respawnedInPlace {
+		t.Fatal("must NOT choose RespawnInPlace after the restart cleared the worktree")
+	}
+	if !respawnedFresh {
+		t.Fatal("expected a fresh respawn once the stale worktree pointer was cleared")
+	}
+}
+
 func TestRespawnDueRetries_BackoffNotElapsed_Waits(t *testing.T) {
 	cfg := &config.Config{
 		Repo:              "owner/repo",

--- a/internal/orchestrator/review_repair_test.go
+++ b/internal/orchestrator/review_repair_test.go
@@ -43,6 +43,31 @@ func TestTryClaimReviewRepairSlot_HonoursBudget(t *testing.T) {
 	}
 }
 
+// #874: a worker start that fails after the slot was claimed must release the
+// attempt, so the bounded budget is not spent by a start that never produced a
+// worker and the still-active approval remains dispatchable next cycle.
+func TestReleaseReviewRepairSlot_RestoresBudgetAfterFailedStart(t *testing.T) {
+	o := &Orchestrator{cfg: reviewRepairCfg(1)}
+	s := state.NewState()
+	target := &state.SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "deadbeef0000"}
+	payload := &state.SupervisorReviewRepairPayload{HeadSHA: "deadbeef0000", MaxRetries: 1, Backend: "claude"}
+
+	if !o.tryClaimReviewRepairSlot(s, target, payload) {
+		t.Fatal("first claim must succeed")
+	}
+	// Simulate the failed start: the dispatcher releases the claimed slot.
+	o.releaseReviewRepairSlot(s, target, payload)
+
+	track, _ := s.LookupReviewRepairTrack(564, "deadbeef0000")
+	if track.Attempts != 0 || track.Exhausted {
+		t.Fatalf("after release: track=%+v, want attempts=0 not exhausted", track)
+	}
+	// Budget restored: the next cycle can claim the same (pr,head) again.
+	if !o.tryClaimReviewRepairSlot(s, target, payload) {
+		t.Fatal("claim after release must succeed — a failed start must not burn the budget")
+	}
+}
+
 // A new head SHA on the same PR (the repair worker pushed a fix) opens
 // a fresh budget. The orchestrator must allow the next claim.
 func TestTryClaimReviewRepairSlot_NewHeadSHAFreshBudget(t *testing.T) {

--- a/internal/orchestrator/review_repair_test.go
+++ b/internal/orchestrator/review_repair_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -127,5 +128,106 @@ func TestSupervisorSelectedReviewRepair_RequiresEffectiveApproval(t *testing.T) 
 	})
 	if payload, _ := o.supervisorSelectedReviewRepair(s, 442); payload == nil {
 		t.Fatal("expected dispatch after awaiting_dispatch approval was recorded")
+	}
+}
+
+// reviewRepairApproval builds an effective spawn_review_repair approval whose
+// durable payload targets head.
+func reviewRepairApproval(issue, pr int, head string) state.Approval {
+	return state.Approval{
+		ID:     "ap-durable",
+		Action: supervisor.ActionSpawnReviewRepair,
+		Status: state.ApprovalStatusAwaitingDispatch,
+		Target: &state.SupervisorTarget{Issue: issue, PR: pr, HeadSHA: head},
+		ReviewRepair: &state.SupervisorReviewRepairPayload{
+			HeadSHA: head,
+			Backend: "claude",
+			Findings: []state.SupervisorReviewFinding{
+				{Path: "internal/foo.go", Line: 1, Body: "P1: bad", Severity: "P1"},
+			},
+		},
+	}
+}
+
+// #874: the dispatcher must converge from a durable approval's payload even
+// when the LATEST supervisor decision is monitor_open_pr (the live sup-307
+// wedge). The head guard reads the PR head; when it matches the approved
+// payload, the payload + approval id are returned for dispatch.
+func TestResolveReviewRepairDispatch_ConsumesDurableApprovalPayload(t *testing.T) {
+	o := &Orchestrator{cfg: reviewRepairCfg(1), ghPRHeadSHAFn: func(pr int) (string, error) {
+		return "deadbeef", nil
+	}}
+	s := state.NewState()
+	now := time.Now().UTC()
+	// Latest decision is monitor_open_pr — carries no review-repair payload.
+	s.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "mon-1",
+		CreatedAt:         now,
+		RecommendedAction: supervisor.ActionMonitorOpenPR,
+		Target:            &state.SupervisorTarget{Issue: 442, PR: 564, HeadSHA: "deadbeef"},
+	}, state.DefaultSupervisorDecisionLimit)
+	s.Approvals = append(s.Approvals, reviewRepairApproval(442, 564, "deadbeef"))
+
+	payload, target, approvalID := o.resolveReviewRepairDispatch(s, 442)
+	if payload == nil || target == nil {
+		t.Fatal("expected dispatch from the durable approval payload despite monitor_open_pr being latest")
+	}
+	if approvalID != "ap-durable" {
+		t.Fatalf("approvalID = %q, want ap-durable (approval-sourced dispatch)", approvalID)
+	}
+	if target.PR != 564 || len(payload.Findings) != 1 {
+		t.Fatalf("payload/target = %+v / %+v", payload, target)
+	}
+}
+
+// #874 changed-head: when the PR head has moved past the approved payload, the
+// dispatcher must NOT repair the stale revision — it supersedes the approval
+// and declines to dispatch.
+func TestResolveReviewRepairDispatch_ChangedHeadSupersedes(t *testing.T) {
+	o := &Orchestrator{cfg: reviewRepairCfg(1), ghPRHeadSHAFn: func(pr int) (string, error) {
+		return "newhead", nil
+	}}
+	s := state.NewState()
+	s.Approvals = append(s.Approvals, reviewRepairApproval(442, 564, "oldhead"))
+
+	payload, _, _ := o.resolveReviewRepairDispatch(s, 442)
+	if payload != nil {
+		t.Fatal("changed head must not dispatch a stale-revision repair")
+	}
+	if s.Approvals[0].Status != state.ApprovalStatusSuperseded {
+		t.Fatalf("approval status = %q, want superseded after head moved", s.Approvals[0].Status)
+	}
+}
+
+// #874: a head-read error is handled conservatively — leave the approval
+// pending rather than repair a possibly-wrong revision.
+func TestResolveReviewRepairDispatch_HeadReadErrorLeavesPending(t *testing.T) {
+	o := &Orchestrator{cfg: reviewRepairCfg(1), ghPRHeadSHAFn: func(pr int) (string, error) {
+		return "", context.DeadlineExceeded
+	}}
+	s := state.NewState()
+	s.Approvals = append(s.Approvals, reviewRepairApproval(442, 564, "oldhead"))
+
+	if payload, _, _ := o.resolveReviewRepairDispatch(s, 442); payload != nil {
+		t.Fatal("head-read error must not dispatch")
+	}
+	if s.Approvals[0].Status != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("approval status = %q, want still awaiting_dispatch after a head-read error", s.Approvals[0].Status)
+	}
+}
+
+// #874: a pending (unapproved) durable approval must NOT dispatch — the
+// cautious gate has to clear first.
+func TestResolveReviewRepairDispatch_PendingApprovalDoesNotDispatch(t *testing.T) {
+	o := &Orchestrator{cfg: reviewRepairCfg(1), ghPRHeadSHAFn: func(pr int) (string, error) {
+		return "deadbeef", nil
+	}}
+	s := state.NewState()
+	pending := reviewRepairApproval(442, 564, "deadbeef")
+	pending.Status = state.ApprovalStatusPending
+	s.Approvals = append(s.Approvals, pending)
+
+	if payload, _, _ := o.resolveReviewRepairDispatch(s, 442); payload != nil {
+		t.Fatal("a pending (unapproved) approval must not be dispatched")
 	}
 }

--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -480,7 +480,26 @@ func enrichSpawnReviewRepairDecision(decision *state.SupervisorDecision, st *sta
 	// distinct approval (approvalTargetsEqual includes HeadSHA) and repeat
 	// clicks on the same head coalesce to the one record.
 	decision.Target.HeadSHA = payload.HeadSHA
-	if decision.Target.Issue == 0 && provenTarget != nil {
+	// The proven target's issue is authoritative for this PR: the dispatcher
+	// selects durable review-repair approvals by target issue
+	// (approvalSelectedReviewRepair), so a caller-supplied issue that
+	// contradicts the proof would mint an approval that runs the repair with
+	// the wrong issue/PR pairing or is never selected for the PR's real issue.
+	// Adopt the proven issue; reject a nonzero caller issue that disagrees with
+	// a precise reason rather than silently overriding operator intent (#874).
+	if provenTarget != nil && provenTarget.Issue > 0 {
+		if decision.Target.Issue > 0 && decision.Target.Issue != provenTarget.Issue {
+			msg := fmt.Sprintf(
+				"cannot enqueue spawn_review_repair for PR #%d: issue_number #%d does not match the PR's proven issue #%d. "+
+					"Omit issue_number or pass #%d.",
+				prNumber, decision.Target.Issue, provenTarget.Issue, provenTarget.Issue)
+			return safeActionResult{
+				handled: true,
+				status:  http.StatusConflict,
+				body:    map[string]string{"error": msg},
+				err:     fmt.Errorf("spawn_review_repair PR #%d: issue #%d mismatches proven issue #%d", prNumber, decision.Target.Issue, provenTarget.Issue),
+			}, false
+		}
 		decision.Target.Issue = provenTarget.Issue
 	}
 	return safeActionResult{}, true

--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -354,6 +354,21 @@ func dispatchApprovalAction(req controlActionRequest, cfg *config.Config, stateD
 
 	now := time.Now().UTC()
 	decision := buildApprovalDecision(id, req, cfg, authenticatedActor, now)
+
+	// #874: a manual spawn_review_repair enqueue must persist a durable
+	// payload (repo/issue/PR/head SHA/blocking findings/backend) or be
+	// rejected before any mutation. The dispatcher consumes that payload
+	// directly; without it the approval would enter awaiting_dispatch with
+	// no dispatcher path (the exact live wedge on sup-307 / #866). The server
+	// cannot compute review findings itself, so it reuses a payload the
+	// supervisor already proved on this PR's current head.
+	if id == config.SupervisorActionSpawnReviewRepair {
+		res, ok := enrichSpawnReviewRepairDecision(&decision, st, req.PRNumber)
+		if !ok {
+			return res
+		}
+	}
+
 	approval := st.RecordPendingApprovalForDecision(decision, now)
 	if approval == nil {
 		return safeActionResult{handled: true, status: http.StatusInternalServerError, body: map[string]string{"error": "failed to record approval"}, err: errors.New("RecordPendingApprovalForDecision returned nil")}
@@ -430,6 +445,45 @@ func validateApprovalRequest(id string, req controlActionRequest) error {
 		}
 	}
 	return nil
+}
+
+// enrichSpawnReviewRepairDecision stamps a proven review-repair payload onto a
+// manual spawn_review_repair decision, or returns a rejection result when no
+// proof exists for the target PR (#874). The proof — head SHA, blocking
+// findings, backend — is reused from a payload the supervisor already observed
+// on this PR (an effective approval or a recent decision); the durable payload
+// then rides the minted approval so the dispatcher can converge on exactly one
+// worker without a coincident latest supervisor decision. Returns (result,
+// ok): ok=false means the caller must return result (an HTTP rejection) instead
+// of recording the approval.
+func enrichSpawnReviewRepairDecision(decision *state.SupervisorDecision, st *state.State, prNumber int) (safeActionResult, bool) {
+	payload, provenTarget, ok := st.EffectiveReviewRepairPayloadForPR(prNumber)
+	if !ok {
+		msg := fmt.Sprintf(
+			"cannot enqueue spawn_review_repair for PR #%d: no proven blocking review findings on its current head. "+
+				"The supervisor mints a scoped review-repair (with head SHA + findings) automatically once a green, "+
+				"mergeable, retry-exhausted PR is blocked by review — approve that when it appears. A manual enqueue "+
+				"without that proof would stall in awaiting_dispatch with no dispatcher path, so it is refused here.",
+			prNumber)
+		return safeActionResult{
+			handled: true,
+			status:  http.StatusConflict,
+			body:    map[string]string{"error": msg},
+			err:     fmt.Errorf("spawn_review_repair PR #%d: no proven review-repair payload to enqueue", prNumber),
+		}, false
+	}
+	decision.ReviewRepair = payload
+	if decision.Target == nil {
+		decision.Target = &state.SupervisorTarget{PR: prNumber}
+	}
+	// Key the approval on the proven head SHA so a later head push mints a
+	// distinct approval (approvalTargetsEqual includes HeadSHA) and repeat
+	// clicks on the same head coalesce to the one record.
+	decision.Target.HeadSHA = payload.HeadSHA
+	if decision.Target.Issue == 0 && provenTarget != nil {
+		decision.Target.Issue = provenTarget.Issue
+	}
+	return safeActionResult{}, true
 }
 
 // buildApprovalDecision constructs a synthetic SupervisorDecision so the

--- a/internal/server/review_repair_test.go
+++ b/internal/server/review_repair_test.go
@@ -4,16 +4,47 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/befeast/maestro/internal/state"
 )
 
-// #565: HTTP enqueue for spawn_review_repair must (a) accept the verb
-// (no 400 "unknown action"), (b) require pr_number, (c) record a
-// pending approval bound to the supervisor target so the cautious gate
-// path is reusable from the dashboard.
-func TestApprovalAction_SpawnReviewRepair_Enqueues202(t *testing.T) {
+// seedProvenReviewRepair writes a supervisor decision carrying a review-repair
+// payload for (issue, pr, head) into the state at dir, so a manual enqueue can
+// prove the payload (#874). Mirrors what the supervisor records once it
+// observes blocking review findings on a green, mergeable, retry-exhausted PR.
+func seedProvenReviewRepair(t *testing.T, dir string, issue, pr int, head string) {
+	t.Helper()
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	st.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "dec-proof",
+		CreatedAt:         time.Now().UTC(),
+		RecommendedAction: "spawn_review_repair",
+		Target:            &state.SupervisorTarget{Issue: issue, PR: pr, HeadSHA: head},
+		ReviewRepair: &state.SupervisorReviewRepairPayload{
+			HeadSHA: head,
+			Backend: "claude",
+			Findings: []state.SupervisorReviewFinding{
+				{Path: "internal/foo.go", Line: 42, Body: "P1: fix this", Severity: "P1"},
+			},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+}
+
+// #565/#874: HTTP enqueue for spawn_review_repair, when the supervisor has
+// already proven blocking findings on the PR head, records a pending approval
+// that DURABLY carries the review-repair payload (head SHA + findings), so the
+// orchestrator dispatcher can converge without a coincident latest decision.
+func TestApprovalAction_SpawnReviewRepair_Enqueues202WithDurablePayload(t *testing.T) {
 	cfg, dir := approvalEnqueueCfg(t)
+	seedProvenReviewRepair(t, dir, 442, 564, "deadbeefcafe")
+
 	srv := New(cfg, nil)
 	srv.SetActionDeps(&fakeActionGH{}, nil)
 
@@ -36,11 +67,44 @@ func TestApprovalAction_SpawnReviewRepair_Enqueues202(t *testing.T) {
 	if len(st.Approvals) != 1 {
 		t.Fatalf("approvals = %d, want 1", len(st.Approvals))
 	}
-	if got := st.Approvals[0].Action; got != "spawn_review_repair" {
-		t.Fatalf("approval action = %q, want spawn_review_repair", got)
+	a := st.Approvals[0]
+	if a.Action != "spawn_review_repair" {
+		t.Fatalf("approval action = %q, want spawn_review_repair", a.Action)
 	}
-	if got := st.Approvals[0].Target; got == nil || got.PR != 564 || got.Issue != 442 {
-		t.Fatalf("target = %+v, want PR=564 issue=442", got)
+	if a.Target == nil || a.Target.PR != 564 || a.Target.Issue != 442 {
+		t.Fatalf("target = %+v, want PR=564 issue=442", a.Target)
+	}
+	if a.Target.HeadSHA != "deadbeefcafe" {
+		t.Fatalf("target head = %q, want the proven head deadbeefcafe (idempotency key)", a.Target.HeadSHA)
+	}
+	if a.ReviewRepair == nil {
+		t.Fatal("approval.ReviewRepair is nil — the durable payload was not persisted; the dispatcher would have no path")
+	}
+	if a.ReviewRepair.HeadSHA != "deadbeefcafe" || len(a.ReviewRepair.Findings) != 1 {
+		t.Fatalf("payload = %+v, want head deadbeefcafe with 1 finding", a.ReviewRepair)
+	}
+}
+
+// #874: a manual spawn_review_repair enqueue with NO proven payload must be
+// rejected before any mutation — otherwise the approval enters awaiting_dispatch
+// with no dispatcher path (the live sup-307 / #866 wedge). The rejection is a
+// 409 with a precise reason and leaves state untouched.
+func TestApprovalAction_SpawnReviewRepair_RejectsWhenUnproven(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"spawn_review_repair","pr_number":564,"issue_number":442}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (no proven payload); body=%s", w.Code, w.Body.String())
+	}
+
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(st.Approvals) != 0 {
+		t.Fatalf("approvals = %d, want 0 — a rejected enqueue must not mutate state", len(st.Approvals))
 	}
 }
 

--- a/internal/server/review_repair_test.go
+++ b/internal/server/review_repair_test.go
@@ -119,3 +119,57 @@ func TestApprovalAction_SpawnReviewRepair_RequiresPRNumber(t *testing.T) {
 		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
 	}
 }
+
+// #874: a caller-supplied issue_number that contradicts the PR's proven issue
+// must be rejected before any mutation. The dispatcher selects durable
+// review-repair approvals by target issue, so minting one against the wrong
+// issue would run the repair with a wrong issue/PR pairing (or never be
+// selected for the PR's real issue). The rejection is a 409 and leaves state
+// untouched.
+func TestApprovalAction_SpawnReviewRepair_RejectsMismatchedIssue(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	seedProvenReviewRepair(t, dir, 442, 564, "deadbeefcafe")
+
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	// Proven issue is 442; caller asserts 999.
+	w := postApprovalAction(t, srv, `{"action_id":"spawn_review_repair","pr_number":564,"issue_number":999}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (issue mismatch); body=%s", w.Code, w.Body.String())
+	}
+
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(st.Approvals) != 0 {
+		t.Fatalf("approvals = %d, want 0 — a mismatched enqueue must not mutate state", len(st.Approvals))
+	}
+}
+
+// #874: omitting issue_number adopts the PR's proven issue, so the minted
+// approval carries the correct issue/PR pairing the dispatcher selects on.
+func TestApprovalAction_SpawnReviewRepair_AdoptsProvenIssueWhenOmitted(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	seedProvenReviewRepair(t, dir, 442, 564, "deadbeefcafe")
+
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"spawn_review_repair","pr_number":564}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(st.Approvals) != 1 {
+		t.Fatalf("approvals = %d, want 1", len(st.Approvals))
+	}
+	if a := st.Approvals[0]; a.Target == nil || a.Target.Issue != 442 || a.Target.PR != 564 {
+		t.Fatalf("target = %+v, want proven issue=442 PR=564", a.Target)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -913,8 +913,24 @@ func workerActionAffordances(readOnly bool, endpoint string, worker sessionInfo)
 			merge.DisabledReason = "No PR is associated with this worker; approve merge becomes available once a PR is open."
 		}
 	}
+	restart := newApprovalControlAction("restart_worker", "Restart", "Enqueue a cautious-gate approval to restart this worker.", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, readOnly)
+	if worker.PRNumber > 0 {
+		// #874: restarting a worker that already owns an open PR is the wrong
+		// control — restart_worker deletes the worktree, which would strand
+		// or discard the PR branch. The supported in-place path is
+		// spawn_review_repair (address review feedback without touching the
+		// worktree), and stop_worker still terminates if that is the intent.
+		// Disable Restart for this state and name the alternative so the
+		// operator is not offered an action the dispatcher cannot complete.
+		restart.Disabled = true
+		if readOnly {
+			restart.DisabledReason = readOnlyDisabledReason() + fmt.Sprintf(" Additionally, this worker has open PR #%d — restart is unsupported for an open PR; use review-repair (in place) or Stop.", worker.PRNumber)
+		} else {
+			restart.DisabledReason = fmt.Sprintf("This worker has open PR #%d; restart would delete its worktree and strand the PR branch. Use review-repair to address review feedback in place, or Stop to terminate.", worker.PRNumber)
+		}
+	}
 	return []controlAction{
-		newApprovalControlAction("restart_worker", "Restart", "Enqueue a cautious-gate approval to restart this worker.", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, readOnly),
+		restart,
 		newApprovalControlAction("stop_worker", "Stop", "Enqueue a cautious-gate approval to stop this worker.", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, readOnly),
 		newSafeControlAction("mark_issue_ready", "Mark ready", "Add the maestro-ready label so the supervisor picks the issue up.", "issue", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, readOnly),
 		newSafeControlAction("mark_issue_blocked", "Mark blocked", "Add the blocked label so the supervisor holds the issue.", "issue", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, readOnly),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1467,6 +1467,34 @@ func assertReadOnlyAction(t *testing.T, action controlAction) {
 	}
 }
 
+// #874: the Restart affordance must be disabled for a worker that owns an open
+// PR (restart deletes the worktree and would strand the PR branch), and the
+// disabled reason must name the supported in-place alternative. Stop stays
+// enabled. A PR-less worker keeps Restart enabled.
+func TestWorkerActionAffordances_RestartDisabledForOpenPR(t *testing.T) {
+	withPR := workerActionAffordances(false, "/api/v1/actions", sessionInfo{Slot: "slot-0", IssueNumber: 42, PRNumber: 867})
+	restart := findControlAction(t, withPR, "restart_worker")
+	if !restart.Disabled {
+		t.Fatalf("restart_worker for an open-PR worker should be disabled, got %+v", restart)
+	}
+	if !contains(restart.DisabledReason, "PR #867") {
+		t.Fatalf("disabled reason = %q, want it to name the open PR", restart.DisabledReason)
+	}
+	if !contains(restart.DisabledReason, "review-repair") {
+		t.Fatalf("disabled reason = %q, want it to name the supported review-repair alternative", restart.DisabledReason)
+	}
+	stop := findControlAction(t, withPR, "stop_worker")
+	if stop.Disabled {
+		t.Fatalf("stop_worker for an open-PR worker should stay enabled, got %+v", stop)
+	}
+
+	noPR := workerActionAffordances(false, "/api/v1/actions", sessionInfo{Slot: "slot-1", IssueNumber: 43})
+	restartNoPR := findControlAction(t, noPR, "restart_worker")
+	if restartNoPR.Disabled {
+		t.Fatalf("restart_worker for a PR-less worker should be enabled, got %+v", restartNoPR)
+	}
+}
+
 func TestHandleStateProjectBlockedKeepsAttentionForOpenPR(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{Repo: "test/repo", MaxParallel: 1, StateDir: dir}

--- a/internal/state/review_repair_approval_test.go
+++ b/internal/state/review_repair_approval_test.go
@@ -1,0 +1,159 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func reviewRepairDecision(issue, pr int, head string) SupervisorDecision {
+	return SupervisorDecision{
+		ID:                "dec-1",
+		CreatedAt:         time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC),
+		RecommendedAction: approvalActionSpawnReviewRepair,
+		Risk:              "mutating",
+		RequiresApproval:  true,
+		Repo:              "BeFeast/maestro",
+		Project:           "BeFeast/maestro",
+		Target:            &SupervisorTarget{Issue: issue, PR: pr, HeadSHA: head},
+		ReviewRepair: &SupervisorReviewRepairPayload{
+			HeadSHA: head,
+			Backend: "claude",
+			Findings: []SupervisorReviewFinding{
+				{Path: "internal/foo.go", Line: 42, Body: "P1: fix", Severity: "P1"},
+			},
+		},
+	}
+}
+
+// #874: an approval minted from a spawn_review_repair decision must DURABLY
+// carry the review-repair payload, so the dispatcher can converge from the
+// approval alone without a coincident latest decision.
+func TestRecordPendingApprovalForDecision_PersistsReviewRepairPayload(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	st := NewState()
+	approval := st.RecordPendingApprovalForDecision(reviewRepairDecision(442, 564, "deadbeef"), now)
+	if approval == nil {
+		t.Fatal("RecordPendingApprovalForDecision returned nil")
+	}
+	if approval.ReviewRepair == nil {
+		t.Fatal("approval.ReviewRepair is nil — payload not persisted")
+	}
+	if approval.ReviewRepair.HeadSHA != "deadbeef" || len(approval.ReviewRepair.Findings) != 1 {
+		t.Fatalf("payload = %+v, want head deadbeef + 1 finding", approval.ReviewRepair)
+	}
+	// Deep copy: mutating the approval's payload must not touch the decision's.
+	approval.ReviewRepair.Findings[0].Body = "mutated"
+	fresh := st.RecordPendingApprovalForDecision(reviewRepairDecision(442, 564, "deadbeef"), now)
+	if fresh.ReviewRepair.Findings[0].Body != "mutated" {
+		// same identity → refreshed in place; the refresh re-clones from the
+		// decision, so it should be back to the decision's value.
+		if fresh.ReviewRepair.Findings[0].Body != "P1: fix" {
+			t.Fatalf("refreshed payload body = %q, want the decision value", fresh.ReviewRepair.Findings[0].Body)
+		}
+	}
+}
+
+// #874: daemon restart — the durable payload must survive a Save/Load round
+// trip so the dispatcher path works after the process restarts.
+func TestReviewRepairApproval_SurvivesSaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	st := NewState()
+	st.RecordPendingApprovalForDecision(reviewRepairDecision(442, 564, "deadbeef"), now)
+	if err := Save(dir, st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	reloaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(reloaded.Approvals) != 1 {
+		t.Fatalf("approvals = %d, want 1", len(reloaded.Approvals))
+	}
+	rr := reloaded.Approvals[0].ReviewRepair
+	if rr == nil || rr.HeadSHA != "deadbeef" || len(rr.Findings) != 1 {
+		t.Fatalf("reloaded payload = %+v, want durable head + finding", rr)
+	}
+}
+
+// #874: EffectiveReviewRepairPayloadForPR proves the payload for a manual
+// enqueue — preferring an effective approval, then a recent decision, and
+// returning false when nothing proves it.
+func TestEffectiveReviewRepairPayloadForPR(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+
+	// No proof.
+	empty := NewState()
+	if _, _, ok := empty.EffectiveReviewRepairPayloadForPR(564); ok {
+		t.Fatal("empty state must not prove a review-repair payload")
+	}
+
+	// Proof from a decision only.
+	fromDecision := NewState()
+	fromDecision.RecordSupervisorDecision(reviewRepairDecision(442, 564, "cafe1234"), DefaultSupervisorDecisionLimit)
+	payload, target, ok := fromDecision.EffectiveReviewRepairPayloadForPR(564)
+	if !ok || payload == nil || payload.HeadSHA != "cafe1234" {
+		t.Fatalf("decision proof: ok=%v payload=%+v", ok, payload)
+	}
+	if target == nil || target.Issue != 442 {
+		t.Fatalf("decision proof target = %+v, want issue 442", target)
+	}
+	// Wrong PR is not proven.
+	if _, _, ok := fromDecision.EffectiveReviewRepairPayloadForPR(999); ok {
+		t.Fatal("PR 999 must not be proven from a PR 564 decision")
+	}
+
+	// Proof from an effective approval wins.
+	fromApproval := NewState()
+	fromApproval.RecordPendingApprovalForDecision(reviewRepairDecision(442, 564, "beef5678"), now)
+	payload, _, ok = fromApproval.EffectiveReviewRepairPayloadForPR(564)
+	if !ok || payload == nil || payload.HeadSHA != "beef5678" {
+		t.Fatalf("approval proof: ok=%v payload=%+v", ok, payload)
+	}
+}
+
+// #874 changed-head: a spawn_review_repair approval whose durable payload head
+// no longer matches the PR's current head must be superseded so the dispatcher
+// never repairs a stale revision.
+func TestSupersedeReviewRepairApprovalsForStaleHead(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	st := NewState()
+	st.RecordPendingApprovalForDecision(reviewRepairDecision(442, 564, "oldhead"), now)
+
+	// Matching head → nothing superseded.
+	if ids := st.SupersedeReviewRepairApprovalsForStaleHead(564, "oldhead", now, "reason"); len(ids) != 0 {
+		t.Fatalf("matching head superseded %v, want none", ids)
+	}
+	if st.Approvals[0].Status != ApprovalStatusPending {
+		t.Fatalf("status = %q, want still pending", st.Approvals[0].Status)
+	}
+
+	// Moved head → superseded.
+	ids := st.SupersedeReviewRepairApprovalsForStaleHead(564, "newhead", now.Add(time.Minute), "head moved")
+	if len(ids) != 1 {
+		t.Fatalf("moved head superseded %v, want 1", ids)
+	}
+	if st.Approvals[0].Status != ApprovalStatusSuperseded {
+		t.Fatalf("status = %q, want superseded", st.Approvals[0].Status)
+	}
+}
+
+// #874: after dispatch, the durable-approval path resolves the approval so it
+// is not re-dispatched and no active approval is left behind.
+func TestResolveDispatchedReviewRepairApproval(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	st := NewState()
+	a := st.RecordPendingApprovalForDecision(reviewRepairDecision(442, 564, "head"), now)
+	id := a.ID
+
+	if !st.ResolveDispatchedReviewRepairApproval(id, now, "dispatched") {
+		t.Fatal("resolve returned false for an active approval")
+	}
+	if st.Approvals[0].Status != ApprovalStatusSuperseded {
+		t.Fatalf("status = %q, want superseded", st.Approvals[0].Status)
+	}
+	// Idempotent: a second resolve is a no-op.
+	if st.ResolveDispatchedReviewRepairApproval(id, now, "again") {
+		t.Fatal("second resolve should return false (already terminal)")
+	}
+}

--- a/internal/state/review_repair_approval_test.go
+++ b/internal/state/review_repair_approval_test.go
@@ -157,3 +157,78 @@ func TestResolveDispatchedReviewRepairApproval(t *testing.T) {
 		t.Fatal("second resolve should return false (already terminal)")
 	}
 }
+
+// #874 regression: the orchestrator can dispatch a durable review-repair
+// approval while it is still Approved (before the supervisor executor moves it
+// to awaiting_dispatch). Resolving after dispatch must make an Approved record
+// terminal, not silently leave it active while reporting success.
+func TestResolveDispatchedReviewRepairApproval_FromApproved(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	st := NewState()
+	a := st.RecordPendingApprovalForDecision(reviewRepairDecision(442, 564, "head"), now)
+	id := a.ID
+	if _, err := st.ApproveApproval(id, now, "operator", "approve"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if st.Approvals[0].Status != ApprovalStatusApproved {
+		t.Fatalf("precondition: status = %q, want approved", st.Approvals[0].Status)
+	}
+
+	if !st.ResolveDispatchedReviewRepairApproval(id, now.Add(time.Minute), "dispatched") {
+		t.Fatal("resolve returned false for an approved (active) approval")
+	}
+	if st.Approvals[0].Status != ApprovalStatusSuperseded {
+		t.Fatalf("status = %q, want superseded", st.Approvals[0].Status)
+	}
+}
+
+// #874 regression: a changed head must supersede an already-approved (not yet
+// dispatched) review-repair approval, not just a pending one — otherwise the
+// stale-revision repair stays active and re-selectable.
+func TestSupersedeReviewRepairApprovalsForStaleHead_FromApproved(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	st := NewState()
+	a := st.RecordPendingApprovalForDecision(reviewRepairDecision(442, 564, "oldhead"), now)
+	if _, err := st.ApproveApproval(a.ID, now, "operator", "approve"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if st.Approvals[0].Status != ApprovalStatusApproved {
+		t.Fatalf("precondition: status = %q, want approved", st.Approvals[0].Status)
+	}
+
+	ids := st.SupersedeReviewRepairApprovalsForStaleHead(564, "newhead", now.Add(time.Minute), "head moved")
+	if len(ids) != 1 {
+		t.Fatalf("moved head superseded %v, want 1", ids)
+	}
+	if st.Approvals[0].Status != ApprovalStatusSuperseded {
+		t.Fatalf("status = %q, want superseded", st.Approvals[0].Status)
+	}
+}
+
+// #874 regression: a failed worker start must not burn a review-repair attempt.
+// ReleaseReviewRepairAttempt rolls back the claimed slot so the same (pr,head)
+// can be dispatched again on a later cycle.
+func TestReleaseReviewRepairAttempt(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	st := NewState()
+
+	// Budget of 1 attempt: claim it, then a failed start releases it.
+	if _, spawned := st.RecordReviewRepairAttempt(564, "head", 442, "", 1, now); !spawned {
+		t.Fatal("first claim should be granted")
+	}
+	// Budget is now spent — a second claim without release is refused.
+	if _, spawned := st.RecordReviewRepairAttempt(564, "head", 442, "", 1, now); spawned {
+		t.Fatal("second claim should be refused before release (budget spent)")
+	}
+
+	st.ReleaseReviewRepairAttempt(564, "head", now.Add(time.Minute))
+
+	track, ok := st.LookupReviewRepairTrack(564, "head")
+	if !ok || track.Attempts != 0 || track.Exhausted {
+		t.Fatalf("after release: track=%+v ok=%v, want attempts=0 not exhausted", track, ok)
+	}
+	// The freed slot is dispatchable again.
+	if _, spawned := st.RecordReviewRepairAttempt(564, "head", 442, "", 1, now.Add(2*time.Minute)); !spawned {
+		t.Fatal("claim after release should be granted again")
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1019,6 +1019,7 @@ const (
 	approvalActionCloseIssueBatch   = "close_issue_batch"
 	approvalActionSpawnWorker       = "spawn_worker"
 	approvalActionSpawnRepairWorker = "spawn_repair_worker"
+	approvalActionSpawnReviewRepair = "spawn_review_repair"
 )
 
 // Approval records a risky supervisor decision that needs explicit resolution.
@@ -1047,6 +1048,17 @@ type Approval struct {
 	// LessonProposalID links apply_lesson_proposal approvals to the durable
 	// proposed rule they gate. Rejection/apply transitions update that record.
 	LessonProposalID string `json:"lesson_proposal_id,omitempty"`
+
+	// ReviewRepair carries the scoped review-repair payload (head SHA,
+	// blocking findings, backend) for a spawn_review_repair approval (#874).
+	// Before #874 this payload lived only on the SupervisorDecision, so the
+	// orchestrator dispatcher resolved it from LatestSupervisorDecision(); a
+	// manually enqueued approval (or one whose decision aged out of the
+	// bounded decision ring) had no payload and could enter awaiting_dispatch
+	// with no dispatcher path. Persisting the payload on the durable approval
+	// lets the dispatcher converge on exactly one worker without a coincident
+	// latest supervisor decision. nil for every non-review-repair approval.
+	ReviewRepair *SupervisorReviewRepairPayload `json:"review_repair,omitempty"`
 }
 
 type ApprovalAudit struct {
@@ -2201,6 +2213,11 @@ func (s *State) RecordPendingApprovalForDecision(decision SupervisorDecision, no
 		TargetStateHash: freshTargetStateHash,
 		Repo:            decision.Repo,
 		Project:         decision.Project,
+		// #874: persist the review-repair payload on the durable approval so
+		// the orchestrator dispatcher can converge from the approval alone,
+		// without needing the coincident LatestSupervisorDecision to still be
+		// a spawn_review_repair carrying the payload.
+		ReviewRepair: cloneReviewRepairPayload(decision.ReviewRepair),
 	}
 	approval.PayloadHash = approval.ComputePayloadHash()
 	approval.Audit = append(approval.Audit, ApprovalAudit{
@@ -2236,9 +2253,75 @@ func (s *State) refreshPendingApproval(approval *Approval, decision SupervisorDe
 	if strings.TrimSpace(decision.Project) != "" {
 		approval.Project = decision.Project
 	}
+	// #874: refresh the durable review-repair payload from a re-minted
+	// decision that still carries one (a fresh supervisor cycle observed new
+	// findings on the same head). Never clobber a good payload with nil — a
+	// non-review-repair re-evaluation of the same target identity must not
+	// strip the proof the dispatcher needs.
+	if decision.ReviewRepair != nil {
+		approval.ReviewRepair = cloneReviewRepairPayload(decision.ReviewRepair)
+	}
 	approval.TargetStateHash = targetStateHash
 	approval.UpdatedAt = normalizedTime(now)
 	approval.PayloadHash = approval.ComputePayloadHash()
+}
+
+// EffectiveReviewRepairPayloadForPR returns a proven review-repair payload
+// (head SHA, blocking findings, backend) for the given PR, searched first on
+// still-effective approvals and then on the recent supervisor decisions
+// (#874). It is the "prove it or reject it" source for a manual
+// spawn_review_repair enqueue: the manual control cannot compute review
+// findings itself, so it reuses a payload the supervisor already observed on
+// this PR. Returns (nil, nil, false) when no such proof exists — the caller
+// must then reject the enqueue rather than mint an approval no dispatcher can
+// complete. The returned payload/target are deep copies safe to stamp onto a
+// fresh decision.
+func (s *State) EffectiveReviewRepairPayloadForPR(prNumber int) (*SupervisorReviewRepairPayload, *SupervisorTarget, bool) {
+	if s == nil || prNumber <= 0 {
+		return nil, nil, false
+	}
+	// Effective approvals win: they are durable across the bounded decision
+	// ring and already carry the payload since #874. Newest UpdatedAt first.
+	var bestApproval *Approval
+	for i := range s.Approvals {
+		a := &s.Approvals[i]
+		if a.Action != approvalActionSpawnReviewRepair || a.ReviewRepair == nil {
+			continue
+		}
+		switch a.Status {
+		case ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch:
+		default:
+			continue
+		}
+		if a.Target == nil || a.Target.PR != prNumber {
+			continue
+		}
+		if bestApproval == nil || a.UpdatedAt.After(bestApproval.UpdatedAt) {
+			bestApproval = a
+		}
+	}
+	if bestApproval != nil {
+		return cloneReviewRepairPayload(bestApproval.ReviewRepair), cloneSupervisorTarget(bestApproval.Target), true
+	}
+	// Fall back to the most recent supervisor decision that observed blocking
+	// findings on this PR.
+	var best *SupervisorDecision
+	for i := range s.SupervisorDecisions {
+		d := &s.SupervisorDecisions[i]
+		if d.RecommendedAction != approvalActionSpawnReviewRepair || d.ReviewRepair == nil {
+			continue
+		}
+		if d.Target == nil || d.Target.PR != prNumber {
+			continue
+		}
+		if best == nil || d.CreatedAt.After(best.CreatedAt) {
+			best = d
+		}
+	}
+	if best == nil {
+		return nil, nil, false
+	}
+	return cloneReviewRepairPayload(best.ReviewRepair), cloneSupervisorTarget(best.Target), true
 }
 
 // approvalIDInUse reports whether any approval already carries id. Used by the
@@ -2720,6 +2803,64 @@ func (s *State) StaleSpawnRepairWorkerApprovalsForResolvedIssue(issueNumber int,
 	return staled
 }
 
+// SupersedeReviewRepairApprovalsForStaleHead supersedes every still-active
+// spawn_review_repair approval for prNumber whose durable payload targets a
+// head SHA other than currentHead (#874 changed-head). Dispatching such an
+// approval would repair a revision that no longer exists on the PR, so the
+// approval is superseded instead — the next supervisor cycle re-evaluates the
+// current head and mints a fresh proof if findings remain. Returns the ids
+// superseded.
+func (s *State) SupersedeReviewRepairApprovalsForStaleHead(prNumber int, currentHead string, now time.Time, reason string) []string {
+	if s == nil || prNumber <= 0 {
+		return nil
+	}
+	current := strings.TrimSpace(currentHead)
+	var ids []string
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if approval.Action != approvalActionSpawnReviewRepair || approval.ReviewRepair == nil {
+			continue
+		}
+		if approval.Target == nil || approval.Target.PR != prNumber {
+			continue
+		}
+		if strings.TrimSpace(approval.ReviewRepair.HeadSHA) == current && current != "" {
+			continue
+		}
+		switch approval.Status {
+		case ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch:
+			s.markApprovalSuperseded(approval, now, reason)
+			ids = append(ids, approval.ID)
+		}
+	}
+	return ids
+}
+
+// ResolveDispatchedReviewRepairApproval supersedes the effective
+// spawn_review_repair approval with the given id once the orchestrator has
+// actually dispatched its worker (#874). This keeps the durable-approval
+// dispatch path from re-resolving (and re-reading the PR head) every cycle,
+// and leaves no active approval behind after a repair reaches a worker.
+// Returns true when an active approval was superseded.
+func (s *State) ResolveDispatchedReviewRepairApproval(id string, now time.Time, reason string) bool {
+	if s == nil || strings.TrimSpace(id) == "" {
+		return false
+	}
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if approval.ID != id || approval.Action != approvalActionSpawnReviewRepair {
+			continue
+		}
+		switch approval.Status {
+		case ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch:
+			s.markApprovalSuperseded(approval, now, reason)
+			return true
+		}
+		return false
+	}
+	return false
+}
+
 // ActiveSpawnRepairWorkerApprovalIssues returns the sorted, distinct set of
 // issue numbers that still carry an active (pending/approved/awaiting_dispatch)
 // spawn_repair_worker approval. The orchestrator's standing reconciler (#866)
@@ -3036,6 +3177,17 @@ func cloneSupervisorTarget(target *SupervisorTarget) *SupervisorTarget {
 	}
 	clone := *target
 	clone.Issues = append([]SupervisorIssueTarget(nil), target.Issues...)
+	return &clone
+}
+
+// cloneReviewRepairPayload deep-copies a review-repair payload so an
+// approval carries its own copy independent of the source decision (#874).
+func cloneReviewRepairPayload(payload *SupervisorReviewRepairPayload) *SupervisorReviewRepairPayload {
+	if payload == nil {
+		return nil
+	}
+	clone := *payload
+	clone.Findings = append([]SupervisorReviewFinding(nil), payload.Findings...)
 	return &clone
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1239,6 +1239,36 @@ func (s *State) RecordReviewRepairAttempt(prNumber int, headSHA string, issueNum
 	return track, true
 }
 
+// ReleaseReviewRepairAttempt rolls back a single attempt previously taken by
+// RecordReviewRepairAttempt for (pr,head_sha) — used when the dispatch that
+// claimed the slot failed to actually start a worker (#874). A failed start
+// must not burn an attempt from the bounded repair budget, or a run of start
+// failures would exhaust the budget and permanently reject an approved repair
+// that never reached a worker. Decrements the counter (never below zero) and
+// clears an Exhausted flag whose timestamp coincides with this rolled-back
+// attempt. No-op when there is no track or no attempt to release.
+func (s *State) ReleaseReviewRepairAttempt(prNumber int, headSHA string, now time.Time) {
+	if s == nil || prNumber <= 0 || s.ReviewRepairTracks == nil {
+		return
+	}
+	key := reviewRepairTrackKey(prNumber, headSHA)
+	track, ok := s.ReviewRepairTracks[key]
+	if !ok || track.Attempts <= 0 {
+		return
+	}
+	track.Attempts--
+	// A just-claimed attempt never sets Exhausted (RecordReviewRepairAttempt
+	// leaves it false on the budget-reaching attempt), but stay defensive: if
+	// the released attempt was the one that tipped the pair into Exhausted,
+	// undo it so the freed slot is dispatchable again.
+	if track.Attempts == 0 {
+		track.Exhausted = false
+		track.ExhaustedAt = time.Time{}
+	}
+	track.LastDecisionAt = normalizedTime(now)
+	s.ReviewRepairTracks[key] = track
+}
+
 // MarkReviewRepairExhausted records that a (pr,head_sha) pair has run
 // out of repair attempts and the operator must take over. Idempotent —
 // calling twice does not multiply the timestamp.
@@ -2827,9 +2857,11 @@ func (s *State) SupersedeReviewRepairApprovalsForStaleHead(prNumber int, current
 		if strings.TrimSpace(approval.ReviewRepair.HeadSHA) == current && current != "" {
 			continue
 		}
-		switch approval.Status {
-		case ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch:
-			s.markApprovalSuperseded(approval, now, reason)
+		// Supersede from any active state, Approved included — a changed head
+		// makes an already-approved (but not yet dispatched) repair target a
+		// stale revision that must not reach a worker (#874).
+		if s.supersedeApprovalFrom(approval, now, reason,
+			ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch) {
 			ids = append(ids, approval.ID)
 		}
 	}
@@ -2851,12 +2883,12 @@ func (s *State) ResolveDispatchedReviewRepairApproval(id string, now time.Time, 
 		if approval.ID != id || approval.Action != approvalActionSpawnReviewRepair {
 			continue
 		}
-		switch approval.Status {
-		case ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch:
-			s.markApprovalSuperseded(approval, now, reason)
-			return true
-		}
-		return false
+		// The durable-approval dispatch path spawns from an Approved (or
+		// AwaitingDispatch) record, so the terminal transition must cover
+		// Approved too — otherwise the approval stays active and re-selectable
+		// while SQLite is told it is terminal (#874).
+		return s.supersedeApprovalFrom(approval, now, reason,
+			ApprovalStatusPending, ApprovalStatusApproved, ApprovalStatusAwaitingDispatch)
 	}
 	return false
 }
@@ -2949,8 +2981,32 @@ func (s *State) markApprovalSuperseded(approval *Approval, now time.Time, reason
 	// #515: AwaitingDispatch is "still in flight on a separate loop";
 	// reconcile must be allowed to supersede it once the side effect
 	// it's awaiting actually lands (e.g. spawn_worker -> worker started).
-	if approval.Status != ApprovalStatusPending && approval.Status != ApprovalStatusAwaitingDispatch {
-		return
+	// Approved is intentionally excluded here: an approved record is queued
+	// in the supervisor executor (ApprovalsAwaitingExecution), so a general
+	// reconciler must not yank it out from under the executor.
+	s.supersedeApprovalFrom(approval, now, reason, ApprovalStatusPending, ApprovalStatusAwaitingDispatch)
+}
+
+// supersedeApprovalFrom transitions approval → superseded when its current
+// status is one of allowedFrom, appending an audit entry, and reports whether
+// the transition happened. It is the shared core of markApprovalSuperseded; the
+// review-repair dispatch path (#874) also supersedes from Approved because the
+// orchestrator dispatches a durable review-repair approval directly — racing
+// the supervisor executor that would otherwise move it Approved →
+// AwaitingDispatch — so the just-dispatched (or stale-head) approval must become
+// terminal from whichever active state it is observed in. Returning true only on
+// a real transition keeps callers from reporting success (and mirroring a
+// terminal status to SQLite) while the record silently stays active.
+func (s *State) supersedeApprovalFrom(approval *Approval, now time.Time, reason string, allowedFrom ...ApprovalStatus) bool {
+	transition := false
+	for _, from := range allowedFrom {
+		if approval.Status == from {
+			transition = true
+			break
+		}
+	}
+	if !transition {
+		return false
 	}
 	approval.Status = ApprovalStatusSuperseded
 	approval.UpdatedAt = normalizedTime(now)
@@ -2961,6 +3017,7 @@ func (s *State) markApprovalSuperseded(approval *Approval, now time.Time, reason
 		PayloadHash:     approval.PayloadHash,
 		TargetStateHash: s.ApprovalTargetStateHash(approval.Target),
 	})
+	return true
 }
 
 func spawnWorkerApprovalMatchesSession(approval *Approval, slot string, sess *Session) bool {

--- a/internal/supervisor/restart_worker_test.go
+++ b/internal/supervisor/restart_worker_test.go
@@ -1,0 +1,28 @@
+package supervisor
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #874: after a restart tears down the worktree, the session's stale
+// worktree/PR pointers must be cleared so respawnDueRetries fresh-respawns
+// instead of choosing RespawnInPlace against a directory that no longer exists.
+func TestClearWorktreeAfterRestart(t *testing.T) {
+	sess := &state.Session{
+		IssueNumber: 42,
+		Status:      state.StatusDead,
+		Worktree:    "/wt/slot-1",
+		PRNumber:    867,
+	}
+	clearWorktreeAfterRestart(sess)
+	if sess.Worktree != "" {
+		t.Fatalf("Worktree = %q, want cleared", sess.Worktree)
+	}
+	if sess.PRNumber != 0 {
+		t.Fatalf("PRNumber = %d, want cleared", sess.PRNumber)
+	}
+	// Nil-safe.
+	clearWorktreeAfterRestart(nil)
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -4115,7 +4115,9 @@ func commandBinary(cmd, fallback string) string {
 //     clear NextRetryAt so the orchestrator does NOT respawn.
 //   - restart_worker: terminate the worker, mark StatusDead with
 //     NextRetryAt = now so respawnDueRetries picks it up on the next
-//     dispatcher cycle.
+//     dispatcher cycle. worker.Stop removed the worktree, so the stale
+//     worktree/PR pointers are cleared (#874) — otherwise respawnDueRetries
+//     would choose RespawnInPlace against a directory that no longer exists.
 func newWorkerController(cfg *config.Config) approver.WorkerControllerFuncs {
 	return approver.WorkerControllerFuncs{
 		Stop: func(slot string, sess *state.Session) error {
@@ -4136,9 +4138,27 @@ func newWorkerController(cfg *config.Config) approver.WorkerControllerFuncs {
 			sess.Status = state.StatusDead
 			sess.FinishedAt = &now
 			sess.NextRetryAt = &now
+			clearWorktreeAfterRestart(sess)
 			return nil
 		},
 	}
+}
+
+// clearWorktreeAfterRestart drops the worktree + PR pointers of a session that
+// worker.Stop just tore down for a restart (#874). worker.Stop removes the
+// worktree directory but does not touch the struct fields; leaving them set
+// makes respawnDueRetries take the RespawnInPlace branch (sess.PRNumber != 0 &&
+// sess.Worktree != "") against a directory that no longer exists. Clearing them
+// forces a fresh respawn — the only convergent choice once the directory is
+// gone. restart_worker never runs for an open-PR session (the executor refuses
+// it and the fleet UI disables it), so this cannot silently discard PR work; it
+// is the fresh-restart cleanup for the process-restart case.
+func clearWorktreeAfterRestart(sess *state.Session) {
+	if sess == nil {
+		return
+	}
+	sess.Worktree = ""
+	sess.PRNumber = 0
 }
 
 // executeApprovedApprovals runs any approvals currently in status=approved


### PR DESCRIPTION
Refs #874

Two operator repair controls could enqueue actions their dispatcher could never complete for a finished `pr_open` session. This makes every surfaced/enqueued PR repair control either persist enough payload to converge on exactly one worker, or reject before mutation with a precise reason.

## Changes

**`spawn_review_repair`**
- The review-repair payload (head SHA, blocking findings, backend) now persists on the durable `Approval`, not only on the bounded supervisor decision ring.
- The orchestrator dispatcher consumes the durable approval payload directly, so an approved review-repair converges without a coincident latest supervisor decision. A changed PR head supersedes the approval (never repairs a stale revision); a head-read error leaves it pending. The approval is superseded once its worker actually starts, so nothing lingers.
- A manual HTTP enqueue proves the payload from state (an effective approval or a recent decision) or is rejected `409` before any state mutation.

**`restart_worker`**
- The executor refuses restart for a session that owns an open PR (restart deletes the worktree and would strand the PR branch); the fleet API disables the affordance and names the supported in-place alternative. `stop_worker` is unaffected.
- The restart controllers clear the stale worktree/PR pointers after the worktree is torn down, so `respawnDueRetries` fresh-respawns instead of choosing `RespawnInPlace` against a directory that no longer exists.

No CI/review bypass, no automatic merge, no concurrency change.

## Testing
- `go test ./...` (all packages pass)
- `go build ./cmd/maestro/`
- `gofmt` clean; `go vet` clean on changed packages
- agent-lint self-test passes
- Added unit tests: durable payload persistence + Save/Load round-trip (daemon restart), payload-proof lookup, changed-head supersede, post-dispatch resolve, durable-approval dispatch vs `monitor_open_pr`, pending-approval gating, manual enqueue prove/reject, executor restart refusal on open PR (and stop still allowed), fleet affordance disable, and cleared-worktree fresh respawn.

## Still requires runtime verification
The live canary (one harmless Mission Control PR repair reaching a worker and leaving no active approval behind) is an operator/runtime check against the running fleet and is not exercised by this PR's unit tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes operator repair controls converge safely or reject before changing state. The main changes are:

- Persists review-repair payloads on durable approvals.
- Dispatches approved repairs after validating the current PR head.
- Resolves approvals after startup and restores attempts when startup fails.
- Validates manual repair targets before enqueueing them.
- Rejects destructive restarts for workers associated with open PRs.
- Clears stale worktree and PR state after supported restarts.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the updated approval, dispatch, or restart paths.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared review-repair-lifecycle-01-before.log and review-repair-lifecycle-02-after.log and confirmed they are the same-scope repeat captures of 15 named state, orchestrator, and server tests, and both exited with code 0.
- Observed runtime signals in the targeted logs, including stale-head approval supersession, head-read-error pending retention, and manual enqueue rejections for unproven and mismatched requests.
- Verified review-repair-full-suite.log shows every repository package passing with exit 0.
- Verified review-repair-maestro-build.log records a successful command build with exit 0.

<a href="https://app.greptile.com/trex/runs/14180997/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds durable repair payloads, proof lookup, attempt rollback, and terminal transitions for active approvals. |
| internal/orchestrator/orchestrator.go | Dispatches durable approvals, validates PR heads, rolls back failed claims, and consumes successfully dispatched approvals. |
| internal/server/actions.go | Requires proven repair payloads and rejects mismatched issue targets before recording an approval. |
| internal/approver/executor.go | Rejects restart requests for sessions associated with an open PR. |
| internal/supervisor/supervisor.go | Clears stale worktree and PR pointers after a supported restart. |
| cmd/maestro/main.go | Applies the same post-restart session cleanup in the CLI worker controller. |

<sub>Reviews (3): Last reviewed commit: ["fix: review-repair approvals become term..."](https://github.com/befeast/maestro/commit/4980eeef7c2bc9c68cf4486f81438777360bb417) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43696189)</sub>

<!-- /greptile_comment -->