### PR TITLE
fix: skip settled sessions in open PR selection

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2682,7 +2682,7 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 	var bestMergeReasons []string
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
-		if sess == nil || e.sessionResolvedOnGitHub(sess, cache) {
+		if sess == nil || !sessionCanStillBlockProgress(sess.Status) || e.sessionResolvedOnGitHub(sess, cache) {
 			continue
 		}
 		var pr github.PR

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -964,6 +964,40 @@ func TestDetectPRStuckStates_SkipsSettledSessionsBeforeRemoteResolution(t *testi
 	}
 }
 
+func TestSessionWithOpenPR_SkipsSettledSessionsBeforeRemoteResolution(t *testing.T) {
+	reader := &fakeReader{}
+	eng := testEngine(testConfig(t), reader)
+	st := state.NewState()
+	st.Sessions["done-slot"] = &state.Session{
+		IssueNumber: 101,
+		Status:      state.StatusDone,
+		PRNumber:    201,
+	}
+	st.Sessions["landed-slot"] = &state.Session{
+		IssueNumber: 102,
+		Status:      state.StatusCodeLanded,
+		PRNumber:    202,
+	}
+
+	_, _, _, found, _, _ := eng.sessionWithOpenPR(st, nil, newResolutionCache(eng.reader))
+
+	if found {
+		t.Fatal("settled session was selected as an open-PR candidate")
+	}
+	if got := reader.mergedPRCalls[201]; got != 0 {
+		t.Fatalf("done session PR remote-resolution calls = %d, want 0", got)
+	}
+	if got := reader.mergedPRCalls[202]; got != 0 {
+		t.Fatalf("code_landed session PR remote-resolution calls = %d, want 0", got)
+	}
+	if got := reader.closedIssueCalls[101]; got != 0 {
+		t.Fatalf("done session issue remote-resolution calls = %d, want 0", got)
+	}
+	if got := reader.closedIssueCalls[102]; got != 0 {
+		t.Fatalf("code_landed session issue remote-resolution calls = %d, want 0", got)
+	}
+}
+
 func TestDecide_FailingChecksExplained(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{


### PR DESCRIPTION
Refs #940

Post-deploy validation of #978/#979 caught one remaining historical PR read during the TX10 supervisor pulse: `sessionWithOpenPR` still called remote session resolution before filtering statuses, so `done` and `code_landed` history could not be candidates but still caused GitHub reads.

This applies the existing `sessionCanStillBlockProgress` invariant before remote resolution in that selection path and adds a regression proving settled sessions produce zero PR/issue resolution calls.

Tests:
- focused supervisor regressions
- `go test ./internal/supervisor`
- `umask 0022; go test -p 1 ./...`
- `go build ./cmd/maestro/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR skips settled sessions earlier when selecting open PR work. The main changes are:

- Adds the existing progress-blocking status guard before `sessionWithOpenPR` performs remote GitHub resolution.
- Keeps `done` and `code_landed` sessions out of open-PR candidate selection.
- Adds a regression test that confirms settled sessions make zero PR and issue resolution calls.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge with minimal risk.

The change is narrowly scoped and reuses the existing `sessionCanStillBlockProgress` invariant. The new test directly covers the reported settled-session remote-resolution path.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused -run command to verify the settled-session regression tests; the tests all passed and the process exited with code 0.
- Executed the full supervisor package test suite to validate package-level results; the package tests passed and the process exited with code 0.
- Recorded the execution environment and log capture: commands were run from the project root with timeout wrappers, and logs were saved to the artifacts area for review.

<a href="https://app.greptile.com/trex/runs/14929391/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds the existing progress-blocking status guard before remote GitHub resolution in `sessionWithOpenPR`; no issues found. |
| internal/supervisor/supervisor_test.go | Adds a focused regression confirming settled sessions are neither selected nor remotely resolved; no issues found. |

<sub>Reviews (1): Last reviewed commit: ["fix: skip settled sessions in open PR se..."](https://github.com/befeast/maestro/commit/d0f50521b0bdaa2777a155a5422a7def6e3cef2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45270493)</sub>

<!-- /greptile_comment -->