### PR TITLE
fix: bind CI repair to current PR head

### DIFF
--- a/internal/orchestrator/failing_check_test.go
+++ b/internal/orchestrator/failing_check_test.go
@@ -312,7 +312,7 @@ func TestHandleCIFailureRetry_CapturesFailingCheck(t *testing.T) {
 		s := state.NewState()
 		sess := &state.Session{IssueNumber: 42, IssueTitle: "t", Status: state.StatusPROpen, PRNumber: 10, Worktree: "/tmp/wt"}
 		s.Sessions["slot-1"] = sess
-		o.handleCIFailureRetry(s, "slot-1", sess, github.PR{Number: 10})
+		o.handleCIFailureRetry(s, "slot-1", sess, github.PR{Number: 10}, "")
 		return sess
 	}
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4260,6 +4260,16 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 	}
 
 	for slotName, sess := range s.Sessions {
+		// NextRetryAt is meaningful only while a dead session is queued for an
+		// in-place respawn. A pr_open session already owns its canonical PR and
+		// has no pending process start; retaining an expired retry marker there
+		// makes Fleet report a contradictory "open PR + overdue retry" state and
+		// can survive daemon restarts indefinitely. Normalize legacy/racy state
+		// before any remote reconciliation so the durable store self-heals.
+		if sess.Status == state.StatusPROpen && sess.NextRetryAt != nil {
+			log.Printf("[orch] clearing stale retry marker for pr_open session %s / PR #%d", slotName, sess.PRNumber)
+			sess.NextRetryAt = nil
+		}
 		switch sess.Status {
 		case state.StatusDone, state.StatusCodeLanded, state.StatusDead, state.StatusConflictFailed, state.StatusFailed, state.StatusRetryExhausted:
 			now := time.Now().UTC()
@@ -5157,9 +5167,7 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			}
 			// Auto-retry on CI failure: close the PR, capture CI output, and schedule retry
 			if sess.LastNotifiedStatus != "ci_failure" && sess.LastNotifiedStatus != "ci_retry_exhausted" {
-				sess.NotifiedCIFail = true // backward compat
-
-				o.handleCIFailureRetry(s, slotName, sess, pr)
+				o.handleCIFailureRetry(s, slotName, sess, pr, gateTransition.HeadSHA)
 			}
 		case "pending":
 			persistGate()
@@ -5973,11 +5981,17 @@ func (o *Orchestrator) handleReviewFeedbackRetry(s *state.State, slotName string
 // destroy canonical identity: closing the PR and clearing its session lease
 // let the ready issue dispatch a second worker before the retry completed
 // (live #949 / OK Player #346).
-func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, sess *state.Session, pr github.PR) {
+func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, sess *state.Session, pr github.PR, expectedHead string) {
 	maxRetries := o.cfg.MaxRetriesPerIssue
 	totalAttempts := s.FailedAttemptsForIssue(sess.IssueNumber) + sess.RetryCount
 
 	if maxRetries > 0 && totalAttempts >= maxRetries {
+		// Exhaustion is also a mutation of the exact PR lifecycle. Never mark a
+		// newer head retry-exhausted from an obsolete failed rollup.
+		if strings.TrimSpace(expectedHead) != "" && !o.prGateHeadMatches(pr.Number, expectedHead) {
+			return
+		}
+		sess.NotifiedCIFail = true // backward compat
 		log.Printf("[orch] CI failure on PR #%d — retry limit reached (%d/%d) for issue #%d",
 			pr.Number, totalAttempts, maxRetries, sess.IssueNumber)
 		alreadyNotified := sess.LastNotifiedStatus == "ci_retry_exhausted"
@@ -6018,6 +6032,16 @@ func (o *Orchestrator) handleCIFailureRetry(s *state.State, slotName string, ses
 	// exact lint constraint its previous push broke, not just "agent-lint
 	// failed" — this was the observed PR #850 blindness.
 	failingCheckContext := o.collectFailingCheckContext(pr.Number)
+
+	// The reads above can take seconds. A worker/operator push in that window
+	// invalidates every captured failure/review excerpt just as surely as a push
+	// before the caller's first head check. Re-check immediately before the first
+	// durable session mutation; the next cycle will observe the new head and
+	// decide from its own rollup instead of repairing stale evidence.
+	if strings.TrimSpace(expectedHead) != "" && !o.prGateHeadMatches(pr.Number, expectedHead) {
+		return
+	}
+	sess.NotifiedCIFail = true // backward compat
 
 	// Preserve the exact PR lease. Cleanup may already have cleared the
 	// worktree field on a terminal transition; record only the deterministic

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3224,6 +3224,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 			sess.PRNumber = pr.Number
 			sess.PID = 0
 			sess.TmuxSession = ""
+			sess.NextRetryAt = nil
 			now := time.Now().UTC()
 			sess.FinishedAt = &now
 			state.MarkWorkerEnded(sess, now)
@@ -5142,6 +5143,15 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			ready = append(ready, mergeCandidate{slotName: slotName, sess: sess, pr: pr})
 		case "failure":
 			persistGate()
+			// A failed rollup is actionable only for the exact head that was
+			// observed. Attribution stamping, an operator push, or another repair
+			// can advance the branch between listOpenPRsForCycle and this decision.
+			// Success/review paths already re-check this identity before mutating;
+			// failure must do the same or an old red head can schedule a repair
+			// after the new head is already pending (OK Player PR #388).
+			if gateObservable && !o.prGateHeadMatches(pr.Number, gateTransition.HeadSHA) {
+				continue
+			}
 			if sess.Status == state.StatusQueued {
 				sess.Status = state.StatusPROpen
 			}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -245,6 +245,7 @@ func TestSelectPrompt_CaseInsensitiveLabel(t *testing.T) {
 // to pr_open so that IssueInProgress returns true and no duplicate worker is spawned.
 func TestReconcileRunningSessions_DeadWorkerWithOpenPR_TransitionsToPROpen(t *testing.T) {
 	s := state.NewState()
+	retryAt := time.Now().UTC().Add(-time.Minute)
 	s.Sessions["mae-5"] = &state.Session{
 		IssueNumber: 105,
 		IssueTitle:  "fix crash",
@@ -252,6 +253,7 @@ func TestReconcileRunningSessions_DeadWorkerWithOpenPR_TransitionsToPROpen(t *te
 		PID:         9999,
 		TmuxSession: "maestro-mae-5",
 		Branch:      "feat/mae-5-105-fix-crash",
+		NextRetryAt: &retryAt,
 	}
 
 	openPRs := []github.PR{
@@ -281,6 +283,9 @@ func TestReconcileRunningSessions_DeadWorkerWithOpenPR_TransitionsToPROpen(t *te
 	}
 	if sess.TmuxSession != "" {
 		t.Fatalf("tmux_session = %q, want empty", sess.TmuxSession)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatalf("next_retry_at = %v, want nil after authoritative PR-open reconciliation", sess.NextRetryAt)
 	}
 	if sess.FinishedAt == nil {
 		t.Fatal("finished_at should be set")

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -335,6 +335,40 @@ func TestReconcileRunningSessions_DeadWithPendingRetry_NotFlippedToPROpen(t *tes
 	}
 }
 
+func TestCheckSessions_PROpenClearsStaleRetryMarker(t *testing.T) {
+	retryAt := time.Now().UTC().Add(-time.Minute)
+	s := state.NewState()
+	s.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406,
+		IssueTitle:  "canonical Flatpak repair",
+		Status:      state.StatusPROpen,
+		NextRetryAt: &retryAt,
+		RetryCount:  2,
+		Branch:      "feat/ok-player-345-flatpak-beta-retry",
+		PRNumber:    388,
+	}
+	o := &Orchestrator{
+		cfg:                 &config.Config{StateDir: t.TempDir()},
+		listOpenPRsFn:       func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn:     func(int) (bool, error) { return false, nil },
+		pidAliveFn:          func(int) bool { return false },
+		tmuxSessionExistsFn: func(string) bool { return false },
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["ok-player-302"]
+	if sess.Status != state.StatusPROpen {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusPROpen)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatalf("next_retry_at = %v, want nil for pr_open canonical session", sess.NextRetryAt)
+	}
+	if sess.RetryCount != 2 {
+		t.Fatalf("retry_count = %d, want preserved history 2", sess.RetryCount)
+	}
+}
+
 func TestCheckSessions_DonePRReleasesTerminalClaimAfterIssueCloses(t *testing.T) {
 	finishedAt := time.Now().UTC().Add(-time.Minute)
 	s := state.NewState()

--- a/internal/orchestrator/pr_gate_progress_test.go
+++ b/internal/orchestrator/pr_gate_progress_test.go
@@ -147,6 +147,50 @@ func TestAutoMergePRs_HeadChangeDuringReviewDefersExactSnapshotAndMerge(t *testi
 	}
 }
 
+func TestAutoMergePRs_HeadChangeAfterFailedRollupDoesNotScheduleStaleRetry(t *testing.T) {
+	pr := github.PR{Number: 388, HeadRefName: "feat/current-head-race"}
+	cfg := &config.Config{
+		Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none",
+		MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000,
+	}
+	o, merged := newMergeTestOrchestrator(cfg, []github.PR{pr})
+	oldHead := strings.Repeat("a", 40)
+	newHead := strings.Repeat("b", 40)
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{
+			HeadSHA: oldHead, Verdict: "failure", Fingerprint: strings.Repeat("9", 16), Complete: true,
+		}, nil
+	}
+	o.ghPRHeadSHAFn = func(int) (string, error) { return newHead, nil }
+	o.ghPRChecksOutputFn = func(int) (string, error) {
+		t.Fatal("stale failed head must not be consumed into a repair prompt")
+		return "", nil
+	}
+	o.ghCollectPRReviewFeedbackFn = func(int) (string, error) {
+		t.Fatal("stale failed head must not read review feedback for a repair")
+		return "", nil
+	}
+	o.ghPRFailingChecksFn = func(int) ([]github.FailingCheck, error) {
+		t.Fatal("stale failed head must not read failing-check logs for a repair")
+		return nil, nil
+	}
+	st := makeTestState([]github.PR{pr})
+	sess := st.Sessions["slot-0"]
+
+	o.autoMergePRs(st)
+
+	if sess.Status != state.StatusPROpen || sess.RetryCount != 0 || sess.NextRetryAt != nil {
+		t.Fatalf("stale failed head mutated session: status=%q retry=%d next=%v", sess.Status, sess.RetryCount, sess.NextRetryAt)
+	}
+	if len(*merged) != 0 {
+		t.Fatalf("head changed during failed-rollup observation but PR merged: %v", *merged)
+	}
+	snapshot := mustLatestPRGateSnapshot(t, st, sess.IssueNumber, pr.Number)
+	if snapshot.HeadSHA != oldHead || snapshot.CIEffectiveVerdict != state.PRGateCIFailure {
+		t.Fatalf("failed-head observation was not retained as read-only history: %+v", snapshot)
+	}
+}
+
 func TestAutoMergePRs_AttributionDeferralStillObservesCurrentPRGate(t *testing.T) {
 	pr := github.PR{Number: 13, HeadRefName: "feat/deferred-attribution"}
 	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none"}

--- a/internal/orchestrator/pr_gate_progress_test.go
+++ b/internal/orchestrator/pr_gate_progress_test.go
@@ -191,6 +191,49 @@ func TestAutoMergePRs_HeadChangeAfterFailedRollupDoesNotScheduleStaleRetry(t *te
 	}
 }
 
+func TestAutoMergePRs_HeadChangeWhileCollectingFailureContextDoesNotScheduleStaleRetry(t *testing.T) {
+	pr := github.PR{Number: 389, HeadRefName: "feat/late-head-race"}
+	cfg := &config.Config{
+		Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none",
+		MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000,
+	}
+	o, merged := newMergeTestOrchestrator(cfg, []github.PR{pr})
+	oldHead := strings.Repeat("c", 40)
+	newHead := strings.Repeat("d", 40)
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{
+			HeadSHA: oldHead, Verdict: "failure", Fingerprint: strings.Repeat("8", 16), Complete: true,
+		}, nil
+	}
+	headReads := 0
+	o.ghPRHeadSHAFn = func(int) (string, error) {
+		headReads++
+		if headReads == 1 {
+			return oldHead, nil
+		}
+		return newHead, nil
+	}
+	o.ghPRChecksOutputFn = func(int) (string, error) { return "old head failed", nil }
+	o.ghCollectPRReviewFeedbackFn = func(int) (string, error) { return "old head review", nil }
+	o.ghPRFailingChecksFn = func(int) ([]github.FailingCheck, error) {
+		return []github.FailingCheck{{Name: "old-check", Conclusion: "failure", Excerpt: "old head"}}, nil
+	}
+	st := makeTestState([]github.PR{pr})
+	sess := st.Sessions["slot-0"]
+
+	o.autoMergePRs(st)
+
+	if headReads != 2 {
+		t.Fatalf("head reads = %d, want pre-context and pre-mutation checks", headReads)
+	}
+	if sess.Status != state.StatusPROpen || sess.RetryCount != 0 || sess.NextRetryAt != nil || sess.NotifiedCIFail || sess.CIFailureOutput != "" || sess.FailingCheckContext != "" || sess.PreviousAttemptFeedback != "" {
+		t.Fatalf("late head move persisted stale retry context: %+v", sess)
+	}
+	if len(*merged) != 0 {
+		t.Fatalf("head changed while collecting failed context but PR merged: %v", *merged)
+	}
+}
+
 func TestAutoMergePRs_AttributionDeferralStillObservesCurrentPRGate(t *testing.T) {
 	pr := github.PR{Number: 13, HeadRefName: "feat/deferred-attribution"}
 	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none"}

--- a/internal/orchestrator/zombie_respawn_test.go
+++ b/internal/orchestrator/zombie_respawn_test.go
@@ -142,7 +142,7 @@ func TestRespawnDueRetries_PROpenDuringCIRetryThenMerged_NoRespawn(t *testing.T)
 	s.Sessions["ok-player-1"] = sess
 
 	// Step 1: CI fails — maestro retains PR #135 and schedules an in-place retry.
-	o.handleCIFailureRetry(s, "ok-player-1", sess, github.PR{Number: 135, HeadRefName: sess.Branch})
+	o.handleCIFailureRetry(s, "ok-player-1", sess, github.PR{Number: 135, HeadRefName: sess.Branch}, "")
 
 	if sess.Status != state.StatusDead || sess.NextRetryAt == nil {
 		t.Fatalf("after CI-retry: status = %q nextRetryAt = %v, want dead with a scheduled retry", sess.Status, sess.NextRetryAt)

--- a/internal/worker/attribution.go
+++ b/internal/worker/attribution.go
@@ -28,6 +28,11 @@ func beginSessionAttempt(cfg *config.Config, sess *state.Session, backendName, r
 	sess.UsageTokensWatermark = 0
 	sess.TokensUsedAttempt = 0
 	sess.WorkerOutcome = ""
+	// A scheduled retry owns NextRetryAt only until a replacement process has
+	// actually started. Keeping the elapsed timestamp on a Running attempt makes
+	// Fleet report contradictory queued/running state and lets a later terminal
+	// transition accidentally inherit an already-due retry.
+	sess.NextRetryAt = nil
 	recordBackendAttribution(cfg, sess, backendName, reason, previousEndReason, now)
 }
 

--- a/internal/worker/attribution_test.go
+++ b/internal/worker/attribution_test.go
@@ -64,6 +64,22 @@ func TestRecordBackendAttribution_FirstCall_SnapshotsMetadata(t *testing.T) {
 	}
 }
 
+func TestBeginSessionAttemptClearsScheduledRetryMarker(t *testing.T) {
+	cfg := attribCfgWithBackends()
+	retryAt := time.Date(2026, 7, 18, 5, 43, 24, 0, time.UTC)
+	sess := &state.Session{Status: state.StatusDead, NextRetryAt: &retryAt}
+	now := retryAt.Add(time.Second)
+
+	beginSessionAttempt(cfg, sess, "claude", "in_place_respawn", "ci_failure", now)
+
+	if sess.Status != state.StatusRunning {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusRunning)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatalf("next_retry_at = %v, want nil once replacement attempt is running", sess.NextRetryAt)
+	}
+}
+
 func TestRecordBackendAttribution_SecondCall_ClosesPreviousAndAppends(t *testing.T) {
 	cfg := attribCfgWithBackends()
 	sess := &state.Session{}


### PR DESCRIPTION
## What changed

- re-check the exact PR head before a failed CI rollup can schedule an in-place repair;
- clear the scheduled retry marker when a replacement worker attempt actually starts;
- clear a stale retry marker when a missing runtime is truthfully reconciled to its existing open PR;
- add regression coverage for the live OK Player PR #388 head-change race and both retry-marker transitions.

## Root cause

The success and review branches already guarded their side effects with an exact-head recheck, but the CI-failure branch did not. An attribution push advanced PR #388 to a new pending head while the same orchestration cycle still held an old failed rollup, so Maestro scheduled a repair for the obsolete revision. Separately, `beginSessionAttempt` and `running -> pr_open` reconciliation retained `NextRetryAt`, leaving contradictory retry state after the reservation was no longer valid.

## Impact

CI repair is now bound to the revision that actually failed. A newer pending head is observed without consuming retry budget or briefly presenting a queued retry as a live worker. Canonical session/worktree/PR identity remains unchanged.

Refs #940. The issue remains open until the required eight-hour soak is completed.

## Validation

- `go test -count=10 -run 'TestAutoMergePRs_HeadChangeAfterFailedRollupDoesNotScheduleStaleRetry|TestReconcileRunningSessions_DeadWorkerWithOpenPR_TransitionsToPROpen' ./internal/orchestrator`
- `go test -count=10 -run 'TestBeginSessionAttemptClearsScheduledRetryMarker' ./internal/worker`
- `go test ./...`
- `go build ./cmd/maestro/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps CI repair state tied to the PR head that actually failed. The main changes are:

- Re-checks the current PR head before scheduling or marking CI retry exhaustion.
- Re-checks again after collecting failure context, before mutating durable session state.
- Clears stale `NextRetryAt` markers when a session is reconciled to `pr_open`.
- Clears scheduled retry markers when a replacement worker attempt starts.
- Adds tests for the failed-head race and retry-marker transitions.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped to orchestration state transitions and include focused tests for the reported races.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex completed the requested verification, but local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds exact PR-head rechecks before CI retry mutations and clears stale retry markers for canonical PR-open sessions. |
| internal/orchestrator/pr_gate_progress_test.go | Adds tests for failed-rollup head races before and after failure-context collection. |
| internal/orchestrator/orchestrator_test.go | Extends reconciliation coverage to assert stale retry markers are cleared when sessions return to PR-open. |
| internal/worker/attribution.go | Clears scheduled retry timestamps when a replacement worker attempt starts. |
| internal/worker/attribution_test.go | Adds coverage confirming replacement attempts clear scheduled retry markers. |
| internal/orchestrator/failing_check_test.go | Updates CI-failure retry test call sites for the new expected-head parameter. |
| internal/orchestrator/zombie_respawn_test.go | Updates an existing CI retry respawn test for the new handler signature. |

<sub>Reviews (2): Last reviewed commit: ["fix: close late PR head retry race"](https://github.com/befeast/maestro/commit/e544808284836566a2da5b938f9055e9f923b152) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45289992)</sub>

<!-- /greptile_comment -->