### PR TITLE
fix: keep live terminal evidence authoritative

### DIFF
--- a/internal/supervisor/material_progress.go
+++ b/internal/supervisor/material_progress.go
@@ -349,9 +349,11 @@ func terminalCheckpointProgress(sess *state.Session) (string, bool) {
 	}
 	parts := make([]string, 0, 3)
 	complete := true
+	liveTerminal := false
 	if strings.TrimSpace(sess.TmuxSession) != "" {
 		if live, ok := tmuxProgressFingerprint(sess.TmuxSession); ok {
 			parts = append(parts, "tmux="+live)
+			liveTerminal = true
 		} else {
 			complete = false
 		}
@@ -360,7 +362,12 @@ func terminalCheckpointProgress(sess *state.Session) (string, bool) {
 	}
 	if checkpoint, ok := boundedFileFingerprintProbe(sess.CheckpointFile, 1<<20); checkpoint != "" {
 		parts = append(parts, "checkpoint="+checkpoint)
-	} else if !ok {
+	} else if !ok && !liveTerminal {
+		// A checkpoint is an optional durable fallback while the exact live tmux
+		// terminal is readable. In-place resume can legitimately consume/remove
+		// CHECKPOINT.md while retaining its path in historical session state; that
+		// stale optional path must not poison fresh terminal evidence forever. If
+		// the live terminal is also unavailable, keep failing closed.
 		complete = false
 	}
 	return progress.Fingerprint(parts...), complete

--- a/internal/supervisor/material_progress_test.go
+++ b/internal/supervisor/material_progress_test.go
@@ -697,6 +697,37 @@ cat "$TMUX_FAKE_OUTPUT"
 	}
 }
 
+func TestTerminalCheckpointProgress_LiveTmuxIsCompleteWhenConsumedCheckpointIsMissing(t *testing.T) {
+	bin := t.TempDir()
+	outputPath := filepath.Join(bin, "output")
+	script := filepath.Join(bin, "tmux")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+if [ "$1" = "has-session" ]; then
+  exit 1
+fi
+if [ "$1" != "capture-pane" ] || [ "$2" != "-p" ] || [ "$3" != "-t" ] || [ "$4" != "=mae-exact:" ]; then
+  exit 91
+fi
+cat "$TMUX_FAKE_OUTPUT"
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outputPath, []byte("live terminal progress\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_FAKE_OUTPUT", outputPath)
+
+	sess := &state.Session{
+		TmuxSession:    "mae-exact",
+		CheckpointFile: filepath.Join(bin, "consumed-CHECKPOINT.md"),
+	}
+	got, complete := terminalCheckpointProgress(sess)
+	if got == "" || !complete {
+		t.Fatalf("live tmux with consumed checkpoint = (%q,%t), want non-empty complete evidence", got, complete)
+	}
+}
+
 func TestTmuxProgressFingerprint_TimeoutAndOverflowAreIncomplete(t *testing.T) {
 	bin := t.TempDir()
 	script := filepath.Join(bin, "tmux")


### PR DESCRIPTION
Refs #940

## Problem
An in-place resume can consume or remove `CHECKPOINT.md` while the session retains its historical checkpoint path. The stalled-progress watchdog successfully captures the exact live tmux pane, then incorrectly marks the combined terminal signal unavailable because that optional checkpoint file is gone. This suppresses recovery indefinitely.

## Fix
Treat successful exact live-tmux capture as complete terminal evidence even when the optional historical checkpoint path is missing. If tmux is also unavailable, the probe remains incomplete and recovery still fails closed.

## Verification
- New regression for live tmux plus consumed checkpoint
- Focused regression 5x
- `go test ./internal/supervisor`
- `go test ./...`
- `go build ./cmd/maestro/`

Live evidence: OK Player slots `ok-player-302` and `ok-player-305` had logs and exact tmux panes advancing while Fleet reported `terminal_checkpoint` unavailable solely because their configured CHECKPOINT.md paths no longer existed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates terminal progress evidence handling for sessions with live tmux output. The main changes are:

- Treats successful exact tmux capture as complete terminal evidence when the historical checkpoint file is missing.
- Keeps terminal evidence incomplete when both live tmux and the configured checkpoint fallback are unavailable.
- Adds a regression test for live tmux evidence with a consumed or missing checkpoint path.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to terminal evidence completeness, preserves the fail-closed path when live tmux is unavailable, and includes focused tests for the reported case.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex grepped the test suite to locate the target regression test name and the neighboring live tmux material progress test.
- T-Rex executed the focused 5x regression run and captured the exact command, timestamps, verbose output, and exit code 0.
- T-Rex ran the broader supervisor package test command, recording timestamps, verbose output, and exit code 0.
- T-Rex logged the tmux availability check, confirming that no real tmux binary was on PATH, consistent with mocked unit coverage.

<a href="https://app.greptile.com/trex/runs/14934245/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/material_progress.go | Updates terminal checkpoint completeness so exact live tmux evidence remains complete when the configured checkpoint fallback is unavailable. |
| internal/supervisor/material_progress_test.go | Adds a regression covering live tmux evidence with a consumed or missing checkpoint file. |

<sub>Reviews (1): Last reviewed commit: ["fix: keep live terminal evidence authori..."](https://github.com/befeast/maestro/commit/cf73d5bf179233ab3e8ea7a104cfe782231bdf7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45282992)</sub>

<!-- /greptile_comment -->