### PR TITLE
Fix in-place worker attempt projection

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4120,6 +4120,14 @@ func fleetSupersedingIssueSession(candidate sessionInfo, all []sessionInfo) (ses
 		switch state.SessionStatus(peer.Status) {
 		case state.StatusPROpen, state.StatusCodeLanded:
 			return peer, true
+		case state.StatusDone:
+			// A terminal peer is authoritative only when it owns the issue's
+			// delivered PR and this attempt was explicitly reconciled as a
+			// duplicate. Do not hide a genuine failed follow-up merely because
+			// an older session for the issue once completed.
+			if peer.PRNumber > 0 && candidate.WorkerOutcome == "duplicate_dispatch_reconciled" {
+				return peer, true
+			}
 		}
 	}
 	return sessionInfo{}, false

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -3924,6 +3924,32 @@ func TestFleetSupersedingIssueSessionSuppressesTerminalDuplicate(t *testing.T) {
 	}
 }
 
+func TestFleetSupersedingIssueSessionUsesCanonicalMergedPRForReconciledDuplicate(t *testing.T) {
+	duplicate := sessionInfo{
+		Slot:           "ok-player-271",
+		IssueNumber:    328,
+		Status:         string(state.StatusFailed),
+		NeedsAttention: true,
+		WorkerOutcome:  "duplicate_dispatch_reconciled",
+	}
+	canonical := sessionInfo{
+		Slot:        "ok-player-250",
+		IssueNumber: 328,
+		Status:      string(state.StatusDone),
+		PRNumber:    363,
+	}
+	got, ok := fleetSupersedingIssueSession(duplicate, []sessionInfo{duplicate, canonical})
+	if !ok || got.Slot != canonical.Slot {
+		t.Fatalf("superseding merged session = %+v, %v; want %s", got, ok, canonical.Slot)
+	}
+
+	genuineFailure := duplicate
+	genuineFailure.WorkerOutcome = ""
+	if got, ok := fleetSupersedingIssueSession(genuineFailure, []sessionInfo{genuineFailure, canonical}); ok {
+		t.Fatalf("genuine failed follow-up incorrectly superseded: %+v", got)
+	}
+}
+
 func TestFleetSupersedingIssueSessionUsesCanonicalOpenPR(t *testing.T) {
 	duplicate := sessionInfo{
 		Slot:           "ok-player-259",

--- a/internal/server/runtime_breakdown_test.go
+++ b/internal/server/runtime_breakdown_test.go
@@ -91,6 +91,35 @@ func TestRuntimeBreakdownRunningSessionWorkerRuntimeIsLiveWallClock(t *testing.T
 	}
 }
 
+func TestRuntimeBreakdownRunningRespawnIgnoresPriorWorkerEndAndUsesActiveRouteModel(t *testing.T) {
+	now := time.Now().UTC()
+	priorEnd := now.Add(-time.Hour)
+	sess := &state.Session{
+		IssueNumber:   346,
+		IssueTitle:    "Fedora packaging",
+		StartedAt:     now.Add(-2 * time.Minute),
+		Status:        state.StatusRunning,
+		Backend:       "sol",
+		Model:         "claude-fable-5",
+		WorkerEndedAt: &priorEnd,
+		Attribution: []state.BackendAttribution{
+			{Backend: "claude", Model: "claude-fable-5", StartedAt: now.Add(-time.Hour), EndedAt: &priorEnd},
+			{Backend: "sol", Provider: "openai", Model: "gpt-5.6-sol", Effort: "high", StartedAt: now.Add(-2 * time.Minute)},
+		},
+	}
+
+	info := makeSessionInfo("BeFeast/ok-player", "ok-player-272", sess)
+	if info.WorkerRuntimeSeconds < 100 || info.WorkerRuntimeSeconds > 140 {
+		t.Fatalf("worker runtime = %d, want current attempt around 120s", info.WorkerRuntimeSeconds)
+	}
+	if info.WorkerEndedAt != "" {
+		t.Fatalf("running worker exposed stale worker_ended_at %q", info.WorkerEndedAt)
+	}
+	if info.Model != "gpt-5.6-sol" {
+		t.Fatalf("model = %q, want active route gpt-5.6-sol", info.Model)
+	}
+}
+
 // TestMarkWorkerEndedIsIdempotent guards against later status transitions
 // (pr_open -> code_landed -> done) sliding WorkerEndedAt forward and
 // undoing the agent-vs-workflow distinction.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -416,7 +416,7 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 		IssueURL:          githubIssueURL(repo, sess.IssueNumber),
 		Status:            string(sess.Status),
 		Backend:           sess.Backend,
-		Model:             sess.Model,
+		Model:             currentSessionModel(sess),
 		PRNumber:          sess.PRNumber,
 		PRURL:             githubPRURL(repo, sess.PRNumber),
 		TokensUsedAttempt: sess.TokensUsedAttempt,
@@ -458,11 +458,14 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 	info.WorkflowRuntimeSeconds = info.RuntimeSeconds
 
 	workerEnd := end
-	if sess.WorkerEndedAt != nil {
+	// A running attempt is authoritative over a stale terminal marker left by
+	// an older binary. This also repairs the live projection immediately after
+	// upgrading, before that session is respawned again.
+	if sess.Status == state.StatusRunning {
+		workerEnd = now
+	} else if sess.WorkerEndedAt != nil {
 		workerEnd = *sess.WorkerEndedAt
 		info.WorkerEndedAt = sess.WorkerEndedAt.Format(time.RFC3339)
-	} else if sess.Status == state.StatusRunning {
-		workerEnd = now
 	}
 	workerDur := workerEnd.Sub(sess.StartedAt).Round(time.Second)
 	if workerDur < 0 {
@@ -512,6 +515,23 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 	}
 
 	return info
+}
+
+// currentSessionModel returns the model for the live route. A backend may not
+// self-report usage/model data immediately (or at all), so the active
+// attribution segment is the truthful configured fallback. Terminal sessions
+// retain the last self-reported model for historical display.
+func currentSessionModel(sess *state.Session) string {
+	if sess == nil {
+		return ""
+	}
+	if sess.Status == state.StatusRunning && len(sess.Attribution) > 0 {
+		active := sess.Attribution[len(sess.Attribution)-1]
+		if active.EndedAt == nil && active.Backend == sess.Backend && strings.TrimSpace(active.Model) != "" {
+			return active.Model
+		}
+	}
+	return sess.Model
 }
 
 func githubIssueURL(repo string, issueNumber int) string {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -199,7 +199,7 @@ type Session struct {
 	// configured per-backend pricing estimate.
 	Model                    string     `json:"model,omitempty"`                  // model the backend reported for this run (e.g. glm-5.2:cloud, claude-opus-4-8)
 	CostUSDBackend           float64    `json:"cost_usd_backend,omitempty"`       // USD cost the backend self-reported (Pi cost.total / claude total_cost_usd)
-	UsageTokensWatermark     int        `json:"usage_tokens_watermark,omitempty"` // #730/#737: high-water mark of a backend usage stream's full-log cumulative token count (Pi --mode json, claude stream-json); persists across respawns so re-parsing the appended log/jsonl does not double-count prior attempts
+	UsageTokensWatermark     int        `json:"usage_tokens_watermark,omitempty"` // #730/#737: high-water mark of the current attempt's backend usage stream; reset when an attempt log is rotated so a replacement process starts from its own zero while TokensUsedTotal remains cumulative
 	LongRunning              bool       `json:"long_running,omitempty"`
 	RebaseAttempted          bool       `json:"rebase_attempted,omitempty"`
 	NotifiedCIFail           bool       `json:"notified_ci_fail,omitempty"`           // deprecated: use LastNotifiedStatus

--- a/internal/worker/attribution.go
+++ b/internal/worker/attribution.go
@@ -7,6 +7,30 @@ import (
 	"github.com/befeast/maestro/internal/state"
 )
 
+// beginSessionAttempt resets fields whose meaning is scoped to the currently
+// executing backend process while preserving issue/worktree identity and the
+// cumulative attribution/token history. Recovery and phase transitions reuse
+// the same state.Session, so leaving a previous attempt's terminal timestamp or
+// self-reported model behind makes a live replacement look finished (and can
+// label a Sol worker as Fable in Mission Control).
+func beginSessionAttempt(cfg *config.Config, sess *state.Session, backendName, reason, previousEndReason string, now time.Time) {
+	if sess == nil {
+		return
+	}
+	now = now.UTC()
+	sess.StartedAt = now
+	sess.FinishedAt = nil
+	sess.WorkerEndedAt = nil
+	sess.Status = state.StatusRunning
+	sess.Backend = backendName
+	sess.Model = ""
+	sess.CostUSDBackend = 0
+	sess.UsageTokensWatermark = 0
+	sess.TokensUsedAttempt = 0
+	sess.WorkerOutcome = ""
+	recordBackendAttribution(cfg, sess, backendName, reason, previousEndReason, now)
+}
+
 // recordBackendAttribution appends a new BackendAttribution segment to
 // sess.Attribution and closes the previous one's EndedAt + EndReason.
 // Called from every place that sets sess.Backend (Start, Respawn,

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -235,16 +235,9 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 	sess.PID = pid
 	sess.TmuxSession = tmuxName
 	sess.LogFile = logFile
-	sess.StartedAt = time.Now().UTC()
-	sess.FinishedAt = nil
-	sess.Status = state.StatusRunning
-	sess.Backend = backendName
-	// #513: in-place respawn (post-checkpoint resume) — record a new
-	// segment so the timeline shows where the previous segment ended
-	// and the new one began.
-	recordBackendAttribution(cfg, sess, backendName, "in_place_respawn", "in_place_respawn", time.Now())
-	sess.TokensUsedAttempt = 0
-	sess.WorkerOutcome = ""
+	// #513/#931: start a new attempt projection while preserving the same
+	// worktree/session identity and cumulative attribution history.
+	beginSessionAttempt(cfg, sess, backendName, "in_place_respawn", "in_place_respawn", time.Now())
 	sess.NotifiedCIFail = false
 	sess.LastNotifiedStatus = ""
 	sess.LastOutputHash = ""

--- a/internal/worker/checkpoint_test.go
+++ b/internal/worker/checkpoint_test.go
@@ -5,11 +5,57 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/state"
 )
+
+func TestBeginSessionAttemptClearsPriorProjectionAndPreservesHistory(t *testing.T) {
+	ended := time.Date(2026, 7, 17, 11, 5, 0, 0, time.UTC)
+	started := ended.Add(time.Hour)
+	sess := &state.Session{
+		IssueNumber:          346,
+		PRNumber:             335,
+		Worktree:             "/tmp/kept-worktree",
+		Branch:               "feat/kept-branch",
+		Backend:              "claude",
+		Model:                "claude-fable-5",
+		Status:               state.StatusDead,
+		FinishedAt:           &ended,
+		WorkerEndedAt:        &ended,
+		CostUSDBackend:       1.25,
+		UsageTokensWatermark: 1_730_413,
+		TokensUsedAttempt:    1_730_413,
+		TokensUsedTotal:      1_730_413,
+		WorkerOutcome:        "failed",
+		Attribution: []state.BackendAttribution{{
+			Backend: "claude", Model: "claude-fable-5", StartedAt: ended.Add(-time.Minute),
+		}},
+	}
+	cfg := &config.Config{Model: config.ModelConfig{Backends: map[string]config.BackendDef{
+		"sol": {Provider: "openai", Model: "gpt-5.6-sol", Effort: "high"},
+	}}}
+
+	beginSessionAttempt(cfg, sess, "sol", "in_place_respawn", "in_place_respawn", started)
+
+	if sess.Status != state.StatusRunning || sess.Backend != "sol" || !sess.StartedAt.Equal(started) {
+		t.Fatalf("live attempt = status %q backend %q start %v", sess.Status, sess.Backend, sess.StartedAt)
+	}
+	if sess.FinishedAt != nil || sess.WorkerEndedAt != nil || sess.Model != "" || sess.CostUSDBackend != 0 {
+		t.Fatalf("stale projection retained: finished=%v ended=%v model=%q cost=%v", sess.FinishedAt, sess.WorkerEndedAt, sess.Model, sess.CostUSDBackend)
+	}
+	if sess.TokensUsedAttempt != 0 || sess.UsageTokensWatermark != 0 || sess.WorkerOutcome != "" {
+		t.Fatalf("attempt counters not reset: attempt=%d watermark=%d outcome=%q", sess.TokensUsedAttempt, sess.UsageTokensWatermark, sess.WorkerOutcome)
+	}
+	if sess.TokensUsedTotal != 1_730_413 || sess.Worktree != "/tmp/kept-worktree" || sess.Branch != "feat/kept-branch" || sess.PRNumber != 335 {
+		t.Fatalf("cumulative/session identity changed: total=%d worktree=%q branch=%q PR=%d", sess.TokensUsedTotal, sess.Worktree, sess.Branch, sess.PRNumber)
+	}
+	if len(sess.Attribution) != 2 || sess.Attribution[0].EndedAt == nil || sess.Attribution[1].Backend != "sol" || sess.Attribution[1].Model != "gpt-5.6-sol" || sess.Attribution[1].EndedAt != nil {
+		t.Fatalf("attribution = %+v", sess.Attribution)
+	}
+}
 
 func TestSaveCheckpoint_WritesFile(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -114,14 +114,9 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 	sess.PID = pid
 	sess.TmuxSession = tmuxName
 	sess.LogFile = logFile
-	sess.StartedAt = time.Now().UTC()
-	sess.FinishedAt = nil
-	sess.Status = state.StatusRunning
-	sess.Backend = backendName
+	beginSessionAttempt(cfg, sess, backendName, "phase_transition", "phase_transition", time.Now())
 	sess.LastOutputHash = ""
 	sess.LastOutputChangedAt = time.Time{}
-	sess.TokensUsedAttempt = 0
-	sess.WorkerOutcome = ""
 	sess.LastNotifiedStatus = ""
 
 	return nil

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -334,19 +334,15 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	sess.PID = pid
 	sess.TmuxSession = tmuxName
 	sess.LogFile = logFile
-	sess.StartedAt = time.Now().UTC()
-	sess.FinishedAt = nil
-	sess.Status = state.StatusRunning
+	now := time.Now()
 	sess.PRNumber = 0
-	sess.Backend = backendName
-	// #513: stamp the fallover attribution segment.
-	recordBackendAttribution(cfg, sess, backendName, "fallover", "fallover", time.Now())
+	// #513/#931: stamp the fallover segment and clear the previous attempt's
+	// terminal/model projection without losing cumulative history.
+	beginSessionAttempt(cfg, sess, backendName, "fallover", "fallover", now)
 	sess.NotifiedCIFail = false
 	sess.LastNotifiedStatus = ""
 	sess.LastOutputHash = ""
 	sess.LastOutputChangedAt = time.Time{}
-	sess.TokensUsedAttempt = 0
-	sess.WorkerOutcome = ""
 	// CIFailureOutput and PreviousAttemptFeedback are normally cleared by
 	// respawnDueRetries before this call, but cleared here defensively in
 	// case Respawn is called from other paths.


### PR DESCRIPTION
## Summary
- reset attempt-scoped runtime, model, watermark, and outcome fields for every in-place respawn/fallover/phase transition while preserving cumulative usage and session/worktree/PR identity
- project active-attribution model and running runtime truthfully in Fleet MC even when legacy terminal fields remain
- suppress explicitly reconciled no-PR duplicate attempts behind their canonical completed session with merged PR
- cover Sol respawn projection and canonical-done duplicate reconciliation with regression tests

Refs #931
Refs #933

## Validation
- `umask 077; go test ./internal/worker ./internal/server`
- `umask 077; go test ./...`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes worker attempt projection during respawns, fallovers, and phase transitions. The main changes are:

- Centralizes attempt-scoped reset logic for runtime, model, watermark, token-attempt, cost, and outcome fields.
- Updates Fleet session projection to show the active attribution model and live worker runtime for running attempts.
- Narrows duplicate-attempt suppression to explicitly reconciled no-PR attempts behind canonical completed PR sessions.
- Adds tests for respawn projection, active model display, and canonical duplicate reconciliation.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are targeted, reuse a shared helper for previously duplicated reset logic, and include tests for the affected projection and duplicate-reconciliation paths. No functional or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Performed focused validation and confirmed that internal/worker and internal/server reported ok.
- Executed the full-suite validation across all packages, including cached revalidation for internal/worker and internal/server.
- Verified that the validation logs include command, working directory, and exit code headers as requested.

<a href="https://app.greptile.com/trex/runs/14836722/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/attribution.go | Introduces a shared attempt-reset helper that clears attempt-scoped projection fields and records a new attribution segment. |
| internal/server/server.go | Updates session projection to prefer active attribution model for running sessions and ignore stale worker end timestamps while running. |
| internal/server/fleet.go | Adjusts duplicate suppression so reconciled no-PR terminal attempts can be hidden behind canonical completed PR sessions without hiding unrelated failures. |
| internal/worker/checkpoint.go | Uses the shared attempt-reset helper for in-place checkpoint respawns while preserving session and worktree identity. |
| internal/worker/worker.go | Uses the shared attempt-reset helper for fallover respawns while still clearing PR identity for full respawns. |
| internal/worker/phase.go | Uses the shared attempt-reset helper for phase transitions. |
| internal/worker/checkpoint_test.go | Adds tests that attempt reset clears stale runtime, model, and outcome fields while preserving cumulative session identity. |
| internal/server/runtime_breakdown_test.go | Adds tests ensuring running respawns ignore stale worker end times and show the active attribution model. |
| internal/server/fleet_test.go | Adds tests for canonical completed-PR duplicate reconciliation and genuine follow-up failure visibility. |
| internal/state/state.go | Clarifies that the usage watermark is scoped to the current attempt while cumulative usage remains preserved. |

<sub>Reviews (1): Last reviewed commit: ["Suppress reconciled duplicate fleet atte..."](https://github.com/befeast/maestro/commit/0fe921fe764b382ae9af322b0cbb55b15f5147e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45074618)</sub>

<!-- /greptile_comment -->