### PR TITLE
fix: keep one watchdog target per PR

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4921,10 +4921,22 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			// Keep recording the authoritative current head/check rollup while the
 			// safe amend is deferred; otherwise the watchdog retains an old head and
 			// reports a false stale gate while a rerun is visibly in progress.
-			_, _, gateTransition, gateObservable, observedAt, err := o.observePRGateCI(sess, pr)
+			_, ciStatus, gateTransition, gateObservable, observedAt, err := o.observePRGateCI(sess, pr)
 			if err != nil {
 				log.Printf("[orch] CI status for PR #%d while attribution is deferred: %v", pr.Number, err)
 			} else if gateObservable {
+				// Complete the read-only gate observation when CI is green. This
+				// remains merge-inert: attribution still blocks every ready/merge
+				// path, but a successful review must not remain durable "unknown".
+				if ciStatus == "success" {
+					if o.reviewGate() == "none" {
+						addPRGateReviewDisabled(&gateTransition)
+					} else if verdict, reviewErr := o.prReviewGateVerdict(pr.Number); reviewErr != nil {
+						log.Printf("[orch] review gate check PR #%d while attribution is deferred: %v", pr.Number, reviewErr)
+					} else if o.prGateHeadMatches(pr.Number, gateTransition.HeadSHA) {
+						addPRGateReviewVerdict(&gateTransition, verdict)
+					}
+				}
 				o.persistPRGateTransition(s, gateTransition, observedAt)
 			}
 			continue

--- a/internal/orchestrator/pr_gate_progress_test.go
+++ b/internal/orchestrator/pr_gate_progress_test.go
@@ -167,8 +167,36 @@ func TestAutoMergePRs_AttributionDeferralStillObservesCurrentPRGate(t *testing.T
 	o.autoMergePRs(st)
 
 	snapshot := mustLatestPRGateSnapshot(t, st, sess.IssueNumber, pr.Number)
-	if snapshot.HeadSHA != currentHead || snapshot.CIEffectiveVerdict != state.PRGateCIPending || snapshot.CheckRollupFingerprint != strings.Repeat("7", 16) {
+	if snapshot.HeadSHA != currentHead || snapshot.CIEffectiveVerdict != state.PRGateCIPending || snapshot.CheckRollupFingerprint != strings.Repeat("7", 16) || snapshot.ReviewDecision != state.PRGateReviewUnknown {
 		t.Fatalf("deferred-attribution snapshot = %+v", snapshot)
+	}
+	if len(*merged) != 0 {
+		t.Fatalf("attribution-deferred PR unexpectedly merged: %v", *merged)
+	}
+}
+
+func TestAutoMergePRs_AttributionDeferralStillObservesPassingReview(t *testing.T) {
+	pr := github.PR{Number: 14, HeadRefName: "feat/deferred-review"}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "greptile", ReviewGateStreams: []string{"greptile"}}
+	o, merged := newMergeTestOrchestrator(cfg, []github.PR{pr})
+	currentHead := strings.Repeat("d", 40)
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{HeadSHA: currentHead, Verdict: "success", Fingerprint: strings.Repeat("8", 16), Complete: true}, nil
+	}
+	o.ghPRHeadSHAFn = func(int) (string, error) { return currentHead, nil }
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{Passed: true, Streams: []github.ReviewStreamVerdict{{Name: "greptile", Passed: true}}}, nil
+	}
+	o.amendHeadFn = func(string, string, []state.BackendAttribution, time.Time) error { return errAmendDiverged }
+	st := makeTestState([]github.PR{pr})
+	sess := st.Sessions["slot-0"]
+	sess.Attribution = []state.BackendAttribution{{Backend: "sol", StartedAt: time.Now().UTC()}}
+
+	o.autoMergePRs(st)
+
+	snapshot := mustLatestPRGateSnapshot(t, st, sess.IssueNumber, pr.Number)
+	if snapshot.HeadSHA != currentHead || snapshot.CIEffectiveVerdict != state.PRGateCISuccess || snapshot.ReviewDecision != state.PRGateReviewPassed {
+		t.Fatalf("deferred passing-review snapshot = %+v", snapshot)
 	}
 	if len(*merged) != 0 {
 		t.Fatalf("attribution-deferred PR unexpectedly merged: %v", *merged)

--- a/internal/supervisor/material_progress.go
+++ b/internal/supervisor/material_progress.go
@@ -80,11 +80,19 @@ func collectMaterialProgressObservationsForProject(st *state.State, project stri
 	now = now.UTC()
 	slots := make([]string, 0, len(st.Sessions))
 	livePRs := make(map[int]struct{})
+	prGateOwners := make(map[int]string)
 	for slot := range st.Sessions {
 		slots = append(slots, slot)
 		sess := st.Sessions[slot]
 		if sess != nil && sess.Status == state.StatusRunning && sess.PID > 0 && sess.PRNumber > 0 {
 			livePRs[sess.PRNumber] = struct{}{}
+		}
+		if sess == nil || sess.PRNumber <= 0 || (sess.Status != state.StatusPROpen && sess.Status != state.StatusQueued) {
+			continue
+		}
+		ownerSlot, exists := prGateOwners[sess.PRNumber]
+		if !exists || materialProgressGateOwnerPrecedes(slot, sess, ownerSlot, st.Sessions[ownerSlot]) {
+			prGateOwners[sess.PRNumber] = slot
 		}
 	}
 	sort.Strings(slots)
@@ -109,6 +117,13 @@ func collectMaterialProgressObservationsForProject(st *state.State, project stri
 			if _, ownedByLiveWorker := livePRs[sess.PRNumber]; sess.PRNumber > 0 && ownedByLiveWorker {
 				continue
 			}
+			// A PR is one lifecycle gate even when historical/continuation sessions
+			// from different issues reference it. Keep the newest exact session as
+			// the deterministic owner so a completed continuation does not revive a
+			// second overdue target for the same PR.
+			if ownerSlot := prGateOwners[sess.PRNumber]; sess.PRNumber > 0 && ownerSlot != slot {
+				continue
+			}
 			if observation, ok := prGateProgressObservation(st, project, slot, sess, now); ok {
 				observations = append(observations, observation)
 			}
@@ -124,6 +139,22 @@ func collectMaterialProgressObservationsForProject(st *state.State, project stri
 		return observations[i].Target.Key() < observations[j].Target.Key()
 	})
 	return observations
+}
+
+func materialProgressGateOwnerPrecedes(candidateSlot string, candidate *state.Session, currentSlot string, current *state.Session) bool {
+	if candidate == nil {
+		return false
+	}
+	if current == nil || candidate.StartedAt.After(current.StartedAt) {
+		return true
+	}
+	if current.StartedAt.After(candidate.StartedAt) {
+		return false
+	}
+	if candidate.Status != current.Status {
+		return candidate.Status == state.StatusQueued
+	}
+	return candidateSlot < currentSlot
 }
 
 func workerProgressObservation(st *state.State, project, slot string, sess *state.Session, now time.Time) (progress.Observation, bool) {

--- a/internal/supervisor/material_progress_test.go
+++ b/internal/supervisor/material_progress_test.go
@@ -165,6 +165,27 @@ func TestCollectMaterialProgressObservations_LiveWorkerOwnsExactPRGate(t *testin
 	}
 }
 
+func TestCollectMaterialProgressObservations_NewestSessionOwnsSharedPRGate(t *testing.T) {
+	st := state.NewState()
+	now := time.Date(2026, 7, 18, 3, 15, 0, 0, time.UTC)
+	st.Sessions["old-gate"] = &state.Session{
+		IssueNumber: 345, Status: state.StatusPROpen, PRNumber: 388, StartedAt: now.Add(-time.Hour),
+	}
+	st.Sessions["continuation"] = &state.Session{
+		IssueNumber: 406, Status: state.StatusPROpen, PRNumber: 388, StartedAt: now.Add(-time.Minute),
+	}
+	recordTestPRGateSnapshot(t, st, 345, 388, strings.Repeat("a", 40), now.Add(-time.Hour))
+	recordTestPRGateSnapshot(t, st, 406, 388, strings.Repeat("a", 40), now.Add(-time.Minute))
+
+	observations := collectMaterialProgressObservationsForProject(st, "owner/repo", now)
+	if len(observations) != 1 {
+		t.Fatalf("observations = %+v, want one canonical PR gate", observations)
+	}
+	if observations[0].Target.Kind != progress.TargetPRGate || observations[0].Target.IssueNumber != 406 || observations[0].Target.Slot != "continuation" {
+		t.Fatalf("canonical PR target = %+v, want newest continuation", observations[0].Target)
+	}
+}
+
 func TestCollectMaterialProgressObservations_PartialOrWrongProjectPRSnapshotIsIncomplete(t *testing.T) {
 	st := state.NewState()
 	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## What changed

- select one deterministic watchdog owner for each exact PR when multiple historical or continuation sessions reference it;
- prefer a real live worker while it owns the PR, then the newest `pr_open`/`queued` session after the worker finishes;
- complete the read-only review-gate observation while attribution mutation is deferred and CI is green.

## Root cause

The multi-signal collector was session-centric even for PR lifecycle gates. After a continuation worker finished, both the original issue session and the continuation session became independent overdue targets for the same PR. The deferred-attribution path added in #982 refreshed CI and head identity, but intentionally persisted no review observation; a green Greptile result therefore remained durable `unknown`, making the evidence incomplete and preserving the old stalled watermark.

## Impact

One PR now produces one actionable watchdog target, and safe attribution deferral no longer hides a passing/pending/blocked review verdict. Merge safety is unchanged: the attribution precondition still blocks every ready/merge path.

## Validation

- `go test ./internal/orchestrator ./internal/supervisor`
- `go test ./...`
- `go build ./cmd/maestro/`

Refs #940.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates PR gate observation and watchdog ownership behavior. The main changes are:

- Records review-gate results during attribution deferral when CI is green.
- Keeps attribution deferral merge-inert while preserving current gate evidence.
- Selects one deterministic watchdog owner for each PR gate.
- Adds tests for deferred review observation and shared PR-gate ownership.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are narrow and follow existing PR gate and watchdog patterns. Focused tests cover the new deferred-review and PR-gate ownership behavior. No functional or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the requested validation commands and captured stdout and stderr logs for review.
- The focused package tests passed, as shown in the Go test focused log.
- The full Go test suite passed, as shown in the Go test all log.
- The Maestro build completed successfully, as shown in the Maestro build log.
- A helper script named run\_validation.sh was generated to run the validation workflow.

<a href="https://app.greptile.com/trex/runs/14931635/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Records review-gate verdicts during attribution deferral when CI is green while preserving the merge block; no issues found. |
| internal/orchestrator/pr_gate_progress_test.go | Extends attribution-deferral coverage to assert pending reviews stay unknown and passing reviews are observed; no issues found. |
| internal/supervisor/material_progress.go | Deduplicates PR-gate watchdog observations by selecting a deterministic owner per PR while live workers take precedence; no issues found. |
| internal/supervisor/material_progress_test.go | Adds coverage for live-worker ownership and newest-session ownership of shared PR gates; no issues found. |

<sub>Reviews (1): Last reviewed commit: ["fix: keep one watchdog target per PR"](https://github.com/befeast/maestro/commit/ab51cdd2c121328f339cf7e2a5625ef934c47bbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45277668)</sub>

<!-- /greptile_comment -->