### PR TITLE
fix: adopt live repair runtimes after state conflicts

### DIFF
--- a/internal/orchestrator/live_runtime_adoption_test.go
+++ b/internal/orchestrator/live_runtime_adoption_test.go
@@ -137,6 +137,7 @@ func TestSaveStatePreservingLiveRuntimeRecoversSameSessionConflict(t *testing.T)
 	run.TmuxSession = "maestro-slot-1"
 	run.StartedAt = now
 	concurrent.Sessions["slot-1"].LastNotifiedStatus = "concurrent-supervisor-observation"
+	concurrent.Sessions["slot-1"].MaintenanceRetryCount = 7
 	concurrent.LastRunOnceAt = now.Add(time.Minute)
 	if err := state.Save(stateDir, concurrent); err != nil {
 		t.Fatal(err)
@@ -158,6 +159,9 @@ func TestSaveStatePreservingLiveRuntimeRecoversSameSessionConflict(t *testing.T)
 	}
 	if got := loaded.Sessions["slot-1"]; got.Status != state.StatusRunning || got.PID != 6262 {
 		t.Fatalf("persisted runtime = %#v", got)
+	}
+	if got := loaded.Sessions["slot-1"].MaintenanceRetryCount; got != 7 {
+		t.Fatalf("concurrent non-runtime session field lost: maintenance_retry_count=%d", got)
 	}
 	if !loaded.LastRunOnceAt.Equal(now.Add(time.Minute)) {
 		t.Fatalf("concurrent heartbeat lost: %s", loaded.LastRunOnceAt)

--- a/internal/orchestrator/live_runtime_adoption_test.go
+++ b/internal/orchestrator/live_runtime_adoption_test.go
@@ -168,4 +168,52 @@ func TestSaveStatePreservingLiveRuntimeRecoversSameSessionConflict(t *testing.T)
 	}
 }
 
+func TestSaveStatePreservingLiveRuntimeDoesNotResurrectNewerStop(t *testing.T) {
+	stateDir := t.TempDir()
+	worktreeBase := t.TempDir()
+	worktree := worktreeBase + "/slot-1"
+	started := time.Date(2026, 7, 18, 2, 45, 0, 0, time.UTC)
+	initial := state.NewState()
+	initial.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42, Worktree: worktree, Branch: "feat/slot-1-42",
+		Status: state.StatusPROpen, PRNumber: 99, Backend: "sol",
+	}
+	if err := state.Save(stateDir, initial); err != nil {
+		t.Fatal(err)
+	}
+	runSnapshot, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopSnapshot, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := runSnapshot.Sessions["slot-1"]
+	run.Status, run.PID, run.TmuxSession, run.StartedAt = state.StatusRunning, 6262, "maestro-slot-1", started
+	stoppedAt := started.Add(time.Second)
+	stopped := stopSnapshot.Sessions["slot-1"]
+	stopped.Status, stopped.PID, stopped.FinishedAt = state.StatusDead, 0, &stoppedAt
+	if err := state.Save(stateDir, stopSnapshot); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &Orchestrator{
+		cfg:                 &config.Config{StateDir: stateDir, WorktreeBase: worktreeBase},
+		tmuxSessionExistsFn: func(string) bool { return true },
+		tmuxPaneIdentityFn:  func(string) (int, string, error) { return 6262, worktree, nil },
+		pidAliveFn:          func(int) bool { return true },
+	}
+	if err := o.saveStatePreservingLiveRuntime(runSnapshot); err == nil {
+		t.Fatal("newer terminal state must win even if pre-lock liveness probe observed the old runtime")
+	}
+	loaded, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := loaded.Sessions["slot-1"]; got.Status != state.StatusDead || got.PID != 0 {
+		t.Fatalf("newer stop was resurrected: %#v", got)
+	}
+}
+
 func ptrTime(v time.Time) *time.Time { return &v }

--- a/internal/orchestrator/live_runtime_adoption_test.go
+++ b/internal/orchestrator/live_runtime_adoption_test.go
@@ -1,0 +1,167 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestReconcileRunningSessionsAdoptsLiveRepairHiddenBehindPROpen(t *testing.T) {
+	now := time.Date(2026, 7, 18, 2, 40, 0, 0, time.UTC)
+	worktree := t.TempDir()
+	s := state.NewState()
+	s.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406,
+		Worktree:    worktree,
+		Branch:      "feat/ok-player-302-406-repair",
+		Status:      state.StatusPROpen,
+		PRNumber:    388,
+		Backend:     "sol",
+		FinishedAt:  ptrTime(now.Add(-time.Hour)),
+		Attribution: []state.BackendAttribution{{Backend: "sol", StartedAt: now.Add(-2 * time.Hour)}},
+	}
+
+	o := &Orchestrator{
+		cfg: &config.Config{Model: config.ModelConfig{Backends: map[string]config.BackendDef{
+			"sol": {Model: "gpt-5.6-sol"},
+		}}},
+		listOpenPRsFn:       func() ([]github.PR, error) { return nil, nil },
+		tmuxSessionExistsFn: func(name string) bool { return name == "maestro-ok-player-302" },
+		tmuxPaneIdentityFn: func(name string) (int, string, error) {
+			return 4242, worktree, nil
+		},
+		pidAliveFn: func(pid int) bool { return pid == 4242 },
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected live hidden repair to be reconciled")
+	}
+	sess := s.Sessions["ok-player-302"]
+	if sess.Status != state.StatusRunning || sess.PID != 4242 || sess.TmuxSession != "maestro-ok-player-302" {
+		t.Fatalf("adopted runtime = status=%s pid=%d tmux=%q", sess.Status, sess.PID, sess.TmuxSession)
+	}
+	if sess.FinishedAt != nil || sess.WorkerEndedAt != nil {
+		t.Fatalf("adopted live runtime retained terminal timestamps: finished=%v ended=%v", sess.FinishedAt, sess.WorkerEndedAt)
+	}
+	if len(sess.Attribution) != 2 || sess.Attribution[1].Reason != "runtime_adoption" {
+		t.Fatalf("attribution = %#v, want appended runtime_adoption segment", sess.Attribution)
+	}
+}
+
+func TestReconcileRunningSessionsRefusesForeignLiveTmux(t *testing.T) {
+	worktree := t.TempDir()
+	s := state.NewState()
+	s.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 1,
+		Worktree:    worktree,
+		Branch:      "feat/slot-1",
+		Status:      state.StatusPROpen,
+	}
+	o := &Orchestrator{
+		cfg:                 &config.Config{},
+		listOpenPRsFn:       func() ([]github.PR, error) { return nil, nil },
+		tmuxSessionExistsFn: func(string) bool { return true },
+		tmuxPaneIdentityFn:  func(string) (int, string, error) { return 4242, t.TempDir(), nil },
+		pidAliveFn:          func(int) bool { return true },
+	}
+
+	if o.reconcileRunningSessions(s) {
+		t.Fatal("foreign tmux must not be adopted")
+	}
+	if got := s.Sessions["slot-1"].Status; got != state.StatusPROpen {
+		t.Fatalf("status = %s, want pr_open", got)
+	}
+}
+
+func TestEnsureAttributionTrailerDefersWhileExactTmuxIsLive(t *testing.T) {
+	worktree := t.TempDir()
+	called := false
+	o := &Orchestrator{
+		cfg:                 &config.Config{},
+		tmuxSessionExistsFn: func(name string) bool { return name == "maestro-slot-1" },
+		tmuxPaneIdentityFn:  func(string) (int, string, error) { return 5151, worktree, nil },
+		amendHeadFn: func(string, string, []state.BackendAttribution, time.Time) error {
+			called = true
+			return nil
+		},
+	}
+	sess := &state.Session{
+		Worktree: worktree,
+		Branch:   "feat/slot-1",
+		Status:   state.StatusPROpen, // persisted status is deliberately stale
+		Attribution: []state.BackendAttribution{{
+			Backend: "sol", StartedAt: time.Now().UTC(),
+		}},
+	}
+
+	if !o.ensureAttributionTrailerOnBranch("slot-1", sess) {
+		t.Fatal("live worker ownership must defer attribution amend")
+	}
+	if called {
+		t.Fatal("attribution amend ran underneath a live worker")
+	}
+}
+
+func TestSaveStatePreservingLiveRuntimeRecoversSameSessionConflict(t *testing.T) {
+	stateDir := t.TempDir()
+	worktreeBase := t.TempDir()
+	worktree := worktreeBase + "/slot-1"
+	now := time.Date(2026, 7, 18, 2, 45, 0, 0, time.UTC)
+	initial := state.NewState()
+	initial.Sessions["slot-1"] = &state.Session{
+		IssueNumber: 42,
+		Worktree:    worktree,
+		Branch:      "feat/slot-1-42",
+		Status:      state.StatusPROpen,
+		PRNumber:    99,
+		Backend:     "sol",
+	}
+	if err := state.Save(stateDir, initial); err != nil {
+		t.Fatal(err)
+	}
+
+	runSnapshot, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	concurrent, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := runSnapshot.Sessions["slot-1"]
+	run.Status = state.StatusRunning
+	run.PID = 6262
+	run.TmuxSession = "maestro-slot-1"
+	run.StartedAt = now
+	concurrent.Sessions["slot-1"].LastNotifiedStatus = "concurrent-supervisor-observation"
+	concurrent.LastRunOnceAt = now.Add(time.Minute)
+	if err := state.Save(stateDir, concurrent); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &Orchestrator{
+		cfg:                 &config.Config{StateDir: stateDir, WorktreeBase: worktreeBase},
+		tmuxSessionExistsFn: func(name string) bool { return name == "maestro-slot-1" },
+		tmuxPaneIdentityFn:  func(string) (int, string, error) { return 6262, worktree, nil },
+		pidAliveFn:          func(pid int) bool { return pid == 6262 },
+	}
+	if err := o.saveStatePreservingLiveRuntime(runSnapshot); err != nil {
+		t.Fatalf("saveStatePreservingLiveRuntime: %v", err)
+	}
+
+	loaded, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := loaded.Sessions["slot-1"]; got.Status != state.StatusRunning || got.PID != 6262 {
+		t.Fatalf("persisted runtime = %#v", got)
+	}
+	if !loaded.LastRunOnceAt.Equal(now.Add(time.Minute)) {
+		t.Fatalf("concurrent heartbeat lost: %s", loaded.LastRunOnceAt)
+	}
+}
+
+func ptrTime(v time.Time) *time.Time { return &v }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3616,6 +3616,12 @@ func (o *Orchestrator) saveStatePreservingLiveRuntime(s *state.State) error {
 					if current == nil || current.IssueNumber != runtime.IssueNumber || strings.TrimSpace(current.Branch) != strings.TrimSpace(runtime.Branch) || filepath.Clean(current.Worktree) != filepath.Clean(runtime.Worktree) {
 						continue
 					}
+					// A stop/reconcile that completed after this runtime began is
+					// authoritative. The pre-lock liveness observation may have
+					// raced that stop, so never resurrect a newer terminal state.
+					if liveRuntimeSuperseded(current, &runtime) {
+						continue
+					}
 					applyLiveRuntimeProjection(current, &runtime)
 				} else {
 					// A fresh spawn can be absent from the concurrently-written
@@ -3650,6 +3656,25 @@ func (o *Orchestrator) saveStatePreservingLiveRuntime(s *state.State) error {
 		return nil
 	}
 	return nil
+}
+
+func liveRuntimeSuperseded(current, runtime *state.Session) bool {
+	if current == nil || runtime == nil {
+		return true
+	}
+	if current.Status == state.StatusDone || current.Status == state.StatusCodeLanded {
+		return true
+	}
+	if current.Status == state.StatusRunning && current.PID > 0 && current.PID != runtime.PID && !current.StartedAt.Before(runtime.StartedAt) {
+		return true
+	}
+	if current.FinishedAt != nil && !current.FinishedAt.Before(runtime.StartedAt) {
+		return true
+	}
+	if current.WorkerEndedAt != nil && !current.WorkerEndedAt.Before(runtime.StartedAt) {
+		return true
+	}
+	return false
 }
 
 // applyLiveRuntimeProjection copies only fields owned by the external worker

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2554,7 +2554,7 @@ func (o *Orchestrator) RunOnce() error {
 	// Persist immediately when reconciliation changes state, so slot calculation
 	// always sees healed state on disk.
 	if reconciled {
-		if err := state.Save(o.cfg.StateDir, s); err != nil {
+		if err := o.saveStatePreservingLiveRuntime(s); err != nil {
 			return fmt.Errorf("save state after reconcile: %w", err)
 		}
 	}
@@ -2622,7 +2622,7 @@ func (o *Orchestrator) RunOnce() error {
 	state.ReconcileBackendHealth(s, time.Now().UTC())
 
 	// Save after all checks/reconciliation
-	if err := state.Save(o.cfg.StateDir, s); err != nil {
+	if err := o.saveStatePreservingLiveRuntime(s); err != nil {
 		return fmt.Errorf("save state: %w", err)
 	}
 
@@ -2641,7 +2641,7 @@ func (o *Orchestrator) RunOnce() error {
 
 	if slots > 0 {
 		o.startNewWorkers(s, slots)
-		if err := state.Save(o.cfg.StateDir, s); err != nil {
+		if err := o.saveStatePreservingLiveRuntime(s); err != nil {
 			return fmt.Errorf("save state after workers: %w", err)
 		}
 	}
@@ -3148,6 +3148,18 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 
 	reconciled := false
 	for slotName, sess := range s.Sessions {
+		// A worker launch is an external side effect: tmux may have accepted it
+		// even when the following state.Save lost a concurrent supervisor/watchdog
+		// merge race. Older code only inspected StatusRunning, so a live in-place
+		// repair hidden behind the previous pr_open/dead projection became invisible
+		// to Fleet and the progress watchdog indefinitely. Recover exact ownership
+		// before the status filter. Done/code_landed are outcome terminals and must
+		// never be reopened merely because an obsolete pane survived.
+		if sess.Status != state.StatusRunning && sess.Status != state.StatusDone && sess.Status != state.StatusCodeLanded {
+			if o.adoptLiveWorkerRuntime(slotName, sess, time.Now().UTC()) {
+				reconciled = true
+			}
+		}
 		isRestartCheckpointedDead := sess.Status == state.StatusDead && sess.RestartCheckpointAt != nil
 		if sess.Status != state.StatusRunning && !isRestartCheckpointedDead {
 			continue
@@ -3519,6 +3531,126 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 	return reconciled
 }
 
+// adoptLiveWorkerRuntime adopts only the deterministic tmux identity belonging
+// to slotName and only when its pane cwd matches the retained worktree exactly.
+// A same-name foreign/unreadable pane is left untouched and is not evidence of
+// ownership. No worker is started or stopped here, so retrying every cycle is
+// idempotent and cannot create a duplicate.
+func (o *Orchestrator) adoptLiveWorkerRuntime(slotName string, sess *state.Session, observedAt time.Time) bool {
+	if sess == nil || strings.TrimSpace(sess.Worktree) == "" {
+		return false
+	}
+	tmuxName := strings.TrimSpace(sess.TmuxSession)
+	if tmuxName == "" {
+		tmuxName = worker.TmuxSessionName(slotName)
+	}
+	if !o.tmuxSessionExists(tmuxName) {
+		return false
+	}
+	pid, paneWorktree, err := o.tmuxPaneIdentity(tmuxName)
+	if err != nil || pid <= 0 {
+		log.Printf("[orch] reconcile: %s has live tmux %q but pane identity is unreadable (%v); refusing unsafe adoption", slotName, tmuxName, err)
+		return false
+	}
+	if filepath.Clean(paneWorktree) != filepath.Clean(sess.Worktree) {
+		log.Printf("[orch] reconcile: %s refusing foreign tmux %q: pane worktree %q != retained worktree %q", slotName, tmuxName, paneWorktree, sess.Worktree)
+		return false
+	}
+	if !o.pidAlive(pid) {
+		log.Printf("[orch] reconcile: %s tmux %q reported dead pane pid %d; refusing adoption", slotName, tmuxName, pid)
+		return false
+	}
+	previous := sess.Status
+	worker.AdoptLiveRuntime(o.cfg, sess, pid, tmuxName, observedAt)
+	log.Printf("[orch] reconcile: %s adopted live worker runtime hidden behind status=%s (issue #%d, pid=%d, tmux=%q, worktree=%q) — no respawn, no duplicate",
+		slotName, previous, sess.IssueNumber, pid, tmuxName, sess.Worktree)
+	return true
+}
+
+// saveStatePreservingLiveRuntime closes the side-effect/state gap around worker
+// launches. A normal three-way Save remains the fast path. If it conflicts on
+// the same session after tmux already accepted a launch, recover only runtime
+// snapshots whose exact deterministic tmux + pane cwd are still live, and
+// overlay those snapshots onto the latest state under state.Update's lock.
+//
+// Other concurrent supervisor/watchdog fields stay authoritative. This does
+// not retry a spawn and cannot create a process; it merely prevents a proven
+// live worker from becoming invisible because its post-launch Save lost a CAS
+// race. All other conflicting mutations remain fail-closed for the next cycle.
+func (o *Orchestrator) saveStatePreservingLiveRuntime(s *state.State) error {
+	if err := state.Save(o.cfg.StateDir, s); err != nil {
+		if !errors.Is(err, state.ErrStateConflict) {
+			return err
+		}
+		originalErr := err
+		live := make(map[string]state.Session)
+		for slotName, sess := range s.Sessions {
+			if sess == nil || sess.Status != state.StatusRunning || strings.TrimSpace(sess.Worktree) == "" {
+				continue
+			}
+			tmuxName := strings.TrimSpace(sess.TmuxSession)
+			if tmuxName == "" {
+				tmuxName = worker.TmuxSessionName(slotName)
+			}
+			if !o.tmuxSessionExists(tmuxName) {
+				continue
+			}
+			pid, paneWorktree, identityErr := o.tmuxPaneIdentity(tmuxName)
+			if identityErr != nil || pid <= 0 || !o.pidAlive(pid) || filepath.Clean(paneWorktree) != filepath.Clean(sess.Worktree) {
+				continue
+			}
+			copy := *sess
+			copy.PID = pid
+			copy.TmuxSession = tmuxName
+			live[slotName] = copy
+		}
+		if len(live) == 0 {
+			return originalErr
+		}
+
+		adopted := 0
+		updateErr := state.Update(o.cfg.StateDir, func(latest *state.State) error {
+			for slotName, runtime := range live {
+				current, exists := latest.Sessions[slotName]
+				if exists {
+					if current == nil || current.IssueNumber != runtime.IssueNumber || strings.TrimSpace(current.Branch) != strings.TrimSpace(runtime.Branch) || filepath.Clean(current.Worktree) != filepath.Clean(runtime.Worktree) {
+						continue
+					}
+				} else {
+					// A fresh spawn can be absent from the concurrently-written
+					// snapshot. Only accept its deterministic slot worktree; never
+					// attach an arbitrary tmux pane/path as a new session.
+					expected := filepath.Join(o.cfg.WorktreeBase, slotName)
+					if filepath.Clean(runtime.Worktree) != filepath.Clean(expected) {
+						continue
+					}
+				}
+				copy := runtime
+				latest.Sessions[slotName] = &copy
+				adopted++
+			}
+			if adopted == 0 {
+				return state.ErrNoStateChange
+			}
+			return nil
+		})
+		if updateErr != nil {
+			return fmt.Errorf("%w (live-runtime recovery: %v)", originalErr, updateErr)
+		}
+		if adopted == 0 {
+			return originalErr
+		}
+		latest, loadErr := state.Load(o.cfg.StateDir)
+		if loadErr != nil {
+			return fmt.Errorf("reload after preserving %d live runtime(s): %w", adopted, loadErr)
+		}
+		*s = *latest
+		log.Printf("[orch] state conflict recovered by preserving %d exact live worker runtime(s); concurrent supervisor/watchdog fields retained", adopted)
+		return nil
+	}
+	return nil
+}
+
 // reconcilePushedBranch handles a stale running session whose worker died
 // after pushing its branch. Outcomes, in order (#800):
 //
@@ -3661,6 +3793,25 @@ Maestro auto-created this pull request for pushed branch %s because no open pull
 func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *state.Session) (deferred bool) {
 	if sess == nil || len(sess.Attribution) == 0 {
 		return false
+	}
+	// Runtime ownership is stronger evidence than the persisted status. A
+	// repair worker can already be live while a concurrent state write still
+	// shows pr_open/PID=0. Never amend/force-push underneath that agent: doing so
+	// rewrites HEAD while it is editing, testing, or pushing. We intentionally
+	// fail closed even when pane identity is unreadable or foreign; a live exact
+	// tmux name is enough uncertainty to forbid a branch mutation this cycle.
+	tmuxName := strings.TrimSpace(sess.TmuxSession)
+	if tmuxName == "" {
+		tmuxName = worker.TmuxSessionName(slotName)
+	}
+	if o.tmuxSessionExists(tmuxName) {
+		pid, paneWorktree, identityErr := o.tmuxPaneIdentity(tmuxName)
+		if identityErr == nil && pid > 0 && filepath.Clean(paneWorktree) == filepath.Clean(sess.Worktree) {
+			log.Printf("[orch] attribution: deferring amend for %s (live worker owns branch %q via pid=%d tmux=%q)", slotName, sess.Branch, pid, tmuxName)
+		} else {
+			log.Printf("[orch] attribution: deferring amend for %s (tmux %q is live but ownership is not safely readable: pid=%d worktree=%q err=%v)", slotName, tmuxName, pid, paneWorktree, identityErr)
+		}
+		return true
 	}
 	err := o.amendHeadWithAttributionTrailer(sess.Worktree, sess.Branch, sess.Attribution, time.Now().UTC())
 	if err == nil {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3616,6 +3616,7 @@ func (o *Orchestrator) saveStatePreservingLiveRuntime(s *state.State) error {
 					if current == nil || current.IssueNumber != runtime.IssueNumber || strings.TrimSpace(current.Branch) != strings.TrimSpace(runtime.Branch) || filepath.Clean(current.Worktree) != filepath.Clean(runtime.Worktree) {
 						continue
 					}
+					applyLiveRuntimeProjection(current, &runtime)
 				} else {
 					// A fresh spawn can be absent from the concurrently-written
 					// snapshot. Only accept its deterministic slot worktree; never
@@ -3624,9 +3625,9 @@ func (o *Orchestrator) saveStatePreservingLiveRuntime(s *state.State) error {
 					if filepath.Clean(runtime.Worktree) != filepath.Clean(expected) {
 						continue
 					}
+					copy := runtime
+					latest.Sessions[slotName] = &copy
 				}
-				copy := runtime
-				latest.Sessions[slotName] = &copy
 				adopted++
 			}
 			if adopted == 0 {
@@ -3649,6 +3650,41 @@ func (o *Orchestrator) saveStatePreservingLiveRuntime(s *state.State) error {
 		return nil
 	}
 	return nil
+}
+
+// applyLiveRuntimeProjection copies only fields owned by the external worker
+// launch/attempt. Concurrent supervisor fields on the same session (review
+// observations, retry accounting, PR identity, etc.) remain on current. This
+// narrow overlay is the critical distinction between recovering process truth
+// and replaying an entire stale orchestrator snapshot after a CAS conflict.
+func applyLiveRuntimeProjection(current, runtime *state.Session) {
+	if current == nil || runtime == nil {
+		return
+	}
+	current.PID = runtime.PID
+	current.TmuxSession = runtime.TmuxSession
+	current.LogFile = runtime.LogFile
+	current.StartedAt = runtime.StartedAt
+	current.FinishedAt = runtime.FinishedAt
+	current.WorkerEndedAt = runtime.WorkerEndedAt
+	current.Status = state.StatusRunning
+	current.Backend = runtime.Backend
+	current.Model = runtime.Model
+	current.CostUSDBackend = runtime.CostUSDBackend
+	current.UsageTokensWatermark = runtime.UsageTokensWatermark
+	current.TokensUsedAttempt = runtime.TokensUsedAttempt
+	current.WorkerOutcome = runtime.WorkerOutcome
+	current.Attribution = append([]state.BackendAttribution(nil), runtime.Attribution...)
+	current.NextRetryAt = runtime.NextRetryAt
+	current.RestartCheckpointAt = runtime.RestartCheckpointAt
+	current.LastOutputHash = runtime.LastOutputHash
+	current.LastOutputChangedAt = runtime.LastOutputChangedAt
+	current.LastNotifiedStatus = runtime.LastNotifiedStatus
+	current.NotifiedCIFail = runtime.NotifiedCIFail
+	if runtime.BackendSelection != nil {
+		selection := *runtime.BackendSelection
+		current.BackendSelection = &selection
+	}
 }
 
 // reconcilePushedBranch handles a stale running session whose worker died

--- a/internal/worker/attribution.go
+++ b/internal/worker/attribution.go
@@ -31,6 +31,30 @@ func beginSessionAttempt(cfg *config.Config, sess *state.Session, backendName, r
 	recordBackendAttribution(cfg, sess, backendName, reason, previousEndReason, now)
 }
 
+// AdoptLiveRuntime repairs the persisted runtime projection after a worker
+// process was started successfully but the state write that followed lost a
+// concurrent compare-and-merge race. The caller must first prove the exact
+// tmux session, pane PID, and worktree identity; this function deliberately
+// performs no process discovery of its own.
+//
+// Adoption starts a new observable attempt at the time Maestro recovered
+// ownership. That is an honest lower bound for worker_runtime and avoids
+// reusing terminal timestamps/token watermarks from the attempt whose state
+// was stranded. Issue, worktree, branch, and PR identity stay unchanged.
+func AdoptLiveRuntime(cfg *config.Config, sess *state.Session, pid int, tmuxName string, observedAt time.Time) {
+	if sess == nil || pid <= 0 || tmuxName == "" {
+		return
+	}
+	beginSessionAttempt(cfg, sess, sess.Backend, "runtime_adoption", "runtime_state_lost", observedAt)
+	sess.PID = pid
+	sess.TmuxSession = tmuxName
+	sess.NextRetryAt = nil
+	sess.RestartCheckpointAt = nil
+	sess.LastNotifiedStatus = ""
+	sess.LastOutputHash = ""
+	sess.LastOutputChangedAt = time.Time{}
+}
+
 // recordBackendAttribution appends a new BackendAttribution segment to
 // sess.Attribution and closes the previous one's EndedAt + EndReason.
 // Called from every place that sets sess.Backend (Start, Respawn,


### PR DESCRIPTION
## Summary
- adopt exact live tmux repair runtimes when persisted session state is stale
- preserve proven live runtime projections when a post-launch state save loses a concurrent CAS race
- forbid attribution branch amendments while any exact worker tmux remains live

## Live incident
OK Player sessions `ok-player-299`, `ok-player-302`, and `ok-player-305` have real advancing model processes in their retained worktrees, while Fleet reports `pr_open`, `PID=0`, and `workers_running=0`. Attribution reconciliation then rewrote a live repair branch underneath its agent.

## Safety
- exact deterministic tmux name + pane PID + exact pane cwd/worktree are all required
- no worker is spawned, stopped, or restarted by adoption
- done/code_landed sessions are never reopened
- foreign/unreadable tmux identity fails closed
- `max_parallel` and project configuration are untouched

## Tests
- `umask 0022 && go test ./...`
- `go build ./cmd/maestro/`

Refs #940

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates runtime recovery for stale Maestro session state. The main changes are:

- Adopts exact live tmux worker runtimes when persisted session status is stale.
- Preserves live runtime projections after state-save conflicts.
- Defers attribution branch amendments while a matching live worker tmux is present.
- Adds tests for runtime adoption, foreign tmux refusal, attribution deferral, and conflict recovery.

<h3>Confidence Score: 4/5</h3>

This change has one contained state-merge bug that should be fixed before relying on the recovery path.

The runtime adoption checks are narrow and covered by tests, but the conflict recovery path can still drop concurrent notification state by replaying stale fields from the losing snapshot.

internal/orchestrator/orchestrator.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the stale runtime projection scenario that overwrites supervisor notification fields by running a focused Go test.
- Observed in the verbose test output that LastNotifiedStatus changed from 'concurrent-supervisor-observation' to '' and NotifiedCIFail flipped from true to false, and the test failed with an assertion about the overwrite.
- Captured the runtime environment details showing Go 1.25.0, module path, and PATH state to support reproducibility.
- Ran the full Go test plan and confirmed all packages passed with EXIT\_CODE: 0, validating the standard test run path used in the PR.
- Verified the maestro build command completed successfully with EXIT\_CODE: 0, confirming the build environment is stable for the PR checks.

<a href="https://app.greptile.com/trex/runs/14930413/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds live runtime adoption and CAS-conflict recovery, but the recovery overlay overwrites concurrent notification state. |
| internal/orchestrator/live_runtime_adoption_test.go | Adds coverage for live tmux runtime adoption, foreign tmux refusal, attribution deferral, and conflict recovery. |
| internal/worker/attribution.go | Adds `AdoptLiveRuntime` to reset attempt-scoped worker fields and append a runtime adoption attribution segment. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:3707-3708
**Preserve supervisor fields**
`applyLiveRuntimeProjection` is called after a CAS conflict to overlay only the proven live runtime, but these assignments replay stale notification state from the losing snapshot. In the conflict covered by `TestSaveStatePreservingLiveRuntimeRecoversSameSessionConflict`, a concurrent watchdog or supervisor write to `LastNotifiedStatus` is overwritten by `runtime.LastNotifiedStatus`, often empty, so dedupe and status state is lost.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: let newer worker stops win recovery..."](https://github.com/befeast/maestro/commit/5ba03f6e25c2c287029e2040c94848ec45434264) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45271904)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->