### PR TITLE
Prioritize merge-ready PRs and retain terminal issue leases

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3715,6 +3715,20 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					continue
 				}
 			}
+			// A completed PR keeps a terminal-reconciliation issue lease while the
+			// linked issue is still open, closing the merge->close redispatch gap.
+			// Once the forge proves the issue closed, release that lease so Fleet
+			// diagnostics do not retain a permanent active claim. A later explicit
+			// issue reopen is then eligible by design.
+			if sess.Status == state.StatusDone && sess.PRNumber > 0 && sess.FinishedAt != nil && !sess.ReleasedForRedispatch {
+				closed, err := o.isIssueClosed(sess.IssueNumber)
+				if err != nil {
+					log.Printf("[orch] terminal claim check for issue #%d / PR #%d: %v", sess.IssueNumber, sess.PRNumber, err)
+				} else if closed {
+					sess.ReleasedForRedispatch = true
+					log.Printf("[orch] terminal claim reconciled for issue #%d / PR #%d on %s: issue is closed", sess.IssueNumber, sess.PRNumber, slotName)
+				}
+			}
 			// Zombie cleanup: if the underlying issue is closed, transition to done.
 			// This prevents conflict_failed/failed/dead/retry_exhausted sessions from lingering
 			// indefinitely when their issues are closed externally (#187).

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -258,6 +258,33 @@ func TestReconcileRunningSessions_DeadWithPendingRetry_NotFlippedToPROpen(t *tes
 	}
 }
 
+func TestCheckSessions_DonePRReleasesTerminalClaimAfterIssueCloses(t *testing.T) {
+	finishedAt := time.Now().UTC().Add(-time.Minute)
+	s := state.NewState()
+	s.Sessions["ok-player-274"] = &state.Session{
+		IssueNumber: 365, Status: state.StatusDone, PRNumber: 370, FinishedAt: &finishedAt,
+	}
+	if _, ok := s.IssueClaimFor(365); !ok {
+		t.Fatal("done PR must hold a terminal reconciliation claim before issue closure")
+	}
+	o := &Orchestrator{
+		cfg:                 &config.Config{StateDir: t.TempDir()},
+		listOpenPRsFn:       func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn:     func(issueNumber int) (bool, error) { return issueNumber == 365, nil },
+		pidAliveFn:          func(int) bool { return false },
+		tmuxSessionExistsFn: func(string) bool { return false },
+	}
+
+	o.checkSessions(s)
+
+	if !s.Sessions["ok-player-274"].ReleasedForRedispatch {
+		t.Fatal("closed issue must release its completed PR terminal claim")
+	}
+	if _, ok := s.IssueClaimFor(365); ok {
+		t.Fatal("closed issue retained terminal reconciliation claim")
+	}
+}
+
 func TestReconcileRunningSessions_DeadWorkerWithOpenPR_CapturesTokensFromPersistedLog(t *testing.T) {
 	stateDir := t.TempDir()
 	logDir := state.LogDir(stateDir)

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4125,12 +4125,18 @@ func fleetSupersedingIssueSession(candidate sessionInfo, all []sessionInfo) (ses
 			// delivered PR and this attempt was explicitly reconciled as a
 			// duplicate. Do not hide a genuine failed follow-up merely because
 			// an older session for the issue once completed.
-			if peer.PRNumber > 0 && candidate.WorkerOutcome == "duplicate_dispatch_reconciled" {
+			if peer.PRNumber > 0 && (candidate.WorkerOutcome == "duplicate_dispatch_reconciled" || fleetSessionStartedAfterCanonicalCompletion(candidate, peer)) {
 				return peer, true
 			}
 		}
 	}
 	return sessionInfo{}, false
+}
+
+func fleetSessionStartedAfterCanonicalCompletion(candidate, canonical sessionInfo) bool {
+	started, startErr := time.Parse(time.RFC3339, strings.TrimSpace(candidate.StartedAt))
+	finished, finishErr := time.Parse(time.RFC3339, strings.TrimSpace(canonical.FinishedAt))
+	return startErr == nil && finishErr == nil && !started.Before(finished)
 }
 
 func fleetCloseCandidates(project fleetProjectState, st *state.State) []fleetCloseCandidate {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -3950,6 +3950,27 @@ func TestFleetSupersedingIssueSessionUsesCanonicalMergedPRForReconciledDuplicate
 	}
 }
 
+func TestFleetSupersedingIssueSessionUsesCanonicalMergedPRForLaterDuplicate(t *testing.T) {
+	duplicate := sessionInfo{
+		Slot: "ok-player-278", IssueNumber: 365, Status: string(state.StatusDead), NeedsAttention: true,
+		StartedAt: "2026-07-17T13:28:26Z",
+	}
+	canonical := sessionInfo{
+		Slot: "ok-player-274", IssueNumber: 365, Status: string(state.StatusDone), PRNumber: 370,
+		FinishedAt: "2026-07-17T13:28:21Z",
+	}
+	got, ok := fleetSupersedingIssueSession(duplicate, []sessionInfo{duplicate, canonical})
+	if !ok || got.Slot != canonical.Slot {
+		t.Fatalf("later duplicate superseding session = %+v, %v; want %s", got, ok, canonical.Slot)
+	}
+
+	earlierFailure := duplicate
+	earlierFailure.StartedAt = "2026-07-17T13:20:00Z"
+	if got, ok := fleetSupersedingIssueSession(earlierFailure, []sessionInfo{earlierFailure, canonical}); ok {
+		t.Fatalf("earlier genuine failure incorrectly superseded: %+v", got)
+	}
+}
+
 func TestFleetSupersedingIssueSessionUsesCanonicalOpenPR(t *testing.T) {
 	duplicate := sessionInfo{
 		Slot:           "ok-player-259",

--- a/internal/state/issue_claim.go
+++ b/internal/state/issue_claim.go
@@ -25,6 +25,7 @@ const (
 	IssueClaimOpenPRMaintenance    = "open_pr_maintenance"
 	IssueClaimScheduledRetry       = "scheduled_retry"
 	IssueClaimRetainedWorktree     = "retained_worktree"
+	IssueClaimTerminalReconcile    = "terminal_reconciliation"
 	IssueClaimRepairDispatch       = "repair_dispatch"
 	IssueClaimReviewRepairDispatch = "review_repair_dispatch"
 )
@@ -261,6 +262,18 @@ func sessionIssueClaim(slot string, sess *Session) (IssueClaim, bool) {
 		claim.Kind = IssueClaimOpenPRMaintenance
 		claim.Reason = fmt.Sprintf("issue #%d is maintained by session %s for PR #%d", sess.IssueNumber, slot, sess.PRNumber)
 		return claim, true
+	case StatusDone:
+		// A merged/completed PR is not the end of issue identity until forge
+		// reconciliation closes the linked issue (or explicitly releases the
+		// session for redispatch). Without this lease there is a real race:
+		// pr_open -> done removes the open-PR claim, then the still-open issue
+		// retains its ready label and the next selector cycle starts a duplicate
+		// worker before close-issue reconciliation completes.
+		if sess.PRNumber > 0 && sess.FinishedAt != nil && !sess.ReleasedForRedispatch {
+			claim.Kind = IssueClaimTerminalReconcile
+			claim.Reason = fmt.Sprintf("issue #%d awaits terminal reconciliation on completed session %s / PR #%d", sess.IssueNumber, slot, sess.PRNumber)
+			return claim, true
+		}
 	case StatusDead:
 		if sess.NextRetryAt != nil {
 			claim.Kind = IssueClaimScheduledRetry

--- a/internal/state/issue_claim_test.go
+++ b/internal/state/issue_claim_test.go
@@ -86,3 +86,22 @@ func TestIssueClaimFor_DeadScheduledRetryRemainsReserved(t *testing.T) {
 		t.Fatalf("claim = %+v, %v, want scheduled retry", claim, ok)
 	}
 }
+
+func TestIssueClaimFor_DonePRRemainsReservedUntilExplicitRelease(t *testing.T) {
+	s := NewState()
+	finishedAt := time.Now().UTC()
+	s.Sessions["ok-player-274"] = &Session{IssueNumber: 365, Status: StatusDone, PRNumber: 370, FinishedAt: &finishedAt}
+
+	claim, ok := s.IssueClaimFor(365)
+	if !ok || claim.Kind != IssueClaimTerminalReconcile || claim.Session != "ok-player-274" || claim.PRNumber != 370 {
+		t.Fatalf("claim = %+v, %v; want terminal reconciliation lease", claim, ok)
+	}
+	if !s.IssueInProgress(365) {
+		t.Fatal("done PR must keep issue reserved through close-issue reconciliation")
+	}
+
+	s.Sessions["ok-player-274"].ReleasedForRedispatch = true
+	if _, ok := s.IssueClaimFor(365); ok {
+		t.Fatal("explicitly released done session must not retain terminal reconciliation lease")
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -609,7 +609,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	cache := newResolutionCache(e.reader)
 	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false, cache)
 
-	if slot, sess, pr, ok := e.sessionWithOpenPR(st, prs, cache); ok {
+	if slot, sess, pr, mergeReady, mergeReasons, ok := e.sessionWithOpenPR(st, prs, cache); ok {
 		// #565: auto review-repair respawn. When a green+mergeable PR is
 		// settled retry_exhausted on review feedback AND Greptile flags
 		// ≥1 P0/P1 inline comment on its current head SHA, mint a
@@ -665,7 +665,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		// rule, every CLEAN/SUCCESS PR sat in pr_open forever while supervisor
 		// emitted monitor_open_pr loops; the reasoning even claimed "Maestro will
 		// merge when the merge gate allows it" — aspirational, never implemented.
-		if ready, mergeReasons := e.openPRReadyToMerge(slot, sess, pr); ready {
+		if mergeReady {
 			summary := fmt.Sprintf("Merge PR #%d for issue #%d — checks green, mergeable, review gates passed.", pr.Number, sess.IssueNumber)
 			reasons := appendReasons(baseReasons, mergeReasons...)
 			target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
@@ -2653,7 +2653,7 @@ func sessionWithOpenPR(st *state.State, prs []github.PR) (string, *state.Session
 	return "", nil, github.PR{}, false
 }
 
-func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *resolutionCache) (string, *state.Session, github.PR, bool) {
+func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *resolutionCache) (string, *state.Session, github.PR, bool, []string, bool) {
 	branchToPR := make(map[string]github.PR, len(prs))
 	numberToPR := make(map[int]github.PR, len(prs))
 	for _, pr := range prs {
@@ -2665,10 +2665,12 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 	// is intentionally blocked for QA: a later conflict_failed/retry_exhausted
 	// canonical PR still needs the project's one actionable recommendation.
 	// Keep the sort order as a deterministic tie-breaker within each rank.
-	bestRank := 2
+	bestRank := 3
 	var bestSlot string
 	var bestSession *state.Session
 	var bestPR github.PR
+	var bestReady bool
+	var bestMergeReasons []string
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
 		if sess == nil || e.sessionResolvedOnGitHub(sess, cache) {
@@ -2685,25 +2687,37 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 		if !found {
 			continue
 		}
-		rank := 1
-		switch sess.Status {
-		case state.StatusRetryExhausted, state.StatusConflictFailed, state.StatusFailed, state.StatusDead:
+		// Evaluate merge eligibility across the whole candidate set before
+		// choosing one session. Previously every ordinary pr_open candidate had
+		// the same rank, so the lexicographically first slot (often an old
+		// blocked draft) prevented a later CLEAN green PR from ever reaching the
+		// merge rule. One ready PR is the highest-priority action in sequential
+		// merge mode; attention states remain next, then passive PR gates.
+		ready, mergeReasons := e.openPRReadyToMerge(slot, sess, pr)
+		rank := 2
+		if ready {
 			rank = 0
+		} else {
+			switch sess.Status {
+			case state.StatusRetryExhausted, state.StatusConflictFailed, state.StatusFailed, state.StatusDead:
+				rank = 1
+			}
 		}
 		if bestSession == nil || rank < bestRank {
 			bestRank = rank
 			bestSlot, bestSession, bestPR = slot, sess, pr
+			bestReady, bestMergeReasons = ready, mergeReasons
 		}
 		if bestRank == 0 {
-			// sortedSessionNames already provides the deterministic tie-break;
-			// no later candidate can outrank an attention state.
+			// sortedSessionNames provides the deterministic tie-break among
+			// equally merge-ready PRs; no later candidate can outrank this one.
 			break
 		}
 	}
 	if bestSession != nil {
-		return bestSlot, bestSession, bestPR, true
+		return bestSlot, bestSession, bestPR, bestReady, bestMergeReasons, true
 	}
-	return "", nil, github.PR{}, false
+	return "", nil, github.PR{}, false, nil, false
 }
 
 func runningSession(st *state.State) (string, *state.Session, bool) {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1039,6 +1039,44 @@ func TestDecide_BlockedIssueWithOpenPRNeverMintsRepairApproval(t *testing.T) {
 	}
 }
 
+func TestDecide_MergeReadyPRRanksAheadOfOlderBlockedDraft(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.MaxParallel = 20
+	cfg.ExcludeLabels = []string{"blocked"}
+	reader := &fakeReader{
+		issues: []github.Issue{
+			testIssue(331, "old blocked draft", "blocked"),
+			testIssue(365, "clean P0"),
+		},
+		prs: []github.PR{
+			{Number: 335, HeadRefName: "feat/old-draft", State: "OPEN", Mergeable: "MERGEABLE", IsDraft: true},
+			{Number: 370, HeadRefName: "feat/clean-p0", State: "OPEN", Mergeable: "MERGEABLE"},
+		},
+		ciStatuses: map[int]string{335: "success", 370: "success"},
+		greptileOK: map[int]bool{335: true, 370: true},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-247"] = &state.Session{
+		IssueNumber: 331, IssueTitle: "old blocked draft", Status: state.StatusPROpen,
+		PRNumber: 335, Branch: "feat/old-draft",
+	}
+	st.Sessions["ok-player-274"] = &state.Session{
+		IssueNumber: 365, IssueTitle: "clean P0", Status: state.StatusPROpen,
+		PRNumber: 370, Branch: "feat/clean-p0",
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMergePR {
+		t.Fatalf("action = %q, want %q; summary=%q", decision.RecommendedAction, ActionMergePR, decision.Summary)
+	}
+	if decision.Target == nil || decision.Target.PR != 370 || decision.Target.Issue != 365 || decision.Target.Session != "ok-player-274" {
+		t.Fatalf("target = %#v, want clean PR #370 / issue #365 / ok-player-274", decision.Target)
+	}
+}
+
 func TestDecide_RetryExhaustedReadyIssueSpawnsRepairWorkerEvenWhenProjectBlocked(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}


### PR DESCRIPTION
## Summary
- rank merge-ready PRs across the whole open-PR candidate set before choosing a supervisor target, so an older blocked draft cannot head-of-line block a later CLEAN green PR
- retain a `terminal_reconciliation` issue lease after a completed PR while the linked issue remains open, closing the three-second `done -> redispatch` race observed on OK Player #365
- release the terminal lease only after GitHub proves the issue closed (or explicit release), so closed history does not retain active claims
- suppress a later no-PR failed/dead attempt behind the canonical completed PR when timestamps prove it started after canonical completion

## Live incident
- OK Player PR #370 was CLEAN/non-draft/all-green but supervisor repeatedly selected blocked draft #335
- after operator-approved merge `cf4b1b1`, canonical session ok-player-274 became done at 13:28:21 UTC; claim disappeared and ok-player-278 was dispatched at 13:28:24 while issue #365 remained open+ready
- issue #365 is now closed; ok-player-278 produced no diff or PR

## Validation
- `umask 077; go test ./internal/orchestrator ./internal/state ./internal/server ./internal/supervisor`
- `umask 077; go test ./...`

Refs #934

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates PR selection and issue lease handling for completed work. The main changes are:

- Ranks merge-ready open PRs ahead of older blocked or passive PR candidates.
- Keeps a terminal issue lease for completed PR sessions until the linked issue is closed or explicitly released.
- Releases completed-PR terminal leases after issue-close reconciliation confirms the issue is closed.
- Suppresses later no-PR terminal duplicate attempts behind the canonical completed PR when timestamps prove the duplicate started afterward.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are targeted and covered by tests across supervisor selection, issue claims, orchestrator reconciliation, and Fleet display behavior. No functional or security issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the initial go-focused-01-after.log to understand how the wrapper-shell captured the status after the Go tests.
- Confirmed the focused run in go-focused-02-after.log shows EXIT\_STATUS: 0, validating the focused proof against the contract.
- Confirmed the full-suite run in go-full-02-after.log shows EXIT\_STATUS: 0, validating the full-proof against the contract.

<a href="https://app.greptile.com/trex/runs/14843597/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Ranks merge-ready open PR sessions ahead of blocked/passive candidates and reuses precomputed merge reasons in the decision path. |
| internal/state/issue_claim.go | Introduces terminal reconciliation issue claims for completed PR sessions until explicit release or issue closure. |
| internal/orchestrator/orchestrator.go | Adds reconciliation that releases completed-PR terminal issue claims once the linked issue is confirmed closed. |
| internal/server/fleet.go | Updates Fleet supersession logic to hide later no-PR terminal duplicates behind the canonical completed PR when timestamps prove ordering. |
| internal/supervisor/supervisor_test.go | Adds tests for selecting a later merge-ready PR over an older blocked draft. |
| internal/state/issue_claim_test.go | Verifies done PR sessions reserve their issue until released and integrate with issue-in-progress checks. |
| internal/orchestrator/orchestrator_test.go | Covers terminal claim release after issue closure for completed PR sessions. |
| internal/server/fleet_test.go | Adds tests for later duplicate suppression while preserving earlier genuine failures. |

<sub>Reviews (1): Last reviewed commit: ["Release terminal claim after issue closu..."](https://github.com/befeast/maestro/commit/9015402c002ebb9b310cbb903bbe4653200a6428) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45089522)</sub>

<!-- /greptile_comment -->