### PR TITLE
fix: block repair approvals for excluded issues and preserve pulse

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/befeast/maestro/internal/server"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/supervisor"
+	"github.com/befeast/maestro/internal/tmuxsession"
 	"github.com/befeast/maestro/internal/versioning"
 	"github.com/befeast/maestro/internal/watch"
 	"github.com/befeast/maestro/internal/worker"
@@ -2088,13 +2089,10 @@ func logsCmd(args []string) {
 
 			// If worker's tmux session is alive, attach to it for live output
 			tmuxName := worker.TmuxSessionName(slotName)
-			if sess.Status == state.StatusRunning && exec.Command("tmux", "has-session", "-t", tmuxName).Run() == nil {
-				tmuxPath, err := exec.LookPath("tmux")
-				if err != nil {
-					log.Fatalf("find tmux: %v", err)
-				}
+			if sess.Status == state.StatusRunning && tmuxsession.HasSession(tmuxName) {
+				tmuxPath, tmuxArgs := tmuxsession.ClientArgsForSession(tmuxName, "attach-session", "-t", "="+tmuxName+":", "-r")
 				fmt.Printf("Attaching to tmux session %s (read-only)...\n", tmuxName)
-				syscall.Exec(tmuxPath, []string{"tmux", "attach-session", "-t", tmuxName, "-r"}, os.Environ())
+				syscall.Exec(tmuxPath, tmuxArgs, os.Environ())
 				log.Fatalf("exec tmux attach: should not reach here")
 			}
 
@@ -2306,7 +2304,7 @@ func tmuxSessionAlive(name string) bool {
 	if strings.TrimSpace(name) == "" {
 		return false
 	}
-	return exec.Command("tmux", "has-session", "-t", name).Run() == nil
+	return tmuxsession.HasSession(name)
 }
 
 func watchCmd(args []string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -600,6 +600,10 @@ const (
 	// respawn.
 	SupervisorActionRestartWorker = "restart_worker"
 	SupervisorActionStopWorker    = "stop_worker"
+	// SupervisorActionSpawnRepairWorker resumes one explicitly reserved
+	// issue/session in place. Unlike restart_worker it preserves a retained
+	// worktree and never allocates a replacement slot.
+	SupervisorActionSpawnRepairWorker = "spawn_repair_worker"
 	// SupervisorActionSpawnReviewRepair is the auto review-repair respawn verb
 	// minted by the supervisor when a green+mergeable PR is settled
 	// retry_exhausted on review feedback and at least one Greptile P0/P1
@@ -2945,6 +2949,7 @@ func knownSupervisorActions() map[string]bool {
 		SupervisorActionDeleteWorktree:      true,
 		SupervisorActionChangeGlobalConfig:  true,
 		SupervisorActionApplyLessonProposal: true,
+		SupervisorActionSpawnRepairWorker:   true,
 		SupervisorActionSpawnReviewRepair:   true,
 		SupervisorActionRestartWorker:       true,
 		SupervisorActionStopWorker:          true,
@@ -2965,6 +2970,7 @@ func knownSupervisorActionNames() []string {
 		SupervisorActionDeleteWorktree,
 		SupervisorActionChangeGlobalConfig,
 		SupervisorActionApplyLessonProposal,
+		SupervisorActionSpawnRepairWorker,
 		SupervisorActionSpawnReviewRepair,
 		SupervisorActionRestartWorker,
 		SupervisorActionStopWorker,

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2222,8 +2222,10 @@ func (c *Client) PRMergeStatus(prNumber int) (mergeable string, mergeStateStatus
 //
 // Primary path: reads GitHub Check Runs for the PR's head SHA.
 //   - Looks for a check whose name contains "greptile" (case-insensitive).
-//   - conclusion == "success" or "neutral" approves when there are no high
-//     severity Greptile inline review comments on the current head SHA.
+//   - conclusion == "success" or "neutral" is the authoritative Greptile
+//     decision and approves the current head. Greptile uses that successful
+//     check for its "ok to merge" / 4-of-5-or-better verdict; inline findings
+//     remain review detail and must not contradict the completed gate.
 //   - check found, other conclusion → approved=false, pending=false
 //   - check not found → falls through to comment-based fallback
 //
@@ -2255,12 +2257,6 @@ func (c *Client) PRGreptileApproved(prNumber int) (approved bool, pending bool, 
 				return false, false, nil
 			}
 
-			// Greptile check run passed, but high-severity inline comments on
-			// the current head are still actionable and should block the gate.
-			comments, err := c.greptileReviewComments(prNumber)
-			if err == nil && hasGreptileInlineCommentOnHead(comments, sha) {
-				return false, false, nil
-			}
 			return true, false, nil
 		}
 		// No greptile check run found → fall through to comment fallback

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5229,21 +5229,10 @@ func (o *Orchestrator) reconcileGuardedRepairApprovals(s *state.State) {
 	if o == nil || o.cfg == nil || s == nil {
 		return
 	}
-	issues := make(map[int]struct{})
-	for _, claim := range s.ActiveIssueClaims() {
-		switch claim.Kind {
-		case state.IssueClaimRepairDispatch, state.IssueClaimReviewRepairDispatch:
-			issues[claim.IssueNumber] = struct{}{}
-		}
-	}
-	if len(issues) == 0 {
+	numbers := s.ActiveRepairDispatchApprovalIssues()
+	if len(numbers) == 0 {
 		return
 	}
-	numbers := make([]int, 0, len(issues))
-	for issue := range issues {
-		numbers = append(numbers, issue)
-	}
-	sort.Ints(numbers)
 	now := time.Now().UTC()
 	for _, issueNumber := range numbers {
 		issue, err := o.getIssue(issueNumber)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/befeast/maestro/internal/selfdeploy"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/supervisor"
+	"github.com/befeast/maestro/internal/tmuxsession"
 	"github.com/befeast/maestro/internal/versioning"
 	"github.com/befeast/maestro/internal/worker"
 )
@@ -259,7 +260,7 @@ func (o *Orchestrator) tmuxSessionExists(name string) bool {
 	if name == "" {
 		return false
 	}
-	return exec.Command("tmux", "has-session", "-t", name).Run() == nil
+	return tmuxsession.HasSession(name)
 }
 
 func (o *Orchestrator) listOpenPRs() ([]github.PR, error) {
@@ -1763,7 +1764,7 @@ func tmuxCapture(session string) (string, error) {
 	if strings.TrimSpace(session) == "" {
 		return "", fmt.Errorf("empty tmux session")
 	}
-	out, err := exec.Command("tmux", "capture-pane", "-t", session, "-p").Output()
+	out, err := tmuxsession.CommandForSession(session, "capture-pane", "-t", "="+session+":", "-p").Output()
 	if err != nil {
 		return "", err
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4363,7 +4363,24 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			}
 			sess.NotifiedCIFail = false // backward compat
 
-			if o.cfg.AutoRetryReviewFeedback {
+			// The configured review gate is authoritative. In particular, a
+			// successful Greptile check means "ok to merge" (4/5 or 5/5) even
+			// when the review left advisory inline findings. The old ordering
+			// collected P1 comments first and scheduled a repair before reading
+			// the successful gate, producing the contradictory
+			// greptile_not_approved/retry_exhausted state seen on OK Player #361.
+			// Read the verdict first and only feed comments to a repair worker
+			// when the configured gate itself has not passed.
+			var currentReviewVerdict *github.ReviewGateVerdict
+			if o.reviewGate() != "none" {
+				verdict, reviewErr := o.prReviewGateVerdict(pr.Number)
+				if reviewErr == nil {
+					currentReviewVerdict = &verdict
+				}
+			}
+
+			if o.cfg.AutoRetryReviewFeedback &&
+				(currentReviewVerdict == nil || currentReviewVerdict.Pending || !currentReviewVerdict.Passed) {
 				reviewFeedback, err := o.collectPRReviewFeedback(pr.Number)
 				if err != nil {
 					log.Printf("[orch] warn: could not collect review feedback for PR #%d: %v", pr.Number, err)
@@ -4411,11 +4428,17 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				continue
 			}
 
-			reviewVerdict, err := o.prReviewGateVerdict(pr.Number)
-			if err != nil {
-				log.Printf("[orch] review gate check PR #%d: %v", pr.Number, err)
-				persistGate()
-				continue // skip this cycle, try next
+			var reviewVerdict github.ReviewGateVerdict
+			if currentReviewVerdict != nil {
+				reviewVerdict = *currentReviewVerdict
+			} else {
+				var err error
+				reviewVerdict, err = o.prReviewGateVerdict(pr.Number)
+				if err != nil {
+					log.Printf("[orch] review gate check PR #%d: %v", pr.Number, err)
+					persistGate()
+					continue // skip this cycle, try next
+				}
 			}
 			if gateObservable && !o.prGateHeadMatches(pr.Number, gateTransition.HeadSHA) {
 				persistGate()
@@ -4484,6 +4507,27 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		for _, candidate := range ready {
 			o.mergeReadyPR(s, candidate.slotName, candidate.sess, candidate.pr)
 		}
+		return
+	}
+
+	// Sequential means one successful merge at a time, not "the oldest
+	// unmergeable PR blocks the fleet". Freshly preflight candidates and remove
+	// real conflicts before selecting the single merge slot. Conflict repair is
+	// handled against the existing session/worktree by the rebase/repair paths;
+	// skipping it here prevents a failed merge attempt from consuming this
+	// cycle's head-of-line position and lets a younger clean PR advance.
+	mergeableReady := ready[:0]
+	for _, candidate := range ready {
+		mergeable, mergeState, err := o.prMergeStatus(candidate.pr.Number)
+		if err == nil && mergeable == "CONFLICTING" {
+			log.Printf("[orch] sequential merge mode: PR #%d is %s/CONFLICTING — skipping merge slot and leaving canonical session %s for in-place conflict repair",
+				candidate.pr.Number, mergeState, candidate.slotName)
+			continue
+		}
+		mergeableReady = append(mergeableReady, candidate)
+	}
+	ready = mergeableReady
+	if len(ready) == 0 {
 		return
 	}
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7080,6 +7080,32 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 	if backend == "" {
 		backend = o.cfg.Model.Default
 	}
+	previousBackend := backend
+	// A current model:<backend> label is an explicit operator routing decision
+	// and outranks the backend recorded on the failed attempt. This matters for
+	// retained-worktree recovery: changing model:claude to model:sol must resume
+	// the same slot/worktree on Sol, not silently replay the stale Fable route.
+	// Without an explicit label, keep the already-selected session backend so an
+	// in-place recovery does not forget a successful fallover route (#911).
+	var explicitSelection *router.BackendDecision
+	if labelBackend := router.BackendFromLabels(issue); labelBackend != "" {
+		decision := o.resolveBackendDecision(issue)
+		if decision.Backend == labelBackend {
+			if _, exists := o.cfg.Model.Backends[labelBackend]; !exists {
+				log.Printf("[orch] refusing repair dispatch for issue #%d on %s: explicit backend %s is not configured", issue.Number, slot, labelBackend)
+				return false
+			}
+			if blockedBy, retryAt := o.dispatchBackendBlock(s, labelBackend, decision.Model, time.Now().UTC()); blockedBy != "" {
+				log.Printf("[orch] refusing repair dispatch for issue #%d on %s: explicit backend %s is blocked (%s%s)", issue.Number, slot, labelBackend, blockedBy, retryAfterHint(retryAt))
+				return false
+			}
+			if labelBackend != backend {
+				log.Printf("[orch] issue #%d repair recovery honors current model label: %s → %s on retained session %s", issue.Number, backend, labelBackend, slot)
+			}
+			backend = labelBackend
+			explicitSelection = &decision
+		}
+	}
 	promptBase := o.selectPrompt(issue)
 	var err error
 	if sess.PRNumber > 0 {
@@ -7094,6 +7120,12 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 	if err != nil {
 		log.Printf("[orch] repair dispatch for issue #%d on %s failed: %v", issue.Number, slot, err)
 		return false
+	}
+	if explicitSelection != nil {
+		selection := o.policyBackendSelection(*explicitSelection)
+		selection.PreviousBackend = previousBackend
+		sess.BackendSelection = selection
+		sess.Backend = backend
 	}
 	sess.NextRetryAt = nil
 	o.resolveSpawnRepairApproval(s, dispatch.approvalID, slot, target.PR, "repair worker dispatched")

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5042,6 +5042,50 @@ func TestStartNewWorkers_SupervisorRepairSpawnRepairsReservedSessionInPlace(t *t
 	}
 }
 
+func TestStartNewWorkers_SupervisorRepairSpawnHonorsCurrentModelLabelInPlace(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex", "sol")
+	issues := []github.Issue{makeIssue(345, "resume retained packaging work", "model:sol")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.hasOpenPRForIssueFn = func(int) (bool, error) { return false, nil }
+	gotBackend := ""
+	o.respawnInPlaceFn = func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+		gotBackend = backend
+		sess.Status = state.StatusRunning
+		sess.Backend = backend
+		return nil
+	}
+
+	s := state.NewState()
+	s.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345,
+		IssueTitle:  "resume retained packaging work",
+		Status:      state.StatusDead,
+		Worktree:    "/work/ok-player-273",
+		Branch:      "feat/ok-player-273-345",
+		Backend:     "codex",
+	}
+	s.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-repair-label",
+		CreatedAt:         time.Now().UTC(),
+		RecommendedAction: supervisor.ActionSpawnRepairWorker,
+		Risk:              supervisor.RiskMutating,
+		RequiresApproval:  false,
+		Target:            &state.SupervisorTarget{Issue: 345, Session: "ok-player-273"},
+	}, state.DefaultSupervisorDecisionLimit)
+
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 0 {
+		t.Fatalf("fresh starts = %v, want retained-session repair", *started)
+	}
+	if gotBackend != "sol" {
+		t.Fatalf("repair backend = %q, want current explicit label backend sol", gotBackend)
+	}
+	if got := s.Sessions["ok-player-273"].Backend; got != "sol" {
+		t.Fatalf("session backend = %q, want sol", got)
+	}
+}
+
 func TestStartNewWorkers_SupervisorRepairSpawnDoesNotDuplicateRunningWorker(t *testing.T) {
 	cfg := cfgWithBackends("codex", "codex")
 	issues := []github.Issue{makeIssue(808, "repair retry exhausted")}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1949,6 +1949,56 @@ func TestAutoMergePRs_SequentialMergesOnlyFirst(t *testing.T) {
 	}
 }
 
+func TestAutoMergePRs_SequentialSkipsOlderConflictAndMergesCleanPR(t *testing.T) {
+	prs := []github.PR{
+		{Number: 10, HeadRefName: "feat/conflicting"},
+		{Number: 20, HeadRefName: "feat/clean"},
+	}
+
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "sequential"}
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRMergeStatusFn = func(prNumber int) (string, string, error) {
+		if prNumber == 10 {
+			return "CONFLICTING", "dirty", nil
+		}
+		return "MERGEABLE", "clean", nil
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if !reflect.DeepEqual(*merged, []int{20}) {
+		t.Fatalf("merged = %v, want clean PR #20; older conflicting PR must not consume the sequential merge slot", *merged)
+	}
+	if got := s.Sessions["slot-0"].Status; got != state.StatusPROpen {
+		t.Fatalf("conflicting canonical session status = %q, want pr_open for in-place repair", got)
+	}
+}
+
+func TestAutoMergePRs_PassedReviewGateDoesNotRetryAdvisoryFeedback(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{
+		Repo:                    "owner/repo",
+		MergeStrategy:           "sequential",
+		ReviewGate:              "greptile",
+		AutoRetryReviewFeedback: true,
+	}
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghCollectPRReviewFeedbackFn = func(int) (string, error) {
+		return "P1 advisory finding on a head Greptile has approved", nil
+	}
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if !reflect.DeepEqual(*merged, []int{10}) {
+		t.Fatalf("merged = %v, want approved PR #10; successful gate is authoritative", *merged)
+	}
+	if got := s.Sessions["slot-0"].MaintenanceRetryCount; got != 0 {
+		t.Fatalf("maintenance retries = %d, want 0 after successful review gate", got)
+	}
+}
+
 func TestAutoMergePRs_SequentialRespectsInterval(t *testing.T) {
 	prs := []github.PR{
 		{Number: 10, HeadRefName: "feat/a"},

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -175,11 +175,13 @@ func TestReconcileGuardedRepairApprovals_BlockedWithoutReadyLabel(t *testing.T) 
 	review := repairApproval("review-repair-331", 331, 335, state.ApprovalStatusApproved, now)
 	review.Action = supervisor.ActionSpawnReviewRepair
 	review.Target.Session = "ok-player-247"
-	s.Approvals = []state.Approval{classic, review}
+	pending := repairApproval("pending-repair-331", 331, 335, state.ApprovalStatusPending, now)
+	pending.Target.Session = "ok-player-247"
+	s.Approvals = []state.Approval{classic, review, pending}
 
 	o.reconcileGuardedRepairApprovals(s)
 
-	for _, id := range []string{"repair-331", "review-repair-331"} {
+	for _, id := range []string{"repair-331", "review-repair-331", "pending-repair-331"} {
 		if got := approvalStatus(t, s, id); got != state.ApprovalStatusStale {
 			t.Fatalf("approval %s = %q, want stale", id, got)
 		}

--- a/internal/server/actions.go
+++ b/internal/server/actions.go
@@ -190,6 +190,10 @@ func isApprovalRequiredAction(id string) bool {
 		// the orchestrator dispatcher loop spawns the actual worker once
 		// the cautious gate approves.
 		config.SupervisorActionSpawnReviewRepair,
+		// Classic in-place repair is also approval-gated. The target must bind
+		// both issue and reserved session so the dispatcher cannot allocate a
+		// replacement slot or repair a recycled one.
+		config.SupervisorActionSpawnRepairWorker,
 		// #567: per-session worker-control verbs surfaced by the fleet
 		// snapshot — both go through the cautious gate before the
 		// executor calls into the WorkerController.
@@ -431,6 +435,13 @@ func validateApprovalRequest(id string, req controlActionRequest) error {
 		// manually against the latest head).
 		if req.PRNumber <= 0 {
 			return errors.New("pr_number is required for spawn_review_repair")
+		}
+	case config.SupervisorActionSpawnRepairWorker:
+		if err := state.ValidateSlotID(req.Slot); err != nil {
+			return fmt.Errorf("spawn_repair_worker: %w", err)
+		}
+		if req.IssueNumber <= 0 {
+			return errors.New("issue_number is required for spawn_repair_worker (slot-reuse fence)")
 		}
 	case config.SupervisorActionRestartWorker, config.SupervisorActionStopWorker:
 		// #567: the executor / WorkerController needs the slot to kill

--- a/internal/server/approval_action_test.go
+++ b/internal/server/approval_action_test.go
@@ -298,6 +298,24 @@ func TestApprovalAction_RestartWorker_Enqueues202(t *testing.T) {
 	}
 }
 
+func TestApprovalAction_SpawnRepairWorker_EnqueuesReservedSession(t *testing.T) {
+	cfg, dir := approvalEnqueueCfg(t)
+	srv := New(cfg, nil)
+	srv.SetActionDeps(&fakeActionGH{}, nil)
+
+	w := postApprovalAction(t, srv, `{"action_id":"spawn_repair_worker","slot":"ok-player-273","issue_number":345,"reason":"resume retained worktree in place"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	st := loadStateAt(t, dir)
+	if len(st.Approvals) != 1 || st.Approvals[0].Action != "spawn_repair_worker" {
+		t.Fatalf("state.Approvals = %+v", st.Approvals)
+	}
+	if got := st.Approvals[0].Target; got == nil || got.Session != "ok-player-273" || got.Issue != 345 {
+		t.Fatalf("target = %+v, want session=ok-player-273 issue=345", got)
+	}
+}
+
 func TestApprovalAction_StopWorker_Enqueues202(t *testing.T) {
 	cfg, dir := approvalEnqueueCfg(t)
 	srv := New(cfg, nil)

--- a/internal/state/issue_claim.go
+++ b/internal/state/issue_claim.go
@@ -177,13 +177,46 @@ func (s *State) StaleActiveRepairDispatchApprovals(issueNumber int, now time.Tim
 	var staled []Approval
 	for i := range s.Approvals {
 		approval := &s.Approvals[i]
-		if !activeRepairDispatchApproval(approval) || approval.Target.Issue != issueNumber {
+		if !repairDispatchApprovalNeedsGuardReconcile(approval) || approval.Target.Issue != issueNumber {
 			continue
 		}
 		s.markApprovalStale(approval, now, reason)
 		staled = append(staled, *approval)
 	}
 	return staled
+}
+
+// ActiveRepairDispatchApprovalIssues returns every issue with a non-terminal
+// classic or review-repair approval. Pending is included: it cannot dispatch
+// yet, but it is still an operator-visible gate that must become stale when the
+// issue is blocked before approval.
+func (s *State) ActiveRepairDispatchApprovalIssues() []int {
+	if s == nil {
+		return nil
+	}
+	seen := make(map[int]struct{})
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if repairDispatchApprovalNeedsGuardReconcile(approval) {
+			seen[approval.Target.Issue] = struct{}{}
+		}
+	}
+	issues := make([]int, 0, len(seen))
+	for issue := range seen {
+		issues = append(issues, issue)
+	}
+	sort.Ints(issues)
+	return issues
+}
+
+func repairDispatchApprovalNeedsGuardReconcile(approval *Approval) bool {
+	if approval == nil || approval.Target == nil || approval.Target.Issue <= 0 {
+		return false
+	}
+	if approval.Action != approvalActionSpawnRepairWorker && approval.Action != approvalActionSpawnReviewRepair {
+		return false
+	}
+	return approval.Status == ApprovalStatusPending || activeRepairDispatchApproval(approval)
 }
 
 func activeRepairDispatchApproval(approval *Approval) bool {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1829,8 +1829,42 @@ func mergeStateSnapshots(base, current, ours *State) (*State, error) {
 	merged.LastMergeAt = mergeLatestTime(base.LastMergeAt, current.LastMergeAt, ours.LastMergeAt)
 	mergeSpawnDrain(merged, current, ours)
 	mergePaused(merged, current, ours)
+	mergeSupervisorHeartbeat(merged, current, ours)
 	mergeMaterialProgress(merged, current, ours)
 	return merged, nil
+}
+
+// mergeSupervisorHeartbeat preserves the newest completed supervisor pulse
+// across ordinary three-way merges. The orchestrator and material-progress
+// evaluator write the same state concurrently; before this field-specific
+// merge, their otherwise-compatible writes silently kept current's old pulse
+// while accepting the new supervisor decision. Stuck state follows the pulse
+// that produced it. At an equal pulse, a watchdog's stuck=true wins so an
+// unrelated save cannot erase a real overdue verdict; a later RunOnce clears it
+// by advancing LastRunOnceAt.
+func mergeSupervisorHeartbeat(merged, current, ours *State) {
+	switch {
+	case ours.LastRunOnceAt.After(current.LastRunOnceAt):
+		merged.LastRunOnceAt = ours.LastRunOnceAt
+		merged.SupervisorStuck = ours.SupervisorStuck
+		merged.SupervisorStuckReason = ours.SupervisorStuckReason
+	case current.LastRunOnceAt.After(ours.LastRunOnceAt):
+		merged.LastRunOnceAt = current.LastRunOnceAt
+		merged.SupervisorStuck = current.SupervisorStuck
+		merged.SupervisorStuckReason = current.SupervisorStuckReason
+	default:
+		merged.LastRunOnceAt = current.LastRunOnceAt
+		if current.SupervisorStuck || ours.SupervisorStuck {
+			merged.SupervisorStuck = true
+			merged.SupervisorStuckReason = current.SupervisorStuckReason
+			if merged.SupervisorStuckReason == "" {
+				merged.SupervisorStuckReason = ours.SupervisorStuckReason
+			}
+			return
+		}
+		merged.SupervisorStuck = false
+		merged.SupervisorStuckReason = ""
+	}
 }
 
 // mergeSpawnDrain resolves the drain flag (#541) latest-write-wins by

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -363,6 +363,48 @@ func TestBackendHealthMergeKeepsLatest(t *testing.T) {
 	}
 }
 
+func TestStateMergePreservesNewestSupervisorHeartbeat(t *testing.T) {
+	base := NewState()
+	base.LastRunOnceAt = time.Date(2026, 7, 17, 10, 16, 0, 0, time.UTC)
+	base.SupervisorStuck = true
+	base.SupervisorStuckReason = "old pulse"
+	current := cloneState(base)
+	current.Sessions["other-writer"] = &Session{IssueNumber: 1, Status: StatusRunning}
+	ours := cloneState(base)
+	ours.LastRunOnceAt = time.Date(2026, 7, 17, 10, 44, 0, 0, time.UTC)
+	ours.SupervisorStuck = false
+	ours.SupervisorStuckReason = ""
+
+	merged, err := mergeStateSnapshots(base, current, ours)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if !merged.LastRunOnceAt.Equal(ours.LastRunOnceAt) {
+		t.Fatalf("last_run_once_at = %s, want %s", merged.LastRunOnceAt, ours.LastRunOnceAt)
+	}
+	if merged.SupervisorStuck || merged.SupervisorStuckReason != "" {
+		t.Fatalf("new heartbeat did not clear stale verdict: stuck=%v reason=%q", merged.SupervisorStuck, merged.SupervisorStuckReason)
+	}
+}
+
+func TestStateMergePreservesWatchdogStuckAtSameHeartbeat(t *testing.T) {
+	base := NewState()
+	base.LastRunOnceAt = time.Date(2026, 7, 17, 10, 16, 0, 0, time.UTC)
+	current := cloneState(base)
+	current.SupervisorStuck = true
+	current.SupervisorStuckReason = "15-minute threshold exceeded"
+	ours := cloneState(base)
+	ours.BackendHealth["claude"] = BackendHealth{State: BackendHealthAvailable, Since: time.Now().UTC()}
+
+	merged, err := mergeStateSnapshots(base, current, ours)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if !merged.SupervisorStuck || merged.SupervisorStuckReason != current.SupervisorStuckReason {
+		t.Fatalf("watchdog verdict lost: stuck=%v reason=%q", merged.SupervisorStuck, merged.SupervisorStuckReason)
+	}
+}
+
 func TestNotifiedCIFail_OmittedWhenFalse(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/supervisor/material_progress.go
+++ b/internal/supervisor/material_progress.go
@@ -15,6 +15,7 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/progress"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/tmuxsession"
 )
 
 // recordMaterialProgress collects and independently evaluates every exact
@@ -363,7 +364,7 @@ func tmuxProgressFingerprint(session string) (string, bool) {
 	// A pane target needs the trailing colon to identify the first pane of an
 	// exact session name. Without it, tmux interprets "=session" as a pane name
 	// and every real worker observation fails with "can't find pane".
-	cmd := exec.CommandContext(ctx, "tmux", "capture-pane", "-p", "-t", "="+session+":", "-S", tmuxProgressHistoryLines)
+	cmd := tmuxsession.CommandContextForSession(ctx, session, "capture-pane", "-p", "-t", "="+session+":", "-S", tmuxProgressHistoryLines)
 	stdout := &boundedOutput{limit: tmuxProgressMaxOutputBytes}
 	stderr := &boundedOutput{limit: 32 << 10}
 	cmd.Stdout = stdout

--- a/internal/supervisor/registry_drift_test.go
+++ b/internal/supervisor/registry_drift_test.go
@@ -101,6 +101,7 @@ func TestSupervisorMutatingActions_AreInExecutorRegistry(t *testing.T) {
 func TestDecide_SpawnRepairWorkerDecision_IsRegistrySupported(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{
+		issues: []github.Issue{testIssue(1, "spawn repair regression", "maestro-ready")},
 		prs: []github.PR{{
 			Number:      7,
 			HeadRefName: "feat/checks",

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -631,6 +631,23 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		}
 
 		if e.openPRNeedsRepair(st, stuckStates, slot, sess, pr) {
+			guardReason, guardErr := e.currentIssueRepairGuard(sess.IssueNumber)
+			if guardErr != nil {
+				guardReason = fmt.Sprintf("current issue dispatch guards could not be verified: %v", guardErr)
+			}
+			if guardReason != "" {
+				reasons := appendReasons(baseReasons,
+					fmt.Sprintf("Session %s is associated with open PR #%d, but the PR is not progressing", slot, pr.Number),
+					"Repair dispatch is fail-closed against the issue's current forge state",
+					guardReason,
+				)
+				target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
+				decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
+					fmt.Sprintf("Do not start a repair worker for issue #%d while its current dispatch guard holds: %s", sess.IssueNumber, guardReason),
+					RiskSafe, 0.98, target, PolicyRuleExcludedLabels, reasons)
+				decision.StuckStates = stuckStates
+				return decision, nil
+			}
 			reasons := appendReasons(baseReasons,
 				fmt.Sprintf("Session %s is associated with open PR #%d, but the PR is not progressing", slot, pr.Number),
 				"The worker is not actively repairing this PR while it is draft, failing checks, blocked by review, or the live outcome is still failing",
@@ -944,6 +961,29 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		"No action is currently recommended.", RiskSafe, 0.8, nil, policyRule, reasons)
 	decision.StuckStates = stuckStates
 	return withAnalysis(decision), nil
+}
+
+// currentIssueRepairGuard re-reads the current open issue before the
+// supervisor recommends repair for an existing PR. PR/session state alone is
+// insufficient authority: an operator may have added blocked (or another
+// excluded label) after the worker/approval was created. A missing issue is
+// treated as closed and a read failure is returned so the caller can fail
+// closed without minting another approval.
+func (e *Engine) currentIssueRepairGuard(issueNumber int) (string, error) {
+	issues, err := e.reader.ListOpenIssues(nil)
+	if err != nil {
+		return "", err
+	}
+	for _, issue := range issues {
+		if issue.Number != issueNumber {
+			continue
+		}
+		if label, ok := firstMatchingIssueLabel(issue, e.dynamicWaveExcludedLabels()); ok {
+			return fmt.Sprintf("current issue label %q excludes repair dispatch", label), nil
+		}
+		return "", nil
+	}
+	return "issue is not currently open", nil
 }
 
 func tokenBudgetExceededSession(st *state.State) (string, *state.Session, bool) {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2731,6 +2731,12 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 	// spawn_repair_worker is now a registered awaiting-dispatch action, so the
 	// cautious gate can safely authorize that recovery without creating a new
 	// slot, worktree, or PR.
+	if mergeReader, ok := e.reader.(prMergeableReader); ok {
+		if mergeable, err := mergeReader.PRMergeable(pr.Number); err == nil &&
+			strings.EqualFold(strings.TrimSpace(mergeable), "CONFLICTING") {
+			return true
+		}
+	}
 	if pr.IsDraft {
 		return true
 	}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2660,21 +2660,48 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 		branchToPR[pr.HeadRefName] = pr
 		numberToPR[pr.Number] = pr
 	}
+	// Attention states must not sit behind an ordinary open PR merely because
+	// its slot sorts earlier. This is especially important when the earlier PR
+	// is intentionally blocked for QA: a later conflict_failed/retry_exhausted
+	// canonical PR still needs the project's one actionable recommendation.
+	// Keep the sort order as a deterministic tie-breaker within each rank.
+	bestRank := 2
+	var bestSlot string
+	var bestSession *state.Session
+	var bestPR github.PR
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
 		if sess == nil || e.sessionResolvedOnGitHub(sess, cache) {
 			continue
 		}
+		var pr github.PR
+		var found bool
 		if sess.Branch != "" {
-			if pr, ok := branchToPR[sess.Branch]; ok {
-				return slot, sess, pr, true
-			}
+			pr, found = branchToPR[sess.Branch]
 		}
-		if sess.PRNumber > 0 {
-			if pr, ok := numberToPR[sess.PRNumber]; ok {
-				return slot, sess, pr, true
-			}
+		if !found && sess.PRNumber > 0 {
+			pr, found = numberToPR[sess.PRNumber]
 		}
+		if !found {
+			continue
+		}
+		rank := 1
+		switch sess.Status {
+		case state.StatusRetryExhausted, state.StatusConflictFailed, state.StatusFailed, state.StatusDead:
+			rank = 0
+		}
+		if bestSession == nil || rank < bestRank {
+			bestRank = rank
+			bestSlot, bestSession, bestPR = slot, sess, pr
+		}
+		if bestRank == 0 {
+			// sortedSessionNames already provides the deterministic tie-break;
+			// no later candidate can outrank an attention state.
+			break
+		}
+	}
+	if bestSession != nil {
+		return bestSlot, bestSession, bestPR, true
 	}
 	return "", nil, github.PR{}, false
 }
@@ -2699,15 +2726,11 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 	if availableSlots(e.cfg, st) <= 0 {
 		return false
 	}
-	// #556: a retry-exhausted session has spent its retry budget — spawning
-	// another repair worker would not be effective, and the executor refuses
-	// `spawn_repair_worker` because the verb is not in the action registry.
-	// Falling through here lets the deterministic path land on
-	// monitor_open_pr (or merge_pr when the feedback was addressed and the
-	// PR is now green) instead of looping on the refused verb each cycle.
-	if sess.Status == state.StatusRetryExhausted {
-		return false
-	}
+	// A retry-exhausted session may still need an explicitly approved in-place
+	// repair (for example, a real rebase conflict on its canonical open PR).
+	// spawn_repair_worker is now a registered awaiting-dispatch action, so the
+	// cautious gate can safely authorize that recovery without creating a new
+	// slot, worktree, or PR.
 	if pr.IsDraft {
 		return true
 	}
@@ -2721,7 +2744,7 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 			}
 		}
 		switch stuck.Code {
-		case "failing_checks", "greptile_not_approved":
+		case "failing_checks", "greptile_not_approved", "unmergeable_pr":
 			return true
 		case "stale_review_feedback":
 			// Review feedback from a PREVIOUS attempt does not mean the

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -960,6 +960,7 @@ func TestDecide_FailingChecksExplained(t *testing.T) {
 func TestDecide_DeadSessionWithDraftFailingPRRecommendsRepairWorker(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{
+		issues: []github.Issue{testIssue(94, "failing checks", "maestro-ready")},
 		prs: []github.PR{{
 			Number:      31,
 			HeadRefName: "feat/checks",
@@ -995,6 +996,46 @@ func TestDecide_DeadSessionWithDraftFailingPRRecommendsRepairWorker(t *testing.T
 	}
 	if !strings.Contains(strings.ToLower(decision.Summary), "repair worker") {
 		t.Fatalf("summary = %q, want repair worker", decision.Summary)
+	}
+}
+
+func TestDecide_BlockedIssueWithOpenPRNeverMintsRepairApproval(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.MaxParallel = 20
+	cfg.ExcludeLabels = []string{"blocked"}
+	reader := &fakeReader{
+		issues: []github.Issue{testIssue(331, "canonical PR #335", "blocked")},
+		prs: []github.PR{{
+			Number:      335,
+			HeadRefName: "feat/ok-player-247-331-fix",
+			State:       "OPEN",
+			Mergeable:   "MERGEABLE",
+			IsDraft:     true,
+		}},
+		ciStatuses: map[int]string{335: "failure"},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-247"] = &state.Session{
+		IssueNumber: 331,
+		IssueTitle:  "canonical PR #335",
+		Status:      state.StatusPROpen,
+		PRNumber:    335,
+		Branch:      "feat/ok-player-247-331-fix",
+		StartedAt:   time.Now().UTC().Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionMonitorOpenPR)
+	}
+	if decision.RequiresApproval || decision.ApprovalID != "" {
+		t.Fatalf("blocked decision minted approval: requires=%v id=%q", decision.RequiresApproval, decision.ApprovalID)
+	}
+	if !strings.Contains(decision.Summary, `label "blocked"`) {
+		t.Fatalf("summary = %q, want current blocked-label guard", decision.Summary)
 	}
 }
 

--- a/internal/tmuxsession/tmuxsession.go
+++ b/internal/tmuxsession/tmuxsession.go
@@ -1,0 +1,146 @@
+// Package tmuxsession owns Maestro's tmux control boundary.
+//
+// Workers use a private tmux server instead of the caller's default server.
+// When Maestro itself runs as a systemd service, the first worker starts that
+// server in a sibling transient scope.  The worker tree therefore survives a
+// restart of maestro.service instead of remaining in its KillMode=control-group
+// cgroup and being killed with the daemon.
+package tmuxsession
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	tmuxName       = "tmux"
+	bashPath       = "/usr/bin/bash"
+	sudoName       = "sudo"
+	systemdRunName = "systemd-run"
+	privateSocket  = "maestro-workers"
+)
+
+var startMu sync.Mutex
+
+// HasSession checks the restart-safe private server first and then the legacy
+// default server.  The fallback keeps reconciliation able to see sessions that
+// were launched before the private-socket cutover.
+func HasSession(name string) bool {
+	return hasPrivateSession(name) || legacyCommand("has-session", "-t", exactTarget(name)).Run() == nil
+}
+
+// CommandForSession returns a tmux command addressed to the server that owns
+// name.  New sessions always live on the private server; legacy fallback is
+// read/cleanup compatibility only.
+func CommandForSession(name string, args ...string) *exec.Cmd {
+	if hasPrivateSession(name) {
+		return privateCommand(args...)
+	}
+	return legacyCommand(args...)
+}
+
+// CommandContextForSession is CommandForSession with cancellation support.
+func CommandContextForSession(ctx context.Context, name string, args ...string) *exec.Cmd {
+	if hasPrivateSession(name) {
+		return exec.CommandContext(ctx, resolvedPath(tmuxName), append([]string{"-L", privateSocket}, args...)...)
+	}
+	return exec.CommandContext(ctx, resolvedPath(tmuxName), args...)
+}
+
+// ClientArgsForSession returns argv suitable for syscall.Exec of the tmux
+// client. The binary path is deterministic and included as argv[0].
+func ClientArgsForSession(name string, args ...string) (string, []string) {
+	clientArgs := []string{"tmux"}
+	if hasPrivateSession(name) {
+		clientArgs = append(clientArgs, "-L", privateSocket)
+	}
+	return resolvedPath(tmuxName), append(clientArgs, args...)
+}
+
+// StartDetached starts one worker session.  When the private tmux server does
+// not yet exist, a system-service Maestro launches it in a sibling systemd
+// scope.  Subsequent sessions are created by that already-isolated server.
+func StartDetached(name, worktree, runnerPath string) ([]byte, error) {
+	startMu.Lock()
+	defer startMu.Unlock()
+
+	args := []string{"new-session", "-d", "-s", name, "-c", worktree, bashPath, runnerPath}
+	if privateServerAlive() {
+		return privateCommand(args...).CombinedOutput()
+	}
+
+	// INVOCATION_ID is set by systemd for both persistent and transient units.
+	// The fleet daemon is a system unit without a user-bus environment, so use
+	// the system manager through the same passwordless sudo boundary as
+	// self-deploy.  Failing this launch fails closed: launching directly here
+	// would silently put workers back into maestro.service's kill cgroup.
+	if strings.TrimSpace(os.Getenv("INVOCATION_ID")) != "" {
+		unit := fmt.Sprintf("maestro-workers-%d-%d", os.Getpid(), time.Now().Unix())
+		scopeArgs := scopeLaunchArgs(unit, os.Getuid(), os.Getenv("PATH"), args)
+		return exec.Command(resolvedPath(sudoName), scopeArgs...).CombinedOutput()
+	}
+
+	// CLI development runs are not tied to a long-lived service cgroup.  Keep
+	// them functional while still using the private socket so behavior matches
+	// the daemon once the command is imported/reconciled later.
+	return privateCommand(args...).CombinedOutput()
+}
+
+// PanePID returns the pane shell PID for name.
+func PanePID(name string) ([]byte, error) {
+	return CommandForSession(name, "list-panes", "-t", exactTarget(name), "-F", "#{pane_pid}").Output()
+}
+
+// KillSession terminates exactly name without fuzzy tmux target matching.
+func KillSession(name string) ([]byte, error) {
+	return CommandForSession(name, "kill-session", "-t", exactTarget(name)).CombinedOutput()
+}
+
+func hasPrivateSession(name string) bool {
+	return privateCommand("has-session", "-t", exactTarget(name)).Run() == nil
+}
+
+func privateServerAlive() bool {
+	return privateCommand("list-sessions").Run() == nil
+}
+
+func privateCommand(args ...string) *exec.Cmd {
+	return exec.Command(resolvedPath(tmuxName), append([]string{"-L", privateSocket}, args...)...)
+}
+
+func legacyCommand(args ...string) *exec.Cmd {
+	return exec.Command(resolvedPath(tmuxName), args...)
+}
+
+func exactTarget(name string) string {
+	return "=" + strings.TrimSpace(name) + ":"
+}
+
+func scopeLaunchArgs(unit string, uid int, path string, tmuxArgs []string) []string {
+	args := []string{
+		"-n",
+		resolvedPath(systemdRunName),
+		"--scope",
+		"--collect",
+		"--uid=" + strconv.Itoa(uid),
+		"--unit=" + unit,
+	}
+	if strings.TrimSpace(path) != "" {
+		args = append(args, "--setenv=PATH="+path)
+	}
+	args = append(args, resolvedPath(tmuxName), "-L", privateSocket)
+	return append(args, tmuxArgs...)
+}
+
+func resolvedPath(name string) string {
+	if path, err := exec.LookPath(name); err == nil && strings.TrimSpace(path) != "" {
+		return path
+	}
+	return name
+}

--- a/internal/tmuxsession/tmuxsession_test.go
+++ b/internal/tmuxsession/tmuxsession_test.go
@@ -1,0 +1,66 @@
+package tmuxsession
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScopeLaunchArgsUsesSiblingSystemdScopeAndPrivateSocket(t *testing.T) {
+	got := scopeLaunchArgs("maestro-workers-1-2", 1000, "/usr/local/bin:/usr/bin:/bin", []string{
+		"new-session", "-d", "-s", "maestro-ok-player-1", "-c", "/tmp/worktree", bashPath, "/tmp/run.sh",
+	})
+	want := []string{
+		"-n", resolvedPath(systemdRunName), "--scope", "--collect", "--uid=1000", "--unit=maestro-workers-1-2",
+		"--setenv=PATH=/usr/local/bin:/usr/bin:/bin",
+		resolvedPath(tmuxName), "-L", privateSocket,
+		"new-session", "-d", "-s", "maestro-ok-player-1", "-c", "/tmp/worktree", bashPath, "/tmp/run.sh",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("scope argv = %#v, want %#v", got, want)
+	}
+}
+
+func TestStartDetachedUsesSiblingSystemdScope(t *testing.T) {
+	if os.Getenv("MAESTRO_SYSTEMD_INTEGRATION") != "1" {
+		t.Skip("set MAESTRO_SYSTEMD_INTEGRATION=1 on a systemd host")
+	}
+
+	session := fmt.Sprintf("maestro-scope-it-%d", time.Now().UnixNano())
+	runner := t.TempDir() + "/run.sh"
+	if err := os.WriteFile(runner, []byte("#!/usr/bin/bash\nexec /usr/bin/sleep 30\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("INVOCATION_ID", "maestro-tmux-integration")
+	out, err := StartDetached(session, t.TempDir(), runner)
+	if err != nil {
+		t.Fatalf("StartDetached: %v\n%s", err, out)
+	}
+	t.Cleanup(func() { _, _ = KillSession(session) })
+
+	pidBytes, err := PanePID(session)
+	if err != nil {
+		t.Fatalf("PanePID: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		t.Fatalf("parse pane pid %q: %v", pidBytes, err)
+	}
+	cgroup, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		t.Fatalf("read pane cgroup: %v", err)
+	}
+	if !strings.Contains(string(cgroup), "/maestro-workers-") || strings.Contains(string(cgroup), "/maestro.service") {
+		t.Fatalf("pane cgroup = %q, want sibling maestro-workers scope", cgroup)
+	}
+}
+
+func TestExactTargetCannotPrefixMatchAnotherWorker(t *testing.T) {
+	if got, want := exactTarget("maestro-ok-player-26"), "=maestro-ok-player-26:"; got != want {
+		t.Fatalf("exactTarget = %q, want %q", got, want)
+	}
+}

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -14,6 +14,7 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/tmuxsession"
 )
 
 // WorktreeDirty reports whether a retained worker worktree contains any
@@ -119,7 +120,7 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 	// worker grandchildren that reparented away (e.g. headless Chrome) do not
 	// leak across a respawn.
 	tmuxName := TmuxSessionName(slotName)
-	if out, err := exec.Command("tmux", "kill-session", "-t", tmuxName).CombinedOutput(); err != nil {
+	if out, err := tmuxsession.KillSession(tmuxName); err != nil {
 		log.Printf("[worker] tmux kill-session %s: %v (%s)", tmuxName, err, strings.TrimSpace(string(out)))
 	}
 	if sess.PID > 0 && IsAlive(sess.PID) {
@@ -214,13 +215,12 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 	}
 
 	// Start tmux session in existing worktree
-	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", sess.Worktree, "bash", runnerPath)
-	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+	if tmuxOut, err := tmuxsession.StartDetached(tmuxName, sess.Worktree, runnerPath); err != nil {
 		return fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
 	}
 
 	// Get PID
-	pidOut, err := exec.Command("tmux", "list-panes", "-t", tmuxName, "-F", "#{pane_pid}").Output()
+	pidOut, err := tmuxsession.PanePID(tmuxName)
 	if err != nil {
 		return fmt.Errorf("tmux list-panes: %w", err)
 	}

--- a/internal/worker/import.go
+++ b/internal/worker/import.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/tmuxsession"
 )
 
 // ImportResult describes the outcome of importing a single worktree.
@@ -88,14 +89,14 @@ func Import(cfg *config.Config, s *state.State) ([]ImportResult, error) {
 
 		// Check if tmux session is alive
 		tmuxName := TmuxSessionName(slotName)
-		tmuxAlive := exec.Command("tmux", "has-session", "-t", tmuxName).Run() == nil
+		tmuxAlive := tmuxsession.HasSession(tmuxName)
 
 		status := state.StatusDead
 		pid := 0
 		if tmuxAlive {
 			status = state.StatusRunning
 			// Try to get PID from tmux pane
-			if pidOut, err := exec.Command("tmux", "list-panes", "-t", tmuxName, "-F", "#{pane_pid}").Output(); err == nil {
+			if pidOut, err := tmuxsession.PanePID(tmuxName); err == nil {
 				if p, err := strconv.Atoi(strings.TrimSpace(string(pidOut))); err == nil {
 					pid = p
 				}

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"fmt"
 	"log"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/pipeline"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/tmuxsession"
 )
 
 // StartPhase launches a new worker session for a pipeline phase in an existing worktree.
@@ -23,7 +23,7 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 
 	// Kill any leftover tmux session from the previous phase
 	tmuxName := TmuxSessionName(slotName)
-	exec.Command("tmux", "kill-session", "-t", tmuxName).CombinedOutput()
+	tmuxsession.KillSession(tmuxName)
 
 	// Determine backend
 	if backendName == "" {
@@ -94,13 +94,12 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 	}
 
 	// Start tmux session
-	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", sess.Worktree, "bash", runnerPath)
-	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+	if tmuxOut, err := tmuxsession.StartDetached(tmuxName, sess.Worktree, runnerPath); err != nil {
 		return fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
 	}
 
 	// Get PID
-	pidOut, err := exec.Command("tmux", "list-panes", "-t", tmuxName, "-F", "#{pane_pid}").Output()
+	pidOut, err := tmuxsession.PanePID(tmuxName)
 	if err != nil {
 		return fmt.Errorf("tmux list-panes: %w", err)
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/pipeline"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/tmuxsession"
 )
 
 // SlotPrefix derives the slot prefix from the repo name ("BeFeast/panoptikon" → "pan")
@@ -159,13 +160,12 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 
 	// Start tmux session
 	tmuxName := TmuxSessionName(slotName)
-	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", worktreePath, "bash", runnerPath)
-	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+	if tmuxOut, err := tmuxsession.StartDetached(tmuxName, worktreePath, runnerPath); err != nil {
 		return "", fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
 	}
 
 	// Get PID of the shell running inside the tmux pane
-	pidOut, err := exec.Command("tmux", "list-panes", "-t", tmuxName, "-F", "#{pane_pid}").Output()
+	pidOut, err := tmuxsession.PanePID(tmuxName)
 	if err != nil {
 		return "", fmt.Errorf("tmux list-panes: %w", err)
 	}
@@ -312,13 +312,12 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 
 	// Start tmux session
 	tmuxName := TmuxSessionName(slotName)
-	tmuxCmd := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", worktreePath, "bash", runnerPath)
-	if tmuxOut, err := tmuxCmd.CombinedOutput(); err != nil {
+	if tmuxOut, err := tmuxsession.StartDetached(tmuxName, worktreePath, runnerPath); err != nil {
 		return fmt.Errorf("tmux new-session: %w\n%s", err, tmuxOut)
 	}
 
 	// Get PID
-	pidOut, err := exec.Command("tmux", "list-panes", "-t", tmuxName, "-F", "#{pane_pid}").Output()
+	pidOut, err := tmuxsession.PanePID(tmuxName)
 	if err != nil {
 		return fmt.Errorf("tmux list-panes: %w", err)
 	}
@@ -363,7 +362,7 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 func Stop(cfg *config.Config, slotName string, sess *state.Session) error {
 	// Try to kill the tmux session first (covers tmux-spawned workers)
 	tmuxName := TmuxSessionName(slotName)
-	if out, err := exec.Command("tmux", "kill-session", "-t", tmuxName).CombinedOutput(); err != nil {
+	if out, err := tmuxsession.KillSession(tmuxName); err != nil {
 		log.Printf("[worker] tmux kill-session %s: %v (%s)", tmuxName, err, strings.TrimSpace(string(out)))
 	}
 


### PR DESCRIPTION
Refs #892

## Follow-up incident fix

- Re-read the current open issue before recommending repair for an existing PR.
- Fail closed with a safe monitor decision when blocked or another excluded label is present, the issue is closed, or current issue guards cannot be verified.
- Merge `last_run_once_at` and the matching stuck verdict explicitly during concurrent state saves so orchestrator/watchdog writes cannot silently discard a completed supervisor pulse.

## Live evidence

OK Player issue #331 was blocked and its old repair approval had become stale, but the supervisor minted a replacement approval because the open-PR repair path used only session/PR state. The same live state showed decisions at 10:33, 10:39, and 10:44 UTC while `last_run_once_at` remained 10:16 UTC: the three-way state merge accepted the decision but kept the older pulse.

## Tests

- `go test ./internal/state ./internal/supervisor -count=1`
- `umask 077; go test ./...`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens repair approval handling and updates worker session management. The main changes are:

- Re-check current issue state before recommending repair for an open PR.
- Mark pending and approved repair approvals stale when current issue guards block dispatch.
- Preserve supervisor heartbeat and stuck-state fields during concurrent state saves.
- Treat successful Greptile check runs as the authoritative review gate result.
- Move worker tmux operations through a shared private-session helper.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after fixing the contained repair-guard bug.

The state merge, approval reconciliation, and tmux changes are coherent, but the new current-issue guard can block valid repairs for open issues beyond the first GitHub issues page.

`internal/supervisor/supervisor.go`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I attempted to reproduce the page-limited issue guard but was blocked after the maximum steps for this agent were reached, so I could not complete the focused Go repro.
- I inspected the target guard and confirmed the reproduction should exercise currentIssueRepairGuard by invoking e.reader.ListOpenIssues(nil) and checking that the returned slice does not contain the requested issue.
- I located in-package test helpers such as fakeReader, testConfig, and testEngine to enable a temporary focused test.
- I verified test results by reviewing the per-package supervisor log, which shows the command, working directory, timestamps, package results, and an EXIT\_CODE of 0.
- I confirmed the full-suite test run completed successfully by inspecting the umask077 log, which shows the command, working directory, timestamps, all package results, and EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14831906/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds current issue guard checks before repair recommendations and reprioritizes open-PR sessions; the guard incorrectly treats issues beyond the first open-issues page as closed. |
| internal/orchestrator/orchestrator.go | Updates tmux interactions, review-gate ordering, sequential merge conflict skipping, approval reconciliation, and repair backend selection. |
| internal/state/state.go | Adds three-way merge handling for supervisor heartbeat and stuck verdict fields. |
| internal/tmuxsession/tmuxsession.go | Introduces private tmux server helpers with legacy fallback and systemd scope launch support. |
| internal/state/issue_claim.go | Includes pending repair approvals in guard reconciliation and exposes affected issue lookup. |
| internal/server/actions.go | Adds `spawn_repair_worker` approval gating and request validation for slot and issue fences. |
| internal/worker/worker.go | Uses `tmuxsession` helpers for worker start, respawn, and stop tmux operations. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 5287-5288 ([link](https://github.com/befeast/maestro/blob/5d29799e96f949810689711704cac628ef804a5a/internal/orchestrator/orchestrator.go#L5287-L5288)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Use full guard labels**
   `reconcileGuardedRepairApprovals` only checks `o.cfg.ExcludeLabels`, but the supervisor guard rejects the default `blocked`/`wontfix`/`question` set plus `Supervisor.BlockedLabel`. With the default config where `blocked` is not explicitly in `exclude_labels`, an already-approved repair approval remains active and can dispatch after the issue is blocked, so the standing reconciler does not fail closed for the incident case.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 5287-5288

   Comment:
   **Use full guard labels**
   `reconcileGuardedRepairApprovals` only checks `o.cfg.ExcludeLabels`, but the supervisor guard rejects the default `blocked`/`wontfix`/`question` set plus `Supervisor.BlockedLabel`. With the default config where `blocked` is not explicitly in `exclude_labels`, an already-approved repair approval remains active and can dispatch after the issue is blocked, so the standing reconciler does not fail closed for the incident case.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/supervisor.go:973-974
**Page-limited issue guard**
`currentIssueRepairGuard` treats absence from `ListOpenIssues(nil)` as closed, but the GitHub implementation only reads the first `per_page=100` open issues. On repos with more than 100 open issues, a valid older issue outside that page is returned as `issue is not currently open`, so open-PR repair recommendations for it are blocked even when it has no excluded labels.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: resume reserved workers on current ..."](https://github.com/befeast/maestro/commit/9e22ec3329c62913a06e09d20a082650c6680dd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45059419)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->