### PR TITLE
fix: keep backend attribution out of product commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ from the repo root) working in the maestro repository.
 ## Commit-message & PR convention
 
 - **Do NOT add `Co-authored-by: Claude …` or `🤖 Generated with Claude Code`
-  trailers** to commit messages or PR bodies. maestro attributes work via its
-  own durable trailer (below); the Claude/agent byline is noise in this repo's
-  history and is intentionally suppressed.
+  trailers** to commit messages or PR bodies. Maestro attributes work in its
+  internal durable state; agent bylines and control-plane telemetry are noise
+  in product history and are intentionally suppressed.
 
   > Note: the `Co-authored-by` byline is emitted by the Claude Code *harness*,
   > not by maestro code. The deterministic switch that stops it is
@@ -16,12 +16,12 @@ from the repo root) working in the maestro repository.
   > document records the convention; an operator still has to set that flag for
   > the trailer to actually disappear.
 
-- **Do preserve the `Maestro-Backend:` trailer on commits.** maestro stamps it
-  on commit messages (`internal/state/attribution.go`,
-  `state.AttributionTrailerKey`) to record the backend timeline for a session.
-  It is the canonical, queryable attribution for this repo — never strip,
-  rewrite, or duplicate it. It goes on commits only: PR bodies must contain no
-  backend/model attribution, pids, tmux session names, or host-side paths,
+- **Keep backend attribution internal.** Maestro records the backend timeline
+  in its durable state and Fleet Mission Control. Do not add provider/model,
+  effort, retry, host, or session telemetry to product commit messages or PR
+  bodies. Historical `Maestro-Backend:` trailers remain readable, but Maestro
+  must not amend or force-push target branches solely to add them. PR bodies
+  must contain no backend/model attribution, pids, tmux session names, or host-side paths,
   because they land on target repos that may be public (#799).
 
 - **Do NOT use GitHub auto-closing keywords** (`Closes`, `Fixes`, `Resolves`,

--- a/docs/model-routing-rfc.md
+++ b/docs/model-routing-rfc.md
@@ -283,8 +283,9 @@ dispatched to the single `model.default` regardless of band.
 - Surfaced in `maestro status` (the `BACKEND` column,
   `cmd/maestro/main.go:1461`), the fleet API / Mission Control drawer
   (`internal/server/fleet.go:1152-1155`, `internal/server/server.go:381,416`),
-  and the durable `Maestro-Backend:` commit/PR trailer
-  (`internal/state/attribution.go:9-20`).
+  and the durable internal session attribution timeline. Historical
+  `Maestro-Backend:` trailers remain parseable for compatibility, but routing
+  telemetry is not written to product commits (#1000).
 
 The gap: `SelectionReason` records **which lever fired**, not **why the task
 warranted a strength**. And `CandidateScores.Fit`/`Policy` are constant
@@ -495,10 +496,10 @@ Make the decision self-explaining (closing the §1.6 gap):
     (`internal/server/web/mc/src/` never reads `backend_selection`); rendering
     them in the drawer is a tracked frontend follow-up, not part of #791/#792.
     The data is already exposed on the API for whoever wires the view.
-- Keep the durable `Maestro-Backend:` trailer
-  (`internal/state/attribution.go:9-20`) as the canonical backend timeline —
-  escalation simply appends a new segment with its `EndReason`, which the trailer
-  already models.
+- Keep the durable internal session attribution timeline as the canonical
+  backend record. Escalation appends a new segment with its `EndReason` in
+  Maestro state and Fleet; it must not rewrite the product repository's commit
+  history (#1000).
 
 ### 2.8 Rollout
 

--- a/internal/orchestrator/attribution_merge_guard_test.go
+++ b/internal/orchestrator/attribution_merge_guard_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/befeast/maestro/internal/state"
 )
 
-// mergeGuardSession builds a merge-eligible session that carries attribution, so
-// autoMergePRs will attempt the pre-merge attribution amend before deciding
-// whether to merge.
+// mergeGuardSession builds a merge-eligible session carrying a complete
+// internal attribution timeline. That state must not cause any target-branch
+// mutation (#1000).
 func mergeGuardSession(branch string, pr int) *state.Session {
 	return &state.Session{
 		IssueNumber: 858,
@@ -32,119 +32,38 @@ func mergeGuardSession(branch string, pr int) *state.Session {
 	}
 }
 
-// When the pre-merge attribution amend defers (the branch is still advancing
-// under a concurrent worker/operator push), autoMergePRs must NOT let the PR
-// reach the merge decision this cycle: merging now would land it permanently
-// without the required Maestro-Backend trailer while the deferral's promised
-// retry never runs. CI observation is still safe and required for watchdog
-// truth; a later quiet cycle can stamp the trailer and then merge (#858/#940).
-func TestAutoMergePRs_DeferredAttributionBlocksMerge(t *testing.T) {
-	branch := "feat/sup-858-amend-race"
+// Attribution is durable in Maestro state and Fleet, not in product commits.
+// The merge path must ignore the legacy amend hook and continue to observe the
+// authoritative PR gate even if that hook would have failed (#1000).
+func TestAutoMergePRs_InternalAttributionNeverAmendsProductBranch(t *testing.T) {
+	branch := "feat/sup-1000-internal-attribution"
 	s := state.NewState()
 	s.Sessions["sup-858"] = mergeGuardSession(branch, 864)
 
 	ciQueried := false
-	merged := false
+	amendCalled := false
 	o := &Orchestrator{
 		cfg: &config.Config{},
 		listOpenPRsFn: func() ([]github.PR, error) {
 			return []github.PR{{Number: 864, HeadRefName: branch}}, nil
 		},
 		amendHeadFn: func(worktreePath, b string, attribution []state.BackendAttribution, now time.Time) error {
-			return errAmendDeferred
+			amendCalled = true
+			return errors.New("legacy amend hook must be unreachable")
 		},
 		ghPRCIStatusFn: func(prNumber int) (string, error) {
 			ciQueried = true
-			return "success", nil
-		},
-		ghMergePRFn: func(prNumber int) error {
-			merged = true
-			return nil
+			return "", errors.New("stop after proving normal gate observation")
 		},
 	}
 
 	o.autoMergePRs(s)
 
-	if merged {
-		t.Fatal("deferred attribution amend must block the merge — ghMergePRFn was called (#858)")
+	if amendCalled {
+		t.Fatal("merge path invoked legacy attribution amend hook")
 	}
 	if !ciQueried {
-		t.Fatal("deferred attribution amend must still observe CI for watchdog truth")
-	}
-	// The session stays merge-eligible so a later quiet cycle completes it.
-	if s.Sessions["sup-858"].Status != state.StatusPROpen {
-		t.Fatalf("session status = %q, want pr_open (still awaiting a quiet cycle)", s.Sessions["sup-858"].Status)
-	}
-}
-
-// An unexpected amend failure is just as unsafe as a known deferral: the
-// trailer is not known to be on the remote, so the merge path must fail closed.
-// Read-only CI observation remains allowed and keeps durable gate state fresh.
-func TestAutoMergePRs_UnexpectedAttributionFailureBlocksMerge(t *testing.T) {
-	branch := "feat/sup-873-amend-error"
-	s := state.NewState()
-	s.Sessions["sup-873"] = mergeGuardSession(branch, 875)
-
-	ciQueried := false
-	merged := false
-	o := &Orchestrator{
-		cfg: &config.Config{},
-		listOpenPRsFn: func() ([]github.PR, error) {
-			return []github.PR{{Number: 875, HeadRefName: branch}}, nil
-		},
-		amendHeadFn: func(worktreePath, b string, attribution []state.BackendAttribution, now time.Time) error {
-			return errors.New("ordinary git failure")
-		},
-		ghPRCIStatusFn: func(prNumber int) (string, error) {
-			ciQueried = true
-			return "success", nil
-		},
-		ghMergePRFn: func(prNumber int) error {
-			merged = true
-			return nil
-		},
-	}
-
-	o.autoMergePRs(s)
-
-	if merged {
-		t.Fatal("unexpected attribution failure must block the merge")
-	}
-	if !ciQueried {
-		t.Fatal("unexpected attribution failure must still observe CI for watchdog truth")
-	}
-}
-
-// The guard is specific to the deferral: when the attribution amend lands (or is
-// a no-op), autoMergePRs proceeds past the attribution step into the normal
-// merge flow (here it reaches the CI query). This proves the guard does not
-// over-block PRs whose trailer is already settled.
-func TestAutoMergePRs_SettledAttributionProceedsToMergeFlow(t *testing.T) {
-	branch := "feat/sup-858-amend-settled"
-	s := state.NewState()
-	s.Sessions["sup-858"] = mergeGuardSession(branch, 870)
-
-	ciQueried := false
-	o := &Orchestrator{
-		cfg: &config.Config{},
-		listOpenPRsFn: func() ([]github.PR, error) {
-			return []github.PR{{Number: 870, HeadRefName: branch}}, nil
-		},
-		amendHeadFn: func(worktreePath, b string, attribution []state.BackendAttribution, now time.Time) error {
-			return nil // trailer landed / already present
-		},
-		ghPRCIStatusFn: func(prNumber int) (string, error) {
-			ciQueried = true
-			// Return an error so the flow stops here without needing the full
-			// review-gate/merge machinery; reaching this hook is the assertion.
-			return "", errors.New("ci lookup stops the test here")
-		},
-	}
-
-	o.autoMergePRs(s)
-
-	if !ciQueried {
-		t.Fatal("a settled attribution amend must let the merge flow proceed past attribution to the CI query")
+		t.Fatal("normal CI gate observation was blocked by internal attribution state")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3217,7 +3217,6 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		// IssueInProgress to return false and startNewWorkers to spawn a duplicate.
 		if pr, found := branchToPR[sess.Branch]; found {
 			o.updateTokensUsedFromWorkerLog(slotName, sess)
-			o.ensureAttributionTrailerOnBranch(slotName, sess)
 			log.Printf("[orch] reconcile: %s running->pr_open (PR #%d already open for branch %q; %s)",
 				slotName, pr.Number, sess.Branch, strings.Join(reasons, ", "))
 			sess.Status = state.StatusPROpen
@@ -3799,7 +3798,6 @@ func (o *Orchestrator) reconcilePushedBranch(s *state.State, slotName string, se
 	}
 
 	title := autoCreatedPRTitle(sess)
-	o.ensureAttributionTrailerOnBranch(slotName, sess)
 	body := autoCreatedPRBody(sess, branch)
 	prNumber, err := o.createPR(title, body, "main", branch)
 	if err != nil {
@@ -3852,7 +3850,12 @@ Maestro auto-created this pull request for pushed branch %s because no open pull
 `, sess.IssueNumber, branch)
 }
 
-// ensureAttributionTrailerOnBranch stamps the durable Maestro-Backend trailer
+// ensureAttributionTrailerOnBranch is retained only as a compatibility helper
+// for historical trailer tests. Production lifecycle paths no longer call it:
+// backend attribution is internal control-plane state and must never mutate a
+// target repository's commits (#1000).
+//
+// Historically this stamped the durable Maestro-Backend trailer
 // onto the branch head. It returns deferred=true when the amend could not land
 // the trailer this cycle — the branch is advancing under a concurrent push, it
 // diverged from the attributed head, the worktree is mid-write, or the remote
@@ -4306,7 +4309,6 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					if sess.Status == state.StatusDead && sess.NextRetryAt != nil {
 						continue
 					}
-					o.ensureAttributionTrailerOnBranch(slotName, sess)
 					log.Printf("[orch] session %s %s->pr_open (PR #%d now open for branch %q)", slotName, sess.Status, pr.Number, sess.Branch)
 					sess.Status = state.StatusPROpen
 					sess.PRNumber = pr.Number
@@ -4470,7 +4472,6 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 				// Check if there's an open PR for this branch BEFORE marking dead
 				if pr, found := branchToPR[sess.Branch]; found {
 					o.updateTokensUsedFromWorkerLog(slotName, sess)
-					o.ensureAttributionTrailerOnBranch(slotName, sess)
 					log.Printf("[orch] worker %s exited but PR #%d is open — transitioning to pr_open", slotName, pr.Number)
 					sess.Status = state.StatusPROpen
 					sess.PRNumber = pr.Number
@@ -4994,38 +4995,6 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		if sess.PRNumber == 0 {
 			sess.PRNumber = pr.Number
 		}
-		if o.ensureAttributionTrailerOnBranch(slotName, sess) {
-			// The attribution amend deferred because the branch is still moving
-			// under a concurrent worker/operator push. Do NOT let this PR reach
-			// the merge decision this cycle: merging now would land it without
-			// the durable Maestro-Backend trailer, and the deferral's "retry next
-			// cycle" would then have nothing left to amend. Skip it; a later quiet
-			// cycle stamps the trailer and this PR becomes merge-eligible (#858).
-			// Attribution is a merge precondition, not an observability precondition.
-			// Keep recording the authoritative current head/check rollup while the
-			// safe amend is deferred; otherwise the watchdog retains an old head and
-			// reports a false stale gate while a rerun is visibly in progress.
-			_, ciStatus, gateTransition, gateObservable, observedAt, err := o.observePRGateCI(sess, pr)
-			if err != nil {
-				log.Printf("[orch] CI status for PR #%d while attribution is deferred: %v", pr.Number, err)
-			} else if gateObservable {
-				// Complete the read-only gate observation when CI is green. This
-				// remains merge-inert: attribution still blocks every ready/merge
-				// path, but a successful review must not remain durable "unknown".
-				if ciStatus == "success" {
-					if o.reviewGate() == "none" {
-						addPRGateReviewDisabled(&gateTransition)
-					} else if verdict, reviewErr := o.prReviewGateVerdict(pr.Number); reviewErr != nil {
-						log.Printf("[orch] review gate check PR #%d while attribution is deferred: %v", pr.Number, reviewErr)
-					} else if o.prGateHeadMatches(pr.Number, gateTransition.HeadSHA) {
-						addPRGateReviewVerdict(&gateTransition, verdict)
-					}
-				}
-				o.persistPRGateTransition(s, gateTransition, observedAt)
-			}
-			continue
-		}
-
 		// #705: opt-in visual evidence for UI-affecting PRs. One-shot,
 		// advisory — posts a warning comment when evidence is missing but
 		// never blocks or delays the merge flow below.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -487,8 +487,7 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 	}
 
 	var gotTitle, gotBody, gotBase, gotHead string
-	var amendedWorktree, amendedBranch string
-	var amendedAttribution []state.BackendAttribution
+	var amended bool
 	o := &Orchestrator{
 		pidAliveFn:          func(pid int) bool { return false },
 		tmuxSessionExistsFn: func(name string) bool { return false },
@@ -501,9 +500,7 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 			return 144, nil
 		},
 		amendHeadFn: func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
-			amendedWorktree = worktreePath
-			amendedBranch = branch
-			amendedAttribution = append([]state.BackendAttribution(nil), attribution...)
+			amended = true
 			return nil
 		},
 	}
@@ -555,20 +552,17 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 			t.Fatalf("PR body leaks orchestration internals (%q): %q", leak, gotBody)
 		}
 	}
-	if amendedWorktree != "/tmp/mae-8" || amendedBranch != "feat/mae-8-108-add-branch-rescue" {
-		t.Fatalf("amend target = %q/%q", amendedWorktree, amendedBranch)
-	}
-	if len(amendedAttribution) != 2 {
-		t.Fatalf("amended attribution len = %d, want 2", len(amendedAttribution))
+	if amended {
+		t.Fatal("auto-created PR reconciliation must not rewrite the product branch for attribution")
 	}
 	if !s.IssueInProgress(108) {
 		t.Fatal("IssueInProgress(108) must remain true after auto-created PR")
 	}
 }
 
-// The Maestro-Backend attribution trailer stays on commits only; PR bodies on
-// the (possibly public) target repo must not be rewritten to carry it (#799).
-func TestReconcileRunningSessions_OpenPR_AmendsCommitOnly_LeavesPRBodyAlone(t *testing.T) {
+// Backend attribution is internal control-plane state. Reconciliation must
+// adopt the existing PR without changing its public commit or PR body (#1000).
+func TestReconcileRunningSessions_OpenPR_DoesNotAmendProductCommit(t *testing.T) {
 	s := state.NewState()
 	t0 := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
 	s.Sessions["mae-9"] = &state.Session{
@@ -616,8 +610,8 @@ func TestReconcileRunningSessions_OpenPR_AmendsCommitOnly_LeavesPRBodyAlone(t *t
 	if sess.PRNumber != 145 {
 		t.Fatalf("pr_number = %d, want 145", sess.PRNumber)
 	}
-	if !amended {
-		t.Fatal("expected branch head amend hook")
+	if amended {
+		t.Fatal("existing PR reconciliation must not rewrite the product branch for attribution")
 	}
 }
 

--- a/internal/orchestrator/pr_gate_progress_test.go
+++ b/internal/orchestrator/pr_gate_progress_test.go
@@ -234,7 +234,7 @@ func TestAutoMergePRs_HeadChangeWhileCollectingFailureContextDoesNotScheduleStal
 	}
 }
 
-func TestAutoMergePRs_AttributionDeferralStillObservesCurrentPRGate(t *testing.T) {
+func TestAutoMergePRs_PendingGateDoesNotInvokeAttributionAmend(t *testing.T) {
 	pr := github.PR{Number: 13, HeadRefName: "feat/deferred-attribution"}
 	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "none"}
 	o, merged := newMergeTestOrchestrator(cfg, []github.PR{pr})
@@ -244,7 +244,9 @@ func TestAutoMergePRs_AttributionDeferralStillObservesCurrentPRGate(t *testing.T
 			HeadSHA: currentHead, Verdict: "pending", Fingerprint: strings.Repeat("7", 16), Complete: true,
 		}, nil
 	}
+	amended := false
 	o.amendHeadFn = func(string, string, []state.BackendAttribution, time.Time) error {
+		amended = true
 		return errAmendDiverged
 	}
 	st := makeTestState([]github.PR{pr})
@@ -258,11 +260,14 @@ func TestAutoMergePRs_AttributionDeferralStillObservesCurrentPRGate(t *testing.T
 		t.Fatalf("deferred-attribution snapshot = %+v", snapshot)
 	}
 	if len(*merged) != 0 {
-		t.Fatalf("attribution-deferred PR unexpectedly merged: %v", *merged)
+		t.Fatalf("pending PR unexpectedly merged: %v", *merged)
+	}
+	if amended {
+		t.Fatal("PR gate observation must not rewrite the product branch for attribution")
 	}
 }
 
-func TestAutoMergePRs_AttributionDeferralStillObservesPassingReview(t *testing.T) {
+func TestAutoMergePRs_PassingGateDoesNotInvokeAttributionAmend(t *testing.T) {
 	pr := github.PR{Number: 14, HeadRefName: "feat/deferred-review"}
 	cfg := &config.Config{Repo: "owner/repo", MergeStrategy: "parallel", ReviewGate: "greptile", ReviewGateStreams: []string{"greptile"}}
 	o, merged := newMergeTestOrchestrator(cfg, []github.PR{pr})
@@ -274,7 +279,11 @@ func TestAutoMergePRs_AttributionDeferralStillObservesPassingReview(t *testing.T
 	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
 		return github.ReviewGateVerdict{Passed: true, Streams: []github.ReviewStreamVerdict{{Name: "greptile", Passed: true}}}, nil
 	}
-	o.amendHeadFn = func(string, string, []state.BackendAttribution, time.Time) error { return errAmendDiverged }
+	amended := false
+	o.amendHeadFn = func(string, string, []state.BackendAttribution, time.Time) error {
+		amended = true
+		return errAmendDiverged
+	}
 	st := makeTestState([]github.PR{pr})
 	sess := st.Sessions["slot-0"]
 	sess.Attribution = []state.BackendAttribution{{Backend: "sol", StartedAt: time.Now().UTC()}}
@@ -285,8 +294,11 @@ func TestAutoMergePRs_AttributionDeferralStillObservesPassingReview(t *testing.T
 	if snapshot.HeadSHA != currentHead || snapshot.CIEffectiveVerdict != state.PRGateCISuccess || snapshot.ReviewDecision != state.PRGateReviewPassed {
 		t.Fatalf("deferred passing-review snapshot = %+v", snapshot)
 	}
-	if len(*merged) != 0 {
-		t.Fatalf("attribution-deferred PR unexpectedly merged: %v", *merged)
+	if len(*merged) != 1 || (*merged)[0] != pr.Number {
+		t.Fatalf("passing PR was not merged normally: %v", *merged)
+	}
+	if amended {
+		t.Fatal("passing merge gate must not rewrite the product branch for attribution")
 	}
 }
 

--- a/internal/orchestrator/routing_policy.go
+++ b/internal/orchestrator/routing_policy.go
@@ -33,8 +33,8 @@ func applyTierOverride(cfg *config.Config, backendName string, decision router.B
 	for k, v := range cfg.Model.Backends {
 		backends[k] = v
 	}
-	// Set BOTH the #513 attribution Model/Effort (so the dashboard + the durable
-	// Maestro-Backend: trailer reflect the model the tier actually ran, and the
+	// Set BOTH the #513 attribution Model/Effort (so the dashboard and durable
+	// internal session timeline reflect the model the tier actually ran, and the
 	// pi backend, which reads cfg.Model directly, still receives the override) AND
 	// the distinct TierModel/TierEffort carriers that thread into the worker argv
 	// for claude/codex/gemini. The distinct carriers are what keep a non-policy

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1028,7 +1028,7 @@ func assemblePrompt(base string, issue github.Issue, worktreePath, branchName st
 4. Commit your changes with a clear message.
 5. Before committing or opening a PR, check for accidental secrets and generated artifacts. Do NOT commit or mention API keys, bearer tokens, oauth tokens, bot tokens, env values, raw config dumps, or diagnostic logs. Do NOT commit temp/debug artifacts such as tmp/, _tmp/, *.log, *.logs, *.test, or *.test.json unless the issue explicitly requires them.
 6. Keep the PR body minimal and safe. Use: gh pr create --repo %s --title "%s" --body "Refs #%d". Never use closing keywords such as Closes/Fixes/Resolves in PR bodies for Maestro-managed work. Do NOT paste logs, doctor output, env dumps, or secret-bearing snippets into the PR body or comments.
-7. Preserve any Maestro-Backend: attribution trailer that Maestro adds to commit messages. Do NOT add backend/model attribution, pids, tmux session names, or host paths to PR bodies.
+7. Do NOT add backend/model attribution, effort, retry history, pids, tmux session names, or host paths to commit messages or PR bodies. Maestro records this control-plane telemetry internally.
 8. After creating the PR, you are done. Do NOT merge it yourself.
 
 Important: Always run cargo fmt --all before committing if this is a Rust project.

--- a/worker-prompt-template.md
+++ b/worker-prompt-template.md
@@ -96,7 +96,7 @@ When rebasing conflicts in these files: **keep BOTH sides**. Your additions + wh
 ### 7. Done means done
 Once you've opened a PR:
 - If Maestro appended a **Visual Evidence** section to this prompt (the project has `verify.visual` enabled) and your diff touches the listed UI path globs: run the capture command, then attach the resulting screenshots to the PR as a comment with embedded images BEFORE declaring done. If the capture fails, post a PR comment saying so instead — do not block the PR on it.
-- Preserve any `Maestro-Backend:` attribution trailer Maestro adds to commit messages or PR bodies.
+- Keep provider, model, effort, retry, host, and session attribution out of commit messages and PR bodies. Maestro records this control-plane telemetry internally.
 - Verify CI started with REST only:
   `sha=$(gh api repos/OWNER/REPO/pulls/PR_NUMBER --jq .head.sha) && gh api repos/OWNER/REPO/commits/$sha/check-runs --jq '.check_runs[] | {name,status,conclusion}'`
 - Write a brief summary of what you did


### PR DESCRIPTION
## What changed

- remove attribution-commit mutation from existing-PR reconciliation, auto-created PR registration, session exit/recovery reconciliation, and the pre-merge gate
- keep backend/provider/model/effort/retry attribution in Maestro's durable session state and Fleet surfaces
- stop telling workers to preserve or publish control-plane telemetry in commit messages
- replace merge/reconciliation tests with invariants proving the legacy amend hook is never invoked
- retain historical trailer formatting/parsing compatibility

## Root cause

Maestro treated an internal observability record as a required product-commit trailer. After an OK Player worker removed prohibited provider/model metadata from its public history, the next orchestration cycle force-amended and force-pushed the branch, restarting CI. A repair worker would remove it again, creating an unbounded force-push, CI, and token loop.

## Impact

Product branch heads now remain stable across orchestration cycles. Missing `Maestro-Backend` trailers no longer block reconciliation or merge, while the same attribution timeline remains durable and queryable internally.

## Validation

- `umask 077; go test ./...`
- `go build ./cmd/maestro/`
- targeted reconciliation and PR-gate tests assert the legacy amend hook is not called
- `rg` confirms no production call sites remain

Refs #1000

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps Maestro backend attribution out of product commits while preserving it internally. The main changes are:

- Removes production calls that amended branch heads to add `Maestro-Backend` attribution.
- Keeps backend, provider, model, effort, and retry attribution in durable session state and Fleet-facing surfaces.
- Updates worker and repository guidance to prohibit control-plane telemetry in commits and PR bodies.
- Replaces reconciliation and merge-gate tests with invariants that the legacy amend hook is not invoked.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changed production paths consistently remove attribution-amend calls from reconciliation and merge flows. Tests cover the key invariants that the legacy amend hook is not invoked and PR gate behavior still proceeds normally. No blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the full-suite Go test run with umask 077, executing go test ./... from /home/user/repo, starting 2026-07-18T07:40:56+00:00 and finishing 2026-07-18T07:42:00+00:00 with exit code 0.
- Ran a targeted fallback Go test run for internal/orchestrator, internal/worker, and cmd/maestro; the command was umask 077; go test ./internal/orchestrator ./internal/worker ./cmd/maestro from /home/user/repo, starting 2026-07-18T07:42:04+00:00 and finishing 2026-07-18T07:42:12+00:00 with exit code 0.
- Built the Maestro binary using umask 077; the command go build ./cmd/maestro/ ran from /home/user/repo, starting 2026-07-18T07:42:22+00:00 and finishing 2026-07-18T07:42:24+00:00 with exit code 0.
- Checked the production symbol for amendHeadWithAttributionTrailer and amendHeadFn, which showed the retained helper implementation/field in internal/orchestrator/orchestrator.go.
- Performed a production call-site check for ensureAttributionTrailerOnBranch; the check found only the function definition at internal/orchestrator/orchestrator.go:3869 and no production callers.

<a href="https://app.greptile.com/trex/runs/14941217/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Removes attribution trailer mutation calls from reconciliation, session transition, auto-created PR, and auto-merge lifecycle paths while retaining compatibility helper code. |
| internal/orchestrator/attribution_merge_guard_test.go | Replaces merge-blocking attribution trailer tests with an invariant that auto-merge does not invoke the legacy amend hook. |
| internal/orchestrator/orchestrator_test.go | Adjusts reconciliation tests to assert PR adoption and creation do not rewrite product commits for backend attribution. |
| internal/orchestrator/pr_gate_progress_test.go | Updates PR gate tests to verify normal gate observation and merging proceed without invoking attribution amendments. |
| internal/worker/worker.go | Changes worker instructions to prohibit backend/model attribution in commits and PR bodies. |
| worker-prompt-template.md | Updates the worker prompt template to keep provider, model, retry, host, and session telemetry out of public commit and PR text. |
| CLAUDE.md | Updates repo guidance to keep backend and control-plane attribution out of product commit messages and PR bodies. |
| docs/model-routing-rfc.md | Reframes routing attribution as an internal durable session timeline while preserving historical trailer parseability. |
| internal/orchestrator/routing_policy.go | Updates comments to describe routing attribution as dashboard and internal timeline state rather than commit trailers. |

<sub>Reviews (1): Last reviewed commit: ["fix: keep backend attribution out of pro..."](https://github.com/befeast/maestro/commit/9db6a6971a49ccf44700506b0b2fd95bbbdc457e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45299175)</sub>

<!-- /greptile_comment -->