### PR TITLE
fix: elect one canonical supervisor owner per PR

### DIFF
--- a/internal/supervisor/material_progress.go
+++ b/internal/supervisor/material_progress.go
@@ -91,7 +91,7 @@ func collectMaterialProgressObservationsForProject(st *state.State, project stri
 			continue
 		}
 		ownerSlot, exists := prGateOwners[sess.PRNumber]
-		if !exists || materialProgressGateOwnerPrecedes(slot, sess, ownerSlot, st.Sessions[ownerSlot]) {
+		if !exists || prSessionOwnerPrecedes(slot, sess, ownerSlot, st.Sessions[ownerSlot]) {
 			prGateOwners[sess.PRNumber] = slot
 		}
 	}
@@ -141,9 +141,14 @@ func collectMaterialProgressObservationsForProject(st *state.State, project stri
 	return observations
 }
 
-func materialProgressGateOwnerPrecedes(candidateSlot string, candidate *state.Session, currentSlot string, current *state.Session) bool {
+func prSessionOwnerPrecedes(candidateSlot string, candidate *state.Session, currentSlot string, current *state.Session) bool {
 	if candidate == nil {
 		return false
+	}
+	candidateLive := candidate.Status == state.StatusRunning && candidate.PID > 0
+	currentLive := current != nil && current.Status == state.StatusRunning && current.PID > 0
+	if candidateLive != currentLive {
+		return candidateLive
 	}
 	if current == nil || candidate.StartedAt.After(current.StartedAt) {
 		return true

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1703,6 +1703,7 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *re
 			}
 		}
 	}
+	canonicalOwners := e.canonicalOpenPROwners(st, byNumber, byBranch, cache)
 
 	var findings []state.SupervisorStuckState
 	seenPRs := make(map[int]struct{})
@@ -1736,6 +1737,9 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *re
 		}
 		if sess.PRNumber == 0 {
 			target.PR = pr.Number
+		}
+		if ownerSlot := canonicalOwners[pr.Number]; ownerSlot != "" && ownerSlot != slot {
+			continue
 		}
 		if _, ok := seenPRs[pr.Number]; ok {
 			continue
@@ -2669,6 +2673,7 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 		branchToPR[pr.HeadRefName] = pr
 		numberToPR[pr.Number] = pr
 	}
+	canonicalOwners := e.canonicalOpenPROwners(st, numberToPR, branchToPR, cache)
 	// Attention states must not sit behind an ordinary open PR merely because
 	// its slot sorts earlier. This is especially important when the earlier PR
 	// is intentionally blocked for QA: a later conflict_failed/retry_exhausted
@@ -2694,6 +2699,9 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 			pr, found = numberToPR[sess.PRNumber]
 		}
 		if !found {
+			continue
+		}
+		if ownerSlot := canonicalOwners[pr.Number]; ownerSlot != "" && ownerSlot != slot {
 			continue
 		}
 		// Evaluate merge eligibility across the whole candidate set before
@@ -4164,6 +4172,36 @@ func openPRForSession(sess *state.Session, byNumber map[int]github.PR, byBranch 
 		}
 	}
 	return github.PR{}, false
+}
+
+// canonicalOpenPROwners elects one actionable session identity for each open
+// PR. Historical issue/session rows can legitimately remain after an in-place
+// continuation or repair, but they must not compete with the continuation in
+// stuck-state, operator-state, or repair selection. A live worker wins while it
+// is advancing the PR; otherwise the newest unresolved session owns the gate.
+func (e *Engine) canonicalOpenPROwners(st *state.State, byNumber map[int]github.PR, byBranch map[string]github.PR, cache *resolutionCache) map[int]string {
+	owners := make(map[int]string)
+	if st == nil {
+		return owners
+	}
+	for _, slot := range sortedSessionNames(st) {
+		sess := st.Sessions[slot]
+		if sess == nil || !sessionCanStillBlockProgress(sess.Status) || e.sessionResolvedOnGitHub(sess, cache) {
+			continue
+		}
+		if sess.Status == state.StatusRetryExhausted && e.retryExhaustedSessionSupersededByIssueProgress(st, sess) {
+			continue
+		}
+		pr, found := openPRForSession(sess, byNumber, byBranch)
+		if !found {
+			continue
+		}
+		ownerSlot, exists := owners[pr.Number]
+		if !exists || prSessionOwnerPrecedes(slot, sess, ownerSlot, st.Sessions[ownerSlot]) {
+			owners[pr.Number] = slot
+		}
+	}
+	return owners
 }
 
 func sessionCanStillBlockProgress(status state.SessionStatus) bool {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -998,6 +998,76 @@ func TestSessionWithOpenPR_SkipsSettledSessionsBeforeRemoteResolution(t *testing
 	}
 }
 
+func TestDetectPRStuckStates_SharedPRUsesNewestContinuationSession(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "greptile"
+	cfg.AutoRetryReviewFeedback = true
+	reader := &fakeReader{
+		prs:        []github.PR{{Number: 388, HeadRefName: "feat/shared-pr", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{388: "success"},
+		greptileOK: map[int]bool{388: false},
+	}
+	eng := testEngine(cfg, reader)
+	st := state.NewState()
+	st.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345, Status: state.StatusPROpen, PRNumber: 388, Branch: "feat/shared-pr",
+		StartedAt: time.Date(2026, 7, 17, 20, 0, 0, 0, time.UTC),
+	}
+	st.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406, Status: state.StatusPROpen, PRNumber: 388, Branch: "feat/shared-pr",
+		StartedAt: time.Date(2026, 7, 18, 2, 0, 0, 0, time.UTC),
+	}
+
+	findings := eng.detectPRStuckStates(st, reader.prs, newResolutionCache(eng.reader))
+
+	if len(findings) != 1 {
+		t.Fatalf("findings = %#v, want one canonical PR finding", findings)
+	}
+	if findings[0].Code != "greptile_not_approved" || findings[0].Target == nil {
+		t.Fatalf("finding = %#v, want Greptile finding with target", findings[0])
+	}
+	if findings[0].Target.Issue != 406 || findings[0].Target.Session != "ok-player-302" || findings[0].Target.PR != 388 {
+		t.Fatalf("target = %#v, want continuation issue #406 / ok-player-302 / PR #388", findings[0].Target)
+	}
+}
+
+func TestDecide_SharedPRRepairUsesNewestUnblockedContinuation(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.MaxParallel = 20
+	cfg.ExcludeLabels = []string{"blocked"}
+	cfg.ReviewGate = "greptile"
+	cfg.AutoRetryReviewFeedback = true
+	reader := &fakeReader{
+		issues: []github.Issue{
+			testIssue(345, "historical issue", "blocked"),
+			testIssue(406, "continuation", "maestro-ready"),
+		},
+		prs:        []github.PR{{Number: 388, HeadRefName: "feat/shared-pr", State: "OPEN", Mergeable: "MERGEABLE"}},
+		ciStatuses: map[int]string{388: "success"},
+		greptileOK: map[int]bool{388: false},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345, Status: state.StatusPROpen, PRNumber: 388, Branch: "feat/shared-pr",
+		StartedAt: time.Date(2026, 7, 17, 20, 0, 0, 0, time.UTC),
+	}
+	st.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406, Status: state.StatusPROpen, PRNumber: 388, Branch: "feat/shared-pr",
+		StartedAt: time.Date(2026, 7, 18, 2, 0, 0, 0, time.UTC),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnRepairWorker {
+		t.Fatalf("action = %q, want %q; summary=%q", decision.RecommendedAction, ActionSpawnRepairWorker, decision.Summary)
+	}
+	if decision.Target == nil || decision.Target.Issue != 406 || decision.Target.Session != "ok-player-302" || decision.Target.PR != 388 {
+		t.Fatalf("target = %#v, want unblocked continuation issue #406 / ok-player-302 / PR #388", decision.Target)
+	}
+}
+
 func TestDecide_FailingChecksExplained(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{


### PR DESCRIPTION
Fixes the shared-PR identity defect found during #940 soak.

When historical and continuation sessions reference the same open PR, supervisor stuck-state and action selection now elect one canonical owner: a live worker first, otherwise the newest unresolved session. This prevents an old blocked issue from suppressing repair for its unblocked continuation.

Tests:
- `go test ./internal/supervisor`
- `go test ./...`
- `go build ./cmd/maestro/`

Refs #940

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR chooses one canonical supervisor owner when multiple sessions reference the same open PR. The main changes are:

- Shared PR ownership now prefers a live worker, then the newest unresolved session.
- Supervisor stuck-state detection and open-PR action selection now skip non-canonical historical sessions.
- Material-progress gate ownership now uses the same PR session precedence helper.
- Tests cover shared-PR stuck-state targeting and repair selection for continuation sessions.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow, reuses the same ownership helper across the affected supervisor paths, and includes tests for the key shared-PR continuation behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the maestro build log to validate the build command, Go version, output, and exit status.
- Reviewed the supervisor test log to verify the prioritized supervisor package test command ran in the expected context with the correct Go version and a valid exit status.
- Reviewed the all-go-tests log to confirm the full Go test suite ran and produced per-package results and an exit status.

<a href="https://app.greptile.com/trex/runs/14932387/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/material_progress.go | Updates PR gate ownership to prefer live workers and otherwise the newest PR gate session. |
| internal/supervisor/supervisor.go | Adds canonical open-PR owner election and applies it to stuck-state and action selection. |
| internal/supervisor/supervisor_test.go | Adds tests for shared-PR continuation ownership in stuck-state and repair decisions. |

<sub>Reviews (1): Last reviewed commit: ["fix: elect one canonical supervisor owne..."](https://github.com/befeast/maestro/commit/4d8baf5e53852cea4d7248a9b74319e696e0fe90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45279020)</sub>

<!-- /greptile_comment -->