### PR TITLE
fix: resume workers that die during drain

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -59,7 +59,7 @@ type Orchestrator struct {
 	enhancementPromptBase string
 	pidAliveFn            func(pid int) bool
 	tmuxSessionExistsFn   func(name string) bool
-	tmuxPanePIDFn         func(session string) (int, error)
+	tmuxPaneIdentityFn    func(session string) (int, string, error)
 	listOpenPRsFn         func() ([]github.PR, error)
 	remoteBranchExistsFn  func(branch string) (bool, error)
 	createPRFn            func(title, body, base, head string) (int, error)
@@ -267,13 +267,15 @@ func (o *Orchestrator) tmuxSessionExists(name string) bool {
 	return tmuxsession.HasSession(name)
 }
 
-// tmuxPanePID reads the live pane pid of a tmux session, used to adopt an
-// already-running worker whose recorded pid is stale (#877 restart-resume).
-func (o *Orchestrator) tmuxPanePID(session string) (int, error) {
-	if o.tmuxPanePIDFn != nil {
-		return o.tmuxPanePIDFn(session)
+// tmuxPaneIdentity reads the live pane pid and worktree of a tmux session,
+// used to adopt an already-running worker whose recorded pid is stale (#877
+// restart-resume). Both values are required: a matching tmux name alone may
+// refer to a stale or unrelated pane after a failed resume.
+func (o *Orchestrator) tmuxPaneIdentity(session string) (int, string, error) {
+	if o.tmuxPaneIdentityFn != nil {
+		return o.tmuxPaneIdentityFn(session)
 	}
-	return worker.TmuxPanePID(session)
+	return worker.TmuxPaneIdentity(session)
 }
 
 func (o *Orchestrator) listOpenPRs() ([]github.PR, error) {
@@ -3118,13 +3120,31 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 				sess.RestartCheckpointAt = nil
 				log.Printf("[orch] reconcile: %s restart-resume skipped — worktree %q gone (%v); falling through", slotName, wt, statErr)
 			} else if tmuxAlive {
-				// A replacement is already running — adopt it, never respawn over it.
-				if pid, perr := o.tmuxPanePID(tmuxName); perr != nil || pid <= 0 {
+				// A replacement is already running — adopt it only when both its
+				// live PID and worktree match this retained session. Never respawn
+				// over a live pane, and never adopt a same-name foreign pane.
+				pid, paneWorktree, perr := o.tmuxPaneIdentity(tmuxName)
+				if perr != nil || pid <= 0 {
 					// Leave the marker SET so the next cycle retries the (harmless,
 					// non-destructive) adoption, rather than consuming it and falling
 					// to a false running->dead over the live replacement. Unlike a
 					// respawn, an adoption retry cannot loop or duplicate.
-					log.Printf("[orch] reconcile: %s restart-resume — replacement tmux %q alive but pane pid unreadable (%v); will retry adoption next cycle", slotName, tmuxName, perr)
+					log.Printf("[orch] reconcile: %s restart-resume — replacement tmux %q alive but pane identity unreadable (%v); will retry adoption next cycle", slotName, tmuxName, perr)
+				} else if filepath.Clean(paneWorktree) != filepath.Clean(wt) {
+					// A same-name tmux pane in another directory is not this worker.
+					// Fail closed without killing it and consume the automatic resume
+					// marker so the next cycle cannot repeatedly adopt or overwrite an
+					// unrelated process. The retained worktree remains untouched for
+					// explicit operator repair.
+					now := time.Now().UTC()
+					sess.Status = state.StatusDead
+					sess.PID = 0
+					sess.TmuxSession = ""
+					sess.RestartCheckpointAt = nil
+					sess.FinishedAt = &now
+					sess.LastNotifiedStatus = "restart_resume_identity_mismatch"
+					reconciled = true
+					log.Printf("[orch] reconcile: %s restart-resume refused foreign tmux %q: pane worktree %q != retained worktree %q; session left dead, retained worktree preserved, no process killed", slotName, tmuxName, paneWorktree, wt)
 				} else {
 					sess.PID = pid
 					sess.TmuxSession = tmuxName

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3023,7 +3023,16 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 
 	reconciled := false
 	for slotName, sess := range s.Sessions {
-		if sess.Status != state.StatusRunning {
+		isRestartCheckpointedDead := sess.Status == state.StatusDead && sess.RestartCheckpointAt != nil
+		if sess.Status != state.StatusRunning && !isRestartCheckpointedDead {
+			continue
+		}
+		// #967: a worker may die after drain starts but before the daemon's
+		// shutdown checkpoint pass. Its terminal transition carries the restart
+		// marker, but the old draining daemon must not immediately replay it.
+		// The replacement daemon clears the one-shot drain flag on startup and
+		// then consumes the marker below.
+		if isRestartCheckpointedDead && s.DrainActive() {
 			continue
 		}
 		if marker, ok := worker.ReadTokenBudgetMarker(sess.LogFile); ok {
@@ -3126,14 +3135,21 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 				}
 				continue
 			} else if issue, fetchErr := o.getIssue(sess.IssueNumber); fetchErr != nil {
-				sess.RestartCheckpointAt = nil
-				log.Printf("[orch] reconcile: %s restart-resume aborted — could not fetch issue #%d: %v; falling through", slotName, sess.IssueNumber, fetchErr)
+				// A transient GitHub read is not proof that the durable recovery is
+				// invalid. Preserve the marker and retry next cycle; consuming it here
+				// would strand the retained worktree as dead with no retry.
+				log.Printf("[orch] reconcile: %s restart-resume deferred — could not fetch issue #%d: %v; marker preserved for next cycle", slotName, sess.IssueNumber, fetchErr)
+				continue
 			} else {
-				sess.RestartCheckpointAt = nil // exactly-once: consume before the destructive respawn
 				o.updateTokensUsedFromWorkerLog(slotName, sess)
 				promptBase := o.selectPrompt(issue)
 				if respawnErr := o.respawnInPlaceWithConfig(o.cfg, slotName, sess, issue, promptBase, sess.Backend); respawnErr != nil {
-					log.Printf("[orch] reconcile: %s restart-resume in-place failed: %v; falling through to terminal handling", slotName, respawnErr)
+					// RespawnInPlace reconciles against the deterministic tmux identity,
+					// so retrying cannot create a parallel worker. Keep the marker: a
+					// transient backend/launcher failure must not erase recovery intent.
+					sess.Status = state.StatusDead
+					log.Printf("[orch] reconcile: %s restart-resume in-place failed: %v; marker preserved for next cycle", slotName, respawnErr)
+					continue
 				} else {
 					reconciled = true
 					log.Printf("[orch] reconcile: %s resumed in place across restart (issue #%d) — same session, dirty worktree preserved, exactly once (%s)",
@@ -3321,6 +3337,18 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		now := time.Now().UTC()
 		sess.FinishedAt = &now
 		state.MarkWorkerEnded(sess, now)
+		// #967: during graceful drain the daemon shutdown pass may run only
+		// after this flow has already persisted running->dead. Stamp the same
+		// resumable identity here while the cause is still known. Dead markers
+		// are held while drain remains active and consumed by the replacement
+		// daemon, preserving this exact slot/worktree without a new dispatch.
+		if s.DrainActive() && strings.TrimSpace(sess.Worktree) != "" {
+			if _, statErr := os.Stat(sess.Worktree); statErr == nil {
+				stamp := now
+				sess.RestartCheckpointAt = &stamp
+				log.Printf("[orch] reconcile: %s died during drain — retained worktree marked for exact in-place restart resume", slotName)
+			}
+		}
 		reconciled = true
 
 		log.Printf("[orch] reconcile: %s running->dead (%s); pid=%d tmux=%q",

--- a/internal/orchestrator/restart_resume_test.go
+++ b/internal/orchestrator/restart_resume_test.go
@@ -9,6 +9,7 @@ package orchestrator
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -270,14 +271,14 @@ func TestReconcile_RestartCheckpoint_AdoptsLiveReplacement(t *testing.T) {
 	// and its pane pid is the live worker. The old recorded pid is dead.
 	o.tmuxSessionExistsFn = func(name string) bool { return name == slotTmux }
 	o.pidAliveFn = func(pid int) bool { return pid == adoptedPID }
-	o.tmuxPanePIDFn = func(session string) (int, error) {
+	worktree := t.TempDir()
+	o.tmuxPaneIdentityFn = func(session string) (int, string, error) {
 		if session == slotTmux {
-			return adoptedPID, nil
+			return adoptedPID, worktree, nil
 		}
-		return 0, fmt.Errorf("no such session %q", session)
+		return 0, "", fmt.Errorf("no such session %q", session)
 	}
 
-	worktree := t.TempDir()
 	stamp := time.Now().UTC().Add(-30 * time.Second)
 	s := state.NewState()
 	s.Sessions["sup-310"] = &state.Session{
@@ -330,7 +331,9 @@ func TestReconcile_RestartCheckpoint_LiveReplacementUnreadablePID_RetriesNextCyc
 
 	const slotTmux = "maestro-sup-310"
 	o.tmuxSessionExistsFn = func(name string) bool { return name == slotTmux }
-	o.tmuxPanePIDFn = func(session string) (int, error) { return 0, fmt.Errorf("pane gone") }
+	o.tmuxPaneIdentityFn = func(session string) (int, string, error) {
+		return 0, "", fmt.Errorf("pane gone")
+	}
 
 	worktree := t.TempDir()
 	stamp := time.Now().UTC()
@@ -356,6 +359,54 @@ func TestReconcile_RestartCheckpoint_LiveReplacementUnreadablePID_RetriesNextCyc
 	}
 	if sess.Status != state.StatusRunning {
 		t.Fatalf("status = %q, want running — never false-dead over a live replacement", sess.Status)
+	}
+}
+
+// A deterministic tmux name is not sufficient identity. If a failed resume
+// leaves (or encounters) a same-name pane in another worktree, recovery must
+// neither adopt nor kill it, and must not retry into a destructive loop.
+func TestReconcile_RestartCheckpoint_ForeignLiveReplacementFailsClosed(t *testing.T) {
+	resumeCount := 0
+	o := restartResumeOrchestrator(t, &resumeCount)
+
+	const slotTmux = "maestro-sup-310"
+	o.tmuxSessionExistsFn = func(name string) bool { return name == slotTmux }
+	o.tmuxPaneIdentityFn = func(session string) (int, string, error) {
+		return 7777, filepath.Join(t.TempDir(), "foreign"), nil
+	}
+
+	worktree := t.TempDir()
+	stamp := time.Now().UTC()
+	s := state.NewState()
+	s.Sessions["sup-310"] = &state.Session{
+		IssueNumber:         310,
+		Status:              state.StatusRunning,
+		PID:                 4242,
+		TmuxSession:         slotTmux,
+		Branch:              "feat/sup-310-310-in-flight",
+		Worktree:            worktree,
+		Backend:             "claude",
+		RestartCheckpointAt: &stamp,
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected foreign pane identity to reconcile fail-closed state")
+	}
+	sess := s.Sessions["sup-310"]
+	if resumeCount != 0 {
+		t.Fatalf("respawnInPlace fired %d times, want 0", resumeCount)
+	}
+	if sess.Status != state.StatusDead || sess.PID != 0 || sess.TmuxSession != "" {
+		t.Fatalf("session = status %q pid %d tmux %q, want dead/0/empty", sess.Status, sess.PID, sess.TmuxSession)
+	}
+	if sess.RestartCheckpointAt != nil {
+		t.Fatal("marker must be consumed after a foreign-pane identity mismatch")
+	}
+	if sess.Worktree != worktree {
+		t.Fatalf("retained worktree = %q, want preserved %q", sess.Worktree, worktree)
+	}
+	if sess.LastNotifiedStatus != "restart_resume_identity_mismatch" {
+		t.Fatalf("last notified status = %q, want mismatch blocker", sess.LastNotifiedStatus)
 	}
 }
 

--- a/internal/orchestrator/restart_resume_test.go
+++ b/internal/orchestrator/restart_resume_test.go
@@ -101,6 +101,67 @@ func TestReconcile_RestartCheckpoint_ResumesInPlaceExactlyOnce(t *testing.T) {
 	}
 }
 
+// #967: a worker can exit after drain begins but before the daemon shutdown
+// checkpoint pass. The flow that observes the exit must persist a marker on
+// the dead session, hold it while the old daemon is draining, and let only the
+// replacement daemon resume the same slot/worktree.
+func TestReconcile_DrainDeathResumesDeadCheckpointAfterRestart(t *testing.T) {
+	resumeCount := 0
+	o := restartResumeOrchestrator(t, &resumeCount)
+
+	worktree := t.TempDir()
+	s := state.NewState()
+	s.SetSpawnDrain(time.Now().UTC().Add(-time.Minute))
+	s.Sessions["sup-313"] = &state.Session{
+		IssueNumber: 313,
+		IssueTitle:  "dies during drain",
+		Status:      state.StatusRunning,
+		PID:         4245,
+		TmuxSession: "maestro-sup-313",
+		Branch:      "feat/sup-313-313-drain",
+		Worktree:    worktree,
+		Backend:     "claude",
+	}
+
+	// Old daemon observes the worker exit while drain is active. It records a
+	// durable dead checkpoint but must not respawn during this process.
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected drain-time death to change session state")
+	}
+	sess := s.Sessions["sup-313"]
+	if sess.Status != state.StatusDead || sess.RestartCheckpointAt == nil {
+		t.Fatalf("drain-time state = status %q marker %v, want dead with restart marker", sess.Status, sess.RestartCheckpointAt)
+	}
+	if resumeCount != 0 {
+		t.Fatalf("old draining daemon resumed %d workers, want 0", resumeCount)
+	}
+	o.reconcileRunningSessions(s)
+	if resumeCount != 0 {
+		t.Fatalf("old draining daemon replayed dead checkpoint %d times, want 0", resumeCount)
+	}
+
+	// New daemon clears the one-shot drain flag before its first cycle and
+	// consumes the dead marker exactly once on the same logical session.
+	s.ClearSpawnDrain(time.Now().UTC())
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("replacement daemon did not resume dead checkpoint")
+	}
+	if resumeCount != 1 {
+		t.Fatalf("replacement daemon resume count = %d, want 1", resumeCount)
+	}
+	if sess.Status != state.StatusRunning || sess.RestartCheckpointAt != nil {
+		t.Fatalf("resumed state = status %q marker %v, want running with consumed marker", sess.Status, sess.RestartCheckpointAt)
+	}
+	if sess.IssueNumber != 313 || sess.Branch != "feat/sup-313-313-drain" || sess.Worktree != worktree {
+		t.Fatalf("session identity changed: issue=%d branch=%q worktree=%q", sess.IssueNumber, sess.Branch, sess.Worktree)
+	}
+
+	o.reconcileRunningSessions(s)
+	if resumeCount != 1 {
+		t.Fatalf("dead checkpoint resumed %d times, want exactly once", resumeCount)
+	}
+}
+
 // TestReconcile_RestartCheckpoint_SurvivesRestartBoundary is the end-to-end
 // reproduction the #877 review asked for: an in-flight worker checkpointed at
 // shutdown, persisted to the state file, and read back by the NEXT daemon

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -40,6 +40,14 @@ var (
 	}
 )
 
+// TmuxPaneIdentity returns the live pane PID and its current worktree for an
+// exact tmux session. Recovery callers must validate both values before
+// adopting a pane: a deterministic session name alone is not sufficient proof
+// that the pane belongs to the retained worker after a failed respawn.
+func TmuxPaneIdentity(tmuxName string) (int, string, error) {
+	return readTmuxPaneIdentity(tmuxName)
+}
+
 // WorktreeDirty reports whether a retained worker worktree contains any
 // tracked, staged, or untracked changes. Recovery paths use this before a
 // provider transition so completed work is checkpointed instead of being


### PR DESCRIPTION
## Root cause
A worker could exit after graceful drain began but before the daemon shutdown checkpoint pass. The live flow persisted running to dead with no retry or restart marker, so the replacement daemon left the retained worktree stranded and the issue lease suppressed ordinary dispatch.

## Fix
- stamp a retained worker as restart-resumable when it becomes dead during drain
- keep dead checkpoint markers inert in the old draining daemon
- let the replacement daemon resume a checkpoint from running or dead state on the exact slot/worktree
- preserve recovery intent across transient issue-read or launcher failures
- prove exact same-slot, exactly-once recovery across the drain boundary

## Verification
- go test ./internal/orchestrator
- go test ./internal/daemon ./internal/supervisor
- go build ./cmd/maestro/

Refs #967

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves restart recovery for workers that die during graceful drain. The main changes are:

- Marks drain-time dead workers as restart-resumable when their worktree is still present.
- Keeps dead checkpoint markers inactive while the old daemon is still draining.
- Lets the replacement daemon resume checkpointed running or dead sessions in the same slot and worktree.
- Verifies live tmux adoption with both pane PID and worktree identity.
- Adds tests for drain-boundary recovery, retry preservation, and foreign tmux pane handling.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are narrowly scoped to restart and drain recovery, preserve existing fallback behavior, and include focused regression coverage.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- We built the Maestro binary successfully, with exit code 0.
- We ran the orchestrator tests; they completed with PASS and ok and exited with code 0.
- We ran the daemon and supervisor tests; both packages reported ok and exited with code 0.

<a href="https://app.greptile.com/trex/runs/14922438/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Extends restart-resume reconciliation for dead drain checkpoints, transient retry preservation, and tmux worktree identity checks. |
| internal/orchestrator/restart_resume_test.go | Adds regression tests for drain-time worker death, dead checkpoint replay after restart, and foreign live tmux pane rejection. |
| internal/worker/checkpoint.go | Exposes tmux pane PID and current worktree identity for safer restart adoption. |

<sub>Reviews (2): Last reviewed commit: ["fix: validate tmux identity before resta..."](https://github.com/befeast/maestro/commit/92d9c5164ac18a1b9837b144489f83830c55f083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45255115)</sub>

<!-- /greptile_comment -->