### PR TITLE
fix: bound supervisor backends and fail over safely

### DIFF
--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
@@ -53,12 +55,17 @@ type backendLLMClient struct {
 	cfg *config.Config
 }
 
+const (
+	supervisorBackendAttemptTimeout = 45 * time.Second
+	supervisorBackendTotalTimeout   = 3 * time.Minute
+)
+
 func NewBackendLLMClient(cfg *config.Config) LLMClient {
 	return &backendLLMClient{cfg: cfg}
 }
 
 func (c *backendLLMClient) Complete(prompt string) (string, error) {
-	backendName, backendDef, err := supervisorBackend(c.cfg)
+	candidates, err := supervisorBackendCandidates(c.cfg)
 	if err != nil {
 		return "", err
 	}
@@ -80,35 +87,109 @@ func (c *backendLLMClient) Complete(prompt string) (string, error) {
 		return "", fmt.Errorf("close supervisor prompt file: %w", err)
 	}
 
-	backendCfg := worker.BackendConfig{
-		Cmd:        backendDef.Cmd,
-		ExtraArgs:  backendDef.ExtraArgs,
-		PromptMode: backendDef.PromptMode,
-		Provider:   backendDef.Provider,
-		Model:      c.cfg.Supervisor.Model,
-		Effort:     c.cfg.Supervisor.Effort,
-	}
 	worktree := c.cfg.LocalPath
 	if strings.TrimSpace(worktree) == "" {
 		worktree = "."
 	}
-	cmd, stdinFile, err := worker.BuildSupervisorCmd(backendName, backendCfg, promptPath, worktree)
+	deadline := time.Now().Add(supervisorBackendTotalTimeout)
+	var failed []string
+	for _, candidate := range candidates {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		attemptTimeout := supervisorBackendAttemptTimeout
+		if remaining < attemptTimeout {
+			attemptTimeout = remaining
+		}
+		out, runErr := completeSupervisorBackend(candidate.name, candidate.def, c.cfg, promptPath, worktree, attemptTimeout)
+		if runErr == nil {
+			if len(failed) > 0 {
+				log.Printf("[supervisor] backend fallback selected %s after %s failed", candidate.name, strings.Join(failed, ", "))
+			}
+			return strings.TrimSpace(string(out)), nil
+		}
+		failed = append(failed, candidate.name)
+		log.Printf("[supervisor] backend %s unavailable for this cycle; trying configured fallback", candidate.name)
+	}
+	return "", fmt.Errorf("run supervisor backends: all bounded candidates failed (%s)", strings.Join(failed, ", "))
+}
+
+type supervisorBackendCandidate struct {
+	name string
+	def  config.BackendDef
+}
+
+func supervisorBackendCandidates(cfg *config.Config) ([]supervisorBackendCandidate, error) {
+	primary, def, err := supervisorBackend(cfg)
 	if err != nil {
-		return "", fmt.Errorf("build supervisor backend cmd: %w", err)
+		return nil, err
+	}
+	names := append([]string{primary}, cfg.Model.FallbackBackends...)
+	seen := make(map[string]struct{}, len(names))
+	out := make([]supervisorBackendCandidate, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, duplicate := seen[name]; duplicate {
+			continue
+		}
+		seen[name] = struct{}{}
+		candidate, ok := cfg.Model.Backends[name]
+		if !ok || !candidate.IsEnabled() {
+			continue
+		}
+		if name == primary {
+			candidate = def
+		}
+		out = append(out, supervisorBackendCandidate{name: name, def: candidate})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("supervisor has no enabled backend candidates")
+	}
+	return out, nil
+}
+
+func completeSupervisorBackend(name string, def config.BackendDef, cfg *config.Config, promptPath, worktree string, timeout time.Duration) ([]byte, error) {
+	backendCfg := worker.BackendConfig{
+		Cmd: def.Cmd, ExtraArgs: def.ExtraArgs, PromptMode: def.PromptMode, Provider: def.Provider,
+		Model: cfg.Supervisor.Model, Effort: cfg.Supervisor.Effort,
+	}
+	cmd, stdinFile, err := worker.BuildSupervisorCmd(name, backendCfg, promptPath, worktree)
+	if err != nil {
+		return nil, fmt.Errorf("build supervisor backend cmd: %w", err)
 	}
 	if stdinFile != "" {
 		in, err := os.Open(stdinFile)
 		if err != nil {
-			return "", fmt.Errorf("open supervisor prompt stdin: %w", err)
+			return nil, fmt.Errorf("open supervisor prompt stdin: %w", err)
 		}
 		defer in.Close()
 		cmd.Stdin = in
 	}
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("run supervisor backend %q: %w", backendName, err)
+	return outputWithTimeout(cmd, timeout)
+}
+
+func outputWithTimeout(cmd *exec.Cmd, timeout time.Duration) ([]byte, error) {
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Start(); err != nil {
+		return nil, err
 	}
-	return strings.TrimSpace(string(out)), nil
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return out.Bytes(), err
+	case <-timer.C:
+		worker.KillProcessTree(cmd.Process.Pid)
+		<-done
+		return nil, fmt.Errorf("timed out after %s", timeout.Round(time.Second))
+	}
 }
 
 func supervisorBackend(cfg *config.Config) (string, config.BackendDef, error) {
@@ -167,7 +248,13 @@ func (e *Engine) decideWithLLM(st *state.State) (state.SupervisorDecision, error
 	}
 	output, err := client.Complete(prompt)
 	if err != nil {
-		return state.SupervisorDecision{}, err
+		// The deterministic guardrail already selected the only action the LLM
+		// is allowed to agree with. Provider failure must not freeze the project
+		// control loop: preserve that decision and make the degraded route visible.
+		log.Printf("[supervisor] all model backends unavailable; continuing with deterministic guardrail: %v", err)
+		deterministic.ErrorClass = ErrorClassSupervisorBackend
+		deterministic.Reasons = append(deterministic.Reasons, "Supervisor model backends were unavailable; deterministic guardrail executed without model synthesis.")
+		return deterministic, nil
 	}
 	llmDecision, err := ParseLLMDecision(output)
 	if err != nil {

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -186,7 +186,10 @@ func outputWithTimeout(cmd *exec.Cmd, timeout time.Duration) ([]byte, error) {
 	case err := <-done:
 		return out.Bytes(), err
 	case <-timer.C:
-		worker.KillProcessTree(cmd.Process.Pid)
+		// This is already a hard attempt deadline. Do not spend the worker
+		// reaper's two-second SIGTERM grace period here or the bounded fallback
+		// chain can overrun its advertised total deadline.
+		worker.ForceKillProcessTree(cmd.Process.Pid)
 		<-done
 		return nil, fmt.Errorf("timed out after %s", timeout.Round(time.Second))
 	}

--- a/internal/supervisor/llm_timeout_test.go
+++ b/internal/supervisor/llm_timeout_test.go
@@ -1,0 +1,41 @@
+package supervisor
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+func TestOutputWithTimeoutKillsHungBackend(t *testing.T) {
+	started := time.Now()
+	_, err := outputWithTimeout(exec.Command("sh", "-c", "sleep 5"), 25*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %v, want timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("hung backend returned after %s, want bounded cancellation", elapsed)
+	}
+}
+
+func TestSupervisorBackendCandidatesUsesOrderedFallbacks(t *testing.T) {
+	disabled := false
+	cfg := &config.Config{Model: config.ModelConfig{
+		Default:          "claude",
+		FallbackBackends: []string{"claude", "sol", "gpt55"},
+		Backends: map[string]config.BackendDef{
+			"claude": {Cmd: "claude"},
+			"sol":    {Cmd: "codex"},
+			"gpt55":  {Enabled: &disabled, Cmd: "codex"},
+		},
+	}}
+	candidates, err := supervisorBackendCandidates(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 2 || candidates[0].name != "claude" || candidates[1].name != "sol" {
+		t.Fatalf("candidates = %+v, want [claude sol]", candidates)
+	}
+}

--- a/internal/supervisor/llm_timeout_test.go
+++ b/internal/supervisor/llm_timeout_test.go
@@ -11,11 +11,13 @@ import (
 
 func TestOutputWithTimeoutKillsHungBackend(t *testing.T) {
 	started := time.Now()
-	_, err := outputWithTimeout(exec.Command("sh", "-c", "sleep 5"), 25*time.Millisecond)
+	// Ignore SIGTERM so this catches accidental use of the graceful worker
+	// reaper, whose two-second grace period would violate the hard deadline.
+	_, err := outputWithTimeout(exec.Command("sh", "-c", `trap '' TERM; while :; do sleep 1; done`), 25*time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("error = %v, want timeout", err)
 	}
-	if elapsed := time.Since(started); elapsed > time.Second {
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
 		t.Fatalf("hung backend returned after %s, want bounded cancellation", elapsed)
 	}
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -84,6 +84,7 @@ const (
 	ErrorClassGitHubNotFound    = "github_not_found"
 	ErrorClassGitHubRateLimited = "github_rate_limited"
 	ErrorClassUnsupportedClient = "unsupported_client"
+	ErrorClassSupervisorBackend = "supervisor_backend_unavailable"
 
 	SeverityInfo    = "info"
 	SeverityWarning = "warning"

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -2806,6 +2806,25 @@ func TestDecideWithLLM_ApprovalRequiredActionRejectedWithoutApproval(t *testing.
 	}
 }
 
+func TestDecideWithLLM_BackendFailureUsesDeterministicGuardrail(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.ApprovalRequiredActions = []string{ActionMergePR}
+	reader := &fakeReader{issues: []github.Issue{testIssue(940, "prove unattended SLA", "maestro-ready")}}
+	llm := &fakeLLM{err: errors.New("provider unavailable")}
+
+	decision, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker || decision.Target == nil || decision.Target.Issue != 940 {
+		t.Fatalf("decision = %+v, want deterministic spawn_worker for #940", decision)
+	}
+	if decision.ErrorClass != ErrorClassSupervisorBackend {
+		t.Fatalf("ErrorClass = %q, want %q", decision.ErrorClass, ErrorClassSupervisorBackend)
+	}
+}
+
 func TestDecideWithLLM_MalformedOutputRejected(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}

--- a/internal/worker/reap.go
+++ b/internal/worker/reap.go
@@ -61,6 +61,22 @@ func KillProcessTree(pid int) {
 	signalPIDs(pids, syscall.SIGKILL)
 }
 
+// ForceKillProcessTree immediately terminates pid and every currently visible
+// descendant. It is reserved for callers whose own hard deadline has already
+// expired; unlike KillProcessTree it deliberately provides no graceful-exit
+// window.
+func ForceKillProcessTree(pid int) {
+	if pid <= 0 {
+		return
+	}
+
+	pids := []int{pid}
+	if runtime.GOOS == "linux" {
+		pids = collectProcessTree(pid)
+	}
+	signalPIDs(pids, syscall.SIGKILL)
+}
+
 // signalPIDs sends sig to each pid in reverse order (children before the root).
 func signalPIDs(pids []int, sig syscall.Signal) {
 	for i := len(pids) - 1; i >= 0; i-- {


### PR DESCRIPTION
Refs #940.\n\nBounds every supervisor model attempt, follows the configured ordered fallback chain, and continues with the deterministic guardrail if all model routes fail. This prevents provider hangs/cooldowns from freezing LastRunOnceAt and the project queue.\n\nTests: umask 077; go test ./internal/supervisor ./internal/daemon ./internal/config ./internal/orchestrator; go build ./cmd/maestro/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bounds supervisor model calls and keeps the supervisor moving when providers fail. The main changes are:

- Adds per-backend and total supervisor backend timeouts.
- Follows the configured ordered fallback backend chain.
- Falls back to the deterministic guardrail when all model routes fail.
- Adds an immediate process-tree kill helper for hard-deadline callers.
- Adds tests for hung backend cancellation, fallback ordering, and degraded supervisor decisions.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are focused and covered by targeted tests. The timeout and fallback paths preserve existing command construction while preventing supervisor cycles from hanging. No functional or security issues were identified in the changed code.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the explicit-plan Go tests for four packages and confirmed all tests passed with EXIT\_CODE: 0.
- Built the Maestro command with go build ./cmd/maestro/ and verified EXIT\_CODE: 0, followed by cleanup of the Maestro binary.

<a href="https://app.greptile.com/trex/runs/14895734/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/llm.go | Adds bounded supervisor backend attempts, ordered fallback selection, hard process timeouts, and deterministic guardrail fallback when model routes fail. |
| internal/supervisor/llm_timeout_test.go | Covers hard timeout behavior for hung backend processes and ordered fallback candidate selection. |
| internal/supervisor/supervisor.go | Adds a supervisor backend unavailable error class for degraded deterministic decisions. |
| internal/supervisor/supervisor_test.go | Adds tests that LLM backend failure returns the deterministic guardrail decision instead of failing the cycle. |
| internal/worker/reap.go | Adds an immediate SIGKILL process-tree helper for hard timeout handling. |

<sub>Reviews (2): Last reviewed commit: ["fix: enforce hard supervisor backend dea..."](https://github.com/befeast/maestro/commit/b3f2edcb37a9cd4ebe3430ee1ee2c3bfd2fea58b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45201285)</sub>

<!-- /greptile_comment -->