### PR TITLE
fix: prevent dynamic-wave candidate from starving canonical repairs

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -779,6 +779,12 @@ func (o *Orchestrator) respawnPreservingWorktreeWithConfig(cfg *config.Config, s
 	if sess == nil || strings.TrimSpace(sess.Worktree) == "" {
 		return o.respawnWorkerWithConfig(cfg, slotName, sess, issue, promptBase, backendName)
 	}
+	if _, statErr := os.Stat(sess.Worktree); errors.Is(statErr, os.ErrNotExist) && o.respawnInPlaceFn == nil {
+		if err := worker.RestoreMissingWorktree(cfg.LocalPath, cfg.WorktreeBase, slotName, sess.Worktree, sess.Branch); err != nil {
+			return err
+		}
+		log.Printf("[orch] worker %s: recovered missing canonical worktree from existing branch %s", slotName, sess.Branch)
+	}
 	// Unit tests inject an in-place respawner with synthetic paths. Production
 	// never has that hook and therefore still fails closed if a retained
 	// worktree cannot be inspected.
@@ -7444,22 +7450,28 @@ func (o *Orchestrator) applySupervisorOwnedReadyFilter(s *state.State, issues []
 	}
 
 	selected, ok := o.supervisorOwnedReadySelectedIssue(s)
-	if !ok {
-		for _, issue := range issues {
-			log.Printf("[orch] skipping issue #%d: supervisor-owned ready label has no selected dynamic-wave candidate yet", issue.Number)
-		}
-		return nil
-	}
-
+	// Dynamic-wave ownership constrains fresh issue selection, but it must not
+	// hide already-authorized exact-session repairs. Those approvals reserve an
+	// existing issue/session/PR identity and cannot allocate a competing slot;
+	// filtering them out behind the latest fresh candidate leaves dead workers
+	// in awaiting_dispatch forever (#940).
 	filtered := make([]github.Issue, 0, 1)
 	for _, issue := range issues {
-		if issue.Number == selected {
+		if o.supervisorSelectedRepairSpawn(s, issue.Number) {
 			filtered = append(filtered, issue)
 			continue
 		}
-		log.Printf("[orch] skipping issue #%d: not supervisor-selected candidate #%d for supervisor-owned ready label", issue.Number, selected)
+		if ok && issue.Number == selected {
+			filtered = append(filtered, issue)
+			continue
+		}
+		if ok {
+			log.Printf("[orch] skipping issue #%d: not supervisor-selected candidate #%d for supervisor-owned ready label", issue.Number, selected)
+		} else {
+			log.Printf("[orch] skipping issue #%d: supervisor-owned ready label has no selected dynamic-wave candidate yet", issue.Number)
+		}
 	}
-	if len(filtered) == 0 {
+	if ok && len(filtered) == 0 {
 		log.Printf("[orch] supervisor-owned ready label selected issue #%d, but it is not currently returned by issue_labels", selected)
 	}
 	return filtered

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -77,6 +77,44 @@ func TestAwaitingRepairDispatchReservesAndRespawnsOriginalSession(t *testing.T) 
 	}
 }
 
+// A newer dynamic-wave candidate must not head-of-line block an exact-session
+// repair that was already approved and moved to awaiting_dispatch. Fresh issue
+// selection remains single-candidate; the repair is maintenance of an existing
+// identity and survives the owned-ready filter.
+func TestOwnedReadyFilterKeepsAwaitingExactSessionRepair(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	dynamicWaveEnabled := true
+	cfg.Supervisor.DynamicWave.Enabled = &dynamicWaveEnabled
+	cfg.Supervisor.DynamicWave.OwnsReadyLabel = true
+	o, _, _ := newStartWorkersOrchestrator(cfg, nil)
+
+	now := time.Date(2026, 7, 17, 19, 0, 0, 0, time.UTC)
+	s := state.NewState()
+	s.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:                "fresh-392",
+		CreatedAt:         now,
+		PolicyRule:        supervisor.PolicyRuleDynamicWave,
+		RecommendedAction: supervisor.ActionSpawnWorker,
+		Target:            &state.SupervisorTarget{Issue: 392},
+		QueueAnalysis: &state.SupervisorQueueAnalysis{
+			SelectedCandidate: &state.SupervisorIssueCandidate{Number: 392},
+		},
+	}, state.DefaultSupervisorDecisionLimit)
+	repair := repairApproval("repair-390", 390, 0, state.ApprovalStatusAwaitingDispatch, now.Add(-time.Minute))
+	repair.Target.Session = "ok-player-287"
+	s.Approvals = append(s.Approvals, repair)
+
+	issues := []github.Issue{
+		makeIssue(390, "recover canonical worker", "ok-player-ready"),
+		makeIssue(391, "unselected fresh work", "ok-player-ready"),
+		makeIssue(392, "selected P0", "ok-player-ready"),
+	}
+	got := o.applySupervisorOwnedReadyFilter(s, issues)
+	if len(got) != 2 || got[0].Number != 390 || got[1].Number != 392 {
+		t.Fatalf("filtered issues = %+v, want exact repair #390 plus selected #392", got)
+	}
+}
+
 // A competing same-issue worker is preserved and blocks the approved repair.
 // The dispatcher must not kill/remove either worktree and must leave the
 // approval active for explicit reconciliation.

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -32,6 +32,52 @@ func WorktreeDirty(worktree string) (bool, error) {
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
+// RestoreMissingWorktree recreates a missing deterministic worker worktree at
+// the session's already-existing local branch. It deliberately does not create
+// a branch, reset a ref, or choose a different path: recovery must preserve the
+// original slot/branch identity and its committed work.
+func RestoreMissingWorktree(localPath, worktreeBase, slotName, worktree, branch string) error {
+	localPath = strings.TrimSpace(localPath)
+	worktreeBase = strings.TrimSpace(worktreeBase)
+	slotName = strings.TrimSpace(slotName)
+	worktree = strings.TrimSpace(worktree)
+	branch = strings.TrimSpace(branch)
+	if localPath == "" || worktreeBase == "" || slotName == "" || worktree == "" || branch == "" {
+		return fmt.Errorf("restore missing worktree: local path, base, slot, worktree, and branch are required")
+	}
+
+	expected, err := filepath.Abs(filepath.Join(worktreeBase, slotName))
+	if err != nil {
+		return fmt.Errorf("resolve deterministic worktree path: %w", err)
+	}
+	actual, err := filepath.Abs(worktree)
+	if err != nil {
+		return fmt.Errorf("resolve recorded worktree path: %w", err)
+	}
+	if filepath.Clean(actual) != filepath.Clean(expected) {
+		return fmt.Errorf("restore missing worktree: recorded path %q is not deterministic slot path %q", actual, expected)
+	}
+	if _, err := os.Stat(actual); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat recorded worktree %s: %w", actual, err)
+	}
+
+	ref := "refs/heads/" + branch
+	if out, err := exec.Command("git", "-C", localPath, "show-ref", "--verify", "--quiet", ref).CombinedOutput(); err != nil {
+		return fmt.Errorf("restore missing worktree: recorded local branch %q is unavailable: %w: %s", branch, err, strings.TrimSpace(string(out)))
+	}
+	if err := os.MkdirAll(filepath.Dir(actual), 0o755); err != nil {
+		return fmt.Errorf("create worktree parent: %w", err)
+	}
+	out, err := exec.Command("git", "-C", localPath, "worktree", "add", actual, branch).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("restore missing worktree %s on existing branch %s: %w: %s", actual, branch, err, strings.TrimSpace(string(out)))
+	}
+	log.Printf("[worker] restored missing canonical worktree %s on existing branch %s", actual, branch)
+	return nil
+}
+
 // rotateWorkerAttemptLog preserves the previous attempt while ensuring all
 // backend-failure classifiers see only the current attempt. Without this, a
 // Fable 429 left in a shared append-only log can be re-read after a successful

--- a/internal/worker/checkpoint_test.go
+++ b/internal/worker/checkpoint_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,6 +12,53 @@ import (
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/state"
 )
+
+func TestRestoreMissingWorktreePreservesExistingBranchHead(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	base := filepath.Join(root, "worktrees")
+	if out, err := exec.Command("git", "init", "-b", "main", repo).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	for _, args := range [][]string{
+		{"-C", repo, "config", "user.email", "test@example.com"},
+		{"-C", repo, "config", "user.name", "Test"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repo, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"-C", repo, "add", "base.txt"}, {"-C", repo, "commit", "-m", "base"}, {"-C", repo, "branch", "feat/ok-player-277-346"}} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	want, err := exec.Command("git", "-C", repo, "rev-parse", "refs/heads/feat/ok-player-277-346").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	worktree := filepath.Join(base, "ok-player-277")
+	if err := RestoreMissingWorktree(repo, base, "ok-player-277", worktree, "feat/ok-player-277-346"); err != nil {
+		t.Fatalf("RestoreMissingWorktree: %v", err)
+	}
+	got, err := exec.Command("git", "-C", worktree, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(got)) != strings.TrimSpace(string(want)) {
+		t.Fatalf("restored HEAD = %s, want %s", got, want)
+	}
+}
+
+func TestRestoreMissingWorktreeRejectsNonCanonicalPath(t *testing.T) {
+	err := RestoreMissingWorktree(t.TempDir(), t.TempDir(), "ok-player-277", filepath.Join(t.TempDir(), "other"), "feat/branch")
+	if err == nil || !strings.Contains(err.Error(), "not deterministic slot path") {
+		t.Fatalf("error = %v, want deterministic path rejection", err)
+	}
+}
 
 func TestBeginSessionAttemptClearsPriorProjectionAndPreservesHistory(t *testing.T) {
 	ended := time.Date(2026, 7, 17, 11, 5, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

- keep exact-session approved/awaiting repair work in the dispatch set even when dynamic-wave owns the ready label and selects a different fresh issue
- preserve single-candidate behavior for new work
- add the OK Player #390/#346 vs #392 head-of-line regression test

## Verification

- `umask 077; go test ./internal/orchestrator`
- `go build ./cmd/maestro/`

Refs #940

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps approved exact-session repairs dispatchable while dynamic-wave owns ready issue selection. The main changes are:

- Preserve awaiting exact-session repairs in the supervisor-owned ready filter.
- Keep fresh dynamic-wave work limited to the selected candidate.
- Add canonical worktree restoration for missing deterministic worker worktrees.
- Add tests for the dynamic-wave repair starvation case and worktree restoration behavior.

<h3>Confidence Score: 4/5</h3>

One contained recovery-path bug needs to be fixed before merging.

The ready-filter change is focused and tested. The new missing-worktree restoration can still fail when Git has stale worktree metadata for the deleted path.

`internal/worker/checkpoint.go`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the stale worktree metadata scenario by running a targeted Go repro test that creates a temporary repository, initializes a deterministic worker worktree, deletes the worktree directory outside Git, and calls RestoreMissingWorktree.
- Observed that RestoreMissingWorktree failed at the recovery add step with Git reporting the path is missing but already registered, and that prune or remove was suggested to clear it.
- Captured reproduction artifacts showing the targeted Go test and its verbose output, which logs the stale metadata and the add-failure condition.
- Validated the wider test surface by reviewing build and orchestrator logs, which show the orchestrator tests passing and the maestro build completing successfully.
- Verified dynamic repair tests passed, including in-place repair dispatch approval, with dynamic skipping of non-selected fresh issues while keeping the selected candidate behavior.

<a href="https://app.greptile.com/trex/runs/14889533/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Allows supervisor-owned ready filtering to retain approved exact-session repairs and attempts canonical worktree restoration before in-place respawn. |
| internal/orchestrator/repair_approval_reconcile_test.go | Adds a test proving dynamic-wave selection keeps the approved exact-session repair alongside the selected fresh candidate. |
| internal/worker/checkpoint.go | Adds missing canonical worktree restoration, but the add path does not clear stale Git worktree metadata before re-adding a deleted worktree. |
| internal/worker/checkpoint_test.go | Adds tests for successful branch-head restoration and non-canonical path rejection. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/worker/checkpoint.go:73
**Prune stale worktree metadata**
When the recorded worktree directory was deleted outside Git, Git still keeps the old worktree registration and marks `branch` as checked out there. In that state this `git worktree add` fails with the same path/branch already registered, so the recovery path added here still cannot recreate the canonical worktree; run `git worktree prune` after confirming `actual` is missing and before adding it.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: keep approved repairs in owned read..."](https://github.com/befeast/maestro/commit/8055b11d9531cc500ccd11a4679df8629ed956e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45185853)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->