### PR TITLE
fix: show open PR gates in Fleet activity

### DIFF
--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -993,6 +993,16 @@ func TestFleetSnapshotSeparatesLiveWorkersFromPRGates(t *testing.T) {
 		t.Fatalf("save live state: %v", err)
 	}
 
+	// Separated waiting project: open PR work remains, but there is no live
+	// implementation worker or eligible ready issue. Free implementation slots
+	// must not make Fleet erase the PR gate behind a generic queue_empty label.
+	waitingDir := filepath.Join(dir, "separated-waiting")
+	waitingState := state.NewState()
+	waitingState.Sessions["gate-1"] = &state.Session{Status: state.StatusPROpen, PRNumber: 301, IssueNumber: 31}
+	if err := state.Save(waitingDir, waitingState); err != nil {
+		t.Fatalf("save separated waiting state: %v", err)
+	}
+
 	srv := NewFleet([]FleetProject{
 		NewFleetProject("GateBound", "/tmp/gatebound.yaml", "", &config.Config{
 			Repo:        "owner/gatebound",
@@ -1004,6 +1014,12 @@ func TestFleetSnapshotSeparatesLiveWorkersFromPRGates(t *testing.T) {
 			StateDir:       liveDir,
 			MaxParallel:    2,
 			MaxLiveWorkers: 3,
+		}),
+		NewFleetProject("SeparatedWaiting", "/tmp/separated-waiting.yaml", "", &config.Config{
+			Repo:           "owner/separated-waiting",
+			StateDir:       waitingDir,
+			MaxParallel:    20,
+			MaxLiveWorkers: 20,
 		}),
 	}, "127.0.0.1", 8786, true)
 	resp := srv.snapshot()
@@ -1039,8 +1055,19 @@ func TestFleetSnapshotSeparatesLiveWorkersFromPRGates(t *testing.T) {
 		t.Errorf("separated activity = %q, want %q", sep.Activity, state.ActivityImplementing)
 	}
 
-	if resp.Summary.LiveWorkers != 1 || resp.Summary.PRGates != 5 {
-		t.Errorf("summary live_workers=%d pr_gates=%d, want 1/5", resp.Summary.LiveWorkers, resp.Summary.PRGates)
+	waiting := findFleetProject(t, resp.Projects, "SeparatedWaiting")
+	if waiting.LiveWorkers != 0 || waiting.PRGates != 1 || waiting.CapacityUsed != 0 || waiting.LiveWorkerLimit != 20 {
+		t.Fatalf("separated waiting live=%d gates=%d used=%d limit=%d, want 0/1/0/20", waiting.LiveWorkers, waiting.PRGates, waiting.CapacityUsed, waiting.LiveWorkerLimit)
+	}
+	if waiting.Activity != string(state.ActivityWaitingOnGates) {
+		t.Errorf("separated waiting activity = %q, want %q", waiting.Activity, state.ActivityWaitingOnGates)
+	}
+	if !contains(waiting.ActivityReason, "Waiting on PR gates") {
+		t.Errorf("separated waiting reason = %q, want truthful PR-gate explanation", waiting.ActivityReason)
+	}
+
+	if resp.Summary.LiveWorkers != 1 || resp.Summary.PRGates != 6 {
+		t.Errorf("summary live_workers=%d pr_gates=%d, want 1/6", resp.Summary.LiveWorkers, resp.Summary.PRGates)
 	}
 	if resp.Summary.CapacityBlockedByGates != 2 {
 		t.Errorf("summary capacity_blocked_by_gates = %d, want 2", resp.Summary.CapacityBlockedByGates)

--- a/internal/state/capacity_test.go
+++ b/internal/state/capacity_test.go
@@ -151,6 +151,16 @@ func TestClassifyActivity(t *testing.T) {
 			want: ActivityWaitingOnGates,
 		},
 		{
+			name: "separated gates with free slots and no eligible work are still waiting",
+			in:   ActivityInput{Capacity: Capacity{PRGates: 1, AvailableSlots: 20, Separated: true}, EligibleIssues: 0},
+			want: ActivityWaitingOnGates,
+		},
+		{
+			name: "separated gates do not block eligible work when slots remain",
+			in:   ActivityInput{Capacity: Capacity{PRGates: 1, AvailableSlots: 19, Separated: true}, EligibleIssues: 2},
+			want: ActivityIdle,
+		},
+		{
 			name: "empty queue",
 			in:   ActivityInput{Capacity: Capacity{AvailableSlots: 4}, EligibleIssues: 0},
 			want: ActivityQueueEmpty,

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -3827,12 +3827,17 @@ func ClassifyActivity(in ActivityInput) (ProjectActivity, string) {
 	}
 	// Gate-bound: no live worker and no free slot while PRs are open. Only a
 	// problem when eligible work is waiting — that is the recurring #814
-	// intervention loop. With eligible work drained it is simply "waiting".
-	if c.PRGates > 0 && c.AvailableSlots == 0 {
-		if in.EligibleIssues > 0 {
+	// intervention loop. With eligible work drained it is simply "waiting",
+	// including separated-concurrency projects where PR gates intentionally do
+	// not consume otherwise-free implementation slots. Calling that state
+	// queue_empty hides the real gate/outcome work still in flight.
+	if c.PRGates > 0 {
+		if in.EligibleIssues > 0 && c.AvailableSlots == 0 {
 			return ActivityBlockedByGates, fmt.Sprintf("Blocked by PR gates: %d PR gate(s) hold all capacity while %d ready issue(s) wait; raise max_live_workers or max_parallel to keep implementing.", c.PRGates, in.EligibleIssues)
 		}
-		return ActivityWaitingOnGates, fmt.Sprintf("Waiting on PR gates: %d PR(s) open, no eligible work left to dispatch.", c.PRGates)
+		if in.EligibleIssues <= 0 {
+			return ActivityWaitingOnGates, fmt.Sprintf("Waiting on PR gates: %d PR(s) open, no eligible work left to dispatch.", c.PRGates)
+		}
 	}
 	if in.EligibleIssues <= 0 {
 		return ActivityQueueEmpty, "Queue empty: no eligible ready issues to dispatch."


### PR DESCRIPTION
## Summary

- classify a no-worker project with open PR gates as `waiting_on_pr_gates` even when separated concurrency leaves implementation slots free
- preserve `blocked_by_pr_gates` only when gates actually consume all headroom while eligible issues wait
- add state and Fleet regressions for the live separated-concurrency case

## Root cause

`ClassifyActivity` nested both waiting and blocked gate states under `PRGates > 0 && AvailableSlots == 0`. That condition is false by design when `max_live_workers` separates worker capacity from PR gates. A project with an empty ready queue and an open PR/outcome gate therefore fell through to `queue_empty`, hiding the remaining hands-off lifecycle work.

## Live evidence

After #991 deployed, OK Player truthfully had `workers_running=0`, `pr_gates=1`, current-head CI pending, and a separate overdue post-merge verification target. Fleet nevertheless rendered `activity=queue_empty`. This change affects presentation only; it does not alter dispatch, concurrency, labels, models, workers, or approvals.

## Validation

- focused state + Fleet regressions, 10 repeated runs
- `go test ./internal/state ./internal/server`
- `go test ./...`
- `go build ./cmd/maestro/`
- `git diff --check`

Refs #992 and #940.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Fleet activity labels for projects waiting on open PR gates. The main changes are:

- Classifies open PR gates with no eligible work as `waiting_on_pr_gates`, even when worker slots are available.
- Keeps `blocked_by_pr_gates` limited to cases where PR gates consume all headroom while eligible issues wait.
- Adds state and Fleet tests for separated-concurrency PR gate activity.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to operator-facing activity classification and preserves existing handling for live work, approvals, model limits, and gate-bound eligible work.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Inspected the focused validation log to verify the test command, working directory, verbose test output, PASS lines, and EXIT\_CODE 0.
- Verified the Maestro build log shows go build ./cmd/maestro/ completed with EXIT\_CODE 0.
- Checked the diff-check log to confirm git diff --check finished with EXIT\_CODE 0.
- Reviewed the full Go test log to ensure go test ./... completed with EXIT\_CODE 0.

<a href="https://app.greptile.com/trex/runs/14938549/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Updates activity classification so open PR gates with no eligible issues report `waiting_on_pr_gates` even when worker slots are available. |
| internal/state/capacity_test.go | Adds tests for separated-concurrency PR gate classification with and without eligible work. |
| internal/server/fleet_test.go | Adds a Fleet snapshot test for a separated project waiting only on an open PR gate. |

<sub>Reviews (1): Last reviewed commit: ["fix: show open PR gates in fleet activit..."](https://github.com/befeast/maestro/commit/e89cfab939d1bff19ea0193b825748b6da362a0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45292953)</sub>

<!-- /greptile_comment -->