### PR TITLE
fix: validate retained worktrees before recovery

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -84,9 +84,12 @@ type Orchestrator struct {
 	workerRespawnFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 	respawnWorkerFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 	getIssueFn      func(number int) (github.Issue, error)
-	// saveCheckpointFn / respawnInPlaceFn: used for soft token threshold checkpoint+respawn
-	saveCheckpointFn func(sess *state.Session) (string, error)
-	respawnInPlaceFn func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
+	// saveCheckpointFn / restoreWorktreeFn / respawnInPlaceFn: used for soft
+	// token threshold checkpoint+respawn. restoreWorktreeFn lets tests exercise
+	// the production validation path without starting a real model process.
+	saveCheckpointFn  func(sess *state.Session) (string, error)
+	restoreWorktreeFn func(localPath, worktreeBase, slotName, worktree, branch string) error
+	respawnInPlaceFn  func(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error
 
 	// Testing hooks for pipeline phase transitions
 	workerStartPhaseFn func(cfg *config.Config, sess *state.Session, slotName, prompt, backendName string) error
@@ -789,11 +792,19 @@ func (o *Orchestrator) respawnPreservingWorktreeWithConfig(cfg *config.Config, s
 	if sess == nil || strings.TrimSpace(sess.Worktree) == "" {
 		return o.respawnWorkerWithConfig(cfg, slotName, sess, issue, promptBase, backendName)
 	}
-	if _, statErr := os.Stat(sess.Worktree); errors.Is(statErr, os.ErrNotExist) && o.respawnInPlaceFn == nil {
-		if err := worker.RestoreMissingWorktree(cfg.LocalPath, cfg.WorktreeBase, slotName, sess.Worktree, sess.Branch); err != nil {
+	restoreWorktree := o.restoreWorktreeFn
+	if restoreWorktree == nil && o.respawnInPlaceFn == nil {
+		restoreWorktree = worker.RestoreMissingWorktree
+	}
+	if restoreWorktree != nil {
+		// Directory existence is insufficient: a retained directory can contain
+		// a stale .git pointer after administrative metadata was removed. The
+		// restore helper validates Git usability, preserves an invalid directory,
+		// and recreates only the exact canonical slot/path/branch (#957).
+		if err := restoreWorktree(cfg.LocalPath, cfg.WorktreeBase, slotName, sess.Worktree, sess.Branch); err != nil {
 			return err
 		}
-		log.Printf("[orch] worker %s: recovered missing canonical worktree from existing branch %s", slotName, sess.Branch)
+		log.Printf("[orch] worker %s: verified canonical worktree on existing branch %s", slotName, sess.Branch)
 	}
 	// Unit tests inject an in-place respawner with synthetic paths. Production
 	// never has that hook and therefore still fails closed if a retained

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -49,6 +50,76 @@ func TestHashOutput_UsesLast50LinesOnly(t *testing.T) {
 	want := hashOutput(last50)
 	if got != want {
 		t.Fatalf("hashOutput() should only depend on last 50 lines; got %q want %q", got, want)
+	}
+}
+
+func TestRespawnPreservingWorktreeRepairsExistingDirectoryWithInvalidGitMetadata(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	base := filepath.Join(root, "worktrees")
+	worktree := filepath.Join(base, "ok-player-277")
+	branch := "feat/ok-player-277-346"
+	for _, args := range [][]string{
+		{"init", "-b", "main", repo},
+		{"-C", repo, "config", "user.email", "test@example.com"},
+		{"-C", repo, "config", "user.name", "Test"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repo, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", repo, "add", "base.txt"},
+		{"-C", repo, "commit", "-m", "base"},
+		{"-C", repo, "branch", branch},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, ".git"), []byte("gitdir: /missing/admin/metadata\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, "preserved.txt"), []byte("do not lose\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{LocalPath: repo, WorktreeBase: base}
+	sess := &state.Session{IssueNumber: 346, Worktree: worktree, Branch: branch}
+	respawned := false
+	o := &Orchestrator{
+		cfg:               cfg,
+		restoreWorktreeFn: worker.RestoreMissingWorktree,
+		respawnInPlaceFn: func(_ *config.Config, slotName string, _ *state.Session, _ string, _ github.Issue, _, _ string) error {
+			respawned = true
+			if slotName != "ok-player-277" {
+				t.Fatalf("slot = %q, want canonical ok-player-277", slotName)
+			}
+			out, err := exec.Command("git", "-C", worktree, "rev-parse", "--is-inside-work-tree").CombinedOutput()
+			if err != nil || strings.TrimSpace(string(out)) != "true" {
+				t.Fatalf("restored worktree unusable: %v: %s", err, out)
+			}
+			return nil
+		},
+	}
+	if err := o.respawnPreservingWorktreeWithConfig(cfg, "ok-player-277", sess, github.Issue{Number: 346}, "prompt", "sol"); err != nil {
+		t.Fatalf("respawn preserving worktree: %v", err)
+	}
+	if !respawned {
+		t.Fatal("canonical in-place respawn was not invoked")
+	}
+	backups, err := filepath.Glob(worktree + ".orphaned-*")
+	if err != nil || len(backups) != 1 {
+		t.Fatalf("orphan backups = %v, %v; want one", backups, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(backups[0], "preserved.txt")); err != nil || string(got) != "do not lose\n" {
+		t.Fatalf("preserved orphan content = %q, %v", got, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate Git worktree usability before every production in-place recovery
- preserve an existing but invalid directory as an orphan backup and recreate only the canonical slot/path/branch
- add an orchestration-path regression proving preserved contents and same-slot resume

## Live incident

OK Player `ok-player-277` existed on disk, but its `.git` pointer referenced removed administrative metadata. The old recovery path checked only directory existence, then failed in `WorktreeDirty`. The live directory was preserved losslessly, and the same branch/worktree/PR lane was resumed.

## Validation

- `go test ./internal/orchestrator -run TestRespawnPreservingWorktreeRepairsExistingDirectoryWithInvalidGitMetadata -count=1`
- `go test ./internal/orchestrator -count=1`
- `go build ./cmd/maestro/`

Implements #957

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the in-place recovery path for retained worker worktrees. The main changes are:

- Validate retained worktrees with `worker.RestoreMissingWorktree` before checking dirty state.
- Preserve invalid retained directories as orphan backups before recreating the canonical slot path.
- Add a regression test for stale `.git` metadata, preserved contents, and same-slot resume.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The recovery path uses the existing restore helper before inspecting retained worktrees, and test hooks remain isolated from production behavior. The added test covers the reported stale metadata scenario with a real git repository. No blocking issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Retained the initial wrapper targeted attempt artifact; its Go test output was ok, but the wrapper failed due to shell syntax.
- Reran a targeted regression for the orchestrator and confirmed the targeted tests passed with EXIT\_CODE: 0 for internal/orchestrator.
- Reran the full orchestrator package test suite and confirmed it passed with EXIT\_CODE: 0.
- Built the Maestro command package and confirmed the build succeeded with EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14917091/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds a restore-worktree hook and routes production preserving respawns through worktree validation/restoration before dirty checks and in-place respawn. |
| internal/orchestrator/orchestrator_test.go | Adds a regression test that creates an invalid retained worktree, verifies orphan preservation, and confirms recovery resumes in the canonical slot. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/957-restore..."](https://github.com/befeast/maestro/commit/ca539a466f215406d9f30a8ebe649148fe2c6ca3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45242295)</sub>

<!-- /greptile_comment -->