### PR TITLE
fix: fall back to Opus on model overload

### DIFF
--- a/internal/orchestrator/backend_model_cooldown_test.go
+++ b/internal/orchestrator/backend_model_cooldown_test.go
@@ -18,11 +18,12 @@ func credentialAwareFallbackConfig() *config.Config {
 		Repo: "owner/repo",
 		Model: config.ModelConfig{
 			Default:          "fable",
-			FallbackBackends: []string{"codex"},
+			FallbackBackends: []string{"claude-opus", "codex"},
 			Backends: map[string]config.BackendDef{
-				"fable":  {Cmd: "claude --model claude-fable-5"},
-				"sonnet": {Cmd: "claude --model claude-sonnet-4-6"},
-				"codex":  {Cmd: "codex --model gpt-5.5"},
+				"fable":       {Cmd: "claude --model claude-fable-5", Provider: "fable", Model: "claude-fable-5"},
+				"claude-opus": {Cmd: "claude --model claude-opus-4-8", Provider: "fable", Model: "claude-opus-4-8"},
+				"sonnet":      {Cmd: "claude --model claude-sonnet-4-6", Provider: "fable", Model: "claude-sonnet-4-6"},
+				"codex":       {Cmd: "codex --model gpt-5.5", Provider: "openai", Model: "gpt-5.5"},
 			},
 		},
 	}
@@ -77,8 +78,8 @@ func TestReconcileRunningSessions_ModelCredentialPoolExhausted_GatesOnlyRoute(t 
 	if !o.reconcileRunningSessions(s) {
 		t.Fatal("expected model cooldown reconciliation")
 	}
-	if respawned != "codex" {
-		t.Fatalf("respawned backend = %q, want codex after both Fable credentials were unavailable", respawned)
+	if respawned != "claude-opus" {
+		t.Fatalf("respawned backend = %q, want claude-opus after Fable was unavailable", respawned)
 	}
 	if _, ok := s.BackendHealth["fable"]; ok {
 		t.Fatalf("model cooldown must not gate the whole backend: %+v", s.BackendHealth["fable"])
@@ -119,8 +120,8 @@ func TestResolveDispatchBackend_ModelCooldownLeavesOtherProviderModelEligible(t 
 
 	fableIssue := makeIssue(908, "Fable route", "model:fable")
 	decision, ok, _ := o.resolveDispatchBackend(s, fableIssue, now)
-	if !ok || decision.Backend != "codex" {
-		t.Fatalf("Fable decision = %+v ok=%v, want precise fallback to codex", decision, ok)
+	if !ok || decision.Backend != "claude-opus" {
+		t.Fatalf("Fable decision = %+v ok=%v, want same-provider fallback to claude-opus", decision, ok)
 	}
 
 	sonnetIssue := makeIssue(909, "Sonnet route", "model:sonnet")
@@ -187,7 +188,7 @@ func TestRespawnDueRetries_ModelRouteCooldownBreaksSessionAffinity(t *testing.T)
 	o.respawnDueRetries(s, 10)
 
 	sess := s.Sessions["sup-909"]
-	if respawned != "codex" || sess.Backend != "codex" {
+	if respawned != "claude-opus" || sess.Backend != "claude-opus" {
 		t.Fatalf("retry remained pinned to unavailable route: respawned=%q session=%q", respawned, sess.Backend)
 	}
 	if sess.BackendSelection == nil || sess.BackendSelection.SelectionReason != selectionReasonRetryBlockedFallback {

--- a/internal/worker/backendfailure.go
+++ b/internal/worker/backendfailure.go
@@ -33,6 +33,10 @@ import (
 //     not false-positive
 //   - HTTP 404 paired with an HTTP / status / code / error / response marker
 //     (bare "404" is NOT matched — same discipline as http_401)
+//   - HTTP/API 529 paired with an overloaded marker. CLIProxyAPI does not
+//     retry 529 across credentials, so a terminal 529 must cool only the
+//     requested provider/model route and let the orchestrator try a different
+//     model on the same provider before crossing providers (#908).
 var modelUnavailablePatterns = []struct {
 	label string
 	re    *regexp.Regexp
@@ -47,6 +51,11 @@ var modelUnavailablePatterns = []struct {
 	// Not Found" line do not false-positive — only an anchored 404 (e.g. "API
 	// Error: 404", "status: 404") is treated as a model-unavailable signal.
 	{"http_404", regexp.MustCompile(`(?i)\b(?:http|https|status|code|err(?:or)?|response|received)\b[ \t]*[:=]?[ \t]*404\b`)},
+	// A bare 529 or the word "overloaded" is not enough: both must occur on
+	// the same terminal line, and 529 must be anchored to an HTTP/API status
+	// context. This matches Claude's live `API Error: 529 ... overloaded_error`
+	// while avoiding issue numbers, counters, and ordinary work output.
+	{"model_overloaded", regexp.MustCompile(`(?i)(?:\b(?:http|https|status|code|err(?:or)?|response|received)\b[ \t]*[:=]?[ \t]*529\b[^\n]{0,160}\boverloaded(?:_error)?\b|\boverloaded(?:_error)?\b[^\n]{0,160}\b(?:http|https|status|code|err(?:or)?|response|received)\b[ \t]*[:=]?[ \t]*529\b)`)},
 }
 
 // DetectModelUnavailable scans multi-line output for known model-unavailable

--- a/internal/worker/backendfailure_test.go
+++ b/internal/worker/backendfailure_test.go
@@ -59,6 +59,16 @@ func TestDetectModelUnavailable_KnownSignatures(t *testing.T) {
 			output:    "stream error: received 404 from upstream",
 			wantLabel: "http_404",
 		},
+		{
+			name:      "CLIProxyAPI model overloaded",
+			output:    `API Error: 529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+			wantLabel: "model_overloaded",
+		},
+		{
+			name:      "HTTP 529 overloaded",
+			output:    "HTTP 529: Overloaded",
+			wantLabel: "model_overloaded",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -88,6 +98,10 @@ func TestDetectModelUnavailable_NoFalsePositives(t *testing.T) {
 		"the existing model works fine in production",
 		"HTTP 200 OK — model loaded",
 		"all tests passed: 404 assertions",
+		"processed 529 overloaded fixtures successfully",
+		"issue #529 tracks upstream overload handling",
+		"HTTP 529 without an overload marker",
+		"overloaded queue recovered without an HTTP status",
 		"the issue body says the model may not exist, but that is the prompt",
 	}
 	for _, output := range cases {


### PR DESCRIPTION
## What changed

- Classify terminal `HTTP/API 529` responses paired with `overloaded` / `overloaded_error` as a model-scoped backend failure.
- Preserve the issue retry budget and allow the existing provider/model health selector to move to the next model route.
- Pin regression coverage to the live route order: Fable → canonical `claude-opus-4-8` → cross-provider fallbacks.

## Root cause

CLIProxyAPI retries only a fixed set of status codes and does not retry Anthropic `529`. With one Claude credential returning `529 Overloaded` and another serving Fable successfully, a worker could die on the first credential and Maestro did not classify that terminal output as model-specific capacity loss. The resulting retry could cross providers or burn the issue retry budget.

The live fleet now also has a canonical `claude-opus` backend before SOL, so model-scoped Fable failure remains on Anthropic first.

## Validation

- `go test ./internal/worker -run 'TestDetectModelUnavailable' -count=1`
- `go test ./internal/orchestrator -run 'Test(ReconcileRunningSessions_ModelCredentialPoolExhausted|ResolveDispatchBackend_ModelCooldown|RespawnDueRetries_ModelRouteCooldown)' -count=1`
- Live proxy probes after disabling session affinity: first Fable request `529`, second Fable request `200`, canonical Opus request `200`.

Closes #908.
