### PR TITLE
fix: retire invalid repair approvals

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7068,16 +7068,22 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 	target := dispatch.target
 	slot := strings.TrimSpace(target.Session)
 	if slot == "" {
-		log.Printf("[orch] refusing repair dispatch for issue #%d: reservation has no target session", issue.Number)
+		reason := fmt.Sprintf("issue #%d repair reservation has no target session", issue.Number)
+		log.Printf("[orch] refusing repair dispatch: %s", reason)
+		o.staleInvalidSpawnRepairApproval(s, dispatch, reason)
 		return false
 	}
 	sess, ok := s.SessionAt(slot)
 	if !ok || sess.IssueNumber != issue.Number {
-		log.Printf("[orch] refusing repair dispatch for issue #%d: reserved session %s is missing or belongs to another issue", issue.Number, slot)
+		reason := fmt.Sprintf("issue #%d reserved session %s is missing or belongs to another issue", issue.Number, slot)
+		log.Printf("[orch] refusing repair dispatch: %s", reason)
+		o.staleInvalidSpawnRepairApproval(s, dispatch, reason)
 		return false
 	}
 	if target.PR > 0 && sess.PRNumber != target.PR {
-		log.Printf("[orch] refusing repair dispatch for issue #%d: reserved PR #%d no longer matches session %s PR #%d", issue.Number, target.PR, slot, sess.PRNumber)
+		reason := fmt.Sprintf("issue #%d reserved PR #%d no longer matches session %s PR #%d", issue.Number, target.PR, slot, sess.PRNumber)
+		log.Printf("[orch] refusing repair dispatch: %s", reason)
+		o.staleInvalidSpawnRepairApproval(s, dispatch, reason)
 		return false
 	}
 	for _, claim := range s.ActiveIssueClaims() {
@@ -7102,7 +7108,9 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 				continue
 			}
 		}
-		log.Printf("[orch] refusing repair dispatch for issue #%d on %s: competing claim on session %s (%s)", issue.Number, slot, claim.Session, claim.Reason)
+		reason := fmt.Sprintf("issue #%d reserved session %s is superseded by competing canonical claim on session %s (%s)", issue.Number, slot, claim.Session, claim.Reason)
+		log.Printf("[orch] refusing repair dispatch: %s", reason)
+		o.staleInvalidSpawnRepairApproval(s, dispatch, reason)
 		return false
 	}
 
@@ -7183,6 +7191,23 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 	}
 	o.notifier.Sendf("🔄 maestro: repairing issue #%d in place on worker %s: %s", issue.Number, slot, issue.Title)
 	return true
+}
+
+// staleInvalidSpawnRepairApproval makes an irrecoverably invalid exact
+// reservation terminal in both the project state and the SQLite approval
+// mirror. Without this convergence an awaiting_dispatch record is selected and
+// refused every orchestrator cycle forever, presenting a false operator gate
+// and burning control-loop work even though no safe dispatch is possible.
+func (o *Orchestrator) staleInvalidSpawnRepairApproval(s *state.State, dispatch *spawnRepairDispatch, reason string) {
+	if s == nil || dispatch == nil || strings.TrimSpace(dispatch.approvalID) == "" {
+		return
+	}
+	now := time.Now().UTC()
+	if !s.StaleActiveRepairDispatchApproval(dispatch.approvalID, now, reason) {
+		return
+	}
+	log.Printf("[orch] reconciled invalid repair approval %s as stale: %s", dispatch.approvalID, reason)
+	o.mirrorRepairApprovalTerminal(dispatch.approvalID, now, reason)
 }
 
 func (o *Orchestrator) resolveSpawnRepairApproval(s *state.State, approvalID, slot string, pr int, outcome string) {

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -116,8 +116,8 @@ func TestOwnedReadyFilterKeepsAwaitingExactSessionRepair(t *testing.T) {
 }
 
 // A competing same-issue worker is preserved and blocks the approved repair.
-// The dispatcher must not kill/remove either worktree and must leave the
-// approval active for explicit reconciliation.
+// The dispatcher must not kill/remove either worktree and must make the exact
+// obsolete approval terminal so it cannot retry forever.
 func TestAwaitingRepairDispatchRefusesCompetingWorker(t *testing.T) {
 	cfg := cfgWithBackends("codex", "codex")
 	issues := []github.Issue{makeIssue(1, "repair PR #7", "maestro-ready")}
@@ -144,8 +144,44 @@ func TestAwaitingRepairDispatchRefusesCompetingWorker(t *testing.T) {
 	if len(s.Sessions) != 2 || s.Sessions["txc-2"].Worktree != "/work/txc-2" {
 		t.Fatalf("competing material changed: %+v", s.Sessions)
 	}
-	if got := approvalStatus(t, s, "repair-1"); got != state.ApprovalStatusAwaitingDispatch {
-		t.Fatalf("repair approval = %q, want awaiting_dispatch for operator reconciliation", got)
+	if got := approvalStatus(t, s, "repair-1"); got != state.ApprovalStatusStale {
+		t.Fatalf("repair approval = %q, want stale after canonical claim wins", got)
+	}
+}
+
+// The live #940 soak regression: an old awaiting-dispatch approval referenced
+// a session that no longer existed. The dispatcher refused it every minute but
+// left it active for days. One failed exact-reservation validation must stale
+// the approval, preserve every other approval, and make later cycles no-ops.
+func TestAwaitingRepairDispatchMissingReservedSessionBecomesStale(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	issues := []github.Issue{makeIssue(877, "repair PR #891", "maestro-ready")}
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.hasOpenPRForIssueFn = func(issue int) (bool, error) { return issue == 877, nil }
+
+	now := time.Date(2026, 7, 17, 20, 52, 47, 0, time.UTC)
+	s := state.NewState()
+	missing := repairApproval("repair-missing", 877, 891, state.ApprovalStatusAwaitingDispatch, now)
+	missing.Target.Session = "sup-316"
+	unrelated := repairApproval("repair-unrelated", 900, 904, state.ApprovalStatusAwaitingDispatch, now)
+	unrelated.Target.Session = "sup-347"
+	s.Approvals = []state.Approval{missing, unrelated}
+
+	o.startNewWorkers(s, 1)
+	o.startNewWorkers(s, 1)
+
+	if len(*freshStarts) != 0 || len(s.Sessions) != 0 {
+		t.Fatalf("invalid exact repair created work: starts=%v sessions=%v", *freshStarts, s.Sessions)
+	}
+	if got := approvalStatus(t, s, "repair-missing"); got != state.ApprovalStatusStale {
+		t.Fatalf("missing-session approval = %q, want stale", got)
+	}
+	if got := approvalStatus(t, s, "repair-unrelated"); got != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("unrelated approval = %q, want awaiting_dispatch", got)
+	}
+	approval, _ := s.FindApproval("repair-missing")
+	if last := approval.Audit[len(approval.Audit)-1]; last.Event != state.ApprovalAuditStale || !strings.Contains(last.Reason, "sup-316") {
+		t.Fatalf("stale audit = {%q,%q}, want exact missing-session reason", last.Event, last.Reason)
 	}
 }
 

--- a/internal/state/issue_claim.go
+++ b/internal/state/issue_claim.go
@@ -166,6 +166,26 @@ func (s *State) ResolveDispatchedSpawnRepairApproval(id string, now time.Time, r
 	return false
 }
 
+// StaleActiveRepairDispatchApproval retires one exact repair authority after
+// dispatch proves that its durable issue/session/PR reservation is no longer
+// valid. This is intentionally ID-scoped: another independently reviewed
+// repair for the same issue must not be invalidated as a side effect. Repeated
+// calls are idempotent because terminal approvals are ignored.
+func (s *State) StaleActiveRepairDispatchApproval(id string, now time.Time, reason string) bool {
+	if s == nil || strings.TrimSpace(id) == "" {
+		return false
+	}
+	for i := range s.Approvals {
+		approval := &s.Approvals[i]
+		if approval.ID != id || !repairDispatchApprovalNeedsGuardReconcile(approval) {
+			continue
+		}
+		s.markApprovalStale(approval, now, reason)
+		return true
+	}
+	return false
+}
+
 // StaleActiveRepairDispatchApprovals retires delayed repair authority when a
 // current issue guard (for example a newly-added blocked label) says dispatch
 // is no longer allowed. Approval is not timeless authority: dispatch must


### PR DESCRIPTION
## What changed

- make an invalid exact repair reservation terminal when its session is missing, belongs to another issue, no longer matches the reserved PR, or loses to a canonical competing claim;
- mirror the terminal reconciliation into the SQLite approval store;
- keep reconciliation scoped to the exact approval ID so unrelated repair authority is preserved;
- add live-regression coverage for the stale `sup-316` reservation and idempotent subsequent cycles.

## Root cause

`dispatchSpawnRepairWorker` failed closed when an exact issue/session/PR reservation was invalid, but returned without changing the `awaiting_dispatch` approval. The same approval therefore remained the active issue claim and was selected and refused on every orchestrator cycle indefinitely.

## Impact

An invalid repair approval now converges to an audited terminal state without spawning a replacement worker or asking the operator to paste another recovery prompt. Canonical worktrees and competing active work remain untouched.

## Validation

- `umask 077; go test ./internal/state ./internal/orchestrator`
- `umask 077; go test ./...`
- `go build ./cmd/maestro/`

Part of #940.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR retires invalid exact repair approvals instead of retrying them forever. The main changes are:

- Marks invalid repair reservations as stale when the target session is missing, mismatched, or superseded.
- Mirrors the stale terminal transition into the SQLite approval store.
- Keeps stale reconciliation scoped to the exact approval ID.
- Adds tests for the missing-session regression, competing claims, preserved unrelated approvals, and repeated cycles.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to invalid repair reservation cleanup and has targeted tests for the reported stale approval loop.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the narrow internal/state and orchestrator test run, which completed with PASS and EXIT\_CODE: 0.
- T-Rex executed the full Go test suite run, which completed with PASS and EXIT\_CODE: 0.
- T-Rex performed the Maestro build, binary cleanup, and completed with EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14901365/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds terminal reconciliation for invalid exact repair dispatch reservations and mirrors the stale transition to SQLite. |
| internal/orchestrator/repair_approval_reconcile_test.go | Updates competing-worker expectations and adds tests for missing reserved sessions and idempotent later cycles. |
| internal/state/issue_claim.go | Adds ID-scoped stale reconciliation for active repair dispatch approvals while preserving unrelated approvals. |

<sub>Reviews (1): Last reviewed commit: ["fix: retire invalid repair approvals"](https://github.com/befeast/maestro/commit/5f99fe99e23617fe290bbd16b3c0bc5eebbd7e18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45214081)</sub>

<!-- /greptile_comment -->