### PR TITLE
fix: validate sibling repair claims

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7095,21 +7095,39 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 		// sibling reservation before comparing it with this valid exact repair;
 		// otherwise lexical claim order can stale both approvals and lose the
 		// one recovery that was still safe to dispatch.
-		if claim.Kind == state.IssueClaimRepairDispatch {
+		seenInvalidApprovals := make(map[string]struct{})
+		for claim.Kind == state.IssueClaimRepairDispatch {
 			claimed, exists := s.SessionAt(claim.Session)
-			if !exists || claimed.IssueNumber != issue.Number || (claim.PRNumber > 0 && claimed.PRNumber != claim.PRNumber) {
-				reason := fmt.Sprintf("issue #%d competing repair reservation %s is invalid: session missing, belongs to another issue, or no longer matches PR #%d", issue.Number, claim.Session, claim.PRNumber)
-				o.staleInvalidRepairApproval(s, claim.ApprovalID, reason)
-				// Approval reservations suppress the underlying session claim.
-				// Rebuild claims after staling so a real running/open-PR session
-				// cannot be hidden by its obsolete approval and accidentally run
-				// concurrently with the selected repair.
-				revealed, stillClaimed := activeIssueClaimForSession(s, issue.Number, claim.Session)
-				if !stillClaimed {
-					continue
-				}
-				claim = revealed
+			if exists && claimed.IssueNumber == issue.Number && (claim.PRNumber <= 0 || claimed.PRNumber == claim.PRNumber) {
+				break
 			}
+			// More than one obsolete approval can reserve the same missing or
+			// mismatched sibling session. Peel every invalid approval-derived
+			// claim until either no claim remains or a real session claim is
+			// revealed; validating only the first revealed approval loses the
+			// selected canonical repair on the next stale sibling.
+			if claim.ApprovalID == "" {
+				break
+			}
+			if _, repeated := seenInvalidApprovals[claim.ApprovalID]; repeated {
+				break
+			}
+			seenInvalidApprovals[claim.ApprovalID] = struct{}{}
+			reason := fmt.Sprintf("issue #%d competing repair reservation %s is invalid: session missing, belongs to another issue, or no longer matches PR #%d", issue.Number, claim.Session, claim.PRNumber)
+			o.staleInvalidRepairApproval(s, claim.ApprovalID, reason)
+			// Approval reservations suppress the underlying session claim.
+			// Rebuild claims after each stale transition so a real
+			// running/open-PR session cannot remain hidden behind a chain of
+			// obsolete approvals.
+			revealed, stillClaimed := activeIssueClaimForSession(s, issue.Number, claim.Session)
+			if !stillClaimed {
+				claim = state.IssueClaim{}
+				break
+			}
+			claim = revealed
+		}
+		if claim.Session == "" {
+			continue
 		}
 		// A completed older PR can retain the issue's terminal-reconciliation
 		// claim until GitHub closes the issue. That claim must still prevent a

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7090,6 +7090,19 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 		if claim.IssueNumber != issue.Number || claim.Session == "" || claim.Session == slot {
 			continue
 		}
+		// Approval-derived claims are durable intent, not proof that their
+		// reserved session still exists or remains canonical. Retire an invalid
+		// sibling reservation before comparing it with this valid exact repair;
+		// otherwise lexical claim order can stale both approvals and lose the
+		// one recovery that was still safe to dispatch.
+		if claim.Kind == state.IssueClaimRepairDispatch {
+			claimed, exists := s.SessionAt(claim.Session)
+			if !exists || claimed.IssueNumber != issue.Number || (claim.PRNumber > 0 && claimed.PRNumber != claim.PRNumber) {
+				reason := fmt.Sprintf("issue #%d competing repair reservation %s is invalid: session missing, belongs to another issue, or no longer matches PR #%d", issue.Number, claim.Session, claim.PRNumber)
+				o.staleInvalidRepairApproval(s, claim.ApprovalID, reason)
+				continue
+			}
+		}
 		// A completed older PR can retain the issue's terminal-reconciliation
 		// claim until GitHub closes the issue. That claim must still prevent a
 		// fresh implementation dispatch, but it must not veto an explicitly
@@ -7202,12 +7215,19 @@ func (o *Orchestrator) staleInvalidSpawnRepairApproval(s *state.State, dispatch 
 	if s == nil || dispatch == nil || strings.TrimSpace(dispatch.approvalID) == "" {
 		return
 	}
-	now := time.Now().UTC()
-	if !s.StaleActiveRepairDispatchApproval(dispatch.approvalID, now, reason) {
+	o.staleInvalidRepairApproval(s, dispatch.approvalID, reason)
+}
+
+func (o *Orchestrator) staleInvalidRepairApproval(s *state.State, approvalID, reason string) {
+	if s == nil || strings.TrimSpace(approvalID) == "" {
 		return
 	}
-	log.Printf("[orch] reconciled invalid repair approval %s as stale: %s", dispatch.approvalID, reason)
-	o.mirrorRepairApprovalTerminal(dispatch.approvalID, now, reason)
+	now := time.Now().UTC()
+	if !s.StaleActiveRepairDispatchApproval(approvalID, now, reason) {
+		return
+	}
+	log.Printf("[orch] reconciled invalid repair approval %s as stale: %s", approvalID, reason)
+	o.mirrorRepairApprovalTerminal(approvalID, now, reason)
 }
 
 func (o *Orchestrator) resolveSpawnRepairApproval(s *state.State, approvalID, slot string, pr int, outcome string) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7100,7 +7100,15 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 			if !exists || claimed.IssueNumber != issue.Number || (claim.PRNumber > 0 && claimed.PRNumber != claim.PRNumber) {
 				reason := fmt.Sprintf("issue #%d competing repair reservation %s is invalid: session missing, belongs to another issue, or no longer matches PR #%d", issue.Number, claim.Session, claim.PRNumber)
 				o.staleInvalidRepairApproval(s, claim.ApprovalID, reason)
-				continue
+				// Approval reservations suppress the underlying session claim.
+				// Rebuild claims after staling so a real running/open-PR session
+				// cannot be hidden by its obsolete approval and accidentally run
+				// concurrently with the selected repair.
+				revealed, stillClaimed := activeIssueClaimForSession(s, issue.Number, claim.Session)
+				if !stillClaimed {
+					continue
+				}
+				claim = revealed
 			}
 		}
 		// A completed older PR can retain the issue's terminal-reconciliation
@@ -7204,6 +7212,18 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 	}
 	o.notifier.Sendf("🔄 maestro: repairing issue #%d in place on worker %s: %s", issue.Number, slot, issue.Title)
 	return true
+}
+
+func activeIssueClaimForSession(s *state.State, issueNumber int, slot string) (state.IssueClaim, bool) {
+	if s == nil || issueNumber <= 0 || strings.TrimSpace(slot) == "" {
+		return state.IssueClaim{}, false
+	}
+	for _, claim := range s.ActiveIssueClaims() {
+		if claim.IssueNumber == issueNumber && claim.Session == slot {
+			return claim, true
+		}
+	}
+	return state.IssueClaim{}, false
 }
 
 // staleInvalidSpawnRepairApproval makes an irrecoverably invalid exact

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -227,6 +227,50 @@ func TestAwaitingRepairDispatchValidReservationOutranksInvalidSiblingApproval(t 
 	}
 }
 
+// Multiple stale approvals can suppress one another for the same missing
+// sibling session. Reconciliation must peel the whole chain before deciding
+// whether the selected canonical repair has a competing claim.
+func TestAwaitingRepairDispatchValidReservationOutranksMultipleInvalidSiblingApprovals(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	issues := []github.Issue{makeIssue(877, "repair PR #891", "maestro-ready")}
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.hasOpenPRForIssueFn = func(issue int) (bool, error) { return issue == 877, nil }
+	respawns := 0
+	o.respawnInPlaceFn = func(_ *config.Config, slot string, sess *state.Session, _ string, _ github.Issue, _, _ string) error {
+		respawns++
+		if slot != "sup-valid" {
+			t.Fatalf("respawn slot = %q, want sup-valid", slot)
+		}
+		sess.Status = state.StatusRunning
+		return nil
+	}
+
+	now := time.Date(2026, 7, 17, 21, 35, 0, 0, time.UTC)
+	s := state.NewState()
+	s.Sessions["sup-valid"] = &state.Session{IssueNumber: 877, Status: state.StatusDead, PRNumber: 891, Worktree: "/work/sup-valid"}
+	valid := repairApproval("z-valid", 877, 891, state.ApprovalStatusAwaitingDispatch, now)
+	valid.Target.Session = "sup-valid"
+	invalidA := repairApproval("a-invalid", 877, 891, state.ApprovalStatusAwaitingDispatch, now)
+	invalidA.Target.Session = "sup-missing"
+	invalidB := repairApproval("b-invalid", 877, 891, state.ApprovalStatusAwaitingDispatch, now)
+	invalidB.Target.Session = "sup-missing"
+	s.Approvals = []state.Approval{valid, invalidA, invalidB}
+
+	o.startNewWorkers(s, 1)
+
+	if respawns != 1 || len(*freshStarts) != 0 || len(s.Sessions) != 1 {
+		t.Fatalf("valid repair did not dispatch exactly once: respawns=%d fresh=%v sessions=%v", respawns, *freshStarts, s.Sessions)
+	}
+	if got := approvalStatus(t, s, "z-valid"); got != state.ApprovalStatusSuperseded {
+		t.Fatalf("valid approval = %q, want consumed/superseded", got)
+	}
+	for _, id := range []string{"a-invalid", "b-invalid"} {
+		if got := approvalStatus(t, s, id); got != state.ApprovalStatusStale {
+			t.Fatalf("invalid sibling approval %s = %q, want stale", id, got)
+		}
+	}
+}
+
 // Staling an approval can reveal the session claim that the approval had been
 // suppressing. If that real session is still running, it remains canonical and
 // must block the selected repair even though its old approval named a stale PR.

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -185,6 +185,48 @@ func TestAwaitingRepairDispatchMissingReservedSessionBecomesStale(t *testing.T) 
 	}
 }
 
+// A valid exact repair must not lose to a lexically earlier approval-derived
+// claim whose own session is missing. Reconcile the invalid sibling first,
+// then dispatch and consume the valid approval on its canonical worktree.
+func TestAwaitingRepairDispatchValidReservationOutranksInvalidSiblingApproval(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	issues := []github.Issue{makeIssue(877, "repair PR #891", "maestro-ready")}
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.hasOpenPRForIssueFn = func(issue int) (bool, error) { return issue == 877, nil }
+	respawns := 0
+	o.respawnInPlaceFn = func(_ *config.Config, slot string, sess *state.Session, _ string, _ github.Issue, _, _ string) error {
+		respawns++
+		if slot != "sup-valid" {
+			t.Fatalf("respawn slot = %q, want sup-valid", slot)
+		}
+		sess.Status = state.StatusRunning
+		return nil
+	}
+
+	now := time.Date(2026, 7, 17, 21, 1, 32, 0, time.UTC)
+	s := state.NewState()
+	s.Sessions["sup-valid"] = &state.Session{IssueNumber: 877, Status: state.StatusDead, PRNumber: 891, Worktree: "/work/sup-valid"}
+	valid := repairApproval("z-valid", 877, 891, state.ApprovalStatusAwaitingDispatch, now)
+	valid.Target.Session = "sup-valid"
+	invalid := repairApproval("a-invalid", 877, 891, state.ApprovalStatusAwaitingDispatch, now)
+	invalid.Target.Session = "sup-missing"
+	// Selection uses durable insertion order while claims are sorted by ID,
+	// reproducing the review-reported ordering edge.
+	s.Approvals = []state.Approval{valid, invalid}
+
+	o.startNewWorkers(s, 1)
+
+	if respawns != 1 || len(*freshStarts) != 0 || len(s.Sessions) != 1 {
+		t.Fatalf("valid repair did not dispatch exactly once: respawns=%d fresh=%v sessions=%v", respawns, *freshStarts, s.Sessions)
+	}
+	if got := approvalStatus(t, s, "z-valid"); got != state.ApprovalStatusSuperseded {
+		t.Fatalf("valid approval = %q, want consumed/superseded", got)
+	}
+	if got := approvalStatus(t, s, "a-invalid"); got != state.ApprovalStatusStale {
+		t.Fatalf("invalid sibling approval = %q, want stale", got)
+	}
+}
+
 // A repair approval is authority for the state that was reviewed, not a
 // timeless bypass. If the operator adds blocked before dispatch, the current
 // guard wins, the approval becomes stale, and neither an in-place nor a fresh

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -227,6 +227,46 @@ func TestAwaitingRepairDispatchValidReservationOutranksInvalidSiblingApproval(t 
 	}
 }
 
+// Staling an approval can reveal the session claim that the approval had been
+// suppressing. If that real session is still running, it remains canonical and
+// must block the selected repair even though its old approval named a stale PR.
+func TestAwaitingRepairDispatchRechecksSessionRevealedByStaleSiblingApproval(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	issues := []github.Issue{makeIssue(877, "repair PR #891", "maestro-ready")}
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.hasOpenPRForIssueFn = func(issue int) (bool, error) { return issue == 877, nil }
+	respawns := 0
+	o.respawnInPlaceFn = func(_ *config.Config, _ string, _ *state.Session, _ string, _ github.Issue, _, _ string) error {
+		respawns++
+		return nil
+	}
+
+	now := time.Date(2026, 7, 17, 21, 10, 12, 0, time.UTC)
+	s := state.NewState()
+	s.Sessions["sup-valid"] = &state.Session{IssueNumber: 877, Status: state.StatusDead, PRNumber: 891, Worktree: "/work/sup-valid"}
+	s.Sessions["sup-running"] = &state.Session{IssueNumber: 877, Status: state.StatusRunning, PRNumber: 891, Worktree: "/work/sup-running", PID: 9911}
+	selected := repairApproval("z-selected", 877, 891, state.ApprovalStatusAwaitingDispatch, now)
+	selected.Target.Session = "sup-valid"
+	staleSibling := repairApproval("a-stale-pr", 877, 890, state.ApprovalStatusAwaitingDispatch, now)
+	staleSibling.Target.Session = "sup-running"
+	s.Approvals = []state.Approval{selected, staleSibling}
+
+	o.startNewWorkers(s, 1)
+
+	if respawns != 0 || len(*freshStarts) != 0 || len(s.Sessions) != 2 {
+		t.Fatalf("dispatch overlapped revealed running session: respawns=%d fresh=%v sessions=%v", respawns, *freshStarts, s.Sessions)
+	}
+	if got := approvalStatus(t, s, "a-stale-pr"); got != state.ApprovalStatusStale {
+		t.Fatalf("stale-PR sibling approval = %q, want stale", got)
+	}
+	if got := approvalStatus(t, s, "z-selected"); got != state.ApprovalStatusStale {
+		t.Fatalf("selected approval = %q, want stale after revealed running session wins", got)
+	}
+	if got := s.Sessions["sup-running"].Status; got != state.StatusRunning {
+		t.Fatalf("revealed canonical session status = %q, want running", got)
+	}
+}
+
 // A repair approval is authority for the state that was reviewed, not a
 // timeless bypass. If the operator adds blocked before dispatch, the current
 // guard wins, the approval becomes stale, and neither an in-place nor a fresh


### PR DESCRIPTION
## What changed

- revalidate a sibling approval-derived repair claim before allowing it to block a valid exact repair;
- stale an invalid sibling reservation first, then continue the valid canonical in-place dispatch;
- add the review-reported lexical-order regression with two approvals for one issue.

## Why

PR #944 correctly retires an invalid exact reservation, but a lexically earlier invalid sibling approval could appear as a competing claim and cause the selected valid approval to be staled first. The next cycle would stale the sibling too, losing both recoveries. This follow-up makes canonical-session evidence authoritative over approval ordering.

## Safety

- no new slot or worktree is allocated;
- only the exact invalid approval ID becomes stale;
- a valid reservation still dispatches once and is consumed normally;
- unrelated and review-repair authority is not changed.

## Validation

- `umask 077; go test ./internal/orchestrator ./internal/state`
- `umask 077; go test ./...`
- `go build ./cmd/maestro/`

Follow-up to #944; part of #940.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates repair dispatch reconciliation for approval-derived sibling claims. The main changes are:

- Revalidates sibling repair approval claims before they can block an exact repair.
- Marks invalid sibling reservations stale before continuing the valid canonical dispatch.
- Rebuilds issue claims after each stale transition so hidden session claims are considered.
- Adds tests for lexically earlier invalid approvals, multiple invalid sibling approvals, and revealed running sessions.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge, with attention on the repair-dispatch reconciliation path.

The change is narrowly scoped and covered by tests for the reported ordering cases. No new accepted inline issues were identified in this final pass.

`internal/orchestrator/orchestrator.go` contains the central orchestration logic touched by this change.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The narrow orchestrator/state tests passed for internal/orchestrator and internal/state, with EXIT\_CODE 0.
- The full go test ./... suite passed across all packages, with EXIT\_CODE 0.
- The Go build for ./cmd/maestro/ completed with EXIT\_CODE 0.

<a href="https://app.greptile.com/trex/runs/14907700/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds sibling repair-approval revalidation and a shared helper for staling invalid repair approvals. |
| internal/orchestrator/repair_approval_reconcile_test.go | Adds tests for invalid sibling approval ordering, chained stale approvals, and revealed competing sessions. |

<sub>Reviews (3): Last reviewed commit: ["fix: drain stale sibling repair claims"](https://github.com/befeast/maestro/commit/430b91048374f455e594167e55a8c58fcaf0125b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45216336)</sub>

<!-- /greptile_comment -->