### PR TITLE
fix: wait for current-head checks before review repair

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2309,33 +2309,39 @@ commentFallback:
 		return false, false, fmt.Errorf("parse pr %d comments: %w", prNumber, err)
 	}
 
-	foundGreptile := false
-	for _, comment := range comments {
-		bodyLower := strings.ToLower(comment.Body)
-		if !strings.Contains(bodyLower, "greptile") {
-			continue
-		}
-
-		foundGreptile = true
-
-		if strings.Contains(bodyLower, "not safe to merge") || strings.Contains(bodyLower, "unsafe to merge") {
-			return false, false, nil
-		}
-
-		if strings.Contains(bodyLower, "safe to merge") {
-			return true, false, nil
-		}
-
-		if strings.Contains(bodyLower, "confidence score:") && (strings.Contains(bodyLower, "5/5") || strings.Contains(bodyLower, "4/5")) {
-			return true, false, nil
-		}
-	}
-
+	foundGreptile, approved := greptileCommentDecision(comments)
 	if !foundGreptile {
 		return false, true, nil
 	}
+	return approved, false, nil
+}
 
-	return false, false, nil
+// greptileCommentDecision is the legacy comment-mode fallback. Only comments
+// authored by Greptile are verdicts: operator prompts such as "@greptile
+// review" or human status summaries must not turn a missing current-head check
+// into a false rejection. GitHub returns issue comments oldest-first, so the
+// latest bot verdict wins.
+func greptileCommentDecision(comments []issueComment) (found bool, approved bool) {
+	for i := len(comments) - 1; i >= 0; i-- {
+		comment := comments[i]
+		if !isGreptileLogin(comment.User.Login) {
+			continue
+		}
+		bodyLower := strings.ToLower(comment.Body)
+		if strings.Contains(bodyLower, "not safe to merge") || strings.Contains(bodyLower, "unsafe to merge") {
+			return true, false
+		}
+		if strings.Contains(bodyLower, "safe to merge") {
+			return true, true
+		}
+		if strings.Contains(bodyLower, "confidence score:") && (strings.Contains(bodyLower, "5/5") || strings.Contains(bodyLower, "4/5")) {
+			return true, true
+		}
+		// A Greptile-authored comment without an approving phrase is still an
+		// authoritative non-pass in legacy comment mode.
+		return true, false
+	}
+	return false, false
 }
 
 func greptileCheckDecision(checkRuns []greptileCheckRun) (found bool, approved bool, pending bool) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -346,6 +346,32 @@ func TestGreptileCheckDecision(t *testing.T) {
 	}
 }
 
+func TestGreptileCommentDecisionIgnoresHumanMentionsAndUsesLatestBotVerdict(t *testing.T) {
+	comment := func(login, body string) issueComment {
+		var got issueComment
+		got.User.Login = login
+		got.Body = body
+		return got
+	}
+
+	found, approved := greptileCommentDecision([]issueComment{
+		comment("kossoy", "Please run @greptile review on the new exact head"),
+		comment("operator", "Greptile is still pending"),
+	})
+	if found || approved {
+		t.Fatalf("human Greptile mentions = (%t,%t), want no verdict", found, approved)
+	}
+
+	found, approved = greptileCommentDecision([]issueComment{
+		comment("greptile-app[bot]", "Not safe to merge"),
+		comment("kossoy", "@greptile review"),
+		comment("greptile-app[bot]", "Confidence Score: 4/5 — safe to merge"),
+	})
+	if !found || !approved {
+		t.Fatalf("latest Greptile bot verdict = (%t,%t), want approved", found, approved)
+	}
+}
+
 func TestHasGreptileInlineCommentOnHead(t *testing.T) {
 	makeComment := func(login, sha, body string) greptileReviewComment {
 		var c greptileReviewComment

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -8195,6 +8195,13 @@ func (o *Orchestrator) revalidateSpawnRepairPR(target *state.SupervisorTarget) s
 			actionableReason = "current PR head has a merge conflict"
 		}
 	}
+	// A current-head CI run in progress is not repair authority. In particular,
+	// do not let a stale/legacy review verdict override that fresh pending state
+	// and spend another worker before the exact-head checks and review settle.
+	// A real merge conflict above remains immediately actionable.
+	if actionableReason == "" && ci == "pending" {
+		return spawnRepairGateDecision{stale: true, reason: "current PR head checks are pending; no repair is presently actionable"}
+	}
 
 	reviewPending := false
 	if actionableReason == "" {

--- a/internal/orchestrator/repair_dispatch_gate_test.go
+++ b/internal/orchestrator/repair_dispatch_gate_test.go
@@ -57,6 +57,38 @@ func TestSpawnRepairDispatch_CurrentPendingHeadStalesApprovalWithoutRespawn(t *t
 	}
 }
 
+func TestSpawnRepairDispatch_CurrentPendingHeadIgnoresStaleReviewFinding(t *testing.T) {
+	const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cfg := cfgWithBackends("codex", "codex")
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, []github.Issue{makeIssue(7, "repair exact PR", "maestro-ready")})
+	o.hasOpenPRForIssueFn = func(int) (bool, error) { return true, nil }
+	o.ghPRHeadSHAFn = func(int) (string, error) { return head, nil }
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{HeadSHA: head, Verdict: "pending", Complete: true}, nil
+	}
+	o.ghPRMergeStatusFn = func(int) (string, string, error) { return "MERGEABLE", "unstable", nil }
+	reviewReads := 0
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		reviewReads++
+		return github.ReviewGateVerdict{Passed: false}, nil
+	}
+	respawns := 0
+	o.respawnInPlaceFn = func(*config.Config, string, *state.Session, string, github.Issue, string, string) error {
+		respawns++
+		return nil
+	}
+
+	s := repairGateTestState(time.Now().UTC(), head)
+	o.startNewWorkers(s, 1)
+
+	if respawns != 0 || reviewReads != 0 || len(*freshStarts) != 0 {
+		t.Fatalf("pending head consumed stale review: respawns=%d reviewReads=%d fresh=%v", respawns, reviewReads, *freshStarts)
+	}
+	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusStale {
+		t.Fatalf("repair approval = %q, want stale", got)
+	}
+}
+
 func TestSpawnRepairDispatch_HeadMoveStalesBoundApprovalBeforeReadingOldGates(t *testing.T) {
 	const oldHead = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	const newHead = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"


### PR DESCRIPTION
Refs #940

## Problem
A pending current PR head could still dispatch a repair when the legacy Greptile comment fallback returned a non-pass from old or human-authored comments. In live OK Player evidence, PR #388 had exact-head Fedora/Flatpak checks in progress and a fresh `@greptile review` request, but the executor treated historical review state as a blocker and respawned the canonical worker unnecessarily.

## Fix
- A current-head pending CI rollup now stops repair revalidation after merge-conflict inspection, before any review verdict can override it.
- Legacy Greptile comment fallback accepts verdicts only from Greptile-authored comments; operator mentions/status text are ignored.
- The latest Greptile bot verdict wins.

## Verification
- Pending-head + stale review regression, 5x
- Human mention/latest bot verdict regression, 5x
- GitHub and orchestrator package suites
- `go test ./...`
- `go build ./cmd/maestro/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates repair gating around pending checks and legacy Greptile review signals. The main changes are:

- Stop repair revalidation when current-head CI is pending after merge-conflict inspection.
- Ignore human-authored Greptile mentions in the legacy comment fallback.
- Use the latest Greptile bot comment as the legacy verdict.
- Add tests for stale review findings, human mentions, and latest bot verdict handling.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrow and preserve existing failure and merge-conflict repair behavior while adding targeted tests for the reported stale-review paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Recorded the validation command script used for the requested sequence.
- Inspected the 5x focused orchestrator run captured in the repair-dispatch-focused-02-after log and confirmed targeted tests were repeated and passed.
- Validated the 5x focused GitHub Greptile verdict run captured in the github-greptile-focused-02-after.log and confirmed it passed.
- Checked go test -v ./internal/github ./internal/orchestrator completed with PASS and OK for the orchestrator package.
- Verified the full test sweep across all packages completed successfully and the Maestro build succeeded.

<a href="https://app.greptile.com/trex/runs/14935191/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Refactors legacy Greptile comment fallback to consider only Greptile-authored comments and use the latest bot verdict. |
| internal/github/github_test.go | Adds tests for ignoring human Greptile mentions and honoring the latest Greptile bot verdict. |
| internal/orchestrator/orchestrator.go | Short-circuits repair revalidation when current-head checks are pending after merge-conflict inspection. |
| internal/orchestrator/repair_dispatch_gate_test.go | Adds tests ensuring pending current-head checks bypass stale review findings and do not respawn workers. |

<sub>Reviews (1): Last reviewed commit: ["fix: wait for current-head checks before..."](https://github.com/befeast/maestro/commit/e3352e099dd0b7b309ce65466fdc737d30b037a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45284813)</sub>

<!-- /greptile_comment -->