### PR TITLE
fix(github): prefer latest check rerun attempt

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -24,13 +24,20 @@ import (
 )
 
 type greptileCheckRun struct {
-	ID         int64  `json:"id"`
-	Name       string `json:"name"`
-	Status     string `json:"status"`
-	Conclusion string `json:"conclusion"`
-	HTMLURL    string `json:"html_url"`
-	DetailsURL string `json:"details_url"`
-	Output     struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	Conclusion  string `json:"conclusion"`
+	CreatedAt   string `json:"created_at"`
+	StartedAt   string `json:"started_at"`
+	CompletedAt string `json:"completed_at"`
+	HTMLURL     string `json:"html_url"`
+	DetailsURL  string `json:"details_url"`
+	App         struct {
+		ID   int64  `json:"id"`
+		Slug string `json:"slug"`
+	} `json:"app"`
+	Output struct {
 		Title   string `json:"title"`
 		Summary string `json:"summary"`
 		Text    string `json:"text"`
@@ -1523,7 +1530,68 @@ func parseCheckRuns(out []byte) ([]greptileCheckRun, error) {
 	if err := json.Unmarshal(out, &payload); err != nil {
 		return nil, err
 	}
-	return payload.CheckRuns, nil
+	return latestLogicalCheckRuns(payload.CheckRuns), nil
+}
+
+// latestLogicalCheckRuns collapses historical rerun attempts into GitHub's
+// current logical check contexts. The checks API returns every attempt for a
+// commit, so treating all rows as simultaneously authoritative lets an old
+// failure override a newer successful rerun on the same head (#998). GitHub
+// check contexts are identified by app + name; creation/start time and the
+// public monotonic check-run ID select the newest attempt deterministically.
+func latestLogicalCheckRuns(checks []greptileCheckRun) []greptileCheckRun {
+	if len(checks) < 2 {
+		return checks
+	}
+	latest := make(map[string]greptileCheckRun, len(checks))
+	order := make([]string, 0, len(checks))
+	for _, check := range checks {
+		key := logicalCheckRunKey(check)
+		current, ok := latest[key]
+		if !ok {
+			latest[key] = check
+			order = append(order, key)
+			continue
+		}
+		if checkRunNewer(check, current) {
+			latest[key] = check
+		}
+	}
+	result := make([]greptileCheckRun, 0, len(order))
+	for _, key := range order {
+		result = append(result, latest[key])
+	}
+	return result
+}
+
+func logicalCheckRunKey(check greptileCheckRun) string {
+	name := strings.ToLower(strings.TrimSpace(check.Name))
+	if name == "" {
+		return fmt.Sprintf("id:%d", check.ID)
+	}
+	app := fmt.Sprintf("id:%d", check.App.ID)
+	if check.App.ID == 0 {
+		app = "slug:" + strings.ToLower(strings.TrimSpace(check.App.Slug))
+	}
+	return app + "\x00" + name
+}
+
+func checkRunNewer(candidate, current greptileCheckRun) bool {
+	candidateAt := checkRunCreatedAt(candidate)
+	currentAt := checkRunCreatedAt(current)
+	if !candidateAt.Equal(currentAt) {
+		return candidateAt.After(currentAt)
+	}
+	return candidate.ID > current.ID
+}
+
+func checkRunCreatedAt(check greptileCheckRun) time.Time {
+	for _, raw := range []string{check.StartedAt, check.CreatedAt, check.CompletedAt} {
+		if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw)); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
 }
 
 func parseCombinedStatus(out []byte) (combinedStatusResponse, error) {
@@ -1535,6 +1603,7 @@ func parseCombinedStatus(out []byte) (combinedStatusResponse, error) {
 }
 
 func ciStatusFromREST(checks []greptileCheckRun, combined combinedStatusResponse) string {
+	checks = latestLogicalCheckRuns(checks)
 	// GitHub's combined commit-status API returns state:"pending" with
 	// statuses:[] for any commit that has zero legacy commit statuses — the
 	// normal case for repos that report CI exclusively via check-runs.
@@ -1568,6 +1637,7 @@ func ciStatusFromREST(checks []greptileCheckRun, combined combinedStatusResponse
 }
 
 func formatChecksOverview(checks []greptileCheckRun, combined combinedStatusResponse) string {
+	checks = latestLogicalCheckRuns(checks)
 	var lines []string
 	for _, check := range checks {
 		state := strings.TrimSpace(check.Conclusion)
@@ -2206,6 +2276,7 @@ func (c *Client) PRCIStatus(prNumber int) (string, error) {
 }
 
 func ciCheckRollupFingerprint(checks []greptileCheckRun, combined combinedStatusResponse) string {
+	checks = latestLogicalCheckRuns(checks)
 	parts := make([]string, 0, len(checks)+len(combined.Statuses)+1)
 	parts = append(parts, "combined="+strings.ToLower(strings.TrimSpace(combined.State)))
 	for _, check := range checks {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -214,6 +214,38 @@ func TestCIStatusFromREST(t *testing.T) {
 		{name: "cancelled check fails", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "cancelled"}}, want: "failure"},
 		{name: "success checks pass", checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}}, want: "success"},
 		{
+			name: "new success supersedes same-head failed attempt",
+			checks: []greptileCheckRun{
+				{ID: 10, Name: "agent-lint", Status: "completed", Conclusion: "failure", StartedAt: "2026-07-18T06:49:50Z"},
+				{ID: 20, Name: "agent-lint", Status: "completed", Conclusion: "success", StartedAt: "2026-07-18T06:51:30Z"},
+			},
+			want: "success",
+		},
+		{
+			name: "new failure supersedes same-head successful attempt",
+			checks: []greptileCheckRun{
+				{ID: 10, Name: "agent-lint", Status: "completed", Conclusion: "success", StartedAt: "2026-07-18T06:49:50Z"},
+				{ID: 20, Name: "agent-lint", Status: "completed", Conclusion: "failure", StartedAt: "2026-07-18T06:51:30Z"},
+			},
+			want: "failure",
+		},
+		{
+			name: "new pending rerun supersedes same-head failure",
+			checks: []greptileCheckRun{
+				{ID: 10, Name: "agent-lint", Status: "completed", Conclusion: "failure", StartedAt: "2026-07-18T06:49:50Z"},
+				{ID: 20, Name: "agent-lint", Status: "in_progress", StartedAt: "2026-07-18T06:51:30Z"},
+			},
+			want: "pending",
+		},
+		{
+			name: "different failing check remains authoritative",
+			checks: []greptileCheckRun{
+				{ID: 10, Name: "agent-lint", Status: "completed", Conclusion: "success", StartedAt: "2026-07-18T06:51:30Z"},
+				{ID: 20, Name: "build", Status: "completed", Conclusion: "failure", StartedAt: "2026-07-18T06:50:12Z"},
+			},
+			want: "failure",
+		},
+		{
 			name:     "green checks with empty combined pending succeed",
 			checks:   []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}},
 			combined: combinedStatusResponse{State: "pending", Statuses: nil},
@@ -249,6 +281,26 @@ func TestCIStatusFromREST(t *testing.T) {
 				t.Fatalf("ciStatusFromREST() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseCheckRunsKeepsLatestAttemptPerAppAndName(t *testing.T) {
+	checks, err := parseCheckRuns([]byte(`{
+		"check_runs": [
+			{"id": 30, "name": "agent-lint", "status": "completed", "conclusion": "success", "started_at": "2026-07-18T06:51:30Z", "app": {"id": 15368, "slug": "github-actions"}},
+			{"id": 10, "name": "agent-lint", "status": "completed", "conclusion": "failure", "started_at": "2026-07-18T06:49:50Z", "app": {"id": 15368, "slug": "github-actions"}},
+			{"id": 20, "name": "build", "status": "completed", "conclusion": "success", "started_at": "2026-07-18T06:50:12Z", "app": {"id": 15368, "slug": "github-actions"}},
+			{"id": 40, "name": "agent-lint", "status": "completed", "conclusion": "failure", "started_at": "2026-07-18T06:52:00Z", "app": {"id": 999, "slug": "another-app"}}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("parseCheckRuns() error = %v", err)
+	}
+	if len(checks) != 3 {
+		t.Fatalf("len(checks) = %d, want 3 logical contexts: %#v", len(checks), checks)
+	}
+	if checks[0].ID != 30 || checks[0].Conclusion != "success" {
+		t.Fatalf("github-actions agent-lint = %#v, want latest success id 30", checks[0])
 	}
 }
 

--- a/internal/github/pr_check_rollup_test.go
+++ b/internal/github/pr_check_rollup_test.go
@@ -35,3 +35,14 @@ func TestCICheckRollupFingerprint_IsOrderStableAndSemantic(t *testing.T) {
 		t.Fatalf("fingerprint length = %d, want bounded digest", len(first))
 	}
 }
+
+func TestCICheckRollupFingerprintIgnoresSupersededAttemptHistory(t *testing.T) {
+	current := greptileCheckRun{ID: 20, Name: "agent-lint", Status: "completed", Conclusion: "success", StartedAt: "2026-07-18T06:51:30Z"}
+	stale := greptileCheckRun{ID: 10, Name: "agent-lint", Status: "completed", Conclusion: "failure", StartedAt: "2026-07-18T06:49:50Z"}
+
+	want := ciCheckRollupFingerprint([]greptileCheckRun{current}, combinedStatusResponse{})
+	got := ciCheckRollupFingerprint([]greptileCheckRun{stale, current}, combinedStatusResponse{})
+	if got != want {
+		t.Fatalf("superseded attempt changed fingerprint: got=%q want=%q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- collapse historical GitHub check-run attempts by app and check name
- use only the newest same-head attempt for CI status, check summaries, and watchdog fingerprints
- preserve independent checks and make pending or failed reruns authoritative

## Test plan
- `go test ./internal/github -count=1`
- `umask 077; go test ./...`
- `go build ./cmd/maestro/`

Refs #998

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates GitHub check-run handling so rerun history does not override the latest attempt. The main changes are:

- Adds check-run app and timestamp fields to the REST parsing model.
- Collapses check runs by logical app/name context before CI status, overview, and fingerprint calculations.
- Adds tests for newer success, failure, pending reruns, independent checks, and fingerprint stability.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is focused and applies the same normalization across the affected CI status paths. Tests cover the rerun cases described by the PR.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused Go test for the Github package was run and passed with EXIT\_CODE: 0.
- The full Go test suite was run and all packages passed with EXIT\_CODE: 0.
- The Maestro build was executed and completed with EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14940024/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds logical check-run normalization before CI verdicts, check summaries, and rollup fingerprints. |
| internal/github/github_test.go | Adds CI status tests for latest rerun attempts and independent checks. |
| internal/github/pr_check_rollup_test.go | Adds fingerprint coverage for superseded check-run attempts. |

<sub>Reviews (1): Last reviewed commit: ["fix(github): prefer latest check rerun a..."](https://github.com/befeast/maestro/commit/99ef10d666fab4e15b70147e28188b9a1864f3f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45295769)</sub>

<!-- /greptile_comment -->