### PR TITLE
fix: skip settled sessions in supervisor PR scans

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1711,6 +1711,9 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *re
 		if sess == nil {
 			continue
 		}
+		if !sessionCanStillBlockProgress(sess.Status) {
+			continue
+		}
 		if e.sessionResolvedOnGitHub(sess, cache) {
 			continue
 		}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -930,6 +930,40 @@ func TestDecide_ClosedPRWithActiveSessionExplained(t *testing.T) {
 	}
 }
 
+func TestDetectPRStuckStates_SkipsSettledSessionsBeforeRemoteResolution(t *testing.T) {
+	reader := &fakeReader{}
+	eng := testEngine(testConfig(t), reader)
+	st := state.NewState()
+	st.Sessions["done-slot"] = &state.Session{
+		IssueNumber: 101,
+		Status:      state.StatusDone,
+		PRNumber:    201,
+	}
+	st.Sessions["landed-slot"] = &state.Session{
+		IssueNumber: 102,
+		Status:      state.StatusCodeLanded,
+		PRNumber:    202,
+	}
+
+	findings := eng.detectPRStuckStates(st, nil, newResolutionCache(eng.reader))
+
+	if len(findings) != 0 {
+		t.Fatalf("settled sessions produced PR stuck findings: %#v", findings)
+	}
+	if got := reader.mergedPRCalls[201]; got != 0 {
+		t.Fatalf("done session PR remote-resolution calls = %d, want 0", got)
+	}
+	if got := reader.mergedPRCalls[202]; got != 0 {
+		t.Fatalf("code_landed session PR remote-resolution calls = %d, want 0", got)
+	}
+	if got := reader.closedIssueCalls[101]; got != 0 {
+		t.Fatalf("done session issue remote-resolution calls = %d, want 0", got)
+	}
+	if got := reader.closedIssueCalls[102]; got != 0 {
+		t.Fatalf("code_landed session issue remote-resolution calls = %d, want 0", got)
+	}
+}
+
 func TestDecide_FailingChecksExplained(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{


### PR DESCRIPTION
Follow-up for #940.

The supervisor PR-stuck detector called GitHub remote-resolution for every historical session before checking whether its status could still block progress. On large project histories this caused recurring `gh api` fan-out and host load even after the orchestrator terminal polling was bounded in #975.

This change filters `done` and `code_landed` sessions before remote resolution while preserving checks for running, open-PR, queued, failed, dead, and retry-exhausted sessions.

Tests:
- `go test ./internal/supervisor`
- `umask 0022; go test -p 1 ./...`
- `go build ./cmd/maestro/`

Refs #940

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces unnecessary GitHub remote checks during supervisor PR stuck-state scans. The main changes are:

- Skips sessions that can no longer block progress before resolving PR or issue state remotely.
- Preserves stuck-state checks for running, open-PR, queued, failed, dead, and retry-exhausted sessions.
- Adds a test confirming `done` and `code_landed` sessions do not trigger remote PR or issue resolution.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow, reuses the existing blocking-status predicate, and includes tests for the intended remote-call avoidance.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the full supervisor log to verify the end-to-end run completed with exit code 0.
- Reviewed the targeted supervisor PR/stuck session log to confirm PASS for PR/session/stuck tests and exit code 0.
- Reviewed the Maestro Go build log to confirm a successful build and exit code 0.

<a href="https://app.greptile.com/trex/runs/14928421/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds an early session status filter before GitHub remote resolution in PR stuck-state detection. |
| internal/supervisor/supervisor_test.go | Adds coverage confirming settled sessions skip remote PR and issue resolution. |

<sub>Reviews (1): Last reviewed commit: ["fix: skip settled sessions in supervisor..."](https://github.com/befeast/maestro/commit/7b794f120cc01a20230bec6ad82ccd7ccbe6e9d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45268692)</sub>

<!-- /greptile_comment -->