### PR TITLE
fix: fence destructive worker restarts

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -880,6 +880,26 @@ func (e *Executor) executeWorkerControl(approval *state.Approval, verb string, s
 
 	slot := approval.Target.Session
 
+	// #964: an approved worker-control action is a capability for one exact
+	// session snapshot, not a standing instruction for the slot. A delayed
+	// restart can otherwise execute after an in-place repair or redispatch has
+	// changed the canonical session, killing the replacement worker and
+	// deleting its preserved worktree. Recompute the same target-state digest
+	// stamped when the approval was created and skip stale approvals before any
+	// controller side effect.
+	if e.State != nil && strings.TrimSpace(approval.TargetStateHash) != "" {
+		currentHash := e.State.ApprovalTargetStateHash(approval.Target)
+		if currentHash != approval.TargetStateHash {
+			return Result{
+				Status: state.ApprovalStatusExecutionSkipped,
+				Summary: fmt.Sprintf(
+					"%s skipped: session state for slot %s changed after approval; no worker or worktree was touched",
+					verb, slot,
+				),
+			}
+		}
+	}
+
 	// Slot-reuse fence — same shape as executeDeleteWorktree (#488 /
 	// premortem #7). By the time the operator approves a stop/restart,
 	// the slot may have been recycled to a different live issue.
@@ -924,6 +944,21 @@ func (e *Executor) executeWorkerControl(approval *state.Approval, verb string, s
 				slot, sess.PRNumber,
 			),
 			Err: fmt.Errorf("restart_worker on slot %s refused: open PR #%d present", slot, sess.PRNumber),
+		}
+	}
+
+	// #964: restart_worker is destructive in the current controller: it stops
+	// the worker and removes the worktree before the orchestrator recreates the
+	// slot. A retained worktree, even before a PR exists, may contain completed
+	// uncommitted work. Recovery must use the in-place repair path instead.
+	if !stop && sess != nil && strings.TrimSpace(sess.Worktree) != "" {
+		return Result{
+			Status: state.ApprovalStatusExecutionFailed,
+			Summary: fmt.Sprintf(
+				"restart_worker refused: slot %s retains worktree %s; destructive restart could discard completed work. Use spawn_repair_worker to recover the same slot and worktree in place, or stop_worker to terminate.",
+				slot, sess.Worktree,
+			),
+			Err: fmt.Errorf("restart_worker on slot %s refused: retained worktree %s", slot, sess.Worktree),
 		}
 	}
 

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -737,6 +737,59 @@ func TestExecute_RestartWorker_HappyPath(t *testing.T) {
 	}
 }
 
+// #964: an approval stamped for an earlier session snapshot must not execute
+// after the canonical session changes. This fences delayed watchdog approvals
+// before the worker controller can terminate a replacement worker.
+func TestExecute_RestartWorker_StaleTargetStateSkipped(t *testing.T) {
+	wc := &fakeWorkers{}
+	target := &state.SupervisorTarget{Session: "slot-1", Issue: 42}
+	st := state.NewState()
+	st.Sessions["slot-1"] = &state.Session{IssueNumber: 42, Status: state.StatusDead, RetryCount: 1}
+	a := mkApproval(config.SupervisorActionRestartWorker, target, "restart me", "")
+	a.TargetStateHash = st.ApprovalTargetStateHash(target)
+
+	// A repair has already started since the approval was minted.
+	st.Sessions["slot-1"].Status = state.StatusRunning
+	st.Sessions["slot-1"].StartedAt = time.Now().UTC()
+	ex := &Executor{
+		Cfg:      newCfg(),
+		Workers:  wc,
+		Sessions: fakeSessions{"slot-1": st.Sessions["slot-1"]},
+		State:    st,
+	}
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionSkipped {
+		t.Fatalf("status = %q, want execution_skipped; res=%+v", res.Status, res)
+	}
+	if len(wc.restartCalls) != 0 || len(wc.stopCalls) != 0 {
+		t.Fatalf("stale approval must not touch the worker; restart=%+v stop=%+v", wc.restartCalls, wc.stopCalls)
+	}
+	if !strings.Contains(res.Summary, "changed after approval") || !strings.Contains(res.Summary, "no worker or worktree was touched") {
+		t.Fatalf("summary = %q, want stale-state and no-side-effect explanation", res.Summary)
+	}
+}
+
+// #964: a PR-less retained worktree is still canonical durable work. The
+// destructive restart controller must not run; repair resumes it in place.
+func TestExecute_RestartWorker_RefusedForRetainedWorktree(t *testing.T) {
+	wc := &fakeWorkers{}
+	sess := &state.Session{IssueNumber: 42, Status: state.StatusDead, Worktree: "/srv/wt/slot-1"}
+	ex := &Executor{Cfg: newCfg(), Workers: wc, Sessions: fakeSessions{"slot-1": sess}}
+	a := mkApproval(config.SupervisorActionRestartWorker, &state.SupervisorTarget{Session: "slot-1", Issue: 42}, "restart me", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionFailed {
+		t.Fatalf("status = %q, want execution_failed; res=%+v", res.Status, res)
+	}
+	if len(wc.restartCalls) != 0 || len(wc.stopCalls) != 0 {
+		t.Fatalf("retained worktree must not be touched; restart=%+v stop=%+v", wc.restartCalls, wc.stopCalls)
+	}
+	if !strings.Contains(res.Summary, "/srv/wt/slot-1") || !strings.Contains(res.Summary, "spawn_repair_worker") {
+		t.Fatalf("summary = %q, want retained path and in-place repair guidance", res.Summary)
+	}
+}
+
 // #874: restart_worker on a session that owns an open PR is refused before the
 // controller runs — restart deletes the worktree, which would strand or discard
 // the PR branch. The failure summary names the supported in-place alternative.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -981,6 +981,16 @@ func workerActionAffordances(readOnly bool, endpoint string, worker sessionInfo)
 		} else {
 			restart.DisabledReason = fmt.Sprintf("This worker has open PR #%d; restart would delete its worktree and strand the PR branch. Use review-repair to address review feedback in place, or Stop to terminate.", worker.PRNumber)
 		}
+	} else if strings.TrimSpace(worker.Worktree) != "" {
+		// #964: PR-less does not mean disposable. A retained worktree can hold
+		// completed, uncommitted work; the current restart controller deletes it.
+		// Offer only the canonical in-place repair path for this state.
+		restart.Disabled = true
+		if readOnly {
+			restart.DisabledReason = readOnlyDisabledReason() + " Additionally, this worker retains a worktree; recover the same slot in place with repair instead of restarting."
+		} else {
+			restart.DisabledReason = "This worker retains a worktree that may contain completed work; restart would delete it. Recover the same slot and worktree in place with repair, or Stop to terminate."
+		}
 	}
 	return []controlAction{
 		restart,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -967,6 +967,7 @@ func workerActionAffordances(readOnly bool, endpoint string, worker sessionInfo)
 		}
 	}
 	restart := newApprovalControlAction("restart_worker", "Restart", "Enqueue a cautious-gate approval to restart this worker.", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, readOnly)
+	var repair *controlAction
 	if worker.PRNumber > 0 {
 		// #874: restarting a worker that already owns an open PR is the wrong
 		// control — restart_worker deletes the worktree, which would strand
@@ -991,14 +992,25 @@ func workerActionAffordances(readOnly bool, endpoint string, worker sessionInfo)
 		} else {
 			restart.DisabledReason = "This worker retains a worktree that may contain completed work; restart would delete it. Recover the same slot and worktree in place with repair, or Stop to terminate."
 		}
+		inPlace := newApprovalControlAction(
+			config.SupervisorActionSpawnRepairWorker,
+			"Repair in place",
+			"Enqueue a cautious-gate repair that resumes this canonical slot, branch, and retained worktree without creating a duplicate.",
+			"worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, readOnly,
+		)
+		repair = &inPlace
 	}
-	return []controlAction{
+	actions := []controlAction{
 		restart,
 		newApprovalControlAction("stop_worker", "Stop", "Enqueue a cautious-gate approval to stop this worker.", "worker", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, readOnly),
 		newSafeControlAction("mark_issue_ready", "Mark ready", "Add the maestro-ready label so the supervisor picks the issue up.", "issue", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, readOnly),
 		newSafeControlAction("mark_issue_blocked", "Mark blocked", "Add the blocked label so the supervisor holds the issue.", "issue", worker.Slot, worker.IssueNumber, worker.PRNumber, endpoint, readOnly),
 		merge,
 	}
+	if repair != nil {
+		actions = append(actions, *repair)
+	}
+	return actions
 }
 
 // newSafeControlAction returns a button for a safe verb (label/comment).

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1491,7 +1491,18 @@ func TestWorkerActionAffordances_RestartDisabledForOpenPR(t *testing.T) {
 	noPR := workerActionAffordances(false, "/api/v1/actions", sessionInfo{Slot: "slot-1", IssueNumber: 43})
 	restartNoPR := findControlAction(t, noPR, "restart_worker")
 	if restartNoPR.Disabled {
-		t.Fatalf("restart_worker for a PR-less worker should be enabled, got %+v", restartNoPR)
+		t.Fatalf("restart_worker for a PR-less worker without a retained worktree should be enabled, got %+v", restartNoPR)
+	}
+
+	retained := workerActionAffordances(false, "/api/v1/actions", sessionInfo{
+		Slot: "slot-2", IssueNumber: 44, Worktree: "/srv/wt/slot-2",
+	})
+	restartRetained := findControlAction(t, retained, "restart_worker")
+	if !restartRetained.Disabled {
+		t.Fatalf("restart_worker for a retained PR-less worktree should be disabled, got %+v", restartRetained)
+	}
+	if !contains(restartRetained.DisabledReason, "retains a worktree") || !contains(restartRetained.DisabledReason, "same slot") {
+		t.Fatalf("disabled reason = %q, want preserved-work and same-slot repair guidance", restartRetained.DisabledReason)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1504,6 +1504,16 @@ func TestWorkerActionAffordances_RestartDisabledForOpenPR(t *testing.T) {
 	if !contains(restartRetained.DisabledReason, "retains a worktree") || !contains(restartRetained.DisabledReason, "same slot") {
 		t.Fatalf("disabled reason = %q, want preserved-work and same-slot repair guidance", restartRetained.DisabledReason)
 	}
+	repairRetained := findControlAction(t, retained, config.SupervisorActionSpawnRepairWorker)
+	if repairRetained.Disabled {
+		t.Fatalf("in-place repair for a retained PR-less worktree should be enabled, got %+v", repairRetained)
+	}
+	if !repairRetained.RequiresApproval || repairRetained.Target != "slot-2" || repairRetained.IssueNumber != 44 {
+		t.Fatalf("in-place repair action is not scoped to the canonical worker: %+v", repairRetained)
+	}
+	if !contains(repairRetained.Description, "retained worktree") || !contains(repairRetained.Description, "duplicate") {
+		t.Fatalf("repair description = %q, want retained-worktree and duplicate-prevention contract", repairRetained.Description)
+	}
 }
 
 func TestHandleStateProjectBlockedKeepsAttentionForOpenPR(t *testing.T) {


### PR DESCRIPTION
## Root cause
A delayed restart_worker approval remained executable after the canonical session changed. The executor fenced only slot and issue identity, while the restart controller deleted retained worktrees even for PR-less sessions.

## Fix
- skip worker-control approvals when their target-state hash no longer matches live state
- refuse destructive restart for any retained worktree and direct recovery to the in-place repair path
- disable the unsafe Restart affordance in Fleet MC
- cover stale approval and retained PR-less worktree behavior with tests

## Verification
- go test ./internal/approver ./internal/server ./internal/orchestrator
- go build ./cmd/maestro/

Refs #964

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR protects worker restarts from acting on stale or retained session state. The main changes are:

- Skips worker-control approvals when the live target-state hash no longer matches the approved snapshot.
- Refuses destructive `restart_worker` execution when the session still retains a worktree.
- Disables the unsafe Restart action in Mission Control for retained PR-less worktrees.
- Adds tests for stale restart approvals and retained worktree restart affordances.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped and add checks before destructive worker controller calls. Tests cover both stale approval handling and retained worktree UI affordances. No correctness or security issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Go test suite and confirmed that internal/approver, internal/server, and internal/orchestrator tests all reported ok, with EXIT\_CODE: 0.
- Executed go build for ./cmd/maestro/ and verified EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14920970/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/approver/executor.go | Adds stale target-state fencing before worker-control side effects and refuses destructive restarts when the live session retains a worktree. |
| internal/approver/executor_test.go | Adds coverage for stale restart approvals and retained PR-less worktree restart refusal. |
| internal/server/server.go | Disables the restart affordance for retained PR-less worktrees and offers the approval-gated in-place repair action. |
| internal/server/server_test.go | Extends worker action affordance tests for retained worktree restart disabling and repair action scoping. |

<sub>Reviews (1): Last reviewed commit: ["fix: expose retained-worktree repair act..."](https://github.com/befeast/maestro/commit/bad76ce6cf3339fe94156b4df3c97c54bac90711) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45251043)</sub>

<!-- /greptile_comment -->