### PR TITLE
fix: bound historical delivery reconciliation

### DIFF
--- a/internal/orchestrator/delivery_test.go
+++ b/internal/orchestrator/delivery_test.go
@@ -453,7 +453,16 @@ func TestReconcileCodeLandedSessions_RecoversExternalMergeAndWaitsForDelivery(t 
 		},
 	}
 	o := newDeliveryOrch(cfg)
-	o.isPRMergedFn = func(pr int) (bool, error) { return pr == 7, nil }
+	mergedReads := 0
+	mergeInfoReads := 0
+	o.isPRMergedFn = func(pr int) (bool, error) {
+		mergedReads++
+		return pr == 7, nil
+	}
+	o.ghPRMergeInfoFn = func(int) (github.PRMergeInfo, error) {
+		mergeInfoReads++
+		return github.PRMergeInfo{SHA: deliveryMergeSHA, MergedAt: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)}, nil
+	}
 	s := state.NewState()
 	sess := &state.Session{IssueNumber: 42, PRNumber: 7, Status: state.StatusCodeLanded}
 	s.Sessions["slot"] = sess
@@ -465,6 +474,22 @@ func TestReconcileCodeLandedSessions_RecoversExternalMergeAndWaitsForDelivery(t 
 	approvals := deployApprovals(s)
 	if len(approvals) != 1 || approvals[0].Status != state.ApprovalStatusPending {
 		t.Fatalf("standing reconcile did not recover pending delivery: %+v", approvals)
+	}
+	if mergedReads != 1 || mergeInfoReads != 2 {
+		t.Fatalf("initial delivery reconciliation reads merged=%d info=%d, want 1/2", mergedReads, mergeInfoReads)
+	}
+
+	// An unchanged pending approval is checked from durable state without
+	// re-reading GitHub until the bounded terminal reconciliation is due.
+	o.reconcileCodeLandedSessions(s)
+	if mergedReads != 1 || mergeInfoReads != 2 {
+		t.Fatalf("immediate repeated delivery reconciliation reads merged=%d info=%d, want still 1/2", mergedReads, mergeInfoReads)
+	}
+	due := time.Now().UTC().Add(-terminalReconcileInterval - time.Second)
+	sess.LastTerminalReconcileAt = &due
+	o.reconcileCodeLandedSessions(s)
+	if mergedReads != 2 || mergeInfoReads != 4 {
+		t.Fatalf("due delivery reconciliation reads merged=%d info=%d, want 2/4", mergedReads, mergeInfoReads)
 	}
 
 	// Simulate the shared executor's verified terminal row mirrored into state.
@@ -479,6 +504,9 @@ func TestReconcileCodeLandedSessions_RecoversExternalMergeAndWaitsForDelivery(t 
 	}
 	if sess.Status != state.StatusDone {
 		t.Fatalf("status = %q, want done after verified delivery", sess.Status)
+	}
+	if mergedReads != 2 || mergeInfoReads != 4 {
+		t.Fatalf("verified mirror triggered remote reads merged=%d info=%d, want still 2/4", mergedReads, mergeInfoReads)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6048,10 +6048,23 @@ func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 	// from closing while the matching delivery is pending or unverified.
 	ready := make([]*state.Session, 0, len(codeLanded))
 	for _, sess := range codeLanded {
+		now := time.Now().UTC()
+		if !terminalReconcileDue(sess, now) {
+			// Delivery execution is mirrored into project state by the shared
+			// executor. Consume an exact verified mirror immediately without
+			// polling GitHub again; unchanged pending/terminal approvals wait for
+			// the bounded authoritative refresh below (#940).
+			if o.reconcileVerifiedDeliveryFromState(s, sess, o.cfg.EffectiveDelivery()) {
+				ready = append(ready, sess)
+			}
+			continue
+		}
 		if !o.codeLandedPRMerged(sess) {
 			continue
 		}
-		o.ensureMergedPRGateSnapshot(s, sess, time.Now().UTC())
+		checkedAt := time.Now().UTC()
+		sess.LastTerminalReconcileAt = &checkedAt
+		o.ensureMergedPRGateSnapshot(s, sess, checkedAt)
 		if !o.reconcileCodeLandedDelivery(s, sess) {
 			o.syncProject(sess.IssueNumber, github.ProjectStatusLiveVerify)
 			continue
@@ -6101,6 +6114,9 @@ func (o *Orchestrator) reconcileCodeLandedDelivery(s *state.State, sess *state.S
 	if eff.Mode != config.DeliveryModeApprovalRequired || strings.TrimSpace(eff.Command) == "" {
 		return true
 	}
+	if o.reconcileVerifiedDeliveryFromState(s, sess, eff) {
+		return true
+	}
 	if sess == nil || sess.PRNumber <= 0 {
 		log.Printf("[orch] delivery reconcile held: code_landed session has no PR number to pin")
 		return false
@@ -6117,6 +6133,43 @@ func (o *Orchestrator) reconcileCodeLandedDelivery(s *state.State, sess *state.S
 	if completed == nil || completed.Delivery == nil {
 		log.Printf("[orch] delivery reconcile held for PR #%d: approval %s is %s (verified=%v)",
 			sess.PRNumber, approval.ID, approval.Status, approval.Delivery != nil && approval.Delivery.Verified)
+		return false
+	}
+	return o.recordVerifiedDelivery(s, sess, completed)
+}
+
+// reconcileVerifiedDeliveryFromState consumes the exact verified delivery
+// mirror for a code_landed session without any GitHub or repository read. This
+// keeps approval execution responsive while unchanged historical delivery gates
+// use the bounded terminal reconciliation interval instead of polling the forge
+// every orchestrator cycle (#940).
+func (o *Orchestrator) reconcileVerifiedDeliveryFromState(s *state.State, sess *state.Session, eff config.DeliveryConfig) bool {
+	if eff.Mode != config.DeliveryModeApprovalRequired || strings.TrimSpace(eff.Command) == "" {
+		return true
+	}
+	if s == nil || sess == nil || sess.PRNumber <= 0 {
+		return false
+	}
+	digest := eff.ApprovalDigest()
+	var completed *state.Approval
+	for i := range s.Approvals {
+		candidate := &s.Approvals[i]
+		if candidate.Action != state.ApprovalActionDeployProject || candidate.Status != state.ApprovalStatusExecuted ||
+			candidate.Delivery == nil || !candidate.Delivery.Verified || candidate.Delivery.PR != sess.PRNumber ||
+			!strings.EqualFold(strings.TrimSpace(candidate.Delivery.Repo), strings.TrimSpace(o.cfg.Repo)) ||
+			strings.TrimSpace(candidate.Delivery.Project) != strings.TrimSpace(o.cfg.Repo) ||
+			strings.TrimSpace(candidate.Delivery.ConfigDigest) != strings.TrimSpace(digest) {
+			continue
+		}
+		if completed == nil || state.CompareDeliveryGeneration(completed.Delivery, completed.CreatedAt, candidate.Delivery, candidate.CreatedAt) < 0 {
+			completed = candidate
+		}
+	}
+	return o.recordVerifiedDelivery(s, sess, completed)
+}
+
+func (o *Orchestrator) recordVerifiedDelivery(s *state.State, sess *state.Session, completed *state.Approval) bool {
+	if sess == nil || completed == nil || completed.Delivery == nil || !completed.Delivery.Verified {
 		return false
 	}
 	if sess.DeploymentFinishedAt == nil {


### PR DESCRIPTION
Refs #940

Live validation after #975/#978 found a third independent history fan-out: every approval-gated `code_landed` session re-read its merged PR and merge metadata every orchestrator cycle, even when its delivery approval had been rejected, superseded, stale, failed, or remained unchanged. TX10 alone repeated this for PRs #18/#23/#24/#25/#26/#28/#30/#33/#37/#38 each minute.

This change bounds unchanged delivery-gate forge refreshes to the existing nine-minute terminal interval while consuming an exact `executed+verified` durable approval mirror immediately without a remote read. It preserves the ten-minute hands-off contract and does not replay delivery.

Tests:
- focused delivery reconciliation regression with remote-read counters
- `go test ./internal/orchestrator`
- `umask 0022; go test -p 1 ./...`
- `go build ./cmd/maestro/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bounds repeated delivery reconciliation reads for historical `code_landed` sessions. The main changes are:

- Skips unchanged delivery-gate forge refreshes until the terminal reconciliation interval is due.
- Consumes verified delivery approvals from durable state without an extra remote read.
- Adds tests that count merge and merge-info reads across immediate, interval-due, and verified-mirror paths.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the terminal reconcile timestamp handling.

The change is focused and covered by targeted tests, but one contained bug can delay retries after failed delivery reconciliation reads.

`internal/orchestrator/orchestrator.go`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the focused Go regression test for terminal code\_landed reconciliation with injected transient merge-info failures.
- The first reconciliation cycle logged failed PR-gate and delivery merge-info refreshes while stamping LastTerminalReconcileAt.
- The immediate second reconciliation cycle left mergedReads and mergeInfoReads unchanged, showing the failed refresh was not retried because reconciliation was treated as not due.
- Viewed the regression context and after-run logs to verify the counter assertions and test outcomes.

<a href="https://app.greptile.com/trex/runs/14928954/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Bounds code_landed delivery reconciliation and adds state-only verified delivery consumption, but stamps terminal reconciliation before all refresh steps succeed. |
| internal/orchestrator/delivery_test.go | Extends delivery reconciliation tests with remote-read counters for immediate, due, and verified-mirror paths. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:6065-6067
**Avoid stamping failed refreshes**
`LastTerminalReconcileAt` is set before `ensureMergedPRGateSnapshot` and `reconcileCodeLandedDelivery` perform the merge-info or approval refresh. When either read fails, the session records a successful terminal check anyway, so the next cycle skips reconciliation for `terminalReconcileInterval` instead of retrying the failure. This can delay minting or recovering delivery approvals after transient GitHub or ledger errors.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bound historical delivery reconcili..."](https://github.com/befeast/maestro/commit/25607b513e3adfdc262fea8e0265c14f35f4405a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45269624)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->