### PR TITLE
fix: keep active PR gate progress truthful

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2150,9 +2150,9 @@ func (c *Client) MergedPRNumberForBranch(branch string) (int, error) {
 }
 
 // PRCheckRollup is a bounded, non-secret identity for the actual current PR
-// head and its CI/check rollup. Fingerprint hashes check names and closed
-// status/conclusion fields only; it never carries descriptions, URLs, output,
-// annotations, paths, or credentials (#887).
+// head and its CI/check rollup. Fingerprint hashes public check-run IDs, names,
+// and closed status/conclusion fields only; it never carries descriptions,
+// URLs, output, annotations, paths, or credentials (#887/#940).
 type PRCheckRollup struct {
 	HeadSHA     string
 	Verdict     string
@@ -2161,7 +2161,9 @@ type PRCheckRollup struct {
 }
 
 // PRCheckRollup returns the current head, normalized aggregate verdict, and a
-// stable digest of individual check/status transitions. When one of GitHub's
+// stable digest of individual check/status transitions and public check-run
+// identities. A manual rerun on the same head therefore advances once instead
+// of looking identical to the exhausted run it replaced. When one of GitHub's
 // two CI sources is unavailable the legacy aggregate verdict still degrades to
 // the source that did answer, but Complete=false and Fingerprint is absent so a
 // partial poll cannot fabricate material progress.
@@ -2196,8 +2198,8 @@ func ciCheckRollupFingerprint(checks []greptileCheckRun, combined combinedStatus
 	parts := make([]string, 0, len(checks)+len(combined.Statuses)+1)
 	parts = append(parts, "combined="+strings.ToLower(strings.TrimSpace(combined.State)))
 	for _, check := range checks {
-		parts = append(parts, fmt.Sprintf("check:%s:%s:%s",
-			strings.TrimSpace(check.Name), strings.ToLower(strings.TrimSpace(check.Status)), strings.ToLower(strings.TrimSpace(check.Conclusion))))
+		parts = append(parts, fmt.Sprintf("check:%d:%s:%s:%s",
+			check.ID, strings.TrimSpace(check.Name), strings.ToLower(strings.TrimSpace(check.Status)), strings.ToLower(strings.TrimSpace(check.Conclusion))))
 	}
 	for _, status := range combined.Statuses {
 		parts = append(parts, fmt.Sprintf("status:%s:%s",

--- a/internal/github/pr_check_rollup_test.go
+++ b/internal/github/pr_check_rollup_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestCICheckRollupFingerprint_IsOrderStableAndSemantic(t *testing.T) {
 	checks := []greptileCheckRun{
-		{Name: "lint", Status: "completed", Conclusion: "success"},
-		{Name: "test", Status: "in_progress"},
+		{ID: 10, Name: "lint", Status: "completed", Conclusion: "success"},
+		{ID: 20, Name: "test", Status: "in_progress"},
 	}
 	combined := combinedStatusResponse{State: "pending"}
 	combined.Statuses = append(combined.Statuses, struct {
@@ -25,6 +25,11 @@ func TestCICheckRollupFingerprint_IsOrderStableAndSemantic(t *testing.T) {
 	green := ciCheckRollupFingerprint(checks, combined)
 	if green == first {
 		t.Fatalf("individual check transition did not change rollup fingerprint: %q", green)
+	}
+	checks[1] = greptileCheckRun{ID: 21, Name: "test", Status: "in_progress"}
+	rerun := ciCheckRollupFingerprint(checks, combined)
+	if rerun == first {
+		t.Fatalf("same-head check rerun did not change rollup fingerprint: %q", rerun)
 	}
 	if len(first) != 16 {
 		t.Fatalf("fingerprint length = %d, want bounded digest", len(first))

--- a/internal/orchestrator/attribution_merge_guard_test.go
+++ b/internal/orchestrator/attribution_merge_guard_test.go
@@ -36,8 +36,8 @@ func mergeGuardSession(branch string, pr int) *state.Session {
 // under a concurrent worker/operator push), autoMergePRs must NOT let the PR
 // reach the merge decision this cycle: merging now would land it permanently
 // without the required Maestro-Backend trailer while the deferral's promised
-// retry never runs. The guard must short-circuit before even querying CI, so a
-// later quiet cycle can stamp the trailer and then merge (#858).
+// retry never runs. CI observation is still safe and required for watchdog
+// truth; a later quiet cycle can stamp the trailer and then merge (#858/#940).
 func TestAutoMergePRs_DeferredAttributionBlocksMerge(t *testing.T) {
 	branch := "feat/sup-858-amend-race"
 	s := state.NewState()
@@ -68,8 +68,8 @@ func TestAutoMergePRs_DeferredAttributionBlocksMerge(t *testing.T) {
 	if merged {
 		t.Fatal("deferred attribution amend must block the merge — ghMergePRFn was called (#858)")
 	}
-	if ciQueried {
-		t.Fatal("deferred attribution amend must short-circuit before the merge flow continues (CI was queried)")
+	if !ciQueried {
+		t.Fatal("deferred attribution amend must still observe CI for watchdog truth")
 	}
 	// The session stays merge-eligible so a later quiet cycle completes it.
 	if s.Sessions["sup-858"].Status != state.StatusPROpen {
@@ -78,8 +78,8 @@ func TestAutoMergePRs_DeferredAttributionBlocksMerge(t *testing.T) {
 }
 
 // An unexpected amend failure is just as unsafe as a known deferral: the
-// trailer is not known to be on the remote, so the merge path must fail closed
-// before querying CI or attempting the merge.
+// trailer is not known to be on the remote, so the merge path must fail closed.
+// Read-only CI observation remains allowed and keeps durable gate state fresh.
 func TestAutoMergePRs_UnexpectedAttributionFailureBlocksMerge(t *testing.T) {
 	branch := "feat/sup-873-amend-error"
 	s := state.NewState()
@@ -110,8 +110,8 @@ func TestAutoMergePRs_UnexpectedAttributionFailureBlocksMerge(t *testing.T) {
 	if merged {
 		t.Fatal("unexpected attribution failure must block the merge")
 	}
-	if ciQueried {
-		t.Fatal("unexpected attribution failure must short-circuit before CI is queried")
+	if !ciQueried {
+		t.Fatal("unexpected attribution failure must still observe CI for watchdog truth")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4917,8 +4917,16 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			// the durable Maestro-Backend trailer, and the deferral's "retry next
 			// cycle" would then have nothing left to amend. Skip it; a later quiet
 			// cycle stamps the trailer and this PR becomes merge-eligible (#858).
-			// ensureAttributionTrailerOnBranch already logged the concise defer
-			// line, so no extra journal noise here.
+			// Attribution is a merge precondition, not an observability precondition.
+			// Keep recording the authoritative current head/check rollup while the
+			// safe amend is deferred; otherwise the watchdog retains an old head and
+			// reports a false stale gate while a rerun is visibly in progress.
+			_, _, gateTransition, gateObservable, observedAt, err := o.observePRGateCI(sess, pr)
+			if err != nil {
+				log.Printf("[orch] CI status for PR #%d while attribution is deferred: %v", pr.Number, err)
+			} else if gateObservable {
+				o.persistPRGateTransition(s, gateTransition, observedAt)
+			}
 			continue
 		}
 
@@ -4930,33 +4938,11 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		// Check the actual current head plus its aggregate and per-check rollup.
 		// The normalized rollup remains the merge gate; the durable snapshot below
 		// additionally hashes individual check transitions (#887).
-		ciRollup, err := o.prCheckRollup(pr.Number)
+		_, ciStatus, gateTransition, gateObservable, observedAt, err := o.observePRGateCI(sess, pr)
 		if err != nil {
 			log.Printf("[orch] CI status for PR #%d: %v", pr.Number, err)
 			continue
 		}
-		ciStatus := ciRollup.Verdict
-
-		// #424: the aggregate PRCIStatus can stick at "pending" long after
-		// every required check has gone green (a common cause is a legacy
-		// commit-status used by some review bots that never resolves).
-		// GitHub's own per-PR mergeable_state encodes the required-check
-		// verdict. Only "clean" may override the stale aggregate. "unstable"
-		// can coexist with explicitly failed check runs (live #397), so treating
-		// it as success can merge known-red work.
-		if ciStatus == "pending" {
-			if mergeable, mergeState, mErr := o.prMergeStatus(pr.Number); mErr == nil && mergeable == "MERGEABLE" {
-				switch mergeState {
-				case "clean":
-					log.Printf("[orch] PR #%d (%s) aggregate CI=pending but mergeable_state=%s — treating as success (#424)", pr.Number, sess.Branch, mergeState)
-					ciStatus = "success"
-				}
-			}
-		}
-
-		log.Printf("[orch] PR #%d (%s) CI=%s", pr.Number, sess.Branch, ciStatus)
-		gateTransition, gateObservable := o.prGateTransitionForCI(sess, pr, ciRollup, ciStatus)
-		observedAt := time.Now().UTC()
 		persistGate := func() {
 			if gateObservable {
 				o.persistPRGateTransition(s, gateTransition, observedAt)

--- a/internal/orchestrator/pr_gate_progress.go
+++ b/internal/orchestrator/pr_gate_progress.go
@@ -47,6 +47,33 @@ func normalizePRGateCIVerdict(value string) state.PRGateCIVerdict {
 	}
 }
 
+// observePRGateCI reads the exact current PR head/check rollup and applies the
+// narrow mergeable-state compatibility rule used by the merge flow. It does
+// not mutate state: callers may enrich the returned transition with review
+// evidence before persisting it, or persist the CI-only observation when a
+// separate merge precondition (such as attribution) is safely deferred.
+func (o *Orchestrator) observePRGateCI(sess *state.Session, pr github.PR) (github.PRCheckRollup, string, state.PRGateTransition, bool, time.Time, error) {
+	ciRollup, err := o.prCheckRollup(pr.Number)
+	if err != nil {
+		return github.PRCheckRollup{}, "", state.PRGateTransition{}, false, time.Time{}, err
+	}
+	ciStatus := ciRollup.Verdict
+
+	// #424: an aggregate can remain pending after every required check is green.
+	// Only GitHub's clean mergeable state may override it; unstable can coexist
+	// with explicitly failed checks and therefore remains pending/failing.
+	if ciStatus == "pending" {
+		if mergeable, mergeState, mergeErr := o.prMergeStatus(pr.Number); mergeErr == nil && mergeable == "MERGEABLE" && mergeState == "clean" {
+			log.Printf("[orch] PR #%d (%s) aggregate CI=pending but mergeable_state=%s — treating as success (#424)", pr.Number, sess.Branch, mergeState)
+			ciStatus = "success"
+		}
+	}
+
+	log.Printf("[orch] PR #%d (%s) CI=%s", pr.Number, sess.Branch, ciStatus)
+	transition, observable := o.prGateTransitionForCI(sess, pr, ciRollup, ciStatus)
+	return ciRollup, ciStatus, transition, observable, time.Now().UTC(), nil
+}
+
 func (o *Orchestrator) persistPRGateTransition(s *state.State, transition state.PRGateTransition, now time.Time) {
 	if s == nil || strings.TrimSpace(transition.HeadSHA) == "" {
 		return

--- a/internal/orchestrator/pr_gate_progress_test.go
+++ b/internal/orchestrator/pr_gate_progress_test.go
@@ -147,6 +147,34 @@ func TestAutoMergePRs_HeadChangeDuringReviewDefersExactSnapshotAndMerge(t *testi
 	}
 }
 
+func TestAutoMergePRs_AttributionDeferralStillObservesCurrentPRGate(t *testing.T) {
+	pr := github.PR{Number: 13, HeadRefName: "feat/deferred-attribution"}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none"}
+	o, merged := newMergeTestOrchestrator(cfg, []github.PR{pr})
+	currentHead := strings.Repeat("c", 40)
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{
+			HeadSHA: currentHead, Verdict: "pending", Fingerprint: strings.Repeat("7", 16), Complete: true,
+		}, nil
+	}
+	o.amendHeadFn = func(string, string, []state.BackendAttribution, time.Time) error {
+		return errAmendDiverged
+	}
+	st := makeTestState([]github.PR{pr})
+	sess := st.Sessions["slot-0"]
+	sess.Attribution = []state.BackendAttribution{{Backend: "sol", StartedAt: time.Now().UTC()}}
+
+	o.autoMergePRs(st)
+
+	snapshot := mustLatestPRGateSnapshot(t, st, sess.IssueNumber, pr.Number)
+	if snapshot.HeadSHA != currentHead || snapshot.CIEffectiveVerdict != state.PRGateCIPending || snapshot.CheckRollupFingerprint != strings.Repeat("7", 16) {
+		t.Fatalf("deferred-attribution snapshot = %+v", snapshot)
+	}
+	if len(*merged) != 0 {
+		t.Fatalf("attribution-deferred PR unexpectedly merged: %v", *merged)
+	}
+}
+
 func mustLatestPRGateSnapshot(t *testing.T, st *state.State, issueNumber, prNumber int) state.PRGateSnapshot {
 	t.Helper()
 	snapshot, ok := st.LatestPRGateSnapshot("owner/repo", issueNumber, prNumber)

--- a/internal/supervisor/material_progress.go
+++ b/internal/supervisor/material_progress.go
@@ -79,8 +79,13 @@ func collectMaterialProgressObservationsForProject(st *state.State, project stri
 	}
 	now = now.UTC()
 	slots := make([]string, 0, len(st.Sessions))
+	livePRs := make(map[int]struct{})
 	for slot := range st.Sessions {
 		slots = append(slots, slot)
+		sess := st.Sessions[slot]
+		if sess != nil && sess.Status == state.StatusRunning && sess.PID > 0 && sess.PRNumber > 0 {
+			livePRs[sess.PRNumber] = struct{}{}
+		}
 	}
 	sort.Strings(slots)
 
@@ -96,6 +101,14 @@ func collectMaterialProgressObservationsForProject(st *state.State, project stri
 				observations = append(observations, observation)
 			}
 		case state.StatusPROpen, state.StatusQueued:
+			// A live continuation/repair worker that owns this exact PR is the
+			// actionable progress target. Keeping the older pr_open session as a
+			// second gate target fabricates an overdue gate while the repair is
+			// actively advancing (OK Player #345/#406, PR #388). The gate becomes
+			// observable again automatically when the worker leaves StatusRunning.
+			if _, ownedByLiveWorker := livePRs[sess.PRNumber]; sess.PRNumber > 0 && ownedByLiveWorker {
+				continue
+			}
 			if observation, ok := prGateProgressObservation(st, project, slot, sess, now); ok {
 				observations = append(observations, observation)
 			}

--- a/internal/supervisor/material_progress_test.go
+++ b/internal/supervisor/material_progress_test.go
@@ -145,6 +145,26 @@ func TestCollectMaterialProgressObservations_QueuedRemainsAnActivePRGate(t *test
 	}
 }
 
+func TestCollectMaterialProgressObservations_LiveWorkerOwnsExactPRGate(t *testing.T) {
+	st := state.NewState()
+	now := time.Date(2026, 7, 18, 3, 0, 0, 0, time.UTC)
+	st.Sessions["old-gate"] = &state.Session{
+		IssueNumber: 345, Status: state.StatusPROpen, PRNumber: 388, StartedAt: now.Add(-time.Hour),
+	}
+	st.Sessions["continuation"] = &state.Session{
+		IssueNumber: 406, Status: state.StatusRunning, PRNumber: 388, PID: 1234, StartedAt: now.Add(-time.Minute),
+	}
+	recordTestPRGateSnapshot(t, st, 345, 388, strings.Repeat("a", 40), now.Add(-time.Hour))
+
+	observations := collectMaterialProgressObservationsForProject(st, "owner/repo", now)
+	if len(observations) != 1 {
+		t.Fatalf("observations = %+v, want only the live continuation", observations)
+	}
+	if observations[0].Target.Kind != progress.TargetWorker || observations[0].Target.IssueNumber != 406 || observations[0].Target.ProcessID != 1234 {
+		t.Fatalf("active target = %+v, want live continuation worker", observations[0].Target)
+	}
+}
+
 func TestCollectMaterialProgressObservations_PartialOrWrongProjectPRSnapshotIsIncomplete(t *testing.T) {
 	st := state.NewState()
 	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## What changed

- continue reading and persisting the authoritative current PR head/check rollup when an attribution-trailer amend is safely deferred;
- include public GitHub check-run IDs in the bounded rollup fingerprint so a same-head rerun advances the durable gate generation once;
- make a live continuation/repair worker the sole watchdog target for an exact PR, suppressing the older duplicate `pr_gate` target until the worker exits.

## Root cause

The merge loop treated attribution deferral as a reason to skip all later read-only PR observations. A diverged or busy branch could therefore leave the durable PR-gate snapshot pinned to an old head while current CI was actively running. Separately, the watchdog collected both an old `pr_open` session and the live continuation worker for the same PR, producing a false overdue gate alongside real worker progress. Same-head check reruns also reused the prior semantic fingerprint because check-run identity was omitted.

## Impact

Fleet Mission Control and the hands-off watchdog now follow the current GitHub gate generation without weakening attribution or merge safety. Active in-place repair remains canonical and does not produce a competing stale gate recommendation.

## Validation

- `go test ./internal/github ./internal/orchestrator ./internal/supervisor`
- `go test ./...`
- `go build ./cmd/maestro/`

Closes part of #940.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps PR-gate progress state aligned with active PR and worker activity. The main changes are:

- Persists current PR head and CI rollup observations even when attribution-trailer amendments are deferred.
- Adds public check-run IDs to the bounded check-rollup fingerprint so same-head reruns advance the gate generation.
- Suppresses stale duplicate PR-gate watchdog targets while an exact live continuation or repair worker owns the same PR.
- Adds tests for attribution deferral, check-rollup reruns, and live-worker watchdog ownership.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped, preserve merge blocking behavior, and add tests for the updated attribution and watchdog flows.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused package tests and confirmed all three targeted packages passed with EXIT\_CODE: 0.
- Ran the full Go test suite and confirmed all module packages passed or had no test files, with EXIT\_CODE: 0.
- Executed go build ./cmd/maestro/ and confirmed it completed with EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14931215/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Refactors auto-merge CI observation through a shared helper and records CI-only gate progress during attribution deferral. |
| internal/orchestrator/pr_gate_progress.go | Adds a non-mutating CI observation helper that applies the existing mergeable-state compatibility rule before producing gate transitions. |
| internal/supervisor/material_progress.go | Suppresses stale PR-gate watchdog targets while an exact live running worker owns the same PR. |
| internal/github/github.go | Adds public check-run IDs to the PR check-rollup fingerprint so same-head reruns produce a new durable gate generation. |

<sub>Reviews (1): Last reviewed commit: ["fix: keep active PR gate progress truthf..."](https://github.com/befeast/maestro/commit/1a4c263092c55c81af1e963aa751700b1ed5655f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45273899)</sub>

<!-- /greptile_comment -->