### PR TITLE
fix: unblock exact repair behind older terminal claim

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7078,6 +7078,25 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 		if claim.IssueNumber != issue.Number || claim.Session == "" || claim.Session == slot {
 			continue
 		}
+		// A completed older PR can retain the issue's terminal-reconciliation
+		// claim until GitHub closes the issue. That claim must still prevent a
+		// fresh implementation dispatch, but it must not veto an explicitly
+		// approved repair of a newer, already-existing canonical PR/session.
+		// The repair reservation is exact (issue + session + PR), so ignoring
+		// only a chronologically earlier done session cannot create another
+		// worker identity. Other active/open/retry claims continue to fail
+		// closed below.
+		if claim.Kind == state.IssueClaimTerminalReconcile &&
+			claim.Status == string(state.StatusDone) &&
+			claim.PRNumber > 0 && target.PR > 0 && claim.PRNumber != target.PR {
+			prior, exists := s.SessionAt(claim.Session)
+			if exists && prior.Status == state.StatusDone && prior.FinishedAt != nil &&
+				!sess.StartedAt.IsZero() && !prior.FinishedAt.After(sess.StartedAt) {
+				log.Printf("[orch] ignoring older terminal claim on session %s / PR #%d while repairing reserved newer session %s / PR #%d for issue #%d",
+					claim.Session, claim.PRNumber, slot, target.PR, issue.Number)
+				continue
+			}
+		}
 		log.Printf("[orch] refusing repair dispatch for issue #%d on %s: competing claim on session %s (%s)", issue.Number, slot, claim.Session, claim.Reason)
 		return false
 	}
@@ -7124,8 +7143,19 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 	var err error
 	if sess.PRNumber > 0 {
 		if strings.TrimSpace(sess.Worktree) == "" {
-			log.Printf("[orch] refusing repair dispatch for issue #%d on %s: PR #%d worktree is missing", issue.Number, slot, sess.PRNumber)
-			return false
+			// Cleanup can clear the persisted Worktree field after a terminal
+			// attempt even when an operator has restored the exact slot worktree
+			// from the canonical PR branch. Reattach only the deterministic
+			// <worktree_base>/<slot> path and require git worktree metadata; never
+			// discover or allocate a different slot here.
+			restored := filepath.Join(o.cfg.WorktreeBase, slot)
+			if _, statErr := os.Stat(filepath.Join(restored, ".git")); statErr == nil {
+				sess.Worktree = restored
+				log.Printf("[orch] reattached restored worktree %s to reserved repair session %s / PR #%d", restored, slot, sess.PRNumber)
+			} else {
+				log.Printf("[orch] refusing repair dispatch for issue #%d on %s: PR #%d worktree is missing", issue.Number, slot, sess.PRNumber)
+				return false
+			}
 		}
 		err = o.respawnInPlaceWithConfig(o.cfg, slot, sess, issue, promptBase, backend)
 	} else {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -5066,6 +5067,76 @@ func TestStartNewWorkers_SupervisorRepairSpawnRepairsReservedSessionInPlace(t *t
 	}
 	if len(s.Sessions) != 1 || s.Sessions["pan-12"].Status != state.StatusRunning {
 		t.Fatalf("sessions = %+v, want only pan-12 running", s.Sessions)
+	}
+}
+
+func TestStartNewWorkers_ApprovedRepairIgnoresOlderDoneTerminalClaim(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	cfg.WorktreeBase = t.TempDir()
+	restoredWorktree := filepath.Join(cfg.WorktreeBase, "sup-360")
+	if err := os.MkdirAll(restoredWorktree, 0o755); err != nil {
+		t.Fatalf("mkdir restored worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(restoredWorktree, ".git"), []byte("gitdir: test\n"), 0o644); err != nil {
+		t.Fatalf("write restored worktree metadata: %v", err)
+	}
+	issues := []github.Issue{makeIssue(887, "finish watchdog recovery")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.hasOpenPRForIssueFn = func(issueNumber int) (bool, error) {
+		return issueNumber == 887, nil
+	}
+	respawned := ""
+	o.respawnInPlaceFn = func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backend string) error {
+		respawned = slotName
+		sess.Status = state.StatusRunning
+		sess.PID = 5555
+		return nil
+	}
+
+	oldFinished := time.Date(2026, 7, 14, 18, 59, 0, 0, time.UTC)
+	newStarted := oldFinished.Add(24 * time.Hour)
+	s := state.NewState()
+	s.Sessions["sup-318"] = &state.Session{
+		IssueNumber: 887,
+		Status:      state.StatusDone,
+		PRNumber:    893,
+		StartedAt:   oldFinished.Add(-time.Hour),
+		FinishedAt:  &oldFinished,
+	}
+	s.Sessions["sup-360"] = &state.Session{
+		IssueNumber: 887,
+		IssueTitle:  "finish watchdog recovery",
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    914,
+		Branch:      "feat/sup-360-887-watchdog-recovery",
+		Backend:     "codex",
+		StartedAt:   newStarted,
+	}
+	s.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "sup-repair-newer-pr",
+		CreatedAt:         time.Now().UTC(),
+		RecommendedAction: supervisor.ActionSpawnRepairWorker,
+		Risk:              supervisor.RiskMutating,
+		RequiresApproval:  false,
+		Target:            &state.SupervisorTarget{Issue: 887, PR: 914, Session: "sup-360"},
+	}, state.DefaultSupervisorDecisionLimit)
+
+	o.startNewWorkers(s, 1)
+
+	if len(*started) != 0 {
+		t.Fatalf("fresh starts = %v, want exact in-place repair", *started)
+	}
+	if respawned != "sup-360" {
+		t.Fatalf("respawned = %q, want sup-360", respawned)
+	}
+	if got := s.Sessions["sup-318"].Status; got != state.StatusDone {
+		t.Fatalf("older terminal session status = %q, want done", got)
+	}
+	if got := s.Sessions["sup-360"].Worktree; got != restoredWorktree {
+		t.Fatalf("restored worktree = %q, want %q", got, restoredWorktree)
+	}
+	if len(s.Sessions) != 2 {
+		t.Fatalf("sessions = %d, want no new session", len(s.Sessions))
 	}
 }
 


### PR DESCRIPTION
Refs #936.

An explicitly approved repair of a newer canonical PR/session now ignores only a chronologically older `done` terminal-reconciliation claim for a different PR. Running/open/retry competing claims still fail closed, so issue-level duplicate protection remains intact.

Also reattaches an operator-restored exact `<worktree_base>/<slot>` worktree when cleanup previously cleared the persisted path; it never allocates a new slot.

Tests:
- `go test ./internal/orchestrator ./internal/state`
- `go test ./...`
- `go build ./cmd/maestro/`

Urgent dogfood break-fix: approval `approval-baf233b8ece15a1f` is approved but `sup-360` is blocked by the already-merged PR #893 terminal claim. The exact `sup-360` worktree has been restored without discarding its unpushed commit.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates repair dispatch handling for exact reserved repair sessions. The main changes are:

- Ignores only older completed terminal-reconciliation claims from a different PR.
- Keeps active, open, and retry competing claims fail-closed.
- Reattaches the deterministic restored worktree path when git metadata exists.
- Adds a regression test for the restored `sup-360` repair scenario.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow, keeps existing reservation checks, and adds targeted regression coverage.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused package tests and verified exit code 0, using orchestrator-state-01-focused.log.
- Executed the full test suite across all packages and confirmed exit code 0, documented in orchestrator-state-02-full-suite.log.
- Built the CLI and confirmed exit code 0, logged in orchestrator-state-03-cli-build.log.

<a href="https://app.greptile.com/trex/runs/14881060/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Updates repair dispatch conflict handling and exact restored-worktree reattachment. |
| internal/orchestrator/orchestrator_test.go | Adds coverage for repairing a reserved newer PR/session with an older completed terminal claim present. |

<sub>Reviews (1): Last reviewed commit: ["fix: ignore older terminal claim for exa..."](https://github.com/befeast/maestro/commit/bc82cbf52f6e004723312e594fd4576d5ff4cbf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45168946)</sub>

<!-- /greptile_comment -->