### PR TITLE
fix: harden project genesis zero-write flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,16 +126,26 @@ per-project `maestro.yaml` + systemd/launchd unit) is gone; add projects with th
 curl -fsSL https://raw.githubusercontent.com/BeFeast/maestro/main/install.sh | sh
 maestro version   # verify installation
 
-# 2. Clone your target repo (if not already)
-gh repo clone owner/myrepo ~/src/myrepo
+# 2. Choose absolute execution-host paths and create the Management Home Area.
+REPO_PATH="$HOME/src/myrepo"
+WORKTREE_BASE="$HOME/.worktrees/myrepo"
+MANAGEMENT_HOME="$HOME/Obsidian Vault/Dev/Areas/myrepo"
+PROJECT_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+gh repo clone owner/myrepo "$REPO_PATH"   # omit when it is already cloned
+mkdir -p "$WORKTREE_BASE" "$MANAGEMENT_HOME"
 
 # 3. Write a portable project config (repo, local paths, and a stable project_id).
 #    Generate the UUID once and keep it: it is the durable identity apply confirms.
-cat > ~/myrepo.project.yaml <<'YAML'
+cat > "$HOME/myrepo.project.yaml" <<YAML
 repo: owner/myrepo
-local_path: ~/src/myrepo
-worktree_base: ~/.worktrees/myrepo
-project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301   # e.g. `uuidgen | tr A-Z a-z`
+local_path: ${REPO_PATH}
+worktree_base: ${WORKTREE_BASE}
+project_id: ${PROJECT_ID}
+management_home:
+  kind: obsidian
+  path: ${MANAGEMENT_HOME}
+  vault: Obsidian Vault
+  vault_path: Dev/Areas/myrepo
 max_parallel: 3
 issue_labels:
   - enhancement
@@ -143,45 +153,47 @@ model:
   default: claude
 YAML
 
-# 4. Preview the effect on the config store — strictly validated, zero writes.
+# 4. In a second terminal, start the one fleet daemon. Keep this process running;
+#    for a persistent Linux user service, see "Running as a Service" below.
+mkdir -p ~/.maestro
+maestro daemon --watch-store --store ~/.maestro/maestro.db \
+  --approvals-store sqlite --state-store sqlite
+
+# 5. Preview the effect on the config store — strictly validated, zero writes.
 #    Point --db at the same store the daemon unit reads (its --store path):
 maestro project plan  --file ~/myrepo.project.yaml --db ~/.maestro/maestro.db --json
 
-# 5. Apply the exact command in plan receipt `next[0]` — it pins identity,
+# 6. Apply the exact command in plan receipt `next[0]` — it pins identity,
 #    desired config fingerprint, and observed store baseline:
 maestro project apply --file ~/myrepo.project.yaml --db ~/.maestro/maestro.db \
-    --confirm 3f2504e0-4f89-41d3-9a0c-0305e82c3301 \
+    --confirm "$PROJECT_ID" \
     --fingerprint <sha256-from-plan> --baseline <baseline-from-plan> --json
 ```
 
 `plan` never writes; `apply` upserts exactly one row (a second identical apply is a
 reported no-op, and an identity conflict is a hard stop that never overwrites by
-name). The single `maestro daemon --watch-store` observes the new row within one
+name). The running `maestro daemon --watch-store` observes the new row within one
 poll interval and starts one flow — no restart, no `systemctl enable` per project.
 Removing a project stays a separate explicit operator action (`maestro config-store
 rm <name>`).
 
 ```bash
-# Check status
-maestro status
-
-# Watch the Mission Control dashboard (trusted-LAN default: write-enabled)
-#    Add --read-only=true (or set server.read_only: true in YAML) for installs
-#    exposed beyond a trusted LAN; #616 covers optional HTTP auth.
-maestro serve --port 8787
+# The daemon already serves the fleet Mission Control and API; do not start a
+# separate `maestro serve` process for the same fleet.
+curl -fsS http://127.0.0.1:8786/api/v1/fleet
+# Open http://127.0.0.1:8786/ in a browser.
 ```
 
 That's it. Maestro will now pick up issues matching your configured label, spawn AI agents in isolated worktrees, and auto-merge PRs when CI passes.
 
 To manually spawn a worker for a specific issue:
 ```bash
-maestro spawn --issue 42
+maestro spawn --config-store ~/.maestro/maestro.db \
+  --config-store-project owner-myrepo --issue 42
 ```
 
-To watch Maestro from a browser, use the Mission Control dashboard:
-```bash
-maestro serve --config ./maestro.yaml --host 127.0.0.1 --port 8787
-```
+Use the Mission Control already served by the daemon at
+`http://127.0.0.1:8786/`; do not start a second `maestro serve` process.
 
 The dashboard now boots **write-enabled by default** (trusted-LAN posture, #477). The cautious approval gate still guards the four mutating verbs — `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config` — so even a writable HTTP caller cannot bypass operator approval. For installs exposed beyond a trusted LAN, run with `--read-only=true` (or set `server.read_only: true` in YAML) and configure the optional HTTP auth layer (#616, off by default).
 
@@ -193,16 +205,13 @@ To flip fleet-wide or per-project cost/LLM knobs (`supervisor.enabled`, backends
 
 Maestro's dashboard auth is opt-in and disabled by default. The right posture depends on where the port is reachable from:
 
-- **Trusted LAN (default).** When the dashboard is bound to `127.0.0.1` or a network only operators can reach, leave `server.auth` empty. The cautious approval gate still protects `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config` — flipping `--read-only=false` on a trusted LAN does not expose the four destructive verbs.
-- **Exposed / shared network.** When the dashboard is reachable from anywhere outside the trusted LAN — `--host 0.0.0.0`, behind a reverse proxy, on a multi-tenant host — set `server.auth.token_env`. With auth enabled, **every** endpoint (read GETs, write POSTs, and the SPA HTML) rejects unauthenticated requests with `401`; the cautious approval gate still fires for authenticated callers as defense in depth.
+- **Trusted LAN (default).** When the daemon is bound to `127.0.0.1` or a network only operators can reach, leave `server.auth` empty. The cautious approval gate still protects `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config`.
+- **Exposed / shared network.** When the daemon uses `--host 0.0.0.0`, sits behind a reverse proxy, or runs on a multi-tenant host, set `server.auth.token_env` in a project row (the fleet derives one shared auth policy) or start the daemon with `--read-only=true`. With auth enabled, **every** endpoint (read GETs, write POSTs, and the SPA HTML) rejects unauthenticated requests with `401`; the cautious approval gate still fires for authenticated callers as defense in depth.
 
 The token is loaded at runtime from an environment variable populated by your secret manager (Infisical, 1Password CLI, etc.) — never hardcoded in YAML:
 
 ```yaml
 server:
-  host: 0.0.0.0
-  port: 8788
-  read_only: false
   auth:
     token_env: MAESTRO_DASHBOARD_TOKEN   # env var name; populate from your secret manager
     actor_name: dashboard-operator       # optional; audit actor recorded for authed requests
@@ -220,14 +229,22 @@ To watch workers live in a tmux dashboard:
 maestro watch
 ```
 
-## Configuration
+## Project Row Configuration
 
-Create `~/.maestro/config.yaml` or `./maestro.yaml`:
+The following is a configuration reference. For a new project, keep the
+portable YAML outside the code repo and register it through `project plan` /
+`project apply`; the running daemon reads the resulting row, not this file.
 
 ```yaml
 repo: OWNER/REPO
 local_path: /path/to/local/clone
 worktree_base: /path/to/worktrees/repo
+project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
+management_home:
+  kind: obsidian
+  path: /absolute/path/to/Obsidian Vault/Dev/Areas/project
+  vault: Obsidian Vault
+  vault_path: Dev/Areas/project
 max_parallel: 5
 max_runtime_minutes: 120           # hard timeout per worker (default: 120)
 worker_silent_timeout_minutes: 0   # kill worker if tmux output is unchanged for N minutes (0 = disabled)
@@ -246,9 +263,8 @@ session_prefix: prj                # worker session name prefix (default: first 
 state_dir: ~/.maestro/<project>    # state/log directory (default: ~/.maestro/<repo-hash>)
 claude_cmd: claude                 # deprecated: use model.backends.claude.cmd
 server:
-  host: 127.0.0.1                  # bind address for `maestro serve`
-  port: 8787                       # 0 = disabled for `maestro run`
-  read_only: false                 # default: trusted-LAN, writes enabled; flip true for exposed installs (#477)
+  auth:
+    token_env: MAESTRO_DASHBOARD_TOKEN  # optional shared fleet auth; secret value stays in the environment
 issue_labels:                      # preferred label filter (OR semantics)
   - enhancement
 exclude_labels:
@@ -526,39 +542,49 @@ cd /worktree/path && codex exec --dangerously-bypass-approvals-and-sandbox -C /w
 cd /worktree/path && cline -y "<assembled prompt>"
 ```
 
-## Cron Mode
+## Legacy Cron Mode
 
-For automatic operation, run on a cron schedule:
-
-```bash
-# ~/.config/cron/maestro.cron
-*/10 * * * * /usr/local/bin/maestro run --config ~/.maestro/maestro-<project>.yaml --once >> ~/.maestro/maestro-<project>.log 2>&1
-```
-
-Or run as a daemon:
-```bash
-maestro run --interval 10m
-```
+Older installations may still contain `maestro run --once` cron jobs. Do not
+create one for a new project: migrate the YAML through
+`scripts/migrate-to-daemon.sh --dry-run`, then let the single
+`maestro daemon --watch-store` process schedule all project flows.
 
 ## Multi-Project Setup
 
-To run maestro for multiple projects simultaneously, use `session_prefix` and `state_dir` to keep workers and state isolated:
+Register each project as one row in the unified config store. Each portable
+project YAML may still set a distinct `session_prefix` and `state_dir`; apply it
+through `maestro project plan` / `maestro project apply` instead of starting a
+process per YAML:
 
 ```yaml
 # ~/.maestro/maestro-panoptikon.yaml
 repo: BeFeast/panoptikon
+project_id: 11111111-2222-4333-8444-555555555555
+management_home:
+  kind: obsidian
+  path: /srv/example-vault/Dev/Areas/panoptikon
+  vault: Example Vault
+  vault_path: Dev/Areas/panoptikon
 session_prefix: pan           # workers: pan-1, pan-2, ...
 state_dir: ~/.maestro/pan
-worktree_base: ~/.worktrees/panoptikon
+local_path: /srv/example-src/panoptikon
+worktree_base: /srv/example-worktrees/panoptikon
 max_parallel: 5
 ```
 
 ```yaml
 # ~/.maestro/maestro-myapp.yaml
 repo: BeFeast/myapp
+project_id: 66666666-7777-4888-8999-aaaaaaaaaaaa
+management_home:
+  kind: obsidian
+  path: /srv/example-vault/Dev/Areas/myapp
+  vault: Example Vault
+  vault_path: Dev/Areas/myapp
 session_prefix: app           # workers: app-1, app-2, ...
 state_dir: ~/.maestro/app
-worktree_base: ~/.worktrees/myapp
+local_path: /srv/example-src/myapp
+worktree_base: /srv/example-worktrees/myapp
 max_parallel: 3
 ```
 
@@ -610,6 +636,12 @@ scripts/migrate-to-daemon.sh            # prompts before changing a running host
 scripts/migrate-to-daemon.sh --dry-run  # show the actions without applying them
 ```
 
+On upgrade hosts, a compatibility guard detects project rows left in the old
+`~/.maestro/config.db`: default CLI commands stay on that legacy store with a
+warning, and the shipped service refuses to present an empty canonical fleet.
+Run the dry-run/cutover above (or the explicit export/migrate commands printed by
+the error) before switching to `~/.maestro/maestro.db`.
+
 The cutover is non-concurrent per project (it stops the legacy units before
 starting the daemon, so no project is ever driven by both). **Rollback** is
 supported because the legacy unit files stay on disk:
@@ -638,8 +670,8 @@ The fleet dashboard exposes the same as authenticated, audited endpoints —
 `DELETE /api/v1/fleet/projects` (body `{"name": "..."}`) — so you can add a
 project from the UI. On `SIGTERM` (`systemctl --user stop`) the daemon drains
 gracefully in-process: it stops claiming new issues and waits for in-flight
-workers to finish before exiting (bounded by `--drain-timeout`, default 25m,
-inside the unit's `TimeoutStopSec=30min`).
+workers to finish before exiting (bounded by `--drain-timeout`, default 5m,
+inside the unit's `TimeoutStopSec=6min`).
 
 ## Mission Control bundle
 

--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -21,8 +23,9 @@ import (
 
 // daemonCmd runs every project in the config store as one long-lived process:
 // an orchestrator + supervisor loop per project flow, plus a single
-// FleetServer aggregating them all (#756, epic #754). It is strictly opt-in —
-// the legacy maestro@<project> units and `maestro serve` are unaffected.
+// FleetServer aggregating them all (#756, epic #754). Legacy per-project units
+// and a separate `maestro serve` process are migration sources, not peers to a
+// running daemon.
 func daemonCmd(args []string) {
 	fs := flag.NewFlagSet("daemon", flag.ExitOnError)
 	storePath := fs.String("store", defaultConfigStorePath(), "Path to SQLite config store")
@@ -44,6 +47,9 @@ func daemonCmd(args []string) {
 	emergencyDB := fs.String("emergency-db", emergencystore.DefaultDBPath(), "Shared SQLite db path the fleet-wide EMERGENCY STOP switch lives in (#840)")
 	drainTimeout := fs.Duration("drain-timeout", daemon.DefaultDrainTimeout, "Max time the SIGTERM in-process drain waits for in-flight workers to finish (#761)")
 	fs.Parse(args)
+	if err := refuseUnmigratedCanonicalStore(*storePath); err != nil {
+		log.Fatalf("daemon: %v", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -117,8 +123,79 @@ func handleDaemonSignals(ctx context.Context, cancel context.CancelFunc, d *daem
 	cancel()
 }
 
-// defaultConfigStorePath mirrors the config-store default used elsewhere
-// (~/.maestro/config.db).
-func defaultConfigStorePath() string {
+var legacyStoreWarningOnce sync.Once
+
+func canonicalConfigStorePath() string {
+	return filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.db")
+}
+
+func legacyConfigStorePath() string {
 	return filepath.Join(os.Getenv("HOME"), ".maestro", "config.db")
+}
+
+// defaultConfigStorePath is the one unified fleet database used by new
+// installations. An upgrade host whose legacy config.db still contains project
+// rows while maestro.db contains none stays on the legacy path with an explicit
+// migration warning instead of silently presenting an empty fleet.
+func defaultConfigStorePath() string {
+	canonical := canonicalConfigStorePath()
+	legacy := legacyConfigStorePath()
+	needsMigration, err := legacyStoreNeedsMigration(canonical, legacy)
+	if err != nil {
+		legacyStoreWarningOnce.Do(func() {
+			fmt.Fprintf(os.Stderr, "warning: could not inspect legacy Maestro config-store compatibility: %v\n", err)
+		})
+		return canonical
+	}
+	if needsMigration {
+		legacyStoreWarningOnce.Do(func() {
+			fmt.Fprintf(os.Stderr, "warning: legacy project store %s still contains projects while %s does not; defaulting to the legacy store. Export it and migrate into maestro.db before switching the daemon service.\n", legacy, canonical)
+		})
+		return legacy
+	}
+	return canonical
+}
+
+func legacyStoreNeedsMigration(canonical, legacy string) (bool, error) {
+	legacyCount, err := existingProjectCountIfPresent(legacy)
+	if err != nil {
+		return false, fmt.Errorf("inspect %s: %w", legacy, err)
+	}
+	if legacyCount == 0 {
+		return false, nil
+	}
+	canonicalCount, err := existingProjectCountIfPresent(canonical)
+	if err != nil {
+		return false, fmt.Errorf("inspect %s: %w", canonical, err)
+	}
+	return canonicalCount == 0, nil
+}
+
+func existingProjectCountIfPresent(path string) (int, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return 0, nil
+	} else if err != nil {
+		return 0, err
+	}
+	return configstore.ExistingProjectCount(path)
+}
+
+// refuseUnmigratedCanonicalStore protects the shipped service, whose explicit
+// --store path bypasses the compatibility default above. It must not come up as
+// an empty fleet while an older config.db still owns the project rows.
+func refuseUnmigratedCanonicalStore(storePath string) error {
+	canonical := canonicalConfigStorePath()
+	if !sameStorePath(storePath, canonical) {
+		return nil
+	}
+	legacy := legacyConfigStorePath()
+	needsMigration, err := legacyStoreNeedsMigration(canonical, legacy)
+	if err != nil {
+		return err
+	}
+	if !needsMigration {
+		return nil
+	}
+	backupDir := filepath.Join(os.Getenv("HOME"), ".maestro", "config-migration")
+	return fmt.Errorf("legacy project store %s contains projects but canonical store %s does not; refusing an empty-fleet start. Migrate explicitly: maestro config-store export --db %s --dir %s && maestro config-store migrate --db %s --dir %s", legacy, canonical, legacy, backupDir, canonical, backupDir)
 }

--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -143,8 +143,11 @@ func defaultConfigStorePath() string {
 	needsMigration, err := legacyStoreNeedsMigration(canonical, legacy)
 	if err != nil {
 		legacyStoreWarningOnce.Do(func() {
-			fmt.Fprintf(os.Stderr, "warning: could not inspect legacy Maestro config-store compatibility: %v\n", err)
+			fmt.Fprintf(os.Stderr, "warning: could not inspect legacy Maestro config-store compatibility: %v; keeping the legacy path fail-closed so default commands cannot split the fleet\n", err)
 		})
+		if _, statErr := os.Stat(legacy); statErr == nil {
+			return legacy
+		}
 		return canonical
 	}
 	if needsMigration {

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -559,7 +559,7 @@ func configStoreCmd(args []string) {
 		configStoreEdit(args[1:])
 	case "migrate":
 		fs := flag.NewFlagSet("config-store migrate", flag.ExitOnError)
-		dbPath := fs.String("db", filepath.Join(os.Getenv("HOME"), ".maestro", "config.db"), "SQLite config store path")
+		dbPath := fs.String("db", defaultConfigStorePath(), "SQLite config store path")
 		dir := fs.String("dir", filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.d"), "Directory containing project YAML files")
 		fs.Parse(args[1:])
 		store, err := configstore.Open(*dbPath)
@@ -573,7 +573,7 @@ func configStoreCmd(args []string) {
 		fmt.Printf("Migrated YAML configs from %s into SQLite store %s.\n", *dir, *dbPath)
 	case "export":
 		fs := flag.NewFlagSet("config-store export", flag.ExitOnError)
-		dbPath := fs.String("db", filepath.Join(os.Getenv("HOME"), ".maestro", "config.db"), "SQLite config store path")
+		dbPath := fs.String("db", defaultConfigStorePath(), "SQLite config store path")
 		dir := fs.String("dir", filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.d.export"), "Directory to write portable YAML files")
 		fs.Parse(args[1:])
 		store, err := configstore.Open(*dbPath)
@@ -591,11 +591,11 @@ func configStoreCmd(args []string) {
 	}
 }
 
-// configStoreDBFlag registers the shared --db flag (default ~/.maestro/config.db)
+// configStoreDBFlag registers the shared --db flag (default ~/.maestro/maestro.db)
 // used by the per-project CRUD subcommands so they target the same store the
 // daemon reads.
 func configStoreDBFlag(fs *flag.FlagSet) *string {
-	return fs.String("db", filepath.Join(os.Getenv("HOME"), ".maestro", "config.db"), "SQLite config store path")
+	return fs.String("db", defaultConfigStorePath(), "SQLite config store path")
 }
 
 // configStoreAdd implements `config-store add --file <yaml> [--name <name>]`:

--- a/cmd/maestro/project.go
+++ b/cmd/maestro/project.go
@@ -439,6 +439,8 @@ func genesisReconcileFor(command, effect, conflict, watchStore string) genesisRe
 		r.Note = appendNote(r.Note, "a maestro daemon is running WITHOUT --watch-store on this host; it will not hot-reconcile the row — restart it with --watch-store or reconcile manually")
 	case watchStoreDifferentStore:
 		r.Note = appendNote(r.Note, "a maestro daemon with --watch-store is running on this host, but it watches a different --store path; it will not hot-reconcile this row")
+	case watchStoreImplicitStore:
+		r.Note = appendNote(r.Note, "a maestro daemon with --watch-store is running without an explicit --store; its startup-time default cannot be reconstructed safely after store migration — verify the daemon store or restart it with an explicit --store path")
 	case watchStoreNotObserved:
 		r.Note = appendNote(r.Note, "no running maestro daemon was observed from this host; confirm the fleet daemon runs with --watch-store so the row is hot-reconciled")
 	default: // unknown
@@ -529,6 +531,7 @@ const (
 	watchStoreObserved       = "observed"
 	watchStoreRunningWithout = "running-without-watch-store"
 	watchStoreDifferentStore = "running-with-different-store"
+	watchStoreImplicitStore  = "running-with-implicit-store"
 	watchStoreNotObserved    = "not-observed"
 	watchStoreUnknown        = "unknown"
 )
@@ -550,6 +553,7 @@ func probeDaemonWatchStore(expectedStore string) string {
 func classifyDaemonWatchStore(procs [][]string, expectedStore string) string {
 	daemonFound := false
 	watchStoreFound := false
+	implicitStoreFound := false
 	for _, argv := range procs {
 		if !looksLikeMaestroDaemon(argv) {
 			continue
@@ -557,10 +561,18 @@ func classifyDaemonWatchStore(procs [][]string, expectedStore string) string {
 		daemonFound = true
 		if argvHasWatchStore(argv) {
 			watchStoreFound = true
-			if sameStorePath(daemonStorePath(argv), expectedStore) {
+			storePath, explicit := daemonStorePath(argv)
+			if !explicit {
+				implicitStoreFound = true
+				continue
+			}
+			if sameStorePath(storePath, expectedStore) {
 				return watchStoreObserved
 			}
 		}
+	}
+	if implicitStoreFound {
+		return watchStoreImplicitStore
 	}
 	if watchStoreFound {
 		return watchStoreDifferentStore
@@ -571,16 +583,16 @@ func classifyDaemonWatchStore(procs [][]string, expectedStore string) string {
 	return watchStoreNotObserved
 }
 
-func daemonStorePath(argv []string) string {
+func daemonStorePath(argv []string) (string, bool) {
 	for i, arg := range argv {
 		if (arg == "--store" || arg == "-store") && i+1 < len(argv) {
-			return argv[i+1]
+			return argv[i+1], true
 		}
 		if strings.HasPrefix(arg, "--store=") || strings.HasPrefix(arg, "-store=") {
-			return strings.SplitN(arg, "=", 2)[1]
+			return strings.SplitN(arg, "=", 2)[1], true
 		}
 	}
-	return defaultConfigStorePath()
+	return "", false
 }
 
 func sameStorePath(got, want string) bool {

--- a/cmd/maestro/project.go
+++ b/cmd/maestro/project.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/befeast/maestro/internal/configstore"
@@ -99,11 +102,21 @@ func projectCmd(args []string) {
 // effect against the store, and prints a receipt. Exit is non-zero on a
 // validation failure or an identity conflict so an adapter can gate on it.
 func projectPlanCmd(args []string) {
-	fs := flag.NewFlagSet("project plan", flag.ExitOnError)
+	requestedJSON := argsRequestJSON(args)
+	fs := flag.NewFlagSet("project plan", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
 	file := fs.String("file", "", "Path to the portable project YAML")
 	dbPath := fs.String("db", defaultProjectStorePath(), "Path to the SQLite config store")
 	asJSON := fs.Bool("json", false, "Emit the receipt as JSON")
-	fs.Parse(args)
+	if err := fs.Parse(args); err != nil {
+		failGenesis("plan", requestedJSON, "invalid_flags", fmt.Sprintf("project plan: invalid flags: %v", err))
+	}
+	if fs.NArg() != 0 {
+		failGenesis("plan", requestedJSON, "invalid_flags", fmt.Sprintf("project plan: unexpected arguments: %s", strings.Join(fs.Args(), " ")))
+	}
+	if strings.TrimSpace(*dbPath) == "" {
+		failGenesis("plan", *asJSON, "invalid_input", "project plan: --db must not be empty")
+	}
 
 	prepared := prepareGenesisFile(*file, "project plan", *asJSON)
 	if err := validateGenesisRuntime(prepared); err != nil {
@@ -127,14 +140,24 @@ func projectPlanCmd(args []string) {
 // exactly one row idempotently after the confirm/fingerprint gates. Exit is
 // non-zero on any refusal (missing/wrong confirm, stale fingerprint, conflict).
 func projectApplyCmd(args []string) {
-	fs := flag.NewFlagSet("project apply", flag.ExitOnError)
+	requestedJSON := argsRequestJSON(args)
+	fs := flag.NewFlagSet("project apply", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
 	file := fs.String("file", "", "Path to the portable project YAML")
 	dbPath := fs.String("db", defaultProjectStorePath(), "Path to the SQLite config store")
 	confirm := fs.String("confirm", "", "Exact project_id to confirm the write (required)")
 	fingerprint := fs.String("fingerprint", "", "Exact plan-time config fingerprint (required)")
 	baseline := fs.String("baseline", "", "Exact plan-time baseline_fingerprint (required; `absent` for create)")
 	asJSON := fs.Bool("json", false, "Emit the receipt as JSON")
-	fs.Parse(args)
+	if err := fs.Parse(args); err != nil {
+		failGenesis("apply", requestedJSON, "invalid_flags", fmt.Sprintf("project apply: invalid flags: %v", err))
+	}
+	if fs.NArg() != 0 {
+		failGenesis("apply", requestedJSON, "invalid_flags", fmt.Sprintf("project apply: unexpected arguments: %s", strings.Join(fs.Args(), " ")))
+	}
+	if strings.TrimSpace(*dbPath) == "" {
+		failGenesis("apply", *asJSON, "invalid_input", "project apply: --db must not be empty")
+	}
 
 	prepared := prepareGenesisFile(*file, "project apply", *asJSON)
 	if err := validateGenesisRuntime(prepared); err != nil {
@@ -165,6 +188,23 @@ func projectApplyCmd(args []string) {
 	}
 	receipt := buildGenesisReceipt("apply", *dbPath, *file, prepared, report)
 	emitGenesisReceipt(receipt, *asJSON)
+}
+
+// argsRequestJSON preserves the machine-readable error contract even when flag
+// parsing itself fails before the FlagSet can populate its --json variable.
+func argsRequestJSON(args []string) bool {
+	for _, arg := range args {
+		if arg == "--json" || arg == "-json" {
+			return true
+		}
+		for _, prefix := range []string{"--json=", "-json="} {
+			if strings.HasPrefix(arg, prefix) {
+				value, err := strconv.ParseBool(strings.TrimPrefix(arg, prefix))
+				return err != nil || value
+			}
+		}
+	}
+	return false
 }
 
 func validateApplyApproval(p *configstore.PreparedProject, confirm, fingerprint, baseline string) error {
@@ -235,20 +275,46 @@ func validateGenesisRuntime(p *configstore.PreparedProject) error {
 	default:
 		return fmt.Errorf("inspect worktree_base %s: %w", p.WorktreeBase, err)
 	}
+	homeInfo, err := os.Stat(p.ManagementHome.Path)
+	if err != nil {
+		return fmt.Errorf("management_home.path %s is unavailable: %w", p.ManagementHome.Path, err)
+	}
+	if !homeInfo.IsDir() {
+		return fmt.Errorf("management_home.path %s is not a directory", p.ManagementHome.Path)
+	}
 	return nil
 }
 
 func remoteMatchesRepo(remote, repo string) bool {
-	r := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(remote)), ".git")
-	want := strings.ToLower(strings.Trim(strings.TrimSpace(repo), "/"))
-	return want != "" && (strings.HasSuffix(r, "/"+want) || strings.HasSuffix(r, ":"+want))
+	r := strings.TrimSpace(remote)
+	want := strings.ToLower(strings.TrimSuffix(strings.Trim(strings.TrimSpace(repo), "/"), ".git"))
+	lowerRemote := strings.ToLower(r)
+	if strings.HasPrefix(lowerRemote, "git@github.com:") {
+		got := strings.TrimSuffix(strings.TrimPrefix(lowerRemote, "git@github.com:"), ".git")
+		return got == want
+	}
+	u, err := url.Parse(r)
+	if err != nil || !strings.EqualFold(u.Hostname(), "github.com") {
+		return false
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https", "http", "ssh", "git":
+	default:
+		return false
+	}
+	got := strings.TrimSuffix(strings.ToLower(strings.Trim(u.Path, "/")), ".git")
+	return got == want
 }
 
 // planReport previews prepared against the store at dbPath without any write. A
 // store file that does not exist yet is treated as empty (effect create) WITHOUT
 // opening it, so `plan` never creates a schema-only DB — it changes no files.
 func planReport(dbPath string, prepared *configstore.PreparedProject, asJSON bool) *configstore.GenesisReport {
-	if !storeFileExists(dbPath) {
+	exists, err := inspectStoreFile(dbPath)
+	if err != nil {
+		failGenesis("plan", asJSON, "store_preflight_failed", fmt.Sprintf("project plan: inspect config store %s: %v", dbPath, err))
+	}
+	if !exists {
 		return configstore.PlanEmpty(prepared)
 	}
 	store, err := configstore.OpenReadOnly(dbPath)
@@ -266,8 +332,40 @@ func planReport(dbPath string, prepared *configstore.PreparedProject, asJSON boo
 // storeFileExists reports whether the config store path already exists on disk.
 // A missing store is planned as empty rather than created.
 func storeFileExists(path string) bool {
+	exists, _ := inspectStoreFile(path)
+	return exists
+}
+
+func inspectStoreFile(path string) (bool, error) {
 	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
+	if os.IsNotExist(err) {
+		if err := inspectStoreCreateParent(path); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.Mode().IsRegular() {
+		return false, fmt.Errorf("path exists but is not a regular file")
+	}
+	return true, nil
+}
+
+func inspectStoreCreateParent(path string) error {
+	parent := filepath.Dir(path)
+	info, err := os.Stat(parent)
+	if err != nil {
+		return fmt.Errorf("store parent %s is unavailable: %w", parent, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("store parent %s is not a directory", parent)
+	}
+	if info.Mode().Perm()&0o222 == 0 {
+		return fmt.Errorf("store parent %s is not writable", parent)
+	}
+	return nil
 }
 
 // buildGenesisReceipt combines the library report with the CLI-only fields (store
@@ -368,7 +466,7 @@ func genesisNextCommands(command, storePath, file, projectID, fingerprint, basel
 			}
 		}
 		return []string{
-			fmt.Sprintf("maestro project apply --file %s --db %s --confirm %s --fingerprint %s --baseline %s --json", file, storePath, projectID, fingerprint, baseline),
+			fmt.Sprintf("maestro project apply --file %s --db %s --confirm %s --fingerprint %s --baseline %s --json", shellQuote(file), shellQuote(storePath), shellQuote(projectID), shellQuote(fingerprint), shellQuote(baseline)),
 		}
 	case "apply":
 		if effect == configstore.EffectConflict {
@@ -379,10 +477,19 @@ func genesisNextCommands(command, storePath, file, projectID, fingerprint, basel
 		return []string{
 			// Re-running plan is the scriptable confirmation the row landed: it
 			// must now report effect "no-op".
-			fmt.Sprintf("maestro project plan --file %s --db %s --json   # expect effect \"no-op\": the row is stored", file, storePath),
+			fmt.Sprintf("maestro project plan --file %s --db %s --json   # expect effect \"no-op\": the row is stored", shellQuote(file), shellQuote(storePath)),
 		}
 	}
 	return nil
+}
+
+func shellQuote(s string) string {
+	if s != "" && strings.IndexFunc(s, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || strings.ContainsRune("_@%+=:,./-", r))
+	}) == -1 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
 // emitGenesisReceipt prints the receipt as JSON (stable, adapter-facing) or as a
@@ -473,7 +580,7 @@ func daemonStorePath(argv []string) string {
 			return strings.SplitN(arg, "=", 2)[1]
 		}
 	}
-	return ""
+	return defaultConfigStorePath()
 }
 
 func sameStorePath(got, want string) bool {
@@ -486,7 +593,7 @@ func sameStorePath(got, want string) bool {
 }
 
 func defaultProjectStorePath() string {
-	return filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.db")
+	return defaultConfigStorePath()
 }
 
 // looksLikeMaestroDaemon reports whether argv is a `maestro daemon ...`

--- a/cmd/maestro/project_test.go
+++ b/cmd/maestro/project_test.go
@@ -146,11 +146,11 @@ func TestClassifyDaemonWatchStoreRequiresMatchingStore(t *testing.T) {
 	}
 }
 
-func TestClassifyDaemonWatchStoreUsesDaemonDefaultStore(t *testing.T) {
+func TestClassifyDaemonWatchStoreDoesNotGuessImplicitStore(t *testing.T) {
 	t.Setenv("HOME", "/srv/example-home")
 	procs := [][]string{{"/usr/local/bin/maestro", "daemon", "--watch-store"}}
-	if got := classifyDaemonWatchStore(procs, "/srv/example-home/.maestro/maestro.db"); got != watchStoreObserved {
-		t.Fatalf("classify default-store daemon = %q, want observed", got)
+	if got := classifyDaemonWatchStore(procs, "/srv/example-home/.maestro/maestro.db"); got != watchStoreImplicitStore {
+		t.Fatalf("classify implicit-store daemon = %q, want implicit-store", got)
 	}
 }
 
@@ -311,6 +311,10 @@ func TestGenesisReconcileForFoldsWatchStore(t *testing.T) {
 	r = genesisReconcileFor("apply", configstore.EffectCreate, "", watchStoreRunningWithout)
 	if !strings.Contains(r.Note, "WITHOUT --watch-store") {
 		t.Fatalf("running-without note = %q, want a --watch-store warning", r.Note)
+	}
+	r = genesisReconcileFor("apply", configstore.EffectCreate, "", watchStoreImplicitStore)
+	if !strings.Contains(r.Note, "startup-time default") || !strings.Contains(r.Note, "explicit --store") {
+		t.Fatalf("implicit-store note = %q, want migration-safe ambiguity guidance", r.Note)
 	}
 	// A conflict is a hard stop with no reconciliation.
 	r = genesisReconcileFor("plan", configstore.EffectConflict, "boom", watchStoreObserved)

--- a/cmd/maestro/project_test.go
+++ b/cmd/maestro/project_test.go
@@ -10,19 +10,75 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/configstore"
 )
 
 const projectTestYAML = `repo: BeFeast/demo
-local_path: ~/src/demo
-worktree_base: ~/.worktrees/demo
+local_path: /srv/example-src/demo
+worktree_base: /srv/example-worktrees/demo
 project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
 management_home:
   kind: obsidian
-  path: /srv/example-vault/Dev
+  path: /srv/example-vault/Dev/Areas/demo
   vault: Example Vault
   vault_path: Dev/Areas/demo
 `
+
+func TestUnifiedDefaultStorePath(t *testing.T) {
+	t.Setenv("HOME", "/srv/example-home")
+	want := "/srv/example-home/.maestro/maestro.db"
+	if got := defaultConfigStorePath(); got != want {
+		t.Fatalf("defaultConfigStorePath() = %q, want %q", got, want)
+	}
+	if got := defaultProjectStorePath(); got != want {
+		t.Fatalf("defaultProjectStorePath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultStoreProtectsLegacyProjectsUntilMigration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.Mkdir(filepath.Join(home, ".maestro"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := legacyConfigStorePath()
+	legacyStore, err := configstore.Open(legacy)
+	if err != nil {
+		t.Fatalf("open legacy store: %v", err)
+	}
+	if err := legacyStore.UpsertProject(context.Background(), "owner-demo", "repo: owner/demo\n"); err != nil {
+		t.Fatalf("seed legacy store: %v", err)
+	}
+	if err := legacyStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := defaultConfigStorePath(); got != legacy {
+		t.Fatalf("default with unmigrated projects = %q, want legacy %q", got, legacy)
+	}
+	canonical := canonicalConfigStorePath()
+	if err := refuseUnmigratedCanonicalStore(canonical); err == nil || !strings.Contains(err.Error(), "refusing an empty-fleet start") {
+		t.Fatalf("canonical service guard err = %v", err)
+	}
+
+	canonicalStore, err := configstore.Open(canonical)
+	if err != nil {
+		t.Fatalf("open canonical store: %v", err)
+	}
+	if err := canonicalStore.UpsertProject(context.Background(), "owner-demo", "repo: owner/demo\n"); err != nil {
+		t.Fatalf("seed canonical store: %v", err)
+	}
+	if err := canonicalStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := defaultConfigStorePath(); got != canonical {
+		t.Fatalf("default after migration = %q, want canonical %q", got, canonical)
+	}
+	if err := refuseUnmigratedCanonicalStore(canonical); err != nil {
+		t.Fatalf("canonical guard after migration: %v", err)
+	}
+}
 
 func TestClassifyDaemonWatchStore(t *testing.T) {
 	cases := []struct {
@@ -72,6 +128,45 @@ func TestClassifyDaemonWatchStoreRequiresMatchingStore(t *testing.T) {
 	}
 }
 
+func TestClassifyDaemonWatchStoreUsesDaemonDefaultStore(t *testing.T) {
+	t.Setenv("HOME", "/srv/example-home")
+	procs := [][]string{{"/usr/local/bin/maestro", "daemon", "--watch-store"}}
+	if got := classifyDaemonWatchStore(procs, "/srv/example-home/.maestro/maestro.db"); got != watchStoreObserved {
+		t.Fatalf("classify default-store daemon = %q, want observed", got)
+	}
+}
+
+func TestRemoteMatchesRepoGitHubHostsAndSchemes(t *testing.T) {
+	tests := []struct {
+		name   string
+		remote string
+		repo   string
+		want   bool
+	}{
+		{"scp-style SSH", "git@github.com:BeFeast/demo.git", "BeFeast/demo", true},
+		{"case-insensitive SCP host", "GIT@GITHUB.COM:BEFEAST/DEMO.GIT", "BeFeast/demo", true},
+		{"HTTPS", "https://github.com/BeFeast/demo.git", "BeFeast/demo", true},
+		{"HTTP", "http://github.com/BeFeast/demo", "BeFeast/demo", true},
+		{"SSH URL", "ssh://git@github.com/BeFeast/demo.git", "BeFeast/demo", true},
+		{"git protocol", "git://github.com/BeFeast/demo.git", "BeFeast/demo", true},
+		{"case insensitive", "HTTPS://GITHUB.COM/BEFEAST/DEMO.GIT", "BeFeast/demo", true},
+		{"wrong HTTPS host", "https://evil.example/BeFeast/demo.git", "BeFeast/demo", false},
+		{"wrong scp host", "git@gitlab.com:BeFeast/demo.git", "BeFeast/demo", false},
+		{"unsupported file scheme", "file:///tmp/BeFeast/demo.git", "BeFeast/demo", false},
+		{"unsupported FTP scheme", "ftp://github.com/BeFeast/demo.git", "BeFeast/demo", false},
+		{"wrong repository", "https://github.com/BeFeast/other.git", "BeFeast/demo", false},
+		{"extra path component", "https://github.com/mirror/BeFeast/demo.git", "BeFeast/demo", false},
+		{"schemeless URL", "github.com/BeFeast/demo.git", "BeFeast/demo", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := remoteMatchesRepo(tc.remote, tc.repo); got != tc.want {
+				t.Fatalf("remoteMatchesRepo(%q, %q) = %t, want %t", tc.remote, tc.repo, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestArgvHasWatchStore(t *testing.T) {
 	cases := []struct {
 		argv []string
@@ -117,6 +212,44 @@ func TestGenesisNextCommands(t *testing.T) {
 	next = genesisNextCommands("plan", "/x/store.db", "/p.yaml", "the-id", "sha256:desired", configstore.BaselineAbsent, configstore.EffectConflict)
 	if len(next) != 1 || !strings.Contains(next[0], "conflict") {
 		t.Fatalf("conflict next = %v, want conflict guidance", next)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"safe", "/tmp/project.yaml", "/tmp/project.yaml"},
+		{"spaces", "/tmp/project files/config.yaml", "'/tmp/project files/config.yaml'"},
+		{"single quote", "/tmp/it's ready/config.yaml", `'/tmp/it'"'"'s ready/config.yaml'`},
+		{"empty", "", "''"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shellQuote(tc.in); got != tc.want {
+				t.Fatalf("shellQuote(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestArgsRequestJSON(t *testing.T) {
+	tests := []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"--json"}, true},
+		{[]string{"--file", "p.yaml", "--json=true"}, true},
+		{[]string{"--json=garbage"}, true},
+		{[]string{"--json=false"}, false},
+		{[]string{"--file", "p.yaml"}, false},
+	}
+	for _, tc := range tests {
+		if got := argsRequestJSON(tc.args); got != tc.want {
+			t.Fatalf("argsRequestJSON(%q) = %t, want %t", tc.args, got, tc.want)
+		}
 	}
 }
 
@@ -226,6 +359,44 @@ func TestPlanReportExistingStoreChangesNoDatabaseBytesOrSidecars(t *testing.T) {
 	}
 }
 
+func TestPlanReportActiveWALChangesNoDatabaseFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "config.db")
+	store, err := configstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open writable fixture: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertProject(context.Background(), "befeast-demo", projectTestYAML); err != nil {
+		t.Fatalf("seed active WAL fixture: %v", err)
+	}
+	paths := []string{dbPath, dbPath + "-wal", dbPath + "-shm"}
+	before := make(map[string][]byte, len(paths))
+	for _, path := range paths {
+		before[path], err = os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read active WAL fixture %s: %v", path, err)
+		}
+	}
+	prepared, err := configstore.PrepareProject("p.yaml", []byte(projectTestYAML))
+	if err != nil {
+		t.Fatalf("PrepareProject: %v", err)
+	}
+	report := planReport(dbPath, prepared, false)
+	if report.Effect != configstore.EffectNoOp || report.Wrote {
+		t.Fatalf("active-WAL plan = %+v, want no-op+!wrote", report)
+	}
+	for _, path := range paths {
+		after, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read after plan %s: %v", path, err)
+		}
+		if !bytes.Equal(before[path], after) {
+			t.Fatalf("project plan changed active SQLite file %s", path)
+		}
+	}
+}
+
 // A full plan→apply→plan receipt cycle through a real store: the JSON is
 // well-formed and the effect transitions create → no-op, exactly one row lands.
 func TestGenesisReceiptCycle(t *testing.T) {
@@ -304,6 +475,39 @@ func TestStoreFileExists(t *testing.T) {
 	}
 }
 
+func TestInspectStoreFileRejectsNonRegularAndStatErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	exists, err := inspectStoreFile(dir)
+	if err == nil || exists || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("inspectStoreFile(directory) = (%t, %v), want false + non-regular error", exists, err)
+	}
+
+	loop := filepath.Join(dir, "symlink-loop")
+	if err := os.Symlink("symlink-loop", loop); err != nil {
+		t.Fatalf("create symlink loop: %v", err)
+	}
+	exists, err = inspectStoreFile(loop)
+	if err == nil || exists {
+		t.Fatalf("inspectStoreFile(stat error) = (%t, %v), want false + error", exists, err)
+	}
+
+	readOnlyParent := filepath.Join(dir, "read-only")
+	if err := os.Mkdir(readOnlyParent, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(readOnlyParent, 0o755) })
+	exists, err = inspectStoreFile(filepath.Join(readOnlyParent, "maestro.db"))
+	if err == nil || exists || !strings.Contains(err.Error(), "not writable") {
+		t.Fatalf("inspectStoreFile(unwritable parent) = (%t, %v), want false + not-writable error", exists, err)
+	}
+
+	exists, err = inspectStoreFile(filepath.Join(dir, "new", "nested", "maestro.db"))
+	if err == nil || exists || !strings.Contains(err.Error(), "unavailable") {
+		t.Fatalf("inspectStoreFile(missing immediate parent) = (%t, %v), want false + unavailable error", exists, err)
+	}
+}
+
 func TestValidateGenesisRuntime(t *testing.T) {
 	dir := t.TempDir()
 	repoDir := filepath.Join(dir, "repo")
@@ -319,15 +523,28 @@ func TestValidateGenesisRuntime(t *testing.T) {
 		}
 	}
 	p := &configstore.PreparedProject{
-		Repo:         "BeFeast/demo",
-		LocalPath:    repoDir,
-		WorktreeBase: filepath.Join(dir, "worktrees", "demo"),
+		Repo:           "BeFeast/demo",
+		LocalPath:      repoDir,
+		WorktreeBase:   filepath.Join(dir, "worktrees", "demo"),
+		ManagementHome: config.ManagementHomeConfig{Path: filepath.Join(dir, "management-home")},
 	}
 	if err := os.Mkdir(filepath.Dir(p.WorktreeBase), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Mkdir(p.ManagementHome.Path, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := validateGenesisRuntime(p); err != nil {
 		t.Fatalf("valid runtime preflight: %v", err)
+	}
+	if err := os.Remove(p.ManagementHome.Path); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateGenesisRuntime(p); err == nil || !strings.Contains(err.Error(), "management_home.path") {
+		t.Fatalf("missing management home err = %v", err)
+	}
+	if err := os.Mkdir(p.ManagementHome.Path, 0o755); err != nil {
+		t.Fatal(err)
 	}
 	p.Repo = "BeFeast/other"
 	if err := validateGenesisRuntime(p); err == nil || !strings.Contains(err.Error(), "does not match") {

--- a/cmd/maestro/project_test.go
+++ b/cmd/maestro/project_test.go
@@ -80,6 +80,24 @@ func TestDefaultStoreProtectsLegacyProjectsUntilMigration(t *testing.T) {
 	}
 }
 
+func TestDefaultStoreInspectionFailureStaysOnLegacyPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.Mkdir(filepath.Join(home, ".maestro"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := legacyConfigStorePath()
+	if err := os.WriteFile(legacy, []byte("not a sqlite database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := defaultConfigStorePath(); got != legacy {
+		t.Fatalf("default after legacy inspection failure = %q, want fail-closed legacy %q", got, legacy)
+	}
+	if err := refuseUnmigratedCanonicalStore(canonicalConfigStorePath()); err == nil {
+		t.Fatal("explicit canonical service should refuse when legacy inspection fails")
+	}
+}
+
 func TestClassifyDaemonWatchStore(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/cmd/maestro/settings.go
+++ b/cmd/maestro/settings.go
@@ -53,7 +53,7 @@ func settingsUsage() {
 	fmt.Fprintln(os.Stderr, "  audit [--limit N]                        show the settings change journal (who/when/old->new)")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "known keys: "+strings.Join(config.FleetSettingKeys(), ", "))
-	fmt.Fprintln(os.Stderr, "flags: --db <path> (default ~/.maestro/config.db), --actor <name>")
+	fmt.Fprintln(os.Stderr, "flags: --db <path> (default ~/.maestro/maestro.db), --actor <name>")
 }
 
 // splitSettingsArgs separates flag tokens from positional arguments so a key /

--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -4,19 +4,23 @@ Use Fleet Mission Control as the primary operations surface for Maestro-managed 
 
 This runbook is intentionally safe for shared docs. It uses placeholders for local paths and never requires printing tokens, environment variables, raw config dumps, or full worker logs.
 
-## Workshop Services
+## Fleet Service
 
-Reserve these services and ports on the workshop host:
+Run one Maestro service on the execution host:
 
 | Service | Default bind | Port | Purpose | Notes |
 |---|---:|---:|---|---|
-| Fleet Mission Control | `127.0.0.1` | `8787` | The single dashboard for the whole fleet, plus the `/api/v1/fleet` aggregate API and project-scoped routes (`/project/<name>`) | Start with `maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787` (writes enabled on trusted LAN; add `--read-only=true` for exposed installs) |
-| Project runner | none by default | none | Runs `maestro run --config ...` and owns workers, worktrees, PR handling, and merge/deploy loops | It only serves HTTP when that project config has `server.port` set |
-| Supervisor loop | none | none | Runs `maestro supervise --config ...` to record decisions, safe queue label mutations, and approval requests | Can be manual, timer-driven, or a user service |
+| Maestro fleet daemon + Mission Control | `127.0.0.1` CLI default; `0.0.0.0` in the shipped service | `8786` | Runs every project flow and serves the dashboard, `/api/v1/fleet`, and project-scoped routes (`/project/<name>`) | `maestro daemon --watch-store --store ~/.maestro/maestro.db`; the shipped `maestro.service` uses the same store and port |
 | Worker sessions | none | none | tmux sessions and log files created under each project's `state_dir` | Inspect through Mission Control, `maestro status`, or `maestro logs` |
 | OpenClaw relay | `127.0.0.1` | `18789` | Optional Telegram relay endpoint when `telegram.mode: openclaw` is used | Not required for Mission Control |
 
-> Per-project Mission Control ports (`8788+`) were retired in #516. Every project is now reachable through the fleet aggregator at `/project/<name>`. Old `maestro-<project>-web.service` user units can be stopped and disabled; their `server.port` settings in project YAMLs are honored only when a project runs its own single-tenant `maestro serve --config ...` outside the fleet.
+There is no separate fleet dashboard, project runner, or supervisor service. The
+daemon owns all three responsibilities. Per-project ports and
+`maestro-<project>-web.service`, `maestro@<project>`, `fleet.yaml`, and
+`maestro-fleet.service` belong only to the retired topology; use the explicit
+legacy migration procedure in the
+[project setup runbook](project-setup-runbook.md#single-daemon-mission-control-and-config-store-operating-model)
+rather than recreating them.
 
 ### Dashboard auth posture: trusted LAN vs. exposed install
 
@@ -29,17 +33,19 @@ The server advertises both **HTTP Basic** (any username, password equal to the t
 
 ## Config Boundaries
 
-Project config and fleet config have different jobs.
+The config-store row is the runtime source of truth; the portable YAML is an
+approved input to genesis, not a second watched config surface.
 
-| File | Loaded by | Owns | Does not own |
+| Surface | Loaded by | Owns | Does not own |
 |---|---|---|---|
-| `~/.maestro/maestro-<project>.yaml` | `maestro run`, `maestro supervise`, `maestro status`, `maestro logs`, single-project `maestro serve` | Repo, clone path, worktree path, state directory, session prefix, labels, supervisor policy, review gate, merge/deploy policy | Other projects |
-| `~/.maestro/fleet.yaml` | `maestro serve --fleet` | Project display names and project config paths | Queue policy, labels, state directories, review gates, merge behavior |
-| `.maestro/supervisor.yaml`, `.maestro/supervisor.yml`, or `.maestro/supervisor.md` | Loaded beside the project config or inside `local_path/.maestro` | Supervisor policy when the team wants policy beside the repo | Fleet membership |
+| Project row in `~/.maestro/maestro.db` | `maestro daemon --watch-store` | Repo, clone/worktree paths, stable identity, Management Home link, state/session paths, labels, supervisor, review, merge, and deploy policy | Other project rows |
+| Private portable project YAML | `maestro project plan` / `project apply` | Desired project row reviewed during genesis | Runtime fleet membership after apply |
+| In-repo approved policy/specification | Workers and project policy loaders where explicitly supported | Executable requirements and repo-owned policy | Private Management Home planning context |
 
-Fleet config paths may be absolute, `~/...`, or relative to the fleet YAML file. A fleet file should not duplicate project settings. If a project needs a different label, review gate, state directory, or runner interval, change that project's config and restart that project's runner.
-
-`dashboard_url` was historically used to link from the fleet card to a per-project dashboard on its own port. Those ports are retired (#516); the aggregator routes operators to `/project/<name>` instead. Any `dashboard_url` value still present in a fleet.yaml file is ignored and logged as deprecated on load.
+Do not create `fleet.yaml` or duplicate membership in a second file. Add/change a
+row through the supported config-store/project workflow; `--watch-store` applies
+it without restarting the daemon. The built-in dashboard routes operators to
+`/project/<name>` on port `8786`.
 
 Minimal project config shape:
 
@@ -47,6 +53,12 @@ Minimal project config shape:
 repo: OWNER/REPO
 local_path: /path/to/repos/<project>
 worktree_base: /path/to/worktrees/<project>
+project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
+management_home:
+  kind: obsidian
+  path: /absolute/path/to/Obsidian Vault/Dev/Areas/<project>
+  vault: Obsidian Vault
+  vault_path: Dev/Areas/<project>
 state_dir: ~/.maestro/<project>
 session_prefix: prj
 
@@ -66,11 +78,6 @@ outcome:
   runtime_host: production host or platform
   non_goals:
     - Rewrite unrelated subsystems
-
-server:
-  host: 127.0.0.1
-  port: 8788
-  # read_only defaults to false (#477 trusted-LAN posture); set true for exposed installs.
 
 blocker_patterns:
   - "blocked by.*?#(\\d+)"
@@ -109,23 +116,22 @@ supervisor:
     - change_global_config
 ```
 
-Minimal fleet config shape:
-
-```yaml
-projects:
-  - name: project-a
-    config: maestro-project-a.yaml
-  - name: project-b
-    config: maestro-project-b.yaml
-```
-
-`dashboard_url:` is deprecated and silently ignored on load (#516). Every project is reachable at `/project/<name>` on the aggregator port.
+Apply the portable YAML with `maestro project plan` followed by its exact
+`next[0]` command. A second plan must report `no-op`; the daemon then exposes the
+row at `/project/<name>` and in `/api/v1/fleet`.
 
 ## Operating Model
 
-Fleet Mission Control is an observation surface. It loads each project config, reads each project's state/log metadata, and returns one aggregate response from `/api/v1/fleet`. The header starts with one global operator brief across every configured project; project cards, supervisor details, queues, and worker logs are drilldown/debug data after that brief. One project load error is shown on that project card without hiding the rest of the fleet.
+Mission Control is the daemon's built-in operations surface. The daemon reads
+every project row from `maestro.db`, runs one flow per row, reads each flow's
+state/log metadata, and returns one aggregate response from `/api/v1/fleet`. The
+header starts with one global operator brief; project cards, supervisor details,
+queues, and worker logs are drilldown/debug data. One project load error is shown
+on that project card without hiding the rest of the fleet.
 
-The project runner remains the execution surface. It starts workers, reconciles dead sessions, opens and monitors PRs, waits for review gates, merges eligible PRs, deploys when configured, and updates local state.
+The same daemon is the execution surface. Each flow starts workers, reconciles
+dead sessions, opens and monitors PRs, waits for review gates, merges eligible
+PRs, deploys when configured, and updates local state.
 
 When deploying Maestro itself from source on the fleet host, stamp the binary with the release version from `VERSION`; an unstamped source build leaves `maestro version` reporting build metadata instead of the release. Use the same stamped build shape as the release workflow, then verify the installed binary:
 
@@ -138,7 +144,12 @@ go build -trimpath -ldflags "-X main.version=${VERSION}" -o maestro ./cmd/maestr
 ./maestro version
 ```
 
-The supervisor is the explainability and policy surface. It records queue analysis, selected candidates, stuck states, outcome context, safe label mutations, and approval requests. Safe actions are limited to actions explicitly listed in `supervisor.safe_actions`. Risky recommendations are recorded for an operator; approving them with the CLI records the approval but does not execute the risky action by itself.
+Each daemon flow includes its supervisor explainability and policy loop. It
+records queue analysis, selected candidates, stuck states, outcome context, safe
+label mutations, and approval requests. Safe actions are limited to actions
+explicitly listed in `supervisor.safe_actions`. Risky recommendations are
+recorded for an operator; approving them with the CLI records the approval but
+does not execute the risky action by itself.
 
 Each project card shows an outcome status: goal, runtime target, health state, and next action. If no `outcome` brief is configured, Mission Control says so explicitly because merged PR throughput is not the same as a working runtime. If PRs keep merging while runtime health is unknown or failing, the supervisor records `no_outcome_progress` and recommends a read-only deploy/runtime check instead of mutating production.
 
@@ -186,12 +197,12 @@ This algorithm is intentionally explicit and explainable. There is no ML priorit
 
 Use this order during normal operations:
 
-1. Open Fleet Mission Control at `http://127.0.0.1:8787/`.
+1. Open Fleet Mission Control at `http://127.0.0.1:8786/` (or the trusted host address configured by `maestro.service`).
 2. Read the global operator brief first; if it says no action is needed, treat the rest of the page as supporting detail.
 3. If the brief names an action, follow that project, issue/PR/session, and reason before scanning lower-priority cards.
-4. Open a project dashboard link only when the fleet card needs project-level detail.
-5. Use CLI commands with explicit `--config` paths when you need local state, logs, or a supervised decision.
-6. Restart services rather than editing state files by hand.
+4. Open `/project/<name>` only when the fleet card needs project-level detail.
+5. Use config-store selectors when a supported CLI diagnostic needs one project.
+6. Never edit state files by hand; restart the one daemon service only when the daemon process itself is unhealthy.
 
 ## Queue Policy
 
@@ -265,30 +276,27 @@ Supervisor approvals are stale-sensitive. A pending approval becomes stale if th
 
 ## Safe Commands
 
-Use explicit config paths for project commands. These commands are safe for local operation because they do not print token values or dump entire configs. Treat worker logs as potentially sensitive and avoid pasting full logs into PRs or issues.
+Use the shared store plus an explicit project row for project-scoped diagnostics.
+These commands do not print token values or dump entire configs. Treat worker
+logs as potentially sensitive and avoid pasting full logs into PRs or issues.
 
 ```bash
-# Fleet dashboard and API (writes enabled by default on trusted LAN; add --read-only=true for exposed installs)
-maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787
-curl -fsS http://127.0.0.1:8787/api/v1/fleet
+# Fleet daemon, dashboard, and API
+maestro daemon --watch-store --store ~/.maestro/maestro.db \
+  --approvals-store sqlite --state-store sqlite
+curl -fsS http://127.0.0.1:8786/api/v1/fleet
 
-# Project status and queue analysis
-maestro status --config ~/.maestro/maestro-<project>.yaml
-maestro status --config ~/.maestro/maestro-<project>.yaml --json
-maestro supervise --config ~/.maestro/maestro-<project>.yaml --once
-maestro supervise --config ~/.maestro/maestro-<project>.yaml --once --json
+# Project status and read-only queue analysis (use the config-store row name)
+maestro status --config-store ~/.maestro/maestro.db --config-store-project <project> --json
+maestro supervise --config-store ~/.maestro/maestro.db --config-store-project <project> --once --dry-run --json
 
-# Worker logs through Maestro
-maestro logs --config ~/.maestro/maestro-<project>.yaml
-maestro logs --config ~/.maestro/maestro-<project>.yaml <session>
+# Worker status/log excerpts are available from the project's Mission Control
+# route; keep full logs on the execution host.
 
-# Service status and restart
-systemctl --user status maestro@<project>.service --no-pager
-journalctl --user -u maestro@<project>.service --since "30 minutes ago" --no-pager
-systemctl --user restart maestro@<project>.service
-systemctl --user status maestro-fleet.service --no-pager
-journalctl --user -u maestro-fleet.service --since "30 minutes ago" --no-pager
-systemctl --user restart maestro-fleet.service
+# The only Maestro service (Linux user-service installation)
+systemctl --user status maestro.service --no-pager
+journalctl --user -u maestro.service --since "30 minutes ago" --no-pager
+systemctl --user restart maestro.service   # only when the daemon itself is unhealthy
 ```
 
 Avoid these during incident handling unless you are deliberately debugging credentials: `env`, raw config dumps, `gh auth token`, shell history dumps, and full worker log pastebacks.
@@ -312,14 +320,14 @@ Mission Control indicators: queue `eligible=0`, `no_eligible_issues`, `all_eligi
 
 Safe response:
 
-1. Run `maestro supervise --config ~/.maestro/maestro-<project>.yaml --once` and read the queue summary.
+1. Run `maestro supervise --config-store ~/.maestro/maestro.db --config-store-project <project> --once --dry-run --json` and read the queue summary.
 2. If there are no open issues, add or wait for work.
 3. If issues are missing the ready label, add the configured `supervisor.ready_label` or let the supervisor add it when `add_ready_label` is allowed.
 4. If issues are excluded, remove the blocking/excluded label only after confirming the issue is actually runnable.
 5. If issues are held as parent/meta work, decompose or retitle/relabel only when the issue should become executable work.
 6. If issues are blocked by dependencies, close or resolve the blocker issue before expecting a worker to start.
-7. If dynamic wave reports non-runnable project status, move one issue to a configured runnable status or update `supervisor.dynamic_wave.runnable_project_statuses` in the project config.
-8. Restart the project runner only if config changed: `systemctl --user restart maestro@<project>.service`.
+7. If dynamic wave reports non-runnable project status, move one issue to a configured runnable status or deliberately update `supervisor.dynamic_wave.runnable_project_statuses` in the project row.
+8. Store changes are hot-reloaded; do not restart the daemon merely because one project config changed.
 
 ### Running but dead PID
 
@@ -327,11 +335,11 @@ Mission Control indicators: status `running` with `alive=false`, CLI `ALIVE no`,
 
 Safe response:
 
-1. Run `maestro status --config ~/.maestro/maestro-<project>.yaml` to confirm the session and PID.
-2. Inspect the session with `maestro logs --config ~/.maestro/maestro-<project>.yaml <session>`.
-3. Restart the project runner with `systemctl --user restart maestro@<project>.service` so the next reconciliation cycle can mark the session dead and retry if eligible.
-4. If you intentionally need to reconcile immediately, run `maestro run --config ~/.maestro/maestro-<project>.yaml --once` knowing it can progress orchestration for that project.
-5. Do not edit `state.json` manually.
+1. Run `maestro status --config-store ~/.maestro/maestro.db --config-store-project <project> --json` to confirm the session and PID.
+2. Inspect the session through the project's Mission Control route; keep full logs on the execution host.
+3. Let the daemon's next reconciliation cycle mark the session dead and retry if eligible.
+4. Restart `maestro.service` only if the daemon process itself is unhealthy, not to restart one project flow.
+5. Do not edit `state.json` manually or launch a competing `maestro run --once` process.
 
 ### PR open waiting Greptile
 
@@ -343,7 +351,7 @@ Safe response:
 2. Check the GitHub PR page if it remains pending unusually long.
 3. If Greptile is not approved, address the feedback or let the configured retry path handle review feedback.
 4. Do not spawn another worker for the same issue while the PR is open.
-5. Change `review_gate` only as an explicit project policy decision, then restart the project runner.
+5. Change `review_gate` only as an explicit project policy decision; the daemon hot-reloads the changed store row.
 
 ### Retry exhausted
 
@@ -354,7 +362,7 @@ Safe response:
 1. Inspect the session status and logs with explicit `--config` commands.
 2. If a PR is still open, keep it in normal merge flow when checks and review gates pass.
 3. If checks failed or no usable PR exists, review failed attempts, split or clarify the issue, and retry intentionally.
-4. If retrying is appropriate, update the issue/config first, then start a new worker with `maestro spawn --config ~/.maestro/maestro-<project>.yaml --issue <number>`.
+4. If retrying is appropriate, update the issue/project row first, then start a new worker with `maestro spawn --config-store ~/.maestro/maestro.db --config-store-project <project> --issue <number>`.
 5. Do not increase retry budgets globally just to clear one incident unless that is the intended project policy change.
 
 ### Stale approval
@@ -364,14 +372,10 @@ Mission Control indicators: approval status `stale` or CLI error `approval is st
 Safe response:
 
 1. Do not approve the stale approval.
-2. Run `maestro supervise --config ~/.maestro/maestro-<project>.yaml --once` to record a fresh decision.
+2. Let the daemon supervisor record a fresh decision, or run a read-only diagnostic with the config-store selectors shown above.
 3. Review the new target, risk, reasons, and stuck states.
-4. Resolve the new approval ID if needed:
-
-```bash
-maestro supervise approve --config ~/.maestro/maestro-<project>.yaml --actor <operator> --reason "approved after fresh status check" <approval-or-decision-id>
-maestro supervise reject --config ~/.maestro/maestro-<project>.yaml --actor <operator> --reason "state changed" <approval-or-decision-id>
-```
+4. Resolve the new approval through the project's Mission Control approval
+   inbox, which is already bound to the daemon flow and shared approval store.
 
 ### Stale supervisor sessions
 
@@ -388,7 +392,7 @@ Safe response:
    - **Idle/worktree path:** the session is past `idle_after_minutes` AND, when `require_worktree_missing` is true, its recorded worktree path is missing on disk.
    - **Linked-PR-merged path:** the session's branch (head ref recorded as `branch` in the API, e.g. `feat/sup-44-346-…`) maps to a PR that the project state already classifies as merged. This path fires regardless of idle time, so a freshly retry-exhausted session whose PR has just merged stops haunting `attention` immediately.
 3. Reconciled sessions are recorded in `audit-log.jsonl` under the project's `state_dir` with action `stale_session_reconciled`. The audit `reason` field carries the trigger (`linked PR merged` for the new path, otherwise the legacy idle-window reason). Sessions remain searchable in `workers` for drilldown.
-4. To temporarily disable filtering for a project, set `stale_session_reconciler.enabled: false` and restart the project runner.
+4. To temporarily disable filtering for a project, set `stale_session_reconciler.enabled: false` in the project row; the daemon hot-reloads it.
 5. To keep only the legacy idle/worktree behaviour from PR #400, set `stale_session_reconciler.merged_pr_dismisses: false`.
 6. To tighten the idle path during dogfood/recovery, lower `idle_after_minutes` (for example `60` for one hour). Keep `require_worktree_missing: true` so a live worker is never reclaimed.
 7. The reconciler reads PR state from the existing project state snapshot (sessions already transitioned to `done`/`code_landed`); it does not issue ad-hoc `gh` calls in the snapshot path.
@@ -412,14 +416,15 @@ Safe response:
 2. Confirm the GitHub user or app has access to the repo and project board.
 3. Retry after GitHub rate limits or project API incidents clear.
 4. If dynamic wave depends on project status, keep work paused until project item data is reliable or make an explicit temporary policy change in the project config.
-5. Restart only the affected project runner after config or auth is fixed.
+5. Project-row changes hot-reload. Restart the single daemon only if the daemon process itself remains unhealthy after auth/config is fixed.
 6. Do not paste raw GraphQL output, tokens, or local config contents into issues or PRs.
 
 ## Operator Checklist
 
-- Fleet dashboard is reachable on `127.0.0.1:8787`; on a trusted LAN it is write-enabled by default (#477), with the cautious approval gate guarding `merge_pr` / `close_issue` / `delete_worktree` / `change_global_config`.
-- Every project in `~/.maestro/fleet.yaml` has a distinct `state_dir`, `session_prefix`, and optional project dashboard port.
-- Project commands use `--config ~/.maestro/maestro-<project>.yaml`.
+- The single daemon and Mission Control are reachable on port `8786`; on a trusted LAN it is write-enabled by default (#477), with the cautious approval gate guarding `merge_pr` / `close_issue` / `delete_worktree` / `change_global_config`.
+- `maestro.service`, project genesis, and operator commands all use `~/.maestro/maestro.db`.
+- Every project row has a distinct stable identity, `state_dir`, and `session_prefix`; there are no per-project dashboard ports or services.
+- Project diagnostics use explicit `--config-store` and `--config-store-project` selectors where supported.
 - Dynamic wave has known runnable statuses and clear ready/blocked label ownership.
 - Greptile gate policy is explicit per project.
 - Approvals are fresh before being approved or rejected.

--- a/docs/fleet-settings-runbook.md
+++ b/docs/fleet-settings-runbook.md
@@ -65,7 +65,7 @@ maestro settings rm supervisor.enabled --project <row>
 maestro settings audit
 ```
 
-Flags: `--db <path>` (default `~/.maestro/config.db`), `--actor <name>` (default
+Flags: `--db <path>` (default `~/.maestro/maestro.db`), `--actor <name>` (default
 `cli:<user>`), and `--limit N` on `audit`. Flags may appear before or after the
 `key`/`key=value` argument.
 

--- a/docs/handoff-epic-format.md
+++ b/docs/handoff-epic-format.md
@@ -235,7 +235,7 @@ supervisor:
       - "## Issue Wave"
       - "## Route Replacement Map"
       - "## Done For The Epic"
-    preflight_command: /home/god/.maestro/bin/scribe-redesign-preflight.sh
+    preflight_command: /opt/maestro/bin/scribe-redesign-preflight.sh
     require_preflight_before_create: true
     require_preflight_before_spawn: true
     max_children_per_cycle: 1
@@ -243,8 +243,8 @@ supervisor:
   completion_gates:
     required_labels: [needs-visual-verification, ui-redesign]
     body_markers: ["## Live Visual Verification"]
-    live_visual_command: /home/god/.maestro/bin/scribe-live-visual.sh
-    deployment_status_command: /home/god/.maestro/bin/scribe-deploy-status.sh
+    live_visual_command: /opt/maestro/bin/scribe-live-visual.sh
+    deployment_status_command: /opt/maestro/bin/scribe-deploy-status.sh
     verification_label: awaiting-verification
 ```
 

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -119,15 +119,23 @@ Issues with any exclude label are skipped even if they also have a required labe
 
 ---
 
-## 4. Maestro Config (`maestro-<project>.yaml`)
+## 4. Portable Maestro Project Config
 
-Create the config file at `~/.maestro/maestro-<project>.yaml`. Example:
+Create a private portable YAML outside the code repo, then register it with the
+`project plan` / `project apply` flow below. The daemon reads the resulting store
+row; it does not watch this YAML file. Example:
 
 ```yaml
 # Repository
 repo: YOUR_ORG/YOUR_REPO
 local_path: /path/to/local/clone
 worktree_base: /path/to/worktrees/repo
+project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
+management_home:
+  kind: obsidian
+  path: /absolute/path/to/Obsidian Vault/Dev/Areas/your-project
+  vault: Obsidian Vault
+  vault_path: Dev/Areas/your-project
 
 # Issue filtering
 issue_labels:
@@ -186,23 +194,10 @@ supervisor:
     - delete_worktree
     - change_global_config
 
-# Model backends. MCP is opt-in per backend; omit mcp to spawn workers
-# without external MCP tools.
+# Select a fleet-shared backend. Portable genesis files do not define
+# model.backends; configure those once at fleet scope.
 model:
   default: claude
-  backends:
-    claude:
-      cmd: claude
-    codex:
-      cmd: codex
-      # mcp:
-      #   servers:
-      #     docs:
-      #       command: npx
-      #       args: ["-y", "@example/docs-mcp"]
-      #     symbols:
-      #       url: https://mcp.example.com/mcp
-      #       bearer_token_env_var: SYMBOLS_MCP_TOKEN
 
 # Concurrency
 max_parallel: 5
@@ -434,9 +429,10 @@ there is no per-project service. The old `maestro init` wizard (per-project
 a redirect to the flow below.
 
 Register a project with the zero-write `plan` / idempotent `apply` genesis flow.
-Write a portable project config with `repo`, `local_path`, `worktree_base`, and a
-stable `project_id` (generate the UUID once — it is the durable identity `apply`
-confirms), then:
+Write a portable project config with canonical `owner/repository`, absolute
+execution-host `local_path` / `worktree_base`, a stable lowercase `project_id`,
+and a complete `management_home` block. Generate the UUID once — it is the
+durable identity `apply` confirms. Then:
 
 Point `--db` at the same store the daemon unit reads (its `--store` path; the
 shipped `maestro.service` uses `%h/.maestro/maestro.db`).
@@ -453,8 +449,8 @@ maestro project apply --file ~/myproject.project.yaml --db ~/.maestro/maestro.db
 
 `plan` is read-only and reports the predicted effect (`create` / `update` /
 `no-op` / `conflict`) plus a config fingerprint. `apply` refuses a missing/wrong
-`--confirm`, the exact desired `--fingerprint`, and the plan-time store
-`--baseline`; a config-file or concurrent store change is refused. A second
+`--confirm`, a mismatched desired `--fingerprint`, or a mismatched plan-time store
+`--baseline`; config-file and concurrent store changes are refused. A second
 identical apply is a reported no-op; an identity conflict is a hard
 stop that never overwrites a row by name. Both emit a machine-readable receipt
 (store, project id, fingerprint, effect, daemon-reconciliation expectation, exact
@@ -468,23 +464,53 @@ Removal/rollback stays a separate explicit operator action:
 maestro config-store rm --db ~/.maestro/maestro.db <name>   # drains the flow; the daemon reconciles the removal
 ```
 
-The daemon itself runs from a single unit (see the fleet unit below); if it is not
+The daemon itself runs from the single unit described below; if it is not
 running with `--watch-store`, a newly applied row is picked up only on its next
 restart, and `project apply` says so in its receipt.
 
-### Fleet dashboard operating model
+### Single-daemon Mission Control and config-store operating model
 
-Use the fleet dashboard when one operator needs a read-only overview across multiple Maestro-managed repos without SSH spelunking. Each repo still has its own project config, state directory, `session_prefix`, and optional per-project dashboard; the fleet dashboard loads those configs, keeps them visible in project tabs, and aggregates active workers through `/api/v1/fleet`.
+`~/.maestro/maestro.db` is the authoritative fleet config store. Do not create a
+new `maestro.d`, `fleet.yaml`, per-project unit, or separate `maestro serve`
+process for a newly registered project. The one `maestro daemon --watch-store`
+process runs every project flow and serves the fleet Mission Control/API on
+`127.0.0.1:8786` by default.
 
-For day-to-day operations, review gates, queue policy, approvals, and safe recovery steps, see the [Fleet Mission Control operating runbook](fleet-mission-control-runbook.md).
+For day-to-day operations, review gates, queue policy, approvals, dashboard
+exposure, and safe recovery steps, see the
+[Fleet Mission Control operating runbook](fleet-mission-control-runbook.md).
 
-Trusted-LAN default (#477): the fleet dashboard now boots write-enabled out of the box. The cautious approval gate still guards `merge_pr`, `close_issue`, `delete_worktree`, and `change_global_config`, so the writable HTTP surface cannot bypass operator approval for those four verbs. For installs exposed beyond a trusted LAN, pass `--read-only=true` (or set `server.read_only: true` in YAML) and configure the optional HTTP auth layer that #616 wires up (off by default). This supersedes the prior "never flip --read-only before auth" caveat.
+Start the daemon manually for an interactive test:
 
-### Runtime config store (phase 1)
+```bash
+mkdir -p ~/.maestro
+maestro daemon --watch-store --store ~/.maestro/maestro.db \
+  --approvals-store sqlite --state-store sqlite
+```
 
-Runtime project settings can be imported from `~/.maestro/maestro.d/*.yaml` into a small SQLite store. Phase 1 keeps the YAML files as the fallback read path; write-path changes, change history, and Mission Control settings UI edits are follow-up work.
+For a persistent Linux user service, install the repository's single
+`maestro.service` and enable that one unit:
 
-Proposed SQLite schema:
+```bash
+mkdir -p ~/.maestro
+mkdir -p ~/.config/systemd/user
+cp maestro.service ~/.config/systemd/user/maestro.service
+systemctl --user daemon-reload
+systemctl --user enable --now maestro.service
+systemctl --user status maestro.service
+```
+
+The service and every `project plan` / `project apply` command must point to the
+same `maestro.db`. Adding or changing a row is hot-reconciled; it does not require
+a daemon restart or another service. Verify the fleet API after apply:
+
+```bash
+curl -fsS http://127.0.0.1:8786/api/v1/fleet
+```
+
+The schema below is implementation context, not a second setup path.
+
+Core project tables:
 
 ```sql
 CREATE TABLE global (
@@ -510,101 +536,45 @@ CREATE TABLE project (
 
 `project.config_yaml` stores the project config without `model.backends`; `backends.definition_yaml` stores each backend definition once and the loader reconstructs the effective config before applying the existing YAML parser defaults and validation. Import rejects divergent definitions for the same backend name so the backend chain cannot silently fork per project.
 
-One-shot migration:
+Existing installations that still have legacy `maestro.d` files or
+`maestro@<project>` units should use the explicit, operator-confirmed cutover
+script from a repository checkout. This is migration guidance, not the topology
+for a new project:
 
-```sh
-maestro config-store migrate --db ~/.maestro/config.db --dir ~/.maestro/maestro.d
+```bash
+scripts/migrate-to-daemon.sh --dry-run
+scripts/migrate-to-daemon.sh
 ```
 
-Read from the store:
+Compatibility guard: when legacy `~/.maestro/config.db` still contains project
+rows and `~/.maestro/maestro.db` contains none, default CLI commands remain on
+the legacy store and warn. The shipped service refuses to start an empty
+canonical fleet until the projects are explicitly exported and migrated; follow
+the exact commands in that error or use the cutover script above.
+
+An explicit portable backup can be exported without changing the running
+topology:
 
 ```sh
-maestro run --config-store ~/.maestro/config.db
-maestro serve --config-store ~/.maestro/config.db --port 8787
+maestro config-store export --db ~/.maestro/maestro.db --dir /path/to/maestro-config-backup
 ```
 
-If `--config-store` is set and the store cannot be opened or read, Maestro falls back to the YAML paths passed with `--config`. Without YAML paths, store load failure remains fatal so operators do not accidentally run with an unintended default config.
-
-Export portable YAML backups:
-
-```sh
-maestro config-store export --db ~/.maestro/config.db --dir ~/.maestro/maestro.d.export
-```
-
-Exports restore the shared backend definitions into each YAML file so the result can be loaded by the legacy YAML loader or copied to another host.
+Exports restore shared backend definitions into each YAML file. Do not point a
+second daemon or `maestro serve` process at the export.
 
 To add a project:
 
-1. Create or update `~/.maestro/maestro-<project>.yaml` using the config shape above.
-2. Use a distinct `state_dir` and `session_prefix` for each project so worker sessions and state files do not overlap.
-3. Add the project to `~/.maestro/fleet.yaml` with a human name and config path. Every project is reachable through the unified Mission Control aggregator at `/project/<name>` (#516); per-project dashboard ports are retired and no longer need a separate user unit.
-4. Restart the fleet dashboard service and verify `/api/v1/fleet`.
+1. Create the portable YAML described in the genesis section above.
+2. Review `maestro project plan --json` and run its exact `next[0]` command.
+3. Re-run plan and require `effect: "no-op"`.
+4. Verify exactly one project flow in `http://127.0.0.1:8786/api/v1/fleet`.
 
-Minimal two-project fleet file:
+The daemon's fleet response includes `refreshed_at` plus per-project freshness
+metadata. Project cards show snapshot age and isolate a project's load error
+without hiding the rest of the fleet.
 
-```yaml
-# ~/.maestro/fleet.yaml
-projects:
-  - name: api
-    config: maestro-api.yaml
-  - name: web
-    config: maestro-web.yaml
-```
-
-`config` may be absolute, `~/...`, or relative to the fleet YAML file. `dashboard_url` is deprecated (#516); any value still present is silently overridden with the project-scoped MC route on load. For dogfooding, add Maestro's own project config to the same fleet file so the team can watch Maestro manage Maestro alongside application repos.
-
-Run the fleet dashboard manually (writes enabled by default on the trusted LAN; add `--read-only=true` for exposed installs):
-
-```bash
-maestro serve --fleet ~/.maestro/fleet.yaml --host 127.0.0.1 --port 8787
-```
-
-Verify the API:
-
-```bash
-curl -fsS http://127.0.0.1:8787/api/v1/fleet
-```
-
-The fleet response includes `refreshed_at` plus per-project freshness metadata. Project cards show snapshot age and are marked stale when the latest state or log snapshot is older than 15 minutes; one project's load error is shown on that card without hiding the rest of the fleet. Queue snapshots split skipped work into `excluded`, `held/meta`, `blocked-deps`, and non-runnable project status counts so an idle project shows why no worker starts.
-
-`--fleet` versus repeated `--config`:
-
-| Mode | Use it when | Notes |
-|---|---|---|
-| `maestro serve --fleet ~/.maestro/fleet.yaml --port 8787` | You want a stable operating model for a shared dashboard or systemd service | Supports human project names and relative config paths; project-scoped routes (`/project/<name>`) are served from the same port |
-| `maestro serve --config a.yaml --config b.yaml --port 8787` | You want a quick local aggregate view without writing a fleet file | Project names are derived from `repo` |
-
-For a persistent user service, create a dedicated fleet dashboard unit:
-
-```ini
-# ~/.config/systemd/user/maestro-fleet.service
-[Unit]
-Description=Maestro fleet dashboard
-After=network.target
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/maestro serve --fleet %h/.maestro/fleet.yaml --host 127.0.0.1 --port 8787
-Restart=on-failure
-RestartSec=10
-
-[Install]
-WantedBy=default.target
-```
-
-Enable it:
-
-```bash
-systemctl --user daemon-reload
-systemctl --user enable --now maestro-fleet.service
-systemctl --user status maestro-fleet.service
-```
-
-Bind to the LAN only on a trusted network or behind a firewall/reverse proxy. For non-LAN exposure, force `--read-only=true` and configure the auth layer (#616):
-
-```bash
-maestro serve --fleet ~/.maestro/fleet.yaml --host 0.0.0.0 --port 8787 --read-only=true
-```
+Do not create a dedicated fleet dashboard unit. Mission Control is part of the
+same daemon process that runs the project flows.
 
 ---
 
@@ -790,10 +760,11 @@ Use this checklist when onboarding a new repo to maestro:
 - [ ] Branch protection on `main` requiring PR + status checks
 - [ ] Labels created: `bug`, `enhancement`, `documentation`
 - [ ] Exclude labels created: `wontfix`, `question`, `blocked`, `duplicate`, `invalid`
-- [ ] `maestro-<project>.yaml` config file created
+- [ ] Portable project YAML includes `repo`, absolute execution-host paths, a stable `project_id`, and `management_home`
 - [ ] `scripts/deploy.sh` written, tested manually, made executable
 - [ ] Worker prompt template written with test requirements
 - [ ] Post-deploy smoke test in deploy script
 - [ ] Version bump configured (CI workflow or maestro `versioning` block)
-- [ ] `maestro run --once` succeeds (picks an issue, spawns a worker)
+- [ ] `maestro project plan` is reviewed, its exact `next[0]` apply command succeeds, and a second plan reports `no-op`
+- [ ] The single `maestro daemon --watch-store` shows exactly one hot-loaded flow in `/api/v1/fleet`
 - [ ] Telegram notifications working (if configured)

--- a/install.sh
+++ b/install.sh
@@ -84,15 +84,34 @@ main() {
 
     echo
     echo "Next steps (single daemon + config store):"
-    echo "  1. Install and start the daemon unit:"
-    echo "     cp maestro.service ~/.config/systemd/user/ && systemctl --user enable --now maestro.service"
-    echo "  2. Register a project (write a portable YAML with repo/local_path/worktree_base/project_id):"
+    echo "  1. Start the one fleet daemon (keep this process running):"
+    echo "     mkdir -p \$HOME/.maestro"
+    echo "     ${INSTALL_DIR}/maestro daemon --watch-store --store \$HOME/.maestro/maestro.db \\"
+    echo "       --approvals-store sqlite --state-store sqlite"
+    if [ "$OS" = "linux" ]; then
+        echo
+        echo "     Optional persistent Linux user service:"
+        if [ "$INSTALL_DIR" = "/usr/local/bin" ]; then
+            echo "     mkdir -p \$HOME/.config/systemd/user"
+            echo "     curl -fsSL https://raw.githubusercontent.com/${REPO}/${LATEST}/maestro.service -o \$HOME/.config/systemd/user/maestro.service"
+            echo "     systemctl --user daemon-reload && systemctl --user enable --now maestro.service"
+        else
+            echo "     The shipped maestro.service uses /usr/local/bin/maestro; update ExecStart"
+            echo "     to ${INSTALL_DIR}/maestro before enabling it."
+        fi
+    else
+        echo "     No launchd plist is shipped; use the foreground command above or your"
+        echo "     preferred macOS process manager."
+    fi
+    echo
+    echo "  2. Register a project (portable YAML: repo, absolute local/worktree paths,"
+    echo "     lowercase project_id, and management_home):"
     echo "     maestro project plan  --file <project.yaml> --db ~/.maestro/maestro.db --json"
     echo "     # Run the exact next[0] command returned by the approved plan receipt:"
     echo "     maestro project apply --file <project.yaml> --db ~/.maestro/maestro.db --confirm <project-id> --fingerprint <sha256-from-plan> --baseline <baseline-from-plan> --json"
     echo
-    echo "The daemon runs with --watch-store and hot-reconciles new rows — no per-project service."
-    echo "Migrating from legacy per-project units? Run scripts/migrate-to-daemon.sh."
+    echo "The running daemon hot-reconciles new rows — no per-project service or separate serve process."
+    echo "Migrating a legacy host? From a source checkout, review scripts/migrate-to-daemon.sh --dry-run first."
 }
 
 main

--- a/internal/approvalstore/store.go
+++ b/internal/approvalstore/store.go
@@ -111,9 +111,9 @@ type Store struct {
 	db *sql.DB
 }
 
-// DefaultDBPath is the shared approvals database (~/.maestro/maestro.db),
-// a sibling of the config store's config.db. A single file holds every
-// project's approvals; rows are tagged by project/repo/state_dir.
+// DefaultDBPath is the unified fleet database (~/.maestro/maestro.db). A single
+// file holds config, approvals, state, and the other fleet tables; rows are
+// tagged by project/repo/state_dir where required.
 func DefaultDBPath() string {
 	return filepath.Join(os.Getenv("HOME"), ".maestro", "maestro.db")
 }

--- a/internal/config/project_identity_test.go
+++ b/internal/config/project_identity_test.go
@@ -12,7 +12,7 @@ repo: BeFeast/maestro
 project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
 management_home:
   kind: obsidian
-  path: /home/god/Obsidian/Dev
+  path: /srv/example-vault/Dev
   vault: Obsidian Vault
   vault_path: Dev/Areas/maestro
 `
@@ -26,7 +26,7 @@ func TestParse_ProjectIdentityExampleRoundTrips(t *testing.T) {
 		t.Fatalf("project_id = %q, want the example UUID", cfg.ProjectID)
 	}
 	mh := cfg.ManagementHome
-	if mh.Kind != "obsidian" || mh.Path != "/home/god/Obsidian/Dev" ||
+	if mh.Kind != "obsidian" || mh.Path != "/srv/example-vault/Dev" ||
 		mh.Vault != "Obsidian Vault" || mh.VaultPath != "Dev/Areas/maestro" {
 		t.Fatalf("management_home not parsed verbatim: %+v", mh)
 	}

--- a/internal/configstore/genesis.go
+++ b/internal/configstore/genesis.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -43,12 +44,13 @@ var ErrIdentityConflict = errors.New("config-store identity conflict")
 // carries everything plan/apply need without re-parsing, so the fingerprint the
 // operator reviewed in `plan` is exactly the one `apply` gates on.
 type PreparedProject struct {
-	Name         string
-	ProjectID    string
-	Repo         string
-	LocalPath    string
-	WorktreeBase string
-	Fingerprint  string
+	Name           string
+	ProjectID      string
+	Repo           string
+	LocalPath      string
+	WorktreeBase   string
+	ManagementHome config.ManagementHomeConfig
+	Fingerprint    string
 	// Canonical is the deterministic project document the fingerprint is taken
 	// over (backends normalized, re-marshaled). Raw is the original file bytes,
 	// stored verbatim on apply so comments/ordering survive the round-trip that
@@ -62,6 +64,7 @@ type PreparedProject struct {
 // would touch, reported so an adapter can see why an effect was chosen.
 type ExistingRow struct {
 	Name        string `json:"name"`
+	Repo        string `json:"repo,omitempty"`
 	ProjectID   string `json:"project_id,omitempty"`
 	Fingerprint string `json:"fingerprint"`
 }
@@ -93,9 +96,6 @@ type GenesisReport struct {
 //   - repo required (config.Parse) — the derived project name comes from it;
 //   - a valid, present project_id (the durable identity the flow is built around);
 //   - local_path and worktree_base required (a genesis row must be runnable).
-//
-// A missing management_home is allowed but warned: an external bootstrap adapter
-// cannot correlate the row back to a control-room home without it.
 func PrepareProject(sourcePath string, data []byte) (*PreparedProject, error) {
 	cfg, err := config.ParseStrict(data)
 	if err != nil {
@@ -115,11 +115,25 @@ func PrepareProject(sourcePath string, data []byte) (*PreparedProject, error) {
 	if backends := detachBackends(&source); len(backends) > 0 {
 		return nil, fmt.Errorf("portable project genesis must not define shared model.backends; configure fleet backends separately before plan/apply")
 	}
+	repo := strings.TrimSpace(cfg.Repo)
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" || strings.ContainsAny(repo, "\\ ") {
+		return nil, fmt.Errorf("repo must use the canonical owner/repository form; got %q", repo)
+	}
 	if strings.TrimSpace(cfg.LocalPath) == "" {
 		return nil, fmt.Errorf("local_path is required for project plan/apply (the on-disk clone the daemon works from)")
 	}
 	if strings.TrimSpace(cfg.WorktreeBase) == "" {
 		return nil, fmt.Errorf("worktree_base is required for project plan/apply (the base dir worker worktrees are created under)")
+	}
+	if !filepath.IsAbs(cfg.LocalPath) || !filepath.IsAbs(cfg.WorktreeBase) {
+		return nil, fmt.Errorf("local_path and worktree_base must resolve to absolute execution-host paths")
+	}
+	if !cfg.ManagementHome.Configured() {
+		return nil, fmt.Errorf("management_home is required for project genesis so the durable row remains linked to its PM/control-room home (#869)")
+	}
+	if !filepath.IsAbs(strings.TrimSpace(cfg.ManagementHome.Path)) {
+		return nil, fmt.Errorf("management_home.path must be an absolute execution-host path")
 	}
 	name, err := ProjectNameFor(sourcePath, data)
 	if err != nil {
@@ -129,20 +143,16 @@ func PrepareProject(sourcePath string, data []byte) (*PreparedProject, error) {
 	if err != nil {
 		return nil, fmt.Errorf("canonicalize config: %w", err)
 	}
-	var warnings []string
-	if !cfg.ManagementHome.Configured() {
-		warnings = append(warnings, "no management_home block is set; an external bootstrap adapter cannot correlate this row back to a PM/control-room home (#869)")
-	}
 	return &PreparedProject{
-		Name:         name,
-		ProjectID:    id,
-		Repo:         cfg.Repo,
-		LocalPath:    cfg.LocalPath,
-		WorktreeBase: cfg.WorktreeBase,
-		Fingerprint:  fp,
-		Canonical:    canonical,
-		Raw:          data,
-		Warnings:     warnings,
+		Name:           name,
+		ProjectID:      id,
+		Repo:           cfg.Repo,
+		LocalPath:      cfg.LocalPath,
+		WorktreeBase:   cfg.WorktreeBase,
+		ManagementHome: cfg.ManagementHome,
+		Fingerprint:    fp,
+		Canonical:      canonical,
+		Raw:            data,
 	}, nil
 }
 
@@ -151,8 +161,8 @@ func PrepareProject(sourcePath string, data []byte) (*PreparedProject, error) {
 // reordering, whitespace) do NOT move the fingerprint, while any real change to a
 // value or a list DOES:
 //
-//   - backends are detached and re-attached in sorted order (matching a
-//     stored+exported row), then every mapping's keys are sorted recursively;
+//   - fleet-shared backends are detached, syntax-only presentation is removed,
+//     then every mapping's keys are sorted recursively;
 //   - sequences are left in place (their order is semantically meaningful, e.g.
 //     issue_labels / ordered_queue.issues).
 //
@@ -170,6 +180,7 @@ func canonicalProjectDoc(data []byte) ([]byte, string, error) {
 	// no-op regardless of unrelated fleet backend changes.
 	detachBackends(&root)
 	removeEmptyTopLevelMapping(&root, "model")
+	normalizeYAMLPresentation(&root)
 	sortMappingKeys(&root)
 	out, err := marshalNode(&root)
 	if err != nil {
@@ -177,6 +188,22 @@ func canonicalProjectDoc(data []byte) ([]byte, string, error) {
 	}
 	sum := sha256.Sum256(out)
 	return out, "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+// normalizeYAMLPresentation removes syntax-only details that the config decoder
+// does not treat as state. Comments, flow/block layout, and scalar quoting must
+// not invalidate an approved plan when the effective values are unchanged.
+func normalizeYAMLPresentation(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+	node.HeadComment = ""
+	node.LineComment = ""
+	node.FootComment = ""
+	node.Style = 0
+	for _, child := range node.Content {
+		normalizeYAMLPresentation(child)
+	}
 }
 
 func removeEmptyTopLevelMapping(root *yaml.Node, key string) {
@@ -318,18 +345,19 @@ func (s *Store) ApplyProject(ctx context.Context, p *PreparedProject, confirm, w
 		Existing:            existing,
 		Warnings:            p.Warnings,
 	}
-	if wb != report.BaselineFingerprint {
-		return report, fmt.Errorf("config store changed since plan (approved baseline %s, current %s); re-run `maestro project plan` and review before applying", wb, report.BaselineFingerprint)
-	}
 	switch effect {
 	case EffectConflict:
 		return report, fmt.Errorf("%w: %s", ErrIdentityConflict, conflict)
 	case EffectNoOp:
-		// Second identical apply: the matching row already exists, so this is a
-		// reported no-op and nothing is written.
+		// Desired state is already present. Accept even a stale plan baseline so
+		// retrying the exact approved command after a lost response is genuinely
+		// idempotent; identity and desired-fingerprint gates already matched.
 		report.Wrote = false
 		return report, nil
 	case EffectCreate, EffectUpdate:
+		if wb != report.BaselineFingerprint {
+			return report, fmt.Errorf("config store changed since plan (approved baseline %s, current %s); re-run `maestro project plan` and review before applying", wb, report.BaselineFingerprint)
+		}
 		if err := upsertProjectTx(ctx, tx, p.Name, string(p.Raw)); err != nil {
 			return nil, err
 		}
@@ -360,7 +388,12 @@ func evaluateProjectTx(ctx context.Context, tx *sql.Tx, p *PreparedProject) (eff
 	if row == nil {
 		return EffectCreate, "", nil, nil
 	}
-	if row.ProjectID != "" && row.ProjectID != p.ProjectID {
+	if !strings.EqualFold(strings.TrimSpace(row.Repo), strings.TrimSpace(p.Repo)) {
+		return EffectConflict,
+			fmt.Sprintf("project %q already exists for repo %q, not incoming repo %q; refusing basename adoption", p.Name, row.Repo, p.Repo),
+			row, nil
+	}
+	if row.ProjectID != "" && !strings.EqualFold(row.ProjectID, p.ProjectID) {
 		return EffectConflict,
 			fmt.Sprintf("project %q already exists with a different project_id (stored %s, incoming %s); refusing to overwrite by name", p.Name, row.ProjectID, p.ProjectID),
 			row, nil
@@ -388,7 +421,7 @@ func existingRowTx(ctx context.Context, tx *sql.Tx, name string) (*ExistingRow, 
 	if err := yaml.Unmarshal([]byte(data), &root); err != nil {
 		return nil, err
 	}
-	return &ExistingRow{Name: name, ProjectID: scalarAt(&root, "project_id"), Fingerprint: fp}, nil
+	return &ExistingRow{Name: name, Repo: scalarAt(&root, "repo"), ProjectID: scalarAt(&root, "project_id"), Fingerprint: fp}, nil
 }
 
 func projectNameByIDTx(ctx context.Context, tx *sql.Tx, id, exclude string) (string, error) {
@@ -447,7 +480,12 @@ func (s *Store) evaluate(ctx context.Context, p *PreparedProject) (effect, confl
 	if row == nil {
 		return EffectCreate, "", nil, nil
 	}
-	if row.ProjectID != "" && row.ProjectID != p.ProjectID {
+	if !strings.EqualFold(strings.TrimSpace(row.Repo), strings.TrimSpace(p.Repo)) {
+		return EffectConflict,
+			fmt.Sprintf("project %q already exists for repo %q, not incoming repo %q; refusing basename adoption", p.Name, row.Repo, p.Repo),
+			row, nil
+	}
+	if row.ProjectID != "" && !strings.EqualFold(row.ProjectID, p.ProjectID) {
 		return EffectConflict,
 			fmt.Sprintf("project %q already exists with a different project_id (stored %s, incoming %s); refusing to overwrite by name", p.Name, row.ProjectID, p.ProjectID),
 			row, nil
@@ -482,7 +520,7 @@ func (s *Store) existingRow(ctx context.Context, name string) (*ExistingRow, err
 	if err := yaml.Unmarshal(exported, &root); err != nil {
 		return nil, err
 	}
-	return &ExistingRow{Name: name, ProjectID: scalarAt(&root, "project_id"), Fingerprint: fp}, nil
+	return &ExistingRow{Name: name, Repo: scalarAt(&root, "repo"), ProjectID: scalarAt(&root, "project_id"), Fingerprint: fp}, nil
 }
 
 // projectNameByID returns the name of a stored project whose project_id equals
@@ -513,7 +551,7 @@ func (s *Store) projectNameByID(ctx context.Context, id, exclude string) (string
 		if err := yaml.Unmarshal([]byte(stored), &root); err != nil {
 			return "", err
 		}
-		if scalarAt(&root, "project_id") == id {
+		if strings.EqualFold(strings.TrimSpace(scalarAt(&root, "project_id")), id) {
 			return n, nil
 		}
 	}

--- a/internal/configstore/genesis_test.go
+++ b/internal/configstore/genesis_test.go
@@ -3,18 +3,19 @@ package configstore
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 )
 
 const genesisYAML = `repo: BeFeast/maestro
-local_path: ~/src/maestro
-worktree_base: ~/.worktrees/maestro
+local_path: /srv/example-src/maestro
+worktree_base: /srv/example-worktrees/maestro
 project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
 management_home:
   kind: obsidian
-  path: /srv/example-vault/Dev
+  path: /srv/example-vault/Dev/Areas/maestro
   vault: Example Vault
   vault_path: Dev/Areas/maestro
 `
@@ -38,15 +39,15 @@ func TestPrepareProjectValid(t *testing.T) {
 // The fingerprint is deterministic and insensitive to key ordering / backend
 // map ordering, so plan and apply of the same config always agree.
 func TestPrepareProjectFingerprintStable(t *testing.T) {
-	reordered := `local_path: ~/src/maestro
+	reordered := `local_path: /srv/example-src/maestro
 project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
-worktree_base: ~/.worktrees/maestro
+worktree_base: /srv/example-worktrees/maestro
 repo: BeFeast/maestro
 management_home:
   vault_path: Dev/Areas/maestro
   kind: obsidian
   vault: Example Vault
-  path: /srv/example-vault/Dev
+  path: /srv/example-vault/Dev/Areas/maestro
 `
 	a, err := PrepareProject("a.yaml", []byte(genesisYAML))
 	if err != nil {
@@ -59,8 +60,16 @@ management_home:
 	if a.Fingerprint != b.Fingerprint {
 		t.Fatalf("fingerprint not stable across key order: %s vs %s", a.Fingerprint, b.Fingerprint)
 	}
+	presentationOnly := strings.Replace(genesisYAML, "repo: BeFeast/maestro", "# owner/repo\nrepo: \"BeFeast/maestro\" # canonical", 1)
+	d, err := PrepareProject("d.yaml", []byte(presentationOnly))
+	if err != nil {
+		t.Fatalf("PrepareProject presentation-only: %v", err)
+	}
+	if a.Fingerprint != d.Fingerprint {
+		t.Fatalf("fingerprint moved for comments/scalar quoting: %s vs %s", a.Fingerprint, d.Fingerprint)
+	}
 	// A real config change must move the fingerprint.
-	changed := strings.Replace(genesisYAML, "~/src/maestro", "/srv/maestro", 1)
+	changed := strings.Replace(genesisYAML, "/srv/example-src/maestro", "/srv/changed-src/maestro", 1)
 	c, err := PrepareProject("c.yaml", []byte(changed))
 	if err != nil {
 		t.Fatalf("PrepareProject c: %v", err)
@@ -83,6 +92,10 @@ func TestPrepareProjectRejections(t *testing.T) {
 		{"missing repo", "local_path: ~/src/x\nworktree_base: ~/.wt/x\nproject_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301\n", "repo is required"},
 		{"missing local_path", "repo: BeFeast/maestro\nworktree_base: ~/.wt/x\nproject_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301\n", "local_path is required"},
 		{"missing worktree_base", "repo: BeFeast/maestro\nlocal_path: ~/src/x\nproject_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301\n", "worktree_base is required"},
+		{"invalid repo shape", strings.Replace(genesisYAML, "repo: BeFeast/maestro", "repo: maestro", 1), "owner/repository"},
+		{"relative local path", strings.Replace(genesisYAML, "local_path: /srv/example-src/maestro", "local_path: relative/src", 1), "absolute execution-host paths"},
+		{"missing management_home", "repo: BeFeast/maestro\nlocal_path: /srv/example-src/x\nworktree_base: /srv/example-worktrees/x\nproject_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301\n", "management_home is required"},
+		{"relative management_home", strings.Replace(genesisYAML, "path: /srv/example-vault/Dev/Areas/maestro", "path: relative/vault", 1), "management_home.path must be an absolute"},
 		{"invalid management_home", "repo: BeFeast/maestro\nlocal_path: ~/src/x\nworktree_base: ~/.wt/x\nproject_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301\nmanagement_home:\n  kind: notion\n", "not supported"},
 		{"shared backend definition", "repo: BeFeast/maestro\nlocal_path: ~/src/x\nworktree_base: ~/.wt/x\nproject_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301\nmodel:\n  default: claude\n  backends:\n    claude:\n      provider: claude\n", "must not define shared model.backends"},
 	}
@@ -165,16 +178,14 @@ func TestApplyProjectIdempotent(t *testing.T) {
 		t.Fatalf("after first apply names = %v, want [befeast-maestro]", names)
 	}
 
-	// A fresh prepare of the same bytes (the adapter re-reads the file) is a no-op.
+	// Retry the exact same approved command (including its now-stale `absent`
+	// baseline), as an adapter would after losing the first response. It must be
+	// a no-op rather than forcing a new plan.
 	p2, err := PrepareProject("portable.yaml", []byte(genesisYAML))
 	if err != nil {
 		t.Fatalf("re-prepare: %v", err)
 	}
-	secondPlan, err := store.PlanProject(ctx, p2)
-	if err != nil {
-		t.Fatalf("second plan: %v", err)
-	}
-	second, err := store.ApplyProject(ctx, p2, confirm, p2.Fingerprint, secondPlan.BaselineFingerprint)
+	second, err := store.ApplyProject(ctx, p2, confirm, p2.Fingerprint, BaselineAbsent)
 	if err != nil {
 		t.Fatalf("second apply: %v", err)
 	}
@@ -276,7 +287,7 @@ func TestApplyProjectRefusesStoreDriftSincePlan(t *testing.T) {
 
 	// Another process creates the same identity with different config after the
 	// plan. Apply must not reinterpret the approved create as an update.
-	drifted := strings.Replace(genesisYAML, "~/src/maestro", "/srv/concurrent-change", 1)
+	drifted := strings.Replace(genesisYAML, "/srv/example-src/maestro", "/srv/concurrent-change", 1)
 	if err := store.UpsertProject(ctx, p.Name, drifted); err != nil {
 		t.Fatalf("seed concurrent change: %v", err)
 	}
@@ -293,6 +304,82 @@ func TestApplyProjectRefusesStoreDriftSincePlan(t *testing.T) {
 	}
 	if cfg.LocalPath != "/srv/concurrent-change" {
 		t.Fatalf("apply overwrote concurrent config: local_path=%q", cfg.LocalPath)
+	}
+}
+
+func TestApplyProjectConcurrentSameIdentityCreatesAtMostOneRow(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "config.db")
+	storeA, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store A: %v", err)
+	}
+	defer storeA.Close()
+	storeB, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store B: %v", err)
+	}
+	defer storeB.Close()
+
+	pA, err := PrepareProject("a.yaml", []byte(genesisYAML))
+	if err != nil {
+		t.Fatalf("prepare A: %v", err)
+	}
+	otherYAML := strings.Replace(genesisYAML, "repo: BeFeast/maestro", "repo: BeFeast/other", 1)
+	pB, err := PrepareProject("b.yaml", []byte(otherYAML))
+	if err != nil {
+		t.Fatalf("prepare B: %v", err)
+	}
+	planA, err := storeA.PlanProject(ctx, pA)
+	if err != nil {
+		t.Fatalf("plan A: %v", err)
+	}
+	planB, err := storeB.PlanProject(ctx, pB)
+	if err != nil {
+		t.Fatalf("plan B: %v", err)
+	}
+	if planA.BaselineFingerprint != BaselineAbsent || planB.BaselineFingerprint != BaselineAbsent {
+		t.Fatalf("initial baselines = (%q, %q), want absent", planA.BaselineFingerprint, planB.BaselineFingerprint)
+	}
+
+	start := make(chan struct{})
+	ready := make(chan struct{}, 2)
+	results := make(chan error, 2)
+	apply := func(store *Store, p *PreparedProject, baseline string) {
+		ready <- struct{}{}
+		<-start
+		_, err := store.ApplyProject(ctx, p, p.ProjectID, p.Fingerprint, baseline)
+		results <- err
+	}
+	go apply(storeA, pA, planA.BaselineFingerprint)
+	go apply(storeB, pB, planB.BaselineFingerprint)
+	<-ready
+	<-ready
+	close(start)
+
+	successes := 0
+	for range 2 {
+		if err := <-results; err == nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("concurrent applies succeeded %d times, want exactly one", successes)
+	}
+
+	names, err := storeA.projectNames(ctx)
+	if err != nil {
+		t.Fatalf("list final projects: %v", err)
+	}
+	if len(names) != 1 {
+		t.Fatalf("concurrent applies created rows %v, want exactly one", names)
+	}
+	cfg, err := storeA.Load(ctx, names[0])
+	if err != nil {
+		t.Fatalf("load winning project: %v", err)
+	}
+	if cfg.ProjectID != pA.ProjectID {
+		t.Fatalf("winning project_id = %q, want %q", cfg.ProjectID, pA.ProjectID)
 	}
 }
 
@@ -364,5 +451,29 @@ func TestApplyProjectIdentityConflictOtherName(t *testing.T) {
 	// No new row was created for befeast-maestro.
 	if names, _ := store.projectNames(ctx); len(names) != 1 {
 		t.Fatalf("conflict created an extra row: %v", names)
+	}
+}
+
+func TestApplyProjectRejectsIdlessSameNameForDifferentRepo(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	legacy := strings.Replace(genesisYAML, "repo: BeFeast/maestro", "repo: Other/project", 1)
+	legacy = strings.Replace(legacy, "project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301\n", "", 1)
+	if err := store.UpsertProject(ctx, "befeast-maestro", legacy); err != nil {
+		t.Fatalf("seed id-less legacy row: %v", err)
+	}
+	p, err := PrepareProject("portable.yaml", []byte(genesisYAML))
+	if err != nil {
+		t.Fatalf("PrepareProject: %v", err)
+	}
+	plan, err := store.PlanProject(ctx, p)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if plan.Effect != EffectConflict || !strings.Contains(plan.Conflict, "basename adoption") {
+		t.Fatalf("plan = %+v, want repo conflict", plan)
+	}
+	if _, err := store.ApplyProject(ctx, p, p.ProjectID, p.Fingerprint, plan.BaselineFingerprint); !errors.Is(err, ErrIdentityConflict) {
+		t.Fatalf("apply err = %v, want identity conflict", err)
 	}
 }

--- a/internal/configstore/project_identity_test.go
+++ b/internal/configstore/project_identity_test.go
@@ -13,7 +13,7 @@ local_path: ~/src/maestro
 project_id: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
 management_home:
   kind: obsidian
-  path: /home/god/Obsidian/Dev
+  path: /srv/example-vault/Dev
   vault: Obsidian Vault
   vault_path: Dev/Areas/maestro
 `
@@ -37,7 +37,7 @@ func TestUpsertReloadExportLosslessForIdentity(t *testing.T) {
 		t.Fatalf("reloaded project_id = %q", cfg.ProjectID)
 	}
 	if cfg.ManagementHome.Kind != "obsidian" || cfg.ManagementHome.VaultPath != "Dev/Areas/maestro" ||
-		cfg.ManagementHome.Vault != "Obsidian Vault" || cfg.ManagementHome.Path != "/home/god/Obsidian/Dev" {
+		cfg.ManagementHome.Vault != "Obsidian Vault" || cfg.ManagementHome.Path != "/srv/example-vault/Dev" {
 		t.Fatalf("reloaded management_home lost fields: %+v", cfg.ManagementHome)
 	}
 
@@ -119,6 +119,27 @@ func TestUpsertProjectImmutableProjectID(t *testing.T) {
 	}
 	if cfg.ProjectID != "3f2504e0-4f89-41d3-9a0c-0305e82c3301" {
 		t.Fatalf("stored id changed after a rejected edit: %q", cfg.ProjectID)
+	}
+}
+
+func TestUpsertProjectNormalizesLegacyUppercaseProjectID(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	uppercase := strings.Replace(identityProjectYAML,
+		"3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+		"3F2504E0-4F89-41D3-9A0C-0305E82C3301", 1)
+	if err := store.UpsertProject(ctx, "befeast-maestro", uppercase); err != nil {
+		t.Fatalf("seed legacy uppercase id: %v", err)
+	}
+	if err := store.UpsertProject(ctx, "befeast-maestro", identityProjectYAML); err != nil {
+		t.Fatalf("same UUID in canonical lowercase should be allowed: %v", err)
+	}
+	cfg, err := store.Load(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("load normalized row: %v", err)
+	}
+	if cfg.ProjectID != "3f2504e0-4f89-41d3-9a0c-0305e82c3301" {
+		t.Fatalf("project_id = %q, want canonical lowercase", cfg.ProjectID)
 	}
 }
 

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -71,7 +71,7 @@ type Store struct {
 func Open(path string) (*Store, error) {
 	// busy_timeout makes a connection wait (up to 5s) for a lock instead of
 	// erroring with "database is locked" immediately: the daemon's watch-loop
-	// reads config.db (ProjectsFingerprint every tick, Load on add) while
+	// reads maestro.db (ProjectsFingerprint every tick, Load on add) while
 	// `config-store add/rm/edit` writes it from a SEPARATE process (#757). WAL
 	// lets a reader and a writer proceed concurrently across processes. The
 	// pragmas go in the DSN so modernc applies them to every pooled connection.
@@ -106,38 +106,196 @@ func OpenReadOnly(path string) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	u := &url.URL{Scheme: "file", Path: abs}
-	q := u.Query()
-	q.Set("mode", "ro")
-	walExists := pathExists(abs + "-wal")
-	shmExists := pathExists(abs + "-shm")
-	switch {
-	case !walExists && !shmExists:
-		// A closed/checkpointed DB has no WAL state to discover. Immutable mode
-		// prevents SQLite from creating read-lock sidecars, preserving the
-		// zero-file-write plan contract.
-		q.Set("immutable", "1")
-	case walExists != shmExists:
-		return nil, fmt.Errorf("config store has an incomplete WAL sidecar set; refusing zero-write read-only open")
+	snapshot, err := readSQLiteSnapshot(abs)
+	if err != nil {
+		return nil, err
 	}
-	q.Add("_pragma", "busy_timeout(5000)")
-	q.Add("_pragma", "query_only(1)")
-	u.RawQuery = q.Encode()
-	db, err := sql.Open("sqlite", u.String())
+	// Committed WAL frames are already overlaid. Mark the detached image as
+	// rollback-journal format so the in-memory connection never looks for a
+	// filesystem WAL after deserialization.
+	snapshot[18], snapshot[19] = 1, 1
+	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		return nil, err
 	}
 	db.SetMaxOpenConns(1)
-	if err := db.Ping(); err != nil {
+	db.SetMaxIdleConns(1)
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	err = conn.Raw(func(driverConn any) error {
+		deserializer, ok := driverConn.(interface{ Deserialize([]byte) error })
+		if !ok {
+			return fmt.Errorf("sqlite driver does not support in-memory deserialize")
+		}
+		return deserializer.Deserialize(snapshot)
+	})
+	conn.Close()
+	if err != nil {
 		db.Close()
 		return nil, err
 	}
 	return &Store{db: db}, nil
 }
 
-func pathExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
+// ExistingProjectCount inspects an existing store without changing its files.
+// A unified database that contains approvals/state tables but has not yet been
+// initialized as a config store reports zero projects.
+func ExistingProjectCount(path string) (int, error) {
+	store, err := OpenReadOnly(path)
+	if err != nil {
+		return 0, err
+	}
+	defer store.Close()
+	var tableCount int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'project'`).Scan(&tableCount); err != nil {
+		return 0, err
+	}
+	if tableCount == 0 {
+		return 0, nil
+	}
+	var count int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM project`).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// readSQLiteSnapshot reads the database and optional WAL twice. Returning only
+// equal pairs means a concurrent checkpoint/reset cannot produce a torn hybrid
+// snapshot. It never opens SQLite's locking or shared-memory files.
+func readSQLiteSnapshot(path string) ([]byte, error) {
+	const attempts = 5
+	for i := 0; i < attempts; i++ {
+		db1, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		wal1, err := readOptionalFile(path + "-wal")
+		if err != nil {
+			return nil, err
+		}
+		db2, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		wal2, err := readOptionalFile(path + "-wal")
+		if err != nil {
+			return nil, err
+		}
+		if bytes.Equal(db1, db2) && bytes.Equal(wal1, wal2) {
+			return applySQLiteWAL(db1, wal1)
+		}
+	}
+	return nil, fmt.Errorf("config store changed continuously while taking a zero-write snapshot; retry plan")
+}
+
+func readOptionalFile(path string) ([]byte, error) {
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	return b, err
+}
+
+// applySQLiteWAL reconstructs the last committed database image using SQLite's
+// documented WAL salts and cumulative checksums. A partial or uncommitted tail
+// is ignored; malformed committed state is rejected instead of guessed.
+func applySQLiteWAL(mainDB, wal []byte) ([]byte, error) {
+	if len(mainDB) < 100 || string(mainDB[:16]) != "SQLite format 3\x00" {
+		return nil, fmt.Errorf("invalid SQLite database header")
+	}
+	if len(wal) == 0 {
+		return append([]byte(nil), mainDB...), nil
+	}
+	if len(wal) < 32 {
+		return nil, fmt.Errorf("truncated SQLite WAL header")
+	}
+	magic := binary.BigEndian.Uint32(wal[0:4])
+	var order binary.ByteOrder
+	switch magic {
+	case 0x377f0682:
+		order = binary.LittleEndian
+	case 0x377f0683:
+		order = binary.BigEndian
+	default:
+		return nil, fmt.Errorf("invalid SQLite WAL magic 0x%x", magic)
+	}
+	if version := binary.BigEndian.Uint32(wal[4:8]); version != 3007000 {
+		return nil, fmt.Errorf("unsupported SQLite WAL format version %d", version)
+	}
+	pageSize := int(binary.BigEndian.Uint32(wal[8:12]))
+	if pageSize == 0 {
+		pageSize = 65536
+	}
+	if pageSize < 512 || pageSize > 65536 || pageSize&(pageSize-1) != 0 {
+		return nil, fmt.Errorf("invalid SQLite WAL page size %d", pageSize)
+	}
+	mainPageSize := int(binary.BigEndian.Uint16(mainDB[16:18]))
+	if mainPageSize == 1 {
+		mainPageSize = 65536
+	}
+	if pageSize != mainPageSize {
+		return nil, fmt.Errorf("SQLite WAL page size %d does not match database page size %d", pageSize, mainPageSize)
+	}
+	s0, s1 := walChecksum(order, 0, 0, wal[:24])
+	if s0 != binary.BigEndian.Uint32(wal[24:28]) || s1 != binary.BigEndian.Uint32(wal[28:32]) {
+		return nil, fmt.Errorf("invalid SQLite WAL header checksum")
+	}
+
+	frameSize := 24 + pageSize
+	frames := (len(wal) - 32) / frameSize
+	lastCommit, commitPages := -1, uint32(0)
+	for i := 0; i < frames; i++ {
+		off := 32 + i*frameSize
+		frame := wal[off : off+frameSize]
+		if !bytes.Equal(frame[8:16], wal[16:24]) {
+			break
+		}
+		s0, s1 = walChecksum(order, s0, s1, frame[:8])
+		s0, s1 = walChecksum(order, s0, s1, frame[24:])
+		if s0 != binary.BigEndian.Uint32(frame[16:20]) || s1 != binary.BigEndian.Uint32(frame[20:24]) {
+			break
+		}
+		if binary.BigEndian.Uint32(frame[0:4]) == 0 {
+			return nil, fmt.Errorf("invalid SQLite WAL page number 0")
+		}
+		if pages := binary.BigEndian.Uint32(frame[4:8]); pages > 0 {
+			lastCommit, commitPages = i, pages
+		}
+	}
+	if lastCommit < 0 {
+		return append([]byte(nil), mainDB...), nil
+	}
+	total := uint64(commitPages) * uint64(pageSize)
+	const maxGenesisSnapshotBytes = uint64(1 << 30)
+	if total == 0 || total > uint64(^uint(0)>>1) || total > maxGenesisSnapshotBytes {
+		return nil, fmt.Errorf("invalid SQLite WAL commit size %d", commitPages)
+	}
+	out := make([]byte, int(total))
+	copy(out, mainDB)
+	for i := 0; i <= lastCommit; i++ {
+		off := 32 + i*frameSize
+		pageNumber := binary.BigEndian.Uint32(wal[off : off+4])
+		if pageNumber > commitPages {
+			// A later committed transaction may shrink a database. Pages above
+			// its final size are intentionally omitted from the snapshot.
+			continue
+		}
+		start := int(pageNumber-1) * pageSize
+		copy(out[start:start+pageSize], wal[off+24:off+frameSize])
+	}
+	return out, nil
+}
+
+func walChecksum(order binary.ByteOrder, s0, s1 uint32, data []byte) (uint32, uint32) {
+	for i := 0; i+8 <= len(data); i += 8 {
+		s0 += order.Uint32(data[i:i+4]) + s1
+		s1 += order.Uint32(data[i+4:i+8]) + s0
+	}
+	return s0, s1
 }
 
 func (s *Store) Close() error {
@@ -535,7 +693,8 @@ ON CONFLICT(name) DO UPDATE SET config_yaml = excluded.config_yaml, updated_at =
 //   - incoming id empty            -> preserve the stored id (ordinary edits do
 //     not implicitly clear identity);
 //   - stored id empty              -> allowed (adding an id to a legacy id-less row);
-//   - stored == incoming           -> allowed (no change);
+//   - stored == incoming           -> allowed (UUID comparison ignores case so
+//     a legacy uppercase row can be normalized to canonical lowercase);
 //   - stored != incoming, both set -> REJECTED as an identity mismatch.
 //
 // A genuinely different id is an explicit migration concern, not an ordinary
@@ -562,7 +721,7 @@ func enforceImmutableProjectID(ctx context.Context, tx *sql.Tx, name string, inc
 		setMappingChild(incomingRoot, "project_id", &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: stored})
 		return nil
 	}
-	if stored != "" && stored != incoming {
+	if stored != "" && !strings.EqualFold(stored, incoming) {
 		return fmt.Errorf("project %q: project_id is immutable (stored %q, refusing to overwrite with %q); create a new project or run an explicit migration to change it", name, stored, incoming)
 	}
 	return nil

--- a/internal/configstore/store_test.go
+++ b/internal/configstore/store_test.go
@@ -1,6 +1,7 @@
 package configstore
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -70,6 +71,51 @@ supervisor:
 	fromStore.SettingsSources = nil // provenance map is set by Load, absent from Parse
 	if !reflect.DeepEqual(fromStore, fromYAML) {
 		t.Fatalf("store config differs from yaml\nstore=%#v\nyaml=%#v", fromStore.Model, fromYAML.Model)
+	}
+}
+
+func TestApplySQLiteWALValidatesHeaderChecksum(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "maestro.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertProject(ctx, "owner-demo", "repo: owner/demo\n"); err != nil {
+		t.Fatalf("seed WAL: %v", err)
+	}
+	mainDB, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read main database: %v", err)
+	}
+	wal, err := os.ReadFile(path + "-wal")
+	if err != nil {
+		t.Fatalf("read WAL: %v", err)
+	}
+	if _, err := applySQLiteWAL(mainDB, wal); err != nil {
+		t.Fatalf("valid WAL: %v", err)
+	}
+	corrupt := append([]byte(nil), wal...)
+	corrupt[24] ^= 0xff
+	if _, err := applySQLiteWAL(mainDB, corrupt); err == nil || !strings.Contains(err.Error(), "header checksum") {
+		t.Fatalf("corrupt WAL err = %v, want header checksum rejection", err)
+	}
+	badVersion := append([]byte(nil), wal...)
+	badVersion[7] ^= 0xff
+	if _, err := applySQLiteWAL(mainDB, badVersion); err == nil || !strings.Contains(err.Error(), "format version") {
+		t.Fatalf("bad-version WAL err = %v, want format-version rejection", err)
+	}
+	want, err := applySQLiteWAL(mainDB, wal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := applySQLiteWAL(mainDB, append(append([]byte(nil), wal...), 1, 2, 3, 4, 5))
+	if err != nil {
+		t.Fatalf("partial WAL tail should be ignored: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("partial WAL tail changed reconstructed snapshot")
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -307,8 +307,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if len(named) == 0 {
+	if len(named) == 0 && d.projectStore == nil {
 		return errors.New("config store has no projects")
+	}
+	if len(named) == 0 {
+		log.Printf("[daemon] config store has no projects yet — serving an empty fleet and waiting for --watch-store hot-add")
 	}
 
 	// Dedup on the flow's real identity (StateDir, falling back to Repo), not

--- a/internal/daemon/project_identity_reload_test.go
+++ b/internal/daemon/project_identity_reload_test.go
@@ -30,7 +30,7 @@ func TestIdentityChangedIgnoresProjectMetadata(t *testing.T) {
 		ProjectID:     "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
 		ManagementHome: config.ManagementHomeConfig{
 			Kind:      "obsidian",
-			Path:      "/home/god/Obsidian/Dev",
+			Path:      "/srv/example-vault/Dev",
 			Vault:     "Obsidian Vault",
 			VaultPath: "Dev/Areas/maestro",
 		},

--- a/internal/daemon/watch_test.go
+++ b/internal/daemon/watch_test.go
@@ -161,6 +161,37 @@ func TestWatchStoreLoopHotAddsAndRemoves(t *testing.T) {
 	}
 }
 
+func TestWatchStoreEmptyFleetWaitsForFirstProject(t *testing.T) {
+	store := newFakeWatchStore()
+	var run, sup loopTracker
+	d := newWatchDaemon(store, run.loop, sup.superviseLoop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	if names := fleetProjectNames(t, d); len(names) != 0 {
+		t.Fatalf("initial fleet projects = %v, want empty", names)
+	}
+	if got := atomic.LoadInt64(&run.started); got != 0 {
+		t.Fatalf("flows started before first row = %d, want 0", got)
+	}
+
+	store.Set("alpha", testConfig(t, "owner/alpha"))
+	waitForNames(t, d, "alpha")
+	waitFor(t, func() bool { return atomic.LoadInt64(&run.started) == 1 })
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancellation")
+	}
+}
+
 // A store-backed flow must receive a non-nil reload channel so an edited config
 // row hot-reloads its orchestrator (#757). A nil channel would silently disable
 // reload.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -487,7 +487,7 @@ func TestAutoCreatedPRBody_NoOrchestrationInternals(t *testing.T) {
 		IssueTitle:  "sanitize auto-created PR bodies",
 		PID:         4242,
 		TmuxSession: "maestro-mae-1",
-		Worktree:    "/home/god/worktrees/example/mae-1",
+		Worktree:    "/srv/example-worktrees/mae-1",
 	}
 	body := autoCreatedPRBody(sess, "feat/mae-1-799-sanitize")
 	if !strings.Contains(body, "Refs #799") {
@@ -496,7 +496,7 @@ func TestAutoCreatedPRBody_NoOrchestrationInternals(t *testing.T) {
 	if !strings.Contains(body, "feat/mae-1-799-sanitize") {
 		t.Fatalf("body missing branch name: %q", body)
 	}
-	for _, leak := range []string{"Maestro-Backend", "pid", "tmux", "state_dir", "4242", "maestro-mae-1", "/home/god"} {
+	for _, leak := range []string{"Maestro-Backend", "pid", "tmux", "state_dir", "4242", "maestro-mae-1", "/srv/example-worktrees"} {
 		if strings.Contains(body, leak) {
 			t.Fatalf("PR body leaks orchestration internals (%q): %q", leak, body)
 		}

--- a/internal/server/fleet_project_identity_test.go
+++ b/internal/server/fleet_project_identity_test.go
@@ -19,7 +19,7 @@ func TestProjectSnapshotExposesProjectIdentity(t *testing.T) {
 		ProjectID: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
 		ManagementHome: config.ManagementHomeConfig{
 			Kind:      "obsidian",
-			Path:      "/home/god/Obsidian/Dev",
+			Path:      "/srv/example-vault/Dev",
 			Vault:     "Obsidian Vault",
 			VaultPath: "Dev/Areas/maestro",
 		},
@@ -35,7 +35,7 @@ func TestProjectSnapshotExposesProjectIdentity(t *testing.T) {
 		t.Fatalf("payload management_home should be present")
 	}
 	if item.ManagementHome.Kind != "obsidian" || item.ManagementHome.VaultPath != "Dev/Areas/maestro" ||
-		item.ManagementHome.Vault != "Obsidian Vault" || item.ManagementHome.Path != "/home/god/Obsidian/Dev" {
+		item.ManagementHome.Vault != "Obsidian Vault" || item.ManagementHome.Path != "/srv/example-vault/Dev" {
 		t.Fatalf("management_home fields not surfaced verbatim: %+v", item.ManagementHome)
 	}
 	if item.EffectiveConfig.ProjectID != item.ProjectID || item.EffectiveConfig.ManagementHome == nil ||

--- a/internal/worker/attribution_test.go
+++ b/internal/worker/attribution_test.go
@@ -27,7 +27,7 @@ func attribCfgWithBackends() *config.Config {
 					Effort:   "medium",
 				},
 				"freellm": {
-					Cmd: "/home/god/.maestro/bin/maestro-freellm",
+					Cmd: "/srv/example-home/.maestro/bin/maestro-freellm",
 					// Intentionally no metadata — backends without
 					// declared attribution still work; UI shows "—".
 				},

--- a/internal/worker/reap_test.go
+++ b/internal/worker/reap_test.go
@@ -18,7 +18,7 @@ func TestSelectVisualQAKills_MatchesByCmdlineAndCwd(t *testing.T) {
 		// Matches: cwd is under the visual-QA temp dir (crashpad handler).
 		{PID: 102, Cmdline: "chrome_crashpad_handler", Cwd: "/tmp/scribe-visual-qa-abc123"},
 		// No match: generic chrome with an unrelated profile — must NOT be killed.
-		{PID: 103, Cmdline: "chrome --user-data-dir=/home/god/.config/google-chrome"},
+		{PID: 103, Cmdline: "chrome --user-data-dir=/srv/example-home/.config/google-chrome"},
 		// No match: unrelated process.
 		{PID: 104, Cmdline: "node server.js", Cwd: "/srv/app"},
 		// Ignored: non-positive PID is never selected.


### PR DESCRIPTION
Implements #880.

## Root cause

The read-only genesis path opened an active SQLite WAL database through the ordinary VFS. Even with `mode=ro`, SQLite mapped the WAL index read-write and changed `-shm` read marks. The project command and the rest of the single-daemon CLI also evolved with different default database names, while validation and docs still admitted pieces of the retired multi-process topology.

## What changed

- Build a stable in-memory SQLite snapshot from two equal main-DB/WAL reads, validate WAL salts and cumulative checksums, overlay only the last committed transaction, and deserialize without opening the live SHM file.
- Add an active-writer regression that byte-compares DB, WAL, and SHM before and after plan.
- Use `~/.maestro/maestro.db` consistently for daemon, project, config-store, settings, service guidance, and runbooks.
- Protect upgrades with legacy-store detection: default CLI use stays on a populated `config.db` with a migration warning, while the explicit canonical service fails closed instead of presenting an empty fleet.
- Fail closed on invalid store paths, non-GitHub/wrong-repo origins, relative execution paths, incomplete Management Home metadata, and same-name legacy rows belonging to another repository.
- Shell-quote generated next commands and keep flag-parse failures inside the versioned JSON error envelope.
- Normalize presentation-only YAML changes and legacy uppercase UUID casing without weakening identity immutability.
- Add a two-connection concurrent-apply regression proving at most one row wins for one durable identity.
- Let an empty `--watch-store` daemon serve a zero-project fleet and wait for the first genesis row instead of exiting.
- Rewrite active setup/operations guidance around one daemon, one store, and the built-in Mission Control; retain old units and fleet files only as explicit migration context.
- Replace host-specific paths in public examples and fixtures with neutral paths.

## Validation

- `go test ./...`
- `go vet ./...`
- concurrent apply regression repeated 50 times; prior race-detector run passed
- `bun test && bun run build`
- `sh -n install.sh`
- `git diff --check`
- isolated runtime cycle: zero-write create plan, exact apply, then no-op plan
- fresh-install runtime cycle: empty daemon stayed healthy, hot-loaded exactly one first row, accepted an exact stale-baseline apply retry as no-op, then reconciled explicit removal back to zero flows
- isolated active-WAL daemon: DB/WAL/SHM hashes unchanged across three plans
- live unified database: plan reported the expected existing project and all three hashes remained unchanged; no live row was applied or changed

The temporary hot-load/apply/cleanup production canary remains an explicit post-merge gate, after CI and review are green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens project genesis and unifies the single-daemon store workflow. The main changes are:

- Builds read-only SQLite snapshots without modifying live WAL or SHM files.
- Standardizes the default fleet database as `~/.maestro/maestro.db`.
- Protects upgrades that still use the legacy project store.
- Strengthens project path, repository, identity, and metadata validation.
- Adds concurrent apply and empty-fleet daemon coverage.
- Updates setup and operations guidance for the single-daemon model.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The legacy inspection failure now stays on the legacy store instead of selecting the canonical store. The explicit canonical service fails closed when compatibility inspection cannot complete. No additional blocking issue qualifies for this follow-up review.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated memory invariants by confirming the DB, WAL, and SHM digests remained identical before and after the operation.
- Verified the project row count stayed at 0 before and after, and the harness reported a successful run with exit code 0 and ALL\_THREE\_FILES\_IDENTICAL=true.
- Concluded the contract validation shows all three tracked files are identical, indicating no unintended changes occurred during the run.

<a href="https://app.greptile.com/trex/runs/14180462/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/maestro/daemon.go | Adds compatibility-aware store selection and prevents the canonical service from starting against an empty store during migration. |
| cmd/maestro/project.go | Strengthens genesis validation, JSON error handling, command quoting, store checks, and daemon reconciliation guidance. |
| internal/configstore/store.go | Adds stable SQLite snapshot and WAL processing for zero-write project planning. |
| internal/configstore/genesis.go | Hardens project identity, metadata normalization, and concurrent apply behavior. |
| internal/daemon/daemon.go | Allows a watched daemon to remain active with an empty fleet and reconcile the first project row. |

<sub>Reviews (3): Last reviewed commit: ["fix: report implicit daemon stores safel..."](https://github.com/befeast/maestro/commit/d7dc6ae5960bd6831690e32cecbbde3420df938d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43697946)</sub>

<!-- /greptile_comment -->