### PR TITLE
security: stop persisting proxy credentials in units and worker artifacts

### DIFF
--- a/docs/worker-credential-boundary-runbook.md
+++ b/docs/worker-credential-boundary-runbook.md
@@ -18,8 +18,8 @@ credential copy.
 ## File contract
 
 - The file is a regular file owned by the Maestro service user, mode `0600` or
-  stricter, below a directory that is not group/other writable. Symlinks in the
-  path are rejected.
+  stricter, below an owner-only directory owned by that same user (mode `0700`
+  or stricter). Symlinks in the path are rejected.
 - Use simple `KEY=value` assignments. Single- or double-quoted values are
   accepted. Only `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`,
   `ANTHROPIC_AUTH_TOKEN`, `CLIPROXY_API_KEY`, `GEMINI_API_KEY`,
@@ -62,7 +62,9 @@ Startup reconciliation removes legacy `*-run.env` copies and the obsolete
 exports/source lines, and masks known legacy values in text state, prompts,
 postmortems, audit JSONL, structured output, and logs. Log masking is same-inode
 and same-length, so an active worker's open append descriptor remains valid; the
-scrub never signals or kills a process.
+scrub never signals or kills a process. It also repairs recognized worker text
+artifacts to owner-only modes and the worker log directory to `0700`, even when
+there is no currently known value to mask.
 
 ## Rotation, canary, and zero-copy proof
 

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -140,7 +140,7 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 
 	// Prepare log file
 	logDir := state.LogDir(cfg.StateDir)
-	if err := os.MkdirAll(logDir, 0755); err != nil {
+	if err := ensureWorkerLogDir(logDir); err != nil {
 		return fmt.Errorf("create log dir: %w", err)
 	}
 	logFile := filepath.Join(logDir, slotName+".log")

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"fmt"
 	"log"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -62,7 +61,7 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 
 	// Prepare log file
 	logDir := state.LogDir(cfg.StateDir)
-	if err := os.MkdirAll(logDir, 0755); err != nil {
+	if err := ensureWorkerLogDir(logDir); err != nil {
 		return fmt.Errorf("create log dir: %w", err)
 	}
 	logFile := fmt.Sprintf("%s/%s-%s.log", logDir, slotName, sess.Phase)

--- a/internal/worker/prompt_utf8.go
+++ b/internal/worker/prompt_utf8.go
@@ -1,8 +1,15 @@
 package worker
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+)
+
+const (
+	workerPromptFileMode = 0o600
+	workerLogDirMode     = 0o700
 )
 
 func sanitizePromptUTF8(prompt string) string {
@@ -10,5 +17,20 @@ func sanitizePromptUTF8(prompt string) string {
 }
 
 func writePromptFile(path, prompt string) error {
-	return os.WriteFile(path, []byte(sanitizePromptUTF8(prompt)), 0644)
+	return writeFileAtomicMode(filepath.Dir(path), path, sanitizePromptUTF8(prompt), workerPromptFileMode)
+}
+
+func ensureWorkerLogDir(path string) error {
+	if err := os.MkdirAll(path, workerLogDirMode); err != nil {
+		return err
+	}
+	dir, err := openOwnedDirNoFollow(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	if err := dir.Chmod(workerLogDirMode); err != nil {
+		return fmt.Errorf("chmod worker log dir: %w", err)
+	}
+	return nil
 }

--- a/internal/worker/prompt_utf8_test.go
+++ b/internal/worker/prompt_utf8_test.go
@@ -1,0 +1,85 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWritePromptFileAtomicallyEnforcesOwnerOnlyMode(t *testing.T) {
+	dir := t.TempDir()
+	prompt := filepath.Join(dir, "slot-a-prompt.md")
+	if err := os.WriteFile(prompt, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write old prompt: %v", err)
+	}
+	if err := os.Chmod(prompt, 0o644); err != nil {
+		t.Fatalf("chmod old prompt: %v", err)
+	}
+
+	if err := writePromptFile(prompt, "new prompt"); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+	data, err := os.ReadFile(prompt)
+	if err != nil {
+		t.Fatalf("read prompt: %v", err)
+	}
+	if string(data) != "new prompt" {
+		t.Fatalf("prompt = %q, want replacement content", data)
+	}
+	if info, err := os.Stat(prompt); err != nil {
+		t.Fatalf("stat prompt: %v", err)
+	} else if info.Mode().Perm() != workerPromptFileMode {
+		t.Fatalf("prompt mode = %o, want %o", info.Mode().Perm(), workerPromptFileMode)
+	}
+}
+
+func TestWritePromptFileReplacesSymlinkWithoutTouchingTarget(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(t.TempDir(), "victim")
+	if err := os.WriteFile(victim, []byte("untouched"), 0o600); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+	prompt := filepath.Join(dir, "slot-a-prompt.md")
+	if err := os.Symlink(victim, prompt); err != nil {
+		t.Fatalf("symlink prompt: %v", err)
+	}
+
+	if err := writePromptFile(prompt, "private prompt"); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+	if data, err := os.ReadFile(victim); err != nil || string(data) != "untouched" {
+		t.Fatalf("victim changed through prompt symlink: data=%q err=%v", data, err)
+	}
+	if info, err := os.Lstat(prompt); err != nil {
+		t.Fatalf("lstat prompt: %v", err)
+	} else if !info.Mode().IsRegular() || info.Mode().Perm() != workerPromptFileMode {
+		t.Fatalf("prompt was not replaced by an owner-only regular file: %v", info.Mode())
+	}
+}
+
+func TestEnsureWorkerLogDirRepairsModeAndRejectsSymlink(t *testing.T) {
+	logDir := filepath.Join(t.TempDir(), "logs")
+	if err := os.Mkdir(logDir, 0o755); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	if err := os.Chmod(logDir, 0o755); err != nil {
+		t.Fatalf("chmod logs: %v", err)
+	}
+	if err := ensureWorkerLogDir(logDir); err != nil {
+		t.Fatalf("ensure logs: %v", err)
+	}
+	if info, err := os.Stat(logDir); err != nil {
+		t.Fatalf("stat logs: %v", err)
+	} else if info.Mode().Perm() != workerLogDirMode {
+		t.Fatalf("log dir mode = %o, want %o", info.Mode().Perm(), workerLogDirMode)
+	}
+
+	target := t.TempDir()
+	linked := filepath.Join(t.TempDir(), "logs")
+	if err := os.Symlink(target, linked); err != nil {
+		t.Fatalf("symlink logs: %v", err)
+	}
+	if err := ensureWorkerLogDir(linked); err == nil {
+		t.Fatal("symlinked worker log directory was accepted")
+	}
+}

--- a/internal/worker/search_guardrail.go
+++ b/internal/worker/search_guardrail.go
@@ -615,12 +615,15 @@ func openPrivateCredentialFile(path string) (*os.File, error) {
 		return nil, fmt.Errorf("open credential parent without following links: %w", err)
 	}
 	defer parent.Close()
-	var parentStat unix.Stat_t
-	if err := unix.Fstat(int(parent.Fd()), &parentStat); err != nil {
+	parentInfo, err := parent.Stat()
+	if err != nil {
 		return nil, fmt.Errorf("stat credential parent: %w", err)
 	}
-	if os.FileMode(parentStat.Mode).Perm()&0o022 != 0 {
-		return nil, fmt.Errorf("parent dir is group/other writable")
+	if err := checkOwnedByUs(parentPath, parentInfo); err != nil {
+		return nil, fmt.Errorf("credential parent: %w", err)
+	}
+	if parentInfo.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("credential parent is group/other accessible (mode %o)", parentInfo.Mode().Perm())
 	}
 	fd, err := unix.Openat(int(parent.Fd()), filepath.Base(path), unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {
@@ -983,8 +986,8 @@ func ScrubLegacyRunArtifacts(stateDir string) {
 		scrubRunnerScript(path)
 	}
 
-	if len(secrets) == 0 {
-		return
+	if err := ensureWorkerLogDir(filepath.Join(stateDir, "logs")); err != nil && !os.IsNotExist(err) {
+		log.Printf("[worker] repair worker log dir permissions: %v", err)
 	}
 	if approvedBoundary != "" {
 		approvedBoundary, _ = filepath.Abs(approvedBoundary)
@@ -1148,7 +1151,20 @@ func scrubSecretValuesInPlace(path string, secrets []string) (bool, error) {
 			maxLen = len(secret)
 		}
 	}
+	repairedMode := os.FileMode(0o600)
+	if info.Mode().Perm()&0o100 != 0 {
+		repairedMode = 0o700
+	}
+	modeChanged := info.Mode().Perm() != repairedMode
 	if maxLen == 0 || info.Size() == 0 {
+		if modeChanged {
+			if err := f.Chmod(repairedMode); err != nil {
+				return false, err
+			}
+			if err := f.Sync(); err != nil {
+				return false, err
+			}
+		}
 		return false, nil
 	}
 	const chunkSize = 64 * 1024
@@ -1188,11 +1204,7 @@ func scrubSecretValuesInPlace(path string, secrets []string) (bool, error) {
 			break
 		}
 	}
-	if changed {
-		repairedMode := os.FileMode(0o600)
-		if info.Mode().Perm()&0o100 != 0 {
-			repairedMode = 0o700
-		}
+	if changed || modeChanged {
 		if err := f.Chmod(repairedMode); err != nil {
 			return false, err
 		}

--- a/internal/worker/search_guardrail_test.go
+++ b/internal/worker/search_guardrail_test.go
@@ -547,6 +547,15 @@ func TestValidatePrivateCredentialFile(t *testing.T) {
 	if err := validatePrivateCredentialFile(good); err != nil {
 		t.Fatalf("valid file rejected: %v", err)
 	}
+	if err := os.Chmod(dir, 0o710); err != nil {
+		t.Fatalf("chmod accessible credential dir: %v", err)
+	}
+	if err := validatePrivateCredentialFile(good); err == nil {
+		t.Fatal("credential file below a group-accessible parent was accepted")
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("restore credential dir mode: %v", err)
+	}
 
 	link := filepath.Join(dir, "link.env")
 	if err := os.Symlink(good, link); err != nil {
@@ -722,6 +731,71 @@ func TestRunWorkerWithCredentialsInjectsOnlyAtExecTime(t *testing.T) {
 	}
 	if output.String() != fmt.Sprintf("%d|unset", len(current)) {
 		t.Fatalf("exec-time environment proof = %q, want current length and no stale key", output.String())
+	}
+}
+
+func TestCredentialArgvHelperProcess(t *testing.T) {
+	if os.Getenv("MAESTRO_TEST_CREDENTIAL_ARGV_HELPER") != "1" {
+		return
+	}
+	secret := os.Getenv("OPENAI_API_KEY")
+	if secret == "" {
+		os.Exit(92)
+	}
+	for _, arg := range os.Args {
+		if strings.Contains(arg, secret) {
+			os.Exit(93)
+		}
+	}
+	_, _ = fmt.Fprint(os.Stdout, "argv-clean")
+	os.Exit(0)
+}
+
+func TestRunWorkerWithCredentialsKeepsCredentialOutOfProcessArguments(t *testing.T) {
+	canary := "CANARY-" + "child-argv-zero-copy-" + "0888"
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("chmod credential dir: %v", err)
+	}
+	credentialFile := filepath.Join(dir, "worker.env")
+	if err := os.WriteFile(credentialFile, []byte("OPENAI_API_KEY="+shellQuote(canary)+"\n"), 0o600); err != nil {
+		t.Fatalf("write credential file: %v", err)
+	}
+	t.Setenv("MAESTRO_TEST_CREDENTIAL_ARGV_HELPER", "1")
+	var output bytes.Buffer
+	err := RunWorkerWithCredentials(credentialFile, []string{
+		os.Args[0], "-test.run=^TestCredentialArgvHelperProcess$",
+	}, strings.NewReader(""), &output)
+	if err != nil {
+		t.Fatalf("run argv helper: %v (%q)", err, output.String())
+	}
+	if output.String() != "argv-clean" {
+		t.Fatalf("argv helper output = %q", output.String())
+	}
+}
+
+func TestShippedSystemdUnitContainsNoLiteralWorkerCredential(t *testing.T) {
+	canary := "CANARY-" + "systemd-unit-zero-copy-" + "0888"
+	t.Setenv("OPENAI_API_KEY", canary)
+	unit, err := os.ReadFile(filepath.Join("..", "..", "maestro.service"))
+	if err != nil {
+		t.Fatalf("read shipped maestro.service: %v", err)
+	}
+	text := string(unit)
+	if strings.Contains(text, canary) {
+		t.Fatal("shipped systemd unit contains the synthetic credential value")
+	}
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Environment=") {
+			continue
+		}
+		assignment := strings.Trim(strings.TrimPrefix(line, "Environment="), `"'`)
+		for _, key := range workerCredentialSecretKeys {
+			if strings.HasPrefix(assignment, key+"=") {
+				t.Fatalf("shipped systemd unit has a literal %s assignment", key)
+			}
+		}
 	}
 }
 
@@ -973,8 +1047,8 @@ func TestScrubLegacyRunArtifactsPreservesApprovedBoundaryInsideStateDir(t *testi
 	}
 }
 
-// #888: a legacy runner without credential material still has its permissions
-// repaired, while unrelated artifacts are untouched.
+// #888: a legacy runner without credential material and recognized worker text
+// artifacts still have their permissions repaired.
 func TestScrubLegacyRunArtifactsRepairsPlainRunnerPerms(t *testing.T) {
 	for _, key := range workerCredentialEnvKeys {
 		t.Setenv(key, "")
@@ -1003,8 +1077,13 @@ func TestScrubLegacyRunArtifactsRepairsPlainRunnerPerms(t *testing.T) {
 	if info, _ := os.Stat(runner); info.Mode().Perm() != workerRunnerScriptMode {
 		t.Fatalf("plain runner perm = %o, want %o", info.Mode().Perm(), workerRunnerScriptMode)
 	}
-	if info, _ := os.Stat(unrelated); info.Mode().Perm() != 0o644 {
-		t.Fatalf("unrelated file perm changed to %o", info.Mode().Perm())
+	if info, _ := os.Stat(unrelated); info.Mode().Perm() != 0o600 {
+		t.Fatalf("worker text artifact perm = %o, want 600", info.Mode().Perm())
+	}
+	if info, err := os.Stat(filepath.Join(stateDir, "logs")); err != nil {
+		t.Fatalf("stat repaired log dir: %v", err)
+	} else if info.Mode().Perm() != workerLogDirMode {
+		t.Fatalf("worker log dir perm = %o, want %o", info.Mode().Perm(), workerLogDirMode)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -128,7 +128,7 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 
 	// Prepare log file
 	logDir := state.LogDir(cfg.StateDir)
-	if err := os.MkdirAll(logDir, 0755); err != nil {
+	if err := ensureWorkerLogDir(logDir); err != nil {
 		return "", fmt.Errorf("create log dir: %w", err)
 	}
 	logFile := filepath.Join(logDir, slotName+".log")
@@ -276,7 +276,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 
 	// Prepare log file
 	logDir := state.LogDir(cfg.StateDir)
-	if err := os.MkdirAll(logDir, 0755); err != nil {
+	if err := ensureWorkerLogDir(logDir); err != nil {
 		return fmt.Errorf("create log dir: %w", err)
 	}
 	logFile := filepath.Join(logDir, slotName+".log")


### PR DESCRIPTION
Refs #888

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens how worker credentials and worker artifacts are handled. The main changes are:

- Enforces owner-only modes for prompt files and worker log directories.
- Requires credential parent directories to be owned by the service user and inaccessible to group/other users.
- Repairs recognized legacy worker text artifact and log directory permissions during credential scrubbing.
- Adds tests for symlink replacement, argv cleanliness, systemd unit credential absence, and permission repair behavior.
- Updates the worker credential boundary runbook to match the stricter file contract.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changed paths reuse existing no-follow and ownership validation helpers, tighten permissions on sensitive worker artifacts, and include focused tests for the main credential-boundary behaviors.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Go test command for the worker credential boundary with verbose output and confirmed the test run exited with code 0.
- Executed the full worker package credential-boundary tests, which passed including TestSyntheticCredentialCanaryExistsOnlyInApprovedBoundary, TestRunWorkerWithCredentialsRedactsBeforeReturningOutput, and TestScrubLegacyRunArtifacts, ending with exit code 0.

<a href="https://app.greptile.com/trex/runs/14567893/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/worker-credential-boundary-runbook.md | Documents the stricter owner-only credential directory contract and artifact permission repair behavior. |
| internal/worker/prompt_utf8.go | Adds owner-only prompt file writes and log directory permission enforcement via existing no-follow helpers. |
| internal/worker/search_guardrail.go | Tightens credential parent validation to owner-only access and repairs recognized artifact/log permissions even without secrets to redact. |
| internal/worker/search_guardrail_test.go | Expands tests for stricter credential boundary validation, zero-copy argv behavior, service unit checks, and permission repair. |
| internal/worker/worker.go | Uses the shared owner-only log directory helper across initial start and respawn paths. |

<sub>Reviews (1): Last reviewed commit: ["security: harden worker credential artif..."](https://github.com/befeast/maestro/commit/0835523791a9cd14fdbf789af869777857a0caab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44512182)</sub>

<!-- /greptile_comment -->