### PR TITLE
P1: Honor Greptile 4/5 pass and reflect merge intent/terminal PR truth

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2291,11 +2291,7 @@ commentFallback:
 			return false, false, nil
 		}
 
-		if strings.Contains(bodyLower, "safe to merge") {
-			return true, false, nil
-		}
-
-		if strings.Contains(bodyLower, "confidence score:") && (strings.Contains(bodyLower, "5/5") || strings.Contains(bodyLower, "4/5")) {
+		if greptileBodyApproves(bodyLower) {
 			return true, false, nil
 		}
 	}
@@ -2305,6 +2301,20 @@ commentFallback:
 	}
 
 	return false, false, nil
+}
+
+func greptileBodyApproves(bodyLower string) bool {
+	bodyLower = strings.ToLower(bodyLower)
+	if strings.Contains(bodyLower, "not ok to merge") || strings.Contains(bodyLower, "not okay to merge") || strings.Contains(bodyLower, "not safe to merge") || strings.Contains(bodyLower, "unsafe to merge") {
+		return false
+	}
+	if strings.Contains(bodyLower, "ok to merge") || strings.Contains(bodyLower, "okay to merge") || strings.Contains(bodyLower, "safe to merge") {
+		return true
+	}
+	if strings.Contains(bodyLower, "4/5") || strings.Contains(bodyLower, "5/5") {
+		return strings.Contains(bodyLower, "confidence score") || strings.Contains(bodyLower, "score:")
+	}
+	return false
 }
 
 func greptileCheckDecision(checkRuns []greptileCheckRun) (found bool, approved bool, pending bool) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -346,6 +346,31 @@ func TestGreptileCheckDecision(t *testing.T) {
 	}
 }
 
+func TestGreptileBodyApprovesScoreAndExplicitVerdict(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "four of five confidence passes", body: "Greptile Review\nConfidence Score: 4/5\nP2 notes only", want: true},
+		{name: "five of five confidence passes", body: "Confidence score: 5/5", want: true},
+		{name: "explicit ok to merge passes", body: "Greptile result: OK to merge", want: true},
+		{name: "explicit not ok to merge blocks", body: "Greptile result: not OK to merge", want: false},
+		{name: "explicit not okay to merge blocks", body: "Greptile result: not okay to merge", want: false},
+		{name: "explicit not safe to merge blocks", body: "Greptile result: not safe to merge", want: false},
+		{name: "explicit unsafe to merge blocks", body: "Greptile result: unsafe to merge", want: false},
+		{name: "three of five does not pass", body: "Confidence Score: 3/5\nAction required", want: false},
+		{name: "unrelated fraction does not pass", body: "Reviewed 4/5 files", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := greptileBodyApproves(strings.ToLower(tt.body)); got != tt.want {
+				t.Fatalf("greptileBodyApproves(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHasGreptileInlineCommentOnHead(t *testing.T) {
 	makeComment := func(login, sha, body string) greptileReviewComment {
 		var c greptileReviewComment

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1353,11 +1353,12 @@ type fleetProjectState struct {
 	// without operator action — see fleetSessionIsConvergenceBound and
 	// issue #598). The SPA project card uses this to render a calm
 	// "auto-merging" line instead of an alarming attention CTA.
-	SelfResolving   int                   `json:"self_resolving,omitempty"`
-	Active          []sessionInfo         `json:"active,omitempty"`
-	Attention       []sessionInfo         `json:"attention,omitempty"`
-	Approvals       []fleetApprovalState  `json:"approvals,omitempty"`
-	ApprovalSummary map[string]int        `json:"approval_summary,omitempty"`
+	SelfResolving   int                  `json:"self_resolving,omitempty"`
+	Active          []sessionInfo        `json:"active,omitempty"`
+	Attention       []sessionInfo        `json:"attention,omitempty"`
+	Approvals       []fleetApprovalState `json:"approvals,omitempty"`
+	ApprovalSummary map[string]int       `json:"approval_summary,omitempty"`
+	terminalPR      sessionInfo
 	Actions         []controlAction       `json:"actions,omitempty"`
 	CloseCandidates []fleetCloseCandidate `json:"close_candidates,omitempty"`
 	Supervisor      supervisorInfo        `json:"supervisor"`
@@ -2803,7 +2804,7 @@ func addFleetOperatorSummary(summary *fleetSummary, operator fleetOperatorState)
 
 func fleetOperatorStateIsActive(kind string) bool {
 	switch strings.TrimSpace(kind) {
-	case "working", "monitoring_pr", "pending_dispatch":
+	case "working", "monitoring_pr", "pending_dispatch", "merge_requested", "merge_approved", "merge_executing", "merge_executed", "code_landed":
 		return true
 	default:
 		return false
@@ -2931,9 +2932,9 @@ type fleetNextActionCandidate struct {
 // kinds (working, monitoring_pr, idle, ...) are excluded from the brief.
 func fleetNextActionPriorityForKind(kind string) (int, bool) {
 	switch strings.TrimSpace(kind) {
-	case "error", "dispatch_failure", "metered_backend", "stale_worker":
+	case "error", "dispatch_failure", "metered_backend", "merge_failed", "stale_worker":
 		return 0, true
-	case "attention":
+	case "attention", "merge_rejected":
 		return 1, true
 	case "outcome_drift", "stale", "no_eligible_issues", "queue_blocked":
 		return 2, true
@@ -3193,6 +3194,16 @@ func fleetNextActionCTAForProject(kind string, op fleetOperatorState) string {
 		return "Resolve stuck dispatch"
 	case "metered_backend":
 		return "Fix metered supervisor backend" // #838
+	case "merge_failed":
+		if op.PRNumber > 0 {
+			return fmt.Sprintf("Reconcile PR #%d merge", op.PRNumber)
+		}
+		return "Reconcile merge"
+	case "merge_rejected":
+		if op.PRNumber > 0 {
+			return fmt.Sprintf("Review PR #%d merge request", op.PRNumber)
+		}
+		return "Review merge request"
 	case "stale_worker":
 		if op.PRNumber > 0 {
 			return fmt.Sprintf("Open worker log for PR #%d", op.PRNumber)
@@ -3321,7 +3332,7 @@ func highestPriorityPendingFleetApproval(approvals []fleetApprovalState) *fleetA
 
 func fleetOperatorKindNeedsAction(kind string) bool {
 	switch strings.TrimSpace(kind) {
-	case "error", "dispatch_failure", "metered_backend", "stale_worker", "attention", "stale", "outcome_drift", "no_eligible_issues", "queue_blocked":
+	case "error", "dispatch_failure", "metered_backend", "merge_failed", "merge_rejected", "stale_worker", "attention", "stale", "outcome_drift", "no_eligible_issues", "queue_blocked":
 		return true
 	default:
 		return false
@@ -3381,11 +3392,11 @@ func fleetOperatorStatePriority(kind string) int {
 		return 0
 	case "dispatch_failure":
 		return 1
-	case "metered_backend":
+	case "metered_backend", "merge_failed":
 		// #838: supervisor LLM disabled + per-token cost burn risk — an error-tone
 		// project outage that must sort near the top of the fleet list.
 		return 1
-	case "stale_worker":
+	case "merge_rejected", "stale_worker":
 		return 2
 	case "attention":
 		return 3
@@ -3397,7 +3408,7 @@ func fleetOperatorStatePriority(kind string) int {
 		return 6
 	case "working":
 		return 7
-	case "monitoring_pr":
+	case "merge_requested", "merge_approved", "merge_executing", "merge_executed", "code_landed", "monitoring_pr":
 		return 8
 	case "auto_merging":
 		// #598: convergence-bound, calm — sort alongside monitoring_pr,
@@ -4037,6 +4048,9 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	workers := make([]fleetWorkerState, 0, len(projectState.All))
 	for _, worker := range projectState.All {
 		worker.Actions = workerActionAffordances(item.ReadOnly, "/api/v1/fleet/actions", worker)
+		if fleetSessionIsTerminalPRTruth(worker) && item.terminalPR.PRNumber == 0 {
+			item.terminalPR = worker
+		}
 		if audit, isStale := staleSlots[worker.Slot]; isStale {
 			worker.NeedsAttention = false
 			if reason := strings.TrimSpace(audit.Reason); reason != "" {
@@ -4350,6 +4364,12 @@ func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorStat
 	if state, ok := fleetMeteredBackendOperatorState(project); ok {
 		return state
 	}
+	if state, ok := fleetTerminalPROperatorState(project); ok {
+		return state
+	}
+	if state, ok := fleetMergeActionOperatorState(project); ok {
+		return state
+	}
 	if project.NeedsAttention > 0 {
 		// #598: separate "self-resolving" sessions (retry_exhausted with an
 		// open PR and no failing-check evidence — convergence will auto-merge
@@ -4511,6 +4531,130 @@ func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorStat
 		Summary:    summary,
 		NextAction: "Change labels/dependencies/project status if these issues should run now.",
 	}
+}
+
+func fleetSessionIsTerminalPRTruth(worker sessionInfo) bool {
+	if worker.PRNumber <= 0 {
+		return false
+	}
+	switch state.SessionStatus(worker.Status) {
+	case state.StatusCodeLanded:
+		return true
+	default:
+		return false
+	}
+}
+
+func fleetTerminalPROperatorState(project fleetProjectState) (fleetOperatorState, bool) {
+	worker := project.terminalPR
+	if !fleetSessionIsTerminalPRTruth(worker) {
+		return fleetOperatorState{}, false
+	}
+	label := "PR merged"
+	summary := fmt.Sprintf("PR #%d is merged; terminal forge truth outranks stale CI or review-gate data.", worker.PRNumber)
+	if state.SessionStatus(worker.Status) == state.StatusCodeLanded {
+		label = "Code landed"
+		summary = fmt.Sprintf("PR #%d is merged and code has landed.", worker.PRNumber)
+	}
+	return fleetOperatorState{
+		Kind:        "code_landed",
+		Tone:        "healthy",
+		Label:       label,
+		Summary:     summary,
+		NextAction:  "No operator action is required for this PR.",
+		Session:     worker.Slot,
+		IssueNumber: worker.IssueNumber,
+		IssueURL:    firstNonEmpty(worker.IssueURL, githubIssueURL(project.Repo, worker.IssueNumber)),
+		PRNumber:    worker.PRNumber,
+		PRURL:       firstNonEmpty(worker.PRURL, githubPRURL(project.Repo, worker.PRNumber)),
+	}, true
+}
+
+func fleetMergeActionOperatorState(project fleetProjectState) (fleetOperatorState, bool) {
+	approval, ok := latestFleetMergeApproval(project.Approvals)
+	if !ok {
+		return fleetOperatorState{}, false
+	}
+	status := state.ApprovalStatus(approval.Status)
+	prNumber := approval.PRNumber
+	issueNumber := approval.IssueNumber
+	session := approval.Session
+	base := fleetOperatorState{
+		Kind:        "merge_requested",
+		Tone:        "busy",
+		Label:       "Merge requested",
+		Summary:     fleetMergeActionSummary(approval),
+		NextAction:  "Wait for the durable merge action to advance.",
+		IssueNumber: issueNumber,
+		IssueURL:    firstNonEmpty(approval.IssueURL, githubIssueURL(project.Repo, issueNumber)),
+		PRNumber:    prNumber,
+		PRURL:       firstNonEmpty(approval.PRURL, githubPRURL(project.Repo, prNumber)),
+		Session:     session,
+	}
+	switch status {
+	case state.ApprovalStatusPending:
+		base.Tone = "attention"
+		base.NextAction = "Approve or reject the pending merge request."
+	case state.ApprovalStatusApproved, state.ApprovalStatusAwaitingDispatch:
+		base.Kind = "merge_approved"
+		base.Label = "Merge approved"
+		base.NextAction = "Wait for the merge executor to pick up the approved request."
+	case state.ApprovalStatusExecuting:
+		base.Kind = "merge_executing"
+		base.Label = "Merge executing"
+		base.NextAction = "Wait for GitHub to accept or settle the merge."
+	case state.ApprovalStatusExecuted:
+		base.Kind = "merge_executed"
+		base.Label = "Merge executed"
+		base.NextAction = "Wait for the next GitHub reconciliation to record the terminal merged state."
+	case state.ApprovalStatusRejected:
+		base.Kind = "merge_rejected"
+		base.Tone = "attention"
+		base.Label = "Merge rejected"
+		base.NextAction = "Review the rejected merge request and decide whether a new attempt is needed."
+	case state.ApprovalStatusExecutionFailed:
+		base.Kind = "merge_failed"
+		base.Tone = "error"
+		base.Label = "Merge failed"
+		base.NextAction = "Reconcile the PR merge state and retry only if the PR is still open."
+	default:
+		return fleetOperatorState{}, false
+	}
+	return base, true
+}
+
+func latestFleetMergeApproval(approvals []fleetApprovalState) (fleetApprovalState, bool) {
+	var selected fleetApprovalState
+	found := false
+	for _, approval := range approvals {
+		if strings.TrimSpace(approval.Action) != config.SupervisorActionMergePR {
+			continue
+		}
+		if !fleetMergeApprovalStatusVisible(state.ApprovalStatus(approval.Status)) {
+			continue
+		}
+		if !found || fleetApprovalRecency(approval).After(fleetApprovalRecency(selected)) {
+			selected, found = approval, true
+		}
+	}
+	return selected, found
+}
+
+func fleetMergeApprovalStatusVisible(status state.ApprovalStatus) bool {
+	switch status {
+	case state.ApprovalStatusPending, state.ApprovalStatusApproved, state.ApprovalStatusAwaitingDispatch, state.ApprovalStatusExecuting, state.ApprovalStatusExecuted, state.ApprovalStatusRejected, state.ApprovalStatusExecutionFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func fleetMergeActionSummary(approval fleetApprovalState) string {
+	target := "merge"
+	if approval.PRNumber > 0 {
+		target = fmt.Sprintf("merge PR #%d", approval.PRNumber)
+	}
+	return fmt.Sprintf("Maestro recorded %s request %s with status %s.", target, approval.ID, firstNonEmpty(approval.Status, "unknown"))
 }
 
 // partitionFleetAttentionByResolvability splits attention sessions into

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -340,6 +340,164 @@ func TestFleetWorkersOrderActuallyRunningFirst(t *testing.T) {
 	}
 }
 
+func TestFleetMergeActionOperatorStateMapsStatuses(t *testing.T) {
+	now := time.Date(2026, 7, 15, 14, 20, 0, 0, time.UTC)
+	statuses := []struct {
+		status state.ApprovalStatus
+		kind   string
+		label  string
+		tone   string
+		next   string
+	}{
+		{state.ApprovalStatusPending, "merge_requested", "Merge requested", "attention", "Approve or reject"},
+		{state.ApprovalStatusApproved, "merge_approved", "Merge approved", "busy", "executor"},
+		{state.ApprovalStatusAwaitingDispatch, "merge_approved", "Merge approved", "busy", "executor"},
+		{state.ApprovalStatusExecuting, "merge_executing", "Merge executing", "busy", "GitHub"},
+		{state.ApprovalStatusExecuted, "merge_executed", "Merge executed", "busy", "terminal merged"},
+		{state.ApprovalStatusRejected, "merge_rejected", "Merge rejected", "attention", "rejected merge"},
+		{state.ApprovalStatusExecutionFailed, "merge_failed", "Merge failed", "error", "Reconcile"},
+	}
+	for _, tt := range statuses {
+		t.Run(string(tt.status), func(t *testing.T) {
+			project := fleetProjectState{
+				Name: "Project",
+				Repo: "owner/repo",
+				Approvals: []fleetApprovalState{{
+					ID:          "approval-898",
+					Action:      config.SupervisorActionMergePR,
+					Status:      string(tt.status),
+					IssueNumber: 19,
+					PRNumber:    26,
+					createdAt:   now,
+					updatedAt:   now,
+				}},
+			}
+			got, ok := fleetMergeActionOperatorState(project)
+			if !ok {
+				t.Fatal("fleetMergeActionOperatorState returned false")
+			}
+			if got.Kind != tt.kind || got.Label != tt.label || got.Tone != tt.tone {
+				t.Fatalf("operator state = %+v, want kind=%q label=%q tone=%q", got, tt.kind, tt.label, tt.tone)
+			}
+			if !contains(got.Summary, "approval-898") || !contains(got.Summary, string(tt.status)) {
+				t.Fatalf("summary = %q, want approval id and status", got.Summary)
+			}
+			if !contains(got.NextAction, tt.next) {
+				t.Fatalf("next_action = %q, want %q", got.NextAction, tt.next)
+			}
+		})
+	}
+}
+
+func TestFleetSnapshotMergeRequestOutranksStaleGreptileAttention(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 15, 14, 17, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["pcp-11"] = &state.Session{
+		IssueNumber:     19,
+		IssueTitle:      "Project control plane templates",
+		Status:          state.StatusRetryExhausted,
+		StartedAt:       now.Add(-20 * time.Minute),
+		PRNumber:        26,
+		CIFailureOutput: "",
+	}
+	st.Approvals = append(st.Approvals, state.Approval{
+		ID:        "approval-c835b8f27cd0e394",
+		Action:    config.SupervisorActionMergePR,
+		Status:    state.ApprovalStatusPending,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Target:    &state.SupervisorTarget{Issue: 19, PR: 26, Session: "pcp-11"},
+		Summary:   "Merge PR #26 after Greptile 4/5 passed.",
+	})
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	cfg := &config.Config{Repo: "owner/repo", StateDir: dir, MaxParallel: 1}
+	resp := NewFleet([]FleetProject{NewFleetProject("Project", "", "", cfg)}, "127.0.0.1", 0, false).snapshot()
+	got := resp.Projects[0].OperatorState
+	if got.Kind != "merge_requested" || got.PRNumber != 26 {
+		t.Fatalf("operator state = %+v, want merge_requested for PR #26", got)
+	}
+	if !contains(got.Summary, "approval-c835b8f27cd0e394") || !contains(got.Summary, "pending") {
+		t.Fatalf("summary = %q, want durable approval id/status", got.Summary)
+	}
+	if contains(strings.ToLower(got.Summary+" "+got.NextAction), "not approved") || contains(got.NextAction, "Address Greptile feedback") {
+		t.Fatalf("operator text still exposes stale Greptile blocker: %+v", got)
+	}
+}
+
+func TestFleetSnapshotTerminalPROutranksStaleReviewState(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 15, 14, 19, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["pcp-11"] = &state.Session{
+		IssueNumber: 19,
+		IssueTitle:  "Project control plane templates",
+		Status:      state.StatusCodeLanded,
+		StartedAt:   now.Add(-30 * time.Minute),
+		FinishedAt:  fleetTimePtr(now),
+		PRNumber:    26,
+	}
+	st.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "stale-greptile",
+		CreatedAt:         now.Add(-time.Minute),
+		RecommendedAction: "spawn_repair_worker",
+		Summary:           "PR #26 is not approved by Greptile.",
+		Target:            &state.SupervisorTarget{Issue: 19, PR: 26, Session: "pcp-11"},
+	}, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	cfg := &config.Config{Repo: "owner/repo", StateDir: dir, MaxParallel: 1}
+	resp := NewFleet([]FleetProject{NewFleetProject("Project", "", "", cfg)}, "127.0.0.1", 0, false).snapshot()
+	got := resp.Projects[0].OperatorState
+	if got.Kind != "code_landed" || got.Label != "Code landed" || got.PRNumber != 26 {
+		t.Fatalf("operator state = %+v, want terminal code_landed for PR #26", got)
+	}
+	text := strings.ToLower(got.Summary + " " + got.NextAction)
+	if contains(text, "not approved") || contains(text, "review-repair") || contains(text, "greptile feedback") {
+		t.Fatalf("terminal PR state leaked stale review action: %+v", got)
+	}
+}
+
+func TestFleetSnapshotDonePRDoesNotBecomeTerminalPRTruth(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 15, 14, 21, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["pcp-11"] = &state.Session{
+		IssueNumber: 19,
+		IssueTitle:  "Project control plane templates",
+		Status:      state.StatusDone,
+		StartedAt:   now.Add(-30 * time.Minute),
+		FinishedAt:  fleetTimePtr(now),
+		PRNumber:    26,
+	}
+	st.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:        "review-gate",
+		CreatedAt: now.Add(-time.Minute),
+		StuckStates: []state.SupervisorStuckState{{
+			Code:              "greptile_not_approved",
+			Severity:          "blocked",
+			Summary:           "PR #26 is not approved by Greptile.",
+			RecommendedAction: "Address Greptile feedback before merging.",
+			Target:            &state.SupervisorTarget{Issue: 19, PR: 26, Session: "pcp-11"},
+		}},
+	}, state.DefaultSupervisorDecisionLimit)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	cfg := &config.Config{Repo: "owner/repo", StateDir: dir, MaxParallel: 1}
+	resp := NewFleet([]FleetProject{NewFleetProject("Project", "", "", cfg)}, "127.0.0.1", 0, false).snapshot()
+	got := resp.Projects[0].OperatorState
+	if got.Kind == "code_landed" {
+		t.Fatalf("StatusDone with PRNumber was treated as merged terminal PR truth: %+v", got)
+	}
+	if got.Kind != "attention" || got.PRNumber != 26 {
+		t.Fatalf("operator state = %+v, want review attention for PR #26", got)
+	}
+}
+
 func TestFleetEffectiveConfigIsSanitized(t *testing.T) {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "state")


### PR DESCRIPTION
Refs #898

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Greptile merge approval handling and Fleet operator state for merge-related workflows. The main changes are:

- Accepts Greptile 4/5 and 5/5 confidence comments as approval signals.
- Adds explicit negative verdict guards for legacy Greptile comments.
- Adds Fleet operator states for merge requests, merge execution, merge failures, rejected merges, and terminal `code_landed` PRs.
- Adds tests for Greptile verdict parsing and Fleet merge-state precedence.

<h3>Confidence Score: 4/5</h3>

Mostly safe, with one contained user-visible Fleet summary bug.

The main paths have focused tests, but the global brief can report an in-flight merge as healthy idle.

`internal/server/fleet.go`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the merge\_executing scenario by running a focused Go test in package internal/server that exercises buildFleetOperatorBrief with exactly one project whose OperatorState.Kind is merge\_executing and no approvals, and observed the global brief logged as idle.
- I validated the broader contract behavior by reviewing targeted logs showing all Greptile approval subtests pass (including 4/5 and 5/5 with a positive merge verdict and several rejection cases) and by checking fleet merge state mappings across pending/approved/awaiting\_dispatch/executing/executed/rejected, while noting the initial combined run failed due to a server build issue and a rerun was later needed.

<a href="https://app.greptile.com/trex/runs/14569298/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/github/github.go | Centralizes legacy Greptile comment approval parsing for explicit OK and 4/5 or 5/5 confidence verdicts. |
| internal/github/github_test.go | Adds table tests for Greptile body approval parsing across positive, negative, and unrelated score text. |
| internal/server/fleet.go | Adds terminal PR and merge-action operator states, with one remaining global brief aggregation bug. |
| internal/server/fleet_test.go | Adds tests for merge status mapping, merge-request precedence, terminal `code_landed` truth, and avoiding `done` as merged truth. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/server/fleet.go`, line 2882-2893 ([link](https://github.com/befeast/maestro/blob/86d4ec81cc4dfe26b877ff63f6e7d7a961d8d6fb/internal/server/fleet.go#L2882-L2893)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Keep merge states visible**
   `fleetOperatorStateIsActive` now classifies `merge_approved`, `merge_executing`, `merge_executed`, and `code_landed` as active, but the global brief’s non-actionable summary still counts only `working`, `monitoring_pr`, and `pending_dispatch`. When a fleet has only a `merge_executing` project and no pending approval, `parts` stays empty and the brief reports `all projects are healthy idle`, hiding the in-flight merge.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused Go test source for merge\_executing-only fleet brief](https://app.greptile.com/trex/artifacts/37f41c9c-a72e-4faa-8c03-d0498a03af81)**

   - Contains supporting evidence from the run (text/x-go; charset=utf-8).

   **[Repro: verbose Go test output showing idle global brief for merge\_executing-only fleet](https://app.greptile.com/trex/artifacts/1465366e-4b6a-4b51-aa46-b3698d99ccd2)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/14569298/artifacts?artifact=37f41c9c-a72e-4faa-8c03-d0498a03af81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/server/fleet.go
   Line: 2882-2893

   Comment:
   **Keep merge states visible**
   `fleetOperatorStateIsActive` now classifies `merge_approved`, `merge_executing`, `merge_executed`, and `code_landed` as active, but the global brief’s non-actionable summary still counts only `working`, `monitoring_pr`, and `pending_dispatch`. When a fleet has only a `merge_executing` project and no pending approval, `parts` stays empty and the brief reports `all projects are healthy idle`, hiding the in-flight merge.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/server/fleet.go:2882-2893
**Keep merge states visible**
`fleetOperatorStateIsActive` now classifies `merge_approved`, `merge_executing`, `merge_executed`, and `code_landed` as active, but the global brief’s non-actionable summary still counts only `working`, `monitoring_pr`, and `pending_dispatch`. When a fleet has only a `merge_executing` project and no pending approval, `parts` stays empty and the brief reports `all projects are healthy idle`, hiding the in-flight merge.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-348-89..."](https://github.com/befeast/maestro/commit/86d4ec81cc4dfe26b877ff63f6e7d7a961d8d6fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44501354)</sub>

<!-- /greptile_comment -->