### PR TITLE
fix: prevent watchdog saves from regressing supervisor pulse

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1779,6 +1779,15 @@ func (s *State) copyFrom(src *State) {
 	s.Paused = src.Paused
 	s.PausedAt = src.PausedAt
 	s.MaterialProgress = src.MaterialProgress
+	// Keep the caller's in-memory snapshot aligned with the merged file. Save
+	// calls copyFrom after a three-way merge, then rememberLoaded records the
+	// merged file hash. Omitting the heartbeat tuple here leaves a long-lived
+	// writer (notably the material-progress watchdog) holding an older pulse
+	// while believing it loaded the current file. Its next non-conflicting save
+	// can then regress LastRunOnceAt and resurrect an obsolete stuck verdict.
+	s.LastRunOnceAt = src.LastRunOnceAt
+	s.SupervisorStuck = src.SupervisorStuck
+	s.SupervisorStuckReason = src.SupervisorStuckReason
 }
 
 func cloneState(s *State) *State {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -405,6 +405,65 @@ func TestStateMergePreservesWatchdogStuckAtSameHeartbeat(t *testing.T) {
 	}
 }
 
+func TestSaveConcurrentWatchdogSecondWriteDoesNotRegressSupervisorHeartbeat(t *testing.T) {
+	dir := t.TempDir()
+	oldPulse := time.Date(2026, 7, 17, 11, 53, 50, 0, time.UTC)
+	newPulse := time.Date(2026, 7, 17, 12, 0, 2, 0, time.UTC)
+
+	seed := NewState()
+	seed.LastRunOnceAt = oldPulse
+	seed.SupervisorStuck = true
+	seed.SupervisorStuckReason = "old pulse exceeded threshold"
+	if err := Save(dir, seed); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	// The supervisor and the independently scheduled material-progress
+	// evaluator both retain snapshots loaded from the same old file.
+	supervisorState, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load supervisor state: %v", err)
+	}
+	watchdogState, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load watchdog state: %v", err)
+	}
+
+	supervisorState.LastRunOnceAt = newPulse
+	supervisorState.SupervisorStuck = false
+	supervisorState.SupervisorStuckReason = ""
+	if err := Save(dir, supervisorState); err != nil {
+		t.Fatalf("supervisor save: %v", err)
+	}
+
+	// First watchdog save conflicts and three-way-merges with the newer pulse.
+	// copyFrom must update its long-lived in-memory snapshot as well as disk.
+	watchdogState.MaterialProgress = &MaterialProgress{LastEvaluatedAt: newPulse.Add(time.Second)}
+	if err := Save(dir, watchdogState); err != nil {
+		t.Fatalf("first watchdog save: %v", err)
+	}
+	if !watchdogState.LastRunOnceAt.Equal(newPulse) || watchdogState.SupervisorStuck || watchdogState.SupervisorStuckReason != "" {
+		t.Fatalf("watchdog snapshot kept stale heartbeat tuple after merge: pulse=%s stuck=%v reason=%q",
+			watchdogState.LastRunOnceAt, watchdogState.SupervisorStuck, watchdogState.SupervisorStuckReason)
+	}
+
+	// The next evaluator save is non-conflicting because rememberLoaded carries
+	// the merged file hash. Before #929, this exact save wrote the stale pulse
+	// back to disk even though the preceding merge had selected newPulse.
+	watchdogState.MaterialProgress.LastEvaluatedAt = newPulse.Add(2 * time.Second)
+	if err := Save(dir, watchdogState); err != nil {
+		t.Fatalf("second watchdog save: %v", err)
+	}
+	got, err := Load(dir)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !got.LastRunOnceAt.Equal(newPulse) || got.SupervisorStuck || got.SupervisorStuckReason != "" {
+		t.Fatalf("second watchdog save regressed heartbeat tuple: pulse=%s stuck=%v reason=%q",
+			got.LastRunOnceAt, got.SupervisorStuck, got.SupervisorStuckReason)
+	}
+}
+
 func TestNotifiedCIFail_OmittedWhenFalse(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
Refs #929.

## Root cause

The three-way merge correctly selected the newest supervisor heartbeat, but `State.copyFrom` did not copy that heartbeat tuple back into the long-lived writer. `rememberLoaded` then paired the merged file hash with a stale in-memory pulse, so the next non-conflicting watchdog save regressed `last_run_once_at`.

## Changes

- copy `LastRunOnceAt`, `SupervisorStuck`, and `SupervisorStuckReason` from the merged snapshot;
- add an exact two-writer/two-watchdog-save regression test reproducing the live failure.

## Verification

- `go test ./internal/state -run TestSaveConcurrentWatchdogSecondWriteDoesNotRegressSupervisorHeartbeat -count=1`
- `umask 077; go test ./...`

This is a direct urgent Maestro break-fix from the OK Player duplicate-dispatch/control-loop incident. It does not change OK Player code, project concurrency, labels, or models.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a state merge regression in supervisor heartbeat persistence. The main changes are:

- Copies `LastRunOnceAt`, `SupervisorStuck`, and `SupervisorStuckReason` back into the long-lived `State` after a three-way merge.
- Keeps the in-memory writer snapshot aligned with the merged file hash recorded by `rememberLoaded`.
- Adds regression coverage for two loaded writers and consecutive watchdog saves.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow and keeps the caller snapshot consistent with the already-merged persisted state. The new test covers the reported save sequence directly.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the targeted regression proof for the internal/state package, showing the regression test passed with EXIT\_CODE 0.
- Validated the full-suite proof under umask 077, showing all Go packages passed with EXIT\_CODE 0.

<a href="https://app.greptile.com/trex/runs/14834577/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Updates `State.copyFrom` so merged supervisor heartbeat and stuck-state fields are copied back into the caller snapshot. |
| internal/state/state_test.go | Adds regression coverage for the two-writer watchdog save sequence that previously regressed the supervisor heartbeat. |

<sub>Reviews (1): Last reviewed commit: ["fix: retain merged supervisor heartbeat ..."](https://github.com/befeast/maestro/commit/3ec0c8c044ff0a64329073ded8bd37f088d0517c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45071045)</sub>

<!-- /greptile_comment -->