### PR TITLE
fix: allow attribution past preserved checkpoint

### DIFF
--- a/internal/orchestrator/attribution_amend_test.go
+++ b/internal/orchestrator/attribution_amend_test.go
@@ -90,6 +90,42 @@ func trailerCount(msg string) int {
 	return strings.Count(msg, state.AttributionTrailerKey+":")
 }
 
+func TestEnsureAttributionTrailer_IgnoresOnlyPreservedUntrackedCheckpoint(t *testing.T) {
+	origin, wt, _, branch := setupAmendRepo(t)
+	checkpoint := filepath.Join(wt, "CHECKPOINT.md")
+	amendWrite(t, wt, "CHECKPOINT.md", "durable worker progress\n")
+	o := &Orchestrator{tmuxSessionExistsFn: func(string) bool { return false }}
+	sess := &state.Session{
+		Worktree: wt, Branch: branch, Attribution: testAttribution(), CheckpointFile: checkpoint,
+	}
+
+	if deferred := o.ensureAttributionTrailerOnBranch("slot-checkpoint", sess); deferred {
+		t.Fatal("exact untracked session checkpoint incorrectly deferred attribution")
+	}
+	if got, err := os.ReadFile(checkpoint); err != nil || string(got) != "durable worker progress\n" {
+		t.Fatalf("checkpoint was not preserved: content=%q err=%v", got, err)
+	}
+	headMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", branch)
+	if trailerCount(headMsg) != 1 {
+		t.Fatalf("remote trailer count = %d, want 1:\n%s", trailerCount(headMsg), headMsg)
+	}
+}
+
+func TestAmendHead_IgnoredCheckpointDoesNotHideOtherUntrackedWork(t *testing.T) {
+	origin, wt, _, branch := setupAmendRepo(t)
+	amendWrite(t, wt, "CHECKPOINT.md", "durable worker progress\n")
+	amendWrite(t, wt, "product-change.txt", "uncommitted product work\n")
+
+	err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), time.Now().UTC(), "CHECKPOINT.md")
+	if !errors.Is(err, errAmendWorktreeBusy) {
+		t.Fatalf("other untracked work must keep amend fail-closed, got %v", err)
+	}
+	headMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", branch)
+	if strings.Contains(headMsg, state.AttributionTrailerKey+":") {
+		t.Fatalf("dirty product worktree was amended despite fail-closed guard:\n%s", headMsg)
+	}
+}
+
 // On a stale-info rejection, the amend re-fetches, re-applies the trailer onto
 // the commit the worker actually pushed, and retries — landing the trailer
 // exactly once without discarding the worker's concurrent commit.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3885,7 +3885,7 @@ func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *s
 		}
 		return true
 	}
-	err := o.amendHeadWithAttributionTrailer(sess.Worktree, sess.Branch, sess.Attribution, time.Now().UTC())
+	err := o.amendHeadWithAttributionTrailer(sess.Worktree, sess.Branch, sess.Attribution, time.Now().UTC(), sess.CheckpointFile)
 	if err == nil {
 		return false
 	}
@@ -3915,11 +3915,32 @@ func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *s
 	}
 }
 
-func (o *Orchestrator) amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
+func (o *Orchestrator) amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time, checkpointFile string) error {
 	if o.amendHeadFn != nil {
 		return o.amendHeadFn(worktreePath, branch, attribution, now)
 	}
-	return amendHeadWithAttributionTrailer(worktreePath, branch, attribution, now)
+	// CHECKPOINT.md is a Maestro-owned resumability artifact, not product work.
+	// A completed worker may deliberately leave it untracked in the canonical
+	// worktree. Ignore only this session's exact checkpoint path, and only while
+	// it is untracked; every other dirty path remains a hard amend deferral.
+	ignoredCheckpoint := attributionCheckpointRelativePath(worktreePath, checkpointFile)
+	return amendHeadWithAttributionTrailer(worktreePath, branch, attribution, now, ignoredCheckpoint)
+}
+
+func attributionCheckpointRelativePath(worktreePath, checkpointFile string) string {
+	worktreePath = strings.TrimSpace(worktreePath)
+	checkpointFile = strings.TrimSpace(checkpointFile)
+	if worktreePath == "" || checkpointFile == "" {
+		return ""
+	}
+	if !filepath.IsAbs(checkpointFile) {
+		checkpointFile = filepath.Join(worktreePath, checkpointFile)
+	}
+	rel, err := filepath.Rel(worktreePath, checkpointFile)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(rel))
 }
 
 // amendMaxAttempts bounds how many times amendHeadWithAttributionTrailer will
@@ -4013,7 +4034,7 @@ func isStaleInfoLeaseRejection(out string) bool {
 // When the remote advances between our fetch and our push, git rejects the lease
 // with "stale info"; the amend re-fetches and retries with backoff, deferring
 // (errAmendDeferred) if the branch keeps moving (#858).
-func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
+func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time, ignoredUntrackedPaths ...string) error {
 	worktreePath = strings.TrimSpace(worktreePath)
 	branch = strings.TrimSpace(branch)
 	if worktreePath == "" || branch == "" || len(attribution) == 0 {
@@ -4027,14 +4048,15 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 	}
 
 	for attempt := 1; attempt <= amendMaxAttempts; attempt++ {
-		// Never amend over a dirty tree: a worker may still be writing, and a
-		// force-push here could clobber uncommitted work the lease cannot
-		// protect (it only guards committed history). Defer instead.
-		status, err := amendGitCommand(worktreePath, "status", "--porcelain").CombinedOutput()
+		// Never amend over product work: a worker may still be writing, and a
+		// force-push here could clobber changes the lease cannot protect (it only
+		// guards committed history). The sole exception is the exact untracked
+		// Maestro checkpoint explicitly supplied by the owning session.
+		status, err := amendGitCommand(worktreePath, "status", "--porcelain=v1", "-z", "--untracked-files=all").CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("git status: %w\n%s", err, status)
 		}
-		if strings.TrimSpace(string(status)) != "" {
+		if attributionWorktreeHasBlockingChanges(status, ignoredUntrackedPaths) {
 			return errAmendWorktreeBusy
 		}
 
@@ -4143,6 +4165,34 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 		}
 	}
 	return errAmendDeferred
+}
+
+// attributionWorktreeHasBlockingChanges permits only explicitly named
+// untracked Maestro artifacts. Tracked modifications, staged files, renames,
+// and every other untracked path remain blocking. Porcelain -z keeps filenames
+// unquoted; a rename emits an extra path record, which intentionally falls
+// through as blocking rather than being parsed optimistically.
+func attributionWorktreeHasBlockingChanges(status []byte, ignoredUntrackedPaths []string) bool {
+	ignored := make(map[string]struct{}, len(ignoredUntrackedPaths))
+	for _, path := range ignoredUntrackedPaths {
+		path = filepath.ToSlash(filepath.Clean(strings.TrimSpace(path)))
+		if path != "" && path != "." {
+			ignored[path] = struct{}{}
+		}
+	}
+	for _, record := range strings.Split(string(status), "\x00") {
+		if record == "" {
+			continue
+		}
+		if len(record) >= 4 && record[:3] == "?? " {
+			path := filepath.ToSlash(filepath.Clean(record[3:]))
+			if _, ok := ignored[path]; ok {
+				continue
+			}
+		}
+		return true
+	}
+	return false
 }
 
 // fetchRemoteBranchOID fetches the remote branch tip into FETCH_HEAD and returns


### PR DESCRIPTION
## Summary

- allow attribution amend to proceed when the only dirty path is the owning session's exact untracked checkpoint
- preserve the checkpoint while stamping and pushing the attribution trailer
- keep every other untracked, tracked, staged, renamed, or modified path fail-closed

## Root cause

After an in-place worker completed, its canonical worktree intentionally retained untracked `CHECKPOINT.md` for durable recovery. `ensureAttributionTrailerOnBranch` treated any porcelain output as active product writes. The missing attribution trailer therefore remained permanently deferred, and the merge flow only observed red CI without scheduling the canonical repair. OK Player PR #388 reproduced this after worker `ok-player-302` had exited with no live tmux or model process.

## Impact

Completed work remains recoverable and the canonical branch can still receive its required attribution trailer. Once stamped, normal failed-CI repair can resume in place; no checkpoint deletion, duplicate worktree, or branch overwrite is needed.

## Validation

- exact untracked checkpoint preservation + remote trailer regression: 10 repeated runs
- checkpoint plus unrelated untracked product file remains blocked: 10 repeated runs
- complete attribution amend test group
- `go test ./internal/orchestrator ./internal/server ./internal/supervisor ./internal/state`
- `go test ./...`
- `go build ./cmd/maestro/`
- `git diff --check`

Refs #940

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lets attribution amend continue when only the session checkpoint is untracked. The main changes are:

- Pass the session checkpoint path into the attribution amend flow.
- Convert the checkpoint path to an exact worktree-relative ignored path.
- Parse NUL-delimited git porcelain output so only that untracked checkpoint is allowed.
- Add tests for preserving the checkpoint and blocking unrelated untracked work.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow, keeps fail-closed behavior for tracked, staged, renamed, and unrelated untracked paths, and includes focused tests for the changed behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran attribution checkpoint regression tests and verified they passed, including TestEnsureAttributionTrailer\_IgnoresOnlyPreservedUntrackedCheckpoint and TestAmendHead\_IgnoredCheckpointDoesNotHideOtherUntrackedWork.
- Ran the internal/orchestrator package tests and confirmed the package test run passed with PASS and EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14936921/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Updates attribution amend dirty-worktree detection to ignore only the owning session's exact untracked checkpoint while preserving fail-closed behavior for other changes. |
| internal/orchestrator/attribution_amend_test.go | Adds tests for preserving an untracked checkpoint during attribution amend and blocking when any additional untracked product work exists. |

<sub>Reviews (1): Last reviewed commit: ["fix: allow attribution past preserved ch..."](https://github.com/befeast/maestro/commit/2e2bafef15c93032ca8201fd47c40f9383ff2a0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45288420)</sub>

<!-- /greptile_comment -->