### PR TITLE
fix: keep live PR workers out of gate selection

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1741,6 +1741,15 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *re
 		if ownerSlot := canonicalOwners[pr.Number]; ownerSlot != "" && ownerSlot != slot {
 			continue
 		}
+		// A live worker is already the actuator for this exact PR. Reporting the
+		// same review/CI gate as a separate stuck target makes Fleet claim the
+		// active repair is blocked and lets it head-of-line block another PR that
+		// has no worker. Worker silence is tracked independently by the bounded
+		// material-progress watchdog; only return this PR to gate supervision
+		// after the worker leaves the running state.
+		if sess.Status == state.StatusRunning && sess.PID > 0 {
+			continue
+		}
 		if _, ok := seenPRs[pr.Number]; ok {
 			continue
 		}
@@ -2702,6 +2711,13 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 			continue
 		}
 		if ownerSlot := canonicalOwners[pr.Number]; ownerSlot != "" && ownerSlot != slot {
+			continue
+		}
+		// Do not spend the project's single supervisor recommendation monitoring
+		// a PR that already has a live exact worker. This preserves parallel
+		// hands-off repair: another independent overdue PR can be selected now,
+		// while the worker watchdog remains responsible for the running attempt.
+		if sess.Status == state.StatusRunning && sess.PID > 0 {
 			continue
 		}
 		// Evaluate merge eligibility across the whole candidate set before

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1068,6 +1068,59 @@ func TestDecide_SharedPRRepairUsesNewestUnblockedContinuation(t *testing.T) {
 	}
 }
 
+func TestDecide_LivePRWorkerDoesNotBlockIndependentGateRepair(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.MaxParallel = 20
+	cfg.ReviewGate = "greptile"
+	cfg.AutoRetryReviewFeedback = true
+	reader := &fakeReader{
+		issues: []github.Issue{
+			testIssue(406, "active repair", "maestro-ready"),
+			testIssue(412, "independent gate", "maestro-ready"),
+		},
+		prs: []github.PR{
+			{Number: 388, HeadRefName: "feat/active-repair", State: "OPEN", Mergeable: "MERGEABLE"},
+			{Number: 413, HeadRefName: "feat/independent-gate", State: "OPEN", Mergeable: "MERGEABLE"},
+		},
+		ciStatuses: map[int]string{388: "success", 413: "success"},
+		greptileOK: map[int]bool{388: false, 413: false},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406, Status: state.StatusRunning, PID: 1234,
+		PRNumber: 388, Branch: "feat/active-repair",
+		StartedAt: time.Date(2026, 7, 18, 3, 43, 0, 0, time.UTC),
+	}
+	st.Sessions["ok-player-305"] = &state.Session{
+		IssueNumber: 412, Status: state.StatusPROpen,
+		PRNumber: 413, Branch: "feat/independent-gate",
+		StartedAt: time.Date(2026, 7, 18, 2, 21, 0, 0, time.UTC),
+	}
+
+	eng := testEngine(cfg, reader)
+	findings := eng.detectPRStuckStates(st, reader.prs, newResolutionCache(eng.reader))
+	for _, finding := range findings {
+		if finding.Target != nil && finding.Target.PR == 388 {
+			t.Fatalf("live worker PR produced a separate stuck finding: %#v", finding)
+		}
+	}
+	stuck := requireStuckState(t, state.SupervisorDecision{StuckStates: findings}, "greptile_not_approved")
+	if stuck.Target == nil || stuck.Target.Issue != 412 || stuck.Target.Session != "ok-player-305" || stuck.Target.PR != 413 {
+		t.Fatalf("independent finding target = %#v, want issue #412 / ok-player-305 / PR #413", stuck.Target)
+	}
+
+	decision, err := eng.Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnRepairWorker {
+		t.Fatalf("action = %q, want %q; summary=%q", decision.RecommendedAction, ActionSpawnRepairWorker, decision.Summary)
+	}
+	if decision.Target == nil || decision.Target.Issue != 412 || decision.Target.Session != "ok-player-305" || decision.Target.PR != 413 {
+		t.Fatalf("decision target = %#v, want issue #412 / ok-player-305 / PR #413", decision.Target)
+	}
+}
+
 func TestDecide_FailingChecksExplained(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{


### PR DESCRIPTION
A live worker already actuating an exact PR no longer produces a duplicate supervisor stuck/gate candidate. This lets independent overdue PRs use parallel repair lanes instead of being head-of-line blocked by a PR already under active repair.

Tests:
- `go test ./internal/supervisor`
- `go test ./...`
- `go build ./cmd/maestro/`

Refs #940

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps live PR repair workers out of supervisor gate selection. The main changes are:

- Skips running exact-PR sessions when detecting PR stuck states.
- Skips running exact-PR sessions when selecting the open PR supervisor recommendation.
- Adds a regression test for choosing an independent overdue PR while another PR is under active repair.

<h3>Confidence Score: 4/5</h3>

This change has one contained supervisor decision issue to fix before merging.

The intended selection behavior is localized and covered by a regression test, but the new guard can suppress gate supervision for stale running sessions with dead PIDs because it checks only for a positive `PID`.

`internal/supervisor/supervisor.go`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Inspected the live-worker guard logic in internal/supervisor/supervisor.go at lines 1750 and 2720 during verification; the run was blocked by the step limit before any runtime evidence could be captured.
- T-Rex attempted the requested verification run, but no local artifacts were uploaded for review.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Skips running PR sessions from stuck and gate selection, but the positive-PID check should verify the process is alive before hiding the PR. |
| internal/supervisor/supervisor_test.go | Adds coverage for a live PR worker not blocking an independent gate repair candidate. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/supervisor/supervisor.go:2720-2722
**Verify the worker is live**
This skip treats any positive `PID` as an active actuator, but stale `StatusRunning` sessions can keep a dead PID until reconciliation. With spare capacity, `sessionWithOpenPR` now ignores that PR, `shouldWaitForRunningWorker` returns false, and `Decide` can move on to another issue instead of surfacing or repairing the blocked PR. The same guard at line `1750` needs the same liveness check.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: skip live workers in PR gate select..."](https://github.com/befeast/maestro/commit/87ccb2a3a1292ccebedfbd2d888a94c425a38962) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45280204)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->