### PR TITLE
fix: configure Codex 0.144 rollout budget object

### DIFF
--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -160,10 +160,22 @@ func (codexBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*e
 		// codex exec's public JSONL reports usage only at turn completion. The
 		// native rollout budget is enforced inside the agent loop after every
 		// provider response, including sub-agent work, so it is the enforceable
-		// live proxy for the configured Maestro ceiling.
+		// live proxy for the configured Maestro ceiling. Codex 0.144 changed
+		// rollout_budget from a boolean feature to a configured feature object:
+		// `--enable rollout_budget` now replaces that object and discards its
+		// limit. Set the object's enabled field directly and provide the required
+		// reminder thresholds instead.
+		reminders := make([]string, 0, 2)
+		for _, divisor := range []int{5, 10} {
+			threshold := cfg.TokenBudget / divisor
+			if threshold > 0 && threshold < cfg.TokenBudget {
+				reminders = append(reminders, strconv.Itoa(threshold))
+			}
+		}
 		args = append(args,
-			"--enable", "rollout_budget",
+			"-c", "features.rollout_budget.enabled=true",
 			"-c", fmt.Sprintf("features.rollout_budget.limit_tokens=%d", cfg.TokenBudget),
+			"-c", fmt.Sprintf("features.rollout_budget.reminder_at_remaining_tokens=[%s]", strings.Join(reminders, ",")),
 			"-c", "features.rollout_budget.sampling_token_weight=1.0",
 			"-c", "features.rollout_budget.prefill_token_weight=1.0",
 		)

--- a/internal/worker/token_budget_test.go
+++ b/internal/worker/token_budget_test.go
@@ -104,10 +104,24 @@ func TestBuildWorkerCmd_TokenBudgetFailClosedAndCodexProxy(t *testing.T) {
 			t.Fatal(err)
 		}
 		joined := strings.Join(cmd.Args, " ")
-		for _, want := range []string{"--json", "--enable rollout_budget", "features.rollout_budget.limit_tokens=80000", "sampling_token_weight=1.0", "prefill_token_weight=1.0"} {
+		for _, want := range []string{"--json", "features.rollout_budget.enabled=true", "features.rollout_budget.limit_tokens=80000", "features.rollout_budget.reminder_at_remaining_tokens=[16000,8000]", "sampling_token_weight=1.0", "prefill_token_weight=1.0"} {
 			if !strings.Contains(joined, want) {
 				t.Errorf("codex args missing %q: %s", want, joined)
 			}
+		}
+		if strings.Contains(joined, "--enable rollout_budget") {
+			t.Errorf("codex args use boolean rollout_budget form that discards configured limits: %s", joined)
+		}
+	})
+
+	t.Run("codex tiny budget emits valid required reminder list", func(t *testing.T) {
+		cmd, _, err := BuildWorkerCmd("codex", BackendConfig{Cmd: "codex", UsageStream: true, TokenBudget: 1}, "/tmp/prompt", "/tmp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		joined := strings.Join(cmd.Args, " ")
+		if !strings.Contains(joined, "features.rollout_budget.reminder_at_remaining_tokens=[]") {
+			t.Fatalf("codex args missing valid empty reminder list: %s", joined)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- replace the incompatible boolean `--enable rollout_budget` form with the configured feature object required by Codex 0.144
- provide deterministic 20%/10% reminder thresholds (or a valid empty list for tiny budgets)
- retain native hard-budget weights and JSON usage telemetry

## Verification

- `umask 077; go test ./internal/worker ./internal/orchestrator`
- `go build ./cmd/maestro/`
- live `_worker-exec` smoke test against Codex 0.144.5 completed a real turn and emitted terminal usage

Refs #938

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Codex worker token-budget configuration for Codex 0.144. The main changes are:

- Switches from the boolean `--enable rollout_budget` flag to `features.rollout_budget.enabled=true`.
- Adds configured rollout budget limit, reminder thresholds, and token weights.
- Updates tests for normal budgets and tiny budgets with an empty reminder list.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to Codex command argument construction and includes targeted tests for the changed behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Go test suite for the codex rollout and captured a verbose transcript showing the tests completed with PASS and exit status 0.
- Verified the build step by inspecting the build log, which shows go build ./cmd/maestro/ exited successfully with code 0.
- Checked the Codex CLI availability proof and confirmed that the CLI was not found in PATH, explaining why the CLI check did not proceed.

<a href="https://app.greptile.com/trex/runs/14884986/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/backend.go | Updates Codex command arguments to configure the rollout budget feature object with deterministic reminder thresholds. |
| internal/worker/token_budget_test.go | Updates Codex budget assertions and adds coverage for tiny-budget empty reminder lists. |

<sub>Reviews (1): Last reviewed commit: ["fix: configure Codex rollout budget obje..."](https://github.com/befeast/maestro/commit/46dc093bbd2acc9e7ba263890c3a2858348767c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45179097)</sub>

<!-- /greptile_comment -->