### PR TITLE
fix: resume green draft PRs in place

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1863,6 +1863,17 @@ func (c *Client) getRESTPull(prNumber int) (restPull, error) {
 	return pr, nil
 }
 
+// PRDetails returns the current forge metadata for one PR. Unlike a cached
+// open-PR list, this exact read is suitable for an actuation guard whose safety
+// depends on mutable metadata such as draft/open state.
+func (c *Client) PRDetails(prNumber int) (PR, error) {
+	pr, err := c.getRESTPull(prNumber)
+	if err != nil {
+		return PR{}, err
+	}
+	return pr.pr(), nil
+}
+
 func (c *Client) pullHeadSHA(prNumber int) (string, error) {
 	pr, err := c.getRESTPull(prNumber)
 	if err != nil {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -161,6 +161,7 @@ type Orchestrator struct {
 	ghCollectPRReviewFeedbackFn  func(prNumber int) (string, error)
 	ghCloseIssueFn               func(number int, comment string) error
 	ghPRHeadSHAFn                func(prNumber int) (string, error)
+	ghPRDetailsFn                func(prNumber int) (github.PR, error)
 	ghPRMergeInfoFn              func(prNumber int) (github.PRMergeInfo, error)
 	ghCommentPRFn                func(prNumber int, body string) error
 	ghPRChangedFilesFn           func(prNumber int) ([]string, error)
@@ -688,6 +689,16 @@ func (o *Orchestrator) prHeadSHA(prNumber int) (string, error) {
 		return "", fmt.Errorf("no github client configured for head SHA")
 	}
 	return o.gh.PRHeadSHA(prNumber)
+}
+
+func (o *Orchestrator) prDetails(prNumber int) (github.PR, error) {
+	if o.ghPRDetailsFn != nil {
+		return o.ghPRDetailsFn(prNumber)
+	}
+	if o.gh == nil {
+		return github.PR{}, fmt.Errorf("no github client configured for PR details")
+	}
+	return o.gh.PRDetails(prNumber)
 }
 
 func (o *Orchestrator) commentPR(prNumber int, body string) error {
@@ -8185,6 +8196,7 @@ func (o *Orchestrator) revalidateSpawnRepairPR(target *state.SupervisorTarget) s
 		}
 	}
 
+	reviewPending := false
 	if actionableReason == "" {
 		review, reviewErr := o.prReviewGateVerdict(pr)
 		if reviewErr != nil {
@@ -8193,6 +8205,7 @@ func (o *Orchestrator) revalidateSpawnRepairPR(target *state.SupervisorTarget) s
 		if !review.Pending && !review.Passed {
 			actionableReason = "current PR head has blocking review findings"
 		}
+		reviewPending = review.Pending
 	}
 
 	latestHead, err := o.prHeadSHA(pr)
@@ -8201,6 +8214,24 @@ func (o *Orchestrator) revalidateSpawnRepairPR(target *state.SupervisorTarget) s
 	}
 	if actionableReason != "" {
 		return spawnRepairGateDecision{actionable: true, reason: actionableReason}
+	}
+	// A green open draft is still explicitly incomplete. Supervisor already
+	// treats draft PRs as repairable, so the executor must not reinterpret green
+	// CI as terminal and strand a deliberate WIP forever. Re-read this mutable
+	// metadata from the exact PR at actuation time (not the cycle's cached list),
+	// and wait rather than spend while a review is still in progress. A green
+	// non-draft PR remains stale repair intent and proceeds through merge gates.
+	if ci == "success" && !reviewPending {
+		details, detailsErr := o.prDetails(pr)
+		if detailsErr != nil {
+			return spawnRepairGateDecision{reason: fmt.Sprintf("current PR draft state is unavailable: %v", detailsErr)}
+		}
+		if !strings.EqualFold(strings.TrimSpace(details.State), "OPEN") {
+			return spawnRepairGateDecision{stale: true, reason: "current PR is no longer open"}
+		}
+		if details.IsDraft {
+			return spawnRepairGateDecision{actionable: true, reason: "current PR remains an explicit draft/WIP continuation"}
+		}
 	}
 
 	switch ci {

--- a/internal/orchestrator/repair_dispatch_gate_test.go
+++ b/internal/orchestrator/repair_dispatch_gate_test.go
@@ -146,3 +146,73 @@ func TestSpawnRepairDispatch_CurrentReviewFindingAllowsExactInPlaceRepair(t *tes
 		t.Fatalf("repair approval = %q, want consumed/superseded", got)
 	}
 }
+
+func TestSpawnRepairDispatch_CurrentGreenDraftAllowsExactInPlaceContinuation(t *testing.T) {
+	const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cfg := cfgWithBackends("codex", "codex")
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, []github.Issue{makeIssue(7, "continue explicit draft", "maestro-ready")})
+	o.hasOpenPRForIssueFn = func(int) (bool, error) { return true, nil }
+	o.ghPRHeadSHAFn = func(int) (string, error) { return head, nil }
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{HeadSHA: head, Verdict: "success", Complete: true}, nil
+	}
+	o.ghPRMergeStatusFn = func(int) (string, string, error) { return "MERGEABLE", "clean", nil }
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{Passed: true}, nil
+	}
+	o.ghPRDetailsFn = func(pr int) (github.PR, error) {
+		return github.PR{Number: pr, State: "OPEN", IsDraft: true, Body: "<!-- maestro:wip -->"}, nil
+	}
+	respawns := 0
+	o.respawnInPlaceFn = func(_ *config.Config, slot string, sess *state.Session, _ string, _ github.Issue, _, _ string) error {
+		if slot != "slot-7" {
+			t.Fatalf("respawn slot = %q, want slot-7", slot)
+		}
+		respawns++
+		sess.Status = state.StatusRunning
+		return nil
+	}
+
+	s := repairGateTestState(time.Now().UTC(), head)
+	o.startNewWorkers(s, 1)
+
+	if respawns != 1 || len(*freshStarts) != 0 || len(s.Sessions) != 1 {
+		t.Fatalf("exact draft continuation mismatch: respawns=%d fresh=%v sessions=%d", respawns, *freshStarts, len(s.Sessions))
+	}
+	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusSuperseded {
+		t.Fatalf("repair approval = %q, want consumed/superseded", got)
+	}
+}
+
+func TestSpawnRepairDispatch_CurrentGreenNonDraftStalesRepair(t *testing.T) {
+	const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cfg := cfgWithBackends("codex", "codex")
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, []github.Issue{makeIssue(7, "ready PR", "maestro-ready")})
+	o.hasOpenPRForIssueFn = func(int) (bool, error) { return true, nil }
+	o.ghPRHeadSHAFn = func(int) (string, error) { return head, nil }
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{HeadSHA: head, Verdict: "success", Complete: true}, nil
+	}
+	o.ghPRMergeStatusFn = func(int) (string, string, error) { return "MERGEABLE", "clean", nil }
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{Passed: true}, nil
+	}
+	o.ghPRDetailsFn = func(pr int) (github.PR, error) {
+		return github.PR{Number: pr, State: "OPEN", IsDraft: false}, nil
+	}
+	respawns := 0
+	o.respawnInPlaceFn = func(*config.Config, string, *state.Session, string, github.Issue, string, string) error {
+		respawns++
+		return nil
+	}
+
+	s := repairGateTestState(time.Now().UTC(), head)
+	o.startNewWorkers(s, 1)
+
+	if respawns != 0 || len(*freshStarts) != 0 {
+		t.Fatalf("green non-draft repair dispatched: respawns=%d fresh=%v", respawns, *freshStarts)
+	}
+	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusStale {
+		t.Fatalf("repair approval = %q, want stale", got)
+	}
+}


### PR DESCRIPTION
Align repair actuation with supervisor semantics: a current green open Draft/WIP remains incomplete and may resume its exact canonical session, while a green non-draft PR still rejects stale repair intent and proceeds through merge flow. Draft/open state is re-read from the exact PR at actuation time.

Tests:
- `go test ./internal/orchestrator ./internal/github`
- `go test ./...`
- `go build ./cmd/maestro/`

Refs #940

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates repair dispatch gating for green draft PRs. The main changes are:

- Adds an exact PR metadata read for current draft and open state.
- Lets green open draft PRs resume their canonical repair session in place.
- Keeps green non-draft PRs on the stale repair path.
- Adds tests for green draft continuation and green non-draft staling.

<h3>Confidence Score: 4/5</h3>

One contained repair-gate bug needs to be fixed before merging.

Green PRs with pending review verdicts are treated as stale instead of retryable on the changed path.

internal/orchestrator/orchestrator.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the pending-review stale path by running a targeted Go test that exercises revalidateSpawnRepairPR with CI success and prReviewGateVerdict returning Pending true.
- Observed in the test logs that spawnRepairGateDecision reported actionable false, stale true, and the reason that the current PR head is green and has no actionable conflict or review blocker, with prDetailsRead being false.
- Reviewed the internal test log to understand the exit conditions, noting EXIT\_CODE: 1 and that there are passing gate tests around lines 1984-1999 followed by a focused command failure and final package/command failure, indicating no distinct new changed-code failure beyond the pending-review stale behavior ledger.

<a href="https://app.greptile.com/trex/runs/14933580/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds an exact PR metadata read backed by the existing REST pull parser. |
| internal/orchestrator/orchestrator.go | Adds draft-aware repair revalidation, with one pending-review path that now stales repair approval incorrectly. |
| internal/orchestrator/repair_dispatch_gate_test.go | Adds tests for green draft and green non-draft repair dispatch behavior. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/orchestrator/orchestrator.go`, line 8237-8241 ([link](https://github.com/befeast/maestro/blob/d7891e0158ec200ceda660ceee602ac9affdb51d/internal/orchestrator/orchestrator.go#L8237-L8241)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Pending reviews go stale**
   When `ci == "success"` and `review.Pending` is true, this path skips the draft re-read at line 8224 and falls through to the `success` case. That marks the repair approval stale, so a green draft with an in-progress review loses its resumable repair intent instead of retrying later.

   

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: targeted Go test source for green PR with pending review gate](https://app.greptile.com/trex/artifacts/344ffe89-3646-4d64-9cea-8544cf9e4377)**

   - Contains supporting evidence from the run (text/x-go; charset=utf-8).

   **[Repro: verbose go test output showing stale decision for pending review](https://app.greptile.com/trex/artifacts/d1eb27e1-4fd2-4828-bd7a-9eac5e6ab4ba)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/14933580/artifacts?artifact=344ffe89-3646-4d64-9cea-8544cf9e4377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/orchestrator/orchestrator.go
   Line: 8237-8241

   Comment:
   **Pending reviews go stale**
   When `ci == "success"` and `review.Pending` is true, this path skips the draft re-read at line 8224 and falls through to the `success` case. That marks the repair approval stale, so a green draft with an in-progress review loses its resumable repair intent instead of retrying later.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:8237-8241
**Pending reviews go stale**
When `ci == "success"` and `review.Pending` is true, this path skips the draft re-read at line 8224 and falls through to the `success` case. That marks the repair approval stale, so a green draft with an in-progress review loses its resumable repair intent instead of retrying later.

```suggestion
	if ci == "success" && reviewPending {
		return spawnRepairGateDecision{reason: "current PR review gate is pending; repair authority remains retryable"}
	}

	switch ci {
	case "pending":
		return spawnRepairGateDecision{stale: true, reason: "current PR head checks are pending; no repair is presently actionable"}
	case "success":
		return spawnRepairGateDecision{stale: true, reason: "current PR head is green and has no actionable conflict or review blocker"}
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow exact repair of green draft P..."](https://github.com/befeast/maestro/commit/d7891e0158ec200ceda660ceee602ac9affdb51d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45281703)</sub>

<!-- /greptile_comment -->