### PR TITLE
fix: reconcile closed-unmerged PR sessions truthfully

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1406,6 +1406,14 @@ func prReferencesIssue(pr PR, issueNumber int) bool {
 	return issueRefRegexp(issueNumber).MatchString(pr.Title + "\n" + stripCodeForRefMatch(pr.Body))
 }
 
+// PRReferencesIssue reports whether the PR title/body references issueNumber.
+// It exposes the same code/log-safe matcher used by HasOpenPRForIssue so
+// control-plane reconcilers can match an already-fetched open-PR snapshot
+// without issuing another GitHub request.
+func PRReferencesIssue(pr PR, issueNumber int) bool {
+	return prReferencesIssue(pr, issueNumber)
+}
+
 // prClosesIssue is the STRICT variant for "this merged PR closed issue N".
 // Unlike prReferencesIssue, it requires one of GitHub's recognised closing
 // keywords (close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved)

--- a/internal/orchestrator/closed_unmerged_reconcile_test.go
+++ b/internal/orchestrator/closed_unmerged_reconcile_test.go
@@ -25,7 +25,7 @@ func TestReconcileFalseDoneSessionAdoptsSoleOpenCanonicalPR(t *testing.T) {
 		isIssueClosedFn: func(int) (bool, error) { return false, nil },
 	}
 
-	o.reconcileFalseDoneSessionsWithOpenPRs(s, []github.PR{{
+	o.reconcileTerminalSessionsWithOpenPRs(s, []github.PR{{
 		Number:      388,
 		HeadRefName: "feat/ok-player-345-flatpak-beta-retry",
 		Title:       "Linux packaging for #345",
@@ -51,7 +51,7 @@ func TestReconcileFalseDoneSessionRefusesAmbiguousOpenPRs(t *testing.T) {
 	s.Sessions["slot"] = &state.Session{IssueNumber: 345, Status: state.StatusDone, PRNumber: 389}
 	o := &Orchestrator{}
 
-	o.reconcileFalseDoneSessionsWithOpenPRs(s, []github.PR{
+	o.reconcileTerminalSessionsWithOpenPRs(s, []github.PR{
 		{Number: 388, Title: "first #345"},
 		{Number: 390, Title: "second #345"},
 	})
@@ -72,10 +72,56 @@ func TestReconcileDoneSessionKeepsAuthoritativeMergedOutcome(t *testing.T) {
 		},
 	}
 
-	o.reconcileFalseDoneSessionsWithOpenPRs(s, []github.PR{{Number: 388, Title: "follow-up #345"}})
+	o.reconcileTerminalSessionsWithOpenPRs(s, []github.PR{{Number: 388, Title: "follow-up #345"}})
 
 	if got := s.Sessions["slot"]; got.Status != state.StatusDone || got.PRNumber != 389 {
 		t.Fatalf("authoritative merged session mutated: %+v", got)
+	}
+}
+
+func TestReconcileCanonicalPRSelectsExactHistoricalSessionAfterCompetingWorkerStops(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["ok-player-272"] = &state.Session{
+		IssueNumber:        346,
+		Status:             state.StatusFailed,
+		Branch:             "feat/older-duplicate",
+		LastClosedPRNumber: 372,
+	}
+	s.Sessions["ok-player-277"] = &state.Session{
+		IssueNumber:        346,
+		Status:             state.StatusFailed,
+		Branch:             "feat/canonical-fedora",
+		LastClosedPRNumber: 397,
+	}
+	s.Sessions["ok-player-294"] = &state.Session{
+		IssueNumber: 346,
+		Status:      state.StatusRunning,
+		Branch:      "feat/new-duplicate",
+	}
+	o := &Orchestrator{
+		isIssueClosedFn: func(int) (bool, error) { return false, nil },
+	}
+	prs := []github.PR{{Number: 397, HeadRefName: "feat/canonical-fedora", Title: "Fedora fix for #346"}}
+
+	// A live competing lease makes reconciliation fail closed.
+	o.reconcileTerminalSessionsWithOpenPRs(s, prs)
+	if got := s.Sessions["ok-player-277"].Status; got != state.StatusFailed {
+		t.Fatalf("canonical session activated while competing worker runs: %q", got)
+	}
+
+	// Once the duplicate is terminal, the exact branch/PR match wins over
+	// every other historical session without allocating a new identity.
+	s.Sessions["ok-player-294"].Status = state.StatusFailed
+	o.reconcileTerminalSessionsWithOpenPRs(s, prs)
+	canonical := s.Sessions["ok-player-277"]
+	if canonical.Status != state.StatusPROpen || canonical.PRNumber != 397 || canonical.Branch != "feat/canonical-fedora" {
+		t.Fatalf("canonical session = %+v, want ok-player-277 bound to open PR #397", canonical)
+	}
+	if got := s.Sessions["ok-player-272"].Status; got != state.StatusFailed {
+		t.Fatalf("older historical session activated: %q", got)
+	}
+	if got := s.Sessions["ok-player-294"].Status; got != state.StatusFailed {
+		t.Fatalf("new duplicate historical session activated: %q", got)
 	}
 }
 

--- a/internal/orchestrator/closed_unmerged_reconcile_test.go
+++ b/internal/orchestrator/closed_unmerged_reconcile_test.go
@@ -1,0 +1,107 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestReconcileFalseDoneSessionAdoptsSoleOpenCanonicalPR(t *testing.T) {
+	finished := time.Date(2026, 7, 17, 17, 13, 56, 0, time.UTC)
+	s := state.NewState()
+	s.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345,
+		Status:      state.StatusDone,
+		PRNumber:    389,
+		Branch:      "feat/duplicate-389",
+		FinishedAt:  &finished,
+	}
+	o := &Orchestrator{
+		isPRMergedFn:    func(int) (bool, error) { return false, nil },
+		isIssueClosedFn: func(int) (bool, error) { return false, nil },
+	}
+
+	o.reconcileFalseDoneSessionsWithOpenPRs(s, []github.PR{{
+		Number:      388,
+		HeadRefName: "feat/ok-player-345-flatpak-beta-retry",
+		Title:       "Linux packaging for #345",
+	}})
+
+	sess := s.Sessions["ok-player-273"]
+	if sess.Status != state.StatusPROpen {
+		t.Fatalf("status = %q, want pr_open", sess.Status)
+	}
+	if sess.PRNumber != 388 || sess.Branch != "feat/ok-player-345-flatpak-beta-retry" {
+		t.Fatalf("canonical identity = PR #%d branch %q, want PR #388 canonical branch", sess.PRNumber, sess.Branch)
+	}
+	if sess.LastClosedPRNumber != 389 {
+		t.Fatalf("last closed PR = %d, want 389", sess.LastClosedPRNumber)
+	}
+	if sess.FinishedAt != nil {
+		t.Fatalf("finished_at retained after reopening canonical PR: %v", sess.FinishedAt)
+	}
+}
+
+func TestReconcileFalseDoneSessionRefusesAmbiguousOpenPRs(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["slot"] = &state.Session{IssueNumber: 345, Status: state.StatusDone, PRNumber: 389}
+	o := &Orchestrator{}
+
+	o.reconcileFalseDoneSessionsWithOpenPRs(s, []github.PR{
+		{Number: 388, Title: "first #345"},
+		{Number: 390, Title: "second #345"},
+	})
+
+	if got := s.Sessions["slot"]; got.Status != state.StatusDone || got.PRNumber != 389 {
+		t.Fatalf("ambiguous reconcile mutated session: %+v", got)
+	}
+}
+
+func TestReconcileDoneSessionKeepsAuthoritativeMergedOutcome(t *testing.T) {
+	s := state.NewState()
+	s.Sessions["slot"] = &state.Session{IssueNumber: 345, Status: state.StatusDone, PRNumber: 389}
+	o := &Orchestrator{
+		isPRMergedFn: func(pr int) (bool, error) { return pr == 389, nil },
+		isIssueClosedFn: func(int) (bool, error) {
+			t.Fatal("merged PR is authoritative; issue state should not be queried")
+			return false, nil
+		},
+	}
+
+	o.reconcileFalseDoneSessionsWithOpenPRs(s, []github.PR{{Number: 388, Title: "follow-up #345"}})
+
+	if got := s.Sessions["slot"]; got.Status != state.StatusDone || got.PRNumber != 389 {
+		t.Fatalf("authoritative merged session mutated: %+v", got)
+	}
+}
+
+func TestAutoMergeClosedUnmergedPRReleasesOpenIssue(t *testing.T) {
+	o := &Orchestrator{
+		cfg:             &config.Config{Repo: "owner/repo"},
+		notifier:        &notify.Notifier{},
+		listOpenPRsFn:   func() ([]github.PR, error) { return nil, nil },
+		isPRMergedFn:    func(int) (bool, error) { return false, nil },
+		isIssueClosedFn: func(int) (bool, error) { return false, nil },
+	}
+	s := state.NewState()
+	s.Sessions["slot"] = &state.Session{
+		IssueNumber: 345,
+		Status:      state.StatusPROpen,
+		PRNumber:    389,
+		Branch:      "feat/duplicate-389",
+	}
+
+	o.autoMergePRs(s)
+
+	sess := s.Sessions["slot"]
+	if sess.Status != state.StatusFailed || !sess.ReleasedForRedispatch {
+		t.Fatalf("session = %+v, want failed/released after closed-unmerged PR", sess)
+	}
+	if sess.PRNumber != 0 || sess.LastClosedPRNumber != 389 {
+		t.Fatalf("PR identity = current %d last_closed %d, want 0/389", sess.PRNumber, sess.LastClosedPRNumber)
+	}
+}

--- a/internal/orchestrator/closed_unmerged_reconcile_test.go
+++ b/internal/orchestrator/closed_unmerged_reconcile_test.go
@@ -1,6 +1,9 @@
 package orchestrator
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -124,6 +127,77 @@ func TestReconcileCanonicalPRSelectsExactHistoricalSessionAfterCompetingWorkerSt
 	if got := s.Sessions["ok-player-294"].Status; got != state.StatusFailed {
 		t.Fatalf("new duplicate historical session activated: %q", got)
 	}
+}
+
+func TestReconcileActiveCanonicalPRReceivesTerminalSiblingCommitHandoffOnce(t *testing.T) {
+	repo := newReconcileBranchRepo(t)
+	runReconcileGit(t, repo, "branch", "canonical")
+	runReconcileGit(t, repo, "switch", "-c", "preserved-sibling")
+	if err := os.WriteFile(filepath.Join(repo, "repair.txt"), []byte("preserved repair\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReconcileGit(t, repo, "add", "repair.txt")
+	runReconcileGit(t, repo, "commit", "-m", "preserved repair")
+	wantCommit := strings.TrimSpace(runReconcileGit(t, repo, "rev-parse", "HEAD"))
+
+	s := state.NewState()
+	s.Sessions["canonical-slot"] = &state.Session{
+		IssueNumber: 346,
+		Status:      state.StatusPROpen,
+		PRNumber:    397,
+		Branch:      "canonical",
+	}
+	s.Sessions["preserved-slot"] = &state.Session{
+		IssueNumber: 346,
+		Status:      state.StatusRetryExhausted,
+		Branch:      "preserved-sibling",
+	}
+	o := &Orchestrator{cfg: &config.Config{LocalPath: repo}}
+	prs := []github.PR{{Number: 397, HeadRefName: "canonical", Title: "Fedora fix for #346"}}
+
+	o.reconcileTerminalSessionsWithOpenPRs(s, prs)
+	feedback := s.Sessions["canonical-slot"].PreviousAttemptFeedback
+	for _, want := range []string{"preserved-slot", "preserved-sibling", wantCommit} {
+		if !strings.Contains(feedback, want) {
+			t.Fatalf("handoff missing %q: %s", want, feedback)
+		}
+	}
+	if got := s.Sessions["canonical-slot"].PreviousAttemptFeedbackKind; got != "recovery_handoff" {
+		t.Fatalf("feedback kind = %q, want recovery_handoff", got)
+	}
+	if got := s.Sessions["canonical-slot"].Status; got != state.StatusPROpen {
+		t.Fatalf("canonical status = %q, want pr_open", got)
+	}
+
+	// Repeated minute-level reconciliation must not grow the prompt forever.
+	o.reconcileTerminalSessionsWithOpenPRs(s, prs)
+	if got := s.Sessions["canonical-slot"].PreviousAttemptFeedback; got != feedback {
+		t.Fatalf("handoff was duplicated:\n%s", got)
+	}
+}
+
+func newReconcileBranchRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runReconcileGit(t, repo, "init", "-b", "main")
+	runReconcileGit(t, repo, "config", "user.email", "test@example.com")
+	runReconcileGit(t, repo, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReconcileGit(t, repo, "add", "README.md")
+	runReconcileGit(t, repo, "commit", "-m", "seed")
+	return repo
+}
+
+func runReconcileGit(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	cmdArgs := append([]string{"-C", repo}, args...)
+	out, err := exec.Command("git", cmdArgs...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
 }
 
 func TestAppendRecoveryHandoffContextRequiresExistingCanonicalPR(t *testing.T) {

--- a/internal/orchestrator/closed_unmerged_reconcile_test.go
+++ b/internal/orchestrator/closed_unmerged_reconcile_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -122,6 +123,15 @@ func TestReconcileCanonicalPRSelectsExactHistoricalSessionAfterCompetingWorkerSt
 	}
 	if got := s.Sessions["ok-player-294"].Status; got != state.StatusFailed {
 		t.Fatalf("new duplicate historical session activated: %q", got)
+	}
+}
+
+func TestAppendRecoveryHandoffContextRequiresExistingCanonicalPR(t *testing.T) {
+	prompt := appendRecoveryHandoffContext("base", "- session duplicate: unique commit `abc123`")
+	for _, want := range []string{"existing PR", "abc123", "do NOT open another PR"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("recovery prompt missing %q: %s", want, prompt)
+		}
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4273,7 +4273,7 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	// duplicate PR hid an older canonical draft). Rebind only when exactly one
 	// open PR references the issue. Multiple candidates are ambiguous and must
 	// remain untouched; choosing one would manufacture a new canonical identity.
-	o.reconcileFalseDoneSessionsWithOpenPRs(s, prs)
+	o.reconcileTerminalSessionsWithOpenPRs(s, prs)
 
 	type mergeCandidate struct {
 		slotName string
@@ -4597,36 +4597,85 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	}
 }
 
-func (o *Orchestrator) reconcileFalseDoneSessionsWithOpenPRs(s *state.State, prs []github.PR) {
+func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs []github.PR) {
 	if s == nil || len(prs) == 0 {
 		return
 	}
-	for _, slotName := range sortedStateSessionNames(s) {
-		sess := s.Sessions[slotName]
-		if sess == nil || sess.Status != state.StatusDone || sess.IssueNumber <= 0 {
+	prsByIssue := make(map[int][]github.PR)
+	for _, pr := range prs {
+		for _, sess := range s.Sessions {
+			if sess == nil || sess.IssueNumber <= 0 || !github.PRReferencesIssue(pr, sess.IssueNumber) {
+				continue
+			}
+			already := false
+			for _, known := range prsByIssue[sess.IssueNumber] {
+				if known.Number == pr.Number {
+					already = true
+					break
+				}
+			}
+			if !already {
+				prsByIssue[sess.IssueNumber] = append(prsByIssue[sess.IssueNumber], pr)
+			}
+		}
+	}
+
+	for issue, matches := range prsByIssue {
+		if len(matches) != 1 {
+			log.Printf("[orch] terminal/open-PR reconcile held for issue #%d: %d open PRs reference the issue; canonical identity is ambiguous", issue, len(matches))
 			continue
 		}
-		matches := make([]github.PR, 0, 1)
-		for _, pr := range prs {
-			if github.PRReferencesIssue(pr, sess.IssueNumber) {
-				matches = append(matches, pr)
+		canonical := matches[0]
+		var allSlots, exactSlots []string
+		activeOther := ""
+		for _, slotName := range sortedStateSessionNames(s) {
+			sess := s.Sessions[slotName]
+			if sess == nil || sess.IssueNumber != issue {
+				continue
+			}
+			allSlots = append(allSlots, slotName)
+			if repairIssueSessionActive(sess.Status) {
+				activeOther = slotName
+			}
+			if (sess.Status == state.StatusDone || sess.Status == state.StatusFailed) &&
+				(sess.PRNumber == canonical.Number || sess.LastClosedPRNumber == canonical.Number || sess.Branch == canonical.HeadRefName) {
+				exactSlots = append(exactSlots, slotName)
 			}
 		}
-		if len(matches) != 1 {
-			if len(matches) > 1 {
-				log.Printf("[orch] false-done reconcile held for issue #%d / session %s: %d open PRs reference the issue; canonical identity is ambiguous", sess.IssueNumber, slotName, len(matches))
-			}
+		if activeOther != "" {
+			// Never activate a second session while another issue-level lease is
+			// live, even if the open PR points at an older canonical branch.
+			continue
+		}
+
+		candidateSlot := ""
+		switch {
+		case len(exactSlots) == 1:
+			candidateSlot = exactSlots[0]
+		case len(exactSlots) > 1:
+			log.Printf("[orch] terminal/open-PR reconcile held for issue #%d / PR #%d: %d terminal sessions claim the canonical identity", issue, canonical.Number, len(exactSlots))
+			continue
+		case len(allSlots) == 1:
+			candidateSlot = allSlots[0]
+		default:
+			log.Printf("[orch] terminal/open-PR reconcile held for issue #%d / PR #%d: no exact session among %d historical sessions", issue, canonical.Number, len(allSlots))
+			continue
+		}
+		sess := s.Sessions[candidateSlot]
+		if sess == nil || (sess.Status != state.StatusDone && sess.Status != state.StatusFailed) {
 			continue
 		}
 		merged := false
 		var err error
-		if sess.PRNumber > 0 {
+		if sess.PRNumber > 0 && sess.PRNumber != canonical.Number {
 			merged, err = o.isPRMerged(sess.PRNumber)
-		} else {
+		} else if sess.PRNumber == 0 && sess.LastClosedPRNumber > 0 && sess.LastClosedPRNumber != canonical.Number {
+			merged, err = o.isPRMerged(sess.LastClosedPRNumber)
+		} else if sess.PRNumber == 0 && sess.LastClosedPRNumber == 0 {
 			merged, err = o.hasMergedPRForIssue(sess.IssueNumber)
 		}
 		if err != nil {
-			log.Printf("[orch] false-done reconcile held for issue #%d / session %s: authoritative merge state unavailable: %v", sess.IssueNumber, slotName, err)
+			log.Printf("[orch] terminal/open-PR reconcile held for issue #%d / session %s: authoritative merge state unavailable: %v", sess.IssueNumber, candidateSlot, err)
 			continue
 		}
 		if merged {
@@ -4634,13 +4683,12 @@ func (o *Orchestrator) reconcileFalseDoneSessionsWithOpenPRs(s *state.State, prs
 		}
 		closed, err := o.isIssueClosed(sess.IssueNumber)
 		if err != nil {
-			log.Printf("[orch] false-done reconcile held for issue #%d / session %s: authoritative issue state unavailable: %v", sess.IssueNumber, slotName, err)
+			log.Printf("[orch] terminal/open-PR reconcile held for issue #%d / session %s: authoritative issue state unavailable: %v", sess.IssueNumber, candidateSlot, err)
 			continue
 		}
 		if closed {
 			continue
 		}
-		canonical := matches[0]
 		oldPR := sess.PRNumber
 		if oldPR > 0 && oldPR != canonical.Number {
 			sess.LastClosedPRNumber = oldPR
@@ -4650,7 +4698,7 @@ func (o *Orchestrator) reconcileFalseDoneSessionsWithOpenPRs(s *state.State, prs
 		sess.Status = state.StatusPROpen
 		sess.FinishedAt = nil
 		sess.ReleasedForRedispatch = false
-		log.Printf("[orch] reconciled false done session %s for issue #%d: closed/unavailable PR #%d replaced by sole open canonical PR #%d on branch %s", slotName, sess.IssueNumber, oldPR, canonical.Number, canonical.HeadRefName)
+		log.Printf("[orch] reconciled terminal session %s for issue #%d: closed/unavailable PR #%d replaced by sole open canonical PR #%d on branch %s", candidateSlot, sess.IssueNumber, oldPR, canonical.Number, canonical.HeadRefName)
 	}
 }
 
@@ -5123,8 +5171,11 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 		pr.Number, sess.IssueNumber, sess.IssueTitle, sess.MaintenanceRetryCount, maxRetries, backoffMs/1000)
 }
 
-// handleCIFailureRetry closes the failed PR, captures CI output, cleans up,
-// and schedules a retry for the worker (respecting max_retries_per_issue).
+// handleCIFailureRetry captures the failed checks and schedules an in-place
+// repair on the same slot/worktree/branch/PR. A red check is not a reason to
+// destroy canonical identity: closing the PR and clearing its session lease
+// let the ready issue dispatch a second worker before the retry completed
+// (live #949 / OK Player #346).
 func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, sess *state.Session, pr github.PR) {
 	maxRetries := o.cfg.MaxRetriesPerIssue
 	totalAttempts := s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount
@@ -5149,14 +5200,14 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 		return
 	}
 
-	// Capture CI failure output before closing the PR
+	// Capture CI failure output while the failed head is still authoritative.
 	ciOutput, err := o.prChecksOutput(pr.Number)
 	if err != nil {
 		log.Printf("[orch] warn: could not capture CI output for PR #%d: %v", pr.Number, err)
 		ciOutput = "(CI output unavailable)"
 	}
 
-	// Collect Greptile review feedback before closing the PR
+	// Collect review feedback for the same in-place repair prompt.
 	reviewFeedback, err := o.collectPRReviewFeedback(pr.Number)
 	if err != nil {
 		log.Printf("[orch] warn: could not collect review feedback for PR #%d: %v", pr.Number, err)
@@ -5166,23 +5217,22 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 	// takes — its failure conclusion makes the aggregate CI verdict "failure".
 	// CIFailureOutput above is only the bare checks overview (name + state); the
 	// concrete `##[error]` annotation lines that say WHY the check failed live
-	// here. Capture them before closing the PR so the retry worker sees the
+	// here. Capture them while the failed head is authoritative so the retry worker sees the
 	// exact lint constraint its previous push broke, not just "agent-lint
 	// failed" — this was the observed PR #850 blindness.
 	failingCheckContext := o.collectFailingCheckContext(pr.Number)
 
-	// Close the failed PR with an explanation
-	closeComment := fmt.Sprintf("CI failed — maestro is closing this PR and respawning a new worker to retry (attempt %d).\n\nCI output:\n```\n%s\n```",
-		sess.RetryCount+1, ciOutput)
-	if err := o.closePR(pr.Number, closeComment); err != nil {
-		log.Printf("[orch] warn: could not close PR #%d: %v — skipping retry", pr.Number, err)
-		return
+	// Preserve the exact PR lease. Cleanup may already have cleared the
+	// worktree field on a terminal transition; record only the deterministic
+	// same-slot path so respawnPreservingWorktreeWithConfig can restore the
+	// retained local branch without allocating a new slot or branch.
+	sess.PRNumber = pr.Number
+	if strings.TrimSpace(sess.Branch) == "" {
+		sess.Branch = pr.HeadRefName
 	}
-	log.Printf("[orch] closed PR #%d due to CI failure", pr.Number)
-
-	// Clean up the worktree
-	o.stopWorker(slotName, sess)
-	sess.Worktree = ""
+	if strings.TrimSpace(sess.Worktree) == "" && strings.TrimSpace(o.cfg.WorktreeBase) != "" {
+		sess.Worktree = filepath.Join(o.cfg.WorktreeBase, slotName)
+	}
 
 	// Store CI failure output and review feedback for the next worker
 	sess.CIFailureOutput = ciOutput
@@ -5194,23 +5244,21 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 		sess.PreviousAttemptFeedbackKind = ""
 	}
 
-	// Schedule retry with exponential backoff. Remember which PR this retry
-	// closed (#800): if an operator reopens and merges it while the backoff
-	// runs, the pre-respawn staleness check cancels the retry.
+	// Schedule the same-session repair with exponential backoff. The open PR
+	// remains the issue-level lease throughout the wait, so ordinary dispatch
+	// cannot race the repair with a fresh worker.
 	sess.RetryCount++
 	backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
 	retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
 	sess.NextRetryAt = &retryAt
 	sess.Status = state.StatusDead
-	sess.LastClosedPRNumber = pr.Number
-	sess.PRNumber = 0
 	now := time.Now().UTC()
 	sess.FinishedAt = &now
 	state.MarkWorkerEnded(sess, now)
 
-	log.Printf("[orch] CI failure on PR #%d — scheduling retry %d in %dms for issue #%d",
-		pr.Number, sess.RetryCount, backoffMs, sess.IssueNumber)
-	o.notifier.Sendf("🔄 maestro: CI failed on PR #%d (issue #%d: %s), retry %d scheduled in %ds",
+	log.Printf("[orch] CI failure on PR #%d — scheduling in-place retry %d in %dms for issue #%d on session %s",
+		pr.Number, sess.RetryCount, backoffMs, sess.IssueNumber, slotName)
+	o.notifier.Sendf("🔄 maestro: CI failed on PR #%d (issue #%d: %s), in-place retry %d scheduled in %ds",
 		pr.Number, sess.IssueNumber, sess.IssueTitle, sess.RetryCount, backoffMs/1000)
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4663,7 +4663,14 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 		}
 		if activeOther != "" {
 			// Never activate a second session while another issue-level lease is
-			// live, even if the open PR points at an older canonical branch.
+			// live, even if the open PR points at an older canonical branch. The
+			// active canonical session still needs a durable handoff from terminal
+			// sibling branches, however: otherwise work preserved by a duplicate
+			// worker remains invisible once the canonical PR is reattached.
+			active := s.Sessions[activeOther]
+			if active != nil && (active.PRNumber == canonical.Number || active.Branch == canonical.HeadRefName) {
+				o.attachPreservedSiblingHandoffs(s, issue, activeOther, active, canonical, allSlots)
+			}
 			continue
 		}
 
@@ -4724,26 +4731,6 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 				continue
 			}
 		}
-		var handoffs []string
-		if o.cfg != nil && strings.TrimSpace(o.cfg.LocalPath) != "" {
-			for _, siblingSlot := range allSlots {
-				if siblingSlot == candidateSlot {
-					continue
-				}
-				sibling := s.Sessions[siblingSlot]
-				if sibling == nil || strings.TrimSpace(sibling.Branch) == "" || sibling.Branch == canonical.HeadRefName {
-					continue
-				}
-				commits, err := worker.UniqueBranchCommits(o.cfg.LocalPath, canonical.HeadRefName, sibling.Branch)
-				if err != nil {
-					log.Printf("[orch] terminal/open-PR reconcile: could not inspect preserved sibling branch %s for issue #%d: %v", sibling.Branch, issue, err)
-					continue
-				}
-				if len(commits) > 0 {
-					handoffs = append(handoffs, fmt.Sprintf("- session %s branch `%s`: unique commits `%s`", siblingSlot, sibling.Branch, strings.Join(commits, "`, `")))
-				}
-			}
-		}
 		oldPR := sess.PRNumber
 		if oldPR > 0 && oldPR != canonical.Number {
 			sess.LastClosedPRNumber = oldPR
@@ -4753,17 +4740,49 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 		sess.Status = state.StatusPROpen
 		sess.FinishedAt = nil
 		sess.ReleasedForRedispatch = false
-		if len(handoffs) > 0 {
-			handoff := strings.Join(handoffs, "\n")
-			if strings.TrimSpace(sess.PreviousAttemptFeedback) == "" {
-				sess.PreviousAttemptFeedback = handoff
-				sess.PreviousAttemptFeedbackKind = "recovery_handoff"
-			} else {
-				sess.PreviousAttemptFeedback += "\n\nPreserved sibling work:\n" + handoff
-			}
-		}
+		o.attachPreservedSiblingHandoffs(s, issue, candidateSlot, sess, canonical, allSlots)
 		log.Printf("[orch] reconciled terminal session %s for issue #%d: closed/unavailable PR #%d replaced by sole open canonical PR #%d on branch %s", candidateSlot, sess.IssueNumber, oldPR, canonical.Number, canonical.HeadRefName)
 	}
+}
+
+func (o *Orchestrator) attachPreservedSiblingHandoffs(s *state.State, issue int, canonicalSlot string, canonicalSession *state.Session, canonical github.PR, allSlots []string) {
+	if o.cfg == nil || strings.TrimSpace(o.cfg.LocalPath) == "" || canonicalSession == nil {
+		return
+	}
+	var handoffs []string
+	for _, siblingSlot := range allSlots {
+		if siblingSlot == canonicalSlot {
+			continue
+		}
+		sibling := s.Sessions[siblingSlot]
+		if sibling == nil || repairIssueSessionActive(sibling.Status) || strings.TrimSpace(sibling.Branch) == "" || sibling.Branch == canonical.HeadRefName {
+			continue
+		}
+		commits, err := worker.UniqueBranchCommits(o.cfg.LocalPath, canonical.HeadRefName, sibling.Branch)
+		if err != nil {
+			log.Printf("[orch] terminal/open-PR reconcile: could not inspect preserved sibling branch %s for issue #%d: %v", sibling.Branch, issue, err)
+			continue
+		}
+		if len(commits) == 0 {
+			continue
+		}
+		handoff := fmt.Sprintf("- session %s branch `%s`: unique commits `%s`", siblingSlot, sibling.Branch, strings.Join(commits, "`, `"))
+		if strings.Contains(canonicalSession.PreviousAttemptFeedback, handoff) {
+			continue
+		}
+		handoffs = append(handoffs, handoff)
+	}
+	if len(handoffs) == 0 {
+		return
+	}
+	handoff := strings.Join(handoffs, "\n")
+	if strings.TrimSpace(canonicalSession.PreviousAttemptFeedback) == "" {
+		canonicalSession.PreviousAttemptFeedback = handoff
+		canonicalSession.PreviousAttemptFeedbackKind = "recovery_handoff"
+	} else {
+		canonicalSession.PreviousAttemptFeedback += "\n\nPreserved sibling work:\n" + handoff
+	}
+	log.Printf("[orch] attached preserved sibling commit handoff to canonical session %s for issue #%d / PR #%d", canonicalSlot, issue, canonical.Number)
 }
 
 func (o *Orchestrator) releaseClosedUnmergedSession(sess *state.Session, slotName string) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1828,8 +1828,9 @@ func appendCIFailureContext(promptBase, ciOutput string, attempt int) string {
 
 ## IMPORTANT: Previous CI Failure (Attempt %d)
 
-A previous worker created a PR for this issue, but CI failed. The PR has been closed.
-You are a retry worker — please fix the CI failures described below.
+The current canonical PR for this issue failed CI and remains open.
+You are an in-place retry worker on that same branch and worktree. Fix the CI
+failures described below, push to the existing PR, and do NOT open another PR.
 
 **CI output from the failed run:**
 `+"```"+`
@@ -1854,6 +1855,22 @@ The following code review comments were left on the previous PR. Address ALL of 
 IMPORTANT: Address ALL code review findings above before creating a new PR.
 Do NOT repeat the same mistakes.
 `, promptBase, feedback)
+}
+
+func appendRecoveryHandoffContext(promptBase, handoff string) string {
+	return fmt.Sprintf(`%s
+
+### Preserved Work From a Superseded Session
+
+Maestro recovered the canonical issue/PR identity after a duplicate or stale
+session. The following committed work is preserved locally:
+
+%s
+
+Inspect these exact commits, carry every useful change onto your current
+canonical branch, and push only to the existing PR. Do NOT delete the preserved
+branch/worktree and do NOT open another PR.
+`, promptBase, handoff)
 }
 
 // failingCheckExcerptCapBytes hard-caps the failing-check excerpt placed in a
@@ -2196,6 +2213,8 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 		if sess.PreviousAttemptFeedback != "" {
 			if sess.PreviousAttemptFeedbackKind == "rebase_conflict" {
 				promptBase = appendRebaseConflictContext(promptBase, sess.PreviousAttemptFeedback)
+			} else if sess.PreviousAttemptFeedbackKind == "recovery_handoff" {
+				promptBase = appendRecoveryHandoffContext(promptBase, sess.PreviousAttemptFeedback)
 			} else {
 				if sess.PreviousAttemptFeedbackKind == state.RetryReasonReviewFeedback {
 					sess.RetryReason = state.RetryReasonReviewFeedback
@@ -4705,6 +4724,26 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 				continue
 			}
 		}
+		var handoffs []string
+		if o.cfg != nil && strings.TrimSpace(o.cfg.LocalPath) != "" {
+			for _, siblingSlot := range allSlots {
+				if siblingSlot == candidateSlot {
+					continue
+				}
+				sibling := s.Sessions[siblingSlot]
+				if sibling == nil || strings.TrimSpace(sibling.Branch) == "" || sibling.Branch == canonical.HeadRefName {
+					continue
+				}
+				commits, err := worker.UniqueBranchCommits(o.cfg.LocalPath, canonical.HeadRefName, sibling.Branch)
+				if err != nil {
+					log.Printf("[orch] terminal/open-PR reconcile: could not inspect preserved sibling branch %s for issue #%d: %v", sibling.Branch, issue, err)
+					continue
+				}
+				if len(commits) > 0 {
+					handoffs = append(handoffs, fmt.Sprintf("- session %s branch `%s`: unique commits `%s`", siblingSlot, sibling.Branch, strings.Join(commits, "`, `")))
+				}
+			}
+		}
 		oldPR := sess.PRNumber
 		if oldPR > 0 && oldPR != canonical.Number {
 			sess.LastClosedPRNumber = oldPR
@@ -4714,6 +4753,15 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 		sess.Status = state.StatusPROpen
 		sess.FinishedAt = nil
 		sess.ReleasedForRedispatch = false
+		if len(handoffs) > 0 {
+			handoff := strings.Join(handoffs, "\n")
+			if strings.TrimSpace(sess.PreviousAttemptFeedback) == "" {
+				sess.PreviousAttemptFeedback = handoff
+				sess.PreviousAttemptFeedbackKind = "recovery_handoff"
+			} else {
+				sess.PreviousAttemptFeedback += "\n\nPreserved sibling work:\n" + handoff
+			}
+		}
 		log.Printf("[orch] reconciled terminal session %s for issue #%d: closed/unavailable PR #%d replaced by sole open canonical PR #%d on branch %s", candidateSlot, sess.IssueNumber, oldPR, canonical.Number, canonical.HeadRefName)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4689,6 +4689,22 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 		if closed {
 			continue
 		}
+		// A retained terminal worktree may still be checked out on the closed
+		// duplicate branch. Metadata alone cannot adopt the canonical PR because
+		// RespawnInPlace deliberately preserves the existing checkout. Reattach a
+		// clean worktree first and fail closed on dirty/mismatched state so no work
+		// is lost or accidentally pushed to the wrong PR.
+		if strings.TrimSpace(sess.Worktree) != "" {
+			if _, statErr := os.Stat(sess.Worktree); statErr == nil {
+				if err := worker.EnsureWorktreeBranch(sess.Worktree, canonical.HeadRefName); err != nil {
+					log.Printf("[orch] terminal/open-PR reconcile held for issue #%d / session %s: canonical worktree reattach failed: %v", sess.IssueNumber, candidateSlot, err)
+					continue
+				}
+			} else if !errors.Is(statErr, os.ErrNotExist) {
+				log.Printf("[orch] terminal/open-PR reconcile held for issue #%d / session %s: stat retained worktree: %v", sess.IssueNumber, candidateSlot, statErr)
+				continue
+			}
+		}
 		oldPR := sess.PRNumber
 		if oldPR > 0 && oldPR != canonical.Number {
 			sess.LastClosedPRNumber = oldPR

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4311,6 +4311,22 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		if !found {
 			if sess.Status == state.StatusRetryExhausted {
 				if sess.PRNumber == 0 {
+					// A no-PR terminal sibling is not an issue-level blocker when
+					// another open PR already owns the issue. In particular, it must
+					// not apply the blocked label behind the canonical PR's back.
+					// Preserve the sibling for commit handoff and let the canonical
+					// PR maintenance path converge in place.
+					canonicalOpen := false
+					for _, openPR := range prs {
+						if github.PRReferencesIssue(openPR, sess.IssueNumber) {
+							canonicalOpen = true
+							break
+						}
+					}
+					if canonicalOpen {
+						log.Printf("[orch] no-PR retry_exhausted session %s for issue #%d is superseded by an open canonical PR — preserving sibling work without blocking the issue", slotName, sess.IssueNumber)
+						continue
+					}
 					// #577: worker exhausted retries without ever producing a PR
 					// (e.g. the issue was already implemented by a prior merge via
 					// `Refs #N`, so the worker found zero diff). Without action the
@@ -4400,13 +4416,14 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		// #424: the aggregate PRCIStatus can stick at "pending" long after
 		// every required check has gone green (a common cause is a legacy
 		// commit-status used by some review bots that never resolves).
-		// GitHub's own per-PR mergeable_state already encodes the
-		// required-check verdict, so "clean" or "unstable" overrides the
-		// stale aggregate and lets autoMergePRs converge instead of looping.
+		// GitHub's own per-PR mergeable_state encodes the required-check
+		// verdict. Only "clean" may override the stale aggregate. "unstable"
+		// can coexist with explicitly failed check runs (live #397), so treating
+		// it as success can merge known-red work.
 		if ciStatus == "pending" {
 			if mergeable, mergeState, mErr := o.prMergeStatus(pr.Number); mErr == nil && mergeable == "MERGEABLE" {
 				switch mergeState {
-				case "clean", "unstable":
+				case "clean":
 					log.Printf("[orch] PR #%d (%s) aggregate CI=pending but mergeable_state=%s — treating as success (#424)", pr.Number, sess.Branch, mergeState)
 					ciStatus = "success"
 				}
@@ -4653,7 +4670,7 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 				continue
 			}
 			allSlots = append(allSlots, slotName)
-			if repairIssueSessionActive(sess.Status) {
+			if repairIssueSessionActive(sess.Status) || (sess.PRNumber == canonical.Number && sess.Status == state.StatusRetryExhausted) {
 				activeOther = slotName
 			}
 			if (sess.Status == state.StatusDone || sess.Status == state.StatusFailed) &&

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4268,6 +4268,13 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		numberToPR[pr.Number] = pr
 	}
 
+	// A session previously marked done from a disappearing branch can
+	// contradict the authoritative open-PR snapshot (live #949: a closed
+	// duplicate PR hid an older canonical draft). Rebind only when exactly one
+	// open PR references the issue. Multiple candidates are ambiguous and must
+	// remain untouched; choosing one would manufacture a new canonical identity.
+	o.reconcileFalseDoneSessionsWithOpenPRs(s, prs)
+
 	type mergeCandidate struct {
 		slotName string
 		sess     *state.Session
@@ -4305,7 +4312,29 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				o.reconcileClosedPRRetryExhausted(s, slotName, sess)
 				continue
 			}
-			log.Printf("[orch] no open PR found for branch %s (slot %s) — assuming merged/closed", sess.Branch, slotName)
+			merged := false
+			var mergedErr error
+			if sess.PRNumber > 0 {
+				merged, mergedErr = o.isPRMerged(sess.PRNumber)
+			} else {
+				merged, mergedErr = o.hasMergedPRForIssue(sess.IssueNumber)
+			}
+			if mergedErr != nil {
+				log.Printf("[orch] no open PR found for branch %s (slot %s), but merge state is unavailable: %v — preserving session for retry", sess.Branch, slotName, mergedErr)
+				continue
+			}
+			if !merged {
+				closed, closedErr := o.isIssueClosed(sess.IssueNumber)
+				if closedErr != nil {
+					log.Printf("[orch] no open PR found for branch %s (slot %s), but issue state is unavailable: %v — preserving session for retry", sess.Branch, slotName, closedErr)
+					continue
+				}
+				if !closed {
+					o.releaseClosedUnmergedSession(sess, slotName)
+					continue
+				}
+			}
+			log.Printf("[orch] no open PR found for branch %s (slot %s) — authoritative merge/closed outcome confirmed", sess.Branch, slotName)
 			if !o.canMarkDoneForOutcome(s, sess, fmt.Sprintf("PR for branch %s is no longer open", sess.Branch)) {
 				if sess.Status != state.StatusCodeLanded && sess.PRNumber > 0 {
 					o.markCodeLanded(sess, sess.PRNumber)
@@ -4566,6 +4595,80 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	if len(ready) > 1 {
 		log.Printf("[orch] sequential merge mode: deferring %d additional ready PR(s) to next cycle", len(ready)-1)
 	}
+}
+
+func (o *Orchestrator) reconcileFalseDoneSessionsWithOpenPRs(s *state.State, prs []github.PR) {
+	if s == nil || len(prs) == 0 {
+		return
+	}
+	for _, slotName := range sortedStateSessionNames(s) {
+		sess := s.Sessions[slotName]
+		if sess == nil || sess.Status != state.StatusDone || sess.IssueNumber <= 0 {
+			continue
+		}
+		matches := make([]github.PR, 0, 1)
+		for _, pr := range prs {
+			if github.PRReferencesIssue(pr, sess.IssueNumber) {
+				matches = append(matches, pr)
+			}
+		}
+		if len(matches) != 1 {
+			if len(matches) > 1 {
+				log.Printf("[orch] false-done reconcile held for issue #%d / session %s: %d open PRs reference the issue; canonical identity is ambiguous", sess.IssueNumber, slotName, len(matches))
+			}
+			continue
+		}
+		merged := false
+		var err error
+		if sess.PRNumber > 0 {
+			merged, err = o.isPRMerged(sess.PRNumber)
+		} else {
+			merged, err = o.hasMergedPRForIssue(sess.IssueNumber)
+		}
+		if err != nil {
+			log.Printf("[orch] false-done reconcile held for issue #%d / session %s: authoritative merge state unavailable: %v", sess.IssueNumber, slotName, err)
+			continue
+		}
+		if merged {
+			continue
+		}
+		closed, err := o.isIssueClosed(sess.IssueNumber)
+		if err != nil {
+			log.Printf("[orch] false-done reconcile held for issue #%d / session %s: authoritative issue state unavailable: %v", sess.IssueNumber, slotName, err)
+			continue
+		}
+		if closed {
+			continue
+		}
+		canonical := matches[0]
+		oldPR := sess.PRNumber
+		if oldPR > 0 && oldPR != canonical.Number {
+			sess.LastClosedPRNumber = oldPR
+		}
+		sess.PRNumber = canonical.Number
+		sess.Branch = canonical.HeadRefName
+		sess.Status = state.StatusPROpen
+		sess.FinishedAt = nil
+		sess.ReleasedForRedispatch = false
+		log.Printf("[orch] reconciled false done session %s for issue #%d: closed/unavailable PR #%d replaced by sole open canonical PR #%d on branch %s", slotName, sess.IssueNumber, oldPR, canonical.Number, canonical.HeadRefName)
+	}
+}
+
+func (o *Orchestrator) releaseClosedUnmergedSession(sess *state.Session, slotName string) {
+	if sess == nil {
+		return
+	}
+	now := time.Now().UTC()
+	oldPR := sess.PRNumber
+	if oldPR > 0 {
+		sess.LastClosedPRNumber = oldPR
+	}
+	sess.PRNumber = 0
+	sess.Status = state.StatusFailed
+	sess.ReleasedForRedispatch = true
+	sess.FinishedAt = &now
+	state.MarkWorkerEnded(sess, now)
+	log.Printf("[orch] PR #%d for issue #%d / session %s closed without merge while issue remains open — released for truthful redispatch", oldPR, sess.IssueNumber, slotName)
 }
 
 // greptileRetriggerComment is the PR comment that asks Greptile to (re)run
@@ -5330,17 +5433,9 @@ func (o *Orchestrator) reconcileGuardedRepairApprovals(s *state.State) {
 // under an operator.
 func (o *Orchestrator) repairApprovalIssueResolved(s *state.State, issue int) (bool, string) {
 	activeSession := false
-	doneSession := false
-	failedSession := false
 	for _, sess := range s.Sessions {
 		if sess == nil || sess.IssueNumber != issue {
 			continue
-		}
-		if sess.Status == state.StatusDone {
-			doneSession = true
-		}
-		if state.IsTerminal(sess.Status) && sess.Status != state.StatusDone {
-			failedSession = true
 		}
 		if repairIssueSessionActive(sess.Status) {
 			activeSession = true
@@ -5349,9 +5444,6 @@ func (o *Orchestrator) repairApprovalIssueResolved(s *state.State, issue int) (b
 	if activeSession {
 		return false, ""
 	}
-	if doneSession && !failedSession {
-		return true, fmt.Sprintf("issue #%d resolved (session done) — repair worker moot", issue)
-	}
 	closed, err := o.isIssueClosed(issue)
 	if err != nil {
 		log.Printf("[orch] repair-approval reconcile: issue #%d closed-state check failed; leaving approval pending: %v", issue, err)
@@ -5359,6 +5451,14 @@ func (o *Orchestrator) repairApprovalIssueResolved(s *state.State, issue int) (b
 	}
 	if closed {
 		return true, fmt.Sprintf("issue #%d closed — repair worker moot", issue)
+	}
+	merged, err := o.hasMergedPRForIssue(issue)
+	if err != nil {
+		log.Printf("[orch] repair-approval reconcile: issue #%d merged-PR check failed; leaving approval pending: %v", issue, err)
+		return false, ""
+	}
+	if merged {
+		return true, fmt.Sprintf("issue #%d has an authoritative merged PR — repair worker moot", issue)
 	}
 	return false, ""
 }
@@ -7205,11 +7305,21 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 				sess.Worktree = restored
 				log.Printf("[orch] reattached restored worktree %s to reserved repair session %s / PR #%d", restored, slot, sess.PRNumber)
 			} else {
-				log.Printf("[orch] refusing repair dispatch for issue #%d on %s: PR #%d worktree is missing", issue.Number, slot, sess.PRNumber)
-				return false
+				// Cleanup may have removed the worktree directory while retaining
+				// the canonical local branch. Record the deterministic path and let
+				// the preserving recovery helper recreate that exact worktree; it
+				// fails closed if the branch is unavailable or another worktree owns it.
+				sess.Worktree = restored
 			}
 		}
-		err = o.respawnInPlaceWithConfig(o.cfg, slot, sess, issue, promptBase, backend)
+		if o.respawnInPlaceFn != nil {
+			// Synthetic tests provide their own in-place executor and paths.
+			// Production has no hook and always takes the checkpointing,
+			// missing-worktree-restoring path below.
+			err = o.respawnInPlaceWithConfig(o.cfg, slot, sess, issue, promptBase, backend)
+		} else {
+			err = o.respawnPreservingWorktreeWithConfig(o.cfg, slot, sess, issue, promptBase, backend)
+		}
 	} else {
 		err = o.respawnPreservingWorktreeWithConfig(o.cfg, slot, sess, issue, promptBase, backend)
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1332,6 +1332,9 @@ func TestAutoMergePRs_MissingOpenPRDoesNotBecomeDoneWhenOutcomePassRequiredFails
 		},
 	}
 	o, merged := newMergeTestOrchestrator(cfg, nil)
+	o.isPRMergedFn = func(prNumber int) (bool, error) {
+		return prNumber == 10, nil
+	}
 	s := makeTestState([]github.PR{{Number: 10, HeadRefName: "feat/a"}})
 	s.OutcomeHealth = &outcome.HealthCheckResult{
 		CheckedAt: time.Now().UTC(),

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2859,13 +2859,13 @@ func TestAutoMergePRs_CIFailureBlocksMerge(t *testing.T) {
 		t.Errorf("merged PR #%d, want #20", merged[0])
 	}
 
-	// PR #10 should have been closed and session scheduled for retry
-	if len(closedPRs) != 1 || closedPRs[0] != 10 {
-		t.Errorf("closedPRs = %v, want [10]", closedPRs)
+	// PR #10 remains canonical while its same-session repair is scheduled.
+	if len(closedPRs) != 0 {
+		t.Errorf("closedPRs = %v, want none", closedPRs)
 	}
 	for _, sess := range s.Sessions {
-		if sess.PRNumber == 0 && sess.IssueNumber == 100 {
-			// This is the session for PR #10 (PR cleared after CI failure retry)
+		if sess.PRNumber == 10 && sess.IssueNumber == 100 {
+			// This is the session for PR #10 (identity retained for in-place retry).
 			if sess.Status != state.StatusDead {
 				t.Errorf("CI-failed session status = %q, want %q", sess.Status, state.StatusDead)
 			}
@@ -8591,7 +8591,7 @@ func newCIFailureRetryOrchestrator(cfg *config.Config, prs []github.PR, ciStatus
 	}, &merged, &closedPRs
 }
 
-func TestAutoMergePRs_CIFailure_ClosesPRAndSchedulesRetry(t *testing.T) {
+func TestAutoMergePRs_CIFailure_KeepsCanonicalPRAndSchedulesInPlaceRetry(t *testing.T) {
 	prs := []github.PR{
 		{Number: 10, HeadRefName: "feat/a"},
 	}
@@ -8606,9 +8606,9 @@ func TestAutoMergePRs_CIFailure_ClosesPRAndSchedulesRetry(t *testing.T) {
 		t.Fatalf("expected 0 merges, got %d", len(*merged))
 	}
 
-	// Should close the PR
-	if len(*closedPRs) != 1 || (*closedPRs)[0] != 10 {
-		t.Fatalf("closedPRs = %v, want [10]", *closedPRs)
+	// A failed check must not destroy canonical PR identity.
+	if len(*closedPRs) != 0 {
+		t.Fatalf("closedPRs = %v, want none for in-place retry", *closedPRs)
 	}
 
 	// Session should be dead with NextRetryAt scheduled
@@ -8622,17 +8622,14 @@ func TestAutoMergePRs_CIFailure_ClosesPRAndSchedulesRetry(t *testing.T) {
 	if sess.RetryCount != 1 {
 		t.Fatalf("RetryCount = %d, want 1", sess.RetryCount)
 	}
-	if sess.PRNumber != 0 {
-		t.Fatalf("PRNumber = %d, want 0 (cleared after PR close)", sess.PRNumber)
+	if sess.PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want 10 (same PR retained)", sess.PRNumber)
 	}
 	if sess.CIFailureOutput == "" {
 		t.Fatal("CIFailureOutput should be set")
 	}
 	if sess.FinishedAt == nil {
 		t.Fatal("FinishedAt should be set")
-	}
-	if sess.Worktree != "" {
-		t.Fatalf("Worktree = %q, want empty (cleaned up)", sess.Worktree)
 	}
 }
 
@@ -8709,9 +8706,9 @@ func TestAutoMergePRs_CIFailure_UnlimitedRetries(t *testing.T) {
 
 	o.autoMergePRs(s)
 
-	// Should close the PR and schedule retry
-	if len(*closedPRs) != 1 {
-		t.Fatalf("closedPRs = %v, want 1 PR closed (unlimited retries)", *closedPRs)
+	// Should preserve the PR and schedule an in-place retry.
+	if len(*closedPRs) != 0 {
+		t.Fatalf("closedPRs = %v, want none (unlimited in-place retries)", *closedPRs)
 	}
 	sess := s.Sessions["slot-0"]
 	if sess.Status != state.StatusDead {
@@ -8722,7 +8719,7 @@ func TestAutoMergePRs_CIFailure_UnlimitedRetries(t *testing.T) {
 	}
 }
 
-func TestAutoMergePRs_CIFailure_ClosePRFails_NoRetry(t *testing.T) {
+func TestAutoMergePRs_CIFailure_DoesNotDependOnClosePR(t *testing.T) {
 	prs := []github.PR{
 		{Number: 10, HeadRefName: "feat/a"},
 	}
@@ -8762,13 +8759,16 @@ func TestAutoMergePRs_CIFailure_ClosePRFails_NoRetry(t *testing.T) {
 
 	o.autoMergePRs(s)
 
-	// When closePR fails, session should stay in pr_open (no retry scheduled)
+	// closePR is deliberately absent; the in-place retry must still schedule.
 	sess := s.Sessions["slot-0"]
-	if sess.Status != state.StatusPROpen {
-		t.Fatalf("status = %q, want %q (closePR failed, no retry)", sess.Status, state.StatusPROpen)
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want %q (closePR is not part of retry)", sess.Status, state.StatusDead)
 	}
-	if sess.NextRetryAt != nil {
-		t.Fatal("NextRetryAt should be nil when closePR fails")
+	if sess.NextRetryAt == nil {
+		t.Fatal("NextRetryAt should be set without closing the PR")
+	}
+	if sess.PRNumber != 10 {
+		t.Fatalf("PRNumber = %d, want canonical PR 10 retained", sess.PRNumber)
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2764,9 +2764,9 @@ func TestAutoMergePRs_CIPendingAndMergeStateBlocked_DoesNotMerge(t *testing.T) {
 	}
 }
 
-// mergeable_state="unstable" — only non-required checks are failing, so
-// the PR is still safe to merge under the same #424 override.
-func TestAutoMergePRs_CIPendingMergeStateUnstable_Merges(t *testing.T) {
+// mergeable_state="unstable" can coexist with failed check runs. It is not
+// authoritative green evidence and must never override the check rollup.
+func TestAutoMergePRs_CIPendingMergeStateUnstable_DoesNotMerge(t *testing.T) {
 	prs := []github.PR{{Number: 102, HeadRefName: "feat/unstable"}}
 
 	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none"}
@@ -2798,8 +2798,8 @@ func TestAutoMergePRs_CIPendingMergeStateUnstable_Merges(t *testing.T) {
 
 	o.autoMergePRs(s)
 
-	if len(merged) != 1 || merged[0] != 102 {
-		t.Fatalf("merged = %v, want [102] (mergeable_state=unstable should still allow merge)", merged)
+	if len(merged) != 0 {
+		t.Fatalf("merged = %v, want [] (mergeable_state=unstable must not override pending/failed checks)", merged)
 	}
 }
 
@@ -10037,6 +10037,51 @@ func TestAutoMergePRs_NoPRRetryExhaustedAppliesBlockedLabel(t *testing.T) {
 	o.autoMergePRs(s)
 	if len(addedLabels) != 0 {
 		t.Fatalf("second cycle re-applied labels = %v, want none (idempotency)", addedLabels)
+	}
+}
+
+func TestAutoMergePRs_NoPRRetryExhaustedSiblingDoesNotBlockCanonicalOpenPR(t *testing.T) {
+	cfg := &config.Config{
+		Repo:       "owner/repo",
+		ReviewGate: "none",
+		Supervisor: config.SupervisorConfig{BlockedLabel: "blocked"},
+	}
+	addedLabels := make(map[int]string)
+	o := &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return []github.PR{{Number: 397, HeadRefName: "canonical", Title: "Fedora fix for #346"}}, nil
+		},
+		ghPRCIStatusFn: func(int) (string, error) { return "pending", nil },
+		ghPRMergeStatusFn: func(int) (string, string, error) {
+			return "MERGEABLE", "blocked", nil
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			addedLabels[number] = label
+			return nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["canonical-slot"] = &state.Session{
+		IssueNumber: 346,
+		Status:      state.StatusRetryExhausted,
+		PRNumber:    397,
+		Branch:      "canonical",
+	}
+	s.Sessions["preserved-sibling"] = &state.Session{
+		IssueNumber: 346,
+		Status:      state.StatusRetryExhausted,
+		Branch:      "preserved-sibling",
+	}
+
+	o.autoMergePRs(s)
+
+	if len(addedLabels) != 0 {
+		t.Fatalf("terminal sibling applied labels behind canonical PR: %v", addedLabels)
+	}
+	if got := s.Sessions["preserved-sibling"].LastNotifiedStatus; got == noPRReconciledStatus {
+		t.Fatalf("terminal sibling was falsely reconciled as a blocking no-PR outcome")
 	}
 }
 

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -415,12 +415,19 @@ func approvalStatus(t *testing.T, s *state.State, id string) state.ApprovalStatu
 // regression: even when the edge-triggered post-merge stale call was lost (the
 // live #858 incident left the approval pending with only its `created` audit
 // event), the standing reconciler stales the moot spawn_repair_worker approval
-// on the next cycle because the target issue's session is already done. Unrelated
+// on the next cycle because GitHub confirms the target issue is closed. A local
+// done token alone is not authoritative (#949). Unrelated
 // approvals — a repair approval for an actively-worked issue and a spawn_worker
 // approval — are untouched, and the pass is idempotent.
 func TestReconcileResolvedRepairApprovals_DoneSessionSelfHeals(t *testing.T) {
 	now := time.Date(2026, 7, 10, 9, 47, 0, 0, time.UTC)
-	o := &Orchestrator{cfg: &config.Config{Repo: "owner/repo"}, notifier: &notify.Notifier{}}
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo"},
+		notifier: &notify.Notifier{},
+		isIssueClosedFn: func(issue int) (bool, error) {
+			return issue == 858, nil
+		},
+	}
 
 	s := state.NewState()
 	s.Sessions = map[string]*state.Session{
@@ -441,8 +448,8 @@ func TestReconcileResolvedRepairApprovals_DoneSessionSelfHeals(t *testing.T) {
 	}
 	moot, _ := s.FindApproval("ap-repair-858")
 	last := moot.Audit[len(moot.Audit)-1]
-	if last.Event != state.ApprovalAuditStale || !strings.Contains(last.Reason, "session done") {
-		t.Fatalf("stale audit = {%q,%q}, want stale reason mentioning session done", last.Event, last.Reason)
+	if last.Event != state.ApprovalAuditStale || !strings.Contains(last.Reason, "closed") {
+		t.Fatalf("stale audit = {%q,%q}, want stale reason mentioning authoritative issue close", last.Event, last.Reason)
 	}
 	if got := approvalStatus(t, s, "ap-repair-900"); got != state.ApprovalStatusPending {
 		t.Fatalf("repair approval for actively-worked issue = %q, want pending (untouched)", got)
@@ -460,6 +467,33 @@ func TestReconcileResolvedRepairApprovals_DoneSessionSelfHeals(t *testing.T) {
 	moot2, _ := s.FindApproval("ap-repair-858")
 	if len(moot2.Audit) != auditLen {
 		t.Fatalf("re-run appended audit entries (%d -> %d); reconcile must be idempotent", auditLen, len(moot2.Audit))
+	}
+}
+
+// A false local done token must not erase repair authority while GitHub still
+// shows an open issue and no merged linked PR (#949).
+func TestReconcileResolvedRepairApprovals_FalseDoneDoesNotStale(t *testing.T) {
+	now := time.Date(2026, 7, 17, 19, 22, 0, 0, time.UTC)
+	o := &Orchestrator{
+		cfg:                   &config.Config{Repo: "owner/repo"},
+		notifier:              &notify.Notifier{},
+		isIssueClosedFn:       func(int) (bool, error) { return false, nil },
+		hasMergedPRForIssueFn: func(int) (bool, error) { return false, nil },
+	}
+	s := state.NewState()
+	s.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345,
+		Status:      state.StatusDone,
+		PRNumber:    389,
+	}
+	s.Approvals = []state.Approval{
+		repairApproval("repair-345", 345, 388, state.ApprovalStatusAwaitingDispatch, now),
+	}
+
+	o.reconcileResolvedRepairApprovals(s)
+
+	if got := approvalStatus(t, s, "repair-345"); got != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("approval = %q, want awaiting_dispatch while issue remains open and unmerged", got)
 	}
 }
 

--- a/internal/orchestrator/zombie_respawn_test.go
+++ b/internal/orchestrator/zombie_respawn_test.go
@@ -118,12 +118,11 @@ func TestRespawnDueRetries_SessionPRMerged_RetiresInsteadOfRespawning(t *testing
 }
 
 // Regression for the BeFeast/ok-player 2026-07-02 incident (#800): CI fails on
-// the PR, the CI-retry path closes it and schedules a backoff retry; an
-// operator then pushes a fix, reopens the PR, and merges it. When the backoff
-// elapses the orchestrator must NOT respawn — the closed-then-merged PR is
-// tracked via LastClosedPRNumber and invalidates the retry even though the
+// the PR and schedules an in-place backoff retry; an operator then pushes a fix
+// and merges that same open PR. When the backoff elapses the orchestrator must
+// NOT respawn — the retained canonical PR invalidates the retry even though the
 // issue itself is still open (maestro PRs carry no auto-closing keywords).
-func TestRespawnDueRetries_PRClosedByCIRetryThenReopenedAndMerged_NoRespawn(t *testing.T) {
+func TestRespawnDueRetries_PROpenDuringCIRetryThenMerged_NoRespawn(t *testing.T) {
 	respawned := false
 	o := zombieRetryOrchestrator(t, &respawned)
 	o.ghPRChecksOutputFn = func(prNumber int) (string, error) { return "build failed", nil }
@@ -142,21 +141,21 @@ func TestRespawnDueRetries_PRClosedByCIRetryThenReopenedAndMerged_NoRespawn(t *t
 	}
 	s.Sessions["ok-player-1"] = sess
 
-	// Step 1: CI fails — maestro closes PR #135 and schedules a retry.
+	// Step 1: CI fails — maestro retains PR #135 and schedules an in-place retry.
 	o.handleCIFailureRetry(s, "ok-player-1", sess, github.PR{Number: 135, HeadRefName: sess.Branch})
 
 	if sess.Status != state.StatusDead || sess.NextRetryAt == nil {
 		t.Fatalf("after CI-retry: status = %q nextRetryAt = %v, want dead with a scheduled retry", sess.Status, sess.NextRetryAt)
 	}
-	if sess.PRNumber != 0 {
-		t.Fatalf("after CI-retry: PRNumber = %d, want 0 (PR closed)", sess.PRNumber)
+	if sess.PRNumber != 135 {
+		t.Fatalf("after CI-retry: PRNumber = %d, want 135 (canonical PR retained)", sess.PRNumber)
 	}
-	if sess.LastClosedPRNumber != 135 {
-		t.Fatalf("after CI-retry: LastClosedPRNumber = %d, want 135", sess.LastClosedPRNumber)
+	if sess.LastClosedPRNumber == 135 {
+		t.Fatalf("after CI-retry: LastClosedPRNumber = %d, canonical PR must remain open", sess.LastClosedPRNumber)
 	}
 
-	// Step 2: operator pushes a fix, reopens PR #135, and merges it. The
-	// issue stays open (no auto-closing keywords on maestro PRs).
+	// Step 2: operator pushes a fix and merges PR #135 during backoff. The issue
+	// stays open (no auto-closing keywords on maestro PRs).
 	o.isPRMergedFn = func(prNumber int) (bool, error) {
 		return prNumber == 135, nil
 	}
@@ -171,7 +170,7 @@ func TestRespawnDueRetries_PRClosedByCIRetryThenReopenedAndMerged_NoRespawn(t *t
 	o.respawnDueRetries(s, 10)
 
 	if respawned {
-		t.Fatal("worker must NOT respawn after the CI-closed PR was reopened and merged")
+		t.Fatal("worker must NOT respawn after the retained PR merged during CI backoff")
 	}
 	if sess.Status != state.StatusCodeLanded {
 		t.Fatalf("status = %q, want %q", sess.Status, state.StatusCodeLanded)

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4122,6 +4122,13 @@ func fleetSupersedingIssueSession(candidate sessionInfo, all []sessionInfo) (ses
 		switch state.SessionStatus(peer.Status) {
 		case state.StatusPROpen, state.StatusCodeLanded:
 			return peer, true
+		case state.StatusRetryExhausted:
+			// A retry-exhausted canonical session still owns its open PR and
+			// remains the only valid repair identity. A no-PR terminal sibling
+			// must not dominate operator_state or ask the operator to restart it.
+			if peer.PRNumber > 0 {
+				return peer, true
+			}
 		case state.StatusDone:
 			// A terminal peer is authoritative only when it owns the issue's
 			// delivered PR and this attempt was explicitly reconciled as a

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -3996,6 +3996,26 @@ func TestFleetSupersedingIssueSessionUsesCanonicalOpenPR(t *testing.T) {
 	}
 }
 
+func TestFleetSupersedingIssueSessionUsesRetryExhaustedCanonicalOpenPR(t *testing.T) {
+	duplicate := sessionInfo{
+		Slot:           "ok-player-294",
+		IssueNumber:    346,
+		Status:         string(state.StatusRetryExhausted),
+		NeedsAttention: true,
+	}
+	canonical := sessionInfo{
+		Slot:           "ok-player-277",
+		IssueNumber:    346,
+		Status:         string(state.StatusRetryExhausted),
+		PRNumber:       397,
+		NeedsAttention: true,
+	}
+	got, ok := fleetSupersedingIssueSession(duplicate, []sessionInfo{duplicate, canonical})
+	if !ok || got.Slot != canonical.Slot {
+		t.Fatalf("superseding retry-exhausted PR session = %+v, %v; want %s", got, ok, canonical.Slot)
+	}
+}
+
 // TestFleetAPIRetryExhaustedWithOpenPRSelfResolvesCalmly pins the #598
 // regression. A retry_exhausted session whose linked PR is still open and
 // whose last notification is NOT a CI failure is convergence-bound: the

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -55,6 +55,39 @@ func WorktreeDirty(worktree string) (bool, error) {
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
+// EnsureWorktreeBranch verifies that a retained worktree is attached to the
+// branch recorded by its canonical session. It switches only a clean worktree;
+// dirty changes are never stashed, reset, or moved implicitly because doing so
+// would make recovery destructive and could attach work to the wrong PR.
+func EnsureWorktreeBranch(worktree, branch string) error {
+	worktree = strings.TrimSpace(worktree)
+	branch = strings.TrimSpace(branch)
+	if worktree == "" || branch == "" {
+		return fmt.Errorf("ensure worktree branch: worktree and branch are required")
+	}
+	currentOut, err := exec.Command("git", "-C", worktree, "symbolic-ref", "--short", "HEAD").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("inspect retained worktree branch: %w: %s", err, strings.TrimSpace(string(currentOut)))
+	}
+	current := strings.TrimSpace(string(currentOut))
+	if current == branch {
+		return nil
+	}
+	dirty, err := WorktreeDirty(worktree)
+	if err != nil {
+		return err
+	}
+	if dirty {
+		return fmt.Errorf("retained worktree is dirty on branch %q; refusing to switch to canonical branch %q", current, branch)
+	}
+	out, err := exec.Command("git", "-C", worktree, "switch", branch).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("switch retained worktree from %q to canonical branch %q: %w: %s", current, branch, err, strings.TrimSpace(string(out)))
+	}
+	log.Printf("[worker] reattached retained worktree %s from branch %s to canonical branch %s", worktree, current, branch)
+	return nil
+}
+
 // RestoreMissingWorktree recreates a missing deterministic worker worktree at
 // the session's already-existing local branch. It deliberately does not create
 // a branch, reset a ref, or choose a different path: recovery must preserve the

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -66,10 +66,16 @@ func EnsureWorktreeBranch(worktree, branch string) error {
 		return fmt.Errorf("ensure worktree branch: worktree and branch are required")
 	}
 	currentOut, err := exec.Command("git", "-C", worktree, "symbolic-ref", "--short", "HEAD").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("inspect retained worktree branch: %w: %s", err, strings.TrimSpace(string(currentOut)))
-	}
 	current := strings.TrimSpace(string(currentOut))
+	if err != nil {
+		// A valid retained checkout may be detached after an interrupted
+		// rebase/gate repair. Treat that as a branch mismatch, not as proof the
+		// worktree is unusable. Dirty state still fails closed below.
+		if insideOut, insideErr := exec.Command("git", "-C", worktree, "rev-parse", "--is-inside-work-tree").CombinedOutput(); insideErr != nil || strings.TrimSpace(string(insideOut)) != "true" {
+			return fmt.Errorf("inspect retained worktree branch: %w: %s", err, strings.TrimSpace(string(currentOut)))
+		}
+		current = "detached HEAD"
+	}
 	if current == branch {
 		return nil
 	}

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -88,6 +88,34 @@ func EnsureWorktreeBranch(worktree, branch string) error {
 	return nil
 }
 
+// UniqueBranchCommits returns patch-unique, non-merge commits that exist on a
+// preserved sibling branch but not on the canonical branch. Recovery uses the
+// exact immutable SHAs as a handoff to the canonical repair worker instead of
+// silently abandoning completed work or opening a duplicate PR.
+func UniqueBranchCommits(localPath, canonicalBranch, siblingBranch string) ([]string, error) {
+	localPath = strings.TrimSpace(localPath)
+	canonicalBranch = strings.TrimSpace(canonicalBranch)
+	siblingBranch = strings.TrimSpace(siblingBranch)
+	if localPath == "" || canonicalBranch == "" || siblingBranch == "" {
+		return nil, fmt.Errorf("unique branch commits: repository and both branches are required")
+	}
+	if canonicalBranch == siblingBranch {
+		return nil, nil
+	}
+	out, err := exec.Command(
+		"git", "-C", localPath, "log", "--format=%H", "--cherry-pick", "--right-only", "--no-merges",
+		canonicalBranch+"..."+siblingBranch,
+	).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("compare canonical branch %q with preserved sibling %q: %w: %s", canonicalBranch, siblingBranch, err, strings.TrimSpace(string(out)))
+	}
+	commits := strings.Fields(string(out))
+	if len(commits) > 20 {
+		commits = commits[:20]
+	}
+	return commits, nil
+}
+
 // RestoreMissingWorktree recreates a missing deterministic worker worktree at
 // the session's already-existing local branch. It deliberately does not create
 // a branch, reset a ref, or choose a different path: recovery must preserve the

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -113,8 +113,23 @@ func RestoreMissingWorktree(localPath, worktreeBase, slotName, worktree, branch 
 	if filepath.Clean(actual) != filepath.Clean(expected) {
 		return fmt.Errorf("restore missing worktree: recorded path %q is not deterministic slot path %q", actual, expected)
 	}
-	if _, err := os.Stat(actual); err == nil {
-		return nil
+	backup := ""
+	if info, err := os.Stat(actual); err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("restore missing worktree: recorded path %s exists but is not a directory", actual)
+		}
+		if out, gitErr := exec.Command("git", "-C", actual, "rev-parse", "--is-inside-work-tree").CombinedOutput(); gitErr == nil && strings.TrimSpace(string(out)) == "true" {
+			return EnsureWorktreeBranch(actual, branch)
+		}
+		// Cleanup can remove Git's worktree metadata before failing to remove
+		// root-owned build artifacts. Preserve the entire orphaned directory and
+		// restore the deterministic path from the retained branch; directory
+		// existence alone is not proof of a usable worktree.
+		backup = fmt.Sprintf("%s.orphaned-%d", actual, time.Now().UTC().UnixNano())
+		if err := os.Rename(actual, backup); err != nil {
+			return fmt.Errorf("preserve orphaned worktree directory %s: %w", actual, err)
+		}
+		log.Printf("[worker] preserved orphaned worktree directory %s at %s before canonical restore", actual, backup)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("stat recorded worktree %s: %w", actual, err)
 	}
@@ -126,8 +141,18 @@ func RestoreMissingWorktree(localPath, worktreeBase, slotName, worktree, branch 
 	if err := os.MkdirAll(filepath.Dir(actual), 0o755); err != nil {
 		return fmt.Errorf("create worktree parent: %w", err)
 	}
+	// Clear only stale administrative records for paths Git already considers
+	// missing. This never deletes a working tree or branch.
+	if out, err := exec.Command("git", "-C", localPath, "worktree", "prune", "--expire", "now").CombinedOutput(); err != nil {
+		return fmt.Errorf("prune stale worktree metadata before restore: %w: %s", err, strings.TrimSpace(string(out)))
+	}
 	out, err := exec.Command("git", "-C", localPath, "worktree", "add", actual, branch).CombinedOutput()
 	if err != nil {
+		if backup != "" {
+			if _, statErr := os.Stat(actual); errors.Is(statErr, os.ErrNotExist) {
+				_ = os.Rename(backup, actual)
+			}
+		}
 		return fmt.Errorf("restore missing worktree %s on existing branch %s: %w: %s", actual, branch, err, strings.TrimSpace(string(out)))
 	}
 	log.Printf("[worker] restored missing canonical worktree %s on existing branch %s", actual, branch)

--- a/internal/worker/checkpoint_test.go
+++ b/internal/worker/checkpoint_test.go
@@ -140,6 +140,43 @@ func TestRestoreMissingWorktreeRejectsNonCanonicalPath(t *testing.T) {
 	}
 }
 
+func TestRestoreMissingWorktreePreservesOrphanedDirectoryAndRecreatesCheckout(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	base := filepath.Join(root, "worktrees")
+	runBranchGit(t, root, "init", "-b", "main", repo)
+	runBranchGit(t, repo, "config", "user.email", "test@example.com")
+	runBranchGit(t, repo, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repo, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runBranchGit(t, repo, "add", "base.txt")
+	runBranchGit(t, repo, "commit", "-m", "base")
+	runBranchGit(t, repo, "branch", "feat/canonical")
+
+	worktree := filepath.Join(base, "ok-player-277")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, "preserved-artifact.txt"), []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RestoreMissingWorktree(repo, base, "ok-player-277", worktree, "feat/canonical"); err != nil {
+		t.Fatalf("RestoreMissingWorktree: %v", err)
+	}
+	if got := strings.TrimSpace(runBranchGit(t, worktree, "branch", "--show-current")); got != "feat/canonical" {
+		t.Fatalf("restored branch = %q, want feat/canonical", got)
+	}
+	backups, err := filepath.Glob(worktree + ".orphaned-*")
+	if err != nil || len(backups) != 1 {
+		t.Fatalf("orphan backups = %v, %v; want exactly one", backups, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(backups[0], "preserved-artifact.txt")); err != nil || string(got) != "keep me\n" {
+		t.Fatalf("orphaned content was not preserved: %q, %v", got, err)
+	}
+}
+
 func TestBeginSessionAttemptClearsPriorProjectionAndPreservesHistory(t *testing.T) {
 	ended := time.Date(2026, 7, 17, 11, 5, 0, 0, time.UTC)
 	started := ended.Add(time.Hour)

--- a/internal/worker/worktree_branch_test.go
+++ b/internal/worker/worktree_branch_test.go
@@ -42,6 +42,40 @@ func TestEnsureWorktreeBranchPreservesDirtyRetainedCheckout(t *testing.T) {
 	}
 }
 
+func TestEnsureWorktreeBranchReattachesCleanDetachedCheckout(t *testing.T) {
+	repo := newBranchTestRepo(t)
+	runBranchGit(t, repo, "branch", "canonical")
+	runBranchGit(t, repo, "switch", "--detach", "HEAD")
+
+	if err := EnsureWorktreeBranch(repo, "canonical"); err != nil {
+		t.Fatalf("EnsureWorktreeBranch: %v", err)
+	}
+	if got := strings.TrimSpace(runBranchGit(t, repo, "branch", "--show-current")); got != "canonical" {
+		t.Fatalf("current branch = %q, want canonical", got)
+	}
+}
+
+func TestEnsureWorktreeBranchPreservesDirtyDetachedCheckout(t *testing.T) {
+	repo := newBranchTestRepo(t)
+	runBranchGit(t, repo, "branch", "canonical")
+	runBranchGit(t, repo, "switch", "--detach", "HEAD")
+	path := filepath.Join(repo, "work.txt")
+	if err := os.WriteFile(path, []byte("preserve detached work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := EnsureWorktreeBranch(repo, "canonical")
+	if err == nil || !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("error = %v, want dirty-worktree refusal", err)
+	}
+	if got := strings.TrimSpace(runBranchGit(t, repo, "branch", "--show-current")); got != "" {
+		t.Fatalf("current branch = %q, want detached checkout retained", got)
+	}
+	if got, readErr := os.ReadFile(path); readErr != nil || string(got) != "preserve detached work\n" {
+		t.Fatalf("dirty detached change was not preserved: %q, %v", got, readErr)
+	}
+}
+
 func TestUniqueBranchCommitsReturnsOnlySiblingPatch(t *testing.T) {
 	repo := newBranchTestRepo(t)
 	runBranchGit(t, repo, "branch", "canonical")

--- a/internal/worker/worktree_branch_test.go
+++ b/internal/worker/worktree_branch_test.go
@@ -1,0 +1,67 @@
+package worker
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureWorktreeBranchSwitchesCleanRetainedCheckout(t *testing.T) {
+	repo := newBranchTestRepo(t)
+	runBranchGit(t, repo, "branch", "canonical")
+	runBranchGit(t, repo, "switch", "-c", "duplicate")
+
+	if err := EnsureWorktreeBranch(repo, "canonical"); err != nil {
+		t.Fatalf("EnsureWorktreeBranch: %v", err)
+	}
+	if got := strings.TrimSpace(runBranchGit(t, repo, "branch", "--show-current")); got != "canonical" {
+		t.Fatalf("current branch = %q, want canonical", got)
+	}
+}
+
+func TestEnsureWorktreeBranchPreservesDirtyRetainedCheckout(t *testing.T) {
+	repo := newBranchTestRepo(t)
+	runBranchGit(t, repo, "branch", "canonical")
+	runBranchGit(t, repo, "switch", "-c", "duplicate")
+	path := filepath.Join(repo, "work.txt")
+	if err := os.WriteFile(path, []byte("preserve me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := EnsureWorktreeBranch(repo, "canonical")
+	if err == nil || !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("error = %v, want dirty-worktree refusal", err)
+	}
+	if got := strings.TrimSpace(runBranchGit(t, repo, "branch", "--show-current")); got != "duplicate" {
+		t.Fatalf("current branch = %q, want duplicate retained", got)
+	}
+	if got, readErr := os.ReadFile(path); readErr != nil || string(got) != "preserve me\n" {
+		t.Fatalf("dirty change was not preserved: %q, %v", got, readErr)
+	}
+}
+
+func newBranchTestRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runBranchGit(t, repo, "init", "-b", "main")
+	runBranchGit(t, repo, "config", "user.email", "test@example.com")
+	runBranchGit(t, repo, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runBranchGit(t, repo, "add", "README.md")
+	runBranchGit(t, repo, "commit", "-m", "seed")
+	return repo
+}
+
+func runBranchGit(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	cmdArgs := append([]string{"-C", repo}, args...)
+	out, err := exec.Command("git", cmdArgs...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}

--- a/internal/worker/worktree_branch_test.go
+++ b/internal/worker/worktree_branch_test.go
@@ -42,6 +42,26 @@ func TestEnsureWorktreeBranchPreservesDirtyRetainedCheckout(t *testing.T) {
 	}
 }
 
+func TestUniqueBranchCommitsReturnsOnlySiblingPatch(t *testing.T) {
+	repo := newBranchTestRepo(t)
+	runBranchGit(t, repo, "branch", "canonical")
+	runBranchGit(t, repo, "switch", "-c", "duplicate")
+	if err := os.WriteFile(filepath.Join(repo, "repair.txt"), []byte("preserved repair\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runBranchGit(t, repo, "add", "repair.txt")
+	runBranchGit(t, repo, "commit", "-m", "preserved repair")
+	want := strings.TrimSpace(runBranchGit(t, repo, "rev-parse", "HEAD"))
+
+	got, err := UniqueBranchCommits(repo, "canonical", "duplicate")
+	if err != nil {
+		t.Fatalf("UniqueBranchCommits: %v", err)
+	}
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("unique commits = %v, want [%s]", got, want)
+	}
+}
+
 func newBranchTestRepo(t *testing.T) string {
 	t.Helper()
 	repo := t.TempDir()


### PR DESCRIPTION
## Summary

- stop treating a missing open PR as proof that it merged
- reconcile a false local `done` session to the sole authoritative open canonical PR for its issue
- keep repair approvals active until GitHub confirms issue close or a linked merge
- restore the deterministic same-slot worktree from the retained canonical branch before in-place repair

## Live incident

During the OK Player unattended soak, issue #345 remained open/ready with canonical draft PR #388, while closed-unmerged duplicate PR #389 left session `ok-player-273` falsely `done`. Maestro then staled the PR #388 repair approval and reported zero running workers with available capacity.

## Safety

- no OK Player code changes
- no new slot/branch/PR identity for repair
- ambiguous multiple-open-PR cases fail closed
- GitHub merge/issue reads fail closed

## Tests

- `umask 077 && TMPDIR=/home/god/.cache/maestro-test-tmp go test -p 1 ./...`
- `go build ./cmd/maestro/`

Refs #949

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes Maestro reconciliation so closed-unmerged and false-terminal sessions defer to GitHub’s authoritative PR and issue state. The main changes are:

- Rebinds false local `done` sessions to the sole open canonical PR for the issue.
- Keeps CI repair retries on the same slot, worktree, branch, and PR instead of closing the PR.
- Preserves sibling branch work as recovery handoff context for the canonical repair worker.
- Restores deterministic missing worktrees from retained local branches.
- Updates fleet operator state to prefer retry-exhausted sessions that still own a PR.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are focused on reconciliation and recovery paths, with targeted tests for the incident scenarios reviewed.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The run-go-validation.sh script was generated and used to orchestrate the Go reconciliation validation commands.
- The test phase ran and produced a log that captured the command, working directory, TMPDIR, umask, package results, elapsed time, and exit status 0.
- The build phase ran and produced a log that captured the command, working directory, TMPDIR, umask, elapsed time, and exit status 0.

<a href="https://app.greptile.com/trex/runs/14910180/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Changes reconciliation to treat GitHub merge/issue state as authoritative, retain canonical PR identity for CI repair, restore deterministic worktrees, and preserve sibling branch handoffs. |
| internal/worker/checkpoint.go | Adds clean worktree branch reattachment, missing deterministic worktree restoration, and sibling unique-commit inspection helpers. |
| internal/server/fleet.go | Treats retry-exhausted sessions with a PR as canonical superseding sessions for fleet operator-state display. |
| internal/orchestrator/closed_unmerged_reconcile_test.go | Adds tests for false-done closed-unmerged sessions, canonical PR adoption, sibling handoff, and closed-unmerged release behavior. |
| internal/orchestrator/orchestrator_test.go | Updates auto-merge and CI-failure tests for in-place repair, closed-unmerged redispatch, and stricter `mergeable_state` handling. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Worker worktree restoration test fails on retained orphaned checkout**

   - **Bug**
     - The full serialized Go test suite fails in the changed worker checkpoint/worktree area. `TestRestoreMissingWorktreePreservesOrphanedDirectoryAndRecreatesCheckout` reports: `RestoreMissingWorktree: inspect retained worktree branch: exit status 128: fatal: ref HEAD is not a symbolic ref`. This prevents the adjusted PR validation suite from passing.
   - **Cause**
     - The changed worktree restoration/checkpoint path appears to inspect the retained orphaned worktree with `git symbolic-ref HEAD`, but in this exercised scenario HEAD is detached or otherwise not a symbolic ref, causing restoration validation to fail.
   - **Fix**
     - Update the restore/inspection logic or the test setup so orphaned retained directories are handled without requiring HEAD to be a symbolic ref, then rerun `umask 077 && TMPDIR=<0700-dir> go test -p 1 ./...` and the maestro build.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix: recover clean detached worker check..."](https://github.com/befeast/maestro/commit/c1485ae154e293d3bbd5a244c7044f084bf15677) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45222025)</sub>

<!-- /greptile_comment -->