### PR TITLE
fix: recover unexpected worker exits within the orchestrator cycle

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3362,6 +3362,11 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 
 		oldPID := sess.PID
 		oldTmux := tmuxName
+		// Evaluate retry capacity while this attempt is still Running. Once the
+		// status becomes Dead, FailedAttemptsForIssue includes this session; adding
+		// sess.RetryCount after that would count the same exit twice and suppress
+		// the first recovery when max_retries_per_issue is 1.
+		unexpectedRetryAllowed := strings.TrimSpace(sess.Worktree) != "" && o.canRetryIssue(s, sess)
 		o.updateTokensUsedFromWorkerLog(slotName, sess)
 		sess.Status = state.StatusDead
 		sess.PID = 0
@@ -3380,7 +3385,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 				sess.RestartCheckpointAt = &stamp
 				log.Printf("[orch] reconcile: %s died during drain — retained worktree marked for exact in-place restart resume", slotName)
 			}
-		} else if strings.TrimSpace(sess.Worktree) != "" && o.canRetryIssue(s, sess) {
+		} else if unexpectedRetryAllowed {
 			if _, statErr := os.Stat(sess.Worktree); statErr == nil {
 				// Unexpected process loss used to become an unscheduled dead
 				// session. Dead sessions are outside the material-progress watchdog,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2152,6 +2152,18 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 				slotName, sess.IssueNumber, sess.IssueTitle)
 			continue
 		}
+		// A saved retry is not authority to bypass the issue's current dispatch
+		// guards. The issue may have gained `blocked` (or another configured
+		// exclude label) while the worker ran or while the retry waited. Preserve
+		// the canonical session/worktree and re-check next cycle; never consume
+		// the retry into a forbidden or duplicate worker.
+		if github.HasLabel(issue, o.cfg.ExcludeLabels) {
+			retryAt := time.Now().UTC().Add(time.Minute)
+			sess.NextRetryAt = &retryAt
+			log.Printf("[orch] worker %s retry deferred until %s: issue #%d has a current excluded label",
+				slotName, retryAt.Format(time.RFC3339), sess.IssueNumber)
+			continue
+		}
 
 		promptBase := o.selectPrompt(issue)
 
@@ -3367,6 +3379,20 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 				stamp := now
 				sess.RestartCheckpointAt = &stamp
 				log.Printf("[orch] reconcile: %s died during drain — retained worktree marked for exact in-place restart resume", slotName)
+			}
+		} else if strings.TrimSpace(sess.Worktree) != "" && o.canRetryIssue(s, sess) {
+			if _, statErr := os.Stat(sess.Worktree); statErr == nil {
+				// Unexpected process loss used to become an unscheduled dead
+				// session. Dead sessions are outside the material-progress watchdog,
+				// so recovery waited for a later supervisor cycle and could exceed
+				// the 10-minute SLA. Reserve an immediate bounded retry here;
+				// respawnDueRetries runs in this same orchestrator cycle and reuses
+				// the exact slot/branch/worktree after re-checking GitHub guards.
+				retryAt := now
+				sess.RetryCount++
+				sess.RetryReason = state.RetryReasonStalledProgress
+				sess.NextRetryAt = &retryAt
+				log.Printf("[orch] reconcile: %s scheduled immediate canonical in-place retry %d after unexpected worker exit", slotName, sess.RetryCount)
 			}
 		}
 		reconciled = true

--- a/internal/orchestrator/restart_resume_test.go
+++ b/internal/orchestrator/restart_resume_test.go
@@ -133,6 +133,9 @@ func TestReconcile_DrainDeathResumesDeadCheckpointAfterRestart(t *testing.T) {
 	if sess.Status != state.StatusDead || sess.RestartCheckpointAt == nil {
 		t.Fatalf("drain-time state = status %q marker %v, want dead with restart marker", sess.Status, sess.RestartCheckpointAt)
 	}
+	if sess.NextRetryAt != nil {
+		t.Fatalf("drain-time death must wait for replacement-daemon resume, got ordinary retry %v", sess.NextRetryAt)
+	}
 	if resumeCount != 0 {
 		t.Fatalf("old draining daemon resumed %d workers, want 0", resumeCount)
 	}

--- a/internal/orchestrator/unexpected_exit_retry_test.go
+++ b/internal/orchestrator/unexpected_exit_retry_test.go
@@ -26,9 +26,11 @@ func TestUnexpectedWorkerExitSchedulesImmediateCanonicalRetry(t *testing.T) {
 	respawned := 0
 	o := &Orchestrator{
 		cfg: &config.Config{
-			Repo:               "owner/repo",
-			StateDir:           t.TempDir(),
-			MaxRetriesPerIssue: 3,
+			Repo:     "owner/repo",
+			StateDir: t.TempDir(),
+			// One allowed retry must still recover the first unexpected exit; the
+			// current running attempt must not be counted twice.
+			MaxRetriesPerIssue: 1,
 		},
 		repo:                 "owner/repo",
 		notifier:             &notify.Notifier{},

--- a/internal/orchestrator/unexpected_exit_retry_test.go
+++ b/internal/orchestrator/unexpected_exit_retry_test.go
@@ -1,0 +1,130 @@
+package orchestrator
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// A process that disappears without a PR used to become Dead without a
+// NextRetryAt. Because dead sessions are not material-progress watchdog
+// targets, the session then waited for a later supervisor repair cycle and the
+// live OK Player incident exceeded the ten-minute recovery SLA. The 60-second
+// orchestrator pass must reserve and execute one bounded retry in the same
+// canonical slot/worktree instead.
+func TestUnexpectedWorkerExitSchedulesImmediateCanonicalRetry(t *testing.T) {
+	worktree := t.TempDir()
+	if out, err := exec.Command("git", "init", "-b", "main", worktree).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	respawned := 0
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:               "owner/repo",
+			StateDir:           t.TempDir(),
+			MaxRetriesPerIssue: 3,
+		},
+		repo:                 "owner/repo",
+		notifier:             &notify.Notifier{},
+		promptBase:           "test prompt",
+		pidAliveFn:           func(int) bool { return false },
+		tmuxSessionExistsFn:  func(string) bool { return false },
+		listOpenPRsFn:        func() ([]github.PR, error) { return nil, nil },
+		remoteBranchExistsFn: func(string) (bool, error) { return false, nil },
+		isIssueClosedFn:      func(int) (bool, error) { return false, nil },
+		getIssueFn:           func(number int) (github.Issue, error) { return makeIssue(number, "recover me"), nil },
+		respawnInPlaceFn: func(_ *config.Config, slot string, sess *state.Session, _ string, issue github.Issue, _, _ string) error {
+			respawned++
+			if slot != "ok-player-302" || issue.Number != 406 {
+				t.Fatalf("respawn identity = %s/#%d, want ok-player-302/#406", slot, issue.Number)
+			}
+			if sess.Worktree != worktree || sess.Branch != "feat/ok-player-302-406-recover" {
+				t.Fatalf("canonical identity changed: worktree=%q branch=%q", sess.Worktree, sess.Branch)
+			}
+			sess.Status = state.StatusRunning
+			sess.PID = 5555
+			sess.TmuxSession = "maestro-ok-player-302"
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	s.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406,
+		IssueTitle:  "recover me",
+		Status:      state.StatusRunning,
+		PID:         4242,
+		TmuxSession: "maestro-ok-player-302",
+		Branch:      "feat/ok-player-302-406-recover",
+		Worktree:    worktree,
+		Backend:     "sol",
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("dead process was not reconciled")
+	}
+	sess := s.Sessions["ok-player-302"]
+	if sess.Status != state.StatusDead || sess.NextRetryAt == nil {
+		t.Fatalf("reconciled state = %q retry=%v, want dead with immediate retry", sess.Status, sess.NextRetryAt)
+	}
+	if sess.RetryCount != 1 || sess.RetryReason != state.RetryReasonStalledProgress {
+		t.Fatalf("retry metadata = count %d reason %q", sess.RetryCount, sess.RetryReason)
+	}
+	if sess.NextRetryAt.After(time.Now().UTC()) {
+		t.Fatalf("retry scheduled in the future: %s", sess.NextRetryAt)
+	}
+	if !s.IssueInProgress(406) {
+		t.Fatal("scheduled canonical retry must retain the issue dispatch lease")
+	}
+
+	// This is Step 2b of the same orchestrator cycle.
+	o.respawnDueRetries(s, 1)
+	if respawned != 1 {
+		t.Fatalf("in-place respawn count = %d, want 1", respawned)
+	}
+	if sess.Status != state.StatusRunning || sess.PID != 5555 {
+		t.Fatalf("resumed state = status %q pid %d", sess.Status, sess.PID)
+	}
+}
+
+func TestDueRetryDefersWhenIssueGainsExcludedLabel(t *testing.T) {
+	respawned := false
+	past := time.Now().UTC().Add(-time.Second)
+	o := &Orchestrator{
+		cfg:             &config.Config{Repo: "owner/repo", ExcludeLabels: []string{"blocked"}},
+		repo:            "owner/repo",
+		notifier:        &notify.Notifier{},
+		promptBase:      "test prompt",
+		isIssueClosedFn: func(int) (bool, error) { return false, nil },
+		getIssueFn: func(number int) (github.Issue, error) {
+			return makeIssue(number, "blocked after exit", "blocked"), nil
+		},
+		respawnWorkerFn: func(*config.Config, string, *state.Session, string, github.Issue, string, string) error {
+			respawned = true
+			return nil
+		},
+	}
+	s := state.NewState()
+	sess := &state.Session{
+		IssueNumber: 407,
+		IssueTitle:  "blocked after exit",
+		Status:      state.StatusDead,
+		RetryCount:  1,
+		NextRetryAt: &past,
+	}
+	s.Sessions["ok-player-303"] = sess
+
+	o.respawnDueRetries(s, 1)
+	if respawned {
+		t.Fatal("excluded issue must not consume delayed retry authority")
+	}
+	if sess.Status != state.StatusDead || sess.NextRetryAt == nil || !sess.NextRetryAt.After(time.Now().UTC()) {
+		t.Fatalf("blocked retry state = status %q retry=%v, want preserved deferred retry", sess.Status, sess.NextRetryAt)
+	}
+}


### PR DESCRIPTION
## Summary

- schedule a bounded retry immediately when a running worker disappears without a PR
- preserve the existing slot, branch, and worktree through the retry path
- re-check current excluded labels before consuming delayed retry authority
- keep graceful drain recovery isolated from ordinary crash retry

## Live incident

OK Player issue #406 / slot ok-player-302 died at 00:40:10 UTC and was recovered only at 00:52:17 UTC through the later supervisor cycle. The 12m07s latency violated the 10-minute hands-off SLA because dead sessions are absent from material-progress watchdog targets.

## Validation

- go test ./internal/orchestrator ./internal/supervisor ./internal/daemon ./internal/server ./internal/state
- go build ./cmd/maestro/

Continues #940.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates orchestrator retry handling for unexpected worker exits. The main changes are:

- Schedule an immediate bounded retry when a running worker disappears without opening a PR.
- Preserve the existing slot, branch, and worktree through the retry path.
- Re-check current excluded labels before retry respawn.
- Keep graceful drain recovery separate from ordinary crash retry behavior.
- Add regression tests for immediate retry, excluded-label deferral, and drain isolation.

<h3>Confidence Score: 5/5</h3>

This PR appears safe to merge with low risk.

The changes are localized to retry scheduling and preserve existing recovery behavior. The added tests cover the main new paths. No verified functional or security issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the package suite; internal/orchestrator, internal/supervisor, internal/daemon, internal/server, and internal/state all reported ok and finished with exit code 0.
- Executed the CLI build; there was no compiler output and it finished with exit code 0.
- Ran the focused orchestrator tests; tests such as TestUnexpectedWorkerExitSchedulesImmediateCanonicalRetry, TestReconcile\_RestartCheckpoint\_ResumesInPlaceExactlyOnce, TestReconcile\_DrainDeathResumesDeadCheckpointAfterRestart, and TestRespawnDueRetries\_StalledProgressResumesExactWorktreeInPlace passed, ending with PASS and exit code 0.

<a href="https://app.greptile.com/trex/runs/14926012/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds current exclude-label rechecks before due retry respawn and schedules bounded immediate in-place retries for unexpected worker exits. |
| internal/orchestrator/restart_resume_test.go | Extends drain-death restart-resume coverage to assert graceful drain does not schedule ordinary retry state. |
| internal/orchestrator/unexpected_exit_retry_test.go | Adds coverage for immediate canonical retry after unexpected exits and for deferring retries when excluded labels appear. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-785-94..."](https://github.com/befeast/maestro/commit/0333e8058991978d47a3f614fd95b19b2b64ac98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45262987)</sub>

<!-- /greptile_comment -->