### PR TITLE
fix: pin system service runtime identity

### DIFF
--- a/internal/selfdeploy/restart_topology_test.go
+++ b/internal/selfdeploy/restart_topology_test.go
@@ -53,6 +53,27 @@ func TestMaestroServiceKillOwnershipExplicit(t *testing.T) {
 	}
 }
 
+// #953: maestro.service is a system-scoped unit. Without an explicit User and
+// home/store path, systemd expands %h for root and self-deploy boots an empty
+// fleet from /root/.maestro instead of the operator's live config store.
+func TestMaestroServiceUsesDeterministicRuntimeIdentity(t *testing.T) {
+	unit := repoFile(t, "maestro.service")
+	for _, want := range []string{
+		"User=god",
+		"WorkingDirectory=/home/god",
+		"Environment=PATH=/home/god/.local/bin:/home/god/.bun/bin:/home/god/.npm-global/bin:/usr/local/bin:/usr/bin:/bin",
+		"--store /home/god/.maestro/maestro.db",
+		"WantedBy=multi-user.target",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("maestro.service missing deterministic system-runtime directive %q", want)
+		}
+	}
+	if strings.Contains(unit, "%h/.maestro") {
+		t.Error("system-scoped maestro.service must not derive the fleet store from manager HOME")
+	}
+}
+
 // #877: a fix that requires a unit change (KillMode) lives in the unit file, not
 // the binary, so the self-deploy script must ship the unit alongside the binary
 // — install it over the live FragmentPath, daemon-reload, and roll it back on

--- a/maestro.service
+++ b/maestro.service
@@ -8,9 +8,11 @@ Description=Maestro agent orchestrator (single-service daemon, all projects)
 After=network.target
 
 [Service]
+User=god
+WorkingDirectory=/home/god
 Type=simple
-Environment=PATH=%h/.local/bin:%h/.bun/bin:%h/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
-# One unified SQLite database (%h/.maestro/maestro.db) holds config + approvals +
+Environment=PATH=/home/god/.local/bin:/home/god/.bun/bin:/home/god/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
+# One unified SQLite database (/home/god/.maestro/maestro.db) holds config + approvals +
 # state; --approvals-db / --state-db default to that same file. --watch-store lets
 # the daemon hot add/remove/reload projects from the store (and powers dashboard
 # project CRUD: POST/DELETE /api/v1/fleet/projects) without a restart.
@@ -22,7 +24,7 @@ Environment=PATH=%h/.local/bin:%h/.bun/bin:%h/.npm-global/bin:/usr/local/bin:/us
 # is the write-path safety boundary.
 ExecStart=/usr/local/bin/maestro daemon \
     --host 0.0.0.0 \
-    --store %h/.maestro/maestro.db \
+    --store /home/god/.maestro/maestro.db \
     --port 8786 \
     --watch-store \
     --approvals-store sqlite \
@@ -62,4 +64,4 @@ Restart=on-failure
 RestartSec=30
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- run the system-scoped fleet unit explicitly as `god` from `/home/god`
- use deterministic PATH and `/home/god/.maestro/maestro.db` instead of system-manager `%h`
- restore the correct multi-user install target
- add a unit topology regression test for runtime identity and store path

## Live incident

Self-deploy after PR #951 installed the repository unit from the prior restart-topology change. Because it omitted `User=god`, systemd ran it as root and expanded `%h` to `/root`; the daemon entered a restart loop against `/root/.maestro/maestro.db`. The live unit was repaired and the existing OK Player worker `ok-player-296` remained alive on the same PID/worktree.

## Validation

- `go test ./internal/selfdeploy`
- `go build ./cmd/maestro/`
- live `systemctl show maestro.service -p User -p MainPID` reports `User=god` and an active PID

Implements #953

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins the system service runtime identity and store path. The main changes are:

- Run `maestro.service` as `god` from `/home/god`.
- Replace `%h`-based PATH and SQLite store expansion with explicit `/home/god` paths.
- Restore installation under `multi-user.target`.
- Add a regression test for the service user, working directory, PATH, store path, and install target.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to the systemd unit and matching regression coverage. The updated directives match the incident fix described in the PR. No conflicting unit behavior was found in the reviewed changes.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the self-deploy validation harness, executing the focused test, package test, and build, and captured outputs and exit codes in the transcript.
- The transcript shows the Go build passed, while systemd-related checks could not complete in the sandbox because maestro is not installed and the init system bus is unavailable.
- I reviewed the wrapper script that records the exact validation harness used for the run.

<a href="https://app.greptile.com/trex/runs/14914561/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/selfdeploy/restart_topology_test.go | Adds a regression test ensuring the system unit pins the runtime user, working directory, PATH, store path, and install target. |
| maestro.service | Pins the system service to run as `god` from `/home/god`, uses deterministic paths, and installs under `multi-user.target`. |

<sub>Reviews (1): Last reviewed commit: ["fix: pin system service runtime identity"](https://github.com/befeast/maestro/commit/dc32ab163501d50528d5d53a8856b88c42895882) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45239542)</sub>

<!-- /greptile_comment -->
