### PR TITLE
fix: elect one lifecycle owner per open PR

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4828,6 +4828,14 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	// open PR references the issue. Multiple candidates are ambiguous and must
 	// remain untouched; choosing one would manufacture a new canonical identity.
 	o.reconcileTerminalSessionsWithOpenPRs(s, prs)
+	// One open PR is one maintenance/merge lifecycle even when a continuation
+	// issue and its historical source issue both retain exact session records.
+	// Gate side effects (CI retry accounting, review repair, rebase, merge) must
+	// run through one deterministic owner. Without this, a red head can be
+	// observed twice: the current continuation safely defers while its branch is
+	// moving, then an older session consumes retry budget and becomes
+	// retry_exhausted for the same PR (OK Player #388 / issues #345 and #406).
+	mergeOwners := canonicalMergeFlowOwners(s, branchToPR, numberToPR)
 
 	type mergeCandidate struct {
 		slotName string
@@ -4915,6 +4923,10 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			now := time.Now().UTC()
 			sess.FinishedAt = &now
 			state.MarkWorkerEnded(sess, now)
+			continue
+		}
+		if owner := mergeOwners[pr.Number]; owner != "" && owner != slotName {
+			log.Printf("[orch] PR #%d lifecycle is owned by canonical session %s; skipping historical session %s", pr.Number, owner, slotName)
 			continue
 		}
 
@@ -5468,6 +5480,68 @@ func mergeFlowEligibleStatus(sess *state.Session) bool {
 	default:
 		return false
 	}
+}
+
+// canonicalMergeFlowOwners elects exactly one session for each open PR before
+// autoMergePRs performs any gate mutation. The ordering deliberately matches
+// supervisor/watchdog PR ownership: a live worker wins; otherwise the newest
+// unresolved session wins, with stable tie-breaking. Keeping this election
+// local to the current open-PR snapshot also means a closed/merged PR is left
+// to terminal reconciliation rather than retaining a synthetic owner.
+func canonicalMergeFlowOwners(s *state.State, byBranch map[string]github.PR, byNumber map[int]github.PR) map[int]string {
+	owners := make(map[int]string)
+	if s == nil {
+		return owners
+	}
+	for _, slot := range sortedStateSessionNames(s) {
+		sess := s.Sessions[slot]
+		if !mergeFlowOwnerEligibleStatus(sess) {
+			continue
+		}
+		pr, found := mergeFlowPRForSession(sess, byBranch, byNumber)
+		if !found {
+			continue
+		}
+		currentSlot, exists := owners[pr.Number]
+		if !exists || mergeFlowOwnerPrecedes(slot, sess, currentSlot, s.Sessions[currentSlot]) {
+			owners[pr.Number] = slot
+		}
+	}
+	return owners
+}
+
+func mergeFlowOwnerEligibleStatus(sess *state.Session) bool {
+	if sess == nil {
+		return false
+	}
+	switch sess.Status {
+	case state.StatusRunning, state.StatusPROpen, state.StatusQueued, state.StatusDead,
+		state.StatusFailed, state.StatusConflictFailed, state.StatusRetryExhausted:
+		return sess.PRNumber > 0 || strings.TrimSpace(sess.Branch) != ""
+	default:
+		return false
+	}
+}
+
+func mergeFlowOwnerPrecedes(candidateSlot string, candidate *state.Session, currentSlot string, current *state.Session) bool {
+	if candidate == nil {
+		return false
+	}
+	candidateLive := candidate.Status == state.StatusRunning && candidate.PID > 0
+	currentLive := current != nil && current.Status == state.StatusRunning && current.PID > 0
+	if candidateLive != currentLive {
+		return candidateLive
+	}
+	if current == nil || candidate.StartedAt.After(current.StartedAt) {
+		return true
+	}
+	if current.StartedAt.After(candidate.StartedAt) {
+		return false
+	}
+	if candidate.Status != current.Status {
+		return candidate.Status == state.StatusQueued
+	}
+	return candidateSlot < currentSlot
 }
 
 // isSettledRetryExhausted reports whether a session has already been marked
@@ -7397,12 +7471,21 @@ func (o *Orchestrator) rebaseConflicts(s *state.State) {
 	}
 
 	branchToPR := make(map[string]github.PR)
+	numberToPR := make(map[int]github.PR)
 	for _, pr := range prs {
 		branchToPR[pr.HeadRefName] = pr
+		numberToPR[pr.Number] = pr
 	}
+	owners := canonicalMergeFlowOwners(s, branchToPR, numberToPR)
 
 	for slotName, sess := range s.Sessions {
-		pr, hasPR := branchToPR[sess.Branch]
+		pr, hasPR := mergeFlowPRForSession(sess, branchToPR, numberToPR)
+		if hasPR {
+			if owner := owners[pr.Number]; owner != "" && owner != slotName {
+				log.Printf("[orch] PR #%d rebase lifecycle is owned by canonical session %s; skipping historical session %s", pr.Number, owner, slotName)
+				continue
+			}
+		}
 
 		switch sess.Status {
 		case state.StatusPROpen:

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -4133,6 +4133,46 @@ func TestRebaseConflicts_OpenPRBehindMainUpdatesUnderMaintenance(t *testing.T) {
 	}
 }
 
+func TestRebaseConflicts_SharedPRMutatesOnlyNewestContinuation(t *testing.T) {
+	updateCalled := 0
+	prs := []github.PR{{Number: 388, HeadRefName: "feat/shared-pr"}}
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		listOpenPRsFn: func() ([]github.PR, error) {
+			return prs, nil
+		},
+		ghPRMergeStatusFn: func(prNumber int) (string, string, error) {
+			return "MERGEABLE", "behind", nil
+		},
+		ghUpdateBranchFn: func(prNumber int) error {
+			updateCalled++
+			return nil
+		},
+	}
+	s := state.NewState()
+	s.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345, Status: state.StatusPROpen, PRNumber: 388, Branch: "feat/shared-pr",
+		StartedAt: time.Date(2026, 7, 17, 23, 6, 0, 0, time.UTC),
+	}
+	s.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406, Status: state.StatusPROpen, PRNumber: 388, Branch: "feat/shared-pr",
+		StartedAt: time.Date(2026, 7, 18, 4, 57, 43, 0, time.UTC),
+	}
+
+	o.rebaseConflicts(s)
+
+	if updateCalled != 1 {
+		t.Fatalf("updateBranch called %d times, want exactly one canonical update", updateCalled)
+	}
+	if got := s.Sessions["ok-player-273"].Status; got != state.StatusPROpen {
+		t.Fatalf("historical session status = %q, want untouched pr_open", got)
+	}
+	if got := s.Sessions["ok-player-302"].Status; got != state.StatusQueued {
+		t.Fatalf("canonical continuation status = %q, want queued after update", got)
+	}
+}
+
 // #602 — When the merge fails with a non-"not up to date" error AND GitHub
 // reports MERGEABLE (so it's not actually a conflict), fall through to the
 // existing single-notification merge_failed path instead of mis-routing.
@@ -8768,6 +8808,62 @@ func TestAutoMergePRs_CIFailure_KeepsCanonicalPRAndSchedulesInPlaceRetry(t *test
 	}
 	if sess.FinishedAt == nil {
 		t.Fatal("FinishedAt should be set")
+	}
+}
+
+func TestAutoMergePRs_SharedPRFailureMutatesOnlyNewestContinuation(t *testing.T) {
+	prs := []github.PR{{Number: 388, HeadRefName: "feat/shared-pr"}}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000}
+	o, _, closedPRs := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{388: "failure"})
+	s := state.NewState()
+	s.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345, Status: state.StatusPROpen, PRNumber: 388, Branch: "feat/shared-pr",
+		StartedAt: time.Date(2026, 7, 17, 23, 6, 0, 0, time.UTC), RetryCount: 3,
+	}
+	s.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406, Status: state.StatusPROpen, PRNumber: 388, Branch: "feat/shared-pr",
+		StartedAt: time.Date(2026, 7, 18, 4, 57, 43, 0, time.UTC),
+	}
+
+	o.autoMergePRs(s)
+
+	historical := s.Sessions["ok-player-273"]
+	if historical.Status != state.StatusPROpen || historical.LastNotifiedStatus != "" {
+		t.Fatalf("historical session mutated by shared PR failure: %+v", historical)
+	}
+	canonical := s.Sessions["ok-player-302"]
+	if canonical.Status != state.StatusDead || canonical.NextRetryAt == nil || canonical.RetryCount != 1 {
+		t.Fatalf("canonical continuation = %+v, want one scheduled in-place retry", canonical)
+	}
+	if canonical.PRNumber != 388 || len(*closedPRs) != 0 {
+		t.Fatalf("canonical identity changed: pr=%d closed=%v", canonical.PRNumber, *closedPRs)
+	}
+}
+
+func TestAutoMergePRs_SharedPRLiveContinuationBlocksHistoricalGateMutation(t *testing.T) {
+	prs := []github.PR{{Number: 388, HeadRefName: "feat/shared-pr"}}
+	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000}
+	o, _, closedPRs := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{388: "failure"})
+	s := state.NewState()
+	s.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345, Status: state.StatusPROpen, PRNumber: 388, Branch: "feat/shared-pr",
+		StartedAt: time.Date(2026, 7, 17, 23, 6, 0, 0, time.UTC), RetryCount: 3,
+	}
+	s.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406, Status: state.StatusRunning, PRNumber: 388, Branch: "feat/shared-pr", PID: 12345,
+		StartedAt: time.Date(2026, 7, 18, 4, 57, 43, 0, time.UTC),
+	}
+
+	o.autoMergePRs(s)
+
+	if got := s.Sessions["ok-player-273"]; got.Status != state.StatusPROpen || got.LastNotifiedStatus != "" {
+		t.Fatalf("historical session mutated while canonical repair is live: %+v", got)
+	}
+	if got := s.Sessions["ok-player-302"]; got.Status != state.StatusRunning || got.RetryCount != 0 {
+		t.Fatalf("live canonical continuation mutated by merge flow: %+v", got)
+	}
+	if len(*closedPRs) != 0 {
+		t.Fatalf("shared PR closed while canonical repair is live: %v", *closedPRs)
 	}
 }
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4101,6 +4101,25 @@ func fleetSupersedingIssueSession(candidate sessionInfo, all []sessionInfo) (ses
 	if candidate.IssueNumber <= 0 || !candidate.NeedsAttention {
 		return sessionInfo{}, false
 	}
+	// A PR is one lifecycle artifact even when a continuation issue and its
+	// historical source issue both retain session rows. Suppress a terminal
+	// attention row behind the deterministic current owner of that exact PR;
+	// otherwise an old retry_exhausted attempt can dominate operator_state while
+	// the newer continuation is the only session allowed to repair the PR.
+	if candidate.PRNumber > 0 {
+		owner := candidate
+		for _, peer := range all {
+			if peer.Slot == candidate.Slot || peer.PRNumber != candidate.PRNumber || !fleetSessionCanOwnOpenPR(peer) {
+				continue
+			}
+			if fleetPRSessionOwnerPrecedes(peer, owner) {
+				owner = peer
+			}
+		}
+		if owner.Slot != candidate.Slot {
+			return owner, true
+		}
+	}
 	// A terminal attempt with its own PR is not merely stale execution state:
 	// it may still require operator action or reconciliation for that distinct
 	// artifact. Only no-PR duplicate attempts may be hidden behind the issue's
@@ -4142,6 +4161,44 @@ func fleetSupersedingIssueSession(candidate sessionInfo, all []sessionInfo) (ses
 		}
 	}
 	return sessionInfo{}, false
+}
+
+func fleetSessionCanOwnOpenPR(sess sessionInfo) bool {
+	if sess.PRNumber <= 0 {
+		return false
+	}
+	switch state.SessionStatus(sess.Status) {
+	case state.StatusRunning, state.StatusPROpen, state.StatusQueued, state.StatusDead,
+		state.StatusFailed, state.StatusConflictFailed, state.StatusRetryExhausted:
+		return true
+	default:
+		return false
+	}
+}
+
+func fleetPRSessionOwnerPrecedes(candidate, current sessionInfo) bool {
+	candidateLive := fleetSessionActuallyRunning(candidate)
+	currentLive := fleetSessionActuallyRunning(current)
+	if candidateLive != currentLive {
+		return candidateLive
+	}
+	candidateStarted, candidateErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(candidate.StartedAt))
+	currentStarted, currentErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(current.StartedAt))
+	if candidateErr == nil && currentErr != nil {
+		return true
+	}
+	if candidateErr == nil && currentErr == nil {
+		if candidateStarted.After(currentStarted) {
+			return true
+		}
+		if currentStarted.After(candidateStarted) {
+			return false
+		}
+	}
+	if candidate.Status != current.Status {
+		return state.SessionStatus(candidate.Status) == state.StatusQueued
+	}
+	return candidate.Slot < current.Slot
 }
 
 func fleetSessionStartedAfterCanonicalCompletion(candidate, canonical sessionInfo) bool {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -4037,6 +4037,28 @@ func TestFleetSupersedingIssueSessionUsesRetryExhaustedCanonicalOpenPR(t *testin
 	}
 }
 
+func TestFleetSupersedingIssueSessionSuppressesHistoricalSharedPRAttention(t *testing.T) {
+	historical := sessionInfo{
+		Slot: "ok-player-273", IssueNumber: 345, Status: string(state.StatusRetryExhausted),
+		PRNumber: 388, NeedsAttention: true, StartedAt: "2026-07-17T23:06:00Z",
+	}
+	continuation := sessionInfo{
+		Slot: "ok-player-302", IssueNumber: 406, Status: string(state.StatusPROpen),
+		PRNumber: 388, StartedAt: "2026-07-18T04:57:43Z",
+	}
+
+	got, ok := fleetSupersedingIssueSession(historical, []sessionInfo{historical, continuation})
+	if !ok || got.Slot != continuation.Slot {
+		t.Fatalf("shared-PR owner = %+v, %v; want %s", got, ok, continuation.Slot)
+	}
+
+	otherPR := continuation
+	otherPR.PRNumber = 413
+	if got, ok := fleetSupersedingIssueSession(historical, []sessionInfo{historical, otherPR}); ok {
+		t.Fatalf("different PR incorrectly superseded historical attention: %+v", got)
+	}
+}
+
 // TestFleetAPIRetryExhaustedWithOpenPRSelfResolvesCalmly pins the #598
 // regression. A retry_exhausted session whose linked PR is still open and
 // whose last notification is NOT a CI failure is convergence-bound: the


### PR DESCRIPTION
## Summary

- elect one canonical lifecycle owner before applying CI, review, rebase, retry, or merge side effects to an open PR
- let a running or retry-pending canonical continuation hold the PR lease so historical sessions cannot mutate the same gate
- suppress historical same-PR retry-exhausted attention behind the canonical continuation in Fleet Mission Control

## Root cause

`autoMergePRs` iterated session records rather than unique open PR lifecycles. OK Player PR #388 was referenced by historical issue #345 (`ok-player-273`) and continuation issue #406 (`ok-player-302`). When the current head became red, the continuation safely deferred while its worktree was considered busy, but the same cycle then processed the historical row, consumed its exhausted retry budget, and made it dominate `operator_state`.

## Impact

Each exact open PR now has one deterministic owner across running, retry-pending, and gate phases. A failed head schedules at most one in-place repair on the newest canonical continuation; no historical worker can consume retry budget, create contradictory attention, or compete for the same PR.

## Validation

- shared red PR / newest continuation regression: 10 repeated runs
- shared red PR / live continuation lease regression: 10 repeated runs
- shared behind/conflicting PR / canonical rebase owner regression: 10 repeated runs
- Fleet historical same-PR attention suppression regression: 10 repeated runs
- `go test ./internal/orchestrator ./internal/server ./internal/supervisor ./internal/state`
- `go test ./...`
- `go build ./cmd/maestro/`
- `git diff --check`

Refs #940

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes one session the canonical owner for each open PR lifecycle. The main changes are:

- Elects a deterministic owner before CI, review, rebase, retry, and merge side effects.
- Skips historical sessions that reference the same open PR but are not the elected owner.
- Applies the same ownership rule to automatic rebase handling.
- Suppresses historical same-PR retry-exhausted attention in Fleet Mission Control.
- Adds tests for shared PR failure, live continuation leasing, rebase ownership, and Fleet attention suppression.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped to owner election and attention suppression, and the updated tests cover the reported shared-PR lifecycle paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The targeted proof log shows the orchestrator selected canonical session ok-player-302, skipped historical ok-player-273, and scheduled retries only on the newest continuation, with the Fleet suppression test passing repeatedly.
- The safety-net log reports ok for github.com/befeast/maestro/internal/orchestrator, internal/server, internal/supervisor, and internal/state.
- Build and diff logs capture successful command headers and EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14936475/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds canonical open-PR lifecycle owner election and applies it to merge and rebase gate mutations. |
| internal/orchestrator/orchestrator_test.go | Adds tests for shared-PR failure, live continuation leasing, and rebase ownership behavior. |
| internal/server/fleet.go | Suppresses historical same-PR attention rows behind the deterministic Fleet PR owner. |
| internal/server/fleet_test.go | Adds coverage for hiding historical retry-exhausted attention only when sessions share the same PR. |

<sub>Reviews (2): Last reviewed commit: ["fix: elect one lifecycle owner per open ..."](https://github.com/befeast/maestro/commit/4005c17607391d85bbb2afe6647200c6e7cfcea6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45287165)</sub>

<!-- /greptile_comment -->