### PR TITLE
fix: make bounded worker recovery hands-off

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2364,9 +2364,6 @@ func parse(data []byte) (*Config, error) {
 	if cfg.Supervisor.ApprovalRequiredActions == nil {
 		cfg.Supervisor.ApprovalRequiredActions = []string{
 			"review_retry_exhausted",
-			"spawn_worker",
-			"spawn_repair_worker",
-			"spawn_review_repair",
 			"label_issue_ready",
 			"add_ready_label",
 			"open_child_issue",

--- a/internal/config/handoff_planner_test.go
+++ b/internal/config/handoff_planner_test.go
@@ -140,4 +140,9 @@ func TestSupervisorDefaults_IncludeHandoffActions(t *testing.T) {
 	if !approval["open_child_issue"] {
 		t.Errorf("ApprovalRequiredActions missing open_child_issue: %#v", cfg.Supervisor.ApprovalRequiredActions)
 	}
+	for _, action := range []string{"spawn_worker", "spawn_repair_worker", "spawn_review_repair"} {
+		if approval[action] {
+			t.Errorf("mechanical action %q must be autonomous by default: %#v", action, cfg.Supervisor.ApprovalRequiredActions)
+		}
+	}
 }

--- a/internal/config/review_repair_test.go
+++ b/internal/config/review_repair_test.go
@@ -25,8 +25,9 @@ func TestParse_ReviewRepairDefaults(t *testing.T) {
 		t.Error("FallThroughMergeEnabled must default to false")
 	}
 
-	// Default policy lists must contain spawn_review_repair so cautious
-	// mode gates it and the executor registry mints it.
+	// Review repair is bounded to the canonical PR/head attempt and therefore
+	// runs as hands-off mechanical recovery by default. It remains allowed, but
+	// must not create an operator approval.
 	wantInAllowed := false
 	for _, a := range cfg.Supervisor.AllowedActions {
 		if a == SupervisorActionSpawnReviewRepair {
@@ -44,8 +45,8 @@ func TestParse_ReviewRepairDefaults(t *testing.T) {
 			break
 		}
 	}
-	if !wantInApprovalRequired {
-		t.Errorf("ApprovalRequiredActions missing %q: %v", SupervisorActionSpawnReviewRepair, cfg.Supervisor.ApprovalRequiredActions)
+	if wantInApprovalRequired {
+		t.Errorf("ApprovalRequiredActions unexpectedly gates %q: %v", SupervisorActionSpawnReviewRepair, cfg.Supervisor.ApprovalRequiredActions)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7094,10 +7094,9 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 		// closed below.
 		if claim.Kind == state.IssueClaimTerminalReconcile &&
 			claim.Status == string(state.StatusDone) &&
-			claim.PRNumber > 0 && target.PR > 0 && claim.PRNumber != target.PR {
+			claim.PRNumber > 0 && target.PR > claim.PRNumber {
 			prior, exists := s.SessionAt(claim.Session)
-			if exists && prior.Status == state.StatusDone && prior.FinishedAt != nil &&
-				!sess.StartedAt.IsZero() && !prior.FinishedAt.After(sess.StartedAt) {
+			if exists && prior.Status == state.StatusDone {
 				log.Printf("[orch] ignoring older terminal claim on session %s / PR #%d while repairing reserved newer session %s / PR #%d for issue #%d",
 					claim.Session, claim.PRNumber, slot, target.PR, issue.Number)
 				continue

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5094,7 +5094,6 @@ func TestStartNewWorkers_ApprovedRepairIgnoresOlderDoneTerminalClaim(t *testing.
 	}
 
 	oldFinished := time.Date(2026, 7, 14, 18, 59, 0, 0, time.UTC)
-	newStarted := oldFinished.Add(24 * time.Hour)
 	s := state.NewState()
 	s.Sessions["sup-318"] = &state.Session{
 		IssueNumber: 887,
@@ -5110,7 +5109,9 @@ func TestStartNewWorkers_ApprovedRepairIgnoresOlderDoneTerminalClaim(t *testing.
 		PRNumber:    914,
 		Branch:      "feat/sup-360-887-watchdog-recovery",
 		Backend:     "codex",
-		StartedAt:   newStarted,
+		// Cleanup/import can lose the attempt timestamp. Canonical PR identity,
+		// not an optional timestamp, orders an older completed PR claim.
+		StartedAt: time.Time{},
 	}
 	s.RecordSupervisorDecision(state.SupervisorDecision{
 		ID:                "sup-repair-newer-pr",

--- a/internal/supervisor/handoff_planner_test.go
+++ b/internal/supervisor/handoff_planner_test.go
@@ -257,6 +257,11 @@ func TestDefaultAllowedActions_IncludesOpenChildIssue(t *testing.T) {
 	if !seenApproval[ActionOpenChildIssue] {
 		t.Errorf("defaultApprovalRequiredActions missing %q", ActionOpenChildIssue)
 	}
+	for _, action := range []string{ActionSpawnWorker, ActionSpawnRepairWorker, ActionSpawnReviewRepair} {
+		if seenApproval[action] {
+			t.Errorf("defaultApprovalRequiredActions unexpectedly gates mechanical action %q", action)
+		}
+	}
 }
 
 // Test: canonicalAction maps "create_issue" / "create_child_issue" → open_child_issue.

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -459,8 +459,6 @@ func defaultAllowedActions() []string {
 func defaultApprovalRequiredActions() []string {
 	return []string{
 		ActionReviewRetryExhausted,
-		ActionSpawnWorker,
-		ActionSpawnRepairWorker,
 		ActionLabelIssueReady,
 		ActionOpenChildIssue,
 	}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -2786,6 +2786,9 @@ func TestDecideWithLLM_UnknownActionRejected(t *testing.T) {
 func TestDecideWithLLM_ApprovalRequiredActionRejectedWithoutApproval(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
+	// Explicit operator policy can still gate mechanical dispatch even though
+	// hands-off projects no longer do so by default.
+	cfg.Supervisor.ApprovalRequiredActions = []string{ActionSpawnWorker}
 	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
 	llm := &fakeLLM{output: `{
   "summary": "Issue #42 is ready to feed.",


### PR DESCRIPTION
Part of #940: removes the manual-approval bottleneck from the mechanical hands-off path.\n\nMakes ordinary ready-queue dispatch and bounded canonical session/PR repair autonomous by default. Irreversible actions remain governed by supervisor.approval_required; operators can still explicitly gate mechanical verbs.\n\nTests: umask 077; go test ./internal/config ./internal/supervisor ./internal/orchestrator; go build ./cmd/maestro/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes bounded supervisor recovery paths run without default manual approval. The main changes are:

- Removes ordinary worker, repair worker, and review-repair spawn actions from default approval-required lists.
- Keeps explicit operator approval gates for mechanical dispatch actions when configured.
- Updates config and supervisor tests for the new default approval policy.
- Allows exact newer PR/session repair reservations to ignore older completed terminal claims when timestamps are unavailable.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrow and covered by focused tests for default approval behavior and timestamp-loss repair dispatch.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Go toolchain version check was executed and completed with exit code 0.
- Internal/config, internal/supervisor, and internal/orchestrator tests ran and passed with exit code 0.
- The Maestro CLI build finished successfully with exit code 0 and produced the binary.
- The final artifacts listing confirms the final proof files are present in the artifacts bundle.

<a href="https://app.greptile.com/trex/runs/14892297/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Updates parsed supervisor defaults so mechanical worker and repair spawn actions remain allowed but no longer require approval by default. |
| internal/config/handoff_planner_test.go | Extends config default tests to assert handoff actions remain gated while mechanical spawn actions are autonomous by default. |
| internal/config/review_repair_test.go | Adjusts review-repair default coverage to require allowed-but-not-approval-gated behavior. |
| internal/orchestrator/orchestrator.go | Relaxes repair dispatch conflict handling so an exact newer canonical PR/session repair is not blocked by an older completed terminal claim. |
| internal/orchestrator/orchestrator_test.go | Updates repair dispatch regression coverage for missing timestamps and canonical PR-number ordering. |
| internal/supervisor/handoff_planner_test.go | Adds supervisor fallback default assertions that mechanical spawn actions are not approval-gated. |
| internal/supervisor/llm.go | Updates supervisor fallback approval-required defaults to stop gating ordinary worker and repair spawns. |
| internal/supervisor/supervisor_test.go | Makes the approval-gate rejection test explicitly configure `spawn_worker` as approval-required under the new defaults. |

<sub>Reviews (2): Last reviewed commit: ["fix: reconcile older terminal PR claims"](https://github.com/befeast/maestro/commit/114fad325a8ee66bfdfa55a7295c6f90d6fc622b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45193315)</sub>

<!-- /greptile_comment -->