### PR TITLE
fix: surface actionable idle blockers

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4021,24 +4021,6 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 			item.ApprovalSummary[approval.Status]++
 		}
 	}
-	// #814: classify why the project is (not) implementing so operators can tell
-	// an empty queue from a gate-bound-but-eligible pipeline. Signals are read
-	// from the same snapshot: eligible from the supervisor queue analysis,
-	// pending approvals from the approval summary, model limits from backend
-	// health.
-	eligibleIssues := 0
-	if item.QueueSnapshot != nil {
-		eligibleIssues = item.QueueSnapshot.Eligible
-	}
-	activity, activityReason := state.ClassifyActivity(state.ActivityInput{
-		Capacity:         capacity,
-		EligibleIssues:   eligibleIssues,
-		PendingApprovals: item.ApprovalSummary["pending"],
-		BackendsBlocked:  allBackendsBlocked(item.BackendHealth, configuredWorkerBackends(cfg)),
-		Paused:           item.Paused,
-	})
-	item.Activity = string(activity)
-	item.ActivityReason = activityReason
 	staleAudits := reconcileStaleSessions(cfg, st, now)
 	staleSlots := make(map[string]state.StaleSessionAudit, len(staleAudits))
 	for _, audit := range staleAudits {
@@ -4087,6 +4069,28 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 			item.Active = append(item.Active, worker)
 		}
 	}
+	// #814/#996: classify only after canonical attention has been counted and
+	// stale/historical sessions have been suppressed. Otherwise a failed,
+	// retry-exhausted open PR has no live worker or PRGate capacity entry and
+	// falsely falls through to queue_empty while its in-place repair is pending.
+	eligibleIssues := 0
+	if item.QueueSnapshot != nil {
+		eligibleIssues = item.QueueSnapshot.Eligible
+	}
+	actionableAttention := item.NeedsAttention - item.SelfResolving
+	if actionableAttention < 0 {
+		actionableAttention = 0
+	}
+	activity, activityReason := state.ClassifyActivity(state.ActivityInput{
+		Capacity:            capacity,
+		EligibleIssues:      eligibleIssues,
+		PendingApprovals:    item.ApprovalSummary["pending"],
+		ActionableAttention: actionableAttention,
+		BackendsBlocked:     allBackendsBlocked(item.BackendHealth, configuredWorkerBackends(cfg)),
+		Paused:              item.Paused,
+	})
+	item.Activity = string(activity)
+	item.ActivityReason = activityReason
 	item.OperatorState = buildFleetProjectOperatorState(item)
 	return item, workers
 }

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -4243,6 +4243,12 @@ func TestFleetAPIRetryExhaustedWithFailedChecksRemainsActionable(t *testing.T) {
 		t.Fatalf("verdict tone = %q, want attention (failing-CI PR is operator-actionable)", resp.Verdict.Tone)
 	}
 	project := findFleetProject(t, resp.Projects, "maestro")
+	if project.Activity != string(state.ActivityNeedsAttention) {
+		t.Fatalf("project activity = %q, want %q (failed canonical work must not render queue_empty)", project.Activity, state.ActivityNeedsAttention)
+	}
+	if !contains(project.ActivityReason, "Needs attention") {
+		t.Fatalf("project activity reason = %q, want explicit attention blocker", project.ActivityReason)
+	}
 	if project.OperatorState.Kind != "attention" {
 		t.Fatalf("project operator_state.kind = %q, want attention", project.OperatorState.Kind)
 	}

--- a/internal/state/capacity_test.go
+++ b/internal/state/capacity_test.go
@@ -141,6 +141,11 @@ func TestClassifyActivity(t *testing.T) {
 			want: ActivityBlockedByApprovals,
 		},
 		{
+			name: "actionable failed work is not an empty queue",
+			in:   ActivityInput{Capacity: Capacity{AvailableSlots: 4}, EligibleIssues: 0, ActionableAttention: 1},
+			want: ActivityNeedsAttention,
+		},
+		{
 			name: "gate-bound with eligible work is the intervention loop",
 			in:   ActivityInput{Capacity: Capacity{PRGates: 3, AvailableSlots: 0}, EligibleIssues: 5},
 			want: ActivityBlockedByGates,

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -3792,6 +3792,7 @@ const (
 	ActivityWaitingOnGates       ProjectActivity = "waiting_on_pr_gates"     // no live worker, PRs open, and no eligible work left — just waiting for gates
 	ActivityBlockedByApprovals   ProjectActivity = "blocked_by_approvals"    // dispatch is held pending an operator approval decision
 	ActivityBlockedByModelLimits ProjectActivity = "blocked_by_model_limits" // every eligible backend is blocked by a model/usage limit
+	ActivityNeedsAttention       ProjectActivity = "needs_attention"         // no live worker; canonical actionable work requires repair/reconciliation
 	ActivityPaused               ProjectActivity = "paused"                  // operator paused the project
 	ActivityQueueEmpty           ProjectActivity = "queue_empty"             // no eligible ready issues remain
 	ActivityIdle                 ProjectActivity = "idle"                    // idle for none of the more specific reasons above
@@ -3800,11 +3801,12 @@ const (
 // ActivityInput carries the non-session signals ClassifyActivity needs beyond
 // the session-derived Capacity snapshot.
 type ActivityInput struct {
-	Capacity         Capacity
-	EligibleIssues   int  // ready issues that could be dispatched now
-	PendingApprovals int  // spawn/merge approvals awaiting an operator decision
-	BackendsBlocked  bool // every eligible backend is blocked by a model/usage limit
-	Paused           bool // operator paused the project
+	Capacity            Capacity
+	EligibleIssues      int  // ready issues that could be dispatched now
+	PendingApprovals    int  // spawn/merge approvals awaiting an operator decision
+	ActionableAttention int  // canonical, non-self-resolving worker/session blockers
+	BackendsBlocked     bool // every eligible backend is blocked by a model/usage limit
+	Paused              bool // operator paused the project
 }
 
 // ClassifyActivity returns the ProjectActivity token and a concise
@@ -3824,6 +3826,9 @@ func ClassifyActivity(in ActivityInput) (ProjectActivity, string) {
 	}
 	if in.PendingApprovals > 0 {
 		return ActivityBlockedByApprovals, fmt.Sprintf("Blocked by approvals: %d decision(s) awaiting an operator.", in.PendingApprovals)
+	}
+	if in.ActionableAttention > 0 {
+		return ActivityNeedsAttention, fmt.Sprintf("Needs attention: %d actionable worker/session blocker(s) require repair or reconciliation.", in.ActionableAttention)
 	}
 	// Gate-bound: no live worker and no free slot while PRs are open. Only a
 	// problem when eligible work is waiting — that is the recurring #814


### PR DESCRIPTION
Refs #996.

## What changed

- classify Fleet activity only after canonical attention and stale-session reconciliation are known
- add a `needs_attention` activity state for actionable, non-self-resolving blockers
- preserve the existing precedence for live work, pause, backend limits, approvals, and PR gates
- pin the retry-exhausted/current-head-failure incident with state and Fleet integration tests

## Root cause

Fleet classified activity before it counted canonical attention sessions. A retry-exhausted PR with failed current-head checks contributed neither a live worker nor a `pr_open` capacity gate, so an empty eligible queue incorrectly produced `queue_empty` while an in-place repair was pending.

## Validation

- `go test ./internal/state -run "TestClassifyActivity|TestSessionAttentionFor_RetryExhaustedPRWithFailedChecks" -count=1`
- `go test ./internal/server -run "TestFleetAPIRetryExhaustedWithFailedChecksRemainsActionable|TestFleetCapacitySplitAndActivity" -count=1`
- `umask 077; go test ./...`
- `go build ./cmd/maestro/`

The initial full-suite run under shell umask `0002` correctly tripped existing prompt-directory security tests; rerunning with the owner-only test invariant (`umask 077`) passed the full suite.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Fleet activity classification so actionable blockers are surfaced correctly. The main changes are:

- Delays project activity classification until stale and canonical attention reconciliation are complete.
- Adds a `needs_attention` activity state for actionable, non-self-resolving worker or session blockers.
- Preserves higher-priority activity states for live work, pauses, backend limits, approvals, and PR gates.
- Adds regression coverage for retry-exhausted PRs with failed current-head checks.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to activity classification and includes targeted tests for the reported regression. No correctness or security issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran Go validation tests and saved a transcript that records command, working directory, exit code, and duration for targeted tests, the full test suite, and the build.
- The state test transcript shows TestClassifyActivity subcases for live workers, pause precedence, model limits, approvals, failed actionable work, PR gates, empty queue, and idle work, all passing.
- The server test transcript shows TestFleetAPIRetryExhaustedWithFailedChecksRemainsActionable passing.
- The full-suite transcript shows all Go packages passing and the build transcript reports a successful command build.

<a href="https://app.greptile.com/trex/runs/14939412/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Moves Fleet activity classification after stale and canonical attention reconciliation, then passes actionable attention into the classifier. |
| internal/state/state.go | Adds the `needs_attention` activity state and classifier input while preserving existing precedence. |
| internal/server/fleet_test.go | Extends Fleet API coverage for retry-exhausted failed-check PRs to assert `needs_attention` activity. |
| internal/state/capacity_test.go | Adds classifier coverage for actionable attention when the eligible queue is empty. |

<sub>Reviews (1): Last reviewed commit: ["fix: surface actionable idle blockers"](https://github.com/befeast/maestro/commit/9e5e18fcfc2475bf74103d34ce12be814ebaca90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45294622)</sub>

<!-- /greptile_comment -->