### PR TITLE
fix: require fresh green PR gate evidence

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4066,7 +4066,7 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 		if worker.NeedsAttention {
 			item.NeedsAttention++
 			item.Attention = append(item.Attention, worker)
-			if fleetSessionIsConvergenceBound(worker) {
+			if fleetSessionIsConvergenceBound(worker, item.Supervisor.Latest) {
 				item.SelfResolving++
 			}
 		}
@@ -4434,7 +4434,7 @@ func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorStat
 		// attention is self-resolving the project reads calm ("auto-merging,
 		// no action needed") instead of alarming the fleet verdict with a
 		// passive `Action required — p1`.
-		actionable, autoMerging := partitionFleetAttentionByResolvability(project.Attention)
+		actionable, autoMerging := partitionFleetAttentionByResolvability(project.Attention, project.Supervisor.Latest)
 		if len(actionable) == 0 && len(autoMerging) > 0 {
 			return fleetAutoMergingOperatorState(project, autoMerging[0])
 		}
@@ -4597,9 +4597,9 @@ func buildFleetProjectOperatorState(project fleetProjectState) fleetOperatorStat
 // will auto-merge it as soon as the merge gate clears, so the fleet verdict
 // must not alarm with `Action required — p1`. Other shapes are returned in
 // the actionable slice; the order of both slices mirrors the input.
-func partitionFleetAttentionByResolvability(workers []sessionInfo) (actionable, autoMerging []sessionInfo) {
+func partitionFleetAttentionByResolvability(workers []sessionInfo, latest *supervisorDecisionInfo) (actionable, autoMerging []sessionInfo) {
 	for _, w := range workers {
-		if fleetSessionIsConvergenceBound(w) {
+		if fleetSessionIsConvergenceBound(w, latest) {
 			autoMerging = append(autoMerging, w)
 			continue
 		}
@@ -4611,12 +4611,13 @@ func partitionFleetAttentionByResolvability(workers []sessionInfo) (actionable, 
 // fleetSessionIsConvergenceBound reports whether a session in the
 // attention list is "self-resolving" — convergence (the orchestrator's
 // auto-merge once gates clear) will resolve it without operator action.
-// Today this is the retry_exhausted-with-open-PR-and-no-failing-checks
-// shape from issue #598: a green PR whose retry budget has been used up
-// but whose merge will land naturally once the merge gate clears. A PR
-// known to have failed checks (CIFailureOutput / LastNotifiedStatus =
-// ci_failure) is NOT convergence-bound and stays actionable.
-func fleetSessionIsConvergenceBound(worker sessionInfo) bool {
+// Today this is the retry_exhausted-with-open-PR shape from issue #598, but
+// only when the latest supervisor reconciliation contains positive GitHub
+// evidence that the PR checks succeeded. Absence of failure evidence is not
+// proof of green: session notification fields can lag a freshly failed check
+// run, which previously produced the false "checks are green" state from
+// issue #955. Any current gate blocker for the same PR wins over success.
+func fleetSessionIsConvergenceBound(worker sessionInfo, latest *supervisorDecisionInfo) bool {
 	if state.SessionStatus(worker.Status) != state.StatusRetryExhausted {
 		return false
 	}
@@ -4626,7 +4627,28 @@ func fleetSessionIsConvergenceBound(worker sessionInfo) bool {
 	if strings.EqualFold(strings.TrimSpace(worker.LastNotification), "ci_failure") {
 		return false
 	}
-	return true
+	if latest == nil {
+		return false
+	}
+	checksSucceeded := false
+	for _, stuck := range latest.StuckStates {
+		if stuck.Target == nil || stuck.Target.PR != worker.PRNumber {
+			continue
+		}
+		switch strings.TrimSpace(stuck.Code) {
+		case "failing_checks", state.StuckPendingChecks, "draft_pr", "unmergeable_pr",
+			"greptile_not_approved", "greptile_pending", "review_gate_not_approved",
+			"review_gate_pending", state.StuckReviewRepairExhausted:
+			return false
+		case "retry_exhausted_open_pr":
+			for _, evidence := range stuck.Evidence {
+				if strings.Contains(strings.ToLower(evidence), "checks=success") {
+					checksSucceeded = true
+				}
+			}
+		}
+	}
+	return checksSucceeded
 }
 
 // fleetAutoMergingOperatorState builds the calm operator state for a

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -176,14 +176,15 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	if len(resp.Attention) != resp.Summary.NeedsAttention {
 		t.Fatalf("attention inbox len = %d, want %d", len(resp.Attention), resp.Summary.NeedsAttention)
 	}
-	if resp.Projects[0].Name != "One" {
-		t.Fatalf("first project = %q, want One", resp.Projects[0].Name)
+	// Fleet projects are deliberately sorted by current operator priority, so
+	// an attention project may precede the first configured project. Assert the
+	// named project's aggregate instead of depending on live priority order.
+	one := findFleetProject(t, resp.Projects, "One")
+	if len(one.Active) != 2 {
+		t.Fatalf("project active len = %d, want 2", len(one.Active))
 	}
-	if len(resp.Projects[0].Active) != 2 {
-		t.Fatalf("project active len = %d, want 2", len(resp.Projects[0].Active))
-	}
-	if !resp.Projects[0].Outcome.Configured || resp.Projects[0].Outcome.Goal != "One is deployed" || resp.Projects[0].Outcome.HealthState != outcome.HealthUnknown {
-		t.Fatalf("project outcome = %+v, want configured unknown health", resp.Projects[0].Outcome)
+	if !one.Outcome.Configured || one.Outcome.Goal != "One is deployed" || one.Outcome.HealthState != outcome.HealthUnknown {
+		t.Fatalf("project outcome = %+v, want configured unknown health", one.Outcome)
 	}
 	if len(resp.Workers) != 4 {
 		t.Fatalf("fleet workers len = %d, want 4", len(resp.Workers))
@@ -210,10 +211,10 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	for _, action := range worker.Actions {
 		assertFleetReadOnlyAction(t, action)
 	}
-	if len(resp.Projects[0].Actions) != 3 {
-		t.Fatalf("project actions = %d, want 3", len(resp.Projects[0].Actions))
+	if len(one.Actions) != 3 {
+		t.Fatalf("project actions = %d, want 3", len(one.Actions))
 	}
-	for _, action := range resp.Projects[0].Actions {
+	for _, action := range one.Actions {
 		assertFleetReadOnlyAction(t, action)
 		if action.Target != "One" {
 			t.Fatalf("project action target = %q, want project name One", action.Target)
@@ -229,8 +230,9 @@ func TestFleetAPIAggregatesProjects(t *testing.T) {
 	if !contains(attentionWorker.NextAction, "Fix failing checks") {
 		t.Fatalf("attention next_action = %q, want fix checks guidance", attentionWorker.NextAction)
 	}
-	if resp.Projects[1].NeedsAttention != len(resp.Projects[1].Attention) {
-		t.Fatalf("project attention count = %d, reasons = %d", resp.Projects[1].NeedsAttention, len(resp.Projects[1].Attention))
+	two := findFleetProject(t, resp.Projects, "Two")
+	if two.NeedsAttention != len(two.Attention) {
+		t.Fatalf("project attention count = %d, reasons = %d", two.NeedsAttention, len(two.Attention))
 	}
 }
 

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -4048,6 +4048,13 @@ func TestFleetAPIRetryExhaustedWithOpenPRSelfResolvesCalmly(t *testing.T) {
 			Project:           "maestro",
 			RecommendedAction: "monitor_open_pr",
 			Risk:              "safe",
+			StuckStates: []state.SupervisorStuckState{
+				{
+					Code:     "retry_exhausted_open_pr",
+					Target:   &state.SupervisorTarget{Issue: 442, PR: 564},
+					Evidence: []string{"Session sup-stuck status=retry_exhausted pr=564 checks=success"},
+				},
+			},
 		},
 	})
 
@@ -4124,8 +4131,7 @@ func TestFleetAPIRetryExhaustedWithFailedChecksRemainsActionable(t *testing.T) {
 			PRNumber:           600,
 			StartedAt:          finishedRecent.Add(-time.Hour),
 			FinishedAt:         &finishedRecent,
-			LastNotifiedStatus: "ci_failure",
-			CIFailureOutput:    "FAIL: pkg/foo TestBar",
+			LastNotifiedStatus: "review_retry_exhausted",
 		},
 	}, []state.SupervisorDecision{
 		{
@@ -4134,6 +4140,17 @@ func TestFleetAPIRetryExhaustedWithFailedChecksRemainsActionable(t *testing.T) {
 			Project:           "maestro",
 			RecommendedAction: "monitor_open_pr",
 			Risk:              "safe",
+			StuckStates: []state.SupervisorStuckState{
+				{
+					Code:     "retry_exhausted_open_pr",
+					Target:   &state.SupervisorTarget{Issue: 443, PR: 600},
+					Evidence: []string{"Session sup-failing status=retry_exhausted pr=600 checks=failure"},
+				},
+				{
+					Code:   "failing_checks",
+					Target: &state.SupervisorTarget{Issue: 443, PR: 600},
+				},
+			},
 		},
 	})
 


### PR DESCRIPTION
## Summary

- require fresh positive GitHub check evidence before classifying a retry-exhausted PR as auto-merging
- make any current CI, mergeability, draft, Greptile, or review-gate blocker override stale success
- add an exact regression where the session notification is stale but the latest supervisor reconciliation says checks failed

## Live incident

OK Player PR #397 had four failed Fedora jobs. Its canonical session still carried an older non-CI notification, so Fleet Mission Control claimed “checks are green” until a later supervisor refresh. Absence of a cached failure was incorrectly treated as proof of success.

## Validation

- `go test ./internal/server -run 'TestFleetAPIRetryExhaustedWith(OpenPRSelfResolvesCalmly|FailedChecksRemainsActionable)' -count=1`
- `go build ./cmd/maestro/`
- full `go test ./internal/server` reached unrelated pre-existing order-sensitive failure `TestFleetAPIAggregatesProjects`

Implements #955

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens how Fleet classifies retry-exhausted PRs as self-resolving. The main changes are:

- Requires fresh supervisor evidence with `checks=success` before showing a retry-exhausted PR as auto-merging.
- Keeps PRs actionable when current supervisor stuck states show failing checks, pending gates, draft status, mergeability, Greptile, or review-gate blockers.
- Updates Fleet tests for the green path, the failed-check regression, and project lookup independent of priority ordering.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow, backed by targeted tests, and preserves actionable status unless current supervisor evidence proves checks are successful with no blockers.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The targeted regression test command was executed and completed with exit code 0, with its details captured in the targeted regression log.
- The Maestro build command was executed and completed with exit code 0, with its details captured in the Maestro build log.
- Both logs were reviewed and linked as artifacts to confirm accessibility via their uploaded URLs.

<a href="https://app.greptile.com/trex/runs/14916177/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Updates convergence-bound classification to require fresh supervisor evidence for successful checks and to keep current PR gate blockers actionable. |
| internal/server/fleet_test.go | Updates order-sensitive Fleet assertions and adds tests for green versus failed-check retry-exhausted PR handling. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-779-95..."](https://github.com/befeast/maestro/commit/53cabe53243377644e74085e8941563282412aba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45241740)</sub>

<!-- /greptile_comment -->