### PR TITLE
fix: terminalize closed sessions without delivery

### DIFF
--- a/internal/orchestrator/closed_unmerged_reconcile_test.go
+++ b/internal/orchestrator/closed_unmerged_reconcile_test.go
@@ -65,6 +65,63 @@ func TestReconcileFalseDoneSessionRefusesAmbiguousOpenPRs(t *testing.T) {
 	}
 }
 
+func TestReconcileUnscheduledDeadSessionAdoptsSoleOpenPR(t *testing.T) {
+	repo := newReconcileBranchRepo(t)
+	canonicalBranch := "feat/ok-player-345-flatpak-beta-retry"
+	runReconcileGit(t, repo, "switch", "-c", canonicalBranch)
+	finished := time.Now().UTC().Add(-time.Minute)
+	s := state.NewState()
+	s.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406,
+		Status:      state.StatusDead,
+		Branch:      "feat/ok-player-302-406-synthetic",
+		Worktree:    repo,
+		FinishedAt:  &finished,
+	}
+	o := &Orchestrator{
+		hasMergedPRForIssueFn: func(int) (bool, error) { return false, nil },
+		isIssueClosedFn:       func(int) (bool, error) { return false, nil },
+	}
+
+	o.reconcileTerminalSessionsWithOpenPRs(s, []github.PR{{
+		Number:      388,
+		HeadRefName: canonicalBranch,
+		Title:       "Flatpak continuation",
+		Body:        "Refs #406",
+	}})
+
+	sess := s.Sessions["ok-player-302"]
+	if sess.Status != state.StatusPROpen || sess.PRNumber != 388 || sess.Branch != canonicalBranch {
+		t.Fatalf("reconciled session = %+v, want pr_open on existing PR #388", sess)
+	}
+	if sess.Worktree != repo || sess.FinishedAt != nil {
+		t.Fatalf("canonical worktree/timing changed: worktree=%q finished=%v", sess.Worktree, sess.FinishedAt)
+	}
+}
+
+func TestReconcileDeadSessionWithPendingRetryDoesNotAdoptOpenPR(t *testing.T) {
+	retryAt := time.Now().UTC().Add(time.Minute)
+	s := state.NewState()
+	s.Sessions["slot"] = &state.Session{
+		IssueNumber: 406,
+		Status:      state.StatusDead,
+		Branch:      "synthetic",
+		NextRetryAt: &retryAt,
+	}
+	o := &Orchestrator{}
+
+	o.reconcileTerminalSessionsWithOpenPRs(s, []github.PR{{
+		Number:      388,
+		HeadRefName: "canonical",
+		Body:        "Refs #406",
+	}})
+
+	sess := s.Sessions["slot"]
+	if sess.Status != state.StatusDead || sess.PRNumber != 0 || sess.NextRetryAt == nil {
+		t.Fatalf("pending retry was consumed by PR adoption: %+v", sess)
+	}
+}
+
 func TestReconcileDoneSessionKeepsAuthoritativeMergedOutcome(t *testing.T) {
 	s := state.NewState()
 	s.Sessions["slot"] = &state.Session{IssueNumber: 345, Status: state.StatusDone, PRNumber: 389}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4807,7 +4807,7 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 			if repairIssueSessionActive(sess.Status) || (sess.PRNumber == canonical.Number && sess.Status == state.StatusRetryExhausted) {
 				activeOther = slotName
 			}
-			if (sess.Status == state.StatusDone || sess.Status == state.StatusFailed) &&
+			if terminalOpenPRAdoptionCandidate(sess) &&
 				(sess.PRNumber == canonical.Number || sess.LastClosedPRNumber == canonical.Number || sess.Branch == canonical.HeadRefName) {
 				exactSlots = append(exactSlots, slotName)
 			}
@@ -4839,7 +4839,7 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 			continue
 		}
 		sess := s.Sessions[candidateSlot]
-		if sess == nil || (sess.Status != state.StatusDone && sess.Status != state.StatusFailed) {
+		if !terminalOpenPRAdoptionCandidate(sess) {
 			continue
 		}
 		merged := false
@@ -4893,6 +4893,27 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 		sess.ReleasedForRedispatch = false
 		o.attachPreservedSiblingHandoffs(s, issue, candidateSlot, sess, canonical, allSlots)
 		log.Printf("[orch] reconciled terminal session %s for issue #%d: closed/unavailable PR #%d replaced by sole open canonical PR #%d on branch %s", candidateSlot, sess.IssueNumber, oldPR, canonical.Number, canonical.HeadRefName)
+	}
+}
+
+// terminalOpenPRAdoptionCandidate reports whether authoritative GitHub state
+// may rebind this non-running session to the sole open PR that references its
+// issue. An unscheduled dead session is eligible: the worker may have pushed to
+// an existing PR branch that differs from the synthetic session branch before
+// exiting. A dead session with NextRetryAt is deliberately excluded because it
+// still owns a pending in-place retry; flipping it to pr_open would consume the
+// retry without running the repair (#758).
+func terminalOpenPRAdoptionCandidate(sess *state.Session) bool {
+	if sess == nil {
+		return false
+	}
+	switch sess.Status {
+	case state.StatusDone, state.StatusFailed:
+		return true
+	case state.StatusDead:
+		return sess.NextRetryAt == nil
+	default:
+		return false
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6157,6 +6157,28 @@ func (o *Orchestrator) canMarkDoneForOutcome(s *state.State, sess *state.Session
 	if status.HealthState == outcome.HealthHealthy {
 		return true
 	}
+	// #970: project-wide outcome drift only gates a session that owns a merged
+	// product revision. A closed/cancelled issue with no discoverable merged PR
+	// has nothing left to deploy or live-verify; retaining its prior dead/failed
+	// status forever makes a reconciled issue dominate Fleet operator_state and
+	// hold a resumable-worktree claim indefinitely. The project outcome remains
+	// independently visible and actionable, but this no-delivery session may
+	// become terminal. Conversely, a merged revision discovered only through the
+	// branch/issue link must still enter code_landed and remain held here.
+	if sess != nil {
+		prNumber, err := o.mergedPRForDoneLikeSession(sess)
+		if err != nil {
+			log.Printf("[orch] %s, but merged delivery identity could not be verified while outcome health is %s: %v — holding out of done", trigger, status.HealthState, err)
+			return false
+		}
+		if prNumber <= 0 {
+			log.Printf("[orch] %s with no merged delivery identity; project outcome health is %s but does not keep this session non-terminal", trigger, status.HealthState)
+			return true
+		}
+		if sess.Status != state.StatusCodeLanded || sess.PRNumber != prNumber {
+			o.markCodeLanded(sess, prNumber)
+		}
+	}
 	issue := 0
 	if sess != nil {
 		issue = sess.IssueNumber

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6090,19 +6090,19 @@ func (o *Orchestrator) mergedPRForDoneLikeSession(sess *state.Session) (int, err
 			return sess.PRNumber, nil
 		}
 	}
+	if sess.LastClosedPRNumber > 0 && sess.LastClosedPRNumber != sess.PRNumber {
+		merged, err := o.isPRMerged(sess.LastClosedPRNumber)
+		if err != nil {
+			return 0, fmt.Errorf("check recorded closed PR #%d: %w", sess.LastClosedPRNumber, err)
+		}
+		if merged {
+			return sess.LastClosedPRNumber, nil
+		}
+	}
 	if branch := strings.TrimSpace(sess.Branch); branch != "" {
 		prNumber, err := o.mergedPRForBranch(branch)
 		if err != nil {
 			return 0, fmt.Errorf("check merged PR for branch %q: %w", branch, err)
-		}
-		if prNumber > 0 {
-			return prNumber, nil
-		}
-	}
-	if sess.IssueNumber > 0 {
-		prNumber, err := o.mergedPRForIssue(sess.IssueNumber)
-		if err != nil {
-			return 0, fmt.Errorf("check merged PR for issue #%d: %w", sess.IssueNumber, err)
 		}
 		if prNumber > 0 {
 			return prNumber, nil
@@ -6164,7 +6164,7 @@ func (o *Orchestrator) canMarkDoneForOutcome(s *state.State, sess *state.Session
 	// hold a resumable-worktree claim indefinitely. The project outcome remains
 	// independently visible and actionable, but this no-delivery session may
 	// become terminal. Conversely, a merged revision discovered only through the
-	// branch/issue link must still enter code_landed and remain held here.
+	// recorded PR/branch link must still enter code_landed and remain held here.
 	if sess != nil {
 		prNumber, err := o.mergedPRForDoneLikeSession(sess)
 		if err != nil {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5871,7 +5871,10 @@ func TestCheckSessions_ClosedNoDeliveryIssueBecomesDoneWhenProjectOutcomeFails(t
 			return 0, nil
 		},
 		mergedPRForIssueFn: func(issueNumber int) (int, error) {
-			return 0, nil
+			// A prior lifecycle of this issue shipped PR #77 before the issue was
+			// reopened. That historical issue-level link must not be attributed to
+			// this later no-delivery session.
+			return 77, nil
 		},
 		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
 			t.Fatalf("terminal reconciliation must preserve the retained worktree; workerStopFn must not run")
@@ -5927,12 +5930,7 @@ func TestCheckSessions_ClosedMergedIssueRemainsCodeLandedWhenProjectOutcomeFails
 		notifier:        &notify.Notifier{},
 		listOpenPRsFn:   func() ([]github.PR, error) { return nil, nil },
 		isIssueClosedFn: func(issueNumber int) (bool, error) { return true, nil },
-		mergedPRForIssueFn: func(issueNumber int) (int, error) {
-			if issueNumber != 100 {
-				t.Fatalf("merged PR lookup issue = %d, want 100", issueNumber)
-			}
-			return 77, nil
-		},
+		isPRMergedFn:    func(prNumber int) (bool, error) { return prNumber == 77, nil },
 	}
 
 	s := state.NewState()
@@ -5943,10 +5941,11 @@ func TestCheckSessions_ClosedMergedIssueRemainsCodeLandedWhenProjectOutcomeFails
 		Summary:   "live verifier failed",
 	}
 	s.Sessions["pan-10"] = &state.Session{
-		IssueNumber: 100,
-		IssueTitle:  "merged worker",
-		Status:      state.StatusFailed,
-		FinishedAt:  &now,
+		IssueNumber:        100,
+		IssueTitle:         "merged worker",
+		Status:             state.StatusFailed,
+		LastClosedPRNumber: 77,
+		FinishedAt:         &now,
 	}
 
 	o.checkSessions(s)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5843,8 +5843,13 @@ func TestCheckSessions_FailedClosedIssue_TransitionsToDone(t *testing.T) {
 	}
 }
 
-func TestCheckSessions_ClosedIssueDoesNotBecomeDoneWhenOutcomePassRequiredFails(t *testing.T) {
+func TestCheckSessions_ClosedNoDeliveryIssueBecomesDoneWhenProjectOutcomeFails(t *testing.T) {
 	now := time.Now().UTC()
+	worktree := t.TempDir()
+	preserved := filepath.Join(worktree, "preserved.txt")
+	if err := os.WriteFile(preserved, []byte("completed work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	o := &Orchestrator{
 		cfg: &config.Config{
 			Repo:              "owner/repo",
@@ -5862,8 +5867,14 @@ func TestCheckSessions_ClosedIssueDoesNotBecomeDoneWhenOutcomePassRequiredFails(
 		isIssueClosedFn: func(issueNumber int) (bool, error) {
 			return true, nil
 		},
+		mergedPRForBranchFn: func(branch string) (int, error) {
+			return 0, nil
+		},
+		mergedPRForIssueFn: func(issueNumber int) (int, error) {
+			return 0, nil
+		},
 		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
-			t.Fatalf("workerStopFn should not run before outcome verification passes")
+			t.Fatalf("terminal reconciliation must preserve the retained worktree; workerStopFn must not run")
 			return nil
 		},
 	}
@@ -5880,14 +5891,69 @@ func TestCheckSessions_ClosedIssueDoesNotBecomeDoneWhenOutcomePassRequiredFails(
 		IssueTitle:  "failed worker",
 		Status:      state.StatusFailed,
 		Branch:      "feat/pan-10-100-failed",
+		Worktree:    worktree,
 		FinishedAt:  &now,
 	}
 
 	o.checkSessions(s)
 
 	sess := s.Sessions["pan-10"]
-	if sess.Status != state.StatusFailed {
-		t.Fatalf("status = %q, want %q until live verification passes", sess.Status, state.StatusFailed)
+	if sess.Status != state.StatusDone {
+		t.Fatalf("status = %q, want %q: no merged revision is owned by this closed issue", sess.Status, state.StatusDone)
+	}
+	if sess.Branch != "feat/pan-10-100-failed" {
+		t.Fatalf("branch = %q, want retained branch unchanged", sess.Branch)
+	}
+	if sess.Worktree != worktree {
+		t.Fatalf("worktree = %q, want retained %q", sess.Worktree, worktree)
+	}
+	if _, err := os.Stat(preserved); err != nil {
+		t.Fatalf("retained work disappeared: %v", err)
+	}
+}
+
+func TestCheckSessions_ClosedMergedIssueRemainsCodeLandedWhenProjectOutcomeFails(t *testing.T) {
+	now := time.Now().UTC()
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:              "owner/repo",
+			MaxRuntimeMinutes: 120,
+			Outcome: outcome.Brief{
+				DesiredOutcome:      "Live app works",
+				VerifierCommand:     "check-live",
+				PassRequiredForDone: boolPtr(true),
+			},
+		},
+		notifier:        &notify.Notifier{},
+		listOpenPRsFn:   func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn: func(issueNumber int) (bool, error) { return true, nil },
+		mergedPRForIssueFn: func(issueNumber int) (int, error) {
+			if issueNumber != 100 {
+				t.Fatalf("merged PR lookup issue = %d, want 100", issueNumber)
+			}
+			return 77, nil
+		},
+	}
+
+	s := state.NewState()
+	s.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: now,
+		State:     outcome.HealthFailing,
+		Signal:    "verifier_command",
+		Summary:   "live verifier failed",
+	}
+	s.Sessions["pan-10"] = &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "merged worker",
+		Status:      state.StatusFailed,
+		FinishedAt:  &now,
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["pan-10"]
+	if sess.Status != state.StatusCodeLanded || sess.PRNumber != 77 {
+		t.Fatalf("session = status %q PR #%d, want code_landed PR #77 until live verification passes", sess.Status, sess.PRNumber)
 	}
 }
 


### PR DESCRIPTION
## Summary

- let a closed/cancelled no-delivery session become terminal even when project-wide outcome health is failing
- keep merged revisions at `code_landed` until delivery/outcome verification passes
- preserve retained worktrees and branch identity during terminal state reconciliation

## Live root cause

OK Player issue #401 is closed, but its no-PR session `ok-player-300` remained `dead` and dominated Fleet operator state because the global outcome gate applied even though this session owns no pending product revision. The project outcome is already represented independently.

## Verification

- `go test ./internal/orchestrator -run 'TestCheckSessions_Closed(NoDeliveryIssueBecomesDoneWhenProjectOutcomeFails|MergedIssueRemainsCodeLandedWhenProjectOutcomeFails)' -count=1`
- `go test ./internal/orchestrator -count=1`
- `go test ./internal/server ./internal/daemon ./internal/supervisor -count=1`
- `go build ./cmd/maestro/`

Refs #970.

Urgent Maestro-only break-fix during the active OK Player hands-off soak. No OK Player code or project concurrency setting changed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates orchestrator handling for closed sessions without delivery. The main changes are:

- Allows closed or cancelled no-delivery sessions to become `done` even when project outcome health is failing.
- Keeps sessions with a discovered merged PR at `code_landed` until delivery and outcome verification pass.
- Lets unscheduled dead sessions adopt a sole open PR while preserving pending retries, branch identity, and retained worktrees.
- Adds regression tests for no-delivery closure, merged-delivery gating, dead-session PR adoption, and pending-retry exclusion.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are narrowly scoped to terminal reconciliation and outcome gating. Tests cover the new no-delivery, merged-delivery, dead-session adoption, and pending-retry behavior. No correctness or security issues were identified in the changed paths reviewed.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused orchestrator test for TestCheckSessions\_Closed(NoDeliveryIssueBecomesDoneWhenProjectOutcomeFails|MergedIssueRemainsCodeLandedWhenProjectOutcomeFails) and confirmed it exited with code 0.
- Validated broader contract coverage by running the orchestrator tests, the affected-package tests, and the maestro build, all exiting with code 0.
- Archived and attached five log artifacts capturing the test runs for reviewer inspection.
- Cross-checked the reported exit codes and confirmed that all tests reported success based on the proofs provided.

<a href="https://app.greptile.com/trex/runs/14925622/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Updates terminal/open-PR reconciliation and outcome gating so no-delivery closed sessions can become done while merged delivery identities are held at code_landed. |
| internal/orchestrator/orchestrator_test.go | Adds coverage for closed no-delivery sessions bypassing project-wide outcome failure and merged sessions remaining code_landed under the same condition. |
| internal/orchestrator/closed_unmerged_reconcile_test.go | Adds reconciliation tests for unscheduled dead-session open PR adoption and pending-retry exclusion. |

<sub>Reviews (3): Last reviewed commit: ["fix: reconcile dead sessions to existing..."](https://github.com/befeast/maestro/commit/840aecc228c173ebe07fc1fa4c8e55b563c3b737) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45260715)</sub>

<!-- /greptile_comment -->