### PR TITLE
fix: monitor drafts while current-head CI runs

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2784,6 +2784,18 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 			return true
 		}
 	}
+	// A draft/WIP marker means the PR still needs lifecycle work, but it does
+	// not make that work actionable while the exact current head is already
+	// being tested. Recommending a repair here disagrees with the executor's
+	// current-head guard, burns one supervisor call every cycle, and presents a
+	// false action in Fleet. Conflicts remain actionable above; failed CI and an
+	// unavailable/unknown CI read retain the existing fail-closed repair path.
+	if ciReader, ok := e.reader.(prCIStatusReader); ok {
+		if ciStatus, err := ciReader.PRCIStatus(pr.Number); err == nil &&
+			strings.EqualFold(strings.TrimSpace(ciStatus), "pending") {
+			return false
+		}
+	}
 	if pr.IsDraft {
 		return true
 	}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -136,6 +136,15 @@ func (f *fakeReader) PRCIStatus(prNumber int) (string, error) {
 	return f.ciStatuses[prNumber], nil
 }
 
+func (f *fakeReader) PRMergeable(prNumber int) (string, error) {
+	for _, pr := range f.prs {
+		if pr.Number == prNumber {
+			return pr.Mergeable, nil
+		}
+	}
+	return "", nil
+}
+
 func (f *fakeReader) PRMergeStatus(prNumber int) (string, string, error) {
 	mergeable := ""
 	for _, pr := range f.prs {
@@ -725,6 +734,94 @@ func TestDecide_OpenPR_CIPending_StaysMonitor(t *testing.T) {
 	}
 	if !strings.Contains(strings.ToLower(decision.Summary), "ci status=pending") {
 		t.Fatalf("summary = %q, want a substring naming CI status pending", decision.Summary)
+	}
+}
+
+func TestDecide_DraftPRCurrentHeadCIPending_StaysMonitor(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	cfg.MaxParallel = 20
+	cfg.MaxLiveWorkers = 20
+	reader := &fakeReader{
+		issues:     []github.Issue{{Number: 406, Title: "Flatpak repair"}},
+		prs:        []github.PR{{Number: 388, HeadRefName: "feat/flatpak", Mergeable: "MERGEABLE", IsDraft: true}},
+		ciStatuses: map[int]string{388: "pending"},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406,
+		Status:      state.StatusRetryExhausted,
+		Branch:      "feat/flatpak",
+		PRNumber:    388,
+		RetryCount:  3,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr while exact-head CI is pending", decision.RecommendedAction)
+	}
+	if decision.Target == nil || decision.Target.PR != 388 || decision.Target.Session != "ok-player-302" {
+		t.Fatalf("target = %#v, want canonical PR #388 / ok-player-302", decision.Target)
+	}
+}
+
+func TestDecide_DraftPRCurrentHeadCIFailed_RecommendsRepair(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	cfg.MaxParallel = 20
+	cfg.MaxLiveWorkers = 20
+	reader := &fakeReader{
+		issues:     []github.Issue{{Number: 407, Title: "Flatpak red"}},
+		prs:        []github.PR{{Number: 389, HeadRefName: "feat/flatpak-red", Mergeable: "MERGEABLE", IsDraft: true}},
+		ciStatuses: map[int]string{389: "failure"},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-303"] = &state.Session{
+		IssueNumber: 407,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/flatpak-red",
+		PRNumber:    389,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnRepairWorker {
+		t.Fatalf("action = %q, want spawn_repair_worker for a failed draft head", decision.RecommendedAction)
+	}
+}
+
+func TestDecide_ConflictingDraftPRWithCIPending_RecommendsConflictRepair(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	cfg.MaxParallel = 20
+	cfg.MaxLiveWorkers = 20
+	reader := &fakeReader{
+		issues:     []github.Issue{{Number: 408, Title: "Conflict"}},
+		prs:        []github.PR{{Number: 390, HeadRefName: "feat/conflict", Mergeable: "CONFLICTING", IsDraft: true}},
+		ciStatuses: map[int]string{390: "pending"},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-304"] = &state.Session{
+		IssueNumber: 408,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/conflict",
+		PRNumber:    390,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnRepairWorker {
+		t.Fatalf("action = %q, want conflict repair to outrank pending CI", decision.RecommendedAction)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make the deterministic supervisor monitor a draft/WIP PR while its exact current head is already running CI
- keep conflicts actionable before the pending-CI guard
- preserve repair recommendations for genuinely failed draft heads
- add live-derived pending, failed, and conflicting regressions

## Root cause

`openPRNeedsRepair` returned true for every draft as soon as capacity was available. It never asked the reader whether the current head was pending. The orchestrator executor had the stronger current-head pre-dispatch guard and refused the action, so each supervisor pulse could spend a model call recommending a repair that deterministic execution already knew was not actionable.

## Live evidence

On OK Player PR #388, the orchestrator recorded `CI=pending` every 60 seconds and refused the repair recommendation every cycle. The supervisor nevertheless emitted `spawn_repair_worker` at 06:20 and 06:25 UTC using the obsolete failed-head narrative. No duplicate worker started, but Fleet and the supervisor action history were misleading and the supervisor call was wasted.

## Behavior

- conflicting PR: repair remains actionable even if CI is pending
- current-head CI pending: monitor the canonical PR, do not recommend repair
- current-head CI failure: existing in-place repair behavior remains
- unknown/unavailable CI: existing fail-closed behavior remains

No project config, concurrency, labels, models, worktrees, branches, or PR identity changes.

## Validation

- three focused regressions plus the existing pending-CI test, 10 repeated runs
- `go test ./internal/supervisor`
- `go test ./...`
- `go build ./cmd/maestro/`
- `git diff --check`

Refs #994, #940, and #991.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the deterministic supervisor behavior for draft PRs while current-head CI is running. The main changes are:

- Monitor draft/WIP PRs when their current CI status is `pending`.
- Keep conflict repair actionable before the pending-CI check.
- Preserve repair recommendations for failed draft heads and unknown CI reads.
- Add tests for pending, failed, and conflicting draft PR decision paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to supervisor decision ordering and includes focused tests for the changed behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the supervisor package tests; go test -v ./internal/supervisor completed with ok.
- Checked code diffs; git diff --check exited 0, indicating no issues.
- Built the Maestro binary; go build ./cmd/maestro/ completed with exit code 0.
- Created and uploaded the supervisor validation log artifact containing the full command output for review.

<a href="https://app.greptile.com/trex/runs/14938839/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Adds a pending-CI guard before draft PR repair recommendations while preserving conflict and failure repair paths. |
| internal/supervisor/supervisor_test.go | Adds focused supervisor decision tests for draft pending CI, failed draft CI, and conflicting draft PRs. |

<sub>Reviews (1): Last reviewed commit: ["fix: monitor drafts while current-head C..."](https://github.com/befeast/maestro/commit/b7b1f18c809510c34f8452fd3881e21996a540c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45293534)</sub>

<!-- /greptile_comment -->