### PR TITLE
fix: revalidate repair dispatch against live PR gates

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7634,6 +7634,9 @@ func (o *Orchestrator) revalidateSpawnRepairPR(target *state.SupervisorTarget) s
 	if observedHead := strings.TrimSpace(rollup.HeadSHA); observedHead != "" && !strings.EqualFold(observedHead, currentHead) {
 		return spawnRepairGateDecision{reason: "PR head changed while current checks were being read"}
 	}
+	if !rollup.Complete {
+		return spawnRepairGateDecision{reason: "current PR check rollup is incomplete; repair authority remains retryable"}
+	}
 	ci := strings.ToLower(strings.TrimSpace(rollup.Verdict))
 	actionableReason := ""
 	if ci == "failure" {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7384,6 +7384,12 @@ type spawnRepairDispatch struct {
 	approvalID string
 }
 
+type spawnRepairGateDecision struct {
+	actionable bool
+	stale      bool
+	reason     string
+}
+
 func (o *Orchestrator) resolveSpawnRepairDispatch(s *state.State, issueNumber int) *spawnRepairDispatch {
 	if s == nil || issueNumber <= 0 {
 		return nil
@@ -7503,6 +7509,17 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 		o.resolveSpawnRepairApproval(s, dispatch.approvalID, slot, target.PR, "reserved session already running")
 		return false
 	}
+	if target.PR > 0 {
+		gate := o.revalidateSpawnRepairPR(target)
+		if !gate.actionable {
+			log.Printf("[orch] refusing repair dispatch for issue #%d / PR #%d on %s: %s", issue.Number, target.PR, slot, gate.reason)
+			if gate.stale {
+				o.staleInvalidSpawnRepairApproval(s, dispatch, gate.reason)
+			}
+			return false
+		}
+		log.Printf("[orch] current PR gate authorizes in-place repair for issue #%d / PR #%d on %s: %s", issue.Number, target.PR, slot, gate.reason)
+	}
 
 	backend := strings.TrimSpace(sess.Backend)
 	if backend == "" {
@@ -7583,6 +7600,82 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 	}
 	o.notifier.Sendf("🔄 maestro: repairing issue #%d in place on worker %s: %s", issue.Number, slot, issue.Title)
 	return true
+}
+
+// revalidateSpawnRepairPR prevents a delayed approval or supervisor decision
+// from replaying a repair against a PR state that no longer exists. The live
+// GitHub head and gates, not the state captured when the decision was minted,
+// authorize worker spend. A current CI failure, merge conflict, or blocking
+// review finding is actionable; pending/green gates make an old repair intent
+// stale. Read errors and unknown states fail closed without consuming the
+// approval so a later healthy control-loop read can retry safely.
+func (o *Orchestrator) revalidateSpawnRepairPR(target *state.SupervisorTarget) spawnRepairGateDecision {
+	if target == nil || target.PR <= 0 {
+		return spawnRepairGateDecision{actionable: true, reason: "repair has no PR gate to revalidate"}
+	}
+	pr := target.PR
+	currentHead, err := o.prHeadSHA(pr)
+	if err != nil || strings.TrimSpace(currentHead) == "" {
+		return spawnRepairGateDecision{reason: fmt.Sprintf("current PR head is unavailable: %v", err)}
+	}
+	currentHead = strings.TrimSpace(currentHead)
+	boundHead := strings.TrimSpace(target.HeadSHA)
+	if boundHead != "" && !strings.EqualFold(boundHead, currentHead) {
+		return spawnRepairGateDecision{
+			stale:  true,
+			reason: fmt.Sprintf("repair intent was bound to head %s, but current head is %s", shortHeadSHA(boundHead), shortHeadSHA(currentHead)),
+		}
+	}
+
+	rollup, err := o.prCheckRollup(pr)
+	if err != nil {
+		return spawnRepairGateDecision{reason: fmt.Sprintf("current PR checks are unavailable: %v", err)}
+	}
+	if observedHead := strings.TrimSpace(rollup.HeadSHA); observedHead != "" && !strings.EqualFold(observedHead, currentHead) {
+		return spawnRepairGateDecision{reason: "PR head changed while current checks were being read"}
+	}
+	ci := strings.ToLower(strings.TrimSpace(rollup.Verdict))
+	actionableReason := ""
+	if ci == "failure" {
+		actionableReason = "current-head CI is failing"
+	}
+
+	if actionableReason == "" {
+		mergeable, mergeState, mergeErr := o.prMergeStatus(pr)
+		if mergeErr != nil {
+			return spawnRepairGateDecision{reason: fmt.Sprintf("current PR merge state is unavailable: %v", mergeErr)}
+		}
+		if strings.EqualFold(strings.TrimSpace(mergeable), "CONFLICTING") || strings.EqualFold(strings.TrimSpace(mergeState), "dirty") {
+			actionableReason = "current PR head has a merge conflict"
+		}
+	}
+
+	if actionableReason == "" {
+		review, reviewErr := o.prReviewGateVerdict(pr)
+		if reviewErr != nil {
+			return spawnRepairGateDecision{reason: fmt.Sprintf("current PR review gate is unavailable: %v", reviewErr)}
+		}
+		if !review.Pending && !review.Passed {
+			actionableReason = "current PR head has blocking review findings"
+		}
+	}
+
+	latestHead, err := o.prHeadSHA(pr)
+	if err != nil || !strings.EqualFold(strings.TrimSpace(latestHead), currentHead) {
+		return spawnRepairGateDecision{reason: "PR head changed while repair gates were being revalidated"}
+	}
+	if actionableReason != "" {
+		return spawnRepairGateDecision{actionable: true, reason: actionableReason}
+	}
+
+	switch ci {
+	case "pending":
+		return spawnRepairGateDecision{stale: true, reason: "current PR head checks are pending; no repair is presently actionable"}
+	case "success":
+		return spawnRepairGateDecision{stale: true, reason: "current PR head is green and has no actionable conflict or review blocker"}
+	default:
+		return spawnRepairGateDecision{reason: fmt.Sprintf("current PR check verdict %q is not authoritative", ci)}
+	}
 }
 
 func activeIssueClaimForSession(s *state.State, issueNumber int, slot string) (state.IssueClaim, bool) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5101,6 +5101,7 @@ func TestStartNewWorkers_SupervisorRepairSpawnRepairsReservedSessionInPlace(t *t
 	cfg := cfgWithBackends("codex", "codex")
 	issues := []github.Issue{makeIssue(767, "repair stale PR")}
 	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	authorizeCurrentFailedRepairGate(o, 769)
 	o.hasOpenPRForIssueFn = func(issueNumber int) (bool, error) {
 		return issueNumber == 767, nil
 	}
@@ -5156,6 +5157,7 @@ func TestStartNewWorkers_ApprovedRepairIgnoresOlderDoneTerminalClaim(t *testing.
 	}
 	issues := []github.Issue{makeIssue(887, "finish watchdog recovery")}
 	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	authorizeCurrentFailedRepairGate(o, 914)
 	o.hasOpenPRForIssueFn = func(issueNumber int) (bool, error) {
 		return issueNumber == 887, nil
 	}

--- a/internal/orchestrator/repair_approval_reconcile_test.go
+++ b/internal/orchestrator/repair_approval_reconcile_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,6 +17,22 @@ import (
 	"github.com/befeast/maestro/internal/supervisor"
 )
 
+func authorizeCurrentFailedRepairGate(o *Orchestrator, pr int) {
+	head := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	o.ghPRHeadSHAFn = func(got int) (string, error) {
+		if got != pr {
+			return "", fmt.Errorf("unexpected PR #%d", got)
+		}
+		return head, nil
+	}
+	o.ghPRCheckRollupFn = func(got int) (github.PRCheckRollup, error) {
+		if got != pr {
+			return github.PRCheckRollup{}, fmt.Errorf("unexpected PR #%d", got)
+		}
+		return github.PRCheckRollup{HeadSHA: head, Verdict: "failure", Complete: true}, nil
+	}
+}
+
 // TestAwaitingRepairDispatchReservesAndRespawnsOriginalSession is the #892
 // incident regression: PR #7 is retained on txc-1, its approved repair is
 // awaiting dispatch, and the ready issue is visible to the normal poll. The
@@ -27,6 +44,7 @@ func TestAwaitingRepairDispatchReservesAndRespawnsOriginalSession(t *testing.T) 
 	cfg.StateDir = t.TempDir()
 	issues := []github.Issue{makeIssue(1, "repair PR #7", "maestro-ready")}
 	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, issues)
+	authorizeCurrentFailedRepairGate(o, 7)
 	o.hasOpenPRForIssueFn = func(issue int) (bool, error) { return issue == 1, nil }
 	respawns := 0
 	o.respawnInPlaceFn = func(cfg *config.Config, slot string, sess *state.Session, repo string, issue github.Issue, prompt, backend string) error {
@@ -192,6 +210,7 @@ func TestAwaitingRepairDispatchValidReservationOutranksInvalidSiblingApproval(t 
 	cfg := cfgWithBackends("codex", "codex")
 	issues := []github.Issue{makeIssue(877, "repair PR #891", "maestro-ready")}
 	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, issues)
+	authorizeCurrentFailedRepairGate(o, 891)
 	o.hasOpenPRForIssueFn = func(issue int) (bool, error) { return issue == 877, nil }
 	respawns := 0
 	o.respawnInPlaceFn = func(_ *config.Config, slot string, sess *state.Session, _ string, _ github.Issue, _, _ string) error {
@@ -234,6 +253,7 @@ func TestAwaitingRepairDispatchValidReservationOutranksMultipleInvalidSiblingApp
 	cfg := cfgWithBackends("codex", "codex")
 	issues := []github.Issue{makeIssue(877, "repair PR #891", "maestro-ready")}
 	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, issues)
+	authorizeCurrentFailedRepairGate(o, 891)
 	o.hasOpenPRForIssueFn = func(issue int) (bool, error) { return issue == 877, nil }
 	respawns := 0
 	o.respawnInPlaceFn = func(_ *config.Config, slot string, sess *state.Session, _ string, _ github.Issue, _, _ string) error {
@@ -278,6 +298,7 @@ func TestAwaitingRepairDispatchRechecksSessionRevealedByStaleSiblingApproval(t *
 	cfg := cfgWithBackends("codex", "codex")
 	issues := []github.Issue{makeIssue(877, "repair PR #891", "maestro-ready")}
 	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, issues)
+	authorizeCurrentFailedRepairGate(o, 891)
 	o.hasOpenPRForIssueFn = func(issue int) (bool, error) { return issue == 877, nil }
 	respawns := 0
 	o.respawnInPlaceFn = func(_ *config.Config, _ string, _ *state.Session, _ string, _ github.Issue, _, _ string) error {

--- a/internal/orchestrator/repair_dispatch_gate_test.go
+++ b/internal/orchestrator/repair_dispatch_gate_test.go
@@ -1,0 +1,122 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func repairGateTestState(now time.Time, head string) *state.State {
+	s := state.NewState()
+	s.Sessions["slot-7"] = &state.Session{
+		IssueNumber: 7,
+		IssueTitle:  "repair exact PR",
+		Status:      state.StatusDead,
+		PRNumber:    70,
+		Worktree:    "/work/slot-7",
+		Branch:      "feat/slot-7-7-repair",
+		Backend:     "codex",
+	}
+	approval := repairApproval("repair-7", 7, 70, state.ApprovalStatusAwaitingDispatch, now)
+	approval.Target.Session = "slot-7"
+	approval.Target.HeadSHA = head
+	s.Approvals = []state.Approval{approval}
+	return s
+}
+
+func TestSpawnRepairDispatch_CurrentPendingHeadStalesApprovalWithoutRespawn(t *testing.T) {
+	const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cfg := cfgWithBackends("codex", "codex")
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, []github.Issue{makeIssue(7, "repair exact PR", "maestro-ready")})
+	o.hasOpenPRForIssueFn = func(int) (bool, error) { return true, nil }
+	o.ghPRHeadSHAFn = func(int) (string, error) { return head, nil }
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{HeadSHA: head, Verdict: "pending", Complete: true}, nil
+	}
+	o.ghPRMergeStatusFn = func(int) (string, string, error) { return "MERGEABLE", "unstable", nil }
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{Pending: true, Streams: []github.ReviewStreamVerdict{{Name: "greptile", Pending: true}}}, nil
+	}
+	respawns := 0
+	o.respawnInPlaceFn = func(*config.Config, string, *state.Session, string, github.Issue, string, string) error {
+		respawns++
+		return nil
+	}
+
+	s := repairGateTestState(time.Now().UTC(), head)
+	o.startNewWorkers(s, 1)
+
+	if respawns != 0 || len(*freshStarts) != 0 {
+		t.Fatalf("repair dispatched for pending current head: respawns=%d fresh=%v", respawns, *freshStarts)
+	}
+	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusStale {
+		t.Fatalf("repair approval = %q, want stale", got)
+	}
+}
+
+func TestSpawnRepairDispatch_HeadMoveStalesBoundApprovalBeforeReadingOldGates(t *testing.T) {
+	const oldHead = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const newHead = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	cfg := cfgWithBackends("codex", "codex")
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, []github.Issue{makeIssue(7, "repair exact PR", "maestro-ready")})
+	o.hasOpenPRForIssueFn = func(int) (bool, error) { return true, nil }
+	o.ghPRHeadSHAFn = func(int) (string, error) { return newHead, nil }
+	checkReads := 0
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		checkReads++
+		return github.PRCheckRollup{HeadSHA: oldHead, Verdict: "failure", Complete: true}, nil
+	}
+
+	s := repairGateTestState(time.Now().UTC(), oldHead)
+	o.startNewWorkers(s, 1)
+
+	if checkReads != 0 || len(*freshStarts) != 0 {
+		t.Fatalf("stale-head repair read old gates or dispatched: checkReads=%d fresh=%v", checkReads, *freshStarts)
+	}
+	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusStale {
+		t.Fatalf("repair approval = %q, want stale", got)
+	}
+}
+
+func TestSpawnRepairDispatch_CurrentReviewFindingAllowsExactInPlaceRepair(t *testing.T) {
+	const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cfg := cfgWithBackends("codex", "codex")
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, []github.Issue{makeIssue(7, "repair exact PR", "maestro-ready")})
+	o.hasOpenPRForIssueFn = func(int) (bool, error) { return true, nil }
+	o.ghPRHeadSHAFn = func(int) (string, error) { return head, nil }
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{HeadSHA: head, Verdict: "success", Complete: true}, nil
+	}
+	o.ghPRMergeStatusFn = func(int) (string, string, error) { return "MERGEABLE", "clean", nil }
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{
+			Passed: false,
+			Streams: []github.ReviewStreamVerdict{{
+				Name: "greptile", Passed: false,
+				Findings: []github.ReviewComment{{Path: "main.go", Line: 7, Body: "correctness", User: "greptile"}},
+			}},
+		}, nil
+	}
+	respawns := 0
+	o.respawnInPlaceFn = func(_ *config.Config, slot string, sess *state.Session, _ string, _ github.Issue, _, _ string) error {
+		if slot != "slot-7" {
+			t.Fatalf("respawn slot = %q, want slot-7", slot)
+		}
+		respawns++
+		sess.Status = state.StatusRunning
+		return nil
+	}
+
+	s := repairGateTestState(time.Now().UTC(), head)
+	o.startNewWorkers(s, 1)
+
+	if respawns != 1 || len(*freshStarts) != 0 || len(s.Sessions) != 1 {
+		t.Fatalf("exact review repair mismatch: respawns=%d fresh=%v sessions=%d", respawns, *freshStarts, len(s.Sessions))
+	}
+	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusSuperseded {
+		t.Fatalf("repair approval = %q, want consumed/superseded", got)
+	}
+}

--- a/internal/orchestrator/repair_dispatch_gate_test.go
+++ b/internal/orchestrator/repair_dispatch_gate_test.go
@@ -81,6 +81,32 @@ func TestSpawnRepairDispatch_HeadMoveStalesBoundApprovalBeforeReadingOldGates(t 
 	}
 }
 
+func TestSpawnRepairDispatch_PartialGreenRollupFailsClosedWithoutConsumingApproval(t *testing.T) {
+	const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cfg := cfgWithBackends("codex", "codex")
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, []github.Issue{makeIssue(7, "repair exact PR", "maestro-ready")})
+	o.hasOpenPRForIssueFn = func(int) (bool, error) { return true, nil }
+	o.ghPRHeadSHAFn = func(int) (string, error) { return head, nil }
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{HeadSHA: head, Verdict: "success", Complete: false}, nil
+	}
+	respawns := 0
+	o.respawnInPlaceFn = func(*config.Config, string, *state.Session, string, github.Issue, string, string) error {
+		respawns++
+		return nil
+	}
+
+	s := repairGateTestState(time.Now().UTC(), head)
+	o.startNewWorkers(s, 1)
+
+	if respawns != 0 || len(*freshStarts) != 0 {
+		t.Fatalf("repair dispatched from partial green rollup: respawns=%d fresh=%v", respawns, *freshStarts)
+	}
+	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("repair approval = %q, want awaiting_dispatch for retryable partial read", got)
+	}
+}
+
 func TestSpawnRepairDispatch_CurrentReviewFindingAllowsExactInPlaceRepair(t *testing.T) {
 	const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	cfg := cfgWithBackends("codex", "codex")

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4135,7 +4135,8 @@ func fleetSupersedingIssueSession(candidate sessionInfo, all []sessionInfo) (ses
 			// delivered PR and this attempt was explicitly reconciled as a
 			// duplicate. Do not hide a genuine failed follow-up merely because
 			// an older session for the issue once completed.
-			if peer.PRNumber > 0 && (candidate.WorkerOutcome == "duplicate_dispatch_reconciled" || fleetSessionStartedAfterCanonicalCompletion(candidate, peer)) {
+			if peer.PRNumber > 0 && !peer.ReleasedForRedispatch &&
+				(candidate.WorkerOutcome == "duplicate_dispatch_reconciled" || fleetSessionStartedAfterCanonicalCompletion(candidate, peer)) {
 				return peer, true
 			}
 		}

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -3977,6 +3977,21 @@ func TestFleetSupersedingIssueSessionUsesCanonicalMergedPRForLaterDuplicate(t *t
 	}
 }
 
+func TestFleetSupersedingIssueSessionDoesNotUseReleasedDoneSessionForReopenedFollowUp(t *testing.T) {
+	followUp := sessionInfo{
+		Slot: "ok-player-292", IssueNumber: 343, Status: string(state.StatusDead), NeedsAttention: true,
+		StartedAt: "2026-07-17T23:25:21Z",
+	}
+	oldCompleted := sessionInfo{
+		Slot: "ok-player-262", IssueNumber: 343, Status: string(state.StatusDone), PRNumber: 357,
+		FinishedAt: "2026-07-17T09:37:56Z", ReleasedForRedispatch: true,
+	}
+
+	if got, ok := fleetSupersedingIssueSession(followUp, []sessionInfo{followUp, oldCompleted}); ok {
+		t.Fatalf("released terminal session incorrectly hid reopened follow-up: %+v", got)
+	}
+}
+
 func TestFleetSupersedingIssueSessionUsesCanonicalOpenPR(t *testing.T) {
 	duplicate := sessionInfo{
 		Slot:           "ok-player-259",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -337,6 +337,10 @@ type sessionInfo struct {
 	TokensUsedTotal    int    `json:"tokens_used_total"`
 	TokenBudgetMeasure string `json:"token_budget_measure,omitempty"`
 	WorkerOutcome      string `json:"worker_outcome,omitempty"`
+	// ReleasedForRedispatch means a terminal session no longer owns the issue.
+	// Fleet duplicate projection must preserve this bit so an older completed
+	// PR cannot hide a genuine follow-up after the issue is reopened (#949).
+	ReleasedForRedispatch bool `json:"released_for_redispatch,omitempty"`
 	// #739: cache-aware split token breakdown when the backend stamped it
 	// (claude stream-json / Pi). Surfaced so the cost panel can show the
 	// cache-read discount; zero for backends that report only a combined total.
@@ -416,34 +420,35 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 	}
 	now := time.Now().UTC()
 	info := sessionInfo{
-		Slot:               slot,
-		IssueNumber:        sess.IssueNumber,
-		IssueTitle:         sess.IssueTitle,
-		IssueURL:           githubIssueURL(repo, sess.IssueNumber),
-		Status:             string(sess.Status),
-		Backend:            sess.Backend,
-		Model:              currentSessionModel(sess),
-		PRNumber:           sess.PRNumber,
-		PRURL:              githubPRURL(repo, sess.PRNumber),
-		TokensUsedAttempt:  sess.TokensUsedAttempt,
-		TokensUsedTotal:    sess.TokensUsedTotal,
-		TokenBudgetMeasure: tokenBudgetMeasure,
-		WorkerOutcome:      sess.WorkerOutcome,
-		TokensInput:        sess.TokensInput,
-		TokensOutput:       sess.TokensOutput,
-		TokensCacheRead:    sess.TokensCacheRead,
-		TokensCacheWrite:   sess.TokensCacheWrite,
-		CostUSDBackend:     sess.CostUSDBackend,
-		StartedAt:          sess.StartedAt.Format(time.RFC3339),
-		Worktree:           sess.Worktree,
-		Branch:             sess.Branch,
-		TmuxSession:        watchSessionName(slot, sess),
-		HasLog:             strings.TrimSpace(sess.LogFile) != "",
-		RetryCount:         sess.RetryCount,
-		LastNotification:   sess.LastNotifiedStatus,
-		BackendSelection:   sess.BackendSelection,
-		Attribution:        sess.Attribution,
-		Live:               state.SessionLiveAt(sess, now),
+		Slot:                  slot,
+		IssueNumber:           sess.IssueNumber,
+		IssueTitle:            sess.IssueTitle,
+		IssueURL:              githubIssueURL(repo, sess.IssueNumber),
+		Status:                string(sess.Status),
+		Backend:               sess.Backend,
+		Model:                 currentSessionModel(sess),
+		PRNumber:              sess.PRNumber,
+		PRURL:                 githubPRURL(repo, sess.PRNumber),
+		TokensUsedAttempt:     sess.TokensUsedAttempt,
+		TokensUsedTotal:       sess.TokensUsedTotal,
+		TokenBudgetMeasure:    tokenBudgetMeasure,
+		WorkerOutcome:         sess.WorkerOutcome,
+		ReleasedForRedispatch: sess.ReleasedForRedispatch,
+		TokensInput:           sess.TokensInput,
+		TokensOutput:          sess.TokensOutput,
+		TokensCacheRead:       sess.TokensCacheRead,
+		TokensCacheWrite:      sess.TokensCacheWrite,
+		CostUSDBackend:        sess.CostUSDBackend,
+		StartedAt:             sess.StartedAt.Format(time.RFC3339),
+		Worktree:              sess.Worktree,
+		Branch:                sess.Branch,
+		TmuxSession:           watchSessionName(slot, sess),
+		HasLog:                strings.TrimSpace(sess.LogFile) != "",
+		RetryCount:            sess.RetryCount,
+		LastNotification:      sess.LastNotifiedStatus,
+		BackendSelection:      sess.BackendSelection,
+		Attribution:           sess.Attribution,
+		Live:                  state.SessionLiveAt(sess, now),
 	}
 
 	// Calculate runtime breakdown (#426). The workflow runtime is the


### PR DESCRIPTION
Refs #961

## Root cause
The repair dispatcher revalidated the durable issue/session/PR reservation but never re-read the current GitHub head and gates. A delayed approved repair could therefore replay after a new push while checks were pending or green.

## Fix
- bind repair authority to the current PR head when a decision carries a SHA
- authorize spend only for current CI failure, merge conflict, or blocking review findings
- stale pending/green repair intents instead of spawning
- fail closed on unknown/unavailable gate reads without consuming authority
- preserve exact-session in-place repair for real current blockers

## Verification
- go test ./internal/orchestrator
- go build ./cmd/maestro/
- full go test ./... reaches an unrelated existing temp-directory permission failure in internal/worker: directory 001 is group/other writable

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR revalidates repair dispatch against the current PR state before starting repair work. The main changes are:

- Bind repair authority to the current PR head when a decision includes a SHA.
- Re-check live CI, merge status, and review gates before dispatching a repair worker.
- Stale pending or green repair intents instead of spending repair authority.
- Preserve `ReleasedForRedispatch` in fleet session data so reopened follow-up work is not hidden by older completed PR sessions.
- Add tests for stale heads, pending gates, partial gate reads, review blockers, and released fleet sessions.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped, fail closed on unavailable live gate reads, and include focused tests for the updated dispatch and fleet projection behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the Maestro build completed with EXIT\_CODE: 0.
- Verified the orchestrator test log shows PASS and EXIT\_CODE: 0.
- Verified the server test log shows PASS and EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14919623/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds live PR head, check, merge, and review gate revalidation before repair dispatch. |
| internal/orchestrator/repair_dispatch_gate_test.go | Adds tests for pending heads, stale head bindings, partial rollups, and review-finding repair dispatch. |
| internal/orchestrator/repair_approval_reconcile_test.go | Adds a shared helper for current failed repair gate authorization in reconciliation tests. |
| internal/orchestrator/orchestrator_test.go | Updates existing repair dispatch tests to satisfy the new live gate requirement. |
| internal/server/fleet.go | Stops released terminal sessions from superseding reopened follow-up work in fleet projection. |
| internal/server/server.go | Exposes `ReleasedForRedispatch` in `sessionInfo` for fleet duplicate projection. |
| internal/server/fleet_test.go | Adds coverage for released completed sessions not hiding reopened follow-up attempts. |

<sub>Reviews (1): Last reviewed commit: ["fix: keep partial PR gate reads retryabl..."](https://github.com/befeast/maestro/commit/f594f5ea2964e6c8f39590558171526c07f41b2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45248106)</sub>

<!-- /greptile_comment -->