### PR TITLE
fix: self-deploy restart no longer kills in-flight tmux workers (#877)

### DIFF
--- a/docs/self-deploy-runbook.md
+++ b/docs/self-deploy-runbook.md
@@ -58,6 +58,27 @@ The script then:
    stop path runs, so existing **drain semantics are honored**: if your unit
    declares `ExecStop=... drain`, in-flight workers finish before the stop
    completes. Budget for this in `timeout_minutes`.
+
+   **Cgroup / kill ownership — in-flight workers span the restart (#877).** A
+   restart of `maestro.service` must not kill in-flight tmux workers before the
+   drain completes. Two things guarantee that, and both live in-repo:
+   - `maestro.service` declares **`KillMode=process`** (not the systemd default
+     `control-group`). The unit's stop/restart kill is scoped to the daemon's
+     *main* process, so systemd never SIGTERM/SIGKILLs the rest of the unit's
+     control group. The default `control-group` would sweep the worker tmux
+     server and every Claude worker out with the daemon — even while the
+     daemon's in-process drain still reported them running — and the next daemon
+     would mark them `running -> dead` (the 2026-07-12 incident).
+   - maestro launches each worker's tmux server inside a transient
+     **`systemd-run --user --scope`** cgroup (`internal/worker/spawn.go`), a
+     *sibling* of `maestro.service` rather than a child. The worker (and its
+     dirty worktree) therefore outlives a restart of the daemon unit; on the
+     next start the orchestrator re-attaches to the still-live pane instead of a
+     false `running -> dead` (`adoptSurvivingTmux`). On a host without a usable
+     user manager the scope launch degrades to an in-cgroup launch, and
+     `KillMode=process` is the belt that still keeps that worker alive. This
+     makes permanent the manual workaround (resume the run scripts in a tmux
+     server outside the service cgroup).
 4. **Verifies health** — the installed CLI must report the stamped version
    (`maestro version` → `maestro v<VERSION>+g<shortsha>`), every unit must be
    `active`, and (when a health URL is configured) the **running process**

--- a/internal/config/systemd_unit_test.go
+++ b/internal/config/systemd_unit_test.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #877: a self-deploy `systemctl restart maestro.service` must not kill
+// in-flight tmux workers before the daemon's in-process drain completes. The
+// root cause was the shipped unit relying on the systemd default
+// KillMode=control-group, which SIGTERM/SIGKILLs the WHOLE cgroup — including
+// worker tmux servers spawned as daemon descendants. These tests pin the
+// production unit topology so a future edit cannot silently reintroduce the
+// cgroup-sweep hazard.
+func readServiceUnit(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join("..", "..", "maestro.service")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	return string(data)
+}
+
+func TestServiceUnit_KillModeIsProcessNotControlGroup(t *testing.T) {
+	unit := readServiceUnit(t)
+
+	// The unit must declare KillMode=process explicitly: the stop/restart kill
+	// is scoped to the daemon's main process, so worker tmux servers are never
+	// swept out of the cgroup by a self-deploy restart.
+	if !unitHasDirective(unit, "KillMode", "process") {
+		t.Fatalf("maestro.service must declare KillMode=process (explicit kill ownership, #877)")
+	}
+
+	// The default control-group kill is exactly the hazard #877 fixed; it must
+	// not be reintroduced.
+	if unitHasDirective(unit, "KillMode", "control-group") {
+		t.Fatalf("maestro.service must NOT use KillMode=control-group — it sweeps in-flight workers (#877)")
+	}
+}
+
+func TestServiceUnit_DrainTopologyIntact(t *testing.T) {
+	unit := readServiceUnit(t)
+
+	// The in-process drain needs room before systemd escalates to SIGKILL, and
+	// there is no per-unit ExecStop=maestro drain in the single-service world.
+	// Scan directives, not comments (the rationale comment mentions ExecStop).
+	if !unitHasKey(unit, "TimeoutStopSec") {
+		t.Fatalf("maestro.service must set TimeoutStopSec to give the in-process drain room before SIGKILL")
+	}
+	if unitHasKey(unit, "ExecStop") {
+		t.Fatalf("maestro.service must not declare ExecStop — the single-service daemon drains in-process on SIGTERM (#761)")
+	}
+}
+
+func TestServiceUnit_DocumentsCgroupOwnership(t *testing.T) {
+	unit := readServiceUnit(t)
+
+	// Acceptance criterion: KillMode / scope ownership is explicit and
+	// documented. The unit must reference the issue and the out-of-cgroup scope
+	// mechanism so the topology is self-explaining to an operator.
+	if !strings.Contains(unit, "#877") {
+		t.Fatalf("maestro.service should document the cgroup/kill ownership rationale (#877)")
+	}
+	if !strings.Contains(unit, "systemd-run") && !strings.Contains(unit, "scope") {
+		t.Fatalf("maestro.service should document that worker tmux servers run in a scope outside the unit cgroup")
+	}
+}
+
+// unitHasDirective reports whether a systemd unit sets key=value on a
+// non-comment line (comment lines start with '#').
+func unitHasDirective(unit, key, value string) bool {
+	want := key + "=" + value
+	for _, line := range strings.Split(unit, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if trimmed == want {
+			return true
+		}
+	}
+	return false
+}
+
+// unitHasKey reports whether a systemd unit assigns key= on any non-comment
+// line (a directive), ignoring comments that merely mention the key.
+func unitHasKey(unit, key string) bool {
+	for _, line := range strings.Split(unit, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, key+"=") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -58,6 +59,7 @@ type Orchestrator struct {
 	enhancementPromptBase string
 	pidAliveFn            func(pid int) bool
 	tmuxSessionExistsFn   func(name string) bool
+	tmuxPanePIDFn         func(name string) int
 	listOpenPRsFn         func() ([]github.PR, error)
 	remoteBranchExistsFn  func(branch string) (bool, error)
 	createPRFn            func(title, body, base, head string) (int, error)
@@ -259,6 +261,58 @@ func (o *Orchestrator) tmuxSessionExists(name string) bool {
 		return false
 	}
 	return exec.Command("tmux", "has-session", "-t", name).Run() == nil
+}
+
+// tmuxPanePID returns the live pane PID of tmux session name, or 0 if the
+// session is gone or its PID cannot be read.
+func (o *Orchestrator) tmuxPanePID(name string) int {
+	if o.tmuxPanePIDFn != nil {
+		return o.tmuxPanePIDFn(name)
+	}
+	if name == "" {
+		return 0
+	}
+	out, err := exec.Command("tmux", "list-panes", "-t", name, "-F", "#{pane_pid}").Output()
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0
+	}
+	return pid
+}
+
+// adoptSurvivingTmux handles the #877 case where a running session's recorded
+// pane PID reads dead but its tmux session is still live. Because maestro
+// launches worker tmux servers in a transient `systemd-run --user --scope`
+// cgroup outside maestro.service (internal/worker/spawn.go), a self-deploy
+// restart of the daemon leaves the worker running; the recorded PID is normally
+// still alive across the restart, but if it went stale (e.g. a phase transition
+// the previous daemon did not persist) a naive liveness check would declare a
+// false running->dead — stranding the dirty worktree and re-dispatching a
+// duplicate. When the tmux session survives with a live pane, adopt it: refresh
+// the recorded PID/session and keep the session running exactly once. Returns
+// true when the session was adopted (caller should treat it as still live).
+func (o *Orchestrator) adoptSurvivingTmux(slotName string, sess *state.Session) bool {
+	tmuxName := sess.TmuxSession
+	if tmuxName == "" {
+		tmuxName = worker.TmuxSessionName(slotName)
+	}
+	if !o.tmuxSessionExists(tmuxName) {
+		return false
+	}
+	pid := o.tmuxPanePID(tmuxName)
+	if pid <= 0 || !o.pidAlive(pid) {
+		return false
+	}
+	if pid != sess.PID {
+		log.Printf("[orch] reconcile: %s tmux session %s survived a daemon restart with a live pane (pid %d, recorded %d) — adopting, no running->dead transition (#877)",
+			slotName, tmuxName, pid, sess.PID)
+	}
+	sess.PID = pid
+	sess.TmuxSession = tmuxName
+	return true
 }
 
 func (o *Orchestrator) listOpenPRs() ([]github.PR, error) {
@@ -2832,6 +2886,15 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 			continue
 		}
 
+		// #877: the recorded pane PID reads dead/missing but the tmux session is
+		// still live — the worker survived a self-deploy restart in its transient
+		// scope outside maestro.service's cgroup. Adopt the surviving pane (refresh
+		// the recorded PID) rather than a false running->dead + duplicate dispatch.
+		if o.adoptSurvivingTmux(slotName, sess) {
+			reconciled = true
+			continue
+		}
+
 		// Worker process/session is gone. Before marking dead, check whether it
 		// already opened a PR. If so, transition to pr_open — the worker succeeded.
 		// Without this check, reconcile would mark the session dead, causing
@@ -3628,6 +3691,15 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				now := time.Now().UTC()
 				sess.FinishedAt = &now
 				state.MarkWorkerEnded(sess, now)
+				continue
+			}
+
+			// #877: a worker's tmux server runs in a transient scope outside
+			// maestro.service's cgroup, so it (and the worker) survive a
+			// self-deploy restart of the daemon. If the recorded pane PID reads
+			// dead but the tmux session is still live, adopt the surviving pane
+			// rather than declaring a false running->dead over a live worker.
+			if sess.PID > 0 && !o.pidAlive(sess.PID) && o.adoptSurvivingTmux(slotName, sess) {
 				continue
 			}
 

--- a/internal/orchestrator/restart_survive_test.go
+++ b/internal/orchestrator/restart_survive_test.go
@@ -1,0 +1,113 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #877: a self-deploy restart of maestro.service must not kill in-flight tmux
+// workers. maestro launches worker tmux servers in a transient `systemd-run
+// --user --scope` cgroup that is a sibling of the unit, so a worker (and its
+// dirty worktree) spans the restart and the next daemon re-attaches to the
+// still-live pane. The recorded pane PID is normally still alive across the
+// restart; but if it went stale while the tmux session survived, the reconcile
+// must adopt the surviving pane instead of a false running->dead + duplicate
+// dispatch.
+
+// TestReconcileRunningSessions_AdoptsSurvivingTmuxAcrossRestart drives the whole
+// reconcile: a running session whose recorded PID reads dead but whose tmux
+// session survives with a live pane must stay running (PID refreshed), not be
+// marked dead. A false dead here strands the dirty worktree and re-dispatches a
+// duplicate worker.
+func TestReconcileRunningSessions_AdoptsSurvivingTmuxAcrossRestart(t *testing.T) {
+	const stalePID, livePanePID = 4242, 9999
+
+	o := &Orchestrator{
+		cfg:        &config.Config{Repo: "owner/repo"},
+		pidAliveFn: func(pid int) bool { return pid == livePanePID },
+		tmuxSessionExistsFn: func(name string) bool {
+			return name == "maestro-slot-1" // the worker's tmux server survived the restart
+		},
+		tmuxPanePIDFn: func(name string) int {
+			if name == "maestro-slot-1" {
+				return livePanePID
+			}
+			return 0
+		},
+		listOpenPRsFn: func() ([]github.PR, error) { return []github.PR{}, nil },
+	}
+
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 310,
+		IssueTitle:  "in-flight dogfood worker",
+		Status:      state.StatusRunning,
+		PID:         stalePID,
+		TmuxSession: "maestro-slot-1",
+		Branch:      "feat/slot-1-310-x",
+		Worktree:    "/wt/slot-1", // dirty worktree must survive
+	}
+
+	o.reconcileRunningSessions(s)
+
+	sess := s.Sessions["slot-1"]
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want running (surviving worker must not be marked dead) (#877)", sess.Status)
+	}
+	if sess.PID != livePanePID {
+		t.Fatalf("PID = %d, want %d (adopt the surviving pane's live pid)", sess.PID, livePanePID)
+	}
+	if sess.Worktree != "/wt/slot-1" {
+		t.Fatalf("Worktree = %q, want preserved", sess.Worktree)
+	}
+	if sess.FinishedAt != nil {
+		t.Fatalf("FinishedAt = %v, want nil (worker still running)", sess.FinishedAt)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatalf("NextRetryAt = %v, want nil (no retry — the worker never died)", sess.NextRetryAt)
+	}
+}
+
+func TestAdoptSurvivingTmux(t *testing.T) {
+	newOrch := func(sessionExists bool, panePID int, live func(int) bool) *Orchestrator {
+		return &Orchestrator{
+			cfg:                 &config.Config{Repo: "owner/repo"},
+			pidAliveFn:          live,
+			tmuxSessionExistsFn: func(string) bool { return sessionExists },
+			tmuxPanePIDFn:       func(string) int { return panePID },
+		}
+	}
+
+	t.Run("adopts a live surviving session and refreshes the pid", func(t *testing.T) {
+		o := newOrch(true, 9999, func(pid int) bool { return pid == 9999 })
+		sess := &state.Session{Status: state.StatusRunning, PID: 4242, TmuxSession: "maestro-slot-1"}
+		if !o.adoptSurvivingTmux("slot-1", sess) {
+			t.Fatal("expected adoption of a surviving tmux session")
+		}
+		if sess.PID != 9999 {
+			t.Fatalf("PID = %d, want 9999 (refreshed to the live pane)", sess.PID)
+		}
+	})
+
+	t.Run("does not adopt when the tmux session is gone", func(t *testing.T) {
+		o := newOrch(false, 0, func(int) bool { return false })
+		sess := &state.Session{Status: state.StatusRunning, PID: 4242, TmuxSession: "maestro-slot-1"}
+		if o.adoptSurvivingTmux("slot-1", sess) {
+			t.Fatal("must not adopt when the session is truly gone — that is a real death")
+		}
+		if sess.PID != 4242 {
+			t.Fatalf("PID = %d, want unchanged 4242", sess.PID)
+		}
+	})
+
+	t.Run("does not adopt a session whose pane pid is dead", func(t *testing.T) {
+		o := newOrch(true, 9999, func(int) bool { return false }) // pane pid not alive
+		sess := &state.Session{Status: state.StatusRunning, PID: 4242, TmuxSession: "maestro-slot-1"}
+		if o.adoptSurvivingTmux("slot-1", sess) {
+			t.Fatal("must not adopt when the surviving session's pane is dead")
+		}
+	})
+}

--- a/internal/supervisor/restart_worker_test.go
+++ b/internal/supervisor/restart_worker_test.go
@@ -6,6 +6,84 @@ import (
 	"github.com/befeast/maestro/internal/state"
 )
 
+// #877 reproduction: a self-deploy `systemctl restart maestro.service` used to
+// kill in-flight tmux workers before the in-process drain completed, because the
+// worker tmux server shared the unit's control group. The fix launches worker
+// tmux servers in a transient scope outside that cgroup, so a worker spans the
+// restart. This test models that survival at the supervisor layer: two in-flight
+// workers whose recorded pane PIDs read dead after the restart but whose tmux
+// sessions are still live must NOT raise a "dead_running_pid" blocked finding —
+// which would nudge an operator to reconcile a genuinely-live worker to dead.
+func TestSupervisor_SurvivingTmuxWorkersNotFlaggedDeadAfterRestart(t *testing.T) {
+	cfg := testConfig(t)
+	st := state.NewState()
+	for _, slot := range []string{"sup-310", "sup-311"} {
+		st.Sessions[slot] = &state.Session{
+			IssueNumber: 310,
+			IssueTitle:  "in-flight dogfood worker",
+			Status:      state.StatusRunning,
+			PID:         424242, // stale recorded pid after the restart
+			TmuxSession: "maestro-" + slot,
+			Worktree:    "/wt/" + slot, // dirty worktree must survive
+			StartedAt:   testEngineNow(),
+		}
+	}
+
+	eng := testEngine(cfg, &fakeReader{})
+	eng.pidAlive = func(pid int) bool { return false }     // recorded pids are stale
+	eng.tmuxAlive = func(name string) bool { return true } // tmux servers survived the restart
+
+	decision, err := eng.Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == "dead_running_pid" {
+			t.Fatalf("surviving worker flagged dead_running_pid across a restart (%s) — false running->dead (#877)", stuck.Summary)
+		}
+	}
+	// The dirty worktrees and running status must be intact for the resume.
+	if got := st.RunningSessionCount(); got != 2 {
+		t.Fatalf("RunningSessionCount = %d, want 2 (surviving workers stay in-flight so drain waits)", got)
+	}
+}
+
+// The survival guard must not blanket-suppress the finding: a worker whose PID
+// AND tmux session are both gone is genuinely dead and must still be flagged.
+func TestSupervisor_TrulyDeadWorkerStillFlagged(t *testing.T) {
+	cfg := testConfig(t)
+	st := state.NewState()
+	st.Sessions["sup-312"] = &state.Session{
+		IssueNumber: 312,
+		IssueTitle:  "genuinely dead worker",
+		Status:      state.StatusRunning,
+		PID:         424242,
+		TmuxSession: "maestro-sup-312",
+		StartedAt:   testEngineNow(),
+	}
+
+	eng := testEngine(cfg, &fakeReader{})
+	eng.pidAlive = func(pid int) bool { return false }
+	eng.tmuxAlive = func(name string) bool { return false } // tmux session also gone
+
+	decision, err := eng.Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if _, found := findStuckState(decision, "dead_running_pid"); !found {
+		t.Fatal("a worker with both PID and tmux session gone must still be flagged dead_running_pid")
+	}
+}
+
+func findStuckState(decision state.SupervisorDecision, code string) (state.SupervisorStuckState, bool) {
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == code {
+			return stuck, true
+		}
+	}
+	return state.SupervisorStuckState{}, false
+}
+
 // #874: after a restart tears down the worktree, the session's stale
 // worktree/PR pointers must be cleared so respawnDueRetries fresh-respawns
 // instead of choosing RespawnInPlace against a directory that no longer exists.

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -180,6 +180,7 @@ type Engine struct {
 	llm               LLMClient
 	now               func() time.Time
 	pidAlive          func(pid int) bool
+	tmuxAlive         func(name string) bool
 	stat              func(name string) (os.FileInfo, error)
 	lookPath          func(file string) (string, error)
 	preflight         PreflightRunner
@@ -205,6 +206,7 @@ func NewEngine(cfg *config.Config, reader Reader) *Engine {
 		reader:            reader,
 		now:               func() time.Time { return time.Now().UTC() },
 		pidAlive:          pidAlive,
+		tmuxAlive:         tmuxSessionAlive,
 		stat:              os.Stat,
 		lookPath:          exec.LookPath,
 		preflight:         defaultPreflightRunner,
@@ -1500,12 +1502,19 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time, cache *
 		target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}
 
 		if sess.Status == state.StatusRunning {
-			if sess.PID <= 0 {
+			// #877: a worker's tmux server runs in a transient scope outside
+			// maestro.service's cgroup, so it survives a self-deploy restart of
+			// the daemon. A live tmux session therefore means the worker is still
+			// executing even when the recorded pane PID went stale across the
+			// restart — do not raise a "dead running pid" finding that would nudge
+			// an operator to reconcile a genuinely-live worker to dead.
+			tmuxLive := e.tmuxAlive(workerTmuxName(slot, sess))
+			if sess.PID <= 0 && !tmuxLive {
 				findings = append(findings, stuckState("dead_running_pid", SeverityBlocked,
 					fmt.Sprintf("Worker %s is marked running, but no live process is recorded.", slot),
 					"Run a Maestro reconciliation cycle or inspect the worker before dispatching more work.", true, target,
 					fmt.Sprintf("Session %s status=running pid=%d", slot, sess.PID)))
-			} else if !e.pidAlive(sess.PID) {
+			} else if sess.PID > 0 && !e.pidAlive(sess.PID) && !tmuxLive {
 				findings = append(findings, stuckState("dead_running_pid", SeverityBlocked,
 					fmt.Sprintf("Worker %s is marked running, but PID %d is not alive.", slot, sess.PID),
 					"Run a Maestro reconciliation cycle so the session can be marked dead and retried if eligible.", true, target,
@@ -3953,6 +3962,27 @@ func pidAlive(pid int) bool {
 		return false
 	}
 	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// tmuxSessionAlive reports whether the worker's detached tmux session exists.
+// Because maestro launches worker tmux servers in a transient scope outside
+// maestro.service's cgroup (#877), a worker survives a self-deploy restart of
+// the daemon; a live tmux session means the runner script is still executing,
+// even if the recorded pane PID went stale across the restart.
+func tmuxSessionAlive(name string) bool {
+	if name == "" {
+		return false
+	}
+	return exec.Command("tmux", "has-session", "-t", name).Run() == nil
+}
+
+// workerTmuxName returns the tmux session name for a running session, falling
+// back to the derived name when the session did not record one.
+func workerTmuxName(slot string, sess *state.Session) string {
+	if sess != nil && sess.TmuxSession != "" {
+		return sess.TmuxSession
+	}
+	return worker.TmuxSessionName(slot)
 }
 
 func stuckState(code, severity, summary, recommendedAction string, supervisorCanAct bool, target *state.SupervisorTarget, evidence ...string) state.SupervisorStuckState {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -221,6 +221,9 @@ func testEngine(cfg *config.Config, reader *fakeReader) *Engine {
 	eng := NewEngine(cfg, reader)
 	eng.now = func() time.Time { return time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC) }
 	eng.pidAlive = func(pid int) bool { return true }
+	// Deterministic tmux liveness: no surviving worker tmux session in unit
+	// tests (avoids shelling out to a real tmux). #877 tests override this.
+	eng.tmuxAlive = func(name string) bool { return false }
 	eng.lookPath = func(file string) (string, error) { return file, nil }
 	// Isolate the in-process enrollment dedup (#569) so each test starts
 	// with an empty set and does not bleed state into sibling tests.

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -169,8 +169,7 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 	}
 
 	// Start tmux session in existing worktree
-	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", sess.Worktree, "bash", runnerPath)
-	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+	if tmuxOut, err := LaunchTmuxSession(tmuxName, sess.Worktree, runnerPath); err != nil {
 		return fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
 	}
 

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -91,8 +91,7 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 	}
 
 	// Start tmux session
-	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", sess.Worktree, "bash", runnerPath)
-	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+	if tmuxOut, err := LaunchTmuxSession(tmuxName, sess.Worktree, runnerPath); err != nil {
 		return fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
 	}
 

--- a/internal/worker/spawn.go
+++ b/internal/worker/spawn.go
@@ -1,0 +1,103 @@
+package worker
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// spawn.go centralizes how a worker's detached tmux session is launched.
+//
+// The bug (#877): `maestro daemon` runs as maestro.service; each worker's tmux
+// server is started with `exec.Command("tmux", "new-session", ...)`, so — being
+// a descendant of the daemon — it lands in maestro.service's control group. On
+// a self-deploy the deploy script runs `systemctl restart maestro.service`;
+// with the unit's kill semantics that restart terminated the WHOLE cgroup —
+// tmux server and in-flight Claude workers included — even while the daemon's
+// in-process drain still reported those workers running, and the next daemon
+// marked them running->dead over surviving dirty worktrees.
+//
+// The fix: when running under systemd, launch the tmux server inside a transient
+// `systemd-run --user --scope` cgroup. A scope unit is a SIBLING of
+// maestro.service, not a child, so a restart of maestro.service no longer sweeps
+// the worker out — the worker (and its dirty worktree) spans the deploy and the
+// next daemon re-attaches to the still-live pane. This makes permanent the
+// operator's manual workaround (resume the run scripts in a tmux server outside
+// the service cgroup). On a host without a usable user manager the scope launch
+// degrades to a bare in-cgroup tmux launch (protected in turn by the unit's
+// KillMode=process), so worker spawning never hard-fails on scope unavailability.
+
+// tmuxNewSessionArgv is the bare argv that starts a worker's detached tmux
+// session running runnerPath (via bash) in workdir.
+func tmuxNewSessionArgv(tmuxName, workdir, runnerPath string) []string {
+	return []string{"tmux", "new-session", "-d", "-s", tmuxName, "-c", workdir, "bash", runnerPath}
+}
+
+// scopeWrapArgv wraps a command argv in `systemd-run --user --scope` so the
+// process it starts — here the detached tmux server — is placed in a transient
+// scope cgroup that is a sibling of maestro.service rather than a child of it
+// (#877). --collect unloads the scope once it empties (the last worker exits);
+// the `--` terminates systemd-run's own option parsing so the wrapped argv is
+// passed through verbatim.
+func scopeWrapArgv(argv []string) []string {
+	wrap := []string{
+		"systemd-run", "--user", "--scope", "--collect",
+		"--description=maestro worker tmux server (out-of-cgroup, #877)",
+		"--",
+	}
+	return append(wrap, argv...)
+}
+
+// runUnderSystemdScope reports whether worker tmux servers should be launched in
+// a transient systemd scope outside the daemon's service cgroup. True only when
+// the daemon is running inside a systemd unit (systemd sets INVOCATION_ID for a
+// unit's processes) AND `systemd-run` is on PATH. Otherwise a bare tmux launch
+// is used — non-systemd hosts, CI, and tests, where the cgroup hazard does not
+// exist. MAESTRO_TMUX_NO_SCOPE=1 force-disables the scope path as an operator
+// escape hatch. Indirected through a var so tests can pin the decision.
+var runUnderSystemdScope = func() bool {
+	if os.Getenv("MAESTRO_TMUX_NO_SCOPE") == "1" {
+		return false
+	}
+	if os.Getenv("INVOCATION_ID") == "" {
+		return false
+	}
+	_, err := exec.LookPath("systemd-run")
+	return err == nil
+}
+
+// execTmuxCombined runs argv and returns its combined output. Indirected through
+// a var so tests can observe the exact argv and simulate launch failures without
+// spawning a real tmux/systemd-run.
+var execTmuxCombined = func(argv []string) ([]byte, error) {
+	return exec.Command(argv[0], argv[1:]...).CombinedOutput()
+}
+
+// LaunchTmuxSession starts a worker's detached tmux session running runnerPath
+// in workdir. Under systemd it launches the tmux server inside a transient
+// `systemd-run --user --scope` cgroup so a `systemctl restart` of maestro.service
+// (self-deploy) does not sweep the in-flight worker out with the daemon (#877).
+// If the scope launch fails (e.g. no user manager / DBus in the daemon's
+// environment) it clears any partially-created session and falls back to a bare
+// in-cgroup tmux launch, so worker spawning still succeeds — it just won't
+// survive a service restart on that host. Returns the launcher's combined output
+// (for error context) and error.
+func LaunchTmuxSession(tmuxName, workdir, runnerPath string) ([]byte, error) {
+	base := tmuxNewSessionArgv(tmuxName, workdir, runnerPath)
+	if !runUnderSystemdScope() {
+		return execTmuxCombined(base)
+	}
+	out, err := execTmuxCombined(scopeWrapArgv(base))
+	if err == nil {
+		return out, nil
+	}
+	// The scope launch failed. systemd-run typically errors before exec (no
+	// user manager / DBus), so the session usually was never created — but be
+	// defensive: clear any partial session so the fallback new-session cannot
+	// fail on a duplicate name, then retry in-cgroup.
+	log.Printf("[worker] systemd-run scope launch of tmux session %s failed (%v); falling back to in-cgroup launch — this worker will NOT survive a service restart on this host: %s",
+		tmuxName, err, strings.TrimSpace(string(out)))
+	_, _ = execTmuxCombined([]string{"tmux", "kill-session", "-t", tmuxName})
+	return execTmuxCombined(base)
+}

--- a/internal/worker/spawn_test.go
+++ b/internal/worker/spawn_test.go
@@ -1,0 +1,133 @@
+package worker
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// #877: a worker's tmux server must be launched outside maestro.service's
+// control group so a self-deploy `systemctl restart` cannot sweep an in-flight
+// worker out with the daemon. These tests pin the argv the launcher builds and
+// its fallback behavior when the scope launch is unavailable.
+
+func TestTmuxNewSessionArgv(t *testing.T) {
+	got := tmuxNewSessionArgv("maestro-slot-1", "/wt/slot-1", "/state/slot-1-run.sh")
+	want := []string{"tmux", "new-session", "-d", "-s", "maestro-slot-1", "-c", "/wt/slot-1", "bash", "/state/slot-1-run.sh"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tmuxNewSessionArgv = %v, want %v", got, want)
+	}
+}
+
+func TestScopeWrapArgv(t *testing.T) {
+	base := tmuxNewSessionArgv("maestro-slot-1", "/wt/slot-1", "/state/slot-1-run.sh")
+	got := scopeWrapArgv(base)
+
+	// systemd-run --user --scope places the tmux server in a transient scope
+	// cgroup that is a SIBLING of maestro.service.
+	if got[0] != "systemd-run" {
+		t.Fatalf("scope argv[0] = %q, want systemd-run", got[0])
+	}
+	if !contains(got, "--user") || !contains(got, "--scope") {
+		t.Fatalf("scope argv missing --user/--scope: %v", got)
+	}
+	// The `--` terminator must precede the wrapped command so tmux's own args
+	// are never parsed by systemd-run.
+	dashIdx, tmuxIdx := indexOf(got, "--"), indexOf(got, "tmux")
+	if dashIdx < 0 || tmuxIdx < 0 || dashIdx >= tmuxIdx {
+		t.Fatalf("expected `--` before tmux in %v (dash=%d tmux=%d)", got, dashIdx, tmuxIdx)
+	}
+	// The wrapped command must be the base argv verbatim, in order.
+	if !reflect.DeepEqual(got[tmuxIdx:], base) {
+		t.Fatalf("wrapped argv = %v, want base %v", got[tmuxIdx:], base)
+	}
+}
+
+func TestLaunchTmuxSession_BareWhenNotUnderSystemd(t *testing.T) {
+	defer restoreSpawnSeams(runUnderSystemdScope, execTmuxCombined)
+	runUnderSystemdScope = func() bool { return false }
+
+	var calls [][]string
+	execTmuxCombined = func(argv []string) ([]byte, error) {
+		calls = append(calls, argv)
+		return nil, nil
+	}
+
+	if _, err := LaunchTmuxSession("maestro-slot-1", "/wt/slot-1", "/state/run.sh"); err != nil {
+		t.Fatalf("LaunchTmuxSession: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one exec, got %d: %v", len(calls), calls)
+	}
+	if calls[0][0] != "tmux" {
+		t.Fatalf("expected bare tmux launch, got %v", calls[0])
+	}
+}
+
+func TestLaunchTmuxSession_ScopeWhenUnderSystemd(t *testing.T) {
+	defer restoreSpawnSeams(runUnderSystemdScope, execTmuxCombined)
+	runUnderSystemdScope = func() bool { return true }
+
+	var calls [][]string
+	execTmuxCombined = func(argv []string) ([]byte, error) {
+		calls = append(calls, argv)
+		return nil, nil
+	}
+
+	if _, err := LaunchTmuxSession("maestro-slot-1", "/wt/slot-1", "/state/run.sh"); err != nil {
+		t.Fatalf("LaunchTmuxSession: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one exec, got %d: %v", len(calls), calls)
+	}
+	if calls[0][0] != "systemd-run" {
+		t.Fatalf("expected scope-wrapped launch, got %v", calls[0])
+	}
+}
+
+func TestLaunchTmuxSession_FallsBackOnScopeFailure(t *testing.T) {
+	defer restoreSpawnSeams(runUnderSystemdScope, execTmuxCombined)
+	runUnderSystemdScope = func() bool { return true }
+
+	var calls [][]string
+	execTmuxCombined = func(argv []string) ([]byte, error) {
+		calls = append(calls, argv)
+		if argv[0] == "systemd-run" {
+			return []byte("Failed to connect to bus"), fmt.Errorf("systemd-run failed")
+		}
+		return nil, nil // kill-session + bare new-session succeed
+	}
+
+	if _, err := LaunchTmuxSession("maestro-slot-1", "/wt/slot-1", "/state/run.sh"); err != nil {
+		t.Fatalf("LaunchTmuxSession should fall back cleanly, got err: %v", err)
+	}
+	// Expect: scope attempt (fails) → kill-session (clear partial) → bare launch.
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 execs (scope, kill-session, bare), got %d: %v", len(calls), calls)
+	}
+	if calls[0][0] != "systemd-run" {
+		t.Fatalf("first exec should be scope attempt, got %v", calls[0])
+	}
+	if !(calls[1][0] == "tmux" && calls[1][1] == "kill-session") {
+		t.Fatalf("second exec should clear a partial session, got %v", calls[1])
+	}
+	if !(calls[2][0] == "tmux" && calls[2][1] == "new-session") {
+		t.Fatalf("third exec should be the bare in-cgroup launch, got %v", calls[2])
+	}
+}
+
+func restoreSpawnSeams(underSystemd func() bool, exec func([]string) ([]byte, error)) {
+	runUnderSystemdScope = underSystemd
+	execTmuxCombined = exec
+}
+
+func contains(ss []string, want string) bool { return indexOf(ss, want) >= 0 }
+
+func indexOf(ss []string, want string) int {
+	for i, s := range ss {
+		if s == want {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -153,8 +153,7 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 
 	// Start tmux session
 	tmuxName := TmuxSessionName(slotName)
-	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", worktreePath, "bash", runnerPath)
-	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+	if tmuxOut, err := LaunchTmuxSession(tmuxName, worktreePath, runnerPath); err != nil {
 		return "", fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
 	}
 
@@ -301,8 +300,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 
 	// Start tmux session
 	tmuxName := TmuxSessionName(slotName)
-	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", worktreePath, "bash", runnerPath)
-	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+	if tmuxOut, err := LaunchTmuxSession(tmuxName, worktreePath, runnerPath); err != nil {
 		return fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
 	}
 

--- a/maestro.service
+++ b/maestro.service
@@ -33,6 +33,20 @@ ExecStart=/usr/local/bin/maestro daemon \
 # daemon's own --drain-timeout (default 5m) finishes well inside this window
 # (#817).
 TimeoutStopSec=6min
+# Cgroup / kill ownership (#877). The default KillMode=control-group makes a
+# `systemctl stop|restart` (notably a self-deploy restart) SIGTERM — then, at
+# TimeoutStopSec, SIGKILL — EVERY process in the unit's control group. A worker's
+# tmux server, spawned as a descendant of the daemon, would otherwise land in
+# that cgroup and be swept out mid-flight, killing in-flight Claude workers while
+# the daemon's own drain still reported them "running" and the next daemon marked
+# them running->dead. KillMode=process scopes the unit's stop/restart to the
+# daemon's MAIN process only: the daemon owns worker lifecycle (in-process drain
+# on the first SIGTERM), and worker tmux servers — which maestro launches in a
+# transient `systemd-run --user --scope` cgroup that is a SIBLING of this unit,
+# not a child (internal/worker/spawn.go) — are never a target of this unit's
+# kill. The scope launch is the primary guarantee; KillMode=process is the belt
+# that also protects the in-cgroup fallback path on hosts without a usable scope.
+KillMode=process
 Restart=on-failure
 RestartSec=30
 


### PR DESCRIPTION
Implements #877

A self-deploy `systemctl restart maestro.service` killed in-flight tmux
workers before the in-process drain completed. The worker tmux server was
spawned as a daemon descendant, so it shared the unit's control group, and
the default `KillMode=control-group` SIGTERM/SIGKILLed the whole cgroup — even
while the daemon still reported those workers running. The next daemon then
marked them `running -> dead` over surviving dirty worktrees.

## Changes
- **`maestro.service`**: explicit `KillMode=process` + documented cgroup/kill
  ownership. The stop/restart kill is scoped to the daemon's main process, so
  worker tmux servers are never swept out of the cgroup.
- **`internal/worker/spawn.go`** (new): launch each worker's tmux server in a
  transient `systemd-run --user --scope` cgroup (a sibling of the unit, not a
  child) so it outlives a restart of the daemon unit. Graceful fallback to a
  bare in-cgroup launch when no user manager is available (`KillMode=process`
  is the belt that protects that path).
- **orchestrator**: before marking a running session dead on a dead pane PID,
  adopt a surviving tmux session (re-derive the live pane PID) — no false
  `running -> dead`, no duplicate dispatch.
- **supervisor**: a surviving tmux session suppresses the `dead_running_pid`
  finding so an operator is not nudged to reconcile a live worker to dead.
- **docs/self-deploy-runbook.md**: document the topology and worker survival.

## Testing
- `go test ./...` (full suite) — pass
- `go build ./cmd/maestro/` — pass
- New tests: unit-topology assertions (`KillMode=process`, no `ExecStop`,
  documented), scope-launch argv + fallback, orchestrator adopt-surviving-tmux
  reconcile, supervisor surviving-vs-truly-dead worker findings.

Live-canary verification (one worker spanning a real self-deploy restart
without a false `running -> dead`) remains an operator step, so this PR does
not auto-close the issue.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps tmux workers alive across self-deploy restarts. The main changes are:

- Launch worker tmux servers in transient systemd user scopes with a fallback path.
- Set `KillMode=process` for the Maestro service.
- Adopt surviving tmux panes during orchestrator reconciliation.
- Suppress supervisor dead-worker findings for surviving tmux sessions.
- Add restart-survival tests and deployment documentation.

<h3>Confidence Score: 4/5</h3>

The worker launch fallback and tmux liveness checks can terminate or misclassify active workers and need fixes before merging.

A duplicate session error causes the fallback to kill the existing worker. Multi-pane tmux output prevents adoption of a surviving worker. A retained tmux session can hide a dead runner from the supervisor.

internal/worker/spawn.go, internal/orchestrator/orchestrator.go, internal/supervisor/supervisor.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the fallback behavior of LaunchTmuxSession when a pre-existing named session caused a duplicate launch, followed by killing the old session and retrying creation.
- Reproduced the multi-pane adoption scenario, where the tmux shim returned two live pane PIDs and the adoption logic returned false, with the test failing as intended.
- Reproduced the session-existence behavior that hides a dead worker, showing suppression when tmuxAlive is true and detection when tmuxAlive is false.
- Recorded end-to-end test suite run and build status, including EXIT\_CODE 0 and an environment blocker note about a bus connection issue.

<a href="https://app.greptile.com/trex/runs/14209397/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/worker/spawn.go | Adds scoped tmux launching and fallback behavior; the fallback can terminate a pre-existing worker session. |
| internal/orchestrator/orchestrator.go | Adds surviving-session adoption, but its PID parser rejects valid multi-pane tmux output. |
| internal/supervisor/supervisor.go | Uses tmux session existence to suppress dead-worker findings without checking whether the worker pane remains alive. |
| maestro.service | Scopes service termination to the daemon process and documents worker cgroup ownership. |
| internal/worker/spawn_test.go | Covers scope argument construction and ordinary fallback behavior, but not preservation of an existing session. |
| internal/orchestrator/restart_survive_test.go | Covers single-pane adoption through injected liveness functions but not real multi-pane output. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/supervisor/supervisor.go`, line 1511-1522 ([link](https://github.com/befeast/maestro/blob/6505582344092fc693af6c0c1f9cb7a7a87f0406/internal/supervisor/supervisor.go#L1511-L1522)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Session Existence Hides Dead Worker**

   A successful `tmux has-session` does not prove that the worker pane is still running. If `remain-on-exit` preserves a dead pane, or another pane remains after the runner exits, `tmuxLive` suppresses `dead_running_pid` even though the recorded worker PID is dead, leaving the slot stuck instead of prompting reconciliation.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused Go test harness for the dead-PID and tmux-session liveness matrix](https://app.greptile.com/trex/artifacts/135aeeae-5fb5-4cfd-af24-91e167fd1eaf)**

   - Contains supporting evidence from the run (text/x-go; charset=utf-8).

   **[Repro: verbose focused test output showing suppression with tmuxAlive=true and detection with tmuxAlive=false](https://app.greptile.com/trex/artifacts/4b42486c-7557-46e8-aa7c-2c6e85dec626)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/14209397/artifacts?artifact=135aeeae-5fb5-4cfd-af24-91e167fd1eaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/supervisor/supervisor.go
   Line: 1511-1522

   Comment:
   **Session Existence Hides Dead Worker**

   A successful `tmux has-session` does not prove that the worker pane is still running. If `remain-on-exit` preserves a dead pane, or another pane remains after the runner exits, `tmuxLive` suppresses `dead_running_pid` even though the recorded worker PID is dead, leaving the slot stuck instead of prompting reconciliation.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/worker/spawn.go:99-102
**Fallback Kills Existing Worker**

When a session with this name already exists, the scoped `tmux new-session` returns a duplicate-session error. This fallback then kills that live session and starts a replacement, whereas the old direct launch returned the error without terminating the existing worker. Cleanup must distinguish a session partially created by this attempt from one that already existed.

### Issue 2 of 3
internal/orchestrator/orchestrator.go:275-281
**Multiple Panes Block Adoption**

When a surviving worker session has another pane, such as an operator debugging pane, `list-panes` returns multiple newline-separated PIDs. Parsing the entire output with `Atoi` fails, so adoption is skipped and reconciliation can mark the live worker dead, strand its worktree, and dispatch duplicate work.

### Issue 3 of 3
internal/supervisor/supervisor.go:1511-1522
**Session Existence Hides Dead Worker**

A successful `tmux has-session` does not prove that the worker pane is still running. If `remain-on-exit` preserves a dead pane, or another pane remains after the runner exits, `tmuxLive` suppresses `dead_running_pid` even though the recorded worker PID is dead, leaving the slot stuck instead of prompting reconciliation.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep in-flight tmux workers alive a..."](https://github.com/befeast/maestro/commit/6505582344092fc693af6c0c1f9cb7a7a87f0406) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43756394)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->